### PR TITLE
Small Rust fixes

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1173,6 +1173,7 @@ int dummy;
         else:
             raise InvalidArguments('Unknown target type for rustc.')
         args.append(cratetype)
+        args += ['--crate-name', target.name]
         args += rustc.get_buildtype_args(self.get_option_for_target('buildtype', target))
         depfile = os.path.join(target.subdir, target.name + '.d')
         args += ['--emit', 'dep-info={}'.format(depfile), '--emit', 'link']

--- a/test cases/rust/6 named staticlib/installed_files.txt
+++ b/test cases/rust/6 named staticlib/installed_files.txt
@@ -1,0 +1,2 @@
+usr/bin/prog?exe
+usr/lib/libnamed_stuff.rlib

--- a/test cases/rust/6 named staticlib/meson.build
+++ b/test cases/rust/6 named staticlib/meson.build
@@ -1,0 +1,5 @@
+project('rust static library', 'rust')
+
+l = static_library('named_stuff', 'stuff.rs', install : true)
+e = executable('prog', 'prog.rs', link_with : l, install : true)
+test('linktest', e)

--- a/test cases/rust/6 named staticlib/prog.rs
+++ b/test cases/rust/6 named staticlib/prog.rs
@@ -1,0 +1,3 @@
+extern crate named_stuff;
+
+fn main() { println!("printing: {}", named_stuff::explore()); }

--- a/test cases/rust/6 named staticlib/stuff.rs
+++ b/test cases/rust/6 named staticlib/stuff.rs
@@ -1,0 +1,1 @@
+pub fn explore() -> &'static str { "librarystring" }


### PR DESCRIPTION
A couple small fixes to improve quality of life for Rustaceans:

First, pass the target name to `rustc` as a `crate-name` argument, rather than relying on pragmas within the Rust source files. This reduces the extent to which existing Rust sources must be modified in order to work under Meson.

Second, use the default Ninja behavior for `rustc`-generated depfiles. This prevents unnecessary rebuilding; see c93ef9b.