### PR TITLE
compilers: Don't pass /D for debugoptimized build type

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -28,3 +28,4 @@ Yoav Alon
 Martin Ejdestig
 Rémi Nicole
 Damián Nohales
+Nirbheek Chauhan

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -61,7 +61,7 @@ gnulike_buildtype_args = {'plain' : [],
 
 msvc_buildtype_args = {'plain' : [],
                        'debug' : ["/MDd", "/ZI", "/Ob0", "/Od", "/RTC1"],
-                       'debugoptimized' : ["/MD", "/Zi", "/O2", "/Ob1", "/D"],
+                       'debugoptimized' : ["/MD", "/Zi", "/O2", "/Ob1"],
                        'release' : ["/MD", "/O2", "/Ob2"]}
 
 gnulike_buildtype_linker_args = {}


### PR DESCRIPTION
/D is the same as -D and stands for define not debug. Passing this would swallow
the next argument.