### PR TITLE
pkgconfig: add suppport for custom variables during generation

### DIFF
--- a/docs/markdown/Pkgconfig-module.md
+++ b/docs/markdown/Pkgconfig-module.md
@@ -20,3 +20,4 @@ The generated file's properties are specified with the following keyword argumen
 - `requires_private` list of strings to put in the `Requires.private` field
 - `libraries_private` list of strings to put in the `Libraries.private` field
 - `install_dir` the directory to install to, defaults to the value of option `libdir` followed by `/pkgconfig`
+- `variables` a list of strings with custom variables to add to the generated file. The strings must be in the form `name=value` and may reference other pkgconfig variables, e.g. `datadir=${prefix}/share`. The names `prefix`, `libdir` and `installdir` are reserved and may not be used.

--- a/docs/markdown/Release-notes-for-0.41.0.md
+++ b/docs/markdown/Release-notes-for-0.41.0.md
@@ -24,3 +24,17 @@ The ninja backend now quotes special characters that may be interpreted by
 ninja itself, providing better interoperability with custom commands. This
 support may not be perfect; please report any issues found with special
 characters to the issue tracker.
+
+## Pkgconfig support for custom variables
+
+The Pkgconfig module object can add arbitrary variables to the generated .pc
+file with the new `variables` keyword:
+```meson
+pkg.generate(libraries : libs,
+             subdirs : h,
+             version : '1.0',
+             name : 'libsimple',
+             filebase : 'simple',
+             description : 'A simple demo library.',
+             variables : ['datadir=${prefix}/data'])
+```

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1174,6 +1174,8 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertTrue(simple_dep.found())
         self.assertEqual(simple_dep.get_version(), '1.0')
         self.assertIn('-lfoo', simple_dep.get_link_args())
+        self.assertEqual(simple_dep.get_pkgconfig_variable('foo'), 'bar')
+        self.assertPathEqual(simple_dep.get_pkgconfig_variable('datadir'), '/usr/data')
 
     def test_vala_c_warnings(self):
         '''

--- a/test cases/common/51 pkgconfig-gen/meson.build
+++ b/test cases/common/51 pkgconfig-gen/meson.build
@@ -41,4 +41,6 @@ pkgg.generate(
   libraries : lib2,
   name : 'libfoo',
   version : libver,
-  description : 'A foo library.')
+  description : 'A foo library.',
+  variables : ['foo=bar', 'datadir=${prefix}/data']
+)

--- a/test cases/failing/47 pkgconfig variables reserved/meson.build
+++ b/test cases/failing/47 pkgconfig variables reserved/meson.build
@@ -1,0 +1,16 @@
+project('variables-reserved-test', 'c', version : '1.0')
+
+pkgg = import('pkgconfig')
+lib = shared_library('simple', 'simple.c')
+libver = '1.0'
+h = install_headers('simple.h')
+
+pkgg.generate(
+  libraries : [lib, '-lz'],
+  subdirs : '.',
+  version : libver,
+  name : 'libsimple',
+  filebase : 'simple',
+  description : 'A simple demo library.',
+  variables : [ 'prefix=/tmp/' ]
+)

--- a/test cases/failing/47 pkgconfig variables reserved/simple.c
+++ b/test cases/failing/47 pkgconfig variables reserved/simple.c
@@ -1,0 +1,5 @@
+#include"simple.h"
+
+int simple_function() {
+    return 42;
+}

--- a/test cases/failing/47 pkgconfig variables reserved/simple.h
+++ b/test cases/failing/47 pkgconfig variables reserved/simple.h
@@ -1,0 +1,6 @@
+#ifndef SIMPLE_H_
+#define SIMPLE_H_
+
+int simple_function();
+
+#endif

--- a/test cases/failing/48 pkgconfig variables zero length/meson.build
+++ b/test cases/failing/48 pkgconfig variables zero length/meson.build
@@ -1,0 +1,16 @@
+project('variables-zero-length-test', 'c', version : '1.0')
+
+pkgg = import('pkgconfig')
+lib = shared_library('simple', 'simple.c')
+libver = '1.0'
+h = install_headers('simple.h')
+
+pkgg.generate(
+  libraries : [lib, '-lz'],
+  subdirs : '.',
+  version : libver,
+  name : 'libsimple',
+  filebase : 'simple',
+  description : 'A simple demo library.',
+  variables : [ '=value' ]
+)

--- a/test cases/failing/48 pkgconfig variables zero length/simple.c
+++ b/test cases/failing/48 pkgconfig variables zero length/simple.c
@@ -1,0 +1,5 @@
+#include"simple.h"
+
+int simple_function() {
+    return 42;
+}

--- a/test cases/failing/48 pkgconfig variables zero length/simple.h
+++ b/test cases/failing/48 pkgconfig variables zero length/simple.h
@@ -1,0 +1,6 @@
+#ifndef SIMPLE_H_
+#define SIMPLE_H_
+
+int simple_function();
+
+#endif

--- a/test cases/failing/49 pkgconfig variables zero length value/meson.build
+++ b/test cases/failing/49 pkgconfig variables zero length value/meson.build
@@ -1,0 +1,16 @@
+project('variables-zero-length-value-test', 'c', version : '1.0')
+
+pkgg = import('pkgconfig')
+lib = shared_library('simple', 'simple.c')
+libver = '1.0'
+h = install_headers('simple.h')
+
+pkgg.generate(
+  libraries : [lib, '-lz'],
+  subdirs : '.',
+  version : libver,
+  name : 'libsimple',
+  filebase : 'simple',
+  description : 'A simple demo library.',
+  variables : [ 'key=' ]
+)

--- a/test cases/failing/49 pkgconfig variables zero length value/simple.c
+++ b/test cases/failing/49 pkgconfig variables zero length value/simple.c
@@ -1,0 +1,5 @@
+#include"simple.h"
+
+int simple_function() {
+    return 42;
+}

--- a/test cases/failing/49 pkgconfig variables zero length value/simple.h
+++ b/test cases/failing/49 pkgconfig variables zero length value/simple.h
@@ -1,0 +1,6 @@
+#ifndef SIMPLE_H_
+#define SIMPLE_H_
+
+int simple_function();
+
+#endif

--- a/test cases/failing/50 pkgconfig variables not key value/meson.build
+++ b/test cases/failing/50 pkgconfig variables not key value/meson.build
@@ -1,0 +1,16 @@
+project('variables-not-key-value-test', 'c', version : '1.0')
+
+pkgg = import('pkgconfig')
+lib = shared_library('simple', 'simple.c')
+libver = '1.0'
+h = install_headers('simple.h')
+
+pkgg.generate(
+  libraries : [lib, '-lz'],
+  subdirs : '.',
+  version : libver,
+  name : 'libsimple',
+  filebase : 'simple',
+  description : 'A simple demo library.',
+  variables : [ 'this_should_be_key_value' ]
+)

--- a/test cases/failing/50 pkgconfig variables not key value/simple.c
+++ b/test cases/failing/50 pkgconfig variables not key value/simple.c
@@ -1,0 +1,5 @@
+#include"simple.h"
+
+int simple_function() {
+    return 42;
+}

--- a/test cases/failing/50 pkgconfig variables not key value/simple.h
+++ b/test cases/failing/50 pkgconfig variables not key value/simple.h
@@ -1,0 +1,6 @@
+#ifndef SIMPLE_H_
+#define SIMPLE_H_
+
+int simple_function();
+
+#endif


### PR DESCRIPTION
Usage:
```meson
pkgconfig.generate(
  ...
  description : 'A library with custom variables.',
  variables : [ 'foo=bar', 'datadir=${prefix}/data' ]
)
```
The variables 'prefix', 'libdir' and 'includedir' are reserved, meson will
fail with an error message.

Variables can reference each other, e.g.

```meson
  variables : [ 'datadir=${prefix}/data',
                'otherdatadir=${datadir}/other' ]
```
meson does not check this for correctness or that the referenced variable
exists, we merely keep the same order as specified.