### PR TITLE
Warn if -fPIC is passed instead of pic to static libraries (instead of erroring out)

### DIFF
--- a/test cases/common/62 exe static shared/meson.build
+++ b/test cases/common/62 exe static shared/meson.build
@@ -1,7 +1,11 @@
 project('statchain', 'c')
 
 subdir('subdir')
-statlib = static_library('stat', 'stat.c', link_with : shlib, pic : true)
+# Test that -fPIC in c_args is also accepted
+statlib2 = static_library('stat2', 'stat2.c', c_args : '-fPIC', pic : false)
+# Test that pic is needed for both direct and indirect static library
+# dependencies of shared libraries (on Linux and BSD)
+statlib = static_library('stat', 'stat.c', link_with : [shlib, statlib2], pic : true)
 shlib2 = shared_library('shr2', 'shlib2.c', link_with : statlib)
 exe = executable('prog', 'prog.c', link_with : shlib2)
 test('runtest', exe)

--- a/test cases/common/62 exe static shared/shlib2.c
+++ b/test cases/common/62 exe static shared/shlib2.c
@@ -1,7 +1,8 @@
 #include "subdir/exports.h"
 
 int statlibfunc(void);
+int statlibfunc2(void);
 
 int DLL_PUBLIC shlibfunc2(void) {
-    return statlibfunc() - 18;
+    return statlibfunc() - statlibfunc2();
 }

--- a/test cases/common/62 exe static shared/stat2.c
+++ b/test cases/common/62 exe static shared/stat2.c
@@ -1,0 +1,3 @@
+int statlibfunc2() {
+    return 18;
+}

--- a/test cases/frameworks/7 gnome/mkenums/meson.build
+++ b/test cases/frameworks/7 gnome/mkenums/meson.build
@@ -32,7 +32,7 @@ enums_h2 = gnome.mkenums('abc2',
 
 enums_c2 = gnome.mkenums('abc2',
   sources : 'meson-sample.h',
-  depends : enums_h2,
+  depends : [enums_h1, enums_h2],
   c_template : 'enums2.c.in',
   ftail : '/* trailing source file info */',
   install_header : true,


### PR DESCRIPTION
Also print the name of the static library that has PIC-related issues, and test for all this.

This fixes issues people are having right now building gstreamer (and other projects) because we started requiring `pic : true`.