### PR TITLE
Add a new method for arrays: array.found()

### DIFF
--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -391,7 +391,7 @@ class InterpreterBase:
         if isinstance(obj, int):
             return self.int_method_call(obj, method_name, args)
         if isinstance(obj, list):
-            return self.array_method_call(obj, method_name, self.reduce_arguments(args)[0])
+            return self.array_method_call(obj, method_name, *self.reduce_arguments(args))
         if isinstance(obj, mesonlib.File):
             raise InvalidArguments('File object "%s" is not callable.' % obj)
         if not isinstance(obj, InterpreterObject):
@@ -496,7 +496,7 @@ class InterpreterBase:
     def unknown_function_called(self, func_name):
             raise InvalidCode('Unknown function "%s".' % func_name)
 
-    def array_method_call(self, obj, method_name, args):
+    def array_method_call(self, obj, method_name, args, kwargs):
         if method_name == 'contains':
             return self.check_contains(obj, args)
         elif method_name == 'length':
@@ -519,6 +519,19 @@ class InterpreterBase:
                     raise InvalidArguments(m.format(index, len(obj)))
                 return fallback
             return obj[index]
+        elif method_name == 'found':
+            # Nothing to check, nothing found
+            if not obj:
+                return False
+            # Check all dependencies and verify that they were found. Can also
+            # be used for external programs, if someone wants to.
+            for each in mesonlib.flatten(obj):
+                if not hasattr(each, 'found_method'):
+                    m = 'Array element {!r} does not have a \'found\' method'
+                    raise InterpreterException(m.format(each))
+                if not each.found_method(args, kwargs):
+                    return False
+            return True
         m = 'Arrays do not have a method called {!r}.'
         raise InterpreterException(m.format(method_name))
 

--- a/test cases/linuxlike/5 dependency versions/meson.build
+++ b/test cases/linuxlike/5 dependency versions/meson.build
@@ -54,3 +54,14 @@ foreach d : ['sdl2', 'gnustep', 'wx', 'gl', 'python3', 'boost', 'gtest', 'gmock'
     dep.version()
   endif
 endforeach
+
+# An empty array means 'not found', for convenience
+assert([].found() == false, '[] should not have been found')
+# An array of found objects is found
+assert([dependency('zlib')].found() == true, '[zlib] should have been found')
+# An array of found objects and an empty array is found because arguments are flattened
+assert([dependency('zlib'), []].found() == true, '[zlib] should have been found')
+# An array of found and not-found objects is not found
+assert([dependency('zlib'), dependency('', required : false)].found() == false, '[zlib, \'\'] should not have been found')
+# An array of not-found objects is not found
+assert([dependency('no-way-this-exists', required : false)].found() == false, '[\'no-way-this-exists\'] should not have been found')


### PR DESCRIPTION
This allows users to check if all the dependencies in a list of dependencies were found. Also allows you to use `[]` as a placeholder for a dependency that was not found. We already recommend the following idiom:

```meson
feature_deps = []
if get_option('build-feature') != 'no'
  feature_deps = [dependency('dep1', required : get_option('build-feature') == 'yes'),
                            dependency('dep2', required : get_option('build-feature') == 'yes')]
endif

...

executable('feature', 'src.c', dependencies : feature_deps)
```

This would allow people to do this:

```meson
if feature_deps.found()
  executable('feature', 'src.c', dependencies : feature_deps)
endif
```

Instead of having to check the entire list of deps. This is also useful when you want to only check a single dependency since it avoids having to store a boolean variable called 'found_dep1' or similar for every feature that you check for.

As a bonus, this can also be used for checking if a list of external programs were all found.