### PR TITLE
Allow to add build-only includes

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2055,17 +2055,20 @@ rule FORTRAN_DEP_HACK
                     expdir = os.path.join(basedir, d)
                 else:
                     expdir = basedir
-                srctreedir = os.path.join(self.build_to_src, expdir)
-                # Add source subdir first so that the build subdir overrides it
-                sargs = compiler.get_include_args(srctreedir, i.is_system)
-                commands += sargs
+
+                if not i.is_build_only:
+                    srctreedir = os.path.join(self.build_to_src, expdir)
+                    # Add source subdir first so that the build subdir overrides it
+                    sargs = compiler.get_include_args(srctreedir, i.is_system)
+                    commands += sargs
+
                 # There may be include dirs where a build directory has not been
                 # created for some source dir. For example if someone does this:
                 #
                 # inc = include_directories('foo/bar/baz')
                 #
                 # But never subdir()s into the actual dir.
-                if os.path.isdir(os.path.join(self.environment.get_build_dir(), expdir)):
+                if i.is_build_only or os.path.isdir(os.path.join(self.environment.get_build_dir(), expdir)):
                     bargs = compiler.get_include_args(expdir, i.is_system)
                 else:
                     bargs = []

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -175,7 +175,7 @@ class Build:
         return link_args.get(compiler.get_language(), [])
 
 class IncludeDirs:
-    def __init__(self, curdir, dirs, is_system, extra_build_dirs=None):
+    def __init__(self, curdir, dirs, is_system, extra_build_dirs=None, is_build_only=False):
         self.curdir = curdir
         self.incdirs = dirs
         self.is_system = is_system
@@ -185,6 +185,7 @@ class IncludeDirs:
             self.extra_build_dirs = []
         else:
             self.extra_build_dirs = extra_build_dirs
+        self.is_build_only = is_build_only
 
     def __repr__(self):
         r = '<{} {}/{}>'

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1302,7 +1302,7 @@ permitted_kwargs = {'add_global_arguments': {'language'},
                     'executable': exe_kwargs,
                     'find_program': {'required'},
                     'generator': {'arguments', 'output', 'depfile'},
-                    'include_directories': {'is_system'},
+                    'include_directories': {'is_system', 'is_build_only'},
                     'install_data': {'install_dir', 'install_mode', 'sources'},
                     'install_headers': {'install_dir', 'subdir'},
                     'install_man': {'install_dir'},
@@ -2595,6 +2595,7 @@ class Interpreter(InterpreterBase):
         build_root = self.environment.get_build_dir()
         absbase_src = os.path.join(src_root, self.subdir)
         absbase_build = os.path.join(build_root, self.subdir)
+        is_build_only = kwargs.get('is_build_only', False)
 
         for a in args:
             if a.startswith(src_root):
@@ -2617,12 +2618,12 @@ different subdirectory.
 ''')
             absdir_src = os.path.join(absbase_src, a)
             absdir_build = os.path.join(absbase_build, a)
-            if not os.path.isdir(absdir_src) and not os.path.isdir(absdir_build):
+            if not is_build_only and not os.path.isdir(absdir_src) and not os.path.isdir(absdir_build):
                 raise InvalidArguments('Include dir %s does not exist.' % a)
         is_system = kwargs.get('is_system', False)
         if not isinstance(is_system, bool):
             raise InvalidArguments('Is_system must be boolean.')
-        i = IncludeDirsHolder(build.IncludeDirs(self.subdir, args, is_system))
+        i = IncludeDirsHolder(build.IncludeDirs(self.subdir, args, is_system, None, is_build_only))
         return i
 
     @permittedKwargs(permitted_kwargs['add_test_setup'])


### PR DESCRIPTION
This allows to add includes that should be considered only on the build
directory. It fixes the situation for code generators that may
generate tree completely different from source tree: the directory is
added as an include relative to the build directory only.

Closes #1855.