### PR TITLE
interpreter: Always flatten when unholding arrays

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -707,6 +707,7 @@ def windows_proof_rmtree(f):
 
 def unholder_array(entries):
     result = []
+    entries = flatten(entries)
     for e in entries:
         if hasattr(e, 'held_object'):
             e = e.held_object

--- a/test cases/common/87 declare dep/entity/meson.build
+++ b/test cases/common/87 declare dep/entity/meson.build
@@ -1,6 +1,6 @@
 entity_lib = static_library('entity', 'entity1.c')
 
-entity_dep = declare_dependency(link_with : entity_lib,
+entity_dep = declare_dependency(link_with : [[entity_lib]],
   include_directories : include_directories('.'),
   sources : 'entity2.c',
   compile_args : ['-DUSING_ENT=1'],


### PR DESCRIPTION
Otherwise we might end up with wrapper holders in the `Build` object and pickling will then fail, defeating the purpose of the holder objects.

Closes https://github.com/mesonbuild/meson/issues/2211