### PR TITLE
Ensure same compiler flags are used for compiling PCH as normal sources

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -211,9 +211,10 @@ int dummy;
     # http://clang.llvm.org/docs/JSONCompilationDatabase.html
     def generate_compdb(self):
         ninja_exe = environment.detect_ninja()
+        pch_compilers = ['%s_PCH' % i for i in self.build.compilers]
         native_compilers = ['%s_COMPILER' % i for i in self.build.compilers]
         cross_compilers = ['%s_CROSS_COMPILER' % i for i in self.build.cross_compilers]
-        ninja_compdb = [ninja_exe, '-t', 'compdb'] + native_compilers + cross_compilers
+        ninja_compdb = [ninja_exe, '-t', 'compdb'] + pch_compilers + native_compilers + cross_compilers
         builddir = self.environment.get_build_dir()
         try:
             jsondb = subprocess.check_output(ninja_compdb, cwd=builddir)
@@ -2193,8 +2194,7 @@ rule FORTRAN_DEP_HACK
         return commands, dep, dst, [objname]
 
     def generate_gcc_pch_command(self, target, compiler, pch):
-        commands = []
-        commands += self.generate_basic_compiler_args(target, compiler)
+        commands = self._generate_single_compile(target, compiler)
         dst = os.path.join(self.get_target_private_dir(target),
                            os.path.split(pch)[-1] + '.' + compiler.get_pch_suffix())
         dep = dst + '.' + compiler.get_depfile_suffix()

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1877,6 +1877,13 @@ class LinuxlikeTests(BasePlatformTests):
         install_rpath = get_rpath(os.path.join(self.installdir, 'usr/bin/prog'))
         self.assertEqual(install_rpath, '/baz')
 
+    def test_pch_with_address_sanitizer(self):
+        testdir = os.path.join(self.common_test_dir, '13 pch')
+        self.init(testdir, ['-Db_sanitize=address'])
+        self.build()
+        compdb = self.get_compdb()
+        for i in compdb:
+            self.assertIn("-fsanitize=address", i["command"])
 
 class LinuxArmCrossCompileTests(BasePlatformTests):
     '''


### PR DESCRIPTION
Precompiled headers should generally be compiled with the same flags as
the sources that will include the header. Some deviations are safe,
however, most will cause the compiler to reject the precompiled header
or possibly lead to compiler crashes.