### PR TITLE
Add UNIX large file support via compiler always-args

### DIFF
--- a/test cases/linuxlike/10 large file support/meson.build
+++ b/test cases/linuxlike/10 large file support/meson.build
@@ -1,0 +1,12 @@
+project('trivial test', 'c')
+
+cc = meson.get_compiler('c')
+
+size = cc.sizeof('off_t')
+assert(size == 8, 'off_t size is @0@ bytes instead of 8'.format(size))
+
+code = '''#if !defined(_FILE_OFFSET_BITS) || (_FILE_OFFSET_BITS != 64)
+#error "Large-file support was not enabled"
+#endif'''
+
+assert(cc.compiles(code, name : 'checking for LFS'), 'Large file support was not enabled')


### PR DESCRIPTION
On 32-bit Linux and BSD, all libcs support this. Musl always enables it, and UClibc behaves like Glibc unless it's built without large file support (which is a terrible idea).

http://wiki.musl-libc.org/wiki/FAQ#Q:_do_i_need_to_define_LARGEFILE64_SOURCE_to_get_64bit_off_t_.3F
https://git.uclibc.org/uClibc/tree/include/features.h#n326

macOS now only ships 64-bit, so this is irrelevant there.

32-bit Windows and older versions of Bionic do not have transparent large file support and you must use `lseek64`, etc there, so this won't affect those. Newer Bionic versions behave like Glibc in theory.

https://msdn.microsoft.com/en-us/library/1yee101t.aspx
http://code.google.com/p/android/issues/detail?id=64613

Closes https://github.com/mesonbuild/meson/issues/1032