### PR TITLE
Fix boost test on cygwin

### DIFF
--- a/test cases/frameworks/1 boost/linkexe.cc
+++ b/test cases/frameworks/1 boost/linkexe.cc
@@ -1,3 +1,5 @@
+#define _XOPEN_SOURCE 500
+
 #include<boost/thread.hpp>
 
 boost::recursive_mutex m;


### PR DESCRIPTION
With the headers from cygwin-devel-2.10.0-1, getpagesize() is not prototyped
unless an appropriate feature test macro is defined.

Future work: investigate if this needs to be defined by
BoostDependency.get_compile_args() or in Boost.