### PR TITLE
Enable the detection of ccache for cross compilation

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -349,7 +349,7 @@ class Environment:
         evar = 'CC'
         if self.is_cross_build() and want_cross:
             compilers = [self.cross_info.config['binaries']['c']]
-            ccache = []
+            ccache = self.detect_ccache()
             is_cross = True
             if self.cross_info.need_exe_wrapper():
                 exe_wrap = self.cross_info.config['binaries'].get('exe_wrapper', None)


### PR DESCRIPTION
The feature was enabled only for native compilation, so enable it even
for cross compilation.