### PR TITLE
custom targets: Don't replace \\ with /

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -839,25 +839,6 @@ class Backend:
         # Substitute the rest of the template strings
         values = mesonlib.get_filenames_templates_dict(inputs, outputs)
         cmd = mesonlib.substitute_values(cmd, values)
-        # This should not be necessary but removing it breaks
-        # building GStreamer on Windows. The underlying issue
-        # is problems with quoting backslashes on Windows
-        # which is the seventh circle of hell. The downside is
-        # that this breaks custom targets whose command lines
-        # have backslashes. If you try to fix this be sure to
-        # check that it does not break GST.
-        #
-        # The bug causes file paths such as c:\foo to get escaped
-        # into c:\\foo.
-        #
-        # Unfortunately we have not been able to come up with an
-        # isolated test case for this so unless you manage to come up
-        # with one, the only way is to test the building with Gst's
-        # setup. Note this in your MR or ping us and we will get it
-        # fixed.
-        #
-        # https://github.com/mesonbuild/meson/pull/737
-        cmd = [i.replace('\\', '/') for i in cmd]
         return inputs, outputs, cmd
 
     def run_postconf_scripts(self):

--- a/test cases/common/48 test args/copyfile.py
+++ b/test cases/common/48 test args/copyfile.py
@@ -3,4 +3,18 @@
 import sys
 import shutil
 
+# If either of these use `\` as the path separator, it will cause problems with
+# MSYS, MSYS2, and Cygwin tools that expect the path separator to always be
+# `/`. All Native-Windows tools also accept `/` as the path separator, so
+# it's fine to always use that for arguments.
+# See: https://github.com/mesonbuild/meson/issues/1564
+#
+# Note that this applies to both MinGW and MSVC toolchains since people use
+# MSYS tools with both, or use a mixed toolchain environment.
+if '\\' in sys.argv[1]:
+    raise RuntimeError('Found \\ in source arg {!r}'.format(sys.argv[1]))
+
+if '\\' in sys.argv[2]:
+    raise RuntimeError('Found \\ in dest arg {!r}'.format(sys.argv[2]))
+
 shutil.copyfile(sys.argv[1], sys.argv[2])

--- a/test cases/common/48 test args/meson.build
+++ b/test cases/common/48 test args/meson.build
@@ -27,9 +27,5 @@ test('file arg', testerpy, args : testfile, env : env_array)
 
 copy = find_program('copyfile.py')
 tester = executable('tester', 'tester.c')
-testfilect = custom_target('testfile',
-                           input : testfile,
-                           output : 'outfile.txt',
-                           build_by_default : true,
-                           command : [copy, '@INPUT@', '@OUTPUT@'])
+subdir('sub1')
 test('custom target arg', tester, args : testfilect, env : env_array)

--- a/test cases/common/48 test args/sub1/meson.build
+++ b/test cases/common/48 test args/sub1/meson.build
@@ -1,0 +1,7 @@
+# Needs to be in a subdir so the @OUTPUT@ contains a path seperator since it is
+# relative to the build root.
+testfilect = custom_target('testfile',
+                           input : testfile,
+                           output : 'outfile.txt',
+                           build_by_default : true,
+                           command : [copy, '@INPUT@', '@OUTPUT@'])


### PR DESCRIPTION
This is no longer required since we always use `/` as the path separator for file arguments on Windows now. The only effect this now has is to mangle the string args people pass to custom targets.

Closes https://github.com/mesonbuild/meson/issues/1564

I verified that gstreamer builds fine even with this removed now. Also modified an existing test for this.