### PR TITLE
Allow many version conditions for pkg-config deps

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1017,9 +1017,11 @@ int dummy;
             args += valac.get_werror_args()
         for d in target.get_external_deps():
             if isinstance(d, dependencies.PkgConfigDependency):
-                if d.name == 'glib-2.0' and d.version_requirement is not None \
-                   and d.version_requirement.startswith(('>=', '==')):
-                    args += ['--target-glib', d.version_requirement[2:]]
+                if d.name == 'glib-2.0' and d.version_reqs is not None:
+                    for req in d.version_reqs:
+                        if req.startswith(('>=', '==')):
+                            args += ['--target-glib', req[2:]]
+                            break
                 args += ['--pkg', d.name]
             elif isinstance(d, dependencies.ExternalLibrary):
                 args += d.get_lang_args('vala')

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1862,7 +1862,8 @@ requirements use the version keyword argument instead.''')
             if 'version' in kwargs:
                 wanted = kwargs['version']
                 found = cached_dep.get_version()
-                if not cached_dep.found() or not mesonlib.version_compare(found, wanted):
+                if not cached_dep.found() or \
+                   not mesonlib.version_compare_many(found, wanted)[0]:
                     # Cached dep has the wrong version. Check if an external
                     # dependency or a fallback dependency provides it.
                     cached_dep = None

--- a/test cases/failing/37 pkgconfig dependency impossible conditions/meson.build
+++ b/test cases/failing/37 pkgconfig dependency impossible conditions/meson.build
@@ -1,0 +1,3 @@
+project('impossible-dep-test', 'c', version : '1.0')
+
+dependency('zlib', version : ['>=1.0', '<1.0'])

--- a/test cases/linuxlike/5 dependency versions/meson.build
+++ b/test cases/linuxlike/5 dependency versions/meson.build
@@ -10,6 +10,17 @@ assert(zlib.type_name() == 'pkgconfig', 'zlib should be of type "pkgconfig" not 
 zlibver = dependency('zlib', version : '<1.0', required : false)
 assert(zlibver.found() == false, 'zlib <1.0 should not be found!')
 
+# Find external dependencies with various version restrictions
+dependency('zlib', version : '>=1.0')
+dependency('zlib', version : '<=9999')
+dependency('zlib', version : '=' + zlib.version())
+
+# Find external dependencies with multiple version restrictions
+dependency('zlib', version : ['>=1.0', '<=9999'])
+if dependency('zlib', version : ['<=1.0', '>=9999', '=' + zlib.version()], required : false).found()
+  error('zlib <=1.0 >=9999 should not have been found')
+endif
+
 # Test https://github.com/mesonbuild/meson/pull/610
 dependency('somebrokenlib', version : '>=2.0', required : false)
 dependency('somebrokenlib', version : '>=1.0', required : false)


### PR DESCRIPTION
Sometimes we want to restrict the acceptable versions to a list of versions, or a smallest-version + largest-version, or both. For instance, GStreamer's opencv plugin is only compatible with `3.1.0 >= opencv >= 2.3.0`.

The output looks like this if none of the conditions are matched:

```
Native dependency zlib found: NO found '1.2.8' but need: '<1.0'
```

If only some of the conditions are matched:

```
Native dependency zlib found: NO found '1.2.8' but need: '<=1.0', '>=9999' ; matched: '=1.2.8'
```