### PR TITLE
vs2010: give each target an own temp dir

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -272,7 +272,7 @@ class Vs2010Backend(backends.Backend):
         outdir = ET.SubElement(direlem, 'OutDir')
         outdir.text = '.\\'
         intdir = ET.SubElement(direlem, 'IntDir')
-        intdir.text = 'test-temp\\'
+        intdir.text = target.get_id() + '\\'
         tname = ET.SubElement(direlem, 'TargetName')
         tname.text = target.name
         return root
@@ -395,7 +395,7 @@ class Vs2010Backend(backends.Backend):
         outdir = ET.SubElement(direlem, 'OutDir')
         outdir.text = '.\\'
         intdir = ET.SubElement(direlem, 'IntDir')
-        intdir.text = os.path.join(self.get_target_dir(target), target.get_basename() + '.dir') + '\\'
+        intdir.text = target.get_id() + '\\'
         tname = ET.SubElement(direlem, 'TargetName')
         tname.text = target_name
         inclinc = ET.SubElement(direlem, 'LinkIncremental')
@@ -604,7 +604,7 @@ class Vs2010Backend(backends.Backend):
         outdir = ET.SubElement(direlem, 'OutDir')
         outdir.text = '.\\'
         intdir = ET.SubElement(direlem, 'IntDir')
-        intdir.text = 'test-temp\\'
+        intdir.text = 'regen-temp\\'
         tname = ET.SubElement(direlem, 'TargetName')
         tname.text = project_name
 


### PR DESCRIPTION
The 'Rebuild' target fails in mysterious ways if multiple targets use the same directories because of output files being deleted between two build steps (e.g. test case 78 fails on Rebuild, whereas Clean + Build work just fine).