### PR TITLE
Export MESONINTROSPECT to postconf/install/run_command scripts

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -20,7 +20,8 @@ from .. import mlog
 from .. import compilers
 import json
 import subprocess
-from ..mesonlib import MesonException, get_compiler_for_source, classify_unity_sources
+from ..mesonlib import MesonException, get_meson_script
+from ..mesonlib import get_compiler_for_source, classify_unity_sources
 from ..compilers import CompilerArgs
 
 class CleanTrees:
@@ -33,7 +34,7 @@ class CleanTrees:
         self.trees = trees
 
 class InstallData:
-    def __init__(self, source_dir, build_dir, prefix, strip_bin):
+    def __init__(self, source_dir, build_dir, prefix, strip_bin, mesonintrospect):
         self.source_dir = source_dir
         self.build_dir = build_dir
         self.prefix = prefix
@@ -46,6 +47,7 @@ class InstallData:
         self.po = []
         self.install_scripts = []
         self.install_subdirs = []
+        self.mesonintrospect = mesonintrospect
 
 class ExecutableSerialisation:
     def __init__(self, name, fname, cmd_args, env, is_cross, exe_wrapper,
@@ -673,7 +675,7 @@ class Backend:
     def run_postconf_scripts(self):
         env = {'MESON_SOURCE_ROOT': self.environment.get_source_dir(),
                'MESON_BUILD_ROOT': self.environment.get_build_dir(),
-               }
+               'MESONINTROSPECT': get_meson_script(self.environment, 'mesonintrospect')}
         child_env = os.environ.copy()
         child_env.update(env)
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -24,7 +24,7 @@ from .. import mlog
 from .. import compilers
 from ..build import BuildTarget
 from ..compilers import CompilerArgs
-from ..mesonlib import MesonException, File
+from ..mesonlib import MesonException, File, get_meson_script
 from ..environment import Environment
 
 def split_o_flags_args(args):
@@ -379,8 +379,10 @@ class Vs2010Backend(backends.Backend):
         customstep = ET.SubElement(action, 'PostBuildEvent')
         cmd_raw = [target.command] + target.args
         cmd = [sys.executable, os.path.join(self.environment.get_script_dir(), 'commandrunner.py'),
-               self.environment.get_build_dir(), self.environment.get_source_dir(),
-               self.get_target_dir(target)]
+               self.environment.get_build_dir(),
+               self.environment.get_source_dir(),
+               self.get_target_dir(target),
+               get_meson_script(self.environment, 'mesonintrospect')]
         for i in cmd_raw:
             if isinstance(i, build.BuildTarget):
                 cmd.append(os.path.join(self.environment.get_build_dir(), self.get_target_filename(i)))
@@ -1123,11 +1125,8 @@ if %%errorlevel%% neq 0 goto :VCEnd'''
         postbuild = ET.SubElement(action, 'PostBuildEvent')
         ET.SubElement(postbuild, 'Message')
         # FIXME: No benchmarks?
-        meson_py = self.environment.get_build_command()
-        (base, ext) = os.path.splitext(meson_py)
-        mesontest_py = base + 'test' + ext
         test_command = [sys.executable,
-                        mesontest_py,
+                        get_meson_script(self.environment, 'mesontest'),
                         '--no-rebuild']
         if not self.environment.coredata.get_builtin_option('stdsplit'):
             test_command += ['--no-stdsplit']

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -173,6 +173,15 @@ class File:
     def relative_name(self):
         return os.path.join(self.subdir, self.fname)
 
+def get_meson_script(env, script):
+    '''
+    Given the path of `meson.py`/`meson`, get the path of a meson script such
+    as `mesonintrospect` or `mesontest`.
+    '''
+    meson_py = env.get_build_command()
+    (base, ext) = os.path.splitext(meson_py)
+    return os.path.join(os.path.dirname(base), script + ext)
+
 def get_compiler_for_source(compilers, src):
     for comp in compilers:
         if comp.can_compile(src):

--- a/mesonbuild/scripts/commandrunner.py
+++ b/mesonbuild/scripts/commandrunner.py
@@ -17,11 +17,11 @@ what to run, sets up the environment and executes the command."""
 
 import sys, os, subprocess, shutil
 
-def run_command(source_dir, build_dir, subdir, command, arguments):
+def run_command(source_dir, build_dir, subdir, mesonintrospect, command, arguments):
     env = {'MESON_SOURCE_ROOT': source_dir,
            'MESON_BUILD_ROOT': build_dir,
            'MESON_SUBDIR': subdir,
-           }
+           'MESONINTROSPECT': mesonintrospect}
     cwd = os.path.join(source_dir, subdir)
     child_env = os.environ.copy()
     child_env.update(env)
@@ -47,9 +47,10 @@ def run(args):
     src_dir = args[0]
     build_dir = args[1]
     subdir = args[2]
-    command = args[3]
-    arguments = args[4:]
-    pc = run_command(src_dir, build_dir, subdir, command, arguments)
+    mesonintrospect = args[3]
+    command = args[4]
+    arguments = args[5:]
+    pc = run_command(src_dir, build_dir, subdir, mesonintrospect, command, arguments)
     pc.wait()
     return pc.returncode
 

--- a/mesonbuild/scripts/meson_install.py
+++ b/mesonbuild/scripts/meson_install.py
@@ -174,7 +174,7 @@ def run_install_script(d):
            'MESON_BUILD_ROOT': d.build_dir,
            'MESON_INSTALL_PREFIX': d.prefix,
            'MESON_INSTALL_DESTDIR_PREFIX': d.fullprefix,
-           }
+           'MESONINTROSPECT': d.mesonintrospect}
     child_env = os.environ.copy()
     child_env.update(env)
 

--- a/test cases/common/141 mesonintrospect from scripts/check_env.py
+++ b/test cases/common/141 mesonintrospect from scripts/check_env.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+do_print = False
+
+if len(sys.argv) > 1:
+    do_print = bool(sys.argv[1])
+
+if 'MESONINTROSPECT' not in os.environ:
+    raise RuntimeError('MESONINTROSPECT not found')
+
+mesonintrospect = os.environ['MESONINTROSPECT']
+
+if not os.path.isfile(mesonintrospect):
+    raise RuntimeError('{!r} does not exist'.format(mesonintrospect))
+
+if do_print:
+    print(mesonintrospect, end='')

--- a/test cases/common/141 mesonintrospect from scripts/meson.build
+++ b/test cases/common/141 mesonintrospect from scripts/meson.build
@@ -1,0 +1,14 @@
+project('mesonintrospect from scripts', 'c')
+
+python = import('python3').find_python()
+
+ret = run_command(python, ['check_env.py', '1'])
+if ret.returncode() == 0
+  find_program(ret.stdout())
+else
+  message(ret.stdout())
+  message(ret.stderr())
+endif
+
+meson.add_postconf_script('check_env.py')
+meson.add_install_script('check_env.py')


### PR DESCRIPTION
Points to the `mesonintrospect.py` script corresponding to the currently-running version of Meson.

Includes a test for all three methods of running scripts/commands.

Closes https://github.com/mesonbuild/meson/issues/1385