### PR TITLE
Add more version information to compiler

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -831,7 +831,7 @@ class ClangCCompiler(ClangCompiler, CCompiler):
 
 class GnuCCompiler(GnuCompiler, CCompiler):
     def __init__(self, exelist, version, gcc_type, is_cross, exe_wrapper=None, defines=None, **kwargs):
-        CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
+        CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper, **kwargs)
         GnuCompiler.__init__(self, gcc_type, defines)
         default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'1': default_warn_args,
@@ -870,7 +870,7 @@ class GnuCCompiler(GnuCompiler, CCompiler):
 
 class IntelCCompiler(IntelCompiler, CCompiler):
     def __init__(self, exelist, version, icc_type, is_cross, exe_wrapper=None, **kwargs):
-        CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
+        CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper, **kwargs)
         IntelCompiler.__init__(self, icc_type)
         self.lang_header = 'c-header'
         default_warn_args = ['-Wall', '-w3', '-diag-disable:remark', '-Wpch-messages']

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -42,11 +42,11 @@ from .compilers import (
 
 
 class CCompiler(Compiler):
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None):
+    def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwargs):
         # If a child ObjC or CPP class has already set it, don't set it ourselves
         if not hasattr(self, 'language'):
             self.language = 'c'
-        super().__init__(exelist, version)
+        super().__init__(exelist, version, **kwargs)
         self.id = 'unknown'
         self.is_cross = is_cross
         self.can_compile_suffixes.add('h')
@@ -798,8 +798,8 @@ class CCompiler(Compiler):
 
 
 class ClangCCompiler(ClangCompiler, CCompiler):
-    def __init__(self, exelist, version, clang_type, is_cross, exe_wrapper=None):
-        CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
+    def __init__(self, exelist, version, clang_type, is_cross, exe_wrapper=None, **kwargs):
+        CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper, **kwargs)
         ClangCompiler.__init__(self, clang_type)
         default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'1': default_warn_args,
@@ -830,7 +830,7 @@ class ClangCCompiler(ClangCompiler, CCompiler):
 
 
 class GnuCCompiler(GnuCompiler, CCompiler):
-    def __init__(self, exelist, version, gcc_type, is_cross, exe_wrapper=None, defines=None):
+    def __init__(self, exelist, version, gcc_type, is_cross, exe_wrapper=None, defines=None, **kwargs):
         CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
         GnuCompiler.__init__(self, gcc_type, defines)
         default_warn_args = ['-Wall', '-Winvalid-pch']
@@ -869,7 +869,7 @@ class GnuCCompiler(GnuCompiler, CCompiler):
 
 
 class IntelCCompiler(IntelCompiler, CCompiler):
-    def __init__(self, exelist, version, icc_type, is_cross, exe_wrapper=None):
+    def __init__(self, exelist, version, icc_type, is_cross, exe_wrapper=None, **kwargs):
         CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
         IntelCompiler.__init__(self, icc_type)
         self.lang_header = 'c-header'

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -598,7 +598,7 @@ class Compiler:
     # compiler or the C library. Currently only used for MSVC.
     ignore_libs = ()
 
-    def __init__(self, exelist, version):
+    def __init__(self, exelist, version, **kwargs):
         if isinstance(exelist, str):
             self.exelist = [exelist]
         elif isinstance(exelist, list):
@@ -612,6 +612,10 @@ class Compiler:
             self.can_compile_suffixes = set(self.file_suffixes)
         self.default_suffix = self.file_suffixes[0]
         self.version = version
+        if 'full_version' in kwargs:
+            self.full_version = kwargs['full_version']
+        else:
+            self.full_version = None
         self.base_options = []
 
     def __repr__(self):

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -28,11 +28,11 @@ from .compilers import (
 )
 
 class CPPCompiler(CCompiler):
-    def __init__(self, exelist, version, is_cross, exe_wrap):
+    def __init__(self, exelist, version, is_cross, exe_wrap, **kwargs):
         # If a child ObjCPP class has already set it, don't set it ourselves
         if not hasattr(self, 'language'):
             self.language = 'cpp'
-        CCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
+        CCompiler.__init__(self, exelist, version, is_cross, exe_wrap, **kwargs)
 
     def get_display_language(self):
         return 'C++'
@@ -66,8 +66,8 @@ class CPPCompiler(CCompiler):
 
 
 class ClangCPPCompiler(ClangCompiler, CPPCompiler):
-    def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None):
-        CPPCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
+    def __init__(self, exelist, version, cltype, is_cross, exe_wrapper=None, **kwargs):
+        CPPCompiler.__init__(self, exelist, version, is_cross, exe_wrapper, **kwargs)
         ClangCompiler.__init__(self, cltype)
         default_warn_args = ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor']
         self.warn_args = {'1': default_warn_args,
@@ -92,8 +92,8 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
 
 
 class GnuCPPCompiler(GnuCompiler, CPPCompiler):
-    def __init__(self, exelist, version, gcc_type, is_cross, exe_wrap, defines):
-        CPPCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
+    def __init__(self, exelist, version, gcc_type, is_cross, exe_wrap, defines, **kwargs):
+        CPPCompiler.__init__(self, exelist, version, is_cross, exe_wrap, **kwargs)
         GnuCompiler.__init__(self, gcc_type, defines)
         default_warn_args = ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor']
         self.warn_args = {'1': default_warn_args,
@@ -133,8 +133,8 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
 
 
 class IntelCPPCompiler(IntelCompiler, CPPCompiler):
-    def __init__(self, exelist, version, icc_type, is_cross, exe_wrap):
-        CPPCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
+    def __init__(self, exelist, version, icc_type, is_cross, exe_wrap, **kwargs):
+        CPPCompiler.__init__(self, exelist, version, is_cross, exe_wrap, **kwargs)
         IntelCompiler.__init__(self, icc_type)
         self.lang_header = 'c++-header'
         default_warn_args = ['-Wall', '-w3', '-diag-disable:remark',

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -19,9 +19,9 @@ from ..mesonlib import EnvironmentException
 from .compilers import Compiler, mono_buildtype_args
 
 class MonoCompiler(Compiler):
-    def __init__(self, exelist, version):
+    def __init__(self, exelist, version, **kwargs):
         self.language = 'cs'
-        super().__init__(exelist, version)
+        super().__init__(exelist, version, **kwargs)
         self.id = 'mono'
         self.monorunner = 'mono'
 

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -42,9 +42,9 @@ d_feature_args = {'gcc':  {'unittest': '-funittest',
                   }
 
 class DCompiler(Compiler):
-    def __init__(self, exelist, version, is_cross):
+    def __init__(self, exelist, version, is_cross, **kwargs):
         self.language = 'd'
-        super().__init__(exelist, version)
+        super().__init__(exelist, version, **kwargs)
         self.id = 'unknown'
         self.is_cross = is_cross
 
@@ -224,8 +224,8 @@ class DCompiler(Compiler):
 
 
 class GnuDCompiler(DCompiler):
-    def __init__(self, exelist, version, is_cross):
-        DCompiler.__init__(self, exelist, version, is_cross)
+    def __init__(self, exelist, version, is_cross, **kwargs):
+        DCompiler.__init__(self, exelist, version, is_cross, **kwargs)
         self.id = 'gcc'
         default_warn_args = ['-Wall', '-Wdeprecated']
         self.warn_args = {'1': default_warn_args,
@@ -267,8 +267,8 @@ class GnuDCompiler(DCompiler):
 
 
 class LLVMDCompiler(DCompiler):
-    def __init__(self, exelist, version, is_cross):
-        DCompiler.__init__(self, exelist, version, is_cross)
+    def __init__(self, exelist, version, is_cross, **kwargs):
+        DCompiler.__init__(self, exelist, version, is_cross, **kwargs)
         self.id = 'llvm'
         self.base_options = ['b_coverage', 'b_colorout']
 
@@ -321,8 +321,8 @@ class LLVMDCompiler(DCompiler):
 
 
 class DmdDCompiler(DCompiler):
-    def __init__(self, exelist, version, is_cross):
-        DCompiler.__init__(self, exelist, version, is_cross)
+    def __init__(self, exelist, version, is_cross, **kwargs):
+        DCompiler.__init__(self, exelist, version, is_cross, **kwargs)
         self.id = 'dmd'
         self.base_options = ['b_coverage', 'b_colorout']
 

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -31,9 +31,9 @@ from .compilers import (
 )
 
 class FortranCompiler(Compiler):
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None):
+    def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwargs):
         self.language = 'fortran'
-        super().__init__(exelist, version)
+        super().__init__(exelist, version, **kwargs)
         self.is_cross = is_cross
         self.exe_wrapper = exe_wrapper
         # Not really correct but I don't have Fortran compilers to test with. Sorry.
@@ -149,8 +149,8 @@ end program prog
 
 
 class GnuFortranCompiler(FortranCompiler):
-    def __init__(self, exelist, version, gcc_type, is_cross, exe_wrapper=None, defines=None):
-        super().__init__(exelist, version, is_cross, exe_wrapper=None)
+    def __init__(self, exelist, version, gcc_type, is_cross, exe_wrapper=None, defines=None, **kwargs):
+        super().__init__(exelist, version, is_cross, exe_wrapper=None, **kwargs)
         self.gcc_type = gcc_type
         self.defines = defines or {}
         self.id = 'gcc'
@@ -181,8 +181,8 @@ class GnuFortranCompiler(FortranCompiler):
 
 
 class G95FortranCompiler(FortranCompiler):
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None):
-        super().__init__(exelist, version, is_cross, exe_wrapper=None)
+    def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwags):
+        super().__init__(exelist, version, is_cross, exe_wrapper=None, **kwags)
         self.id = 'g95'
 
     def get_module_outdir_args(self, path):
@@ -205,8 +205,8 @@ class G95FortranCompiler(FortranCompiler):
 
 
 class SunFortranCompiler(FortranCompiler):
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None):
-        super().__init__(exelist, version, is_cross, exe_wrapper=None)
+    def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwags):
+        super().__init__(exelist, version, is_cross, exe_wrapper=None, **kwags)
         self.id = 'sun'
 
     def get_dependency_gen_args(self, outtarget, outfile):
@@ -228,9 +228,9 @@ class SunFortranCompiler(FortranCompiler):
 class IntelFortranCompiler(IntelCompiler, FortranCompiler):
     std_warn_args = ['-warn', 'all']
 
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None):
+    def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwags):
         self.file_suffixes = ('f90', 'f', 'for', 'ftn', 'fpp')
-        FortranCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
+        FortranCompiler.__init__(self, exelist, version, is_cross, exe_wrapper, **kwags)
         # FIXME: Add support for OS X and Windows in detect_fortran_compiler so
         # we are sent the type of compiler
         IntelCompiler.__init__(self, ICC_STANDARD)
@@ -246,8 +246,8 @@ class IntelFortranCompiler(IntelCompiler, FortranCompiler):
 class PathScaleFortranCompiler(FortranCompiler):
     std_warn_args = ['-fullwarn']
 
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None):
-        super().__init__(exelist, version, is_cross, exe_wrapper=None)
+    def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwags):
+        super().__init__(exelist, version, is_cross, exe_wrapper=None, **kwags)
         self.id = 'pathscale'
 
     def get_module_outdir_args(self, path):
@@ -259,8 +259,8 @@ class PathScaleFortranCompiler(FortranCompiler):
 class PGIFortranCompiler(FortranCompiler):
     std_warn_args = ['-Minform=inform']
 
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None):
-        super().__init__(exelist, version, is_cross, exe_wrapper=None)
+    def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwags):
+        super().__init__(exelist, version, is_cross, exe_wrapper=None, **kwags)
         self.id = 'pgi'
 
     def get_module_incdir_args(self):
@@ -279,8 +279,8 @@ class PGIFortranCompiler(FortranCompiler):
 class Open64FortranCompiler(FortranCompiler):
     std_warn_args = ['-fullwarn']
 
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None):
-        super().__init__(exelist, version, is_cross, exe_wrapper=None)
+    def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwags):
+        super().__init__(exelist, version, is_cross, exe_wrapper=None, **kwags)
         self.id = 'open64'
 
     def get_module_outdir_args(self, path):
@@ -293,8 +293,8 @@ class Open64FortranCompiler(FortranCompiler):
 class NAGFortranCompiler(FortranCompiler):
     std_warn_args = []
 
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None):
-        super().__init__(exelist, version, is_cross, exe_wrapper=None)
+    def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwags):
+        super().__init__(exelist, version, is_cross, exe_wrapper=None, **kwags)
         self.id = 'nagfor'
 
     def get_module_outdir_args(self, path):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -666,8 +666,9 @@ class Environment:
         except OSError:
             raise EnvironmentException('Could not execute C# compiler "%s"' % ' '.join(exelist))
         version = search_version(out)
+        full_version = out.split('\n', 1)[0]
         if 'Mono' in out:
-            return MonoCompiler(exelist, version)
+            return MonoCompiler(exelist, version, full_version=full_version)
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
 
     def detect_vala_compiler(self):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -556,6 +556,7 @@ class Environment:
                     continue
 
                 version = search_version(out)
+                full_version = out.split('\n', 1)[0]
 
                 if 'GNU Fortran' in out:
                     defines = self.get_gnu_compiler_defines(compiler)

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -505,7 +505,7 @@ class Environment:
                 gtype = self.get_gnu_compiler_type(defines)
                 version = self.get_gnu_version_from_defines(defines)
                 cls = GnuCCompiler if lang == 'c' else GnuCPPCompiler
-                return cls(ccache + compiler, version, gtype, is_cross, exe_wrap, defines, full_version=full_version )
+                return cls(ccache + compiler, version, gtype, is_cross, exe_wrap, defines, full_version=full_version)
             if 'clang' in out:
                 if 'Apple' in out or mesonlib.for_darwin(want_cross, self):
                     cltype = CLANG_OSX
@@ -565,29 +565,29 @@ class Environment:
                         continue
                     gtype = self.get_gnu_compiler_type(defines)
                     version = self.get_gnu_version_from_defines(defines)
-                    return GnuFortranCompiler(compiler, version, gtype, is_cross, exe_wrap, defines)
+                    return GnuFortranCompiler(compiler, version, gtype, is_cross, exe_wrap, defines, full_version=full_version)
 
                 if 'G95' in out:
-                    return G95FortranCompiler(compiler, version, is_cross, exe_wrap)
+                    return G95FortranCompiler(compiler, version, is_cross, exe_wrap, full_version=full_version)
 
                 if 'Sun Fortran' in err:
                     version = search_version(err)
-                    return SunFortranCompiler(compiler, version, is_cross, exe_wrap)
+                    return SunFortranCompiler(compiler, version, is_cross, exe_wrap, full_version=full_version)
 
                 if 'ifort (IFORT)' in out:
-                    return IntelFortranCompiler(compiler, version, is_cross, exe_wrap)
+                    return IntelFortranCompiler(compiler, version, is_cross, exe_wrap, full_version=full_version)
 
                 if 'PathScale EKOPath(tm)' in err:
-                    return PathScaleFortranCompiler(compiler, version, is_cross, exe_wrap)
+                    return PathScaleFortranCompiler(compiler, version, is_cross, exe_wrap, full_version=full_version)
 
                 if 'PGI Compilers' in out:
-                    return PGIFortranCompiler(compiler, version, is_cross, exe_wrap)
+                    return PGIFortranCompiler(compiler, version, is_cross, exe_wrap, full_version=full_version)
 
                 if 'Open64 Compiler Suite' in err:
-                    return Open64FortranCompiler(compiler, version, is_cross, exe_wrap)
+                    return Open64FortranCompiler(compiler, version, is_cross, exe_wrap, full_version=full_version)
 
                 if 'NAG Fortran' in err:
-                    return NAGFortranCompiler(compiler, version, is_cross, exe_wrap)
+                    return NAGFortranCompiler(compiler, version, is_cross, exe_wrap, full_version=full_version)
         self._handle_exceptions(popen_exceptions, compilers)
 
     def get_scratch_dir(self):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -496,6 +496,7 @@ class Environment:
                 popen_exceptions[' '.join(compiler + [arg])] = e
                 continue
             version = search_version(out)
+            full_version = out.split('\n', 1)[0]
             if 'Free Software Foundation' in out:
                 defines = self.get_gnu_compiler_defines(compiler)
                 if not defines:
@@ -504,7 +505,7 @@ class Environment:
                 gtype = self.get_gnu_compiler_type(defines)
                 version = self.get_gnu_version_from_defines(defines)
                 cls = GnuCCompiler if lang == 'c' else GnuCPPCompiler
-                return cls(ccache + compiler, version, gtype, is_cross, exe_wrap, defines)
+                return cls(ccache + compiler, version, gtype, is_cross, exe_wrap, defines, full_version=full_version )
             if 'clang' in out:
                 if 'Apple' in out or mesonlib.for_darwin(want_cross, self):
                     cltype = CLANG_OSX
@@ -513,7 +514,7 @@ class Environment:
                 else:
                     cltype = CLANG_STANDARD
                 cls = ClangCCompiler if lang == 'c' else ClangCPPCompiler
-                return cls(ccache + compiler, version, cltype, is_cross, exe_wrap)
+                return cls(ccache + compiler, version, cltype, is_cross, exe_wrap, full_version=full_version)
             if 'Microsoft' in out or 'Microsoft' in err:
                 # Latest versions of Visual Studio print version
                 # number to stderr but earlier ones print version
@@ -532,7 +533,7 @@ class Environment:
                 # TODO: add microsoft add check OSX
                 inteltype = ICC_STANDARD
                 cls = IntelCCompiler if lang == 'c' else IntelCPPCompiler
-                return cls(ccache + compiler, version, inteltype, is_cross, exe_wrap)
+                return cls(ccache + compiler, version, inteltype, is_cross, exe_wrap, full_version=full_version)
         self._handle_exceptions(popen_exceptions, compilers)
 
     def detect_c_compiler(self, want_cross):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -723,12 +723,13 @@ class Environment:
         except OSError:
             raise EnvironmentException('Could not execute D compiler "%s"' % ' '.join(exelist))
         version = search_version(out)
+        full_version = out.split('\n', 1)[0]
         if 'LLVM D compiler' in out:
-            return compilers.LLVMDCompiler(exelist, version, is_cross)
+            return compilers.LLVMDCompiler(exelist, version, is_cross, full_version=full_version)
         elif 'gdc' in out:
-            return compilers.GnuDCompiler(exelist, version, is_cross)
+            return compilers.GnuDCompiler(exelist, version, is_cross, full_version=full_version)
         elif 'Digital Mars' in out:
-            return compilers.DmdDCompiler(exelist, version, is_cross)
+            return compilers.DmdDCompiler(exelist, version, is_cross, full_version=full_version)
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
 
     def detect_swift_compiler(self):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2021,7 +2021,11 @@ to directly access options of other subprojects.''')
                         continue
                     else:
                         raise
-            mlog.log('Native %s compiler: ' % comp.get_display_language(), mlog.bold(' '.join(comp.get_exelist())), ' (%s %s)' % (comp.id, comp.version), sep='')
+            if comp.full_version != None:
+                version_string= ' (%s %s "%s")' % (comp.id, comp.version, comp.full_version)
+            else:
+                version_string= ' (%s %s)' % (comp.id, comp.version)
+            mlog.log('Native %s compiler: ' % comp.get_display_language(), mlog.bold(' '.join(comp.get_exelist())), version_string , sep='')
             if not comp.get_language() in self.coredata.external_args:
                 (preproc_args, compile_args, link_args) = environment.get_args_from_envvars(comp)
                 self.coredata.external_preprocess_args[comp.get_language()] = preproc_args

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2021,11 +2021,11 @@ to directly access options of other subprojects.''')
                         continue
                     else:
                         raise
-            if comp.full_version != None:
-                version_string= ' (%s %s "%s")' % (comp.id, comp.version, comp.full_version)
+            if comp.full_version is not None:
+                version_string = ' (%s %s "%s")' % (comp.id, comp.version, comp.full_version)
             else:
-                version_string= ' (%s %s)' % (comp.id, comp.version)
-            mlog.log('Native %s compiler: ' % comp.get_display_language(), mlog.bold(' '.join(comp.get_exelist())), version_string , sep='')
+                version_string = ' (%s %s)' % (comp.id, comp.version)
+            mlog.log('Native %s compiler: ' % comp.get_display_language(), mlog.bold(' '.join(comp.get_exelist())), version_string, sep='')
             if not comp.get_language() in self.coredata.external_args:
                 (preproc_args, compile_args, link_args) = environment.get_args_from_envvars(comp)
                 self.coredata.external_preprocess_args[comp.get_language()] = preproc_args


### PR DESCRIPTION
Fixes issue #2762.

Add full_version variable to class Compiler and selected subclasses. It is passed as named parameter. For selected compilers the first line of `CC --version` is passed to full_version.

When the full_version is given it is printed as an additional version information.

This feature is currently only added to limited set of compilers.