### PR TITLE
Fix access to the pkgconfig path in CrossBuildInfo

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -87,9 +87,9 @@ class PkgConfigDependency(Dependency):
             self.libs = []
             return
         if environment.is_cross_build() and want_cross:
-            if "pkgconfig" not in environment.cross_info:
+            if "pkgconfig" not in environment.cross_info.config["binaries"]:
                 raise DependencyException('Pkg-config binary missing from cross file.')
-            pkgbin = environment.cross_info['pkgconfig']
+            pkgbin = environment.cross_info.config["binaries"]['pkgconfig']
             self.type_string = 'Cross'
         else:
             pkgbin = 'pkg-config'


### PR DESCRIPTION
Fixes

```
Traceback (most recent call last):
  File "/usr/bin/meson", line 194, in run
    app.generate()
  File "/usr/bin/meson", line 135, in generate
    intr.run()
  File "/usr/share/meson/interpreter.py", line 953, in run
    self.evaluate_codeblock(self.ast)
  File "/usr/share/meson/interpreter.py", line 975, in evaluate_codeblock
    raise e
  File "/usr/share/meson/interpreter.py", line 969, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "/usr/share/meson/interpreter.py", line 1040, in evaluate_statement
    return self.assignment(cur)
  File "/usr/share/meson/interpreter.py", line 1759, in assignment
    value = self.evaluate_statement(node.value)
  File "/usr/share/meson/interpreter.py", line 1038, in evaluate_statement
    return self.function_call(cur)
  File "/usr/share/meson/interpreter.py", line 1740, in function_call
    return self.funcs[func_name](node, self.flatten(posargs), kwargs)
  File "/usr/share/meson/interpreter.py", line 1387, in func_dependency
    dep = dependencies.find_external_dependency(name, self.environment, kwargs)
  File "/usr/share/meson/dependencies.py", line 1034, in find_external_dependency
    raise pkg_exc
  File "/usr/share/meson/dependencies.py", line 1023, in find_external_dependency
    pkgdep = PkgConfigDependency(name, environment, kwargs)
  File "/usr/share/meson/dependencies.py", line 90, in __init__
    if "pkgconfig" not in environment.cross_info:
TypeError: argument of type 'CrossBuildInfo' is not iterable
```