### PR TITLE
tests/37 has header: Also test the fallback include check

### DIFF
--- a/test cases/common/37 has header/meson.build
+++ b/test cases/common/37 has header/meson.build
@@ -9,39 +9,41 @@ configure_file(input : non_existant_header,
   output : non_existant_header,
   configuration : configuration_data())
 
-foreach comp : [meson.get_compiler('c'), meson.get_compiler('cpp')]
-  if not comp.has_header('stdio.h')
-    error('Stdio missing.')
-  endif
+# Test that the fallback to __has_include also works on all compilers
+args = [[], ['-U__has_include']]
 
-  # stdio.h doesn't actually need stdlib.h, but just test that setting the
-  # prefix does not result in an error.
-  if not comp.has_header('stdio.h', prefix : '#include <stdlib.h>')
-    error('Stdio missing.')
-  endif
+foreach arg : args
+  foreach comp : [meson.get_compiler('c'), meson.get_compiler('cpp')]
+    assert(comp.has_header('stdio.h', args : arg), 'Stdio missing.')
 
-  # XInput.h should not require type definitions from windows.h, but it does
-  # require macro definitions. Specifically, it requires an arch setting for
-  # VS2015 at least.
-  # We only do this check on MSVC because MinGW often defines its own wrappers
-  # that pre-include windows.h
-  if comp.get_id() == 'msvc'
-    if not comp.has_header('XInput.h', prefix : '#include <windows.h>')
-      error('XInput.h should not be missing on Windows')
+    # stdio.h doesn't actually need stdlib.h, but just test that setting the
+    # prefix does not result in an error.
+    assert(comp.has_header('stdio.h', prefix : '#include <stdlib.h>', args : arg),
+           'Stdio missing.')
+
+    # XInput.h should not require type definitions from windows.h, but it does
+    # require macro definitions. Specifically, it requires an arch setting for
+    # VS2015 at least.
+    # We only do this check on MSVC because MinGW often defines its own wrappers
+    # that pre-include windows.h
+    if comp.get_id() == 'msvc'
+      assert(comp.has_header('XInput.h', prefix : '#include <windows.h>', args : arg),
+             'XInput.h should not be missing on Windows')
+      assert(comp.has_header('XInput.h', prefix : '#define _X86_', args : arg),
+             'XInput.h should not need windows.h')
     endif
-    if not comp.has_header('XInput.h', prefix : '#define _X86_')
-      error('XInput.h should not need windows.h')
+
+    # Test that the following GCC bug doesn't happen:
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80005
+    # https://github.com/mesonbuild/meson/issues/1458
+    if host_system == 'linux'
+      assert(comp.has_header('linux/if.h', args : arg),
+             'Could not find <linux/if.h>')
     endif
-  endif
 
-  # Test that the following GCC bug doesn't happen:
-  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80005
-  # https://github.com/mesonbuild/meson/issues/1458
-  if host_system == 'linux'
-    assert(comp.has_header('linux/if.h'), 'Could not find <linux/if.h>')
-  endif
-
-  # This header exists in the source and the builddir, but we still must not
-  # find it since we are looking in the system directories.
-  assert(not comp.has_header(non_existant_header), 'Found non-existant header.')
+    # This header exists in the source and the builddir, but we still must not
+    # find it since we are looking in the system directories.
+    assert(not comp.has_header(non_existant_header, args : arg),
+           'Found non-existant header.')
+  endforeach
 endforeach

--- a/test cases/common/37 has header/meson.build
+++ b/test cases/common/37 has header/meson.build
@@ -10,7 +10,12 @@ configure_file(input : non_existant_header,
   configuration : configuration_data())
 
 # Test that the fallback to __has_include also works on all compilers
-args = [[], ['-U__has_include']]
+if host_system != 'darwin'
+  args = [[], ['-U__has_include']]
+else
+  # On Darwin's clang you can't redefine builtin macros so the above doesn't work
+  args = [[]]
+endif
 
 foreach arg : args
   foreach comp : [meson.get_compiler('c'), meson.get_compiler('cpp')]


### PR DESCRIPTION
Also forcibly undefine `__has_include` and test that the fallback include check in `cc.has_header()` works.

This is important because all the latest compilers support it now and we might have no test coverage at all by accident. GCC 5, ICC 17, Clang 3.8, and VS2015 Update 2 already support it.