### PR TITLE
cross: Fix host_machine.system in the example iphone cross config.

### DIFF
--- a/cross/iphone.txt
+++ b/cross/iphone.txt
@@ -20,7 +20,7 @@ has_function_printf = true
 has_function_hfkerhisadf = false
 
 [host_machine]
-system = 'ios'
+system = 'darwin'
 cpu_family = 'arm'
 cpu = 'armv7'
 endian = 'little'


### PR DESCRIPTION
To avoid confusing users about the semantics of this field.

See #1821 for details.