### PR TITLE
Add a test for shared_library using link_whole and non-empty source list

### DIFF
--- a/test cases/common/180 shared library link whole/meson.build
+++ b/test cases/common/180 shared library link whole/meson.build
@@ -1,0 +1,16 @@
+project('whole archive', 'c')
+
+cc = meson.get_compiler('c')
+
+if cc.get_id() == 'msvc'
+  if cc.version().version_compare('<19')
+    error('MESON_SKIP_TEST link_whole only works on VS2015 or newer.')
+  endif
+endif
+
+static1 = static_library('static1', 'static1.c')
+static2 = static_library('static2', 'static2.c')
+
+shared = shared_library('shared', 'shared.c', link_whole : [static1, static2])
+exe = executable('exe', 'test.c', link_with : shared)
+test('prog', exe)

--- a/test cases/common/180 shared library link whole/shared.c
+++ b/test cases/common/180 shared library link whole/shared.c
@@ -1,0 +1,3 @@
+int meson_test_shared(void) {
+    return 10;
+}

--- a/test cases/common/180 shared library link whole/shared.h
+++ b/test cases/common/180 shared library link whole/shared.h
@@ -1,0 +1,1 @@
+int meson_test_shared(void);

--- a/test cases/common/180 shared library link whole/static1.c
+++ b/test cases/common/180 shared library link whole/static1.c
@@ -1,0 +1,3 @@
+int meson_test_static_1(void) {
+    return 20;
+}

--- a/test cases/common/180 shared library link whole/static1.h
+++ b/test cases/common/180 shared library link whole/static1.h
@@ -1,0 +1,1 @@
+int meson_test_static_1(void);

--- a/test cases/common/180 shared library link whole/static2.c
+++ b/test cases/common/180 shared library link whole/static2.c
@@ -1,0 +1,3 @@
+int meson_test_static_2(void) {
+    return 30;
+}

--- a/test cases/common/180 shared library link whole/static2.h
+++ b/test cases/common/180 shared library link whole/static2.h
@@ -1,0 +1,1 @@
+int meson_test_static_2(void);

--- a/test cases/common/180 shared library link whole/test.c
+++ b/test cases/common/180 shared library link whole/test.c
@@ -1,0 +1,21 @@
+#include "static1.h"
+#include "static2.h"
+#include "shared.h"
+
+#include <stdio.h>
+
+int main(void) {
+    if (meson_test_shared() != 10) {
+        printf("bad shared\n");
+        return 1;
+    }
+    if (meson_test_static_1() != 20) {
+        printf("bad static1\n");
+        return 1;
+    }
+    if (meson_test_static_2() != 30) {
+        printf("bad static2\n");
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
This is a weird bug I am trying to reproduce. The test is trivial and fails with
```text
LINK : fatal error LNK1104: cannot open file 'shared.lib'
ninja: build stopped: subcommand failed.
 ```