### PR TITLE
Fix a problem when anyone actually tries to use a non-found dependency

### DIFF
--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -15,7 +15,8 @@
 from .base import (  # noqa: F401
     Dependency, DependencyException, DependencyMethods, ExternalProgram,
     ExternalDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
-    PkgConfigDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language)
+    PkgConfigDependency, find_external_dependency, get_dep_identifier, packages,
+    _packages_accept_language, NotFoundDependency)
 from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDependency
 from .misc import (BoostDependency, MPIDependency, Python3Dependency, ThreadDependency, PcapDependency, CupsDependency, LibWmfDependency)
 from .platform import AppleFrameworks

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -62,6 +62,9 @@ class DependencyMethods(Enum):
 
 class Dependency:
     def __init__(self, type_name, kwargs):
+        if type(self) == Dependency.__class__:
+            raise MesonException('The class Dependency() should not be directly instantiated')
+
         self.name = "null"
         self.version = 'none'
         self.language = None # None means C-like
@@ -199,6 +202,11 @@ class ExternalDependency(Dependency):
 
     def get_compiler(self):
         return self.compiler
+
+
+class NotFoundDependency(ExternalDependency):
+    def __init__(self, environment):
+        super().__init__('not-found', environment, None, {})
 
 
 class ConfigToolDependency(ExternalDependency):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -23,7 +23,7 @@ from .wrap import wrap, WrapMode
 from . import mesonlib
 from .mesonlib import FileMode, Popen_safe, listify, extract_as_list
 from .dependencies import ExternalProgram
-from .dependencies import InternalDependency, Dependency, DependencyException
+from .dependencies import InternalDependency, Dependency, DependencyException, NotFoundDependency
 from .interpreterbase import InterpreterBase
 from .interpreterbase import check_stringlist, noPosargs, noKwargs, stringArgs, permittedKwargs
 from .interpreterbase import InterpreterException, InvalidArguments, InvalidCode
@@ -2212,7 +2212,7 @@ to directly access options of other subprojects.''')
         if name == '':
             if required:
                 raise InvalidArguments('Dependency is both required and not-found')
-            return DependencyHolder(Dependency('not-found', {}))
+            return DependencyHolder(NotFoundDependency(self.environment))
 
         if '<' in name or '>' in name or '=' in name:
             raise InvalidArguments('Characters <, > and = are forbidden in dependency names. To specify'

--- a/test cases/common/171 not-found dependency/meson.build
+++ b/test cases/common/171 not-found dependency/meson.build
@@ -1,4 +1,4 @@
-project('dep-test')
+project('dep-test', 'c')
 
 dep = dependency('', required:false)
 if dep.found()
@@ -6,3 +6,6 @@ if dep.found()
 endif
 
 assert(dep.type_name() == 'not-found', 'dependency should be of type "not-found" not ' + dep.type_name())
+
+library('testlib', 'testlib.c', dependencies: [dep])
+subdir('sub', if_found: dep)

--- a/test cases/common/171 not-found dependency/sub/meson.build
+++ b/test cases/common/171 not-found dependency/sub/meson.build
@@ -1,0 +1,1 @@
+error('should be disabled by subdir(if_found:)')


### PR DESCRIPTION
Make not-found dependency object identically to prior to PR #2615
Extend test case to cover uses of the not-found dependency object

Fixes #2872

Also, prevent direct instantiation of class Dependency, since
BuildTarget.add_deps() rejects that.

It might be better to fix BuildTarget.add_deps() and look for any other
similar problems...