### PR TITLE
Find Boost dep when there is an extra lib to link

### DIFF
--- a/ciimage/Dockerfile
+++ b/ciimage/Dockerfile
@@ -9,5 +9,6 @@ RUN apt-get -y update && apt-get -y upgrade \
 && apt-get -y install llvm libsdl2-dev \
 && apt-get -y install python3-pip libxml2-dev libxslt1-dev cmake libyaml-dev \
 && apt-get -y install openmpi-bin libopenmpi-dev \
+&& apt-get -y install libboost-log-dev \
 && apt-get -y install libvulkan-dev libpcap-dev \
 && python3 -m pip install hotdoc codecov

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -142,7 +142,7 @@ class BoostDependency(ExternalDependency):
 
     def validate_requested(self):
         for m in self.requested_modules:
-            if m not in self.src_modules:
+            if m not in self.src_modules and m not in self.lib_modules and m + '-mt' not in self.lib_modules_mt:
                 msg = 'Requested Boost module {!r} not found'
                 raise DependencyException(msg.format(m))
 

--- a/test cases/frameworks/1 boost/extralib.cpp
+++ b/test cases/frameworks/1 boost/extralib.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <boost/log/trivial.hpp>
+#include <boost/log/expressions.hpp>
+#include <boost/log/utility/setup/console.hpp>
+#include <boost/log/utility/setup/common_attributes.hpp>
+
+using namespace std;
+namespace logging = boost::log;
+
+void InitLogger() {
+  logging::add_common_attributes();
+  logging::register_simple_formatter_factory<logging::trivial::severity_level, char>("Severity");
+  string log_format = "%TimeStamp% [%Severity%] - %Message%";
+
+  logging::add_console_log(
+    cout,
+    logging::keywords::format = log_format
+  );
+}
+
+int main(int argc, char **argv) {
+  InitLogger();
+  BOOST_LOG_TRIVIAL(trace) << "SOMETHING";
+  return 0;
+}

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -1,6 +1,10 @@
 project('boosttest', 'cpp',
   default_options : ['cpp_std=c++11'])
 
+add_project_arguments(['-DBOOST_LOG_DYN_LINK'],
+  language : 'cpp'
+)
+
 # We want to have multiple separate configurations of Boost
 # within one project. The need to be independent of each other.
 # Use one without a library dependency and one with it.
@@ -10,15 +14,18 @@ linkdep = dependency('boost', modules : ['thread', 'system'])
 staticdep = dependency('boost', modules : ['thread', 'system'], static : true)
 testdep = dependency('boost', modules : 'test')
 nomoddep = dependency('boost')
+extralibdep = dependency('boost', modules : ['thread', 'system', 'log_setup', 'log'])
 
 nolinkexe = executable('nolinkedexe', 'nolinkexe.cc', dependencies : nolinkdep)
 linkexe = executable('linkedexe', 'linkexe.cc', dependencies : linkdep)
 staticexe = executable('staticlinkedexe', 'linkexe.cc', dependencies : staticdep)
 unitexe = executable('utf', 'unit_test.cpp', dependencies: testdep)
 nomodexe = executable('nomod', 'nomod.cpp', dependencies : nomoddep)
+extralibexe = executable('extralibexe', 'extralib.cpp', dependencies : extralibdep)
 
 test('Boost nolinktest', nolinkexe)
 test('Boost linktest', linkexe)
 test('Boost statictest', staticexe)
 test('Boost UTF test', unitexe)
 test('Boost nomod', nomodexe)
+test('Boost extralib test', extralibexe)


### PR DESCRIPTION
There are several components in Boost which must be linked with extra
libraries. Boost Log is one of them and in special circumstances needs
linking with boost_log_setup.

http://www.boost.org/doc/libs/1_64_0/libs/log/doc/html/log/detailed/utilities.html#log.detailed.utilities.setup

This fix covers the case when there is no source file corresponding to
the additional library.