### PR TITLE
Add /System/Library/Frameworks to the OSX framework search path

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -551,7 +551,7 @@ class ExtraFrameworkDependency(ExternalDependency):
     def detect(self, name, path):
         lname = name.lower()
         if path is None:
-            paths = ['/Library/Frameworks']
+            paths = ['/System/Library/Frameworks', '/Library/Frameworks']
         else:
             paths = [path]
         for p in paths:


### PR DESCRIPTION
Add /System/Library/Frameworks to the default ExtraFrameworkDependency search path. That's where the apple provided frameworks are.