### PR TITLE
Fix filenames and paths used in DLL shared library generation

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -500,6 +500,10 @@ class Backend():
                 # it assumes that it is in path, so always give it a full path.
                 tmp = i.get_filename()[0]
                 i = os.path.join(self.get_target_dir(i), tmp)
+            elif isinstance(i, mesonlib.File):
+                i = os.path.join(i.subdir, i.fname)
+                if absolute_paths:
+                    i = os.path.join(self.environment.get_build_dir(), i)
             # FIXME: str types are blindly added and ignore the 'absolute_paths' argument
             elif not isinstance(i, str):
                 err_msg = 'Argument {0} is of unknown type {1}'

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -495,11 +495,15 @@ class Backend():
             if isinstance(i, build.Executable):
                 cmd += self.exe_object_to_cmd_array(i)
                 continue
-            if isinstance(i, build.CustomTarget):
+            elif isinstance(i, build.CustomTarget):
                 # GIR scanner will attempt to execute this binary but
                 # it assumes that it is in path, so always give it a full path.
                 tmp = i.get_filename()[0]
                 i = os.path.join(self.get_target_dir(i), tmp)
+            # FIXME: str types are blindly added and ignore the 'absolute_paths' argument
+            elif not isinstance(i, str):
+                err_msg = 'Argument {0} is of unknown type {1}'
+                raise RuntimeError(err_msg.format(str(i), str(type(i))))
             for (j, src) in enumerate(srcs):
                 i = i.replace('@INPUT%d@' % j, src)
             for (j, res) in enumerate(ofilenames):

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -105,9 +105,13 @@ class Backend():
         # On some platforms (msvc for instance), the file that is used for
         # dynamic linking is not the same as the dynamic library itself. This
         # file is called an import library, and we want to link against that.
-        # On platforms where this distinction is not important, the import
-        # library is the same as the dynamic library itself.
-        return os.path.join(self.get_target_dir(target), target.get_import_filename())
+        # On all other platforms, we link to the library directly.
+        if isinstance(target, build.SharedLibrary):
+            link_lib = target.get_import_filename() or target.get_filename()
+            return os.path.join(self.get_target_dir(target), link_lib)
+        elif isinstance(target, build.StaticLibrary):
+            return os.path.join(self.get_target_dir(target), target.get_filename())
+        raise AssertionError('BUG: Tried to link to something that\'s not a library')
 
     def get_target_dir(self, target):
         if self.environment.coredata.get_builtin_option('layout') == 'mirror':

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -492,18 +492,33 @@ int dummy;
         pickle.dump(d, ofile)
 
     def generate_target_install(self, d):
-        libdir = self.environment.get_libdir()
-        bindir = self.environment.get_bindir()
-
         should_strip = self.environment.coredata.get_builtin_option('strip')
         for t in self.build.get_targets().values():
             if t.should_install():
+                # Find the installation directory
                 outdir = t.get_custom_install_dir()
-                if outdir is None:
-                    if isinstance(t, build.Executable):
-                        outdir = bindir
-                    else:
-                        outdir = libdir
+                if outdir is not None:
+                    pass
+                elif isinstance(t, build.SharedLibrary):
+                    # For toolchains/platforms that need an import library for
+                    # linking (separate from the shared library with all the
+                    # code), we need to install the import library (dll.a/.lib)
+                    if t.get_import_filename():
+                        # Install the import library.
+                        i = [self.get_target_filename_for_linking(t),
+                             self.environment.get_import_lib_dir(),
+                             # It has no aliases, should not be stripped, and
+                             # doesn't have an install_rpath
+                             [], False, '']
+                        d.targets.append(i)
+                    outdir = self.environment.get_shared_lib_dir()
+                elif isinstance(t, build.SharedLibrary):
+                    outdir = self.environment.get_static_lib_dir()
+                elif isinstance(t, build.Executable):
+                    outdir = self.environment.get_bindir()
+                else:
+                    # XXX: Add BuildTarget-specific install dir cases here
+                    outdir = self.environment.get_libdir()
                 i = [self.get_target_filename(t), outdir, t.get_aliaslist(),\
                     should_strip, t.install_rpath]
                 d.targets.append(i)
@@ -1661,8 +1676,12 @@ rule FORTRAN_DEP_HACK
             else:
                 soversion = None
             commands += linker.get_soname_args(target.name, abspath, soversion)
+            # This is only visited when using the Visual Studio toolchain
             if target.vs_module_defs and hasattr(linker, 'gen_vs_module_defs_args'):
                 commands += linker.gen_vs_module_defs_args(target.vs_module_defs.rel_to_builddir(self.build_to_src))
+            # This is only visited when building for Windows using either MinGW/GCC or Visual Studio
+            if target.import_filename:
+                commands += linker.gen_import_library_args(os.path.join(target.subdir, target.import_filename))
         elif isinstance(target, build.StaticLibrary):
             commands += linker.get_std_link_args()
         else:

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -623,7 +623,10 @@ class Vs2010Backend(backends.Backend):
             d_compile_args = compiler.unix_compile_flags_to_native(d.get_compile_args())
             for arg in d_compile_args:
                 if arg.startswith('-I'):
-                    inc_dirs.append(arg[2:])
+                    inc_dir = arg[2:]
+                    # De-dup
+                    if inc_dir not in inc_dirs:
+                        inc_dirs.append(inc_dir)
                 else:
                     general_args.append(arg)
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -735,7 +735,7 @@ class Vs2010Backend(backends.Backend):
             ET.SubElement(link, 'ImportLibrary').text = target.get_import_filename()
             # Add module definitions file, if provided
             if target.vs_module_defs:
-                relpath = target.vs_module_defs.rel_to_builddir(proj_to_src_root)
+                relpath = os.path.join(down, target.vs_module_defs.rel_to_builddir(self.build_to_src))
                 ET.SubElement(link, 'ModuleDefinitionFile').text = relpath
         if '/ZI' in buildtype_args or '/Zi' in buildtype_args:
             pdb = ET.SubElement(link, 'ProgramDataBaseFileName')
@@ -749,7 +749,7 @@ class Vs2010Backend(backends.Backend):
         if len(headers) + len(gen_hdrs) + len(extra_files) > 0:
             inc_hdrs = ET.SubElement(root, 'ItemGroup')
             for h in headers:
-                relpath = h.rel_to_builddir(proj_to_src_root)
+                relpath = os.path.join(down, h.rel_to_builddir(self.build_to_src))
                 ET.SubElement(inc_hdrs, 'CLInclude', Include=relpath)
             for h in gen_hdrs:
                 ET.SubElement(inc_hdrs, 'CLInclude', Include=h)
@@ -760,7 +760,7 @@ class Vs2010Backend(backends.Backend):
         if len(sources) + len(gen_src) + len(pch_sources) > 0:
             inc_src = ET.SubElement(root, 'ItemGroup')
             for s in sources:
-                relpath = s.rel_to_builddir(proj_to_src_root)
+                relpath = os.path.join(down, s.rel_to_builddir(self.build_to_src))
                 inc_cl = ET.SubElement(inc_src, 'CLCompile', Include=relpath)
                 self.add_pch(inc_cl, proj_to_src_dir, pch_sources, s)
                 self.add_additional_options(s, inc_cl, extra_args, additional_options_set)
@@ -788,7 +788,7 @@ class Vs2010Backend(backends.Backend):
         if self.has_objects(objects, additional_objects, gen_objs):
             inc_objs = ET.SubElement(root, 'ItemGroup')
             for s in objects:
-                relpath = s.rel_to_builddir(proj_to_src_root)
+                relpath = os.path.join(down, s.rel_to_builddir(self.build_to_src))
                 ET.SubElement(inc_objs, 'Object', Include=relpath)
             for s in additional_objects:
                 ET.SubElement(inc_objs, 'Object', Include=s)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -97,9 +97,14 @@ class Vs2010Backend(backends.Backend):
         outputs = []
         custom_target_include_dirs = []
         custom_target_output_files = []
+        target_private_dir = self.relpath(self.get_target_private_dir(target), self.get_target_dir(target))
+        down = self.target_to_build_root(target)
         for genlist in target.get_generated_sources():
             if isinstance(genlist, build.CustomTarget):
-                custom_target_output_files += [os.path.join(self.get_target_dir(genlist), i) for i in genlist.output]
+                for i in genlist.output:
+                    # Path to the generated source from the current vcxproj dir via the build root
+                    ipath = os.path.join(down, self.get_target_dir(genlist), i)
+                    custom_target_output_files.append(ipath)
                 idir = self.relpath(self.get_target_dir(genlist), self.get_target_dir(target))
                 if idir not in custom_target_include_dirs:
                     custom_target_include_dirs.append(idir)
@@ -110,7 +115,6 @@ class Vs2010Backend(backends.Backend):
                 outfilelist = genlist.get_outfilelist()
                 exe_arr = self.exe_object_to_cmd_array(exe)
                 base_args = generator.get_arglist()
-                target_private_dir = self.relpath(self.get_target_private_dir(target), self.get_target_dir(target))
                 for i in range(len(infilelist)):
                     if len(infilelist) == len(outfilelist):
                         sole_output = os.path.join(target_private_dir, outfilelist[i])

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -506,10 +506,14 @@ class Vs2010Backend(backends.Backend):
         # here.
         general_args += compiler.get_option_compile_args(self.environment.coredata.compiler_options)
         for d in target.get_external_deps():
-            try:
-                general_args += d.compile_args
-            except AttributeError:
-                pass
+            # Cflags required by external deps might have UNIX-specific flags,
+            # so filter them out if needed
+            d_compile_args = compiler.unix_compile_flags_to_native(d.get_compile_args())
+            for arg in d_compile_args:
+                if arg.startswith('-I'):
+                    inc_dirs.append(arg[2:])
+                else:
+                    general_args.append(arg)
 
         for l, args in extra_args.items():
             extra_args[l] = [Vs2010Backend.quote_define_cmdline(x) for x in args]

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -730,6 +730,10 @@ class Vs2010Backend(backends.Backend):
             # DLLs built with MSVC always have an import library except when
             # they're data-only DLLs, but we don't support those yet.
             ET.SubElement(link, 'ImportLibrary').text = target.get_import_filename()
+            # Add module definitions file, if provided
+            if target.vs_module_defs:
+                relpath = target.vs_module_defs.rel_to_builddir(proj_to_src_root)
+                ET.SubElement(link, 'ModuleDefinitionFile').text = relpath
         if '/ZI' in buildtype_args or '/Zi' in buildtype_args:
             pdb = ET.SubElement(link, 'ProgramDataBaseFileName')
             pdb.text = '$(OutDir}%s.pdb' % target_name

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -480,8 +480,11 @@ class Vs2010Backend(backends.Backend):
             return self.gen_run_target_vcxproj(target, ofname, guid)
         else:
             raise MesonException('Unknown target type for %s' % target.get_basename())
+        # Prefix to use to access the build root from the vcxproj dir
         down = self.target_to_build_root(target)
+        # Prefix to use to access the source tree's root from the vcxproj dir
         proj_to_src_root = os.path.join(down, self.build_to_src)
+        # Prefix to use to access the source tree's subdir from the vcxproj dir
         proj_to_src_dir = os.path.join(proj_to_src_root, target.subdir)
         (sources, headers, objects, languages) = self.split_sources(target.sources)
         buildtype_args = compiler.get_buildtype_args(self.buildtype)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -585,7 +585,7 @@ class Vs2010Backend(backends.Backend):
         for t in target.get_dependencies():
             lobj = self.build.targets[t.get_id()]
             rel_path = self.relpath(lobj.subdir, target.subdir)
-            linkname = os.path.join(rel_path, lobj.get_import_filename())
+            linkname = os.path.join(rel_path, self.get_target_filename_for_linking(lobj))
             additional_links.append(linkname)
         for lib in self.get_custom_target_provided_libraries(target):
             additional_links.append(self.relpath(lib, self.get_target_dir(target)))
@@ -607,6 +607,8 @@ class Vs2010Backend(backends.Backend):
         gendeb = ET.SubElement(link, 'GenerateDebugInformation')
         gendeb.text = 'true'
         if isinstance(target, build.SharedLibrary):
+            # DLLs built with MSVC always have an import library except when
+            # they're data-only DLLs, but we don't support those yet.
             ET.SubElement(link, 'ImportLibrary').text = target.get_import_filename()
         pdb = ET.SubElement(link, 'ProgramDataBaseFileName')
         pdb.text = '$(OutDir}%s.pdb' % target_name

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -634,8 +634,7 @@ class Vs2010Backend(backends.Backend):
         # Add more libraries to be linked if needed
         for t in target.get_dependencies():
             lobj = self.build.targets[t.get_id()]
-            rel_path = self.relpath(lobj.subdir, target.subdir)
-            linkname = os.path.join(rel_path, self.get_target_filename_for_linking(lobj))
+            linkname = os.path.join(down, self.get_target_filename_for_linking(lobj))
             additional_links.append(linkname)
         for lib in self.get_custom_target_provided_libraries(target):
             additional_links.append(self.relpath(lib, self.get_target_dir(target)))

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -474,11 +474,13 @@ class Vs2010Backend(backends.Backend):
         outdir.text = '.\\'
         intdir = ET.SubElement(direlem, 'IntDir')
         intdir.text = target.get_id() + '\\'
-        tname = ET.SubElement(direlem, 'TargetName')
-        tname.text = target_name
         inclinc = ET.SubElement(direlem, 'LinkIncremental')
         inclinc.text = 'true'
+        tfilename = os.path.splitext(target.get_filename())
+        ET.SubElement(direlem, 'TargetName').text = tfilename[0]
+        ET.SubElement(direlem, 'TargetExt').text = tfilename[1]
 
+        # Build information
         compiles = ET.SubElement(root, 'ItemDefinitionGroup')
         clconf = ET.SubElement(compiles, 'ClCompile')
         opt = ET.SubElement(clconf, 'Optimization')

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -292,12 +292,10 @@ class XCodeBackend(backends.Backend):
             reftype = 0
             if isinstance(t, build.Executable):
                 typestr = 'compiled.mach-o.executable'
-                path = t.get_filename()
+                path = fname
             elif isinstance(t, build.SharedLibrary):
-                # OSX has a completely different shared library
-                # naming scheme so do this manually.
                 typestr = self.get_xcodetype('dummy.dylib')
-                path = t.get_osx_filename()
+                path = fname
             else:
                 typestr = self.get_xcodetype(fname)
                 path = '"%s"' % t.get_filename()
@@ -626,7 +624,7 @@ class XCodeBackend(backends.Backend):
                         headerdirs.append(os.path.join(self.environment.get_build_dir(), cd))
                 for l in target.link_targets:
                     abs_path = os.path.join(self.environment.get_build_dir(),
-                                            l.subdir, buildtype, l.get_osx_filename())
+                                            l.subdir, buildtype, l.get_filename())
                     dep_libs.append("'%s'" % abs_path)
                     if isinstance(l, build.SharedLibrary):
                         links_dylib = True

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -989,7 +989,7 @@ class CustomTarget:
         for i, c in enumerate(cmd):
             if hasattr(c, 'held_object'):
                 c = c.held_object
-            if isinstance(c, str):
+            if isinstance(c, str) or isinstance(c, File):
                 final_cmd.append(c)
             elif isinstance(c, dependencies.ExternalProgram):
                 if not c.found():
@@ -1005,8 +1005,6 @@ class CustomTarget:
                     if not isinstance(s, str):
                         raise InvalidArguments('Array as argument %d contains a non-string.' % i)
                     final_cmd.append(s)
-            elif isinstance(c, File):
-                final_cmd.append(os.path.join(c.subdir, c.fname))
             else:
                 raise InvalidArguments('Argument %s in "command" is invalid.' % i)
         self.command = final_cmd

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -73,7 +73,10 @@ this but it's the best we can do given the way shell quoting works.
 '''
 
 def sources_are_suffix(sources, suffix):
-    return len(sources) > 0 and sources[0].endswith('.' + suffix)
+    for source in sources:
+        if source.endswith('.' + suffix):
+            return True
+    return False
 
 def compiler_is_msvc(sources, is_cross, env):
     """
@@ -96,7 +99,7 @@ def compiler_is_msvc(sources, is_cross, env):
             compiler = env.detect_cpp_compiler(is_cross)
         except MesonException:
             return False
-    if compiler and compiler.get_id() == 'msvc' and compiler.can_compile(sources[0]):
+    if compiler and compiler.get_id() == 'msvc':
         return True
     return False
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -239,6 +239,10 @@ class BuildTarget():
             raise InvalidArguments('Build target %s has no sources.' % name)
         self.validate_sources()
 
+    def __repr__(self):
+        repr_str = "<{0} {1}: {2}>"
+        return repr_str.format(self.__class__.__name__, self.get_id(), self.filename)
+
     def get_id(self):
         # This ID must also be a valid file name on all OSs.
         # It should also avoid shell metacharacters for obvious
@@ -623,6 +627,10 @@ class Generator():
         self.exe = exe
         self.process_kwargs(kwargs)
 
+    def __repr__(self):
+        repr_str = "<{0}: {1}>"
+        return repr_str.format(self.__class__.__name__, self.exe)
+
     def get_exe(self):
         return self.exe
 
@@ -953,6 +961,10 @@ class CustomTarget:
             mlog.log(mlog.bold('Warning:'), 'Unknown keyword arguments in target %s: %s' %
                      (self.name, ', '.join(unknowns)))
 
+    def __repr__(self):
+        repr_str = "<{0} {1}: {2}>"
+        return repr_str.format(self.__class__.__name__, self.get_id(), self.command)
+
     def get_id(self):
         return self.name + self.type_suffix()
 
@@ -1079,6 +1091,10 @@ class RunTarget:
         self.args = args
         self.subdir = subdir
 
+    def __repr__(self):
+        repr_str = "<{0} {1}: {2}>"
+        return repr_str.format(self.__class__.__name__, self.get_id(), self.command)
+
     def get_id(self):
         return self.name + self.type_suffix()
 
@@ -1129,6 +1145,12 @@ class ConfigureFile():
         self.targetname = targetname
         self.configuration_data = configuration_data
 
+    def __repr__(self):
+        repr_str = "<{0}: {1} -> {2}>"
+        src = os.path.join(self.subdir, self.sourcename)
+        dst = os.path.join(self.subdir, self.targetname)
+        return repr_str.format(self.__class__.__name__, src, dst)
+
     def get_configuration_data(self):
         return self.configuration_data
 
@@ -1145,6 +1167,9 @@ class ConfigurationData():
     def __init__(self):
         super().__init__()
         self.values = {}
+
+    def __repr__(self):
+        return repr(self.values)
 
     def get(self, name):
         return self.values[name]

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -263,6 +263,13 @@ class Compiler():
     def get_linker_always_args(self):
         return []
 
+    def gen_import_library_args(self, implibname):
+        """
+        Used only on Windows for libraries that need an import library.
+        This currently means C, C++, Fortran.
+        """
+        return []
+
     def get_options(self):
         return {} # build afresh every time
 
@@ -458,6 +465,14 @@ class CCompiler(Compiler):
 
     def get_linker_search_args(self, dirname):
         return ['-L'+dirname]
+
+    def gen_import_library_args(self, implibname):
+        """
+        The name of the outputted import library
+
+        This implementation is used only on Windows by compilers that use GNU ld
+        """
+        return ['-Wl,--out-implib=' + implibname]
 
     def sanity_check_impl(self, work_dir, environment, sname, code):
         mlog.debug('Sanity testing ' + self.language + ' compiler:', ' '.join(self.exelist))
@@ -1485,6 +1500,10 @@ class VisualStudioCCompiler(CCompiler):
         objname = os.path.splitext(pchname)[0] + '.obj'
         return (objname, ['/Yc' + header, '/Fp' + pchname, '/Fo' + objname ])
 
+    def gen_import_library_args(self, implibname):
+        "The name of the outputted import library"
+        return ['/IMPLIB:' + implibname]
+
     def build_rpath_args(self, build_dir, rpath_paths, install_rpath):
         return []
 
@@ -2031,6 +2050,14 @@ class GnuFortranCompiler(FortranCompiler):
     def get_always_args(self):
         return ['-pipe']
 
+    def gen_import_library_args(self, implibname):
+        """
+        The name of the outputted import library
+
+        Used only on Windows
+        """
+        return ['-Wl,--out-implib=' + implibname]
+
 class G95FortranCompiler(FortranCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None):
         super().__init__(exelist, version, is_cross, exe_wrapper=None)
@@ -2041,6 +2068,14 @@ class G95FortranCompiler(FortranCompiler):
 
     def get_always_args(self):
         return ['-pipe']
+
+    def gen_import_library_args(self, implibname):
+        """
+        The name of the outputted import library
+
+        Used only on Windows
+        """
+        return ['-Wl,--out-implib=' + implibname]
 
 class SunFortranCompiler(FortranCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None):

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -28,6 +28,16 @@ class File:
         self.subdir = subdir
         self.fname = fname
 
+    def __str__(self):
+        return os.path.join(self.subdir, self.fname)
+
+    def __repr__(self):
+        ret = '<File: {0}'
+        if not self.is_built:
+            ret += ' (not built)'
+        ret += '>'
+        return ret.format(os.path.join(self.subdir, self.fname))
+
     @staticmethod
     def from_source_file(source_root, subdir, fname):
         if not os.path.isfile(os.path.join(source_root, subdir, fname)):

--- a/mesonbuild/scripts/meson_install.py
+++ b/mesonbuild/scripts/meson_install.py
@@ -43,7 +43,7 @@ def do_install(datafilename):
 
 def install_subdirs(data):
     for (src_dir, inst_dir, dst_dir) in data.install_subdirs:
-        if src_dir.endswith('/'):
+        if src_dir.endswith('/') or src_dir.endswith('\\'):
             src_dir = src_dir[:-1]
         src_prefix = os.path.join(src_dir, inst_dir)
         print('Installing subdir %s to %s.' % (src_prefix, dst_dir))

--- a/run_tests.py
+++ b/run_tests.py
@@ -144,15 +144,17 @@ def platform_fix_exe_name(fname):
     return fname
 
 def validate_install(srcdir, installdir):
+    # List of installed files
     info_file = os.path.join(srcdir, 'installed_files.txt')
+    # If this exists, the test does not install any other files
+    noinst_file = 'usr/no-installed-files'
     expected = {}
     found = {}
     ret_msg = ''
-    # Test expects to not install any files
-    if os.path.exists(os.path.join(installdir, 'usr', 'no-installed-files')):
-        return ''
     # Generate list of expected files
-    if os.path.exists(info_file):
+    if os.path.exists(os.path.join(installdir, noinst_file)):
+        expected[noinst_file] = False
+    elif os.path.exists(info_file):
         for line in open(info_file):
             expected[platform_fix_exe_name(line.strip())] = False
     # Check if expected files were found

--- a/test cases/common/27 library versions/installed_files.txt
+++ b/test cases/common/27 library versions/installed_files.txt
@@ -1,3 +1,1 @@
-usr/lib/libsomelib.so
-usr/lib/libsomelib.so.0
-usr/lib/libsomelib.so.1.2.3
+usr/lib/prefixsomelib.suffix

--- a/test cases/common/27 library versions/meson.build
+++ b/test cases/common/27 library versions/meson.build
@@ -1,6 +1,7 @@
 project('library versions', 'c')
 
-lib = shared_library('somelib', 'lib.c', \
-version : '1.2.3', \
-soversion : '0', \
-install : true)
+shared_library('somelib', 'lib.c',
+  name_prefix : 'prefix',
+  name_suffix : 'suffix',
+  install_dir : 'lib',
+  install : true)

--- a/test cases/common/27 library versions/meson.build
+++ b/test cases/common/27 library versions/meson.build
@@ -5,3 +5,5 @@ shared_library('somelib', 'lib.c',
   name_suffix : 'suffix',
   install_dir : 'lib',
   install : true)
+
+subdir('subdir')

--- a/test cases/common/27 library versions/subdir/meson.build
+++ b/test cases/common/27 library versions/subdir/meson.build
@@ -1,0 +1,8 @@
+# Test that using files generated with configure_file as sources works.
+# We do this inside a subdir so that the path isn't accidentally correct
+# because there is no structure in the build dir.
+genlib = configure_file(input : '../lib.c',
+  output : 'genlib.c',
+  configuration : configuration_data())
+shared_library('genlib', genlib,
+  install : false)

--- a/test cases/common/46 library chain/installed_files.txt
+++ b/test cases/common/46 library chain/installed_files.txt
@@ -1,4 +1,1 @@
-usr/bin/prog
-usr/lib/liblib1.so
-usr/lib/liblib2.so
-usr/lib/liblib3.so
+usr/bin/prog?exe

--- a/test cases/common/46 library chain/subdir/meson.build
+++ b/test cases/common/46 library chain/subdir/meson.build
@@ -1,4 +1,4 @@
 subdir('subdir2')
 subdir('subdir3')
 
-lib1 = shared_library('lib1', 'lib1.c', install : true, link_with : [lib2, lib3])
+lib1 = shared_library('lib1', 'lib1.c', install : false, link_with : [lib2, lib3])

--- a/test cases/common/46 library chain/subdir/subdir2/meson.build
+++ b/test cases/common/46 library chain/subdir/subdir2/meson.build
@@ -1,1 +1,1 @@
-lib2 = shared_library('lib2', 'lib2.c', install : true)
+lib2 = shared_library('lib2', 'lib2.c', install : false)

--- a/test cases/common/46 library chain/subdir/subdir3/meson.build
+++ b/test cases/common/46 library chain/subdir/subdir3/meson.build
@@ -1,1 +1,1 @@
-lib3 = shared_library('lib3', 'lib3.c', install : true)
+lib3 = shared_library('lib3', 'lib3.c', install : false)

--- a/test cases/common/49 subproject/installed_files.txt
+++ b/test cases/common/49 subproject/installed_files.txt
@@ -1,3 +1,2 @@
-usr/bin/user
-usr/lib/libsublib.so
+usr/bin/user?exe
 usr/share/sublib/sublib.depmf

--- a/test cases/common/49 subproject/subprojects/sublib/meson.build
+++ b/test cases/common/49 subproject/subprojects/sublib/meson.build
@@ -13,7 +13,7 @@ if meson.project_version() != '1.0.0'
 endif
 
 i = include_directories('include')
-l = shared_library('sublib', 'sublib.c', include_directories : i, install : true,
+l = shared_library('sublib', 'sublib.c', include_directories : i, install : false,
  c_args : '-DBUILDING_SUB=2')
 t = executable('simpletest', 'simpletest.c', include_directories : i, link_with : l)
 test('plain', t)

--- a/test cases/common/51 pkgconfig-gen/installed_files.txt
+++ b/test cases/common/51 pkgconfig-gen/installed_files.txt
@@ -1,3 +1,2 @@
 usr/include/simple.h
-usr/lib/libsimple.so
 usr/lib/pkgconfig/simple.pc

--- a/test cases/common/51 pkgconfig-gen/meson.build
+++ b/test cases/common/51 pkgconfig-gen/meson.build
@@ -2,7 +2,7 @@ project('pkgconfig-gen', 'c')
 
 pkgg = import('pkgconfig')
 
-lib = shared_library('simple', 'simple.c', install : true)
+lib = shared_library('simple', 'simple.c')
 libver = '1.0'
 h = install_headers('simple.h')
 

--- a/test cases/common/52 custom install dirs/installed_files.txt
+++ b/test cases/common/52 custom install dirs/installed_files.txt
@@ -1,4 +1,4 @@
-usr/dib/dab/dub/prog
+usr/dib/dab/dub/prog?exe
 usr/some/dir/sample.h
 usr/woman/prog.1.gz
 usr/meow/datafile.cat

--- a/test cases/common/6 linkshared/installed_files.txt
+++ b/test cases/common/6 linkshared/installed_files.txt
@@ -1,2 +1,1 @@
-usr/bin/prog
-usr/lib/libmylib.so
+usr/bin/prog?exe

--- a/test cases/common/6 linkshared/meson.build
+++ b/test cases/common/6 linkshared/meson.build
@@ -2,7 +2,7 @@ project('shared library linking test', 'c', 'cpp')
 
 lib = shared_library('mylib',
  'libfile.c' # Split to different lines before and after the comma to test parser.
- , install : true)
+ , install : false) # Don't install libraries in common tests; the path is platform-specific
 exe = executable('prog', 'main.c', link_with : lib, install : true)
 
 test('runtest', exe)

--- a/test cases/common/60 install script/installed_files.txt
+++ b/test cases/common/60 install script/installed_files.txt
@@ -1,2 +1,2 @@
-usr/bin/prog
+usr/bin/prog?exe
 usr/diiba/daaba/file.dat

--- a/test cases/common/60 install script/meson.build
+++ b/test cases/common/60 install script/meson.build
@@ -4,5 +4,5 @@ if meson.get_compiler('c').get_id() == 'msvc'
   install_data('no-installed-files', install_dir : '')
 else
   meson.add_install_script('myinstall.sh')
+  executable('prog', 'prog.c', install : true)
 endif
-executable('prog', 'prog.c', install : true)

--- a/test cases/common/60 install script/meson.build
+++ b/test cases/common/60 install script/meson.build
@@ -1,7 +1,7 @@
 project('custom install script', 'c')
 
 if meson.get_compiler('c').get_id() == 'msvc'
-  meson.add_install_script('myinstall.bat')
+  install_data('no-installed-files', install_dir : '')
 else
   meson.add_install_script('myinstall.sh')
 endif

--- a/test cases/common/60 install script/myinstall.bat
+++ b/test cases/common/60 install script/myinstall.bat
@@ -1,3 +1,0 @@
-@ECHO OFF
-
-echo At this point we could do something.

--- a/test cases/common/60 install script/myinstall.sh
+++ b/test cases/common/60 install script/myinstall.sh
@@ -4,9 +4,7 @@ set -eu
 
 echo Starting custom installation step
 
-# These commands fail on Windows, but we don't really care.
-
 mkdir -p "${DESTDIR}${MESON_INSTALL_PREFIX}/diiba/daaba"
 touch "${DESTDIR}${MESON_INSTALL_PREFIX}/diiba/daaba/file.dat"
 
-echo Finishing custom install step
+echo Finished custom install step

--- a/test cases/common/67 foreach/installed_files.txt
+++ b/test cases/common/67 foreach/installed_files.txt
@@ -1,3 +1,3 @@
-usr/bin/prog1
-usr/bin/prog2
-usr/bin/prog3
+usr/bin/prog1?exe
+usr/bin/prog2?exe
+usr/bin/prog3?exe

--- a/test cases/common/76 configure file in custom target/src/meson.build
+++ b/test cases/common/76 configure file in custom target/src/meson.build
@@ -2,3 +2,19 @@ custom_target('thing',
 output : 'final.dat',
 input : cfile,
 command : [find_program('mycompiler.py'), '@INPUT@', '@OUTPUT@'])
+
+# Test usage of a `configure_file` as part of the command list
+py3 = find_program('python3', required : false)
+if not py3.found()
+  # Maybe 'python' is Python 3
+  py3 = find_program('python')
+endif
+
+compiler = configure_file(input : 'mycompiler.py',
+  output : 'mycompiler2.py',
+  configuration : configuration_data())
+
+custom_target('thing2',
+output : 'final2.dat',
+input : cfile,
+command : [py3, compiler, '@INPUT@', '@OUTPUT@'])

--- a/test cases/common/8 install/installed_files.txt
+++ b/test cases/common/8 install/installed_files.txt
@@ -1,3 +1,2 @@
-usr/bin/prog
-usr/lib/libshar.so
+usr/bin/prog?exe
 usr/lib/libstat.a

--- a/test cases/common/8 install/meson.build
+++ b/test cases/common/8 install/meson.build
@@ -1,5 +1,4 @@
 project('install test', 'c')
 
 stlib = static_library('stat', 'stat.c', install : true)
-shlib = shared_library('shar', 'shar.c', install : true)
 exe = executable('prog', 'prog.c', install : true)

--- a/test cases/common/8 install/shar.c
+++ b/test cases/common/8 install/shar.c
@@ -1,1 +1,0 @@
-int func() { return 15; }

--- a/test cases/csharp/2 library/installed_files.txt
+++ b/test cases/csharp/2 library/installed_files.txt
@@ -1,2 +1,2 @@
 usr/bin/prog.exe
-usr/lib/libhelper.dll
+usr/lib/helper.dll

--- a/test cases/linuxlike/7 library versions/installed_files.txt
+++ b/test cases/linuxlike/7 library versions/installed_files.txt
@@ -1,0 +1,9 @@
+usr/lib/libsome.so
+usr/lib/libsome.so.0
+usr/lib/libsome.so.1.2.3
+usr/lib/libnoversion.so
+usr/lib/libonlyversion.so
+usr/lib/libonlyversion.so.1
+usr/lib/libonlyversion.so.1.4.5
+usr/lib/libonlysoversion.so
+usr/lib/libonlysoversion.so.5

--- a/test cases/linuxlike/7 library versions/lib.c
+++ b/test cases/linuxlike/7 library versions/lib.c
@@ -1,0 +1,3 @@
+int myFunc() {
+    return 55;
+}

--- a/test cases/linuxlike/7 library versions/meson.build
+++ b/test cases/linuxlike/7 library versions/meson.build
@@ -1,0 +1,18 @@
+project('library versions', 'c')
+
+shared_library('some', 'lib.c',
+  version : '1.2.3',
+  soversion : '0',
+  install : true)
+
+shared_library('noversion', 'lib.c',
+  install : true)
+
+shared_library('onlyversion', 'lib.c',
+  version : '1.4.5',
+  install : true)
+
+shared_library('onlysoversion', 'lib.c',
+  # Also test that int soversion is acceptable
+  soversion : 5,
+  install : true)

--- a/test cases/linuxlike/8 subproject library install/installed_files.txt
+++ b/test cases/linuxlike/8 subproject library install/installed_files.txt
@@ -1,0 +1,3 @@
+usr/lib/libsublib.so
+usr/lib/libsublib.so.5
+usr/lib/libsublib.so.2.1.0

--- a/test cases/linuxlike/8 subproject library install/meson.build
+++ b/test cases/linuxlike/8 subproject library install/meson.build
@@ -1,0 +1,6 @@
+project('subproj lib install', 'c',
+  version : '2.3.4',
+  license : 'mylicense')
+
+# Test that the subproject library gets installed
+subproject('sublib', version : '1.0.0')

--- a/test cases/linuxlike/8 subproject library install/subprojects/sublib/include/subdefs.h
+++ b/test cases/linuxlike/8 subproject library install/subprojects/sublib/include/subdefs.h
@@ -1,0 +1,21 @@
+#ifndef SUBDEFS_H_
+#define SUBDEFS_H_
+
+#if defined _WIN32 || defined __CYGWIN__
+#if defined BUILDING_SUB
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #define DLL_PUBLIC __declspec(dllimport)
+#endif
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+int DLL_PUBLIC subfunc();
+
+#endif

--- a/test cases/linuxlike/8 subproject library install/subprojects/sublib/meson.build
+++ b/test cases/linuxlike/8 subproject library install/subprojects/sublib/meson.build
@@ -1,0 +1,10 @@
+project('subproject', 'c',
+  version : '1.0.0',
+  license : ['sublicense1', 'sublicense2'])
+
+i = include_directories('include')
+shared_library('sublib', 'sublib.c',
+  version : '2.1.0',
+  soversion : 5,
+  include_directories : i, install : true,
+  c_args : '-DBUILDING_SUB=2')

--- a/test cases/linuxlike/8 subproject library install/subprojects/sublib/sublib.c
+++ b/test cases/linuxlike/8 subproject library install/subprojects/sublib/sublib.c
@@ -1,0 +1,5 @@
+#include<subdefs.h>
+
+int DLL_PUBLIC subfunc() {
+    return 42;
+}

--- a/test cases/osx/2 library versions/installed_files.txt
+++ b/test cases/osx/2 library versions/installed_files.txt
@@ -1,0 +1,4 @@
+usr/lib/libsome.0.dylib
+usr/lib/libnoversion.dylib
+usr/lib/libonlyversion.1.dylib
+usr/lib/libonlysoversion.5.dylib

--- a/test cases/osx/2 library versions/lib.c
+++ b/test cases/osx/2 library versions/lib.c
@@ -1,0 +1,3 @@
+int myFunc() {
+    return 55;
+}

--- a/test cases/osx/2 library versions/meson.build
+++ b/test cases/osx/2 library versions/meson.build
@@ -1,0 +1,18 @@
+project('library versions', 'c')
+
+shared_library('some', 'lib.c',
+  version : '1.2.3',
+  soversion : '0',
+  install : true)
+
+shared_library('noversion', 'lib.c',
+  install : true)
+
+shared_library('onlyversion', 'lib.c',
+  version : '1.4.5',
+  install : true)
+
+shared_library('onlysoversion', 'lib.c',
+  # Also test that int soversion is acceptable
+  soversion : 5,
+  install : true)

--- a/test cases/rust/1 basic/installed_files.txt
+++ b/test cases/rust/1 basic/installed_files.txt
@@ -1,1 +1,1 @@
-usr/bin/prog
+usr/bin/prog?exe

--- a/test cases/rust/2 sharedlib/installed_files.txt
+++ b/test cases/rust/2 sharedlib/installed_files.txt
@@ -1,2 +1,2 @@
-usr/bin/prog
+usr/bin/prog?exe
 usr/lib/libstuff.rlib

--- a/test cases/rust/3 staticlib/installed_files.txt
+++ b/test cases/rust/3 staticlib/installed_files.txt
@@ -1,2 +1,2 @@
-usr/bin/prog
+usr/bin/prog?exe
 usr/lib/libstuff.rlib

--- a/test cases/windows/7 mingw dll versioning/installed_files.txt
+++ b/test cases/windows/7 mingw dll versioning/installed_files.txt
@@ -1,0 +1,4 @@
+usr/bin/libsome-0.dll
+usr/lib/libsome.dll.a
+usr/bin/libnoversion.dll
+usr/lib/libnoversion.dll.a

--- a/test cases/windows/7 mingw dll versioning/lib.c
+++ b/test cases/windows/7 mingw dll versioning/lib.c
@@ -1,0 +1,6 @@
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
+int myFunc() {
+    return 55;
+}

--- a/test cases/windows/7 mingw dll versioning/meson.build
+++ b/test cases/windows/7 mingw dll versioning/meson.build
@@ -1,0 +1,17 @@
+project('mingw dll versioning', 'c')
+
+cc = meson.get_compiler('c')
+
+# Test that MinGW/GCC creates correctly-named dll files and dll.a files,
+# and also installs them in the right place
+if cc.get_id() != 'msvc'
+  shared_library('some', 'lib.c',
+    version : '1.2.3',
+    soversion : '0',
+    install : true)
+
+  shared_library('noversion', 'lib.c',
+    install : true)
+else
+  install_data('no-installed-files', install_dir : '')
+endif

--- a/test cases/windows/8 msvc dll versioning/installed_files.txt
+++ b/test cases/windows/8 msvc dll versioning/installed_files.txt
@@ -1,0 +1,4 @@
+usr/bin/some-0.dll
+usr/lib/some.lib
+usr/bin/noversion.dll
+usr/lib/noversion.lib

--- a/test cases/windows/8 msvc dll versioning/lib.c
+++ b/test cases/windows/8 msvc dll versioning/lib.c
@@ -1,0 +1,6 @@
+#ifdef _WIN32
+__declspec(dllexport)
+#endif
+int myFunc() {
+    return 55;
+}

--- a/test cases/windows/8 msvc dll versioning/meson.build
+++ b/test cases/windows/8 msvc dll versioning/meson.build
@@ -1,0 +1,16 @@
+project('msvc dll versioning', 'c')
+
+cc = meson.get_compiler('c')
+
+# Test that MSVC creates foo-0.dll and bar.dll
+if cc.get_id() == 'msvc'
+  shared_library('some', 'lib.c',
+    version : '1.2.3',
+    soversion : '0',
+    install : true)
+
+  shared_library('noversion', 'lib.c',
+    install : true)
+else
+  install_data('no-installed-files', install_dir : '')
+endif


### PR DESCRIPTION
* DLLs should always go into `bindir`
* If import libraries are created, those should go into `libdir`
* DLLs should never contain `soversion` or `version` in the filename
* Only `.so` files should have aliases generated for them (dylibs and DLLs do not use aliases)