### PR TITLE
Don't fail on not-required not-found deps in forcefallback mode

### DIFF
--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -15,7 +15,7 @@
 from .boost import BoostDependency
 from .base import (  # noqa: F401
     Dependency, DependencyException, DependencyMethods, ExternalProgram, NonExistingExternalProgram,
-    ExternalDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
+    ExternalDependency, NotFoundDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
     PkgConfigDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language)
 from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDependency
 from .misc import (MPIDependency, Python3Dependency, ThreadDependency, PcapDependency, CupsDependency, LibWmfDependency)

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -209,6 +209,14 @@ class ExternalDependency(Dependency):
         return self.compiler
 
 
+class NotFoundDependency(Dependency):
+    def __init__(self, environment):
+        super().__init__('not-found', {})
+        self.env = environment
+        self.name = 'not-found'
+        self.is_found = False
+
+
 class ConfigToolDependency(ExternalDependency):
 
     """Class representing dependencies found using a config tool."""

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -23,7 +23,7 @@ from .wrap import wrap, WrapMode
 from . import mesonlib
 from .mesonlib import FileMode, Popen_safe, listify, extract_as_list, has_path_sep
 from .dependencies import ExternalProgram
-from .dependencies import InternalDependency, Dependency, DependencyException
+from .dependencies import InternalDependency, Dependency, NotFoundDependency, DependencyException
 from .interpreterbase import InterpreterBase
 from .interpreterbase import check_stringlist, noPosargs, noKwargs, stringArgs, permittedKwargs, permittedMethodKwargs
 from .interpreterbase import InterpreterException, InvalidArguments, InvalidCode, SubdirDoneRequest
@@ -2377,7 +2377,7 @@ to directly access options of other subprojects.''')
         if name == '':
             if required:
                 raise InvalidArguments('Dependency is both required and not-found')
-            return DependencyHolder(Dependency('not-found', {}))
+            return DependencyHolder(NotFoundDependency(self.environment))
 
         if '<' in name or '>' in name or '=' in name:
             raise InvalidArguments('Characters <, > and = are forbidden in dependency names. To specify'
@@ -2401,7 +2401,7 @@ to directly access options of other subprojects.''')
 
             # We need to actually search for this dep
             exception = None
-            dep = None
+            dep = NotFoundDependency(self.environment)
 
             # Search for it outside the project
             if self.coredata.wrap_mode != WrapMode.forcefallback or 'fallback' not in kwargs:
@@ -2413,7 +2413,7 @@ to directly access options of other subprojects.''')
                 exception = DependencyException("fallback for %s not found" % name)
 
             # Search inside the projects list
-            if not dep or not dep.found():
+            if not dep.found():
                 if 'fallback' in kwargs:
                     fallback_dep = self.dependency_fallback(name, kwargs)
                     if fallback_dep:
@@ -2421,7 +2421,7 @@ to directly access options of other subprojects.''')
                         # cannot cache them. They must always be evaluated else
                         # we won't actually read all the build files.
                         return fallback_dep
-                if not dep:
+                if required:
                     assert(exception is not None)
                     raise exception
 

--- a/test cases/unit/27 forcefallback/meson.build
+++ b/test cases/unit/27 forcefallback/meson.build
@@ -2,7 +2,8 @@ project('mainproj', 'c',
   default_options : ['wrap_mode=forcefallback'])
 
 zlib_dep = dependency('zlib', fallback: ['notzlib', 'zlib_dep'])
+notfound_dep = dependency('cannotabletofind', fallback: ['definitelynotfound', 'some_var'], required : false)
 
-test_not_zlib = executable('test_not_zlib', ['test_not_zlib.c'], dependencies: [zlib_dep])
+test_not_zlib = executable('test_not_zlib', ['test_not_zlib.c'], dependencies: [zlib_dep, notfound_dep])
 
 test('test_not_zlib', test_not_zlib)


### PR DESCRIPTION
Otherwise, we will fail if we could not setup a subproject for an optional fallback dependency.

This involves the creation of a new dummy NotFoundDependency.