### PR TITLE
dependencies: Allow setting config-tool binaries in cross file

### DIFF
--- a/docs/markdown/snippets/config-tool-cross.md
+++ b/docs/markdown/snippets/config-tool-cross.md
@@ -1,0 +1,13 @@
+# Config-Tool based dependencies can be specified in a cross file
+
+Tools like LLVM and pcap use a config tool for dependencies, this is a script
+or binary that is run to get configuration information (cflags, ldflags, etc)
+from.
+
+These binaries may now be specified in the `binaries` section of a cross file.
+
+```dosini
+[binaries]
+cc = ...
+llvm-config = '/usr/bin/llvm-config32'
+```

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -211,6 +211,7 @@ class ConfigToolDependency(ExternalDependency):
     def __init__(self, name, environment, language, kwargs):
         super().__init__('config-tool', environment, language, kwargs)
         self.name = name
+        self.native = kwargs.get('native', False)
         self.tools = listify(kwargs.get('tools', self.tools))
 
         req_version = kwargs.get('version', None)
@@ -250,8 +251,20 @@ class ConfigToolDependency(ExternalDependency):
         if not isinstance(versions, list) and versions is not None:
             versions = listify(versions)
 
+        if self.env.is_cross_build() and not self.native:
+            cross_file = self.env.cross_info.config['binaries']
+            try:
+                tools = [cross_file[self.tool_name]]
+            except KeyError:
+                mlog.warning('No entry for {0} specified in your cross file. '
+                             'Falling back to searching PATH. This may find a '
+                             'native version of {0}!'.format(self.tool_name))
+                tools = self.tools
+        else:
+            tools = self.tools
+
         best_match = (None, None)
-        for tool in self.tools:
+        for tool in tools:
             try:
                 p, out = Popen_safe([tool, '--version'])[:2]
             except (FileNotFoundError, PermissionError):


### PR DESCRIPTION
This allows for much easier cross compiler configuration for tools like
LLVM. This patch does honor the 'native' keyword, and falls back to
searching PATH if the binary name is not specified.

I'd be fin with either removing the fallback behavior, or marking it as
deprecated.

Fixes #2921