### PR TITLE
Fix undefined variables in cross-compile.

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -859,11 +859,11 @@ int main(int argc, char **argv) {{
 %s
 int temparray[%d-sizeof(%s)];
 '''
-        if not self.compiles(element_exists_templ.format(prefix, element), env, args, dependencies):
+        if not self.compiles(element_exists_templ.format(prefix, element), env, extra_args, dependencies):
             return -1
         for i in range(1, 1024):
             code = templ % (prefix, i, element)
-            if self.compiles(code, env, args, dependencies):
+            if self.compiles(code, env, extra_args, dependencies):
                 if self.id == 'msvc':
                     # MSVC refuses to construct an array of zero size, so
                     # the test only succeeds when i is sizeof(element) + 1
@@ -907,11 +907,11 @@ struct tmp {
 
 int testarray[%d-offsetof(struct tmp, target)];
 '''
-        if not self.compiles(type_exists_templ.format(typename), env, args, dependencies):
+        if not self.compiles(type_exists_templ.format(typename), env, extra_args, dependencies):
             return -1
         for i in range(1, 1024):
             code = templ % (typename, i)
-            if self.compiles(code, env, args, dependencies):
+            if self.compiles(code, env, extra_args, dependencies):
                 if self.id == 'msvc':
                     # MSVC refuses to construct an array of zero size, so
                     # the test only succeeds when i is sizeof(element) + 1

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -113,11 +113,11 @@ class PkgConfigDependency(Dependency):
         # When finding dependencies for cross-compiling, we don't care about
         # the 'native' pkg-config
         if want_cross:
-            if 'pkgconfig' not in env.cross_info.config['binaries']:
+            if 'pkgconfig' not in environment.cross_info.config['binaries']:
                 if self.required:
                     raise DependencyException('Pkg-config binary missing from cross file')
             else:
-                pkgbin = environment.cross_info.config['binaries']['pkgconfig']
+                PkgConfigDependency.pkgbin = environment.cross_info.config['binaries']['pkgconfig']
         # Only search for the native pkg-config the first time and
         # store the result in the class definition
         elif PkgConfigDependency.pkgbin is None:


### PR DESCRIPTION
I believe this fixes #1219, though I'm not certain that cross-compiling is 100% working yet as I don't have a fully working project to test yet. It does work for the case in #1219 at least.