### PR TITLE
Cache the scripts used for postconf and install phases

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -641,7 +641,7 @@ class Backend():
         child_env.update(env)
 
         for s in self.build.postconf_scripts:
-            cmd = s['exe'].get_command() + s['args']
+            cmd = s['exe'] + s['args']
             subprocess.check_call(cmd, env=child_env)
 
     # Subprojects of subprojects may cause the same dep args to be used

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1482,9 +1482,9 @@ class Data():
         for s in self.sources:
             assert(isinstance(s, File))
 
-class InstallScript(dict):
+class RunScript(dict):
     def __init__(self, script, args):
-        super(InstallScript, self).__init__()
+        super().__init__()
         assert(isinstance(script, list))
         assert(isinstance(args, list))
         self['exe'] = script

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -614,7 +614,7 @@ can not be used with the current version of glib-compiled-resources, due to
             args.append('--media=' + '@@'.join(media))
         if langs:
             args.append('--langs=' + '@@'.join(langs))
-        inscript = build.InstallScript(script, args)
+        inscript = build.RunScript(script, args)
 
         potargs = [state.environment.get_build_command(), '--internal', 'yelphelper', 'pot',
                    '--subdir=' + state.subdir,
@@ -698,7 +698,7 @@ can not be used with the current version of glib-compiled-resources, due to
         args += self._get_build_args(kwargs, state)
         res = [build.RunTarget(targetname, command[0], command[1:] + args, [], state.subdir)]
         if kwargs.get('install', True):
-            res.append(build.InstallScript(command, args))
+            res.append(build.RunScript(command, args))
         return res
 
     def _get_build_args(self, kwargs, state):

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -109,7 +109,7 @@ class I18nModule:
                 pkg_arg]
         if lang_arg:
             args.append(lang_arg)
-        iscript = build.InstallScript(script, args)
+        iscript = build.RunScript(script, args)
 
         return [pottarget, gmotarget, iscript, updatepotarget]
 

--- a/test cases/common/60 install script/installed_files.txt
+++ b/test cases/common/60 install script/installed_files.txt
@@ -1,2 +1,4 @@
 usr/bin/prog?exe
 usr/diiba/daaba/file.dat
+usr/this/should/also-work.dat
+usr/this/does/something-different.dat.in

--- a/test cases/common/60 install script/meson.build
+++ b/test cases/common/60 install script/meson.build
@@ -2,3 +2,6 @@ project('custom install script', 'c')
 
 executable('prog', 'prog.c', install : true)
 meson.add_install_script('myinstall.py', 'diiba/daaba', 'file.dat')
+meson.add_install_script('myinstall.py', 'this/should', 'also-work.dat')
+
+subdir('src')

--- a/test cases/common/60 install script/src/meson.build
+++ b/test cases/common/60 install script/src/meson.build
@@ -1,0 +1,1 @@
+meson.add_install_script('myinstall.py', 'this/does', 'something-different.dat')

--- a/test cases/common/60 install script/src/myinstall.py
+++ b/test cases/common/60 install script/src/myinstall.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+prefix = os.environ['MESON_INSTALL_DESTDIR_PREFIX']
+
+dirname = os.path.join(prefix, sys.argv[1])
+
+os.makedirs(dirname)
+with open(os.path.join(dirname, sys.argv[2] + '.in'), 'w') as f:
+    f.write('')


### PR DESCRIPTION
Cache the absolute dir that the script is searched in and the name of the script. These are the only two things that change.

Update the test to test for both #1235 and the case when a script of the same name is in a different directory (which also covers the subproject case).

Closes #1235