### PR TITLE
Meson recognize .C files as C sources while it is C++

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -32,7 +32,7 @@ lib_suffixes = ('a', 'lib', 'dll', 'dylib', 'so')
 # This means we can't include .h headers here since they could be C, C++, ObjC, etc.
 lang_suffixes = {
     'c': ('c',),
-    'cpp': ('cpp', 'cc', 'cxx', 'c++', 'hh', 'hpp', 'ipp', 'hxx'),
+    'cpp': ('cpp', 'cc', 'cxx', 'c++', 'hh', 'hpp', 'ipp', 'hxx', 'C'),
     # f90, f95, f03, f08 are for free-form fortran ('f90' recommended)
     # f, for, ftn, fpp are for fixed-form fortran ('f' or 'for' recommended)
     'fortran': ('f90', 'f95', 'f03', 'f08', 'f', 'for', 'ftn', 'fpp'),
@@ -637,7 +637,7 @@ class Compiler:
     def can_compile(self, src):
         if hasattr(src, 'fname'):
             src = src.fname
-        suffix = os.path.splitext(src)[1].lower()
+        suffix = os.path.splitext(src)[1]
         if suffix and suffix[1:] in self.can_compile_suffixes:
             return True
         return False
@@ -1020,7 +1020,7 @@ class GnuCompiler:
             self.base_options.append('b_lundef')
         self.base_options.append('b_asneeded')
         # All GCC backends can do assembly
-        self.can_compile_suffixes.add('s')
+        self.can_compile_suffixes.update(['s', 'S'])
 
     # TODO: centralise this policy more globally, instead
     # of fragmenting it into GnuCompiler and ClangCompiler
@@ -1110,7 +1110,7 @@ class ClangCompiler:
             self.base_options.append('b_lundef')
         self.base_options.append('b_asneeded')
         # All Clang backends can do assembly and LLVM IR
-        self.can_compile_suffixes.update(['ll', 's'])
+        self.can_compile_suffixes.update(['ll', 's', 'S'])
 
     # TODO: centralise this policy more globally, instead
     # of fragmenting it into GnuCompiler and ClangCompiler
@@ -1204,7 +1204,7 @@ class IntelCompiler:
         self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage',
                              'b_colorout', 'b_ndebug', 'b_staticpic', 'b_lundef', 'b_asneeded']
         # Assembly
-        self.can_compile_suffixes.add('s')
+        self.can_compile_suffixes.update(['s', 'S'])
 
     def get_pic_args(self):
         return ['-fPIC']

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -32,7 +32,7 @@ lib_suffixes = ('a', 'lib', 'dll', 'dylib', 'so')
 # This means we can't include .h headers here since they could be C, C++, ObjC, etc.
 lang_suffixes = {
     'c': ('c',),
-    'cpp': ('cpp', 'cc', 'cxx', 'c++', 'hh', 'hpp', 'ipp', 'hxx', 'C'),
+    'cpp': ('cpp', 'cc', 'cxx', 'c++', 'H', 'hh', 'hpp', 'ipp', 'hxx', 'C'),
     # f90, f95, f03, f08 are for free-form fortran ('f90' recommended)
     # f, for, ftn, fpp are for fixed-form fortran ('f' or 'for' recommended)
     'fortran': ('f90', 'f95', 'f03', 'f08', 'f', 'for', 'ftn', 'fpp'),
@@ -642,7 +642,7 @@ class Compiler:
         if suffix and suffix[1:] in self.can_compile_suffixes:
             return True
         # We keep the old case insensitive behaviour
-        if suffix.lower() and suffix[1:] in self.can_compile_suffixes:
+        if suffix and suffix[1:].lower() in self.can_compile_suffixes:
             return True
         return False
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -637,8 +637,12 @@ class Compiler:
     def can_compile(self, src):
         if hasattr(src, 'fname'):
             src = src.fname
+        # We try first in case sensitive mode detect .C as C++ code instead of C
         suffix = os.path.splitext(src)[1]
         if suffix and suffix[1:] in self.can_compile_suffixes:
+            return True
+        # We keep the old case insensitive behaviour
+        if suffix.lower() and suffix[1:] in self.can_compile_suffixes:
             return True
         return False
 

--- a/test cases/common/2 cpp/meson.build
+++ b/test cases/common/2 cpp/meson.build
@@ -6,4 +6,7 @@ if meson.get_compiler('cpp').get_id() == 'intel'
 endif
 
 exe = executable('trivialprog', 'trivial.cc', extra_files : 'something.txt')
+exe2 = executable('trivialprog2', 'trivial2.C')
+
 test('runtest', exe)
+test('runtest', exe2)

--- a/test cases/common/2 cpp/meson.build
+++ b/test cases/common/2 cpp/meson.build
@@ -1,12 +1,17 @@
 project('c++ test', 'cpp')
 
-if meson.get_compiler('cpp').get_id() == 'intel'
+compiler_id = meson.get_compiler('cpp').get_id()
+
+if compiler_id == 'intel'
   # Error out if the -std=xxx option is incorrect
   add_project_arguments('-diag-error', '10159', language : 'cpp')
 endif
 
 exe = executable('trivialprog', 'trivial.cc', extra_files : 'something.txt')
-exe2 = executable('trivialprog2', 'trivial2.C')
 
 test('runtest', exe)
-test('runtest', exe2)
+
+if (compiler_id == 'gcc') or (compiler_id == 'clang')
+  exe2 = executable('trivialprog2', 'trivial2.C')
+  test('runtest2', exe2)
+endif

--- a/test cases/common/2 cpp/trivial2.C
+++ b/test cases/common/2 cpp/trivial2.C
@@ -1,0 +1,6 @@
+#include<iostream>
+
+int main(int argc, char **argv) {
+  std::cout << ".C is recognized as C++ source" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
This PR adds .C as C++ extension and makes Meson case sensitive for
file extension detection.

I saw that while porting [SAMRAI](https://github.com/jeandet/SAMRAI) to meson they use .C as file extension for all their C++ sources.