### PR TITLE
dependencies: Fix traceback always setting 'variable'

### DIFF
--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -188,6 +188,7 @@ class PkgConfigDependency(Dependency):
         p = subprocess.Popen([self.pkgbin, '--variable=%s' % variable_name, self.name],
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         out = p.communicate()[0]
+        variable = ''
         if p.returncode != 0:
             if self.required:
                 raise DependencyException('%s dependency %s not found.' %

--- a/test cases/frameworks/7 gnome/gir/meson.build
+++ b/test cases/frameworks/7 gnome/gir/meson.build
@@ -14,6 +14,8 @@ girexe = executable(
   link_with : girlib
 )
 
+fake_dep = dependency('no-way-this-exists', required: false)
+
 gnome.generate_gir(
   girlib,
   sources : libsources,
@@ -22,6 +24,7 @@ gnome.generate_gir(
   symbol_prefix : 'meson_',
   identifier_prefix : 'Meson',
   includes : ['GObject-2.0'],
+  dependencies : [fake_dep],
   install : true
 )
 


### PR DESCRIPTION
if pkg-config return != 0 and the dep is not required, it will not be set