### PR TITLE
gnome: Guard all cflags passed to g-ir-scanner

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -459,10 +459,6 @@ class GnomeModule(ExtensionModule):
             sanitize = compiler.get_options().get('b_sanitize')
             if sanitize:
                 cflags += compilers.sanitizer_compile_args(sanitize)
-        if cflags:
-            scan_command += ['--cflags-begin']
-            scan_command += cflags
-            scan_command += ['--cflags-end']
         if kwargs.get('symbol_prefix'):
             sym_prefix = kwargs.pop('symbol_prefix')
             if not isinstance(sym_prefix, str):
@@ -525,9 +521,12 @@ class GnomeModule(ExtensionModule):
         # ldflags will be misinterpreted by gir scanner (showing
         # spurious dependencies) but building GStreamer fails if they
         # are not used here.
-        cflags, ldflags, gi_includes = self._get_dependencies_flags(deps, state, depends,
-                                                                    use_gir_args=True)
-        scan_command += list(cflags)
+        dep_cflags, ldflags, gi_includes = self._get_dependencies_flags(deps, state, depends,
+                                                                        use_gir_args=True)
+        cflags += list(dep_cflags)
+        scan_command += ['--cflags-begin']
+        scan_command += cflags
+        scan_command += ['--cflags-end']
         # need to put our output directory first as we need to use the
         # generated libraries instead of any possibly installed system/prefix
         # ones.

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -367,7 +367,8 @@ class GnomeModule(ExtensionModule):
                         gi_includes.update([girdir])
             elif isinstance(dep, (build.StaticLibrary, build.SharedLibrary)):
                 for incd in dep.get_include_dirs():
-                    cflags.update(incd.get_incdirs())
+                    for idir in incd.get_incdirs():
+                        cflags.update(["-I%s" % idir])
             else:
                 mlog.log('dependency %s not handled to build gir files' % dep)
                 continue


### PR DESCRIPTION
While g-ir-scanner's compatible -I and -D flags cover what most pkg-config
files use, there's no guarantee that files don't set anything more exotic
that conflicts with the tool's own options.

For a real world example, mozjs-38 has '-include some-header-file.h', which
translates to '--include nclude another-file-to-scan.h' for the scanner;
unless for some reason there's an 'nclude' GIR available on the system,
the target will thus fail.

Avoid this case by pointing g-ir-scanner to the correct pkg-config file
instead of passing any cflags directly.

Picked up from #1868.