### PR TITLE
vs2010: support precompiled headers

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -432,6 +432,8 @@ class Vs2010Backend(backends.Backend):
             pch = target.get_pch(lang)
             if len(pch) == 0:
                 continue
+            if len(pch_sources) > 0:
+                raise MesonException('VS2010 backend does not support multiple precompiled header files.')
             pch_node.text = 'Use'
             pch_file = ET.SubElement(clconf, 'PrecompiledHeaderFile')
             pch_file.text = pch[0]


### PR DESCRIPTION
This brings support for precompiled headers in the vs2010 backend.

There are 3 supported cases:
- no pch at all: do nothing
- pch only for either `C` or `C++`: use per target PrecompiledHeader settings
- pch for both `C` **and** `C++`: use PrecompiledHeader settings per file, decide between `C` or `C++` pch based on the suffix of the source file that is being compiled.
