### PR TITLE
Never install the glib-mkenums generated C source

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1046,6 +1046,12 @@ This will become a hard error in the future.''')
             raise MesonException(
                 'Sources keyword argument must be a string or array.')
 
+        # The `install_header` argument will be used by mkenums() when
+        # not using template files, so we need to forcibly unset it
+        # when generating the C source file, otherwise we will end up
+        # installing it
+        c_file_kwargs['install_header'] = False
+
         header_prefix = kwargs.get('header_prefix', '')
         decl_decorator = kwargs.get('decorator', '')
         func_prefix = kwargs.get('function_prefix', '')

--- a/test cases/frameworks/7 gnome/installed_files.txt
+++ b/test cases/frameworks/7 gnome/installed_files.txt
@@ -1,6 +1,7 @@
 usr/include/enums.h
 usr/include/enums2.h
 usr/include/enums3.h
+usr/include/enums5.h
 usr/include/marshaller.h
 usr/lib/?libgir_lib.so
 usr/lib/?libdep1lib.so

--- a/test cases/frameworks/7 gnome/mkenums/meson.build
+++ b/test cases/frameworks/7 gnome/mkenums/meson.build
@@ -123,6 +123,7 @@ enums4 = gnome.mkenums_simple('enums4', sources : 'meson-sample.h',
 enumexe4 = executable('enumprog4', 'main4.c', enums4, dependencies : gobj)
 
 enums5 = gnome.mkenums_simple('enums5', sources : 'meson-sample.h',
+                              install_header : true,
                               decorator : 'MESON_EXPORT',
                               header_prefix : '#include "meson-decls.h"')
 enumexe5 = executable('enumprog5', main, enums5, dependencies : gobj)


### PR DESCRIPTION
When using gnome.mkenums_simple() we end up installing the generated
C source file alongside the C header file, if `install_header` is set
to True. This is caused by mkenums_simple() acting as a wrapper for
mkenums() without template files; mkenums() won't be able to know if
we're generating the header or the source, and will use the presence
of `install_header` as the deciding factor as to whether the generated
file should be installed.

When generating the C source file, we should always unset the
`install_header` option to False, just like mkenums() expects.

Closes #3373