### PR TITLE
[wip] Improve boost windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,7 +56,7 @@ skip_commits:
 install:
   - cmd: set "ORIG_PATH=%PATH%"
   # Boost 1.56.0: https://www.appveyor.com/docs/build-environment/#boost
-  #- cmd: set "BOOST_ROOT=C:\Libraries\boost"
+  - cmd: set "BOOST_ROOT=C:\Libraries\boost"
   # Use the x86 python only when building for x86 for the cpython tests.
   # For all other archs (including, say, arm), use the x64 python.
   - ps: (new-object net.webclient).DownloadFile('https://www.dropbox.com/s/bbzvepq85hv47x1/ninja.exe?dl=1', 'C:\projects\meson\ninja.exe')

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -49,12 +49,18 @@ pkg-config files. Meson has autodetection support for some of these.
 
 ## Boost ##
 
-Boost is not a single dependency but rather a group of different
-libraries. To use Boost with Meson, simply list which Boost modules
-you would like to use.
+Boost is not a single dependency but rather a group of different libraries. To
+use headers-only modules from Boost you don't have to list any extra modules.
 
 ```meson
-boost_dep = dependency('boost', modules : ['thread', 'utility'])
+boost_dep = dependency('boost')
+exe = executable('myprog', 'file.cc', dependencies : boost_dep)
+```
+
+To use a compiled module of Boost, simply list the ones you would like to use.
+
+```meson
+boost_dep = dependency('boost', modules : ['thread', 'regex'])
 exe = executable('myprog', 'file.cc', dependencies : boost_dep)
 ```
 
@@ -64,6 +70,8 @@ use those to link against your targets.
 If your boost headers or libraries are in non-standard locations you
 can set the BOOST_ROOT, BOOST_INCLUDEDIR, and/or BOOST_LIBRARYDIR
 environment variables.
+
+NOTE: On Windows it will search for boost in C:\Boost.
 
 ## GTest and GMock ##
 

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -39,6 +39,9 @@ class BoostDependency(ExternalDependency):
 
     def __init__(self, environment, kwargs):
         super().__init__('boost', environment, 'cpp', kwargs)
+        # Building boost for static linking is default in windows. Is this even possible?
+        if mesonlib.is_windows() and 'static' not in kwargs.keys():
+            self.static = True
         self.libdir = None
         try:
             self.boost_root = os.environ['BOOST_ROOT']

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -86,14 +86,12 @@ class BoostDependency(ExternalDependency):
         self.boost_inc_subdir = os.path.join(self.incdir, 'boost')
         mlog.debug('Boost library root dir is', self.boost_root)
         mlog.debug('Boost library include dir is', self.boost_inc_subdir)
-        self.src_modules = {}
         self.lib_modules = {}
         self.lib_modules_mt = {}
         self.detect_version()
         self.requested_modules = self.get_requested(kwargs)
         module_str = ', '.join(self.requested_modules)
         if self.is_found:
-            self.detect_src_modules()
             self.detect_lib_modules()
             self.validate_requested()
             if self.boost_root is not None:
@@ -154,7 +152,7 @@ class BoostDependency(ExternalDependency):
 
     def validate_requested(self):
         for m in self.requested_modules:
-            if m not in self.src_modules and m not in self.lib_modules and m + '-mt' not in self.lib_modules_mt:
+            if m not in self.lib_modules and m + '-mt' not in self.lib_modules_mt:
                 msg = 'Requested Boost module {!r} not found'
                 raise DependencyException(msg.format(m))
 
@@ -171,12 +169,6 @@ class BoostDependency(ExternalDependency):
                     self.version = ver.replace('_', '.')
                     self.is_found = True
                     return
-
-    def detect_src_modules(self):
-        for entry in os.listdir(self.boost_inc_subdir):
-            entry = os.path.join(self.boost_inc_subdir, entry)
-            if stat.S_ISDIR(os.stat(entry).st_mode):
-                self.src_modules[os.path.split(entry)[-1]] = True
 
     def detect_lib_modules(self):
         if mesonlib.is_windows():

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -191,7 +191,7 @@ class BoostDependency(ExternalDependency):
             return
         libdir = libdir[0]
         # Don't override what was set in the environment
-        if self.libdir:
+        if not self.libdir:
             self.libdir = libdir
         globber = 'libboost_*-gd-*.lib' if self.static else 'boost_*-gd-*.lib'  # FIXME
         for entry in glob.glob(os.path.join(libdir, globber)):

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -60,16 +60,19 @@ class BoostDependency(ExternalDependency):
                 if 'BOOST_INCLUDEDIR' in os.environ:
                     self.incdir = os.environ['BOOST_INCLUDEDIR']
                 else:
+                    # If headers where install with `layout=system` or manually
+                    # copied they should be in include/boost:
+                    self.incdir = os.path.join(self.boost_root, 'include')
+
+                    # if include/boost does not exist, look for
+                    # include/boost-X_X/boost. That is the correct place if
+                    # `layout=versioned`.
                     boost_incs = glob.glob(os.path.join(self.boost_root, 'include', 'boost-*'))
-                    if os.path.isdir(os.path.join(self.boost_root, 'include', 'boost')):
-                        # If headers where install with `layout=system` or manually copied.
-                        self.incdir = os.path.join(self.boost_root, 'include')
-                    elif len(boost_incs) > 0:
-                        # If boost was installed with `layout=versioned` headers are in version-specific folders
-                        # FIXME: Should pick version according to version requirement in meson.build
-                        #        Take the one that sorts highest alphabetically for now..
+                    if not os.path.isdir(os.path.join(self.boost_root, 'include', 'boost')) and len(boost_incs) > 0:
+                        # FIXME: Should pick version according to version
+                        # requirement in meson.build. Take the one that sorts
+                        # highest alphabetically for now..
                         self.incdir = sorted(boost_incs)[-1]
-                    # Headers not found...
             else:
                 if 'BOOST_INCLUDEDIR' in os.environ:
                     self.incdir = os.environ['BOOST_INCLUDEDIR']

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -86,10 +86,10 @@ class BoostDependency(ExternalDependency):
             mlog.log("Dependency Boost (%s) found:" % module_str, mlog.red('NO'))
 
     def detect_win_root(self):
-        globtext = 'c:\\local\\boost_*'
-        files = glob.glob(globtext)
-        if len(files) > 0:
-            return files[0]
+        # This is the default install path if `.\b2 install` is run.
+        defaultpath = 'C:\\Boost'
+        if os.path.isdir(defaultpath):
+            return defaultpath
         return 'C:\\'
 
     def get_compile_args(self):

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -208,15 +208,15 @@ class BoostDependency(ExternalDependency):
             (_, fname) = os.path.split(entry)
             base = fname.split('_', 1)[1]
             modname = base.split('-', 1)[0]
-            self.lib_modules_mt[modname] = fname
-        # If boost was intalled as layout=system
-        globber = 'libboost_*.lib' if self.static else 'boost_*.lib'
-        for entry in glob.glob(os.path.join(libdir, globber)):
-            (_, fname) = os.path.split(entry)
-            base = fname.split('_', 1)[1]
-            modname = base.split('-', 1)[0]
-            self.lib_modules_mt[modname] = fname
-        mlog.debug('Boost libraries are', ' '.join(self.lib_modules_mt.keys()))
+            self.lib_modules[modname] = fname
+        if not self.lib_modules:
+            # If boost was intalled as layout=system
+            globber = 'libboost_*.lib' if self.static else 'boost_*.lib'
+            for entry in glob.glob(os.path.join(libdir, globber)):
+                (_, fname) = os.path.split(entry)
+                modname = fname.split('_', 1)[1][:-4]
+                self.lib_modules[modname] = fname
+        mlog.debug('Boost libraries are', ' '.join(self.lib_modules.keys()))
 
     def detect_lib_modules_nix(self):
         if self.static:
@@ -252,8 +252,8 @@ class BoostDependency(ExternalDependency):
         args.append('-L' + self.libdir)
         for module in self.requested_modules:
             module = BoostDependency.name2lib.get(module, module)
-            if module in self.lib_modules_mt:
-                args.append(self.lib_modules_mt[module])
+            if module in self.lib_modules:
+                args.append(self.lib_modules[module])
         return args
 
     def get_link_args(self):

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -40,8 +40,8 @@ class BoostDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
         super().__init__('boost', environment, 'cpp', kwargs)
         # Building boost for static linking is default in windows. Is this even possible?
-        if mesonlib.is_windows() and 'static' not in kwargs.keys():
-            self.static = True
+        #if mesonlib.is_windows() and 'static' not in kwargs.keys():
+        #    self.static = True
         self.libdir = None
         try:
             self.boost_root = os.environ['BOOST_ROOT']

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -97,14 +97,7 @@ class BoostDependency(ExternalDependency):
 
     def get_compile_args(self):
         args = []
-        if self.boost_root is not None:
-            if mesonlib.is_windows():
-                include_dir = self.boost_root
-            else:
-                include_dir = os.path.join(self.boost_root, 'include')
-        else:
-            include_dir = self.incdir
-
+        include_dir = self.incdir
         # Use "-isystem" when including boost headers instead of "-I"
         # to avoid compiler warnings/failures when "-Werror" is used
 

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -64,8 +64,8 @@ class BoostDependency(ExternalDependency):
                 else:
                     self.incdir = '/usr/include'
 
-                if 'BOOST_LIBRARYDIR' in os.environ:
-                    self.libdir = os.environ['BOOST_LIBRARYDIR']
+            if 'BOOST_LIBRARYDIR' in os.environ:
+                self.libdir = os.environ['BOOST_LIBRARYDIR']
         else:
             self.incdir = os.path.join(self.boost_root, 'include')
         self.boost_inc_subdir = os.path.join(self.incdir, 'boost')

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -224,9 +224,10 @@ class BoostDependency(ExternalDependency):
 
     def get_win_link_args(self):
         args = []
-        # TODO: should this check self.libdir?
-        if self.boost_root:
-            args.append('-L' + self.libdir)
+        # libdir is not set (and not needed) if only headers are used.
+        if not self.libdir:
+            return args
+        args.append('-L' + self.libdir)
         for module in self.requested_modules:
             module = BoostDependency.name2lib.get(module, module)
             if module in self.lib_modules_mt:

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -11,13 +11,14 @@ add_project_arguments(['-DBOOST_LOG_DYN_LINK'],
 
 linkdep = dependency('boost', modules : ['thread', 'system'])
 staticdep = dependency('boost', modules : ['thread', 'system'], static : true)
+testdep = dependency('boost', modules : ['unit_test_framework'])
 nomoddep = dependency('boost')
 extralibdep = dependency('boost', modules : ['thread', 'system', 'log_setup', 'log'])
 
 nolinkexe = executable('nolinkedexe', 'nolinkexe.cc', dependencies : nomoddep)
 linkexe = executable('linkedexe', 'linkexe.cc', dependencies : linkdep)
 staticexe = executable('staticlinkedexe', 'linkexe.cc', dependencies : staticdep)
-unitexe = executable('utf', 'unit_test.cpp', dependencies : nomoddep)
+unitexe = executable('utf', 'unit_test.cpp', dependencies : testdep)
 nomodexe = executable('nomod', 'nomod.cpp', dependencies : nomoddep)
 extralibexe = executable('extralibexe', 'extralib.cpp', dependencies : extralibdep)
 

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -9,17 +9,15 @@ add_project_arguments(['-DBOOST_LOG_DYN_LINK'],
 # within one project. The need to be independent of each other.
 # Use one without a library dependency and one with it.
 
-nolinkdep = dependency('boost', modules: 'utility')
 linkdep = dependency('boost', modules : ['thread', 'system'])
 staticdep = dependency('boost', modules : ['thread', 'system'], static : true)
-testdep = dependency('boost', modules : 'test')
 nomoddep = dependency('boost')
 extralibdep = dependency('boost', modules : ['thread', 'system', 'log_setup', 'log'])
 
-nolinkexe = executable('nolinkedexe', 'nolinkexe.cc', dependencies : nolinkdep)
+nolinkexe = executable('nolinkedexe', 'nolinkexe.cc', dependencies : nomoddep)
 linkexe = executable('linkedexe', 'linkexe.cc', dependencies : linkdep)
 staticexe = executable('staticlinkedexe', 'linkexe.cc', dependencies : staticdep)
-unitexe = executable('utf', 'unit_test.cpp', dependencies: testdep)
+unitexe = executable('utf', 'unit_test.cpp', dependencies : nomoddep)
 nomodexe = executable('nomod', 'nomod.cpp', dependencies : nomoddep)
 extralibexe = executable('extralibexe', 'extralib.cpp', dependencies : extralibdep)
 


### PR DESCRIPTION
Tried to improve boost support for windows. Please review

I would like to support the following cases:
1. Copy boost_x_x_x\boost to C:\Boost\include\boost. (Using only boost headers)
2. Boost on windows using default build configuration (layout=versioned, link=static)
```
 C:\Boost
 |-- include
 |   `-- boost-1_65
 |       `-- boost
 |           `-- *.hpp files
 `-- lib
     `-- libboost_*-gd-1_65.lib files
```
3. Boost on windows using non-default build config (layout=system, link=dynamic)
```
- C:\Boost
  |-- include
  |   `-- boost
  |       `-- *.hpp files
  `-- lib
      `-- boost_*.lib files
```