### PR TITLE
Include target build directory while compiling Java, for generated code dependencies

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1035,6 +1035,7 @@ int dummy;
         args += compiler.get_output_args(self.get_target_private_dir(target))
         curdir = target.get_subdir()
         sourcepath = os.path.join(self.build_to_src, curdir) + os.pathsep
+        sourcepath += os.path.normpath(curdir) + os.pathsep
         for i in target.include_dirs:
             for idir in i.get_incdirs():
                 sourcepath += os.path.join(self.build_to_src, i.curdir, idir) + os.pathsep

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1033,12 +1033,12 @@ int dummy;
         args += self.build.get_project_args(compiler, target.subproject)
         args += target.get_java_args()
         args += compiler.get_output_args(self.get_target_private_dir(target))
-        sourcepath = ''
+        curdir = target.get_subdir()
+        sourcepath = os.path.join(self.build_to_src, curdir) + os.pathsep
         for i in target.include_dirs:
             for idir in i.get_incdirs():
                 sourcepath += os.path.join(self.build_to_src, i.curdir, idir) + os.pathsep
-        if sourcepath != '':
-            args += ['-sourcepath', sourcepath]
+        args += ['-sourcepath', sourcepath]
         rel_src = src.rel_to_builddir(self.build_to_src)
         plain_class_path = src.fname[:-4] + 'class'
         rel_obj = os.path.join(self.get_target_private_dir(target), plain_class_path)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1033,9 +1033,12 @@ int dummy;
         args += self.build.get_project_args(compiler, target.subproject)
         args += target.get_java_args()
         args += compiler.get_output_args(self.get_target_private_dir(target))
+        sourcepath = ''
         for i in target.include_dirs:
             for idir in i.get_incdirs():
-                args += ['-sourcepath', os.path.join(self.build_to_src, i.curdir, idir)]
+                sourcepath += os.path.join(self.build_to_src, i.curdir, idir) + os.pathsep
+        if sourcepath != '':
+            args += ['-sourcepath', sourcepath]
         rel_src = src.rel_to_builddir(self.build_to_src)
         plain_class_path = src.fname[:-4] + 'class'
         rel_obj = os.path.join(self.get_target_private_dir(target), plain_class_path)

--- a/test cases/java/5 includedirs/com/mesonbuild/Simple.java
+++ b/test cases/java/5 includedirs/com/mesonbuild/Simple.java
@@ -1,0 +1,8 @@
+package com.mesonbuild;
+
+class Simple {
+    public static void main(String [] args) {
+        TextPrinter t = new TextPrinter("Printing from Java.");
+        t.print();
+    }
+}

--- a/test cases/java/5 includedirs/com/mesonbuild/TextPrinter.java
+++ b/test cases/java/5 includedirs/com/mesonbuild/TextPrinter.java
@@ -1,0 +1,14 @@
+package com.mesonbuild;
+
+class TextPrinter {
+
+    private String msg;
+    
+    TextPrinter(String s) {
+        msg = s;
+    }
+    
+    public void print() {
+        System.out.println(msg);
+    }
+}

--- a/test cases/java/5 includedirs/meson.build
+++ b/test cases/java/5 includedirs/meson.build
@@ -1,0 +1,15 @@
+# The Ninja backend used to try and pass -sourcepath repeatedly for
+# multiple includes which would discard prior includes. Since this
+# won't compile without the '.' include, this ensures that multiple
+# paths are passed in a [semi-]colon separated list instead...
+
+project('includedirsjava', 'java')
+
+javaprog = jar('myprog',
+ 'com/mesonbuild/Simple.java',
+ 'com/mesonbuild/TextPrinter.java',
+  main_class : 'com.mesonbuild.Simple',
+  include_directories : [ include_directories('com'),
+                          include_directories('.'),
+                          include_directories('com/mesonbuild') ])
+test('subdirtest', javaprog)

--- a/test cases/java/6 no includedirs/com/mesonbuild/Simple.java
+++ b/test cases/java/6 no includedirs/com/mesonbuild/Simple.java
@@ -1,0 +1,8 @@
+package com.mesonbuild;
+
+class Simple {
+    public static void main(String [] args) {
+        TextPrinter t = new TextPrinter("Printing from Java.");
+        t.print();
+    }
+}

--- a/test cases/java/6 no includedirs/com/mesonbuild/TextPrinter.java
+++ b/test cases/java/6 no includedirs/com/mesonbuild/TextPrinter.java
@@ -1,0 +1,14 @@
+package com.mesonbuild;
+
+class TextPrinter {
+
+    private String msg;
+    
+    TextPrinter(String s) {
+        msg = s;
+    }
+    
+    public void print() {
+        System.out.println(msg);
+    }
+}

--- a/test cases/java/6 no includedirs/meson.build
+++ b/test cases/java/6 no includedirs/meson.build
@@ -1,0 +1,14 @@
+# It used to be necessary to pass:
+#
+#   include_directories: include_directories('.')
+#
+# to any use of jar() to compile source code with inter-file class
+# dependencies. This is now the default behaviour.
+
+project('noincludedirsjava', 'java')
+
+javaprog = jar('myprog',
+ 'com/mesonbuild/Simple.java',
+ 'com/mesonbuild/TextPrinter.java',
+  main_class : 'com.mesonbuild.Simple')
+test('subdirtest', javaprog)

--- a/test cases/java/7 codegen/com/mesonbuild/Config.java.in
+++ b/test cases/java/7 codegen/com/mesonbuild/Config.java.in
@@ -1,0 +1,5 @@
+package com.mesonbuild;
+
+public class Config {
+    public static final boolean FOOBAR = @foobar@;
+}

--- a/test cases/java/7 codegen/com/mesonbuild/Simple.java
+++ b/test cases/java/7 codegen/com/mesonbuild/Simple.java
@@ -1,0 +1,12 @@
+package com.mesonbuild;
+
+import com.mesonbuild.Config;
+
+class Simple {
+    public static void main(String [] args) {
+        if (Config.FOOBAR) {
+            TextPrinter t = new TextPrinter("Printing from Java.");
+            t.print();
+        }
+    }
+}

--- a/test cases/java/7 codegen/com/mesonbuild/TextPrinter.java
+++ b/test cases/java/7 codegen/com/mesonbuild/TextPrinter.java
@@ -1,0 +1,14 @@
+package com.mesonbuild;
+
+class TextPrinter {
+
+    private String msg;
+    
+    TextPrinter(String s) {
+        msg = s;
+    }
+    
+    public void print() {
+        System.out.println(msg);
+    }
+}

--- a/test cases/java/7 codegen/com/mesonbuild/meson.build
+++ b/test cases/java/7 codegen/com/mesonbuild/meson.build
@@ -1,0 +1,6 @@
+
+conf_data = configuration_data()
+conf_data.set('foobar', 'true')
+config_file = configure_file(input : 'Config.java.in',
+                             output : 'Config.java',
+                             configuration : conf_data)

--- a/test cases/java/7 codegen/meson.build
+++ b/test cases/java/7 codegen/meson.build
@@ -1,0 +1,15 @@
+# If we generate code under the build directory then the backend needs to add
+# the build directory to the -sourcepath passed to javac otherwise the compiler
+# won't be able to handle the -implicit:class behaviour of automatically
+# compiling dependency classes.
+
+project('codegenjava', 'java')
+
+subdir('com/mesonbuild')
+
+javaprog = jar('myprog',
+ config_file,
+ 'com/mesonbuild/Simple.java',
+ 'com/mesonbuild/TextPrinter.java',
+  main_class : 'com.mesonbuild.Simple')
+test('subdirtest', javaprog)


### PR DESCRIPTION
The first two patches here are orthogonal really and have separate pull requests (https://github.com/mesonbuild/meson/pull/3026 and https://github.com/mesonbuild/meson/pull/3027) but are required for the last patch.

This addresses https://github.com/mesonbuild/meson/issues/3023 for me, such that it's possible to use `configure_file()` to generate a `.java` configuration class file and then reference that class from non-generated Java source code that's part of the same package.

The included `test cases/java/7 codegen` test basically shows what I was trying to do.