### PR TITLE
Add link to `meson` github topic

### DIFF
--- a/docs/markdown/Users.md
+++ b/docs/markdown/Users.md
@@ -4,7 +4,8 @@ title: Users
 
 # List of projects using Meson
 
-If you have a project that uses Meson that you want to add to this list, please [file a pull-request](https://github.com/mesonbuild/meson/edit/master/docs/markdown/Users.md) for it. All the software on this list is tested for regressions before release, so it's highly recommended that projects add themselves here.
+If you have a project that uses Meson that you want to add to this list, please [file a pull-request](https://github.com/mesonbuild/meson/edit/master/docs/markdown/Users.md) for it. All the software on this list is tested for regressions before release, so it's highly recommended that projects add themselves here. Some additional projects are
+listed in the [`meson` GitHub topic](https://github.com/topics/meson).
 
  - [AQEMU](https://github.com/tobimensch/aqemu), a Qt GUI for QEMU virtual machines, since version 0.9.3
  - [Arduino sample project](https://github.com/jpakkane/mesonarduino)


### PR DESCRIPTION
Showcases a number of projects that are not shown in the existing list.