### PR TITLE
Enhance mesonconfig.py help

### DIFF
--- a/coredata.py
+++ b/coredata.py
@@ -44,17 +44,18 @@ class MesonException(Exception):
         Exception.__init__(self, *args, **kwargs)
 
 class UserOption:
-    def __init__(self, name, description):
+    def __init__(self, name, description, choices):
         super().__init__()
         self.name = name
+        self.choices = choices
         self.description = description
 
     def parse_string(self, valuestring):
         return valuestring
 
 class UserStringOption(UserOption):
-    def __init__(self, name, description, value):
-        super().__init__(name, description)
+    def __init__(self, name, description, value, choices=None):
+        super().__init__(name, description, choices)
         self.set_value(value)
 
     def validate(self, value):
@@ -72,7 +73,7 @@ class UserStringOption(UserOption):
 
 class UserBooleanOption(UserOption):
     def __init__(self, name, description, value):
-        super().__init__(name, description)
+        super().__init__(name, description, '[true, false]')
         self.set_value(value)
 
     def tobool(self, thing):
@@ -96,8 +97,7 @@ class UserBooleanOption(UserOption):
 
 class UserComboOption(UserOption):
     def __init__(self, name, description, choices, value):
-        super().__init__(name, description)
-        self.choices = choices
+        super().__init__(name, description, choices)
         if not isinstance(self.choices, list):
             raise MesonException('Combo choices must be an array.')
         for i in self.choices:
@@ -112,8 +112,8 @@ class UserComboOption(UserOption):
         self.value = newvalue
 
 class UserStringArrayOption(UserOption):
-    def __init__(self, name, description, value):
-        super().__init__(name, description)
+    def __init__(self, name, description, value, **kwargs):
+        super().__init__(name, description, kwargs.get('choices', []))
         self.set_value(value)
 
     def set_value(self, newvalue):

--- a/mesonconf.py
+++ b/mesonconf.py
@@ -53,16 +53,33 @@ class Conf:
     def print_aligned(self, arr):
         if len(arr) == 0:
             return
-        longest_name = max((len(x[0]) for x in arr))
-        longest_descr = max((len(x[1]) for x in arr))
+        titles = ['Option', 'Description', 'Current Value', '']
+        longest_name = len(titles[0])
+        longest_descr = len(titles[1])
+        longest_value = len(titles[2])
+        longest_possible_value = len(titles[3])
+        for x in arr:
+          longest_name = max(longest_name, len(x[0]))
+          longest_descr = max(longest_descr, len(x[1]))
+          longest_value = max(longest_value, len(str(x[2])))
+          longest_possible_value = max(longest_possible_value, len(x[3]))
+
+        if longest_possible_value > 0:
+          titles[3] = 'Possible Values'
+        print('  %s%s %s%s %s%s %s' % (titles[0], ' '*(longest_name - len(titles[0])), titles[1], ' '*(longest_descr - len(titles[1])), titles[2], ' '*(longest_value - len(titles[2])), titles[3]))
+        print('  %s%s %s%s %s%s %s' % ('-'*len(titles[0]), ' '*(longest_name - len(titles[0])), '-'*len(titles[1]), ' '*(longest_descr - len(titles[1])), '-'*len(titles[2]), ' '*(longest_value - len(titles[2])), '-'*len(titles[3])))
         for i in arr:
             name = i[0]
             descr = i[1]
             value = i[2]
+            if isinstance(value, bool):
+                value = 'true' if value else 'false'
+            possible_values = i[3]
             namepad = ' '*(longest_name - len(name))
             descrpad = ' '*(longest_descr - len(descr))
-            f = '%s%s %s%s' % (name, namepad, descr, descrpad)
-            print(f, value)
+            valuepad = ' '*(longest_value - len(str(value)))
+            f = '  %s%s %s%s %s%s %s' % (name, namepad, descr, descrpad, value, valuepad, possible_values)
+            print(f)
 
     def set_options(self, options):
         for o in options:
@@ -97,62 +114,69 @@ class Conf:
 
 
     def print_conf(self):
-        print('Core properties\n')
-        print('Source dir', self.build.environment.source_dir)
-        print('Build dir ', self.build.environment.build_dir)
+        print('Core properties:')
+        print('  Source dir', self.build.environment.source_dir)
+        print('  Build dir ', self.build.environment.build_dir)
         print('')
-        print('Core options\n')
+        print('Core options:')
         carr = []
-        carr.append(['buildtype', 'Build type', self.coredata.get_builtin_option('buildtype')])
-        carr.append(['warning_level', 'Warning level', self.coredata.get_builtin_option('warning_level')])
-        carr.append(['strip', 'Strip on install', self.coredata.get_builtin_option('strip')])
-        carr.append(['coverage', 'Coverage report', self.coredata.get_builtin_option('coverage')])
-        carr.append(['use_pch', 'Precompiled headers', self.coredata.get_builtin_option('use_pch')])
-        carr.append(['unity', 'Unity build', self.coredata.get_builtin_option('unity')])
-        carr.append(['default_library', 'Default library type', self.coredata.get_builtin_option('default_library')])
+        booleans = '[true, false]'
+        carr.append(['buildtype', 'Build type', self.coredata.get_builtin_option('buildtype'), build_types])
+        carr.append(['warning_level', 'Warning level', self.coredata.get_builtin_option('warning_level'), warning_levels])
+        carr.append(['strip', 'Strip on install', self.coredata.get_builtin_option('strip'), booleans])
+        carr.append(['coverage', 'Coverage report', self.coredata.get_builtin_option('coverage'), booleans])
+        carr.append(['use_pch', 'Precompiled headers', self.coredata.get_builtin_option('use_pch'), booleans])
+        carr.append(['unity', 'Unity build', self.coredata.get_builtin_option('unity'), booleans])
+        carr.append(['default_library', 'Default library type', self.coredata.get_builtin_option('default_library'), booleans])
         self.print_aligned(carr)
         print('')
-        print('Compiler arguments\n')
+        print('Compiler arguments:')
         for (lang, args) in self.coredata.external_args.items():
-            print(lang + 'args', str(args))
+            print('  ' + lang + 'args', str(args))
         print('')
-        print('Linker args\n')
+        print('Linker args:')
         for (lang, args) in self.coredata.external_link_args.items():
-            print(lang + 'linkargs', str(args))
+            print('  ' + lang + 'linkargs', str(args))
         print('')
+        print('Compiler options:')
         okeys = sorted(self.coredata.compiler_options.keys())
         if len(okeys) == 0:
-            print('No compiler options\n')
+            print('  No compiler options\n')
         else:
-            print('Compiler options\n')
             coarr = []
             for k in okeys:
                 o = self.coredata.compiler_options[k]
-                coarr.append([k, o.description, o.value])
+                coarr.append([k, o.description, o.value, ''])
             self.print_aligned(coarr)
         print('')
-        print('Directories\n')
+        print('Directories:')
         parr = []
-        parr.append(['prefix', 'Install prefix', self.coredata.get_builtin_option('prefix')])
-        parr.append(['libdir', 'Library directory', self.coredata.get_builtin_option('libdir')])
-        parr.append(['bindir', 'Binary directory', self.coredata.get_builtin_option('bindir')])
-        parr.append(['includedir', 'Header directory', self.coredata.get_builtin_option('includedir')])
-        parr.append(['datadir', 'Data directory', self.coredata.get_builtin_option('datadir')])
-        parr.append(['mandir', 'Man page directory', self.coredata.get_builtin_option('mandir')])
-        parr.append(['localedir', 'Locale file directory', self.coredata.get_builtin_option('localedir')])
+        parr.append(['prefix', 'Install prefix', self.coredata.get_builtin_option('prefix'), ''])
+        parr.append(['libdir', 'Library directory', self.coredata.get_builtin_option('libdir'), ''])
+        parr.append(['bindir', 'Binary directory', self.coredata.get_builtin_option('bindir'), ''])
+        parr.append(['includedir', 'Header directory', self.coredata.get_builtin_option('includedir'), ''])
+        parr.append(['datadir', 'Data directory', self.coredata.get_builtin_option('datadir'), ''])
+        parr.append(['mandir', 'Man page directory', self.coredata.get_builtin_option('mandir'), ''])
+        parr.append(['localedir', 'Locale file directory', self.coredata.get_builtin_option('localedir'), ''])
         self.print_aligned(parr)
         print('')
+        print('Project options:')
         if len(self.coredata.user_options) == 0:
-            print('This project does not have user options')
+            print('  This project does not have any options')
         else:
-            print('Project options\n')
             options = self.coredata.user_options
             keys = list(options.keys())
             keys.sort()
             optarr = []
             for key in keys:
                 opt = options[key]
-                optarr.append([key, opt.description, opt.value])
+                if (opt.choices is None) or (len(opt.choices) == 0):
+                  # Zero length list or string
+                  choices = '';
+                else:
+                  # A non zero length list or string, convert to string
+                  choices = str(opt.choices);
+                optarr.append([key, opt.description, opt.value, choices])
             self.print_aligned(optarr)
 
 if __name__ == '__main__':
@@ -172,7 +196,7 @@ if __name__ == '__main__':
             c.save()
         else:
             c.print_conf()
-    except coredata.MesonException as e:
+    except ConfException as e:
         print('Meson configurator encountered an error:\n')
         print(e)
 

--- a/optinterpreter.py
+++ b/optinterpreter.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2015 The Meson development team
+# Copyright 2013-2014 The Meson development team
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ optname_regex = re.compile('[^a-zA-Z0-9_-]')
 
 def StringParser(name, description, kwargs):
     return coredata.UserStringOption(name, description,
-                                     kwargs.get('value', ''))
+                                     kwargs.get('value', ''), kwargs.get('choices', []))
 
 def BooleanParser(name, description, kwargs):
     return coredata.UserBooleanOption(name, description, kwargs.get('value', True))


### PR DESCRIPTION
Added code to output the 'Possible values' and
also titles for the columns.

Added code so 'choices' is allowed for all
UserOption's.

For testing I created a trivial meson_options.txt:
```
[wink@wink-envy c-mpscfifo]$ cat meson_options.txt 
option('string_option', type : 'string', value : 'String B', description : 'The description', choices : ['String A', 'String B'])
option('bool_option', type : 'boolean', value : false, description : 'A boolean')
option('combo_option', type : 'combo', value : 'two', decription : 'Select the option', choices : ['one', 'two', '3'], )
```
Here is the old output:
```
[wink@wink-envy c-mpscfifo]$ mesonconf build
Core properties

Source dir /home/wink/prgs/c-mpscfifo
Build dir  /home/wink/prgs/c-mpscfifo/build

Core options

buildtype Build type          debug
warnlevel Warning level       1
strip     Strip on install    False
coverage  Coverage report     False
pch       Precompiled headers True
unity     Unity build         False

Compiler arguments

cargs []

Linker args

clinkargs []

Directories

prefix     Install prefix        /usr/local
libdir     Library directory     lib64
bindir     Binary directory      bin
includedir Header directory      include
datadir    Data directory        share
mandir     Man page directory    share/man
localedir  Locale file directory share/locale

Project options

bool_option   A boolean       False
combo_option  combo_option    two
string_option The description the value of string_option
```
Here is the new output with the 'Possible Values' plus column titles and using two character
indentation:
```
[wink@wink-envy c-mpscfifo]$ ~/foss/meson/mesonconf.py build
Core properties:
  Source dir /home/wink/prgs/c-mpscfifo
  Build dir  /home/wink/prgs/c-mpscfifo/build

Core options:
  Option    Description         Current Value Possible Values
  ------    -----------         ------------- ---------------
  buildtype Build type          debug         ['plain', 'debug', 'debugoptimized', 'release']
  warnlevel Warning level       1             ['1', '2', '3']
  strip     Strip on install    False         [True, False]
  coverage  Coverage report     False         [True, False]
  pch       Precompiled headers True          [True, False]
  unity     Unity build         False         [True, False]

Compiler arguments:
  cargs []

Linker args:
  clinkargs []

Directories:
  Option     Description           Current Value 
  ------     -----------           ------------- 
  prefix     Install prefix        /usr/local    
  libdir     Library directory     lib64         
  bindir     Binary directory      bin           
  includedir Header directory      include       
  datadir    Data directory        share         
  mandir     Man page directory    share/man     
  localedir  Locale file directory share/locale  

Project options:
  Option        Description     Current Value Possible Values
  ------        -----------     ------------- ---------------
  bool_option   A boolean       False         ['True', 'False']
  combo_option  combo_option    two           ['one', 'two', '3']
  string_option The description String B      ['String A', 'String B'] 
```