### PR TITLE
vs: Fix visual studio version in solution file

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -61,6 +61,7 @@ class Vs2010Backend(backends.Backend):
         self.project_file_version = '10.0.30319.1'
         self.sources_conflicts = {}
         self.platform_toolset = None
+        self.vs_version = '2010'
 
     def object_filename_from_source(self, target, source):
         basename = os.path.basename(source.fname)
@@ -218,7 +219,7 @@ class Vs2010Backend(backends.Backend):
     def generate_solution(self, sln_filename, projlist):
         ofile = open(sln_filename, 'w')
         ofile.write('Microsoft Visual Studio Solution File, Format Version 11.00\n')
-        ofile.write('# Visual Studio 2010\n')
+        ofile.write('# Visual Studio ' + self.vs_version + '\n')
         prj_templ = prj_line = 'Project("{%s}") = "%s", "%s", "{%s}"\n'
         for p in projlist:
             prj_line = prj_templ % (self.environment.coredata.guid, p[0], p[1], p[2])

--- a/mesonbuild/backend/vs2015backend.py
+++ b/mesonbuild/backend/vs2015backend.py
@@ -20,6 +20,7 @@ class Vs2015Backend(Vs2010Backend):
     def __init__(self, build):
         super().__init__(build)
         self.platform_toolset = 'v140'
+        self.vs_version = '2015'
 
     @staticmethod
     def has_objects(objects, additional_objects, generated_objects):


### PR DESCRIPTION
This version is used by `explorer.exe` and other tools to guess what version of Visual Studio this solution corresponds to (filetype detection). It changes at least the icon shown for the file in explorer for me.