### PR TITLE
Various gtkdoc fixes

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -136,14 +136,14 @@ Note that very old versions of yelp may not support symlinked media; At least 3.
 
 ### gnome.gtkdoc()
 
-Compiles and installs gtkdoc documentation. Takes one positional arguments; The name of the module.
+Compiles and installs gtkdoc documentation into `prefix/share/gtk-doc/html`. Takes one positional argument: The name of the module.
 
 * `main_xml`: specifies the main XML file
 * `main_sgml`: equal to `main_xml`
 * `src_dir`: include_directories to include
 * `dependencies`: a list of dependencies
 * `install`: if true, installs the generated docs
-* `install_dir`: the directory to install the generated docs
+* `install_dir`: the directory to install the generated docs relative to the gtk-doc html dir or an absolute path (default: module name)
 * `scan_args`: a list of arguments to pass to `gtkdoc-scan`
 * `scanobjs_args`: a list of arguments to pass to `gtkdoc-scangobj`
 * `gobject_typesfile`: a list of type files

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -291,11 +291,8 @@ class GnomeModule(ExtensionModule):
 
     def _get_link_args(self, state, lib, depends=None, include_rpath=False,
                        use_gir_args=False):
+        link_command = []
         # Construct link args
-        if gir_has_extra_lib_arg() and use_gir_args:
-            link_command = ['--extra-library=' + lib.name]
-        else:
-            link_command = ['-l' + lib.name]
         if isinstance(lib, build.SharedLibrary):
             libdir = os.path.join(state.environment.get_build_dir(), state.backend.get_target_dir(lib))
             link_command.append('-L' + libdir)
@@ -312,6 +309,10 @@ class GnomeModule(ExtensionModule):
                 link_command.append('-Wl,-rpath,' + libdir)
             if depends:
                 depends.append(lib)
+        if gir_has_extra_lib_arg() and use_gir_args:
+            link_command.append('--extra-library=' + lib.name)
+        else:
+            link_command.append('-l' + lib.name)
         return link_command
 
     def _get_dependencies_flags(self, deps, state, depends=None, include_rpath=False,

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -218,12 +218,14 @@ def run(args):
         options.mode)
 
     if 'MESON_INSTALL_PREFIX' in os.environ:
-        install_dir = options.install_dir if options.install_dir else options.modulename
         destdir = os.environ.get('DESTDIR', '')
-        installdir = destdir_join(destdir, os.environ['MESON_INSTALL_PREFIX'])
+        install_prefix = destdir_join(destdir, os.environ['MESON_INSTALL_PREFIX'])
+        install_dir = options.install_dir if options.install_dir else options.modulename
+        if os.path.isabs(install_dir):
+            install_dir = destdir_join(destdir, install_dir)
         install_gtkdoc(options.builddir,
                        options.subdir,
-                       installdir,
+                       install_prefix,
                        'share/gtk-doc/html',
                        install_dir)
     return 0


### PR DESCRIPTION
commit a0bd896b2fcee3f9a0fc30df6775e2e325294024

    gnome module: Add -lfoo after -Lbar LDFLAGS
    
    Otherwise they won't take effect

commit 04ac7a48447b884544d160ebee824ad571408c79

    gnome.gtkdoc: Handle absolute install_dirs correctly
    
    Must prepend DESTDIR in case it's absolute. Also document that by
    default it is relative to the gtk-doc html directory.
