### PR TITLE
module pkgconfig: added install_dir attribute

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -44,3 +44,4 @@ Matthias Klumpp
 Elliott Sales de Andrade
 Patrick Griffis
 Iain Lane
+Daniel Brendle

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -87,7 +87,11 @@ class PkgConfigModule:
         priv_reqs = mesonlib.stringlistify(kwargs.get('requires_private', []))
         priv_libs = mesonlib.stringlistify(kwargs.get('libraries_private', []))
         pcfile = filebase + '.pc'
-        pkgroot = os.path.join(state.environment.coredata.get_builtin_option('libdir'), 'pkgconfig')
+        pkgroot = kwargs.get('install_dir',None)
+        if pkgroot is None:
+            pkgroot = os.path.join(state.environment.coredata.get_builtin_option('libdir'), 'pkgconfig')
+        if not isinstance(pkgroot, str):
+            raise mesonlib.MesonException('Install_dir must be a string.')
         self.generate_pkgconfig_file(state, libs, subdirs, name, description, version, filebase,
                                      pub_reqs, priv_reqs, priv_libs)
         return build.Data(False, state.environment.get_scratch_dir(), [pcfile], pkgroot)


### PR DESCRIPTION
the pkgconfig module automatically specified to install the
pkgconfig file to {libdir}/pkgconfig. Default settings in meson
already include multiarch-directories like x86_64-gnu-linux into
the libdir. pkgconfig usually does not check inside multiarch-dirs
for any pkgconfig-files.
to make this a bit more flexible, this commit introduces the
install_dir attribute for pkgconfig.generate. if it is set, the
default install path will be overridden by the users input