### PR TITLE
Fix detection of include dirs with gnu compiler and non US locale

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -923,11 +923,14 @@ def get_largefile_args(compiler):
 def gnulike_default_include_dirs(compiler, lang):
     if lang == 'cpp':
         lang = 'c++'
+    env = os.environ.copy()
+    env["LC_ALL"] = 'C'
     p = subprocess.Popen(
         compiler + ['-x{}'.format(lang), '-E', '-v', '-'],
         stdin=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
-        stdout=subprocess.PIPE
+        stdout=subprocess.PIPE,
+        env=env
     )
     stderr = p.stderr.read().decode('utf-8')
     parse_state = 0

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -925,8 +925,9 @@ def gnulike_default_include_dirs(compiler, lang):
         lang = 'c++'
     env = os.environ.copy()
     env["LC_ALL"] = 'C'
+    cmd = compiler + ['-x{}'.format(lang), '-E', '-v', '-']
     p = subprocess.Popen(
-        compiler + ['-x{}'.format(lang), '-E', '-v', '-'],
+        cmd,
         stdin=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
@@ -949,6 +950,8 @@ def gnulike_default_include_dirs(compiler, lang):
                 break
             else:
                 paths.append(line[1:])
+    if len(paths) == 0:
+        mlog.warning('No include directory found parsing "{cmd}" output'.format(cmd=" ".join(cmd)))
     return paths
 
 class GnuCompiler:


### PR DESCRIPTION
Auto detection was based on parsing gcc's output so we have to
ensure that it is always 'C'.