### PR TITLE
Fix test cases/windows/5 resources

### DIFF
--- a/test cases/windows/5 resources/prog.c
+++ b/test cases/windows/5 resources/prog.c
@@ -9,6 +9,6 @@ WinMain(
     LPSTR lpszCmdLine,
     int nCmdShow) {
     HICON hIcon;
-    hIcon = LoadIcon(NULL, IDI_APPLICATION);
+    hIcon = LoadIcon(GetModuleHandle(NULL), MAKEINTRESOURCE(MY_ICON));
     return hIcon ? 0 : 1;
 }


### PR DESCRIPTION
Currently, this test only tries to load a predefined icon, so the resource
compilation and linking can be completely removed from the meson.build and
it still passes.

Change to try to load the icon contained in the resources we compile.