### PR TITLE
install: Also ignore PermissionError for selinux

### DIFF
--- a/mesonbuild/scripts/meson_install.py
+++ b/mesonbuild/scripts/meson_install.py
@@ -101,7 +101,7 @@ def restore_selinux_context(to_file):
             use_selinux = False
             msg = "{!r}: Failed to restore SELinux context, ignoring SELinux context for all remaining files..."
             print(msg.format(to_file, e.returncode))
-    except (FileNotFoundError, subprocess.CalledProcessError) as e:
+    except (FileNotFoundError, PermissionError, subprocess.CalledProcessError) as e:
         # If we don't have selinux or selinuxenabled returned 1, failure
         # is ignored quietly.
         use_selinux = False


### PR DESCRIPTION
When the user does not have permissions to run `selinuxenabled`, a `PermissionError` is raised instead of `FileNotFoundError`.

Closes https://github.com/mesonbuild/meson/issues/2257