### PR TITLE
Properly handle Files used in CustomTarget commands.

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -547,7 +547,7 @@ class Backend():
                 tmp = i.get_filename()[0]
                 i = os.path.join(self.get_target_dir(i), tmp)
             elif isinstance(i, mesonlib.File):
-                i = os.path.join(i.subdir, i.fname)
+                i = i.rel_to_builddir(self.build_to_src)
                 if absolute_paths:
                     i = os.path.join(self.environment.get_build_dir(), i)
             # FIXME: str types are blindly added and ignore the 'absolute_paths' argument

--- a/test cases/common/57 custom target chain/meson.build
+++ b/test cases/common/57 custom target chain/meson.build
@@ -4,7 +4,7 @@ python = find_program('python3')
 
 comp = '@0@/@1@'.format(meson.current_source_dir(), 'my_compiler.py')
 comp2 = '@0@/@1@'.format(meson.current_source_dir(), 'my_compiler2.py')
-infile = '@0@/@1@'.format(meson.current_source_dir(), 'data_source.txt')
+infile = files('data_source.txt')[0]
 
 mytarget = custom_target('bindat',
   output : 'data.dat',


### PR DESCRIPTION
Using `files(...)` as an element of a custom command did not work because the paths were not expanded correctly.

I'm also wondering about the line mentioned in my comment [here](https://github.com/mesonbuild/meson/commit/86c401e7b0e2ca6dfb28d857f756e1007117636d#commitcomment-18804935). As noted, that blanket replacement affects all command-line arguments and not just the paths, breaking anything using a backslash in the command-line; is it really necessary?