### PR TITLE
mconf: re-implement print_aligned fixes #3149

### DIFF
--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -233,8 +233,7 @@ class Conf:
                     # Zero length list or string
                     choices = ''
                 else:
-                    # A non zero length list or string, convert to string
-                    choices = str(opt.choices)
+                    choices = opt.choices
                 optarr.append({'name': key,
                                'descr': opt.description,
                                'value': opt.value,

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -138,22 +138,20 @@ class Conf:
                          'value': self.coredata.get_builtin_option(key),
                          'choices': coredata.get_builtin_option_choices(key)})
         self.print_aligned(carr)
-        bekeys = sorted(self.coredata.backend_options)
-        if not bekeys:
+        if not self.coredata.backend_options:
             print('  No backend options\n')
         else:
             bearr = []
-            for k in bekeys:
+            for k in sorted(self.coredata.backend_options):
                 o = self.coredata.backend_options[k]
                 bearr.append({'name': k, 'descr': o.description, 'value': o.value, 'choices': ''})
             self.print_aligned(bearr)
         print('\nBase options:')
-        okeys = sorted(self.coredata.base_options)
-        if not okeys:
+        if not self.coredata.base_options:
             print('  No base options\n')
         else:
             coarr = []
-            for k in okeys:
+            for k in sorted(self.coredata.base_options):
                 o = self.coredata.base_options[k]
                 coarr.append({'name': k, 'descr': o.description, 'value': o.value, 'choices': o.choices})
             self.print_aligned(coarr)
@@ -164,12 +162,11 @@ class Conf:
         for (lang, args) in self.coredata.external_link_args.items():
             print('  ' + lang + '_link_args', str(args))
         print('\nCompiler options:')
-        okeys = sorted(self.coredata.compiler_options)
-        if not okeys:
+        if not self.coredata.compiler_options:
             print('  No compiler options\n')
         else:
             coarr = []
-            for k in okeys:
+            for k in self.coredata.compiler_options:
                 o = self.coredata.compiler_options[k]
                 coarr.append({'name': k, 'descr': o.description, 'value': o.value, 'choices': ''})
             self.print_aligned(coarr)
@@ -198,11 +195,9 @@ class Conf:
         if not self.coredata.user_options:
             print('  This project does not have any options')
         else:
-            options = self.coredata.user_options
-            keys = sorted(options)
             optarr = []
-            for key in keys:
-                opt = options[key]
+            for key in sorted(self.coredata.user_options):
+                opt = self.coredata.user_options[key]
                 if (opt.choices is None) or (not opt.choices):
                     # Zero length list or string
                     choices = ''

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -140,7 +140,7 @@ class Conf:
                          'choices': coredata.get_builtin_option_choices(key)})
         self.print_aligned(carr)
         print('')
-        bekeys = sorted(self.coredata.backend_options.keys())
+        bekeys = sorted(self.coredata.backend_options)
         if not bekeys:
             print('  No backend options\n')
         else:
@@ -151,7 +151,7 @@ class Conf:
             self.print_aligned(bearr)
         print('')
         print('Base options:')
-        okeys = sorted(self.coredata.base_options.keys())
+        okeys = sorted(self.coredata.base_options)
         if not okeys:
             print('  No base options\n')
         else:
@@ -170,7 +170,7 @@ class Conf:
             print('  ' + lang + '_link_args', str(args))
         print('')
         print('Compiler options:')
-        okeys = sorted(self.coredata.compiler_options.keys())
+        okeys = sorted(self.coredata.compiler_options)
         if not okeys:
             print('  No compiler options\n')
         else:
@@ -207,8 +207,7 @@ class Conf:
             print('  This project does not have any options')
         else:
             options = self.coredata.user_options
-            keys = list(options.keys())
-            keys.sort()
+            keys = sorted(options)
             optarr = []
             for key in keys:
                 opt = options[key]

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -45,7 +45,8 @@ class Conf:
         # are erased when Meson is executed the next time, i.e. when
         # Ninja is run.
 
-    def print_aligned(self, arr):
+    @staticmethod
+    def print_aligned(arr):
         def make_lower_case(val):
             if isinstance(val, bool):
                 return str(val).lower()

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -130,8 +130,7 @@ class Conf:
         print('Core properties:')
         print('  Source dir', self.build.environment.source_dir)
         print('  Build dir ', self.build.environment.build_dir)
-        print('')
-        print('Core options:')
+        print('\nCore options:\n')
         carr = []
         for key in ['buildtype', 'warning_level', 'werror', 'strip', 'unity', 'default_library']:
             carr.append({'name': key,
@@ -139,7 +138,6 @@ class Conf:
                          'value': self.coredata.get_builtin_option(key),
                          'choices': coredata.get_builtin_option_choices(key)})
         self.print_aligned(carr)
-        print('')
         bekeys = sorted(self.coredata.backend_options)
         if not bekeys:
             print('  No backend options\n')
@@ -149,8 +147,7 @@ class Conf:
                 o = self.coredata.backend_options[k]
                 bearr.append({'name': k, 'descr': o.description, 'value': o.value, 'choices': ''})
             self.print_aligned(bearr)
-        print('')
-        print('Base options:')
+        print('\nBase options:')
         okeys = sorted(self.coredata.base_options)
         if not okeys:
             print('  No base options\n')
@@ -160,16 +157,13 @@ class Conf:
                 o = self.coredata.base_options[k]
                 coarr.append({'name': k, 'descr': o.description, 'value': o.value, 'choices': o.choices})
             self.print_aligned(coarr)
-        print('')
-        print('Compiler arguments:')
+        print('\nCompiler arguments:')
         for (lang, args) in self.coredata.external_args.items():
             print('  ' + lang + '_args', str(args))
-        print('')
-        print('Linker args:')
+        print('\nLinker args:')
         for (lang, args) in self.coredata.external_link_args.items():
             print('  ' + lang + '_link_args', str(args))
-        print('')
-        print('Compiler options:')
+        print('\nCompiler options:')
         okeys = sorted(self.coredata.compiler_options)
         if not okeys:
             print('  No compiler options\n')
@@ -179,8 +173,7 @@ class Conf:
                 o = self.coredata.compiler_options[k]
                 coarr.append({'name': k, 'descr': o.description, 'value': o.value, 'choices': ''})
             self.print_aligned(coarr)
-        print('')
-        print('Directories:')
+        print('\nDirectories:')
         parr = []
         for key in ['prefix',
                     'libdir',
@@ -201,8 +194,7 @@ class Conf:
                          'value': self.coredata.get_builtin_option(key),
                          'choices': coredata.get_builtin_option_choices(key)})
         self.print_aligned(parr)
-        print('')
-        print('Project options:')
+        print('\nProject options:')
         if not self.coredata.user_options:
             print('  This project does not have any options')
         else:
@@ -221,8 +213,7 @@ class Conf:
                                'value': opt.value,
                                'choices': choices})
             self.print_aligned(optarr)
-        print('')
-        print('Testing options:')
+        print('\nTesting options:')
         tarr = []
         for key in ['stdsplit', 'errorlogs']:
             tarr.append({'name': key,

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, os
+import os
+import sys
 import argparse
-from . import coredata, mesonlib, build
+from . import (coredata, mesonlib, build)
 
 parser = argparse.ArgumentParser(prog='meson configure')
 
@@ -24,8 +25,10 @@ parser.add_argument('directory', nargs='*')
 parser.add_argument('--clearcache', action='store_true', default=False,
                     help='Clear cached state (e.g. found dependencies)')
 
+
 class ConfException(mesonlib.MesonException):
     pass
+
 
 class Conf:
     def __init__(self, build_dir):
@@ -218,6 +221,7 @@ class Conf:
                          'choices': coredata.get_builtin_option_choices(key)})
         self.print_aligned(tarr)
 
+
 def run(args):
     args = mesonlib.expand_arguments(args)
     if not args:
@@ -249,6 +253,7 @@ def run(args):
         print(e)
         return 1
     return 0
+
 
 if __name__ == '__main__':
     sys.exit(run(sys.argv[1:]))


### PR DESCRIPTION
Reading the code I came to the conclusion that only boolean values are made lower case and the new code reflects this. I can't think of other values but please do let me know if there are.

Now all array options with string in them retain their case properly.

edit: Added several cleanups, pep8. Can split this off into another PR if needed.