### PR TITLE
environment: Don't add CFLAGS to link_args

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -696,23 +696,23 @@ class Environment():
 def get_args_from_envvars(lang):
     if lang == 'c':
         compile_args = os.environ.get('CFLAGS', '').split()
-        link_args = compile_args + os.environ.get('LDFLAGS', '').split()
+        link_args = os.environ.get('LDFLAGS', '').split()
         compile_args += os.environ.get('CPPFLAGS', '').split()
     elif lang == 'cpp':
         compile_args = os.environ.get('CXXFLAGS', '').split()
-        link_args = compile_args + os.environ.get('LDFLAGS', '').split()
+        link_args = os.environ.get('LDFLAGS', '').split()
         compile_args += os.environ.get('CPPFLAGS', '').split()
     elif lang == 'objc':
         compile_args = os.environ.get('OBJCFLAGS', '').split()
-        link_args = compile_args + os.environ.get('LDFLAGS', '').split()
+        link_args = os.environ.get('LDFLAGS', '').split()
         compile_args += os.environ.get('CPPFLAGS', '').split()
     elif lang == 'objcpp':
         compile_args = os.environ.get('OBJCXXFLAGS', '').split()
-        link_args = compile_args + os.environ.get('LDFLAGS', '').split()
+        link_args = os.environ.get('LDFLAGS', '').split()
         compile_args += os.environ.get('CPPFLAGS', '').split()
     elif lang == 'fortran':
         compile_args = os.environ.get('FFLAGS', '').split()
-        link_args = compile_args + os.environ.get('LDFLAGS', '').split()
+        link_args = os.environ.get('LDFLAGS', '').split()
     else:
         compile_args = []
         link_args = []


### PR DESCRIPTION
Linkers don't always understand compiler flags and almost never need them. When the linker is not the same as the compiler, this can even cause a build error or several hundred warnings.

This is particularly problematic with MSVC. Each flag added to `CFLAGS` also gets passed to `link.exe` and causes a warning for each and every linker invocation.

I'm not aware of any other build system that does this, so I don't think we should do it either. There are toolchain-specific ways of passing flags to the linker via the compiler already.