### PR TITLE
vs2010: fix include directories

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -421,11 +421,8 @@ class Vs2010Backend(backends.Backend):
         clconf = ET.SubElement(compiles, 'ClCompile')
         opt = ET.SubElement(clconf, 'Optimization')
         opt.text = 'disabled'
-        inc_dirs = [proj_to_src_dir, self.get_target_private_dir(target)]
-        cur_dir = target.subdir
-        if cur_dir == '':
-            cur_dir= '.'
-        inc_dirs.append(cur_dir)
+        inc_dirs = ['.', self.relpath(self.get_target_private_dir(target), self.get_target_dir(target)),
+                    proj_to_src_dir]
 
         extra_args = {'c': [], 'cpp': []}
         for l, args in self.environment.coredata.external_args.items():


### PR DESCRIPTION
Everything in the VS project file is relative to the project file itself.
The project file gets put in the target.subdir, so to include files from there we just need to use `.`.
To include from the private dir, we need to use the relative path from the target dir to the target private dir.