### PR TITLE
added *.pyc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ packagecache
 
 /docs/built_docs
 /docs/hotdoc-private*
+
+*.pyc


### PR DESCRIPTION
`.pyc` files are never checked into `git` and they can occur, e.g.

    mesonbuild/__init__.pyc
    mesonbuild/coredata.pyc
    mesonbuild/mesonlib.pyc

so it doesn't hurt to exclude them.