### PR TITLE
Support running Meson as a Python zip application

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -45,3 +45,4 @@ Elliott Sales de Andrade
 Patrick Griffis
 Iain Lane
 Daniel Brendle
+Franz Zapata

--- a/meson.py
+++ b/meson.py
@@ -17,8 +17,14 @@
 from mesonbuild import mesonmain
 import sys, os
 
-thisfile = __file__
-if not os.path.isabs(thisfile):
-    thisfile = os.path.normpath(os.path.join(os.getcwd(), thisfile))
+def main():
+    thisfile = __file__
+    if not os.path.isabs(thisfile):
+        thisfile = os.path.normpath(os.path.join(os.getcwd(), thisfile))
+    if __package__ == '':
+        thisfile = os.path.dirname(thisfile)
 
-sys.exit(mesonmain.run(thisfile, sys.argv[1:]))
+    sys.exit(mesonmain.run(thisfile, sys.argv[1:]))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This allows Meson to be packaged as a zip archive which can be directly executed by Python (see [zipapp][1]). Creating these archives can be done with Python itself since 3.5:

````sh
# With 'meson-build' being a git clone
python3 -m zipapp -p '/usr/bin/env python3' -m meson:main -o meson meson-build
````

The resulting archive can be executed like a script: `python3 meson`, or run directly  as `./meson`.

I believe this is related to #588.

[1]: https://docs.python.org/3/library/zipapp.html