### PR TITLE
cross compiling fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.pydevproject
 /.settings
 /.cproject
+/.idea
 
 __pycache__
 /install dir

--- a/authors.txt
+++ b/authors.txt
@@ -36,3 +36,4 @@ Tim-Philipp Müller
 Emmanuele Bassi
 Martin Hostettler
 Sam Thursfield
+Noam Meltzer

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -226,7 +226,10 @@ class Backend():
 
     def determine_linker(self, target, src):
         if isinstance(target, build.StaticLibrary):
-            return self.build.static_linker
+            if self.build.static_cross_linker is not None:
+                return self.build.static_cross_linker
+            else:
+                return self.build.static_linker
         if len(self.build.compilers) == 1:
             return self.build.compilers[0]
         # Currently a bit naive. C++ must

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -246,7 +246,7 @@ class Environment():
                 version = 'unknown version'
             if 'apple' in out and 'Free Software Foundation' in out:
                 return GnuCCompiler(ccache + [compiler], version, GCC_OSX, is_cross, exe_wrap)
-            if (out.startswith('cc') or 'gcc' in out) and \
+            if (out.startswith('cc') or 'gcc' in out.lower()) and \
                 'Free Software Foundation' in out:
                 lowerout = out.lower()
                 if 'mingw' in lowerout or 'msys' in lowerout or 'mingw' in compiler.lower():


### PR DESCRIPTION
1. `determine_linker()`: choose static cross linker for cross compiling
1. be more resilient for identifying gcc compilers