### PR TITLE
vs: Always use a wrapper for custom target commands

### DIFF
--- a/test cases/common/117 custom target capture/meson.build
+++ b/test cases/common/117 custom target capture/meson.build
@@ -2,10 +2,6 @@ project('custom target', 'c')
 
 python3 = import('python3').find_python()
 
-if meson.backend().startswith('vs')
-  error('MESON_SKIP_TEST: capturing of custom target output is broken with the VS backends')
-endif
-
 # Note that this will not add a dependency to the compiler executable.
 # Code will not be rebuilt if it changes.
 comp = '@0@/@1@'.format(meson.current_source_dir(), 'my_compiler.py')


### PR DESCRIPTION
Besides fixing output capture, it also fixes a strange bug in MSBuild where if the command list is too long, it will remove random characters from the command list before passing it to the command.

Closes https://github.com/mesonbuild/meson/issues/1417