### PR TITLE
Fix PIC unittest failure and make it more useful

### DIFF
--- a/meson.py
+++ b/meson.py
@@ -18,10 +18,8 @@ from mesonbuild import mesonmain
 import sys, os
 
 def main():
-    launcher = sys.argv[0]
-    # resolve the command path if not launched from $PATH
-    if os.path.split(launcher)[0]:
-        launcher = os.path.realpath(launcher)
+    # Always resolve the command path so Ninja can find it for regen, tests, etc.
+    launcher = os.path.realpath(sys.argv[0])
     return mesonmain.run(launcher, sys.argv[1:])
 
 if __name__ == '__main__':

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest, os, sys, shutil
+import unittest, os, sys, shutil, time
 import subprocess
 import re, json
 import tempfile
@@ -77,9 +77,15 @@ class LinuxlikeTests(unittest.TestCase):
         self.init(testdir)
         compdb = self.get_compdb()
         self.assertTrue('-fPIC' in compdb[0]['command'])
-        self.setconf('-Db_staticpic=true')
+        # This is needed to increase the difference between build.ninja's
+        # timestamp and coredata.dat's timestamp due to a Ninja bug.
+        # https://github.com/ninja-build/ninja/issues/371
+        time.sleep(1)
+        self.setconf('-Db_staticpic=false')
+        # Regenerate build
         self.build()
-        self.assertFalse('-fPIC' not in compdb[0]['command'])
+        compdb = self.get_compdb()
+        self.assertTrue('-fPIC' not in compdb[0]['command'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The PIC unittest failure was intermittent due to https://github.com/ninja-build/ninja/issues/371

Also make the PIC unittest actually test that `b_staticpic` works by setting it to false, regenerating, and checking the new compdb.