### PR TITLE
Split generator @BASENAME@ at the first extension.

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -761,14 +761,14 @@ class Generator():
 
     def get_base_outnames(self, inname):
         plainname = os.path.split(inname)[1]
-        basename = plainname.split('.')[0]
+        basename = os.path.splitext(plainname)[0]
         return [x.replace('@BASENAME@', basename).replace('@PLAINNAME@', plainname) for x in self.outputs]
 
     def get_dep_outname(self, inname):
         if self.depfile is None:
             raise InvalidArguments('Tried to get dep name for rule that does not have dependency file defined.')
         plainname = os.path.split(inname)[1]
-        basename = plainname.split('.')[0]
+        basename = os.path.splitext(plainname)[0]
         return self.depfile.replace('@BASENAME@', basename).replace('@PLAINNAME@', plainname)
 
     def get_arglist(self):

--- a/test cases/common/118 allgenerate/meson.build
+++ b/test cases/common/118 allgenerate/meson.build
@@ -5,7 +5,7 @@ project('all sources generated', 'c', 'cpp')
 comp = find_program('converter.py')
 
 g = generator(comp,
-  output : '@BASENAME@.cpp',
+  output : '@BASENAME@',
   arguments : ['@INPUT@', '@OUTPUT@'])
 
 c = g.process('foobar.cpp.in')


### PR DESCRIPTION
Sometimes, you have a command that will work with multiple types of files, so you'd like to use a generic generator for it. This _could_ be done by naming the input as `filename.real_extension.temporary_extension`, but `@BASENAME@` gets stripped of _all_ extensions, making it difficult to do so easily.

An alternative is to just name the input `filename.real_extension` and use `@PLAINNAME@`, _but_ I'm trying to keep compatibility with autotools, so I'm fairly certain I need to keep the extra extension.