### PR TITLE
custom_target: Substitute @OUTPUT@ and @INPUT properly

### DIFF
--- a/test cases/common/56 custom target/meson.build
+++ b/test cases/common/56 custom target/meson.build
@@ -9,7 +9,7 @@ comp = '@0@/@1@'.format(meson.current_source_dir(), 'my_compiler.py')
 mytarget = custom_target('bindat',
 output : 'data.dat',
 input : 'data_source.txt',
-command : [python, comp, '@INPUT@', '@OUTPUT@'],
+command : [python, comp, '--input=@INPUT@', '--output=@OUTPUT@'],
 install : true,
 install_dir : 'subdir'
 )

--- a/test cases/common/56 custom target/my_compiler.py
+++ b/test cases/common/56 custom target/my_compiler.py
@@ -3,13 +3,14 @@
 import sys
 
 if __name__ == '__main__':
-    if len(sys.argv) != 3:
-        print(sys.argv[0], 'input_file output_file')
+    if len(sys.argv) != 3 or not sys.argv[1].startswith('--input') or \
+       not sys.argv[2].startswith('--output'):
+        print(sys.argv[0], '--input=input_file --output=output_file')
         sys.exit(1)
-    with open(sys.argv[1]) as f:
+    with open(sys.argv[1].split('=')[1]) as f:
         ifile = f.read()
     if ifile != 'This is a text only input file.\n':
         print('Malformed input')
         sys.exit(1)
-    with open(sys.argv[2], 'w') as ofile:
+    with open(sys.argv[2].split('=')[1], 'w') as ofile:
         ofile.write('This is a binary output file.\n')


### PR DESCRIPTION
They weren't being substituted if they were a part of a command argument, ala `--output=@OUTPUT@`, etc.

Closes https://github.com/mesonbuild/meson/issues/824