### PR TITLE
Linker flag for Windows GUI applications was missing on MSVC.

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -896,6 +896,9 @@ class VisualStudioCCompiler(CCompiler):
     def get_linker_search_args(self, dirname):
         return ['/LIBPATH:' + dirname]
 
+    def get_gui_app_args(self):
+        return ['/SUBSYSTEM:WINDOWS']
+
     def get_pic_args(self):
         return [] # PIC is handled by the loader on Windows
 


### PR DESCRIPTION
Helps with #2327.