### PR TITLE
Support tree structured options

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -18,19 +18,26 @@ from .mesonlib import MesonException, default_libdir, default_libexecdir, defaul
 version = '0.34.0.dev1'
 backendlist = ['ninja', 'vs2010', 'vs2015', 'xcode']
 
+class SubOption:
+    def __init__(self, name, parent, description):
+        self.name = name
+        self.parent = parent
+        self.description = description
+
 class UserOption:
-    def __init__(self, name, description, choices):
+    def __init__(self, name, description, choices, parent=None):
         super().__init__()
         self.name = name
         self.choices = choices
         self.description = description
+        self.parent = parent
 
     def parse_string(self, valuestring):
         return valuestring
 
 class UserStringOption(UserOption):
-    def __init__(self, name, description, value, choices=None):
-        super().__init__(name, description, choices)
+    def __init__(self, name, description, value, parent=None, choices=None):
+        super().__init__(name, description, choices, parent)
         self.set_value(value)
 
     def validate(self, value):
@@ -47,8 +54,8 @@ class UserStringOption(UserOption):
         self.value = newvalue
 
 class UserBooleanOption(UserOption):
-    def __init__(self, name, description, value):
-        super().__init__(name, description, [ True, False ])
+    def __init__(self, name, description, value, parent=None):
+        super().__init__(name, description, [ True, False ], parent)
         self.set_value(value)
 
     def tobool(self, thing):
@@ -74,8 +81,8 @@ class UserBooleanOption(UserOption):
         return self.value
 
 class UserComboOption(UserOption):
-    def __init__(self, name, description, choices, value):
-        super().__init__(name, description, choices)
+    def __init__(self, name, description, choices, value, parent=None):
+        super().__init__(name, description, choices, parent)
         if not isinstance(self.choices, list):
             raise MesonException('Combo choices must be an array.')
         for i in self.choices:
@@ -90,8 +97,8 @@ class UserComboOption(UserOption):
         self.value = newvalue
 
 class UserStringArrayOption(UserOption):
-    def __init__(self, name, description, value, **kwargs):
-        super().__init__(name, description, kwargs.get('choices', []))
+    def __init__(self, name, description, value, parent=None, **kwargs):
+        super().__init__(name, description, kwargs.get('choices', []), parent)
         self.set_value(value)
 
     def set_value(self, newvalue):
@@ -120,6 +127,7 @@ class CoreData():
         self.version = version
         self.init_builtins(options)
         self.user_options = {}
+        self.suboptions = {} # In GUIs these would be called "submenus".
         self.compiler_options = {}
         self.base_options = {}
         self.external_args = {} # These are set from "the outside" with e.g. mesonconf

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -216,7 +216,9 @@ class Environment():
             previous_is_plaind = i == '-D'
         return False
 
-    def merge_options(self, options):
+    def merge_options(self, options, suboptions):
+        for (name, value) in suboptions.items():
+            self.coredata.suboptions[name] = value
         for (name, value) in options.items():
             if name not in self.coredata.user_options:
                 self.coredata.user_options[name] = value

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1028,7 +1028,7 @@ class Interpreter():
             oi = optinterpreter.OptionInterpreter(self.subproject, \
                                                   self.build.environment.cmd_line_options.projectoptions)
             oi.process(option_file)
-            self.build.environment.merge_options(oi.options)
+            self.build.environment.merge_options(oi.options, oi.suboptions)
         mesonfile = os.path.join(self.source_root, self.subdir, environment.build_filename)
         if not os.path.isfile(mesonfile):
             raise InvalidArguments('Missing Meson file in %s' % mesonfile)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -86,25 +86,11 @@ def list_target_files(target_name, coredata, builddata):
     print(json.dumps(sources))
 
 def list_buildoptions(coredata, builddata):
-    buildtype= {'choices': ['plain', 'debug', 'debugoptimized', 'release', 'minsize'],
-                'type' : 'combo',
-                'value' : coredata.get_builtin_option('buildtype'),
-                'description' : 'Build type',
-                'name' : 'type'}
-    strip = {'value' : coredata.get_builtin_option('strip'),
-             'type' : 'boolean',
-             'description' : 'Strip on install',
-             'name' : 'strip'}
-    unity = {'value' : coredata.get_builtin_option('unity'),
-             'type' : 'boolean',
-             'description' : 'Unity build',
-             'name' : 'unity'}
-    all_opt = []
-    all_opt.append({'name' : 'core',
-                    'description' : 'Core options',
-                    'type' : 'suboption',
-                    'value' : [buildtype, strip, unity],
-                    })
+    all_opt = [{'name' : 'builtin',
+                'description': 'Meson builtin options',
+                'type': 'suboption',
+                'value': get_keys(coredata.builtins),
+                }]
     all_opt.append({'name': 'user',
                     'description' : 'User defined options',
                     'type' : 'suboption',
@@ -161,6 +147,8 @@ def get_keys(options):
     keys = list(options.keys())
     keys.sort()
     for key in keys:
+        if key == 'backend': # The backend can never be changed.
+            continue
         opt = options[key]
         optlist.append(opt2dict(key, opt))
     return optlist

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -85,36 +85,73 @@ def list_target_files(target_name, coredata, builddata):
     sources = [os.path.join(i.subdir, i.fname) for i in sources]
     print(json.dumps(sources))
 
+def split_options(user_options, suboptions):
+    main_options = {}
+    main_suboptions = {}
+    subproject_options = {}
+    subproject_suboptions = {} 
+    for k in user_options.keys():
+        if ':' in k:
+            subproject_options[k] = user_options[k]
+        else:
+            main_options[k] = user_options[k]
+    for k in suboptions.keys():
+        if ':' in k:
+            subproject_suboptions[k] = suboptions[k]
+        else:
+            main_suboptions[k] = suboptions[k]
+    return (main_options, main_suboptions, subproject_options, subproject_suboptions)
+
 def list_buildoptions(coredata, builddata):
+    (main_options, main_suboptions, subproject_options, subproject_suboptions) = split_options(coredata.user_options, coredata.suboptions)
     all_opt = [{'name' : 'builtin',
                 'description': 'Meson builtin options',
                 'type': 'suboption',
                 'value': get_keys(coredata.builtins),
                 }]
-    all_opt.append({'name': 'user',
-                    'description' : 'User defined options',
+    all_opt.append({'name': 'base',
+                    'description' : 'Base options',
                     'type' : 'suboption',
-                    'value' : build_usertree(coredata.suboptions, coredata.user_options),
+                    'value' : get_keys(coredata.base_options),
                     })
     all_opt.append({'name' : 'compilers',
                     'description' : 'Options for compilers',
                     'type' : 'suboption',
                     'value' : get_keys(coredata.compiler_options),
                     })
-    all_opt.append({'name': 'base',
-                    'description' : 'Base options',
+    all_opt.append({'name': 'user',
+                    'description' : 'User options',
                     'type' : 'suboption',
-                    'value' : get_keys(coredata.base_options),
+                    'value' : build_usertree(main_options, main_suboptions),
                     })
+    all_opt += build_subprojecttree(subproject_options, subproject_suboptions)
     print(json.dumps(all_opt, indent=2))
 
-def build_usertree(suboptions, user_options, subbranch=None):
+def build_subprojecttree(options, suboptions):
+    result = []
+    sp_names = {}
+    for n in options.keys():
+        sp_names[n.split(':')[0]] = True
+    for n in suboptions.keys():
+        sp_names[n.split(':')[0]] = True
+    for subproject in sorted(sp_names.keys()):
+        prefix = subproject + ':'
+        cur_opt = {x.name : x for x in options.values() if x.name.startswith(prefix)}
+        cur_subopt = {x.name : x for x in suboptions.values() if x.name.startswith(prefix)}
+        result.append({'name' : subproject,
+                      'description' : 'Options of subproject: %s' % subproject,
+                      'type' : 'suboption',
+                      'value' :  build_usertree(cur_opt, cur_subopt)
+                      })
+    return result
+
+def build_usertree(user_options, suboptions, subbranch=None):
     current = []
     current_suboptions = [x for x in suboptions.values() if x.parent == subbranch]
     current_options = [x for x in user_options.values() if x.parent == subbranch]
     for so in current_suboptions:
         subentry = {'type' : 'subobject',
-                    'value' : build_usertree(suboptions, user_options, so.name),
+                    'value' : build_usertree(user_options, suboptions, so.name),
                     'description' : so.description,
                     'name' : so.name
                     }

--- a/test cases/common/47 options/meson_options.txt
+++ b/test cases/common/47 options/meson_options.txt
@@ -1,3 +1,7 @@
 option('testoption', type : 'string', value : 'optval', description : 'An option to do something')
 option('other_one', type : 'boolean', value : false)
 option('combo_opt', type : 'combo', choices : ['one', 'two', 'combo'], value : 'combo')
+suboption('suboptions')
+option('subbool', type : 'boolean', parent : 'suboptions', description : 'An option in a submenu.')
+suboption('subsuboptions', parent : 'suboptions')
+option('subsubbool', type : 'boolean', parent : 'subsuboptions', description : 'A subsubmenuoption.')


### PR DESCRIPTION
DON'T MERGE YET!

This is a POC of #707. Allow defining a tree structure for options. Also put all existing options into a hierarchy. Option names remain unique. This is needed for big projects with complex configuration setups like KConfig.
