### PR TITLE
Use dependencies for cc.find_library()

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1438,8 +1438,12 @@ the following methods:
   value of `dependency`. If the keyword argument `required` is false,
   Meson will proceed even if the library is not found. By default the
   library is searched for in the system library directory
-  (e.g. /usr/lib). This can be overridden with the `dirs` keyword
-  argument, which can be either a string or a list of strings.
+  (e.g. /usr/lib). If libraries are installed outside of the system
+  library directory, the `dependencies` keyword argument can be used
+  to look in additional directories. Furthermore, if it is known in
+  which directory the library is to be found, the list of search
+  directories can be overridden with the `dirs` keyword argument,
+  which can be either a string or a list of strings.
 
 - `first_supported_argument(list_of_strings)`, given a list of
   strings, returns the first argument that passes the `has_argument`

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -766,7 +766,7 @@ class CCompiler(Compiler):
             raise AssertionError('BUG: unknown libtype {!r}'.format(libtype))
         return prefixes, suffixes
 
-    def find_library(self, libname, env, extra_dirs, libtype='default'):
+    def find_library(self, libname, env, extra_dirs, libtype='default', dependencies = None):
         # These libraries are either built-in or invalid
         if libname in self.ignore_libs:
             return []
@@ -778,7 +778,7 @@ class CCompiler(Compiler):
         # Only try to find std libs if no extra dirs specified.
         if not extra_dirs and libtype == 'default':
             args = ['-l' + libname]
-            if self.links(code, env, extra_args=args):
+            if self.links(code, env, extra_args=args, dependencies=dependencies):
                 return args
         # Ensure that we won't modify the list that was passed to us
         extra_dirs = extra_dirs[:]

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -74,7 +74,7 @@ class ValaCompiler(Compiler):
             return ['--debug']
         return []
 
-    def find_library(self, libname, env, extra_dirs):
+    def find_library(self, libname, env, extra_dirs, dependencies = None):
         if extra_dirs and isinstance(extra_dirs, str):
             extra_dirs = [extra_dirs]
         # Valac always looks in the default vapi dir, so only search there if

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1147,7 +1147,8 @@ class CompilerHolder(InterpreterObject):
         for i in search_dirs:
             if not os.path.isabs(i):
                 raise InvalidCode('Search directory %s is not an absolute path.' % i)
-        linkargs = self.compiler.find_library(libname, self.environment, search_dirs)
+        deps = self.determine_dependencies(kwargs)
+        linkargs = self.compiler.find_library(libname, self.environment, search_dirs, dependencies = deps)
         if required and not linkargs:
             raise InterpreterException('{} library {!r} not found'.format(self.compiler.get_display_language(), libname))
         lib = dependencies.ExternalLibrary(libname, linkargs, self.environment,


### PR DESCRIPTION
Allows the `dependencies' keyword argument to be used with the
cc.find_library() command. This has the effect of adding the compile and
link arguments of each dependency to the command-line which may be
necessary to find the library. The `dirs' keyword argument can still be
used to specify a list of search directories that overrides any of the
dependencies specified.

Note that specifying the list of search directories is not safe unless
you know exactly what you are doing because it will not attempt to link
to the library. Instead it will return the path to the library if it
exists, but that does not automatically guarantee that the library can
really be linked against (for example during cross-compilation). This
can lead the configuration step to succeed but give an error during
linking. Attempting to link against the library using the library paths
provided by the dependencies should therefore be the preferred method.

Signed-off-by: Thierry Reding <treding@nvidia.com>