### PR TITLE
Fix cross compile execution test.

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -23,3 +23,4 @@ Marko Raatikainen
 German Diago Gomez
 Kyle Manna
 Haakon Sporsheim
+Wink Saville

--- a/compilers.py
+++ b/compilers.py
@@ -263,13 +263,20 @@ class CCompiler(Compiler):
         ofile = open(source_name, 'w')
         ofile.write('int main(int argc, char **argv) { int class=0; return class; }\n')
         ofile.close()
-        pc = subprocess.Popen(self.exelist + [source_name, '-o', binary_name])
+        cmdlist = self.exelist + [source_name]
+        if self.is_cross and (self.exe_wrapper is None):
+            # Compile only as there is no execution wrapper
+            binary_name += '.o'
+            cmdlist += ['-c']
+        cmdlist += ['-o', binary_name]
+        mlog.debug('Compile test command: ' + ' '.join(cmdlist))
+        pc = subprocess.Popen(cmdlist)
         pc.wait()
         if pc.returncode != 0:
             raise EnvironmentException('Compiler %s can not compile programs.' % self.name_string())
         if self.is_cross:
             if self.exe_wrapper is None:
-                # Can't check if the binaries run so we have to assume they do
+                mlog.debug('Cross compile and no exe_wrapper, do not run and assume OK')
                 return
             cmdlist = self.exe_wrapper + [binary_name]
         else:


### PR DESCRIPTION
If this is a cross compile build type but there is no execution wrapper
then we can only compile and do not attempt to link. The reason is for
bare metal builds the run time is unknown and linking will fail.