### PR TITLE
Allow test to depend on executable target in cross build. 

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -505,8 +505,9 @@ class Backend:
                 cmd = [os.path.join(self.environment.get_build_dir(), self.get_target_filename(t.get_exe()))]
             is_cross = self.environment.is_cross_build() and \
                 self.environment.cross_info.need_cross_compiler() and \
-                self.environment.cross_info.need_exe_wrapper() and \
-                exe.is_cross
+                self.environment.cross_info.need_exe_wrapper()
+            if isinstance(exe, build.BuildTarget):
+                is_cross = is_cross and exe.is_cross
             if is_cross:
                 exe_wrapper = self.environment.cross_info.config['binaries'].get('exe_wrapper', None)
             else:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -505,7 +505,8 @@ class Backend:
                 cmd = [os.path.join(self.environment.get_build_dir(), self.get_target_filename(t.get_exe()))]
             is_cross = self.environment.is_cross_build() and \
                 self.environment.cross_info.need_cross_compiler() and \
-                self.environment.cross_info.need_exe_wrapper()
+                self.environment.cross_info.need_exe_wrapper() and \
+                exe.is_cross
             if is_cross:
                 exe_wrapper = self.environment.cross_info.config['binaries'].get('exe_wrapper', None)
             else:

--- a/test cases/common/1 trivial/meson.build
+++ b/test cases/common/1 trivial/meson.build
@@ -12,7 +12,7 @@ if meson.get_compiler('c').get_id() == 'intel'
 endif
 
 if meson.is_cross_build()
-  native_exe = executable('native-trivialprog', sources : sources)
+  native_exe = executable('native-trivialprog', sources : sources, native : true)
   test('native exe in cross build', native_exe)
 endif
 

--- a/test cases/common/1 trivial/meson.build
+++ b/test cases/common/1 trivial/meson.build
@@ -11,6 +11,11 @@ if meson.get_compiler('c').get_id() == 'intel'
   add_project_arguments('-diag-error', '10159', language : 'c')
 endif
 
+if meson.is_cross_build()
+  native_exe = executable('native-trivialprog', sources : sources)
+  test('native exe in cross build', native_exe)
+endif
+
 exe = executable('trivialprog', sources : sources)
 
 test('runtest', exe) # This is a comment


### PR DESCRIPTION
Allow mixed test in crossbuild.
Use exe.is_cross to check if the executable tested
need to be wrapped by the exe_wrapper.

This option test is added in mesonbuild/backend/backends.py:write_test_serialisation.