### PR TITLE
tests/linuxlike/1: Improve zlib pkg-config test

### DIFF
--- a/test cases/linuxlike/1 pkg-config/meson.build
+++ b/test cases/linuxlike/1 pkg-config/meson.build
@@ -2,11 +2,16 @@ project('external dependency', 'c')
 
 # Zlib is probably on all dev machines.
 
-dep = dependency('zlib', version : '>=1.2.8')
-exe = executable('zlibprog', 'prog.c', dependencies : dep)
+dep = dependency('zlib', version : '>=1.2')
+exe = executable('zlibprog', 'prog-checkver.c',
+  dependencies : dep,
+  c_args : '-DFOUND_ZLIB="' + dep.version() + '"')
 
-assert(dep.version().version_compare('>=1.2.8'), 'Pkg-config version numbers exposed incorrectly.')
+assert(dep.version().version_compare('>=1.2'), 'Pkg-config version numbers exposed incorrectly.')
 
+# Check that the version exposed by zlib internally is the same as the one we
+# retrieve from the pkg-config file. This assumes that the packager didn't mess
+# up, but we can be reasonably sure of that.
 test('zlibtest', exe)
 
 zprefix = dep.get_pkgconfig_variable('prefix') # Always set but we can't be sure what the value is.

--- a/test cases/linuxlike/1 pkg-config/prog-checkver.c
+++ b/test cases/linuxlike/1 pkg-config/prog-checkver.c
@@ -1,0 +1,15 @@
+#include <zlib.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char **argv) {
+    void * something = deflate;
+    if(strcmp(ZLIB_VERSION, FOUND_ZLIB) != 0) {
+        printf("Meson found '%s' but zlib is '%s'\n", FOUND_ZLIB, ZLIB_VERSION);
+        return 2;
+    }
+    if(something != 0)
+        return 0;
+    printf("Couldn't find 'deflate'\n");
+    return 1;
+}


### PR DESCRIPTION
Just checking that the version retrieved from the pkg-config file matches is not enough. It's nearly tautological since it just checks that we aren't returning garbage in `dep.version()`. Instead, check in the
test executable that the pkg-config version retrieved matches the `ZLIB_VERSION` exported by zlib.

Also don't require zlib 1.2.8 since RHEL (EPEL) 7 still has 1.2.7 and we don't really need 1.2.8 anyway.