### PR TITLE
compilers: prefer C++ over objc in clink_langs

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -49,7 +49,7 @@ cpp_suffixes = lang_suffixes['cpp'] + ('h',)
 c_suffixes = lang_suffixes['c'] + ('h',)
 # List of languages that can be linked with C code directly by the linker
 # used in build.py:process_compilers() and build.py:get_dynamic_linker()
-clike_langs = ('objcpp', 'objc', 'd', 'cpp', 'c', 'fortran',)
+clike_langs = ('d', 'objcpp', 'cpp', 'objc', 'c', 'fortran',)
 clike_suffixes = ()
 for _l in clike_langs:
     clike_suffixes += lang_suffixes[_l]

--- a/test cases/objc/6 c++ project objc subproject/master.cpp
+++ b/test cases/objc/6 c++ project objc subproject/master.cpp
@@ -1,0 +1,11 @@
+
+#include <iostream>
+
+extern "C"
+int foo();
+
+int main() {
+  std::cout << "Starting\n";
+  std::cout << foo() << "\n";
+  return 0;
+}

--- a/test cases/objc/6 c++ project objc subproject/meson.build
+++ b/test cases/objc/6 c++ project objc subproject/meson.build
@@ -1,0 +1,6 @@
+project('master', ['cpp'])
+
+foo = subproject('foo')
+dep = foo.get_variable('foo_dep')
+
+executable('master', 'master.cpp', dependencies: dep)

--- a/test cases/objc/6 c++ project objc subproject/subprojects/foo/foo.m
+++ b/test cases/objc/6 c++ project objc subproject/subprojects/foo/foo.m
@@ -1,0 +1,4 @@
+
+int foo() {
+  return 42;
+}

--- a/test cases/objc/6 c++ project objc subproject/subprojects/foo/meson.build
+++ b/test cases/objc/6 c++ project objc subproject/subprojects/foo/meson.build
@@ -1,0 +1,5 @@
+project('foo', ['objc'])
+
+l = static_library('foo', 'foo.m')
+
+foo_dep = declare_dependency(link_with : l)


### PR DESCRIPTION
Otherwise we will try to use the objc compiler when linking projects with both objc and C++.

Technically we should use the objc++ linker when doing this, but on most (all?) systems the objc++ linker is `c++`, which is the same as the C++ linker.

Closes https://github.com/mesonbuild/meson/issues/2468