### PR TITLE
Fix string format recursive replace

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2983,12 +2983,19 @@ different subdirectory.
     def format_string(self, templ, args):
         if isinstance(args, mparser.ArgumentNode):
             args = args.arguments
-        for (i, arg) in enumerate(args):
+        arg_strings = []
+        for arg in args:
             arg = self.evaluate_statement(arg)
             if isinstance(arg, bool): # Python boolean is upper case.
                 arg = str(arg).lower()
-            templ = templ.replace('@{}@'.format(i), str(arg))
-        return templ
+            arg_strings.append(str(arg))
+
+        def arg_replace(match):
+            idx = int(match.group(1))
+            if idx >= len(arg_strings):
+                raise InterpreterException('Format placeholder @{}@ out of range.'.format(idx))
+            return arg_strings[idx]
+        return re.sub(r'@(\d+)@', arg_replace, templ)
 
     # Only permit object extraction from the same subproject
     def validate_extraction(self, buildtarget):

--- a/test cases/common/42 string operations/meson.build
+++ b/test cases/common/42 string operations/meson.build
@@ -13,6 +13,8 @@ subs2 = '42'
 
 assert(templ2.format(subs2) == '42', 'String formatting with variables is broken.')
 
+assert('@@0@@ @@1@@'.format(1, 2) == '@1@ @2@', 'String format is recursive.')
+
 long = 'abcde'
 prefix = 'abc'
 suffix = 'cde'


### PR DESCRIPTION
Currently `format_string()` replaces all occurrences of each placeholder in turn. This can lead to wrong results like:
~~~Meson
# prints '2 @2@' instead of '@1@ @2@'
message('@@0@@ @@1@@'.format(1, 2))

# prints MesonMesonMesonMesonMesonMesonMesonMeson instead of @1@@1@
message('@0@'.format('@1@@1@', '@2@@2@', '@3@@3@', 'Meson'))
~~~

This also adds an error if a placeholder index is out of range in the format string -- I don't know if this is a good idea, or if a warning would be better.