### PR TITLE
Fix pkg-config error handling on OS X

### DIFF
--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -30,8 +30,7 @@ from . import mesonlib
 from .environment import detect_cpu_family, for_windows
 
 class DependencyException(MesonException):
-    def __init__(self, *args, **kwargs):
-        MesonException.__init__(self, *args, **kwargs)
+    '''Exceptions raised while trying to find dependencies'''
 
 class Dependency():
     def __init__(self, type_name='unknown'):
@@ -170,9 +169,8 @@ class PkgConfigDependency(Dependency):
                 if not self.silent:
                     mlog.log(*found_msg)
                 if self.required:
-                    raise DependencyException(
-                        'Invalid version of a dependency, needed %s %s found %s.' %
-                        (name, not_found, self.modversion))
+                    m = 'Invalid version of dependency, need {!r} {!r} found {!r}.'
+                    raise DependencyException(m.format(name, not_found, self.modversion))
                 return
         found_msg += [mlog.green('YES'), self.modversion]
         if not self.silent:

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -1443,7 +1443,9 @@ def find_external_dependency(name, environment, kwargs):
     if mesonlib.is_osx():
         fwdep = ExtraFrameworkDependency(name, required)
         if required and not fwdep.found():
-            raise DependencyException('Dependency "%s" not found' % name)
+            m = 'Dependency {!r} not found, tried Extra Frameworks ' \
+                'and Pkg-Config:\n\n' + str(pkg_exc)
+            raise DependencyException(m.format(name))
         return fwdep
     if pkg_exc is not None:
         raise pkg_exc

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -173,12 +173,14 @@ class PkgConfigDependency(Dependency):
                     raise DependencyException(m.format(name, not_found, self.modversion))
                 return
         found_msg += [mlog.green('YES'), self.modversion]
-        if not self.silent:
-            mlog.log(*found_msg)
         # Fetch cargs to be used while using this dependency
         self._set_cargs()
         # Fetch the libraries and library paths needed for using this
         self._set_libs()
+        # Print the found message only at the very end because fetching cflags
+        # and libs can also fail if other needed pkg-config files aren't found.
+        if not self.silent:
+            mlog.log(*found_msg)
 
     def __repr__(self):
         s = '<{0} {1}: {2} {3}>'

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -19,12 +19,10 @@ import platform, subprocess, operator, os, shutil, re
 from glob import glob
 
 class MesonException(Exception):
-    def __init__(self, *args, **kwargs):
-        Exception.__init__(self, *args, **kwargs)
+    '''Exceptions thrown by Meson'''
 
 class EnvironmentException(MesonException):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    '''Exceptions thrown while processing and creating the build environment'''
 
 class File:
     def __init__(self, is_built, subdir, fname):


### PR DESCRIPTION
1. Derive all exceptions correctly from base exceptions

Don't need to define `__init__` and manually call the parent init. Doing so messes up the error message you get by doing `str(exception)` because it includes the current class name in it repeatedly.

2. Print pkg-config error when framework dep isn't found

Without this, macOS users can't figure out why a particular dependency wasn't found because the pkg-config error message gets masked by the fresh and useless `DependencyException`.

3. pkgdep: Print found message after setting cargs/libs

Fetching cflags and libs can also fail if, for instance, the `pkg-config` file for a dependency needed by this package isn't found. Without this, we will print `"Found: YES"` and then `"Found: NO"`.