### PR TITLE
Consider compilers used in static_library parents

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2017,7 +2017,7 @@ class Interpreter(InterpreterBase):
         if progobj is None:
             progobj = self.program_from_system(args)
         if required and (progobj is None or not progobj.found()):
-            raise InvalidArguments('Program "%s" not found or not executable' % exename)
+            raise InvalidArguments('Program "%s" not found or not executable' % args[0])
         if progobj is None:
             return ExternalProgramHolder(dependencies.ExternalProgram('nonexistingprogram'))
         return progobj

--- a/test cases/common/146 C and CPP link/meson.build
+++ b/test cases/common/146 C and CPP link/meson.build
@@ -65,10 +65,44 @@ libfoo = shared_library(
 #
 # VS2010 lacks the /WHOLEARCHIVE option that later versions of MSVC support, so
 # don't run this tests on that backend.
-if meson.backend() != 'vs2010'
+if not (cxx.get_id() == 'msvc' and cxx.version().version_compare('<19'))
   libfoowhole = shared_library(
     'foowhole',
     ['foobar.c', 'foobar.h'],
     link_whole : [libc, libcpp],
   )
 endif
+
+# Test sublinking (linking C and C++, then linking that to C)
+libfoo_static = static_library(
+  'foo_static',
+  ['foobar.c', 'foobar.h'],
+  link_with : [libc, libcpp],
+)
+
+libsub = shared_library(
+  'sub',
+  ['sub.c', 'sub.h'],
+  link_with : libfoo_static,
+)
+
+if not (cxx.get_id() == 'msvc' and cxx.version().version_compare('<19'))
+  libsubwhole = shared_library(
+    'subwhole',
+    ['sub.c', 'sub.h'],
+    link_whole : libfoo_static,
+  )
+endif
+
+# Test that it really is recursive
+libsub_static = static_library(
+  'sub_static',
+  ['sub.c', 'sub.h'],
+  link_with : libfoo_static,
+)
+
+libsubsub = shared_library(
+  'subsub',
+  ['dummy.c'],
+  link_with : libsub_static,
+)

--- a/test cases/common/146 C and CPP link/sub.c
+++ b/test cases/common/146 C and CPP link/sub.c
@@ -1,0 +1,19 @@
+/* Copyright © 2017 Dylan Baker
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sub.h"
+
+float a_half(void) {
+    return .5;
+}

--- a/test cases/common/146 C and CPP link/sub.h
+++ b/test cases/common/146 C and CPP link/sub.h
@@ -1,0 +1,16 @@
+/* Copyright © 2017 Dylan Baker
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+float a_half(void);


### PR DESCRIPTION
Currently meson only considers what compiler/linker were used by a
Target's immediate sources or objects, not the sources of libraries it's
linked with by the link_with and link_whole keywords. This means that if
given 3 libraries: libA which is C++, libB which is C, and libC which is
also C, and libC links with libB which links with libA then linking libC
will be attempted with the C linker, and will fail.

This patch corrects that by adding the compilers used by sub libraries
to the collection of compilers considered by meson when picking a
linker.

This implementation is recursive, since each Target adds it's parent's
dependencies.