### PR TITLE
add_{project,global}_link_arguments require a 'language' argument

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1273,6 +1273,8 @@ build_target_kwargs = exe_kwargs.copy()
 build_target_kwargs.update(['target_type'])
 
 permitted_kwargs = {'add_global_arguments': {'language'},
+                    'add_global_link_arguments': {'language'},
+                    'add_project_link_arguments': {'language'},
                     'add_languages': {'required'},
                     'add_project_arguments': {'language'},
                     'add_test_setup': {'exe_wrapper', 'gdb', 'timeout_multiplier', 'env'},
@@ -2602,7 +2604,7 @@ different subdirectory.
     def func_add_global_arguments(self, node, args, kwargs):
         self.add_global_arguments(node, self.build.global_args, args, kwargs)
 
-    @noKwargs
+    @permittedKwargs(permitted_kwargs['add_global_link_arguments'])
     @stringArgs
     def func_add_global_link_arguments(self, node, args, kwargs):
         self.add_global_arguments(node, self.build.global_link_args, args, kwargs)
@@ -2612,7 +2614,7 @@ different subdirectory.
     def func_add_project_arguments(self, node, args, kwargs):
         self.add_project_arguments(node, self.build.projects_args, args, kwargs)
 
-    @noKwargs
+    @permittedKwargs(permitted_kwargs['add_project_link_arguments'])
     @stringArgs
     def func_add_project_link_arguments(self, node, args, kwargs):
         self.add_project_arguments(node, self.build.projects_link_args, args, kwargs)

--- a/test cases/common/146 C and CPP link/meson.build
+++ b/test cases/common/146 C and CPP link/meson.build
@@ -14,6 +14,10 @@
 
 project('C and C++ static link test', ['c', 'cpp'])
 
+# Verify that adding link arguments works.
+add_global_link_arguments('', language : 'c')
+add_project_link_arguments('', language : 'c')
+
 libc = static_library('cfoo', ['foo.c', 'foo.h'])
 
 # Test that linking C libs to external static C++ libs uses the C++ linker


### PR DESCRIPTION
Commit 325a231a added stricter keyword argument checking, but didn't enable
keyword arguments for `add_projects_link_arguments()` and
`add_global_link_arguments()`. This makes them fail with this error:

```
Meson encountered an error in file meson.build, line 19, column 0:
Function does not take keyword arguments.
```

However, the language argument is required. Removing it produces this error
instead:

```
Meson encountered an error in file meson.build, line 19, column 0:
Missing language definition in add_project_link_arguments
```

Fix this by adding `language` as a required keyword argument. Also add calls to
these in the `146 C and CPP link` test case.