### PR TITLE
depfixer: Instance of XXX has no XXX member

### DIFF
--- a/depfixer.py
+++ b/depfixer.py
@@ -23,35 +23,36 @@ DT_RPATH = 15
 DT_STRTAB = 5
 DT_SONAME = 14
 
-def init_datasizes(self, ptrsize, is_le):
-    if is_le:
-        p = '<'
-    else:
-        p = '>'
-    self.Half = p+'h'
-    self.HalfSize = 2
-    self.Word = p+'I'
-    self.WordSize = 4
-    self.Sword = p+'i'
-    self.SwordSize = 4
-    if ptrsize == 64:
-        self.Addr = p+'Q'
-        self.AddrSize = 8
-        self.Off = p+'Q'
-        self.OffSize = 8
-        self.XWord = p+'Q'
-        self.XWordSize = 8
-        self.Sxword = p+'q'
-        self.SxwordSize = 8
-    else:
-        self.Addr = p+'I'
-        self.AddrSize = 4
-        self.Off = p+'I'
-        self.OffSize = 4
+class DataSizes():
+    def __init__(self, ptrsize, is_le):
+        if is_le:
+            p = '<'
+        else:
+            p = '>'
+        self.Half = p+'h'
+        self.HalfSize = 2
+        self.Word = p+'I'
+        self.WordSize = 4
+        self.Sword = p+'i'
+        self.SwordSize = 4
+        if ptrsize == 64:
+            self.Addr = p+'Q'
+            self.AddrSize = 8
+            self.Off = p+'Q'
+            self.OffSize = 8
+            self.XWord = p+'Q'
+            self.XWordSize = 8
+            self.Sxword = p+'q'
+            self.SxwordSize = 8
+        else:
+            self.Addr = p+'I'
+            self.AddrSize = 4
+            self.Off = p+'I'
+            self.OffSize = 4
 
-class DynamicEntry():
+class DynamicEntry(DataSizes):
     def __init__(self, ifile, ptrsize, is_le):
-        init_datasizes(self, ptrsize, is_le)
+        super().__init__(ptrsize, is_le)
         self.ptrsize = ptrsize
         if ptrsize == 64:
             self.d_tag = struct.unpack(self.Sxword, ifile.read(self.SxwordSize))[0];
@@ -68,9 +69,9 @@ class DynamicEntry():
             ofile.write(struct.pack(self.Sword, self.d_tag))
             ofile.write(struct.pack(self.Word, self.val))
 
-class SectionHeader():
+class SectionHeader(DataSizes):
     def __init__(self, ifile, ptrsize, is_le):
-        init_datasizes(self, ptrsize, is_le)
+        super().__init__(ptrsize, is_le)
         if ptrsize == 64:
             is_64 = True
         else:
@@ -108,13 +109,12 @@ class SectionHeader():
         else:
             self.sh_entsize = struct.unpack(self.Word, ifile.read(self.WordSize))[0]
 
-class Elf():
-
+class Elf(DataSizes):
     def __init__(self, bfile):
         self.bfile = bfile
         self.bf = open(bfile, 'r+b')
         (self.ptrsize, self.is_le) = self.detect_elf_type()
-        init_datasizes(self, self.ptrsize, self.is_le)
+        super().__init__(self.ptrsize, self.is_le)
         self.parse_header()
         self.parse_sections()
         self.parse_dynamic()


### PR DESCRIPTION
```
************* Module depfixer
E: 57,39: Instance of 'DynamicEntry' has no 'Sxword' member (no-member)
E: 57,63: Instance of 'DynamicEntry' has no 'SxwordSize' member (no-member)
E: 58,37: Instance of 'DynamicEntry' has no 'XWord' member (no-member)
E: 58,60: Instance of 'DynamicEntry' has no 'XWordSize' member (no-member)
E: 60,39: Instance of 'DynamicEntry' has no 'Sword' member (no-member)
E: 60,62: Instance of 'DynamicEntry' has no 'SwordSize' member (no-member)
E: 61,37: Instance of 'DynamicEntry' has no 'Word' member (no-member)
E: 61,59: Instance of 'DynamicEntry' has no 'WordSize' member (no-member)
E: 65,36: Instance of 'DynamicEntry' has no 'Sxword' member (no-member)
E: 66,36: Instance of 'DynamicEntry' has no 'XWord' member (no-member)
E: 68,36: Instance of 'DynamicEntry' has no 'Sword' member (no-member)
E: 69,36: Instance of 'DynamicEntry' has no 'Word' member (no-member)
E: 79,37: Instance of 'SectionHeader' has no 'Word' member (no-member)
E: 79,59: Instance of 'SectionHeader' has no 'WordSize' member (no-member)
E: 81,37: Instance of 'SectionHeader' has no 'Word' member (no-member)
E: 81,59: Instance of 'SectionHeader' has no 'WordSize' member (no-member)
E: 84,42: Instance of 'SectionHeader' has no 'XWord' member (no-member)
E: 84,65: Instance of 'SectionHeader' has no 'XWordSize' member (no-member)
E: 86,42: Instance of 'SectionHeader' has no 'Word' member (no-member)
E: 86,64: Instance of 'SectionHeader' has no 'WordSize' member (no-member)
E: 88,37: Instance of 'SectionHeader' has no 'Addr' member (no-member)
E: 88,59: Instance of 'SectionHeader' has no 'AddrSize' member (no-member)
E: 90,39: Instance of 'SectionHeader' has no 'Off' member (no-member)
E: 90,60: Instance of 'SectionHeader' has no 'OffSize' member (no-member)
E: 93,41: Instance of 'SectionHeader' has no 'XWord' member (no-member)
E: 93,64: Instance of 'SectionHeader' has no 'XWordSize' member (no-member)
E: 95,41: Instance of 'SectionHeader' has no 'Word' member (no-member)
E: 95,63: Instance of 'SectionHeader' has no 'WordSize' member (no-member)
E: 97,37: Instance of 'SectionHeader' has no 'Word' member (no-member)
E: 97,59: Instance of 'SectionHeader' has no 'WordSize' member (no-member)
E: 99,37: Instance of 'SectionHeader' has no 'Word' member (no-member)
E: 99,59: Instance of 'SectionHeader' has no 'WordSize' member (no-member)
E:102,46: Instance of 'SectionHeader' has no 'XWord' member (no-member)
E:102,69: Instance of 'SectionHeader' has no 'XWordSize' member (no-member)
E:104,46: Instance of 'SectionHeader' has no 'Word' member (no-member)
E:104,68: Instance of 'SectionHeader' has no 'WordSize' member (no-member)
E:107,44: Instance of 'SectionHeader' has no 'XWord' member (no-member)
E:107,67: Instance of 'SectionHeader' has no 'XWordSize' member (no-member)
E:109,44: Instance of 'SectionHeader' has no 'Word' member (no-member)
E:109,66: Instance of 'SectionHeader' has no 'WordSize' member (no-member)
E:148,36: Instance of 'Elf' has no 'Half' member (no-member)
E:148,60: Instance of 'Elf' has no 'HalfSize' member (no-member)
E:149,39: Instance of 'Elf' has no 'Half' member (no-member)
E:149,63: Instance of 'Elf' has no 'HalfSize' member (no-member)
E:150,39: Instance of 'Elf' has no 'Word' member (no-member)
E:150,63: Instance of 'Elf' has no 'WordSize' member (no-member)
E:151,37: Instance of 'Elf' has no 'Addr' member (no-member)
E:151,61: Instance of 'Elf' has no 'AddrSize' member (no-member)
E:152,37: Instance of 'Elf' has no 'Off' member (no-member)
E:152,60: Instance of 'Elf' has no 'OffSize' member (no-member)
E:153,37: Instance of 'Elf' has no 'Off' member (no-member)
E:153,60: Instance of 'Elf' has no 'OffSize' member (no-member)
E:154,37: Instance of 'Elf' has no 'Word' member (no-member)
E:154,61: Instance of 'Elf' has no 'WordSize' member (no-member)
E:155,38: Instance of 'Elf' has no 'Half' member (no-member)
E:155,62: Instance of 'Elf' has no 'HalfSize' member (no-member)
E:156,41: Instance of 'Elf' has no 'Half' member (no-member)
E:156,65: Instance of 'Elf' has no 'HalfSize' member (no-member)
E:157,37: Instance of 'Elf' has no 'Half' member (no-member)
E:157,61: Instance of 'Elf' has no 'HalfSize' member (no-member)
E:158,41: Instance of 'Elf' has no 'Half' member (no-member)
E:158,65: Instance of 'Elf' has no 'HalfSize' member (no-member)
E:159,37: Instance of 'Elf' has no 'Half' member (no-member)
E:159,61: Instance of 'Elf' has no 'HalfSize' member (no-member)
E:160,40: Instance of 'Elf' has no 'Half' member (no-member)
E:160,64: Instance of 'Elf' has no 'HalfSize' member (no-member)
```