### PR TITLE
vs backends: Translate unix link and compile flags

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -495,7 +495,7 @@ class Vs2010Backend(backends.Backend):
                 extra_args[l] += args
         for l, args in target.extra_args.items():
             if l in extra_args:
-                extra_args[l] += args
+                extra_args[l] += compiler.unix_compile_flags_to_native(args)
         general_args = compiler.get_buildtype_args(self.buildtype).copy()
         # FIXME all the internal flags of VS (optimization etc) are represented
         # by their own XML elements. In theory we should split all flags to those
@@ -575,11 +575,8 @@ class Vs2010Backend(backends.Backend):
         extra_link_args = compiler.get_option_link_args(self.environment.coredata.compiler_options)
         extra_link_args += compiler.get_buildtype_linker_args(self.buildtype)
         for l in self.environment.coredata.external_link_args.values():
-            for a in l:
-                extra_link_args.append(a)
-        for l in target.link_args:
-            for a in l:
-                extra_link_args.append(a)
+            extra_link_args += compiler.unix_link_flags_to_native(l)
+        extra_link_args += compiler.unix_link_flags_to_native(target.link_args)
         if len(extra_link_args) > 0:
             extra_link_args.append('%(AdditionalOptions)')
             ET.SubElement(link, "AdditionalOptions").text = ' '.join(extra_link_args)


### PR DESCRIPTION
We allow build files to contain (at least) -l and -L link flags, and we filter out MinGW-specific compiler flags that are not valid or needed with MSVC such as -mms-bitfields. So convert those to msvc-style arguments in the same way that the Ninja backend does.

Global arguments, build type arguments, etc which are always compiler-specific don't need to be translated.