### PR TITLE
mesontest: Improve test suite selection.

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2080,14 +2080,14 @@ requirements use the version keyword argument instead.''')
             workdir = None
         if not isinstance(timeout, int):
             raise InterpreterException('Timeout must be an integer.')
-        suite = mesonlib.stringlistify(kwargs.get('suite', ''))
-        if self.is_subproject():
-            newsuite = []
-            for s in suite:
-                if len(s) > 0:
-                    s = '.' + s
-                newsuite.append(self.subproject.replace(' ', '_').replace('.', '_') + s)
-            suite = newsuite
+        suite = []
+        for s in mesonlib.stringlistify(kwargs.get('suite', '')):
+            if len(s) > 0:
+                s = ':' + s
+            if self.is_subproject():
+                suite.append(self.subproject.replace(' ', '_').replace(':', '_') + s)
+            else:
+                suite.append(self.build.project_name.replace(' ', '_').replace(':', '_') + s)
         t = Test(args[0], suite, args[1].held_object, par, cmd_args, env, should_fail, timeout, workdir)
         if is_base_test:
             self.build.tests.append(t)

--- a/test cases/unit/4 suite selection/failing_test.c
+++ b/test cases/unit/4 suite selection/failing_test.c
@@ -1,0 +1,1 @@
+int main() { return -1 ; }

--- a/test cases/unit/4 suite selection/meson.build
+++ b/test cases/unit/4 suite selection/meson.build
@@ -1,0 +1,13 @@
+project('mainprj', 'c')
+
+subproject('subprjfail')
+subproject('subprjsucc')
+subproject('subprjmix')
+
+test('mainprj-failing_test',
+  executable('failing_test', 'failing_test.c'),
+  suite : 'fail')
+
+test('mainprj-successful_test',
+  executable('successful_test', 'successful_test.c'),
+  suite : 'success')

--- a/test cases/unit/4 suite selection/subprojects/subprjfail/failing_test.c
+++ b/test cases/unit/4 suite selection/subprojects/subprjfail/failing_test.c
@@ -1,0 +1,1 @@
+int main() { return -1 ; }

--- a/test cases/unit/4 suite selection/subprojects/subprjfail/meson.build
+++ b/test cases/unit/4 suite selection/subprojects/subprjfail/meson.build
@@ -1,0 +1,5 @@
+project('subprjfail', 'c')
+
+test('subprjfail-failing_test',
+  executable('failing_test', 'failing_test.c'),
+  suite : 'fail')

--- a/test cases/unit/4 suite selection/subprojects/subprjmix/failing_test.c
+++ b/test cases/unit/4 suite selection/subprojects/subprjmix/failing_test.c
@@ -1,0 +1,1 @@
+int main() { return -1 ; }

--- a/test cases/unit/4 suite selection/subprojects/subprjmix/meson.build
+++ b/test cases/unit/4 suite selection/subprojects/subprjmix/meson.build
@@ -1,0 +1,9 @@
+project('subprjmix', 'c')
+
+test('subprjmix-failing_test',
+  executable('failing_test', 'failing_test.c'),
+  suite : 'fail')
+
+test('subprjmix-successful_test',
+  executable('successful_test', 'successful_test.c'),
+  suite : 'success')

--- a/test cases/unit/4 suite selection/subprojects/subprjmix/successful_test.c
+++ b/test cases/unit/4 suite selection/subprojects/subprjmix/successful_test.c
@@ -1,0 +1,1 @@
+int main() { return 0 ; }

--- a/test cases/unit/4 suite selection/subprojects/subprjsucc/meson.build
+++ b/test cases/unit/4 suite selection/subprojects/subprjsucc/meson.build
@@ -1,0 +1,5 @@
+project('subprjsucc', 'c')
+
+test('subprjsucc-successful_test',
+  executable('successful_test', 'successful_test.c'),
+  suite : 'success')

--- a/test cases/unit/4 suite selection/subprojects/subprjsucc/successful_test.c
+++ b/test cases/unit/4 suite selection/subprojects/subprjsucc/successful_test.c
@@ -1,0 +1,1 @@
+int main() { return 0 ; }

--- a/test cases/unit/4 suite selection/successful_test.c
+++ b/test cases/unit/4 suite selection/successful_test.c
@@ -1,0 +1,1 @@
+int main() { return 0 ; }


### PR DESCRIPTION
Continue discussion from #1252. Could also fix #1273.

Apparently mesontest's suite option already accepted arguments of the format "$subproject.$suite" so the idea was to extend this functionality.

With this change:

- --suite option can be given multiple times.
- Also "$main_project.$suite" is accepted.
- Any project name can be used as such as a suite selector.
- Any suite name can be used to match tests from any project if prefixed with a period ('.').
- The output with the --list option matches the output from when it is not given (w.r.t. the test project, suite and name combination).

Some examples:

- All tests in $main_project: --suite $main_project
- All tests in $subproject: --suite $subproject
- All tests in $main_project part of suite 'foobar': --suite $main_project.foobar
- All tests part of a suite called 'foobar' (in any project): --suite .foobar
- All tests in $subproject's suite 'barfoo' and all tests in $subproject2: --suite $subproject.barfoo --suite $subproject2
- All tests with the name 'supertest' or 'shittytest' in $subproject's suite 'feaX': --suite $subproject.feaX supertest shittytest

Output will look like: `$project.$suite / $test_name` or just `$test_name` if all the tests belong to the same suite (and project).