### PR TITLE
gnome: Only translate -l flags to --extra-library

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -367,7 +367,7 @@ class GnomeModule(ExtensionModule):
                     # Hack to avoid passing some compiler options in
                     if lib.startswith("-W"):
                         continue
-                    if gir_has_extra_lib_arg() and use_gir_args:
+                    if gir_has_extra_lib_arg() and use_gir_args and lib.startswith("-l"):
                         lib = lib.replace('-l', '--extra-library=', 1)
                     ldflags.update([lib])
 


### PR DESCRIPTION
Other linker arguments may contain '-l' as well, for instance
'-L/usr/lib/x86_64-linux-gnu/foo' with Debian-style multiarch.