### PR TITLE
Fix dependency() ignoring required attribute when checked second or t…

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1857,6 +1857,13 @@ requirements use the version keyword argument instead.''')
                     # Cached dep has the wrong version. Check if an external
                     # dependency or a fallback dependency provides it.
                     cached_dep = None
+
+            # Don't re-use cached dep if it wasn't required but this one is,
+            # so we properly go into fallback/error code paths
+            if 'required' in kwargs and cached_dep is not None:
+                if not cached_dep.required and kwargs.get('required', True):
+                    cached_dep = None
+
         if cached_dep:
             dep = cached_dep
         else:

--- a/test cases/failing/34 dependency not-required then required/meson.build
+++ b/test cases/failing/34 dependency not-required then required/meson.build
@@ -1,0 +1,4 @@
+project('dep-test', 'c', version : '1.0')
+
+foo_dep = dependency('foo-bar-xyz-12.3', required : false)
+bar_dep = dependency('foo-bar-xyz-12.3', required : true)


### PR DESCRIPTION
…hird time

If first checking for a dependency as not-required, and then later
checking for the same dependency again as required, we would not
error out saying the dependency is missing, but just silently
re-use the cached dependency object from the first check and then
likely fail at build time if the dependency is not actually there.

With test case.

Fixes #964.