### PR TITLE
interpreter: Switch to prev_subdir on non-existant subdir

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1824,6 +1824,7 @@ class Interpreter():
         self.build_def_files.append(buildfilename)
         absname = os.path.join(self.environment.get_source_dir(), buildfilename)
         if not os.path.isfile(absname):
+            self.subdir = prev_subdir
             raise InterpreterException('Nonexistant build def file %s.' % buildfilename)
         code = open(absname, encoding='utf8').read()
         assert(isinstance(code, str))


### PR DESCRIPTION
This fixes the error message as reported on https://github.com/mesonbuild/meson/issues/532