### PR TITLE
Fix typo in release note snippet for get_unquoted

### DIFF
--- a/docs/markdown/snippets/get_unquoted.md
+++ b/docs/markdown/snippets/get_unquoted.md
@@ -1,4 +1,4 @@
-# `get_unquoted()` mehod for the `configuration` data object
+# `get_unquoted()` method for the `configuration` data object
 
-New convenience method that allow reusing a variable value
+New convenience method that allows reusing a variable value
 defined quoted. Useful in C for config.h strings for example.


### PR DESCRIPTION
Grammar is still a bit fractured, but I'm not entirely sure what it's trying to say.