### PR TITLE
Remove duplicated values in array options

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -147,7 +147,7 @@ class UserArrayOption(UserOption):
             if value.startswith('['):
                 newvalue = ast.literal_eval(value)
             else:
-                newvalue = [v.strip() for v in value.split(',')]
+                newvalue = [v.strip() for v in OrderedDict.fromkeys(value.split(','))]
         if not isinstance(newvalue, list):
             raise MesonException('"{0}" should be a string array, but it is not'.format(str(newvalue)))
         for i in newvalue:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from . import mlog
 import pickle, os, uuid
 import sys
 from pathlib import PurePath
@@ -147,7 +148,10 @@ class UserArrayOption(UserOption):
             if value.startswith('['):
                 newvalue = ast.literal_eval(value)
             else:
-                newvalue = [v.strip() for v in OrderedDict.fromkeys(value.split(','))]
+                newvalue = [v.strip() for v in value.split(',')]
+                if len(set(newvalue)) != len(newvalue):
+                    mlog.log(mlog.red('DEPRECATION:'), '''Duplicated values in an array type is deprecated.
+This will become a hard error in the future.''')
         if not isinstance(newvalue, list):
             raise MesonException('"{0}" should be a string array, but it is not'.format(str(newvalue)))
         for i in newvalue:


### PR DESCRIPTION
Array options can receive duplicated values, which can produce errors if case those duplicated values make processing some elements twice when they are expected to be processed only once.