### PR TITLE
Run all D tests if a recent enough GDC is used

### DIFF
--- a/test cases/d/3 shared library/meson.build
+++ b/test cases/d/3 shared library/meson.build
@@ -1,7 +1,10 @@
 project('D Shared Library', 'd')
 
-if meson.get_compiler('d').get_id() == 'gcc'
-  error('MESON_SKIP_TEST: GDC can not build shared libraries')
+dc = meson.get_compiler('d')
+if dc.get_id() == 'gcc'
+  if dc.version().version_compare('< 7')
+    error('MESON_SKIP_TEST: GDC < 7.0 can not build shared libraries')
+  endif
 endif
 
 ldyn = shared_library('stuff', 'libstuff.d', install : true)

--- a/test cases/d/4 library versions/meson.build
+++ b/test cases/d/4 library versions/meson.build
@@ -1,7 +1,10 @@
 project('D library versions', 'd')
 
-if meson.get_compiler('d').get_id() == 'gcc'
-  error('MESON_SKIP_TEST: GDC can not build shared libraries')
+dc = meson.get_compiler('d')
+if dc.get_id() == 'gcc'
+  if dc.version().version_compare('< 7')
+    error('MESON_SKIP_TEST: GDC < 7.0 can not build shared libraries')
+  endif
 endif
 
 shared_library('some', 'lib.d',

--- a/test cases/d/7 multilib/meson.build
+++ b/test cases/d/7 multilib/meson.build
@@ -1,7 +1,10 @@
 project('D Multiple Versioned Shared Libraries', 'd')
 
-if meson.get_compiler('d').get_id() == 'gcc'
-  error('MESON_SKIP_TEST: GDC can not build shared libraries (2016)')
+dc = meson.get_compiler('d')
+if dc.get_id() == 'gcc'
+  if dc.version().version_compare('< 7')
+    error('MESON_SKIP_TEST: GDC < 7.0 can not build shared libraries')
+  endif
 endif
 
 ldyn1 = shared_library('say1',

--- a/test cases/d/8 has multi arguments/meson.build
+++ b/test cases/d/8 has multi arguments/meson.build
@@ -2,7 +2,7 @@ project('D has arguments test', 'd')
 
 compiler = meson.get_compiler('d')
 
-assert(compiler.compiles('int i;'), 'Basic code test does not comple: ' + compiler.get_id())
+assert(compiler.compiles('int i;'), 'Basic code test does not compile: ' + compiler.get_id())
 assert(compiler.has_multi_arguments(['-I.', '-J.']), 'Multi argument test does not work: ' + compiler.get_id())
 assert(compiler.has_argument('-I.'), 'Basic argument test does not work: ' + compiler.get_id())
-assert(compiler.has_argument('-flag_a_d_compiler_defenaitly_does_not_have') == false, 'Basic argument test does not work: ' + compiler.get_id())
+assert(compiler.has_argument('-flag_a_d_compiler_definitely_does_not_have') == false, 'Basic argument test does not work: ' + compiler.get_id())


### PR DESCRIPTION
A while back, the GDC D compiler didn't have shared library support, but that feature is there now for more than a year. That means it's safe to enable these tests now.

This PR also resolves a few typos.
