### PR TITLE
Bring into compliance with flake8

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os, pickle, re, shlex, shutil, subprocess, sys
+import os, pickle, re, shlex, subprocess, sys
 from collections import OrderedDict
 
 from . import backends

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -83,10 +83,9 @@ class NinjaBuildElement:
 
     def write(self, outfile):
         self.check_outputs()
-        line = 'build %s: %s %s' % (
-            ' '.join([ninja_quote(i) for i in self.outfilenames]),
-            self.rule,
-            ' '.join([ninja_quote(i) for i in self.infilenames]))
+        line = 'build %s: %s %s' % (' '.join([ninja_quote(i) for i in self.outfilenames]),
+                                    self.rule,
+                                    ' '.join([ninja_quote(i) for i in self.infilenames]))
         if len(self.deps) > 0:
             line += ' | ' + ' '.join([ninja_quote(x) for x in self.deps])
         if len(self.orderdeps) > 0:
@@ -721,8 +720,7 @@ int dummy;
                     # On toolchains/platforms that use an import library for
                     # linking (separate from the shared library with all the
                     # code), we need to install that too (dll.a/.lib).
-                    if (isinstance(t, build.SharedLibrary) or
-                        isinstance(t, build.Executable)) and t.get_import_filename():
+                    if (isinstance(t, build.SharedLibrary) or isinstance(t, build.Executable)) and t.get_import_filename():
                         if custom_install_dir:
                             # If the DLL is installed into a custom directory,
                             # install the import library into the same place so
@@ -856,8 +854,9 @@ int dummy;
         self.create_target_alias('meson-test', outfile)
 
         # And then benchmarks.
-        cmd = self.environment.get_build_command(True) + ['test', '--benchmark', '--logbase',
-               'benchmarklog', '--num-processes=1', '--no-rebuild']
+        cmd = self.environment.get_build_command(True) + [
+            'test', '--benchmark', '--logbase',
+            'benchmarklog', '--num-processes=1', '--no-rebuild']
         elem = NinjaBuildElement(self.all_outputs, 'meson-benchmark', 'CUSTOM_COMMAND', ['all', 'PHONY'])
         elem.add_item('COMMAND', cmd)
         elem.add_item('DESC', 'Running benchmark suite.')
@@ -1576,9 +1575,10 @@ int dummy;
     def generate_swift_compile_rules(self, compiler, outfile):
         rule = 'rule %s_COMPILER\n' % compiler.get_language()
         full_exe = [ninja_quote(x) for x in self.environment.get_build_command()] + [
-                    '--internal',
-                    'dirchanger',
-                    '$RUNDIR']
+            '--internal',
+            'dirchanger',
+            '$RUNDIR',
+        ]
         invoc = (' '.join(full_exe) + ' ' +
                  ' '.join(ninja_quote(i) for i in compiler.get_exelist()))
         command = ' command = %s $ARGS $in\n' % invoc
@@ -2527,10 +2527,11 @@ rule FORTRAN_DEP_HACK
     def generate_dist(self, outfile):
         elem = NinjaBuildElement(self.all_outputs, 'meson-dist', 'CUSTOM_COMMAND', 'PHONY')
         elem.add_item('DESC', 'Creating source packages')
-        elem.add_item('COMMAND', self.environment.get_build_command() +
-            ['--internal', 'dist',
-             self.environment.source_dir,
-             self.environment.build_dir] + self.environment.get_build_command())
+        elem.add_item('COMMAND', self.environment.get_build_command() + [
+            '--internal', 'dist',
+            self.environment.source_dir,
+            self.environment.build_dir,
+        ] + self.environment.get_build_command())
         elem.add_item('pool', 'console')
         elem.write(outfile)
         # Alias that runs the target defined above

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -383,8 +383,7 @@ class Vs2010Backend(backends.Backend):
         cmd = [sys.executable, os.path.join(self.environment.get_script_dir(), 'commandrunner.py'),
                self.environment.get_build_dir(),
                self.environment.get_source_dir(),
-               self.get_target_dir(target)] + \
-               self.environment.get_build_command()
+               self.get_target_dir(target)] + self.environment.get_build_command()
         for i in cmd_raw:
             if isinstance(i, build.BuildTarget):
                 cmd.append(os.path.join(self.environment.get_build_dir(), self.get_target_filename(i)))
@@ -926,8 +925,7 @@ class Vs2010Backend(backends.Backend):
         ofile.text = '$(OutDir)%s' % target.get_filename()
         subsys = ET.SubElement(link, 'SubSystem')
         subsys.text = subsystem
-        if (isinstance(target, build.SharedLibrary) or
-            isinstance(target, build.Executable)) and target.get_import_filename():
+        if (isinstance(target, build.SharedLibrary) or isinstance(target, build.Executable)) and target.get_import_filename():
             # DLLs built with MSVC always have an import library except when
             # they're data-only DLLs, but we don't support those yet.
             ET.SubElement(link, 'ImportLibrary').text = target.get_import_filename()

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -22,7 +22,6 @@ from .. import build
 from .. import dependencies
 from .. import mlog
 from .. import compilers
-from ..build import BuildTarget
 from ..compilers import CompilerArgs
 from ..mesonlib import MesonException, File
 from ..environment import Environment

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1025,5 +1025,3 @@ class VisualStudioCCompiler(CCompiler):
             # and the can not be called.
             return None
         return vs32_instruction_set_args.get(instruction_set, None)
-
-

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -252,7 +252,7 @@ vs32_instruction_set_args = {'mmx': ['/arch:SSE'], # There does not seem to be a
                              'avx': ['/arch:AVX'],
                              'avx2': ['/arch:AVX2'],
                              'neon': None,
-}
+                             }
 
 # The 64 bit compiler defaults to /arch:avx.
 vs64_instruction_set_args = {'mmx': ['/arch:AVX'],

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1028,7 +1028,6 @@ class CompilerHolder(InterpreterObject):
             h)
         return result
 
-
     def first_supported_argument_method(self, args, kwargs):
         for i in mesonlib.stringlistify(args):
             if self.compiler.has_argument(i, self.environment):
@@ -1245,48 +1244,50 @@ class MesonMain(InterpreterObject):
 
 pch_kwargs = set(['c_pch', 'cpp_pch'])
 
-lang_arg_kwargs = set(['c_args',
-                       'cpp_args',
-                       'd_args',
-                       'd_import_dirs',
-                       'd_unittest',
-                       'd_module_versions',
-                       'fortran_args',
-                       'java_args',
-                       'objc_args',
-                       'objcpp_args',
-                       'rust_args',
-                       'vala_args',
-                       'cs_args',
-                   ])
+lang_arg_kwargs = set([
+    'c_args',
+    'cpp_args',
+    'd_args',
+    'd_import_dirs',
+    'd_unittest',
+    'd_module_versions',
+    'fortran_args',
+    'java_args',
+    'objc_args',
+    'objcpp_args',
+    'rust_args',
+    'vala_args',
+    'cs_args',
+])
 
 vala_kwargs = set(['vala_header', 'vala_gir', 'vala_vapi'])
 rust_kwargs = set(['rust_crate_type'])
 cs_kwargs = set(['resources', 'cs_args'])
 
-buildtarget_kwargs = set(['build_by_default',
-                          'build_rpath',
-                          'dependencies',
-                          'extra_files',
-                          'gui_app',
-                          'link_with',
-                          'link_whole',
-                          'link_args',
-                          'link_depends',
-                          'implicit_include_directories',
-                          'include_directories',
-                          'install',
-                          'install_rpath',
-                          'install_dir',
-                          'name_prefix',
-                          'name_suffix',
-                          'native',
-                          'objects',
-                          'override_options',
-                          'pic',
-                          'sources',
-                          'vs_module_defs',
-                      ])
+buildtarget_kwargs = set([
+    'build_by_default',
+    'build_rpath',
+    'dependencies',
+    'extra_files',
+    'gui_app',
+    'link_with',
+    'link_whole',
+    'link_args',
+    'link_depends',
+    'implicit_include_directories',
+    'include_directories',
+    'install',
+    'install_rpath',
+    'install_dir',
+    'name_prefix',
+    'name_suffix',
+    'native',
+    'objects',
+    'override_options',
+    'pic',
+    'sources',
+    'vs_module_defs',
+])
 
 build_target_common_kwargs = (
     buildtarget_kwargs |
@@ -2013,7 +2014,7 @@ class Interpreter(InterpreterBase):
             if not isinstance(use_native, bool):
                 raise InvalidArguments('Argument to "native" must be a boolean.')
             if not use_native:
-                 progobj = self.program_from_cross_file(args)
+                progobj = self.program_from_cross_file(args)
         if progobj is None:
             progobj = self.program_from_system(args)
         if required and (progobj is None or not progobj.found()):

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -122,11 +122,11 @@ class MesonApp:
         if os.path.exists(priv_dir):
             if not handshake:
                 print('Directory already configured, exiting Meson. Just run your build command\n'
-                '(e.g. ninja) and Meson will regenerate as necessary. If ninja fails, run ninja\n'
-                'reconfigure to force Meson to regenerate.\n'
-                '\nIf build failures persist, manually wipe your build directory to clear any\n'
-                'stored system data.\n'
-                '\nTo change option values, run meson configure instead.')
+                      '(e.g. ninja) and Meson will regenerate as necessary. If ninja fails, run ninja\n'
+                      'reconfigure to force Meson to regenerate.\n'
+                      '\nIf build failures persist, manually wipe your build directory to clear any\n'
+                      'stored system data.\n'
+                      '\nTo change option values, run meson configure instead.')
                 sys.exit(0)
         else:
             if handshake:

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -4,7 +4,6 @@ from .. import build
 from .. import dependencies
 from .. import mlog
 from ..mesonlib import MesonException
-from ..interpreterbase import permittedKwargs, noKwargs
 
 class permittedSnippetKwargs:
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -697,18 +697,22 @@ This will become a hard error in the future.''')
             args.append('--langs=' + '@@'.join(langs))
         inscript = build.RunScript(script, args)
 
-        potargs = state.environment.get_build_command() + ['--internal', 'yelphelper', 'pot',
-                   '--subdir=' + state.subdir,
-                   '--id=' + project_id,
-                   '--sources=' + source_str]
+        potargs = state.environment.get_build_command() + [
+            '--internal', 'yelphelper', 'pot',
+            '--subdir=' + state.subdir,
+            '--id=' + project_id,
+            '--sources=' + source_str,
+        ]
         pottarget = build.RunTarget('help-' + project_id + '-pot', potargs[0],
                                     potargs[1:], [], state.subdir)
 
-        poargs = state.environment.get_build_command() + ['--internal', 'yelphelper', 'update-po',
-                  '--subdir=' + state.subdir,
-                  '--id=' + project_id,
-                  '--sources=' + source_str,
-                  '--langs=' + '@@'.join(langs)]
+        poargs = state.environment.get_build_command() + [
+            '--internal', 'yelphelper', 'update-po',
+            '--subdir=' + state.subdir,
+            '--id=' + project_id,
+            '--sources=' + source_str,
+            '--langs=' + '@@'.join(langs),
+        ]
         potarget = build.RunTarget('help-' + project_id + '-update-po', poargs[0],
                                    poargs[1:], [], state.subdir)
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -17,7 +17,6 @@ functionality such as gobject-introspection, gresources and gtk-doc'''
 
 from .. import build
 import os
-import sys
 import copy
 import subprocess
 from . import ModuleReturnValue
@@ -30,7 +29,7 @@ from .. import interpreter
 from . import GResourceTarget, GResourceHeaderTarget, GirTarget, TypelibTarget, VapiTarget
 from . import find_program, get_include_args
 from . import ExtensionModule
-from . import noKwargs, permittedKwargs
+from ..interpreterbase import noKwargs, permittedKwargs
 
 # gresource compilation is broken due to the way
 # the resource compiler and Ninja clash about it

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import shutil
 
 from os import path
@@ -20,7 +19,7 @@ from .. import coredata, mesonlib, build
 from ..mesonlib import MesonException
 from . import ModuleReturnValue
 from . import ExtensionModule
-from . import permittedKwargs
+from ..interpreterbase import permittedKwargs
 
 PRESET_ARGS = {
     'glib': [

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -72,8 +72,10 @@ class I18nModule(ExtensionModule):
         datadirs = self._get_data_dirs(state, mesonlib.stringlistify(kwargs.pop('data_dirs', [])))
         datadirs = '--datadirs=' + ':'.join(datadirs) if datadirs else None
 
-        command = state.environment.get_build_command() + ['--internal', 'msgfmthelper',
-                   '@INPUT@', '@OUTPUT@', file_type, podir]
+        command = state.environment.get_build_command() + [
+            '--internal', 'msgfmthelper',
+            '@INPUT@', '@OUTPUT@', file_type, podir
+        ]
         if datadirs:
             command.append(datadirs)
 

--- a/mesonbuild/modules/modtest.py
+++ b/mesonbuild/modules/modtest.py
@@ -14,7 +14,7 @@
 
 from . import ModuleReturnValue
 from . import ExtensionModule
-from . import noKwargs
+from ..interpreterbase import noKwargs
 
 class TestModule(ExtensionModule):
 

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -19,7 +19,7 @@ from .. import mesonlib
 from .. import mlog
 from . import ModuleReturnValue
 from . import ExtensionModule
-from . import permittedKwargs
+from ..interpreterbase import permittedKwargs
 
 
 class PkgConfigModule(ExtensionModule):

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -18,7 +18,8 @@ from .. import mesonlib, dependencies
 
 from . import ExtensionModule
 from mesonbuild.modules import ModuleReturnValue
-from . import noKwargs, permittedSnippetKwargs
+from . import permittedSnippetKwargs
+from ..interpreterbase import noKwargs
 from ..interpreter import shlib_kwargs
 
 mod_kwargs = set()

--- a/mesonbuild/modules/qt4.py
+++ b/mesonbuild/modules/qt4.py
@@ -20,7 +20,7 @@ from ..dependencies import Qt4Dependency
 from . import ExtensionModule
 import xml.etree.ElementTree as ET
 from . import ModuleReturnValue
-from . import permittedKwargs
+from ..interpreterbase import permittedKwargs
 
 class Qt4Module(ExtensionModule):
     tools_detected = False

--- a/mesonbuild/modules/qt5.py
+++ b/mesonbuild/modules/qt5.py
@@ -20,7 +20,7 @@ from ..dependencies import Qt5Dependency
 from . import ExtensionModule
 import xml.etree.ElementTree as ET
 from . import ModuleReturnValue
-from . import permittedKwargs
+from ..interpreterbase import permittedKwargs
 
 class Qt5Module(ExtensionModule):
     tools_detected = False

--- a/mesonbuild/modules/rpm.py
+++ b/mesonbuild/modules/rpm.py
@@ -22,7 +22,7 @@ from .. import mlog
 from . import GirTarget, TypelibTarget
 from . import ModuleReturnValue
 from . import ExtensionModule
-from . import noKwargs
+from ..interpreterbase import noKwargs
 
 import os
 

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -20,7 +20,7 @@ from ..mesonlib import MesonException, extract_as_list
 from . import get_include_args
 from . import ModuleReturnValue
 from . import ExtensionModule
-from . import permittedKwargs
+from ..interpreterbase import permittedKwargs
 
 class WindowsModule(ExtensionModule):
 

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -299,7 +299,7 @@ class Resolver:
     def extract_package(self, package):
         if sys.version_info < (3, 5):
             try:
-                import lzma
+                import lzma # noqa: F401
                 del lzma
             except ImportError:
                 pass

--- a/mesonrewriter.py
+++ b/mesonrewriter.py
@@ -30,4 +30,3 @@ if __name__ == '__main__':
     print('Warning: This executable is deprecated. Use "meson rewrite" instead.',
           file=sys.stderr)
     sys.exit(mesonmain.run(['rewrite'] + sys.argv[1:]))
-

--- a/mesonrewriter.py
+++ b/mesonrewriter.py
@@ -23,7 +23,7 @@
 # - move targets
 # - reindent?
 
-from mesonbuild import mesonmain, mlog
+from mesonbuild import mesonmain
 import sys
 
 if __name__ == '__main__':

--- a/msi/createmsi.py
+++ b/msi/createmsi.py
@@ -56,7 +56,7 @@ class PackageGenerator:
                 'Title': 'Meson',
                 'Description': 'Meson executables',
                 'Level': '1',
-                'Absent': 'disallow', 
+                'Absent': 'disallow',
             },
             self.staging_dirs[1]: {
                 'Id': 'NinjaProgram',
@@ -109,7 +109,7 @@ class PackageGenerator:
             'Language': '1033',
             'Codepage':  '1252',
             'Version': self.version,
-            })
+        })
 
         package = ET.SubElement(product, 'Package',  {
             'Id': '*',
@@ -121,7 +121,7 @@ class PackageGenerator:
             'Languages': '1033',
             'Compressed': 'yes',
             'SummaryCodepage': '1252',
-            })
+        })
 
         if self.bytesize == 64:
             package.set('Platform', 'x64')
@@ -129,25 +129,26 @@ class PackageGenerator:
             'Id': '1',
             'Cabinet': 'meson.cab',
             'EmbedCab': 'yes',
-            })
+        })
         targetdir = ET.SubElement(product, 'Directory', {
             'Id': 'TARGETDIR',
             'Name': 'SourceDir',
-            })
+        })
         progfiledir = ET.SubElement(targetdir, 'Directory', {
-            'Id' : self.progfile_dir,
-            })
+            'Id': self.progfile_dir,
+        })
         installdir = ET.SubElement(progfiledir, 'Directory', {
             'Id': 'INSTALLDIR',
-            'Name': 'Meson'})
+            'Name': 'Meson',
+        })
 
         ET.SubElement(product, 'Property', {
             'Id': 'WIXUI_INSTALLDIR',
             'Value': 'INSTALLDIR',
-            })
+        })
         ET.SubElement(product, 'UIRef', {
             'Id': 'WixUI_FeatureTree',
-            })
+        })
         for sd in self.staging_dirs:
             assert(os.path.isdir(sd))
         top_feature = ET.SubElement(product, 'Feature', {
@@ -157,7 +158,7 @@ class PackageGenerator:
             'Display': 'expand',
             'Level': '1',
             'ConfigurableDirectory': 'INSTALLDIR',
-            })
+        })
         for sd in self.staging_dirs:
             nodes = {}
             for root, dirs, files in os.walk(sd):
@@ -165,7 +166,7 @@ class PackageGenerator:
                 nodes[root] = cur_node
             self.create_xml(nodes, sd, installdir, sd)
             self.build_features(nodes, top_feature, sd)
-        ET.ElementTree(self.root).write(self.main_xml, encoding='utf-8',xml_declaration=True)
+        ET.ElementTree(self.root).write(self.main_xml, encoding='utf-8', xml_declaration=True)
         # ElementTree can not do prettyprinting so do it manually
         import xml.dom.minidom
         doc = xml.dom.minidom.parse(self.main_xml)
@@ -177,8 +178,7 @@ class PackageGenerator:
         for component_id in self.feature_components[staging_dir]:
             ET.SubElement(feature, 'ComponentRef', {
                 'Id': component_id,
-                })
-        
+            })
 
     def create_xml(self, nodes, current_dir, parent_xml_node, staging_dir):
         cur_node = nodes[current_dir]
@@ -187,7 +187,7 @@ class PackageGenerator:
             comp_xml_node = ET.SubElement(parent_xml_node, 'Component', {
                 'Id': component_id,
                 'Guid': gen_guid(),
-                })
+            })
             self.feature_components[staging_dir].append(component_id)
             if self.bytesize == 64:
                 comp_xml_node.set('Win64', 'yes')
@@ -208,14 +208,14 @@ class PackageGenerator:
                     'Id': file_id,
                     'Name': f,
                     'Source': os.path.join(current_dir, f),
-                    })
+                })
 
         for dirname in cur_node.dirs:
             dir_id = os.path.join(current_dir, dirname).replace('\\', '_').replace('/', '_')
             dir_node = ET.SubElement(parent_xml_node, 'Directory', {
                 'Id': dir_id,
                 'Name': dirname,
-                })
+            })
             self.create_xml(nodes, os.path.join(current_dir, dirname), dir_node, staging_dir)
 
     def build_package(self):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1946,7 +1946,7 @@ cpu = 'armv7' # Not sure if correct.
 endian = 'little'
 ''' % os.path.join(testdir, 'some_cross_tool.py'))
         crossfile.flush()
-        self.init(testdir, ['--cross-file='+crossfile.name])
+        self.init(testdir, ['--cross-file=' + crossfile.name])
 
     def test_reconfigure(self):
         testdir = os.path.join(self.unit_test_dir, '13 reconfigure')

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,10 @@ ignore =
     E305,
     # E401: multiple imports on one line
     E401,
-    # too many leading '#' for block comment
+    # E266: too many leading '#' for block comment
     E266,
-    # module level import not at top of file
-    E402
+    # E402: module level import not at top of file
+    E402,
+    # E731: do not assign a lambda expression, use a def (too many false positives)
+    E731
 max-line-length = 120

--- a/test cases/common/147 mesonintrospect from scripts/check_env.py
+++ b/test cases/common/147 mesonintrospect from scripts/check_env.py
@@ -16,8 +16,8 @@ mesonintrospect = os.environ['MESONINTROSPECT']
 
 introspect_arr = shlex.split(mesonintrospect)
 
-#print(mesonintrospect)
-#print(introspect_arr)
+# print(mesonintrospect)
+# print(introspect_arr)
 
 some_executable = introspect_arr[0]
 


### PR DESCRIPTION
Currently, flake8-compliance is being checked by SideCI, which only regression-tests flake8 compliance.  It only ensures that *new*code passes flake8.

That's kind of an F-U to would-be contributors who want to run do a pre-flight test locally before filing the pull request.  They'll get a screenful of messages from flake8, and they'll have to try to weed through those looking for filename/linenumbers that they changed (or, since we're programmers, run flake8 the upstream, run it on our version, and diff the outputs).

Also, this is just a good thing for the codebase.

OK, the title of the PR lied, just a little bit.  I left 5 complaints from flake8 intact.  For most of them, I could just delete the offending line, but I have a feeling that each is actually a subtle bug that might take a little more thought/knowledge to fix (that the unused variable *should* be used, not deleted).

```
./mesonbuild/interpreter.py:2021:81: F821 undefined name 'exename'
./mesonbuild/backend/ninjabackend.py:108:13: F841 local variable 'noq_templ' is assigned to but never used
./mesonbuild/backend/ninjabackend.py:1789:9: F841 local variable 'source_target_dir' is assigned to but never used
./mesonbuild/backend/ninjabackend.py:1813:13: F841 local variable 'relout' is assigned to but never used
./msi/createmsi.py:205:17: F841 local variable 'file_source' is assigned to but never used
```