### PR TITLE
Make base options accessible via get_option()

### DIFF
--- a/docs/markdown/Release-notes-for-0.42.0.md
+++ b/docs/markdown/Release-notes-for-0.42.0.md
@@ -37,6 +37,13 @@ pkg.generate(libraries : libs,
              extra_cflags : '-Dfoo' )
 ```
 
+## Base options accessible via get_option()
+
+Base options are now accessible via the get_option() function.
+```meson
+uses_lto = get_option('b_lto')
+```
+
 ## Allow crate type configuration for Rust compiler
 
 Rust targets now take an optional `rust_crate_type` keyword, allowing

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1655,6 +1655,10 @@ class Interpreter(InterpreterBase):
             raise InterpreterException('Argument required for get_option.')
         optname = args[0]
         try:
+            return compilers.base_options[optname].value
+        except KeyError:
+            pass
+        try:
             return self.environment.get_coredata().get_builtin_option(optname)
         except RuntimeError:
             pass

--- a/test cases/common/47 options/meson.build
+++ b/test cases/common/47 options/meson.build
@@ -12,6 +12,10 @@ if get_option('combo_opt') != 'combo'
   error('Incorrect value to combo option.')
 endif
 
+if get_option('b_lto') != false
+  error('Incorrect value in base option.')
+endif
+
 if get_option('includedir') != 'include'
   error('Incorrect value in builtin option.')
 endif


### PR DESCRIPTION
This feature is useful to me because C files in my project don't include any system headers, but rely on the precompiled header to include them.

Meson automagically includes the precompiled header when that feature is enabled (by default). When configuring meson with `-Db_pch=false` it is up to me to include the needed system headers.

With this patch applied, I can achieve this with the following:
```meson
executable(..., c_args: get_option('b_pch') ? [] : ['-include', 'pch/pch.h'])
```