### PR TITLE
Add build_args() that can be passed as extra_args to build targets

### DIFF
--- a/test cases/common/189 bothlibraries/libfile.c
+++ b/test cases/common/189 bothlibraries/libfile.c
@@ -1,6 +1,10 @@
 #include "mylib.h"
 
+#ifdef STATIC_COMPILATION
 DO_EXPORT int retval = 42;
+#else
+DO_EXPORT int retval = 43;
+#endif
 
 DO_EXPORT int func() {
     return retval;

--- a/test cases/common/189 bothlibraries/main.c
+++ b/test cases/common/189 bothlibraries/main.c
@@ -1,8 +1,15 @@
+#include <stdlib.h>
 #include "mylib.h"
 
 DO_IMPORT int func();
 DO_IMPORT int retval;
 
-int main(int argc, char **arg) {
-    return func() == retval ? 0 : 1;
+int main(int argc, char *argv[]) {
+    if (func() != retval)
+        return 1;
+
+    if (argc > 1 && atoi(argv[1]) != retval)
+        return 1;
+
+    return 0;
 }

--- a/test cases/common/189 bothlibraries/meson.build
+++ b/test cases/common/189 bothlibraries/meson.build
@@ -10,3 +10,19 @@ exe_both = executable('prog-both', 'main.c', link_with : both_libs)
 test('runtest-shared', exe_shared)
 test('runtest-static', exe_static)
 test('runtest-both', exe_both)
+
+args = build_args()
+args.add_compiler_args('-DSTATIC_COMPILATION',
+  target_type : 'static_library',
+  language : 'c',
+)
+
+both_libs = both_libraries('mylib-diffargs', 'libfile.c', extra_args : args)
+exe_shared = executable('prog-shared-diffargs', 'main.c',
+                        link_with : both_libs.get_shared_lib())
+exe_static = executable('prog-static-diffargs', 'main.c',
+                        c_args : ['-DSTATIC_COMPILATION'],
+                        link_with : both_libs.get_static_lib())
+
+test('runtest-shared-diffargs', exe_shared, args : '43')
+test('runtest-static-diffargs', exe_static, args : '42')


### PR DESCRIPTION
The principal use-case is to pass different compiler flags to library() depending if it's building the static or shared library.

Closes: #3304
