### PR TITLE
compilers: Fix typo in visual studio warning argument 

### DIFF
--- a/test cases/common/94 default options/meson.build
+++ b/test cases/common/94 default options/meson.build
@@ -2,6 +2,7 @@ project('default options', 'cpp', 'c', default_options : [
   'buildtype=debugoptimized',
   'cpp_std=c++03',
   'cpp_eh=none',
+  'warning_level=3',
   ])
 
 cpp = meson.get_compiler('cpp')
@@ -9,10 +10,15 @@ cpp = meson.get_compiler('cpp')
 assert(get_option('buildtype') == 'debugoptimized', 'Build type default value wrong.')
 
 if cpp.get_id() == 'msvc'
-  assert(get_option('cpp_eh') == 'none', 'MSVC eh value wrong.')
+  cpp_eh = get_option('cpp_eh')
+  assert(cpp_eh == 'none', 'MSVC eh value is "' + cpp_eh + '" instead of "none"')
 else
-  assert(get_option('cpp_std') == 'c++03', 'C++ std value wrong.')
+  cpp_std = get_option('cpp_std')
+  assert(cpp_std == 'c++03', 'C++ std value is "' + cpp_std + '" instead of c++03.')
 endif
+
+w_level = get_option('warning_level')
+assert(w_level == '3', 'warning level "' + w_level + '" instead of "3"')
 
 # FIXME. Since we no longer accept invalid options to c_std etc,
 # there is no simple way to test this. Gcc does not seem to expose


### PR DESCRIPTION
+ a test for it