### PR TITLE
Create pdb files with MSVC

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -118,6 +118,12 @@ class Backend():
             return os.path.join(self.get_target_dir(target), target.get_filename())
         raise AssertionError('BUG: Tried to link to something that\'s not a library')
 
+    def get_target_debug_filename(self, target):
+        fname = target.get_debug_filename()
+        if not fname:
+            raise AssertionError("BUG: Tried to generate debug filename when it doesn't exist")
+        return os.path.join(self.get_target_dir(target), fname)
+
     def get_target_dir(self, target):
         if self.environment.coredata.get_builtin_option('layout') == 'mirror':
             dirname = target.get_subdir()

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1521,6 +1521,7 @@ rule FORTRAN_DEP_HACK
             commands+= compiler.get_include_args(i, False)
         if self.environment.coredata.base_options.get('b_pch', False):
             commands += self.get_pch_include_args(compiler, target)
+        commands += compiler.get_compile_debugfile_args(rel_obj)
         crstr = ''
         if target.is_cross:
             crstr = '_CROSS'

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1521,7 +1521,8 @@ rule FORTRAN_DEP_HACK
             commands+= compiler.get_include_args(i, False)
         if self.environment.coredata.base_options.get('b_pch', False):
             commands += self.get_pch_include_args(compiler, target)
-        commands += compiler.get_compile_debugfile_args(rel_obj)
+
+        commands += compiler.get_compile_debugfile_args(self.get_target_filename_abs(target))
         crstr = ''
         if target.is_cross:
             crstr = '_CROSS'
@@ -1590,6 +1591,8 @@ rule FORTRAN_DEP_HACK
         just_name = os.path.split(header)[1]
         (objname, pch_args) = compiler.gen_pch_args(just_name, source, dst)
         commands += pch_args
+        tfilename = self.get_target_filename_abs(target)
+        commands += compiler.get_compile_debugfile_args(tfilename)
         dep = dst + '.' + compiler.get_depfile_suffix()
         return (commands, dep, dst, [objname])
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1433,19 +1433,6 @@ rule FORTRAN_DEP_HACK
             return []
         return compiler.get_no_stdinc_args()
 
-
-    def get_pdb_name_suffix(self, target):
-        if isinstance(target, build.Executable):
-            suffix = '__exe'
-        elif isinstance(target, build.SharedLibrary):
-            suffix = '__dll'
-        elif isinstance(target, build.StaticLibrary):
-            suffix = '__lib'
-        else:
-            raise MesonException('Tried to build PDB for a non-buildtarget. Please file a bug.')
-        return suffix
-
-
     def get_compile_debugfile_args(self, compiler, target, objfile):
         if compiler.id != 'msvc':
             return []
@@ -1473,16 +1460,14 @@ rule FORTRAN_DEP_HACK
         #
         # If you feel that the above is completely wrong and all of this is
         # actually doable, please send patches.
-        suffix = self.get_pdb_name_suffix(target)
         if target.has_pch():
             tfilename = self.get_target_filename_abs(target)
-            return compiler.get_compile_debugfile_args(tfilename, suffix)
+            return compiler.get_compile_debugfile_args(tfilename)
         else:
-            return compiler.get_compile_debugfile_args(objfile, suffix)
+            return compiler.get_compile_debugfile_args(objfile)
 
     def get_link_debugfile_args(self, linker, target, outname):
-        suffix = self.get_pdb_name_suffix(target)
-        return linker.get_link_debugfile_args(outname, suffix)
+        return linker.get_link_debugfile_args(outname)
 
     def generate_single_compile(self, target, outfile, src, is_generated=False, header_deps=[], order_deps=[]):
         if(isinstance(src, str) and src.endswith('.h')):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -523,6 +523,13 @@ int dummy;
                 else:
                     # XXX: Add BuildTarget-specific install dir cases here
                     outdir = self.environment.get_libdir()
+                if isinstance(t, build.SharedLibrary) or isinstance(t, build.Executable):
+                    if t.get_debug_filename():
+                        # Install the debug symbols file in the same place as
+                        # the target itself. It has no aliases, should not be
+                        # stripped, and doesn't have an install_rpath
+                        i = [self.get_target_debug_filename(t), outdir, [], False, '']
+                        d.targets.append(i)
                 i = [self.get_target_filename(t), outdir, t.get_aliaslist(),\
                     should_strip, t.install_rpath]
                 d.targets.append(i)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1669,6 +1669,7 @@ rule FORTRAN_DEP_HACK
                                                      linker)
         commands += linker.get_buildtype_linker_args(self.environment.coredata.get_builtin_option('buildtype'))
         commands += linker.get_option_link_args(self.environment.coredata.compiler_options)
+        commands += linker.get_link_debugfile_args(outname)
         if not(isinstance(target, build.StaticLibrary)):
             commands += self.environment.coredata.external_link_args[linker.get_language()]
         if isinstance(target, build.Executable):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -205,6 +205,8 @@ class BuildTarget():
         self.link_targets = []
         self.link_depends = []
         self.filename = 'no_name'
+        # The file with debugging symbols
+        self.debug_filename = None
         self.need_install = False
         self.pch = {}
         self.extra_args = {}
@@ -466,6 +468,15 @@ class BuildTarget():
     def get_filename(self):
         return self.filename
 
+    def get_debug_filename(self):
+        """
+        The name of the file that contains debugging symbols for this target
+
+        Returns None if there are no debugging symbols or if they are embedded
+        in the filename itself
+        """
+        return self.debug_filename
+
     def get_extra_args(self, language):
         return self.extra_args.get(language, [])
 
@@ -708,6 +719,11 @@ class Executable(BuildTarget):
         self.filename = self.name
         if self.suffix:
             self.filename += '.' + self.suffix
+        # See determine_debug_filenames() in build.SharedLibrary
+        buildtype = environment.coredata.get_builtin_option('buildtype')
+        if compiler_is_msvc(self.sources, is_cross, environment) and \
+           buildtype.startswith('debug'):
+            self.debug_filename = self.prefix + self.name + '.pdb'
 
     def type_suffix(self):
         return "@exe"
@@ -733,6 +749,11 @@ class StaticLibrary(BuildTarget):
             else:
                 self.suffix = 'a'
         self.filename = self.prefix + self.name + '.' + self.suffix
+        # See determine_debug_filenames() in build.SharedLibrary
+        buildtype = environment.coredata.get_builtin_option('buildtype')
+        if compiler_is_msvc(self.sources, is_cross, environment) and \
+           buildtype.startswith('debug'):
+            self.debug_filename = self.prefix + self.name + '.pdb'
 
     def type_suffix(self):
         return "@sta"
@@ -755,6 +776,7 @@ class SharedLibrary(BuildTarget):
             self.suffix = None
         self.basic_filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
         self.determine_filenames(is_cross, environment)
+        self.determine_debug_filenames(is_cross, environment)
 
     def determine_filenames(self, is_cross, env):
         """
@@ -845,6 +867,21 @@ class SharedLibrary(BuildTarget):
         if self.suffix == None:
             self.suffix = suffix
         self.filename = self.filename_tpl.format(self)
+
+    def determine_debug_filenames(self, is_cross, env):
+        """
+        Determine the debug filename(s) using the prefix/name/etc detected in
+        determine_filenames() above.
+        """
+        buildtype = env.coredata.get_builtin_option('buildtype')
+        if compiler_is_msvc(self.sources, is_cross, env) and buildtype.startswith('debug'):
+            # Currently we only implement separate debug symbol files for MSVC
+            # since the toolchain does it for us. Other toolchains embed the
+            # debugging symbols in the file itself by default.
+            if self.soversion:
+                self.debug_filename = '{0.prefix}{0.name}-{0.soversion}.pdb'.format(self)
+            else:
+                self.debug_filename = '{0.prefix}{0.name}.pdb'.format(self)
 
     def process_kwargs(self, kwargs, environment):
         super().process_kwargs(kwargs, environment)

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -357,6 +357,9 @@ class Compiler():
     def get_compile_debugfile_args(self, rel_obj):
         return []
 
+    def get_link_debugfile_args(self, rel_obj):
+        return []
+
 class CCompiler(Compiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None):
         super().__init__(exelist, version)
@@ -1608,6 +1611,10 @@ class VisualStudioCCompiler(CCompiler):
         pdbarr = rel_obj.split('.')[:-1] + ['pdb']
         return ['/Fd' + '.'.join(pdbarr)]
 
+    def get_link_debugfile_args(self, targetfile):
+        pdbarr = targetfile.split('.')[:-1] + ['pdb']
+        return ['/DEBUG', '/PDB:' + '.'.join(pdbarr)]
+
 class VisualStudioCPPCompiler(VisualStudioCCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrap):
         VisualStudioCCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
@@ -2283,6 +2290,10 @@ class VisualStudioLinker():
 
     def unix_compile_flags_to_native(self, args):
         return args[:]
+
+    def get_link_debugfile_args(self, targetfile):
+        pdbarr = targetfile.split('.')[:-1] + ['pdb']
+        return ['/DEBUG', '/PDB:' + '.'.join(pdbarr)]
 
 class ArLinker():
 

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -352,6 +352,11 @@ class Compiler():
     def get_colorout_args(self, colortype):
         return []
 
+    # Some compilers (msvc) write debug info to a separate file.
+    # These args specify where it should be written.
+    def get_compile_debugfile_args(self, rel_obj):
+        return []
+
 class CCompiler(Compiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None):
         super().__init__(exelist, version)
@@ -1598,6 +1603,10 @@ class VisualStudioCCompiler(CCompiler):
         if p.returncode != 0:
             raise MesonException('Compiling test app failed.')
         return not(warning_text in stde or warning_text in stdo)
+
+    def get_compile_debugfile_args(self, rel_obj):
+        pdbarr = rel_obj.split('.')[:-1] + ['pdb']
+        return ['/Fd' + '.'.join(pdbarr)]
 
 class VisualStudioCPPCompiler(VisualStudioCCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrap):

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1436,16 +1436,11 @@ class SwiftCompiler(Compiler):
 class VisualStudioCCompiler(CCompiler):
     std_warn_args = ['/W3']
     std_opt_args= ['/O2']
-    vs2010_always_args = ['/nologo', '/showIncludes']
-    vs2013_always_args = ['/nologo', '/showIncludes', '/FS']
 
     def __init__(self, exelist, version, is_cross, exe_wrap):
         CCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
         self.id = 'msvc'
-        if int(version.split('.')[0]) > 17:
-            self.always_args = VisualStudioCCompiler.vs2013_always_args
-        else:
-            self.always_args = VisualStudioCCompiler.vs2010_always_args
+        self.always_args = ['/nologo', '/showIncludes']
         self.warn_args = {'1': ['/W2'],
                           '2': ['/W3'],
                           '3': ['/w4']}

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -354,10 +354,10 @@ class Compiler():
 
     # Some compilers (msvc) write debug info to a separate file.
     # These args specify where it should be written.
-    def get_compile_debugfile_args(self, rel_obj):
+    def get_compile_debugfile_args(self, rel_obj, fname_suffix):
         return []
 
-    def get_link_debugfile_args(self, rel_obj):
+    def get_link_debugfile_args(self, rel_obj, fname_suffix):
         return []
 
 class CCompiler(Compiler):
@@ -1607,12 +1607,16 @@ class VisualStudioCCompiler(CCompiler):
             raise MesonException('Compiling test app failed.')
         return not(warning_text in stde or warning_text in stdo)
 
-    def get_compile_debugfile_args(self, rel_obj):
-        pdbarr = rel_obj.split('.')[:-1] + ['pdb']
+    def get_compile_debugfile_args(self, rel_obj, name_suffix):
+        pdbarr = rel_obj.split('.')[:-1]
+        pdbarr[-1] += name_suffix
+        pdbarr += ['pdb']
         return ['/Fd' + '.'.join(pdbarr)]
 
-    def get_link_debugfile_args(self, targetfile):
-        pdbarr = targetfile.split('.')[:-1] + ['pdb']
+    def get_link_debugfile_args(self, targetfile, name_suffix):
+        pdbarr = targetfile.split('.')[:-1]
+        pdbarr[-1] += name_suffix
+        pdbarr += ['pdb']
         return ['/DEBUG', '/PDB:' + '.'.join(pdbarr)]
 
 class VisualStudioCPPCompiler(VisualStudioCCompiler):
@@ -2291,8 +2295,10 @@ class VisualStudioLinker():
     def unix_compile_flags_to_native(self, args):
         return args[:]
 
-    def get_link_debugfile_args(self, targetfile):
-        pdbarr = targetfile.split('.')[:-1] + ['pdb']
+    def get_link_debugfile_args(self, targetfile, name_suffix):
+        pdbarr = targetfile.split('.')[:-1]
+        pdbarr[-1] += name_suffix
+        pdbarr += ['pdb']
         return ['/DEBUG', '/PDB:' + '.'.join(pdbarr)]
 
 class ArLinker():
@@ -2344,5 +2350,5 @@ class ArLinker():
     def unix_compile_flags_to_native(self, args):
         return args[:]
 
-    def get_link_debugfile_args(self, targetfile):
+    def get_link_debugfile_args(self, targetfile, suffix):
         return []

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -2343,3 +2343,6 @@ class ArLinker():
 
     def unix_compile_flags_to_native(self, args):
         return args[:]
+
+    def get_link_debugfile_args(self, targetfile):
+        return []

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -354,10 +354,10 @@ class Compiler():
 
     # Some compilers (msvc) write debug info to a separate file.
     # These args specify where it should be written.
-    def get_compile_debugfile_args(self, rel_obj, fname_suffix):
+    def get_compile_debugfile_args(self, rel_obj):
         return []
 
-    def get_link_debugfile_args(self, rel_obj, fname_suffix):
+    def get_link_debugfile_args(self, rel_obj):
         return []
 
 class CCompiler(Compiler):
@@ -1607,15 +1607,13 @@ class VisualStudioCCompiler(CCompiler):
             raise MesonException('Compiling test app failed.')
         return not(warning_text in stde or warning_text in stdo)
 
-    def get_compile_debugfile_args(self, rel_obj, name_suffix):
+    def get_compile_debugfile_args(self, rel_obj):
         pdbarr = rel_obj.split('.')[:-1]
-        pdbarr[-1] += name_suffix
         pdbarr += ['pdb']
         return ['/Fd' + '.'.join(pdbarr)]
 
-    def get_link_debugfile_args(self, targetfile, name_suffix):
+    def get_link_debugfile_args(self, targetfile):
         pdbarr = targetfile.split('.')[:-1]
-        pdbarr[-1] += name_suffix
         pdbarr += ['pdb']
         return ['/DEBUG', '/PDB:' + '.'.join(pdbarr)]
 
@@ -2295,9 +2293,8 @@ class VisualStudioLinker():
     def unix_compile_flags_to_native(self, args):
         return args[:]
 
-    def get_link_debugfile_args(self, targetfile, name_suffix):
+    def get_link_debugfile_args(self, targetfile):
         pdbarr = targetfile.split('.')[:-1]
-        pdbarr[-1] += name_suffix
         pdbarr += ['pdb']
         return ['/DEBUG', '/PDB:' + '.'.join(pdbarr)]
 
@@ -2350,5 +2347,5 @@ class ArLinker():
     def unix_compile_flags_to_native(self, args):
         return args[:]
 
-    def get_link_debugfile_args(self, targetfile, suffix):
+    def get_link_debugfile_args(self, targetfile):
         return []

--- a/run_tests.py
+++ b/run_tests.py
@@ -168,7 +168,7 @@ def validate_install(srcdir, installdir):
     # Check if there are any unexpected files
     found = get_relative_files_list_from_dir(installdir)
     for fname in found:
-        if fname not in expected:
+        if fname not in expected and not fname.endswith('.pdb'):
             ret_msg += 'Extra file {0} found.\n'.format(fname)
     return ret_msg
 

--- a/test cases/common/86 same basename/meson.build
+++ b/test cases/common/86 same basename/meson.build
@@ -1,13 +1,11 @@
 project('same basename', 'c')
 
+subdir('sharedsub')
+subdir('staticsub')
+
 # Use the same source file to check that each top level target
 # has its own unique working directory. If they don't
 # then the .o files will clobber each other.
-shlib = shared_library('name', 'lib.c', c_args : '-DSHAR')
-
-# On Windows a static lib is now libfoo.a, so it does not conflict with foo.lib
-# from the shared library above
-stlib = static_library('name', 'lib.c', c_args : '-DSTAT')
 
 exe1 = executable('name', 'exe1.c', link_with : stlib)
 exe2 = executable('name2', 'exe2.c', link_with : shlib)

--- a/test cases/common/86 same basename/sharedsub/meson.build
+++ b/test cases/common/86 same basename/sharedsub/meson.build
@@ -1,0 +1,1 @@
+shlib = shared_library('name', '../lib.c', c_args : '-DSHAR')

--- a/test cases/common/86 same basename/staticsub/meson.build
+++ b/test cases/common/86 same basename/staticsub/meson.build
@@ -1,0 +1,3 @@
+# On Windows a static lib is now libfoo.a, so it does not conflict with foo.lib
+# from the shared library above
+stlib = static_library('name', '../lib.c', c_args : '-DSTAT')


### PR DESCRIPTION
Works with pch. Does not work with object extraction. It seems to be impossible to support both because pdb files can be either per-object or per-target.

 - per-object files can have different pdb paths and they are joined during linking but for some reason pch files *must* have the path to the target
 - per-target files work but then you can't take an object file from `foo.pdb` and put it in `bar.pdb`
