### PR TITLE
Interpreter: ensure build_def_files defined before parse_project()

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1391,6 +1391,8 @@ class Interpreter(InterpreterBase):
         self.subproject_stack = []
         self.default_project_options = default_project_options[:] # Passed from the outside, only used in subprojects.
         self.build_func_dict()
+        # build_def_files needs to be defined before parse_project is called
+        self.build_def_files = [os.path.join(self.subdir, environment.build_filename)]
         self.parse_project()
         self.builtin['build_machine'] = BuildMachine(self.coredata.compilers)
         if not self.build.environment.is_cross_build():
@@ -1406,7 +1408,6 @@ class Interpreter(InterpreterBase):
                 self.builtin['target_machine'] = CrossMachineInfo(cross_info.config['target_machine'])
             else:
                 self.builtin['target_machine'] = self.builtin['host_machine']
-        self.build_def_files = [os.path.join(self.subdir, environment.build_filename)]
 
     def build_func_dict(self):
         self.funcs.update({'add_global_arguments': self.func_add_global_arguments,


### PR DESCRIPTION
Mesa has 4 build systems currently, set our version in a file called
VERSION, and read that in to each build system to simplify the release
process. For meson this is accomplished by using run_command within the
project() function declaration itself, and with meson <= 0.43.0 this
works fine. Commit 1b0048a7022a89f461cf4d01e7cdbf995bab70f5 makes
scripts that are run through run_command a rebuild dependency, but the
attribute used to store that information is set after the project()
command is processed. This breaks mesa.

The solution is to set that list before calling parse_project.

Fixes #2597