### PR TITLE
Try harder to use the C compiler for compiling asm

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -57,6 +57,17 @@ clike_suffixes += ('h', 'll', 's')
 
 # All these are only for C-like languages; see `clike_langs` above.
 
+def sort_clike(lang):
+    '''
+    Sorting function to sort the list of languages according to
+    reversed(compilers.clike_langs) and append the unknown langs in the end.
+    The purpose is to prefer C over C++ for files that can be compiled by
+    both such as assembly, C, etc. Also applies to ObjC, ObjC++, etc.
+    '''
+    if lang not in clike_langs:
+        return 1
+    return -clike_langs.index(lang)
+
 def is_header(fname):
     if hasattr(fname, 'fname'):
         fname = fname.fname

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -514,6 +514,11 @@ class Compiler:
         self.version = version
         self.base_options = []
 
+    def __repr__(self):
+        repr_str = "<{0}: v{1} `{2}`>"
+        return repr_str.format(self.__class__.__name__, self.version,
+                               ' '.join(self.exelist))
+
     def can_compile(self, src):
         if hasattr(src, 'fname'):
             src = src.fname

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -14,6 +14,7 @@
 
 import pickle, os, uuid
 from pathlib import PurePath
+from collections import OrderedDict
 from .mesonlib import MesonException, commonpath
 from .mesonlib import default_libdir, default_libexecdir, default_prefix
 
@@ -128,8 +129,8 @@ class CoreData:
         else:
             self.cross_file = None
         self.wrap_mode = options.wrap_mode
-        self.compilers = {}
-        self.cross_compilers = {}
+        self.compilers = OrderedDict()
+        self.cross_compilers = OrderedDict()
         self.deps = {}
         self.modules = {}
         # Only to print a warning if it changes between Meson invocations.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1752,10 +1752,22 @@ class Interpreter(InterpreterBase):
         self.coredata.compiler_options = new_options
         return comp, cross_comp
 
+    @staticmethod
+    def sort_clike(lang):
+        '''
+        Sorting function to sort the list of languages according to
+        reversed(compilers.clike_langs) and append the unknown langs in the end.
+        The purpose is to prefer C over C++ for files that can be compiled by
+        both such as assembly, C, etc. Also applies to ObjC, ObjC++, etc.
+        '''
+        if lang not in compilers.clike_langs:
+            return 1
+        return -compilers.clike_langs.index(lang)
+
     def add_languages(self, args, required):
         success = True
         need_cross_compiler = self.environment.is_cross_build() and self.environment.cross_info.need_cross_compiler()
-        for lang in args:
+        for lang in sorted(args, key=self.sort_clike):
             lang = lang.lower()
             if lang in self.coredata.compilers:
                 comp = self.coredata.compilers[lang]

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1752,22 +1752,10 @@ class Interpreter(InterpreterBase):
         self.coredata.compiler_options = new_options
         return comp, cross_comp
 
-    @staticmethod
-    def sort_clike(lang):
-        '''
-        Sorting function to sort the list of languages according to
-        reversed(compilers.clike_langs) and append the unknown langs in the end.
-        The purpose is to prefer C over C++ for files that can be compiled by
-        both such as assembly, C, etc. Also applies to ObjC, ObjC++, etc.
-        '''
-        if lang not in compilers.clike_langs:
-            return 1
-        return -compilers.clike_langs.index(lang)
-
     def add_languages(self, args, required):
         success = True
         need_cross_compiler = self.environment.is_cross_build() and self.environment.cross_info.need_cross_compiler()
-        for lang in sorted(args, key=self.sort_clike):
+        for lang in sorted(args, key=compilers.sort_clike):
             lang = lang.lower()
             if lang in self.coredata.compilers:
                 comp = self.coredata.compilers[lang]

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1613,6 +1613,8 @@ class Interpreter(InterpreterBase):
 
     @stringArgs
     def func_project(self, node, args, kwargs):
+        if len(args) < 1:
+            raise InvalidArguments('Not enough arguments to project(). Needs at least the project name.')
         default_options = kwargs.get('default_options', [])
         if self.environment.first_invocation and (len(default_options) > 0 or
                                                   len(self.default_project_options) > 0):
@@ -1625,8 +1627,6 @@ class Interpreter(InterpreterBase):
                                                   )
             oi.process(self.option_file)
             self.build.environment.merge_options(oi.options)
-        if len(args) < 2:
-            raise InvalidArguments('Not enough arguments to project(). Needs at least the project name and one language')
         self.active_projectname = args[0]
         self.project_version = kwargs.get('version', 'undefined')
         if self.build.project_version is None:

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -39,7 +39,7 @@ def build_ssl_context():
     return ctx
 
 def quiet_git(cmd):
-    pc = subprocess.Popen(['git'] + cmd, stdout=subprocess.PIPE)
+    pc = subprocess.Popen(['git'] + cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = pc.communicate()
     if pc.returncode != 0:
         return False, err

--- a/run_tests.py
+++ b/run_tests.py
@@ -21,6 +21,12 @@ import subprocess
 import platform
 from mesonbuild import mesonlib
 
+def using_vs_backend():
+    for arg in sys.argv[1:]:
+        if arg.startswith('--backend=vs'):
+            return True
+    return False
+
 if __name__ == '__main__':
     returncode = 0
     # Running on a developer machine? Be nice!
@@ -32,7 +38,10 @@ if __name__ == '__main__':
         units += ['LinuxlikeTests']
     elif mesonlib.is_windows():
         units += ['WindowsTests']
-    returncode += subprocess.call([sys.executable, 'run_unittests.py', '-v'] + units)
+    # Unit tests always use the Ninja backend, so just skip them if we're
+    # testing the VS backend
+    if not using_vs_backend():
+        returncode += subprocess.call([sys.executable, 'run_unittests.py', '-v'] + units)
     # Ubuntu packages do not have a binary without -6 suffix.
     if shutil.which('arm-linux-gnueabihf-gcc-6') and not platform.machine().startswith('arm'):
         print('Running cross compilation tests.\n')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -880,6 +880,11 @@ class AllPlatformTests(BasePlatformTests):
 
     def test_always_prefer_c_compiler_for_asm(self):
         testdir = os.path.join(self.common_test_dir, '141 c cpp and asm')
+        # Skip if building with MSVC
+        env = Environment(testdir, self.builddir, self.meson_command,
+                          get_fake_options(self.prefix), [])
+        if env.detect_c_compiler(False).get_id() == 'msvc':
+            raise unittest.SkipTest('MSVC can\'t compile assembly')
         self.init(testdir)
         commands = {'cpp-asm': {}, 'cpp-c-asm': {}, 'c-cpp-asm': {}}
         for cmd in self.get_compdb():

--- a/test cases/common/141 c cpp and asm/main.c
+++ b/test cases/common/141 c cpp and asm/main.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+
+int get_retval(void);
+
+int main(int argc, char **argv) {
+  printf("C seems to be working.\n");
+  return get_retval();
+}

--- a/test cases/common/141 c cpp and asm/main.cpp
+++ b/test cases/common/141 c cpp and asm/main.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+
+extern "C" {
+  int get_retval(void);
+  int get_cval(void);
+}
+
+int main(int argc, char **argv) {
+  std::cout << "C++ seems to be working." << std::endl;
+  return get_retval();
+}

--- a/test cases/common/141 c cpp and asm/meson.build
+++ b/test cases/common/141 c cpp and asm/meson.build
@@ -1,0 +1,17 @@
+project('c cpp and asm', 'c', 'cpp')
+
+cpu = host_machine.cpu_family()
+
+supported_cpus = ['arm', 'x86', 'x86_64']
+
+if not supported_cpus.contains(cpu)
+  error('MESON_SKIP_TEST unsupported cpu:' + cpu)
+endif
+
+if meson.get_compiler('c').get_id() == 'msvc'
+  error('MESON_SKIP_TEST MSVC can\'t compile assembly')
+endif
+
+test('test-cpp-asm', executable('cpp-asm', ['main.cpp', 'retval-' + cpu + '.S']))
+test('test-c-cpp-asm', executable('c-cpp-asm', ['somelib.c', 'main.cpp', 'retval-' + cpu + '.S']))
+test('test-cpp-c-asm', executable('cpp-c-asm', ['main.cpp', 'somelib.c', 'retval-' + cpu + '.S']))

--- a/test cases/common/141 c cpp and asm/meson.build
+++ b/test cases/common/141 c cpp and asm/meson.build
@@ -12,6 +12,7 @@ if meson.get_compiler('c').get_id() == 'msvc'
   error('MESON_SKIP_TEST MSVC can\'t compile assembly')
 endif
 
+test('test-c-asm', executable('c-asm', ['main.c', 'retval-' + cpu + '.S']))
 test('test-cpp-asm', executable('cpp-asm', ['main.cpp', 'retval-' + cpu + '.S']))
 test('test-c-cpp-asm', executable('c-cpp-asm', ['somelib.c', 'main.cpp', 'retval-' + cpu + '.S']))
 test('test-cpp-c-asm', executable('cpp-c-asm', ['main.cpp', 'somelib.c', 'retval-' + cpu + '.S']))

--- a/test cases/common/141 c cpp and asm/retval-arm.S
+++ b/test cases/common/141 c cpp and asm/retval-arm.S
@@ -1,0 +1,8 @@
+#include "symbol-underscore.h"
+
+.text
+.globl SYMBOL_NAME(get_retval)
+
+SYMBOL_NAME(get_retval):
+	mov	r0, #0
+	mov	pc, lr

--- a/test cases/common/141 c cpp and asm/retval-x86.S
+++ b/test cases/common/141 c cpp and asm/retval-x86.S
@@ -1,0 +1,8 @@
+#include "symbol-underscore.h"
+
+.text
+.globl SYMBOL_NAME(get_retval)
+
+SYMBOL_NAME(get_retval):
+	xorl	%eax, %eax
+	retl

--- a/test cases/common/141 c cpp and asm/retval-x86_64.S
+++ b/test cases/common/141 c cpp and asm/retval-x86_64.S
@@ -1,0 +1,8 @@
+#include "symbol-underscore.h"
+
+.text
+.globl SYMBOL_NAME(get_retval)
+
+SYMBOL_NAME(get_retval):
+	xorl	%eax, %eax
+	retq

--- a/test cases/common/141 c cpp and asm/somelib.c
+++ b/test cases/common/141 c cpp and asm/somelib.c
@@ -1,0 +1,3 @@
+int get_cval (void) {
+  return 0;
+}

--- a/test cases/common/141 c cpp and asm/symbol-underscore.h
+++ b/test cases/common/141 c cpp and asm/symbol-underscore.h
@@ -1,0 +1,5 @@
+#if defined(__WIN32__) || defined(__APPLE__)
+# define SYMBOL_NAME(name) _##name
+#else
+# define SYMBOL_NAME(name) name
+#endif

--- a/test cases/common/9 header install/meson.build
+++ b/test cases/common/9 header install/meson.build
@@ -1,4 +1,4 @@
-project('header install', 'c')
+project('header install')
 
 as_array = ['subdir.h']
 

--- a/test cases/unit/5 compiler detection/meson.build
+++ b/test cases/unit/5 compiler detection/meson.build
@@ -3,6 +3,6 @@ project('trivial test',
         meson_version : '>=0.27.0')
 
 executable('trivialc', 'trivial.c')
-executable('trivialcpp', 'trivial.cpp')
+executable('trivialcpp', 'trivial.cc')
 executable('trivialobjc', 'trivial.m')
 executable('trivialobjcpp', 'trivial.mm')


### PR DESCRIPTION
Use an ordered dict for the compiler dictionary and sort it according to a priority order: fortran, c, c++, etc. This also ensures that builds are reproducible because it would be a toss-up whether a C or a C++ compiler would be used based on the order in which `compilers.items()` would return items. Closes #1370

Also don't require a language/compiler for configuring. Closes #1208 