### PR TITLE
Add Compiler.filter_arguments()

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1286,6 +1286,10 @@ the following methods:
 - `get_id()` returns a string identifying the compiler. For example,
   `gcc`, `msvc`, [and more](Compiler-properties.md#compiler-id).
 
+- `get_supported_arguments(list_of_string)` returns an array
+  containing only the arguments supported by the compiler, as if
+  `has_argument` were called on them individually.
+
 - `compiles(code)` returns true if the code fragment given in the
   positional argument compiles, you can specify external dependencies
   to use with `dependencies` keyword argument, `code` can be either a

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1260,6 +1260,12 @@ the following methods:
   the positional argument, you can specify external dependencies to
   use with `dependencies` keyword argument.
 
+- `compiles(code)` returns true if the code fragment given in the
+  positional argument compiles, you can specify external dependencies
+  to use with `dependencies` keyword argument, `code` can be either a
+  string containing source code or a `file` object pointing to the
+  source code.
+
 - `compute_int(expr, ...')` computes the value of the given expression
   (as an example `1 + 2`). When cross compiling this is evaluated with
   an iterative algorithm, you can specify keyword arguments `low`
@@ -1289,12 +1295,6 @@ the following methods:
 - `get_supported_arguments(list_of_string)` returns an array
   containing only the arguments supported by the compiler, as if
   `has_argument` were called on them individually.
-
-- `compiles(code)` returns true if the code fragment given in the
-  positional argument compiles, you can specify external dependencies
-  to use with `dependencies` keyword argument, `code` can be either a
-  string containing source code or a `file` object pointing to the
-  source code.
 
 - `has_argument(argument_name)` returns true if the compiler accepts
   the specified command line argument, that is, can compile code

--- a/docs/markdown/snippets/get-supported-arguments.md
+++ b/docs/markdown/snippets/get-supported-arguments.md
@@ -1,0 +1,23 @@
+# Easier handling of supported compiler arguments
+
+A common pattern for handling multiple desired compiler arguments, was to
+test their presence and add them to an array one-by-one, e.g.:
+
+    warning_flags_maybe = [
+      '-Wsomething',
+      '-Wanother-thing',
+      '-Wno-the-other-thing',
+    ]
+    warning_flags = []
+    foreach flag : warning_flags_maybe
+      if cc.has_argument(flag)
+        warning_flags += flag
+      endif
+    endforeach
+    cc.add_project_argument(warning_flags)
+
+A helper has been added for the foreach/has_argument pattern, so you can
+now simply do:
+
+    warning_flags = [ ... ]
+    flags = cc.get_supported_flags(warning_flags)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -712,6 +712,13 @@ class Compiler:
             'Language {} does not support has_multi_arguments.'.format(
                 self.get_display_language()))
 
+    def get_supported_arguments(self, args, env):
+        supported_args = []
+        for arg in args:
+            if self.has_argument(arg, env):
+                supported_args.append(arg)
+        return supported_args
+
     def get_cross_extra_flags(self, environment, link):
         extra_flags = []
         if self.is_cross and environment:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -652,6 +652,7 @@ class CompilerHolder(InterpreterObject):
                              'find_library': self.find_library_method,
                              'has_argument': self.has_argument_method,
                              'has_multi_arguments': self.has_multi_arguments_method,
+                             'get_supported_arguments': self.get_supported_arguments_method,
                              'first_supported_argument': self.first_supported_argument_method,
                              'unittest_args': self.unittest_args_method,
                              'symbols_have_underscore_prefix': self.symbols_have_underscore_prefix_method,
@@ -1012,6 +1013,22 @@ class CompilerHolder(InterpreterObject):
                 self.compiler.get_display_language(), ' '.join(args)),
             h)
         return result
+
+    def get_supported_arguments_method(self, args, kwargs):
+        args = mesonlib.stringlistify(args)
+        result = self.compiler.get_supported_arguments(args, self.environment)
+        if len(result) == len(args):
+            h = mlog.green('YES')
+        elif len(result) > 0:
+            h = mlog.yellow('SOME')
+        else:
+            h = mlog.red('NO')
+        mlog.log(
+            'Compiler for {} supports arguments {}:'.format(
+                self.compiler.get_display_language(), ' '.join(args)),
+            h)
+        return result
+
 
     def first_supported_argument_method(self, args, kwargs):
         for i in mesonlib.stringlistify(args):

--- a/test cases/common/112 has arg/meson.build
+++ b/test cases/common/112 has arg/meson.build
@@ -19,6 +19,9 @@ assert(not cc.has_argument(isnt_arg), 'Arg that should be broken is not.')
 assert(cpp.has_argument(is_arg), 'Arg that should have worked does not work.')
 assert(not cpp.has_argument(isnt_arg), 'Arg that should be broken is not.')
 
+assert(cc.get_supported_arguments([is_arg, isnt_arg, useless]) == [is_arg, useless], 'Arg filtering returned different result.')
+assert(cpp.get_supported_arguments([is_arg, isnt_arg, useless]) == [is_arg, useless], 'Arg filtering returned different result.')
+
 # Have useless at the end to ensure that the search goes from front to back.
 l1 = cc.first_supported_argument([isnt_arg, is_arg, isnt_arg, useless])
 l2 = cc.first_supported_argument(isnt_arg, isnt_arg, isnt_arg)


### PR DESCRIPTION
Add a helper for the common pattern of:
```
  args_to_use = []
  foreach arg: candidate_args
    if cc.has_argument(arg)
      args_to_use += arg
    endif
  endforeach
```

Replaced with:
`  args_to_use = cc.filter_arguments(candidate_args)`