### PR TITLE
Don't close fds when executing programs

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -79,3 +79,4 @@ Aaron Plattner
 Jon Turney
 Wade Berrier
 Richard Hughes
+Michael Olbrich

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -504,6 +504,7 @@ def expand_arguments(args):
 
 def Popen_safe(args, write=None, stderr=subprocess.PIPE, **kwargs):
     p = subprocess.Popen(args, universal_newlines=True,
+                         close_fds=False,
                          stdout=subprocess.PIPE,
                          stderr=stderr, **kwargs)
     o, e = p.communicate(write)


### PR DESCRIPTION
Tools that execute meson might open file descriptors for the programs to
use. Such as a file descriptor for a logfile.

In my case, I'm calling meson from a cross build environment. The compiler is actually a wrapper script that manipulates the compiler arguments to simplify cross compiling. For debugging it writes the final command line to a previously opened file descriptor. That works quite nicely with just about anything (autoconf, cmake, make, ninja, ...) but fails with meson without this patch.