### PR TITLE
Print warning when linker arguments are passed to has_argument

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -804,6 +804,13 @@ class CCompiler(Compiler):
         return ['-pthread']
 
     def has_multi_arguments(self, args, env):
+        for arg in args:
+            if arg.startswith('-Wl,'):
+                mlog.warning('''{} looks like a linker argument, but has_argument
+and other similar methods only support checking compiler arguments.
+Using them to check linker arguments are never supported, and results
+are likely to be wrong regardless of the compiler you are using.
+'''.format(arg))
         return self.compiles('int i;\n', env, extra_args=args)
 
 

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -14,6 +14,7 @@
 
 import os.path
 
+from .. import mlog
 from .. import coredata
 from ..mesonlib import version_compare
 
@@ -174,6 +175,13 @@ class IntelCPPCompiler(IntelCompiler, CPPCompiler):
         return []
 
     def has_multi_arguments(self, args, env):
+        for arg in args:
+            if arg.startswith('-Wl,'):
+                mlog.warning('''{} looks like a linker argument, but has_argument
+and other similar methods only support checking compiler arguments.
+Using them to check linker arguments are never supported, and results
+are likely to be wrong regardless of the compiler you are using.
+'''.format(arg))
         return super().has_multi_arguments(args + ['-diag-error', '10006'], env)
 
 


### PR DESCRIPTION
The reference manual of meson says `has_argument` method of a compiler object can be used to check whether a compiler flag is supported, but, unfortunately, some projects use it to check linker arguments and they are probably not aware of the wrong results caused by their wrong usage.

Here is a simple example:
```meson
project('test', 'c', 'cpp')
cc = meson.get_compiler('c')
cxx = meson.get_compiler('cpp')
cc.has_argument('-Wl,--hello-world')
cxx.has_argument('-Wl,--verbose')
```

When we use Clang to configure the project, tests always fail.
```
The Meson build system
Version: 0.45.0.dev1
Native C compiler: clang50 (clang 5.0.1 "clang version 5.0.1 (tags/RELEASE_501/final)")
Native C++ compiler: clang++50 (clang 5.0.1 "clang version 5.0.1 (tags/RELEASE_501/final)")
Compiler for C supports argument -Wl,--hello-world: NO
Compiler for C++ supports argument -Wl,--verbose: NO
```

When we use GCC to configure the project, tests always succeed:
```
The Meson build system
Version: 0.45.0.dev1
Native C compiler: gcc7 (gcc 7.2.0 "gcc7 (FreeBSD Ports Collection) 7.2.0")
Native C++ compiler: g++7 (gcc 7.2.0 "g++7 (FreeBSD Ports Collection) 7.2.0")
Compiler for C supports argument -Wl,--hello-world: YES
Compiler for C++ supports argument -Wl,--verbose: YES
```

Both results are wrong. `-Wl,--hello-world` should be rejected and `-Wl,--verbose` should be accepted.

This problem has been found in colord, libgepub, libgusb, gnome-color-manager, gnome-builder, gnome-packagekit, gnome-software, gstreamer. It looks like a common mistake and I think we should warn developers of their wrong usage. Here is the result of `grep` on the JHBuild directory on my system:
```
/home/lantw44/gnome/build/libgusb/meson-logs/meson-log.txt: clang: error: -Wl,-z,relro: 'linker' input unused [-Werror,-Wunused-command-line-argument]
/home/lantw44/gnome/build/libgusb/meson-logs/meson-log.txt: clang: error: -Wl,-z,now: 'linker' input unused [-Werror,-Wunused-command-line-argument]
/home/lantw44/gnome/build/colord/meson-logs/meson-log.txt: clang: error: -Wl,-z,relro: 'linker' input unused [-Werror,-Wunused-command-line-argument]
/home/lantw44/gnome/build/colord/meson-logs/meson-log.txt: clang: error: -Wl,-z,now: 'linker' input unused [-Werror,-Wunused-command-line-argument]
/home/lantw44/gnome/build/gnome-color-manager/meson-logs/meson-log.txt: clang: error: -Wl,-z,relro: 'linker' input unused [-Werror,-Wunused-command-line-argument]
/home/lantw44/gnome/build/gnome-color-manager/meson-logs/meson-log.txt: clang: error: -Wl,-z,now: 'linker' input unused [-Werror,-Wunused-command-line-argument]
/home/lantw44/gnome/build/gstreamer/meson-logs/meson-log.txt: clang: error: -Wl,-Bsymbolic-functions: 'linker' input unused [-Werror,-Wunused-command-line-argument]
/home/lantw44/gnome/build/libgepub/meson-logs/meson-log.txt: clang: error: -Wl,--version-script,/home/lantw44/gnome/source/libgepub/libgepub/gepub.map: 'linker' input unused [-Werror,-Wunused-command-line-argument]
/home/lantw44/gnome/build/gnome-software/meson-logs/meson-log.txt: clang: error: -Wl,-z,relro: 'linker' input unused [-Werror,-Wunused-command-line-argument]
/home/lantw44/gnome/build/gnome-software/meson-logs/meson-log.txt: clang: error: -Wl,-z,now: 'linker' input unused [-Werror,-Wunused-command-line-argument]
/home/lantw44/gnome/build/gnome-builder/meson-logs/meson-log.txt: clang: error: -Wl,-z,relro: 'linker' input unused [-Werror,-Wunused-command-line-argument]
/home/lantw44/gnome/build/gnome-builder/meson-logs/meson-log.txt: clang: error: -Wl,-z,now: 'linker' input unused [-Werror,-Wunused-command-line-argument]
/home/lantw44/gnome/build/gnome-packagekit/meson-logs/meson-log.txt: clang: error: -Wl,-z,relro: 'linker' input unused [-Werror,-Wunused-command-line-argument]
/home/lantw44/gnome/build/gnome-packagekit/meson-logs/meson-log.txt: clang: error: -Wl,-z,now: 'linker' input unused [-Werror,-Wunused-command-line-argument]
```