### PR TITLE
vala: Don't pass -o and -C at the same time

### DIFF
--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -35,10 +35,10 @@ class ValaCompiler(Compiler):
         return False # Because compiles into C.
 
     def get_output_args(self, target):
-        return ['-o', target]
+        return [] # Because compiles into C.
 
     def get_compile_only_args(self):
-        return ['-C']
+        return [] # Because compiles into C.
 
     def get_pic_args(self):
         return []


### PR DESCRIPTION
Fixes "warning: --output and -o have no effect when -C or --ccode is set"

get_always_args() adds -C which is already disabling the direct compilation
ability of valac for which -o is used.