### PR TITLE
vala: Custom header and vapi name (fix #892)

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -992,11 +992,11 @@ int dummy;
             # Library name
             args += ['--library=' + target.name]
             # Outputted header
-            hname = os.path.join(self.get_target_dir(target), target.name + '.h')
+            hname = os.path.join(self.get_target_dir(target), target.vala_header if isinstance(target.vala_header, str) else (target.name + '.h'))
             args += ['-H', hname]
             valac_outputs.append(hname)
             # Outputted vapi file
-            base_vapi = target.name + '.vapi'
+            base_vapi = target.vala_vapi if isinstance(target.vala_vapi, str) else (target.name + '.vapi')
             vapiname = os.path.join(self.get_target_dir(target), base_vapi)
             # Force valac to write the vapi file in the target build dir.
             # Without this, it will write it inside c_out_dir

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -999,7 +999,7 @@ int dummy;
             vapiname = os.path.join(self.get_target_dir(target), target.vala_vapi)
             # Force valac to write the vapi file in the target build dir.
             # Without this, it will write it inside c_out_dir
-            args += ['--vapi=../' + target.vala_vapi]
+            args += ['--vapi', os.path.join('..', target.vala_vapi)]
             valac_outputs.append(vapiname)
         if self.environment.coredata.get_builtin_option('werror'):
             args += valac.get_werror_args()

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -992,15 +992,14 @@ int dummy;
             # Library name
             args += ['--library=' + target.name]
             # Outputted header
-            hname = os.path.join(self.get_target_dir(target), target.vala_header if isinstance(target.vala_header, str) else (target.name + '.h'))
+            hname = os.path.join(self.get_target_dir(target), target.vala_header)
             args += ['-H', hname]
             valac_outputs.append(hname)
             # Outputted vapi file
-            base_vapi = target.vala_vapi if isinstance(target.vala_vapi, str) else (target.name + '.vapi')
-            vapiname = os.path.join(self.get_target_dir(target), base_vapi)
+            vapiname = os.path.join(self.get_target_dir(target), target.vala_vapi)
             # Force valac to write the vapi file in the target build dir.
             # Without this, it will write it inside c_out_dir
-            args += ['--vapi=../' + base_vapi]
+            args += ['--vapi=../' + target.vala_vapi]
             valac_outputs.append(vapiname)
         if self.environment.coredata.get_builtin_option('werror'):
             args += valac.get_werror_args()

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -55,6 +55,8 @@ known_lib_kwargs.update({'version' : True, # Only for shared libs
                          'name_prefix' : True,
                          'name_suffix' : True,
                          'vs_module_defs' : True, # Only for shared libs
+                         'vala_header': True,
+                         'vala_vapi': True,
                          'pic' : True, # Only for static libs
                         })
 
@@ -449,6 +451,9 @@ class BuildTarget():
         if not isinstance(valalist, list):
             valalist = [valalist]
         self.add_compiler_args('vala', valalist)
+        if not isinstance(self, Executable):
+            self.vala_header = kwargs.get('vala_header', None)
+            self.vala_vapi = kwargs.get('vala_vapi', None)
         dlist = stringlistify(kwargs.get('d_args', []))
         self.add_compiler_args('d', dlist)
         self.link_args = kwargs.get('link_args', [])

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -452,8 +452,8 @@ class BuildTarget():
             valalist = [valalist]
         self.add_compiler_args('vala', valalist)
         if not isinstance(self, Executable):
-            self.vala_header = kwargs.get('vala_header', None)
-            self.vala_vapi = kwargs.get('vala_vapi', None)
+            self.vala_header = kwargs.get('vala_header', self.name + '.h')
+            self.vala_vapi = kwargs.get('vala_vapi', self.name + '.vapi')
         dlist = stringlistify(kwargs.get('d_args', []))
         self.add_compiler_args('d', dlist)
         self.link_args = kwargs.get('link_args', [])

--- a/test cases/vala/12 custom output/meson.build
+++ b/test cases/vala/12 custom output/meson.build
@@ -1,0 +1,9 @@
+project('valatest', 'c', 'vala')
+
+glib = dependency('glib-2.0')
+gobject = dependency('gobject-2.0')
+
+library('foo-1.0', 'foo.vala',
+        vala_header: 'foo.h',
+        vala_vapi: 'foo.vapi',
+        dependencies: [glib, gobject])


### PR DESCRIPTION
The same is done for the `--gir` flag in #634.