### PR TITLE
added len() and is_empty() for interpreter String type

### DIFF
--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -491,6 +491,10 @@ class InterpreterBase:
             if not isinstance(cmpr, str):
                 raise InterpreterException('Version_compare() argument must be a string.')
             return mesonlib.version_compare(obj, cmpr)
+        elif method_name == 'len':
+            return len(obj)
+        elif method_name == 'is_empty':
+            return not (obj and obj.strip())
         raise InterpreterException('Unknown method "%s" for a string.' % method_name)
 
     def unknown_function_called(self, func_name):

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -491,7 +491,7 @@ class InterpreterBase:
             if not isinstance(cmpr, str):
                 raise InterpreterException('Version_compare() argument must be a string.')
             return mesonlib.version_compare(obj, cmpr)
-        elif method_name == 'len':
+        elif method_name == 'length':
             return len(obj)
         elif method_name == 'is_empty':
             return not (obj and obj.strip())

--- a/test cases/common/42 string operations/meson.build
+++ b/test cases/common/42 string operations/meson.build
@@ -67,3 +67,18 @@ assert(not version_number.version_compare('!=1.2.8'), 'Version_compare neq broke
 
 assert(version_number.version_compare('<2.0'), 'Version_compare major less broken')
 assert(version_number.version_compare('>0.9'), 'Version_compare major greater broken')
+
+empty = ''
+empty_whitespace = ' \n'
+not_empty = 'abc'
+not_empty_whitespace = 'a b c \n'
+
+assert(empty.len() == 0, 'len broken')
+assert(empty_whitespace.len() == 2, 'len broken')
+assert(not_empty.len() == 3, 'len broken')
+assert(not_empty_whitespace.len() == 7, 'len broken')
+
+assert(empty.is_empty() == true, 'is_empty broken')
+assert(empty_whitespace.is_empty() == true, 'is_empty broken')
+assert(not_empty.is_empty() == false, 'is_empty broken')
+assert(not_empty_whitespace.is_empty() == false, 'is_empty broken')

--- a/test cases/common/42 string operations/meson.build
+++ b/test cases/common/42 string operations/meson.build
@@ -73,10 +73,10 @@ empty_whitespace = ' \n'
 not_empty = 'abc'
 not_empty_whitespace = 'a b c \n'
 
-assert(empty.len() == 0, 'len broken')
-assert(empty_whitespace.len() == 2, 'len broken')
-assert(not_empty.len() == 3, 'len broken')
-assert(not_empty_whitespace.len() == 7, 'len broken')
+assert(empty.length() == 0, 'length broken')
+assert(empty_whitespace.length() == 2, 'length broken')
+assert(not_empty.length() == 3, 'length broken')
+assert(not_empty_whitespace.length() == 7, 'length broken')
 
 assert(empty.is_empty() == true, 'is_empty broken')
 assert(empty_whitespace.is_empty() == true, 'is_empty broken')


### PR DESCRIPTION
I added the following functions to the interpreter String type:

**length()**
Returns the length of the string.

**is_empty()**
Determines if the string is empty by checking if it has zero length or is composed entirely of whitespace.

I've also included tests by amending **test cases/common/42 string operations**