### PR TITLE
Modify mesonintrospect --dependencies so 1 element in list is 1 depen…

### DIFF
--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -160,9 +160,9 @@ def list_deps(coredata):
     result = []
     for d in coredata.deps.values():
         if d.found():
-            args = {'compile_args': d.get_compile_args(),
-                    'link_args': d.get_link_args()}
-            result += [d.name, args]
+            result += [{'name': d.name,
+                        'compile_args': d.get_compile_args(),
+                        'link_args': d.get_link_args()}]
     print(json.dumps(result))
 
 def list_tests(testdata):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1828,6 +1828,28 @@ class LinuxlikeTests(BasePlatformTests):
                     return
         raise RuntimeError('Linker entries not found in the Ninja file.')
 
+    def test_introspect_dependencies(self):
+        '''
+        Tests that mesonintrospect --dependencies returns expected output.
+        '''
+        testdir = os.path.join(self.framework_test_dir, '7 gnome')
+        self.init(testdir)
+        glib_found = False
+        gobject_found = False
+        deps = self.introspect('--dependencies')
+        self.assertIsInstance(deps, list)
+        for dep in deps:
+            self.assertIsInstance(dep, dict)
+            self.assertIn('name', dep)
+            self.assertIn('compile_args', dep)
+            self.assertIn('link_args', dep)
+            if dep['name'] == 'glib-2.0':
+                glib_found = True
+            elif dep['name'] == 'gobject-2.0':
+                gobject_found = True
+        self.assertTrue(glib_found)
+        self.assertTrue(gobject_found)
+
 class LinuxArmCrossCompileTests(BasePlatformTests):
     '''
     Tests that verify cross-compilation to Linux/ARM


### PR DESCRIPTION
…dency

Makes it less awkward for tools to parse the data.

Was modified to return a list, with two elements for each dependency,
instead of a dictionary in ac1c929f66bde7209f1bd7e2d995dbd3949e1d8b .

Closes #2018.