### PR TITLE
tests/common/159: Don't try to run 'echo'

### DIFF
--- a/test cases/common/159 reserved targets/meson.build
+++ b/test cases/common/159 reserved targets/meson.build
@@ -26,6 +26,9 @@ subdir('uninstall')
 
 subdir('runtarget')
 
+py3 = import('python3').find_python()
+
 custom_target('ctlist-test', output : 'out.txt',
-              command : ['echo'], capture : true,
+              command : [py3, '-c', 'print("")'],
+              capture : true,
               build_by_default : true)


### PR DESCRIPTION
It's not available on Windows. It was passing in the CI because bash tools are available on AppVeyor by default.