### PR TITLE
Fix regexp match for qmake version

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -688,7 +688,7 @@ class Qt5Dependency(Dependency):
         if not 'version 5' in stdo:
             mlog.log('QMake is not for Qt5.')
             return
-        self.version = re.search('5(\.\d+)+', stdo).match(0)
+        self.version = re.search('5(\.\d+)+', stdo).group(0)
         (stdo, _) = subprocess.Popen(['qmake', '-query'], stdout=subprocess.PIPE).communicate()
         qvars = {}
         for line in stdo.decode().split('\n'):


### PR DESCRIPTION
There's a bug which causes qmake version check to fail:

    AttributeError: '_sre.SRE_Match' object has no attribute 'match'

Python re.search returns MatchObject, which does not have match function. You need to use group instead.