### PR TITLE
Replace testing options with a "test command" option.

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -856,8 +856,17 @@ int dummy;
         cmd = self.environment.get_build_command(True) + ['test', '--no-rebuild']
         if not self.environment.coredata.get_builtin_option('stdsplit'):
             cmd += ['--no-stdsplit']
-        if self.environment.coredata.get_builtin_option('errorlogs'):
+        out = self.environment.coredata.get_builtin_option('output')
+        if out == 'on-error':
             cmd += ['--print-errorlogs']
+        elif out == 'always':
+            cmd += ['--verbose']
+        suite = self.environment.coredata.get_builtin_option('suite')
+        if suite:
+            cmd += ['--suite=%s' % suite]
+        setup = self.environment.coredata.get_builtin_option('setup')
+        if setup:
+            cmd += ['--setup=%s' % setup]
         elem = NinjaBuildElement(self.all_outputs, 'meson-test', 'CUSTOM_COMMAND', ['all', 'PHONY'])
         elem.add_item('COMMAND', cmd)
         elem.add_item('DESC', 'Running all tests.')

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1176,8 +1176,17 @@ if %%errorlevel%% neq 0 goto :VCEnd'''
         test_command = self.environment.get_build_command() + ['test', '--no-rebuild']
         if not self.environment.coredata.get_builtin_option('stdsplit'):
             test_command += ['--no-stdsplit']
-        if self.environment.coredata.get_builtin_option('errorlogs'):
+        out = self.environment.coredata.get_builtin_option('output')
+        if out == 'on-error':
             test_command += ['--print-errorlogs']
+        elif out == 'always':
+            test_command += ['--verbose']
+        suite = self.environment.coredata.get_builtin_option('suite')
+        if suite:
+            test_command += ['--suite=%s' % suite]
+        setup = self.environment.coredata.get_builtin_option('setup')
+        if setup:
+            test_command += ['--setup=%s' % setup]
         cmd_templ = '''setlocal
 "%s"
 if %%errorlevel%% neq 0 goto :cmEnd

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -409,9 +409,13 @@ builtin_options = {
     'warning_level':   [UserComboOption, 'Compiler warning level to use.', ['1', '2', '3'], '1'],
     'layout':          [UserComboOption, 'Build directory layout.', ['mirror', 'flat'], 'mirror'],
     'default_library': [UserComboOption, 'Default library type.', ['shared', 'static'], 'shared'],
+
     'backend':         [UserComboOption, 'Backend to use.', backendlist, 'ninja'],
+
+    'suite':           [UserStringOption, 'Run only a specific suite of tests.', ''],
+    'setup':           [UserStringOption, 'Run tests using a specific test setup.', ''],
     'stdsplit':        [UserBooleanOption, 'Split stdout and stderr in test logs.', True],
-    'errorlogs':       [UserBooleanOption, "Whether to print the logs from failing tests.", True],
+    'output':          [UserComboOption, 'When to output test logs.', ['always', 'on-error', 'never'], 'on-error'],
 }
 
 # Special prefix-dependent defaults for installation directories that reside in

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -166,6 +166,7 @@ class Conf:
                          'choices': coredata.get_builtin_option_choices(key)})
         self.print_aligned(carr)
         print('')
+        print('Backend options:')
         bekeys = sorted(self.coredata.backend_options.keys())
         if not bekeys:
             print('  No backend options\n')

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -253,12 +253,16 @@ class Conf:
         print('')
         print('Testing options:')
         tarr = []
-        for key in ['stdsplit', 'errorlogs']:
-            tarr.append({'name': key,
-                         'descr': coredata.get_builtin_option_description(key),
-                         'value': self.coredata.get_builtin_option(key),
-                         'choices': coredata.get_builtin_option_choices(key)})
-        self.print_aligned(tarr)
+        for keyset in [['suite', 'setup'], ['stdsplit', 'output']]:
+            if len(tarr):
+                print('')
+                tarr = []
+            for key in keyset:
+                tarr.append({'name': key,
+                             'descr': coredata.get_builtin_option_description(key),
+                             'value': self.coredata.get_builtin_option(key),
+                             'choices': coredata.get_builtin_option_choices(key)})
+            self.print_aligned(tarr)
 
 def run(args):
     args = mesonlib.expand_arguments(args)

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -64,8 +64,6 @@ def create_parser():
     add_builtin_argument(p, 'layout')
     add_builtin_argument(p, 'default-library')
     add_builtin_argument(p, 'warnlevel', dest='warning_level')
-    add_builtin_argument(p, 'stdsplit', action='store_false')
-    add_builtin_argument(p, 'errorlogs', action='store_false')
     p.add_argument('--cross-file', default=None,
                    help='File describing cross compilation environment.')
     p.add_argument('-D', action='append', dest='projectoptions', default=[], metavar="option",


### PR DESCRIPTION
Remove testing options `stdsplit` and `errorlogs` and allow one to freely define the test command to be used from the `test` target.

Also removes the corresponding options from the main meson command so this could perhaps be considered as an API breaking change?

By allowing developer's to choose the test command they can even replace the mesontest altogether if they would so choose.

Current revision uses `%m` in the test command to expand to the meson itself. E.g.

```
$ ../meson/meson.py configure b
[snip]
  Option       Current Value                                        Description
  ------       -------------                                        -----------
  test_command %m test --no-rebuild --no-stdsplit --print-errorlogs The command to invoke to run tests.
[snip]
```

Fixes #1885.

EDIT: PR no longer replaces the testing options with a "test command" but only updates them.