### PR TITLE
Avoid sorting object list before generating target

### DIFF
--- a/ninjabackend.py
+++ b/ninjabackend.py
@@ -77,8 +77,6 @@ class NinjaBuildElement():
         self.elems.append((name, elems))
 
     def write(self, outfile):
-        # Sort inputs so the command line does not change.
-        # This allows Ninja to skip unnecessary rebuilds.
         line = 'build %s: %s %s' % (' '.join([ninja_quote(i) for i in self.outfilenames]),\
                                     self.rule,
                                     ' '.join([ninja_quote(i) for i in self.infilenames]))
@@ -259,8 +257,7 @@ class NinjaBackend(backends.Backend):
             for src in self.generate_unity_files(target, unity_src):
                 obj_list.append(self.generate_single_compile(target, outfile, src, True, unity_deps + header_deps))
         linker = self.determine_linker(target, src_list)
-        # Sort object list to preserve command line over multiple invocations.
-        elem = self.generate_link(target, outfile, outname, sorted(obj_list), linker, pch_objects)
+        elem = self.generate_link(target, outfile, outname, obj_list, linker, pch_objects)
         self.generate_shlib_aliases(target, self.get_target_dir(target), outfile, elem)
         self.processed_targets[name] = True
 


### PR DESCRIPTION
When adding objects to a build target (specifically static libraries)
they should appear at the end of the object list. Sorting the list always
put them at the beginning of the list.

Tested using the following `meson.build`:

    project('order test', 'cpp')

    executable('ordertest', ['main.cpp', 'p.cpp', 'q.cpp', 'r.cpp', 's.cpp', 't.cpp', 'u.cpp', 'v.cpp', 'w.cpp', 'x.cpp', 'y.cpp', 'z.cpp'], objects: ['liba.a', 'libb.a', 'libc.a', 'libd.a', 'libe.a', 'libf.a', 'libg.a', 'libh.a', 'libi.so', 'libj.so', 'libk.so', 'libl.so', 'libm.so', 'libn.so', 'libo.so', 'libp.so'])

Attempting to build twice did not cause the target to be rebuilt due to order changes:

    $ meson.py ..
    The Meson build system
    Version: 0.26.0-research
    Source dir: /home/afiefh/tmp/testmesonorder
    Build dir: /home/afiefh/tmp/testmesonorder/build
    Build type: native build
    Project name: order test
    Native cpp compiler: c++ (gcc 4.9.2-10ubuntu13)
    Build targets in project: 1
    afiefh@afiefh-Desktop:~/tmp/testmesonorder/build$ ~/src/ninja/ninja -v
    [1/13] c++ '-pipe' '-Wall' '-Wpedantic' '-Winvalid-pch' '-Wnon-virtual-dtor' '-g' '-Iordertest@exe' '-I..' '-I.' '-MMD' '-MQ' 'ordertest@exe/main.cpp.o' '-MF' 'ordertest@exe/main.cpp.o.d' -o 'ordertest@exe/main.cpp.o' -c ../main.cpp
    [2/13] c++ '-pipe' '-Wall' '-Wpedantic' '-Winvalid-pch' '-Wnon-virtual-dtor' '-g' '-Iordertest@exe' '-I..' '-I.' '-MMD' '-MQ' 'ordertest@exe/p.cpp.o' '-MF' 'ordertest@exe/p.cpp.o.d' -o 'ordertest@exe/p.cpp.o' -c ../p.cpp
    [3/13] c++ '-pipe' '-Wall' '-Wpedantic' '-Winvalid-pch' '-Wnon-virtual-dtor' '-g' '-Iordertest@exe' '-I..' '-I.' '-MMD' '-MQ' 'ordertest@exe/q.cpp.o' '-MF' 'ordertest@exe/q.cpp.o.d' -o 'ordertest@exe/q.cpp.o' -c ../q.cpp
    [4/13] c++ '-pipe' '-Wall' '-Wpedantic' '-Winvalid-pch' '-Wnon-virtual-dtor' '-g' '-Iordertest@exe' '-I..' '-I.' '-MMD' '-MQ' 'ordertest@exe/r.cpp.o' '-MF' 'ordertest@exe/r.cpp.o.d' -o 'ordertest@exe/r.cpp.o' -c ../r.cpp
    [5/13] c++ '-pipe' '-Wall' '-Wpedantic' '-Winvalid-pch' '-Wnon-virtual-dtor' '-g' '-Iordertest@exe' '-I..' '-I.' '-MMD' '-MQ' 'ordertest@exe/s.cpp.o' '-MF' 'ordertest@exe/s.cpp.o.d' -o 'ordertest@exe/s.cpp.o' -c ../s.cpp
    [6/13] c++ '-pipe' '-Wall' '-Wpedantic' '-Winvalid-pch' '-Wnon-virtual-dtor' '-g' '-Iordertest@exe' '-I..' '-I.' '-MMD' '-MQ' 'ordertest@exe/t.cpp.o' '-MF' 'ordertest@exe/t.cpp.o.d' -o 'ordertest@exe/t.cpp.o' -c ../t.cpp
    [7/13] c++ '-pipe' '-Wall' '-Wpedantic' '-Winvalid-pch' '-Wnon-virtual-dtor' '-g' '-Iordertest@exe' '-I..' '-I.' '-MMD' '-MQ' 'ordertest@exe/u.cpp.o' '-MF' 'ordertest@exe/u.cpp.o.d' -o 'ordertest@exe/u.cpp.o' -c ../u.cpp
    [8/13] c++ '-pipe' '-Wall' '-Wpedantic' '-Winvalid-pch' '-Wnon-virtual-dtor' '-g' '-Iordertest@exe' '-I..' '-I.' '-MMD' '-MQ' 'ordertest@exe/v.cpp.o' '-MF' 'ordertest@exe/v.cpp.o.d' -o 'ordertest@exe/v.cpp.o' -c ../v.cpp
    [9/13] c++ '-pipe' '-Wall' '-Wpedantic' '-Winvalid-pch' '-Wnon-virtual-dtor' '-g' '-Iordertest@exe' '-I..' '-I.' '-MMD' '-MQ' 'ordertest@exe/w.cpp.o' '-MF' 'ordertest@exe/w.cpp.o.d' -o 'ordertest@exe/w.cpp.o' -c ../w.cpp
    [10/13] c++ '-pipe' '-Wall' '-Wpedantic' '-Winvalid-pch' '-Wnon-virtual-dtor' '-g' '-Iordertest@exe' '-I..' '-I.' '-MMD' '-MQ' 'ordertest@exe/x.cpp.o' '-MF' 'ordertest@exe/x.cpp.o.d' -o 'ordertest@exe/x.cpp.o' -c ../x.cpp
    [11/13] c++ '-pipe' '-Wall' '-Wpedantic' '-Winvalid-pch' '-Wnon-virtual-dtor' '-g' '-Iordertest@exe' '-I..' '-I.' '-MMD' '-MQ' 'ordertest@exe/y.cpp.o' '-MF' 'ordertest@exe/y.cpp.o.d' -o 'ordertest@exe/y.cpp.o' -c ../y.cpp
    [12/13] c++ '-pipe' '-Wall' '-Wpedantic' '-Winvalid-pch' '-Wnon-virtual-dtor' '-g' '-Iordertest@exe' '-I..' '-I.' '-MMD' '-MQ' 'ordertest@exe/z.cpp.o' '-MF' 'ordertest@exe/z.cpp.o.d' -o 'ordertest@exe/z.cpp.o' -c ../z.cpp
    [13/13] c++   -o ordertest 'ordertest@exe/main.cpp.o' 'ordertest@exe/p.cpp.o' 'ordertest@exe/q.cpp.o' 'ordertest@exe/r.cpp.o' 'ordertest@exe/s.cpp.o' 'ordertest@exe/t.cpp.o' 'ordertest@exe/u.cpp.o' 'ordertest@exe/v.cpp.o' 'ordertest@exe/w.cpp.o' 'ordertest@exe/x.cpp.o' 'ordertest@exe/y.cpp.o' 'ordertest@exe/z.cpp.o' ../liba.a ../libb.a ../libc.a ../libd.a ../libe.a ../libf.a ../libg.a ../libh.a ../libi.so ../libj.so ../libk.so ../libl.so ../libm.so ../libn.so ../libo.so ../libp.so  
    $ touch ../meson.build 
    $ ~/src/ninja/ninja -v 
    [1/1] '/usr/bin/python3' '/home/afiefh/src/mymeson/meson/meson.py' '/home/afiefh/tmp/testmesonorder' '/home/afiefh/tmp/testmesonorder/build' --backend ninja secret-handshake
    The Meson build system
    Version: 0.26.0-research
    Source dir: /home/afiefh/tmp/testmesonorder
    Build dir: /home/afiefh/tmp/testmesonorder/build
    Build type: native build
    Project name: order test
    Native cpp compiler: c++ (gcc 4.9.2-10ubuntu13)
    Build targets in project: 1
    ninja: no work to do.