### PR TITLE
Fix detection of clang "optimization arguments"

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1041,8 +1041,11 @@ class ClangCompiler:
         return get_gcc_soname_args(gcc_type, prefix, shlib_name, suffix, path, soversion, is_shared_module)
 
     def has_multi_arguments(self, args, env):
+        myargs = ['-Werror=unknown-warning-option', '-Werror=unused-command-line-argument']
+        if mesonlib.version_compare(self.version, '>=3.6.0'):
+            myargs.append('-Werror=ignored-optimization-argument')
         return super().has_multi_arguments(
-            ['-Werror=unknown-warning-option', '-Werror=unused-command-line-argument'] + args,
+            myargs + args,
             env)
 
     def has_function(self, funcname, prefix, env, extra_args=None, dependencies=None):

--- a/test cases/common/112 has arg/meson.build
+++ b/test cases/common/112 has arg/meson.build
@@ -42,3 +42,10 @@ if cc.get_id() == 'gcc'
   assert(cc.has_multi_arguments(pre_arg), 'Arg that should have worked does not work.')
   assert(cc.has_multi_arguments([pre_arg, arg]), 'Arg that should have worked does not work.')
 endif
+
+if cc.get_id() == 'clang' and cc.version().version_compare('<=4.0.0')
+  # 4.0.0 does not support -fpeel-loops. Newer versions may.
+  # Please adjust above version number as new versions of clang are released.
+  notyet_arg = '-fpeel-loops'
+  assert(not cc.has_argument(notyet_arg), 'Arg that should be broken (unless clang added support recently) is not.')
+endif


### PR DESCRIPTION
Somewhere around version 3.5.0, clang added
-Wignored-optimization-argument.

We can't add -Werror=ignored-optimization-argument without breaking older
clang (because it would trip unknown-warning-option itself), so collapse
the command line into a simple "-Werror".

See also #755

A version of this commit without the test, because I don't expect the test to be accurate forever (someday clang might start supporting -fpeel-loops, or any other currently unsupported flag I might choose) if you prefer: f3374af443742544c92947eeae213ea001fdcd16