### PR TITLE
Fix detection of MSVC 2008 version.

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -539,10 +539,14 @@ class Environment:
                 cls = ClangCCompiler if lang == 'c' else ClangCPPCompiler
                 return cls(ccache + compiler, version, cltype, is_cross, exe_wrap)
             if 'Microsoft' in out or 'Microsoft' in err:
-                # Visual Studio prints version number to stderr but
-                # everything else to stdout. Why? Lord only knows.
+                # Latest versions of Visual Studio print version 
+                # number to stderr but earlier ones print version
+                # on stdout.  Why? Lord only knows.
+                # Check both outputs to figure out version.
                 version = search_version(err)
-                if not err or not err.split('\n')[0]:
+                if version == 'unknown version':
+                    version = search_version(out)
+                if version == 'unknown version':
                     m = 'Failed to detect MSVC compiler arch: stderr was\n{!r}'
                     raise EnvironmentException(m.format(err))
                 is_64 = err.split('\n')[0].endswith(' x64')

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -539,7 +539,7 @@ class Environment:
                 cls = ClangCCompiler if lang == 'c' else ClangCPPCompiler
                 return cls(ccache + compiler, version, cltype, is_cross, exe_wrap)
             if 'Microsoft' in out or 'Microsoft' in err:
-                # Latest versions of Visual Studio print version 
+                # Latest versions of Visual Studio print version
                 # number to stderr but earlier ones print version
                 # on stdout.  Why? Lord only knows.
                 # Check both outputs to figure out version.


### PR DESCRIPTION
This is a small fix for users of older versions of MSVC like me.  As the comment in the patch says, MSVC version is normally printed on stderr (bizarre, right?), but older versions printed on stdout.  This change checks both before giving up.