### PR TITLE
Improvements for gnome.gtkdoc

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -568,6 +568,7 @@ class GnomeModule:
         args += self.unpack_args('--fixxrefargs=', 'fixxref_args', kwargs)
         args += self.unpack_args('--html-assets=', 'html_assets', kwargs, state)
         args += self.unpack_args('--content-files=', 'content_files', kwargs, state)
+        args += self.unpack_args('--ignore-headers=', 'ignore_headers', kwargs)
         args += self.unpack_args('--installdir=', 'install_dir', kwargs, state)
         args += self.get_build_args(kwargs, state)
         res = [build.RunTarget(targetname, command[0], command[1:] + args, [], state.subdir)]

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -39,6 +39,7 @@ parser.add_argument('--ldflags', dest='ldflags', default='')
 parser.add_argument('--cflags', dest='cflags', default='')
 parser.add_argument('--content-files', dest='content_files', default='')
 parser.add_argument('--html-assets', dest='html_assets', default='')
+parser.add_argument('--ignore-headers', dest='ignore_headers', default='')
 parser.add_argument('--installdir', dest='install_dir')
 
 def gtkdoc_run_check(cmd, cwd):
@@ -56,7 +57,7 @@ def gtkdoc_run_check(cmd, cwd):
 def build_gtkdoc(source_root, build_root, doc_subdir, src_subdir,
                  main_file, module, html_args, scan_args, fixxref_args,
                  gobject_typesfile, scanobjs_args, ld, cc, ldflags, cflags,
-                 html_assets, content_files):
+                 html_assets, content_files, ignore_headers):
     print("Building documentation for %s" % module)
 
     abs_src = os.path.join(source_root, src_subdir)
@@ -91,7 +92,8 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdir,
 
     scan_cmd = ['gtkdoc-scan',
                 '--module=' + module,
-                '--source-dir=' + abs_src] + scan_args
+                '--source-dir=' + abs_src,
+                '--ignore-headers=' + ignore_headers] + scan_args
     gtkdoc_run_check(scan_cmd, abs_out)
 
     if gobject_typesfile:
@@ -176,7 +178,8 @@ def run(args):
         options.ldflags,
         options.cflags,
         options.html_assets.split('@@') if options.html_assets else [],
-        options.content_files.split('@@') if options.content_files else [])
+        options.content_files.split('@@') if options.content_files else [],
+        options.ignore_headers.split('@@') if options.ignore_headers else [])
 
     if 'MESON_INSTALL_PREFIX' in os.environ:
         install_dir = options.install_dir if options.install_dir else options.modulename

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -69,6 +69,10 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdir,
     if os.path.exists(sections):
         content_files.append(sections)
 
+    overrides = os.path.join(doc_src, module + "-overrides.txt")
+    if os.path.exists(overrides):
+        content_files.append(overrides)
+
     # Copy files to build directory
     for f in content_files:
         f_abs = os.path.join(doc_src, f)


### PR DESCRIPTION
We're still missing a couple of features from the autotools-based gtk-doc integration, namely:

 * honoring `$DOC_MODULE-overrides.txt` if found in the doc's srcdir
 * ignoring headers during `gtkdoc-scan` without necessarily passing `--ignore-headers` to the `scan_args` positional argument