### PR TITLE
Dump coredata earlier.

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -349,10 +349,9 @@ class Environment:
     def is_cross_build(self):
         return self.cross_info is not None
 
-    def dump_coredata(self, mtime):
+    def dump_coredata(self):
         cdf = os.path.join(self.get_build_dir(), Environment.coredata_file)
         coredata.save(self.coredata, cdf)
-        os.utime(cdf, times=(mtime, mtime))
         return cdf
 
     def get_script_dir(self):


### PR DESCRIPTION
Unfortunately, `time.time` and file timestamps are not guaranteed to be in sync and due to various kernel caches may be different enough to cause rebuilds to fail [1]. This was masked by older ninja versions that could not read sub-second timestamps.

[1] https://travis-ci.org/mesonbuild/meson/jobs/296797872