### PR TITLE
Use dependency link arguments in C# targets

### DIFF
--- a/test cases/csharp/4 pkgconfig/meson.build
+++ b/test cases/csharp/4 pkgconfig/meson.build
@@ -1,0 +1,7 @@
+project('C# pkg-config', 'cs')
+
+nunit_dep = dependency('nunit')
+nunit_runner = find_program('nunit-console')
+
+test_lib = library('test_lib', 'test-lib.cs', dependencies: nunit_dep)
+test('nunit test', nunit_runner, args: test_lib)

--- a/test cases/csharp/4 pkgconfig/test-lib.cs
+++ b/test cases/csharp/4 pkgconfig/test-lib.cs
@@ -1,0 +1,11 @@
+using NUnit.Framework;
+
+[TestFixture]
+public class NUnitTest
+{
+    [Test]
+    public void Test() 
+    {
+        Assert.AreEqual(1 + 1, 2);
+    }
+}


### PR DESCRIPTION
This allows C# projects to use pkgconfig.