### PR TITLE
Give a helpful exception when target has no name

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2231,6 +2231,8 @@ class Interpreter():
             self.coredata.target_guids[idname] = str(uuid.uuid4()).upper()
 
     def build_target(self, node, args, kwargs, targetholder):
+        if len(args) == 0:
+            raise InterpreterException('Target does not have a name.')
         name = args[0]
         sources = args[1:]
         if self.environment.is_cross_build():


### PR DESCRIPTION
I mistakenly added this somewhere in a long meson.build file:

    libproject_foo = library(
    )

Meson rewarded me with this:

    Traceback (most recent call last):
      ...
      File "/home/sam/meson/mesonbuild/interpreter.py", line 1835, in func_shared_lib
        return self.build_target(node, args, kwargs, SharedLibraryHolder)
      File "/home/sam/meson/mesonbuild/interpreter.py", line 2234, in build_target
        name = args[0]
    IndexError: list index out of range

Now, you get a more helpful error instead:

    Meson encountered an error in file meson.build, line 369, column 0:
    Target does not have a name.