### PR TITLE
Create the .po file with the `update_po` subcommand if it doesn't exist

### DIFF
--- a/mesonbuild/scripts/gettext.py
+++ b/mesonbuild/scripts/gettext.py
@@ -70,7 +70,10 @@ def update_po(src_sub, pkgname, langs):
     potfile = os.path.join(src_sub, pkgname + '.pot')
     for l in langs:
         pofile = os.path.join(src_sub, l + '.po')
-        subprocess.check_call(['msgmerge', '-q', '-o', pofile, pofile, potfile])
+        if os.path.exists(pofile):
+            subprocess.check_call(['msgmerge', '-q', '-o', pofile, pofile, potfile])
+        else:
+            subprocess.check_call(['msginit', '--input', potfile, '--output-file', pofile, '--locale', l, '--no-translator'])
     return 0
 
 def do_install(src_sub, bld_sub, dest, pkgname, langs):


### PR DESCRIPTION
If the .po file is missing, it leads to installation error, so better give a way for the developer to easily create one from the template.