### PR TITLE
Add support for dependency files in custom targets.

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -551,6 +551,11 @@ class Backend():
             else:
                 if '@OUTDIR@' in i:
                     i = i.replace('@OUTDIR@', outdir)
+                elif '@DEPFILE@' in i:
+                    if target.depfile is None:
+                        raise MesonException('Custom target %s has @DEPFILE@ but no depfile keyword argument.' % target.name)
+                    dfilename = os.path.join(self.get_target_private_dir(target), target.depfile)
+                    i = i.replace('@DEPFILE@', dfilename)
                 elif '@PRIVATE_OUTDIR_' in i:
                     match = re.search('@PRIVATE_OUTDIR_(ABS_)?([-a-zA-Z0-9.@:]*)@', i)
                     source = match.group(0)
@@ -558,7 +563,6 @@ class Backend():
                         lead_dir = ''
                     else:
                         lead_dir = self.environment.get_build_dir()
-                    target_id = match.group(2)
                     i = i.replace(source,
                                   os.path.join(lead_dir,
                                                outdir))

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -931,6 +931,7 @@ class CustomTarget:
                     'build_always' : True,
                     'depends' : True,
                     'depend_files' : True,
+                    'depfile' : True,
                     }
 
     def __init__(self, name, subdir, kwargs):
@@ -939,6 +940,7 @@ class CustomTarget:
         self.dependencies = []
         self.extra_depends = []
         self.depend_files = [] # Files that this target depends on but are not on the command line.
+        self.depfile = None
         self.process_kwargs(kwargs)
         self.extra_files = []
         self.install_rpath = ''
@@ -983,6 +985,13 @@ class CustomTarget:
                 raise InvalidArguments('Output must not contain a path segment.')
         if 'command' not in kwargs:
             raise InvalidArguments('Missing keyword argument "command".')
+        if 'depfile' in kwargs:
+            depfile = kwargs['depfile']
+            if not isinstance(depfile, str):
+                raise InvalidArguments('Depfile must be a string.')
+            if os.path.split(depfile)[1] != depfile:
+                raise InvalidArguments('Depfile must be a plain filename without a subdirectory.')
+            self.depfile = depfile
         cmd = kwargs['command']
         if not(isinstance(cmd, list)):
             cmd = [cmd]

--- a/test cases/common/29 pipeline/meson.build
+++ b/test cases/common/29 pipeline/meson.build
@@ -6,8 +6,9 @@ e1 = executable('srcgen', 'srcgen.c', native : true)
 
 # Generate a source file that needs to be included in the build.
 gen = generator(e1, \
- output  : '@BASENAME@.c', # Line continuation inside arguments should work without needing a "\".
- arguments : ['@INPUT@', '@OUTPUT@'])
+  depfile : '@BASENAME@.d',
+  output  : '@BASENAME@.c', # Line continuation inside arguments should work without needing a "\".
+  arguments : ['@INPUT@', '@OUTPUT@', '@DEPFILE@'])
 
 generated = gen.process(['input_src.dat'])
 

--- a/test cases/common/29 pipeline/srcgen.c
+++ b/test cases/common/29 pipeline/srcgen.c
@@ -1,5 +1,6 @@
 #include<stdio.h>
 #include<assert.h>
+#include<string.h>
 
 #define ARRSIZE 80
 
@@ -7,17 +8,20 @@ int main(int argc, char **argv) {
     char arr[ARRSIZE];
     char *ofilename;
     char *ifilename;
+    char *dfilename;
     FILE *ifile;
     FILE *ofile;
+    FILE *depfile;
     size_t bytes;
+    int i;
 
-    if(argc != 3) {
-        fprintf(stderr, "%s <input file> <output file>\n", argv[0]);
+    if(argc != 4) {
+        fprintf(stderr, "%s <input file> <output file> <dependency file>\n", argv[0]);
         return 1;
     }
     ifilename = argv[1];
     ofilename = argv[2];
-    printf("%s\n", ifilename);
+    dfilename = argv[3];
     ifile = fopen(argv[1], "r");
     if(!ifile) {
         fprintf(stderr, "Could not open source file %s.\n", argv[1]);
@@ -34,7 +38,32 @@ int main(int argc, char **argv) {
     assert(bytes > 0);
     fwrite(arr, 1, bytes, ofile);
 
+    depfile = fopen(dfilename, "w");
+    if(!depfile) {
+        fprintf(stderr, "Could not open depfile %s\n", ofilename);
+        fclose(ifile);
+        fclose(ofile);
+        return 1;
+    }
+    for(i=0; i<strlen(ofilename); i++) {
+        if(ofilename[i] == ' ') {
+            fwrite("\\ ", 1, 2, depfile);
+        } else {
+            fwrite(&ofilename[i], 1, 1, depfile);
+        }
+    }
+    fwrite(": ", 1, 2, depfile);
+    for(i=0; i<strlen(ifilename); i++) {
+        if(ifilename[i] == ' ') {
+            fwrite("\\ ", 1, 2, depfile);
+        } else {
+            fwrite(&ifilename[i], 1, 1, depfile);
+        }
+    }
+    fwrite("\n", 1, 1, depfile);
+
     fclose(ifile);
     fclose(ofile);
+    fclose(depfile);
     return 0;
 }

--- a/test cases/common/56 custom target/depfile/dep.py
+++ b/test cases/common/56 custom target/depfile/dep.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import sys, os
+from glob import glob
+
+_, srcdir, depfile, output = sys.argv
+
+depfiles = glob(os.path.join(srcdir, '*'))
+
+quoted_depfiles = [x.replace(' ', '\ ') for x in depfiles]
+
+open(output, 'w').write('I am the result of globbing.')
+open(depfile, 'w').write('%s: %s\n' % (output, ' '.join(quoted_depfiles)))

--- a/test cases/common/56 custom target/depfile/meson.build
+++ b/test cases/common/56 custom target/depfile/meson.build
@@ -1,0 +1,7 @@
+
+
+mytarget = custom_target('depfile',
+  output : 'dep.dat',
+  depfile : 'dep.dat.d',
+  command : [find_program('dep.py'), meson.current_source_dir(), '@DEPFILE@', '@OUTPUT@'],
+)

--- a/test cases/common/56 custom target/meson.build
+++ b/test cases/common/56 custom target/meson.build
@@ -13,3 +13,5 @@ command : [python, comp, '@INPUT@', '@OUTPUT@'],
 install : true,
 install_dir : 'subdir'
 )
+
+subdir('depfile')


### PR DESCRIPTION
The only unfortunate bit is that custom targets already have keyword arguments `depends` and `depend_files` so adding `depfile` is a bit confusing. Could not think of a better name, though.