### PR TITLE
Use ssl when connecting to wrapdb

### DIFF
--- a/wraptool.py
+++ b/wraptool.py
@@ -18,9 +18,50 @@ import urllib.request, json
 import sys, os
 import configparser
 import shutil
+try:
+    import ssl
+    has_ssl = True
+    API_ROOT = 'https://wrapdb.mesonbuild.com/v1/'
+except ImportError:
+    print('Warning: ssl not available, traffic not authenticated.')
+    has_ssl = False
+    API_ROOT = 'http://wrapdb.mesonbuild.com/v1/'
+
 from glob import glob
 
-API_ROOT = 'http://wrapdb.mesonbuild.com/v1/'
+wrapdb_certificate = '''-----BEGIN CERTIFICATE-----
+MIIFkzCCA3ugAwIBAgIJAIjVMWLmbJWUMA0GCSqGSIb3DQEBCwUAMGAxCzAJBgNV
+BAYTAkZJMRUwEwYDVQQHDAxEZWZhdWx0IENpdHkxGjAYBgNVBAoMEVRoZSBNZXNv
+biBQcm9qZWN0MR4wHAYDVQQDDBV3cmFwZGIubWVzb25idWlsZC5jb20wHhcNMTUw
+NzIxMTk0NjI1WhcNMTYwNzIwMTk0NjI1WjBgMQswCQYDVQQGEwJGSTEVMBMGA1UE
+BwwMRGVmYXVsdCBDaXR5MRowGAYDVQQKDBFUaGUgTWVzb24gUHJvamVjdDEeMBwG
+A1UEAwwVd3JhcGRiLm1lc29uYnVpbGQuY29tMIICIjANBgkqhkiG9w0BAQEFAAOC
+Ag8AMIICCgKCAgEArucsF2GNXW6PqGlW3egD3LxIX+YTWc7MscM5MFryoQEdCsxm
+ME50J2bKZxyJIO+0bCyjvGQNbQxNIvu03ftMYVvbr949km+qafFy63U+QISXOdK1
+oAPIeQnxjwTt+xK/2E8NjChQeWMOb6iX0hsxRtBWoL35SP541xGjgjWKOJTErqcV
+YdDiiTaChZMb9oV4qNEipBKHvU0EmLsF1Lm8psw332QlR5eqmCk12LtV7l5kVH38
+XD+aDpuB5CajcWdEQMDk4rDW6HkjNGnxYRWglMop1WbQvBLVlQ3r16BQT/Gz6x/B
+5CLNjiQ1D9LzaGK0UUr2NnxXiZyE0DgNVK9HlNilE4tjapY4mRK2XanGKuCVIGhY
+xuKB2UI2XbKXweNphHZh5L6a5tutxqkcj+ic0J7Fk+Kyk5smmjQC6DNRxEiQ88CJ
+v7K29KaoqN0q/Gp5abc0YOXR9uA2L8TFbd+I58flSPL9XB/iYcTB4ExIHvYhzSjZ
+P0HvkA3mpFpWcvpbGAhA4JkPBQL8jgUQlZnbKb2EdXKEwR7ccOuEEpQW0WL+qGBV
+vm2xyrO+0Xr1pz0NKiPiBTi6pT883/9Jq1ybngBlyx1xBAF0cxJI8OrdkvYR0U2D
+8I94AwKJRGiYgwsR/0OEY1CBXZDEs29AJYy8S+W1VUphwwL0+7meqUue1ucCAwEA
+AaNQME4wHQYDVR0OBBYEFBHwvUp78l9J1g1LmElHnh3clzyBMB8GA1UdIwQYMBaA
+FBHwvUp78l9J1g1LmElHnh3clzyBMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEL
+BQADggIBAGiS/N3rchOTNADL9iGPEwTBt4aN3RzGALoxmQz/xahyr4NwsjY8rag5
+hVr1M6eZ3+NTRRC3fgPMGYVBbuN51N9SffEgRjAZzOkmBX7fLwTFY3ywsddWiomF
+8kstor3103IEzPej9nNlQOht7+HKd1ggchji8+zFFGedmOxLweY5985Ze6TNaqVD
+ONZ2u7RmkfpgNUDoMsfHyRnENcsQrJXXS1Pp2TRhb/+0NrqrdSorIKYlt5FP/GkZ
+OBdm61RfwHLi72SmkeDGPeOYoS2b0SYNuoXHIX+fjVOOIES0A4jRXsQC10cKGZws
+IuXNVLrWaLQq874op0oVteR5guW7Rr0KGRNA6MJt67H2VxPtoyaxCXjygoX0+a92
+KlDBb8geKOkNfoXg4fRF2Qxh+j5VLBgJyR+x/YYUdG89kDc+Tb3By3PVWi5ypAPC
+UPYkc0F8hB9h9KYe78UnzqIRw+YjFN8bKJQS+DXBLyRmp35gn1yp/Vw2O7Vk+E7m
+SuYF28YTKF/woZWdJH1aQDO0erUBXdiycZVeKbdm3jenNPHTiF/Wt22CXIlGjj83
+G+eGrvfQVk3oXRn+YlypIbxkV8eI1wOina799oiflQmvV8EevAS4dkJObahV6rtZ
+qf3ZjWGS595JCwW0fq6AAtL+ygMSr6+DcjGibYbWTL3GmiMtUeWr
+-----END CERTIFICATE-----
+'''
 
 help_templ = '''This program allows you to manage your Wrap dependencies
 using the online wrap database http://wrapdb.mesonbuild.com.
@@ -46,8 +87,19 @@ Commands:
 def print_help():
     print(help_templ % sys.argv[0])
 
+def build_ssl_context():
+    ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+    ctx.options |= ssl.OP_NO_SSLv2
+    ctx.options |= ssl.OP_NO_SSLv3
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    ctx.load_verify_locations(cadata=wrapdb_certificate)
+    return ctx
+
 def get_result(urlstring):
-    u = urllib.request.urlopen(urlstring)
+    if has_ssl:
+        u = urllib.request.urlopen(urlstring, context=build_ssl_context())
+    else:
+        u = urllib.request.urlopen(urlstring)
     data = u.read().decode('utf-8')
     jd = json.loads(data)
     if jd['output'] != 'ok':


### PR DESCRIPTION
Connect to wrapdb using our own certificate and verify that it is valid. Before merge we need to set up ssl support in the wrapdb service. After that we can change the wrapdb service to create https urls.

We should leave http connections available. Unfortunately there are many people behind unreasonable firewalls that need to access the wrapdb. They'll need to manually hack the code or download wrap definitions by hand but it is at least possible. 

Since this certificate is not signed by anyone, should we put the ssl service to a nonstandard port? That way people won't browse to it by accident.