### PR TITLE
Enable re-compilation of GNOME gschema files if they have changed.

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -196,6 +196,13 @@ When called, this method will compile the gschemas in the current
 directory. Note that this is not for installing schemas and is only
 useful when running the application locally for example during tests.
 
+* `build_by_default`: causes, when set to true, to have this target be
+  built by default, that is, when invoking plain `ninja`, the default
+  value is true for all built target types
+* `depend_files`: files ([`string`](#string-object),
+  [`files()`](#files), or [`configure_file()`](#configure_file)) of
+  schema source XML files that should trigger a re-compile if changed.
+
 ### gnome.gdbus_codegen()
 
 Compiles the given XML schema into gdbus source code. Takes two

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -626,7 +626,7 @@ class GnomeModule(ExtensionModule):
         rv = [scan_target, typelib_target]
         return ModuleReturnValue(rv, rv)
 
-    @permittedKwargs({'build_by_default'})
+    @permittedKwargs({'build_by_default', 'depend_files'})
     def compile_schemas(self, state, args, kwargs):
         if args:
             raise MesonException('Compile_schemas does not take positional arguments.')


### PR DESCRIPTION
Fixes issue #2770

* mesonbuild/modules/gnome.py (GnomeModule.compile_schemas): Allow the
  depend_files kwarg.

* docs/markdown/Gnome-module.md: Add docs for new kwarg (and the only
  other one that is permitted).