### PR TITLE
vala: Generate coverage with '--debug'

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1021,6 +1021,9 @@ class ValaCompiler(Compiler):
     def get_exelist(self):
         return self.exelist
 
+    def get_coverage_args(self):
+        return ['--debug']
+
     def get_werror_args(self):
         return ['--fatal-warnings']
 


### PR DESCRIPTION
The Vala compiler generate '#line' directives when '--debug' is enabled,
which is essential to understand what part of the original sources are
covered.