### PR TITLE
Support skipped tests

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -56,3 +56,4 @@ Aurelien Jarno
 Mark Schulte
 Paulo Antonio Alvarez
 Olexa Bilaniuk
+Daniel Stone

--- a/test cases/common/124 test skip/meson.build
+++ b/test cases/common/124 test skip/meson.build
@@ -1,0 +1,4 @@
+project('test skip', 'c')
+
+exe_test_skip = executable('test_skip', 'test_skip.c')
+test('test_skip', exe_test_skip)

--- a/test cases/common/124 test skip/test_skip.c
+++ b/test cases/common/124 test skip/test_skip.c
@@ -1,0 +1,4 @@
+int main(int argc, char *argv[])
+{
+	return 77;
+}


### PR DESCRIPTION
Knowing whether a test failed to run as its prerequisites were not
available, or whether those prerequisites were available and produced
unexpected/incorrect results, is a useful differentiation.

Add support for skipped tests by testing for exit code 77, used through
autotools/piglit/etc to denote a test which detected this and decided to
skip.