### PR TITLE
Flatten isinstance calls.

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -359,8 +359,7 @@ class Backend():
     def build_target_link_arguments(self, compiler, deps):
         args = []
         for d in deps:
-            if not isinstance(d, build.StaticLibrary) and\
-            not isinstance(d, build.SharedLibrary):
+            if not isinstance(d, (build.StaticLibrary, build.SharedLibrary)):
                 raise RuntimeError('Tried to link with a non-library target "%s".' % d.get_basename())
             if isinstance(compiler, compilers.LLVMDCompiler):
                 args.extend(['-L', self.get_target_filename_for_linking(d)])

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1488,9 +1488,7 @@ rule FORTRAN_DEP_HACK
             else:
                 raise build.InvalidArguments('Invalid source type.')
             abs_src = os.path.join(self.environment.get_build_dir(), rel_src)
-        if isinstance(src, RawFilename):
-            src_filename = src.fname
-        elif isinstance(src, File):
+        if isinstance(src, (RawFilename, File)):
             src_filename = src.fname
         elif os.path.isabs(src):
             src_filename = os.path.basename(src)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -253,11 +253,9 @@ class BuildTarget():
         for s in objects:
             if hasattr(s, 'held_object'):
                 s = s.held_object
-            if isinstance(s, str):
+            if isinstance(s, (str, ExtractedObjects)):
                 self.objects.append(s)
-            elif isinstance(s, ExtractedObjects):
-                self.objects.append(s)
-            elif isinstance(s, GeneratedList) or isinstance(s, CustomTarget):
+            elif isinstance(s, (GeneratedList, CustomTarget)):
                 msg =  'Generated files are not allowed in the \'objects\' kwarg ' + \
                     'for target {!r}.\nIt is meant only for '.format(self.name) + \
                     'pre-built object files that are shipped with the\nsource ' + \
@@ -279,7 +277,7 @@ class BuildTarget():
                 if not s in added_sources:
                     self.sources.append(s)
                     added_sources[s] = True
-            elif isinstance(s, GeneratedList) or isinstance(s, CustomTarget):
+            elif isinstance(s, (GeneratedList, CustomTarget)):
                 self.generated.append(s)
             else:
                 msg = 'Bad source of type {!r} in target {!r}.'.format(type(s).__name__, self.name)
@@ -546,8 +544,7 @@ class BuildTarget():
         for t in target:
             if hasattr(t, 'held_object'):
                 t = t.held_object
-            if not isinstance(t, StaticLibrary) and \
-            not isinstance(t, SharedLibrary):
+            if not isinstance(t, (StaticLibrary, SharedLibrary)):
                 raise InvalidArguments('Link target is not library.')
             if self.is_cross != t.is_cross:
                 raise InvalidArguments('Tried to mix cross built and native libraries in target %s.' % self.name)
@@ -612,7 +609,7 @@ class Generator():
         exe = args[0]
         if hasattr(exe, 'held_object'):
             exe = exe.held_object
-        if not isinstance(exe, Executable) and not isinstance(exe, dependencies.ExternalProgram):
+        if not isinstance(exe, (Executable, dependencies.ExternalProgram)):
             raise InvalidArguments('First generator argument must be an executable.')
         self.exe = exe
         self.process_kwargs(kwargs)
@@ -964,7 +961,7 @@ class CustomTarget:
         for c in self.sources:
             if hasattr(c, 'held_object'):
                 c = c.held_object
-            if isinstance(c, BuildTarget) or isinstance(c, CustomTarget) or isinstance(c, GeneratedList):
+            if isinstance(c, (BuildTarget, CustomTarget, GeneratedList)):
                 deps.append(c)
         return deps
 
@@ -991,13 +988,13 @@ class CustomTarget:
         for i, c in enumerate(cmd):
             if hasattr(c, 'held_object'):
                 c = c.held_object
-            if isinstance(c, str) or isinstance(c, File):
+            if isinstance(c, (str, File)):
                 final_cmd.append(c)
             elif isinstance(c, dependencies.ExternalProgram):
                 if not c.found():
                     raise InvalidArguments('Tried to use not found external program in a build rule.')
                 final_cmd += c.get_command()
-            elif isinstance(c, BuildTarget) or isinstance(c, CustomTarget):
+            elif isinstance(c, (BuildTarget, CustomTarget)):
                 self.dependencies.append(c)
                 final_cmd.append(c)
             elif isinstance(c, list):
@@ -1031,7 +1028,7 @@ class CustomTarget:
         for ed in extra_deps:
             while hasattr(ed, 'held_object'):
                 ed = ed.held_object
-            if not isinstance(ed, CustomTarget) and not isinstance(ed, BuildTarget):
+            if not isinstance(ed, (CustomTarget, BuildTarget)):
                 raise InvalidArguments('Can only depend on toplevel targets.')
             self.extra_depends.append(ed)
         depend_files = kwargs.get('depend_files', [])

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -799,7 +799,7 @@ class CrossBuildInfo():
             raise mesonlib.MesonException('Cross file is missing "binaries".')
 
     def ok_type(self, i):
-        return isinstance(i, str) or isinstance(i, int) or isinstance(i, bool)
+        return isinstance(i, (str, int, bool))
 
     def parse_datafile(self, filename):
         config = configparser.ConfigParser()

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1104,7 +1104,7 @@ class Interpreter():
             if isinstance(v, build.CustomTarget):
                 self.add_target(v.name, v)
                 outvalues.append(CustomTargetHolder(v, self))
-            elif isinstance(v, int) or isinstance(v, str):
+            elif isinstance(v, (int, str)):
                 outvalues.append(v)
             elif isinstance(v, build.Executable):
                 self.add_target(v.name, v)
@@ -2089,11 +2089,7 @@ class Interpreter():
     def flatten(self, args):
         if isinstance(args, mparser.StringNode):
             return args.value
-        if isinstance(args, str):
-            return args
-        if isinstance(args, InterpreterObject):
-            return args
-        if isinstance(args, int):
+        if isinstance(args, (int, str, InterpreterObject)):
             return args
         result = []
         for a in args:
@@ -2109,8 +2105,8 @@ class Interpreter():
     def source_strings_to_files(self, sources):
         results = []
         for s in sources:
-            if isinstance(s, mesonlib.File) or isinstance(s, GeneratedListHolder) or \
-            isinstance(s, CustomTargetHolder):
+            if isinstance(s, (mesonlib.File, GeneratedListHolder,
+                              CustomTargetHolder)):
                 pass
             elif isinstance(s, str):
                 s = mesonlib.File.from_source_file(self.environment.source_dir, self.subdir, s)
@@ -2208,14 +2204,8 @@ class Interpreter():
             raise InvalidCode('Unknown function "%s".' % func_name)
 
     def is_assignable(self, value):
-        if isinstance(value, InterpreterObject) or \
-            isinstance(value, dependencies.Dependency) or\
-            isinstance(value, str) or\
-            isinstance(value, int) or \
-            isinstance(value, list) or \
-            isinstance(value, mesonlib.File):
-            return True
-        return False
+        return isinstance(value, (InterpreterObject, dependencies.Dependency,
+                                  str, int, list, mesonlib.File))
 
     def assignment(self, node):
         assert(isinstance(node, mparser.AssignmentNode))
@@ -2321,9 +2311,8 @@ class Interpreter():
         raise InterpreterException('Unknown method "%s" for a string.' % method_name)
 
     def to_native(self, arg):
-        if isinstance(arg, mparser.StringNode) or \
-           isinstance(arg, mparser.NumberNode) or \
-           isinstance(arg, mparser.BooleanNode):
+        if isinstance(arg, (mparser.StringNode, mparser.NumberNode,
+                            mparser.BooleanNode)):
             return arg.value
         return arg
 
@@ -2476,9 +2465,7 @@ class Interpreter():
         return iobject[index]
 
     def is_elementary_type(self, v):
-        if isinstance(v, (int, float, str, bool, list)):
-            return True
-        return False
+        return isinstance(v, (int, float, str, bool, list))
 
     def evaluate_comparison(self, node):
         v1 = self.evaluate_statement(node.left)

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -65,7 +65,7 @@ class PkgConfigModule:
         for l in libs:
             if hasattr(l, 'held_object'):
                 l = l.held_object
-            if not (isinstance(l, build.SharedLibrary) or isinstance(l, build.StaticLibrary)):
+            if not isinstance(l, (build.SharedLibrary, build.StaticLibrary)):
                 raise mesonlib.MesonException('Library argument not a library object.')
             processed_libs.append(l)
         libs = processed_libs

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -98,14 +98,11 @@ class OptionInterpreter:
     def reduce_single(self, arg):
         if isinstance(arg, str):
             return arg
-        elif isinstance(arg, mparser.StringNode):
-            return arg.value
-        elif isinstance(arg, mparser.BooleanNode):
+        elif isinstance(arg, (mparser.StringNode, mparser.BooleanNode,
+                              mparser.NumberNode)):
             return arg.value
         elif isinstance(arg, mparser.ArrayNode):
             return [self.reduce_single(curarg) for curarg in arg.args.arguments]
-        elif isinstance(arg, mparser.NumberNode):
-            return arg.value
         else:
             raise OptionException('Arguments may only be string, int, bool, or array of those.')
 


### PR DESCRIPTION
That is, `isinstance(x, y)` or `isinstance(x, z)` can be flattened with a tuple to `isinstance(x, (y, z))`.

This shortens several lines, especially in the negative case.