### PR TITLE
--warnlevel got renamed to --warning-level

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -437,6 +437,8 @@ def add_builtin_argument(p, name):
 def register_builtin_arguments(parser):
     for n in builtin_options:
         add_builtin_argument(parser, n)
+    parser.add_argument('-D', action='append', dest='projectoptions', default=[], metavar="option",
+                        help='Set the value of an option, can be used several times to set multiple options.')
 
 builtin_options = {
     'buildtype':  [UserComboOption, 'Build type to use.', ['plain', 'debug', 'debugoptimized', 'release', 'minsize'], 'debug'],

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -390,12 +390,6 @@ def get_builtin_option_action(optname):
         return 'store_true'
     return None
 
-def get_builtin_option_destination(optname):
-    optname = optname.replace('-', '_')
-    if optname == 'warnlevel':
-        return 'warning_level'
-    return optname
-
 def get_builtin_option_default(optname, prefix='', noneIfSuppress=False):
     if is_builtin_option(optname):
         o = builtin_options[optname]
@@ -415,30 +409,64 @@ def get_builtin_option_default(optname, prefix='', noneIfSuppress=False):
     else:
         raise RuntimeError('Tried to get the default value for an unknown builtin option \'%s\'.' % optname)
 
+def get_builtin_option_cmdline_name(name):
+    if name == 'warning_level':
+        return '--warnlevel'
+    else:
+        return '--' + name.replace('_', '-')
+
 def add_builtin_argument(p, name):
     kwargs = {}
-    k = get_builtin_option_destination(name)
-    c = get_builtin_option_choices(k)
-    b = get_builtin_option_action(k)
-    h = get_builtin_option_description(k)
+    c = get_builtin_option_choices(name)
+    b = get_builtin_option_action(name)
+    h = get_builtin_option_description(name)
     if not b:
-        h = h.rstrip('.') + ' (default: %s).' % get_builtin_option_default(k)
+        h = h.rstrip('.') + ' (default: %s).' % get_builtin_option_default(name)
     else:
         kwargs['action'] = b
     if c and not b:
         kwargs['choices'] = c
-    default = get_builtin_option_default(k, noneIfSuppress=True)
+    default = get_builtin_option_default(name, noneIfSuppress=True)
     if default is not None:
         kwargs['default'] = default
     else:
         kwargs['default'] = argparse.SUPPRESS
-    p.add_argument('--' + name.replace('_', '-'), help=h, **kwargs)
+    kwargs['dest'] = name
+
+    cmdline_name = get_builtin_option_cmdline_name(name)
+    p.add_argument(cmdline_name, help=h, **kwargs)
 
 def register_builtin_arguments(parser):
     for n in builtin_options:
         add_builtin_argument(parser, n)
     parser.add_argument('-D', action='append', dest='projectoptions', default=[], metavar="option",
                         help='Set the value of an option, can be used several times to set multiple options.')
+
+def filter_builtin_options(args, original_args):
+    """Filter out any builtin arguments passed as -- instead of -D.
+
+    Error if an argument is passed with -- and -D
+    """
+    for name in builtin_options:
+        # Check if user passed --option. Cannot use hasattr(args, name) here
+        # because they are all set with default value if user didn't pass it.
+        cmdline_name = get_builtin_option_cmdline_name(name)
+        has_dashdash = any([a.startswith(cmdline_name) for a in original_args])
+
+        # Chekc if user passed -Doption=value
+        has_dashd = any([a.startswith('{}='.format(name)) for a in args.projectoptions])
+
+        # Passing both is ambigous, abort
+        if has_dashdash and has_dashd:
+            raise MesonException(
+                'Got argument {0} as both -D{0} and {1}. Pick one.'.format(name, cmdline_name))
+
+        # Pretend --option never existed
+        if has_dashdash:
+            args.projectoptions.append('{}={}'.format(name, getattr(args, name)))
+        if hasattr(args, name):
+            delattr(args, name)
+
 
 builtin_options = {
     'buildtype':  [UserComboOption, 'Build type to use.', ['plain', 'debug', 'debugoptimized', 'release', 'minsize'], 'debug'],

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -27,19 +27,6 @@ def buildparser():
     return parser
 
 
-def filter_builtin_options(args, original_args):
-    """Filter out any args passed with -- instead of -D."""
-    for arg in original_args:
-        if not arg.startswith('--') or arg == '--clearcache':
-            continue
-        name = arg.lstrip('--').split('=', 1)[0]
-        if any([a.startswith(name + '=') for a in args.projectoptions]):
-            raise mesonlib.MesonException(
-                'Got argument {0} as both -D{0} and --{0}. Pick one.'.format(name))
-        args.projectoptions.append('{}={}'.format(name, getattr(args, name)))
-        delattr(args, name)
-
-
 class ConfException(mesonlib.MesonException):
     pass
 
@@ -241,7 +228,7 @@ def run(args):
     if not args:
         args = [os.getcwd()]
     options = buildparser().parse_args(args)
-    filter_builtin_options(options, args)
+    coredata.filter_builtin_options(options, args)
     if len(options.directory) > 1:
         print('%s <build directory>' % args[0])
         print('If you omit the build directory, the current directory is substituted.')

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -21,8 +21,6 @@ def buildparser():
     parser = argparse.ArgumentParser(prog='meson configure')
     coredata.register_builtin_arguments(parser)
 
-    parser.add_argument('-D', action='append', default=[], dest='sets',
-                        help='Set an option to the given value.')
     parser.add_argument('directory', nargs='*')
     parser.add_argument('--clearcache', action='store_true', default=False,
                         help='Clear cached state (e.g. found dependencies)')
@@ -35,10 +33,10 @@ def filter_builtin_options(args, original_args):
         if not arg.startswith('--') or arg == '--clearcache':
             continue
         name = arg.lstrip('--').split('=', 1)[0]
-        if any([a.startswith(name + '=') for a in args.sets]):
+        if any([a.startswith(name + '=') for a in args.projectoptions]):
             raise mesonlib.MesonException(
                 'Got argument {0} as both -D{0} and --{0}. Pick one.'.format(name))
-        args.sets.append('{}={}'.format(name, getattr(args, name)))
+        args.projectoptions.append('{}={}'.format(name, getattr(args, name)))
         delattr(args, name)
 
 
@@ -255,8 +253,8 @@ def run(args):
     try:
         c = Conf(builddir)
         save = False
-        if len(options.sets) > 0:
-            c.set_options(options.sets)
+        if len(options.projectoptions) > 0:
+            c.set_options(options.projectoptions)
             save = True
         elif options.clearcache:
             c.clear_cache()

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -30,8 +30,6 @@ def create_parser():
     coredata.register_builtin_arguments(p)
     p.add_argument('--cross-file', default=None,
                    help='File describing cross compilation environment.')
-    p.add_argument('-D', action='append', dest='projectoptions', default=[], metavar="option",
-                   help='Set the value of an option, can be used several times to set multiple options.')
     p.add_argument('-v', '--version', action='version',
                    version=coredata.version)
     # See the mesonlib.WrapMode enum for documentation

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -57,11 +57,12 @@ def filter_builtin_options(args, original_args):
     if meson_opts:
         for arg in meson_opts:
             value = arguments[arg]
-            if any([a.startswith('--{}'.format(arg)) for a in original_args]):
+            cmdline_name = coredata.get_builtin_option_cmdline_name(arg)
+            if any([a.startswith(cmdline_name) for a in original_args]):
                 raise MesonException(
-                    'Argument "{0}" passed as both --{0} and -D{0}, but only '
-                    'one is allowed'.format(arg))
-            setattr(args, coredata.get_builtin_option_destination(arg), value)
+                    'Argument "{0}" passed as both {1} and -D{0}, but only '
+                    'one is allowed'.format(arg, cmdline_name))
+            setattr(args, arg, value)
 
             # Remove the builtin option from the project args values
             args.projectoptions.remove('{}={}'.format(arg, value))

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2073,6 +2073,45 @@ recommended as it can lead to undefined behaviour on some platforms''')
         self._test_same_option_twice_configure(
             'one', ['-Done=foo', '-Done=bar'])
 
+    def test_command_line(self):
+        testdir = os.path.join(self.unit_test_dir, '30 command line')
+
+        self.init(testdir)
+        obj = mesonbuild.coredata.load(self.builddir)
+        self.assertEqual(obj.builtins['default_library'].value, 'shared')
+        self.wipe()
+
+        self.init(testdir, extra_args=['--warnlevel=2'])
+        obj = mesonbuild.coredata.load(self.builddir)
+        self.assertEqual(obj.builtins['warning_level'].value, '2')
+        self.setconf('--warnlevel=3')
+        obj = mesonbuild.coredata.load(self.builddir)
+        self.assertEqual(obj.builtins['warning_level'].value, '3')
+        self.wipe()
+
+        self.init(testdir, extra_args=['-Dwarning_level=2'])
+        obj = mesonbuild.coredata.load(self.builddir)
+        self.assertEqual(obj.builtins['warning_level'].value, '2')
+        self.setconf('-Dwarning_level=3')
+        obj = mesonbuild.coredata.load(self.builddir)
+        self.assertEqual(obj.builtins['warning_level'].value, '3')
+        self.wipe()
+
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.init(testdir, extra_args=['--warnlevel=1', '-Dwarning_level=3'])
+        self.assertEqual(cm.exception.returncode, 1)
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.setconf('--warnlevel=1', '-Dwarning_level=3')
+        self.assertEqual(cm.exception.returncode, 1)
+        self.wipe()
+
+        self.init(testdir, extra_args=['--default-library=static'])
+        obj = mesonbuild.coredata.load(self.builddir)
+        self.assertEqual(obj.builtins['default_library'].value, 'static')
+        self.setconf('--default-library=shared')
+        obj = mesonbuild.coredata.load(self.builddir)
+        self.assertEqual(obj.builtins['default_library'].value, 'shared')
+        self.wipe()
 
 
 class FailureTests(BasePlatformTests):

--- a/test cases/unit/30 command line/meson.build
+++ b/test cases/unit/30 command line/meson.build
@@ -1,0 +1,1 @@
+project('command line test', 'c')


### PR DESCRIPTION
Noticed this regression while working on #3473, I'm working on a larger refactoring of the command line parser, but this could already be merged, IMO.