### PR TITLE
link_whole should be considered a source for targets

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -155,6 +155,12 @@ class Backend:
             dirname = 'meson-out'
         return dirname
 
+    def get_target_dir_relative_to(self, t, o):
+        '''Get a target dir relative to another target's directory'''
+        target_dir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(t))
+        othert_dir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(o))
+        return os.path.relpath(target_dir, othert_dir)
+
     def get_target_source_dir(self, target):
         dirname = os.path.join(self.build_to_src, self.get_target_dir(target))
         return dirname

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -532,6 +532,8 @@ class Vs2010Backend(backends.Backend):
                 if lpath in lpaths:
                     lpaths.remove(lpath)
                 lpaths.append(lpath)
+            elif arg.startswith(('/', '-')):
+                other.append(arg)
             # It's ok if we miss libraries with non-standard extensions here.
             # They will go into the general link arguments.
             elif arg.endswith('.lib') or arg.endswith('.a'):

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -333,6 +333,11 @@ class Vs2010Backend(backends.Backend):
     def quote_arguments(self, arr):
         return ['"%s"' % i for i in arr]
 
+    def add_project_reference(self, root, include, projid):
+        ig = ET.SubElement(root, 'ItemGroup')
+        pref = ET.SubElement(ig, 'ProjectReference', Include=include)
+        ET.SubElement(pref, 'Project').text = '{%s}' % projid
+
     def create_basic_crap(self, target):
         project_name = target.name
         root = ET.Element('Project', {'DefaultTargets': "Build",
@@ -1009,9 +1014,8 @@ class Vs2010Backend(backends.Backend):
 
         ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.targets')
         # Reference the regen target.
-        ig = ET.SubElement(root, 'ItemGroup')
-        pref = ET.SubElement(ig, 'ProjectReference', Include=os.path.join(self.environment.get_build_dir(), 'REGEN.vcxproj'))
-        ET.SubElement(pref, 'Project').text = self.environment.coredata.regen_guid
+        regen_vcxproj = os.path.join(self.environment.get_build_dir(), 'REGEN.vcxproj')
+        self.add_project_reference(root, regen_vcxproj, self.environment.coredata.regen_guid)
         self._prettyprint_vcxproj_xml(ET.ElementTree(root), ofname)
 
     def gen_regenproj(self, project_name, ofname):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -357,7 +357,7 @@ class BuildTarget(Target):
         self.process_compilers()
         self.process_kwargs(kwargs, environment)
         self.check_unknown_kwargs(kwargs)
-        if not self.sources and not self.generated and not self.objects:
+        if not any([self.sources, self.generated, self.objects, self.link_whole]):
             raise InvalidArguments('Build target %s has no sources.' % name)
         self.process_compilers_late()
         self.validate_sources()

--- a/test cases/common/145 whole archive/allofme/meson.build
+++ b/test cases/common/145 whole archive/allofme/meson.build
@@ -1,0 +1,1 @@
+stlib = static_library('allofme', '../libfile.c')

--- a/test cases/common/145 whole archive/exe/meson.build
+++ b/test cases/common/145 whole archive/exe/meson.build
@@ -1,0 +1,2 @@
+exe = executable('prog', '../prog.c',
+  link_with : dylib)

--- a/test cases/common/145 whole archive/exe2/meson.build
+++ b/test cases/common/145 whole archive/exe2/meson.build
@@ -1,0 +1,1 @@
+exe2 = executable('prog2', '../prog.c', link_with : dylib2)

--- a/test cases/common/145 whole archive/meson.build
+++ b/test cases/common/145 whole archive/meson.build
@@ -1,5 +1,7 @@
 project('whole archive', 'c')
 
+add_project_arguments('-I' + meson.source_root(), language : 'c')
+
 cc = meson.get_compiler('c')
 
 if cc.get_id() == 'msvc'
@@ -8,22 +10,15 @@ if cc.get_id() == 'msvc'
   endif
 endif
 
-stlib = static_library('allofme', 'libfile.c')
-
-# Nothing in dylib.c uses func1, so the linker would throw it
-# away and thus linking the exe would fail.
-dylib = shared_library('shlib', 'dylib.c',
-  link_whole : stlib)
-
-exe = executable('prog', 'prog.c',
-  link_with : dylib)
+subdir('allofme')
+subdir('shlib')
+subdir('exe')
 
 test('prog', exe)
 
 # link_whole only
-static = static_library('static', 'dylib.c')
-dylib2 = shared_library('link_whole', link_whole : [stlib, static])
-
-exe2 = executable('prog2', 'prog.c', link_with : dylib2)
+subdir('stlib')
+subdir('wholeshlib')
+subdir('exe2')
 
 test('prog2', exe2)

--- a/test cases/common/145 whole archive/meson.build
+++ b/test cases/common/145 whole archive/meson.build
@@ -20,3 +20,10 @@ exe = executable('prog', 'prog.c',
 
 test('prog', exe)
 
+# link_whole only
+static = static_library('static', 'dylib.c')
+dylib2 = shared_library('link_whole', link_whole : [stlib, static])
+
+exe2 = executable('prog2', 'prog.c', link_with : dylib2)
+
+test('prog2', exe2)

--- a/test cases/common/145 whole archive/shlib/meson.build
+++ b/test cases/common/145 whole archive/shlib/meson.build
@@ -1,0 +1,4 @@
+# Nothing in dylib.c uses func1, so the linker would throw it
+# away and thus linking the exe would fail.
+dylib = shared_library('shlib', '../dylib.c',
+  link_whole : stlib)

--- a/test cases/common/145 whole archive/stlib/meson.build
+++ b/test cases/common/145 whole archive/stlib/meson.build
@@ -1,0 +1,1 @@
+static = static_library('static', '../dylib.c')

--- a/test cases/common/145 whole archive/wholeshlib/meson.build
+++ b/test cases/common/145 whole archive/wholeshlib/meson.build
@@ -1,0 +1,1 @@
+dylib2 = shared_library('link_whole', link_whole : [stlib, static])


### PR DESCRIPTION
Currently sources, generated sources, and objects are considered to be
sources for a target, but link_whole should also fulfill the sources
requirement.

Fixes #2180