### PR TITLE
Fix dependency('boost') on Cygwin

### DIFF
--- a/ci/appveyor-install.bat
+++ b/ci/appveyor-install.bat
@@ -1,5 +1,5 @@
 set CACHE=C:\cache
-set CYGWIN_MIRROR="http://cygwin.mirror.constant.com"
+set CYGWIN_MIRROR=http://cygwin.mirror.constant.com
 
 if _%arch%_ == _x64_ set SETUP=setup-x86_64.exe && set CYGWIN_ROOT=C:\cygwin64
 if _%arch%_ == _x86_ set SETUP=setup-x86.exe && set CYGWIN_ROOT=C:\cygwin
@@ -7,5 +7,13 @@ if _%arch%_ == _x86_ set SETUP=setup-x86.exe && set CYGWIN_ROOT=C:\cygwin
 if not exist %CACHE% mkdir %CACHE%
 
 echo Updating Cygwin and installing ninja and test prerequisites
-%CYGWIN_ROOT%\%SETUP% -qnNdO -R "%CYGWIN_ROOT%" -s "%CYGWIN_MIRROR%" -l "%CACHE%" -g -P "ninja,gcc-objc,gcc-objc++,libglib2.0-devel,zlib-devel,python3-pip"
+%CYGWIN_ROOT%\%SETUP% -qnNdO -R "%CYGWIN_ROOT%" -s "%CYGWIN_MIRROR%" -l "%CACHE%" -g -P ^
+gcc-objc++,^
+gcc-objc,^
+libboost-devel,^
+libglib2.0-devel,^
+ninja,^
+python3-pip,^
+zlib-devel
+
 echo Install done

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -365,7 +365,7 @@ class BoostDependency(ExternalDependency):
         for module in self.requested_modules:
             args = None
             libname = 'boost_' + module
-            if self.is_multithreading and not mesonlib.for_linux(self.want_cross, self.env):
+            if self.is_multithreading and mesonlib.for_darwin(self.want_cross, self.env):
                 # - Linux leaves off -mt but libraries are multithreading-aware.
                 # - Mac requires -mt for multithreading, so should not fall back to non-mt libraries.
                 libname = libname + '-mt'

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -495,12 +495,9 @@ def detect_tests_to_run():
     if mesonlib.is_windows():
         # TODO: Set BOOST_ROOT in .appveyor.yml
         gathered_tests += [('framework', ['test cases/frameworks/1 boost'], 'BOOST_ROOT' not in os.environ)]
-    elif mesonlib.is_osx():
+    elif mesonlib.is_osx() or mesonlib.is_cygwin():
         # Just do the BOOST test
         gathered_tests += [('framework', ['test cases/frameworks/1 boost'], False)]
-    elif mesonlib.is_cygwin():
-        # Skip all the framework tests
-        gathered_tests += [('framework', gather_tests('test cases/frameworks'), True)]
     else:
         gathered_tests += [('framework', gather_tests('test cases/frameworks'), False)]
     return gathered_tests

--- a/test cases/frameworks/1 boost/extralib.cpp
+++ b/test cases/frameworks/1 boost/extralib.cpp
@@ -1,3 +1,5 @@
+#define _XOPEN_SOURCE 500
+
 #include <iostream>
 #include <boost/log/trivial.hpp>
 #include <boost/log/expressions.hpp>


### PR DESCRIPTION
Fix `dependency('boost')` on Cygwin, broken in PR #2824
  