### PR TITLE
Check for header folder and add rpath for macOS frameworks

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -894,9 +894,13 @@ class ExtraFrameworkDependency(ExternalDependency):
         for p in paths:
             for d in os.listdir(p):
                 fullpath = os.path.join(p, d)
+                headerpath = os.path.join(fullpath, 'Headers')
                 if lname != d.split('.')[0].lower():
                     continue
                 if not stat.S_ISDIR(os.stat(fullpath).st_mode):
+                    continue
+                # framework folder needs to contain the "Headers" subdir
+                if not os.path.exists(headerpath):
                     continue
                 self.path = p
                 self.name = d
@@ -912,7 +916,7 @@ class ExtraFrameworkDependency(ExternalDependency):
 
     def get_link_args(self):
         if self.found():
-            return ['-F' + self.path, '-framework', self.name.split('.')[0]]
+            return ['-F' + self.path, '-framework', self.name.split('.')[0], '-Wl,-rpath,' + self.path]
         return []
 
     def get_version(self):


### PR DESCRIPTION
This patch fixes these two errors on macos:
```
dyld: Library not loaded: @rpath/QtCore.framework/Versions/5/QtCore
```

and 
```
fatal error: 'QGraphicsPixmapItem' file not found
```

Adding the rpath for frameworks may solve these two open issues (or may not)
#3077 
#2121

While the include directory error comes from the fact that meson would include the non-existing header dir `~/Qt/5.9.1/clang_64/lib/QtCore.framework.dSYM/Headers` because the correct one `~/Qt/5.9.1/clang_64/lib/QtCore.framework/Headers` is in the same `os.listdir`.

I've added a check to ensure the Headers subfolder is present. 

Thanks
