### PR TITLE
Vulkan dependency module

### DIFF
--- a/docs/markdown/Release-notes-for-0.42.0.md
+++ b/docs/markdown/Release-notes-for-0.42.0.md
@@ -83,3 +83,8 @@ flag manually, e.g. via `link_args` to a target. This is not
 recommended because having multiple rpath causes them to stomp on each
 other. This warning will become a hard error in some future release.
 
+## Vulkan dependency module
+
+Vulkan can now be used as native dependency. The dependency module will detect 
+the VULKAN_SDK environment variable or otherwise try to receive the vulkan
+library and header via pkgconfig or from the system.

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -19,7 +19,7 @@ from .base import (  # noqa: F401
 from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDependency
 from .misc import BoostDependency, Python3Dependency, ThreadDependency
 from .platform import AppleFrameworks
-from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency
+from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, VulkanDependency
 
 
 packages.update({
@@ -44,4 +44,5 @@ packages.update({
     'qt5': Qt5Dependency,
     'sdl2': SDL2Dependency,
     'wxwidgets': WxDependency,
+    'vulkan': VulkanDependency,
 })

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -542,7 +542,7 @@ class VulkanDependency(ExternalDependency):
 
                 if not find_lib:
                     raise DependencyException('VULKAN_SDK point to invalid directory (no lib)')
-                
+
                 if not os.path.isfile(header):
                     raise DependencyException('VULKAN_SDK point to invalid directory (no include)')
 

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -505,7 +505,7 @@ class VulkanDependency(ExternalDependency):
                     raise DependencyException('VULKAN_SDK must be an absolute path.')
 
                 # TODO: this config might not work on some platforms, fix bugs as reported
-                # we at least have to detect other 64-bit platforms (e.g. armv8)
+                # we should at least detect other 64-bit platforms (e.g. armv8)
                 lib_name = 'vulkan'
                 if mesonlib.is_windows():
                     lib_name = 'vulkan-1'
@@ -520,8 +520,8 @@ class VulkanDependency(ExternalDependency):
                 self.link_args.append('-L' + os.path.join(self.vulkan_sdk, lib_dir))
                 self.link_args.append('-l' + lib_name)
 
-                # TODO: find a way to retrieve this from the sdk
-                # we could try go guess it depending on the vulkan_sdk path
+                # TODO: find a way to retrieve the version from the sdk?
+                # we could try go guess it depending on the vulkan_sdk path.
                 # usually the paths last component is the vulkan version
                 # but this might be modified at installation
                 self.version = '1'

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -556,7 +556,7 @@ class VulkanDependency(ExternalDependency):
             else:
                 # simply try to guess it, usually works on linux
                 libs = self.compiler.find_library('vulkan', environment, [])
-                if libs != None and self.compiler.has_header('vulkan/vulkan.h', '', environment):
+                if libs is not None and self.compiler.has_header('vulkan/vulkan.h', '', environment):
                     self.type_name = 'system'
                     self.is_found = True
                     self.version = 1 # TODO

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -493,42 +493,42 @@ class WxDependency(ExternalDependency):
                 pass
         WxDependency.wxconfig_found = False
         mlog.log('Found wx-config:', mlog.red('NO'))
-        
+
 class VulkanDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
         super().__init__('vulkan', environment, None, kwargs)
-        
+
         if DependencyMethods.SYSTEM in self.methods:
             try:
                 self.vulkan_sdk = os.environ['VULKAN_SDK']
                 if not os.path.isabs(self.vulkan_sdk):
                     raise DependencyException('VULKAN_SDK must be an absolute path.')
-                    
+
                 # TODO: this config might not work on some platforms, fix bugs as reported
                 # we at least have to detect other 64-bit platforms (e.g. armv8)
                 lib_name = 'vulkan'
                 if mesonlib.is_windows():
                     lib_name = 'vulkan-1'
-                    
+
                 lib_dir = 'Lib32'
                 if detect_cpu({}) == 'x86_64':
                     lib_dir = 'Lib'
-                    
+
                 self.type_name = 'vulkan_sdk'
                 self.is_found = True
                 self.compile_args.append('-I' + os.path.join(self.vulkan_sdk, 'Include'))
                 self.link_args.append('-L' + os.path.join(self.vulkan_sdk, lib_dir))
                 self.link_args.append('-l' + lib_name)
-                
+
                 # TODO: find a way to retrieve this from the sdk
                 # we could try go guess it depending on the vulkan_sdk path
                 # usually the paths last component is the vulkan version
                 # but this might be modified at installation
-                self.version = '1' 
+                self.version = '1'
                 return
             except KeyError:
                 self.vulkan_sdk = None
-            
+
         if DependencyMethods.PKGCONFIG in self.methods:
             try:
                 pcdep = PkgConfigDependency('vulkan', environment, kwargs)
@@ -541,8 +541,6 @@ class VulkanDependency(ExternalDependency):
                     return
             except Exception:
                 pass
-            
+
     def get_methods(self):
         return [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM]
-
-

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -498,37 +498,6 @@ class VulkanDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
         super().__init__('vulkan', environment, None, kwargs)
 
-        if DependencyMethods.SYSTEM in self.methods:
-            try:
-                self.vulkan_sdk = os.environ['VULKAN_SDK']
-                if not os.path.isabs(self.vulkan_sdk):
-                    raise DependencyException('VULKAN_SDK must be an absolute path.')
-
-                # TODO: this config might not work on some platforms, fix bugs as reported
-                # we should at least detect other 64-bit platforms (e.g. armv8)
-                lib_name = 'vulkan'
-                if mesonlib.is_windows():
-                    lib_name = 'vulkan-1'
-
-                lib_dir = 'Lib32'
-                if detect_cpu({}) == 'x86_64':
-                    lib_dir = 'Lib'
-
-                self.type_name = 'vulkan_sdk'
-                self.is_found = True
-                self.compile_args.append('-I' + os.path.join(self.vulkan_sdk, 'Include'))
-                self.link_args.append('-L' + os.path.join(self.vulkan_sdk, lib_dir))
-                self.link_args.append('-l' + lib_name)
-
-                # TODO: find a way to retrieve the version from the sdk?
-                # we could try go guess it depending on the vulkan_sdk path.
-                # usually the paths last component is the vulkan version
-                # but this might be modified at installation
-                self.version = '1'
-                return
-            except KeyError:
-                self.vulkan_sdk = None
-
         if DependencyMethods.PKGCONFIG in self.methods:
             try:
                 pcdep = PkgConfigDependency('vulkan', environment, kwargs)
@@ -541,6 +510,59 @@ class VulkanDependency(ExternalDependency):
                     return
             except Exception:
                 pass
+
+        if DependencyMethods.SYSTEM in self.methods:
+            try:
+                self.vulkan_sdk = os.environ['VULKAN_SDK']
+                if not os.path.isabs(self.vulkan_sdk):
+                    raise DependencyException('VULKAN_SDK must be an absolute path.')
+            except KeyError:
+                self.vulkan_sdk = None
+
+            if self.vulkan_sdk:
+                # TODO: this config might not work on some platforms, fix bugs as reported
+                # we should at least detect other 64-bit platforms (e.g. armv8)
+                lib_name = 'vulkan'
+                if mesonlib.is_windows():
+                    lib_name = 'vulkan-1'
+                    lib_dir = 'Lib32'
+                    inc_dir = 'Include'
+                    if detect_cpu({}) == 'x86_64':
+                        lib_dir = 'Lib'
+                else:
+                    lib_name = 'vulkan'
+                    lib_dir = 'lib'
+                    inc_dir = 'include'
+
+                # make sure header and lib are valid
+                inc_path = os.path.join(self.vulkan_sdk, inc_dir)
+                header = os.path.join(inc_path, 'vulkan', 'vulkan.h')
+                lib_path = os.path.join(self.vulkan_sdk, lib_dir)
+                find_lib = self.compiler.find_library('vulkan', environment, lib_path)
+
+                if not (find_lib and os.path.isfile(header)):
+                    raise DependencyException('VULKAN_SDK point to invalid directory')
+
+                self.type_name = 'vulkan_sdk'
+                self.is_found = True
+                self.compile_args.append('-I' + inc_path)
+                self.link_args.append('-L' + lib_path)
+                self.link_args.append('-l' + lib_name)
+
+                # TODO: find a way to retrieve the version from the sdk?
+                # Usually it is a part of the path to it (but does not have to be)
+                self.version = '1'
+                return
+            else:
+                # simply try to guess it, usually works on linux
+                libs = self.compiler.find_library('vulkan', environment, [])
+                if libs != None and self.compiler.has_header('vulkan/vulkan.h', '', environment):
+                    self.type_name = 'system'
+                    self.is_found = True
+                    self.version = 1 # TODO
+                    for lib in libs:
+                        self.link_args.append(lib)
+                    return
 
     def get_methods(self):
         return [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM]

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -538,10 +538,13 @@ class VulkanDependency(ExternalDependency):
                 inc_path = os.path.join(self.vulkan_sdk, inc_dir)
                 header = os.path.join(inc_path, 'vulkan', 'vulkan.h')
                 lib_path = os.path.join(self.vulkan_sdk, lib_dir)
-                find_lib = self.compiler.find_library('vulkan', environment, lib_path)
+                find_lib = self.compiler.find_library(lib_name, environment, lib_path)
 
-                if not (find_lib and os.path.isfile(header)):
-                    raise DependencyException('VULKAN_SDK point to invalid directory')
+                if not find_lib:
+                    raise DependencyException('VULKAN_SDK point to invalid directory (no lib)')
+                
+                if not os.path.isfile(header):
+                    raise DependencyException('VULKAN_SDK point to invalid directory (no include)')
 
                 self.type_name = 'vulkan_sdk'
                 self.is_found = True

--- a/test cases/frameworks/17 vulkan/meson.build
+++ b/test cases/frameworks/17 vulkan/meson.build
@@ -1,0 +1,7 @@
+project('vulkan test', 'c')
+
+sdl2_dep = dependency('vulkan')
+
+e = executable('vulkanprog', 'vulkanprog.c', dependencies : sdl2_dep)
+
+test('vulkantest', e)

--- a/test cases/frameworks/17 vulkan/meson.build
+++ b/test cases/frameworks/17 vulkan/meson.build
@@ -1,6 +1,6 @@
 project('vulkan test', 'c')
 
-sdl2_dep = dependency('vulkan')
+vulkan_dep = dependency('vulkan')
 
 e = executable('vulkanprog', 'vulkanprog.c', dependencies : sdl2_dep)
 

--- a/test cases/frameworks/17 vulkan/meson.build
+++ b/test cases/frameworks/17 vulkan/meson.build
@@ -2,6 +2,6 @@ project('vulkan test', 'c')
 
 vulkan_dep = dependency('vulkan')
 
-e = executable('vulkanprog', 'vulkanprog.c', dependencies : sdl2_dep)
+e = executable('vulkanprog', 'vulkanprog.c', dependencies : vulkan_dep)
 
 test('vulkantest', e)

--- a/test cases/frameworks/17 vulkan/vulkanprog.c
+++ b/test cases/frameworks/17 vulkan/vulkanprog.c
@@ -3,21 +3,11 @@
 
 int main()
 {
-    VkApplicationInfo application_info = {
-        VK_STRUCTURE_TYPE_APPLICATION_INFO,
-        	NULL,
-        	"sway",
-        	VK_MAKE_VERSION(1,0,0),
-        	"wlroots",
-        	VK_MAKE_VERSION(1,0,0),
-        	VK_MAKE_VERSION(1,0,0)
-    };
-
     VkInstanceCreateInfo instance_create_info = {
         	VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
         	NULL,
         	0,
-        	&application_info,
+        	NULL,
         	0,
         	NULL,
         	0,
@@ -31,5 +21,6 @@ int main()
       	return ret;
     }
 
+    vkDestroyInstance(instance, NULL);
     return 0;    
 }

--- a/test cases/frameworks/17 vulkan/vulkanprog.c
+++ b/test cases/frameworks/17 vulkan/vulkanprog.c
@@ -1,0 +1,35 @@
+#include <vulkan/vulkan.h>
+#include <stdio.h>
+
+int main()
+{
+    VkApplicationInfo application_info = {
+        VK_STRUCTURE_TYPE_APPLICATION_INFO,
+        	NULL,
+        	"sway",
+        	VK_MAKE_VERSION(1,0,0),
+        	"wlroots",
+        	VK_MAKE_VERSION(1,0,0),
+        	VK_MAKE_VERSION(1,0,0)
+    };
+
+    VkInstanceCreateInfo instance_create_info = {
+        	VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+        	NULL,
+        	0,
+        	&application_info,
+        	0,
+        	NULL,
+        	0,
+        	NULL,
+    };
+
+    VkInstance instance;
+    VkResult ret = vkCreateInstance(&instance_create_info, NULL, &instance);
+    if(ret != VK_SUCCESS) {
+        printf("Could not create vulkan instance: %d\n", ret);
+      	return ret;
+    }
+
+    return 0;    
+}

--- a/test cases/frameworks/17 vulkan/vulkanprog.c
+++ b/test cases/frameworks/17 vulkan/vulkanprog.c
@@ -14,13 +14,13 @@ int main()
         	NULL,
     };
 
+    // we don't actually require instance creation to succeed since
+    // we cannot expect test environments to have a vulkan driver installed.
+    // As long as this does not produce as segmentation fault or similar,
+    // everything's alright.
     VkInstance instance;
-    VkResult ret = vkCreateInstance(&instance_create_info, NULL, &instance);
-    if(ret != VK_SUCCESS) {
-        printf("Could not create vulkan instance: %d\n", ret);
-      	return ret;
-    }
-
-    vkDestroyInstance(instance, NULL);
+    if(vkCreateInstance(&instance_create_info, NULL, &instance) == VK_SUCCESS)
+        vkDestroyInstance(instance, NULL);
+        
     return 0;    
 }


### PR DESCRIPTION
This adds a first version of a vulkan dependency module (and a test for it).
My python is actually not the best and i mostly copied what the other dependency classes seem to do, so this really needs some reviews. It might have issues (the test worked for me on windows though, will test it soon on linux).
Also see the TODO notes in the code. They are not critical for the time being IMO but just be aware it might not work correctly on 64 bit platforms other than x86_64 64 and the version is not yet fully reported (when not using pkgconfig). Latter is not too critical since there only is version 1.0 atm (and the gl dep has the same issue).
It is probably already a huge improvement over having to pass the VULKAN_SDK path to a custom meson option when using vulkan on a platform with vulkan sdk installed though (e.g. windows).