### PR TITLE
fix normal path cantain subprojects break configure

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2819,6 +2819,12 @@ different subdirectory.
             raise InterpreterException('Sandbox violation: Tried to grab file %s from a nested subproject.' % segments[-1])
         sproj_name = segments[segments.index(self.subproject_dir) + 1]
         if sproj_name != self.subproject_directory_name:
+            # return when a full file path not belong to any subprojects, but
+            # it contain name 'subprojects' or customized subproject name
+            file_path = os.path.abspath(os.path.join(self.environment.source_dir, subdir, fname))
+            subproject_root = os.path.abspath(os.path.join(self.environment.source_dir, self.subproject_dir))
+            if not file_path.startswith(subproject_root):
+                return
             raise InterpreterException('Sandbox violation: Tried to grab file %s from a different subproject.' % segments[-1])
 
     def source_strings_to_files(self, sources):

--- a/test cases/common/162 wrap file should not failed/meson.build
+++ b/test cases/common/162 wrap file should not failed/meson.build
@@ -1,3 +1,7 @@
 project('mainproj', 'c')
 
 subproject('zlib')
+
+executable('grabprog', files('src/subprojects/prog.c'))
+executable('grabprog2', files('src/subprojects/foo/prog2.c'))
+subdir('src')

--- a/test cases/common/162 wrap file should not failed/src/meson.build
+++ b/test cases/common/162 wrap file should not failed/src/meson.build
@@ -1,0 +1,2 @@
+executable('grabprog3', files('subprojects/prog.c'))
+executable('grabprog4', files('subprojects/foo/prog2.c'))

--- a/test cases/common/162 wrap file should not failed/src/subprojects/foo/prog2.c
+++ b/test cases/common/162 wrap file should not failed/src/subprojects/foo/prog2.c
@@ -1,0 +1,7 @@
+#include<stdio.h>
+
+int main(int argc, char **argv) {
+    printf("Do not have a file layout like this in your own projects.\n");
+    printf("This is only to test that this works.\n");
+    return 0;
+}

--- a/test cases/common/162 wrap file should not failed/src/subprojects/prog.c
+++ b/test cases/common/162 wrap file should not failed/src/subprojects/prog.c
@@ -1,0 +1,7 @@
+#include<stdio.h>
+
+int main(int argc, char **argv) {
+    printf("Do not have a file layout like this in your own projects.\n");
+    printf("This is only to test that this works.\n");
+    return 0;
+}

--- a/test cases/common/162 wrap file should not failed/subprojects/zlib-1.2.8/foo.c
+++ b/test cases/common/162 wrap file should not failed/subprojects/zlib-1.2.8/foo.c
@@ -1,0 +1,3 @@
+int dummy_func() {
+    return 42;
+}

--- a/test cases/failing/63 subproj filegrab/meson.build
+++ b/test cases/failing/63 subproj filegrab/meson.build
@@ -1,3 +1,5 @@
 project('mainproj', 'c')
 
+# Try to grab a file from a parent project.
+
 subproject('a')

--- a/test cases/failing/64 grab subproj/meson.build
+++ b/test cases/failing/64 grab subproj/meson.build
@@ -1,0 +1,7 @@
+project('grabber', 'c')
+
+# Try to grab a file from a child subproject.
+
+subproject('foo')
+
+executable('foo', 'subprojects/foo/sub.c')

--- a/test cases/failing/64 grab subproj/subprojects/foo/meson.build
+++ b/test cases/failing/64 grab subproj/subprojects/foo/meson.build
@@ -1,0 +1,3 @@
+project('foo', 'c')
+
+message('I do nothing.')

--- a/test cases/failing/64 grab subproj/subprojects/foo/sub.c
+++ b/test cases/failing/64 grab subproj/subprojects/foo/sub.c
@@ -1,0 +1,6 @@
+#include<stdio.h>
+
+int main(int argc, char **argv) {
+    printf("I am a subproject executable file.\n");
+    return 0;
+}

--- a/test cases/failing/65 grab sibling/meson.build
+++ b/test cases/failing/65 grab sibling/meson.build
@@ -1,0 +1,3 @@
+project('master', 'c')
+
+subproject('a')

--- a/test cases/failing/65 grab sibling/subprojects/a/meson.build
+++ b/test cases/failing/65 grab sibling/subprojects/a/meson.build
@@ -1,0 +1,3 @@
+project('a', 'c')
+
+executable('sneaky', '../b/sneaky.c')

--- a/test cases/failing/65 grab sibling/subprojects/b/meson.build
+++ b/test cases/failing/65 grab sibling/subprojects/b/meson.build
@@ -1,0 +1,3 @@
+projecT('b', 'c')
+
+message('I do nothing.')

--- a/test cases/failing/65 grab sibling/subprojects/b/sneaky.c
+++ b/test cases/failing/65 grab sibling/subprojects/b/sneaky.c
@@ -1,0 +1,6 @@
+#include<stdio.h>
+
+int main(int argc, char **argv) {
+    printf("I can only come into existance via trickery.\n");
+    return 0;
+}


### PR DESCRIPTION
some normalize path contain name 'subprojects' or
custom subproject name, the file will be treat
as that belong to a subproject.

fix #2481