### PR TITLE
Update the Frida URL and description.

### DIFF
--- a/docs/markdown/Users.md
+++ b/docs/markdown/Users.md
@@ -9,7 +9,7 @@ If you have a project that uses Meson that you want to add to this list, let us 
  - [AQEMU](https://github.com/tobimensch/aqemu), a Qt GUI for QEMU virtual machines, since version 0.9.3
  - [Arduino sample project](https://github.com/jpakkane/mesonarduino)
  - [Emeus](https://github.com/ebassi/emeus), Constraint based layout manager for GTK+
- - [Frida.re](https://github.com/frida/frida-core), a code tracing framework
+ - [Frida](https://www.frida.re/), a dynamic binary instrumentation toolkit
  - [GLib](https://github.com/centricular/glib/), cross-platform C library used by GTK+ (not merged yet)
  - [Gnome Builder](https://git.gnome.org/browse/gnome-builder/), an IDE for the Gnome platform
  - [Gnome MPV](https://github.com/gnome-mpv/gnome-mpv), Gnome frontend to the mpv video player


### PR DESCRIPTION
The website is a bit friendlier than the GitHub repos, though it currently
focuses a bit too much on the code tracing use-cases but I plan on
improving that. (To highlight that it is also designed for building application-
specific developer tools, fault-injection, augmenting existing applications
e.g. building a HUD for an existing game, testing, UI automation, creating
Pokémon Go cheats, building custom fuzzers, etc.)