### PR TITLE
Fix include_directories handling in subprojects for compiler tests

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -696,7 +696,8 @@ class CompilerHolder(InterpreterObject):
             if not isinstance(i, IncludeDirsHolder):
                 raise InterpreterException('Include directories argument must be an include_directories object.')
             for idir in i.held_object.get_incdirs():
-                idir = os.path.join(self.environment.get_source_dir(), idir)
+                idir = os.path.join(self.environment.get_source_dir(),
+                                    i.held_object.get_curdir(), idir)
                 args += self.compiler.get_include_args(idir, False)
         if not nobuiltins:
             opts = self.environment.coredata.compiler_options

--- a/test cases/common/163 includedir subproj/meson.build
+++ b/test cases/common/163 includedir subproj/meson.build
@@ -1,0 +1,9 @@
+project('include dir in subproj test', 'c')
+
+
+subproject('inctest')
+
+
+exe = executable('prog', 'prog.c')
+
+test('dummy', exe)

--- a/test cases/common/163 includedir subproj/prog.c
+++ b/test cases/common/163 includedir subproj/prog.c
@@ -1,0 +1,4 @@
+
+int main(int argc, char **argv) {
+  return 0;
+}

--- a/test cases/common/163 includedir subproj/subprojects/inctest/include/incfile.h
+++ b/test cases/common/163 includedir subproj/subprojects/inctest/include/incfile.h
@@ -1,0 +1,2 @@
+
+/* file which is used in the subproject */

--- a/test cases/common/163 includedir subproj/subprojects/inctest/meson.build
+++ b/test cases/common/163 includedir subproj/subprojects/inctest/meson.build
@@ -1,0 +1,13 @@
+
+project('subproj with includedir', 'c')
+
+
+
+compile_check = '''
+#include "incfile.h"
+'''
+
+if not meson.get_compiler('c').compiles(compile_check, name : 'include in subproj',
+                                        include_directories: include_directories('include'))
+  error('failed')
+endif


### PR DESCRIPTION
`include_directories` did not contain the subproject source directory when performing compiler checks.  This PR adds a test case and a fix.