### PR TITLE
interpreter: Add path() method to ExternalProgramHolder types

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -808,6 +808,8 @@ class CustomTarget:
                     if not isinstance(s, str):
                         raise InvalidArguments('Array as argument %d contains a non-string.' % i)
                     final_cmd.append(s)
+            elif isinstance(c, File):
+                final_cmd.append(os.path.join(c.subdir, c.fname))
             else:
                 raise InvalidArguments('Argument %s in "command" is invalid.' % i)
         self.command = final_cmd

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -242,10 +242,14 @@ class ExternalProgramHolder(InterpreterObject):
     def __init__(self, ep):
         InterpreterObject.__init__(self)
         self.held_object = ep
-        self.methods.update({'found': self.found_method})
+        self.methods.update({'found': self.found_method,
+                             'path': self.path_method})
 
     def found_method(self, args, kwargs):
         return self.found()
+
+    def path_method(self, args, kwargs):
+        return self.get_command()
 
     def found(self):
         return self.held_object.found()

--- a/test cases/common/105 find program path/meson.build
+++ b/test cases/common/105 find program path/meson.build
@@ -1,0 +1,11 @@
+project('find program', 'c')
+
+prog = find_program('program.py')
+
+# Use either Python3 or 2 to run this
+python = find_program('python3', required : false)
+if not python.found()
+  python = find_program('python')
+endif
+
+run_command(python, prog.path())

--- a/test cases/common/105 find program path/program.py
+++ b/test cases/common/105 find program path/program.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print("Found")


### PR DESCRIPTION
In practice, with these two commits we can do:

```
flex = find_program('flex')
cdata.set('FLEX', flex.path())
if cc.get_id() == 'msvc'
  cdata.set('FLEX_ARGS', '--wincompat')
else
  cdata.set('FLEX_ARGS', '')
endif

gen_lex = configure_file(input : 'gen_lex.py.in',
  output : 'gen_lex.py',
  configuration : cdata)

parser = custom_target('parselex',
  input : 'parse.l',
  output : ['lex.priv_gst_parse_yy.c', 'parse_lex.h'],
  command : [python, gen_lex, '@OUTPUT0@', '@OUTPUT1@', '@INPUT@', 'DUMMY']
)
```