### PR TITLE
docs: Add 'cygwin' to reference table for .system()

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -55,6 +55,7 @@ These are provided by the `.system()` method call.
 | linux               | |
 | darwin              | Either OSX or iOS |
 | windows             | Any version of Windows |
+| cygwin              | The Cygwin environment for Windows |
 
 Any string not listed above is not guaranteed to remain stable in
 future releases.


### PR DESCRIPTION
This aligns this table with the set of values tested for by test case
common/140