### PR TITLE
Use the linker to check if a specific function is provided by the toolchain or runtime

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -258,6 +258,9 @@ class Compiler():
     def has_header(self, *args, **kwargs):
         raise EnvironmentException('Language %s does not support header checks.' % self.language)
 
+    def has_header_symbol(self, *args, **kwargs):
+        raise EnvironmentException('Language %s does not support header symbol checks.' % self.language)
+
     def compiles(self, *args, **kwargs):
         raise EnvironmentException('Language %s does not support compile checks.' % self.language)
 
@@ -459,6 +462,13 @@ class CCompiler(Compiler):
 int someSymbolHereJustForFun;
 '''
         return self.compiles(templ % hname, extra_args)
+
+    def has_header_symbol(self, hname, symbol, prefix, extra_args=[]):
+        templ = '''{2}
+#include <{0}>
+int main () {{ {1}; }}'''
+        # Pass -O0 to ensure that the symbol isn't optimized away
+        return self.compiles(templ.format(hname, symbol, prefix), extra_args + ['-O0'])
 
     def compile(self, code, srcname, extra_args=[]):
         commands = self.get_exelist()

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -350,6 +350,9 @@ class CCompiler(Compiler):
     def get_compile_only_args(self):
         return ['-c']
 
+    def get_no_optimization_args(self):
+        return ['-O0']
+
     def get_output_args(self, target):
         return ['-o', target]
 
@@ -468,7 +471,8 @@ int someSymbolHereJustForFun;
 #include <{0}>
 int main () {{ {1}; }}'''
         # Pass -O0 to ensure that the symbol isn't optimized away
-        return self.compiles(templ.format(hname, symbol, prefix), extra_args + ['-O0'])
+        extra_args += self.get_no_optimization_args()
+        return self.compiles(templ.format(hname, symbol, prefix), extra_args)
 
     def compile(self, code, srcname, extra_args=[]):
         commands = self.get_exelist()
@@ -697,7 +701,8 @@ int main(int argc, char **argv) {
         # special functions that ignore all includes and defines, so we just
         # directly try to link via main().
         # Add -O0 to ensure that the symbol isn't optimized away by the compiler
-        return self.links('int main() {{ {0}; }}'.format('__builtin_' + funcname), extra_args + ['-O0'])
+        extra_args += self.get_no_optimization_args()
+        return self.links('int main() {{ {0}; }}'.format('__builtin_' + funcname), extra_args)
 
     def has_member(self, typename, membername, prefix, extra_args=[]):
         templ = '''%s
@@ -1297,6 +1302,9 @@ class VisualStudioCCompiler(CCompiler):
 
     def get_compile_only_args(self):
         return ['/c']
+
+    def get_no_optimization_args(self):
+        return ['/Od']
 
     def get_output_args(self, target):
         if target.endswith('.exe'):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -575,6 +575,7 @@ class CompilerHolder(InterpreterObject):
                              'get_id': self.get_id_method,
                              'sizeof': self.sizeof_method,
                              'has_header': self.has_header_method,
+                             'has_header_symbol': self.has_header_symbol_method,
                              'run' : self.run_method,
                              'has_function' : self.has_function_method,
                              'has_member' : self.has_member_method,
@@ -750,6 +751,24 @@ class CompilerHolder(InterpreterObject):
         else:
             h = mlog.red('NO')
         mlog.log('Has header "%s":' % string, h)
+        return haz
+
+    def has_header_symbol_method(self, args, kwargs):
+        if len(args) != 2:
+            raise InterpreterException('has_header_symbol method takes exactly two arguments.')
+        check_stringlist(args)
+        hname = args[0]
+        symbol = args[1]
+        prefix = kwargs.get('prefix', '')
+        if not isinstance(prefix, str):
+            raise InterpreterException('Prefix argument of has_function must be a string.')
+        extra_args = self.determine_args(kwargs)
+        haz = self.compiler.has_header_symbol(hname, symbol, prefix, extra_args)
+        if haz:
+            h = mlog.green('YES')
+        else:
+            h = mlog.red('NO')
+        mlog.log('Header <{0}> has symbol "{1}":'.format(hname, symbol), h)
         return haz
 
     def find_library_method(self, args, kwargs):

--- a/test cases/common/111 has header symbol/meson.build
+++ b/test cases/common/111 has header symbol/meson.build
@@ -1,0 +1,18 @@
+project('has header symbol', 'c')
+
+cc = meson.get_compiler('c')
+
+assert (cc.has_header_symbol('stdio.h', 'int'), 'base types should always be available')
+assert (cc.has_header_symbol('stdio.h', 'printf'), 'printf function not found')
+assert (cc.has_header_symbol('stdio.h', 'FILE'), 'FILE structure not found')
+assert (cc.has_header_symbol('limits.h', 'INT_MAX'), 'INT_MAX define not found')
+assert (not cc.has_header_symbol('limits.h', 'guint64'), 'guint64 is not defined in limits.h')
+assert (not cc.has_header_symbol('stdlib.h', 'FILE'), 'FILE structure is defined in stdio.h, not stdlib.h')
+assert (not cc.has_header_symbol('stdlol.h', 'printf'), 'stdlol.h shouldn\'t exist')
+assert (not cc.has_header_symbol('stdlol.h', 'int'), 'shouldn\'t be able to find "int" with invalid header')
+
+# This is likely only available on Glibc, so just test for it
+if cc.has_function('ppoll')
+  assert (not cc.has_header_symbol('poll.h', 'ppoll'), 'ppoll should not be accessible without _GNU_SOURCE')
+  assert (cc.has_header_symbol('poll.h', 'ppoll', prefix : '#define _GNU_SOURCE'), 'ppoll should be accessible with _GNU_SOURCE')
+endif

--- a/test cases/common/43 has function/meson.build
+++ b/test cases/common/43 has function/meson.build
@@ -6,6 +6,30 @@ if not cc.has_function('printf', prefix : '#include<stdio.h>')
   error('Existing function not found.')
 endif
 
+# Should also be able to detect it without specifying the header
+# We check for a different function here to make sure the result is
+# not taken from a cache (ie. the check above)
+assert(cc.has_function('fprintf'), 'Existing function not found without include')
+
 if cc.has_function('hfkerhisadf', prefix : '#include<stdio.h>')
   error('Found non-existant function.')
+endif
+
+# With glibc on Linux lchmod is a stub that will always return an error,
+# we want to detect that and declare that the function is not available.
+# We can't check for the C library used here of course, but if it's not
+# implemented in glibc it's probably not implemented in any other 'slimmer'
+# C library variants either, so the check should be safe either way hopefully.
+if host_machine.system() == 'linux' and cc.get_id() == 'gcc'
+  assert (cc.has_function('poll', prefix : '#include <poll.h>'), 'couldn\'t detect poll when defined by a header')
+  assert (not cc.has_function('lchmod', prefix : '''#include <sys/stat.h>
+                                                    #include <unistd.h>'''), 'lchmod check should have failed')
+endif
+
+# For some functions one needs to define _GNU_SOURCE before including the
+# right headers to get them picked up. Make sure we can detect these functions
+# as well without any prefix
+if cc.has_header_symbol('sys/socket.h', 'recvmmsg', prefix : '#define _GNU_SOURCE')
+  # We assume that if recvmmsg exists sendmmsg does too
+  assert (cc.has_function('sendmmsg'), 'Failed to detect existing function')
 endif


### PR DESCRIPTION
This allows build files to not bother with providing system headers under `prefix` while checking if a function exists, providing convenience similar to how autoconf macros work. This is especially convenient when you need to have multiple `#ifdef`s and `#define`s to get at the symbol in the header which would then have to be duplicated in the build file and in the source. It is also a much cleaner check since it ensures that the symbol is a function.