### PR TITLE
Cross-compilation fixes carried by Yocto/OpenEmbedded project

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1518,7 +1518,7 @@ int dummy;
  rspfile_content = $ARGS  {output_args} $in $LINK_ARGS {cross_args} $aliasing
 '''
                 else:
-                    command_template = ' command = {executable} $ARGS {output_args} $in $LINK_ARGS {cross_args} $aliasing\n'
+                    command_template = ' command = {executable} $ARGS {cross_args} {output_args} $in $LINK_ARGS $aliasing\n'
                 command = command_template.format(
                     executable=' '.join(compiler.get_linker_exelist()),
                     cross_args=' '.join(cross_args),

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -775,6 +775,10 @@ This will become a hard error in the future.''')
                 '--mode=' + mode]
         if namespace:
             args.append('--namespace=' + namespace)
+        gtkdoc_exe_wrapper = state.environment.cross_info.config["properties"].get('gtkdoc_exe_wrapper', None)
+        if gtkdoc_exe_wrapper is not None:
+            args.append('--gtkdoc-exe-wrapper=' + gtkdoc_exe_wrapper)
+
         args += self._unpack_args('--htmlargs=', 'html_args', kwargs)
         args += self._unpack_args('--scanargs=', 'scan_args', kwargs)
         args += self._unpack_args('--scanobjsargs=', 'scanobjs_args', kwargs)
@@ -831,14 +835,22 @@ This will become a hard error in the future.''')
         cflags.update(get_include_args(inc_dirs))
         cflags.update(state.environment.coredata.external_args['c'])
         ldflags.update(state.environment.coredata.external_link_args['c'])
+
+        cross_c_args = " ".join(state.environment.cross_info.config["properties"].get('c_args', ""))
+        cross_link_args = " ".join(state.environment.cross_info.config["properties"].get('c_link_args', ""))
+
         if cflags:
-            args += ['--cflags=%s' % ' '.join(cflags)]
+            args += ['--cflags=%s %s' % (cross_c_args,' '.join(cflags))]
         if ldflags:
-            args += ['--ldflags=%s' % ' '.join(ldflags)]
+            args += ['--ldflags=%s %s' % (cross_link_args, ' '.join(ldflags))]
         compiler = state.environment.coredata.compilers.get('c')
-        if compiler:
+        cross_compiler = state.environment.coredata.cross_compilers.get('c')
+        if compiler and not state.environment.is_cross_build():
             args += ['--cc=%s' % ' '.join(compiler.get_exelist())]
             args += ['--ld=%s' % ' '.join(compiler.get_linker_exelist())]
+        elif cross_compiler and state.environment.is_cross_build():
+            args += ['--cc=%s' % ' '.join(cross_compiler.get_exelist())]
+            args += ['--ld=%s' % ' '.join(cross_compiler.get_linker_exelist())]
 
         return args
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -390,8 +390,6 @@ class GnomeModule(ExtensionModule):
             raise MesonException('Gir takes one argument')
         if kwargs.get('install_dir'):
             raise MesonException('install_dir is not supported with generate_gir(), see "install_dir_gir" and "install_dir_typelib"')
-        giscanner = find_program('g-ir-scanner', 'Gir')
-        gicompiler = find_program('g-ir-compiler', 'Gir')
         girtarget = args[0]
         while hasattr(girtarget, 'held_object'):
             girtarget = girtarget.held_object
@@ -402,6 +400,8 @@ class GnomeModule(ExtensionModule):
                 self.gir_dep = PkgConfigDependency('gobject-introspection-1.0',
                                                    state.environment,
                                                    {'native': True})
+            giscanner = os.environ['PKG_CONFIG_SYSROOT_DIR'] + self.gir_dep.get_pkgconfig_variable('g_ir_scanner', {})
+            gicompiler = os.environ['PKG_CONFIG_SYSROOT_DIR'] + self.gir_dep.get_pkgconfig_variable('g_ir_compiler', {})
             pkgargs = self.gir_dep.get_compile_args()
         except Exception:
             raise MesonException('gobject-introspection dependency was not found, gir cannot be generated.')

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -45,6 +45,7 @@ parser.add_argument('--ignore-headers', dest='ignore_headers', default='')
 parser.add_argument('--namespace', dest='namespace', default='')
 parser.add_argument('--mode', dest='mode', default='')
 parser.add_argument('--installdir', dest='install_dir')
+parser.add_argument('--gtkdoc-exe-wrapper', dest='gtkdoc_exe_wrapper')
 
 def gtkdoc_run_check(cmd, cwd, library_path=None):
     env = dict(os.environ)
@@ -54,7 +55,7 @@ def gtkdoc_run_check(cmd, cwd, library_path=None):
     # This preserves the order of messages.
     p, out = Popen_safe(cmd, cwd=cwd, env=env, stderr=subprocess.STDOUT)[0:2]
     if p.returncode != 0:
-        err_msg = ["{!r} failed with status {:d}".format(cmd[0], p.returncode)]
+        err_msg = ["{!r} failed with status {:d}".format(cmd, p.returncode)]
         if out:
             err_msg.append(out)
         raise MesonException('\n'.join(err_msg))
@@ -62,7 +63,7 @@ def gtkdoc_run_check(cmd, cwd, library_path=None):
 def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
                  main_file, module,
                  html_args, scan_args, fixxref_args, mkdb_args,
-                 gobject_typesfile, scanobjs_args, ld, cc, ldflags, cflags,
+                 gobject_typesfile, scanobjs_args, gtkdoc_exe_wrapper, ld, cc, ldflags, cflags,
                  html_assets, content_files, ignore_headers, namespace,
                  expand_content_files, mode):
     print("Building documentation for %s" % module)
@@ -115,6 +116,9 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
     if gobject_typesfile:
         scanobjs_cmd = ['gtkdoc-scangobj'] + scanobjs_args + ['--types=' + gobject_typesfile,
                                                               '--module=' + module,
+                                                              '--run=' + gtkdoc_exe_wrapper,
+                                                              '--cc=' + cc,
+                                                              '--ld=' + ld,
                                                               '--cflags=' + cflags,
                                                               '--ldflags=' + ldflags,
                                                               '--ld=' + ld]
@@ -219,6 +223,7 @@ def run(args):
         mkdbargs,
         options.gobject_typesfile,
         scanobjsargs,
+        options.gtkdoc_exe_wrapper,
         options.ld,
         options.cc,
         options.ldflags,


### PR DESCRIPTION
Hello,
here are the fixes we carry in the Yocto project to make meson work in a cross-compilation environment with system root directory set to something else than /.

I do realize they might not be merge-able, or that I'm doing something really wrong or silly in them - if you can suggest better ways to take care of these things, I'd appreciate. (also looking forward to see what meson CI thinks of them :)

Thanks,
Alex