### PR TITLE
Bring some order to modules

### DIFF
--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -45,6 +45,11 @@ def get_include_args(environment, include_dirs, prefix='-I'):
 
     return dirs_str
 
+class ModuleReturnValue:
+    def __init__(self, return_value, new_objects):
+        self.return_value = return_value
+        assert(isinstance(new_objects, list))
+        self.new_objects = new_objects
 
 class GResourceTarget(build.CustomTarget):
     def __init__(self, name, subdir, kwargs):

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -15,6 +15,8 @@
 from os import path
 from .. import coredata, mesonlib, build
 from ..mesonlib import MesonException
+from . import ModuleReturnValue
+
 import sys
 import shutil
 
@@ -59,7 +61,8 @@ class I18nModule:
 
         kwargs['command'] = ['msgfmt', '--' + file_type,
                              '--template', '@INPUT@', '-d', podir, '-o', '@OUTPUT@']
-        return build.CustomTarget(kwargs['output'] + '_merge', state.subdir, kwargs)
+        ct = build.CustomTarget(kwargs['output'] + '_merge', state.subdir, kwargs)
+        return ModuleReturnValue(ct, [ct])
 
     def gettext(self, state, args, kwargs):
         if len(args) != 1:
@@ -114,7 +117,7 @@ class I18nModule:
             args.append(lang_arg)
         iscript = build.RunScript(script, args)
 
-        return [pottarget, gmotarget, iscript, updatepotarget]
+        return ModuleReturnValue(None, [pottarget, gmotarget, iscript, updatepotarget])
 
 def initialize():
     return I18nModule()

--- a/mesonbuild/modules/modtest.py
+++ b/mesonbuild/modules/modtest.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from . import ModuleReturnValue
+
 class TestModule:
 
     def print_hello(self, state, args, kwargs):
         print('Hello from a Meson module')
+        rv = ModuleReturnValue(None, [])
+        return rv
 
 def initialize():
     return TestModule()

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -15,6 +15,8 @@
 from .. import build
 from .. import mesonlib
 from .. import mlog
+from . import ModuleReturnValue
+
 import os
 
 class PkgConfigModule:
@@ -138,7 +140,8 @@ class PkgConfigModule:
         self.generate_pkgconfig_file(state, libs, subdirs, name, description, url,
                                      version, pcfile, pub_reqs, priv_reqs,
                                      conflicts, priv_libs)
-        return build.Data(mesonlib.File(True, state.environment.get_scratch_dir(), pcfile), pkgroot)
+        res = build.Data(mesonlib.File(True, state.environment.get_scratch_dir(), pcfile), pkgroot)
+        return ModuleReturnValue(res, [res])
 
 def initialize():
     return PkgConfigModule()

--- a/mesonbuild/modules/qt4.py
+++ b/mesonbuild/modules/qt4.py
@@ -18,6 +18,7 @@ from .. import build
 from ..mesonlib import MesonException, Popen_safe
 from ..dependencies import Qt4Dependency
 import xml.etree.ElementTree as ET
+from . import ModuleReturnValue
 
 class Qt4Module():
     tools_detected = False
@@ -153,7 +154,7 @@ class Qt4Module():
             moc_gen = build.Generator([self.moc], moc_kwargs)
             moc_output = moc_gen.process_files('Qt4 moc source', moc_sources, state)
             sources.append(moc_output)
-        return sources
+        return ModuleReturnValue(sources, sources)
 
 def initialize():
     mlog.warning('rcc dependencies will not work properly until this upstream issue is fixed:',

--- a/mesonbuild/modules/qt5.py
+++ b/mesonbuild/modules/qt5.py
@@ -18,6 +18,7 @@ from .. import build
 from ..mesonlib import MesonException, Popen_safe
 from ..dependencies import Qt5Dependency
 import xml.etree.ElementTree as ET
+from . import ModuleReturnValue
 
 class Qt5Module():
     tools_detected = False
@@ -159,7 +160,7 @@ class Qt5Module():
             moc_gen = build.Generator([self.moc], moc_kwargs)
             moc_output = moc_gen.process_files('Qt5 moc source', moc_sources, state)
             sources.append(moc_output)
-        return sources
+        return ModuleReturnValue(sources, sources)
 
 def initialize():
     mlog.warning('rcc dependencies will not work reliably until this upstream issue is fixed:',

--- a/mesonbuild/modules/rpm.py
+++ b/mesonbuild/modules/rpm.py
@@ -20,6 +20,7 @@ from .. import compilers
 import datetime
 from .. import mlog
 from . import GirTarget, TypelibTarget
+from . import ModuleReturnValue
 
 import os
 
@@ -153,6 +154,7 @@ class RPMModule:
             fn.write('- \n')
             fn.write('\n')
         mlog.log('RPM spec template written to %s.spec.\n' % proj)
+        return ModuleReturnValue(None, [])
 
 def initialize():
     return RPMModule()

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -15,6 +15,8 @@
 from .. import mesonlib, dependencies, build
 from ..mesonlib import MesonException
 from . import get_include_args
+from . import ModuleReturnValue
+
 import os
 
 class WindowsModule:
@@ -54,7 +56,7 @@ class WindowsModule:
                       'arguments': res_args}
         res_gen = build.Generator([rescomp], res_kwargs)
         res_output = res_gen.process_files('Windows resource', args, state)
-        return res_output
+        return ModuleReturnValue(res_output, [res_output])
 
 def initialize():
     return WindowsModule()

--- a/test cases/frameworks/7 gnome/gdbus/meson.build
+++ b/test cases/frameworks/7 gnome/gdbus/meson.build
@@ -1,9 +1,10 @@
 gdbus_src = gnome.gdbus_codegen('generated-gdbus', 'com.example.Sample.xml',
-interface_prefix : 'com.example.',
-namespace : 'Sample')
+  interface_prefix : 'com.example.',
+  namespace : 'Sample')
 
 gdbus_exe = executable('gdbus-test', 'gdbusprog.c',
-gdbus_src,
-include_directories : include_directories('..'),
-dependencies : giounix)
+  gdbus_src,
+  include_directories : include_directories('..'),
+  dependencies : giounix)
+
 test('gdbus', gdbus_exe)


### PR DESCRIPTION
Our module API is a bit of a wild west. This is first step towards something better. Create a return value object that encapsulates the result of a module invocation. It contains two items

 - the object to return to Meson script
 - the list of new objects to append to build etc

The implementation is broken in many ways and many tests do not pass. The point of this is to be something to get the discussion rolling.

This also adds code that checks that the module does not alter build objects behind our back. All modules should be append only and return new things in the array, the interpreter takes care of putting them in their respective places. This way we have alteration logic in one centralized place.