### PR TITLE
ninja: Generator is more informative on what it is doing.

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1818,7 +1818,7 @@ rule FORTRAN_DEP_HACK
                 elem.add_item('DEPFILE', depfile)
             if len(extra_dependencies) > 0:
                 elem.add_dep(extra_dependencies)
-            elem.add_item('DESC', 'Generating $out')
+            elem.add_item('DESC', 'Generating {!r}.'.format(sole_output))
             if isinstance(exe, build.BuildTarget):
                 elem.add_dep(self.get_target_filename(exe))
             elem.add_item('COMMAND', cmdlist)


### PR DESCRIPTION
Currently the generation of generator() rules make a mystery out of what it is doing during a build. It would be nice if it was a little more informative.

See build steps 1 through 3 as an example:

```
ninja: Entering directory `build'
[1/12] Generating $out
[2/12] Generating $out
[3/12] Generating $out
[4/12] Linking static target libyasm_static.a.
[5/12] Compiling C object 'yasm_app@exe/src_main.c.o'.
[6/12] Compiling C object 'yasm_shared_app@exe/src_main.c.o'.
[7/12] Compiling C object 'yasm_static_app@exe/src_main.c.o'.
[8/12] Linking target libyasm_shared.so.
[9/12] Linking target yasm_app.
[10/12] Linking target yasm_static_app.
[11/12] Generating symbol file 'yasm_shared@sha/libyasm_shared.so.symbols'.
[12/12] Linking target yasm_shared_app.
```

With the provided patch the log looks similar to what is happening when compiling C files.

Disclaimer: I never wrote anything in Python nor do I have a great insight about the meson source code. So this approach may be totally off target. Also I'm not sure if the `sole_output` variable is the correct one to use here as a few lines above it is checked if it is empty?

```
ninja: Entering directory `build'
[1/12] Generating 'yasm_app@exe/yasm.asm.o'.
[2/12] Generating 'yasm_static@sta/yasm.asm.o'.
[3/12] Generating 'yasm_shared@sha/yasm.asm.o'.
[4/12] Linking static target libyasm_static.a.
[5/12] Compiling C object 'yasm_app@exe/src_main.c.o'.
[6/12] Compiling C object 'yasm_static_app@exe/src_main.c.o'.
[7/12] Compiling C object 'yasm_shared_app@exe/src_main.c.o'.
[8/12] Linking target libyasm_shared.so.
[9/12] Linking target yasm_app.
[10/12] Linking target yasm_static_app.
[11/12] Generating symbol file 'yasm_shared@sha/libyasm_shared.so.symbols'.
[12/12] Linking target yasm_shared_app.
```

Bonus question: How should generators be written to avoid name clashing? If for example I have `src/yasm.asm` and `src2/yasm.asm` and I want them to be handled by the same generator. For the C files this seems to be handled by prefixing the destination filename with the directories and an underscore. With generators this does not seem to be the case?