### PR TITLE
LLVM: Fix dynamic vs statically linking.

### DIFF
--- a/docs/markdown/snippets/llvm-static-linking.md
+++ b/docs/markdown/snippets/llvm-static-linking.md
@@ -1,0 +1,8 @@
+# LLVM dependency supports both dynamic and static linking
+
+The LLVM dependency has been improved to consistently use dynamic linking.
+Previously recent version (>= 3.9) would link dynamically while older versions
+would link statically.
+
+Now LLVM also accepts the `static` keyword to enable statically linking to LLVM
+modules instead of dynamically linking.

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -137,6 +137,7 @@ class LLVMDependency(ExternalDependency):
         # the C linker works fine if only using the C API.
         super().__init__('llvm-config', environment, 'cpp', kwargs)
         self.provided_modules = []
+        self.required_modules = set()
         self.llvmconfig = None
         self.__best_found = None
         # FIXME: Support multiple version requirements ala PkgConfigDependency
@@ -180,7 +181,7 @@ class LLVMDependency(ExternalDependency):
         self.check_components(opt_modules, required=False)
 
         p, out = Popen_safe(
-            [self.llvmconfig, '--libs', '--ldflags'])[:2]
+            [self.llvmconfig, '--libs', '--ldflags'] + list(self.required_modules))[:2]
         if p.returncode != 0:
             raise DependencyException('Could not generate libs for LLVM.')
         self.link_args = strip_system_libdirs(environment, shlex.split(out))
@@ -206,6 +207,7 @@ class LLVMDependency(ExternalDependency):
                         raise DependencyException(
                             'Could not find required LLVM Component: {}'.format(mod))
             else:
+                self.required_modules.add(mod)
                 mlog.log('LLVM module', mod, 'found:', mlog.green('YES'))
 
     def check_llvmconfig(self, version_req):

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -188,15 +188,24 @@ class LLVMDependency(ExternalDependency):
         modules = stringlistify(extract_as_list(kwargs, 'modules'))
         self.check_components(modules)
 
-    def check_components(self, modules):
-        """Check for llvm components (modules in meson terms). """
+        opt_modules = stringlistify(extract_as_list(kwargs, 'optional_modules'))
+        self.check_components(opt_modules, required=False)
+
+    def check_components(self, modules, required=True):
+        """Check for llvm components (modules in meson terms).
+
+        The required option is whether the module is required, not whether LLVM
+        is required.
+        """
         for mod in sorted(set(modules)):
             if mod not in self.modules:
-                mlog.log('LLVM module', mod, 'found:', mlog.red('NO'))
-                self.is_found = False
-                if self.required:
-                    raise DependencyException(
-                        'Could not find required LLVM Component: {}'.format(mod))
+                mlog.log('LLVM module', mod, 'found:', mlog.red('NO'),
+                         '(optional)' if not required else '')
+                if required:
+                    self.is_found = False
+                    if self.required:
+                        raise DependencyException(
+                            'Could not find required LLVM Component: {}'.format(mod))
             else:
                 mlog.log('LLVM module', mod, 'found:', mlog.green('YES'))
 

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -186,6 +186,10 @@ class LLVMDependency(ExternalDependency):
         self.modules = shlex.split(out)
 
         modules = stringlistify(extract_as_list(kwargs, 'modules'))
+        self.check_components(modules)
+
+    def check_components(self, modules):
+        """Check for llvm components (modules in meson terms). """
         for mod in sorted(set(modules)):
             if mod not in self.modules:
                 mlog.log('LLVM module', mod, 'found:', mlog.red('NO'))

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -139,6 +139,7 @@ class LLVMDependency(ExternalDependency):
         self.provided_modules = []
         self.required_modules = set()
         self.llvmconfig = None
+        self.static = kwargs.get('static', False)
         self.__best_found = None
         # FIXME: Support multiple version requirements ala PkgConfigDependency
         req_version = kwargs.get('version', None)
@@ -180,8 +181,9 @@ class LLVMDependency(ExternalDependency):
         opt_modules = stringlistify(extract_as_list(kwargs, 'optional_modules'))
         self.check_components(opt_modules, required=False)
 
+        link_args = ['--link-static', '--system-libs'] if self.static else ['--link-shared']
         p, out = Popen_safe(
-            [self.llvmconfig, '--libs', '--ldflags'] + list(self.required_modules))[:2]
+            [self.llvmconfig, '--libs', '--ldflags'] + link_args + list(self.required_modules))[:2]
         if p.returncode != 0:
             raise DependencyException('Could not generate libs for LLVM.')
         self.link_args = strip_system_libdirs(environment, shlex.split(out))

--- a/test cases/frameworks/15 llvm/meson.build
+++ b/test cases/frameworks/15 llvm/meson.build
@@ -13,6 +13,9 @@ assert(d.found() == false, 'not-found llvm module found')
 d = dependency('llvm', version : '<0.1', required : false)
 assert(d.found() == false, 'ancient llvm module found')
 
+d = dependency('llvm', optional_modules : 'not-found', required : false)
+assert(d.found() == true, 'optional module stopped llvm from being found.')
+
 executable('sum', 'sum.c',  dependencies : [
   llvm_dep,
   dependency('zlib'),

--- a/test cases/frameworks/15 llvm/meson.build
+++ b/test cases/frameworks/15 llvm/meson.build
@@ -17,5 +17,5 @@ executable('sum', 'sum.c',  dependencies : [
   llvm_dep,
   dependency('zlib'),
   meson.get_compiler('c').find_library('dl', required : false),
-  dependency('tinfo'),
+  dependency('glib-2.0'),
   ])

--- a/test cases/frameworks/15 llvm/meson.build
+++ b/test cases/frameworks/15 llvm/meson.build
@@ -1,12 +1,5 @@
 project('llvmtest', ['c', 'cpp'], default_options : ['c_std=c99'])
 
-llvm_dep = dependency(
-  'llvm',
-  modules : ['bitwriter', 'asmprinter', 'executionengine', 'target',
-             'mcjit', 'nativecodegen'],
-  required : true,
-)
-
 d = dependency('llvm', modules : 'not-found', required : false)
 assert(d.found() == false, 'not-found llvm module found')
 
@@ -16,9 +9,23 @@ assert(d.found() == false, 'ancient llvm module found')
 d = dependency('llvm', optional_modules : 'not-found', required : false)
 assert(d.found() == true, 'optional module stopped llvm from being found.')
 
-executable('sum', 'sum.c',  dependencies : [
-  llvm_dep,
-  dependency('zlib'),
-  meson.get_compiler('c').find_library('dl', required : false),
-  dependency('glib-2.0'),
-  ])
+foreach static : [true, false]
+  llvm_dep = dependency(
+    'llvm',
+    modules : ['bitwriter', 'asmprinter', 'executionengine', 'target',
+               'mcjit', 'nativecodegen'],
+    required : true,
+    static : static,
+  )
+  name = static ? 'static' : 'dynamic'
+  executable(
+    'sum-@0@'.format(name),
+    'sum.c',
+    dependencies : [
+      llvm_dep,
+      dependency('zlib'),
+      dependency('glib-2.0'),
+      meson.get_compiler('c').find_library('dl', required : false),
+    ]
+  )
+endforeach


### PR DESCRIPTION
This fixes a ciritical bug with LLVM, namely that with LLVM < 3.9 we currently statically link, but for >= 3.9 we dynamically link. That's bad. To fix this I've implemented support for the `static` flag so that users can toggle whether they want static or dynamic linking. On top of that this adds logic to properly handle dynamic linking on LLVM < 3.9 (because llvm-config on those versions can't tell you how to dynamically link).