### PR TITLE
gnome: Split header and code targets in gdbus_codegen()

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -235,9 +235,18 @@ files and the second specifies the XML file name.
 * `object_manager`: *(Added 0.40.0)* if true generates object manager code
 * `annotations`: *(Added 0.43.0)* list of lists of 3 strings for the annotation for `'ELEMENT', 'KEY', 'VALUE'`
 * `docbook`: *(Added 0.43.0)* prefix to generate `'PREFIX'-NAME.xml` docbooks
+* `build_by_default`: causes, when set to true, to have this target be
+  built by default, that is, when invoking plain `ninja`, the default
+  value is true for all built target types
+* `install_dir`: (*Added 0.46.0*) location to install the header or
+  bundle depending on previous options
+* `install_header`: (*Added 0.46.0*) if true, install the header file
 
-Returns an opaque object containing the source files. Add it to a top
-level target's source list.
+If gdbus-codegen version is greater than 2.55.2 it will return at
+most three targets, one for the souce code, one for the header and
+another one for the files generated with docbook. Otherwise, it
+returns an opaque object containing the source files. Add it to a
+top level target's source list.
 
 Example:
 

--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -242,11 +242,14 @@ files and the second specifies the XML file name.
   bundle depending on previous options
 * `install_header`: (*Added 0.46.0*) if true, install the header file
 
-If gdbus-codegen version is greater than 2.55.2 it will return at
-most three targets, one for the souce code, one for the header and
-another one for the files generated with docbook. Otherwise, it
-returns an opaque object containing the source files. Add it to a
-top level target's source list.
+Starting *0.46.0*, this function returns a list of at least two custom targets
+(in order): one for the source code and one for the header. The list will
+contain a third custom target for the generated docbook files if that keyword
+argument is passed.
+
+Earlier versions return a single custom target representing all the outputs.
+Generally, you should just add this list of targets to a top level target's
+source list.
 
 Example:
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -873,10 +873,9 @@ This will become a hard error in the future.''')
     def gdbus_codegen(self, state, args, kwargs):
         if len(args) != 2:
             raise MesonException('Gdbus_codegen takes two arguments, name and xml file.')
-        namebase = args[0]
+        namebase = args[0] + '-gdbus'
         xml_file = args[1]
-        target_name = namebase + '-gdbus'
-        cmd = [find_program('gdbus-codegen', target_name)]
+        cmd = [find_program('gdbus-codegen', namebase)]
         if 'interface_prefix' in kwargs:
             cmd += ['--interface-prefix', kwargs.pop('interface_prefix')]
         if 'namespace' in kwargs:
@@ -922,7 +921,7 @@ This will become a hard error in the future.''')
             targets.append(build.CustomTarget(output, state.subdir, state.subproject, custom_kwargs))
 
             if 'docbook' in kwargs:
-                docbook = kwargs.pop('docbook')
+                docbook = kwargs['docbook']
                 if not isinstance(docbook, str):
                     raise MesonException('docbook value must be a string.')
 
@@ -937,7 +936,7 @@ This will become a hard error in the future.''')
                 targets.append(build.CustomTarget(output, state.subdir, state.subproject, custom_kwargs))
         else:
             if 'docbook' in kwargs:
-                docbook = kwargs.pop('docbook')
+                docbook = kwargs['docbook']
                 if not isinstance(docbook, str):
                     raise MesonException('docbook value must be a string.')
 
@@ -955,9 +954,13 @@ This will become a hard error in the future.''')
                              'command': cmd,
                              'build_by_default': build_by_default
                              }
-            ct = build.CustomTarget(target_name, state.subdir, state.subproject, custom_kwargs)
-            targets = [ct, ct, ct]
-        return ModuleReturnValue(targets, targets)
+            ct = build.CustomTarget(namebase, state.subdir, state.subproject, custom_kwargs)
+            # Ensure that the same number (and order) of arguments are returned
+            # regardless of the gdbus-codegen (glib) version being used
+            targets = [ct, ct]
+            if 'docbook' in kwargs:
+                targets.append(ct)
+        return ModuleReturnValue(targets, [ct])
 
     @permittedKwargs({'sources', 'c_template', 'h_template', 'install_header', 'install_dir',
                       'comments', 'identifier_prefix', 'symbol_prefix', 'eprod', 'vprod',

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -922,7 +922,11 @@ This will become a hard error in the future.''')
             targets.append(build.CustomTarget(output, state.subdir, state.subproject, custom_kwargs))
 
             if 'docbook' in kwargs:
-                docbook_cmd = cmd + ['--output-directory', '@OUTDIR@', '--generate-docbook', kwargs.pop('docbook'), '@INPUT@']
+                docbook = kwargs.pop('docbook')
+                if not isinstance(docbook, str):
+                    raise MesonException('docbook value must be a string.')
+
+                docbook_cmd = cmd + ['--output-directory', '@OUTDIR@', '--generate-docbook', docbook, '@INPUT@']
 
                 output = namebase + '-docbook'
                 custom_kwargs = {'input': xml_file,
@@ -933,7 +937,11 @@ This will become a hard error in the future.''')
                 targets.append(build.CustomTarget(output, state.subdir, state.subproject, custom_kwargs))
         else:
             if 'docbook' in kwargs:
-                cmd += ['--generate-docbook', kwargs.pop('docbook')]
+                docbook = kwargs.pop('docbook')
+                if not isinstance(docbook, str):
+                    raise MesonException('docbook value must be a string.')
+
+                cmd += ['--generate-docbook', docbook]
 
             # https://git.gnome.org/browse/glib/commit/?id=ee09bb704fe9ccb24d92dd86696a0e6bb8f0dc1a
             if mesonlib.version_compare(self._get_native_glib_version(state), '>= 2.51.3'):

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -873,9 +873,10 @@ This will become a hard error in the future.''')
     def gdbus_codegen(self, state, args, kwargs):
         if len(args) != 2:
             raise MesonException('Gdbus_codegen takes two arguments, name and xml file.')
-        namebase = args[0] + '-gdbus'
+        namebase = args[0]
         xml_file = args[1]
-        cmd = [find_program('gdbus-codegen', namebase)]
+        target_name = namebase + '-gdbus'
+        cmd = [find_program('gdbus-codegen', target_name)]
         if 'interface_prefix' in kwargs:
             cmd += ['--interface-prefix', kwargs.pop('interface_prefix')]
         if 'namespace' in kwargs:
@@ -954,7 +955,7 @@ This will become a hard error in the future.''')
                              'command': cmd,
                              'build_by_default': build_by_default
                              }
-            ct = build.CustomTarget(namebase, state.subdir, state.subproject, custom_kwargs)
+            ct = build.CustomTarget(target_name, state.subdir, state.subproject, custom_kwargs)
             # Ensure that the same number (and order) of arguments are returned
             # regardless of the gdbus-codegen (glib) version being used
             targets = [ct, ct]

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -935,6 +935,8 @@ This will become a hard error in the future.''')
                                  'build_by_default': build_by_default
                                  }
                 targets.append(build.CustomTarget(output, state.subdir, state.subproject, custom_kwargs))
+
+            objects = targets
         else:
             if 'docbook' in kwargs:
                 docbook = kwargs['docbook']
@@ -961,7 +963,8 @@ This will become a hard error in the future.''')
             targets = [ct, ct]
             if 'docbook' in kwargs:
                 targets.append(ct)
-        return ModuleReturnValue(targets, [ct])
+            objects = [ct]
+        return ModuleReturnValue(targets, objects)
 
     @permittedKwargs({'sources', 'c_template', 'h_template', 'install_header', 'install_dir',
                       'comments', 'identifier_prefix', 'symbol_prefix', 'eprod', 'vprod',

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -869,7 +869,7 @@ This will become a hard error in the future.''')
         return []
 
     @permittedKwargs({'interface_prefix', 'namespace', 'object_manager', 'build_by_default',
-                      'annotations', 'docbook'})
+                      'annotations', 'docbook', 'install', 'install_header'})
     def gdbus_codegen(self, state, args, kwargs):
         if len(args) != 2:
             raise MesonException('Gdbus_codegen takes two arguments, name and xml file.')
@@ -883,8 +883,7 @@ This will become a hard error in the future.''')
             cmd += ['--c-namespace', kwargs.pop('namespace')]
         if kwargs.get('object_manager', False):
             cmd += ['--c-generate-object-manager']
-        if 'docbook' in kwargs:
-            cmd += ['--generate-docbook', kwargs.pop('docbook')]
+        build_by_default = kwargs.get('build_by_default', False)
 
         # Annotations are a bit ugly in that they are a list of lists of strings...
         annotations = kwargs.pop('annotations', [])
@@ -898,21 +897,59 @@ This will become a hard error in the future.''')
                 raise MesonException('Annotations must be made up of 3 strings for ELEMENT, KEY, and VALUE')
             cmd += ['--annotate'] + annotation
 
-        # https://git.gnome.org/browse/glib/commit/?id=ee09bb704fe9ccb24d92dd86696a0e6bb8f0dc1a
-        if mesonlib.version_compare(self._get_native_glib_version(state), '>= 2.51.3'):
-            cmd += ['--output-directory', '@OUTDIR@', '--generate-c-code', namebase, '@INPUT@']
+        # https://git.gnome.org/browse/glib/commit/?id=e4d68c7b3e8b01ab1a4231bf6da21d045cb5a816
+        if mesonlib.version_compare(self._get_native_glib_version(state), '>= 2.55.2'):
+            targets = []
+            install_header = kwargs.get('install_header', False)
+            install_dir = kwargs.get('install_dir', state.environment.coredata.get_builtin_option('includedir'))
+
+            output = namebase + '.c'
+            custom_kwargs = {'input': xml_file,
+                             'output': output,
+                             'command': cmd + ['--body', '--output', '@OUTDIR@/' + output, '@INPUT@'],
+                             'build_by_default': build_by_default
+                             }
+            targets.append(build.CustomTarget(output, state.subdir, state.subproject, custom_kwargs))
+
+            output = namebase + '.h'
+            custom_kwargs = {'input': xml_file,
+                             'output': output,
+                             'command': cmd + ['--header', '--output', '@OUTDIR@/' + output, '@INPUT@'],
+                             'build_by_default': build_by_default,
+                             'install': install_header,
+                             'install_dir': install_dir
+                             }
+            targets.append(build.CustomTarget(output, state.subdir, state.subproject, custom_kwargs))
+
+            if 'docbook' in kwargs:
+                docbook_cmd = cmd + ['--output-directory', '@OUTDIR@', '--generate-docbook', kwargs.pop('docbook'), '@INPUT@']
+
+                output = namebase + '-docbook'
+                custom_kwargs = {'input': xml_file,
+                                 'output': output,
+                                 'command': docbook_cmd,
+                                 'build_by_default': build_by_default
+                                 }
+                targets.append(build.CustomTarget(output, state.subdir, state.subproject, custom_kwargs))
         else:
-            self._print_gdbus_warning()
-            cmd += ['--generate-c-code', '@OUTDIR@/' + namebase, '@INPUT@']
-        outputs = [namebase + '.c', namebase + '.h']
-        custom_kwargs = {'input': xml_file,
-                         'output': outputs,
-                         'command': cmd
-                         }
-        if 'build_by_default' in kwargs:
-            custom_kwargs['build_by_default'] = kwargs['build_by_default']
-        ct = build.CustomTarget(target_name, state.subdir, state.subproject, custom_kwargs)
-        return ModuleReturnValue(ct, [ct])
+            if 'docbook' in kwargs:
+                cmd += ['--generate-docbook', kwargs.pop('docbook')]
+
+            # https://git.gnome.org/browse/glib/commit/?id=ee09bb704fe9ccb24d92dd86696a0e6bb8f0dc1a
+            if mesonlib.version_compare(self._get_native_glib_version(state), '>= 2.51.3'):
+                cmd += ['--output-directory', '@OUTDIR@', '--generate-c-code', namebase, '@INPUT@']
+            else:
+                self._print_gdbus_warning()
+                cmd += ['--generate-c-code', '@OUTDIR@/' + namebase, '@INPUT@']
+            outputs = [namebase + '.c', namebase + '.h']
+            custom_kwargs = {'input': xml_file,
+                             'output': outputs,
+                             'command': cmd,
+                             'build_by_default': build_by_default
+                             }
+            ct = build.CustomTarget(target_name, state.subdir, state.subproject, custom_kwargs)
+            targets = [ct, ct, ct]
+        return ModuleReturnValue(targets, targets)
 
     @permittedKwargs({'sources', 'c_template', 'h_template', 'install_header', 'install_dir',
                       'comments', 'identifier_prefix', 'symbol_prefix', 'eprod', 'vprod',

--- a/test cases/frameworks/7 gnome/gdbus/meson.build
+++ b/test cases/frameworks/7 gnome/gdbus/meson.build
@@ -1,3 +1,12 @@
+gdbus_src = gnome.gdbus_codegen('generated-gdbus-no-docbook', 'com.example.Sample.xml',
+  interface_prefix : 'com.example.',
+  namespace : 'Sample',
+  annotations : [
+    ['com.example.Hello()', 'org.freedesktop.DBus.Deprecated', 'true']
+  ],
+)
+assert(gdbus_src.length() == 2, 'expected 2 targets')
+
 gdbus_src = gnome.gdbus_codegen('generated-gdbus', 'com.example.Sample.xml',
   interface_prefix : 'com.example.',
   namespace : 'Sample',
@@ -6,6 +15,7 @@ gdbus_src = gnome.gdbus_codegen('generated-gdbus', 'com.example.Sample.xml',
   ],
   docbook : 'generated-gdbus-doc'
 )
+assert(gdbus_src.length() == 3, 'expected 3 targets')
 
 gdbus_exe = executable('gdbus-test', 'gdbusprog.c',
   gdbus_src,


### PR DESCRIPTION
The development version of `glib` (2.55.2) has acquired support for [generating gdbus header and source code files separately](https://bugzilla.gnome.org/show_bug.cgi?id=791015).

This PR allows dependencies to be more fine grained on those targets depending only on the header, which is needed for [some](https://bugzilla.gnome.org/show_bug.cgi?id=789877#c16) [ports](https://github.com/mesonbuild/meson/issues/2893#issuecomment-355856606).