### PR TITLE
docs: fixed meson syntax for Generating-sources.md

### DIFF
--- a/docs/markdown/Generating-sources.md
+++ b/docs/markdown/Generating-sources.md
@@ -24,8 +24,8 @@ Custom targets can take zero or more input files and use them to generate one or
 
 ```meson
 gen_src = custom_target('gen-output',
-                        input : ['somefile1.c', 'file2.c']
-                        output : ['out.c', 'out.h']
+                        input : ['somefile1.c', 'file2.c'],
+                        output : ['out.c', 'out.h'],
                         command : [mycomp, '@INPUT@',
                                    '--c-out', '@OUTPUT0@',
                                    '--h-out', '@OUTPUT1@'])


### PR DESCRIPTION
Syntax is off for generating sources, needs commas.

Signed-off-by: Marty Plummer <ntzrmtthihu777@gmail.com>