### PR TITLE
python3 dep: Check arch of libraries before using

### DIFF
--- a/test cases/python3/2 extmodule/meson.build
+++ b/test cases/python3/2 extmodule/meson.build
@@ -3,10 +3,14 @@ project('Python extension module', 'c',
 # Because Windows Python ships only with optimized libs,
 # we must build this project the same way.
 
-py3_dep = dependency('python3')
+py3_dep = dependency('python3', required : false)
 
-subdir('ext')
+if py3_dep.found()
+  subdir('ext')
 
-test('extmod',
-  find_program('blaster.py'),
-  env : ['PYTHONPATH=' + pypathdir])
+  test('extmod',
+    find_program('blaster.py'),
+    env : ['PYTHONPATH=' + pypathdir])
+else
+  error('MESON_SKIP_TEST: Python3 libraries not found, skipping test.')
+endif

--- a/test cases/python3/3 cython/meson.build
+++ b/test cases/python3/3 cython/meson.build
@@ -2,10 +2,9 @@ project('cython', 'c',
   default_options : ['warning_level=3'])
 
 cython = find_program('cython3', required : false)
+py3_dep = dependency('python3', required : false)
 
-if cython.found()
-  py3_dep = dependency('python3')
-
+if cython.found() and py3_dep.found()
   subdir('libdir')
 
   test('cython tester',
@@ -13,5 +12,5 @@ if cython.found()
     env : ['PYTHONPATH=' + pydir]
   )
 else
-  error('MESON_SKIP_TEST: Cython not found, skipping test.')
+  error('MESON_SKIP_TEST: Cython3 or Python3 libraries not found, skipping test.')
 endif


### PR DESCRIPTION
On Windows, we can build with both 32-bit and 64-bit compilers, but the Python is either 32-bit or 64-bit. Check the architecture of the found Python libraries and don't use them if they don't match our build_machine.

Also skip the tests if the Python 3 dependency is not found.