### PR TITLE
Fix directory context for git wrap check

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -66,3 +66,4 @@ Dima Krasner
 Fabio Porcedda
 Rodrigo Lourenço
 Sebastian Stang
+Marc Becker

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -129,7 +129,7 @@ class Resolver:
         is_there = os.path.isdir(checkoutdir)
         if is_there:
             try:
-                subprocess.check_call(['git', 'rev-parse'])
+                subprocess.check_call(['git', 'rev-parse'], cwd=checkoutdir)
                 is_there = True
             except subprocess.CalledProcessError:
                 raise RuntimeError('%s is not empty but is not a valid '


### PR DESCRIPTION
If directory for git wrap exists, `git rev-parse` check fails due to running with bad working directory.
Error is masked when main project is itself a git repository (or located inside one).

Are there reasons why wrapped subproject are not downloaded into the build folder instead?