### PR TITLE
Support data types larger than 128 bytes for cross-compilation

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1423,8 +1423,12 @@ the following methods:
   value of `dependency`. If the keyword argument `required` is false,
   Meson will proceed even if the library is not found. By default the
   library is searched for in the system library directory
-  (e.g. /usr/lib). This can be overridden with the `dirs` keyword
-  argument, which can be either a string or a list of strings.
+  (e.g. /usr/lib). If libraries are installed outside of the system
+  library directory, the `dependencies` keyword argument can be used
+  to look in additional directories. Furthermore, if it is known in
+  which directory the library is to be found, the list of search
+  directories can be overridden with the `dirs` keyword argument,
+  which can be either a string or a list of strings.
 
 - `first_supported_argument(list_of_strings)`, given a list of
   strings, returns the first argument that passes the `has_argument`

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -416,7 +416,7 @@ class CCompiler(Compiler):
         }}'''
         if not self.compiles(t.format(**fargs), env, extra_args, dependencies):
             return -1
-        return self.cross_compute_int('sizeof(%s)' % typename, 1, 128, None, prefix, env, extra_args, dependencies)
+        return self.cross_compute_int('sizeof(%s)' % typename, 1, 1024, None, prefix, env, extra_args, dependencies)
 
     def sizeof(self, typename, prefix, env, extra_args=None, dependencies=None):
         if extra_args is None:

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -766,7 +766,7 @@ class CCompiler(Compiler):
             raise AssertionError('BUG: unknown libtype {!r}'.format(libtype))
         return prefixes, suffixes
 
-    def find_library(self, libname, env, extra_dirs, libtype='default'):
+    def find_library(self, libname, env, dependencies, extra_dirs, libtype='default'):
         # These libraries are either built-in or invalid
         if libname in self.ignore_libs:
             return []
@@ -778,7 +778,7 @@ class CCompiler(Compiler):
         # Only try to find std libs if no extra dirs specified.
         if not extra_dirs and libtype == 'default':
             args = ['-l' + libname]
-            if self.links(code, env, extra_args=args):
+            if self.links(code, env, extra_args=args, dependencies=dependencies):
                 return args
         # Ensure that we won't modify the list that was passed to us
         extra_dirs = extra_dirs[:]

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -74,7 +74,7 @@ class ValaCompiler(Compiler):
             return ['--debug']
         return []
 
-    def find_library(self, libname, env, extra_dirs):
+    def find_library(self, libname, env, dependencies, extra_dirs):
         if extra_dirs and isinstance(extra_dirs, str):
             extra_dirs = [extra_dirs]
         # Valac always looks in the default vapi dir, so only search there if

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1147,7 +1147,8 @@ class CompilerHolder(InterpreterObject):
         for i in search_dirs:
             if not os.path.isabs(i):
                 raise InvalidCode('Search directory %s is not an absolute path.' % i)
-        linkargs = self.compiler.find_library(libname, self.environment, search_dirs)
+        deps = self.determine_dependencies(kwargs)
+        linkargs = self.compiler.find_library(libname, self.environment, deps, search_dirs)
         if required and not linkargs:
             raise InterpreterException('{} library {!r} not found'.format(self.compiler.get_display_language(), libname))
         lib = dependencies.ExternalLibrary(libname, linkargs, self.environment,


### PR DESCRIPTION
Recent versions of systemd fail to cross-compile using Meson because the cross-compile check for cc.sizeof() is limited to 128 bytes. systemd tries to check for the existence of struct statx which is 256 bytes on AArch64 and therefore fails. Note that it doesn't fail to detect the optional struct and continue, but meson will actually abort during configuration with the following error:

    meson.build:483:8: ERROR: Cross-compile check overflowed

This pull request contains two commits, one which adds a check to "common/35 sizeof" that checks for the existence of struct statx on Linux (which currently fails the same way as for systemd) and a second patch that bumps the size limit for cc.sizeof() to 1024 for cross-compile checks.