### PR TITLE
docs: replace occurences of set_install_script()

### DIFF
--- a/docs/markdown/Creating-Linux-binaries.md
+++ b/docs/markdown/Creating-Linux-binaries.md
@@ -61,7 +61,7 @@ The aim is to put the executable in `/tmp/myapp/bin` and shared libraries to `/t
 Make the script run during install with this:
 
 ```meson
-meson.set_install_script('linux_bundler.sh')
+meson.add_install_script('linux_bundler.sh')
 ```
 
 ## Final steps

--- a/docs/markdown/Creating-OSX-packages.md
+++ b/docs/markdown/Creating-OSX-packages.md
@@ -56,7 +56,7 @@ If you are not using any external libraries, this is all you need to do. You now
 As an example we are going to use the [SDL2](https://libsdl.org/) framework. In order to bundle it in our app, we first specify an installer script to run.
 
 ```meson
-meson.set_install_script('install_script.sh')
+meson.add_install_script('install_script.sh')
 ```
 
 The install script does two things. First it copies the whole framework into our bundle.

--- a/docs/markdown/Installing.md
+++ b/docs/markdown/Installing.md
@@ -56,7 +56,7 @@ As you can see, Meson sets up some environment variables to help you write your 
 Telling Meson to run this script at install time is a one-liner.
 
 ```meson
-meson.set_install_script('myscript.sh')
+meson.add_install_script('myscript.sh')
 ```
 
 The argument is the name of the script file relative to the current subdirectory.


### PR DESCRIPTION
The method has been replaced with add_install_script().

Signed-off-by: Ernestas Kulik <ernestas.kulik@gmail.com>