### PR TITLE
gnome: add mkenums_simple()

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -72,6 +72,12 @@ Returns an array of two elements which are: `[c_source, header_file]`
 
 Generates enum files for GObject using the `glib-mkenums` tool. The first argument is the base name of the output files.
 
+This method is essentially a wrapper around the `glib-mkenums` tool's command line API. It is the most featureful method for enum creation.
+
+Typically you either provide template files or you specify the various template sections manually as strings.
+
+Most libraries and applications will be using the same standard template with only minor tweaks, in which case the `gnome.mkenums_simple()` convenience method can be used instead.
+
 Note that if you `#include` the generated header in any of the sources for a build target, you must add the generated header to the build target's list of sources to codify the dependency. This is true for all generated sources, not just `mkenums`.
 
 * `sources`: the list of sources to make enums with
@@ -90,6 +96,49 @@ Note that if you `#include` the generated header in any of the sources for a bui
 * `vtail`: value tail
 
 *Added 0.35.0*
+
+Returns an array of two elements which are: `[c_source, header_file]`
+
+### gnome.mkenums_simple()
+
+Generates enum `.c` and `.h` files for GObject using the `glib-mkenums` tool
+with the standard template used by most GObject-based C libraries. The first
+argument is the base name of the output files.
+
+Note that if you `#include` the generated header in any of the sources for a
+build target, you must add the generated header to the build target's list of
+sources to codify the dependency. This is true for all generated sources, not
+just `mkenums_simple`.
+
+* `sources`: the list of sources to make enums with
+* `install_header`: if true, install the generated header
+* `install_dir`: directory to install the header
+* `identifier_prefix`: prefix to use for the identifiers
+* `symbol_prefix`: prefix to use for the symbols
+* `header_prefix`: additional prefix at the top of the header file, e.g. for extra includes (which may be needed if you specify a decorator for the function declarations)
+* `decorator`: optional decorator for the function declarations, e.g. `GTK_AVAILABLE` or `GST_EXPORT`
+* `function_prefix`: additional prefix for function names, e.g. in case you want to add a leading underscore to functions used only internally
+* `body_prefix`: additional prefix at the top of the body file, e.g. for extra includes
+
+Example:
+
+```meson
+gnome = import('gnome')
+
+my_headers = ['myheader1.h', 'myheader2.h']
+my_sources = ['mysource1.c', 'mysource2.c']
+
+# will generate myenums.c and myenums.h based on enums in myheader1.h and myheader2.h
+enums = gnome.mkenums_simple('myenums', sources : my_headers)
+
+mylib = library('my', my_sources, enums,
+                include_directories: my_incs,
+                dependencies: my_deps,
+                c_args: my_cargs,
+                install: true)
+```
+
+*Added 0.42.0*
 
 Returns an array of two elements which are: `[c_source, header_file]`
 

--- a/docs/markdown/Release-notes-for-0.42.0.md
+++ b/docs/markdown/Release-notes-for-0.42.0.md
@@ -140,3 +140,10 @@ using the `pcap-config` tool. It is used like any other dependency:
 ```meson
 pcap_dep = dependency('pcap', version : '>=1.0')
 ```
+
+## GNOME module mkenums_simple() addition
+
+Most libraries and applications use the same standard templates for
+glib-mkenums. There is now a new `mkenums_simple()` convenience method
+that passes those default templates to glib-mkenums and allows some tweaks
+such as optional function decorators or leading underscores.

--- a/test cases/frameworks/7 gnome/mkenums/main4.c
+++ b/test cases/frameworks/7 gnome/mkenums/main4.c
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <string.h>
+#include <glib-object.h>
+#include "enums4.h"
+#include "meson-sample.h"
+
+int main(int argc, char **argv) {
+    GEnumClass *xenum = g_type_class_ref(MESON_TYPE_THE_XENUM);
+    GFlagsClass *flags_enum = g_type_class_ref(MESON_TYPE_THE_FLAGS_ENUM);
+    if (g_enum_get_value_by_name(xenum, "MESON_THE_XVALUE")->value != MESON_THE_XVALUE) {
+        fprintf(stderr, "Get MESON_THE_XVALUE by name failed.\n");
+        return 1;
+    }
+    if (g_enum_get_value_by_nick(xenum, "the-xvalue")->value != MESON_THE_XVALUE) {
+        fprintf(stderr, "Get MESON_THE_XVALUE by nick failed.\n");
+        return 2;
+    }
+    if (g_flags_get_value_by_name(flags_enum, "MESON_THE_FIRST_VALUE")->value != MESON_THE_FIRST_VALUE) {
+        fprintf(stderr, "Get MESON_THE_FIRST_VALUE by name failed.\n");
+        return 3;
+    }
+    if (g_flags_get_value_by_nick(flags_enum, "the-first-value")->value != MESON_THE_FIRST_VALUE) {
+        fprintf(stderr, "Get MESON_THE_FIRST_VALUE by nick failed.\n");
+        return 4;
+    }
+
+    /* Make sure that funcs are generated with leading underscore as requested */
+    if (!_meson_the_xenum_get_type())
+      g_error ("Bad!");
+
+    g_type_class_unref(xenum);
+    g_type_class_unref(flags_enum);
+    fprintf(stderr, "All ok.\n");
+    return 0;
+}

--- a/test cases/frameworks/7 gnome/mkenums/main5.c
+++ b/test cases/frameworks/7 gnome/mkenums/main5.c
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <string.h>
+#include <glib-object.h>
+#include "enums5.h"
+#include "meson-sample.h"
+
+int main(int argc, char **argv) {
+    GEnumClass *xenum = g_type_class_ref(MESON_TYPE_THE_XENUM);
+    GFlagsClass *flags_enum = g_type_class_ref(MESON_TYPE_THE_FLAGS_ENUM);
+    if (g_enum_get_value_by_name(xenum, "MESON_THE_XVALUE")->value != MESON_THE_XVALUE) {
+        fprintf(stderr, "Get MESON_THE_XVALUE by name failed.\n");
+        return 1;
+    }
+    if (g_enum_get_value_by_nick(xenum, "the-xvalue")->value != MESON_THE_XVALUE) {
+        fprintf(stderr, "Get MESON_THE_XVALUE by nick failed.\n");
+        return 2;
+    }
+    if (g_flags_get_value_by_name(flags_enum, "MESON_THE_FIRST_VALUE")->value != MESON_THE_FIRST_VALUE) {
+        fprintf(stderr, "Get MESON_THE_FIRST_VALUE by name failed.\n");
+        return 3;
+    }
+    if (g_flags_get_value_by_nick(flags_enum, "the-first-value")->value != MESON_THE_FIRST_VALUE) {
+        fprintf(stderr, "Get MESON_THE_FIRST_VALUE by nick failed.\n");
+        return 4;
+    }
+
+    /* Make sure that funcs do not have any extra prefix */
+    if (!meson_the_xenum_get_type())
+      g_error ("Bad!");
+
+    g_type_class_unref(xenum);
+    g_type_class_unref(flags_enum);
+    fprintf(stderr, "All ok.\n");
+    return 0;
+}

--- a/test cases/frameworks/7 gnome/mkenums/meson-decls.h
+++ b/test cases/frameworks/7 gnome/mkenums/meson-decls.h
@@ -1,0 +1,2 @@
+#pragma once
+#define MESON_EXPORT extern

--- a/test cases/frameworks/7 gnome/mkenums/meson.build
+++ b/test cases/frameworks/7 gnome/mkenums/meson.build
@@ -117,3 +117,12 @@ main = configure_file(
 enumexe3 = executable('enumprog3', main, enums_c3, enums_h3,
 dependencies : gobj)
 test('enum test 3', enumexe3)
+
+enums4 = gnome.mkenums_simple('enums4', sources : 'meson-sample.h',
+                              function_prefix : '_')
+enumexe4 = executable('enumprog4', 'main4.c', enums4, dependencies : gobj)
+
+enums5 = gnome.mkenums_simple('enums5', sources : 'meson-sample.h',
+                              decorator : 'MESON_EXPORT',
+                              header_prefix : '#include "meson-decls.h"')
+enumexe5 = executable('enumprog5', main, enums5, dependencies : gobj)


### PR DESCRIPTION
99% of all mkenums uses in C libraries use the same basic template,
so add a mkenums_simple() function that takes care of everything for
us based on that template.

Features:
 - optional function declaration decorator such as GLIB_AVAILABLE
 - optional extra header prefix (e.g. for include needed for decorator)
 - optional function prefix (e.g. to add leading underscores)

Fixes issue #1384