### PR TITLE
pkgconfig: Handle library names starting with 'lib'

### DIFF
--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -87,6 +87,7 @@ class PkgConfigDependency(Dependency):
         self.is_libtool = False
         self.required = kwargs.get('required', True)
         self.static = kwargs.get('static', False)
+        self.silent = kwargs.get('silent', False)
         if not isinstance(self.static, bool):
             raise DependencyException('Static keyword must be boolean')
         self.cargs = []
@@ -132,14 +133,16 @@ class PkgConfigDependency(Dependency):
             if not self.is_found:
                 found_msg += [mlog.red('NO'), 'found {!r}'.format(self.modversion),
                               'but need {!r}'.format(self.version_requirement)]
-                mlog.log(*found_msg)
+                if not self.silent:
+                    mlog.log(*found_msg)
                 if self.required:
                     raise DependencyException(
                         'Invalid version of a dependency, needed %s %s found %s.' %
                         (name, self.version_requirement, self.modversion))
                 return
         found_msg += [mlog.green('YES'), self.modversion]
-        mlog.log(*found_msg)
+        if not self.silent:
+            mlog.log(*found_msg)
         # Fetch cargs to be used while using this dependency
         self._set_cargs()
         # Fetch the libraries and library paths needed for using this
@@ -214,14 +217,16 @@ class PkgConfigDependency(Dependency):
                                  stderr=subprocess.PIPE)
             out = p.communicate()[0]
             if p.returncode == 0:
-                mlog.log('Found pkg-config:', mlog.bold(shutil.which('pkg-config')),
-                         '(%s)' % out.decode().strip())
+                if not self.silent:
+                    mlog.log('Found pkg-config:', mlog.bold(shutil.which('pkg-config')),
+                             '(%s)' % out.decode().strip())
                 PkgConfigDependency.pkgconfig_found = True
                 return
         except Exception:
             pass
         PkgConfigDependency.pkgconfig_found = False
-        mlog.log('Found Pkg-config:', mlog.red('NO'))
+        if not self.silent:
+            mlog.log('Found Pkg-config:', mlog.red('NO'))
 
     def found(self):
         return self.is_found

--- a/test cases/common/51 pkgconfig-gen/installed_files.txt
+++ b/test cases/common/51 pkgconfig-gen/installed_files.txt
@@ -1,2 +1,3 @@
 usr/include/simple.h
 usr/lib/pkgconfig/simple.pc
+usr/lib/pkgconfig/libfoo.pc

--- a/test cases/common/51 pkgconfig-gen/meson.build
+++ b/test cases/common/51 pkgconfig-gen/meson.build
@@ -15,5 +15,15 @@ pkgg.generate(
   description : 'A simple demo library.',
   requires : 'glib-2.0', # Not really, but only here to test that this works.
   requires_private : ['gio-2.0', 'gobject-2.0'],
-  libraries_private : '-lz',
-)
+  libraries_private : '-lz')
+
+# Test that name_prefix='' and name='libfoo' results in '-lfoo'
+lib2 = shared_library('libfoo', 'simple.c',
+  name_prefix : '',
+  version : libver)
+
+pkgg.generate(
+  libraries : lib2,
+  name : 'libfoo',
+  version : libver,
+  description : 'A foo library.')


### PR DESCRIPTION
Sometimes people want the library to start with `lib` everywhere, which is achieved by setting `name_prefix` to `''` and the target name to `'libfoo'`. In that case, try to get the `pkg-config` `'-lfoo'` arg correct. Also, don't warn about anything on Windows.

The other commits add a unittest for this. Had to make some changes to `PkgConfigDependency` to make this work.