### PR TITLE
Fix several more lint errors

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -18,7 +18,7 @@ import subprocess, os.path
 import tempfile
 from .import mesonlib
 from . import mlog
-from .mesonlib import MesonException, version_compare, Popen_safe
+from .mesonlib import EnvironmentException, MesonException, version_compare, Popen_safe
 from . import coredata
 
 """This file contains the data files of all compilers Meson knows
@@ -313,10 +313,6 @@ def build_unix_rpath_args(build_dir, rpath_paths, install_rpath):
             else:
                 paths = paths + ':' + padding
         return ['-Wl,-rpath,' + paths]
-
-class EnvironmentException(MesonException):
-    def __init(self, *args, **kwargs):
-        Exception.__init__(self, *args, **kwargs)
 
 class CrossNoRunException(MesonException):
     def __init(self, *args, **kwargs):

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -65,9 +65,6 @@ class Dependency():
     def need_threads(self):
         return False
 
-    def type_name(self):
-        return self.type_name
-
     def get_pkgconfig_variable(self, variable_name):
         raise MesonException('Tried to get a pkg-config variable from a non-pkgconfig dependency.')
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1229,7 +1229,7 @@ class Interpreter(InterpreterBase):
                 outvalues.append(v)
             elif isinstance(v, build.Executable):
                 self.add_target(v.name, v)
-                outvalues.append(ExecutableHolder(v))
+                outvalues.append(ExecutableHolder(v, self))
             elif isinstance(v, list):
                 outvalues.append(self.module_method_callback(v))
             elif isinstance(v, build.GeneratedList):
@@ -1572,15 +1572,15 @@ class Interpreter(InterpreterBase):
         elif lang == 'vala':
             comp = self.environment.detect_vala_compiler()
             if need_cross_compiler:
-                        cross_comp = comp  # Vala is too (I think).
+                cross_comp = comp  # Vala compiles to platform-independent C
         elif lang == 'd':
-            comp = self.environment.detect_d_compiler()
+            comp = self.environment.detect_d_compiler(False)
             if need_cross_compiler:
-                cross_comp = comp  # D as well (AFAIK).
+                cross_comp = self.environment.detect_d_compiler(True)
         elif lang == 'rust':
             comp = self.environment.detect_rust_compiler()
             if need_cross_compiler:
-                cross_comp = comp  # FIXME, probably not correct.
+                cross_comp = comp  # FIXME, not correct.
         elif lang == 'fortran':
             comp = self.environment.detect_fortran_compiler(False)
             if need_cross_compiler:

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -22,6 +22,10 @@ class MesonException(Exception):
     def __init__(self, *args, **kwargs):
         Exception.__init__(self, *args, **kwargs)
 
+class EnvironmentException(MesonException):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
 class File:
     def __init__(self, is_built, subdir, fname):
         self.is_built = is_built

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -24,6 +24,7 @@ from ..mesonlib import MesonException, Popen_safe
 from ..dependencies import Dependency, PkgConfigDependency, InternalDependency
 from .. import mlog
 from .. import mesonlib
+from .. import compilers
 from .. import interpreter
 from . import find_program, GResourceTarget, GResourceHeaderTarget, GirTarget, TypelibTarget, VapiTarget
 


### PR DESCRIPTION
Found by Igor Gnatenko

Some of these are regressions. Others have existed forever.

If I was a good contributor, I would write tests to cover all these codepaths that are untested. But I am a bad contributor. BAD!

```
************* Module mesonbuild.compilers
E:498,19: Using variable 'p' before assignment (used-before-assignment)
************* Module mesonbuild.interpreter
E:1232,33: No value for argument 'interp' in constructor call (no-value-for-parameter)
************* Module mesonbuild.dependencies
E: 68, 4: An attribute defined in mesonbuild.dependencies line 39 hides this method (method-hidden)
************* Module mesonbuild.environment
E: 26, 0: class already defined line 19 (function-redefined)
E: 68,18: Undefined variable 'InterpreterException' (undefined-variable)
E:641,39: Undefined variable 'want_cross' (undefined-variable)
E:850,94: Undefined variable 'varname' (undefined-variable)
E:854,94: Undefined variable 'varname' (undefined-variable)
E:860,102: Undefined variable 'varname' (undefined-variable)
E:863,94: Undefined variable 'varname' (undefined-variable)
************* Module mesonbuild.modules.gnome
E:438,26: Undefined variable 'compilers' (undefined-variable)
```