### PR TITLE
Fix install_subdir() installation message

### DIFF
--- a/mesonbuild/scripts/meson_install.py
+++ b/mesonbuild/scripts/meson_install.py
@@ -218,11 +218,11 @@ def do_install(datafilename):
 
 def install_subdirs(d):
     for (src_dir, dst_dir, mode, exclude) in d.install_subdirs:
-        print('Installing subdir %s to %s' % (src_dir, dst_dir))
-        dst_dir = get_destdir_path(d, dst_dir)
-        d.dirmaker.makedirs(dst_dir, exist_ok=True)
-        do_copydir(d, src_dir, dst_dir, exclude)
-        set_mode(dst_dir, mode)
+        full_dst_dir = get_destdir_path(d, dst_dir)
+        print('Installing subdir %s to %s' % (src_dir, full_dst_dir))
+        d.dirmaker.makedirs(full_dst_dir, exist_ok=True)
+        do_copydir(d, src_dir, full_dst_dir, exclude)
+        set_mode(full_dst_dir, mode)
 
 def install_data(d):
     for i in d.data:


### PR DESCRIPTION
Print full destination path in 'Installing subdir ...' message,
including DESTDIR, consistent with other installation functions.
Use separate dst_dir and full_dst_dir variables to avoid mixing up
the order in the future and make code more readable.
Closes #3006.