### PR TITLE
Run postconf scripts after dumping coredata.

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -349,6 +349,7 @@ class Environment:
         cdf = os.path.join(self.get_build_dir(), Environment.coredata_file)
         coredata.save(self.coredata, cdf)
         os.utime(cdf, times=(mtime, mtime))
+        return cdf
 
     def get_script_dir(self):
         import mesonbuild.scripts


### PR DESCRIPTION
MESONINTROSPECT is set when running postconf scripts, which implies that introspection is possible. But it isn't really possible because coredata hasn't been written yet. We also still need to make sure to delete coredata if any postconf scripts fail.