### PR TITLE
ac_converter.py: loop over `sizes'

### DIFF
--- a/tools/ac_converter.py
+++ b/tools/ac_converter.py
@@ -296,7 +296,7 @@ endforeach
 
 # Convert sizeof checks.
 
-for elem, typename in size:
+for elem, typename in sizes:
     print("cdata.set('%s', cc.sizeof('%s'))" % (elem, typename))
 
 print('''


### PR DESCRIPTION
I ran `ac_converter.py`, and it crashed

```
Traceback (most recent call last):
  File "ac_converter.py", line 299, in <module>
    for elem, typename in size:
```

I think it's a typo like this.