### PR TITLE
fix some of pylint's undefined-variable

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -16,6 +16,7 @@ import os, pickle, re
 from .. import build
 from .. import dependencies
 from .. import mesonlib
+from .. import mlog
 from .. import compilers
 import json
 import subprocess

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -251,7 +251,7 @@ int dummy;
             # either in the source root, or generated with configure_file and
             # in the build root
             if not isinstance(s, File):
-                raise InvalidArguments('All sources in target {!r} must be of type mesonlib.File'.format(t))
+                raise InvalidArguments('All sources in target {!r} must be of type mesonlib.File'.format(s))
             f = s.rel_to_builddir(self.build_to_src)
             srcs[f] = s
         return srcs

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1383,7 +1383,7 @@ rule FORTRAN_DEP_HACK
             return
         rule = 'rule llvm_ir{}_COMPILER\n'.format('_CROSS' if is_cross else '')
         args = [' '.join([ninja_quote(i) for i in compiler.get_exelist()]),
-                ' '.join(self.get_cross_info_lang_args(compiler, is_cross)),
+                ' '.join(self.get_cross_info_lang_args(compiler.language, is_cross)),
                 ' '.join(compiler.get_output_args('$out')),
                 ' '.join(compiler.get_compile_only_args())]
         if mesonlib.is_windows():

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -1,5 +1,6 @@
 from .. import build
 from .. import dependencies
+from ..mesonlib import MesonException
 
 _found_programs = {}
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -696,7 +696,7 @@ can not be used with the current version of glib-compiled-resources, due to
         args += self._unpack_args('--ignore-headers=', 'ignore_headers', kwargs)
         args += self._unpack_args('--installdir=', 'install_dir', kwargs, state)
         args += self._get_build_args(kwargs, state)
-        res = [build.RunTarget(targetname, command[0], command[1:] + sargs, [], state.subdir)]
+        res = [build.RunTarget(targetname, command[0], command[1:] + args, [], state.subdir)]
         if kwargs.get('install', True):
             res.append(build.InstallScript(command, args))
         return res

--- a/mesonbuild/modules/rpm.py
+++ b/mesonbuild/modules/rpm.py
@@ -103,7 +103,7 @@ class RPMModule:
                              mlog.bold('dnf provides %s' % lib.fullpath))
             for prog in state.environment.coredata.ext_progs.values():
                 if not prog.found():
-                    fn.write('BuildRequires: %{_bindir}/%s # FIXME\n' %
+                    fn.write('BuildRequires: %%{_bindir}/%s # FIXME\n' %
                              prog.get_name())
                 else:
                     fn.write('BuildRequires: %s\n' % ' '.join(prog.fullpath))

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -100,7 +100,7 @@ class Resolver:
             else:
                 mlog.warning('Subproject directory %s is empty, possibly because of an unfinished'
                       'checkout, removing to reclone' % dirname)
-                os.rmdir(checkoutdir)
+                os.rmdir(dirname)
         except NotADirectoryError:
             raise RuntimeError('%s is not a directory, can not use as subproject.' % dirname)
         except FileNotFoundError:


### PR DESCRIPTION
```python
************* Module mesonbuild.dependencies
E:116,34: Undefined variable 'env' (undefined-variable)
************* Module mesonbuild.compilers
E:498,19: Using variable 'p' before assignment (used-before-assignment)
************* Module mesonbuild.modules.rpm
E:106,29: Unsupported format character '{' (0x7b) at index 16 (bad-format-character)
************* Module mesonbuild.modules
E: 12,14: Undefined variable 'MesonException' (undefined-variable)
************* Module mesonbuild.modules.gnome
E:699,69: Undefined variable 'sargs' (undefined-variable)
************* Module mesonbuild.wrap.wrap
E:103,25: Undefined variable 'checkoutdir' (undefined-variable)
************* Module mesonbuild.backend.backends
E: 83,16: Undefined variable 'mlog' (undefined-variable)
************* Module mesonbuild.backend.ninjabackend
E:254,105: Undefined variable 't' (undefined-variable)
```

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>