### PR TITLE
dependency: Fix version check for a not-found dependency

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1644,7 +1644,7 @@ class Interpreter():
             if 'version' in kwargs:
                 wanted = kwargs['version']
                 found = cached_dep.get_version()
-                if not found or not mesonlib.version_compare(found, wanted):
+                if not cached_dep.found() or not mesonlib.version_compare(found, wanted):
                     # Cached dep has the wrong version. Check if an external
                     # dependency or a fallback dependency provides it.
                     cached_dep = None

--- a/test cases/linuxlike/5 dependency versions/meson.build
+++ b/test cases/linuxlike/5 dependency versions/meson.build
@@ -9,6 +9,10 @@ assert(zlib.version() == zlibver.version(), 'zlib versions did not match!')
 zlibver = dependency('zlib', version : '<1.0', required : false)
 assert(zlibver.found() == false, 'zlib <1.0 should not be found!')
 
+# Test https://github.com/mesonbuild/meson/pull/610
+dependency('somebrokenlib', version : '>=2.0', required : false)
+dependency('somebrokenlib', version : '>=1.0', required : false)
+
 # Find internal dependency without version
 somelibver = dependency('somelib',
   fallback : ['somelibnover', 'some_dep'])


### PR DESCRIPTION
The check was wrong, and we were passing 'none' as the 'found' version to the version compare if the cached dep was a not-found dependency