### PR TITLE
find_library: Ignore libs on MSVC properly

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -676,11 +676,11 @@ class CCompiler(Compiler):
         raise RuntimeError('BUG: {!r} check failed unexpectedly'.format(n))
 
     def find_library(self, libname, env, extra_dirs):
+        # These libraries are either built-in or invalid
+        if libname in self.ignore_libs:
+            return []
         # First try if we can just add the library as -l.
-        code = '''int main(int argc, char **argv) {
-    return 0;
-}
-        '''
+        code = 'int main(int argc, char **argv) { return 0; }'
         if extra_dirs and isinstance(extra_dirs, str):
             extra_dirs = [extra_dirs]
         # Gcc + co seem to prefer builtin lib dirs to -L dirs.
@@ -811,6 +811,7 @@ class IntelCCompiler(IntelCompiler, CCompiler):
 class VisualStudioCCompiler(CCompiler):
     std_warn_args = ['/W3']
     std_opt_args = ['/O2']
+    ignore_libs = ('m', 'c', 'pthread')
 
     def __init__(self, exelist, version, is_cross, exe_wrap, is_64):
         CCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
@@ -941,7 +942,7 @@ class VisualStudioCCompiler(CCompiler):
             # Translate GNU-style -lfoo library name to the import library
             elif i.startswith('-l'):
                 name = i[2:]
-                if name in ('m', 'c', 'pthread'):
+                if name in cls.ignore_libs:
                     # With MSVC, these are provided by the C runtime which is
                     # linked in by default
                     continue

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -586,6 +586,10 @@ class CompilerArgs(list):
         self.__iadd__(args)
 
 class Compiler:
+    # Libraries to ignore in find_library() since they are provided by the
+    # compiler or the C library. Currently only used for MSVC.
+    ignore_libs = ()
+
     def __init__(self, exelist, version):
         if isinstance(exelist, str):
             self.exelist = [exelist]

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1431,6 +1431,23 @@ class WindowsTests(BasePlatformTests):
         self.assertPathEqual(prog.get_command()[0], sys.executable)
         self.assertPathBasenameEqual(prog.get_path(), 'test-script-ext.py')
 
+    def test_ignore_libs(self):
+        '''
+        Test that find_library on libs that are to be ignored returns an empty
+        array of arguments. Must be a unit test because we cannot inspect
+        ExternalLibraryHolder from build files.
+        '''
+        testdir = os.path.join(self.platform_test_dir, '1 basic')
+        env = Environment(testdir, self.builddir, self.meson_command,
+                          get_fake_options(self.prefix), [])
+        cc = env.detect_c_compiler(False)
+        if cc.id != 'msvc':
+            raise unittest.SkipTest('Not using MSVC')
+        # To force people to update this test, and also test
+        self.assertEqual(set(cc.ignore_libs), {'c', 'm', 'pthread'})
+        for l in cc.ignore_libs:
+            self.assertEqual(cc.find_library(l, env, []), [])
+
 
 class LinuxlikeTests(BasePlatformTests):
     '''


### PR DESCRIPTION
In addition to filtering libs out while generating the command-line, we must also filter them out in `find_library()` otherwise these libs will be detected as "found" on Windows with MSVC.

Closes https://github.com/mesonbuild/meson/issues/1509