### PR TITLE
Do not pass -Weverything to Clang at warning level 3

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1393,7 +1393,7 @@ class ClangCCompiler(CCompiler):
         self.id = 'clang'
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch'],
-                          '3' : ['-Weverything']}
+                          '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch']}
 
     def get_buildtype_args(self, buildtype):
         return gnulike_buildtype_args[buildtype]
@@ -1484,7 +1484,7 @@ class ClangCPPCompiler(CPPCompiler):
         self.id = 'clang'
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor'],
-                          '3': ['-Weverything']}
+                          '3': ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor']}
 
     def get_buildtype_args(self, buildtype):
         return gnulike_buildtype_args[buildtype]


### PR DESCRIPTION
-Weverything is not a good match for behavior of other compilers at warning
level 3. Align flags with what Meson passes to GCC instead.

The warnings generated are often conflicting with what the user most
probably wants. E.g.:

* -Wc++98-compat does not make sense when building code that uses -std= to
  set a later standard.

* -Wpadding warns when compiler pads classes and structs for better
  performance, probably something the user wants.

These warnings, and maybe a couple of others, can of course be disabled by
Meson with -Wno-* but it is not future proof (other warnings that makes
sense to disable by default may be added which means Meson will probably
have to pass different flags depending on the Clang version).

It is also problematic to compile many system and library headers with
-Weverything. For instance:

* stdio.h and sigaction.h on Linux makes use of recursive macros
  (-Wdisabled-macro-expansion).

* Many library headers make use of deprecated functionality (-Wdeprecated).

* Many library (e.g. GTK+ and Qt) headers trigger Clangs Doxygen warnings
  (-Wdocumentation-unknown-command and -Wdocumentation).

There are a couple of more warnings that need to be disabled when building
files that use GTK+ and Qt. GTest is also problematic.