### PR TITLE
Allow listing deprecated keyword arguments

### DIFF
--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -57,8 +57,9 @@ def stringArgs(f):
 
 class permittedKwargs:
 
-    def __init__(self, permitted):
+    def __init__(self, permitted, deprecated=None):
         self.permitted = permitted
+        self.deprecated = deprecated or {}
 
     def __call__(self, f):
         @wraps(f)
@@ -70,7 +71,12 @@ class permittedKwargs:
                 subdir = node_or_state.subdir
                 lineno = node_or_state.current_lineno
             for k in kwargs:
-                if k not in self.permitted:
+                if k in self.deprecated:
+                    fname = os.path.join(subdir, environment.build_filename)
+                    replacement = self.deprecated.get(k, 'This will become a hard error in the future.')
+                    mlog.log(mlog.red('DEPRECATION:'), '''Passed deprecated keyword argument "%s" in %s line %d.
+%s.''' % (k, fname, lineno, replacement))
+                elif k not in self.permitted:
                     fname = os.path.join(subdir, environment.build_filename)
                     mlog.warning('''Passed invalid keyword argument "%s" in %s line %d.
 This will become a hard error in the future.''' % (k, fname, lineno))

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -73,9 +73,12 @@ class permittedKwargs:
             for k in kwargs:
                 if k in self.deprecated:
                     fname = os.path.join(subdir, environment.build_filename)
-                    replacement = self.deprecated.get(k, 'This will become a hard error in the future.')
+                    replacement = self.deprecated[k]
+                    if not replacement:
+                        replacement = 'Please remove the keyword argument'
                     mlog.log(mlog.red('DEPRECATION:'), '''Passed deprecated keyword argument "%s" in %s line %d.
-%s.''' % (k, fname, lineno, replacement))
+%s.
+This will become a hard error in the future.''' % (k, fname, lineno, replacement))
                 elif k not in self.permitted:
                     fname = os.path.join(subdir, environment.build_filename)
                     mlog.warning('''Passed invalid keyword argument "%s" in %s line %d.


### PR DESCRIPTION
The `permittedKwargs` decorator should have the ability to define a list of deprecated arguments, and thus warn about their use.

For a potential use of this, see PR #2216.