### PR TITLE
Support for shared modules

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1927,7 +1927,8 @@ rule FORTRAN_DEP_HACK
         commands += linker.get_linker_always_args()
         if not isinstance(target, build.StaticLibrary):
             commands += compilers.get_base_link_args(self.environment.coredata.base_options,
-                                                     linker)
+                                                     linker,
+                                                     isinstance(target, build.SharedModule))
         commands += linker.get_buildtype_linker_args(self.environment.coredata.get_builtin_option('buildtype'))
         commands += linker.get_option_link_args(self.environment.coredata.compiler_options)
         commands += self.get_link_debugfile_args(linker, target, outname)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1937,13 +1937,17 @@ rule FORTRAN_DEP_HACK
         if isinstance(target, build.Executable):
             commands += linker.get_std_exe_link_args()
         elif isinstance(target, build.SharedLibrary):
-            commands += linker.get_std_shared_lib_link_args()
+            if isinstance(target, build.SharedModule):
+                commands += linker.get_std_shared_module_link_args()
+            else:
+                commands += linker.get_std_shared_lib_link_args()
             commands += linker.get_pic_args()
             if hasattr(target, 'soversion'):
                 soversion = target.soversion
             else:
                 soversion = None
-            commands += linker.get_soname_args(target.prefix, target.name, target.suffix, abspath, soversion)
+            commands += linker.get_soname_args(target.prefix, target.name, target.suffix,
+                                               abspath, soversion, isinstance(target, build.SharedModule))
             # This is only visited when using the Visual Studio toolchain
             if target.vs_module_defs and hasattr(linker, 'gen_vs_module_defs_args'):
                 commands += linker.gen_vs_module_defs_args(target.vs_module_defs.rel_to_builddir(self.build_to_src))

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -139,6 +139,7 @@ class NinjaBackend(backends.Backend):
 
     def __init__(self, build):
         super().__init__(build)
+        self.name = 'ninja'
         self.ninja_filename = 'build.ninja'
         self.fortran_deps = {}
         self.all_outputs = {}

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -783,6 +783,8 @@ class Vs2010Backend(backends.Backend):
             extra_link_args += l
         if not isinstance(target, build.StaticLibrary):
             extra_link_args += target.link_args
+            if isinstance(target, build.SharedModule):
+                extra_link_args += compiler.get_std_shared_module_link_args()
             # External deps must be last because target link libraries may depend on them.
             for dep in target.get_external_deps():
                 extra_link_args += dep.get_link_args()

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -58,6 +58,7 @@ class RegenInfo():
 class Vs2010Backend(backends.Backend):
     def __init__(self, build):
         super().__init__(build)
+        self.name = 'vs2010'
         self.project_file_version = '10.0.30319.1'
         self.sources_conflicts = {}
         self.platform_toolset = None

--- a/mesonbuild/backend/vs2015backend.py
+++ b/mesonbuild/backend/vs2015backend.py
@@ -19,6 +19,7 @@ from .vs2010backend import Vs2010Backend
 class Vs2015Backend(Vs2010Backend):
     def __init__(self, build):
         super().__init__(build)
+        self.name = 'vs2015'
         self.platform_toolset = 'v140'
         self.vs_version = '2015'
 

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -22,6 +22,7 @@ from ..mesonlib import MesonException
 class XCodeBackend(backends.Backend):
     def __init__(self, build):
         super().__init__(build)
+        self.name = 'xcode'
         self.project_uid = self.environment.coredata.guid.replace('-', '')[:24]
         self.project_conflist = self.gen_id()
         self.indent = '       '

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1129,6 +1129,16 @@ class SharedLibrary(BuildTarget):
     def type_suffix(self):
         return "@sha"
 
+# A shared library that is meant to be used with dlopen rather than linking
+# into something else.
+class SharedModule(SharedLibrary):
+    def __init__(self, name, subdir, subproject, is_cross, sources, objects, environment, kwargs):
+        if 'version' in kwargs:
+            raise MesonException('Shared modules must not specify the version kwarg.')
+        if 'soversion' in kwargs:
+            raise MesonException('Shared modules must not specify the soversion kwarg.')
+        super().__init__(name, subdir, subproject, is_cross, sources, objects, environment, kwargs)
+
 class CustomTarget:
     known_kwargs = {'input' : True,
                     'output' : True,

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -248,7 +248,7 @@ def get_base_compile_args(options, compiler):
         pass
     return args
 
-def get_base_link_args(options, linker):
+def get_base_link_args(options, linker, is_shared_module):
     args = []
     # FIXME, gcc/clang specific.
     try:
@@ -269,7 +269,7 @@ def get_base_link_args(options, linker):
     except KeyError:
         pass
     try:
-        if options['b_lundef'].value:
+        if not is_shared_module and options['b_lundef'].value:
             args.append('-Wl,--no-undefined')
     except KeyError:
         pass

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1926,6 +1926,9 @@ class VisualStudioCCompiler(CCompiler):
         pdbarr += ['pdb']
         return ['/DEBUG', '/PDB:' + '.'.join(pdbarr)]
 
+    def get_std_shared_module_link_args(self):
+        return ['/DLL', '/FORCE:UNRESOLVED']
+
 class VisualStudioCPPCompiler(VisualStudioCCompiler, CPPCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrap):
         self.language = 'cpp'

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -2208,7 +2208,7 @@ class ClangCompiler():
 
     def get_std_shared_module_link_args(self):
         if self.clang_type == CLANG_OSX:
-            return ['-bundle']
+            return ['-bundle', '-Wl,-undefined,dynamic_lookup']
         return ['-shared']
 
 class ClangCCompiler(ClangCompiler, CCompiler):

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1926,9 +1926,6 @@ class VisualStudioCCompiler(CCompiler):
         pdbarr += ['pdb']
         return ['/DEBUG', '/PDB:' + '.'.join(pdbarr)]
 
-    def get_std_shared_module_link_args(self):
-        return ['/DLL', '/FORCE:UNRESOLVED']
-
 class VisualStudioCPPCompiler(VisualStudioCCompiler, CPPCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrap):
         self.language = 'cpp'

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -532,7 +532,7 @@ class CCompiler(Compiler):
         # Almost every compiler uses this for disabling warnings
         return ['-w']
 
-    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion):
+    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion, is_shared_module):
         return []
 
     def split_shlib_to_parts(self, fname):
@@ -1148,7 +1148,7 @@ class MonoCompiler(Compiler):
     def get_link_args(self, fname):
         return ['-r:' + fname]
 
-    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion):
+    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion, is_shared_module):
         return []
 
     def get_werror_args(self):
@@ -1229,7 +1229,7 @@ class JavaCompiler(Compiler):
         self.id = 'unknown'
         self.javarunner = 'java'
 
-    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion):
+    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion, is_shared_module):
         return []
 
     def get_werror_args(self):
@@ -1528,7 +1528,7 @@ class DCompiler(Compiler):
     def get_std_shared_lib_link_args(self):
         return ['-shared']
 
-    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion):
+    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion, is_shared_module):
         return []
 
     def get_unittest_args(self):
@@ -2178,7 +2178,7 @@ class ClangCompiler():
         # so it might change semantics at any time.
         return ['-include-pch', os.path.join (pch_dir, self.get_pch_name (header))]
 
-    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion):
+    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion, is_shared_module):
         if self.clang_type == CLANG_STANDARD:
             gcc_type = GCC_STANDARD
         elif self.clang_type == CLANG_OSX:
@@ -2187,7 +2187,7 @@ class ClangCompiler():
             gcc_type = GCC_MINGW
         else:
             raise MesonException('Unreachable code when converting clang type to gcc type.')
-        return get_gcc_soname_args(gcc_type, prefix, shlib_name, suffix, path, soversion)
+        return get_gcc_soname_args(gcc_type, prefix, shlib_name, suffix, path, soversion, is_shared_module)
 
     def has_argument(self, arg, env):
         return super().has_argument(['-Werror=unknown-warning-option', arg], env)

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -586,6 +586,10 @@ class SharedLibraryHolder(BuildTargetHolder):
     def __init__(self, target, interp):
         super().__init__(target, interp)
 
+class SharedModuleHolder(BuildTargetHolder):
+    def __init__(self, target, interp):
+        super().__init__(target, interp)
+
 class JarHolder(BuildTargetHolder):
     def __init__(self, target, interp):
         super().__init__(target, interp)
@@ -1203,6 +1207,7 @@ class Interpreter():
                       'dependency' : self.func_dependency,
                       'static_library' : self.func_static_lib,
                       'shared_library' : self.func_shared_lib,
+                      'shared_module' : self.func_shared_module,
                       'library' : self.func_library,
                       'jar' : self.func_jar,
                       'build_target': self.func_build_target,
@@ -1961,6 +1966,9 @@ requirements use the version keyword argument instead.''')
     def func_shared_lib(self, node, args, kwargs):
         return self.build_target(node, args, kwargs, SharedLibraryHolder)
 
+    def func_shared_module(self, node, args, kwargs):
+        return self.build_target(node, args, kwargs, SharedModuleHolder)
+
     def func_library(self, node, args, kwargs):
         if self.coredata.get_builtin_option('default_library') == 'shared':
             return self.func_shared_lib(node, args, kwargs)
@@ -2448,6 +2456,8 @@ requirements use the version keyword argument instead.''')
             targetclass = build.Executable
         elif targetholder is SharedLibraryHolder:
             targetclass = build.SharedLibrary
+        elif targetholder is SharedModuleHolder:
+            targetclass = build.SharedModule
         elif targetholder is StaticLibraryHolder:
             targetclass = build.StaticLibrary
         elif targetholder is JarHolder:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1027,6 +1027,7 @@ class MesonMain(InterpreterObject):
                              'version': self.version_method,
                              'project_name' : self.project_name_method,
                              'get_cross_property': self.get_cross_property_method,
+                             'backend' : self.backend_method,
                             })
 
     def add_install_script_method(self, args, kwargs):
@@ -1064,6 +1065,9 @@ class MesonMain(InterpreterObject):
         if sub == '':
             return src
         return os.path.join(src, sub)
+
+    def backend_method(self, args, kwargs):
+        return self.interpreter.backend.name
 
     def source_root_method(self, args, kwargs):
         return self.interpreter.environment.source_dir

--- a/test cases/common/125 shared module/meson.build
+++ b/test cases/common/125 shared module/meson.build
@@ -1,4 +1,8 @@
 project('shared module', 'c')
 
-shared_module('mymodule', 'module.c')
+dl = meson.get_compiler('c').find_library('dl', required : false)
+l = shared_library('runtime', 'runtime.c')
+m = shared_module('mymodule', 'module.c')
+e = executable('prog', 'prog.c', link_with : l, dependencies : dl)
+test('import test', e, args : [m.full_path()])
 

--- a/test cases/common/125 shared module/meson.build
+++ b/test cases/common/125 shared module/meson.build
@@ -2,7 +2,18 @@ project('shared module', 'c')
 
 dl = meson.get_compiler('c').find_library('dl', required : false)
 l = shared_library('runtime', 'runtime.c')
-m = shared_module('mymodule', 'module.c')
+if host_machine.system() == 'darwin' or host_machine.system() == 'windows'
+  # At least in OSX and seemingly also on Windows you must have
+  # all symbols present when linking a module.
+  #
+  # In Linux many projects build plugins without linking to
+  # the runtime so they have undefined symbols. We need to support
+  # both for ease of transitioning.
+  mlink = [l]
+else
+  mlink = []
+endif
+m = shared_module('mymodule', 'module.c', link_with : mlink)
 e = executable('prog', 'prog.c', link_with : l, dependencies : dl)
 test('import test', e, args : [m.full_path()])
 

--- a/test cases/common/125 shared module/meson.build
+++ b/test cases/common/125 shared module/meson.build
@@ -2,18 +2,11 @@ project('shared module', 'c')
 
 dl = meson.get_compiler('c').find_library('dl', required : false)
 l = shared_library('runtime', 'runtime.c')
-if host_machine.system() == 'darwin' or host_machine.system() == 'windows'
-  # At least in OSX and seemingly also on Windows you must have
-  # all symbols present when linking a module.
-  #
-  # In Linux many projects build plugins without linking to
-  # the runtime so they have undefined symbols. We need to support
-  # both for ease of transitioning.
-  mlink = [l]
-else
-  mlink = []
-endif
-m = shared_module('mymodule', 'module.c', link_with : mlink)
+# Do NOT link the module with the runtime library. This
+# is a common approach for plugins that are only used
+# with dlopen. Any symbols are resolved dynamically
+# at runtime
+m = shared_module('mymodule', 'module.c')
 e = executable('prog', 'prog.c', link_with : l, dependencies : dl)
 test('import test', e, args : [m.full_path()])
 

--- a/test cases/common/125 shared module/meson.build
+++ b/test cases/common/125 shared module/meson.build
@@ -1,0 +1,4 @@
+project('shared module', 'c')
+
+shared_module('mymodule', 'module.c')
+

--- a/test cases/common/125 shared module/meson.build
+++ b/test cases/common/125 shared module/meson.build
@@ -1,5 +1,9 @@
 project('shared module', 'c')
 
+if meson.backend().startswith('vs')
+  error('MESON_SKIP_TEST for some reason /FORCE does not work in the VS backend.')
+endif
+
 dl = meson.get_compiler('c').find_library('dl', required : false)
 l = shared_library('runtime', 'runtime.c')
 # Do NOT link the module with the runtime library. This

--- a/test cases/common/125 shared module/module.c
+++ b/test cases/common/125 shared module/module.c
@@ -9,6 +9,54 @@
   #endif
 #endif
 
+#ifdef _WIN32
+
+#include <stdio.h>
+#include <windows.h>
+#include <tlhelp32.h>
+
+typedef int (*fptr) (void);
+
+/* Unlike Linux and OS X, when a library is loaded, all the symbols aren't
+ * loaded into a single namespace. You must fetch the symbol by iterating over
+ * all loaded modules. Code for finding the function from any of the loaded
+ * modules is taken from gmodule.c in glib */
+fptr find_any_f (const char *name) {
+    fptr f;
+    HANDLE snapshot;
+    MODULEENTRY32 me32;
+
+    snapshot = CreateToolhelp32Snapshot (TH32CS_SNAPMODULE, 0);
+    if (snapshot == (HANDLE) -1) {
+        printf("Could not get snapshot\n");
+        return 0;
+    }
+
+    me32.dwSize = sizeof (me32);
+
+    f = NULL;
+    if (Module32First (snapshot, &me32)) {
+        do {
+            if ((f = (fptr) GetProcAddress (me32.hModule, name)) != NULL)
+                break;
+        } while (Module32Next (snapshot, &me32));
+    }
+
+    CloseHandle (snapshot);
+    return f;
+}
+
+int DLL_PUBLIC func() {
+    fptr f;
+
+    f = find_any_f ("func_from_language_runtime");
+    if (f != NULL)
+        return f();
+    printf ("Could not find function\n");
+    return 1;
+}
+
+#else
 /*
  * Shared modules often have references to symbols that are not defined
  * at link time, but which will be provided from deps of the executable that
@@ -17,6 +65,7 @@
  */
 int func_from_language_runtime();
 
-int DLL_PUBLIC func() {
+int DLL_PUBLIC func(void) {
     return func_from_language_runtime();
 }
+#endif

--- a/test cases/common/125 shared module/module.c
+++ b/test cases/common/125 shared module/module.c
@@ -1,0 +1,22 @@
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+/*
+ * Shared modules often have references to symbols that are not defined
+ * at link time, but which will be provided by the executable that
+ * dlopens it. We need to make sure that this works, i.e. that we do
+ * not pass -Wl,--no-undefined when linking modules.
+ */
+int nonexisting_function();
+
+int DLL_PUBLIC func() {
+    return nonexisting_function();
+}

--- a/test cases/common/125 shared module/module.c
+++ b/test cases/common/125 shared module/module.c
@@ -11,12 +11,12 @@
 
 /*
  * Shared modules often have references to symbols that are not defined
- * at link time, but which will be provided by the executable that
+ * at link time, but which will be provided from deps of the executable that
  * dlopens it. We need to make sure that this works, i.e. that we do
  * not pass -Wl,--no-undefined when linking modules.
  */
-int nonexisting_function();
+int func_from_language_runtime();
 
 int DLL_PUBLIC func() {
-    return nonexisting_function();
+    return func_from_language_runtime();
 }

--- a/test cases/common/125 shared module/prog.c
+++ b/test cases/common/125 shared module/prog.c
@@ -1,0 +1,38 @@
+#ifdef _WIN32
+// FIXME: add implementation using Winapi functions for dlopen.
+
+int main(int argc, char **argv) {
+    return 0;
+}
+
+#else
+
+#include<dlfcn.h>
+#include<assert.h>
+#include<stdio.h>
+
+int func();
+int func_from_language_runtime();
+
+int main(int argc, char **argv) {
+    void *dl;
+    int (*importedfunc)();
+    int success;
+    char *error;
+
+    dlerror();
+    dl = dlopen(argv[1], RTLD_LAZY);
+    error = dlerror();
+    if(error) {
+        printf("Could not open %s: %s\n", argv[1], error);
+        return 1;
+    }
+    importedfunc = (int (*)()) dlsym(dl, "func");
+    assert(importedfunc);
+    assert(importedfunc != func_from_language_runtime);
+    success = (*importedfunc)() == func_from_language_runtime();
+    dlclose(dl);
+    return !success;
+}
+
+#endif

--- a/test cases/common/125 shared module/prog.c
+++ b/test cases/common/125 shared module/prog.c
@@ -1,38 +1,102 @@
-#ifdef _WIN32
-// FIXME: add implementation using Winapi functions for dlopen.
 
-int main(int argc, char **argv) {
-    return 0;
+#include <stdio.h>
+
+int func_from_language_runtime(void);
+typedef int (*fptr) (void);
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+wchar_t*
+win32_get_last_error (void)
+{
+    wchar_t *msg = NULL;
+
+    FormatMessageW (FORMAT_MESSAGE_ALLOCATE_BUFFER
+                    | FORMAT_MESSAGE_IGNORE_INSERTS
+                    | FORMAT_MESSAGE_FROM_SYSTEM,
+                    NULL, GetLastError (), 0,
+                    (LPWSTR) &msg, 0, NULL);
+    return msg;
+}
+
+int
+main (int argc, char **argv)
+{
+    HINSTANCE handle;
+    fptr importedfunc;
+    int expected, actual;
+    int ret = 1;
+
+    handle = LoadLibraryA (argv[1]);
+    if (!handle) {
+        wchar_t *msg = win32_get_last_error ();
+        printf ("Could not open %s: %S\n", argv[1], msg);
+        goto nohandle;
+    }
+
+    importedfunc = (fptr) GetProcAddress (handle, "func");
+    if (importedfunc == NULL) {
+        wchar_t *msg = win32_get_last_error ();
+        printf ("Could not find 'func': %S\n", msg);
+        goto out;
+    }
+
+    actual = importedfunc ();
+    expected = func_from_language_runtime ();
+    if (actual != expected) {
+        printf ("Got %i instead of %i\n", actual, expected);
+        goto out;
+    }
+
+    ret = 0;
+out:
+    FreeLibrary (handle);
+nohandle:
+    return ret;
 }
 
 #else
 
 #include<dlfcn.h>
 #include<assert.h>
-#include<stdio.h>
-
-int func();
-int func_from_language_runtime();
 
 int main(int argc, char **argv) {
     void *dl;
-    int (*importedfunc)();
-    int success;
+    fptr importedfunc;
+    int expected, actual;
     char *error;
+    int ret = 1;
 
     dlerror();
     dl = dlopen(argv[1], RTLD_LAZY);
     error = dlerror();
     if(error) {
         printf("Could not open %s: %s\n", argv[1], error);
-        return 1;
+        goto nodl;
     }
-    importedfunc = (int (*)()) dlsym(dl, "func");
-    assert(importedfunc);
+
+    importedfunc = (fptr) dlsym(dl, "func");
+    if (importedfunc == NULL) {
+        printf ("Could not find 'func'\n");
+        goto out;
+    }
+
     assert(importedfunc != func_from_language_runtime);
-    success = (*importedfunc)() == func_from_language_runtime();
+
+    actual = (*importedfunc)();
+    expected = func_from_language_runtime ();
+    if (actual != expected) {
+        printf ("Got %i instead of %i\n", actual, expected);
+        goto out;
+    }
+
+    ret = 0;
+out:
     dlclose(dl);
-    return !success;
+nodl:
+    return ret;
 }
 
 #endif

--- a/test cases/common/125 shared module/runtime.c
+++ b/test cases/common/125 shared module/runtime.c
@@ -1,0 +1,19 @@
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+/*
+ * This file pretends to be a language runtime that supports extension
+ * modules.
+ */
+
+int func_from_language_runtime() {
+    return 86;
+}

--- a/test cases/common/125 shared module/runtime.c
+++ b/test cases/common/125 shared module/runtime.c
@@ -14,6 +14,6 @@
  * modules.
  */
 
-int DLL_PUBLIC func_from_language_runtime() {
+int DLL_PUBLIC func_from_language_runtime(void) {
     return 86;
 }

--- a/test cases/common/125 shared module/runtime.c
+++ b/test cases/common/125 shared module/runtime.c
@@ -14,6 +14,6 @@
  * modules.
  */
 
-int func_from_language_runtime() {
+int DLL_PUBLIC func_from_language_runtime() {
     return 86;
 }


### PR DESCRIPTION
With a test to verify that `-Wl,--no-undefined` is not used. May be a bit rough still:

 - not tested on Windows, not sure if MSVC wants extra flags
 - left prefix at `lib` instead of empty because both are used in the wild and the former is less surprising
