### PR TITLE
environment: Improve for_darwin() to cover additional flavors.

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -209,7 +209,7 @@ def for_darwin(is_cross, env):
     if not is_cross:
         return mesonlib.is_osx()
     elif env.cross_info.has_host():
-        return env.cross_info.config['host_machine']['system'] == 'darwin'
+        return env.cross_info.config['host_machine']['system'] in ('darwin', 'macos', 'ios', 'tvos', 'watchos')
     return False
 
 


### PR DESCRIPTION
Note that the `host_machine.system` property should be the specific system
and not its family, otherwise we will assume that we can run iOS Simulator
binaries on macOS.

Technically the simulator flavors are separate targets, but wasn't sure if I
should take it that far or how to name them.