### PR TITLE
enhance test framework to read meson arguments from a file per test

### DIFF
--- a/test cases/common/109 testframework options/meson.build
+++ b/test cases/common/109 testframework options/meson.build
@@ -1,0 +1,5 @@
+project('options', 'c')
+
+assert(get_option('testoption') == 'A string with spaces', 'Incorrect value for testoption option.')
+assert(get_option('other_one') == true, 'Incorrect value for other_one option.')
+assert(get_option('combo_opt') == 'one', 'Incorrect value for combo_opt option.')

--- a/test cases/common/109 testframework options/meson_options.txt
+++ b/test cases/common/109 testframework options/meson_options.txt
@@ -1,0 +1,3 @@
+option('testoption', type : 'string', value : 'optval', description : 'An option to do something')
+option('other_one', type : 'boolean', value : false)
+option('combo_opt', type : 'combo', choices : ['one', 'two', 'combo'], value : 'combo')

--- a/test cases/common/109 testframework options/test_args.txt
+++ b/test cases/common/109 testframework options/test_args.txt
@@ -1,0 +1,4 @@
+# This file is not read by meson itself, but by the test framework.
+# It is not possible to pass arguments to meson from a file.
+['--werror', '-D', 'testoption=A string with spaces', '-D', 'other_one=true', \
+ '-D', 'combo_opt=one']


### PR DESCRIPTION
A `test_args.txt` file in the same directory as the test case will be parsed by the test framework and the content will be passed as arguments to meson during configuration.
The arguments are put before any `extra_args` to make them overwritable
from the command line.

This allows to test that `-D options` command line arguments properly overwrite default options and also allows every other command line argument to be tested for effectiveness, which might come in handy when implementing #429.