### PR TITLE
Fix missing comma in backend.Backend.dedup_arguments()

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -620,7 +620,7 @@ class Backend():
         final_commands = []
         previous = '-fsuch_arguments=woof'
         for c in commands:
-            if c.startswith(('-I' '-L', '/LIBPATH')):
+            if c.startswith(('-I', '-L', '/LIBPATH')):
                 if c in includes:
                     continue
                 includes[c] = True


### PR DESCRIPTION
This error meant that -I flags passed to the compiler were never
actually deduplicated.