### PR TITLE
Deduplicate dependencies resolved to absolute paths

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -526,15 +526,22 @@ class CompilerArgs(list):
     def append_direct(self, arg):
         '''
         Append the specified argument without any reordering or de-dup
+        except for absolute paths where the order of include search directories
+        is not relevant
         '''
-        super().append(arg)
+        if os.path.isabs(arg):
+            self.append(arg)
+        else:
+            super().append(arg)
 
     def extend_direct(self, iterable):
         '''
         Extend using the elements in the specified iterable without any
-        reordering or de-dup
+        reordering or de-dup except for absolute paths where the order of
+        include search directories is not relevant
         '''
-        super().extend(iterable)
+        for elem in iterable:
+            self.append_direct(elem)
 
     def __add__(self, args):
         new = CompilerArgs(self, self.compiler)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -198,6 +198,12 @@ class InternalTests(unittest.TestCase):
         # Direct-adding the same library again still adds it
         l.append_direct('-lbar')
         self.assertEqual(l, ['-Lfoodir', '-lfoo', '-Lbardir', '-lbar', '-lbar'])
+        # Direct-adding with absolute path deduplicates
+        l.append_direct('/libbaz.a')
+        self.assertEqual(l, ['-Lfoodir', '-lfoo', '-Lbardir', '-lbar', '-lbar', '/libbaz.a'])
+        # Adding libbaz again does nothing
+        l.append_direct('/libbaz.a')
+        self.assertEqual(l, ['-Lfoodir', '-lfoo', '-Lbardir', '-lbar', '-lbar', '/libbaz.a'])
 
     def test_string_templates_substitution(self):
         dictfunc = mesonbuild.mesonlib.get_filenames_templates_dict


### PR DESCRIPTION
If paths are absolute the order of search directories is not relevant as the path is already resolved.

This fix is likely to be related to #3071.