### PR TITLE
gnome: Don't pass ldflags to g-ir-scanner

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -372,8 +372,8 @@ class GnomeModule:
             deps = [deps]
         deps = (girtarget.get_all_link_deps() + girtarget.get_external_deps() +
                 deps)
-        cflags, ldflags, gi_includes = self.get_dependencies_flags(deps, state, depends)
-        scan_command += list(cflags) + list(ldflags)
+        cflags, _, gi_includes = self.get_dependencies_flags(deps, state, depends)
+        scan_command += list(cflags)
         for i in gi_includes:
             scan_command += ['--add-include-path=%s' % i]
 


### PR DESCRIPTION
In this context -l refers to shared libraries that the gir provides so you end up with a dozen unnecessary libs in your gir file.

The cflags are also probably extraneous but I didn't touch them for now. (They should probably be in the `--cflags-begin` section anyway).