### PR TITLE
pkgconfig: Also ignore not found deps passed directly to pc generator

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -66,29 +66,28 @@ class DependenciesHelper:
             elif hasattr(obj, 'generated_pc'):
                 processed_reqs.append(obj.generated_pc)
             elif isinstance(obj, dependencies.PkgConfigDependency):
-                processed_reqs.append(obj.name)
+                if obj.found():
+                    processed_reqs.append(obj.name)
             elif isinstance(obj, dependencies.ThreadDependency):
                 processed_libs += obj.get_compiler().thread_link_flags(obj.env)
                 processed_cflags += obj.get_compiler().thread_flags(obj.env)
             elif isinstance(obj, dependencies.Dependency):
-                processed_libs += obj.get_link_args()
-                processed_cflags += obj.get_compile_args()
+                if obj.found():
+                    processed_libs += obj.get_link_args()
+                    processed_cflags += obj.get_compile_args()
             elif isinstance(obj, (build.SharedLibrary, build.StaticLibrary)):
                 processed_libs.append(obj)
                 if public:
                     if not hasattr(obj, 'generated_pc'):
                         obj.generated_pc = self.name
                     self.add_priv_libs(obj.get_dependencies())
-                    self.add_priv_libs(self.strip_unfound(obj.get_external_deps()))
+                    self.add_priv_libs(obj.get_external_deps())
             elif isinstance(obj, str):
                 processed_libs.append(obj)
             else:
                 raise mesonlib.MesonException('library argument not a string, library or dependency object.')
 
         return processed_libs, processed_reqs, processed_cflags
-
-    def strip_unfound(self, deps):
-        return [x for x in deps if not hasattr(x, 'found') or x.found()]
 
     def remove_dups(self):
         self.pub_libs = list(set(self.pub_libs))

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2067,11 +2067,17 @@ class LinuxlikeTests(BasePlatformTests):
         '''
         Test that generated pkg-config files correctly handle dependencies
         '''
-
         testdir = os.path.join(self.common_test_dir, '51 pkgconfig-gen')
         self.init(testdir)
+        privatedir1 = self.privatedir
 
-        os.environ['PKG_CONFIG_LIBDIR'] = self.privatedir
+        self.new_builddir()
+        os.environ['PKG_CONFIG_LIBDIR'] = privatedir1
+        testdir = os.path.join(self.common_test_dir, '51 pkgconfig-gen', 'dependencies')
+        self.init(testdir)
+        privatedir2 = self.privatedir
+
+        os.environ['PKG_CONFIG_LIBDIR'] = os.pathsep.join([privatedir1, privatedir2])
         cmd = ['pkg-config', 'dependency-test']
 
         out = self._run(cmd + ['--print-requires']).strip().split()

--- a/test cases/common/51 pkgconfig-gen/dependencies/exposed.c
+++ b/test cases/common/51 pkgconfig-gen/dependencies/exposed.c
@@ -1,0 +1,3 @@
+int exposed_function() {
+    return 42;
+}

--- a/test cases/common/51 pkgconfig-gen/dependencies/internal.c
+++ b/test cases/common/51 pkgconfig-gen/dependencies/internal.c
@@ -1,0 +1,3 @@
+int internal_function() {
+    return 42;
+}

--- a/test cases/common/51 pkgconfig-gen/dependencies/meson.build
+++ b/test cases/common/51 pkgconfig-gen/dependencies/meson.build
@@ -1,0 +1,38 @@
+project('pkgconfig-gen-dependencies', 'c')
+
+pkgg = import('pkgconfig')
+
+# libmain internally use libinternal and expose libexpose in its API
+exposed_lib = shared_library('libexposed', 'exposed.c')
+internal_lib = shared_library('libinternal', 'internal.c')
+main_lib = shared_library('libmain', link_with : [exposed_lib, internal_lib])
+
+pkgg.generate(libraries : exposed_lib,
+  version : '1.0',
+  name : 'libexposed',
+  description : 'An exposed library in dependency test.'
+)
+
+# Declare a few different Dependency objects
+pc_dep = dependency('libfoo')
+notfound_dep = dependency('notfound', required : false)
+threads_dep = dependency('threads')
+custom_dep = declare_dependency(link_args : ['-lcustom'], compile_args : ['-DCUSTOM'])
+custom2_dep = declare_dependency(link_args : ['-lcustom2'], compile_args : ['-DCUSTOM2'])
+
+# Generate a PC file:
+# - Having libmain in libraries should pull implicitely libexposed and libinternal in Libs.private
+# - Having libexposed in libraries should remove it from Libs.private
+# - We generated a pc file for libexposed so it should be in Requires instead of Libs
+# - Having threads_dep in libraries should add '-pthread' in both Libs and Cflags
+# - Having custom_dep in libraries and libraries_private should only add it in Libs
+# - Having custom2_dep in libraries_private should not add its Cflags
+# - Having pc_dep in libraries_private should add it in Requires.private
+# - notfound_dep is not required so it shouldn't appear in the pc file.
+pkgg.generate(libraries : [main_lib, exposed_lib, threads_dep , custom_dep],
+  libraries_private : [custom_dep, custom2_dep, pc_dep, notfound_dep],
+  version : '1.0',
+  name : 'dependency-test',
+  filebase : 'dependency-test',
+  description : 'A dependency test.'
+)

--- a/test cases/common/51 pkgconfig-gen/meson.build
+++ b/test cases/common/51 pkgconfig-gen/meson.build
@@ -46,36 +46,3 @@ pkgg.generate(
   description : 'A foo library.',
   variables : ['foo=bar', 'datadir=${prefix}/data']
 )
-
-# libmain internally use libinternal and expose libexpose in its API
-exposed_lib = shared_library('libexposed', 'simple.c')
-internal_lib = shared_library('libinternal', 'simple.c')
-main_lib = shared_library('libmain', link_with : [exposed_lib, internal_lib])
-
-pkgg.generate(libraries : exposed_lib,
-  version : libver,
-  name : 'libexposed',
-  description : 'An exposed library in dependency test.'
-)
-
-# Declare a few different Dependency objects
-pc_dep = dependency('libfoo', required : false)
-threads_dep = dependency('threads', required : false)
-custom_dep = declare_dependency(link_args : ['-lcustom'], compile_args : ['-DCUSTOM'])
-custom2_dep = declare_dependency(link_args : ['-lcustom2'], compile_args : ['-DCUSTOM2'])
-
-# Generate a PC file:
-# - Having libmain in libraries should pull implicitely libexposed and libinternal in Libs.private
-# - Having libexposed in libraries should remove it from Libs.private
-# - We generated a pc file for libexposed so it should be in Requires instead of Libs
-# - Having threads_dep in libraries should add '-pthread' in both Libs and Cflags
-# - Having custom_dep in libraries and libraries_private should only add it in Libs
-# - Having custom2_dep in libraries_private should not add its Cflags
-# - Having pc_dep in libraries_private should add it in Requires.private
-pkgg.generate(libraries : [main_lib, exposed_lib, threads_dep , custom_dep],
-  libraries_private : [custom_dep, custom2_dep, pc_dep],
-  version : libver,
-  name : 'dependency-test',
-  filebase : 'dependency-test',
-  description : 'A dependency test.'
-)


### PR DESCRIPTION
Currently only not found deps implicitly pulled from a Library object
are ignored. We should also ignore not found deps passed directly to
generate() method.
   
This makes the unit testing more complicated because libfoo pkgconfig
dependency cannot be found when generated from the within the same
meson.build.


This is a more complete fix for issue #2911 