### PR TITLE
shared_library: Add vs_module_defs to link_depends

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -876,6 +876,8 @@ class SharedLibrary(BuildTarget):
                 self.vs_module_defs = File.from_absolute_file(path)
             else:
                 self.vs_module_defs = File.from_source_file(environment.source_dir, self.subdir, path)
+            # link_depends can be an absolute path or relative to self.subdir
+            self.link_depends.append(path)
 
     def check_unknown_kwargs(self, kwargs):
         self.check_unknown_kwargs_int(kwargs, known_shlib_kwargs)


### PR DESCRIPTION
With this, if the module definitions file is edited, the shared library and all reverse-dependencies will be re-linked.

Fixes #643