### PR TITLE
meson: try harder to infer build and source directories if called wit…

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -223,15 +223,22 @@ def run(mainfile, args):
         return 0
     args = options.directories
     if len(args) == 0 or len(args) > 2:
-        print('{} <source directory> <build directory>'.format(sys.argv[0]))
-        print('If you omit either directory, the current directory is substituted.')
-        print('Run {} --help for more information.'.format(sys.argv[0]))
-        return 1
-    dir1 = args[0]
-    if len(args) > 1:
-        dir2 = args[1]
+        # if there's a meson.build in the dir above, and not in the current
+        # directory, assume we're in the build directory
+        if len(args) == 0 and not os.path.exists('meson.build') and os.path.exists('../meson.build'):
+            dir1 = '..'
+            dir2 = '.'
+        else:
+            print('{} <source directory> <build directory>'.format(sys.argv[0]))
+            print('If you omit either directory, the current directory is substituted.')
+            print('Run {} --help for more information.'.format(sys.argv[0]))
+            return 1
     else:
-        dir2 = '.'
+        dir1 = args[0]
+        if len(args) > 1:
+            dir2 = args[1]
+        else:
+            dir2 = '.'
     while os.path.islink(mainfile):
         resolved = os.readlink(mainfile)
         if resolved[0] != '/':


### PR DESCRIPTION
…hout arguments

If there's no meson.build file in the current directory
and there is one in the parent directory, assume that
we are in the build directory.

Don't know how you feel about this I think a common pattern is to create a build directory as sub-dir of the source directory, and it would be nice if one could just call 'meson' and it'd do the right thing automatically, but I can also see why one wouldn't want this of course, so feel free to reject.

(Didn't add myself to authors because it seems too trivial)