### PR TITLE
fix lookup of boost modules when cross-compiling on osx

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -202,7 +202,7 @@ class BoostDependency(Dependency):
             self.lib_modules_mt[modname] = fname
 
     def detect_lib_modules_nix(self):
-        if mesonlib.is_osx():
+        if mesonlib.is_osx() and not self.want_cross:
             libsuffix = 'dylib'
         else:
             libsuffix = 'so'


### PR DESCRIPTION
Hi,

when cross-compiling for android-ndk on osx we noticed that the boost dependencies are not being picked up at linking time.

It seems the current code simply assumes .dylib on osx, and since we're cross compiling it there the .libs will be .so.

Many thanks