### PR TITLE
Fix b_ndebug=if-release silently not working

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2137,8 +2137,7 @@ rule FORTRAN_DEP_HACK
         return incs
 
     def _generate_single_compile(self, target, compiler, is_generated=False):
-        base_proxy = backends.OptionOverrideProxy(target.option_overrides,
-                                                  self.environment.coredata.base_options)
+        base_proxy = self.get_base_options_for_target(target)
         # Create an empty commands list, and start adding arguments from
         # various sources in the order in which they must override each other
         commands = CompilerArgs(compiler)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -315,7 +315,9 @@ def get_base_compile_args(options, compiler):
     except KeyError:
         pass
     try:
-        if options['b_ndebug'].value == 'true' or (options['b_ndebug'].value == 'if-release' and options['buildtype'] == 'release'):
+        if (options['b_ndebug'].value == 'true' or
+                (options['b_ndebug'].value == 'if-release' and
+                 options['buildtype'].value == 'release')):
             args += ['-DNDEBUG']
     except KeyError:
         pass

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1895,6 +1895,20 @@ int main(int argc, char **argv) {
                     exception_raised = True
         self.assertTrue(exception_raised, 'Double locking did not raise exception.')
 
+    def test_ndebug_if_release_disabled(self):
+        testdir = os.path.join(self.unit_test_dir, '25 ndebug if-release')
+        self.init(testdir, extra_args=['--buildtype=release', '-Db_ndebug=if-release'])
+        self.build()
+        exe = os.path.join(self.builddir, 'main')
+        self.assertEqual(b'NDEBUG=1', subprocess.check_output(exe).strip())
+
+    def test_ndebug_if_release_enabled(self):
+        testdir = os.path.join(self.unit_test_dir, '25 ndebug if-release')
+        self.init(testdir, extra_args=['--buildtype=debugoptimized', '-Db_ndebug=if-release'])
+        self.build()
+        exe = os.path.join(self.builddir, 'main')
+        self.assertEqual(b'NDEBUG=0', subprocess.check_output(exe).strip())
+
 
 class FailureTests(BasePlatformTests):
     '''

--- a/test cases/common/185 ndebug if-release enabled/main.c
+++ b/test cases/common/185 ndebug if-release enabled/main.c
@@ -1,0 +1,15 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int meson_test_side_effect = EXIT_FAILURE;
+
+int meson_test_set_side_effect(void) {
+    meson_test_side_effect = EXIT_SUCCESS;
+    return 1;
+}
+
+int main(void) {
+    // meson_test_side_effect is set only if assert is executed
+    assert(meson_test_set_side_effect());
+    return meson_test_side_effect;
+}

--- a/test cases/common/185 ndebug if-release enabled/meson.build
+++ b/test cases/common/185 ndebug if-release enabled/meson.build
@@ -1,0 +1,7 @@
+project('ndebug enabled', 'c',
+        default_options : [
+          'buildtype=debugoptimized',
+          'b_ndebug=if-release',
+        ])
+
+test('exe', executable('main', 'main.c'))

--- a/test cases/common/185 ndebug if-release enabled/meson.build
+++ b/test cases/common/185 ndebug if-release enabled/meson.build
@@ -4,4 +4,8 @@ project('ndebug enabled', 'c',
           'b_ndebug=if-release',
         ])
 
+if meson.get_compiler('c').get_id() == 'msvc'
+  error('MESON_SKIP_TEST b_ndebug is not supported on Visual Studio')
+endif
+
 test('exe', executable('main', 'main.c'))

--- a/test cases/common/186 ndebug if-release disabled/main.c
+++ b/test cases/common/186 ndebug if-release disabled/main.c
@@ -1,0 +1,7 @@
+#include <assert.h>
+#include <stdlib.h>
+
+int main(void) {
+    assert(0);
+    return EXIT_SUCCESS;
+}

--- a/test cases/common/186 ndebug if-release disabled/meson.build
+++ b/test cases/common/186 ndebug if-release disabled/meson.build
@@ -1,0 +1,7 @@
+project('ndebug disabled', 'c',
+        default_options : [
+          'buildtype=release',
+          'b_ndebug=if-release',
+        ])
+
+test('exe', executable('main', 'main.c'))

--- a/test cases/common/186 ndebug if-release disabled/meson.build
+++ b/test cases/common/186 ndebug if-release disabled/meson.build
@@ -4,4 +4,8 @@ project('ndebug disabled', 'c',
           'b_ndebug=if-release',
         ])
 
+if meson.get_compiler('c').get_id() == 'msvc'
+  error('MESON_SKIP_TEST b_ndebug is not supported on Visual Studio')
+endif
+
 test('exe', executable('main', 'main.c'))

--- a/test cases/unit/25 ndebug if-release/main.c
+++ b/test cases/unit/25 ndebug if-release/main.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+#ifdef NDEBUG
+    printf("NDEBUG=1\n");
+#else
+    printf("NDEBUG=0\n");
+#endif
+    return 0;
+}

--- a/test cases/unit/25 ndebug if-release/meson.build
+++ b/test cases/unit/25 ndebug if-release/meson.build
@@ -1,0 +1,3 @@
+project('ndebug enabled', 'c')
+
+executable('main', 'main.c')

--- a/test cases/unit/25 ndebug if-release/meson.build
+++ b/test cases/unit/25 ndebug if-release/meson.build
@@ -1,3 +1,7 @@
 project('ndebug enabled', 'c')
 
+if meson.get_compiler('c').get_id() == 'msvc'
+  error('MESON_SKIP_TEST b_ndebug is not supported on Visual Studio')
+endif
+
 executable('main', 'main.c')


### PR DESCRIPTION
Co-authored-by: David Seifert <soap@gentoo.org>

This reveals a bug with `b_ndebug=if-release`. This feature was introduced in #1896 but it never worked and never was tested.
Currently `compilers.get_base_compile_args()` does not have target context, e.g. `buildtype`. The problem is `if-release` depends on target settings, particularly `buildtype`.

So the question is
- Do we want `compilers.get_base_compile_args()` to be independent from target options?
- Do we want to keep abstraction-breaking `if-release` at all? Probably yes because users like it. But it never worked...
- Could it be that it should be `c_ndebug` option which can depend on target?