### PR TITLE
compilers: Ignore -pthread in link flags with MSVC

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1953,6 +1953,9 @@ class VisualStudioCCompiler(CCompiler):
                     continue
                 else:
                     i = name + '.lib'
+            # -pthread in link flags is only used on Linux
+            elif i == '-pthread':
+                continue
             result.append(i)
         return result
 


### PR DESCRIPTION
Sometimes .pc files add `-pthread` in `Libs:` instead of `-lpthread`, so ignore that too when building with MSVC.

Example: https://ci.appveyor.com/project/thiblahute/gst-build-ge9m5/build/1.0.55