### PR TITLE
Specifying a custom meson.build file for git/hg subprojects 

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -237,7 +237,7 @@ class Resolver:
                                           cwd=checkoutdir)
         else:
             subprocess.check_call(['hg', 'clone', p.get('url'),
-                                   p.get('directorz')], cwd=self.subdir_root)
+                                   p.get('directory')], cwd=self.subdir_root)
             if revno.lower() != 'tip':
                 subprocess.check_call(['hg', 'checkout', revno],
                                       cwd=checkoutdir)

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -245,9 +245,8 @@ class Resolver:
     def get_build_file(self, p):
         build_file = p.get('build_file')
         print('Looking for %s' % build_file)
-        checkoutdir = os.path.join(self.subdir_root, p.get('directory'))
-        bf_name = os.path.basename(build_file)
-        dst_file = os.path.join(checkoutdir,"meson.build")
+        checkoutdir = os.path.join(self.subdir_root, p.get('directory'))        
+        dst_file = os.path.join(checkoutdir, "meson.build")
         url = urlparse(build_file)
         buff = []
 
@@ -265,7 +264,7 @@ class Resolver:
             except Exception as e:
                 print('Could not read {}'.format(src_file))
                 raise RuntimeError('Could not copy build file from %s\n%s'
-                % (src_file, e))
+                                   % (src_file, e))
 
         # Copy meson.build file for subproject
         try:
@@ -273,7 +272,7 @@ class Resolver:
                 d.write(buff)
         except Exception as e:
             raise RuntimeError('Could not copy build file to %s\n%s'
-                % (dst_file, e))
+                               % (dst_file, e))
 
 
     def get_data(self, url):

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -15,6 +15,7 @@
 from .. import mlog
 import contextlib
 import urllib.request, os, hashlib, shutil
+from urllib.parse import urlparse
 import subprocess
 import sys
 from pathlib import Path
@@ -95,6 +96,9 @@ class PackageDefinition:
     def has_patch(self):
         return 'patch_url' in self.values
 
+    def has_build_file(self):
+        return 'build_file' in self.values
+
 class Resolver:
     def __init__(self, subdir_root, wrap_mode=WrapMode(1)):
         self.wrap_mode = wrap_mode
@@ -147,6 +151,16 @@ class Resolver:
             self.get_hg(p)
         else:
             raise AssertionError('Unreachable code.')
+
+        if p.has_build_file():
+            self.get_build_file(p)
+        else:
+            # Check for a file <name>.meson.build file
+            # in the subproject directory
+            build_file = os.path.join(self.subdir_root, "%s.meson.build" % packagename)
+            if os.path.isfile(build_file):
+                p.set('build_file', build_file)
+                self.get_build_file(p)
         return p.get('directory')
 
     def resolve_git_submodule(self, dirname):
@@ -223,10 +237,44 @@ class Resolver:
                                           cwd=checkoutdir)
         else:
             subprocess.check_call(['hg', 'clone', p.get('url'),
-                                   p.get('directory')], cwd=self.subdir_root)
+                                   p.get('directorz')], cwd=self.subdir_root)
             if revno.lower() != 'tip':
                 subprocess.check_call(['hg', 'checkout', revno],
                                       cwd=checkoutdir)
+
+    def get_build_file(self, p):
+        build_file = p.get('build_file')
+        print('Looking for %s' % build_file)
+        checkoutdir = os.path.join(self.subdir_root, p.get('directory'))
+        bf_name = os.path.basename(build_file)
+        dst_file = os.path.join(checkoutdir,"meson.build")
+        url = urlparse(build_file)
+        buff = []
+
+        # Get data buffer depending on location prefix (http(s))
+        if url.netloc:
+            buff = self.get_data(build_file)
+        else:
+            src_file = os.path.join(self.subdir_root, build_file)
+            if not os.path.exists(src_file):
+                print('Could not find {}'.format(src_file))
+                raise RuntimeError('Build file does not exist! %s' % src_file)
+            try:
+                with open(src_file) as s:
+                    buff = s.read()
+            except Exception as e:
+                print('Could not read {}'.format(src_file))
+                raise RuntimeError('Could not copy build file from %s\n%s'
+                % (src_file, e))
+
+        # Copy meson.build file for subproject
+        try:
+            with open(dst_file, 'w+') as d:
+                d.write(buff)
+        except Exception as e:
+            raise RuntimeError('Could not copy build file to %s\n%s'
+                % (dst_file, e))
+
 
     def get_data(self, url):
         blocksize = 10 * 1024

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -245,7 +245,7 @@ class Resolver:
     def get_build_file(self, p):
         build_file = p.get('build_file')
         print('Looking for %s' % build_file)
-        checkoutdir = os.path.join(self.subdir_root, p.get('directory'))        
+        checkoutdir = os.path.join(self.subdir_root, p.get('directory'))
         dst_file = os.path.join(checkoutdir, "meson.build")
         url = urlparse(build_file)
         buff = []


### PR DESCRIPTION
When including a subproject via [wrap-git] meson will fail if it does not contain a meson.build file (which is in most cases). Intended as helper alongside wrapdb, for example if the subproject is only needed to an extent which is not in the wrapdb or if the build system is offline (clean room). 
This will allow to specify 'build_file' in the .wrap file which will be copied into the checkout directory once checkout is complete. Furthermore it will look for a file <wrapname>.meson.build in the subproject directory and copy it to checkout directory if no build file is specified. 
