### PR TITLE
cmake2meson improvements

### DIFF
--- a/tools/cmake2meson.py
+++ b/tools/cmake2meson.py
@@ -26,7 +26,7 @@ class Token:
 
 class Statement:
     def __init__(self, name, args):
-        self.name = name
+        self.name = name.lower()
         self.args = args
 
 class Lexer:

--- a/tools/cmake2meson.py
+++ b/tools/cmake2meson.py
@@ -120,7 +120,10 @@ class Parser:
             args.append(self.arguments())
             self.expect('rparen')
         arg = self.current
-        if self.accept('string') \
+        if self.accept('comment'):
+            rest = self.arguments()
+            args += rest
+        elif self.accept('string') \
                 or self.accept('varexp') \
                 or self.accept('id'):
             args.append(arg)

--- a/tools/cmake2meson.py
+++ b/tools/cmake2meson.py
@@ -158,7 +158,7 @@ class Converter:
             if i.tid == 'id':
                 res.append("'%s'" % i.value)
             elif i.tid == 'varexp':
-                res.append('%s' % i.value)
+                res.append('%s' % i.value.lower())
             elif i.tid == 'string':
                 res.append("'%s'" % i.value)
             else:


### PR DESCRIPTION
These commits fix various issues with cmake2meson, I encountered.

1.: statements in cmake are case-insensitive. 
So, convert statement names to lower-case, so that the comparisons match

2.: comments in multi-line arguments cause a runtime error
```
set(FOO
    arg1
    # arg2
    arg3
)
```

3.: variable names are converted to lower-case in set statments, but their usage is not
```
set(FOO_SOURCES foo.c bar.c)
add_executable(foo, ${FOO_SOURCES})
```

Before this commit, this would result in 
```
foo_sources = ['foo.c', 'bar.c']
foo_lib = static_library('foo', FOO_SOURCES)
```
