### PR TITLE
rpm: Meson gnome

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -39,3 +39,5 @@
       cat %{_vpath_builddir}/meson-logs/testlog.txt; \
       echo "-----END TESTLOG-----"; \
       exit $rc; )
+
+%meson_gnome  %meson -i '-DG_DISABLE_CAST_CHECKS'

--- a/data/macros.meson
+++ b/data/macros.meson
@@ -1,9 +1,9 @@
 %__meson %{_bindir}/meson
 %__meson_wrap_mode nodownload
 
-%meson \
-    export CFLAGS="${CFLAGS:-%__global_cflags}"       \
-    export CXXFLAGS="${CXXFLAGS:-%__global_cxxflags}" \
+%meson(i:) \
+    export CFLAGS="${CFLAGS:-%__global_cflags %{-f*}}"       \
+    export CXXFLAGS="${CXXFLAGS:-%__global_cxxflags %{-f*}}" \
     export FFLAGS="${FFLAGS:-%__global_fflags}"       \
     export FCFLAGS="${FCFLAGS:-%__global_fcflags}"    \
     export LDFLAGS="${LDFLAGS:-%__global_ldflags}"    \


### PR DESCRIPTION
Distributions doing release-type builds are currently encouraged to used the "plain" build type and add their own specific flavor of build flags. This is what the current %meson macro implementation does for RPM based distributions.

Unfortunately adding the same additional repeating set of flags to a large number of packages using %meson quickly becomes tedious. eg. -DG_DISABLE_CAST_CHECKS which is the current recommendation for release builds from GNOME.

This PR adds an argument (-i) to %meson that allows easy addition to cflags/cxxflags and then uses this flag to introduce a new macro %meson_gnome which does the right thing for RPM release builds of glib/gnome based software.

Obviouslly the %meson_gnome macro could be implemented as exporting overided CFLGAGS/CXXFLAGS, without adding additional changes to %meson, but it seesm to me to be more elegant to extend the default macro for possible use of the flags elsewhere