### PR TITLE
gnome.gtkdoc: Fix generated files used as content files

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -792,7 +792,7 @@ This will become a hard error in the future.''')
                                                   state.backend.get_target_dir(s),
                                                   s.get_outputs()[0]))
             elif isinstance(s, mesonlib.File):
-                content_files.append(s.rel_to_builddir(state.build_to_src))
+                content_files.append(os.path.join(state.environment.get_build_dir(), s.subdir, s.fname))
             elif isinstance(s, build.GeneratedList):
                 depends.append(s)
                 for gen_src in s.get_outputs():


### PR DESCRIPTION
The `gtkdoc` function in the `gnome` module is able to use generated files as content files, but the path to these is wrong in the used command line.

This should fix half of the problem from issue #3317, because it also involves #2909 that should also be fixed by #3189.