### PR TITLE
Don't use dict.keys() to check membership

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -819,7 +819,7 @@ def get_args_from_envvars(compiler):
     if hasattr(compiler, 'get_linker_exelist'):
         compiler_is_linker = (compiler.get_exelist() == compiler.get_linker_exelist())
 
-    if lang not in cflags_mapping.keys():
+    if lang not in cflags_mapping:
         return [], [], []
 
     compile_flags = os.environ.get(cflags_mapping[lang], '')

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -371,7 +371,7 @@ def do_replacement(regex, line, confdata):
     match = re.search(regex, line)
     while match:
         varname = match.group(1)
-        if varname in confdata.keys():
+        if varname in confdata:
             (var, desc) = confdata.get(varname)
             if isinstance(var, str):
                 pass


### PR DESCRIPTION
It's much faster to do 'if a in dict' instead of 'if a in dict.keys()',
since the latter constructs an iterator and walks that iterator and then
tests equality at each step, and the former does a single hash lookup.