### PR TITLE
docs: fix generator code sample

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -312,7 +312,7 @@ Meson will then do the right thing.
 ### generator()
 
 ``` meson
-    generator_object gen(*executable*, ...)
+    generator_object generator(*executable*, ...)
 ```
 
 See also: [`custom_target`](#custom_target)


### PR DESCRIPTION
`gen(*executable*, ...)` should be `generator(*executable*, ...)` as `gen` as a function does not exist.