### PR TITLE
gnome.gtkdoc: Add support for non string based content files

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -777,32 +777,38 @@ This will become a hard error in the future.''')
         args += self._unpack_args('--mkdbargs=', 'mkdb_args', kwargs)
         args += self._unpack_args('--html-assets=', 'html_assets', kwargs, state)
 
+        depends = []
         content_files = []
         for s in mesonlib.extract_as_list(kwargs, 'content_files'):
             if hasattr(s, 'held_object'):
                 s = s.held_object
             if isinstance(s, (build.CustomTarget, build.CustomTargetIndex)):
+                depends.append(s)
                 content_files.append(os.path.join(state.environment.get_build_dir(),
                                                   state.backend.get_target_dir(s),
                                                   s.get_outputs()[0]))
             elif isinstance(s, mesonlib.File):
                 content_files.append(s.rel_to_builddir(state.build_to_src))
             elif isinstance(s, build.GeneratedList):
+                depends.append(s)
                 for gen_src in s.get_outputs():
                     content_files.append(os.path.join(state.environment.get_source_dir(),
                                                       state.subdir,
                                                       gen_src))
-            else:
+            elif isinstance(s, str):
                 content_files.append(os.path.join(state.environment.get_source_dir(),
                                                   state.subdir,
                                                   s))
+            else:
+                raise MesonException(
+                    'Invalid object type: {!r}'.format(s.__class__.__name__))
         args += ['--content-files=' + '@@'.join(content_files)]
 
         args += self._unpack_args('--expand-content-files=', 'expand_content_files', kwargs, state)
         args += self._unpack_args('--ignore-headers=', 'ignore_headers', kwargs)
         args += self._unpack_args('--installdir=', 'install_dir', kwargs, state)
         args += self._get_build_args(kwargs, state)
-        res = [build.RunTarget(targetname, command[0], command[1:] + args, [], state.subdir, state.subproject)]
+        res = [build.RunTarget(targetname, command[0], command[1:] + args, depends, state.subdir, state.subproject)]
         if kwargs.get('install', True):
             res.append(build.RunScript(command, args))
         return ModuleReturnValue(None, res)

--- a/test cases/frameworks/10 gtk-doc/doc/foobar-docs.sgml
+++ b/test cases/frameworks/10 gtk-doc/doc/foobar-docs.sgml
@@ -34,6 +34,7 @@
       </para>
     </partintro>
     <xi:include href="xml/foo.xml"/>
+    <xi:include href="../include/bar.xml"/>
     <xi:include href="xml/foo-version.xml"/>
   </reference>
 

--- a/test cases/frameworks/10 gtk-doc/doc/meson.build
+++ b/test cases/frameworks/10 gtk-doc/doc/meson.build
@@ -4,4 +4,8 @@ configure_file(input : 'version.xml.in',
   output : 'version.xml',
   configuration : cdata)
 
-gnome.gtkdoc('foobar', src_dir : inc, main_sgml : 'foobar-docs.sgml', install : true)
+gnome.gtkdoc('foobar',
+  src_dir : inc,
+  main_sgml : 'foobar-docs.sgml',
+  content_files : docbook,
+  install : true)

--- a/test cases/frameworks/10 gtk-doc/include/generate-enums-docbook.py
+++ b/test cases/frameworks/10 gtk-doc/include/generate-enums-docbook.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+import sys
+
+DOC_HEADER = '''<?xml version='1.0'?>
+<?xml-stylesheet type="text/xsl" href="http://docbook.sourceforge.net/release/xsl/current/xhtml/docbook.xsl"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN" "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
+
+<refentry id="{0}">
+  <refmeta>
+    <refentrytitle role="top_of_page" id="{0}.top_of_page">{0}</refentrytitle>
+    <refmiscinfo>{0}</refmiscinfo>
+  </refmeta>
+  <refnamediv>
+    <refname>{0}</refname>
+    <refpurpose></refpurpose>
+  </refnamediv>
+
+  <refsect2 id="{1}" role="enum">
+    <title>enum {1}</title>
+    <indexterm zone="{1}">
+      <primary>{1}</primary>
+    </indexterm>
+    <para><link linkend="{1}">{1}</link></para>
+    <refsect3 role="enum_members">
+      <title>Values</title>
+      <informaltable role="enum_members_table" pgwide="1" frame="none">
+        <tgroup cols="4">
+          <colspec colname="enum_members_name" colwidth="300px" />
+          <colspec colname="enum_members_value" colwidth="100px"/>
+          <colspec colname="enum_members_description" />
+          <tbody>
+'''
+
+DOC_ENUM = '''            <row role="constant">
+              <entry role="enum_member_name"><para>{0}</para><para></para></entry>
+              <entry role="enum_member_value"><para>= <literal>{1}</literal></para><para></para></entry>
+              <entry role="enum_member_description"></entry>
+            </row>'''
+
+DOC_FOOTER = '''
+          </tbody>
+        </tgroup>
+      </informaltable>
+    </refsect3>
+  </refsect2>
+</refentry>
+'''
+
+if __name__ == '__main__':
+    if len(sys.argv) >= 4:
+        with open(sys.argv[1], 'w') as doc_out:
+            enum_name = sys.argv[2]
+            enum_type = sys.argv[3]
+
+            doc_out.write(DOC_HEADER.format(enum_name, enum_type))
+            for i, enum in enumerate(sys.argv[4:]):
+                doc_out.write(DOC_ENUM.format(enum, i))
+            doc_out.write(DOC_FOOTER)
+    else:
+        print('Use: ' + sys.argv[0] + ' out name type [enums]')
+
+    sys.exit(0)

--- a/test cases/frameworks/10 gtk-doc/include/meson.build
+++ b/test cases/frameworks/10 gtk-doc/include/meson.build
@@ -8,3 +8,9 @@ configure_file(input : 'foo-version.h.in',
   configuration : cdata,
   install : true,
   install_dir : get_option('includedir'))
+
+generate_enums_docbook = find_program('generate-enums-docbook.py')
+
+docbook = custom_target('enum-docbook',
+  output : 'bar.xml',
+  command : [generate_enums_docbook, '@OUTPUT@', 'BAR', 'BAR_TYPE', 'BAR_FOO'])


### PR DESCRIPTION
gnome's gtkdoc function does not support content files which are not strings. However, there are situations where files generated by other targets might be needed.