### PR TITLE
Fix generator test

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -37,7 +37,6 @@ class Vs2010Backend(backends.Backend):
         self.source_suffix_in_obj = False
 
     def generate_custom_generator_commands(self, target, parent_node):
-        idgroup = ET.SubElement(parent_node, 'ItemDefinitionGroup')
         all_output_files = []
         commands = []
         inputs = []
@@ -73,13 +72,15 @@ class Vs2010Backend(backends.Backend):
                     commands.append(' '.join(self.special_quote(fullcmd)))
                     inputs.append(infilename)
                     outputs.extend(outfiles)
-        cbs = ET.SubElement(idgroup, 'CustomBuildStep')
-        ET.SubElement(cbs, 'Command').text = '\r\n'.join(commands)
-        ET.SubElement(cbs, 'Inputs').text = ";".join(inputs)
-        ET.SubElement(cbs, 'Outputs').text = ';'.join(outputs)
-        ET.SubElement(cbs, 'Message').text = 'Generating custom sources.'
-        pg = ET.SubElement(parent_node, 'PropertyGroup')
-        ET.SubElement(pg, 'CustomBuildBeforeTargets').text = 'ClCompile'
+        if len(commands) > 0:
+            idgroup = ET.SubElement(parent_node, 'ItemDefinitionGroup')
+            cbs = ET.SubElement(idgroup, 'CustomBuildStep')
+            ET.SubElement(cbs, 'Command').text = '\r\n'.join(commands)
+            ET.SubElement(cbs, 'Inputs').text = ";".join(inputs)
+            ET.SubElement(cbs, 'Outputs').text = ';'.join(outputs)
+            ET.SubElement(cbs, 'Message').text = 'Generating custom sources.'
+            pg = ET.SubElement(parent_node, 'PropertyGroup')
+            ET.SubElement(pg, 'CustomBuildBeforeTargets').text = 'ClCompile'
         return all_output_files
 
     def generate(self, interp):

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -493,13 +493,12 @@ class Vs2010Backend(backends.Backend):
             for s in gen_src:
                 relpath =  self.relpath(s, target.subdir)
                 ET.SubElement(inc_src, 'CLCompile', Include=relpath)
-        if len(objects) + len(gen_objs) > 0:
+        if len(objects) > 0:
+            # Do not add gen_objs to project file. Those are automatically used by MSBuild, because they are part of
+            # the CustomBuildStep Outputs.
             inc_objs = ET.SubElement(root, 'ItemGroup')
             for s in objects:
                 relpath = s.rel_to_builddir(proj_to_src_root)
-                ET.SubElement(inc_objs, 'Object', Include=relpath)
-            for s in gen_objs:
-                relpath =  self.relpath(s, target.subdir)
                 ET.SubElement(inc_objs, 'Object', Include=relpath)
         ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.targets')
         # Reference the regen target.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -50,7 +50,7 @@ class Vs2010Backend(backends.Backend):
                 if isinstance(exe, build.BuildTarget):
                     exe_file = os.path.join(self.environment.get_build_dir(), self.get_target_filename(exe))
                 else:
-                    exe_file = exe.get_command()
+                    exe_file = exe.get_command()[0]
                 base_args = generator.get_arglist()
                 for i in range(len(infilelist)):
                     if len(infilelist) == len(outfilelist):

--- a/test cases/common/59 object generator/obj_generator.py
+++ b/test cases/common/59 object generator/obj_generator.py
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     ifile = sys.argv[2]
     ofile = sys.argv[3]
     if compiler.endswith('cl'):
-        cmd = [compiler, '/nologo', '/Fo'+ofile, '/c', ifile]
+        cmd = [compiler, '/nologo', '/MDd', '/Fo'+ofile, '/c', ifile]
     else:
         cmd = [compiler, '-c', ifile, '-o', ofile]
     sys.exit(subprocess.call(cmd))


### PR DESCRIPTION
Two issues were fixed:

1. With ninja, we must pass the '/MDd' flag to cl.exe in the generator to fix the usage of conflicting libraries.
2. Generators for vs2010 were completely broken:
a) Generator output files are added to sources, which will be added as <CLCompile Include>. However, MSBuild expects .obj files in <Object Include>.
b) Each generator command was added as a separate CustomBuildStep, but MSBuild only supports a single CustomBuildStep. Thus, all commands must be merged into a single one.