### PR TITLE
Allow id to contain a pipe "|"

### DIFF
--- a/tools/cmake2meson.py
+++ b/tools/cmake2meson.py
@@ -36,7 +36,7 @@ class Lexer:
             ('ignore', re.compile(r'[ \t]')),
             ('string', re.compile(r'"([^\\]|(\\.))*?"', re.M)),
             ('varexp', re.compile(r'\${[-_0-9a-z/A-Z.]+}')),
-            ('id', re.compile('''[,-><${}=+_0-9a-z/A-Z@.*]+''')),
+            ('id', re.compile('''[,-><${}=+_0-9a-z/A-Z|@.*]+''')),
             ('eol', re.compile(r'\n')),
             ('comment', re.compile(r'\#.*')),
             ('lparen', re.compile(r'\(')),


### PR DESCRIPTION
For instance in [color](https://github.com/bagage/color/blob/master/tests/CMakeLists.txt#L26) project tests contains a `|` character.