### PR TITLE
Add dep.get_pkgconfig_variable(default:)

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1682,6 +1682,8 @@ an external dependency with the following methods:
    dependency, error out. (*Added 0.44.0*) You can also redefine a
    variable by passing a list to the `define_variable` parameter
    that can affect the retrieved variable: `['prefix', '/'])`.
+   (*Added 0.45.0*) A warning is issued if the variable is not defined,
+   unless a `default` parameter is specified.
 
  - `get_configtool_variable(varname)` (*Added 0.44.0*) will get the 
    command line argument from the config tool (with `--` prepended), or,

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -561,7 +561,10 @@ class PkgConfigDependency(ExternalDependency):
             if not variable:
                 ret, out = self._call_pkgbin(['--print-variables', self.name])
                 if not re.search(r'^' + variable_name + r'$', out, re.MULTILINE):
-                    mlog.warning("pkgconfig variable '%s' not defined for dependency %s." % (variable_name, self.name))
+                    if 'default' in kwargs:
+                        variable = kwargs['default']
+                    else:
+                        mlog.warning("pkgconfig variable '%s' not defined for dependency %s." % (variable_name, self.name))
 
         mlog.debug('Got pkgconfig variable %s : %s' % (variable_name, variable))
         return variable

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -362,7 +362,7 @@ class GnomeModule(ExtensionModule):
                     ldflags.update([lib])
 
                 if isinstance(dep, PkgConfigDependency):
-                    girdir = dep.get_pkgconfig_variable("girdir", {})
+                    girdir = dep.get_pkgconfig_variable("girdir", {'default': ''})
                     if girdir:
                         gi_includes.update([girdir])
             elif isinstance(dep, (build.StaticLibrary, build.SharedLibrary)):
@@ -553,7 +553,7 @@ class GnomeModule(ExtensionModule):
                         if subdir not in typelib_includes:
                             typelib_includes.append(subdir)
             elif isinstance(dep, PkgConfigDependency):
-                girdir = dep.get_pkgconfig_variable("girdir", {})
+                girdir = dep.get_pkgconfig_variable("girdir", {'default': ''})
                 if girdir and girdir not in typelib_includes:
                     typelib_includes.append(girdir)
         # ldflags will be misinterpreted by gir scanner (showing

--- a/test cases/linuxlike/1 pkg-config/meson.build
+++ b/test cases/linuxlike/1 pkg-config/meson.build
@@ -17,6 +17,8 @@ test('zlibtest', exe)
 zprefix = dep.get_pkgconfig_variable('prefix') # Always set but we can't be sure what the value is.
 # pkg-config returns empty string for not defined variables
 assert(dep.get_pkgconfig_variable('nonexisting') == '', 'Value of unknown variable is not empty.')
+# ... unless default: is used
+assert(dep.get_pkgconfig_variable('nonexisting', default: 'foo') == 'foo', 'Value of unknown variable is not defaulted.')
 # pkg-config is able to replace variables
 assert(dep.get_pkgconfig_variable('prefix', define_variable: ['prefix', '/tmp']) == '/tmp', 'prefix variable has not been replaced.')
 


### PR DESCRIPTION
Also use that to squelch the warning for internal uses which handle the
variable missing case (just gnome at the moment)

A follow up to PR #2914