### PR TITLE
Fix path for str arguments to depend_files

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -738,9 +738,9 @@ class Backend:
                     deps.append(i.rel_to_builddir(self.build_to_src))
             else:
                 if absolute_paths:
-                    deps.append(os.path.join(self.environment.get_build_dir(), i))
+                    deps.append(os.path.join(self.environment.get_source_dir(), target.subdir, i))
                 else:
-                    deps.append(os.path.join(self.build_to_src, i))
+                    deps.append(os.path.join(self.build_to_src, target.subdir, i))
         return deps
 
     def eval_custom_target_command(self, target, absolute_outputs=False):

--- a/test cases/common/166 custom target subdir depend files/copyfile.py
+++ b/test cases/common/166 custom target subdir depend files/copyfile.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import sys
+import shutil
+
+shutil.copyfile(sys.argv[1], sys.argv[2])

--- a/test cases/common/166 custom target subdir depend files/meson.build
+++ b/test cases/common/166 custom target subdir depend files/meson.build
@@ -1,0 +1,7 @@
+project('custom target subdir depend files', 'c')
+
+copy = find_program('copyfile.py')
+
+subdir('subdir')
+
+executable('foo', foo_src)

--- a/test cases/common/166 custom target subdir depend files/subdir/dep.dat
+++ b/test cases/common/166 custom target subdir depend files/subdir/dep.dat
@@ -1,0 +1,1 @@
+You can depend on this file.

--- a/test cases/common/166 custom target subdir depend files/subdir/foo.c.in
+++ b/test cases/common/166 custom target subdir depend files/subdir/foo.c.in
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+    printf("foo is working.\n");
+    return 0;
+}

--- a/test cases/common/166 custom target subdir depend files/subdir/meson.build
+++ b/test cases/common/166 custom target subdir depend files/subdir/meson.build
@@ -1,0 +1,6 @@
+foo_src = custom_target('foo_src',
+  depend_files : 'dep.dat',
+  input : 'foo.c.in',
+  output : 'foo.c',
+  command : [copy, '@INPUT@', '@OUTPUT@']
+)


### PR DESCRIPTION
This is an attempt to fix #2633.

I can't get the unit tests to run locally (looks like it fails due to meson not being on same drive as temp directory), so opening a PR to see what CI says.
