### PR TITLE
Add a test to find libfoo.X.dylib via -lfoo

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -814,12 +814,10 @@ class SharedLibrary(BuildTarget):
         elif for_darwin(is_cross, env):
             prefix = 'lib'
             suffix = 'dylib'
-            if self.soversion:
-                # libfoo.X.dylib
-                self.filename_tpl = '{0.prefix}{0.name}.{0.soversion}.{0.suffix}'
-            else:
-                # libfoo.dylib
-                self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
+            # libfoo.dylib
+            self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
+            # On OS X, the filename should never have the soversion
+            # See: https://github.com/mesonbuild/meson/pull/680
         else:
             prefix = 'lib'
             suffix = 'so'

--- a/test cases/osx/2 library versions/exe.orig.c
+++ b/test cases/osx/2 library versions/exe.orig.c
@@ -1,0 +1,4 @@
+int
+main (int argc, char *argv[])
+{
+}

--- a/test cases/osx/2 library versions/installed_files.txt
+++ b/test cases/osx/2 library versions/installed_files.txt
@@ -1,4 +1,4 @@
-usr/lib/libsome.0.dylib
+usr/lib/libsome.dylib
 usr/lib/libnoversion.dylib
-usr/lib/libonlyversion.1.dylib
-usr/lib/libonlysoversion.5.dylib
+usr/lib/libonlyversion.dylib
+usr/lib/libonlysoversion.dylib

--- a/test cases/osx/2 library versions/meson.build
+++ b/test cases/osx/2 library versions/meson.build
@@ -1,18 +1,41 @@
 project('library versions', 'c')
 
-shared_library('some', 'lib.c',
+some = shared_library('some', 'lib.c',
   version : '1.2.3',
   soversion : '0',
   install : true)
 
-shared_library('noversion', 'lib.c',
+noversion = shared_library('noversion', 'lib.c',
   install : true)
 
-shared_library('onlyversion', 'lib.c',
+onlyversion = shared_library('onlyversion', 'lib.c',
   version : '1.4.5',
   install : true)
 
-shared_library('onlysoversion', 'lib.c',
+onlysoversion = shared_library('onlysoversion', 'lib.c',
   # Also test that int soversion is acceptable
   soversion : 5,
   install : true)
+
+# Hack to make the executables below depend on the shared libraries above
+# without actually adding them as `link_with` dependencies since we want to try
+# linking to them with -lfoo linker arguments.
+out = custom_target('library-dependency-hack',
+  input : 'exe.orig.c',
+  output : 'exe.c',
+  depends : [some, noversion, onlyversion, onlysoversion],
+  command : ['cp', '@INPUT@', '@OUTPUT@'])
+
+# Manually test if the linker can find the above libraries
+# i.e., whether they were generated with the right naming scheme
+executable('manuallink1', out,
+  link_args : ['-L.', '-lsome'])
+
+executable('manuallink2', out,
+  link_args : ['-L.', '-lnoversion'])
+
+executable('manuallink3', out,
+  link_args : ['-L.', '-lonlyversion'])
+
+executable('manuallink4', out,
+  link_args : ['-L.', '-lonlysoversion'])


### PR DESCRIPTION
Alex Băluț reported that on OS X `libfoo.0.dylib` cannot be found as `-lfoo` by the linker, and you must use `-lfoo.0` instead. Add a test for this so the CI can catch such problems. The next commit will contain the fix.

(Please don't push this yet. I want to use the CI to test my fix since I don't have access to an OS X machine right now.)