### PR TITLE
unit tests: Select test cases inside run_unittests.py

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -190,13 +190,6 @@ if __name__ == '__main__':
     # Run tests
     print(mlog.bold('Running unittests.').get_text(mlog.colorize_console))
     print()
-    units = ['InternalTests', 'AllPlatformTests', 'FailureTests']
-    if mesonlib.is_linux():
-        units += ['LinuxlikeTests']
-        if should_run_linux_cross_tests():
-            units += ['LinuxArmCrossCompileTests']
-    elif mesonlib.is_windows():
-        units += ['WindowsTests']
     # Can't pass arguments to unit tests, so set the backend to use in the environment
     env = os.environ.copy()
     env['MESON_UNIT_TEST_BACKEND'] = backend.name
@@ -208,8 +201,7 @@ if __name__ == '__main__':
                         'coverage.process_startup()\n')
             env['COVERAGE_PROCESS_START'] = '.coveragerc'
             env['PYTHONPATH'] = os.pathsep.join([td] + env.get('PYTHONPATH', []))
-
-        returncode += subprocess.call([sys.executable, 'run_unittests.py', '-v'] + units, env=env)
+        returncode += subprocess.call([sys.executable, 'run_unittests.py', '-v'], env=env)
         # Ubuntu packages do not have a binary without -6 suffix.
         if should_run_linux_cross_tests():
             print(mlog.bold('Running cross compilation tests.').get_text(mlog.colorize_console))

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -30,7 +30,7 @@ import mesonbuild.mlog
 import mesonbuild.compilers
 import mesonbuild.environment
 import mesonbuild.mesonlib
-from mesonbuild.mesonlib import is_windows, is_osx, is_cygwin, windows_proof_rmtree
+from mesonbuild.mesonlib import is_linux, is_windows, is_osx, is_cygwin, windows_proof_rmtree
 from mesonbuild.environment import Environment
 from mesonbuild.dependencies import DependencyException
 from mesonbuild.dependencies import PkgConfigDependency, ExternalProgram
@@ -38,6 +38,7 @@ from mesonbuild.dependencies import PkgConfigDependency, ExternalProgram
 from run_tests import exe_suffix, get_fake_options, FakeEnvironment
 from run_tests import get_builddir_target_args, get_backend_commands, Backend
 from run_tests import ensure_backend_detects_changes, run_configure_inprocess
+from run_tests import should_run_linux_cross_tests
 
 
 def get_dynamic_section_entry(fname, entry):
@@ -1980,4 +1981,12 @@ def unset_envs():
 
 if __name__ == '__main__':
     unset_envs()
-    unittest.main(buffer=True)
+    cases = ['InternalTests', 'AllPlatformTests', 'FailureTests']
+    if is_linux():
+        cases += ['LinuxlikeTests']
+        if should_run_linux_cross_tests():
+            cases += ['LinuxArmCrossCompileTests']
+    elif is_windows():
+        cases += ['WindowsTests']
+
+    unittest.main(defaultTest=cases, buffer=True)


### PR DESCRIPTION
This allows people to directly run `./run_unittests.py` without having to worry about selecting the right test cases for the platform they are on.

I did this as a first step in figuring out how to run our unit tests in parallel, but that turned out to be more work than I expected it to be. `unittest.TestRunner` is a surprisingly complex class. Perhaps someone else can work on that, but this PR is useful in itself.