### PR TITLE
Add Mercurial dist support

### DIFF
--- a/docs/markdown/Release-notes-for-0.42.0.md
+++ b/docs/markdown/Release-notes-for-0.42.0.md
@@ -7,4 +7,7 @@ short-description: Release notes for 0.42 (preliminary)
 
 # New features
 
-Add features here as code is merged to master.
+## Distribution tarballs from Mercurial repositories
+
+Creating distribution tarballs can now be made out of projects based on
+Mercurial. As before, this remains possible only with the Ninja backend.

--- a/mesonbuild/scripts/dist.py
+++ b/mesonbuild/scripts/dist.py
@@ -29,10 +29,11 @@ def create_hash(fname):
     m = hashlib.sha256()
     m.update(open(fname, 'rb').read())
     with open(hashname, 'w') as f:
-        f.write('%s %s\n' % (m.hexdigest(), os.path.split(fname)[-1]))
+        f.write('%s %s\n' % (m.hexdigest(), os.path.basename(fname)))
+
 
 def create_zip(zipfilename, packaging_dir):
-    prefix = os.path.split(packaging_dir)[0]
+    prefix = os.path.dirname(packaging_dir)
     removelen = len(prefix) + 1
     with zipfile.ZipFile(zipfilename,
                          'w',
@@ -81,7 +82,7 @@ def create_dist(dist_name, src_root, bld_root, dist_sub):
     xzname = distdir + '.tar.xz'
     # Should use shutil but it got xz support only in 3.5.
     with tarfile.open(xzname, 'w:xz') as tf:
-        tf.add(distdir, os.path.split(distdir)[1])
+        tf.add(distdir, dist_name)
     # Create only .tar.xz for now.
     # zipname = distdir + '.zip'
     # create_zip(zipname, distdir)


### PR DESCRIPTION
I was going to copy all the git code but as far as I can tell, `hg archive` does everything we need except for not supporting .xz files (which can easily be approximated out of Python stdlib.)

As far as I can tell, you can't clone without subrepos, so we don't need the extra code to bundle them, and Mercurial has a flag to include subrepos (`-S`) in archives anyway.