### PR TITLE
scripts: Use destdir_join fix for all DESTDIR prefixing

### DIFF
--- a/mesonbuild/scripts/__init__.py
+++ b/mesonbuild/scripts/__init__.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# Copyright 2016 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def destdir_join(d1, d2):
+    # c:\destdir + c:\prefix must produce c:\destdir\prefix
+    if len(d1) > 1 and d1[1] == ':' and \
+        len(d2) > 1 and d2[1] == ':':
+        return d1 + d2[2:]
+    return d1 + d2

--- a/mesonbuild/scripts/gettext.py
+++ b/mesonbuild/scripts/gettext.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import os, subprocess, shutil
+from mesonbuild.scripts import destdir_join
 
 def run_potgen(src_sub, pkgname, args):
     listfile = os.path.join(src_sub, 'POTFILES')
@@ -56,7 +57,8 @@ def run(args):
         langs = args[4:]
         src_sub = os.path.join(os.environ['MESON_SOURCE_ROOT'], subdir)
         bld_sub = os.path.join(os.environ['MESON_BUILD_ROOT'], subdir)
-        dest = os.environ.get('DESTDIR') + os.path.join(os.environ['MESON_INSTALL_PREFIX'], instsubdir)
+        destdir = os.environ.get('DESTDIR', '')
+        dest = destdir_join(destdir, os.path.join(os.environ['MESON_INSTALL_PREFIX'], instsubdir))
         if gen_gmo(src_sub, bld_sub, langs) != 0:
             return 1
         do_install(src_sub, bld_sub, dest, pkgname, langs)

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -17,6 +17,7 @@ import sys, os
 import subprocess
 import shutil
 import argparse
+from mesonbuild.scripts import destdir_join
 
 parser = argparse.ArgumentParser()
 
@@ -113,10 +114,8 @@ def run(args):
                  fixxrefargs)
 
     if 'MESON_INSTALL_PREFIX' in os.environ:
-        if 'DESTDIR' in os.environ:
-            installdir = os.environ['DESTDIR'] + os.environ['MESON_INSTALL_PREFIX']
-        else:
-            installdir = os.environ['MESON_INSTALL_PREFIX']
+        destdir = os.environ.get('DESTDIR', '')
+        installdir = destdir_join(destdir, os.environ['MESON_INSTALL_PREFIX'])
         install_gtkdoc(options.builddir,
                        options.subdir,
                        installdir,

--- a/mesonbuild/scripts/meson_install.py
+++ b/mesonbuild/scripts/meson_install.py
@@ -17,6 +17,7 @@
 import sys, pickle, os, shutil, subprocess, gzip, platform
 from glob import glob
 from mesonbuild.scripts import depfixer
+from mesonbuild.scripts import destdir_join
 
 def do_copy(from_file, to_file):
     try:
@@ -27,21 +28,10 @@ def do_copy(from_file, to_file):
     shutil.copyfile(from_file, to_file)
     shutil.copystat(from_file, to_file)
 
-def destdir_join(d1, d2):
-    # c:\destdir + c:\prefix must produce c:\destdir\prefix
-    if len(d1) > 1 and d1[1] == ':' and \
-        len(d2) > 1 and d2[1] == ':':
-        return d1 + d2[2:]
-    return d1 + d2
-
 def do_install(datafilename):
     ifile = open(datafilename, 'rb')
     d = pickle.load(ifile)
-    destdir_var = 'DESTDIR'
-    if destdir_var in os.environ:
-        d.destdir = os.environ[destdir_var]
-    else:
-        d.destdir = ''
+    d.destdir = os.environ.get('DESTDIR', '')
     d.fullprefix = destdir_join(d.destdir, d.prefix)
 
     install_subdirs(d) # Must be first, because it needs to delete the old subtree.


### PR DESCRIPTION
Also fixes a bug in the gettext module where an exception would be thrown if DESTDIR wasn't exported in the environment