### PR TITLE
rpm: use VPATH macro

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -1,6 +1,4 @@
 %__meson %{_bindir}/meson
-%__sourcedir .
-%__builddir %{_target_platform}
 
 %meson \
     export CFLAGS="${CFLAGS:-%__global_cflags}"       \
@@ -8,26 +6,26 @@
     export FFLAGS="${FFLAGS:-%__global_fflags}"       \
     export FCFLAGS="${FCFLAGS:-%__global_fcflags}"    \
     export LDFLAGS="${LDFLAGS:-%__global_ldflags}"    \
-    %{__meson}                            \\\
-        --buildtype=plain                 \\\
-        --prefix=%{_prefix}               \\\
-        --libdir=%{_libdir}               \\\
-        --libexecdir=%{_libexecdir}       \\\
-        --bindir=%{_bindir}               \\\
-        --includedir=%{_includedir}       \\\
-        --datadir=%{_datadir}             \\\
-        --mandir=%{_mandir}               \\\
-        --localedir=%{_datadir}/locale    \\\
-        --sysconfdir=%{_sysconfdir}       \\\
-        --localstatedir=%{_localstatedir} \\\
-        %{__sourcedir} %{__builddir}      \\\
+    %{__meson}                              \\\
+        --buildtype=plain                   \\\
+        --prefix=%{_prefix}                 \\\
+        --libdir=%{_libdir}                 \\\
+        --libexecdir=%{_libexecdir}         \\\
+        --bindir=%{_bindir}                 \\\
+        --includedir=%{_includedir}         \\\
+        --datadir=%{_datadir}               \\\
+        --mandir=%{_mandir}                 \\\
+        --localedir=%{_datadir}/locale      \\\
+        --sysconfdir=%{_sysconfdir}         \\\
+        --localstatedir=%{_localstatedir}   \\\
+        %{_vpath_srcdir} %{_vpath_builddir} \\\
         %{nil}
 
 %meson_build \
-    %ninja_build -C %{__builddir}
+    %ninja_build -C %{_vpath_builddir}
 
 %meson_install \
-    %ninja_install -C %{__builddir}
+    %ninja_install -C %{_vpath_builddir}
 
 %meson_test \
-    %ninja_test -C %{__builddir}
+    %ninja_test -C %{_vpath_builddir}


### PR DESCRIPTION
This is more or less standardized way to have one variable which
will work for all buildsystems defined in redhat-rpm-config.

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>