### PR TITLE
ninjabackend: Try symlinking and ignore if it doesn't work

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1717,16 +1717,16 @@ rule FORTRAN_DEP_HACK
     def generate_shlib_aliases(self, target, outdir):
         basename = target.get_filename()
         aliases = target.get_aliaslist()
-        if not mesonlib.is_windows():
-            for alias in aliases:
-                aliasfile = os.path.join(self.environment.get_build_dir(), outdir, alias)
-                try:
-                    os.remove(aliasfile)
-                except Exception:
-                    pass
+        for alias in aliases:
+            aliasfile = os.path.join(self.environment.get_build_dir(), outdir, alias)
+            try:
+                os.remove(aliasfile)
+            except Exception:
+                pass
+            try:
                 os.symlink(basename, aliasfile)
-        else:
-            mlog.debug("Library versioning disabled because host does not support symlinks.")
+            except OSError:
+                mlog.debug("Library versioning disabled because we do not have symlink creation privileges")
 
     def generate_gcov_clean(self, outfile):
             gcno_elem = NinjaBuildElement(self.all_outputs, 'clean-gcno', 'CUSTOM_COMMAND', 'PHONY')


### PR DESCRIPTION
Instead of checking if we're on Windows and not even trying, try to symlink and if that fails due to insufficient privileges, then just continue. This allows people who know what they're doing to allow users other than Administrators to make symlinks on Windows, or allows them to just run Meson as an Administrator.

I will note however that DLLs should not have aliases that are symlinked anyway (and the library versioning information should not be in the filename for DLLs either). Will send a patch for that once I have one.