### PR TITLE
Add a testcase for linking C and C++ static archives into a shared li…

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2313,9 +2313,11 @@ class Interpreter(InterpreterBase):
                 raise InterpreterException('Input must be a string or a file')
             if isinstance(inputfile, str):
                 inputfile = os.path.join(self.subdir, inputfile)
+                ifile_abs = os.path.join(self.environment.source_dir, inputfile)
             else:
+                ifile_abs = inputfile.absolute_path(self.environment.source_dir,
+                                                    self.environment.build_dir)
                 inputfile = inputfile.relative_name()
-            ifile_abs = os.path.join(self.environment.source_dir, inputfile)
         elif 'command' in kwargs and '@INPUT@' in kwargs['command']:
             raise InterpreterException('@INPUT@ used as command argument, but no input file specified.')
         # Validate output

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -982,14 +982,7 @@ class CompilerHolder(InterpreterObject):
         if required and not linkargs:
             l = self.compiler.language.capitalize()
             raise InterpreterException('{} library {!r} not found'.format(l, libname))
-        # If this is set to None, the library and link arguments are for
-        # a C-like compiler. Otherwise, it's for some other language that has
-        # a find_library implementation. We do this because it's easier than
-        # maintaining a list of languages that can consume C libraries.
-        lang = None
-        if self.compiler.language == 'vala':
-            lang = 'vala'
-        lib = dependencies.ExternalLibrary(libname, linkargs, language=lang)
+        lib = dependencies.ExternalLibrary(libname, linkargs, self.compiler.language)
         return ExternalLibraryHolder(lib)
 
     def has_argument_method(self, args, kwargs):

--- a/test cases/common/146 C and CPP link/foo.c
+++ b/test cases/common/146 C and CPP link/foo.c
@@ -1,0 +1,19 @@
+/* Copyright © 2017 Dylan Baker
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "foo.h"
+
+int forty_two(void) {
+    return 42;
+}

--- a/test cases/common/146 C and CPP link/foo.cpp
+++ b/test cases/common/146 C and CPP link/foo.cpp
@@ -1,0 +1,24 @@
+/* Copyright © 2017 Dylan Baker
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <vector>
+#include <boost/assign/list_of.hpp>
+
+namespace {
+    std::vector<int> numbers = boost::assign::list_of(61);
+}
+
+extern "C" int six_one(void) {
+    return numbers[1];
+}

--- a/test cases/common/146 C and CPP link/foo.cpp
+++ b/test cases/common/146 C and CPP link/foo.cpp
@@ -13,10 +13,17 @@
  * limitations under the License.
  */
 #include <vector>
-#include <boost/assign/list_of.hpp>
+
+const int cnums[] = {0, 61};
+
+template<typename T, int N>
+std::vector<T> makeVector(const T (&data)[N])
+{
+    return std::vector<T>(data, data+N);
+}
 
 namespace {
-    std::vector<int> numbers = boost::assign::list_of(61);
+    std::vector<int> numbers = makeVector(cnums);
 }
 
 extern "C" int six_one(void) {

--- a/test cases/common/146 C and CPP link/foo.h
+++ b/test cases/common/146 C and CPP link/foo.h
@@ -1,0 +1,16 @@
+/* Copyright © 2017 Dylan Baker
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+int forty_two(void);

--- a/test cases/common/146 C and CPP link/foo.hpp
+++ b/test cases/common/146 C and CPP link/foo.hpp
@@ -1,0 +1,24 @@
+/* Copyright © 2017 Dylan Baker
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int six_one(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test cases/common/146 C and CPP link/foobar.c
+++ b/test cases/common/146 C and CPP link/foobar.c
@@ -1,0 +1,23 @@
+/* Copyright © 2017 Dylan Baker
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "foo.h"
+#include "foo.hpp"
+#include "foobar.h"
+
+void mynumbers(int nums[]) {
+    nums[0] = forty_two();
+    nums[1] = six_one();
+}

--- a/test cases/common/146 C and CPP link/foobar.h
+++ b/test cases/common/146 C and CPP link/foobar.h
@@ -1,0 +1,16 @@
+/* Copyright © 2017 Dylan Baker
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+void mynumbers(int nums[]);

--- a/test cases/common/146 C and CPP link/meson.build
+++ b/test cases/common/146 C and CPP link/meson.build
@@ -1,0 +1,28 @@
+# Copyright © 2017 Dylan Baker
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project('C and C++ static link test', ['c', 'cpp'],
+        default_options : ['cpp_std=c++03'])
+
+dep_boost = dependency('boost')
+
+libcppfoo = static_library('cppfoo', ['foo.cpp', 'foo.hpp'],
+                           dependencies : dep_boost)
+libcfoo = static_library('cfoo', ['foo.c', 'foo.h'])
+
+libfoo = shared_library(
+  'foo',
+  ['foobar.c', 'foobar.h'],
+  link_with : [libcfoo, libcppfoo],
+)

--- a/test cases/common/146 C and CPP link/meson.build
+++ b/test cases/common/146 C and CPP link/meson.build
@@ -14,11 +14,45 @@
 
 project('C and C++ static link test', ['c', 'cpp'])
 
-libcppfoo = static_library('cppfoo', ['foo.cpp', 'foo.hpp'])
-libcfoo = static_library('cfoo', ['foo.c', 'foo.h'])
+libc = static_library('cfoo', ['foo.c', 'foo.h'])
+
+# Test that linking C libs to external static C++ libs uses the C++ linker
+# Since we can't depend on the test system to provide this, we create one
+# ourselves at configure time and then 'find' it with cxx.find_library().
+cxx = meson.get_compiler('cpp')
+
+if cxx.get_id() == 'msvc'
+  compile_cmd = ['/c', '@INPUT@', '/Fo@OUTPUT@']
+  stlib_cmd = ['lib', '/OUT:@OUTPUT@', '@INPUT@']
+else
+  compile_cmd = ['-c', '-fPIC', '@INPUT@', '-o', '@OUTPUT@']
+  stlib_cmd = ['ar', 'csr', '@OUTPUT@', '@INPUT@']
+endif
+
+foo_cpp_o = configure_file(
+  input : 'foo.cpp',
+  output : 'foo.cpp.o',
+  command : cxx.cmd_array() + compile_cmd)
+
+configure_file(
+  input : foo_cpp_o,
+  output : 'libstcppext.a',
+  command : stlib_cmd)
+
+libstcppext = cxx.find_library('stcppext', dirs : meson.current_build_dir())
+
+libfooext = shared_library(
+  'fooext',
+  ['foobar.c', 'foobar.h'],
+  link_with : libc,
+  dependencies : libstcppext,
+)
+
+# Test that linking C libs to internal static C++ libs uses the C++ linker
+libcpp = static_library('cppfoo', ['foo.cpp', 'foo.hpp'])
 
 libfoo = shared_library(
   'foo',
   ['foobar.c', 'foobar.h'],
-  link_with : [libcfoo, libcppfoo],
+  link_with : [libc, libcpp],
 )

--- a/test cases/common/146 C and CPP link/meson.build
+++ b/test cases/common/146 C and CPP link/meson.build
@@ -12,13 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project('C and C++ static link test', ['c', 'cpp'],
-        default_options : ['cpp_std=c++03'])
+project('C and C++ static link test', ['c', 'cpp'])
 
-dep_boost = dependency('boost')
-
-libcppfoo = static_library('cppfoo', ['foo.cpp', 'foo.hpp'],
-                           dependencies : dep_boost)
+libcppfoo = static_library('cppfoo', ['foo.cpp', 'foo.hpp'])
 libcfoo = static_library('cfoo', ['foo.c', 'foo.h'])
 
 libfoo = shared_library(


### PR DESCRIPTION
…brary

This exercises a regression where the C rather than C++ linker is
chosen, resulting in symbol errors.

Test for #1653 

This test fails against master, but passes against 0.39.1