### PR TITLE
Support lcc compiler for e2k (Elbrus) architecture

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -498,7 +498,7 @@ class Environment:
                 continue
             version = search_version(out)
             full_version = out.split('\n', 1)[0]
-            if 'Free Software Foundation' in out:
+            if 'Free Software Foundation' or ('e2k' and 'lcc') in out:
                 defines = self.get_gnu_compiler_defines(compiler)
                 if not defines:
                     popen_exceptions[' '.join(compiler)] = 'no pre-processor defines'
@@ -611,7 +611,7 @@ class Environment:
                 popen_exceptions[' '.join(compiler + arg)] = e
                 continue
             version = search_version(out)
-            if 'Free Software Foundation' in out:
+            if 'Free Software Foundation' or ('e2k' and 'lcc') in out:
                 defines = self.get_gnu_compiler_defines(compiler)
                 if not defines:
                     popen_exceptions[' '.join(compiler)] = 'no pre-processor defines'
@@ -638,7 +638,7 @@ class Environment:
                 popen_exceptions[' '.join(compiler + arg)] = e
                 continue
             version = search_version(out)
-            if 'Free Software Foundation' in out:
+            if 'Free Software Foundation' or ('e2k' and 'lcc') in out:
                 defines = self.get_gnu_compiler_defines(compiler)
                 if not defines:
                     popen_exceptions[' '.join(compiler)] = 'no pre-processor defines'


### PR DESCRIPTION
Added a support for lcc compiler for Elbrus processors based on e2k architecture.
Examples of such CPUs:
https://en.wikipedia.org/wiki/Elbrus-8S
https://en.wikipedia.org/wiki/Elbrus-2S%2B

Such compiler have a similar behavior as gcc (option compatibility), but, instead of 'Free Software Foundation' string, its version infomation contains strings 'lcc' and 'e2k' like this:

lcc:1.21.22:Oct-15-2017:e2k-v4-linux
gcc (GCC) 4.8.0 compatible

So specific strings in environment.py were altered.