### PR TITLE
dependencies: Allow pkg-config to define variables

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -117,7 +117,7 @@ class Dependency:
     def need_threads(self):
         return False
 
-    def get_pkgconfig_variable(self, variable_name):
+    def get_pkgconfig_variable(self, variable_name, kwargs):
         raise NotImplementedError('{!r} is not a pkgconfig dependency'.format(self.name))
 
 
@@ -316,8 +316,20 @@ class PkgConfigDependency(ExternalDependency):
                 self.is_libtool = True
             self.link_args.append(lib)
 
-    def get_pkgconfig_variable(self, variable_name):
-        ret, out = self._call_pkgbin(['--variable=' + variable_name, self.name])
+    def get_pkgconfig_variable(self, variable_name, kwargs):
+        options = ['--variable=' + variable_name, self.name]
+
+        if 'define_variable' in kwargs:
+          definition = kwargs.get('define_variable', [])
+          if not isinstance(definition, list):
+              raise MesonException('define_variable takes a list')
+
+          if len(definition) != 2 or not all(isinstance(i, str) for i in definition):
+              raise MesonException('define_variable must be made up of 2 strings for VARIABLENAME and VARIABLEVALUE')
+
+          options = ['--define-variable=' + '='.join(definition)] + options
+
+        ret, out = self._call_pkgbin(options)
         variable = ''
         if ret != 0:
             if self.required:

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -320,14 +320,14 @@ class PkgConfigDependency(ExternalDependency):
         options = ['--variable=' + variable_name, self.name]
 
         if 'define_variable' in kwargs:
-          definition = kwargs.get('define_variable', [])
-          if not isinstance(definition, list):
-              raise MesonException('define_variable takes a list')
+            definition = kwargs.get('define_variable', [])
+            if not isinstance(definition, list):
+                raise MesonException('define_variable takes a list')
 
-          if len(definition) != 2 or not all(isinstance(i, str) for i in definition):
-              raise MesonException('define_variable must be made up of 2 strings for VARIABLENAME and VARIABLEVALUE')
+            if len(definition) != 2 or not all(isinstance(i, str) for i in definition):
+                raise MesonException('define_variable must be made up of 2 strings for VARIABLENAME and VARIABLEVALUE')
 
-          options = ['--define-variable=' + '='.join(definition)] + options
+            options = ['--define-variable=' + '='.join(definition)] + options
 
         ret, out = self._call_pkgbin(options)
         variable = ''

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -677,11 +677,11 @@ class Python3Dependency(ExternalDependency):
         else:
             return [DependencyMethods.PKGCONFIG]
 
-    def get_pkgconfig_variable(self, variable_name):
+    def get_pkgconfig_variable(self, variable_name, kwargs):
         if self.pkgdep:
-            return self.pkgdep.get_pkgconfig_variable(variable_name)
+            return self.pkgdep.get_pkgconfig_variable(variable_name, kwargs)
         else:
-            return super().get_pkgconfig_variable(variable_name)
+            return super().get_pkgconfig_variable(variable_name, kwargs)
 
 
 class PcapDependency(ExternalDependency):

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -240,7 +240,7 @@ class QtBaseDependency(ExternalDependency):
         self.bindir = self.get_pkgconfig_host_bins(core)
         if not self.bindir:
             # If exec_prefix is not defined, the pkg-config file is broken
-            prefix = core.get_pkgconfig_variable('exec_prefix')
+            prefix = core.get_pkgconfig_variable('exec_prefix', {})
             if prefix:
                 self.bindir = os.path.join(prefix, 'bin')
 
@@ -360,7 +360,7 @@ class Qt4Dependency(QtBaseDependency):
         applications = ['moc', 'uic', 'rcc', 'lupdate', 'lrelease']
         for application in applications:
             try:
-                return os.path.dirname(core.get_pkgconfig_variable('%s_location' % application))
+                return os.path.dirname(core.get_pkgconfig_variable('%s_location' % application, {}))
             except MesonException:
                 pass
 
@@ -370,7 +370,7 @@ class Qt5Dependency(QtBaseDependency):
         QtBaseDependency.__init__(self, 'qt5', env, kwargs)
 
     def get_pkgconfig_host_bins(self, core):
-        return core.get_pkgconfig_variable('host_bins')
+        return core.get_pkgconfig_variable('host_bins', {})
 
 
 # There are three different ways of depending on SDL2:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -294,7 +294,7 @@ class DependencyHolder(InterpreterObject, ObjectHolder):
         varname = args[0]
         if not isinstance(varname, str):
             raise InterpreterException('Variable name must be a string.')
-        return self.held_object.get_pkgconfig_variable(varname)
+        return self.held_object.get_pkgconfig_variable(varname, kwargs)
 
 class InternalDependencyHolder(InterpreterObject, ObjectHolder):
     def __init__(self, dep):

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -370,7 +370,7 @@ class GnomeModule(ExtensionModule):
                     ldflags.update([lib])
 
                 if isinstance(dep, PkgConfigDependency):
-                    girdir = dep.get_pkgconfig_variable("girdir")
+                    girdir = dep.get_pkgconfig_variable("girdir", {})
                     if girdir:
                         gi_includes.update([girdir])
             elif isinstance(dep, (build.StaticLibrary, build.SharedLibrary)):
@@ -561,7 +561,7 @@ class GnomeModule(ExtensionModule):
                         if subdir not in typelib_includes:
                             typelib_includes.append(subdir)
             elif isinstance(dep, PkgConfigDependency):
-                girdir = dep.get_pkgconfig_variable("girdir")
+                girdir = dep.get_pkgconfig_variable("girdir", {})
                 if girdir and girdir not in typelib_includes:
                     typelib_includes.append(girdir)
         # ldflags will be misinterpreted by gir scanner (showing

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1807,8 +1807,8 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertTrue(foo_dep.found())
         self.assertEqual(foo_dep.get_version(), '1.0')
         self.assertIn('-lfoo', foo_dep.get_link_args())
-        self.assertEqual(foo_dep.get_pkgconfig_variable('foo'), 'bar')
-        self.assertPathEqual(foo_dep.get_pkgconfig_variable('datadir'), '/usr/data')
+        self.assertEqual(foo_dep.get_pkgconfig_variable('foo', {}), 'bar')
+        self.assertPathEqual(foo_dep.get_pkgconfig_variable('datadir', {}), '/usr/data')
 
     def test_vala_c_warnings(self):
         '''

--- a/test cases/linuxlike/1 pkg-config/meson.build
+++ b/test cases/linuxlike/1 pkg-config/meson.build
@@ -17,6 +17,8 @@ test('zlibtest', exe)
 zprefix = dep.get_pkgconfig_variable('prefix') # Always set but we can't be sure what the value is.
 # pkg-config returns empty string for not defined variables
 assert(dep.get_pkgconfig_variable('nonexisting') == '', 'Value of unknown variable is not empty.')
+# pkg-config is able to replace variables
+assert(dep.get_pkgconfig_variable('includedir', define_variable: ['prefix', '/tmp']) == '/tmp/include', 'prefix variable has not been replaced.')
 
 # Test that dependencies of dependencies work.
 dep2 = declare_dependency(dependencies : dep)

--- a/test cases/linuxlike/1 pkg-config/meson.build
+++ b/test cases/linuxlike/1 pkg-config/meson.build
@@ -18,7 +18,7 @@ zprefix = dep.get_pkgconfig_variable('prefix') # Always set but we can't be sure
 # pkg-config returns empty string for not defined variables
 assert(dep.get_pkgconfig_variable('nonexisting') == '', 'Value of unknown variable is not empty.')
 # pkg-config is able to replace variables
-assert(dep.get_pkgconfig_variable('includedir', define_variable: ['prefix', '/tmp']) == '/tmp/include', 'prefix variable has not been replaced.')
+assert(dep.get_pkgconfig_variable('prefix', define_variable: ['prefix', '/tmp']) == '/tmp', 'prefix variable has not been replaced.')
 
 # Test that dependencies of dependencies work.
 dep2 = declare_dependency(dependencies : dep)


### PR DESCRIPTION
pkg-config enables to define variables by using the `--define-variable` option. This allows some packages to redefine relative paths, so files can be installed in the same relative paths but under prefix.

This code tries to solve the problem with some GNOME packages, where they generate `D-Bus` services, `systemd` units, `gio` modules, etc.. All of these have in common that the paths where those files have to be located, can be checked on their correspondant `pc` files. However, although those paths are relative to some defined variables, they are pointing to paths in the system, which may cause some issues on installation.