### PR TITLE
[Qt module] Add experimental Warning on wrong file extensions

### DIFF
--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -15,7 +15,7 @@
 import os
 from .. import mlog
 from .. import build
-from ..mesonlib import MesonException, Popen_safe, extract_as_list
+from ..mesonlib import MesonException, Popen_safe, extract_as_list, File
 from ..dependencies import Qt4Dependency, Qt5Dependency
 import xml.etree.ElementTree as ET
 from . import ModuleReturnValue, get_include_args
@@ -67,7 +67,18 @@ class QtBaseModule:
                 mlog.log(' {}:'.format(compiler_name.lower()), mlog.red('NO'))
         self.tools_detected = True
 
+    def check_extensions(self, tool, file_list, expected_extensions):
+        for fname in file_list:
+            if isinstance(fname, File):
+                fname = fname.fname
+            if '.' in fname:
+                ext = fname.split('.')[-1]
+                if ext not in expected_extensions:
+                    mlog.warning('''Qt{qt_ver} {tool}, wrong file extension "{fname}", expecting one of {expected}'''.format(
+                        qt_ver=self.qt_version, tool=tool, fname=fname, expected=expected_extensions))
+
     def parse_qrc(self, state, fname):
+        self.check_extensions("Rcc", [fname], ["qrc"])
         abspath = os.path.join(state.environment.source_dir, state.subdir, fname)
         relative_part = os.path.split(fname)[0]
         try:
@@ -122,6 +133,7 @@ class QtBaseModule:
             sources.append(ui_output)
         inc = get_include_args(include_dirs=include_directories)
         if len(moc_headers) > 0:
+            self.check_extensions("Moc", moc_headers, ["hpp", "h", "H", "hh", "h++"])
             arguments = moc_extra_arguments + inc + ['@INPUT@', '-o', '@OUTPUT@']
             moc_kwargs = {'output': 'moc_@BASENAME@.cpp',
                           'arguments': arguments}
@@ -129,6 +141,7 @@ class QtBaseModule:
             moc_output = moc_gen.process_files('Qt{} moc header'.format(self.qt_version), moc_headers, state)
             sources.append(moc_output)
         if len(moc_sources) > 0:
+            self.check_extensions("Moc", moc_sources, ["cpp", "cxx", "cc", "C", "cp", "c++"])
             arguments = moc_extra_arguments + ['@INPUT@', '-o', '@OUTPUT@']
             moc_kwargs = {'output': '@BASENAME@.moc',
                           'arguments': arguments}

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -81,5 +81,11 @@ foreach qt : ['qt4', 'qt5']
     plugin = library(qt + 'plugin', 'plugin/plugin.cpp', pluginpreprocess,
           include_directories : plugin_includes,
           dependencies : qtcore)
+
+
+    # Expect a warning since mainWindow.h is a header
+    qtmodule.preprocess(moc_sources : 'mainWindow.h')
+    # Expect a warning since mainWindow.cpp isn't a header
+    qtmodule.preprocess(moc_headers : 'mainWindow.cpp')
   endif
 endforeach


### PR DESCRIPTION
This is a test to add warning when an user gives a file with a wrong
extension to preprocess method.

This behaviour might be generalized to meson other modules.
It also should print meson.build file line.