### PR TITLE
A couple of simple fixes for generating MSVC pdb files

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -88,8 +88,8 @@ else:
                                          })
 
 msvc_buildtype_linker_args = {'plain' : [],
-                              'debug' : [],
-                              'debugoptimized' : [],
+                              'debug' : ['/DEBUG'],
+                              'debugoptimized' : ['/DEBUG'],
                               'release' : [],
                               'minsize' : ['/INCREMENTAL:NO'],
                               }

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1393,16 +1393,11 @@ class SwiftCompiler(Compiler):
 class VisualStudioCCompiler(CCompiler):
     std_warn_args = ['/W3']
     std_opt_args= ['/O2']
-    vs2010_always_args = ['/nologo', '/showIncludes']
-    vs2013_always_args = ['/nologo', '/showIncludes', '/FS']
 
     def __init__(self, exelist, version, is_cross, exe_wrap):
         CCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
         self.id = 'msvc'
-        if int(version.split('.')[0]) > 17:
-            self.always_args = VisualStudioCCompiler.vs2013_always_args
-        else:
-            self.always_args = VisualStudioCCompiler.vs2010_always_args
+        self.always_args = ['/nologo', '/showIncludes']
         self.warn_args = {'1': ['/W2'],
                           '2': ['/W3'],
                           '3': ['/w4']}
@@ -1449,9 +1444,17 @@ class VisualStudioCCompiler(CCompiler):
         return ['/Od']
 
     def get_output_args(self, target):
+        # Manually name the pdb file to avoid filename conflicts during parallel
+        # builds: failure due to 'cannot open program database vc140.pdb', etc.
+        #
+        # Only specify it for transient compiled object files because for an
+        # exe called something.exe the pdb filename is already something.pdb
+        #
+        # Will be ignored by the compiler if debug info generation is disabled
+        pdb_args = ['/Fd' + target.rsplit('.', 1)[0] + '.pdb']
         if target.endswith('.exe'):
             return ['/Fe' + target]
-        return ['/Fo' + target]
+        return pdb_args + ['/Fo' + target]
 
     def get_dependency_gen_args(self, outtarget, outfile):
         return []

--- a/test cases/common/86 same basename/meson.build
+++ b/test cases/common/86 same basename/meson.build
@@ -1,15 +1,22 @@
-project('same basename', 'c')
+project('same basename', 'c',
+  # Disable debugging otherwise the .pdb filenames for the DLL and EXE collide
+  # when building with MSVC
+  default_options : ['buildtype=release'])
+
+# Disable incremental linking lest the .ilk files for the DLL and EXE collide
+if meson.get_compiler('c').get_id() == 'msvc'
+  add_global_link_arguments('/INCREMENTAL:NO', language : 'c')
+endif
 
 # Use the same source file to check that each top level target
 # has its own unique working directory. If they don't
 # then the .o files will clobber each other.
 shlib = shared_library('name', 'lib.c', c_args : '-DSHAR')
+# Also create a static library of the same name to verify that there's no
+# filename collisions on Windows. This should output libname.a
+stlib = static_library('name', 'lib.c', c_args : '-DSTAT')
 
-# On Windows a static lib is a foo.lib but a share library
-# is both a foo.dll and a foo.lib. Put static in subdir to avoid
-# name clashes.
-subdir('sub')
-
+# Create an executable with the same name as the libraries above
 exe1 = executable('name', 'exe1.c', link_with : stlib)
 exe2 = executable('name2', 'exe2.c', link_with : shlib)
 

--- a/test cases/common/86 same basename/sub/meson.build
+++ b/test cases/common/86 same basename/sub/meson.build
@@ -1,1 +1,0 @@
-stlib = static_library('name', '../lib.c', c_args : '-DSTAT')


### PR DESCRIPTION
1) Without these flags to the linker, the compiler generates the debugging information but the linker discards it since it wasn't told to generate the corresponding `.pdb` file.

2) Passing `/FS` forces `.pdb` file writes to be serialized through `MSPDBSRV.exe` which slows down the build, and doesn't solve the concurrency issues with the use of a single temporary pdb file for all object files. Instead, use a separate one for each object file with `/Fd`. The commit message has more details.