### PR TITLE
Remove references to `mesontest`

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -95,10 +95,10 @@ the following:
 - `gdb` if `true`, the tests are also run under `gdb`
 - `timeout_multiplier` a number to multiply the test timeout with
 
-To use the test setup, run `mesontest --setup=*name*` inside the build dir.
+To use the test setup, run `meson test --setup=*name*` inside the build dir.
 
 Note that all these options are also available while running the
-`mesontest` script for running tests instead of `ninja test` or
+`meson test` script for running tests instead of `ninja test` or
 `msbuild RUN_TESTS.vcxproj`, etc depending on the backend.
 
 ### benchmark()
@@ -1084,7 +1084,7 @@ arguments are the following.
   for the test
 
 Defined tests can be run in a backend-agnostic way by calling
-`mesontest` inside the build dir, or by using backend-specific
+`meson test` inside the build dir, or by using backend-specific
 commands, such as `ninja test` or `msbuild RUN_TESTS.vcxproj`.
 
 ### vcs_tag()

--- a/docs/markdown/Unit-tests.md
+++ b/docs/markdown/Unit-tests.md
@@ -95,7 +95,7 @@ Meson also supports running the tests under GDB. Just doing this:
 $ meson test --gdb testname
 ```
 
-Mesontest will launch `gdb` all set up to run the test. Just type `run` in the GDB command prompt to start the program.
+Meson will launch `gdb` all set up to run the test. Just type `run` in the GDB command prompt to start the program.
 
 The second use case is a test that segfaults only rarely. In this case you can invoke the following command:
 
@@ -103,8 +103,8 @@ The second use case is a test that segfaults only rarely. In this case you can i
 $ meson test --gdb --repeat=10000 testname
 ```
 
-This runs the test up to 10 000 times under GDB automatically. If the program crashes, GDB will halt and the user can debug the application. Note that testing timeouts are disabled in this case so mesontest will not kill `gdb` while the developer is still debugging it. The downside is that if the test binary freezes, the test runner will wait forever.
+This runs the test up to 10 000 times under GDB automatically. If the program crashes, GDB will halt and the user can debug the application. Note that testing timeouts are disabled in this case so `meson test` will not kill `gdb` while the developer is still debugging it. The downside is that if the test binary freezes, the test runner will wait forever.
 
-For further information see the command line help of Mesontest by running `mesontest -h`.
+For further information see the command line help of Meson by running `meson test -h`.
 
 **NOTE:** If `meson test` does not work for you, you likely have a old version of Meson. In that case you should call `mesontest` instead. If `mesontest` doesn't work either you have a very old version prior to 0.37.0 and should upgrade.

--- a/man/meson.1
+++ b/man/meson.1
@@ -115,12 +115,14 @@ print command line help
 
 .SH The test command
 
-Mesontest is a helper tool for running test suites of projects using Meson.
+.B meson test
+is a helper tool for running test suites of projects using Meson.
 The default way of running tests is to invoke the default build command:
 
 \fBninja [\fR \fItest\fR \fB]\fR
 
-Mesontest provides a richer set of tools for invoking tests.
+.B meson test
+provides a richer set of tools for invoking tests.
 
 .SS "options:"
 .TP

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -619,6 +619,6 @@ def run(args):
             return th.doit()
         return th.run_special()
     except TestException as e:
-        print('Mesontest encountered an error:\n')
+        print('Meson test encountered an error:\n')
         print(e)
         return 1


### PR DESCRIPTION
`mesontest` is deprecated, and shouldn't be suggested to users anymore.