### PR TITLE
compilers: Make to_native() idempotent again

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -414,7 +414,7 @@ class CompilerArgs(list):
 
         a) Whether an argument can be 'overriden' by a later argument.  For
            example, -DFOO defines FOO and -UFOO undefines FOO. In this case, we
-           can safely remove the previous occurance and add a new one. The same
+           can safely remove the previous occurrence and add a new one. The same
            is true for include paths and library paths with -I and -L. For
            these we return `2`. See `dedup2_prefixes` and `dedup2_args`.
         b) Arguments that once specified cannot be undone, such as `-c` or
@@ -447,22 +447,34 @@ class CompilerArgs(list):
             return True
         return False
 
-    def to_native(self):
+    def _fix_broken_linkers(self):
         # Check if we need to add --start/end-group for circular dependencies
         # between static libraries.
-        if get_compiler_uses_gnuld(self.compiler):
-            group_started = False
-            for each in self:
-                if not each.startswith('-l') and not each.endswith('.a'):
-                    continue
-                i = self.index(each)
-                if not group_started:
-                    # First occurance of a library
-                    self.insert(i, '-Wl,--start-group')
-                    group_started = True
-            # Last occurance of a library
-            if group_started:
-                self.insert(i + 1, '-Wl,--end-group')
+        if not get_compiler_uses_gnuld(self.compiler):
+            return
+        group_start = None
+        group_end = None
+        for i, each in enumerate(self):
+            # Must ensure that we don't accidentally nest --start/end-group
+            # since older `ld` versions (such as 2.20) barf on that:
+            # https://github.com/mesonbuild/meson/issues/1936
+            # We could add complicated logic here to detect nesting, but
+            # users should not be adding --start-group themselves. KISS for now.
+            if each.endswith('--start-group'):
+                return
+            if not each.startswith('-l') and not each.endswith('.a'):
+                continue
+            if group_start is None:
+                # First occurrence of a library
+                group_start = i
+            # Last seen occurrence of a library
+            group_end = i
+        if group_start is not None and group_end is not None:
+            self.insert(group_start, '-Wl,--start-group')
+            self.insert(group_end + 2, '-Wl,--end-group')
+
+    def to_native(self):
+        self._fix_broken_linkers()
         return self.compiler.unix_args_to_native(self)
 
     def append_direct(self, arg):
@@ -494,15 +506,15 @@ class CompilerArgs(list):
             raise TypeError('can only concatenate list (not "{}") to list'.format(args))
         for arg in args:
             # If the argument can be de-duped, do it either by removing the
-            # previous occurance of it and adding a new one, or not adding the
-            # new occurance.
+            # previous occurrence of it and adding a new one, or not adding the
+            # new occurrence.
             dedup = self._can_dedup(arg)
             if dedup == 1:
                 # Argument already exists and adding a new instance is useless
                 if arg in self or arg in pre or arg in post:
                     continue
             if dedup == 2:
-                # Remove all previous occurances of the arg and add it anew
+                # Remove all previous occurrences of the arg and add it anew
                 if arg in self:
                     self.remove(arg)
                 if arg in pre:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1792,9 +1792,12 @@ class LinuxlikeTests(BasePlatformTests):
         else:
             raise unittest.SkipTest('No --start-group, not using GNU ld?')
         nested = re.compile('--start-group.*--start-group')
+        correct = re.compile('--start-group.*-lz.*--end-group')
         for line in mesonlog:
             if '--start-group' in line:
                 self.assertNotRegex(line, nested)
+                if '-lz' in line:
+                    self.assertRegex(line, correct)
 
 
 class LinuxArmCrossCompileTests(BasePlatformTests):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1388,6 +1388,10 @@ class LinuxlikeTests(BasePlatformTests):
     '''
     Tests that should run on Linux and *BSD
     '''
+    def setUp(self):
+        super().setUp()
+        self.platform_test_dir = os.path.join(self.src_root, 'test cases/linuxlike')
+
     def test_basic_soname(self):
         '''
         Test that the soname is set correctly for shared libraries. This can't
@@ -1773,6 +1777,25 @@ class LinuxlikeTests(BasePlatformTests):
                         previous_index = current_index
                     return
         raise RuntimeError('Linker entries not found in the Ninja file.')
+
+    def test_library_group_nesting(self):
+        '''
+        Older ld versions (such as 2.20) error out on nested library groupings
+        with --start/end-group: https://github.com/mesonbuild/meson/issues/1936
+        '''
+        testdir = os.path.join(self.platform_test_dir, '1 pkg-config')
+        self.init(testdir)
+        mesonlog = self.get_meson_log()
+        for line in mesonlog:
+            if '--start-group' in line:
+                break
+        else:
+            raise unittest.SkipTest('No --start-group, not using GNU ld?')
+        nested = re.compile('--start-group.*--start-group')
+        for line in mesonlog:
+            if '--start-group' in line:
+                self.assertNotRegex(line, nested)
+
 
 class LinuxArmCrossCompileTests(BasePlatformTests):
     '''


### PR DESCRIPTION
Don't try to add `--start-group` if we already have `--start-group` somewhere in the command line. This is a simplistic way of ensuring that we don't have nested `--start/end-group` pairs which cause linker errors with older ld (2.20).

Includes a unit test.

Closes https://github.com/mesonbuild/meson/issues/1936