### PR TITLE
gnome: If pkg-config is not found, assume glib is 2.54

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -67,8 +67,12 @@ class GnomeModule(ExtensionModule):
         global native_glib_version
         if native_glib_version is None:
             glib_dep = PkgConfigDependency('glib-2.0', state.environment,
-                                           {'native': True})
-            native_glib_version = glib_dep.get_version()
+                                           {'native': True, 'required': False})
+            if glib_dep.found():
+                native_glib_version = glib_dep.get_version()
+            else:
+                mlog.warning('Could not detect glib version, assuming 2.0')
+                native_glib_version = '2.0'
         return native_glib_version
 
     def __print_gresources_warning(self, state):

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -71,8 +71,9 @@ class GnomeModule(ExtensionModule):
             if glib_dep.found():
                 native_glib_version = glib_dep.get_version()
             else:
-                mlog.warning('Could not detect glib version, assuming 2.0')
-                native_glib_version = '2.0'
+                mlog.warning('Could not detect glib version, assuming 2.54. '
+                             'You may get build errors if your glib is older.')
+                native_glib_version = '2.54'
         return native_glib_version
 
     def __print_gresources_warning(self, state):


### PR DESCRIPTION
Checking the pkg-config file to confirm tool versions is a hack, and should eventually be replaced with checking the actual versions of the tools.

This is needed to build glib on Windows with the new override_find_program functionality. It's a pessimistic assumption, but it won't break the module since it runs `find_program()` on the needed tools anyway.