### PR TITLE
gnome: Fix translation of -l to --extra-library args

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -368,7 +368,7 @@ class GnomeModule(ExtensionModule):
                     if lib.startswith("-W"):
                         continue
                     if gir_has_extra_lib_arg() and use_gir_args:
-                        lib = lib.replace('-l', '--extra-library=')
+                        lib = lib.replace('-l', '--extra-library=', 1)
                     ldflags.update([lib])
 
                 if isinstance(dep, PkgConfigDependency):


### PR DESCRIPTION
We prefer to use the --extra-library parameter for passing -l arguments
to g-ir-scanner, however we need to be careful to only replace the first
'-l' occurrence to not translate
  '-lfoo-lib'
to
  '--extra-library=foo--extra-library=ib'