### PR TITLE
Upload test logs as artifacts on AppVeyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,3 +19,7 @@ build_script:
 
 test_script:
   - cmd: PATH c:\python34;%PATH% && python3 run_tests.py --backend=ninja
+
+on_finish:
+  - appveyor PushArtifact meson-test-run.txt -DeploymentName "Text test logs"
+  - appveyor PushArtifact meson-test-run.xml -DeploymentName "XML test logs"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,7 +18,7 @@ build_script:
   - cmd: echo No build step.
 
 test_script:
-  - cmd: PATH c:\python34;%PATH% && python3 run_tests.py --backend=ninja
+  - cmd: PATH c:\python34;%PATH%; && python3 run_tests.py --backend=ninja
 
 on_finish:
   - appveyor PushArtifact meson-test-run.txt -DeploymentName "Text test logs"


### PR DESCRIPTION
I assume fewer people have Windows setups, so as much information as possible is better. For example, in #833, the test results were fairly unclear as to the problem. However, if you check the test log, it clearly shows the exception that was raised while configuring one of the tests.

This enables uploading of the test logs, an example of which you can see [here for #833](https://ci.appveyor.com/project/jpakkane/meson/build/1.0.478/artifacts).