### PR TITLE
RFC: Add dependency for LLVM. Fixes #1611

### DIFF
--- a/docs/markdown/Release-notes-for-0.41.0.md
+++ b/docs/markdown/Release-notes-for-0.41.0.md
@@ -8,3 +8,7 @@ short-description: Release notes for 0.41 (preliminary)
 # New features
 
 Add features here as code is merged to master.
+
+## Dependency Handler for LLVM
+
+Native support for linking against LLVM using the `dependency` function.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -909,7 +909,14 @@ You probably should put it in link_with instead.''')
         # Pick a compiler based on the language priority-order
         for l in clike_langs:
             if l in self.compilers or l in dep_langs:
-                return all_compilers[l]
+                try:
+                    return all_compilers[l]
+                except KeyError:
+                    raise MesonException(
+                        'Could not get a dynamic linker for build target {!r}. '
+                        'Requires a linker for language "{}", but that is not '
+                        'a project language.'.format(self.name, l))
+
         m = 'Could not get a dynamic linker for build target {!r}'
         raise AssertionError(m.format(self.name))
 

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -356,13 +356,16 @@ class WxDependency(Dependency):
     def __init__(self, environment, kwargs):
         Dependency.__init__(self, 'wx', kwargs)
         self.is_found = False
+        # FIXME: use version instead of modversion
         self.modversion = 'none'
         if WxDependency.wx_found is None:
             self.check_wxconfig()
         if not WxDependency.wx_found:
+            # FIXME: this message could be printed after Dependncy found
             mlog.log("Neither wx-config-3.0 nor wx-config found; can't detect dependency")
             return
 
+        # FIXME: This should print stdout and stderr using mlog.debug
         p, out = Popen_safe([self.wxc, '--version'])[0:2]
         if p.returncode != 0:
             mlog.log('Dependency wxwidgets found:', mlog.red('NO'))
@@ -382,10 +385,12 @@ class WxDependency(Dependency):
             # wx-config seems to have a cflags as well but since it requires C++,
             # this should be good, at least for now.
             p, out = Popen_safe([self.wxc, '--cxxflags'])[0:2]
+            # FIXME: this error should only be raised if required is true
             if p.returncode != 0:
                 raise DependencyException('Could not generate cargs for wxwidgets.')
             self.cargs = out.split()
 
+            # FIXME: this error should only be raised if required is true
             p, out = Popen_safe([self.wxc, '--libs'] + self.requested_modules)[0:2]
             if p.returncode != 0:
                 raise DependencyException('Could not generate libs for wxwidgets.')

--- a/test cases/frameworks/15 llvm/meson.build
+++ b/test cases/frameworks/15 llvm/meson.build
@@ -1,0 +1,10 @@
+project('llvmtest', ['c', 'cpp'], default_options : ['c_std=c99'])
+
+llvm_dep = dependency(
+  'llvm',
+  modules : ['bitwriter', 'asmprinter', 'executionengine', 'target',
+             'mcjit', 'nativecodegen'],
+  required : true,
+)
+
+executable('sum', 'sum.c',  dependencies : llvm_dep)

--- a/test cases/frameworks/15 llvm/sum.c
+++ b/test cases/frameworks/15 llvm/sum.c
@@ -1,0 +1,76 @@
+/** This code is public domain, and taken from 
+ * https://github.com/paulsmith/getting-started-llvm-c-api/blob/master/sum.c
+ */
+/**
+ * LLVM equivalent of:
+ *
+ * int sum(int a, int b) {
+ *     return a + b;
+ * }
+ */
+
+#include <llvm-c/Core.h>
+#include <llvm-c/ExecutionEngine.h>
+#include <llvm-c/Target.h>
+#include <llvm-c/Analysis.h>
+#include <llvm-c/BitWriter.h>
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char const *argv[]) {
+    LLVMModuleRef mod = LLVMModuleCreateWithName("my_module");
+
+    LLVMTypeRef param_types[] = { LLVMInt32Type(), LLVMInt32Type() };
+    LLVMTypeRef ret_type = LLVMFunctionType(LLVMInt32Type(), param_types, 2, 0);
+    LLVMValueRef sum = LLVMAddFunction(mod, "sum", ret_type);
+
+    LLVMBasicBlockRef entry = LLVMAppendBasicBlock(sum, "entry");
+
+    LLVMBuilderRef builder = LLVMCreateBuilder();
+    LLVMPositionBuilderAtEnd(builder, entry);
+    LLVMValueRef tmp = LLVMBuildAdd(builder, LLVMGetParam(sum, 0), LLVMGetParam(sum, 1), "tmp");
+    LLVMBuildRet(builder, tmp);
+
+    char *error = NULL;
+    LLVMVerifyModule(mod, LLVMAbortProcessAction, &error);
+    LLVMDisposeMessage(error);
+
+    LLVMExecutionEngineRef engine;
+    error = NULL;
+    LLVMLinkInMCJIT();
+    LLVMInitializeNativeAsmPrinter();
+    LLVMInitializeNativeTarget();
+    if (LLVMCreateExecutionEngineForModule(&engine, mod, &error) != 0) {
+        fprintf(stderr, "failed to create execution engine\n");
+        abort();
+    }
+    if (error) {
+        fprintf(stderr, "error: %s\n", error);
+        LLVMDisposeMessage(error);
+        exit(EXIT_FAILURE);
+    }
+
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s x y\n", argv[0]);
+        exit(EXIT_FAILURE);
+    }
+    long long x = strtoll(argv[1], NULL, 10);
+    long long y = strtoll(argv[2], NULL, 10);
+
+    LLVMGenericValueRef args[] = {
+        LLVMCreateGenericValueOfInt(LLVMInt32Type(), x, 0),
+        LLVMCreateGenericValueOfInt(LLVMInt32Type(), y, 0)
+    };
+    LLVMGenericValueRef res = LLVMRunFunction(engine, sum, 2, args);
+    printf("%d\n", (int)LLVMGenericValueToInt(res, 0));
+
+    // Write out bitcode to file
+    if (LLVMWriteBitcodeToFile(mod, "sum.bc") != 0) {
+        fprintf(stderr, "error writing bitcode to file, skipping\n");
+    }
+
+    LLVMDisposeBuilder(builder);
+    LLVMDisposeExecutionEngine(engine);
+}


### PR DESCRIPTION
This adds a depdendncy wrapper for llvm-config based on the wxwidgets
dependency. IT handles libs, version, include dir, and the llvm unique
concept of components. These components are individual pieces of the
LLVM library that may or may not be available depending on the platform.