### PR TITLE
tests: add test to make sure include_directories() order is maintained

### DIFF
--- a/test cases/common/138 include order/inc1/hdr.h
+++ b/test cases/common/138 include order/inc1/hdr.h
@@ -1,0 +1,1 @@
+#define SOME_DEFINE 42

--- a/test cases/common/138 include order/inc2/hdr.h
+++ b/test cases/common/138 include order/inc2/hdr.h
@@ -1,0 +1,1 @@
+#undef SOME_DEFINE

--- a/test cases/common/138 include order/meson.build
+++ b/test cases/common/138 include order/meson.build
@@ -30,3 +30,7 @@ f = executable('somefxe', 'sub4/main.c',
 
 test('eh', e)
 test('oh', f)
+
+# Test that the order in include_directories() is maintained
+incs = include_directories('inc1', 'inc2')
+executable('ordertest', 'ordertest.c', include_directories: incs)

--- a/test cases/common/138 include order/ordertest.c
+++ b/test cases/common/138 include order/ordertest.c
@@ -1,0 +1,11 @@
+#include "hdr.h"
+
+#if !defined(SOME_DEFINE) || SOME_DEFINE != 42
+#error "Should have picked up hdr.h from inc1/hdr.h"
+#endif
+
+int
+main (int c, char ** argv)
+{
+  return 0;
+}


### PR DESCRIPTION
`incs = include_directories('inc1', 'inc2')` will lead to `-Iinc2 -Iinc1` in `ninja.build`.

I believe the order specified should be maintained.

This PR adds a unit test that fails because the order is reversed.