### PR TITLE
wraptool: Allow promoting a subproject called foo.wrap

### DIFF
--- a/mesonbuild/wrap/wraptool.py
+++ b/mesonbuild/wrap/wraptool.py
@@ -160,8 +160,11 @@ def promote(argument):
     path_segment, subproject_name = os.path.split(argument)
     spdir_name = 'subprojects'
     sprojs = mesonlib.detect_subprojects(spdir_name)
+    # The command we suggest ends with .wrap, so allow that too
+    if subproject_name.endswith('.wrap'):
+        subproject_name = subproject_name[:-5]
     if subproject_name not in sprojs:
-        sys.exit('Subproject %s not found in directory tree.' % subproject_name)
+        sys.exit('Subproject {!r} not found in directory tree'.format(subproject_name))
     matches = sprojs[subproject_name]
     if len(matches) == 1:
         do_promotion(matches[0], spdir_name)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1777,7 +1777,7 @@ int main(int argc, char **argv) {
         self.assertTrue(os.path.isdir(scommondir))
         promoted_wrap = os.path.join(spdir, 'athing.wrap')
         self.assertFalse(os.path.isfile(promoted_wrap))
-        subprocess.check_call(self.wrap_command + ['promote', 'athing'], cwd=workdir)
+        subprocess.check_call(self.wrap_command + ['promote', 'athing.wrap'], cwd=workdir)
         self.assertTrue(os.path.isfile(promoted_wrap))
         self.init(workdir)
         self.build()


### PR DESCRIPTION
During setup we suggest running `meson wrap promote path/to/foo.wrap` so accept that syntax too.