### PR TITLE
dependencies: Add a new class ExternalDependency

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -55,6 +55,8 @@ skip_commits:
 
 install:
   - cmd: set "ORIG_PATH=%PATH%"
+  # Boost 1.56.0: https://www.appveyor.com/docs/build-environment/#boost
+  #- cmd: set "BOOST_ROOT=C:\Libraries\boost"
   # Use the x86 python only when building for x86 for the cpython tests.
   # For all other archs (including, say, arm), use the x64 python.
   - ps: (new-object net.webclient).DownloadFile('https://www.dropbox.com/s/bbzvepq85hv47x1/ninja.exe?dl=1', 'C:\projects\meson\ninja.exe')

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -429,7 +429,7 @@ class Backend:
                                 break
                     commands += ['--pkg', dep.name]
                 elif isinstance(dep, dependencies.ExternalLibrary):
-                    commands += dep.get_lang_args('vala')
+                    commands += dep.get_link_args('vala')
             else:
                 commands += dep.get_compile_args()
             # Qt needs -fPIC for executables

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -29,26 +29,24 @@ from ..environment import Environment
 
 def autodetect_vs_version(build):
     vs_version = os.getenv('VisualStudioVersion', None)
-    if vs_version:
-        if vs_version == '14.0':
-            from mesonbuild.backend.vs2015backend import Vs2015Backend
-            return Vs2015Backend(build)
-        if vs_version == '15.0':
-            from mesonbuild.backend.vs2017backend import Vs2017Backend
-            return Vs2017Backend(build)
-        raise MesonException('Could not detect Visual Studio (unknown Visual Studio version: "{}")!\n'
-                             'Please specify the exact backend to use.'.format(vs_version))
-
     vs_install_dir = os.getenv('VSINSTALLDIR', None)
-    if not vs_install_dir:
-        raise MesonException('Could not detect Visual Studio (neither VisualStudioVersion nor VSINSTALLDIR set in '
-                             'environment)!\nPlease specify the exact backend to use.')
-
+    if not vs_version and not vs_install_dir:
+        raise MesonException('Could not detect Visual Studio: VisualStudioVersion and VSINSTALLDIR are unset!\n'
+                             'Are we inside a Visual Studio build environment? '
+                             'You can also try specifying the exact backend to use.')
+    # VisualStudioVersion is set since Visual Studio 12.0, but sometimes
+    # vcvarsall.bat doesn't set it, so also use VSINSTALLDIR
+    if vs_version == '14.0' or 'Visual Studio 14' in vs_install_dir:
+        from mesonbuild.backend.vs2015backend import Vs2015Backend
+        return Vs2015Backend(build)
+    if vs_version == '15.0' or 'Visual Studio 17' in vs_install_dir or \
+       'Visual Studio\\2017' in vs_install_dir:
+        from mesonbuild.backend.vs2017backend import Vs2017Backend
+        return Vs2017Backend(build)
     if 'Visual Studio 10.0' in vs_install_dir:
         return Vs2010Backend(build)
-
-    raise MesonException('Could not detect Visual Studio (unknown VSINSTALLDIR: "{}")!\n'
-                         'Please specify the exact backend to use.'.format(vs_install_dir))
+    raise MesonException('Could not detect Visual Studio using VisualStudioVersion: {!r} or VSINSTALLDIR: {!r}!\n'
+                         'Please specify the exact backend to use.'.format(vs_version, vs_install_dir))
 
 def split_o_flags_args(args):
     """

--- a/mesonbuild/backend/vs2017backend.py
+++ b/mesonbuild/backend/vs2017backend.py
@@ -24,4 +24,6 @@ class Vs2017Backend(Vs2010Backend):
         self.platform_toolset = 'v141'
         self.vs_version = '2017'
         # WindowsSDKVersion should be set by command prompt.
-        self.windows_target_platform_version = os.getenv('WindowsSDKVersion', None).rstrip('\\')
+        sdk_version = os.environ.get('WindowsSDKVersion', None)
+        if sdk_version:
+            self.windows_target_platform_version = sdk_version.rstrip('\\')

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -806,7 +806,7 @@ class BuildTarget(Target):
                 self.external_deps.append(extpart)
                 # Deps of deps.
                 self.add_deps(dep.ext_deps)
-            elif isinstance(dep, dependencies.Dependency):
+            elif isinstance(dep, dependencies.ExternalDependency):
                 self.external_deps.append(dep)
                 self.process_sourcelist(dep.get_sources())
             elif isinstance(dep, BuildTarget):

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -1773,7 +1773,7 @@ class ValaCompiler(Compiler):
         for d in extra_dirs:
             vapi = os.path.join(d, libname + '.vapi')
             if os.path.isfile(vapi):
-                return vapi
+                return [vapi]
         mlog.debug('Searched {!r} and {!r} wasn\'t found'.format(extra_dirs, libname))
         return None
 

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 from .base import (  # noqa: F401
-    Dependency, DependencyException, DependencyMethods, ExternalProgram, ExternalLibrary, ExtraFrameworkDependency,
-    InternalDependency, PkgConfigDependency, find_external_dependency, get_dep_identifier, packages)
+    Dependency, DependencyException, DependencyMethods, ExternalProgram,
+    ExternalDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
+    PkgConfigDependency, find_external_dependency, get_dep_identifier, packages)
 from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDependency
 from .misc import BoostDependency, Python3Dependency, ThreadDependency
 from .platform import AppleFrameworks

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -59,7 +59,10 @@ class Dependency:
         self.compile_args = []
         self.link_args = []
         self.sources = []
-        method = DependencyMethods(kwargs.get('method', 'auto'))
+        method = kwargs.get('method', 'auto')
+        if method not in [e.value for e in DependencyMethods]:
+            raise DependencyException('method {!r} is invalid'.format(method))
+        method = DependencyMethods(method)
 
         # Set the detection method. If the method is set to auto, use any available method.
         # If method is set to a specific string, allow only that detection method.
@@ -68,7 +71,7 @@ class Dependency:
         elif method in self.get_methods():
             self.methods = [method]
         else:
-            raise MesonException(
+            raise DependencyException(
                 'Unsupported detection method: {}, allowed methods are {}'.format(
                     method.value,
                     mlog.format_list(map(lambda x: x.value, [DependencyMethods.AUTO] + self.get_methods()))))

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -139,7 +139,7 @@ class ExternalDependency(Dependency):
         self.static = kwargs.get('static', False)
         if not isinstance(self.static, bool):
             raise DependencyException('Static keyword must be boolean')
-        # Is this dependency for cross-com,pilation?
+        # Is this dependency for cross-compilation?
         if 'native' in kwargs and self.env.is_cross_build():
             self.want_cross = not kwargs['native']
         else:
@@ -619,7 +619,7 @@ def find_external_dependency(name, env, kwargs):
     except Exception as e:
         pkg_exc = e
     if mesonlib.is_osx():
-        fwdep = ExtraFrameworkDependency(name, required, None, env, kwargs)
+        fwdep = ExtraFrameworkDependency(name, False, None, env, None, kwargs)
         if required and not fwdep.found():
             m = 'Dependency {!r} not found, tried Extra Frameworks ' \
                 'and Pkg-Config:\n\n' + str(pkg_exc)

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -510,8 +510,6 @@ class ExternalLibrary(ExternalDependency):
         self.is_found = False
         if link_args:
             self.is_found = True
-            if not isinstance(link_args, list):
-                link_args = [link_args]
             self.link_args = link_args
         if not silent:
             if self.is_found:

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -22,29 +22,20 @@ import shutil
 from .. import mlog
 from .. import mesonlib
 from ..mesonlib import version_compare, Popen_safe
-from .base import Dependency, DependencyException, PkgConfigDependency, dependency_get_compiler
+from .base import DependencyException, ExternalDependency, PkgConfigDependency
 
-class GTestDependency(Dependency):
+class GTestDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
-        Dependency.__init__(self, 'gtest', kwargs)
-        self.env = environment
+        super().__init__('gtest', environment, 'cpp', kwargs)
         self.main = kwargs.get('main', False)
-        self.name = 'gtest'
-        self.include_dir = '/usr/include'
         self.src_dirs = ['/usr/src/gtest/src', '/usr/src/googletest/googletest/src']
-
-        self.cpp_compiler = dependency_get_compiler('cpp', environment, kwargs)
-        if self.cpp_compiler is None:
-            raise DependencyException('Tried to use gtest but a C++ compiler is not defined.')
         self.detect()
 
-    def found(self):
-        return self.is_found
-
     def detect(self):
-        gtest_detect = self.cpp_compiler.find_library("gtest", self.env, [])
-        gtest_main_detect = self.cpp_compiler.find_library("gtest_main", self.env, [])
-        if gtest_detect and gtest_main_detect:
+        self.version = '1.something_maybe'
+        gtest_detect = self.compiler.find_library("gtest", self.env, [])
+        gtest_main_detect = self.compiler.find_library("gtest_main", self.env, [])
+        if gtest_detect and (not self.main or gtest_main_detect):
             self.is_found = True
             self.compile_args = []
             self.link_args = gtest_detect
@@ -64,7 +55,6 @@ class GTestDependency(Dependency):
         else:
             mlog.log('Dependency GTest found:', mlog.red('NO'))
             self.is_found = False
-        return self.is_found
 
     def detect_srcdir(self):
         for s in self.src_dirs:
@@ -78,37 +68,17 @@ class GTestDependency(Dependency):
                 return True
         return False
 
-    def get_compile_args(self):
-        arr = []
-        if self.include_dir != '/usr/include':
-            arr.append('-I' + self.include_dir)
-        if hasattr(self, 'src_include_dir'):
-            arr.append('-I' + self.src_include_dir)
-        return arr
-
-    def get_link_args(self):
-        return self.link_args
-
-    def get_version(self):
-        return '1.something_maybe'
-
-    def get_sources(self):
-        return self.sources
-
     def need_threads(self):
         return True
 
 
-class GMockDependency(Dependency):
+class GMockDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
-        Dependency.__init__(self, 'gmock', kwargs)
+        super().__init__('gmock', environment, 'cpp', kwargs)
+        self.version = '1.something_maybe'
         # GMock may be a library or just source.
         # Work with both.
-        self.name = 'gmock'
-        cpp_compiler = dependency_get_compiler('cpp', environment, kwargs)
-        if cpp_compiler is None:
-            raise DependencyException('Tried to use gmock but a C++ compiler is not defined.')
-        gmock_detect = cpp_compiler.find_library("gmock", environment, [])
+        gmock_detect = self.compiler.find_library("gmock", self.env, [])
         if gmock_detect:
             self.is_found = True
             self.compile_args = []
@@ -133,29 +103,12 @@ class GMockDependency(Dependency):
                     self.sources = [all_src]
                 mlog.log('Dependency GMock found:', mlog.green('YES'), '(building self)')
                 return
-
         mlog.log('Dependency GMock found:', mlog.red('NO'))
         self.is_found = False
 
-    def get_version(self):
-        return '1.something_maybe'
 
-    def get_compile_args(self):
-        return self.compile_args
-
-    def get_sources(self):
-        return self.sources
-
-    def get_link_args(self):
-        return self.link_args
-
-    def found(self):
-        return self.is_found
-
-
-class LLVMDependency(Dependency):
-    """LLVM dependency.
-
+class LLVMDependency(ExternalDependency):
+    """
     LLVM uses a special tool, llvm-config, which has arguments for getting
     c args, cxx args, and ldargs as well as version.
     """
@@ -182,15 +135,11 @@ class LLVMDependency(Dependency):
     __cpp_blacklist = {'-DNDEBUG'}
 
     def __init__(self, environment, kwargs):
-        super().__init__('llvm-config', kwargs)
         # It's necessary for LLVM <= 3.8 to use the C++ linker. For 3.9 and 4.0
         # the C linker works fine if only using the C API.
-        self.language = 'cpp'
-        self.cargs = []
-        self.libs = []
+        super().__init__('llvm-config', environment, 'cpp', kwargs)
         self.modules = []
-
-        required = kwargs.get('required', True)
+        # FIXME: Support multiple version requirements ala PkgConfigDependency
         req_version = kwargs.get('version', None)
         if self.llvmconfig is None:
             self.check_llvmconfig(req_version)
@@ -201,14 +150,14 @@ class LLVMDependency(Dependency):
             else:
                 mlog.log("No llvm-config found; can't detect dependency")
             mlog.log('Dependency LLVM found:', mlog.red('NO'))
-            if required:
+            if self.required:
                 raise DependencyException('Dependency LLVM not found')
             return
 
         p, out, err = Popen_safe([self.llvmconfig, '--version'])
         if p.returncode != 0:
             mlog.debug('stdout: {}\nstderr: {}'.format(out, err))
-            if required:
+            if self.required:
                 raise DependencyException('Dependency LLVM not found')
             return
         else:
@@ -220,12 +169,13 @@ class LLVMDependency(Dependency):
                 [self.llvmconfig, '--libs', '--ldflags', '--system-libs'])[:2]
             if p.returncode != 0:
                 raise DependencyException('Could not generate libs for LLVM.')
-            self.libs = shlex.split(out)
+            self.link_args = shlex.split(out)
 
             p, out = Popen_safe([self.llvmconfig, '--cppflags'])[:2]
             if p.returncode != 0:
                 raise DependencyException('Could not generate includedir for LLVM.')
-            self.cargs = list(mesonlib.OrderedSet(shlex.split(out)).difference(self.__cpp_blacklist))
+            cargs = mesonlib.OrderedSet(shlex.split(out))
+            self.compile_args = list(cargs.difference(self.__cpp_blacklist))
 
             p, out = Popen_safe([self.llvmconfig, '--components'])[:2]
             if p.returncode != 0:
@@ -237,20 +187,11 @@ class LLVMDependency(Dependency):
             if mod not in self.modules:
                 mlog.log('LLVM module', mod, 'found:', mlog.red('NO'))
                 self.is_found = False
-                if required:
+                if self.required:
                     raise DependencyException(
                         'Could not find required LLVM Component: {}'.format(mod))
             else:
                 mlog.log('LLVM module', mod, 'found:', mlog.green('YES'))
-
-    def get_version(self):
-        return self.version
-
-    def get_compile_args(self):
-        return self.cargs
-
-    def get_link_args(self):
-        return self.libs
 
     @classmethod
     def check_llvmconfig(cls, version_req):
@@ -288,8 +229,12 @@ class LLVMDependency(Dependency):
 
 
 class ValgrindDependency(PkgConfigDependency):
-    def __init__(self, environment, kwargs):
-        PkgConfigDependency.__init__(self, 'valgrind', environment, kwargs)
+    '''
+    Consumers of Valgrind usually only need the compile args and do not want to
+    link to its (static) libraries.
+    '''
+    def __init__(self, env, kwargs):
+        super().__init__('valgrind', env, None, kwargs)
 
     def get_link_args(self):
         return []

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -202,6 +202,8 @@ class LLVMDependency(ExternalDependency):
                 out = out.strip()
                 if p.returncode != 0:
                     continue
+                # FIXME: As soon as some llvm-config is found, version checks
+                # in further dependnecy() calls will be ignored
                 if version_req:
                     if version_compare(out, version_req, strict=True):
                         if cls.__best_found and version_compare(out, '<={}'.format(cls.__best_found), strict=True):

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -126,8 +126,8 @@ class BoostDependency(ExternalDependency):
 
     def get_requested(self, kwargs):
         candidates = kwargs.get('modules', [])
-        if isinstance(candidates, str):
-            return [candidates]
+        if not isinstance(candidates, list):
+            candidates = [candidates]
         for c in candidates:
             if not isinstance(c, str):
                 raise DependencyException('Boost module argument is not a string.')
@@ -136,7 +136,8 @@ class BoostDependency(ExternalDependency):
     def validate_requested(self):
         for m in self.requested_modules:
             if m not in self.src_modules:
-                raise DependencyException('Requested Boost module "%s" not found.' % m)
+                msg = 'Requested Boost module {!r} not found'
+                raise DependencyException(msg.format(m))
 
     def detect_version(self):
         try:

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -23,25 +23,19 @@ from .. import mlog
 from .. import mesonlib
 from ..environment import detect_cpu_family
 
-from .base import Dependency, DependencyException, DependencyMethods, ExtraFrameworkDependency, PkgConfigDependency
+from .base import DependencyException, DependencyMethods
+from .base import ExternalDependency, ExtraFrameworkDependency, PkgConfigDependency
 
 
-class BoostDependency(Dependency):
+class BoostDependency(ExternalDependency):
     # Some boost libraries have different names for
     # their sources and libraries. This dict maps
     # between the two.
     name2lib = {'test': 'unit_test_framework'}
 
     def __init__(self, environment, kwargs):
-        Dependency.__init__(self, 'boost', kwargs)
-        self.name = 'boost'
-        self.environment = environment
+        super().__init__('boost', environment, 'cpp', kwargs)
         self.libdir = ''
-        self.static = kwargs.get('static', False)
-        if 'native' in kwargs and environment.is_cross_build():
-            self.want_cross = not kwargs['native']
-        else:
-            self.want_cross = environment.is_cross_build()
         try:
             self.boost_root = os.environ['BOOST_ROOT']
             if not os.path.isabs(self.boost_root):
@@ -72,7 +66,7 @@ class BoostDependency(Dependency):
         self.detect_version()
         self.requested_modules = self.get_requested(kwargs)
         module_str = ', '.join(self.requested_modules)
-        if self.version is not None:
+        if self.is_found:
             self.detect_src_modules()
             self.detect_lib_modules()
             self.validate_requested()
@@ -83,9 +77,6 @@ class BoostDependency(Dependency):
             mlog.log('Dependency Boost (%s) found:' % module_str, mlog.green('YES'), info)
         else:
             mlog.log("Dependency Boost (%s) found:" % module_str, mlog.red('NO'))
-        if 'cpp' not in self.environment.coredata.compilers:
-            raise DependencyException('Tried to use Boost but a C++ compiler is not defined.')
-        self.cpp_compiler = self.environment.coredata.compilers['cpp']
 
     def detect_win_root(self):
         globtext = 'c:\\local\\boost_*'
@@ -130,7 +121,7 @@ class BoostDependency(Dependency):
         # names in order to handle cases like cross-compiling where we
         # might have a different sysroot.
         if not include_dir.endswith(('/usr/include', '/usr/local/include')):
-            args.append("".join(self.cpp_compiler.get_include_args(include_dir, True)))
+            args.append("".join(self.compiler.get_include_args(include_dir, True)))
         return args
 
     def get_requested(self, kwargs):
@@ -147,17 +138,10 @@ class BoostDependency(Dependency):
             if m not in self.src_modules:
                 raise DependencyException('Requested Boost module "%s" not found.' % m)
 
-    def found(self):
-        return self.version is not None
-
-    def get_version(self):
-        return self.version
-
     def detect_version(self):
         try:
             ifile = open(os.path.join(self.boost_inc_subdir, 'version.hpp'))
         except FileNotFoundError:
-            self.version = None
             return
         with ifile:
             for line in ifile:
@@ -165,8 +149,8 @@ class BoostDependency(Dependency):
                     ver = line.split()[-1]
                     ver = ver[1:-1]
                     self.version = ver.replace('_', '.')
+                    self.is_found = True
                     return
-        self.version = None
 
     def detect_src_modules(self):
         for entry in os.listdir(self.boost_inc_subdir):
@@ -180,7 +164,7 @@ class BoostDependency(Dependency):
         return self.detect_lib_modules_nix()
 
     def detect_lib_modules_win(self):
-        arch = detect_cpu_family(self.environment.coredata.compilers)
+        arch = detect_cpu_family(self.env.coredata.compilers)
         # Guess the libdir
         if arch == 'x86':
             gl = 'lib32*'
@@ -254,10 +238,10 @@ class BoostDependency(Dependency):
             module = BoostDependency.name2lib.get(module, module)
             libname = 'boost_' + module
             # The compiler's library detector is the most reliable so use that first.
-            default_detect = self.cpp_compiler.find_library(libname, self.environment, [])
+            default_detect = self.compiler.find_library(libname, self.env, [])
             if default_detect is not None:
                 if module == 'unit_testing_framework':
-                    emon_args = self.cpp_compiler.find_library('boost_test_exec_monitor')
+                    emon_args = self.compiler.find_library('boost_test_exec_monitor')
                 else:
                     emon_args = None
                 args += default_detect
@@ -286,9 +270,9 @@ class BoostDependency(Dependency):
         return 'thread' in self.requested_modules
 
 
-class ThreadDependency(Dependency):
+class ThreadDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
-        super().__init__('threads', {})
+        super().__init__('threads', environment, None, {})
         self.name = 'threads'
         self.is_found = True
         mlog.log('Dependency', mlog.bold(self.name), 'found:', mlog.green('YES'))
@@ -300,19 +284,18 @@ class ThreadDependency(Dependency):
         return 'unknown'
 
 
-class Python3Dependency(Dependency):
+class Python3Dependency(ExternalDependency):
     def __init__(self, environment, kwargs):
-        super().__init__('python3', kwargs)
+        super().__init__('python3', environment, None, kwargs)
         self.name = 'python3'
-        self.is_found = False
         # We can only be sure that it is Python 3 at this point
         self.version = '3'
         if DependencyMethods.PKGCONFIG in self.methods:
             try:
                 pkgdep = PkgConfigDependency('python3', environment, kwargs)
                 if pkgdep.found():
-                    self.cargs = pkgdep.cargs
-                    self.libs = pkgdep.libs
+                    self.compile_args = pkgdep.get_compile_args()
+                    self.link_args = pkgdep.get_link_args()
                     self.version = pkgdep.get_version()
                     self.is_found = True
                     return
@@ -324,10 +307,11 @@ class Python3Dependency(Dependency):
             elif mesonlib.is_osx() and DependencyMethods.EXTRAFRAMEWORK in self.methods:
                 # In OSX the Python 3 framework does not have a version
                 # number in its name.
-                fw = ExtraFrameworkDependency('python', False, None, kwargs)
+                fw = ExtraFrameworkDependency('python', False, None, self.env,
+                                              self.language, kwargs)
                 if fw.found():
-                    self.cargs = fw.get_compile_args()
-                    self.libs = fw.get_link_args()
+                    self.compile_args = fw.get_compile_args()
+                    self.link_args = fw.get_link_args()
                     self.is_found = True
         if self.is_found:
             mlog.log('Dependency', mlog.bold(self.name), 'found:', mlog.green('YES'))
@@ -359,22 +343,16 @@ class Python3Dependency(Dependency):
             return
         inc = sysconfig.get_path('include')
         platinc = sysconfig.get_path('platinclude')
-        self.cargs = ['-I' + inc]
+        self.compile_args = ['-I' + inc]
         if inc != platinc:
-            self.cargs.append('-I' + platinc)
+            self.compile_args.append('-I' + platinc)
         # Nothing exposes this directly that I coulf find
         basedir = sysconfig.get_config_var('base')
         vernum = sysconfig.get_config_var('py_version_nodot')
-        self.libs = ['-L{}/libs'.format(basedir),
-                     '-lpython{}'.format(vernum)]
+        self.link_args = ['-L{}/libs'.format(basedir),
+                          '-lpython{}'.format(vernum)]
         self.version = sysconfig.get_config_var('py_version_short')
         self.is_found = True
-
-    def get_compile_args(self):
-        return self.cargs
-
-    def get_link_args(self):
-        return self.libs
 
     def get_methods(self):
         if mesonlib.is_windows():
@@ -383,6 +361,3 @@ class Python3Dependency(Dependency):
             return [DependencyMethods.PKGCONFIG, DependencyMethods.EXTRAFRAMEWORK]
         else:
             return [DependencyMethods.PKGCONFIG]
-
-    def get_version(self):
-        return self.version

--- a/mesonbuild/dependencies/platform.py
+++ b/mesonbuild/dependencies/platform.py
@@ -17,25 +17,21 @@
 
 from .. import mesonlib
 
-from .base import Dependency, DependencyException
+from .base import ExternalDependency, DependencyException
 
 
-class AppleFrameworks(Dependency):
-    def __init__(self, environment, kwargs):
-        Dependency.__init__(self, 'appleframeworks', kwargs)
+class AppleFrameworks(ExternalDependency):
+    def __init__(self, env, kwargs):
+        super().__init__('appleframeworks', env, None, kwargs)
         modules = kwargs.get('modules', [])
         if isinstance(modules, str):
             modules = [modules]
         if not modules:
             raise DependencyException("AppleFrameworks dependency requires at least one module.")
         self.frameworks = modules
-
-    def get_link_args(self):
-        args = []
+        # FIXME: Use self.compiler to check if the frameworks are available
         for f in self.frameworks:
-            args.append('-framework')
-            args.append(f)
-        return args
+            self.link_args += ['-framework', f]
 
     def found(self):
         return mesonlib.is_osx()

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -310,7 +310,8 @@ class QtBaseDependency(ExternalDependency):
         libdir = qvars['QT_INSTALL_LIBS']
         for m in modules:
             fname = 'Qt' + m
-            fwdep = ExtraFrameworkDependency(fname, kwargs.get('required', True), libdir, kwargs)
+            fwdep = ExtraFrameworkDependency(fname, False, libdir, self.env,
+                                             self.language, kwargs)
             self.cargs.append('-F' + libdir)
             if fwdep.found():
                 self.is_found = True
@@ -400,7 +401,8 @@ class SDL2Dependency(ExternalDependency):
             mlog.debug('Could not find sdl2-config binary, trying next.')
         if DependencyMethods.EXTRAFRAMEWORK in self.methods:
             if mesonlib.is_osx():
-                fwdep = ExtraFrameworkDependency('sdl2', False, None, kwargs)
+                fwdep = ExtraFrameworkDependency('sdl2', False, None, self.env,
+                                                 self.language, kwargs)
                 if fwdep.found():
                     self.is_found = True
                     self.compile_args = fwdep.get_compile_args()

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -427,7 +427,6 @@ class WxDependency(ExternalDependency):
         if WxDependency.wx_found is None:
             self.check_wxconfig()
         if not WxDependency.wx_found:
-            # FIXME: this message could be printed after Dependncy found
             mlog.log("Neither wx-config-3.0 nor wx-config found; can't detect dependency")
             return
 
@@ -466,11 +465,11 @@ class WxDependency(ExternalDependency):
         if modules not in kwargs:
             return []
         candidates = kwargs[modules]
-        if isinstance(candidates, str):
-            return [candidates]
+        if not isinstance(candidates, list):
+            candidates = [candidates]
         for c in candidates:
             if not isinstance(c, str):
-                raise DependencyException('wxwidgets module argument is not a string.')
+                raise DependencyException('wxwidgets module argument is not a string')
         return candidates
 
     def check_wxconfig(self):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -973,7 +973,8 @@ class CompilerHolder(InterpreterObject):
         if required and not linkargs:
             l = self.compiler.language.capitalize()
             raise InterpreterException('{} library {!r} not found'.format(l, libname))
-        lib = dependencies.ExternalLibrary(libname, linkargs, self.compiler.language)
+        lib = dependencies.ExternalLibrary(libname, linkargs, self.environment,
+                                           self.compiler.language)
         return ExternalLibraryHolder(lib)
 
     def has_argument_method(self, args, kwargs):

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -312,7 +312,11 @@ def run(mainfile, args):
             else:
                 mlog.log(mlog.red('\nMeson encountered an error:'))
             mlog.log(e)
+            if os.environ.get('MESON_FORCE_BACKTRACE'):
+                raise
         else:
+            if os.environ.get('MESON_FORCE_BACKTRACE'):
+                raise
             traceback.print_exc()
         return 1
     return 0

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -68,7 +68,7 @@ class GnomeModule(ExtensionModule):
         if native_glib_version is None:
             glib_dep = PkgConfigDependency('glib-2.0', state.environment,
                                            {'native': True})
-            native_glib_version = glib_dep.get_modversion()
+            native_glib_version = glib_dep.get_version()
         return native_glib_version
 
     def __print_gresources_warning(self, state):

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -34,7 +34,7 @@ import time
 import multiprocessing
 import concurrent.futures as conc
 import re
-from run_unittests import get_fake_options
+from run_unittests import get_fake_options, run_configure_inprocess
 
 from run_tests import get_backend_commands, get_backend_args_for_dir, Backend
 from run_tests import ensure_backend_detects_changes
@@ -248,18 +248,6 @@ def log_text_file(logfile, testdir, stdo, stde):
             f[2].cancel()
         executor.shutdown()
         raise StopException()
-
-def run_configure_inprocess(commandlist):
-    old_stdout = sys.stdout
-    sys.stdout = mystdout = StringIO()
-    old_stderr = sys.stderr
-    sys.stderr = mystderr = StringIO()
-    try:
-        returncode = mesonmain.run(commandlist[0], commandlist[1:])
-    finally:
-        sys.stdout = old_stdout
-        sys.stderr = old_stderr
-    return returncode, mystdout.getvalue(), mystderr.getvalue()
 
 def run_test_inprocess(testdir):
     old_stdout = sys.stdout

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -371,7 +371,7 @@ def _run_test(testdir, test_build_dir, install_dir, extra_args, compiler, backen
     return TestResult(validate_install(testdir, install_dir, compiler), BuildStep.validate, stdo, stde, mesonlog, gen_time, build_time, test_time)
 
 def gather_tests(testdir):
-    tests = [t.replace('\\', '/').split('/', 2)[2] for t in glob(os.path.join(testdir, '*'))]
+    tests = [t.replace('\\', '/').split('/', 2)[2] for t in glob(testdir + '/*')]
     testlist = [(int(t.split()[0]), t) for t in tests]
     testlist.sort()
     tests = [os.path.join(testdir, t[1]) for t in testlist]
@@ -425,7 +425,6 @@ def detect_tests_to_run():
         ('platform-windows', 'windows', not mesonlib.is_windows() and not mesonlib.is_cygwin()),
         ('platform-linux', 'linuxlike', mesonlib.is_osx() or mesonlib.is_windows()),
 
-        ('framework', 'frameworks', mesonlib.is_osx() or mesonlib.is_windows() or mesonlib.is_cygwin()),
         ('java', 'java', backend is not Backend.ninja or mesonlib.is_osx() or not have_java()),
         ('C#', 'csharp', backend is not Backend.ninja or not shutil.which('mcs')),
         ('vala', 'vala', backend is not Backend.ninja or not shutil.which('valac')),
@@ -436,7 +435,15 @@ def detect_tests_to_run():
         ('swift', 'swift', backend not in (Backend.ninja, Backend.xcode) or not shutil.which('swiftc')),
         ('python3', 'python3', backend is not Backend.ninja),
     ]
-    return [(name, gather_tests('test cases/' + subdir), skip) for name, subdir, skip in all_tests]
+    gathered_tests = [(name, gather_tests('test cases/' + subdir), skip) for name, subdir, skip in all_tests]
+    if mesonlib.is_windows():
+        # TODO: Set BOOST_ROOT in .appveyor.yml
+        gathered_tests += [('framework', ['test cases/frameworks/1 boost'], 'BOOST_ROOT' not in os.environ)]
+    elif mesonlib.is_osx() or mesonlib.is_cygwin():
+        gathered_tests += [('framework', gather_tests('test cases/frameworks'), True)]
+    else:
+        gathered_tests += [('framework', gather_tests('test cases/frameworks'), False)]
+    return gathered_tests
 
 def run_tests(all_tests, log_name_base, extra_args):
     global stop, executor, futures

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -434,7 +434,7 @@ def detect_tests_to_run():
         ('objective c', 'objc', backend not in (Backend.ninja, Backend.xcode) or mesonlib.is_windows() or not have_objc_compiler()),
         ('fortran', 'fortran', backend is not Backend.ninja or not shutil.which('gfortran')),
         ('swift', 'swift', backend not in (Backend.ninja, Backend.xcode) or not shutil.which('swiftc')),
-        ('python3', 'python3', backend is not Backend.ninja or not shutil.which('python3')),
+        ('python3', 'python3', backend is not Backend.ninja),
     ]
     return [(name, gather_tests('test cases/' + subdir), skip) for name, subdir, skip in all_tests]
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -121,6 +121,8 @@ def should_run_linux_cross_tests():
 class FakeEnvironment(object):
     def __init__(self):
         self.cross_info = None
+        self.coredata = lambda: None
+        self.coredata.compilers = {}
 
     def is_cross_build(self):
         return False

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1316,6 +1316,19 @@ class FailureTests(BasePlatformTests):
         self.assertMesonRaises("dependency('llvm', modules : 'fail')",
                                "(required.*fail|{})".format(self.dnf))
 
+    def test_boost_notfound_dependency(self):
+        # Can be run even if Boost is found or not
+        self.assertMesonRaises("dependency('boost', modules : 1)",
+                               "module.*not a string")
+        self.assertMesonRaises("dependency('boost', modules : 'fail')",
+                               "(fail.*not found|{})".format(self.dnf))
+
+    def test_boost_BOOST_ROOT_dependency(self):
+        # Test BOOST_ROOT; can be run even if Boost is found or not
+        os.environ['BOOST_ROOT'] = 'relative/path'
+        self.assertMesonRaises("dependency('boost')",
+                               "(BOOST_ROOT.*absolute|{})".format(self.dnf))
+
 
 class WindowsTests(BasePlatformTests):
     '''

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1256,6 +1256,10 @@ class FailureTests(BasePlatformTests):
         for contents, match in a:
             self.assertMesonRaises(contents, match)
 
+    def test_llvm_dependency(self):
+        self.assertMesonRaises("dependency('llvm', modules : 'fail')",
+                               "(required.*fail|{})".format(self.dnf))
+
 
 class WindowsTests(BasePlatformTests):
     '''

--- a/test cases/frameworks/15 llvm/meson.build
+++ b/test cases/frameworks/15 llvm/meson.build
@@ -7,4 +7,11 @@ llvm_dep = dependency(
   required : true,
 )
 
+d = dependency('llvm', modules : 'not-found', required : false)
+assert(d.found() == false, 'not-found llvm module found')
+
+# XXX: Version checks are broken, see FIXME in LLVMDependency
+#d = dependency('llvm', version : '<0.1', required : false)
+#assert(d.found() == false, 'ancient llvm module found')
+
 executable('sum', 'sum.c',  dependencies : llvm_dep)

--- a/test cases/frameworks/16 sdl2/meson.build
+++ b/test cases/frameworks/16 sdl2/meson.build
@@ -1,0 +1,9 @@
+project('sdl2 test', 'c')
+
+sdl2_dep = dependency('sdl2', version : '>=2.0.0', required : false)
+
+if sdl2_dep.found()
+  e = executable('sdl2prog', 'sdl2prog.c', dependencies : sdl2_dep)
+
+  test('sdl2test', e)
+endif

--- a/test cases/frameworks/16 sdl2/meson.build
+++ b/test cases/frameworks/16 sdl2/meson.build
@@ -1,9 +1,10 @@
 project('sdl2 test', 'c')
 
-sdl2_dep = dependency('sdl2', version : '>=2.0.0', required : false)
+sdl2_dep = dependency('sdl2', version : '>=2.0.0')
 
-if sdl2_dep.found()
-  e = executable('sdl2prog', 'sdl2prog.c', dependencies : sdl2_dep)
+e = executable('sdl2prog', 'sdl2prog.c', dependencies : sdl2_dep)
 
-  test('sdl2test', e)
-endif
+test('sdl2test', e)
+
+# Ensure that we can find it with sdl2-config too
+configdep = dependency('sdl2', method : 'sdlconfig')

--- a/test cases/frameworks/16 sdl2/sdl2prog.c
+++ b/test cases/frameworks/16 sdl2/sdl2prog.c
@@ -1,0 +1,33 @@
+/* vim: set sts=4 sw=4 et : */
+
+#include <stdio.h>
+#include <SDL_version.h>
+
+int main(int argc, char *argv[]) {
+    SDL_version compiled;
+    SDL_version linked;
+
+    SDL_VERSION(&compiled);
+    SDL_GetVersion(&linked);
+
+    if (compiled.major != linked.major) {
+        fprintf(stderr, "Compiled major '%u' != linked major '%u'",
+                compiled.major, linked.major);
+        return -1;
+    }
+
+    if (compiled.minor != linked.minor) {
+        fprintf(stderr, "Compiled minor '%u' != linked minor '%u'",
+                compiled.minor, linked.minor);
+        return -2;
+    }
+#if 0
+    /* Disabled because sometimes this is 'micro' and sometimes 'patch' */
+    if (compiled.micro != linked.micro) {
+        fprintf(stderr, "Compiled micro '%u' != linked micro '%u'",
+                compiled.micro, linked.micro);
+        return -3;
+    }
+#endif
+    return 0;
+}

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -8,16 +8,22 @@ foreach qt : ['qt4', 'qt5']
   if qt == 'qt5'
     qt_modules += qt5_modules
   endif
+
   # Test that invalid modules are indeed not found
   fakeqtdep = dependency(qt, modules : ['DefinitelyNotFound'], required : false, method : get_option('method'))
   if fakeqtdep.found()
     error('Invalid qt dep incorrectly found!')
   endif
+
   # Test that partially-invalid modules are indeed not found
   fakeqtdep = dependency(qt, modules : ['Core', 'DefinitelyNotFound'], required : false, method : get_option('method'))
   if fakeqtdep.found()
     error('Invalid qt dep incorrectly found!')
   endif
+
+  # Ensure that the "no-Core-module-specified" code branch is hit
+  nocoredep = dependency(qt, modules : ['Gui'], required : qt == 'qt5', method : get_option('method'))
+
   # If qt4 modules are found, test that. qt5 is required.
   qtdep = dependency(qt, modules : qt_modules, required : qt == 'qt5', method : get_option('method'))
   if qtdep.found()

--- a/test cases/linuxlike/5 dependency versions/meson.build
+++ b/test cases/linuxlike/5 dependency versions/meson.build
@@ -90,9 +90,15 @@ if meson.is_cross_build()
   assert(native_prefix != cross_prefix, 'native prefix == cross_prefix == ' + native_prefix)
 endif
 
+objc_found = add_languages('objc', required : false)
+
 foreach d : ['sdl2', 'gnustep', 'wx', 'gl', 'python3', 'boost', 'gtest', 'gmock']
-  dep = dependency(d, required : false)
-  if dep.found()
-    dep.version()
+  if d == 'gnustep' and not objc_found
+    message('Skipping gnustep because no ObjC compiler found')
+  else
+    dep = dependency(d, required : false)
+    if dep.found()
+      dep.version()
+    endif
   endif
 endforeach

--- a/test cases/osx/4 framework/meson.build
+++ b/test cases/osx/4 framework/meson.build
@@ -10,8 +10,13 @@
 
 project('xcode framework test', 'c', default_options : ['libdir=libtest'])
 
-dep_libs = [dependency('appleframeworks', modules : ['OpenGL'], required : true)]
-dep_main = [dependency('appleframeworks', modules : ['Foundation'], required : true)]
+dep_libs = dependency('appleframeworks', modules : ['OpenGL'], required : false)
+if not dep_libs.found()
+  error('OpenGL framework not found')
+endif
+assert(dep_libs.type_name() == 'appleframeworks', 'type_name is wrong')
+
+dep_main = dependency('appleframeworks', modules : ['Foundation'])
 
 stlib = static_library('stat', 'stat.c', install : true, dependencies: dep_libs)
 exe = executable('prog', 'prog.c', install : true, dependencies: dep_main)


### PR DESCRIPTION
This class now consolidates a lot of the logic that each external dependency was duplicating in its class definition.

All external dependencies now set:

* self.version
* self.compile_args and self.link_args
* self.is_found (if found)
* self.sources
* etc

And the abstract `ExternalDependency` class defines the methods that will fetch those properties. Some classes still override that for various reasons, but those should also be migrated to properties as far as possible.

Next step is to consolidate and standardize the way in which we call 'configuration binaries' such as `sdl2-config`, `llvm-config`, `pkg-config`, etc. Currently each class has to duplicate code involved with that even though the format is very similar.

Currently only pkg-config supports multiple version requirements, and some classes don't even properly check the version requirement. That will also become easier now.

Also adds a missing SDL2 test.