### PR TITLE
Fix validation of man page extension.

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -454,7 +454,10 @@ class Man(InterpreterObject):
 
     def validate_sources(self):
         for s in self.sources:
-            num = int(s.split('.')[-1])
+            try:
+                num = int(s.split('.')[-1])
+            except (IndexError, ValueError):
+                num = 0
             if num < 1 or num > 8:
                 raise InvalidArguments('Man file must have a file extension of a number between 1 and 8')
 

--- a/test cases/failing/31 invalid man extension/meson.build
+++ b/test cases/failing/31 invalid man extension/meson.build
@@ -1,0 +1,2 @@
+project('man install', 'c')
+m1 = install_man('foo.a1')

--- a/test cases/failing/32 no man extension/meson.build
+++ b/test cases/failing/32 no man extension/meson.build
@@ -1,0 +1,2 @@
+project('man install', 'c')
+m1 = install_man('foo')


### PR DESCRIPTION
If the extension does not exist or is not a number, the error message is not raised because the assumptions cause a different exception.