### PR TITLE
Compiler options

### DIFF
--- a/backends.py
+++ b/backends.py
@@ -210,6 +210,7 @@ class Backend():
         commands += compiler.get_always_args()
         if self.environment.coredata.buildtype != 'plain':
             commands += compiler.get_warn_args(self.environment.coredata.warning_level)
+        commands += compiler.get_option_compile_args(self.environment.coredata.compiler_options)
         commands += self.build.get_global_args(compiler)
         commands += self.environment.coredata.external_args[compiler.get_language()]
         commands += target.get_extra_args(compiler.get_language())

--- a/compilers.py
+++ b/compilers.py
@@ -1023,6 +1023,22 @@ class VisualStudioCPPCompiler(VisualStudioCCompiler):
         if pe.returncode != 0:
             raise EnvironmentException('Executables created by C++ compiler %s are not runnable.' % self.name_string())
 
+    def get_options(self):
+        return {'cpp_eh' : mesonlib.UserComboOption('cpp_eh',
+                                                    'C++ exception handling type.',
+                                                    ['none', 'a', 's', 'sc'],
+                                                    'sc')}
+
+    def get_option_compile_args(self, options):
+        args = []
+        std = options['cpp_eh']
+        if std.value != 'none':
+            args.append('/EH' + std.value)
+        return args
+
+    def get_option_link_args(self, options):
+        return []
+
 GCC_STANDARD = 0
 GCC_OSX = 1
 GCC_MINGW = 2
@@ -1259,7 +1275,7 @@ class ClangCPPCompiler(CPPCompiler):
         return ['-include-pch', os.path.join (pch_dir, self.get_pch_name (header))]
 
     def get_options(self):
-        return {'c_std' : mesonlib.UserComboOption('cpp_std', 'C++ language standard to use',
+        return {'cpp_std' : mesonlib.UserComboOption('cpp_std', 'C++ language standard to use',
                                                    ['none', 'c++03', 'c++11', 'c++1y'],
                                                    'c++11')}
 

--- a/compilers.py
+++ b/compilers.py
@@ -134,6 +134,15 @@ class Compiler():
     def get_linker_always_args(self):
         return []
 
+    def get_options(self):
+        return {} # build afresh every time
+
+    def get_option_compile_args(self, options):
+        return []
+
+    def get_option_link_args(self, options):
+        return []
+
 class CCompiler(Compiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None):
         super().__init__(exelist, version)
@@ -1066,6 +1075,21 @@ class GnuCCompiler(CCompiler):
     def can_compile(self, filename):
         return super().can_compile(filename) or filename.split('.')[-1].lower() == 's' # Gcc can do asm, too.
 
+    def get_options(self):
+        return {'c_std' : mesonlib.UserComboOption('c_std', 'C language standard to use',
+                                                   ['none', 'c89', 'c99', 'c11', 'gnu89', 'gnu99', 'gnu11'],
+                                                   'c11')}
+
+    def get_option_compile_args(self, options):
+        args = []
+        std = options['c_std']
+        if std.value != 'none':
+            args.append('-std=' + std.value)
+        return args
+
+    def get_option_link_args(self, options):
+        return []
+
 class GnuObjCCompiler(ObjCCompiler):
     std_opt_args = ['-O2']
 
@@ -1154,6 +1178,20 @@ class ClangCCompiler(CCompiler):
         # so it might change semantics at any time.
         return ['-include-pch', os.path.join (pch_dir, self.get_pch_name (header))]
 
+    def get_options(self):
+        return {'c_std' : mesonlib.UserComboOption('c_std', 'C language standard to use',
+                                                   ['none', 'c89', 'c99', 'c11'],
+                                                   'c11')}
+
+    def get_option_compile_args(self, options):
+        args = []
+        std = options['c_std']
+        if std.value != 'none':
+            args.append('-std=' + std.value)
+        return args
+
+    def get_option_link_args(self, options):
+        return []
 
 class GnuCPPCompiler(CPPCompiler):
     # may need to separate the latter to extra_debug_args or something
@@ -1182,6 +1220,21 @@ class GnuCPPCompiler(CPPCompiler):
     def get_soname_args(self, shlib_name, path, soversion):
         return get_gcc_soname_args(self.gcc_type, shlib_name, path, soversion)
 
+    def get_options(self):
+        return {'cpp_std' : mesonlib.UserComboOption('cpp_std', 'C language standard to use',
+                                                   ['none', 'c++03', 'c++11', 'c++1y'],
+                                                   'c++11')}
+
+    def get_option_compile_args(self, options):
+        args = []
+        std = options['cpp_std']
+        if std.value != 'none':
+            args.append('-std=' + std.value)
+        return args
+
+    def get_option_link_args(self, options):
+        return []
+
 class ClangCPPCompiler(CPPCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None):
         CPPCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
@@ -1204,6 +1257,21 @@ class ClangCPPCompiler(CPPCompiler):
         # This flag is internal to Clang (or at least not documented on the man page)
         # so it might change semantics at any time.
         return ['-include-pch', os.path.join (pch_dir, self.get_pch_name (header))]
+
+    def get_options(self):
+        return {'c_std' : mesonlib.UserComboOption('cpp_std', 'C++ language standard to use',
+                                                   ['none', 'c++03', 'c++11', 'c++1y'],
+                                                   'c++11')}
+
+    def get_option_compile_args(self, options):
+        args = []
+        std = options['cpp_std']
+        if std.value != 'none':
+            args.append('-std=' + std.value)
+        return args
+
+    def get_option_link_args(self, options):
+        return []
 
 class FortranCompiler(Compiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None):
@@ -1495,6 +1563,9 @@ class VisualStudioLinker():
     def thread_link_flags(self):
         return []
 
+    def get_option_link_args(self, options):
+        return []
+
 class ArLinker():
     std_args = ['csr']
 
@@ -1527,4 +1598,7 @@ class ArLinker():
         return []
 
     def thread_link_flags(self):
+        return []
+
+    def get_option_link_args(self, options):
         return []

--- a/coredata.py
+++ b/coredata.py
@@ -61,6 +61,7 @@ class CoreData():
         self.werror = options.werror
         self.layout = options.layout
         self.user_options = {}
+        self.compiler_options = {}
         self.external_args = {} # These are set from "the outside" with e.g. mesonconf
         self.external_link_args = {}
         if options.cross_file is not None:

--- a/interpreter.py
+++ b/interpreter.py
@@ -1330,6 +1330,13 @@ class Interpreter():
                 if cross_comp is not None:
                     cross_comp.sanity_check(self.environment.get_scratch_dir())
                     self.coredata.cross_compilers[lang] = cross_comp
+                new_options = comp.get_options()
+                optprefix = lang + '_'
+                for i in new_options:
+                    if not i.startswith(optprefix):
+                        raise InterpreterException('Internal error, %s has incorrect prefix.' % i)
+                new_options.update(self.coredata.compiler_options)
+                self.coredata.compiler_options = new_options
             mlog.log('Native %s compiler: ' % lang, mlog.bold(' '.join(comp.get_exelist())), ' (%s %s)' % (comp.id, comp.version), sep='')
             if not comp.get_language() in self.coredata.external_args:
                 (ext_compile_args, ext_link_args) = environment.get_args_from_envvars(comp.get_language())

--- a/interpreter.py
+++ b/interpreter.py
@@ -1209,15 +1209,20 @@ class Interpreter():
         if len(args) != 1:
             raise InterpreterException('Argument required for get_option.')
         optname = args[0]
-        if optname not in coredata.builtin_options and self.is_subproject():
-            optname = self.subproject + ':' + optname
         try:
             return self.environment.get_coredata().get_builtin_option(optname)
         except RuntimeError:
             pass
-        if optname not in self.environment.coredata.user_options:
+        try:
+            return self.environment.coredata.compiler_options[optname].value
+        except KeyError:
+            pass
+        if optname not in coredata.builtin_options and self.is_subproject():
+            optname = self.subproject + ':' + optname
+        try:
+            return self.environment.coredata.user_options[optname].value
+        except KeyError:
             raise InterpreterException('Tried to access unknown option "%s".' % optname)
-        return self.environment.coredata.user_options[optname].value
 
     @noKwargs
     def func_configuration_data(self, node, args, kwargs):

--- a/mesonconf.py
+++ b/mesonconf.py
@@ -64,13 +64,6 @@ class Conf:
             f = '%s%s %s%s' % (name, namepad, descr, descrpad)
             print(f, value)
 
-    def tobool(self, thing):
-        if thing.lower() == 'true':
-            return True
-        if thing.lower() == 'false':
-            return False
-        raise ConfException('Value %s is not boolean (true or false).' % thing)
-
     def set_options(self, options):
         for o in options:
             if '=' not in o:
@@ -127,18 +120,10 @@ class Conf:
                 self.coredata.localedir = v
             elif k in self.coredata.user_options:
                 tgt = self.coredata.user_options[k]
-                if isinstance(tgt, mesonlib.UserBooleanOption):
-                    tgt.set_value(self.tobool(v))
-                elif isinstance(tgt, mesonlib.UserComboOption):
-                    try:
-                        tgt.set_value(v)
-                    except coredata.MesonException:
-                        raise ConfException('Value of %s must be one of %s.' %
-                                            (k, tgt.choices))
-                elif isinstance(tgt, mesonlib.UserStringOption):
-                    tgt.set_value(v)
-                else:
-                    raise ConfException('Internal error, unknown option type.')
+                tgt.set_value(v)
+            elif k in self.coredata.compiler_options:
+                tgt = self.coredata.compiler_options[k]
+                tgt.set_value(v)
             elif k.endswith('linkargs'):
                 lang = k[:-8]
                 if not lang in self.coredata.external_link_args:
@@ -181,6 +166,17 @@ class Conf:
         for (lang, args) in self.coredata.external_link_args.items():
             print(lang + 'linkargs', str(args))
         print('')
+        okeys = sorted(self.coredata.compiler_options.keys())
+        if len(okeys) == 0:
+            print('No compiler options\n')
+        else:
+            print('Compiler options\n')
+            coarr = []
+            for k in okeys:
+                o = self.coredata.compiler_options[k]
+                coarr.append([k, o.description, o.value])
+            self.print_aligned(coarr)
+        print('')
         print('Directories\n')
         parr = []
         parr.append(['prefix', 'Install prefix', self.coredata.prefix])
@@ -193,7 +189,7 @@ class Conf:
         self.print_aligned(parr)
         print('')
         if len(self.coredata.user_options) == 0:
-            print('This project does not have any options')
+            print('This project does not have user options')
         else:
             print('Project options\n')
             options = self.coredata.user_options

--- a/mesonconf.py
+++ b/mesonconf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2014 The Meson development team
+# Copyright 2014-2015 The Meson development team
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import sys, os
 import pickle
 import argparse
-import coredata, optinterpreter
+import coredata, mesonlib
 from meson import build_types, layouts, warning_levels
 
 parser = argparse.ArgumentParser()
@@ -127,15 +127,15 @@ class Conf:
                 self.coredata.localedir = v
             elif k in self.coredata.user_options:
                 tgt = self.coredata.user_options[k]
-                if isinstance(tgt, optinterpreter.UserBooleanOption):
+                if isinstance(tgt, mesonlib.UserBooleanOption):
                     tgt.set_value(self.tobool(v))
-                elif isinstance(tgt, optinterpreter.UserComboOption):
+                elif isinstance(tgt, mesonlib.UserComboOption):
                     try:
                         tgt.set_value(v)
-                    except optinterpreter.OptionException:
+                    except coredata.MesonException:
                         raise ConfException('Value of %s must be one of %s.' %
                                             (k, tgt.choices))
-                elif isinstance(tgt, optinterpreter.UserStringOption):
+                elif isinstance(tgt, mesonlib.UserStringOption):
                     tgt.set_value(v)
                 else:
                     raise ConfException('Internal error, unknown option type.')

--- a/mesongui.py
+++ b/mesongui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2013 The Meson development team
+# Copyright 2013-2015 The Meson development team
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import sys, os, pickle, time, shutil
-import build, coredata, environment, optinterpreter
+import build, coredata, environment, mesonlib
 from PyQt5 import uic
 from PyQt5.QtWidgets import QApplication, QMainWindow, QHeaderView
 from PyQt5.QtWidgets import QComboBox, QCheckBox
@@ -272,14 +272,14 @@ class OptionForm:
         self.opt_widgets = []
         for key in keys:
             opt = options[key]
-            if isinstance(opt, optinterpreter.UserStringOption):
+            if isinstance(opt, mesonlib.UserStringOption):
                 w = PyQt5.QtWidgets.QLineEdit(opt.value)
                 w.textChanged.connect(self.user_option_changed)
-            elif isinstance(opt, optinterpreter.UserBooleanOption):
+            elif isinstance(opt, mesonlib.UserBooleanOption):
                 w = QCheckBox('')
                 w.setChecked(opt.value)
                 w.stateChanged.connect(self.user_option_changed)
-            elif isinstance(opt, optinterpreter.UserComboOption):
+            elif isinstance(opt, mesonlib.UserComboOption):
                 w = QComboBox()
                 for i in opt.choices:
                     w.addItem(i)

--- a/mesonintrospect.py
+++ b/mesonintrospect.py
@@ -22,7 +22,7 @@ Currently only works for the Ninja backend. Others use generated
 project files and don't need this info."""
 
 import json, pickle
-import coredata, build, optinterpreter
+import coredata, build, mesonlib
 import argparse
 import sys, os
 
@@ -107,7 +107,11 @@ def list_buildoptions(coredata, builddata):
              'description' : 'Unity build',
              'name' : 'unity'}
     optlist = [buildtype, strip, coverage, pch, unity]
-    options = coredata.user_options
+    add_keys(optlist, coredata.user_options)
+    add_keys(optlist, coredata.compiler_options)
+    print(json.dumps(optlist))
+
+def add_keys(optlist, options):
     keys = list(options.keys())
     keys.sort()
     for key in keys:
@@ -115,11 +119,11 @@ def list_buildoptions(coredata, builddata):
         optdict = {}
         optdict['name'] = key
         optdict['value'] = opt.value
-        if isinstance(opt, optinterpreter.UserStringOption):
+        if isinstance(opt, mesonlib.UserStringOption):
             typestr = 'string'
-        elif isinstance(opt, optinterpreter.UserBooleanOption):
+        elif isinstance(opt, mesonlib.UserBooleanOption):
             typestr = 'boolean'
-        elif isinstance(opt, optinterpreter.UserComboOption):
+        elif isinstance(opt, mesonlib.UserComboOption):
             optdict['choices'] = opt.choices
             typestr = 'combo'
         else:
@@ -127,7 +131,6 @@ def list_buildoptions(coredata, builddata):
         optdict['type'] = typestr
         optdict['description'] = opt.description
         optlist.append(optdict)
-    print(json.dumps(optlist))
 
 def list_buildsystem_files(coredata, builddata):
     src_dir = builddata.environment.get_source_dir()

--- a/mesonintrospect.py
+++ b/mesonintrospect.py
@@ -126,6 +126,8 @@ def add_keys(optlist, options):
         elif isinstance(opt, mesonlib.UserComboOption):
             optdict['choices'] = opt.choices
             typestr = 'combo'
+        elif isinstance(opt, mesonlib.UserStringArrayOption):
+            typestr = 'stringarray'
         else:
             raise RuntimeError("Unknown option type")
         optdict['type'] = typestr

--- a/mesonlib.py
+++ b/mesonlib.py
@@ -279,10 +279,17 @@ class UserBooleanOption(UserOption):
         super().__init__(name, description)
         self.set_value(value)
 
+    def tobool(self, thing):
+        if isinstance(thing, bool):
+            return thing
+        if thing.lower() == 'true':
+            return True
+        if thing.lower() == 'false':
+            return False
+        raise MesonException('Value %s is not boolean (true or false).' % thing)
+
     def set_value(self, newvalue):
-        if not isinstance(newvalue, bool):
-            raise MesonException('Value "%s" for boolean option "%s" is not a boolean.' % (str(newvalue), self.name))
-        self.value = newvalue
+        self.value = self.tobool(newvalue)
 
     def parse_string(self, valuestring):
         if valuestring == 'false':

--- a/mesonlib.py
+++ b/mesonlib.py
@@ -314,3 +314,20 @@ class UserComboOption(UserOption):
             optionsstring = ', '.join(['"%s"' % (item,) for item in self.choices])
             raise MesonException('Value "%s" for combo option "%s" is not one of the choices. Possible choices are: %s.' % (newvalue, self.name, optionsstring))
         self.value = newvalue
+
+class UserStringArrayOption(UserOption):
+    def __init__(self, name, description, value):
+        super().__init__(name, description)
+        self.set_value(value)
+
+    def set_value(self, newvalue):
+        if isinstance(newvalue, str):
+            if not newvalue.startswith('['):
+                raise MesonException('Valuestring does not define an array: ' + newvalue)
+            newvalue = eval(newvalue, {}, {}) # Yes, it is unsafe.
+        if not isinstance(newvalue, list):
+            raise MesonException('String array value is not an array.')
+        for i in newvalue:
+            if not isinstance(i, str):
+                raise MesonException('String array element not a string.')
+        self.value = newvalue

--- a/mesonlib.py
+++ b/mesonlib.py
@@ -255,3 +255,55 @@ def replace_if_different(dst, dst_tmp):
         pass
     os.replace(dst_tmp, dst)
 
+class UserOption:
+    def __init__(self, name, description):
+        super().__init__()
+        self.name = name
+        self.description = description
+
+    def parse_string(self, valuestring):
+        return valuestring
+
+class UserStringOption(UserOption):
+    def __init__(self, name, description, value):
+        super().__init__(name, description)
+        self.set_value(value)
+
+    def set_value(self, newvalue):
+        if not isinstance(newvalue, str):
+            raise MesonException('Value "%s" for string option "%s" is not a string.' % (str(newvalue), self.name))
+        self.value = newvalue
+
+class UserBooleanOption(UserOption):
+    def __init__(self, name, description, value):
+        super().__init__(name, description)
+        self.set_value(value)
+
+    def set_value(self, newvalue):
+        if not isinstance(newvalue, bool):
+            raise MesonException('Value "%s" for boolean option "%s" is not a boolean.' % (str(newvalue), self.name))
+        self.value = newvalue
+
+    def parse_string(self, valuestring):
+        if valuestring == 'false':
+            return False
+        if valuestring == 'true':
+            return True
+        raise MesonException('Value "%s" for boolean option "%s" is not a boolean.' % (valuestring, self.name))
+
+class UserComboOption(UserOption):
+    def __init__(self, name, description, choices, value):
+        super().__init__(name, description)
+        self.choices = choices
+        if not isinstance(self.choices, list):
+            raise MesonException('Combo choices must be an array.')
+        for i in self.choices:
+            if not isinstance(i, str):
+                raise MesonException('Combo choice elements must be strings.')
+        self.set_value(value)
+
+    def set_value(self, newvalue):
+        if newvalue not in self.choices:
+            optionsstring = ', '.join(['"%s"' % (item,) for item in self.choices])
+            raise MesonException('Value "%s" for combo option "%s" is not one of the choices. Possible choices are: %s.' % (newvalue, self.name, optionsstring))
+        self.value = newvalue

--- a/ninjabackend.py
+++ b/ninjabackend.py
@@ -1452,6 +1452,7 @@ rule FORTRAN_DEP_HACK
         commands = []
         commands += linker.get_linker_always_args()
         commands += linker.get_buildtype_linker_args(self.environment.coredata.buildtype)
+        commands += linker.get_option_link_args(self.environment.coredata.compiler_options)
         if not(isinstance(target, build.StaticLibrary)):
             commands += self.environment.coredata.external_link_args[linker.get_language()]
         if isinstance(target, build.Executable):

--- a/optinterpreter.py
+++ b/optinterpreter.py
@@ -17,6 +17,22 @@ import coredata, mesonlib
 import os, re
 
 forbidden_option_names = coredata.builtin_options
+forbidden_prefixes = {'c_': True,
+                      'cpp_': True,
+                      'rust_': True,
+                      'fortran_': True,
+                      'objc_': True,
+                      'objcpp_': True,
+                      'vala_': True,
+                      'csharp_': True
+                      }
+
+def is_invalid_name(name):
+    if name in forbidden_option_names:
+        return True
+    if name in forbidden_prefixes:
+        return True
+    return False
 
 class OptionException(coredata.MesonException):
     pass
@@ -120,7 +136,7 @@ class OptionInterpreter:
             raise OptionException('Positional argument must be a string.')
         if optname_regex.search(opt_name) is not None:
             raise OptionException('Option names can only contain letters, numbers or dashes.')
-        if opt_name in forbidden_option_names:
+        if is_invalid_name(opt_name):
             raise OptionException('Option name %s is reserved.' % opt_name)
         if self.subproject != '':
             opt_name = self.subproject + ':' + opt_name

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -1,9 +1,5 @@
 project('boosttest', 'cpp')
 
-if meson.get_compiler('cpp').get_id() == 'msvc'
-  add_global_arguments('/EHsc', language : 'cpp')
-endif
-
 # We want to have multiple separate configurations of Boost
 # within one project. The need to be independent of each other.
 # Use one without a library dependency and one with it.

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -1,8 +1,6 @@
 project('boosttest', 'cpp')
 
-if meson.get_compiler('cpp').get_id() != 'msvc'
-  add_global_arguments('-std=c++11', language : 'cpp')
-else
+if meson.get_compiler('cpp').get_id() == 'msvc'
   add_global_arguments('/EHsc', language : 'cpp')
 endif
 

--- a/test cases/frameworks/4 qt5/meson.build
+++ b/test cases/frameworks/4 qt5/meson.build
@@ -3,10 +3,6 @@ project('qt5 build test', 'cpp')
 qt5 = import('qt5')
 qt5dep = dependency('qt5', modules : ['Core', 'Gui', 'Widgets'])
 
-if meson.get_compiler('cpp').get_id() != 'msvc'
-  add_global_arguments('-std=c++11', language : 'cpp')
-endif
-
 prep = qt5.preprocess(
 moc_headers : ['mainWindow.h'], # These need to be fed through the moc tool before use. 
 ui_files : 'mainWindow.ui',     # XML files that need to be compiled with the uic tol.

--- a/test cases/frameworks/9 wxwidgets/meson.build
+++ b/test cases/frameworks/9 wxwidgets/meson.build
@@ -1,7 +1,5 @@
 project('wxwidgets test', 'cpp')
 
-add_global_arguments('-std=c++11', language : 'cpp')
-
 wxd = dependency('wxwidgets', version : '>=3.0.0')
 
 wp = executable('wxprog', 'wxprog.cpp',


### PR DESCRIPTION
Compilers can add options to determine their behaviour. These include things such as (not all implemented yet):

- language standard
- unwind semantics on Windows
- pgo flags, maybe move coverage flags there too
