### PR TITLE
Improve escaping in configuration files

### DIFF
--- a/test cases/common/16 configure file/config6.h.in
+++ b/test cases/common/16 configure file/config6.h.in
@@ -1,0 +1,19 @@
+/* No escape */
+#define MESSAGE1 "@var1@"
+
+/* Single escape means no replace */
+#define MESSAGE2 "\@var1@"
+
+/* Replace pairs of escapes before '@' or '\@' with escape characters
+ * (note we have to double number of pairs due to C string escaping)
+ */
+#define MESSAGE3 "\\\\@var1@"
+
+/* Pairs of escapes and then single escape to avoid replace */
+#define MESSAGE4 "\\\\\@var1@"
+
+/* Check escaped variable does not overlap following variable */
+#define MESSAGE5 "\@var1@var2@"
+
+/* Check escape character outside variables */
+#define MESSAGE6 "\\ @ \@ \\\\@ \\\\\@"

--- a/test cases/common/16 configure file/meson.build
+++ b/test cases/common/16 configure file/meson.build
@@ -120,3 +120,14 @@ configure_file(
   configuration : conf5
 )
 test('test5', executable('prog5', 'prog5.c'))
+
+# Test escaping
+conf6 = configuration_data()
+conf6.set('var1', 'foo')
+conf6.set('var2', 'bar')
+configure_file(
+  input : 'config6.h.in',
+  output : '@BASENAME@',
+  configuration : conf6
+)
+test('test6', executable('prog6', 'prog6.c'))

--- a/test cases/common/16 configure file/prog6.c
+++ b/test cases/common/16 configure file/prog6.c
@@ -1,0 +1,11 @@
+#include <string.h>
+#include <config6.h>
+
+int main(int argc, char **argv) {
+    return strcmp(MESSAGE1, "foo")
+        || strcmp(MESSAGE2, "@var1@")
+        || strcmp(MESSAGE3, "\\foo")
+        || strcmp(MESSAGE4, "\\@var1@")
+        || strcmp(MESSAGE5, "@var1bar")
+        || strcmp(MESSAGE6, "\\ @ @ \\@ \\@");
+}


### PR DESCRIPTION
This attempts to address the issues with escaping in configuration files mentioned in #2667.

Specifically,
  - The escape character is removed from the output (`\@var@` -> `@var@`)
  - Two escapes before `@` inserts a literal `\`
  - Escaped `@` no longer prevents next variable from working (`\@random@var@`)
