### PR TITLE
Don't show tracebacks for MesonException in helper scripts

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -246,7 +246,13 @@ def run(mainfile, args):
         return 1
     if len(args) >= 2 and args[0] == '--internal':
         if args[1] != 'regenerate':
-            sys.exit(run_script_command(args[1:]))
+            script = args[1]
+            try:
+                sys.exit(run_script_command(args[1:]))
+            except MesonException as e:
+                mlog.log(mlog.red('\nError in {} helper script:'.format(script)))
+                mlog.log(e)
+                sys.exit(1)
         args = args[2:]
         handshake = True
     else:


### PR DESCRIPTION
I hit an issue when building gtk-doc documentation. The issue is
my fault, but the error output from Meson makes it look like an
internal error:

    [0/1] 'Running external command libtracker-sparql-doc.'
    Building documentation for libtracker-sparql
    Traceback (most recent call last):
      File "/home/sam/meson/meson.py", line 26, in <module>
        sys.exit(main())
      File "/home/sam/meson/meson.py", line 23, in main
        return mesonmain.run(launcher, sys.argv[1:])
      File "/home/sam/meson/mesonbuild/mesonmain.py", line 249, in run
        sys.exit(run_script_command(args[1:]))
      File "/home/sam/meson/mesonbuild/mesonmain.py", line 239, in run_script_command
        return cmdfunc(cmdargs)
      File "/home/sam/meson/mesonbuild/scripts/gtkdochelper.py", line 183, in run
        options.ignore_headers.split('@@') if options.ignore_headers else [])
      File "/home/sam/meson/mesonbuild/scripts/gtkdochelper.py", line 133, in build_gtkdoc
        gtkdoc_run_check(mkhtml_cmd, os.path.join(abs_out, 'html'))
      File "/home/sam/meson/mesonbuild/scripts/gtkdochelper.py", line 55, in gtkdoc_run_check
        raise MesonException('\n'.join(err_msg))
    mesonbuild.mesonlib.MesonException: 'gtkdoc-mkhtml' failed with status 6
    warning: failed to load external entity "../overview.sgml"
    ../libtracker-sparql-docs.sgml:20: element include: XInclude error :
    could not load ../overview.sgml, and no fallback was found
    warning: failed to load external entity "../examples.sgml"
    ../libtracker-sparql-docs.sgml:41: element include: XInclude error :
    could not load ../examples.sgml, and no fallback was found

    FAILED: libtracker-sparql-doc

After this patch, the output is much clearer:

    [0/1] 'Running external command libtracker-sparql-doc.'
    Building documentation for libtracker-sparql

    Error in gtkdoc helper script:
    'gtkdoc-mkhtml' failed with status 6
    warning: failed to load external entity "../overview.sgml"
    ../libtracker-sparql-docs.sgml:20: element include: XInclude error :
    could not load ../overview.sgml, and no fallback was found
    warning: failed to load external entity "../examples.sgml"
    ../libtracker-sparql-docs.sgml:41: element include: XInclude error :
    could not load ../examples.sgml, and no fallback was found

Note the actual errors from xsltproc are swallowed by gtkdoc-mkhtml
1.25.1, they're only displayed in the example above because I made a
patch: <https://bugzilla.gnome.org/show_bug.cgi?id=774812>