### PR TITLE
Accept -D for meson level options durring initial configuration

### DIFF
--- a/docs/markdown/snippets/d-options-for-meson-setup.md
+++ b/docs/markdown/snippets/d-options-for-meson-setup.md
@@ -1,0 +1,6 @@
+## Meson now accepts -D for builtin arguments at setup time like configure time
+
+Previously meson required that builtin arguments (like prefix) be passed as
+`--prefix` to `meson` and `-Dprefix` to `meson configure`. Meson now accepts -D
+form like meson configure does. `meson configure` still does not accept the
+`--prefix` form.

--- a/docs/markdown/snippets/d-options-for-meson-setup.md
+++ b/docs/markdown/snippets/d-options-for-meson-setup.md
@@ -1,6 +1,6 @@
-## Meson now accepts -D for builtin arguments at setup time like configure time
+## Meson and meson configure now accept the same arguments
 
 Previously meson required that builtin arguments (like prefix) be passed as
-`--prefix` to `meson` and `-Dprefix` to `meson configure`. Meson now accepts -D
-form like meson configure does. `meson configure` still does not accept the
-`--prefix` form.
+`--prefix` to `meson` and `-Dprefix` to `meson configure`. `meson` now accepts -D
+form like `meson configure` has. `meson configure` also accepts the `--prefix`
+form, like `meson` has.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -367,6 +367,12 @@ def get_builtin_option_action(optname):
         return 'store_true'
     return None
 
+def get_builtin_option_destination(optname):
+    optname = optname.replace('-', '_')
+    if optname == 'warnlevel':
+        return 'warning_level'
+    return optname
+
 def get_builtin_option_default(optname, prefix='', noneIfSuppress=False):
     if is_builtin_option(optname):
         o = builtin_options[optname]

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -359,6 +359,14 @@ def get_builtin_option_description(optname):
     else:
         raise RuntimeError('Tried to get the description for an unknown builtin option \'%s\'.' % optname)
 
+def get_builtin_option_action(optname):
+    default = builtin_options[optname][2]
+    if default is True:
+        return 'store_false'
+    elif default is False:
+        return 'store_true'
+    return None
+
 def get_builtin_option_default(optname, prefix='', noneIfSuppress=False):
     if is_builtin_option(optname):
         o = builtin_options[optname]

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2225,10 +2225,12 @@ to directly access options of other subprojects.''')
                     self.coredata.external_args.setdefault(lang, []).append(optvalue)
             # Otherwise, look for definitions from environment
             # variables such as CFLAGS.
-            if not comp.get_language() in self.coredata.external_args:
-                (preproc_args, compile_args, link_args) = environment.get_args_from_envvars(comp)
+            (preproc_args, compile_args, link_args) = environment.get_args_from_envvars(comp)
+            if not comp.get_language() in self.coredata.external_preprocess_args:
                 self.coredata.external_preprocess_args[comp.get_language()] = preproc_args
+            if not comp.get_language() in self.coredata.external_args:
                 self.coredata.external_args[comp.get_language()] = compile_args
+            if not comp.get_language() in self.coredata.external_link_args:
                 self.coredata.external_link_args[comp.get_language()] = link_args
             self.build.add_compiler(comp)
             if need_cross_compiler:

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -19,6 +19,7 @@ from . import (coredata, mesonlib, build)
 
 def buildparser():
     parser = argparse.ArgumentParser(prog='meson configure')
+    coredata.register_builtin_arguments(parser)
 
     parser.add_argument('-D', action='append', default=[], dest='sets',
                         help='Set an option to the given value.')
@@ -26,6 +27,19 @@ def buildparser():
     parser.add_argument('--clearcache', action='store_true', default=False,
                         help='Clear cached state (e.g. found dependencies)')
     return parser
+
+
+def filter_builtin_options(args, original_args):
+    """Filter out any args passed with -- instead of -D."""
+    for arg in original_args:
+        if not arg.startswith('--') or arg == '--clearcache':
+            continue
+        name = arg.lstrip('--').split('=', 1)[0]
+        if any([a.startswith(name + '=') for a in args.sets]):
+            raise mesonlib.MesonException(
+                'Got argument {0} as both -D{0} and --{0}. Pick one.'.format(name))
+        args.sets.append('{}={}'.format(name, getattr(args, name)))
+        delattr(args, name)
 
 
 class ConfException(mesonlib.MesonException):
@@ -229,6 +243,7 @@ def run(args):
     if not args:
         args = [os.getcwd()]
     options = buildparser().parse_args(args)
+    filter_builtin_options(options, args)
     if len(options.directory) > 1:
         print('%s <build directory>' % args[0])
         print('If you omit the build directory, the current directory is substituted.')

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -28,10 +28,12 @@ default_warning = '1'
 def add_builtin_argument(p, name, **kwargs):
     k = kwargs.get('dest', name.replace('-', '_'))
     c = coredata.get_builtin_option_choices(k)
-    b = kwargs.get('action', None) in ['store_true', 'store_false']
+    b = coredata.get_builtin_option_action(k)
     h = coredata.get_builtin_option_description(k)
     if not b:
         h = h.rstrip('.') + ' (default: %s).' % coredata.get_builtin_option_default(k)
+    else:
+        kwargs['action'] = b
     if c and not b:
         kwargs['choices'] = c
     default = coredata.get_builtin_option_default(k, noneIfSuppress=True)
@@ -58,14 +60,14 @@ def create_parser():
     add_builtin_argument(p, 'sharedstatedir')
     add_builtin_argument(p, 'backend')
     add_builtin_argument(p, 'buildtype')
-    add_builtin_argument(p, 'strip', action='store_true')
+    add_builtin_argument(p, 'strip')
     add_builtin_argument(p, 'unity')
-    add_builtin_argument(p, 'werror', action='store_true')
+    add_builtin_argument(p, 'werror')
     add_builtin_argument(p, 'layout')
     add_builtin_argument(p, 'default-library')
     add_builtin_argument(p, 'warnlevel', dest='warning_level')
-    add_builtin_argument(p, 'stdsplit', action='store_false')
-    add_builtin_argument(p, 'errorlogs', action='store_false')
+    add_builtin_argument(p, 'stdsplit')
+    add_builtin_argument(p, 'errorlogs')
     p.add_argument('--cross-file', default=None,
                    help='File describing cross compilation environment.')
     p.add_argument('-D', action='append', dest='projectoptions', default=[], metavar="option",

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -26,7 +26,7 @@ from .wrap import WrapMode, wraptool
 default_warning = '1'
 
 def add_builtin_argument(p, name, **kwargs):
-    k = kwargs.get('dest', name.replace('-', '_'))
+    k = coredata.get_builtin_option_destination(name)
     c = coredata.get_builtin_option_choices(k)
     b = coredata.get_builtin_option_action(k)
     h = coredata.get_builtin_option_description(k)
@@ -65,7 +65,7 @@ def create_parser():
     add_builtin_argument(p, 'werror')
     add_builtin_argument(p, 'layout')
     add_builtin_argument(p, 'default-library')
-    add_builtin_argument(p, 'warnlevel', dest='warning_level')
+    add_builtin_argument(p, 'warnlevel')
     add_builtin_argument(p, 'stdsplit')
     add_builtin_argument(p, 'errorlogs')
     p.add_argument('--cross-file', default=None,

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -25,29 +25,9 @@ from .wrap import WrapMode, wraptool
 
 default_warning = '1'
 
-def add_builtin_argument(p, name):
-    kwargs = {}
-    k = coredata.get_builtin_option_destination(name)
-    c = coredata.get_builtin_option_choices(k)
-    b = coredata.get_builtin_option_action(k)
-    h = coredata.get_builtin_option_description(k)
-    if not b:
-        h = h.rstrip('.') + ' (default: %s).' % coredata.get_builtin_option_default(k)
-    else:
-        kwargs['action'] = b
-    if c and not b:
-        kwargs['choices'] = c
-    default = coredata.get_builtin_option_default(k, noneIfSuppress=True)
-    if default is not None:
-        kwargs['default'] = default
-    else:
-        kwargs['default'] = argparse.SUPPRESS
-    p.add_argument('--' + name, help=h, **kwargs)
-
 def create_parser():
     p = argparse.ArgumentParser(prog='meson')
-    for n in coredata.builtin_options:
-        add_builtin_argument(p, n)
+    coredata.register_builtin_arguments(p)
     p.add_argument('--cross-file', default=None,
                    help='File describing cross compilation environment.')
     p.add_argument('-D', action='append', dest='projectoptions', default=[], metavar="option",

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -25,7 +25,8 @@ from .wrap import WrapMode, wraptool
 
 default_warning = '1'
 
-def add_builtin_argument(p, name, **kwargs):
+def add_builtin_argument(p, name):
+    kwargs = {}
     k = coredata.get_builtin_option_destination(name)
     c = coredata.get_builtin_option_choices(k)
     b = coredata.get_builtin_option_action(k)
@@ -45,29 +46,8 @@ def add_builtin_argument(p, name, **kwargs):
 
 def create_parser():
     p = argparse.ArgumentParser(prog='meson')
-    add_builtin_argument(p, 'prefix')
-    add_builtin_argument(p, 'libdir')
-    add_builtin_argument(p, 'libexecdir')
-    add_builtin_argument(p, 'bindir')
-    add_builtin_argument(p, 'sbindir')
-    add_builtin_argument(p, 'includedir')
-    add_builtin_argument(p, 'datadir')
-    add_builtin_argument(p, 'mandir')
-    add_builtin_argument(p, 'infodir')
-    add_builtin_argument(p, 'localedir')
-    add_builtin_argument(p, 'sysconfdir')
-    add_builtin_argument(p, 'localstatedir')
-    add_builtin_argument(p, 'sharedstatedir')
-    add_builtin_argument(p, 'backend')
-    add_builtin_argument(p, 'buildtype')
-    add_builtin_argument(p, 'strip')
-    add_builtin_argument(p, 'unity')
-    add_builtin_argument(p, 'werror')
-    add_builtin_argument(p, 'layout')
-    add_builtin_argument(p, 'default-library')
-    add_builtin_argument(p, 'warnlevel')
-    add_builtin_argument(p, 'stdsplit')
-    add_builtin_argument(p, 'errorlogs')
+    for n in coredata.builtin_options:
+        add_builtin_argument(p, n)
     p.add_argument('--cross-file', default=None,
                    help='File describing cross compilation environment.')
     p.add_argument('-D', action='append', dest='projectoptions', default=[], metavar="option",


### PR DESCRIPTION
The first three patches are some nice cleanups in this area I already had, but the last is the bread and butter of this PR. Basically let's not have different arguments for `meson` and `meson configure`