### PR TITLE
Enable linux-like unit tests on all posix-like platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew uninstall python mercurial; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python@2 python@3 mercurial; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python@2 python@3 mercurial qt; fi
   # Use a Ninja with QuLogic's patch: https://github.com/ninja-build/ninja/issues/1219
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir -p $HOME/tools; curl -L http://nirbheek.in/files/binaries/ninja/macos/ninja -o $HOME/tools/ninja; chmod +x $HOME/tools/ninja; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker pull jpakkane/mesonci:artful; fi
@@ -50,4 +50,4 @@ script:
         withgit \
           /bin/sh -c "cd /root && mkdir -p tools; wget -c http://nirbheek.in/files/binaries/ninja/linux-amd64/ninja -O /root/tools/ninja; chmod +x /root/tools/ninja; CC=$CC CXX=$CXX OBJC=$CC OBJCXX=$CXX PATH=/root/tools:$PATH MESON_FIXED_NINJA=1 ./run_tests.py -- $MESON_ARGS && chmod -R a+rwX .coverage"
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) CPPFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib OBJC=$CC OBJCXX=$CXX PATH=$HOME/tools:$PATH MESON_FIXED_NINJA=1 ./run_tests.py --backend=ninja -- $MESON_ARGS ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) CPPFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib OBJC=$CC OBJCXX=$CXX PATH=$HOME/tools:/usr/local/opt/qt/bin:$PATH MESON_FIXED_NINJA=1 ./run_tests.py --backend=ninja -- $MESON_ARGS ; fi

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -320,10 +320,15 @@ class QtBaseDependency(ExternalDependency):
 
     def _framework_detect(self, qvars, modules, kwargs):
         libdir = qvars['QT_INSTALL_LIBS']
+
+        # ExtraFrameworkDependency doesn't support any methods
+        fw_kwargs = kwargs.copy()
+        fw_kwargs.pop('method', None)
+
         for m in modules:
             fname = 'Qt' + m
             fwdep = ExtraFrameworkDependency(fname, False, libdir, self.env,
-                                             self.language, kwargs)
+                                             self.language, fw_kwargs)
             self.compile_args.append('-F' + libdir)
             if fwdep.found():
                 self.compile_args += fwdep.get_compile_args()

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -281,7 +281,8 @@ class QtBaseDependency(ExternalDependency):
             (k, v) = tuple(line.split(':', 1))
             qvars[k] = v
         if mesonlib.is_osx():
-            return self._framework_detect(qvars, mods, kwargs)
+            self._framework_detect(qvars, mods, kwargs)
+            return qmake
         incdir = qvars['QT_INSTALL_HEADERS']
         self.compile_args.append('-I' + incdir)
         libdir = qvars['QT_INSTALL_LIBS']

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -325,9 +325,12 @@ class QtBaseDependency(ExternalDependency):
                                              self.language, kwargs)
             self.compile_args.append('-F' + libdir)
             if fwdep.found():
-                self.is_found = True
                 self.compile_args += fwdep.get_compile_args()
                 self.link_args += fwdep.get_link_args()
+            else:
+                break
+        else:
+            self.is_found = True
         # Used by self.compilers_detect()
         self.bindir = self.get_qmake_host_bins(qvars)
 

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -23,7 +23,7 @@ from collections import OrderedDict
 from .. import mlog
 from .. import mesonlib
 from ..mesonlib import (
-    MesonException, Popen_safe, extract_as_list, for_windows,
+    MesonException, Popen_safe, extract_as_list, for_windows, for_cygwin,
     version_compare_many
 )
 from ..environment import detect_cpu
@@ -285,6 +285,10 @@ class QtBaseDependency(ExternalDependency):
         incdir = qvars['QT_INSTALL_HEADERS']
         self.compile_args.append('-I' + incdir)
         libdir = qvars['QT_INSTALL_LIBS']
+        if for_cygwin(self.env.is_cross_build(), self.env):
+            shlibext = '.dll.a'
+        else:
+            shlibext = '.so'
         # Used by self.compilers_detect()
         self.bindir = self.get_qmake_host_bins(qvars)
         self.is_found = True
@@ -306,7 +310,7 @@ class QtBaseDependency(ExternalDependency):
                         self.is_found = False
                         break
             else:
-                libfile = os.path.join(libdir, 'lib{}{}.so'.format(self.qtpkgname, module))
+                libfile = os.path.join(libdir, 'lib{}{}{}'.format(self.qtpkgname, module, shlibext))
                 if not os.path.isfile(libfile):
                     self.is_found = False
                     break

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -35,7 +35,7 @@ import mesonbuild.coredata
 import mesonbuild.modules.gnome
 from mesonbuild.interpreter import ObjectHolder
 from mesonbuild.mesonlib import (
-    is_linux, is_windows, is_osx, is_cygwin, is_dragonflybsd,
+    is_windows, is_osx, is_cygwin, is_dragonflybsd,
     windows_proof_rmtree, python_command, meson_command, version_compare,
 )
 from mesonbuild.environment import Environment, detect_ninja
@@ -49,6 +49,9 @@ from run_tests import should_run_linux_cross_tests
 
 
 def get_dynamic_section_entry(fname, entry):
+    if is_cygwin() or is_osx():
+            raise unittest.SkipTest('Test only applicable to ELF platforms')
+
     try:
         raw_out = subprocess.check_output(['readelf', '-d', fname],
                                           universal_newlines=True)
@@ -526,6 +529,8 @@ class BasePlatformTests(unittest.TestCase):
         if inprocess:
             try:
                 (returncode, out, err) = run_configure(self.meson_mainfile, self.meson_args + args + extra_args)
+                if 'MESON_SKIP_TEST' in out:
+                    raise unittest.SkipTest('Project requested skipping.')
                 if returncode != 0:
                     self._print_meson_log()
                     print('Stdout:\n')
@@ -2135,6 +2140,9 @@ class LinuxlikeTests(BasePlatformTests):
         is true and not when it is false. This can't be an ordinary test case
         because we need to inspect the compiler database.
         '''
+        if is_cygwin() or is_osx():
+            raise unittest.SkipTest('PIC not relevant')
+
         testdir = os.path.join(self.common_test_dir, '3 static')
         self.init(testdir)
         compdb = self.get_compdb()
@@ -2214,6 +2222,8 @@ class LinuxlikeTests(BasePlatformTests):
         database.
         https://github.com/mesonbuild/meson/issues/864
         '''
+        if not shutil.which('valac'):
+            raise unittest.SkipTest('valac not installed.')
         testdir = os.path.join(self.vala_test_dir, '5 target glib')
         self.init(testdir)
         compdb = self.get_compdb()
@@ -2283,6 +2293,9 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertTrue(msg in mesonlog or msg2 in mesonlog)
 
     def _test_soname_impl(self, libpath, install):
+        if is_cygwin() or is_osx:
+            raise unittest.SkipTest('Test only applicable to ELF and linuxlike sonames')
+
         testdir = os.path.join(self.unit_test_dir, '1 soname')
         self.init(testdir)
         self.build()
@@ -2356,7 +2369,9 @@ class LinuxlikeTests(BasePlatformTests):
         # Check that all the listed -std=xxx options for this compiler work
         # just fine when used
         for v in compiler.get_options()[lang_std].choices:
-            if compiler.get_id() == 'clang' and version_compare(compiler.version, '<5.0.0') and '17' in v:
+            if (compiler.get_id() == 'clang' and '17' in v and
+                (version_compare(compiler.version, '<5.0.0') or
+                 (compiler.clang_type == mesonbuild.compilers.CLANG_OSX and version_compare(compiler.version, '<9.2')))):
                 continue
             std_opt = '{}={}'.format(lang_std, v)
             self.init(testdir, ['-D' + std_opt])
@@ -2489,6 +2504,9 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertNotIn('-Werror', c03_comp)
 
     def test_run_installed(self):
+        if is_cygwin() or is_osx():
+            raise unittest.SkipTest('LD_LIBRARY_PATH and RPATH not applicable')
+
         testdir = os.path.join(self.unit_test_dir, '7 run installed')
         self.init(testdir)
         self.build()
@@ -2558,6 +2576,8 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertTrue(gobject_found)
 
     def test_build_rpath(self):
+        if is_cygwin():
+            raise unittest.SkipTest('Windows PE/COFF binaries do not use RPATH')
         testdir = os.path.join(self.unit_test_dir, '11 build_rpath')
         self.init(testdir)
         self.build()
@@ -2575,6 +2595,9 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertEqual(install_rpath, 'baz')
 
     def test_pch_with_address_sanitizer(self):
+        if is_cygwin():
+            raise unittest.SkipTest('asan not available on Cygwin')
+
         testdir = os.path.join(self.common_test_dir, '13 pch')
         self.init(testdir, ['-Db_sanitize=address'])
         self.build()
@@ -2627,6 +2650,9 @@ endian = 'little'
         Test that valac outputs generated C files in the expected location when
         the builddir is a subdir of the source tree.
         '''
+        if not shutil.which('valac'):
+            raise unittest.SkipTest('valac not installed.')
+
         testdir = os.path.join(self.vala_test_dir, '8 generated sources')
         newdir = os.path.join(self.builddir, 'srctree')
         shutil.copytree(testdir, newdir)
@@ -2750,7 +2776,7 @@ def unset_envs():
 if __name__ == '__main__':
     unset_envs()
     cases = ['InternalTests', 'AllPlatformTests', 'FailureTests']
-    if is_linux():
+    if not is_windows():
         cases += ['LinuxlikeTests']
         if should_run_linux_cross_tests():
             cases += ['LinuxArmCrossCompileTests']

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2270,11 +2270,8 @@ class LinuxlikeTests(BasePlatformTests):
         if not shutil.which('qmake-qt5'):
             if not shutil.which('qmake'):
                 raise unittest.SkipTest('QMake not found')
-            # For some inexplicable reason qmake --version gives different
-            # results when run from the command line vs invoked by Python.
-            # Check for both cases in case this behavior changes in the future.
-            output = subprocess.getoutput(['qmake', '--version'])
-            if 'Qt version 5' not in output and 'qt5' not in output:
+            output = subprocess.getoutput('qmake --version')
+            if 'Qt version 5' not in output:
                 raise unittest.SkipTest('Qmake found, but it is not for Qt 5.')
         # Disable pkg-config codepath and force searching with qmake/qmake-qt5
         testdir = os.path.join(self.framework_test_dir, '4 qt')


### PR DESCRIPTION
Enable linux-like unit tests on all posix-like platforms

This reveals a few problems with `dependency('qt4|5', method: 'qmake')` on osx and cygwin, so fix those as well.