### PR TITLE
don't create unneeded internal dependency objects

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -851,13 +851,14 @@ This will become a hard error in a future Meson release.''')
                     self.link(l)
                 for l in dep.whole_libraries:
                     self.link_whole(l)
-                # Those parts that are external.
-                extpart = dependencies.InternalDependency('undefined',
-                                                          [],
-                                                          dep.compile_args,
-                                                          dep.link_args,
-                                                          [], [], [], [])
-                self.external_deps.append(extpart)
+                if dep.compile_args or dep.link_args:
+                    # Those parts that are external.
+                    extpart = dependencies.InternalDependency('undefined',
+                                                              [],
+                                                              dep.compile_args,
+                                                              dep.link_args,
+                                                              [], [], [], [])
+                    self.external_deps.append(extpart)
                 # Deps of deps.
                 self.add_deps(dep.ext_deps)
             elif isinstance(dep, dependencies.Dependency):


### PR DESCRIPTION
when flattening the chained dependencies of an object, we don't need to
create any new internal dependencies if all the fields to be added to it
are empty.

For projects with a lot of libraries and dependency objects this can lead
to noticeable performance improvements.