### PR TITLE
ninjabackend: Try to guess library dependencies for linker invocation.

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -726,7 +726,7 @@ class CCompiler(Compiler):
                         return False
         raise RuntimeError('BUG: {!r} check failed unexpectedly'.format(n))
 
-    def get_library_naming(self, env, libtype):
+    def get_library_naming(self, env, libtype, strict=False):
         '''
         Get library prefixes and suffixes for the target platform ordered by
         priority
@@ -734,7 +734,10 @@ class CCompiler(Compiler):
         stlibext = ['a']
         # We've always allowed libname to be both `foo` and `libfoo`,
         # and now people depend on it
-        prefixes = ['lib', '']
+        if strict and self.id != 'msvc': # lib prefix is not usually used with msvc
+            prefixes = ['lib']
+        else:
+            prefixes = ['lib', '']
         # Library suffixes and prefixes
         if for_darwin(env.is_cross_build(), env):
             shlibext = ['dylib']

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -55,7 +55,6 @@ for _l in clike_langs:
     clike_suffixes += lang_suffixes[_l]
 clike_suffixes += ('h', 'll', 's')
 
-# XXX: Use this in is_library()?
 soregex = re.compile(r'.*\.so(\.[0-9]+)?(\.[0-9]+)?(\.[0-9]+)?$')
 
 # All these are only for C-like languages; see `clike_langs` above.
@@ -102,6 +101,10 @@ def is_object(fname):
 def is_library(fname):
     if hasattr(fname, 'fname'):
         fname = fname.fname
+
+    if soregex.match(fname):
+        return True
+
     suffix = fname.split('.')[-1]
     return suffix in lib_suffixes
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1923,6 +1923,55 @@ recommended as it can lead to undefined behaviour on some platforms''')
         exe = os.path.join(self.builddir, 'main')
         self.assertEqual(b'NDEBUG=0', subprocess.check_output(exe).strip())
 
+    def test_guessed_linker_dependencies(self):
+        '''
+        Test that meson adds dependencies for libraries based on the final
+        linker command line.
+        '''
+        # build library
+        testdirbase = os.path.join(self.unit_test_dir, '26 guessed linker dependencies')
+        testdirlib = os.path.join(testdirbase, 'lib')
+        extra_args = None
+        env = Environment(testdirlib, self.builddir, self.meson_command,
+                          get_fake_options(self.prefix), [])
+        if env.detect_c_compiler(False).get_id() != 'msvc':
+            # static libraries are not linkable with -l with msvc because meson installs them
+            # as .a files which unix_args_to_native will not know as it expects libraries to use
+            # .lib as extension. For a DLL the import library is installed as .lib. Thus for msvc
+            # this tests needs to use shared libraries to test the path resolving logic in the
+            # dependency generation code path.
+            extra_args = ['--default-library', 'static']
+        self.init(testdirlib, extra_args=extra_args)
+        self.build()
+        self.install()
+        libbuilddir = self.builddir
+        installdir = self.installdir
+        libdir = os.path.join(self.installdir, self.prefix.lstrip('/').lstrip('\\'), 'lib')
+
+        # build user of library
+        self.new_builddir()
+        # replace is needed because meson mangles platform pathes passed via LDFLAGS
+        os.environ["LDFLAGS"] = '-L{}'.format(libdir.replace('\\', '/'))
+        self.init(os.path.join(testdirbase, 'exe'))
+        del os.environ["LDFLAGS"]
+        self.build()
+        self.assertBuildIsNoop()
+
+        # rebuild library
+        exebuilddir = self.builddir
+        self.installdir = installdir
+        self.builddir = libbuilddir
+        # Microsoft's compiler is quite smart about touching import libs on changes,
+        # so ensure that there is actually a change in symbols.
+        self.setconf('-Dmore_exports=true')
+        self.build()
+        self.install()
+        # no ensure_backend_detects_changes needed because self.setconf did that already
+
+        # assert user of library will be rebuild
+        self.builddir = exebuilddir
+        self.assertRebuiltTarget('app')
+
 
 class FailureTests(BasePlatformTests):
     '''

--- a/test cases/unit/26 guessed linker dependencies/exe/app.c
+++ b/test cases/unit/26 guessed linker dependencies/exe/app.c
@@ -1,0 +1,6 @@
+void liba_func();
+
+int main() {
+    liba_func();
+    return 0;
+}

--- a/test cases/unit/26 guessed linker dependencies/exe/meson.build
+++ b/test cases/unit/26 guessed linker dependencies/exe/meson.build
@@ -1,0 +1,7 @@
+project('exe', ['c'])
+
+executable('app',
+  'app.c',
+  # Use uninterpreted strings to avoid path finding by dependency or compiler.find_library
+  link_args: ['-ltest-lib']
+  )

--- a/test cases/unit/26 guessed linker dependencies/lib/lib.c
+++ b/test cases/unit/26 guessed linker dependencies/lib/lib.c
@@ -1,0 +1,20 @@
+#if defined _WIN32
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+void DLL_PUBLIC liba_func() {
+}
+
+#ifdef MORE_EXPORTS
+
+void DLL_PUBLIC libb_func() {
+}
+
+#endif

--- a/test cases/unit/26 guessed linker dependencies/lib/meson.build
+++ b/test cases/unit/26 guessed linker dependencies/lib/meson.build
@@ -1,0 +1,11 @@
+project('lib1', ['c'])
+
+c_args = []
+
+# Microsoft's compiler is quite smart about touching import libs on changes,
+# so ensure that there is actually a change in symbols.
+if get_option('more_exports')
+    c_args += '-DMORE_EXPORTS'
+endif
+
+a = library('test-lib', 'lib.c', c_args: c_args, install: true)

--- a/test cases/unit/26 guessed linker dependencies/lib/meson_options.txt
+++ b/test cases/unit/26 guessed linker dependencies/lib/meson_options.txt
@@ -1,0 +1,1 @@
+option('more_exports', type : 'boolean', value : false)


### PR DESCRIPTION
The linkers currently do not support ninja compatible output of
dependencies used while linking. Try to guess which files will be used
while linking in python code and generate conservative dependencies to
ensure changes in linked libraries are detected.
    
This generates dependencies on the best match for static and shared
linking, but this should not be a problem, except for spurious
rebuilding when only one of them changes, which should not be a problem.
    
Also makes sure to ignore any libraries generated inside the build, to
keep the optimisation working where changes in a shared library only
cause relink if the symbols have changed as well.
