### PR TITLE
Add support for using git submodules as subprojects

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -127,7 +127,7 @@ class CoreData:
             self.cross_file = os.path.join(os.getcwd(), options.cross_file)
         else:
             self.cross_file = None
-
+        self.wrap_mode = options.wrap_mode
         self.compilers = {}
         self.cross_compilers = {}
         self.deps = {}

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1498,11 +1498,13 @@ class Interpreter(InterpreterBase):
             raise InvalidCode('Recursive include of subprojects: %s.' % incpath)
         if dirname in self.subprojects:
             return self.subprojects[dirname]
-        r = wrap.Resolver(os.path.join(self.build.environment.get_source_dir(), self.subproject_dir))
-        resolved = r.resolve(dirname)
-        if resolved is None:
-            msg = 'Subproject directory {!r} does not exist and cannot be downloaded.'
-            raise InterpreterException(msg.format(os.path.join(self.subproject_dir, dirname)))
+        subproject_dir_abs = os.path.join(self.environment.get_source_dir(), self.subproject_dir)
+        r = wrap.Resolver(subproject_dir_abs)
+        try:
+            resolved = r.resolve(dirname)
+        except RuntimeError as e:
+            msg = 'Subproject directory {!r} does not exist and cannot be downloaded:\n{}'
+            raise InterpreterException(msg.format(os.path.join(self.subproject_dir, dirname), e))
         subdir = os.path.join(self.subproject_dir, resolved)
         os.makedirs(os.path.join(self.build.environment.get_build_dir(), subdir), exist_ok=True)
         self.args_frozen = True

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -20,7 +20,7 @@ from . import mlog
 from . import build
 from . import optinterpreter
 from . import compilers
-from .wrap import wrap
+from .wrap import wrap, WrapMode
 from . import mesonlib
 from .mesonlib import FileMode, Popen_safe
 from .dependencies import InternalDependency, Dependency
@@ -1499,7 +1499,7 @@ class Interpreter(InterpreterBase):
         if dirname in self.subprojects:
             return self.subprojects[dirname]
         subproject_dir_abs = os.path.join(self.environment.get_source_dir(), self.subproject_dir)
-        r = wrap.Resolver(subproject_dir_abs)
+        r = wrap.Resolver(subproject_dir_abs, self.coredata.wrap_mode)
         try:
             resolved = r.resolve(dirname)
         except RuntimeError as e:
@@ -1911,6 +1911,11 @@ requirements use the version keyword argument instead.''')
         return fbinfo
 
     def dependency_fallback(self, name, kwargs):
+        if self.coredata.wrap_mode in (WrapMode.nofallback, WrapMode.nodownload):
+            mlog.log('Not looking for a fallback subproject for the dependency',
+                     mlog.bold(name), 'because:\nAutomatic wrap-based fallback '
+                     'dependency downloading is disabled.')
+            return None
         dirname, varname = self.get_subproject_infos(kwargs)
         # Try to execute the subproject
         try:

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -20,6 +20,7 @@ from . import build
 import platform
 from . import mlog, coredata
 from .mesonlib import MesonException
+from .wrap import WrapMode
 
 
 parser = argparse.ArgumentParser()
@@ -67,6 +68,10 @@ parser.add_argument('-D', action='append', dest='projectoptions', default=[],
                     help='Set project options.')
 parser.add_argument('-v', '--version', action='version',
                     version=coredata.version)
+                    # See the mesonlib.WrapMode enum for documentation
+parser.add_argument('--wrap-mode', default=WrapMode.default,
+                    type=lambda t: getattr(WrapMode, t), choices=WrapMode,
+                    help='Special wrap mode to use')
 parser.add_argument('directories', nargs='*')
 
 class MesonApp:

--- a/mesonbuild/wrap/__init__.py
+++ b/mesonbuild/wrap/__init__.py
@@ -1,0 +1,31 @@
+from enum import Enum
+
+# Used for the --wrap-mode command-line argument
+#
+# Special wrap modes:
+#   nofallback: Don't download wraps for dependency() fallbacks
+#   nodownload: Don't download wraps for all subproject() calls
+#
+# subprojects are used for two purposes:
+# 1. To download and build dependencies by using .wrap
+#    files if they are not provided by the system. This is
+#    usually expressed via dependency(..., fallback: ...).
+# 2. To download and build 'copylibs' which are meant to be
+#    used by copying into your project. This is always done
+#    with an explicit subproject() call.
+#
+# --wrap-mode=nofallback will never do (1)
+# --wrap-mode=nodownload will do neither (1) nor (2)
+#
+# If you are building from a release tarball, you should be
+# able to safely use 'nodownload' since upstream is
+# expected to ship all required sources with the tarball.
+#
+# If you are building from a git repository, you will want
+# to use 'nofallback' so that any 'copylib' wraps will be
+# download as subprojects.
+#
+# Note that these options do not affect subprojects that
+# are git submodules since those are only usable in git
+# repositories, and you almost always want to download them.
+WrapMode = Enum('WrapMode', 'default nofallback nodownload')

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -18,6 +18,7 @@ import urllib.request, os, hashlib, shutil
 import subprocess
 import sys
 from pathlib import Path
+from . import WrapMode
 
 try:
     import ssl
@@ -94,7 +95,8 @@ class PackageDefinition:
         return 'patch_url' in self.values
 
 class Resolver:
-    def __init__(self, subdir_root):
+    def __init__(self, subdir_root, wrap_mode=WrapMode(1)):
+        self.wrap_mode = wrap_mode
         self.subdir_root = subdir_root
         self.cachedir = os.path.join(self.subdir_root, 'packagecache')
 
@@ -119,6 +121,12 @@ class Resolver:
         # Check if the subproject is a git submodule
         if self.resolve_git_submodule(dirname):
             return packagename
+
+        # Don't download subproject data based on wrap file if requested.
+        # Git submodules are ok (see above)!
+        if self.wrap_mode is WrapMode.nodownload:
+            m = 'Automatic wrap-based subproject downloading is disabled'
+            raise RuntimeError(m)
 
         # Check if there's a .wrap file for this subproject
         fname = os.path.join(self.subdir_root, packagename + '.wrap')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -48,6 +48,7 @@ def get_fake_options(prefix):
     import argparse
     opts = argparse.Namespace()
     opts.cross_file = None
+    opts.wrap_mode = None
     opts.prefix = prefix
     return opts
 


### PR DESCRIPTION
Closes #1449.

Also adds a new option `--wrap-mode` that implements special wrap modes for use by packagers.

  nofallback: Don't download wraps for dependency() fallbacks
  nodownload: Don't download wraps for all subproject() calls

Subprojects are used for two purposes:
1. To download and build dependencies by using `.wrap` files if they are not provided by the system. This is usually expressed via `dependency(..., fallback: ...)`.
2. To download and build 'copylibs' which are meant to be used by copying into your project. This is always done with an explicit `subproject()` call.

`--wrap-mode=nofallback` will never do (1)
`--wrap-mode=nodownload` will do neither (1) nor (2)

If you are building from a release tarball, you should be able to safely use `nodownload` since upstream is expected to ship all required sources with the tarball.

If you are building from a git repository, you will want to use `nofallback` so that any 'copylib' wraps will be download as subprojects.

Note that these options do not affect subprojects that are git submodules since those are only usable in git repositories, and you almost always want to download them.