### PR TITLE
adding C++98 to versions that meson can support as combo options

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -76,7 +76,7 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
 
     def get_options(self):
         return {'cpp_std': coredata.UserComboOption('cpp_std', 'C++ language standard to use',
-                                                    ['none', 'c++03', 'c++11', 'c++14', 'c++1z',
+                                                    ['none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++1z',
                                                      'gnu++11', 'gnu++14', 'gnu++1z'],
                                                     'none')}
 
@@ -102,7 +102,7 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
 
     def get_options(self):
         opts = {'cpp_std': coredata.UserComboOption('cpp_std', 'C++ language standard to use',
-                                                    ['none', 'c++03', 'c++11', 'c++14', 'c++1z',
+                                                    ['none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++1z',
                                                      'gnu++03', 'gnu++11', 'gnu++14', 'gnu++1z'],
                                                     'none'),
                 'cpp_debugstl': coredata.UserBooleanOption('cpp_debugstl',


### PR DESCRIPTION
A package i am porting to meson needs c++98, shouldn't this be enough, or is more required?