### PR TITLE
Fix warning making static libs on msvc/ninja

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -70,3 +70,4 @@ Marc Becker
 Michal Sojka
 Aaron Small
 Joe Baldino
+Peter Harris

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -3055,9 +3055,8 @@ class VisualStudioLinker(StaticLinker):
         return VisualStudioCCompiler.unix_args_to_native(args)
 
     def get_link_debugfile_args(self, targetfile):
-        pdbarr = targetfile.split('.')[:-1]
-        pdbarr += ['pdb']
-        return ['/DEBUG', '/PDB:' + '.'.join(pdbarr)]
+        # Static libraries do not have PDB files
+        return []
 
 class ArLinker(StaticLinker):
 


### PR DESCRIPTION
The MSVC static library tool, lib.exe, does not understand the same set of arguments as the linker. Avoid a warning by not adding /DEBUG or /PDB to the command line when invoking lib.exe.