### PR TITLE
gnome: Update required version for glib-compile-resources depfile fixes

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -31,7 +31,7 @@ from .. import interpreter
 #
 # https://github.com/ninja-build/ninja/issues/1184
 # https://bugzilla.gnome.org/show_bug.cgi?id=774368
-gresource_dep_needed_version = '>9.99.99'
+gresource_dep_needed_version = '>= 2.52.0'
 
 native_glib_version = None
 girwarning_printed = False

--- a/test cases/frameworks/7 gnome/resources/meson.build
+++ b/test cases/frameworks/7 gnome/resources/meson.build
@@ -11,7 +11,7 @@ simple_res_exe = executable('simple-resources-test',
   dependencies: gio)
 test('simple resource test', simple_res_exe)
 
-if glib.version() >= '9.99.9'
+if glib.version() >= '2.52.0'
   # This test cannot pass if GLib version is older than 9.99.9.
   # Meson will raise an error if the user tries to use the 'dependencies'
   # argument and the version of GLib is too old for generated resource


### PR DESCRIPTION
Note that this version is not yet released