### PR TITLE
Can give many alternative names to find_program to simplify searching.

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1834,18 +1834,22 @@ class Interpreter():
                     break
             self.coredata.base_options[optname] = oobj
 
+    @stringArgs
     def func_find_program(self, node, args, kwargs):
-        self.validate_arguments(args, 1, [str])
+        if len(args) == 0:
+            raise InterpreterException('No program name specified.')
         required = kwargs.get('required', True)
         if not isinstance(required, bool):
             raise InvalidArguments('"required" argument must be a boolean.')
-        exename = args[0]
         # Search for scripts relative to current subdir.
         # Do not cache found programs because find_program('foobar')
         # might give different results when run from different source dirs.
         search_dir = os.path.join(self.environment.get_source_dir(), self.subdir)
-        extprog = dependencies.ExternalProgram(exename, search_dir=search_dir)
-        progobj = ExternalProgramHolder(extprog)
+        for exename in args:
+            extprog = dependencies.ExternalProgram(exename, search_dir=search_dir)
+            progobj = ExternalProgramHolder(extprog)
+            if progobj.found():
+                return progobj
         if required and not progobj.found():
             raise InvalidArguments('Program "%s" not found.' % exename)
         return progobj

--- a/test cases/common/31 find program/meson.build
+++ b/test cases/common/31 find program/meson.build
@@ -9,7 +9,7 @@ if build_machine.system() == 'windows'
   # the program can be found.
   cp = find_program('xcopy')
 else
-  cp = find_program('cp')
+  cp = find_program('donotfindme', 'cp')
   gen = generator(cp, \
    output  : '@BASENAME@.c', \
    arguments : ['@INPUT@', '@OUTPUT@'])


### PR DESCRIPTION
This allows you to find a tool with many alternative names simpler:

    foo_exe = find_program('foo', 'foo.py', 'foo12', 'foo12.py') # The first found one is returned.