### PR TITLE
Always run all framework tests on all platforms

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -495,7 +495,13 @@ class PkgConfigDependency(ExternalDependency):
         return converted
 
     def _set_cargs(self):
-        ret, out = self._call_pkgbin(['--cflags', self.name])
+        env = None
+        if self.language == 'fortran':
+            # gfortran doesn't appear to look in system paths for INCLUDE files,
+            # so don't allow pkg-config to suppress -I flags for system paths
+            env = os.environ.copy()
+            env['PKG_CONFIG_ALLOW_SYSTEM_CFLAGS'] = '1'
+        ret, out = self._call_pkgbin(['--cflags', self.name], env=env)
         if ret != 0:
             raise DependencyException('Could not generate cargs for %s:\n\n%s' %
                                       (self.name, out))

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -5,6 +5,11 @@ add_project_arguments(['-DBOOST_LOG_DYN_LINK'],
   language : 'cpp'
 )
 
+dep = dependency('boost', required: false)
+if not dep.found()
+  error('MESON_SKIP_TEST boost not found.')
+endif
+
 # We want to have multiple separate configurations of Boost
 # within one project. The need to be independent of each other.
 # Use one without a library dependency and one with it.

--- a/test cases/frameworks/10 gtk-doc/meson.build
+++ b/test cases/frameworks/10 gtk-doc/meson.build
@@ -1,5 +1,10 @@
 project('gtkdoctest', 'c', version : '1.0.0')
 
+gtkdoc = find_program('gtkdoc-scan', required: false)
+if not gtkdoc.found()
+  error('MESON_SKIP_TEST gtkdoc not found.')
+endif
+
 gnome = import('gnome')
 
 assert(gnome.gtkdoc_html_dir('foobar') == 'share/gtk-doc/html/foobar', 'Gtkdoc install dir is incorrect.')

--- a/test cases/frameworks/11 gir subproject/meson.build
+++ b/test cases/frameworks/11 gir subproject/meson.build
@@ -1,5 +1,16 @@
 project('gobject-introspection-with-subproject', 'c')
 
+gir = find_program('g-ir-scanner', required: false)
+if not gir.found()
+  error('MESON_SKIP_TEST g-ir-scanner not found.')
+endif
+
+python3 = import('python3')
+py3 = python3.find_python()
+if run_command(py3, '-c', 'import gi;').returncode() != 0
+    error('MESON_SKIP_TEST python3-gi not found')
+endif
+
 gnome = import('gnome')
 gobj = dependency('gobject-2.0')
 
@@ -7,4 +18,3 @@ add_global_arguments('-DMESON_TEST', language : 'c')
 meson_gir = dependency('meson-gir', fallback : ['mesongir', 'meson_gir'])
 
 subdir('gir')
-

--- a/test cases/frameworks/12 multiple gir/meson.build
+++ b/test cases/frameworks/12 multiple gir/meson.build
@@ -1,5 +1,10 @@
 project('multiple-gobject-introspection', 'c')
 
+gir = find_program('g-ir-scanner', required: false)
+if not gir.found()
+  error('MESON_SKIP_TEST g-ir-scanner not found.')
+endif
+
 gnome = import('gnome')
 gobj = dependency('gobject-2.0')
 

--- a/test cases/frameworks/13 yelp/meson.build
+++ b/test cases/frameworks/13 yelp/meson.build
@@ -1,2 +1,8 @@
 project('yelp', 'c')
+
+itstool = find_program('itstool', required: false)
+if not itstool.found()
+  error('MESON_SKIP_TEST itstool not found.')
+endif
+
 subdir('help')

--- a/test cases/frameworks/15 llvm/meson.build
+++ b/test cases/frameworks/15 llvm/meson.build
@@ -17,7 +17,7 @@ assert(d.found() == true, 'optional module stopped llvm from being found.')
 dep_tinfo = dependency('tinfo', required : false)
 if not dep_tinfo.found()
   cpp = meson.get_compiler('cpp')
-  dep_tinfo = cpp.find_library('tinfo')
+  dep_tinfo = cpp.find_library('tinfo', required: false)
 endif
 
 foreach static : [true, false]

--- a/test cases/frameworks/15 llvm/meson.build
+++ b/test cases/frameworks/15 llvm/meson.build
@@ -1,5 +1,10 @@
 project('llvmtest', ['c', 'cpp'], default_options : ['c_std=c99'])
 
+d = dependency('llvm', required : false)
+if not d.found()
+  error('MESON_SKIP_TEST llvm not found.')
+endif
+
 d = dependency('llvm', modules : 'not-found', required : false)
 assert(d.found() == false, 'not-found llvm module found')
 

--- a/test cases/frameworks/16 sdl2/meson.build
+++ b/test cases/frameworks/16 sdl2/meson.build
@@ -1,6 +1,10 @@
 project('sdl2 test', 'c')
 
-sdl2_dep = dependency('sdl2', version : '>=2.0.0')
+sdl2_dep = dependency('sdl2', version : '>=2.0.0', required: false)
+
+if not sdl2_dep.found()
+  error('MESON_SKIP_TEST sdl2 not found.')
+endif
 
 e = executable('sdl2prog', 'sdl2prog.c', dependencies : sdl2_dep)
 

--- a/test cases/frameworks/19 pcap/meson.build
+++ b/test cases/frameworks/19 pcap/meson.build
@@ -1,6 +1,10 @@
 project('pcap test', 'c')
 
-pcap_dep = dependency('pcap', version : '>=1.0')
+pcap_dep = dependency('pcap', version : '>=1.0', required: false)
+
+if not pcap_dep.found()
+  error('MESON_SKIP_TEST pcap not found.')
+endif
 
 pcap_ver = pcap_dep.version()
 assert(pcap_ver.split('.').length() > 1, 'pcap version is "@0@"'.format(pcap_ver))
@@ -9,6 +13,6 @@ e = executable('pcap_prog', 'pcap_prog.c', dependencies : pcap_dep)
 
 test('pcaptest', e)
 
-# Ensure discovery bia the configuration tools work also
+# Ensure discovery via the configuration tools work also
 pcap_dep = dependency('pcap', version : '>=1.0', method : 'pcap-config')
 pcap_dep = dependency('pcap', version : '>=1.0', method : 'config-tool')

--- a/test cases/frameworks/19 pcap/pcap_prog.c
+++ b/test cases/frameworks/19 pcap/pcap_prog.c
@@ -4,6 +4,12 @@ int
 main()
 {
     char errbuf[PCAP_ERRBUF_SIZE];
-    pcap_t *p = pcap_create(NULL, errbuf);
+#ifdef __APPLE__
+    // source = NULL for "any" doesn't work on macOS (linux only?)
+    char *source = "en0";
+#else
+    char *source = NULL;
+#endif
+    pcap_t *p = pcap_create(source, errbuf);
     return p == NULL;
 }

--- a/test cases/frameworks/20 cups/meson.build
+++ b/test cases/frameworks/20 cups/meson.build
@@ -1,6 +1,10 @@
 project('cups test', 'c')
 
-cups_dep = dependency('cups', version : '>=1.4')
+cups_dep = dependency('cups', version : '>=1.4', required: false)
+
+if not cups_dep.found()
+  error('MESON_SKIP_TEST cups not found.')
+endif
 
 e = executable('cups_prog', 'cups_prog.c', dependencies : cups_dep)
 

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -21,6 +21,14 @@ foreach qt : ['qt4', 'qt5']
     error('Invalid qt dep incorrectly found!')
   endif
 
+  # This test should be skipped if qt5 isn't found
+  if qt == 'qt5'
+    dep = dependency(qt, modules : ['Core'], required : false, method : get_option('method'))
+    if not dep.found()
+      error('MESON_SKIP_TEST qt5 not found.')
+    endif
+  endif
+
   # Ensure that the "no-Core-module-specified" code branch is hit
   nocoredep = dependency(qt, modules : ['Gui'], required : qt == 'qt5', method : get_option('method'))
 

--- a/test cases/frameworks/6 gettext/installed_files.txt
+++ b/test cases/frameworks/6 gettext/installed_files.txt
@@ -1,4 +1,4 @@
-usr/bin/intlprog
+usr/bin/intlprog?exe
 usr/share/locale/de/LC_MESSAGES/intltest.mo
 usr/share/locale/fi/LC_MESSAGES/intltest.mo
 usr/share/applications/test.desktop

--- a/test cases/frameworks/6 gettext/meson.build
+++ b/test cases/frameworks/6 gettext/meson.build
@@ -1,5 +1,14 @@
 project('gettext example', 'c')
 
+gettext = find_program('gettext', required: false)
+if not gettext.found()
+  error('MESON_SKIP_TEST gettext not found.')
+endif
+
+if not meson.get_compiler('c').has_header('libintl.h')
+  error('MESON_SKIP_TEST libintl.h not found.')
+endif
+
 i18n = import('i18n')
 
 subdir('po')

--- a/test cases/frameworks/7 gnome/meson.build
+++ b/test cases/frameworks/7 gnome/meson.build
@@ -1,5 +1,16 @@
 project('gobject-introspection', 'c')
 
+glib = dependency('glib-2.0', required: false)
+if not glib.found()
+  error('MESON_SKIP_TEST glib not found.')
+endif
+
+python3 = import('python3')
+py3 = python3.find_python()
+if run_command(py3, '-c', 'import gi;').returncode() != 0
+    error('MESON_SKIP_TEST python3-gi not found')
+endif
+
 cc = meson.get_compiler('c')
 
 add_global_arguments('-DMESON_TEST', language : 'c')

--- a/test cases/frameworks/8 flex/meson.build
+++ b/test cases/frameworks/8 flex/meson.build
@@ -4,8 +4,16 @@ project('flex and bison', 'c')
 # may output headers that are necessary to build
 # the sources of a different generator.
 
-flex = find_program('flex')
-bison = find_program('bison')
+flex = find_program('flex', required: false)
+bison = find_program('bison', required: false)
+
+if not flex.found()
+  error('MESON_SKIP_TEST flex not found.')
+endif
+
+if not bison.found()
+  error('MESON_SKIP_TEST bison not found.')
+endif
 
 lgen = generator(flex,
 output : '@PLAINNAME@.yy.c',
@@ -23,4 +31,3 @@ e = executable('pgen', 'prog.c',
 lfiles, pfiles)
 
 test('parsertest', e)
-

--- a/test cases/frameworks/8 flex/prog.c
+++ b/test cases/frameworks/8 flex/prog.c
@@ -6,6 +6,8 @@
 #include<stdio.h>
 #include<stdlib.h>
 
+extern int yyparse();
+
 int main(int argc, char **argv) {
     /*
     int input;


### PR DESCRIPTION
Always run all framework tests on all platforms, but allow them to be skipped, when not running under CI for linux.

This should:
- make framework tests more useful in a non-CI environment, where all the prereqs might not be installed, as tests are allowed to be skipped
- run applicable framework tests on platforms other than linux
- preserves the original intent of having framework tests run under CI be required to pass, not get skipped