### PR TITLE
rpm: use meson's syntax to specify sourcedir and builddir

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -8,22 +8,20 @@
     export FFLAGS="%{optflags} -I%{_fmoddir}"  \
     export FCFLAGS="%{optflags} -I%{_fmoddir}" \
     export LDFLAGS="%{?__global_ldflags}"      \
-    mkdir -p %{__builddir}                     \
-    pushd %{__builddir}                        \
-        %{__meson}                            \\\
-            --buildtype=plain                 \\\
-            --prefix=%{_prefix}               \\\
-            --libdir=%{_libdir}               \\\
-            --libexecdir=%{_libexecdir}       \\\
-            --bindir=%{_bindir}               \\\
-            --includedir=%{_includedir}       \\\
-            --datadir=%{_datadir}             \\\
-            --mandir=%{_mandir}               \\\
-            --localedir=%{_datadir}/locale    \\\
-            --sysconfdir=%{_sysconfdir}       \\\
-            --localstatedir=%{_localstatedir} \\\
-            $OLDPWD/%{__sourcedir}             \
-    popd
+    %{__meson}                            \\\
+        --buildtype=plain                 \\\
+        --prefix=%{_prefix}               \\\
+        --libdir=%{_libdir}               \\\
+        --libexecdir=%{_libexecdir}       \\\
+        --bindir=%{_bindir}               \\\
+        --includedir=%{_includedir}       \\\
+        --datadir=%{_datadir}             \\\
+        --mandir=%{_mandir}               \\\
+        --localedir=%{_datadir}/locale    \\\
+        --sysconfdir=%{_sysconfdir}       \\\
+        --localstatedir=%{_localstatedir} \\\
+        %{__sourcedir} %{__builddir}      \\\
+        %{nil}
 
 %meson_build \
     %ninja_build -C %{__builddir}


### PR DESCRIPTION
When user uses %meson -Denable_cool_feature=true current macro fails
because RPM adds flag after popd:
...
pushd x86_64-redhat-linux-gnu
  /usr/bin/meson ... $OLDPWD/.
popd -Denable_cool_feature

Since meson can accept $srcdir and $builddir arugments we don't have
this problem with pushd/popd. It also simplifies things a bit.

Reported-by: Richard Hughes <richard@hughsie.com>
References: https://bugzilla.redhat.com/show_bug.cgi?id=1401062
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>