### PR TITLE
Add prefix before including limits.h in has_function checks

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -716,8 +716,16 @@ class CCompiler(Compiler):
     def has_header(self, hname, prefix, env, extra_args=None, dependencies=None):
         if extra_args is None:
             extra_args = []
-        code = '{}\n#include<{}>\nint someUselessSymbol;'.format(prefix, hname)
-        return self.compiles(code, env, extra_args, dependencies, 'preprocess')
+        code = '''{0}
+        #ifdef __has_include
+         #if !__has_include(<{1}>)
+          #error "Header '{1}' could not be found"
+         #endif
+        #else
+         #include<{1}>
+        #endif'''
+        return self.compiles(code.format(prefix, hname), env, extra_args,
+                             dependencies, 'preprocess')
 
     def has_header_symbol(self, hname, symbol, prefix, env, extra_args=None, dependencies=None):
         if extra_args is None:

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -949,12 +949,13 @@ class CCompiler(Compiler):
         """
         # Define the symbol to something else since it is defined by the
         # includes or defines listed by the user or by the compiler. This may
-        # include, for instance _GNU_SOURCE. Then, undef the symbol to get rid
-        # of it completely.
+        # include, for instance _GNU_SOURCE which must be defined before
+        # limits.h, which includes features.h
+        # Then, undef the symbol to get rid of it completely.
         head = '''
         #define {func} meson_disable_define_of_{func}
-        #include <limits.h>
         {prefix}
+        #include <limits.h>
         #undef {func}
         '''
         # Override any GCC internal prototype and declare our own definition for
@@ -980,8 +981,9 @@ class CCompiler(Compiler):
         user for the function prototype while checking if a function exists.
         """
         # Add the 'prefix', aka defines, includes, etc that the user provides
-        # This may include, for instance _GNU_SOURCE
-        head = '#include <limits.h>\n{prefix}\n'
+        # This may include, for instance _GNU_SOURCE which must be defined
+        # before limits.h, which includes features.h
+        head = '{prefix}\n#include <limits.h>\n'
         # We don't know what the function takes or returns, so return it as an int.
         # Just taking the address or comparing it to void is not enough because
         # compilers are smart enough to optimize it away. The resulting binary

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1057,7 +1057,16 @@ int main(int argc, char **argv) {
         # posix_memalign in the headers to point to that builtin which results
         # in an invalid detection.
         if '#include' not in prefix:
-            code = 'int main() {{ {0}; }}'
+            code = '''
+            int main() {{
+            #ifdef __has_builtin
+                #if !__has_builtin({0})
+                    #error "built-in {0} not found"
+                #endif
+            #else
+                {0};
+            #endif
+            }}'''
             return self.links(code.format('__builtin_' + funcname), env,
                               extra_args, dependencies)
         else:

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1046,6 +1046,10 @@ class CCompiler(Compiler):
         if self.links(templ.format(**fargs), env, extra_args, dependencies):
             return True
 
+        # MSVC does not have compiler __builtin_-s.
+        if self.get_id() == 'msvc':
+            return False
+
         # Detect function as a built-in
         #
         # Some functions like alloca() are defined as compiler built-ins which

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -2473,7 +2473,7 @@ class IntelCCompiler(IntelCompiler, CCompiler):
         return ['-shared']
 
     def has_multi_arguments(self, args, env):
-        return super(IntelCCompiler, self).has_multi_arguments(args + ['-diag-error', '10006'], env)
+        return super().has_multi_arguments(args + ['-diag-error', '10006'], env)
 
 
 class IntelCPPCompiler(IntelCompiler, CPPCompiler):
@@ -2521,7 +2521,7 @@ class IntelCPPCompiler(IntelCompiler, CPPCompiler):
         return self.get_no_optimization_args()
 
     def has_multi_arguments(self, args, env):
-        return super(IntelCPPCompiler, self).has_multi_arguments(args + ['-diag-error', '10006'], env)
+        return super().has_multi_arguments(args + ['-diag-error', '10006'], env)
 
 
 class FortranCompiler(Compiler):

--- a/test cases/common/43 has function/meson.build
+++ b/test cases/common/43 has function/meson.build
@@ -28,6 +28,11 @@ foreach cc : compilers
     assert(cc.has_function('fprintf', prefix : '#include <stdio.h>',
                            args : unit_test_args),
            '"fprintf" function not found with include (on msvc).')
+    # Compiler intrinsics
+    assert(cc.has_function('strcmp'),
+           'strcmp intrinsic should have been found on MSVC')
+    assert(cc.has_function('strcmp', prefix : '#include <string.h>'),
+           'strcmp intrinsic should have been found with #include on MSVC')
   endif
 
   if cc.has_function('hfkerhisadf', prefix : '#include<stdio.h>',

--- a/test cases/common/43 has function/meson.build
+++ b/test cases/common/43 has function/meson.build
@@ -4,6 +4,10 @@ host_system = host_machine.system()
 
 # This is used in the `test_compiler_check_flags_order` unit test
 unit_test_args = '-I/tmp'
+defines_has_builtin = '''#ifndef __has_builtin
+#error "no __has_builtin"
+#endif
+'''
 compilers = [meson.get_compiler('c'), meson.get_compiler('cpp')]
 
 foreach cc : compilers
@@ -40,20 +44,33 @@ foreach cc : compilers
   # We can't check for the C library used here of course, but if it's not
   # implemented in glibc it's probably not implemented in any other 'slimmer'
   # C library variants either, so the check should be safe either way hopefully.
-  if host_system == 'linux'
+  if host_system == 'linux' or host_system == 'darwin'
     assert (cc.has_function('poll', prefix : '#include <poll.h>',
                             args : unit_test_args),
             'couldn\'t detect "poll" when defined by a header')
     lchmod_prefix = '#include <sys/stat.h>\n#include <unistd.h>'
-    assert (not cc.has_function('lchmod', prefix : lchmod_prefix,
-                                args : unit_test_args),
-            '"lchmod" check should have failed')
+    if host_system == 'linux'
+      assert (not cc.has_function('lchmod', prefix : lchmod_prefix,
+                                  args : unit_test_args),
+              '"lchmod" check should have failed')
+    else
+      # macOS and *BSD have lchmod
+      assert (cc.has_function('lchmod', prefix : lchmod_prefix,
+                                  args : unit_test_args),
+              '"lchmod" check should have succeeded')
+    endif
     # Check that built-ins are found properly both with and without headers
     assert(cc.has_function('alloca', args : unit_test_args),
-           'built-in alloca must be found on Linux')
+           'built-in alloca must be found on ' + host_system)
     assert(cc.has_function('alloca', prefix : '#include <alloca.h>',
            args : unit_test_args),
-           'built-in alloca must be found on Linux with #include')
+           'built-in alloca must be found with #include')
+    if not cc.compiles(defines_has_builtin, args : unit_test_args)
+      assert(not cc.has_function('alloca',
+             prefix : '#include <alloca.h>\n#undef alloca',
+             args : unit_test_args),
+             'built-in alloca must not be found with #include and #undef')
+    endif
   endif
 
   # For some functions one needs to define _GNU_SOURCE before including the

--- a/test cases/common/43 has function/meson.build
+++ b/test cases/common/43 has function/meson.build
@@ -31,12 +31,16 @@ foreach cc : compilers
     error('Found non-existent function "hfkerhisadf".')
   endif
 
+  if cc.has_function('hfkerhisadf', args : unit_test_args)
+    error('Found non-existent function "hfkerhisadf".')
+  endif
+
   # With glibc on Linux lchmod is a stub that will always return an error,
   # we want to detect that and declare that the function is not available.
   # We can't check for the C library used here of course, but if it's not
   # implemented in glibc it's probably not implemented in any other 'slimmer'
   # C library variants either, so the check should be safe either way hopefully.
-  if host_system == 'linux' and cc.get_id() == 'gcc'
+  if host_system == 'linux'
     assert (cc.has_function('poll', prefix : '#include <poll.h>',
                             args : unit_test_args),
             'couldn\'t detect "poll" when defined by a header')


### PR DESCRIPTION
prefix might define `_GNU_SOURCE`, which *must* be defined before your first include of `limits.h`, so we must define it first. There's not really any downsides to including `limits.h` after the prefix.

Also has a bunch of other compiler check-related cleanups and speedups.