### PR TITLE
Heavy cleanup in compilers and BuildTarget

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -238,27 +238,6 @@ class Backend():
             self.write_benchmark_file(datafile)
         return (test_data, benchmark_data)
 
-    def has_source_suffix(self, target, suffix):
-        for s in target.get_sources():
-            if s.endswith(suffix):
-                return True
-        return False
-
-    def has_vala(self, target):
-        return self.has_source_suffix(target, '.vala')
-
-    def has_rust(self, target):
-        return self.has_source_suffix(target, '.rs')
-
-    def has_cs(self, target):
-        return self.has_source_suffix(target, '.cs')
-
-    def has_swift(self, target):
-        return self.has_source_suffix(target, '.swift')
-
-    def has_d(self, target):
-        return self.has_source_suffix(target, '.d')
-
     def determine_linker(self, target, src):
         if isinstance(target, build.StaticLibrary):
             if self.build.static_cross_linker is not None:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -233,18 +233,18 @@ int dummy;
         if isinstance(target, build.Jar):
             self.generate_jar_target(target, outfile)
             return
-        if 'rust' in self.environment.coredata.compilers.keys() and self.has_rust(target):
+        if 'rust' in target.compilers:
             self.generate_rust_target(target, outfile)
             return
-        if 'cs' in self.environment.coredata.compilers.keys() and self.has_cs(target):
+        if 'cs' in target.compilers:
             self.generate_cs_target(target, outfile)
             return
-        if 'vala' in self.environment.coredata.compilers.keys() and self.has_vala(target):
-            vala_output_files = self.generate_vala_compile(target, outfile)
-            gen_src_deps += vala_output_files
-        if 'swift' in self.environment.coredata.compilers.keys() and self.has_swift(target):
+        if 'swift' in target.compilers:
             self.generate_swift_target(target, outfile)
             return
+        if 'vala' in target.compilers:
+            vala_output_files = self.generate_vala_compile(target, outfile)
+            gen_src_deps += vala_output_files
         self.scan_fortran_module_outputs(target)
         # The following deals with C/C++ compilation.
         (gen_src, gen_other_deps) = self.process_dep_gens(outfile, target)
@@ -717,8 +717,7 @@ int dummy;
         outname_rel = os.path.join(self.get_target_dir(target), fname)
         src_list = target.get_sources()
         class_list = []
-        compiler = self.get_compiler_for_source(src_list[0], False)
-        assert(compiler.get_language() == 'java')
+        compiler = target.compilers['java']
         c = 'c'
         m = ''
         e = ''
@@ -768,8 +767,7 @@ int dummy;
         fname = target.get_filename()
         outname_rel = os.path.join(self.get_target_dir(target), fname)
         src_list = target.get_sources()
-        compiler = self.get_compiler_for_source(src_list[0], False)
-        assert(compiler.get_language() == 'cs')
+        compiler = target.compilers['cs']
         rel_srcs = [s.rel_to_builddir(self.build_to_src) for s in src_list]
         deps = []
         commands = target.extra_args.get('cs', [])
@@ -846,7 +844,7 @@ int dummy;
 
     def generate_vala_compile(self, target, outfile):
         """Vala is compiled into C. Set up all necessary build steps here."""
-        valac = self.environment.coredata.compilers['vala']
+        valac = target.compilers['vala']
         (src, vapi_src) = self.split_vala_sources(target.get_sources())
         vapi_src = [x.rel_to_builddir(self.build_to_src) for x in vapi_src]
         extra_dep_files = []
@@ -909,7 +907,7 @@ int dummy;
         return generated_c_files
 
     def generate_rust_target(self, target, outfile):
-        rustc = self.environment.coredata.compilers['rust']
+        rustc = target.compilers['rust']
         relsrc = []
         for i in target.get_sources():
             if not rustc.can_compile(i):
@@ -1000,7 +998,7 @@ int dummy;
 
     def generate_swift_target(self, target, outfile):
         module_name = self.target_swift_modulename(target)
-        swiftc = self.environment.coredata.compilers['swift']
+        swiftc = target.compilers['swift']
         abssrc = []
         abs_headers = []
         header_imports = []

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -240,8 +240,7 @@ int dummy;
             self.generate_cs_target(target, outfile)
             return
         if 'vala' in self.environment.coredata.compilers.keys() and self.has_vala(target):
-            vc = self.environment.coredata.compilers['vala']
-            vala_output_files = self.generate_vala_compile(vc, target, outfile)
+            vala_output_files = self.generate_vala_compile(target, outfile)
             gen_src_deps += vala_output_files
         if 'swift' in self.environment.coredata.compilers.keys() and self.has_swift(target):
             self.generate_swift_target(target, outfile)
@@ -845,7 +844,7 @@ int dummy;
                     break
         return result
 
-    def generate_vala_compile(self, compiler, target, outfile):
+    def generate_vala_compile(self, target, outfile):
         """Vala is compiled into C. Set up all necessary build steps here."""
         valac = self.environment.coredata.compilers['vala']
         (src, vapi_src) = self.split_vala_sources(target.get_sources())
@@ -866,8 +865,8 @@ int dummy;
         generated_c_files = []
         outputs = [vapiname]
         args = []
-        args += self.build.get_global_args(compiler)
-        args += compiler.get_buildtype_args(self.environment.coredata.get_builtin_option('buildtype'))
+        args += self.build.get_global_args(valac)
+        args += valac.get_buildtype_args(self.environment.coredata.get_builtin_option('buildtype'))
         args += ['-d', self.get_target_private_dir(target)]
         args += ['-C']#, '-o', cname]
         if not isinstance(target, build.Executable):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -51,36 +51,16 @@ known_shlib_kwargs.update({'version' : True,
                            'name_suffix' : True,
                            'vs_module_defs' : True})
 
-def sources_are_suffix(sources, suffix):
-    for source in sources:
-        if source.endswith('.' + suffix):
-            return True
-    return False
-
-def compiler_is_msvc(sources, is_cross, env):
+def compilers_are_msvc(compilers):
     """
-    Since each target does not currently have the compiler information attached
-    to it, we must do this detection manually here.
-
-    This detection is purposely incomplete and will cause bugs if other code is
-    extended and this piece of code is forgotten.
+    Check if all the listed compilers are MSVC. Used by Executable,
+    StaticLibrary, and SharedLibrary for deciding when to use MSVC-specific
+    file naming.
     """
-    compiler = None
-    if sources_are_suffix(sources, 'c'):
-        try:
-            compiler = env.detect_c_compiler(is_cross)
-        except MesonException:
+    for compiler in compilers.values():
+        if compiler.get_id() != 'msvc':
             return False
-    elif sources_are_suffix(sources, 'cxx') or \
-         sources_are_suffix(sources, 'cpp') or \
-         sources_are_suffix(sources, 'cc'):
-        try:
-            compiler = env.detect_cpp_compiler(is_cross)
-        except MesonException:
-            return False
-    if compiler and compiler.get_id() == 'msvc':
-        return True
-    return False
+    return True
 
 
 class InvalidArguments(MesonException):
@@ -234,7 +214,9 @@ class BuildTarget():
         self.subdir = subdir
         self.subproject = subproject # Can not be calculated from subdir as subproject dirname can be changed per project.
         self.is_cross = is_cross
+        self.environment = environment
         self.sources = []
+        self.compilers = {}
         self.objects = []
         self.external_deps = []
         self.include_dirs = []
@@ -256,6 +238,7 @@ class BuildTarget():
             len(self.generated) == 0 and \
             len(self.objects) == 0:
             raise InvalidArguments('Build target %s has no sources.' % name)
+        self.process_compilers()
         self.validate_sources()
 
     def __repr__(self):
@@ -319,6 +302,27 @@ class BuildTarget():
             else:
                 msg = 'Bad source of type {!r} in target {!r}.'.format(type(s).__name__, self.name)
                 raise InvalidArguments(msg)
+
+    @staticmethod
+    def can_compile_remove_sources(compiler, sources):
+        removed = False
+        for s in sources[:]:
+            if compiler.can_compile(s):
+                sources.remove(s)
+                removed = True
+        return removed
+
+    def process_compilers(self):
+        if len(self.sources) == 0:
+            return
+        sources = list(self.sources)
+        if self.is_cross:
+            compilers = self.environment.coredata.cross_compilers
+        else:
+            compilers = self.environment.coredata.compilers
+        for lang, compiler in compilers.items():
+            if self.can_compile_remove_sources(compiler, sources):
+                self.compilers[lang] = compiler
 
     def validate_sources(self):
         if len(self.sources) > 0:
@@ -768,7 +772,7 @@ class Executable(BuildTarget):
             self.prefix = ''
         if not hasattr(self, 'suffix'):
             # Executable for Windows or C#/Mono
-            if for_windows(is_cross, environment) or sources_are_suffix(self.sources, 'cs'):
+            if for_windows(is_cross, environment) or 'cs' in self.compilers:
                 self.suffix = 'exe'
             else:
                 self.suffix = ''
@@ -777,8 +781,7 @@ class Executable(BuildTarget):
             self.filename += '.' + self.suffix
         # See determine_debug_filenames() in build.SharedLibrary
         buildtype = environment.coredata.get_builtin_option('buildtype')
-        if compiler_is_msvc(self.sources, is_cross, environment) and \
-           buildtype.startswith('debug'):
+        if compilers_are_msvc(self.compilers) and buildtype.startswith('debug'):
             self.debug_filename = self.prefix + self.name + '.pdb'
 
     def type_suffix(self):
@@ -787,7 +790,7 @@ class Executable(BuildTarget):
 class StaticLibrary(BuildTarget):
     def __init__(self, name, subdir, subproject, is_cross, sources, objects, environment, kwargs):
         super().__init__(name, subdir, subproject, is_cross, sources, objects, environment, kwargs)
-        if sources_are_suffix(self.sources, 'cs'):
+        if 'cs' in self.compilers:
             raise InvalidArguments('Static libraries not supported for C#.')
         # By default a static library is named libfoo.a even on Windows because
         # MSVC does not have a consistent convention for what static libraries
@@ -800,15 +803,14 @@ class StaticLibrary(BuildTarget):
             self.prefix = 'lib'
         if not hasattr(self, 'suffix'):
             # Rust static library crates have .rlib suffix
-            if sources_are_suffix(self.sources, 'rs'):
+            if 'rust' in self.compilers:
                 self.suffix = 'rlib'
             else:
                 self.suffix = 'a'
         self.filename = self.prefix + self.name + '.' + self.suffix
         # See determine_debug_filenames() in build.SharedLibrary
         buildtype = environment.coredata.get_builtin_option('buildtype')
-        if compiler_is_msvc(self.sources, is_cross, environment) and \
-           buildtype.startswith('debug'):
+        if compilers_are_msvc(self.compilers) and buildtype.startswith('debug'):
             self.debug_filename = self.prefix + self.name + '.pdb'
 
     def type_suffix(self):
@@ -864,12 +866,12 @@ class SharedLibrary(BuildTarget):
         if self.prefix != None and self.suffix != None:
             pass
         # C# and Mono
-        elif sources_are_suffix(self.sources, 'cs'):
+        elif 'cs' in self.compilers:
             prefix = ''
             suffix = 'dll'
             self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
         # Rust
-        elif sources_are_suffix(self.sources, 'rs'):
+        elif 'rust' in self.compilers:
             # Currently, we always build --crate-type=rlib
             prefix = 'lib'
             suffix = 'rlib'
@@ -881,7 +883,7 @@ class SharedLibrary(BuildTarget):
             suffix = 'dll'
             self.vs_import_filename = '{0}.lib'.format(self.name)
             self.gcc_import_filename = 'lib{0}.dll.a'.format(self.name)
-            if compiler_is_msvc(self.sources, is_cross, env):
+            if compilers_are_msvc(self.compilers):
                 # Shared library is of the form foo.dll
                 prefix = ''
                 # Import library is called foo.lib
@@ -928,7 +930,7 @@ class SharedLibrary(BuildTarget):
         determine_filenames() above.
         """
         buildtype = env.coredata.get_builtin_option('buildtype')
-        if compiler_is_msvc(self.sources, is_cross, env) and buildtype.startswith('debug'):
+        if compilers_are_msvc(self.compilers) and buildtype.startswith('debug'):
             # Currently we only implement separate debug symbol files for MSVC
             # since the toolchain does it for us. Other toolchains embed the
             # debugging symbols in the file itself by default.

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1259,7 +1259,7 @@ class ValaCompiler(Compiler):
         self.language = 'vala'
         super().__init__(exelist, version)
         self.version = version
-        self.id = 'unknown'
+        self.id = 'valac'
         self.is_cross = False
 
     def name_string(self):
@@ -1293,7 +1293,7 @@ class RustCompiler(Compiler):
     def __init__(self, exelist, version):
         self.language = 'rust'
         super().__init__(exelist, version)
-        self.id = 'unknown'
+        self.id = 'rustc'
 
     def needs_static_linker(self):
         return False

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -332,6 +332,15 @@ class Compiler():
             return True
         return False
 
+    def get_id(self):
+        return self.id
+
+    def get_language(self):
+        return self.language
+
+    def get_exelist(self):
+        return self.exelist[:]
+
     def get_always_args(self):
         return []
 
@@ -465,9 +474,6 @@ class CCompiler(Compiler):
     def build_rpath_args(self, build_dir, rpath_paths, install_rpath):
         return build_unix_rpath_args(build_dir, rpath_paths, install_rpath)
 
-    def get_id(self):
-        return self.id
-
     def get_dependency_gen_args(self, outtarget, outfile):
         return ['-MMD', '-MQ', outtarget, '-MF', outfile]
 
@@ -476,9 +482,6 @@ class CCompiler(Compiler):
 
     def get_depfile_suffix(self):
         return 'd'
-
-    def get_language(self):
-        return self.language
 
     def get_default_suffix(self):
         return self.default_suffix
@@ -1090,20 +1093,11 @@ class MonoCompiler(Compiler):
     def build_rpath_args(self, build_dir, rpath_paths, install_rpath):
         return []
 
-    def get_id(self):
-        return self.id
-
     def get_dependency_gen_args(self, outtarget, outfile):
         return []
 
-    def get_language(self):
-        return self.language
-
     def get_default_suffix(self):
         return self.default_suffix
-
-    def get_exelist(self):
-        return self.exelist[:]
 
     def get_linker_exelist(self):
         return self.exelist[:]
@@ -1186,20 +1180,11 @@ class JavaCompiler(Compiler):
     def build_rpath_args(self, build_dir, rpath_paths, install_rpath):
         return []
 
-    def get_id(self):
-        return self.id
-
     def get_dependency_gen_args(self, outtarget, outfile):
         return []
 
-    def get_language(self):
-        return self.language
-
     def get_default_suffix(self):
         return self.default_suffix
-
-    def get_exelist(self):
-        return self.exelist[:]
 
     def get_linker_exelist(self):
         return self.exelist[:]
@@ -1283,14 +1268,8 @@ class ValaCompiler(Compiler):
     def needs_static_linker(self):
         return False # Because compiles into C.
 
-    def get_exelist(self):
-        return self.exelist[:]
-
     def get_werror_args(self):
         return ['--fatal-warnings']
-
-    def get_language(self):
-        return self.language
 
     def sanity_check(self, work_dir, environment):
         src = 'valatest.vala'
@@ -1322,15 +1301,6 @@ class RustCompiler(Compiler):
     def name_string(self):
         return ' '.join(self.exelist)
 
-    def get_exelist(self):
-        return self.exelist[:]
-
-    def get_id(self):
-        return self.id
-
-    def get_language(self):
-        return self.language
-
     def sanity_check(self, work_dir, environment):
         source_name = os.path.join(work_dir, 'sanity.rs')
         output_name = os.path.join(work_dir, 'rusttest')
@@ -1359,9 +1329,6 @@ class SwiftCompiler(Compiler):
         self.id = 'llvm'
         self.is_cross = False
 
-    def get_id(self):
-        return self.id
-
     def get_linker_exelist(self):
         return self.exelist[:]
 
@@ -1371,14 +1338,8 @@ class SwiftCompiler(Compiler):
     def needs_static_linker(self):
         return True
 
-    def get_exelist(self):
-        return self.exelist[:]
-
     def get_werror_args(self):
         return ['--fatal-warnings']
-
-    def get_language(self):
-        return self.language
 
     def get_dependency_gen_args(self, outtarget, outfile):
         return ['-emit-dependencies']
@@ -1466,15 +1427,6 @@ class DCompiler(Compiler):
 
     def name_string(self):
         return ' '.join(self.exelist)
-
-    def get_exelist(self):
-        return self.exelist
-
-    def get_id(self):
-        return self.id
-
-    def get_language(self):
-        return self.language
 
     def get_linker_exelist(self):
         return self.exelist[:]
@@ -2176,17 +2128,8 @@ class FortranCompiler(Compiler):
         self.gcc_type = GCC_STANDARD
         self.id = "IMPLEMENTATION CLASSES MUST SET THIS"
 
-    def get_id(self):
-        return self.id
-
     def name_string(self):
         return ' '.join(self.exelist)
-
-    def get_exelist(self):
-        return self.exelist[:]
-
-    def get_language(self):
-        return self.language
 
     def get_pic_args(self):
         if self.gcc_type == GCC_MINGW:

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -474,7 +474,12 @@ class BoostDependency(Dependency):
     def __init__(self, environment, kwargs):
         Dependency.__init__(self)
         self.name = 'boost'
+        self.environment = environment
         self.libdir = ''
+        if 'native' in kwargs and environment.is_cross_build():
+            want_cross = not kwargs['native']
+        else:
+            want_cross = environment.is_cross_build()
         try:
             self.boost_root = os.environ['BOOST_ROOT']
             if not os.path.isabs(self.boost_root):
@@ -482,6 +487,8 @@ class BoostDependency(Dependency):
         except KeyError:
             self.boost_root = None
         if self.boost_root is None:
+            if want_cross:
+                raise DependencyException('BOOST_ROOT is needed while cross-compiling')
             if mesonlib.is_windows():
                 self.boost_root = self.detect_win_root()
                 self.incdir = self.boost_root

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -110,9 +110,8 @@ def detect_windows_arch(compilers):
             platform = os.environ.get('Platform', 'x86').lower()
             if platform == 'x86':
                 return platform
-        if compiler.id == 'gcc':
-            # TODO: Implement this
-            pass
+        if compiler.id == 'gcc' and compiler.has_define('__i386__'):
+            return 'x86'
     return os_arch
 
 def detect_cpu_family(compilers):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -375,7 +375,8 @@ class GeneratedListHolder(InterpreterObject):
         self.held_object.add_file(a)
 
 class BuildMachine(InterpreterObject):
-    def __init__(self):
+    def __init__(self, compilers):
+        self.compilers = compilers
         InterpreterObject.__init__(self)
         self.methods.update({'system' : self.system_method,
                              'cpu_family' : self.cpu_family_method,
@@ -384,10 +385,10 @@ class BuildMachine(InterpreterObject):
                             })
 
     def cpu_family_method(self, args, kwargs):
-        return environment.detect_cpu_family()
+        return environment.detect_cpu_family(self.compilers)
 
     def cpu_method(self, args, kwargs):
-        return environment.detect_cpu()
+        return environment.detect_cpu(self.compilers)
 
     def system_method(self, args, kwargs):
         return environment.detect_system()
@@ -1099,7 +1100,7 @@ class Interpreter():
         self.variables = {}
         self.builtin = {}
         self.parse_project()
-        self.builtin['build_machine'] = BuildMachine()
+        self.builtin['build_machine'] = BuildMachine(self.coredata.compilers)
         if not self.build.environment.is_cross_build():
             self.builtin['host_machine'] = self.builtin['build_machine']
             self.builtin['target_machine'] = self.builtin['build_machine']

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1069,6 +1069,8 @@ class Interpreter():
 
     def __init__(self, build, backend, subproject='', subdir='', subproject_dir='subprojects'):
         self.build = build
+        self.environment = build.environment
+        self.coredata = self.environment.get_coredata()
         self.backend = backend
         self.subproject = subproject
         self.subdir = subdir
@@ -1096,6 +1098,7 @@ class Interpreter():
         self.sanity_check_ast()
         self.variables = {}
         self.builtin = {}
+        self.parse_project()
         self.builtin['build_machine'] = BuildMachine()
         if not self.build.environment.is_cross_build():
             self.builtin['host_machine'] = self.builtin['build_machine']
@@ -1111,10 +1114,8 @@ class Interpreter():
             else:
                 self.builtin['target_machine'] = self.builtin['host_machine']
         self.builtin['meson'] = MesonMain(build, self)
-        self.environment = build.environment
         self.build_func_dict()
         self.build_def_files = [os.path.join(self.subdir, environment.build_filename)]
-        self.coredata = self.environment.get_coredata()
         self.generators = []
         self.visited_subdirs = {}
         self.global_args_frozen = False
@@ -1166,6 +1167,15 @@ class Interpreter():
                       'environment' : self.func_environment,
                      }
 
+    def parse_project(self):
+        """
+        Parses project() and initializes languages, compilers etc. Do this
+        early because we need this before we parse the rest of the AST.
+        """
+        project = self.ast.lines[0]
+        args, kwargs = self.reduce_arguments(project.args)
+        self.func_project(project, args, kwargs)
+
     def module_method_callback(self, invalues):
         unwrap_single = False
         if invalues is None:
@@ -1214,6 +1224,10 @@ class Interpreter():
         first = self.ast.lines[0]
         if not isinstance(first, mparser.FunctionNode) or first.func_name != 'project':
             raise InvalidCode('First statement must be a call to project')
+        args = self.reduce_arguments(first.args)[0]
+        if len(args) < 2:
+            raise InvalidArguments('Not enough arguments to project(). Needs at least the project name and one language')
+
 
     def check_cross_stdlibs(self):
         if self.build.environment.is_cross_build():
@@ -1232,10 +1246,12 @@ class Interpreter():
                     pass
 
     def run(self):
-        self.evaluate_codeblock(self.ast)
+        # Evaluate everything after the first line, which is project() because
+        # we already parsed that in self.parse_project()
+        self.evaluate_codeblock(self.ast, start=1)
         mlog.log('Build targets in project:', mlog.bold(str(len(self.build.targets))))
 
-    def evaluate_codeblock(self, node):
+    def evaluate_codeblock(self, node, start=0):
         if node is None:
             return
         if not isinstance(node, mparser.CodeBlockNode):
@@ -1244,7 +1260,7 @@ class Interpreter():
             e.colno = node.colno
             raise e
         statements = node.lines
-        i = 0
+        i = start
         while i < len(statements):
             cur = statements[i]
             try:
@@ -1565,9 +1581,6 @@ class Interpreter():
 
     @stringArgs
     def func_project(self, node, args, kwargs):
-        if len(args) < 2:
-            raise InvalidArguments('Not enough arguments to project(). Needs at least the project name and one language')
-
         if not self.is_subproject():
             self.build.project_name = args[0]
             if self.environment.first_invocation and 'default_options' in kwargs:
@@ -1589,7 +1602,7 @@ class Interpreter():
                 raise InterpreterException('Meson version is %s but project requires %s.' % (cv, pv))
         self.build.projects[self.subproject] = args[0]
         mlog.log('Project name: ', mlog.bold(args[0]), sep='')
-        self.add_languages(node, args[1:], True)
+        self.add_languages(args[1:], True)
         langs = self.coredata.compilers.keys()
         if 'vala' in langs:
             if not 'c' in langs:
@@ -1599,7 +1612,7 @@ class Interpreter():
 
     @stringArgs
     def func_add_languages(self, node, args, kwargs):
-        return self.add_languages(node, args, kwargs.get('required', True))
+        return self.add_languages(args, kwargs.get('required', True))
 
     @noKwargs
     def func_message(self, node, args, kwargs):
@@ -1619,8 +1632,6 @@ class Interpreter():
             raise InvalidArguments('Function accepts only strings, integers, lists and lists thereof.')
 
         mlog.log(mlog.bold('Message:'), argstr)
-        return
-
 
     @noKwargs
     def func_error(self, node, args, kwargs):
@@ -1697,7 +1708,7 @@ class Interpreter():
         self.coredata.compiler_options = new_options
         return (comp, cross_comp)
 
-    def add_languages(self, node, args, required):
+    def add_languages(self, args, required):
         success = True
         need_cross_compiler = self.environment.is_cross_build() and self.environment.cross_info.need_cross_compiler()
         for lang in args:

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -91,9 +91,6 @@ def is_windows():
     platname = platform.system().lower()
     return platname == 'windows' or 'mingw' in platname
 
-def is_32bit():
-    return not(sys.maxsize > 2**32)
-
 def is_debianlike():
     return os.path.isfile('/etc/debian_version')
 


### PR DESCRIPTION
This PR is a result of several hours of yak-shaving. I wanted to fix one small thing: remove the quirk that we have where we take the architecture that Python was built with as the OS architecture. This is fine on Linux and OS X, but it is commonly broken on Windows because people sometimes install 32-bit Python on 64-bit Windows.

This led to me fixing the general problem that we require a cross-info file even while building 32-bit apps on 64-bit Windows even though no other Windows build system has this requirement.

That led to a natural way to fix MinGW detection on Windows (#650) and to fix the boost arch detection under Windows (#526).

Finally, this led me to the `compiler_is_msvc()` mess in `build.py` and so now we also include the list of compilers used for a target with that target, and we can start moving the target-sources-meet-XYZ-criteria checks into `BuildTarget` instead of duplicating them in small helper functions in `build.py`, `backends.py`, `ninjabackend.py`, etc.