### PR TITLE
strip trailing backslash from WindowsSDKVersion

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -72,3 +72,4 @@ Aaron Small
 Joe Baldino
 Peter Harris
 Roger Boerdijk
+melak47

--- a/mesonbuild/backend/vs2017backend.py
+++ b/mesonbuild/backend/vs2017backend.py
@@ -24,4 +24,4 @@ class Vs2017Backend(Vs2010Backend):
         self.platform_toolset = 'v141'
         self.vs_version = '2017'
         # WindowsSDKVersion should be set by command prompt.
-        self.windows_target_platform_version = os.getenv('WindowsSDKVersion', None)
+        self.windows_target_platform_version = os.getenv('WindowsSDKVersion', None).rstrip('\\')


### PR DESCRIPTION
This fixes #1537.