### PR TITLE
Add bool to_string() and to_int() methods

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2017,6 +2017,30 @@ class Interpreter():
             reduced_pos = [reduced_pos]
         return (reduced_pos, reduced_kw)
 
+    def bool_method_call(self, obj, method_name, args):
+        obj = self.to_native(obj)
+        (posargs, _) = self.reduce_arguments(args)
+        if method_name == 'to_string':
+           if len(posargs) == 0:
+             if obj == True:
+               return 'true'
+             else:
+               return 'false'
+           elif len(posargs) == 2 and isinstance(posargs[0], str) and isinstance(posargs[1], str):
+             if obj == True:
+               return posargs[0]
+             else:
+               return posargs[1]
+           else:
+               raise InterpreterException('bool.to_string() must have either no arguments or exactly two string arguments.')
+        elif method_name == 'to_int':
+          if obj == True:
+            return 1
+          else:
+            return 0
+        else:
+            raise InterpreterException('Unknown method "%s" for a boolean.' % method_name)
+
     def string_method_call(self, obj, method_name, args):
         obj = self.to_native(obj)
         (posargs, _) = self.reduce_arguments(args)
@@ -2089,6 +2113,8 @@ class Interpreter():
             obj = obj.get_value()
         if isinstance(obj, str):
             return self.string_method_call(obj, method_name, args)
+        if isinstance(obj, bool):
+            return self.bool_method_call(obj, method_name, args)
         if isinstance(obj, list):
             return self.array_method_call(obj, method_name, self.reduce_arguments(args)[0])
         if not isinstance(obj, InterpreterObject):

--- a/test cases/common/42 string formatting/meson.build
+++ b/test cases/common/42 string formatting/meson.build
@@ -45,3 +45,9 @@ assert('#include <foo/bar.h>'.underscorify() == '_include__foo_bar_h_', 'Broken 
 assert('Do SomeThing 09'.underscorify() == 'Do_SomeThing_09', 'Broken underscorify')
 
 assert('3'.to_int() == 3, 'String int conversion does not work.')
+
+assert(true.to_string() == 'true', 'bool string conversion failed')
+assert(false.to_string() == 'false', 'bool string conversion failed')
+assert(true.to_string('yes', 'no') == 'yes', 'bool string conversion with args failed')
+assert(false.to_string('yes', 'no') == 'no', 'bool string conversion with args failed')
+assert('@0@'.format(true) == 'true', 'bool string formatting failed')

--- a/test cases/common/68 number arithmetic/meson.build
+++ b/test cases/common/68 number arithmetic/meson.build
@@ -32,3 +32,6 @@ assert(not(3 > 4), 'Gt broken')
 assert(4 >= 3, 'Gte broken')
 assert(not(3 >= 4), 'Gte broken')
 assert(3 >= 3, 'Gte broken')
+
+assert(true.to_int() == 1,'bool to_int() broken')
+assert(false.to_int() == 0,'bool to_int() broken')


### PR DESCRIPTION
bool to_int() will return 0 or 1, useful if one wants to set
a define to 0 or 1 based on a boolean result instead of having
it just defined or undefined.

bool to_string() will return 'true' or 'false' by default same
as when using it to format a string, but with the additional
possibility to specify two extra string arguments to be returned
as true/false values, e.g. to_string('yes', 'no'). This can be
useful when outputting messages to be shown to the user.