### PR TITLE
RPM macros: export LANG=c.UTF-8

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -2,6 +2,7 @@
 %__meson_wrap_mode nodownload
 
 %meson \
+    export LANG=C.UTF-8 \
     export CFLAGS="${CFLAGS:-%__global_cflags}"       \
     export CXXFLAGS="${CXXFLAGS:-%__global_cxxflags}" \
     export FFLAGS="${FFLAGS:-%__global_fflags}"       \
@@ -27,10 +28,13 @@
         %{nil}
 
 %meson_build \
+    export LANG=C.UTF-8 \
     %ninja_build -C %{_vpath_builddir}
 
 %meson_install \
+    export LANG=C.UTF-8 \
     %ninja_install -C %{_vpath_builddir}
 
 %meson_test \
+    export LANG=C.UTF-8 \
     %ninja_test -C %{_vpath_builddir}


### PR DESCRIPTION
meson is spitting out warnings if the build system does not use a
UTF-8 locale. As users of the macros are most likely to be in some
kind of headless build systems, locale is not of a big importance per
se, so we can simply export LANG=C.UTF-8 and silence meson's warnings.