### PR TITLE
Fix macOS dylib naming and compatibility version — DO NOT MERGE YET

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -2259,7 +2259,11 @@ def get_gcc_soname_args(gcc_type, prefix, shlib_name, suffix, path, soversion, i
     elif gcc_type == GCC_OSX:
         if is_shared_module:
             return []
-        return ['-install_name', os.path.join(path, 'lib' + shlib_name + '.dylib')]
+        args = ['-install_name', os.path.join(path, 'lib' + shlib_name + '.dylib')]
+        if soversion:
+            # FIXME: What about -current_version?
+            args += ['-compatibility_version', soversion]
+        return args
     else:
         raise RuntimeError('Not implemented yet.')
 

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -731,7 +731,7 @@ class CCompiler(Compiler):
         # Almost every compiler uses this for disabling warnings
         return ['-w']
 
-    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion, is_shared_module):
+    def get_soname_args(self, *args):
         return []
 
     def split_shlib_to_parts(self, fname):
@@ -1424,7 +1424,7 @@ class MonoCompiler(Compiler):
     def get_link_args(self, fname):
         return ['-r:' + fname]
 
-    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion, is_shared_module):
+    def get_soname_args(self, *args):
         return []
 
     def get_werror_args(self):
@@ -1505,7 +1505,7 @@ class JavaCompiler(Compiler):
         self.id = 'unknown'
         self.javarunner = 'java'
 
-    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion, is_shared_module):
+    def get_soname_args(self, *args):
         return []
 
     def get_werror_args(self):
@@ -1812,9 +1812,9 @@ class DCompiler(Compiler):
     def get_std_shared_lib_link_args(self):
         return ['-shared']
 
-    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion, is_shared_module):
+    def get_soname_args(self, *args):
         # FIXME: Make this work for Windows, MacOS and cross-compiling
-        return get_gcc_soname_args(GCC_STANDARD, prefix, shlib_name, suffix, path, soversion, is_shared_module)
+        return get_gcc_soname_args(GCC_STANDARD, *args)
 
     def get_unittest_args(self):
         return ['-unittest']
@@ -2253,7 +2253,7 @@ def get_gcc_soname_args(gcc_type, prefix, shlib_name, suffix, path, soversion, i
         sostr = ''
     else:
         sostr = '.' + soversion
-    if gcc_type == GCC_STANDARD or gcc_type == GCC_MINGW:
+    if gcc_type in (GCC_STANDARD, GCC_MINGW):
         # Might not be correct for mingw but seems to work.
         return ['-Wl,-soname,%s%s.%s%s' % (prefix, shlib_name, suffix, sostr)]
     elif gcc_type == GCC_OSX:
@@ -2320,8 +2320,8 @@ class GnuCompiler:
     def split_shlib_to_parts(self, fname):
         return os.path.split(fname)[0], fname
 
-    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion, is_shared_module):
-        return get_gcc_soname_args(self.gcc_type, prefix, shlib_name, suffix, path, soversion, is_shared_module)
+    def get_soname_args(self, *args):
+        return get_gcc_soname_args(self.gcc_type, *args)
 
     def get_std_shared_lib_link_args(self):
         if self.gcc_type == GCC_OSX:
@@ -2460,7 +2460,7 @@ class ClangCompiler:
         # so it might change semantics at any time.
         return ['-include-pch', os.path.join(pch_dir, self.get_pch_name(header))]
 
-    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion, is_shared_module):
+    def get_soname_args(self, *args):
         if self.clang_type == CLANG_STANDARD:
             gcc_type = GCC_STANDARD
         elif self.clang_type == CLANG_OSX:
@@ -2469,7 +2469,7 @@ class ClangCompiler:
             gcc_type = GCC_MINGW
         else:
             raise MesonException('Unreachable code when converting clang type to gcc type.')
-        return get_gcc_soname_args(gcc_type, prefix, shlib_name, suffix, path, soversion, is_shared_module)
+        return get_gcc_soname_args(gcc_type, *args)
 
     def has_multi_arguments(self, args, env):
         return super().has_multi_arguments(
@@ -2589,7 +2589,7 @@ class IntelCompiler:
     def split_shlib_to_parts(self, fname):
         return os.path.split(fname)[0], fname
 
-    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion, is_shared_module):
+    def get_soname_args(self, *args):
         if self.icc_type == ICC_STANDARD:
             gcc_type = GCC_STANDARD
         elif self.icc_type == ICC_OSX:
@@ -2598,7 +2598,7 @@ class IntelCompiler:
             gcc_type = GCC_MINGW
         else:
             raise MesonException('Unreachable code when converting icc type to gcc type.')
-        return get_gcc_soname_args(gcc_type, prefix, shlib_name, suffix, path, soversion, is_shared_module)
+        return get_gcc_soname_args(gcc_type, *args)
 
     def get_std_shared_lib_link_args(self):
         # FIXME: Don't know how icc works on OSX
@@ -2749,8 +2749,8 @@ end program prog
     def split_shlib_to_parts(self, fname):
         return os.path.split(fname)[0], fname
 
-    def get_soname_args(self, prefix, shlib_name, suffix, path, soversion, is_shared_module):
-        return get_gcc_soname_args(self.gcc_type, prefix, shlib_name, suffix, path, soversion, is_shared_module)
+    def get_soname_args(self, *args):
+        return get_gcc_soname_args(self.gcc_type, *args)
 
     def get_dependency_gen_args(self, outtarget, outfile):
         # Disabled until this is fixed:

--- a/test cases/osx/2 library versions/meson.build
+++ b/test cases/osx/2 library versions/meson.build
@@ -39,3 +39,23 @@ test('manually linked 3', executable('manuallink3', out,
 
 test('manually linked 4', executable('manuallink4', out,
   link_args : ['-L.', '-lonlysoversion']))
+
+# Test that the -compatibility_version option enforces a minimum library
+# version at runtime
+subdir('oldlib')
+
+newversion = shared_library('testversion', 'lib.c',
+  soversion : 4)
+
+# Link with the newer dylib and run with it too
+pass = executable('library-version-matching', out,
+  link_with : newversion)
+
+# Link with the newer dylib, and try to run using the older one
+fail = executable('library-version-notmatching', out,
+  # Set the runtime path to the old-version library's build directory
+  link_args : ['-Wl,-rpath,' + oldlib_builddir],
+  link_with : newversion)
+
+test('passing-library-version', pass)
+test('failing-library-version', fail, should_fail : true)

--- a/test cases/osx/2 library versions/oldlib/meson.build
+++ b/test cases/osx/2 library versions/oldlib/meson.build
@@ -1,0 +1,6 @@
+# Can't build two libraries with the name 'testversion' in the same project, so
+# use this hack to effectively get the same library name
+oldversion = shared_library('estversion', '../lib.c',
+  name_prefix : 'libt',
+  soversion : 3)
+oldlib_builddir = meson.current_build_dir()


### PR DESCRIPTION
This is v2 of https://github.com/mesonbuild/meson/pull/680, to fix our dylibs a bit.

* Include the major version in the dylib name (not the minor or micro)
* Add `-compatibility_version` (after testing, I will also add `-current_version`)
* Add tests that check whether you can actually link against the built libraries with `-lfoo` syntax
* Add a test to ensure that the compatibility version is set properly by trying to run with a different library with an older compatibility version at run time.