### PR TITLE
Update the list of possible llvm-config binaries

### DIFF
--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -162,11 +162,19 @@ class LLVMDependency(Dependency):
 
     # Ordered list of llvm-config binaries to try. Start with base, then try
     # newest back to oldest (3.5 is abitrary), and finally the devel version.
+    # Please note that llvm-config-5.0 is a development snapshot and it should
+    # not be moved to the beginning of the list. The only difference between
+    # llvm-config-5.0 and llvm-config-devel is that the former is used by
+    # Debian and the latter is used by FreeBSD.
     llvm_config_bins = [
-        'llvm-config', 'llvm-config-4.0', 'llvm-config-3.9', 'llvm-config39',
-        'llvm-config-3.8', 'llvm-config38', 'llvm-config-3.7', 'llvm-config37',
-        'llvm-config-3.6', 'llvm-config36', 'llvm-config-3.5', 'llvm-config35',
-        'llvm-config-devel',
+        'llvm-config', # base
+        'llvm-config-4.0', 'llvm-config40', # latest stable release
+        'llvm-config-3.9', 'llvm-config39', # old stable releases
+        'llvm-config-3.8', 'llvm-config38',
+        'llvm-config-3.7', 'llvm-config37',
+        'llvm-config-3.6', 'llvm-config36',
+        'llvm-config-3.5', 'llvm-config35',
+        'llvm-config-5.0', 'llvm-config-devel', # development snapshot
     ]
     llvmconfig = None
     _llvmconfig_found = False


### PR DESCRIPTION
This commit syncs the list with gnome-builder, which updates its list
in https://bugzilla.gnome.org/show_bug.cgi?id=782296.

llvm-config40 is added becaue LLVM 4.0 becomes a stable release.
llvm-config-5.0 is added to the bottom of the list because it is still
a development snapshot (svn trunk).

Please do not move llvm-config-5.0 to the beginning of the list unless LLVM 5.0 is released as a stable version. Both llvm-config-5.0 and llvm-config-devel are names of llvm-config used for LLVM svn trunk. llvm-config-5.0 is used by Debian and llvm-config-devel is used by FreeBSD.