### PR TITLE
Fix caching of external dependencies of various types

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -160,7 +160,7 @@ class CoreData:
         self.wrap_mode = options.wrap_mode
         self.compilers = OrderedDict()
         self.cross_compilers = OrderedDict()
-        self.deps = {}
+        self.deps = OrderedDict()
         self.modules = {}
         # Only to print a warning if it changes between Meson invocations.
         self.pkgconf_envvar = os.environ.get('PKG_CONFIG_PATH', '')

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -127,6 +127,7 @@ class PkgConfigDependency(Dependency):
     def __init__(self, name, environment, kwargs):
         Dependency.__init__(self, 'pkgconfig', kwargs)
         self.is_libtool = False
+        self.version_reqs = kwargs.get('version', None)
         self.required = kwargs.get('required', True)
         self.static = kwargs.get('static', False)
         self.silent = kwargs.get('silent', False)
@@ -187,7 +188,6 @@ class PkgConfigDependency(Dependency):
                                           ''.format(self.type_string, name))
             return
         found_msg = [self.type_string + ' dependency', mlog.bold(name), 'found:']
-        self.version_reqs = kwargs.get('version', None)
         if self.version_reqs is None:
             self.is_found = True
         else:

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -1742,21 +1742,17 @@ class LLVMDependency(Dependency):
         return True
 
 
-def get_dep_identifier(name, kwargs):
-    elements = [name]
-    modlist = kwargs.get('modules', [])
-    if isinstance(modlist, str):
-        modlist = [modlist]
-    for module in modlist:
-        elements.append(module)
-    # We use a tuple because we need a non-mutable structure to use as the key
-    # of a dictionary and a string has potential for name collisions
-    identifier = tuple(elements)
-    identifier += ('main', kwargs.get('main', False))
-    identifier += ('static', kwargs.get('static', False))
-    if 'fallback' in kwargs:
-        f = kwargs.get('fallback')
-        identifier += ('fallback', f[0], f[1])
+def get_dep_identifier(name, kwargs, want_cross):
+    # Need immutable objects since the identifier will be used as a dict key
+    identifier = (name, want_cross)
+    for key, value in kwargs.items():
+        # Ignore versions, they will be handled by the caller
+        if key == 'version':
+            continue
+        # All keyword arguments are strings, ints, or lists (or lists of lists)
+        if isinstance(value, list):
+            value = frozenset(mesonlib.flatten(value))
+        identifier += (key, value)
     return identifier
 
 def find_external_dependency(name, environment, kwargs):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2226,7 +2226,7 @@ class Interpreter(InterpreterBase):
         absname = os.path.join(self.environment.get_source_dir(), buildfilename)
         if not os.path.isfile(absname):
             self.subdir = prev_subdir
-            raise InterpreterException('Nonexistent build def file %s.' % buildfilename)
+            raise InterpreterException('Non-existent build file {!r}'.format(buildfilename))
         with open(absname, encoding='utf8') as f:
             code = f.read()
         assert(isinstance(code, str))

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1882,25 +1882,24 @@ class Interpreter(InterpreterBase):
             # was found already.
             # We only return early if we find a usable cached dependency since
             # there might be multiple cached dependencies like this.
-            w = identifier[1]
+            wanted = identifier[1]
             for trial, trial_dep in self.coredata.deps.items():
                 # trial[1], identifier[1] are the version requirements
                 if trial[0] != identifier[0] or trial[2:] != identifier[2:]:
                     continue
-                # The version requirements are the only thing that's different.
                 if trial_dep.found():
-                    # Cached dependency was found. We're close.
-                    f = trial_dep.get_version()
-                    if not w or mesonlib.version_compare_many(f, w)[0]:
-                        # We either don't care about the version, or the
-                        # cached dep version matches our requirements! Yay!
+                    found = trial_dep.get_version()
+                    if not wanted or mesonlib.version_compare_many(found, wanted)[0]:
+                        # We either don't care about the version, or our
+                        # version requirements matched the trial dep's version,
+                        # and the trial dep was a found dep!
                         return identifier, trial_dep
-                elif 'fallback' not in kwargs:
-                    # this cached dependency matched everything but was
-                    # not-found. Tentatively set this as the dep to use.
-                    # If no other cached dep matches, we will use this as the
-                    # not-found dep.
+                elif not trial[1]:
+                    # If the not-found cached dep did not have any version
+                    # requirements, this probably means the external dependency
+                    # cannot be found.
                     cached_dep = trial_dep
+                    break
         # There's a subproject fallback specified for this not-found dependency
         # which might provide it, so we must check it.
         if cached_dep and not cached_dep.found() and 'fallback' in kwargs:

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -305,7 +305,7 @@ def version_compare(vstr1, vstr2, strict=False):
     return cmpop(varr1, varr2)
 
 def version_compare_many(vstr1, conditions):
-    if not isinstance(conditions, (list, tuple)):
+    if not isinstance(conditions, (list, tuple, frozenset)):
         conditions = [conditions]
     found = []
     not_found = []

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -161,12 +161,12 @@ def list_buildsystem_files(coredata, builddata):
     print(json.dumps(filelist))
 
 def list_deps(coredata):
-    result = {}
-    for d in coredata.deps.values():
+    result = []
+    for d in coredata.deps:
         if d.found():
             args = {'compile_args': d.get_compile_args(),
                     'link_args': d.get_link_args()}
-            result[d.name] = args
+            result += [d.name, args]
     print(json.dumps(result))
 
 def list_tests(testdata):

--- a/run_tests.py
+++ b/run_tests.py
@@ -16,6 +16,7 @@
 
 import os
 import sys
+import time
 import shutil
 import subprocess
 import platform
@@ -97,6 +98,13 @@ def get_backend_commands(backend, debug=False):
     else:
         raise AssertionError('Unknown backend: {!r}'.format(backend))
     return cmd, clean_cmd, test_cmd, install_cmd, uninstall_cmd
+
+def ensure_backend_detects_changes(backend):
+    # This is needed to increase the difference between build.ninja's
+    # timestamp and the timestamp of whatever you changed due to a Ninja
+    # bug: https://github.com/ninja-build/ninja/issues/371
+    if backend is Backend.ninja:
+        time.sleep(1)
 
 def get_fake_options(prefix):
     import argparse

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -30,6 +30,7 @@ from mesonbuild.dependencies import PkgConfigDependency, ExternalProgram
 
 from run_tests import exe_suffix, get_fake_options, FakeEnvironment
 from run_tests import get_builddir_target_args, get_backend_commands, Backend
+from run_tests import ensure_backend_detects_changes
 
 
 def get_soname(fname):
@@ -355,13 +356,6 @@ class BasePlatformTests(unittest.TestCase):
             # XCode backend is untested with unit tests, help welcome!
             self.no_rebuild_stdout = 'UNKNOWN BACKEND {!r}'.format(self.backend.name)
 
-    def ensure_backend_detects_changes(self):
-        # This is needed to increase the difference between build.ninja's
-        # timestamp and the timestamp of whatever you changed due to a Ninja
-        # bug: https://github.com/ninja-build/ninja/issues/371
-        if self.backend is Backend.ninja:
-            time.sleep(1)
-
     def _print_meson_log(self):
         log = os.path.join(self.logdir, 'meson-log.txt')
         if not os.path.isfile(log):
@@ -439,14 +433,14 @@ class BasePlatformTests(unittest.TestCase):
 
     def setconf(self, arg, will_build=True):
         if will_build:
-            self.ensure_backend_detects_changes()
+            ensure_backend_detects_changes(self.backend)
         self._run(self.mconf_command + [arg, self.builddir])
 
     def wipe(self):
         shutil.rmtree(self.builddir)
 
     def utime(self, f):
-        self.ensure_backend_detects_changes()
+        ensure_backend_detects_changes(self.backend)
         os.utime(f)
 
     def get_compdb(self):

--- a/test cases/linuxlike/1 pkg-config/meson.build
+++ b/test cases/linuxlike/1 pkg-config/meson.build
@@ -45,4 +45,3 @@ inc = include_directories('incdir')
 
 r = cc.run(code, include_directories : inc, dependencies : zlibdep)
 assert(r.returncode() == 0, 'Running manual zlib test failed.')
-

--- a/test cases/linuxlike/5 dependency versions/meson.build
+++ b/test cases/linuxlike/5 dependency versions/meson.build
@@ -62,10 +62,23 @@ assert(somefail_dep.found() == false, 'somefail_dep found via wrong fallback')
 fallbackzlib_dep = dependency('zlib',
   fallback : ['somelib', 'fakezlib_dep'])
 assert(fallbackzlib_dep.type_name() == 'pkgconfig', 'fallbackzlib_dep should be of type "pkgconfig", not ' + fallbackzlib_dep.type_name())
-# Check that the above dependency was not found because it wasn't checked, not because the fallback didn't work
+# Check that the above dependency was pkgconfig because the fallback wasn't
+# checked, not because the fallback didn't work
 fakezlib_dep = dependency('fakezlib',
   fallback : ['somelib', 'fakezlib_dep'])
 assert(fakezlib_dep.type_name() == 'internal', 'fakezlib_dep should be of type "internal", not ' + fakezlib_dep.type_name())
+
+# Check that you can find a dependency by not specifying a version after not
+# finding it by specifying a version. We add `static: true` here so that the
+# previously cached zlib dependencies don't get checked.
+dependency('zlib', static : true, version : '>=8000', required : false)
+dependency('zlib', static : true)
+
+# Check that you can find a dependency by specifying a correct version after
+# not finding it by specifying a wrong one. We add `method: pkg-config` here so that
+# the previously cached zlib dependencies don't get checked.
+bzip2 = dependency('zlib', method : 'pkg-config', version : '>=9000', required : false)
+bzip2 = dependency('zlib', method : 'pkg-config', version : '>=1.0')
 
 if meson.is_cross_build()
   # Test caching of native and cross dependencies

--- a/test cases/linuxlike/5 dependency versions/meson.build
+++ b/test cases/linuxlike/5 dependency versions/meson.build
@@ -48,6 +48,16 @@ fakezlib_dep = dependency('zlib',
   fallback : ['somelib', 'fakezlib_dep'])
 assert(fakezlib_dep.type_name() == 'internal', 'fakezlib_dep should be of type "internal", not ' + fakezlib_dep.type_name())
 
+if meson.is_cross_build()
+  # Test caching of native and cross dependencies
+  # https://github.com/mesonbuild/meson/issues/1736
+  cross_prefix = dependency('zlib').get_pkgconfig_variable('prefix')
+  native_prefix = dependency('zlib', native : true).get_pkgconfig_variable('prefix')
+  assert(cross_prefix != '', 'cross zlib prefix is not defined')
+  assert(native_prefix != '', 'native zlib prefix is not defined')
+  assert(native_prefix != cross_prefix, 'native prefix == cross_prefix == ' + native_prefix)
+endif
+
 foreach d : ['sdl2', 'gnustep', 'wx', 'gl', 'python3', 'boost', 'gtest', 'gmock']
   dep = dependency(d, required : false)
   if dep.found()

--- a/test cases/linuxlike/5 dependency versions/meson.build
+++ b/test cases/linuxlike/5 dependency versions/meson.build
@@ -21,10 +21,18 @@ if dependency('zlib', version : ['<=1.0', '>=9999', '=' + zlib.version()], requi
   error('zlib <=1.0 >=9999 should not have been found')
 endif
 
+# Test that a versionless zlib is found after not finding an optional zlib dep with version reqs
+zlibopt = dependency('zlib', required : false)
+assert(zlibopt.found() == true, 'zlib not found')
+
 # Test https://github.com/mesonbuild/meson/pull/610
 dependency('somebrokenlib', version : '>=2.0', required : false)
 dependency('somebrokenlib', version : '>=1.0', required : false)
 
+# Search for an external dependency that won't be found, but must later be
+# found via fallbacks
+somelibnotfound = dependency('somelib', required : false)
+assert(somelibnotfound.found() == false, 'somelibnotfound was found?')
 # Find internal dependency without version
 somelibver = dependency('somelib',
   fallback : ['somelibnover', 'some_dep'])
@@ -37,14 +45,25 @@ somelib = dependency('somelib',
 somelibver = dependency('somelib',
   version : '>= 0.3',
   fallback : ['somelibver', 'some_dep'])
-# Find somelib again, but with a fallback that will fail
+# Find somelib again, but with a fallback that will fail because subproject does not exist
 somelibfail = dependency('somelib',
   version : '>= 0.2',
   required : false,
   fallback : ['somelibfail', 'some_dep'])
 assert(somelibfail.found() == false, 'somelibfail found via wrong fallback')
+# Find somelib again, but with a fallback that will fail because dependency does not exist
+somefail_dep = dependency('somelib',
+  version : '>= 0.2',
+  required : false,
+  fallback : ['somelib', 'somefail_dep'])
+assert(somefail_dep.found() == false, 'somefail_dep found via wrong fallback')
 
-fakezlib_dep = dependency('zlib',
+# Fallback should only be used if the primary was not found
+fallbackzlib_dep = dependency('zlib',
+  fallback : ['somelib', 'fakezlib_dep'])
+assert(fallbackzlib_dep.type_name() == 'pkgconfig', 'fallbackzlib_dep should be of type "pkgconfig", not ' + fallbackzlib_dep.type_name())
+# Check that the above dependency was not found because it wasn't checked, not because the fallback didn't work
+fakezlib_dep = dependency('fakezlib',
   fallback : ['somelib', 'fakezlib_dep'])
 assert(fakezlib_dep.type_name() == 'internal', 'fakezlib_dep should be of type "internal", not ' + fakezlib_dep.type_name())
 


### PR DESCRIPTION
All our cached_dep magic was totally useless since we ended up using the same identifier for native and cross deps. Just nuke all this `cached_dep` code since it is very error-prone and improve the identifier generation instead.

For instance, this is broken *right now* with the `type_name` kwarg.

Add a bunch of tests to ensure that all this actually works...

Closes https://github.com/mesonbuild/meson/issues/1736

Also list deps properly in mesonintrospect.