### PR TITLE
Add cross-platform PIC support for static libraries

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -341,6 +341,8 @@ class Backend():
             commands += compiler.get_werror_args()
         if isinstance(target, build.SharedLibrary):
             commands += compiler.get_pic_args()
+        if isinstance(target, build.StaticLibrary) and target.pic:
+            commands += compiler.get_pic_args()
         for dep in target.get_external_deps():
             # Cflags required by external deps might have UNIX-specific flags,
             # so filter them out if needed

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1934,8 +1934,8 @@ class GnuCompiler:
             return defines[define]
 
     def get_pic_args(self):
-        if self.gcc_type == GCC_MINGW:
-            return [] # On Window gcc defaults to fpic being always on.
+        if self.gcc_type in (GCC_MINGW, GCC_OSX):
+            return [] # On Window and OS X, pic is always on.
         return ['-fPIC']
 
     def get_buildtype_args(self, buildtype):
@@ -2059,6 +2059,11 @@ class ClangCompiler():
             self.base_options.append('b_lundef')
             self.base_options.append('b_asneeded')
 
+    def get_pic_args(self):
+        if self.clang_type in (CLANG_WIN, CLANG_OSX):
+            return [] # On Window and OS X, pic is always on.
+        return ['-fPIC']
+
     def get_buildtype_args(self, buildtype):
         return gnulike_buildtype_args[buildtype]
 
@@ -2174,8 +2179,8 @@ class FortranCompiler(Compiler):
         return ' '.join(self.exelist)
 
     def get_pic_args(self):
-        if self.gcc_type == GCC_MINGW:
-            return [] # On Windows gcc defaults to fpic being always on.
+        if self.gcc_type in (GCC_MINGW, GCC_OSX):
+            return [] # On Window and OS X, pic is always on.
         return ['-fPIC']
 
     def get_std_shared_lib_link_args(self):

--- a/test cases/common/62 exe static shared/meson.build
+++ b/test cases/common/62 exe static shared/meson.build
@@ -1,6 +1,7 @@
 project('statchain', 'c')
 
 subdir('subdir')
-statlib = static_library('stat', 'stat.c', link_with : shlib)
-exe = executable('prog', 'prog.c', link_with : statlib)
+statlib = static_library('stat', 'stat.c', link_with : shlib, pic : true)
+shlib2 = shared_library('shr2', 'shlib2.c', link_with : statlib)
+exe = executable('prog', 'prog.c', link_with : shlib2)
 test('runtest', exe)

--- a/test cases/common/62 exe static shared/prog.c
+++ b/test cases/common/62 exe static shared/prog.c
@@ -1,5 +1,10 @@
+int shlibfunc2();
 int statlibfunc();
 
 int main(int argc, char **argv) {
-    return statlibfunc() == 42 ? 0 : 1;
+    if (statlibfunc() != 42)
+        return 1;
+    if (shlibfunc2() != 24)
+        return 1;
+    return 0;
 }

--- a/test cases/common/62 exe static shared/shlib2.c
+++ b/test cases/common/62 exe static shared/shlib2.c
@@ -1,0 +1,7 @@
+#include "subdir/exports.h"
+
+int statlibfunc(void);
+
+int DLL_PUBLIC shlibfunc2(void) {
+    return statlibfunc() - 18;
+}

--- a/test cases/common/62 exe static shared/subdir/exports.h
+++ b/test cases/common/62 exe static shared/subdir/exports.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif

--- a/test cases/common/62 exe static shared/subdir/shlib.c
+++ b/test cases/common/62 exe static shared/subdir/shlib.c
@@ -1,13 +1,4 @@
-#if defined _WIN32 || defined __CYGWIN__
-  #define DLL_PUBLIC __declspec(dllexport)
-#else
-  #if defined __GNUC__
-    #define DLL_PUBLIC __attribute__ ((visibility("default")))
-  #else
-    #pragma message ("Compiler does not support symbol visibility.")
-    #define DLL_PUBLIC
-  #endif
-#endif
+#include "exports.h"
 
 int DLL_PUBLIC shlibfunc() {
     return 42;

--- a/test cases/failing/33 exe static shared/meson.build
+++ b/test cases/failing/33 exe static shared/meson.build
@@ -1,0 +1,11 @@
+project('statchain', 'c')
+
+host_system = host_machine.system()
+if host_system == 'windows' or host_system == 'darwin'
+  error('Test only fails on Linux and BSD')
+endif
+
+statlib = static_library('stat', 'stat.c', pic : false)
+shlib2 = shared_library('shr2', 'shlib2.c', link_with : statlib)
+exe = executable('prog', 'prog.c', link_with : shlib2)
+test('runtest', exe)

--- a/test cases/failing/33 exe static shared/prog.c
+++ b/test cases/failing/33 exe static shared/prog.c
@@ -1,0 +1,10 @@
+int shlibfunc2();
+int statlibfunc();
+
+int main(int argc, char **argv) {
+    if (statlibfunc() != 42)
+        return 1;
+    if (shlibfunc2() != 24)
+        return 1;
+    return 0;
+}

--- a/test cases/failing/33 exe static shared/shlib2.c
+++ b/test cases/failing/33 exe static shared/shlib2.c
@@ -1,0 +1,16 @@
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+int statlibfunc(void);
+
+int DLL_PUBLIC shlibfunc2(void) {
+    return 24;
+}

--- a/test cases/failing/33 exe static shared/stat.c
+++ b/test cases/failing/33 exe static shared/stat.c
@@ -1,0 +1,3 @@
+int statlibfunc() {
+    return 42;
+}


### PR DESCRIPTION
With C/C++, on Windows you don't need to pass any arguments for a static library to be PIC. On UNIX platforms you need to pass `-fPIC`.

Other languages such as D have compiler-specific PIC arguments required for PIC support in static libraries on UNIX platforms.

This kwarg allows people to specify which static libraries should be built with PIC support. This is usually used for static libraries that will be linked into shared libraries.