### PR TITLE
Fix bug include_directories(['p1','p2']) add -Ip2 -Ip1 (reversed order)

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2106,7 +2106,10 @@ rule FORTRAN_DEP_HACK
         # Hence, we must reverse the list so that the order is preserved.
         for i in reversed(target.get_include_dirs()):
             basedir = i.get_curdir()
-            for d in i.get_incdirs():
+            # We should iterate include dirs in reversed orders because
+            # -Ipath will add to begin of array. And without reverse
+            # flags will be added in reversed order.
+            for d in reversed(i.get_incdirs()):
                 # Avoid superfluous '/.' at the end of paths when d is '.'
                 if d not in ('', '.'):
                     expdir = os.path.join(basedir, d)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -768,7 +768,8 @@ class Vs2010Backend(backends.Backend):
             # These are per-target, but we still add them as per-file because we
             # need them to be looked in first.
             for d in reversed(target.get_include_dirs()):
-                for i in d.get_incdirs():
+                # reversed is used to keep order of includes
+                for i in reversed(d.get_incdirs()):
                     curdir = os.path.join(d.get_curdir(), i)
                     args.append('-I' + self.relpath(curdir, target.subdir)) # build dir
                     args.append('-I' + os.path.join(proj_to_src_root, curdir)) # src dir

--- a/test cases/common/138 include order/inc1/hdr.h
+++ b/test cases/common/138 include order/inc1/hdr.h
@@ -1,0 +1,1 @@
+#define SOME_DEFINE 42

--- a/test cases/common/138 include order/inc2/hdr.h
+++ b/test cases/common/138 include order/inc2/hdr.h
@@ -1,0 +1,1 @@
+#undef SOME_DEFINE

--- a/test cases/common/138 include order/meson.build
+++ b/test cases/common/138 include order/meson.build
@@ -30,3 +30,7 @@ f = executable('somefxe', 'sub4/main.c',
 
 test('eh', e)
 test('oh', f)
+
+# Test that the order in include_directories() is maintained
+incs = include_directories('inc1', 'inc2')
+executable('ordertest', 'ordertest.c', include_directories: incs)

--- a/test cases/common/138 include order/ordertest.c
+++ b/test cases/common/138 include order/ordertest.c
@@ -1,0 +1,11 @@
+#include "hdr.h"
+
+#if !defined(SOME_DEFINE) || SOME_DEFINE != 42
+#error "Should have picked up hdr.h from inc1/hdr.h"
+#endif
+
+int
+main (int c, char ** argv)
+{
+  return 0;
+}


### PR DESCRIPTION
Here @tp-m mentioned aboud bug with reversed order. This patch will fix this bug.
https://github.com/mesonbuild/meson/pull/2975