### PR TITLE
Fix macOS dylib file naming to include the major version + tests

### DIFF
--- a/test cases/linuxlike/7 library versions/exe.orig.c
+++ b/test cases/linuxlike/7 library versions/exe.orig.c
@@ -1,0 +1,5 @@
+int
+main (int argc, char *argv[])
+{
+  return 0;
+}

--- a/test cases/linuxlike/7 library versions/meson.build
+++ b/test cases/linuxlike/7 library versions/meson.build
@@ -1,18 +1,43 @@
 project('library versions', 'c')
 
-shared_library('some', 'lib.c',
+some = shared_library('some', 'lib.c',
   version : '1.2.3',
   soversion : '0',
   install : true)
 
-shared_library('noversion', 'lib.c',
+noversion = shared_library('noversion', 'lib.c',
   install : true)
 
-shared_library('onlyversion', 'lib.c',
+onlyversion = shared_library('onlyversion', 'lib.c',
   version : '1.4.5',
   install : true)
 
-shared_library('onlysoversion', 'lib.c',
+onlysoversion = shared_library('onlysoversion', 'lib.c',
   # Also test that int soversion is acceptable
   soversion : 5,
   install : true)
+
+# Hack to make the executables below depend on the shared libraries above
+# without actually adding them as `link_with` dependencies since we want to try
+# linking to them with -lfoo linker arguments.
+out = custom_target('library-dependency-hack',
+  input : 'exe.orig.c',
+  output : 'exe.c',
+  depends : [some, noversion, onlyversion, onlysoversion],
+  command : ['cp', '@INPUT@', '@OUTPUT@'])
+
+rpath_arg = '-Wl,-rpath,' + meson.current_build_dir()
+
+# Manually test if the linker can find the above libraries
+# i.e., whether they were generated with the right naming scheme
+test('manually linked 1', executable('manuallink1', out,
+  link_args : ['-L.', '-lsome', rpath_arg]))
+
+test('manually linked 2', executable('manuallink2', out,
+  link_args : ['-L.', '-lnoversion', rpath_arg]))
+
+test('manually linked 3', executable('manuallink3', out,
+  link_args : ['-L.', '-lonlyversion', rpath_arg]))
+
+test('manually linked 4', executable('manuallink4', out,
+  link_args : ['-L.', '-lonlysoversion', rpath_arg]))

--- a/test cases/osx/2 library versions/CMakeLists.txt
+++ b/test cases/osx/2 library versions/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.6.0)
+project(dylibversion C)
+
+# This file is here for debugging purposes to easily compare how
+# CMake does it.
+
+add_library(noversion SHARED lib.c)
+
+# libonlysoversion.dylib -> libonlysoversion.5.dylib
+# libonlyversion.1.4.5.dylib
+
+add_library(onlyversion SHARED lib.c)
+set_target_properties(onlyversion PROPERTIES VERSION 1.4.5)
+
+# libnoversion.dylib
+# libonlysoversion.5.dylib
+
+add_library(onlysoversion SHARED lib.c)
+set_target_properties(onlysoversion PROPERTIES SOVERSION 5)
+
+# libsome.1.4.5.dylib
+# libsome.5.dylib -> libsome.1.4.5.dylib
+# libsome.dylib -> libsome.5.dylib
+
+add_library(some SHARED lib.c)
+set_target_properties(some PROPERTIES VERSION 1.4.5 SOVERSION 5)

--- a/test cases/osx/2 library versions/installed_files.txt
+++ b/test cases/osx/2 library versions/installed_files.txt
@@ -1,4 +1,7 @@
 usr/lib/libsome.dylib
+usr/lib/libsome.0.dylib
 usr/lib/libnoversion.dylib
 usr/lib/libonlyversion.dylib
+usr/lib/libonlyversion.1.dylib
 usr/lib/libonlysoversion.dylib
+usr/lib/libonlysoversion.5.dylib

--- a/test cases/windows/7 mingw dll versioning/exe.orig.c
+++ b/test cases/windows/7 mingw dll versioning/exe.orig.c
@@ -1,0 +1,5 @@
+int
+main (int argc, char *argv[])
+{
+  return 0;
+}

--- a/test cases/windows/7 mingw dll versioning/installed_files.txt
+++ b/test cases/windows/7 mingw dll versioning/installed_files.txt
@@ -2,3 +2,7 @@ usr/bin/libsome-0.dll
 usr/lib/libsome.dll.a
 usr/bin/libnoversion.dll
 usr/lib/libnoversion.dll.a
+usr/bin/libonlyversion-1.dll
+usr/lib/libonlyversion.dll.a
+usr/bin/libonlysoversion-5.dll
+usr/lib/libonlysoversion.dll.a

--- a/test cases/windows/7 mingw dll versioning/meson.build
+++ b/test cases/windows/7 mingw dll versioning/meson.build
@@ -8,10 +8,42 @@ endif
 
 # Test that MinGW/GCC creates correctly-named dll files and dll.a files,
 # and also installs them in the right place
-shared_library('some', 'lib.c',
+some = shared_library('some', 'lib.c',
   version : '1.2.3',
   soversion : '0',
   install : true)
 
-shared_library('noversion', 'lib.c',
+noversion = shared_library('noversion', 'lib.c',
   install : true)
+
+onlyversion = shared_library('onlyversion', 'lib.c',
+  version : '1.4.5',
+  install : true)
+
+onlysoversion = shared_library('onlysoversion', 'lib.c',
+  # Also test that int soversion is acceptable
+  soversion : 5,
+  install : true)
+
+# Hack to make the executables below depend on the shared libraries above
+# without actually adding them as `link_with` dependencies since we want to try
+# linking to them with -lfoo linker arguments.
+out = custom_target('library-dependency-hack',
+  input : 'exe.orig.c',
+  output : 'exe.c',
+  depends : [some, noversion, onlyversion, onlysoversion],
+  command : ['cp', '@INPUT@', '@OUTPUT@'])
+
+# Manually test if the linker can find the above libraries
+# i.e., whether they were generated with the right naming scheme
+test('manually linked 1', executable('manuallink1', out,
+  link_args : ['-L.', '-lsome']))
+
+test('manually linked 2', executable('manuallink2', out,
+  link_args : ['-L.', '-lnoversion']))
+
+test('manually linked 3', executable('manuallink3', out,
+  link_args : ['-L.', '-lonlyversion']))
+
+test('manually linked 4', executable('manuallink4', out,
+  link_args : ['-L.', '-lonlysoversion']))

--- a/test cases/windows/8 msvc dll versioning/exe.orig.c
+++ b/test cases/windows/8 msvc dll versioning/exe.orig.c
@@ -1,0 +1,5 @@
+int
+main (int argc, char *argv[])
+{
+  return 0;
+}

--- a/test cases/windows/8 msvc dll versioning/installed_files.txt
+++ b/test cases/windows/8 msvc dll versioning/installed_files.txt
@@ -4,3 +4,7 @@ usr/lib/some.lib
 usr/bin/noversion.dll
 usr/bin/noversion.pdb
 usr/lib/noversion.lib
+usr/bin/onlyversion-1.dll
+usr/lib/onlyversion.lib
+usr/bin/onlysoversion-5.dll
+usr/lib/onlysoversion.lib

--- a/test cases/windows/8 msvc dll versioning/meson.build
+++ b/test cases/windows/8 msvc dll versioning/meson.build
@@ -6,11 +6,44 @@ if cc.get_id() != 'msvc'
   error('MESON_SKIP_TEST: test is only for msvc')
 endif
 
-# Test that MSVC creates foo-0.dll and bar.dll
-shared_library('some', 'lib.c',
+# Test that MSVC creates correctly-named dll files and .lib files,
+# and also installs them in the right place
+some = shared_library('some', 'lib.c',
   version : '1.2.3',
   soversion : '0',
   install : true)
 
-shared_library('noversion', 'lib.c',
+noversion = shared_library('noversion', 'lib.c',
   install : true)
+
+onlyversion = shared_library('onlyversion', 'lib.c',
+  version : '1.4.5',
+  install : true)
+
+onlysoversion = shared_library('onlysoversion', 'lib.c',
+  # Also test that int soversion is acceptable
+  soversion : 5,
+  install : true)
+
+# Hack to make the executables below depend on the shared libraries above
+# without actually adding them as `link_with` dependencies since we want to try
+# linking to them with -lfoo linker arguments.
+out = custom_target('library-dependency-hack',
+  input : 'exe.orig.c',
+  output : 'exe.c',
+  depends : [some, noversion, onlyversion, onlysoversion],
+  command : ['cp', '@INPUT@', '@OUTPUT@'])
+
+# Manually test if the linker can find the above libraries
+# i.e., whether they were generated with the right naming scheme
+test('manually linked 1', executable('manuallink1', out,
+  link_args : ['-L.', '-lsome']))
+
+test('manually linked 2', executable('manuallink2', out,
+  link_args : ['-L.', '-lnoversion']))
+
+test('manually linked 3', executable('manuallink3', out,
+  link_args : ['-L.', '-lonlyversion']))
+
+test('manually linked 4', executable('manuallink4', out,
+  link_args : ['-L.', '-lonlysoversion']))


### PR DESCRIPTION
Subset of https://github.com/mesonbuild/meson/pull/1445, for the next release.