### PR TITLE
Add string '.matches' method to match a regex

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -23,7 +23,7 @@ from . import compilers
 from .wrap import wrap
 from . import mesonlib
 
-import os, sys, subprocess, shutil, uuid, re
+import os, sys, subprocess, shutil, uuid, re, fnmatch
 from functools import wraps
 
 import importlib
@@ -2410,7 +2410,7 @@ class Interpreter():
                 return obj.split(s)
             else:
                 return obj.split()
-        elif method_name == 'startswith' or method_name == 'contains' or method_name == 'endswith':
+        elif method_name in ['startswith', 'contains', 'endswith', 'matches']:
             s = posargs[0]
             if not isinstance(s, str):
                 raise InterpreterException('Argument must be a string.')
@@ -2418,7 +2418,13 @@ class Interpreter():
                 return obj.startswith(s)
             elif method_name == 'contains':
                 return obj.find(s) >= 0
-            return obj.endswith(s)
+            elif method_name == 'endswith':
+                return obj.endswith(s)
+            elif method_name == 'matches':
+                for glob_pattern in s.split('|'):
+                    if fnmatch.fnmatch(obj, glob_pattern):
+                        return True
+                return False
         elif method_name == 'to_int':
             try:
                 return int(obj)

--- a/test cases/common/42 string operations/meson.build
+++ b/test cases/common/42 string operations/meson.build
@@ -33,6 +33,22 @@ assert(long.contains('bcd'), 'Does not contain middle part')
 
 assert(not long.contains('dc'), 'Broken contains')
 
+assert(long.matches(prefix + '*'), 'No prefix match')
+assert(not long.matches(prefix), 'Prefix alone should not have matched')
+assert(long.matches('*' + suffix), 'No suffix match')
+assert(long.matches('??' + suffix), 'No suffix match')
+assert(not long.matches('?' + suffix), 'No suffix match')
+assert(not long.matches(suffix), 'Suffix alone should not have matched')
+assert(not long.matches(suffix + '*'), 'Broken glob match (suffix at start)')
+assert(not long.matches('*' + prefix), 'Broken glob match (prefix at end)')
+assert('i586'.matches('i?86'), 'Broken glob match (? subst)')
+assert('i586'.matches('i[3456]86'), 'Broken glob match (sequence)')
+assert('i586'.matches('i[3-6]86'), 'Broken glob match (sequence range)')
+assert(not 'i586'.matches('i[34678]86'), 'Broken glob match (sequence)')
+assert(not 'i586'.matches('i[36-]86'), 'Broken glob match (sequence range)')
+assert('i586'.matches('i386|i486|i586'), 'Broken glob match (multiple options)')
+assert('i586'.matches('i386|i486|i58*'), 'Broken glob match (multiple options)')
+
 assert(long.to_upper() == 'ABCDE', 'Broken to_upper')
 
 assert(long.to_upper().to_lower() == long, 'Broken to_lower')


### PR DESCRIPTION
This allows to write some if statements with lots of options
in a tighter way, or to replace most of the common case/esac
blocks used in configure scripts, e.g.

```
if host_cpu_family.matches('(x86|x86_64|s390.*|arm.*|crisv32.*|etrax.*)')
 ...
endif
```