### PR TITLE
backends: Add custom target inc dirs before target inc dirs

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2038,6 +2038,12 @@ rule FORTRAN_DEP_HACK
         # Add compiler args and include paths from several sources; defaults,
         # build options, external dependencies, etc.
         commands += self.generate_basic_compiler_args(target, compiler, no_warn_args)
+        # Add custom target dirs as includes automatically, but before
+        # target-specific include directories.
+        # XXX: Not sure if anyone actually uses this? It can cause problems in
+        # situations which increase the likelihood for a header name collision,
+        # such as in subprojects.
+        commands += self.get_custom_target_dir_include_args(target, compiler)
         # Add include dirs from the `include_directories:` kwarg on the target
         # and from `include_directories:` of internal deps of the target.
         #
@@ -2081,14 +2087,12 @@ rule FORTRAN_DEP_HACK
         # from external dependencies, internal dependencies, and from
         # per-target `include_directories:`
         #
-        # We prefer headers in the build dir and the custom target dir over the
-        # source dir since, for instance, the user might have an
-        # srcdir == builddir Autotools build in their source tree. Many
-        # projects that are moving to Meson have both Meson and Autotools in
-        # parallel as part of the transition.
+        # We prefer headers in the build dir over the source dir since, for
+        # instance, the user might have an srcdir == builddir Autotools build
+        # in their source tree. Many projects that are moving to Meson have
+        # both Meson and Autotools in parallel as part of the transition.
         if target.implicit_include_directories:
             commands += self.get_source_dir_include_args(target, compiler)
-        commands += self.get_custom_target_dir_include_args(target, compiler)
         if target.implicit_include_directories:
             commands += self.get_build_dir_include_args(target, compiler)
         # Finally add the private dir for the target to the include path. This

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -763,6 +763,10 @@ class Vs2010Backend(backends.Backend):
             # This is where Visual Studio will insert target_args, target_defines,
             # etc, which are added later from external deps (see below).
             args += ['%(AdditionalOptions)', '%(PreprocessorDefinitions)', '%(AdditionalIncludeDirectories)']
+            # Add custom target dirs as includes automatically, but before
+            # target-specific include dirs. See _generate_single_compile() in
+            # the ninja backend for caveats.
+            args += ['-I' + arg for arg in generated_files_include_dirs]
             # Add include dirs from the `include_directories:` kwarg on the target
             # and from `include_directories:` of internal deps of the target.
             #
@@ -789,14 +793,12 @@ class Vs2010Backend(backends.Backend):
             if l in file_args:
                 file_args[l] += args
         # The highest priority includes. In order of directory search:
-        # target private dir, target build dir, generated sources include dirs,
-        # target source dir
+        # target private dir, target build dir, target source dir
         for args in file_args.values():
             t_inc_dirs = [self.relpath(self.get_target_private_dir(target),
                                        self.get_target_dir(target))]
             if target.implicit_include_directories:
                 t_inc_dirs += ['.']
-            t_inc_dirs += generated_files_include_dirs
             if target.implicit_include_directories:
                 t_inc_dirs += [proj_to_src_dir]
             args += ['-I' + arg for arg in t_inc_dirs]

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -899,7 +899,7 @@ class AllPlatformTests(BasePlatformTests):
             raise Exception('Could not find someexe and somfxe commands')
         # Check include order for 'someexe'
         incs = [a for a in shlex.split(execmd) if a.startswith("-I")]
-        self.assertEqual(len(incs), 8)
+        self.assertEqual(len(incs), 9)
         # target private dir
         self.assertPathEqual(incs[0], "-Isub4/someexe@exe")
         # target build subdir
@@ -916,6 +916,8 @@ class AllPlatformTests(BasePlatformTests):
         self.assertPathEqual(incs[6], "-Isub1")
         # target internal dependency include_directories: source dir
         self.assertPathBasenameEqual(incs[7], 'sub1')
+        # custom target include dir
+        self.assertPathEqual(incs[8], '-Ictsub')
         # Check include order for 'somefxe'
         incs = [a for a in shlex.split(fxecmd) if a.startswith('-I')]
         self.assertEqual(len(incs), 9)

--- a/test cases/common/138 include order/ctsub/copyfile.py
+++ b/test cases/common/138 include order/ctsub/copyfile.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import sys
+import shutil
+
+shutil.copyfile(sys.argv[1], sys.argv[2])

--- a/test cases/common/138 include order/ctsub/main.h
+++ b/test cases/common/138 include order/ctsub/main.h
@@ -1,0 +1,1 @@
+#error "ctsub/main.h included"

--- a/test cases/common/138 include order/ctsub/meson.build
+++ b/test cases/common/138 include order/ctsub/meson.build
@@ -1,0 +1,9 @@
+# https://github.com/mesonbuild/meson/pull/2291
+copy = find_program('copyfile.py')
+configure_file(input : 'main.h',
+               output : 'main.h',
+               command : [copy, '@INPUT@', '@OUTPUT@'])
+ctfile = custom_target('emptyfile',
+                       input : 'emptyfile.c',
+                       output : 'emptyfile.c',
+                       command : [copy, '@INPUT@', '@OUTPUT@'])

--- a/test cases/common/138 include order/meson.build
+++ b/test cases/common/138 include order/meson.build
@@ -10,6 +10,8 @@ project('include order', 'c')
 # 5. Include paths added via `include_directories:` of internal deps
 #    Within this, the build dir takes precedence over the source dir
 
+# Custom target dir with a built header
+subdir('ctsub')
 # Defines an internal dep
 subdir('sub1')
 # Defines a per-target include path

--- a/test cases/common/138 include order/sub4/meson.build
+++ b/test cases/common/138 include order/sub4/meson.build
@@ -1,4 +1,4 @@
-e = executable('someexe', 'main.c',
+e = executable('someexe', 'main.c', ctfile,
                c_args : ['-I' + sub3],
                include_directories : j,
                dependencies : dep)


### PR DESCRIPTION
Custom target include dirs must be overridable by target-specific include dirs otherwise in case of header name collisions, the user has no way to override this behaviour. This is happening right now for gtk+ and graphene when graphene is used via a subproject.