### PR TITLE
Add Genie files to Vala

### DIFF
--- a/docs/markdown/Release-notes-for-0.42.0.md
+++ b/docs/markdown/Release-notes-for-0.42.0.md
@@ -11,3 +11,9 @@ short-description: Release notes for 0.42 (preliminary)
 
 Creating distribution tarballs can now be made out of projects based on
 Mercurial. As before, this remains possible only with the Ninja backend.
+
+
+## Add support for Genie to Vala compiler
+
+The Vala compiler has an alternative syntax, Genie, that uses the `.gs`
+file extension. Meson now recognises and uses Genie files.

--- a/docs/markdown/Vala.md
+++ b/docs/markdown/Vala.md
@@ -1,14 +1,14 @@
 ---
 title: Vala
-short-description: Compiling Vala programs
+short-description: Compiling Vala and Genie programs
 ...
 
 # Compiling Vala applications
 
-Meson has support for compiling Vala programs. A skeleton Vala file looks like this.
+Meson has support for compiling Vala and Genie programs. A skeleton `meson.build` file for Vala looks like this:
 
 ```meson
-project('valaprog', ['vala', 'c'])
+project('valaprog', 'vala', 'c')
 
 glib_dep = dependency('glib-2.0')
 gobject_dep = dependency('gobject-2.0')

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -307,7 +307,7 @@ class Backend:
         if isinstance(source, mesonlib.File):
             source = source.fname
         # foo.vala files compile down to foo.c and then foo.c.o, not foo.vala.o
-        if source.endswith('.vala'):
+        if source.endswith(('.vala', '.gs')):
             if is_unity:
                 return source[:-5] + '.c.' + self.environment.get_object_suffix()
             source = os.path.join(self.get_target_private_dir(target), source[:-5] + '.c')

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1005,7 +1005,7 @@ int dummy;
 
     def split_vala_sources(self, t):
         """
-        Splits the target's sources into .vala, .vapi, and other sources.
+        Splits the target's sources into .vala, .gs, .vapi, and other sources.
         Handles both pre-existing and generated sources.
 
         Returns a tuple (vala, vapi, others) each of which is a dictionary with
@@ -1026,7 +1026,7 @@ int dummy;
                       'mesonlib.File, not {!r}'.format(t, s)
                 raise InvalidArguments(msg)
             f = s.rel_to_builddir(self.build_to_src)
-            if s.endswith('.vala'):
+            if s.endswith(('.vala', '.gs')):
                 srctype = vala
             elif s.endswith('.vapi'):
                 srctype = vapi
@@ -1037,7 +1037,7 @@ int dummy;
         for gensrc in t.get_generated_sources():
             for s in gensrc.get_outputs():
                 f = self.get_target_generated_dir(t, gensrc, s)
-                if s.endswith('.vala'):
+                if s.endswith(('.vala', '.gs')):
                     srctype = vala
                 elif s.endswith('.vapi'):
                     srctype = vapi
@@ -1061,7 +1061,7 @@ int dummy;
         (vala_src, vapi_src, other_src) = self.split_vala_sources(target)
         extra_dep_files = []
         if not vala_src:
-            msg = 'Vala library {!r} has no Vala source files.'
+            msg = 'Vala library {!r} has no Vala or Genie source files.'
             raise InvalidArguments(msg.format(target.name))
 
         valac = target.compilers['vala']

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -39,7 +39,7 @@ lang_suffixes = {
     'objc': ('m',),
     'objcpp': ('mm',),
     'rust': ('rs',),
-    'vala': ('vala', 'vapi'),
+    'vala': ('vala', 'vapi', 'gs'),
     'cs': ('cs',),
     'swift': ('swift',),
     'java': ('java',),

--- a/test cases/vala/19 genie/meson.build
+++ b/test cases/vala/19 genie/meson.build
@@ -1,0 +1,6 @@
+project('genietest', 'vala', 'c')
+
+valadeps = [dependency('glib-2.0'), dependency('gobject-2.0')]
+
+e = executable('genieprog', 'prog.gs', dependencies : valadeps)
+test('genietest', e)

--- a/test cases/vala/19 genie/prog.gs
+++ b/test cases/vala/19 genie/prog.gs
@@ -1,0 +1,2 @@
+init
+	print ("Genie is working.")

--- a/test cases/vala/20 genie multiple mixed sources/c_test_one.c
+++ b/test cases/vala/20 genie multiple mixed sources/c_test_one.c
@@ -1,0 +1,5 @@
+#include <glib.h>
+
+gboolean c_test_one_is_true (void) {
+    return TRUE;
+}

--- a/test cases/vala/20 genie multiple mixed sources/c_test_two.c
+++ b/test cases/vala/20 genie multiple mixed sources/c_test_two.c
@@ -1,0 +1,5 @@
+#include <glib.h>
+
+gboolean c_test_two_is_true (void) {
+    return TRUE;
+}

--- a/test cases/vala/20 genie multiple mixed sources/init.gs
+++ b/test cases/vala/20 genie multiple mixed sources/init.gs
@@ -1,0 +1,11 @@
+def extern c_test_one_is_true():bool
+def extern c_test_two_is_true():bool
+
+init
+	assert( new Genie.TestOne().is_true() )
+	assert( new Genie.TestTwo().is_true() )
+	assert( new Vala.TestOne().is_true() )
+	assert( new Vala.TestTwo().is_true() )
+	assert( c_test_one_is_true() )
+	assert( c_test_two_is_true() )
+

--- a/test cases/vala/20 genie multiple mixed sources/meson.build
+++ b/test cases/vala/20 genie multiple mixed sources/meson.build
@@ -1,0 +1,19 @@
+project( 'Genie multiple and mixed sources', 'vala', 'c' )
+
+genie_deps = [
+    dependency( 'glib-2.0' ),
+    dependency( 'gobject-2.0' ),
+]
+
+sources = [
+    'init.gs',
+    'test_one.gs',
+    'test_two.gs',
+    'vala_test_one.vala',
+    'vala_test_two.vala',
+    'c_test_one.c',
+    'c_test_two.c',
+]
+
+prog = executable( 'genie_prog', sources, dependencies: genie_deps )
+test( 'Given a Genie program when it is compiled from multiple mixed sources then it should work', prog )

--- a/test cases/vala/20 genie multiple mixed sources/test_one.gs
+++ b/test cases/vala/20 genie multiple mixed sources/test_one.gs
@@ -1,0 +1,5 @@
+namespace Genie
+
+	class TestOne
+		def is_true():bool
+			return true

--- a/test cases/vala/20 genie multiple mixed sources/test_two.gs
+++ b/test cases/vala/20 genie multiple mixed sources/test_two.gs
@@ -1,0 +1,5 @@
+namespace Genie
+
+	class TestTwo
+		def is_true():bool
+			return true

--- a/test cases/vala/20 genie multiple mixed sources/vala_test_one.vala
+++ b/test cases/vala/20 genie multiple mixed sources/vala_test_one.vala
@@ -1,0 +1,7 @@
+namespace Vala {
+    public class TestOne {
+        public bool is_true() {
+            return true;
+        }
+    }
+}

--- a/test cases/vala/20 genie multiple mixed sources/vala_test_two.vala
+++ b/test cases/vala/20 genie multiple mixed sources/vala_test_two.vala
@@ -1,0 +1,7 @@
+namespace Vala {
+    public class TestTwo {
+        public bool is_true() {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Genie is an alternative syntax for the Vala compiler that drops the C heritage squiggly braces and semi-colons in favour of Python like significant leading white space for blocks and other syntactic tweaks.

This PR adds the Genie file extension, .gs, to the Vala compiler class and backend in Meson.