### PR TITLE
vala: Build with '--nostdpkg'

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -988,6 +988,7 @@ int dummy;
         # found inside the build tree (generated sources).
         args += ['-d', c_out_dir]
         args += ['-C']
+        args += ['--nostdpkg']
         if not isinstance(target, build.Executable):
             # Library name
             args += ['--library=' + target.name]

--- a/test cases/vala/11 mixed sources/meson.build
+++ b/test cases/vala/11 mixed sources/meson.build
@@ -1,7 +1,8 @@
 project('foo', 'c', 'vala')
 
 glib = dependency('glib-2.0')
+gobject = dependency('gobject-2.0')
 
 subdir('c')
-e = executable('foo', 'c/foo.c', retval, 'vala/bar.vala', dependencies: [glib])
+e = executable('foo', 'c/foo.c', retval, 'vala/bar.vala', dependencies: [glib, gobject])
 test('test foo', e)


### PR DESCRIPTION
Since Vala require 'glib-2.0' and 'gobject-2.0' dependencies, it's better to fail at 'valac' step with meaningful error.

Before:

```
FAILED: valaprog@exe/valaprog@exe_prog.c.o 
cc  '-Ivalaprog@exe' '-fdiagnostics-color=always' '-I..' '-I.' '-pipe' '-Wall' '-Winvalid-pch' '-O0' '-g' '-MMD' '-MQ' 'valaprog@exe/valaprog@exe_prog.c.o' '-MF' 'valaprog@exe/valaprog@exe_prog.c.o.d' -o 'valaprog@exe/valaprog@exe_prog.c.o' -c 'valaprog@exe/prog.c'
valaprog@exe/prog.c:5:18: erreur fatale : glib.h : No such file or directory
 #include <glib.h>
                  ^
compilation terminée.
ninja: build stopped: subcommand failed.
```

After:

```
FAILED: valaprog.vapi valaprog@exe/prog.c 
valac '--debug' '-d' 'valaprog@exe' '-C' '--nostdpkg' '--vapi=../valaprog.vapi' ../prog.vala
error: The namespace name `GLib' could not be found
../prog.vala:1.18-1.21: error: The symbol `GLib' could not be found
class MainProg : GLib.Object {
                 ^^^^
../prog.vala:3.19-3.21: error: The type name `int' could not be found
    public static int main(string[] args) {
                  ^^^
../prog.vala:3.28-3.33: error: The type name `string' could not be found
    public static int main(string[] args) {
                           ^^^^^^
Compilation failed: 4 error(s), 0 warning(s)
ninja: build stopped: subcommand failed.
```

And if only `gobject-2.0` is missing

```
FAILED: valaprog.vapi valaprog@exe/prog.c 
valac '--debug' '-d' 'valaprog@exe' '-C' '--nostdpkg' '--vapi=../valaprog.vapi' '--pkg' 'glib-2.0' ../prog.vala
../prog.vala:1.18-1.28: error: The type name `GLib.Object' could not be found
class MainProg : GLib.Object {
                 ^^^^^^^^^^^
Compilation failed: 1 error(s), 0 warning(s)
ninja: build stopped: subcommand failed.
```
