### PR TITLE
allow libdir/includedir/etc. be absolute paths

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -36,11 +36,6 @@ class UserStringOption(UserOption):
     def validate(self, value):
         if not isinstance(value, str):
             raise MesonException('Value "%s" for string option "%s" is not a string.' % (str(value), self.name))
-        if self.name == 'prefix' and not os.path.isabs(value):
-            raise MesonException('Prefix option value \'{0}\' must be an absolute path.'.format(value))
-        if self.name in ('libdir', 'bindir', 'includedir', 'datadir', 'mandir', 'localedir') \
-            and os.path.isabs(value):
-            raise MesonException('Option %s must not be an absolute path.' % self.name)
 
     def set_value(self, newvalue):
         self.validate(newvalue)

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -70,7 +70,7 @@ class MesonApp():
     def __init__(self, dir1, dir2, script_launcher, handshake, options, original_cmd_line_args):
         (self.source_dir, self.build_dir) = self.validate_dirs(dir1, dir2, handshake)
         if not os.path.isabs(options.prefix):
-            raise RuntimeError('--prefix value \'{0}\' must be an absolute path: '.format(options.prefix))
+            raise RuntimeError('--prefix value must be an absolute path: {!r}'.format(options.prefix))
         if options.prefix.endswith('/') or options.prefix.endswith('\\'):
             # On Windows we need to preserve the trailing slash if the
             # string is of type 'C:\' because 'C:' is not an absolute path.


### PR DESCRIPTION
In Fedora we don't care about prefix, we want to ensure that libdir
is /usr/lib64, localedir is /usr/share/locale, and cetera.

Additionally, we don't need to ensure that prefix is absolute as we
check it in main.

Fixes: cc19bf0f45f9 ("Move option validation in objects rather than doing it only in the conf script.")
Closes: https://github.com/mesonbuild/meson/issues/869
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>