### PR TITLE
Proposal for a "query_exists" function for Meson

### DIFF
--- a/mesonbuild/astinterpreter.py
+++ b/mesonbuild/astinterpreter.py
@@ -88,6 +88,7 @@ class AstInterpreter(interpreterbase.InterpreterBase):
                            'set_variable': self.func_set_variable,
                            'get_variable': self.func_get_variable,
                            'is_variable': self.func_is_variable,
+                           'query_exists': self.func_do_nothing
                            })
 
     def func_do_nothing(self, node, args, kwargs):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1306,13 +1306,13 @@ class Interpreter(InterpreterBase):
 
     @stringArgs
     def func_query_exists(self, node, args, kwargs):
-        check_files = kwargs.get('check_files',True)
-        check_folders = kwargs.get('check_folders',True)
+        check_files = kwargs.get('check_files', True)
+        check_folders = kwargs.get('check_folders', True)
         for fname in args:
             fullpath = os.path.join(self.environment.source_dir, self.subdir, fname)
             if (check_files and os.path.isfile(fullpath)) or (check_folders and os.path.isdir(fullpath)):
                 return fname
-        if (kwargs.get('fail',True)):
+        if (kwargs.get('fail', True)):
             error_string = 'None of these paths do exist:\n'
             for fname in args:
                 error_string += '\t{:s}\n'.format(fname)

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1225,6 +1225,7 @@ class Interpreter(InterpreterBase):
                            'assert': self.func_assert,
                            'environment': self.func_environment,
                            'join_paths': self.func_join_paths,
+                           'query_exists': self.func_query_exists,
                            })
 
     def module_method_callback(self, invalues):
@@ -1302,6 +1303,22 @@ class Interpreter(InterpreterBase):
     @noKwargs
     def func_files(self, node, args, kwargs):
         return [mesonlib.File.from_source_file(self.environment.source_dir, self.subdir, fname) for fname in args]
+
+    @stringArgs
+    def func_query_exists(self, node, args, kwargs):
+        check_files = kwargs.get('check_files',True)
+        check_folders = kwargs.get('check_folders',True)
+        for fname in args:
+            fullpath = os.path.join(self.environment.source_dir, self.subdir, fname)
+            if (check_files and os.path.isfile(fullpath)) or (check_folders and os.path.isdir(fullpath)):
+                return fname
+        if (kwargs.get('fail',True)):
+            error_string = 'None of these paths do exist:\n'
+            for fname in args:
+                error_string += '\t{:s}\n'.format(fname)
+            raise mesonlib.MesonException(error_string)
+        else:
+            return ""
 
     @noPosargs
     def func_declare_dependency(self, node, args, kwargs):


### PR DESCRIPTION
This function receives a string or an array of strings with paths
(relative or absolute). If at least one of the paths (which can
point to a file or a folder) does exist, it will return a string
with the first one that exists.

If none of those paths do exist, by default it will fail, showing
the list of files not available (but will return an empty string
if the "fail" keyword argument is set to False).

It is possible to exclude files (for checking only folders)
by setting the "check_files" keyword argument to False. Also
it is possible to exclude folders (for checking only files)
by setting the "check_folders" keyword argument to False.

This function can be used to check if libraries that doesn't
have a pkgconfig file are installed, by checking if their
header files exists. Since these can be stored at least at
two possible paths ("/usr/include/..." or "/usr/local/include")
it is mandatory to be able to check every possible place and
fail only if it is not available in any of them.

This function will be very useful for Autovala's Meson backend.