### PR TITLE
gnome: Flatten the sources for generate_gir()

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -423,7 +423,7 @@ class GnomeModule(ExtensionModule):
             raise MesonException('gobject-introspection dependency was not found, gir cannot be generated.')
         ns = kwargs.pop('namespace')
         nsversion = kwargs.pop('nsversion')
-        libsources = kwargs.pop('sources')
+        libsources = mesonlib.flatten(kwargs.pop('sources'))
         girfile = '%s-%s.gir' % (ns, nsversion)
         srcdir = os.path.join(state.environment.get_source_dir(), state.subdir)
         builddir = os.path.join(state.environment.get_build_dir(), state.subdir)


### PR DESCRIPTION
If we don't do that, the traversal of the sources list to generate the sources file for g-ir-scanner is going to explode with a Python backtrace like this one:

```
  File "/usr/lib/python3.5/site-packages/mesonbuild/modules/gnome.py", line 463, in generate_gir
    gir_filelist.write(os.path.join(srcdir, s) + '\n')
  File "/usr/lib/python3.5/posixpath.py", line 89, in join
    genericpath._check_arg_types('join', a, *p)
  File "/usr/lib/python3.5/genericpath.py", line 143, in _check_arg_types
    (funcname, s.__class__.__name__)) from None
```

if the sources list contains a list.

This is the result of commit aeaefce81e91232512e0a56ce6a1a83a14c84bb4.