### PR TITLE
Ninja backend: objects generated with custom_target can be linked

### DIFF
--- a/ninjabackend.py
+++ b/ninjabackend.py
@@ -206,6 +206,8 @@ class NinjaBackend(backends.Backend):
                         else:
                             obj_list.append(self.generate_single_compile(target, outfile, RawFilename(src), True,
                                                                          header_deps))
+                    elif self.environment.is_object(src):
+                        obj_list.append(src)
                     else:
                         # Assume anything not specifically a source file is a header. This is because
                         # people generate files with weird suffixes (.inc, .fh) that they then include


### PR DESCRIPTION
I tried to compile some OpenCL source into resources that would be linked into the main program. That didn't work out, because generated objects couldn't be linked. This patch fixes that for Ninja backend.
