### PR TITLE
tests: Use /usr/bin/env python3

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -21,3 +21,4 @@ Jouni Roivas
 Rafaël Kooi
 Marko Raatikainen
 German Diago Gomez
+Kyle Manna

--- a/test cases/common/56 custom target/my_compiler.py
+++ b/test cases/common/56 custom target/my_compiler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 

--- a/test cases/common/57 custom target chain/my_compiler.py
+++ b/test cases/common/57 custom target chain/my_compiler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 

--- a/test cases/common/57 custom target chain/my_compiler2.py
+++ b/test cases/common/57 custom target chain/my_compiler2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 

--- a/test cases/common/59 object generator/obj_generator.py
+++ b/test cases/common/59 object generator/obj_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Mimic a binary that generates an object file (e.g. windres).
 


### PR DESCRIPTION
* Use the env variable so $PATH is searched instead of hardcoded
* Enables a local python build to take priority over system python build
  as commonly used by tools like virtualenv.