### PR TITLE
Use portable path separator in wrappers.

### DIFF
--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -53,7 +53,8 @@ def run_exe(exe):
     child_env = os.environ.copy()
     child_env.update(exe.env)
     if len(exe.extra_paths) > 0:
-        child_env['PATH'] = ';'.join(exe.extra_paths + ['']) + child_env['PATH']
+        child_env['PATH'] = (os.pathsep.join(exe.extra_paths + ['']) +
+                             child_env['PATH'])
     p = subprocess.Popen(cmd + exe.cmd_args,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,

--- a/mesonbuild/scripts/meson_test.py
+++ b/mesonbuild/scripts/meson_test.py
@@ -134,7 +134,8 @@ def run_single_test(wrap, test):
 
         child_env.update(test.env)
         if len(test.extra_paths) > 0:
-            child_env['PATH'] = child_env['PATH'] + ';'.join([''] + test.extra_paths)
+            child_env['PATH'] = (child_env['PATH'] +
+                                 os.pathsep.join([''] + test.extra_paths))
         if is_windows():
             setsid = None
         else:


### PR DESCRIPTION
The semicolon only separates paths on Windows, but the wrapper is sometimes used on other platforms.