### PR TITLE
Add include_directories to windows.compile_resources.

### DIFF
--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -14,6 +14,7 @@
 
 from .. import mesonlib, dependencies, build
 from ..mesonlib import MesonException
+from . import get_include_args
 import os
 
 class WindowsModule:
@@ -26,7 +27,16 @@ class WindowsModule:
 
     def compile_resources(self, state, args, kwargs):
         comp = self.detect_compiler(state.compilers)
+
         extra_args = mesonlib.stringlistify(kwargs.get('args', []))
+        inc_dirs = kwargs.pop('include_directories', [])
+        if not isinstance(inc_dirs, list):
+            inc_dirs = [inc_dirs]
+        for incd in inc_dirs:
+            if not isinstance(incd.held_object, (str, build.IncludeDirs)):
+                raise MesonException('Resource include dirs should be include_directories().')
+        extra_args += get_include_args(state.environment, inc_dirs)
+
         if comp.id == 'msvc':
             rescomp = dependencies.ExternalProgram('rc', silent=True)
             res_args = extra_args + ['/nologo', '/fo@OUTPUT@', '@INPUT@']

--- a/test cases/windows/5 resources/inc/resource.h
+++ b/test cases/windows/5 resources/inc/resource.h
@@ -1,0 +1,1 @@
+#define ICON_ID 1

--- a/test cases/windows/5 resources/meson.build
+++ b/test cases/windows/5 resources/meson.build
@@ -1,9 +1,12 @@
 project('winmain', 'c')
 
 win = import('windows')
+res = win.compile_resources('myres.rc',
+  include_directories : include_directories('inc')
+)
 
 exe = executable('prog', 'prog.c',
-  win.compile_resources('myres.rc'),
+  res,
   gui_app : true)
 
 test('winmain', exe)

--- a/test cases/windows/5 resources/myres.rc
+++ b/test cases/windows/5 resources/myres.rc
@@ -1,3 +1,4 @@
 #include<windows.h>
+#include"resource.h"
 
-1 ICON "sample.ico"
+ICON_ID ICON "sample.ico"


### PR DESCRIPTION
Resource files can `#include` things, so might need to be able to set the search path for that. I've only tested this on a cross-compile; hopefully it works on Windows-proper as well.