### PR TITLE
d: Handle linker search paths correctly for non-GNU compilers

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1858,6 +1858,16 @@ class DCompiler(Compiler):
                 # translate library link flag
                 dcargs.append('-L' + arg)
                 continue
+            elif arg.startswith('-L/') or arg.startswith('-L./'):
+                # we need to handle cases where -L is set by e.g. a pkg-config
+                # setting to select a linker search path. We can however not
+                # unconditionally prefix '-L' with '-L' because the user might
+                # have set this flag too to do what it is intended to for this
+                # compiler (pass flag through to the linker)
+                # Hence, we guess here whether the flag was intended to pass
+                # a linker search path.
+                dcargs.append('-L' + arg)
+                continue
             dcargs.append(arg)
 
         return dcargs


### PR DESCRIPTION
This is a really really ugly hack, and I would be happy for any advice in how to do it better.
The root problem is LDC and DMD defining the `-L` flag as "pass to the linker", while GCC considers it to mean "add path to linker search path".
Pkg-config files always assume the GCC flag definition.

Since unconditionally appending `-L` will break user's build definitions when they intentionally want the LDC/DMD meaning of `-L`, we can't do that (also, we might end up in weird `-L` appending loops if we aren't careful).

So, in order to e.g. support pkg-config files in `/usr/local/`, this patch will guess what the meaning of `-L` was - if something definitely resembling a path follows, we will direct it to the system linker, otherwise leave the `-L` flag untouched.

I dislike this solution, but I don't see a better one at time (this patch will likely work most of the time).