### PR TITLE
Multiple outputs fixes

### DIFF
--- a/docs/markdown/Generating-sources.md
+++ b/docs/markdown/Generating-sources.md
@@ -67,7 +67,7 @@ Generators can also generate multiple output files with unknown names:
 
 ```meson
 gen2 = generator(someprog,
-                 outputs : ['@BASENAME@.c', '@BASENAME@.h'],
+                 output : ['@BASENAME@.c', '@BASENAME@.h'],
                  arguments : ['--out_dir=@BUILD_DIR@', '@INPUT@'])
 ```
 

--- a/test cases/common/118 multiple outputs/converter.py
+++ b/test cases/common/118 multiple outputs/converter.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import sys
+
+basename = sys.argv[1]
+open("{}.cpp".format(basename)).write("""
+#include<stdio.h>
+
+int main(int argc, char **argv) {
+  printf("I was made from {0}.\n");
+  return 0;
+}
+""".format(basename))
+
+open("{}.h".format(basename)).write("""
+int main(int argc, char **argv);
+""")

--- a/test cases/common/118 multiple outputs/foobar.cfg
+++ b/test cases/common/118 multiple outputs/foobar.cfg
@@ -1,0 +1,1 @@
+name = main

--- a/test cases/common/118 multiple outputs/meson.build
+++ b/test cases/common/118 multiple outputs/meson.build
@@ -1,0 +1,12 @@
+# Must have two languages here to exercise linker language
+# selection bug
+project('all sources generated', 'c', 'cpp')
+
+comp = find_program('converter.py')
+
+g = generator(comp,
+  outputs : ['@BASENAME@.h', '@BASENAME@.cpp'],
+  arguments : ['@INPUT@'])
+
+c = g.process('foobar.cfg')
+prog = executable('genexe', c)

--- a/test cases/common/118 multiple outputs/meson.build
+++ b/test cases/common/118 multiple outputs/meson.build
@@ -5,7 +5,7 @@ project('all sources generated', 'c', 'cpp')
 comp = find_program('converter.py')
 
 g = generator(comp,
-  outputs : ['@BASENAME@.h', '@BASENAME@.cpp'],
+  output : ['@BASENAME@.h', '@BASENAME@.cpp'],
   arguments : ['@INPUT@'])
 
 c = g.process('foobar.cfg')


### PR DESCRIPTION
 * Fix the `outputs` reference [Generating-sources.md](https://github.com/mesonbuild/meson/compare/master...mithro:multiple-outputs?expand=1#diff-43e1d028fe3f15becd6c359768d2850f).
 * Adding a simple multiple output arguments generator test.