### PR TITLE
Exclude subprojects when doing coverage

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -655,11 +655,30 @@ int dummy;
             # Alias that runs the target defined above
             self.create_target_alias('meson-coverage-html', outfile)
             elem = NinjaBuildElement(self.all_outputs, os.path.join(htmloutdir, 'index.html'), 'CUSTOM_COMMAND', '')
-            command = [lcov_exe, '--directory', self.environment.get_build_dir(),
-                       '--capture', '--output-file', covinfo, '--no-checksum',
-                       '&&', genhtml_exe, '--prefix', self.environment.get_build_dir(),
-                       '--output-directory', htmloutdir, '--title', 'Code coverage',
-                       '--legend', '--show-details', covinfo]
+
+            subproject_dir = self.build.get_subproject_dir()
+            command = [lcov_exe,
+                       '--directory', self.environment.get_build_dir(),
+                       '--capture',
+                       '--output-file', covinfo,
+                       '--no-checksum',
+                       '&&', lcov_exe,
+                       '--extract',
+                       covinfo,
+                       os.path.join(self.environment.get_source_dir(), '*'),
+                       '--output-file', covinfo,
+                       '&&', lcov_exe,
+                       '--remove',
+                       covinfo,
+                       os.path.join(self.environment.get_source_dir(), subproject_dir, '*'),
+                       '--output-file', covinfo,
+                       '&&', genhtml_exe,
+                       '--prefix', self.environment.get_build_dir(),
+                       '--output-directory', htmloutdir,
+                       '--title', 'Code coverage',
+                       '--legend',
+                       '--show-details',
+                       covinfo]
             elem.add_item('COMMAND', command)
             elem.add_item('DESC', 'Generating HTML coverage report.')
             elem.write(outfile)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -114,6 +114,7 @@ class Build:
         self.static_linker = None
         self.static_cross_linker = None
         self.subprojects = {}
+        self.subproject_dir = ''
         self.install_scripts = []
         self.postconf_scripts = []
         self.install_dirs = []
@@ -138,6 +139,9 @@ class Build:
 
     def get_project(self):
         return self.projects['']
+
+    def get_subproject_dir(self):
+        return self.subproject_dir
 
     def get_targets(self):
         return self.targets

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1945,6 +1945,8 @@ to directly access options of other subprojects.''')
                 raise InterpreterException('Subproject_dir must not contain a ".." segment.')
             self.subproject_dir = spdirname
 
+        self.build.subproject_dir = self.subproject_dir
+
         if 'meson_version' in kwargs:
             cv = coredata.version
             pv = kwargs['meson_version']


### PR DESCRIPTION
Currently the coverage will include both system sources and subproject sources. I updated the calls to `lcov` to remove source files that are not of interest to the current project.