### PR TITLE
vala: add stubs for thread flag methods

### DIFF
--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -94,3 +94,9 @@ class ValaCompiler(Compiler):
                 return [vapi]
         mlog.debug('Searched {!r} and {!r} wasn\'t found'.format(extra_dirs, libname))
         return None
+
+    def thread_flags(self):
+        return []
+
+    def thread_link_flags(self):
+        return []


### PR DESCRIPTION
As the Vala compiler does not define thread_flags() and
thread_link_flags(), depending on threads in any capacity will cause Meson to
fail.

Fixes #2720.