### PR TITLE
Fix xcode backend to run "meson test" instead of a nonexistent script.

### DIFF
--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -565,9 +565,7 @@ class XCodeBackend(backends.Backend):
         self.write_line(');')
         self.write_line('runOnlyForDeploymentPostprocessing = 0;')
         self.write_line('shellPath = /bin/sh;')
-        script_root = self.environment.get_script_dir()
-        test_script = os.path.join(script_root, 'meson_test.py')
-        cmd = mesonlib.python_command + [test_script, test_data, '--wd', self.environment.get_build_dir()]
+        cmd = mesonlib.meson_command + ['test', test_data, '-C', self.environment.get_build_dir()]
         cmdstr = ' '.join(["'%s'" % i for i in cmd])
         self.write_line('shellScript = "%s";' % cmdstr)
         self.write_line('showEnvVarsInLog = 0;')

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -109,8 +109,6 @@ def setup_commands(optbackend):
     if backend is None:
         if msbuild_exe is not None:
             backend = 'vs' # Meson will auto-detect VS version to use
-        elif mesonlib.is_osx():
-            backend = 'xcode'
         else:
             backend = 'ninja'
     # Set backend arguments for Meson


### PR DESCRIPTION
Most of the tests still fail, but at least this tries to run them instead of just bailing out up front. Also switching the default backend to ninja on OS X for run_project_tests.