### PR TITLE
Make external library no-op when used with incompatible target

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -528,7 +528,10 @@ class ExternalLibrary(ExternalDependency):
         C-like code. Note that C++ libraries *can* be linked with C code with
         a C++ linker (and vice-versa).
         '''
-        if self.language == 'vala' and language != 'vala':
+        # Using a vala library in a non-vala target, or a non-vala library in a vala target
+        # XXX: This should be extended to other non-C linkers such as Rust
+        if (self.language == 'vala' and language != 'vala') or \
+           (language == 'vala' and self.language != 'vala'):
             return []
         return self.link_args
 

--- a/test cases/vala/16 mixed dependence/meson.build
+++ b/test cases/vala/16 mixed dependence/meson.build
@@ -1,6 +1,10 @@
 project('mixed dependence', 'vala', 'c')
 
-deps = [dependency('glib-2.0'), dependency('gobject-2.0')]
+cc = meson.get_compiler('c')
+
+deps = [dependency('glib-2.0'), dependency('gobject-2.0'),
+        # Should be ignored, see https://github.com/mesonbuild/meson/issues/1939
+        cc.find_library('z')]
 
 mixer = static_library('mixer', 'mixer.vala', 'mixer-glue.c',
   dependencies : deps)


### PR DESCRIPTION
This is how it used to behave earlier, but we accidentally regressed

Includes a test.

Closes https://github.com/mesonbuild/meson/issues/1939