### PR TITLE
qt: Fix qmake detection on Linux and Windows

### DIFF
--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -1,7 +1,12 @@
 project('qt4 and 5 build test', 'cpp')
 
+qt5_modules = ['Widgets']
 foreach qt : ['qt4', 'qt5']
-  qtdep = dependency(qt, modules : ['Core', 'Gui', 'Widgets'], required : qt == 'qt5')
+  qt_modules = ['Core', 'Gui']
+  if qt == 'qt5'
+    qt_modules += qt5_modules
+  endif
+  qtdep = dependency(qt, modules : qt_modules, required : qt == 'qt5')
   if qtdep.found()
     qtmodule = import(qt)
 

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -6,6 +6,17 @@ foreach qt : ['qt4', 'qt5']
   if qt == 'qt5'
     qt_modules += qt5_modules
   endif
+  # Test that invalid modules are indeed not found
+  fakeqtdep = dependency(qt, modules : ['DefinitelyNotFound'], required : false)
+  if fakeqtdep.found()
+    error('Invalid qt dep incorrectly found!')
+  endif
+  # Test that partially-invalid modules are indeed not found
+  fakeqtdep = dependency(qt, modules : ['Core', 'DefinitelyNotFound'], required : false)
+  if fakeqtdep.found()
+    error('Invalid qt dep incorrectly found!')
+  endif
+  # If qt4 modules are found, test that. qt5 is required.
   qtdep = dependency(qt, modules : qt_modules, required : qt == 'qt5')
   if qtdep.found()
     qtmodule = import(qt)


### PR DESCRIPTION
qmake detection for both Qt4 and Qt5 detection was assuming that it was only used on Windows, which is incorrect. It can also be used on Linux for cross-compilation or in general when `pkg-config` is not available.

It was also not failing properly for both Qt5 and Qt4 when no libraries were found, and was assuming that the `.dll` was always available.

Qt4 detection with qmake was also completely broken.

Also prevents unwanted injection of partially-found qt dependencies in targets by unsetting `self.cargs` and `self.largs`
