### PR TITLE
ldc: Don't make warnings fatal by default

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1758,8 +1758,8 @@ class LLVMDCompiler(DCompiler):
         return ['-I' + path]
 
     def get_warn_args(self, level):
-        if level == '2':
-            return ['-wi']
+        if level == '2' or level == '3':
+            return ['-w', '-wi']
         else:
             return ['-w']
 


### PR DESCRIPTION
Simple changes which makes warnings non-fatal by default when compiling with LDC ("-w" is like "-Werror" while "-wi" is like "-Wall")