### PR TITLE
python3: Fix 'sysconfig_path' for platform-dependant paths

### DIFF
--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -68,7 +68,7 @@ class Python3Module(ExtensionModule):
             raise mesonlib.MesonException('{} is not a valid path name {}.'.format(path_name, valid_names))
 
         # Get a relative path without a prefix, e.g. lib/python3.6/site-packages
-        path = sysconfig.get_path(path_name, vars={'base': '', 'platbase': ''})[1:]
+        path = sysconfig.get_path(path_name, vars={'base': '', 'platbase': '', 'installed_base': ''})[1:]
         return ModuleReturnValue(path, [])
 
 

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -68,7 +68,7 @@ class Python3Module(ExtensionModule):
             raise mesonlib.MesonException('{} is not a valid path name {}.'.format(path_name, valid_names))
 
         # Get a relative path without a prefix, e.g. lib/python3.6/site-packages
-        path = sysconfig.get_path(path_name, vars={'base': ''})[1:]
+        path = sysconfig.get_path(path_name, vars={'base': '', 'platbase': ''})[1:]
         return ModuleReturnValue(path, [])
 
 

--- a/test cases/python3/1 basic/meson.build
+++ b/test cases/python3/1 basic/meson.build
@@ -9,8 +9,19 @@ if py3_version.version_compare('< 3.2')
 endif
 
 py3_purelib = py3_mod.sysconfig_path('purelib')
-if not py3_purelib.endswith('site-packages')
+if not py3_purelib.startswith('lib') or not py3_purelib.endswith('site-packages')
   error('Python3 purelib path seems invalid?')
+endif
+
+# could be 'lib64' on some systems
+py3_platlib = py3_mod.sysconfig_path('platlib')
+if not py3_platlib.startswith('lib') or not py3_platlib.endswith('site-packages')
+  error('Python3 platlib path seems invalid?')
+endif
+
+py3_include = py3_mod.sysconfig_path('include')
+if not py3_include.startswith('include')
+  error('Python3 include path seems invalid?')
 endif
 
 main = files('prog.py')

--- a/test cases/python3/1 basic/meson.build
+++ b/test cases/python3/1 basic/meson.build
@@ -9,18 +9,19 @@ if py3_version.version_compare('< 3.2')
 endif
 
 py3_purelib = py3_mod.sysconfig_path('purelib')
-if not py3_purelib.startswith('lib') or not py3_purelib.endswith('site-packages')
+if not py3_purelib.to_lower().startswith('lib') or not py3_purelib.endswith('site-packages')
   error('Python3 purelib path seems invalid?')
 endif
 
-# could be 'lib64' on some systems
+# could be 'lib64' or 'Lib' on some systems
 py3_platlib = py3_mod.sysconfig_path('platlib')
-if not py3_platlib.startswith('lib') or not py3_platlib.endswith('site-packages')
+if not py3_platlib.to_lower().startswith('lib') or not py3_platlib.endswith('site-packages')
   error('Python3 platlib path seems invalid?')
 endif
 
+# could be 'Include' on Windows
 py3_include = py3_mod.sysconfig_path('include')
-if not py3_include.startswith('include')
+if not py3_include.to_lower().startswith('include')
   error('Python3 include path seems invalid?')
 endif
 


### PR DESCRIPTION
Include 'platbase' for stripping the prefix for 'platlib' and 'platinclude'.

This is necessary for installing platform-dependant Python modules such as GI overrides.