### PR TITLE
Support glib-genmarshal from GLib 2.54

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -61,7 +61,8 @@ the output files.
 * `internal`: if true, mark generated sources as internal
 * `skip_source`: if true, skip source location comments
 * `valist_marshallers`: if true, generate va_list marshallers
-
+* `extra_args`: (*Added 0.42.0*) additional command line arguments to pass
+  to `glib-genmarshal` (*Requires GLib 2.54*)
 
 *Added 0.35.0*
 

--- a/test cases/frameworks/7 gnome/genmarshal/meson.build
+++ b/test cases/frameworks/7 gnome/genmarshal/meson.build
@@ -1,7 +1,8 @@
 marshallers = gnome.genmarshal('marshaller',
 sources : 'marshaller.list',
 install_header : true,
-install_dir : get_option('includedir'))
+install_dir : get_option('includedir'),
+extra_args : ['-UG_ENABLE_DEBUG', '--prototypes'])
 
 marshaller_c = marshallers[0]
 marshaller_h = marshallers[1]


### PR DESCRIPTION
Glib-genmarshal has new command line arguments, and Meson should support them.