### PR TITLE
Support additional search paths in find_program

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -260,7 +260,7 @@ This function is deprecated and in the 0.31.0 release it was moved to [the compi
     program find_program(program_name1, program_name2, ...)
 ```
 
-`program_name1` here is a string that can be an executable or script to be searched for in `PATH`, or a script in the current source directory.
+`program_name1` here is a string that can be an executable or script to be searched for in `PATH`, or a script in the current source directory.  Additional search paths can be specified using the 'search_paths' keyword argument.
 
 Meson will also autodetect scripts with a shebang line and run them with the executable/interpreter specified in it both on Windows (because the command invocator will reject the command otherwise) and UNIXes (if the script file does not have the executable bit set). Hence, you *must not* manually add the interpreter while using this script as part of a list of commands.
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1823,11 +1823,24 @@ class Interpreter(InterpreterBase):
         required = kwargs.get('required', True)
         if not isinstance(required, bool):
             raise InvalidArguments('"required" argument must be a boolean.')
+        # Get the additional search paths
+        search_paths = kwargs.get('search_paths', [])
+        if not isinstance(search_paths, list):
+            search_paths = [search_paths]
+        for path in search_paths:
+            if not isinstance(path, str):
+                raise InvalidArguments('"search_paths" argument must contain '
+                                       'a string, or list of strings.')
+        # Add exenames prefixed with search paths
+        prefixed_names = []
+        for exename in args:
+            for path in search_paths:
+                prefixed_names.append(os.path.join(path, exename).replace('\\', '/'))
         # Search for scripts relative to current subdir.
         # Do not cache found programs because find_program('foobar')
         # might give different results when run from different source dirs.
         source_dir = os.path.join(self.environment.get_source_dir(), self.subdir)
-        for exename in args:
+        for exename in [*args, *prefixed_names]:
             if isinstance(exename, mesonlib.File):
                 if exename.is_built:
                     search_dir = os.path.join(self.environment.get_build_dir(),
@@ -1845,18 +1858,6 @@ class Interpreter(InterpreterBase):
             progobj = ExternalProgramHolder(extprog)
             if progobj.found():
                 return progobj
-            # Search additional paths provided in search_paths argument
-            search_paths = kwargs.get('search_paths', [])
-            if not isinstance(search_paths, list):
-                search_paths = [search_paths]
-            for path in search_paths:
-                if not isinstance(path, str):
-                    raise InvalidArguments('"search_paths" argument must contain '
-                                           'a string, or list of strings.')
-                extprog = dependencies.ExternalProgram(exename, search_dir=path)
-                progobj = ExternalProgramHolder(extprog)
-                if progobj.found():
-                    return progobj
         if required and not progobj.found():
             raise InvalidArguments('Program "%s" not found.' % exename)
         return progobj

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1845,6 +1845,18 @@ class Interpreter(InterpreterBase):
             progobj = ExternalProgramHolder(extprog)
             if progobj.found():
                 return progobj
+            # Search additional paths provided in search_paths argument
+            search_paths = kwargs.get('search_paths', [])
+            if not isinstance(search_paths, list):
+                search_paths = [search_paths]
+            for path in search_paths:
+                if not isinstance(path, str):
+                    raise InvalidArguments('"search_paths" argument must contain '
+                                           'a string, or list of strings.')
+                extprog = dependencies.ExternalProgram(exename, search_dir=path)
+                progobj = ExternalProgramHolder(extprog)
+                if progobj.found():
+                    return progobj
         if required and not progobj.found():
             raise InvalidArguments('Program "%s" not found.' % exename)
         return progobj

--- a/test cases/common/105 find program path/meson.build
+++ b/test cases/common/105 find program path/meson.build
@@ -23,3 +23,9 @@ foreach f : [prog, find_program(py), find_program(progf)]
   assert(ret.returncode() == 0, 'can\'t run @0@'.format(prog.path()))
   assert(ret.stdout().strip() == 'Found', 'wrong output from @0@'.format(prog.path()))
 endforeach
+
+# Source file via string with additional search path
+prog = find_program('program2.py', search_paths : 'scripts')
+ret = run_command(prog)
+assert(ret.returncode() == 0, 'can\'t run @0@'.format(prog.path()))
+assert(ret.stdout().strip() == 'Found', 'wrong output from @0@'.format(prog.path()))

--- a/test cases/common/105 find program path/scripts/program2.py
+++ b/test cases/common/105 find program path/scripts/program2.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print("Found")


### PR DESCRIPTION
Sometimes you need to search for a program or script that is not located in your top-level source directory, or build directory.