### PR TITLE
Fix an uninitialized variable access error.

### DIFF
--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -392,6 +392,8 @@ class InterpreterBase:
             return self.int_method_call(obj, method_name, args)
         if isinstance(obj, list):
             return self.array_method_call(obj, method_name, self.reduce_arguments(args)[0])
+        if isinstance(obj, mesonlib.File):
+            raise InvalidArguments('File object "%s" is not callable.' % obj)
         if not isinstance(obj, InterpreterObject):
             raise InvalidArguments('Variable "%s" is not callable.' % object_name)
         (args, kwargs) = self.reduce_arguments(args)


### PR DESCRIPTION
To reproduce, one could write:

    foo = files('foo.c')
    foo[0].path()

and get:

    Traceback (most recent call last):
    [snip]
      File "/home/trhd/Projects/meson/mesonbuild/interpreterbase.py", line 398, in method_call
        raise InvalidArguments('Variable "%s" is not callable.' % object_name)
    UnboundLocalError: local variable 'object_name' referenced before assignment

Fix this by handling file objects separately.