### PR TITLE
Add write_file and tests

### DIFF
--- a/mesonbuild/astinterpreter.py
+++ b/mesonbuild/astinterpreter.py
@@ -56,6 +56,7 @@ class AstInterpreter(interpreterbase.InterpreterBase):
                            'install_subdir': self.func_do_nothing,
                            'configuration_data': self.func_do_nothing,
                            'configure_file': self.func_do_nothing,
+                           'write_file': self.func_do_nothing,
                            'find_program': self.func_do_nothing,
                            'include_directories': self.func_do_nothing,
                            'add_global_arguments': self.func_do_nothing,

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2727,7 +2727,7 @@ root and issuing %s.
         mesonlib.write_textfile(ofile_abs, text)
 
         # Install file if requested
-        ibool= kwargs.get('install', None)
+        ibool = kwargs.get('install', None)
         idir = kwargs.get('install_dir', None)
         if isinstance(ibool, bool) and ibool and isinstance(idir, str):
             cfile = mesonlib.File.from_built_file(ofile_path, ofile_fname)

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -549,6 +549,11 @@ def do_mesondefine(line, confdata):
     else:
         raise MesonException('#mesondefine argument "%s" is of unknown type.' % varname)
 
+def write_textfile(dst, text):
+    dst_tmp = dst + '~'
+    with open(dst_tmp, 'w', encoding='utf-8') as f:
+        f.write(text)
+    replace_if_different(dst, dst_tmp)
 
 def do_conf_file(src, dst, confdata):
     try:

--- a/test cases/common/175 write file/meson.build
+++ b/test cases/common/175 write file/meson.build
@@ -1,0 +1,21 @@
+project('write file test', 'cpp')
+
+# Change this to see the file rebuilt
+content = '\n'.join([
+  '#pragma once',
+  '#include <string>',
+  'static const std::string test_value = "this is the new value";',
+  '// new line to force rebuild',
+])
+
+write_file(
+  output: 'test_writefile.h',
+  text: content,
+  install_dir: get_option('datadir'),
+  install: false
+)
+
+executable('testexe',
+  'should_not_rebuild.cpp',
+  include_directories: [ include_directories('.'), ],
+)

--- a/test cases/common/175 write file/should_not_rebuild.cpp
+++ b/test cases/common/175 write file/should_not_rebuild.cpp
@@ -1,0 +1,16 @@
+#include <iostream>
+
+#include "test_writefile.h"
+
+#warning The file was rebuilt !!
+
+void function_no_rebuild() {
+  std::cout << "Hello world!" << std::endl;
+  std::cout << "Test value: " << test_value << std::endl;
+}
+
+
+int main(int argc, char const *argv[]) {
+  function_no_rebuild();
+  return 0;
+}


### PR DESCRIPTION
Following #2666 :

This adds a meson function, with this syntax:
```
write_file(
    output: 'the_output_file.txt',
    text: 'the_text_to_write'
)
```
Remarks:
* That may be less verbose to use: `write_file('the_output_file.txt', 'the_text_to_write')`

* If the text does not end with an endline, it's appended.
* The output file is replaced only if the content was changed.