### PR TITLE
Introduce install_umask to determine permissions of files in install tree. Default it to 022

### DIFF
--- a/docs/markdown/snippets/install_umask.md
+++ b/docs/markdown/snippets/install_umask.md
@@ -1,0 +1,17 @@
+## New built-in option install_umask with a default value 022
+
+This umask is used to define the default permissions of files and directories
+created in the install tree. Files will preserve their executable mode, but the
+exact permissions will obey the install_umask.
+
+The install_umask can be overridden in the meson command-line:
+
+    $ meson --install-umask=027 builddir/
+
+A project can also override the default in the project() call:
+
+    project('myproject', 'c',
+      default_options : ['install_umask=027'])
+
+To disable the install_umask, set it to 'preserve', in which case permissions
+are copied from the files in their origin.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -37,11 +37,13 @@ class CleanTrees:
         self.trees = trees
 
 class InstallData:
-    def __init__(self, source_dir, build_dir, prefix, strip_bin, mesonintrospect):
+    def __init__(self, source_dir, build_dir, prefix, strip_bin,
+                 install_umask, mesonintrospect):
         self.source_dir = source_dir
         self.build_dir = build_dir
         self.prefix = prefix
         self.strip_bin = strip_bin
+        self.install_umask = install_umask
         self.targets = []
         self.headers = []
         self.man = []

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -668,7 +668,9 @@ int dummy;
         d = InstallData(self.environment.get_source_dir(),
                         self.environment.get_build_dir(),
                         self.environment.get_prefix(),
-                        strip_bin, self.environment.get_build_command() + ['introspect'])
+                        strip_bin,
+                        self.environment.coredata.get_builtin_option('install_umask'),
+                        self.environment.get_build_command() + ['introspect'])
         elem = NinjaBuildElement(self.all_outputs, 'meson-install', 'CUSTOM_COMMAND', 'PHONY')
         elem.add_dep('all')
         elem.add_item('DESC', 'Installing files.')

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -456,7 +456,7 @@ builtin_options = {
     'backend':         [UserComboOption, 'Backend to use.', backendlist, 'ninja'],
     'stdsplit':        [UserBooleanOption, 'Split stdout and stderr in test logs.', True],
     'errorlogs':       [UserBooleanOption, "Whether to print the logs from failing tests.", True],
-    'install_umask':   [UserUmaskOption, 'Default umask to apply on permissions of installed files.', None],
+    'install_umask':   [UserUmaskOption, 'Default umask to apply on permissions of installed files.', '022'],
 }
 
 # Special prefix-dependent defaults for installation directories that reside in

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -105,6 +105,22 @@ class UserIntegerOption(UserOption):
         except ValueError:
             raise MesonException('Value string "%s" is not convertable to an integer.' % valuestring)
 
+class UserUmaskOption(UserIntegerOption):
+    def __init__(self, name, description, value, yielding=None):
+        super().__init__(name, description, 0, 0o777, value, yielding)
+
+    def set_value(self, newvalue):
+        if newvalue is None or newvalue == 'preserve':
+            self.value = None
+        else:
+            super().set_value(newvalue)
+
+    def toint(self, valuestring):
+        try:
+            return int(valuestring, 8)
+        except ValueError as e:
+            raise MesonException('Invalid mode: {}'.format(e))
+
 class UserComboOption(UserOption):
     def __init__(self, name, description, choices, value, yielding=None):
         super().__init__(name, description, choices, yielding)
@@ -345,12 +361,12 @@ def is_builtin_option(optname):
 
 def get_builtin_option_choices(optname):
     if is_builtin_option(optname):
-        if builtin_options[optname][0] == UserStringOption:
-            return None
+        if builtin_options[optname][0] == UserComboOption:
+            return builtin_options[optname][2]
         elif builtin_options[optname][0] == UserBooleanOption:
             return [True, False]
         else:
-            return builtin_options[optname][2]
+            return None
     else:
         raise RuntimeError('Tried to get the supported values for an unknown builtin option \'%s\'.' % optname)
 
@@ -379,6 +395,8 @@ def get_builtin_option_default(optname, prefix='', noneIfSuppress=False):
         o = builtin_options[optname]
         if o[0] == UserComboOption:
             return o[3]
+        if o[0] == UserIntegerOption:
+            return o[4]
         if optname in builtin_dir_noprefix_options:
             if noneIfSuppress:
                 # Return None if argparse defaulting should be suppressed for
@@ -438,6 +456,7 @@ builtin_options = {
     'backend':         [UserComboOption, 'Backend to use.', backendlist, 'ninja'],
     'stdsplit':        [UserBooleanOption, 'Split stdout and stderr in test logs.', True],
     'errorlogs':       [UserBooleanOption, "Whether to print the logs from failing tests.", True],
+    'install_umask':   [UserUmaskOption, 'Default umask to apply on permissions of installed files.', None],
 }
 
 # Special prefix-dependent defaults for installation directories that reside in

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -152,7 +152,7 @@ class Conf:
         print('  Build dir ', self.build.environment.build_dir)
         print('\nCore options:\n')
         carr = []
-        for key in ['buildtype', 'warning_level', 'werror', 'strip', 'unity', 'default_library']:
+        for key in ['buildtype', 'warning_level', 'werror', 'strip', 'unity', 'default_library', 'install_umask']:
             carr.append({'name': key,
                          'descr': coredata.get_builtin_option_description(key),
                          'value': self.coredata.get_builtin_option(key),

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2669,6 +2669,74 @@ class LinuxlikeTests(BasePlatformTests):
             # The chown failed nonfatally if we're not root
             self.assertEqual(0, statf.st_uid)
 
+    def test_install_umask(self):
+        '''
+        Test that files are installed with correct permissions using default
+        install umask of 022, regardless of the umask at time the worktree
+        was checked out or the build was executed.
+        '''
+        # Copy source tree to a temporary directory and change permissions
+        # there to simulate a checkout with umask 002.
+        orig_testdir = os.path.join(self.unit_test_dir, '24 install umask')
+        # Create a new testdir under tmpdir.
+        tmpdir = os.path.realpath(tempfile.mkdtemp())
+        self.addCleanup(windows_proof_rmtree, tmpdir)
+        testdir = os.path.join(tmpdir, '24 install umask')
+        # Copy the tree using shutil.copyfile, which will use the current umask
+        # instead of preserving permissions of the old tree.
+        save_umask = os.umask(0o002)
+        self.addCleanup(os.umask, save_umask)
+        shutil.copytree(orig_testdir, testdir, copy_function=shutil.copyfile)
+        # Preserve the executable status of subdir/sayhello though.
+        os.chmod(os.path.join(testdir, 'subdir', 'sayhello'), 0o775)
+        self.init(testdir)
+        # Run the build under a 027 umask now.
+        os.umask(0o027)
+        self.build()
+        # And keep umask 027 for the install step too.
+        self.install()
+
+        for executable in [
+                'bin/prog',
+                'share/subdir/sayhello',
+        ]:
+            f = os.path.join(self.installdir, 'usr', *executable.split('/'))
+            found_mode = stat.filemode(os.stat(f).st_mode)
+            want_mode = '-rwxr-xr-x'
+            self.assertEqual(want_mode, found_mode,
+                             msg=('Expected file %s to have mode %s but found %s instead.' %
+                                  (executable, want_mode, found_mode)))
+
+        for directory in [
+                'usr',
+                'usr/bin',
+                'usr/include',
+                'usr/share',
+                'usr/share/man',
+                'usr/share/man/man1',
+                'usr/share/subdir',
+        ]:
+            f = os.path.join(self.installdir, *directory.split('/'))
+            found_mode = stat.filemode(os.stat(f).st_mode)
+            want_mode = 'drwxr-xr-x'
+            self.assertEqual(want_mode, found_mode,
+                             msg=('Expected directory %s to have mode %s but found %s instead.' %
+                                  (directory, want_mode, found_mode)))
+
+        for datafile in [
+                'include/sample.h',
+                'share/datafile.cat',
+                'share/file.dat',
+                'share/man/man1/prog.1.gz',
+                'share/subdir/datafile.dog',
+        ]:
+            f = os.path.join(self.installdir, 'usr', *datafile.split('/'))
+            found_mode = stat.filemode(os.stat(f).st_mode)
+            want_mode = '-rw-r--r--'
+            self.assertEqual(want_mode, found_mode,
+                             msg=('Expected file %s to have mode %s but found %s instead.' %
+                                  (datafile, want_mode, found_mode)))
+
     def test_cpp_std_override(self):
         testdir = os.path.join(self.unit_test_dir, '6 std override')
         self.init(testdir)

--- a/test cases/common/12 data/meson.build
+++ b/test cases/common/12 data/meson.build
@@ -1,4 +1,5 @@
-project('data install test', 'c')
+project('data install test', 'c',
+  default_options : ['install_umask=preserve'])
 install_data(sources : 'datafile.dat', install_dir : 'share/progname')
 # Some file in /etc that is only read-write by root; add a sticky bit for testing
 install_data(sources : 'etcfile.dat', install_dir : '/etc', install_mode : 'rw------T')

--- a/test cases/common/66 install subdir/meson.build
+++ b/test cases/common/66 install subdir/meson.build
@@ -1,4 +1,5 @@
-project('install a whole subdir', 'c')
+project('install a whole subdir', 'c',
+  default_options : ['install_umask=preserve'])
 
 # A subdir with an exclusion:
 install_subdir('sub2',

--- a/test cases/unit/24 install umask/datafile.cat
+++ b/test cases/unit/24 install umask/datafile.cat
@@ -1,0 +1,1 @@
+Installed cat is installed.

--- a/test cases/unit/24 install umask/meson.build
+++ b/test cases/unit/24 install umask/meson.build
@@ -1,0 +1,7 @@
+project('install umask', 'c')
+executable('prog', 'prog.c', install : true)
+install_headers('sample.h')
+install_man('prog.1')
+install_data('datafile.cat', install_dir : get_option('prefix') + '/share')
+install_subdir('subdir', install_dir : get_option('prefix') + '/share')
+meson.add_install_script('myinstall.py', 'share', 'file.dat')

--- a/test cases/unit/24 install umask/myinstall.py
+++ b/test cases/unit/24 install umask/myinstall.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+prefix = os.environ['MESON_INSTALL_DESTDIR_PREFIX']
+
+dirname = os.path.join(prefix, sys.argv[1])
+
+try:
+    os.makedirs(dirname)
+except FileExistsError:
+    if not os.path.isdir(dirname):
+        raise
+
+with open(os.path.join(dirname, sys.argv[2]), 'w') as f:
+    f.write('')

--- a/test cases/unit/24 install umask/prog.1
+++ b/test cases/unit/24 install umask/prog.1
@@ -1,0 +1,1 @@
+Man up, you.

--- a/test cases/unit/24 install umask/prog.c
+++ b/test cases/unit/24 install umask/prog.c
@@ -1,0 +1,3 @@
+int main(int argc, char **arv) {
+    return 0;
+}

--- a/test cases/unit/24 install umask/sample.h
+++ b/test cases/unit/24 install umask/sample.h
@@ -1,0 +1,6 @@
+#ifndef SAMPLE_H
+#define SAMPLE_H
+
+int wackiness();
+
+#endif

--- a/test cases/unit/24 install umask/subdir/datafile.dog
+++ b/test cases/unit/24 install umask/subdir/datafile.dog
@@ -1,0 +1,1 @@
+Installed dog is installed.

--- a/test cases/unit/24 install umask/subdir/sayhello
+++ b/test cases/unit/24 install umask/subdir/sayhello
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo 'Hello, World!'


### PR DESCRIPTION
So this patch set introduces a new built-in option `install_umask` which can be used to define the permissions of files in the install tree.

It defaults to `022`, which is the typical option expected on install, executables and directories get mode `0755` and data files get mode `0644`.

It can be changed by users, using `meson --install-umask=...`, or by projects, setting it on the `default_options` of their `project()` call.

The umask can be disabled by setting `install_umask=none`, in which case the previous behavior of copying the same permissions from the build or source tree are preserved.

Also introduced a unit test to check the behavior of this feature. The unit test simulates the case where a tree is checked out with umask `002`, then the build and install steps are done with umask `027`, but the final tree under $DESTDIR has the expected modes of `0755` and `0644`.

(One interesting follow up for this PR would be to add support for `install_mode` to more functions. I'd be happy to work on such a PR, but I think it's best to review and push this one first, in order to avoid scope creep.)

Fixes #3160.