### PR TITLE
RunScripts dependencies

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -719,6 +719,9 @@ int dummy;
                         strip_bin, self.environment.get_build_command() + ['introspect'])
         elem = NinjaBuildElement(self.all_outputs, 'meson-install', 'CUSTOM_COMMAND', 'PHONY')
         elem.add_dep('all')
+        for i in self.build.install_scripts:
+            for dep in i['deps']:
+                elem.add_dep(dep.name)
         elem.add_item('DESC', 'Installing files.')
         elem.add_item('COMMAND', self.environment.get_build_command() + ['--internal', 'install', install_data_file])
         elem.add_item('pool', 'console')

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1923,12 +1923,13 @@ class Data:
                 raise MesonException('Size of rename argument is different from number of sources')
 
 class RunScript(dict):
-    def __init__(self, script, args):
+    def __init__(self, script, args, deps=[]):
         super().__init__()
         assert(isinstance(script, list))
         assert(isinstance(args, list))
         self['exe'] = script
         self['args'] = args
+        self['deps'] = deps
 
 class TestSetup:
     def __init__(self, *, exe_wrapper=None, gdb=None, timeout_multiplier=None, env=None):

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -812,9 +812,10 @@ This will become a hard error in the future.''')
         args += self._unpack_args('--ignore-headers=', 'ignore_headers', kwargs)
         args += self._unpack_args('--installdir=', 'install_dir', kwargs, state)
         args += self._get_build_args(kwargs, state)
-        res = [build.RunTarget(targetname, command[0], command[1:] + args, depends, state.subdir, state.subproject)]
+        t = build.RunTarget(targetname, command[0], command[1:] + args, depends, state.subdir, state.subproject)
+        res = [t]
         if kwargs.get('install', True):
-            res.append(build.RunScript(command, args))
+            res.append(build.RunScript(command, args, [t]))
         return ModuleReturnValue(None, res)
 
     def _get_build_args(self, kwargs, state):


### PR DESCRIPTION
After the addition of generated content files to `gtkdoc`, there has been a need to relate `RunScripts` with dependencies so these are built in time for those `RunScripts` that need them.

This PR adds an optional dependecies to `RunScripts`. This also makes `gtkdoc` `RunTarget`, which has a corresponding `RunScript` to be related, so the latter ends triggering the first which also triggers its corresponding dependencies to be build making all the dependencies for the `RunScript` to be present.