### PR TITLE
Always build parser objects anew to avoid leaking old data.

### DIFF
--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -17,13 +17,15 @@ import sys
 import argparse
 from . import (coredata, mesonlib, build)
 
-parser = argparse.ArgumentParser(prog='meson configure')
+def buildparser():
+    parser = argparse.ArgumentParser(prog='meson configure')
 
-parser.add_argument('-D', action='append', default=[], dest='sets',
-                    help='Set an option to the given value.')
-parser.add_argument('directory', nargs='*')
-parser.add_argument('--clearcache', action='store_true', default=False,
-                    help='Clear cached state (e.g. found dependencies)')
+    parser.add_argument('-D', action='append', default=[], dest='sets',
+                        help='Set an option to the given value.')
+    parser.add_argument('directory', nargs='*')
+    parser.add_argument('--clearcache', action='store_true', default=False,
+                        help='Clear cached state (e.g. found dependencies)')
+    return parser
 
 
 class ConfException(mesonlib.MesonException):
@@ -226,7 +228,7 @@ def run(args):
     args = mesonlib.expand_arguments(args)
     if not args:
         args = [os.getcwd()]
-    options = parser.parse_args(args)
+    options = buildparser().parse_args(args)
     if len(options.directory) > 1:
         print('%s <build directory>' % args[0])
         print('If you omit the build directory, the current directory is substituted.')

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -26,26 +26,28 @@ import argparse
 import sys, os
 import pathlib
 
-parser = argparse.ArgumentParser(prog='meson introspect')
-parser.add_argument('--targets', action='store_true', dest='list_targets', default=False,
-                    help='List top level targets.')
-parser.add_argument('--installed', action='store_true', dest='list_installed', default=False,
-                    help='List all installed files and directories.')
-parser.add_argument('--target-files', action='store', dest='target_files', default=None,
-                    help='List source files for a given target.')
-parser.add_argument('--buildsystem-files', action='store_true', dest='buildsystem_files', default=False,
-                    help='List files that make up the build system.')
-parser.add_argument('--buildoptions', action='store_true', dest='buildoptions', default=False,
-                    help='List all build options.')
-parser.add_argument('--tests', action='store_true', dest='tests', default=False,
-                    help='List all unit tests.')
-parser.add_argument('--benchmarks', action='store_true', dest='benchmarks', default=False,
-                    help='List all benchmarks.')
-parser.add_argument('--dependencies', action='store_true', dest='dependencies', default=False,
-                    help='List external dependencies.')
-parser.add_argument('--projectinfo', action='store_true', dest='projectinfo', default=False,
-                    help='Information about projects.')
-parser.add_argument('builddir', nargs='?', help='The build directory')
+def buildparser():
+    parser = argparse.ArgumentParser(prog='meson introspect')
+    parser.add_argument('--targets', action='store_true', dest='list_targets', default=False,
+                        help='List top level targets.')
+    parser.add_argument('--installed', action='store_true', dest='list_installed', default=False,
+                        help='List all installed files and directories.')
+    parser.add_argument('--target-files', action='store', dest='target_files', default=None,
+                        help='List source files for a given target.')
+    parser.add_argument('--buildsystem-files', action='store_true', dest='buildsystem_files', default=False,
+                        help='List files that make up the build system.')
+    parser.add_argument('--buildoptions', action='store_true', dest='buildoptions', default=False,
+                        help='List all build options.')
+    parser.add_argument('--tests', action='store_true', dest='tests', default=False,
+                        help='List all unit tests.')
+    parser.add_argument('--benchmarks', action='store_true', dest='benchmarks', default=False,
+                        help='List all benchmarks.')
+    parser.add_argument('--dependencies', action='store_true', dest='dependencies', default=False,
+                        help='List external dependencies.')
+    parser.add_argument('--projectinfo', action='store_true', dest='projectinfo', default=False,
+                        help='Information about projects.')
+    parser.add_argument('builddir', nargs='?', help='The build directory')
+    return parser
 
 def determine_installed_path(target, installdata):
     install_target = None
@@ -202,7 +204,7 @@ def list_projinfo(builddata):
 
 def run(args):
     datadir = 'meson-private'
-    options = parser.parse_args(args)
+    options = buildparser().parse_args(args)
     if options.builddir is not None:
         datadir = os.path.join(options.builddir, datadir)
     if not os.path.isdir(datadir):

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -59,47 +59,49 @@ def determine_worker_count():
             num_workers = 1
     return num_workers
 
-parser = argparse.ArgumentParser(prog='meson test')
-parser.add_argument('--repeat', default=1, dest='repeat', type=int,
-                    help='Number of times to run the tests.')
-parser.add_argument('--no-rebuild', default=False, action='store_true',
-                    help='Do not rebuild before running tests.')
-parser.add_argument('--gdb', default=False, dest='gdb', action='store_true',
-                    help='Run test under gdb.')
-parser.add_argument('--list', default=False, dest='list', action='store_true',
-                    help='List available tests.')
-parser.add_argument('--wrapper', default=None, dest='wrapper', type=shlex.split,
-                    help='wrapper to run tests with (e.g. Valgrind)')
-parser.add_argument('-C', default='.', dest='wd',
-                    help='directory to cd into before running')
-parser.add_argument('--suite', default=[], dest='include_suites', action='append', metavar='SUITE',
-                    help='Only run tests belonging to the given suite.')
-parser.add_argument('--no-suite', default=[], dest='exclude_suites', action='append', metavar='SUITE',
-                    help='Do not run tests belonging to the given suite.')
-parser.add_argument('--no-stdsplit', default=True, dest='split', action='store_false',
-                    help='Do not split stderr and stdout in test logs.')
-parser.add_argument('--print-errorlogs', default=False, action='store_true',
-                    help="Whether to print failing tests' logs.")
-parser.add_argument('--benchmark', default=False, action='store_true',
-                    help="Run benchmarks instead of tests.")
-parser.add_argument('--logbase', default='testlog',
-                    help="Base name for log file.")
-parser.add_argument('--num-processes', default=determine_worker_count(), type=int,
-                    help='How many parallel processes to use.')
-parser.add_argument('-v', '--verbose', default=False, action='store_true',
-                    help='Do not redirect stdout and stderr')
-parser.add_argument('-q', '--quiet', default=False, action='store_true',
-                    help='Produce less output to the terminal.')
-parser.add_argument('-t', '--timeout-multiplier', type=float, default=None,
-                    help='Define a multiplier for test timeout, for example '
-                    ' when running tests in particular conditions they might take'
-                    ' more time to execute.')
-parser.add_argument('--setup', default=None, dest='setup',
-                    help='Which test setup to use.')
-parser.add_argument('--test-args', default=[], type=shlex.split,
-                    help='Arguments to pass to the specified test(s) or all tests')
-parser.add_argument('args', nargs='*',
-                    help='Optional list of tests to run')
+def buildparser():
+    parser = argparse.ArgumentParser(prog='meson test')
+    parser.add_argument('--repeat', default=1, dest='repeat', type=int,
+                        help='Number of times to run the tests.')
+    parser.add_argument('--no-rebuild', default=False, action='store_true',
+                        help='Do not rebuild before running tests.')
+    parser.add_argument('--gdb', default=False, dest='gdb', action='store_true',
+                        help='Run test under gdb.')
+    parser.add_argument('--list', default=False, dest='list', action='store_true',
+                        help='List available tests.')
+    parser.add_argument('--wrapper', default=None, dest='wrapper', type=shlex.split,
+                        help='wrapper to run tests with (e.g. Valgrind)')
+    parser.add_argument('-C', default='.', dest='wd',
+                        help='directory to cd into before running')
+    parser.add_argument('--suite', default=[], dest='include_suites', action='append', metavar='SUITE',
+                        help='Only run tests belonging to the given suite.')
+    parser.add_argument('--no-suite', default=[], dest='exclude_suites', action='append', metavar='SUITE',
+                        help='Do not run tests belonging to the given suite.')
+    parser.add_argument('--no-stdsplit', default=True, dest='split', action='store_false',
+                        help='Do not split stderr and stdout in test logs.')
+    parser.add_argument('--print-errorlogs', default=False, action='store_true',
+                        help="Whether to print failing tests' logs.")
+    parser.add_argument('--benchmark', default=False, action='store_true',
+                        help="Run benchmarks instead of tests.")
+    parser.add_argument('--logbase', default='testlog',
+                        help="Base name for log file.")
+    parser.add_argument('--num-processes', default=determine_worker_count(), type=int,
+                        help='How many parallel processes to use.')
+    parser.add_argument('-v', '--verbose', default=False, action='store_true',
+                        help='Do not redirect stdout and stderr')
+    parser.add_argument('-q', '--quiet', default=False, action='store_true',
+                        help='Produce less output to the terminal.')
+    parser.add_argument('-t', '--timeout-multiplier', type=float, default=None,
+                        help='Define a multiplier for test timeout, for example '
+                        ' when running tests in particular conditions they might take'
+                        ' more time to execute.')
+    parser.add_argument('--setup', default=None, dest='setup',
+                        help='Which test setup to use.')
+    parser.add_argument('--test-args', default=[], type=shlex.split,
+                        help='Arguments to pass to the specified test(s) or all tests')
+    parser.add_argument('args', nargs='*',
+                        help='Optional list of tests to run')
+    return parser
 
 
 class TestException(mesonlib.MesonException):
@@ -622,7 +624,7 @@ def rebuild_all(wd):
     return True
 
 def run(args):
-    options = parser.parse_args(args)
+    options = buildparser().parse_args(args)
 
     if options.benchmark:
         options.num_processes = 1

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -29,18 +29,20 @@ from mesonbuild import mlog
 import sys, traceback
 import argparse
 
-parser = argparse.ArgumentParser(prog='meson rewrite')
+def buildparser():
+    parser = argparse.ArgumentParser(prog='meson rewrite')
 
-parser.add_argument('--sourcedir', default='.',
-                    help='Path to source directory.')
-parser.add_argument('--target', default=None,
-                    help='Name of target to edit.')
-parser.add_argument('--filename', default=None,
-                    help='Name of source file to add or remove to target.')
-parser.add_argument('commands', nargs='+')
+    parser.add_argument('--sourcedir', default='.',
+                        help='Path to source directory.')
+    parser.add_argument('--target', default=None,
+                        help='Name of target to edit.')
+    parser.add_argument('--filename', default=None,
+                        help='Name of source file to add or remove to target.')
+    parser.add_argument('commands', nargs='+')
+    return parser
 
 def run(args):
-    options = parser.parse_args(args)
+    options = buildparser().parse_args(args)
     if options.target is None or options.filename is None:
         sys.exit("Must specify both target and filename.")
     print('This tool is highly experimental, use with care.')

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -21,8 +21,10 @@ import subprocess
 
 options = None
 
-parser = argparse.ArgumentParser()
-parser.add_argument('args', nargs='+')
+def buildparser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('args', nargs='+')
+    return parser
 
 def is_windows():
     platname = platform.system().lower()
@@ -70,7 +72,7 @@ def run_exe(exe):
 
 def run(args):
     global options
-    options = parser.parse_args(args)
+    options = buildparser().parse_args(args)
     if len(options.args) != 1:
         print('Test runner for Meson. Do not run on your own, mmm\'kay?')
         print(sys.argv[0] + ' [data file]')


### PR DESCRIPTION
Might help with #3290.

Scripts not converted yet because they are always run in a fresh process.