### PR TITLE
LLVM cpp blacklist

### DIFF
--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -1648,7 +1648,7 @@ class LLVMDependency(Dependency):
             self.check_llvmconfig(req_version)
         if not self._llvmconfig_found:
             if self.__best_found is not None:
-                mlog.log('found {!r} but need:'.format(self.version),
+                mlog.log('found {!r} but need:'.format(self.__best_found),
                          req_version)
             else:
                 mlog.log("No llvm-config found; can't detect dependency")

--- a/mesonbuild/dependencies.py
+++ b/mesonbuild/dependencies.py
@@ -1631,6 +1631,7 @@ class LLVMDependency(Dependency):
     llvmconfig = None
     _llvmconfig_found = False
     __best_found = None
+    __cpp_blacklist = {'-DNDEBUG'}
 
     def __init__(self, environment, kwargs):
         super().__init__('llvm-config', kwargs)
@@ -1676,7 +1677,7 @@ class LLVMDependency(Dependency):
             p, out = Popen_safe([self.llvmconfig, '--cppflags'])[:2]
             if p.returncode != 0:
                 raise DependencyException('Could not generate includedir for LLVM.')
-            self.cargs = shlex.split(out)
+            self.cargs = list(mesonlib.OrderedSet(shlex.split(out)).difference(self.__cpp_blacklist))
 
             p, out = Popen_safe([self.llvmconfig, '--components'])[:2]
             if p.returncode != 0:

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -708,7 +708,8 @@ class OrderedSet(collections.MutableSet):
     def __repr__(self):
         # Don't print 'OrderedSet("")' for an empty set.
         if self.__container:
-            return 'OrderedSet("{}")'.format('", "'.join(self.__container.keys()))
+            return 'OrderedSet("{}")'.format(
+                '", "'.join(repr(e) for e in self.__container.keys()))
         return 'OrderedSet()'
 
     def add(self, value):

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -722,3 +722,6 @@ class OrderedSet(collections.MutableSet):
     def update(self, iterable):
         for item in iterable:
             self.__container[item] = None
+
+    def difference(self, set_):
+        return type(self)(e for e in self if e not in set_)


### PR DESCRIPTION
This adds a blacklist to LLVM for it's CPPflags, to remove garabage like -NDEBUG, which llvm-config-3.7 includes.

This also has a small bug fix for the `OrderedSet.__repr__` protocol, and adds a `difference` method to `OrderedSet`