### PR TITLE
Don't fail include_directories if the dir is only in the build path

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2369,7 +2369,10 @@ class Interpreter(InterpreterBase):
     @stringArgs
     def func_include_directories(self, node, args, kwargs):
         src_root = self.environment.get_source_dir()
-        absbase = os.path.join(src_root, self.subdir)
+        build_root = self.environment.get_build_dir()
+        absbase_src = os.path.join(src_root, self.subdir)
+        absbase_build = os.path.join(build_root, self.subdir)
+
         for a in args:
             if a.startswith(src_root):
                 raise InvalidArguments('''Tried to form an absolute path to a source dir. You should not do that but use
@@ -2389,8 +2392,9 @@ put in the include directories by default so you only need to do
 include_directories('.') if you intend to use the result in a
 different subdirectory.
 ''')
-            absdir = os.path.join(absbase, a)
-            if not os.path.isdir(absdir):
+            absdir_src = os.path.join(absbase_src, a)
+            absdir_build = os.path.join(absbase_build, a)
+            if not os.path.isdir(absdir_src) and not os.path.isdir(absdir_build):
                 raise InvalidArguments('Include dir %s does not exist.' % a)
         is_system = kwargs.get('is_system', False)
         if not isinstance(is_system, bool):


### PR DESCRIPTION
The docs say that `include_directories` includes both the path in source and build root. Consequently, if the include path doesn't exist in the source path but in the build path, we should still allow `include_directories` to work.

I am generating code in a new dir in the build directory and want to include that. The auto-generated directory doesn't exist in the source path, so currently calling `include_directories` fails.

This patch makes `include_directories` only fail if we couldn't find the to-be-included directory in path the build and source paths.

Cheers,
    Matthias