### PR TITLE
Set clang_type to CLANG_WIN on windows.

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -481,6 +481,8 @@ class Environment:
             if 'clang' in out:
                 if 'Apple' in out or for_darwin(want_cross, self):
                     cltype = CLANG_OSX
+                elif 'windows' in out or for_windows(want_cross, self):
+                    cltype = CLANG_WIN
                 else:
                     cltype = CLANG_STANDARD
                 cls = ClangCCompiler if lang == 'c' else ClangCPPCompiler


### PR DESCRIPTION
On my windows system  ```clang_type``` in ```ClangCCompiler``` was ```CLANG_STANDARD```, causing meson to produce build files with unsupported flags like -fPIC.

```bash
> ninja
[1/12] Compiling C object enet/enet@sta/peer.c.obj.
FAILED: enet/enet@sta/peer.c.obj
clang @enet/enet@sta/peer.c.obj.rsp
clang.exe: error: unsupported option '-fPIC' for target 'x86_64-pc-windows-msvc'
```

I don't know if ```CLANG_STANDARD``` is the intended setting or not, but setting it to ```CLANG_WIN``` fixed the bug I had.

```bash
> clang --version
clang version 4.0.0 (tags/RELEASE_400/final)
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: C:\Program Files\LLVM\bin
```