### PR TITLE
Don't expose private module methods

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -981,6 +981,8 @@ class ModuleHolder(InterpreterObject):
             fn = getattr(self.held_object, method_name)
         except AttributeError:
             raise InvalidArguments('Module %s does not have method %s.' % (self.modname, method_name))
+        if method_name.startswith('_'):
+            raise InvalidArguments('Function {!r} in module {!r} is private.'.format(method_name, self.modname))
         state = ModuleState()
         state.build_to_src = os.path.relpath(self.interpreter.environment.get_source_dir(),
                                              self.interpreter.environment.get_build_dir())


### PR DESCRIPTION
This is the common Python convention for private methods so lets not expose these to build files as they are implementation details and their behavior is undefined.
