### PR TITLE
[WIP] Add Watcom C/C++ Toolchain Support

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -476,6 +476,10 @@ class Backend:
                 continue
             if isinstance(compiler, (compilers.LLVMDCompiler, compilers.DmdDCompiler)):
                 d_arg = '-L' + d_arg
+            # Libraries must unconditionally be prefixed with "library ", even
+            # if not using libpath.
+            elif isinstance(compiler, compilers.WatcomCCompiler):
+                d_arg = 'library ' + d_arg
             args.append(d_arg)
         return args
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1505,6 +1505,8 @@ int dummy;
  rspfile = $out.rsp
  rspfile_content = $ARGS  {output_args} $in $LINK_ARGS {cross_args} $aliasing
 '''
+                elif compiler.get_id() == 'watcom':
+                    command_template = ' command = {executable} $ARGS {output_args} $in_mangled $LINK_ARGS {cross_args} $aliasing\n'
                 else:
                     command_template = ' command = {executable} $ARGS {output_args} $in $LINK_ARGS {cross_args} $aliasing\n'
                 command = command_template.format(
@@ -2481,10 +2483,20 @@ rule FORTRAN_DEP_HACK
         dep_targets = [self.get_dependency_filename(t) for t in dependencies]
         dep_targets.extend([self.get_dependency_filename(t)
                             for t in target.link_depends])
+
         (qf, winpaths) = self.query_commandline_hacks(linker)
         elem = NinjaBuildElement(self.all_outputs, outname, linker_rule, obj_list, qf, winpaths)
         elem.add_dep(dep_targets + custom_target_libraries)
         elem.add_item('LINK_ARGS', commands)
+
+        if linker.get_id() == 'watcom':
+            objs_mangled = []
+            for obj in obj_list:
+                objs_mangled.append('\'{}\''.format(obj))
+
+            in_mangled = 'file ' + ', '.join(objs_mangled)
+            elem.add_item('in_mangled', in_mangled)
+
         return elem
 
     def get_dependency_filename(self, t):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1500,7 +1500,7 @@ int dummy;
                     except KeyError:
                         pass
                 rule = 'rule %s%s_LINKER\n' % (langname, crstr)
-                if mesonlib.is_windows():
+                if mesonlib.is_windows() and not compiler.get_id() == 'watcom':
                     command_template = ''' command = {executable} @$out.rsp
  rspfile = $out.rsp
  rspfile_content = $ARGS  {output_args} $in $LINK_ARGS {cross_args} $aliasing
@@ -1679,7 +1679,7 @@ rule FORTRAN_DEP_HACK
                 d = quote_func(d)
             quoted_depargs.append(d)
         cross_args = self.get_cross_info_lang_args(langname, is_cross)
-        if mesonlib.is_windows() and not compiler.get_id() == "watcom":
+        if mesonlib.is_windows() and not compiler.get_id() == 'watcom':
             command_template = ''' command = {executable} @$out.rsp
  rspfile = $out.rsp
  rspfile_content = {cross_args} $ARGS {dep_args} {output_args} {compile_only_args} $in
@@ -1767,7 +1767,7 @@ rule FORTRAN_DEP_HACK
             for langname, compiler in cclist.items():
                 if compiler.get_id() == 'clang':
                     self.generate_llvm_ir_compile_rule(compiler, True, outfile)
-                self.generate_compile_rule_for(langname, compiler, True, outfile, qf, winpaths)
+                self.generate_compile_rule_for(langname, compiler, True, outfile)
                 self.generate_pch_rule_for(langname, compiler, True, outfile)
         outfile.write('\n')
 
@@ -2481,7 +2481,8 @@ rule FORTRAN_DEP_HACK
         dep_targets = [self.get_dependency_filename(t) for t in dependencies]
         dep_targets.extend([self.get_dependency_filename(t)
                             for t in target.link_depends])
-        elem = NinjaBuildElement(self.all_outputs, outname, linker_rule, obj_list)
+        (qf, winpaths) = self.query_commandline_hacks(linker)
+        elem = NinjaBuildElement(self.all_outputs, outname, linker_rule, obj_list, qf, winpaths)
         elem.add_dep(dep_targets + custom_target_libraries)
         elem.add_item('LINK_ARGS', commands)
         return elem

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -22,7 +22,7 @@ from .. import build
 from .. import mlog
 from .. import dependencies
 from .. import compilers
-from ..compilers import CompilerArgs
+from ..compilers import CompilerArgs, WatcomCCompiler
 from ..linkers import ArLinker
 from ..mesonlib import File, MesonException, OrderedSet
 from ..mesonlib import get_compiler_for_source
@@ -1668,7 +1668,7 @@ rule FORTRAN_DEP_HACK
                 d = quote_func(d)
             quoted_depargs.append(d)
         cross_args = self.get_cross_info_lang_args(langname, is_cross)
-        if mesonlib.is_windows():
+        if mesonlib.is_windows() and not type(compiler) is WatcomCCompiler:
             command_template = ''' command = {executable} @$out.rsp
  rspfile = $out.rsp
  rspfile_content = {cross_args} $ARGS {dep_args} {output_args} {compile_only_args} $in

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -130,6 +130,10 @@ class NinjaBuildElement:
                 newelems.append(quoter(i))
             line += ' '.join(newelems)
             line += '\n'
+
+            # Include/Depfiles paths need to be overridden too.
+            if self.windows_paths:
+                line = line.replace('/', '\\')
             outfile.write(line)
         outfile.write('\n')
 

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -79,6 +79,7 @@ __all__ = [
     'ValaCompiler',
     'VisualStudioCCompiler',
     'VisualStudioCPPCompiler',
+    'WatcomCCompiler',
 ]
 
 # Bring symbols from each module into compilers sub-package namespace
@@ -119,6 +120,7 @@ from .c import (
     GnuCCompiler,
     IntelCCompiler,
     VisualStudioCCompiler,
+    WatcomCCompiler,
 )
 from .cpp import (
     CPPCompiler,

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1037,8 +1037,17 @@ class WatcomCCompiler(CCompiler):
         # /showIncludes is needed for build dependency tracking in Ninja
         # See: https://ninja-build.org/manual.html#_deps
         self.always_args = ['-zq', '-fr']
+
         self.warn_args = {'1': ['-w=2'],
                           '2': ['-w=3'],
                           '3': ['-w=4']}
         self.base_options = ['b_pch'] # FIXME add lto, pgo and the like
         self.is_64 = False
+
+    def unix_args_to_native(self):
+        pass
+
+    def get_output_args(self, target):
+        if target.endswith('.exe'):
+            return ['-fe=' + target]
+        return ['-fo=' + target]

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -27,6 +27,8 @@ from .compilers import (
     msvc_winlibs,
     vs32_instruction_set_args,
     vs64_instruction_set_args,
+    watcom_buildtype_args,
+    watcom_buildtype_linker_args,
     ClangCompiler,
     Compiler,
     CompilerArgs,
@@ -1028,3 +1030,15 @@ class VisualStudioCCompiler(CCompiler):
         return vs32_instruction_set_args.get(instruction_set, None)
 
 
+class WatcomCCompiler(CCompiler):
+    def __init__(self, exelist, version, is_cross, exe_wrap, is_64):
+        CCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
+        self.id = 'watcom'
+        # /showIncludes is needed for build dependency tracking in Ninja
+        # See: https://ninja-build.org/manual.html#_deps
+        self.always_args = ['-zq', '-fr']
+        self.warn_args = {'1': ['-w=2'],
+                          '2': ['-w=3'],
+                          '3': ['-w=4']}
+        self.base_options = ['b_pch'] # FIXME add lto, pgo and the like
+        self.is_64 = False

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1069,6 +1069,9 @@ class WatcomCCompiler(CCompiler):
     def get_buildtype_linker_args(self, buildtype):
         return watcom_buildtype_linker_args[buildtype]
 
+    def get_linker_search_args(self, dirname):
+        return ['libpath ' + dirname]
+
     @classmethod
     def unix_args_to_native(cls, args):
         result = []
@@ -1080,7 +1083,7 @@ class WatcomCCompiler(CCompiler):
             if i.startswith('-I'):
                 i = '-i=' + i[2:]
             if i.startswith('-L'):
-                i = 'library ' + i[2:]
+                i = 'libpath ' + i[2:]
             # Translate GNU-style -lfoo library name to the import library
             elif i.startswith('-l'):
                 name = i[2:]
@@ -1089,7 +1092,7 @@ class WatcomCCompiler(CCompiler):
                     # linked in by default
                     continue
                 else:
-                    i = name + '.lib'
+                    i = 'library ' + name + '.lib'
             # -pthread in link flags is only used on Linux
             elif i == '-pthread':
                 continue

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1048,6 +1048,15 @@ class WatcomCCompiler(CCompiler):
     def get_always_args(self):
         return self.always_args
 
+    def get_linker_exelist(self):
+        return ["wlink"]
+
+    def get_linker_always_args(self):
+        return ['option quiet']
+
+    def get_linker_output_args(self, outputname):
+        return ['name ' + outputname]
+
     def get_dependency_gen_args(self, outtarget, outfile):
         return []
 

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1048,6 +1048,9 @@ class WatcomCCompiler(CCompiler):
     def get_always_args(self):
         return self.always_args
 
+    def get_pic_args(self):
+        return [] # PIC is handled by the loader on Windows
+
     def get_linker_exelist(self):
         return ["wlink"]
 
@@ -1077,7 +1080,7 @@ class WatcomCCompiler(CCompiler):
             if i.startswith('-I'):
                 i = '-i=' + i[2:]
             if i.startswith('-L'):
-                i = '-\"library' + i[2:] + '\"'
+                i = 'library ' + i[2:]
             # Translate GNU-style -lfoo library name to the import library
             elif i.startswith('-l'):
                 name = i[2:]

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -58,7 +58,7 @@ class CCompiler(Compiler):
 
     def get_always_args(self):
         '''
-        Args that are always-on for all C compilers other than MSVC
+        Args that are always-on for all C compilers other than MSVC and Watcom
         '''
         return ['-pipe'] + get_largefile_args(self)
 
@@ -1044,6 +1044,13 @@ class WatcomCCompiler(CCompiler):
         self.base_options = ['b_pch'] # FIXME add lto, pgo and the like
         self.is_64 = False
 
+    # Override CCompiler.get_always_args
+    def get_always_args(self):
+        return self.always_args
+
+    def get_dependency_gen_args(self, outtarget, outfile):
+        return []
+
     def get_buildtype_args(self, buildtype):
         return watcom_buildtype_args[buildtype]
 
@@ -1058,8 +1065,10 @@ class WatcomCCompiler(CCompiler):
             # -pthread is only valid for GCC
             if i in ('-mms-bitfields', '-pthread'):
                 continue
+            if i.startswith('-I'):
+                i = '-i=' + i[2:]
             if i.startswith('-L'):
-                i = '/LIBPATH:' + i[2:]
+                i = '-\"library' + i[2:] + '\"'
             # Translate GNU-style -lfoo library name to the import library
             elif i.startswith('-l'):
                 name = i[2:]

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -119,6 +119,13 @@ msvc_buildtype_args = {'plain': [],
                        'minsize': ["/MD", "/Zi", "/Os", "/Ob1"],
                        }
 
+watcom_buildtype_args = {'plain': [],
+                         'debug': ["-ad", "-od", "-d2"],
+                         'debugoptimized': ["-ad", "-onatx", "-d2"],
+                         'release': ["-ad", "-onatx"],
+                         'minsize': ["-ad", "-onasx"],
+                        }
+
 apple_buildtype_linker_args = {'plain': [],
                                'debug': [],
                                'debugoptimized': [],
@@ -139,6 +146,13 @@ msvc_buildtype_linker_args = {'plain': [],
                               'release': [],
                               'minsize': ['/INCREMENTAL:NO'],
                               }
+
+watcom_buildtype_linker_args = {'plain': [],
+                                'debug': [],
+                                'debugoptimized': [],
+                                'release': [],
+                                'minsize': [],
+                                }
 
 java_buildtype_args = {'plain': [],
                        'debug': ['-g'],

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -537,7 +537,6 @@ class Environment:
                 arg = '--version'
             try:
                 p, out, err = Popen_safe(compiler + [arg])
-                print(out)
             except OSError as e:
                 popen_exceptions[' '.join(compiler + [arg])] = e
                 continue

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -15,7 +15,7 @@
 import configparser, os, platform, re, shlex, shutil, subprocess
 
 from . import coredata
-from .linkers import ArLinker, VisualStudioLinker
+from .linkers import ArLinker, VisualStudioLinker, WatcomLinker
 from . import mesonlib
 from .mesonlib import EnvironmentException, Popen_safe
 from . import mlog
@@ -815,6 +815,8 @@ class Environment:
         for linker in linkers:
             if 'lib' in linker or 'lib.exe' in linker:
                 arg = '/?'
+            elif 'wlib' in linker:
+                arg = '-v'
             else:
                 arg = '--version'
             try:
@@ -828,6 +830,8 @@ class Environment:
                 return ArLinker(linker)
             if p.returncode == 1 and err.startswith('usage'): # OSX
                 return ArLinker(linker)
+            if p.returncode == 8 and 'Open Watcom Library Manager' in out:
+                return WatcomLinker(linker)
         self._handle_exceptions(popen_exceptions, linkers, 'linker')
         raise EnvironmentException('Unknown static linker "%s"' % ' '.join(linkers))
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -320,6 +320,7 @@ class Environment:
         self.vs_static_linker = ['lib']
         self.gcc_static_linker = ['gcc-ar']
         self.clang_static_linker = ['llvm-ar']
+        self.watcom_static_linker = ['wlib']
 
         # Various prefixes and suffixes for import libraries, shared libraries,
         # static libraries, and executables.
@@ -809,6 +810,8 @@ class Environment:
             elif isinstance(compiler, compilers.ClangCompiler):
                 # Use llvm-ar if available; needed for LTO
                 linkers = [self.clang_static_linker, self.default_static_linker]
+            elif isinstance(compiler, compilers.WatcomCCompiler):
+                linkers = [self.watcom_static_linker]
             else:
                 linkers = [self.default_static_linker]
         popen_exceptions = {}

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -531,8 +531,8 @@ class Environment:
                     if found_cl in watcom_cls:
                         continue
                 arg = '/?'
-            elif ['wcc', 'wcc.exe', 'wcc386', 'wcc386.exe'] in compiler:
-                arg = '-h'
+            elif ['wcl', 'wcl.exe', 'wcl386', 'wcl386.exe'] in compiler:
+                arg = '-v'
             else:
                 arg = '--version'
             try:

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -64,6 +64,53 @@ class VisualStudioLinker(StaticLinker):
         return []
 
 
+class WatcomLinker(StaticLinker):
+    always_args = ['-zq', '-fr']
+
+    def __init__(self, exelist):
+        self.exelist = exelist
+
+    def get_exelist(self):
+        return self.exelist[:]
+
+    def get_std_link_args(self):
+        return []
+
+    def get_buildtype_linker_args(self, buildtype):
+        return []
+
+    def get_output_args(self, target):
+        return ['-fe=' + target]
+
+    def get_coverage_link_args(self):
+        return []
+
+    def get_always_args(self):
+        return WatcomLinker.always_args
+
+    def get_linker_always_args(self):
+        return WatcomLinker.always_args
+
+    def build_rpath_args(self, build_dir, from_dir, rpath_paths, build_rpath, install_rpath):
+        return []
+
+    def thread_link_flags(self):
+        return []
+
+    def get_option_link_args(self, options):
+        return []
+
+    @classmethod
+    def unix_args_to_native(cls, args):
+        from .compilers import WatcomCCompiler
+        return WatcomCCompiler.unix_args_to_native(args)
+
+    def get_link_debugfile_args(self, targetfile):
+        # Static libraries do not have PDB files
+        return []
+
+
+
 class ArLinker(StaticLinker):
 
     def __init__(self, exelist):

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -80,7 +80,7 @@ class WatcomLinker(StaticLinker):
         return []
 
     def get_output_args(self, target):
-        return []
+        return [target]
 
     def get_coverage_link_args(self):
         return []

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -65,7 +65,7 @@ class VisualStudioLinker(StaticLinker):
 
 
 class WatcomLinker(StaticLinker):
-    always_args = ['-zq', '-fr']
+    always_args = ['-q']
 
     def __init__(self, exelist):
         self.exelist = exelist
@@ -80,7 +80,7 @@ class WatcomLinker(StaticLinker):
         return []
 
     def get_output_args(self, target):
-        return ['-fe=' + target]
+        return []
 
     def get_coverage_link_args(self):
         return []


### PR DESCRIPTION
Watcom C/C++ is a still-developed (but no recent releases) compiler that can target a few vintage (DOS, Win 3.x, OS/2) and bare-metal (80186, 80286) environments that gcc cannot. One of the requirements for
me moving [libmodem](https://github.com/cr1901/libmodem) from `scons` to another build system was that I need to still be able to target non-MSVC and non-gcc compilers.

Sadly, Watcom has poorly-behaving command-line parsing (it very much shows its age). There were a few hacks I had to make to get compiling to work properly. `wcc386` is the compiler proper, `wcl386` is the compiler driver, `wlink` is the linker.

Any changes in files that are shared between compilers are guarded to only run when the compiler ID equals `watcom`:

* `wcc`/`wcl` still follows the old DOS convention of allowing `/` as input arguments on Windows, and the . End result is `wcc`/`wcl` chokes _badly_ with quoted arguments and Unix paths (on Windows). I added a `query_commandline_hacks` function in `ninjabackend.py`, whose output can be passed to `NinjaBuildElement` constructor to allow overriding how `build` rules are generated. 
 * `wlink` syntax is extremely esoteric, but the compiler driver only handles a subset of all linker arguments. I use the solution [here](https://github.com/ninja-build/ninja/issues/1312#issuecomment-325492404) to get `wlink` to behave.
* Ditto with `wlib`, although less so.
* `meson` appears to favor absolute paths to libraries when possible, instead of using `-l`, or `library my_lib` using native args. Passing a library to `wlink` without notifying it that the input file is a library is an error. I haven't figured out all locations where this occurs in `meson`, but see 6a3e0a8 for an example of one location.

TODO:
- [x] Single source file compiles to exe
- [x] Multiple source file compiles to exe
- [x] Static library creation
- [x] Compile `executable` using `link_with`
- [ ] Ensure library name output uses OS conventions. Right now, uses *nix convention, which works on Windows (`find_library` appears to search for _both_ Windows and *nix conventions)
- [ ] Compile `executable` with `compiler.find_library()`
- [ ] Compile `executable` using `declare_dependency()`
- [ ] Shared library creation/dll support
- [ ] Precompiled header support
- [ ] Test debug/release configurations
- [ ] Switch from `wcl` back to `wcc`. Using `wcl` is _only_ necessary to get the sanity check to pass, and it
doesn't work exceptionally well.
- [ ] Test that all of the above work on Linux
- [ ] Port the [mTCP](http://www.brutman.com/mTCP/) TCP/IP stack build system to `meson`
- [ ] PEP8

Features I do not intend to add:
* Make dependencies- in theory it should work, and I even have a commit for this. But I had trouble making dependency files appear in the correct directories, so I put this aside.
* LTO- Linker doesn't support it.