### PR TITLE
test24: check that a target extra_arg is not applied to other targets

### DIFF
--- a/test cases/common/24 target arg/func2.c
+++ b/test cases/common/24 target arg/func2.c
@@ -1,0 +1,9 @@
+#ifdef CTHING
+#error "Local C argument set in wrong target"
+#endif
+
+#ifdef CPPTHING
+#error "Local CPP argument set in wrong target"
+#endif
+
+int func() { return 0; }

--- a/test cases/common/24 target arg/meson.build
+++ b/test cases/common/24 target arg/meson.build
@@ -3,5 +3,7 @@ project('local arg test', 'cpp', 'c')
 exe1 = executable('prog', 'prog.cc', 'func.c', \
 c_args   : '-DCTHING', \
 cpp_args : '-DCPPTHING')
+exe2 = executable('prog2', 'prog2.cc', 'func2.c')
 
 test('prog1', exe1)
+test('prog2', exe2)

--- a/test cases/common/24 target arg/prog2.cc
+++ b/test cases/common/24 target arg/prog2.cc
@@ -1,0 +1,13 @@
+#ifdef CTHING
+#error "Local C argument set in wrong target"
+#endif
+
+#ifdef CPPTHING
+#error "Local CPP argument set in wrong target"
+#endif
+
+extern "C" int func();
+
+int main(int argc, char **argv) {
+    return func();
+}


### PR DESCRIPTION
Target specific args should only be applied to a single target, so make sure they are not applied in another target.