### PR TITLE
compilers: Always include limits.h to make the stub machinery work

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -692,6 +692,7 @@ int main(int argc, char **argv) {
         # Then, undef the symbol to get rid of it completely.
         templ = '''
         #define {1} meson_disable_define_of_{1}
+        #include <limits.h>
         {0}
         #undef {1}
         '''
@@ -709,6 +710,8 @@ int main(int argc, char **argv) {
         # glibc defines functions that are not available on Linux as stubs that
         # fail with ENOSYS (such as e.g. lchmod). In this case we want to fail
         # instead of detecting the stub as a valid symbol.
+        # We always include limits.h above to ensure that these are defined for
+        # stub functions.
         stubs_fail = '''
         #if defined __stub_{1} || defined __stub___{1}
         fail fail fail this function is not going to work


### PR DESCRIPTION
Without this, the stubs check for things like `lchmod` fails and it's incorrectly detected as being available (glibc exports the symbol but it always fails). `limits.h` includes `features.h` which includes `gnu/stubs.h` which defines all the functions that are actually stubs.

`limits.h` is a requirement of the C language and is available with all compilers and platforms from the last two decades. If `limits.h` is not available, the compiler only supports an ancient dialect of C and lots of other things will break too.