### PR TITLE
Make ConfigTool version suffix stripping robust

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -17,7 +17,6 @@
 
 import os
 import re
-import sys
 import stat
 import shlex
 import shutil

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -207,6 +207,7 @@ class ConfigToolDependency(ExternalDependency):
 
     tools = None
     tool_name = None
+    __strip_version = re.compile(r'^[0-9.]*')
 
     def __init__(self, name, environment, language, kwargs):
         super().__init__('config-tool', environment, language, kwargs)
@@ -221,6 +222,15 @@ class ConfigToolDependency(ExternalDependency):
             self.config = None
             return
         self.version = version
+
+    def _sanitize_version(self, version):
+        """Remove any non-numeric, non-point version suffixes."""
+        m = self.__strip_version.match(version)
+        if m:
+            # Ensure that there isn't a trailing '.', such as an input like
+            # `1.2.3.git-1234`
+            return m.group(0).rstrip('.')
+        return version
 
     @classmethod
     def factory(cls, name, environment, language, kwargs, tools, tool_name):
@@ -259,7 +269,7 @@ class ConfigToolDependency(ExternalDependency):
             if p.returncode != 0:
                 continue
 
-            out = out.strip()
+            out = self._sanitize_version(out.strip())
             # Some tools, like pcap-config don't supply a version, but also
             # dont fail with --version, in that case just assume that there is
             # only one verison and return it.

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -146,16 +146,6 @@ class LLVMDependency(ConfigToolDependency):
             return
         self.static = kwargs.get('static', False)
 
-        # Currently meson doesn't really attempt to handle pre-release versions,
-        # so strip the 'svn' off the end, since it will probably cuase problems
-        # for users who want the patch version.
-        #
-        # If LLVM is built from svn then "svn" will be appended to the version
-        # string, if it's built from a git mirror then "git-<very short sha>"
-        # will be appended instead.
-        self.version = self.version.rstrip('svn')
-        self.version = self.version.split('git')[0]
-
         self.provided_modules = self.get_config_value(['--components'], 'modules')
         modules = stringlistify(extract_as_list(kwargs, 'modules'))
         self.check_components(modules)


### PR DESCRIPTION
It came up today that someone could add some new suffix to what `llvm-config --version` returns. Which is true. So let's not play wack-a-mole anymore, a regex will be much more robust for stripping unwanted suffixes.