### PR TITLE
Fix Visual Studio version detection for the `vs` backend

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -29,10 +29,9 @@ from ..environment import Environment
 def autodetect_vs_version(build):
     vs_version = os.getenv('VisualStudioVersion', None)
     vs_install_dir = os.getenv('VSINSTALLDIR', None)
-    if not vs_version and not vs_install_dir:
-        raise MesonException('Could not detect Visual Studio: VisualStudioVersion and VSINSTALLDIR are unset!\n'
-                             'Are we inside a Visual Studio build environment? '
-                             'You can also try specifying the exact backend to use.')
+    if not vs_install_dir:
+        raise MesonException('Could not detect Visual Studio: Environment variable VSINSTALLDIR is not set!\n'
+                             'Are you running meson from the Visual Studio Developer Command Prompt?')
     # VisualStudioVersion is set since Visual Studio 12.0, but sometimes
     # vcvarsall.bat doesn't set it, so also use VSINSTALLDIR
     if vs_version == '14.0' or 'Visual Studio 14' in vs_install_dir:

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -172,6 +172,7 @@ class MesonApp:
         elif self.options.backend == 'vs':
             from .backend import vs2010backend
             g = vs2010backend.autodetect_vs_version(b)
+            env.coredata.set_builtin_option('backend', g.name)
             mlog.log('Auto detected Visual Studio backend:', mlog.bold(g.name))
         elif self.options.backend == 'vs2010':
             from .backend import vs2010backend


### PR DESCRIPTION
When Visual Studio invokes the REGEN target, only the
VisualStudioVersion environment variable is set and VSINSTALLDIR left
unset. The version checker did not like this state of affairs.

Fixes #2848