### PR TITLE
build regeneration can update wrap-git and wrap-hg in some cases.

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1925,8 +1925,9 @@ requirements use the version keyword argument instead.''')
             raise
         # If the subproject execution failed in a non-fatal way, don't raise an
         # exception; let the caller handle things.
-        except:
-            mlog.log('Also couldn\'t find a fallback subproject in',
+        except Exception as e:
+            mlog.warning(e)
+            mlog.log('Couldn\'t find a fallback subproject in',
                     mlog.bold(os.path.join(self.subproject_dir, dirname)),
                     'for the dependency', mlog.bold(name))
             return None

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -99,7 +99,7 @@ class Resolver:
                 ' ensure clean download' % dirname)
                 os.rmdir(dirname)
         except NotADirectoryError:
-            raise RuntimeError('%s is not a directory, can not use as subproject.' % dirname)
+            raise RuntimeError('%s is not a directory, can not use as subproject.' %dirname)
         except FileNotFoundError:
             pass
 
@@ -111,7 +111,7 @@ class Resolver:
             if os.path.isdir(dirname):
                 # project already there? great, use it!
                 # only for the file case because otherwise we prevent git 
-                # and hg from updating the subproject. or doing that fancy git push feature that doesn't belong
+                # and hg from updating the subproject.
                 return packagename
             if not os.path.isdir(self.cachedir):
                 os.mkdir(self.cachedir)
@@ -164,15 +164,16 @@ class Resolver:
         revno = p.get('revision')
         is_there = os.path.isdir(checkoutdir)
         if is_there:
-            #Need to add a check that the directory is a valid HG repo
+            if not os.path.isdir(os.path.join(checkoutdir, '.hg')):
+                raise RuntimeError('Subproject %s is not a valid mercurial repo.'%p.get('directory'))
             if revno.lower() == 'tip':
                 # Failure to do pull is not a fatal error,
                 # because otherwise you can't develop without
                 # a working net connection.
                 subprocess.call(['hg', 'pull'], cwd=checkoutdir)
-                subprocess.call(['hg','update','tip'],cwd = checkoutdir)
+                subprocess.call(['hg', 'update', 'tip'],cwd = checkoutdir)
             else:
-                #check that the tag/branch/revision we want is available in the
+                # check that the tag/branch/revision we want is available in the
                 # repo, if not, pull and update.
                 if subprocess.call(['hg', 'checkout', revno], cwd=checkoutdir) != 0:
                     subprocess.check_call(['hg', 'pull'], cwd=checkoutdir)

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -94,13 +94,10 @@ class Resolver:
         fname = os.path.join(self.subdir_root, packagename + '.wrap')
         dirname = os.path.join(self.subdir_root, packagename)
         try:
-            if os.listdir(dirname):
-                # The directory is there and not empty? Great, use it.
-                return packagename
-            else:
-                mlog.warning('Subproject directory %s is empty, possibly because of an unfinished'
-                      'checkout, removing to reclone' % dirname)
-                os.rmdir(checkoutdir)
+            if not os.listdir(dirname):
+                mlog.warning('Subproject directory %s is empty, removing to'
+                ' ensure clean download' % dirname)
+                os.rmdir(dirname)
         except NotADirectoryError:
             raise RuntimeError('%s is not a directory, can not use as subproject.' % dirname)
         except FileNotFoundError:
@@ -111,6 +108,11 @@ class Resolver:
             return None
         p = PackageDefinition(fname)
         if p.type == 'file':
+            if os.path.isdir(dirname):
+                # project already there? great, use it!
+                # only for the file case because otherwise we prevent git 
+                # and hg from updating the subproject. or doing that fancy git push feature that doesn't belong
+                return packagename
             if not os.path.isdir(self.cachedir):
                 os.mkdir(self.cachedir)
             self.download(p, packagename)
@@ -130,12 +132,11 @@ class Resolver:
         if is_there:
             try:
                 subprocess.check_call(['git', 'rev-parse'])
-                is_there = True
             except subprocess.CalledProcessError:
                 raise RuntimeError('%s is not empty but is not a valid '
                                     'git repository, we can not work with it'
-                                    ' as a subproject directory.' % (
-                                        checkoutdir))
+                                    ' as a subproject directory.' 
+                                    % (checkoutdir))
 
             if revno.lower() == 'head':
                 # Failure to do pull is not a fatal error,
@@ -163,12 +164,16 @@ class Resolver:
         revno = p.get('revision')
         is_there = os.path.isdir(checkoutdir)
         if is_there:
+            #Need to add a check that the directory is a valid HG repo
             if revno.lower() == 'tip':
                 # Failure to do pull is not a fatal error,
                 # because otherwise you can't develop without
                 # a working net connection.
                 subprocess.call(['hg', 'pull'], cwd=checkoutdir)
+                subprocess.call(['hg','update','tip'],cwd = checkoutdir)
             else:
+                #check that the tag/branch/revision we want is available in the
+                # repo, if not, pull and update.
                 if subprocess.call(['hg', 'checkout', revno], cwd=checkoutdir) != 0:
                     subprocess.check_call(['hg', 'pull'], cwd=checkoutdir)
                     subprocess.check_call(['hg', 'checkout', revno],

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -94,7 +94,12 @@ class Resolver:
         fname = os.path.join(self.subdir_root, packagename + '.wrap')
         dirname = os.path.join(self.subdir_root, packagename)
         try:
-            if not os.listdir(dirname):
+            if os.listdir(dirname):
+                if not os.path.isfile(fname) :
+                    # The directory is there, not empty and there isn't a wrap file?
+                    # Great, use it.
+                    return packagename
+            else:
                 mlog.warning('Subproject directory %s is empty, removing to'
                 ' ensure clean download' % dirname)
                 os.rmdir(dirname)


### PR DESCRIPTION
Wrap.py: Made it so using an already downloaded subproject is only for the wrap-file case. The capacity to update a repository was already in get_git() and get_hg(), but they were always getting bypassed by this. 

Also did a bit of cleanup.
interpreter.py: There’s a catch all except clause at the line 1928, it didn’t give the user any information whatsoever about the exception it caught. Now it at least print it to the log as a warning.