### PR TITLE
mesonlib: close file before (re)moving

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -320,14 +320,17 @@ def dump_conf_header(ofilename, cdata):
 def replace_if_different(dst, dst_tmp):
     # If contents are identical, don't touch the file to prevent
     # unnecessary rebuilds.
+    different = True
     try:
         with open(dst, 'r') as f1, open(dst_tmp, 'r') as f2:
             if f1.read() == f2.read():
-                os.unlink(dst_tmp)
-                return
+                different = False
     except FileNotFoundError:
         pass
-    os.replace(dst_tmp, dst)
+    if different:
+        os.replace(dst_tmp, dst)
+    else:
+        os.unlink(dst_tmp)
 
 def stringlistify(item):
     if isinstance(item, str):


### PR DESCRIPTION
On windows, attempting to unlink an open file results in a
PermissionError, so close the file and then remove it.