### PR TITLE
rpm: print testlog from subshell

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -34,8 +34,8 @@
 
 %meson_test \
     %ninja_test -C %{_vpath_builddir} || \
-    { rc=$?; \
+    ( rc=$?; \
       echo "-----BEGIN TESTLOG-----"; \
       cat %{_vpath_builddir}/meson-logs/testlog.txt; \
       echo "-----END TESTLOG-----"; \
-      exit $rc; }
+      exit $rc; )


### PR DESCRIPTION
false || { rc=$?; echo $rc; exit $rc } || :

Exits current shell without possibility to prevent that.

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>