### PR TITLE
vs2010: use copy of buildtype_args to not change global state

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -437,7 +437,7 @@ class Vs2010Backend(backends.Backend):
         for l, args in target.extra_args.items():
             if l in extra_args:
                 extra_args[l] += args
-        general_args = compiler.get_buildtype_args(self.buildtype)
+        general_args = compiler.get_buildtype_args(self.buildtype).copy()
         # FIXME all the internal flags of VS (optimization etc) are represented
         # by their own XML elements. In theory we should split all flags to those
         # that have an XML element and those that don't and serialise them


### PR DESCRIPTION
We do not want the modifications of general_args to propagate to the global buildtype_args.

This fixes test case 87 failing when the `dep_user` target (which uses `-DUSING_ENT=1`) was built before the `entity` target. This happens randomly because the build order depends on the random uuid.

After `dep_user` was built, the `-DUSING_ENT=1` definition gets added to the global buildtype_args and thus gets used when comiling `entity`, which is wrong.