### PR TITLE
Support file perms for install_data and install_subdir

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -459,7 +459,8 @@ class Backend:
         mfobj['projects'] = self.build.dep_manifest
         with open(ifilename, 'w') as f:
             f.write(json.dumps(mfobj))
-        d.data.append([ifilename, ofilename])
+        # Copy file from, to, and with mode unchanged
+        d.data.append([ifilename, ofilename, None])
 
     def get_regen_filelist(self):
         '''List of all files whose alteration means that the build

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -700,7 +700,7 @@ int dummy;
                 assert(isinstance(f, mesonlib.File))
                 plain_f = os.path.split(f.fname)[1]
                 dstabs = os.path.join(subdir, plain_f)
-                i = [f.absolute_path(srcdir, builddir), dstabs]
+                i = [f.absolute_path(srcdir, builddir), dstabs, de.install_mode]
                 d.data.append(i)
 
     def generate_subdir_install(self, d):
@@ -715,7 +715,7 @@ int dummy;
                 inst_dir = sd.installable_subdir
             src_dir = os.path.join(self.environment.get_source_dir(), subdir)
             dst_dir = os.path.join(self.environment.get_prefix(), sd.install_dir)
-            d.install_subdirs.append([src_dir, inst_dir, dst_dir])
+            d.install_subdirs.append([src_dir, inst_dir, dst_dir, sd.install_mode])
 
     def generate_tests(self, outfile):
         self.serialise_tests()

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1502,9 +1502,10 @@ class ConfigurationData:
 # A bit poorly named, but this represents plain data files to copy
 # during install.
 class Data:
-    def __init__(self, sources, install_dir):
+    def __init__(self, sources, install_dir, install_mode=None):
         self.sources = sources
         self.install_dir = install_dir
+        self.install_mode = install_mode
         if not isinstance(self.sources, list):
             self.sources = [self.sources]
         for s in self.sources:

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -316,6 +316,7 @@ class WxDependency(Dependency):
     def __init__(self, environment, kwargs):
         Dependency.__init__(self, 'wx')
         self.is_found = False
+        self.modversion = 'none'
         if WxDependency.wx_found is None:
             self.check_wxconfig()
         if not WxDependency.wx_found:

--- a/test cases/common/12 data/installed_files.txt
+++ b/test cases/common/12 data/installed_files.txt
@@ -3,3 +3,4 @@ usr/share/progname/fileobject_datafile.dat
 usr/share/progname/vanishing.dat
 usr/share/progname/vanishing2.dat
 etc/etcfile.dat
+usr/bin/runscript.sh

--- a/test cases/common/12 data/meson.build
+++ b/test cases/common/12 data/meson.build
@@ -1,7 +1,14 @@
 project('data install test', 'c')
 install_data(sources : 'datafile.dat', install_dir : 'share/progname')
-install_data(sources : 'etcfile.dat', install_dir : '/etc')
-install_data(files('fileobject_datafile.dat'), install_dir : 'share/progname')
+# Some file in /etc that is only read-write by root; add a sticky bit for testing
+install_data(sources : 'etcfile.dat', install_dir : '/etc', install_mode : 'rw------T')
+# Some script that needs to be executable by the group
+install_data('runscript.sh',
+  install_dir : get_option('bindir'),
+  install_mode : ['rwxr-sr-x', 'root', 0])
+install_data(files('fileobject_datafile.dat'),
+  install_dir : 'share/progname',
+  install_mode : [false, false, 0])
 
 subdir('vanishing')
 

--- a/test cases/common/12 data/runscript.sh
+++ b/test cases/common/12 data/runscript.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Runscript"

--- a/test cases/common/66 install subdir/meson.build
+++ b/test cases/common/66 install subdir/meson.build
@@ -1,5 +1,7 @@
 project('install a whole subdir', 'c')
 
 subdir('subdir')
-install_subdir('sub1', install_dir : 'share')
+# A subdir with write perms only for the owner
+# and read-list perms for owner and group
+install_subdir('sub1', install_dir : 'share', install_mode : ['rwxr-x--t', 'root'])
 install_subdir('sub/sub1', install_dir : 'share')

--- a/test cases/common/66 install subdir/subdir/meson.build
+++ b/test cases/common/66 install subdir/subdir/meson.build
@@ -1,1 +1,3 @@
-install_subdir('sub1', install_dir : 'share')
+install_subdir('sub1', install_dir : 'share',
+  # This mode will be overriden by the mode set in the outer install_subdir
+  install_mode : 'rwxr-x---')


### PR DESCRIPTION
With the `install_mode:` kwarg, you can now specify the file and directory permissions to be used while installing.

The format of the `install_mode:` kwarg is the same as the symbolic notation used by `ls -l` with the first character that specifies `d`, `-`, `c`, etc for the file type omitted since that is always obvious from the context.

Includes unit tests for the same. Sadly these only run on Linux right now, but we want them to run on all platforms. We do set the mode in the integration tests for all platforms but we don't check if they were
actually set correctly.

We will also need an `install_mode:` kwarg for `build_target`s, but that's a bit more involved since it should involve cleaning up `generate_target_install()`. Will add that in another PR.