### PR TITLE
Detect gettext tools

### DIFF
--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 from os import path
-from .. import coredata, mesonlib, build
+from .. import coredata, mesonlib, build, dependencies
 import sys
+
+have_all_gettext_tools = None
 
 class I18nModule:
 
@@ -26,6 +28,17 @@ class I18nModule:
                 return [line.strip() for line in f if not line.strip().startswith('#')]
         except (FileNotFoundError, PermissionError):
             return []
+
+    def has_gettext_tools(self):
+       global have_all_gettext_tools
+       if have_all_gettext_tools == None:
+           have_all_gettext_tools = True
+           gettext_programs = ['xgettext', 'msgfmt', 'msgmerge']
+           for prog in gettext_programs:
+               dep = dependencies.ExternalProgram(prog)
+               if not dep.found():
+                   have_all_gettext_tools = False
+       return have_all_gettext_tools
 
     def gettext(self, state, args, kwargs):
         if len(args) != 1:

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 from os import path
-from .. import coredata, mesonlib, build, dependencies
+from .. import coredata, mesonlib, build, dependencies, mlog
 import sys
 
 have_all_gettext_tools = None
+gettext_tools_warning_printed = False
 
 class I18nModule:
 
@@ -49,6 +50,12 @@ class I18nModule:
             raise coredata.MesonException('List of languages empty.')
         datadirs = mesonlib.stringlistify(kwargs.get('data_dirs', []))
         extra_args = mesonlib.stringlistify(kwargs.get('args', []))
+
+        if not self.has_gettext_tools():
+            global gettext_tools_warning_printed
+            if gettext_tools_warning_printed == False:
+                mlog.warning("Some gettext tools were not found. Installation of languages won't be available until all tools are installed")
+                gettext_tools_warning_printed = True
 
         pkg_arg = '--pkgname=' + packagename
         lang_arg = '--langs=' + '@@'.join(languages)


### PR DESCRIPTION
I have implemented two ideas here:

1. Detect the necessary gettext tools at configuration time and warn the user if they are not found

2. Check if the tools are available at install time, and again warn the user if we can't find them.

This is meant for #821, as always, ideas and comments are welcome.
