### PR TITLE
Let pkgconfig generation use external dependencies for libraries

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -17,6 +17,7 @@ import os
 from .. import build
 from .. import mesonlib
 from .. import mlog
+from . import dependencies
 from . import ModuleReturnValue
 from . import ExtensionModule
 from ..interpreterbase import permittedKwargs
@@ -78,6 +79,8 @@ class PkgConfigModule(ExtensionModule):
                 for l in libs:
                     if isinstance(l, str):
                         yield l
+                    elif isinstance(l, dependencies.ExternalLibrary):
+                        yield '-l%s' % l.get_name()
                     else:
                         install_dir = l.get_custom_install_dir()[0]
                         if install_dir is False:
@@ -115,7 +118,7 @@ class PkgConfigModule(ExtensionModule):
         for l in libs:
             if hasattr(l, 'held_object'):
                 l = l.held_object
-            if not isinstance(l, (build.SharedLibrary, build.StaticLibrary, str)):
+            if not isinstance(l, (build.SharedLibrary, build.StaticLibrary, dependencies.ExternalLibrary, str)):
                 raise mesonlib.MesonException('Library argument not a library object nor a string.')
             processed_libs.append(l)
         return processed_libs

--- a/test cases/common/51 pkgconfig-gen/meson.build
+++ b/test cases/common/51 pkgconfig-gen/meson.build
@@ -44,3 +44,17 @@ pkgg.generate(
   description : 'A foo library.',
   variables : ['foo=bar', 'datadir=${prefix}/data']
 )
+
+# Testing for external library inclusion
+libm = meson.get_compiler('c').find_library('m', required : true)
+
+lib3 = shared_library('libbar', 'simple.c',
+  name_prefix : '',
+  version : libver)
+
+pkgg.generate(
+  libraries : [ lib3, libm ],
+  name : 'libbar',
+  version : libver,
+  description : 'A foo library.',
+)


### PR DESCRIPTION
This allows for the pkgconfig generation to use the results of the
find_library method.
