### PR TITLE
Fixed SyntaxError in itstool invocation in yelphelper.py during installation

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -55,3 +55,4 @@ Jouni Kosonen
 Aurelien Jarno
 Mark Schulte
 Paulo Antonio Alvarez
+Olexa Bilaniuk

--- a/mesonbuild/scripts/yelphelper.py
+++ b/mesonbuild/scripts/yelphelper.py
@@ -34,7 +34,7 @@ def build_pot(srcdir, project_id, sources):
     # Must be relative paths
     sources = [os.path.join('C', source) for source in sources]
     outfile = os.path.join(srcdir, project_id + '.pot')
-    subprocess.call(['itstool', '-o', outfile, *sources])
+    subprocess.call(['itstool', '-o', outfile]+sources)
 
 def update_po(srcdir, project_id, langs):
     potfile = os.path.join(srcdir, project_id + '.pot')
@@ -55,9 +55,8 @@ def merge_translations(blddir, sources, langs):
     for lang in langs:
         subprocess.call([
             'itstool', '-m', os.path.join(blddir, lang, lang + '.gmo'),
-            '-o', os.path.join(blddir, lang),
-            *sources,
-        ])
+            '-o', os.path.join(blddir, lang)
+        ]+sources)
 
 def install_help(srcdir, blddir, sources, media, langs, install_dir, destdir, project_id, symlinks):
     c_install_dir = os.path.join(install_dir, 'C', project_id)


### PR DESCRIPTION
During a `python3.4 setup.py install`, the yelphelper.py script errors out with:

    SyntaxError: can use starred expression only as assignment target

Fix this problem.