### PR TITLE
compilers: MSVC does not understand the -lfoo syntax

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1179,6 +1179,9 @@ class VisualStudioCCompiler(CCompiler):
         for i in args:
             if i.startswith('-L'):
                 i = '/LIBPATH:' + i[2:]
+            # Translate GNU-style -lfoo library name to the import library
+            if i.startswith('-l'):
+                i = i[2:] + '.lib'
             result.append(i)
         return result
 


### PR DESCRIPTION
The only way we get -lfoo syntax is from pkg-config files generated using
mingw-gcc, in which case what we really want is the dll.a import library, so
just translate -lfoo to libfoo.dll.a