### PR TITLE
Add a Vala test generating GIR and typelib files

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1032,10 +1032,14 @@ int dummy;
             valac_outputs.append(hname)
             # Outputted vapi file
             vapiname = os.path.join(self.get_target_dir(target), target.vala_vapi)
-            # Force valac to write the vapi file in the target build dir.
+            # Force valac to write the vapi and gir files in the target build dir.
             # Without this, it will write it inside c_out_dir
             args += ['--vapi', os.path.join('..', target.vala_vapi)]
             valac_outputs.append(vapiname)
+            if isinstance(target.vala_gir, str):
+                girname = os.path.join(self.get_target_dir(target), target.vala_gir)
+                args += ['--gir', os.path.join('..',  target.vala_gir)]
+                valac_outputs.append(girname)
         if self.environment.coredata.get_builtin_option('werror'):
             args += valac.get_werror_args()
         for d in target.get_external_deps():

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -57,6 +57,7 @@ known_lib_kwargs.update({'version' : True, # Only for shared libs
                          'vs_module_defs' : True, # Only for shared libs
                          'vala_header': True,
                          'vala_vapi': True,
+                         'vala_gir' : True,
                          'pic' : True, # Only for static libs
                         })
 
@@ -498,6 +499,7 @@ class BuildTarget():
         if not isinstance(self, Executable):
             self.vala_header = kwargs.get('vala_header', self.name + '.h')
             self.vala_vapi = kwargs.get('vala_vapi', self.name + '.vapi')
+        self.vala_gir = kwargs.get('vala_gir', None)
         dlist = stringlistify(kwargs.get('d_args', []))
         self.add_compiler_args('d', dlist)
         self.link_args = kwargs.get('link_args', [])

--- a/test cases/vala/9 gir/foo.vala
+++ b/test cases/vala/9 gir/foo.vala
@@ -1,0 +1,7 @@
+namespace Foo
+{
+	public int bar ()
+	{
+		return 0;
+	}
+}

--- a/test cases/vala/9 gir/meson.build
+++ b/test cases/vala/9 gir/meson.build
@@ -1,0 +1,16 @@
+project('foo', 'c', 'vala')
+
+glib = dependency('glib-2.0')
+gobject = dependency('gobject-2.0')
+g_ir_compiler = find_program('g-ir-compiler')
+
+foo = shared_library('foo', 'foo.vala',
+                     vala_gir: 'Foo-1.0.gir',
+                     dependencies: [glib, gobject])
+
+custom_target('foo-typelib',
+              command: [g_ir_compiler, '--output', '@OUTPUT@', '@INPUT@'],
+              input: meson.current_build_dir() + '/Foo-1.0.gir',
+              output: 'Foo-1.0.typelib',
+              depends: foo)
+


### PR DESCRIPTION
There's been some questions on IRC about setting up the build to use specific features of the Vala compiler and considering the lack of examples, I decided to write some more.

I don't like adding `foo@sha` in the path, but I couldn't figure another way of doing this. Maybe adding a `vala_gir` option?
