### PR TITLE
Re-introduce patch to fix linking with MSVC by linking with import library

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -87,6 +87,14 @@ class Backend():
         filename = os.path.join(targetdir, fname)
         return filename
 
+    def get_target_filename_for_linking(self, target):
+        # On some platforms (msvc for instance), the file that is used for
+        # dynamic linking is not the same as the dynamic library itself. This
+        # file is called an import library, and we want to link against that.
+        # On platforms where this distinction is not important, the import
+        # library is the same as the dynamic library itself.
+        return os.path.join(self.get_target_dir(target), target.get_import_filename())
+
     def get_target_dir(self, target):
         if self.environment.coredata.get_builtin_option('layout') == 'mirror':
             dirname = target.get_subdir()
@@ -263,11 +271,7 @@ class Backend():
             if not isinstance(d, build.StaticLibrary) and\
             not isinstance(d, build.SharedLibrary):
                 raise RuntimeError('Tried to link with a non-library target "%s".' % d.get_basename())
-            fname = self.get_target_filename(d)
-            if compiler.id == 'msvc':
-                if fname.endswith('dll'):
-                    fname = fname[:-3] + 'lib'
-            args.append(fname)
+            args.append(self.get_target_filename_for_linking(d))
             # If you have executable e that links to shared lib s1 that links to shared library s2
             # you have to specify s2 as well as s1 when linking e even if e does not directly use
             # s2. Gcc handles this case fine but Clang does not for some reason. Thus we need to

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -98,7 +98,12 @@ class Environment():
         if (not cross and mesonlib.is_windows()) \
         or (cross and self.cross_info.has_host() and self.cross_info.config['host_machine']['system'] == 'windows'):
             self.exe_suffix = 'exe'
-            self.import_lib_suffix = 'lib'
+            if self.detect_c_compiler(cross).get_id() == 'msvc':
+                self.import_lib_suffix = 'lib'
+            else:
+                # MinGW-GCC doesn't generate and can't link with a .lib
+                # It uses the DLL file as the import library
+                self.import_lib_suffix = 'dll'
             self.shared_lib_suffix = 'dll'
             self.shared_lib_prefix = ''
             self.static_lib_suffix = 'lib'
@@ -546,7 +551,7 @@ class Environment():
     def get_exe_suffix(self):
         return self.exe_suffix
 
-    # On Windows the library has suffix dll
+    # On Windows (MSVC) the library has suffix dll
     # but you link against a file that has suffix lib.
     def get_import_lib_suffix(self):
         return self.import_lib_suffix


### PR DESCRIPTION
The previous patch that did this had to be reverted because it broke compilation with MinGW-GCC.

The attached patch series now also makes sure to set the import lib suffix to .dll when building on Windows with MinGW-GCC since GCC does not use import libraries at all (hence the DLL **is** the import library).

I'm detecting the compiler when the environment is initialized, but I can't think of another layer to do this at. Above the environment is the build.BuildTarget (which doesn't keep a reference to the compiler) and then the top-level Backends class (which can't know).