### PR TITLE
gnome: Ensure gir always works with asan, even if used together with ubsan

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -480,7 +480,7 @@ class GnomeModule(ExtensionModule):
             if 'b_sanitize' in compiler.base_options:
                 sanitize = state.environment.coredata.base_options['b_sanitize'].value
                 cflags += compilers.sanitizer_compile_args(sanitize)
-                if sanitize == 'address':
+                if 'address' in sanitize.split(','):
                     ldflags += ['-lasan']
                 # FIXME: Linking directly to libasan is not recommended but g-ir-scanner
                 # does not understand -f LDFLAGS. https://bugzilla.gnome.org/show_bug.cgi?id=783892


### PR DESCRIPTION
This really resolves #1910 by making it also work in cases where asan
and ubsan are used together via "-Db_sanitize=address,undefined".

(Apparently you also need to keep the order "address,undefined", using "undefined,address" is not accepted by meson - maybe this needs a more general refactoring to accept arbitrary combinations of sanitizers, but this PR at least fixes the immediate issue of not being able to use ubsan and asan together in any Meson project that uses GIR)