### PR TITLE
vs2010: Support source files with same name from different subdirs

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -129,7 +129,6 @@ class NinjaBackend(backends.Backend):
 
     def __init__(self, build):
         super().__init__(build)
-        self.source_suffix_in_objs = True
         self.ninja_filename = 'build.ninja'
         self.fortran_deps = {}
         self.all_outputs = {}

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -16,6 +16,8 @@ import os, sys
 import pickle
 
 from mesonbuild import compilers
+from mesonbuild.build import BuildTarget
+from mesonbuild.mesonlib import File
 from . import backends
 from .. import build
 from .. import dependencies
@@ -35,15 +37,35 @@ class Vs2010Backend(backends.Backend):
     def __init__(self, build):
         super().__init__(build)
         self.project_file_version = '10.0.30319.1'
+        self.sources_conflicts = {}
 
     def object_filename_from_source(self, target, source):
         basename = os.path.basename(source.fname)
         filename_without_extension = '.'.join(basename.split('.')[:-1])
-        if basename in target.sources_conflicts:
+        if basename in self.sources_conflicts[target.get_id()]:
             # If there are multiple source files with the same basename, we must resolve the conflict
             # by giving each a unique object output file.
             filename_without_extension = '.'.join(source.fname.split('.')[:-1]).replace('/', '_').replace('\\', '_')
         return filename_without_extension + '.' + self.environment.get_object_suffix()
+
+    def resolve_source_conflicts(self):
+        for name, target in self.build.targets.items():
+            if not isinstance(target, BuildTarget):
+                continue
+            conflicts = {}
+            for s in target.get_sources():
+                if hasattr(s, 'held_object'):
+                    s = s.held_object
+                if not isinstance(s, File):
+                    continue
+                basename = os.path.basename(s.fname)
+                conflicting_sources = conflicts.get(basename, None)
+                if conflicting_sources is None:
+                    conflicting_sources = []
+                    conflicts[basename] = conflicting_sources
+                conflicting_sources.append(s)
+            self.sources_conflicts[target.get_id()] = {name: src_conflicts for name, src_conflicts in conflicts.items()
+                                                       if len(src_conflicts) > 1}
 
     def generate_custom_generator_commands(self, target, parent_node):
         all_output_files = []
@@ -93,6 +115,7 @@ class Vs2010Backend(backends.Backend):
         return all_output_files
 
     def generate(self, interp):
+        self.resolve_source_conflicts()
         self.interpreter = interp
         self.platform = 'Win32'
         self.buildtype = self.environment.coredata.get_builtin_option('buildtype')
@@ -574,7 +597,7 @@ class Vs2010Backend(backends.Backend):
                 self.add_pch(inc_cl, proj_to_src_dir, pch_sources, s)
                 self.add_additional_options(s, inc_cl, extra_args, additional_options_set)
                 basename = os.path.basename(s.fname)
-                if basename in target.sources_conflicts:
+                if basename in self.sources_conflicts[target.get_id()]:
                     ET.SubElement(inc_cl, 'ObjectFileName').text = "$(IntDir)" + self.object_filename_from_source(target, s)
             for s in gen_src:
                 relpath =  self.relpath(s, target.subdir)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -566,6 +566,11 @@ class Vs2010Backend(backends.Backend):
                 inc_cl = ET.SubElement(inc_src, 'CLCompile', Include=relpath)
                 self.add_pch(inc_cl, proj_to_src_dir, pch_sources, s)
                 self.add_additional_options(s, inc_cl, extra_args, additional_options_set)
+                basename = os.path.basename(s.fname)
+                if basename in target.sources_conflicts:
+                    obj_name = '.'.join(s.split('.')[:-1]).replace('/', '_')\
+                               + '.' + self.environment.get_object_suffix()
+                    ET.SubElement(inc_cl, 'ObjectFileName').text = "$(IntDir)" + obj_name
             for s in gen_src:
                 relpath =  self.relpath(s, target.subdir)
                 inc_cl = ET.SubElement(inc_src, 'CLCompile', Include=relpath)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -184,7 +184,6 @@ class BuildTarget():
         self.subproject = subproject # Can not be calculated from subdir as subproject dirname can be changed per project.
         self.is_cross = is_cross
         self.sources = []
-        self.sources_conflicts = {}
         self.objects = []
         self.external_deps = []
         self.include_dirs = []
@@ -245,7 +244,6 @@ class BuildTarget():
         if not isinstance(sources, list):
             sources = [sources]
         added_sources = {} # If the same source is defined multiple times, use it only once.
-        conflicts = {} # We must resolve conflicts if multiple source files from different subdirs have the same name.
         for s in sources:
             # Holder unpacking. Ugly.
             if hasattr(s, 'held_object'):
@@ -254,19 +252,10 @@ class BuildTarget():
                 if not s in added_sources:
                     self.sources.append(s)
                     added_sources[s] = True
-                    basename = os.path.basename(s.fname)
-                    conflicting_sources = conflicts.get(basename, None)
-                    if conflicting_sources is None:
-                        conflicting_sources = []
-                    conflicting_sources.append(s)
-                    conflicts[basename] = conflicting_sources
             elif isinstance(s, GeneratedList) or isinstance(s, CustomTarget):
                 self.generated.append(s)
             else:
                 raise InvalidArguments('Bad source in target %s.' % self.name)
-        for basename, conflicting_sources in conflicts.items():
-            if len(conflicting_sources) > 1:
-                self.sources_conflicts[basename] = conflicting_sources
 
     def validate_sources(self):
         if len(self.sources) > 0:

--- a/test cases/common/110 extract same name/lib.c
+++ b/test cases/common/110 extract same name/lib.c
@@ -1,0 +1,3 @@
+int func1() {
+    return 23;
+}

--- a/test cases/common/110 extract same name/main.c
+++ b/test cases/common/110 extract same name/main.c
@@ -1,0 +1,6 @@
+int func1();
+int func2();
+
+int main(int argc, char **argv) {
+    return !(func1() == 23 && func2() == 42);
+}

--- a/test cases/common/110 extract same name/meson.build
+++ b/test cases/common/110 extract same name/meson.build
@@ -1,0 +1,6 @@
+project('object extraction', 'c')
+
+lib = shared_library('somelib', ['lib.c', 'src/lib.c'])
+obj = lib.extract_objects(['lib.c', 'src/lib.c'])
+exe = executable('main', 'main.c', objects: obj)
+test('extraction', exe)

--- a/test cases/common/110 extract same name/src/lib.c
+++ b/test cases/common/110 extract same name/src/lib.c
@@ -1,0 +1,3 @@
+int func2() {
+    return 42;
+}


### PR DESCRIPTION
Fixes test case 54.
This also adds a test case for extracting objects with the same source filename.