### PR TITLE
Get generated headers from link_whole_targets as meson does for link_targets

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -14,6 +14,7 @@
 
 import os, pickle, re, shlex, subprocess
 from collections import OrderedDict
+import itertools
 from pathlib import PurePath
 
 from . import backends
@@ -263,7 +264,7 @@ int dummy;
             vala_header = File.from_built_file(self.get_target_dir(target), target.vala_header)
             header_deps.append(vala_header)
         # Recurse and find generated headers
-        for dep in target.link_targets:
+        for dep in itertools.chain(target.link_targets, target.link_whole_targets):
             if isinstance(dep, (build.StaticLibrary, build.SharedLibrary)):
                 header_deps += self.get_generated_headers(dep)
         return header_deps

--- a/test cases/common/180 generator link whole/export.h
+++ b/test cases/common/180 generator link whole/export.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#if defined BUILDING_EMBEDDED
+  #define DLL_PUBLIC
+#elif defined _WIN32 || defined __CYGWIN__
+  #if defined BUILDING_DLL
+    #define DLL_PUBLIC __declspec(dllexport)
+  #else
+    #define DLL_PUBLIC __declspec(dllimport)
+  #endif
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif

--- a/test cases/common/180 generator link whole/generator.py
+++ b/test cases/common/180 generator link whole/generator.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import os
+import os.path
+import sys
+
+
+def main():
+    name = os.path.splitext(os.path.basename(sys.argv[1]))[0]
+    out = sys.argv[2]
+    hname = os.path.join(out, name + '.h')
+    cname = os.path.join(out, name + '.c')
+    print(os.getcwd(), hname)
+    with open(hname, 'w') as hfile:
+        hfile.write('''
+#pragma once
+#include "export.h"
+int DLL_PUBLIC {name}();
+'''.format(name=name))
+    with open(cname, 'w') as cfile:
+        cfile.write('''
+#include "{name}.h"
+int {name}() {{
+    return {size};
+}}
+'''.format(name=name, size=len(name)))
+
+
+if __name__ == '__main__':
+    main()

--- a/test cases/common/180 generator link whole/main.c
+++ b/test cases/common/180 generator link whole/main.c
@@ -1,0 +1,11 @@
+#include "meson_test_function.h"
+
+#include <stdio.h>
+
+int main() {
+    if (meson_test_function() != 19) {
+        printf("Bad meson_test_function()\n");
+        return 1;
+    }
+    return 0;
+}

--- a/test cases/common/180 generator link whole/meson.build
+++ b/test cases/common/180 generator link whole/meson.build
@@ -1,5 +1,12 @@
 project('generator link_whole', 'c')
 
+cc = meson.get_compiler('c')
+if cc.get_id() == 'msvc'
+  if cc.version().version_compare('<19')
+    error('MESON_SKIP_TEST link_whole only works on VS2015 or newer.')
+  endif
+endif
+
 # This just generates foo.h and foo.c with int foo() defined.
 gen_py = find_program('generator.py')
 gen = generator(gen_py,

--- a/test cases/common/180 generator link whole/meson.build
+++ b/test cases/common/180 generator link whole/meson.build
@@ -1,0 +1,58 @@
+project('generator link_whole', 'c')
+
+# This just generates foo.h and foo.c with int foo() defined.
+gen_py = find_program('generator.py')
+gen = generator(gen_py,
+  output: ['@BASENAME@.h', '@BASENAME@.c'],
+  arguments : ['@INPUT@', '@BUILD_DIR@'])
+
+# Test 1: link directly into executable
+srcs = gen.process('meson_test_function.tmpl')
+exe = executable('exe1', [srcs, 'main.c'], c_args : '-DBUILDING_EMBEDDED')
+test('test1', exe)
+
+# Test 2: link into shared library and access from executable
+srcs = gen.process('meson_test_function.tmpl')
+shlib2 = shared_library('shlib2', [srcs], c_args : '-DBUILDING_DLL')
+exe = executable('exe2', 'main.c',
+  link_with : shlib2,
+  include_directories : shlib2.private_dir_include(),
+)
+test('test2', exe)
+
+# Test 3: link into static library and access from executable
+srcs = gen.process('meson_test_function.tmpl')
+stlib3 = static_library('stlib3', [srcs], c_args : '-DBUILDING_EMBEDDED')
+exe = executable('exe3', 'main.c',
+  c_args : '-DBUILDING_EMBEDDED',
+  link_with : stlib3,
+  include_directories : stlib3.private_dir_include(),
+)
+test('test3', exe)
+
+# Test 4: link into static library, link into shared
+# and access from executable. To make sure static_library
+# is not dropped use pull_meson_test_function helper.
+srcs = gen.process('meson_test_function.tmpl')
+stlib4 = static_library('stlib4', [srcs], c_args : '-DBUILDING_DLL')
+shlib4 = shared_library('shlib4', 'pull_meson_test_function.c',
+  c_args : '-DBUILDING_DLL',
+  link_with : stlib4,
+  include_directories : stlib4.private_dir_include(),
+)
+exe = executable('exe4', 'main.c',
+  link_with : shlib4,
+  include_directories : stlib4.private_dir_include(),
+)
+test('test4', exe)
+
+# Test 5: link into static library, link_whole into shared
+# and access from executable
+srcs = gen.process('meson_test_function.tmpl')
+stlib5 = static_library('stlib5', [srcs], c_args : '-DBUILDING_DLL')
+shlib5 = shared_library('shlib5', link_whole : stlib5)
+exe = executable('exe5', 'main.c',
+  link_with : shlib5,
+  include_directories : stlib5.private_dir_include(),
+)
+test('test5', exe)

--- a/test cases/common/180 generator link whole/pull_meson_test_function.c
+++ b/test cases/common/180 generator link whole/pull_meson_test_function.c
@@ -1,0 +1,6 @@
+#include "export.h"
+#include "meson_test_function.h"
+
+int DLL_PUBLIC function_puller() {
+    return meson_test_function();
+}


### PR DESCRIPTION
This test covers usage of generated files in static_library that is later linked into shared_library.
This test is flaky because dependencies are not set correctly. Tests are not robust because the only way I found to trigger this reliably is building with `-j20`. But it randomly fails at least in specific test case so it might be good enough.

5th test is what actually fails, all the rest is just a verification that something very similar works fine.
I copied `build.ninja` below, the difference between 4th and 5th tests is that I replaced `link_with` with `link_whole`, and dependency on header file disappeared. Since header file is created by generator and dependency does not exist, ninja will not necessary execute generator before trying to compile `main.c.o`, and this will manifest in missing `meson_test_function.h`. Note that `-j20` is helpful because it forces ninja to execute everything at the same time. I did not figure out robust way to write a test for meson, but since it is naturally flaky it randomly fails in CI. Example is below:

```text
$ ninja -vC build -j20
ninja: Entering directory `build'
[1/30] cc  -Iexe5@exe -I. -I.. -Istlib5@sta -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -g -MD -MQ 'exe5@exe/main.c.o' -MF 'exe5@exe/main.c.o.d' -o 'exe5@exe/main.c.o' -c ../main.c
FAILED: exe5@exe/main.c.o
cc  -Iexe5@exe -I. -I.. -Istlib5@sta -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -g -MD -MQ 'exe5@exe/main.c.o' -MF 'exe5@exe/main.c.o.d' -o 'exe5@exe/main.c.o' -c ../main.c
../main.c:1:10: fatal error: meson_test_function.h: No such file or directory
 #include "meson_test_function.h"
          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
[2/30] '/home/$USER/meson/test cases/common/180 generator link whole/generator.py' ../meson_test_function.tmpl exe1@exe
/home/$USER/meson/test cases/common/180 generator link whole/build exe1@exe/meson_test_function.h
[3/30] '/home/$USER/meson/test cases/common/180 generator link whole/generator.py' ../meson_test_function.tmpl shlib2@sha
/home/$USER/meson/test cases/common/180 generator link whole/build shlib2@sha/meson_test_function.h
[4/30] '/home/$USER/meson/test cases/common/180 generator link whole/generator.py' ../meson_test_function.tmpl stlib3@sta
/home/$USER/meson/test cases/common/180 generator link whole/build stlib3@sta/meson_test_function.h
[5/30] '/home/$USER/meson/test cases/common/180 generator link whole/generator.py' ../meson_test_function.tmpl stlib4@sta
/home/$USER/meson/test cases/common/180 generator link whole/build stlib4@sta/meson_test_function.h
[6/30] '/home/$USER/meson/test cases/common/180 generator link whole/generator.py' ../meson_test_function.tmpl stlib5@sta
/home/$USER/meson/test cases/common/180 generator link whole/build stlib5@sta/meson_test_function.h
ninja: build stopped: subcommand failed.
```

#### 4th test object file

```text
build exe4@exe/main.c.o: c_COMPILER ../main.c || stlib4@sta/meson_test_function.h
 DEPFILE = exe4@exe/main.c.o.d
 ARGS = -Iexe4@exe -I. -I.. -Istlib4@sta -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -g

```

#### 5th test object file

```text
build exe5@exe/main.c.o: c_COMPILER ../main.c
 DEPFILE = exe5@exe/main.c.o.d
 ARGS = -Iexe5@exe -I. -I.. -Istlib5@sta -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -g
```

#### Full output for 4th and 5th test

```text
build stlib4@sta/meson_test_function.h stlib4@sta/meson_test_function.c: CUSTOM_COMMAND ../meson_test_function.tmpl
 DESC = Generating$ ''.
 COMMAND = '/home/$USER/meson/test$ cases/common/180$ generator$ link$ whole/generator.py' ../meson_test_function.tmpl stlib4@sta

build stlib4@sta/meson-generated_meson_test_function.c.o: c_COMPILER stlib4@sta/meson_test_function.c | stlib4@sta/meson_test_function.h
 DEPFILE = stlib4@sta/meson-generated_meson_test_function.c.o.d
 ARGS = -Istlib4@sta -I. -I.. -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -g -fPIC -DBUILDING_DLL

build libstlib4.a: STATIC_LINKER stlib4@sta/meson-generated_meson_test_function.c.o
 LINK_ARGS = csrD

build shlib4@sha/pull_meson_test_function.c.o: c_COMPILER ../pull_meson_test_function.c || stlib4@sta/meson_test_function.h
 DEPFILE = shlib4@sha/pull_meson_test_function.c.o.d
 ARGS = -Ishlib4@sha -I. -I.. -Istlib4@sta -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -g -fPIC -DBUILDING_DLL

build shlib4@sha/libshlib4.so.symbols: SHSYM libshlib4.so

build libshlib4.so: c_LINKER shlib4@sha/pull_meson_test_function.c.o | libstlib4.a
 LINK_ARGS = -Wl,--no-undefined -Wl,--as-needed -shared -fPIC -Wl,--start-group -Wl,-soname,libshlib4.so libstlib4.a -Wl,--end-group

build exe4@exe/main.c.o: c_COMPILER ../main.c || stlib4@sta/meson_test_function.h
 DEPFILE = exe4@exe/main.c.o.d
 ARGS = -Iexe4@exe -I. -I.. -Istlib4@sta -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -g

build exe4: c_LINKER exe4@exe/main.c.o | shlib4@sha/libshlib4.so.symbols
 LINK_ARGS = -Wl,--no-undefined -Wl,--as-needed -Wl,--start-group libshlib4.so -Wl,--end-group '-Wl,-rpath,$$ORIGIN/' '-Wl,-rpath-link,/home/$USER/meson/test$ cases/common/180$ generator$ link$ whole/build/'

build stlib5@sta/meson_test_function.h stlib5@sta/meson_test_function.c: CUSTOM_COMMAND ../meson_test_function.tmpl
 DESC = Generating$ ''.
 COMMAND = '/home/$USER/meson/test$ cases/common/180$ generator$ link$ whole/generator.py' ../meson_test_function.tmpl stlib5@sta

build stlib5@sta/meson-generated_meson_test_function.c.o: c_COMPILER stlib5@sta/meson_test_function.c | stlib5@sta/meson_test_function.h
 DEPFILE = stlib5@sta/meson-generated_meson_test_function.c.o.d
 ARGS = -Istlib5@sta -I. -I.. -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -g -fPIC -DBUILDING_DLL

build libstlib5.a: STATIC_LINKER stlib5@sta/meson-generated_meson_test_function.c.o
 LINK_ARGS = csrD

build shlib5@sha/libshlib5.so.symbols: SHSYM libshlib5.so

build libshlib5.so: c_LINKER  | libstlib5.a
 LINK_ARGS = -Wl,--no-undefined -Wl,--as-needed -shared -fPIC -Wl,--start-group -Wl,-soname,libshlib5.so -Wl,--whole-archive libstlib5.a -Wl,--end-group -Wl,--no-whole-archive

build exe5@exe/main.c.o: c_COMPILER ../main.c
 DEPFILE = exe5@exe/main.c.o.d
 ARGS = -Iexe5@exe -I. -I.. -Istlib5@sta -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O0 -g

build exe5: c_LINKER exe5@exe/main.c.o | shlib5@sha/libshlib5.so.symbols
 LINK_ARGS = -Wl,--no-undefined -Wl,--as-needed -Wl,--start-group libshlib5.so -Wl,--end-group '-Wl,-rpath,$$ORIGIN/' '-Wl,-rpath-link,/home/$USER/meson/test$ cases/common/180$ generator$ link$ whole/build/'

```