### PR TITLE
Print correct command in help message

### DIFF
--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -17,7 +17,7 @@ import pickle
 import argparse
 from . import coredata, mesonlib
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(prog='meson configure')
 
 parser.add_argument('-D', action='append', default=[], dest='sets',
                     help='Set an option to the given value.')

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -24,7 +24,7 @@ from .mesonlib import MesonException
 from .wrap import WrapMode, wraptool
 
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(prog='meson')
 
 default_warning = '1'
 

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -25,7 +25,7 @@ import argparse
 import sys, os
 import pathlib
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(prog='meson introspect')
 parser.add_argument('--targets', action='store_true', dest='list_targets', default=False,
                     help='List top level targets.')
 parser.add_argument('--installed', action='store_true', dest='list_installed', default=False,

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -58,7 +58,7 @@ def determine_worker_count():
             num_workers = 1
     return num_workers
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(prog='meson test')
 parser.add_argument('--repeat', default=1, dest='repeat', type=int,
                     help='Number of times to run the tests.')
 parser.add_argument('--no-rebuild', default=False, action='store_true',

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -29,7 +29,7 @@ from mesonbuild import mlog
 import sys, traceback
 import argparse
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(prog='meson rewrite')
 
 parser.add_argument('--sourcedir', default='.',
                     help='Path to source directory.')


### PR DESCRIPTION
Taking mconf for instance:
before:

    $ meson configure --help
    usage: meson [-h] [-D SETS] [--clearcache] [directory [directory ...]]

after:

    $ meson configure --help
    usage: meson configure [-h] [-D SETS] [--clearcache] [directory [directory ...]]