### PR TITLE
Add root include directory to vs2010 backend

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -742,6 +742,9 @@ class Vs2010Backend(backends.Backend):
                 curdir = os.path.join(d.curdir, i)
                 target_inc_dirs.append(self.relpath(curdir, target.subdir))  # build dir
 
+        # Append the root include directory
+        incroot = os.path.join(self.environment.get_prefix(), self.environment.get_includedir()).replace('\\', '/')
+        target_inc_dirs.append(incroot)
         target_inc_dirs.append('%(AdditionalIncludeDirectories)')
         ET.SubElement(clconf, 'AdditionalIncludeDirectories').text = ';'.join(target_inc_dirs)
         target_defines.append('%(PreprocessorDefinitions)')


### PR DESCRIPTION
Always add root include directory to the vcproj backend. 
If for example this is included 

    #include "somelib/libapi.h"

We need to have the parent of `sumelib` which is `prefix/include` to be in the include directories.