### PR TITLE
Add support for BOOST_INCLUDEDIR and BOOST_LIBRARYDIR

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -77,3 +77,4 @@ Philipp Ittershagen
 Dylan Baker
 Aaron Plattner
 Jon Turney
+Wade Berrier


### PR DESCRIPTION
In case they are not decendants of BOOST_ROOT...

(Idea copied from CMake FindBoost)

Possible fix for #1562