### PR TITLE
Prevent projects from grabbing other projects' options.

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1700,6 +1700,9 @@ class Interpreter(InterpreterBase):
         if len(args) != 1:
             raise InterpreterException('Argument required for get_option.')
         optname = args[0]
+        if ':' in optname:
+            raise InterpreterException('''Having a colon in option name is forbidden, projects are not allowed
+to directly access options of other subprojects.''')
         try:
             return self.environment.get_coredata().base_options[optname].value
         except KeyError:

--- a/test cases/failing/61 getoption prefix/meson.build
+++ b/test cases/failing/61 getoption prefix/meson.build
@@ -1,0 +1,5 @@
+project('getopt prefix')
+
+subproject('abc')
+
+get_option('abc:foo')

--- a/test cases/failing/61 getoption prefix/subprojects/abc/meson.build
+++ b/test cases/failing/61 getoption prefix/subprojects/abc/meson.build
@@ -1,0 +1,1 @@
+project('abc', 'c')

--- a/test cases/failing/61 getoption prefix/subprojects/abc/meson_options.txt
+++ b/test cases/failing/61 getoption prefix/subprojects/abc/meson_options.txt
@@ -1,0 +1,1 @@
+option('foo', type : 'boolean')


### PR DESCRIPTION
They are supposed to be sandboxed after all.