### PR TITLE
Don't crash if a meson.build file is empty

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -75,3 +75,4 @@ Roger Boerdijk
 melak47
 Philipp Ittershagen
 Dylan Baker
+Aaron Plattner

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -407,6 +407,7 @@ class Parser:
     def __init__(self, code, subdir):
         self.lexer = Lexer(code)
         self.stream = self.lexer.lex(subdir)
+        self.current = Token('eof', '', 0, 0, 0, (0, 0), None)
         self.getsym()
         self.in_ternary = False
 

--- a/test cases/common/144 empty build file/meson.build
+++ b/test cases/common/144 empty build file/meson.build
@@ -1,0 +1,2 @@
+project('subdir with empty meson.build test', 'c')
+subdir('subdir')


### PR DESCRIPTION
Commit 9adef3a8e878 caused an empty meson.build file to generate a traceback:

 Traceback (most recent call last):
   File "/usr/lib/python3.6/site-packages/mesonbuild/mparser.py", line 415, in getsym
     self.current = next(self.stream)
 StopIteration

 During handling of the above exception, another exception occurred:

 Traceback (most recent call last):
   File "/usr/lib/python3.6/site-packages/mesonbuild/mesonmain.py", line 298, in run
     app.generate()
   File "/usr/lib/python3.6/site-packages/mesonbuild/mesonmain.py", line 180, in generate
     intr.run()
   File "/usr/lib/python3.6/site-packages/mesonbuild/interpreter.py", line 2529, in run
     super().run()
   File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 125, in run
     self.evaluate_codeblock(self.ast, start=1)
   File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 146, in evaluate_codeblock
     raise e
   File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 140, in evaluate_codeblock
     self.evaluate_statement(cur)
   File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 151, in evaluate_statement
     return self.function_call(cur)
   File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 372, in function_call
     return self.funcs[func_name](node, self.flatten(posargs), kwargs)
   File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 47, in wrapped
     return f(self, node, args, kwargs)
   File "/usr/lib/python3.6/site-packages/mesonbuild/interpreter.py", line 2237, in func_subdir
     self.evaluate_codeblock(codeblock)
   File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 146, in evaluate_codeblock
     raise e
   File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 140, in evaluate_codeblock
     self.evaluate_statement(cur)
   File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 151, in evaluate_statement
     return self.function_call(cur)
   File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 372, in function_call
     return self.funcs[func_name](node, self.flatten(posargs), kwargs)
   File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 47, in wrapped
     return f(self, node, args, kwargs)
   File "/usr/lib/python3.6/site-packages/mesonbuild/interpreter.py", line 2233, in func_subdir
     codeblock = mparser.Parser(code, self.subdir).parse()
   File "/usr/lib/python3.6/site-packages/mesonbuild/mparser.py", line 410, in __init__
     self.getsym()
   File "/usr/lib/python3.6/site-packages/mesonbuild/mparser.py", line 417, in getsym
     self.current = Token('eof', '', self.current.line_start, self.current.lineno, self.current.colno + self.current.bytespan[1] - self.current.bytespan[0], (0, 0), None)
 AttributeError: 'Parser' object has no attribute 'current'

Fix the parser so it instead fails with

 Meson encountered an error:
 No statements in code.