### PR TITLE
Add 'compiles' and 'has_multi_arguments' for dlang.

### DIFF
--- a/test cases/d/8 has multi arguments/meson.build
+++ b/test cases/d/8 has multi arguments/meson.build
@@ -2,5 +2,15 @@ project('D has arguments test', 'd')
 
 compiler = meson.get_compiler('d')
 
-compiler.compiles('int i;')
-compiler.has_argument('-I.')
+if not compiler.compiles('int i;')
+  error(''.join(['compiles is broken for d compiler: ', compiler.get_id()]))
+endif
+if not compiler.has_multi_arguments(['-I.', '-J.'])
+  error(''.join(['has_multi_arguments is broken for d compiler: ', compiler.get_id()]))
+endif
+if not compiler.has_argument('-I.')
+  error(''.join(['has_argument is broken for d compiler: ', compiler.get_id()]))
+endif
+if compiler.has_argument('-flag_a_d_compiler_defenaitly_does_not_have')
+  error(''.join(['has_argument is broken for d compiler: ', compiler.get_id()]))
+endif

--- a/test cases/d/8 has multi arguments/meson.build
+++ b/test cases/d/8 has multi arguments/meson.build
@@ -1,0 +1,6 @@
+project('D has arguments test', 'd')
+
+compiler = meson.get_compiler('d')
+
+compiler.compiles('int i;')
+compiler.has_argument('-I.')

--- a/test cases/d/8 has multi arguments/meson.build
+++ b/test cases/d/8 has multi arguments/meson.build
@@ -2,15 +2,7 @@ project('D has arguments test', 'd')
 
 compiler = meson.get_compiler('d')
 
-if not compiler.compiles('int i;')
-  error(''.join(['compiles is broken for d compiler: ', compiler.get_id()]))
-endif
-if not compiler.has_multi_arguments(['-I.', '-J.'])
-  error(''.join(['has_multi_arguments is broken for d compiler: ', compiler.get_id()]))
-endif
-if not compiler.has_argument('-I.')
-  error(''.join(['has_argument is broken for d compiler: ', compiler.get_id()]))
-endif
-if compiler.has_argument('-flag_a_d_compiler_defenaitly_does_not_have')
-  error(''.join(['has_argument is broken for d compiler: ', compiler.get_id()]))
-endif
+assert(compiler.compiles('int i;'), 'Basic code test does not comple: ' + compiler.get_id())
+assert(compiler.has_multi_arguments(['-I.', '-J.']), 'Multi argument test does not work: ' + compiler.get_id())
+assert(compiler.has_argument('-I.'), 'Basic argument test does not work: ' + compiler.get_id())
+assert(compiler.has_argument('-flag_a_d_compiler_defenaitly_does_not_have') == false, 'Basic argument test does not work: ' + compiler.get_id())


### PR DESCRIPTION
Add the `compiles` and `has_multi_arguments` to the DCompiler objects, so we can check for supported arguments when using dlang.

One thing to note is that `dependency.get_compile_args()` usually results in arguments the D compiler doesn't support, but that currently also happens when using a `build_target` with a dependency.