### PR TITLE
Can specify a subproject fallback for dependencies.

### DIFF
--- a/test cases/common/95 dep fallback/meson.build
+++ b/test cases/common/95 dep fallback/meson.build
@@ -1,0 +1,6 @@
+project('dep fallback', 'c')
+
+bob = dependency('boblib', fallback : ['boblib', 'bob_dep'])
+
+exe = executable('bobtester', 'tester.c', dependencies : bob)
+test('bobtester', exe)

--- a/test cases/common/95 dep fallback/subprojects/boblib/bob.c
+++ b/test cases/common/95 dep fallback/subprojects/boblib/bob.c
@@ -1,0 +1,5 @@
+#include"bob.h"
+
+const char* get_bob() {
+    return "bob";
+}

--- a/test cases/common/95 dep fallback/subprojects/boblib/bob.h
+++ b/test cases/common/95 dep fallback/subprojects/boblib/bob.h
@@ -1,0 +1,3 @@
+#pragma once
+
+const char* get_bob();

--- a/test cases/common/95 dep fallback/subprojects/boblib/meson.build
+++ b/test cases/common/95 dep fallback/subprojects/boblib/meson.build
@@ -1,0 +1,7 @@
+project('bob', 'c')
+
+boblib = static_library('bob', 'bob.c')
+bobinc = include_directories('.')
+
+bob_dep = declare_dependency(link_with : boblib,
+  include_directories : bobinc)

--- a/test cases/common/95 dep fallback/tester.c
+++ b/test cases/common/95 dep fallback/tester.c
@@ -1,0 +1,13 @@
+#include"bob.h"
+#include<string.h>
+#include<stdio.h>
+
+int main(int argc, char **argv) {
+    if(strcmp("bob", get_bob()) == 0) {
+        printf("Bob is indeed bob.\n");
+    } else {
+        printf("ERROR: bob is not bob.\n");
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
Provide a simple one-liner way to fall back to subprojects for an external dependency. That is, instead of this:

    dep = dependency('foobar', required : false)
    if not dep.found()
      sp = subproject('foobar_dir')
      dep = sp.get_variable('foobar_dep')
    endif

you have this:

    dep = dependency('foobar', fallback : ['foobar_dir', foobar_dep'])

Anything more complicated people can do by hand.