### PR TITLE
Fix a stack trace caused by environment variables in test setups.

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2290,7 +2290,7 @@ class Interpreter(InterpreterBase):
         else:
             if not isinstance(envlist, list):
                 envlist = [envlist]
-            env = {}
+            env = EnvironmentVariablesHolder()
             for e in envlist:
                 if '=' not in e:
                     raise InterpreterException('Env var definition must be of type key=val.')
@@ -2299,7 +2299,8 @@ class Interpreter(InterpreterBase):
                 val = val.strip()
                 if ' ' in k:
                     raise InterpreterException('Env var key must not have spaces in it.')
-                env[k] = val
+                env.add_var(env.held_object.set, [k, val], kwargs)
+            env = env.held_object
         return env
 
     def add_test(self, node, args, kwargs, is_base_test):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -813,6 +813,8 @@ class AllPlatformTests(BasePlatformTests):
         self._run(self.mtest_command + ['--setup=empty'])
         # Setup with only env works
         self._run(self.mtest_command + ['--setup=onlyenv'])
+        self._run(self.mtest_command + ['--setup=onlyenv2'])
+        self._run(self.mtest_command + ['--setup=onlyenv3'])
         # Setup with only a timeout works
         self._run(self.mtest_command + ['--setup=timeout'])
 

--- a/test cases/unit/2 testsetups/meson.build
+++ b/test cases/unit/2 testsetups/meson.build
@@ -16,5 +16,7 @@ test('Test buggy', buggy)
 
 add_test_setup('empty')
 add_test_setup('onlyenv', env : env)
+add_test_setup('onlyenv2', env : 'TEST_ENV=1')
+add_test_setup('onlyenv3', env : ['TEST_ENV=1'])
 add_test_setup('wrapper', exe_wrapper : [vg, '--error-exitcode=1'])
 add_test_setup('timeout', timeout_multiplier : 20)


### PR DESCRIPTION
Seems to fix the issue...

Got this by adding environment variable (as a string) to a test setup (and by then using the setup).