### PR TITLE
Raise InvalidArguments when trying to link against strings

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -863,6 +863,8 @@ You probably should put it in link_with instead.''')
 
     def link(self, target):
         for t in listify(target, unholder=True):
+            if not isinstance(t, Target):
+                raise InvalidArguments('{!r} is not a target.'.format(t))
             if not t.is_linkable_target():
                 raise InvalidArguments('Link target {!r} is not linkable.'.format(t))
             if isinstance(self, SharedLibrary) and isinstance(t, StaticLibrary) and not t.pic:

--- a/test cases/failing/66 string as link target/meson.build
+++ b/test cases/failing/66 string as link target/meson.build
@@ -1,0 +1,2 @@
+project('string as link argument', 'c')
+executable('myprog', 'prog.c', link_with: [ '' ])

--- a/test cases/failing/66 string as link target/prog.c
+++ b/test cases/failing/66 string as link target/prog.c
@@ -1,0 +1,1 @@
+int main(int argc, char **argv) { return 0; }


### PR DESCRIPTION
With executable(), if the link_with argument has a string as one of it's
elements, meson ends up throwing an AttributeError exception:

...
  File "/home/lyudess/Projects/meson/mesonbuild/build.py", line 868, in link
    if not t.is_linkable_target():
AttributeError: 'str' object has no attribute 'is_linkable_target'

Which is not very helpful in figuring out where exactly the project is
trying to link against a string instead of an actual link target. So,
fix this by verifying in BuildTarget.link() that each given target is
actually a Target object and not something else.

Additionally, add a simple test case for this in failing tests. At the
moment, this test case just passes unconditionally due to meson throwing
the AttributeError exception and failing as expected. However, this test
case will be useful eventually if we ever end up making failing tests
more strict about failing gracefully (per advice of QuLogic).