### PR TITLE
Various Qt and pkg-config fixes for windows

### DIFF
--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -1029,8 +1029,9 @@ class QtBaseDependency(Dependency):
         # penalty when using self-built Qt or on platforms
         # where -fPIC is not required. If this is an issue
         # for you, patches are welcome.
-        # Fix this to be more portable, especially to MSVC.
-        return ['-fPIC']
+        if mesonlib.is_linux():
+            return ['-fPIC']
+        return []
 
 class Qt5Dependency(QtBaseDependency):
     def __init__(self, env, kwargs):

--- a/mesonbuild/modules/qt4.py
+++ b/mesonbuild/modules/qt4.py
@@ -107,10 +107,10 @@ class Qt4Module():
         moc_sources = kwargs.pop('moc_sources', [])
         if not isinstance(moc_sources, list):
             moc_sources = [moc_sources]
-        srctmp = kwargs.pop('sources', [])
-        if not isinstance(srctmp, list):
-            srctmp = [srctmp]
-        sources = args[1:] + srctmp
+        sources = kwargs.pop('sources', [])
+        if not isinstance(sources, list):
+            sources = [sources]
+        sources += args[1:]
         self._detect_tools(state.environment)
         err_msg = "{0} sources specified and couldn't find {1}, " \
                   "please check your qt4 installation"
@@ -122,8 +122,11 @@ class Qt4Module():
             qrc_deps = []
             for i in rcc_files:
                 qrc_deps += self.parse_qrc(state, i)
-            basename = os.path.split(rcc_files[0])[1]
-            name = 'qt4-' + basename.replace('.', '_')
+            if len(args) > 0:
+                name = args[0]
+            else:
+                basename = os.path.split(rcc_files[0])[1]
+                name = 'qt4-' + basename.replace('.', '_')
             rcc_kwargs = {'input' : rcc_files,
                     'output' : name + '.cpp',
                     'command' : [self.rcc, '-o', '@OUTPUT@', '@INPUT@'],

--- a/mesonbuild/modules/qt5.py
+++ b/mesonbuild/modules/qt5.py
@@ -113,10 +113,10 @@ class Qt5Module():
         moc_sources = kwargs.pop('moc_sources', [])
         if not isinstance(moc_sources, list):
             moc_sources = [moc_sources]
-        srctmp = kwargs.pop('sources', [])
-        if not isinstance(srctmp, list):
-            srctmp = [srctmp]
-        sources = args[1:] + srctmp
+        sources = kwargs.pop('sources', [])
+        if not isinstance(sources, list):
+            sources = [sources]
+        sources += args[1:]
         self._detect_tools(state.environment)
         err_msg = "{0} sources specified and couldn't find {1}, " \
                   "please check your qt5 installation"
@@ -128,13 +128,16 @@ class Qt5Module():
             qrc_deps = []
             for i in rcc_files:
                 qrc_deps += self.parse_qrc(state, i)
-            basename = os.path.split(rcc_files[0])[1]
+            if len(args) > 0:
+                name = args[0]
+            else:
+                basename = os.path.split(rcc_files[0])[1]
+                name = 'qt5-' + basename.replace('.', '_')
             rcc_kwargs = {'input' : rcc_files,
-                    'output' : basename + '.cpp',
+                    'output' : name + '.cpp',
                     'command' : [self.rcc, '-o', '@OUTPUT@', '@INPUT@'],
                     'depend_files' : qrc_deps,
                     }
-            name = 'qt5-' + basename.replace('.', '_')
             res_target = build.CustomTarget(name, state.subdir, rcc_kwargs)
             sources.append(res_target)
         if len(ui_files) > 0:

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -30,6 +30,9 @@ foreach qt : ['qt4', 'qt5']
       qresources : ['stuff.qrc', 'stuff2.qrc'], # Resource file for rcc compiler.
     )
 
+    # Test that setting a unique name with a positional argument works
+    qtmodule.preprocess(qt + 'teststuff', qresources : ['stuff.qrc'])
+
     qexe = executable(qt + 'app',
       sources : ['main.cpp', 'mainWindow.cpp', # Sources that don't need preprocessing.
       prep],


### PR DESCRIPTION
* Fix detection of tools on Windows. When you pass an absolute path to `shutil.which`, it will not implicitly append any extensions. This is problematic on Windows, so we need to account for that. This fixes detection of Qt tools on Windows which are searched with the full path to the Qt `bindir`.

* Only use Qt `-fPIC` on Linux

* Fix detection of pkg-config on Windows and other platforms (see commit message)