### PR TITLE
gnome: Add include_directories parameter to gtkdoc()

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -723,7 +723,7 @@ This will become a hard error in the future.''')
     @permittedKwargs({'main_xml', 'main_sgml', 'src_dir', 'dependencies', 'install',
                       'install_dir', 'scan_args', 'scanobjs_args', 'gobject_typesfile',
                       'fixxref_args', 'html_args', 'html_assets', 'content_files',
-                      'mkdb_args', 'ignore_headers'})
+                      'mkdb_args', 'ignore_headers', 'include_directories'})
     def gtkdoc(self, state, args, kwargs):
         if len(args) != 1:
             raise MesonException('Gtkdoc must have one positional argument.')


### PR DESCRIPTION
It is already used by generate_gir(), and allow to fix nicely https://bugzilla.gnome.org/show_bug.cgi?id=786796