### PR TITLE
i18n: Fixed gettext permitted Kwargs list

### DIFF
--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -81,7 +81,7 @@ class I18nModule(ExtensionModule):
         ct = build.CustomTarget(kwargs['output'] + '_merge', state.subdir, kwargs)
         return ModuleReturnValue(ct, [ct])
 
-    @permittedKwargs({'po_dir', 'data_dirs', 'type', 'languages'})
+    @permittedKwargs({'po_dir', 'data_dirs', 'type', 'languages', 'args', 'preset'})
     def gettext(self, state, args, kwargs):
         if len(args) != 1:
             raise coredata.MesonException('Gettext requires one positional argument (package name).')


### PR DESCRIPTION
This change fixes the permitted kwargs list which was missing 'preset' and 'args' keywords.