### PR TITLE
pkgconfig: add support for extra_cflags

### DIFF
--- a/docs/markdown/Pkgconfig-module.md
+++ b/docs/markdown/Pkgconfig-module.md
@@ -20,4 +20,5 @@ The generated file's properties are specified with the following keyword argumen
 - `requires_private` list of strings to put in the `Requires.private` field
 - `libraries_private` list of strings to put in the `Libraries.private` field
 - `install_dir` the directory to install to, defaults to the value of option `libdir` followed by `/pkgconfig`
+- `extra_cflags` a list of extra compiler flags to be added to the `Cflags` field after the header search path
 - `variables` a list of strings with custom variables to add to the generated file. The strings must be in the form `name=value` and may reference other pkgconfig variables, e.g. `datadir=${prefix}/share`. The names `prefix`, `libdir` and `installdir` are reserved and may not be used.

--- a/docs/markdown/Release-notes-for-0.42.0.md
+++ b/docs/markdown/Release-notes-for-0.42.0.md
@@ -23,3 +23,16 @@ future this will become a hard error.
 The Vala compiler has an alternative syntax, Genie, that uses the `.gs`
 file extension. Meson now recognises and uses Genie files.
 
+## Pkgconfig support for additional cflags
+
+The Pkgconfig module object can add arbitrary extra cflags to the Cflags
+value in the .pc file, using the "extra_cflags" keyword:
+```meson
+pkg.generate(libraries : libs,
+             subdirs : h,
+             version : '1.0',
+             name : 'libsimple',
+             filebase : 'simple',
+             description : 'A simple demo library.',
+             extra_cflags : '-Dfoo' )
+```

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -44,7 +44,7 @@ class PkgConfigModule(ExtensionModule):
 
     def generate_pkgconfig_file(self, state, libraries, subdirs, name, description,
                                 url, version, pcfile, pub_reqs, priv_reqs,
-                                conflicts, priv_libs, variables):
+                                conflicts, priv_libs, extra_cflags, variables):
         coredata = state.environment.get_coredata()
         outdir = state.environment.scratch_dir
         fname = os.path.join(outdir, pcfile)
@@ -101,6 +101,9 @@ class PkgConfigModule(ExtensionModule):
                     h = ''
                 ofile.write(' ')
                 ofile.write(os.path.join('-I${includedir}', h))
+            for f in extra_cflags:
+                ofile.write(' ')
+                ofile.write(f)
             ofile.write('\n')
 
     def process_libs(self, libs):
@@ -117,7 +120,7 @@ class PkgConfigModule(ExtensionModule):
 
     @permittedKwargs({'libraries', 'version', 'name', 'description', 'filebase',
                       'subdirs', 'requires', 'requires_private', 'libraries_private',
-                      'install_dir', 'variables'})
+                      'install_dir', 'extra_cflags', 'variables'})
     def generate(self, state, args, kwargs):
         if len(args) > 0:
             raise mesonlib.MesonException('Pkgconfig_gen takes no positional arguments.')
@@ -142,6 +145,7 @@ class PkgConfigModule(ExtensionModule):
         pub_reqs = mesonlib.stringlistify(kwargs.get('requires', []))
         priv_reqs = mesonlib.stringlistify(kwargs.get('requires_private', []))
         conflicts = mesonlib.stringlistify(kwargs.get('conflicts', []))
+        extra_cflags = mesonlib.stringlistify(kwargs.get('extra_cflags', []))
 
         def parse_variable_list(stringlist):
             reserved = ['prefix', 'libdir', 'includedir']
@@ -177,7 +181,7 @@ class PkgConfigModule(ExtensionModule):
             raise mesonlib.MesonException('Install_dir must be a string.')
         self.generate_pkgconfig_file(state, libs, subdirs, name, description, url,
                                      version, pcfile, pub_reqs, priv_reqs,
-                                     conflicts, priv_libs, variables)
+                                     conflicts, priv_libs, extra_cflags, variables)
         res = build.Data(mesonlib.File(True, state.environment.get_scratch_dir(), pcfile), pkgroot)
         return ModuleReturnValue(res, [res])
 


### PR DESCRIPTION
Allow the user to pass in arbitrary cflags for putting into the pkgconfig
file generated.