### PR TITLE
improve suite of meson test

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1245,6 +1245,12 @@ Keyword arguments are the following:
 - `workdir` absolute path that will be used as the working directory
   for the test
 
+- 'suite' label attached to this test. `meson test --suite suite_name`
+  run all the tests with suite defined as `suite_name`. Note that by
+  default, the full suite name is `project_name:suite_name`, so if you
+  want to select the test suite of a given (sub)project only, you have
+  to run 'meson test --test project_name:suite_name'
+
 Defined tests can be run in a backend-agnostic way by calling
 `meson test` inside the build dir, or by using backend-specific
 commands, such as `ninja test` or `msbuild RUN_TESTS.vcxproj`.

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1238,18 +1238,18 @@ Keyword arguments are the following:
 - `should_fail` when true the test is considered passed if the
   executable returns a non-zero return value (i.e. reports an error)
 
+- `suite` `'label'` (or list of labels `['label1', 'label2']`)
+  attached to this test. The suite name is qualified by a (sub)project
+  name resulting in `(sub)project_name:label`. In the case of a list
+  of strings, the suite names will be `(sub)project_name:label1`,
+  `(sub)project_name:label2`, etc.
+
 - `timeout` the amount of seconds the test is allowed to run, a test
   that exceeds its time limit is always considered failed, defaults to
   30 seconds
 
 - `workdir` absolute path that will be used as the working directory
   for the test
-
-- 'suite' label attached to this test. `meson test --suite suite_name`
-  run all the tests with suite defined as `suite_name`. Note that by
-  default, the full suite name is `project_name:suite_name`, so if you
-  want to select the test suite of a given (sub)project only, you have
-  to run 'meson test --test project_name:suite_name'
 
 Defined tests can be run in a backend-agnostic way by calling
 `meson test` inside the build dir, or by using backend-specific

--- a/docs/markdown/Unit-tests.md
+++ b/docs/markdown/Unit-tests.md
@@ -71,6 +71,14 @@ You can also run only a single test by giving its name:
 $ meson test testname
 ```
 
+Tests belonging to a suite `suite` can be run as follows
+
+```console
+$ meson test --suite (sub)project_name:suite
+```
+
+Since version *0.46*, `(sub)project_name` can be omitted if it is the top-level project.
+
 Sometimes you need to run the tests multiple times, which is done like this:
 
 ```console

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -476,6 +476,25 @@ TIMEOUT: %4d
             (prj_match, st_match) = TestHarness.split_suite_string(suite)
             for prjst in test.suite:
                 (prj, st) = TestHarness.split_suite_string(prjst)
+
+                # the SUITE can be passed as
+                #     suite_name
+                # or
+                #     project_name:suite_name
+                # so we need to select only the test belonging to project_name
+
+                # this if hanlde the first case (i.e., SUITE == suite_name)
+
+                # in this way we can run tests belonging to different
+                # (sub)projects which share the same suite_name
+                if not st_match and st == prj_match:
+                    return True
+
+                # these two conditions are needed to handle the second option
+                # i.e., SUITE == project_name:suite_name
+
+                # in this way we select the only the tests of
+                # project_name with suite_name
                 if prj_match and prj != prj_match:
                     continue
                 if st_match and st != st_match:


### PR DESCRIPTION
closes #3368.

I was trying to understand the syntax to be used and I realized that with the following `meson.build`
```
project('project_name', ...)

test('test_name', executable, suite: 'suite_name')
```
the correct syntax is
```
meson test --suite project_name:suite_name
```
which seemed a bit odd to me for the case of a unique project. So I extended a bit the functionality such that I can also run
```
meson test --suite suite_name
```

I also added the documentation of the keyword `suite` for the `test()` function (as I understood it)
closes https://github.com/mesonbuild/meson/issues/1674