### PR TITLE
compilers: Debug optimization level should be -Og

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -55,7 +55,9 @@ def is_library(fname):
     return suffix in lib_suffixes
 
 gnulike_buildtype_args = {'plain' : [],
-                          'debug' : ['-g'],
+                          # -O0 is passed for improved debugging information with gcc
+                          # See https://github.com/mesonbuild/meson/pull/509
+                          'debug' : ['-O0', '-g'],
                           'debugoptimized' : ['-O2', '-g'],
                           'release' : ['-O3']}
 


### PR DESCRIPTION
The gcc manual says that `-Og` is the recommended optimization level with `-g`.

> If you are not using some other optimization option, consider using -Og with -g.  With no -O option at all, some compiler passes that collect information useful for debugging do not run at all, so that -Og may result in a better debugging experience.

I noticed this when a bunch of symbols were missing in a backtrace I was investigating.