### PR TITLE
Enable ANSI colors on Windows when ANSICON is set

### DIFF
--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -18,8 +18,10 @@ import sys, os, platform, io
 information about Meson runs. Some output goes to screen,
 some to logging dir and some goes to both."""
 
-colorize_console = platform.system().lower() != 'windows' and os.isatty(sys.stdout.fileno()) and \
-    os.environ.get('TERM') != 'dumb'
+if platform.system().lower() == 'windows':
+    colorize_console = os.isatty(sys.stdout.fileno()) and os.environ.get('ANSICON')
+else:
+    colorize_console = os.isatty(sys.stdout.fileno()) and os.environ.get('TERM') != 'dumb'
 log_dir = None
 log_file = None
 log_fname = 'meson-log.txt'


### PR DESCRIPTION
At the moment ANSI output is disabled on Windows. This enables it when the `ANSICON` environment variable is set, which [ConEmu does](https://conemu.github.io/en/AnsiEscapeCodes.html#Environment_variable).

Recent versions of Windows 10 have an option to enable ANSI support in command prompts, but detecting it requires [calling Windows API](https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences), so it is a bit more involved.