### PR TITLE
Ensure any generation error appears in the logfile and thus in CI output

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -147,10 +147,7 @@ class MesonApp:
     def generate(self):
         env = environment.Environment(self.source_dir, self.build_dir, self.meson_script_launcher, self.options, self.original_cmd_line_args)
         mlog.initialize(env.get_log_dir())
-        try:
-            self._generate(env)
-        finally:
-            mlog.shutdown()
+        self._generate(env)
 
     def _generate(self, env):
         mlog.debug('Build started at', datetime.datetime.now().isoformat())
@@ -374,6 +371,7 @@ def run(original_args, mainfile=None):
             # Error message
             mlog.log(e)
             # Path to log file
+            mlog.shutdown()
             logfile = os.path.join(app.build_dir, environment.Environment.log_dir, mlog.log_fname)
             mlog.log("\nA full log can be found at", mlog.bold(logfile))
             if os.environ.get('MESON_FORCE_BACKTRACE'):
@@ -383,4 +381,7 @@ def run(original_args, mainfile=None):
                 raise
             traceback.print_exc()
         return 1
+    finally:
+        mlog.shutdown()
+
     return 0


### PR DESCRIPTION
Since c2a5ac39, MesonApp.generate() closes the logfile before returning,
which means that when invoked by mesonmain.run(), any MesonException is not
logged there.

MesonApp.generate() does not appear to have any other users I can find.

This somewhat reduces the diagnostic value of the logfile.

This also interacts badly with running project tests in CI, as _run_tests
chooses to report the logfile contents, rather than stdout, for the
configure step, and it thus doesn't report any configure error which caused
a test failure.