### PR TITLE
Allow defining pre-requisite args for has_argument.

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -621,6 +621,7 @@ class CompilerHolder(InterpreterObject):
                              'cmd_array' : self.cmd_array_method,
                              'find_library': self.find_library_method,
                              'has_argument' : self.has_argument_method,
+                             'has_multi_arguments' : self.has_multi_arguments_method,
                              'first_supported_argument' : self.first_supported_argument_method,
                              'unittest_args' : self.unittest_args_method,
                             })
@@ -916,6 +917,19 @@ class CompilerHolder(InterpreterObject):
         else:
             h = mlog.red('NO')
         mlog.log('Compiler for {} supports argument {}:'.format(self.compiler.language, args[0]), h)
+        return result
+
+    def has_multi_arguments_method(self, args, kwargs):
+        args = mesonlib.stringlistify(args)
+        result = self.compiler.has_multi_arguments(args, self.environment)
+        if result:
+            h = mlog.green('YES')
+        else:
+            h = mlog.red('NO')
+        mlog.log(
+            'Compiler for {} supports arguments {}:'.format(
+                self.compiler.language, ' '.join(args)),
+            h)
         return result
 
     def first_supported_argument_method(self, args, kwargs):

--- a/test cases/common/112 has arg/meson.build
+++ b/test cases/common/112 has arg/meson.build
@@ -33,3 +33,12 @@ l2 = cpp.first_supported_argument(isnt_arg, isnt_arg, isnt_arg)
 assert(l1.length() == 1, 'First supported returned wrong result.')
 assert(l1.get(0) == is_arg, 'First supported returned wrong argument.')
 assert(l2.length() == 0, 'First supported did not return empty array.')
+
+if cc.get_id() == 'gcc'
+  pre_arg = '-Wformat'
+  anti_pre_arg = '-Wno-format'
+  arg = '-Werror=format-security'
+  assert(not cc.has_multi_arguments([anti_pre_arg, arg]), 'Arg that should be broken is not.')
+  assert(cc.has_multi_arguments(pre_arg), 'Arg that should have worked does not work.')
+  assert(cc.has_multi_arguments([pre_arg, arg]), 'Arg that should have worked does not work.')
+endif


### PR DESCRIPTION
Sometimes when using `has_argument`, you need to specify _another_ one to get it to work. I really only have the one example, which is in the tests, but only for GCC. I'm not sure if there are any other cases of this sort of thing with other compilers.
