### PR TITLE
validate all options before generating build files

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -29,6 +29,7 @@ c_suffixes = ['c']
 clike_suffixes = c_suffixes + cpp_suffixes
 obj_suffixes = ['o', 'obj', 'res']
 lib_suffixes = ['a', 'lib', 'dll', 'dylib', 'so']
+possible_compiler_options = ['c_std', 'c_winlibs', 'cpp_eh', 'cpp_std', 'cpp_winlibs']
 
 def is_header(fname):
     if hasattr(fname, 'fname'):

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -189,6 +189,11 @@ class CoreData():
     def is_builtin_option(self, optname):
         return optname in self.builtin_options
 
+    def is_known_option(self, optname):
+        return optname in self.user_options \
+            or optname in self.builtin_options \
+            or optname in self.compiler_options
+
 def load(filename):
     obj = pickle.load(open(filename, 'rb'))
     if not isinstance(obj, CoreData):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -175,6 +175,28 @@ class Environment():
                 if type(oldval) != type(value):
                     self.coredata.user_options[name] = value
 
+    def assert_valid_options(self):
+        unknown_options = []
+        unused_options = []
+        for opt in self.cmd_line_options.projectoptions:
+            optname = opt.split('=', 1)[0]
+            if not self.coredata.is_known_option(optname):
+                if optname in possible_compiler_options:
+                    unused_options.append(optname)
+                else:
+                    unknown_options.append(optname)
+        for opt in unused_options:
+            mlog.log(mlog.bold('Warning:'), 'Unused option: %s' % opt)
+        if unknown_options:
+            for opt in unknown_options:
+                mlog.log(mlog.red('Error: unknown project option: %s' % opt))
+            if self.coredata.user_options:
+                mlog.log('Known project options:\n %s' % '\n '.join(self.coredata.user_options))
+            else:
+                mlog.log('Known project options:', mlog.bold('None'))
+            raise MesonException('Unknown project options used.')
+        return
+
     def detect_c_compiler(self, want_cross):
         evar = 'CC'
         if self.is_cross_build() and want_cross:

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -166,6 +166,7 @@ itself as required.'''
         mlog.log('Build machine cpu family:', mlog.bold(intr.builtin['build_machine'].cpu_family_method([], {})))
         mlog.log('Build machine cpu:', mlog.bold(intr.builtin['build_machine'].cpu_method([], {})))
         intr.run()
+        env.assert_valid_options()
         env.dump_coredata()
         g.generate(intr)
         g.run_postconf_scripts()

--- a/test cases/common/110 unused options/meson.build
+++ b/test cases/common/110 unused options/meson.build
@@ -1,0 +1,4 @@
+# This test case should work on all platforms.
+# However, it should print a warning when the compiler does
+# not support the cpp_eh option (like with gcc on Linux).
+project('p', 'cpp', default_options : ['cpp_eh=none'])

--- a/test cases/failing/28 unknown default option/meson.build
+++ b/test cases/failing/28 unknown default option/meson.build
@@ -1,0 +1,1 @@
+project('default options', 'c', default_options: ['other_opt=true'])

--- a/test cases/failing/28 unknown default option/meson_options.txt
+++ b/test cases/failing/28 unknown default option/meson_options.txt
@@ -1,0 +1,1 @@
+option('some_opt', type : 'boolean', value : false)

--- a/test cases/failing/29 unknown option argument/meson.build
+++ b/test cases/failing/29 unknown option argument/meson.build
@@ -1,0 +1,1 @@
+project('options', 'c')

--- a/test cases/failing/29 unknown option argument/meson_options.txt
+++ b/test cases/failing/29 unknown option argument/meson_options.txt
@@ -1,0 +1,2 @@
+option('testoption', type : 'string', value : 'optval', description : 'An option to do something')
+option('other_one', type : 'boolean', value : false)

--- a/test cases/failing/29 unknown option argument/test_args.txt
+++ b/test cases/failing/29 unknown option argument/test_args.txt
@@ -1,0 +1,3 @@
+# This file is not read by meson itself, but by the test framework.
+# It is not possible to pass arguments to meson from a file.
+['-D', 'testoption=something', '-D', 'unknown_option=true']


### PR DESCRIPTION
This fails the build when passing unknown options via command line or as `default_options` in meson.build.

It prints all unknown project options that were used together with a list of all known options, including those from subprojects.

It also prints a warning for all options that are not in use for the current build, but might be on another platform (currently only compiler options that might exist on other platforms like when using `cpp_eh` with gcc on Linux).