### PR TITLE
Don't print traceback when options are invalid

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -300,7 +300,11 @@ def run(original_args, mainfile=None):
         elif cmd_name == 'rewrite':
             return rewriter.run(remaining_args)
         elif cmd_name == 'configure':
-            return mconf.run(remaining_args)
+            try:
+                return mconf.run(remaining_args)
+            except MesonException as e:
+                mlog.log(mlog.red('\nError configuring project:'), e)
+                sys.exit(1)
         elif cmd_name == 'wrap':
             return wraptool.run(remaining_args)
         elif cmd_name == 'runpython':


### PR DESCRIPTION
Currently passing a bad combo or array option, providing a non-boolean
to a bool arg, or a host of other things can cause an traceback from a
MesonException, don't do that.

Fixes #2683