### PR TITLE
gnome: make generate_gir use the correct shared library

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -385,7 +385,13 @@ class GnomeModule:
         # spurious dependencies) but building GStreamer fails if they
         # are not used here.
         cflags, ldflags, gi_includes = self.get_dependencies_flags(deps, state, depends)
-        scan_command += list(cflags) + list(ldflags)
+        scan_command += list(cflags)
+        # need to put our output directory first as we need to use the
+        # generated libraries instead of any possibly installed system/prefix
+        # ones.
+        if isinstance(girtarget, build.SharedLibrary):
+            scan_command += ["-L@PRIVATE_OUTDIR_ABS_%s@" % girtarget.get_id()]
+        scan_command += list(ldflags)
         for i in gi_includes:
             scan_command += ['--add-include-path=%s' % i]
 
@@ -403,7 +409,6 @@ class GnomeModule:
         if isinstance(girtarget, build.Executable):
             scan_command += ['--program', girtarget]
         elif isinstance(girtarget, build.SharedLibrary):
-            scan_command += ["-L@PRIVATE_OUTDIR_ABS_%s@" % girtarget.get_id()]
             libname = girtarget.get_basename()
             scan_command += ['--library', libname]
         scankwargs = {'output' : girfile,


### PR DESCRIPTION
If building in a prefix with a version of the library that's already installed with other dependencies already installed in that prefix, then the installed library was being picked up to link with for gir generation instead of the newly built library.