### PR TITLE
pkgconfig generator: Add cflag from private dependencies

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -39,9 +39,10 @@ class DependenciesHelper:
         self.cflags += cflags
 
     def add_priv_libs(self, libs):
-        libs, reqs, _ = self._process_libs(libs, False)
+        libs, reqs, cflags = self._process_libs(libs, False)
         self.priv_libs += libs
         self.priv_reqs += reqs
+        self.cflags += cflags
 
     def add_pub_reqs(self, reqs):
         self.pub_reqs += self._process_reqs(reqs)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2273,7 +2273,7 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertEqual(sorted(out), sorted(['libfoo']))
 
         out = self._run(cmd + ['--cflags-only-other']).strip().split()
-        self.assertEqual(sorted(out), sorted(['-pthread', '-DCUSTOM']))
+        self.assertEqual(sorted(out), sorted(['-pthread', '-DCUSTOM', '-DCUSTOM2']))
 
         out = self._run(cmd + ['--libs-only-l', '--libs-only-other']).strip().split()
         self.assertEqual(sorted(out), sorted(['-pthread', '-lcustom',


### PR DESCRIPTION
This match the behaviour of pkg-config. Here "private" means the
library's user usually don't need to use symbols from the dependency but
it still exposes it in its API. That means that cflags are needed to
build.

See https://bugs.freedesktop.org/show_bug.cgi?id=105572.