### PR TITLE
vs2010: fix object extraction

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -142,7 +142,7 @@ class Backend():
         return os.path.relpath(os.path.join('dummyprefixdir', todir),\
                                os.path.join('dummyprefixdir', fromdir))
 
-    def flatten_object_list(self, target, proj_dir_to_build_root=''):
+    def flatten_object_list(self, target, proj_dir_to_build_root='', include_dir_names=True):
         obj_list = []
         for obj in target.get_objects():
             if isinstance(obj, str):
@@ -150,7 +150,7 @@ class Backend():
                                  self.build_to_src, target.get_subdir(), obj)
                 obj_list.append(o)
             elif isinstance(obj, build.ExtractedObjects):
-                obj_list += self.determine_ext_objs(obj, proj_dir_to_build_root)
+                obj_list += self.determine_ext_objs(obj, proj_dir_to_build_root, include_dir_names)
             else:
                 raise MesonException('Unknown data type in object list.')
         return obj_list
@@ -207,7 +207,7 @@ class Backend():
                 return c
         raise RuntimeError('Unreachable code')
 
-    def determine_ext_objs(self, extobj, proj_dir_to_build_root=''):
+    def determine_ext_objs(self, extobj, proj_dir_to_build_root='', include_dir_names=True):
         result = []
         targetdir = self.get_target_private_dir(extobj.target)
         suffix = '.' + self.environment.get_object_suffix()
@@ -221,7 +221,12 @@ class Backend():
             if pathsegs[0] == 'subprojects':
                 pathsegs = pathsegs[2:]
             fixedpath = os.sep.join(pathsegs)
-            objbase = osrc.fname.replace('/', '_').replace('\\', '_')
+            if include_dir_names:
+                objbase = osrc_base.replace('/', '_').replace('\\', '_')
+            else:
+                # vs2010 backend puts all obj files without directory prefixes into build dir, so just
+                # use the file name without a directory (will be stripped by os.path.basename() below).
+                objbase = osrc_base
             objname = os.path.join(proj_dir_to_build_root,
                                    targetdir, os.path.basename(objbase) + suffix)
             result.append(objname)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -36,7 +36,7 @@ class Vs2010Backend(backends.Backend):
         super().__init__(build)
         self.project_file_version = '10.0.30319.1'
         # foo.c compiles to foo.obj, not foo.c.obj
-        self.source_suffix_in_obj = False
+        self.source_suffix_in_objs = False
 
     def generate_custom_generator_commands(self, target, parent_node):
         all_output_files = []
@@ -116,7 +116,7 @@ class Vs2010Backend(backends.Backend):
         result = {}
         for o in obj_list:
             if isinstance(o, build.ExtractedObjects):
-                result[o.target.get_basename()] = True
+                result[o.target.get_id()] = True
         return result.keys()
 
     def determine_deps(self, p):
@@ -492,7 +492,7 @@ class Vs2010Backend(backends.Backend):
             rel_path = self.relpath(lobj.subdir, target.subdir)
             linkname = os.path.join(rel_path, lobj.get_import_filename())
             additional_links.append(linkname)
-        for o in self.flatten_object_list(target, down):
+        for o in self.flatten_object_list(target, down, include_dir_names=False):
             assert(isinstance(o, str))
             additional_links.append(o)
         if len(additional_links) > 0:

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -492,9 +492,10 @@ class Vs2010Backend(backends.Backend):
             rel_path = self.relpath(lobj.subdir, target.subdir)
             linkname = os.path.join(rel_path, lobj.get_import_filename())
             additional_links.append(linkname)
+        additional_objects = []
         for o in self.flatten_object_list(target, down, include_dir_names=False):
             assert(isinstance(o, str))
-            additional_links.append(o)
+            additional_objects.append(o)
         if len(additional_links) > 0:
             additional_links.append('%(AdditionalDependencies)')
             ET.SubElement(link, 'AdditionalDependencies').text = ';'.join(additional_links)
@@ -549,13 +550,15 @@ class Vs2010Backend(backends.Backend):
                 # just the file name instead of the relative path to the file.
                 pch_file.text = os.path.split(header)[1]
 
-        if len(objects) > 0:
+        if len(objects) + len(additional_objects) > 0:
             # Do not add gen_objs to project file. Those are automatically used by MSBuild, because they are part of
             # the CustomBuildStep Outputs.
             inc_objs = ET.SubElement(root, 'ItemGroup')
             for s in objects:
                 relpath = s.rel_to_builddir(proj_to_src_root)
                 ET.SubElement(inc_objs, 'Object', Include=relpath)
+            for s in additional_objects:
+                ET.SubElement(inc_objs, 'Object', Include=s)
         ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.targets')
         # Reference the regen target.
         ig = ET.SubElement(root, 'ItemGroup')


### PR DESCRIPTION
This fixes test cases 25, 84, and 88 for the `vs2010` backend.