### PR TITLE
d: Fix linking shared libraries with DMD

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -435,7 +435,7 @@ class Backend:
         for d in deps:
             if not isinstance(d, (build.StaticLibrary, build.SharedLibrary)):
                 raise RuntimeError('Tried to link with a non-library target "%s".' % d.get_basename())
-            if isinstance(compiler, compilers.LLVMDCompiler):
+            if isinstance(compiler, compilers.LLVMDCompiler) or isinstance(compiler, compilers.DmdDCompiler):
                 args += ['-L' + self.get_target_filename_for_linking(d)]
             else:
                 args.append(self.get_target_filename_for_linking(d))

--- a/test cases/d/7 multilib/app.d
+++ b/test cases/d/7 multilib/app.d
@@ -1,0 +1,9 @@
+
+import say1;
+import say2;
+
+void main ()
+{
+    assert (sayHello1 ("Dave") == 4);
+    assert (sayHello2 ("HAL 9000") == 8);
+}

--- a/test cases/d/7 multilib/installed_files.txt
+++ b/test cases/d/7 multilib/installed_files.txt
@@ -1,0 +1,7 @@
+usr/bin/app_d?exe
+usr/lib/libsay1.so
+usr/lib/libsay1.so.0
+usr/lib/libsay1.so.1.2.3
+usr/lib/libsay2.so
+usr/lib/libsay2.so.1
+usr/lib/libsay2.so.1.2.4

--- a/test cases/d/7 multilib/meson.build
+++ b/test cases/d/7 multilib/meson.build
@@ -1,0 +1,21 @@
+project('D Multiple Versioned Shared Libraries', 'd')
+
+if meson.get_compiler('d').get_id() == 'gcc'
+  error('MESON_SKIP_TEST: GDC can not build shared libraries (2016)')
+endif
+
+ldyn1 = shared_library('say1',
+    'say1.d',
+    install: true,
+    version : '1.2.3',
+    soversion : '0'
+)
+ldyn2 = shared_library('say2',
+    'say2.d',
+    install: true,
+    version : '1.2.4',
+    soversion : '1'
+)
+
+ed = executable('app_d', 'app.d', link_with: [ldyn1, ldyn2], install: true)
+test('multilink_test', ed)

--- a/test cases/d/7 multilib/say1.d
+++ b/test cases/d/7 multilib/say1.d
@@ -1,0 +1,9 @@
+
+import std.stdio;
+import std.string : format;
+
+int sayHello1 (string str)
+{
+    writeln ("Hello %s from library 1.".format (str));
+    return 4;
+}

--- a/test cases/d/7 multilib/say2.d
+++ b/test cases/d/7 multilib/say2.d
@@ -1,0 +1,9 @@
+
+import std.stdio;
+import std.string : format;
+
+int sayHello2 (string str)
+{
+    writeln ("Hello %s from library 2.".format (str));
+    return 8;
+}


### PR DESCRIPTION
Pretty self explanatory.
We deal with DMD the same way we deal with the LDC compiler and translate the target flags so that the compiler passes them to the linker.

Fixes issues where people couldn't compile projects with multiple libraries with DMD.