### PR TITLE
Add custom_install_dir to ld path in pkgconfig module

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -37,3 +37,4 @@ Emmanuele Bassi
 Martin Hostettler
 Sam Thursfield
 Noam Meltzer
+Vincent Szolnoky

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -43,6 +43,8 @@ class PkgConfigModule:
             ofile.write('Libraries.private: {}\n'.format(' '.join(priv_libs)))
         ofile.write('Libs: -L${libdir} ')
         for l in libraries:
+            if l.custom_install_dir:
+                ofile.write('-L${prefix}/%s ' % l.custom_install_dir)
             ofile.write('-l%s ' % l.name)
         ofile.write('\n')
         ofile.write('CFlags: ')


### PR DESCRIPTION
Quite common to install shared libs into a subdirectory in the lib directory. Also just in general when they are just installed to a different place other than the standard lib directory.

For example in my projects I set `install_dir : get_option('libdir') + '/my-name'`, so that libs get installed to `/usr/lib/my-name/libmy-name.so` instead of straight into `/usr/lib/libmy-name.so`.