### PR TITLE
Fix option initialization for win32 cross-compile.

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1622,7 +1622,9 @@ class Interpreter():
         if cross_comp is not None:
             cross_comp.sanity_check(self.environment.get_scratch_dir(), self.environment)
             self.coredata.cross_compilers[lang] = cross_comp
-        new_options = comp.get_options()
+            new_options = cross_comp.get_options()
+        else:
+            new_options = comp.get_options()
         optprefix = lang + '_'
         for i in new_options:
             if not i.startswith(optprefix):


### PR DESCRIPTION
This should fix the following traceback when configuring a cross-compile to Windows:
```pytb
Traceback (most recent call last):
  File ".../meson/mesonbuild/mesonmain.py", line 282, in run
    app.generate()
  File ".../meson/mesonbuild/mesonmain.py", line 167, in generate
    intr.run()
  File ".../meson/mesonbuild/interpreter.py", line 1186, in run
    self.evaluate_codeblock(self.ast)
  File ".../meson/mesonbuild/interpreter.py", line 1208, in evaluate_codeblock
    raise e
  File ".../meson/mesonbuild/interpreter.py", line 1202, in evaluate_codeblock
    self.evaluate_statement(cur)
  File ".../meson/mesonbuild/interpreter.py", line 1333, in evaluate_statement
    return self.evaluate_if(cur)
  File ".../meson/mesonbuild/interpreter.py", line 2456, in evaluate_if
    result = self.evaluate_statement(i.condition)
  File ".../meson/mesonbuild/interpreter.py", line 1327, in evaluate_statement
    return self.method_call(cur)
  File ".../meson/mesonbuild/interpreter.py", line 2410, in method_call
    return obj.method_call(method_name, self.flatten(args), kwargs)
  File ".../meson/mesonbuild/interpreter.py", line 91, in method_call
    return self.methods[method_name](args, kwargs)
  File ".../meson/mesonbuild/interpreter.py", line 711, in has_function_method
    extra_args = self.determine_args(kwargs)
  File ".../meson/mesonbuild/interpreter.py", line 621, in determine_args
    args += self.compiler.get_option_link_args(opts)
  File ".../meson/mesonbuild/compilers.py", line 2002, in get_option_link_args
    return options['c_winlibs'].value
KeyError: 'c_winlibs'
```