### PR TITLE
Comparing objects of different type is an error. Closes #2870.

### DIFF
--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -265,6 +265,12 @@ class InterpreterBase:
         if not isinstance(node.elseblock, mparser.EmptyNode):
             self.evaluate_codeblock(node.elseblock)
 
+    def validate_comparison_types(self, val1, val2):
+        if type(val1) != type(val2):
+            mlog.warning('''Trying to compare values of different types ({}, {}).
+The result of this is undefined and will become a hard error
+in a future Meson release.'''.format(type(val1).__name__, type(val2).__name__))
+
     def evaluate_comparison(self, node):
         val1 = self.evaluate_statement(node.left)
         if is_disabler(val1):
@@ -272,15 +278,11 @@ class InterpreterBase:
         val2 = self.evaluate_statement(node.right)
         if is_disabler(val2):
             return val2
+        self.validate_comparison_types(val1, val2)
         if node.ctype == '==':
             return val1 == val2
         elif node.ctype == '!=':
             return val1 != val2
-        elif not isinstance(val1, type(val2)):
-            raise InterpreterException(
-                'Values of different types ({}, {}) cannot be compared using {}.'.format(type(val1).__name__,
-                                                                                         type(val2).__name__,
-                                                                                         node.ctype))
         elif not self.is_elementary_type(val1):
             raise InterpreterException('{} can only be compared for equality.'.format(node.left.value))
         elif not self.is_elementary_type(val2):

--- a/test cases/common/140 get define/meson.build
+++ b/test cases/common/140 get define/meson.build
@@ -45,8 +45,8 @@ foreach lang : ['c', 'cpp']
   if meson.is_cross_build()
     # Can't use an empty array as a fallback here because of
     # https://github.com/mesonbuild/meson/issues/1481
-    lang_args = meson.get_cross_property(lang + '_args', false)
-    if lang_args != false
+    lang_args = meson.get_cross_property(lang + '_args', [])
+    if lang_args.length() != 0
       foreach lang_arg : lang_args
         if lang_arg.contains('MESON_TEST_ISSUE_1665')
           run_1665_test = true


### PR DESCRIPTION
This has some breakage potential for existing projects. Should we deprecate instead?