### PR TITLE
More fixes to compiler detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,5 +40,5 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo FROM jpakkane/mesonci:yakkety > Dockerfile; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo ADD . /root >> Dockerfile; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build -t withgit .; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker run withgit /bin/sh -c "cd /root && TRAVIS=true CC=$CC CXX=$CXX ./run_tests.py -- $MESON_ARGS"; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) ./run_tests.py --backend=ninja -- $MESON_ARGS ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker run withgit /bin/sh -c "cd /root && TRAVIS=true CC=$CC CXX=$CXX OBJC=$CC OBJCXX=$CXX ./run_tests.py -- $MESON_ARGS"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) OBJC=$CC OBJCXX=$CXX ./run_tests.py --backend=ninja -- $MESON_ARGS ; fi

--- a/authors.txt
+++ b/authors.txt
@@ -65,3 +65,4 @@ Mike Sinkovsky
 Dima Krasner
 Fabio Porcedda
 Rodrigo Lourenço
+Sebastian Stang

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -2404,11 +2404,9 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
 
 class GnuObjCCompiler(GnuCompiler, ObjCCompiler):
 
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None, defines=None):
+    def __init__(self, exelist, version, gcc_type, is_cross, exe_wrapper=None, defines=None):
         ObjCCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
-        # Not really correct, but GNU objc is only used on non-OSX non-win. File a bug
-        # if this breaks your use case.
-        GnuCompiler.__init__(self, GCC_STANDARD, defines)
+        GnuCompiler.__init__(self, gcc_type, defines)
         default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
@@ -2416,11 +2414,9 @@ class GnuObjCCompiler(GnuCompiler, ObjCCompiler):
 
 class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):
 
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None, defines=None):
+    def __init__(self, exelist, version, gcc_type, is_cross, exe_wrapper=None, defines=None):
         ObjCPPCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
-        # Not really correct, but GNU objc is only used on non-OSX non-win. File a bug
-        # if this breaks your use case.
-        GnuCompiler.__init__(self, GCC_STANDARD, defines)
+        GnuCompiler.__init__(self, gcc_type, defines)
         default_warn_args = ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor']
         self.warn_args = {'1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
@@ -2549,13 +2545,13 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
 
 class ClangObjCCompiler(ClangCompiler, GnuObjCCompiler):
     def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):
-        GnuObjCCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
+        GnuObjCCompiler.__init__(self, exelist, version, cltype, is_cross, exe_wrapper)
         ClangCompiler.__init__(self, cltype)
         self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage']
 
 class ClangObjCPPCompiler(ClangCompiler, GnuObjCPPCompiler):
     def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):
-        GnuObjCPPCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
+        GnuObjCPPCompiler.__init__(self, exelist, version, cltype, is_cross, exe_wrapper)
         ClangCompiler.__init__(self, cltype)
         self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage']
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -400,9 +400,9 @@ class Environment:
                 errmsg += '\nRunning "{0}" gave "{1}"'.format(c, e)
         raise EnvironmentException(errmsg)
 
-    def detect_c_compiler(self, want_cross):
+    def _detect_c_or_cpp_compiler(self, lang, evar, want_cross):
         popen_exceptions = {}
-        compilers, ccache, is_cross, exe_wrap = self._get_compilers('c', 'CC', want_cross)
+        compilers, ccache, is_cross, exe_wrap = self._get_compilers(lang, evar, want_cross)
         for compiler in compilers:
             if isinstance(compiler, str):
                 compiler = [compiler]
@@ -424,23 +424,33 @@ class Environment:
                     continue
                 gtype = self.get_gnu_compiler_type(defines)
                 version = self.get_gnu_version_from_defines(defines)
-                return GnuCCompiler(ccache + compiler, version, gtype, is_cross, exe_wrap, defines)
+                cls = GnuCCompiler if lang == 'c' else GnuCPPCompiler
+                return cls(ccache + compiler, version, gtype, is_cross, exe_wrap, defines)
             if 'clang' in out:
                 if 'Apple' in out or for_darwin(want_cross, self):
                     cltype = CLANG_OSX
                 else:
                     cltype = CLANG_STANDARD
-                return ClangCCompiler(ccache + compiler, version, cltype, is_cross, exe_wrap)
+                cls = ClangCCompiler if lang == 'c' else ClangCPPCompiler
+                return cls(ccache + compiler, version, cltype, is_cross, exe_wrap)
             if 'Microsoft' in out or 'Microsoft' in err:
                 # Visual Studio prints version number to stderr but
                 # everything else to stdout. Why? Lord only knows.
                 version = search_version(err)
-                return VisualStudioCCompiler(compiler, version, is_cross, exe_wrap)
+                cls = VisualStudioCCompiler if lang == 'c' else VisualStudioCPPCompiler
+                return cls(compiler, version, is_cross, exe_wrap)
             if '(ICC)' in out:
                 # TODO: add microsoft add check OSX
                 inteltype = ICC_STANDARD
-                return IntelCCompiler(ccache + compiler, version, inteltype, is_cross, exe_wrap)
+                cls = IntelCCompiler if lang == 'c' else IntelCPPCompiler
+                return cls(ccache + compiler, version, inteltype, is_cross, exe_wrap)
         self._handle_compiler_exceptions(popen_exceptions, compilers)
+
+    def detect_c_compiler(self, want_cross):
+        return self._detect_c_or_cpp_compiler('c', 'CC', want_cross)
+
+    def detect_cpp_compiler(self, want_cross):
+        return self._detect_c_or_cpp_compiler('cpp', 'CXX', want_cross)
 
     def detect_fortran_compiler(self, want_cross):
         popen_exceptions = {}
@@ -495,46 +505,6 @@ class Environment:
     def get_depfixer(self):
         path = os.path.split(__file__)[0]
         return os.path.join(path, 'depfixer.py')
-
-    def detect_cpp_compiler(self, want_cross):
-        popen_exceptions = {}
-        compilers, ccache, is_cross, exe_wrap = self._get_compilers('cpp', 'CXX', want_cross)
-        for compiler in compilers:
-            if isinstance(compiler, str):
-                compiler = [compiler]
-            basename = os.path.basename(compiler[-1]).lower()
-            if basename == 'cl' or basename == 'cl.exe':
-                arg = '/?'
-            else:
-                arg = '--version'
-            try:
-                p, out, err = Popen_safe(compiler + [arg])
-            except OSError as e:
-                popen_exceptions[' '.join(compiler + [arg])] = e
-                continue
-            version = search_version(out)
-            if 'Free Software Foundation' in out:
-                defines = self.get_gnu_compiler_defines(compiler)
-                if not defines:
-                    popen_exceptions[compiler] = 'no pre-processor defines'
-                    continue
-                gtype = self.get_gnu_compiler_type(defines)
-                version = self.get_gnu_version_from_defines(defines)
-                return GnuCPPCompiler(ccache + compiler, version, gtype, is_cross, exe_wrap, defines)
-            if 'clang' in out:
-                if 'Apple' in out:
-                    cltype = CLANG_OSX
-                else:
-                    cltype = CLANG_STANDARD
-                return ClangCPPCompiler(ccache + compiler, version, cltype, is_cross, exe_wrap)
-            if 'Microsoft' in out or 'Microsoft' in err:
-                version = search_version(err)
-                return VisualStudioCPPCompiler(compiler, version, is_cross, exe_wrap)
-            if '(ICC)' in out:
-                # TODO: add microsoft add check OSX
-                inteltype = ICC_STANDARD
-                return IntelCPPCompiler(ccache + compiler, version, inteltype, is_cross, exe_wrap)
-        self._handle_compiler_exceptions(popen_exceptions, compilers)
 
     def detect_objc_compiler(self, want_cross):
         popen_exceptions = {}

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -373,7 +373,7 @@ class Environment:
         C, C++, ObjC, ObjC++, Fortran so consolidate it here.
         '''
         if self.is_cross_build() and want_cross:
-            compilers = mesonlib.stringlistify(self.cross_info.config['binaries'][lang])
+            compilers = [mesonlib.stringlistify(self.cross_info.config['binaries'][lang])]
             ccache = []
             is_cross = True
             if self.cross_info.need_exe_wrapper():
@@ -381,7 +381,7 @@ class Environment:
             else:
                 exe_wrap = []
         elif evar in os.environ:
-            compilers = shlex.split(os.environ[evar])
+            compilers = [shlex.split(os.environ[evar])]
             ccache = []
             is_cross = False
             exe_wrap = None

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -407,8 +407,7 @@ class Environment:
             if isinstance(compiler, str):
                 compiler = [compiler]
             try:
-                basename = os.path.basename(compiler[-1]).lower()
-                if basename == 'cl' or basename == 'cl.exe':
+                if 'cl' in compiler or 'cl.exe' in compiler:
                     arg = '/?'
                 else:
                     arg = '--version'
@@ -657,8 +656,7 @@ class Environment:
                 linker = [self.vs_static_linker]
             else:
                 linker = [self.default_static_linker]
-        basename = os.path.basename(linker[-1]).lower()
-        if basename == 'lib' or basename == 'lib.exe':
+        if 'lib' in linker or 'lib.exe' in linker:
             arg = '/?'
         else:
             arg = '--version'

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -680,7 +680,7 @@ class Environment:
         else:
             evar = 'AR'
             if evar in os.environ:
-                linker = os.environ[evar].strip()
+                linker = shlex.split(os.environ[evar])
             elif isinstance(compiler, VisualStudioCCompiler):
                 linker = self.vs_static_linker
             else:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -521,8 +521,9 @@ class Environment:
                 if not defines:
                     popen_exceptions[compiler] = 'no pre-processor defines'
                     continue
+                gtype = self.get_gnu_compiler_type(defines)
                 version = self.get_gnu_version_from_defines(defines)
-                return GnuObjCCompiler(ccache + compiler, version, is_cross, exe_wrap, defines)
+                return GnuObjCCompiler(ccache + compiler, version, gtype, is_cross, exe_wrap, defines)
             if out.startswith('Apple LLVM'):
                 return ClangObjCCompiler(ccache + compiler, version, CLANG_OSX, is_cross, exe_wrap)
             if out.startswith('clang'):
@@ -545,8 +546,9 @@ class Environment:
                 if not defines:
                     popen_exceptions[compiler] = 'no pre-processor defines'
                     continue
+                gtype = self.get_gnu_compiler_type(defines)
                 version = self.get_gnu_version_from_defines(defines)
-                return GnuObjCPPCompiler(ccache + compiler, version, is_cross, exe_wrap, defines)
+                return GnuObjCPPCompiler(ccache + compiler, version, gtype, is_cross, exe_wrap, defines)
             if out.startswith('Apple LLVM'):
                 return ClangObjCPPCompiler(ccache + compiler, version, CLANG_OSX, is_cross, exe_wrap)
             if out.startswith('clang'):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -556,6 +556,8 @@ class Environment:
                 return GnuObjCCompiler(ccache + compiler, version, is_cross, exe_wrap, defines)
             if out.startswith('Apple LLVM'):
                 return ClangObjCCompiler(ccache + compiler, version, CLANG_OSX, is_cross, exe_wrap)
+            if out.startswith('clang'):
+                return ClangObjCCompiler(ccache + compiler, version, CLANG_STANDARD, is_cross, exe_wrap)
         self._handle_compiler_exceptions(popen_exceptions, compilers)
 
     def detect_objcpp_compiler(self, want_cross):
@@ -578,6 +580,8 @@ class Environment:
                 return GnuObjCPPCompiler(ccache + compiler, version, is_cross, exe_wrap, defines)
             if out.startswith('Apple LLVM'):
                 return ClangObjCPPCompiler(ccache + compiler, version, CLANG_OSX, is_cross, exe_wrap)
+            if out.startswith('clang'):
+                return ClangObjCPPCompiler(ccache + compiler, version, CLANG_STANDARD, is_cross, exe_wrap)
         self._handle_compiler_exceptions(popen_exceptions, compilers)
 
     def detect_java_compiler(self):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -737,7 +737,9 @@ class AllPlatformTests(BasePlatformTests):
         msvc = mesonbuild.compilers.VisualStudioCCompiler
         ar = mesonbuild.compilers.ArLinker
         lib = mesonbuild.compilers.VisualStudioLinker
-        langs = (('c', 'CC'), ('cpp', 'CXX'), ('objc', 'OBJC'), ('objcpp', 'OBJCXX'))
+        langs = [('c', 'CC'), ('cpp', 'CXX')]
+        if not is_windows():
+            langs += [('objc', 'OBJC'), ('objcpp', 'OBJCXX')]
         testdir = os.path.join(self.unit_test_dir, '5 compiler detection')
         env = Environment(testdir, self.builddir, self.meson_command,
                           get_fake_options(self.prefix), [])

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -801,17 +801,17 @@ class AllPlatformTests(BasePlatformTests):
                 self.assertIsInstance(linker, lib)
                 self.assertEqual(cc.id, 'msvc')
             # Set evar ourselves to a wrapper script that just calls the same
-            # exelist. This is meant to test that setting something like
-            # `ccache gcc` or `distcc ccache gcc` works fine.
+            # exelist + some argument. This is meant to test that setting
+            # something like `ccache gcc -pipe` or `distcc ccache gcc` works.
             wrapper = os.path.join(testdir, 'compiler wrapper.py')
-            wrappercc = [sys.executable, wrapper] + cc.get_exelist()
+            wrappercc = [sys.executable, wrapper] + cc.get_exelist() + cc.get_always_args()
             wrappercc_s = ''
             for w in wrappercc:
                 wrappercc_s += shlex.quote(w) + ' '
             os.environ[evar] = wrappercc_s
             wcc = getattr(env, 'detect_{}_compiler'.format(lang))(False)
             # Check static linker too
-            wrapperlinker = [sys.executable, wrapper] + linker.get_exelist()
+            wrapperlinker = [sys.executable, wrapper] + linker.get_exelist() + linker.get_always_args()
             wrapperlinker_s = ''
             for w in wrapperlinker:
                 wrapperlinker_s += shlex.quote(w) + ' '

--- a/test cases/objc/2 nsstring/meson.build
+++ b/test cases/objc/2 nsstring/meson.build
@@ -4,6 +4,9 @@ if host_machine.system() == 'darwin'
   dep = dependency('appleframeworks', modules : 'foundation')
 else
   dep = dependency('gnustep')
+  if host_machine.system() == 'linux' and meson.get_compiler('objc').get_id() == 'clang'
+    error('MESON_SKIP_TEST: GNUstep is broken on Linux with Clang')
+  endif
 endif
 exe = executable('stringprog', 'stringprog.m', dependencies : dep)
 test('stringtest', exe)

--- a/test cases/unit/5 compiler detection/compiler wrapper.py
+++ b/test cases/unit/5 compiler detection/compiler wrapper.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import sys
+import subprocess
+
+sys.exit(subprocess.call(sys.argv[1:]))

--- a/test cases/unit/5 compiler detection/meson.build
+++ b/test cases/unit/5 compiler detection/meson.build
@@ -1,0 +1,8 @@
+project('trivial test',
+        ['c', 'cpp', 'objc', 'objcpp'],
+        meson_version : '>=0.27.0')
+
+executable('trivialc', 'trivial.c')
+executable('trivialcpp', 'trivial.cpp')
+executable('trivialobjc', 'trivial.m')
+executable('trivialobjcpp', 'trivial.mm')

--- a/test cases/unit/5 compiler detection/trivial.c
+++ b/test cases/unit/5 compiler detection/trivial.c
@@ -1,0 +1,6 @@
+#include<stdio.h>
+
+int main(int argc, char **argv) {
+    printf("Trivial test is working.\n");
+    return 0;
+}

--- a/test cases/unit/5 compiler detection/trivial.cc
+++ b/test cases/unit/5 compiler detection/trivial.cc
@@ -1,0 +1,6 @@
+#include<iostream>
+
+int main(int argc, char **argv) {
+  std::cout << "C++ seems to be working." << std::endl;
+  return 0;
+}

--- a/test cases/unit/5 compiler detection/trivial.m
+++ b/test cases/unit/5 compiler detection/trivial.m
@@ -1,0 +1,5 @@
+#import<stdio.h>
+
+int main(int argc, char **argv) {
+    return 0;
+}

--- a/test cases/unit/5 compiler detection/trivial.mm
+++ b/test cases/unit/5 compiler detection/trivial.mm
@@ -1,0 +1,9 @@
+#import<stdio.h>
+
+class MyClass {
+};
+
+int main(int argc, char **argv) {
+  return 0;
+}
+


### PR DESCRIPTION
* Factor out common code in compiler detection. Code was duplicated across C/C++/ObjC/ObjC++/Fortran and hence was behaving slightly differently in each.

* travis: Also set `OBJC` and `OBJCXX` to `CC`/`CXX` else they are only autodetected and we don't test both GCC and Clang.

* Fix compiler and static linker exelist when set as a list in cross-info or the environment. #1406 was still incorrect. Only realized when I wrote a test for it.

* Use the same function for detection of C and C++ compilers. The logic is exactly identical.

* Support passing of options to compilers and linkers via cross-info or environment

This also includes the changes from #1388 (with attribution), so that one can be closed once this is merged.