### PR TITLE
Search for headers in build dir before source dir. Closes #984.

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1720,10 +1720,11 @@ rule FORTRAN_DEP_HACK
         # Add the root source and build directories as include dirs
         curdir = target.get_subdir()
         tmppath = os.path.normpath(os.path.join(self.build_to_src, curdir))
-        commands += compiler.get_include_args(tmppath, False)
+        src_inc = compiler.get_include_args(tmppath, False)
         if curdir ==  '':
             curdir = '.'
-        commands += compiler.get_include_args(curdir, False)
+        build_inc = compiler.get_include_args(curdir, False)
+        commands += build_inc + src_inc
         # -I args work differently than other ones. In them the first found
         # directory is used whereas for other flags (such as -ffoo -fno-foo) the
         # latest one is used.  Therefore put the internal include directories

--- a/test cases/common/16 configure file/config.h
+++ b/test cases/common/16 configure file/config.h
@@ -1,0 +1,1 @@
+#error "This file should not be included. Build dir must become before source dir in search order"

--- a/test cases/common/16 configure file/prog.c
+++ b/test cases/common/16 configure file/prog.c
@@ -1,5 +1,8 @@
 #include <string.h>
-#include "config.h"
+/* config.h must not be in quotes:
+ * https://gcc.gnu.org/onlinedocs/cpp/Search-Path.html
+ */
+#include <config.h>
 
 #ifdef SHOULD_BE_UNDEF
 #error "FAIL!"

--- a/test cases/common/16 configure file/prog2.c
+++ b/test cases/common/16 configure file/prog2.c
@@ -1,4 +1,4 @@
-#include"config2.h"
+#include<config2.h>
 
 int main(int argc, char **argv) {
     return ZERO_RESULT;


### PR DESCRIPTION
Note that this is impossible to fix if the source code has an include directive using quotes rather than angle brackets:

https://gcc.gnu.org/onlinedocs/cpp/Search-Path.html