### PR TITLE
Two changes to how we inherit cflags/linkflags from the environment

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1255,7 +1255,7 @@ class ValaCompiler(Compiler):
         return False # Because compiles into C.
 
     def get_exelist(self):
-        return self.exelist
+        return self.exelist[:]
 
     def get_werror_args(self):
         return ['--fatal-warnings']
@@ -1299,7 +1299,7 @@ class RustCompiler(Compiler):
         return ' '.join(self.exelist)
 
     def get_exelist(self):
-        return self.exelist
+        return self.exelist[:]
 
     def get_id(self):
         return self.id
@@ -1343,7 +1343,7 @@ class SwiftCompiler(Compiler):
         return self.id
 
     def get_linker_exelist(self):
-        return self.exelist
+        return self.exelist[:]
 
     def name_string(self):
         return ' '.join(self.exelist)
@@ -1352,7 +1352,7 @@ class SwiftCompiler(Compiler):
         return True
 
     def get_exelist(self):
-        return self.exelist
+        return self.exelist[:]
 
     def get_werror_args(self):
         return ['--fatal-warnings']
@@ -1973,7 +1973,7 @@ class FortranCompiler(Compiler):
         return ' '.join(self.exelist)
 
     def get_exelist(self):
-        return self.exelist
+        return self.exelist[:]
 
     def get_language(self):
         return self.language
@@ -2240,7 +2240,7 @@ class VisualStudioLinker():
         self.exelist = exelist
 
     def get_exelist(self):
-        return self.exelist
+        return self.exelist[:]
 
     def get_std_link_args(self):
         return []
@@ -2292,7 +2292,7 @@ class ArLinker():
         return []
 
     def get_exelist(self):
-        return self.exelist
+        return self.exelist[:]
 
     def get_std_link_args(self):
         return self.std_args

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import os, re, subprocess, platform
-from . import coredata, mesonlib
+from . import coredata
+from . import mesonlib
+from . import mlog
 from .compilers import *
 import configparser
 
@@ -700,29 +702,40 @@ class Environment():
 
 
 def get_args_from_envvars(lang):
-    if lang == 'c':
-        compile_args = os.environ.get('CFLAGS', '').split()
-        link_args = compile_args + os.environ.get('LDFLAGS', '').split()
-        compile_args += os.environ.get('CPPFLAGS', '').split()
-    elif lang == 'cpp':
-        compile_args = os.environ.get('CXXFLAGS', '').split()
-        link_args = compile_args + os.environ.get('LDFLAGS', '').split()
-        compile_args += os.environ.get('CPPFLAGS', '').split()
-    elif lang == 'objc':
-        compile_args = os.environ.get('OBJCFLAGS', '').split()
-        link_args = compile_args + os.environ.get('LDFLAGS', '').split()
-        compile_args += os.environ.get('CPPFLAGS', '').split()
-    elif lang == 'objcpp':
-        compile_args = os.environ.get('OBJCXXFLAGS', '').split()
-        link_args = compile_args + os.environ.get('LDFLAGS', '').split()
-        compile_args += os.environ.get('CPPFLAGS', '').split()
-    elif lang == 'fortran':
-        compile_args = os.environ.get('FFLAGS', '').split()
-        link_args = compile_args + os.environ.get('LDFLAGS', '').split()
-    else:
-        compile_args = []
-        link_args = []
-    return (compile_args, link_args)
+    """
+    @lang: Language to fetch environment flags for
+
+    Returns a tuple of (compile_flags, link_flags) for the specified language
+    from the inherited environment
+    """
+    def log_var(var, val):
+        if val:
+            mlog.log('Appending {} from environment: {!r}'.format(var, val))
+
+    if lang not in ('c', 'cpp', 'objc', 'objcpp', 'fortran'):
+        return ([], [])
+
+    # Compile flags
+    cflags_mapping = {'c': 'CFLAGS', 'cpp': 'CXXFLAGS',
+        'objc': 'OBJCFLAGS', 'objcpp': 'OBJCXXFLAGS',
+        'fortran': 'FFLAGS'}
+    compile_flags = os.environ.get(cflags_mapping[lang], '')
+    log_var(cflags_mapping[lang], compile_flags)
+    compile_flags = compile_flags.split()
+
+    # Link flags (same for all languages)
+    link_flags = os.environ.get('LDFLAGS', '')
+    log_var('LDFLAGS', link_flags)
+    link_flags = link_flags.split()
+
+    # Pre-processof rlags (not for fortran)
+    preproc_flags = ''
+    if lang in ('c', 'cpp', 'objc', 'objcpp'):
+        preproc_flags = os.environ.get('CPPFLAGS', '')
+    log_var('CPPFLAGS', preproc_flags)
+    preproc_flags = preproc_flags.split()
+
+    return (compile_flags + preproc_flags, link_flags + compile_flags)
 
 class CrossBuildInfo():
     def __init__(self, filename):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1619,8 +1619,11 @@ class Interpreter():
                     else:
                         raise
             mlog.log('Native %s compiler: ' % lang, mlog.bold(' '.join(comp.get_exelist())), ' (%s %s)' % (comp.id, comp.version), sep='')
+            compiler_is_linker = False
+            if hasattr(comp, 'get_linker_exelist'):
+                compiler_is_linker = (comp.get_exelist() == comp.get_linker_exelist())
             if not comp.get_language() in self.coredata.external_args:
-                (ext_compile_args, ext_link_args) = environment.get_args_from_envvars(comp.get_language())
+                (ext_compile_args, ext_link_args) = environment.get_args_from_envvars(comp.get_language(), compiler_is_linker)
                 self.coredata.external_args[comp.get_language()] = ext_compile_args
                 self.coredata.external_link_args[comp.get_language()] = ext_link_args
             self.build.add_compiler(comp)


### PR DESCRIPTION
a) Print what we inherit

b) Only append compile flags to the link flags when the linker is the same as the compiler