### PR TITLE
Add support for octal and binary int literals

### DIFF
--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -64,6 +64,13 @@ Hexadecimal literals are supported since version 0.45.0:
 int_255 = 0xFF
 ```
 
+Octal and binary literals are supported since version 0.47.0:
+
+```meson
+int_493 = 0o755
+int_1365 = 0b10101010101
+```
+
 Strings can be converted to a number like this:
 
 ```meson

--- a/docs/markdown/snippets/integer-base.md
+++ b/docs/markdown/snippets/integer-base.md
@@ -1,0 +1,9 @@
+## Octal and binary string literals
+
+Octal and binary integer literals can now be used in build and option files.
+
+```meson
+int_493 = 0o755
+int_1365 = 0b10101010101
+```
+

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -94,8 +94,7 @@ class Lexer:
             # Need to be sorted longest to shortest.
             ('ignore', re.compile(r'[ \t]')),
             ('id', re.compile('[_a-zA-Z][_0-9a-zA-Z]*')),
-            ('hexnumber', re.compile('0[xX][0-9a-fA-F]+')),
-            ('number', re.compile(r'\d+')),
+            ('number', re.compile(r'0[bB][01]+|0[oO][0-7]+|0[xX][0-9a-fA-F]+|0|[1-9]\d*')),
             ('eol_cont', re.compile(r'\\\n')),
             ('eol', re.compile(r'\n')),
             ('multiline_string', re.compile(r"'''(.|\n)*?'''", re.M)),
@@ -187,10 +186,7 @@ This will become a hard error in a future Meson release.""", self.getline(line_s
                             lineno += len(lines) - 1
                             line_start = mo.end() - len(lines[-1])
                     elif tid == 'number':
-                        value = int(match_text)
-                    elif tid == 'hexnumber':
-                        tid = 'number'
-                        value = int(match_text, base=16)
+                        value = int(match_text, base=0)
                     elif tid == 'eol' or tid == 'eol_cont':
                         lineno += 1
                         line_start = loc

--- a/test cases/common/68 number arithmetic/meson.build
+++ b/test cases/common/68 number arithmetic/meson.build
@@ -62,3 +62,15 @@ hex2_255 = 0XFF
 
 assert(hex_255 == 255, 'Hex parsing is broken.')
 assert(hex2_255 == 255, 'Uppercase hex parsing is broken.')
+
+bin_123 = 0b1111011
+bin2_123 = 0B1111011
+
+assert(bin_123 == 123, 'Bin number parsing is broken.')
+assert(bin2_123 == 123, 'Uppercase bin number parsing is broken.')
+
+oct_493 = 0o755
+oct2_493 = 0O755
+
+assert(oct_493 == 493, 'Oct number parsing is broken.')
+assert(oct2_493 == 493, 'Uppercase oct number parsing is broken.')

--- a/test cases/failing/76 int literal leading zero/meson.build
+++ b/test cases/failing/76 int literal leading zero/meson.build
@@ -1,0 +1,6 @@
+
+# This should fail.
+# Decimal syntax is 123.
+# Octal syntax is 0o123.
+fail_0123 = 0123
+


### PR DESCRIPTION
Simplify support for alternate bases using `int(..., base=0)` which auto-detects it using the standard Python syntax for numbers.

Octal numbers are useful to specify permission bits and umasks.

Binary numbers are not super useful... But considering we get them for free, let's allow them here too.

Add octal and binary number to a test case. Also update docs and add a snippet for release notes.
