### PR TITLE
Allow more convenient values for UserBooleans

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -63,9 +63,9 @@ class UserBooleanOption(UserOption):
     def tobool(self, thing):
         if isinstance(thing, bool):
             return thing
-        if thing.lower() == 'true':
+        if thing.lower() in ('true', 'yes', 'on', '1'):
             return True
-        if thing.lower() == 'false':
+        if thing.lower() in ('false', 'no', 'off', '0'):
             return False
         raise MesonException('Value %s is not boolean (true or false).' % thing)
 
@@ -73,9 +73,9 @@ class UserBooleanOption(UserOption):
         self.value = self.tobool(newvalue)
 
     def parse_string(self, valuestring):
-        if valuestring == 'false':
+        if valuestring in ('false', 'no', 'off', '0'):
             return False
-        if valuestring == 'true':
+        if valuestring in ('true', 'yes', 'on', '1'):
             return True
         raise MesonException('Value "%s" for boolean option "%s" is not a boolean.' % (valuestring, self.name))
 


### PR DESCRIPTION
Allow the user-specified boolean options to use more commonly used values including yes/no, on/off, 1/0. This is based on a similar feature in CMake which turned out quite convenient for users. Especially, this makes it possible for Meson to integrate better in existing build system logic in Gentoo without having to reinvent the wheel for yet another implementation of booleans (Gentoo uses yes/no for some reason).

I should warn up front that this does not solve all of our problems. For example, systemd developers define their own trinary type on top of the combo option. Having 'freeform' booleans there would require a fair bit more thinking but I think it's the first step in the right direction.

@nirbheek