### PR TITLE
Use target name to decide generated Vala .h & .vapi filenames

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -35,3 +35,4 @@ Rogiel Sulzbach
 Tim-Philipp Müller
 Emmanuele Bassi
 Martin Hostettler
+Sam Thursfield

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -772,7 +772,7 @@ int dummy;
                 if hasattr(i, 'fname'):
                     i = i.fname
                 if i.endswith('vala'):
-                    vapiname = os.path.splitext(os.path.split(i)[1])[0] + '.vapi'
+                    vapiname = dep.name + '.vapi'
                     fullname = os.path.join(self.get_target_dir(dep), vapiname)
                     result.append(fullname)
                     break
@@ -790,7 +790,7 @@ int dummy;
                 vala_input_files.append(s.rel_to_builddir(self.build_to_src))
         if len(src) == 0:
             raise InvalidArguments('Vala library has no Vala source files.')
-        namebase = os.path.splitext(os.path.split(src[0].fname)[1])[0]
+        namebase = target.name
         base_h = namebase + '.h'
         base_vapi = namebase + '.vapi'
         hname = os.path.normpath(os.path.join(self.get_target_dir(target), base_h))


### PR DESCRIPTION
Previously Meson would use the name of the first .vala source file. This
doesn't work for some projects. Tracker is one example: it has
several libraries that mix Vala and C code. In such cases, none of the
.vala files tend to bear the name of the library we actually want to
generate.

This fixes https://github.com/mesonbuild/meson/issues/504