### PR TITLE
Use get_default_include_dirs to detect BOOST_ROOT

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -82,9 +82,6 @@ class BoostDependency(ExternalDependency):
         if 'BOOST_LIBRARYDIR' in os.environ:
             self.libdir = os.environ['BOOST_LIBRARYDIR']
 
-        if self.want_cross and self.boost_root is None and self.incdir is None:
-            raise DependencyException('BOOST_ROOT or BOOST_INCLUDEDIR is needed while cross-compiling')
-
         if self.boost_root is None:
             if mesonlib.is_windows():
                 self.boost_roots = self.detect_win_roots()
@@ -131,7 +128,8 @@ class BoostDependency(ExternalDependency):
         mlog.log('Dependency Boost (%s) found:' % module_str, mlog.green('YES'), info)
 
     def detect_nix_roots(self):
-        return ['/usr/local', '/usr']
+        return [os.path.abspath(os.path.join(x, '..'))
+                for x in self.compiler.get_default_include_dirs()]
 
     def detect_win_roots(self):
         res = []


### PR DESCRIPTION
This removes the need to specify BOOST_ROOT for cross-compilers.

I'm cross-compiling on Fedora which comes with a package for Boost that gets installed in the cross-compilers default path. With this patch it gets detected automatically.

This will also make it easier for someone who has installed a ABI incompatible compiler to `/opt`. Boost from `/usr` shouldn't be mixed with it then.