### PR TITLE
gettext: Respect the --subdir argument before the MESON_SUBDIR var

### DIFF
--- a/mesonbuild/scripts/gettext.py
+++ b/mesonbuild/scripts/gettext.py
@@ -89,7 +89,9 @@ def run(args):
     subcmd = options.command
     langs = options.langs.split('@@') if options.langs else None
     extra_args = options.extra_args.split('@@')
-    subdir = os.environ.get('MESON_SUBDIR', options.subdir)
+    subdir = os.environ.get('MESON_SUBDIR', '')
+    if options.subdir:
+        subdir = options.subdir
     src_sub = os.path.join(os.environ['MESON_SOURCE_ROOT'], subdir)
     bld_sub = os.path.join(os.environ['MESON_BUILD_ROOT'], subdir)
 


### PR DESCRIPTION
In the case of subproject we will properly setup the --subdir argument
but the MESON_SUBDIR is never adapted and will point to an empty string
leading to the following backtrace when building `gst-build`:

```
  msgfmt: error while opening "/home/thiblahute/devel/gstreamer/gst-build/af.po" for reading: No such file or directory
  Traceback (most recent call last):
    File "/home/thiblahute/devel/gstreamer/gst-build/meson/meson.py", line 37, in <module>
      sys.exit(main())
    File "/home/thiblahute/devel/gstreamer/gst-build/meson/meson.py", line 34, in main
      return mesonmain.run(launcher, sys.argv[1:])
    File "/home/thiblahute/devel/gstreamer/gst-build/meson/mesonbuild/mesonmain.py", line 248, in run
      sys.exit(run_script_command(args[1:]))
    File "/home/thiblahute/devel/gstreamer/gst-build/meson/mesonbuild/mesonmain.py", line 236, in run_script_command
      return cmdfunc(cmdargs)
    File "/home/thiblahute/devel/gstreamer/gst-build/meson/mesonbuild/scripts/gettext.py", line 111, in run
      if gen_gmo(src_sub, bld_sub, langs) != 0:
    File "/home/thiblahute/devel/gstreamer/gst-build/meson/mesonbuild/scripts/gettext.py", line 66, in gen_gmo
      '-o', os.path.join(bld_sub, l + '.gmo')])
    File "/usr/lib/python3.5/subprocess.py", line 581, in check_call
      raise CalledProcessError(retcode, cmd)
  subprocess.CalledProcessError: Command '['msgfmt', '/home/thiblahute/devel/gstreamer/gst-build/af.po', '-o', '/home/thiblahute/devel/gstreamer/gst-build/build/af.gmo']' returned non-zero exit status 1
  Failed to run install script: /usr/bin/python3 /home/thiblahute/devel/gstreamer/gst-build/meson/meson.py --internal gettext install --subdir=subprojects/gstreamer/po --localedir=share/locale --pkgname=gstreamer-1.0 --langs=af@@az@@be@@bg@@ca@@cs@@da@@de@@el@@en_GB@@eo@@es@@eu@@fi@@fr@@gl@@hr@@hu@@id@@it@@ja@@lt@@nb@@nl@@pl@@pt_BR@@ro@@ru@@rw@@sk@@sl@@sq@@sr@@sv@@tr@@uk@@vi@@zh_CN@@zh_TW
  FAILED: install
  '/usr/bin/python3' '/home/thiblahute/devel/gstreamer/gst-build/meson/meson.py' '--internal' 'install' '/home/thiblahute/devel/gstreamer/gst-build/build/meson-private/install.dat'
```