### PR TITLE
InternalDependency's are found if all of their dependencies are found

### DIFF
--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -80,6 +80,10 @@ class InternalDependency(Dependency):
     def get_link_args(self):
         return self.link_args
 
+    def found(self):
+        # True when ext_deps is empty
+        return all(d.found() for d in self.ext_deps)
+
     def get_version(self):
         return self.version
 


### PR DESCRIPTION
Make the found-ness of InternalDependencies true if either they
have no dependencies or all their dependencies are also found.