### PR TITLE
declare_dependency: flatten dependencies kwargs allowing [] as no-op dep

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1407,7 +1407,7 @@ class Interpreter(InterpreterBase):
         if not isinstance(sources, list):
             sources = [sources]
         sources = self.source_strings_to_files(self.flatten(sources))
-        deps = kwargs.get('dependencies', [])
+        deps = self.flatten(kwargs.get('dependencies', []))
         if not isinstance(deps, list):
             deps = [deps]
         compile_args = mesonlib.stringlistify(kwargs.get('compile_args', []))

--- a/test cases/common/87 declare dep/meson.build
+++ b/test cases/common/87 declare dep/meson.build
@@ -5,3 +5,20 @@ subdir('entity')
 exe = executable('dep_user', 'main.c',
   dependencies : entity_dep)
 test('dep', exe)
+
+# just to make sure [] works as a no-op dep here
+executable('dummy', 'main.c',
+  dependencies : [entity_dep, []])
+
+# simple case
+declare_dependency(dependencies : entity_dep)
+
+# nested deps should be flattened
+declare_dependency(dependencies : [entity_dep])
+declare_dependency(dependencies : [[entity_dep]])
+
+# check that [] properly works as a no-op dep in declare_dependency() too
+declare_dependency(dependencies : [])
+declare_dependency(dependencies : [[]])
+declare_dependency(dependencies : [entity_dep, []])
+declare_dependency(dependencies : [[], entity_dep])


### PR DESCRIPTION
An empty / no-op dependency can be expressed as []. This works with
the dependencies kwarg in executable targets such as shared_library,
but now with declare_dependency, where it would error out with
"error: Dependencies must be external deps" because the deps are
not flattened in this case. This patch fixes that.

Fixes #1500