### PR TITLE
Fix linking with clang++ on linux if install_rpath.

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -868,7 +868,7 @@ class Compiler:
             # This eats the next argument, which happens to be 'ldstdc++', causing link failures.
             # We can dodge this problem by not adding any rpath_paths if the argument is empty.
             if lpaths.strip() != '':
-                args += ['-Wl,-rpath-link,'+lpaths]
+                args += ['-Wl,-rpath-link,' + lpaths]
         return args
 
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -863,7 +863,12 @@ class Compiler:
             # Not needed on Windows or other platforms that don't use RPATH
             # https://github.com/mesonbuild/meson/issues/1897
             lpaths = ':'.join([os.path.join(build_dir, p) for p in rpath_paths])
-            args += ['-Wl,-rpath-link,' + lpaths]
+
+            # clang expands '-Wl,rpath-link,' to ['-rpath-link'] instead of ['-rpath-link','']
+            # This eats the next argument, which happens to be 'ldstdc++', causing link failures.
+            # We can dodge this problem by not adding any rpath_paths if the argument is empty.
+            if lpaths.strip() != '':
+                args += ['-Wl,-rpath-link,'+lpaths]
         return args
 
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2288,11 +2288,18 @@ class LinuxlikeTests(BasePlatformTests):
         testdir = os.path.join(self.unit_test_dir, '11 build_rpath')
         self.init(testdir)
         self.build()
+        # C program RPATH
         build_rpath = get_rpath(os.path.join(self.builddir, 'prog'))
         self.assertEqual(build_rpath, '$ORIGIN/sub:/foo/bar')
         self.install()
         install_rpath = get_rpath(os.path.join(self.installdir, 'usr/bin/prog'))
         self.assertEqual(install_rpath, '/baz')
+        # C++ program RPATH
+        build_rpath = get_rpath(os.path.join(self.builddir, 'progcxx'))
+        self.assertEqual(build_rpath, '$ORIGIN/sub:/foo/bar')
+        self.install()
+        install_rpath = get_rpath(os.path.join(self.installdir, 'usr/bin/progcxx'))
+        self.assertEqual(install_rpath, 'baz')
 
     def test_pch_with_address_sanitizer(self):
         testdir = os.path.join(self.common_test_dir, '13 pch')

--- a/test cases/unit/11 build_rpath/meson.build
+++ b/test cases/unit/11 build_rpath/meson.build
@@ -1,9 +1,16 @@
-project('build rpath', 'c')
+project('build rpath', 'c', 'cpp')
 
 subdir('sub')
 executable('prog', 'prog.c',
   link_with : l,
   build_rpath : '/foo/bar',
   install_rpath : '/baz',
+  install : true,
+  )
+
+executable('progcxx', 'prog.cc',
+  link_with : l,
+  build_rpath : '/foo/bar',
+  install_rpath : 'baz',
   install : true,
   )

--- a/test cases/unit/11 build_rpath/prog.cc
+++ b/test cases/unit/11 build_rpath/prog.cc
@@ -1,0 +1,8 @@
+#include <string>
+#include <iostream>
+
+int main(int argc, char **argv) {
+    std::string* s = new std::string("Hello");
+    delete s;
+    return 0;
+}


### PR DESCRIPTION
This change should fix linking with clang++ on linux when install_rpath is set.  The problem seems to be that clang expands `-Wl,-rpath-link,` to ['-rpath-link'] instead of ['-rpath-link',''].  This means that the next argument gets eaten by `-rpath-link`, and the next argument happens to be `-lstdc++'.

We avoid this by refusing to add an argument if the path contains only whitespace.
Fixes #2814