### PR TITLE
RFC: Don't version shared libraries for Android

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -282,6 +282,9 @@ def is_osx():
 def is_linux():
     return platform.system().lower() == 'linux'
 
+def is_android():
+    return platform.system().lower() == 'android'
+
 def is_haiku():
     return platform.system().lower() == 'haiku'
 
@@ -348,6 +351,18 @@ def for_darwin(is_cross, env):
         return is_osx()
     elif env.cross_info.has_host():
         return env.cross_info.config['host_machine']['system'] == 'darwin'
+    return False
+
+def for_android(is_cross, env):
+    """
+    Host machine is Android?
+
+    Note: 'host' is the machine on which compiled binaries will run
+    """
+    if not is_cross:
+        return is_android()
+    elif env.cross_info.has_host():
+        return env.cross_info.config['host_machine']['system'] == 'android'
     return False
 
 def for_haiku(is_cross, env):


### PR DESCRIPTION
Android's loader doesn't handle shared library versioning so this avoids adding a suffix to the filename or soname for Android hosts.

In particular this let us avoid modifying all of our shared_library() declarations to be like:

```
if compiler.get_define('__ANDROID__') != ''
    lib = library('dlib', [ 'dlib/all/source.cpp' ],
                  cpp_args: defines,
                  dependencies: deps)
else
    lib = library('dlib', [ 'dlib/all/source.cpp' ],
                  version: '19.7.0',
                  cpp_args: defines,
                  dependencies: deps)
endif
```

I haven't looked at creating unit tests yet but can do if this change seems reasonable.

I was guessing I'd add a `'test cases'/android/` directory, which would be considered if running on linux and an `arm-linux-androideabi-clang` toolchain can be found.

Would also need a unit test based on readelf for checking the sonames.