### PR TITLE
Can set subproject option defaults from command line and master project

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1798,7 +1798,12 @@ requirements use the version keyword argument instead.''')
         dirname, varname = self.get_subproject_infos(kwargs)
         # Try to execute the subproject
         try:
-            self.do_subproject(dirname, {})
+            sp_kwargs = {}
+            try:
+                sp_kwargs['default_options'] = kwargs['default_options']
+            except KeyError:
+                pass
+            self.do_subproject(dirname, sp_kwargs)
         # Invalid code is always an error
         except InvalidCode:
             raise

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1147,12 +1147,7 @@ class Interpreter(InterpreterBase):
         self.backend = backend
         self.subproject = subproject
         self.subproject_dir = subproject_dir
-        option_file = os.path.join(self.source_root, self.subdir, 'meson_options.txt')
-        if os.path.exists(option_file):
-            oi = optinterpreter.OptionInterpreter(self.subproject, \
-                                                  self.build.environment.cmd_line_options.projectoptions)
-            oi.process(option_file)
-            self.build.environment.merge_options(oi.options)
+        self.option_file = os.path.join(self.source_root, self.subdir, 'meson_options.txt')
         self.load_root_meson_file()
         self.sanity_check_ast()
         self.builtin.update({'meson': MesonMain(build, self)})
@@ -1501,6 +1496,12 @@ class Interpreter(InterpreterBase):
             self.build.project_name = args[0]
             if self.environment.first_invocation and 'default_options' in kwargs:
                 self.parse_default_options(kwargs['default_options'])
+        if os.path.exists(self.option_file):
+            oi = optinterpreter.OptionInterpreter(self.subproject, \
+                                                  self.build.environment.cmd_line_options.projectoptions,
+                                                  )
+            oi.process(self.option_file)
+            self.build.environment.merge_options(oi.options)
         if len(args) < 2:
             raise InvalidArguments('Not enough arguments to project(). Needs at least the project name and one language')
         self.active_projectname = args[0]

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -71,8 +71,15 @@ class OptionInterpreter:
     def __init__(self, subproject, command_line_options):
         self.options = {}
         self.subproject = subproject
+        self.sbprefix = subproject + ':'
         self.cmd_line_options = {}
         for o in command_line_options:
+            if self.subproject != '': # Strip the beginning.
+                if not o.startswith(self.sbprefix):
+                    continue
+            else:
+                if ':' in o:
+                    continue
             try:
                 (key, value) = o.split('=', 1)
             except ValueError:

--- a/test cases/unit/3 subproject defaults/meson.build
+++ b/test cases/unit/3 subproject defaults/meson.build
@@ -3,6 +3,8 @@ project('subproject defaults', 'c',
                      'fromcmdline=defopt']   # This should get the value set in command line.
   )
 
+subproject('foob')
+
 assert(get_option('fromcmdline') == 'cmdline', 'Default option defined in cmd line is incorrect: ' + get_option('fromcmdline'))
 assert(get_option('defopoverride') == 'defopt', 'Default option without cmd line override is incorrect: ' + get_option('defopoverride'))
 assert(get_option('fromoptfile') == 'optfile', 'Default value from option file is incorrect: ' + get_option('fromoptfile'))

--- a/test cases/unit/3 subproject defaults/meson.build
+++ b/test cases/unit/3 subproject defaults/meson.build
@@ -1,0 +1,9 @@
+project('subproject defaults', 'c',
+  default_options : ['defopoverride=defopt', # This should be overridden.
+                     'fromcmdline=defopt']   # This should get the value set in command line.
+  )
+
+assert(get_option('fromcmdline') == 'cmdline', 'Default option defined in cmd line is incorrect: ' + get_option('fromcmdline'))
+assert(get_option('defopoverride') == 'defopt', 'Default option without cmd line override is incorrect: ' + get_option('defopoverride'))
+assert(get_option('fromoptfile') == 'optfile', 'Default value from option file is incorrect: ' + get_option('fromoptfile'))
+

--- a/test cases/unit/3 subproject defaults/meson.build
+++ b/test cases/unit/3 subproject defaults/meson.build
@@ -3,7 +3,7 @@ project('subproject defaults', 'c',
                      'fromcmdline=defopt']   # This should get the value set in command line.
   )
 
-subproject('foob')
+subproject('foob', default_options : ['fromspfunc=spfunc', 'fromspfunconly=spfunc'])
 
 assert(get_option('fromcmdline') == 'cmdline', 'Default option defined in cmd line is incorrect: ' + get_option('fromcmdline'))
 assert(get_option('defopoverride') == 'defopt', 'Default option without cmd line override is incorrect: ' + get_option('defopoverride'))

--- a/test cases/unit/3 subproject defaults/meson_options.txt
+++ b/test cases/unit/3 subproject defaults/meson_options.txt
@@ -1,0 +1,3 @@
+option('defopoverride', type : 'string', value : 'optfile', description : 'A value for overriding.')
+option('fromcmdline', type : 'string', value : 'optfile', description : 'A value for overriding.')
+option('fromoptfile', type : 'string', value : 'optfile', description : 'A value for not overriding.')

--- a/test cases/unit/3 subproject defaults/subprojects/foob/meson.build
+++ b/test cases/unit/3 subproject defaults/subprojects/foob/meson.build
@@ -1,0 +1,9 @@
+project('foob', 'c',
+  default_options : ['defopoverride=s_defopt', # This should be overridden.
+                     'fromcmdline=s_defopt']   # This should get the value set in command line.
+  )
+
+assert(get_option('fromcmdline') == 's_cmdline', 'Default option defined in cmd line is incorrect: ' + get_option('fromcmdline'))
+assert(get_option('defopoverride') == 's_defopt', 'Default option without cmd line override is incorrect: ' + get_option('defopoverride'))
+assert(get_option('fromoptfile') == 's_optfile', 'Default value from option file is incorrect: ' + get_option('fromoptfile'))
+

--- a/test cases/unit/3 subproject defaults/subprojects/foob/meson.build
+++ b/test cases/unit/3 subproject defaults/subprojects/foob/meson.build
@@ -1,9 +1,12 @@
 project('foob', 'c',
   default_options : ['defopoverride=s_defopt', # This should be overridden.
+                     'fromspfunc=s_defopt',    # This is specified with a default_options kwarg to subproject()
                      'fromcmdline=s_defopt']   # This should get the value set in command line.
   )
 
 assert(get_option('fromcmdline') == 's_cmdline', 'Default option defined in cmd line is incorrect: ' + get_option('fromcmdline'))
+assert(get_option('fromspfunc') == 'spfunc', 'Default option set with subproject() incorrect: ' + get_option('fromspfunc'))
+assert(get_option('fromspfunconly') == 'spfunc', 'Default option set with subproject() incorrect: ' + get_option('fromspfunc'))
 assert(get_option('defopoverride') == 's_defopt', 'Default option without cmd line override is incorrect: ' + get_option('defopoverride'))
 assert(get_option('fromoptfile') == 's_optfile', 'Default value from option file is incorrect: ' + get_option('fromoptfile'))
 

--- a/test cases/unit/3 subproject defaults/subprojects/foob/meson_options.txt
+++ b/test cases/unit/3 subproject defaults/subprojects/foob/meson_options.txt
@@ -1,0 +1,3 @@
+option('defopoverride', type : 'string', value : 's_optfile', description : 'A value for overriding.')
+option('fromcmdline', type : 'string', value : 's_optfile', description : 'A value for overriding.')
+option('fromoptfile', type : 'string', value : 's_optfile', description : 'A value for not overriding.')

--- a/test cases/unit/3 subproject defaults/subprojects/foob/meson_options.txt
+++ b/test cases/unit/3 subproject defaults/subprojects/foob/meson_options.txt
@@ -1,3 +1,5 @@
 option('defopoverride', type : 'string', value : 's_optfile', description : 'A value for overriding.')
 option('fromcmdline', type : 'string', value : 's_optfile', description : 'A value for overriding.')
+option('fromspfunc', type : 'string', value : 's_optfile', description : 'A value for overriding.')
+option('fromspfunconly', type : 'string', value : 's_optfile', description : 'A value for overriding.')
 option('fromoptfile', type : 'string', value : 's_optfile', description : 'A value for not overriding.')


### PR DESCRIPTION
Currently we can't set project options from the command line when invoking Meson for the first time. This MR adds the possibility to do that both with the command line and in subproject() invocations. The former looks like this:

    meson -Dsubproject:optionname=value <other options>

The latter looks like this:

    subproject('subproject', default_options : ['optionname=value'])

Subproject() overrides values in the subproject's project() call and command line arguments override everything.

This should make it possible to do e.g. `libgd` (if I remember correctly) which is a library that is built inside every project (rather than linking to it) and each project needs different settings for it.