### PR TITLE
mesontest: fix shebang

### DIFF
--- a/mesontest.py
+++ b/mesontest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3 -u
+#!/usr/bin/env python3
 
 # Copyright 2016 The Meson development team
 


### PR DESCRIPTION
This fixes

```
$ ./mesontest.py 
/usr/bin/env: ‘python3 -u’: No such file or directory
```

which was caused by #1842 - sorry

[Here](https://unix.stackexchange.com/questions/63979/shebang-line-with-usr-bin-env-command-argument-fails-on-linux) is some discussion about the issue.