### PR TITLE
RFC: add ability to override executable used for config-tool based dependencies on the command line

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -379,6 +379,12 @@ def get_builtin_option_action(optname):
         return 'store_true'
     return None
 
+def get_builtin_option_destination(optname):
+    optname = optname.replace('-', '_')
+    if optname == 'warnlevel':
+        return 'warning_level'
+    return optname
+
 def get_builtin_option_default(optname, prefix='', noneIfSuppress=False):
     if is_builtin_option(optname):
         o = builtin_options[optname]

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -427,6 +427,13 @@ builtin_options = {
     'stdsplit':        [UserBooleanOption, 'Split stdout and stderr in test logs.', True],
     'errorlogs':       [UserBooleanOption, "Whether to print the logs from failing tests.", True],
 }
+# FIXME: this ins't DRY at all, but importing the dependencies module creates a
+# circular import, and can't even be solved by something ugly like import
+# inside a function
+for t in ['gnustep-config', 'sdl2-config', 'wx-config', 'llvm-config',
+          'pcap-config', 'cups-config', 'libwmf-config']:
+    t = t.replace('-', '_')
+    builtin_options['c_{}'.format(t)] = [UserStringOption, 'Override default search paths for native tool {}.'.format(t), '']
 
 # Special prefix-dependent defaults for installation directories that reside in
 # a path outside of the prefix in FHS and common usage.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -371,6 +371,14 @@ def get_builtin_option_description(optname):
     else:
         raise RuntimeError('Tried to get the description for an unknown builtin option \'%s\'.' % optname)
 
+def get_builtin_option_action(optname):
+    default = builtin_options[optname][2]
+    if default is True:
+        return 'store_false'
+    elif default is False:
+        return 'store_true'
+    return None
+
 def get_builtin_option_default(optname, prefix='', noneIfSuppress=False):
     if is_builtin_option(optname):
         o = builtin_options[optname]

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -261,7 +261,11 @@ class ConfigToolDependency(ExternalDependency):
         if not isinstance(versions, list) and versions is not None:
             versions = listify(versions)
 
-        if self.env.is_cross_build() and not self.native:
+        override = getattr(
+            self.env.cmd_line_options, 'c_' + self.tool_name.replace('-', '_'), None)
+        if override and not self.env.is_cross_build():
+            tools = [override]
+        elif self.env.is_cross_build() and not self.native:
             cross_file = self.env.cross_info.config['binaries']
             try:
                 tools = [cross_file[self.tool_name]]

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -25,7 +25,8 @@ from .wrap import WrapMode, wraptool
 
 default_warning = '1'
 
-def add_builtin_argument(p, name, **kwargs):
+def add_builtin_argument(p, name):
+    kwargs = {}
     k = coredata.get_builtin_option_destination(name)
     c = coredata.get_builtin_option_choices(k)
     b = coredata.get_builtin_option_action(k)
@@ -43,29 +44,8 @@ def add_builtin_argument(p, name, **kwargs):
 
 def create_parser():
     p = argparse.ArgumentParser(prog='meson')
-    add_builtin_argument(p, 'prefix')
-    add_builtin_argument(p, 'libdir')
-    add_builtin_argument(p, 'libexecdir')
-    add_builtin_argument(p, 'bindir')
-    add_builtin_argument(p, 'sbindir')
-    add_builtin_argument(p, 'includedir')
-    add_builtin_argument(p, 'datadir')
-    add_builtin_argument(p, 'mandir')
-    add_builtin_argument(p, 'infodir')
-    add_builtin_argument(p, 'localedir')
-    add_builtin_argument(p, 'sysconfdir')
-    add_builtin_argument(p, 'localstatedir')
-    add_builtin_argument(p, 'sharedstatedir')
-    add_builtin_argument(p, 'backend')
-    add_builtin_argument(p, 'buildtype')
-    add_builtin_argument(p, 'strip')
-    add_builtin_argument(p, 'unity')
-    add_builtin_argument(p, 'werror')
-    add_builtin_argument(p, 'layout')
-    add_builtin_argument(p, 'default-library')
-    add_builtin_argument(p, 'warnlevel')
-    add_builtin_argument(p, 'stdsplit')
-    add_builtin_argument(p, 'errorlogs')
+    for n in coredata.builtin_options:
+        add_builtin_argument(p, n)
     p.add_argument('--cross-file', default=None,
                    help='File describing cross compilation environment.')
     p.add_argument('-D', action='append', dest='projectoptions', default=[], metavar="option",

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -28,7 +28,7 @@ default_warning = '1'
 def add_builtin_argument(p, name, **kwargs):
     k = kwargs.get('dest', name.replace('-', '_'))
     c = coredata.get_builtin_option_choices(k)
-    b = kwargs.get('action', None) in ['store_true', 'store_false']
+    b = coredata.get_builtin_option_action(k)
     h = coredata.get_builtin_option_description(k)
     if not b:
         h = h.rstrip('.') + ' (default: %s).' % coredata.get_builtin_option_default(k)
@@ -58,14 +58,14 @@ def create_parser():
     add_builtin_argument(p, 'sharedstatedir')
     add_builtin_argument(p, 'backend')
     add_builtin_argument(p, 'buildtype')
-    add_builtin_argument(p, 'strip', action='store_true')
+    add_builtin_argument(p, 'strip')
     add_builtin_argument(p, 'unity')
-    add_builtin_argument(p, 'werror', action='store_true')
+    add_builtin_argument(p, 'werror')
     add_builtin_argument(p, 'layout')
     add_builtin_argument(p, 'default-library')
     add_builtin_argument(p, 'warnlevel', dest='warning_level')
-    add_builtin_argument(p, 'stdsplit', action='store_false')
-    add_builtin_argument(p, 'errorlogs', action='store_false')
+    add_builtin_argument(p, 'stdsplit')
+    add_builtin_argument(p, 'errorlogs')
     p.add_argument('--cross-file', default=None,
                    help='File describing cross compilation environment.')
     p.add_argument('-D', action='append', dest='projectoptions', default=[], metavar="option",

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -26,7 +26,7 @@ from .wrap import WrapMode, wraptool
 default_warning = '1'
 
 def add_builtin_argument(p, name, **kwargs):
-    k = kwargs.get('dest', name.replace('-', '_'))
+    k = coredata.get_builtin_option_destination(name)
     c = coredata.get_builtin_option_choices(k)
     b = coredata.get_builtin_option_action(k)
     h = coredata.get_builtin_option_description(k)
@@ -63,7 +63,7 @@ def create_parser():
     add_builtin_argument(p, 'werror')
     add_builtin_argument(p, 'layout')
     add_builtin_argument(p, 'default-library')
-    add_builtin_argument(p, 'warnlevel', dest='warning_level')
+    add_builtin_argument(p, 'warnlevel')
     add_builtin_argument(p, 'stdsplit')
     add_builtin_argument(p, 'errorlogs')
     p.add_argument('--cross-file', default=None,


### PR DESCRIPTION
This series has a few small cleanups to the way that command line options are generated, and then the final patch is the meat of the series. Bascially we've run into problems in mesa where users need to either force a specific version of llvm fo rsome reason, or want to use an llvm-config that is not in $PATH. The solution I've come up with is to add a command line option in the form `c_llvm_config` that can be passed to force config-tool based dependencies to not search PATH, but use that executable. I have mixed feelings about command line arguments, in some ways it feels like a return to the bad old days of `--with-foo-libdir`, on the other hand, these config-tool base dependencies are ugly and unwieldy to deal with and there might not be a better solution.