### PR TITLE
Fix boost link cmd line when compiler.find_library returns None, self…

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -359,11 +359,12 @@ class BoostDependency(ExternalDependency):
             args.append('-L' + self.libdir)
         for lib in self.requested_modules:
             # The compiler's library detector is the most reliable so use that first.
-            default_detect = self.compiler.find_library('boost_' + lib, self.env, [])
+            boost_lib = 'boost_' + lib
+            default_detect = self.compiler.find_library(boost_lib, self.env, [])
             if default_detect is not None:
                 args += default_detect
-            elif lib in self.lib_modules:
-                linkcmd = '-l' + lib
+            elif boost_lib in self.lib_modules:
+                linkcmd = '-l' + boost_lib
                 args.append(linkcmd)
         return args
 


### PR DESCRIPTION
….request_modules doesn't have 'boost_' prefix but lib_modules is keyed on 'boost_*'