### PR TITLE
Log instead of raise if Boost module invalid

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -66,6 +66,11 @@ class BoostDependency(ExternalDependency):
         self.is_multithreading = threading == "multi"
 
         self.requested_modules = self.get_requested(kwargs)
+        invalid_modules = [c for c in self.requested_modules if 'boost_' + c not in BOOST_LIBS]
+        if invalid_modules:
+            mlog.debug('Invalid Boost modules: ' + ', '.join(invalid_modules))
+            self.log_fail()
+            return
 
         self.boost_root = None
         self.boost_roots = []
@@ -198,8 +203,6 @@ class BoostDependency(ExternalDependency):
         for c in candidates:
             if not isinstance(c, str):
                 raise DependencyException('Boost module argument is not a string.')
-            if 'boost_' + c not in BOOST_LIBS:
-                raise DependencyException('Dependency {} not found. It is not a valid boost library.'.format(c))
         return candidates
 
     def validate_requested(self):

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -68,7 +68,7 @@ class BoostDependency(ExternalDependency):
         self.requested_modules = self.get_requested(kwargs)
         invalid_modules = [c for c in self.requested_modules if 'boost_' + c not in BOOST_LIBS]
         if invalid_modules:
-            mlog.debug('Invalid Boost modules: ' + ', '.join(invalid_modules))
+            mlog.warning('Invalid Boost modules: ' + ', '.join(invalid_modules))
             self.log_fail()
             return
 


### PR DESCRIPTION
BOOST_LIBS could become outdated in future versions, which would result
in dependency('boost', modules : [ 'foo' ], required : false) to fail,
although required was set to false. Therefore turn the exception into
log_fail(). If required was set to true, this will still be caught since
is_found remains False.

This also improves logging by printing all invalid module names instead
of only the first one.

I wanted to disable a part of my build using

```
boost_python_dep = dependency('boost', modules : [ 'python3' ], required : false)
if boost_python_dep.found()
    # ...
endif
```

for Meson versions before 14e7b0af2.