### PR TITLE
Fix warning when executable(implib:) is used

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1269,9 +1269,7 @@ build_target_common_kwargs = (
     rust_kwargs |
     cs_kwargs)
 
-exe_kwargs = set()
-exe_kwargs.update(build_target_common_kwargs)
-
+exe_kwargs = (build_target_common_kwargs) | {'implib'}
 shlib_kwargs = (build_target_common_kwargs) | {'version', 'soversion'}
 shmod_kwargs = shlib_kwargs
 stlib_kwargs = shlib_kwargs


### PR DESCRIPTION
PR #1955 added implib to known_exe_kwargs, but since PR #2001 it needs to be
in exe_kwargs as well, to avoid 'WARNING: Passed invalid keyword argument
"implib"' when it is used.