### PR TITLE
Add test(depends) keyword parameter

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1198,6 +1198,13 @@ Keyword arguments are the following:
 - `workdir` absolute path that will be used as the working directory
   for the test
 
+- `depends` specifies that this test depends on the specified
+  target(s), even though it does not take any of them as a command
+  line argument. This is meant for cases where test finds those
+  targets internally, e.g. plugins or globbing. Those targets are built
+  before test is executed even if they have `build_by_default : false`.
+  Since 0.46.0
+
 Defined tests can be run in a backend-agnostic way by calling
 `meson test` inside the build dir, or by using backend-specific
 commands, such as `ninja test` or `msbuild RUN_TESTS.vcxproj`.

--- a/docs/markdown/snippets/test-depends.md
+++ b/docs/markdown/snippets/test-depends.md
@@ -1,0 +1,5 @@
+## test now supports depends keyword parameter
+
+Build targets and custom targets can be listed in depends argument of test
+function. These targets will be built before test is run even if they have
+`build_by_default : false`.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -709,6 +709,9 @@ class Backend:
                 if not isinstance(arg, (build.CustomTarget, build.BuildTarget)):
                     continue
                 result[arg.get_id()] = arg
+            for dep in t.depends:
+                assert isinstance(dep, (build.CustomTarget, build.BuildTarget))
+                result[dep.get_id()] = dep
         return result
 
     def get_custom_target_provided_libraries(self, target):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2624,7 +2624,7 @@ root and issuing %s.
             if 'command' not in kwargs:
                 raise InterpreterException('Missing "command" keyword argument')
             all_args = extract_as_list(kwargs, 'command')
-            deps = extract_as_list(kwargs, 'depends')
+            deps = extract_as_list(kwargs, 'depends', unholder=True)
         else:
             raise InterpreterException('Run_target needs at least one positional argument.')
 
@@ -2639,10 +2639,6 @@ root and issuing %s.
             raise InterpreterException('First argument must be a string.')
         cleaned_deps = []
         for d in deps:
-            try:
-                d = d.held_object
-            except AttributeError:
-                pass
             if not isinstance(d, (build.BuildTarget, build.CustomTarget)):
                 raise InterpreterException('Depends items must be build targets.')
             cleaned_deps.append(d)
@@ -3032,11 +3028,9 @@ different subdirectory.
         if ":" not in setup_name:
             setup_name = (self.subproject if self.subproject else self.build.project_name) + ":" + setup_name
         try:
-            inp = extract_as_list(kwargs, 'exe_wrapper')
+            inp = extract_as_list(kwargs, 'exe_wrapper', unholder=True)
             exe_wrapper = []
             for i in inp:
-                if hasattr(i, 'held_object'):
-                    i = i.held_object
                 if isinstance(i, str):
                     exe_wrapper.append(i)
                 elif isinstance(i, dependencies.ExternalProgram):

--- a/test cases/common/188 test depends/gen.py
+++ b/test cases/common/188 test depends/gen.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import sys
+
+
+def main():
+    with open(sys.argv[1], 'w') as out:
+        out.write(sys.argv[2])
+        out.write('\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/test cases/common/188 test depends/main.c
+++ b/test cases/common/188 test depends/main.c
@@ -1,0 +1,1 @@
+int main(void) { return 0; }

--- a/test cases/common/188 test depends/meson.build
+++ b/test cases/common/188 test depends/meson.build
@@ -1,0 +1,26 @@
+project('test depends', 'c')
+
+gen = find_program('gen.py')
+
+custom_dep = custom_target('custom_dep',
+  build_by_default : false,
+  output : 'custom_dep.txt',
+  command : [gen, '@OUTPUT@', 'custom_dep'],
+)
+
+exe_dep = executable('exe_dep', 'main.c',
+  build_by_default : false,
+)
+
+test_prog = find_program('test.py')
+test('string dependencies', test_prog,
+  args : [
+    # This is declared for convenience,
+    # real use case might have some obscure method
+    # to find these dependencies, e.g. automatic plugin loading.
+    'custom_dep.txt',
+    exe_dep.full_path(),
+  ],
+  depends : [custom_dep, exe_dep],
+  workdir : meson.current_build_dir(),
+)

--- a/test cases/common/188 test depends/test.py
+++ b/test cases/common/188 test depends/test.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import os
+import os.path
+import sys
+
+
+def main():
+    print('Looking in:', os.getcwd())
+    not_found = list()
+    for f in sys.argv[1:]:
+        if not os.path.exists(f):
+            not_found.append(f)
+    if not_found:
+        print('Not found:', ', '.join(not_found))
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Closes #3310 

This implementation adds dependees to `all` the same way as current `exe` and `cmd_args` are added.
If we decide to rework this later and make test dependencies more granular, code is located at the exact same place as other related code so this will be part of change.