### PR TITLE
Add optional configuration and define args to compiler.has_header().

### DIFF
--- a/interpreter.py
+++ b/interpreter.py
@@ -686,12 +686,19 @@ class CompilerHolder(InterpreterObject):
         if len(args) != 1:
             raise InterpreterException('has_header method takes exactly one argument.')
         check_stringlist(args)
+        conf = kwargs.get('configuration', None)
+        if conf is not None and not isinstance(conf, ConfigurationDataHolder):
+            raise InterpreterException('Second argument must be configuration_data.')
         string = args[0]
         haz = self.compiler.has_header(string)
         if haz:
             h = mlog.green('YES')
         else:
             h = mlog.red('NO')
+        if conf:
+            havehdr = 'HAVE_' + str(string).upper().replace('\\', '_').replace('/', '_').replace('.', '_')
+            define = kwargs.get('define', havehdr)
+            conf.held_object.values[define] = 1 if haz else 0
         mlog.log('Has header "%s":' % string, h)
         return haz
 

--- a/test cases/common/94 has header conf/config.h.in
+++ b/test cases/common/94 has header conf/config.h.in
@@ -1,0 +1,1 @@
+#mesondefine HAVE_STDIO_H

--- a/test cases/common/94 has header conf/meson.build
+++ b/test cases/common/94 has header conf/meson.build
@@ -1,0 +1,11 @@
+project('has header', 'c')
+
+cc = meson.get_compiler('c')
+
+conf = configuration_data()
+cc.has_header('stdio.h', configuration : conf)
+cfile = configure_file(input : 'config.h.in',
+output : 'config.h',
+configuration : conf)
+
+test('inctest', executable('inctest', 'prog.c'))

--- a/test cases/common/94 has header conf/prog.c
+++ b/test cases/common/94 has header conf/prog.c
@@ -1,0 +1,12 @@
+#include "config.h"
+#ifdef HAVE_STDIO_H
+#include <stdio.h>
+#else
+#error "FAIL!"
+#endif
+
+int main(int argc, char **argv) {
+    (void) argc;
+    (void) argv;
+    return 0;
+}


### PR DESCRIPTION
This is a bit of a **cowboy** PR. Any feedback is welcome.

First of all, please clean it up as much as you like. Python is not something I use daily.

Second, this is one of the things I like with waf.io. It is very simple to write the config.h.
First thing I noticed when using Meson was that the meson.build file becomes unreadable (in my case I check for 20 headers. (Same goes for a library like glib I guess)) with the normal
```
if cc.has_header('stdlib.h')
  conf.set('HAVE_STDLIB_H')
endif
```
it is also (*more*) error prone when you copy/paste (which is very common thing to do when you are working on build files).

with this patch you only need one line
```
cc.has_header('stdlib.h', configuration : conf)
```

waf.io also generates config.h from scratch without a template config.h.in file which I also likes. Meaning that adding a header check is actually only one line in the build file.

If you think my suggestions are just plain wrong or if this is going in the wrong direction, please educate me and close the pull request. No hard feelings.

Next thing on my list would be to do the same for has_function and others obviously :)