### PR TITLE
rpm: couple of improvements and fixes

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -1,21 +1,29 @@
-%__meson /usr/bin/meson
+%__meson %{_bindir}/meson
+%__sourcedir .
+%__builddir %{_target_platform}
+%__meson_ninja_opts -v %{?_smp_mflags} -C %{__builddir}
 
-%meson() %{expand:\
-  export CFLAGS="%{optflags}" ; \
-  export CXXFLAGS="%{optflags}" ; \
-  export FFLAGS="%{optflags} -I%{_fmoddir}" ; \
-  export FCFLAGS="%{optflags} -I%{_fmoddir}" ; \
-  export LDFLAGS="%{__global_ldflags}" ; \
-  %__meson %{?1} \\\
-        --prefix=%{_prefix}            \\\
-        --libdir=%{_libdir}            \\\
-        --libexecdir=%{_libexecdir}    \\\
-        --bindir=%{_bindir}            \\\
-        --includedir=%{_includedir}    \\\
-        --datadir=%{_datadir}          \\\
-        --mandir=%{_mandir}            \\\
-        --localedir=%{_datadir}/locale \\\
-        --sysconfdir=%{_sysconfdir}    \\\
-        --buildtype=plain \
-        %{nil} \
-}
+%meson \
+    export CFLAGS="%{optflags}"                \
+    export CXXFLAGS="%{optflags}"              \
+    export FFLAGS="%{optflags} -I%{_fmoddir}"  \
+    export FCFLAGS="%{optflags} -I%{_fmoddir}" \
+    export LDFLAGS="%{?__global_ldflags}"      \
+    mkdir -p %{__builddir}                     \
+    pushd %{__builddir}                        \
+        %{__meson}                         \\\
+            --buildtype=plain              \\\
+            --prefix=%{_prefix}            \\\
+            --libdir=%{_libdir}            \\\
+            --libexecdir=%{_libexecdir}    \\\
+            --bindir=%{_bindir}            \\\
+            --includedir=%{_includedir}    \\\
+            --datadir=%{_datadir}          \\\
+            --mandir=%{_mandir}            \\\
+            --localedir=%{_datadir}/locale \\\
+            --sysconfdir=%{_sysconfdir}    \\\
+            $OLDPWD/%{__sourcedir}             \
+    popd
+%meson_build %ninja_build -C %{__builddir}
+%meson_install %ninja_install -C %{__builddir}
+%meson_test %ninja_test -C %{__builddir}

--- a/data/macros.meson
+++ b/data/macros.meson
@@ -23,6 +23,12 @@
             --sysconfdir=%{_sysconfdir}    \\\
             $OLDPWD/%{__sourcedir}             \
     popd
-%meson_build %ninja_build -C %{__builddir}
-%meson_install %ninja_install -C %{__builddir}
-%meson_test %ninja_test -C %{__builddir}
+
+%meson_build \
+    %ninja_build -C %{__builddir}
+
+%meson_install \
+    %ninja_install -C %{__builddir}
+
+%meson_test \
+    %ninja_test -C %{__builddir}

--- a/data/macros.meson
+++ b/data/macros.meson
@@ -1,7 +1,6 @@
 %__meson %{_bindir}/meson
 %__sourcedir .
 %__builddir %{_target_platform}
-%__meson_ninja_opts -v %{?_smp_mflags} -C %{__builddir}
 
 %meson \
     export CFLAGS="%{optflags}"                \


### PR DESCRIPTION
* Don't hardcode /usr/bin, use %{_bindir}
* Implement %meson_build / %meson_install / %meson_test
* Automatic handling of out-of-tree builds

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>