### PR TITLE
Check 'support_64bit_file_offsets' cross-file property

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -457,7 +457,7 @@ class Backend:
         # Add -nostdinc/-nostdinc++ if needed; can't be overridden
         commands += self.get_cross_stdlib_args(target, compiler)
         # Add things like /NOLOGO or -pipe; usually can't be overridden
-        commands += compiler.get_always_args()
+        commands += compiler.get_always_args(self.environment)
         # Only add warning-flags by default if the buildtype enables it, and if
         # we weren't explicitly asked to not emit warnings (for Vala, f.ex)
         if no_warn_args:

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -58,11 +58,11 @@ class CCompiler(Compiler):
     def needs_static_linker(self):
         return True # When compiling static libraries, so yes.
 
-    def get_always_args(self):
+    def get_always_args(self, environment):
         '''
         Args that are always-on for all C compilers other than MSVC
         '''
-        return ['-pipe'] + get_largefile_args(self)
+        return ['-pipe'] + get_largefile_args(self, environment)
 
     def get_linker_debug_crt_args(self):
         """
@@ -322,13 +322,13 @@ class CCompiler(Compiler):
     def compiles(self, code, env, extra_args=None, dependencies=None, mode='compile'):
         args = self._get_compiler_check_args(env, extra_args, dependencies, mode)
         # We only want to compile; not link
-        with self.compile(code, args.to_native(), mode) as p:
+        with self.compile(code, env, args.to_native(), mode) as p:
             return p.returncode == 0
 
     def _links_wrapper(self, code, env, extra_args, dependencies):
         "Shares common code between self.links and self.run"
         args = self._get_compiler_check_args(env, extra_args, dependencies, mode='link')
-        return self.compile(code, args)
+        return self.compile(code, env, args)
 
     def links(self, code, env, extra_args=None, dependencies=None):
         with self._links_wrapper(code, env, extra_args, dependencies) as p:
@@ -494,7 +494,7 @@ class CCompiler(Compiler):
         {delim}\n{define}'''
         args = self._get_compiler_check_args(env, extra_args, dependencies,
                                              mode='preprocess').to_native()
-        with self.compile(code.format(**fargs), args, 'preprocess') as p:
+        with self.compile(code.format(**fargs), env, args, 'preprocess') as p:
             if p.returncode != 0:
                 raise EnvironmentException('Could not get define {!r}'.format(dname))
         # Get the preprocessed value after the delimiter,
@@ -708,7 +708,7 @@ class CCompiler(Compiler):
         args = self.get_cross_extra_flags(env, link=False)
         args += self.get_compiler_check_args()
         n = 'symbols_have_underscore_prefix'
-        with self.compile(code, args, 'compile') as p:
+        with self.compile(code, env, args, 'compile') as p:
             if p.returncode != 0:
                 m = 'BUG: Unable to compile {!r} check: {}'
                 raise RuntimeError(m.format(n, p.stdo))
@@ -937,7 +937,7 @@ class VisualStudioCCompiler(CCompiler):
         self.is_64 = is_64
 
     # Override CCompiler.get_always_args
-    def get_always_args(self):
+    def get_always_args(self, environment):
         return self.always_args
 
     def get_linker_debug_crt_args(self):

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -183,7 +183,7 @@ class DCompiler(Compiler):
     def compiles(self, code, env, extra_args=None, dependencies=None, mode='compile'):
         args = self._get_compiler_check_args(env, extra_args, dependencies, mode)
 
-        with self.compile(code, args, mode) as p:
+        with self.compile(code, env, args, mode) as p:
             return p.returncode == 0
 
     def has_multi_arguments(self, args, env):

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -162,7 +162,7 @@ class GnuFortranCompiler(FortranCompiler):
         if define in self.defines:
             return self.defines[define]
 
-    def get_always_args(self):
+    def get_always_args(self, environment):
         return ['-pipe']
 
     def get_coverage_args(self):
@@ -188,7 +188,7 @@ class G95FortranCompiler(FortranCompiler):
     def get_module_outdir_args(self, path):
         return ['-fmod=' + path]
 
-    def get_always_args(self):
+    def get_always_args(self, environment):
         return ['-pipe']
 
     def get_no_warn_args(self):
@@ -212,7 +212,7 @@ class SunFortranCompiler(FortranCompiler):
     def get_dependency_gen_args(self, outtarget, outfile):
         return ['-fpp']
 
-    def get_always_args(self):
+    def get_always_args(self, environment):
         return []
 
     def get_warn_args(self, level):

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -43,7 +43,7 @@ class ValaCompiler(Compiler):
     def get_pic_args(self):
         return []
 
-    def get_always_args(self):
+    def get_always_args(self, environment):
         return ['-C']
 
     def get_warn_args(self, warning_level):
@@ -63,7 +63,7 @@ class ValaCompiler(Compiler):
     def sanity_check(self, work_dir, environment):
         code = 'class MesonSanityCheck : Object { }'
         args = self.get_cross_extra_flags(environment, link=False)
-        with self.compile(code, args, 'compile') as p:
+        with self.compile(code, environment, args, 'compile') as p:
             if p.returncode != 0:
                 msg = 'Vala compiler {!r} can not compile programs' \
                       ''.format(self.name_string())
@@ -84,7 +84,7 @@ class ValaCompiler(Compiler):
             vapi_args = ['--pkg', libname]
             args = self.get_cross_extra_flags(env, link=False)
             args += vapi_args
-            with self.compile(code, args, 'compile') as p:
+            with self.compile(code, env, args, 'compile') as p:
                 if p.returncode == 0:
                     return vapi_args
         # Not found? Try to find the vapi file itself.


### PR DESCRIPTION
Since we're currently targeting some 32bit Android devices with API level 23 we can't rely on support for `-D_FILE_OFFSET_BITS=64`

(E.g. ref: https://github.com/android-ndk/ndk/issues/442)

This patch adds a check for a 'support_64bit_file_offsets' cross-file property so we have a way to avoid meson passing `-D_FILE_OFFSET_BITS=64` while compiling. 

I can aim to look at writing tests if this seems reasonable.