### PR TITLE
Make it possible to override find_program [skip ci]

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -122,6 +122,8 @@ class Build:
         self.dep_manifest = {}
         self.cross_stdlibs = {}
         self.test_setups = {}
+        self.find_overrides = {}
+        self.searched_programs = set() # The list of all programs that have been searched for.
 
     def add_compiler(self, compiler):
         if self.static_linker is None and compiler.needs_static_linker():

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -210,7 +210,6 @@ class CoreData:
         self.compilers = OrderedDict()
         self.cross_compilers = OrderedDict()
         self.deps = OrderedDict()
-        self.modules = {}
         # Only to print a warning if it changes between Meson invocations.
         self.pkgconf_envvar = os.environ.get('PKG_CONFIG_PATH', '')
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1174,6 +1174,7 @@ class MesonMain(InterpreterObject):
                              'add_install_script': self.add_install_script_method,
                              'add_postconf_script': self.add_postconf_script_method,
                              'install_dependency_manifest': self.install_dependency_manifest_method,
+                             'override_find_program': self.override_find_program_method,
                              'project_version': self.project_version_method,
                              'project_license': self.project_license_method,
                              'version': self.version_method,
@@ -1285,6 +1286,20 @@ class MesonMain(InterpreterObject):
         if not isinstance(args[0], str):
             raise InterpreterException('Argument must be a string.')
         self.build.dep_manifest_name = args[0]
+
+    def override_find_program_method(self, args, kwargs):
+        if len(args) != 2:
+            raise InterpreterException('Override needs two arguments')
+        name = args[0]
+        exe = args[1]
+        if not isinstance(name, str):
+            raise InterpreterException('First argument must be a string')
+        if hasattr(exe, 'held_object'):
+            exe = exe.held_object
+        if not isinstance(exe, dependencies.ExternalProgram):
+            # FIXME, make this work if the exe is an Executable target.
+            raise InterpreterException('Second argument must be an external program.')
+        self.interpreter.add_find_program_override(name, exe)
 
     def project_version_method(self, args, kwargs):
         return self.build.dep_manifest[self.interpreter.active_projectname]['version']
@@ -2182,6 +2197,31 @@ to directly access options of other subprojects.''')
             if progobj.found():
                 return progobj
 
+    def program_from_overrides(self, command_names):
+        for name in command_names:
+            if not isinstance(name, str):
+                continue
+            if name in self.build.find_overrides:
+                exe = self.build.find_overrides[name]
+                mlog.log('Program', mlog.bold(name), 'found:', mlog.green('YES'),
+                         '(overridden: %s)' % ' '.join(exe.command))
+                return ExternalProgramHolder(exe)
+        return None
+
+    def store_name_lookups(self, command_names):
+        for name in command_names:
+            if isinstance(name, str):
+                self.build.searched_programs.add(name)
+
+    def add_find_program_override(self, name, exe):
+        if name in self.build.searched_programs:
+            raise InterpreterException('Tried to override finding of executable "%s" which has already been found.'
+                                       % name)
+        if name in self.build.find_overrides:
+            raise InterpreterException('Tried to override executable "%s" which has already been overridden.'
+                                       % name)
+        self.build.find_overrides[name] = exe
+
     @permittedKwargs(permitted_kwargs['find_program'])
     def func_find_program(self, node, args, kwargs):
         if not args:
@@ -2189,8 +2229,9 @@ to directly access options of other subprojects.''')
         required = kwargs.get('required', True)
         if not isinstance(required, bool):
             raise InvalidArguments('"required" argument must be a boolean.')
-        progobj = None
-        if self.build.environment.is_cross_build():
+        self.store_name_lookups(args)
+        progobj = self.program_from_overrides(args)
+        if progobj is None and self.build.environment.is_cross_build():
             use_native = kwargs.get('native', False)
             if not isinstance(use_native, bool):
                 raise InvalidArguments('Argument to "native" must be a boolean.')

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1430,7 +1430,7 @@ permitted_kwargs = {'add_global_arguments': {'language'},
 class Interpreter(InterpreterBase):
 
     def __init__(self, build, backend, subproject='', subdir='', subproject_dir='subprojects',
-                 default_project_options=[]):
+                 modules = None, default_project_options=[]):
         super().__init__(build.environment.get_source_dir(), subdir)
         self.an_unpicklable_object = mesonlib.an_unpicklable_object
         self.build = build
@@ -1438,6 +1438,10 @@ class Interpreter(InterpreterBase):
         self.coredata = self.environment.get_coredata()
         self.backend = backend
         self.subproject = subproject
+        if modules is None:
+            self.modules = {}
+        else:
+            self.modules = modules
         # Subproject directory is usually the name of the subproject, but can
         # be different for dependencies provided by wrap files.
         self.subproject_directory_name = subdir.split(os.path.sep)[-1]
@@ -1616,13 +1620,13 @@ class Interpreter(InterpreterBase):
             plainname = modname.split('-', 1)[1]
             mlog.warning('Module %s has no backwards or forwards compatibility and might not exist in future releases.' % modname, location=node)
             modname = 'unstable_' + plainname
-        if modname not in self.environment.coredata.modules:
+        if modname not in self.modules:
             try:
                 module = importlib.import_module('mesonbuild.modules.' + modname)
             except ImportError:
                 raise InvalidArguments('Module "%s" does not exist' % (modname, ))
-            self.environment.coredata.modules[modname] = module.initialize()
-        return ModuleHolder(modname, self.environment.coredata.modules[modname], self)
+            self.modules[modname] = module.initialize(self)
+        return ModuleHolder(modname, self.modules[modname], self)
 
     @stringArgs
     @noKwargs
@@ -1799,7 +1803,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         self.global_args_frozen = True
         mlog.log('\nExecuting subproject ', mlog.bold(dirname), '.\n', sep='')
         subi = Interpreter(self.build, self.backend, dirname, subdir, self.subproject_dir,
-                           mesonlib.stringlistify(kwargs.get('default_options', [])))
+                           self.modules, mesonlib.stringlistify(kwargs.get('default_options', [])))
         subi.subprojects = self.subprojects
 
         subi.subproject_stack = self.subproject_stack + [dirname]
@@ -2226,6 +2230,8 @@ to directly access options of other subprojects.''')
     def func_find_program(self, node, args, kwargs):
         if not args:
             raise InterpreterException('No program name specified.')
+        if not isinstance(args, list):
+            args = [args]
         required = kwargs.get('required', True)
         if not isinstance(required, bool):
             raise InvalidArguments('"required" argument must be a boolean.')

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -209,7 +209,8 @@ class MesonApp:
             # Post-conf scripts must be run after writing coredata or else introspection fails.
             g.run_postconf_scripts()
         except:
-            os.unlink(cdf)
+            if 'cdf' in locals():
+                os.unlink(cdf)
             raise
 
 def run_script_command(args):

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -18,25 +18,14 @@ class permittedSnippetKwargs:
             return f(s, interpreter, state, args, kwargs)
         return wrapped
 
-_found_programs = {}
-
 
 class ExtensionModule:
-    def __init__(self):
+    def __init__(self, interpreter):
+        self.interpreter = interpreter
         self.snippets = set() # List of methods that operate only on the interpreter.
 
     def is_snippet(self, funcname):
         return funcname in self.snippets
-
-def find_program(program_name, target_name):
-    if program_name in _found_programs:
-        return _found_programs[program_name]
-    program = dependencies.ExternalProgram(program_name)
-    if not program.found():
-        m = "Target {!r} can't be generated as {!r} could not be found"
-        raise MesonException(m.format(target_name, program_name))
-    _found_programs[program_name] = program
-    return program
 
 
 def get_include_args(include_dirs, prefix='-I'):

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -25,7 +25,7 @@ from .. import mesonlib
 from .. import compilers
 from .. import interpreter
 from . import GResourceTarget, GResourceHeaderTarget, GirTarget, TypelibTarget, VapiTarget
-from . import find_program, get_include_args
+from . import get_include_args
 from . import ExtensionModule
 from . import ModuleReturnValue
 from ..mesonlib import MesonException, OrderedSet, Popen_safe, extract_as_list
@@ -45,14 +45,14 @@ gdbuswarning_printed = False
 gresource_warning_printed = False
 _gir_has_extra_lib_arg = None
 
-def gir_has_extra_lib_arg():
+def gir_has_extra_lib_arg(intr_obj):
     global _gir_has_extra_lib_arg
     if _gir_has_extra_lib_arg is not None:
         return _gir_has_extra_lib_arg
 
     _gir_has_extra_lib_arg = False
     try:
-        g_ir_scanner = find_program('g-ir-scanner', '').get_command()
+        g_ir_scanner = intr_obj.func_find_program(None, 'g-ir-scanner', {}).get_command()
         opts = Popen_safe(g_ir_scanner + ['--help'], stderr=subprocess.STDOUT)[1]
         _gir_has_extra_lib_arg = '--extra-library' in opts
     except (MesonException, FileNotFoundError, subprocess.CalledProcessError):
@@ -302,7 +302,7 @@ class GnomeModule(ExtensionModule):
                 link_command.append('-Wl,-rpath,' + libdir)
             if depends:
                 depends.append(lib)
-        if gir_has_extra_lib_arg() and use_gir_args:
+        if gir_has_extra_lib_arg(self.interpreter) and use_gir_args:
             link_command.append('--extra-library=' + lib.name)
         else:
             link_command.append('-l' + lib.name)
@@ -369,7 +369,7 @@ class GnomeModule(ExtensionModule):
                 mlog.log('dependency {!r} not handled to build gir files'.format(dep))
                 continue
 
-        if gir_has_extra_lib_arg() and use_gir_args:
+        if gir_has_extra_lib_arg(self.interpreter) and use_gir_args:
             fixed_ldflags = OrderedSet()
             for ldflag in ldflags:
                 if ldflag.startswith("-l"):
@@ -388,8 +388,8 @@ class GnomeModule(ExtensionModule):
             raise MesonException('Gir takes one argument')
         if kwargs.get('install_dir'):
             raise MesonException('install_dir is not supported with generate_gir(), see "install_dir_gir" and "install_dir_typelib"')
-        giscanner = find_program('g-ir-scanner', 'Gir')
-        gicompiler = find_program('g-ir-compiler', 'Gir')
+        giscanner = self.interpreter.func_find_program(None, 'g-ir-scanner', {})
+        gicompiler = self.interpreter.func_find_program(None, 'g-ir-compiler', {})
         girtarget = args[0]
         while hasattr(girtarget, 'held_object'):
             girtarget = girtarget.held_object
@@ -637,7 +637,7 @@ class GnomeModule(ExtensionModule):
         srcdir = os.path.join(state.build_to_src, state.subdir)
         outdir = state.subdir
 
-        cmd = [find_program('glib-compile-schemas', 'gsettings-compile')]
+        cmd = [self.interpreter.func_find_program(None, 'glib-compile-schemas', {})]
         cmd += ['--targetdir', outdir, srcdir]
         kwargs['command'] = cmd
         kwargs['input'] = []
@@ -876,7 +876,7 @@ This will become a hard error in the future.''')
         namebase = args[0]
         xml_file = args[1]
         target_name = namebase + '-gdbus'
-        cmd = [find_program('gdbus-codegen', target_name)]
+        cmd = [self.interpreter.func_find_program(None, 'gdbus-codegen', {})]
         if 'interface_prefix' in kwargs:
             cmd += ['--interface-prefix', kwargs.pop('interface_prefix')]
         if 'namespace' in kwargs:
@@ -961,7 +961,7 @@ This will become a hard error in the future.''')
             elif arg not in known_custom_target_kwargs:
                 raise MesonException(
                     'Mkenums does not take a %s keyword argument.' % (arg, ))
-        cmd = [find_program('glib-mkenums', 'mkenums')] + cmd
+        cmd = [self.interpreter.func_find_program(None, ['glib-mkenums', 'mkenums'], {})] + cmd
         custom_kwargs = {}
         for arg in known_custom_target_kwargs:
             if arg in kwargs:
@@ -1151,7 +1151,7 @@ G_END_DECLS'''
 
         new_genmarshal = mesonlib.version_compare(self._get_native_glib_version(state), '>= 2.53.3')
 
-        cmd = [find_program('glib-genmarshal', output + '_genmarshal')]
+        cmd = [self.interpreter.func_find_program(None, 'glib-genmarshal', {})]
         known_kwargs = ['internal', 'nostdinc', 'skip_source', 'stdinc',
                         'valist_marshallers', 'extra_args']
         known_custom_target_kwargs = ['build_always', 'depends',
@@ -1297,9 +1297,9 @@ G_END_DECLS'''
         pkg_cmd, vapi_depends, vapi_packages, vapi_includes = self._extract_vapi_packages(state, kwargs)
         target_name = 'generate_vapi({})'.format(library)
         if 'VAPIGEN' in os.environ:
-            cmd = [find_program(os.environ['VAPIGEN'], target_name)]
+            cmd = [self.interpreter.func_find_program(None, os.environ['VAPIGEN'], {}), target_name]
         else:
-            cmd = [find_program('vapigen', target_name)]
+            cmd = [self.interpreter.func_find_program(None, 'vapigen'), target_name]
         cmd += ['--quiet', '--library=' + library, '--directory=' + build_dir]
         cmd += self._vapi_args_to_command('--vapidir=', 'vapi_dirs', kwargs)
         cmd += self._vapi_args_to_command('--metadatadir=', 'metadata_dirs', kwargs)
@@ -1354,5 +1354,5 @@ G_END_DECLS'''
         created_values.append(rv)
         return ModuleReturnValue(rv, created_values)
 
-def initialize():
-    return GnomeModule()
+def initialize(*args, **kwargs):
+    return GnomeModule(*args, **kwargs)

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -26,8 +26,8 @@ mod_kwargs.update(shlib_kwargs)
 
 
 class Python3Module(ExtensionModule):
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.snippets.add('extension_module')
 
     @permittedSnippetKwargs(mod_kwargs)
@@ -72,5 +72,5 @@ class Python3Module(ExtensionModule):
         return ModuleReturnValue(path, [])
 
 
-def initialize():
-    return Python3Module()
+def initialize(*args, **kwargs):
+    return Python3Module(*args, **kwargs)

--- a/test cases/common/182 find override/meson.build
+++ b/test cases/common/182 find override/meson.build
@@ -1,0 +1,4 @@
+project('find program override', 'c')
+
+subdir('subdir')
+subdir('otherdir')

--- a/test cases/common/182 find override/otherdir/main.c
+++ b/test cases/common/182 find override/otherdir/main.c
@@ -1,0 +1,5 @@
+int be_seeing_you();
+
+int main(int argc, char **argv) {
+    return be_seeing_you() == 6 ? 0 : 1;
+}

--- a/test cases/common/182 find override/otherdir/meson.build
+++ b/test cases/common/182 find override/otherdir/meson.build
@@ -1,0 +1,11 @@
+gen = find_program('codegen') # Should use overridden value set in "subdir".
+
+src = custom_target('arrival',
+  input : 'source.desc',
+  output : 'file.c',
+  command : [gen, '@INPUT@', '@OUTPUT@']
+  )
+
+e = executable('six', 'main.c', src)
+
+test('six', e)

--- a/test cases/common/182 find override/otherdir/source.desc
+++ b/test cases/common/182 find override/otherdir/source.desc
@@ -1,0 +1,1 @@
+be_seeing_you

--- a/test cases/common/182 find override/subdir/converter.py
+++ b/test cases/common/182 find override/subdir/converter.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import sys
+import pathlib
+
+[ifilename, ofilename] = sys.argv[1:3]
+
+ftempl = '''int %s() {
+    return 6;
+}
+'''
+
+d = pathlib.Path(ifilename).read_text().split('\n')[0].strip()
+
+pathlib.Path(ofilename).write_text(ftempl % d)

--- a/test cases/common/182 find override/subdir/meson.build
+++ b/test cases/common/182 find override/subdir/meson.build
@@ -1,0 +1,3 @@
+x = find_program('converter.py')
+
+meson.override_find_program('codegen', x)

--- a/test cases/failing/70 override used/meson.build
+++ b/test cases/failing/70 override used/meson.build
@@ -1,0 +1,5 @@
+project('overridde an already found exe', 'c')
+
+old = find_program('something.py')
+replacement = find_program('other.py')
+meson.override_find_program('something.py', replacement)

--- a/test cases/failing/70 override used/other.py
+++ b/test cases/failing/70 override used/other.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print('Doing something else.')

--- a/test cases/failing/70 override used/something.py
+++ b/test cases/failing/70 override used/something.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print('Doing something.')

--- a/test cases/failing/71 dual override/meson.build
+++ b/test cases/failing/71 dual override/meson.build
@@ -1,0 +1,5 @@
+project('yo dawg', 'c')
+
+p = find_program('overrides.py')
+meson.override_find_program('override', p)
+meson.override_find_program('override', p)

--- a/test cases/failing/71 dual override/overrides.py
+++ b/test cases/failing/71 dual override/overrides.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+
+print('Yo dawg, we put overrides in your overrides,')
+print('so now you can override when you override.')


### PR DESCRIPTION
This is not yet finished, hence the CI skipping.

The point of this PR is that you can do `meson.override_find_program('progname', [program object])` which causes all `find_program`s for `programe` to use the given program object instead.

 - trying to override the name _after_ it has been used is a hard error
 - trying to override an overridden name is a hard error
 - works only for `ExternalProgram` objects but could in theory be expanded to do `Executable` as well but that has more corner cases
 - documentation updates are missing

The point of this is to gather comments to see whether this is a usable approach. With this it should be possible to both bootstrap `glib` by itself and also to make it usable as a subproject on platforms where it is not available.