### PR TITLE
Disallow access options of subprojects

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1713,6 +1713,8 @@ class Interpreter(InterpreterBase):
         except KeyError:
             pass
         if not coredata.is_builtin_option(optname) and self.is_subproject():
+            if ':' in optname:
+                raise InterpreterException('Accessing options "%s" of subprojects is forbidden.' % optname)
             optname = self.subproject + ':' + optname
         try:
             return self.environment.coredata.user_options[optname].value


### PR DESCRIPTION
Subprojects are sandboxed and should not have a way to access other
subprojects' options. The fact that it works currently is a bug.

So acessing options of other subprojects is forbidden and should not even
work.

refer to: issue: #2385 
refer to: PR #2387 