### PR TITLE
Work around GNU ld bug with -rpath,$ORIGIN

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -294,6 +294,15 @@ class Backend:
             raise MesonException(m.format(target.name))
         return l
 
+    def determine_rpath_dirs(self, target):
+        link_deps = target.get_all_link_deps()
+        result = []
+        for ld in link_deps:
+            prospective = self.get_target_dir(ld)
+            if prospective not in result:
+                result.append(prospective)
+        return result
+
     def object_filename_from_source(self, target, source, is_unity):
         if isinstance(source, mesonlib.File):
             source = source.fname

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2334,15 +2334,6 @@ rule FORTRAN_DEP_HACK
         elem.add_item('LINK_ARGS', commands)
         return elem
 
-    def determine_rpath_dirs(self, target):
-        link_deps = target.get_all_link_deps()
-        result = []
-        for ld in link_deps:
-            prospective = self.get_target_dir(ld)
-            if prospective not in result:
-                result.append(prospective)
-        return result
-
     def get_dependency_filename(self, t):
         if isinstance(t, build.SharedLibrary):
             return os.path.join(self.get_target_private_dir(t), self.get_target_filename(t) + '.symbols')

--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -731,35 +731,35 @@ class Compiler:
         raise EnvironmentException('Language %s does not support linking whole archives.' % self.language)
 
     def build_unix_rpath_args(self, build_dir, from_dir, rpath_paths, install_rpath):
-            if not rpath_paths and not install_rpath:
-                return []
-            # The rpaths we write must be relative, because otherwise
-            # they have different length depending on the build
-            # directory. This breaks reproducible builds.
-            rel_rpaths = []
-            for p in rpath_paths:
-                if p == from_dir:
-                    relative = '' # relpath errors out in this case
-                else:
-                    relative = os.path.relpath(p, from_dir)
-                rel_rpaths.append(relative)
-            paths = ':'.join([os.path.join('$ORIGIN', p) for p in rel_rpaths])
-            if len(paths) < len(install_rpath):
-                padding = 'X' * (len(install_rpath) - len(paths))
-                if not paths:
-                    paths = padding
-                else:
-                    paths = paths + ':' + padding
-            args = ['-Wl,-rpath,' + paths]
-            if get_compiler_is_linuxlike(self):
-                # Rpaths to use while linking must be absolute. These are not
-                # written to the binary. Needed only with GNU ld:
-                # https://sourceware.org/bugzilla/show_bug.cgi?id=16936
-                # Not needed on Windows or other platforms that don't use RPATH
-                # https://github.com/mesonbuild/meson/issues/1897
-                lpaths = ':'.join([os.path.join(build_dir, p) for p in rpath_paths])
-                args += ['-Wl,-rpath-link,' + lpaths]
-            return args
+        if not rpath_paths and not install_rpath:
+            return []
+        # The rpaths we write must be relative, because otherwise
+        # they have different length depending on the build
+        # directory. This breaks reproducible builds.
+        rel_rpaths = []
+        for p in rpath_paths:
+            if p == from_dir:
+                relative = '' # relpath errors out in this case
+            else:
+                relative = os.path.relpath(p, from_dir)
+            rel_rpaths.append(relative)
+        paths = ':'.join([os.path.join('$ORIGIN', p) for p in rel_rpaths])
+        if len(paths) < len(install_rpath):
+            padding = 'X' * (len(install_rpath) - len(paths))
+            if not paths:
+                paths = padding
+            else:
+                paths = paths + ':' + padding
+        args = ['-Wl,-rpath,' + paths]
+        if get_compiler_is_linuxlike(self):
+            # Rpaths to use while linking must be absolute. These are not
+            # written to the binary. Needed only with GNU ld:
+            # https://sourceware.org/bugzilla/show_bug.cgi?id=16936
+            # Not needed on Windows or other platforms that don't use RPATH
+            # https://github.com/mesonbuild/meson/issues/1897
+            lpaths = ':'.join([os.path.join(build_dir, p) for p in rpath_paths])
+            args += ['-Wl,-rpath-link,' + lpaths]
+        return args
 
 class CCompiler(Compiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1010,10 +1010,9 @@ class CompilerHolder(InterpreterObject):
         return []
 
 ModuleState = namedtuple('ModuleState', [
-    'build_to_src', 'subdir', 'environment', 'project_name',
-    'project_version', 'compilers', 'targets', 'data', 'headers',
-    'man', 'global_args', 'project_args', 'build_machine',
-    'host_machine', 'target_machine'])
+    'build_to_src', 'subdir', 'environment', 'project_name', 'project_version',
+    'backend', 'compilers', 'targets', 'data', 'headers', 'man', 'global_args',
+    'project_args', 'build_machine', 'host_machine', 'target_machine'])
 
 class ModuleHolder(InterpreterObject):
     def __init__(self, modname, module, interpreter):
@@ -1039,6 +1038,9 @@ class ModuleHolder(InterpreterObject):
             environment=self.interpreter.environment,
             project_name=self.interpreter.build.project_name,
             project_version=self.interpreter.build.dep_manifest[self.interpreter.active_projectname],
+            # The backend object is under-used right now, but we will need it:
+            # https://github.com/mesonbuild/meson/issues/1419
+            backend=self.interpreter.backend,
             compilers=self.interpreter.build.compilers,
             targets=self.interpreter.build.targets,
             data=self.interpreter.build.data,

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -443,12 +443,18 @@ class GnomeModule(ExtensionModule):
                         'Gir includes must be str, GirTarget, or list of them')
 
         cflags = []
-        if state.global_args.get('c'):
-            cflags += state.global_args['c']
-        if state.project_args.get('c'):
-            cflags += state.project_args['c']
-        if 'c' in state.compilers:
-            compiler = state.compilers['c']
+        for lang, compiler in girtarget.compilers.items():
+            # XXX: Can you use g-i with any other language?
+            if lang in ('c', 'cpp', 'objc', 'objcpp', 'd'):
+                break
+        else:
+            lang = None
+            compiler = None
+        if lang and compiler:
+            if state.global_args.get(lang):
+                cflags += state.global_args[lang]
+            if state.project_args.get(lang):
+                cflags += state.project_args[lang]
             sanitize = compiler.get_options().get('b_sanitize')
             if sanitize:
                 cflags += compilers.sanitizer_compile_args(sanitize)


### PR DESCRIPTION
`g-ir-scanner` rejects `-rpath`, so we use `-L` instead which has the same effect.

Closes https://github.com/mesonbuild/meson/issues/1911
