### PR TITLE
Make cs_args a known argument and handle c# external dependencies

### DIFF
--- a/ciimage/Dockerfile
+++ b/ciimage/Dockerfile
@@ -12,4 +12,5 @@ RUN apt-get -y update && apt-get -y upgrade \
 && apt-get -y install libboost-log-dev \
 && apt-get -y install libvulkan-dev libpcap-dev \
 && apt-get -y install gcovr lcov \
+&& apt-get -y install gtk-sharp2 gtk-sharp2-gapi libglib2.0-cil-dev \
 && python3 -m pip install hotdoc codecov

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -967,7 +967,7 @@ int dummy;
         compiler = target.compilers['cs']
         rel_srcs = [s.rel_to_builddir(self.build_to_src) for s in src_list]
         deps = []
-        commands = target.extra_args.get('cs', [])
+        commands = CompilerArgs(compiler, target.extra_args.get('cs', []))
         commands += compiler.get_buildtype_args(buildtype)
         if isinstance(target, build.Executable):
             commands.append('-target:exe')
@@ -993,6 +993,9 @@ int dummy;
             if rel_src.lower().endswith('.cs'):
                 rel_srcs.append(rel_src)
             deps.append(rel_src)
+
+        for dep in target.get_external_deps():
+            commands.extend_direct(dep.get_link_args())
 
         elem = NinjaBuildElement(self.all_outputs, outputs, 'cs_COMPILER', rel_srcs)
         elem.add_dep(deps)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -996,6 +996,8 @@ int dummy;
 
         for dep in target.get_external_deps():
             commands.extend_direct(dep.get_link_args())
+        commands += self.build.get_project_args(compiler, target.subproject)
+        commands += self.build.get_global_args(compiler)
 
         elem = NinjaBuildElement(self.all_outputs, outputs, 'cs_COMPILER', rel_srcs)
         elem.add_dep(deps)

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1238,6 +1238,7 @@ lang_arg_kwargs = set(['c_args',
                        'objcpp_args',
                        'rust_args',
                        'vala_args',
+                       'cs_args',
                    ])
 
 vala_kwargs = set(['vala_header', 'vala_gir', 'vala_vapi'])

--- a/test cases/csharp/4 external dep/hello.txt
+++ b/test cases/csharp/4 external dep/hello.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/test cases/csharp/4 external dep/meson.build
+++ b/test cases/csharp/4 external dep/meson.build
@@ -1,0 +1,4 @@
+project('C# external library', 'cs')
+glib_sharp_2 = dependency('glib-sharp-2.0')
+e = executable('prog', 'prog.cs', dependencies: glib_sharp_2, install : true)
+test('libtest', e, args: [join_paths(meson.current_source_dir(), 'hello.txt')])

--- a/test cases/csharp/4 external dep/prog.cs
+++ b/test cases/csharp/4 external dep/prog.cs
@@ -1,0 +1,8 @@
+using System;
+using GLib;
+
+public class Prog {
+    static public void Main (string[] args) {
+        Console.WriteLine(GLib.FileUtils.GetFileContents(args[0]));
+    }
+}


### PR DESCRIPTION
Avoiding warning about it when it is a well known one.