### PR TITLE
Allow for missing install_dir in install_data()

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -691,6 +691,8 @@ arguments. The following keyword arguments are supported:
   directory. If this is a relative path, it is assumed to be relative
   to the prefix.
 
+  If omitted, the directory defaults to `{datadir}/{projectname}` *(added 0.43.0)*.
+
 - `install_mode` specify the file mode in symbolic format and
   optionally the owner/uid and group/gid for the installed files. For
   example:

--- a/docs/markdown/Release-notes-for-0.43.0.md
+++ b/docs/markdown/Release-notes-for-0.43.0.md
@@ -14,3 +14,9 @@ whose contents should look like this:
     # Feature name
 
     A short description explaining the new feature and how it should be used.
+
+# `install_data()` defaults to `{datadir}/{projectname}`
+
+If `install_data()` is not given an `install_dir` keyword argument, the
+target directory defaults to `{datadir}/{projectname}` (e.g.
+`/usr/share/myproj`).

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -817,6 +817,8 @@ int dummy;
         for de in data:
             assert(isinstance(de, build.Data))
             subdir = de.install_dir
+            if not subdir:
+                subdir = os.path.join(self.environment.get_datadir(), self.interpreter.build.project_name)
             for f in de.sources:
                 assert(isinstance(f, mesonlib.File))
                 plain_f = os.path.split(f.fname)[1]

--- a/test cases/common/12 data/installed_files.txt
+++ b/test cases/common/12 data/installed_files.txt
@@ -2,5 +2,6 @@ usr/share/progname/datafile.dat
 usr/share/progname/fileobject_datafile.dat
 usr/share/progname/vanishing.dat
 usr/share/progname/vanishing2.dat
+usr/share/data install test/somefile.txt
 etc/etcfile.dat
 usr/bin/runscript.sh

--- a/test cases/common/12 data/meson.build
+++ b/test cases/common/12 data/meson.build
@@ -10,6 +10,8 @@ install_data(files('fileobject_datafile.dat'),
   install_dir : 'share/progname',
   install_mode : [false, false, 0])
 
+install_data(files('somefile.txt'))
+
 subdir('vanishing')
 
 install_data(sources : 'vanishing/vanishing2.dat', install_dir : 'share/progname')


### PR DESCRIPTION
The documentation doesn't require it and the interpreter code works around the
possibility of it being None. The ninja backend code however fails with

File "/home/whot/code/meson/mesonbuild/backend/ninjabackend.py", line 796, in generate_data_install
    dstabs = os.path.join(subdir or None, plain_f)
File "/usr/lib64/python3.6/posixpath.py", line 78, in join
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType

If install_dir is missing, default to '.'