### PR TITLE
compilers: Fix header stub change that broke has_function checks on Windows

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -739,7 +739,8 @@ int main(int argc, char **argv) {
         # redefines the symbol to be something else. In that case, we want to
         # still detect the function. We still want to fail if __stub_foo or
         # _stub_foo are defined, of course.
-        if self.links('{0}\n' + stubs_fail + '\nint main() {{ {1}; }}'.format(prefix, funcname), extra_args):
+        header_templ = '#include <limits.h>\n{0}\n' + stubs_fail + '\nint main() {{ {1}; }}'
+        if self.links(header_templ.format(prefix, funcname), extra_args):
             return True
         # Some functions like alloca() are defined as compiler built-ins which
         # are inlined by the compiler, so test for that instead. Built-ins are

--- a/test cases/common/43 has function/meson.build
+++ b/test cases/common/43 has function/meson.build
@@ -9,7 +9,13 @@ endif
 # Should also be able to detect it without specifying the header
 # We check for a different function here to make sure the result is
 # not taken from a cache (ie. the check above)
-assert(cc.has_function('fprintf'), '"fprintf" function not found without include (should always exist).')
+# On MSVC fprintf is defined as an inline function in the header, so it cannot
+# be found without the include.
+if cc.get_id() != 'msvc'
+  assert(cc.has_function('fprintf'), '"fprintf" function not found without include (on !msvc).')
+else
+  assert(cc.has_function('fprintf', prefix : '#include <stdio.h>'), '"fprintf" function not found with include (on msvc).')
+endif
 
 if cc.has_function('hfkerhisadf', prefix : '#include<stdio.h>')
   error('Found non-existent function "hfkerhisadf".')


### PR DESCRIPTION
It broke the check completely (.format() is per-string) and hence broke the inline-header-implementation check needed—especially on Windows.

Fixes https://github.com/mesonbuild/meson/issues/558