### PR TITLE
compilers: Make CCompiler.find_library return value consistent

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1371,10 +1371,10 @@ class CCompiler(Compiler):
             for suffix in suffixes:
                 trial = os.path.join(d, 'lib' + libname + '.' + suffix)
                 if os.path.isfile(trial):
-                    return trial
+                    return [trial]
                 trial2 = os.path.join(d, libname + '.' + suffix)
                 if os.path.isfile(trial2):
-                    return trial2
+                    return [trial2]
         return None
 
     def thread_flags(self):


### PR DESCRIPTION
When the CCompiler.links method call in CCompiler.find_library fails,
find_library resorts to finding the library file itself. In this second
case, the return value is not a list, whereas if links suceeds, the
return value is a list. Make it so that find_library returns a list
in either case.

Closes #1872