### PR TITLE
Add support for objc_args and objcpp_args

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -29,6 +29,7 @@ known_basic_kwargs = {'install': True,
                       'cpp_pch': True,
                       'c_args': True,
                       'objc_args': True,
+                      'objcpp_args': True,
                       'cpp_args': True,
                       'cs_args': True,
                       'vala_args': True,
@@ -632,6 +633,10 @@ class BuildTarget(Target):
         if not isinstance(objclist, list):
           objclist = [objclist]
         self.add_compiler_args('objc', objclist)
+        objcpplist = kwargs.get('objcpp_args', [])
+        if not isinstance(objcpplist, list):
+          objcpplist = [objcpplist]
+        self.add_compiler_args('objcpp', objcpplist)
         fortranlist = kwargs.get('fortran_args', [])
         if not isinstance(fortranlist, list):
             fortranlist = [fortranlist]

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -28,6 +28,7 @@ known_basic_kwargs = {'install': True,
                       'c_pch': True,
                       'cpp_pch': True,
                       'c_args': True,
+                      'objc_args': True,
                       'cpp_args': True,
                       'cs_args': True,
                       'vala_args': True,
@@ -627,6 +628,10 @@ class BuildTarget(Target):
         if not isinstance(valalist, list):
             valalist = [valalist]
         self.add_compiler_args('vala', valalist)
+        objclist = kwargs.get('objc_args', [])
+        if not isinstance(objclist, list):
+          objclist = [objclist]
+        self.add_compiler_args('objc', objclist)
         fortranlist = kwargs.get('fortran_args', [])
         if not isinstance(fortranlist, list):
             fortranlist = [fortranlist]

--- a/test cases/objc/4 objc args/meson.build
+++ b/test cases/objc/4 objc args/meson.build
@@ -1,0 +1,4 @@
+project('objective c args', 'objc')
+
+exe = executable('prog', 'prog.m', objc_args : ['-DMESON_TEST'])
+test('objective c args', exe)

--- a/test cases/objc/4 objc args/prog.m
+++ b/test cases/objc/4 objc args/prog.m
@@ -1,0 +1,11 @@
+#import<stdio.h>
+
+int main(int argc, char **argv)
+{
+#ifdef MESON_TEST
+  int x = 3;
+#endif
+
+  printf("x = %d\n", x);
+  return 0;
+}

--- a/test cases/objc/5 objc++ args/meson.build
+++ b/test cases/objc/5 objc++ args/meson.build
@@ -1,0 +1,4 @@
+project('objective c++ args', 'objcpp')
+
+exe = executable('prog', 'prog.mm', objcpp_args : ['-DMESON_OBJCPP_TEST'])
+test('objective c++ args', exe)

--- a/test cases/objc/5 objc++ args/prog.mm
+++ b/test cases/objc/5 objc++ args/prog.mm
@@ -1,0 +1,16 @@
+#import<stdio.h>
+
+class TestClass
+{
+};
+
+int main(int argc, char **argv)
+{
+#ifdef MESON_OBJCPP_TEST
+int x = 1;
+#endif
+
+  printf("x = %x\n", x);
+
+  return 0;
+}


### PR DESCRIPTION
These commits add support for the objc_args and objcpp_args which allow options
to be passed to the Objecte-C and Objective-C++ compilers respectively. It's meant
for #1766.

Suggestions are welcome.