### PR TITLE
Stop "fixing" command line in CustomTargets.

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -581,7 +581,6 @@ class Backend():
                                   os.path.join(lead_dir,
                                                outdir))
                 cmd.append(i)
-        cmd = [i.replace('\\', '/') for i in cmd]
         return (srcs, ofilenames, cmd)
 
     def run_postconf_scripts(self):


### PR DESCRIPTION
As noted in IRC, all the tests pass without it, and it breaks any command that includes a backslash.

Backslashes are used in paths on Windows though, so let's see if AppVeyor is fine with it.