### PR TITLE
New builtin option: libexecdir for installation of helper executables

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -28,6 +28,7 @@ builtin_options = {'buildtype': True,
                    'unity': True,
                    'prefix': True,
                    'libdir' : True,
+                   'libexecdir' : True,
                    'bindir' : True,
                    'includedir' : True,
                    'datadir' : True,
@@ -159,6 +160,7 @@ class CoreData():
     def init_builtins(self, options):
         self.builtin_options['prefix'] = UserStringOption('prefix', 'Installation prefix', options.prefix)
         self.builtin_options['libdir'] = UserStringOption('libdir', 'Library dir', options.libdir)
+        self.builtin_options['libexecdir'] = UserStringOption('libexecdir', 'Library executables dir', options.libexecdir)
         self.builtin_options['bindir'] = UserStringOption('bindir', 'Executable dir', options.bindir)
         self.builtin_options['includedir'] = UserStringOption('includedir', 'Include dir', options.includedir)
         self.builtin_options['datadir'] = UserStringOption('datadir', 'Data directory', options.datadir)

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -590,6 +590,9 @@ class Environment():
     def get_libdir(self):
         return self.coredata.get_builtin_option('libdir')
 
+    def get_libexecdir(self):
+        return self.coredata.get_builtin_option('libexecdir')
+
     def get_bindir(self):
         return self.coredata.get_builtin_option('bindir')
 

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -154,6 +154,7 @@ class Conf:
         parr = []
         parr.append(['prefix', 'Install prefix', self.coredata.get_builtin_option('prefix'), ''])
         parr.append(['libdir', 'Library directory', self.coredata.get_builtin_option('libdir'), ''])
+        parr.append(['libexecdir', 'Library executables directory', self.coredata.get_builtin_option('libexecdir'), ''])
         parr.append(['bindir', 'Binary directory', self.coredata.get_builtin_option('bindir'), ''])
         parr.append(['includedir', 'Header directory', self.coredata.get_builtin_option('includedir'), ''])
         parr.append(['datadir', 'Data directory', self.coredata.get_builtin_option('datadir'), ''])

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -173,6 +173,10 @@ def default_libdir():
         return 'lib64'
     return 'lib'
 
+def default_libexecdir():
+    # There is no way to auto-detect this, so it must be set at build time
+    return 'libexec'
+
 def get_library_dirs():
     if is_windows():
         return ['C:/mingw/lib'] # Fixme

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -39,6 +39,8 @@ parser.add_argument('--prefix', default=def_prefix, dest='prefix',
                     help='the installation prefix (default: %(default)s)')
 parser.add_argument('--libdir', default=mesonlib.default_libdir(), dest='libdir',
                     help='the installation subdir of libraries (default: %(default)s)')
+parser.add_argument('--libexecdir', default=mesonlib.default_libexecdir(), dest='libexecdir',
+                    help='the installation subdir of library executables (default: %(default)s)')
 parser.add_argument('--bindir', default='bin', dest='bindir',
                     help='the installation subdir of executables (default: %(default)s)')
 parser.add_argument('--includedir', default='include', dest='includedir',


### PR DESCRIPTION
Implementation of --libexecdir option as per https://github.com/mesonbuild/meson/issues/364#issuecomment-197697381