### PR TITLE
Raise clearer error if -Doption is invalid.

### DIFF
--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -73,7 +73,10 @@ class OptionInterpreter:
         self.subproject = subproject
         self.cmd_line_options = {}
         for o in command_line_options:
-            (key, value) = o.split('=', 1)
+            try:
+                (key, value) = o.split('=', 1)
+            except ValueError:
+                raise OptionException('Option {!r} must have a value separated by equals sign.'.format(o))
             self.cmd_line_options[key] = value
 
     def process(self, option_file):


### PR DESCRIPTION
This can occur if you accidentally do something like `meson -Doption-value` instead of `meson -Doption=value`; it would raise an exception instead of printing a clear message.