### PR TITLE
README: Don't recommend using as a standalone script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img src="http://mesonbuild.com/meson_logo.png">
+<img src="http://mesonbuild.com/assets/images/meson_logo.png">
 </p>
 Meson® is a project to create the best possible next-generation
 build system.

--- a/README.md
+++ b/README.md
@@ -29,21 +29,6 @@ pip will download the package automatically). The exact command to
 type to install with pip can very between systems, be sure to use the
 Python 3 version of pip.
 
-#### Creating a standalone script
-
-Meson can be run as a [Python zip
-app](https://docs.python.org/3/library/zipapp.html). To generate the
-executable run the following command:
-
-    python3 -m zipapp -p '/usr/bin/env python3' -m meson:main -o meson <source checkout>
-
-Note that the source checkout may not be `meson` because it would
-clash with the generated binary name.
-
-This will zip all files inside the source checkout into the script
-which includes hundreds of tests, so you might want to temporarily
-remove those before running it.
-
 #### Running
 
 Meson requires that you have a source directory and a build directory


### PR DESCRIPTION
zipapp only has a single entry point, so only the `meson` command will work. `mesontest`, `mesonconf`, `mesonintrospect` won't, which is terrible, really.

Ideally we should have a single entry point for all these instead, but until that happens, we should not recommend zipapps.

Closes https://github.com/mesonbuild/meson/issues/1684