### PR TITLE
tests: Minor fixes to the library-usage tests

### DIFF
--- a/test cases/linuxlike/7 library versions/exe.orig.c
+++ b/test cases/linuxlike/7 library versions/exe.orig.c
@@ -1,5 +1,9 @@
+int myFunc (void);
+
 int
 main (int argc, char *argv[])
 {
-  return 0;
+  if (myFunc() == 55)
+    return 0;
+  return 1;
 }

--- a/test cases/linuxlike/7 library versions/meson.build
+++ b/test cases/linuxlike/7 library versions/meson.build
@@ -26,6 +26,8 @@ out = custom_target('library-dependency-hack',
   depends : [some, noversion, onlyversion, onlysoversion],
   command : ['cp', '@INPUT@', '@OUTPUT@'])
 
+# Need to add this manually because Meson can't add it automatically because
+# it doesn't know that we are linking to libraries in the build directory.
 rpath_arg = '-Wl,-rpath,' + meson.current_build_dir()
 
 # Manually test if the linker can find the above libraries

--- a/test cases/osx/2 library versions/exe.orig.c
+++ b/test cases/osx/2 library versions/exe.orig.c
@@ -1,4 +1,9 @@
+int myFunc (void);
+
 int
 main (int argc, char *argv[])
 {
+  if (myFunc() == 55)
+    return 0;
+  return 1;
 }

--- a/test cases/osx/2 library versions/meson.build
+++ b/test cases/osx/2 library versions/meson.build
@@ -28,14 +28,14 @@ out = custom_target('library-dependency-hack',
 
 # Manually test if the linker can find the above libraries
 # i.e., whether they were generated with the right naming scheme
-executable('manuallink1', out,
-  link_args : ['-L.', '-lsome'])
+test('manually linked 1', executable('manuallink1', out,
+  link_args : ['-L.', '-lsome']))
 
-executable('manuallink2', out,
-  link_args : ['-L.', '-lnoversion'])
+test('manually linked 2', executable('manuallink2', out,
+  link_args : ['-L.', '-lnoversion']))
 
-executable('manuallink3', out,
-  link_args : ['-L.', '-lonlyversion'])
+test('manually linked 3', executable('manuallink3', out,
+  link_args : ['-L.', '-lonlyversion']))
 
-executable('manuallink4', out,
-  link_args : ['-L.', '-lonlysoversion'])
+test('manually linked 4', executable('manuallink4', out,
+  link_args : ['-L.', '-lonlysoversion']))

--- a/test cases/windows/7 mingw dll versioning/exe.orig.c
+++ b/test cases/windows/7 mingw dll versioning/exe.orig.c
@@ -1,5 +1,9 @@
+int myFunc (void);
+
 int
 main (int argc, char *argv[])
 {
-  return 0;
+  if (myFunc() == 55)
+    return 0;
+  return 1;
 }

--- a/test cases/windows/8 msvc dll versioning/exe.orig.c
+++ b/test cases/windows/8 msvc dll versioning/exe.orig.c
@@ -1,5 +1,9 @@
+int myFunc (void);
+
 int
 main (int argc, char *argv[])
 {
-  return 0;
+  if (myFunc() == 55)
+    return 0;
+  return 1;
 }


### PR DESCRIPTION
Actually use the `myFunc()` symbol from the library and actually run the built executable on macOS.

I saw this now, want to ensure that this stuff actually does work on all platforms. Would be nice to get this merged for the release, just to improve the tests.