### PR TITLE
[Dependencies] Add --ldflags to cups-config invocation

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -804,7 +804,7 @@ class CupsDependency(ExternalDependency):
                     self.type_name = 'config-tool'
                     self.version = ctdep.version
                     self.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
-                    self.link_args = ctdep.get_config_value(['--libs'], 'link_args')
+                    self.link_args = ctdep.get_config_value(['--ldflags', '--libs'], 'link_args')
                     self.is_found = True
                     return
             except Exception as e:


### PR DESCRIPTION
--libs only gives libs to link with not flags and link path when necessary.

To reproduce the bug, just build "test cases/frameworks/20 cups"  on FreeBSD.