### PR TITLE
gnome: add 'ignore_headers' to permitted kwarg list for gnome.gtkdoc()

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -153,6 +153,7 @@ Compiles and installs gtkdoc documentation into `prefix/share/gtk-doc/html`. Tak
 * `html_assets`: a list of assets for the HTML pages
 * `content_files`: a list of content files
 * `mkdb_args`: a list of arguments to pass to `gtkdoc-mkdb`
+* `ignore_headers`: a list of header files to ignore
 
 This creates a `$module-doc` target that can be ran to build docs and normally these are only built on install.
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -685,7 +685,7 @@ class GnomeModule(ExtensionModule):
     @permittedKwargs({'main_xml', 'main_sgml', 'src_dir', 'dependencies', 'install',
                       'install_dir', 'scan_args', 'scanobjs_args', 'gobject_typesfile',
                       'fixxref_args', 'html_args', 'html_assets', 'content_files',
-                      'mkdb_args'})
+                      'mkdb_args', 'ignore_headers'})
     def gtkdoc(self, state, args, kwargs):
         if len(args) != 1:
             raise MesonException('Gtkdoc must have one positional argument.')


### PR DESCRIPTION
Subject says it all.