### PR TITLE
Fix GNOME gir generation with lists of dependency lists

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -23,7 +23,7 @@ from enum import Enum
 
 from .. import mlog
 from .. import mesonlib
-from ..mesonlib import MesonException, Popen_safe, flatten, version_compare_many, listify
+from ..mesonlib import MesonException, Popen_safe, version_compare_many, listify
 
 
 # These must be defined in this file to avoid cyclical references.
@@ -586,7 +586,7 @@ class ExtraFrameworkDependency(ExternalDependency):
 
 def get_dep_identifier(name, kwargs, want_cross):
     # Need immutable objects since the identifier will be used as a dict key
-    version_reqs = flatten(kwargs.get('version', []))
+    version_reqs = listify(kwargs.get('version', []))
     if isinstance(version_reqs, list):
         version_reqs = frozenset(version_reqs)
     identifier = (name, version_reqs, want_cross)
@@ -599,7 +599,7 @@ def get_dep_identifier(name, kwargs, want_cross):
             continue
         # All keyword arguments are strings, ints, or lists (or lists of lists)
         if isinstance(value, list):
-            value = frozenset(flatten(value))
+            value = frozenset(listify(value))
         identifier += (key, value)
     return identifier
 

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -21,7 +21,7 @@ import shutil
 
 from .. import mlog
 from .. import mesonlib
-from ..mesonlib import version_compare, Popen_safe
+from ..mesonlib import version_compare, Popen_safe, stringlistify, extract_as_list
 from .base import DependencyException, ExternalDependency, PkgConfigDependency
 
 class GTestDependency(ExternalDependency):
@@ -185,7 +185,7 @@ class LLVMDependency(ExternalDependency):
             raise DependencyException('Could not generate modules for LLVM.')
         self.modules = shlex.split(out)
 
-        modules = mesonlib.stringlistify(mesonlib.flatten(kwargs.get('modules', [])))
+        modules = stringlistify(extract_as_list(kwargs, 'modules'))
         for mod in sorted(set(modules)):
             if mod not in self.modules:
                 mlog.log('LLVM module', mod, 'found:', mlog.red('NO'))

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -199,9 +199,6 @@ def classify_unity_sources(compilers, sources):
             compsrclist[comp].append(src)
     return compsrclist
 
-def flatten(item):
-    return listify(item, flatten=True)
-
 def is_osx():
     return platform.system().lower() == 'darwin'
 
@@ -466,34 +463,45 @@ def replace_if_different(dst, dst_tmp):
     else:
         os.unlink(dst_tmp)
 
-
-def listify(item, flatten=True):
+def listify(item, flatten=True, unholder=False):
     '''
-    Returns a list with all args embedded in a list if they are not of type list.
+    Returns a list with all args embedded in a list if they are not a list.
     This function preserves order.
+    @flatten: Convert lists of lists to a flat list
+    @unholder: Replace each item with the object it holds, if required
+
+    Note: unholding only works recursively when flattening
     '''
     if not isinstance(item, list):
+        if unholder and hasattr(item, 'held_object'):
+            item = item.held_object
         return [item]
     result = []
-    if flatten:
-        for i in item:
-            if isinstance(i, list):
-                result += listify(i, flatten=True)
-            else:
-                result.append(i)
-    else:
-        for i in item:
+    for i in item:
+        if unholder and hasattr(i, 'held_object'):
+            i = i.held_object
+        if flatten and isinstance(i, list):
+            result += listify(i, flatten=True, unholder=unholder)
+        else:
             result.append(i)
     return result
 
 
-def extract_as_list(dict_object, *keys, pop=False):
+def extract_as_list(dict_object, *keys, pop=False, **kwargs):
     '''
     Extracts all values from given dict_object and listifies them.
     '''
+    result = []
+    fetch = dict_object.get
     if pop:
-        return flatten([dict_object.pop(key, []) for key in keys])
-    return flatten([dict_object.get(key, []) for key in keys])
+        fetch = dict_object.pop
+    # If there's only one key, we don't return a list with one element
+    if len(keys) == 1:
+        return listify(fetch(keys[0], []), **kwargs)
+    # Return a list of values corresponding to *keys
+    for key in keys:
+        result.append(listify(fetch(key, []), **kwargs))
+    return result
 
 
 def typeslistify(item, types):
@@ -751,15 +759,6 @@ def windows_proof_rmtree(f):
             time.sleep(d)
     # Try one last time and throw if it fails.
     shutil.rmtree(f)
-
-def unholder_array(entries):
-    result = []
-    entries = flatten(entries)
-    for e in entries:
-        if hasattr(e, 'held_object'):
-            e = e.held_object
-        result.append(e)
-    return result
 
 class OrderedSet(collections.MutableSet):
     """A set that preserves the order in which items are added, by first

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -200,15 +200,7 @@ def classify_unity_sources(compilers, sources):
     return compsrclist
 
 def flatten(item):
-    if not isinstance(item, list):
-        return [item]
-    result = []
-    for i in item:
-        if isinstance(i, list):
-            result += flatten(i)
-        else:
-            result.append(i)
-    return result
+    return listify(item, flatten=True)
 
 def is_osx():
     return platform.system().lower() == 'darwin'
@@ -475,23 +467,33 @@ def replace_if_different(dst, dst_tmp):
         os.unlink(dst_tmp)
 
 
-def listify(*args):
+def listify(item, flatten=True):
     '''
     Returns a list with all args embedded in a list if they are not of type list.
     This function preserves order.
     '''
-    if len(args) == 1:  # Special case with one single arg
-        return args[0] if type(args[0]) is list else [args[0]]
-    return [item if type(item) is list else [item] for item in args]
+    if not isinstance(item, list):
+        return [item]
+    result = []
+    if flatten:
+        for i in item:
+            if isinstance(i, list):
+                result += listify(i, flatten=True)
+            else:
+                result.append(i)
+    else:
+        for i in item:
+            result.append(i)
+    return result
 
 
-def extract_as_list(dict_object, *keys, pop = False):
+def extract_as_list(dict_object, *keys, pop=False):
     '''
     Extracts all values from given dict_object and listifies them.
     '''
     if pop:
-        return listify(*[dict_object.pop(key, []) for key in keys])
-    return listify(*[dict_object.get(key, []) for key in keys])
+        return flatten([dict_object.pop(key, []) for key in keys])
+    return flatten([dict_object.get(key, []) for key in keys])
 
 
 def typeslistify(item, types):

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -20,7 +20,7 @@ import os
 import copy
 import subprocess
 from . import ModuleReturnValue
-from ..mesonlib import MesonException, OrderedSet, unholder_array, Popen_safe
+from ..mesonlib import MesonException, OrderedSet, Popen_safe, extract_as_list
 from ..dependencies import Dependency, PkgConfigDependency, InternalDependency
 from .. import mlog
 from .. import mesonlib
@@ -323,7 +323,7 @@ class GnomeModule(ExtensionModule):
         cflags = OrderedSet()
         ldflags = OrderedSet()
         gi_includes = OrderedSet()
-        deps = unholder_array(deps)
+        deps = mesonlib.listify(deps, unholder=True)
 
         for dep in deps:
             if isinstance(dep, InternalDependency):
@@ -415,7 +415,7 @@ class GnomeModule(ExtensionModule):
             raise MesonException('gobject-introspection dependency was not found, gir cannot be generated.')
         ns = kwargs.pop('namespace')
         nsversion = kwargs.pop('nsversion')
-        libsources = mesonlib.flatten(kwargs.pop('sources'))
+        libsources = mesonlib.extract_as_list(kwargs, 'sources', pop=True)
         girfile = '%s-%s.gir' % (ns, nsversion)
         srcdir = os.path.join(state.environment.get_source_dir(), state.subdir)
         builddir = os.path.join(state.environment.get_build_dir(), state.subdir)
@@ -524,7 +524,7 @@ class GnomeModule(ExtensionModule):
                 raise MesonException('Gir export packages must be str or list')
 
         deps = (girtarget.get_all_link_deps() + girtarget.get_external_deps() +
-                unholder_array(kwargs.pop('dependencies', [])))
+                extract_as_list(kwargs, 'dependencies', pop=True, unholder=True))
         # Need to recursively add deps on GirTarget sources from our
         # dependencies and also find the include directories needed for the
         # typelib generation custom target below.
@@ -791,7 +791,7 @@ This will become a hard error in the future.''')
 
     def _get_build_args(self, kwargs, state):
         args = []
-        deps = unholder_array(kwargs.get('dependencies', []))
+        deps = extract_as_list(kwargs, 'dependencies', unholder=True)
         cflags, ldflags, gi_includes = self._get_dependencies_flags(deps, state, include_rpath=True)
         inc_dirs = mesonlib.extract_as_list(kwargs, 'include_directories')
         for incd in inc_dirs:

--- a/test cases/frameworks/7 gnome/gir/meson.build
+++ b/test cases/frameworks/7 gnome/gir/meson.build
@@ -27,7 +27,7 @@ gnome.generate_gir(
   identifier_prefix : 'Meson',
   includes : ['GObject-2.0', 'MesonDep1-1.0'],
   # dep1_dep pulls in dep2_dep for us
-  dependencies : [fake_dep, dep1_dep],
+  dependencies : [[fake_dep, dep1_dep]],
   install : true,
   build_by_default : true,
   # Test that unknown kwargs do not crash the parser.


### PR DESCRIPTION
Also add a repr() for all objects used by the interpreter, which is needed because in some places we include them in logs and the output is totally unusable otherwise.