### PR TITLE
llvm: don't add --system-libs

### DIFF
--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -169,7 +169,7 @@ class LLVMDependency(ExternalDependency):
         self.version = out.strip().rstrip('svn')
 
         p, out = Popen_safe(
-            [self.llvmconfig, '--libs', '--ldflags', '--system-libs'])[:2]
+            [self.llvmconfig, '--libs', '--ldflags'])[:2]
         if p.returncode != 0:
             raise DependencyException('Could not generate libs for LLVM.')
         self.link_args = shlex.split(out)


### PR DESCRIPTION
On LLVM < 4.0 this adds linker arguments like -lm, which we don't want.

Related #2442, 2437