### PR TITLE
Add dependency type for Valgrind

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -72,3 +72,4 @@ Aaron Small
 Joe Baldino
 Peter Harris
 Roger Boerdijk
+Dylan Baker

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -1483,6 +1483,14 @@ class Python3Dependency(Dependency):
     def get_version(self):
         return self.version
 
+class ValgrindDependency(PkgConfigDependency):
+
+    def __init__(self, environment, kwargs):
+        PkgConfigDependency.__init__(self, 'valgrind', environment, kwargs)
+
+    def get_link_args(self):
+        return []
+
 def get_dep_identifier(name, kwargs):
     elements = [name]
     modlist = kwargs.get('modules', [])
@@ -1544,4 +1552,5 @@ packages = {'boost': BoostDependency,
             'gl': GLDependency,
             'threads': ThreadDependency,
             'python3': Python3Dependency,
+            'valgrind': ValgrindDependency,
             }


### PR DESCRIPTION
Valgrind is a bit of a strange beast, in general use one isn't supposed
to link against valgrinds libs, instead, including the headers does magic
to make valgrind work.

This patch implements a simple ValgrindDependency class subclassed from
PkgConfigDependency, that overwrites (effectively) only the
get_link_args method to always return an empty list. This solution may
seem strange, but I think that it follows the principle of least
surprise, and simplifies the most common use case for valgrind.

Essentially without this every valgrind consumer would be forced to
implement the following code to have a usable valgrind dependency
object:

_dep = dependency('valgrind', required : false)
if _dep.found()
  valgrind_dep = declare_dependency(
    compile_args : _dep.get_pkgconfig_variable('Cflags')
  )
else
  valgrind_dep = []
endif

While the above is workable, it's surprising behavior and the above code
snippet becomes boilerplate that everyone needs to copy into their meson
files.

Fixes #826 