### PR TITLE
Strip GCC comments from output before parsing in get_define. Closes #…

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -782,7 +782,7 @@ class CCompiler(Compiler):
         return self.exelist[:]
 
     def get_preprocess_only_args(self):
-        return ['-E']
+        return ['-E', '-P']
 
     def get_compile_only_args(self):
         return ['-c']
@@ -2135,7 +2135,7 @@ class VisualStudioCCompiler(CCompiler):
         return ['/FI' + base, '/Yu' + base, '/Fp' + os.path.join(pch_dir, pchname)]
 
     def get_preprocess_only_args(self):
-        return ['/E']
+        return ['/EP']
 
     def get_compile_only_args(self):
         return ['/c']

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1139,10 +1139,10 @@ class CCompiler(Compiler):
         delim = '"MESON_GET_DEFINE_DELIMITER"'
         fargs = {'prefix': prefix, 'define': dname, 'delim': delim}
         code = '''
+        {prefix}
         #ifndef {define}
         # define {define}
         #endif
-        {prefix}
         {delim}\n{define}'''
         args = self._get_compiler_check_args(env, extra_args, dependencies,
                                              mode='preprocess').to_native()

--- a/test cases/common/140 get define/meson.build
+++ b/test cases/common/140 get define/meson.build
@@ -20,6 +20,15 @@ foreach lang : ['c', 'cpp']
     error('Please report a bug and help us improve support for this platform')
   endif
 
+  if cc.find_library('z', required : false).found()
+    # When a C file containing #include <foo.h> is pre-processed and foo.h is
+    # found in the compiler's default search path, GCC inserts an extra comment
+    # between the delimiter and the define which causes a parsing error.
+    # https://github.com/mesonbuild/meson/issues/1726
+    ver = cc.get_define('ZLIB_VER_MAJOR', prefix : '#include <zlib.h>')
+    assert(ver == '1', 'ZLIB_VER_MAJOR value is "@0@" instead of "1"'.format(ver))
+  endif
+
   # Check that an undefined value is empty.
   have = cc.get_define('MESON_FAIL_VALUE')
   assert(have == '', 'MESON_FAIL_VALUE value is "@0@" instead of ""'.format(have))


### PR DESCRIPTION
…1726.

No test, because I don't want to add build-dep on cups just for this. If someone can come up with a way to create the problematic output, please post below.