### PR TITLE
fix eval_custom_target_command() to use absolute paths for output files

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -381,7 +381,11 @@ class Backend():
         return exe_arr
 
     def eval_custom_target_command(self, target, absolute_paths=False):
-        ofilenames = [os.path.join(self.get_target_dir(target), i) for i in target.output]
+        if not absolute_paths:
+            ofilenames = [os.path.join(self.get_target_dir(target), i) for i in target.output]
+        else:
+            ofilenames = [os.path.join(self.environment.get_build_dir(), self.get_target_dir(target), i) \
+                          for i in target.output]
         srcs = []
         outdir = self.get_target_dir(target)
         # Many external programs fail on empty arguments.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -306,10 +306,8 @@ class Vs2010Backend(backends.Backend):
         (srcs, ofilenames, cmd) = self.eval_custom_target_command(target, True)
         cmd_templ = '''"%s" '''*len(cmd)
         ET.SubElement(customstep, 'Command').text = cmd_templ % tuple(cmd)
-        ET.SubElement(customstep, 'Outputs').text = ';'.join([os.path.join(self.environment.get_build_dir(), i)\
-                                                              for i in ofilenames])
-        ET.SubElement(customstep, 'Inputs').text = ';'.join([os.path.join(self.environment.get_build_dir(), i) \
-                                                             for i in srcs])
+        ET.SubElement(customstep, 'Outputs').text = ';'.join(ofilenames)
+        ET.SubElement(customstep, 'Inputs').text = ';'.join(srcs)
         ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.targets')
         tree = ET.ElementTree(root)
         tree.write(ofname, encoding='utf-8', xml_declaration=True)


### PR DESCRIPTION
This makes CustomTarget's command use absolute paths for output files if the keyword arg `absolute_paths` is `True`.

Relative paths in VS projects are evaluated from the project directory, whereas meson treats all paths relative from the build directory. To make these work nicely together, it is better to use absolute paths like it is already done for input files.