### PR TITLE
Don't add subproject name when option contain colon

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1713,7 +1713,8 @@ class Interpreter(InterpreterBase):
         except KeyError:
             pass
         if not coredata.is_builtin_option(optname) and self.is_subproject():
-            optname = self.subproject + ':' + optname
+            if ':' not in optname:
+                optname = self.subproject + ':' + optname
         try:
             return self.environment.coredata.user_options[optname].value
         except KeyError:


### PR DESCRIPTION
A project A need depend on options value of subproject project B,
project A can get option of B by get_option('B:some_option'),
this is work fine.

But someone(e.x. project C) need clone project A as their subproject,
meson builddir will raise error: can't find option 'A:B:some_option'

fix issue: #2385 