### PR TITLE
tests: Don't fail wxwidgets test if wxwidgets is not installed

### DIFF
--- a/test cases/frameworks/9 wxwidgets/meson.build
+++ b/test cases/frameworks/9 wxwidgets/meson.build
@@ -1,8 +1,9 @@
 project('wxwidgets test', 'cpp')
 
-wxd = dependency('wxwidgets', version : '>=3.0.0')
+wxd = dependency('wxwidgets', version : '>=3.0.0', required : false)
 
-wp = executable('wxprog', 'wxprog.cpp',
-dependencies : wxd)
+if wxd.found()
+  wp = executable('wxprog', 'wxprog.cpp', dependencies : wxd)
 
-test('wxtest', wp)
+  test('wxtest', wp)
+endif


### PR DESCRIPTION
The widgets pull in lots of deprecated libraries, so don't require it