### PR TITLE
Support running Meson as a Python zip application (2nd try)

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -14,15 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mesonbuild import mesonmain
-import sys, os
+import meson
+import sys
 
-def main():
-    launcher = sys.argv[0]
-    # resolve the command path if not launched from $PATH
-    if os.path.split(launcher)[0]:
-        launcher = os.path.realpath(launcher)
-    return mesonmain.run(launcher, sys.argv[1:])
-
-if __name__ == '__main__':
-    sys.exit(main())
+sys.exit(meson.main())


### PR DESCRIPTION
This reintroduces the [zipapp](https://docs.python.org/3/library/zipapp.html) support, as detailed in #823. The code retains the `argv[0]` fixes, so the issue mentioned in #830 shouldn't be present anymore.

I also added a `__main__.py`. This lets the zipapp command run without explicitly stating the name of the main function:
```
python -m zipapp -p '/usr/bin/env python3' -o meson <source checkout>
```

Alternatively, a really tiny zipapp can be created by packaging only the files meson needs to run:
```
cd <source checkout>
zip -r meson.zip meson.py __main__.py mesonbuild
python -m zipapp -p '/usr/bin/env python3' -o meson meson.zip
```