### PR TITLE
Fix shared libraries for fortran

### DIFF
--- a/build.py
+++ b/build.py
@@ -630,6 +630,7 @@ class SharedLibrary(BuildTarget):
             self.prefix = environment.get_shared_lib_prefix()
             self.suffix = environment.get_shared_lib_suffix()
         self.importsuffix = environment.get_import_lib_suffix()
+        self.filename = self.prefix + self.name + '.' + self.suffix
 
     def process_kwargs(self, kwargs, environment):
         super().process_kwargs(kwargs, environment)

--- a/compilers.py
+++ b/compilers.py
@@ -1260,6 +1260,14 @@ class FortranCompiler():
     def get_language(self):
         return self.language
 
+    def get_pic_args(self):
+        if self.gcc_type == GCC_MINGW:
+            return [] # On Windows gcc defaults to fpic being always on.
+        return ['-fPIC']
+
+    def get_std_shared_lib_link_args(self):
+        return ['-shared']
+
     def needs_static_linker(self):
         return True
 

--- a/test cases/fortran/6 dynamic/dynamic.f95
+++ b/test cases/fortran/6 dynamic/dynamic.f95
@@ -1,0 +1,17 @@
+module dynamic
+  implicit none
+
+  private
+  public :: hello
+
+  interface hello
+     module procedure say
+  end interface hello
+
+contains
+
+  subroutine say
+    print *, "Hello, hello..."
+  end subroutine say
+
+end module dynamic

--- a/test cases/fortran/6 dynamic/main.f95
+++ b/test cases/fortran/6 dynamic/main.f95
@@ -1,0 +1,6 @@
+program main
+  use dynamic
+  implicit none
+
+  call hello()
+end program main

--- a/test cases/fortran/6 dynamic/meson.build
+++ b/test cases/fortran/6 dynamic/meson.build
@@ -1,0 +1,4 @@
+project('dynamic_fortran', 'fortran')
+
+dynamic = shared_library('dynamic', 'dynamic.f95')
+executable('test_exe', 'main.f95', link_with : dynamic)


### PR DESCRIPTION
Hello,

the creation of shared libraries with Fortran (at least gfortran) failed because of a few missing methods. Also building of the libraries failed, because the shared library file names were left to the default of 'no_name'. I also added a test case that reproduced the problem.

A disclaimer: I am just starting with Fortran, so the created Fortan code and used compiler options should be consider "a best guess". But at least this works better in my narrow use case.

Thanks,

-Marko