### PR TITLE
interpreter: Print an error if the fallback dependency variable is not found

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1810,9 +1810,12 @@ class Interpreter():
                 raise
             else:
                 return None
-        dep = self.subprojects[dirname].get_variable_method([varname], {})
+        try:
+            dep = self.subprojects[dirname].get_variable_method([varname], {})
+        except KeyError:
+            raise InterpreterException('Fallback variable {!r} in the subproject {!r} does not exist'.format(varname, dirname))
         if not isinstance(dep, (DependencyHolder, InternalDependencyHolder)):
-            raise InterpreterException('Fallback variable is not a dependency object.')
+            raise InterpreterException('Fallback variable {!r} in the subproject {!r} is not a dependency object.'.format(varname, dirname))
         # Check if the version of the declared dependency matches what we want
         if 'version' in kwargs:
             wanted = kwargs['version']


### PR DESCRIPTION
Without this you get a traceback like this:

```
Traceback (most recent call last):
  File "/home/nirbheek/projects/repositories/github/meson.git/mesonbuild/mesonmain.py", line 282, in run
    app.generate()
  File "/home/nirbheek/projects/repositories/github/meson.git/mesonbuild/mesonmain.py", line 167, in generate
    intr.run()
  File "/home/nirbheek/projects/repositories/github/meson.git/mesonbuild/interpreter.py", line 1227, in run
    self.evaluate_codeblock(self.ast)
  File "/home/nirbheek/projects/repositories/github/meson.git/mesonbuild/interpreter.py", line 1249, in evaluate_codeblock
    raise e
  File "/home/nirbheek/projects/repositories/github/meson.git/mesonbuild/interpreter.py", line 1243, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "/home/nirbheek/projects/repositories/github/meson.git/mesonbuild/interpreter.py", line 1366, in evaluate_statement
    return self.assignment(cur)
  File "/home/nirbheek/projects/repositories/github/meson.git/mesonbuild/interpreter.py", line 2315, in assignment
    value = self.evaluate_statement(node.value)
  File "/home/nirbheek/projects/repositories/github/meson.git/mesonbuild/interpreter.py", line 1364, in evaluate_statement
    return self.function_call(cur)
  File "/home/nirbheek/projects/repositories/github/meson.git/mesonbuild/interpreter.py", line 2302, in function_call
    return self.funcs[func_name](node, self.flatten(posargs), kwargs)
  File "/home/nirbheek/projects/repositories/github/meson.git/mesonbuild/interpreter.py", line 1787, in func_dependency
    fallback_dep = self.dependency_fallback(name, kwargs)
  File "/home/nirbheek/projects/repositories/github/meson.git/mesonbuild/interpreter.py", line 1813, in dependency_fallback
    dep = self.subprojects[dirname].get_variable_method([varname], {})
  File "/home/nirbheek/projects/repositories/github/meson.git/mesonbuild/interpreter.py", line 620, in get_variable_method
    return self.held_object.variables[varname]
KeyError: 'bobtester_dep'
```