### PR TITLE
executable(): New keyword argument "link_args_pre"

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1284,10 +1284,10 @@ int dummy;
                 if mesonlib.is_windows():
                     command_template = ''' command = {executable} @$out.rsp
  rspfile = $out.rsp
- rspfile_content = $ARGS  {output_args} $in $LINK_ARGS {cross_args} $aliasing
+ rspfile_content = $ARGS  {output_args} $LINK_ARGS_PRE $in $LINK_ARGS {cross_args} $aliasing
 '''
                 else:
-                    command_template = ' command = {executable} $ARGS {output_args} $in $LINK_ARGS {cross_args} $aliasing\n'
+                    command_template = ' command = {executable} $ARGS {output_args} $LINK_ARGS_PRE $in $LINK_ARGS {cross_args} $aliasing\n'
                 command = command_template.format(
                     executable=' '.join(compiler.get_linker_exelist()),
                     cross_args=' '.join(cross_args),
@@ -2190,6 +2190,7 @@ rule FORTRAN_DEP_HACK
         elem = NinjaBuildElement(self.all_outputs, outname, linker_rule, obj_list)
         elem.add_dep(dep_targets + custom_target_libraries)
         elem.add_item('LINK_ARGS', commands)
+        elem.add_item('LINK_ARGS_PRE', target.link_args_pre)
         return elem
 
     def determine_rpath_dirs(self, target):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -32,6 +32,7 @@ known_basic_kwargs = {'install': True,
                       'fortran_args': True,
                       'd_args': True,
                       'java_args': True,
+                      'link_args_pre': True,
                       'link_args': True,
                       'link_depends': True,
                       'link_with': True,
@@ -583,6 +584,14 @@ class BuildTarget(Target):
         self.vala_gir = kwargs.get('vala_gir', None)
         dlist = stringlistify(kwargs.get('d_args', []))
         self.add_compiler_args('d', dlist)
+
+        self.link_args_pre = kwargs.get('link_args_pre', [])
+        if not isinstance(self.link_args_pre, list):
+            self.link_args = [self.link_args_pre]
+        for i in self.link_args_pre:
+            if not isinstance(i, str):
+                raise InvalidArguments('Link_args_pre arguments must be strings.')
+
         self.link_args = kwargs.get('link_args', [])
         if not isinstance(self.link_args, list):
             self.link_args = [self.link_args]


### PR DESCRIPTION
Add a new keyword argument to the "executable" function.

The content of this argument will be put befere the "$in $LINK_ARGS" arguments was:
    ... {output_args} $in $LINK_ARGS ...
now is:
    ... {output_args} $LINK_ARGS_PRE $in $LINK_ARGS ...
    
Example for supporting a circular dependency:
    
    executable('name', src, link_args_pre : '-Wl,--start-group', objects : obj, link_args : '-Wl,--end-group')
