### PR TITLE
Update 'manual tests/2 multiwrap' libpng dependency to 1.6.34

### DIFF
--- a/manual tests/2 multiwrap/subprojects/libpng.wrap
+++ b/manual tests/2 multiwrap/subprojects/libpng.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = libpng-1.6.17
+directory = libpng-1.6.34
 
-source_url = ftp://ftp.simplesystems.org/pub/libpng/png/src/history/libpng16/libpng-1.6.17.tar.xz
-source_filename = libpng-1.6.17.tar.xz
-source_hash = 98507b55fbe5cd43c51981f2924e4671fd81fe35d52dc53357e20f2c77fa5dfd
+source_url = ftp://ftp-osl.osuosl.org/pub/libpng/src/libpng16/libpng-1.6.34.tar.xz
+source_filename = libpng-1.6.34.tar.xz
+source_hash = 2f1e960d92ce3b3abd03d06dfec9637dfbd22febf107a536b44f7a47c60659f6
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/libpng/1.6.17/6/get_zip
-patch_filename = libpng-1.6.17-6-wrap.zip
-patch_hash = 8bd272e28e6ae84691935e84bca9f5eb02632221e6faccf427eb71bf745a7295
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/libpng/1.6.34/1/get_zip
+patch_filename = libpng-1.6.34-1-wrap.zip
+patch_hash = 2123806eba8180c164e33a210f2892bbeb2473b69e56aecc786574e9221e6f20


### PR DESCRIPTION
1.6.17-6 has a bug with missing -lm linking on ArchLinux.
See https://github.com/mesonbuild/libpng/pull/7