### PR TITLE
cpp_std trivial fixes

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -25,3 +25,4 @@ Kyle Manna
 Haakon Sporsheim
 Wink Saville
 Yoav Alon
+Martin Ejdestig

--- a/compilers.py
+++ b/compilers.py
@@ -1423,7 +1423,7 @@ class GnuCPPCompiler(CPPCompiler):
 
     def get_options(self):
         opts = {'cpp_std' : coredata.UserComboOption('cpp_std', 'C++ language standard to use',
-                                                     ['none', 'c++03', 'c++11', 'c++1y'],
+                                                     ['none', 'c++03', 'c++11', 'c++14'],
                                                      'c++11')}
         if self.gcc_type == GCC_MINGW:
             opts.update({
@@ -1469,7 +1469,7 @@ class ClangCPPCompiler(CPPCompiler):
 
     def get_options(self):
         return {'cpp_std' : coredata.UserComboOption('cpp_std', 'C++ language standard to use',
-                                                   ['none', 'c++03', 'c++11', 'c++1y'],
+                                                   ['none', 'c++03', 'c++11', 'c++14'],
                                                    'c++11')}
 
     def get_option_compile_args(self, options):

--- a/compilers.py
+++ b/compilers.py
@@ -1422,7 +1422,7 @@ class GnuCPPCompiler(CPPCompiler):
         return get_gcc_soname_args(self.gcc_type, shlib_name, path, soversion)
 
     def get_options(self):
-        opts = {'cpp_std' : coredata.UserComboOption('cpp_std', 'C language standard to use',
+        opts = {'cpp_std' : coredata.UserComboOption('cpp_std', 'C++ language standard to use',
                                                      ['none', 'c++03', 'c++11', 'c++1y'],
                                                      'c++11')}
         if self.gcc_type == GCC_MINGW:


### PR DESCRIPTION
The first commit fixes a typo, but I am a bit hesitant about the second commit.

Should the list be extended with c++14 instead? I chose not to do that since I figured c++1y was just temporary until the standard was finished (and it is decprecated in GCC now). But how is backwards compatibility handled in Meson at this stage? Will this break projects that rely on c++1y? Is that OK?

I used "project(..., default_options : [ 'cpp_std=c++14' ])" before this change so I am guessing the check is not that strict. Though... is it supposed to be and I was just lucky and stumbled into a bug?