### PR TITLE
Allow subproject dirs in subdirectories in the source tree again

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1883,10 +1883,14 @@ to directly access options of other subprojects.''')
             raise InvalidCode('Second call to project().')
         if not self.is_subproject() and 'subproject_dir' in kwargs:
             spdirname = kwargs['subproject_dir']
+            if not isinstance(spdirname, str):
+                raise InterpreterException('Subproject_dir must be a string')
             if os.path.isabs(spdirname):
                 raise InterpreterException('Subproject_dir must not be an absolute path.')
             if spdirname.startswith('.'):
                 raise InterpreterException('Subproject_dir must not begin with a period.')
+            if '..' in spdirname:
+                raise InterpreterException('Subproject_dir must not contain a ".." segment.')
             self.subproject_dir = spdirname
 
         if 'meson_version' in kwargs:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1883,8 +1883,8 @@ to directly access options of other subprojects.''')
             raise InvalidCode('Second call to project().')
         if not self.is_subproject() and 'subproject_dir' in kwargs:
             spdirname = kwargs['subproject_dir']
-            if '/' in spdirname or '\\' in spdirname:
-                raise InterpreterException('Subproject_dir must not contain a path segment.')
+            if os.path.isabs(spdirname):
+                raise InterpreterException('Subproject_dir must not be an absolute path.')
             if spdirname.startswith('.'):
                 raise InterpreterException('Subproject_dir must not begin with a period.')
             self.subproject_dir = spdirname


### PR DESCRIPTION
The previous change disallowed any subdirectories for subproject dirs,
and therefore broke a couple of projects making use of that.
This change still prevents people from setting subproject dirs that are
not in the project's source tree, while allowing to specify any path
within the project's directory again.

This fixes the regression described in https://github.com/mesonbuild/meson/issues/2719