### PR TITLE
Fix OSX CI with current homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ matrix:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew uninstall python mercurial; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python@2 python@3 mercurial; fi
   # Use a Ninja with QuLogic's patch: https://github.com/ninja-build/ninja/issues/1219
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir -p $HOME/tools; curl -L http://nirbheek.in/files/binaries/ninja/macos/ninja -o $HOME/tools/ninja; chmod +x $HOME/tools/ninja; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker pull jpakkane/mesonci:artful; fi


### PR DESCRIPTION
Since [1], python3 is now an alias for python, so installing it, rather than
upgrading it, will fail.

It also seems that homebrew can't do this upgrade without breaking python2, so
uninstall and reinstall python2 (and mercurial which depends on it) to work
around that problem.

[1] https://brew.sh/2018/01/19/homebrew-1.5.0/