### PR TITLE
Don't use --export-dynamic on Cygwin

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -416,7 +416,7 @@ be passed to [shared and static libraries](#library).
   dynamically exported, allowing modules built using the
   [`shared_module`](#shared_module) function to refer to functions,
   variables and other symbols defined in the executable itself. Implies
-  the `implib` argument.  Since 0.44.0
+  the `implib` argument.  Since 0.45.0
 - `implib` when set to true, an import library is generated for the
   executable (the name of the import library is based on *exe_name*).
   Alternatively, when set to a string, that gives the base name for

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -184,7 +184,7 @@ class CCompiler(Compiler):
         return []
 
     def gen_export_dynamic_link_args(self, env):
-        if for_windows(env.is_cross_build(), env):
+        if for_windows(env.is_cross_build(), env) or for_cygwin(env.is_cross_build(), env):
             return ['-Wl,--export-all-symbols']
         elif for_darwin(env.is_cross_build(), env):
             return []


### PR DESCRIPTION
After PR #2662, running test case common/125 shared module/ on Cygwin gets
me:

$ ninja -C _build
ninja: Entering directory `_build'
[7/7] Linking target prog.exe.
/usr/lib/gcc/x86_64-pc-cygwin/6.4.0/../../../../x86_64-pc-cygwin/bin/ld: warning: --export-dynamic is not supported for PE+ targets, did you mean --export-all-symbols?

Also, fix doc for correct version of first apperance.

Future work: Notwithstanding the hint that ld gives, these options are not
equivalent, and it's not clear we should be using it here:
--export-all-symbols is the default behaviour, and if the exports are
restricted by explicit annotations or a .def file, this option might be
overriding that...