### PR TITLE
Fix regex used in custom target evaluation

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -598,11 +598,17 @@ class Backend():
                 i = i.replace('@OUTDIR@', outdir)
             elif '@DEPFILE@' in i:
                 if target.depfile is None:
-                    raise MesonException('Custom target %s has @DEPFILE@ but no depfile keyword argument.' % target.name)
+                    msg = 'Custom target {!r} has @DEPFILE@ but no depfile ' \
+                          'keyword argument.'.format(target.name)
+                    raise MesonException(msg)
                 dfilename = os.path.join(outdir, target.depfile)
                 i = i.replace('@DEPFILE@', dfilename)
             elif '@PRIVATE_OUTDIR_' in i:
-                match = re.search('@PRIVATE_OUTDIR_(ABS_)?([-a-zA-Z0-9.@:]*)@', i)
+                match = re.search('@PRIVATE_OUTDIR_(ABS_)?([^\/\s*]*)@', i)
+                if not match:
+                    msg = 'Custom target {!r} has an invalid argument {!r}' \
+                          ''.format(target.name, i)
+                    raise MesonException(msg)
                 source = match.group(0)
                 if match.group(1) is None and not absolute_paths:
                     lead_dir = ''

--- a/test cases/frameworks/7 gnome/gir/meson.build
+++ b/test cases/frameworks/7 gnome/gir/meson.build
@@ -1,7 +1,7 @@
 libsources = ['meson-sample.c', 'meson-sample.h']
 
 girlib = shared_library(
-  'girlib',
+  'gir_lib',
   sources : libsources,
   dependencies : gobj,
   install : true

--- a/test cases/frameworks/7 gnome/installed_files.txt
+++ b/test cases/frameworks/7 gnome/installed_files.txt
@@ -3,6 +3,6 @@ usr/include/enums2.h
 usr/include/enums3.h
 usr/include/marshaller.h
 usr/lib/girepository-1.0/Meson-1.0.typelib
-usr/lib/libgirlib.so
+usr/lib/libgir_lib.so
 usr/share/gir-1.0/Meson-1.0.gir
 usr/share/glib-2.0/schemas/com.github.meson.gschema.xml


### PR DESCRIPTION
Instead of using a whitelist, use a blacklist. Also print a more useful error if the regex fails to match.

Use an underscore in the gir test to trigger this.

Fixes #436