### PR TITLE
New options for controlling test output.

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -18,7 +18,7 @@ from .. import dependencies
 from .. import mesonlib
 import json
 import subprocess
-from ..coredata import MesonException
+from ..mesonlib import MesonException
 
 class InstallData():
     def __init__(self, source_dir, build_dir, prefix):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -18,10 +18,9 @@ from .. import build
 from .. import mlog
 from .. import dependencies
 from .. import compilers
-from ..mesonlib import File
+from ..mesonlib import File, MesonException
 from .backends import InstallData
 from ..build import InvalidArguments
-from ..coredata import MesonException
 import os, sys, pickle, re
 import subprocess, shutil
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -586,6 +586,8 @@ int dummy;
         cmd = [ sys.executable, self.environment.get_build_command(), '--internal', 'test' ]
         if not self.environment.coredata.get_builtin_option('stdsplit'):
             cmd += ['--no-stdsplit']
+        if self.environment.coredata.get_builtin_option('errorlogs'):
+            cmd += ['--print-errorlogs']
         cmd += [ test_data ]
         elem = NinjaBuildElement(self.all_outputs, 'test', 'CUSTOM_COMMAND', ['all', 'PHONY'])
         elem.add_item('COMMAND', cmd)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -583,7 +583,10 @@ int dummy;
         valgrind = environment.find_valgrind()
         script_root = self.environment.get_script_dir()
         test_data = os.path.join(self.environment.get_scratch_dir(), 'meson_test_setup.dat')
-        cmd = [sys.executable, self.environment.get_build_command(), '--internal', 'test', test_data]
+        cmd = [ sys.executable, self.environment.get_build_command(), '--internal', 'test' ]
+        if not self.environment.coredata.get_builtin_option('stdsplit'):
+            cmd += ['--no-stdsplit']
+        cmd += [ test_data ]
         elem = NinjaBuildElement(self.all_outputs, 'test', 'CUSTOM_COMMAND', ['all', 'PHONY'])
         elem.add_item('COMMAND', cmd)
         elem.add_item('DESC', 'Running all tests.')

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -24,7 +24,7 @@ from .. import dependencies
 from .. import mlog
 import xml.etree.ElementTree as ET
 import xml.dom.minidom
-from ..coredata import MesonException
+from ..mesonlib import MesonException
 from ..environment import Environment
 
 class RegenInfo():

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -17,7 +17,7 @@ from .. import build
 from .. import mesonlib
 import uuid, os, sys
 
-from ..coredata import MesonException
+from ..mesonlib import MesonException
 
 class XCodeBackend(backends.Backend):
     def __init__(self, build):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -17,7 +17,7 @@ from . import environment
 from . import dependencies
 from . import mlog
 import copy, os
-from .mesonlib import File, flatten
+from .mesonlib import File, flatten, MesonException
 
 known_basic_kwargs = {'install' : True,
                       'c_pch' : True,
@@ -71,7 +71,7 @@ We are fully aware that these are not really usable or pleasant ways to do
 this but it's the best we can do given the way shell quoting works.
 '''
 
-class InvalidArguments(coredata.MesonException):
+class InvalidArguments(MesonException):
     pass
 
 class Build:
@@ -299,10 +299,10 @@ class BuildTarget():
                 srclist = [srclist]
             for src in srclist:
                 if not isinstance(src, str):
-                    raise coredata.MesonException('Extraction arguments must be strings.')
+                    raise MesonException('Extraction arguments must be strings.')
                 src = File(False, self.subdir, src)
                 if src not in self.sources:
-                    raise coredata.MesonException('Tried to extract unknown source %s.' % src)
+                    raise MesonException('Tried to extract unknown source %s.' % src)
                 obj_src.append(src)
         return ExtractedObjects(self, obj_src)
 

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -16,7 +16,7 @@ import subprocess, os.path
 import tempfile
 from .import mesonlib
 from . import mlog
-from .coredata import MesonException
+from .mesonlib import MesonException
 from . import coredata
 
 """This file contains the data files of all compilers Meson knows

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -211,6 +211,7 @@ builtin_options = {
         'default_library'   : [ UserComboOption, 'Default library type.', [ 'shared', 'static' ], 'shared' ],
         'backend'           : [ UserComboOption, 'Backend to use.', [ 'ninja', 'vs2010', 'xcode' ], 'ninja' ],
         'stdsplit'          : [ UserBooleanOption, 'Split stdout and stderr in test logs.', True ],
+        'errorlogs'         : [ UserBooleanOption, "Whether to print the logs from failing tests.", False ],
         }
 
 forbidden_target_names = {'clean': None,

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -210,6 +210,7 @@ builtin_options = {
         'layout'            : [ UserComboOption, 'Build directory layout.', ['mirror', 'flat' ], 'mirror' ],
         'default_library'   : [ UserComboOption, 'Default library type.', [ 'shared', 'static' ], 'shared' ],
         'backend'           : [ UserComboOption, 'Backend to use.', [ 'ninja', 'vs2010', 'xcode' ], 'ninja' ],
+        'stdsplit'          : [ UserBooleanOption, 'Split stdout and stderr in test logs.', True ],
         }
 
 forbidden_target_names = {'clean': None,

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pickle, os, uuid
+from .mesonlib import MesonException
 
 version = '0.31.0.dev1'
 
@@ -38,10 +39,6 @@ builtin_options = {'buildtype': True,
                    'layout' : True,
                    'default_library': True,
                   }
-
-class MesonException(Exception):
-    def __init__(self, *args, **kwargs):
-        Exception.__init__(self, *args, **kwargs)
 
 class UserOption:
     def __init__(self, name, description, choices):

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -22,7 +22,7 @@
 import re
 import os, stat, glob, subprocess, shutil
 import sysconfig
-from . coredata import MesonException
+from . mesonlib import MesonException
 from . import mlog
 from . import mesonlib
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -19,7 +19,7 @@ import configparser
 
 build_filename = 'meson.build'
 
-class EnvironmentException(coredata.MesonException):
+class EnvironmentException(mesonlib.MesonException):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -657,11 +657,11 @@ class CrossBuildInfo():
         if 'target_machine' in self.config:
             return
         if not 'host_machine' in self.config:
-            raise coredata.MesonException('Cross info file must have either host or a target machine.')
+            raise mesonlib.MesonException('Cross info file must have either host or a target machine.')
         if not 'properties' in self.config:
-            raise coredata.MesonException('Cross file is missing "properties".')
+            raise mesonlib.MesonException('Cross file is missing "properties".')
         if not 'binaries' in self.config:
-            raise coredata.MesonException('Cross file is missing "binaries".')
+            raise mesonlib.MesonException('Cross file is missing "binaries".')
 
     def ok_type(self, i):
         return isinstance(i, str) or isinstance(i, int) or isinstance(i, bool)

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -28,7 +28,7 @@ from functools import wraps
 
 import importlib
 
-class InterpreterException(coredata.MesonException):
+class InterpreterException(mesonlib.MesonException):
     pass
 
 class InvalidCode(InterpreterException):
@@ -932,7 +932,7 @@ class Interpreter():
         assert(isinstance(code, str))
         try:
             self.ast = mparser.Parser(code).parse()
-        except coredata.MesonException as me:
+        except mesonlib.MesonException as me:
             me.file = environment.build_filename
             raise me
         self.sanity_check_ast()
@@ -1801,7 +1801,7 @@ class Interpreter():
         assert(isinstance(code, str))
         try:
             codeblock = mparser.Parser(code).parse()
-        except coredata.MesonException as me:
+        except mesonlib.MesonException as me:
             me.file = buildfilename
             raise me
         self.evaluate_codeblock(codeblock)

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1341,7 +1341,7 @@ class Interpreter():
             return self.environment.coredata.compiler_options[optname].value
         except KeyError:
             pass
-        if optname not in coredata.builtin_options and self.is_subproject():
+        if not coredata.is_builtin_option(optname) and self.is_subproject():
             optname = self.subproject + ':' + optname
         try:
             return self.environment.coredata.user_options[optname].value
@@ -1364,8 +1364,7 @@ class Interpreter():
             if '=' not in option:
                 raise InterpreterException('All default options must be of type key=value.')
             key, value = option.split('=', 1)
-            builtin_options = self.coredata.builtin_options
-            if key in builtin_options:
+            if coredata.is_builtin_option(key):
                 if not self.environment.had_argument_for(key):
                     self.coredata.set_builtin_option(key, value)
                 # If this was set on the command line, do not override.

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -26,7 +26,7 @@ parser.add_argument('-D', action='append', default=[], dest='sets',
                     help='Set an option to the given value.')
 parser.add_argument('directory', nargs='*')
 
-class ConfException(coredata.MesonException):
+class ConfException(mesonlib.MesonException):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -187,6 +187,13 @@ class Conf:
                   choices = str(opt.choices);
                 optarr.append([key, opt.description, opt.value, choices])
             self.print_aligned(optarr)
+        print('')
+        print('Testing options:')
+        tarr = []
+        for key in [ 'stdsplit', 'errorlogs' ]:
+            tarr.append([key, coredata.get_builtin_option_description(key),
+                self.coredata.get_builtin_option(key), coredata.get_builtin_option_choices(key)])
+        self.print_aligned(tarr)
 
 def run(args):
     args = mesonlib.expand_arguments(args)

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -179,6 +179,9 @@ def default_libexecdir():
     # There is no way to auto-detect this, so it must be set at build time
     return 'libexec'
 
+def default_prefix():
+    return 'c:/' if is_windows() else '/usr/local'
+
 def get_library_dirs():
     if is_windows():
         return ['C:/mingw/lib'] # Fixme

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -18,7 +18,9 @@ import platform, subprocess, operator, os, shutil, re, sys
 
 from glob import glob
 
-from .coredata import MesonException
+class MesonException(Exception):
+    def __init__(self, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
 
 class File:
     def __init__(self, is_built, subdir, fname):

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -22,7 +22,6 @@ from . import build
 import platform
 from . import mlog, coredata
 from .mesonlib import MesonException
-from .coredata import build_types, layouts, warning_levels, libtypelist
 
 backendlist = ['ninja', 'vs2010', 'xcode']
 
@@ -30,49 +29,40 @@ parser = argparse.ArgumentParser()
 
 default_warning = '1'
 
-if mesonlib.is_windows():
-    def_prefix = 'c:/'
-else:
-    def_prefix = '/usr/local'
+def add_builtin_argument(name, **kwargs):
+    k = kwargs.get('dest', name.replace('-', '_'))
+    c = coredata.get_builtin_option_choices(k)
+    b = True if kwargs.get('action', None) in [ 'store_true', 'store_false' ] else False
+    h = coredata.get_builtin_option_description(k)
+    if not b:
+        h = h.rstrip('.') + ' (default: %s).' % coredata.get_builtin_option_default(k)
+    if c and not b:
+        kwargs['choices'] = c
+    parser.add_argument('--' + name, default=coredata.get_builtin_option_default(k), help=h, **kwargs)
 
-parser.add_argument('--prefix', default=def_prefix, dest='prefix',
-                    help='the installation prefix (default: %(default)s)')
-parser.add_argument('--libdir', default=mesonlib.default_libdir(), dest='libdir',
-                    help='the installation subdir of libraries (default: %(default)s)')
-parser.add_argument('--libexecdir', default=mesonlib.default_libexecdir(), dest='libexecdir',
-                    help='the installation subdir of library executables (default: %(default)s)')
-parser.add_argument('--bindir', default='bin', dest='bindir',
-                    help='the installation subdir of executables (default: %(default)s)')
-parser.add_argument('--includedir', default='include', dest='includedir',
-                    help='relative path of installed headers (default: %(default)s)')
-parser.add_argument('--datadir', default='share', dest='datadir',
-                    help='relative path to the top of data file subdirectory (default: %(default)s)')
-parser.add_argument('--mandir', default='share/man', dest='mandir',
-                    help='relative path of man files (default: %(default)s)')
-parser.add_argument('--localedir', default='share/locale', dest='localedir',
-                    help='relative path of locale data (default: %(default)s)')
-parser.add_argument('--backend', default='ninja', dest='backend', choices=backendlist,
-                    help='backend to use (default: %(default)s)')
-parser.add_argument('--buildtype', default='debug', choices=build_types, dest='buildtype',
-                    help='build type go use (default: %(default)s)')
-parser.add_argument('--strip', action='store_true', dest='strip', default=False,\
-                    help='strip targets on install (default: %(default)s)')
-parser.add_argument('--unity', action='store_true', dest='unity', default=False,\
-                    help='unity build')
-parser.add_argument('--werror', action='store_true', dest='werror', default=False,\
-                    help='Treat warnings as errors')
-parser.add_argument('--layout', choices=layouts, dest='layout', default='mirror',\
-                    help='Build directory layout.')
-parser.add_argument('--default-library', choices=libtypelist, dest='default_library',
-                    default='shared', help='Default library type.')
-parser.add_argument('--warnlevel', default=default_warning, dest='warning_level', choices=warning_levels,\
-                    help='Level of compiler warnings to use (larger is more, default is %(default)s)')
-parser.add_argument('--cross-file', default=None, dest='cross_file',
-                    help='file describing cross compilation environment')
+add_builtin_argument('prefix')
+add_builtin_argument('libdir')
+add_builtin_argument('libexecdir')
+add_builtin_argument('bindir')
+add_builtin_argument('includedir')
+add_builtin_argument('datadir')
+add_builtin_argument('mandir')
+add_builtin_argument('localedir')
+add_builtin_argument('backend')
+add_builtin_argument('buildtype')
+add_builtin_argument('strip', action='store_true')
+add_builtin_argument('unity', action='store_true')
+add_builtin_argument('werror', action='store_true')
+add_builtin_argument('layout')
+add_builtin_argument('default-library')
+add_builtin_argument('warnlevel', dest='warning_level')
+
+parser.add_argument('--cross-file', default=None,
+                    help='File describing cross compilation environment.')
 parser.add_argument('-D', action='append', dest='projectoptions', default=[],
                     help='Set project options.')
 parser.add_argument('-v', '--version', action='store_true', dest='print_version', default=False,
-                    help='Print version.')
+                    help='Print version information.')
 parser.add_argument('directories', nargs='*')
 
 class MesonApp():

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -21,8 +21,8 @@ from . import environment, interpreter, mesonlib
 from . import build
 import platform
 from . import mlog, coredata
-
-from .coredata import MesonException, build_types, layouts, warning_levels, libtypelist
+from .mesonlib import MesonException
+from .coredata import build_types, layouts, warning_levels, libtypelist
 
 backendlist = ['ninja', 'vs2010', 'xcode']
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -18,7 +18,7 @@ functionality such as gobject-introspection and gresources.'''
 from .. import build
 import os, sys
 import subprocess
-from ..coredata import MesonException
+from ..mesonlib import MesonException
 from .. import mlog
 from .. import mesonlib
 

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -55,7 +55,7 @@ class PkgConfigModule:
 
     def generate(self, state, args, kwargs):
         if len(args) > 0:
-            raise coredata.MesonException('Pkgconfig_gen takes no positional arguments.')
+            raise mesonlib.MesonException('Pkgconfig_gen takes no positional arguments.')
         libs = kwargs.get('libraries', [])
         if not isinstance(libs, list):
             libs = [libs]
@@ -64,22 +64,22 @@ class PkgConfigModule:
             if hasattr(l, 'held_object'):
                 l = l.held_object
             if not (isinstance(l, build.SharedLibrary) or isinstance(l, build.StaticLibrary)):
-                raise coredata.MesonException('Library argument not a library object.')
+                raise mesonlib.MesonException('Library argument not a library object.')
             processed_libs.append(l)
         libs = processed_libs
         subdirs = mesonlib.stringlistify(kwargs.get('subdirs', ['.']))
         version = kwargs.get('version', '')
         if not isinstance(version, str):
-            raise coredata.MesonException('Version must be a string.')
+            raise mesonlib.MesonException('Version must be a string.')
         name = kwargs.get('name', None)
         if not isinstance(name, str):
-            raise coredata.MesonException('Name not specified.')
+            raise mesonlib.MesonException('Name not specified.')
         filebase = kwargs.get('filebase', name)
         if not isinstance(filebase, str):
-            raise coredata.MesonException('Filebase must be a string.')
+            raise mesonlib.MesonException('Filebase must be a string.')
         description = kwargs.get('description', None)
         if not isinstance(description, str):
-            raise coredata.MesonException('Description is not a string.')
+            raise mesonlib.MesonException('Description is not a string.')
         pub_reqs = mesonlib.stringlistify(kwargs.get('requires', []))
         priv_reqs = mesonlib.stringlistify(kwargs.get('requires_private', []))
         priv_libs = mesonlib.stringlistify(kwargs.get('libraries_private', []))

--- a/mesonbuild/modules/qt4.py
+++ b/mesonbuild/modules/qt4.py
@@ -15,7 +15,7 @@
 from .. import dependencies, mlog
 import os, subprocess
 from .. import build
-from ..coredata import MesonException
+from ..mesonlib import MesonException
 import xml.etree.ElementTree as ET
 
 class Qt4Module():

--- a/mesonbuild/modules/qt5.py
+++ b/mesonbuild/modules/qt5.py
@@ -15,7 +15,7 @@
 from .. import dependencies, mlog
 import os, subprocess
 from .. import build
-from ..coredata import MesonException
+from ..mesonlib import MesonException
 import xml.etree.ElementTree as ET
 
 class Qt5Module():

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .. import mesonlib, dependencies, build
-from ..coredata import MesonException
+from ..mesonlib import MesonException
 import os
 
 class WindowsModule:

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import re
-from .coredata import MesonException
+from .mesonlib import MesonException
 
 class ParseException(MesonException):
     def __init__(self, text, lineno, colno):

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -17,7 +17,7 @@ from . import coredata
 from . import mesonlib
 import os, re
 
-forbidden_option_names = coredata.builtin_options
+forbidden_option_names = coredata.get_builtin_options()
 forbidden_prefixes = {'c_': True,
                       'cpp_': True,
                       'rust_': True,

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -14,6 +14,7 @@
 
 from . import mparser
 from . import coredata
+from . import mesonlib
 import os, re
 
 forbidden_option_names = coredata.builtin_options
@@ -37,7 +38,7 @@ def is_invalid_name(name):
         return True
     return False
 
-class OptionException(coredata.MesonException):
+class OptionException(mesonlib.MesonException):
     pass
 
 optname_regex = re.compile('[^a-zA-Z0-9_-]')
@@ -77,7 +78,7 @@ class OptionInterpreter:
     def process(self, option_file):
         try:
             ast = mparser.Parser(open(option_file, 'r', encoding='utf8').read()).parse()
-        except coredata.MesonException as me:
+        except mesonlib.MesonException as me:
             me.file = option_file
             raise me
         if not isinstance(ast, mparser.CodeBlockNode):

--- a/mesonbuild/scripts/meson_benchmark.py
+++ b/mesonbuild/scripts/meson_benchmark.py
@@ -39,9 +39,10 @@ def print_json_log(jsonlogfile, rawruns, test_name, i):
     for r in rawruns:
         runobj = {'duration': r.duration,
                   'stdout': r.stdo,
-                  'stderr': r.stde,
                   'returncode' : r.returncode,
                   'duration' : r.duration}
+        if r.stde:
+            runobj['stderr'] = r.stde
         runs.append(runobj)
     jsonobj['runs'] = runs
     jsonlogfile.write(json.dumps(jsonobj) + '\n')

--- a/mesonbuild/scripts/meson_test.py
+++ b/mesonbuild/scripts/meson_test.py
@@ -44,13 +44,14 @@ parser.add_argument('args', nargs='+')
 
 
 class TestRun():
-    def __init__(self, res, returncode, duration, stdo, stde, cmd):
+    def __init__(self, res, returncode, should_fail, duration, stdo, stde, cmd):
         self.res = res
         self.returncode = returncode
         self.duration = duration
         self.stdo = stdo
         self.stde = stde
         self.cmd = cmd
+        self.should_fail = should_fail
 
     def get_log(self):
         res = '--- command ---\n'
@@ -160,7 +161,7 @@ def run_single_test(wrap, test):
         else:
             res = 'FAIL'
         returncode = p.returncode
-    return TestRun(res, returncode, duration, stdo, stde, cmd)
+    return TestRun(res, returncode, test.should_fail, duration, stdo, stde, cmd)
 
 def print_stats(numlen, tests, name, result, i, logfile, jsonlogfile):
     global collected_logs, error_count, options
@@ -172,7 +173,7 @@ def print_stats(numlen, tests, name, result, i, logfile, jsonlogfile):
         (num, name, padding1, result.res, padding2, result.duration)
     print(result_str)
     result_str += "\n\n" + result.get_log()
-    if result.returncode != 0:
+    if (result.returncode != 0) != result.should_fail:
         error_count += 1
         if options.print_errorlogs:
             collected_logs.append(result_str)

--- a/mesonbuild/scripts/meson_test.py
+++ b/mesonbuild/scripts/meson_test.py
@@ -26,6 +26,7 @@ def is_windows():
     return platname == 'windows' or 'mingw' in platname
 
 tests_failed = []
+options = None
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--wrapper', default=None, dest='wrapper',
@@ -171,7 +172,8 @@ def filter_tests(suite, tests):
         return tests
     return [x for x in tests if suite in x.suite]
 
-def run_tests(options, datafilename):
+def run_tests(datafilename):
+    global options
     logfile_base = 'meson-logs/testlog'
     if options.wrapper is None:
         wrap = []
@@ -222,7 +224,7 @@ def run_tests(options, datafilename):
     return logfilename
 
 def run(args):
-    global tests_failed
+    global tests_failed, options
     tests_failed = [] # To avoid state leaks when invoked multiple times (running tests in-process)
     options = parser.parse_args(args)
     if len(options.args) != 1:
@@ -231,7 +233,7 @@ def run(args):
     if options.wd is not None:
         os.chdir(options.wd)
     datafile = options.args[0]
-    logfilename = run_tests(options, datafile)
+    logfilename = run_tests(datafile)
     returncode = 0
     if len(tests_failed) > 0:
         print('\nOutput of failed tests (max 10):')


### PR DESCRIPTION
It is at times very inconvenient to have stdout and stderr separated in
the test logs as the relation between different messages (from stdout and
stderr) gets lost. Comparing time stamps can also be very tedious. An
option for disabling this feature thus seemed useful.

It is at times also very inconvenient to get the output of failed tests
printed to the user at the end of testing. Individual test logs can get
huge in some projects in which case the actual results of all the tests
can e.g. get flushed away from the terminal (the size of the scrollback
buffer is usually limited). An option for controlling how the output of
failed tests gets shown to the user was hence seen as a useful addition.

These changes introduce the options --no-stdsplit for disabling the
division of tests' output to stdout and stderr and --test-output for
controlling how the failed tests' output is shown during testing. The
latter expects one of the following arguments: 'none' (no logs from tests
get printed directly to the user), 'mix' (the output of failed tests gets
printed immediately to the user) and 'append' (the output of all the
failed tests gets printed to the user after the last test has been
executed).
