### PR TITLE
Move compiler common functionality to own class

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -2091,26 +2091,6 @@ class ClangCompiler():
         # so it might change semantics at any time.
         return ['-include-pch', os.path.join (pch_dir, self.get_pch_name (header))]
 
-class ClangObjCCompiler(GnuObjCCompiler):
-    def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):
-        super().__init__(exelist, version, is_cross, exe_wrapper)
-        self.id = 'clang'
-        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage']
-        self.clang_type = cltype
-        if self.clang_type != CLANG_OSX:
-            self.base_options.append('b_lundef')
-            self.base_options.append('b_asneeded')
-
-class ClangObjCPPCompiler(GnuObjCPPCompiler):
-    def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):
-        super().__init__(exelist, version, is_cross, exe_wrapper)
-        self.id = 'clang'
-        self.clang_type = cltype
-        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage']
-        if self.clang_type != CLANG_OSX:
-            self.base_options.append('b_lundef')
-            self.base_options.append('b_asneeded')
-
 class ClangCCompiler(ClangCompiler, CCompiler):
     def __init__(self, exelist, version, clang_type, is_cross, exe_wrapper=None):
         CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
@@ -2169,6 +2149,26 @@ class ClangCPPCompiler(ClangCompiler,   CPPCompiler):
 
     def can_compile(self, filename):
         return super().can_compile(filename) or filename.split('.')[-1].lower() == 's' # Clang can do asm, too.
+
+class ClangObjCCompiler(GnuObjCCompiler):
+    def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):
+        super().__init__(exelist, version, is_cross, exe_wrapper)
+        self.id = 'clang'
+        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage']
+        self.clang_type = cltype
+        if self.clang_type != CLANG_OSX:
+            self.base_options.append('b_lundef')
+            self.base_options.append('b_asneeded')
+
+class ClangObjCPPCompiler(GnuObjCPPCompiler):
+    def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):
+        super().__init__(exelist, version, is_cross, exe_wrapper)
+        self.id = 'clang'
+        self.clang_type = cltype
+        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage']
+        if self.clang_type != CLANG_OSX:
+            self.base_options.append('b_lundef')
+            self.base_options.append('b_asneeded')
 
 class FortranCompiler(Compiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None):

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1939,6 +1939,11 @@ class GnuCompiler:
     def __init__(self, gcc_type):
         self.id = 'gcc'
         self.gcc_type = gcc_type
+        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage',
+                             'b_colorout']
+        if self.gcc_type != GCC_OSX:
+            self.base_options.append('b_lundef')
+            self.base_options.append('b_asneeded')
 
     def get_colorout_args(self, colortype):
         if mesonlib.version_compare(self.version, '>=4.9.0'):
@@ -1975,11 +1980,6 @@ class GnuCCompiler(GnuCompiler, CCompiler):
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch'],
                           '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch']}
-        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage',
-                             'b_colorout']
-        if self.gcc_type != GCC_OSX:
-            self.base_options.append('b_lundef')
-            self.base_options.append('b_asneeded')
 
     def can_compile(self, filename):
         return super().can_compile(filename) or filename.split('.')[-1].lower() == 's' # Gcc can do asm, too.
@@ -2015,11 +2015,6 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '3': ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor']}
-        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage',
-                             'b_colorout']
-        if self.gcc_type != GCC_OSX:
-            self.base_options.append('b_lundef')
-            self.base_options.append('b_asneeded')
 
     def get_options(self):
         opts = {'cpp_std' : coredata.UserComboOption('cpp_std', 'C++ language standard to use',
@@ -2060,10 +2055,6 @@ class GnuObjCCompiler(GnuCompiler,ObjCCompiler):
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch'],
                           '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch']}
-        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage']
-        if self.gcc_type != GCC_OSX:
-            self.base_options.append('b_lundef')
-            self.base_options.append('b_asneeded')
 
 class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):
 
@@ -2075,10 +2066,6 @@ class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor']}
-        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage']
-        if self.gcc_type != GCC_OSX:
-            self.base_options.append('b_lundef')
-            self.base_options.append('b_asneeded')
 
 class ClangObjCCompiler(GnuObjCCompiler):
     def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1934,9 +1934,9 @@ def get_gcc_soname_args(gcc_type, shlib_name, path, soversion):
         raise RuntimeError('Not implemented yet.')
 
 
-class GnuCCompiler(CCompiler):
-    def __init__(self, exelist, version, gcc_type, is_cross, exe_wrapper=None):
-        CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
+class GnuCompiler:
+    # Functionality that is common to all GNU family compilers.
+    def __init__(self, gcc_type):
         self.id = 'gcc'
         self.gcc_type = gcc_type
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch'],
@@ -1958,14 +1958,14 @@ class GnuCCompiler(CCompiler):
             return [] # On Window gcc defaults to fpic being always on.
         return ['-fPIC']
 
-    def get_always_args(self):
-        return ['-pipe']
-
     def get_buildtype_args(self, buildtype):
         return gnulike_buildtype_args[buildtype]
 
     def get_buildtype_linker_args(self, buildtype):
         return gnulike_buildtype_linker_args[buildtype]
+
+    def get_always_args(self):
+        return ['-pipe']
 
     def get_pch_suffix(self):
         return 'gch'
@@ -1975,6 +1975,11 @@ class GnuCCompiler(CCompiler):
 
     def get_soname_args(self, shlib_name, path, soversion):
         return get_gcc_soname_args(self.gcc_type, shlib_name, path, soversion)
+
+class GnuCCompiler(GnuCompiler, CCompiler):
+    def __init__(self, exelist, version, gcc_type, is_cross, exe_wrapper=None):
+        CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
+        GnuCompiler.__init__(self, gcc_type)
 
     def can_compile(self, filename):
         return super().can_compile(filename) or filename.split('.')[-1].lower() == 's' # Gcc can do asm, too.

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -2050,15 +2050,13 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
             return options['cpp_winlibs'].value
         return []
 
-class GnuObjCCompiler(ObjCCompiler):
-    std_opt_args = ['-O2']
+class GnuObjCCompiler(GnuCompiler,ObjCCompiler):
 
     def __init__(self, exelist, version, is_cross, exe_wrapper=None):
         ObjCCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
-        self.id = 'gcc'
         # Not really correct, but GNU objc is only used on non-OSX non-win. File a bug
         # if this breaks your use case.
-        self.gcc_type = GCC_STANDARD
+        GnuCompiler.__init__(self, GCC_STANDARD)
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch'],
                           '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch']}
@@ -2067,27 +2065,13 @@ class GnuObjCCompiler(ObjCCompiler):
             self.base_options.append('b_lundef')
             self.base_options.append('b_asneeded')
 
-    def get_buildtype_args(self, buildtype):
-        return gnulike_buildtype_args[buildtype]
-
-    def get_buildtype_linker_args(self, buildtype):
-        return gnulike_buildtype_linker_args[buildtype]
-
-    def get_pch_suffix(self):
-        return 'gch'
-
-    def get_soname_args(self, shlib_name, path, soversion):
-        return get_gcc_soname_args(self.gcc_type, shlib_name, path, soversion)
-
-class GnuObjCPPCompiler(ObjCPPCompiler):
-    std_opt_args = ['-O2']
+class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):
 
     def __init__(self, exelist, version, is_cross, exe_wrapper=None):
         ObjCCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
-        self.id = 'gcc'
         # Not really correct, but GNU objc is only used on non-OSX non-win. File a bug
         # if this breaks your use case.
-        self.gcc_type = GCC_STANDARD
+        GnuCompiler.__init__(self, GCC_STANDARD)
         self.warn_args = {'1': ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor']}
@@ -2095,18 +2079,6 @@ class GnuObjCPPCompiler(ObjCPPCompiler):
         if self.gcc_type != GCC_OSX:
             self.base_options.append('b_lundef')
             self.base_options.append('b_asneeded')
-
-    def get_buildtype_args(self, buildtype):
-        return gnulike_buildtype_args[buildtype]
-
-    def get_buildtype_linker_args(self, buildtype):
-        return gnulike_buildtype_linker_args[buildtype]
-
-    def get_pch_suffix(self):
-        return 'gch'
-
-    def get_soname_args(self, shlib_name, path, soversion):
-        return get_gcc_soname_args(self.gcc_type, shlib_name, path, soversion)
 
 class ClangObjCCompiler(GnuObjCCompiler):
     def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -2067,34 +2067,10 @@ class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):
                           '2': ['-Wall', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor'],
                           '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch', '-Wnon-virtual-dtor']}
 
-class ClangObjCCompiler(GnuObjCCompiler):
-    def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):
-        super().__init__(exelist, version, is_cross, exe_wrapper)
-        self.id = 'clang'
-        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage']
-        self.clang_type = cltype
-        if self.clang_type != CLANG_OSX:
-            self.base_options.append('b_lundef')
-            self.base_options.append('b_asneeded')
-
-class ClangObjCPPCompiler(GnuObjCPPCompiler):
-    def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):
-        super().__init__(exelist, version, is_cross, exe_wrapper)
-        self.id = 'clang'
-        self.clang_type = cltype
-        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage']
-        if self.clang_type != CLANG_OSX:
-            self.base_options.append('b_lundef')
-            self.base_options.append('b_asneeded')
-
-class ClangCCompiler(CCompiler):
-    def __init__(self, exelist, version, clang_type, is_cross, exe_wrapper=None):
-        CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
+class ClangCompiler():
+    def __init__(self, clang_type):
         self.id = 'clang'
         self.clang_type = clang_type
-        self.warn_args = {'1': ['-Wall', '-Winvalid-pch'],
-                          '2': ['-Wall', '-Wextra', '-Winvalid-pch'],
-                          '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch']}
         self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage']
         if self.clang_type != CLANG_OSX:
             self.base_options.append('b_lundef')
@@ -2118,6 +2094,37 @@ class ClangCCompiler(CCompiler):
         # so it might change semantics at any time.
         return ['-include-pch', os.path.join (pch_dir, self.get_pch_name (header))]
 
+    def has_argument(self, arg, env):
+        return super().has_argument(['-Werror=unknown-warning-option', arg], env)
+
+class ClangObjCCompiler(GnuObjCCompiler):
+    def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):
+        super().__init__(exelist, version, is_cross, exe_wrapper)
+        self.id = 'clang'
+        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage']
+        self.clang_type = cltype
+        if self.clang_type != CLANG_OSX:
+            self.base_options.append('b_lundef')
+            self.base_options.append('b_asneeded')
+
+class ClangObjCPPCompiler(GnuObjCPPCompiler):
+    def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):
+        super().__init__(exelist, version, is_cross, exe_wrapper)
+        self.id = 'clang'
+        self.clang_type = cltype
+        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage']
+        if self.clang_type != CLANG_OSX:
+            self.base_options.append('b_lundef')
+            self.base_options.append('b_asneeded')
+
+class ClangCCompiler(ClangCompiler, CCompiler):
+    def __init__(self, exelist, version, clang_type, is_cross, exe_wrapper=None):
+        CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
+        ClangCompiler.__init__(self, clang_type)
+        self.warn_args = {'1': ['-Wall', '-Winvalid-pch'],
+                          '2': ['-Wall', '-Wextra', '-Winvalid-pch'],
+                          '3' : ['-Wall', '-Wpedantic', '-Wextra', '-Winvalid-pch']}
+
     def get_options(self):
         return {'c_std' : coredata.UserComboOption('c_std', 'C language standard to use',
                                                    ['none', 'c89', 'c99', 'c11'],
@@ -2132,9 +2139,6 @@ class ClangCCompiler(CCompiler):
 
     def get_option_link_args(self, options):
         return []
-
-    def has_argument(self, arg, env):
-        return super().has_argument(['-Werror=unknown-warning-option', arg], env)
 
 
 class ClangCPPCompiler(CPPCompiler):


### PR DESCRIPTION
So a Gnu C compiler has very little in it, it just inherits from a generic Gnu compiler and a generic C compiler