### PR TITLE
Fix `array` type name

### DIFF
--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -140,7 +140,7 @@ def add_keys(optlist, options):
             optdict['choices'] = opt.choices
             typestr = 'combo'
         elif isinstance(opt, coredata.UserArrayOption):
-            typestr = 'stringarray'
+            typestr = 'array'
         else:
             raise RuntimeError("Unknown option type")
         optdict['type'] = typestr

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1588,7 +1588,7 @@ int main(int argc, char **argv) {
         expected = {
             'name': 'list',
             'description': 'list',
-            'type': 'stringarray',
+            'type': 'array',
             'value': ['foo', 'bar'],
         }
         tdir = os.path.join(self.unit_test_dir, '18 array option')
@@ -1612,7 +1612,7 @@ int main(int argc, char **argv) {
         expected = {
             'name': 'list',
             'description': 'list',
-            'type': 'stringarray',
+            'type': 'array',
             'value': ['foo', 'bar'],
         }
         tdir = os.path.join(self.unit_test_dir, '18 array option')

--- a/test cases/common/169 array option/meson.build
+++ b/test cases/common/169 array option/meson.build
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-project('stringarray default options')
+project('array default options')
 
 assert(get_option('array') == ['foo', 'bar'], 'Default value for array is not equal to choices')


### PR DESCRIPTION
c9351ce30c03d107279090da7825096951a705d3 introduced the type as `array`, so mintro should expose it under the same name.

(while at it, rename test 169 to be coherent)

Note that there's one last `stringarray` reference in the code, at [run_unittests.py:1635](https://github.com/mesonbuild/meson/blob/master/run_unittests.py#L1635), which is an unused function. Didn't dig into it more, but I'm guessing there's a call missing from somewhere?