### PR TITLE
vala: Implement valac.find_library

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1045,6 +1045,8 @@ int dummy;
                    and d.version_requirement.startswith(('>=', '==')):
                     args += ['--target-glib', d.version_requirement[2:]]
                 args += ['--pkg', d.name]
+            elif isinstance(d, dependencies.ExternalLibrary):
+                args += d.get_lang_args('vala')
         extra_args = []
 
         for a in target.extra_args.get('vala', []):

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -454,29 +454,37 @@ class ExternalProgram():
         return self.name
 
 class ExternalLibrary(Dependency):
-    def __init__(self, name, link_args=None, silent=False):
+    # TODO: Add `lang` to the parent Dependency object so that dependencies can
+    # be expressed for languages other than C-like
+    def __init__(self, name, link_args=None, language=None, silent=False):
         super().__init__('external')
         self.name = name
-        # Rename fullpath to link_args once standalone find_library() gets removed.
-        if link_args is not None:
-            if isinstance(link_args, list):
-                self.link_args = link_args
+        self.is_found = False
+        self.link_args = []
+        self.lang_args = []
+        if link_args:
+            self.is_found = True
+            if not isinstance(link_args, list):
+                link_args = [link_args]
+            if language:
+                self.lang_args = {language: link_args}
             else:
-                self.link_args = [link_args]
-        else:
-            self.link_args = link_args
+                self.link_args = link_args
         if not silent:
-            if self.found():
+            if self.is_found:
                 mlog.log('Library', mlog.bold(name), 'found:', mlog.green('YES'))
             else:
                 mlog.log('Library', mlog.bold(name), 'found:', mlog.red('NO'))
 
     def found(self):
-        return self.link_args is not None
+        return self.is_found
 
     def get_link_args(self):
-        if self.found():
-            return self.link_args
+        return self.link_args
+
+    def get_lang_args(self, lang):
+        if lang in self.lang_args:
+            return self.lang_args[lang]
         return []
 
 class BoostDependency(Dependency):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -941,9 +941,17 @@ class CompilerHolder(InterpreterObject):
             if not os.path.isabs(i):
                 raise InvalidCode('Search directory %s is not an absolute path.' % i)
         linkargs = self.compiler.find_library(libname, self.environment, search_dirs)
-        if required and linkargs is None:
-            raise InterpreterException('Library {} not found'.format(libname))
-        lib = dependencies.ExternalLibrary(libname, linkargs)
+        if required and not linkargs:
+            l = self.compiler.language.capitalize()
+            raise InterpreterException('{} library {!r} not found'.format(l, libname))
+        # If this is set to None, the library and link arguments are for
+        # a C-like compiler. Otherwise, it's for some other language that has
+        # a find_library implementation. We do this because it's easier than
+        # maintaining a list of languages that can consume C libraries.
+        lang = None
+        if self.compiler.language == 'vala':
+            lang = 'vala'
+        lib = dependencies.ExternalLibrary(libname, linkargs, language=lang)
         return ExternalLibraryHolder(lib)
 
     def has_argument_method(self, args, kwargs):

--- a/test cases/vala/13 find library/meson.build
+++ b/test cases/vala/13 find library/meson.build
@@ -1,0 +1,9 @@
+project('find vala library', 'vala', 'c')
+
+valac = meson.get_compiler('vala')
+
+gobject = dependency('gobject-2.0')
+zlib = valac.find_library('zlib')
+
+e = executable('zlibtest', 'test.vala', dependencies : [gobject, zlib])
+test('testzlib', e)

--- a/test cases/vala/13 find library/test.vala
+++ b/test cases/vala/13 find library/test.vala
@@ -1,0 +1,6 @@
+using ZLib;
+
+public static int main(string[] args) {
+    stdout.printf("ZLIB_VERSION is: %s\n", ZLib.VERSION.STRING);
+    return 0;
+}

--- a/test cases/vala/4 config/meson-something-else.vapi
+++ b/test cases/vala/4 config/meson-something-else.vapi
@@ -1,0 +1,1 @@
+public const string SOMETHING_ELSE;

--- a/test cases/vala/4 config/meson.build
+++ b/test cases/vala/4 config/meson.build
@@ -1,11 +1,15 @@
 project('valatest', 'vala', 'c')
 
-valadeps = [dependency('glib-2.0'), dependency('gobject-2.0')]
+valac = meson.get_compiler('vala')
+# Try to find our library
+valadeps = [valac.find_library('meson-something-else', dirs : meson.current_source_dir())]
+valadeps += [dependency('glib-2.0'), dependency('gobject-2.0')]
 
 e = executable(
 'valaprog',
 sources : ['config.vapi', 'prog.vala'],
 dependencies : valadeps,
-c_args : '-DDATA_DIRECTORY="@0@"'.format(meson.current_source_dir())
+c_args : ['-DDATA_DIRECTORY="@0@"'.format(meson.current_source_dir()),
+          '-DSOMETHING_ELSE="Out of this world!"']
 )
 test('valatest', e)

--- a/test cases/vala/4 config/prog.vala
+++ b/test cases/vala/4 config/prog.vala
@@ -2,6 +2,7 @@ class MainProg : GLib.Object {
 
     public static int main(string[] args) {
         stdout.printf("DATA_DIRECTORY is: %s.\n", DATA_DIRECTORY);
+        stdout.printf("SOMETHING_ELSE is: %s.\n", SOMETHING_ELSE);
         return 0;
     }
 }


### PR DESCRIPTION
Moves `CCompiler.compile` to `Compiler.compile` so that `ValaCompiler` can use it. Also rewrite `ValaCompiler.sanity_check` to use it since it does a simple compile check.

At the same time, it enhances `ExternalLibrary` to support arguments for languages other than C-like.

Includes a test for this that links against zlib through Vala and searches for a custom `.vapi` file inside the source tree, although this feature is supposed to be used for `.vapi` files outside the source tree. Vapis inside the source tree should just be added as sources.

Closes #983 and #687 