### PR TITLE
Fix ninja clean in some edge cases + a bonus windows fix

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -154,10 +154,12 @@ class NinjaBackend(backends.Backend):
     def detect_vs_dep_prefix(self, tempfilename):
         '''VS writes its dependency in a locale dependent format.
         Detect the search prefix to use.'''
-        # Of course there is another program called 'cl' on
-        # some platforms. Let's just require that on Windows
-        # cl points to msvc.
-        if not mesonlib.is_windows() or shutil.which('cl') is None:
+        for compiler in self.build.compilers.values():
+            # Have to detect the dependency format
+            if compiler.id == 'msvc':
+                break
+        else:
+            # None of our compilers are MSVC, we're done.
             return open(tempfilename, 'a')
         filename = os.path.join(self.environment.get_scratch_dir(),
                                 'incdetect.c')

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -165,6 +165,12 @@ class GnuFortranCompiler(FortranCompiler):
     def get_always_args(self):
         return ['-pipe']
 
+    def get_coverage_args(self):
+        return ['--coverage']
+
+    def get_coverage_link_args(self):
+        return ['--coverage']
+
     def gen_import_library_args(self, implibname):
         """
         The name of the outputted import library

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2742,9 +2742,12 @@ different subdirectory.
     def add_target(self, name, tobj):
         if name == '':
             raise InterpreterException('Target name must not be empty.')
+        if name.startswith('meson-'):
+            raise InvalidArguments("Target names starting with 'meson-' are reserved "
+                                   "for Meson's internal use. Please rename.")
         if name in coredata.forbidden_target_names:
-            raise InvalidArguments('Target name "%s" is reserved for Meson\'s internal use. Please rename.'
-                                   % name)
+            raise InvalidArguments("Target name '%s' is reserved for Meson's "
+                                   "internal use. Please rename." % name)
         # To permit an executable and a shared library to have the
         # same name, such as "foo.exe" and "libfoo.a".
         idname = tobj.get_id()

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -30,6 +30,7 @@ import mesonbuild.mlog
 import mesonbuild.compilers
 import mesonbuild.environment
 import mesonbuild.mesonlib
+import mesonbuild.coredata
 from mesonbuild.mesonlib import is_linux, is_windows, is_osx, is_cygwin, windows_proof_rmtree
 from mesonbuild.environment import Environment
 from mesonbuild.dependencies import DependencyException
@@ -1277,6 +1278,18 @@ int main(int argc, char **argv) {
                         '"-D" "FOO" "-D" "BAR"' in cmd or
                         '/D FOO /D BAR' in cmd or
                         '"/D" "FOO" "/D" "BAR"' in cmd)
+
+    def test_all_forbidden_targets_tested(self):
+        '''
+        Test that all forbidden targets are tested in the '159 reserved targets'
+        test. Needs to be a unit test because it accesses Meson internals.
+        '''
+        testdir = os.path.join(self.common_test_dir, '159 reserved targets')
+        targets = mesonbuild.coredata.forbidden_target_names
+        # We don't actually define a target with this name
+        targets.pop('build.ninja')
+        for i in targets:
+            self.assertPathExists(os.path.join(testdir, i))
 
 
 class FailureTests(BasePlatformTests):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -467,7 +467,7 @@ class BasePlatformTests(unittest.TestCase):
         return output
 
     def init(self, srcdir, extra_args=None, default_args=True, inprocess=False):
-        self.assertTrue(os.path.exists(srcdir))
+        self.assertPathExists(srcdir)
         if extra_args is None:
             extra_args = []
         if not isinstance(extra_args, list):
@@ -628,6 +628,14 @@ class BasePlatformTests(unittest.TestCase):
         else:
             raise RuntimeError('Invalid backend: {!r}'.format(self.backend.name))
 
+    def assertPathExists(self, path):
+        m = 'Path {!r} should exist'.format(path)
+        self.assertTrue(os.path.exists(path), msg=m)
+
+    def assertPathDoesNotExist(self, path):
+        m = 'Path {!r} should not exist'.format(path)
+        self.assertFalse(os.path.exists(path), msg=m)
+
 
 class AllPlatformTests(BasePlatformTests):
     '''
@@ -773,11 +781,11 @@ class AllPlatformTests(BasePlatformTests):
         exename = os.path.join(self.installdir, 'usr/bin/prog' + exe_suffix)
         testdir = os.path.join(self.common_test_dir, '8 install')
         self.init(testdir)
-        self.assertFalse(os.path.exists(exename))
+        self.assertPathDoesNotExist(exename)
         self.install()
-        self.assertTrue(os.path.exists(exename))
+        self.assertPathExists(exename)
         self.uninstall()
-        self.assertFalse(os.path.exists(exename))
+        self.assertPathDoesNotExist(exename)
 
     def test_testsetups(self):
         if not shutil.which('valgrind'):
@@ -868,10 +876,10 @@ class AllPlatformTests(BasePlatformTests):
         self.build()
         genfile = os.path.join(self.builddir, 'generated.dat')
         exe = os.path.join(self.builddir, 'fooprog' + exe_suffix)
-        self.assertTrue(os.path.exists(genfile))
-        self.assertFalse(os.path.exists(exe))
+        self.assertPathExists(genfile)
+        self.assertPathDoesNotExist(exe)
         self.build(target=('fooprog' + exe_suffix))
-        self.assertTrue(os.path.exists(exe))
+        self.assertPathExists(exe)
 
     def test_internal_include_order(self):
         testdir = os.path.join(self.common_test_dir, '138 include order')
@@ -1240,8 +1248,8 @@ int main(int argc, char **argv) {
             self.build('dist')
             distfile = os.path.join(self.distdir, 'disttest-1.4.3.tar.xz')
             checksumfile = distfile + '.sha256sum'
-            self.assertTrue(os.path.exists(distfile))
-            self.assertTrue(os.path.exists(checksumfile))
+            self.assertPathExists(distfile)
+            self.assertPathExists(checksumfile)
 
     def test_rpath_uses_ORIGIN(self):
         '''
@@ -1604,35 +1612,35 @@ class LinuxlikeTests(BasePlatformTests):
 
         # File without aliases set.
         nover = os.path.join(libpath, 'libnover.so')
-        self.assertTrue(os.path.exists(nover))
+        self.assertPathExists(nover)
         self.assertFalse(os.path.islink(nover))
         self.assertEqual(get_soname(nover), 'libnover.so')
         self.assertEqual(len(glob(nover[:-3] + '*')), 1)
 
         # File with version set
         verset = os.path.join(libpath, 'libverset.so')
-        self.assertTrue(os.path.exists(verset + '.4.5.6'))
+        self.assertPathExists(verset + '.4.5.6')
         self.assertEqual(os.readlink(verset), 'libverset.so.4')
         self.assertEqual(get_soname(verset), 'libverset.so.4')
         self.assertEqual(len(glob(verset[:-3] + '*')), 3)
 
         # File with soversion set
         soverset = os.path.join(libpath, 'libsoverset.so')
-        self.assertTrue(os.path.exists(soverset + '.1.2.3'))
+        self.assertPathExists(soverset + '.1.2.3')
         self.assertEqual(os.readlink(soverset), 'libsoverset.so.1.2.3')
         self.assertEqual(get_soname(soverset), 'libsoverset.so.1.2.3')
         self.assertEqual(len(glob(soverset[:-3] + '*')), 2)
 
         # File with version and soversion set to same values
         settosame = os.path.join(libpath, 'libsettosame.so')
-        self.assertTrue(os.path.exists(settosame + '.7.8.9'))
+        self.assertPathExists(settosame + '.7.8.9')
         self.assertEqual(os.readlink(settosame), 'libsettosame.so.7.8.9')
         self.assertEqual(get_soname(settosame), 'libsettosame.so.7.8.9')
         self.assertEqual(len(glob(settosame[:-3] + '*')), 2)
 
         # File with version and soversion set to different values
         bothset = os.path.join(libpath, 'libbothset.so')
-        self.assertTrue(os.path.exists(bothset + '.1.2.3'))
+        self.assertPathExists(bothset + '.1.2.3')
         self.assertEqual(os.readlink(bothset), 'libbothset.so.1.2.3')
         self.assertEqual(os.readlink(bothset + '.1.2.3'), 'libbothset.so.4.5.6')
         self.assertEqual(get_soname(bothset), 'libbothset.so.1.2.3')
@@ -1719,9 +1727,9 @@ class LinuxlikeTests(BasePlatformTests):
     def test_unity_subproj(self):
         testdir = os.path.join(self.common_test_dir, '49 subproject')
         self.init(testdir, extra_args='--unity=subprojects')
-        self.assertTrue(os.path.exists(os.path.join(self.builddir, 'subprojects/sublib/simpletest@exe/simpletest-unity.c')))
-        self.assertTrue(os.path.exists(os.path.join(self.builddir, 'subprojects/sublib/sublib@sha/sublib-unity.c')))
-        self.assertFalse(os.path.exists(os.path.join(self.builddir, 'user@exe/user-unity.c')))
+        self.assertPathExists(os.path.join(self.builddir, 'subprojects/sublib/simpletest@exe/simpletest-unity.c'))
+        self.assertPathExists(os.path.join(self.builddir, 'subprojects/sublib/sublib@sha/sublib-unity.c'))
+        self.assertPathDoesNotExist(os.path.join(self.builddir, 'user@exe/user-unity.c'))
         self.build()
 
     def test_installed_modes(self):

--- a/test cases/common/159 reserved targets/PHONY/meson.build
+++ b/test cases/common/159 reserved targets/PHONY/meson.build
@@ -1,0 +1,1 @@
+executable('test-PHONY', '../test.c')

--- a/test cases/common/159 reserved targets/all/meson.build
+++ b/test cases/common/159 reserved targets/all/meson.build
@@ -1,0 +1,1 @@
+executable('test-all', '../test.c')

--- a/test cases/common/159 reserved targets/benchmark/meson.build
+++ b/test cases/common/159 reserved targets/benchmark/meson.build
@@ -1,0 +1,1 @@
+executable('test-benchmark', '../test.c')

--- a/test cases/common/159 reserved targets/clean-ctlist/meson.build
+++ b/test cases/common/159 reserved targets/clean-ctlist/meson.build
@@ -1,0 +1,1 @@
+executable('test-clean-ctlist', '../test.c')

--- a/test cases/common/159 reserved targets/clean-gcda/meson.build
+++ b/test cases/common/159 reserved targets/clean-gcda/meson.build
@@ -1,0 +1,1 @@
+executable('test-clean-gcda', '../test.c')

--- a/test cases/common/159 reserved targets/clean-gcno/meson.build
+++ b/test cases/common/159 reserved targets/clean-gcno/meson.build
@@ -1,0 +1,1 @@
+executable('test-clean-gcno', '../test.c')

--- a/test cases/common/159 reserved targets/clean/meson.build
+++ b/test cases/common/159 reserved targets/clean/meson.build
@@ -1,0 +1,1 @@
+executable('test-clean', '../test.c')

--- a/test cases/common/159 reserved targets/coverage-html/meson.build
+++ b/test cases/common/159 reserved targets/coverage-html/meson.build
@@ -1,0 +1,1 @@
+executable('test-coverage-html', '../test.c')

--- a/test cases/common/159 reserved targets/coverage-text/meson.build
+++ b/test cases/common/159 reserved targets/coverage-text/meson.build
@@ -1,0 +1,1 @@
+executable('test-coverage-text', '../test.c')

--- a/test cases/common/159 reserved targets/coverage-xml/meson.build
+++ b/test cases/common/159 reserved targets/coverage-xml/meson.build
@@ -1,0 +1,1 @@
+executable('test-coverage-xml', '../test.c')

--- a/test cases/common/159 reserved targets/coverage/meson.build
+++ b/test cases/common/159 reserved targets/coverage/meson.build
@@ -1,0 +1,1 @@
+executable('test-coverage', '../test.c')

--- a/test cases/common/159 reserved targets/dist/meson.build
+++ b/test cases/common/159 reserved targets/dist/meson.build
@@ -1,0 +1,1 @@
+executable('test-dist', '../test.c')

--- a/test cases/common/159 reserved targets/distcheck/meson.build
+++ b/test cases/common/159 reserved targets/distcheck/meson.build
@@ -1,0 +1,1 @@
+executable('test-distcheck', '../test.c')

--- a/test cases/common/159 reserved targets/install/meson.build
+++ b/test cases/common/159 reserved targets/install/meson.build
@@ -1,0 +1,1 @@
+executable('test-install', '../test.c')

--- a/test cases/common/159 reserved targets/meson.build
+++ b/test cases/common/159 reserved targets/meson.build
@@ -15,7 +15,10 @@ subdir('coverage-xml')
 subdir('dist')
 subdir('distcheck')
 subdir('install')
-subdir('phony')
+# We end up creating duplicate lowercase target names for this on
+# case-insensitive HFS+, so disable it
+# https://travis-ci.org/mesonbuild/meson/jobs/264468097
+#subdir('phony')
 subdir('PHONY')
 subdir('reconfigure')
 subdir('scan-build')

--- a/test cases/common/159 reserved targets/meson.build
+++ b/test cases/common/159 reserved targets/meson.build
@@ -1,5 +1,6 @@
-project('reserved target names', 'c',
-        default_options : ['b_coverage=true'])
+project('reserved target names', 'c')
+        # FIXME: Setting this causes it to leak to all other tests
+        #default_options : ['b_coverage=true']
 
 subdir('all')
 subdir('benchmark')

--- a/test cases/common/159 reserved targets/meson.build
+++ b/test cases/common/159 reserved targets/meson.build
@@ -1,0 +1,28 @@
+project('reserved target names', 'c',
+        default_options : ['b_coverage=true'])
+
+subdir('all')
+subdir('benchmark')
+subdir('clean')
+subdir('clean-ctlist')
+subdir('clean-gcda')
+subdir('clean-gcno')
+subdir('coverage')
+subdir('coverage-html')
+subdir('coverage-text')
+subdir('coverage-xml')
+subdir('dist')
+subdir('distcheck')
+subdir('install')
+subdir('phony')
+subdir('PHONY')
+subdir('reconfigure')
+subdir('scan-build')
+subdir('test')
+subdir('uninstall')
+
+subdir('runtarget')
+
+custom_target('ctlist-test', output : 'out.txt',
+              command : ['echo'], capture : true,
+              build_by_default : true)

--- a/test cases/common/159 reserved targets/phony/meson.build
+++ b/test cases/common/159 reserved targets/phony/meson.build
@@ -1,0 +1,1 @@
+executable('test-phony', '../test.c')

--- a/test cases/common/159 reserved targets/reconfigure/meson.build
+++ b/test cases/common/159 reserved targets/reconfigure/meson.build
@@ -1,0 +1,1 @@
+executable('test-reconfigure', '../test.c')

--- a/test cases/common/159 reserved targets/runtarget/meson.build
+++ b/test cases/common/159 reserved targets/runtarget/meson.build
@@ -1,0 +1,2 @@
+configure_file(output : 'config.h', configuration: configuration_data())
+run_target('runtarget', command : ['echo'])

--- a/test cases/common/159 reserved targets/scan-build/meson.build
+++ b/test cases/common/159 reserved targets/scan-build/meson.build
@@ -1,0 +1,1 @@
+executable('test-scan-build', '../test.c')

--- a/test cases/common/159 reserved targets/test.c
+++ b/test cases/common/159 reserved targets/test.c
@@ -1,0 +1,3 @@
+int main(int argc, char *argv[]) {
+  return 0;
+}

--- a/test cases/common/159 reserved targets/test/meson.build
+++ b/test cases/common/159 reserved targets/test/meson.build
@@ -1,0 +1,1 @@
+executable('test-test', '../test.c')

--- a/test cases/common/159 reserved targets/uninstall/meson.build
+++ b/test cases/common/159 reserved targets/uninstall/meson.build
@@ -1,0 +1,1 @@
+executable('test-uninstall', '../test.c')


### PR DESCRIPTION
commit cae5caa7f1d804b8821bf55081707597e73fb7a1:

run_unittests: Add a helper for asserting path existence
It is useful to have a message displayed if the assert is fired.


commit 0c518a8077c200ffed61fad3ada7c726a5a6cbfd:

Add a test for dirs with reserved target names
And for dirs with the same name as run_target()s

Reproduces https://github.com/mesonbuild/meson/issues/1644


commit 5d5d935449a042d394a487306a7d906959a8cec6:

ninja: Fix cleaning in various edge cases
We need to use target aliases for reserved target names and run
targets to workaround a ninja bug:

https://github.com/ninja-build/ninja/issues/828

Closes https://github.com/mesonbuild/meson/issues/1644


commit ed4cffd692ec5262b859fe5607378f8eb36ff947:

ninja: Fix detection of vs compiler usage
Just because cl.exe exists in PATH doesn't mean we are using it right
now. Instead, check the list of compilers that were configured.
