### PR TITLE
gnome: Use --pkg to pass pkg-config cflags to g-ir-scanner

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -332,7 +332,10 @@ class GnomeModule(ExtensionModule):
                                             source.held_object.get_subdir())])
             # This should be any dependency other than an internal one.
             elif isinstance(dep, Dependency):
-                cflags.update(dep.get_compile_args())
+                if isinstance(dep, PkgConfigDependency) and use_gir_args:
+                    cflags.update(["--pkg=%s" % dep.get_name()])
+                else:
+                    cflags.update(dep.get_compile_args())
                 for lib in dep.get_link_args():
                     if (os.path.isabs(lib) and
                             # For PkgConfigDependency only:


### PR DESCRIPTION
While g-ir-scanner compatible -I and -D flags cover what most pkg-config
files use, there's no guarantee that files don't set anything more exotic
that conflicts with the tool's own options.

For a real world example, mozjs-38 has '-include some-header-file.h', which
translates to '--include nclude another-file-to-scan.h' for the scanner;
unless for some reason there's an 'nclude' GIR available on the system,
the target will thus fail.

Avoid this case by pointing g-ir-scanner to the correct pkg-config file
instead of passing any cflags directly.