### PR TITLE
Exclude system sources from test coverage

### DIFF
--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -58,6 +58,7 @@ def coverage(source_root, build_root, log_dir):
                                '-o', covinfo])
         remove_dir_from_trace(lcov_exe, covinfo, '/usr/include/*')
         remove_dir_from_trace(lcov_exe, covinfo, '/usr/local/include/*')
+        remove_dir_from_trace(lcov_exe, covinfo, '/usr/src/*')
         subprocess.check_call([genhtml_exe,
                                '--prefix', build_root,
                                '--output-directory', htmloutdir,


### PR DESCRIPTION
Exclude /usr/src/ from code coverage, this is included for e.g. gtest/gmock.