### PR TITLE
Normalize the path of a configured file to avoid dupes

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1822,7 +1822,7 @@ rule FORTRAN_DEP_HACK
 
         ninja_command = environment.detect_ninja()
         if ninja_command is None:
-            raise MesonException('Could not detect ninja command')
+            raise MesonException('Could not detect Ninja v1.6 or newer)')
         elem = NinjaBuildElement(self.all_outputs, 'clean', 'CUSTOM_COMMAND', 'PHONY')
         elem.add_item('COMMAND', [ninja_command, '-t', 'clean'])
         elem.add_item('description', 'Cleaning')

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -45,11 +45,13 @@ def find_valgrind():
 def detect_ninja():
     for n in ['ninja', 'ninja-build']:
         try:
-            p = subprocess.Popen([n, '--version'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            p = subprocess.Popen([n, '--version'], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
         except FileNotFoundError:
             continue
-        p.communicate()
-        if p.returncode == 0:
+        version = p.communicate()[0].decode(errors='ignore')
+        # Perhaps we should add a way for the caller to know the failure mode
+        # (not found or too old)
+        if p.returncode == 0 and mesonlib.version_compare(version, ">=1.6"):
             return n
 
 def detect_cpu_family():

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1987,7 +1987,9 @@ class Interpreter():
                 raise InterpreterException('Argument "configuration" is not of type configuration_data')
             ofile_abs = os.path.join(self.environment.build_dir, self.subdir, output)
             if inputfile is not None:
-                conffile = os.path.join(self.subdir, inputfile)
+                # Normalize the path of the conffile to avoid duplicates
+                # This is especially important to convert '/' to '\' on Windows
+                conffile = os.path.normpath(os.path.join(self.subdir, inputfile))
                 if conffile not in self.build_def_files:
                     self.build_def_files.append(conffile)
                 os.makedirs(os.path.join(self.environment.build_dir, self.subdir), exist_ok=True)

--- a/run_cross_test.py
+++ b/run_cross_test.py
@@ -34,7 +34,7 @@ meson_command = './meson.py'
 extra_flags = ['--cross-file', sys.argv[1]]
 ninja_command = environment.detect_ninja()
 if ninja_command is None:
-    raise RuntimeError('Could not find Ninja executable.')
+    raise RuntimeError('Could not find Ninja v1.6 or newer')
 compile_commands = [ninja_command]
 test_commands = [ninja_command, 'test']
 install_commands = [ninja_command, 'install']

--- a/run_tests.py
+++ b/run_tests.py
@@ -116,7 +116,7 @@ def setup_commands(backend):
         backend_flags = []
         ninja_command = environment.detect_ninja()
         if ninja_command is None:
-            raise RuntimeError('Could not find Ninja executable.')
+            raise RuntimeError('Could not find Ninja v1.6 or newer')
         if print_debug:
             compile_commands = [ninja_command, '-v']
         else:

--- a/run_tests.py
+++ b/run_tests.py
@@ -121,6 +121,7 @@ def setup_commands(backend):
             compile_commands = [ninja_command, '-v']
         else:
             compile_commands = [ninja_command]
+        compile_commands += ['-w', 'dupbuild=err']
         test_commands = [ninja_command, 'test', 'benchmark']
         install_commands = [ninja_command, 'install']
 

--- a/test cases/common/114 multiple dir configure file/meson.build
+++ b/test cases/common/114 multiple dir configure file/meson.build
@@ -1,0 +1,7 @@
+project('multiple dir configure file', 'c')
+
+subdir('subdir')
+
+configure_file(input : 'subdir/someinput.in',
+  output : 'outputhere',
+  configuration : configuration_data())

--- a/test cases/common/114 multiple dir configure file/subdir/meson.build
+++ b/test cases/common/114 multiple dir configure file/subdir/meson.build
@@ -1,0 +1,4 @@
+configure_file(input : 'someinput.in',
+  output : 'outputsubdir',
+  install : false,
+  configuration : configuration_data())


### PR DESCRIPTION
Several targets can refer to the same input file to configure_file in different paths, so normalize it to avoid duplicate filenames in the build file. Ninja warns about this, and we test for it too now.

This is easy to reproduce with the attached test case on Windows. The conffile gets added once as `subdir/testinput.in` and once as `subdir\testinput.in`. Then the first path is converted to the second path while writing out the Ninja build file. `os.path.normpath` converts `/` to `\` and avoids it in the first place.

Again, this would not have been a problem if we used an immutable `File` type. ;)