### PR TITLE
Add a way to pass options to subprojects

### DIFF
--- a/test cases/common/50 subproject options/meson.build
+++ b/test cases/common/50 subproject options/meson.build
@@ -5,3 +5,9 @@ subproject('subproject')
 if not get_option('opt')
   error('option unset when it should be set')
 endif
+
+subproject('subproject1', options: 'opt1=true')
+
+if not get_option('opt1')
+  error('option unset when it should be set')
+endif

--- a/test cases/common/50 subproject options/meson_options.txt
+++ b/test cases/common/50 subproject options/meson_options.txt
@@ -1,1 +1,2 @@
 option('opt', type : 'boolean', value : true, description : 'main project option')
+option('opt1', type : 'boolean', value : true, description : 'main project option 1')

--- a/test cases/common/50 subproject options/subprojects/subproject1/meson.build
+++ b/test cases/common/50 subproject options/subprojects/subproject1/meson.build
@@ -1,0 +1,5 @@
+project('subproject1', 'c')
+
+if not get_option('opt1')
+  error('option set when it should be unset.')
+endif

--- a/test cases/common/50 subproject options/subprojects/subproject1/meson_options.txt
+++ b/test cases/common/50 subproject options/subprojects/subproject1/meson_options.txt
@@ -1,0 +1,1 @@
+option('opt1', type : 'boolean', value : false, description : 'subproject1 option')


### PR DESCRIPTION
In some cases we might want to build subprojects with particular options
maybe based on the main project options etc... Add an `options` argument
to the `subproject` function and a `fallback_options` to the
`dependency` one.