### PR TITLE
setup.cfg: ignore couple of PEP8 errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,7 @@
 [flake8]
-max-line-length = 999
+ignore =
+    # E261: at least two spaces before inline comment
+    E261,
+    # E501: line too long
+    E501
+max-line-length = 120


### PR DESCRIPTION
We don't care about E261 and temporarily ignore E501.

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>