### PR TITLE
Use module path for getting scripts dir

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -131,7 +131,8 @@ class Environment():
         coredata.save(self.coredata, cdf)
 
     def get_script_dir(self):
-        return os.path.join(os.path.dirname(self.meson_script_file), '../scripts')
+        import mesonbuild.scripts
+        return os.path.dirname(mesonbuild.scripts.__file__)
 
     def get_log_dir(self):
         return self.log_dir

--- a/mesonbuild/scripts/delwithsuffix.py
+++ b/mesonbuild/scripts/delwithsuffix.py
@@ -17,7 +17,7 @@
 import os, sys
 
 def run(args):
-    if len(sys.argv) != 2:
+    if len(sys.argv) != 3:
         print('delwithsuffix.py <root of subdir to process> <suffix to delete>')
         sys.exit(1)
 


### PR DESCRIPTION
This is for systems which have a special way of handling python versions (like python-exec for gentoo).

Also, the number of argv for the delwithsuffix.py script should be 3, including the script name ;-)