### PR TITLE
Replaced appveyor account by mesonbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ build system.
 
 [![PyPI](https://img.shields.io/pypi/v/meson.svg)](https://pypi.python.org/pypi/meson)
 [![Travis](https://travis-ci.org/mesonbuild/meson.svg?branch=master)](https://travis-ci.org/mesonbuild/meson)
-[![Appveyor](https://ci.appveyor.com/api/projects/status/l5c8v71ninew2i3p?svg=true)](https://ci.appveyor.com/project/jpakkane/meson)
+[![Appveyor](https://ci.appveyor.com/api/projects/status/7jfaotriu8d8ncov?svg=true)](https://ci.appveyor.com/project/mesonbuild/meson)
 [![Codecov](https://codecov.io/gh/mesonbuild/meson/coverage.svg?branch=master)](https://codecov.io/gh/mesonbuild/meson/branch/master)
 
 #### Dependencies


### PR DESCRIPTION
Intentionally not setting [skip ci] to check that it works.

- Renamed `Owners` team to `Core` since github complains about `Owners` being misleading, it became a role and team has no effect. `Core` also gives full administrative access to Appveyor.
- `jpakkane@gmail.com` is added as Appveyor administrator directly, without team management. This will prevent accident lockout in case of github misconfiguration.
- `Contributors` team is added, it provides `Contributor` role in Appveyor, it allows to start and stop builds only. This is the way to allow people to start/stop builds without giving privileges to break something else.
- [Rolling builds](https://www.appveyor.com/docs/build-configuration/#rolling-builds) feature is enabled, but for pull requests only. If you push new commit to PR it will cancel all previous builds. I believe there is a value to have more complete history for master. I verified that it works in this PR.
- Removed [jpakkane/meson](https://ci.appveyor.com/project/jpakkane/meson) hook from [mesonbuild/meson](https://github.com/mesonbuild/meson).
- Added a hook to `mesonbuild` to update Appveyor about team changes.