### PR TITLE
PkgConfigDependency: Add option to choose between shared or static

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -124,8 +124,9 @@ files will be compiled only once and object files will be reused to build both
 shared and static libraries, unless `b_staticpic` user option or `pic` argument
 are set to false in which case sources will be compiled twice.
 
-The returned [buildtarget](#build-target-object) always represents the shared
-library. In addition it supports the following extra methods:
+The returned [buildtarget](#build-target-object) represents either the static or
+the shared library depending on the value of the `default_link` user option.
+In addition it supports the following extra methods:
 
 - `get_shared_lib()` returns the shared library build target
 - `get_static_lib()` returns the static library build target

--- a/docs/markdown/snippets/both-libraries.md
+++ b/docs/markdown/snippets/both-libraries.md
@@ -6,4 +6,5 @@ files will be reused to build both shared and static libraries, unless
 `b_staticpic` user option or `pic` argument are set to false in which case
 sources will be compiled twice.
 
-The returned `buildtarget` object always represents the shared library.
+The returned `buildtarget` object represents either the static or
+the shared library depending on the value of the new `default_link` user option.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -423,6 +423,7 @@ builtin_options = {
     'warning_level':   [UserComboOption, 'Compiler warning level to use.', ['1', '2', '3'], '1'],
     'layout':          [UserComboOption, 'Build directory layout.', ['mirror', 'flat'], 'mirror'],
     'default_library': [UserComboOption, 'Default library type.', ['shared', 'static', 'both'], 'shared'],
+    'default_link':    [UserComboOption, 'Default link method when both are possible', ['shared', 'static'], 'shared'],
     'backend':         [UserComboOption, 'Backend to use.', backendlist, 'ninja'],
     'stdsplit':        [UserBooleanOption, 'Split stdout and stderr in test logs.', True],
     'errorlogs':       [UserBooleanOption, "Whether to print the logs from failing tests.", True],

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -370,7 +370,7 @@ def is_builtin_option(optname):
 
 def get_builtin_option_choices(optname):
     if is_builtin_option(optname):
-        if builtin_options[optname][0] == UserStringOption:
+        if builtin_options[optname][0] in [UserStringOption, UserArrayOption]:
             return None
         elif builtin_options[optname][0] == UserBooleanOption:
             return [True, False]
@@ -424,6 +424,7 @@ builtin_options = {
     'layout':          [UserComboOption, 'Build directory layout.', ['mirror', 'flat'], 'mirror'],
     'default_library': [UserComboOption, 'Default library type.', ['shared', 'static', 'both'], 'shared'],
     'default_link':    [UserComboOption, 'Default link method when both are possible', ['shared', 'static'], 'shared'],
+    'static_paths':    [UserArrayOption, 'Paths under which static libraries are allowed', ['/']],
     'backend':         [UserComboOption, 'Backend to use.', backendlist, 'ninja'],
     'stdsplit':        [UserBooleanOption, 'Split stdout and stderr in test logs.', True],
     'errorlogs':       [UserBooleanOption, "Whether to print the logs from failing tests.", True],

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -610,9 +610,9 @@ class SharedLibraryHolder(BuildTargetHolder):
 
 class BothLibrariesHolder(BuildTargetHolder):
     def __init__(self, shared_holder, static_holder, interp):
-        # FIXME: This build target always represents the shared library, but
-        # that should be configurable.
-        super().__init__(shared_holder.held_object, interp)
+        opt = interp.coredata.get_builtin_option('default_link')
+        holder = shared_holder if opt == 'shared' else static_holder
+        super().__init__(holder.held_object, interp)
         self.shared_holder = shared_holder
         self.static_holder = static_holder
         self.methods.update({'get_shared_lib': self.get_shared_lib_method,

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -138,7 +138,8 @@ class Conf:
         print('  Build dir ', self.build.environment.build_dir)
         print('\nCore options:\n')
         carr = []
-        for key in ['buildtype', 'warning_level', 'werror', 'strip', 'unity', 'default_library']:
+        for key in ['buildtype', 'warning_level', 'werror', 'strip', 'unity', 'default_library',
+                    'default_link']:
             carr.append({'name': key,
                          'descr': coredata.get_builtin_option_description(key),
                          'value': self.coredata.get_builtin_option(key),

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -139,7 +139,7 @@ class Conf:
         print('\nCore options:\n')
         carr = []
         for key in ['buildtype', 'warning_level', 'werror', 'strip', 'unity', 'default_library',
-                    'default_link']:
+                    'default_link', 'static_paths']:
             carr.append({'name': key,
                          'descr': coredata.get_builtin_option_description(key),
                          'value': self.coredata.get_builtin_option(key),

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -63,6 +63,7 @@ def create_parser():
     add_builtin_argument(p, 'werror', action='store_true')
     add_builtin_argument(p, 'layout')
     add_builtin_argument(p, 'default-library')
+    add_builtin_argument(p, 'default-link')
     add_builtin_argument(p, 'warnlevel', dest='warning_level')
     add_builtin_argument(p, 'stdsplit', action='store_false')
     add_builtin_argument(p, 'errorlogs', action='store_false')

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -64,6 +64,7 @@ def create_parser():
     add_builtin_argument(p, 'layout')
     add_builtin_argument(p, 'default-library')
     add_builtin_argument(p, 'default-link')
+    add_builtin_argument(p, 'static-paths')
     add_builtin_argument(p, 'warnlevel', dest='warning_level')
     add_builtin_argument(p, 'stdsplit', action='store_false')
     add_builtin_argument(p, 'errorlogs', action='store_false')

--- a/test cases/unit/21 default static/SDK/meson.build
+++ b/test cases/unit/21 default static/SDK/meson.build
@@ -1,0 +1,6 @@
+project('default-static-sdk', 'c')
+
+pkgg = import('pkgconfig')
+
+lib = both_libraries('sdk', 'sdk.c', install: true)
+pkgg.generate(lib)

--- a/test cases/unit/21 default static/SDK/sdk.c
+++ b/test cases/unit/21 default static/SDK/sdk.c
@@ -1,0 +1,5 @@
+#include "sdk.h"
+
+int sdk_function() {
+    return 2;
+}

--- a/test cases/unit/21 default static/SDK/sdk.h
+++ b/test cases/unit/21 default static/SDK/sdk.h
@@ -1,0 +1,1 @@
+int sdk_function(void);

--- a/test cases/unit/21 default static/main.c
+++ b/test cases/unit/21 default static/main.c
@@ -1,0 +1,8 @@
+#include <stdlib.h>
+
+#include "platform/platform.h"
+#include "SDK/sdk.h"
+
+int main() {
+    return platform_function() + sdk_function() == 3 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test cases/unit/21 default static/meson.build
+++ b/test cases/unit/21 default static/meson.build
@@ -1,0 +1,8 @@
+project('default-static', 'c')
+
+sdk_dep = dependency('sdk')
+platform_dep = dependency('platform')
+
+app = executable('app', 'main.c', dependencies : [sdk_dep, platform_dep])
+
+test('default-static', app)

--- a/test cases/unit/21 default static/platform/meson.build
+++ b/test cases/unit/21 default static/platform/meson.build
@@ -1,0 +1,6 @@
+project('default-static-platform', 'c')
+
+pkgg = import('pkgconfig')
+
+lib = both_libraries('platform', 'platform.c', install: true)
+pkgg.generate(lib)

--- a/test cases/unit/21 default static/platform/platform.c
+++ b/test cases/unit/21 default static/platform/platform.c
@@ -1,0 +1,5 @@
+#include"platform.h"
+
+int platform_function() {
+    return 1;
+}

--- a/test cases/unit/21 default static/platform/platform.h
+++ b/test cases/unit/21 default static/platform/platform.h
@@ -1,0 +1,1 @@
+int platform_function(void);


### PR DESCRIPTION
This adds 2 global project options:
- default_link: Tells that we prefer static link when possible. This
option could be used in more places where both static and shared
libraries are available (e.g. future both_library()).
- static_paths: List of path prefixes where it is allowed to use static
libraries. By default it has "/" which means all paths are allowed.
Sometimes it is useful to have there the path to an SDK that we want to
static link and keep dynamic link for everything else (e.g. plateform
libraries).

Closes #2765.