### PR TITLE
vs2010: fix target_to_build_root method

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -217,10 +217,8 @@ class Vs2010Backend(backends.Backend):
         if target.subdir == '':
             return ''
 
-        directories = os.path.split(target.subdir)
-        directories = list(filter(bool,directories)) #Filter out empty strings
-
-        return '/'.join(['..']*len(directories))
+        directories = target.subdir.split(os.sep)
+        return os.sep.join(['..']*len(directories))
 
     def special_quote(self, arr):
         return ['&quot;%s&quot;' % i for i in arr]

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -217,7 +217,7 @@ class Vs2010Backend(backends.Backend):
         if target.subdir == '':
             return ''
 
-        directories = target.subdir.split(os.sep)
+        directories = os.path.normpath(target.subdir).split(os.sep)
         return os.sep.join(['..']*len(directories))
 
     def special_quote(self, arr):

--- a/test cases/common/106 subproject subdir/meson.build
+++ b/test cases/common/106 subproject subdir/meson.build
@@ -1,0 +1,6 @@
+project('proj', 'c')
+subproject('sub')
+libSub = dependency('sub', fallback: ['sub', 'libSub'])
+
+exe = executable('prog', 'prog.c', dependencies: libSub)
+test('subproject subdir', exe)

--- a/test cases/common/106 subproject subdir/prog.c
+++ b/test cases/common/106 subproject subdir/prog.c
@@ -1,0 +1,5 @@
+#include <sub.h>
+
+int main() {
+	return sub();
+}

--- a/test cases/common/106 subproject subdir/subprojects/sub/lib/meson.build
+++ b/test cases/common/106 subproject subdir/subprojects/sub/lib/meson.build
@@ -1,0 +1,2 @@
+lib = static_library('sub', 'sub.c')
+libSub = declare_dependency(include_directories: include_directories('.'), link_with: lib)

--- a/test cases/common/106 subproject subdir/subprojects/sub/lib/sub.c
+++ b/test cases/common/106 subproject subdir/subprojects/sub/lib/sub.c
@@ -1,0 +1,5 @@
+#include "sub.h"
+
+int sub() {
+	return 0;
+}

--- a/test cases/common/106 subproject subdir/subprojects/sub/lib/sub.h
+++ b/test cases/common/106 subproject subdir/subprojects/sub/lib/sub.h
@@ -1,0 +1,6 @@
+#ifndef SUB_H
+#define SUB_H
+
+int sub();
+
+#endif

--- a/test cases/common/106 subproject subdir/subprojects/sub/meson.build
+++ b/test cases/common/106 subproject subdir/subprojects/sub/meson.build
@@ -1,0 +1,2 @@
+project('sub', 'c')
+subdir('lib')


### PR DESCRIPTION
Python's os.path.split() does not split the path into its components.
Instead, split the path with str.split() using the OS's file system
separator.

I also added a test case that failed before and now passes, because the subdir folder is three levels deep.