### PR TITLE
Support passing extra arguments to gtkdoc-fixxref

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -33,3 +33,4 @@ Nicolas Schneider
 Luke Adams
 Rogiel Sulzbach
 Tim-Philipp Müller
+Emmanuele Bassi

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -289,6 +289,7 @@ class GnomeModule:
                 '--modulename=' + modulename]
         args += self.unpack_args('--htmlargs=', 'html_args', kwargs)
         args += self.unpack_args('--scanargs=', 'scan_args', kwargs)
+        args += self.unpack_args('--fixxrefargs=', 'fixxref_args', kwargs)
         res = [build.RunTarget(targetname, command[0], command[1:] + args, state.subdir)]
         if kwargs.get('install', True):
             res.append(build.InstallScript(command + args))

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -28,9 +28,10 @@ parser.add_argument('--mainfile', dest='mainfile')
 parser.add_argument('--modulename', dest='modulename')
 parser.add_argument('--htmlargs', dest='htmlargs', default='')
 parser.add_argument('--scanargs', dest='scanargs', default='')
+parser.add_argument('--fixxrefargs', dest='fixxrefargs', default='')
 
 def build_gtkdoc(source_root, build_root, doc_subdir, src_subdir,
-                 main_file, module, html_args, scan_args):
+                 main_file, module, html_args, scan_args, fixxref_args):
     abs_src = os.path.join(source_root, src_subdir)
     abs_out = os.path.join(build_root, doc_subdir)
     htmldir = os.path.join(abs_out, 'html')
@@ -76,7 +77,7 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdir,
     subprocess.check_call(mkhtml_cmd, cwd=os.path.join(abs_out, 'html'), shell=False)
     fixref_cmd = ['gtkdoc-fixxref',
                   '--module=' + module,
-                  '--module-dir=html']
+                  '--module-dir=html'] + fixxref_args
 #    print(fixref_cmd)
 #    sys.exit(1)
     subprocess.check_call(fixref_cmd, cwd=abs_out)
@@ -97,6 +98,10 @@ def run(args):
         scanargs = options.scanargs.split('@@')
     else:
         scanargs = []
+    if len(options.fixxrefargs) > 0:
+        fixxrefargs = options.fixxrefargs.split('@@')
+    else:
+        fixxrefargs = []
     build_gtkdoc(options.sourcedir,
                  options.builddir,
                  options.subdir,
@@ -104,7 +109,8 @@ def run(args):
                  options.mainfile,
                  options.modulename,
                  htmlargs,
-                 scanargs)
+                 scanargs,
+                 fixxrefargs)
 
     if 'MESON_INSTALL_PREFIX' in os.environ:
         if 'DESTDIR' in os.environ:


### PR DESCRIPTION
The extra arguments are typically used to specified the location of
installed API references that gtk-doc can use to create cross links
for symbols.

Fixes #555