### PR TITLE
add support for cups dependencies

### DIFF
--- a/ciimage/Dockerfile
+++ b/ciimage/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get -y update && apt-get -y upgrade \
 && apt-get -y install python3-pip libxml2-dev libxslt1-dev cmake libyaml-dev \
 && apt-get -y install openmpi-bin libopenmpi-dev \
 && apt-get -y install libboost-log-dev \
-&& apt-get -y install libvulkan-dev libpcap-dev \
+&& apt-get -y install libvulkan-dev libpcap-dev libcups2-dev \
 && apt-get -y install gcovr lcov \
 && apt-get -y install gtk-sharp2 gtk-sharp2-gapi libglib2.0-cil-dev \
 && python3 -m pip install hotdoc codecov

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -132,6 +132,16 @@ automatically:
 pcap_dep = dependency('pcap', version : '>=1.0')
 ```
 
+## CUPS
+
+The cups library does not ship with pkg-config at the time or writing
+but instead it has its own `cups-config` util. Meson will use it
+automatically:
+
+```meson
+cups_dep = dependency('cups', version : '>=1.4')
+```
+
 ## Declaring your own
 
 You can declare your own dependency objects that can be used

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -17,7 +17,7 @@ from .base import (  # noqa: F401
     ExternalDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
     PkgConfigDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language)
 from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDependency
-from .misc import (BoostDependency, MPIDependency, Python3Dependency, ThreadDependency, PcapDependency)
+from .misc import (BoostDependency, MPIDependency, Python3Dependency, ThreadDependency, PcapDependency, CupsDependency)
 from .platform import AppleFrameworks
 from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, VulkanDependency
 
@@ -35,6 +35,7 @@ packages.update({
     'python3': Python3Dependency,
     'threads': ThreadDependency,
     'pcap': PcapDependency,
+    'cups': CupsDependency,
 
     # From platform:
     'appleframeworks': AppleFrameworks,

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -46,6 +46,8 @@ class DependencyMethods(Enum):
     SDLCONFIG = 'sdlconfig'
     # Detect using pcap-config
     PCAPCONFIG = 'pcap-config'
+    # Detect using cups-config
+    CUPSCONFIG = 'cups-config'
     # This is only supported on OSX - search the frameworks directory by name.
     EXTRAFRAMEWORK = 'extraframework'
     # Detect using the sysconfig module.

--- a/test cases/frameworks/20 cups/cups_prog.c
+++ b/test cases/frameworks/20 cups/cups_prog.c
@@ -1,0 +1,7 @@
+#include <cups/cups.h>
+
+int
+main()
+{
+    return !cupsGetDefault();
+}

--- a/test cases/frameworks/20 cups/cups_prog.c
+++ b/test cases/frameworks/20 cups/cups_prog.c
@@ -3,5 +3,6 @@
 int
 main()
 {
-    return !cupsGetDefault();
+    cupsGetDefault();
+    return 0;
 }

--- a/test cases/frameworks/20 cups/meson.build
+++ b/test cases/frameworks/20 cups/meson.build
@@ -1,0 +1,7 @@
+project('cups test', 'c')
+
+cups_dep = dependency('cups', version : '>=1.4')
+
+e = executable('cups_prog', 'cups_prog.c', dependencies : cups_dep)
+
+test('cupstest', e)


### PR DESCRIPTION
libcups has its own cups-config tool rather than using pkg-config.
This adds support for cups-config, based on pcap-config and
sdl2-config implementations.

This change also includes the unit test case and documentation for
cups dependency object implementation, and libcups2 dep to CI image.

One known package that uses libcups and needs this is
gnome-control-center.