### PR TITLE
Appveyor: Fail build if a job fails

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -146,3 +146,6 @@ on_finish:
 
 cache:
   - C:\cache
+
+matrix:
+  fast_finish: true


### PR DESCRIPTION
Adding `fast_finish: true` should fail the build faster if a job fails. Hopefully this will reduce the time spent waiting for appveyor results.

See: https://www.appveyor.com/docs/build-configuration/#failing-strategy