### PR TITLE
Do not obliterate old rpath because it might be used due to read only…

### DIFF
--- a/test cases/unit/7 run installed/foo/foo.c
+++ b/test cases/unit/7 run installed/foo/foo.c
@@ -1,0 +1,3 @@
+int foo() {
+    return 0;
+}

--- a/test cases/unit/7 run installed/foo/meson.build
+++ b/test cases/unit/7 run installed/foo/meson.build
@@ -1,0 +1,7 @@
+# Try to invoke linker constant string deduplication,
+# to ensure we are not clobbering shared strings.
+# Name everything possible just as "foo".
+foolib = shared_library('foo', 'foo.c',
+  install_dir : 'foo',
+  install : true)
+

--- a/test cases/unit/7 run installed/meson.build
+++ b/test cases/unit/7 run installed/meson.build
@@ -1,0 +1,9 @@
+project('foo', 'c',
+  default_options : 'libdir=lib')
+
+subdir('foo')
+
+executable('prog', 'prog.c',
+  link_with : foolib,
+  install : true)
+

--- a/test cases/unit/7 run installed/prog.c
+++ b/test cases/unit/7 run installed/prog.c
@@ -1,0 +1,5 @@
+int foo();
+
+int main(int argc, char **argv) {
+    return foo();
+}


### PR DESCRIPTION
… data sharing. Closes #1619.

No test because creating one would require duplicating all of Xorg.