### PR TITLE
Add Autoconf header template support.

### DIFF
--- a/docs/markdown/Configuration.md
+++ b/docs/markdown/Configuration.md
@@ -32,7 +32,11 @@ More specifically, Meson will find all strings of the type `@varname@` and repla
 
 For more complex configuration file generation Meson provides a second form. To use it, put a line like this in your configuration file.
 
+```c
     #mesondefine TOKEN
+    /* Or Autoconf Style*/
+    #undef TOKEN
+```
 
 The replacement that happens depends on what the value and type of TOKEN is:
 

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -393,10 +393,10 @@ def do_replacement(regex, line, confdata):
         match = re.search(regex, line)
     return line, missing_variables
 
-def do_mesondefine(line, confdata):
+def do_define(line, confdata, pattern):
     arr = line.split()
     if len(arr) != 2:
-        raise MesonException('#mesondefine does not contain exactly two tokens: %s', line.strip())
+        raise MesonException('%s does not contain exactly two tokens: %s' % pattern, line.strip())
     varname = arr[1]
     try:
         (v, desc) = confdata.get(varname)
@@ -412,7 +412,7 @@ def do_mesondefine(line, confdata):
     elif isinstance(v, str):
         return '#define %s %s\n' % (varname, v)
     else:
-        raise MesonException('#mesondefine argument "%s" is of unknown type.' % varname)
+        raise MesonException('%pattern argument "%s" is of unknown type.' % (pattern, varname))
 
 
 def do_conf_file(src, dst, confdata):
@@ -428,7 +428,9 @@ def do_conf_file(src, dst, confdata):
     missing_variables = set()
     for line in data:
         if line.startswith('#mesondefine'):
-            line = do_mesondefine(line, confdata)
+            line = do_define(line, confdata, '#mesondefine')
+        elif line.startswith('#undef'):
+            line = do_define(line, confdata, '#undef')
         else:
             line, missing = do_replacement(regex, line, confdata)
             missing_variables.update(missing)

--- a/test cases/common/16 configure file/config.h.in
+++ b/test cases/common/16 configure file/config.h.in
@@ -3,3 +3,6 @@
 
 #mesondefine BE_TRUE
 #mesondefine SHOULD_BE_UNDEF
+
+#undef BE_TRUE_AUTOCONF_STYLE
+#undef SHOULD_BE_UNDEF_AUTOCONF_STYLE

--- a/test cases/common/16 configure file/meson.build
+++ b/test cases/common/16 configure file/meson.build
@@ -6,6 +6,7 @@ conf.set('var', 'mystring')
 conf.set('other', 'string 2')
 conf.set('second', ' bonus')
 conf.set('BE_TRUE', true)
+conf.set('BE_TRUE_AUTOCONF_STYLE', true)
 
 assert(conf.get('var') == 'mystring', 'Get function is not working.')
 assert(conf.get('var', 'default') == 'mystring', 'Get function is not working.')

--- a/test cases/common/16 configure file/prog.c
+++ b/test cases/common/16 configure file/prog.c
@@ -8,8 +8,14 @@
 #error "FAIL!"
 #endif
 
+#ifdef SHOULD_BE_UNDEF_AUTOCONF_STYLE
+#error "FAIL!"
+#endif
+
 int main(int argc, char **argv) {
 #ifndef BE_TRUE
+    return 1;
+#elif undefined BE_TRUE_AUTOCONF_STYLE
     return 1;
 #else
     return strcmp(MESSAGE, "mystring");


### PR DESCRIPTION
This PR adds [Autoconf header template style](https://www.gnu.org/software/autoconf/manual/autoconf-2.66/html_node/Header-Templates.html#Header-Templates) support. This might ease conversion from Autotools, and allow to keep both build systems together.