### PR TITLE
Added new base options

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -254,7 +254,7 @@ class Backend():
         commands += self.environment.coredata.external_args[compiler.get_language()]
         commands += target.get_extra_args(compiler.get_language())
         commands += compiler.get_buildtype_args(self.environment.coredata.get_builtin_option('buildtype'))
-        if self.environment.coredata.get_builtin_option('coverage'):
+        if self.environment.coredata.base_options.get('b_coverage', False):
             commands += compiler.get_coverage_args()
         if self.environment.coredata.get_builtin_option('werror'):
             commands += compiler.get_werror_args()

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -203,8 +203,11 @@ class Backend():
                 if c.can_compile(s):
                     return cpp
         for c in self.build.compilers:
-            if c.get_language() != 'vala':
-                return c
+            if c.get_language() == 'vala':
+                continue
+            for s in src:
+                if c.can_compile(s):
+                    return c
         raise RuntimeError('Unreachable code')
 
     def determine_ext_objs(self, extobj, proj_dir_to_build_root=''):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -247,7 +247,7 @@ int dummy;
         self.generate_custom_generator_rules(target, outfile)
         outname = self.get_target_filename(target)
         obj_list = []
-        use_pch = self.environment.coredata.get_builtin_option('use_pch')
+        use_pch = self.environment.coredata.base_options.get('b_pch', False)
         is_unity = self.environment.coredata.get_builtin_option('unity')
         if use_pch and target.has_pch():
             pch_objects = self.generate_pch(target, outfile)
@@ -1487,7 +1487,7 @@ rule FORTRAN_DEP_HACK
         rel_obj = os.path.join(self.get_target_private_dir(target), obj_basename)
         rel_obj += '.' + self.environment.get_object_suffix()
         dep_file = compiler.depfile_for_object(rel_obj)
-        if self.environment.coredata.get_builtin_option('use_pch'):
+        if self.environment.coredata.base_options.get('b_pch', False):
             pchlist = target.get_pch(compiler.language)
         else:
             pchlist = []
@@ -1506,7 +1506,7 @@ rule FORTRAN_DEP_HACK
                     custom_target_include_dirs.append(idir)
         for i in custom_target_include_dirs:
             commands+= compiler.get_include_args(i, False)
-        if self.environment.coredata.get_builtin_option('use_pch'):
+        if self.environment.coredata.base_options.get('b_pch', False):
             commands += self.get_pch_include_args(compiler, target)
         crstr = ''
         if target.is_cross:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -182,7 +182,7 @@ int dummy;
         self.generate_tests(outfile)
         outfile.write('# Install rules\n\n')
         self.generate_install(outfile)
-        if self.environment.coredata.get_builtin_option('coverage'):
+        if self.environment.coredata.base_options.get('b_coverage', False):
             outfile.write('# Coverage rules\n\n')
             self.generate_coverage_rules(outfile)
         outfile.write('# Suffix\n\n')
@@ -1431,7 +1431,8 @@ rule FORTRAN_DEP_HACK
         commands = []
         # The first thing is implicit include directories: source, build and private.
         commands += compiler.get_include_args(self.get_target_private_dir(target), False)
-        commands += compilers.get_base_compile_args(self.environment.coredata.base_options)
+        commands += compilers.get_base_compile_args(self.environment.coredata.base_options,
+                                                    compiler)
         curdir = target.get_subdir()
         tmppath = os.path.normpath(os.path.join(self.build_to_src, curdir))
         commands += compiler.get_include_args(tmppath, False)
@@ -1640,7 +1641,8 @@ rule FORTRAN_DEP_HACK
         commands = []
         commands += linker.get_linker_always_args()
         if not isinstance(target, build.StaticLibrary):
-            commands += compilers.get_base_link_args(self.environment.coredata.base_options)
+            commands += compilers.get_base_link_args(self.environment.coredata.base_options,
+                                                     linker)
         commands += linker.get_buildtype_linker_args(self.environment.coredata.get_builtin_option('buildtype'))
         commands += linker.get_option_link_args(self.environment.coredata.compiler_options)
         if not(isinstance(target, build.StaticLibrary)):
@@ -1682,7 +1684,7 @@ rule FORTRAN_DEP_HACK
                         commands += dep.get_link_args()
         commands += linker.build_rpath_args(self.environment.get_build_dir(),\
                                             self.determine_rpath_dirs(target), target.install_rpath)
-        if self.environment.coredata.get_builtin_option('coverage'):
+        if self.environment.coredata.base_options.get('b_coverage', False):
             commands += linker.get_coverage_link_args()
         custom_target_libraries = self.get_custom_target_provided_libraries(target)
         commands += extra_args
@@ -1797,7 +1799,7 @@ rule FORTRAN_DEP_HACK
         elem = NinjaBuildElement(self.all_outputs, 'clean', 'CUSTOM_COMMAND', 'PHONY')
         elem.add_item('COMMAND', [ninja_command, '-t', 'clean'])
         elem.add_item('description', 'Cleaning')
-        if self.environment.coredata.get_builtin_option('coverage'):
+        if self.environment.coredata.base_options.get('b_coverage', False):
             self.generate_gcov_clean(outfile)
             elem.add_dep('clean-gcda')
             elem.add_dep('clean-gcno')

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -17,6 +17,7 @@ from .. import environment, mesonlib
 from .. import build
 from .. import mlog
 from .. import dependencies
+from .. import compilers
 from ..mesonlib import File
 from .backends import InstallData
 from ..build import InvalidArguments
@@ -1430,6 +1431,7 @@ rule FORTRAN_DEP_HACK
         commands = []
         # The first thing is implicit include directories: source, build and private.
         commands += compiler.get_include_args(self.get_target_private_dir(target), False)
+        commands += compilers.get_base_compile_args(self.environment.coredata.base_options)
         curdir = target.get_subdir()
         tmppath = os.path.normpath(os.path.join(self.build_to_src, curdir))
         commands += compiler.get_include_args(tmppath, False)
@@ -1637,6 +1639,8 @@ rule FORTRAN_DEP_HACK
         abspath = os.path.join(self.environment.get_build_dir(), target.subdir)
         commands = []
         commands += linker.get_linker_always_args()
+        if not isinstance(target, build.StaticLibrary):
+            commands += compilers.get_base_link_args(self.environment.coredata.base_options)
         commands += linker.get_buildtype_linker_args(self.environment.coredata.get_builtin_option('buildtype'))
         commands += linker.get_option_link_args(self.environment.coredata.compiler_options)
         if not(isinstance(target, build.StaticLibrary)):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -294,20 +294,20 @@ int dummy;
                                                                          header_deps=header_deps))
         src_list = []
         for src in gen_src_deps:
-                src_list.append(src)
-                if is_unity:
-                    unity_src.append(os.path.join(self.environment.get_build_dir(), src))
+            src_list.append(src)
+            if is_unity:
+                unity_src.append(os.path.join(self.environment.get_build_dir(), src))
+                header_deps.append(src)
+            else:
+                # Generated targets are ordered deps because the must exist
+                # before the sources compiling them are used. After the first
+                # compile we get precise dependency info from dep files.
+                # This should work in all cases. If it does not, then just
+                # move them from orderdeps to proper deps.
+                if self.environment.is_header(src):
                     header_deps.append(src)
                 else:
-                    # Generated targets are ordered deps because the must exist
-                    # before the sources compiling them are used. After the first
-                    # compile we get precise dependency info from dep files.
-                    # This should work in all cases. If it does not, then just
-                    # move them from orderdeps to proper deps.
-                    if self.environment.is_header(src):
-                        header_deps.append(src)
-                    else:
-                        obj_list.append(self.generate_single_compile(target, outfile, src, True, [], header_deps))
+                    obj_list.append(self.generate_single_compile(target, outfile, src, True, [], header_deps))
         for src in target.get_sources():
             if src.endswith('.vala'):
                 continue

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -113,7 +113,9 @@ msvc_winlibs = ['kernel32.lib', 'user32.lib', 'gdi32.lib',
                 'uuid.lib', 'comdlg32.lib', 'advapi32.lib']
 
 
-base_options = {'b_lto': coredata.UserBooleanOption('b_lto', 'Use link time optimization', False),
+base_options = {
+                'b_pch': coredata.UserBooleanOption('b_lto', 'Use precompiled headers', False),
+                'b_lto': coredata.UserBooleanOption('b_lto', 'Use link time optimization', False),
                 'b_sanitize': coredata.UserComboOption('b_sanitize',
                                                        'Code sanitizer to use',
                                                        ['none', 'address', 'thread', 'undefined', 'memory'],
@@ -1190,6 +1192,7 @@ class VisualStudioCCompiler(CCompiler):
         self.warn_args = {'1': ['/W2'],
                           '2': ['/W3'],
                           '3': ['/w4']}
+        self.base_options = ['b_pch'] # FIXME add lto, pgo and the like
 
     def get_always_args(self):
         return self.always_args
@@ -1312,6 +1315,7 @@ class VisualStudioCPPCompiler(VisualStudioCCompiler):
         VisualStudioCCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
         self.language = 'cpp'
         self.default_suffix = 'cpp'
+        self.base_options = ['b_pch'] # FIXME add lto, pgo and the like
 
     def can_compile(self, filename):
         suffix = filename.split('.')[-1]
@@ -1388,7 +1392,7 @@ class GnuCCompiler(CCompiler):
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch'],
                           '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch']}
-        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize']
         if self.gcc_type != GCC_OSX:
             self.base_options.append('b_lundef')
 
@@ -1453,7 +1457,7 @@ class GnuObjCCompiler(ObjCCompiler):
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch'],
                           '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch']}
-        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize']
         if self.gcc_type != GCC_OSX:
             self.base_options.append('b_lundef')
 
@@ -1481,7 +1485,7 @@ class GnuObjCPPCompiler(ObjCPPCompiler):
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor']}
-        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize']
         if self.gcc_type != GCC_OSX:
             self.base_options.append('b_lundef')
 
@@ -1501,7 +1505,7 @@ class ClangObjCCompiler(GnuObjCCompiler):
     def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):
         super().__init__(exelist, version, is_cross, exe_wrapper)
         self.id = 'clang'
-        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize']
         self.clang_type = cltype
         if self.clang_type != CLANG_OSX:
             self.base_options.append('b_lundef')
@@ -1511,7 +1515,7 @@ class ClangObjCPPCompiler(GnuObjCPPCompiler):
         super().__init__(exelist, version, is_cross, exe_wrapper)
         self.id = 'clang'
         self.clang_type = cltype
-        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize']
         if self.clang_type != CLANG_OSX:
             self.base_options.append('b_lundef')
 
@@ -1523,7 +1527,7 @@ class ClangCCompiler(CCompiler):
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch'],
                           '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch']}
-        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize']
         if self.clang_type != CLANG_OSX:
             self.base_options.append('b_lundef')
 
@@ -1571,7 +1575,7 @@ class GnuCPPCompiler(CPPCompiler):
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '3': ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor']}
-        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize']
         if self.gcc_type != GCC_OSX:
             self.base_options.append('b_lundef')
 
@@ -1621,7 +1625,7 @@ class ClangCPPCompiler(CPPCompiler):
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '3': ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor']}
         self.clang_type = cltype
-        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize']
         if self.clang_type != CLANG_OSX:
             self.base_options.append('b_lundef')
 

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -122,6 +122,9 @@ base_options = {'b_lto': coredata.UserBooleanOption('b_lto', 'Use link time opti
                 'b_pgo': coredata.UserComboOption('b_pgo', 'Use profile guide optimization',
                                                   ['off', 'generate', 'use'],
                                                   'off'),
+                'b_coverage': coredata.UserBooleanOption('b_coverage',
+                                                         'Enable coverage tracking.',
+                                                         True),
                 }
 
 def sanitizer_compile_args(value):
@@ -138,7 +141,7 @@ def sanitizer_link_args(value):
     args = ['-fsanitize=' + value]
     return args
 
-def get_base_compile_args(options):
+def get_base_compile_args(options, compiler):
     args = []
     # FIXME, gcc/clang specific.
     try:
@@ -158,9 +161,14 @@ def get_base_compile_args(options):
             args.append('-fprofile-use')
     except KeyError:
         pass
+    try:
+        if options['b_coverage'].value:
+            args += compiler.get_coverage_args()
+    except KeyError:
+        pass
     return args
 
-def get_base_link_args(options):
+def get_base_link_args(options, linker):
     args = []
     # FIXME, gcc/clang specific.
     try:
@@ -183,6 +191,11 @@ def get_base_link_args(options):
     try:
         if options['b_lundef'].value:
             args.append('-Wl,--no-undefined')
+    except KeyError:
+        pass
+    try:
+        if options['b_coverage'].value:
+            args += linker.get_coverage_link_args()
     except KeyError:
         pass
     return args

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1348,6 +1348,11 @@ GCC_STANDARD = 0
 GCC_OSX = 1
 GCC_MINGW = 2
 
+CLANG_STANDARD = 0
+CLANG_OSX = 1
+CLANG_WIN = 2
+# Possibly clang-cl?
+
 def get_gcc_soname_args(gcc_type, shlib_name, path, soversion):
     if soversion is None:
         sostr = ''
@@ -1480,22 +1485,34 @@ class GnuObjCPPCompiler(ObjCPPCompiler):
         return get_gcc_soname_args(self.gcc_type, shlib_name, path, soversion)
 
 class ClangObjCCompiler(GnuObjCCompiler):
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None):
+    def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):
         super().__init__(exelist, version, is_cross, exe_wrapper)
         self.id = 'clang'
+        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        self.clang_type = cltype
+        if self.clang_type != CLANG_OSX:
+            self.base_options.append('b_lundef')
 
 class ClangObjCPPCompiler(GnuObjCPPCompiler):
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None):
+    def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):
         super().__init__(exelist, version, is_cross, exe_wrapper)
         self.id = 'clang'
+        self.clang_type = cltype
+        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        if self.clang_type != CLANG_OSX:
+            self.base_options.append('b_lundef')
 
 class ClangCCompiler(CCompiler):
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None):
+    def __init__(self, exelist, version, clang_type, is_cross, exe_wrapper=None):
         CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
         self.id = 'clang'
+        self.clang_type = clang_type
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch'],
                           '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch']}
+        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        if self.clang_type != CLANG_OSX:
+            self.base_options.append('b_lundef')
 
     def get_buildtype_args(self, buildtype):
         return gnulike_buildtype_args[buildtype]
@@ -1584,12 +1601,16 @@ class GnuCPPCompiler(CPPCompiler):
         return []
 
 class ClangCPPCompiler(CPPCompiler):
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None):
+    def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):
         CPPCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
         self.id = 'clang'
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '3': ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor']}
+        self.clang_type = cltype
+        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        if self.clang_type != CLANG_OSX:
+            self.base_options.append('b_lundef')
 
     def get_buildtype_args(self, buildtype):
         return gnulike_buildtype_args[buildtype]

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -121,7 +121,7 @@ base_options = {'b_lto': coredata.UserBooleanOption('b_lto', 'Use link time opti
                 'b_lundef': coredata.UserBooleanOption('b_lundef', 'Use -Wl,--no-undefined when linking', True),
                 'b_pgo': coredata.UserComboOption('b_pgo', 'Use profile guide optimization',
                                                   ['off', 'generate', 'use'],
-                                                  'off')
+                                                  'off'),
                 }
 
 def sanitizer_compile_args(value):

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1370,7 +1370,9 @@ class GnuCCompiler(CCompiler):
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch'],
                           '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch']}
-        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize', 'b_lundef']
+        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        if self.gcc_type != GCC_OSX:
+            self.base_options.append('b_lundef')
 
     def get_pic_args(self):
         if self.gcc_type == GCC_MINGW:
@@ -1433,7 +1435,9 @@ class GnuObjCCompiler(ObjCCompiler):
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch'],
                           '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch']}
-        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize', 'b_lundef']
+        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        if self.gcc_type != GCC_OSX:
+            self.base_options.append('b_lundef')
 
     def get_buildtype_args(self, buildtype):
         return gnulike_buildtype_args[buildtype]
@@ -1459,7 +1463,9 @@ class GnuObjCPPCompiler(ObjCPPCompiler):
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor']}
-        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize', 'b_lundef']
+        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        if self.gcc_type != GCC_OSX:
+            self.base_options.append('b_lundef')
 
     def get_buildtype_args(self, buildtype):
         return gnulike_buildtype_args[buildtype]
@@ -1535,7 +1541,9 @@ class GnuCPPCompiler(CPPCompiler):
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '3': ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor']}
-        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize', 'b_lundef']
+        self.base_options = ['b_lto', 'b_pgo', 'b_sanitize']
+        if self.gcc_type != GCC_OSX:
+            self.base_options.append('b_lundef')
 
     def get_always_args(self):
         return ['-pipe']

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -170,7 +170,6 @@ class CoreData():
         self.builtin_options['strip'] = UserBooleanOption('strip', 'Strip on install', options.strip)
         self.builtin_options['use_pch'] = UserBooleanOption('use_pch', 'Use precompiled headers', options.use_pch)
         self.builtin_options['unity'] = UserBooleanOption('unity', 'Unity build', options.unity)
-        self.builtin_options['coverage'] = UserBooleanOption('coverage', 'Enable coverage', options.coverage)
         self.builtin_options['warning_level'] = UserComboOption('warning_level', 'Warning level', warning_levels, options.warning_level)
         self.builtin_options['werror'] = UserBooleanOption('werror', 'Warnings are errors', options.werror)
         self.builtin_options['layout'] = UserComboOption('layout', 'Build dir layout', layouts, options.layout)

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -24,7 +24,6 @@ libtypelist = ['shared', 'static']
 builtin_options = {'buildtype': True,
                    'strip': True,
                    'coverage': True,
-                   'pch': True,
                    'unity': True,
                    'prefix': True,
                    'libdir' : True,
@@ -168,7 +167,6 @@ class CoreData():
         self.builtin_options['backend'] = UserStringOption('backend', 'Backend to use', options.backend)
         self.builtin_options['buildtype'] = UserComboOption('buildtype', 'Build type', build_types, options.buildtype)
         self.builtin_options['strip'] = UserBooleanOption('strip', 'Strip on install', options.strip)
-        self.builtin_options['use_pch'] = UserBooleanOption('use_pch', 'Use precompiled headers', options.use_pch)
         self.builtin_options['unity'] = UserBooleanOption('unity', 'Unity build', options.unity)
         self.builtin_options['warning_level'] = UserComboOption('warning_level', 'Warning level', warning_levels, options.warning_level)
         self.builtin_options['werror'] = UserBooleanOption('werror', 'Warnings are errors', options.werror)

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -144,6 +144,7 @@ class CoreData():
         self.init_builtins(options)
         self.user_options = {}
         self.compiler_options = {}
+        self.base_options = {}
         self.external_args = {} # These are set from "the outside" with e.g. mesonconf
         self.external_link_args = {}
         if options.cross_file is not None:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -222,7 +222,11 @@ class Environment():
                     gtype = GCC_STANDARD
                 return GnuCCompiler(ccache + [compiler], version, gtype, is_cross, exe_wrap)
             if 'clang' in out:
-                return ClangCCompiler(ccache + [compiler], version, is_cross, exe_wrap)
+                if 'Apple' in out:
+                    cltype = CLANG_OSX
+                else:
+                    cltype = CLANG_STANDARD
+                return ClangCCompiler(ccache + [compiler], version, cltype, is_cross, exe_wrap)
             if 'Microsoft' in out or 'Microsoft' in err:
                 # Visual Studio prints version number to stderr but
                 # everything else to stdout. Why? Lord only knows.
@@ -346,7 +350,11 @@ class Environment():
                     gtype = GCC_STANDARD
                 return GnuCPPCompiler(ccache + [compiler], version, gtype, is_cross, exe_wrap)
             if 'clang' in out:
-                return ClangCPPCompiler(ccache + [compiler], version, is_cross, exe_wrap)
+                if 'Apple' in out:
+                    cltype = CLANG_OSX
+                else:
+                    cltype = CLANG_STANDARD
+                return ClangCPPCompiler(ccache + [compiler], version, cltype, is_cross, exe_wrap)
             if 'Microsoft' in out or 'Microsoft' in err:
                 version = re.search(Environment.version_regex, err).group()
                 return VisualStudioCPPCompiler([compiler], version, is_cross, exe_wrap)
@@ -377,7 +385,7 @@ class Environment():
             'Free Software Foundation' in out:
             return GnuObjCCompiler(exelist, version, is_cross, exe_wrap)
         if out.startswith('Apple LLVM'):
-            return ClangObjCCompiler(exelist, version, is_cross, exe_wrap)
+            return ClangObjCCompiler(exelist, version, CLANG_OSX, is_cross, exe_wrap)
         if 'apple' in out and 'Free Software Foundation' in out:
             return GnuObjCCompiler(exelist, version, is_cross, exe_wrap)
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
@@ -407,7 +415,7 @@ class Environment():
             'Free Software Foundation' in out:
             return GnuObjCPPCompiler(exelist, version, is_cross, exe_wrap)
         if out.startswith('Apple LLVM'):
-            return ClangObjCPPCompiler(exelist, version, is_cross, exe_wrap)
+            return ClangObjCPPCompiler(exelist, version, CLANG_OSX, is_cross, exe_wrap)
         if 'apple' in out and 'Free Software Foundation' in out:
             return GnuObjCPPCompiler(exelist, version, is_cross, exe_wrap)
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1528,10 +1528,16 @@ class Interpreter():
         return success
 
     def add_base_options(self, compiler):
+        proj_opt = self.environment.cmd_line_options.projectoptions
         for optname in compiler.base_options:
             if optname in self.coredata.base_options:
                 continue
-            self.coredata.base_options[optname] = compilers.base_options[optname]
+            oobj = compilers.base_options[optname]
+            for po in proj_opt:
+                if po.startswith(optname + '='):
+                    oobj.set_value(po.split('=', 1)[1])
+                    break
+            self.coredata.base_options[optname] = oobj
 
     def func_find_program(self, node, args, kwargs):
         self.validate_arguments(args, 1, [str])

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -19,6 +19,7 @@ from . import dependencies
 from . import mlog
 from . import build
 from . import optinterpreter
+from . import compilers
 from .wrap import wrap
 from . import mesonlib
 
@@ -1523,7 +1524,14 @@ class Interpreter():
                 self.build.add_cross_compiler(cross_comp)
             if self.environment.is_cross_build() and not need_cross_compiler:
                 self.build.add_cross_compiler(comp)
+            self.add_base_options(comp)
         return success
+
+    def add_base_options(self, compiler):
+        for optname in compiler.base_options:
+            if optname in self.coredata.base_options:
+                continue
+            self.coredata.base_options[optname] = compilers.base_options[optname]
 
     def func_find_program(self, node, args, kwargs):
         self.validate_arguments(args, 1, [str])

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -128,7 +128,6 @@ class Conf:
         carr.append(['warning_level', 'Warning level', self.coredata.get_builtin_option('warning_level'), warning_levels])
         carr.append(['werror', 'Treat warnings as errors', self.coredata.get_builtin_option('werror'), booleans])
         carr.append(['strip', 'Strip on install', self.coredata.get_builtin_option('strip'), booleans])
-        carr.append(['use_pch', 'Precompiled headers', self.coredata.get_builtin_option('use_pch'), booleans])
         carr.append(['unity', 'Unity build', self.coredata.get_builtin_option('unity'), booleans])
         carr.append(['default_library', 'Default library type', self.coredata.get_builtin_option('default_library'), libtypelist])
         self.print_aligned(carr)

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -94,6 +94,9 @@ class Conf:
             elif k in self.coredata.compiler_options:
                 tgt = self.coredata.compiler_options[k]
                 tgt.set_value(v)
+            elif k in self.coredata.base_options:
+                tgt = self.coredata.base_options[k]
+                tgt.set_value(v)
             elif k.endswith('linkargs'):
                 lang = k[:-8]
                 if not lang in self.coredata.external_link_args:
@@ -130,6 +133,17 @@ class Conf:
         carr.append(['unity', 'Unity build', self.coredata.get_builtin_option('unity'), booleans])
         carr.append(['default_library', 'Default library type', self.coredata.get_builtin_option('default_library'), libtypelist])
         self.print_aligned(carr)
+        print('')
+        print('Base options:')
+        okeys = sorted(self.coredata.base_options.keys())
+        if len(okeys) == 0:
+            print('  No base options\n')
+        else:
+            coarr = []
+            for k in okeys:
+                o = self.coredata.base_options[k]
+                coarr.append([k, o.description, o.value, ''])
+            self.print_aligned(coarr)
         print('')
         print('Compiler arguments:')
         for (lang, args) in self.coredata.external_args.items():

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -128,7 +128,6 @@ class Conf:
         carr.append(['warning_level', 'Warning level', self.coredata.get_builtin_option('warning_level'), warning_levels])
         carr.append(['werror', 'Treat warnings as errors', self.coredata.get_builtin_option('werror'), booleans])
         carr.append(['strip', 'Strip on install', self.coredata.get_builtin_option('strip'), booleans])
-        carr.append(['coverage', 'Coverage report', self.coredata.get_builtin_option('coverage'), booleans])
         carr.append(['use_pch', 'Precompiled headers', self.coredata.get_builtin_option('use_pch'), booleans])
         carr.append(['unity', 'Unity build', self.coredata.get_builtin_option('unity'), booleans])
         carr.append(['default_library', 'Default library type', self.coredata.get_builtin_option('default_library'), libtypelist])

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -55,8 +55,6 @@ parser.add_argument('--buildtype', default='debug', choices=build_types, dest='b
                     help='build type go use (default: %(default)s)')
 parser.add_argument('--strip', action='store_true', dest='strip', default=False,\
                     help='strip targets on install (default: %(default)s)')
-parser.add_argument('--enable-gcov', action='store_true', dest='coverage', default=False,\
-                    help='measure test coverage')
 parser.add_argument('--disable-pch', action='store_false', dest='use_pch', default=True,\
                     help='do not use precompiled headers')
 parser.add_argument('--unity', action='store_true', dest='unity', default=False,\

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -55,8 +55,6 @@ parser.add_argument('--buildtype', default='debug', choices=build_types, dest='b
                     help='build type go use (default: %(default)s)')
 parser.add_argument('--strip', action='store_true', dest='strip', default=False,\
                     help='strip targets on install (default: %(default)s)')
-parser.add_argument('--disable-pch', action='store_false', dest='use_pch', default=True,\
-                    help='do not use precompiled headers')
 parser.add_argument('--unity', action='store_true', dest='unity', default=False,\
                     help='unity build')
 parser.add_argument('--werror', action='store_true', dest='werror', default=False,\

--- a/mesonbuild/mgui.py
+++ b/mesonbuild/mgui.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2013-2015 The Meson development team
+# Copyright 2013-2016 The Meson development team
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -249,10 +249,6 @@ class OptionForm:
         strip.setChecked(self.coredata.get_builtin_option('strip'))
         strip.stateChanged.connect(self.strip_changed)
         self.form.addRow('Strip on install', strip)
-        coverage = QCheckBox("")
-        coverage.setChecked(self.coredata.get_builtin_option('coverage'))
-        coverage.stateChanged.connect(self.coverage_changed)
-        self.form.addRow('Enable coverage', coverage)
         pch = QCheckBox("")
         pch.setChecked(self.coredata.get_builtin_option('use_pch'))
         pch.stateChanged.connect(self.pch_changed)
@@ -316,13 +312,6 @@ class OptionForm:
         else:
             ns = True
         self.coredata.strip = ns
-
-    def coverage_changed(self, newState):
-        if newState == 0:
-            ns = False
-        else:
-            ns = True
-        self.coredata.coverage = ns
 
     def pch_changed(self, newState):
         if newState == 0:

--- a/mesonbuild/mgui.py
+++ b/mesonbuild/mgui.py
@@ -249,10 +249,6 @@ class OptionForm:
         strip.setChecked(self.coredata.get_builtin_option('strip'))
         strip.stateChanged.connect(self.strip_changed)
         self.form.addRow('Strip on install', strip)
-        pch = QCheckBox("")
-        pch.setChecked(self.coredata.get_builtin_option('use_pch'))
-        pch.stateChanged.connect(self.pch_changed)
-        self.form.addRow('Enable pch', pch)
         unity = QCheckBox("")
         unity.setChecked(self.coredata.get_builtin_option('unity'))
         unity.stateChanged.connect(self.unity_changed)
@@ -312,13 +308,6 @@ class OptionForm:
         else:
             ns = True
         self.coredata.strip = ns
-
-    def pch_changed(self, newState):
-        if newState == 0:
-            ns = False
-        else:
-            ns = True
-        self.coredata.use_pch = ns
 
     def unity_changed(self, newState):
         if newState == 0:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -89,28 +89,29 @@ def list_target_files(target_name, coredata, builddata):
 def list_buildoptions(coredata, builddata):
     buildtype= {'choices': ['plain', 'debug', 'debugoptimized', 'release'],
                 'type' : 'combo',
-                'value' : coredata.buildtype,
+                'value' : coredata.builtin_options['buildtype'].value,
                 'description' : 'Build type',
                 'name' : 'type'}
-    strip = {'value' : coredata.strip,
+    strip = {'value' : coredata.builtin_options['strip'].value,
              'type' : 'boolean',
              'description' : 'Strip on install',
              'name' : 'strip'}
-    coverage = {'value': coredata.coverage,
+    coverage = {'value': coredata.builtin_options['coverage'].value,
                 'type' : 'boolean',
                 'description' : 'Enable coverage',
                 'name' : 'coverage'}
-    pch = {'value' : coredata.use_pch,
+    pch = {'value' : coredata.builtin_options['use_pch'].value,
            'type' : 'boolean',
            'description' : 'Use precompiled headers',
            'name' : 'pch'}
-    unity = {'value' : coredata.unity,
+    unity = {'value' : coredata.builtin_options['unity'].value,
              'type' : 'boolean',
              'description' : 'Unity build',
              'name' : 'unity'}
     optlist = [buildtype, strip, coverage, pch, unity]
     add_keys(optlist, coredata.user_options)
     add_keys(optlist, coredata.compiler_options)
+    add_keys(optlist, coredata.base_options)
     print(json.dumps(optlist))
 
 def add_keys(optlist, options):
@@ -121,14 +122,14 @@ def add_keys(optlist, options):
         optdict = {}
         optdict['name'] = key
         optdict['value'] = opt.value
-        if isinstance(opt, mesonlib.UserStringOption):
+        if isinstance(opt, coredata.UserStringOption):
             typestr = 'string'
-        elif isinstance(opt, mesonlib.UserBooleanOption):
+        elif isinstance(opt, coredata.UserBooleanOption):
             typestr = 'boolean'
-        elif isinstance(opt, mesonlib.UserComboOption):
+        elif isinstance(opt, coredata.UserComboOption):
             optdict['choices'] = opt.choices
             typestr = 'combo'
-        elif isinstance(opt, mesonlib.UserStringArrayOption):
+        elif isinstance(opt, coredata.UserStringArrayOption):
             typestr = 'stringarray'
         else:
             raise RuntimeError("Unknown option type")

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -96,15 +96,11 @@ def list_buildoptions(coredata, builddata):
              'type' : 'boolean',
              'description' : 'Strip on install',
              'name' : 'strip'}
-    pch = {'value' : coredata.builtin_options['use_pch'].value,
-           'type' : 'boolean',
-           'description' : 'Use precompiled headers',
-           'name' : 'pch'}
     unity = {'value' : coredata.builtin_options['unity'].value,
              'type' : 'boolean',
              'description' : 'Unity build',
              'name' : 'unity'}
-    optlist = [buildtype, strip, pch, unity]
+    optlist = [buildtype, strip, unity]
     add_keys(optlist, coredata.user_options)
     add_keys(optlist, coredata.compiler_options)
     add_keys(optlist, coredata.base_options)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -96,10 +96,6 @@ def list_buildoptions(coredata, builddata):
              'type' : 'boolean',
              'description' : 'Strip on install',
              'name' : 'strip'}
-    coverage = {'value': coredata.builtin_options['coverage'].value,
-                'type' : 'boolean',
-                'description' : 'Enable coverage',
-                'name' : 'coverage'}
     pch = {'value' : coredata.builtin_options['use_pch'].value,
            'type' : 'boolean',
            'description' : 'Use precompiled headers',
@@ -108,7 +104,7 @@ def list_buildoptions(coredata, builddata):
              'type' : 'boolean',
              'description' : 'Unity build',
              'name' : 'unity'}
-    optlist = [buildtype, strip, coverage, pch, unity]
+    optlist = [buildtype, strip, pch, unity]
     add_keys(optlist, coredata.user_options)
     add_keys(optlist, coredata.compiler_options)
     add_keys(optlist, coredata.base_options)

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from . import mparser
-from . import coredata, mesonlib
+from . import coredata
 import os, re
 
 forbidden_option_names = coredata.builtin_options
@@ -24,13 +24,16 @@ forbidden_prefixes = {'c_': True,
                       'objc_': True,
                       'objcpp_': True,
                       'vala_': True,
-                      'csharp_': True
+                      'csharp_': True,
+                      'swift_': True,
+                      'b_': True,
                       }
 
 def is_invalid_name(name):
     if name in forbidden_option_names:
         return True
-    if name in forbidden_prefixes:
+    pref = name.split('_')[0] + '_'
+    if pref in forbidden_prefixes:
         return True
     return False
 


### PR DESCRIPTION
The point of this is to create a new type of option. This option can come from any of a number of languages/compilers and should be used for all languages that support it. The simplest example is `-fsanitize=address` which should be enablable with a single option rather than one for C, one for C++, one for ObjC and so on.

This is not yet final but posted here for comments. There are some options that are enabled for gcc. Add clang, VS options and flags and so on before merging if this turns out to be a good solution.

This MR supersedes both #402 and #427.