### PR TITLE
llvm: fix static linking

### DIFF
--- a/test cases/frameworks/15 llvm/meson.build
+++ b/test cases/frameworks/15 llvm/meson.build
@@ -9,6 +9,12 @@ assert(d.found() == false, 'ancient llvm module found')
 d = dependency('llvm', optional_modules : 'not-found', required : false)
 assert(d.found() == true, 'optional module stopped llvm from being found.')
 
+dep_tinfo = dependency('tinfo', required : false)
+if not dep_tinfo.found()
+  cpp = meson.get_compiler('cpp')
+  dep_tinfo = cpp.find_library('tinfo')
+endif
+
 foreach static : [true, false]
   llvm_dep = dependency(
     'llvm',
@@ -22,9 +28,8 @@ foreach static : [true, false]
     'sum-@0@'.format(name),
     'sum.c',
     dependencies : [
-      llvm_dep,
+      llvm_dep, dep_tinfo,
       dependency('zlib'),
-      dependency('glib-2.0'),
       meson.get_compiler('c').find_library('dl', required : false),
     ]
   )


### PR DESCRIPTION
I left a hack patch in a pull request for LLVM, and the result is that
LLVM doesn't link with static builds. The real problem that needed 
to be solved is that some distros have pkg-config for tinfo, other's
don't, so the correct solution is to use cpp_compiler.find_library if 
dependency() fails.