### PR TITLE
CI: Use QuLogic's Ninja patches

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -57,9 +57,11 @@ install:
   - cmd: set "ORIG_PATH=%PATH%"
   # Boost 1.56.0: https://www.appveyor.com/docs/build-environment/#boost
   #- cmd: set "BOOST_ROOT=C:\Libraries\boost"
+  # Use a Ninja with QuLogic's patch: https://github.com/ninja-build/ninja/issues/1219
+  - cmd: set "MESON_FIXED_NINJA=1"
+  - ps: (new-object net.webclient).DownloadFile('http://nirbheek.in/files/binaries/ninja/win32/ninja.exe', 'C:\projects\meson\ninja.exe')
   # Use the x86 python only when building for x86 for the cpython tests.
   # For all other archs (including, say, arm), use the x64 python.
-  - ps: (new-object net.webclient).DownloadFile('https://www.dropbox.com/s/bbzvepq85hv47x1/ninja.exe?dl=1', 'C:\projects\meson\ninja.exe')
   - cmd: if %arch%==x86 (set MESON_PYTHON_PATH=C:\python34) else (set MESON_PYTHON_PATH=C:\python34-x64)
 
   # Set paths and config for each build type.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -49,10 +49,6 @@ branches:
   only:
     - master
 
-skip_commits:
-  files:
-    - docs/**/*
-
 install:
   - cmd: set "ORIG_PATH=%PATH%"
   # Boost 1.56.0: https://www.appveyor.com/docs/build-environment/#boost

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ matrix:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja python3; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
+  # Use a Ninja with QuLogic's patch: https://github.com/ninja-build/ninja/issues/1219
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir -p $HOME/tools; curl -L http://nirbheek.in/files/binaries/ninja/macos/ninja -o $HOME/tools/ninja; chmod +x $HOME/tools/ninja; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker pull jpakkane/mesonci:zesty; fi
   - pip3 install codecov
   - mkdir .coverage
@@ -47,9 +49,9 @@ script:
       ci_env=`bash <(curl -s https://codecov.io/env)`
       docker run $ci_env -v ${PWD}/.coverage:/root/.coverage \
         withgit \
-          /bin/sh -c "cd /root && CC=$CC CXX=$CXX OBJC=$CC OBJCXX=$CXX ./run_tests.py --cov -- $MESON_ARGS && chmod -R a+rwX .coverage"
+          /bin/sh -c "cd /root && mkdir -p tools; wget -c http://nirbheek.in/files/binaries/ninja/linux-amd64/ninja -O /root/tools/ninja; chmod +x /root/tools/ninja; CC=$CC CXX=$CXX OBJC=$CC OBJCXX=$CXX PATH=/root/tools:$PATH MESON_FIXED_NINJA=1 ./run_tests.py --cov -- $MESON_ARGS && chmod -R a+rwX .coverage"
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) OBJC=$CC OBJCXX=$CXX ./run_tests.py --cov --backend=ninja -- $MESON_ARGS ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) OBJC=$CC OBJCXX=$CXX PATH=$HOME/tools:$PATH MESON_FIXED_NINJA=1 ./run_tests.py --cov --backend=ninja -- $MESON_ARGS ; fi
 
 after_success:
   - coverage3 combine

--- a/ci/appveyor-install.bat
+++ b/ci/appveyor-install.bat
@@ -1,5 +1,7 @@
 set CACHE=C:\cache
 set CYGWIN_MIRROR="http://cygwin.mirror.constant.com"
+set CYGWIN_ADDITIONAL_REPO="http://www.dronecode.org.uk/cygwin/"
+set CYGWIN_ADDITIONAL_REPO_KEY="http://www.dronecode.org.uk/cygwin/dronecode.gpg"
 
 if _%arch%_ == _x64_ set SETUP=setup-x86_64.exe && set CYGWIN_ROOT=C:\cygwin64
 if _%arch%_ == _x86_ set SETUP=setup-x86.exe && set CYGWIN_ROOT=C:\cygwin
@@ -7,5 +9,5 @@ if _%arch%_ == _x86_ set SETUP=setup-x86.exe && set CYGWIN_ROOT=C:\cygwin
 if not exist %CACHE% mkdir %CACHE%
 
 echo Updating Cygwin and installing ninja and test prerequisites
-%CYGWIN_ROOT%\%SETUP% -qnNdO -R "%CYGWIN_ROOT%" -s "%CYGWIN_MIRROR%" -l "%CACHE%" -g -P "ninja,gcc-objc,gcc-objc++,libglib2.0-devel,zlib-devel,python3-pip"
+%CYGWIN_ROOT%\%SETUP% -qnNdO -R "%CYGWIN_ROOT%" -s "%CYGWIN_MIRROR%" -s "%CYGWIN_ADDITIONAL_REPO%" -K "%CYGWIN_ADDITIONAL_REPO_KEY%" -l "%CACHE%" -g -P "ninja,gcc-objc,gcc-objc++,libglib2.0-devel,zlib-devel,python3-pip"
 echo Install done

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -89,16 +89,19 @@ def find_coverage_tools():
         genhtml_exe = None
     return gcovr_exe, lcov_exe, genhtml_exe
 
-def detect_ninja(version='1.5'):
+def detect_ninja(version='1.5', log=False):
     for n in ['ninja', 'ninja-build']:
         try:
             p, found = Popen_safe([n, '--version'])[0:2]
         except (FileNotFoundError, PermissionError):
             # Doesn't exist in PATH or isn't executable
             continue
+        found = found.strip()
         # Perhaps we should add a way for the caller to know the failure mode
         # (not found or too old)
         if p.returncode == 0 and mesonlib.version_compare(found, '>=' + version):
+            if log:
+                mlog.log('Found ninja-{} at {}'.format(found, shlex.quote(shutil.which(n))))
             return n
 
 def detect_native_windows_arch():

--- a/run_tests.py
+++ b/run_tests.py
@@ -105,7 +105,10 @@ def get_backend_commands(backend, debug=False):
 
 def ensure_backend_detects_changes(backend):
     # We're using a ninja with QuLogic's patch for sub-1s resolution timestamps
-    if 'MESON_FIXED_NINJA' in os.environ:
+    # and not running on HFS+ which only stores dates in seconds:
+    # https://developer.apple.com/legacy/library/technotes/tn/tn1150.html#HFSPlusDates
+    # FIXME: Upgrade Travis image to Apple FS when that becomes available
+    if 'MESON_FIXED_NINJA' in os.environ and not mesonlib.is_osx():
         return
     # This is needed to increase the difference between build.ninja's
     # timestamp and the timestamp of whatever you changed due to a Ninja

--- a/run_tests.py
+++ b/run_tests.py
@@ -104,6 +104,9 @@ def get_backend_commands(backend, debug=False):
     return cmd, clean_cmd, test_cmd, install_cmd, uninstall_cmd
 
 def ensure_backend_detects_changes(backend):
+    # We're using a ninja with QuLogic's patch for sub-1s resolution timestamps
+    if 'MESON_FIXED_NINJA' in os.environ:
+        return
     # This is needed to increase the difference between build.ninja's
     # timestamp and the timestamp of whatever you changed due to a Ninja
     # bug: https://github.com/ninja-build/ninja/issues/371


### PR DESCRIPTION
This way we get some testing for the patches, and speed up our builds.

My server is hosted on a UK Linode, so it should have good uptimes. However, we should likely move this into the Docker image at least for Linux, and perhaps put it in a CI cache for the rest. Current timings:

Windows: [1h 1m](https://ci.appveyor.com/project/jpakkane/meson/build/2886)
Linux + macOS: [1h 24m](https://travis-ci.org/mesonbuild/meson/builds/241687175)

Linux currently takes 16-17 min per job, macOS takes 9 min, with a lot of it spent in `brew`.