### PR TITLE
Extend install_mode to all installable targets

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -204,6 +204,8 @@ the `@variable@` syntax.
 - `install_dir` the subdirectory to install the generated file to
   (e.g. `share/myproject`), if omitted or given the value of empty
   string, the file is not installed.
+- `install_mode` *(added 0.47.0)* specify the file mode in symbolic format
+  and optionally the owner/uid and group/gid for the installed files.
 - `output` the output file name (since v0.41.0, may contain
   `@PLAINNAME@` or `@BASENAME@` substitutions). In configuration mode,
   the permissions of the input file (if it is specified) are copied to
@@ -261,6 +263,8 @@ following.
 - `input` list of source files. As of 0.41.0 the list will be flattened.
 - `install` when true, this target is installed during the install step
 - `install_dir` directory to install to
+- `install_mode` *(added 0.47.0)* the file mode and optionally the
+  owner/uid and group/gid
 - `output` list of output files
 
 The list of strings passed to the `command` keyword argument accept
@@ -472,6 +476,8 @@ be passed to [shared and static libraries](#library).
   relative to the `prefix` specified. F.ex, if you want to install
   plugins into a subdir, you'd use something like this: `install_dir :
   join_paths(get_option('libdir'), 'projectname-1.0'`).
+- `install_mode` *(added 0.47.0)* specify the file mode in symbolic format
+  and optionally the owner/uid and group/gid for the installed files.
 - `install_rpath` a string to set the target's rpath to after install
   (but *not* before that)
 - `objects` list of prebuilt object files (usually for third party
@@ -814,6 +820,11 @@ This will install `common.h` and `kola.h` into `/{prefix}/cust/myproj`:
 install_headers('common.h', 'proj/kola.h', install_dir : 'cust', subdir : 'myproj')
 ```
 
+The `install_mode` argument can be used to specify the file mode in symbolic
+format and optionally the owner/uid and group/gid for the installed files.
+An example value could be `['rwxr-sr-x', 'root', 'root']`.
+*(Added 0.47.0)*.
+
 ### install_man()
 
 ``` meson
@@ -825,6 +836,11 @@ man directory during the install step. This directory can be
 overridden by specifying it with the `install_dir` keyword
 argument. All man pages are compressed during installation and
 installed with a `.gz` suffix.
+
+The `install_mode` argument can be used to specify the file mode in symbolic
+format and optionally the owner/uid and group/gid for the installed files.
+An example value could be `['rwxr-sr-x', 'root', 'root']`.
+*(Added 0.47.0)*.
 
 ### install_subdir()
 
@@ -843,6 +859,8 @@ The following keyword arguments are supported:
 - `exclude_directories`: a list of directory names that should not be installed.
   Names are interpreted as paths relative to the `subdir_name` location.
 - `install_dir`: the location to place the installed subdirectory.
+- `install_mode`: the file mode in symbolic format and optionally
+  the owner/uid and group/gid for the installed files. *(Added 0.47.0)*
 - `strip_directory`: install directory contents. `strip_directory=false` by default.
   If `strip_directory=false` only last component of source path is used.
   Since 0.45.0

--- a/docs/markdown/snippets/install_mode-extended.md
+++ b/docs/markdown/snippets/install_mode-extended.md
@@ -1,0 +1,8 @@
+## install_mode argument extended to all installable targets
+
+It is now possible to pass an install_mode argument to all installable targets,
+such as executable(), libraries, headers, man pages and custom/generated
+targets.
+
+The install_mode argument can be used to specify the file mode in symbolic
+format and optionally the owner/uid and group/gid for the installed files.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -64,6 +64,7 @@ buildtarget_kwargs = set([
     'install',
     'install_rpath',
     'install_dir',
+    'install_mode',
     'name_prefix',
     'name_suffix',
     'native',
@@ -668,6 +669,9 @@ class BuildTarget(Target):
     def get_custom_install_dir(self):
         return self.install_dir
 
+    def get_custom_install_mode(self):
+        return self.install_mode
+
     def process_kwargs(self, kwargs, environment):
         super().process_kwargs(kwargs)
         self.copy_kwargs(kwargs)
@@ -745,6 +749,7 @@ This will become a hard error in a future Meson release.''')
         # the list index of that item will not be installed
         self.install_dir = typeslistify(kwargs.get('install_dir', [None]),
                                         (str, bool))
+        self.install_mode = kwargs.get('install_mode', None)
         main_class = kwargs.get('main_class', '')
         if not isinstance(main_class, str):
             raise InvalidArguments('Main class must be a string')
@@ -1626,6 +1631,7 @@ class CustomTarget(Target):
         'capture',
         'install',
         'install_dir',
+        'install_mode',
         'build_always',
         'depends',
         'depend_files',
@@ -1774,9 +1780,11 @@ class CustomTarget(Target):
                 # If an item in this list is False, the output corresponding to
                 # the list index of that item will not be installed
                 self.install_dir = typeslistify(kwargs['install_dir'], (str, bool))
+                self.install_mode = kwargs.get('install_mode', None)
         else:
             self.install = False
             self.install_dir = [None]
+            self.install_mode = None
         self.build_always = kwargs.get('build_always', False)
         if not isinstance(self.build_always, bool):
             raise InvalidArguments('Argument build_always must be a boolean.')
@@ -1802,6 +1810,9 @@ class CustomTarget(Target):
 
     def get_custom_install_dir(self):
         return self.install_dir
+
+    def get_custom_install_mode(self):
+        return self.install_mode
 
     def get_outputs(self):
         return self.outputs

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -975,12 +975,25 @@ def get_filenames_templates_dict(inputs, outputs):
     return values
 
 
+def _make_tree_writable(topdir):
+    # Ensure all files and directories under topdir are writable
+    # (and readable) by owner.
+    for d, _, files in os.walk(topdir):
+        os.chmod(d, os.stat(d).st_mode | stat.S_IWRITE | stat.S_IREAD)
+        for fname in files:
+            fpath = os.path.join(d, fname)
+            if os.path.isfile(fpath):
+                os.chmod(fpath, os.stat(fpath).st_mode | stat.S_IWRITE | stat.S_IREAD)
+
+
 def windows_proof_rmtree(f):
     # On Windows if anyone is holding a file open you can't
     # delete it. As an example an anti virus scanner might
     # be scanning files you are trying to delete. The only
     # way to fix this is to try again and again.
     delays = [0.1, 0.1, 0.2, 0.2, 0.2, 0.5, 0.5, 1, 1, 1, 1, 2]
+    # Start by making the tree wriable.
+    _make_tree_writable(f)
     for d in delays:
         try:
             shutil.rmtree(f)

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -303,6 +303,8 @@ def pass_libdir_to_test(dirname):
         return False
     if '39 libdir' in dirname:
         return False
+    if '201 install_mode' in dirname:
+        return False
     return True
 
 def _run_test(testdir, test_build_dir, install_dir, extra_args, compiler, backend, flags, commands, should_fail):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2787,6 +2787,39 @@ class LinuxlikeTests(BasePlatformTests):
             # The chown failed nonfatally if we're not root
             self.assertEqual(0, statf.st_uid)
 
+    def test_installed_modes_extended(self):
+        '''
+        Test that files are installed with correct permissions using install_mode.
+        '''
+        testdir = os.path.join(self.common_test_dir, '201 install_mode')
+        self.init(testdir)
+        self.build()
+        self.install()
+
+        for fsobj, want_mode in [
+                ('bin', 'drwxr-x---'),
+                ('bin/runscript.sh', '-rwxr-sr-x'),
+                ('bin/trivialprog', '-rwxr-sr-x'),
+                ('include', 'drwxr-x---'),
+                ('include/config.h', '-rw-rwSr--'),
+                ('include/rootdir.h', '-r--r--r-T'),
+                ('lib', 'drwxr-x---'),
+                ('lib/libstat.a', '-rw---Sr--'),
+                ('share', 'drwxr-x---'),
+                ('share/man', 'drwxr-x---'),
+                ('share/man/man1', 'drwxr-x---'),
+                ('share/man/man1/foo.1.gz', '-r--r--r-T'),
+                ('share/sub1', 'drwxr-x---'),
+                ('share/sub1/second.dat', '-rwxr-x--t'),
+                ('subdir', 'drwxr-x---'),
+                ('subdir/data.dat', '-rw-rwSr--'),
+        ]:
+            f = os.path.join(self.installdir, 'usr', *fsobj.split('/'))
+            found_mode = stat.filemode(os.stat(f).st_mode)
+            self.assertEqual(want_mode, found_mode,
+                             msg=('Expected file %s to have mode %s but found %s instead.' %
+                                  (fsobj, want_mode, found_mode)))
+
     def test_install_umask(self):
         '''
         Test that files are installed with correct permissions using default

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2778,7 +2778,7 @@ class LinuxlikeTests(BasePlatformTests):
         self.init(testdir)
         self.install()
 
-        f = os.path.join(self.installdir, 'usr', 'share', 'sub1')
+        f = os.path.join(self.installdir, 'usr', 'share', 'sub1', 'second.dat')
         statf = os.stat(f)
         found_mode = stat.filemode(statf.st_mode)
         want_mode = 'rwxr-x--t'

--- a/test cases/common/201 install_mode/config.h.in
+++ b/test cases/common/201 install_mode/config.h.in
@@ -1,0 +1,5 @@
+#define MESSAGE "@var@"
+#define OTHER "@other@" "@second@" "@empty@"
+
+#mesondefine BE_TRUE
+#mesondefine SHOULD_BE_UNDEF

--- a/test cases/common/201 install_mode/data_source.txt
+++ b/test cases/common/201 install_mode/data_source.txt
@@ -1,0 +1,1 @@
+This is a text only input file.

--- a/test cases/common/201 install_mode/foo.1
+++ b/test cases/common/201 install_mode/foo.1
@@ -1,0 +1,1 @@
+this is a man page of foo.1 its contents are irrelevant

--- a/test cases/common/201 install_mode/installed_files.txt
+++ b/test cases/common/201 install_mode/installed_files.txt
@@ -1,0 +1,8 @@
+usr/bin/runscript.sh
+usr/bin/trivialprog?exe
+usr/include/config.h
+usr/include/rootdir.h
+usr/libtest/libstat.a
+usr/share/man/man1/foo.1.gz
+usr/share/sub1/second.dat
+usr/subdir/data.dat

--- a/test cases/common/201 install_mode/meson.build
+++ b/test cases/common/201 install_mode/meson.build
@@ -1,0 +1,52 @@
+project('install_mode test', 'c',
+  default_options : ['install_umask=027', 'libdir=libtest'])
+
+# confirm no regressions in install_data
+install_data('runscript.sh',
+  install_dir : get_option('bindir'),
+  install_mode : ['rwxr-sr-x', 'root', 0])
+
+# confirm no regressions in install_subdir
+install_subdir('sub1',
+  install_dir : 'share',
+  install_mode : ['rwxr-x--t', 'root'])
+
+# test install_mode in configure_file
+conf = configuration_data()
+conf.set('var', 'mystring')
+conf.set('other', 'string 2')
+conf.set('second', ' bonus')
+conf.set('BE_TRUE', true)
+configure_file(input : 'config.h.in',
+  output : 'config.h',
+  configuration : conf,
+  install_dir : 'include',
+  install_mode : 'rw-rwSr--')
+
+# test install_mode in custom_target
+custom_target('bindat',
+  output : 'data.dat',
+  input : 'data_source.txt',
+  command : ['cp', '@INPUT@', '@OUTPUT@'],
+  install : true,
+  install_dir : 'subdir',
+  install_mode : 'rw-rwSr--')
+
+# test install_mode in install_headers
+install_headers('rootdir.h',
+  install_mode : 'r--r--r-T')
+
+# test install_mode in install_man
+install_man('foo.1',
+  install_mode : 'r--r--r-T')
+
+# test install_mode in executable
+executable('trivialprog',
+  sources : 'trivial.c',
+  install : true,
+  install_mode : ['rwxr-sr-x', 'root', 'root'])
+
+# test install_mode in static_library
+static_library('stat', 'stat.c',
+  install : true,
+  install_mode : ['rw---Sr--'])

--- a/test cases/common/201 install_mode/rootdir.h
+++ b/test cases/common/201 install_mode/rootdir.h
@@ -1,0 +1,3 @@
+/* This header goes to include dir root. */
+
+int root_func();

--- a/test cases/common/201 install_mode/runscript.sh
+++ b/test cases/common/201 install_mode/runscript.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Runscript"

--- a/test cases/common/201 install_mode/stat.c
+++ b/test cases/common/201 install_mode/stat.c
@@ -1,0 +1,1 @@
+int func() { return 933; }

--- a/test cases/common/201 install_mode/sub1/second.dat
+++ b/test cases/common/201 install_mode/sub1/second.dat
@@ -1,0 +1,1 @@
+Test that multiple install_subdirs meld their results.

--- a/test cases/common/201 install_mode/trivial.c
+++ b/test cases/common/201 install_mode/trivial.c
@@ -1,0 +1,6 @@
+#include<stdio.h>
+
+int main(int argc, char **argv) {
+    printf("Trivial test is working.\n");
+    return 0;
+}


### PR DESCRIPTION
This PR makes it possible to pass any target that can be installed (such as `executable()`, libraries, headers, man pages and custom/generated files) and `install_mode` keyword attribute, that can be used to customize the mode of the installed files and optionally user/group ownership.

This makes it possible to install compiled executables as setuid/setgid binaries, which wasn't really easy to accomplish before this change...

It should also mitigate the effects from enforcing a default umask on the installation, since by using install_mode developers can now control the exact mode they wish to have for installed files, giving them full control over it while still keeping useful default behavior.

**NOTE**: This PR changes the behavior of how `install_mode` behaves on rules like `install_subdir`, in that the mode and permissions will apply to the files installed and not to the directory tree. Applying the mode to the directory tree does not make sense when the mode does not include the executable bit, so in that sense it makes it impossible to specify a non-executable mode for the installed files... (See commit 69186b575996543832355a40400b4a23e3c844ed and its descriptions for more details on that.) We might need a follow up for that later, but for now this I think this is a step in the right direction. 

/cc @jpakkane 

Cheers,
Filipe
