### PR TITLE
compiler: Use cross tools args in sanity check.

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -34,3 +34,4 @@ Luke Adams
 Rogiel Sulzbach
 Tim-Philipp Müller
 Emmanuele Bassi
+Martin Hostettler

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1557,10 +1557,10 @@ class Interpreter():
                 # cross_comp = self.environment.detect_fortran_compiler(True)
         else:
             raise InvalidCode('Tried to use unknown language "%s".' % lang)
-        comp.sanity_check(self.environment.get_scratch_dir())
+        comp.sanity_check(self.environment.get_scratch_dir(), self.environment)
         self.coredata.compilers[lang] = comp
         if cross_comp is not None:
-            cross_comp.sanity_check(self.environment.get_scratch_dir())
+            cross_comp.sanity_check(self.environment.get_scratch_dir(), self.environment)
             self.coredata.cross_compilers[lang] = cross_comp
         new_options = comp.get_options()
         optprefix = lang + '_'


### PR DESCRIPTION
Add support for *_args from cross file to sanity check for tools that don’t properly compile (or link if exewrapper is also given) without these arguments.

Also minimally fixes sanity check when cross compiling objective C.

This doesn’t use unix_link_flags_to_native or unix_compile_flags_to_native because the ninja backend also doesn’t apply these transformations. Which is ok, because we can expect cross files to use native argument syntax because they are inherently compiler implementation specific anyway.

This does not overlap with #586, it might be possible to use get_cross_extra_flags there too.