### PR TITLE
EmptyNode needs a line/column number too.

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -68,3 +68,4 @@ Rodrigo Lourenço
 Sebastian Stang
 Marc Becker
 Michal Sojka
+Aaron Small


### PR DESCRIPTION
As per #1459, there are some cases where EmptyNode's position is referenced, resulting in printing an unhelpful error message.

Not all of the places EmptyNode is used are referenced, so they don't all need a column/line number, but it doesn't hurt to add it everywhere just in case.