### PR TITLE
tests: Use #!/usr/bin/env python3 for all scripts

### DIFF
--- a/test cases/common/105 find program path/program.py
+++ b/test cases/common/105 find program path/program.py
@@ -1,3 +1,3 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 print("Found")

--- a/test cases/common/107 postconf/postconf.py
+++ b/test cases/common/107 postconf/postconf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 

--- a/test cases/common/108 postconf with args/postconf.py
+++ b/test cases/common/108 postconf with args/postconf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os
 

--- a/test cases/common/113 generatorcustom/catter.py
+++ b/test cases/common/113 generatorcustom/catter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test cases/common/113 generatorcustom/gen.py
+++ b/test cases/common/113 generatorcustom/gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test cases/common/118 allgenerate/converter.py
+++ b/test cases/common/118 allgenerate/converter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test cases/common/129 object only target/obj_generator.py
+++ b/test cases/common/129 object only target/obj_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Mimic a binary that generates an object file (e.g. windres).
 

--- a/test cases/common/131 custom target directory install/docgen.py
+++ b/test cases/common/131 custom target directory install/docgen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/test cases/common/133 configure file in generator/src/gen.py
+++ b/test cases/common/133 configure file in generator/src/gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test cases/common/134 generated llvm ir/copyfile.py
+++ b/test cases/common/134 generated llvm ir/copyfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import shutil

--- a/test cases/common/135 generated assembly/copyfile.py
+++ b/test cases/common/135 generated assembly/copyfile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import shutil

--- a/test cases/common/48 test args/tester.py
+++ b/test cases/common/48 test args/tester.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test cases/common/58 run target/check_exists.py
+++ b/test cases/common/58 run target/check_exists.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/test cases/common/58 run target/converter.py
+++ b/test cases/common/58 run target/converter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test cases/common/58 run target/fakeburner.py
+++ b/test cases/common/58 run target/fakeburner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/test cases/common/58 run target/meson.build
+++ b/test cases/common/58 run target/meson.build
@@ -19,15 +19,17 @@ hex = custom_target('exe.hex',
   ],
 )
 
+fakeburner = find_program('fakeburner.py')
+
 # These emulates the Arduino flasher application. It sandwiches the filename inside
 # a packed argument. Thus we need to declare it manually.
 run_target('upload',
-  command : ['fakeburner.py', 'x:@0@:y'.format(exe.full_path())],
+  command : [fakeburner, 'x:@0@:y'.format(exe.full_path())],
   depends : exe,
 )
 
 run_target('upload2',
-  command : ['fakeburner.py', 'x:@0@:y'.format(hex.full_path())],
+  command : [fakeburner, 'x:@0@:y'.format(hex.full_path())],
   depends : hex,
 )
 

--- a/test cases/common/60 install script/myinstall.py
+++ b/test cases/common/60 install script/myinstall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/test cases/common/60 install script/src/myinstall.py
+++ b/test cases/common/60 install script/src/myinstall.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/test cases/common/61 custom target source output/generator.py
+++ b/test cases/common/61 custom target source output/generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os
 

--- a/test cases/common/64 custom header generator/makeheader.py
+++ b/test cases/common/64 custom header generator/makeheader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # NOTE: this file does not have the executable bit set. This tests that
 # Meson can automatically parse shebang lines.

--- a/test cases/common/65 multiple generators/mygen.py
+++ b/test cases/common/65 multiple generators/mygen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os
 

--- a/test cases/common/72 build always/version_gen.py
+++ b/test cases/common/72 build always/version_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os, subprocess
 

--- a/test cases/common/76 configure file in custom target/src/mycompiler.py
+++ b/test cases/common/76 configure file in custom target/src/mycompiler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test cases/common/77 external test program/mytest.py
+++ b/test cases/common/77 external test program/mytest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/test cases/common/78 ctarget dependency/gen1.py
+++ b/test cases/common/78 ctarget dependency/gen1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import time, sys
 

--- a/test cases/common/78 ctarget dependency/gen2.py
+++ b/test cases/common/78 ctarget dependency/gen2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os
 from glob import glob

--- a/test cases/common/93 private include/stlib/compiler.py
+++ b/test cases/common/93 private include/stlib/compiler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os
 

--- a/test cases/common/95 dep fallback/gensrc.py
+++ b/test cases/common/95 dep fallback/gensrc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import shutil

--- a/test cases/common/95 dep fallback/subprojects/boblib/genbob.py
+++ b/test cases/common/95 dep fallback/subprojects/boblib/genbob.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test cases/common/98 gen extra/srcgen.py
+++ b/test cases/common/98 gen extra/srcgen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import argparse

--- a/test cases/frameworks/7 gnome/resources-data/meson.build
+++ b/test cases/frameworks/7 gnome/resources-data/meson.build
@@ -1,5 +1,7 @@
 subdir('subdir')
 
+python3 = import('python3').find_python()
+
 fake_generator_script = '''
 import os, sys
 assert os.path.exists(sys.argv[1]), "File %s not found" % sys.argv[1]
@@ -11,6 +13,6 @@ print("This is a generated resource.")
 res3_txt = custom_target('res3.txt',
   input: 'res3.txt.in',
   output: 'res3.txt',
-  command: ['python3', '-c', fake_generator_script, '@INPUT@'],
+  command: [python3, '-c', fake_generator_script, '@INPUT@'],
   capture: true,
 )


### PR DESCRIPTION
We automatically convert that to use `sys.executable` now which is always available on all platforms (because we're running with it).

On some platforms like NetBSD, `python` doesn't exist, and you must use a specific python version. On most other distros, `python` is Python 2, and we don't want to depend on that.

Closes https://github.com/mesonbuild/meson/issues/695

All these scripts were being used as `find_program()`, so we do not lose any test coverage by doing this.