### PR TITLE
Refactor and simplify install_subdir()

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -843,17 +843,14 @@ int dummy;
 
     def generate_subdir_install(self, d):
         for sd in self.build.get_install_subdirs():
-            inst_subdir = sd.installable_subdir.rstrip('/')
-            idir_parts = inst_subdir.split('/')
-            if len(idir_parts) > 1:
-                subdir = os.path.join(sd.source_subdir, '/'.join(idir_parts[:-1]))
-                inst_dir = idir_parts[-1]
-            else:
-                subdir = sd.source_subdir
-                inst_dir = sd.installable_subdir
-            src_dir = os.path.join(self.environment.get_source_dir(), subdir)
-            dst_dir = os.path.join(self.environment.get_prefix(), sd.install_dir)
-            d.install_subdirs.append([src_dir, inst_dir, dst_dir, sd.install_mode, sd.exclude])
+            src_dir = os.path.join(self.environment.get_source_dir(),
+                                   sd.source_subdir,
+                                   sd.installable_subdir).rstrip('/')
+            dst_dir = os.path.join(self.environment.get_prefix(),
+                                   sd.install_dir,
+                                   os.path.basename(src_dir))
+            d.install_subdirs.append([src_dir, dst_dir, sd.install_mode,
+                                      sd.exclude])
 
     def generate_tests(self, outfile):
         self.serialize_tests()

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2677,7 +2677,7 @@ root and issuing %s.
                     raise InvalidArguments('Exclude argument not a string.')
                 elif os.path.isabs(f):
                     raise InvalidArguments('Exclude argument cannot be absolute.')
-            exclude_files = {os.path.join(subdir, f) for f in exclude}
+            exclude_files = set(exclude)
         else:
             exclude_files = set()
         if 'exclude_directories' in kwargs:
@@ -2687,7 +2687,7 @@ root and issuing %s.
                     raise InvalidArguments('Exclude argument not a string.')
                 elif os.path.isabs(d):
                     raise InvalidArguments('Exclude argument cannot be absolute.')
-            exclude_directories = {os.path.join(subdir, f) for f in exclude}
+            exclude_directories = set(exclude)
         else:
             exclude_directories = set()
         exclude = (exclude_files, exclude_directories)


### PR DESCRIPTION
- Pass exclude_files and exclude_directories relative to src_dir,
  same as specified by user and documented in public install_subdir().
- Make do_copydir() interface similar to do_copyfile():
  install src_dir contents to dst_dir.
- Remove src_prefix/src_dir code, it adds confusion and duplicates arguments.
  Use single src_dir parameter instead.
- Make callers specify that src_dir contents should be installed
  under dst_dir/basename(src_dir) if necessary.
- Use os.path.relpath() instead of string manipulations on paths.
- Add documentation to do_copydir(): specify types and add usage example.