### PR TITLE
ninja: Also include Vala headers in generated headers

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -232,6 +232,9 @@ int dummy;
             for src in genlist.get_outputs():
                 if self.environment.is_header(src):
                     header_deps.append(self.get_target_generated_dir(target, genlist, src))
+        if 'vala' in target.compilers and not isinstance(target, build.Executable):
+            vala_header = File.from_built_file(self.get_target_dir(target), target.vala_header)
+            header_deps.append(vala_header)
         # Recurse and find generated headers
         for dep in target.link_targets:
             if isinstance(dep, (build.StaticLibrary, build.SharedLibrary)):
@@ -1080,7 +1083,7 @@ int dummy;
             args += ['--library=' + target.name]
             # Outputted header
             hname = os.path.join(self.get_target_dir(target), target.vala_header)
-            args += ['-H', hname]
+            args += ['-H', hname, '--use-header']
             valac_outputs.append(hname)
             # Outputted vapi file
             vapiname = os.path.join(self.get_target_dir(target), target.vala_vapi)

--- a/test cases/vala/16 mixed dependence/app.vala
+++ b/test cases/vala/16 mixed dependence/app.vala
@@ -1,0 +1,7 @@
+namespace App {
+    public static int main(string[] args) {
+        var mixer = new Mixer();
+        print("Current volume is %u\n", mixer.get_volume());
+        return 0;
+    }
+}

--- a/test cases/vala/16 mixed dependence/meson.build
+++ b/test cases/vala/16 mixed dependence/meson.build
@@ -1,0 +1,12 @@
+project('mixed dependence', 'vala', 'c')
+
+deps = [dependency('glib-2.0'), dependency('gobject-2.0')]
+
+mixer = static_library('mixer', 'mixer.vala', 'mixer-glue.c',
+  dependencies : deps)
+
+app = executable('app', 'app.vala',
+  link_with : mixer,
+  dependencies : deps)
+
+test('valamixeddependencetest', app)

--- a/test cases/vala/16 mixed dependence/mixer-glue.c
+++ b/test cases/vala/16 mixed dependence/mixer-glue.c
@@ -1,0 +1,5 @@
+#include "mixer.h"
+
+guint mixer_get_volume(Mixer *mixer) {
+    return 11;
+}

--- a/test cases/vala/16 mixed dependence/mixer.vala
+++ b/test cases/vala/16 mixed dependence/mixer.vala
@@ -1,0 +1,3 @@
+public class Mixer : Object {
+    public extern uint get_volume();
+}

--- a/test cases/vala/17 plain consumer/app.c
+++ b/test cases/vala/17 plain consumer/app.c
@@ -1,0 +1,11 @@
+#include "badger.h"
+
+int main(int argc, char *argv[]) {
+    Badger *badger;
+
+    badger = g_object_new(TYPE_BADGER, NULL);
+    g_print("Badger whose name is '%s'\n", badger_get_name(badger));
+    g_object_unref(badger);
+
+    return 0;
+}

--- a/test cases/vala/17 plain consumer/badger.vala
+++ b/test cases/vala/17 plain consumer/badger.vala
@@ -1,0 +1,10 @@
+public class Badger : Object {
+    public string name {
+        get;
+        construct;
+    }
+
+    Badger() {
+        Object(name: "Joe");
+    }
+}

--- a/test cases/vala/17 plain consumer/meson.build
+++ b/test cases/vala/17 plain consumer/meson.build
@@ -1,0 +1,12 @@
+project('plain consumer', 'vala', 'c')
+
+deps = [dependency('glib-2.0'), dependency('gobject-2.0')]
+
+badger = static_library('badger', 'badger.vala',
+  dependencies : deps)
+
+app = executable('app', 'app.c',
+  link_with : badger,
+  dependencies : deps)
+
+test('valaplainconsumertest', app)


### PR DESCRIPTION
Simplified version of #1779, which also covers the case where a non-Vala
target consumes a Vala target.