### PR TITLE
Removed minor typos in documentation.

### DIFF
--- a/docs/markdown/Quick-guide.md
+++ b/docs/markdown/Quick-guide.md
@@ -62,7 +62,7 @@ $ CFLAGS=... CXXFLAGS=... LDFLAGS=.. meson --prefix /usr --buildtype=plain build
 $ ninja -v -C builddir
 $ ninja -C builddir test
 $ DESTDIR=/path/to/staging/root ninja -C builddir install
-````
+```
 
 The command line switch `--buildtype=plain` tells Meson not to add its own flags to the command line. This gives the packager total control on used flags.
 

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -40,7 +40,7 @@ project('foobar', 'c')
 if compiling_for_osx
   add_languages('objc')
 endif
-````
+```
 
 Takes one keyword argument, `required`. It defaults to `true`, which means that if any of the languages specified is not found, Meson will halt. Returns true if all languages specified were found and false otherwise.
 

--- a/docs/markdown/Subprojects.md
+++ b/docs/markdown/Subprojects.md
@@ -62,7 +62,7 @@ proj_dep = declare_dependency(...)
 Then you can use the subproject in the master project like this:
 
 ```meson
-sp_dep = dependency('subproj_pkgconfig_name', fallback : ['subproj_name', 'proj_dep']
+sp_dep = dependency('subproj_pkgconfig_name', fallback : ['subproj_name', 'proj_dep'])
 ```
 
 This uses the system dependency when available and the self built version if not. If you want to always use the subproject, that is also possible, just use `subproject` and `get_variable` as discussed above to get the dependency object.


### PR DESCRIPTION
Here are the last typo I found in the doc.
I mostly checked meson code samples in documentation. I checked that no comma/parenthesis where missing. I red most of the text, I didn't found anything else :).