### PR TITLE
gnome: Fix typo in gtkdoc_html_dir, so it returns the correct path

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -798,7 +798,7 @@ class GnomeModule(ExtensionModule):
         modulename = args[0]
         if not isinstance(modulename, str):
             raise MesonException('Argument must be a string')
-        return ModuleReturnValue(os.path.join('share/gtkdoc/html', modulename), [])
+        return ModuleReturnValue(os.path.join('share/gtk-doc/html', modulename), [])
 
     @staticmethod
     def _unpack_args(arg, kwarg_name, kwargs, expend_file_state=None):

--- a/test cases/frameworks/10 gtk-doc/meson.build
+++ b/test cases/frameworks/10 gtk-doc/meson.build
@@ -2,7 +2,7 @@ project('gtkdoctest', 'c', version : '1.0.0')
 
 gnome = import('gnome')
 
-assert(gnome.gtkdoc_html_dir('foobar') == 'share/gtkdoc/html/foobar', 'Gtkdoc install dir is incorrect.')
+assert(gnome.gtkdoc_html_dir('foobar') == 'share/gtk-doc/html/foobar', 'Gtkdoc install dir is incorrect.')
 
 inc = include_directories('include')
 


### PR DESCRIPTION
The path returned by `gtkdoc_html_dir()` is wrong(tm) (probably a copy&paste error or typo). This PR fixes that.