### PR TITLE
Add declare_dependency() link_whole parameter

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -267,6 +267,8 @@ keyword arguments.
   - `include_directories`, the directories to add to header search path
   - `link_args`, link arguments to use
   - `link_with`, libraries to link against
+  - `link_whole`, libraries to link fully, same as [`executable`](#executable)
+    Since 0.46.0
   - `sources`, sources to add to targets (or generated header files
     that should be built before sources including them are built)
   - `version`, the version of this dependency, such as `1.2.3`

--- a/docs/markdown/snippets/declare_dependency-link_whole.md
+++ b/docs/markdown/snippets/declare_dependency-link_whole.md
@@ -1,0 +1,4 @@
+## declare_dependency() supports link_whole
+
+`declare_dependency()` supports `link_whole` parameter.
+`link_whole` propagates to build target that uses dependency.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -838,12 +838,14 @@ This will become a hard error in a future Meson release.''')
                 self.add_include_dirs(dep.include_directories)
                 for l in dep.libraries:
                     self.link(l)
+                for l in dep.whole_libraries:
+                    self.link_whole(l)
                 # Those parts that are external.
                 extpart = dependencies.InternalDependency('undefined',
                                                           [],
                                                           dep.compile_args,
                                                           dep.link_args,
-                                                          [], [], [])
+                                                          [], [], [], [])
                 self.external_deps.append(extpart)
                 # Deps of deps.
                 self.add_deps(dep.ext_deps)

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -145,7 +145,7 @@ class Dependency:
 
 
 class InternalDependency(Dependency):
-    def __init__(self, version, incdirs, compile_args, link_args, libraries, sources, ext_deps):
+    def __init__(self, version, incdirs, compile_args, link_args, libraries, whole_libraries, sources, ext_deps):
         super().__init__('internal', {})
         self.version = version
         self.is_found = True
@@ -153,6 +153,7 @@ class InternalDependency(Dependency):
         self.compile_args = compile_args
         self.link_args = link_args
         self.libraries = libraries
+        self.whole_libraries = whole_libraries
         self.sources = sources
         self.ext_deps = ext_deps
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1390,7 +1390,7 @@ permitted_kwargs = {'add_global_arguments': {'language'},
                     'configure_file': {'input', 'output', 'configuration', 'command', 'install_dir', 'capture', 'install'},
                     'custom_target': {'input', 'output', 'command', 'install', 'install_dir', 'build_always', 'capture', 'depends', 'depend_files', 'depfile', 'build_by_default'},
                     'dependency': {'default_options', 'fallback', 'language', 'main', 'method', 'modules', 'optional_modules', 'native', 'required', 'static', 'version'},
-                    'declare_dependency': {'include_directories', 'link_with', 'sources', 'dependencies', 'compile_args', 'link_args', 'version'},
+                    'declare_dependency': {'include_directories', 'link_with', 'sources', 'dependencies', 'compile_args', 'link_args', 'link_whole', 'version'},
                     'executable': exe_kwargs,
                     'find_program': {'required', 'native'},
                     'generator': {'arguments', 'output', 'depfile', 'capture', 'preserve_path_from'},
@@ -1622,6 +1622,7 @@ class Interpreter(InterpreterBase):
             raise InterpreterException('Version must be a string.')
         incs = extract_as_list(kwargs, 'include_directories', unholder=True)
         libs = extract_as_list(kwargs, 'link_with', unholder=True)
+        libs_whole = extract_as_list(kwargs, 'link_whole', unholder=True)
         sources = extract_as_list(kwargs, 'sources')
         sources = listify(self.source_strings_to_files(sources), unholder=True)
         deps = extract_as_list(kwargs, 'dependencies', unholder=True)
@@ -1641,7 +1642,7 @@ class Interpreter(InterpreterBase):
                 raise InterpreterException('''Entries in "link_with" may only be self-built targets,
 external dependencies (including libraries) must go to "dependencies".''')
         dep = dependencies.InternalDependency(version, incs, compile_args,
-                                              link_args, libs, sources, final_deps)
+                                              link_args, libs, libs_whole, sources, final_deps)
         return DependencyHolder(dep)
 
     @noKwargs

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1350,7 +1350,7 @@ G_END_DECLS'''
         # - add relevant directories to include dirs
         incs = [build.IncludeDirs(state.subdir, ['.'] + vapi_includes, False)]
         sources = [vapi_target] + vapi_depends
-        rv = InternalDependency(None, incs, [], [], link_with, sources, [])
+        rv = InternalDependency(None, incs, [], [], link_with, [], sources, [])
         created_values.append(rv)
         return ModuleReturnValue(rv, created_values)
 

--- a/test cases/common/145 whole archive/exe3/meson.build
+++ b/test cases/common/145 whole archive/exe3/meson.build
@@ -1,0 +1,1 @@
+exe3 = executable('prog3', '../prog.c', link_with : sh_func2_dep_func1)

--- a/test cases/common/145 whole archive/exe4/meson.build
+++ b/test cases/common/145 whole archive/exe4/meson.build
@@ -1,0 +1,1 @@
+exe4 = executable('prog4', '../prog.c', link_with : sh_func2_transdep_func1)

--- a/test cases/common/145 whole archive/meson.build
+++ b/test cases/common/145 whole archive/meson.build
@@ -30,3 +30,12 @@ subdir('sh_only_link_whole')
 subdir('exe2')
 # Test that both func1 and func2 are accessible from shared library
 test('prog2', exe2)
+
+# Test 3: link_whole can be used in declare_dependency()
+func1_dep = declare_dependency(link_whole : [st_func1])
+# Use dependency to link func1 into shared library
+subdir('sh_func2_dep_func1')
+# Link exe3 with shared library
+subdir('exe3')
+# Test that both func1 and func2 are accessible from shared library
+test('prog3', exe3)

--- a/test cases/common/145 whole archive/meson.build
+++ b/test cases/common/145 whole archive/meson.build
@@ -39,3 +39,12 @@ subdir('sh_func2_dep_func1')
 subdir('exe3')
 # Test that both func1 and func2 are accessible from shared library
 test('prog3', exe3)
+
+# Test 4: link_whole can be used in transitive declare_dependency()
+func1_trans_dep = declare_dependency(dependencies : func1_dep)
+# Use transitive dependency to link func1 into shared library
+subdir('sh_func2_transdep_func1')
+# Link exe4 with shared library
+subdir('exe4')
+# Test that both func1 and func2 are accessible from shared library
+test('prog4', exe4)

--- a/test cases/common/145 whole archive/sh_func2_dep_func1/meson.build
+++ b/test cases/common/145 whole archive/sh_func2_dep_func1/meson.build
@@ -1,0 +1,4 @@
+# Same as sh_func2_linked_func1, # func2.c does not depend on func1(),
+# so without link_whole compiler would throw func1() away.
+# This is the same version of the test with a dependency object instead.
+sh_func2_dep_func1 = shared_library('sh_func2_dep_func1', '../func2.c', dependencies : func1_dep)

--- a/test cases/common/145 whole archive/sh_func2_transdep_func1/meson.build
+++ b/test cases/common/145 whole archive/sh_func2_transdep_func1/meson.build
@@ -1,0 +1,6 @@
+# Same as sh_func2_dep_func1 but dependency is transitive.
+# func2.c does not have any reference to func1() so without link_whole compiler
+# should throw func1() out.
+sh_func2_transdep_func1 = shared_library(
+  'sh_func2_transdep_func1', '../func2.c',
+  dependencies : func1_trans_dep)


### PR DESCRIPTION
Additionally
- Removed unnecessary unpacking of link targets `BuildTarget.process_kwargs()`.
- Refactored of 'common/145 whole archive' test case because it was extremely hard to follow.
- Added test cases verify that `link_whole` works directly and as transitive dependency.

This partially covers #3046 

Due to a lot of renames in test case refactoring it might be easier to review test case changes commit by commit.