### PR TITLE
Add support for language list in add_*_arguments

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2479,9 +2479,9 @@ different subdirectory.
         if 'language' not in kwargs:
             raise InvalidCode('Missing language definition in {}'.format(node.func_name))
 
-        lang = kwargs['language'].lower()
-        args = argsdict.get(lang, []) + args
-        argsdict[lang] = args
+        for lang in mesonlib.stringlistify(kwargs['language']):
+            lang = lang.lower()
+            argsdict[lang] = argsdict.get(lang, []) + args
 
     def func_environment(self, node, args, kwargs):
         return EnvironmentVariablesHolder()

--- a/test cases/common/123 subproject project arguments/exe.c
+++ b/test cases/common/123 subproject project arguments/exe.c
@@ -18,6 +18,10 @@
 #error
 #endif
 
+#ifndef PROJECT_OPTION_C_CPP
+#error
+#endif
+
 int main(int argc, char **argv) {
     return 0;
 }

--- a/test cases/common/123 subproject project arguments/exe.cpp
+++ b/test cases/common/123 subproject project arguments/exe.cpp
@@ -18,6 +18,10 @@
 #error
 #endif
 
+#ifndef PROJECT_OPTION_C_CPP
+#error
+#endif
+
 int main(int argc, char **argv) {
     return 0;
 }

--- a/test cases/common/123 subproject project arguments/meson.build
+++ b/test cases/common/123 subproject project arguments/meson.build
@@ -4,11 +4,13 @@ project('project options tester', 'c', 'cpp',
 
 add_global_arguments('-DGLOBAL_ARGUMENT', language: 'c')
 add_project_arguments('-DPROJECT_OPTION', language: 'c')
-add_project_arguments('-DPROJECT_OPTION_1', language: 'c')
 add_project_arguments('-DPROJECT_OPTION_CPP', language: 'cpp')
 add_project_arguments('-DPROJECT_OPTION_C_CPP', language: ['c', 'cpp'])
 
 sub = subproject('subexe', version : '1.0.0')
+
+add_project_arguments('-DPROJECT_OPTION_1', language: 'c')
+
 e = executable('exe', 'exe.c')
 e = executable('execpp', 'exe.cpp')
 test('exetest', e)

--- a/test cases/common/123 subproject project arguments/meson.build
+++ b/test cases/common/123 subproject project arguments/meson.build
@@ -6,6 +6,7 @@ add_global_arguments('-DGLOBAL_ARGUMENT', language: 'c')
 add_project_arguments('-DPROJECT_OPTION', language: 'c')
 add_project_arguments('-DPROJECT_OPTION_1', language: 'c')
 add_project_arguments('-DPROJECT_OPTION_CPP', language: 'cpp')
+add_project_arguments('-DPROJECT_OPTION_C_CPP', language: ['c', 'cpp'])
 
 sub = subproject('subexe', version : '1.0.0')
 e = executable('exe', 'exe.c')

--- a/test cases/common/123 subproject project arguments/subprojects/subexe/subexe.c
+++ b/test cases/common/123 subproject project arguments/subprojects/subexe/subexe.c
@@ -6,6 +6,10 @@
 #error
 #endif
 
+#ifdef PROJECT_OPTION_C_CPP
+#error
+#endif
+
 #ifndef GLOBAL_ARGUMENT
 #error
 #endif

--- a/test cases/common/23 global arg/meson.build
+++ b/test cases/common/23 global arg/meson.build
@@ -3,6 +3,8 @@ project('global arg test', 'cpp', 'c')
 add_global_arguments('-DMYTHING', language : 'c')
 add_global_arguments('-DMYCPPTHING', language : 'cpp')
 
+add_global_arguments('-DMYCANDCPPTHING', language: ['c', 'cpp'])
+
 exe1 = executable('prog', 'prog.c')
 exe2 = executable('prog2', 'prog.cc')
 

--- a/test cases/common/23 global arg/prog.c
+++ b/test cases/common/23 global arg/prog.c
@@ -6,6 +6,10 @@
 #error "Wrong global argument set"
 #endif
 
+#ifndef MYCANDCPPTHING
+#error "Global argument not set"
+#endif
+
 int main(int argc, char **argv) {
     return 0;
 }

--- a/test cases/common/23 global arg/prog.cc
+++ b/test cases/common/23 global arg/prog.cc
@@ -6,6 +6,10 @@
 #error "Global argument not set"
 #endif
 
+#ifndef MYCANDCPPTHING
+#error "Global argument not set"
+#endif
+
 int main(int argc, char **argv) {
     return 0;
 }


### PR DESCRIPTION
When using meson to build a mixed C/C++ code base with defines that need to be consistent for both languages, I had to add the arguments twice (and declare an extra variable):
```
args = [] # ...
add_project_arguments(args, language : 'c')
add_project_arguments(args, language : 'cpp')
```

This PR refactors the common code for handling project/global/link arguments and adds the ability to take a list as the `language` kwarg.

A possible update to the[ documentation](https://github.com/mesonbuild/meson/wiki/Reference-manual#add_global_arguments) would simply consist of adding a sentence in the function description of add_global_arguments, since all other variants refer to it:

> Adds the positional arguments to the compiler command line for the languages specified in language keyword argument. **If a list of languages is given, the arguments are added to each of the corresponding compiler command lines.**