### PR TITLE
Add method to get values from config tool based dependency

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -178,32 +178,22 @@ the list of sources for the target. The `modules` keyword of
 `dependency` works just like it does with Boost. It tells which
 subparts of Qt the program uses.
 
-## Pcap
+## Dependencies using config tools
 
-The pcap library does not ship with pkg-config at the time or writing
-but instead it has its own `pcap-config` util. Meson will use it
-automatically:
+CUPS, LLVM, PCAP, WxWidgets, libwmf, and GnuStep either do not provide
+pkg-config modules or additionally can be detected via a config tool
+(cups-config, llvm-config, etc). Meson has native support for these tools, and
+then can be found like other dependencies:
 
 ```meson
 pcap_dep = dependency('pcap', version : '>=1.0')
-```
-
-## CUPS
-
-The cups library does not ship with pkg-config at the time or writing
-but instead it has its own `cups-config` util. Meson will use it
-automatically:
-
-```meson
 cups_dep = dependency('cups', version : '>=1.4')
+llvm_dep = dependency('llvm', version : '>=4.0')
 ```
 
-## LibWMF
-
-The libwmf library does not ship with pkg-config at the time or writing
-but instead it has its own `libwmf-config` util. Meson will use it
-automatically:
+Some of these tools (like wmf and cups) provide both pkg-config and config
+tools support. You can force one or another via the method keyword:
 
 ```meson
-libwmf_dep = dependency('libwmf', version : '>=0.2.8')
+wmf_dep = dependency('wmf', method : 'config-tool')
 ```

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1608,6 +1608,10 @@ an external dependency with the following methods:
    pkg-config variable specified, or, if invoked on a non pkg-config
    dependency, error out
 
+ - `get_configtool_variable(varname)` (*Added 0.44.0*) will get the 
+   command line argument from the config tool (with `--` prepended), or,
+   if invoked on a non config-tool dependency, error out.
+
  - `type_name()` which returns a string describing the type of the
    dependency, the most common values are `internal` for deps created
    with `declare_dependencies` and `pkgconfig` for system dependencies

--- a/docs/markdown/snippets/config-tool-variable-method.md
+++ b/docs/markdown/snippets/config-tool-variable-method.md
@@ -1,0 +1,11 @@
+# Config-Tool based dependencies gained a method to get arbitrary options
+
+A number of dependencies (CUPS, LLVM, pcap, WxWidgets, GnuStep) use a config
+tool instead of pkg-config. As of this version they now have a
+`get_configtool_variable` method, which is analogous to the
+`get_pkgconfig_variable` for pkg config.
+
+```meson
+dep_llvm = dependency('LLVM')
+llvm_inc_dir = dep_llvm.get_configtool_variable('includedir')
+```

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -46,8 +46,6 @@ class DependencyMethods(Enum):
     QMAKE = 'qmake'
     # Just specify the standard link arguments, assuming the operating system provides the library.
     SYSTEM = 'system'
-    # Detect using pcap-config
-    PCAPCONFIG = 'pcap-config'
     # Detect using libwmf-config
     LIBWMFCONFIG = 'libwmf-config'
     # This is only supported on OSX - search the frameworks directory by name.
@@ -59,6 +57,7 @@ class DependencyMethods(Enum):
     # For backewards compatibility
     SDLCONFIG = 'sdlconfig'
     CUPSCONFIG = 'cups-config'
+    PCAPCONFIG = 'pcap-config'
 
 
 class Dependency:
@@ -78,7 +77,8 @@ class Dependency:
 
         # This sets per-too config methods which are deprecated to to the new
         # generic CONFIG_TOOL value.
-        if method in [DependencyMethods.SDLCONFIG, DependencyMethods.CUPSCONFIG]:
+        if method in [DependencyMethods.SDLCONFIG, DependencyMethods.CUPSCONFIG,
+                      DependencyMethods.PCAPCONFIG]:
             mlog.warning(textwrap.dedent("""\
                 Configuration method {} has been deprecated in favor of
                 'config-tool'. This will be removed in a future version of

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -247,11 +247,12 @@ class ConfigToolDependency(ExternalDependency):
         return True
 
     def get_config_value(self, args, stage):
-        p, out, _ = Popen_safe([self.config] + args)
+        p, out, err = Popen_safe([self.config] + args)
         if p.returncode != 0:
             if self.required:
-                raise DependencyException('Could not generate {} for {}'.format(
-                    stage, self.name))
+                raise DependencyException(
+                    'Could not generate {} for {}.\n{}'.format(
+                        stage, self.name, err))
             return []
         return shlex.split(out)
 

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -48,8 +48,6 @@ class DependencyMethods(Enum):
     SYSTEM = 'system'
     # Detect using pcap-config
     PCAPCONFIG = 'pcap-config'
-    # Detect using cups-config
-    CUPSCONFIG = 'cups-config'
     # Detect using libwmf-config
     LIBWMFCONFIG = 'libwmf-config'
     # This is only supported on OSX - search the frameworks directory by name.
@@ -60,6 +58,7 @@ class DependencyMethods(Enum):
     CONFIG_TOOL = 'config-tool'
     # For backewards compatibility
     SDLCONFIG = 'sdlconfig'
+    CUPSCONFIG = 'cups-config'
 
 
 class Dependency:
@@ -79,7 +78,7 @@ class Dependency:
 
         # This sets per-too config methods which are deprecated to to the new
         # generic CONFIG_TOOL value.
-        if method in [DependencyMethods.SDLCONFIG]:
+        if method in [DependencyMethods.SDLCONFIG, DependencyMethods.CUPSCONFIG]:
             mlog.warning(textwrap.dedent("""\
                 Configuration method {} has been deprecated in favor of
                 'config-tool'. This will be removed in a future version of

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -20,6 +20,7 @@ import sys
 import stat
 import shlex
 import shutil
+import textwrap
 from enum import Enum
 
 from .. import mlog
@@ -45,8 +46,6 @@ class DependencyMethods(Enum):
     QMAKE = 'qmake'
     # Just specify the standard link arguments, assuming the operating system provides the library.
     SYSTEM = 'system'
-    # Detect using sdl2-config
-    SDLCONFIG = 'sdlconfig'
     # Detect using pcap-config
     PCAPCONFIG = 'pcap-config'
     # Detect using cups-config
@@ -59,6 +58,8 @@ class DependencyMethods(Enum):
     SYSCONFIG = 'sysconfig'
     # Specify using a "program"-config style tool
     CONFIG_TOOL = 'config-tool'
+    # For backewards compatibility
+    SDLCONFIG = 'sdlconfig'
 
 
 class Dependency:
@@ -75,6 +76,15 @@ class Dependency:
         if method not in [e.value for e in DependencyMethods]:
             raise DependencyException('method {!r} is invalid'.format(method))
         method = DependencyMethods(method)
+
+        # This sets per-too config methods which are deprecated to to the new
+        # generic CONFIG_TOOL value.
+        if method in [DependencyMethods.SDLCONFIG]:
+            mlog.warning(textwrap.dedent("""\
+                Configuration method {} has been deprecated in favor of
+                'config-tool'. This will be removed in a future version of
+                meson.""".format(method)))
+            method = DependencyMethods.CONFIG_TOOL
 
         # Set the detection method. If the method is set to auto, use any available method.
         # If method is set to a specific string, allow only that detection method.

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -24,7 +24,9 @@ from enum import Enum
 
 from .. import mlog
 from .. import mesonlib
-from ..mesonlib import MesonException, Popen_safe, version_compare_many, listify
+from ..mesonlib import (
+    MesonException, Popen_safe, version_compare_many, version_compare, listify
+)
 
 
 # These must be defined in this file to avoid cyclical references.
@@ -55,6 +57,8 @@ class DependencyMethods(Enum):
     EXTRAFRAMEWORK = 'extraframework'
     # Detect using the sysconfig module.
     SYSCONFIG = 'sysconfig'
+    # Specify using a "program"-config style tool
+    CONFIG_TOOL = 'config-tool'
 
 
 class Dependency:
@@ -165,6 +169,94 @@ class ExternalDependency(Dependency):
 
     def get_compiler(self):
         return self.compiler
+
+
+class ConfigToolDependency(ExternalDependency):
+
+    """Class representing dependencies found using a config tool."""
+
+    tools = None
+    tool_name = None
+
+    def __init__(self, name, environment, language, kwargs):
+        super().__init__('config-tool', environment, language, kwargs)
+        self.name = name
+        self.tools = listify(kwargs.get('tools', self.tools))
+
+        req_version = kwargs.get('version', None)
+        tool, version = self.find_config(req_version)
+        self.config = tool
+        self.is_found = self.report_config(version, req_version)
+        if not self.is_found:
+            self.config = None
+            return
+        self.version = version
+
+    def find_config(self, versions=None):
+        """Helper method that searchs for config tool binaries in PATH and
+        returns the one that best matches the given version requirements.
+        """
+        if not isinstance(versions, list) and versions is not None:
+            versions = listify(versions)
+
+        best_match = (None, None)
+        for tool in self.tools:
+            try:
+                p, out = Popen_safe([tool, '--version'])[:2]
+            except (FileNotFoundError, PermissionError):
+                continue
+            if p.returncode != 0:
+                continue
+
+            out = out.strip()
+            # Some tools, like pcap-config don't supply a version, but also
+            # dont fail with --version, in that case just assume that there is
+            # only one verison and return it.
+            if not out:
+                return (tool, 'none')
+            if versions:
+                is_found = version_compare_many(out, versions)[0]
+                # This allows returning a found version without a config tool,
+                # which is useful to inform the user that you found version x,
+                # but y was required.
+                if not is_found:
+                    tool = None
+            if best_match[1]:
+                if version_compare(out, '> {}'.format(best_match[1])):
+                    best_match = (tool, out)
+            else:
+                best_match = (tool, out)
+
+        return best_match
+
+    def report_config(self, version, req_version):
+        """Helper method to print messages about the tool."""
+        if self.config is None:
+            if version is not None:
+                mlog.log('found {} {!r} but need:'.format(self.tool_name, version),
+                         req_version)
+            else:
+                mlog.log("No {} found; can't detect dependency".format(self.tool_name))
+            mlog.log('Dependency {} found:'.format(self.name), mlog.red('NO'))
+            if self.required:
+                raise DependencyException('Dependency {} not found'.format(self.name))
+            return False
+        mlog.log('Found {}:'.format(self.tool_name), mlog.bold(shutil.which(self.config)),
+                 '({})'.format(version))
+        mlog.log('Dependency {} found:'.format(self.name), mlog.green('YES'))
+        return True
+
+    def get_config_value(self, args, stage):
+        p, out, _ = Popen_safe([self.config] + args)
+        if p.returncode != 0:
+            if self.required:
+                raise DependencyException('Could not generate {} for {}'.format(
+                    stage, self.name))
+            return []
+        return shlex.split(out)
+
+    def get_methods(self):
+        return [DependencyMethods.AUTO, DependencyMethods.CONFIG_TOOL]
 
 
 class PkgConfigDependency(ExternalDependency):

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -46,8 +46,6 @@ class DependencyMethods(Enum):
     QMAKE = 'qmake'
     # Just specify the standard link arguments, assuming the operating system provides the library.
     SYSTEM = 'system'
-    # Detect using libwmf-config
-    LIBWMFCONFIG = 'libwmf-config'
     # This is only supported on OSX - search the frameworks directory by name.
     EXTRAFRAMEWORK = 'extraframework'
     # Detect using the sysconfig module.
@@ -58,6 +56,7 @@ class DependencyMethods(Enum):
     SDLCONFIG = 'sdlconfig'
     CUPSCONFIG = 'cups-config'
     PCAPCONFIG = 'pcap-config'
+    LIBWMFCONFIG = 'libwmf-config'
 
 
 class Dependency:
@@ -78,7 +77,7 @@ class Dependency:
         # This sets per-too config methods which are deprecated to to the new
         # generic CONFIG_TOOL value.
         if method in [DependencyMethods.SDLCONFIG, DependencyMethods.CUPSCONFIG,
-                      DependencyMethods.PCAPCONFIG]:
+                      DependencyMethods.PCAPCONFIG, DependencyMethods.LIBWMFCONFIG]:
             mlog.warning(textwrap.dedent("""\
                 Configuration method {} has been deprecated in favor of
                 'config-tool'. This will be removed in a future version of

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -82,7 +82,7 @@ class Dependency:
             raise DependencyException(
                 'Unsupported detection method: {}, allowed methods are {}'.format(
                     method.value,
-                    mlog.format_list(map(lambda x: x.value, [DependencyMethods.AUTO] + self.get_methods()))))
+                    mlog.format_list([x.value for x in [DependencyMethods.AUTO] + self.get_methods()])))
 
     def __repr__(self):
         s = '<{0} {1}: {2}>'

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -17,14 +17,16 @@
 
 import os
 import re
-import shlex
 import shutil
 
 from .. import mlog
 from .. import mesonlib
 from ..mesonlib import version_compare, Popen_safe, stringlistify, extract_as_list
-from .base import DependencyException, ExternalDependency, PkgConfigDependency
-from .base import strip_system_libdirs
+from .base import (
+    DependencyException, ExternalDependency, PkgConfigDependency,
+    strip_system_libdirs, ConfigToolDependency,
+)
+
 
 class GTestDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
@@ -109,7 +111,7 @@ class GMockDependency(ExternalDependency):
         self.is_found = False
 
 
-class LLVMDependency(ExternalDependency):
+class LLVMDependency(ConfigToolDependency):
     """
     LLVM uses a special tool, llvm-config, which has arguments for getting
     c args, cxx args, and ldargs as well as version.
@@ -121,7 +123,7 @@ class LLVMDependency(ExternalDependency):
     # not be moved to the beginning of the list. The only difference between
     # llvm-config-6.0 and llvm-config-devel is that the former is used by
     # Debian and the latter is used by FreeBSD.
-    llvm_config_bins = [
+    tools = [
         'llvm-config', # base
         'llvm-config-5.0', 'llvm-config50', # latest stable release
         'llvm-config-4.0', 'llvm-config40', # old stable releases
@@ -132,61 +134,31 @@ class LLVMDependency(ExternalDependency):
         'llvm-config-3.5', 'llvm-config35',
         'llvm-config-6.0', 'llvm-config-devel', # development snapshot
     ]
+    tool_name = 'llvm-config'
     __cpp_blacklist = {'-DNDEBUG'}
 
     def __init__(self, environment, kwargs):
         # It's necessary for LLVM <= 3.8 to use the C++ linker. For 3.9 and 4.0
         # the C linker works fine if only using the C API.
-        super().__init__('llvm-config', environment, 'cpp', kwargs)
+        super().__init__('config-tool', environment, 'cpp', kwargs)
         self.provided_modules = []
         self.required_modules = set()
-        self.llvmconfig = None
+        if not self.is_found:
+            return
         self.static = kwargs.get('static', False)
-        self.__best_found = None
-        # FIXME: Support multiple version requirements ala PkgConfigDependency
-        req_version = kwargs.get('version', None)
-        self.check_llvmconfig(req_version)
-        if self.llvmconfig is None:
-            if self.__best_found is not None:
-                mlog.log('found {!r} but need:'.format(self.__best_found),
-                         req_version)
-            else:
-                mlog.log("No llvm-config found; can't detect dependency")
-            mlog.log('Dependency LLVM found:', mlog.red('NO'))
-            if self.required:
-                raise DependencyException('Dependency LLVM not found')
-            return
-
-        p, out, err = Popen_safe([self.llvmconfig, '--version'])
-        if p.returncode != 0:
-            mlog.debug('stdout: {}\nstderr: {}'.format(out, err))
-            if self.required:
-                raise DependencyException('Dependency LLVM not found')
-            mlog.log('Dependency LLVM found:', mlog.red('NO'))
-            return
-
-        mlog.log('Dependency LLVM found:', mlog.green('YES'))
-        self.is_found = True
 
         # Currently meson doesn't really atempt to handle pre-release versions,
         # so strip the 'svn' off the end, since it will probably cuase problems
         # for users who want the patch version.
-        self.version = out.strip().rstrip('svn')
+        self.version = self.version.rstrip('svn')
 
-        p, out, err = Popen_safe([self.llvmconfig, '--components'])
-        if p.returncode != 0:
-            raise DependencyException('Could not generate modules for LLVM:\n' + err)
-        self.provided_modules = shlex.split(out)
-
+        self.provided_modules = self.get_config_value(['--components'], 'modules')
         modules = stringlistify(extract_as_list(kwargs, 'modules'))
         self.check_components(modules)
         opt_modules = stringlistify(extract_as_list(kwargs, 'optional_modules'))
         self.check_components(opt_modules, required=False)
 
-        p, out, err = Popen_safe([self.llvmconfig, '--cppflags'])
-        if p.returncode != 0:
-            raise DependencyException('Could not generate includedir for LLVM:\n' + err)
-        cargs = mesonlib.OrderedSet(shlex.split(out))
+        cargs = set(self.get_config_value(['--cppflags'], 'compile_args'))
         self.compile_args = list(cargs.difference(self.__cpp_blacklist))
 
         if version_compare(self.version, '>= 3.9'):
@@ -198,11 +170,9 @@ class LLVMDependency(ExternalDependency):
     def _set_new_link_args(self):
         """How to set linker args for LLVM versions >= 3.9"""
         link_args = ['--link-static', '--system-libs'] if self.static else ['--link-shared']
-        p, out, err = Popen_safe(
-            [self.llvmconfig, '--libs', '--ldflags'] + link_args + list(self.required_modules))
-        if p.returncode != 0:
-            raise DependencyException('Could not generate libs for LLVM:\n' + err)
-        self.link_args = shlex.split(out)
+        self.link_args = self.get_config_value(
+            ['--libs', '--ldflags'] + link_args + list(self.required_modules),
+            'link_args')
 
     def _set_old_link_args(self):
         """Setting linker args for older versions of llvm.
@@ -213,20 +183,15 @@ class LLVMDependency(ExternalDependency):
         of course we do.
         """
         if self.static:
-            p, out, err = Popen_safe(
-                [self.llvmconfig, '--libs', '--ldflags', '--system-libs'] + list(self.required_modules))
-            if p.returncode != 0:
-                raise DependencyException('Could not generate libs for LLVM:\n' + err)
-            self.link_args = shlex.split(out)
+            self.link_args = self.get_config_value(
+                ['--libs', '--ldflags', '--system-libs'] + list(self.required_modules),
+                'link_args')
         else:
             # llvm-config will provide arguments for static linking, so we get
             # to figure out for ourselves what to link with. We'll do that by
             # checking in the directory provided by --libdir for a library
             # called libLLVM-<ver>.(so|dylib|dll)
-            p, out, err = Popen_safe([self.llvmconfig, '--libdir'])
-            if p.returncode != 0:
-                raise DependencyException('Could not generate libs for LLVM:\n' + err)
-            libdir = out.strip()
+            libdir = self.get_config_value(['--libdir'], 'link_args')[0]
 
             expected_name = 'libLLVM-{}'.format(self.version)
             re_name = re.compile(r'{}.(so|dll|dylib)'.format(expected_name))
@@ -258,34 +223,6 @@ class LLVMDependency(ExternalDependency):
             else:
                 self.required_modules.add(mod)
                 mlog.log('LLVM module', mod, 'found:', mlog.green('YES'))
-
-    def check_llvmconfig(self, version_req):
-        """Try to find the highest version of llvm-config."""
-        for llvmconfig in self.llvm_config_bins:
-            try:
-                p, out = Popen_safe([llvmconfig, '--version'])[0:2]
-                out = out.strip()
-                if p.returncode != 0:
-                    continue
-                if version_req:
-                    if version_compare(out, version_req, strict=True):
-                        if self.__best_found and version_compare(
-                                out, '<={}'.format(self.__best_found), strict=True):
-                            continue
-                        self.__best_found = out
-                        self.llvmconfig = llvmconfig
-                else:
-                    # If no specific version is requested use the first version
-                    # found, since that should be the best.
-                    self.__best_found = out
-                    self.llvmconfig = llvmconfig
-                    break
-            except (FileNotFoundError, PermissionError):
-                pass
-        if self.__best_found:
-            mlog.log('Found llvm-config:',
-                     mlog.bold(shutil.which(self.llvmconfig)),
-                     '({})'.format(out.strip()))
 
     def need_threads(self):
         return True

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -105,14 +105,16 @@ class GnuStepDependency(ExternalDependency):
                  mlog.green('YES'), self.version)
 
     def weird_filter(self, elems):
-        """When building packages, the output of the enclosing Make
-is sometimes mixed among the subprocess output. I have no idea
-why. As a hack filter out everything that is not a flag."""
+        """When building packages, the output of the enclosing Make is
+        sometimes mixed among the subprocess output. I have no idea why. As a
+        hack filter out everything that is not a flag.
+        """
         return [e for e in elems if e.startswith('-')]
 
     def filter_args(self, args):
-        """gnustep-config returns a bunch of garbage args such
-        as -O2 and so on. Drop everything that is not needed."""
+        """gnustep-config returns a bunch of garbage args such as -O2 and so
+        on. Drop everything that is not needed.
+        """
         result = []
         for f in args:
             if f.startswith('-D') \

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -274,6 +274,7 @@ class DependencyHolder(InterpreterObject, ObjectHolder):
                              'type_name': self.type_name_method,
                              'version': self.version_method,
                              'get_pkgconfig_variable': self.pkgconfig_method,
+                             'get_configtool_variable': self.configtool_method,
                              })
 
     def type_name_method(self, args, kwargs):
@@ -295,6 +296,15 @@ class DependencyHolder(InterpreterObject, ObjectHolder):
         if not isinstance(varname, str):
             raise InterpreterException('Variable name must be a string.')
         return self.held_object.get_pkgconfig_variable(varname)
+
+    def configtool_method(self, args, kwargs):
+        args = listify(args)
+        if len(args) != 1:
+            raise InterpreterException('get_configtool_variable takes exactly one argument.')
+        varname = args[0]
+        if not isinstance(varname, str):
+            raise InterpreterException('Variable name must be a string.')
+        return self.held_object.get_configtool_variable(varname)
 
 class InternalDependencyHolder(InterpreterObject, ObjectHolder):
     def __init__(self, dep):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1661,7 +1661,7 @@ class FailureTests(BasePlatformTests):
             raise unittest.SkipTest('wx-config or wx-config-3.0 found')
         self.assertMesonRaises("dependency('wxwidgets')", self.dnf)
         self.assertMesonOutputs("dependency('wxwidgets', required : false)",
-                                "nor wx-config found")
+                                "No wx-config found;")
 
     def test_wx_dependency(self):
         if not shutil.which('wx-config-3.0') and not shutil.which('wx-config'):

--- a/test cases/common/165 config tool variable/meson.build
+++ b/test cases/common/165 config tool variable/meson.build
@@ -1,0 +1,31 @@
+# Copyright © 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project('config tool variable', 'cpp')
+
+
+dep_llvm = dependency('llvm', required : false)
+if not dep_llvm.found()
+  error('MESON_SKIP_TEST LLVM not installed.')
+endif
+
+includedir = dep_llvm.get_configtool_variable('includedir')
+includedir = join_paths(includedir, 'llvm')
+if host_machine.system() == 'windows'
+  cmd = run_command(['dir', includedir])
+else
+  cmd = run_command(['ls', includedir])
+endif
+
+assert(cmd.returncode() == 0, 'did not run successfully')

--- a/test cases/frameworks/16 sdl2/meson.build
+++ b/test cases/frameworks/16 sdl2/meson.build
@@ -6,5 +6,8 @@ e = executable('sdl2prog', 'sdl2prog.c', dependencies : sdl2_dep)
 
 test('sdl2test', e)
 
-# Ensure that we can find it with sdl2-config too
+# Ensure that we can find it with sdl2-config too, using the legacy method name
 configdep = dependency('sdl2', method : 'sdlconfig')
+
+# And the modern method name
+configdep = dependency('sdl2', method : 'config-tool')

--- a/test cases/frameworks/19 pcap/meson.build
+++ b/test cases/frameworks/19 pcap/meson.build
@@ -8,3 +8,7 @@ assert(pcap_ver.split('.').length() > 1, 'pcap version is "@0@"'.format(pcap_ver
 e = executable('pcap_prog', 'pcap_prog.c', dependencies : pcap_dep)
 
 test('pcaptest', e)
+
+# Ensure discovery bia the configuration tools work also
+pcap_dep = dependency('pcap', version : '>=1.0', method : 'pcap-config')
+pcap_dep = dependency('pcap', version : '>=1.0', method : 'config-tool')

--- a/test cases/frameworks/20 cups/meson.build
+++ b/test cases/frameworks/20 cups/meson.build
@@ -5,3 +5,8 @@ cups_dep = dependency('cups', version : '>=1.4')
 e = executable('cups_prog', 'cups_prog.c', dependencies : cups_dep)
 
 test('cupstest', e)
+
+# ensure we can find the cups dependency via the legacy and modern config-tool
+# options
+dep = dependency('cups', version : '>=1.4', method : 'cups-config')
+dep = dependency('cups', version : '>=1.4', method : 'config-tool')

--- a/test cases/frameworks/21 libwmf/meson.build
+++ b/test cases/frameworks/21 libwmf/meson.build
@@ -7,3 +7,8 @@ message('libwmf version is "@0@"'.format(libwmf_ver))
 e = executable('libwmf_prog', 'libwmf_prog.c', dependencies : libwmf_dep)
 
 test('libwmftest', e)
+
+# Test using the method keyword:
+
+dependency('libwmf', method : 'config-tool')
+dependency('libwmf', method : 'libwmf-config')

--- a/test cases/frameworks/21 libwmf/meson.build
+++ b/test cases/frameworks/21 libwmf/meson.build
@@ -1,6 +1,6 @@
 project('libwmf test', 'c')
 
-libwmf_dep = dependency('libwmf', version : '>=3.0')
+libwmf_dep = dependency('libwmf', version : '>= 0.2.8')
 libwmf_ver = libwmf_dep.version()
 assert(libwmf_ver.split('.').length() > 1, 'libwmf version is "@0@"'.format(libwmf_ver))
 message('libwmf version is "@0@"'.format(libwmf_ver))


### PR DESCRIPTION
What I want is to bet able to get the includepath from LLVM. What ended up happening was a lot of refactoring to get there.

This series adds a new ConfigToolDependency class, which acts as a share base class for for config tool dependencies like llvm, wxwidgets, and gnustep. It also allows this class to be used in factory type constructors (like cups and pcap). Among the features this adds is unified argument detection, support for multiple version comparisons, and a unified config-tool method name.

This is based on my previous llvm patches (that are waiting for merge already), because this code allows the LLVMDependency to be simplified further.