### PR TITLE
Install link function

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -471,6 +471,21 @@ Installs the specified man files from the source tree into system's man director
 
 Installs the entire given subdirectory and its contents from the source tree to the location specified by the keyword argument `install_dir`. Note that due to implementation issues this command deletes the entire target dir before copying the files, so you should never use `install_subdir` to install into two overlapping directories (such as `foo` and `foo/bar`) because if you do the behavior is undefined.
 
+### install_link()
+
+``` meson
+    ctarget install_link(source, destination)
+```
+
+Installs a target as a hard or symbolic. Symlinks can only be created from installed targets, while hard links can be created from both targets regardless of whether they're installed or not. It will preserve the file extension of the source file, if it has one.
+
+It additionally supports the following keyword arguments:
+
+ - `install_dir`, the location to install to, this keyword is required.
+ - `type`, a string that must be either `symbolic` or `hard` which controls the kind of link that creatdd. This keyword is optional, and defaults to `symbolic`.
+
+Available since 0.41.0
+
 ### is_variable()
 
 ``` meson

--- a/docs/markdown/Release-notes-for-0.41.0.md
+++ b/docs/markdown/Release-notes-for-0.41.0.md
@@ -13,6 +13,7 @@ Add features here as code is merged to master.
 
 Native support for linking against LLVM using the `dependency` function.
 
+
 ## vcs_tag keyword fallback is is now optional
 
 The `fallback` keyword in `vcs_tag` is now optional. If not given, its value
@@ -38,3 +39,8 @@ pkg.generate(libraries : libs,
              description : 'A simple demo library.',
              variables : ['datadir=${prefix}/data'])
 ```
+
+## install_link function
+
+Adds support for creating symbolic from installed targets and hard links from
+both installed and not installed targets.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2016 The Meson development team
+# Copyright 2012-2017 The Meson development team
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ class InstallData:
         self.po = []
         self.install_scripts = []
         self.install_subdirs = []
+        self.fs_links = []
         self.mesonintrospect = mesonintrospect
 
 class ExecutableSerialisation:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -626,6 +626,7 @@ int dummy;
         self.generate_data_install(d)
         self.generate_custom_install_script(d)
         self.generate_subdir_install(d)
+        self.generate_fs_link_install(d)
         elem.write(outfile)
 
         with open(install_data_file, 'wb') as ofile:
@@ -749,6 +750,18 @@ int dummy;
                 abspath = f.absolute_path(srcdir, builddir)
                 i = [abspath, outdir]
                 d.headers.append(i)
+
+    def generate_fs_link_install(self, d):
+        for s in self.build.get_fs_links():
+            if s.source.need_install:
+                source = os.path.join(s.source.get_custom_install_dir()[0],
+                                      s.source.get_outputs()[0])
+            else:
+                source = os.path.join(self.environment.get_build_dir(),
+                                      s.source.get_subdir(),
+                                      s.source.get_filename())
+            output = os.path.join(s.install_dir, s.output)
+            d.fs_links.append((source, output, s.type))
 
     def generate_man_install(self, d):
         manroot = self.environment.get_mandir()

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -96,6 +96,7 @@ class Build:
         self.headers = []
         self.man = []
         self.data = []
+        self.fs_links = []
         self.static_linker = None
         self.static_cross_linker = None
         self.subprojects = {}
@@ -141,6 +142,9 @@ class Build:
 
     def get_data(self):
         return self.data
+
+    def get_fs_links(self):
+        return self.fs_links
 
     def get_install_subdirs(self):
         return self.install_dirs

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -17,6 +17,7 @@
 import stat
 import platform, subprocess, operator, os, shutil, re
 import collections
+import contextlib
 
 from glob import glob
 
@@ -725,3 +726,16 @@ class OrderedSet(collections.MutableSet):
 
     def difference(self, set_):
         return type(self)(e for e in self if e not in set_)
+
+
+@contextlib.contextmanager
+def chdir(new):
+    """Change directory and guarantee a return to the previous directory in
+    case of an exception.
+    """
+    current = os.getcwd()
+    os.chdir(new)
+    try:
+        yield
+    finally:
+        os.chdir(current)

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -206,6 +206,16 @@ def platform_fix_name(fname):
         else:
             fname = re.sub(r'\?lib', 'lib', fname)
 
+    # TODO: What about library versions?
+    if fname.endswith('?so'):
+        fname = fname[:-3]
+        if mesonlib.is_osx():
+            return fname + '.dylib'
+        elif mesonlib.is_windows() or mesonlib.is_cygwin():
+            return fname + '.dll'
+        else:
+            return fname + '.so'
+
     if fname.endswith('?exe'):
         fname = fname[:-4]
         if mesonlib.is_windows() or mesonlib.is_cygwin():

--- a/syntax-highlighting/vim/syntax/meson.vim
+++ b/syntax-highlighting/vim/syntax/meson.vim
@@ -92,6 +92,7 @@ syn keyword mesonBuiltin
   \ include_directories
   \ install_data
   \ install_headers
+  \ install_link
   \ install_man
   \ install_subdir
   \ is_variable

--- a/test cases/common/150 install_link/1/2/3/4/foo.c
+++ b/test cases/common/150 install_link/1/2/3/4/foo.c
@@ -1,0 +1,18 @@
+/* Copyright © 2017 Dylan Baker
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+int myfunc(void) {
+    return 0;
+}

--- a/test cases/common/150 install_link/1/2/3/4/meson.build
+++ b/test cases/common/150 install_link/1/2/3/4/meson.build
@@ -1,0 +1,18 @@
+# Copyright © 2017 Dylan Baker
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+libthing = static_library(
+  'thing',
+  ['foo.c'],
+)

--- a/test cases/common/150 install_link/1/2/3/meson.build
+++ b/test cases/common/150 install_link/1/2/3/meson.build
@@ -1,0 +1,3 @@
+subdir('4')
+
+install_link(libthing, 'libother', install_dir : get_option('libdir'), type : 'hard')

--- a/test cases/common/150 install_link/foo.c
+++ b/test cases/common/150 install_link/foo.c
@@ -1,0 +1,19 @@
+/* Copyright © 2017 Dylan Baker
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdio.h>
+
+int main() {
+    printf("Hello World!");
+}

--- a/test cases/common/150 install_link/installed_files.txt
+++ b/test cases/common/150 install_link/installed_files.txt
@@ -1,0 +1,12 @@
+usr/bin/foo?exe
+usr/bin/bar?exe
+usr/bin/ish?exe
+usr/bin/subdir/bar2?exe
+usr/bin/custom2?exe
+usr/bin/custom3?exe
+usr/custom/custom?exe
+usr/lib/libfoo.a
+usr/lib/libbar.a
+usr/lib/libish.a
+usr/lib/libtwo?so
+usr/lib/libother.a

--- a/test cases/common/150 install_link/meson.build
+++ b/test cases/common/150 install_link/meson.build
@@ -1,0 +1,63 @@
+# Copyright © 2017 Dylan Baker
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project('149 install_link test', 'c')
+
+if host_machine.system() == 'windows'
+  error('MESON_SKIP_TEST this test is not relavent on windows')
+endif
+
+foo = executable(
+  'foo',
+  'foo.c',
+  install : true,
+)
+
+install_link(foo, 'bar', install_dir : get_option('bindir'))
+install_link(foo, 'ish', install_dir : get_option('bindir'), type : 'hard')
+install_link(foo, 'bar2', install_dir : join_paths(get_option('bindir'), 'subdir'))
+install_link(foo, 'ish2', install_dir : join_paths(get_option('bindir'), 'subdir'), type : 'hard')
+
+
+# Test an executable with a custom install_dir
+custom_exe = executable(
+  'custom',
+  'foo.c',
+  install : true,
+  install_dir : 'custom',
+)
+install_link(custom_exe, 'custom2', install_dir : get_option('bindir'), type : 'hard')
+install_link(custom_exe, 'custom3', install_dir : get_option('bindir'))
+
+# Test a library
+libfoo = static_library(
+  'foo',
+  'foo.c',
+  install : true,
+)
+install_link(libfoo, 'libbar', install_dir : get_option('libdir'), type : 'hard')
+install_link(libfoo, 'libish', install_dir : get_option('libdir'))
+
+# Test a hard link with non-installed target
+# 
+# This is only legal when using hard links, because of the nature of hard
+# links.
+libone = shared_library(
+  'one',
+  'foo.c',
+  install : false,
+)
+install_link(libone, 'libtwo', install_dir : get_option('libdir'), type : 'hard')
+
+subdir('1/2/3')


### PR DESCRIPTION
This adds a function, `install_link`, that can be used to create additional symbolic or hard links in the install directory. These links are created at install time (ie, during `ninja install`). As a result this code isn't run on backends that don't have an install (such as the Visual Studio backends).

The intended purpose of this function is for two use cases. The first is requested by systemd, the ability to symlink executables from 'systemd-<foo>' to '<foo>'. The second, which is needed by mesa, is to allow hard linking a single shared_library to multiple locations in the source tree.

Comes complete with documentation and passing test case.