### PR TITLE
Re-link remaining github wiki urls to mesonbuild.com site

### DIFF
--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -29,7 +29,7 @@ endif
 let s:cpo_save = &cpo
 setlocal cpo&vim
 
-" https://github.com/mesonbuild/meson/wiki/Syntax
+" http://mesonbuild.com/Syntax.html
 syn keyword mesonConditional	elif else if endif
 syn keyword mesonRepeat	foreach endforeach
 syn keyword mesonOperator	and not or
@@ -55,7 +55,7 @@ syn match   mesonEscape	"\\N{\a\+\%(\s\a\+\)*}" contained
 syn match   mesonEscape	"\\$"
 
 " Meson only supports integer numbers
-" https://github.com/mesonbuild/meson/wiki/Syntax#numbers
+" http://mesonbuild.com/Syntax.html#numbers
 syn match   mesonNumber	"\<\d\+\>"
 
 " booleans

--- a/docs/markdown/Generating-sources.md
+++ b/docs/markdown/Generating-sources.md
@@ -4,7 +4,7 @@ short-description: Generation of source files before compilation
 
 # Generating sources
 
-  Sometimes source files need to be preprocessed before they are passed to the actual compiler. As an example you might want build an IDL compiler and then run some files through that to generate actual source files. In Meson this is done with [`generator()`](https://github.com/mesonbuild/meson/wiki/Reference-manual#generator) or [`custom_target()`](https://github.com/mesonbuild/meson/wiki/Reference-manual#custom_target).
+  Sometimes source files need to be preprocessed before they are passed to the actual compiler. As an example you might want build an IDL compiler and then run some files through that to generate actual source files. In Meson this is done with [`generator()`](Reference-manual.md#generator) or [`custom_target()`](Reference-manual.md#custom_target).
 
 ## Using custom_target()
 
@@ -45,7 +45,7 @@ Generators are similar to custom targets, except that we define a *generator*, w
 
 Note that generators should only be used for outputs that will only be used as inputs for a build target or a custom target. When you use the processed output of a generator in multiple targets, the generator will be run multiple times to create outputs for each target. Each output will be created in a target-private directory `@BUILD_DIR@`.
 
-If you want to generate files for general purposes such as for generating headers to be used by several sources, or data that will be installed, and so on, use a [`custom_target()`](https://github.com/mesonbuild/meson/wiki/Reference-manual#custom_target) instead.
+If you want to generate files for general purposes such as for generating headers to be used by several sources, or data that will be installed, and so on, use a [`custom_target()`](Reference-manual.md#custom_target) instead.
 
 
 ```meson

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1585,7 +1585,7 @@ The following methods are defined for all [arrays](Syntax.md#arrays):
 - `length()`, the size of the array
 
 You can also iterate over arrays with the [`foreach`
-statement](https://github.com/mesonbuild/meson/wiki/Syntax#foreach-statements).
+statement](Syntax.md#foreach-statements).
 
 ## Returned objects
 

--- a/docs/markdown/Release-notes-for-0.38.0.md
+++ b/docs/markdown/Release-notes-for-0.38.0.md
@@ -78,7 +78,7 @@ When using compilers that implement the [`__has_include()` preprocessor macro](h
 
 # Array indexing now supports fallback values
 
-The second argument to the array [`.get()`](https://github.com/mesonbuild/meson/wiki/Reference-manual#array-object) function is now returned if the specified index could not be found
+The second argument to the array [`.get()`](Reference-manual.md#array-object) function is now returned if the specified index could not be found
 ```meson
 array = [10, 11, 12, 13]
 array.get(0) # this will return `10`

--- a/docs/markdown/_Sidebar.md
+++ b/docs/markdown/_Sidebar.md
@@ -7,7 +7,7 @@
 * [Tests](Unit-tests.md)
 * [Syntax](Syntax.md)
 
-### [Modules](https://github.com/mesonbuild/meson/wiki/Module-reference.md)
+### [Modules](Module-reference.md)
 
 * [gnome](Gnome-module.md)
 * [i18n](i18n-module.md)

--- a/docs/markdown/i18n-module.md
+++ b/docs/markdown/i18n-module.md
@@ -40,7 +40,7 @@ This function also defines targets for maintainers to use:
 ### i18n.merge_file()
 
 This merges translations into a text file using `msgfmt`. See
-[custom_target](https://github.com/mesonbuild/meson/wiki/Reference%20manual#custom_target)
+[custom_target](Reference-manual.md#custom_target)
 for normal keywords. In addition it accepts these keywords:
 
 * `data_dirs`: (*Added 0.41.0*) list of directories for its files (See


### PR DESCRIPTION
I clicked a broken link, and that annoyed me enough to fix all of them.

BTW it would be probably pretty good idea to nuke all pages from https://github.com/mesonbuild/meson.wiki to ensure they return 404, and disappear from various web search indexes.