### PR TITLE
Enable default linker optimisations in MSVC release and minsize builds

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -137,8 +137,11 @@ gnulike_buildtype_linker_args = {'plain': [],
 msvc_buildtype_linker_args = {'plain': [],
                               'debug': [],
                               'debugoptimized': [],
-                              'release': [],
-                              'minsize': ['/INCREMENTAL:NO'],
+                              # The otherwise implicit REF and ICF linker
+                              # optimisations are disabled by /DEBUG.
+                              # REF implies ICF.
+                              'release': ['/OPT:REF'],
+                              'minsize': ['/INCREMENTAL:NO', '/OPT:REF'],
                               }
 
 java_buildtype_args = {'plain': [],


### PR DESCRIPTION
The `/DEBUG` flag is always used with MSVC to get debugging information (#684), but it also disables the[ `REF` and `ICF` linker optimisations](https://docs.microsoft.com/en-gb/cpp/build/reference/opt-optimizations) that MSVC enables by default in release builds.
Patch enables these explicitly for buildtypes `release` and `minsize`.