### PR TITLE
configuration_data: can pass descriptions to setters

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1271,7 +1271,7 @@ class ConfigurationData():
         return repr(self.values)
 
     def get(self, name):
-        return self.values[name]
+        return self.values[name]                 # (val, desc)
 
     def keys(self):
         return self.values.keys()

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -228,40 +228,44 @@ class ConfigurationDataHolder(InterpreterObject):
     def mark_used(self):
         self.used = True
 
-    def validate_args(self, args):
+    def validate_args(self, args, kwargs):
         if len(args) != 2:
             raise InterpreterException("Configuration set requires 2 arguments.")
         if self.used:
             raise InterpreterException("Can not set values on configuration object that has been used.")
         name = args[0]
         val = args[1]
+        desc = kwargs.get('description', None)
         if not isinstance(name, str):
             raise InterpreterException("First argument to set must be a string.")
-        return (name, val)
+        if desc is not None and not isinstance(desc, str):
+            raise InterpreterException('Description must be a string.')
+
+        return (name, val, desc)
 
     def set_method(self, args, kwargs):
-        (name, val) = self.validate_args(args)
-        self.held_object.values[name] = val
+        (name, val, desc) = self.validate_args(args, kwargs)
+        self.held_object.values[name] = (val, desc)
 
     def set_quoted_method(self, args, kwargs):
-        (name, val) = self.validate_args(args)
+        (name, val, desc) = self.validate_args(args, kwargs)
         if not isinstance(val, str):
             raise InterpreterException("Second argument to set_quoted must be a string.")
         escaped_val = '\\"'.join(val.split('"'))
-        self.held_object.values[name] = '"' + escaped_val + '"'
+        self.held_object.values[name] = ('"' + escaped_val + '"', desc)
 
     def set10_method(self, args, kwargs):
-        (name, val) = self.validate_args(args)
+        (name, val, desc) = self.validate_args(args, kwargs)
         if val:
-            self.held_object.values[name] = 1
+            self.held_object.values[name] = (1, desc)
         else:
-            self.held_object.values[name] = 0
+            self.held_object.values[name] = (0, desc)
 
     def has_method(self, args, kwargs):
         return args[0] in self.held_object.values
 
     def get(self, name):
-        return self.held_object.values[name]
+        return self.held_object.values[name]     # (val, desc)
 
     def keys(self):
         return self.held_object.values.keys()

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -221,7 +221,7 @@ def do_replacement(regex, line, confdata):
     while match:
         varname = match.group(1)
         if varname in confdata.keys():
-            var = confdata.get(varname)
+            (var, desc) = confdata.get(varname)
             if isinstance(var, str):
                 pass
             elif isinstance(var, int):
@@ -240,7 +240,7 @@ def do_mesondefine(line, confdata):
         raise MesonException('#mesondefine does not contain exactly two tokens: %s', line.strip())
     varname = arr[1]
     try:
-        v = confdata.get(varname)
+        (v, desc) = confdata.get(varname)
     except KeyError:
         return '/* #undef %s */\n' % varname
     if isinstance(v, bool):
@@ -289,7 +289,9 @@ def dump_conf_header(ofilename, cdata):
 
 ''')
         for k in sorted(cdata.keys()):
-            v = cdata.get(k)
+            (v, desc) = cdata.get(k)
+            if desc:
+                ofile.write('/* %s */\n' % desc)
             if isinstance(v, bool):
                 if v:
                     ofile.write('#define %s\n\n' % k)

--- a/test cases/common/16 configure file/meson.build
+++ b/test cases/common/16 configure file/meson.build
@@ -34,7 +34,7 @@ test('inctest2', executable('prog2', 'prog2.c'))
 # Generate a conf file without an input file.
 
 dump = configuration_data()
-dump.set_quoted('SHOULD_BE_STRING', 'string')
+dump.set_quoted('SHOULD_BE_STRING', 'string', description : 'A string')
 dump.set_quoted('SHOULD_BE_STRING2', 'A "B" C')
 dump.set_quoted('SHOULD_BE_STRING3', 'A "" C')
 dump.set_quoted('SHOULD_BE_STRING4', 'A " C')
@@ -42,7 +42,7 @@ dump.set('SHOULD_BE_RETURN', 'return')
 dump.set('SHOULD_BE_DEFINED', true)
 dump.set('SHOULD_BE_UNDEFINED', false)
 dump.set('SHOULD_BE_ONE', 1)
-dump.set('SHOULD_BE_ZERO', 0)
+dump.set('SHOULD_BE_ZERO', 0, description : 'Absolutely zero')
 dump.set('SHOULD_BE_QUOTED_ONE', '"1"')
 configure_file(output : 'config3.h',
   configuration : dump)


### PR DESCRIPTION
Add support for passing a description string as third argument
to configuration data setter methods. The description string
will be used when meson generates the entire configure file
without a template, autoconf-style.

Not really essential, but was always a bit dissatisfying to port over AC_DEFINE*() statements to meson without anywhere to pass the description string ;)