### PR TITLE
Allow tests to mark themselves as skipped during runtime.

### DIFF
--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -379,7 +379,7 @@ def run_tests(extra_args):
             futures.append((testname, t, result))
         for (testname, t, result) in futures:
             result = result.result()
-            if result is None:
+            if result is None or 'MESON_SKIP_TEST' in result.stdo:
                 print('Skipping:', t)
                 current_test = ET.SubElement(current_suite, 'testcase', {'name' : testname,
                                                                          'classname' : name})

--- a/test cases/common/121 skip/meson.build
+++ b/test cases/common/121 skip/meson.build
@@ -1,0 +1,4 @@
+project('skip', 'c')
+
+error('MESON_SKIP_TEST this test is always skipped.')
+

--- a/test cases/frameworks/10 gtk-doc/meson.build
+++ b/test cases/frameworks/10 gtk-doc/meson.build
@@ -8,4 +8,6 @@ inc = include_directories('include')
 
 # We have to disable this test until this bug fix has landed to
 # distros https://bugzilla.gnome.org/show_bug.cgi?id=753145
-# subdir('doc')
+error('MESON_SKIP_TEST can not enable gtk-doc test until upstream fixes have landed.')
+
+subdir('doc')

--- a/test cases/python3/3 cython/meson.build
+++ b/test cases/python3/3 cython/meson.build
@@ -13,5 +13,5 @@ if cython.found()
     env : ['PYTHONPATH=' + pydir]
   )
 else
-  message('Cython not found, skipping test.')
+  error('MESON_SKIP_TEST: Cython not found, skipping test.')
 endif


### PR DESCRIPTION
This makes skipped tests visible in the logs and reduces the number of if branches in test projects.