### PR TITLE
Fix Xcode backend

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -30,3 +30,4 @@ Rémi Nicole
 Damián Nohales
 Nirbheek Chauhan
 Nicolas Schneider
+Rogiel Sulzbach


### PR DESCRIPTION
This makes the following changes:
 * Replaces @ on target names by -
 * Explicitly closes the file for force flushing (this fixes an issue on which the last 2 or 3 lines weren't being written to disk)
 * Adds another check on the PBXBuildFile stage to get the file name if the returned source type is a File instead of a string

Fixes issue #337 