### PR TITLE
javac: Don't fail if there's no JVM

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import shutil
 import contextlib
 import subprocess, os.path
 import tempfile
@@ -1274,11 +1275,20 @@ class JavaCompiler(Compiler):
         pc.wait()
         if pc.returncode != 0:
             raise EnvironmentException('Java compiler %s can not compile programs.' % self.name_string())
-        cmdlist = [self.javarunner, obj]
-        pe = subprocess.Popen(cmdlist, cwd=work_dir)
-        pe.wait()
-        if pe.returncode != 0:
-            raise EnvironmentException('Executables created by Java compiler %s are not runnable.' % self.name_string())
+        runner = shutil.which(self.javarunner)
+        if runner:
+            cmdlist = [runner, obj]
+            pe = subprocess.Popen(cmdlist, cwd=work_dir)
+            pe.wait()
+            if pe.returncode != 0:
+                raise EnvironmentException('Executables created by Java compiler %s are not runnable.' % self.name_string())
+        else:
+            m = "Java Virtual Machine wasn't found, but it's needed by Meson. " \
+                "Please install a JRE.\nIf you have specific needs where this " \
+                "requirement doesn't make sense, please open a bug at " \
+                "https://github.com/mesonbuild/meson/issues/new and tell us " \
+                "all about it."
+            raise EnvironmentException(m)
 
     def needs_static_linker(self):
         return False

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -338,7 +338,7 @@ def detect_tests_to_run():
     all_tests.append(('platform-windows', gather_tests('test cases/windows'), False if mesonlib.is_windows() else True))
     all_tests.append(('platform-linux', gather_tests('test cases/linuxlike'), False if not (mesonlib.is_osx() or mesonlib.is_windows()) else True))
     all_tests.append(('framework', gather_tests('test cases/frameworks'), False if not mesonlib.is_osx() and not mesonlib.is_windows() else True))
-    all_tests.append(('java', gather_tests('test cases/java'), False if not mesonlib.is_osx() and shutil.which('javac') else True))
+    all_tests.append(('java', gather_tests('test cases/java'), False if not mesonlib.is_osx() and shutil.which('javac') and shutil.which('java') else True))
     all_tests.append(('C#', gather_tests('test cases/csharp'), False if shutil.which('mcs') else True))
     all_tests.append(('vala', gather_tests('test cases/vala'), False if shutil.which('valac') else True))
     all_tests.append(('rust', gather_tests('test cases/rust'), False if shutil.which('rustc') else True))


### PR DESCRIPTION
A JVM is not required to compile Java executables. Without this, we error out with an exception if `javac` is found but `java` isn't:

```
[...]
File "mesonbuild/interpreter.py", line 1759, in detect_compilers
  comp.sanity_check(self.environment.get_scratch_dir(), self.environment)
File "mesonbuild/compilers.py", line 1279, in sanity_check
  pe = subprocess.Popen(cmdlist, cwd=work_dir)
File "/usr/lib64/python3.5/subprocess.py", line 947, in __init__
  restore_signals, start_new_session)
File "/usr/lib64/python3.5/subprocess.py", line 1551, in _execute_child
  raise child_exception_type(errno_num, err_msg)
FileNotFoundError: [Errno 2] No such file or directory: 'java'
```