### PR TITLE
ninja: Fix cross-build when using the compiler's stdlib

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1397,7 +1397,7 @@ rule FORTRAN_DEP_HACK
     def get_cross_stdlib_args(self, target, compiler):
         if not target.is_cross:
             return []
-        if self.environment.cross_info.has_stdlib(compiler.language):
+        if not self.environment.cross_info.has_stdlib(compiler.language):
             return []
         return compiler.get_no_stdinc_args()
 


### PR DESCRIPTION
Logic was reversed. We want to pass `-nostdinc` when there's no `c_stdlib` specified in the cross-info file.

Without this all cross building is broken because `-nostdinc` is always passed and standard headers provided by the compiler can't be found.