### PR TITLE
meson_install.py: Start by checking if the shebang is directly runnable

### DIFF
--- a/mesonbuild/scripts/meson_install.py
+++ b/mesonbuild/scripts/meson_install.py
@@ -118,10 +118,14 @@ def run_install_script(d):
         if platform.system().lower() == 'windows' and suffix != '.bat':
             first_line = open(script).readline().strip()
             if first_line.startswith('#!'):
-                commands = first_line[2:].split('#')[0].strip().split()
-                commands[0] = shutil.which(commands[0].split('/')[-1])
-                if commands[0] is None:
-                    raise RuntimeError("Don't know how to run script %s." % script)
+                if shutil.which(first_line[2:]):
+                    commands = [first_line[2:]]
+                else:
+                    commands = first_line[2:].split('#')[0].strip().split()
+                    commands[0] = shutil.which(commands[0].split('/')[-1])
+                    if commands[0] is None:
+                        commands
+                        raise RuntimeError("Don't know how to run script %s." % script)
                 final_command = commands + [script] + i.cmd_arr[1:]
         else:
             final_command = i.cmd_arr
@@ -129,8 +133,8 @@ def run_install_script(d):
             rc = subprocess.call(final_command, env=child_env)
             if rc != 0:
                 sys.exit(rc)
-        except Exception:
-            print('Failed to run install script:', i.cmd_arr[0])
+        except:
+            print('Failed to run install script:', *i.cmd_arr)
             sys.exit(1)
 
 def is_elf_platform():


### PR DESCRIPTION
On Windows, the shebang parsing in meson_install.py breaks because the shebang path can have spaces ("C:/Program Files/Python35" is the default Python 3 installation path), so just try to find it verbatim first before trying to parse it and extracting another potential path.