### PR TITLE
gnome: Fix wrong include path

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -376,9 +376,7 @@ class GnomeModule(ExtensionModule):
                     if girdir:
                         gi_includes.update([girdir])
             elif isinstance(dep, (build.StaticLibrary, build.SharedLibrary)):
-                for incd in dep.get_include_dirs():
-                    for idir in incd.get_incdirs():
-                        cflags.update(["-I%s" % idir])
+                cflags.update(get_include_args(dep.get_include_dirs()))
             else:
                 mlog.log('dependency %s not handled to build gir files' % dep)
                 continue


### PR DESCRIPTION
When dealing with the SharedLibrary or StaticLibrary include
directories, we where not taking into acount that path are relative to
the source tree. With proper helper, this works now. This fixues issue
where the gir may be generated bug from headers found in the prefix. 

This fixes issue #2093 