### PR TITLE
Fix how rpath directories are handled.

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -763,14 +763,10 @@ class Compiler:
         # directory. This breaks reproducible builds.
         rel_rpaths = []
         for p in rpath_paths:
-            # p can be an empty string for build_dir (relative path), but
-            # os.path.relpath() below won't like that.
-            if p == '':
-                p = build_dir
             if p == from_dir:
                 relative = '' # relpath errors out in this case
             else:
-                relative = os.path.relpath(p, from_dir)
+                relative = os.path.relpath(os.path.join(build_dir, p), os.path.join(build_dir, from_dir))
             rel_rpaths.append(relative)
         paths = ':'.join([os.path.join('$ORIGIN', p) for p in rel_rpaths])
         if len(paths) < len(install_rpath):


### PR DESCRIPTION
Linking a library from a directory below the executable's directory caused
an invalid path to be written in the executable's RPATH.

To reproduce:

- This works: `mkdir b && cd b && ../meson.py ../test\ cases/common/154\ library\ at\ root/ && ninja test && cd ..`
- This doesn't:  `./meson.py b test\ cases/common/154\ library\ at\ root/ && cd b && ninja test && cd ..`