### PR TITLE
Fix pcap dependency, str.strip() now takes an argument, add cc.get_return_value()

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1429,7 +1429,9 @@ are immutable, all operations return their results as a new string.
 - `startswith(string)` returns true if string starts with the string
   specified as the argument
 
-- `strip()` removes whitespace at the beginning and end of the string
+- `strip()` removes whitespace at the beginning and end of the string  
+  *(added 0.43.0)* optionally can take one positional string argument,
+  and all characters in that string will be stripped
 
 - `to_int` returns the string converted to an integer (error if string
   is not a number)

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -607,19 +607,6 @@ class PcapDependency(ExternalDependency):
                          mlog.green('YES'), '(%s)' % pcapconf)
                 return
             mlog.debug('Could not find pcap-config binary, trying next.')
-        if DependencyMethods.EXTRAFRAMEWORK in self.methods:
-            if mesonlib.is_osx():
-                fwdep = ExtraFrameworkDependency('pcap', False, None, self.env,
-                                                 self.language, kwargs)
-                if fwdep.found():
-                    self.is_found = True
-                    self.compile_args = fwdep.get_compile_args()
-                    self.link_args = fwdep.get_link_args()
-                    # FIXME: Test on macOS
-                    #self.version = self.get_pcap_lib_version()
-                    self.version = '2' # FIXME
-                    return
-            mlog.log('Dependency', mlog.bold('pcap'), 'found:', mlog.red('NO'))
 
     def get_methods(self):
         if mesonlib.is_osx():

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -577,6 +577,7 @@ class Python3Dependency(ExternalDependency):
         else:
             return [DependencyMethods.PKGCONFIG]
 
+
 class PcapDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
         super().__init__('pcap', environment, None, kwargs)
@@ -600,7 +601,7 @@ class PcapDependency(ExternalDependency):
                 self.compile_args = stdo.strip().split()
                 stdo = Popen_safe(['pcap-config', '--libs'])[1]
                 self.link_args = stdo.strip().split()
-                self.version = '0'
+                self.version = self.get_pcap_lib_version()
                 self.is_found = True
                 mlog.log('Dependency', mlog.bold('pcap'), 'found:',
                          mlog.green('YES'), '(%s)' % pcapconf)
@@ -614,7 +615,9 @@ class PcapDependency(ExternalDependency):
                     self.is_found = True
                     self.compile_args = fwdep.get_compile_args()
                     self.link_args = fwdep.get_link_args()
-                    self.version = '2'  # FIXME
+                    # FIXME: Test on macOS
+                    #self.version = self.get_pcap_lib_version()
+                    self.version = '2' # FIXME
                     return
             mlog.log('Dependency', mlog.bold('pcap'), 'found:', mlog.red('NO'))
 
@@ -623,6 +626,11 @@ class PcapDependency(ExternalDependency):
             return [DependencyMethods.PKGCONFIG, DependencyMethods.PCAPCONFIG, DependencyMethods.EXTRAFRAMEWORK]
         else:
             return [DependencyMethods.PKGCONFIG, DependencyMethods.PCAPCONFIG]
+
+    def get_pcap_lib_version(self):
+        return self.compiler.get_return_value('pcap_lib_version', 'string',
+                                              '#include <pcap.h>', self.env, [], [self])
+
 
 class CupsDependency(ExternalDependency):
     def __init__(self, environment, kwargs):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -882,7 +882,7 @@ class CompilerHolder(InterpreterObject):
         extra_args = self.determine_args(kwargs)
         deps = self.determine_dependencies(kwargs)
         value = self.compiler.get_define(element, prefix, self.environment, extra_args, deps)
-        mlog.log('Checking for value of define "%s": %s' % (element, value))
+        mlog.log('Fetching value of define "%s": %s' % (element, value))
         return value
 
     def compiles_method(self, args, kwargs):

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -450,9 +450,25 @@ class InterpreterBase:
         else:
             raise InterpreterException('Unknown method "%s" for an integer.' % method_name)
 
+    @staticmethod
+    def _get_one_string_posarg(posargs, method_name):
+        if len(posargs) > 1:
+            m = '{}() must have zero or one arguments'
+            raise InterpreterException(m.format(method_name))
+        elif len(posargs) == 1:
+            s = posargs[0]
+            if not isinstance(s, str):
+                m = '{}() argument must be a string'
+                raise InterpreterException(m.format(method_name))
+            return s
+        return None
+
     def string_method_call(self, obj, method_name, args):
         (posargs, _) = self.reduce_arguments(args)
         if method_name == 'strip':
+            s = self._get_one_string_posarg(posargs, 'strip')
+            if s is not None:
+                return obj.strip(s)
             return obj.strip()
         elif method_name == 'format':
             return self.format_string(obj, args)
@@ -463,15 +479,10 @@ class InterpreterBase:
         elif method_name == 'underscorify':
             return re.sub(r'[^a-zA-Z0-9]', '_', obj)
         elif method_name == 'split':
-            if len(posargs) > 1:
-                raise InterpreterException('Split() must have at most one argument.')
-            elif len(posargs) == 1:
-                s = posargs[0]
-                if not isinstance(s, str):
-                    raise InterpreterException('Split() argument must be a string')
+            s = self._get_one_string_posarg(posargs, 'split')
+            if s is not None:
                 return obj.split(s)
-            else:
-                return obj.split()
+            return obj.split()
         elif method_name == 'startswith' or method_name == 'contains' or method_name == 'endswith':
             s = posargs[0]
             if not isinstance(s, str):

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -585,7 +585,7 @@ def check_file(fname):
     with open(fname, 'rb') as f:
         lines = f.readlines()
     for line in lines:
-        if b'\t' in line:
+        if line.startswith(b'\t'):
             print("File %s contains a literal tab on line %d. Only spaces are permitted." % (fname, linenum))
             sys.exit(1)
         if b'\r' in line:

--- a/test cases/common/42 string operations/meson.build
+++ b/test cases/common/42 string operations/meson.build
@@ -67,3 +67,10 @@ assert(not version_number.version_compare('!=1.2.8'), 'Version_compare neq broke
 
 assert(version_number.version_compare('<2.0'), 'Version_compare major less broken')
 assert(version_number.version_compare('>0.9'), 'Version_compare major greater broken')
+
+assert(' spaces	tabs	'.strip() == 'spaces	tabs', 'Spaces and tabs badly stripped')
+assert(''' 
+multiline string	'''.strip() == '''multiline string''', 'Newlines badly stripped')
+assert('"1.1.20"'.strip('"') == '1.1.20', '" badly stripped')
+assert('"1.1.20"'.strip('".') == '1.1.20', '". badly stripped')
+assert('"1.1.20"   '.strip('" ') == '1.1.20', '". badly stripped')

--- a/test cases/frameworks/19 pcap/meson.build
+++ b/test cases/frameworks/19 pcap/meson.build
@@ -2,6 +2,9 @@ project('pcap test', 'c')
 
 pcap_dep = dependency('pcap', version : '>=1.0')
 
+pcap_ver = pcap_dep.version()
+assert(pcap_ver.split('.').length() > 1, 'pcap version is "@0@"'.format(pcap_ver))
+
 e = executable('pcap_prog', 'pcap_prog.c', dependencies : pcap_dep)
 
 test('pcaptest', e)


### PR DESCRIPTION
commit c569ea7c97a2cfcf49f7d3c121a39e519b2726f6

str.strip() can now take a positional argument All the specified characters in the specified argument will be stripped. If unspecified, the old behaviour is used. Includes tests.

commit 6f87f94f5bbe25c913c94a4b23ba18feb143abf4

Add a new compiler method: get_return_value()

This method accepts a single function that takes no arguments and returns a single value which can be a value that can be cast to a 64-bit signed integer, or a string, and returns that value.
    
Mostly useful for running foolib_version() functions that return the currently-available version of libraries.

commit 0ae03d86b7bc836fc35d0fc692937bdb9cbdabe0

dependencies: Add version detection to pcap

--

The `PcapDependency()` changes are untested on macOS (will test that tomorrow), but we could probably ship it as-is anyway since this PR only improves things overall.