### PR TITLE
Exclude llvm/clang lib headers from test coverage

### DIFF
--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -59,6 +59,7 @@ def coverage(source_root, build_root, log_dir):
         remove_dir_from_trace(lcov_exe, covinfo, '/usr/include/*')
         remove_dir_from_trace(lcov_exe, covinfo, '/usr/local/include/*')
         remove_dir_from_trace(lcov_exe, covinfo, '/usr/src/*')
+        remove_dir_from_trace(lcov_exe, covinfo, '/usr/lib/llvm-*/include/*')
         subprocess.check_call([genhtml_exe,
                                '--prefix', build_root,
                                '--output-directory', htmloutdir,


### PR DESCRIPTION
Exclude /usr/lib/llvm-*/include/ from coverage. This is the include directory used by LibClang and LibTooling