### PR TITLE
compilers: Add the buildtype args for checks that perform linking

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -533,7 +533,12 @@ int main () {{ {1}; }}'''
         ofile = open(srcname, 'w')
         ofile.write(code)
         ofile.close()
-        extra_args = self.unix_link_flags_to_native(extra_args) + \
+        # Need to add buildtype args to select the CRT to use with MSVC
+        # This is needed especially while trying to link with static libraries
+        # since MSVC won't auto-select a CRT for us in that case and will error
+        # out asking us to select one.
+        extra_args = self.get_buildtype_args('debug') + \
+            self.unix_link_flags_to_native(extra_args) + \
             self.get_output_args(dstname)
         p = self.compile(code, srcname, extra_args)
         try:
@@ -553,6 +558,8 @@ int main () {{ {1}; }}'''
         ofile.close()
         exename = srcname + '.exe' # Is guaranteed to be executable on every platform.
         commands = self.get_exelist()
+        # Same reasoning as self.links() above
+        commands += self.get_buildtype_args('debug')
         commands += self.unix_link_flags_to_native(extra_args)
         commands.append(srcname)
         commands += self.get_output_args(exename)


### PR DESCRIPTION
This is required for checking for compiler checks that involve linking to a static library with MSVC. Without this, MSVC errors out since no CRT is specified.

These also don't hurt with other compilers since they simply force the check to use debugging mode which should not do optimizations and change the result of the check.