### PR TITLE
vim: Add warning function to list of builtins

### DIFF
--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -112,6 +112,7 @@ syn keyword mesonBuiltin
   \ target_machine
   \ test
   \ vcs_tag
+  \ warning
 
 if exists("meson_space_error_highlight")
   " trailing whitespace


### PR DESCRIPTION
This should have been added in 0.44.0 and wasn't.