### PR TITLE
Allow declare_dependency() to create external dependencies

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -831,12 +831,14 @@ This will become a hard error in a future Meson release.''')
                 for l in dep.libraries:
                     self.link(l)
                 # Those parts that are external.
-                extpart = dependencies.InternalDependency('undefined',
-                                                          [],
-                                                          dep.compile_args,
-                                                          dep.link_args,
-                                                          [], [], [])
+                extpart = dependencies.DeclaredExternalDependency('undefined',
+                                                                  dep.compile_args,
+                                                                  dep.link_args, [])
                 self.external_deps.append(extpart)
+                # Deps of deps.
+                self.add_deps(dep.ext_deps)
+            elif isinstance(dep, dependencies.DeclaredExternalDependency):
+                self.external_deps.append(dep)
                 # Deps of deps.
                 self.add_deps(dep.ext_deps)
             elif isinstance(dep, dependencies.ExternalDependency):

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -14,7 +14,7 @@
 
 from .base import (  # noqa: F401
     Dependency, DependencyException, DependencyMethods, ExternalProgram,
-    ExternalDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
+    ExternalDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency, DeclaredExternalDependency,
     PkgConfigDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language)
 from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDependency
 from .misc import (BoostDependency, MPIDependency, Python3Dependency, ThreadDependency, PcapDependency, CupsDependency, LibWmfDependency)

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -203,7 +203,7 @@ class ExternalDependency(Dependency):
 
 class DeclaredExternalDependency(Dependency):
     def __init__(self, version, compile_args, link_args, ext_deps):
-        super().__init__('external_declared', {})
+        super().__init__('declared_external', {})
         self.version = version
         self.is_found = True
         self.compile_args = compile_args

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -201,6 +201,23 @@ class ExternalDependency(Dependency):
         return self.compiler
 
 
+class DeclaredExternalDependency(Dependency):
+    def __init__(self, version, compile_args, link_args, ext_deps):
+        super().__init__('external_declared', {})
+        self.version = version
+        self.is_found = True
+        self.compile_args = compile_args
+        self.link_args = link_args
+        self.ext_deps = ext_deps
+
+    def get_pkgconfig_variable(self, variable_name, kwargs):
+        raise DependencyException('Method "get_pkgconfig_variable()" is '
+                                  'invalid for a declared external dependency')
+
+    def get_configtool_variable(self, variable_name):
+        raise DependencyException('Method "get_configtool_variable()" is '
+                                  'invalid for a declared external dependency')
+
 class ConfigToolDependency(ExternalDependency):
 
     """Class representing dependencies found using a config tool."""

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1839,12 +1839,12 @@ class FailureTests(BasePlatformTests):
         dep = declare_dependency(dependencies : zlib_dep)
         dep.get_pkgconfig_variable('foo')
         '''
-        self.assertMesonRaises(code, "Method.*pkgconfig.*is invalid.*internal")
+        self.assertMesonRaises(code, "Method.*pkgconfig.*is invalid.*declared external")
         code = '''zlib_dep = dependency('zlib', required : false)
         dep = declare_dependency(dependencies : zlib_dep)
         dep.get_configtool_variable('foo')
         '''
-        self.assertMesonRaises(code, "Method.*configtool.*is invalid.*internal")
+        self.assertMesonRaises(code, "Method.*configtool.*is invalid.*declared external")
 
     def test_bad_option(self):
         tdir = os.path.join(self.unit_test_dir, '19 bad command line options')


### PR DESCRIPTION
IIUC, if `declare_dependency()` doesn't specify sources, include directories or libraries and doesn't depend on internal dependencies, it could be treated as an external dependency, i.e. used at configuration time.
This PR changes `declare_dependency()` so that it returns `DeclaredExternalDependency` object (`Dependency` subclass) if the condition above holds.
It allows to use declared dependencies in `has_function()` etc methods.

#### Motivation
Some external dependencies do not fit [yet] to what `find_library()` or `dependency()` offer.
E.g. MKL (#2835), which requires complex flags combination (e.g. `-fopenmp -m64 -I$MKL_ROOT/include -Wl,--start-group $MKL_ROOT/lib/intel64/libmkl_gf_lp64.a $MKL_ROOT/lib/intel64/libmkl_gnu_thread.a $MKL_ROOT/lib/intel64/libmkl_core.a -Wl,--end-group -lpthread -lm -ldl`).
These flags may be provided by configuration options (`meson_options.txt`) and `declare_dependency()` is a nice way to convert them into a configure-time dependency object.