### PR TITLE
Do not colorize output on dumb terminals

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -67,3 +67,4 @@ Fabio Porcedda
 Rodrigo Lourenço
 Sebastian Stang
 Marc Becker
+Michal Sojka

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -18,7 +18,8 @@ import sys, os, platform, io
 information about Meson runs. Some output goes to screen,
 some to logging dir and some goes to both."""
 
-colorize_console = platform.system().lower() != 'windows' and os.isatty(sys.stdout.fileno())
+colorize_console = platform.system().lower() != 'windows' and os.isatty(sys.stdout.fileno()) and \
+    os.environ.get('TERM') != 'dumb'
 log_dir = None
 log_file = None
 


### PR DESCRIPTION
Dumb terminal is provided e.g. by Emacs for programs run within it.