### PR TITLE
Fix MSVC backend crashes when `c_pch` or `cpp_pch` is not an array

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2254,7 +2254,7 @@ rule FORTRAN_DEP_HACK
 
     def generate_msvc_pch_command(self, target, compiler, pch):
         if len(pch) != 2:
-            raise RuntimeError('MSVC requires one header and one source to produce precompiled headers.')
+            raise MesonException('MSVC requires one header and one source to produce precompiled headers.')
         header = pch[0]
         source = pch[1]
         pchname = compiler.get_pch_name(header)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -863,7 +863,7 @@ class Vs2010Backend(backends.Backend):
             pch_node.text = 'Use'
             if compiler.id == 'msvc':
                 if len(pch) != 2:
-                    raise RuntimeError('MSVC requires one header and one source to produce precompiled headers.')
+                    raise MesonException('MSVC requires one header and one source to produce precompiled headers.')
                 pch_sources[lang] = [pch[0], pch[1], lang]
             else:
                 # I don't know whether its relevant but let's handle other compilers


### PR DESCRIPTION
This should fix #2833.