### PR TITLE
gnome.py: typelib files should be installed in libdir

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -228,9 +228,7 @@ class GnomeModule:
 
         kwargs['output'] = typelib_output
         kwargs['command'] = typelib_cmd
-        # Note that this can't be libdir, because e.g. on Debian it points to
-        # lib/x86_64-linux-gnu but the girepo dir is always under lib.
-        kwargs['install_dir'] = 'lib/girepository-1.0'
+        kwargs['install_dir'] = os.path.join(state.environment.get_libdir(), 'girepository-1.0')
         typelib_target = TypelibTarget(typelib_output, state.subdir, kwargs)
         return [scan_target, typelib_target]
 


### PR DESCRIPTION
The typelib files should be installed in libdir, even on debian (which
has them in /usr/lib/x86_64-linux-gnu/girepository-1.0/).