### PR TITLE
Consider link_whole_targets when determining linker

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -14,6 +14,7 @@
 
 import copy, os, re
 from collections import OrderedDict
+import itertools
 
 from . import environment
 from . import dependencies
@@ -936,7 +937,7 @@ You probably should put it in link_with instead.''')
                 langs.append(dep.language)
         # Check if any of the internal libraries this target links to were
         # written in this language
-        for link_target in self.link_targets:
+        for link_target in itertools.chain(self.link_targets, self.link_whole_targets):
             for language in link_target.compilers:
                 if language not in langs:
                     langs.append(language)

--- a/test cases/common/146 C and CPP link/meson.build
+++ b/test cases/common/146 C and CPP link/meson.build
@@ -60,3 +60,15 @@ libfoo = shared_library(
   ['foobar.c', 'foobar.h'],
   link_with : [libc, libcpp],
 )
+
+# Test that link_whole is also honored
+#
+# VS2010 lacks the /WHOLEARCHIVE option that later versions of MSVC support, so
+# don't run this tests on that backend.
+if meson.backend() != 'vs2010'
+  libfoowhole = shared_library(
+    'foowhole',
+    ['foobar.c', 'foobar.h'],
+    link_whole : [libc, libcpp],
+  )
+endif


### PR DESCRIPTION
Currently if a target uses link_whole, and one of those archives is a
C++, but the files for the target are C linking will fail when the C
linker attempts to link the C++ files. This patches add
link_whole_targets to the list of languages in the target so the correct
linker will be selected.