### PR TITLE
fix rpath related backtrace

### DIFF
--- a/mesonbuild/compilers.py
+++ b/mesonbuild/compilers.py
@@ -762,8 +762,8 @@ class Compiler:
         # directory. This breaks reproducible builds.
         rel_rpaths = []
         for p in rpath_paths:
-            if p == from_dir:
-                relative = '' # relpath errors out in this case
+            if p == from_dir or p == '':
+                relative = '' # relpath errors out in these cases
             else:
                 relative = os.path.relpath(p, from_dir)
             rel_rpaths.append(relative)


### PR DESCRIPTION
The code appears to be wanting to avoid errors, but doesn't handle the
case presented here.

NOTE: I'm running into this on the 0.41.1 release and on master.  Surprised that it's not popping up for anyone else?