### PR TITLE
Bunch of minor changes

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -83,7 +83,9 @@ class Backend():
         targetdir = self.get_target_dir(target)
         fname = target.get_filename()
         if isinstance(fname, list):
-            fname = fname[0] # HORROR, HORROR! Fix this.
+            # FIXME FIXME FIXME: build.CustomTarget has multiple output files
+            # and get_filename() returns them all
+            fname = fname[0]
         filename = os.path.join(targetdir, fname)
         return filename
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -62,7 +62,7 @@ class UserStringOption(UserOption):
         if not isinstance(value, str):
             raise MesonException('Value "%s" for string option "%s" is not a string.' % (str(newvalue), self.name))
         if self.name == 'prefix' and not os.path.isabs(value):
-            raise MesonException('Prefix option must be an absolute path.')
+            raise MesonException('Prefix option value \'{0}\' must be an absolute path.'.format(value))
         if self.name in ('libdir', 'bindir', 'includedir', 'datadir', 'mandir', 'localedir') \
             and os.path.isabs(value):
             raise MesonException('Option %s must not be an absolute path.' % self.name)

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -82,7 +82,7 @@ class MesonApp():
     def __init__(self, dir1, dir2, script_file, handshake, options):
         (self.source_dir, self.build_dir) = self.validate_dirs(dir1, dir2, handshake)
         if not os.path.isabs(options.prefix):
-            raise RuntimeError('--prefix must be an absolute path.')
+            raise RuntimeError('--prefix value \'{0}\' must be an absolute path: '.format(options.prefix))
         if options.prefix.endswith('/') or options.prefix.endswith('\\'):
             options.prefix = options.prefix[:-1]
         self.meson_script_file = script_file


### PR DESCRIPTION
Update a comment, print prefix when erroring out due to invalid prefix.

On Windows, the default prefix when running from git seems to be "c:" which is not a valid absolute path according to Python (it should be c:\"), which is how I came across that. I'm still debugging that issue, and will post another patch for that later.