### PR TITLE
Use flake8-isort to enforce imports not being a mess

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import meson
 import sys
+
+import meson
 
 sys.exit(meson.main())

--- a/contributing.txt
+++ b/contributing.txt
@@ -18,12 +18,12 @@ following:
 - all new features must come with a test (or several if it is
   a big feature)
 
-Meson uses Flake8 for style guide enforcement. The Flake8 options for
-the project are contained in setup.cfg.
+Meson uses Flake8 with the isort plugin for style guide enforcement.
+The Flake8 options for the project are contained in setup.cfg.
 
 To run Flake8 on your local clone of Meson:
 
- $ python3 -m pip install flake8
+ $ python3 -m pip install flake8-isort
  $ cd meson
  $ flake8
 

--- a/ghwt.py
+++ b/ghwt.py
@@ -19,8 +19,14 @@
 # An emergency wraptool(1) replacement downloader that downloads
 # directly from GitHub in case wrapdb.mesonbuild.com is down.
 
-import urllib.request, json, sys, os, shutil, subprocess
-import configparser, hashlib
+import configparser
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import urllib.request
 
 private_repos = {'meson', 'wrapweb', 'meson-ci'}
 

--- a/manual tests/4 standalone binaries/build_windows_package.py
+++ b/manual tests/4 standalone binaries/build_windows_package.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 
-import os, urllib.request, shutil, subprocess
+import os
+import shutil
+import subprocess
+import urllib.request
 from glob import glob
 
 sdl_url = 'http://libsdl.org/release/SDL2-devel-2.0.3-VC.zip'

--- a/meson.py
+++ b/meson.py
@@ -14,8 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mesonbuild import mesonmain, mesonlib
-import sys, os, locale
+import locale
+import os
+import sys
+
+from mesonbuild import mesonlib, mesonmain
+
 
 def main():
     # Warn if the locale is not UTF-8. This can cause various unfixable issues

--- a/mesonbuild/astinterpreter.py
+++ b/mesonbuild/astinterpreter.py
@@ -15,12 +15,12 @@
 # This class contains the basic functionality needed to run any interpreter
 # or an interpreter-based tool.
 
-from . import interpreterbase, mlog, mparser, mesonlib
-from . import environment
+import os
+import sys
 
+from . import environment, interpreterbase, mesonlib, mlog, mparser
 from .interpreterbase import InterpreterException, InvalidArguments
 
-import os, sys
 
 class DontCareObject(interpreterbase.InterpreterObject):
     pass

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -12,19 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os, pickle, re
-from .. import build
-from .. import dependencies
-from .. import mesonlib
-from .. import mlog
-from .. import compilers
 import json
-import subprocess
-from ..mesonlib import MesonException
-from ..mesonlib import get_compiler_for_source, classify_unity_sources
-from ..compilers import CompilerArgs
-from collections import OrderedDict
+import os
+import pickle
+import re
 import shlex
+import subprocess
+from collections import OrderedDict
+
+from .. import build, compilers, dependencies, mesonlib, mlog
+from ..compilers import CompilerArgs
+from ..mesonlib import (
+    MesonException,
+    classify_unity_sources,
+    get_compiler_for_source,
+)
+
 
 class CleanTrees:
     '''

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -12,22 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os, pickle, re, shlex, subprocess, sys
+import os
+import pickle
+import re
+import shlex
+import subprocess
+import sys
 from collections import OrderedDict
 
 from . import backends
-from .. import modules
-from .. import environment, mesonlib
-from .. import build
-from .. import mlog
-from .. import dependencies
-from .. import compilers
+from .. import (
+    build,
+    compilers,
+    dependencies,
+    environment,
+    mesonlib,
+    mlog,
+    modules,
+)
+from ..build import InvalidArguments
 from ..compilers import CompilerArgs
 from ..linkers import ArLinker
-from ..mesonlib import File, MesonException, OrderedSet
-from ..mesonlib import get_compiler_for_source
+from ..mesonlib import (
+    File,
+    MesonException,
+    OrderedSet,
+    get_compiler_for_source,
+)
 from .backends import CleanTrees, InstallData
-from ..build import InvalidArguments
 
 if mesonlib.is_windows():
     quote_func = lambda s: '"{}"'.format(s)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -12,19 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os, sys
+import os
 import pickle
+import sys
 import xml.dom.minidom
 import xml.etree.ElementTree as ET
 
 from . import backends
-from .. import build
-from .. import dependencies
-from .. import mlog
-from .. import compilers
+from .. import build, compilers, dependencies, mlog
 from ..compilers import CompilerArgs
-from ..mesonlib import MesonException, File
 from ..environment import Environment
+from ..mesonlib import File, MesonException
+
 
 def autodetect_vs_version(build):
     vs_version = os.getenv('VisualStudioVersion', None)

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import backends
-from .. import build
-from .. import dependencies
-from .. import mesonlib
-import uuid, os, sys
+import os
+import sys
+import uuid
 
+from . import backends
+from .. import build, dependencies, mesonlib
 from ..mesonlib import MesonException
+
 
 class XCodeBackend(backends.Backend):
     def __init__(self, build):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -12,18 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy, os, re
-from collections import OrderedDict
+import copy
 import itertools
+import os
+import re
+from collections import OrderedDict
 
-from . import environment
-from . import dependencies
-from . import mlog
-from .mesonlib import File, MesonException, listify, extract_as_list
-from .mesonlib import flatten, typeslistify, stringlistify, classify_unity_sources
-from .mesonlib import get_filenames_templates_dict, substitute_values
-from .environment import for_windows, for_darwin, for_cygwin
-from .compilers import is_object, clike_langs, sort_clike, lang_suffixes
+from . import dependencies, environment, mlog
+from .compilers import clike_langs, is_object, lang_suffixes, sort_clike
+from .environment import for_cygwin, for_darwin, for_windows
+from .mesonlib import (
+    File,
+    MesonException,
+    classify_unity_sources,
+    extract_as_list,
+    flatten,
+    get_filenames_templates_dict,
+    listify,
+    stringlistify,
+    substitute_values,
+    typeslistify,
+)
 
 known_basic_kwargs = {'install': True,
                       'c_pch': True,

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -81,38 +81,6 @@ __all__ = [
     'VisualStudioCPPCompiler',
 ]
 
-# Bring symbols from each module into compilers sub-package namespace
-from .compilers import (
-    GCC_OSX,
-    GCC_MINGW,
-    GCC_CYGWIN,
-    GCC_STANDARD,
-    CLANG_OSX,
-    CLANG_WIN,
-    CLANG_STANDARD,
-    ICC_OSX,
-    ICC_WIN,
-    ICC_STANDARD,
-    base_options,
-    clike_langs,
-    c_suffixes,
-    cpp_suffixes,
-    get_base_compile_args,
-    get_base_link_args,
-    is_header,
-    is_source,
-    is_assembly,
-    is_llvm_ir,
-    is_object,
-    is_library,
-    lang_suffixes,
-    sanitizer_compile_args,
-    sort_clike,
-    ClangCompiler,
-    CompilerArgs,
-    GnuCompiler,
-    IntelCompiler,
-)
 from .c import (
     CCompiler,
     ClangCCompiler,
@@ -120,20 +88,47 @@ from .c import (
     IntelCCompiler,
     VisualStudioCCompiler,
 )
+# Bring symbols from each module into compilers sub-package namespace
+from .compilers import (
+    CLANG_OSX,
+    CLANG_STANDARD,
+    CLANG_WIN,
+    GCC_CYGWIN,
+    GCC_MINGW,
+    GCC_OSX,
+    GCC_STANDARD,
+    ICC_OSX,
+    ICC_STANDARD,
+    ICC_WIN,
+    ClangCompiler,
+    CompilerArgs,
+    GnuCompiler,
+    IntelCompiler,
+    base_options,
+    c_suffixes,
+    clike_langs,
+    cpp_suffixes,
+    get_base_compile_args,
+    get_base_link_args,
+    is_assembly,
+    is_header,
+    is_library,
+    is_llvm_ir,
+    is_object,
+    is_source,
+    lang_suffixes,
+    sanitizer_compile_args,
+    sort_clike,
+)
 from .cpp import (
-    CPPCompiler,
     ClangCPPCompiler,
+    CPPCompiler,
     GnuCPPCompiler,
     IntelCPPCompiler,
     VisualStudioCPPCompiler,
 )
 from .cs import MonoCompiler
-from .d import (
-    DCompiler,
-    DmdDCompiler,
-    GnuDCompiler,
-    LLVMDCompiler,
-)
+from .d import DCompiler, DmdDCompiler, GnuDCompiler, LLVMDCompiler
 from .fortran import (
     FortranCompiler,
     G95FortranCompiler,
@@ -146,16 +141,8 @@ from .fortran import (
     SunFortranCompiler,
 )
 from .java import JavaCompiler
-from .objc import (
-    ObjCCompiler,
-    ClangObjCCompiler,
-    GnuObjCCompiler,
-)
-from .objcpp import (
-    ObjCPPCompiler,
-    ClangObjCPPCompiler,
-    GnuObjCPPCompiler,
-)
+from .objc import ClangObjCCompiler, GnuObjCCompiler, ObjCCompiler
+from .objcpp import ClangObjCPPCompiler, GnuObjCPPCompiler, ObjCPPCompiler
 from .rust import RustCompiler
 from .swift import SwiftCompiler
 from .vala import ValaCompiler

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -12,21 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import subprocess, os.path, tempfile
+import os.path
+import subprocess
+import tempfile
 
-from .. import mlog
-from .. import coredata
-from ..mesonlib import EnvironmentException, version_compare, Popen_safe, listify
-
+from .. import coredata, mlog
+from ..mesonlib import (
+    EnvironmentException,
+    Popen_safe,
+    listify,
+    version_compare,
+)
 from .compilers import (
     GCC_MINGW,
-    get_largefile_args,
-    gnu_winlibs,
-    msvc_buildtype_args,
-    msvc_buildtype_linker_args,
-    msvc_winlibs,
-    vs32_instruction_set_args,
-    vs64_instruction_set_args,
     ClangCompiler,
     Compiler,
     CompilerArgs,
@@ -34,6 +32,13 @@ from .compilers import (
     GnuCompiler,
     IntelCompiler,
     RunResult,
+    get_largefile_args,
+    gnu_winlibs,
+    msvc_buildtype_args,
+    msvc_buildtype_linker_args,
+    msvc_winlibs,
+    vs32_instruction_set_args,
+    vs64_instruction_set_args,
 )
 
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -12,13 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib, os.path, re, tempfile
+import contextlib
+import os.path
+import re
+import tempfile
 
+from .. import coredata, mesonlib, mlog
 from ..linkers import StaticLinker
-from .. import coredata
-from .. import mlog
-from .. import mesonlib
-from ..mesonlib import EnvironmentException, MesonException, version_compare, Popen_safe
+from ..mesonlib import (
+    EnvironmentException,
+    MesonException,
+    Popen_safe,
+    version_compare,
+)
 
 """This file contains the data files of all compilers Meson knows
 about. To support a new compiler, add its information below.

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -16,16 +16,16 @@ import os.path
 
 from .. import coredata
 from ..mesonlib import version_compare
-
 from .c import CCompiler, VisualStudioCCompiler
 from .compilers import (
     GCC_MINGW,
-    gnu_winlibs,
-    msvc_winlibs,
     ClangCompiler,
     GnuCompiler,
     IntelCompiler,
+    gnu_winlibs,
+    msvc_winlibs,
 )
+
 
 class CPPCompiler(CCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrap):

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os.path, subprocess
+import os.path
+import subprocess
 
 from ..mesonlib import EnvironmentException
-
 from .compilers import Compiler, mono_buildtype_args
+
 
 class MonoCompiler(Compiler):
     def __init__(self, exelist, version):

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os.path, subprocess
+import os.path
+import subprocess
 
 from ..mesonlib import EnvironmentException, version_compare
-
 from .compilers import (
     GCC_STANDARD,
+    Compiler,
+    CompilerArgs,
     d_dmd_buildtype_args,
     d_gdc_buildtype_args,
     d_ldc_buildtype_args,
     get_gcc_soname_args,
     gnu_color_args,
-    Compiler,
-    CompilerArgs,
 )
 
 d_feature_args = {'gcc':  {'unittest': '-funittest',

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -12,23 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os.path, subprocess
+import os.path
+import subprocess
 
 from ..mesonlib import EnvironmentException, is_osx
-
 from .compilers import (
     GCC_CYGWIN,
     GCC_MINGW,
     GCC_OSX,
     GCC_STANDARD,
     ICC_STANDARD,
+    Compiler,
+    IntelCompiler,
     apple_buildtype_linker_args,
     get_gcc_soname_args,
     gnulike_buildtype_args,
     gnulike_buildtype_linker_args,
-    Compiler,
-    IntelCompiler,
 )
+
 
 class FortranCompiler(Compiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None):

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os.path, shutil, subprocess
+import os.path
+import shutil
+import subprocess
 
 from ..mesonlib import EnvironmentException
-
 from .compilers import Compiler, java_buildtype_args
+
 
 class JavaCompiler(Compiler):
     def __init__(self, exelist, version):

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os.path, subprocess
+import os.path
+import subprocess
 
 from ..mesonlib import EnvironmentException
-
 from .c import CCompiler
 from .compilers import ClangCompiler, GnuCompiler
+
 
 class ObjCCompiler(CCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrap):

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os.path, subprocess
+import os.path
+import subprocess
 
 from ..mesonlib import EnvironmentException
-
-from .cpp import CPPCompiler
 from .compilers import ClangCompiler, GnuCompiler
+from .cpp import CPPCompiler
+
 
 class ObjCPPCompiler(CPPCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrap):

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import subprocess, os.path
+import os.path
+import subprocess
 
 from ..mesonlib import EnvironmentException, Popen_safe
-
 from .compilers import Compiler, rust_buildtype_args
+
 
 class RustCompiler(Compiler):
     def __init__(self, exelist, version):

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import subprocess, os.path
+import os.path
+import subprocess
 
 from ..mesonlib import EnvironmentException
-
 from .compilers import Compiler, swift_buildtype_args
+
 
 class SwiftCompiler(Compiler):
     def __init__(self, exelist, version):

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -16,8 +16,8 @@ import os.path
 
 from .. import mlog
 from ..mesonlib import EnvironmentException, version_compare
-
 from .compilers import Compiler
+
 
 class ValaCompiler(Compiler):
     def __init__(self, exelist, version):

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -12,12 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pickle, os, uuid
-from pathlib import PurePath
-from collections import OrderedDict
-from .mesonlib import MesonException, commonpath
-from .mesonlib import default_libdir, default_libexecdir, default_prefix
 import ast
+import os
+import pickle
+import uuid
+from collections import OrderedDict
+from pathlib import PurePath
+
+from .mesonlib import (
+    MesonException,
+    commonpath,
+    default_libdir,
+    default_libexecdir,
+    default_prefix,
+)
 
 version = '0.43.0.dev1'
 backendlist = ['ninja', 'vs', 'vs2010', 'vs2015', 'vs2017', 'xcode']

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -13,14 +13,44 @@
 # limitations under the License.
 
 from .base import (  # noqa: F401
-    Dependency, DependencyException, DependencyMethods, ExternalProgram,
-    ExternalDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
-    PkgConfigDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language)
-from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDependency
-from .misc import (BoostDependency, MPIDependency, Python3Dependency, ThreadDependency, PcapDependency, CupsDependency)
+    Dependency,
+    DependencyException,
+    DependencyMethods,
+    ExternalDependency,
+    ExternalLibrary,
+    ExternalProgram,
+    ExtraFrameworkDependency,
+    InternalDependency,
+    PkgConfigDependency,
+    _packages_accept_language,
+    find_external_dependency,
+    get_dep_identifier,
+    packages,
+)
+from .dev import (
+    GMockDependency,
+    GTestDependency,
+    LLVMDependency,
+    ValgrindDependency,
+)
+from .misc import (
+    BoostDependency,
+    CupsDependency,
+    MPIDependency,
+    PcapDependency,
+    Python3Dependency,
+    ThreadDependency,
+)
 from .platform import AppleFrameworks
-from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, VulkanDependency
-
+from .ui import (
+    GLDependency,
+    GnuStepDependency,
+    Qt4Dependency,
+    Qt5Dependency,
+    SDL2Dependency,
+    VulkanDependency,
+    WxDependency,
+)
 
 packages.update({
     # From dev:

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -21,10 +21,14 @@ import stat
 import sys
 from enum import Enum
 
-from .. import mlog
-from .. import mesonlib
-from ..mesonlib import MesonException, Popen_safe, flatten, version_compare_many, listify
-
+from .. import mesonlib, mlog
+from ..mesonlib import (
+    MesonException,
+    Popen_safe,
+    flatten,
+    listify,
+    version_compare_many,
+)
 
 # These must be defined in this file to avoid cyclical references.
 packages = {}

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -19,10 +19,10 @@ import os
 import shlex
 import shutil
 
-from .. import mlog
-from .. import mesonlib
-from ..mesonlib import version_compare, Popen_safe
+from .. import mesonlib, mlog
+from ..mesonlib import Popen_safe, version_compare
 from .base import DependencyException, ExternalDependency, PkgConfigDependency
+
 
 class GTestDependency(ExternalDependency):
     def __init__(self, environment, kwargs):

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -18,17 +18,21 @@ import glob
 import os
 import re
 import shlex
-import stat
 import shutil
+import stat
 import sysconfig
 
-from .. import mlog
-from .. import mesonlib
-from ..mesonlib import Popen_safe, extract_as_list
+from .. import mesonlib, mlog
 from ..environment import detect_cpu_family
-
-from .base import DependencyException, DependencyMethods
-from .base import ExternalDependency, ExternalProgram, ExtraFrameworkDependency, PkgConfigDependency
+from ..mesonlib import Popen_safe, extract_as_list
+from .base import (
+    DependencyException,
+    DependencyMethods,
+    ExternalDependency,
+    ExternalProgram,
+    ExtraFrameworkDependency,
+    PkgConfigDependency,
+)
 
 
 class BoostDependency(ExternalDependency):

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -1,4 +1,4 @@
-﻿# Copyright 2013-2017 The Meson development team
+# Copyright 2013-2017 The Meson development team
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mesonbuild/dependencies/platform.py
+++ b/mesonbuild/dependencies/platform.py
@@ -16,8 +16,7 @@
 # platform-specific (generally speaking).
 
 from .. import mesonlib
-
-from .base import ExternalDependency, DependencyException
+from .base import DependencyException, ExternalDependency
 
 
 class AppleFrameworks(ExternalDependency):

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -21,14 +21,22 @@ import shutil
 import subprocess
 from collections import OrderedDict
 
-from .. import mlog
-from .. import mesonlib
-from ..mesonlib import MesonException, Popen_safe, version_compare, extract_as_list
-from ..environment import for_windows, detect_cpu
-
-from .base import DependencyException, DependencyMethods
-from .base import ExternalDependency, ExternalProgram
-from .base import ExtraFrameworkDependency, PkgConfigDependency
+from .. import mesonlib, mlog
+from ..environment import detect_cpu, for_windows
+from ..mesonlib import (
+    MesonException,
+    Popen_safe,
+    extract_as_list,
+    version_compare,
+)
+from .base import (
+    DependencyException,
+    DependencyMethods,
+    ExternalDependency,
+    ExternalProgram,
+    ExtraFrameworkDependency,
+    PkgConfigDependency,
+)
 
 
 class GLDependency(ExternalDependency):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import configparser, os, platform, re, shlex, shutil, subprocess
-
-from . import coredata
-from .linkers import ArLinker, VisualStudioLinker
-from . import mesonlib
-from .mesonlib import EnvironmentException, Popen_safe
-from . import mlog
+import configparser
+import os
+import platform
+import re
+import shlex
+import shutil
+import subprocess
 import sys
 
-from . import compilers
+from . import compilers, coredata, mesonlib, mlog
 from .compilers import (
     CLANG_OSX,
     CLANG_STANDARD,
@@ -31,14 +31,6 @@ from .compilers import (
     GCC_OSX,
     GCC_STANDARD,
     ICC_STANDARD,
-    is_assembly,
-    is_header,
-    is_library,
-    is_llvm_ir,
-    is_object,
-    is_source,
-)
-from .compilers import (
     ClangCCompiler,
     ClangCPPCompiler,
     ClangObjCCompiler,
@@ -63,7 +55,15 @@ from .compilers import (
     ValaCompiler,
     VisualStudioCCompiler,
     VisualStudioCPPCompiler,
+    is_assembly,
+    is_header,
+    is_library,
+    is_llvm_ir,
+    is_object,
+    is_source,
 )
+from .linkers import ArLinker, VisualStudioLinker
+from .mesonlib import EnvironmentException, Popen_safe
 
 build_filename = 'meson.build'
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -11,30 +11,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import mparser
-from . import environment
-from . import coredata
-from . import dependencies
-from . import mlog
-from . import build
-from . import optinterpreter
-from . import compilers
-from .wrap import wrap, WrapMode
-from . import mesonlib
-from .mesonlib import FileMode, Popen_safe, listify, extract_as_list
-from .dependencies import ExternalProgram
-from .dependencies import InternalDependency, Dependency, DependencyException
-from .interpreterbase import InterpreterBase
-from .interpreterbase import check_stringlist, noPosargs, noKwargs, stringArgs, permittedKwargs
-from .interpreterbase import InterpreterException, InvalidArguments, InvalidCode
-from .interpreterbase import InterpreterObject, MutableInterpreterObject
-from .modules import ModuleReturnValue
-
-import os, sys, shutil, uuid
-import re, shlex
+import importlib
+import os
+import re
+import shlex
+import shutil
+import sys
+import uuid
 from collections import namedtuple
 
-import importlib
+from . import (
+    build,
+    compilers,
+    coredata,
+    dependencies,
+    environment,
+    mesonlib,
+    mlog,
+    mparser,
+    optinterpreter,
+)
+from .dependencies import (
+    Dependency,
+    DependencyException,
+    ExternalProgram,
+    InternalDependency,
+)
+from .interpreterbase import (
+    InterpreterBase,
+    InterpreterException,
+    InterpreterObject,
+    InvalidArguments,
+    InvalidCode,
+    MutableInterpreterObject,
+    check_stringlist,
+    noKwargs,
+    noPosargs,
+    permittedKwargs,
+    stringArgs,
+)
+from .mesonlib import FileMode, Popen_safe, extract_as_list, listify
+from .modules import ModuleReturnValue
+from .wrap import WrapMode, wrap
 
 run_depr_printed = False
 

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -15,11 +15,12 @@
 # This class contains the basic functionality needed to run any interpreter
 # or an interpreter-based tool.
 
-from . import mparser, mesonlib, mlog
-from . import environment, dependencies
-
-import os, copy, re
+import copy
+import os
+import re
 from functools import wraps
+
+from . import dependencies, environment, mesonlib, mlog, mparser
 
 # Decorators for method calls.
 

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -14,6 +14,7 @@
 
 from .mesonlib import Popen_safe
 
+
 class StaticLinker:
     pass
 

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, os
-import pickle
 import argparse
+import os
+import pickle
+import sys
+
 from . import coredata, mesonlib
 
 parser = argparse.ArgumentParser()

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -14,12 +14,16 @@
 
 """A library of random helper functionality."""
 
-import sys
-import stat
-import time
-import platform, subprocess, operator, os, shutil, re
 import collections
-
+import operator
+import os
+import platform
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import time
 from glob import glob
 
 # Put this in objects that should not get dumped to pickle files

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -24,7 +24,7 @@ from glob import glob
 
 # Put this in objects that should not get dumped to pickle files
 # by accident.
-import threading
+import threading  # isort:skip
 an_unpicklable_object = threading.Lock()
 
 class MesonException(Exception):

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -12,17 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, stat, traceback, pickle, argparse
-import time, datetime
+import argparse
+import datetime
 import os.path
-from . import environment, interpreter, mesonlib
-from . import build
-from . import mconf, mintro, mtest, rewriter
+import pickle
 import platform
-from . import mlog, coredata
+import stat
+import sys
+import time
+import traceback
+
+from . import (
+    build,
+    coredata,
+    environment,
+    interpreter,
+    mconf,
+    mesonlib,
+    mintro,
+    mlog,
+    mtest,
+    rewriter,
+)
 from .mesonlib import MesonException
 from .wrap import WrapMode, wraptool
-
 
 parser = argparse.ArgumentParser()
 

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -19,11 +19,14 @@ tests and so on. All output is in JSON for simple parsing.
 Currently only works for the Ninja backend. Others use generated
 project files and don't need this info."""
 
-import json, pickle
-from . import coredata, build
 import argparse
-import sys, os
+import json
+import os
 import pathlib
+import pickle
+import sys
+
+from . import build, coredata
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--targets', action='store_true', dest='list_targets', default=False,

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, os, platform, io
+import io
+import os
+import platform
+import sys
 
 """This is (mostly) a standalone module used to write logging
 information about Meson runs. Some output goes to screen,

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -1,9 +1,8 @@
 import os
 
-from .. import build
-from .. import dependencies
-from .. import mlog
+from .. import build, dependencies, mlog
 from ..mesonlib import MesonException
+
 
 class permittedSnippetKwargs:
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -15,21 +15,25 @@
 '''This module provides helper functions for Gnome/GLib related
 functionality such as gobject-introspection, gresources and gtk-doc'''
 
-from .. import build
-import os
 import copy
+import os
 import subprocess
-from . import ModuleReturnValue
-from ..mesonlib import MesonException, OrderedSet, Popen_safe
-from ..dependencies import Dependency, PkgConfigDependency, InternalDependency
-from .. import mlog
-from .. import mesonlib
-from .. import compilers
-from .. import interpreter
-from . import GResourceTarget, GResourceHeaderTarget, GirTarget, TypelibTarget, VapiTarget
-from . import find_program, get_include_args
-from . import ExtensionModule
+
+from . import (
+    ExtensionModule,
+    GirTarget,
+    GResourceHeaderTarget,
+    GResourceTarget,
+    ModuleReturnValue,
+    TypelibTarget,
+    VapiTarget,
+    find_program,
+    get_include_args,
+)
+from .. import build, compilers, interpreter, mesonlib, mlog
+from ..dependencies import Dependency, InternalDependency, PkgConfigDependency
 from ..interpreterbase import noKwargs, permittedKwargs
+from ..mesonlib import MesonException, OrderedSet, Popen_safe
 
 # gresource compilation is broken due to the way
 # the resource compiler and Ninja clash about it

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 
 import shutil
-
 from os import path
-from .. import coredata, mesonlib, build
-from ..mesonlib import MesonException
-from . import ModuleReturnValue
-from . import ExtensionModule
+
+from . import ExtensionModule, ModuleReturnValue
+from .. import build, coredata, mesonlib
 from ..interpreterbase import permittedKwargs
+from ..mesonlib import MesonException
 
 PRESET_ARGS = {
     'glib': [

--- a/mesonbuild/modules/modtest.py
+++ b/mesonbuild/modules/modtest.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import ModuleReturnValue
-from . import ExtensionModule
+from . import ExtensionModule, ModuleReturnValue
 from ..interpreterbase import noKwargs
+
 
 class TestModule(ExtensionModule):
 

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -14,11 +14,8 @@
 
 import os
 
-from .. import build
-from .. import mesonlib
-from .. import mlog
-from . import ModuleReturnValue
-from . import ExtensionModule
+from . import ExtensionModule, ModuleReturnValue
+from .. import build, mesonlib, mlog
 from ..interpreterbase import permittedKwargs
 
 

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -14,13 +14,13 @@
 
 import sys
 import sysconfig
-from .. import mesonlib, dependencies
 
-from . import ExtensionModule
 from mesonbuild.modules import ModuleReturnValue
-from . import permittedSnippetKwargs
-from ..interpreterbase import noKwargs
+
+from . import ExtensionModule, permittedSnippetKwargs
+from .. import dependencies, mesonlib
 from ..interpreter import shlib_kwargs
+from ..interpreterbase import noKwargs
 
 mod_kwargs = set()
 mod_kwargs.update(shlib_kwargs)

--- a/mesonbuild/modules/qt4.py
+++ b/mesonbuild/modules/qt4.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 import os
-from .. import mlog
-from .. import build
-from ..mesonlib import MesonException, Popen_safe, extract_as_list
-from ..dependencies import Qt4Dependency
-from . import ExtensionModule
 import xml.etree.ElementTree as ET
-from . import ModuleReturnValue
+
+from . import ExtensionModule, ModuleReturnValue
+from .. import build, mlog
+from ..dependencies import Qt4Dependency
 from ..interpreterbase import permittedKwargs
+from ..mesonlib import MesonException, Popen_safe, extract_as_list
+
 
 class Qt4Module(ExtensionModule):
     tools_detected = False

--- a/mesonbuild/modules/qt5.py
+++ b/mesonbuild/modules/qt5.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 import os
-from .. import mlog
-from .. import build
-from ..mesonlib import MesonException, Popen_safe, extract_as_list
-from ..dependencies import Qt5Dependency
-from . import ExtensionModule
 import xml.etree.ElementTree as ET
-from . import ModuleReturnValue
+
+from . import ExtensionModule, ModuleReturnValue
+from .. import build, mlog
+from ..dependencies import Qt5Dependency
 from ..interpreterbase import permittedKwargs
+from ..mesonlib import MesonException, Popen_safe, extract_as_list
+
 
 class Qt5Module(ExtensionModule):
     tools_detected = False

--- a/mesonbuild/modules/rpm.py
+++ b/mesonbuild/modules/rpm.py
@@ -15,16 +15,13 @@
 '''This module provides helper functions for RPM related
 functionality such as generating template RPM spec file.'''
 
-from .. import build
-from .. import compilers
 import datetime
-from .. import mlog
-from . import GirTarget, TypelibTarget
-from . import ModuleReturnValue
-from . import ExtensionModule
+import os
+
+from . import ExtensionModule, GirTarget, ModuleReturnValue, TypelibTarget
+from .. import build, compilers, mlog
 from ..interpreterbase import noKwargs
 
-import os
 
 class RPMModule(ExtensionModule):
 

--- a/mesonbuild/modules/unstable_simd.py
+++ b/mesonbuild/modules/unstable_simd.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .. import mesonlib, compilers, mlog
-
 from . import ExtensionModule
+from .. import compilers, mesonlib, mlog
+
 
 class SimdModule(ExtensionModule):
 

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -14,13 +14,11 @@
 
 import os
 
-from .. import mlog
-from .. import mesonlib, dependencies, build
-from ..mesonlib import MesonException, extract_as_list
-from . import get_include_args
-from . import ModuleReturnValue
-from . import ExtensionModule
+from . import ExtensionModule, ModuleReturnValue, get_include_args
+from .. import build, dependencies, mesonlib, mlog
 from ..interpreterbase import permittedKwargs
+from ..mesonlib import MesonException, extract_as_list
+
 
 class WindowsModule(ExtensionModule):
 

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 import re
-from .mesonlib import MesonException
+
 from . import mlog
+from .mesonlib import MesonException
+
 
 class ParseException(MesonException):
     def __init__(self, text, line, lineno, colno):

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -14,20 +14,23 @@
 
 # A tool to run tests in many different ways.
 
-import shlex
-import subprocess, sys, os, argparse
-import pickle
-from mesonbuild import build
-from mesonbuild import environment
-from mesonbuild.dependencies import ExternalProgram
-from mesonbuild import mesonlib
-from mesonbuild import mlog
-
-import time, datetime, multiprocessing, json
+import argparse
 import concurrent.futures as conc
+import datetime
+import json
+import multiprocessing
+import os
+import pickle
 import platform
-import signal
 import random
+import shlex
+import signal
+import subprocess
+import sys
+import time
+
+from mesonbuild import build, environment, mesonlib, mlog
+from mesonbuild.dependencies import ExternalProgram
 
 # GNU autotools interprets a return code of 77 from tests it executes to
 # mean that the test should be skipped.

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import mparser
-from . import coredata
-from . import mesonlib
-import os, re
+import os
+import re
+
+from . import coredata, mesonlib, mparser
 
 forbidden_option_names = coredata.get_builtin_options()
 forbidden_prefixes = {'c_',

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -23,11 +23,13 @@
 # - move targets
 # - reindent?
 
-import mesonbuild.astinterpreter
-from mesonbuild.mesonlib import MesonException
-from mesonbuild import mlog
-import sys, traceback
 import argparse
+import sys
+import traceback
+
+import mesonbuild.astinterpreter
+from mesonbuild import mlog
+from mesonbuild.mesonlib import MesonException
 
 parser = argparse.ArgumentParser()
 

--- a/mesonbuild/scripts/cleantrees.py
+++ b/mesonbuild/scripts/cleantrees.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import os
-import sys
-import shutil
 import pickle
+import shutil
+import sys
+
 
 def rmtrees(build_dir, trees):
     for t in trees:

--- a/mesonbuild/scripts/commandrunner.py
+++ b/mesonbuild/scripts/commandrunner.py
@@ -15,7 +15,12 @@
 """This program is a wrapper to run external commands. It determines
 what to run, sets up the environment and executes the command."""
 
-import sys, os, subprocess, shutil, shlex
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+
 
 def run_command(source_dir, build_dir, subdir, meson_command, command, arguments):
     env = {'MESON_SOURCE_ROOT': source_dir,

--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import subprocess
+import sys
+
 from mesonbuild import environment
 
-import sys, os, subprocess
 
 def remove_dir_from_trace(lcov_command, covfile, dirname):
     tmpfile = covfile + '.tmp'

--- a/mesonbuild/scripts/delwithsuffix.py
+++ b/mesonbuild/scripts/delwithsuffix.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os, sys
+import os
+import sys
+
 
 def run(args):
     if len(args) != 2:

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 
-import sys, struct
+import struct
+import sys
 
 SHT_STRTAB = 3
 DT_NEEDED = 1

--- a/mesonbuild/scripts/dirchanger.py
+++ b/mesonbuild/scripts/dirchanger.py
@@ -15,7 +15,10 @@
 '''CD into dir given as first argument and execute
 the command given in the rest of the arguments.'''
 
-import os, subprocess, sys
+import os
+import subprocess
+import sys
+
 
 def run(args):
     dirname = args[0]

--- a/mesonbuild/scripts/dist.py
+++ b/mesonbuild/scripts/dist.py
@@ -13,17 +13,20 @@
 # limitations under the License.
 
 
+import hashlib
 import lzma
 import os
+import pickle
 import shutil
 import subprocess
-import pickle
-import hashlib
-import tarfile, zipfile
+import tarfile
 import tempfile
+import zipfile
 from glob import glob
+
 from mesonbuild.environment import detect_ninja
 from mesonbuild.mesonlib import windows_proof_rmtree
+
 
 def create_hash(fname):
     hashname = fname + '.sha256sum'

--- a/mesonbuild/scripts/gettext.py
+++ b/mesonbuild/scripts/gettext.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import os
 import shutil
-import argparse
 import subprocess
+
 from . import destdir_join
 
 parser = argparse.ArgumentParser()

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, os
-import subprocess
-import shutil
 import argparse
-from ..mesonlib import MesonException, Popen_safe
+import os
+import shutil
+import subprocess
+import sys
+
 from . import destdir_join
+from ..mesonlib import MesonException, Popen_safe
 
 parser = argparse.ArgumentParser()
 

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
 import argparse
+import os
 import pickle
 import platform
+import sys
 
 from ..mesonlib import Popen_safe
 

--- a/mesonbuild/scripts/meson_install.py
+++ b/mesonbuild/scripts/meson_install.py
@@ -12,12 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, pickle, os, shutil, subprocess, gzip, platform, errno
+import errno
+import gzip
+import os
+import pickle
+import platform
 import shlex
+import shutil
+import subprocess
+import sys
 from glob import glob
-from . import depfixer
-from . import destdir_join
-from ..mesonlib import is_windows, Popen_safe
+
+from . import depfixer, destdir_join
+from ..mesonlib import Popen_safe, is_windows
 
 install_log_file = None
 use_selinux = True

--- a/mesonbuild/scripts/msgfmthelper.py
+++ b/mesonbuild/scripts/msgfmthelper.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import argparse
-import subprocess
 import os
+import subprocess
 
 parser = argparse.ArgumentParser()
 parser.add_argument('input')

--- a/mesonbuild/scripts/regen_checker.py
+++ b/mesonbuild/scripts/regen_checker.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, os
-import pickle, subprocess
+import os
+import pickle
+import subprocess
+import sys
 
 # This could also be used for XCode.
 

--- a/mesonbuild/scripts/scanbuild.py
+++ b/mesonbuild/scripts/scanbuild.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 import os
-import subprocess
 import shutil
+import subprocess
 import tempfile
+
 from ..environment import detect_ninja
+
 
 def scanbuild(exename, srcdir, blddir, privdir, logdir, args):
     with tempfile.TemporaryDirectory(dir=privdir) as scandir:

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -20,10 +20,12 @@
 # This file is basically a reimplementation of
 # http://cgit.freedesktop.org/libreoffice/core/commit/?id=3213cd54b76bc80a6f0516aac75a48ff3b2ad67c
 
-import os, sys
+import argparse
+import os
+import sys
+
 from .. import mesonlib
 from ..mesonlib import Popen_safe
-import argparse
 
 parser = argparse.ArgumentParser()
 

--- a/mesonbuild/scripts/vcstagger.py
+++ b/mesonbuild/scripts/vcstagger.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, os, subprocess, re
+import os
+import re
+import subprocess
+import sys
+
 
 def config_vcs_tag(infile, outfile, fallback, source_dir, replace_string, regex_selector, cmd):
     try:

--- a/mesonbuild/scripts/yelphelper.py
+++ b/mesonbuild/scripts/yelphelper.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import subprocess
-import shutil
 import argparse
-from .. import mlog
+import os
+import shutil
+import subprocess
+
 from . import destdir_join
+from .. import mlog
 from .gettext import read_linguas
 
 parser = argparse.ArgumentParser()

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .. import mlog
 import contextlib
-import urllib.request, os, hashlib, shutil
+import hashlib
+import os
+import shutil
 import subprocess
 import sys
+import urllib.request
 from pathlib import Path
+
 from . import WrapMode
+from .. import mlog
 
 try:
     import ssl

--- a/mesonbuild/wrap/wraptool.py
+++ b/mesonbuild/wrap/wraptool.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
-import sys, os
 import configparser
+import json
+import os
 import shutil
-
+import sys
 from glob import glob
 
 from .wrap import API_ROOT, open_wrapdburl
+
 
 help_templ = '''This program allows you to manage your Wrap dependencies
 using the online wrap database http://wrapdb.mesonbuild.com.

--- a/mesonconf.py
+++ b/mesonconf.py
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mesonbuild import mesonmain
 import sys
+
+from mesonbuild import mesonmain
 
 if __name__ == '__main__':
     print('Warning: This executable is deprecated. Use "meson configure" instead.',

--- a/mesonintrospect.py
+++ b/mesonintrospect.py
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mesonbuild import mesonmain
 import sys
+
+from mesonbuild import mesonmain
 
 if __name__ == '__main__':
     print('Warning: This executable is deprecated. Use "meson introspect" instead.',

--- a/mesonrewriter.py
+++ b/mesonrewriter.py
@@ -23,8 +23,9 @@
 # - move targets
 # - reindent?
 
-from mesonbuild import mesonmain
 import sys
+
+from mesonbuild import mesonmain
 
 if __name__ == '__main__':
     print('Warning: This executable is deprecated. Use "meson rewrite" instead.',

--- a/mesontest.py
+++ b/mesontest.py
@@ -16,8 +16,9 @@
 
 # A tool to run tests in many different ways.
 
-from mesonbuild import mesonmain
 import sys
+
+from mesonbuild import mesonmain
 
 if __name__ == '__main__':
     print('Warning: This executable is deprecated. Use "meson test" instead.',

--- a/msi/createmsi.py
+++ b/msi/createmsi.py
@@ -14,13 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, os, subprocess, shutil, uuid
-from glob import glob
+import os
 import platform
+import shutil
+import subprocess
+import sys
+import uuid
 import xml.etree.ElementTree as ET
+from glob import glob
+
+from mesonbuild import coredata
 
 sys.path.append(os.getcwd())
-from mesonbuild import coredata
 
 def gen_guid():
     return str(uuid.uuid4()).upper()

--- a/run_cross_test.py
+++ b/run_cross_test.py
@@ -22,10 +22,17 @@ Not part of the main test suite because of two reasons:
 
 Eventually migrate to something fancier.'''
 
-import sys, os
+import os
+import sys
 
-from run_project_tests import gather_tests, run_tests, StopException, setup_commands
-from run_project_tests import failing_logs
+from run_project_tests import (
+    StopException,
+    failing_logs,
+    gather_tests,
+    run_tests,
+    setup_commands,
+)
+
 
 def runtests(cross_file):
     commontests = [('common', gather_tests('test cases/common'), False)]

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -14,29 +14,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from glob import glob
+import argparse
+import concurrent.futures as conc
 import itertools
-import os, subprocess, shutil, sys, signal
-from io import StringIO
+import multiprocessing
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import xml.etree.ElementTree as ET
 from ast import literal_eval
 from enum import Enum
-import tempfile
-from mesonbuild import mtest
-from mesonbuild import environment
-from mesonbuild import mesonlib
-from mesonbuild import mlog
-from mesonbuild.mesonlib import stringlistify, Popen_safe
-from mesonbuild.coredata import backendlist
-import argparse
-import xml.etree.ElementTree as ET
-import time
-import multiprocessing
-import concurrent.futures as conc
-import re
-from run_unittests import get_fake_options, run_configure_inprocess
+from glob import glob
+from io import StringIO
 
-from run_tests import get_backend_commands, get_backend_args_for_dir, Backend
-from run_tests import ensure_backend_detects_changes
+from mesonbuild import environment, mesonlib, mlog, mtest
+from mesonbuild.coredata import backendlist
+from mesonbuild.mesonlib import Popen_safe, stringlistify
+
+from run_tests import (
+    Backend,
+    ensure_backend_detects_changes,
+    get_backend_args_for_dir,
+    get_backend_commands,
+)
+from run_unittests import get_fake_options, run_configure_inprocess
 
 
 class BuildStep(Enum):

--- a/run_tests.py
+++ b/run_tests.py
@@ -15,19 +15,18 @@
 # limitations under the License.
 
 import os
-import sys
-import time
+import platform
 import shutil
 import subprocess
+import sys
 import tempfile
-import platform
-from mesonbuild import mesonlib
-from mesonbuild import mesonmain
-from mesonbuild import mlog
-from mesonbuild.environment import detect_ninja
-from io import StringIO
+import time
 from enum import Enum
 from glob import glob
+from io import StringIO
+
+from mesonbuild import mesonlib, mesonmain, mlog
+from mesonbuild.environment import detect_ninja
 
 Backend = Enum('Backend', 'ninja vs xcode')
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -13,33 +13,50 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import stat
-import shlex
-import subprocess
-import re, json
-import tempfile
+import json
 import os
+import re
+import shlex
 import shutil
+import stat
+import subprocess
 import sys
+import tempfile
 import unittest
 from configparser import ConfigParser
 from glob import glob
 from pathlib import PurePath
 
-import mesonbuild.mlog
 import mesonbuild.compilers
+import mesonbuild.coredata
 import mesonbuild.environment
 import mesonbuild.mesonlib
-import mesonbuild.coredata
-from mesonbuild.mesonlib import is_linux, is_windows, is_osx, is_cygwin, windows_proof_rmtree
+import mesonbuild.mlog
+from mesonbuild.dependencies import (
+    DependencyException,
+    ExternalProgram,
+    PkgConfigDependency,
+)
 from mesonbuild.environment import Environment
-from mesonbuild.dependencies import DependencyException
-from mesonbuild.dependencies import PkgConfigDependency, ExternalProgram
+from mesonbuild.mesonlib import (
+    is_cygwin,
+    is_linux,
+    is_osx,
+    is_windows,
+    windows_proof_rmtree,
+)
 
-from run_tests import exe_suffix, get_fake_options, FakeEnvironment
-from run_tests import get_builddir_target_args, get_backend_commands, Backend
-from run_tests import ensure_backend_detects_changes, run_configure_inprocess
-from run_tests import should_run_linux_cross_tests
+from run_tests import (
+    Backend,
+    FakeEnvironment,
+    ensure_backend_detects_changes,
+    exe_suffix,
+    get_backend_commands,
+    get_builddir_target_args,
+    get_fake_options,
+    run_configure_inprocess,
+    should_run_linux_cross_tests,
+)
 
 
 def get_dynamic_section_entry(fname, entry):

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,9 @@ ignore =
     # E731: do not assign a lambda expression, use a def (too many false positives)
     E731
 max-line-length = 120
+
+[isort]
+not_skip = __init__.py
+# 3 = Vertical Hanging Indent
+multi_line_output = 3
+include_trailing_comma = True

--- a/test cases/common/103 manygen/subdir/manygen.py
+++ b/test cases/common/103 manygen/subdir/manygen.py
@@ -2,11 +2,14 @@
 
 from __future__ import print_function
 
+import os
+import shutil
+import subprocess
+import sys
+
 # Generates a static library, object file, source
 # file and a header file.
 
-import sys, os
-import shutil, subprocess
 
 with open(sys.argv[1]) as f:
     funcname = f.readline().strip()

--- a/test cases/common/108 postconf with args/postconf.py
+++ b/test cases/common/108 postconf with args/postconf.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-import sys, os
+import os
+import sys
 
 template = '''#pragma once
 

--- a/test cases/common/129 object only target/obj_generator.py
+++ b/test cases/common/129 object only target/obj_generator.py
@@ -2,7 +2,8 @@
 
 # Mimic a binary that generates an object file (e.g. windres).
 
-import sys, subprocess
+import subprocess
+import sys
 
 if __name__ == '__main__':
     if len(sys.argv) != 4:

--- a/test cases/common/134 generated llvm ir/copyfile.py
+++ b/test cases/common/134 generated llvm ir/copyfile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys
 import shutil
+import sys
 
 shutil.copyfile(sys.argv[1], sys.argv[2])

--- a/test cases/common/135 generated assembly/copyfile.py
+++ b/test cases/common/135 generated assembly/copyfile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys
 import shutil
+import sys
 
 shutil.copyfile(sys.argv[1], sys.argv[2])

--- a/test cases/common/138 include order/ctsub/copyfile.py
+++ b/test cases/common/138 include order/ctsub/copyfile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys
 import shutil
+import sys
 
 shutil.copyfile(sys.argv[1], sys.argv[2])

--- a/test cases/common/143 custom target object output/obj_generator.py
+++ b/test cases/common/143 custom target object output/obj_generator.py
@@ -2,7 +2,8 @@
 
 # Mimic a binary that generates an object file (e.g. windres).
 
-import sys, subprocess
+import subprocess
+import sys
 
 if __name__ == '__main__':
     if len(sys.argv) != 4:

--- a/test cases/common/147 mesonintrospect from scripts/check_env.py
+++ b/test cases/common/147 mesonintrospect from scripts/check_env.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 import os
-import sys
 import shlex
+import sys
 
 do_print = False
 

--- a/test cases/common/148 custom target multiple outputs/generator.py
+++ b/test cases/common/148 custom target multiple outputs/generator.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-import sys, os
+import os
+import sys
 
 if len(sys.argv) != 3:
     print(sys.argv[0], '<namespace>', '<output dir>')

--- a/test cases/common/16 configure file/basename.py
+++ b/test cases/common/16 configure file/basename.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
-import sys
 import argparse
 import os
+import sys
+
 
 def main():
     parser = argparse.ArgumentParser()

--- a/test cases/common/16 configure file/file_contains.py
+++ b/test cases/common/16 configure file/file_contains.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-import sys
 import argparse
+import sys
+
 
 def main():
     parser = argparse.ArgumentParser()

--- a/test cases/common/16 configure file/generator-without-input-file.py
+++ b/test cases/common/16 configure file/generator-without-input-file.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-import sys, os
+import os
+import sys
 from pathlib import Path
 
 if len(sys.argv) != 2:

--- a/test cases/common/16 configure file/generator.py
+++ b/test cases/common/16 configure file/generator.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-import sys, os
+import os
+import sys
 from pathlib import Path
 
 if len(sys.argv) != 3:

--- a/test cases/common/16 configure file/touch.py
+++ b/test cases/common/16 configure file/touch.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
-import sys
 import argparse
+import sys
 from pathlib import Path
+
 
 def main():
     parser = argparse.ArgumentParser()

--- a/test cases/common/48 test args/copyfile.py
+++ b/test cases/common/48 test args/copyfile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys
 import shutil
+import sys
 
 shutil.copyfile(sys.argv[1], sys.argv[2])

--- a/test cases/common/56 custom target/depfile/dep.py
+++ b/test cases/common/56 custom target/depfile/dep.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-import sys, os
+import os
+import sys
 from glob import glob
 
 _, srcdir, depfile, output = sys.argv

--- a/test cases/common/59 object generator/obj_generator.py
+++ b/test cases/common/59 object generator/obj_generator.py
@@ -2,7 +2,8 @@
 
 # Mimic a binary that generates an object file (e.g. windres).
 
-import sys, subprocess
+import subprocess
+import sys
 
 if __name__ == '__main__':
     if len(sys.argv) != 4:

--- a/test cases/common/61 custom target source output/generator.py
+++ b/test cases/common/61 custom target source output/generator.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-import sys, os
+import os
+import sys
 
 if len(sys.argv) != 2:
     print(sys.argv[0], '<output dir>')

--- a/test cases/common/65 multiple generators/mygen.py
+++ b/test cases/common/65 multiple generators/mygen.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-import sys, os
+import os
+import sys
 
 if len(sys.argv) != 3:
     print("You is fail.")

--- a/test cases/common/72 build always/version_gen.py
+++ b/test cases/common/72 build always/version_gen.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 
-import sys, os, subprocess
+import os
+import subprocess
+import sys
+
 
 def generate(infile, outfile, fallback):
     workdir = os.path.split(infile)[0]

--- a/test cases/common/78 ctarget dependency/gen1.py
+++ b/test cases/common/78 ctarget dependency/gen1.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-import time, sys
+import sys
+import time
 
 # Make sure other script runs first if dependency
 # is missing.

--- a/test cases/common/78 ctarget dependency/gen2.py
+++ b/test cases/common/78 ctarget dependency/gen2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-import sys, os
+import os
+import sys
 from glob import glob
 
 files = glob(os.path.join(sys.argv[1], '*.tmp'))

--- a/test cases/common/93 private include/stlib/compiler.py
+++ b/test cases/common/93 private include/stlib/compiler.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-import sys, os
+import os
+import sys
 
 assert(len(sys.argv) == 3)
 

--- a/test cases/common/95 dep fallback/gensrc.py
+++ b/test cases/common/95 dep fallback/gensrc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys
 import shutil
+import sys
 
 shutil.copyfile(sys.argv[1], sys.argv[2])

--- a/test cases/common/98 gen extra/srcgen.py
+++ b/test cases/common/98 gen extra/srcgen.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
-import sys
 import argparse
+import sys
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--input', dest='input',

--- a/test cases/common/98 gen extra/srcgen2.py
+++ b/test cases/common/98 gen extra/srcgen2.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
+import argparse
 import os
 import sys
-import argparse
 
 parser = argparse.ArgumentParser()
 parser.add_argument('target_dir',

--- a/test cases/failing/43 custom target outputs not matching install_dirs/generator.py
+++ b/test cases/failing/43 custom target outputs not matching install_dirs/generator.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-import sys, os
+import os
+import sys
 
 if len(sys.argv) != 3:
     print(sys.argv[0], '<namespace>', '<output dir>')

--- a/test cases/frameworks/7 gnome/resources/copyfile.py
+++ b/test cases/frameworks/7 gnome/resources/copyfile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys
 import shutil
+import sys
 
 shutil.copy(sys.argv[1], sys.argv[2])

--- a/test cases/frameworks/7 gnome/resources/resources.py
+++ b/test cases/frameworks/7 gnome/resources/resources.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import os
+
 from gi.repository import Gio
 
 if __name__ == '__main__':

--- a/test cases/python3/1 basic/prog.py
+++ b/test cases/python3/1 basic/prog.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-from gluon import gluonator
 import sys
+
+from gluon import gluonator
 
 print('Running mainprog from root dir.')
 

--- a/test cases/python3/1 basic/subdir/subprog.py
+++ b/test cases/python3/1 basic/subdir/subprog.py
@@ -3,8 +3,9 @@
 # In order to run this program, PYTHONPATH must be set to
 # point to source root.
 
-from gluon import gluonator
 import sys
+
+from gluon import gluonator
 
 print('Running mainprog from subdir.')
 

--- a/test cases/python3/2 extmodule/blaster.py
+++ b/test cases/python3/2 extmodule/blaster.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-import tachyon
 import sys
+
+import tachyon
 
 result = tachyon.phaserize('shoot')
 

--- a/test cases/python3/3 cython/cytest.py
+++ b/test cases/python3/3 cython/cytest.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-from storer import Storer
 import sys
+
+from storer import Storer
 
 s = Storer()
 

--- a/test cases/unit/5 compiler detection/compiler wrapper.py
+++ b/test cases/unit/5 compiler detection/compiler wrapper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys
 import subprocess
+import sys
 
 sys.exit(subprocess.call(sys.argv[1:]))

--- a/test cases/vala/8 generated sources/src/copy_file.py
+++ b/test cases/vala/8 generated sources/src/copy_file.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys
 import shutil
+import sys
 
 shutil.copyfile(sys.argv[1], sys.argv[2])

--- a/test cases/windows/8 dll versioning/copyfile.py
+++ b/test cases/windows/8 dll versioning/copyfile.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import sys
 import shutil
+import sys
 
 shutil.copyfile(sys.argv[1], sys.argv[2])

--- a/tools/ac_converter.py
+++ b/tools/ac_converter.py
@@ -27,7 +27,6 @@ that are unrelated to configure checks.
 
 import sys
 
-
 # Add stuff here as it is encountered.
 function_data = \
     {'HAVE_FEENABLEEXCEPT': ('feenableexcept', 'fenv.h'),

--- a/tools/cmake2meson.py
+++ b/tools/cmake2meson.py
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, os
+import os
 import re
+import sys
+
 
 class Token:
     def __init__(self, tid, value):

--- a/wraptool.py
+++ b/wraptool.py
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mesonbuild.wrap import wraptool
 import sys
+
+from mesonbuild.wrap import wraptool
 
 sys.exit(wraptool.run(sys.argv[1:]))


### PR DESCRIPTION
In many of the files, the imports are a mess: in seemingly random order, split across lines in weird ways, et c.  

I'd like to use flake8-isort to enforce sane ordering and layout of the imports.  I chose flake8-isort over flake8-import-order because it is built on the separate `isort` command, which can be used to tidy the existing files in an automated way; which makes adopting it much nicer for existing large codebases.

### Issues:

Now, AFAICT, there is no way to tell flake8 which plugins you would like it to use; it simply uses all install plugins.  I've updated `contributing.md` to say to install `flake8-isort`, but there's no hint for existing developers that they need to install anything else, until CI tells them...

Except that SideCI has no way of installing anything.  I emailed their support to verify that I wasn't missing something; I got back "Sorry, SideCI doesn't support Flake8 plugins.  Your opinion is very valuable, so we want to challenge it.  Would you please wait until we announce new features?"  So SideCI won't start warning about this either.

So, what about moving the flake8 run to Travis CI, and ditching SideCI?   Unfortunately, it wouldn't get formatted into the pretty report that SideCI generates anymore.  Also, we'd first have to fix the remaining 4 issues that flake8 complains about.