### PR TITLE
vs: Fix Meson invocation while doing regen

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -127,6 +127,7 @@ class Environment():
             self.first_invocation = False
         except FileNotFoundError:
             self.coredata = coredata.CoreData(options)
+            self.coredata.meson_script_file = self.meson_script_file
             self.first_invocation = True
         if self.coredata.cross_file:
             self.cross_info = CrossBuildInfo(self.coredata.cross_file)

--- a/mesonbuild/scripts/regen_checker.py
+++ b/mesonbuild/scripts/regen_checker.py
@@ -33,25 +33,28 @@ def need_regen(regeninfo, regen_timestamp):
     Vs2010Backend.touch_regen_timestamp(regeninfo.build_dir)
     return False
 
-def regen(regeninfo):
+def regen(regeninfo, mesonscript, backend):
     scriptdir = os.path.split(__file__)[0]
-    mesonscript = os.path.join(scriptdir, '../../', 'meson')
     cmd = [sys.executable,
            mesonscript,
            '--internal',
            'regenerate',
            regeninfo.build_dir,
            regeninfo.source_dir,
-           '--backend=vs2010']
+           '--backend=' + backend]
     subprocess.check_call(cmd)
 
 def run(args):
     private_dir = args[0]
     dumpfile = os.path.join(private_dir, 'regeninfo.dump')
+    coredata = os.path.join(private_dir, 'coredata.dat')
     regeninfo = pickle.load(open(dumpfile, 'rb'))
+    coredata = pickle.load(open(coredata, 'rb'))
+    mesonscript = coredata.meson_script_file
+    backend = coredata.get_builtin_option('backend')
     regen_timestamp = os.stat(dumpfile).st_mtime
     if need_regen(regeninfo, regen_timestamp):
-        regen(regeninfo)
+        regen(regeninfo, mesonscript, backend)
     sys.exit(0)
 
 if __name__ == '__main__':


### PR DESCRIPTION
The Meson script is not always in `$scriptdir/../../` -- for instance if installed with `pip` on Windows, the scriptdir is in:
```
C:/Python35/Lib/site-packages/meson-0.33.0.dev1-py3.5.egg.disabled/mesonbuild/scripts
```
and the meson.py script is in:
```
C:/Python35/Scripts
```
So, let's save the path available as `Environment().meson_script_file` into the `coredata.dat` private file and use that to invoke Meson when doing regen.

Also, let's fetch the backend that was used from the coredata too instead of hard-coding vs2010. Both these were causing a hard failure while doing regen with msbuild or visual studio.