### PR TITLE
Update test() in Reference Manual

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -369,9 +369,8 @@ can be of the following types:
 These input files can be sources, objects, libraries, or any other
 file. Meson will automatically categorize them based on the extension
 and use them accordingly. For instance, sources (`.c`, `.cpp`,
-`.vala`, `.rs`, etc) will be compiled, objects (`.o`, `.obj`) and
-libraries (`.so`, `.dll`, etc) will be linked, and all other files
-(headers, unknown extensions, etc) will be ignored.
+`.vala`, `.rs`, etc) will be compiled and objects (`.o`, `.obj`) and
+libraries (`.so`, `.dll`, etc) will be linked.
 
 With the Ninja backend, Meson will create a build-time [order-only
 dependency](https://ninja-build.org/manual.html#ref_dependencies) on

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1167,9 +1167,17 @@ argument to [`dependency()`](#dependency).
     void test(name, executable, ...)
 ```
 
-Defines a unit test. Takes two positional arguments, the first is the
-name of this test and the second is the executable to run. Keyword
-arguments are the following.
+Defines a test to run with the test harness. Takes two positional arguments,
+the first is the name of the test and the second is the executable to run.
+The executable can be an [executable build target object](#build-target-object)
+returned by [`executable()`](#executable) or an
+[external program object](#external-program-object) returned by
+[`find_program()`](#find_program). The executable's exit code is used by the
+test harness to record the outcome of the test, for example exit code zero
+indicates success. For more on the Meson test harness protocol read
+[Unit Tests](Unit-tests.md).
+
+Keyword arguments are the following:
 
 - `args` arguments to pass to the executable
 


### PR DESCRIPTION
Clarifies that `test()` can take an external program and removes statement that `executable()` ignores unknown files. See #3283.