### PR TITLE
Add cross-compilation support for `rustc`

### DIFF
--- a/cross/ubuntu-armhf.txt
+++ b/cross/ubuntu-armhf.txt
@@ -3,6 +3,7 @@
 # when cross compiled binaries can't be run we don't do that
 c = '/usr/bin/arm-linux-gnueabihf-gcc-7'
 cpp = '/usr/bin/arm-linux-gnueabihf-g++-7'
+rust = ['rustc', '--target', 'arm-unknown-linux-gnueabihf', '-C', 'linker=/usr/bin/arm-linux-gnueabihf-gcc-7']
 ar = '/usr/arm-linux-gnueabihf/bin/ar'
 strip = '/usr/arm-linux-gnueabihf/bin/strip'
 pkgconfig = '/usr/bin/arm-linux-gnueabihf-pkg-config'

--- a/docs/markdown/snippets/rust-cross.md
+++ b/docs/markdown/snippets/rust-cross.md
@@ -1,0 +1,16 @@
+## Rust cross-compilation
+
+Cross-compilation is now supported for Rust targets. Like other
+cross-compilers, the Rust binary must be specified in your cross
+file. It should specify a `--target` (as installed by `rustup target`)
+and a custom linker pointing to your C cross-compiler. For example:
+
+```
+[binaries]
+c = '/usr/bin/arm-linux-gnueabihf-gcc-7'
+rust = [
+    'rustc',
+    '--target', 'arm-unknown-linux-gnueabihf',
+    '-C', 'linker=/usr/bin/arm-linux-gnueabihf-gcc-7',
+]
+```

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1291,7 +1291,11 @@ int dummy;
             # installations
             for rpath_arg in rpath_args:
                 args += ['-C', 'link-arg=' + rpath_arg + ':' + os.path.join(rustc.get_sysroot(), 'lib')]
-        element = NinjaBuildElement(self.all_outputs, target_name, 'rust_COMPILER', relsrc)
+        crstr = ''
+        if target.is_cross:
+            crstr = '_CROSS'
+        compiler_name = 'rust%s_COMPILER' % crstr
+        element = NinjaBuildElement(self.all_outputs, target_name, compiler_name, relsrc)
         if len(orderdeps) > 0:
             element.add_orderdep(orderdeps)
         element.add_item('ARGS', args)
@@ -1579,8 +1583,11 @@ int dummy;
         outfile.write(restat)
         outfile.write('\n')
 
-    def generate_rust_compile_rules(self, compiler, outfile):
-        rule = 'rule %s_COMPILER\n' % compiler.get_language()
+    def generate_rust_compile_rules(self, compiler, outfile, is_cross):
+        crstr = ''
+        if is_cross:
+            crstr = '_CROSS'
+        rule = 'rule %s%s_COMPILER\n' % (compiler.get_language(), crstr)
         invoc = ' '.join([ninja_quote(i) for i in compiler.get_exelist()])
         command = ' command = %s $ARGS $in\n' % invoc
         description = ' description = Compiling Rust source $in.\n'
@@ -1671,8 +1678,7 @@ rule FORTRAN_DEP_HACK
                 self.generate_vala_compile_rules(compiler, outfile)
             return
         if langname == 'rust':
-            if not is_cross:
-                self.generate_rust_compile_rules(compiler, outfile)
+            self.generate_rust_compile_rules(compiler, outfile, is_cross)
             return
         if langname == 'swift':
             if not is_cross:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1992,9 +1992,9 @@ to directly access options of other subprojects.''')
             if need_cross_compiler:
                 cross_comp = self.environment.detect_d_compiler(True)
         elif lang == 'rust':
-            comp = self.environment.detect_rust_compiler()
+            comp = self.environment.detect_rust_compiler(False)
             if need_cross_compiler:
-                cross_comp = comp  # FIXME, not correct.
+                cross_comp = self.environment.detect_rust_compiler(True)
         elif lang == 'fortran':
             comp = self.environment.detect_fortran_compiler(False)
             if need_cross_compiler:

--- a/test cases/rust/4 polyglot/meson.build
+++ b/test cases/rust/4 polyglot/meson.build
@@ -1,5 +1,5 @@
 project('rust and c polyglot executable', 'c', 'rust')
 
-l = library('stuff', 'stuff.rs', install : true)
+l = library('stuff', 'stuff.rs', rust_crate_type: 'cdylib', install : true)
 e = executable('prog', 'prog.c', link_with : l, install : true)
 test('polyglottest', e)


### PR DESCRIPTION
This patch is largely modeled on the relatively-straightforward code for Fortran cross-compilation, so there might be some intricacies missing.

Also, it's hard to follow what's going on with cross-compilation in the test suite (when I try to invoke it, I just get a bunch of `Generating the build system failed.`), so this has only been tested on my actual projects. I did add the appropriate binary to the cross file that's used for the tests, though.