### PR TITLE
cross: Add compiler cross_args after normal args

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1660,9 +1660,9 @@ rule FORTRAN_DEP_HACK
         if mesonlib.is_windows():
             command_template = ' command = {executable} @$out.rsp\n' \
                                ' rspfile = $out.rsp\n' \
-                               ' rspfile_content = {cross_args} $ARGS {output_args} {compile_only_args} $in\n'
+                               ' rspfile_content =  $ARGS{cross_args} {output_args} {compile_only_args} $in\n'
         else:
-            command_template = ' command = {executable} {cross_args} $ARGS {output_args} {compile_only_args} $in\n'
+            command_template = ' command = {executable} $ARGS {cross_args} {output_args} {compile_only_args} $in\n'
         command = command_template.format(
             executable=' '.join([ninja_quote(i) for i in compiler.get_exelist()]),
             cross_args=' '.join(self.get_cross_info_lang_args(compiler.language, is_cross)),
@@ -1721,10 +1721,10 @@ rule FORTRAN_DEP_HACK
         if mesonlib.is_windows():
             command_template = ''' command = {executable} @$out.rsp
  rspfile = $out.rsp
- rspfile_content = {cross_args} $ARGS {dep_args} {output_args} {compile_only_args} $in
+ rspfile_content = $ARGS {cross_args} {dep_args} {output_args} {compile_only_args} $in
 '''
         else:
-            command_template = ' command = {executable} {cross_args} $ARGS {dep_args} {output_args} {compile_only_args} $in\n'
+            command_template = ' command = {executable} $ARGS {cross_args} {dep_args} {output_args} {compile_only_args} $in\n'
         command = command_template.format(
             executable=' '.join([ninja_quote(i) for i in compiler.get_exelist()]),
             cross_args=' '.join(cross_args),
@@ -1769,7 +1769,7 @@ rule FORTRAN_DEP_HACK
             output = ''
         else:
             output = ' '.join(compiler.get_output_args('$out'))
-        command = " command = {executable} {cross_args} $ARGS {dep_args} {output_args} {compile_only_args} $in\n".format(
+        command = " command = {executable} $ARGS {cross_args} {dep_args} {output_args} {compile_only_args} $in\n".format(
             executable=' '.join(compiler.get_exelist()),
             cross_args=' '.join(cross_args),
             dep_args=' '.join(quoted_depargs),

--- a/test cases/unit/29 cross file overrides always args/meson.build
+++ b/test cases/unit/29 cross file overrides always args/meson.build
@@ -1,0 +1,3 @@
+project('cross compile args override always args', 'c')
+
+executable('no-file-offset-bits', 'test.c')

--- a/test cases/unit/29 cross file overrides always args/test.c
+++ b/test cases/unit/29 cross file overrides always args/test.c
@@ -1,0 +1,8 @@
+#ifdef _FILE_OFFSET_BITS
+  #error "_FILE_OFFSET_BITS should not be set"
+#endif
+
+int main(int argc, char *argv[])
+{
+  return 0;
+}

--- a/test cases/unit/29 cross file overrides always args/ubuntu-armhf-overrides.txt
+++ b/test cases/unit/29 cross file overrides always args/ubuntu-armhf-overrides.txt
@@ -1,0 +1,19 @@
+[binaries]
+# we could set exe_wrapper = qemu-arm-static but to test the case
+# when cross compiled binaries can't be run we don't do that
+c = '/usr/bin/arm-linux-gnueabihf-gcc'
+cpp = '/usr/bin/arm-linux-gnueabihf-g++'
+rust = ['rustc', '--target', 'arm-unknown-linux-gnueabihf', '-C', 'linker=/usr/bin/arm-linux-gnueabihf-gcc-7']
+ar = '/usr/arm-linux-gnueabihf/bin/ar'
+strip = '/usr/arm-linux-gnueabihf/bin/strip'
+pkgconfig = '/usr/bin/arm-linux-gnueabihf-pkg-config'
+
+[properties]
+root = '/usr/arm-linux-gnueabihf'
+c_args = ['-U_FILE_OFFSET_BITS']
+
+[host_machine]
+system = 'linux'
+cpu_family = 'arm'
+cpu = 'armv7' # Not sure if correct.
+endian = 'little'


### PR DESCRIPTION
This way they override all other arguments. This matches the order of link arguments too.

Note that this means `-I` flags will come in afterwards and not override anything else, but this is correct since that's how toolchain paths work normally too -- they are searched last.

Closes https://github.com/mesonbuild/meson/issues/3089

Supersedes https://github.com/mesonbuild/meson/pull/2996