### PR TITLE
ninja: Pass absolute path of files to run targets

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -515,10 +515,10 @@ int dummy;
                 arg_strings.append(os.path.join(self.environment.get_build_dir(), relfname))
                 deps.append(relfname)
             elif isinstance(i, mesonlib.File):
-                arg_strings.append(i.rel_to_builddir(self.build_to_src))
+                relfname = i.rel_to_builddir(self.build_to_src)
+                arg_strings.append(os.path.join(self.environment.get_build_dir(), relfname))
             else:
-                mlog.debug(str(i))
-                raise MesonException('Unreachable code in generate_run_target.')
+                raise AssertionError('Unreachable code in generate_run_target: ' + str(i))
         elem = NinjaBuildElement(self.all_outputs, target.name, 'CUSTOM_COMMAND', [])
         cmd = runnerscript + [self.environment.get_source_dir(), self.environment.get_build_dir(), target.subdir]
         texe = target.command

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -73,6 +73,9 @@ class LinuxlikeTests(unittest.TestCase):
     def build(self):
         self.output += subprocess.check_output(self.ninja_command)
 
+    def run_target(self, target):
+        self.output += subprocess.check_output(self.ninja_command + [target])
+
     def setconf(self, arg):
         self.output += subprocess.check_output(self.mconf_command + [arg, self.builddir])
 
@@ -172,6 +175,11 @@ class LinuxlikeTests(unittest.TestCase):
             intro = intro[::-1]
         self.assertEqual(intro[0]['install_filename'], '/usr/local/libtest/libstat.a')
         self.assertEqual(intro[1]['install_filename'], '/usr/local/bin/prog')
+
+    def test_run_target_files_path(self):
+        testdir = os.path.join(self.common_test_dir, '58 run target')
+        self.init(testdir)
+        self.run_target('check_exists')
 
 if __name__ == '__main__':
     unittest.main()

--- a/test cases/common/58 run target/check_exists.py
+++ b/test cases/common/58 run target/check_exists.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+if not os.path.isfile(sys.argv[1]):
+    raise Exception("Couldn't find {!r}".format(sys.argv[1]))

--- a/test cases/common/58 run target/meson.build
+++ b/test cases/common/58 run target/meson.build
@@ -35,8 +35,8 @@ python3 = find_program('python3')
 run_target('py3hi',
   command : [python3, '-c', 'print("I am Python3.")'])
 
-run_target('ct_in_arg',
-  command : ['echo', hex, files('helloprinter.c')])
+run_target('check_exists',
+  command : [find_program('check_exists.py'), files('helloprinter.c')])
 
 # What if the output of a custom_target is the command to
 # execute. Obviously this will not work as hex is not an


### PR DESCRIPTION
We already pass everything else (custom targets, build targets, etc) as absolute paths, and this is the only sane way to handle this till we rework the codebase to use `File` objects everywhere (after reworking the `File` object itself).

Fixes #957
