### PR TITLE
Fix vs2010 regen

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -580,8 +580,7 @@ if %%errorlevel%% neq 0 goto :VCEnd'''
             ('" "'.join(regen_command), private_dir)
         ET.SubElement(custombuild, 'Outputs').text = os.path.join(self.environment.get_scratch_dir(), 'regen.stamp')
         deps = self.get_regen_filelist()
-        depstr = ';'.join([os.path.join(self.environment.get_source_dir(), d) for d in deps])
-        ET.SubElement(custombuild, 'AdditionalInputs').text = depstr
+        ET.SubElement(custombuild, 'AdditionalInputs').text = ';'.join(deps)
         ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.targets')
         ET.SubElement(root, 'ImportGroup', Label='ExtensionTargets')
         tree = ET.ElementTree(root)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -94,9 +94,6 @@ class Vs2010Backend(backends.Backend):
         self.generate_solution(sln_filename, projlist)
         self.generate_regen_info(sln_filename)
         open(os.path.join(self.environment.get_scratch_dir(), 'regen.stamp'), 'wb')
-        rulefile = os.path.join(self.environment.get_scratch_dir(), 'regen.rule')
-        if not os.path.exists(rulefile):
-            open(rulefile, 'w').write("# For some reason this needs to be here.")
 
     def generate_regen_info(self, sln_filename):
         deps = self.get_regen_filelist()
@@ -573,7 +570,11 @@ exit /b %%1
 :cmDone
 if %%errorlevel%% neq 0 goto :VCEnd'''
         igroup = ET.SubElement(root, 'ItemGroup')
-        custombuild = ET.SubElement(igroup, 'CustomBuild', Include='meson-private/regen.rule')
+        rulefile = os.path.join(self.environment.get_scratch_dir(), 'regen.rule')
+        if not os.path.exists(rulefile):
+            with open(rulefile, 'w') as f:
+                f.write("# Meson regen file.")
+        custombuild = ET.SubElement(igroup, 'CustomBuild', Include=rulefile)
         message = ET.SubElement(custombuild, 'Message')
         message.text = 'Checking whether solution needs to be regenerated.'
         ET.SubElement(custombuild, 'Command').text = cmd_templ % \

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -21,13 +21,13 @@ from .. import mlog
 import xml.etree.ElementTree as ET
 import xml.dom.minidom
 from ..coredata import MesonException
+from ..environment import Environment
 
 class RegenInfo():
-    def __init__(self, source_dir, build_dir, depfiles, solutionfile):
+    def __init__(self, source_dir, build_dir, depfiles):
         self.source_dir = source_dir
         self.build_dir = build_dir
         self.depfiles = depfiles
-        self.solutionfile = solutionfile
 
 class Vs2010Backend(backends.Backend):
     def __init__(self, build):
@@ -92,15 +92,22 @@ class Vs2010Backend(backends.Backend):
         self.gen_testproj('RUN_TESTS', os.path.join(self.environment.get_build_dir(), 'RUN_TESTS.vcxproj'))
         self.gen_regenproj('REGEN', os.path.join(self.environment.get_build_dir(), 'REGEN.vcxproj'))
         self.generate_solution(sln_filename, projlist)
-        self.generate_regen_info(sln_filename)
-        open(os.path.join(self.environment.get_scratch_dir(), 'regen.stamp'), 'wb')
+        self.generate_regen_info()
+        Vs2010Backend.touch_regen_timestamp(self.environment.get_build_dir())
 
-    def generate_regen_info(self, sln_filename):
+    @staticmethod
+    def get_regen_stampfile(build_dir):
+        return os.path.join(os.path.join(build_dir, Environment.private_dir), 'regen.stamp')
+
+    @staticmethod
+    def touch_regen_timestamp(build_dir):
+        open(Vs2010Backend.get_regen_stampfile(build_dir), 'w').close()
+
+    def generate_regen_info(self):
         deps = self.get_regen_filelist()
         regeninfo = RegenInfo(self.environment.get_source_dir(),
                               self.environment.get_build_dir(),
-                              deps,
-                              sln_filename)
+                              deps)
         pickle.dump(regeninfo, open(os.path.join(self.environment.get_scratch_dir(), 'regeninfo.dump'), 'wb'))
 
     def get_obj_target_deps(self, obj_list):
@@ -579,7 +586,7 @@ if %%errorlevel%% neq 0 goto :VCEnd'''
         message.text = 'Checking whether solution needs to be regenerated.'
         ET.SubElement(custombuild, 'Command').text = cmd_templ % \
             ('" "'.join(regen_command), private_dir)
-        ET.SubElement(custombuild, 'Outputs').text = os.path.join(self.environment.get_scratch_dir(), 'regen.stamp')
+        ET.SubElement(custombuild, 'Outputs').text = Vs2010Backend.get_regen_stampfile(self.environment.get_build_dir())
         deps = self.get_regen_filelist()
         ET.SubElement(custombuild, 'AdditionalInputs').text = ';'.join(deps)
         ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.targets')

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -126,7 +126,7 @@ class Environment():
     def is_cross_build(self):
         return self.cross_info is not None
 
-    def generating_finished(self):
+    def dump_coredata(self):
         cdf = os.path.join(self.get_build_dir(), Environment.coredata_file)
         coredata.save(self.coredata, cdf)
 

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -166,8 +166,8 @@ itself as required.'''
         mlog.log('Build machine cpu family:', mlog.bold(intr.builtin['build_machine'].cpu_family_method([], {})))
         mlog.log('Build machine cpu:', mlog.bold(intr.builtin['build_machine'].cpu_method([], {})))
         intr.run()
+        env.dump_coredata()
         g.generate(intr)
-        env.generating_finished()
         dumpfile = os.path.join(env.get_scratch_dir(), 'build.dat')
         pickle.dump(b, open(dumpfile, 'wb'))
 


### PR DESCRIPTION
Fixes vs2010 build file regeneration, as discussed in #418.

A regeneration is now triggered only if a dependency (i.e. any `meson.build` file and `coredata.dat`) has changed since the solution was generated.

This is a two-step solution:

1. Usage of MSBuild incremental build support: Declare dependencies and an output file. MSBuild compares the timestamps and calls meson if:
  - it has not run the target once before (i.e. at the first build)
  - the output file is missing
  - any input file is newer than the output file

2. meson then checks all dependencies again and only regenerates the solution if any input file is newer than the output file. This additional check is needed to not regenerate the solution on the first build or if the timestamp file is missing (because of a clean build).

Should we add a test for this? If so, how? This would need special behavior in the test setup to detect if a regeneration took place.