### PR TITLE
Force a Ninja regeneration before each project test

### DIFF
--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -271,6 +271,11 @@ def _run_test(testdir, test_build_dir, install_dir, extra_args, flags, compile_c
         return TestResult('Test that should have failed to build succeeded', stdo, stde, mesonlog, gen_time)
     if pc.returncode != 0:
         return TestResult('Compiling source code failed.', stdo, stde, mesonlog, gen_time, build_time)
+    # Touch the meson.build file to force a regenerate so we can test that
+    # regeneration works. We need to sleep for 0.2s because Ninja tracks mtimes
+    # at a low resolution: https://github.com/ninja-build/ninja/issues/371
+    time.sleep(0.2)
+    os.utime(os.path.join(testdir, 'meson.build'))
     test_start = time.time()
     # Note that we don't test that running e.g. 'ninja test' actually
     # works. One hopes that this is a common enough happening that

--- a/test cases/linuxlike/5 dependency versions/meson.build
+++ b/test cases/linuxlike/5 dependency versions/meson.build
@@ -47,3 +47,10 @@ assert(somelibfail.found() == false, 'somelibfail found via wrong fallback')
 fakezlib_dep = dependency('zlib',
   fallback : ['somelib', 'fakezlib_dep'])
 assert(fakezlib_dep.type_name() == 'internal', 'fakezlib_dep should be of type "internal", not ' + fakezlib_dep.type_name())
+
+foreach d : ['sdl2', 'gnustep', 'wx', 'gl', 'python3', 'boost', 'gtest', 'gmock']
+  dep = dependency(d, required : false)
+  if dep.found()
+    dep.version()
+  endif
+endforeach


### PR DESCRIPTION
We have no test coverage for regeneration at all, which is why issues like #1246 slide by without us noticing. With this, we will run a regen on every test during `ninja test` after it has been compiled. This will not affect test times too much since the regen will not rebuild anything at all since there have been no source changes.