### PR TITLE
Two fixes for cc.cross_sizeof and cc.cross_alignment

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -579,7 +579,7 @@ int main () {{ {1}; }}'''
         element_exists_templ = '''#include <stdio.h>
 {0}
 int main(int argc, char **argv) {{
-    {1};
+    {1} something;
 }}
 '''
         templ = '''#include <stdio.h>
@@ -622,6 +622,11 @@ int main(int argc, char **argv) {
         return int(res.stdout)
 
     def cross_alignment(self, typename, env, extra_args=[]):
+        type_exists_templ = '''#include <stdio.h>
+int main(int argc, char **argv) {{
+    {0} something;
+}}
+'''
         templ = '''#include<stddef.h>
 struct tmp {
   char c;
@@ -634,6 +639,9 @@ int testarray[%d-offsetof(struct tmp, target)];
             extra_args += env.cross_info.config['properties'][self.language + '_args']
         except KeyError:
             pass
+        extra_args += self.get_no_optimization_args()
+        if not self.compiles(type_exists_templ.format(typename)):
+            return -1
         for i in range(1, 1024):
             code = templ % (typename, i)
             if self.compiles(code, extra_args):

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -596,6 +596,10 @@ int temparray[%d-sizeof(%s)];
         for i in range(1, 1024):
             code = templ % (prefix, i, element)
             if self.compiles(code, extra_args):
+                if self.id == 'msvc':
+                    # MSVC refuses to construct an array of zero size, so
+                    # the test only succeeds when i is sizeof(element) + 1
+                    return i - 1
                 return i
         raise EnvironmentException('Cross checking sizeof overflowed.')
 
@@ -633,6 +637,10 @@ int testarray[%d-offsetof(struct tmp, target)];
         for i in range(1, 1024):
             code = templ % (typename, i)
             if self.compiles(code, extra_args):
+                if self.id == 'msvc':
+                    # MSVC refuses to construct an array of zero size, so
+                    # the test only succeeds when i is sizeof(element) + 1
+                    return i - 1
                 return i
         raise EnvironmentException('Cross checking offsetof overflowed.')
 


### PR DESCRIPTION
On MSVC, there's an off-by-one because the compiler refuses to allocate a static array of zero length. So the test only succeeds when `i` is `sizeof(element) + 1`.

Secondly, the `element_exists` check was breaking with pointer types because of a syntax error. It was also missing with `cc.cross_alignment`.