### PR TITLE
Test case which demonstrates Issue #3169

### DIFF
--- a/test cases/common/100 print null/meson.build
+++ b/test cases/common/100 print null/meson.build
@@ -1,0 +1,9 @@
+project('100 print null')
+
+find_file_list = run_command(find_program('find'), '-type', 'f', '-print0')
+assert(find_file_list.returncode() == 0, 'Didn\'t find any files.')
+
+found_files = []
+foreach l : find_file_list.stdout().split('\0')
+	found_files += [files([l])]
+endforeach


### PR DESCRIPTION
This test case demonstrates the issue in #3169

> On Linux you can have some *super* weird characters in your paths -- include newlines. This means the only safe character you can use is the null terminator.
> 
> find and xarg provide tools for doing this;
> * From the find man page;
> ```
>        -print0
>               True;  print  the  full  file  name on the standard output, followed by a null character
>               (instead of the newline character that -print uses).  This allows file names  that  con‐
>               tain newlines or other types of white space to be correctly interpreted by programs that
>               process the find output.  This option corresponds to the -0 option of xargs.
> ```
> 
> * From the xargs man page;
> ```
>        -0, --null
>               Input  items are terminated by a null character instead of by whitespace, and the quotes
>               and backslash are not special (every character is taken literally).  Disables the end of
>               file  string,  which  is treated like any other argument.  Useful when input items might
>               contain white space, quote marks, or backslashes.  The GNU find -print0 option  produces
>               input suitable for this mode.
> ```
> 
> However, when you try and to this with meson using the following;
> ```meson
> project('100 print null')
> 
> find_file_list = run_command(find_program('find'), '-type', 'f', '-print0')
> assert(find_file_list.returncode() == 0, 'Didn\'t find any files.')
> 
> found_files = []
> foreach l : find_file_list.stdout().split('\0')
> 	found_files += [files([l])]
> endforeach
> ```
> you get the following error;
> ```
> tansell@tansell:~/github/mesonbuild/meson/test cases/common/100 print null$ meson build .
> The Meson build system
> Version: 0.45.0.dev1
> Source dir: XXXX/github/mesonbuild/meson/test cases/common/100 print null
> Build dir: XXXX/github/mesonbuild/meson/test cases/common/100 print null/build
> Build type: native build
> Project name: 100 print null
> Build machine cpu family: x86_64
> Build machine cpu: x86_64
> Program find found: YES (/usr/bin/find)
> Traceback (most recent call last):
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/mesonmain.py", line
> 363, in run
>     app.generate()
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/mesonmain.py", line
> 150, in generate
>     self._generate(env)
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/mesonmain.py", line
> 197, in _generate
>     intr.run()
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreter.py", line 2992, in run
>     super().run()
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 173, in run
>     self.evaluate_codeblock(self.ast, start=1)
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 195, in evaluate_codeblock
>     raise e
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 189, in evaluate_codeblock
>     self.evaluate_statement(cur)
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 230, in evaluate_statement
>     return self.evaluate_foreach(cur)
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 404, in evaluate_foreach
>     self.evaluate_codeblock(node.block)
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 195, in evaluate_codeblock
>     raise e
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 189, in evaluate_codeblock
>     self.evaluate_statement(cur)
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 232, in evaluate_statement
>     return self.evaluate_plusassign(cur)
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 409, in evaluate_plusassign
>     addition = self.evaluate_statement(node.value)
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 216, in evaluate_statement
>     return self.evaluate_arraystatement(cur)
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 243, in evaluate_arraystatement
>     (arguments, kwargs) = self.reduce_arguments(cur.args)
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 640, in reduce_arguments
>     reduced_pos = [self.evaluate_statement(arg) for arg in args.arguments]
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 640, in <listcomp>
>     reduced_pos = [self.evaluate_statement(arg) for arg in args.arguments]
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 200, in evaluate_statement
>     return self.function_call(cur)
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 456, in function_call
>     return self.funcs[func_name](node, self.flatten(posargs), kwargs)
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 55, in wrapped
>     return f(self, node, args, kwargs)
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreterbase.py", line 47, in wrapped
>     return f(self, node, args, kwargs)
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreter.py", line 1614, in func_files
>     return [mesonlib.File.from_source_file(self.environment.source_dir, self.subdir, fname) for fname in
> args]
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/interpreter.py", line 1614, in <listcomp>
>     return [mesonlib.File.from_source_file(self.environment.source_dir, self.subdir, fname) for fname in
> args]
>   File "XXXX/.local/lib/python3.5/site-packages/mesonbuild/mesonlib.py", line 230, in from_source_file
>     if not os.path.isfile(os.path.join(source_root, subdir, fname)):
>   File "/usr/lib/python3.5/genericpath.py", line 30, in isfile
>     st = os.stat(path)
> ValueError: embedded null byte
> ```