### PR TITLE
d: Detect recent DMD compilers

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -731,7 +731,7 @@ class Environment:
             return compilers.LLVMDCompiler(exelist, version, is_cross, full_version=full_version)
         elif 'gdc' in out:
             return compilers.GnuDCompiler(exelist, version, is_cross, full_version=full_version)
-        elif 'Digital Mars' in out:
+        elif 'The D Language Foundation' in out or 'Digital Mars' in out:
             return compilers.DmdDCompiler(exelist, version, is_cross, full_version=full_version)
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
 


### PR DESCRIPTION
They now are published by the D Language Foundation, and not Digital
Mars. Therefore, their signature has changed slightly.
(We can not check for 'DMD', because that string appears in every
compiler version output to denote the frontend version used by the
compiler).

It would be awesome if this fix could also be added to a recent point release of Meson, to get it out into the wild quickly (it broke quite a few project's CI).