### PR TITLE
environment: Read VALAC from the environment and use it if set

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -633,7 +633,10 @@ class Environment:
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
 
     def detect_vala_compiler(self):
-        exelist = ['valac']
+        if 'VALAC' in os.environ:
+            exelist = shlex.split(os.environ['VALAC'])
+        else:
+            exelist = ['valac']
         try:
             p, out = Popen_safe(exelist + ['--version'])[0:2]
         except OSError:


### PR DESCRIPTION
The valac binary was hard coded in meson. We now check if VALAC is
defined in the environment, and if it is, use its value as the vala
compiler, if not, we proceed with the hard coded binary name.

This is meant for #1645, I don't really know how to provide a test case for this, as it will
require two vala compilers in the environment. Nonetheless, I hope this will be useful,
even as a starting point.