### PR TITLE
Add += support for strings and integers

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2169,8 +2169,16 @@ class Interpreter():
         # Remember that all variables are immutable. We must always create a
         # full new variable and then assign it.
         old_variable = self.get_variable(varname)
-        if not isinstance(old_variable, list):
-            raise InvalidArguments('The += operator currently only works with arrays.')
+        if isinstance(old_variable, str):
+          if not isinstance(addition, str):
+            raise InvalidArguments('The += operator requires a string on the right hand side if the variable on the left is a string')
+          new_value = old_variable + addition
+        elif isinstance(old_variable, int):
+          if not isinstance(addition, int):
+            raise InvalidArguments('The += operator requires an int on the right hand side if the variable on the left is an int')
+          new_value = old_variable + addition
+        elif not isinstance(old_variable, list):
+            raise InvalidArguments('The += operator currently only works with arrays, strings or ints ')
         # Add other data types here.
         else:
             if isinstance(addition, list):

--- a/test cases/common/91 plusassign/meson.build
+++ b/test cases/common/91 plusassign/meson.build
@@ -43,3 +43,28 @@ x += x
 if x.length() != 4
   error('Incorrect selfappend.')
 endif
+
+# += on strings
+
+bra = 'bra'
+foo = 'A'
+foo += bra
+foo += 'cada'
+foo += bra
+assert (foo == 'Abracadabra', 'string += failure [@0@]'.format(foo))
+assert (bra == 'bra', 'string += modified right argument!')
+foo += ' ' + foo
+assert (foo == 'Abracadabra Abracadabra', 'string += failure [@0@]'.format(foo))
+
+# += on ints
+
+foo = 5
+foo += 6
+assert (foo == 11, 'int += failure [@0@]'.format(foo))
+bar = 99
+foo += bar
+assert (foo == 110, 'int += failure [@0@]'.format(foo))
+assert (bar == 99, 'int += modified right argument"')
+bar += foo + 1
+assert (bar == 210, 'int += failure [@0@]'.format(bar))
+assert (foo == 110, 'int += modified right argument"')


### PR DESCRIPTION
I found myself doing

     foo += 'bar'

for strings. This makes it work.