### PR TITLE
mesonlib: replace OrderedSet implementation

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -687,17 +687,89 @@ def get_filenames_templates_dict(inputs, outputs):
             values['@OUTDIR@'] = '.'
     return values
 
-class OrderedSet(collections.OrderedDict):
+
+class OrderedSet(collections.MutableSet):
     '''
     A 'set' equivalent that preserves the order in which items are added.
 
-    This is a hack implementation that wraps OrderedDict. It may not be the
-    most efficient solution and might need fixing to override more methods.
+    Recipe from http://code.activestate.com/recipes/576694/, modified to
+    allow pickling.
     '''
     def __init__(self, iterable=None):
-        if iterable:
-            self.update(iterable)
+        self.end = end = []
+        end += [None, end, end]         # sentinel node for doubly linked list
+        self.map = {}                   # key --> [key, prev, next]
+        if iterable is not None:
+            self |= iterable
+
+    def __len__(self):
+        return len(self.map)
+
+    def __contains__(self, key):
+        return key in self.map
+
+    def add(self, key):
+        if key not in self.map:
+            end = self.end
+            curr = end[1]
+            curr[2] = end[1] = self.map[key] = [key, curr, end]
+
+    def __getstate__(self):
+        if len(self) == 0:
+            # The state can't be an empty list.
+            # We need to return a truthy value, or else
+            # __setstate__ won't be run.
+            #
+            # This could have been done more gracefully by always putting
+            # the state in a tuple, but this way is backwards- and forwards-
+            # compatible with previous versions of OrderedSet.
+            return (None,)
+        else:
+            return list(self)
+
+    def __setstate__(self, state):
+        if state == (None,):
+            self.__init__([])
+        else:
+            self.__init__(state)
+
+    def discard(self, key):
+        if key in self.map:
+            key, prev, nxt = self.map.pop(key)
+            prev[2] = nxt
+            nxt[1] = prev
+
+    def __iter__(self):
+        end = self.end
+        curr = end[2]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[2]
+
+    def __reversed__(self):
+        end = self.end
+        curr = end[1]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[1]
+
+    # pylint: disable=arguments-differ
+    def pop(self, last=True):
+        if not self:
+            raise KeyError('set is empty')
+        key = self.end[1][0] if last else self.end[2][0]
+        self.discard(key)
+        return key
+
+    def __repr__(self):
+        if not self:
+            return '%s()' % (self.__class__.__name__,)
+        return '%s(%r)' % (self.__class__.__name__, list(self))
+
+    def __eq__(self, other):
+        if isinstance(other, OrderedSet):
+            return len(self) == len(other) and list(self) == list(other)
+        return set(self) == set(other)
 
     def update(self, iterable):
-        for item in iterable:
-            self[item] = True
+        self |= iterable

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -24,7 +24,7 @@ from pathlib import PurePath
 import mesonbuild.compilers
 import mesonbuild.environment
 import mesonbuild.mesonlib
-from mesonbuild.mesonlib import is_windows, is_osx, is_cygwin
+from mesonbuild.mesonlib import is_windows, is_osx, is_cygwin, OrderedSet
 from mesonbuild.environment import Environment
 from mesonbuild.dependencies import PkgConfigDependency, ExternalProgram
 
@@ -315,6 +315,13 @@ class InternalTests(unittest.TestCase):
         # Many outputs, can't use @OUTPUT@ like this
         cmd = ['@OUTPUT@.out', 'ordinary', 'strings']
         self.assertRaises(ME, substfunc, cmd, d)
+
+    def test_ordered_set(self):
+        oset = OrderedSet()
+        oset.update(['a', 'b', 'c'])
+        self.assertListEqual(['a', 'b', 'c'], list(oset))
+        oset |= ['c', 'd', 'e', 'f']
+        self.assertListEqual(['a', 'b', 'c', 'd', 'e', 'f'], list(oset))
 
 
 class BasePlatformTests(unittest.TestCase):


### PR DESCRIPTION
This is a proposed solution for #1670 , which didn't work with python 3.4. An alternative solution would be to simply chain up the __init__ method, but I think this solution is the most appropriate, as it gives us an API that's actually closer to the set() API, with the ability to use set operators (|=, ...).

Adds a simple unit test that was failing with the previous implementation using python 3.4.