### PR TITLE
Consider `link_whole` as well as `link_with` for Vala deps

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -992,7 +992,7 @@ int dummy;
         the build directory.
         """
         result = OrderedSet()
-        for dep in target.link_targets:
+        for dep in target.link_targets + target.link_whole_targets:
             for i in dep.sources:
                 if hasattr(i, 'fname'):
                     i = i.fname


### PR DESCRIPTION
Otherwise, when you have a static helper library written in Vala
that you want to `link_whole` into a shared library you have to
manually add the .vapi file as a source, or pass both `link_with`
and `link_whole`.