### PR TITLE
Verify that failing tests are failing with an error, not a python exception

### DIFF
--- a/docs/markdown/Running-Meson.md
+++ b/docs/markdown/Running-Meson.md
@@ -146,3 +146,9 @@ Meson has a standard command line help feature. It can be accessed
 with the following command.
 
     meson --help
+
+Exit status
+==
+
+Meson exits with status 0 if successful, 1 for problems with the command line or
+meson.build file, and 2 for internal errors.

--- a/man/meson.1
+++ b/man/meson.1
@@ -202,6 +202,19 @@ show available versions of the specified project
 \fBstatus\fR
 show installed and available versions of currently used subprojects
 
+.SH EXIT STATUS
+
+.TP
+.B 0
+Successful.
+.TP
+.B 1
+Usage error, or an error parsing or executing meson.build.
+.TP
+.B 2
+Internal error.
+.TP
+
 .SH SEE ALSO
 
 http://mesonbuild.com/

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -695,10 +695,11 @@ class Environment:
         for compiler in compilers:
             if isinstance(compiler, str):
                 compiler = [compiler]
+            arg = ['--version']
             try:
-                p, out = Popen_safe(compiler + ['--version'])[0:2]
+                p, out = Popen_safe(compiler + arg)[0:2]
             except OSError as e:
-                popen_exceptions[compiler] = e
+                popen_exceptions[' '.join(compiler + arg)] = e
                 continue
 
             version = search_version(out)

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1470,7 +1470,6 @@ class Interpreter(InterpreterBase):
                            'disabler': self.func_disabler,
                            'environment': self.func_environment,
                            'error': self.func_error,
-                           'exception': self.func_exception,
                            'executable': self.func_executable,
                            'generator': self.func_generator,
                            'gettext': self.func_gettext,
@@ -1504,6 +1503,8 @@ class Interpreter(InterpreterBase):
                            'test': self.func_test,
                            'vcs_tag': self.func_vcs_tag,
                            })
+        if 'MESON_UNIT_TEST' in os.environ:
+            self.funcs.update({'exception': self.func_exception})
 
     def holderify(self, item):
         if isinstance(item, list):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1470,6 +1470,7 @@ class Interpreter(InterpreterBase):
                            'disabler': self.func_disabler,
                            'environment': self.func_environment,
                            'error': self.func_error,
+                           'exception': self.func_exception,
                            'executable': self.func_executable,
                            'generator': self.func_generator,
                            'gettext': self.func_gettext,
@@ -1982,6 +1983,11 @@ to directly access options of other subprojects.''')
     def func_error(self, node, args, kwargs):
         self.validate_arguments(args, 1, [str])
         raise InterpreterException('Error encountered: ' + args[0])
+
+    @noKwargs
+    def func_exception(self, node, args, kwargs):
+        self.validate_arguments(args, 0, [])
+        raise Exception()
 
     def detect_compilers(self, lang, need_cross_compiler):
         cross_comp = None

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -283,8 +283,8 @@ class InterpreterBase:
         # different types, which will one day become an error.
         if not valid and (node.ctype == '==' or node.ctype == '!='):
             mlog.warning('''Trying to compare values of different types ({}, {}) using {}.
-The result of this is undefined and will become a hard error
-in a future Meson release.'''.format(type(val1).__name__, type(val2).__name__, node.ctype))
+The result of this is undefined and will become a hard error in a future Meson release.'''
+                         .format(type(val1).__name__, type(val2).__name__, node.ctype), location=node)
         if node.ctype == '==':
             return val1 == val2
         elif node.ctype == '!=':

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -376,11 +376,12 @@ def run(original_args, mainfile=None):
             mlog.log("\nA full log can be found at", mlog.bold(logfile))
             if os.environ.get('MESON_FORCE_BACKTRACE'):
                 raise
+            return 1
         else:
             if os.environ.get('MESON_FORCE_BACKTRACE'):
                 raise
             traceback.print_exc()
-        return 1
+            return 2
     finally:
         mlog.shutdown()
 

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -321,9 +321,12 @@ def _run_test(testdir, test_build_dir, install_dir, extra_args, compiler, backen
         mesonlog = no_meson_log_msg
     gen_time = time.time() - gen_start
     if should_fail == 'meson':
-        if returncode != 0:
+        if returncode == 1:
             return TestResult('', BuildStep.configure, stdo, stde, mesonlog, gen_time)
-        return TestResult('Test that should have failed succeeded', BuildStep.configure, stdo, stde, mesonlog, gen_time)
+        elif returncode != 0:
+            return TestResult('Test exited with unexpected status {}'.format(returncode), BuildStep.configure, stdo, stde, mesonlog, gen_time)
+        else:
+            return TestResult('Test that should have failed succeeded', BuildStep.configure, stdo, stde, mesonlog, gen_time)
     if returncode != 0:
         return TestResult('Generating the build system failed.', BuildStep.configure, stdo, stde, mesonlog, gen_time)
     # Touch the meson.build file to force a regenerate so we can test that

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1938,6 +1938,7 @@ class FailureTests(BasePlatformTests):
         Test exit status on python exception
         '''
         tdir = os.path.join(self.unit_test_dir, '21 exit status')
+        os.environ['MESON_UNIT_TEST'] = '1'
         with self.assertRaises(subprocess.CalledProcessError) as cm:
             self.init(tdir, inprocess=False)
         self.assertEqual(cm.exception.returncode, 2)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1933,6 +1933,16 @@ class FailureTests(BasePlatformTests):
         self.assertRegex(out, r'Also couldn\'t find a fallback subproject in '
                          '.*subprojects.*failingsubproj.*for the dependency.*somedep')
 
+    def test_exception_exit_status(self):
+        '''
+        Test exit status on python exception
+        '''
+        tdir = os.path.join(self.unit_test_dir, '21 exit status')
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.init(tdir, inprocess=False)
+        self.assertEqual(cm.exception.returncode, 2)
+        self.wipe()
+
 
 class WindowsTests(BasePlatformTests):
     '''

--- a/test cases/common/19 comparison/meson.build
+++ b/test cases/common/19 comparison/meson.build
@@ -126,3 +126,14 @@ test('equalfalse', exe13)
 test('equaltrue', exe14)
 test('nequaltrue', exe15)
 test('nequalfalse', exe16)
+
+# Equality comparisons of different elementary types
+# (these all cause warnings currently, will become an error in future)
+
+assert([] != 'st', 'not equal')
+assert([] != 1, 'not equal')
+assert(2 != 'st', 'not equal')
+
+assert(not ([] == 'st'), 'not equal')
+assert(not ([] == 1), 'not equal')
+assert(not (2 == 'st'), 'not equal')

--- a/test cases/unit/21 exit status/meson.build
+++ b/test cases/unit/21 exit status/meson.build
@@ -1,0 +1,2 @@
+project('exit status')
+exception()


### PR DESCRIPTION

PR #2527 suggests "making failing tests more strict about failing
gracefully".

To achive this, make meson exit with distinct exit statuses for meson errors
and python exceptions, and check the exit status is as expected for failing
tests.

I can't see how to write a test for this, within the current framework.

You can test this change by reverting the fix (but not the test) from commit
1a159db8 and verifying that 'test cases/failing/66 string as link target'
fails.