### PR TITLE
compilers: While linking, filter out libraries that are bundled with the MSVC runtime

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1220,7 +1220,13 @@ class VisualStudioCCompiler(CCompiler):
                 i = '/LIBPATH:' + i[2:]
             # Translate GNU-style -lfoo library name to the import library
             if i.startswith('-l'):
-                i = i[2:] + '.lib'
+                name = i[2:]
+                if name in ('m', 'c'):
+                    # With MSVC, these are provided by the C runtime which is
+                    # linked in by default
+                    continue
+                else:
+                    i = name + '.lib'
             result.append(i)
         return result
 


### PR DESCRIPTION
pkg-config files often contain -lm and -lc in "Libs:" which causes a build failure on MSVC because m.lib doesn't exist. The API is provided by the C runtime library itself.