### PR TITLE
Consolidate warning location formatting

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1574,7 +1574,7 @@ class Interpreter(InterpreterBase):
         modname = args[0]
         if modname.startswith('unstable-'):
             plainname = modname.split('-', 1)[1]
-            mlog.warning('Module %s has no backwards or forwards compatibility and might not exist in future releases.' % modname)
+            mlog.warning('Module %s has no backwards or forwards compatibility and might not exist in future releases' % modname, location=node)
             modname = 'unstable_' + plainname
         if modname not in self.environment.coredata.modules:
             try:
@@ -2732,7 +2732,7 @@ root and issuing %s.
                     mlog.warning(
                         "The variable(s) %s in the input file %s are not "
                         "present in the given configuration data" % (
-                            var_list, inputfile))
+                            var_list, inputfile), location=node)
             else:
                 mesonlib.dump_conf_header(ofile_abs, conf.held_object)
             conf.mark_used()

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1935,7 +1935,7 @@ to directly access options of other subprojects.''')
     @noKwargs
     def func_warning(self, node, args, kwargs):
         argstr = self.get_message_string_arg(node)
-        mlog.warning('%s in file %s, line %d' % (argstr, os.path.join(node.subdir, 'meson.build'), node.lineno))
+        mlog.warning(argstr, location=node)
 
     @noKwargs
     def func_error(self, node, args, kwargs):

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -103,6 +103,13 @@ def log(*args, **kwargs):
     force_print(*arr, **kwargs)
 
 def warning(*args, **kwargs):
+    from . import environment
+
+    if kwargs.get('location'):
+        location = kwargs['location']
+        del kwargs['location']
+        args += ('in file {}, line {}.'.format(os.path.join(location.subdir, environment.build_filename), location.lineno),)
+
     log(yellow('WARNING:'), *args, **kwargs)
 
 # Format a list for logging purposes as a string. It separates

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os, re
+import re
 from .mesonlib import MesonException
 from . import mlog
 
@@ -368,7 +368,8 @@ class ArgumentNode:
 
     def set_kwarg(self, name, value):
         if name in self.kwargs:
-            mlog.warning('Keyword argument "%s" defined multiple times in file %s, line %d. This will be an error in future Meson releases.' % (name, os.path.join(self.subdir, 'meson.build'), self.lineno))
+            mlog.warning('Keyword argument "{}" defined multiple times'.format(name), location=self)
+            mlog.warning('This will be an error in future Meson releases.')
         self.kwargs[name] = value
 
     def num_args(self):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1717,6 +1717,7 @@ int main(int argc, char **argv) {
             r'WARNING: subdir warning in file sub' + os.path.sep + r'meson.build, line 4',
             r'WARNING: Module unstable-simd has no backwards or forwards compatibility and might not exist in future releases in file meson.build, line 7',
             r"WARNING: The variable(s) 'MISSING' in the input file conf.in are not present in the given configuration data in file meson.build, line 10",
+            r'WARNING: Passed invalid keyword argument "invalid" in file meson.build, line 1'
         ]:
             self.assertRegex(out, re.escape(expected))
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1710,10 +1710,15 @@ int main(int argc, char **argv) {
     def test_warning_location(self):
         tdir = os.path.join(self.unit_test_dir, '20 warning location')
         out = self.init(tdir)
-        self.assertRegex(out, r'WARNING: Keyword argument "link_with" defined multiple times in file meson.build, line 4')
-        self.assertRegex(out, r'WARNING: Keyword argument "link_with" defined multiple times in file sub' + re.escape(os.path.sep) + r'meson.build, line 3')
-        self.assertRegex(out, r'WARNING: a warning of some sort in file meson.build, line 6')
-        self.assertRegex(out, r'WARNING: subdir warning in file sub' + re.escape(os.path.sep) + r'meson.build, line 4')
+        for expected in [
+            r'WARNING: Keyword argument "link_with" defined multiple times in file meson.build, line 4',
+            r'WARNING: Keyword argument "link_with" defined multiple times in file sub' + os.path.sep + r'meson.build, line 3',
+            r'WARNING: a warning of some sort in file meson.build, line 6',
+            r'WARNING: subdir warning in file sub' + os.path.sep + r'meson.build, line 4',
+            r'WARNING: Module unstable-simd has no backwards or forwards compatibility and might not exist in future releases in file meson.build, line 7',
+            r"WARNING: The variable(s) 'MISSING' in the input file conf.in are not present in the given configuration data in file meson.build, line 10",
+        ]:
+            self.assertRegex(out, re.escape(expected))
 
     def test_templates(self):
         ninja = detect_ninja()

--- a/test cases/unit/20 warning location/conf.in
+++ b/test cases/unit/20 warning location/conf.in
@@ -1,0 +1,1 @@
+@MISSING@

--- a/test cases/unit/20 warning location/meson.build
+++ b/test cases/unit/20 warning location/meson.build
@@ -1,4 +1,4 @@
-project('warning location', 'c')
+project('warning location', 'c', invalid: 'cheese')
 a = library('liba', 'a.c')
 b = library('libb', 'b.c')
 executable('main', 'main.c', link_with: a, link_with: b)

--- a/test cases/unit/20 warning location/meson.build
+++ b/test cases/unit/20 warning location/meson.build
@@ -1,6 +1,10 @@
-project('duplicate kwarg', 'c')
+project('warning location', 'c')
 a = library('liba', 'a.c')
 b = library('libb', 'b.c')
 executable('main', 'main.c', link_with: a, link_with: b)
 subdir('sub')
 warning('a warning of some sort')
+import('unstable-simd')
+
+conf_data = configuration_data()
+configure_file(input: 'conf.in' , output: 'conf', configuration: conf_data)


### PR DESCRIPTION
Consolidate warning location formatting, and wire it up in a few more places.

I ended up absorbing the final full-stop into the location formatter, and moving the "This will be an error in future Meson releases." note onto a separate line, to avoid the formatter getting hugely complex, but maybe that's not the best idea.

Groundwork for #2854
