### PR TITLE
Return subproject source root when asking for meson.source_root() in …

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -943,7 +943,11 @@ class MesonMain(InterpreterObject):
         return os.path.join(src, sub)
 
     def source_root_method(self, args, kwargs):
-        return self.interpreter.environment.source_dir
+        if self.interpreter.subproject == '':
+            return self.interpreter.environment.source_dir
+        return os.path.join(self.interpreter.environment.source_dir,
+                            self.interpreter.subproject_dir,
+                            self.interpreter.subproject)
 
     def build_root_method(self, args, kwargs):
         return self.interpreter.environment.build_dir


### PR DESCRIPTION
…a subproject. Closes #722.
