### PR TITLE
Ignore threads if not supported by the compiler

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -871,6 +871,9 @@ class Compiler:
                 args += ['-Wl,-rpath-link,' + lpaths]
         return args
 
+    def thread_flags(self, env):
+        return []
+
 
 GCC_STANDARD = 0
 GCC_OSX = 1


### PR DESCRIPTION
My attempt to fix #2834.
`need_threads` are ignored if the compiler doesn't support `thread_flags`.