### PR TITLE
Fix use of deps in docs

### DIFF
--- a/docs/markdown/Subprojects.md
+++ b/docs/markdown/Subprojects.md
@@ -42,7 +42,7 @@ else
   l = sp.get_variable('l')
 endif
 exe = executable('prog', 'prog.c', include_directories : i, link_with : l,
-                 deps : dep, install : true)
+                 dependencies : dep, install : true)
 ```
 
 With this setup the system dependency is used when it is available, otherwise we fall back on the bundled version.


### PR DESCRIPTION
I copy-pasted from the example and it didn't work, so went to the reference manual and found out it is `dependencies` instead of `deps` (changed in 2c65b1f).