### PR TITLE
s/Nonexistant/Nonexistent/g

### DIFF
--- a/mesonbuild/astinterpreter.py
+++ b/mesonbuild/astinterpreter.py
@@ -129,7 +129,7 @@ class AstInterpreter(interpreterbase.InterpreterBase):
         absname = os.path.join(self.source_root, buildfilename)
         if not os.path.isfile(absname):
             self.subdir = prev_subdir
-            raise InterpreterException('Nonexistant build def file %s.' % buildfilename)
+            raise InterpreterException('Nonexistent build def file %s.' % buildfilename)
         with open(absname, encoding='utf8') as f:
             code = f.read()
         assert(isinstance(code, str))

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2023,7 +2023,7 @@ requirements use the version keyword argument instead.''')
         absname = os.path.join(self.environment.get_source_dir(), buildfilename)
         if not os.path.isfile(absname):
             self.subdir = prev_subdir
-            raise InterpreterException('Nonexistant build def file %s.' % buildfilename)
+            raise InterpreterException('Nonexistent build def file %s.' % buildfilename)
         with open(absname, encoding='utf8') as f:
             code = f.read()
         assert(isinstance(code, str))


### PR DESCRIPTION
There is basically no such word in english, "nonexistant".
American people use "nonexistent" and British people used
to have "non-existent", but some time ago they did away with
the hyphens, so there is only one option really: "nonexistent".

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>