### PR TITLE
dependency: Check that cached_dep has the 'required' attribute

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1856,12 +1856,10 @@ requirements use the version keyword argument instead.''')
                     # Cached dep has the wrong version. Check if an external
                     # dependency or a fallback dependency provides it.
                     cached_dep = None
-
             # Don't re-use cached dep if it wasn't required but this one is,
             # so we properly go into fallback/error code paths
-            if 'required' in kwargs and cached_dep is not None:
-                if not cached_dep.required and kwargs.get('required', True):
-                    cached_dep = None
+            if kwargs.get('required', True) and not getattr(cached_dep, 'required', False):
+                cached_dep = None
 
         if cached_dep:
             dep = cached_dep

--- a/test cases/failing/34 dependency not-required then required/meson.build
+++ b/test cases/failing/34 dependency not-required then required/meson.build
@@ -1,4 +1,4 @@
 project('dep-test', 'c', version : '1.0')
 
 foo_dep = dependency('foo-bar-xyz-12.3', required : false)
-bar_dep = dependency('foo-bar-xyz-12.3', required : true)
+bar_dep = dependency('foo-bar-xyz-12.3')


### PR DESCRIPTION
Closes https://github.com/mesonbuild/meson/issues/992

`self.required` is only valid on pkg-config dependencies, so we should check that the object has that attribute before checking its value.

All other `Dependency` objects all implicitly assume that the dependency is not "required". We should probably change that and default to `required : True` for them.