### PR TITLE
vs2010: fix compile args

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -222,7 +222,9 @@ class Vs2010Backend(backends.Backend):
         objects = []
         languages = []
         for i in srclist:
-            if self.environment.is_object(i):
+            if self.environment.is_header(i):
+                headers.append(i)
+            elif self.environment.is_object(i):
                 objects.append(i)
             elif self.environment.is_source(i):
                 sources.append(i)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -222,15 +222,15 @@ class Vs2010Backend(backends.Backend):
         objects = []
         languages = []
         for i in srclist:
-            lang = self.lang_from_source_file(i)
-            if lang not in languages:
-                languages.append(lang)
             if self.environment.is_header(i):
                 headers.append(i)
             elif self.environment.is_object(i):
                 objects.append(i)
             else:
                 sources.append(i)
+                lang = self.lang_from_source_file(i)
+                if lang not in languages:
+                    languages.append(lang)
         return (sources, headers, objects, languages)
 
     def target_to_build_root(self, target):

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -444,7 +444,10 @@ class Vs2010Backend(backends.Backend):
         # here.
         general_args += compiler.get_option_compile_args(self.environment.coredata.compiler_options)
         for d in target.get_external_deps():
-            general_args += d.compile_args
+            try:
+                general_args += d.compile_args
+            except AttributeError:
+                pass
 
         languages += gen_langs
         has_language_specific_args = any(l != extra_args['c'] for l in extra_args.values())

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -222,9 +222,7 @@ class Vs2010Backend(backends.Backend):
         objects = []
         languages = []
         for i in srclist:
-            if self.environment.is_header(i):
-                headers.append(i)
-            elif self.environment.is_object(i):
+            if self.environment.is_object(i):
                 objects.append(i)
             elif self.environment.is_source(i):
                 sources.append(i)
@@ -232,8 +230,8 @@ class Vs2010Backend(backends.Backend):
                 if lang not in languages:
                     languages.append(lang)
             else:
-                # TODO: what to do with those? E.g. generated header files with custom extension (test case 64)
-                pass
+                # Everything that is not an object or source file is considered a header.
+                headers.append(i)
         return (sources, headers, objects, languages)
 
     def target_to_build_root(self, target):

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -226,11 +226,14 @@ class Vs2010Backend(backends.Backend):
                 headers.append(i)
             elif self.environment.is_object(i):
                 objects.append(i)
-            else:
+            elif self.environment.is_source(i):
                 sources.append(i)
                 lang = self.lang_from_source_file(i)
                 if lang not in languages:
                     languages.append(lang)
+            else:
+                # TODO: what to do with those? E.g. generated header files with custom extension (test case 64)
+                pass
         return (sources, headers, objects, languages)
 
     def target_to_build_root(self, target):


### PR DESCRIPTION
This fixes test cases 23 and 24 for the vs2010 backend.

I chose to refactor those test cases to remove the check for language specific arguments that should not be `#define`d, since MSBuild does not support language specific preprocessor definitions by default.

Instead, I added these more special test cases as 109 and 110. Reason: the low number test cases should demonstrate basic features, whereas higher ones should test more special edge cases.