### PR TITLE
Only default to dpkg-architecture output in Debian derivatives

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -51,3 +51,4 @@ Guillaume Poirier-Morency
 Scott D Phillips
 Gautier Pelloux-Prayer
 Alexandre Foley
+Jouni Kosonen

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -165,15 +165,17 @@ def version_compare(vstr1, vstr2):
     return cmpop(varr1, varr2)
 
 def default_libdir():
-    try:
-        pc = subprocess.Popen(['dpkg-architecture', '-qDEB_HOST_MULTIARCH'],
-                              stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
-        (stdo, _) = pc.communicate()
-        if pc.returncode == 0:
-            archpath = stdo.decode().strip()
-            return 'lib/' + archpath
-    except Exception:
-        pass
+    if is_debianlike():
+        try:
+            pc = subprocess.Popen(['dpkg-architecture', '-qDEB_HOST_MULTIARCH'],
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.DEVNULL)
+            (stdo, _) = pc.communicate()
+            if pc.returncode == 0:
+                archpath = stdo.decode().strip()
+                return 'lib/' + archpath
+        except Exception:
+            pass
     if os.path.isdir('/usr/lib64') and not os.path.islink('/usr/lib64'):
         return 'lib64'
     return 'lib'


### PR DESCRIPTION
Commit 28476aa7 replaced testing for debianness with trying to execute dpkg-architecture.
This is a problem when that program exists but the distribution is not a Debian derivative.

cf. https://bugs.gentoo.org/show_bug.cgi?id=591564

