### PR TITLE
Update GIR include paths

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -262,9 +262,10 @@ class GnomeModule:
         if not isinstance(inc_dirs, list):
             inc_dirs = [inc_dirs]
         for incd in inc_dirs:
-            if not isinstance(incd.held_object, build.IncludeDirs):
+            if not isinstance(incd.held_object, (str, build.IncludeDirs)):
                 raise MesonException(
                     'Gir include dirs should be include_directories().')
+        scan_command += self.get_include_args(state, inc_dirs)
         scan_command += self.get_include_args(state, gir_inc_dirs + inc_dirs,
                                               prefix='--add-include-path=')
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -209,6 +209,7 @@ class GnomeModule:
                                                 os.path.join(state.environment.get_build_dir(),
                                                              source.held_object.get_subdir())]
                 elif isinstance(dep.held_object, dependencies.PkgConfigDependency):
+                    scan_command += dep.held_object.get_compile_args()
                     for lib in dep.held_object.libs:
                         if os.path.isabs(lib) and dep.held_object.is_libtool:
                             scan_command += ["-L%s" % os.path.dirname(lib)]

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -252,7 +252,7 @@ class GnomeModule:
                     # Hack to avoid passing some compiler options in
                     if lib.startswith("-W"):
                         continue
-                        scan_command += [lib]
+                    scan_command += [lib]
 
                 if isinstance(dep, dependencies.PkgConfigDependency):
                     girdir = dep.get_variable("girdir")

--- a/test cases/frameworks/12 multiple gir/gir/meson-subsample.c
+++ b/test cases/frameworks/12 multiple gir/gir/meson-subsample.c
@@ -1,0 +1,124 @@
+#include "meson-subsample.h"
+
+struct _MesonSubSample
+{
+  MesonSample parent_instance;
+
+  gchar *msg;
+};
+
+G_DEFINE_TYPE (MesonSubSample, meson_sub_sample, MESON_TYPE_SAMPLE)
+
+enum {
+  PROP_0,
+  PROP_MSG,
+  LAST_PROP
+};
+
+static GParamSpec *gParamSpecs [LAST_PROP];
+
+/**
+ * meson_sub_sample_new:
+ * @msg: The message to set.
+ *
+ * Allocates a new #MesonSubSample.
+ *
+ * Returns: (transfer full): a #MesonSubSample.
+ */
+MesonSubSample *
+meson_sub_sample_new (const gchar *msg)
+{
+  g_return_val_if_fail (msg != NULL, NULL);
+
+  return g_object_new (MESON_TYPE_SUB_SAMPLE,
+                       "message", msg,
+                       NULL);
+}
+
+static void
+meson_sub_sample_finalize (GObject *object)
+{
+  MesonSubSample *self = (MesonSubSample *)object;
+
+  g_clear_pointer (&self->msg, g_free);
+
+  G_OBJECT_CLASS (meson_sub_sample_parent_class)->finalize (object);
+}
+
+static void
+meson_sub_sample_get_property (GObject    *object,
+                           guint       prop_id,
+                           GValue     *value,
+                           GParamSpec *pspec)
+{
+  MesonSubSample *self = MESON_SUB_SAMPLE (object);
+
+  switch (prop_id)
+    {
+    case PROP_MSG:
+      g_value_set_string (value, self->msg);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+meson_sub_sample_set_property (GObject      *object,
+                           guint         prop_id,
+                           const GValue *value,
+                           GParamSpec   *pspec)
+{
+  MesonSubSample *self = MESON_SUB_SAMPLE (object);
+
+  switch (prop_id)
+    {
+    case PROP_MSG:
+      self->msg = g_value_dup_string (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+meson_sub_sample_class_init (MesonSubSampleClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = meson_sub_sample_finalize;
+  object_class->get_property = meson_sub_sample_get_property;
+  object_class->set_property = meson_sub_sample_set_property;
+
+  gParamSpecs [PROP_MSG] =
+    g_param_spec_string ("message",
+                         "Message",
+                         "The message to print.",
+                         NULL,
+                         (G_PARAM_READWRITE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_properties (object_class, LAST_PROP, gParamSpecs);
+}
+
+static void
+meson_sub_sample_init (MesonSubSample *self)
+{
+}
+
+/**
+ * meson_sub_sample_print_message:
+ * @self: a #MesonSubSample.
+ *
+ * Prints the message.
+ *
+ * Returns: Nothing.
+ */
+void
+meson_sub_sample_print_message (MesonSubSample *self)
+{
+  g_return_if_fail (MESON_IS_SUB_SAMPLE (self));
+
+  g_print ("Message: %s\n", self->msg);
+}

--- a/test cases/frameworks/12 multiple gir/gir/meson-subsample.h
+++ b/test cases/frameworks/12 multiple gir/gir/meson-subsample.h
@@ -1,0 +1,17 @@
+#ifndef MESON_SUB_SAMPLE_H
+#define MESON_SUB_SAMPLE_H
+
+#include <glib-object.h>
+#include <meson-sample.h>
+
+G_BEGIN_DECLS
+
+#define MESON_TYPE_SUB_SAMPLE (meson_sub_sample_get_type())
+
+G_DECLARE_FINAL_TYPE (MesonSubSample, meson_sub_sample, MESON, SUB_SAMPLE, MesonSample)
+
+MesonSubSample *meson_sub_sample_new           (const gchar *msg);
+
+G_END_DECLS
+
+#endif /* MESON_SUB_SAMPLE_H */

--- a/test cases/frameworks/12 multiple gir/gir/meson.build
+++ b/test cases/frameworks/12 multiple gir/gir/meson.build
@@ -18,12 +18,11 @@ gnome.generate_gir(
   girsubproject,
   sources : libsources,
   include_directories : girlib_inc,
-  dependencies : [gobj, girlib_dep],
   nsversion : '1.0',
   namespace : 'MesonSub',
   symbol_prefix : 'meson_sub_',
   identifier_prefix : 'MesonSub',
-  includes : ['GObject-2.0', 'Meson-1.0'],
+  includes : ['GObject-2.0', meson_gir],
   install : true
 )
 

--- a/test cases/frameworks/12 multiple gir/gir/meson.build
+++ b/test cases/frameworks/12 multiple gir/gir/meson.build
@@ -17,7 +17,6 @@ girexe = executable(
 gnome.generate_gir(
   girsubproject,
   sources : libsources,
-  include_directories : girlib_inc,
   nsversion : '1.0',
   namespace : 'MesonSub',
   symbol_prefix : 'meson_sub_',

--- a/test cases/frameworks/12 multiple gir/gir/meson.build
+++ b/test cases/frameworks/12 multiple gir/gir/meson.build
@@ -1,0 +1,32 @@
+libsources = ['meson-subsample.c', 'meson-subsample.h']
+
+girsubproject = shared_library(
+  'girsubproject',
+  sources : libsources,
+  dependencies : [gobj, girlib_dep],
+  install : true
+)
+
+girexe = executable(
+  'girprog',
+  sources : 'prog.c',
+  dependencies : [gobj, girlib_dep],
+  link_with : girsubproject
+)
+
+gnome.generate_gir(
+  girsubproject,
+  sources : libsources,
+  include_directories : girlib_inc,
+  dependencies : [gobj, girlib_dep],
+  nsversion : '1.0',
+  namespace : 'MesonSub',
+  symbol_prefix : 'meson_sub_',
+  identifier_prefix : 'MesonSub',
+  includes : ['GObject-2.0', 'Meson-1.0'],
+  install : true
+)
+
+message('TEST: ' + girsubproject.outdir())
+
+test('gobject introspection/subproject/c', girexe)

--- a/test cases/frameworks/12 multiple gir/gir/prog.c
+++ b/test cases/frameworks/12 multiple gir/gir/prog.c
@@ -1,0 +1,12 @@
+#include "meson-subsample.h"
+
+gint
+main (gint   argc,
+      gchar *argv[])
+{
+  MesonSample * i = (MesonSample*) meson_sub_sample_new ("Hello, sub/meson/c!");
+  meson_sample_print_message (i);
+  g_object_unref (i);
+
+  return 0;
+}

--- a/test cases/frameworks/12 multiple gir/installed_files.txt
+++ b/test cases/frameworks/12 multiple gir/installed_files.txt
@@ -1,0 +1,6 @@
+usr/lib/girepository-1.0/Meson-1.0.typelib
+usr/lib/girepository-1.0/MesonSub-1.0.typelib
+usr/lib/libgirlib.so
+usr/lib/libgirsubproject.so
+usr/share/gir-1.0/Meson-1.0.gir
+usr/share/gir-1.0/MesonSub-1.0.gir

--- a/test cases/frameworks/12 multiple gir/meson.build
+++ b/test cases/frameworks/12 multiple gir/meson.build
@@ -1,0 +1,7 @@
+project('multiple-gobject-introspection', 'c')
+
+gnome = import('gnome')
+gobj = dependency('gobject-2.0')
+
+subdir('mesongir')
+subdir('gir')

--- a/test cases/frameworks/12 multiple gir/mesongir/meson-sample.c
+++ b/test cases/frameworks/12 multiple gir/mesongir/meson-sample.c
@@ -1,0 +1,126 @@
+#include "meson-sample.h"
+
+typedef struct _MesonSamplePrivate
+{
+  gchar *msg;
+} MesonSamplePrivate;
+
+
+G_DEFINE_TYPE_WITH_PRIVATE (MesonSample, meson_sample, G_TYPE_OBJECT)
+
+enum {
+  PROP_0,
+  PROP_MSG,
+  LAST_PROP
+};
+
+static GParamSpec *gParamSpecs [LAST_PROP];
+
+/**
+ * meson_sample_new:
+ * @msg: The message to set.
+ *
+ * Allocates a new #MesonSample.
+ *
+ * Returns: (transfer full): a #MesonSample.
+ */
+MesonSample *
+meson_sample_new (const gchar *msg)
+{
+  g_return_val_if_fail (msg != NULL, NULL);
+
+  return g_object_new (MESON_TYPE_SAMPLE,
+                       "message", msg,
+                       NULL);
+}
+
+static void
+meson_sample_finalize (GObject *object)
+{
+  MesonSamplePrivate *priv = meson_sample_get_instance_private ((MesonSample *) object);
+
+  g_clear_pointer (&priv->msg, g_free);
+
+  G_OBJECT_CLASS (meson_sample_parent_class)->finalize (object);
+}
+
+static void
+meson_sample_get_property (GObject    *object,
+                           guint       prop_id,
+                           GValue     *value,
+                           GParamSpec *pspec)
+{
+  MesonSamplePrivate *priv = meson_sample_get_instance_private ((MesonSample *) object);
+
+  switch (prop_id)
+    {
+    case PROP_MSG:
+      g_value_set_string (value, priv->msg);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+meson_sample_set_property (GObject      *object,
+                           guint         prop_id,
+                           const GValue *value,
+                           GParamSpec   *pspec)
+{
+  MesonSamplePrivate *priv = meson_sample_get_instance_private ((MesonSample *) object);
+
+  switch (prop_id)
+    {
+    case PROP_MSG:
+      priv->msg = g_value_dup_string (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+meson_sample_class_init (MesonSampleClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = meson_sample_finalize;
+  object_class->get_property = meson_sample_get_property;
+  object_class->set_property = meson_sample_set_property;
+
+  gParamSpecs [PROP_MSG] =
+    g_param_spec_string ("message",
+                         "Message",
+                         "The message to print.",
+                         NULL,
+                         (G_PARAM_READWRITE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_properties (object_class, LAST_PROP, gParamSpecs);
+}
+
+static void
+meson_sample_init (MesonSample *self)
+{
+}
+
+/**
+ * meson_sample_print_message:
+ * @self: a #MesonSample.
+ *
+ * Prints the message.
+ *
+ */
+void
+meson_sample_print_message (MesonSample *self)
+{
+  MesonSamplePrivate *priv;
+
+  g_return_if_fail (MESON_IS_SAMPLE (self));
+
+  priv = meson_sample_get_instance_private (self);
+
+  g_print ("Message: %s\n", priv->msg);
+}

--- a/test cases/frameworks/12 multiple gir/mesongir/meson-sample.h.in
+++ b/test cases/frameworks/12 multiple gir/mesongir/meson-sample.h.in
@@ -1,0 +1,22 @@
+#ifndef MESON_SAMPLE_H
+#define MESON_SAMPLE_H
+
+#include <@HEADER@>
+
+G_BEGIN_DECLS
+
+#define MESON_TYPE_SAMPLE (meson_sample_get_type())
+
+G_DECLARE_DERIVABLE_TYPE (MesonSample, meson_sample, MESON, SAMPLE, GObject)
+
+struct _MesonSampleClass {
+    GObjectClass parent_class;
+};
+
+
+MesonSample *meson_sample_new           (const gchar *msg);
+void         meson_sample_print_message (MesonSample *self);
+
+G_END_DECLS
+
+#endif /* MESON_SAMPLE_H */

--- a/test cases/frameworks/12 multiple gir/mesongir/meson.build
+++ b/test cases/frameworks/12 multiple gir/mesongir/meson.build
@@ -1,0 +1,37 @@
+conf = configuration_data()
+conf.set('HEADER', 'glib-object.h')
+
+meson_sample_header = configure_file(
+  input : 'meson-sample.h.in',
+  output : 'meson-sample.h',
+  configuration : conf)
+
+libsources = ['meson-sample.c', meson_sample_header]
+
+girlib = shared_library(
+  'girlib',
+  sources : libsources,
+  dependencies : gobj,
+  install : true
+)
+
+girtarget = gnome.generate_gir(
+  girlib,
+  sources : libsources,
+  nsversion : '1.0',
+  namespace : 'Meson',
+  symbol_prefix : 'meson_',
+  identifier_prefix : 'Meson',
+  includes : ['GObject-2.0'],
+  install : true
+)
+meson_gir = girtarget[0]
+meson_typelib = girtarget[1]
+
+girlib_inc = include_directories('.')
+girlib_dep = declare_dependency(link_with : girlib,
+  include_directories : [girlib_inc],
+  dependencies : [gobj],
+  # Everything that uses libgst needs this built to compile
+  sources : girtarget,
+)


### PR DESCRIPTION
This modifies the search paths for GIR generation:

* Include paths coming from the target only add its source path. Instead add include paths in a manner similar to the ninja backend, with both source and build directories.
* Add include paths from all types of `Dependency`s of the target _and_ pull those dependencies directly from the target from which the GIR is being built.
* Previously, to "link" with another GIR being built, you had to add the name in the `includes` argument and the `GirTarget` in the `dependencies` argument to set the search path. Now, you can specify the `GirTarget` in the `includes` and the correct name & search path are added.
* Confusingly, the `include_directories` applied to the search path for GIR files only. Now it's applied to header searches as well.

I probably need to come up with some way to test this...