### PR TITLE
Add generation of meson.build files from existing sources to "meson init"

### DIFF
--- a/docs/markdown/snippets/improved-meson-init.md
+++ b/docs/markdown/snippets/improved-meson-init.md
@@ -1,0 +1,19 @@
+## Autogeneration of simple meson.build files
+
+A feature to generate a meson.build file compiling given C/C++ source
+files into a single executable has been added to "meson init". By
+default, it will take all recognizable source files in the current
+directory.  You can also specify a list of dependencies with the -d
+flag and automatically invoke a build with the -b flag to check if the
+code builds with those dependencies. 
+
+For example,
+
+```meson
+meson init -fbd sdl2,gl
+```
+
+will look for C or C++ files in the current directory, generate a
+meson.build for them with the dependencies of sdl2 and gl and
+immediately try to build it, overwriting any previous meson.build and
+build directory.

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -122,8 +122,7 @@ int main(int argc, char **argv) {{
 
 hello_c_meson_template = '''project('{project_name}', 'c',
   version : '{version}',
-  default_options : ['warning_level=3',
-                     'cpp_std=c++14'])
+  default_options : ['warning_level=3'])
 
 exe = executable('{exe_name}', '{source_name}',
   install : true)
@@ -147,7 +146,8 @@ int main(int argc, char **argv) {{
 
 hello_cpp_meson_template = '''project('{project_name}', 'cpp',
   version : '{version}',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3',
+                     'cpp_std=c++14'])
 
 exe = executable('{exe_name}', '{source_name}',
   install : true)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1775,6 +1775,9 @@ int main(int argc, char **argv) {
                               workdir=tmpdir)
                     self._run(ninja,
                               workdir=os.path.join(tmpdir, 'builddir'))
+            with tempfile.TemporaryDirectory() as tmpdir:
+                open(os.path.join(tmpdir, 'foo.' + lang), 'w').write('int main() {}')
+                self._run(meson_command + ['init', '-b'], workdir=tmpdir)
 
     # The test uses mocking and thus requires that
     # the current process is the one to run the Meson steps.


### PR DESCRIPTION
This adds the possibility to generate a meson.build file completely automagically for the simple case of a single C or C++ executable. You might get things to build just by saying "meson init -b".

Since this is my first contribution, feedback is very welcome.

(The previous pull request https://github.com/mesonbuild/meson/pull/3146 was from the wrong branch, this should be better.)
