### PR TITLE
Allow passing generated files to shared_module vs_module_def. Closes #1605

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1203,6 +1203,10 @@ class SharedLibrary(BuildTarget):
                 self.vs_module_defs = path
                 # link_depends can be an absolute path or relative to self.subdir
                 self.link_depends.append(path.absolute_path(environment.source_dir, environment.build_dir))
+            else:
+                raise InvalidArguments(
+                    'Shared library vs_module_defs must be either a string, '
+                    'or a file object')
 
     def check_unknown_kwargs(self, kwargs):
         self.check_unknown_kwargs_int(kwargs, known_lib_kwargs)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1191,12 +1191,18 @@ class SharedLibrary(BuildTarget):
         # Visual Studio module-definitions file
         if 'vs_module_defs' in kwargs:
             path = kwargs['vs_module_defs']
-            if os.path.isabs(path):
-                self.vs_module_defs = File.from_absolute_file(path)
-            else:
-                self.vs_module_defs = File.from_source_file(environment.source_dir, self.subdir, path)
-            # link_depends can be an absolute path or relative to self.subdir
-            self.link_depends.append(path)
+            if isinstance(path, str):
+                if os.path.isabs(path):
+                    self.vs_module_defs = File.from_absolute_file(path)
+                else:
+                    self.vs_module_defs = File.from_source_file(environment.source_dir, self.subdir, path)
+                # link_depends can be an absolute path or relative to self.subdir
+                self.link_depends.append(path)
+            elif isinstance(path, File):
+                # When passing a generated file.
+                self.vs_module_defs = path
+                # link_depends can be an absolute path or relative to self.subdir
+                self.link_depends.append(path.absolute_path(environment.source_dir, environment.build_dir))
 
     def check_unknown_kwargs(self, kwargs):
         self.check_unknown_kwargs_int(kwargs, known_lib_kwargs)

--- a/test cases/windows/10 vs module defs generated/meson.build
+++ b/test cases/windows/10 vs module defs generated/meson.build
@@ -1,0 +1,7 @@
+project('generated_dll_module_defs', 'c')
+
+if meson.get_compiler('c').get_id() == 'msvc'
+  subdir('subdir')
+  exe = executable('prog', 'prog.c', link_with : shlib)
+  test('runtest', exe)
+endif

--- a/test cases/windows/10 vs module defs generated/prog.c
+++ b/test cases/windows/10 vs module defs generated/prog.c
@@ -1,0 +1,5 @@
+int somedllfunc();
+
+int main(int argc, char **argv) {
+    return somedllfunc() == 42 ? 0 : 1;
+}

--- a/test cases/windows/10 vs module defs generated/subdir/meson.build
+++ b/test cases/windows/10 vs module defs generated/subdir/meson.build
@@ -1,0 +1,9 @@
+conf = configuration_data()
+conf.set('func', 'somedllfunc')
+def_file = configure_file(
+  input: 'somedll.def.in',
+  output: 'somedll.def',
+  configuration : conf,
+)
+
+shlib = shared_library('somedll', 'somedll.c', vs_module_defs : def_file)

--- a/test cases/windows/10 vs module defs generated/subdir/somedll.c
+++ b/test cases/windows/10 vs module defs generated/subdir/somedll.c
@@ -1,0 +1,5 @@
+#ifdef _MSC_VER
+int somedllfunc() {
+    return 42;
+}
+#endif

--- a/test cases/windows/10 vs module defs generated/subdir/somedll.def.in
+++ b/test cases/windows/10 vs module defs generated/subdir/somedll.def.in
@@ -1,0 +1,2 @@
+EXPORTS
+    @func@


### PR DESCRIPTION
This detects and allows passing a generated file as a vs_module_def, it
also adds a testcase that tests using configure_file to generate the
.def file.