### PR TITLE
Stable ordering of some commandlines generated by 'gnome' module

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -22,6 +22,7 @@ import json
 import subprocess
 from ..mesonlib import MesonException, get_compiler_for_source, classify_unity_sources
 from ..compilers import CompilerArgs
+from collections import OrderedDict
 
 class CleanTrees:
     '''
@@ -542,7 +543,7 @@ class Backend:
         return newargs
 
     def get_build_by_default_targets(self):
-        result = {}
+        result = OrderedDict()
         # Get all build and custom targets that must be built by default
         for name, t in self.build.get_targets().items():
             if t.build_by_default or t.install or t.build_always:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2276,7 +2276,10 @@ rule FORTRAN_DEP_HACK
         cmds = []
         for (k, v) in self.environment.coredata.user_options.items():
             cmds.append('-D' + k + '=' + (v.value if isinstance(v.value, str) else str(v.value).lower()))
-        return cmds
+        # The order of these arguments must be the same between runs of Meson
+        # to ensure reproducible output. The order we pass them shouldn't
+        # affect behaviour in any other way.
+        return sorted(cmds)
 
     # For things like scan-build and other helper tools we might have.
     def generate_utils(self, outfile):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -82,9 +82,9 @@ class Build:
         self.project_version = None
         self.environment = environment
         self.projects = {}
-        self.targets = {}
-        self.compilers = {}
-        self.cross_compilers = {}
+        self.targets = OrderedDict()
+        self.compilers = OrderedDict()
+        self.cross_compilers = OrderedDict()
         self.global_args = {}
         self.projects_args = {}
         self.global_link_args = {}
@@ -325,6 +325,9 @@ class BuildTarget(Target):
         self.process_compilers()
         self.validate_sources()
         self.validate_cross_install(environment)
+
+    def __lt__(self, other):
+        return self.get_id() < other.get_id()
 
     def __repr__(self):
         repr_str = "<{0} {1}: {2}>"
@@ -1257,6 +1260,9 @@ class CustomTarget(Target):
             mlog.warning('Unknown keyword arguments in target %s: %s' %
                          (self.name, ', '.join(unknowns)))
 
+    def __lt__(self, other):
+        return self.get_id() < other.get_id()
+
     def __repr__(self):
         repr_str = "<{0} {1}: {2}>"
         return repr_str.format(self.__class__.__name__, self.get_id(), self.command)
@@ -1416,6 +1422,9 @@ class RunTarget(Target):
         self.command = command
         self.args = args
         self.dependencies = dependencies
+
+    def __lt__(self, other):
+        return self.get_id() < other.get_id()
 
     def __repr__(self):
         repr_str = "<{0} {1}: {2}>"

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -16,6 +16,7 @@
 
 import stat
 import platform, subprocess, operator, os, shutil, re
+import collections
 
 from glob import glob
 
@@ -672,3 +673,18 @@ def get_filenames_templates_dict(inputs, outputs):
         if values['@OUTDIR@'] == '':
             values['@OUTDIR@'] = '.'
     return values
+
+class OrderedSet(collections.OrderedDict):
+    '''
+    A 'set' equivalent that preserves the order in which items are added.
+
+    This is a hack implementation that wraps OrderedDict. It may not be the
+    most efficient solution and might need fixing to override more methods.
+    '''
+    def __init__(self, iterable=None):
+        if iterable:
+            self.update(iterable)
+
+    def update(self, iterable):
+        for item in iterable:
+            self[item] = True

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -21,7 +21,7 @@ import sys
 import copy
 import subprocess
 from . import ModuleReturnValue
-from ..mesonlib import MesonException, Popen_safe
+from ..mesonlib import MesonException, OrderedSet, Popen_safe
 from ..dependencies import Dependency, PkgConfigDependency, InternalDependency
 from .. import mlog
 from .. import mesonlib
@@ -154,7 +154,7 @@ class GnomeModule(ExtensionModule):
         # Ensure build directories of generated deps are included
         source_dirs += subdirs
 
-        for source_dir in set(source_dirs):
+        for source_dir in OrderedSet(source_dirs):
             cmd += ['--sourcedir', source_dir]
 
         if 'c_name' in kwargs:
@@ -299,9 +299,9 @@ class GnomeModule(ExtensionModule):
 
     def _get_dependencies_flags(self, deps, state, depends=None, include_rpath=False,
                                 use_gir_args=False):
-        cflags = set()
-        ldflags = set()
-        gi_includes = set()
+        cflags = OrderedSet()
+        ldflags = OrderedSet()
+        gi_includes = OrderedSet()
         if not isinstance(deps, list):
             deps = [deps]
 


### PR DESCRIPTION
I've been seeing .gir targets getting rebuilt every time I change a meson.build file. This turned out to be because the generated commandline in the build.ninja file has arguments in random order. Ninja rebuilds targets any time the commandline that generates them is changed. So where a `set` type is used to store commandline argments, we should always run it through `sorted` before writing it out so that it generates the same commandline every time.

It's also good to write the rules to the build.ninja file in a stable order, it doesn't affect functionality but it makes it much easier to track down places that are changing unnecessarily and causing spurious rebuilds.