### PR TITLE
custom_target: Recursively flatten `command:`

### DIFF
--- a/test cases/common/56 custom target/meson.build
+++ b/test cases/common/56 custom target/meson.build
@@ -8,11 +8,13 @@ endif
 # Note that this will not add a dependency to the compiler executable.
 # Code will not be rebuilt if it changes.
 comp = '@0@/@1@'.format(meson.current_source_dir(), 'my_compiler.py')
+# Test that files() in command: works. The compiler just discards it.
+useless = files('installed_files.txt')
 
 mytarget = custom_target('bindat',
 output : 'data.dat',
 input : 'data_source.txt',
-command : [python, comp, '--input=@INPUT@', '--output=@OUTPUT@'],
+command : [python, comp, '--input=@INPUT@', '--output=@OUTPUT@', useless],
 install : true,
 install_dir : 'subdir'
 )

--- a/test cases/common/56 custom target/my_compiler.py
+++ b/test cases/common/56 custom target/my_compiler.py
@@ -1,16 +1,21 @@
 #!/usr/bin/env python3
 
+import os
 import sys
 
+assert(os.path.exists(sys.argv[3]))
+
+args = sys.argv[:-1]
+
 if __name__ == '__main__':
-    if len(sys.argv) != 3 or not sys.argv[1].startswith('--input') or \
-       not sys.argv[2].startswith('--output'):
-        print(sys.argv[0], '--input=input_file --output=output_file')
+    if len(args) != 3 or not args[1].startswith('--input') or \
+       not args[2].startswith('--output'):
+        print(args[0], '--input=input_file --output=output_file')
         sys.exit(1)
-    with open(sys.argv[1].split('=')[1]) as f:
+    with open(args[1].split('=')[1]) as f:
         ifile = f.read()
     if ifile != 'This is a text only input file.\n':
         print('Malformed input')
         sys.exit(1)
-    with open(sys.argv[2].split('=')[1], 'w') as ofile:
+    with open(args[2].split('=')[1], 'w') as ofile:
         ofile.write('This is a binary output file.\n')


### PR DESCRIPTION
Without this, `files()` in the arguments give an error because it's a list of `mesonlib.File` objects:

    Array as argument 1 contains a non-string.

It also breaks in nested lists. Includes a test for this.

Reported by @ebassi on IRC.