### PR TITLE
Allow value 'if-release' for b_ndebug project option.

### DIFF
--- a/docs/markdown/snippets/if-release.md
+++ b/docs/markdown/snippets/if-release.md
@@ -1,0 +1,7 @@
+## b_ndebug : if-release
+
+The value `if-release` can be given for the `b_ndebug` project option.
+
+This will make the `NDEBUG` pre-compiler macro to be defined for release
+type builds as if the `b_ndebug` project option had had the value `true`
+defined for it.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -224,9 +224,8 @@ base_options = {'b_pch': coredata.UserBooleanOption('b_pch', 'Use precompiled he
                 'b_colorout': coredata.UserComboOption('b_colorout', 'Use colored output',
                                                        ['auto', 'always', 'never'],
                                                        'always'),
-                'b_ndebug': coredata.UserBooleanOption('b_ndebug',
-                                                       'Disable asserts',
-                                                       False),
+                'b_ndebug': coredata.UserComboOption('b_ndebug', 'Disable asserts',
+                                                     ['true', 'false', 'if-release'], 'false'),
                 'b_staticpic': coredata.UserBooleanOption('b_staticpic',
                                                           'Build static libraries as position independent',
                                                           True),
@@ -313,7 +312,7 @@ def get_base_compile_args(options, compiler):
     except KeyError:
         pass
     try:
-        if options['b_ndebug'].value:
+        if options['b_ndebug'].value == 'true' or (options['b_ndebug'].value == 'if-release' and options['buildtype'] == 'release'):
             args += ['-DNDEBUG']
     except KeyError:
         pass


### PR DESCRIPTION
When set, NDEBUG will be automatically defined for for release builds but
not for other build types.