### PR TITLE
add project/global args and include_dirs (useful for module maps) to …

### DIFF
--- a/test cases/swift/6 modulemap/main.swift
+++ b/test cases/swift/6 modulemap/main.swift
@@ -1,0 +1,5 @@
+import mylib
+
+let num = getNumber()
+
+print("The number returned from C code is: \(num).")

--- a/test cases/swift/6 modulemap/meson.build
+++ b/test cases/swift/6 modulemap/meson.build
@@ -1,0 +1,8 @@
+project('mixed', 'c', 'swift')
+
+i = include_directories('.')
+lib = static_library('mylib', 'mylib.c')
+exe = executable('prog', 'main.swift',
+  include_directories : [i],
+  link_with : lib)
+test('c module', exe)

--- a/test cases/swift/6 modulemap/module.modulemap
+++ b/test cases/swift/6 modulemap/module.modulemap
@@ -1,0 +1,5 @@
+module mylib [extern_c] {
+    header "mylib.h"
+    link "mylib"
+    export *
+}

--- a/test cases/swift/6 modulemap/mylib.c
+++ b/test cases/swift/6 modulemap/mylib.c
@@ -1,0 +1,5 @@
+#include"mylib.h"
+
+int getNumber() {
+    return 42;
+}

--- a/test cases/swift/6 modulemap/mylib.h
+++ b/test cases/swift/6 modulemap/mylib.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int getNumber();

--- a/test cases/swift/7 modulemap subdir/main.swift
+++ b/test cases/swift/7 modulemap subdir/main.swift
@@ -1,0 +1,5 @@
+import mylib
+
+let num = getNumber()
+
+print("The number returned from C code is: \(num).")

--- a/test cases/swift/7 modulemap subdir/meson.build
+++ b/test cases/swift/7 modulemap subdir/meson.build
@@ -1,0 +1,6 @@
+project('mixed', 'c', 'swift')
+add_project_arguments('-embed-bitcode', language : 'swift')
+subdir('mylib')
+exe = executable('prog', 'main.swift',
+  dependencies : dep)
+test('c module', exe)

--- a/test cases/swift/7 modulemap subdir/mylib/meson.build
+++ b/test cases/swift/7 modulemap subdir/mylib/meson.build
@@ -1,0 +1,4 @@
+
+i = include_directories('.')
+lib = static_library('mylib', 'mylib.c')
+dep = declare_dependency(include_directories : i, link_with : lib)

--- a/test cases/swift/7 modulemap subdir/mylib/module.modulemap
+++ b/test cases/swift/7 modulemap subdir/mylib/module.modulemap
@@ -1,0 +1,5 @@
+module mylib [extern_c] {
+    header "mylib.h"
+    link "mylib"
+    export *
+}

--- a/test cases/swift/7 modulemap subdir/mylib/mylib.c
+++ b/test cases/swift/7 modulemap subdir/mylib/mylib.c
@@ -1,0 +1,5 @@
+#include"mylib.h"
+
+int getNumber() {
+    return 42;
+}

--- a/test cases/swift/7 modulemap subdir/mylib/mylib.h
+++ b/test cases/swift/7 modulemap subdir/mylib/mylib.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int getNumber();


### PR DESCRIPTION
…swift targets

Follow up from https://github.com/mesonbuild/meson/pull/1912 since I somehow messed the branch and nothing was merged.

Hopefully this is a better patch. It includes 2 new tests with one using a declare_dependency. It also allows to pass other arguments to compiler.