### PR TITLE
Allow multiple arguments to subproject object's get_variable method.

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1725,7 +1725,9 @@ opaque object representing it.
 
 - `get_variable(name)` fetches the specified variable from inside the
   subproject. This is useful to, for instance, get a [declared
-  dependency](#declare_dependency) from the subproject.
+  dependency](#declare_dependency) from the subproject. Multiple variable
+  names can be given to fetch several variables at a time, in which case
+  the returned type will be a list of variable values.
 
 ### `run result` object
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -677,12 +677,12 @@ class SubprojectHolder(InterpreterObject, ObjectHolder):
                              })
 
     def get_variable_method(self, args, kwargs):
-        if len(args) != 1:
-            raise InterpreterException('Get_variable takes one argument.')
-        varname = args[0]
-        if not isinstance(varname, str):
-            raise InterpreterException('Get_variable takes a string argument.')
-        return self.held_object.variables[varname]
+        retval = []
+        for varname in args:
+            if not isinstance(varname, str):
+                raise InterpreterException('Get_variable takes string argument(s).')
+            retval += [self.held_object.variables[varname]]
+        return retval[0] if len(retval) == 1 else retval
 
 class CompilerHolder(InterpreterObject):
     def __init__(self, compiler, env):


### PR DESCRIPTION
Return a list of values when a subproject object's get_variable method
is given more than one argument at a time.

--

Thought this might be useful. I for one would like to be able to do this:

`my_deps = subproject('foobar').get_variables('foo', 'bar', 'zomg')`.

The downsides that I can see:
- The return type changes to list if there is more than one argument to the `get_variable`method.
- It might be confusing to some that one can not give multiple arguments to the `get_variable` method not part of a submodule object.