### PR TITLE
Update references from mesonconf to meson configure

### DIFF
--- a/docs/markdown/Configuring-a-build-directory.md
+++ b/docs/markdown/Configuring-a-build-directory.md
@@ -9,11 +9,11 @@ generated. For example you might want to change from a debug build
 into a release build, set custom compiler flags, change the build
 options provided in your `meson_options.txt` file and so on.
 
-The main tool for this is the `mesonconf` script. You may also use the
+The main tool for this is the `meson configure` command. You may also use the
 `mesongui` graphical application if you want. However this document
 describes the use of the command line client.
 
-You invoke `mesonconf` by giving it the location of your build dir. If
+You invoke `meson configure` by giving it the location of your build dir. If
 omitted, the current working directory is used instead. Here's a
 sample output for a simple project.
 
@@ -56,7 +56,7 @@ the option. To set an option you use the `-D` option. For example,
 changing the installation prefix from `/usr/local` to `/tmp/testroot`
 you would issue the following command.
 
-    mesonconf -Dprefix=/tmp/testroot
+    meson configure -Dprefix=/tmp/testroot
 
 Then you would run your build command (usually `ninja`), which would
 cause Meson to detect that the build setup has changed and do all the

--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -34,7 +34,7 @@ The next thing to display is the list of options that can be set. These include 
 
     mesonintrospect.py --buildoptions
 
-To set the options, use the `mesonconf.py` binary.
+To set the options, use the `meson configure` command.
 
 Compilation and unit tests are done as usual by running the `ninja` and `ninja test` commands. A JSON formatted result log can be found in `workspace/project/builddir/meson-logs/testlog.json`.
 

--- a/docs/markdown/Precompiled-headers.md
+++ b/docs/markdown/Precompiled-headers.md
@@ -40,7 +40,7 @@ Toggling the usage of precompiled headers
 
 If you wish to compile your project without precompiled headers, you
 can change the value of the pch option by passing `-Db_pch=false`
-argument to Meson at configure time or later with `mesonconf`. You can
+argument to Meson at configure time or later with `meson configure`. You can
 also toggle the use of pch in a configured build directory with the
 GUI tool. You don't have to do any changes to the source
 code. Typically this is done to test whether your project compiles

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -871,7 +871,7 @@ Project supports the following keyword arguments.
 
  - `default_options` takes an array of strings. The strings are in the
    form `key=value` and have the same format as options to
-   `mesonconf`. For example to set the default project type you would
+   `meson configure`. For example to set the default project type you would
    set this: `default_options : ['buildtype=debugoptimized']`. Note
    that these settings are only used when running Meson for the first
    time. Global options such as `buildtype` can only be specified in

--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -102,7 +102,7 @@ The coverage report can be found in the meson-logs subdirectory.
 By default the debug build does not use any optimizations. This is the desired approach most of the time. However some projects benefit from having some minor optimizations enabled. GCC even has a specific compiler flag `-Og` for this. To enable its use, just issue the following command.
 
 ```console
-$ mesonconf -Dc_args=-Og
+$ meson configure -Dc_args=-Og
 ```
 
 This causes all subsequent builds to use this command line argument.
@@ -139,7 +139,7 @@ Then we need to run the program with some representative input. This step depend
 Once that is done we change the compiler flags to use the generated information and rebuild.
 
 ```console
-$ mesonconf -Db_pgo=use
+$ meson configure -Db_pgo=use
 $ ninja
 ```
 


### PR DESCRIPTION
This updates references to mesonconf to meson configure. Some references (such as older release notes and deprecation warnings) were left in the documentation.

Fixes #2372