### PR TITLE
interpreter: Prevent targets from using 'meson-' prefix

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2227,6 +2227,8 @@ class Interpreter(InterpreterBase):
             raise InvalidArguments('Subdir contains ..')
         if self.subdir == '' and args[0] == self.subproject_dir:
             raise InvalidArguments('Must not go into subprojects dir with subdir(), use subproject() instead.')
+        if self.subdir == '' and args[0].startswith('meson-'):
+            raise InvalidArguments('The "meson-" prefix is reserved and cannot be used for top-level subdir().')
         prev_subdir = self.subdir
         subdir = os.path.join(prev_subdir, args[0])
         if os.path.isabs(subdir):

--- a/test cases/failing/51 reserved meson prefix/meson.build
+++ b/test cases/failing/51 reserved meson prefix/meson.build
@@ -1,0 +1,3 @@
+project('test')
+
+subdir('meson-foo')


### PR DESCRIPTION
It's currently possible to break Meson by having a subdir named `meson-private` or a target named `meson-logs`.

Ideally we want to prevent this before people start thinking it's a good idea to name stuff this way.

There's also `build.ninja` and `custom_commands.json` that should be protected this way.