### PR TITLE
Add support for @CURRENT_SOURCE_DIR@ in generator arguments

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -318,6 +318,7 @@ In addition to the above substitutions, the `arguments` keyword argument also ac
 - `@OUTPUT@`: the full path to the output file
 - `@INPUT@`: the full path to the input file
 - `@SOURCE_DIR@`: the full path to the root of the source tree
+- `@CURRENT_SOURCE_DIR@`: this is the directory where the currently processed meson.build is located in
 - `@BUILD_DIR@`: the full path to the root of the build dir where the output will be placed
 
 NOTE: Generators should only be used for outputs that will ***only*** be used as inputs for a [build target](#build_target) or a [custom target](#custom_target). When you use the processed output of a generator in multiple targets, the generator will be run multiple times to create outputs for each target. Each output will be created in a target-private directory `@BUILD_DIR@`.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -149,6 +149,10 @@ class Backend:
             dirname = 'meson-out'
         return dirname
 
+    def get_target_source_dir(self, target):
+        dirname = os.path.join(self.build_to_src, self.get_target_dir(target))
+        return dirname
+
     def get_target_private_dir(self, target):
         dirname = os.path.join(self.get_target_dir(target), target.get_basename() + target.type_suffix())
         return dirname

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1650,6 +1650,7 @@ rule FORTRAN_DEP_HACK
         outfilelist = genlist.get_outputs()
         base_args = generator.get_arglist()
         extra_dependencies = [os.path.join(self.build_to_src, i) for i in genlist.extra_depends]
+        source_target_dir = self.get_target_source_dir(target)
         for i in range(len(infilelist)):
             if len(generator.outputs) == 1:
                 sole_output = os.path.join(self.get_target_private_dir(target), outfilelist[i])
@@ -1676,6 +1677,7 @@ rule FORTRAN_DEP_HACK
             relout = self.get_target_private_dir(target)
             args = [x.replace("@SOURCE_DIR@", self.build_to_src).replace("@BUILD_DIR@", relout)
                     for x in args]
+            args = [x.replace("@CURRENT_SOURCE_DIR@", source_target_dir) for x in args]
             args = [x.replace("@SOURCE_ROOT@", self.build_to_src).replace("@BUILD_ROOT@", '.')
                     for x in args]
             cmdlist = exe_arr + self.replace_extra_args(args, genlist)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -120,6 +120,7 @@ class Vs2010Backend(backends.Backend):
         custom_target_include_dirs = []
         custom_target_output_files = []
         target_private_dir = self.relpath(self.get_target_private_dir(target), self.get_target_dir(target))
+        source_target_dir = self.get_target_source_dir(target)
         down = self.target_to_build_root(target)
         for genlist in target.get_generated_sources():
             if isinstance(genlist, build.CustomTarget):
@@ -154,6 +155,7 @@ class Vs2010Backend(backends.Backend):
                     args = [x.replace("@SOURCE_DIR@", self.environment.get_source_dir())
                              .replace("@BUILD_DIR@", target_private_dir)
                             for x in args]
+                    args = [x.replace("@CURRENT_SOURCE_DIR@", source_target_dir) for x in args]
                     args = [x.replace("@SOURCE_ROOT@", self.environment.get_source_dir())
                              .replace("@BUILD_ROOT@", self.environment.get_build_dir())
                             for x in args]

--- a/test cases/frameworks/5 protocol buffers/asubdir/defs.proto
+++ b/test cases/frameworks/5 protocol buffers/asubdir/defs.proto
@@ -1,0 +1,3 @@
+message Dummy {
+  required string text = 1;
+}

--- a/test cases/frameworks/5 protocol buffers/asubdir/main.cpp
+++ b/test cases/frameworks/5 protocol buffers/asubdir/main.cpp
@@ -1,0 +1,9 @@
+#include "defs.pb.h"
+
+int main(int argc, char **argv) {
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+    Dummy *d = new Dummy;
+    delete d;
+    google::protobuf::ShutdownProtobufLibrary();
+    return 0;
+}

--- a/test cases/frameworks/5 protocol buffers/asubdir/meson.build
+++ b/test cases/frameworks/5 protocol buffers/asubdir/meson.build
@@ -1,0 +1,8 @@
+subdirgen = generator(protoc, \
+  output    : ['@BASENAME@.pb.cc', '@BASENAME@.pb.h'],
+  arguments : ['--proto_path=@CURRENT_SOURCE_DIR@', '--cpp_out=@BUILD_DIR@', '@INPUT@'])
+
+generated = subdirgen.process('defs.proto')
+e = executable('subdir-prog', 'main.cpp', generated,
+ dependencies : dep)
+test('subdir-prototest', e)

--- a/test cases/frameworks/5 protocol buffers/meson.build
+++ b/test cases/frameworks/5 protocol buffers/meson.build
@@ -16,3 +16,5 @@ generated = gen.process('defs.proto')
 e = executable('prog', 'main.cpp', generated,
  dependencies : dep)
 test('prototest', e)
+
+subdir('asubdir')


### PR DESCRIPTION
Allow users to specify @CURRENT_SOURCE_DIR@ in generator arguments
to specify the current target source directory.
This is useful when creating protobuf generator objects in sub-directories
because protoc will then generate files in the expected location.

Fixes #1622.