### PR TITLE
Fix 'meson introspect --target-files' for a custom target

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3232,7 +3232,11 @@ root and issuing %s.
         name = args[0]
         kwargs['install_mode'] = self._get_kwarg_install_mode(kwargs)
         if 'input' in kwargs:
-            kwargs['input'] = self.source_strings_to_files(extract_as_list(kwargs, 'input'))
+            try:
+                kwargs['input'] = self.source_strings_to_files(extract_as_list(kwargs, 'input'))
+            except mesonlib.MesonException:
+                mlog.warning('''Custom target input \'%s\' can\'t be converted to File object(s).
+This will become a hard error in the future.''' % kwargs['input'])
         tg = CustomTargetHolder(build.CustomTarget(name, self.subdir, self.subproject, kwargs), self)
         self.add_target(name, tg.held_object)
         return tg

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3231,6 +3231,8 @@ root and issuing %s.
         'Implementation-only, without FeatureNew checks, for internal use'
         name = args[0]
         kwargs['install_mode'] = self._get_kwarg_install_mode(kwargs)
+        if 'input' in kwargs:
+            kwargs['input'] = self.source_strings_to_files(extract_as_list(kwargs, 'input'))
         tg = CustomTargetHolder(build.CustomTarget(name, self.subdir, self.subproject, kwargs), self)
         self.add_target(name, tg.held_object)
         return tg
@@ -3908,7 +3910,7 @@ Try setting b_lundef to false instead.'''.format(self.coredata.base_options['b_s
             sources = [sources]
         for s in sources:
             if isinstance(s, (mesonlib.File, GeneratedListHolder,
-                              CustomTargetHolder, CustomTargetIndexHolder)):
+                              TargetHolder, CustomTargetIndexHolder)):
                 pass
             elif isinstance(s, str):
                 self.validate_within_subproject(self.subdir, s)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2372,6 +2372,38 @@ int main(int argc, char **argv) {
                 self.init(testdir, ['--cross-file=' + name], inprocess=True)
                 self.wipe()
 
+    def test_introspect_target_files(self):
+        '''
+        Tests that mesonintrospect --target-files returns expected output.
+        '''
+        testdir = os.path.join(self.common_test_dir, '8 install')
+        self.init(testdir)
+        expected = {
+            'stat@sta': ['stat.c'],
+            'prog@exe': ['prog.c'],
+        }
+        t_intro = self.introspect('--targets')
+        self.assertCountEqual([t['id'] for t in t_intro], expected)
+        for t in t_intro:
+            id = t['id']
+            tf_intro = self.introspect(['--target-files', id])
+            self.assertEqual(tf_intro, expected[id])
+        self.wipe()
+
+        testdir = os.path.join(self.common_test_dir, '53 custom target')
+        self.init(testdir)
+        expected = {
+            'bindat@cus': ['data_source.txt'],
+            'depfile@cus': [],
+        }
+        t_intro = self.introspect('--targets')
+        self.assertCountEqual([t['id'] for t in t_intro], expected)
+        for t in t_intro:
+            id = t['id']
+            tf_intro = self.introspect(['--target-files', id])
+            self.assertEqual(tf_intro, expected[id])
+        self.wipe()
+
     def test_compiler_run_command(self):
         '''
         The test checks that the compiler object can be passed to


### PR DESCRIPTION
Add testcase for, and fix `meson introspect --target-files` for a custom target, broken since 0.26.0 (PR #225)
For a CustomTarget, sources is a list of filenames as strings, not File objects.

Closes #2783