### PR TITLE
Skip handling non-available dependencies

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -429,6 +429,9 @@ class Backend:
         # NOTE: We must preserve the order in which external deps are
         # specified, so we reverse the list before iterating over it.
         for dep in reversed(target.get_external_deps()):
+            if not dep.found():
+                continue
+
             if compiler.language == 'vala':
                 if isinstance(dep, dependencies.PkgConfigDependency):
                     if dep.name == 'glib-2.0' and dep.version_reqs is not None:

--- a/test cases/vala/3 dep/meson.build
+++ b/test cases/vala/3 dep/meson.build
@@ -2,7 +2,10 @@ project('giotest', 'vala', 'c')
 
 glib = dependency('glib-2.0')
 gobject = dependency('gobject-2.0')
-gio = dependency('gio-2.0')
+gio = [dependency('gio-2.0'),
+       # https://github.com/mesonbuild/meson/issues/1484
+       dependency('gio-unix-2.0', required : false),
+       dependency('gio-windows-2.0', required : false)]
 
 e = executable('gioprog', 'gioprog.vala',
 dependencies : [glib, gobject, gio])


### PR DESCRIPTION
This way, an optional dependency can always be added on Vala targets without
meson adding --pkg

(see e.g. https://bugzilla.gnome.org/show_bug.cgi?id=784062)