### PR TITLE
Use include-uninstalled for internal gir deps.

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -456,7 +456,7 @@ class GnomeModule(ExtensionModule):
                                      inc.get_subdir()),
                     ]
                     scan_command += [
-                        "--include=%s" % (inc.get_basename()[:-4], ),
+                        "--include-uninstalled=%s" % (os.path.join(inc.get_subdir(), inc.get_basename()), )
                     ]
                     depends += [inc]
                 else:

--- a/test cases/frameworks/12 multiple gir/mesongir/meson.build
+++ b/test cases/frameworks/12 multiple gir/mesongir/meson.build
@@ -23,6 +23,7 @@ girtarget = gnome.generate_gir(
   symbol_prefix : 'meson_',
   identifier_prefix : 'Meson',
   includes : ['GObject-2.0'],
+  export_packages : 'meson',
   install : true
 )
 meson_gir = girtarget[0]


### PR DESCRIPTION
This stops g-ir-scanner from trying to search for the pkg-config file for an internal gir, which won't be available.