### PR TITLE
Change type_suffix to return dash-xxx.

### DIFF
--- a/build.py
+++ b/build.py
@@ -611,7 +611,7 @@ class Executable(BuildTarget):
             self.filename = self.name
 
     def type_suffix(self):
-        return "@exe"
+        return "-exe"
 
 class StaticLibrary(BuildTarget):
     def __init__(self, name, subdir, subproject, is_cross, sources, objects, environment, kwargs):
@@ -631,7 +631,7 @@ class StaticLibrary(BuildTarget):
         return self.get_filename()
 
     def type_suffix(self):
-        return "@sta"
+        return "-sta"
 
 class SharedLibrary(BuildTarget):
     def __init__(self, name, subdir, subproject, is_cross, sources, objects, environment, kwargs):
@@ -702,7 +702,7 @@ class SharedLibrary(BuildTarget):
         return aliases
 
     def type_suffix(self):
-        return "@sha"
+        return "-sha"
 
 class CustomTarget:
     known_kwargs = {'input' : True,
@@ -824,7 +824,7 @@ class CustomTarget:
         return []
 
     def type_suffix(self):
-        return "@cus"
+        return "-cus"
 
 class RunTarget:
     def __init__(self, name, command, args, subdir):
@@ -858,7 +858,7 @@ class RunTarget:
         return self.name
 
     def type_suffix(self):
-        return "@run"
+        return "-run"
 
 class Jar(BuildTarget):
     def __init__(self, name, subdir, subproject, is_cross, sources, objects, environment, kwargs):
@@ -872,7 +872,7 @@ class Jar(BuildTarget):
         return self.main_class
 
     def type_suffix(self):
-        return "@jar"
+        return "-jar"
 
 class ConfigureFile():
 


### PR DESCRIPTION
Using an @ in a file name for linker scripts is not allowed,
this also could be a problem for other programs, so I suggest
using dash, '-', rather than @.

As an example in baremetal-hi/link.meson.ld, the current solution that
Jussi provided was to use an asterisk, '*', in the file name see:
  https://github.com/winksaville/baremetal-hi/commit/d358e064bb6526df2a221d022df600093cd61c89

But using an asterisk to resolve the problem could cause multiple matches
leading to unforeseen errors.