### PR TITLE
interpreter: Add meson.get_cross_binary()

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -702,6 +702,8 @@ The `meson` object allows you to introspect various properties of the system. Th
 
 - `version()` return a string with the version of Meson.
 
+- `get_cross_binary(binname, fallback_value)` returns the given binary from a cross file, the optional second argument is returned if not cross compiling or the given binary is not specified.
+
 - `get_cross_property(propname, fallback_value)` returns the given property from a cross file, the optional second argument is returned if not cross compiling or the given property is not found.
 
 - `install_dependency_manifest(output_name)` installs a manifest file containing a list of all subprojects, their versions and license files to the file name given as the argument.

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -897,6 +897,9 @@ class CrossBuildInfo:
     def get_stdlib(self, language):
         return self.config['properties'][language + '_stdlib']
 
+    def get_binaries(self):
+        return self.config['binaries']
+
     def get_properties(self):
         return self.config['properties']
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1079,6 +1079,7 @@ class MesonMain(InterpreterObject):
                              'project_version': self.project_version_method,
                              'version': self.version_method,
                              'project_name': self.project_name_method,
+                             'get_cross_binary': self.get_cross_binary_method,
                              'get_cross_property': self.get_cross_property_method,
                              'backend': self.backend_method,
                              })
@@ -1195,6 +1196,20 @@ class MesonMain(InterpreterObject):
 
     def project_name_method(self, args, kwargs):
         return self.interpreter.active_projectname
+
+    def get_cross_binary_method(self, args, kwargs):
+        if len(args) < 1 or len(args) > 2:
+            raise InterpreterException('Must have one or two arguments.')
+        binname = args[0]
+        if not isinstance(binname, str):
+            raise InterpreterException('Binary name must be string.')
+        try:
+            binaries = self.interpreter.environment.cross_info.get_binaries()
+            return binaries[binname]
+        except Exception:
+            if len(args) == 2:
+                return args[1]
+            raise InterpreterException('Unknown cross binary: %s.' % binname)
 
     def get_cross_property_method(self, args, kwargs):
         if len(args) < 1 or len(args) > 2:


### PR DESCRIPTION
Analogous to `meson.get_cross_property()`.

Useful in cases where a `custom_target()` needs to e.g. use the cross-
environment's `strip` tool in order to generate a stripped version of
a given input before codesigning and embedding it in a library.