### PR TITLE
Add an option to dependencies called 'method'.

### DIFF
--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -268,7 +268,7 @@ class PkgConfigDependency(Dependency):
         return self.libs
 
     def get_methods(self):
-        return ['pkgconfig']
+        return ['pkg-config']
 
     def check_pkgconfig(self):
         evar = 'PKG_CONFIG'
@@ -985,7 +985,7 @@ class QtBaseDependency(Dependency):
         # Keep track of the detection methods used, for logging purposes.
         methods = []
         # Prefer pkg-config, then fallback to `qmake -query`
-        if 'pkgconfig' in self.methods:
+        if 'pkg-config' in self.methods:
             self._pkgconfig_detect(mods, env, kwargs)
             methods.append('pkgconfig')
         if not self.is_found and 'qmake' in self.methods:
@@ -1137,7 +1137,7 @@ class QtBaseDependency(Dependency):
         return self.largs
 
     def get_methods(self):
-        return ['pkgconfig', 'qmake']
+        return ['pkg-config', 'qmake']
 
     def found(self):
         return self.is_found
@@ -1301,7 +1301,7 @@ class GLDependency(Dependency):
         self.is_found = False
         self.cargs = []
         self.linkargs = []
-        if 'pkgconfig' in self.methods:
+        if 'pkg-config' in self.methods:
             try:
                 pcdep = PkgConfigDependency('gl', environment, kwargs)
                 if pcdep.found():
@@ -1333,9 +1333,9 @@ class GLDependency(Dependency):
 
     def get_methods(self):
         if mesonlib.is_osx() or mesonlib.is_windows():
-            return ['pkgconfig', 'system']
+            return ['pkg-config', 'system']
         else:
-            return ['pkgconfig']
+            return ['pkg-config']
 
 # There are three different ways of depending on SDL2:
 # sdl2-config, pkg-config and OSX framework
@@ -1345,7 +1345,7 @@ class SDL2Dependency(Dependency):
         self.is_found = False
         self.cargs = []
         self.linkargs = []
-        if 'pkgconfig' in self.methods:
+        if 'pkg-config' in self.methods:
             try:
                 pcdep = PkgConfigDependency('sdl2', environment, kwargs)
                 if pcdep.found():
@@ -1397,9 +1397,9 @@ class SDL2Dependency(Dependency):
 
     def get_methods(self):
         if mesonlib.is_osx():
-            return ['pkgconfig', 'sdlconfig', 'extraframework']
+            return ['pkg-config', 'sdlconfig', 'extraframework']
         else:
-            return ['pkgconfig', 'sdlconfig']
+            return ['pkg-config', 'sdlconfig']
 
 class ExtraFrameworkDependency(Dependency):
     def __init__(self, name, required, path, kwargs):
@@ -1465,7 +1465,7 @@ class Python3Dependency(Dependency):
         self.is_found = False
         # We can only be sure that it is Python 3 at this point
         self.version = '3'
-        if 'pkgconfig' in self.methods:
+        if 'pkg-config' in self.methods:
             try:
                 pkgdep = PkgConfigDependency('python3', environment, kwargs)
                 if pkgdep.found():
@@ -1536,11 +1536,11 @@ class Python3Dependency(Dependency):
 
     def get_methods(self):
         if mesonlib.is_windows():
-            return ['pkgconfig', 'sysconfig']
+            return ['pkg-config', 'sysconfig']
         elif mesonlib.is_osx():
-            return ['pkgconfig', 'extraframework']
+            return ['pkg-config', 'extraframework']
         else:
-            return ['pkgconfig']
+            return ['pkg-config']
 
     def get_version(self):
         return self.version

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -99,3 +99,16 @@ def log(*args, **kwargs):
 
 def warning(*args, **kwargs):
     log(yellow('WARNING:'), *args, **kwargs)
+
+# Format a list for logging purposes as a string. It separates
+# all but the last item with commas, and the last with 'and'.
+def format_list(list):
+    l = len(list)
+    if l > 2:
+        return ' and '.join([', '.join(list[:-1]), list[-1]])
+    elif l == 2:
+        return ' and '.join(list)
+    elif l == 1:
+        return list[0]
+    else:
+        return ''

--- a/mesonbuild/modules/qt4.py
+++ b/mesonbuild/modules/qt4.py
@@ -24,14 +24,14 @@ from . import ModuleReturnValue
 class Qt4Module(ExtensionModule):
     tools_detected = False
 
-    def _detect_tools(self, env):
+    def _detect_tools(self, env, method):
         if self.tools_detected:
             return
         mlog.log('Detecting Qt4 tools')
         # FIXME: We currently require Qt4 to exist while importing the module.
         # We should make it gracefully degrade and not create any targets if
         # the import is marked as 'optional' (not implemented yet)
-        kwargs = {'required': 'true', 'modules': 'Core', 'silent': 'true'}
+        kwargs = {'required': 'true', 'modules': 'Core', 'silent': 'true', 'method': method}
         qt4 = Qt4Dependency(env, kwargs)
         # Get all tools and then make sure that they are the right version
         self.moc, self.uic, self.rcc = qt4.compilers_detect()
@@ -113,7 +113,8 @@ class Qt4Module(ExtensionModule):
         if not isinstance(sources, list):
             sources = [sources]
         sources += args[1:]
-        self._detect_tools(state.environment)
+        method = kwargs.get('method', 'auto')
+        self._detect_tools(state.environment, method)
         err_msg = "{0} sources specified and couldn't find {1}, " \
                   "please check your qt4 installation"
         if len(moc_headers) + len(moc_sources) > 0 and not self.moc.found():

--- a/mesonbuild/modules/qt5.py
+++ b/mesonbuild/modules/qt5.py
@@ -24,14 +24,14 @@ from . import ModuleReturnValue
 class Qt5Module(ExtensionModule):
     tools_detected = False
 
-    def _detect_tools(self, env):
+    def _detect_tools(self, env, method):
         if self.tools_detected:
             return
         mlog.log('Detecting Qt5 tools')
         # FIXME: We currently require Qt5 to exist while importing the module.
         # We should make it gracefully degrade and not create any targets if
         # the import is marked as 'optional' (not implemented yet)
-        kwargs = {'required': 'true', 'modules': 'Core', 'silent': 'true'}
+        kwargs = {'required': 'true', 'modules': 'Core', 'silent': 'true', 'method': method}
         qt5 = Qt5Dependency(env, kwargs)
         # Get all tools and then make sure that they are the right version
         self.moc, self.uic, self.rcc = qt5.compilers_detect()
@@ -119,7 +119,8 @@ class Qt5Module(ExtensionModule):
         if not isinstance(sources, list):
             sources = [sources]
         sources += args[1:]
-        self._detect_tools(state.environment)
+        method = kwargs.get('method', 'auto')
+        self._detect_tools(state.environment, method)
         err_msg = "{0} sources specified and couldn't find {1}, " \
                   "please check your qt5 installation"
         if len(moc_headers) + len(moc_sources) > 0 and not self.moc.found():

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1121,7 +1121,7 @@ class LinuxlikeTests(BasePlatformTests):
         if qt4 != 0 or qt5 != 0:
             raise unittest.SkipTest('Qt not found with pkg-config')
         testdir = os.path.join(self.framework_test_dir, '4 qt')
-        self.init(testdir, ['-Dmethod=pkgconfig'])
+        self.init(testdir, ['-Dmethod=pkg-config'])
         # Confirm that the dependency was found with qmake
         msg = 'Qt4 native `pkg-config` dependency (modules: Core, Gui) found: YES\n'
         msg2 = 'Qt5 native `pkg-config` dependency (modules: Core, Gui) found: YES\n'

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1121,7 +1121,7 @@ class LinuxlikeTests(BasePlatformTests):
         if qt4 != 0 or qt5 != 0:
             raise unittest.SkipTest('Qt not found with pkg-config')
         testdir = os.path.join(self.framework_test_dir, '4 qt')
-        self.init(testdir)
+        self.init(testdir, ['-Dmethod=pkgconfig'])
         # Confirm that the dependency was found with qmake
         msg = 'Qt4 native `pkg-config` dependency (modules: Core, Gui) found: YES\n'
         msg2 = 'Qt5 native `pkg-config` dependency (modules: Core, Gui) found: YES\n'
@@ -1144,10 +1144,8 @@ class LinuxlikeTests(BasePlatformTests):
             if 'Qt version 5' not in output and 'qt5' not in output:
                 raise unittest.SkipTest('Qmake found, but it is not for Qt 5.')
         # Disable pkg-config codepath and force searching with qmake/qmake-qt5
-        os.environ['PKG_CONFIG_LIBDIR'] = self.builddir
-        os.environ['PKG_CONFIG_PATH'] = self.builddir
         testdir = os.path.join(self.framework_test_dir, '4 qt')
-        self.init(testdir)
+        self.init(testdir, ['-Dmethod=qmake'])
         # Confirm that the dependency was found with qmake
         msg = 'Qt5 native `qmake-qt5` dependency (modules: Core) found: YES\n'
         msg2 = 'Qt5 native `qmake` dependency (modules: Core) found: YES\n'

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -9,17 +9,17 @@ foreach qt : ['qt4', 'qt5']
     qt_modules += qt5_modules
   endif
   # Test that invalid modules are indeed not found
-  fakeqtdep = dependency(qt, modules : ['DefinitelyNotFound'], required : false)
+  fakeqtdep = dependency(qt, modules : ['DefinitelyNotFound'], required : false, method : get_option('method'))
   if fakeqtdep.found()
     error('Invalid qt dep incorrectly found!')
   endif
   # Test that partially-invalid modules are indeed not found
-  fakeqtdep = dependency(qt, modules : ['Core', 'DefinitelyNotFound'], required : false)
+  fakeqtdep = dependency(qt, modules : ['Core', 'DefinitelyNotFound'], required : false, method : get_option('method'))
   if fakeqtdep.found()
     error('Invalid qt dep incorrectly found!')
   endif
   # If qt4 modules are found, test that. qt5 is required.
-  qtdep = dependency(qt, modules : qt_modules, required : qt == 'qt5')
+  qtdep = dependency(qt, modules : qt_modules, required : qt == 'qt5', method : get_option('method'))
   if qtdep.found()
     qtmodule = import(qt)
 
@@ -30,10 +30,11 @@ foreach qt : ['qt4', 'qt5']
       moc_headers : ['mainWindow.h'],           # These need to be fed through the moc tool before use. 
       ui_files : 'mainWindow.ui',               # XML files that need to be compiled with the uic tol.
       qresources : ['stuff.qrc', 'stuff2.qrc'], # Resource file for rcc compiler.
+      method : get_option('method')
     )
 
     # Test that setting a unique name with a positional argument works
-    qtmodule.preprocess(qt + 'teststuff', qresources : ['stuff.qrc'])
+    qtmodule.preprocess(qt + 'teststuff', qresources : ['stuff.qrc'], method : get_option('method'))
 
     qexe = executable(qt + 'app',
       sources : ['main.cpp', 'mainWindow.cpp', # Sources that don't need preprocessing.
@@ -43,7 +44,7 @@ foreach qt : ['qt4', 'qt5']
     # We need a console test application because some test environments
     # do not have an X server.
 
-    qtcore = dependency(qt, modules : 'Core')
+    qtcore = dependency(qt, modules : 'Core', method : get_option('method'))
 
     qtcoreapp = executable(qt + 'core', 'q5core.cpp',
       dependencies : qtcore)
@@ -55,7 +56,8 @@ foreach qt : ['qt4', 'qt5']
     # files from sources.
     manpreprocessed = qtmodule.preprocess(
       moc_sources : 'manualinclude.cpp',
-      moc_headers : 'manualinclude.h')
+      moc_headers : 'manualinclude.h',
+      method : get_option('method'))
 
     qtmaninclude = executable(qt + 'maninclude',
       sources : ['manualinclude.cpp', manpreprocessed],

--- a/test cases/frameworks/4 qt/meson_options.txt
+++ b/test cases/frameworks/4 qt/meson_options.txt
@@ -1,0 +1,1 @@
+option('method', type : 'string', value : 'auto', description : 'The method to use to find Qt')


### PR DESCRIPTION
This can be used to configure a detection method, for those types of dependencies that have
more than one means of detection.

The default detection methods are unchanged if 'method' is not
specified, and all dependencies support the method 'auto', which is the
same as not specifying a method.

The dependencies which do support multiple detection methods
additionally support other values, depending on the dependency.

The Qt module's preprocess function also uses a dependency to fix preprocessing tools, so it also now takes a method argument, which is passed on to the dependency finder.

Closes #1472 
Closes #711 