### PR TITLE
find_program: Find scripts without extensions on Windows

### DIFF
--- a/test cases/windows/9 find program/meson.build
+++ b/test cases/windows/9 find program/meson.build
@@ -1,0 +1,4 @@
+project('find program', 'c')
+
+prog = find_program('test-script')
+test('script', prog)

--- a/test cases/windows/9 find program/test-script
+++ b/test cases/windows/9 find program/test-script
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+print('1')


### PR DESCRIPTION
Because of how files and executables work on Windows, scripts that use an interpreter must have an extension, and that extension must be associated with an interpreter. The full list of executable extensions is available in the PATHEXT environment variable.

However, UNIX-like OSes use an executable bit and read the shebang to figure out what interpreter to use, and the scripts don't need to have extensions. We can now detect these scripts using find_program by manually searching in PATH and reading the shebang.
