### PR TITLE
Revert slashes in filenames being a hard error to give downstream pro…

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -271,7 +271,10 @@ class EnvironmentVariables:
 class Target:
     def __init__(self, name, subdir, build_by_default):
         if '/' in name or '\\' in name:
-            raise InvalidArguments('Target name must not contain a path separator.')
+            # Fix failing test 53 when this becomes an error.
+            mlog.warning('''Target "%s" has a path separator in its name.
+This is not supported, it can cause unexpected failures and will become
+a hard error in the future.''' % name)
         self.name = name
         self.subdir = subdir
         self.build_by_default = build_by_default

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2595,14 +2595,7 @@ different subdirectory.
         else:
             mlog.debug('Unknown target type:', str(targetholder))
             raise RuntimeError('Unreachable code')
-        # Fix failing test 53 when removing this.
-        if '/' in name or '\\' in name:
-            mlog.warning('Target name must not contain a path separator. This will become a hard error in a future release.')
-            subpart, name = os.path.split(name)
-            subdir = os.path.join(self.subdir, subpart)
-        else:
-            subdir = self.subdir
-        target = targetclass(name, subdir, self.subproject, is_cross, sources, objs, self.environment, kwargs)
+        target = targetclass(name, self.subdir, self.subproject, is_cross, sources, objs, self.environment, kwargs)
         if is_cross:
             self.add_cross_stdlib_info(target)
         l = targetholder(target, self)


### PR DESCRIPTION
…jects time to transition.

With a slightly modified #1744 and this we should have no regressions compared to the last release _and_ we can ship reproducible builds which is a big feature.

This commit does not have any opinion on the uniqueness of target names. That war should be fought elsewhere.