### PR TITLE
vs: Fix custom target generated object paths

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -878,7 +878,7 @@ class Vs2010Backend(backends.Backend):
             assert(isinstance(o, str))
             additional_objects.append(o)
         for o in custom_objs:
-            additional_objects.append(self.relpath(o, self.get_target_dir(target)))
+            additional_objects.append(o)
         if len(additional_links) > 0:
             additional_links.append('%(AdditionalDependencies)')
             ET.SubElement(link, 'AdditionalDependencies').text = ';'.join(additional_links)

--- a/test cases/common/139 custom target object output/meson.build
+++ b/test cases/common/139 custom target object output/meson.build
@@ -1,0 +1,16 @@
+project('custom target object output', 'c')
+
+comp = find_program('obj_generator.py')
+
+if host_machine.system() == 'windows'
+  outputname = '@BASENAME@.obj'
+else
+  outputname = '@BASENAME@.o'
+endif
+
+cc = meson.get_compiler('c').cmd_array().get(-1)
+
+subdir('objdir')
+subdir('progdir')
+
+test('objgen', e)

--- a/test cases/common/139 custom target object output/obj_generator.py
+++ b/test cases/common/139 custom target object output/obj_generator.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Mimic a binary that generates an object file (e.g. windres).
+
+import sys, subprocess
+
+if __name__ == '__main__':
+    if len(sys.argv) != 4:
+        print(sys.argv[0], 'compiler input_file output_file')
+        sys.exit(1)
+    compiler = sys.argv[1]
+    ifile = sys.argv[2]
+    ofile = sys.argv[3]
+    if compiler.endswith('cl'):
+        cmd = [compiler, '/nologo', '/MDd', '/Fo' + ofile, '/c', ifile]
+    else:
+        cmd = [compiler, '-c', ifile, '-o', ofile]
+    sys.exit(subprocess.call(cmd))

--- a/test cases/common/139 custom target object output/objdir/meson.build
+++ b/test cases/common/139 custom target object output/objdir/meson.build
@@ -1,0 +1,5 @@
+# Generate an object file manually.
+object = custom_target('object',
+  input : 'source.c',
+  output : outputname,
+  command : [comp, cc, '@INPUT@', '@OUTPUT@'])

--- a/test cases/common/139 custom target object output/objdir/source.c
+++ b/test cases/common/139 custom target object output/objdir/source.c
@@ -1,0 +1,3 @@
+int func1_in_obj() {
+    return 0;
+}

--- a/test cases/common/139 custom target object output/progdir/meson.build
+++ b/test cases/common/139 custom target object output/progdir/meson.build
@@ -1,0 +1,1 @@
+e = executable('prog', 'prog.c', object)

--- a/test cases/common/139 custom target object output/progdir/prog.c
+++ b/test cases/common/139 custom target object output/progdir/prog.c
@@ -1,0 +1,5 @@
+int func1_in_obj();
+
+int main(int argc, char **argv) {
+    return func1_in_obj();
+}


### PR DESCRIPTION
The paths are already relative to the target dir. This was totally untested till this point.

Includes a test for this which generates and builds in subdirs. If all the generation and usage is done in the build root, this bug will obviously not be triggered.