### PR TITLE
Create and install dependency manifests

### DIFF
--- a/backends.py
+++ b/backends.py
@@ -311,8 +311,8 @@ class Backend():
     def generate_dep_manifests(self):
         for t in self.build.targets.values():
             if isinstance(t, build.Executable):
-                fname = t.name + '.depmf'
-                ofname = os.path.join(self.environment.get_build_dir(), t.subdir, fname + '.dependencies.json')
+                fname = t.name + '.dependencies.json'
+                ofname = os.path.join(self.environment.get_build_dir(), t.subdir, fname)
                 mf = {'version': 1,
                       'type' : 'dependency manifest'}
                 mf['dependencies'] = self.transitive_internal_deps(t)

--- a/backends.py
+++ b/backends.py
@@ -16,6 +16,7 @@ import os, pickle
 import build
 import dependencies
 import mesonlib
+import json
 from coredata import MesonException
 
 class TestSerialisation:
@@ -298,3 +299,21 @@ class Backend():
                 ofile.write(' ')
             ofile.write('\n')
 
+    def transitive_internal_deps(self, target):
+        deps = {}
+        for i in target.internal_deps:
+            if isinstance(i, dependencies.InternalDependency):
+                deps[i.name] = i.version
+        for l in target.link_targets:
+            deps.update(self.transitive_internal_deps(l))
+        return deps
+
+    def generate_dep_manifests(self):
+        for t in self.build.targets.values():
+            if isinstance(t, build.Executable):
+                fname = t.name + '.depmf'
+                ofname = os.path.join(self.environment.get_build_dir(), t.subdir, fname + '.dependencies.json')
+                mf = {'version': 1,
+                      'type' : 'dependency manifest'}
+                mf['dependencies'] = self.transitive_internal_deps(t)
+                open(ofname, 'w').write(json.dumps(mf) + '\n')

--- a/build.py
+++ b/build.py
@@ -74,6 +74,7 @@ class Build:
         self.pkgconfig_gens = []
         self.install_scripts = []
         self.install_dirs = []
+        self.install_dependency_manifests = False
 
     def has_language(self, language):
         for i in self.compilers:

--- a/build.py
+++ b/build.py
@@ -147,6 +147,7 @@ class BuildTarget():
         self.sources = []
         self.objects = []
         self.external_deps = []
+        self.internal_deps = []
         self.include_dirs = []
         self.link_targets = []
         self.link_depends = []
@@ -423,6 +424,7 @@ class BuildTarget():
             if hasattr(dep, 'held_object'):
                 dep = dep.held_object
             if isinstance(dep, dependencies.InternalDependency):
+                self.internal_deps.append(dep) # We don't need this for codegen, only for dep manifest.
                 self.process_sourcelist(dep.sources)
                 self.add_include_dirs(dep.include_directories)
                 for l in dep.libraries:

--- a/dependencies.py
+++ b/dependencies.py
@@ -59,8 +59,10 @@ class Dependency():
         return False
 
 class InternalDependency():
-    def __init__(self, incdirs, libraries, sources):
+    def __init__(self, name, version, incdirs, libraries, sources):
         super().__init__()
+        self.name = name
+        self.version = version
         self.include_directories = incdirs
         self.libraries = libraries
         self.sources = sources

--- a/interpreter.py
+++ b/interpreter.py
@@ -993,8 +993,12 @@ class Interpreter():
     def func_files(self, node, args, kwargs):
         return [mesonlib.File.from_source_file(self.environment.source_dir, self.subdir, fname) for fname in args]
 
-    @noPosargs
+    @stringArgs
     def func_declare_dependency(self, node, args, kwargs):
+        if len(args) != 1:
+            raise InterpreterException('Declare_dependency takes one argument.')
+        name = args[0]
+        version = kwargs.get('version', 'unknown')
         incs = kwargs.get('include_directories', [])
         if not isinstance(incs, list):
             incs = [incs]
@@ -1005,7 +1009,7 @@ class Interpreter():
         if not isinstance(sources, list):
             sources = [sources]
         sources = self.source_strings_to_files(self.flatten(sources))
-        dep = dependencies.InternalDependency(incs, libs, sources)
+        dep = dependencies.InternalDependency(name, version, incs, libs, sources)
         return InternalDependencyHolder(dep)
 
     def set_variable(self, varname, variable):

--- a/interpreter.py
+++ b/interpreter.py
@@ -723,7 +723,11 @@ class MesonMain(InterpreterObject):
                              'source_root' : self.source_root_method,
                              'build_root' : self.build_root_method,
                              'add_install_script' : self.add_install_script_method,
+                             'install_dependency_manifests': self.install_dependency_manifests_method,
                             })
+
+    def install_dependency_manifests_method(self, args, kwargs):
+        self.build.install_dependency_manifests = True
 
     def add_install_script_method(self, args, kwargs):
         if len(args) != 1:

--- a/meson_install.py
+++ b/meson_install.py
@@ -22,8 +22,8 @@ class InstallData():
         self.source_dir = source_dir
         self.build_dir= build_dir
         self.prefix = prefix
-        self.targets = []
         self.depfixer = depfixer
+        self.targets = []
         self.headers = []
         self.man = []
         self.data = []
@@ -35,11 +35,7 @@ class InstallData():
 def do_install(datafilename):
     ifile = open(datafilename, 'rb')
     d = pickle.load(ifile)
-    destdir_var = 'DESTDIR'
-    if destdir_var in os.environ:
-        d.destdir = os.environ[destdir_var]
-    else:
-        d.destdir = ''
+    d.destdir = os.environ.get('DESTDIR', '')
     d.fullprefix = d.destdir + d.prefix
 
     install_subdirs(d) # Must be first, because it needs to delete the old subtree.

--- a/ninjabackend.py
+++ b/ninjabackend.py
@@ -116,6 +116,7 @@ class NinjaBackend(backends.Backend):
         self.fortran_deps = {}
 
     def generate(self):
+        self.generate_dep_manifests()
         outfilename = os.path.join(self.environment.get_build_dir(), self.ninja_filename)
         tempfilename = outfilename + '~'
         outfile = open(tempfilename, 'w')

--- a/test cases/common/85 internal dependency/proj1/meson.build
+++ b/test cases/common/85 internal dependency/proj1/meson.build
@@ -6,6 +6,8 @@ p1lib = static_library('proj1', 'proj1f1.c',
 
 indirect_source = files('proj1f2.c')
 
-proj1_dep = declare_dependency(include_directories : incdirs,
+proj1_dep = declare_dependency('proj1',
+  version : '0.0.0',
+  include_directories : incdirs,
   link_with : p1lib,
   sources : ['proj1f3.c', indirect_source])

--- a/test cases/common/87 declare dep/entity/meson.build
+++ b/test cases/common/87 declare dep/entity/meson.build
@@ -1,5 +1,7 @@
 entity_lib = static_library('entity', 'entity1.c')
 
-entity_dep = declare_dependency(link_with : entity_lib,
+entity_dep = declare_dependency('entity',
+  version : '1.0',
+  link_with : entity_lib,
   include_directories : include_directories('.'),
   sources : 'entity2.c')

--- a/test cases/common/87 declare dep/installed_files.txt
+++ b/test cases/common/87 declare dep/installed_files.txt
@@ -1,0 +1,2 @@
+usr/bin/dep_user
+usr/bin/dep_user.dependencies.json

--- a/test cases/common/87 declare dep/meson.build
+++ b/test cases/common/87 declare dep/meson.build
@@ -3,5 +3,9 @@ project('declare dependency', 'c')
 subdir('entity')
 
 exe = executable('dep_user', 'main.c',
-  dependencies : entity_dep)
+  dependencies : entity_dep,
+  install: true)
+
 test('dep', exe)
+
+meson.install_dependency_manifests()


### PR DESCRIPTION
A common problem when embedding sources is that you can't tell for any given executable what libraries it has. It might have an insecure version of OpenSSL, for example. This MR adds a *dependency manifest*, which lists each internally used dependency and its version. With this information it is easy to find executables that have unsafe dependencies and prevent them from running.

The format of the file is not final, more of a suggestion to get the ball rolling.