### PR TITLE
	gnome.py: compile gschemas to $prefix/share/glib-2.0/schemas/

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -338,11 +338,9 @@ class GnomeModule:
         return [scan_target, typelib_target]
 
     def compile_schemas(self, state, args, kwargs):
-        if len(args) != 0:
-            raise MesonException('Compile_schemas does not take positional arguments.')
-        srcdir = os.path.join(state.build_to_src, state.subdir)
-        outdir = state.subdir
-        cmd = ['glib-compile-schemas', '--targetdir', outdir, srcdir]
+        srcdir = os.path.join(state.build_to_src, state.subdir, args[0])
+        outdir = os.path.join(state.environment.get_prefix(), 'share/glib-2.0/schemas')
+        cmd = ['glib-compile-schemas', srcdir, '--targetdir', outdir]
         kwargs['command'] = cmd
         kwargs['input'] = []
         kwargs['output'] = 'gschemas.compiled'

--- a/test cases/frameworks/7 gnome/schemas/meson.build
+++ b/test cases/frameworks/7 gnome/schemas/meson.build
@@ -1,5 +1,5 @@
 
-compiled = gnome.compile_schemas()
+compiled = gnome.compile_schemas('com.github.meson.gschema.xml')
 install_data('com.github.meson.gschema.xml',
 install_dir : 'share/glib-2.0/schemas')
 


### PR DESCRIPTION
There's probably a reason why it was not like this... but I couldn't figure out, so this is what I came up with.