### PR TITLE
vs2010: fix dependencies of CustomTarget

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -123,7 +123,7 @@ class Vs2010Backend(backends.Backend):
         all_deps = {}
         target = self.build.targets[p[0]]
         if isinstance(target, build.CustomTarget):
-            for d in target.dependencies:
+            for d in target.get_target_dependencies():
                 all_deps[d.get_id()] = True
             return all_deps
         if isinstance(target, build.RunTarget):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -806,6 +806,16 @@ class CustomTarget:
     def get_id(self):
         return self.name + self.type_suffix()
 
+    def get_target_dependencies(self):
+        deps = self.dependencies[:]
+        deps += self.extra_depends
+        for c in self.sources:
+            if hasattr(c, 'held_object'):
+                c = c.held_object
+            if isinstance(c, BuildTarget) or isinstance(c, CustomTarget):
+                deps.append(c)
+        return deps
+
     def process_kwargs(self, kwargs):
         self.sources = kwargs.get('input', [])
         if not isinstance(self.sources, list):


### PR DESCRIPTION
Previously, the vs2010 backend did only consider the `dependencies` attribute of `CustomTarget` to set up the internal project dependencies.

However, there might also be dependencies on `input` files (that are outputs of other targets) and on additional `depends` targets. These are now considered as well.