### PR TITLE
Open mesontest logfiles using utf-8

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -509,8 +509,8 @@ TIMEOUT: %4d
         self.logfilename = logfile_base + '.txt'
         self.jsonlogfilename = logfile_base + '.json'
 
-        self.jsonlogfile = open(self.jsonlogfilename, 'w')
-        self.logfile = open(self.logfilename, 'w')
+        self.jsonlogfile = open(self.jsonlogfilename, 'w', encoding='utf-8')
+        self.logfile = open(self.logfilename, 'w', encoding='utf-8')
 
         self.logfile.write('Log of Meson test suite run on %s\n\n'
                            % datetime.datetime.now().isoformat())


### PR DESCRIPTION
Otherwise unit tests fail on windows when they output some
non-ascii data, see the python trace [here](https://ci.appveyor.com/project/nyorain/dlg/build/1.0.51/job/5at83tuynh77lj60) for example (the project includes a unit tests that outputs some weird utf-8 chars).

This was just a fix i found that worked, not sure if hard coding it is actually a good idea. But on the other hand this is already done at multiple places in meson so it should not really give anybody problems.