### PR TITLE
pkgconfig: Fix absolute 'libdir' and 'includedir'

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -45,10 +45,10 @@ class PkgConfigModule:
         fname = os.path.join(outdir, pcfile)
         with open(fname, 'w') as ofile:
             ofile.write('prefix=%s\n' % coredata.get_builtin_option('prefix'))
-            ofile.write('libdir=${prefix}/%s\n' %
-                        coredata.get_builtin_option('libdir'))
-            ofile.write('includedir=${prefix}/%s\n\n' %
-                        coredata.get_builtin_option('includedir'))
+            # '${prefix}' is ignored if the second path is absolute (see
+            # 'os.path.join' for details)
+            ofile.write('libdir=%s\n' % os.path.join('${prefix}', coredata.get_builtin_option('libdir')))
+            ofile.write('includedir=%s\n' %  os.path.join('${prefix}', coredata.get_builtin_option('includedir')))
             ofile.write('Name: %s\n' % name)
             if len(description) > 0:
                 ofile.write('Description: %s\n' % description)


### PR DESCRIPTION
If an absolute path is provided (e.g. `--libdir=/usr/lib64`), it has to end literally in the pkg-config file.

This is posing a problem with the current RPM macros because `%{_libdir}` and `%{_includedir} are absolute.

I don't know if this could be problematic elsewhere.