### PR TITLE
gnome: Add check_gir() method

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -49,3 +49,4 @@ Franz Zapata
 Emanuele Aina
 Guillaume Poirier-Morency
 Scott D Phillips
+Florian Müllner

--- a/test cases/frameworks/7 gnome/gir/meson.build
+++ b/test cases/frameworks/7 gnome/gir/meson.build
@@ -16,6 +16,10 @@ girexe = executable(
 
 fake_dep = dependency('no-way-this-exists', required: false)
 
+gnome.check_gir('GObject', version: '2.0', symbols: ['Binding.get_source'])
+gnome.check_gir('GObject', required: false, symbols: ['FakeObj.fake_method'])
+gnome.check_gir('FakeDep', required: false)
+
 gnome.generate_gir(
   girlib,
   sources : libsources,


### PR DESCRIPTION
Autotools Archive recently gained macros for checking for
gobject-introspection runtime dependencies[0]. While those
are not required to build a project, a clear error message
at build-time is much easier for users or packagers to figure
out than possibly cryptic runtime failures, so those checks
turn out to be quite useful for non-compiled languages.
To not lose that ability when moving to meson, add a check_gir()
method to the gnome module that implements the functionality of
the AX_CHECK_GIRS_GJS and AC_CHECK_GIR_SYMBOLS_GJS macros.

[0] http://endlessmblog.com/gjs-and-autoconf/
