### PR TITLE
gnome: Print useful error if missing compile_resource arg

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -45,6 +45,9 @@ class GnomeModule:
         if not isinstance(source_dirs, list):
             source_dirs = [source_dirs]
 
+        if len(args) < 2:
+            raise MesonException('Not enough arguments; The name of the resource and the path to the XML file are required')
+
         ifile = args[1]
         if isinstance(ifile, mesonlib.File):
             ifile = os.path.join(ifile.subdir, ifile.fname)


### PR DESCRIPTION
Better than a raw IndexError.