### PR TITLE
Small cosmetic cleanups for ConfigTool dependencies and LLVM

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -284,17 +284,18 @@ class ConfigToolDependency(ExternalDependency):
         """Helper method to print messages about the tool."""
         if self.config is None:
             if version is not None:
-                mlog.log('found {} {!r} but need:'.format(self.tool_name, version),
-                         req_version)
+                mlog.log('Found', mlog.bold(self.tool_name), repr(version),
+                         mlog.red('NO'), '(needed', req_version, ')')
             else:
-                mlog.log("No {} found; can't detect dependency".format(self.tool_name))
-            mlog.log('Dependency {} found:'.format(self.name), mlog.red('NO'))
+                mlog.log('Found', mlog.bold(self.tool_name), repr(req_version),
+                         mlog.red('NO'))
+            mlog.log('Dependency', mlog.bold(self.name), 'found:', mlog.red('NO'))
             if self.required:
                 raise DependencyException('Dependency {} not found'.format(self.name))
             return False
         mlog.log('Found {}:'.format(self.tool_name), mlog.bold(shutil.which(self.config)),
                  '({})'.format(version))
-        mlog.log('Dependency {} found:'.format(self.name), mlog.green('YES'))
+        mlog.log('Dependency', mlog.bold(self.name), 'found:', mlog.green('YES'))
         return True
 
     def get_config_value(self, args, stage):

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -213,7 +213,7 @@ class LLVMDependency(ConfigToolDependency):
         """
         for mod in sorted(set(modules)):
             if mod not in self.provided_modules:
-                mlog.log('LLVM module', mod, 'found:', mlog.red('NO'),
+                mlog.log('LLVM module', mlog.bold(mod), 'found:', mlog.red('NO'),
                          '(optional)' if not required else '')
                 if required:
                     self.is_found = False
@@ -222,7 +222,7 @@ class LLVMDependency(ConfigToolDependency):
                             'Could not find required LLVM Component: {}'.format(mod))
             else:
                 self.required_modules.add(mod)
-                mlog.log('LLVM module', mod, 'found:', mlog.green('YES'))
+                mlog.log('LLVM module', mlog.bold(mod), 'found:', mlog.green('YES'))
 
     def need_threads(self):
         return True

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -140,7 +140,7 @@ class LLVMDependency(ConfigToolDependency):
     def __init__(self, environment, kwargs):
         # It's necessary for LLVM <= 3.8 to use the C++ linker. For 3.9 and 4.0
         # the C linker works fine if only using the C API.
-        super().__init__('config-tool', environment, 'cpp', kwargs)
+        super().__init__('LLVM', environment, 'cpp', kwargs)
         self.provided_modules = []
         self.required_modules = set()
         if not self.is_found:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1741,7 +1741,7 @@ class FailureTests(BasePlatformTests):
             raise unittest.SkipTest('wx-config or wx-config-3.0 found')
         self.assertMesonRaises("dependency('wxwidgets')", self.dnf)
         self.assertMesonOutputs("dependency('wxwidgets', required : false)",
-                                "No wx-config found;")
+                                "Dependency .*WxWidgets.* found: .*NO.*")
 
     def test_wx_dependency(self):
         if not shutil.which('wx-config-3.0') and not shutil.which('wx-config'):


### PR DESCRIPTION
This series fixes inconsistent use of `mlog` methods in the `ConfigToolDependency` class compared to other dependency classes (like `PkgConfigDependency`). It also fixes LLVM printing `config-tool` instead of `LLVM` when searching for that dependency.