### PR TITLE
Don't add dependencies recursively while linking

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -453,15 +453,11 @@ class Backend:
         for d in deps:
             if not isinstance(d, (build.StaticLibrary, build.SharedLibrary)):
                 raise RuntimeError('Tried to link with a non-library target "%s".' % d.get_basename())
-            if isinstance(compiler, compilers.LLVMDCompiler) or isinstance(compiler, compilers.DmdDCompiler):
-                args += ['-L' + self.get_target_filename_for_linking(d)]
+            if isinstance(compiler, (compilers.LLVMDCompiler, compilers.DmdDCompiler)):
+                d_arg = '-L' + self.get_target_filename_for_linking(d)
             else:
-                args.append(self.get_target_filename_for_linking(d))
-            # If you have executable e that links to shared lib s1 that links to shared library s2
-            # you have to specify s2 as well as s1 when linking e even if e does not directly use
-            # s2. Gcc handles this case fine but Clang does not for some reason. Thus we need to
-            # explictly specify all libraries every time.
-            args += self.build_target_link_arguments(compiler, d.get_dependencies())
+                d_arg = self.get_target_filename_for_linking(d)
+            args.append(d_arg)
         return args
 
     def determine_windows_extra_paths(self, target):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -58,22 +58,22 @@ class NinjaBuildElement:
             self.infilenames = [infilenames]
         else:
             self.infilenames = infilenames
-        self.deps = []
-        self.orderdeps = []
+        self.deps = set()
+        self.orderdeps = set()
         self.elems = []
         self.all_outputs = all_outputs
 
     def add_dep(self, dep):
         if isinstance(dep, list):
-            self.deps += dep
+            self.deps.update(dep)
         else:
-            self.deps.append(dep)
+            self.deps.add(dep)
 
     def add_orderdep(self, dep):
         if isinstance(dep, list):
-            self.orderdeps += dep
+            self.orderdeps.update(dep)
         else:
-            self.orderdeps.append(dep)
+            self.orderdeps.add(dep)
 
     def add_item(self, name, elems):
         if isinstance(elems, str):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -139,7 +139,7 @@ class InternalTests(unittest.TestCase):
         self.assertEqual(a, ['-Ibar', '-Ifoo', '-Ibaz', '-I..', '-I.', '-O3', '-O2', '-Wall'])
 
         ## Test that reflected addition works
-        # Test that adding to a list with just one old arg works and DOES NOT yield the same array
+        # Test that adding to a list with just one old arg works and yields the same array
         a = ['-Ifoo'] + a
         self.assertEqual(a, ['-Ibar', '-Ifoo', '-Ibaz', '-I..', '-I.', '-O3', '-O2', '-Wall'])
         # Test that adding to a list with just one new arg that is not pre-pended works
@@ -148,6 +148,19 @@ class InternalTests(unittest.TestCase):
         # Test that adding to a list with two new args preserves the order
         a = ['-Ldir', '-Lbah'] + a
         self.assertEqual(a, ['-Ibar', '-Ifoo', '-Ibaz', '-I..', '-I.', '-Ldir', '-Lbah', '-Werror', '-O3', '-O2', '-Wall'])
+        # Test that adding to a list with old args does nothing
+        a = ['-Ibar', '-Ibaz', '-Ifoo'] + a
+        self.assertEqual(a, ['-Ibar', '-Ifoo', '-Ibaz', '-I..', '-I.', '-Ldir', '-Lbah', '-Werror', '-O3', '-O2', '-Wall'])
+
+        ## Test that adding libraries works
+        l = cargsfunc(c, ['-Lfoodir', '-lfoo'])
+        self.assertEqual(l, ['-Lfoodir', '-lfoo'])
+        # Adding a library and a libpath appends both correctly
+        l += ['-Lbardir', '-lbar']
+        self.assertEqual(l, ['-Lbardir', '-Lfoodir', '-lfoo', '-lbar'])
+        # Adding the same library again does nothing
+        l += ['-lbar']
+        self.assertEqual(l, ['-Lbardir', '-Lfoodir', '-lfoo', '-lbar'])
 
     def test_commonpath(self):
         from os.path import sep

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1266,15 +1266,15 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertIsNotNone(vala_command)
         self.assertIsNotNone(c_command)
         # -w suppresses all warnings, should be there in Vala but not in C
-        self.assertIn("'-w'", vala_command)
-        self.assertNotIn("'-w'", c_command)
+        self.assertIn(" -w ", vala_command)
+        self.assertNotIn(" -w ", c_command)
         # -Wall enables all warnings, should be there in C but not in Vala
-        self.assertNotIn("'-Wall'", vala_command)
-        self.assertIn("'-Wall'", c_command)
+        self.assertNotIn(" -Wall ", vala_command)
+        self.assertIn(" -Wall ", c_command)
         # -Werror converts warnings to errors, should always be there since it's
         # injected by an unrelated piece of code and the project has werror=true
-        self.assertIn("'-Werror'", vala_command)
-        self.assertIn("'-Werror'", c_command)
+        self.assertIn(" -Werror ", vala_command)
+        self.assertIn(" -Werror ", c_command)
 
     def test_qt5dependency_pkgconfig_detection(self):
         '''
@@ -1405,7 +1405,7 @@ class LinuxlikeTests(BasePlatformTests):
             self.init(testdir, ['-D' + std_opt])
             cmd = self.get_compdb()[0]['command']
             if v != 'none':
-                cmd_std = "'-std={}'".format(v)
+                cmd_std = " -std={} ".format(v)
                 self.assertIn(cmd_std, cmd)
             try:
                 self.build()
@@ -1420,7 +1420,7 @@ class LinuxlikeTests(BasePlatformTests):
         os.environ[env_flags] = cmd_std
         self.init(testdir)
         cmd = self.get_compdb()[0]['command']
-        qcmd_std = "'{}'".format(cmd_std)
+        qcmd_std = " {} ".format(cmd_std)
         self.assertIn(qcmd_std, cmd)
         with self.assertRaises(subprocess.CalledProcessError,
                                msg='{} should have failed'.format(qcmd_std)):

--- a/test cases/common/153 recursive linking/3rdorderdeps/lib.c.in
+++ b/test cases/common/153 recursive linking/3rdorderdeps/lib.c.in
@@ -1,0 +1,8 @@
+#include "../lib.h"
+
+int get_@DEPENDENCY@dep_value (void);
+
+SYMBOL_EXPORT
+int get_@LIBTYPE@@DEPENDENCY@dep_value (void) {
+  return get_@DEPENDENCY@dep_value ();
+}

--- a/test cases/common/153 recursive linking/3rdorderdeps/main.c.in
+++ b/test cases/common/153 recursive linking/3rdorderdeps/main.c.in
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+#include "../lib.h"
+
+SYMBOL_IMPORT int get_@LIBTYPE@@DEPENDENCY@dep_value (void);
+
+int main(int argc, char *argv[]) {
+  int val;
+
+  val = get_@LIBTYPE@@DEPENDENCY@dep_value ();
+  if (val != @VALUE@) {
+    printf("@LIBTYPE@@DEPENDENCY@ was %i instead of @VALUE@\n", val);
+    return -1;
+  }
+  return 0;
+}

--- a/test cases/common/153 recursive linking/3rdorderdeps/meson.build
+++ b/test cases/common/153 recursive linking/3rdorderdeps/meson.build
@@ -16,8 +16,10 @@ foreach dep2 : ['sh', 'st']
 
       if libtype == 'sh'
         target = 'shared_library'
+        build_args = []
       elif libtype == 'st'
         target = 'static_library'
+        build_args = ['-DMESON_STATIC_BUILD']
       else
         error('Unknown libtype "@0@"'.format(libtype))
       endif
@@ -31,13 +33,16 @@ foreach dep2 : ['sh', 'st']
                              output : name + '-lib.c',
                              configuration : cdata)
       dep = get_variable(dep1 + dep2 + 'dep')
-      dep3_lib = build_target(name, lib_c, link_with : dep, target_type : target)
+      dep3_lib = build_target(name, lib_c, link_with : dep,
+                              target_type : target,
+                              c_args : build_args)
       dep3_libs += [dep3_lib]
 
       main_c = configure_file(input : 'main.c.in',
                               output : name + '-main.c',
                               configuration : cdata)
-      dep3_bin = executable(name, main_c, link_with : dep3_lib)
+      dep3_bin = executable(name, main_c, link_with : dep3_lib,
+                            c_args : build_args)
       test(name + 'test', dep3_bin)
     endforeach
   endforeach

--- a/test cases/common/153 recursive linking/3rdorderdeps/meson.build
+++ b/test cases/common/153 recursive linking/3rdorderdeps/meson.build
@@ -1,0 +1,44 @@
+dep3_libs = []
+
+# Permutate all combinations of shared and static libraries up to three levels
+# executable -> shared -> static -> shared (etc)
+foreach dep2 : ['sh', 'st']
+  foreach dep1 : ['sh', 'st']
+    foreach libtype : ['sh', 'st']
+      name = libtype + dep1 + dep2
+      if dep2 == 'sh'
+        libret = 1
+      elif dep2 == 'st'
+        libret = 2
+      else
+        error('Unknown dep2 "@0@"'.format(dep2))
+      endif
+
+      if libtype == 'sh'
+        target = 'shared_library'
+      elif libtype == 'st'
+        target = 'static_library'
+      else
+        error('Unknown libtype "@0@"'.format(libtype))
+      endif
+
+      cdata = configuration_data()
+      cdata.set('DEPENDENCY', dep1 + dep2)
+      cdata.set('LIBTYPE', libtype)
+      cdata.set('VALUE', libret)
+
+      lib_c = configure_file(input : 'lib.c.in',
+                             output : name + '-lib.c',
+                             configuration : cdata)
+      dep = get_variable(dep1 + dep2 + 'dep')
+      dep3_lib = build_target(name, lib_c, link_with : dep, target_type : target)
+      dep3_libs += [dep3_lib]
+
+      main_c = configure_file(input : 'main.c.in',
+                              output : name + '-main.c',
+                              configuration : cdata)
+      dep3_bin = executable(name, main_c, link_with : dep3_lib)
+      test(name + 'test', dep3_bin)
+    endforeach
+  endforeach
+endforeach

--- a/test cases/common/153 recursive linking/circular/lib1.c
+++ b/test cases/common/153 recursive linking/circular/lib1.c
@@ -1,0 +1,6 @@
+int get_st2_prop (void);
+int get_st3_prop (void);
+
+int get_st1_value (void) {
+  return get_st2_prop () + get_st3_prop ();
+}

--- a/test cases/common/153 recursive linking/circular/lib2.c
+++ b/test cases/common/153 recursive linking/circular/lib2.c
@@ -1,0 +1,6 @@
+int get_st1_prop (void);
+int get_st3_prop (void);
+
+int get_st2_value (void) {
+  return get_st1_prop () + get_st3_prop ();
+}

--- a/test cases/common/153 recursive linking/circular/lib3.c
+++ b/test cases/common/153 recursive linking/circular/lib3.c
@@ -1,0 +1,6 @@
+int get_st1_prop (void);
+int get_st2_prop (void);
+
+int get_st3_value (void) {
+  return get_st1_prop () + get_st2_prop ();
+}

--- a/test cases/common/153 recursive linking/circular/main.c
+++ b/test cases/common/153 recursive linking/circular/main.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+
+#include "../lib.h"
+
+int get_st1_value (void);
+int get_st2_value (void);
+int get_st3_value (void);
+
+int main(int argc, char *argv[]) {
+  int val;
+
+  val = get_st1_value ();
+  if (val != 5) {
+    printf("st1 value was %i instead of 5\n", val);
+    return -1;
+  }
+  val = get_st2_value ();
+  if (val != 4) {
+    printf("st2 value was %i instead of 4\n", val);
+    return -2;
+  }
+  val = get_st3_value ();
+  if (val != 3) {
+    printf("st3 value was %i instead of 3\n", val);
+    return -3;
+  }
+  return 0;
+}

--- a/test cases/common/153 recursive linking/circular/meson.build
+++ b/test cases/common/153 recursive linking/circular/meson.build
@@ -1,0 +1,5 @@
+st1 = static_library('st1', 'lib1.c', 'prop1.c')
+st2 = static_library('st2', 'lib2.c', 'prop2.c')
+st3 = static_library('st3', 'lib3.c', 'prop3.c')
+
+test('circular', executable('circular', 'main.c', link_with : [st1, st2, st3]))

--- a/test cases/common/153 recursive linking/circular/prop1.c
+++ b/test cases/common/153 recursive linking/circular/prop1.c
@@ -1,0 +1,3 @@
+int get_st1_prop (void) {
+  return 1;
+}

--- a/test cases/common/153 recursive linking/circular/prop2.c
+++ b/test cases/common/153 recursive linking/circular/prop2.c
@@ -1,0 +1,3 @@
+int get_st2_prop (void) {
+  return 2;
+}

--- a/test cases/common/153 recursive linking/circular/prop3.c
+++ b/test cases/common/153 recursive linking/circular/prop3.c
@@ -1,0 +1,3 @@
+int get_st3_prop (void) {
+  return 3;
+}

--- a/test cases/common/153 recursive linking/lib.h
+++ b/test cases/common/153 recursive linking/lib.h
@@ -1,6 +1,11 @@
 #if defined _WIN32
-  #define SYMBOL_IMPORT __declspec(dllimport)
-  #define SYMBOL_EXPORT __declspec(dllexport)
+  #ifdef MESON_STATIC_BUILD
+   #define SYMBOL_EXPORT
+   #define SYMBOL_IMPORT
+  #else
+   #define SYMBOL_IMPORT __declspec(dllimport)
+   #define SYMBOL_EXPORT __declspec(dllexport)
+  #endif
 #else
   #define SYMBOL_IMPORT
   #if defined __GNUC__

--- a/test cases/common/153 recursive linking/lib.h
+++ b/test cases/common/153 recursive linking/lib.h
@@ -1,0 +1,12 @@
+#if defined _WIN32
+  #define SYMBOL_IMPORT __declspec(dllimport)
+  #define SYMBOL_EXPORT __declspec(dllexport)
+#else
+  #define SYMBOL_IMPORT
+  #if defined __GNUC__
+    #define SYMBOL_EXPORT __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define SYMBOL_EXPORT
+  #endif
+#endif

--- a/test cases/common/153 recursive linking/main.c
+++ b/test cases/common/153 recursive linking/main.c
@@ -2,12 +2,12 @@
 
 #include "lib.h"
 
-SYMBOL_IMPORT int get_stnodep_value (void);
+int get_stnodep_value (void);
+int get_stshdep_value (void);
+int get_ststdep_value (void);
 SYMBOL_IMPORT int get_shnodep_value (void);
 SYMBOL_IMPORT int get_shshdep_value (void);
 SYMBOL_IMPORT int get_shstdep_value (void);
-SYMBOL_IMPORT int get_stshdep_value (void);
-SYMBOL_IMPORT int get_ststdep_value (void);
 
 int main(int argc, char *argv[]) {
   int val;

--- a/test cases/common/153 recursive linking/main.c
+++ b/test cases/common/153 recursive linking/main.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+
+#include "lib.h"
+
+SYMBOL_IMPORT int get_stnodep_value (void);
+SYMBOL_IMPORT int get_shnodep_value (void);
+SYMBOL_IMPORT int get_shshdep_value (void);
+SYMBOL_IMPORT int get_shstdep_value (void);
+SYMBOL_IMPORT int get_stshdep_value (void);
+SYMBOL_IMPORT int get_ststdep_value (void);
+
+int main(int argc, char *argv[]) {
+  int val;
+
+  val = get_shnodep_value ();
+  if (val != 1) {
+    printf("shnodep was %i instead of 1\n", val);
+    return -1;
+  }
+  val = get_stnodep_value ();
+  if (val != 2) {
+    printf("stnodep was %i instead of 2\n", val);
+    return -2;
+  }
+  val = get_shshdep_value ();
+  if (val != 1) {
+    printf("shshdep was %i instead of 1\n", val);
+    return -3;
+  }
+  val = get_shstdep_value ();
+  if (val != 2) {
+    printf("shstdep was %i instead of 2\n", val);
+    return -4;
+  }
+  val = get_stshdep_value ();
+  if (val != 1) {
+    printf("shstdep was %i instead of 1\n", val);
+    return -5;
+  }
+  val = get_ststdep_value ();
+  if (val != 2) {
+    printf("ststdep was %i instead of 2\n", val);
+    return -6;
+  }
+  return 0;
+}

--- a/test cases/common/153 recursive linking/meson.build
+++ b/test cases/common/153 recursive linking/meson.build
@@ -20,3 +20,7 @@ test('alldeps',
 
 # More combinations of static and shared libraries
 subdir('3rdorderdeps')
+
+# Circular dependencies between static libraries
+# This requires the use of --start/end-group with GNU ld
+subdir('circular')

--- a/test cases/common/153 recursive linking/meson.build
+++ b/test cases/common/153 recursive linking/meson.build
@@ -1,0 +1,22 @@
+project('recursive dependencies', 'c')
+
+# Test that you can link a shared executable to:
+# - A shared library with no other deps
+subdir('shnodep')
+# - A static library with no other deps
+subdir('stnodep')
+# - A shared library with a shared library dep
+subdir('shshdep')
+# - A shared library with a static library dep
+subdir('shstdep')
+# - A static library with a shared library dep
+subdir('stshdep')
+# - A static library with a static library dep
+subdir('ststdep')
+
+test('alldeps',
+     executable('alldeps', 'main.c',
+                link_with : [shshdep, shstdep, ststdep, stshdep]))
+
+# More combinations of static and shared libraries
+subdir('3rdorderdeps')

--- a/test cases/common/153 recursive linking/shnodep/lib.c
+++ b/test cases/common/153 recursive linking/shnodep/lib.c
@@ -1,0 +1,6 @@
+#include "../lib.h"
+
+SYMBOL_EXPORT
+int get_shnodep_value (void) {
+  return 1;
+}

--- a/test cases/common/153 recursive linking/shnodep/meson.build
+++ b/test cases/common/153 recursive linking/shnodep/meson.build
@@ -1,0 +1,1 @@
+shnodep = shared_library('shnodep', 'lib.c')

--- a/test cases/common/153 recursive linking/shshdep/lib.c
+++ b/test cases/common/153 recursive linking/shshdep/lib.c
@@ -1,0 +1,8 @@
+#include "../lib.h"
+
+int get_shnodep_value (void);
+
+SYMBOL_EXPORT
+int get_shshdep_value (void) {
+  return get_shnodep_value ();
+}

--- a/test cases/common/153 recursive linking/shshdep/meson.build
+++ b/test cases/common/153 recursive linking/shshdep/meson.build
@@ -1,0 +1,1 @@
+shshdep = shared_library('shshdep', 'lib.c', link_with : shnodep)

--- a/test cases/common/153 recursive linking/shstdep/lib.c
+++ b/test cases/common/153 recursive linking/shstdep/lib.c
@@ -1,0 +1,8 @@
+#include "../lib.h"
+
+int get_stnodep_value (void);
+
+SYMBOL_EXPORT
+int get_shstdep_value (void) {
+  return get_stnodep_value ();
+}

--- a/test cases/common/153 recursive linking/shstdep/meson.build
+++ b/test cases/common/153 recursive linking/shstdep/meson.build
@@ -1,0 +1,1 @@
+shstdep = shared_library('shstdep', 'lib.c', link_with : stnodep)

--- a/test cases/common/153 recursive linking/stnodep/lib.c
+++ b/test cases/common/153 recursive linking/stnodep/lib.c
@@ -1,0 +1,6 @@
+#include "../lib.h"
+
+SYMBOL_EXPORT
+int get_stnodep_value (void) {
+  return 2;
+}

--- a/test cases/common/153 recursive linking/stnodep/meson.build
+++ b/test cases/common/153 recursive linking/stnodep/meson.build
@@ -1,1 +1,2 @@
-stnodep = static_library('stnodep', 'lib.c')
+stnodep = static_library('stnodep', 'lib.c',
+                         c_args : '-DMESON_STATIC_BUILD')

--- a/test cases/common/153 recursive linking/stnodep/meson.build
+++ b/test cases/common/153 recursive linking/stnodep/meson.build
@@ -1,0 +1,1 @@
+stnodep = static_library('stnodep', 'lib.c')

--- a/test cases/common/153 recursive linking/stshdep/lib.c
+++ b/test cases/common/153 recursive linking/stshdep/lib.c
@@ -1,0 +1,8 @@
+#include "../lib.h"
+
+int get_shnodep_value (void);
+
+SYMBOL_EXPORT
+int get_stshdep_value (void) {
+  return get_shnodep_value ();
+}

--- a/test cases/common/153 recursive linking/stshdep/meson.build
+++ b/test cases/common/153 recursive linking/stshdep/meson.build
@@ -1,0 +1,1 @@
+stshdep = static_library('stshdep', 'lib.c', link_with : shnodep)

--- a/test cases/common/153 recursive linking/stshdep/meson.build
+++ b/test cases/common/153 recursive linking/stshdep/meson.build
@@ -1,1 +1,2 @@
-stshdep = static_library('stshdep', 'lib.c', link_with : shnodep)
+stshdep = static_library('stshdep', 'lib.c', link_with : shnodep,
+                         c_args : '-DMESON_STATIC_BUILD')

--- a/test cases/common/153 recursive linking/ststdep/lib.c
+++ b/test cases/common/153 recursive linking/ststdep/lib.c
@@ -1,0 +1,8 @@
+#include "../lib.h"
+
+int get_stnodep_value (void);
+
+SYMBOL_EXPORT
+int get_ststdep_value (void) {
+  return get_stnodep_value ();
+}

--- a/test cases/common/153 recursive linking/ststdep/meson.build
+++ b/test cases/common/153 recursive linking/ststdep/meson.build
@@ -1,1 +1,2 @@
-ststdep = static_library('ststdep', 'lib.c', link_with : stnodep)
+ststdep = static_library('ststdep', 'lib.c', link_with : stnodep,
+                         c_args : '-DMESON_STATIC_BUILD')

--- a/test cases/common/153 recursive linking/ststdep/meson.build
+++ b/test cases/common/153 recursive linking/ststdep/meson.build
@@ -1,0 +1,1 @@
+ststdep = static_library('ststdep', 'lib.c', link_with : stnodep)

--- a/test cases/frameworks/7 gnome/gir/meson.build
+++ b/test cases/frameworks/7 gnome/gir/meson.build
@@ -12,7 +12,7 @@ girlib = shared_library(
 girexe = executable(
   'girprog',
   sources : 'prog.c',
-  dependencies : [glib, gobj, gir],
+  dependencies : [glib, gobj, gir, dep1_dep],
   link_with : girlib
 )
 

--- a/test cases/vala/11 generated vapi/meson.build
+++ b/test cases/vala/11 generated vapi/meson.build
@@ -6,7 +6,7 @@ subdir('libbar')
 
 vapiexe = executable('vapigen-test',
   'main.vala',
-  dependencies: [dependency('gobject-2.0'), libbar_vapi],
+  dependencies: [dependency('gobject-2.0'), libfoo_vapi, libbar_vapi],
   install: true,
 )
 


### PR DESCRIPTION
We were doing this on the basis of an old comment, but there was no test for it and I couldn't reproduce the issue with clang on Linux at all.

Let's add a test and see if it breaks anywhere if we stop doing this.

Halves the size of gstreamer's build.ninja from 19M to 8.5M

Closes https://github.com/mesonbuild/meson/issues/1057