### PR TITLE
Fix typo in reference tables

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -57,7 +57,7 @@ These are provided by the `.system()` method call.
 | windows             | Any version of Windows |
 | cygwin              | The Cygwin environment for Windows |
 | haiku               | |
-| freebsd             | FreeBSD and it's derivatives |
+| freebsd             | FreeBSD and its derivatives |
 | dragonfly           | DragonFly BSD |
 | netbsd              | |
 


### PR DESCRIPTION
The possessive form of "its" does not contain an apostrophe.