### PR TITLE
meson_install: os.symlink may be implemented and still not work

### DIFF
--- a/mesonbuild/scripts/meson_install.py
+++ b/mesonbuild/scripts/meson_install.py
@@ -194,7 +194,7 @@ def install_targets(d):
                 except FileNotFoundError:
                     pass
                 os.symlink(os.path.split(fname)[-1], symlinkfilename)
-            except NotImplementedError:
+            except (NotImplementedError, OSError):
                 if not printed_symlink_error:
                     print("Symlink creation does not work on this platform.")
                     printed_symlink_error = True


### PR DESCRIPTION
If os.symlink is implemented but isn't allowed, meson_install will error out. This trivial change fixes that.