### PR TITLE
Target file name must not contain a path separator as that breaks things.

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -268,6 +268,8 @@ class EnvironmentVariables:
 
 class Target:
     def __init__(self, name, subdir, build_by_default):
+        if '/' in name or '\\' in name:
+            raise InvalidArguments('Target name must not contain a path separator.')
         self.name = name
         self.subdir = subdir
         self.build_by_default = build_by_default

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2593,7 +2593,14 @@ different subdirectory.
         else:
             mlog.debug('Unknown target type:', str(targetholder))
             raise RuntimeError('Unreachable code')
-        target = targetclass(name, self.subdir, self.subproject, is_cross, sources, objs, self.environment, kwargs)
+        # Fix failing test 53 when removing this.
+        if '/' in name or '\\' in name:
+            mlog.warning('Target name must not contain a path separator. This will become a hard error in a future release.')
+            subpart, name = os.path.split(name)
+            subdir = os.path.join(self.subdir, subpart)
+        else:
+            subdir = self.subdir
+        target = targetclass(name, subdir, self.subproject, is_cross, sources, objs, self.environment, kwargs)
         if is_cross:
             self.add_cross_stdlib_info(target)
         l = targetholder(target, self)

--- a/test cases/failing/53 slashname/meson.build
+++ b/test cases/failing/53 slashname/meson.build
@@ -1,0 +1,12 @@
+project('slashname', 'c')
+
+# Traverse this subdir so the corresponding dir
+# is created inside the build dir.
+subdir('sub')
+
+# Try to create an executable that would go in the "sub" dir
+# inside the build dir. This is prohibited.
+executable('sub/prog', pf)
+
+error('Re-enable me once slash in name is finally prohibited.')
+

--- a/test cases/failing/53 slashname/sub/meson.build
+++ b/test cases/failing/53 slashname/sub/meson.build
@@ -1,0 +1,2 @@
+pf = files('prog.c')
+

--- a/test cases/failing/53 slashname/sub/prog.c
+++ b/test cases/failing/53 slashname/sub/prog.c
@@ -1,0 +1,6 @@
+#include<stdio.h>
+
+int main(int argc, char **argv) {
+    printf("I should not be run ever.\n");
+    return 1;
+}


### PR DESCRIPTION
Note that this change will break GStreamer. They have (by accident probably) test targets that are named `somedir/testname` which then get output into a different directory than all other code is expecting. As an example evaluating relative rpaths breaks.

I made this error out. If this is too harsh we could make it into a deprecation instead and manually move the path segment from the target name to the subdir part. But eventually this will become a hard error because all our documentation says that targets go in the corresponding build dir.