### PR TITLE
Fix a syntax error in an example in 'Generating sources'.

### DIFF
--- a/docs/markdown/Generating-sources.md
+++ b/docs/markdown/Generating-sources.md
@@ -127,7 +127,7 @@ argument list as separate elements.
 gen3 = generator(genprog,
                  output : '@BASENAME@.cc',
                  arguments : ['@INPUT@', '@EXTRA_ARGS@', '@OUTPUT@'])
-gen3_src1 = gen3.process('input1.y)
+gen3_src1 = gen3.process('input1.y')
 gen3_src2 = gen3.process('input2.y', extra_args: '--foo')
 gen3_src3 = gen3.process('input3.y', extra_args: ['--foo', '--bar'])
 ```


### PR DESCRIPTION
There was a syntax error in the example I have submitted in my previous PR. This fixes it.
I have only noticed it now, when I saw it deployed on the website, with syntax highlighting.