### PR TITLE
Support parse wrap files ship with subproject

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1667,7 +1667,7 @@ class Interpreter(InterpreterBase):
         if dirname in self.subprojects:
             return self.subprojects[dirname]
         subproject_dir_abs = os.path.join(self.environment.get_source_dir(), self.subproject_dir)
-        r = wrap.Resolver(subproject_dir_abs, self.coredata.wrap_mode)
+        r = wrap.Resolver(subproject_dir_abs, self.build.environment.get_build_dir(), self.coredata.wrap_mode)
         try:
             resolved = r.resolve(dirname)
         except RuntimeError as e:
@@ -2784,7 +2784,6 @@ different subdirectory.
     def run(self):
         super().run()
         mlog.log('Build targets in project:', mlog.bold(str(len(self.build.targets))))
-
 
     # Check that the indicated file is within the same subproject
     # as we currently are. This is to stop people doing


### PR DESCRIPTION
With this feature, main meson project don't
need track and keep all wrap files that ship
whih subprojects now.

Without this, people should uncompress a package,
copy all wrap files to subprojects directory by manually.

This is special usefully when build all packages
from scratch, e.g. cross compile a package to
arm/mips, in this case, hundreds of wrap files
need maintain