### PR TITLE
Fix literal backslash syntax

### DIFF
--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -84,7 +84,7 @@ single quote do it like this:
 single quote = 'contains a \' character'
 ```
 
-Similarly `\n` gets converted to a newline and `\\\\` to a single
+Similarly `\n` gets converted to a newline and `\\` to a single
 backslash.
 
 #### String concatenation


### PR DESCRIPTION
In CommonMark, there are no backslash escapes in code spans, so only two backslashes in the source document are necessary to produce two backslashes in the output document.