### PR TITLE
Patchset to allow using meson for gstreamer-sharp

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -987,10 +987,19 @@ int dummy;
             outputs = [outname_rel, outname_rel + '.mdb']
         else:
             outputs = [outname_rel]
+        generated_sources = self.get_target_generated_sources(target)
+        for rel_src in generated_sources.keys():
+            dirpart, fnamepart = os.path.split(rel_src)
+            if rel_src.lower().endswith('.cs'):
+                rel_srcs.append(rel_src)
+            deps.append(rel_src)
+
         elem = NinjaBuildElement(self.all_outputs, outputs, 'cs_COMPILER', rel_srcs)
         elem.add_dep(deps)
         elem.add_item('ARGS', commands)
         elem.write(outfile)
+
+        self.generate_generator_list_rules(target, outfile)
 
     def generate_single_java_compile(self, src, target, compiler, outfile):
         args = []

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -375,8 +375,6 @@ class GnomeModule(ExtensionModule):
                     # Hack to avoid passing some compiler options in
                     if lib.startswith("-W"):
                         continue
-                    if gir_has_extra_lib_arg() and use_gir_args and lib.startswith("-l"):
-                        lib = lib.replace('-l', '--extra-library=', 1)
                     ldflags.update([lib])
 
                 if isinstance(dep, PkgConfigDependency):
@@ -389,6 +387,14 @@ class GnomeModule(ExtensionModule):
                 mlog.log('dependency %s not handled to build gir files' % dep)
                 continue
 
+        if gir_has_extra_lib_arg() and use_gir_args:
+            fixed_ldflags = set()
+            for ldflag in ldflags:
+                if ldflag.startswith("-l"):
+                    fixed_ldflags.add(ldflag.replace('-l', '--extra-library=', 1))
+                else:
+                    fixed_ldflags.add(ldflag)
+            ldflags = fixed_ldflags
         return cflags, ldflags, gi_includes
 
     @permittedKwargs({'sources', 'nsversion', 'namespace', 'symbol_prefix', 'identifier_prefix',

--- a/test cases/csharp/2 library/meson.build
+++ b/test cases/csharp/2 library/meson.build
@@ -1,5 +1,15 @@
 project('C# library', 'cs')
 
-l = shared_library('helper', 'helper.cs', install : true)
+python3 = import('python3').find_python()
+generated_sources = custom_target('gen_sources',
+    input: 'helper.cs',
+    output: 'helper.cs',
+    command: [python3, '-c',
+      'import shutil, sys; shutil.copyfile(sys.argv[1], sys.argv[2])',
+      '@INPUT@', '@OUTPUT@']
+)
+
+l = shared_library('helper', generated_sources, install : true)
+
 e = executable('prog', 'prog.cs', link_with : l, install : true)
 test('libtest', e)


### PR DESCRIPTION
Two simple patches:
 - First makes sure that we properly set dependency on generated sources (generators and custom targets results)
 - The other makes sure that we do not have wrong, extra `shared-library` set in the gir file