### PR TITLE
Optimize dep guessing

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -44,6 +44,8 @@ from .compilers import (
 
 
 class CCompiler(Compiler):
+    library_dirs_cache = {}
+
     def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwargs):
         # If a child ObjC or CPP class has already set it, don't set it ourselves
         if not hasattr(self, 'language'):
@@ -157,7 +159,7 @@ class CCompiler(Compiler):
     def get_std_shared_lib_link_args(self):
         return ['-shared']
 
-    def get_library_dirs(self):
+    def get_library_dirs_real(self):
         env = os.environ.copy()
         env['LC_ALL'] = 'C'
         stdo = Popen_safe(self.exelist + ['--print-search-dirs'], env=env)[1]
@@ -166,6 +168,12 @@ class CCompiler(Compiler):
                 libstr = line.split('=', 1)[1]
                 return libstr.split(':')
         return []
+
+    def get_library_dirs(self):
+        key = tuple(self.exelist)
+        if key not in self.library_dirs_cache:
+            self.library_dirs_cache[key] = self.get_library_dirs_real()
+        return self.library_dirs_cache[key][:]
 
     def get_pic_args(self):
         return ['-fPIC']


### PR DESCRIPTION
Meson still produces quite a lot of duplicated linker arguments for e.g. gtk+. Limits the impact of those to the runtime by removing those from the working lists for dependency guessing.

This reduces total runtime of meson for a gtk+ based test case from around 37 seconds to around 8.