### PR TITLE
Add file encoding to configure_file

### DIFF
--- a/docs/markdown/Configuration.md
+++ b/docs/markdown/Configuration.md
@@ -113,6 +113,14 @@ Will produce:
 #define BAR
 ```
 
+## Dealing with file encodings
+
+The default meson file encoding to configure files is utf-8. If you need to
+configure a file that is not utf-8 encoded the encoding keyword will allow
+you to specify which file encoding to use. It is however strongly advised to
+convert your non utf-8 file to utf-8 whenever possible. Supported file
+encodings are those of python3, see [standard-encodings](https://docs.python.org/3/library/codecs.html#standard-encodings).
+
 # A full example
 
 Generating and using a configuration file requires the following steps:

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -214,6 +214,9 @@ the `@variable@` syntax.
   was specified. It defaults to `c`, in which case preprocessor directives
   will be prefixed with `#`, you can also use `nasm`, in which case the
   prefix will be `%`.
+- `encoding` *(added v0.47.0)* set the file encoding for the input and output file,
+  defaults to utf-8. The supported encodings are those of python3, see
+  [standard-encodings](https://docs.python.org/3/library/codecs.html#standard-encodings).
 
 ### custom_target()
 

--- a/docs/markdown/snippets/configure_file_encoding.md
+++ b/docs/markdown/snippets/configure_file_encoding.md
@@ -1,0 +1,12 @@
+## New encoding keyword for configure_file
+
+Add a new keyword to [`configure_file()`](#Reference-manual.md#configure_file)
+that allows the developer to specify the input and output file encoding.
+
+If the file encoding of the input is not UTF-8 meson can crash (see #1542).
+A crash as with UTF-16 is the best case and the worst meson will silently
+corrupt the output file for example with ISO-2022-JP. For additional details
+see pull request #3135.
+
+The new keyword defaults to UTF-8 and the documentation strongly suggest to
+convert the file to UTF-8 when possible.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1724,7 +1724,7 @@ permitted_kwargs = {'add_global_arguments': {'language'},
                     'add_test_setup': {'exe_wrapper', 'gdb', 'timeout_multiplier', 'env'},
                     'benchmark': {'args', 'env', 'should_fail', 'timeout', 'workdir', 'suite'},
                     'build_target': known_build_target_kwargs,
-                    'configure_file': {'input', 'output', 'configuration', 'command', 'copy', 'install_dir', 'install_mode', 'capture', 'install', 'format', 'output_format'},
+                    'configure_file': {'input', 'output', 'configuration', 'command', 'copy', 'install_dir', 'install_mode', 'capture', 'install', 'format', 'output_format', 'encoding'},
                     'custom_target': {'input', 'output', 'command', 'install', 'install_dir', 'install_mode', 'build_always', 'capture', 'depends', 'depend_files', 'depfile', 'build_by_default'},
                     'dependency': {'default_options', 'fallback', 'language', 'main', 'method', 'modules', 'optional_modules', 'native', 'required', 'static', 'version', 'private_headers'},
                     'declare_dependency': {'include_directories', 'link_with', 'sources', 'dependencies', 'compile_args', 'link_args', 'link_whole', 'version'},
@@ -3322,8 +3322,10 @@ root and issuing %s.
             mlog.log('Configuring', mlog.bold(output), 'using configuration')
             if inputfile is not None:
                 os.makedirs(os.path.join(self.environment.build_dir, self.subdir), exist_ok=True)
+                file_encoding = kwargs.setdefault('encoding', 'utf-8')
                 missing_variables = mesonlib.do_conf_file(ifile_abs, ofile_abs,
-                                                          conf.held_object, fmt)
+                                                          conf.held_object, fmt,
+                                                          file_encoding)
                 if missing_variables:
                     var_list = ", ".join(map(repr, sorted(missing_variables)))
                     mlog.warning(
@@ -3350,7 +3352,8 @@ root and issuing %s.
                                            (res.stdout, res.stderr))
             if 'capture' in kwargs and kwargs['capture']:
                 dst_tmp = ofile_abs + '~'
-                with open(dst_tmp, 'w', encoding='utf-8') as f:
+                file_encoding = kwargs.setdefault('encoding', 'utf-8')
+                with open(dst_tmp, 'w', encoding=file_encoding) as f:
                     f.writelines(res.stdout)
                 if ifile_abs:
                     shutil.copymode(ifile_abs, dst_tmp)

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -623,9 +623,9 @@ def do_mesondefine(line, confdata):
         raise MesonException('#mesondefine argument "%s" is of unknown type.' % varname)
 
 
-def do_conf_file(src, dst, confdata, format):
+def do_conf_file(src, dst, confdata, format, encoding='utf-8'):
     try:
-        with open(src, encoding='utf-8') as f:
+        with open(src, encoding=encoding) as f:
             data = f.readlines()
     except Exception as e:
         raise MesonException('Could not read input file %s: %s' % (src, str(e)))
@@ -652,8 +652,11 @@ def do_conf_file(src, dst, confdata, format):
             missing_variables.update(missing)
         result.append(line)
     dst_tmp = dst + '~'
-    with open(dst_tmp, 'w', encoding='utf-8') as f:
-        f.writelines(result)
+    try:
+        with open(dst_tmp, 'w', encoding=encoding) as f:
+            f.writelines(result)
+    except Exception as e:
+        raise MesonException('Could not write output file %s: %s' % (dst, str(e)))
     shutil.copymode(src, dst_tmp)
     replace_if_different(dst, dst_tmp)
     return missing_variables

--- a/test cases/common/16 configure file/config8.h.in
+++ b/test cases/common/16 configure file/config8.h.in
@@ -1,0 +1,3 @@
+#define MESSAGE "@var@"
+
+#define "non isolatin1 char Ä fails decode with utf-8"

--- a/test cases/common/16 configure file/meson.build
+++ b/test cases/common/16 configure file/meson.build
@@ -174,3 +174,13 @@ ret = run_command(check_file, inf, outf)
 if ret.returncode() != 0
   error('Error running command: @0@\n@1@'.format(ret.stdout(), ret.stderr()))
 endif
+
+# Test non isolatin1 encoded input file which fails to decode with utf-8
+conf8 = configuration_data()
+conf8.set('var', 'foo')
+configure_file(
+  input : 'config8.h.in',
+  output : '@BASENAME@',
+  encoding : 'koi8-r',
+  configuration : conf8
+)

--- a/test cases/failing/79 non ascii in ascii encoded configure file/config9.h.in
+++ b/test cases/failing/79 non ascii in ascii encoded configure file/config9.h.in
@@ -1,0 +1,1 @@
+#define MESSAGE "@var@"

--- a/test cases/failing/79 non ascii in ascii encoded configure file/meson.build
+++ b/test cases/failing/79 non ascii in ascii encoded configure file/meson.build
@@ -1,0 +1,10 @@
+project('non acsii to ascii encoding', 'c')
+# Writing a non ASCII character with a ASCII encoding should fail
+conf9 = configuration_data()
+conf9.set('var', 'д')
+configure_file(
+  input : 'config9.h.in',
+  output : '@BASENAME@',
+  encoding : 'ascii',
+  configuration : conf9
+)


### PR DESCRIPTION
meson should not make the assumption that all files are encoded in utf-8 or isolatin1 when passed to configure_file. The new keyword will allow the user to provide the encoding for the the input and output file. It will default to utf-8 so all current code will keep working.

In #1542 people suggest to detect the encoding. This may work for some file but in the end this is nothing more than an educated guess. Meson should not guess if it can ask the user.

Fixes #1542