### PR TITLE
Fix a missing path issue causing Python traceback.

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -763,6 +763,10 @@ class Compiler:
         # directory. This breaks reproducible builds.
         rel_rpaths = []
         for p in rpath_paths:
+            # p can be an empty string for build_dir (relative path), but
+            # os.path.relpath() below won't like that.
+            if p == '':
+                p = build_dir
             if p == from_dir:
                 relative = '' # relpath errors out in this case
             else:

--- a/test cases/common/154 library at root/lib.c
+++ b/test cases/common/154 library at root/lib.c
@@ -1,0 +1,6 @@
+#if defined _WIN32 || defined __CYGWIN__
+__declspec(dllexport)
+#endif
+int fn(void) {
+    return -1;
+}

--- a/test cases/common/154 library at root/main/main.c
+++ b/test cases/common/154 library at root/main/main.c
@@ -1,0 +1,5 @@
+extern int fn(void);
+
+int main() {
+    return 1 + fn();
+}

--- a/test cases/common/154 library at root/main/meson.build
+++ b/test cases/common/154 library at root/main/meson.build
@@ -1,0 +1,2 @@
+exe = executable('main', 'main.c', link_with : lib)
+test('stuff works', exe)

--- a/test cases/common/154 library at root/meson.build
+++ b/test cases/common/154 library at root/meson.build
@@ -1,0 +1,3 @@
+project('lib@root', 'c')
+lib = shared_library('lib', 'lib.c')
+subdir('main')


### PR DESCRIPTION
A path was missing from a call to os.path.relpath when linking a
library from the project root. Fix this by defining the directory of the
build root as ".".

An example traceback:

Traceback (most recent call last):
```
  File "/home/trhd/Projects/meson/mesonbuild/mesonmain.py", line 307, in run
    app.generate()
  File "/home/trhd/Projects/meson/mesonbuild/mesonmain.py", line 182, in generate
    g.generate(intr)
  File "/home/trhd/Projects/meson/mesonbuild/backend/ninjabackend.py", line 194, in generate
    self.generate_target(t, outfile)
  File "/home/trhd/Projects/meson/mesonbuild/backend/ninjabackend.py", line 445, in generate_target
    elem = self.generate_link(target, outfile, outname, obj_list, linker, pch_objects)
  File "/home/trhd/Projects/meson/mesonbuild/backend/ninjabackend.py", line 2321, in generate_link
    target.install_rpath)
  File "/home/trhd/Projects/meson/mesonbuild/compilers.py", line 815, in build_rpath_args
    return self.build_unix_rpath_args(build_dir, from_dir, rpath_paths, install_rpath)
  File "/home/trhd/Projects/meson/mesonbuild/compilers.py", line 744, in build_unix_rpath_args
    relative = os.path.relpath(p, from_dir)
  File "/usr/lib/python3.6/posixpath.py", line 448, in relpath
    raise ValueError("no path specified")
ValueError: no path specified
```