### PR TITLE
gnome: Fix parsing of resource custom target files

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -259,21 +259,28 @@ class GnomeModule(ExtensionModule):
                 if hasattr(dep, 'held_object'):
                     dep = dep.held_object
                 if isinstance(dep, mesonlib.File):
-                    if dep.fname == missing_basename:
-                        found = True
-                        dep_files.remove(missing)
-                        dep_files.append(dep)
-                        subdirs.append(dep.subdir)
-                        break
+                    if dep.fname != missing_basename:
+                        continue
+                    found = True
+                    dep_files.remove(missing)
+                    dep_files.append(dep)
+                    subdirs.append(dep.subdir)
+                    break
                 elif isinstance(dep, build.CustomTarget):
-                    if dep.get_basename() == missing_basename:
+                    fname = None
+                    outputs = {(o, os.path.basename(o)) for o in dep.get_outputs()}
+                    for o, baseo in outputs:
+                        if baseo == missing_basename:
+                            fname = o
+                            break
+                    if fname is not None:
                         found = True
                         dep_files.remove(missing)
                         dep_files.append(
                             mesonlib.File(
                                 is_built=True,
                                 subdir=dep.get_subdir(),
-                                fname=dep.get_basename()))
+                                fname=fname))
                         depends.append(dep)
                         subdirs.append(dep.get_subdir())
                         break

--- a/test cases/frameworks/7 gnome/resources-data/meson.build
+++ b/test cases/frameworks/7 gnome/resources-data/meson.build
@@ -10,7 +10,7 @@ print("This is a generated resource.")
 
 # Generate file res3.txt from file res3.txt.in. This is then included
 # in a GResource file, driven by resources/meson.build.
-res3_txt = custom_target('res3.txt',
+res3_txt = custom_target('res3',
   input: 'res3.txt.in',
   output: 'res3.txt',
   command: [python3, '-c', fake_generator_script, '@INPUT@'],


### PR DESCRIPTION
`gnome.compile_resources()` was not parsing custom target sources properly. It was using the custom target name as the output of the custom target instead of looking at the list of outputs.

Also modify the GNOME framework test to expose this.