### PR TITLE
appveyor: Don't run appveyor for docs only changes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,6 +49,10 @@ branches:
   only:
     - master
 
+skip_commits:
+  files:
+    - docs/**/*
+
 install:
   # Use the x86 python only when building for x86 for the cpython tests.
   # For all other archs (including, say, arm), use the x64 python.


### PR DESCRIPTION
Appveyor takes a *long* time to run (~45 minutes per commit currently),
and it does no parallelism. It is possible to skip merge requests that
only touch documentation, this commit adds that support.

Because Appveyor (and Travis) test a merge of the pull request into
master and not the branch itself this will only skip builds that only
touch docs, and not pull requests that do both doc and non-doc changes.