### PR TITLE
Allow specifying some toolchain executables using env

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -57,3 +57,4 @@ Mark Schulte
 Paulo Antonio Alvarez
 Olexa Bilaniuk
 Daniel Stone
+Marc-Antoine Perennou

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -229,12 +229,17 @@ class PkgConfigDependency(Dependency):
 
     def check_pkgconfig(self):
         try:
-            p = subprocess.Popen(['pkg-config', '--version'], stdout=subprocess.PIPE,
+            evar = 'PKG_CONFIG'
+            if evar in os.environ:
+                pkgbin = os.environ[evar].strip()
+            else:
+                pkgbin = 'pkg-config'
+            p = subprocess.Popen([pkgbin, '--version'], stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
             out = p.communicate()[0]
             if p.returncode == 0:
                 if not self.silent:
-                    mlog.log('Found pkg-config:', mlog.bold(shutil.which('pkg-config')),
+                    mlog.log('Found pkg-config:', mlog.bold(shutil.which(pkgbin)),
                              '(%s)' % out.decode().strip())
                 PkgConfigDependency.pkgconfig_found = True
                 return

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -123,7 +123,11 @@ class PkgConfigDependency(Dependency):
             pkgbin = environment.cross_info.config["binaries"]['pkgconfig']
             self.type_string = 'Cross'
         else:
-            pkgbin = 'pkg-config'
+            evar = 'PKG_CONFIG'
+            if evar in os.environ:
+                pkgbin = os.environ[evar].strip()
+            else:
+                pkgbin = 'pkg-config'
             self.type_string = 'Native'
 
         mlog.debug('Determining dependency %s with pkg-config executable %s.' % (name, pkgbin))

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -371,14 +371,15 @@ can not be used with the current version of glib-compiled-resources, due to
         if not isinstance(girtarget, (build.Executable, build.SharedLibrary)):
             raise MesonException('Gir target must be an executable or shared library')
         try:
-            pkgstr = subprocess.check_output(['pkg-config', '--cflags', 'gobject-introspection-1.0'])
+            gir_dep = dependencies.PkgConfigDependency(
+                'gobject-introspection-1.0', state.environment, {'native': True})
+            pkgargs = gir_dep.get_compile_args()
         except Exception:
             global girwarning_printed
             if not girwarning_printed:
                 mlog.warning('gobject-introspection dependency was not found, disabling gir generation.')
                 girwarning_printed = True
             return []
-        pkgargs = pkgstr.decode().strip().split()
         ns = kwargs.pop('namespace')
         nsversion = kwargs.pop('nsversion')
         libsources = kwargs.pop('sources')

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -22,7 +22,7 @@
 # This file is basically a reimplementation of
 # http://cgit.freedesktop.org/libreoffice/core/commit/?id=3213cd54b76bc80a6f0516aac75a48ff3b2ad67c
 
-import sys, subprocess
+import os, sys, subprocess
 from mesonbuild import mesonlib
 import argparse
 
@@ -49,7 +49,12 @@ def write_if_changed(text, outfilename):
         f.write(text)
 
 def linux_syms(libfilename, outfilename):
-    pe = subprocess.Popen(['readelf', '-d', libfilename], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    evar = 'READELF'
+    if evar in os.environ:
+        readelfbin = os.environ[evar].strip()
+    else:
+        readelfbin = 'readelf'
+    pe = subprocess.Popen([readelfbin, '-d', libfilename], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output = pe.communicate()[0].decode()
     if pe.returncode != 0:
         raise RuntimeError('Readelf does not work')

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -54,13 +54,18 @@ def linux_syms(libfilename, outfilename):
         readelfbin = os.environ[evar].strip()
     else:
         readelfbin = 'readelf'
+    evar = 'NM'
+    if evar in os.environ:
+        nmbin = os.environ[evar].strip()
+    else:
+        nmbin = 'nm'
     pe = subprocess.Popen([readelfbin, '-d', libfilename], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output = pe.communicate()[0].decode()
     if pe.returncode != 0:
         raise RuntimeError('Readelf does not work')
     result = [x for x in output.split('\n') if 'SONAME' in x]
     assert(len(result) <= 1)
-    pnm = subprocess.Popen(['nm', '--dynamic', '--extern-only', '--defined-only', '--format=posix', libfilename],
+    pnm = subprocess.Popen([nmbin, '--dynamic', '--extern-only', '--defined-only', '--format=posix', libfilename],
                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     output = pnm.communicate()[0].decode()
     if pnm.returncode != 0:


### PR DESCRIPTION
On Exherbo, during the configuration and compilation of packages, we're in a sandboxed environment where "unprefixed" tools such as cc, readelf or pkg-config are not available. All tools are prefixed by the target triple, even for native compilation.
While CC is handled correctly, others aren't (pkg-config, readelf and nm were my blockers).

I tried to follow the coding-style and idioms from other parts of the code and I believe the changes are simple enough but If another approach is preferred I can update the patchset as needed.