### PR TITLE
Fix CustomTargets used as sources to CustomTargets.

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -527,7 +527,7 @@ class Backend():
                 i = i.held_object
             if isinstance(i, str):
                 fname = [os.path.join(self.build_to_src, target.subdir, i)]
-            elif isinstance(i, build.BuildTarget):
+            elif isinstance(i, (build.BuildTarget, build.CustomTarget)):
                 fname = [self.get_target_filename(i)]
             elif isinstance(i, build.GeneratedList):
                 fname = [os.path.join(self.get_target_private_dir(target), p) for p in i.get_outfilelist()]

--- a/test cases/common/57 custom target chain/installed_files.txt
+++ b/test cases/common/57 custom target chain/installed_files.txt
@@ -1,1 +1,2 @@
 usr/subdir/data2.dat
+usr/subdir/data3.dat

--- a/test cases/common/57 custom target chain/meson.build
+++ b/test cases/common/57 custom target chain/meson.build
@@ -18,4 +18,12 @@ mytarget2 = custom_target('bindat2',
   install_dir : 'subdir'
 )
 
+mytarget3 = custom_target('bindat3',
+  output : 'data3.dat',
+  input : [mytarget],
+  command : [python, comp2, '@INPUT@', '@OUTPUT@'],
+  install : true,
+  install_dir : 'subdir'
+)
+
 subdir('usetarget')


### PR DESCRIPTION
Otherwise an error is raised that `CustomTarget` does not have a `rel_to_builddir` method.