### PR TITLE
Add module argument to library()

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -929,6 +929,9 @@ The keyword arguments for this are the same as for [`executable`](#executable) w
 - `rust_crate_type` specifies the crate type for Rust
   libraries. Defaults to `dylib` for shared libraries and `rlib` for
   static libraries.
+- `module` if set to `true` and a shared library is built (because
+  `default_library` is `shared` or `both`), a [shared module](#shared_module)
+  will be built instead. Since 0.46.0.
 
 `static_library`, `shared_library` and `both_libraries` also accept these keyword
 arguments.

--- a/docs/markdown/snippets/both-libraries.md
+++ b/docs/markdown/snippets/both-libraries.md
@@ -7,3 +7,7 @@ files will be reused to build both shared and static libraries, unless
 sources will be compiled twice.
 
 The returned `buildtarget` object always represents the shared library.
+
+A new `module` keyword argument has been added to `library()` and
+`both_libraries()` functions to build a `shared_module()` instead of the shared
+library. This is useful to build a module that can also be statically linked.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1445,7 +1445,8 @@ class MesonMain(InterpreterObject):
 
 known_library_kwargs = (
     build.known_shlib_kwargs |
-    build.known_stlib_kwargs
+    build.known_stlib_kwargs |
+    {'module'}
 )
 
 known_build_target_kwargs = (
@@ -3258,6 +3259,13 @@ different subdirectory.
             ef = extract_as_list(kwargs, 'extra_files')
             kwargs['extra_files'] = self.source_strings_to_files(ef)
         self.check_sources_exist(os.path.join(self.source_root, self.subdir), sources)
+
+        module = kwargs.get('module', False)
+        if not isinstance(module, bool):
+            raise InterpreterException('Module keyword argument must be boolean')
+        if module and targetholder is SharedLibraryHolder:
+            targetholder = SharedModuleHolder
+
         if targetholder is ExecutableHolder:
             targetclass = build.Executable
         elif targetholder is SharedLibraryHolder:

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -87,6 +87,7 @@ class DependenciesHelper:
         processed_reqs = []
         processed_cflags = []
         for obj in libs:
+            shared_library_only = getattr(obj, 'shared_library_only', False)
             if hasattr(obj, 'pcdep'):
                 pcdeps = mesonlib.listify(obj.pcdep)
                 for d in pcdeps:
@@ -105,7 +106,7 @@ class DependenciesHelper:
                 if obj.found():
                     processed_libs += obj.get_link_args()
                     processed_cflags += obj.get_compile_args()
-            elif isinstance(obj, build.SharedLibrary) and obj.shared_library_only:
+            elif shared_library_only:
                 # Do not pull dependencies for shared libraries because they are
                 # only required for static linking. Adding private requires has
                 # the side effect of exposing their cflags, which is the


### PR DESCRIPTION
When set to `true` and a shared library is built (because `default_library` is `shared` or `both`), a shared module will be built instead.

This PR is based on the both-libraries PR.