### PR TITLE
Improve error when using the dependencies kwarg

### DIFF
--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -37,6 +37,10 @@ class Dependency():
         self.is_found = False
         self.type_name = type_name
 
+    def __repr__(self):
+        s = '<{0} {1}: {2}>'
+        return s.format(self.__class__.__name__, self.name, self.is_found)
+
     def get_compile_args(self):
         return []
 


### PR DESCRIPTION
The error message is misleading (talks about external dependencies), and doesn't tell you what you need to do (use the output of `declare_dependency`, `dependency`, or `find_library`). At the same time rename `add_external_deps` to `add_deps` since it adds internal deps too.

Plus many more error message improvements all over the place.