### PR TITLE
RFC: Use git-ls-files for dist-git

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1589,7 +1589,7 @@ class Interpreter(InterpreterBase):
             search_dir = os.path.join(srcdir, self.subdir)
             prog = ExternalProgram(cmd, silent=True, search_dir=search_dir)
             if not prog.found():
-                raise InterpreterException('Program or command {!r} not found'
+                raise InterpreterException('Program or command {!r} not found '
                                            'or not executable'.format(cmd))
             cmd = prog
         expanded_args = []


### PR DESCRIPTION
By using git-ls-files, we can make dist work without cloning the repo/submodules, so it should also work fine offline. Furthermore, it also takes into accound modified files, which allows to verify make dist work before committing.

Though this may be detrimental to current users of mesons that may expect the command to work with the committed files. Imho, either meson should put a big fat warning, or meson should generate a -dirty version using an approach similar to what #688 requests (which I am also looking at).  