### PR TITLE
intrp: Consolidate subproject dep checking and logging

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1880,6 +1880,29 @@ class FailureTests(BasePlatformTests):
             return
         raise unittest.SkipTest("objc and objcpp found, can't test detection failure")
 
+    def test_subproject_variables(self):
+        '''
+        Test that:
+        1. The correct message is outputted when a not-required dep is not
+           found and the fallback subproject is also not found.
+        2. A not-found not-required dep with a fallback subproject outputs the
+           correct message when the fallback subproject is found but the
+           variable inside it is not.
+        3. A fallback dependency is found from the subproject parsed in (2)
+        4. A not-required fallback dependency is not found because the
+           subproject failed to parse.
+        '''
+        tdir = os.path.join(self.unit_test_dir, '20 subproj dep variables')
+        out = self.init(tdir, inprocess=True)
+        self.assertRegex(out, r"Also couldn't find a fallback subproject "
+                         "in.*subprojects.*nosubproj.*for the dependency.*somedep")
+        self.assertRegex(out, r'Dependency.*somenotfounddep.*from subproject.*'
+                         'subprojects.*somesubproj.*found:.*NO')
+        self.assertRegex(out, r'Dependency.*zlibproxy.*from subproject.*'
+                         'subprojects.*somesubproj.*found:.*YES.*(cached)')
+        self.assertRegex(out, r'Also couldn\'t find a fallback subproject in '
+                         '.*subprojects.*failingsubproj.*for the dependency.*somedep')
+
 
 class WindowsTests(BasePlatformTests):
     '''

--- a/test cases/unit/20 subproj dep variables/meson.build
+++ b/test cases/unit/20 subproj dep variables/meson.build
@@ -1,0 +1,13 @@
+project('subproj found dep not found', 'c')
+
+dependency('somedep', required : false,
+           fallback : ['nosubproj', 'dep_name'])
+
+dependency('somedep', required : false,
+           fallback : ['failingsubproj', 'dep_name'])
+
+dependency('somenotfounddep', required : false,
+           fallback : ['somesubproj', 'dep_name'])
+
+dependency('zlibproxy', required : true,
+           fallback : ['somesubproj', 'zlibproxy_dep'])

--- a/test cases/unit/20 subproj dep variables/subprojects/failingsubproj/meson.build
+++ b/test cases/unit/20 subproj dep variables/subprojects/failingsubproj/meson.build
@@ -1,0 +1,3 @@
+project('failingsubproj', 'c')
+
+dep_name = declare_dependency('arg')

--- a/test cases/unit/20 subproj dep variables/subprojects/somesubproj/meson.build
+++ b/test cases/unit/20 subproj dep variables/subprojects/somesubproj/meson.build
@@ -1,0 +1,3 @@
+project('dep', 'c')
+
+zlibproxy_dep = declare_dependency(dependencies : dependency('zlib', required : false))


### PR DESCRIPTION
If a dep is not found on the system and a fallback is specified, we have two cases:

1. Look for the dependency in a pre-initialized subproject
2. Initialize the subproject and look for the dependency

Both these require version comparing, ensuring the fetched variable is a dependency, and printing a success message, erroring out, etc.

Now we share the relevant code instead of duplicating it. It already diverged, so this is a good thing.

As a side-effect, we now log fallback dependencies in the same format
as system dependencies:

```
Dependency libva found: YES
Dependency libva found: YES (cached)
```
```
Dependency glib-2.0 from subproject subprojects/glib found: YES
Dependency glib-2.0 from subproject subprojects/glib found: YES (cached)
```