### PR TITLE
dependencies: Don't use NotImplementedError for invalid methods

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -131,10 +131,10 @@ class Dependency:
         return False
 
     def get_pkgconfig_variable(self, variable_name, kwargs):
-        raise NotImplementedError('{!r} is not a pkgconfig dependency'.format(self.name))
+        raise DependencyException('{!r} is not a pkgconfig dependency'.format(self.name))
 
     def get_configtool_variable(self, variable_name):
-        raise NotImplementedError('{!r} is not a config-tool dependency'.format(self.name))
+        raise DependencyException('{!r} is not a config-tool dependency'.format(self.name))
 
 
 class InternalDependency(Dependency):
@@ -148,6 +148,14 @@ class InternalDependency(Dependency):
         self.libraries = libraries
         self.sources = sources
         self.ext_deps = ext_deps
+
+    def get_pkgconfig_variable(self, variable_name, kwargs):
+        raise DependencyException('Method "get_pkgconfig_variable()" is '
+                                  'invalid for an internal dependency')
+
+    def get_configtool_variable(self, variable_name):
+        raise DependencyException('Method "get_configtool_variable()" is '
+                                  'invalid for an internal dependency')
 
 
 class ExternalDependency(Dependency):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1766,6 +1766,22 @@ class FailureTests(BasePlatformTests):
         self.assertMesonRaises("dependency('boost')",
                                "(BOOST_ROOT.*absolute|{})".format(self.dnf))
 
+    def test_dependency_invalid_method(self):
+        code = '''zlib_dep = dependency('zlib', required : false)
+        zlib_dep.get_configtool_variable('foo')
+        '''
+        self.assertMesonRaises(code, "'zlib' is not a config-tool dependency")
+        code = '''zlib_dep = dependency('zlib', required : false)
+        dep = declare_dependency(dependencies : zlib_dep)
+        dep.get_pkgconfig_variable('foo')
+        '''
+        self.assertMesonRaises(code, "Method.*pkgconfig.*is invalid.*internal")
+        code = '''zlib_dep = dependency('zlib', required : false)
+        dep = declare_dependency(dependencies : zlib_dep)
+        dep.get_configtool_variable('foo')
+        '''
+        self.assertMesonRaises(code, "Method.*configtool.*is invalid.*internal")
+
 
 class WindowsTests(BasePlatformTests):
     '''


### PR DESCRIPTION
Using `NotImplementedError` throws an ugly traceback to the user which does not print the line number or any other information making it impossible to figure out what's causing it.

Also override it for internal dependencies because `self.name` is `"null"` for them.

Reported by @1ace on IRC.