### PR TITLE
Improve error handling when failing to execute program.

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -275,7 +275,10 @@ def run_script_command(args):
         cmdfunc = abc.run
     else:
         raise MesonException('Unknown internal command {}.'.format(cmdname))
-    return cmdfunc(cmdargs)
+    try:
+        return cmdfunc(cmdargs)
+    except PermissionError as err:
+        raise MesonException('Error executing "{}". {}'.format(cmdargs[-1], err))
 
 def run(original_args, mainfile=None):
     if sys.version_info < (3, 4):

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -275,10 +275,7 @@ def run_script_command(args):
         cmdfunc = abc.run
     else:
         raise MesonException('Unknown internal command {}.'.format(cmdname))
-    try:
-        return cmdfunc(cmdargs)
-    except PermissionError as err:
-        raise MesonException('Error executing "{}". {}'.format(cmdargs[-1], err))
+    return cmdfunc(cmdargs)
 
 def run(original_args, mainfile=None):
     if sys.version_info < (3, 4):

--- a/mesonbuild/scripts/commandrunner.py
+++ b/mesonbuild/scripts/commandrunner.py
@@ -40,6 +40,9 @@ def run_command(source_dir, build_dir, subdir, meson_command, command, arguments
     except FileNotFoundError:
         print('Could not execute command "%s". File not found.' % command)
         sys.exit(1)
+    except PermissionError:
+        print('Could not execute command "%s". File not executable.' % command)
+        sys.exit(1)
 
 def run(args):
     if len(args) < 4:

--- a/mesonbuild/scripts/commandrunner.py
+++ b/mesonbuild/scripts/commandrunner.py
@@ -38,7 +38,7 @@ def run_command(source_dir, build_dir, subdir, meson_command, command, arguments
     try:
         return subprocess.Popen(command_array, env=child_env, cwd=cwd)
     except FileNotFoundError:
-        print('Could not execute command "%s".' % command)
+        print('Could not execute command "%s". File not found.' % command)
         sys.exit(1)
 
 def run(args):


### PR DESCRIPTION
When trying to run a program and the program is not found mention the error cause explicitly in the error message.

Catch if executing a program fails due to file permissions and raise a proper error. This fixes #2733.

Should meson check for more errors when trying to execute a program and generally fail more gracefully?