### PR TITLE
gnome: Fix depend_files listing for compile_resources

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -33,6 +33,7 @@ import mesonbuild.compilers
 import mesonbuild.environment
 import mesonbuild.mesonlib
 import mesonbuild.coredata
+import mesonbuild.modules.gnome
 from mesonbuild.interpreter import ObjectHolder
 from mesonbuild.mesonlib import (
     is_linux, is_windows, is_osx, is_cygwin, is_dragonflybsd,
@@ -525,7 +526,10 @@ class BasePlatformTests(unittest.TestCase):
         self.privatedir = os.path.join(self.builddir, 'meson-private')
         if inprocess:
             try:
-                out = run_configure(self.meson_mainfile, self.meson_args + args + extra_args)[1]
+                (returncode, out, _) = run_configure(self.meson_mainfile, self.meson_args + args + extra_args)
+                if returncode != 0:
+                    self._print_meson_log()
+                    raise RuntimeError('Configure failed')
             except:
                 self._print_meson_log()
                 raise
@@ -2597,6 +2601,21 @@ endian = 'little'
         self.change_builddir(builddir)
         self.init(testdir)
         self.build()
+
+    def test_old_gnome_module_codepaths(self):
+        '''
+        A lot of code in the GNOME module is conditional on the version of the
+        glib tools that are installed, and breakages in the old code can slip
+        by once the CI has a newer glib version. So we force the GNOME module
+        to pretend that it's running on an ancient glib so the fallback code is
+        also tested.
+        '''
+        testdir = os.path.join(self.framework_test_dir, '7 gnome')
+        os.environ['MESON_UNIT_TEST_PRETEND_GLIB_OLD'] = "1"
+        mesonbuild.modules.gnome.native_glib_version = '2.20'
+        self.init(testdir, inprocess=True)
+        self.build()
+        mesonbuild.modules.gnome.native_glib_version = None
 
 
 class LinuxArmCrossCompileTests(BasePlatformTests):

--- a/test cases/frameworks/7 gnome/meson.build
+++ b/test cases/frameworks/7 gnome/meson.build
@@ -9,6 +9,19 @@ if cc.get_id() == 'intel'
   add_global_arguments('-wd2282', language : 'c')
 endif
 
+py3 = import('python3').find_python()
+pycode = '''import os, sys
+if "MESON_UNIT_TEST_PRETEND_GLIB_OLD" in os.environ:
+  sys.exit(0)
+sys.exit(1)
+'''
+
+pretend_glib_old = false
+res = run_command(py3, '-c', pycode)
+if res.returncode() == 0
+  pretend_glib_old = true
+endif
+
 gnome = import('gnome')
 gio = dependency('gio-2.0')
 giounix = dependency('gio-unix-2.0')

--- a/test cases/frameworks/7 gnome/resources/meson.build
+++ b/test cases/frameworks/7 gnome/resources/meson.build
@@ -29,7 +29,7 @@ gnome.compile_resources('simple-resources',
 )
 test('simple resource test (gresource)', find_program('resources.py'))
 
-if glib.version() >= '2.52.0'
+if not pretend_glib_old and glib.version() >= '2.52.0'
   # This test cannot pass if GLib version is older than 9.99.9.
   # Meson will raise an error if the user tries to use the 'dependencies'
   # argument and the version of GLib is too old for generated resource


### PR DESCRIPTION
Also add a unit test that will test all codepaths for old Glib tools versions.

Closes https://github.com/mesonbuild/meson/issues/2860