### PR TITLE
run_project_tests: Enable parallel build for VS backend

### DIFF
--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -168,7 +168,7 @@ def setup_commands(backend):
         if backend is None:
             backend = 'vs2010'
         backend_flags = ['--backend=' + backend]
-        compile_commands = ['msbuild']
+        compile_commands = ['msbuild', '/m']
         test_commands = ['msbuild', 'RUN_TESTS.vcxproj']
     elif backend == 'xcode' or (backend is None and mesonlib.is_osx()):
         backend_flags = ['--backend=xcode']


### PR DESCRIPTION
Should shave off ~2 min on the CI out of ~16 min. Let's see when the CI runs. Comparing it with https://ci.appveyor.com/project/jpakkane/meson/build/1.0.2146.