### PR TITLE
ccache: Enable auto detection for cross compilation 

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -63,3 +63,4 @@ Kseniia Vasilchuk
 Philipp Geier
 Mike Sinkovsky
 Dima Krasner
+Fabio Porcedda

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -349,7 +349,7 @@ class Environment:
         evar = 'CC'
         if self.is_cross_build() and want_cross:
             compilers = [self.cross_info.config['binaries']['c']]
-            ccache = []
+            ccache = self.detect_ccache()
             is_cross = True
             if self.cross_info.need_exe_wrapper():
                 exe_wrap = self.cross_info.config['binaries'].get('exe_wrapper', None)


### PR DESCRIPTION
The feature was enabled only for native compilation, so enable it even
for cross compilation.