### PR TITLE
compilers: Return -1 from cc.sizeof if the symbol could not be found

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -574,7 +574,7 @@ int main(int argc, char **argv) {
 '''
         res = self.run(templ % (prefix, element), extra_args)
         if not res.compiled:
-            raise EnvironmentException('Could not compile sizeof test.')
+            return -1
         if res.returncode != 0:
             raise EnvironmentException('Could not run sizeof test binary.')
         return int(res.stdout)


### PR DESCRIPTION
Allows people to avoid adding a separate check for the symbol existing in case it's platform-specific