### PR TITLE
Honor dependency `fallback` argument even if the dependency is not required

### DIFF
--- a/test cases/common/95 dep fallback/meson.build
+++ b/test cases/common/95 dep fallback/meson.build
@@ -1,6 +1,10 @@
 project('dep fallback', 'c')
 
-bob = dependency('boblib', fallback : ['boblib', 'bob_dep'])
+bob = dependency('boblib', fallback : ['boblib', 'bob_dep'], required: false)
+if not bob.found()
+    error('Bob is actually needed')
+endif
+jimmy = dependency('jimmylib', fallback : ['jimmylib', 'jimmy_dep'], required: false)
 
 exe = executable('bobtester', 'tester.c', dependencies : bob)
 test('bobtester', exe)


### PR DESCRIPTION
You can potentially have a fallback subproject and if that subproject
fails, you can continue without that dependency