### PR TITLE
Use system() instead of name() which is a confusing term.

### DIFF
--- a/cross/ubuntu-armhf.txt
+++ b/cross/ubuntu-armhf.txt
@@ -22,6 +22,6 @@ has_function_printf = true
 has_function_hfkerhisadf = false
 
 [host_machine]
-name = 'linux'
+system = 'linux'
 cpu = 'arm'
 endian = 'little'

--- a/cross/ubuntu-faketarget.txt
+++ b/cross/ubuntu-faketarget.txt
@@ -7,6 +7,6 @@
 # binaries directly.
 
 [target_machine]
-name = 'linux'
+system = 'linux'
 cpu = 'mips'
 endian = 'little'

--- a/cross/ubuntu-mingw.txt
+++ b/cross/ubuntu-mingw.txt
@@ -12,11 +12,11 @@ strip = '/usr/bin/i686-w64-mingw32-strip'
 root = '/usr/i686-w64-mingw32'
 
 [host_machine]
-name = 'windows'
+system = 'windows'
 cpu = 'x86'
 endian = 'little'
 
 [target_machine]
-name = 'darwin'
+system = 'darwin'
 cpu = 'arm'
 endian = 'little'

--- a/environment.py
+++ b/environment.py
@@ -91,7 +91,7 @@ class Environment():
 
         cross = self.is_cross_build()
         if (not cross and mesonlib.is_windows()) \
-        or (cross and self.cross_info.has_host() and self.cross_info.config['host_machine']['name'] == 'windows'):
+        or (cross and self.cross_info.has_host() and self.cross_info.config['host_machine']['system'] == 'windows'):
             self.exe_suffix = 'exe'
             self.import_lib_suffix = 'lib'
             self.shared_lib_suffix = 'dll'
@@ -102,7 +102,7 @@ class Environment():
         else:
             self.exe_suffix = ''
             if (not cross and mesonlib.is_osx()) or \
-            (cross and self.cross_info.has_host() and self.cross_info.config['host_machine']['name'] == 'darwin'):
+            (cross and self.cross_info.has_host() and self.cross_info.config['host_machine']['system'] == 'darwin'):
                 self.shared_lib_suffix = 'dylib'
             else:
                 self.shared_lib_suffix = 'so'

--- a/interpreter.py
+++ b/interpreter.py
@@ -305,7 +305,7 @@ class GeneratedListHolder(InterpreterObject):
 class BuildMachine(InterpreterObject):
     def __init__(self):
         InterpreterObject.__init__(self)
-        self.methods.update({'name' : self.name_method,
+        self.methods.update({'system' : self.system_method,
                              'cpu' : self.cpu_method,
                              'endian' : self.endian_method,
                             })
@@ -326,7 +326,7 @@ class BuildMachine(InterpreterObject):
         # Add fixes here as bugs are reported.
         return trial
 
-    def name_method(self, args, kwargs):
+    def system_method(self, args, kwargs):
         return platform.system().lower()
 
     def endian_method(self, args, kwargs):
@@ -338,13 +338,13 @@ class CrossMachineInfo(InterpreterObject):
     def __init__(self, cross_info):
         InterpreterObject.__init__(self)
         self.info = cross_info
-        self.methods.update({'name' : self.name_method,
+        self.methods.update({'system' : self.system_method,
                              'cpu' : self.cpu_method,
                              'endian' : self.endian_method,
                             })
 
-    def name_method(self, args, kwargs):
-        return self.info['name']
+    def system_method(self, args, kwargs):
+        return self.info['system']
 
     def cpu_method(self, args, kwargs):
         return self.info['cpu']

--- a/ninjabackend.py
+++ b/ninjabackend.py
@@ -1289,7 +1289,7 @@ rule FORTRAN_DEP_HACK
         symname = os.path.join(targetdir, target_name + '.symbols')
         elem = NinjaBuildElement(symname, 'SHSYM', target_name)
         if self.environment.is_cross_build() and self.environment.cross_info.need_cross_compiler():
-            elem.add_item('CROSS', '--cross-host=' + self.environment.cross_info.config['host_machine']['name'])
+            elem.add_item('CROSS', '--cross-host=' + self.environment.cross_info.config['host_machine']['system'])
         elem.write(outfile)
 
     def generate_link(self, target, outfile, outname, obj_list, linker, extra_args=[]):

--- a/test cases/common/31 find program/meson.build
+++ b/test cases/common/31 find program/meson.build
@@ -1,6 +1,6 @@
 project('find program', 'c')
 
-if build_machine.name() == 'windows'
+if build_machine.system() == 'windows'
   # Things Windows does not provide:
   #  - an executable to copy files without prompting
   #  - working command line quoting

--- a/test cases/common/38 run program/meson.build
+++ b/test cases/common/38 run program/meson.build
@@ -1,6 +1,6 @@
 project('run command', 'c')
 
-if build_machine.name() == 'windows'
+if build_machine.system() == 'windows'
   c = run_command('cmd', '/c', 'echo', 'hello')
 else
   c = run_command('echo', 'hello')
@@ -24,7 +24,7 @@ endif
 
 # Now the same with a script.
 
-if build_machine.name() == 'windows'
+if build_machine.system() == 'windows'
   cs = run_command('scripts/hello.bat')
 else
   cs = run_command('scripts/hello.sh')

--- a/test cases/common/55 file grabber/meson.build
+++ b/test cases/common/55 file grabber/meson.build
@@ -9,7 +9,7 @@ project('grabber', 'c')
 # acceptable to you, then we're certainly not going to stop you. Just don't
 # file bugs when it fails. :)
 
-if build_machine.name() == 'windows'
+if build_machine.system() == 'windows'
   c = run_command('grabber.bat')
   grabber = find_program('grabber2.bat')
 else

--- a/test cases/common/59 object generator/meson.build
+++ b/test cases/common/59 object generator/meson.build
@@ -6,7 +6,7 @@ python = find_program('python3')
 # Code will not be rebuilt if it changes.
 comp = '@0@/@1@'.format(meson.current_source_dir(), 'obj_generator.py')
 
-if host_machine.name() == 'windows'
+if host_machine.system() == 'windows'
   outputname = '@BASENAME@.obj'
 else
   outputname = '@BASENAME@.o'

--- a/test cases/objc/2 nsstring/meson.build
+++ b/test cases/objc/2 nsstring/meson.build
@@ -1,6 +1,6 @@
 project('nsstring', 'objc')
 
-if host_machine.name() == 'darwin'
+if host_machine.system() == 'darwin'
   dep = dependency('appleframeworks', modules : 'foundation')
 else
   dep = dependency('gnustep')

--- a/test cases/prebuilt object/1 basic/meson.build
+++ b/test cases/prebuilt object/1 basic/meson.build
@@ -9,7 +9,7 @@
 
 project('prebuilt object', 'c')
 
-if host_machine.name() == 'windows'
+if host_machine.system() == 'windows'
   prebuilt = 'prebuilt.obj'
 else
   prebuilt = 'prebuilt.o'


### PR DESCRIPTION
Currently we expose the system type (Linux/Darwin/etc) via the `name()` method. This is a bit confusing and name can mean a lot of different things for different people. This MR replaces it with `system()`. It could also be `platform()` or something else. Proposals for a better name are gladly accepted.