### PR TITLE
Implement executable(gui_app:) for gcc on Windows

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2169,6 +2169,9 @@ rule FORTRAN_DEP_HACK
         if isinstance(target, build.Executable):
             # Currently only used with the Swift compiler to add '-emit-executable'
             commands += linker.get_std_exe_link_args()
+            # If gui_app, and that's significant on this platform
+            if target.gui_app and hasattr(linker, 'get_gui_app_args'):
+                commands += linker.get_gui_app_args()
         elif isinstance(target, build.SharedLibrary):
             if isinstance(target, build.SharedModule):
                 commands += linker.get_std_shared_module_link_args()

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -2461,6 +2461,10 @@ class GnuCompiler:
         # For other targets, discard the .def file.
         return []
 
+    def get_gui_app_args(self):
+        if self.gcc_type in (GCC_CYGWIN, GCC_MINGW):
+            return ['-mwindows']
+        return []
 
 class GnuCCompiler(GnuCompiler, CCompiler):
     def __init__(self, exelist, version, gcc_type, is_cross, exe_wrapper=None, defines=None):


### PR DESCRIPTION
Note that gui_app: is currently ignored when using the ninja backend with VS
compilers, so I guess you get the default linker behaviour, which the
documentation says is guessing the subsystem depending on if a main or
WinMain symbol exists...