### PR TITLE
New API: find_python3 returns full path to Python3

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1101,6 +1101,7 @@ class Interpreter():
                       'add_global_link_arguments' : self.func_add_global_link_arguments,
                       'add_languages' : self.func_add_languages,
                       'find_program' : self.func_find_program,
+                      'find_python3' : self.func_find_python3,
                       'find_library' : self.func_find_library,
                       'configuration_data' : self.func_configuration_data,
                       'run_command' : self.func_run_command,
@@ -1711,6 +1712,14 @@ class Interpreter():
         if required and not progobj.found():
             raise InvalidArguments('Program "%s" not found.' % exename)
         return progobj
+
+    def func_find_python3(self, node, args, kwargs):
+        self.validate_arguments(args, 0, [])
+        fullpath = sys.executable
+        if fullpath is None:
+            raise InterpreterException('Unable to find Python 3: sys.executable is empty')
+        extprog = dependencies.ExternalProgram('Python3', fullpath=fullpath)
+        return ExternalProgramHolder(extprog)
 
     def func_find_library(self, node, args, kwargs):
         mlog.log(mlog.red('DEPRECATION:'), 'find_library() is removed, use the corresponding method in compiler object instead.')

--- a/test cases/common/105 find program path/meson.build
+++ b/test cases/common/105 find program path/meson.build
@@ -2,8 +2,7 @@ project('find program', 'c')
 
 prog = find_program('program.py')
 
-# Python 3 is guaranteed to be available because Meson
-# is implemented in it.
-python = find_program('python3')
+# Python 3 should always be available because Meson is implemented in it.
+python = find_python3()
 
 run_command(python, prog.path())

--- a/test cases/common/117 custom target capture/meson.build
+++ b/test cases/common/117 custom target capture/meson.build
@@ -1,6 +1,6 @@
 project('custom target', 'c')
 
-python = find_program('python3')
+python = find_python3()
 
 # Note that this will not add a dependency to the compiler executable.
 # Code will not be rebuilt if it changes.

--- a/test cases/common/16 configure file/meson.build
+++ b/test cases/common/16 configure file/meson.build
@@ -19,7 +19,7 @@ cfile)
 test('inctest', e)
 
 # Now generate a header file with an external script.
-genprog = find_program('python3')
+genprog = find_python3()
 scriptfile = '@0@/generator.py'.format(meson.current_source_dir())
 ifile = '@0@/dummy.dat'.format(meson.current_source_dir())
 ofile = '@0@/config2.h'.format(meson.current_build_dir())

--- a/test cases/common/56 custom target/meson.build
+++ b/test cases/common/56 custom target/meson.build
@@ -1,6 +1,6 @@
 project('custom target', 'c')
 
-python = find_program('python3')
+python = find_python3()
 
 # Note that this will not add a dependency to the compiler executable.
 # Code will not be rebuilt if it changes.

--- a/test cases/common/57 custom target chain/meson.build
+++ b/test cases/common/57 custom target chain/meson.build
@@ -1,6 +1,6 @@
 project('custom target', 'c')
 
-python = find_program('python3')
+python = find_python3()
 
 comp = '@0@/@1@'.format(meson.current_source_dir(), 'my_compiler.py')
 comp2 = '@0@/@1@'.format(meson.current_source_dir(), 'my_compiler2.py')

--- a/test cases/common/58 run target/meson.build
+++ b/test cases/common/58 run target/meson.build
@@ -31,7 +31,7 @@ run_target('upload2',
   depends : hex,
 )
 
-python3 = find_program('python3')
+python3 = find_python3()
 run_target('py3hi',
   command : [python3, '-c', 'print("I am Python3.")'])
 

--- a/test cases/common/59 object generator/meson.build
+++ b/test cases/common/59 object generator/meson.build
@@ -1,6 +1,6 @@
 project('object generator', 'c')
 
-python = find_program('python3')
+python = find_python3()
 
 # Note that this will not add a dependency to the compiler executable.
 # Code will not be rebuilt if it changes.

--- a/test cases/common/76 configure file in custom target/src/meson.build
+++ b/test cases/common/76 configure file in custom target/src/meson.build
@@ -4,11 +4,7 @@ input : cfile,
 command : [find_program('mycompiler.py'), '@INPUT@', '@OUTPUT@'])
 
 # Test usage of a `configure_file` as part of the command list
-py3 = find_program('python3', required : false)
-if not py3.found()
-  # Maybe 'python' is Python 3
-  py3 = find_program('python')
-endif
+py3 = find_python3()
 
 compiler = configure_file(input : 'mycompiler.py',
   output : 'mycompiler2.py',

--- a/test cases/python3/1 basic/meson.build
+++ b/test cases/python3/1 basic/meson.build
@@ -1,6 +1,6 @@
 project('python sample', 'c')
 
-py3 = find_program('python3')
+py3 = find_python3()
 
 main = files('prog.py')
 


### PR DESCRIPTION
The executable name for Python varies depending on the platform that you're on. It can be `python` (Windows, Gentoo, Arch Linux, etc), `python3` (Debian, Fedora, Ubuntu), `python3.5` (NetBSD, etc), and so on. Since Meson is written in Python 3, we always know what the full path to the Python 3 executable is, so this makes build files much more portable.

`find_python2` can be added if there is demand for it, but ideally scripts used for building should just use Python 3 to minimize build dependencies.
