### PR TITLE
compilers: /LD is not needed for PIC support in DLLs

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1128,7 +1128,7 @@ class VisualStudioCCompiler(CCompiler):
         return ['/OUT:' + outputname]
 
     def get_pic_args(self):
-        return ['/LD']
+        return [] # PIC is handled by the loader on Windows
 
     def get_std_shared_lib_link_args(self):
         return ['/DLL']


### PR DESCRIPTION
On Windows, the advantages of PIC are provided by the runtime DLL loader. /LD is
also only valid as an argument to cl.exe, and the linker link.exe just barfs
when it sees it.

The code assumes that the compiler is the same as the linker which caused this
problem to occur.