### PR TITLE
Regex used for configuration data substitution is too broad

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -252,7 +252,9 @@ def do_mesondefine(line, confdata):
 
 def do_conf_file(src, dst, confdata):
     data = open(src).readlines()
-    regex = re.compile('@(.*?)@')
+    # Only allow (a-z, A-Z, 0-9, _, -) as valid characters for a define
+    # Also allow escaping '@' with '\@'
+    regex = re.compile(r'[^\\]?@([-a-zA-Z0-9_]+)@')
     result = []
     for line in data:
         if line.startswith('#mesondefine'):


### PR DESCRIPTION
There is almost no case in which you'd want to substitute anything other than a-zA-Z0-9_-, so just require that. Also allow people to 'escape' @ as \@. This is used by gobject/glib-mkenum.in, which is a Perl script.

Currently it incorrectly substitutes the following with blank spaces:

```
@DEFINE1@ @DEFINE@                  (when both DEFINE1 and DEFINE2 are defined)
@@, s@\n@ @, etc                    (common Perl constructs)
name@email.com user@another.com     (author emails in a comment)
name\@email.com user\@another.com   (escaped \@ in a Perl file)
```

And many more.