### PR TITLE
Qt5-Module: Add `moc_extra_arguments` keyword support.

### DIFF
--- a/docs/markdown/Qt5-module.md
+++ b/docs/markdown/Qt5-module.md
@@ -5,11 +5,11 @@ tools and steps required for Qt. The module has one method.
 
 ## preprocess
 
-This method takes five keyword arguments, `moc_headers`,
-`moc_sources`, `ui_files` and `qresources` which define the files that
-require preprocessing with `moc`, `uic` and `rcc` and 'include_directories' which might be needed by moc. It returns an
-opaque object that should be passed to a main build target. A simple
-example would look like this:
+This method takes six keyword arguments, `moc_headers`, `moc_sources`, `ui_files`, `qresources`
+and `moc_extra_arguments` which define the files that require preprocessing with `moc`, `uic`
+and `rcc` and 'include_directories' which might be needed by moc as well as (optional)
+additional arguments. It returns an opaque object that should be passed to a main build target.
+A simple example would look like this:
 
 ```meson
 qt5 = import('qt5')

--- a/docs/markdown/Qt5-module.md
+++ b/docs/markdown/Qt5-module.md
@@ -5,10 +5,13 @@ tools and steps required for Qt. The module has one method.
 
 ## preprocess
 
-This method takes six keyword arguments, `moc_headers`, `moc_sources`, `ui_files`, `qresources`
-and `moc_extra_arguments` which define the files that require preprocessing with `moc`, `uic`
-and `rcc` and 'include_directories' which might be needed by moc as well as (optional)
-additional arguments. It returns an opaque object that should be passed to a main build target.
+This method takes the following keyword arguments:
+ - `moc_headers`, `moc_sources`, `ui_files`, `qresources`, which define the files that require preprocessing with `moc`, `uic` and `rcc`
+ - `include_directories`, the directories to add to header search path for `moc` (optional)
+ - `moc_extra_arguments`, any additional arguments to `moc` (optional).
+
+It returns an opaque object that should be passed to a main build target.
+
 A simple example would look like this:
 
 ```meson

--- a/docs/markdown/Qt5-module.md
+++ b/docs/markdown/Qt5-module.md
@@ -8,7 +8,7 @@ tools and steps required for Qt. The module has one method.
 This method takes the following keyword arguments:
  - `moc_headers`, `moc_sources`, `ui_files`, `qresources`, which define the files that require preprocessing with `moc`, `uic` and `rcc`
  - `include_directories`, the directories to add to header search path for `moc` (optional)
- - `moc_extra_arguments`, any additional arguments to `moc` (optional).
+ - `moc_extra_arguments`, any additional arguments to `moc` (optional). Available since v0.44.0.
 
 It returns an opaque object that should be passed to a main build target.
 

--- a/docs/markdown/Qt5-module.md
+++ b/docs/markdown/Qt5-module.md
@@ -18,7 +18,9 @@ A simple example would look like this:
 qt5 = import('qt5')
 qt5_dep = dependency('qt5', modules: ['Core', 'Gui'])
 inc = include_directories('includes')
-moc_files = qt5.preprocess(moc_headers : 'myclass.h', include_directories: inc)
+moc_files = qt5.preprocess(moc_headers : 'myclass.h',
+                           moc_extra_arguments: ['-DMAKES_MY_MOC_HEADER_COMPILE'],
+                           include_directories: inc)
 executable('myprog', 'main.cpp', 'myclass.cpp', moc_files,
            include_directories: inc,
            dependencies : qt5_dep)

--- a/docs/markdown/snippets/qt5-moc_extra_arguments.md
+++ b/docs/markdown/snippets/qt5-moc_extra_arguments.md
@@ -1,0 +1,8 @@
+# Adds support for additional Qt5-Module keyword `moc_extra_arguments`
+
+When `moc`-ing sources, the `moc` tool does not know about any
+preprocessor macros. The generated code might not match the input
+files when the linking with the moc input sources happens.
+
+This amendment allows to specify a a list of additional arguments
+passed to the `moc` tool. They are called `moc_extra_arguments`.

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -122,10 +122,7 @@ class QtBaseModule:
             sources.append(ui_output)
         inc = get_include_args(include_dirs=include_directories)
         if len(moc_headers) > 0:
-            if len(moc_extra_arguments) > 0:
-                arguments = moc_extra_arguments + inc + ['@INPUT@', '-o', '@OUTPUT@']
-            else:
-                arguments = inc + ['@INPUT@', '-o', '@OUTPUT@']
+            arguments = moc_extra_arguments + inc + ['@INPUT@', '-o', '@OUTPUT@']
             moc_kwargs = {'output': 'moc_@BASENAME@.cpp',
                           'arguments': arguments}
             moc_gen = build.Generator([self.moc], moc_kwargs)

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -129,11 +129,7 @@ class QtBaseModule:
             moc_output = moc_gen.process_files('Qt{} moc header'.format(self.qt_version), moc_headers, state)
             sources.append(moc_output)
         if len(moc_sources) > 0:
-            if len(moc_extra_arguments) > 0:
-                concatinated_moc_extra_arguments = ' '.join(moc_extra_arguments)
-                arguments = [concatinated_moc_extra_arguments, '@INPUT@', '-o', '@OUTPUT@']
-            else:
-                arguments = ['@INPUT@', '-o', '@OUTPUT@']
+            arguments = [moc_extra_arguments, '@INPUT@', '-o', '@OUTPUT@']
             moc_kwargs = {'output': '@BASENAME@.moc',
                           'arguments': arguments}
             moc_gen = build.Generator([self.moc], moc_kwargs)

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -129,7 +129,7 @@ class QtBaseModule:
             moc_output = moc_gen.process_files('Qt{} moc header'.format(self.qt_version), moc_headers, state)
             sources.append(moc_output)
         if len(moc_sources) > 0:
-            arguments = [moc_extra_arguments, '@INPUT@', '-o', '@OUTPUT@']
+            arguments = moc_extra_arguments + ['@INPUT@', '-o', '@OUTPUT@']
             moc_kwargs = {'output': '@BASENAME@.moc',
                           'arguments': arguments}
             moc_gen = build.Generator([self.moc], moc_kwargs)

--- a/test cases/frameworks/4 qt/manualinclude.cpp
+++ b/test cases/frameworks/4 qt/manualinclude.cpp
@@ -6,18 +6,20 @@
 ManualInclude::ManualInclude() {
 }
 
+void ManualInclude::myslot(void) {
+	;
+}
+
 class MocClass : public QObject {
     Q_OBJECT
 };
 
-void testSlot() {
-	;
-}
-
 int main(int argc, char **argv) {
     ManualInclude mi;
     MocClass mc;
-    QObject::connect(&mi, &ManualInclude::mysignal, &testSlot);
+    QObject::connect(&mi, SIGNAL(mysignal(void)),
+                     &mi, SLOT(myslot(void)));
+    emit mi.mysignal();
     return 0;
 }
 

--- a/test cases/frameworks/4 qt/manualinclude.cpp
+++ b/test cases/frameworks/4 qt/manualinclude.cpp
@@ -10,9 +10,14 @@ class MocClass : public QObject {
     Q_OBJECT
 };
 
+void testSlot() {
+	;
+}
+
 int main(int argc, char **argv) {
     ManualInclude mi;
     MocClass mc;
+    QObject::connect(&mi, &ManualInclude::mysignal, &testSlot);
     return 0;
 }
 

--- a/test cases/frameworks/4 qt/manualinclude.h
+++ b/test cases/frameworks/4 qt/manualinclude.h
@@ -9,7 +9,9 @@ class ManualInclude : public QObject {
 public:
     ManualInclude();
 
+#if defined(MOC_EXTRA_FLAG)
 signals:
+#endif
     int mysignal();
 };
 

--- a/test cases/frameworks/4 qt/manualinclude.h
+++ b/test cases/frameworks/4 qt/manualinclude.h
@@ -8,6 +8,10 @@ class ManualInclude : public QObject {
 
 public:
     ManualInclude();
+#if defined(MOC_EXTRA_FLAG)
+public slots:
+#endif
+    void myslot(void);
 
 #if defined(MOC_EXTRA_FLAG)
 signals:

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -61,6 +61,7 @@ foreach qt : ['qt4', 'qt5']
     # headers but the user must manually include moc
     # files from sources.
     manpreprocessed = qtmodule.preprocess(
+      moc_extra_arguments : ['-DMOC_EXTRA_FLAG'], # This is just a random macro to test `moc_extra_arguments`
       moc_sources : 'manualinclude.cpp',
       moc_headers : 'manualinclude.h',
       method : get_option('method'))


### PR DESCRIPTION
This commit adds support for an additional `moc_extra_arguments` keyword.
It becomes especially handy, when `moc`-ed sources conditionally provide
`slots`, depending on compile time macros (i.e. defines).