### PR TITLE
Port gtk-doc module to the latest RunTarget syntax

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -290,7 +290,7 @@ class GnomeModule:
         args += self.unpack_args('--htmlargs=', 'html_args', kwargs)
         args += self.unpack_args('--scanargs=', 'scan_args', kwargs)
         args += self.unpack_args('--fixxrefargs=', 'fixxref_args', kwargs)
-        res = [build.RunTarget(targetname, command[0], command[1:] + args, state.subdir)]
+        res = [build.RunTarget(targetname, command[0], command[1:] + args, [], state.subdir)]
         if kwargs.get('install', True):
             res.append(build.InstallScript(command + args))
         return res


### PR DESCRIPTION
Also print status code and stdout/stderr on error while running gtk-doc utils.

We still can't enable the gtk-doc test because of https://bugzilla.gnome.org/show_bug.cgi?id=769125, but I've tested that it passes if I apply the patch on that bug manually.