### PR TITLE
swift tests: Port to Swift 3

### DIFF
--- a/test cases/swift/2 multifile/main.swift
+++ b/test cases/swift/2 multifile/main.swift
@@ -1,1 +1,1 @@
-printSomething("String from main")
+printSomething(text:"String from main")

--- a/test cases/swift/4 generate/gen/main.swift
+++ b/test cases/swift/4 generate/gen/main.swift
@@ -4,7 +4,11 @@
     import Glibc
 #endif
 
+#if swift(>=3.0)
+let fname = CommandLine.arguments[1]
+#else
 let fname = Process.arguments[1]
+#endif
 let code = "public func getGenerated() -> Int {\n    return 42\n}\n"
 
 let f = fopen(fname, "w")


### PR DESCRIPTION
This fixes the tests on my Mac Mini. Should remain compatible with Swift 2.2.