### PR TITLE
Improve CI integration with development versions of Meson

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -26,6 +26,7 @@ from ..build import BuildTarget
 from ..compilers import CompilerArgs
 from ..mesonlib import MesonException, File, get_meson_script
 from ..environment import Environment
+from ..coredata import private_dir as meson_private_dir
 
 def autodetect_vs_version(build):
     vs_version = os.getenv('VisualStudioVersion', None)
@@ -190,7 +191,7 @@ class Vs2010Backend(backends.Backend):
 
     @staticmethod
     def get_regen_stampfile(build_dir):
-        return os.path.join(os.path.join(build_dir, Environment.private_dir), 'regen.stamp')
+        return os.path.join(os.path.join(build_dir, meson_private_dir), 'regen.stamp')
 
     @staticmethod
     def touch_regen_timestamp(build_dir):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -232,18 +232,14 @@ def search_version(text):
     return 'unknown version'
 
 class Environment:
-    private_dir = 'meson-private'
-    log_dir = 'meson-logs'
-    coredata_file = os.path.join(private_dir, 'coredata.dat')
+    coredata_file = os.path.join(coredata.private_dir, 'coredata.dat')
 
     def __init__(self, source_dir, build_dir, main_script_launcher, options, original_cmd_line_args):
         self.source_dir = source_dir
         self.build_dir = build_dir
         self.meson_script_launcher = main_script_launcher
-        self.scratch_dir = os.path.join(build_dir, Environment.private_dir)
-        self.log_dir = os.path.join(build_dir, Environment.log_dir)
-        os.makedirs(self.scratch_dir, exist_ok=True)
-        os.makedirs(self.log_dir, exist_ok=True)
+        self.scratch_dir = os.path.join(build_dir, coredata.private_dir)
+        self.log_dir = os.path.join(build_dir, coredata.log_dir)
         try:
             cdf = os.path.join(self.get_build_dir(), Environment.coredata_file)
             self.coredata = coredata.load(cdf)
@@ -261,6 +257,9 @@ class Environment:
             self.cross_info = None
         self.cmd_line_options = options
         self.original_cmd_line_args = original_cmd_line_args
+        # Create private dir and log dir if needed
+        os.makedirs(self.scratch_dir, exist_ok=True)
+        os.makedirs(self.log_dir, exist_ok=True)
 
         # List of potential compilers.
         if mesonlib.is_windows():


### PR DESCRIPTION
Now, you can set `MESON_CI_MODE` in the environment to tell Meson to automatically wipe the builddir on version mismatch and reconfigure from scratch.

Also specify that the Meson development version should be incremented when the format of any serialized data changes, such as new class variables in the Coredata class, Dependency classes, meson script pickled data, etc.

This is very useful for projects that want to continuously build their project against Meson git master. Without this, they would need to manually wipe the builddir whenever Meson changed serialized data formats or when we made a new release that changed the version.

Will rebase this PR when we go back to development.