### PR TITLE
dependencies: Also strip git version from llvm version

### DIFF
--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -150,7 +150,12 @@ class LLVMDependency(ConfigToolDependency):
         # Currently meson doesn't really attempt to handle pre-release versions,
         # so strip the 'svn' off the end, since it will probably cuase problems
         # for users who want the patch version.
+        #
+        # If LLVM is built from svn then "svn" will be appended to the version
+        # string, if it's built from a git mirror then "git-<very short sha>"
+        # will be appended instead.
         self.version = self.version.rstrip('svn')
+        self.version = self.version.split('git')[0]
 
         self.provided_modules = self.get_config_value(['--components'], 'modules')
         modules = stringlistify(extract_as_list(kwargs, 'modules'))


### PR DESCRIPTION
Because TravisCI adds git-20170101 (or so) to the end of the LLVM
version they install in their default images.

Fixes: #2786