### PR TITLE
Ban calling required dep found

### DIFF
--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -49,7 +49,7 @@ class Dependency:
     def get_link_args(self):
         return []
 
-    def found(self):
+    def found(self, **kwargs):
         return self.is_found
 
     def get_sources(self):
@@ -280,9 +280,6 @@ class PkgConfigDependency(Dependency):
                 mlog.log('Found Pkg-config:', mlog.red('NO'))
         return pkgbin
 
-    def found(self):
-        return self.is_found
-
     def extract_field(self, la_file, fieldname):
         with open(la_file) as f:
             for line in f:
@@ -397,9 +394,6 @@ class WxDependency(Dependency):
                 pass
         WxDependency.wxconfig_found = False
         mlog.log('Found wx-config:', mlog.red('NO'))
-
-    def found(self):
-        return self.is_found
 
 class ExternalProgram:
     windows_exts = ('exe', 'msc', 'com', 'bat')
@@ -522,7 +516,7 @@ class ExternalProgram:
                     return commands
         return [None]
 
-    def found(self):
+    def found(self, **kwargs):
         return self.command[0] is not None
 
     def get_command(self):
@@ -560,9 +554,6 @@ class ExternalLibrary(Dependency):
                 mlog.log('Library', mlog.bold(name), 'found:', mlog.green('YES'))
             else:
                 mlog.log('Library', mlog.bold(name), 'found:', mlog.red('NO'))
-
-    def found(self):
-        return self.is_found
 
     def get_name(self):
         return self.name
@@ -661,7 +652,7 @@ class BoostDependency(Dependency):
             if m not in self.src_modules:
                 raise DependencyException('Requested Boost module "%s" not found.' % m)
 
-    def found(self):
+    def found(self, **kwargs):
         return self.version is not None
 
     def get_version(self):
@@ -804,9 +795,6 @@ class GTestDependency(Dependency):
         self.src_dirs = ['/usr/src/gtest/src', '/usr/src/googletest/googletest/src']
         self.detect()
 
-    def found(self):
-        return self.is_found
-
     def detect(self):
         trial_dirs = mesonlib.get_library_dirs()
         glib_found = False
@@ -921,9 +909,6 @@ class GMockDependency(Dependency):
 
     def get_link_args(self):
         return self.link_args
-
-    def found(self):
-        return self.is_found
 
 class QtBaseDependency(Dependency):
     def __init__(self, name, env, kwargs):
@@ -1103,9 +1088,6 @@ class QtBaseDependency(Dependency):
     def get_link_args(self):
         return self.largs
 
-    def found(self):
-        return self.is_found
-
     def get_exe_args(self, compiler):
         # Originally this was -fPIE but nowadays the default
         # for upstream and distros seems to be -reduce-relocations
@@ -1207,7 +1189,7 @@ why. As a hack filter out everything that is not a flag."""
                                       ''.format(self.confprog, var))
         return o.strip()
 
-    def found(self):
+    def found(self, **kwargs):
         return self.args is not None
 
     def get_version(self):
@@ -1238,7 +1220,7 @@ class AppleFrameworks(Dependency):
             args.append(f)
         return args
 
-    def found(self):
+    def found(self, **kwargs):
         return mesonlib.is_osx()
 
     def get_version(self):
@@ -1327,9 +1309,6 @@ class SDL2Dependency(Dependency):
     def get_link_args(self):
         return self.linkargs
 
-    def found(self):
-        return self.is_found
-
     def get_version(self):
         return self.version
 
@@ -1371,7 +1350,7 @@ class ExtraFrameworkDependency(Dependency):
             return ['-F' + self.path, '-framework', self.name.split('.')[0]]
         return []
 
-    def found(self):
+    def found(self, **kwargs):
         return self.name is not None
 
     def get_version(self):

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -38,6 +38,7 @@ class Dependency:
         self.name = "null"
         self.is_found = False
         self.type_name = type_name
+        self.required = False
 
     def __repr__(self):
         s = '<{0} {1}: {2}>'
@@ -50,6 +51,8 @@ class Dependency:
         return []
 
     def found(self, **kwargs):
+        if self.required and kwargs.get('from_interpreter', False):
+            raise MesonException('Cannot call found() on a required dependency; this will always be true.')
         return self.is_found
 
     def get_sources(self):
@@ -1190,6 +1193,8 @@ why. As a hack filter out everything that is not a flag."""
         return o.strip()
 
     def found(self, **kwargs):
+        if self.required and kwargs.get('from_interpreter', False):
+            raise MesonException('Cannot call found() on a required dependency; this will always be true.')
         return self.args is not None
 
     def get_version(self):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -250,7 +250,7 @@ class DependencyHolder(InterpreterObject):
         if self.held_object.type_name == 'internal':
             return True
 
-        return self.held_object.found()
+        return self.held_object.found(from_interpreter=True)
 
     def version_method(self, args, kwargs):
         return self.held_object.get_version()

--- a/test cases/failing/43 call found on required dep/meson.build
+++ b/test cases/failing/43 call found on required dep/meson.build
@@ -1,0 +1,6 @@
+project('call-found-on-required-dep', 'c')
+
+dep_thr = dependency('zlib')
+if dep_thr.found()
+    message('found zlib, which is actually bad')
+endif


### PR DESCRIPTION
```
foo = dependency('foo')
if foo.found()
    ...
endif
```

This seems like an anti-pattern which ought to be illegal, as reading it suggests that foo is an optional dependency, when in fact it is required and the configure step will bomb out if it's not found.

Seen in the real, actual, wild:
https://lists.freedesktop.org/archives/mesa-dev/2017-March/149620.html

I typed the code out, before realising that it actually makes this kind of thing impossible:
```
if get_option('foo') == 'auto'
  dep_foo = dependency('foo', required: false)
elif get_option('foo') == 'yes'
  dep_foo = dependency('foo')
endif

# don't care how we arrived at the conclusion, but we are going to use 'foo' now
if dep_foo.found()
  stuff = things
endif
```

So I'm not really sure whether or not it's a good idea. *shrug*