### PR TITLE
mesontest: Set MALLOC_PERTURB_ to a random value

### DIFF
--- a/mesontest.py
+++ b/mesontest.py
@@ -25,6 +25,7 @@ import time, datetime, multiprocessing, json
 import concurrent.futures as conc
 import platform
 import signal
+import random
 
 # GNU autotools interprets a return code of 77 from tests it executes to
 # mean that the test should be skipped.
@@ -220,6 +221,14 @@ class TestHarness:
             child_env.update(test.env)
             if len(test.extra_paths) > 0:
                 child_env['PATH'] += ';'.join([''] + test.extra_paths)
+
+            # If MALLOC_PERTURB_ is not set, or if it is set to an empty value,
+            # (i.e., the test or the environment don't explicitly set it), set
+            # it ourselves. We do this unconditionally because it is extremely
+            # useful to have in tests.
+            # Setting MALLOC_PERTURB_="0" will completely disable this feature.
+            if 'MALLOC_PERTURB_' not in child_env or not child_env['MALLOC_PERTURB_']:
+                child_env['MALLOC_PERTURB_'] = str(random.randint(1, 255))
 
             setsid = None
             stdout = None


### PR DESCRIPTION
This is useful enough that we can enable this for everyone. If people really don't want this, they can pass `MALLOC_PERTURB_=0` in the environment or in the test.