### PR TITLE
[skip ci] docs: Add reference table for language args parameter names

### DIFF
--- a/docs/markdown/Adding-arguments.md
+++ b/docs/markdown/Adding-arguments.md
@@ -49,6 +49,8 @@ executable('prog', 'prog.cc', cpp_args : '-DCPPTHING')
 Here we create a C++ executable with an extra argument that is used
 during compilation but not for linking.
 
+You can find the parameter name for other languages in the [reference tables](Reference-tables.md).
+
 Specifying extra linker arguments is done in the same way:
 
 ```meson

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -63,3 +63,21 @@ These are provided by the `.system()` method call.
 
 Any string not listed above is not guaranteed to remain stable in
 future releases.
+
+
+## Language arguments parameter names
+
+These are the parameter names for passing language specific arguments to your build target.
+
+| Language      | Parameter name |
+| -----         | -----
+| C             | c_args |
+| C++           | cpp_args |
+| C#            | cs_args |
+| D             | d_args |
+| Fortran       | fortran_args |
+| Java          | java_args |
+| Objective C   | objc_args |
+| Objective C++ | objcpp_args |
+| Rust          | rust_args |
+| Vala          | vala_args |


### PR DESCRIPTION
I couldn't find these in the docs. Managed to guess it for C#, but guessing alone isn't a good thing. :)