### PR TITLE
fix fallback variable name

### DIFF
--- a/manual tests/2 multiwrap/meson.build
+++ b/manual tests/2 multiwrap/meson.build
@@ -6,7 +6,7 @@ project('multiwrap', 'c',
 cc = meson.get_compiler('c')
 
 luadep = dependency('lua', fallback : ['lua', 'lua_dep'])
-pngdep = dependency('libpng', fallback : ['libpng', 'pngdep'])
+pngdep = dependency('libpng', fallback : ['libpng', 'png_dep'])
 
 executable('prog', 'prog.c',
   dependencies : [pngdep, luadep])


### PR DESCRIPTION
Hi,

The variable name in the wrap meson build appears to be png_dep and not pngdep and the fallback will fail on my ubuntu 17.10.