### PR TITLE
Use universal_newlines=True for all Popen calls

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -18,7 +18,7 @@ from .. import build
 from .. import mlog
 from .. import dependencies
 from .. import compilers
-from ..mesonlib import File, MesonException, get_compiler_for_source
+from ..mesonlib import File, MesonException, get_compiler_for_source, Popen_safe
 from .backends import InstallData
 from ..build import InvalidArguments
 import os, sys, pickle, re
@@ -158,18 +158,14 @@ class NinjaBackend(backends.Backend):
 int dummy;
 ''')
 
-        pc = subprocess.Popen(['cl', '/showIncludes', '/c', 'incdetect.c'],
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE,
-                              cwd=self.environment.get_scratch_dir())
+        pc, stdo = Popen_safe(['cl', '/showIncludes', '/c', 'incdetect.c'],
+                              cwd=self.environment.get_scratch_dir())[0:2]
 
-        (stdo, _) = pc.communicate()
-
-        for line in stdo.split(b'\r\n'):
-            if line.endswith(b'stdio.h'):
-                matchstr = b':'.join(line.split(b':')[0:2]) + b':'
-                with open(tempfilename, 'ab') as binfile:
-                    binfile.write(b'msvc_deps_prefix = ' + matchstr + b'\r\n')
+        for line in stdo.split('\n'):
+            if line.endswith('stdio.h'):
+                matchstr = ':'.join(line.split(':')[0:2]) + ':'
+                with open(tempfilename, 'a') as binfile:
+                    binfile.write('msvc_deps_prefix = ' + matchstr + '\n')
                 return open(tempfilename, 'a')
         raise MesonException('Could not determine vs dep dependency prefix string.')
 

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -385,3 +385,10 @@ def expand_arguments(args):
             print(e)
             return None
     return expended_args
+
+def Popen_safe(args, write=None, stderr=subprocess.PIPE, **kwargs):
+    p = subprocess.Popen(args, universal_newlines=True,
+                         stdout=subprocess.PIPE,
+                         stderr=stderr, **kwargs)
+    o, e = p.communicate(write)
+    return (p, o, e)

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -20,7 +20,7 @@ import os
 import sys
 import copy
 import subprocess
-from ..mesonlib import MesonException
+from ..mesonlib import MesonException, Popen_safe
 from .. import dependencies
 from .. import mlog
 from .. import mesonlib
@@ -197,9 +197,7 @@ can not be used with the current version of glib-compiled-resources, due to
             cmd += ['--sourcedir', os.path.join(state.subdir, source_dir)]
         cmd += ['--sourcedir', state.subdir] # Current dir
 
-        pc = subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True,
-                              cwd=state.environment.get_source_dir())
-        (stdout, _) = pc.communicate()
+        pc, stdout = Popen_safe(cmd, cwd=state.environment.get_source_dir())[0:2]
         if pc.returncode != 0:
             mlog.warning('glib-compile-resources has failed to get the dependencies for {}'.format(cmd[1]))
             raise subprocess.CalledProcessError(pc.returncode, cmd)

--- a/mesonbuild/modules/qt4.py
+++ b/mesonbuild/modules/qt4.py
@@ -15,7 +15,7 @@
 import os, subprocess
 from .. import mlog
 from .. import build
-from ..mesonlib import MesonException
+from ..mesonlib import MesonException, Popen_safe
 from ..dependencies import Qt4Dependency
 import xml.etree.ElementTree as ET
 
@@ -37,11 +37,9 @@ class Qt4Module():
         # Moc and rcc return a non-zero result when doing so.
         # What kind of an idiot thought that was a good idea?
         if self.moc.found():
-            mp = subprocess.Popen(self.moc.get_command() + ['-v'],
-                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (stdout, stderr) = mp.communicate()
-            stdout = stdout.decode().strip()
-            stderr = stderr.decode().strip()
+            stdout, stderr = Popen_safe(self.moc.get_command() + ['-v'])[1:3]
+            stdout = stdout.strip()
+            stderr = stderr.strip()
             if 'Qt Meta' in stderr:
                 moc_ver = stderr
             else:
@@ -52,11 +50,9 @@ class Qt4Module():
         else:
             mlog.log(' moc:', mlog.red('NO'))
         if self.uic.found():
-            up = subprocess.Popen(self.uic.get_command() + ['-v'],
-                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (stdout, stderr) = up.communicate()
-            stdout = stdout.decode().strip()
-            stderr = stderr.decode().strip()
+            stdout, stderr = Popen_safe(self.uic.get_command() + ['-v'])[1:3]
+            stdout = stdout.strip()
+            stderr = stderr.strip()
             if 'version 4.' in stderr:
                 uic_ver = stderr
             else:
@@ -67,11 +63,9 @@ class Qt4Module():
         else:
             mlog.log(' uic:', mlog.red('NO'))
         if self.rcc.found():
-            rp = subprocess.Popen(self.rcc.get_command() + ['-v'],
-                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (stdout, stderr) = rp.communicate()
-            stdout = stdout.decode().strip()
-            stderr = stderr.decode().strip()
+            stdout, stderr = Popen_safe(self.rcc.get_command() + ['-v'])[1:3]
+            stdout = stdout.strip()
+            stderr = stderr.strip()
             if 'version 4.' in stderr:
                 rcc_ver = stderr
             else:

--- a/mesonbuild/modules/qt5.py
+++ b/mesonbuild/modules/qt5.py
@@ -15,7 +15,7 @@
 import os, subprocess
 from .. import mlog
 from .. import build
-from ..mesonlib import MesonException
+from ..mesonlib import MesonException, Popen_safe
 from ..dependencies import Qt5Dependency
 import xml.etree.ElementTree as ET
 
@@ -37,11 +37,9 @@ class Qt5Module():
         # Moc and rcc return a non-zero result when doing so.
         # What kind of an idiot thought that was a good idea?
         if self.moc.found():
-            mp = subprocess.Popen(self.moc.get_command() + ['-v'],
-                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (stdout, stderr) = mp.communicate()
-            stdout = stdout.decode().strip()
-            stderr = stderr.decode().strip()
+            stdout, stderr = Popen_safe(self.moc.get_command() + ['-v'])[1:3]
+            stdout = stdout.strip()
+            stderr = stderr.strip()
             if 'Qt 5' in stderr:
                 moc_ver = stderr
             elif '5.' in stdout:
@@ -54,11 +52,9 @@ class Qt5Module():
         else:
             mlog.log(' moc:', mlog.red('NO'))
         if self.uic.found():
-            up = subprocess.Popen(self.uic.get_command() + ['-v'],
-                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (stdout, stderr) = up.communicate()
-            stdout = stdout.decode().strip()
-            stderr = stderr.decode().strip()
+            stdout, stderr = Popen_safe(self.uic.get_command() + ['-v'])[1:3]
+            stdout = stdout.strip()
+            stderr = stderr.strip()
             if 'version 5.' in stderr:
                 uic_ver = stderr
             elif '5.' in stdout:
@@ -71,11 +67,9 @@ class Qt5Module():
         else:
             mlog.log(' uic:', mlog.red('NO'))
         if self.rcc.found():
-            rp = subprocess.Popen(self.rcc.get_command() + ['-v'],
-                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (stdout, stderr) = rp.communicate()
-            stdout = stdout.decode().strip()
-            stderr = stderr.decode().strip()
+            stdout, stderr = Popen_safe(self.rcc.get_command() + ['-v'])[1:3]
+            stdout = stdout.strip()
+            stderr = stderr.strip()
             if 'version 5.' in stderr:
                 rcc_ver = stderr
             elif '5.' in stdout:

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -21,7 +21,7 @@ import pickle
 import platform
 import subprocess
 
-import mesonbuild
+from ..mesonlib import MesonException, Popen_safe
 
 options = None
 
@@ -45,7 +45,7 @@ def run_exe(exe):
     else:
         if exe.is_cross:
             if exe.exe_runner is None:
-                raise Exception('BUG: Trying to run cross-compiled exes with no wrapper')
+                raise AssertionError('BUG: Trying to run cross-compiled exes with no wrapper')
             else:
                 cmd = [exe.exe_runner] + exe.fname
         else:
@@ -55,17 +55,12 @@ def run_exe(exe):
     if len(exe.extra_paths) > 0:
         child_env['PATH'] = (os.pathsep.join(exe.extra_paths + ['']) +
                              child_env['PATH'])
-    p = subprocess.Popen(cmd + exe.cmd_args,
-                         stdout=subprocess.PIPE,
-                         stderr=subprocess.PIPE,
-                         env=child_env,
-                         cwd=exe.workdir)
-    stdout, stderr = p.communicate()
+    p, stdout, stderr = Popen_safe(cmd + exe.cmd_args, env=child_env, cwd=exe.workdir)
     if exe.capture and p.returncode == 0:
-        with open(exe.capture, 'wb') as output:
+        with open(exe.capture, 'w') as output:
             output.write(stdout)
     if stderr:
-        sys.stderr.buffer.write(stderr)
+        sys.stderr.write(stderr)
     return p.returncode
 
 def run(args):

--- a/mesonbuild/scripts/meson_install.py
+++ b/mesonbuild/scripts/meson_install.py
@@ -18,6 +18,7 @@ import sys, pickle, os, shutil, subprocess, gzip, platform
 from glob import glob
 from . import depfixer
 from . import destdir_join
+from ..mesonlib import MesonException, Popen_safe
 
 install_log_file = None
 
@@ -205,12 +206,11 @@ def install_targets(d):
         do_copy(fname, outname)
         if should_strip:
             print('Stripping target')
-            ps = subprocess.Popen(['strip', outname], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            (stdo, stde) = ps.communicate()
+            ps, stdo, stde = Popen_safe(['strip', outname])
             if ps.returncode != 0:
                 print('Could not strip file.\n')
-                print('Stdout:\n%s\n' % stdo.decode())
-                print('Stderr:\n%s\n' % stde.decode())
+                print('Stdout:\n%s\n' % stdo)
+                print('Stderr:\n%s\n' % stde)
                 sys.exit(1)
         printed_symlink_error = False
         for alias in aliases:


### PR DESCRIPTION
Instead of adding it everywhere manually, create a wrapper called `mesonlib.Popen_safe` and use that everywhere that we call an executable and extract its output.

This will also allow us to tweak it to do more/different things if needed for some locales and/or systems.

Closes #1079

(need @msink to test this before it's pushed)