### PR TITLE
Allow forcing undefined symbols on a per-target basis.

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1820,6 +1820,9 @@ rule FORTRAN_DEP_HACK
         commands += linker.get_buildtype_linker_args(self.environment.coredata.get_builtin_option('buildtype'))
         commands += linker.get_option_link_args(self.environment.coredata.compiler_options)
         commands += self.get_link_debugfile_args(linker, target, outname)
+        if (isinstance(target, (build.SharedLibrary, build.Executable)) and
+                target.allow_undefined):
+            commands += linker.get_linker_allow_undefined()
         if not(isinstance(target, build.StaticLibrary)):
             commands += self.environment.coredata.external_link_args[linker.get_language()]
         if isinstance(target, build.Executable):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -33,6 +33,7 @@ known_basic_kwargs = {'install' : True,
                       'link_with' : True,
                       'include_directories': True,
                       'dependencies' : True,
+                      'allow_undefined' : True,
                       'install_dir' : True,
                       'main_class' : True,
                       'gui_app' : True,
@@ -235,6 +236,8 @@ class BuildTarget():
         # The file with debugging symbols
         self.debug_filename = None
         self.need_install = False
+        # Whether to force allow/disallow undefined references
+        self.allow_undefined = None
         self.pch = {}
         self.extra_args = {}
         self.generated = []
@@ -527,6 +530,14 @@ class BuildTarget():
                     raise InvalidArguments('name_suffix must be a string.')
                 self.suffix = name_suffix
                 self.name_suffix_set = True
+        if 'allow_undefined' in kwargs:
+            if isinstance(self, StaticLibrary):
+                raise InvalidArguments('Argument allow_undefined cannot be '
+                                       'used on static libraries.')
+            self.allow_undefined = kwargs['allow_undefined']
+            if not isinstance(self.allow_undefined, bool):
+                raise InvalidArguments(
+                    'Argument allow_undefined is not a boolean.')
         if isinstance(self, StaticLibrary):
             # You can't disable PIC on OS X. The compiler ignores -fno-PIC.
             # PIC is always on for Windows (all code is position-independent

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -373,6 +373,9 @@ class Compiler():
     def get_option_link_args(self, options):
         return []
 
+    def get_linker_allow_undefined(self):
+        return []
+
     def has_header(self, *args, **kwargs):
         raise EnvironmentException('Language %s does not support header checks.' % self.language)
 
@@ -1773,6 +1776,9 @@ class VisualStudioCCompiler(CCompiler):
     def get_option_link_args(self, options):
         return options['c_winlibs'].value[:]
 
+    def get_linker_allow_undefined(self):
+        return ['/FORCE:UNRESOLVED']
+
     def unix_link_flags_to_native(self, args):
         result = []
         for i in args:
@@ -1938,6 +1944,9 @@ class GnuCompiler:
     def get_pch_suffix(self):
         return 'gch'
 
+    def get_linker_allow_undefined(self):
+        return ['-Wl,--warn-unresolved-symbols']
+
     def split_shlib_to_parts(self, fname):
         return (os.path.split(fname)[0], fname)
 
@@ -2057,6 +2066,14 @@ class ClangCompiler():
 
     def get_buildtype_linker_args(self, buildtype):
         return gnulike_buildtype_linker_args[buildtype]
+
+    def get_linker_allow_undefined(self):
+        if self.clang_type in (CLANG_STANDARD, CLANG_WIN):
+            return ['-Wl,--warn-unresolved-symbols']
+        elif self.clang_type == CLANG_OSX:
+            return ['-Wl,-undefined,dynamic_lookup']
+        else:
+            raise MesonException('Unreachable code when checking clang type.')
 
     def get_pch_suffix(self):
         return 'pch'
@@ -2280,6 +2297,9 @@ class GnuFortranCompiler(FortranCompiler):
     def get_always_args(self):
         return ['-pipe']
 
+    def get_linker_allow_undefined(self):
+        return ['-Wl,--warn-unresolved-symbols']
+
     def gen_import_library_args(self, implibname):
         """
         The name of the outputted import library
@@ -2437,6 +2457,9 @@ class VisualStudioLinker():
     def get_option_link_args(self, options):
         return []
 
+    def get_linker_allow_undefined(self):
+        return []
+
     def unix_link_flags_to_native(self, args):
         return args[:]
 
@@ -2489,6 +2512,9 @@ class ArLinker():
         return []
 
     def get_option_link_args(self, options):
+        return []
+
+    def get_linker_allow_undefined(self):
         return []
 
     def unix_link_flags_to_native(self, args):

--- a/test cases/common/119 unresolved symbols/meson.build
+++ b/test cases/common/119 unresolved symbols/meson.build
@@ -1,0 +1,20 @@
+project('unresolved symbols', 'c', 'cpp')
+
+executable('unresolved-program', 'unresolved-symbol.c',
+  c_args : '-DEXECUTABLE',
+  allow_undefined : true)
+
+shared_library('unresolved', 'unresolved-symbol.c',
+  allow_undefined : true)
+
+cpp_file = configure_file(
+  input : 'unresolved-symbol.c',
+  output : 'unresolved-symbol.cpp',
+  configuration : configuration_data())
+
+executable('unresolved-cpp-program', cpp_file,
+  cpp_args : '-DEXECUTABLE',
+  allow_undefined : true)
+
+shared_library('unresolved-cpp', cpp_file,
+  allow_undefined : true)

--- a/test cases/common/119 unresolved symbols/unresolved-symbol.c
+++ b/test cases/common/119 unresolved symbols/unresolved-symbol.c
@@ -1,0 +1,12 @@
+void some_unresolved_symbol(void);
+
+int
+#ifdef EXECUTABLE
+main(void)
+#else
+do_stuff(void)
+#endif
+{
+  some_unresolved_symbol();
+  return 0;
+}

--- a/test cases/failing build/2 unresolved symbols/meson.build
+++ b/test cases/failing build/2 unresolved symbols/meson.build
@@ -1,0 +1,16 @@
+project('unresolved symbols', 'c', 'cpp')
+
+executable('unresolved-program', 'unresolved-symbol.c',
+  c_args : '-DEXECUTABLE')
+
+shared_library('unresolved', 'unresolved-symbol.c')
+
+cpp_file = configure_file(
+  input : 'unresolved-symbol.c',
+  output : 'unresolved-symbol.cpp',
+  configuration : configuration_data())
+
+executable('unresolved-cpp-program', cpp_file,
+  cpp_args : '-DEXECUTABLE')
+
+shared_library('unresolved-cpp', cpp_file)

--- a/test cases/failing build/2 unresolved symbols/unresolved-symbol.c
+++ b/test cases/failing build/2 unresolved symbols/unresolved-symbol.c
@@ -1,0 +1,12 @@
+void some_unresolved_symbol(void);
+
+int
+#ifdef EXECUTABLE
+main(void)
+#else
+do_stuff(void)
+#endif
+{
+  some_unresolved_symbol();
+  return 0;
+}


### PR DESCRIPTION
~~This is a bit of a hack, so I'm open to suggestions.~~

Sometimes, when you're building plugins, you _don't_ want to link to another shared library, or maybe you expect the symbols to be in the executable or something. With the default `b_lundef`, you can never build these because of the undefined symbols. Plus, the rest of the code is all properly defined, so I still want to use that default as well.

This PR allows overriding `b_lundef` on a per-target basis (currently only for shared libraries.)
