### PR TITLE
contributing.txt: Remove a sentence that refers to authors.txt

### DIFF
--- a/contributing.txt
+++ b/contributing.txt
@@ -2,8 +2,7 @@ Contributing to the Meson build system
 
 There are two simple ways to submit your patches. The preferred way is
 to send a github pull request. Small changes can also be sent as
-patches as emails to the Meson mailing list. Remember to add your name
-to the list of contributors in authors.txt.
+patches as emails to the Meson mailing list.
 
 
 Python Coding style


### PR DESCRIPTION
The authors.txt file was removed a while ago (9141cd78aabb2e).