### PR TITLE
Run unit tests on more platforms, and more

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -215,13 +215,13 @@ class Backend:
         exe_data = os.path.join(self.environment.get_scratch_dir(), scratch_file)
         with open(exe_data, 'wb') as f:
             if isinstance(exe, dependencies.ExternalProgram):
-                exe_fullpath = exe.fullpath
+                exe_cmd = exe.get_command()
                 exe_needs_wrapper = False
             elif isinstance(exe, (build.BuildTarget, build.CustomTarget)):
-                exe_fullpath = [self.get_target_filename_abs(exe)]
+                exe_cmd = [self.get_target_filename_abs(exe)]
                 exe_needs_wrapper = exe.is_cross
             else:
-                exe_fullpath = [exe]
+                exe_cmd = [exe]
                 exe_needs_wrapper = False
             is_cross = exe_needs_wrapper and \
                 self.environment.is_cross_build() and \
@@ -235,7 +235,7 @@ class Backend:
                 extra_paths = self.determine_windows_extra_paths(exe)
             else:
                 extra_paths = []
-            es = ExecutableSerialisation(basename, exe_fullpath, cmd_args, env,
+            es = ExecutableSerialisation(basename, exe_cmd, cmd_args, env,
                                          is_cross, exe_wrapper, workdir,
                                          extra_paths, capture)
             pickle.dump(es, f)
@@ -444,9 +444,9 @@ class Backend:
         for t in tests:
             exe = t.get_exe()
             if isinstance(exe, dependencies.ExternalProgram):
-                fname = exe.fullpath
+                cmd = exe.get_command()
             else:
-                fname = [os.path.join(self.environment.get_build_dir(), self.get_target_filename(t.get_exe()))]
+                cmd = [os.path.join(self.environment.get_build_dir(), self.get_target_filename(t.get_exe()))]
             is_cross = self.environment.is_cross_build() and \
                 self.environment.cross_info.need_cross_compiler() and \
                 self.environment.cross_info.need_exe_wrapper()
@@ -471,7 +471,7 @@ class Backend:
                     cmd_args.append(self.get_target_filename(a))
                 else:
                     raise MesonException('Bad object in test command.')
-            ts = TestSerialisation(t.get_name(), t.suite, fname, is_cross, exe_wrapper,
+            ts = TestSerialisation(t.get_name(), t.suite, cmd, is_cross, exe_wrapper,
                                    t.is_parallel, cmd_args, t.env, t.should_fail,
                                    t.timeout, t.workdir, extra_paths)
             arr.append(ts)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -395,7 +395,7 @@ class Vs2010Backend(backends.Backend):
             if isinstance(i, build.BuildTarget):
                 cmd.append(os.path.join(self.environment.get_build_dir(), self.get_target_filename(i)))
             elif isinstance(i, dependencies.ExternalProgram):
-                cmd += i.fullpath
+                cmd += i.get_command()
             else:
                 cmd.append(i)
         cmd_templ = '''"%s" ''' * len(cmd)

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -564,6 +564,9 @@ class ExternalLibrary(Dependency):
     def found(self):
         return self.is_found
 
+    def get_name(self):
+        return self.name
+
     def get_link_args(self):
         return self.link_args
 

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -120,8 +120,8 @@ class PkgConfigDependency(Dependency):
                 if self.required:
                     raise DependencyException('Pkg-config binary missing from cross file')
             else:
-                potential_pkgbin = ExternalProgram(environment.cross_info.config['binaries'].get('pkgconfig', 'non_existing_binary'),
-                                                   silent=True)
+                pkgname = environment.cross_info.config['binaries']['pkgconfig']
+                potential_pkgbin = ExternalProgram(pkgname, silent=True)
                 if potential_pkgbin.found():
                     # FIXME, we should store all pkg-configs in ExternalPrograms.
                     # However that is too destabilizing a change to do just before release.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1421,7 +1421,8 @@ class Interpreter(InterpreterBase):
         elif isinstance(cmd, str):
             cmd = [cmd]
         else:
-            raise InterpreterException('First argument is of incorrect type.')
+            raise InterpreterException('First argument should be find_program() '
+                                       'or string, not {!r}'.format(cmd))
         expanded_args = []
         for a in mesonlib.flatten(cargs):
             if isinstance(a, str):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -308,9 +308,6 @@ class ExternalLibraryHolder(InterpreterObject):
     def found_method(self, args, kwargs):
         return self.found()
 
-    def get_filename(self):
-        return self.held_object.fullpath
-
     def get_name(self):
         return self.held_object.name
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -285,16 +285,16 @@ class ExternalProgramHolder(InterpreterObject):
         return self.found()
 
     def path_method(self, args, kwargs):
-        return self.get_command()
+        return self.held_object.get_path()
 
     def found(self):
         return self.held_object.found()
 
     def get_command(self):
-        return self.held_object.fullpath
+        return self.held_object.get_command()
 
     def get_name(self):
-        return self.held_object.name
+        return self.held_object.get_name()
 
 class ExternalLibraryHolder(InterpreterObject):
     def __init__(self, el):

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -23,6 +23,7 @@ import json, pickle
 from . import coredata, build
 import argparse
 import sys, os
+import pathlib
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--targets', action='store_true', dest='list_targets', default=False,
@@ -56,7 +57,9 @@ def determine_installed_path(target, installdata):
     fname = i[0]
     outdir = i[1]
     outname = os.path.join(installdata.prefix, outdir, os.path.split(fname)[-1])
-    return outname
+    # Normalize the path by using os.path.sep consistently, etc.
+    # Does not change the effective path.
+    return str(pathlib.PurePath(outname))
 
 
 def list_installed(installdata):

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -111,23 +111,11 @@ def list_target_files(target_name, coredata, builddata):
     print(json.dumps(sources))
 
 def list_buildoptions(coredata, builddata):
-    buildtype = {'choices': ['plain', 'debug', 'debugoptimized', 'release', 'minsize'],
-                 'type': 'combo',
-                 'value': coredata.get_builtin_option('buildtype'),
-                 'description': 'Build type',
-                 'name': 'type'}
-    strip = {'value': coredata.get_builtin_option('strip'),
-             'type': 'boolean',
-             'description': 'Strip on install',
-             'name': 'strip'}
-    unity = {'value': coredata.get_builtin_option('unity'),
-             'type': 'boolean',
-             'description': 'Unity build',
-             'name': 'unity'}
-    optlist = [buildtype, strip, unity]
+    optlist = []
     add_keys(optlist, coredata.user_options)
     add_keys(optlist, coredata.compiler_options)
     add_keys(optlist, coredata.base_options)
+    add_keys(optlist, coredata.builtins)
     print(json.dumps(optlist))
 
 def add_keys(optlist, options):

--- a/mesonbuild/modules/qt4.py
+++ b/mesonbuild/modules/qt4.py
@@ -48,7 +48,7 @@ class Qt4Module(ExtensionModule):
                 raise MesonException('Moc preprocessor is not for Qt 4. Output:\n%s\n%s' %
                                      (stdout, stderr))
             mlog.log(' moc:', mlog.green('YES'), '(%s, %s)' %
-                     (' '.join(self.moc.fullpath), moc_ver.split()[-1]))
+                     (self.moc.get_path(), moc_ver.split()[-1]))
         else:
             mlog.log(' moc:', mlog.red('NO'))
         if self.uic.found():
@@ -61,7 +61,7 @@ class Qt4Module(ExtensionModule):
                 raise MesonException('Uic compiler is not for Qt4. Output:\n%s\n%s' %
                                      (stdout, stderr))
             mlog.log(' uic:', mlog.green('YES'), '(%s, %s)' %
-                     (' '.join(self.uic.fullpath), uic_ver.split()[-1]))
+                     (self.uic.get_path(), uic_ver.split()[-1]))
         else:
             mlog.log(' uic:', mlog.red('NO'))
         if self.rcc.found():
@@ -74,7 +74,7 @@ class Qt4Module(ExtensionModule):
                 raise MesonException('Rcc compiler is not for Qt 4. Output:\n%s\n%s' %
                                      (stdout, stderr))
             mlog.log(' rcc:', mlog.green('YES'), '(%s, %s)'
-                     % (' '.join(self.rcc.fullpath), rcc_ver.split()[-1]))
+                     % (self.rcc.get_path(), rcc_ver.split()[-1]))
         else:
             mlog.log(' rcc:', mlog.red('NO'))
         self.tools_detected = True

--- a/mesonbuild/modules/qt5.py
+++ b/mesonbuild/modules/qt5.py
@@ -50,7 +50,7 @@ class Qt5Module(ExtensionModule):
                 raise MesonException('Moc preprocessor is not for Qt 5. Output:\n%s\n%s' %
                                      (stdout, stderr))
             mlog.log(' moc:', mlog.green('YES'), '(%s, %s)' %
-                     (' '.join(self.moc.fullpath), moc_ver.split()[-1]))
+                     (self.moc.get_path(), moc_ver.split()[-1]))
         else:
             mlog.log(' moc:', mlog.red('NO'))
         if self.uic.found():
@@ -65,7 +65,7 @@ class Qt5Module(ExtensionModule):
                 raise MesonException('Uic compiler is not for Qt 5. Output:\n%s\n%s' %
                                      (stdout, stderr))
             mlog.log(' uic:', mlog.green('YES'), '(%s, %s)' %
-                     (' '.join(self.uic.fullpath), uic_ver.split()[-1]))
+                     (self.uic.get_path(), uic_ver.split()[-1]))
         else:
             mlog.log(' uic:', mlog.red('NO'))
         if self.rcc.found():
@@ -80,7 +80,7 @@ class Qt5Module(ExtensionModule):
                 raise MesonException('Rcc compiler is not for Qt 5. Output:\n%s\n%s' %
                                      (stdout, stderr))
             mlog.log(' rcc:', mlog.green('YES'), '(%s, %s)'
-                     % (' '.join(self.rcc.fullpath), rcc_ver.split()[-1]))
+                     % (self.rcc.get_path(), rcc_ver.split()[-1]))
         else:
             mlog.log(' rcc:', mlog.red('NO'))
         self.tools_detected = True

--- a/mesonbuild/modules/rpm.py
+++ b/mesonbuild/modules/rpm.py
@@ -108,7 +108,7 @@ class RPMModule(ExtensionModule):
                     fn.write('BuildRequires: %%{_bindir}/%s # FIXME\n' %
                              prog.get_name())
                 else:
-                    fn.write('BuildRequires: %s\n' % ' '.join(prog.fullpath))
+                    fn.write('BuildRequires: {}\n'.format(prog.get_path()))
             fn.write('BuildRequires: meson\n')
             fn.write('\n')
             fn.write('%description\n')

--- a/mesonbuild/modules/rpm.py
+++ b/mesonbuild/modules/rpm.py
@@ -98,11 +98,12 @@ class RPMModule(ExtensionModule):
             for dep in state.environment.coredata.deps:
                 fn.write('BuildRequires: pkgconfig(%s)\n' % dep[0])
             for lib in state.environment.coredata.ext_libs.values():
-                fn.write('BuildRequires: %s # FIXME\n' % lib.fullpath)
-                mlog.warning('replace', mlog.bold(lib.fullpath), 'with real package.',
+                name = lib.get_name()
+                fn.write('BuildRequires: {} # FIXME\n'.format(name))
+                mlog.warning('replace', mlog.bold(name), 'with the real package.',
                              'You can use following command to find package which '
                              'contains this lib:',
-                             mlog.bold('dnf provides %s' % lib.fullpath))
+                             mlog.bold("dnf provides '*/lib{}.so".format(name))
             for prog in state.environment.coredata.ext_progs.values():
                 if not prog.found():
                     fn.write('BuildRequires: %%{_bindir}/%s # FIXME\n' %

--- a/run_tests.py
+++ b/run_tests.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     if mesonlib.is_linux():
         returncode += subprocess.call([sys.executable, 'run_unittests.py', '-v'])
     else:
-        returncode += subprocess.call([sys.executable, 'run_unittests.py', '-v', 'InternalTests'])
+        returncode += subprocess.call([sys.executable, 'run_unittests.py', '-v', 'InternalTests', 'AllPlatformTests'])
     # Ubuntu packages do not have a binary without -6 suffix.
     if shutil.which('arm-linux-gnueabihf-gcc-6') and not platform.machine().startswith('arm'):
         print('Running cross compilation tests.\n')

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright 2012-2016 The Meson development team
+# Copyright 2012-2017 The Meson development team
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,10 +21,12 @@ from mesonbuild import mesonlib
 if __name__ == '__main__':
     returncode = 0
     print('Running unittests.\n')
+    units = ['InternalTests', 'AllPlatformTests']
     if mesonlib.is_linux():
-        returncode += subprocess.call([sys.executable, 'run_unittests.py', '-v'])
-    else:
-        returncode += subprocess.call([sys.executable, 'run_unittests.py', '-v', 'InternalTests', 'AllPlatformTests'])
+        units += ['LinuxlikeTests']
+    elif mesonlib.is_windows():
+        units += ['WindowsTests']
+    returncode += subprocess.call([sys.executable, 'run_unittests.py', '-v'] + units)
     # Ubuntu packages do not have a binary without -6 suffix.
     if shutil.which('arm-linux-gnueabihf-gcc-6') and not platform.machine().startswith('arm'):
         print('Running cross compilation tests.\n')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -180,7 +180,9 @@ class BasePlatformTests(unittest.TestCase):
         super().setUp()
         src_root = os.path.dirname(__file__)
         src_root = os.path.join(os.getcwd(), src_root)
-        self.builddir = tempfile.mkdtemp()
+        # In case the directory is inside a symlinked directory, find the real
+        # path otherwise we might not find the srcdir from inside the builddir.
+        self.builddir = os.path.realpath(tempfile.mkdtemp())
         self.logdir = os.path.join(self.builddir, 'meson-logs')
         self.prefix = '/usr'
         self.libdir = os.path.join(self.prefix, 'lib')
@@ -857,9 +859,9 @@ class RewriterTests(unittest.TestCase):
     def setUp(self):
         super().setUp()
         src_root = os.path.dirname(__file__)
-        self.testroot = tempfile.mkdtemp()
+        self.testroot = os.path.realpath(tempfile.mkdtemp())
         self.rewrite_command = [sys.executable, os.path.join(src_root, 'mesonrewriter.py')]
-        self.tmpdir = tempfile.mkdtemp()
+        self.tmpdir = os.path.realpath(tempfile.mkdtemp())
         self.workdir = os.path.join(self.tmpdir, 'foo')
         self.test_dir = os.path.join(src_root, 'test cases/rewrite')
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -585,9 +585,9 @@ class WindowsTests(BasePlatformTests):
         self.assertTrue(prog1.found(), msg='cmd not found')
         prog2 = ExternalProgram('cmd.exe')
         self.assertTrue(prog2.found(), msg='cmd.exe not found')
-        self.assertPathEqual(prog1.fullpath[0], prog2.fullpath[0])
+        self.assertPathEqual(prog1.get_path(), prog2.get_path())
         # Find cmd with an absolute path that's missing the extension
-        cmd_path = prog2.fullpath[0][:-4]
+        cmd_path = prog2.get_path()[:-4]
         prog = ExternalProgram(cmd_path)
         self.assertTrue(prog.found(), msg='{!r} not found'.format(cmd_path))
         # Finding a script with no extension inside a directory works
@@ -600,13 +600,13 @@ class WindowsTests(BasePlatformTests):
         os.environ['PATH'] += os.pathsep + testdir
         prog = ExternalProgram('test-script-ext')
         self.assertTrue(prog.found(), msg='test-script-ext not found in PATH')
-        self.assertPathEqual(prog.fullpath[0], sys.executable)
-        self.assertPathBasenameEqual(prog.fullpath[1], 'test-script-ext.py')
+        self.assertPathEqual(prog.get_command()[0], sys.executable)
+        self.assertPathBasenameEqual(prog.get_path(), 'test-script-ext.py')
         # Finding a script in PATH with extension works and adds the interpreter
         prog = ExternalProgram('test-script-ext.py')
         self.assertTrue(prog.found(), msg='test-script-ext.py not found in PATH')
-        self.assertPathEqual(prog.fullpath[0], sys.executable)
-        self.assertPathBasenameEqual(prog.fullpath[1], 'test-script-ext.py')
+        self.assertPathEqual(prog.get_command()[0], sys.executable)
+        self.assertPathBasenameEqual(prog.get_path(), 'test-script-ext.py')
 
 
 class LinuxlikeTests(BasePlatformTests):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -202,9 +202,12 @@ class BasePlatformTests(unittest.TestCase):
         os.environ = self.orig_env
         super().tearDown()
 
-    def _run(self, command):
-        self.output += subprocess.check_output(command, stderr=subprocess.STDOUT,
-                                               env=os.environ.copy())
+    def _run(self, command, return_output=False):
+        output = subprocess.check_output(command, stderr=subprocess.STDOUT,
+                                         env=os.environ.copy())
+        self.output += output
+        if return_output:
+            return output
 
     def init(self, srcdir, extra_args=None, default_args=True):
         if extra_args is None:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -356,7 +356,7 @@ class AllPlatformTests(BasePlatformTests):
         self.build()
         before = self._run(['ar', 't', os.path.join(self.builddir, libname)]).split()
         # Filter out non-object-file contents
-        before = [f for f in before if f.endswith((b'.o', b'.obj'))]
+        before = [f for f in before if f.endswith(('.o', '.obj'))]
         # Static library should contain only one object
         self.assertEqual(len(before), 1, msg=before)
         # Change the source to be built into the static library
@@ -364,7 +364,7 @@ class AllPlatformTests(BasePlatformTests):
         self.build()
         after = self._run(['ar', 't', os.path.join(self.builddir, libname)]).split()
         # Filter out non-object-file contents
-        after = [f for f in after if f.endswith((b'.o', b'.obj'))]
+        after = [f for f in after if f.endswith(('.o', '.obj'))]
         # Static library should contain only one object
         self.assertEqual(len(after), 1, msg=after)
         # and the object must have changed

--- a/test cases/common/105 find program path/meson.build
+++ b/test cases/common/105 find program path/meson.build
@@ -8,3 +8,11 @@ if not python.found()
 endif
 
 run_command(python, prog.path())
+
+progf = files('program.py')
+py = configure_file(input : 'program.py',
+                    output : 'builtprogram.py',
+                    configuration : configuration_data())
+
+find_program(py)
+find_program(progf)

--- a/test cases/common/105 find program path/meson.build
+++ b/test cases/common/105 find program path/meson.build
@@ -1,18 +1,25 @@
 project('find program', 'c')
 
-prog = find_program('program.py')
-
 python = find_program('python3', required : false)
 if not python.found()
   python = find_program('python')
 endif
 
-run_command(python, prog.path())
-
+# Source file via string
+prog = find_program('program.py')
+# Source file via files()
 progf = files('program.py')
+# Built file
 py = configure_file(input : 'program.py',
                     output : 'builtprogram.py',
                     configuration : configuration_data())
 
-find_program(py)
-find_program(progf)
+foreach f : [prog, find_program(py), find_program(progf)]
+  ret = run_command(python, f.path())
+  assert(ret.returncode() == 0, 'can\'t manually run @0@'.format(prog.path()))
+  assert(ret.stdout().strip() == 'Found', 'wrong output from manually-run @0@'.format(prog.path()))
+
+  ret = run_command(f)
+  assert(ret.returncode() == 0, 'can\'t run @0@'.format(prog.path()))
+  assert(ret.stdout().strip() == 'Found', 'wrong output from @0@'.format(prog.path()))
+endforeach

--- a/test cases/common/119 pathjoin/meson.build
+++ b/test cases/common/119 pathjoin/meson.build
@@ -1,8 +1,17 @@
 project('pathjoin', 'c')
 
+# Test string-args form since that is the canonical way
 assert(join_paths('foo') == 'foo', 'Single argument join is broken')
 assert(join_paths('foo', 'bar') == 'foo/bar', 'Path joining is broken')
 assert(join_paths('foo', 'bar', 'baz') == 'foo/bar/baz', 'Path joining is broken')
 assert(join_paths('/foo', 'bar') == '/foo/bar', 'Path joining is broken')
 assert(join_paths('foo', '/bar') == '/bar', 'Absolute path joining is broken')
 assert(join_paths('/foo', '/bar') == '/bar', 'Absolute path joining is broken')
+
+# Test array form since people are using that too
+assert(join_paths(['foo']) == 'foo', 'Single argument join is broken')
+assert(join_paths(['foo', 'bar']) == 'foo/bar', 'Path joining is broken')
+assert(join_paths(['foo', 'bar', 'baz']) == 'foo/bar/baz', 'Path joining is broken')
+assert(join_paths(['/foo', 'bar']) == '/foo/bar', 'Path joining is broken')
+assert(join_paths(['foo', '/bar']) == '/bar', 'Absolute path joining is broken')
+assert(join_paths(['/foo', '/bar']) == '/bar', 'Absolute path joining is broken')

--- a/test cases/common/3 static/libfile2.c
+++ b/test cases/common/3 static/libfile2.c
@@ -1,0 +1,3 @@
+int libfunc2() {
+    return 4;
+}

--- a/test cases/common/3 static/meson.build
+++ b/test cases/common/3 static/meson.build
@@ -1,3 +1,4 @@
 project('static library test', 'c')
-lib = static_library('mylib', 'libfile.c',
+
+lib = static_library('mylib', get_option('source'),
   link_args : '-THISMUSTNOBEUSED') # Static linker needs to ignore all link args.

--- a/test cases/common/3 static/meson_options.txt
+++ b/test cases/common/3 static/meson_options.txt
@@ -1,0 +1,1 @@
+option('source', type : 'combo', choices : ['libfile.c', 'libfile2.c'], value : 'libfile.c')

--- a/test cases/common/94 default options/meson.build
+++ b/test cases/common/94 default options/meson.build
@@ -1,4 +1,5 @@
 project('default options', 'cpp', 'c', default_options : [
+  'prefix=/absoluteprefix',
   'buildtype=debugoptimized',
   'cpp_std=c++11',
   'cpp_eh=none',

--- a/test cases/windows/9 find program/meson.build
+++ b/test cases/windows/9 find program/meson.build
@@ -1,4 +1,12 @@
 project('find program', 'c')
 
+# Test that we can find native windows executables
+find_program('cmd')
+find_program('cmd.exe')
+
+# Test that a script file with an extension can be found
+ext = find_program('test-script-ext.py')
+test('ext', ext)
+# Test that a script file without an extension can be found
 prog = find_program('test-script')
 test('script', prog)

--- a/test cases/windows/9 find program/test-script-ext.py
+++ b/test cases/windows/9 find program/test-script-ext.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print('ext/noext')


### PR DESCRIPTION
Does not need to be merged for 0.38.1

* Also return builtin options when `mesonintrospect --buildoptions` is called
* Add unit tests for #1341 #1345 #1349 
* Fix #1355 and add a cross-platform unit test for it

More commits incoming.