### PR TITLE
regression: pkgconfig module: Fix Fix regression in Requires.private generation.

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -59,7 +59,7 @@ class DependenciesHelper:
             elif hasattr(obj, 'pcdep'):
                 pcdeps = mesonlib.listify(obj.pcdep)
                 for d in pcdeps:
-                    processed_reqs += d.name
+                    processed_reqs.append(d.name)
                     self.add_version_reqs(d.name, obj.version_reqs)
             elif isinstance(obj, dependencies.PkgConfigDependency):
                 if obj.found():

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -456,7 +456,6 @@ class InternalTests(unittest.TestCase):
                     self.assertTrue(False, 'A file without .md suffix in snippets dir: ' + f.name)
 
     def test_pkgconfig_module(self):
-        deps = mesonbuild.modules.pkgconfig.DependenciesHelper("thislib")
 
         class Mock:
             pass
@@ -465,7 +464,15 @@ class InternalTests(unittest.TestCase):
         mock.pcdep = Mock()
         mock.pcdep.name = "some_name"
         mock.version_reqs = []
+
+        # pkgconfig dependency as lib
+        deps = mesonbuild.modules.pkgconfig.DependenciesHelper("thislib")
         deps.add_pub_libs([mock])
+        self.assertEqual(deps.format_reqs(deps.pub_reqs), "some_name")
+
+        # pkgconfig dependency as requires
+        deps = mesonbuild.modules.pkgconfig.DependenciesHelper("thislib")
+        deps.add_pub_reqs([mock])
         self.assertEqual(deps.format_reqs(deps.pub_reqs), "some_name")
 
 


### PR DESCRIPTION
The fix for Requires generation in #3406 missed a second code path with the same
problem.

Passing a pkgconfig dependency to requires would produce Q, t, 5, C, o,r, e'
instead of 'Qt5Core'.

This was introduced in 8efd940.