### PR TITLE
Fix Ninja rule nondeterminism by sorting ASCIIbetically.

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -53,3 +53,4 @@ Gautier Pelloux-Prayer
 Alexandre Foley
 Jouni Kosonen
 Aurelien Jarno
+Olexa Bilaniuk

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -90,6 +90,8 @@ class NinjaBuildElement():
 
     def write(self, outfile):
         self.check_outputs()
+        self.outfilenames = sorted(self.outfilenames)
+        self.infilenames  = sorted(self.infilenames)
         line = 'build %s: %s %s' % (' '.join([ninja_quote(i) for i in self.outfilenames]),\
                                     self.rule,
                                     ' '.join([ninja_quote(i) for i in self.infilenames]))


### PR DESCRIPTION
The static linker rule `(ar csrD $out $in)`, in particular, seems
sensitive to the order of the elements in `$in`. Fix this by sorting
using Python's `sorted()`, which by default sorts strings:

1) ASCIIbetically (and thus independently of locale, which is what we
require) and
2) Stably.

The same problem probably also exists in other backends elsewhere and
probably other situations as well.

Setting the environment variable `PYTHONHASHSEED=0` also avoids this
problem, by removing nondeterminism from iterators over unordered data
structures like Python `dict`s.

This issue arose while I was trying to enforce _reproducible builds_ but could not. I was building something that depended on GoogleTest's `libgtest_main` C++ library, linked statically from `gtest-all.cc` and `gtest_main.cc`, and with 50% probability a side-by-side build would fail. I managed to isolate the problem to `libgtest_main.a` and looked at `build.ninja`; It turns out that the reproduction would fail whenever Build A had the rule
```
build 3rdparty/libgtest_main.a: STATIC_LINKER 3rdparty/gtest_main@sta/_longlongpath_googletest_src_gtest-all.cc.o 3rdparty/gtest_main@sta/_longlongpath_googletest_src_gtest_main.cc.o
```
while Build B had switched `gtest_main.cc.o` and `gtest-all.cc.o`:
```
build 3rdparty/libgtest_main.a: STATIC_LINKER 3rdparty/gtest_main@sta/_longlongpath_googletest_src_gtest_main.cc.o 3rdparty/gtest_main@sta/_longlongpath_googletest_src_gtest-all.cc.o 
```
or vice-versa. This is in spite of `ar csrD` having been invoked with the `D` flag for deterministic handling.
```bash
$ ar csrD 3rdparty/libgtest_main01.a 3rdparty/gtest_main@sta/_longlongpath_googletest_src_gtest-all.cc.o 3rdparty/gtest_main@sta/_longlongpath_googletest_src_gtest_main.cc.o
$ ar csrD 3rdparty/libgtest_main10.a 3rdparty/gtest_main@sta/_longlongpath_googletest_src_gtest_main.cc.o 3rdparty/gtest_main@sta/_longlongpath_googletest_src_gtest-all.cc.o
$ md5sum 3rdparty/
gtest_main@sta/    libgtest_main01.a  libgtest_main10.a  libgtest_main.a    
$ md5sum 3rdparty/*.a
9dc4a95c2962a4c862fd641e67d1e8b9  3rdparty/libgtest_main01.a
a0e9d789f91063f458928787169f346d  3rdparty/libgtest_main10.a
9dc4a95c2962a4c862fd641e67d1e8b9  3rdparty/libgtest_main.a
```