### PR TITLE
pkgconfig deps: Warn when a static library isn't found

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -780,9 +780,12 @@ class CCompiler(Compiler):
             args = ['-l' + libname]
             if self.links(code, env, extra_args=args):
                 return args
+        # Ensure that we won't modify the list that was passed to us
+        extra_dirs = extra_dirs[:]
+        # Search in the system libraries too
+        extra_dirs += self.get_library_dirs()
         # Not found or we want to use a specific libtype? Try to find the
         # library file itself.
-        extra_dirs += self.get_library_dirs()
         prefixes, suffixes = self.get_library_naming(env, libtype)
         # Triply-nested loop!
         for d in extra_dirs:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1563,9 +1563,13 @@ int main(int argc, char **argv) {
 
     def test_pkgconfig_static(self):
         '''
-        Test that the we only use static libraries when `static: true` is
+        Test that the we prefer static libraries when `static: true` is
         passed to dependency() with pkg-config. Can't be an ordinary test
         because we need to build libs and try to find them from meson.build
+
+        Also test that it's not a hard error to have unsatisfiable library deps
+        since system libraries -lm will never be found statically.
+        https://github.com/mesonbuild/meson/issues/2785
         '''
         if not shutil.which('pkg-config'):
             raise unittest.SkipTest('pkg-config not found')

--- a/test cases/frameworks/7 gnome/meson.build
+++ b/test cases/frameworks/7 gnome/meson.build
@@ -17,6 +17,9 @@ gobj = dependency('gobject-2.0')
 gir = dependency('gobject-introspection-1.0')
 gmod = dependency('gmodule-2.0')
 
+# Test that static deps don't error out when static libraries aren't found
+glib_static = dependency('glib-2.0', static : true)
+
 subdir('resources-data')
 subdir('resources')
 subdir('gir')

--- a/test cases/unit/17 pkgconfig static/foo.pc.in
+++ b/test cases/unit/17 pkgconfig static/foo.pc.in
@@ -7,4 +7,5 @@ Name: libfoo
 Description: A foo library.
 Version: 1.0
 Libs: -L${libdir} -lfoo
+Libs.private: -lm
 Cflags: -I${includedir}


### PR DESCRIPTION
A hard error makes this feature useless in most cases since a static library usually won't be found for every library, particularly system libraries like -lm. Instead, warn so the user can provide the static library if they wish.

This feature will be expanded and made more extensible and more usable in the future.

Closes https://github.com/mesonbuild/meson/issues/2785