### PR TITLE
Silence failed restorecon calls when $DESTDIR is set

### DIFF
--- a/mesonbuild/scripts/meson_install.py
+++ b/mesonbuild/scripts/meson_install.py
@@ -87,6 +87,8 @@ def set_mode(path, mode):
 def restore_selinux_contexts():
     '''
     Restores the SELinux context for files in @selinux_updates
+
+    If $DESTDIR is set, do not warn if the call fails.
     '''
     try:
         subprocess.check_call(['selinuxenabled'])
@@ -98,7 +100,7 @@ def restore_selinux_contexts():
     with subprocess.Popen(['restorecon', '-F', '-f-', '-0'],
                           stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as proc:
         out, err = proc.communicate(input=b'\0'.join(os.fsencode(f) for f in selinux_updates) + b'\0')
-        if proc.returncode != 0:
+        if proc.returncode != 0 and not os.environ.get('DESTDIR'):
             print('Failed to restore SELinux context of installed files...',
                   'Standard output:', out.decode(),
                   'Standard error:', err.decode(), sep='\n')


### PR DESCRIPTION
This avoids hundres of warnings like:
Warning no default label for /var/tmp/instroot.hUbtYJ/path/to/some/binary

$DESTDIR is usually set to a temporary path, in which case the path is
unknown to selinux. For that case we could just skip the restorecon
calls.  But sometimes it is used with a path to container. In that
case, most of the time, selinux has no context for that path. But we
can't rule that out somebody added custom context rules for the
container. So let's still call restorecon, but silence the warning.