### PR TITLE
Use re.sub instead of replace loop

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -394,9 +394,9 @@ def get_library_dirs():
 
 
 def do_replacement(regex, line, confdata):
-    match = re.search(regex, line)
     missing_variables = set()
-    while match:
+
+    def variable_replace(match):
         varname = match.group(1)
         if varname in confdata:
             (var, desc) = confdata.get(varname)
@@ -409,9 +409,8 @@ def do_replacement(regex, line, confdata):
         else:
             missing_variables.add(varname)
             var = ''
-        line = line.replace('@' + varname + '@', var)
-        match = re.search(regex, line)
-    return line, missing_variables
+        return var
+    return re.sub(regex, variable_replace, line), missing_variables
 
 def do_mesondefine(line, confdata):
     arr = line.split()
@@ -443,7 +442,7 @@ def do_conf_file(src, dst, confdata):
         raise MesonException('Could not read input file %s: %s' % (src, str(e)))
     # Only allow (a-z, A-Z, 0-9, _, -) as valid characters for a define
     # Also allow escaping '@' with '\@'
-    regex = re.compile(r'[^\\]?@([-a-zA-Z0-9_]+)@')
+    regex = re.compile(r'(?<!\\)@([-a-zA-Z0-9_]+)@')
     result = []
     missing_variables = set()
     for line in data:

--- a/test cases/common/16 configure file/config5.h.in
+++ b/test cases/common/16 configure file/config5.h.in
@@ -1,0 +1,1 @@
+#define MESSAGE "@var@"

--- a/test cases/common/16 configure file/meson.build
+++ b/test cases/common/16 configure file/meson.build
@@ -109,3 +109,14 @@ configs = [
 foreach c : configs
     test('@0@'.format(c), file_contains_py, args: [ c, test_string ])
 endforeach
+
+# Test variable is substituted only once
+conf5 = configuration_data()
+conf5.set('var', '@var2@')
+conf5.set('var2', 'error')
+configure_file(
+  input : 'config5.h.in',
+  output : '@BASENAME@',
+  configuration : conf5
+)
+test('test5', executable('prog5', 'prog5.c'))

--- a/test cases/common/16 configure file/prog5.c
+++ b/test cases/common/16 configure file/prog5.c
@@ -1,0 +1,6 @@
+#include <string.h>
+#include <config5.h>
+
+int main(int argc, char **argv) {
+    return strcmp(MESSAGE, "@var2@");
+}


### PR DESCRIPTION
This should make the replace faster (at least time complexity wise, practice needs timing). Also this avoids recursive substitutions like:
~~~Meson
c = configuration_data()

c.set('a', '@a@@a@')

configure_file(
  input : 'evil.in',
  output : 'evil',
  configuration : c
)
~~~
where file `evil.in` contains `@a@`.

I don't know if any project depends on recursive substitution, but I hope not.