### PR TITLE
Fix #1993

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2263,7 +2263,7 @@ rule FORTRAN_DEP_HACK
                 commands += linker.get_gui_app_args()
             # If implib, and that's significant on this platform (i.e. Windows using either GCC or Visual Studio)
             if target.import_filename:
-                commands += linker.gen_import_library_args(os.path.join(target.subdir, target.import_filename))
+                commands += linker.gen_import_library_args(os.path.join(self.get_target_dir(target), target.import_filename))
         elif isinstance(target, build.SharedLibrary):
             if isinstance(target, build.SharedModule):
                 commands += linker.get_std_shared_module_link_args()
@@ -2280,7 +2280,7 @@ rule FORTRAN_DEP_HACK
                 commands += linker.gen_vs_module_defs_args(target.vs_module_defs.rel_to_builddir(self.build_to_src))
             # This is only visited when building for Windows using either GCC or Visual Studio
             if target.import_filename:
-                commands += linker.gen_import_library_args(os.path.join(target.subdir, target.import_filename))
+                commands += linker.gen_import_library_args(os.path.join(self.get_target_dir(target), target.import_filename))
         elif isinstance(target, build.StaticLibrary):
             commands += linker.get_std_link_args()
         else:


### PR DESCRIPTION
With this patch 'dll.a' files on windows will be in meson-out where they are expected for linking when meson was configured using --layout=flat. Not sure if it works using visual studio, this fix is only for ninja (but i guess it was only a bug in the ninja backend).
Might be worth adding a test for this but since it needs --layout=flat, not sure how/where a test could be added.