### PR TITLE
Fix Rust compiler-private library ambiguity

### DIFF
--- a/docs/markdown/snippets/rust-private-disambiguation.md
+++ b/docs/markdown/snippets/rust-private-disambiguation.md
@@ -1,0 +1,6 @@
+## Rust compiler-private library disambiguation
+
+When building a Rust target with Rust library dependencies, an
+`--extern` argument is now specified to avoid ambiguity between the
+dependency library, and any crates of the same name in `rustc`'s
+private sysroot.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1274,6 +1274,10 @@ int dummy;
         linkdirs = OrderedDict()
         for d in target.link_targets:
             linkdirs[d.subdir] = True
+            # specify `extern CRATE_NAME=OUTPUT_FILE` for each Rust
+            # dependency, so that collisions with libraries in rustc's
+            # sysroot don't cause ambiguity
+            args += ['--extern', '{}={}'.format(d.name, os.path.join(d.subdir, d.filename))]
         for d in linkdirs.keys():
             if d == '':
                 d = '.'

--- a/test cases/rust/7 private crate collision/installed_files.txt
+++ b/test cases/rust/7 private crate collision/installed_files.txt
@@ -1,0 +1,2 @@
+usr/bin/prog?exe
+usr/lib/librand.rlib

--- a/test cases/rust/7 private crate collision/meson.build
+++ b/test cases/rust/7 private crate collision/meson.build
@@ -1,0 +1,5 @@
+project('rust private crate collision', 'rust')
+
+l = static_library('rand', 'rand.rs', install : true)
+e = executable('prog', 'prog.rs', link_with : l, install : true)
+test('linktest', e)

--- a/test cases/rust/7 private crate collision/prog.rs
+++ b/test cases/rust/7 private crate collision/prog.rs
@@ -1,0 +1,3 @@
+extern crate rand;
+
+fn main() { println!("printing: {}", rand::explore()); }

--- a/test cases/rust/7 private crate collision/rand.rs
+++ b/test cases/rust/7 private crate collision/rand.rs
@@ -1,0 +1,4 @@
+// use a name that collides with one of the rustc_private libraries
+#![crate_name = "rand"]
+
+pub fn explore() -> &'static str { "librarystring" }


### PR DESCRIPTION
When building a Rust target with Rust library dependencies, an
`--extern` argument is now specified to avoid ambiguity between the
dependency library, and any crates of the same name in `rustc`'s
private sysroot.

Includes an illustrative test case.