### PR TITLE
gtkdoc: ignore SameFileError

### DIFF
--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -92,8 +92,11 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
     # Copy files to build directory
     for f in content_files:
         f_abs = os.path.join(doc_src, f)
-        shutil.copyfile(f_abs, os.path.join(
-            abs_out, os.path.basename(f_abs)))
+        try:
+            shutil.copyfile(f_abs, os.path.join(
+                abs_out, os.path.basename(f_abs)))
+        except shutil.SameFileError:
+            pass
 
     shutil.rmtree(htmldir, ignore_errors=True)
     try:


### PR DESCRIPTION
When using the new support for generated content files it can happen
that the generated file is already in the right place (because due to
past hacks going back to automake based gtkdoc that was the way the
project made it all work). Instead of failing we can just ignore that
error.

Yes I know the unit test is missing. I'm a python-illiterate person, so I wanted to see whether I'm on the right track first before spending tons of time trying to figure out how to add a unit test for this issue. Once that's settled I can try typing the unit test and revise the pull request.