### PR TITLE
Add static flag for Boost dependency

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2017 The Meson development team
+﻿# Copyright 2013-2017 The Meson development team
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ class BoostDependency(Dependency):
         self.name = 'boost'
         self.environment = environment
         self.libdir = ''
+        self.static = kwargs.get('static', False)
         if 'native' in kwargs and environment.is_cross_build():
             self.want_cross = not kwargs['native']
         else:
@@ -194,7 +195,7 @@ class BoostDependency(Dependency):
             return
         libdir = libdir[0]
         self.libdir = libdir
-        globber = 'boost_*-gd-*.lib'  # FIXME
+        globber = 'libboost_*-gd-*.lib' if self.static else 'boost_*-gd-*.lib'  # FIXME
         for entry in glob.glob(os.path.join(libdir, globber)):
             (_, fname) = os.path.split(entry)
             base = fname.split('_', 1)[1]

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -203,7 +203,9 @@ class BoostDependency(Dependency):
             self.lib_modules_mt[modname] = fname
 
     def detect_lib_modules_nix(self):
-        if mesonlib.is_osx() and not self.want_cross:
+        if self.static:
+            libsuffix = 'a'
+        elif mesonlib.is_osx() and not self.want_cross:
             libsuffix = 'dylib'
         else:
             libsuffix = 'so'
@@ -221,7 +223,7 @@ class BoostDependency(Dependency):
                 name = lib.split('.')[0].split('_', 1)[-1]
                 # I'm not 100% sure what to do here. Some distros
                 # have modules such as thread only as -mt versions.
-                if entry.endswith('-mt.so'):
+                if entry.endswith('-mt.{}'.format(libsuffix)):
                     self.lib_modules_mt[name] = True
                 else:
                     self.lib_modules[name] = True

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -7,15 +7,18 @@ project('boosttest', 'cpp',
 
 nolinkdep = dependency('boost', modules: 'utility')
 linkdep = dependency('boost', modules : ['thread', 'system'])
+staticdep = dependency('boost', modules : ['thread', 'system'], static : true)
 testdep = dependency('boost', modules : 'test')
 nomoddep = dependency('boost')
 
 nolinkexe = executable('nolinkedexe', 'nolinkexe.cc', dependencies : nolinkdep)
 linkexe = executable('linkedexe', 'linkexe.cc', dependencies : linkdep)
+staticexe = executable('linkedexe', 'linkexe.cc', dependencies : staticdep)
 unitexe = executable('utf', 'unit_test.cpp', dependencies: testdep)
 nomodexe = executable('nomod', 'nomod.cpp', dependencies : nomoddep)
 
-test('Boost nolinktext', nolinkexe)
-test('Boost linktext', linkexe)
+test('Boost nolinktest', nolinkexe)
+test('Boost linktest', linkexe)
+test('Boost statictest', staticexe)
 test('Boost UTF test', unitexe)
 test('Boost nomod', nomodexe)


### PR DESCRIPTION
This is mainly to get static linking for Boost working correctly on Windows.

I patched the module-finding behavior for *nix anyway, but since the generated linker arguments omitted the file extension, the static libraries were already being properly linked.