### PR TITLE
Add possibility to run Python scripts with current interpreter

### DIFF
--- a/docs/markdown/snippets/builtin-python.md
+++ b/docs/markdown/snippets/builtin-python.md
@@ -1,0 +1,9 @@
+# Embedded Python in Windows MSI packages
+
+Meson now ships an internal version of Python in the MSI installer packages.
+This means that it can run Python scripts that are part of your build
+transparently. That is, if you do the following:
+
+    myprog = find_program('myscript.py')
+
+Then Meson will run the script with its internal Python version if necessary.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2524,7 +2524,7 @@ rule FORTRAN_DEP_HACK
         gcno_elem = NinjaBuildElement(self.all_outputs, 'meson-clean-gcno', 'CUSTOM_COMMAND', 'PHONY')
         script_root = self.environment.get_script_dir()
         clean_script = os.path.join(script_root, 'delwithsuffix.py')
-        gcno_elem.add_item('COMMAND', [sys.executable, clean_script, '.', 'gcno'])
+        gcno_elem.add_item('COMMAND', mesonlib.python_command + [clean_script, '.', 'gcno'])
         gcno_elem.add_item('description', 'Deleting gcno files.')
         gcno_elem.write(outfile)
         # Alias that runs the target defined above
@@ -2533,7 +2533,7 @@ rule FORTRAN_DEP_HACK
         gcda_elem = NinjaBuildElement(self.all_outputs, 'meson-clean-gcda', 'CUSTOM_COMMAND', 'PHONY')
         script_root = self.environment.get_script_dir()
         clean_script = os.path.join(script_root, 'delwithsuffix.py')
-        gcda_elem.add_item('COMMAND', [sys.executable, clean_script, '.', 'gcda'])
+        gcda_elem.add_item('COMMAND', mesonlib.python_command + [clean_script, '.', 'gcda'])
         gcda_elem.add_item('description', 'Deleting gcda files.')
         gcda_elem.write(outfile)
         # Alias that runs the target defined above

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -396,10 +396,11 @@ class Vs2010Backend(backends.Backend):
         action = ET.SubElement(root, 'ItemDefinitionGroup')
         customstep = ET.SubElement(action, 'PostBuildEvent')
         cmd_raw = [target.command] + target.args
-        cmd = [sys.executable, os.path.join(self.environment.get_script_dir(), 'commandrunner.py'),
-               self.environment.get_build_dir(),
-               self.environment.get_source_dir(),
-               self.get_target_dir(target)] + self.environment.get_build_command()
+        cmd = mesonlib.python_command +
+            [os.path.join(self.environment.get_script_dir(), 'commandrunner.py'),
+             self.environment.get_build_dir(),
+             self.environment.get_source_dir(),
+             self.get_target_dir(target)] + self.environment.get_build_command()
         for i in cmd_raw:
             if isinstance(i, build.BuildTarget):
                 cmd.append(os.path.join(self.environment.get_build_dir(), self.get_target_filename(i)))

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -23,7 +23,7 @@ from .. import dependencies
 from .. import mlog
 from .. import compilers
 from ..compilers import CompilerArgs
-from ..mesonlib import MesonException, File
+from ..mesonlib import MesonException, File, python_command
 from ..environment import Environment
 
 def autodetect_vs_version(build):
@@ -396,7 +396,7 @@ class Vs2010Backend(backends.Backend):
         action = ET.SubElement(root, 'ItemDefinitionGroup')
         customstep = ET.SubElement(action, 'PostBuildEvent')
         cmd_raw = [target.command] + target.args
-        cmd = mesonlib.python_command +
+        cmd = python_command + \
             [os.path.join(self.environment.get_script_dir(), 'commandrunner.py'),
              self.environment.get_build_dir(),
              self.environment.get_source_dir(),

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -567,7 +567,7 @@ class XCodeBackend(backends.Backend):
         self.write_line('shellPath = /bin/sh;')
         script_root = self.environment.get_script_dir()
         test_script = os.path.join(script_root, 'meson_test.py')
-        cmd = [sys.executable, test_script, test_data, '--wd', self.environment.get_build_dir()]
+        cmd = mesonlib.python_command[test_script, test_data, '--wd', self.environment.get_build_dir()]
         cmdstr = ' '.join(["'%s'" % i for i in cmd])
         self.write_line('shellScript = "%s";' % cmdstr)
         self.write_line('showEnvVarsInLog = 0;')

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -567,7 +567,7 @@ class XCodeBackend(backends.Backend):
         self.write_line('shellPath = /bin/sh;')
         script_root = self.environment.get_script_dir()
         test_script = os.path.join(script_root, 'meson_test.py')
-        cmd = mesonlib.python_command[test_script, test_data, '--wd', self.environment.get_build_dir()]
+        cmd = mesonlib.python_command + [test_script, test_data, '--wd', self.environment.get_build_dir()]
         cmdstr = ' '.join(["'%s'" % i for i in cmd])
         self.write_line('shellScript = "%s";' % cmdstr)
         self.write_line('showEnvVarsInLog = 0;')

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -434,7 +434,7 @@ class ExternalProgram:
                         commands = commands[1:]
                     # Windows does not ship python3.exe, but we know the path to it
                     if len(commands) > 0 and commands[0] == 'python3':
-                        commands[0] = sys.executable
+                        commands = mesonlib.python_command + commands[1:]
                 return commands + [script]
         except Exception:
             pass

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -325,14 +325,10 @@ class Environment:
         return self.coredata
 
     def get_build_command(self, unbuffered=False):
-        # If running an executable created with cx_freeze,
-        # Python might not be installed so don't prefix
-        # the command with it.
-        if sys.executable.endswith('meson.exe'):
-            return [sys.executable]
-        if unbuffered:
-            [sys.executable, '-u', self.meson_script_launcher]
-        return [sys.executable, self.meson_script_launcher]
+        cmd = mesonlib.meson_command[:]
+        if unbuffered and 'python' in cmd[0]:
+            cmd = [cmd[0],'-u'] + cmd[1:]
+        return cmd
 
     def is_header(self, fname):
         return is_header(fname)

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -327,7 +327,7 @@ class Environment:
     def get_build_command(self, unbuffered=False):
         cmd = mesonlib.meson_command[:]
         if unbuffered and 'python' in cmd[0]:
-            cmd = [cmd[0],'-u'] + cmd[1:]
+            cmd.insert(1, '-u')
         return cmd
 
     def is_header(self, fname):

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -22,6 +22,15 @@ import collections
 
 from glob import glob
 
+if sys.executable.endswith('meson.exe'):
+    # In Windows and using the MSI installed executable.
+    meson_command = [sys.executable]
+    python_command = [sys.executable, 'runpython']
+else:
+    meson_command = [sys.executable, os.path.join(os.path.split(__file__)[0], '..', 'meson.py')]
+    python_command = [sys.executable]
+
+
 # Put this in objects that should not get dumped to pickle files
 # by accident.
 import threading

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -22,12 +22,12 @@ import collections
 
 from glob import glob
 
-if sys.executable.endswith('meson.exe'):
+if os.path.basename(sys.executable) == 'meson.exe':
     # In Windows and using the MSI installed executable.
     meson_command = [sys.executable]
     python_command = [sys.executable, 'runpython']
 else:
-    meson_command = [sys.executable, os.path.join(os.path.split(__file__)[0], '..', 'meson.py')]
+    meson_command = [sys.executable, os.path.join(os.path.dirname(__file__), '..', 'meson.py')]
     python_command = [sys.executable]
 
 

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -155,7 +155,7 @@ class MesonApp:
 
     def _generate(self, env):
         mlog.debug('Build started at', datetime.datetime.now().isoformat())
-        mlog.debug('Python binary:', sys.executable)
+        mlog.debug('Main binary:', sys.executable)
         mlog.debug('Python system:', platform.system())
         mlog.log(mlog.bold('The Meson build system'))
         self.check_pkgconfig_envvar(env)

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -23,12 +23,9 @@ from . import mlog, coredata
 from .mesonlib import MesonException
 from .wrap import WrapMode, wraptool
 
-
-parser = argparse.ArgumentParser(prog='meson')
-
 default_warning = '1'
 
-def add_builtin_argument(name, **kwargs):
+def add_builtin_argument(p, name, **kwargs):
     k = kwargs.get('dest', name.replace('-', '_'))
     c = coredata.get_builtin_option_choices(k)
     b = True if kwargs.get('action', None) in ['store_true', 'store_false'] else False
@@ -42,31 +39,45 @@ def add_builtin_argument(name, **kwargs):
         kwargs['default'] = default
     else:
         kwargs['default'] = argparse.SUPPRESS
-    parser.add_argument('--' + name, help=h, **kwargs)
+    p.add_argument('--' + name, help=h, **kwargs)
 
-add_builtin_argument('prefix')
-add_builtin_argument('libdir')
-add_builtin_argument('libexecdir')
-add_builtin_argument('bindir')
-add_builtin_argument('sbindir')
-add_builtin_argument('includedir')
-add_builtin_argument('datadir')
-add_builtin_argument('mandir')
-add_builtin_argument('infodir')
-add_builtin_argument('localedir')
-add_builtin_argument('sysconfdir')
-add_builtin_argument('localstatedir')
-add_builtin_argument('sharedstatedir')
-add_builtin_argument('backend')
-add_builtin_argument('buildtype')
-add_builtin_argument('strip', action='store_true')
-add_builtin_argument('unity')
-add_builtin_argument('werror', action='store_true')
-add_builtin_argument('layout')
-add_builtin_argument('default-library')
-add_builtin_argument('warnlevel', dest='warning_level')
-add_builtin_argument('stdsplit', action='store_false')
-add_builtin_argument('errorlogs', action='store_false')
+def create_parser():
+    p = argparse.ArgumentParser(prog='meson')
+    add_builtin_argument(p, 'prefix')
+    add_builtin_argument(p, 'libdir')
+    add_builtin_argument(p, 'libexecdir')
+    add_builtin_argument(p, 'bindir')
+    add_builtin_argument(p, 'sbindir')
+    add_builtin_argument(p, 'includedir')
+    add_builtin_argument(p, 'datadir')
+    add_builtin_argument(p, 'mandir')
+    add_builtin_argument(p, 'infodir')
+    add_builtin_argument(p, 'localedir')
+    add_builtin_argument(p, 'sysconfdir')
+    add_builtin_argument(p, 'localstatedir')
+    add_builtin_argument(p, 'sharedstatedir')
+    add_builtin_argument(p, 'backend')
+    add_builtin_argument(p, 'buildtype')
+    add_builtin_argument(p, 'strip', action='store_true')
+    add_builtin_argument(p, 'unity')
+    add_builtin_argument(p, 'werror', action='store_true')
+    add_builtin_argument(p, 'layout')
+    add_builtin_argument(p, 'default-library')
+    add_builtin_argument(p, 'warnlevel', dest='warning_level')
+    add_builtin_argument(p, 'stdsplit', action='store_false')
+    add_builtin_argument(p, 'errorlogs', action='store_false')
+    p.add_argument('--cross-file', default=None,
+                   help='File describing cross compilation environment.')
+    p.add_argument('-D', action='append', dest='projectoptions', default=[], metavar="option",
+                   help='Set the value of an option, can be used several times to set multiple options.')
+    p.add_argument('-v', '--version', action='version',
+                   version=coredata.version)
+    # See the mesonlib.WrapMode enum for documentation
+    p.add_argument('--wrap-mode', default=WrapMode.default,
+                   type=wrapmodetype, choices=WrapMode,
+                   help='Special wrap mode to use')
+    p.add_argument('directories', nargs='*')
+    return p
 
 def wrapmodetype(string):
     try:
@@ -75,18 +86,6 @@ def wrapmodetype(string):
         msg = ', '.join([t.name.lower() for t in WrapMode])
         msg = 'invalid argument {!r}, use one of {}'.format(string, msg)
         raise argparse.ArgumentTypeError(msg)
-
-parser.add_argument('--cross-file', default=None,
-                    help='File describing cross compilation environment.')
-parser.add_argument('-D', action='append', dest='projectoptions', default=[], metavar="option",
-                    help='Set the value of an option, can be used several times to set multiple options.')
-parser.add_argument('-v', '--version', action='version',
-                    version=coredata.version)
-# See the mesonlib.WrapMode enum for documentation
-parser.add_argument('--wrap-mode', default=WrapMode.default,
-                    type=wrapmodetype, choices=WrapMode,
-                    help='Special wrap mode to use')
-parser.add_argument('directories', nargs='*')
 
 class MesonApp:
 
@@ -278,12 +277,13 @@ def run_script_command(args):
         raise MesonException('Unknown internal command {}.'.format(cmdname))
     return cmdfunc(cmdargs)
 
-def run(args, mainfile=None):
+def run(original_args, mainfile=None):
     if sys.version_info < (3, 4):
         print('Meson works correctly only with python 3.4+.')
         print('You have python %s.' % sys.version)
         print('Please update your environment')
         return 1
+    args = original_args[:]
     if len(args) > 0:
         # First check if we want to run a subcommand.
         cmd_name = args[0]
@@ -325,6 +325,8 @@ def run(args, mainfile=None):
     else:
         handshake = False
 
+    parser = create_parser()
+
     args = mesonlib.expand_arguments(args)
     options = parser.parse_args(args)
     args = options.directories
@@ -348,7 +350,7 @@ def run(args, mainfile=None):
     try:
         if mainfile is None:
             raise AssertionError('I iz broken. Sorry.')
-        app = MesonApp(dir1, dir2, mainfile, handshake, options, sys.argv)
+        app = MesonApp(dir1, dir2, mainfile, handshake, options, original_args)
     except Exception as e:
         # Log directory does not exist, so just print
         # to stdout.

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -303,6 +303,12 @@ def run(args, mainfile=None):
             return mconf.run(remaining_args)
         elif cmd_name == 'wrap':
             return wraptool.run(remaining_args)
+        elif cmd_name == 'runpython':
+            import runpy
+            script_file = remaining_args[0]
+            sys.argv[1:] = remaining_args[1:]
+            runpy.run_path(script_file, run_name='__main__')
+            sys.exit(0)
 
     # No special command? Do the basic setup/reconf.
     if len(args) >= 2 and args[0] == '--internal':

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -52,7 +52,7 @@ class Python3Module(ExtensionModule):
 
     @noKwargs
     def find_python(self, state, args, kwargs):
-        py3 = dependencies.ExternalProgram('python3', sys.executable, silent=True)
+        py3 = dependencies.ExternalProgram('python3', mesonlib.python_command, silent=True)
         return ModuleReturnValue(py3, [py3])
 
     @noKwargs

--- a/mesonbuild/scripts/regen_checker.py
+++ b/mesonbuild/scripts/regen_checker.py
@@ -32,15 +32,11 @@ def need_regen(regeninfo, regen_timestamp):
     return False
 
 def regen(regeninfo, mesonscript, backend):
-    if sys.executable.lower().endswith('meson.exe'):
-        cmd_exe = [sys.executable]
-    else:
-        cmd_exe = [sys.executable, mesonscript]
-    cmd = cmd_exe + ['--internal',
-           'regenerate',
-           regeninfo.build_dir,
-           regeninfo.source_dir,
-           '--backend=' + backend]
+    cmd = mesonlib.meson_command + ['--internal',
+                                    'regenerate',
+                                    regeninfo.build_dir,
+                                    regeninfo.source_dir,
+                                    '--backend=' + backend]
     subprocess.check_call(cmd)
 
 def run(args):

--- a/mesonbuild/scripts/regen_checker.py
+++ b/mesonbuild/scripts/regen_checker.py
@@ -14,6 +14,7 @@
 
 import sys, os
 import pickle, subprocess
+from mesonbuild.mesonlib import meson_command
 
 # This could also be used for XCode.
 
@@ -32,11 +33,11 @@ def need_regen(regeninfo, regen_timestamp):
     return False
 
 def regen(regeninfo, mesonscript, backend):
-    cmd = mesonlib.meson_command + ['--internal',
-                                    'regenerate',
-                                    regeninfo.build_dir,
-                                    regeninfo.source_dir,
-                                    '--backend=' + backend]
+    cmd = meson_command + ['--internal',
+                           'regenerate',
+                           regeninfo.build_dir,
+                           regeninfo.source_dir,
+                           '--backend=' + backend]
     subprocess.check_call(cmd)
 
 def run(args):

--- a/msi/createmsi.py
+++ b/msi/createmsi.py
@@ -17,6 +17,7 @@
 import sys, os, subprocess, shutil, uuid
 from glob import glob
 import platform
+import shutil
 import xml.etree.ElementTree as ET
 
 sys.path.append(os.getcwd())
@@ -82,9 +83,7 @@ class PackageGenerator:
         modules = [os.path.splitext(os.path.split(x)[1])[0] for x in glob(os.path.join('mesonbuild/modules/*'))]
         modules = ['mesonbuild.modules.' + x for x in modules if not x.startswith('_')]
         modulestr = ','.join(modules)
-        python = 'c:\\Python\python.exe'
-        if sys.executable:
-            python = sys.executable
+        python = shutil.which('python')
         cxfreeze = os.path.join(os.path.dirname(python), "Scripts", "cxfreeze")
         if not os.path.isfile(cxfreeze):
             print("ERROR: This script requires cx_freeze module")

--- a/msi/createmsi.py
+++ b/msi/createmsi.py
@@ -17,7 +17,6 @@
 import sys, os, subprocess, shutil, uuid
 from glob import glob
 import platform
-import shutil
 import xml.etree.ElementTree as ET
 
 sys.path.append(os.getcwd())

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -603,7 +603,7 @@ def check_meson_commands_work():
     testdir = 'test cases/common/1 trivial'
     with AutoDeletedDir(tempfile.mkdtemp(prefix='b ', dir='.')) as build_dir:
         print('Checking that configuring works...')
-        gen_cmd = [sys.executable, meson_command, testdir, build_dir] + backend_flags
+        gen_cmd = mesonlib.meson_command + [testdir, build_dir] + backend_flags
         pc, o, e = Popen_safe(gen_cmd)
         if pc.returncode != 0:
             raise RuntimeError('Failed to configure {!r}:\n{}\n{}'.format(testdir, e, o))

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -33,7 +33,7 @@ import time
 import multiprocessing
 import concurrent.futures as conc
 import re
-from run_unittests import get_fake_options, run_configure_inprocess
+from run_unittests import get_fake_options, run_configure
 
 from run_tests import get_backend_commands, get_backend_args_for_dir, Backend
 from run_tests import ensure_backend_detects_changes
@@ -327,9 +327,9 @@ def _run_test(testdir, test_build_dir, install_dir, extra_args, compiler, backen
     test_args = parse_test_args(testdir)
     gen_start = time.time()
     # Configure in-process
-    gen_command = [meson_command, '--prefix', '/usr', '--libdir', 'lib', testdir, test_build_dir]\
+    gen_args = ['--prefix', '/usr', '--libdir', 'lib', testdir, test_build_dir]\
         + flags + test_args + extra_args
-    (returncode, stdo, stde) = run_configure_inprocess(gen_command)
+    (returncode, stdo, stde) = run_configure(meson_command, gen_args)
     try:
         logfile = os.path.join(test_build_dir, 'meson-logs/meson-log.txt')
         with open(logfile, errors='ignore') as f:

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -322,13 +322,30 @@ def run_test(skipped, testdir, extra_args, compiler, backend, flags, commands, s
             finally:
                 mlog.shutdown() # Close the log file because otherwise Windows wets itself.
 
+def pass_prefix_to_test(dirname):
+    if '40 prefix' in dirname:
+        return False
+    return True
+
+def pass_libdir_to_test(dirname):
+    if '8 install' in dirname:
+        return False
+    if '39 libdir' in dirname:
+        return False
+    return True
+
 def _run_test(testdir, test_build_dir, install_dir, extra_args, compiler, backend, flags, commands, should_fail):
     compile_commands, clean_commands, install_commands, uninstall_commands = commands
     test_args = parse_test_args(testdir)
     gen_start = time.time()
     # Configure in-process
-    gen_args = ['--prefix', '/usr', '--libdir', 'lib', testdir, test_build_dir]\
-        + flags + test_args + extra_args
+    if pass_prefix_to_test(testdir):
+        gen_args = ['--prefix', '/usr']
+    else:
+        gen_args = []
+    if pass_libdir_to_test(testdir):
+        gen_args += ['--libdir', 'lib']
+    gen_args += [testdir, test_build_dir] + flags + test_args + extra_args
     (returncode, stdo, stde) = run_configure(meson_command, gen_args)
     try:
         logfile = os.path.join(test_build_dir, 'meson-logs/meson-log.txt')

--- a/run_tests.py
+++ b/run_tests.py
@@ -223,11 +223,12 @@ if __name__ == '__main__':
                         'coverage.process_startup()\n')
             env['COVERAGE_PROCESS_START'] = '.coveragerc'
             env['PYTHONPATH'] = os.pathsep.join([td] + env.get('PYTHONPATH', []))
-        returncode += subprocess.call([sys.executable, 'run_unittests.py', '-v'], env=env)
+        returncode += subprocess.call(mesonlib.python_command + ['run_unittests.py', '-v'], env=env)
         # Ubuntu packages do not have a binary without -6 suffix.
         if should_run_linux_cross_tests():
             print(mlog.bold('Running cross compilation tests.').get_text(mlog.colorize_console))
             print()
-            returncode += subprocess.call([sys.executable, 'run_cross_test.py', 'cross/ubuntu-armhf.txt'], env=env)
-        returncode += subprocess.call([sys.executable, 'run_project_tests.py'] + sys.argv[1:], env=env)
+            returncode += subprocess.call(mesonlib.python_command + ['run_cross_test.py', 'cross/ubuntu-armhf.txt'],
+                                          env=env)
+        returncode += subprocess.call(mesonlib.python_command + ['run_project_tests.py'] + sys.argv[1:], env=env)
     sys.exit(returncode)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -40,7 +40,7 @@ from mesonbuild.dependencies import PkgConfigDependency, ExternalProgram
 
 from run_tests import exe_suffix, get_fake_options, FakeEnvironment
 from run_tests import get_builddir_target_args, get_backend_commands, Backend
-from run_tests import ensure_backend_detects_changes, run_configure_inprocess
+from run_tests import ensure_backend_detects_changes, run_configure
 from run_tests import should_run_linux_cross_tests
 
 
@@ -460,8 +460,9 @@ class BasePlatformTests(unittest.TestCase):
         # Get the backend
         # FIXME: Extract this from argv?
         self.backend = getattr(Backend, os.environ.get('MESON_UNIT_TEST_BACKEND', 'ninja'))
-        self.meson_args = [os.path.join(src_root, 'meson.py'), '--backend=' + self.backend.name]
-        self.meson_command = [sys.executable] + self.meson_args
+        self.meson_mainfile = os.path.join(src_root, 'meson.py')
+        self.meson_args = ['--backend=' + self.backend.name]
+        self.meson_command = [sys.executable, self.meson_mainfile] + self.meson_args
         self.mconf_command = [sys.executable, os.path.join(src_root, 'meson.py'), 'configure']
         self.mintro_command = [sys.executable, os.path.join(src_root, 'meson.py'), 'introspect']
         self.mtest_command = [sys.executable, os.path.join(src_root, 'meson.py'), 'test', '-C', self.builddir]
@@ -527,7 +528,7 @@ class BasePlatformTests(unittest.TestCase):
         self.privatedir = os.path.join(self.builddir, 'meson-private')
         if inprocess:
             try:
-                out = run_configure_inprocess(self.meson_args + args + extra_args)[1]
+                out = run_configure(self.meson_mainfile, self.meson_args + args + extra_args)[1]
             except:
                 self._print_meson_log()
                 raise

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -41,7 +41,7 @@ from mesonbuild.dependencies import PkgConfigDependency, ExternalProgram
 
 from run_tests import exe_suffix, get_fake_options, FakeEnvironment
 from run_tests import get_builddir_target_args, get_backend_commands, Backend
-from run_tests import ensure_backend_detects_changes, run_configure
+from run_tests import ensure_backend_detects_changes, run_configure, meson_exe
 from run_tests import should_run_linux_cross_tests
 
 
@@ -1588,6 +1588,9 @@ class FailureTests(BasePlatformTests):
         Assert that running meson configure on the specified @contents raises
         a error message matching regex @match.
         '''
+        if meson_exe is not None:
+            # Because the exception happens in a different process.
+            raise unittest.SkipTest('Can not test assert raise tests with an external Meson command.')
         if langs is None:
             langs = []
         with open(self.mbuild, 'w') as f:


### PR DESCRIPTION
When using the MSI installer version, Python might not be available on the current system (or it might be the wrong version). Thus add functionality to run Python scripts with the embedded interpreter.

This is not finished yet. I need to fix all places where `sys.executable` is being used. Just putting this here to run through CI first and to gather comments.