### PR TITLE
Add system dependencies for LLVM test.

### DIFF
--- a/test cases/frameworks/15 llvm/meson.build
+++ b/test cases/frameworks/15 llvm/meson.build
@@ -13,4 +13,9 @@ assert(d.found() == false, 'not-found llvm module found')
 d = dependency('llvm', version : '<0.1', required : false)
 assert(d.found() == false, 'ancient llvm module found')
 
-executable('sum', 'sum.c',  dependencies : llvm_dep)
+executable('sum', 'sum.c',  dependencies : [
+  llvm_dep,
+  dependency('zlib'),
+  meson.get_compiler('c').find_library('dl', required : false),
+  dependency('tinfo'),
+  ])


### PR DESCRIPTION
Needed on Debian Sid since `--system-libs` is no longer used.