### PR TITLE
find_program: Don't leak mutable array in get_command()

### DIFF
--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -476,7 +476,7 @@ class ExternalProgram():
         return self.fullpath[0] is not None
 
     def get_command(self):
-        return self.fullpath
+        return self.fullpath[:]
 
     def get_name(self):
         return self.name


### PR DESCRIPTION
In several places in the gnome module, we are getting an array from this and directly appending to it which changes the original command array ever since we started caching the `find_program` results.

We urgently need to move to immutable types for all object properties.

Reported by Alexandor Larsson on IRC.