### PR TITLE
Windowspath

### DIFF
--- a/meson_test.py
+++ b/meson_test.py
@@ -95,6 +95,8 @@ def run_single_test(wrap, test):
         starttime = time.time()
         child_env = os.environ.copy()
         child_env.update(test.env)
+        if len(test.extra_paths) > 0:
+            child_env['PATH'] = child_env['PATH'] + ';'.join([''] + test.extra_paths)
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                              env=child_env)
         timed_out = False

--- a/test cases/common/46 library chain/subdir/lib1.c
+++ b/test cases/common/46 library chain/subdir/lib1.c
@@ -1,6 +1,17 @@
 int lib2fun();
 int lib3fun();
 
-int libfun() {
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+int DLL_PUBLIC libfun() {
   return lib2fun() + lib3fun();
 }

--- a/test cases/common/46 library chain/subdir/subdir2/lib2.c
+++ b/test cases/common/46 library chain/subdir/subdir2/lib2.c
@@ -1,3 +1,14 @@
-int lib2fun() {
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+int DLL_PUBLIC lib2fun() {
   return 0;
 }

--- a/test cases/common/46 library chain/subdir/subdir3/lib3.c
+++ b/test cases/common/46 library chain/subdir/subdir3/lib3.c
@@ -1,3 +1,14 @@
-int lib3fun()  {
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+int DLL_PUBLIC lib3fun()  {
   return 0;
 }

--- a/test cases/common/49 subproject/subprojects/sublib/include/subdefs.h
+++ b/test cases/common/49 subproject/subprojects/sublib/include/subdefs.h
@@ -1,6 +1,21 @@
 #ifndef SUBDEFS_H_
 #define SUBDEFS_H_
 
-int subfunc();
+#if defined _WIN32 || defined __CYGWIN__
+#if defined BUILDING_SUB
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #define DLL_PUBLIC __declspec(dllimport)
+#endif
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+int DLL_PUBLIC subfunc();
 
 #endif

--- a/test cases/common/49 subproject/subprojects/sublib/meson.build
+++ b/test cases/common/49 subproject/subprojects/sublib/meson.build
@@ -5,6 +5,7 @@ if not meson.is_subproject()
 endif
 
 i = include_directories('include')
-l = shared_library('sublib', 'sublib.c', include_directories : i, install : true)
+l = shared_library('sublib', 'sublib.c', include_directories : i, install : true,
+ c_args : '-DBUILDING_SUB=2')
 t = executable('simpletest', 'simpletest.c', include_directories : i, link_with : l)
 test('plain', t)

--- a/test cases/common/49 subproject/subprojects/sublib/sublib.c
+++ b/test cases/common/49 subproject/subprojects/sublib/sublib.c
@@ -1,5 +1,5 @@
 #include<subdefs.h>
 
-int subfunc() {
+int DLL_PUBLIC subfunc() {
     return 42;
 }

--- a/test cases/common/53 subproject subproject/subprojects/a/a.c
+++ b/test cases/common/53 subproject subproject/subprojects/a/a.c
@@ -1,4 +1,15 @@
 int func2();
 
-int func() { return func2(); }
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+int DLL_PUBLIC func() { return func2(); }
 

--- a/test cases/common/53 subproject subproject/subprojects/b/b.c
+++ b/test cases/common/53 subproject subproject/subprojects/b/b.c
@@ -1,3 +1,14 @@
-int func2() {
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+int DLL_PUBLIC func2() {
     return 42;
 }

--- a/test cases/common/60 install script/meson.build
+++ b/test cases/common/60 install script/meson.build
@@ -1,4 +1,8 @@
 project('custom install script', 'c')
 
-meson.set_install_script('myinstall.sh')
+if meson.get_compiler('c').get_id() == 'msvc'
+  meson.set_install_script('myinstall.bat')
+else
+  meson.set_install_script('myinstall.sh')
+endif
 executable('prog', 'prog.c', install : true)

--- a/test cases/common/62 exe static shared/subdir/shlib.c
+++ b/test cases/common/62 exe static shared/subdir/shlib.c
@@ -1,3 +1,14 @@
-int shlibfunc() {
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+int DLL_PUBLIC shlibfunc() {
     return 42;
 }

--- a/test cases/common/79 shared subproject/subprojects/B/b.c
+++ b/test cases/common/79 shared subproject/subprojects/B/b.c
@@ -1,7 +1,19 @@
 #include<stdlib.h>
+#if defined _WIN32 || defined __CYGWIN__
+#define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+
 char func_c();
 
-char func_b() {
+char DLL_PUBLIC func_b() {
     if(func_c() != 'c') {
         exit(3);
     }

--- a/test cases/common/79 shared subproject/subprojects/C/c.c
+++ b/test cases/common/79 shared subproject/subprojects/C/c.c
@@ -1,3 +1,14 @@
-char func_c() {
+#if defined _WIN32 || defined __CYGWIN__
+#define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+char DLL_PUBLIC func_c() {
     return 'c';
 }

--- a/test cases/common/80 shared subproject 2/subprojects/B/b.c
+++ b/test cases/common/80 shared subproject 2/subprojects/B/b.c
@@ -1,7 +1,18 @@
 #include<stdlib.h>
 char func_c();
 
-char func_b() {
+#if defined _WIN32 || defined __CYGWIN__
+#define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+char DLL_PUBLIC func_b() {
     if(func_c() != 'c') {
         exit(3);
     }

--- a/test cases/common/80 shared subproject 2/subprojects/C/c.c
+++ b/test cases/common/80 shared subproject 2/subprojects/C/c.c
@@ -1,3 +1,14 @@
-char func_c() {
+#if defined _WIN32 || defined __CYGWIN__
+#define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+char DLL_PUBLIC func_c() {
     return 'c';
 }

--- a/test cases/common/82 custom subproject dir/custom_subproject_dir/B/b.c
+++ b/test cases/common/82 custom subproject dir/custom_subproject_dir/B/b.c
@@ -1,7 +1,18 @@
 #include<stdlib.h>
 char func_c();
 
-char func_b() {
+#if defined _WIN32 || defined __CYGWIN__
+#define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+char DLL_PUBLIC func_b() {
     if(func_c() != 'c') {
         exit(3);
     }

--- a/test cases/common/82 custom subproject dir/custom_subproject_dir/C/c.c
+++ b/test cases/common/82 custom subproject dir/custom_subproject_dir/C/c.c
@@ -1,3 +1,14 @@
-char func_c() {
+#if defined _WIN32 || defined __CYGWIN__
+#define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+char DLL_PUBLIC func_c() {
     return 'c';
 }

--- a/test cases/common/86 same basename/lib.c
+++ b/test cases/common/86 same basename/lib.c
@@ -1,5 +1,16 @@
+#if defined _WIN32 || defined __CYGWIN__
+#define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
 #if defined SHAR
-int func() {
+int DLL_PUBLIC func() {
     return 1;
 }
 #elif defined STAT


### PR DESCRIPTION
Windows does not have rpath so simulate it by adding the path segments to PATH when running tests.

Then fix all unit tests that were broken on MSVC that were masked by this.
