### PR TITLE
VS backends can read platform toolsets from environment

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -81,7 +81,7 @@ class Vs2010Backend(backends.Backend):
         self.name = 'vs2010'
         self.project_file_version = '10.0.30319.1'
         self.sources_conflicts = {}
-        self.platform_toolset = None
+        self.platform_toolset = os.environ.get('PlatformToolset', None)
         self.vs_version = '2010'
         self.windows_target_platform_version = None
 

--- a/mesonbuild/backend/vs2015backend.py
+++ b/mesonbuild/backend/vs2015backend.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from .vs2010backend import Vs2010Backend
 
 
@@ -19,5 +21,5 @@ class Vs2015Backend(Vs2010Backend):
     def __init__(self, build):
         super().__init__(build)
         self.name = 'vs2015'
-        self.platform_toolset = 'v140'
+        self.platform_toolset = os.environ.get('PlatformToolset', 'v140')
         self.vs_version = '2015'

--- a/mesonbuild/backend/vs2017backend.py
+++ b/mesonbuild/backend/vs2017backend.py
@@ -21,7 +21,7 @@ class Vs2017Backend(Vs2010Backend):
     def __init__(self, build):
         super().__init__(build)
         self.name = 'vs2017'
-        self.platform_toolset = 'v141'
+        self.platform_toolset = os.environ.get('PlatformToolset', 'v141')
         self.vs_version = '2017'
         # WindowsSDKVersion should be set by command prompt.
         sdk_version = os.environ.get('WindowsSDKVersion', None)


### PR DESCRIPTION
I added this feature because having hardcoded PlatformToolset is very uncomfortable for my projects.