### PR TITLE
mesonintrospect: List all installed files

### DIFF
--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -65,7 +65,13 @@ def determine_installed_path(target, installdata):
 def list_installed(installdata):
     res = {}
     if installdata is not None:
+        for path, installdir, aliases, unknown1, unknown2 in installdata.targets:
+            res[os.path.join(installdata.build_dir, path)] = os.path.join(installdata.prefix, installdir, os.path.basename(path))
         for path, installpath, unused_prefix in installdata.data:
+            res[path] = os.path.join(installdata.prefix, installpath)
+        for path, installdir in installdata.headers:
+            res[path] = os.path.join(installdata.prefix, installdir, os.path.basename(path))
+        for path, installpath in installdata.man:
             res[path] = os.path.join(installdata.prefix, installpath)
     print(json.dumps(res))
 


### PR DESCRIPTION
Currently mesonintrospect only lists data (`configure_file()` and `install_data()`). This fixes that.
We could probably go further and allow for something `mesonintrospect --installed=data` to filter.
To keep compatibility, all paths are absolute and e.g. symlinks are not listed.

However, the code uses `install.dat` and notes that it is used for the Ninja backend only. Reworking this code to use the actual Meson targets could be a good idea.

Also, gettext files are not listed because they are installed through a Meson-wrapped install script, even though `install.dat` contains `po` and `po_package_name` that I believe are translation-related (but I didn’t check).