### PR TITLE
Dragonfly

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -57,6 +57,7 @@ These are provided by the `.system()` method call.
 | windows             | Any version of Windows |
 | cygwin              | The Cygwin environment for Windows |
 | haiku               | |
+| dragonfly           | DragonFly BSD |
 
 Any string not listed above is not guaranteed to remain stable in
 future releases.

--- a/test cases/common/140 get define/meson.build
+++ b/test cases/common/140 get define/meson.build
@@ -19,6 +19,9 @@ foreach lang : ['c', 'cpp']
   elif host_system == 'haiku'
     d = cc.get_define('__HAIKU__')
     assert(d == '1', '__HAIKU__ value is @0@ instead of 1'.format(d))
+  elif host_system == 'dragonfly'
+    d = cc.get_define('__DragonFly__')
+    assert(d == '1', '__DragonFly__ value is @0@ instead of 1'.format(d))
   else
     error('Please report a bug and help us improve support for this platform')
   endif


### PR DESCRIPTION
just more obscure operating system stuff I need for mesa and freinds.

There area  couple of uinit tests that fail on dragonfly as well, though they're different ones than freebsd.