### PR TITLE
Enable colors with Clang

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -63,3 +63,4 @@ Kseniia Vasilchuk
 Philipp Geier
 Mike Sinkovsky
 Dima Krasner
+Rodrigo Lourenço

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -188,6 +188,10 @@ gnu_color_args = {'auto': ['-fdiagnostics-color=auto'],
                   'never': ['-fdiagnostics-color=never'],
                   }
 
+clang_color_args = {'always': ['-Xclang', '-fcolor-diagnostics'],
+                    'never': ['-Xclang', '-fno-color-diagnostics'],
+                    }
+
 base_options = {'b_pch': coredata.UserBooleanOption('b_pch', 'Use precompiled headers', True),
                 'b_lto': coredata.UserBooleanOption('b_lto', 'Use link time optimization', False),
                 'b_sanitize': coredata.UserComboOption('b_sanitize',
@@ -2427,7 +2431,7 @@ class ClangCompiler:
         self.id = 'clang'
         self.clang_type = clang_type
         self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage',
-                             'b_ndebug', 'b_staticpic']
+                             'b_ndebug', 'b_staticpic', 'b_colorout']
         if self.clang_type != CLANG_OSX:
             self.base_options.append('b_lundef')
             self.base_options.append('b_asneeded')
@@ -2438,6 +2442,11 @@ class ClangCompiler:
         if self.clang_type in (CLANG_WIN, CLANG_OSX):
             return [] # On Window and OS X, pic is always on.
         return ['-fPIC']
+
+    def get_colorout_args(self, colortype):
+        if mesonlib.version_compare(self.version, '>=3.3'):
+            return clang_color_args[colortype][:]
+        return []
 
     def get_buildtype_args(self, buildtype):
         return gnulike_buildtype_args[buildtype]

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -2444,7 +2444,7 @@ class ClangCompiler:
         return ['-fPIC']
 
     def get_colorout_args(self, colortype):
-        if mesonlib.version_compare(self.version, '>=3.3'):
+        if mesonlib.version_compare(self.version, '>=3.1'):
             return clang_color_args[colortype][:]
         return []
 

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -188,7 +188,8 @@ gnu_color_args = {'auto': ['-fdiagnostics-color=auto'],
                   'never': ['-fdiagnostics-color=never'],
                   }
 
-clang_color_args = {'always': ['-Xclang', '-fcolor-diagnostics'],
+clang_color_args = {'auto': ['-Xclang', '-fcolor-diagnostics'],
+                    'always': ['-Xclang', '-fcolor-diagnostics'],
                     'never': ['-Xclang', '-fno-color-diagnostics'],
                     }
 
@@ -2444,9 +2445,7 @@ class ClangCompiler:
         return ['-fPIC']
 
     def get_colorout_args(self, colortype):
-        if mesonlib.version_compare(self.version, '>=3.1'):
-            return clang_color_args[colortype][:]
-        return []
+        return clang_color_args[colortype][:]
 
     def get_buildtype_args(self, buildtype):
         return gnulike_buildtype_args[buildtype]


### PR DESCRIPTION
This PR enables colors when compiling with Clang. The earliest reference I found to the flag's existence was on the [Clang 3.3 User's Manual](http://releases.llvm.org/3.3/tools/clang/docs/UsersManual.html#formatting-of-diagnostics), but to be honest I didn't took too hard. It seems that the "auto" option is no option at all.