### PR TITLE
Configure subsval

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -124,7 +124,7 @@ When a list of strings is passed to the `command:` keyword argument, it takes an
 These are all the supported keyword arguments:
 
 - `input` the input file name. If it's not specified in configuration mode, all the variables in the `configuration:` object (see above) are written to the `output:` file.
-- `output` the output file name. In configuration mode, the permissions of the input file (if it is specified) are copied to the output file.
+- `output` the output file name (may contain `@PLAINNAME@` or `@BASENAME@` substitutions). In configuration mode, the permissions of the input file (if it is specified) are copied to the output file.
 - `configuration` as explained above, this is where you pass the configuration data object as returned by `configuration_data()`
 - `command` as explained above, if specified, Meson does not create the file itself but rather runs the specified command, which allows you to do fully custom file generation
 - `install_dir` the subdirectory to install the generated file to (e.g. `share/myproject`), if omitted the file is not installed.

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -124,7 +124,7 @@ When a list of strings is passed to the `command:` keyword argument, it takes an
 These are all the supported keyword arguments:
 
 - `input` the input file name. If it's not specified in configuration mode, all the variables in the `configuration:` object (see above) are written to the `output:` file.
-- `output` the output file name (may contain `@PLAINNAME@` or `@BASENAME@` substitutions). In configuration mode, the permissions of the input file (if it is specified) are copied to the output file.
+- `output` the output file name (since v0.41.0, may contain `@PLAINNAME@` or `@BASENAME@` substitutions). In configuration mode, the permissions of the input file (if it is specified) are copied to the output file.
 - `configuration` as explained above, this is where you pass the configuration data object as returned by `configuration_data()`
 - `command` as explained above, if specified, Meson does not create the file itself but rather runs the specified command, which allows you to do fully custom file generation
 - `install_dir` the subdirectory to install the generated file to (e.g. `share/myproject`), if omitted the file is not installed.

--- a/docs/markdown/Release-notes-for-0.41.0.md
+++ b/docs/markdown/Release-notes-for-0.41.0.md
@@ -67,3 +67,7 @@ coverage must be combined before producing a report (`coverage3 combine`.)
 All known issues have been fixed and Meson can now build reproducible Debian
 packages out of the box.
 
+## Extended template substitution in configure_file
+
+The output argument of `configure_file()` is parsed for @BASENAME@ and
+@PLAINNAME@ substitutions.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2344,6 +2344,10 @@ class Interpreter(InterpreterBase):
         output = kwargs['output']
         if not isinstance(output, str):
             raise InterpreterException('Output file name must be a string')
+        if ifile_abs:
+            values = mesonlib.get_filenames_templates_dict([ifile_abs], None)
+            outputs = mesonlib.substitute_values([output], values)
+            output = outputs[0]
         if os.path.split(output)[0] != '':
             raise InterpreterException('Output file name must not contain a subdirectory.')
         (ofile_path, ofile_fname) = os.path.split(os.path.join(self.subdir, output))

--- a/test cases/common/16 configure file/config4a.h.in
+++ b/test cases/common/16 configure file/config4a.h.in
@@ -1,0 +1,2 @@
+/* Dummy file */
+#define RESULTA @ZERO@

--- a/test cases/common/16 configure file/config4b.h.in
+++ b/test cases/common/16 configure file/config4b.h.in
@@ -1,0 +1,2 @@
+/* Dummy file */
+#define RESULTB @ZERO@

--- a/test cases/common/16 configure file/meson.build
+++ b/test cases/common/16 configure file/meson.build
@@ -74,3 +74,15 @@ configure_file(output : 'config3.h',
   configuration : dump)
 
 test('Configless.', executable('dumpprog', 'dumpprog.c'))
+
+
+# Config file generation in a loop with @BASENAME@ substitution
+dump = configuration_data()
+dump.set('ZERO', 0)
+config_templates = files(['config4a.h.in', 'config4b.h.in'])
+foreach config_template : config_templates
+  configure_file(input : config_template, output : '@BASENAME@',
+                 configuration : dump)
+endforeach
+
+test('Substituted', executable('prog4', 'prog4.c'))

--- a/test cases/common/16 configure file/prog4.c
+++ b/test cases/common/16 configure file/prog4.c
@@ -1,0 +1,6 @@
+#include <config4a.h>
+#include <config4b.h>
+
+int main(int argc, char **argv) {
+    return RESULTA + RESULTB;
+}


### PR DESCRIPTION
In my opinion it would be beneficial, when the output parameter of ``configure_file()`` would allow variable substitution. Having the need to pre-process Fortran files via ``configure_file()`` due to the restrictions in the ninja-backend, following code would make life somewhat easier:

```
fortran_templates = files(['f1.fpp', 'f2.fpp', ...])

foreach ftemplate : fortran_templates
  fsource = configure_file(input: ftemplate, output : '@BASENAME@.f90',
                           command : [fpp_program, fpp_includearg, '@INPUT@', '@OUTPUT@'])
  fortran_sources += [fsource]
endforeach
```
Currently it is not possible to use ``@BASENAME@`` in the output argument, while this pull request would enable it.