### PR TITLE
User argv[0] to internally relaunch meson.py

### DIFF
--- a/meson.py
+++ b/meson.py
@@ -17,14 +17,4 @@
 from mesonbuild import mesonmain
 import sys, os
 
-def main():
-    thisfile = __file__
-    if not os.path.isabs(thisfile):
-        thisfile = os.path.normpath(os.path.join(os.getcwd(), thisfile))
-    if __package__ == '':
-        thisfile = os.path.dirname(thisfile)
-
-    sys.exit(mesonmain.run(thisfile, sys.argv[1:]))
-
-if __name__ == '__main__':
-    main()
+sys.exit(mesonmain.run(sys.argv[0], sys.argv[1:]))


### PR DESCRIPTION
During Meson installation with eggs, distutils may choose to put
shim scripts in the PATH that only set up the egg requirements
before launching the real `meson.py` contained in the egg.

This means that __file__ points to the real `meson.py` file, but
launching it directly is doomed to fail as it's missing the metadata
contained in the shim to set up the path egg, resulting in errors when
trying to import the `mesonbuild` module.

Using argv[0] works around this issue as it points to the command
used to launch the shim script, so it should be safe to use it again
to relaunch it.