### PR TITLE
has_header: Use "foo.h" syntax instead of <foo.h>

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -892,11 +892,11 @@ class CCompiler(Compiler):
         fargs = {'prefix': prefix, 'header': hname}
         code = '''{prefix}
         #ifdef __has_include
-         #if !__has_include(<{header}>)
+         #if !__has_include("{header}")
           #error "Header '{header}' could not be found"
          #endif
         #else
-         #include<{header}>
+         #include <{header}>
         #endif'''
         return self.compiles(code.format(**fargs), env, extra_args,
                              dependencies, 'preprocess')

--- a/test cases/common/37 has header/meson.build
+++ b/test cases/common/37 has header/meson.build
@@ -1,5 +1,14 @@
 project('has header', 'c', 'cpp')
 
+host_system = host_machine.system()
+
+non_existant_header = 'ouagadougou.h'
+
+# Copy it into the builddir to ensure that it isn't found even if it's there
+configure_file(input : non_existant_header,
+  output : non_existant_header,
+  configuration : configuration_data())
+
 foreach comp : [meson.get_compiler('c'), meson.get_compiler('cpp')]
   if not comp.has_header('stdio.h')
     error('Stdio missing.')
@@ -25,8 +34,14 @@ foreach comp : [meson.get_compiler('c'), meson.get_compiler('cpp')]
     endif
   endif
 
-
-  if comp.has_header('ouagadougou.h')
-    error('Found non-existant header.')
+  # Test that the following GCC bug doesn't happen:
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80005
+  # https://github.com/mesonbuild/meson/issues/1458
+  if host_system == 'linux'
+    assert(comp.has_header('linux/if.h'), 'Could not find <linux/if.h>')
   endif
+
+  # This header exists in the source and the builddir, but we still must not
+  # find it since we are looking in the system directories.
+  assert(not comp.has_header(non_existant_header), 'Found non-existant header.')
 endforeach

--- a/test cases/common/37 has header/ouagadougou.h
+++ b/test cases/common/37 has header/ouagadougou.h
@@ -1,0 +1,1 @@
+#define OMG_THIS_SHOULDNT_BE_FOUND


### PR DESCRIPTION
This is broken on GCC due to a GCC bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80005

It doesn't matter whether we use `<>` or `""` in our checks because we run them from an empty temporary directory anyway.

Includes a test for all this.

Closes https://github.com/mesonbuild/meson/issues/1458