### PR TITLE
config file: write commented undef lines same as autoconf

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -227,7 +227,7 @@ def do_mesondefine(line, confdata):
     try:
         v = confdata.get(varname)
     except KeyError:
-        return '/* undef %s */\n' % varname
+        return '/* #undef %s */\n' % varname
     if isinstance(v, bool):
         if v:
             return '#define %s\n' % varname


### PR DESCRIPTION
For easier diffing to see if anything is missing when porting.