### PR TITLE
Handle a warning location which evaluates to False

### DIFF
--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -107,7 +107,7 @@ def warning(*args, **kwargs):
 
     args = (yellow('WARNING:'),) + args
 
-    if kwargs.get('location'):
+    if 'location' in kwargs:
         location = kwargs['location']
         del kwargs['location']
         location = '{}:{}:'.format(os.path.join(location.subdir, environment.build_filename), location.lineno)


### PR DESCRIPTION
As written in PR #2856, this code isn't quite right.

An ArgumentNode object can evaluate as False (if it's arguments attribute is
an empty sequence).

If that happens, we then try to hand the location kwarg down to print(),
rather than removing it, which causes an invalid keyword argument exception.

This failure can be seen e.g. when generating for gnome-twitch (See [1])

[1] https://travis-ci.org/jon-turney/meson-corpus-test/jobs/343017109