### PR TITLE
llvm: Add configs for freebsd 6.0 and debian 7svn

### DIFF
--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -120,18 +120,19 @@ class LLVMDependency(ConfigToolDependency):
     # newest back to oldest (3.5 is arbitrary), and finally the devel version.
     # Please note that llvm-config-6.0 is a development snapshot and it should
     # not be moved to the beginning of the list. The only difference between
-    # llvm-config-6.0 and llvm-config-devel is that the former is used by
+    # llvm-config-7 and llvm-config-devel is that the former is used by
     # Debian and the latter is used by FreeBSD.
     tools = [
         'llvm-config', # base
-        'llvm-config-5.0', 'llvm-config50', # latest stable release
-        'llvm-config-4.0', 'llvm-config40', # old stable releases
+        'llvm-config-6.0', 'llvm-config60',
+        'llvm-config-5.0', 'llvm-config50',
+        'llvm-config-4.0', 'llvm-config40',
         'llvm-config-3.9', 'llvm-config39',
         'llvm-config-3.8', 'llvm-config38',
         'llvm-config-3.7', 'llvm-config37',
         'llvm-config-3.6', 'llvm-config36',
         'llvm-config-3.5', 'llvm-config35',
-        'llvm-config-6.0', 'llvm-config-devel', # development snapshot
+        'llvm-config-7',   'llvm-config-devel', # development snapshot
     ]
     tool_name = 'llvm-config'
     __cpp_blacklist = {'-DNDEBUG'}


### PR DESCRIPTION
Debian has 7svn in their experimental repo, and FreeBSD has 6.0.r2 in
their ports.