### PR TITLE
Do not install configure_file output if install_dir is empty. Closes …

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -173,7 +173,8 @@ These are all the supported keyword arguments:
   mode, all the variables in the `configuration:` object (see above)
   are written to the `output:` file.
 - `install_dir` the subdirectory to install the generated file to
-  (e.g. `share/myproject`), if omitted the file is not installed.
+  (e.g. `share/myproject`), if omitted or given the value of empty
+  string, the file is not installed.
 - `output` the output file name (since v0.41.0, may contain
   `@PLAINNAME@` or `@BASENAME@` substitutions). In configuration mode,
   the permissions of the input file (if it is specified) are copied to

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2973,9 +2973,11 @@ root and issuing %s.
             conffile = os.path.normpath(inputfile.relative_name())
             if conffile not in self.build_def_files:
                 self.build_def_files.append(conffile)
-        # Install file if requested
+        # Install file if requested, we check for the empty string
+        # for backwards compatibility. That was the behaviour before
+        # 0.45.0 so preserve it.
         idir = kwargs.get('install_dir', None)
-        if isinstance(idir, str):
+        if isinstance(idir, str) and idir:
             cfile = mesonlib.File.from_built_file(ofile_path, ofile_fname)
             self.build.data.append(build.Data([cfile], idir))
         return mesonlib.File.from_built_file(self.subdir, output)

--- a/test cases/common/16 configure file/meson.build
+++ b/test cases/common/16 configure file/meson.build
@@ -131,3 +131,9 @@ configure_file(
   configuration : conf6
 )
 test('test6', executable('prog6', 'prog6.c'))
+
+# test empty install dir string
+cfile = configure_file(input : 'config.h.in',
+  output : 'do_not_get_installed.h',
+  install_dir : '',
+  configuration : conf)


### PR DESCRIPTION
…#3270.