### PR TITLE
mintro: Allow serializing EnvironmentVariables objects

### DIFF
--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -168,7 +168,10 @@ def list_tests(testdata):
         else:
             fname = t.fname
         to['cmd'] = fname + t.cmd_args
-        to['env'] = t.env
+        if isinstance(t.env, build.EnvironmentVariables):
+            to['env'] = t.env.get_env(os.environ)
+        else:
+            to['env'] = t.env
         to['name'] = t.name
         to['workdir'] = t.workdir
         to['timeout'] = t.timeout


### PR DESCRIPTION
Otherwise trying to introspect tests might lead to:

Traceback (most recent call last):
  File "/home/thiblahute/devel/gstreamer/gst-build/meson/mesonintrospect.py", line 20, in <module>
    sys.exit(mintro.run(sys.argv[1:]))
  File "/home/thiblahute/devel/gstreamer/gst-build/meson/mesonbuild/mintro.py", line 213, in run
    list_tests(testdata)
  File "/home/thiblahute/devel/gstreamer/gst-build/meson/mesonbuild/mintro.py", line 178, in list_tests
    print(json.dumps(result))
  File "/usr/lib/python3.5/json/__init__.py", line 230, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib/python3.5/json/encoder.py", line 198, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.5/json/encoder.py", line 256, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.5/json/encoder.py", line 179, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: <mesonbuild.build.EnvironmentVariables object at 0x7f83e8fa8c18> is not JSON serializable