### PR TITLE
Consistently use windows.h, not Windows.h

### DIFF
--- a/test cases/windows/1 basic/prog.c
+++ b/test cases/windows/1 basic/prog.c
@@ -1,4 +1,4 @@
-#include <Windows.h>
+#include <windows.h>
 
 int main(int argc, char **argv) {
     return 0;


### PR DESCRIPTION
This is significant when compiling using gcc on a case-sensitive filesystem.