### PR TITLE
setup.py: set the python_requires field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,9 @@ import sys
 
 from mesonbuild.coredata import version
 
-if sys.version_info[0] < 3:
-    print('Tried to install with Python 2, Meson only supports Python 3.')
+if sys.version_info < (3, 5, 0):
+    print('Tried to install with an unsupported version of Python. '
+          'Meson requires Python 3.5.0 or greater')
     sys.exit(1)
 
 # We need to support Python installations that have nothing but the basic
@@ -62,6 +63,7 @@ setup(name='meson',
       author_email='jpakkane@gmail.com',
       url='http://mesonbuild.com',
       license=' Apache License, Version 2.0',
+      python_requires='>=3.5',
       packages=['mesonbuild',
                 'mesonbuild.backend',
                 'mesonbuild.compilers',


### PR DESCRIPTION
This instructs tools like pip that meson requires python 3.5 or greater,
so if one tries to install on an older version pip will fall back to an
older version of meson.

This won't fix 0.45 since it's already in the wild (unless someone wants
to delete and re-upload the version on pypi). But it should fix future
versions.