### PR TITLE
configure_file: Compare difference in binary mode

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -534,7 +534,7 @@ def replace_if_different(dst, dst_tmp):
     # unnecessary rebuilds.
     different = True
     try:
-        with open(dst, 'r') as f1, open(dst_tmp, 'r') as f2:
+        with open(dst, 'rb') as f1, open(dst_tmp, 'rb') as f2:
             if f1.read() == f2.read():
                 different = False
     except FileNotFoundError:


### PR DESCRIPTION
Otherwise Python will try to use string decode on the configured file and fail if it contains characters that can't be mapped to the current encoding.