### PR TITLE
Allow specifying push URL in .wrap and fix broken subproject directories handling

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -153,6 +153,11 @@ class Resolver:
             if revno.lower() != 'head':
                 subprocess.check_call(['git', 'checkout', revno],
                                       cwd=checkoutdir)
+            push_url = p.get('push-url')
+            if push_url:
+                subprocess.check_call(['git', 'remote', 'set-url',
+                                       '--push', 'origin', push_url],
+                                      cwd=checkoutdir)
     def get_hg(self, p):
         checkoutdir = os.path.join(self.subdir_root, p.get('directory'))
         revno = p.get('revision')


### PR DESCRIPTION
The goal of the `push-url` field in the .wrap is that when we setup the subproject repos, the user (with write acccess to the cloned repository) do not have to reset the remote push URL before being able to push there.

For example in `gst-build` we setup many repository and it is annoying to have to set the push url for each if them.