### PR TITLE
Qt5-Module: add `name` option to rcc

### DIFF
--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -108,7 +108,7 @@ class QtBaseModule:
                 name = 'qt' + str(self.qt_version) + '-' + basename.replace('.', '_')
             rcc_kwargs = {'input': rcc_files,
                           'output': name + '.cpp',
-                          'command': [self.rcc, '--name', '@BASENAME@', '-o', '@OUTPUT@', '@INPUT@'],
+                          'command': [self.rcc, '-name', '@BASENAME@', '-o', '@OUTPUT@', '@INPUT@'],
                           'depend_files': qrc_deps}
             res_target = build.CustomTarget(name, state.subdir, state.subproject, rcc_kwargs)
             sources.append(res_target)

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -108,7 +108,7 @@ class QtBaseModule:
                 name = 'qt' + str(self.qt_version) + '-' + basename.replace('.', '_')
             rcc_kwargs = {'input': rcc_files,
                           'output': name + '.cpp',
-                          'command': [self.rcc, '-o', '@OUTPUT@', '@INPUT@'],
+                          'command': [self.rcc, '--name', '@BASENAME@', '-o', '@OUTPUT@', '@INPUT@'],
                           'depend_files': qrc_deps}
             res_target = build.CustomTarget(name, state.subdir, state.subproject, rcc_kwargs)
             sources.append(res_target)

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -101,17 +101,25 @@ class QtBaseModule:
             qrc_deps = []
             for i in rcc_files:
                 qrc_deps += self.parse_qrc(state, i)
+            # custom output name set? -> one output file, multiple otherwise
             if len(args) > 0:
                 name = args[0]
+                rcc_kwargs = {'input': rcc_files,
+                              'output': name + '.cpp',
+                              'command': [self.rcc, '-name', name, '-o', '@OUTPUT@', '@INPUT@'],
+                              'depend_files': qrc_deps}
+                res_target = build.CustomTarget(name, state.subdir, state.subproject, rcc_kwargs)
+                sources.append(res_target)
             else:
-                basename = os.path.split(rcc_files[0])[1]
-                name = 'qt' + str(self.qt_version) + '-' + basename.replace('.', '_')
-            rcc_kwargs = {'input': rcc_files,
-                          'output': name + '.cpp',
-                          'command': [self.rcc, '-name', '@BASENAME@', '-o', '@OUTPUT@', '@INPUT@'],
-                          'depend_files': qrc_deps}
-            res_target = build.CustomTarget(name, state.subdir, state.subproject, rcc_kwargs)
-            sources.append(res_target)
+                for rcc_file in rcc_files:
+                    basename = os.path.split(rcc_file)[1]
+                    name = 'qt' + str(self.qt_version) + '-' + basename.replace('.', '_')
+                    rcc_kwargs = {'input': rcc_file,
+                                  'output': name + '.cpp',
+                                  'command': [self.rcc, '-name', '@BASENAME@', '-o', '@OUTPUT@', '@INPUT@'],
+                                  'depend_files': qrc_deps}
+                    res_target = build.CustomTarget(name, state.subdir, state.subproject, rcc_kwargs)
+                    sources.append(res_target)
         if len(ui_files) > 0:
             if not self.uic.found():
                 raise MesonException(err_msg.format('UIC', 'uic-qt' + self.qt_version))

--- a/test cases/frameworks/4 qt/main.cpp
+++ b/test cases/frameworks/4 qt/main.cpp
@@ -2,8 +2,10 @@
 #include "mainWindow.h"
 
 int main(int argc, char **argv) {
+  #ifndef UNITY_BUILD
   Q_INIT_RESOURCE(stuff);
   Q_INIT_RESOURCE(stuff2);
+  #endif
   QApplication app(argc, argv);
   MainWindow *win = new MainWindow();
   QImage qi(":/thing.png");

--- a/test cases/frameworks/4 qt/main.cpp
+++ b/test cases/frameworks/4 qt/main.cpp
@@ -2,6 +2,8 @@
 #include "mainWindow.h"
 
 int main(int argc, char **argv) {
+  Q_INIT_RESOURCE(stuff);
+  Q_INIT_RESOURCE(stuff2);
   QApplication app(argc, argv);
   MainWindow *win = new MainWindow();
   QImage qi(":/thing.png");
@@ -13,7 +15,20 @@ int main(int argc, char **argv) {
       return 1;
   }
   win->setWindowTitle("Meson Qt5 build test");
-
+  QLabel *label_stuff = win->findChild<QLabel *>("label_stuff");
+  if(label_stuff == nullptr) {
+      return 1;
+  }
+  int w = label_stuff->width();
+  int h = label_stuff->height();
+  label_stuff->setPixmap(QPixmap::fromImage(qi).scaled(w,h,Qt::KeepAspectRatio));
+  QLabel *label_stuff2 = win->findChild<QLabel *>("label_stuff2");
+  if(label_stuff2 == nullptr) {
+      return 1;
+  }
+  w = label_stuff2->width();
+  h = label_stuff2->height();
+  label_stuff2->setPixmap(QPixmap::fromImage(qi2).scaled(w,h,Qt::KeepAspectRatio));
   win->show();
   return app.exec();
   return 0;

--- a/test cases/frameworks/4 qt/mainWindow.ui
+++ b/test cases/frameworks/4 qt/mainWindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
-    <height>115</height>
+    <width>260</width>
+    <height>313</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -25,6 +25,26 @@
     </property>
     <property name="text">
      <string>I am a button</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_stuff">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>112</y>
+      <width>241</width>
+      <height>91</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_stuff2">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>212</y>
+      <width>241</width>
+      <height>91</height>
+     </rect>
     </property>
    </widget>
   </widget>

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -35,17 +35,26 @@ foreach qt : ['qt4', 'qt5']
     prep = qtmodule.preprocess(
       moc_headers : ['mainWindow.h'],           # These need to be fed through the moc tool before use. 
       ui_files : 'mainWindow.ui',               # XML files that need to be compiled with the uic tol.
-      qresources : ['stuff.qrc', 'stuff2.qrc'], # Resource file for rcc compiler.
       method : get_option('method')
     )
+
+    # Resource file(s) for rcc compiler
+    extra_cpp_args = []
+    if meson.is_unity()
+      extra_cpp_args += '-DUNITY_BUILD'
+      prep_rcc = qtmodule.preprocess(qt + '_unity_ressource', qresources : ['stuff.qrc', 'stuff2.qrc'], method : get_option('method'))
+    else
+      prep_rcc = qtmodule.preprocess(qresources : ['stuff.qrc', 'stuff2.qrc'], method : get_option('method'))
+    endif
 
     # Test that setting a unique name with a positional argument works
     qtmodule.preprocess(qt + 'teststuff', qresources : ['stuff.qrc', 'stuff2.qrc'], method : get_option('method'))
 
     qexe = executable(qt + 'app',
       sources : ['main.cpp', 'mainWindow.cpp', # Sources that don't need preprocessing.
-      prep],
-      dependencies : qtdep)
+      prep, prep_rcc],
+      dependencies : qtdep,
+      cpp_args: extra_cpp_args)
 
     # We need a console test application because some test environments
     # do not have an X server.

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -40,7 +40,7 @@ foreach qt : ['qt4', 'qt5']
     )
 
     # Test that setting a unique name with a positional argument works
-    qtmodule.preprocess(qt + 'teststuff', qresources : ['stuff.qrc'], method : get_option('method'))
+    qtmodule.preprocess(qt + 'teststuff', qresources : ['stuff.qrc', 'stuff2.qrc'], method : get_option('method'))
 
     qexe = executable(qt + 'app',
       sources : ['main.cpp', 'mainWindow.cpp', # Sources that don't need preprocessing.


### PR DESCRIPTION
This patch sets the --name option for files processed with
rcc. It generates an additional initialization function,
which can be used with static linking.

Signed-off-by: Markus Theil <markus.theil@tu-ilmenau.de>