### PR TITLE
Don't error if build directory is already configured and update instructions

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -113,13 +113,13 @@ class MesonApp:
         priv_dir = os.path.join(build_dir, 'meson-private/coredata.dat')
         if os.path.exists(priv_dir):
             if not handshake:
-                msg = '''Trying to run Meson on a build directory that has already been configured.
+                print('''Trying to run Meson on a build directory that has already been configured.
 If you want to build it, just run your build command (e.g. ninja) inside the
 build directory. Meson will autodetect any changes in your setup and regenerate
 itself as required.
 
-If you want to change option values, use the mesonconf tool instead.'''
-                raise RuntimeError(msg)
+If you want to change option values, use the mesonconf tool instead.''')
+                sys.exit(0)
         else:
             if handshake:
                 raise RuntimeError('Something went terribly wrong. Please file a bug.')

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -116,9 +116,10 @@ class MesonApp:
                 print('''Trying to run Meson on a build directory that has already been configured.
 If you want to build it, just run your build command (e.g. ninja) inside the
 build directory. Meson will autodetect any changes in your setup and regenerate
-itself as required.
+itself as required. Though it shouldn't be necessary, running ninja reconfigure
+will force Meson to regenerate the build files.
 
-If you want to change option values, use the mesonconf tool instead.''')
+If you want to change option values, use meson configure instead.''')
                 sys.exit(0)
         else:
             if handshake:


### PR DESCRIPTION
ref https://github.com/mesonbuild/meson/issues/1962

This has been causing some packaging issues. [A number of VCS packages fail here](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=auracle-git) or [manually clean the build directory meaning they lose out on incremental builds](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=rofi-git). While this could be handled by skipping the build step if the directory already exists every package I've seen address this opted to remove the existing directory on the assumption incremental builds aren't supported, as has [at least one package management utility](https://github.com/rmarquis/pacaur/issues/714).

The result is virtually the same during interactive use and if there are no objections getting this out as soon as possible would be immensely helpful. 