### PR TITLE
Make vs_module_defs: do something for gcc on Windows as well

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -582,7 +582,7 @@ Builds a shared library with the given sources. Positional and keyword arguments
 
 - `version` a string specifying the version of this shared library, such as `1.1.0`. On Linux and OS X, this is used to set the shared library version in the filename, such as `libfoo.so.1.1.0` and `libfoo.1.1.0.dylib`. If this is not specified, `soversion` is used instead (see below).
 - `soversion` a string specifying the soversion of this shared library, such as `0`. On Linux and Windows this is used to set the soversion (or equivalent) in the filename. For example, if `soversion` is `4`, a Windows DLL will be called `foo-4.dll` and one of the aliases of the Linux shared library would be `libfoo.so.4`. If this is not specified, the first part of `version` is used instead. For example, if `version` is `3.6.0` and `soversion` is not defined, it is set to `3`.
-- `vs_module_defs` a string pointing to a file or a File object that contains Visual Studio symbol export definitions.
+- `vs_module_defs` a string pointing to a file or a File object that is a Microsoft module definition file for controlling symbol exports, etc., on platforms where that is possible (e.g. Windows).
 
 ### shared_module()
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2179,10 +2179,10 @@ rule FORTRAN_DEP_HACK
             commands += linker.get_soname_args(target.prefix, target.name, target.suffix,
                                                abspath, target.soversion,
                                                isinstance(target, build.SharedModule))
-            # This is only visited when using the Visual Studio toolchain
+            # This is only visited when building for Windows using either GCC or Visual Studio
             if target.vs_module_defs and hasattr(linker, 'gen_vs_module_defs_args'):
                 commands += linker.gen_vs_module_defs_args(target.vs_module_defs.rel_to_builddir(self.build_to_src))
-            # This is only visited when building for Windows using either MinGW/GCC or Visual Studio
+            # This is only visited when building for Windows using either GCC or Visual Studio
             if target.import_filename:
                 commands += linker.gen_import_library_args(os.path.join(target.subdir, target.import_filename))
         elif isinstance(target, build.StaticLibrary):

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -2451,6 +2451,16 @@ class GnuCompiler:
     def get_link_whole_for(self, args):
         return ['-Wl,--whole-archive'] + args + ['-Wl,--no-whole-archive']
 
+    def gen_vs_module_defs_args(self, defsfile):
+        if not isinstance(defsfile, str):
+            raise RuntimeError('Module definitions file should be str')
+        # On Windows targets, .def files may be specified on the linker command
+        # line like an object file.
+        if self.gcc_type in (GCC_CYGWIN, GCC_MINGW):
+            return [defsfile]
+        # For other targets, discard the .def file.
+        return []
+
 
 class GnuCCompiler(GnuCompiler, CCompiler):
     def __init__(self, exelist, version, gcc_type, is_cross, exe_wrapper=None, defines=None):

--- a/test cases/windows/10 vs module defs generated/meson.build
+++ b/test cases/windows/10 vs module defs generated/meson.build
@@ -1,7 +1,5 @@
 project('generated_dll_module_defs', 'c')
 
-if meson.get_compiler('c').get_id() == 'msvc'
-  subdir('subdir')
-  exe = executable('prog', 'prog.c', link_with : shlib)
-  test('runtest', exe)
-endif
+subdir('subdir')
+exe = executable('prog', 'prog.c', link_with : shlib)
+test('runtest', exe)

--- a/test cases/windows/10 vs module defs generated/subdir/somedll.c
+++ b/test cases/windows/10 vs module defs generated/subdir/somedll.c
@@ -1,5 +1,3 @@
-#ifdef _MSC_VER
 int somedllfunc() {
     return 42;
 }
-#endif

--- a/test cases/windows/6 vs module defs/meson.build
+++ b/test cases/windows/6 vs module defs/meson.build
@@ -1,7 +1,5 @@
 project('dll_module_defs', 'c')
 
-if meson.get_compiler('c').get_id() == 'msvc'
-  subdir('subdir')
-  exe = executable('prog', 'prog.c', link_with : shlib)
-  test('runtest', exe)
-endif
+subdir('subdir')
+exe = executable('prog', 'prog.c', link_with : shlib)
+test('runtest', exe)

--- a/test cases/windows/6 vs module defs/subdir/somedll.c
+++ b/test cases/windows/6 vs module defs/subdir/somedll.c
@@ -1,5 +1,3 @@
-#ifdef _MSC_VER
 int somedllfunc() {
     return 42;
 }
-#endif


### PR DESCRIPTION
Module definition files may be useful when building with gcc on Windows also
(e.g. if the existing build uses them, if exports are aliased, if we were
retro enough to export by ordinal, etc.)

Add the .def file to the link command line when using gcc on Windows

Run the appropriate windows tests irrespective of compiler.