### PR TITLE
compilers: Cache compiler checks

### DIFF
--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -191,8 +191,8 @@ class DCompiler(Compiler):
     def compiles(self, code, env, extra_args=None, dependencies=None, mode='compile'):
         args = self._get_compiler_check_args(env, extra_args, dependencies, mode)
 
-        with self.compile(code, args, mode) as p:
-            return p.returncode == 0
+        p = self.compile(code, args, mode)
+        return p.returncode == 0
 
     def has_multi_arguments(self, args, env):
         return self.compiles('int i;\n', env, extra_args=args)

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -63,11 +63,11 @@ class ValaCompiler(Compiler):
     def sanity_check(self, work_dir, environment):
         code = 'class MesonSanityCheck : Object { }'
         args = self.get_cross_extra_flags(environment, link=False)
-        with self.compile(code, args, 'compile') as p:
-            if p.returncode != 0:
-                msg = 'Vala compiler {!r} can not compile programs' \
-                      ''.format(self.name_string())
-                raise EnvironmentException(msg)
+        p = self.compile(code, args, 'compile')
+        if p.returncode != 0:
+            msg = 'Vala compiler {!r} can not compile programs' \
+                  ''.format(self.name_string())
+            raise EnvironmentException(msg)
 
     def get_buildtype_args(self, buildtype):
         if buildtype == 'debug' or buildtype == 'debugoptimized' or buildtype == 'minsize':
@@ -84,9 +84,9 @@ class ValaCompiler(Compiler):
             vapi_args = ['--pkg', libname]
             args = self.get_cross_extra_flags(env, link=False)
             args += vapi_args
-            with self.compile(code, args, 'compile') as p:
-                if p.returncode == 0:
-                    return vapi_args
+            p = self.compile(code, args, 'compile')
+            if p.returncode == 0:
+                return vapi_args
         # Not found? Try to find the vapi file itself.
         for d in extra_dirs:
             vapi = os.path.join(d, libname + '.vapi')


### PR DESCRIPTION
This caching is only for a single run, so it doesn't help reconfigure.
However, it is useful for subproject setups where different subprojects
will run the same compiler checks.

The cache is also per compiler instance.

For gst-build, this halves the number of compiler checks that are run
and reduces configuration time by 20%.