### PR TITLE
vala: Fix global arguments for `valac`

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1056,10 +1056,15 @@ int dummy;
             vala_c_src.append(vala_c_file)
             valac_outputs.append(vala_c_file)
 
+        # TODO: Use self.generate_basic_compiler_args to get something more
+        #       consistent Until then, we should be careful to preserve the
+        #       precedence of arguments if it changes upstream.
         args = []
-        args += self.build.get_global_args(valac)
-        args += self.build.get_project_args(valac, target.subproject)
         args += valac.get_buildtype_args(self.get_option_for_target('buildtype', target))
+        args += self.build.get_project_args(valac, target.subproject)
+        args += self.build.get_global_args(valac)
+        args += self.environment.coredata.external_args[valac.get_language()]
+
         # Tell Valac to output everything in our private directory. Sadly this
         # means it will also preserve the directory components of Vala sources
         # found inside the build tree (generated sources).

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -792,16 +792,18 @@ def get_args_from_envvars(compiler):
     if hasattr(compiler, 'get_linker_exelist'):
         compiler_is_linker = (compiler.get_exelist() == compiler.get_linker_exelist())
 
-    if lang not in ('c', 'cpp', 'objc', 'objcpp', 'fortran', 'd'):
-        return [], [], []
-
     # Compile flags
     cflags_mapping = {'c': 'CFLAGS',
                       'cpp': 'CXXFLAGS',
                       'objc': 'OBJCFLAGS',
                       'objcpp': 'OBJCXXFLAGS',
                       'fortran': 'FFLAGS',
-                      'd': 'DFLAGS'}
+                      'd': 'DFLAGS',
+                      'vala': 'VALAFLAGS'}
+
+    if lang not in cflags_mapping.keys():
+        return [], [], []
+
     compile_flags = os.environ.get(cflags_mapping[lang], '')
     log_var(cflags_mapping[lang], compile_flags)
     compile_flags = shlex.split(compile_flags)


### PR DESCRIPTION
There's two things I would like to address here:
- add `VALAFLAGS` environment variable support
- fix global arguments provided by `-Dvala_args` which are not considered at this point

For `VALAFLAGS`, it is already supported by autotools and waf, so there's not excuse not to have it as well.

I tried to dig a bit into the code to see why the arguments weren't set, but couldn't find anything so far.
