### PR TITLE
docs: Add documentation to dependency variables

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -43,6 +43,21 @@ You can pass the `opt_dep` variable to target construction functions
 whether the actual dependency was found or not. Meson will ignore
 non-found dependencies.
 
+Meson also allows to get variables that are defined in the
+`pkg-config` file. This can be done by using the
+`get_pkgconfig_variable` function.
+
+```meson
+zdep_prefix = zdep.get_pkgconfig_variable('prefix')
+```
+
+These variables can also be redefined by passing the `define_variable`
+parameter, which might be useful in certain situations:
+
+```meson
+zdep_prefix = zdep.get_pkgconfig_variable('prefix', define_variable: ['prefix', '/tmp'])
+```
+
 The dependency detector works with all libraries that provide a
 `pkg-config` file. Unfortunately several packages don't provide
 pkg-config files. Meson has autodetection support for some of these,

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -55,7 +55,7 @@ These variables can also be redefined by passing the `define_variable`
 parameter, which might be useful in certain situations:
 
 ```meson
-zdep_prefix = zdep.get_pkgconfig_variable('prefix', define_variable: ['prefix', '/tmp'])
+zdep_prefix = zdep.get_pkgconfig_variable('libdir', define_variable: ['prefix', '/tmp'])
 ```
 
 The dependency detector works with all libraries that provide a

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1618,7 +1618,9 @@ an external dependency with the following methods:
 
  - `get_pkgconfig_variable(varname)` (*Added 0.36.0*) will get the
    pkg-config variable specified, or, if invoked on a non pkg-config
-   dependency, error out
+   dependency, error out. (*Added 0.44.0*) You can also redefine a
+   variable by passing a list to the `define_variable` parameter
+   that can affect the retrieved variable: `['prefix', '/'])`.
 
  - `get_configtool_variable(varname)` (*Added 0.44.0*) will get the 
    command line argument from the config tool (with `--` prepended), or,


### PR DESCRIPTION
Meson is able to redefine variables when retrieving them from `pkg-config` dependencies since #2663 was merged.. However, the documentation is missing.

This patch adds documentation for this feature.