### PR TITLE
Some fixes

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -26,3 +26,4 @@ Haakon Sporsheim
 Wink Saville
 Yoav Alon
 Martin Ejdestig
+Rémi Nicole

--- a/ninjabackend.py
+++ b/ninjabackend.py
@@ -1740,7 +1740,7 @@ rule FORTRAN_DEP_HACK
             gcno_elem.add_item('COMMAND', [sys.executable, clean_script, '.', 'gcno'])
             gcno_elem.add_item('description', 'Deleting gcno files')
             gcno_elem.write(outfile)
-            self.check_outputs(gcno_elem, gcno_elem)
+            self.check_outputs(gcno_elem)
 
             gcda_elem = NinjaBuildElement('clean-gcda', 'CUSTOM_COMMAND', 'PHONY')
             script_root = self.environment.get_script_dir()

--- a/optinterpreter.py
+++ b/optinterpreter.py
@@ -100,7 +100,7 @@ class OptionInterpreter:
         elif isinstance(arg, mparser.ArrayNode):
             return [self.reduce_single(curarg) for curarg in arg.args.arguments]
         elif isinstance(arg, mparser.NumberNode):
-            return arg.get_value()
+            return arg.value
         else:
             raise OptionException('Arguments may only be string, int, bool, or array of those.')
 


### PR DESCRIPTION
Theses are some fixes that my system didn't like, namely:

- In `ninjabackend.py:1743`, call to a function that takes a unique parameter with 2 arguments (made Meson crash when enabling gcov)
- In `optinterpreter.py:103`, call to a undefined function (made Meson crash when having some options)