### PR TITLE
Update FAQ.md: meson is not elementary particle

### DIFF
--- a/docs/markdown/FAQ.md
+++ b/docs/markdown/FAQ.md
@@ -9,7 +9,7 @@ See also [How do I do X in Meson](howtox.md).
 
 When the name was originally chosen, there were two main limitations: there must not exist either a Debian package or a Sourceforge project of the given name. This ruled out tens of potential project names. At some point the name Gluon was considered. Gluons are elementary particles that hold protons and neutrons together, much like a build system's job is to take pieces of source code and a compiler and bind them to a complete whole.
 
-Unfortunately this name was taken, too. Then the rest of physical elementary particles were examined and Meson was found to be available.
+Unfortunately this name was taken, too. Then the rest of subatomic particles were examined and Meson was found to be available.
 
 ## What is the correct way to use threads (such as pthreads)?
 


### PR DESCRIPTION
Glad to know meson is getting attention recently with the adoption by systemd and Xserver.  I looked at the FAQ and found this technical mistake which most programmer won't be aware of:
>Then the rest of physical elementary particles were examined and Meson was found to be available.

Formerly being a physics student, I find the sentence strange once I read it, and then noticed the problem.

Meson is a hadron, more specifically, hadrons that consists of a quark and a anti-quark.  So, it is a composite particle rather than elementary one.  For those still confused, quarks is elementary because it is not composed of other things.  But meson is composed of quarks.

The real intent of this PR is to let the developers and users of meson to get interested in meson, physically, by googling it, rather than challenging the author.  :stuck_out_tongue: