### PR TITLE
Add a new compiler function 'symbols_have_underscore_prefix'

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -623,6 +623,7 @@ class CompilerHolder(InterpreterObject):
                              'has_argument' : self.has_argument_method,
                              'first_supported_argument' : self.first_supported_argument_method,
                              'unittest_args' : self.unittest_args_method,
+                             'symbols_have_underscore_prefix': self.symbols_have_underscore_prefix_method,
                             })
 
     def version_method(self, args, kwargs):
@@ -697,6 +698,13 @@ class CompilerHolder(InterpreterObject):
 
     def get_id_method(self, args, kwargs):
         return self.compiler.get_id()
+
+    def symbols_have_underscore_prefix_method(self, args, kwargs):
+        '''
+        Check if the compiler prefixes _ (underscore) to global C symbols
+        See: https://en.wikipedia.org/wiki/Name_mangling#C
+        '''
+        return self.compiler.symbols_have_underscore_prefix(self.environment)
 
     def unittest_args_method(self, args, kwargs):
         # At time, only D compilers have this feature.

--- a/test cases/common/126 llvm ir and assembly/main.c
+++ b/test cases/common/126 llvm ir and assembly/main.c
@@ -1,9 +1,14 @@
+#include <stdio.h>
+
 unsigned square_unsigned (unsigned a);
 
 int
 main (int argc, char * argv[])
 {
-  if (square_unsigned (2) != 4)
-    return -1;
+  unsigned int ret = square_unsigned (2);
+  if (ret != 4) {
+    printf("Got %u instead of 4\n", ret);
+    return 1;
+  }
   return 0;
 }

--- a/test cases/common/126 llvm ir and assembly/main.cpp
+++ b/test cases/common/126 llvm ir and assembly/main.cpp
@@ -1,3 +1,4 @@
+#include <stdio.h>
 
 extern "C" {
   unsigned square_unsigned (unsigned a);
@@ -6,7 +7,10 @@ extern "C" {
 int
 main (int argc, char * argv[])
 {
-  if (square_unsigned (2) != 4)
-    return -1;
+  unsigned int ret = square_unsigned (2);
+  if (ret != 4) {
+    printf("Got %u instead of 4\n", ret);
+    return 1;
+  }
   return 0;
 }

--- a/test cases/common/126 llvm ir and assembly/meson.build
+++ b/test cases/common/126 llvm ir and assembly/meson.build
@@ -1,17 +1,54 @@
 project('llvm-ir', 'c', 'cpp')
 
 foreach lang : ['c', 'cpp']
-  cc_id = meson.get_compiler(lang).get_id()
+  cc = meson.get_compiler(lang)
+  cc_id = cc.get_id()
+  ## Build a trivial executale with mixed LLVM IR source
   if cc_id == 'clang'
     e = executable('square_ir_' + lang, 'square.ll', 'main.' + lang)
     test('test IR square' + lang, e)
   endif
-  # FIXME: msvc does not support passing assembly to cl.exe, but you can pass
-  # it to ml.exe and get a compiled object. Meson should add support for
-  # transparently building assembly with ml.exe with MSVC.
-  if cc_id != 'msvc'
-    cpu = host_machine.cpu_family()
-    e = executable('square_asm_' + lang, 'square-' + cpu + '.S', 'main.' + lang)
-    test('test ASM square' + lang, e, args : [e.full_path()])
+  ## Build a trivial executable with mixed assembly source
+  # This also helps test whether cc.symbols_have_underscore_prefix() is working
+  # properly. This is done by assembling some assembly into an object that will
+  # provide the unsigned_squared() symbol to main.c/cpp. This requires the
+  # C symbol mangling to be known in advance.
+  if cc.symbols_have_underscore_prefix()
+    uscore_args = ['-DMESON_TEST__UNDERSCORE_SYMBOL']
+    message('underscore is prefixed')
+  else
+    uscore_args = []
+    message('underscore is NOT prefixed')
   endif
+  cpu = host_machine.cpu_family()
+  square_base = 'square-' + cpu
+  square_impl = square_base + '.S'
+  # MSVC cannot directly compile assembly files, so we pass it through the
+  # cl.exe pre-processor first and then assemble it with the ml.exe assembler.
+  # Then we can link it into the executable.
+  if cc_id == 'msvc'
+    cl = find_program('cl')
+    if cpu == 'x86'
+      ml = find_program('ml')
+    elif cpu == 'x86_64'
+      ml = find_program('ml64')
+    else
+      error('Unsupported cpu family: "' + cpu + '"')
+    endif
+    # Preprocess file (ml doesn't support pre-processing)
+    preproc_name = lang + square_base + '.i'
+    square_preproc = custom_target(lang + square_impl + 'preproc',
+        input : square_impl,
+        output : preproc_name,
+        command : [cl, '/EP', '/P', '/Fi' + preproc_name, '@INPUT@'] + uscore_args)
+    # Use assembled object file instead of the original .S assembly source
+    square_impl = custom_target(lang + square_impl,
+        input : square_preproc,
+        output : lang + square_base + '.obj',
+        command : [ml, '/Fo', '@OUTPUT@', '/c', '@INPUT@'])
+
+  endif
+  e = executable('square_asm_' + lang, square_impl, 'main.' + lang,
+      c_args : uscore_args, cpp_args : uscore_args)
+  test('test ASM square' + lang, e)
 endforeach

--- a/test cases/common/126 llvm ir and assembly/square-x86.S
+++ b/test cases/common/126 llvm ir and assembly/square-x86.S
@@ -1,5 +1,26 @@
 #include "symbol-underscore.h"
 
+/* This sadly doesn't test the symbol underscore stuff. I can't figure out how
+ * to not use an automatic stdcall mechanism and do everything manually. */
+#ifdef _MSC_VER
+
+.386
+.MODEL FLAT, C
+
+PUBLIC square_unsigned
+_TEXT   SEGMENT
+
+square_unsigned PROC var1:DWORD
+        mov     eax, var1
+	imul	eax, eax
+	ret
+square_unsigned ENDP
+
+_TEXT   ENDS
+END
+
+#else
+
 .text
 .globl SYMBOL_NAME(square_unsigned)
 
@@ -7,3 +28,5 @@ SYMBOL_NAME(square_unsigned):
 	movl	4(%esp), %eax
 	imull	%eax, %eax
 	retl
+
+#endif

--- a/test cases/common/126 llvm ir and assembly/square-x86_64.S
+++ b/test cases/common/126 llvm ir and assembly/square-x86_64.S
@@ -1,9 +1,34 @@
 #include "symbol-underscore.h"
 
+#ifdef _MSC_VER /* MSVC on Windows */
+
+PUBLIC SYMBOL_NAME(square_unsigned)
+_TEXT   SEGMENT
+
+SYMBOL_NAME(square_unsigned) PROC
+        mov     eax, ecx
+	imul	eax, eax
+	ret
+SYMBOL_NAME(square_unsigned) ENDP
+
+_TEXT   ENDS
+END
+
+#else
+
 .text
 .globl SYMBOL_NAME(square_unsigned)
 
+# ifdef _WIN32 /* MinGW */
+SYMBOL_NAME(square_unsigned):
+	imull	%ecx, %ecx
+	movl	%ecx, %eax
+	retq
+# else /* Linux and OS X */
 SYMBOL_NAME(square_unsigned):
 	imull	%edi, %edi
 	movl	%edi, %eax
 	retq
+# endif
+
+#endif

--- a/test cases/common/126 llvm ir and assembly/symbol-underscore.h
+++ b/test cases/common/126 llvm ir and assembly/symbol-underscore.h
@@ -1,4 +1,4 @@
-#if defined(__WIN32__) || defined(__APPLE__)
+#if defined(MESON_TEST__UNDERSCORE_SYMBOL)
 # define SYMBOL_NAME(name) _##name
 #else
 # define SYMBOL_NAME(name) name


### PR DESCRIPTION
Check if the compiler prefixes an underscore to global symbols. Very similar to `LT_SYS_SYMBOL_USCORE`. This is useful when linking to compiled assembly code, or other code that does not have its C symbol mangling handled transparently by the compiler.

C symbol mangling is platform and architecture dependent, and a helper function is needed to detect it. Eg: Windows 32-bit prefixes underscore, but 64-bit does not. Linux does not prefix an underscore but OS X does.

Also adds a test for this and fix `cc.compile` with MSVC when only doing compilation.