### PR TITLE
Add option to search for .pc files in $prefix/$libdir/pkgconfig

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -194,6 +194,7 @@ Finds an external dependency (usually a library installed on your system) with t
 - `default_options` *(added 0.37.0)* an array of option values that override those set in the project's `default_options` invocation (like `default_options` in [`project()`](#project), they only have effect when Meson is run for the first time, and command line arguments override any default options in build files)
 - `method` defines the way the dependency is detected, the default is `auto` but can be overridden to be e.g. `qmake` for Qt development, and different dependencies support different values for this (though `auto` will work on all of them)
 - `language` *(added 0.42.0)* defines what language-specific dependency to find if it's available for multiple languages.
+- `search_prefix` *(added 0.43.0)*, when set to true, Meson will pass the prefix path to pkg-config, so `${prefix}/${libdir}/pkgconfig` is searched as a directory where pc files are. (only for `pkg-config` dependencies).
 
 The returned object also has methods that are documented in the [object methods section](#dependency-object) below.
 

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -206,6 +206,18 @@ class PkgConfigDependency(ExternalDependency):
         else:
             self.type_string = 'Native'
 
+        # if search_prefix: true is given, we also search for .pc files in the
+        # prefix/libdir/pkgconfig directory.
+        # The prefix/libdir/pkgconfig directory always contains files for the host
+        # system architecture, so we can't use it if we want a dependency for the build
+        # machine. This only happens when we are cross compiling, but we are
+        # building a native library. So we check we are compiling for the host machine.
+        compiles_for_host = self.want_cross or not self.env.is_cross_build()
+        if compiles_for_host and kwargs.get('search_prefix', False):
+            self.pkgconfig_env = self._add_prefix_search()
+        else:
+            self.pkgconfig_env = os.environ
+
         mlog.debug('Determining dependency {!r} with pkg-config executable '
                    '{!r}'.format(name, self.pkgbin))
         ret, self.version = self._call_pkgbin(['--modversion', name])
@@ -252,8 +264,21 @@ class PkgConfigDependency(ExternalDependency):
         return s.format(self.__class__.__name__, self.name, self.is_found,
                         self.version_reqs)
 
+    def _add_prefix_search(self):
+        prefix_search_path = os.path.join(self.env.coredata.get_builtin_option("prefix"),
+                                          self.env.coredata.get_builtin_option("libdir"),
+                                          "pkgconfig")
+        evar = 'PKG_CONFIG_PATH'
+        env = os.environ.copy()
+        if evar in env:
+            pkgconfdir = env[evar].strip() + os.pathsep + prefix_search_path
+        else:
+            pkgconfdir = prefix_search_path
+        env[evar] = pkgconfdir
+        return env
+
     def _call_pkgbin(self, args):
-        p, out = Popen_safe([self.pkgbin] + args, env=os.environ)[0:2]
+        p, out = Popen_safe([self.pkgbin] + args, env=self.pkgconfig_env)[0:2]
         return p.returncode, out.strip()
 
     def _set_cargs(self):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -646,6 +646,20 @@ class AllPlatformTests(BasePlatformTests):
                 prefix = opt['value']
         self.assertEqual(prefix, '/absoluteprefix')
 
+    def test_library_search_prefix(self):
+        '''
+        Tests that the ${prefix}/${libdir}/pkgconfig directory
+        is searched no matter if prefix is /usr/local or other,
+        as long as the dependency has search_prefix: true
+        '''
+        testdir = os.path.join(self.common_test_dir, '159 pkgconfig search prefix')
+        prefix = os.path.join(self.common_test_dir, '159 pkgconfig search prefix', 'prefix')
+        extra_args = ['--prefix=' + prefix, '--libdir=' + prefix + '/lib']
+        self.init(testdir, extra_args, default_args=False)
+        deps = self.introspect('--dependencies')
+        dep_names = [x['name'] for x in deps]
+        self.assertEqual(dep_names, ['projectA'])
+
     def test_absolute_prefix_libdir(self):
         '''
         Tests that setting absolute paths for --prefix and --libdir work. Can't

--- a/test cases/common/159 pkgconfig search prefix/meson.build
+++ b/test cases/common/159 pkgconfig search prefix/meson.build
@@ -1,0 +1,5 @@
+project('projectC', 'c', version: '1')
+
+dep = dependency('projectA', search_prefix: true, required: false)
+dep2 = dependency('projectB', search_prefix: false, required: false)
+

--- a/test cases/common/159 pkgconfig search prefix/prefix/lib/pkgconfig/projectA.pc
+++ b/test cases/common/159 pkgconfig search prefix/prefix/lib/pkgconfig/projectA.pc
@@ -1,0 +1,8 @@
+prefix=/tmp/test/install
+libdir=${prefix}/lib/x86_64-linux-gnu
+includedir=${prefix}/include
+
+Name: projectA
+Description: ProjectA
+Version: 1
+Cflags: -I${includedir}


### PR DESCRIPTION
pgk-config `.pc` files are written by meson to `$prefix/$libdir/pkgconfig`. However, that same path is not used by meson to look for dependencies.

When multiple projects are installed to the same custom prefix, meson knows how to write .pc files to
`$prefix/$libdir/pkgconfig` in all projects, but meson is not able to find already installed .pc files in that prefix.

The use of subprojects (and wraps) to install missing dependencies automatically to the `$prefix` directory is not practical, as the `dependency()` will not be detected and it will always be reported as missing (because meson does not tell pkg-config to look into `$prefix/$libdir/pkgconfig`).

As a workaround, the user building the projects needs to be smart enough to know where meson is installing the .pc files and define in advance the environment variable `PKG_CONFIG_PATH=$prefix/$libdir/pkgconfig`, so .pc files can be found.

Given that meson *decides* where to write the .pc files inside the `$prefix`, it is reasonable that meson checks *that same path* when looking for dependencies.

Telling the user to find the right `PKG_CONFIG_PATH` value is counter-intuitive, as if meson ever decided to change the installation path it would force all users to fix their extra environment variables, and meson can easily take care of reporting the prefix to pkg-config, if desired.

pkg-config by design gives a special treatment to the `/usr/local` and `/usr` prefixes over the rest, as they are always searched for .pc files. `pkg-config` is not aware of the `$prefix`, unless the user (or meson) reports the path to it.

meson currently gives a special treatment to the `$prefix` when writing .pc files, but does not give the equivalent treatment when looking for .pc files. This pull request addresses that, by allowing the
definition of a `search_prefix` argument to `dependency()`. The meson instruction:

    dep = dependency('core_project', search_prefix: true)

looks for `core_project.pc` in the `PKG_CONFIG_PATH` (if defined by the user),
in `$prefix/$libdir/pkgconfig` and in `PKG_CONFIG_LIBS` (in that order).

The default value for `search_prefix` is false, in order to preserve backwards compatibility. A test case is included.

Feel free to close the pull request if you don't like the patch or the idea behind it. Thanks for meson and for your time reading this.