### PR TITLE
Adding a "Projects using Meson" to Community section

### DIFF
--- a/docs/markdown/index.md
+++ b/docs/markdown/index.md
@@ -33,19 +33,15 @@ developers. The first one is the mailing list, which is hosted at
 The second way is via IRC. The channel to use is `#mesonbuild` at
 [Freenode](https://freenode.net/).
 
-### Projects using Meson
+### [Projects using Meson](http://mesonbuild.com/Users.html)
 
 Many projects out there are using Meson and their communities are also
 a great resource for learning about what (and what not too!) do when
-trying to convert to using Meson. Some example projects are;
+trying to convert to using Meson. 
 
-*   [Meson itself!](https://github.com/mesonbuild/meson#running)
-*   [freedesktop.org](https://www.freedesktop.org/wiki/) related projects include;
-   - [Mesa](https://www.mesa3d.org/meson.html)
-   - [gstreamer](http://blog.nirbheek.in/2016/05/gstreamer-and-meson-new-hope.html)
-   - [Wayland](https://www.phoronix.com/scan.php?page=news_item&px=Wayland-Meson-Build-Sys-Patches)
- * [Gnome](https://wiki.gnome.org/Initiatives/GnomeGoals/MesonPorting) and friends (GTK, etc)
-
+[A short list of Meson users can be found here](http://mesonbuild.com/Users.html)
+but there are many more. We would love to hear about your success
+stories too and how things could be improved too!
 
 ## Development
 

--- a/docs/markdown/index.md
+++ b/docs/markdown/index.md
@@ -33,6 +33,20 @@ developers. The first one is the mailing list, which is hosted at
 The second way is via IRC. The channel to use is `#mesonbuild` at
 [Freenode](https://freenode.net/).
 
+### Projects using Meson
+
+Many projects out there are using Meson and their communities are also
+a great resource for learning about what (and what not too!) do when
+trying to convert to using Meson. Some example projects are;
+
+*   [Meson itself!](https://github.com/mesonbuild/meson#running)
+*   [freedesktop.org](https://www.freedesktop.org/wiki/) related projects include;
+   - [Mesa](https://www.mesa3d.org/meson.html)
+   - [gstreamer](http://blog.nirbheek.in/2016/05/gstreamer-and-meson-new-hope.html)
+   - [Wayland](https://www.phoronix.com/scan.php?page=news_item&px=Wayland-Meson-Build-Sys-Patches)
+ * [Gnome](https://wiki.gnome.org/Initiatives/GnomeGoals/MesonPorting) and friends (GTK, etc)
+
+
 ## Development
 
 All development on Meson is done on the [GitHub


### PR DESCRIPTION
Currently the website doesn't seem to contain any info on projects using Meson. 

A build system lives or dies by the people who are willing to use the project so I've added a small "Projects using Meson" section to the "Community" section of the website.

I'm sure this list could be greatly improved, you should be promoting your success stories!