### PR TITLE
Add dependency support to the checks using the compiler

### DIFF
--- a/test cases/linuxlike/9 compiler checks with dependencies/meson.build
+++ b/test cases/linuxlike/9 compiler checks with dependencies/meson.build
@@ -1,0 +1,31 @@
+project('compiler checks with dependencies', 'c')
+
+cc = meson.get_compiler('c')
+
+glib = dependency ('glib-2.0')
+if glib.found()
+  assert (cc.has_header('glib.h', dependencies : glib), 'glib.h not found')
+  assert (cc.has_type('gint32', prefix : '#include <glib.h>', dependencies : glib), 'gint32 not found')
+  assert (cc.has_function('g_print', dependencies : glib), 'g_print not found')
+  assert (cc.has_member('GError', 'message', prefix : '#include <glib.h>', dependencies : glib), 'GError::message not found')
+  assert (cc.has_header_symbol('glib.h', 'gint32', dependencies : glib), 'gint32 symbol not found')
+  linkcode = '''#include <glib.h>
+int main (int argc, char *argv[]) {
+  GError *error = g_error_new_literal (0, 0, NULL);
+  return error == NULL;
+}
+  '''
+  assert (cc.links(linkcode, dependencies : glib, name : 'Test link against glib'), 'Linking test against glib failed')
+endif
+
+zlib = cc.find_library ('z')
+if zlib.found()
+  linkcode = '''#include<zlib.h>
+int main(int argc, char *argv[]) {
+  void *ptr = (void*)(deflate);
+  return ptr == 0;
+}
+'''
+  assert (cc.has_function('deflate', prefix : '#include<zlib.h>', dependencies : zlib, name : 'Test for function in zlib'), 'has_function test failed.')
+  assert (cc.links(linkcode, dependencies : zlib, name : 'Test link against zlib'), 'Linking test failed against zlib.')
+endif


### PR DESCRIPTION
It is extremely common to need to know within a given dependency if
a given header, symbol, member, function, etc exists that cannot be
determined from the version number alone.

Without passing dependency objects to the various compiler/linker
checks and with many libraries headers/libraries being located in
their own subdirs of the standard prefix, the check for the library
would not find the header/function/symbol/etc.

This commit allows passing dependency objects to the compiler checks so
that the test program can be compiled/linked/run with the necessary
compilation and/or linking flags for that library.

Fixes #134 and #367 

---
Note: For the test, I originally tried to implement my own small library that I could depend on however that became a nightmare for numerous reasons.
1. Such a setup would require building the library so/dll/dylib before the parent meson.build checks for things in it.  This limits the allowed dependencies to only allow external deps.
2.1. Or, would require setting up pkg-config to point to some test directory which means that the aforementioned library would have to be installed as well.
2.2. Which means it would have to be in a path without spaces as both pkg-config and meson get this wrong for cflags/libs.

Instead the test just uses some other common libraries (glib and zlib) like the other tests do.