### PR TITLE
appveyor.yml: Test more than just MSVC2010 + Ninja on x86

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -36,18 +36,22 @@ branches:
     - master
 
 install:
-  - ps: (new-object net.webclient).DownloadFile('https://dl.dropboxusercontent.com/u/37517477/ninja.exe', 'c:\python34\ninja.exe')
-  - cmd: copy c:\python34\python.exe c:\python34\python3.exe
+  # Use the x86 python only when building for x86 for the cpython tests.
+  # For all other archs (including, say, arm), use the x64 python.
+  - ps: (new-object net.webclient).DownloadFile('https://dl.dropboxusercontent.com/u/37517477/ninja.exe', 'C:\projects\meson\ninja.exe')
+  - cmd: if %arch%==x86 (set MESON_PYTHON_PATH=C:\python34) else (set MESON_PYTHON_PATH=C:\python34-x64)
+  - cmd: echo Using Python at %MESON_PYTHON_PATH%
+  - cmd: copy %MESON_PYTHON_PATH%\python.exe %MESON_PYTHON_PATH%\python3.exe
   - cmd: if %compiler%==msvc2010 ( call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" %arch% )
   - cmd: if %compiler%==msvc2015 ( call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %arch% )
 
 build_script:
   - cmd: echo No build step.
-  - cmd: if %backend%==ninja ( "C:\python34\ninja.exe" --version ) else ( MSBuild /version & echo. )
+  - cmd: if %backend%==ninja ( ninja.exe --version ) else ( MSBuild /version & echo. )
 
 test_script:
   - cmd: echo Running tests for %arch% and %compiler% with the %backend% backend
-  - cmd: PATH=c:\python34;%PATH%; && python3 run_tests.py --backend=%backend%
+  - cmd: PATH=%cd%;%MESON_PYTHON_PATH%;%PATH%; && python3 run_tests.py --backend=%backend%
 
 on_finish:
   - appveyor PushArtifact meson-test-run.txt -DeploymentName "Text test logs"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -43,6 +43,7 @@ install:
 
 build_script:
   - cmd: echo No build step.
+  - cmd: if %backend%==ninja ( "C:\python34\ninja.exe" --version ) else ( MSBuild /version & echo. )
 
 test_script:
   - cmd: echo Running tests for %arch% and %compiler% with the %backend% backend

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,23 +2,51 @@ version: 1.0.{build}
 
 os: Visual Studio 2015
 
+environment:
+  matrix:
+    - arch: x86
+      compiler: msvc2010
+      backend: ninja
+
+    - arch: x86
+      compiler: msvc2010
+      backend: vs2010
+
+    - arch: x86
+      compiler: msvc2015
+      backend: ninja
+
+    - arch: x86
+      compiler: msvc2015
+      backend: vs2015
+
+    - arch: x64
+      compiler: msvc2015
+      backend: ninja
+
+    - arch: x64
+      compiler: msvc2015
+      backend: vs2015
+
 platform:
-  - x86
+  - x64
 
 branches:
   only:
     - master
 
 install:
- - ps: (new-object net.webclient).DownloadFile('https://dl.dropboxusercontent.com/u/37517477/ninja.exe', 'c:\python34\ninja.exe')
- - cmd: copy c:\python34\python.exe c:\python34\python3.exe
- - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86'
+  - ps: (new-object net.webclient).DownloadFile('https://dl.dropboxusercontent.com/u/37517477/ninja.exe', 'c:\python34\ninja.exe')
+  - cmd: copy c:\python34\python.exe c:\python34\python3.exe
+  - cmd: if %compiler%==msvc2010 ( call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" %arch% )
+  - cmd: if %compiler%==msvc2015 ( call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %arch% )
 
 build_script:
   - cmd: echo No build step.
 
 test_script:
-  - cmd: PATH c:\python34;%PATH%; && python3 run_tests.py --backend=ninja
+  - cmd: echo Running tests for %arch% and %compiler% with the %backend% backend
+  - cmd: PATH=c:\python34;%PATH%; && python3 run_tests.py --backend=%backend%
 
 on_finish:
   - appveyor PushArtifact meson-test-run.txt -DeploymentName "Text test logs"

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1694,9 +1694,9 @@ rule FORTRAN_DEP_HACK
 
         if target.has_pch():
             tfilename = self.get_target_filename_abs(target)
-            return compiler.get_compile_debugfile_args(tfilename)
+            return compiler.get_compile_debugfile_args(tfilename, pch=True)
         else:
-            return compiler.get_compile_debugfile_args(objfile)
+            return compiler.get_compile_debugfile_args(objfile, pch=False)
 
     def get_link_debugfile_args(self, linker, target, outname):
         return linker.get_link_debugfile_args(outname)

--- a/mesonbuild/scripts/regen_checker.py
+++ b/mesonbuild/scripts/regen_checker.py
@@ -52,7 +52,7 @@ def run(args):
         regeninfo = pickle.load(f)
     with open(coredata, 'rb') as f:
         coredata = pickle.load(f)
-    mesonscript = coredata.meson_script_file
+    mesonscript = coredata.meson_script_launcher
     backend = coredata.get_builtin_option('backend')
     regen_timestamp = os.stat(dumpfile).st_mtime
     if need_regen(regeninfo, regen_timestamp):

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -512,6 +512,21 @@ if __name__ == '__main__':
     options = parser.parse_args()
     setup_commands(options.backend)
 
+    # Appveyor sets the `platform` environment variable which completely messes
+    # up building with the vs2010 and vs2015 backends.
+    #
+    # Specifically, MSBuild reads the `platform` environment variable to set
+    # the configured value for the platform (Win32/x64/arm), which breaks x86
+    # builds.
+    #
+    # Appveyor setting this also breaks our 'native build arch' detection for
+    # Windows in environment.py:detect_windows_arch() by overwriting the value
+    # of `platform` set by vcvarsall.bat.
+    #
+    # While building for x86, `platform` should be unset.
+    if 'APPVEYOR' in os.environ and os.environ['arch'] == 'x86':
+        os.environ.pop('platform')
+
     script_dir = os.path.split(__file__)[0]
     if script_dir != '':
         os.chdir(script_dir)

--- a/test cases/common/103 manygen/subdir/manygen.py
+++ b/test cases/common/103 manygen/subdir/manygen.py
@@ -9,6 +9,7 @@ import shutil, subprocess
 with open(sys.argv[1]) as f:
     funcname = f.readline().strip()
 outdir = sys.argv[2]
+buildtype_args = sys.argv[3]
 
 if not os.path.isdir(outdir):
     print('Outdir does not exist.')
@@ -67,7 +68,7 @@ with open(tmpc, 'w') as f:
 ''' % funcname)
 
 if is_vs:
-    subprocess.check_call([compiler, '/nologo', '/c', '/Fo' + outo, tmpc])
+    subprocess.check_call([compiler, '/nologo', '/c', buildtype_args, '/Fo' + outo, tmpc])
 else:
     subprocess.check_call([compiler, '-c', '-o', outo, tmpc])
 

--- a/test cases/common/103 manygen/subdir/meson.build
+++ b/test cases/common/103 manygen/subdir/meson.build
@@ -1,6 +1,17 @@
 gen = find_program('manygen.py')
 
+buildtype = get_option('buildtype')
+buildtype_args = '-Dfooxxx' # a useless compiler argument
 if meson.get_compiler('c').get_id() == 'msvc'
+  # We need our manually generated code to use the same CRT as the executable.
+  # Taken from compilers.py since build files do not have access to this.
+  if buildtype == 'debug'
+    buildtype_args = '/MDd'
+  elif buildtype == 'debugoptimized'
+    buildtype_args = '/MDd'
+  elif buildtype == 'release'
+    buildtype_args = '/MD'
+  endif
   outfiles = ['gen_func.lib', 'gen_func.c', 'gen_func.h', 'gen_func.o']
 else
   outfiles = ['gen_func.a', 'gen_func.c', 'gen_func.h', 'gen_func.o']
@@ -9,5 +20,5 @@ endif
 generated = custom_target('manygen',
   output : outfiles,
   input : ['funcinfo.def'],
-  command : [gen, '@INPUT@', '@OUTDIR@'],
+  command : [gen, '@INPUT@', '@OUTDIR@', buildtype_args],
 )

--- a/test cases/common/113 generatorcustom/meson.build
+++ b/test cases/common/113 generatorcustom/meson.build
@@ -1,17 +1,21 @@
 project('generatorcustom', 'c')
 
-creator = find_program('gen.py')
-catter = find_program('catter.py')
+if meson.get_compiler('c').get_id() != 'msvc'
+  creator = find_program('gen.py')
+  catter = find_program('catter.py')
 
-gen = generator(creator,
-  output: '@BASENAME@.h',
-  arguments : ['@INPUT@', '@OUTPUT@'])
+  gen = generator(creator,
+    output: '@BASENAME@.h',
+    arguments : ['@INPUT@', '@OUTPUT@'])
 
-hs = gen.process('res1.txt', 'res2.txt')
+  hs = gen.process('res1.txt', 'res2.txt')
 
-allinone = custom_target('alltogether',
-    input : hs,
-    output : 'alltogether.h',
-    command : [catter, '@INPUT@', '@OUTPUT@'])
+  allinone = custom_target('alltogether',
+      input : hs,
+      output : 'alltogether.h',
+      command : [catter, '@INPUT@', '@OUTPUT@'])
 
-executable('proggie', 'main.c', allinone)
+  executable('proggie', 'main.c', allinone)
+else
+  error('MESON_SKIP_TEST: Skipping test on VS backend; see: https://github.com/mesonbuild/meson/issues/1004')
+endif

--- a/test cases/common/51 pkgconfig-gen/meson.build
+++ b/test cases/common/51 pkgconfig-gen/meson.build
@@ -19,7 +19,7 @@ pkgg.generate(
 )
 
 pkgconfig = find_program('pkg-config', required: false)
-if pkgconfig.found()
+if pkgconfig.found() and build_machine.system() != 'windows'
   test('pkgconfig-validation', pkgconfig,
     args: ['--validate', 'simple'],
     env: ['PKG_CONFIG_PATH=' + meson.current_build_dir() + '/meson-private' ],

--- a/test cases/common/62 exe static shared/stat.c
+++ b/test cases/common/62 exe static shared/stat.c
@@ -1,5 +1,7 @@
+#include "subdir/exports.h"
+
 int shlibfunc();
 
-int statlibfunc() {
+int DLL_PUBLIC statlibfunc() {
     return shlibfunc();
 }


### PR DESCRIPTION
Now we test:
 MSVC 2010 + Ninja (x86)
 MSVC 2015 + Ninja (x86)
 MSVC 2015 + Ninja (x86_64)
 MSVC 2010 + MSBuild (x86)
 MSVC 2015 + MSBuild (x86)
 MSVC 2015 + MSBuild (x86_64)

MSVC 2010 Express only shipped with an x86 toolchain, so we can only test x86 for that.