### PR TITLE
Fix linking Objective-C shared libs on OSX.

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -954,8 +954,6 @@ class GnuCompiler:
         return get_gcc_soname_args(self.gcc_type, prefix, shlib_name, suffix, path, soversion, is_shared_module)
 
     def get_std_shared_lib_link_args(self):
-        if self.gcc_type == GCC_OSX:
-            return ['-bundle']
         return ['-shared']
 
     def get_link_whole_for(self, args):


### PR DESCRIPTION
This change amends 04a2e6de making linker.get_std_shared_lib_link_args() always return -shared for SharedLibrary(es) instead of -bundle. SharedModule(s) get linked with linker.get_std_shared_module_link_args() which already correctly returns -bundle.

Before this change -bundle and -install_name ended up being emitted for Objective-C shared libraries, which caused a linking error.