### PR TITLE
Filter out UNIX flags from external deps when using the MSVC compiler

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -245,7 +245,9 @@ class Backend():
         if isinstance(target, build.SharedLibrary):
             commands += compiler.get_pic_args()
         for dep in target.get_external_deps():
-            commands += dep.get_compile_args()
+            # Cflags required by external deps might have UNIX-specific flags,
+            # so filter them out if needed
+            commands += compiler.unix_compile_flags_to_native(dep.get_compile_args())
             if isinstance(target, build.Executable):
                 commands += dep.get_exe_args()
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1681,7 +1681,7 @@ rule FORTRAN_DEP_HACK
         custom_target_libraries = self.get_custom_target_provided_libraries(target)
         commands += extra_args
         commands += custom_target_libraries
-        commands = linker.unixtype_flags_to_native(commands)
+        commands = linker.unix_link_flags_to_native(commands)
         dep_targets = [self.get_dependency_filename(t) for t in dependencies]
         dep_targets += [os.path.join(self.environment.source_dir,
                                      target.subdir, t) for t in target.link_depends]

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -184,7 +184,10 @@ class Compiler():
     def has_function(self, *args, **kwargs):
         raise EnvironmentException('Language %s does not support function checks.' % self.language)
 
-    def unixtype_flags_to_native(self, args):
+    def unix_link_flags_to_native(self, args):
+        return args
+
+    def unix_compile_flags_to_native(self, args):
         return args
 
 class CCompiler(Compiler):
@@ -1174,11 +1177,20 @@ class VisualStudioCCompiler(CCompiler):
     def get_option_link_args(self, options):
         return options['c_winlibs'].value
 
-    def unixtype_flags_to_native(self, args):
+    def unix_link_flags_to_native(self, args):
         result = []
         for i in args:
             if i.startswith('-L'):
                 i = '/LIBPATH:' + i[2:]
+            result.append(i)
+        return result
+
+    def unix_compile_flags_to_native(self, args):
+        result = []
+        for i in args:
+            # -mms-bitfields is specific to MinGW-GCC
+            if i == '-mms-bitfields':
+                continue
             result.append(i)
         return result
 
@@ -1799,7 +1811,10 @@ class VisualStudioLinker():
     def get_option_link_args(self, options):
         return []
 
-    def unixtype_flags_to_native(self, args):
+    def unix_link_flags_to_native(self, args):
+        return args
+
+    def unix_compile_flags_to_native(self, args):
         return args
 
 class ArLinker():
@@ -1845,5 +1860,8 @@ class ArLinker():
     def get_option_link_args(self, options):
         return []
 
-    def unixtype_flags_to_native(self, args):
+    def unix_link_flags_to_native(self, args):
+        return args
+
+    def unix_compile_flags_to_native(self, args):
         return args


### PR DESCRIPTION
This is very useful to prevent compiler noise about invalid cflags; particularly for the -mms-bitfields cflag which most libraries send to the mingw-gcc compiler. More can be added later, and perhaps some unix cflags can be translated as well.

I also renamed "unixtype_flags_to_native" to be more specific because it only filters link flags (and is only used during linking).