### PR TITLE
run_tests.py: skip nice() on Haiku. 

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -215,6 +215,9 @@ def is_osx():
 def is_linux():
     return platform.system().lower() == 'linux'
 
+def is_haiku():
+    return platform.system().lower() == 'haiku'
+
 def is_windows():
     platname = platform.system().lower()
     return platname == 'windows' or 'mingw' in platname

--- a/run_tests.py
+++ b/run_tests.py
@@ -171,7 +171,7 @@ if __name__ == '__main__':
                 backend = Backend.xcode
             break
     # Running on a developer machine? Be nice!
-    if not mesonlib.is_windows() and 'TRAVIS' not in os.environ:
+    if not mesonlib.is_windows() and not mesonlib.is_haiku() and 'TRAVIS' not in os.environ:
         os.nice(20)
     # Appveyor sets the `platform` environment variable which completely messes
     # up building with the vs2010 and vs2015 backends.


### PR DESCRIPTION
A simple patch which allows to run tests on Haiku. Please review.