### PR TITLE
Revert "gnome: Use --pkg to pass pkg-config cflags to g-ir-scanner"

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -332,10 +332,7 @@ class GnomeModule(ExtensionModule):
                                             source.held_object.get_subdir())])
             # This should be any dependency other than an internal one.
             elif isinstance(dep, Dependency):
-                if isinstance(dep, PkgConfigDependency) and use_gir_args:
-                    cflags.update(["--pkg=%s" % dep.get_name()])
-                else:
-                    cflags.update(dep.get_compile_args())
+                cflags.update(dep.get_compile_args())
                 for lib in dep.get_link_args():
                     if (os.path.isabs(lib) and
                             # For PkgConfigDependency only:


### PR DESCRIPTION
Reverts #1868 as it breaks stuff and Travis setup was incorrect and did not flag this.