### PR TITLE
mesontest: use unbuffered IO

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -812,7 +812,7 @@ int dummy;
     def generate_tests(self, outfile):
         self.serialize_tests()
         test_exe = get_meson_script(self.environment, 'mesontest')
-        cmd = [sys.executable, test_exe, '--no-rebuild']
+        cmd = [sys.executable, '-u', test_exe, '--no-rebuild']
         if not self.environment.coredata.get_builtin_option('stdsplit'):
             cmd += ['--no-stdsplit']
         if self.environment.coredata.get_builtin_option('errorlogs'):
@@ -824,7 +824,7 @@ int dummy;
         elem.write(outfile)
 
         # And then benchmarks.
-        cmd = [sys.executable, test_exe, '--benchmark', '--logbase',
+        cmd = [sys.executable, '-u', test_exe, '--benchmark', '--logbase',
                'benchmarklog', '--num-processes=1', '--no-rebuild']
         elem = NinjaBuildElement(self.all_outputs, 'benchmark', 'CUSTOM_COMMAND', ['all', 'PHONY'])
         elem.add_item('COMMAND', cmd)

--- a/mesontest.py
+++ b/mesontest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3 -u
 
 # Copyright 2016 The Meson development team
 


### PR DESCRIPTION
This helps when running mesontest as part of CI.

Closes #1805 

This is needed because I have a project with has ~40 tests and takes about 20 minutes total. Without this fix, I can't see the output of `mesontest` until the test is complete.