### PR TITLE
pkgconfig module: Fix regression that Requires.private is generated as 'Q, t, 5, C, o, r, e' instead of Qt5Core.

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -91,7 +91,7 @@ class DependenciesHelper:
             if hasattr(obj, 'pcdep'):
                 pcdeps = mesonlib.listify(obj.pcdep)
                 for d in pcdeps:
-                    processed_reqs += d.name
+                    processed_reqs.append(d.name)
                     self.add_version_reqs(d.name, obj.version_reqs)
             elif hasattr(obj, 'generated_pc'):
                 processed_reqs.append(obj.generated_pc)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -42,6 +42,7 @@ from mesonbuild.mesonlib import (
 from mesonbuild.environment import Environment, detect_ninja
 from mesonbuild.mesonlib import MesonException, EnvironmentException
 from mesonbuild.dependencies import PkgConfigDependency, ExternalProgram
+import mesonbuild.modules.pkgconfig
 
 from run_tests import exe_suffix, get_fake_options
 from run_tests import get_builddir_target_args, get_backend_commands, Backend
@@ -453,6 +454,19 @@ class InternalTests(unittest.TestCase):
             else:
                 if f.name != 'add_release_note_snippets_here':
                     self.assertTrue(False, 'A file without .md suffix in snippets dir: ' + f.name)
+
+    def test_pkgconfig_module(self):
+        deps = mesonbuild.modules.pkgconfig.DependenciesHelper("thislib")
+
+        class Mock:
+            pass
+
+        mock = Mock()
+        mock.pcdep = Mock()
+        mock.pcdep.name = "some_name"
+        mock.version_reqs = []
+        deps.add_pub_libs([mock])
+        self.assertEqual(deps.format_reqs(deps.pub_reqs), "some_name")
 
 
 class BasePlatformTests(unittest.TestCase):


### PR DESCRIPTION
This was introduced in 8efd940.