### PR TITLE
Detect intel fortran compiler

### DIFF
--- a/authors.txt
+++ b/authors.txt
@@ -81,3 +81,4 @@ Wade Berrier
 Richard Hughes
 Rafael Fontenelle
 Michael Olbrich
+Thomas Hindoe Paaboel Andersen

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -271,7 +271,7 @@ class Environment:
             self.default_cpp = ['c++']
         self.default_objc = ['cc']
         self.default_objcpp = ['c++']
-        self.default_fortran = ['gfortran', 'g95', 'f95', 'f90', 'f77']
+        self.default_fortran = ['gfortran', 'g95', 'f95', 'f90', 'f77', 'ifort']
         self.default_static_linker = ['ar']
         self.vs_static_linker = ['lib']
         self.gcc_static_linker = ['gcc-ar']


### PR DESCRIPTION
The intel fortran compiler "ifort" was not listed in the list of
default fortran compilers. This caused it to not be found unless
explicitly set via the FC.