### PR TITLE
Pass warning arguments to compiler even if buildtype is plain

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -241,8 +241,7 @@ class Backend():
     def generate_basic_compiler_args(self, target, compiler):
         commands = []
         commands += compiler.get_always_args()
-        if self.environment.coredata.get_builtin_option('buildtype') != 'plain':
-            commands += compiler.get_warn_args(self.environment.coredata.get_builtin_option('warning_level'))
+        commands += compiler.get_warn_args(self.environment.coredata.get_builtin_option('warning_level'))
         commands += compiler.get_option_compile_args(self.environment.coredata.compiler_options)
         commands += self.build.get_global_args(compiler)
         commands += self.environment.coredata.external_args[compiler.get_language()]


### PR DESCRIPTION
Noticed when trying to pass custom optimization flags, and hence setting
buildtype to plain, that warnings for different levels were not passed to
compiler.

This was a bit confusing since mesonconf still displayed "warning_level=3"
and -Werror was passed correctly due to "werror=true". So this change
aligns warning_level behavior with werror. That is, heed what is in
project() in meson.build but user can still override if necessary.