### PR TITLE
Report warning/error locations in a format IDEs may already know how to parse

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1574,7 +1574,7 @@ class Interpreter(InterpreterBase):
         modname = args[0]
         if modname.startswith('unstable-'):
             plainname = modname.split('-', 1)[1]
-            mlog.warning('Module %s has no backwards or forwards compatibility and might not exist in future releases' % modname, location=node)
+            mlog.warning('Module %s has no backwards or forwards compatibility and might not exist in future releases.' % modname, location=node)
             modname = 'unstable_' + plainname
         if modname not in self.environment.coredata.modules:
             try:
@@ -2754,7 +2754,7 @@ root and issuing %s.
                     var_list = ", ".join(map(repr, sorted(missing_variables)))
                     mlog.warning(
                         "The variable(s) %s in the input file %s are not "
-                        "present in the given configuration data" % (
+                        "present in the given configuration data." % (
                             var_list, inputfile), location=node)
             else:
                 mesonlib.dump_conf_header(ofile_abs, conf.held_object)

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -74,7 +74,7 @@ class permittedKwargs:
                 loc = None
             for k in kwargs:
                 if k not in self.permitted:
-                    mlog.warning('''Passed invalid keyword argument "{}"'''.format(k), location=loc)
+                    mlog.warning('''Passed invalid keyword argument "{}".'''.format(k), location=loc)
                     mlog.warning('This will become a hard error in the future.')
             return f(s, node_or_state, args, kwargs)
         return wrapped

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -368,10 +368,11 @@ def run(original_args, mainfile=None):
         app.generate()
     except Exception as e:
         if isinstance(e, MesonException):
+            mlog.log()
             if hasattr(e, 'file') and hasattr(e, 'lineno') and hasattr(e, 'colno'):
-                mlog.log(mlog.red('\nMeson encountered an error in file %s, line %d, column %d:' % (e.file, e.lineno, e.colno)))
+                mlog.log('%s:%d:%d:' % (e.file, e.lineno, e.colno), mlog.red('ERROR: '), end='')
             else:
-                mlog.log(mlog.red('\nMeson encountered an error:'))
+                mlog.log(mlog.red('ERROR: '), end='')
             # Error message
             mlog.log(e)
             # Path to log file

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -105,12 +105,15 @@ def log(*args, **kwargs):
 def warning(*args, **kwargs):
     from . import environment
 
+    args = (yellow('WARNING:'),) + args
+
     if kwargs.get('location'):
         location = kwargs['location']
         del kwargs['location']
-        args += ('in file {}, line {}.'.format(os.path.join(location.subdir, environment.build_filename), location.lineno),)
+        location = '{}:{}:'.format(os.path.join(location.subdir, environment.build_filename), location.lineno)
+        args = (location,) + args
 
-    log(yellow('WARNING:'), *args, **kwargs)
+    log(*args, **kwargs)
 
 # Format a list for logging purposes as a string. It separates
 # all but the last item with commas, and the last with 'and'.

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -368,7 +368,7 @@ class ArgumentNode:
 
     def set_kwarg(self, name, value):
         if name in self.kwargs:
-            mlog.warning('Keyword argument "{}" defined multiple times'.format(name), location=self)
+            mlog.warning('Keyword argument "{}" defined multiple times.'.format(name), location=self)
             mlog.warning('This will be an error in future Meson releases.')
         self.kwargs[name] = value
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1691,13 +1691,13 @@ int main(int argc, char **argv) {
         tdir = os.path.join(self.unit_test_dir, '20 warning location')
         out = self.init(tdir)
         for expected in [
-            r'WARNING: Keyword argument "link_with" defined multiple times in file meson.build, line 4',
-            r'WARNING: Keyword argument "link_with" defined multiple times in file sub' + os.path.sep + r'meson.build, line 3',
-            r'WARNING: a warning of some sort in file meson.build, line 6',
-            r'WARNING: subdir warning in file sub' + os.path.sep + r'meson.build, line 4',
-            r'WARNING: Module unstable-simd has no backwards or forwards compatibility and might not exist in future releases in file meson.build, line 7',
-            r"WARNING: The variable(s) 'MISSING' in the input file conf.in are not present in the given configuration data in file meson.build, line 10",
-            r'WARNING: Passed invalid keyword argument "invalid" in file meson.build, line 1'
+            r'meson.build:4: WARNING: Keyword argument "link_with" defined multiple times.',
+            r'sub' + os.path.sep + r'meson.build:3: WARNING: Keyword argument "link_with" defined multiple times.',
+            r'meson.build:6: WARNING: a warning of some sort',
+            r'sub' + os.path.sep + r'meson.build:4: WARNING: subdir warning',
+            r'meson.build:7: WARNING: Module unstable-simd has no backwards or forwards compatibility and might not exist in future releases.',
+            r"meson.build:10: WARNING: The variable(s) 'MISSING' in the input file conf.in are not present in the given configuration data.",
+            r'meson.build:1: WARNING: Passed invalid keyword argument "invalid".',
         ]:
             self.assertRegex(out, re.escape(expected))
 


### PR DESCRIPTION
Examples:

meson.build:2:0: ERROR: Dependency is both required and not-found
meson.build:4: WARNING: Keyword argument "link_with" defined multiple times.

These are already matched by the default compilation-error-regexp-alist in
emacs.

Also:
Don't start 'red' markup until after the \n before an error
Unabsorb full-stop at end of warning with location from mlog.warning()
Update warning_location test

Closes #2854 
