### PR TITLE
Log instead of raise if Boost library not found

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -175,7 +175,7 @@ class BoostDependency(ExternalDependency):
             mlog.debug('Boost library directory is', mlog.bold(self.libdir))
             for m in self.requested_modules:
                 if 'boost_' + m not in self.lib_modules:
-                    mlog.log(mlog.red('ERROR:'), 'Requested Boost library {!r} not found'.format(m))
+                    mlog.debug('Requested Boost library {!r} not found'.format(m))
                     self.log_fail()
                     self.is_found = False
                     return

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -173,7 +173,12 @@ class BoostDependency(ExternalDependency):
         if self.is_found:
             self.detect_lib_modules()
             mlog.debug('Boost library directory is', mlog.bold(self.libdir))
-            self.validate_requested()
+            for m in self.requested_modules:
+                if 'boost_' + m not in self.lib_modules:
+                    mlog.log(mlog.red('ERROR:'), 'Requested Boost library {!r} not found'.format(m))
+                    self.log_fail()
+                    self.is_found = False
+                    return
             self.log_success()
         else:
             self.log_fail()
@@ -261,12 +266,6 @@ class BoostDependency(ExternalDependency):
             if not isinstance(c, str):
                 raise DependencyException('Boost module argument is not a string.')
         return candidates
-
-    def validate_requested(self):
-        for m in self.requested_modules:
-            if 'boost_' + m not in self.lib_modules:
-                msg = 'Requested Boost library {!r} not found'
-                raise DependencyException(msg.format(m))
 
     def detect_version(self):
         try:


### PR DESCRIPTION
Otherwise `dependency('boost', modules : [ 'foo' ], required : false)` would wrongly fail (for the case where foo is valid, but not found).

See my previous PR for the invalid case: #2578