### PR TITLE
Create a dist target

### DIFF
--- a/docs/markdown/Creating-releases.md
+++ b/docs/markdown/Creating-releases.md
@@ -1,0 +1,15 @@
+---
+short-description: Creating releases
+...
+
+# Creating releases
+
+In addition to development, almost all projects provide periodical source releases. These are standalone packages (usually either in tar or zip format) of the source code. They do not contain any revision control metadata, only the source code.
+
+Meson provides a simple way of generating these. It consists of a single command:
+
+    ninja dist
+
+This creates a file called `projectname-version.tar.xz` in the build tree subdirectory `meson-dist`. This archive contains the full contents of the latest commit in revision control including all the submodules. All revision control metadata is removed. Meson then takes this archive and tests that it works by doing a full compile + test + install cycle. If all these pass, Meson will then create a SHA-256 checksum file next to the archive.
+
+**Note**: Meson behaviour is different from Autotools. The Autotools "dist" target packages up the current source tree. Meson packages the latest revision control commit. The reason for this is that it prevents developers from doing accidental releases where the distributed archive does not match any commit in revision control (especially the one tagged for the release).

--- a/docs/markdown/Release-notes-for-0.41.0.md
+++ b/docs/markdown/Release-notes-for-0.41.0.md
@@ -38,3 +38,18 @@ pkg.generate(libraries : libs,
              description : 'A simple demo library.',
              variables : ['datadir=${prefix}/data'])
 ```
+
+## A target for creating tarballs
+
+Creating distribution tarballs is simple:
+
+    ninja dist
+
+This will create a `.tar.xz` archive of the source code including
+submodules without any revision control information. This command also
+verifies that the resulting archive can be built, tested and
+installed. This is roughly equivalent to the `distcheck` target in
+other build systems. Currently this only works for projects using Git
+and only with the Ninja backend.
+
+

--- a/docs/sitemap.txt
+++ b/docs/sitemap.txt
@@ -42,6 +42,7 @@ index.md
 		Build-system-converters.md
 		Configuring-a-build-directory.md
 		Run-targets.md
+		Creating-releases.md
 		Creating-OSX-packages.md
 		Creating-Linux-binaries.md
 	Reference-manual.md

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2379,8 +2379,13 @@ rule FORTRAN_DEP_HACK
     def generate_dist(self, outfile):
         elem = NinjaBuildElement(self.all_outputs, 'dist', 'CUSTOM_COMMAND', 'PHONY')
         elem.add_item('DESC', 'Creating source packages')
-        elem.add_item('COMMAND', [sys.executable, self.environment.get_build_command(), '--internal', 'dist',
-                                  self.environment.source_dir, self.environment.build_dir])
+        elem.add_item('COMMAND', [sys.executable,
+                                  self.environment.get_build_command(),
+                                  '--internal', 'dist',
+                                  self.environment.source_dir,
+                                  self.environment.build_dir,
+                                  sys.executable,
+                                  self.environment.get_build_command()])
         elem.add_item('pool', 'console')
         elem.write(outfile)
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -195,6 +195,7 @@ int dummy;
             self.generate_tests(outfile)
             outfile.write('# Install rules\n\n')
             self.generate_install(outfile)
+            self.generate_dist(outfile)
             if 'b_coverage' in self.environment.coredata.base_options and \
                     self.environment.coredata.base_options['b_coverage'].value:
                 outfile.write('# Coverage rules\n\n')
@@ -2374,6 +2375,14 @@ rule FORTRAN_DEP_HACK
         # to ensure reproducible output. The order we pass them shouldn't
         # affect behavior in any other way.
         return sorted(cmds)
+
+    def generate_dist(self, outfile):
+        elem = NinjaBuildElement(self.all_outputs, 'dist', 'CUSTOM_COMMAND', 'PHONY')
+        elem.add_item('DESC', 'Creating source packages')
+        elem.add_item('COMMAND', [sys.executable, self.environment.get_build_command(), '--internal', 'dist',
+                                  self.environment.source_dir, self.environment.build_dir])
+        elem.add_item('pool', 'console')
+        elem.write(outfile)
 
     # For things like scan-build and other helper tools we might have.
     def generate_utils(self, outfile):

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -347,4 +347,6 @@ forbidden_target_names = {'clean': None,
                           'build.ninja': None,
                           'scan-build': None,
                           'reconfigure': None,
+                          'dist': None,
+                          'distcheck': None,
                           }

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -246,6 +246,9 @@ def run_script_command(args):
     elif cmdname == 'uninstall':
         import mesonbuild.scripts.uninstall as abc
         cmdfunc = abc.run
+    elif cmdname == 'dist':
+        import mesonbuild.scripts.dist as abc
+        cmdfunc = abc.run
     else:
         raise MesonException('Unknown internal command {}.'.format(cmdname))
     return cmdfunc(cmdargs)

--- a/mesonbuild/scripts/dist.py
+++ b/mesonbuild/scripts/dist.py
@@ -98,7 +98,7 @@ def check_dist(packagename, meson_command):
         tf = tarfile.open(packagename)
         tf.extractall(unpackdir)
         srcdir = glob(os.path.join(unpackdir, '*'))[0]
-        if subprocess.call(meson_command + [srcdir, builddir]) != 0:
+        if subprocess.call(meson_command + ['--backend=ninja', srcdir, builddir]) != 0:
             print('Running Meson on distribution package failed')
             return 1
         if subprocess.call([ninja_bin], cwd=builddir) != 0:

--- a/mesonbuild/scripts/dist.py
+++ b/mesonbuild/scripts/dist.py
@@ -1,0 +1,85 @@
+# Copyright 2017 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import shutil
+import argparse
+import subprocess
+import pickle
+import hashlib
+import tarfile, zipfile
+from glob import glob
+
+def create_hash(fname):
+    hashname = fname + '.sha256sum'
+    m = hashlib.sha256()
+    m.update(open(fname, 'rb').read())
+    with open(hashname, 'w') as f:
+        f.write('%s %s\n' % (m.hexdigest(), os.path.split(fname)[-1]))
+
+def create_zip(zipfilename, packaging_dir):
+    prefix = os.path.split(packaging_dir)[0]
+    removelen = len(prefix)+1
+    zf = zipfile.ZipFile(zipfilename, 'w', compression=zipfile.ZIP_DEFLATED,
+                         allowZip64=True)
+    zf.write(packaging_dir, packaging_dir[removelen:])
+    for root, dirs, files in os.walk(packaging_dir):
+        for d in dirs:
+            dname = os.path.join(root, d)
+            zf.write(dname, dname[removelen:])
+        for f in files:
+            fname = os.path.join(root, f)
+            zf.write(fname, fname[removelen:])
+    zf.close()
+
+def create_dist(dist_name, src_root, bld_root, dist_sub):
+    distdir = os.path.join(dist_sub, dist_name)
+    gitdir = os.path.join(src_root, '.git')
+    if os.path.exists(distdir):
+        shutil.rmtree(distdir)
+    os.makedirs(distdir)
+    dest_gitdir = os.path.join(distdir, '.git')
+    shutil.copytree(gitdir, dest_gitdir)
+    subprocess.check_call(['git', 'reset', '--hard'], cwd=distdir)
+    shutil.rmtree(dest_gitdir)
+    for f in glob(os.path.join(distdir, '.git*')):
+        os.unlink(f)
+    xzname = distdir + '.tar.xz'
+    zipname = distdir + '.zip'
+    tf = tarfile.open(xzname, 'w:xz')
+    tf.add(distdir, os.path.split(distdir)[1])
+    tf.close()
+    create_hash(xzname)
+    create_zip(zipname, distdir)
+    create_hash(zipname)
+
+def run(args):
+    src_root = args[0]
+    bld_root = args[1]
+    priv_dir = os.path.join(bld_root, 'meson-private')
+    dist_sub = os.path.join(bld_root, 'meson-dist')
+
+    buildfile = os.path.join(priv_dir, 'build.dat')
+
+    build = pickle.load(open(buildfile, 'rb'))
+    
+    dist_name = build.project_name + '-' + build.project_version
+
+    if not os.path.isdir(os.path.join(src_root, '.git')):
+        print('Dist currently only works with Git repos.')
+        return 1
+    create_dist(dist_name, src_root, bld_root, dist_sub)
+
+    return 0

--- a/mesonbuild/scripts/dist.py
+++ b/mesonbuild/scripts/dist.py
@@ -13,14 +13,16 @@
 # limitations under the License.
 
 
-import os
+import os, sys
 import shutil
 import argparse
 import subprocess
 import pickle
 import hashlib
 import tarfile, zipfile
+import tempfile
 from glob import glob
+from mesonbuild.environment import detect_ninja
 
 def create_hash(fname):
     hashname = fname + '.sha256sum'
@@ -31,18 +33,19 @@ def create_hash(fname):
 
 def create_zip(zipfilename, packaging_dir):
     prefix = os.path.split(packaging_dir)[0]
-    removelen = len(prefix)+1
-    zf = zipfile.ZipFile(zipfilename, 'w', compression=zipfile.ZIP_DEFLATED,
-                         allowZip64=True)
-    zf.write(packaging_dir, packaging_dir[removelen:])
-    for root, dirs, files in os.walk(packaging_dir):
-        for d in dirs:
-            dname = os.path.join(root, d)
-            zf.write(dname, dname[removelen:])
-        for f in files:
-            fname = os.path.join(root, f)
-            zf.write(fname, fname[removelen:])
-    zf.close()
+    removelen = len(prefix) + 1
+    with zipfile.ZipFile(zipfilename,
+                         'w',
+                         compression=zipfile.ZIP_DEFLATED,
+                         allowZip64=True) as zf:
+        zf.write(packaging_dir, packaging_dir[removelen:])
+        for root, dirs, files in os.walk(packaging_dir):
+            for d in dirs:
+                dname = os.path.join(root, d)
+                zf.write(dname, dname[removelen:])
+            for f in files:
+                fname = os.path.join(root, f)
+                zf.write(fname, fname[removelen:])
 
 def create_dist(dist_name, src_root, bld_root, dist_sub):
     distdir = os.path.join(dist_sub, dist_name)
@@ -58,28 +61,66 @@ def create_dist(dist_name, src_root, bld_root, dist_sub):
         os.unlink(f)
     xzname = distdir + '.tar.xz'
     zipname = distdir + '.zip'
-    tf = tarfile.open(xzname, 'w:xz')
-    tf.add(distdir, os.path.split(distdir)[1])
-    tf.close()
-    create_hash(xzname)
+    # Should use shutil but it got xz support only in 3.5.
+    with tarfile.open(xzname, 'w:xz') as tf:
+        tf.add(distdir, os.path.split(distdir)[1])
     create_zip(zipname, distdir)
-    create_hash(zipname)
+    shutil.rmtree(distdir)
+    return (xzname, zipname)
+
+def check_dist(packagename, meson_command):
+    print('Testing distribution package %s.' % packagename)
+    unpackdir = tempfile.mkdtemp()
+    builddir = tempfile.mkdtemp()
+    installdir = tempfile.mkdtemp()
+    ninja_bin = detect_ninja()
+    try:
+        tf = tarfile.open(packagename)
+        tf.extractall(unpackdir)
+        srcdir = glob(os.path.join(unpackdir, '*'))[0]
+        if subprocess.call(meson_command + [srcdir, builddir]) != 0:
+            print('Running Meson on distribution package failed')
+            return 1
+        if subprocess.call([ninja_bin], cwd=builddir) != 0:
+            print('Compiling the distribution package failed.')
+            return 1
+        if subprocess.call([ninja_bin, 'test'], cwd=builddir) != 0:
+            print('Running unit tests on the distribution package failed.')
+            return 1
+        myenv = os.environ.copy()
+        myenv['DESTDIR'] = installdir
+        if subprocess.call([ninja_bin, 'install'], cwd=builddir, env=myenv) != 0:
+            print('Installing the distribution package failed.')
+            return 1
+    finally:
+        shutil.rmtree(srcdir)
+        shutil.rmtree(builddir)
+        shutil.rmtree(installdir)
+    print('Distribution package %s tested.' % packagename)
+    return 0
 
 def run(args):
     src_root = args[0]
     bld_root = args[1]
+    meson_command = args[2:]
     priv_dir = os.path.join(bld_root, 'meson-private')
     dist_sub = os.path.join(bld_root, 'meson-dist')
 
     buildfile = os.path.join(priv_dir, 'build.dat')
 
     build = pickle.load(open(buildfile, 'rb'))
-    
+
     dist_name = build.project_name + '-' + build.project_version
 
     if not os.path.isdir(os.path.join(src_root, '.git')):
         print('Dist currently only works with Git repos.')
         return 1
-    create_dist(dist_name, src_root, bld_root, dist_sub)
-
-    return 0
+    names = create_dist(dist_name, src_root, bld_root, dist_sub)
+    if names is None:
+        return 1
+    rc = check_dist(names[0], meson_command) # Check only one.
+    if rc == 0:
+        # Only create the hash if the build is successfull.
+        for n in names:
+            create_hash(n)
+    return rc


### PR DESCRIPTION
Does not have tests yet or anything else that is fancy.

Rather than think about all things that this should do, let's instead see what we can achieve without any configuration at all. Probably will need some for handling of subprojects.

A simple no-config way to do that would be to ignore those that have wrap files and embed those that do not (such as git submodules).