### PR TITLE
ninjabackend: Use more consistent descriptions

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -851,7 +851,7 @@ int dummy;
              quote_char + ninja_quote(self.environment.get_source_dir()) + quote_char,
              quote_char + ninja_quote(self.environment.get_build_dir()) + quote_char)
         outfile.write(" command = %s %s %s %s %s %s --backend ninja\n" % c)
-        outfile.write(' description = Regenerating build files\n')
+        outfile.write(' description = Regenerating build files.\n')
         outfile.write(' generator = 1\n\n')
         outfile.write('\n')
 
@@ -1351,7 +1351,7 @@ int dummy;
         command = command_template.format(
             executable=' '.join(cmdlist),
             output_args=' '.join(static_linker.get_output_args('$out')))
-        description = ' description = Static linking library $out\n\n'
+        description = ' description = Linking static target $out.\n\n'
         outfile.write(rule)
         outfile.write(command)
         outfile.write(description)
@@ -1394,7 +1394,7 @@ int dummy;
                     cross_args=' '.join(cross_args),
                     output_args=' '.join(compiler.get_linker_output_args('$out'))
                 )
-                description = ' description = Linking target $out'
+                description = ' description = Linking target $out.'
                 outfile.write(rule)
                 outfile.write(command)
                 outfile.write(description)
@@ -1573,7 +1573,7 @@ rule FORTRAN_DEP_HACK
             output_args=' '.join(compiler.get_output_args('$out')),
             compile_only_args=' '.join(compiler.get_compile_only_args())
         )
-        description = ' description = Compiling %s object $out\n' % langname
+        description = ' description = Compiling %s object $out.\n' % langname.title()
         if compiler.get_id() == 'msvc':
             deps = ' deps = msvc\n'
         else:
@@ -1617,7 +1617,7 @@ rule FORTRAN_DEP_HACK
             output_args=output,
             compile_only_args=' '.join(compiler.get_compile_only_args())
         )
-        description = ' description = Precompiling header %s\n' % '$in'
+        description = ' description = Precompiling header %s.\n' % '$in'
         if compiler.get_id() == 'msvc':
             deps = ' deps = msvc\n'
         else:
@@ -2360,7 +2360,7 @@ rule FORTRAN_DEP_HACK
         e.add_item('COMMAND', [sys.executable,
                                self.environment.get_build_command(),
                                '--internal', 'cleantrees', d_file])
-        e.add_item('description', 'Cleaning CustomTarget directories')
+        e.add_item('description', 'Cleaning CustomTarget directories.')
         e.write(outfile)
         # Write out the data file passed to the script
         with open(d_file, 'wb') as ofile:
@@ -2372,14 +2372,14 @@ rule FORTRAN_DEP_HACK
             script_root = self.environment.get_script_dir()
             clean_script = os.path.join(script_root, 'delwithsuffix.py')
             gcno_elem.add_item('COMMAND', [sys.executable, clean_script, '.', 'gcno'])
-            gcno_elem.add_item('description', 'Deleting gcno files')
+            gcno_elem.add_item('description', 'Deleting gcno files.')
             gcno_elem.write(outfile)
 
             gcda_elem = NinjaBuildElement(self.all_outputs, 'clean-gcda', 'CUSTOM_COMMAND', 'PHONY')
             script_root = self.environment.get_script_dir()
             clean_script = os.path.join(script_root, 'delwithsuffix.py')
             gcda_elem.add_item('COMMAND', [sys.executable, clean_script, '.', 'gcda'])
-            gcda_elem.add_item('description', 'Deleting gcda files')
+            gcda_elem.add_item('description', 'Deleting gcda files.')
             gcda_elem.write(outfile)
 
     def get_user_option_args(self):
@@ -2425,7 +2425,7 @@ rule FORTRAN_DEP_HACK
             raise MesonException('Could not detect Ninja v1.6 or newer')
         elem = NinjaBuildElement(self.all_outputs, 'clean', 'CUSTOM_COMMAND', 'PHONY')
         elem.add_item('COMMAND', [ninja_command, '-t', 'clean'])
-        elem.add_item('description', 'Cleaning')
+        elem.add_item('description', 'Cleaning.')
 
         # If we have custom targets in this project, add all their outputs to
         # the list that is passed to the `cleantrees.py` script. The script

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -112,11 +112,12 @@ class NinjaBuildElement:
         line = line.replace('\\', '/')
         outfile.write(line)
 
+        # All the entries that should remain unquoted
+        raw_names = {'DEPFILE', 'DESC', 'pool', 'description'}
+
         for e in self.elems:
             (name, elems) = e
-            should_quote = True
-            if name == 'DEPFILE' or name == 'DESC' or name == 'pool' or name == 'description':
-                should_quote = False
+            should_quote = name not in raw_names
             line = ' %s = ' % name
             q_templ = quote_char + "%s" + quote_char
             noq_templ = "%s"

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2360,7 +2360,7 @@ rule FORTRAN_DEP_HACK
         e.add_item('COMMAND', [sys.executable,
                                self.environment.get_build_command(),
                                '--internal', 'cleantrees', d_file])
-        e.add_item('description', 'Cleaning CustomTarget directories.')
+        e.add_item('description', 'Cleaning custom targets directories.')
         e.write(outfile)
         # Write out the data file passed to the script
         with open(d_file, 'wb') as ofile:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2361,7 +2361,7 @@ rule FORTRAN_DEP_HACK
         e.add_item('COMMAND', [sys.executable,
                                self.environment.get_build_command(),
                                '--internal', 'cleantrees', d_file])
-        e.add_item('description', 'Cleaning custom targets directories.')
+        e.add_item('description', 'Cleaning custom target directories.')
         e.write(outfile)
         # Write out the data file passed to the script
         with open(d_file, 'wb') as ofile:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -966,7 +966,7 @@ int dummy;
     def generate_java_link(self, outfile):
         rule = 'rule java_LINKER\n'
         command = ' command = jar $ARGS\n'
-        description = ' description = Creating jar $out.\n'
+        description = ' description = Creating JAR $out.\n'
         outfile.write(rule)
         outfile.write(command)
         outfile.write(description)
@@ -1429,7 +1429,7 @@ int dummy;
         rule = 'rule %s_COMPILER\n' % compiler.get_language()
         invoc = ' '.join([ninja_quote(i) for i in compiler.get_exelist()])
         command = ' command = %s $ARGS $in\n' % invoc
-        description = ' description = Compiling cs target $out.\n'
+        description = ' description = Compiling C# target $out.\n'
         outfile.write(rule)
         outfile.write(command)
         outfile.write(description)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1430,7 +1430,7 @@ int dummy;
         rule = 'rule %s_COMPILER\n' % compiler.get_language()
         invoc = ' '.join([ninja_quote(i) for i in compiler.get_exelist()])
         command = ' command = %s $ARGS $in\n' % invoc
-        description = ' description = Compiling C# target $out.\n'
+        description = ' description = Compiling C Sharp target $out.\n'
         outfile.write(rule)
         outfile.write(command)
         outfile.write(description)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -115,7 +115,7 @@ class NinjaBuildElement:
         for e in self.elems:
             (name, elems) = e
             should_quote = True
-            if name == 'DEPFILE' or name == 'DESC' or name == 'pool':
+            if name == 'DEPFILE' or name == 'DESC' or name == 'pool' or name == 'description':
                 should_quote = False
             line = ' %s = ' % name
             q_templ = quote_char + "%s" + quote_char


### PR DESCRIPTION
Use a titlecase for arbitrary language, this was we don't have 'C' in
lowercase.

Rename 'Static linking library $out' for 'Linking static target $out.'.

Add missing punctuation.