### PR TITLE
Qt5: Fix rcc file paths

### DIFF
--- a/mesonbuild/modules/qt5.py
+++ b/mesonbuild/modules/qt5.py
@@ -87,15 +87,16 @@ class Qt5Module(ExtensionModule):
         self.tools_detected = True
 
     def parse_qrc(self, state, fname):
-        abspath = os.path.join(state.environment.source_dir, state.subdir, fname)
-        relative_part = os.path.split(fname)[0]
+        abspath = os.path.join(state.environment.source_dir, state.subdir, fname.relative_name())
+        relative_part = os.path.split(fname.relative_name())[0]
         try:
             tree = ET.parse(abspath)
             root = tree.getroot()
             result = []
             for child in root[0]:
                 if child.tag != 'file':
-                    mlog.warning("malformed rcc file: ", os.path.join(state.subdir, fname))
+                    mlog.warning("malformed rcc file: ",
+                                 os.path.join(state.subdir, fname.relative_name()))
                     break
                 else:
                     result.append(os.path.join(state.subdir, relative_part, child.text))
@@ -136,7 +137,7 @@ class Qt5Module(ExtensionModule):
             if len(args) > 0:
                 name = args[0]
             else:
-                basename = os.path.split(rcc_files[0])[1]
+                basename = os.path.split(rcc_files[0].relative_name())[1]
                 name = 'qt5-' + basename.replace('.', '_')
             rcc_kwargs = {'input': rcc_files,
                           'output': name + '.cpp',


### PR DESCRIPTION
`os.path` functions do not accept `mesonlib.File` objects, only str or bytes.

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/mesonbuild/mesonmain.py", line 338, in run
    app.generate()
  File "/usr/lib/python3.6/site-packages/mesonbuild/mesonmain.py", line 181, in generate
    intr.run()
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreter.py", line 2728, in run
    super().run()
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 148, in run
    self.evaluate_codeblock(self.ast, start=1)
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 170, in evaluate_codeblock
    raise e
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 164, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 177, in evaluate_statement
    return self.assignment(cur)
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 572, in assignment
    value = self.evaluate_statement(node.value)
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 179, in evaluate_statement
    return self.method_call(cur)
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 413, in method_call
    return obj.method_call(method_name, self.flatten(args), kwargs)
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreter.py", line 1066, in method_call
    value = fn(state, args, kwargs)
  File "/usr/lib/python3.6/site-packages/mesonbuild/interpreterbase.py", line 77, in wrapped
    return f(s, node_or_state, args, kwargs)
  File "/usr/lib/python3.6/site-packages/mesonbuild/modules/qt5.py", line 135, in preprocess
    qrc_deps += self.parse_qrc(state, i)
  File "/usr/lib/python3.6/site-packages/mesonbuild/modules/qt5.py", line 90, in parse_qrc
    abspath = os.path.join(state.environment.source_dir, state.subdir, fname)
  File "/usr/lib/python3.6/posixpath.py", line 92, in join
    genericpath._check_arg_types('join', a, *p)
  File "/usr/lib/python3.6/genericpath.py", line 149, in _check_arg_types
    (funcname, s.__class__.__name__)) from None
TypeError: join() argument must be str or bytes, not 'File'
```