### PR TITLE
Fix ppoll() test to work on non-glibc platforms

### DIFF
--- a/test cases/common/111 has header symbol/meson.build
+++ b/test cases/common/111 has header symbol/meson.build
@@ -14,8 +14,9 @@ foreach comp : [cc, cpp]
   assert (not comp.has_header_symbol('stdlol.h', 'int'), 'shouldn\'t be able to find "int" with invalid header')
 endforeach
 
-# This is likely only available on Glibc, so just test for it
-if cc.has_function('ppoll')
+# This is available on Glibc, Solaris & the BSD's, so just test for _GNU_SOURCE
+# on Linux
+if cc.has_function('ppoll') and host_machine.system() == 'linux'
   assert (not cc.has_header_symbol('poll.h', 'ppoll'), 'ppoll should not be accessible without _GNU_SOURCE')
   assert (cc.has_header_symbol('poll.h', 'ppoll', prefix : '#define _GNU_SOURCE'), 'ppoll should be accessible with _GNU_SOURCE')
 endif


### PR DESCRIPTION
This test was failing on Solaris, since _GNU_SOURCE is not required for ppoll(), and while I didn't try it on the BSD's, since they have ppoll() as well, without requiring _GNU_SOURCE (as seen in https://github.com/freebsd/freebsd/blob/master/sys/sys/poll.h for instance), made the check linux-specific.