### PR TITLE
Output an appropriate warning when a cross info file does not exist.

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -907,7 +907,12 @@ class CrossBuildInfo:
 
     def parse_datafile(self, filename):
         config = configparser.ConfigParser()
-        config.read(filename)
+        try:
+            f = open(filename, 'r')
+            config.read_file(f, filename)
+            f.close()
+        except FileNotFoundError:
+            raise EnvironmentException('File not found: %s.' % filename)
         # This is a bit hackish at the moment.
         for s in config.sections():
             self.config[s] = {}

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -64,7 +64,7 @@ class permittedKwargs:
         def wrapped(s, node, args, kwargs):
             for k in kwargs:
                 if k not in self.permitted:
-                    mlog.warning('Passed invalid keyword argument %s. This will become a hard error in the future.' % k)
+                    mlog.warning('Passed invalid keyword argument "%s". This will become a hard error in the future.' % k)
             return f(s, node, args, kwargs)
         return wrapped
 

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -15,7 +15,7 @@ class permittedSnippetKwargs:
         def wrapped(s, interpreter, state, args, kwargs):
             for k in kwargs:
                 if k not in self.permitted:
-                    mlog.warning('Passed invalid keyword argument %s. This will become a hard error in the future.' % k)
+                    mlog.warning('Passed invalid keyword argument "%s". This will become a hard error in the future.' % k)
             return f(s, interpreter, state, args, kwargs)
         return wrapped
 


### PR DESCRIPTION
If making a typo, it used to output:
>  Cross info file must have either host or a target machine.
This was not useful at all and looked like there could be a file format
error or some other issue with the content. Let's have an appropriate
error:
> File not found: /some/path

----------
To show how confusing the old error was, I created the issue #2020 because I was just sure something was wrong with my file, while in fact meson was simply not reading my file because I had a typo in the command line (hyphen mistyped into underscore). It took me several dozens of minutes of searching the web for syntax issues, then even looking at meson code until I discovered the boring truth!
A "File not found" error will be far more obvious.