### PR TITLE
Added --strip-all to strip

### DIFF
--- a/mesonbuild/scripts/meson_install.py
+++ b/mesonbuild/scripts/meson_install.py
@@ -241,7 +241,7 @@ def install_targets(d):
                     print('Not stripping jar target:', os.path.split(fname)[1])
                     continue
                 print('Stripping target {!r}'.format(fname))
-                ps, stdo, stde = Popen_safe(['strip', outname])
+                ps, stdo, stde = Popen_safe(['strip', '-s', outname])
                 if ps.returncode != 0:
                     print('Could not strip file.\n')
                     print('Stdout:\n%s\n' % stdo)


### PR DESCRIPTION
I think it's pretty safe to assume that usually, those who pass strip=true want a release build, with less symbols.