### PR TITLE
Compiler checks can only accept external dependencies

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -15,17 +15,16 @@
 import os, sys
 import pickle
 import re
+import xml.dom.minidom
+import xml.etree.ElementTree as ET
 
-from mesonbuild import compilers
-from mesonbuild.build import BuildTarget
-from mesonbuild.mesonlib import File
 from . import backends
 from .. import build
 from .. import dependencies
 from .. import mlog
-import xml.etree.ElementTree as ET
-import xml.dom.minidom
-from ..mesonlib import MesonException
+from .. import compilers
+from ..build import BuildTarget
+from ..mesonlib import MesonException, File
 from ..environment import Environment
 
 def split_o_flags_args(args):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -22,6 +22,7 @@ from . import optinterpreter
 from . import compilers
 from .wrap import wrap
 from . import mesonlib
+from .dependencies import InternalDependency, Dependency
 from mesonbuild.interpreterbase import InterpreterBase
 from mesonbuild.interpreterbase import check_stringlist, noPosargs, noKwargs, stringArgs
 from mesonbuild.interpreterbase import InterpreterException, InvalidArguments, InvalidCode
@@ -649,10 +650,8 @@ class CompilerHolder(InterpreterObject):
         args += mesonlib.stringlistify(kwargs.get('args', []))
         return args
 
-    def determine_dependencies(self, kwargs, allowed_dep_types=None):
+    def determine_dependencies(self, kwargs):
         deps = kwargs.get('dependencies', None)
-        if allowed_dep_types is None:
-            allowed_dep_types = (dependencies.Dependency, dependencies.ExternalLibrary)
         if deps is not None:
             if not isinstance(deps, list):
                 deps = [deps]
@@ -662,8 +661,8 @@ class CompilerHolder(InterpreterObject):
                     d = d.held_object
                 except Exception:
                     pass
-                if not isinstance(d, allowed_dep_types):
-                    raise InterpreterException('Dependencies must be external deps')
+                if isinstance(d, InternalDependency) or not isinstance(d, Dependency):
+                    raise InterpreterException('Dependencies must be external dependencies')
                 final_deps.append(d)
             deps = final_deps
         return deps
@@ -722,7 +721,7 @@ class CompilerHolder(InterpreterObject):
         if not isinstance(prefix, str):
             raise InterpreterException('Prefix argument of has_member must be a string.')
         extra_args = self.determine_args(kwargs)
-        deps = self.determine_dependencies(kwargs, allowed_dep_types=(dependencies.Dependency,))
+        deps = self.determine_dependencies(kwargs)
         had = self.compiler.has_members(typename, [membername], prefix,
                                         self.environment, extra_args, deps)
         if had:
@@ -741,7 +740,7 @@ class CompilerHolder(InterpreterObject):
         if not isinstance(prefix, str):
             raise InterpreterException('Prefix argument of has_members must be a string.')
         extra_args = self.determine_args(kwargs)
-        deps = self.determine_dependencies(kwargs, allowed_dep_types=(dependencies.Dependency,))
+        deps = self.determine_dependencies(kwargs)
         had = self.compiler.has_members(typename, membernames, prefix,
                                         self.environment, extra_args, deps)
         if had:
@@ -798,7 +797,7 @@ class CompilerHolder(InterpreterObject):
         if not isinstance(prefix, str):
             raise InterpreterException('Prefix argument of sizeof must be a string.')
         extra_args = self.determine_args(kwargs)
-        deps = self.determine_dependencies(kwargs, allowed_dep_types=(dependencies.Dependency,))
+        deps = self.determine_dependencies(kwargs)
         esize = self.compiler.sizeof(element, prefix, self.environment, extra_args, deps)
         mlog.log('Checking for size of "%s": %d' % (element, esize))
         return esize
@@ -816,7 +815,7 @@ class CompilerHolder(InterpreterObject):
         if not isinstance(testname, str):
             raise InterpreterException('Testname argument must be a string.')
         extra_args = self.determine_args(kwargs)
-        deps = self.determine_dependencies(kwargs, allowed_dep_types=(dependencies.Dependency,))
+        deps = self.determine_dependencies(kwargs)
         result = self.compiler.compiles(code, self.environment, extra_args, deps)
         if len(testname) > 0:
             if result:
@@ -858,7 +857,7 @@ class CompilerHolder(InterpreterObject):
         if not isinstance(prefix, str):
             raise InterpreterException('Prefix argument of has_header must be a string.')
         extra_args = self.determine_args(kwargs)
-        deps = self.determine_dependencies(kwargs, allowed_dep_types=(dependencies.Dependency,))
+        deps = self.determine_dependencies(kwargs)
         haz = self.compiler.has_header(hname, prefix, self.environment, extra_args, deps)
         if haz:
             h = mlog.green('YES')
@@ -877,7 +876,7 @@ class CompilerHolder(InterpreterObject):
         if not isinstance(prefix, str):
             raise InterpreterException('Prefix argument of has_header_symbol must be a string.')
         extra_args = self.determine_args(kwargs)
-        deps = self.determine_dependencies(kwargs, allowed_dep_types=(dependencies.Dependency,))
+        deps = self.determine_dependencies(kwargs)
         haz = self.compiler.has_header_symbol(hname, symbol, prefix, self.environment, extra_args, deps)
         if haz:
             h = mlog.green('YES')

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -23,10 +23,10 @@ from . import compilers
 from .wrap import wrap
 from . import mesonlib
 from .dependencies import InternalDependency, Dependency
-from mesonbuild.interpreterbase import InterpreterBase
-from mesonbuild.interpreterbase import check_stringlist, noPosargs, noKwargs, stringArgs
-from mesonbuild.interpreterbase import InterpreterException, InvalidArguments, InvalidCode
-from mesonbuild.interpreterbase import InterpreterObject, MutableInterpreterObject
+from .interpreterbase import InterpreterBase
+from .interpreterbase import check_stringlist, noPosargs, noKwargs, stringArgs
+from .interpreterbase import InterpreterException, InvalidArguments, InvalidCode
+from .interpreterbase import InterpreterObject, MutableInterpreterObject
 
 import os, sys, subprocess, shutil, uuid, re
 

--- a/mesonbuild/scripts/gettext.py
+++ b/mesonbuild/scripts/gettext.py
@@ -16,7 +16,7 @@ import os
 import shutil
 import argparse
 import subprocess
-from mesonbuild.scripts import destdir_join
+from . import destdir_join
 
 parser = argparse.ArgumentParser()
 parser.add_argument('command')

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -17,8 +17,8 @@ import sys, os
 import subprocess
 import shutil
 import argparse
-from mesonbuild.mesonlib import MesonException
-from mesonbuild.scripts import destdir_join
+from ..mesonlib import MesonException
+from . import destdir_join
 
 parser = argparse.ArgumentParser()
 

--- a/mesonbuild/scripts/meson_install.py
+++ b/mesonbuild/scripts/meson_install.py
@@ -16,8 +16,8 @@
 
 import sys, pickle, os, shutil, subprocess, gzip, platform
 from glob import glob
-from mesonbuild.scripts import depfixer
-from mesonbuild.scripts import destdir_join
+from . import depfixer
+from . import destdir_join
 
 install_log_file = None
 

--- a/mesonbuild/scripts/regen_checker.py
+++ b/mesonbuild/scripts/regen_checker.py
@@ -29,7 +29,7 @@ def need_regen(regeninfo, regen_timestamp):
     # We must make sure to recreate it, even if we do not regenerate the solution.
     # Otherwise, Visual Studio will always consider the REGEN project out of date.
     print("Everything is up-to-date, regeneration of build files is not needed.")
-    from mesonbuild.backend.vs2010backend import Vs2010Backend
+    from ..backend.vs2010backend import Vs2010Backend
     Vs2010Backend.touch_regen_timestamp(regeninfo.build_dir)
     return False
 

--- a/mesonbuild/scripts/yelphelper.py
+++ b/mesonbuild/scripts/yelphelper.py
@@ -16,9 +16,9 @@ import sys, os
 import subprocess
 import shutil
 import argparse
-from mesonbuild import mlog
-from mesonbuild.mesonlib import MesonException
-from mesonbuild.scripts import destdir_join
+from .. import mlog
+from ..mesonlib import MesonException
+from . import destdir_join
 
 parser = argparse.ArgumentParser()
 parser.add_argument('command')

--- a/test cases/failing/38 has function external dependency/meson.build
+++ b/test cases/failing/38 has function external dependency/meson.build
@@ -1,0 +1,8 @@
+project('has function ext dep', 'c')
+
+cc = meson.get_compiler('c')
+
+mylib = shared_library('mylib', 'mylib.c')
+mylib_dep = declare_dependency(link_with : mylib)
+# Only external dependencies can work here
+cc.has_function('malloc', dependencies : mylib_dep)

--- a/test cases/failing/38 has function external dependency/mylib.c
+++ b/test cases/failing/38 has function external dependency/mylib.c
@@ -1,0 +1,1 @@
+int testfunc(void) { return 0; }


### PR DESCRIPTION
This is how it should've already been, but:

a) The test for this was wrong since `Dependency` is a base class for all dependencies and `isinstance` on an `InternalDependency` will also be true
b) Internal dependencies can't ever be used here anyway because compiler checks are always run at configure time and internal dependencies are only built after that.

Also add a failing test for this which was passing earlier.