### PR TITLE
vala: Add a section about using posixvala

### DIFF
--- a/docs/markdown/Vala.md
+++ b/docs/markdown/Vala.md
@@ -74,3 +74,25 @@ custom_target('foo typelib', command: [g_ir_compiler, '--output', '@OUTPUT@', '@
               install: true,
               install_dir: join_paths(get_option('libdir'), 'girepository-1.0'))
 ```
+
+## Posix mode
+
+Vala requires both `glib-2.0` and `gobject-2.0` to function properly. In that
+perspective, the [posixvala](https://github,com/radare/posixvala) project
+provides a minimal header-only and posix-compatible stub that can be used for
+targeting embedded environment.
+
+```meson
+project('foo', 'c', 'vala')
+
+glib_dep = dependency('glib-posix-2.0')
+gobject_dep = dependency('gobject-posix-2.0')
+
+executable('foo', 'foo.vala',
+           dependencies: [glib_dep, gobject_dep])
+```
+
+If used as a subproject, `glib_posix_dep` and `gobject_posix_dep` variables can
+be imported.
+
+Not all features of the language are made available.


### PR DESCRIPTION
Do not merge! At least not until it gets reviewed and merged in https://github.com/radare/posixvala/pull/11.

It's sort of nice that Meson can work out a stubbed GLib/GObject for Vala without a single change.
