### PR TITLE
backends: avoid extraneous trailing os.path.sep when joining paths

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -156,8 +156,11 @@ class Backend:
         return dirname
 
     def get_target_source_dir(self, target):
-        dirname = os.path.join(self.build_to_src, self.get_target_dir(target))
-        return dirname
+        # if target dir is empty, avoid extraneous trailing / from os.path.join()
+        target_dir = self.get_target_dir(target)
+        if target_dir:
+            return os.path.join(self.build_to_src, target_dir)
+        return self.build_to_src
 
     def get_target_private_dir(self, target):
         dirname = os.path.join(self.get_target_dir(target), target.get_basename() + target.type_suffix())


### PR DESCRIPTION
this handles the case in which `self.get_target_dir(target)` returns an empty string and os.path.join() appends an additional trailing slash

resolves #2336

not sure if this is an acceptable approach, but thought I would submit for comments.