### PR TITLE
Always pass cross-file {lang}_args to compiler checks

### DIFF
--- a/cross/ubuntu-armhf.txt
+++ b/cross/ubuntu-armhf.txt
@@ -9,6 +9,9 @@ pkgconfig = '/usr/bin/arm-linux-gnueabihf-pkg-config'
 
 [properties]
 root = '/usr/arm-linux-gnueabihf'
+# Used in unit test '140 get define'
+c_args = ['-DMESON_TEST_ISSUE_1665=1']
+cpp_args = ['-DMESON_TEST_ISSUE_1665=1']
 
 has_function_printf = true
 has_function_hfkerhisadf = false

--- a/test cases/common/140 get define/meson.build
+++ b/test cases/common/140 get define/meson.build
@@ -28,4 +28,23 @@ foreach lang : ['c', 'cpp']
   have = cc.get_define('MESON_TEST_DEFINE_VALUE')
   expect = get_option('MESON_TEST_DEFINE_VALUE')
   assert(have == expect, 'MESON_TEST_DEFINE_VALUE value is "@0@" instead of "@1@"'.format(have, expect))
+
+  run_1665_test = false
+  if meson.is_cross_build()
+    # Can't use an empty array as a fallback here because of
+    # https://github.com/mesonbuild/meson/issues/1481
+    lang_args = meson.get_cross_property(lang + '_args', false)
+    if lang_args != false
+      foreach lang_arg : lang_args
+        if lang_arg.contains('MESON_TEST_ISSUE_1665')
+          run_1665_test = true
+        endif
+      endforeach
+    endif
+  endif
+
+  if run_1665_test
+    have = cc.get_define('MESON_TEST_ISSUE_1665')
+    assert(have == '1', 'MESON_TEST_ISSUE_1665 value is "@0@" instead of "1"'.format(have))
+  endif
 endforeach


### PR DESCRIPTION
Includes a test for this that will only run on the CI.

Closes https://github.com/mesonbuild/meson/issues/1665