### PR TITLE
Don't crash when using d_module_versions for pkg-config

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -349,7 +349,7 @@ class PkgConfigModule(ExtensionModule):
         if dversions:
             compiler = state.environment.coredata.compilers.get('d')
             if compiler:
-                deps.add_cflags(compiler.get_feature_args({'versions': dversions}))
+                deps.add_cflags(compiler.get_feature_args({'versions': dversions}, None))
 
         def parse_variable_list(stringlist):
             reserved = ['prefix', 'libdir', 'includedir']

--- a/test cases/d/3 shared library/meson.build
+++ b/test cases/d/3 shared library/meson.build
@@ -10,3 +10,12 @@ endif
 ldyn = shared_library('stuff', 'libstuff.d', install : true)
 ed = executable('app_d', 'app.d', link_with : ldyn, install : true)
 test('linktest_dyn', ed)
+
+# test D attributes for pkg-config
+pkgc = import('pkgconfig')
+pkgc.generate(name: 'test',
+              libraries: ldyn,
+              subdirs: 'd/stuff',
+              description: 'A test of D attributes to pkgconfig.generate.',
+              d_module_versions: ['Use_Static']
+)


### PR DESCRIPTION
Fairly self-explanatory, and seems to be a regression in 0.45.
Passing in None here shouldn't be an issue, because `versions` has no dependency on build_to_src anyway.