### PR TITLE
namespace run_targets by subproject

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -534,7 +534,7 @@ int dummy;
         elem.add_item('COMMAND', cmd)
         elem.add_item('description', desc.format(target.name, cmd_type))
         elem.write(outfile)
-        self.processed_targets[target.name + target.type_suffix()] = True
+        self.processed_targets[target.get_id()] = True
 
     def generate_run_target(self, target, outfile):
         cmd = self.environment.get_build_command() + ['--internal', 'commandrunner']
@@ -552,7 +552,12 @@ int dummy;
                 arg_strings.append(os.path.join(self.environment.get_build_dir(), relfname))
             else:
                 raise AssertionError('Unreachable code in generate_run_target: ' + str(i))
-        elem = NinjaBuildElement(self.all_outputs, 'meson-' + target.name, 'CUSTOM_COMMAND', [])
+        if target.subproject != '':
+            subproject_prefix = '{}@@'.format(target.subproject)
+        else:
+            subproject_prefix = ''
+        target_name = 'meson-{}{}'.format(subproject_prefix, target.name)
+        elem = NinjaBuildElement(self.all_outputs, target_name, 'CUSTOM_COMMAND', [])
         cmd += [self.environment.get_source_dir(),
                 self.environment.get_build_dir(),
                 target.subdir] + self.environment.get_build_command()
@@ -588,8 +593,8 @@ int dummy;
         elem.add_item('pool', 'console')
         elem.write(outfile)
         # Alias that runs the target defined above with the name the user specified
-        self.create_target_alias('meson-' + target.name, outfile)
-        self.processed_targets[target.name + target.type_suffix()] = True
+        self.create_target_alias(target_name, outfile)
+        self.processed_targets[target.get_id()] = True
 
     def generate_coverage_rules(self, outfile):
         e = NinjaBuildElement(self.all_outputs, 'meson-coverage', 'CUSTOM_COMMAND', 'PHONY')

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -279,7 +279,7 @@ class EnvironmentVariables:
         return env
 
 class Target:
-    def __init__(self, name, subdir, build_by_default):
+    def __init__(self, name, subdir, subproject, build_by_default):
         if '/' in name or '\\' in name:
             # Fix failing test 53 when this becomes an error.
             mlog.warning('''Target "%s" has a path separator in its name.
@@ -287,6 +287,7 @@ This is not supported, it can cause unexpected failures and will become
 a hard error in the future.''' % name)
         self.name = name
         self.subdir = subdir
+        self.subproject = subproject
         self.build_by_default = build_by_default
         self.install = False
         self.build_always = False
@@ -297,6 +298,15 @@ a hard error in the future.''' % name)
 
     def get_subdir(self):
         return self.subdir
+
+    def get_id(self):
+        # This ID must also be a valid file name on all OSs.
+        # It should also avoid shell metacharacters for obvious
+        # reasons.
+        base = self.name + self.type_suffix()
+        if self.subproject == '':
+            return base
+        return self.subproject + '@@' + base
 
     def process_kwargs(self, kwargs):
         if 'build_by_default' in kwargs:
@@ -320,8 +330,7 @@ a hard error in the future.''' % name)
 
 class BuildTarget(Target):
     def __init__(self, name, subdir, subproject, is_cross, sources, objects, environment, kwargs):
-        super().__init__(name, subdir, True)
-        self.subproject = subproject # Can not be calculated from subdir as subproject dirname can be changed per project.
+        super().__init__(name, subdir, subproject, True)
         self.is_cross = is_cross
         unity_opt = environment.coredata.get_builtin_option('unity')
         self.is_unity = unity_opt == 'on' or (unity_opt == 'subprojects' and subproject != '')
@@ -373,15 +382,6 @@ class BuildTarget(Target):
     def validate_cross_install(self, environment):
         if environment.is_cross_build() and not self.is_cross and self.install:
             raise InvalidArguments('Tried to install a natively built target in a cross build.')
-
-    def get_id(self):
-        # This ID must also be a valid file name on all OSs.
-        # It should also avoid shell metacharacters for obvious
-        # reasons.
-        base = self.name + self.type_suffix()
-        if self.subproject == '':
-            return base
-        return self.subproject + '@@' + base
 
     def check_unknown_kwargs(self, kwargs):
         # Override this method in derived classes that have more
@@ -1509,8 +1509,8 @@ class CustomTarget(Target):
                     'override_options': True,
                     }
 
-    def __init__(self, name, subdir, kwargs, absolute_paths=False):
-        super().__init__(name, subdir, False)
+    def __init__(self, name, subdir, subproject, kwargs, absolute_paths=False):
+        super().__init__(name, subdir, subproject, False)
         self.dependencies = []
         self.extra_depends = []
         self.depend_files = [] # Files that this target depends on but are not on the command line.
@@ -1687,8 +1687,8 @@ class CustomTarget(Target):
         raise NotImplementedError
 
 class RunTarget(Target):
-    def __init__(self, name, command, args, dependencies, subdir):
-        super().__init__(name, subdir, False)
+    def __init__(self, name, command, args, dependencies, subdir, subproject):
+        super().__init__(name, subdir, subproject, False)
         self.command = command
         self.args = args
         self.dependencies = dependencies
@@ -1699,9 +1699,6 @@ class RunTarget(Target):
     def __repr__(self):
         repr_str = "<{0} {1}: {2}>"
         return repr_str.format(self.__class__.__name__, self.get_id(), self.command)
-
-    def get_id(self):
-        return self.name + self.type_suffix()
 
     def get_dependencies(self):
         return self.dependencies

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -606,9 +606,9 @@ class CustomTargetHolder(TargetHolder):
         raise InterpreterException('Cannot delete a member of a CustomTarget')
 
 class RunTargetHolder(InterpreterObject, ObjectHolder):
-    def __init__(self, name, command, args, dependencies, subdir):
+    def __init__(self, name, command, args, dependencies, subdir, subproject):
         InterpreterObject.__init__(self)
-        ObjectHolder.__init__(self, build.RunTarget(name, command, args, dependencies, subdir))
+        ObjectHolder.__init__(self, build.RunTarget(name, command, args, dependencies, subdir, subproject))
 
     def __repr__(self):
         r = '<{} {}: {}>'
@@ -1060,10 +1060,10 @@ class CompilerHolder(InterpreterObject):
         return []
 
 ModuleState = namedtuple('ModuleState', [
-    'build_to_src', 'subdir', 'current_lineno', 'environment', 'project_name',
-    'project_version', 'backend', 'compilers', 'targets', 'data', 'headers',
-    'man', 'global_args', 'project_args', 'build_machine', 'host_machine',
-    'target_machine'])
+    'build_to_src', 'subproject', 'subdir', 'current_lineno', 'environment',
+    'project_name', 'project_version', 'backend', 'compilers', 'targets',
+    'data', 'headers', 'man', 'global_args', 'project_args', 'build_machine',
+    'host_machine', 'target_machine'])
 
 class ModuleHolder(InterpreterObject, ObjectHolder):
     def __init__(self, modname, module, interpreter):
@@ -1085,6 +1085,7 @@ class ModuleHolder(InterpreterObject, ObjectHolder):
         state = ModuleState(
             build_to_src=os.path.relpath(self.interpreter.environment.get_source_dir(),
                                          self.interpreter.environment.get_build_dir()),
+            subproject=self.interpreter.subproject,
             subdir=self.interpreter.subdir,
             current_lineno=self.interpreter.current_lineno,
             environment=self.interpreter.environment,
@@ -2288,7 +2289,7 @@ to directly access options of other subprojects.''')
         if len(args) != 1:
             raise InterpreterException('custom_target: Only one positional argument is allowed, and it must be a string name')
         name = args[0]
-        tg = CustomTargetHolder(build.CustomTarget(name, self.subdir, kwargs), self)
+        tg = CustomTargetHolder(build.CustomTarget(name, self.subdir, self.subproject, kwargs), self)
         self.add_target(name, tg.held_object)
         return tg
 
@@ -2331,7 +2332,7 @@ to directly access options of other subprojects.''')
             cleaned_deps.append(d)
         command = cleaned_args[0]
         cmd_args = cleaned_args[1:]
-        tg = RunTargetHolder(name, command, cmd_args, cleaned_deps, self.subdir)
+        tg = RunTargetHolder(name, command, cmd_args, cleaned_deps, self.subdir, self.subproject)
         self.add_target(name, tg.held_object)
         return tg
 

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -78,21 +78,21 @@ class ModuleReturnValue:
         self.new_objects = new_objects
 
 class GResourceTarget(build.CustomTarget):
-    def __init__(self, name, subdir, kwargs):
-        super().__init__(name, subdir, kwargs)
+    def __init__(self, name, subdir, subproject, kwargs):
+        super().__init__(name, subdir, subproject, kwargs)
 
 class GResourceHeaderTarget(build.CustomTarget):
-    def __init__(self, name, subdir, kwargs):
-        super().__init__(name, subdir, kwargs)
+    def __init__(self, name, subdir, subproject, kwargs):
+        super().__init__(name, subdir, subproject, kwargs)
 
 class GirTarget(build.CustomTarget):
-    def __init__(self, name, subdir, kwargs):
-        super().__init__(name, subdir, kwargs)
+    def __init__(self, name, subdir, subproject, kwargs):
+        super().__init__(name, subdir, subproject, kwargs)
 
 class TypelibTarget(build.CustomTarget):
-    def __init__(self, name, subdir, kwargs):
-        super().__init__(name, subdir, kwargs)
+    def __init__(self, name, subdir, subproject, kwargs):
+        super().__init__(name, subdir, subproject, kwargs)
 
 class VapiTarget(build.CustomTarget):
-    def __init__(self, name, subdir, kwargs):
-        super().__init__(name, subdir, kwargs)
+    def __init__(self, name, subdir, subproject, kwargs):
+        super().__init__(name, subdir, subproject, kwargs)

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -79,7 +79,7 @@ class I18nModule(ExtensionModule):
             command.append(datadirs)
 
         kwargs['command'] = command
-        ct = build.CustomTarget(kwargs['output'] + '_merge', state.subdir, kwargs)
+        ct = build.CustomTarget(kwargs['output'] + '_merge', state.subdir, state.subproject, kwargs)
         return ModuleReturnValue(ct, [ct])
 
     @permittedKwargs({'po_dir', 'data_dirs', 'type', 'languages', 'args', 'preset', 'install'})
@@ -111,12 +111,12 @@ class I18nModule(ExtensionModule):
             potargs.append(datadirs)
         if extra_args:
             potargs.append(extra_args)
-        pottarget = build.RunTarget(packagename + '-pot', potargs[0], potargs[1:], [], state.subdir)
+        pottarget = build.RunTarget(packagename + '-pot', potargs[0], potargs[1:], [], state.subdir, state.subproject)
 
         gmoargs = state.environment.get_build_command() + ['--internal', 'gettext', 'gen_gmo']
         if lang_arg:
             gmoargs.append(lang_arg)
-        gmotarget = build.RunTarget(packagename + '-gmo', gmoargs[0], gmoargs[1:], [], state.subdir)
+        gmotarget = build.RunTarget(packagename + '-gmo', gmoargs[0], gmoargs[1:], [], state.subdir, state.subproject)
 
         updatepoargs = state.environment.get_build_command() + ['--internal', 'gettext', 'update_po', pkg_arg]
         if lang_arg:
@@ -125,7 +125,7 @@ class I18nModule(ExtensionModule):
             updatepoargs.append(datadirs)
         if extra_args:
             updatepoargs.append(extra_args)
-        updatepotarget = build.RunTarget(packagename + '-update-po', updatepoargs[0], updatepoargs[1:], [], state.subdir)
+        updatepotarget = build.RunTarget(packagename + '-update-po', updatepoargs[0], updatepoargs[1:], [], state.subdir, state.subproject)
 
         targets = [pottarget, gmotarget, updatepotarget]
 

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -110,7 +110,7 @@ class QtBaseModule:
                           'output': name + '.cpp',
                           'command': [self.rcc, '-o', '@OUTPUT@', '@INPUT@'],
                           'depend_files': qrc_deps}
-            res_target = build.CustomTarget(name, state.subdir, rcc_kwargs)
+            res_target = build.CustomTarget(name, state.subdir, state.subproject, rcc_kwargs)
             sources.append(res_target)
         if len(ui_files) > 0:
             if not self.uic.found():

--- a/test cases/common/90 identical target name in subproject/meson.build
+++ b/test cases/common/90 identical target name in subproject/meson.build
@@ -3,3 +3,4 @@ project('toplevel bar', 'c')
 subproject('foo')
 
 executable('bar', 'bar.c')
+run_target('nop', 'true')

--- a/test cases/common/90 identical target name in subproject/subprojects/foo/meson.build
+++ b/test cases/common/90 identical target name in subproject/subprojects/foo/meson.build
@@ -1,3 +1,4 @@
 project('subfoo', 'c')
 
 executable('bar', 'bar.c')
+run_target('nop', 'true')


### PR DESCRIPTION
namespace run_targets by subproject
    
Currently, run_target does not get namespaced for each subproject,
unlike executable and others. This means that two subprojects sharing
the same run_target name cause meson to crash.
    
Fix this by moving the subproject namespacing logic from the BuildTarget
class to the Target class.