### PR TITLE
Fix dependency object types returned by custom dependency detection

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -115,7 +115,8 @@ class Dependency:
         As an example, gtest-all.cc when using GTest."""
         return self.sources
 
-    def get_methods(self):
+    @staticmethod
+    def get_methods():
         return [DependencyMethods.AUTO]
 
     def get_name(self):
@@ -308,7 +309,8 @@ class ConfigToolDependency(ExternalDependency):
             return []
         return shlex.split(out)
 
-    def get_methods(self):
+    @staticmethod
+    def get_methods():
         return [DependencyMethods.AUTO, DependencyMethods.CONFIG_TOOL]
 
     def get_configtool_variable(self, variable_name):
@@ -535,7 +537,8 @@ class PkgConfigDependency(ExternalDependency):
         mlog.debug('Got pkgconfig variable %s : %s' % (variable_name, variable))
         return variable
 
-    def get_methods(self):
+    @staticmethod
+    def get_methods():
         return [DependencyMethods.PKGCONFIG]
 
     def check_pkgconfig(self):

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -236,13 +236,16 @@ class ConfigToolDependency(ExternalDependency):
         # instantiated and returned. The reduce function (method) is also
         # attached, since python's pickle module won't be able to do anything
         # with this dynamically generated class otherwise.
-        def reduce(_):
-            return (cls.factory,
-                    (name, environment, language, kwargs, tools, tool_name))
+        def reduce(self):
+            return (cls._unpickle, (), self.__dict__)
         sub = type('{}Dependency'.format(name.capitalize()), (cls, ),
                    {'tools': tools, 'tool_name': tool_name, '__reduce__': reduce})
 
         return sub(name, environment, language, kwargs)
+
+    @classmethod
+    def _unpickle(cls):
+        return cls.__new__(cls)
 
     def find_config(self, versions=None):
         """Helper method that searchs for config tool binaries in PATH and

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -61,15 +61,8 @@ class DependencyMethods(Enum):
 
 
 class Dependency:
-    def __init__(self, type_name, kwargs):
-        self.name = "null"
-        self.version = 'none'
-        self.language = None # None means C-like
-        self.is_found = False
-        self.type_name = type_name
-        self.compile_args = []
-        self.link_args = []
-        self.sources = []
+    @classmethod
+    def _process_method_kw(cls, kwargs):
         method = kwargs.get('method', 'auto')
         if method not in [e.value for e in DependencyMethods]:
             raise DependencyException('method {!r} is invalid'.format(method))
@@ -88,14 +81,27 @@ class Dependency:
         # Set the detection method. If the method is set to auto, use any available method.
         # If method is set to a specific string, allow only that detection method.
         if method == DependencyMethods.AUTO:
-            self.methods = self.get_methods()
-        elif method in self.get_methods():
-            self.methods = [method]
+            methods = cls.get_methods()
+        elif method in cls.get_methods():
+            methods = [method]
         else:
             raise DependencyException(
                 'Unsupported detection method: {}, allowed methods are {}'.format(
                     method.value,
-                    mlog.format_list([x.value for x in [DependencyMethods.AUTO] + self.get_methods()])))
+                    mlog.format_list([x.value for x in [DependencyMethods.AUTO] + cls.get_methods()])))
+
+        return methods
+
+    def __init__(self, type_name, kwargs):
+        self.name = "null"
+        self.version = 'none'
+        self.language = None # None means C-like
+        self.is_found = False
+        self.type_name = type_name
+        self.compile_args = []
+        self.link_args = []
+        self.sources = []
+        self.methods = self._process_method_kw(kwargs)
 
     def __repr__(self):
         s = '<{0} {1}: {2}>'
@@ -890,7 +896,12 @@ def find_external_dependency(name, env, kwargs):
     if lname in packages:
         if lname not in _packages_accept_language and 'language' in kwargs:
             raise DependencyException('%s dependency does not accept "language" keyword argument' % (lname, ))
-        dep = packages[lname](env, kwargs)
+        # Create the dependency object using a factory class method, if one
+        # exists, otherwise it is just constructed directly.
+        if getattr(packages[lname], '_factory', None):
+            dep = packages[lname]._factory(env, kwargs)
+        else:
+            dep = packages[lname](env, kwargs)
         if required and not dep.found():
             raise DependencyException('Dependency "%s" not found' % name)
         return dep

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -75,7 +75,7 @@ class Dependency:
             raise DependencyException('method {!r} is invalid'.format(method))
         method = DependencyMethods(method)
 
-        # This sets per-too config methods which are deprecated to to the new
+        # This sets per-tool config methods which are deprecated to to the new
         # generic CONFIG_TOOL value.
         if method in [DependencyMethods.SDLCONFIG, DependencyMethods.CUPSCONFIG,
                       DependencyMethods.PCAPCONFIG, DependencyMethods.LIBWMFCONFIG]:

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -792,7 +792,8 @@ class Python3Dependency(ExternalDependency):
         self.version = sysconfig.get_config_var('py_version')
         self.is_found = True
 
-    def get_methods(self):
+    @staticmethod
+    def get_methods():
         if mesonlib.is_windows():
             return [DependencyMethods.PKGCONFIG, DependencyMethods.SYSCONFIG]
         elif mesonlib.is_osx():
@@ -839,7 +840,8 @@ class PcapDependency(ExternalDependency):
             except Exception as e:
                 mlog.debug('Pcap not found via pcap-config. Trying next, error was:', str(e))
 
-    def get_methods(self):
+    @staticmethod
+    def get_methods():
         if mesonlib.is_osx():
             return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.EXTRAFRAMEWORK]
         else:
@@ -893,7 +895,8 @@ class CupsDependency(ExternalDependency):
                     return
             mlog.log('Dependency', mlog.bold('cups'), 'found:', mlog.red('NO'))
 
-    def get_methods(self):
+    @staticmethod
+    def get_methods():
         if mesonlib.is_osx():
             return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.EXTRAFRAMEWORK]
         else:
@@ -932,7 +935,8 @@ class LibWmfDependency(ExternalDependency):
             except Exception as e:
                 mlog.debug('cups not found via libwmf-config. Trying next, error was:', str(e))
 
-    def get_methods(self):
+    @staticmethod
+    def get_methods():
         if mesonlib.is_osx():
             return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.EXTRAFRAMEWORK]
         else:

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -923,7 +923,7 @@ class LibWmfDependency(ExternalDependency):
                     'libwmf', environment, None, kwargs, ['libwmf-config'], 'libwmf-config')
                 if ctdep.found():
                     self.config = ctdep.config
-                    self.type_name = 'config-too'
+                    self.type_name = 'config-tool'
                     self.version = ctdep.version
                     self.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
                     self.link_args = ctdep.get_config_value(['--libs'], 'link_args')

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -449,20 +449,6 @@ class VulkanDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
         super().__init__('vulkan', environment, None, kwargs)
 
-        if DependencyMethods.PKGCONFIG in self.methods:
-            try:
-                pcdep = PkgConfigDependency('vulkan', environment, kwargs)
-                if pcdep.found():
-                    self.type_name = 'pkgconfig'
-                    self.is_found = True
-                    self.compile_args = pcdep.get_compile_args()
-                    self.link_args = pcdep.get_link_args()
-                    self.version = pcdep.get_version()
-                    self.pcdep = pcdep
-                    return
-            except Exception:
-                pass
-
         if DependencyMethods.SYSTEM in self.methods:
             try:
                 self.vulkan_sdk = os.environ['VULKAN_SDK']
@@ -518,6 +504,18 @@ class VulkanDependency(ExternalDependency):
                     for lib in libs:
                         self.link_args.append(lib)
                     return
+
+    @classmethod
+    def _factory(cls, environment, kwargs):
+        if DependencyMethods.PKGCONFIG in cls._process_method_kw(kwargs):
+            try:
+                pcdep = PkgConfigDependency('vulkan', environment, kwargs)
+                if pcdep.found():
+                    return pcdep
+            except Exception:
+                pass
+
+        return VulkanDependency(environment, kwargs)
 
     @staticmethod
     def get_methods():

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -38,19 +38,6 @@ from .base import ConfigToolDependency
 class GLDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
         super().__init__('gl', environment, None, kwargs)
-        if DependencyMethods.PKGCONFIG in self.methods:
-            try:
-                pcdep = PkgConfigDependency('gl', environment, kwargs)
-                if pcdep.found():
-                    self.type_name = 'pkgconfig'
-                    self.is_found = True
-                    self.compile_args = pcdep.get_compile_args()
-                    self.link_args = pcdep.get_link_args()
-                    self.version = pcdep.get_version()
-                    self.pcdep = pcdep
-                    return
-            except Exception:
-                pass
         if DependencyMethods.SYSTEM in self.methods:
             if mesonlib.is_osx():
                 self.is_found = True
@@ -66,6 +53,17 @@ class GLDependency(ExternalDependency):
                 # FIXME: Detect version using self.compiler
                 self.version = '1'
                 return
+
+    @classmethod
+    def _factory(cls, environment, kwargs):
+        if DependencyMethods.PKGCONFIG in cls._process_method_kw(kwargs):
+            try:
+                pcdep = PkgConfigDependency('gl', environment, kwargs)
+                if pcdep.found():
+                    return pcdep
+            except Exception:
+                pass
+        return GLDependency(environment, kwargs)
 
     @staticmethod
     def get_methods():

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -67,7 +67,8 @@ class GLDependency(ExternalDependency):
                 self.version = '1'
                 return
 
-    def get_methods(self):
+    @staticmethod
+    def get_methods():
         if mesonlib.is_osx() or mesonlib.is_windows():
             return [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM]
         else:
@@ -337,7 +338,8 @@ class QtBaseDependency(ExternalDependency):
         else:
             return qvars['QT_INSTALL_BINS']
 
-    def get_methods(self):
+    @staticmethod
+    def get_methods():
         return [DependencyMethods.PKGCONFIG, DependencyMethods.QMAKE]
 
     def get_exe_args(self, compiler):
@@ -420,7 +422,8 @@ class SDL2Dependency(ExternalDependency):
                     return
             mlog.log('Dependency', mlog.bold('sdl2'), 'found:', mlog.red('NO'))
 
-    def get_methods(self):
+    @staticmethod
+    def get_methods():
         if mesonlib.is_osx():
             return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.EXTRAFRAMEWORK]
         else:
@@ -526,5 +529,6 @@ class VulkanDependency(ExternalDependency):
                         self.link_args.append(lib)
                     return
 
-    def get_methods(self):
+    @staticmethod
+    def get_methods():
         return [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM]

--- a/test cases/common/174 dependency factory/meson.build
+++ b/test cases/common/174 dependency factory/meson.build
@@ -4,3 +4,13 @@ dep = dependency('gl', method: 'pkg-config', required: false)
 if dep.found() and dep.type_name() == 'pkgconfig'
   dep.get_pkgconfig_variable('prefix')
 endif
+
+dep = dependency('SDL2', method: 'pkg-config', required: false)
+if dep.found() and dep.type_name() == 'pkgconfig'
+  dep.get_pkgconfig_variable('prefix')
+endif
+
+dep = dependency('SDL2', method: 'config-tool', required: false)
+if dep.found() and dep.type_name() == 'configtool'
+  dep.get_configtool_variable('prefix')
+endif

--- a/test cases/common/174 dependency factory/meson.build
+++ b/test cases/common/174 dependency factory/meson.build
@@ -29,3 +29,13 @@ dep = dependency('pcap', method: 'config-tool', required: false)
 if dep.found() and dep.type_name() == 'configtool'
   dep.get_configtool_variable('prefix')
 endif
+
+dep = dependency('cups', method: 'pkg-config', required: false)
+if dep.found() and dep.type_name() == 'pkgconfig'
+  dep.get_pkgconfig_variable('prefix')
+endif
+
+dep = dependency('cups', method: 'config-tool', required: false)
+if dep.found() and dep.type_name() == 'configtool'
+  dep.get_configtool_variable('prefix')
+endif

--- a/test cases/common/174 dependency factory/meson.build
+++ b/test cases/common/174 dependency factory/meson.build
@@ -39,3 +39,13 @@ dep = dependency('cups', method: 'config-tool', required: false)
 if dep.found() and dep.type_name() == 'configtool'
   dep.get_configtool_variable('prefix')
 endif
+
+dep = dependency('libwmf', method: 'pkg-config', required: false)
+if dep.found() and dep.type_name() == 'pkgconfig'
+  dep.get_pkgconfig_variable('prefix')
+endif
+
+dep = dependency('libwmf', method: 'config-tool', required: false)
+if dep.found() and dep.type_name() == 'configtool'
+  dep.get_configtool_variable('prefix')
+endif

--- a/test cases/common/174 dependency factory/meson.build
+++ b/test cases/common/174 dependency factory/meson.build
@@ -14,3 +14,8 @@ dep = dependency('SDL2', method: 'config-tool', required: false)
 if dep.found() and dep.type_name() == 'configtool'
   dep.get_configtool_variable('prefix')
 endif
+
+dep = dependency('Vulkan', method: 'pkg-config', required: false)
+if dep.found() and dep.type_name() == 'pkgconfig'
+  dep.get_pkgconfig_variable('prefix')
+endif

--- a/test cases/common/174 dependency factory/meson.build
+++ b/test cases/common/174 dependency factory/meson.build
@@ -19,3 +19,13 @@ dep = dependency('Vulkan', method: 'pkg-config', required: false)
 if dep.found() and dep.type_name() == 'pkgconfig'
   dep.get_pkgconfig_variable('prefix')
 endif
+
+dep = dependency('pcap', method: 'pkg-config', required: false)
+if dep.found() and dep.type_name() == 'pkgconfig'
+  dep.get_pkgconfig_variable('prefix')
+endif
+
+dep = dependency('pcap', method: 'config-tool', required: false)
+if dep.found() and dep.type_name() == 'configtool'
+  dep.get_configtool_variable('prefix')
+endif

--- a/test cases/common/174 dependency factory/meson.build
+++ b/test cases/common/174 dependency factory/meson.build
@@ -1,0 +1,6 @@
+project('dependency factory')
+
+dep = dependency('gl', method: 'pkg-config', required: false)
+if dep.found() and dep.type_name() == 'pkgconfig'
+  dep.get_pkgconfig_variable('prefix')
+endif


### PR DESCRIPTION
Return a PkgConfgDependency object from custom dependency detection which uses pkgconfig. This allows get_pkgconfig_variable() to work correctly on the result.

Return a ConfigToolDependency subclass object from custom dependency detection which uses a config tool.  This allows get_configtool_variable() to work correctly on the result.

Closes #2905 