### PR TITLE
add support for pcap dependencies

### DIFF
--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -17,7 +17,7 @@ from .base import (  # noqa: F401
     ExternalDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
     PkgConfigDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language)
 from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDependency
-from .misc import (BoostDependency, MPIDependency, Python3Dependency, ThreadDependency)
+from .misc import (BoostDependency, MPIDependency, Python3Dependency, ThreadDependency, PcapDependency)
 from .platform import AppleFrameworks
 from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, VulkanDependency
 
@@ -34,6 +34,7 @@ packages.update({
     'mpi': MPIDependency,
     'python3': Python3Dependency,
     'threads': ThreadDependency,
+    'pcap': PcapDependency,
 
     # From platform:
     'appleframeworks': AppleFrameworks,

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -44,6 +44,8 @@ class DependencyMethods(Enum):
     SYSTEM = 'system'
     # Detect using sdl2-config
     SDLCONFIG = 'sdlconfig'
+    # Detect using pcap-config
+    PCAPCONFIG = 'pcap-config'
     # This is only supported on OSX - search the frameworks directory by name.
     EXTRAFRAMEWORK = 'extraframework'
     # Detect using the sysconfig module.

--- a/test cases/frameworks/19 pcap/meson.build
+++ b/test cases/frameworks/19 pcap/meson.build
@@ -1,0 +1,7 @@
+project('pcap test', 'c')
+
+pcap_dep = dependency('pcap', version : '>=1.0')
+
+e = executable('pcap_prog', 'pcap_prog.c', dependencies : pcap_dep)
+
+test('pcaptest', e)

--- a/test cases/frameworks/19 pcap/pcap_prog.c
+++ b/test cases/frameworks/19 pcap/pcap_prog.c
@@ -1,0 +1,9 @@
+#include <pcap/pcap.h>
+
+int
+main()
+{
+    char errbuf[PCAP_ERRBUF_SIZE];
+    pcap_t *p = pcap_create(NULL, errbuf);
+    return p == NULL;
+}


### PR DESCRIPTION
Libpcap has its own pcap-config tool rather than using pkg-config. Add
support for pcap-config, based on the existing implementation of
sdl2-config that is there already.