### PR TITLE
introduce svn wrap support

### DIFF
--- a/docs/markdown/snippets/wrap-svn.md
+++ b/docs/markdown/snippets/wrap-svn.md
@@ -1,0 +1,4 @@
+# wrap-svn
+
+The [Wrap dependency system](Wrap-dependency-system-manual.md) now supports [Subversion](https://subversion.apache.org/) (svn).
+This support is rudimentary. The repository url has to point to a specific (sub)directory containing the `meson.build` file (typically `trunk/`). However, providing a `revision` is supported.

--- a/manual tests/10 svn wrap/meson.build
+++ b/manual tests/10 svn wrap/meson.build
@@ -1,0 +1,10 @@
+project('Subversion outchecker', 'c')
+
+sp = subproject('samplesubproject')
+
+exe = executable('gitprog', 'prog.c',
+include_directories : sp.get_variable('subproj_inc'),
+link_with : sp.get_variable('subproj_lib'),
+)
+
+test('maintest', exe)

--- a/manual tests/10 svn wrap/prog.c
+++ b/manual tests/10 svn wrap/prog.c
@@ -1,0 +1,6 @@
+#include"subproj.h"
+
+int main(int argc, char **argv) {
+    subproj_function();
+    return 0;
+}

--- a/manual tests/10 svn wrap/subprojects/samplesubproject.wrap
+++ b/manual tests/10 svn wrap/subprojects/samplesubproject.wrap
@@ -1,0 +1,4 @@
+[wrap-svn]
+directory=samplesubproject
+url=https://leif.svn.beanstalkapp.com/samplesubproject/trunk
+revision=head

--- a/manual tests/10 svn wrap/subprojects/samplesubproject.wrap
+++ b/manual tests/10 svn wrap/subprojects/samplesubproject.wrap
@@ -1,4 +1,4 @@
 [wrap-svn]
 directory=samplesubproject
-url=https://leif.svn.beanstalkapp.com/samplesubproject/trunk
+url=https://svn.code.sf.net/p/mesonsubproject/code/trunk
 revision=head

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -238,7 +238,6 @@ class Resolver:
         is_there = os.path.isdir(checkoutdir)
         if is_there:
             svn_info_output = subprocess.getoutput(' '.join(['svn', 'info', '--show-item', 'revision', checkoutdir]))
-            current_revno = int(svn_info_output)
             if current_revno == revno:
                 return
 

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 from pathlib import Path
 from . import WrapMode
+from ..mesonlib import Popen_safe
 
 try:
     import ssl

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -237,7 +237,7 @@ class Resolver:
         revno = p.get('revision')
         is_there = os.path.isdir(checkoutdir)
         if is_there:
-            svn_info_output = subprocess.getoutput(' '.join(['svn', 'info', '--show-item', 'revision', checkoutdir]))
+            current_revno = subprocess.getoutput(' '.join(['svn', 'info', '--show-item', 'revision', checkoutdir]))
             if current_revno == revno:
                 return
 

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -248,11 +248,8 @@ class Resolver:
                     subprocess.check_call(['svn', 'update', '-r', revno],
                                           cwd=checkoutdir)
         else:
-            subprocess.check_call(['svn', 'checkout', p.get('url'),
+            subprocess.check_call(['svn', 'checkout', '-r', revno, p.get('url'),
                                    p.get('directory')], cwd=self.subdir_root)
-            if revno.lower() != 'head':
-                subprocess.check_call(['svn', 'checkout', '-r', revno],
-                                      cwd=checkoutdir)
 
     def get_data(self, url):
         blocksize = 10 * 1024

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -237,7 +237,8 @@ class Resolver:
         revno = p.get('revision')
         is_there = os.path.isdir(checkoutdir)
         if is_there:
-            current_revno = subprocess.getoutput(' '.join(['svn', 'info', '--show-item', 'revision', checkoutdir]))
+            p, out = Popen_safe(['svn', 'info', '--show-item', 'revision', checkoutdir])
+            current_revno = out
             if current_revno == revno:
                 return
 

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -237,16 +237,18 @@ class Resolver:
         revno = p.get('revision')
         is_there = os.path.isdir(checkoutdir)
         if is_there:
+            svn_info_output = subprocess.getoutput(' '.join(['svn', 'info', '--show-item', 'revision', checkoutdir]))
+            current_revno = int(svn_info_output)
+            if current_revno == revno:
+                return
+
             if revno.lower() == 'head':
                 # Failure to do pull is not a fatal error,
                 # because otherwise you can't develop without
                 # a working net connection.
                 subprocess.call(['svn', 'update'], cwd=checkoutdir)
             else:
-                if subprocess.call(['svn', 'update', '-r', revno], cwd=checkoutdir) != 0:
-                    subprocess.check_call(['svn', 'update'], cwd=checkoutdir)
-                    subprocess.check_call(['svn', 'update', '-r', revno],
-                                          cwd=checkoutdir)
+                subprocess.check_call(['svn', 'update', '-r', revno], cwd=checkoutdir)
         else:
             subprocess.check_call(['svn', 'checkout', '-r', revno, p.get('url'),
                                    p.get('directory')], cwd=self.subdir_root)


### PR DESCRIPTION
The [Wrap dependency system](Wrap-dependency-system-manual.md) now supports [Subversion](https://subversion.apache.org/) (svn).
This support is rudimentary. The repository url has to point to a specific (sub)directory containing the `meson.build` file (typically `trunk/`). However, providing a `revision` is supported.