### PR TITLE
Implement cc.find_library for the Visual Studio C/C++ compilers

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1150,6 +1150,9 @@ class VisualStudioCCompiler(CCompiler):
     def get_linker_output_args(self, outputname):
         return ['/OUT:' + outputname]
 
+    def get_linker_search_args(self, dirname):
+        return ['/LIBPATH:' + dirname]
+
     def get_pic_args(self):
         return [] # PIC is handled by the loader on Windows
 
@@ -1180,6 +1183,19 @@ class VisualStudioCCompiler(CCompiler):
 
     def build_rpath_args(self, build_dir, rpath_paths, install_rpath):
         return []
+
+    def find_library(self, libname, extra_dirs):
+        code = '''int main(int argc, char **argv) {
+    return 0;
+}
+        '''
+        args = []
+        for i in extra_dirs:
+            args += self.get_linker_search_args(i)
+        args.append(libname + '.lib')
+        if self.links(code, extra_args=args):
+            return args
+        return None
 
     # FIXME, no idea what these should be.
     def thread_flags(self):


### PR DESCRIPTION
Without this `find_library` always succeeds because MSVC just ignores `-lfoo` as an invalid argument and every `find_library` check passes.