### PR TITLE
Fix installation of statically linked executable for ELF binary.

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -58,3 +58,4 @@ Paulo Antonio Alvarez
 Olexa Bilaniuk
 Daniel Stone
 Marc-Antoine Perennou
+Matthieu Gautier

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -196,6 +196,8 @@ class Elf(DataSizes):
     def parse_dynamic(self):
         sec = self.find_section(b'.dynamic')
         self.dynamic = []
+        if sec is None:
+            return
         self.bf.seek(sec.sh_offset)
         while True:
             e = DynamicEntry(self.bf, self.ptrsize, self.is_le)
@@ -218,6 +220,9 @@ class Elf(DataSizes):
                 soname = i
             if i.d_tag == DT_STRTAB:
                 strtab = i
+        else:
+            print("This file does not have a soname")
+            return
         self.bf.seek(strtab.val + soname.val)
         print(self.read_str())
 
@@ -300,6 +305,8 @@ class Elf(DataSizes):
 
     def remove_rpath_entry(self, entrynum):
         sec = self.find_section(b'.dynamic')
+        if sec is None:
+            return None
         for (i, entry) in enumerate(self.dynamic):
             if entry.d_tag == entrynum:
                 rpentry = self.dynamic[i]


### PR DESCRIPTION
At installation, if the executable is a ELF file, we try to fix the
dependencies in the binary section.
If a executable has been compiled with the --static flag, there is
no .dynamic section in the ELF binary and so we need to handle this case.

The `print_soname(self)` method seems to not been used anywhere, so I'm not sure how to modify it.
(Just print a message (as I've done), print nothing, raise a error...)