### PR TITLE
gnome.gtkdoc(): Include builddir variant of include dirs also

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -676,7 +676,7 @@ can not be used with the current version of glib-compiled-resources, due to
                     header_dirs.append(os.path.join(state.environment.get_source_dir(),
                                                     src_dir.get_curdir(), inc_dir))
             else:
-                header_dirs.append(os.path.normpath(os.path.join(state.subdir, src_dir)))
+                header_dirs.append(src_dir)
 
         args = ['--sourcedir=' + state.environment.get_source_dir(),
                 '--builddir=' + state.environment.get_build_dir(),

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -64,7 +64,15 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
                  expand_content_files, mode):
     print("Building documentation for %s" % module)
 
-    src_dir_args = ['--source-dir=' + os.path.join(source_root, src_dir) for src_dir in src_subdirs]
+    src_dir_args = []
+    for src_dir in src_subdirs:
+        if not os.path.isabs(src_dir):
+            dirs = [os.path.join(source_root, src_dir),
+                    os.path.join(build_root, src_dir)]
+        else:
+            dirs = [src_dir]
+        src_dir_args += ['--source-dir=' + d for d in dirs]
+
     doc_src = os.path.join(source_root, doc_subdir)
     abs_out = os.path.join(build_root, doc_subdir)
     htmldir = os.path.join(abs_out, 'html')


### PR DESCRIPTION
This avoids the need for users to constantly join paths themselves as this is commonly included.