### PR TITLE
has_function: Don't check for builtins with includes

### DIFF
--- a/test cases/common/43 has function/meson.build
+++ b/test cases/common/43 has function/meson.build
@@ -1,5 +1,7 @@
 project('has function', 'c', 'cpp')
 
+host_system = host_machine.system()
+
 # This is used in the `test_compiler_check_flags_order` unit test
 unit_test_args = '-I/tmp'
 compilers = [meson.get_compiler('c'), meson.get_compiler('cpp')]
@@ -34,7 +36,7 @@ foreach cc : compilers
   # We can't check for the C library used here of course, but if it's not
   # implemented in glibc it's probably not implemented in any other 'slimmer'
   # C library variants either, so the check should be safe either way hopefully.
-  if host_machine.system() == 'linux' and cc.get_id() == 'gcc'
+  if host_system == 'linux' and cc.get_id() == 'gcc'
     assert (cc.has_function('poll', prefix : '#include <poll.h>',
                             args : unit_test_args),
             'couldn\'t detect "poll" when defined by a header')
@@ -42,6 +44,12 @@ foreach cc : compilers
     assert (not cc.has_function('lchmod', prefix : lchmod_prefix,
                                 args : unit_test_args),
             '"lchmod" check should have failed')
+    # Check that built-ins are found properly both with and without headers
+    assert(cc.has_function('alloca', args : unit_test_args),
+           'built-in alloca must be found on Linux')
+    assert(cc.has_function('alloca', prefix : '#include <alloca.h>',
+           args : unit_test_args),
+           'built-in alloca must be found on Linux with #include')
   endif
 
   # For some functions one needs to define _GNU_SOURCE before including the


### PR DESCRIPTION
We check for builtins explicitly like this because we want to support finding them without any includes in prefix, but this causes problems with some buggy toolchains such as MSYS2 which define the builtin in the C library but don't expose it via headers.

Doing this allows people to always get the correct answer as long as they specify the includes that are required to find a function while also not forcing people to always specify includes to find a function which is cumbersome.

Closes #1083