### PR TITLE
Add support for passing a module definitions file for exporting symbols while linking

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1657,6 +1657,8 @@ rule FORTRAN_DEP_HACK
             else:
                 soversion = None
             commands += linker.get_soname_args(target.name, abspath, soversion)
+            if target.vs_module_defs and hasattr(linker, 'gen_vs_module_defs_args'):
+                commands += linker.gen_vs_module_defs_args(target.vs_module_defs.rel_to_builddir(self.build_to_src))
         elif isinstance(target, build.StaticLibrary):
             commands += linker.get_std_link_args()
         else:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -47,7 +47,7 @@ known_shlib_kwargs.update({'version' : True,
                            'soversion' : True,
                            'name_prefix' : True,
                            'name_suffix' : True,
-                           })
+                           'vs_module_defs' : True})
 
 backslash_explanation = \
 '''Compiler arguments have a backslash "\\" character. This is unfortunately not
@@ -703,6 +703,7 @@ class SharedLibrary(BuildTarget):
     def __init__(self, name, subdir, subproject, is_cross, sources, objects, environment, kwargs):
         self.version = None
         self.soversion = None
+        self.vs_module_defs = None
         super().__init__(name, subdir, subproject, is_cross, sources, objects, environment, kwargs);
         if len(self.sources) > 0 and self.sources[0].endswith('.cs'):
             prefix = 'lib'
@@ -726,6 +727,12 @@ class SharedLibrary(BuildTarget):
             self.set_version(kwargs['version'])
         if 'soversion' in kwargs:
             self.set_soversion(kwargs['soversion'])
+        if 'vs_module_defs' in kwargs:
+            path = kwargs['vs_module_defs']
+            if (os.path.isabs(path)):
+                self.vs_module_defs = File.from_absolute_file(path)
+            else:
+                self.vs_module_defs = File.from_source_file(environment.source_dir, self.subdir, path)
 
     def check_unknown_kwargs(self, kwargs):
         self.check_unknown_kwargs_int(kwargs, known_shlib_kwargs)

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1252,6 +1252,13 @@ class VisualStudioCCompiler(CCompiler):
     def get_std_shared_lib_link_args(self):
         return ['/DLL']
 
+    def gen_vs_module_defs_args(self, defsfile):
+        if not isinstance(defsfile, str):
+            raise RuntimeError('Module definitions file should be str')
+        # With MSVC, DLLs only export symbols that are explicitly exported,
+        # so if a module defs file is specified, we use that to export symbols
+        return ['/DEF:' + defsfile]
+
     def gen_pch_args(self, header, source, pchname):
         objname = os.path.splitext(pchname)[0] + '.obj'
         return (objname, ['/Yc' + header, '/Fp' + pchname, '/Fo' + objname ])

--- a/test cases/failing/28 no vs module defs/meson.build
+++ b/test cases/failing/28 no vs module defs/meson.build
@@ -1,0 +1,9 @@
+project('dll_no_module_def', 'c')
+
+if meson.get_compiler('c').get_id() != 'msvc'
+  error('Need to use the Visual Studio compiler')
+endif
+
+subdir('subdir')
+exe = executable('prog', 'prog.c', link_with : shlib)
+test('runtest', exe)

--- a/test cases/failing/28 no vs module defs/prog.c
+++ b/test cases/failing/28 no vs module defs/prog.c
@@ -1,0 +1,5 @@
+int somedllfunc();
+
+int main(int argc, char **argv) {
+    return somedllfunc() == 42 ? 0 : 1;
+}

--- a/test cases/failing/28 no vs module defs/subdir/meson.build
+++ b/test cases/failing/28 no vs module defs/subdir/meson.build
@@ -1,0 +1,1 @@
+shlib = shared_library('somedll', 'somedll.c')

--- a/test cases/failing/28 no vs module defs/subdir/somedll.c
+++ b/test cases/failing/28 no vs module defs/subdir/somedll.c
@@ -1,0 +1,7 @@
+/* With MSVC, the DLL created from this will not export any symbols
+ * without a module definitions file specified while linking */
+#ifdef _MSC_VER
+int somedllfunc() {
+    return 42;
+}
+#endif

--- a/test cases/windows/6 vs module defs/meson.build
+++ b/test cases/windows/6 vs module defs/meson.build
@@ -1,0 +1,7 @@
+project('dll_module_defs', 'c')
+
+if meson.get_compiler('c').get_id() == 'msvc'
+  subdir('subdir')
+  exe = executable('prog', 'prog.c', link_with : shlib)
+  test('runtest', exe)
+endif

--- a/test cases/windows/6 vs module defs/prog.c
+++ b/test cases/windows/6 vs module defs/prog.c
@@ -1,0 +1,5 @@
+int somedllfunc();
+
+int main(int argc, char **argv) {
+    return somedllfunc() == 42 ? 0 : 1;
+}

--- a/test cases/windows/6 vs module defs/subdir/meson.build
+++ b/test cases/windows/6 vs module defs/subdir/meson.build
@@ -1,0 +1,1 @@
+shlib = shared_library('somedll', 'somedll.c', vs_module_defs : 'somedll.def')

--- a/test cases/windows/6 vs module defs/subdir/somedll.c
+++ b/test cases/windows/6 vs module defs/subdir/somedll.c
@@ -1,0 +1,5 @@
+#ifdef _MSC_VER
+int somedllfunc() {
+    return 42;
+}
+#endif

--- a/test cases/windows/6 vs module defs/subdir/somedll.def
+++ b/test cases/windows/6 vs module defs/subdir/somedll.def
@@ -1,0 +1,3 @@
+EXPORTS
+	somedllfunc
+


### PR DESCRIPTION
On MSVC, shared libraries only export symbols that have been explicitly exported
either as part of the symbol prototype or via a module definitions file. On
compilers other than MSVC, all symbols are exported in the shared library by
default so this would be a no-op there.

The module defs file path can either be relative to the current source directory
or an absolute path using meson.source_root() + '/some/path'