### PR TITLE
Add an option c_std and cpp_std when building c and c++ targets.

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1864,7 +1864,7 @@ rule FORTRAN_DEP_HACK
         commands += self.escape_extra_args(compiler,
                                            target.get_extra_args(compiler.get_language()))
         # Add per-target compiler standard version.
-        if(target.get_compiler_standard(compiler.get_language()) != None):
+        if(target.get_compiler_standard(compiler.get_language()) is not None):
             commands += [compiler.get_standard_args(target.get_compiler_standard(compiler.get_language()))]
         # Add source dir and build dir. Project-specific and target-specific
         # include paths must override per-target compile args, include paths

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1863,6 +1863,9 @@ rule FORTRAN_DEP_HACK
         # near the end since these are supposed to override everything else.
         commands += self.escape_extra_args(compiler,
                                            target.get_extra_args(compiler.get_language()))
+        # Add per-target compiler standard version.
+        if(target.get_compiler_standard(compiler.get_language()) != None):
+            commands += [compiler.get_standard_args(target.get_compiler_standard(compiler.get_language()))]
         # Add source dir and build dir. Project-specific and target-specific
         # include paths must override per-target compile args, include paths
         # from external dependencies, internal dependencies, and from
@@ -1981,7 +1984,7 @@ rule FORTRAN_DEP_HACK
 
     # Fortran is a bit weird (again). When you link against a library, just compiling a source file
     # requires the mod files that are output when single files are built. To do this right we would need to
-    # scan all inputs and write out explicit deps for each file. That is stoo slow and too much effort so
+    # scan all inputs and write out explicit deps for each file. That is too slow and too much effort so
     # instead just have an ordered dependendy on the library. This ensures all required mod files are created.
     # The real deps are then detected via dep file generation from the compiler. This breaks on compilers that
     # produce incorrect dep files but such is life.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -568,9 +568,9 @@ class BuildTarget(Target):
             clist = [clist]
         self.add_compiler_args('c', clist)
         cstd = kwargs.get('c_std', None)
-        if not isinstance(cstd, str) and cstd != None:
+        if not isinstance(cstd, str) and cstd is not None:
             raise InvalidArguments('c_std argument must be a string.')
-        if cstd != None:
+        if cstd is not None:
             self.set_compiler_standard('c', cstd)
         cpplist = kwargs.get('cpp_args', [])
         if not isinstance(cpplist, list):
@@ -581,9 +581,9 @@ class BuildTarget(Target):
             cslist = [cslist]
         self.add_compiler_args('cs', cslist)
         cppstd = kwargs.get('cpp_std', None)
-        if not isinstance(cppstd, str) and cppstd != None:
+        if not isinstance(cppstd, str) and cppstd is not None:
             raise InvalidArguments('cpp_std argument must be a string.')
-        if cppstd != None:
+        if cppstd is not None:
             self.set_compiler_standard('cpp', cppstd)
         valalist = kwargs.get('vala_args', [])
         if not isinstance(valalist, list):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -26,7 +26,9 @@ known_basic_kwargs = {'install': True,
                       'c_pch': True,
                       'cpp_pch': True,
                       'c_args': True,
+                      'c_std': True,
                       'cpp_args': True,
+                      'cpp_std': True,
                       'cs_args': True,
                       'vala_args': True,
                       'fortran_args': True,
@@ -297,6 +299,7 @@ class BuildTarget(Target):
         self.include_dirs = []
         self.link_targets = []
         self.link_depends = []
+        self.compiler_version = {}
         self.name_prefix_set = False
         self.name_suffix_set = False
         self.filename = 'no_name'
@@ -564,6 +567,11 @@ class BuildTarget(Target):
         if not isinstance(clist, list):
             clist = [clist]
         self.add_compiler_args('c', clist)
+        cstd = kwargs.get('c_std', None)
+        if not isinstance(cstd, str) and cstd != None:
+            raise InvalidArguments('c_std argument must be a string.')
+        if cstd != None:
+            self.set_compiler_standard('c', cstd)
         cpplist = kwargs.get('cpp_args', [])
         if not isinstance(cpplist, list):
             cpplist = [cpplist]
@@ -572,6 +580,11 @@ class BuildTarget(Target):
         if not isinstance(cslist, list):
             cslist = [cslist]
         self.add_compiler_args('cs', cslist)
+        cppstd = kwargs.get('cpp_std', None)
+        if not isinstance(cppstd, str) and cppstd != None:
+            raise InvalidArguments('cpp_std argument must be a string.')
+        if cppstd != None:
+            self.set_compiler_standard('cpp', cppstd)
         valalist = kwargs.get('vala_args', [])
         if not isinstance(valalist, list):
             valalist = [valalist]
@@ -821,6 +834,15 @@ You probably should put it in link_with instead.''')
             self.extra_args[language] += args
         else:
             self.extra_args[language] = args
+
+    def set_compiler_standard(self, language, version):
+        self.compiler_version[language] = version
+
+    def get_compiler_standard(self, language,):
+        if language in self.compiler_version:
+            return self.compiler_version[language]
+        else:
+            return None
 
     def get_aliases(self):
         return {}

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -2156,6 +2156,11 @@ class VisualStudioCCompiler(CCompiler):
             result.append(i)
         return result
 
+    def get_standard_args(self, version):
+        # Visual studio doesn't support standard versions in the C
+        # compiler. Give no argument and hope for the best.
+        return ''
+
     def get_werror_args(self):
         return ['/WX']
 
@@ -2229,6 +2234,13 @@ class VisualStudioCPPCompiler(VisualStudioCCompiler, CPPCompiler):
         if std.value != 'none':
             args.append('/EH' + std.value)
         return args
+
+    def get_standard_args(self, version):
+        # Visual studio only has flags for c++14 and later.
+        if version in ['c++03', 'c++11', 'c++14']:
+            return '/std:c++14'
+        else:
+            raise MesonException('Invalid C++ standard ' + version)
 
     def get_option_link_args(self, options):
         return options['cpp_winlibs'].value[:]

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -2697,7 +2697,7 @@ class IntelCPPCompiler(IntelCompiler, CPPCompiler):
             c_stds += ['c++17']
         if mesonlib.version_compare(self.version, '>=17.0.0'):
             g_stds += ['gnu++14']
-        return c_std + g_stds
+        return c_stds + g_stds
 
     def get_options(self):
         opts = {'cpp_std': coredata.UserComboOption('cpp_std', 'C++ language standard to use',

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -2532,10 +2532,12 @@ class ClangCCompiler(ClangCompiler, CCompiler):
                           '2': default_warn_args + ['-Wextra'],
                           '3': default_warn_args + ['-Wextra', '-Wpedantic']}
 
+    def get_standard_versions(self):
+        return ['c89', 'c99', 'c11', 'gnu89', 'gnu99', 'gnu11']
+
     def get_options(self):
         return {'c_std': coredata.UserComboOption('c_std', 'C language standard to use',
-                                                  ['none', 'c89', 'c99', 'c11',
-                                                   'gnu89', 'gnu99', 'gnu11'],
+                                                  ['none'] + self.get_standard_versions(),
                                                   'none')}
 
     def get_option_compile_args(self, options):
@@ -2544,6 +2546,12 @@ class ClangCCompiler(ClangCompiler, CCompiler):
         if std.value != 'none':
             args.append('-std=' + std.value)
         return args
+
+    def get_standard_args(self, version):
+        if version in self.get_standard_versions():
+            return '-std=' + version
+        else:
+            raise MesonException('Invalid C++ standard ' + version)
 
     def get_option_link_args(self, options):
         return []

--- a/test cases/common/139 standard version/c++11.cc
+++ b/test cases/common/139 standard version/c++11.cc
@@ -1,4 +1,10 @@
 int main()
 {
+    #ifdef _MSC_VER
+    // Visual studio always returns 199711, so disable this test.
+    // https://connect.microsoft.com/VisualStudio/feedback/details/763051/a-value-of-predefined-macro-cplusplus-is-still-199711l
+    return 0;
+    #else
     return __cplusplus == 201103 ? 0 : 1;
+    #endif
 }

--- a/test cases/common/139 standard version/c++11.cc
+++ b/test cases/common/139 standard version/c++11.cc
@@ -1,0 +1,4 @@
+int main()
+{
+    return __cplusplus == 201103 ? 0 : 1;
+}

--- a/test cases/common/139 standard version/c++14.cc
+++ b/test cases/common/139 standard version/c++14.cc
@@ -1,0 +1,4 @@
+int main()
+{
+    return __cplusplus == 201402 ? 0 : 1;
+}

--- a/test cases/common/139 standard version/c++14.cc
+++ b/test cases/common/139 standard version/c++14.cc
@@ -1,4 +1,12 @@
+#include <iostream>
+
 int main()
 {
+    #ifdef _MSC_VER
+    // Visual studio always returns 199711, so disable this test.
+    // https://connect.microsoft.com/VisualStudio/feedback/details/763051/a-value-of-predefined-macro-cplusplus-is-still-199711l
+    return 0;
+    #else
     return __cplusplus == 201402 ? 0 : 1;
+    #endif
 }

--- a/test cases/common/139 standard version/c89.c
+++ b/test cases/common/139 standard version/c89.c
@@ -1,0 +1,9 @@
+int main()
+{
+    /* __STDC_VERSION__ should be 199409L in C89, but it may not be defined at all. */
+    #ifdef __STDC_VERSION
+    return __STDC_VERSION__ ==  199409L ? 0 : 1;
+    #else
+    return 0;
+    #endif
+}

--- a/test cases/common/139 standard version/c99.c
+++ b/test cases/common/139 standard version/c99.c
@@ -1,4 +1,10 @@
 int main()
 {
+    #ifdef _MSC_VER
+    /* Visual studio does not support C standard versions, so
+       fake success for this test. */
+    return 0;
+    #else
     return __STDC_VERSION__ ==  199901L ? 0 : 1;
+    #endif
 }

--- a/test cases/common/139 standard version/c99.c
+++ b/test cases/common/139 standard version/c99.c
@@ -1,0 +1,4 @@
+int main()
+{
+    return __STDC_VERSION__ ==  199901L ? 0 : 1;
+}

--- a/test cases/common/139 standard version/meson.build
+++ b/test cases/common/139 standard version/meson.build
@@ -1,0 +1,6 @@
+project('standard', 'c', 'cpp')
+
+test('c89', executable('c89', 'c89.c', c_std : 'c89'))
+test('c99', executable('c99', 'c99.c', c_std : 'c99'))
+test('c++11', executable('c++11', 'c++11.cc', cpp_std : 'c++11'))
+test('c++14', executable('c++14', 'c++14.cc', cpp_std : 'c++14'))


### PR DESCRIPTION
Allows specifying the c or c++ standard version to use per target. For one of my projects, I need to build two libraries, one must be built as c++03 and one must be built as c++11, this change makes that possible.

The global option to set the standard version remains, however if both are
used at the same time, the command line arguments for both options will
be passed to the compiler, and the compiler may be confused.

Should the global option be removed? It's not like the other options, in that it makes no sense to configure this on the command line, the code is written according to some standard and that's what must be used, so I'm not really sure why it's an option.