### PR TITLE
LLVM: Don't add -L<system path> to link args

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -640,3 +640,14 @@ def find_external_dependency(name, env, kwargs):
         raise pkg_exc
     mlog.log('Dependency', mlog.bold(name), 'found:', mlog.red('NO'))
     return pkgdep
+
+
+def strip_system_libdirs(environment, link_args):
+    """Remove -L<system path> arguments.
+
+    leaving these in will break builds where a user has a version of a library
+    in the system path, and a different version not in the system path if they
+    want to link against the non-system path version.
+    """
+    exclude = {'-L{}'.format(p) for p in environment.get_compiler_system_dirs()}
+    return [l for l in link_args if l not in exclude]

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -23,6 +23,7 @@ from .. import mlog
 from .. import mesonlib
 from ..mesonlib import version_compare, Popen_safe, stringlistify, extract_as_list
 from .base import DependencyException, ExternalDependency, PkgConfigDependency
+from .base import strip_system_libdirs
 
 class GTestDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
@@ -172,8 +173,7 @@ class LLVMDependency(ExternalDependency):
             [self.llvmconfig, '--libs', '--ldflags'])[:2]
         if p.returncode != 0:
             raise DependencyException('Could not generate libs for LLVM.')
-        self.link_args = shlex.split(out)
-
+        self.link_args = strip_system_libdirs(environment, shlex.split(out))
         p, out = Popen_safe([self.llvmconfig, '--cppflags'])[:2]
         if p.returncode != 0:
             raise DependencyException('Could not generate includedir for LLVM.')

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -887,6 +887,24 @@ class Environment:
     def get_datadir(self):
         return self.coredata.get_builtin_option('datadir')
 
+    def get_compiler_system_dirs(self):
+        for comp in self.coredata.compilers.values():
+            if isinstance(comp, compilers.ClangCompiler):
+                index = 1
+                break
+            elif isinstance(comp, compilers.GnuCompiler):
+                index = 2
+                break
+        else:
+            # This option is only supported by gcc and clang. If we don't get a
+            # GCC or Clang compiler return and empty list.
+            return []
+
+        p, out, _ = Popen_safe(comp.get_exelist() + ['-print-search-dirs'])
+        if p.returncode != 0:
+            raise mesonlib.MesonException('Could not calculate system search dirs')
+        out = out.split('\n')[index].lstrip('libraries: =').split(':')
+        return [os.path.normpath(p) for p in out]
 
 def get_args_from_envvars(compiler):
     """


### PR DESCRIPTION
This is a smaller slice of the functionality in a larger LLVM pull request I sent. I hope these patches can land in the 0.43.1 stable release, as this bug is already being rather annoying for mesa with fast moving dependencies like libdrm.