### PR TITLE
Fix absolute prefix/xxxdir subdir check on Windows

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pickle, os, uuid
+from pathlib import PurePath
 from .mesonlib import MesonException, commonpath
 from .mesonlib import default_libdir, default_libexecdir, default_prefix
 
@@ -159,7 +160,10 @@ class CoreData:
         if option.endswith('dir') and os.path.isabs(value) and \
            option not in builtin_dir_noprefix_options:
             # Value must be a subdir of the prefix
-            if commonpath([value, prefix]) != prefix:
+            # commonpath will always return a path in the native format, so we
+            # must use pathlib.PurePath to do the same conversion before
+            # comparing.
+            if commonpath([value, prefix]) != str(PurePath(prefix)):
                 m = 'The value of the {!r} option is {!r} which must be a ' \
                     'subdir of the prefix {!r}.\nNote that if you pass a ' \
                     'relative path, it is assumed to be a subdir of prefix.'

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -15,10 +15,11 @@
 
 import stat
 import shlex
-import unittest, os, sys, shutil, time
 import subprocess
 import re, json
 import tempfile
+import pathlib
+import unittest, os, sys, shutil, time
 from glob import glob
 import mesonbuild.compilers
 import mesonbuild.environment
@@ -169,6 +170,9 @@ class InternalTests(unittest.TestCase):
         self.assertEqual(commonpath(['/usr', '/bin']), sep)
         self.assertEqual(commonpath(['/usr', 'bin']), '')
         self.assertEqual(commonpath(['blam', 'bin']), '')
+        prefix = '/some/path/to/prefix'
+        libdir = '/some/path/to/prefix/libdir'
+        self.assertEqual(commonpath([prefix, libdir]), str(pathlib.PurePath(prefix)))
 
 
 class LinuxlikeTests(unittest.TestCase):


### PR DESCRIPTION
`os.path.commonpath` (and our implementation of it) both always return the path using the native operating system path separator, so we can't just directly compare it since the prefix could be specified in `/`, and `commonpath` would use `\` on Windows.

Also add a unit test for this.

NOTE: This needs to go into 0.38.1, it's a regression! Without this, passing absolute paths for `xxxdir` is completely broken on Windows.