### PR TITLE
vs: support output of generators in custom targets

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -129,10 +129,9 @@ class Vs2010Backend(backends.Backend):
                     args = self.replace_outputs(args, target_private_dir, outfiles_rel)
                     args = [x.replace("@SOURCE_DIR@", self.environment.get_source_dir()).replace("@BUILD_DIR@", target_private_dir)
                             for x in args]
-                    fullcmd = exe_arr + self.replace_extra_args(args, genlist)
-                    command = ' '.join(self.special_quote(fullcmd))
+                    cmd = exe_arr + self.replace_extra_args(args, genlist)
                     cbs = ET.SubElement(idgroup, 'CustomBuild', Include=infilename)
-                    ET.SubElement(cbs, 'Command').text = command
+                    ET.SubElement(cbs, 'Command').text = ' '.join(self.quote_arguments(cmd))
                     ET.SubElement(cbs, 'Outputs').text = ';'.join(outfiles)
         return generator_output_files, custom_target_output_files, custom_target_include_dirs
 
@@ -331,8 +330,8 @@ class Vs2010Backend(backends.Backend):
         directories = os.path.normpath(target.subdir).split(os.sep)
         return os.sep.join(['..'] * len(directories))
 
-    def special_quote(self, arr):
-        return ['&quot;%s&quot;' % i for i in arr]
+    def quote_arguments(self, arr):
+        return ['"%s"' % i for i in arr]
 
     def create_basic_crap(self, target):
         project_name = target.name
@@ -404,8 +403,7 @@ class Vs2010Backend(backends.Backend):
         # from the target dir, not the build root.
         target.absolute_paths = True
         (srcs, ofilenames, cmd) = self.eval_custom_target_command(target, True)
-        cmd_templ = '''"%s" ''' * len(cmd)
-        ET.SubElement(customstep, 'Command').text = cmd_templ % tuple(cmd)
+        ET.SubElement(customstep, 'Command').text = ' '.join(self.quote_arguments(cmd))
         ET.SubElement(customstep, 'Outputs').text = ';'.join(ofilenames)
         ET.SubElement(customstep, 'Inputs').text = ';'.join(srcs)
         ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.targets')

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -93,9 +93,6 @@ class Vs2010Backend(backends.Backend):
 
     def generate_custom_generator_commands(self, target, parent_node):
         generator_output_files = []
-        commands = []
-        inputs = []
-        outputs = []
         custom_target_include_dirs = []
         custom_target_output_files = []
         target_private_dir = self.relpath(self.get_target_private_dir(target), self.get_target_dir(target))
@@ -116,6 +113,7 @@ class Vs2010Backend(backends.Backend):
                 outfilelist = genlist.get_outputs()
                 exe_arr = self.exe_object_to_cmd_array(exe)
                 base_args = generator.get_arglist()
+                idgroup = ET.SubElement(parent_node, 'ItemGroup')
                 for i in range(len(infilelist)):
                     if len(infilelist) == len(outfilelist):
                         sole_output = os.path.join(target_private_dir, outfilelist[i])
@@ -132,18 +130,10 @@ class Vs2010Backend(backends.Backend):
                     args = [x.replace("@SOURCE_DIR@", self.environment.get_source_dir()).replace("@BUILD_DIR@", target_private_dir)
                             for x in args]
                     fullcmd = exe_arr + self.replace_extra_args(args, genlist)
-                    commands.append(' '.join(self.special_quote(fullcmd)))
-                    inputs.append(infilename)
-                    outputs.extend(outfiles)
-        if len(commands) > 0:
-            idgroup = ET.SubElement(parent_node, 'ItemDefinitionGroup')
-            cbs = ET.SubElement(idgroup, 'CustomBuildStep')
-            ET.SubElement(cbs, 'Command').text = '\r\n'.join(commands)
-            ET.SubElement(cbs, 'Inputs').text = ";".join(inputs)
-            ET.SubElement(cbs, 'Outputs').text = ';'.join(outputs)
-            ET.SubElement(cbs, 'Message').text = 'Generating custom sources.'
-            pg = ET.SubElement(parent_node, 'PropertyGroup')
-            ET.SubElement(pg, 'CustomBuildBeforeTargets').text = 'ClCompile'
+                    command = ' '.join(self.special_quote(fullcmd))
+                    cbs = ET.SubElement(idgroup, 'CustomBuild', Include=infilename)
+                    ET.SubElement(cbs, 'Command').text = command
+                    ET.SubElement(cbs, 'Outputs').text = ';'.join(outfiles)
         return generator_output_files, custom_target_output_files, custom_target_include_dirs
 
     def generate(self, interp):
@@ -205,8 +195,7 @@ class Vs2010Backend(backends.Backend):
                 for d in [target.command] + target.args:
                     if isinstance(d, (build.BuildTarget, build.CustomTarget)):
                         all_deps[d.get_id()] = d
-            # BuildTarget
-            else:
+            elif isinstance(target, build.BuildTarget):
                 for ldep in target.link_targets:
                     all_deps[ldep.get_id()] = ldep
                 for obj_id, objdep in self.get_obj_target_deps(target.objects):
@@ -218,6 +207,8 @@ class Vs2010Backend(backends.Backend):
                         gen_exe = gendep.generator.get_exe()
                         if isinstance(gen_exe, build.Executable):
                             all_deps[gen_exe.get_id()] = gen_exe
+            else:
+                raise MesonException('Unknown target type for target %s' % target)
         if not t or not recursive:
             return all_deps
         ret = self.get_target_deps(all_deps, recursive)
@@ -418,6 +409,7 @@ class Vs2010Backend(backends.Backend):
         ET.SubElement(customstep, 'Outputs').text = ';'.join(ofilenames)
         ET.SubElement(customstep, 'Inputs').text = ';'.join(srcs)
         ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.targets')
+        self.generate_custom_generator_commands(target, root)
         tree = ET.ElementTree(root)
         tree.write(ofname, encoding='utf-8', xml_declaration=True)
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -457,14 +457,14 @@ class Vs2010Backend(backends.Backend):
 
     @staticmethod
     def has_objects(objects, additional_objects, generated_objects):
-        # Ignore generated objects, those are automatically used by MSBuild for VS2010, because they are part of
-        # the CustomBuildStep Outputs.
+        # Ignore generated objects, those are automatically used by MSBuild because they are part of
+        # the CustomBuild Outputs.
         return len(objects) + len(additional_objects) > 0
 
     @staticmethod
     def add_generated_objects(node, generated_objects):
-        # Do not add generated objects to project file. Those are automatically used by MSBuild for VS2010, because
-        # they are part of the CustomBuildStep Outputs.
+        # Do not add generated objects to project file. Those are automatically used by MSBuild, because
+        # they are part of the CustomBuild Outputs.
         return
 
     @staticmethod

--- a/mesonbuild/backend/vs2015backend.py
+++ b/mesonbuild/backend/vs2015backend.py
@@ -23,14 +23,3 @@ class Vs2015Backend(Vs2010Backend):
         self.platform_toolset = 'v140'
         self.vs_version = '2015'
 
-    @staticmethod
-    def has_objects(objects, additional_objects, generated_objects):
-        # VS2015 requires generated objects to be added explicitly to the project file.
-        return len(objects) + len(additional_objects) + len(generated_objects) > 0
-
-    @staticmethod
-    def add_generated_objects(node, generated_objects):
-        # VS2015 requires generated objects to be added explicitly to the project file.
-        for s in generated_objects:
-            ET.SubElement(node, 'Object', Include=s)
-        return

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1277,7 +1277,7 @@ class CustomTarget(Target):
         for c in self.sources:
             if hasattr(c, 'held_object'):
                 c = c.held_object
-            if isinstance(c, (BuildTarget, CustomTarget, GeneratedList)):
+            if isinstance(c, (BuildTarget, CustomTarget)):
                 deps.append(c)
         return deps
 
@@ -1402,8 +1402,17 @@ class CustomTarget(Target):
     def get_sources(self):
         return self.sources
 
+    def get_generated_lists(self):
+        genlists = []
+        for c in self.sources:
+            if hasattr(c, 'held_object'):
+                c = c.held_object
+            if isinstance(c, GeneratedList):
+                genlists.append(c)
+        return genlists
+
     def get_generated_sources(self):
-        return []
+        return self.get_generated_lists()
 
     def type_suffix(self):
         return "@cus"

--- a/test cases/common/113 generatorcustom/meson.build
+++ b/test cases/common/113 generatorcustom/meson.build
@@ -1,21 +1,18 @@
 project('generatorcustom', 'c')
 
-if meson.get_compiler('c').get_id() != 'msvc'
-  creator = find_program('gen.py')
-  catter = find_program('catter.py')
+creator = find_program('gen.py')
+catter = find_program('catter.py')
 
-  gen = generator(creator,
-    output: '@BASENAME@.h',
-    arguments : ['@INPUT@', '@OUTPUT@'])
+gen = generator(creator,
+  output: '@BASENAME@.h',
+  arguments : ['@INPUT@', '@OUTPUT@'])
 
-  hs = gen.process('res1.txt', 'res2.txt')
+hs = gen.process('res1.txt', 'res2.txt')
 
-  allinone = custom_target('alltogether',
-      input : hs,
-      output : 'alltogether.h',
-      command : [catter, '@INPUT@', '@OUTPUT@'])
+allinone = custom_target('alltogether',
+    input : hs,
+    output : 'alltogether.h',
+    command : [catter, '@INPUT@', '@OUTPUT@'])
 
-  executable('proggie', 'main.c', allinone)
-else
-  error('MESON_SKIP_TEST: Skipping test on VS backend; see: https://github.com/mesonbuild/meson/issues/1004')
-endif
+executable('proggie', 'main.c', allinone)
+


### PR DESCRIPTION
This basically is 475175f4b5e5aecdd48455efb6a10f4bd7ce7b81 for the visual studio backends.
By changing CustomBuildStep to CustomBuild, the vs2010 and vs2015 backend now behave the same again and the only distinction in the generated solution is the `platform_toolset`, which tells msbuild which compiler version to use.

Closes #1004.