### PR TITLE
Fix meson location detection from other meson tools

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -52,9 +52,13 @@ def detect_meson_py_location():
             if os.path.exists(m_path):
                 return m_path
 
+    # No meson found, which means that either:
+    # a) meson is not installed
+    # b) meson is installed to a non-standard location
+    # c) the script that invoked mesonlib is not the one of meson tools (e.g. run_unittests.py)
     # The only thing remaining is to try to find the bundled executable and
     # pray distro packagers have not moved it.
-    fname = os.path.join(os.path.dirname(__file__), '..', 'meson.py')
+    fname = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'meson.py'))
     if not os.path.exists(fname):
         raise RuntimeError('Could not determine how to run Meson. Please file a bug with details.')
     return fname

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -25,25 +25,32 @@ from glob import glob
 
 def detect_meson_py_location():
     c = sys.argv[0]
-    c_fname = os.path.split(c)[1]
-    if c_fname == 'meson' or c_fname == 'meson.py':
-        # $ /foo/meson.py <args>
-        if os.path.isabs(c):
-            return c
-        # $ meson <args> (gets run from /usr/bin/meson)
+    c_dir, c_fname = os.path.split(c)
+
+    # get the absolute path to the <mesontool> folder
+    m_dir = None
+    if os.path.isabs(c):
+        # $ /foo/<mesontool>.py <args>
+        m_dir = c_dir
+    elif c_dir == '':
+        # $ <mesontool> <args> (gets run from /usr/bin/<mesontool>)
         in_path_exe = shutil.which(c_fname)
         if in_path_exe:
-            # Special case: when run like "./meson.py <opts>" and user has
-            # period in PATH, we need to expand it out, because, for example,
+            m_dir, c_fname = os.path.split(in_path_exe)
+            # Special case: when run like "./meson.py <opts>",
+            # we need to expand it out, because, for example,
             # "ninja test" will be run from a different directory.
-            if '.' in os.environ['PATH'].split(':'):
-                p, f = os.path.split(in_path_exe)
-                if p == '' or p == '.':
-                    return os.path.join(os.getcwd(), f)
-            return in_path_exe
-        # $ python3 ./meson.py <args>
-        if os.path.exists(c):
-            return os.path.join(os.getcwd(), c)
+            if m_dir == '.':
+                m_dir = os.getcwd()
+    else:
+        m_dir = os.path.abspath(c_dir)
+
+    # find meson in m_dir
+    if m_dir is not None:
+        for fname in ['meson', 'meson.py']:
+            m_path = os.path.join(m_dir, fname)
+            if os.path.exists(m_path):
+                return m_path
 
     # The only thing remaining is to try to find the bundled executable and
     # pray distro packagers have not moved it.


### PR DESCRIPTION
ArchLinux meson package installs `wraptool` to `/usr/bin`, so when I try to run it:
```
> wraptool list
Traceback (most recent call last):
  File "/usr/bin/wraptool", line 17, in <module>
    from mesonbuild.wrap import wraptool
  File "/usr/lib/python3.6/site-packages/mesonbuild/wrap/wraptool.py", line 22, in <module>
    from .wrap import API_ROOT, open_wrapdburl
  File "/usr/lib/python3.6/site-packages/mesonbuild/wrap/wrap.py", line 22, in <module>
    from ..mesonlib import Popen_safe
  File "/usr/lib/python3.6/site-packages/mesonbuild/mesonlib.py", line 61, in <module>
    meson_command = python_command + [detect_meson_py_location()]
  File "/usr/lib/python3.6/site-packages/mesonbuild/mesonlib.py", line 28, in detect_meson_py_location
    raise RuntimeError(c_fname)
```

That's because `detect_meson_py_location()` assumes that the only script that could be run like that is `meson` or `meson.py`.
The PR changes the logic of this function a bit:
 * first, it tries to get the absolute path to the meson tool folder
 * then it tries to find meson executable in that folder