### PR TITLE
Fixes for intltest-pot target in gettext test

### DIFF
--- a/mesonbuild/scripts/gettext.py
+++ b/mesonbuild/scripts/gettext.py
@@ -88,7 +88,7 @@ def run(args):
     options = parser.parse_args(args)
     subcmd = options.command
     langs = options.langs.split('@@') if options.langs else None
-    extra_args = options.extra_args.split('@@')
+    extra_args = options.extra_args.split('@@') if options.extra_args else []
     subdir = os.environ.get('MESON_SUBDIR', '')
     if options.subdir:
         subdir = options.subdir

--- a/test cases/frameworks/6 gettext/po/POTFILES
+++ b/test cases/frameworks/6 gettext/po/POTFILES
@@ -1,2 +1,2 @@
 src/intlmain.c
-data/test.desktop
+data/test.desktop.in

--- a/test cases/frameworks/6 gettext/po/intltest.pot
+++ b/test cases/frameworks/6 gettext/po/intltest.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: intltest\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-28 19:59+0300\n"
+"POT-Creation-Date: 2017-05-31 05:16-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,4 +19,16 @@ msgstr ""
 
 #: src/intlmain.c:15
 msgid "International greeting."
+msgstr ""
+
+#: data/test.desktop.in:3
+msgid "Test"
+msgstr ""
+
+#: data/test.desktop.in:4
+msgid "Application"
+msgstr ""
+
+#: data/test.desktop.in:5
+msgid "Test Application"
 msgstr ""


### PR DESCRIPTION
With these changes the target works as expected. The generated desktop file is still missing the translated strings because de.po and fi.po lack them.