### PR TITLE
Prune unneeded transitive dependencies

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -803,12 +803,16 @@ This will become a hard error in a future Meson release.''')
     def get_extra_args(self, language):
         return self.extra_args.get(language, [])
 
-    def get_dependencies(self):
+    def get_dependencies(self, exclude=None):
         transitive_deps = []
+        if exclude is None:
+            exclude = []
         for t in itertools.chain(self.link_targets, self.link_whole_targets):
+            if t in transitive_deps or t in exclude:
+                continue
             transitive_deps.append(t)
             if isinstance(t, StaticLibrary):
-                transitive_deps += t.get_dependencies()
+                transitive_deps += t.get_dependencies(transitive_deps + exclude)
         return transitive_deps
 
     def get_source_subdir(self):


### PR DESCRIPTION
When getting dependencies, we don't need to get the same dependencies and
dependency chains multiple times. If library a depends on x, y and z, and
library b depends on a, then we should not have to iterate through x, y and
z multiple times. Pruning at the stage of scanning the dependencies leads
to significant time savings when running meson