### PR TITLE
Add Windows extra_paths to beginning of PATH when running tests

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -224,7 +224,7 @@ class TestHarness:
 
             child_env.update(test.env)
             if len(test.extra_paths) > 0:
-                child_env['PATH'] += os.pathsep.join([''] + test.extra_paths)
+                child_env['PATH'] = os.pathsep.join(test.extra_paths + ['']) + child_env['PATH']
 
             # If MALLOC_PERTURB_ is not set, or if it is set to an empty value,
             # (i.e., the test or the environment don't explicitly set it), set


### PR DESCRIPTION
Adding it to the end of PATH means that if an installed instance of a DLL
exists, that would be used instead of the built instance.

Compare with run_exe(), which already gets this right.