### PR TITLE
We only need Ninja 1.5.x for the core code

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ build system.
 ####Dependencies
 
  - [Python](http://python.org) (version 3.4 or newer)
- - [Ninja](https://ninja-build.org)
+ - [Ninja](https://ninja-build.org) (version 1.5 or newer)
 
 ####Installing from source
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -36,16 +36,16 @@ def find_coverage_tools():
         genhtml_exe = None
     return (gcovr_exe, lcov_exe, genhtml_exe)
 
-def detect_ninja():
+def detect_ninja(version='1.5'):
     for n in ['ninja', 'ninja-build']:
         try:
-            p, version = Popen_safe([n, '--version'])[0:2]
+            p, found = Popen_safe([n, '--version'])[0:2]
         except (FileNotFoundError, PermissionError):
             # Doesn't exist in PATH or isn't executable
             continue
         # Perhaps we should add a way for the caller to know the failure mode
         # (not found or too old)
-        if p.returncode == 0 and mesonlib.version_compare(version, ">=1.6"):
+        if p.returncode == 0 and mesonlib.version_compare(found, '>=' + version):
             return n
 
 def detect_native_windows_arch():

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -112,7 +112,8 @@ def setup_commands(backend):
         test_commands = ['xcodebuild', '-target', 'RUN_TESTS']
     else:
         backend_flags = []
-        ninja_command = environment.detect_ninja()
+        # We need at least 1.6 because of -w dupbuild=err
+        ninja_command = environment.detect_ninja(version='1.6')
         if ninja_command is None:
             raise RuntimeError('Could not find Ninja v1.6 or newer')
         if do_debug:


### PR DESCRIPTION
This change helps us run on older distros such as Ubuntu LTS which is very lazy in updating even non-core and stable packages such as Ninja.

Ninja 1.6.x is only needed for running the tests.