### PR TITLE
Add the notion of Component

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -132,6 +132,49 @@ The object returned by `build_target` and all convenience wrappers for
 [`library`](#library) has methods that are documented in the [object
 methods section](#build-target-object) below.
 
+### component()
+
+**Since: 0.XX**
+
+``` meson
+some_component = component(<component_name>,
+                           targets: [],
+                           dependencies: [])
+```
+
+Create a component object to pass in target definition so they are optionally built
+depending on user choices.
+
+The component name will generate a new command line option based on its name with tree
+options:
+
+  * `enabled`: The component is enabled, meson configuration fails if a dependency is missing.
+  * `disabled`: The component is disabled not matter what
+  * `auto`: The component is enabled if all dependency are resolved, and disabled otherwise.
+    It is the default value.
+
+___Example___:
+
+Create a component which depends on some external dependency and start building an
+executable depending on whether user activated it or not (and depending on the presence
+of the dependency):
+
+``` meson
+some_dep = dependency('some-dep', required: false)
+my_component = component(<component_name>, dependencies: [some_dep])
+executable(some_component,
+           dependencies: [some_dep],
+           component: my_component)
+```
+
+**Arguments**:
+
+  * `name`: (positional first argument): The name of the component.
+  * `dependency`: A list of [dependencies](#dependency-object) or
+    [components](#component-object) this component depends on.
+
+Returns a [Component](#component-object).
+
 ### configuration_data()
 
 ``` meson
@@ -310,9 +353,13 @@ otherwise. This function supports the following keyword arguments:
   `>1.0.0`, `<=2.3.5` or `3.1.4` for exact matching. (*Added 0.37.0*)
   You can also specify multiple restrictions by passing a list to this
   keyword argument, such as: `['>=3.14.0', '<=4.1.0']`.
+- `components`, specifies a list of component on which the dependency applies,
+  avoiding any check if the component is disabled. This implies adding the
+  new dependency to the component dependency list
 
 The returned object also has methods that are documented in the
 [object methods section](#dependency-object) below.
+
 
 ### error()
 
@@ -1553,6 +1600,16 @@ result file. The replacement assumes a file with C syntax. If your
 generated file is source code in some other language, you probably
 don't want to add a description field because it most likely will
 cause a syntax error.
+
+### `component` object
+
+This object is returned by [`component()`](#component) and is an opaque object representing it.
+
+- `targets()`: Lists all the targets belonging to the component.
+- `enabled()`: Whether the component is enabled or not.
+- `value()`: Current value in [‘enabled’, ‘disabled’, ‘auto’]
+- `dependencies()`: Returns the list of dependency this component has
+- `add_dependencies()`: Adds provided dependencies to the list of dependencies
 
 ### `custom target` object
 

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1374,6 +1374,13 @@ the following methods:
 
 - `version()` returns the compiler's version number as a string.
 
+- `find_dependency(depname)` returns a [`dependency`](#dependency-object). Arguments:
+    * `libs`: A list of library name to be found and used when linking against the return dependency
+    * `headers`: A list of header names to be found for the dependency to be usable
+    * `headers_symbols`: A list of 2 tuples in the form `[['header1_name.h', 'symbol1_name']]`
+    * `required`: Weather the dependency is required
+    * `links`: A list of snippets to be compiled and linked for the dependency to be usable
+
 The following keyword arguments can be used:
 
 - `args` can be used to pass a list of compiler arguments that are

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -633,7 +633,7 @@ class Backend:
     def get_build_by_default_targets(self):
         result = OrderedDict()
         # Get all build and custom targets that must be built by default
-        for name, t in self.build.get_targets().items():
+        for name, t in self.build.get_targets(filter_disabled=True).items():
             if t.build_by_default or t.install or t.build_always:
                 result[name] = t
         # Get all targets used as test executables and arguments. These must

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -305,6 +305,8 @@ int dummy;
         return True
 
     def generate_target(self, target, outfile):
+        if not target.should_build():
+            return
         if isinstance(target, build.CustomTarget):
             self.generate_custom_target(target, outfile)
         if isinstance(target, build.RunTarget):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -806,7 +806,8 @@ This will become a hard error in a future Meson release.''')
                 self.external_deps.append(extpart)
                 # Deps of deps.
                 self.add_deps(dep.ext_deps)
-            elif isinstance(dep, dependencies.ExternalDependency):
+            elif isinstance(dep, (dependencies.ExternalDependency,
+                            dependencies.CustomDependency)):
                 self.external_deps.append(dep)
                 self.process_sourcelist(dep.get_sources())
             elif isinstance(dep, BuildTarget):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -819,7 +819,7 @@ This will become a hard error in a future Meson release.''')
         return self.generated
 
     def should_install(self):
-        return self.need_install
+        return self.need_install and self.should_build()
 
     def has_pch(self):
         return len(self.pch) > 0
@@ -1666,7 +1666,7 @@ class CustomTarget(Target):
         return self.dependencies
 
     def should_install(self):
-        return self.install
+        return self.install and self.should_build()
 
     def get_custom_install_dir(self):
         return self.install_dir

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -136,6 +136,11 @@ class UserComboOption(UserOption):
             raise MesonException('Value %s not one of accepted values.' % value)
         return value
 
+class ComponentOption(UserComboOption):
+    def __init__(self, name, description, value):
+        super().__init__(name, description, ['enabled', 'disabled', 'auto'],
+                         value)
+
 class UserStringArrayOption(UserOption):
     def __init__(self, name, description, value, **kwargs):
         super().__init__(name, description, kwargs.get('choices', []))
@@ -310,6 +315,8 @@ def get_builtin_option_choices(optname):
             return None
         elif builtin_options[optname][0] == UserBooleanOption:
             return [True, False]
+        elif builtin_options[optname][0] == ComponentOption:
+            return ['enabled', 'disabled', 'auto']
         else:
             return builtin_options[optname][2]
     else:
@@ -361,6 +368,7 @@ builtin_options = {
     'layout':          [UserComboOption, 'Build directory layout.', ['mirror', 'flat'], 'mirror'],
     'default_library': [UserComboOption, 'Default library type.', ['shared', 'static'], 'shared'],
     'backend':         [UserComboOption, 'Backend to use.', backendlist, 'ninja'],
+    'components_default_value':  [ComponentOption, 'Enable/Disable all components that default to autodetection.', 'auto'],
     'stdsplit':        [UserBooleanOption, 'Split stdout and stderr in test logs.', True],
     'errorlogs':       [UserBooleanOption, "Whether to print the logs from failing tests.", True],
 }

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -15,7 +15,8 @@
 from .base import (  # noqa: F401
     Dependency, DependencyException, DependencyMethods, ExternalProgram,
     ExternalDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
-    PkgConfigDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language)
+    PkgConfigDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language,
+    CustomDependency)
 from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDependency
 from .misc import (BoostDependency, MPIDependency, Python3Dependency, ThreadDependency, PcapDependency, CupsDependency)
 from .platform import AppleFrameworks

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -118,6 +118,19 @@ class Dependency:
         raise NotImplementedError('{!r} is not a pkgconfig dependency'.format(self.name))
 
 
+class CustomDependency(Dependency):
+    def __init__(self, type_name, found, compile_args, link_args, libraries, deps,
+                 kwargs):
+        super().__init__(type_name, kwargs)
+        self.is_found = found
+        self.compile_args = compile_args
+        self.link_args = link_args
+        for lib in libraries:
+            self.link_args += lib.get_link_args()
+        self.dependencies = deps
+        self.libraries = libraries
+
+
 class InternalDependency(Dependency):
     def __init__(self, version, incdirs, compile_args, link_args, libraries, sources, ext_deps):
         super().__init__('internal', {})

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -132,16 +132,17 @@ class CustomDependency(Dependency):
 
 
 class InternalDependency(Dependency):
-    def __init__(self, version, incdirs, compile_args, link_args, libraries, sources, ext_deps):
+    def __init__(self, version, incdirs, compile_args, link_args, libraries, sources, ext_deps,
+                 found=True):
         super().__init__('internal', {})
         self.version = version
-        self.is_found = True
         self.include_directories = incdirs
         self.compile_args = compile_args
         self.link_args = link_args
         self.libraries = libraries
         self.sources = sources
         self.ext_deps = ext_deps
+        self.is_found = found
 
 
 class ExternalDependency(Dependency):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2452,7 +2452,8 @@ class Interpreter(InterpreterBase):
 
         name = args[0]
         deps = mesonlib.flatten(kwargs.get('dependencies', []))
-        default_value = kwargs.get('default', 'auto')
+        default_value = kwargs.get('default',
+                                   self.coredata.builtins['components_default_value'].value)
         if self.is_subproject():
             option_name = self.subproject + ':' + name
             description = 'Enable %s component for project "%s"' % (name, self.subproject)
@@ -2464,9 +2465,7 @@ class Interpreter(InterpreterBase):
             self.subproject, self.build.environment.cmd_line_options.projectoptions)
         enabled = command_line_options.get(option_name, default_value)
 
-        value = coredata.UserComboOption(option_name, description,
-                                         ['enabled', 'disabled', 'auto'],
-                                         enabled)
+        value = coredata.ComponentOption(option_name, description, enabled)
         self.build.environment.merge_options({option_name: value})
 
         if self.is_subproject() and not name.startswith(self.subproject + ':'):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2645,7 +2645,18 @@ class Interpreter(InterpreterBase):
         if not isinstance(args[0], str):
             raise InterpreterException('First argument of test must be a string.')
         exe = args[1]
-        if not isinstance(exe, (ExecutableHolder, JarHolder, ExternalProgramHolder)):
+        if isinstance(exe, ExecutableHolder):
+            disabling_components = []
+            for component in exe.held_object.components:
+                if component.func_enabled():
+                    continue
+                disabling_components.append(component.name)
+
+            if disabling_components:
+                mlog.log('Test "', mlog.bold(args[0]), '" disabled by ',
+                         'components: ', mlog.red(str(disabling_components)), sep='')
+                return
+        elif not isinstance(exe, (JarHolder, ExternalProgramHolder)):
             if isinstance(exe, mesonlib.File):
                 exe = self.func_find_program(node, (args[1], ), {})
             else:

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -62,6 +62,7 @@ add_builtin_argument('default-library')
 add_builtin_argument('warnlevel', dest='warning_level')
 add_builtin_argument('stdsplit', action='store_false')
 add_builtin_argument('errorlogs', action='store_false')
+add_builtin_argument('components-default-value')
 
 def wrapmodetype(string):
     try:

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -133,6 +133,13 @@ class PkgConfigModule(ExtensionModule):
         name = kwargs.get('name', None)
         if not isinstance(name, str):
             raise mesonlib.MesonException('Name not specified.')
+
+        for l in libs + priv_libs:
+            if isinstance(l, (build.SharedLibrary, build.StaticLibrary)):
+                if not l.should_build():
+                    mlog.log("Not building %s as depending library %s is not being built" % (
+                        name, l.name))
+                    return ModuleReturnValue(None, [])
         filebase = kwargs.get('filebase', name)
         if not isinstance(filebase, str):
             raise mesonlib.MesonException('Filebase must be a string.')

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -73,20 +73,29 @@ class OptionInterpreter:
         self.options = {}
         self.subproject = subproject
         self.sbprefix = subproject + ':'
-        self.cmd_line_options = {}
+        self.cmd_line_options = self.get_command_line_options(subproject,
+                                                              command_line_options)
+
+    @staticmethod
+    def get_command_line_options(subproject, command_line_options):
+        sbprefix = subproject + ':'
+        cmd_line_options = {}
         for o in command_line_options:
-            if self.subproject != '': # Strip the beginning.
+            if subproject != '': # Strip the beginning.
                 # Ignore options that aren't for this subproject
-                if not o.startswith(self.sbprefix):
+                if not o.startswith(sbprefix):
                     continue
             try:
                 (key, value) = o.split('=', 1)
             except ValueError:
                 raise OptionException('Option {!r} must have a value separated by equals sign.'.format(o))
             # Ignore subproject options if not fetching subproject options
-            if self.subproject == '' and ':' in key:
+            if subproject == '' and ':' in key:
                 continue
-            self.cmd_line_options[key] = value
+
+            cmd_line_options[key] = value
+
+        return cmd_line_options
 
     def process(self, option_file):
         try:

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -249,6 +249,9 @@ def validate_install(srcdir, installdir, compiler):
             if fname not in expected and not fname.endswith('.pdb') and compiler == 'cl':
                 ret_msg += 'Extra file {0} found.\n'.format(fname)
 
+    if ret_msg:
+        ret_msg += 'Found files: {0}.\n'.format(found)
+
     return ret_msg
 
 def log_text_file(logfile, testdir, stdo, stde):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1956,26 +1956,27 @@ endian = 'little'
     def test_components(self):
         testdir = os.path.join(self.common_test_dir, '159 components')
         test_data = [
-            (['-Dhello1=disabled'], 'disabled', 'enabled', 'disabled', 'enabled', 'enabled'),
+            (['-Dhello1=disabled'], 'disabled', 'enabled', 'disabled', 'enabled', 'enabled', 'enabled'),
             # hello1 is disabled by the lib
-            (['-Dlib=disabled'], 'disabled', 'enabled', 'disabled', 'enabled', 'enabled'),
+            (['-Dlib=disabled'], 'disabled', 'enabled', 'disabled', 'enabled', 'enabled', 'disabled'),
             (['-Dhello1=disabled', '-Dhello2=disabled'],
-             'disabled', 'disabled', 'disabled', 'enabled', 'enabled'),
+             'disabled', 'disabled', 'disabled', 'enabled', 'enabled', 'enabled'),
             (['-Dhello1=disabled', '-Dhello2=disabled', '-Dhello3=enabled'],
-             'disabled', 'disabled', 'enabled', 'enabled', 'enabled'),
-            (['-Dsubcomponent=disabled'], 'enabled', 'enabled', 'disabled', 'disabled', 'disabled'),
-            (['-Dsubsubcomponent=disabled'], 'enabled', 'enabled', 'disabled', 'enabled', 'disabled'),
-            (['--components-default-value=disabled'], 'disabled', 'disabled', 'disabled', 'disabled', 'disabled'),
-            (['--components-default-value=disabled', '-Dhello3=enabled'], 'disabled', 'disabled', 'enabled', 'disabled', 'disabled'),
+             'disabled', 'disabled', 'enabled', 'enabled', 'enabled', 'enabled'),
+            (['-Dsubcomponent=disabled'], 'enabled', 'enabled', 'disabled', 'disabled', 'disabled', 'enabled'),
+            (['-Dsubsubcomponent=disabled'], 'enabled', 'enabled', 'disabled', 'enabled', 'disabled', 'enabled'),
+            (['--components-default-value=disabled'], 'disabled', 'disabled', 'disabled', 'disabled', 'disabled', 'disabled'),
+            (['--components-default-value=disabled', '-Dhello3=enabled'], 'disabled', 'disabled', 'enabled', 'disabled', 'disabled', 'disabled'),
         ]
 
-        for (options, ehello1, ehello2, ehello3, esubhello, esubsubhello) in test_data:
+        for (options, ehello1, ehello2, ehello3, esubhello, esubsubhello, epkgfile) in test_data:
             self.setUp()
             hello1 = os.path.join(self.builddir, 'hello1')
             hello2 = os.path.join(self.builddir, 'hello2')
             hello3 = os.path.join(self.builddir, 'hello3')
             subhello = os.path.join(self.builddir, 'subdir', 'subhello')
             subsubhello = os.path.join(self.builddir, 'subdir', 'subsubdir', 'subsubhello')
+            pkgfile = os.path.join(self.builddir, 'meson-private', 'simple.pc')
 
             self.init(testdir, options)
             self.build()
@@ -1985,6 +1986,7 @@ endian = 'little'
             self.assertEqual(os.path.exists(hello3), ehello3 == 'enabled', str(options))
             self.assertEqual(os.path.exists(subhello), esubhello == 'enabled', str(options))
             self.assertEqual(os.path.exists(subsubhello), esubsubhello == 'enabled', str(options))
+            self.assertEqual(os.path.exists(pkgfile), epkgfile == 'enabled', str(options))
 
     def test_enabled_component_with_missing_dep_fails(self):
         testdir = os.path.join(self.common_test_dir, '159 components')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1957,6 +1957,8 @@ endian = 'little'
         testdir = os.path.join(self.common_test_dir, '159 components')
         test_data = [
             (['-Dhello1=disabled'], 'disabled', 'enabled', 'disabled', 'enabled', 'enabled'),
+            # hello1 is disabled by the lib
+            (['-Dlib=disabled'], 'disabled', 'enabled', 'disabled', 'enabled', 'enabled'),
             (['-Dhello1=disabled', '-Dhello2=disabled'],
              'disabled', 'disabled', 'disabled', 'enabled', 'enabled'),
             (['-Dhello1=disabled', '-Dhello2=disabled', '-Dhello3=enabled'],

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1966,7 +1966,7 @@ endian = 'little'
             (['-Dsubcomponent=disabled'], 'enabled', 'enabled', 'disabled', 'disabled', 'disabled'),
             (['-Dsubsubcomponent=disabled'], 'enabled', 'enabled', 'disabled', 'enabled', 'disabled'),
             (['--components-default-value=disabled'], 'disabled', 'disabled', 'disabled', 'disabled', 'disabled'),
-            (['--components-default-value=disabled', '-Dhello1=enabled'], 'enabled', 'disabled', 'disabled', 'disabled', 'disabled'),
+            (['--components-default-value=disabled', '-Dhello3=enabled'], 'disabled', 'disabled', 'enabled', 'disabled', 'disabled'),
         ]
 
         for (options, ehello1, ehello2, ehello3, esubhello, esubsubhello) in test_data:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1990,6 +1990,19 @@ endian = 'little'
         with self.assertRaises(subprocess.CalledProcessError):
             self.init(testdir, ['-Dwithdep1=enabled'])
 
+    def test_components_disable_tests(self):
+        testdir = os.path.join(self.common_test_dir, '159 components')
+        self.setUp()
+        self.init(testdir)
+        testlist = self._run(self.mtest_command + ['--list'], workdir=self.builddir)
+        self.assertTrue("No tests defined." in testlist, testlist)
+
+        self.setUp()
+        self.init(testdir, ['-Dhello3=enabled'])
+        testlist = self._run(self.mtest_command + ['--list'], workdir=self.builddir)
+        self.assertTrue("disabled_by_default_test" in testlist, "%s not in '''%s'''" % (
+            'disabled_by_default_test', testlist))
+
     def test_adding_missing_dep_with_enabled_component_fails(self):
         testdir = os.path.join(self.common_test_dir, '159 components')
         self.setUp()

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1963,6 +1963,8 @@ endian = 'little'
              'disabled', 'disabled', 'enabled', 'enabled', 'enabled'),
             (['-Dsubcomponent=disabled'], 'enabled', 'enabled', 'disabled', 'disabled', 'disabled'),
             (['-Dsubsubcomponent=disabled'], 'enabled', 'enabled', 'disabled', 'enabled', 'disabled'),
+            (['--components-default-value=disabled'], 'disabled', 'disabled', 'disabled', 'disabled', 'disabled'),
+            (['--components-default-value=disabled', '-Dhello1=enabled'], 'enabled', 'disabled', 'disabled', 'disabled', 'disabled'),
         ]
 
         for (options, ehello1, ehello2, ehello3, esubhello, esubsubhello) in test_data:

--- a/test cases/common/158 compiler find dependency/meson.build
+++ b/test cases/common/158 compiler find dependency/meson.build
@@ -1,0 +1,24 @@
+project('compiler find dependency', 'c', 'cpp')
+
+cc = meson.get_compiler('c')
+cpp = meson.get_compiler('cpp')
+
+foreach comp : [cc, cpp]
+  assert (comp.find_dependency('stdio_int_' + comp.get_id(),
+    headers_symbols: [['stdio.h', 'int'],]).found(),
+    'base types should always be available')
+  assert (not comp.find_dependency('limits_failure_' + comp.get_id(),
+    headers_symbols: [['limits.h', 'guint64'],], required: false).found(),
+    'guint64 is not defined in limits.h')
+endforeach
+
+if cc.find_library('z', required : false).found()
+  zlib_dep = cc.find_dependency('zlib', libs: ['z'])
+  assert (zlib_dep.found(), 'zlib has been found before.')
+
+  assert (not cc.find_dependency('zlib_wrong_link', libs: ['z'],
+    links: '''#include <glib.h>''', required: false).found(),
+    '<glib.h> should not be includable.')
+
+  executable('ztest', 'ztest.c', dependencies: zlib_dep)
+endif

--- a/test cases/common/158 compiler find dependency/ztest.c
+++ b/test cases/common/158 compiler find dependency/ztest.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <string.h>  // for strlen
+#include <assert.h>
+#include "zlib.h"
+
+// Inspired from: http://stackoverflow.com/questions/7540259/deflate-and-inflate-zlib-h-in-c
+int main(int argc, char* argv[])
+{
+    // original string len = 36
+    char a[50] = "Hello Hello Hello Hello Hello Hello!";
+    char b[50];
+
+    // deflate a into b. (that is, compress a into b)
+    // zlib struct
+    z_stream defstream;
+    defstream.zalloc = Z_NULL;
+    defstream.zfree = Z_NULL;
+    defstream.opaque = Z_NULL;
+    // setup "a" as the input and "b" as the compressed output
+    defstream.avail_in = (uInt)strlen(a)+1; // size of input, string + terminator
+    defstream.next_in = (Bytef *)a; // input char array
+    defstream.avail_out = (uInt)sizeof(b); // size of output
+    defstream.next_out = (Bytef *)b; // output char array
+
+    // the actual compression work.
+    deflateInit(&defstream, Z_BEST_COMPRESSION);
+    deflate(&defstream, Z_FINISH);
+    deflateEnd(&defstream);
+
+    return 0;
+}

--- a/test cases/common/159 components/hello.c
+++ b/test cases/common/159 components/hello.c
@@ -1,0 +1,7 @@
+#include<stdio.h>
+
+int main(int argc, char **argv) {
+    printf("Hello\n");
+    return 0;
+}
+

--- a/test cases/common/159 components/installed_files.txt
+++ b/test cases/common/159 components/installed_files.txt
@@ -1,0 +1,4 @@
+usr/bin/hello2?exe
+usr/bin/hello1?exe
+usr/lib/pkgconfig/simple.pc
+++

--- a/test cases/common/159 components/meson.build
+++ b/test cases/common/159 components/meson.build
@@ -3,13 +3,17 @@ project('component', 'c')
 libcomp = component('lib')
 lib = library('simplelib', 'simplelib.c', components: libcomp)
 
+lib1comp = component('lib1')
+lib1 = library('simplelib1', 'simplelib.c', components: lib1comp)
+lib1_dep = declare_dependency(link_with: lib1)
+
 tcomponent_default_option = component('hello1')
 component_disable_by_default = component('hello3', default: 'disabled')
-
-hello1 = executable('hello_with_lib', sources: 'hello.c',
+hello1 = executable('hello1', sources: 'hello.c',
   components: tcomponent_default_option,
   link_with: lib)
 hello2 = executable('hello2', sources: 'hello.c',
+  dependencies: lib1_dep,
   components: component('hello2'))
 hello3 = executable('hello3', sources: 'hello.c',
         components: [component_disable_by_default])

--- a/test cases/common/159 components/meson.build
+++ b/test cases/common/159 components/meson.build
@@ -1,0 +1,35 @@
+project('component', 'c')
+
+tcomponent_default_option = component('hello1')
+component_disable_by_default = component('hello3', default: 'disabled')
+
+hello1 = executable('hello1', sources: 'hello.c',
+  components: tcomponent_default_option)
+hello2 = executable('hello2', sources: 'hello.c',
+  components: component('hello2'))
+hello3 = executable('hello3', sources: 'hello.c',
+        components: [component_disable_by_default])
+
+# All targets created in subdir/ will be in a new component called 'subcomponent'
+subdir('subdir', components: [component('subcomponent')])
+
+fakedep = dependency('nowaythisdepexists', required : false)
+withdep1 = component('withdep1', dependencies: [fakedep])
+assert(withdep1.dependencies() == [fakedep], 'component.dependencies() failed')
+executable('withdep1', sources: 'hello.c',
+           dependencies: fakedep,
+           components: withdep1)
+
+disabled_component = component('disabled', default: 'disabled')
+fakedep2 = dependency('required_not_existing_with_disabled_component',
+    components: disabled_component)
+assert(not fakedep2.found(),
+  'required_not_existing_with_disabled_component can not possibly exist' +
+  ' and it was disabled anyway.')
+
+n_component = component('disabled_adding_dep_component')
+disabling_n_component_dep = dependency('disabling_n_component', required: false)
+
+n_component.add_dependencies([disabling_n_component_dep])
+assert(not n_component.enabled(), 'n_component should have been disabled by disabling_n_component' +
+  'dependency')

--- a/test cases/common/159 components/meson.build
+++ b/test cases/common/159 components/meson.build
@@ -1,7 +1,7 @@
 project('component', 'c')
 
 libcomp = component('lib')
-lib = library('simplelib', 'simplelib.c', components: libcomp)
+lib = library('simplelib', 'simplelib.c', components: libcomp, install: true)
 
 pkgg = import('pkgconfig')
 pkgg.generate(
@@ -21,12 +21,12 @@ tcomponent_default_option = component('hello1')
 component_disable_by_default = component('hello3', default: 'disabled')
 hello1 = executable('hello1', sources: 'hello.c',
   components: tcomponent_default_option,
-  link_with: lib)
+  link_with: lib, install: true)
 hello2 = executable('hello2', sources: 'hello.c',
   dependencies: lib1_dep,
-  components: component('hello2'))
+  components: component('hello2'), install: true)
 hello3 = executable('hello3', sources: 'hello.c',
-        components: [component_disable_by_default])
+        components: [component_disable_by_default], install: true)
 
 test('disabled_by_default_test', hello3)
 
@@ -38,7 +38,8 @@ withdep1 = component('withdep1', dependencies: [fakedep])
 assert(withdep1.dependencies() == [fakedep], 'component.dependencies() failed')
 executable('withdep1', sources: 'hello.c',
            dependencies: fakedep,
-           components: withdep1)
+           components: withdep1,
+           install: true)
 
 disabled_component = component('disabled', default: 'disabled')
 fakedep2 = dependency('required_not_existing_with_disabled_component',

--- a/test cases/common/159 components/meson.build
+++ b/test cases/common/159 components/meson.build
@@ -5,10 +5,13 @@ component_disable_by_default = component('hello3', default: 'disabled')
 
 hello1 = executable('hello1', sources: 'hello.c',
   components: tcomponent_default_option)
+
 hello2 = executable('hello2', sources: 'hello.c',
   components: component('hello2'))
 hello3 = executable('hello3', sources: 'hello.c',
         components: [component_disable_by_default])
+
+test('disabled_by_default_test', hello3)
 
 # All targets created in subdir/ will be in a new component called 'subcomponent'
 subdir('subdir', components: [component('subcomponent')])

--- a/test cases/common/159 components/meson.build
+++ b/test cases/common/159 components/meson.build
@@ -3,6 +3,16 @@ project('component', 'c')
 libcomp = component('lib')
 lib = library('simplelib', 'simplelib.c', components: libcomp)
 
+pkgg = import('pkgconfig')
+pkgg.generate(
+  libraries : [lib],
+  subdirs : '.',
+  version : '1.0',
+  name : 'simplelib',
+  filebase : 'simple',
+  description : 'A simple demo library.',
+)
+
 lib1comp = component('lib1')
 lib1 = library('simplelib1', 'simplelib.c', components: lib1comp)
 lib1_dep = declare_dependency(link_with: lib1)

--- a/test cases/common/159 components/meson.build
+++ b/test cases/common/159 components/meson.build
@@ -1,11 +1,14 @@
 project('component', 'c')
 
+libcomp = component('lib')
+lib = library('simplelib', 'simplelib.c', components: libcomp)
+
 tcomponent_default_option = component('hello1')
 component_disable_by_default = component('hello3', default: 'disabled')
 
-hello1 = executable('hello1', sources: 'hello.c',
-  components: tcomponent_default_option)
-
+hello1 = executable('hello_with_lib', sources: 'hello.c',
+  components: tcomponent_default_option,
+  link_with: lib)
 hello2 = executable('hello2', sources: 'hello.c',
   components: component('hello2'))
 hello3 = executable('hello3', sources: 'hello.c',

--- a/test cases/common/159 components/simplelib.c
+++ b/test cases/common/159 components/simplelib.c
@@ -1,6 +1,5 @@
 #include "simplelib.h"
 
-int simple_function() {
+int DLL_PUBLIC simple_function() {
     return 42;
 }
-

--- a/test cases/common/159 components/simplelib.c
+++ b/test cases/common/159 components/simplelib.c
@@ -1,0 +1,6 @@
+#include "simplelib.h"
+
+int simple_function() {
+    return 42;
+}
+

--- a/test cases/common/159 components/simplelib.h
+++ b/test cases/common/159 components/simplelib.h
@@ -1,2 +1,12 @@
-int simple_function();
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
 
+int DLL_PUBLIC simple_function();

--- a/test cases/common/159 components/simplelib.h
+++ b/test cases/common/159 components/simplelib.h
@@ -1,0 +1,2 @@
+int simple_function();
+

--- a/test cases/common/159 components/subdir/meson.build
+++ b/test cases/common/159 components/subdir/meson.build
@@ -1,0 +1,5 @@
+subhello = executable('subhello', sources: '../hello.c')
+
+# All targets created in subdir/ will be in a new component called 'subcomponent'
+subdir('subsubdir',
+  components: [component('subsubcomponent')])

--- a/test cases/common/159 components/subdir/subsubdir/meson.build
+++ b/test cases/common/159 components/subdir/subsubdir/meson.build
@@ -1,0 +1,1 @@
+subsubhello = executable('subsubhello', sources: '../../hello.c')


### PR DESCRIPTION
Components is basically a set of target on which we bind a user
option to enable or disable it.

This is basically used to auto generate options to enable and disable
certain parts of a build.

In GStreamer we have many plugins and the user/packager often need
to be able to explicitely say what they want to build and what not. Currently
we would need to add **many** option to allow that and have `if option(xxx)` all
around. The notion of components allows us to do it all very simply.

There are several ways to create a component:

* Creating explicitely in the meson.build file:

```meson
component = component('componentname',
    targets: [],
    enabled: false, # disabled by default, meaning the option is
                    # --enable-componentname instead of the default
                    # --disable-componentname
    dependencies: [another_component], # @componentname is disabled
                                       # if @another_component is disabled
)
```

* Specifying it as a string or reusing previsouly creating one creating a target

```meson
target = library(..., components: ['componentname'])
```

* Specifying it as a string or reusing previsouly creating one for all targets in a subdir

It means that all targets created inside those subdirectories will be contained in
the specified components. You can do so with:

```meson
subdir('somesubdir', components: 'componentname')
```