### PR TITLE
Add -Wl,-dead_strip_dylibs support

### DIFF
--- a/test cases/common/183 as-needed/config.h
+++ b/test cases/common/183 as-needed/config.h
@@ -1,0 +1,14 @@
+#if defined _WIN32 || defined __CYGWIN__
+  #if defined BUILDING_DLL
+    #define DLL_PUBLIC __declspec(dllexport)
+  #else
+    #define DLL_PUBLIC __declspec(dllimport)
+  #endif
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif

--- a/test cases/common/183 as-needed/libA.cpp
+++ b/test cases/common/183 as-needed/libA.cpp
@@ -1,0 +1,7 @@
+#define BUILDING_DLL
+
+#include "libA.h"
+
+namespace meson_test_as_needed {
+  DLL_PUBLIC bool linked = false;
+}

--- a/test cases/common/183 as-needed/libA.h
+++ b/test cases/common/183 as-needed/libA.h
@@ -1,0 +1,5 @@
+#include "config.h"
+
+namespace meson_test_as_needed {
+  DLL_PUBLIC extern bool linked;
+}

--- a/test cases/common/183 as-needed/libB.cpp
+++ b/test cases/common/183 as-needed/libB.cpp
@@ -1,0 +1,19 @@
+#include "libA.h"
+
+#undef DLL_PUBLIC
+#define BUILDING_DLL
+#include "config.h"
+
+namespace meson_test_as_needed {
+  namespace {
+    bool set_linked() {
+      linked = true;
+      return true;
+    }
+    bool stub = set_linked();
+  }
+
+  DLL_PUBLIC int libB_unused_func() {
+    return 0;
+  }
+}

--- a/test cases/common/183 as-needed/main.cpp
+++ b/test cases/common/183 as-needed/main.cpp
@@ -1,0 +1,7 @@
+#include <cstdlib>
+
+#include "libA.h"
+
+int main() {
+  return (meson_test_as_needed::linked == false ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/test cases/common/183 as-needed/meson.build
+++ b/test cases/common/183 as-needed/meson.build
@@ -1,0 +1,13 @@
+project('as-needed test', 'cpp')
+
+# Idea behind this test is to have -Wl,--as-needed prune
+# away unneeded linkages, which would otherwise cause global
+# static initialiser side-effects to set a boolean to true.
+
+# Credits for portable ISO C++ idea go to sarum9in
+
+libA = library('A', 'libA.cpp')
+libB = library('B', 'libB.cpp', link_with : libA)
+
+main_exe = executable('C', 'main.cpp', link_with : [libA, libB])
+test('main test', main_exe)


### PR DESCRIPTION
`-Wl,-dead_strip_dylibs` is the analogue of `-Wl,--as-needed` on macOS.