### PR TITLE
gtestdependency: find libraries using the compiler

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -639,3 +639,16 @@ def find_external_dependency(name, environment, kwargs):
         raise pkg_exc
     mlog.log('Dependency', mlog.bold(name), 'found:', mlog.red('NO'))
     return pkgdep
+
+def dependency_get_compiler(language, environment, kwargs):
+    if 'native' in kwargs and environment.is_cross_build():
+        want_cross = not kwargs['native']
+    else:
+        want_cross = environment.is_cross_build()
+
+    if want_cross:
+        compilers = environment.coredata.cross_compilers
+    else:
+        compilers = environment.coredata.compilers
+
+    return compilers.get(language, None)

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -105,16 +105,14 @@ class GMockDependency(Dependency):
         # GMock may be a library or just source.
         # Work with both.
         self.name = 'gmock'
-        self.libname = 'libgmock.so'
-        trial_dirs = mesonlib.get_library_dirs()
-        gmock_found = False
-        for d in trial_dirs:
-            if os.path.isfile(os.path.join(d, self.libname)):
-                gmock_found = True
-        if gmock_found:
+        cpp_compiler = dependency_get_compiler('cpp', environment, kwargs)
+        if cpp_compiler is None:
+            raise DependencyException('Tried to use gmock but a C++ compiler is not defined.')
+        gmock_detect = cpp_compiler.find_library("gmock", environment, [])
+        if gmock_detect:
             self.is_found = True
             self.compile_args = []
-            self.link_args = ['-lgmock']
+            self.link_args = gmock_detect
             self.sources = []
             mlog.log('Dependency GMock found:', mlog.green('YES'), '(prebuilt)')
             return


### PR DESCRIPTION
Use the compiler object to find gtest libraries. Fixes the following
cases:
- cross compiling looked in host library paths
- static libgtest was not supported