### PR TITLE
gtkdochelper: Fix type file name option

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -79,3 +79,4 @@ Aaron Plattner
 Jon Turney
 Wade Berrier
 Richard Hughes
+Rafael Fontenelle

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -107,7 +107,7 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
     gtkdoc_run_check(scan_cmd, abs_out)
 
     if gobject_typesfile:
-        scanobjs_cmd = ['gtkdoc-scangobj'] + scanobjs_args + [gobject_typesfile,
+        scanobjs_cmd = ['gtkdoc-scangobj'] + scanobjs_args + ['--types=' + gobject_typesfile,
                                                               '--module=' + module,
                                                               '--cflags=' + cflags,
                                                               '--ldflags=' + ldflags]


### PR DESCRIPTION
'gtkdoc-scangobj' script was recently ported to Python (it was Perl), and it now requires providing '--types' option to specify the name of the file to store the types in. Without this option, 'gtkdockelper' will exit with error status 2 and will throw a message "gtkdoc-scangobj: error: unrecognized arguments: <typefile>"