### PR TITLE
rpm: use __global_*flags

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -3,11 +3,11 @@
 %__builddir %{_target_platform}
 
 %meson \
-    export CFLAGS="%{optflags}"                \
-    export CXXFLAGS="%{optflags}"              \
-    export FFLAGS="%{optflags} -I%{_fmoddir}"  \
-    export FCFLAGS="%{optflags} -I%{_fmoddir}" \
-    export LDFLAGS="%{?__global_ldflags}"      \
+    export CFLAGS="${CFLAGS:-%__global_cflags}"       \
+    export CXXFLAGS="${CXXFLAGS:-%__global_cxxflags}" \
+    export FFLAGS="${FFLAGS:-%__global_fflags}"       \
+    export FCFLAGS="${FCFLAGS:-%__global_fcflags}"    \
+    export LDFLAGS="${LDFLAGS:-%__global_ldflags}"    \
     %{__meson}                            \\\
         --buildtype=plain                 \\\
         --prefix=%{_prefix}               \\\


### PR DESCRIPTION
Using RPM's %{optflags} is definitely nice, but not enough. LDFLAGS
are not there, and idea of optflags is too generic. It is supposed
to work under CC and CXX, but apparently someone forgot that there
is difference between these two.

%__global_*flags is not part of RPM itself, it's coming within
redhat-rpm-config which makes our macros file not that portable,
but anyway we already have %__global_ldflags and %ninja_build and
no one complained.

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>