### PR TITLE
Pool feature

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -885,6 +885,7 @@ building of a specific target.
 **Note:** A pool named 'link_pool' is reserved and it is not possible to 
           reference or redefine it.
 
+*Added 0.45.0*
 
 ### project()
 

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -882,6 +882,9 @@ building of a specific target.
 **Note:** A pool named 'console' is automatically configured and available.
           It is not possible to redefine it.
 
+**Note:** A pool named 'link_pool' is reserved and it is not possible to 
+          reference or redefine it.
+
 
 ### project()
 

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -228,6 +228,8 @@ following.
 - `install` when true, this target is installed during the install step
 - `install_dir` directory to install to
 - `output` list of output files
+- `pool` *(added 0.45.0)* specifies that the files generation are tied
+  to a given pool limiting amount of concurrent files at the same time.
 
 The list of strings passed to the `command` keyword argument accept
 the following special string substitutions:
@@ -444,6 +446,9 @@ be passed to [shared and static libraries](#library).
   in the D programming language
 - `d_unittest`, when set to true, the D modules are compiled in debug mode
 - `d_module_versions` list of module versions set when compiling D sources
+- `pool` *(added 0.45.0)* specifies that the files compilation are tied
+  to a given pool limiting amount of concurrent files being compiled at the
+  same time.
 
 The list of `sources`, `objects`, and `dependencies` is always
 flattened, which means you can freely nest and add lists while
@@ -565,6 +570,8 @@ following:
 - `capture` when this argument is set to true, Meson captures `stdout`
   of the `executable` and writes it to the target file specified as
   `output`. Available since v0.43.0.
+- `pool` *(added 0.45.0)* specifies that the files generation are tied
+  to a given pool limiting amount of concurrent files at the same time.
 
 The returned object also has methods that are documented in the
 [object methods section](#generator-object) below.
@@ -860,6 +867,21 @@ This function prints its argument to stdout.
 This function prints its argument to stdout prefixed with WARNING:.
 
 *Added 0.44.0*
+
+### pool()
+
+``` meson
+    void pool(pool_name, depth)
+```
+
+The first argument to this function must be a string defining the name
+of a pool. It is followed by a positive integer representing the depth value.
+Once declared, a pool can be referenced to limit concurrent jobs used during
+building of a specific target.
+
+**Note:** A pool named 'console' is automatically configured and available.
+          It is not possible to redefine it.
+
 
 ### project()
 

--- a/docs/markdown/snippets/pool_feature.md
+++ b/docs/markdown/snippets/pool_feature.md
@@ -1,0 +1,3 @@
+# New pool feature
+
+The `pool` function can be used to declare pool which can be further used in any targets.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -888,10 +888,11 @@ int dummy;
   depth = %d
 
 ''' % num_pools)
+        outfile.write('# Declared pools.\n\n')
         for p in self.interpreter.pools:
             pool_name = p.strip()
 
-            if pool_name == '' or pool_name == 'console':
+            if pool_name == '' or pool_name == 'console' or pool_name == 'link_pool':
                 continue
 
             outfile.write('''pool %s

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -888,6 +888,17 @@ int dummy;
   depth = %d
 
 ''' % num_pools)
+        for p in self.interpreter.pools:
+            pool_name = p.strip()
+
+            if pool_name == '' or pool_name == 'console':
+                continue
+
+            outfile.write('''pool %s
+  depth = %d
+
+''' % (pool_name, self.interpreter.pools[pool_name]))
+
         if self.environment.is_cross_build():
             self.generate_static_link_rules(True, outfile)
         self.generate_static_link_rules(False, outfile)
@@ -1798,6 +1809,7 @@ rule FORTRAN_DEP_HACK
         return args
 
     def generate_genlist_for_target(self, genlist, target, outfile):
+        # @TODO: générer les pools pour des generator()
         generator = genlist.get_generator()
         exe = generator.get_exe()
         exe_arr = self.exe_object_to_cmd_array(exe)
@@ -1854,6 +1866,8 @@ rule FORTRAN_DEP_HACK
             if isinstance(exe, build.BuildTarget):
                 elem.add_dep(self.get_target_filename(exe))
             elem.add_item('COMMAND', cmd)
+            if generator.pool_name != '':
+                elem.add_item('pool', generator.pool_name)
             elem.write(outfile)
 
     def scan_fortran_module_outputs(self, target):
@@ -2232,6 +2246,8 @@ rule FORTRAN_DEP_HACK
             element.add_orderdep(i)
         element.add_item('DEPFILE', dep_file)
         element.add_item('ARGS', commands)
+        if target.pool_name != '':
+            element.add_item('pool', target.pool_name)
         element.write(outfile)
         return rel_obj
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -61,6 +61,7 @@ known_basic_kwargs = {'install': True,
                       'native': True,
                       'build_by_default': True,
                       'override_options': True,
+                      'pool': True,
                       }
 
 # These contain kwargs supported by both static and shared libraries. These are
@@ -292,6 +293,7 @@ a hard error in the future.''' % name)
         self.install = False
         self.build_always = False
         self.option_overrides = {}
+        self.pool_name = ''
 
     def get_basename(self):
         return self.name
@@ -313,6 +315,10 @@ a hard error in the future.''' % name)
             self.build_by_default = kwargs['build_by_default']
             if not isinstance(self.build_by_default, bool):
                 raise InvalidArguments('build_by_default must be a boolean value.')
+        if 'pool' in kwargs:
+            self.pool_name = kwargs['pool']
+            if not isinstance(self.pool_name, str):
+                raise InvalidArguments('pool must be a string value.')
         self.option_overrides = self.parse_overrides(kwargs)
 
     def parse_overrides(self, kwargs):
@@ -1024,6 +1030,7 @@ class Generator:
         self.exe = exe
         self.depfile = None
         self.capture = False
+        self.pool_name = ''
         self.process_kwargs(kwargs)
 
     def __repr__(self):
@@ -1072,6 +1079,11 @@ class Generator:
             if not isinstance(capture, bool):
                 raise InvalidArguments('Capture must be boolean.')
             self.capture = capture
+        if 'pool' in kwargs:
+            pool_name = kwargs['pool']
+            if not isinstance(pool_name, str):
+                raise InvalidArguments('pool must be a string.')
+            self.pool_name = pool_name
 
     def get_base_outnames(self, inname):
         plainname = os.path.split(inname)[1]

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1313,6 +1313,7 @@ lang_arg_kwargs = set([
 vala_kwargs = set(['vala_header', 'vala_gir', 'vala_vapi'])
 rust_kwargs = set(['rust_crate_type'])
 cs_kwargs = set(['resources', 'cs_args'])
+pool_kwargs = set(['pool'])
 
 buildtarget_kwargs = set([
     'build_by_default',
@@ -1345,7 +1346,8 @@ build_target_common_kwargs = (
     pch_kwargs |
     vala_kwargs |
     rust_kwargs |
-    cs_kwargs)
+    cs_kwargs |
+    pool_kwargs)
 
 exe_kwargs = (build_target_common_kwargs) | {'implib'}
 shlib_kwargs = (build_target_common_kwargs) | {'version', 'soversion'}
@@ -1367,18 +1369,19 @@ permitted_kwargs = {'add_global_arguments': {'language'},
                     'benchmark': {'args', 'env', 'should_fail', 'timeout', 'workdir', 'suite'},
                     'build_target': build_target_kwargs,
                     'configure_file': {'input', 'output', 'configuration', 'command', 'install_dir', 'capture', 'install'},
-                    'custom_target': {'input', 'output', 'command', 'install', 'install_dir', 'build_always', 'capture', 'depends', 'depend_files', 'depfile', 'build_by_default'},
+                    'custom_target': {'input', 'output', 'command', 'install', 'install_dir', 'build_always', 'capture', 'depends', 'depend_files', 'depfile', 'build_by_default', 'pool'},
                     'dependency': {'default_options', 'fallback', 'language', 'method', 'modules', 'optional_modules', 'native', 'required', 'static', 'version'},
                     'declare_dependency': {'include_directories', 'link_with', 'sources', 'dependencies', 'compile_args', 'link_args', 'version'},
                     'executable': exe_kwargs,
                     'find_program': {'required', 'native'},
-                    'generator': {'arguments', 'output', 'depfile', 'capture'},
+                    'generator': {'arguments', 'output', 'depfile', 'capture', 'pool'},
                     'include_directories': {'is_system'},
                     'install_data': {'install_dir', 'install_mode', 'sources'},
                     'install_headers': {'install_dir', 'subdir'},
                     'install_man': {'install_dir'},
                     'install_subdir': {'exclude_files', 'exclude_directories', 'install_dir', 'install_mode'},
                     'jar': jar_kwargs,
+                    'pool': {'name', 'depth'},
                     'project': {'version', 'meson_version', 'default_options', 'license', 'subproject_dir'},
                     'run_target': {'command', 'depends'},
                     'shared_library': shlib_kwargs,
@@ -1415,6 +1418,7 @@ class Interpreter(InterpreterBase):
         self.project_args_frozen = False
         self.global_args_frozen = False  # implies self.project_args_frozen
         self.subprojects = {}
+        self.pools = {'console': 1}
         self.subproject_stack = []
         self.default_project_options = default_project_options[:] # Passed from the outside, only used in subprojects.
         self.build_func_dict()
@@ -1475,6 +1479,7 @@ class Interpreter(InterpreterBase):
                            'message': self.func_message,
                            'warning': self.func_warning,
                            'option': self.func_option,
+                           'pool': self.func_pool,
                            'project': self.func_project,
                            'run_target': self.func_run_target,
                            'run_command': self.func_run_command,
@@ -1851,6 +1856,11 @@ to directly access options of other subprojects.''')
                 newoptions = [defopt] + self.environment.cmd_line_options.projectoptions
                 self.environment.cmd_line_options.projectoptions = newoptions
 
+    @permittedKwargs(permitted_kwargs['pool'])
+    @stringArgs
+    def func_pool(self, node, args, kwargs):
+        return self.add_pool(args, kwargs)
+
     @stringArgs
     @permittedKwargs(permitted_kwargs['project'])
     def func_project(self, node, args, kwargs):
@@ -2011,6 +2021,29 @@ to directly access options of other subprojects.''')
         new_options.update(self.coredata.compiler_options)
         self.coredata.compiler_options = new_options
         return comp, cross_comp
+
+    def add_pool(self, args, kwargs):
+        if 'name' not in kwargs:
+            raise InterpreterException('Missing pool name.')
+        elif not isinstance(kwargs['name'], str):
+            raise InterpreterException('Pool name must be a string.')
+
+        name = kwargs['name']
+
+        if name == 'console':
+            raise InterpreterException('"console" pool can\'t be redefined.')
+
+        if 'depth' not in kwargs:
+            raise InterpreterException('Missing pool depth value.')
+        elif not isinstance(kwargs['depth'], int):
+            raise InterpreterException('Pool depth must be an integer.')
+        elif kwargs['depth'] < 1:
+            raise InterpreterException('Pool depth must be >= 1.')
+
+        if name in self.pools:
+            raise InvalidCode('Tried to create pool "%s", but a pool of that name already exists.' % name)
+
+        self.pools[name] = kwargs['depth']
 
     def add_languages(self, args, required):
         success = True
@@ -2407,6 +2440,14 @@ root and issuing %s.
         if len(args) != 1:
             raise InterpreterException('custom_target: Only one positional argument is allowed, and it must be a string name')
         name = args[0]
+
+        pool_name = ''
+        if 'pool' in kwargs:
+            pool_name = kwargs['pool'].strip()
+
+        if pool_name != '' and pool_name not in self.pools:
+            raise InvalidCode('Pool "%s" has not been declared.' % pool_name)
+
         tg = CustomTargetHolder(build.CustomTarget(name, self.subdir, self.subproject, kwargs), self)
         self.add_target(name, tg.held_object)
         return tg
@@ -2456,6 +2497,14 @@ root and issuing %s.
 
     @permittedKwargs(permitted_kwargs['generator'])
     def func_generator(self, node, args, kwargs):
+
+        pool_name = ''
+        if 'pool' in kwargs:
+            pool_name = kwargs['pool'].strip()
+
+        if pool_name != '' and pool_name not in self.pools:
+            raise InvalidCode('Pool "%s" has not been declared.' % pool_name)
+
         gen = GeneratorHolder(self, args, kwargs)
         self.generators.append(gen)
         return gen
@@ -3030,6 +3079,14 @@ different subdirectory.
         else:
             mlog.debug('Unknown target type:', str(targetholder))
             raise RuntimeError('Unreachable code')
+
+        pool_name = ''
+        if 'pool' in kwargs:
+            pool_name = kwargs['pool'].strip()
+
+        if pool_name != '' and pool_name not in self.pools:
+            raise InvalidCode('Pool "%s" has not been declared.' % pool_name)
+
         target = targetclass(name, self.subdir, self.subproject, is_cross, sources, objs, self.environment, kwargs)
         if is_cross:
             self.add_cross_stdlib_info(target)

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1418,7 +1418,7 @@ class Interpreter(InterpreterBase):
         self.project_args_frozen = False
         self.global_args_frozen = False  # implies self.project_args_frozen
         self.subprojects = {}
-        self.pools = {'console': 1}
+        self.pools = {'console': 1, 'link_pool': 1}
         self.subproject_stack = []
         self.default_project_options = default_project_options[:] # Passed from the outside, only used in subprojects.
         self.build_func_dict()
@@ -2030,8 +2030,8 @@ to directly access options of other subprojects.''')
 
         name = kwargs['name']
 
-        if name == 'console':
-            raise InterpreterException('"console" pool can\'t be redefined.')
+        if name == 'console' or name == 'link_pool':
+            raise InterpreterException("\"%s\" pool can't be redefined." % name)
 
         if 'depth' not in kwargs:
             raise InterpreterException('Missing pool depth value.')


### PR DESCRIPTION
Add possibility to limit concurrent jobs running at the same time for a given target.
At work, I use proprietary code generation tools which rely on token server.
As the token server can't deliver several tokens at the same time, file generation fails.

I propose to implement a feature called 'pools' (as in Ninja) to be able to declare custom pools and then reference them in targets so that they are built using a limited amount of concurrent jobs.

I updated Reference manual but not automatic tests yet.

Consider following meson.build file:

```python
project('test', 'c')

# Sources to compile
srcs = ['file0.c', 'file1.c', 'file2.c', 'file3.c', 'file4.c', 'file5.c', 'file6.c', 'file7.c', 'file8.c', 'file9.c', 'file10.c']

# Declare a custom pool
pool(name: 'one_at_a_time', depth: 1)

# Build a library without specifying any particular pool : its files will be compiled in parallel (using N jobs determined automatically by Ninja)
library('lib1', sources: src)

# Build a library specifying a pool : its files will be compiled sequentially (because pool depth is 1) 
library('lib2', pool: 'one_at_a_time', sources: src)

```

  