### PR TITLE
Back to python 3.3 compatibility

### DIFF
--- a/compilers.py
+++ b/compilers.py
@@ -406,7 +406,12 @@ int someSymbolHereJustForFun;
             cmdlist = self.exe_wrapper + [exename]
         else:
             cmdlist = exename
-        pe = subprocess.Popen(cmdlist, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        try:
+            pe = subprocess.Popen(cmdlist, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        except Exception as e:
+            mlog.debug('Could not run: %s (error: %s)\n' % (cmdlist, e))
+            return RunResult(False)
+
         (so, se) = pe.communicate()
         so = so.decode()
         se = se.decode()

--- a/interpreter.py
+++ b/interpreter.py
@@ -1150,7 +1150,7 @@ class Interpreter():
             raise InvalidCode('First argument to set_variable must be a string.')
         if not self.is_assignable(variable):
             raise InvalidCode('Assigned value not of assignable type.')
-        if re.fullmatch('[_a-zA-Z][_0-9a-zA-Z]*', varname) is None:
+        if re.match('[_a-zA-Z][_0-9a-zA-Z]*$', varname) is None:
             raise InvalidCode('Invalid variable name: ' + varname)
         if varname in self.builtin:
             raise InvalidCode('Tried to overwrite internal variable "%s"' % varname)

--- a/meson.py
+++ b/meson.py
@@ -164,8 +164,8 @@ itself as required.'''
         pickle.dump(b, open(dumpfile, 'wb'))
 
 def run(args):
-    if sys.version_info < (3, 4):
-        print('Meson works correctly only with python 3.4+.')
+    if sys.version_info < (3, 3):
+        print('Meson works correctly only with python 3.3+.')
         print('You have python %s.' % sys.version)
         print('Please update your environment')
         return 1

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ build system.
 
 Dependencies
 
-Python   http://python.org (version 3.4 or newer)
+Python   http://python.org (version 3.3 or newer)
 Ninja    http://martine.github.com/ninja/
 
 


### PR DESCRIPTION
I might not be right but I do not get why you need `fullmatch` for that regex?

Current xdg-app for Gnome 3.18 only has python 3.3, so it would be good to bring back compatibility. 