### PR TITLE
Remove arbitrary [-1024,1024] limit in cross_compute_int()

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -984,20 +984,20 @@ class CompilerHolder(InterpreterObject):
         check_stringlist(args)
         expression = args[0]
         prefix = kwargs.get('prefix', '')
-        l = kwargs.get('low', -1024)
-        h = kwargs.get('high', 1024)
+        low = kwargs.get('low', None)
+        high = kwargs.get('high', None)
         guess = kwargs.get('guess', None)
         if not isinstance(prefix, str):
             raise InterpreterException('Prefix argument of compute_int must be a string.')
-        if not isinstance(l, int):
+        if low is not None and not isinstance(low, int):
             raise InterpreterException('Low argument of compute_int must be an int.')
-        if not isinstance(h, int):
+        if high is not None and not isinstance(high, int):
             raise InterpreterException('High argument of compute_int must be an int.')
         if guess is not None and not isinstance(guess, int):
             raise InterpreterException('Guess argument of compute_int must be an int.')
         extra_args = self.determine_args(kwargs)
         deps = self.determine_dependencies(kwargs)
-        res = self.compiler.compute_int(expression, l, h, guess, prefix, self.environment, extra_args, deps)
+        res = self.compiler.compute_int(expression, low, high, guess, prefix, self.environment, extra_args, deps)
         mlog.log('Computing int of "%s": %d' % (expression, res))
         return res
 

--- a/test cases/common/142 compute int/config.h.in
+++ b/test cases/common/142 compute int/config.h.in
@@ -1,2 +1,4 @@
 #define INTSIZE @INTSIZE@
 #define FOOBAR_IN_CONFIG_H @FOOBAR@
+#define MAXINT @MAXINT@
+#define MININT @MININT@

--- a/test cases/common/142 compute int/meson.build
+++ b/test cases/common/142 compute int/meson.build
@@ -7,11 +7,15 @@ cc = meson.get_compiler('c')
 
 intsize = cc.compute_int('sizeof(int)', low : 1, high : 16, guess : 4)
 foobar = cc.compute_int('FOOBAR_IN_FOOBAR_H', prefix : '#include "foobar.h"', include_directories : inc)
+maxint = cc.compute_int('INT_MAX', prefix: '#include <limits.h>')
+minint = cc.compute_int('INT_MIN', prefix: '#include <limits.h>')
 
 cd = configuration_data()
 cd.set('INTSIZE', intsize)
 cd.set('FOOBAR', foobar)
 cd.set('CONFIG', 'config.h')
+cd.set('MAXINT', maxint)
+cd.set('MININT', minint)
 configure_file(input : 'config.h.in', output : 'config.h', configuration : cd)
 s = configure_file(input : 'prog.c.in', output : 'prog.c', configuration : cd)
 
@@ -23,11 +27,15 @@ cpp = meson.get_compiler('cpp')
 
 intsize = cpp.compute_int('sizeof(int)')
 foobar = cpp.compute_int('FOOBAR_IN_FOOBAR_H', prefix : '#include "foobar.h"', include_directories : inc)
+maxint = cpp.compute_int('INT_MAX', prefix: '#include <limits.h>')
+minint = cpp.compute_int('INT_MIN', prefix: '#include <limits.h>')
 
 cdpp = configuration_data()
 cdpp.set('INTSIZE', intsize)
 cdpp.set('FOOBAR', foobar)
 cdpp.set('CONFIG', 'config.hpp')
+cdpp.set('MAXINT', maxint)
+cdpp.set('MININT', minint)
 configure_file(input : 'config.h.in', output : 'config.hpp', configuration : cdpp)
 spp = configure_file(input : 'prog.c.in', output : 'prog.cc', configuration : cdpp)
 

--- a/test cases/common/142 compute int/prog.c.in
+++ b/test cases/common/142 compute int/prog.c.in
@@ -1,6 +1,7 @@
 #include "@CONFIG@"
 #include <stdio.h>
 #include <wchar.h>
+#include <limits.h>
 #include "foobar.h"
 
 int main(int argc, char **argv) {
@@ -10,6 +11,14 @@ int main(int argc, char **argv) {
     }
     if(FOOBAR_IN_CONFIG_H != FOOBAR_IN_FOOBAR_H) {
         fprintf(stderr, "Mismatch: computed int %d, should be %d.\n", FOOBAR_IN_CONFIG_H, FOOBAR_IN_FOOBAR_H);
+        return 1;
+    }
+    if(MAXINT != INT_MAX) {
+        fprintf(stderr, "Mismatch: computed max int %d, should be %d.\n", MAXINT, INT_MAX);
+        return 1;
+    }
+    if(MININT != INT_MIN) {
+        fprintf(stderr, "Mismatch: computed min int %d, should be %d.\n", MININT, INT_MIN);
         return 1;
     }
     return 0;


### PR DESCRIPTION
Copy the algorithm used by autoconf.

It computes the upper and lower limits by starting at [-1,1] and
multiply by 2 at each iteration. This is even faster for small numbers
(the common case), for example it finds value 0 in just 2 compilations
where old algorithm would check for 1024, 512, ..., 0.