### PR TITLE
Do not automatically set warning flags if buildtype is 'plain'

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -373,7 +373,7 @@ class Backend():
             if not isinstance(d, (build.StaticLibrary, build.SharedLibrary)):
                 raise RuntimeError('Tried to link with a non-library target "%s".' % d.get_basename())
             if isinstance(compiler, compilers.LLVMDCompiler):
-                args.extend(['-L', self.get_target_filename_for_linking(d)])
+                args += ['-L' + self.get_target_filename_for_linking(d)]
             else:
                 args.append(self.get_target_filename_for_linking(d))
             # If you have executable e that links to shared lib s1 that links to shared library s2

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1635,7 +1635,8 @@ class DCompiler(Compiler):
         return ['-shared']
 
     def get_soname_args(self, prefix, shlib_name, suffix, path, soversion, is_shared_module):
-        return []
+        # FIXME: Make this work for Windows, MacOS and cross-compiling
+        return get_gcc_soname_args(GCC_STANDARD, prefix, shlib_name, suffix, path, soversion, is_shared_module)
 
     def get_unittest_args(self):
         return ['-unittest']

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1754,10 +1754,13 @@ class LLVMDCompiler(DCompiler):
         return ['-I' + path]
 
     def get_warn_args(self, level):
-        if level == '2':
-            return ['-wi']
+        if level == '2' or level == '3':
+            return ['-wi', '-dw']
         else:
-            return ['-w']
+            return ['-wi']
+
+    def get_werror_args(self):
+        return ['-w']
 
     def get_coverage_args(self):
         return ['-cov']
@@ -1809,7 +1812,7 @@ class DmdDCompiler(DCompiler):
         return ['-I' + path]
 
     def get_warn_args(self, level):
-        return []
+        return ['-wi']
 
     def get_coverage_args(self):
         return ['-cov']


### PR DESCRIPTION
Like the title says.

The `no_warn_args` flag seems to be primarily relevant for Vala, so I didn't use ot touch that one even if we are in 'plain' mode.

This PR also includes a minimal change to make the warning handling when LDC a bit better (warning level 3 would have had *less* warnings than warning level 2 before).

See https://github.com/mesonbuild/meson/pull/1214 for reference.