### PR TITLE
Check if Watcom version of cl exists in the path and avoid using it.

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -511,6 +511,15 @@ class Environment:
             if isinstance(compiler, str):
                 compiler = [compiler]
             if 'cl' in compiler or 'cl.exe' in compiler:
+                if 'WATCOM' in os.environ:
+                    def sanitize(p):
+                        return os.path.normcase(os.path.abspath(p))
+
+                    watcom_cls = [sanitize(os.path.join(os.environ['WATCOM'], 'BINNT', 'cl')),
+                                  sanitize(os.path.join(os.environ['WATCOM'], 'BINNT', 'cl.exe'))]
+                    found_cl = sanitize(shutil.which('cl'))
+                    if found_cl in watcom_cls:
+                        continue
                 arg = '/?'
             else:
                 arg = '--version'

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -511,6 +511,15 @@ class Environment:
             if isinstance(compiler, str):
                 compiler = [compiler]
             if 'cl' in compiler or 'cl.exe' in compiler:
+                # Watcom C provides it's own cl.exe clone that mimics an older
+                # version of Microsoft's compiler. Since Watcom's cl.exe is
+                # just a wrapper, we skip using it if we detect its presence
+                # so as not to confuse Meson when configuring for MSVC.
+                #
+                # Additionally the help text of Watcom's cl.exe is paged, and
+                # the binary will not exit without human intervention. In
+                # practice, Meson will block waiting for Watcom's cl.exe to
+                # exit, which requires user input and thus will never exit.
                 if 'WATCOM' in os.environ:
                     def sanitize(p):
                         return os.path.normcase(os.path.abspath(p))


### PR DESCRIPTION
This pull request fixes a bug where meson would attempt to run any `cl.exe` found on the path, regardless of whether it was Microsoft's version or not.

The OpenWatcom toolchain, used for vintage projects, provides its own `cl.exe` implementation that has a paged help text, expect user intervention to page through the help text. `meson` idles waiting for the compiler to finish running, which will never occur as the compiler is waiting for input.

My solution is to never attempt to use the watcom `cl.exe` (or POSIX `owcc`) wrapper if they are found on the path; they are buggy and can interfere with other vendors.

With this fix, I was able to generate a ninja file with `cc`, `gcc`, and `msvc` from the visual studio command prompt without error.