### PR TITLE
fix checks for gcc disable warning flags

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -814,6 +814,11 @@ and other similar methods only support checking compiler arguments.
 Using them to check linker arguments are never supported, and results
 are likely to be wrong regardless of the compiler you are using.
 '''.format(arg))
+        # some compilers, e.g. GCC, don't warn for unsupported warning-disable
+        # flags, so when we are testing a flag like "-Wno-forgotten-towel", also
+        # check the equivalent enable flag too "-Wforgotten-towel"
+        if len(args) == 1 and args[0].startswith('-Wno-'):
+                args.append('-W' + args[0][5:])
         return self.compiles('int i;\n', env, extra_args=args)
 
 

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -807,18 +807,18 @@ class CCompiler(Compiler):
         return ['-pthread']
 
     def has_multi_arguments(self, args, env):
-        for arg in args:
+        for arg in args[:]:
+            # some compilers, e.g. GCC, don't warn for unsupported warning-disable
+            # flags, so when we are testing a flag like "-Wno-forgotten-towel", also
+            # check the equivalent enable flag too "-Wforgotten-towel"
+            if arg.startswith('-Wno-'):
+                    args.append('-W' + arg[5:])
             if arg.startswith('-Wl,'):
                 mlog.warning('''{} looks like a linker argument, but has_argument
 and other similar methods only support checking compiler arguments.
 Using them to check linker arguments are never supported, and results
 are likely to be wrong regardless of the compiler you are using.
 '''.format(arg))
-        # some compilers, e.g. GCC, don't warn for unsupported warning-disable
-        # flags, so when we are testing a flag like "-Wno-forgotten-towel", also
-        # check the equivalent enable flag too "-Wforgotten-towel"
-        if len(args) == 1 and args[0].startswith('-Wno-'):
-                args.append('-W' + args[0][5:])
         return self.compiles('int i;\n', env, extra_args=args)
 
 

--- a/test cases/common/112 has arg/meson.build
+++ b/test cases/common/112 has arg/meson.build
@@ -39,11 +39,17 @@ assert(l2.length() == 0, 'First supported did not return empty array.')
 
 if cc.get_id() == 'gcc'
   pre_arg = '-Wformat'
-  anti_pre_arg = '-Wno-format'
+  # NOTE: We have special handling for -Wno-foo args because gcc silently
+  # ignores unknown -Wno-foo args unless you pass -Werror, so for this test, we
+  # pass it as two separate arguments.
+  anti_pre_arg = ['-W', 'no-format']
   arg = '-Werror=format-security'
   assert(not cc.has_multi_arguments([anti_pre_arg, arg]), 'Arg that should be broken is not.')
   assert(cc.has_multi_arguments(pre_arg), 'Arg that should have worked does not work.')
   assert(cc.has_multi_arguments([pre_arg, arg]), 'Arg that should have worked does not work.')
+  # Test that gcc correctly errors out on unknown -Wno flags
+  assert(not cc.has_argument('-Wno-lol-meson-test-flags'), 'should error out on unknown -Wno args')
+  assert(not cc.has_multi_arguments(['-Wno-pragmas', '-Wno-lol-meson-test-flags']), 'should error out even if some -Wno args are valid')
 endif
 
 if cc.get_id() == 'clang' and cc.version().version_compare('<=4.0.0')


### PR DESCRIPTION
GCC does not print a warning or error for unknown options if the options
are to disable warnings. Therefore, when checking for options starting
'-Wno-', also check the opposite enabling option.  This fixes the case
where e.g.  -Wno-implicit-fallthrough is incorrectly reported as supported
by gcc 5.4.