### PR TITLE
[Tests] Minor update for CI on Fedora

### DIFF
--- a/test cases/frameworks/9 wxwidgets/meson.build
+++ b/test cases/frameworks/9 wxwidgets/meson.build
@@ -1,4 +1,4 @@
-project('wxwidgets test', 'cpp')
+project('wxwidgets test', 'cpp', default_options : ['cpp_std=c++11'])
 
 wxd = dependency('wxwidgets', version : '>=5', required : false)
 wxd = dependency('wxwidgets', version : '>=3.0.0', required : false)


### PR DESCRIPTION
'test cases/frameworks/9 wxwidgets' fails to build with clang on Fedora because it needs C++11 enabled.

Full log:
```
[0/1] Regenerating build files.
The Meson build system
Version: 0.44.0.dev1
Source dir: /home/jeandet/Documents/prog/meson/test cases/frameworks/9 wxwidgets
Build dir: /home/jeandet/Documents/prog/meson/test cases/frameworks/9 wxwidgets/build
Build type: native build
Project name: wxwidgets test
Native C++ compiler: clang++ (clang 4.0.1)
Build machine cpu family: x86_64
Build machine cpu: x86_64
Found wx-config: /usr/bin/wx-config-3.0 (3.0.3)
Wxwidgets version 3.0.3 does not fullfill requirement >=5
Build targets in project: 1
Found ninja-1.8.2 at /usr/bin/ninja
[1/2] Compiling C++ object 'wxprog@exe/wxprog.cpp.o'.
FAILED: wxprog@exe/wxprog.cpp.o 
clang++  -Iwxprog@exe -I. -I.. -I/usr/lib64/wx/include/gtk3-unicode-3.0 -I/usr/include/wx-3.0 -Xclang -fcolor-diagnostics -pipe -Wall -Winvalid-pch -Wnon-virtual-dtor -O0 -g -D_FILE_OFFSET_BITS=64 -DWXUSINGDLL -D__WXGTK__ -pthread -MMD -MQ 'wxprog@exe/wxprog.cpp.o' -MF 'wxprog@exe/wxprog.cpp.o.d' -o 'wxprog@exe/wxprog.cpp.o' -c ../wxprog.cpp
In file included from ../wxprog.cpp:1:
In file included from ../mainwin.h:3:
In file included from /usr/include/wx-3.0/wx/wx.h:15:
In file included from /usr/include/wx-3.0/wx/object.h:19:
In file included from /usr/include/wx-3.0/wx/memory.h:15:
In file included from /usr/include/wx-3.0/wx/string.h:46:
In file included from /usr/include/wx-3.0/wx/strvararg.h:25:
In file included from /usr/bin/../lib/gcc/x86_64-redhat-linux/7/../../../../include/c++/7/type_traits:35:
/usr/bin/../lib/gcc/x86_64-redhat-linux/7/../../../../include/c++/7/bits/c++0x_warning.h:32:2: error: This file requires compiler and library support for the ISO C++ 2011 standard. This support must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
#error This file requires compiler and library support \
 ^
In file included from ../wxprog.cpp:1:
In file included from ../mainwin.h:3:
In file included from /usr/include/wx-3.0/wx/wx.h:15:
In file included from /usr/include/wx-3.0/wx/object.h:19:
In file included from /usr/include/wx-3.0/wx/memory.h:15:
In file included from /usr/include/wx-3.0/wx/string.h:46:
/usr/include/wx-3.0/wx/strvararg.h:350:18: error: no type named 'is_enum' in namespace 'std'
    typedef std::is_enum<T> is_enum;
            ~~~~~^
/usr/include/wx-3.0/wx/strvararg.h:350:25: error: expected member name or ';' after declaration specifiers
    typedef std::is_enum<T> is_enum;
    ~~~~~~~~~~~~~~~~~~~~^
/usr/include/wx-3.0/wx/strvararg.h:354:54: error: use of undeclared identifier 'is_enum'
    enum { value = wxFormatStringSpecifierNonPodType<is_enum::value>::value };
                                                     ^
4 errors generated.
ninja: build stopped: subcommand failed.

```