### PR TITLE
Fix a problem when anyone actually tries to use a non-found dependency

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -839,7 +839,7 @@ This will become a hard error in a future Meson release.''')
                 self.external_deps.append(extpart)
                 # Deps of deps.
                 self.add_deps(dep.ext_deps)
-            elif isinstance(dep, dependencies.ExternalDependency):
+            elif isinstance(dep, dependencies.Dependency):
                 self.external_deps.append(dep)
                 self.process_sourcelist(dep.get_sources())
             elif isinstance(dep, BuildTarget):

--- a/test cases/common/171 not-found dependency/meson.build
+++ b/test cases/common/171 not-found dependency/meson.build
@@ -1,4 +1,4 @@
-project('dep-test')
+project('dep-test', 'c')
 
 dep = dependency('', required:false)
 if dep.found()
@@ -6,3 +6,6 @@ if dep.found()
 endif
 
 assert(dep.type_name() == 'not-found', 'dependency should be of type "not-found" not ' + dep.type_name())
+
+library('testlib', 'testlib.c', dependencies: [dep])
+subdir('sub', if_found: dep)

--- a/test cases/common/171 not-found dependency/sub/meson.build
+++ b/test cases/common/171 not-found dependency/sub/meson.build
@@ -1,0 +1,1 @@
+error('should be disabled by subdir(if_found:)')


### PR DESCRIPTION
Fix BuildTarget.add_deps() to handle class Dependency
Extend test case to cover uses of the not-found dependency object

Fixes #2872 