### PR TITLE
Add failing test case for overly-strict sandbox violation (#2481)

### DIFF
--- a/test cases/common/162 subproject dir name collision/a.c
+++ b/test cases/common/162 subproject dir name collision/a.c
@@ -1,0 +1,13 @@
+#include<assert.h>
+char func_b();
+char func_c();
+
+int main(int argc, char **argv) {
+    if(func_b() != 'b') {
+        return 1;
+    }
+    if(func_c() != 'c') {
+        return 2;
+    }
+    return 0;
+}

--- a/test cases/common/162 subproject dir name collision/custom_subproject_dir/B/b.c
+++ b/test cases/common/162 subproject dir name collision/custom_subproject_dir/B/b.c
@@ -1,0 +1,20 @@
+#include<stdlib.h>
+char func_c();
+
+#if defined _WIN32 || defined __CYGWIN__
+#define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+char DLL_PUBLIC func_b() {
+    if(func_c() != 'c') {
+        exit(3);
+    }
+    return 'b';
+}

--- a/test cases/common/162 subproject dir name collision/custom_subproject_dir/B/meson.build
+++ b/test cases/common/162 subproject dir name collision/custom_subproject_dir/B/meson.build
@@ -1,0 +1,4 @@
+project('B', 'c')
+C = subproject('C')
+c = C.get_variable('c')
+b = shared_library('b', 'b.c', link_with : c)

--- a/test cases/common/162 subproject dir name collision/custom_subproject_dir/C/c.c
+++ b/test cases/common/162 subproject dir name collision/custom_subproject_dir/C/c.c
@@ -1,0 +1,14 @@
+#if defined _WIN32 || defined __CYGWIN__
+#define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+char DLL_PUBLIC func_c() {
+    return 'c';
+}

--- a/test cases/common/162 subproject dir name collision/custom_subproject_dir/C/meson.build
+++ b/test cases/common/162 subproject dir name collision/custom_subproject_dir/C/meson.build
@@ -1,0 +1,2 @@
+project('C', 'c')
+c = shared_library('c', 'c.c')

--- a/test cases/common/162 subproject dir name collision/meson.build
+++ b/test cases/common/162 subproject dir name collision/meson.build
@@ -1,0 +1,12 @@
+project('A', 'c', subproject_dir:'custom_subproject_dir')
+
+B = subproject('B')
+b = B.get_variable('b')
+
+C = subproject('C')
+c = C.get_variable('c')
+
+subdir('other_subdir')
+
+a = executable('a', 'a.c', link_with : [b, c])
+test('a test', a)

--- a/test cases/common/162 subproject dir name collision/other_subdir/custom_subproject_dir/other.c
+++ b/test cases/common/162 subproject dir name collision/other_subdir/custom_subproject_dir/other.c
@@ -1,0 +1,19 @@
+#include<stdlib.h>
+
+#if defined _WIN32 || defined __CYGWIN__
+#define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+char DLL_PUBLIC func_b() {
+    if('c' != 'c') {
+        exit(3);
+    }
+    return 'b';
+}

--- a/test cases/common/162 subproject dir name collision/other_subdir/meson.build
+++ b/test cases/common/162 subproject dir name collision/other_subdir/meson.build
@@ -1,0 +1,1 @@
+other = shared_library('other', 'custom_subproject_dir/other.c')


### PR DESCRIPTION
This is a modification of test case `82 custom subproject dir` that illustrates the issue raised in #2481