### PR TITLE
Pass -fpch-preprocess to GCC when precompiled headers are used

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -777,6 +777,9 @@ class GnuCCompiler(GnuCompiler, CCompiler):
     def get_std_shared_lib_link_args(self):
         return ['-shared']
 
+    def get_pch_use_args(self, pch_dir, header):
+        return ['-fpch-preprocess', '-include', os.path.split(header)[-1]]
+
 
 class IntelCCompiler(IntelCompiler, CCompiler):
     def __init__(self, exelist, version, icc_type, is_cross, exe_wrapper=None):

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os.path
+
 from .. import coredata
 from ..mesonlib import version_compare
 
@@ -125,6 +127,9 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
         if self.gcc_type == GCC_MINGW:
             return options['cpp_winlibs'].value[:]
         return []
+
+    def get_pch_use_args(self, pch_dir, header):
+        return ['-fpch-preprocess', '-include', os.path.split(header)[-1]]
 
 
 class IntelCPPCompiler(IntelCompiler, CPPCompiler):


### PR DESCRIPTION
CCache requires this flag when building with precompiled headers.
Without it, the preprocessor fails and CCache fallbacks to running the
real compiler.

Users still need to set 'sloppiness' to 'pch_defines,time_macros' in
their ccache.conf file for CCache to cache builds that use precompiled
headers. See the CCache manual for more info:

	https://ccache.samba.org/manual.html#_precompiled_headers