### PR TITLE
gnome.compile_resources(): Add export and install_header kwargs

### DIFF
--- a/test cases/frameworks/7 gnome/installed_files.txt
+++ b/test cases/frameworks/7 gnome/installed_files.txt
@@ -12,3 +12,4 @@ usr/share/gir-1.0/Meson-1.0.gir
 usr/share/gir-1.0/MesonDep1-1.0.gir
 usr/share/gir-1.0/MesonDep2-1.0.gir
 usr/share/glib-2.0/schemas/com.github.meson.gschema.xml
+usr/share/simple-resources.gresource

--- a/test cases/frameworks/7 gnome/installed_files.txt
+++ b/test cases/frameworks/7 gnome/installed_files.txt
@@ -13,3 +13,4 @@ usr/share/gir-1.0/MesonDep1-1.0.gir
 usr/share/gir-1.0/MesonDep2-1.0.gir
 usr/share/glib-2.0/schemas/com.github.meson.gschema.xml
 usr/share/simple-resources.gresource
+usr/include/simple-resources.h

--- a/test cases/frameworks/7 gnome/resources/meson.build
+++ b/test cases/frameworks/7 gnome/resources/meson.build
@@ -11,6 +11,15 @@ simple_res_exe = executable('simple-resources-test',
   dependencies: gio)
 test('simple resource test', simple_res_exe)
 
+gnome.compile_resources('simple-resources',
+  'simple.gresource.xml',
+  gresource_bundle: true,
+  install: true,
+  install_dir: get_option('datadir'),
+  source_dir : '../resources-data',
+)
+test('simple resource test (gresource)', find_program('resources.py'))
+
 if glib.version() >= '2.52.0'
   # This test cannot pass if GLib version is older than 9.99.9.
   # Meson will raise an error if the user tries to use the 'dependencies'

--- a/test cases/frameworks/7 gnome/resources/meson.build
+++ b/test cases/frameworks/7 gnome/resources/meson.build
@@ -3,6 +3,8 @@
 
 simple_resources = gnome.compile_resources('simple-resources',
   'simple.gresource.xml',
+  install_header : true,
+  export : true,
   source_dir : '../resources-data',
   c_name : 'simple_resources')
 

--- a/test cases/frameworks/7 gnome/resources/resources.py
+++ b/test cases/frameworks/7 gnome/resources/resources.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+import os
+from gi.repository import Gio
+
+if __name__ == '__main__':
+    res = Gio.resource_load(os.path.join('resources', 'simple-resources.gresource'))
+    Gio.Resource._register(res)
+
+    data = Gio.resources_lookup_data('/com/example/myprog/res1.txt', Gio.ResourceLookupFlags.NONE)
+    assert(data.get_data() == b'This is a resource.\n')


### PR DESCRIPTION
This defaults to not exporting resources as that is generally what you want but that does make this a breaking change. Along with that if you export your resources you would want to install the header.