### PR TITLE
Don't ignore invalid code related to subproject calls

### DIFF
--- a/test cases/failing/34 non-root subproject/meson.build
+++ b/test cases/failing/34 non-root subproject/meson.build
@@ -1,0 +1,3 @@
+project('non-root subproject', 'c')
+
+subdir('some')

--- a/test cases/failing/34 non-root subproject/some/meson.build
+++ b/test cases/failing/34 non-root subproject/some/meson.build
@@ -1,0 +1,1 @@
+dependency('definitely-doesnt-exist', fallback : ['someproj', 'some_dep'])


### PR DESCRIPTION
We should only silently return from a `dependency()` call if the error is transient (old version, variable not found, etc), not if the subproject invocation itself is incorrect.

For instance, if you use a `dependency(..., fallback : ...)` call in a meson.build not in the root directory, we would always ignore the call instead of erroring out due to invalid usage.

We should consider categorising our exceptions in this manner elsewhere too.
