### PR TITLE
Fix test-failures on armhf

### DIFF
--- a/test cases/common/126 llvm ir and assembly/square-arm.S
+++ b/test cases/common/126 llvm ir and assembly/square-arm.S
@@ -2,6 +2,9 @@
 
 .text
 .globl SYMBOL_NAME(square_unsigned)
+# ifdef __linux__
+.type square_unsigned, %function
+#endif
 
 SYMBOL_NAME(square_unsigned):
 	mul	r1, r0, r0

--- a/test cases/common/126 llvm ir and assembly/square-x86.S
+++ b/test cases/common/126 llvm ir and assembly/square-x86.S
@@ -23,6 +23,9 @@ END
 
 .text
 .globl SYMBOL_NAME(square_unsigned)
+# ifdef __linux__
+.type square_unsigned, %function
+#endif
 
 SYMBOL_NAME(square_unsigned):
 	movl	4(%esp), %eax

--- a/test cases/common/126 llvm ir and assembly/square-x86_64.S
+++ b/test cases/common/126 llvm ir and assembly/square-x86_64.S
@@ -18,6 +18,9 @@ END
 
 .text
 .globl SYMBOL_NAME(square_unsigned)
+# ifdef __linux__
+.type square_unsigned, %function
+#endif
 
 # if defined(_WIN32) || defined(__CYGWIN__) /* msabi */
 SYMBOL_NAME(square_unsigned):


### PR DESCRIPTION
Running test: test cases/common/126 llvm ir and assembly
Log of Meson test suite run on 2017-07-20T12:05:18.314159

1/2 test ASM squarec                        FAIL     0.56 s

--- command ---
/tmp/tmptt1mencu/square_asm_c
-------

2/2 test ASM squarecpp                      FAIL     0.53 s

--- command ---
/tmp/tmptt1mencu/square_asm_cpp
-------


OK:         0
FAIL:       2
SKIP:       0
TIMEOUT:    0