### PR TITLE
ninja: Deduplicate dependent vapis

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -20,7 +20,7 @@ from .. import mlog
 from .. import dependencies
 from .. import compilers
 from ..compilers import CompilerArgs
-from ..mesonlib import File, MesonException
+from ..mesonlib import File, MesonException, OrderedSet
 from ..mesonlib import get_meson_script, get_compiler_for_source, Popen_safe
 from .backends import CleanTrees, InstallData
 from ..build import InvalidArguments
@@ -976,7 +976,7 @@ int dummy;
         the same name as the BuildTarget and return the path to it relative to
         the build directory.
         """
-        result = []
+        result = OrderedSet()
         for dep in target.link_targets:
             for i in dep.sources:
                 if hasattr(i, 'fname'):
@@ -984,9 +984,9 @@ int dummy;
                 if i.endswith('vala'):
                     vapiname = dep.name + '.vapi'
                     fullname = os.path.join(self.get_target_dir(dep), vapiname)
-                    result.append(fullname)
+                    result.add(fullname)
                     break
-        return result
+        return list(result)
 
     def split_vala_sources(self, t):
         """

--- a/test cases/vala/18 vapi consumed twice/app.vala
+++ b/test cases/vala/18 vapi consumed twice/app.vala
@@ -1,0 +1,11 @@
+namespace App {
+    public static int main(string[] args) {
+        var person = new Person();
+        print("Favorite beer of \"%s\" is %s\n", person.name, person.favorite_beer.flavor);
+
+        var beer = new Beer("tasty");
+        print("This beer is %s\n", beer.flavor);
+
+        return 0;
+    }
+}

--- a/test cases/vala/18 vapi consumed twice/beer.vala
+++ b/test cases/vala/18 vapi consumed twice/beer.vala
@@ -1,0 +1,10 @@
+public class Beer : Object {
+    public string flavor {
+        get;
+        construct;
+    }
+
+    public Beer(string flavor) {
+        Object(flavor: flavor);
+    }
+}

--- a/test cases/vala/18 vapi consumed twice/meson.build
+++ b/test cases/vala/18 vapi consumed twice/meson.build
@@ -1,0 +1,15 @@
+project('vapi consumed twice', 'vala', 'c')
+
+base_deps = [dependency('glib-2.0'), dependency('gobject-2.0')]
+
+beer = library('beer', 'beer.vala', dependencies : base_deps)
+beer_dep = declare_dependency(link_with : beer)
+
+person = library('person', 'person.vala', link_with : beer,
+  dependencies : base_deps)
+person_dep = declare_dependency(link_with : person, dependencies : [beer_dep])
+
+app = executable('app', 'app.vala',
+  dependencies : base_deps + [person_dep, beer_dep])
+
+test('valavapiconsumedtwicetest', app)

--- a/test cases/vala/18 vapi consumed twice/person.vala
+++ b/test cases/vala/18 vapi consumed twice/person.vala
@@ -1,0 +1,16 @@
+public class Person : Object {
+    public string name {
+        get {
+            return "Joe Badger";
+        }
+    }
+
+    public Beer favorite_beer {
+        get;
+        construct;
+    }
+
+    public Person() {
+        Object(favorite_beer: new Beer("smooth"));
+    }
+}


### PR DESCRIPTION
The Vala compiler does not like being fed the same `.vapi` multiple times.

Test-case may seem a bit weird, had a hard time distilling this one down
into a minimal test-case. This kind of situations arise if a project has
an internal library and this library is consumed directly and indirectly
by multiple targets.