### PR TITLE
Update prefix-dependent defaults when project(default_options:) changes prefix

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1813,9 +1813,18 @@ to directly access options of other subprojects.''')
             if coredata.is_builtin_option(key):
                 if self.subproject != '':
                     continue # Only the master project is allowed to set global options.
+                # If this was set on the command line, do not override.
                 if not self.environment.had_argument_for(key):
                     self.coredata.set_builtin_option(key, value)
-                # If this was set on the command line, do not override.
+                    # If we are setting the prefix, then other options which
+                    # have prefix-dependent defaults need their value updating,
+                    # if they haven't been explicitly set (i.e. have their
+                    # default value)
+                    if key == 'prefix':
+                        for option in coredata.builtin_dir_noprefix_options:
+                            if not (self.environment.had_argument_for(option) or
+                                    any([k.startswith(option + '=') for k in default_options])):
+                                self.coredata.set_builtin_option(option, coredata.get_builtin_option_default(option, value))
             else:
                 # Option values set with subproject() default_options override those
                 # set in project() default_options.

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -789,6 +789,45 @@ class AllPlatformTests(BasePlatformTests):
                     self.assertEqual(value, expected[prefix][name])
             self.wipe()
 
+    def test_default_options_prefix_dependent_defaults(self):
+        '''
+        Tests that setting a prefix in default_options in project() sets prefix
+        dependent defaults for other options, and that those defaults can
+        be overridden in default_options or by the command line.
+        '''
+        testdir = os.path.join(self.common_test_dir, '173 default options prefix dependent defaults')
+        expected = {
+            '':
+            {'prefix':         '/usr',
+             'sysconfdir':     '/etc',
+             'localstatedir':  '/var',
+             'sharedstatedir': '/sharedstate'},
+            '--prefix=/usr':
+            {'prefix':         '/usr',
+             'sysconfdir':     '/etc',
+             'localstatedir':  '/var',
+             'sharedstatedir': '/sharedstate'},
+            '--sharedstatedir=/var/state':
+            {'prefix':         '/usr',
+             'sysconfdir':     '/etc',
+             'localstatedir':  '/var',
+             'sharedstatedir': '/var/state'},
+            '--sharedstatedir=/var/state --prefix=/usr --sysconfdir=sysconf':
+            {'prefix':         '/usr',
+             'sysconfdir':     'sysconf',
+             'localstatedir':  '/var',
+             'sharedstatedir': '/var/state'},
+        }
+        for args in expected:
+            self.init(testdir, args.split(), default_args=False)
+            opts = self.introspect('--buildoptions')
+            for opt in opts:
+                name = opt['name']
+                value = opt['value']
+                if name in expected[args]:
+                    self.assertEqual(value, expected[args][name])
+            self.wipe()
+
     def test_static_library_overwrite(self):
         '''
         Tests that static libraries are never appended to, always overwritten.

--- a/test cases/common/173 default options prefix dependent defaults/meson.build
+++ b/test cases/common/173 default options prefix dependent defaults/meson.build
@@ -1,0 +1,1 @@
+project('default options prefix dependent defaults ', 'c', default_options : ['sharedstatedir=/sharedstate', 'prefix=/usr'])


### PR DESCRIPTION
Fixes #2811 
