### PR TITLE
Skip CI for documentation-only pull requests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,6 +72,9 @@ install:
   # For all other archs (including, say, arm), use the x64 python.
   - cmd: if %arch%==x86 (set MESON_PYTHON_PATH=C:\python35) else (set MESON_PYTHON_PATH=C:\python35-x64)
 
+  # Skip CI requires python
+  - cmd: python ./skip_ci.py --base-branch-env=APPVEYOR_REPO_BRANCH --is-pull-env=APPVEYOR_PULL_REQUEST_NUMBER
+
   # Set paths for BOOST dll files
   - cmd: if %compiler%==msvc2015 ( if %arch%==x86 ( set "PATH=%PATH%;C:\Libraries\boost_1_59_0\lib32-msvc-14.0" ) else ( set "PATH=%PATH%;C:\Libraries\boost_1_59_0\lib64-msvc-14.0" ) )
   - cmd: if %compiler%==msvc2017 ( if %arch%==x86 ( set "PATH=%PATH%;C:\Libraries\boost_1_64_0\lib32-msvc-14.1" ) else ( set "PATH=%PATH%;C:\Libraries\boost_1_64_0\lib64-msvc-14.1" ) )

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
     compiler: gcc
 
 before_install:
+  - python ./skip_ci.py --base-branch-env=TRAVIS_BRANCH --is-pull-env=TRAVIS_PULL_REQUEST
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew uninstall python mercurial; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python@2 python@3 mercurial qt; fi

--- a/skip_ci.py
+++ b/skip_ci.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright 2018 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import argparse
+import os
+import subprocess
+import sys
+import traceback
+
+
+def check_pr(is_pr_env):
+    if is_pr_env not in os.environ:
+        print('This is not pull request: {} is not set'.format(is_pr_env))
+        sys.exit()
+    elif os.environ[is_pr_env] == 'false':
+        print('This is not pull request: {} is false'.format(is_pr_env))
+        sys.exit()
+
+
+def get_base_branch(base_env):
+    if base_env not in os.environ:
+        print('Unable to determine base branch: {} is not set'.format(base_env))
+        sys.exit()
+    return os.environ[base_env]
+
+
+def get_git_files(base):
+    diff = subprocess.check_output(['git', 'diff', '--name-only', base + '...HEAD'])
+    return diff.strip().split(b'\n')
+
+
+def is_documentation(filename):
+    return filename.startswith(b'docs/')
+
+
+def main():
+    try:
+        parser = argparse.ArgumentParser(description='CI Skipper')
+        parser.add_argument('--base-branch-env', required=True,
+                            help='Branch push is targeted to')
+        parser.add_argument('--is-pull-env', required=True,
+                            help='Variable set if it is a PR')
+        args = parser.parse_args()
+        check_pr(args.is_pull_env)
+        base = get_base_branch(args.base_branch_env)
+        if all(is_documentation(f) for f in get_git_files(base)):
+            print("Don't run CI for documentation-only changes, add '[skip ci]' to commit title.")
+            print('See http://mesonbuild.com/Contributing.html#skipping-integration-tests')
+            sys.exit(1)
+    except Exception:
+        # If this script fails we want build to proceed.
+        # Failure likely means some corner case we did not consider or bug.
+        # Either case this should not prevent CI from running if it is needed,
+        # and we tolerate it if it is run where it is not required.
+        traceback.print_exc()
+        print('There is a BUG in skip_ci.py, exiting.')
+        sys.exit()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Closes #3294

Since this code does not skip CI for direct commits, only pull requests, code coverage should not be affected.

Tested manually.

Commit to master, everything is built normally:
- https://github.com/sarum9in/meson/commit/28576ad0d0f14cde36576e0b7d780aa9ff9db451
- https://travis-ci.org/sarum9in/meson/builds/357160287
- https://ci.appveyor.com/project/sarum9in/meson/build/79

Pull request, documentation only, skipped (~45s per build, yay!):
- https://github.com/sarum9in/meson/pull/11
- https://travis-ci.org/sarum9in/meson/builds/357160403
- https://ci.appveyor.com/project/sarum9in/meson/build/78 

Documentation-only merge, everything is built normally:
- https://github.com/sarum9in/meson/commit/1c33b0489f17c239511a27c5f026be184df7357c
- https://travis-ci.org/sarum9in/meson/builds/357284075
- https://ci.appveyor.com/project/sarum9in/meson/build/80

Pull request with code changes: [this one](#3298).
