### PR TITLE
Small gtkdoc improvements

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -294,7 +294,7 @@ class GnomeModule(ExtensionModule):
         else:
             link_command = ['-l' + lib.name]
         if isinstance(lib, build.SharedLibrary):
-            libdir = state.backend.get_target_dir(lib)
+            libdir = os.path.join(state.environment.get_build_dir(), state.backend.get_target_dir(lib))
             link_command.append('-L' + libdir)
             # Needed for the following binutils bug:
             # https://github.com/mesonbuild/meson/issues/1911

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -303,6 +303,8 @@ class GnomeModule(ExtensionModule):
             for d in state.backend.determine_rpath_dirs(lib):
                 d = os.path.join(state.environment.get_build_dir(), d)
                 link_command.append('-L' + d)
+                if include_rpath:
+                    link_command.append('-Wl,-rpath,' + d)
             if include_rpath:
                 link_command.append('-Wl,-rpath,' + libdir)
             if depends:

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -702,6 +702,8 @@ class GnomeModule(ExtensionModule):
                 for inc_dir in src_dir.get_incdirs():
                     header_dirs.append(os.path.join(state.environment.get_source_dir(),
                                                     src_dir.get_curdir(), inc_dir))
+                    header_dirs.append(os.path.join(state.environment.get_build_dir(),
+                                                    src_dir.get_curdir(), inc_dir))
             else:
                 header_dirs.append(src_dir)
 

--- a/test cases/frameworks/10 gtk-doc/doc/foobar-docs.sgml
+++ b/test cases/frameworks/10 gtk-doc/doc/foobar-docs.sgml
@@ -34,6 +34,7 @@
       </para>
     </partintro>
     <xi:include href="xml/foo.xml"/>
+    <xi:include href="xml/foo-version.xml"/>
   </reference>
 
 </book>

--- a/test cases/frameworks/10 gtk-doc/include/foo-version.h.in
+++ b/test cases/frameworks/10 gtk-doc/include/foo-version.h.in
@@ -1,0 +1,29 @@
+#pragma once
+
+/**
+ * SECTION:version
+ * @section_id: foo-version
+ * @short_description: <filename>foo-version.h</filename>
+ * @title: Foo Versioning
+ */
+
+/**
+ * FOO_MAJOR_VERSION:
+ *
+ * The major version of foo.
+ */
+#define FOO_MAJOR_VERSION (@FOO_MAJOR_VERSION@)
+
+/**
+ * FOO_MINOR_VERSION:
+ *
+ * The minor version of foo.
+ */
+#define FOO_MINOR_VERSION (@FOO_MINOR_VERSION@)
+
+/**
+ * FOO_MICRO_VERSION:
+ *
+ * The micro version of foo.
+ */
+#define FOO_MICRO_VERSION (@FOO_MICRO_VERSION@)

--- a/test cases/frameworks/10 gtk-doc/include/meson.build
+++ b/test cases/frameworks/10 gtk-doc/include/meson.build
@@ -1,0 +1,10 @@
+cdata = configuration_data()
+parts = meson.project_version().split('.')
+cdata.set('FOO_MAJOR_VERSION', parts[0])
+cdata.set('FOO_MINOR_VERSION', parts[1])
+cdata.set('FOO_MICRO_VERSION', parts[2])
+configure_file(input : 'foo-version.h.in',
+  output : 'foo-version.h',
+  configuration : cdata,
+  install : true,
+  install_dir : get_option('includedir'))

--- a/test cases/frameworks/10 gtk-doc/meson.build
+++ b/test cases/frameworks/10 gtk-doc/meson.build
@@ -1,10 +1,12 @@
-project('gtkdoctest', 'c')
+project('gtkdoctest', 'c', version : '1.0.0')
 
 gnome = import('gnome')
 
 assert(gnome.gtkdoc_html_dir('foobar') == 'share/gtkdoc/html/foobar', 'Gtkdoc install dir is incorrect.')
 
 inc = include_directories('include')
+
+subdir('include')
 
 # We have to disable this test until this bug fix has landed to
 # distros https://bugzilla.gnome.org/show_bug.cgi?id=753145


### PR DESCRIPTION
Fix several small things in gtkdoc, mostly involving not using both the build and source directories.

@nirbheek this adds some additional rpath things around your comment about a bug. It doesn't seem to fail for me, but I'm not sure if this might be a problem.