### PR TITLE
Don't try to build unknown source files

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -421,15 +421,17 @@ int dummy;
 
         # Generate compile targets for all the pre-existing sources for this target
         for f, src in target_sources.items():
-            if not self.environment.is_header(src):
-                if self.environment.is_llvm_ir(src):
-                    obj_list.append(self.generate_llvm_ir_compile(target, outfile, src))
-                elif is_unity and self.get_target_source_can_unity(target, src):
-                    abs_src = os.path.join(self.environment.get_build_dir(),
-                                           src.rel_to_builddir(self.build_to_src))
-                    unity_src.append(abs_src)
-                else:
-                    obj_list.append(self.generate_single_compile(target, outfile, src, False, [], header_deps))
+            # Don't try to compile headers and non-source files
+            if self.environment.is_header(src) or not self.environment.is_source(src):
+                continue
+            elif self.environment.is_llvm_ir(src):
+                obj_list.append(self.generate_llvm_ir_compile(target, outfile, src))
+            elif is_unity and self.get_target_source_can_unity(target, src):
+                abs_src = os.path.join(self.environment.get_build_dir(),
+                                       src.rel_to_builddir(self.build_to_src))
+                unity_src.append(abs_src)
+            else:
+                obj_list.append(self.generate_single_compile(target, outfile, src, False, [], header_deps))
         obj_list += self.flatten_object_list(target)
         if is_unity:
             for src in self.generate_unity_files(target, unity_src):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1298,12 +1298,16 @@ class CustomTarget(Target):
         for c in cmd:
             if hasattr(c, 'held_object'):
                 c = c.held_object
-            if isinstance(c, (str, File)):
+            if isinstance(c, str):
+                final_cmd.append(c)
+            elif isinstance(c, File):
+                self.depend_files.append(c)
                 final_cmd.append(c)
             elif isinstance(c, dependencies.ExternalProgram):
                 if not c.found():
                     m = 'Tried to use not-found external program {!r} in "command"'
                     raise InvalidArguments(m.format(c.name))
+                self.depend_files.append(File.from_absolute_file(c.get_path()))
                 final_cmd += c.get_command()
             elif isinstance(c, (BuildTarget, CustomTarget)):
                 self.dependencies.append(c)

--- a/test cases/common/22 header in file list/meson.build
+++ b/test cases/common/22 header in file list/meson.build
@@ -1,4 +1,4 @@
 project('header in file list', 'c')
 
-exe = executable('prog', 'prog.c', 'header.h')
+exe = executable('prog', 'prog.c', 'header.h', 'useless.dt')
 test('basic', exe)

--- a/test cases/common/22 header in file list/prog.c
+++ b/test cases/common/22 header in file list/prog.c
@@ -1,1 +1,3 @@
+#include "header.h"
+
 int main(int argc, char **argv) { return 0; }

--- a/test cases/common/22 header in file list/useless.dt
+++ b/test cases/common/22 header in file list/useless.dt
@@ -1,0 +1,3 @@
+This file is not compiled, and is not a header, but might be used in the
+compilation anyway (such as if it's #include-ed, etc). See:
+https://github.com/mesonbuild/meson/issues/1572

--- a/test cases/common/64 custom header generator/meson.build
+++ b/test cases/common/64 custom header generator/meson.build
@@ -5,7 +5,7 @@ gen = find_program('makeheader.py')
 generated_h = custom_target('makeheader.py',
 output : 'myheader.lh', # Suffix not .h to ensure this works with custom suffixes, too.
 input : 'input.def',
-command : [gen, '@INPUT0@', '@OUTPUT0@'])
+command : [gen, '@INPUT0@', '@OUTPUT0@', files('somefile.txt')])
 
 prog = executable('prog', 'prog.c', generated_h)
 test('gentest', prog)


### PR DESCRIPTION
For the same reason that we don't try to build headers. People are allowed to add arbitrary files to the input files list, but we still depend on the compiler to generate a proper dependency file.

Includes a unit test for this.

Closes https://github.com/mesonbuild/meson/issues/1572