### PR TITLE
gnome.generate_gir: Add gir deps and includes recursively

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -401,6 +401,41 @@ class GnomeModule:
             deps = [deps]
         deps = (girtarget.get_all_link_deps() + girtarget.get_external_deps() +
                 deps)
+        # Need to recursively add deps on GirTarget sources from our
+        # dependencies and also find the include directories needed for the
+        # typelib generation custom target below.
+        typelib_includes = []
+        for dep in deps:
+            if hasattr(dep, 'held_object'):
+                dep = dep.held_object
+            # Add a dependency on each GirTarget listed in dependencies and add
+            # the directory where it will be generated to the typelib includes
+            if isinstance(dep, dependencies.InternalDependency):
+                for source in dep.sources:
+                    if hasattr(source, 'held_object'):
+                        source = source.held_object
+                    if isinstance(source, GirTarget) and source not in depends:
+                        depends.append(source)
+                        subdir = os.path.join(state.environment.get_build_dir(),
+                                              source.get_subdir())
+                        if subdir not in typelib_includes:
+                            typelib_includes.append(subdir)
+            # Do the same, but for dependencies of dependencies. These are
+            # stored in the list of generated sources for each link dep (from
+            # girtarget.get_all_link_deps() above).
+            # FIXME: Store this in the original form from declare_dependency()
+            # so it can be used here directly.
+            elif isinstance(dep, build.SharedLibrary):
+                for source in dep.generated:
+                    if isinstance(source, GirTarget):
+                        subdir = os.path.join(state.environment.get_build_dir(),
+                                              source.get_subdir())
+                        if subdir not in typelib_includes:
+                            typelib_includes.append(subdir)
+            elif isinstance(dep, dependencies.PkgConfigDependency):
+                girdir = dep.get_pkgconfig_variable("girdir")
+                if girdir and girdir not in typelib_includes:
+                    typelib_includes.append(girdir)
         # ldflags will be misinterpreted by gir scanner (showing
         # spurious dependencies) but building GStreamer fails if they
         # are not used here.
@@ -441,22 +476,8 @@ class GnomeModule:
         typelib_cmd = ['g-ir-compiler', scan_target, '--output', '@OUTPUT@']
         typelib_cmd += self._get_include_args(state, gir_inc_dirs,
                                               prefix='--includedir=')
-        for dep in deps:
-            if hasattr(dep, 'held_object'):
-                dep = dep.held_object
-            if isinstance(dep, dependencies.InternalDependency):
-                for source in dep.sources:
-                    if isinstance(source.held_object, GirTarget):
-                        typelib_cmd += [
-                            "--includedir=%s" % (
-                                os.path.join(state.environment.get_build_dir(),
-                                             source.held_object.get_subdir()),
-                            )
-                        ]
-            elif isinstance(dep, dependencies.PkgConfigDependency):
-                girdir = dep.get_pkgconfig_variable("girdir")
-                if girdir:
-                    typelib_cmd += ["--includedir=%s" % (girdir, )]
+        for incdir in typelib_includes:
+            typelib_cmd += ["--includedir=" + incdir]
 
         typelib_kwargs = {
             'output': typelib_output,

--- a/test cases/frameworks/7 gnome/gir/dep1/dep1.c
+++ b/test cases/frameworks/7 gnome/gir/dep1/dep1.c
@@ -1,0 +1,56 @@
+#include "dep1.h"
+
+struct _MesonDep1
+{
+  GObject parent_instance;
+};
+
+G_DEFINE_TYPE (MesonDep1, meson_dep1, G_TYPE_OBJECT)
+
+/**
+ * meson_dep1_new:
+ *
+ * Allocates a new #MesonDep1.
+ *
+ * Returns: (transfer full): a #MesonDep1.
+ */
+MesonDep1 *
+meson_dep1_new (void)
+{
+  return g_object_new (MESON_TYPE_DEP1, NULL);
+}
+
+static void
+meson_dep1_finalize (GObject *object)
+{
+  G_OBJECT_CLASS (meson_dep1_parent_class)->finalize (object);
+}
+
+static void
+meson_dep1_class_init (MesonDep1Class *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = meson_dep1_finalize;
+}
+
+static void
+meson_dep1_init (MesonDep1 *self)
+{
+}
+
+/**
+ * meson_dep1_just_return_it:
+ * @dep: a #MesonDep2.
+ *
+ * Returns the #MesonDep2 that is passed in
+ *
+ * Returns: (transfer none): a #MesonDep2
+ */
+MesonDep2*
+meson_dep1_just_return_it (MesonDep1 *self, MesonDep2 *dep)
+{
+  g_return_val_if_fail (MESON_IS_DEP1 (self), NULL);
+
+  return dep;
+}

--- a/test cases/frameworks/7 gnome/gir/dep1/dep1.h
+++ b/test cases/frameworks/7 gnome/gir/dep1/dep1.h
@@ -1,0 +1,23 @@
+#ifndef MESON_DEP1_H
+#define MESON_DEP1_H
+
+#if !defined (MESON_TEST)
+#error "MESON_TEST not defined."
+#endif
+
+#include <glib-object.h>
+#include "dep2/dep2.h"
+
+G_BEGIN_DECLS
+
+#define MESON_TYPE_DEP1 (meson_dep1_get_type())
+
+G_DECLARE_FINAL_TYPE (MesonDep1, meson_dep1, MESON, DEP1, GObject)
+
+MesonDep1   *meson_dep1_new            (void);
+MesonDep2   *meson_dep1_just_return_it (MesonDep1 *self,
+                                        MesonDep2 *dep);
+
+G_END_DECLS
+
+#endif /* MESON_DEP1_H */

--- a/test cases/frameworks/7 gnome/gir/dep1/dep2/dep2.c
+++ b/test cases/frameworks/7 gnome/gir/dep1/dep2/dep2.c
@@ -1,13 +1,13 @@
-#include "meson-sample.h"
+#include "dep2.h"
 
-struct _MesonSample
+struct _MesonDep2
 {
   GObject parent_instance;
 
   gchar *msg;
 };
 
-G_DEFINE_TYPE (MesonSample, meson_sample, G_TYPE_OBJECT)
+G_DEFINE_TYPE (MesonDep2, meson_dep2, G_TYPE_OBJECT)
 
 enum {
   PROP_0,
@@ -18,35 +18,40 @@ enum {
 static GParamSpec *gParamSpecs [LAST_PROP];
 
 /**
- * meson_sample_new:
+ * meson_dep2_new:
+ * @msg: The message to set.
  *
- * Allocates a new #MesonSample.
+ * Allocates a new #MesonDep2.
  *
- * Returns: (transfer full): a #MesonSample.
+ * Returns: (transfer full): a #MesonDep2.
  */
-MesonSample *
-meson_sample_new (void)
+MesonDep2 *
+meson_dep2_new (const gchar *msg)
 {
-  return g_object_new (MESON_TYPE_SAMPLE, NULL);
+  g_return_val_if_fail (msg != NULL, NULL);
+
+  return g_object_new (MESON_TYPE_DEP2,
+                       "message", msg,
+                       NULL);
 }
 
 static void
-meson_sample_finalize (GObject *object)
+meson_dep2_finalize (GObject *object)
 {
-  MesonSample *self = (MesonSample *)object;
+  MesonDep2 *self = (MesonDep2 *)object;
 
   g_clear_pointer (&self->msg, g_free);
 
-  G_OBJECT_CLASS (meson_sample_parent_class)->finalize (object);
+  G_OBJECT_CLASS (meson_dep2_parent_class)->finalize (object);
 }
 
 static void
-meson_sample_get_property (GObject    *object,
+meson_dep2_get_property (GObject    *object,
                            guint       prop_id,
                            GValue     *value,
                            GParamSpec *pspec)
 {
-  MesonSample *self = MESON_SAMPLE (object);
+  MesonDep2 *self = MESON_DEP2 (object);
 
   switch (prop_id)
     {
@@ -59,12 +64,12 @@ meson_sample_get_property (GObject    *object,
 }
 
 static void
-meson_sample_set_property (GObject      *object,
+meson_dep2_set_property (GObject      *object,
                            guint         prop_id,
                            const GValue *value,
                            GParamSpec   *pspec)
 {
-  MesonSample *self = MESON_SAMPLE (object);
+  MesonDep2 *self = MESON_DEP2 (object);
 
   switch (prop_id)
     {
@@ -77,13 +82,13 @@ meson_sample_set_property (GObject      *object,
 }
 
 static void
-meson_sample_class_init (MesonSampleClass *klass)
+meson_dep2_class_init (MesonDep2Class *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
-  object_class->finalize = meson_sample_finalize;
-  object_class->get_property = meson_sample_get_property;
-  object_class->set_property = meson_sample_set_property;
+  object_class->finalize = meson_dep2_finalize;
+  object_class->get_property = meson_dep2_get_property;
+  object_class->set_property = meson_dep2_set_property;
 
   gParamSpecs [PROP_MSG] =
     g_param_spec_string ("message",
@@ -98,24 +103,22 @@ meson_sample_class_init (MesonSampleClass *klass)
 }
 
 static void
-meson_sample_init (MesonSample *self)
+meson_dep2_init (MesonDep2 *self)
 {
 }
 
 /**
- * meson_sample_print_message:
- * @self: a #MesonSample.
+ * meson_dep2_return_message:
+ * @self: a #MesonDep2.
  *
- * Prints the message.
+ * Returns the message.
  *
- * Returns: Nothing.
+ * Returns: (transfer none): a const gchar*
  */
-void
-meson_sample_print_message (MesonSample *self, MesonDep1 *dep1, MesonDep2 *dep2)
+const gchar*
+meson_dep2_return_message (MesonDep2 *self)
 {
-  MesonDep2 *samedep;
-  g_return_if_fail (MESON_IS_SAMPLE (self));
+  g_return_val_if_fail (MESON_IS_DEP2 (self), NULL);
 
-  samedep = meson_dep1_just_return_it (dep1, dep2);
-  g_print ("Message: %s\n", meson_dep2_return_message (samedep));
+  return (const gchar*) self->msg;
 }

--- a/test cases/frameworks/7 gnome/gir/dep1/dep2/dep2.h
+++ b/test cases/frameworks/7 gnome/gir/dep1/dep2/dep2.h
@@ -1,0 +1,21 @@
+#ifndef MESON_DEP2_H
+#define MESON_DEP2_H
+
+#if !defined (MESON_TEST)
+#error "MESON_TEST not defined."
+#endif
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define MESON_TYPE_DEP2 (meson_dep2_get_type())
+
+G_DECLARE_FINAL_TYPE (MesonDep2, meson_dep2, MESON, DEP2, GObject)
+
+MesonDep2   *meson_dep2_new            (const gchar *msg);
+const gchar *meson_dep2_return_message (MesonDep2 *self);
+
+G_END_DECLS
+
+#endif /* MESON_DEP2_H */

--- a/test cases/frameworks/7 gnome/gir/dep1/dep2/meson.build
+++ b/test cases/frameworks/7 gnome/gir/dep1/dep2/meson.build
@@ -1,0 +1,22 @@
+dep2sources = ['dep2.c', 'dep2.h']
+
+dep2lib = shared_library(
+  'dep2lib',
+  sources : dep2sources,
+  dependencies : gobj,
+  install : true
+)
+
+dep2gir = gnome.generate_gir(
+  dep2lib,
+  sources : dep2sources,
+  nsversion : '1.0',
+  namespace : 'MesonDep2',
+  symbol_prefix : 'meson',
+  identifier_prefix : 'Meson',
+  includes : ['GObject-2.0'],
+  install : true
+)
+
+dep2_dep = declare_dependency(link_with : dep2lib,
+  sources : [dep2gir])

--- a/test cases/frameworks/7 gnome/gir/dep1/meson.build
+++ b/test cases/frameworks/7 gnome/gir/dep1/meson.build
@@ -1,0 +1,29 @@
+subdir('dep2')
+
+dep1sources = ['dep1.c', 'dep1.h']
+
+# Do not need to link to dep2lib because we don't use any symbols from it
+dep1lib = shared_library(
+  'dep1lib',
+  sources : dep1sources,
+  dependencies : gobj,
+  install : true
+)
+
+# But the gir does need it because it we use the MesonDep2* structure defined
+# in the header
+dep1gir = gnome.generate_gir(
+  dep1lib,
+  sources : dep1sources,
+  nsversion : '1.0',
+  namespace : 'MesonDep1',
+  symbol_prefix : 'meson',
+  identifier_prefix : 'Meson',
+  includes : ['GObject-2.0', 'MesonDep2-1.0'],
+  dependencies : [dep2_dep],
+  install : true
+)
+
+dep1_dep = declare_dependency(link_with : dep1lib,
+  dependencies : [dep2_dep],
+  sources : [dep1gir])

--- a/test cases/frameworks/7 gnome/gir/meson-sample.h
+++ b/test cases/frameworks/7 gnome/gir/meson-sample.h
@@ -6,6 +6,7 @@
 #endif
 
 #include <glib-object.h>
+#include "dep1/dep1.h"
 
 G_BEGIN_DECLS
 
@@ -13,8 +14,10 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (MesonSample, meson_sample, MESON, SAMPLE, GObject)
 
-MesonSample *meson_sample_new           (const gchar *msg);
-void         meson_sample_print_message (MesonSample *self);
+MesonSample *meson_sample_new           (void);
+void         meson_sample_print_message (MesonSample *self,
+                                         MesonDep1 *dep1,
+                                         MesonDep2 *dep2);
 
 G_END_DECLS
 

--- a/test cases/frameworks/7 gnome/gir/meson.build
+++ b/test cases/frameworks/7 gnome/gir/meson.build
@@ -1,9 +1,11 @@
+subdir('dep1')
+
 libsources = ['meson-sample.c', 'meson-sample.h']
 
 girlib = shared_library(
   'gir_lib',
   sources : libsources,
-  dependencies : gobj,
+  dependencies : [gobj, dep1_dep],
   install : true
 )
 
@@ -21,15 +23,17 @@ gnome.generate_gir(
   sources : libsources,
   nsversion : '1.0',
   namespace : 'Meson',
-  symbol_prefix : 'meson_',
+  symbol_prefix : 'meson',
   identifier_prefix : 'Meson',
-  includes : ['GObject-2.0'],
-  dependencies : [fake_dep],
+  includes : ['GObject-2.0', 'MesonDep1-1.0'],
+  # dep1_dep pulls in dep2_dep for us
+  dependencies : [fake_dep, dep1_dep],
   install : true
 )
 
 test('gobject introspection/c', girexe)
+gir_paths = ':'.join([girlib.outdir(), dep1lib.outdir(), dep2lib.outdir()])
 test('gobject introspection/py', find_program('prog.py'),
-     env : ['GI_TYPELIB_PATH=' + girlib.outdir(), 
-            'LD_LIBRARY_PATH=' + girlib.outdir(),
+     env : ['GI_TYPELIB_PATH=' + gir_paths, 
+            'LD_LIBRARY_PATH=' + gir_paths,
      ])

--- a/test cases/frameworks/7 gnome/gir/prog.c
+++ b/test cases/frameworks/7 gnome/gir/prog.c
@@ -21,10 +21,14 @@ main (gint   argc,
     return 1;
   }
 
-  MesonSample * i = meson_sample_new ("Hello, meson/c!");
-  meson_sample_print_message (i);
+  MesonSample * i = meson_sample_new ();
+  MesonDep1 * dep1 = meson_dep1_new ();
+  MesonDep2 * dep2 = meson_dep2_new ("Hello, meson/c!");
+  meson_sample_print_message (i, dep1, dep2);
 
   g_object_unref (i);
+  g_object_unref (dep1);
+  g_object_unref (dep2);
   g_option_context_free (ctx);
 
   return 0;

--- a/test cases/frameworks/7 gnome/gir/prog.py
+++ b/test cases/frameworks/7 gnome/gir/prog.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
-from gi.repository import Meson
+from gi.repository import Meson, MesonDep1, MesonDep2
 
 if __name__ == "__main__":
-    s = Meson.Sample.new("Hello, meson/py!")
-    s.print_message()
+    s = Meson.Sample.new()
+    dep1 = MesonDep1.Dep1.new()
+    dep2 = MesonDep2.Dep2.new("Hello, meson/py!")
+    s.print_message(dep1, dep2)

--- a/test cases/frameworks/7 gnome/installed_files.txt
+++ b/test cases/frameworks/7 gnome/installed_files.txt
@@ -2,7 +2,13 @@ usr/include/enums.h
 usr/include/enums2.h
 usr/include/enums3.h
 usr/include/marshaller.h
-usr/lib/girepository-1.0/Meson-1.0.typelib
 usr/lib/libgir_lib.so
+usr/lib/libdep1lib.so
+usr/lib/libdep2lib.so
+usr/lib/girepository-1.0/Meson-1.0.typelib
+usr/lib/girepository-1.0/MesonDep1-1.0.typelib
+usr/lib/girepository-1.0/MesonDep2-1.0.typelib
 usr/share/gir-1.0/Meson-1.0.gir
+usr/share/gir-1.0/MesonDep1-1.0.gir
+usr/share/gir-1.0/MesonDep2-1.0.gir
 usr/share/glib-2.0/schemas/com.github.meson.gschema.xml


### PR DESCRIPTION
Earlier, we were never adding dependencies on other `GirTarget`s that we need. The dependency would only be added indirectly through other `BuildTarget`s such as `SharedLibrary`. Now we add all `GirTarget`s specified in the `dependencies :` kwarg to the list of dependencies of the `GirTarget` that we generate.

Also, we weren't adding include directories for the typelib generation command recursively. We were only adding it for the `GirTarget`s listed under the `dependencies :` kwarg to `gnome.generate_gir`. Now we search all link targets, find `GirTargets`, extract the include dir, and use it.

In summation, dependencies were completely broken. This has been breaking the gstreamer master build ever since we started generating GIRs for modules other than gstreamer-core. This can be reproduced by building without gstreamer development files (`.gir` and `.pc` files) installed on the system.