### PR TITLE
Enable 'test cases/frameworks/10 gtk-doc' for gtkdoc >= 1.26

### DIFF
--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -445,8 +445,8 @@ def skippable(suite, test):
     if not suite.endswith('frameworks'):
         return True
 
-    # gtk-doc test is always skipped pending upstream fixes for spaces in
-    # filenames landing in distros
+    # gtk-doc test may be skipped, pending upstream fixes for spaces in
+    # filenames landing in the distro used for CI
     if test.endswith('10 gtk-doc'):
         return True
 

--- a/test cases/frameworks/10 gtk-doc/meson.build
+++ b/test cases/frameworks/10 gtk-doc/meson.build
@@ -13,8 +13,15 @@ inc = include_directories('include')
 
 subdir('include')
 
-# We have to disable this test until this bug fix has landed to
-# distros https://bugzilla.gnome.org/show_bug.cgi?id=753145
-error('MESON_SKIP_TEST can not enable gtk-doc test until upstream fixes have landed.')
+# disable this test unless a bug fix for spaces in pathnames is present
+# https://bugzilla.gnome.org/show_bug.cgi?id=753145
+result = run_command(gtkdoc, ['--version'])
+gtkdoc_ver = result.stdout().strip()
+if gtkdoc_ver == ''
+  gtkdoc_ver = result.stderr().strip()
+endif
+if gtkdoc_ver.version_compare('<1.26')
+  error('MESON_SKIP_TEST gtk-doc test requires gtkdoc >= 1.26.')
+endif
 
 subdir('doc')


### PR DESCRIPTION
Enable 'test cases/frameworks/10 gtk-doc' if gtkdoc version is 1.26 or
later.

Old versions of gtkdoc-scan also output the version to stdout rather than
stderr, so be sure to handle that...

Follow up to #3060 