### PR TITLE
compilers: Fix error when objc/objc++ compilers are not found

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -608,6 +608,7 @@ class Environment:
                 p, out, err = Popen_safe(compiler + arg)
             except OSError as e:
                 popen_exceptions[' '.join(compiler + arg)] = e
+                continue
             version = search_version(out)
             if 'Free Software Foundation' in out:
                 defines = self.get_gnu_compiler_defines(compiler)
@@ -634,6 +635,7 @@ class Environment:
                 p, out, err = Popen_safe(compiler + arg)
             except OSError as e:
                 popen_exceptions[' '.join(compiler + arg)] = e
+                continue
             version = search_version(out)
             if 'Free Software Foundation' in out:
                 defines = self.get_gnu_compiler_defines(compiler)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -37,7 +37,7 @@ from mesonbuild.interpreter import ObjectHolder
 from mesonbuild.mesonlib import is_linux, is_windows, is_osx, is_cygwin, windows_proof_rmtree
 from mesonbuild.mesonlib import python_command, meson_command, version_compare
 from mesonbuild.environment import Environment
-from mesonbuild.dependencies import DependencyException
+from mesonbuild.mesonlib import MesonException, EnvironmentException
 from mesonbuild.dependencies import PkgConfigDependency, ExternalProgram
 
 from run_tests import exe_suffix, get_fake_options
@@ -1744,7 +1744,7 @@ class FailureTests(BasePlatformTests):
             f.write(contents)
         # Force tracebacks so we can detect them properly
         os.environ['MESON_FORCE_BACKTRACE'] = '1'
-        with self.assertRaisesRegex(DependencyException, match, msg=contents):
+        with self.assertRaisesRegex(MesonException, match, msg=contents):
             # Must run in-process or we'll get a generic CalledProcessError
             self.init(self.srcdir, extra_args=extra_args, inprocess=True)
 
@@ -1864,6 +1864,21 @@ class FailureTests(BasePlatformTests):
         self.assertRegex(
             out,
             r'In subproject one: Unknown command line options: "one:two"')
+
+    def test_objc_cpp_detection(self):
+        '''
+        Test that when we can't detect objc or objcpp, we fail gracefully.
+        '''
+        env = Environment('', self.builddir, self.meson_command,
+                          get_fake_options(self.prefix), [])
+        try:
+            objc = env.detect_objc_compiler(False)
+            objcpp = env.detect_objcpp_compiler(False)
+        except EnvironmentException:
+            code = "add_languages('objc')\nadd_languages('objcpp')"
+            self.assertMesonRaises(code, "Unknown compiler")
+            return
+        raise unittest.SkipTest("objc and objcpp found, can't test detection failure")
 
 
 class WindowsTests(BasePlatformTests):


### PR DESCRIPTION
Earlier it would exit with a traceback:

UnboundLocalError: local variable 'out' referenced before assignment