### PR TITLE
Add support to integer modulo operator

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2595,6 +2595,10 @@ class Interpreter():
             if not isinstance(l, int) or not isinstance(r, int):
                 raise InvalidCode('Division works only with integers.')
             return l // r
+        elif cur.operation == 'mod':
+            if not isinstance(l, int) or not isinstance(r, int):
+                raise InvalidCode('Modulo works only with integers.')
+            return l % r
         else:
             raise InvalidCode('You broke me.')
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2293,6 +2293,22 @@ class Interpreter():
         else:
             raise InterpreterException('Unknown method "%s" for a boolean.' % method_name)
 
+    def int_method_call(self, obj, method_name, args):
+        obj = self.to_native(obj)
+        (posargs, _) = self.reduce_arguments(args)
+        if method_name == 'is_even':
+            if len(posargs) == 0:
+                return obj % 2 == 0
+            else:
+                raise InterpreterException('int.is_even() must have no arguments.')
+        elif method_name == 'is_odd':
+            if len(posargs) == 0:
+                return obj % 2 != 0
+            else:
+                raise InterpreterException('int.is_odd() must have no arguments.')
+        else:
+            raise InterpreterException('Unknown method "%s" for an integer.' % method_name)
+
     def string_method_call(self, obj, method_name, args):
         obj = self.to_native(obj)
         (posargs, _) = self.reduce_arguments(args)
@@ -2379,6 +2395,8 @@ class Interpreter():
             return self.string_method_call(obj, method_name, args)
         if isinstance(obj, bool):
             return self.bool_method_call(obj, method_name, args)
+        if isinstance(obj, int):
+            return self.int_method_call(obj, method_name, args)
         if isinstance(obj, list):
             return self.array_method_call(obj, method_name, self.reduce_arguments(args)[0])
         if not isinstance(obj, InterpreterObject):

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -58,6 +58,7 @@ class Lexer:
             ('plus', re.compile(r'\+')),
             ('dash', re.compile(r'-')),
             ('star', re.compile(r'\*')),
+            ('percent', re.compile(r'\%')),
             ('fslash', re.compile(r'/')),
             ('colon', re.compile(r':')),
             ('equal', re.compile(r'==')),
@@ -434,9 +435,15 @@ class Parser:
         return left
 
     def e5sub(self):
-        left = self.e5mul()
+        left = self.e5mod()
         if self.accept('dash'):
             return ArithmeticNode(left.lineno, left.colno, 'sub', left, self.e5sub())
+        return left
+
+    def e5mod(self):
+        left = self.e5mul()
+        if self.accept('percent'):
+            return ArithmeticNode(left.lineno, left.colno, 'mod', left, self.e5mod())
         return left
 
     def e5mul(self):

--- a/test cases/common/68 number arithmetic/meson.build
+++ b/test cases/common/68 number arithmetic/meson.build
@@ -23,6 +23,8 @@ endif
 
 assert((5 % 2) == 1, 'Integer modulo (odd) is broken')
 assert((4 % 2) == 0, 'Integer modulo (even) is broken')
+assert(2.is_even() == 1, 'int is_even() broken')
+assert(2.is_odd() == 0, 'int is_odd() broken')
 
 assert(3 < 4, 'Lt broken')
 assert(not(4 < 3), 'Lt broken')

--- a/test cases/common/68 number arithmetic/meson.build
+++ b/test cases/common/68 number arithmetic/meson.build
@@ -23,8 +23,22 @@ endif
 
 assert((5 % 2) == 1, 'Integer modulo (odd) is broken')
 assert((4 % 2) == 0, 'Integer modulo (even) is broken')
-assert(2.is_even() == 1, 'int is_even() broken')
-assert(2.is_odd() == 0, 'int is_odd() broken')
+
+if 2 * 1 % 2 != 0
+  error('Modulo precendence with multiplication is broken')
+endif
+if 2 + 1 % 2 != 3
+  error('Modulo precendence with addition is broken')
+endif
+if 9 / 9 % 2 != 1
+  error('Modulo precendence with division is broken')
+endif
+if 9 - 9 % 2 != 8
+  error('Modulo precendence with subtraction is broken')
+endif
+
+assert(2.is_even(), 'int is_even() broken')
+assert(not(2.is_odd()), 'int is_odd() broken')
 
 assert(3 < 4, 'Lt broken')
 assert(not(4 < 3), 'Lt broken')

--- a/test cases/common/68 number arithmetic/meson.build
+++ b/test cases/common/68 number arithmetic/meson.build
@@ -21,6 +21,9 @@ if (5 / 3) * 3 != 3
   error('Integer division is broken')
 endif
 
+assert((5 % 2) == 1, 'Integer modulo (odd) is broken')
+assert((4 % 2) == 0, 'Integer modulo (even) is broken')
+
 assert(3 < 4, 'Lt broken')
 assert(not(4 < 3), 'Lt broken')
 assert(3 <= 4, 'Lte broken')

--- a/test cases/common/68 number arithmetic/meson.build
+++ b/test cases/common/68 number arithmetic/meson.build
@@ -37,8 +37,10 @@ if 9 - 9 % 2 != 8
   error('Modulo precendence with subtraction is broken')
 endif
 
-assert(2.is_even(), 'int is_even() broken')
-assert(not(2.is_odd()), 'int is_odd() broken')
+assert(2.is_even(), 'int is_even() broken for even value')
+assert(not(2.is_odd()), 'int is_odd() broken for even value')
+assert(not(3.is_even()), 'int is_even() broken for odd value')
+assert(3.is_odd(), 'int is_odd() broken for odd value')
 
 assert(3 < 4, 'Lt broken')
 assert(not(4 < 3), 'Lt broken')


### PR DESCRIPTION
Having support for the '%' operator makes it easier to implement
even/odd version checks, like:

    enable_debug = get_option('enable-debug')
    if enable_debug == 'auto'
      if minor_version % 2 == 0
        enable_debug = 'minimum'
      else
        enable_debug = 'yes'
      endif
    endif

which would be impossible without resorting to less obvious long-hand
forms like:

  a - (b * (a / b))