### PR TITLE
gnome: Docbook generation for gdbus_codegen()

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -226,6 +226,7 @@ files and the second specifies the XML file name.
 * `namespace`: namespace of the interface
 * `object_manager`: *(Added 0.40.0)* if true generates object manager code
 * `annotations`: *(Added 0.43.0)* list of lists of 3 strings for the annotation for `'ELEMENT', 'KEY', 'VALUE'`
+* `docbook`: *(Added 0.43.0)* prefix to generate `'PREFIX'-NAME.xml` docbooks
 
 Returns an opaque object containing the source files. Add it to a top
 level target's source list.
@@ -241,7 +242,8 @@ gdbus_src = gnome.gdbus_codegen('example-interface', 'com.example.Sample.xml',
   namespace : 'Sample',
   annotations : [
     ['com.example.Hello()', 'org.freedesktop.DBus.Deprecated', 'true']
-  ]
+  ],
+  docbook : 'example-interface-doc'
 )
 ```
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -850,7 +850,8 @@ class GnomeModule(ExtensionModule):
 
         return []
 
-    @permittedKwargs({'interface_prefix', 'namespace', 'object_manager', 'build_by_default', 'annotations'})
+    @permittedKwargs({'interface_prefix', 'namespace', 'object_manager', 'build_by_default',
+                      'annotations', 'docbook'})
     def gdbus_codegen(self, state, args, kwargs):
         if len(args) != 2:
             raise MesonException('Gdbus_codegen takes two arguments, name and xml file.')
@@ -864,6 +865,8 @@ class GnomeModule(ExtensionModule):
             cmd += ['--c-namespace', kwargs.pop('namespace')]
         if kwargs.get('object_manager', False):
             cmd += ['--c-generate-object-manager']
+        if 'docbook' in kwargs:
+            cmd += ['--generate-docbook', kwargs.pop('docbook')]
 
         # Annotations are a bit ugly in that they are a list of lists of strings...
         annotations = kwargs.pop('annotations', [])

--- a/test cases/frameworks/7 gnome/gdbus/meson.build
+++ b/test cases/frameworks/7 gnome/gdbus/meson.build
@@ -3,7 +3,8 @@ gdbus_src = gnome.gdbus_codegen('generated-gdbus', 'com.example.Sample.xml',
   namespace : 'Sample',
   annotations : [
     ['com.example.Hello()', 'org.freedesktop.DBus.Deprecated', 'true']
-  ]
+  ],
+  docbook : 'generated-gdbus-doc'
 )
 
 gdbus_exe = executable('gdbus-test', 'gdbusprog.c',


### PR DESCRIPTION
Add new 'docbook' argument which generates Docbook documentation for each D-Bus interface. The docbook argument will be used as prefix in `PREFIX`-NAME.xml pattern, and NAME will be replaced by the D-Bus interfaces.