### PR TITLE
Cross-file modifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__
 
 .DS_Store
 *~
+*#*
 packagecache
 /MANIFEST
 /build

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -247,7 +247,10 @@ class Backend():
         commands += compiler.get_warn_args(self.environment.coredata.get_builtin_option('warning_level'))
         commands += compiler.get_option_compile_args(self.environment.coredata.compiler_options)
         commands += self.build.get_global_args(compiler)
-        commands += self.environment.coredata.external_args[compiler.get_language()]
+        crstr = ''
+        if target.is_cross:
+            crstr = '_CROSS'
+        commands += self.environment.coredata.external_args[compiler.get_language()+crstr]
         commands += target.get_extra_args(compiler.get_language())
         commands += compiler.get_buildtype_args(self.environment.coredata.get_builtin_option('buildtype'))
         if self.environment.coredata.get_builtin_option('coverage'):
@@ -317,10 +320,8 @@ class Backend():
             else:
                 fname = [os.path.join(self.environment.get_build_dir(), self.get_target_filename(t.get_exe()))]
             is_cross = self.environment.is_cross_build() and self.environment.cross_info.need_cross_compiler()
-            if is_cross:
-                exe_wrapper = self.environment.cross_info.config['binaries'].get('exe_wrapper', None)
-            else:
-                exe_wrapper = None
+            machine_prop = self.environment.get_machine_properties(is_cross)
+            exe_wrapper = machine_prop.get('exe_wrapper', None)
             if mesonlib.is_windows():
                 extra_paths = self.determine_windows_extra_paths(exe)
             else:

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -538,8 +538,9 @@ int main(int argc, char **argv) {
 '''
         varname = 'has function ' + funcname
         varname = varname.replace(' ', '_')
+        machine_prop = self.cross_info.get_machine_config(self.is_cross)
         if self.is_cross:
-            val = env.cross_info.config['properties'].get(varname, None)
+            val = machine_prop.get(varname, None)
             if val is not None:
                 if isinstance(val, bool):
                     return val
@@ -1682,11 +1683,11 @@ class SunFortranCompiler(FortranCompiler):
 
 class IntelFortranCompiler(FortranCompiler):
     std_warn_args = ['-warn', 'all']
-    
+
     def __init__(self, exelist, version, is_cross, exe_wrapper=None):
         super().__init__(exelist, version, is_cross, exe_wrapper=None)
         self.id = 'intel'
-        
+
     def get_module_outdir_args(self, path):
         return ['-module', path]
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -175,13 +175,13 @@ class Environment():
                 if type(oldval) != type(value):
                     self.coredata.user_options[name] = value
 
-    def detect_c_compiler(self, want_cross):
+    def detect_c_compiler(self, is_cross):
         evar = 'CC'
-        if self.is_cross_build() and want_cross:
-            compilers = [self.cross_info.config['binaries']['c']]
+        machine_prop = self.get_machine_properties(is_cross)
+        if machine_prop:
+            compilers = [machine_prop['c']]
             ccache = []
-            is_cross = True
-            exe_wrap = self.cross_info.config['binaries'].get('exe_wrapper', None)
+            exe_wrap = machine_prop.get('exe_wrapper', None)
         elif evar in os.environ:
             compilers = os.environ[evar].split()
             ccache = []
@@ -230,19 +230,17 @@ class Environment():
                 return VisualStudioCCompiler([compiler], version, is_cross, exe_wrap)
         raise EnvironmentException('Unknown compiler(s): "' + ', '.join(compilers) + '"')
 
-    def detect_fortran_compiler(self, want_cross):
+    def detect_fortran_compiler(self, is_cross):
         evar = 'FC'
-        if self.is_cross_build() and want_cross:
-            compilers = [self.cross_info['fortran']]
-            is_cross = True
-            exe_wrap = self.cross_info.get('exe_wrapper', None)
+        machine_prop = self.get_machine_properties(is_cross)
+        if prop:
+            compilers = [machine_prop['fortran']]
+            exe_wrap = machine_prop.get('exe_wrapper', None)
         elif evar in os.environ:
             compilers = os.environ[evar].split()
-            is_cross = False
             exe_wrap = None
         else:
             compilers = self.default_fortran
-            is_cross = False
             exe_wrap = None
         for compiler in compilers:
             for arg in ['--version', '-V']:
@@ -276,7 +274,7 @@ class Environment():
 
                 if 'ifort (IFORT)' in out:
                   return IntelFortranCompiler([compiler], version, is_cross, exe_wrap)
-                
+
                 if 'PathScale EKOPath(tm)' in err:
                   return PathScaleFortranCompiler([compiler], version, is_cross, exe_wrap)
 
@@ -298,22 +296,20 @@ class Environment():
         path = os.path.split(__file__)[0]
         return os.path.join(path, 'depfixer.py')
 
-    def detect_cpp_compiler(self, want_cross):
+    def detect_cpp_compiler(self, is_cross):
         evar = 'CXX'
-        if self.is_cross_build() and want_cross:
-            compilers = [self.cross_info.config['binaries']['cpp']]
+        machine_prop = self.get_machine_properties(is_cross)
+        if machine_prop:
+            compilers = [machine_prop['cpp']]
             ccache = []
-            is_cross = True
-            exe_wrap = self.cross_info.config['binaries'].get('exe_wrapper', None)
+            exe_wrap = mahine_prop.get('exe_wrapper', None)
         elif evar in os.environ:
             compilers = os.environ[evar].split()
             ccache = []
-            is_cross = False
             exe_wrap = None
         else:
             compilers = self.default_cpp
             ccache = self.detect_ccache()
-            is_cross = False
             exe_wrap = None
         for compiler in compilers:
             basename = os.path.basename(compiler).lower()
@@ -352,14 +348,13 @@ class Environment():
                 return VisualStudioCPPCompiler([compiler], version, is_cross, exe_wrap)
         raise EnvironmentException('Unknown compiler(s) "' + ', '.join(compilers) + '"')
 
-    def detect_objc_compiler(self, want_cross):
-        if self.is_cross_build() and want_cross:
-            exelist = [self.cross_info['objc']]
-            is_cross = True
-            exe_wrap = self.cross_info.get('exe_wrapper', None)
+    def detect_objc_compiler(self, is_cross):
+        machine_prop = self.get_machine_properties(is_cross)
+        if machine_prop:
+            exelist = [machine_prop['objc']]
+            exe_wrap = machine_prop.get('exe_wrapper', None)
         else:
             exelist = self.get_objc_compiler_exelist()
-            is_cross = False
             exe_wrap = None
         try:
             p = subprocess.Popen(exelist + ['--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -382,14 +377,13 @@ class Environment():
             return GnuObjCCompiler(exelist, version, is_cross, exe_wrap)
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
 
-    def detect_objcpp_compiler(self, want_cross):
-        if self.is_cross_build() and want_cross:
-            exelist = [self.cross_info['objcpp']]
-            is_cross = True
-            exe_wrap = self.cross_info.get('exe_wrapper', None)
+    def detect_objcpp_compiler(self, is_cross):
+        machine_prop = self.get_machine_properties(is_cross)
+        if prop:
+            exelist = [machine_prop['objcpp']]
+            exe_wrap = machine_prop.get('exe_wrapper', None)
         else:
             exelist = self.get_objcpp_compiler_exelist()
-            is_cross = False
             exe_wrap = None
         try:
             p = subprocess.Popen(exelist + ['--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -500,8 +494,9 @@ class Environment():
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
 
     def detect_static_linker(self, compiler):
-        if compiler.is_cross:
-            linker = self.cross_info.config['binaries']['ar']
+        machine_prop = self.get_machine_properties(compiler.is_cross)
+        if machine_prop:
+            linker = machine_prop['ar']
         else:
             evar = 'AR'
             if evar in os.environ:
@@ -613,6 +608,13 @@ class Environment():
                 if os.path.isfile(trial):
                     return trial
 
+    def get_machine_properties(self, is_cross):
+        if not self.cross_info:
+            return {}
+        if is_cross:
+            return self.cross_info['host_machine']
+        else:
+            return self.cross_info['target_machine']
 
 def get_args_from_envvars(lang):
     if lang == 'c':
@@ -647,10 +649,6 @@ class CrossBuildInfo():
             return
         if not 'host_machine' in self.config:
             raise coredata.MesonException('Cross info file must have either host or a target machine.')
-        if not 'properties' in self.config:
-            raise coredata.MesonException('Cross file is missing "properties".')
-        if not 'binaries' in self.config:
-            raise coredata.MesonException('Cross file is missing "binaries".')
 
     def ok_type(self, i):
         return isinstance(i, str) or isinstance(i, int) or isinstance(i, bool)
@@ -685,7 +683,7 @@ class CrossBuildInfo():
     def has_target(self):
         return 'target_machine' in self.config
 
-    # Wehn compiling a cross compiler we use the native compiler for everything.
+    # When compiling a cross compiler we use the native compiler for everything.
     # But not when cross compiling a cross compiler.
     def need_cross_compiler(self):
         return 'host_machine' in self.config


### PR DESCRIPTION
This is a Draft version may contain (and certainly does) bugs as was never tested on real. Test cases were not updated either, but before going any further I wanted to ask if it is a good/acceptable direction.

Breaks compatibility!

Main motivation:
I don't like the environment args to specify the toolchain as it is not an integrated part of the build system and it is also platform specific. I'd prefer a solution where the toolchain is given in a single file (like the crossfile) and no other scripts are required to configure the build system.
So it is a modification of the cross-file mechanism:

- Drop 'binaries' and 'properties' entries and move them under machine settings.
  Thus target/host may have different settings for compilers, linkers and their arguments. (Binaries was hard to interpret if it belongs to target or native(host) )
- Toolchain arguments are provided as external_args and external_linker_args
  through the coredata. The cross compiler language name gets a _CROSS postfix
  to differ the native and target compilers. Thus no big modification was required (unless some code removal) for detect languages.
- System property accepts the 'auto' keyword that will extract information from the build(host) machine Thus a toolchain can be provided through cross-file without the need of any platform specific environment settings. It allows to use the default cpu/system/etc infrastructure to limit the toolchain by explicitly specifying them for non-cross builds.

**EDIT**:
A sample non-cross toolchain:
```
[host_machine]
system = 'auto'
c = 'clang'
c_compile_args = '-DFLAGS_REQUIRED_FOR_ALL_COMPILATION'
cpp = 'clang++'
cpp_compile_args = '-DSOME_OTHE_MANDATORY_FLAGS'
```
Another cross-compile sample:
```
[host_machine]
system = 'auto'  # optionaly for host we could interpret the empty string as the auto

# used to build 'compiler'
c = 'clang'  # optional
c_compile_args = '-DFLAGS_REQUIRED_FOR_ALL_COMPILATION'
cpp = 'clang++'
cpp_compile_args = '-DSOME_OTHE_MANDATORY_FLAGS'

# it is allowed but not sure if it is really required
exe_wrapper = ''  

# anything that would correspond to the properties section but for the host machine
has_function_whatever = NO

[target_machine]
system = 'linux'
cpu_family = 'arm'
cpu = 'whatever'
endian = 'little'

#used to build target binaries
c = 'qnx_arm_gcc_compiler'
c_compile_arg='-enable_neon'

# the emulator or some pscp scripts..
exe_wrapper = 'qemu'

# anything that was under properties section
has_function_whatever = YES
```
