### PR TITLE
cross_file: add support for "ccache"

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -63,3 +63,4 @@ Kseniia Vasilchuk
 Philipp Geier
 Mike Sinkovsky
 Dima Krasner
+Fabio Porcedda

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -349,7 +349,9 @@ class Environment:
     def detect_c_compiler(self, want_cross):
         evar = 'CC'
         if self.is_cross_build() and want_cross:
-            compilers = [self.cross_info.config['binaries']['c']]
+            compilers = self.cross_info.config['binaries']['c']
+            if not isinstance(compilers, list):
+                compilers = [compilers]
             ccache = []
             is_cross = True
             if self.cross_info.need_exe_wrapper():
@@ -386,13 +388,13 @@ class Environment:
                     continue
                 gtype = self.get_gnu_compiler_type(defines)
                 version = self.get_gnu_version_from_defines(defines)
-                return GnuCCompiler(ccache + [compiler], version, gtype, is_cross, exe_wrap, defines)
+                return GnuCCompiler(ccache + compilers, version, gtype, is_cross, exe_wrap, defines)
             if 'clang' in out:
                 if 'Apple' in out or for_darwin(want_cross, self):
                     cltype = CLANG_OSX
                 else:
                     cltype = CLANG_STANDARD
-                return ClangCCompiler(ccache + [compiler], version, cltype, is_cross, exe_wrap)
+                return ClangCCompiler(ccache + compilers, version, cltype, is_cross, exe_wrap)
             if 'Microsoft' in out or 'Microsoft' in err:
                 # Visual Studio prints version number to stderr but
                 # everything else to stdout. Why? Lord only knows.
@@ -401,7 +403,7 @@ class Environment:
             if '(ICC)' in out:
                 # TODO: add microsoft add check OSX
                 inteltype = ICC_STANDARD
-                return IntelCCompiler(ccache + [compiler], version, inteltype, is_cross, exe_wrap)
+                return IntelCCompiler(ccache + compilers, version, inteltype, is_cross, exe_wrap)
         errmsg = 'Unknown compiler(s): "' + ', '.join(compilers) + '"'
         if popen_exceptions:
             errmsg += '\nThe follow exceptions were encountered:'

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -19,6 +19,7 @@ from . import mlog
 from .compilers import *
 from .mesonlib import EnvironmentException, Popen_safe
 import configparser
+import shlex
 import shutil
 
 build_filename = 'meson.build'
@@ -356,7 +357,7 @@ class Environment:
             else:
                 exe_wrap = []
         elif evar in os.environ:
-            compilers = os.environ[evar].split()
+            compilers = shlex.split(os.environ[evar])
             ccache = []
             is_cross = False
             exe_wrap = None


### PR DESCRIPTION
Add the possibility to enable the ccache using the cross_file.

To use ccache add the 'ccache' string before the compiler string, e.g.:
    
cross_file.txt:
   
[binaries]
c = ['ccache', '/usr/local/bin/mips-linuc-gcc']

This fixes #1392 .
