### PR TITLE
Convert buildtype to optimization and debug options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.settings
 /.cproject
 /.idea
+/.vscode
 
 __pycache__
 .coverage

--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -74,6 +74,7 @@ platforms or with all compilers:
 | b_bitcode   | false         | true, false             | Embed Apple bitcode, see below |
 | b_colorout  | always        | auto, always, never     | Use colored output |
 | b_coverage  | false         | true, false             | Enable coverage tracking |
+| b_crtlib    | from_buildtype| none, md, mdd, mt, mtd, from_buildtype | VS runtime library to use (since 0.48.0) |
 | b_lundef    | true          | true, false             | Don't allow undefined symbols when linking |
 | b_lto       | false         | true, false             | Use link time optimization |
 | b_ndebug    | false         | true, false, if-release | Disable asserts |

--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -74,7 +74,7 @@ platforms or with all compilers:
 | b_bitcode   | false         | true, false             | Embed Apple bitcode, see below |
 | b_colorout  | always        | auto, always, never     | Use colored output |
 | b_coverage  | false         | true, false             | Enable coverage tracking |
-| b_crtlib    | from_buildtype| none, md, mdd, mt, mtd, from_buildtype | VS runtime library to use (since 0.48.0) |
+| b_vscrt     | from_buildtype| none, md, mdd, mt, mtd, from_buildtype | VS runtime library to use (since 0.48.0) |
 | b_lundef    | true          | true, false             | Don't allow undefined symbols when linking |
 | b_lto       | false         | true, false             | Use link time optimization |
 | b_ndebug    | false         | true, false, if-release | Disable asserts |

--- a/docs/markdown/snippets/buildtype_toggles.md
+++ b/docs/markdown/snippets/buildtype_toggles.md
@@ -18,4 +18,4 @@ meson configure -Doptimization=g
 Similarly we have added a toggle option to select the version of
 Visual Studio C runtime to use. By default it uses the debug runtime
 DLL debug builds and release DLL for release builds but this can be
-manually changed with the new build type option.
+manually changed with the new base option `b_vscrt`.

--- a/docs/markdown/snippets/buildtype_toggles.md
+++ b/docs/markdown/snippets/buildtype_toggles.md
@@ -1,0 +1,21 @@
+## Toggles for build type, optimization and vcrt type
+
+Since the very beginning Meson has provided different project types to
+use, such as *debug* and *minsize*. There is also a *plain* type that
+adds nothing by default but instead makes it the user's responsibility
+to add everything by hand. This works but is a bit tedious.
+
+In this release we have added new new options to manually toggle
+e.g. optimization levels and debug info so those can be changed
+independently of other options. For example by default the debug
+buildtype has no optmization enabled at all. If you wish to use GCC's
+`-Og` instead, you could set it with the following command:
+
+```
+meson configure -Doptimization=g
+```
+
+Similarly we have added a toggle option to select the version of
+Visual Studio C runtime to use. By default it uses the debug runtime
+DLL debug builds and release DLL for release builds but this can be
+manually changed with the new build type option.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -532,6 +532,7 @@ class Backend:
         commands += compiler.get_option_compile_args(copt_proxy)
         # Add buildtype args: optimization level, debugging, etc.
         commands += compiler.get_buildtype_args(self.get_option_for_target('buildtype', target))
+        commands += compiler.get_optimization_args(self.get_option_for_target('optimization', target))
         # Add compile args added using add_project_arguments()
         commands += self.build.get_project_args(compiler, target.subproject)
         # Add compile args added using add_global_arguments()

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -533,6 +533,7 @@ class Backend:
         # Add buildtype args: optimization level, debugging, etc.
         commands += compiler.get_buildtype_args(self.get_option_for_target('buildtype', target))
         commands += compiler.get_optimization_args(self.get_option_for_target('optimization', target))
+        commands += compiler.get_debug_args(self.get_option_for_target('debug', target))
         # Add compile args added using add_project_arguments()
         commands += self.build.get_project_args(compiler, target.subproject)
         # Add compile args added using add_global_arguments()

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1117,6 +1117,7 @@ int dummy;
         args.append(cratetype)
         args += ['--crate-name', target.name]
         args += rustc.get_buildtype_args(self.get_option_for_target('buildtype', target))
+        args += rustc.get_debug_args(self.get_option_for_target('debug', target))
         depfile = os.path.join(target.subdir, target.name + '.d')
         args += ['--emit', 'dep-info={}'.format(depfile), '--emit', 'link']
         args += target.get_extra_args('rust')

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -826,6 +826,8 @@ int dummy;
         deps = []
         commands = CompilerArgs(compiler, target.extra_args.get('cs', []))
         commands += compiler.get_buildtype_args(buildtype)
+        commands += compiler.get_optimization_args(self.get_option_for_target('optimization', target))
+        commands += compiler.get_debug_args(self.get_option_for_target('debug', target))
         if isinstance(target, build.Executable):
             commands.append('-target:exe')
         elif isinstance(target, build.SharedLibrary):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1242,6 +1242,8 @@ int dummy;
                 raise InvalidArguments('Swift target %s contains a non-swift source file.' % target.get_basename())
         os.makedirs(self.get_target_private_dir_abs(target), exist_ok=True)
         compile_args = swiftc.get_compile_only_args()
+        compile_args += swiftc.get_optimization_args(self.get_option_for_target('optimization', target))
+        compile_args += swiftc.get_debug_args(self.get_option_for_target('debug', target))
         compile_args += swiftc.get_module_args(module_name)
         compile_args += self.build.get_project_args(swiftc, target.subproject)
         compile_args += self.build.get_global_args(swiftc)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -32,7 +32,7 @@ from ..compilers import CompilerArgs, CCompiler
 from ..linkers import ArLinker
 from ..mesonlib import File, MesonException, OrderedSet
 from ..mesonlib import get_compiler_for_source, has_path_sep
-from .backends import CleanTrees, InstallData, TargetInstallData
+from .backends import CleanTrees
 from ..build import InvalidArguments
 
 if mesonlib.is_windows():

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -534,9 +534,17 @@ class Vs2010Backend(backends.Backend):
         pch_out = ET.SubElement(inc_cl, 'PrecompiledHeaderOutputFile')
         pch_out.text = '$(IntDir)$(TargetName)-%s.pch' % lang
 
+    def is_argument_with_msbuild_xml_entry(self, entry):
+        # Remove arguments that have a top level XML entry so
+        # they are not used twice.
+        # FIXME add args as needed.
+        return entry[1:].startswith('M')
+
     def add_additional_options(self, lang, parent_node, file_args):
         args = []
         for arg in file_args[lang].to_native():
+            if self.is_argument_with_msbuild_xml_entry(arg):
+                continue
             if arg == '%(AdditionalOptions)':
                 args.append(arg)
             else:
@@ -809,6 +817,7 @@ class Vs2010Backend(backends.Backend):
             if l in file_args:
                 file_args[l] += compilers.get_base_compile_args(self.get_base_options_for_target(target), comp)
                 file_args[l] += comp.get_option_compile_args(self.environment.coredata.compiler_options)
+
         # Add compile args added using add_project_arguments()
         for l, args in self.build.projects_args.get(target.subproject, {}).items():
             if l in file_args:

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -739,14 +739,21 @@ class Vs2010Backend(backends.Backend):
         if '/INCREMENTAL:NO' in buildtype_link_args:
             ET.SubElement(type_config, 'LinkIncremental').text = 'false'
         # CRT type; debug or release
-        if crtlib_type == 'mdd' or (crtlib_type == 'from_buildtype' and self.buildtype == 'debug'):
+        if crtlib_type.value == 'from_buildtype':
+            if self.buildtype == 'debug' or self.buildtype == 'debugoptimized':
+                ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
+                ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreadedDebugDLL'
+            else:
+                ET.SubElement(type_config, 'UseDebugLibraries').text = 'false'
+                ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreaded'
+        elif crtlib_type.value == 'mdd':
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
             ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreadedDebugDLL'
-        elif crtlib_type == 'mt':
+        elif crtlib_type.value == 'mt':
             # FIXME, wrong
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'false'
             ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreaded'
-        elif crtlib_type == 'mtd':
+        elif crtlib_type.value == 'mtd':
             # FIXME, wrong
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
             ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreadedDebug'

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -685,7 +685,7 @@ class Vs2010Backend(backends.Backend):
         compiler = self._get_cl_compiler(target)
         buildtype_args = compiler.get_buildtype_args(self.buildtype)
         buildtype_link_args = compiler.get_buildtype_linker_args(self.buildtype)
-        crtlib_type = self.environment.coredata.base_options['b_crtlib']
+        vscrt_type = self.environment.coredata.base_options['b_vscrt']
         project_name = target.name
         target_name = target.name
         root = ET.Element('Project', {'DefaultTargets': "Build",
@@ -739,21 +739,21 @@ class Vs2010Backend(backends.Backend):
         if '/INCREMENTAL:NO' in buildtype_link_args:
             ET.SubElement(type_config, 'LinkIncremental').text = 'false'
         # CRT type; debug or release
-        if crtlib_type.value == 'from_buildtype':
+        if vscrt_type.value == 'from_buildtype':
             if self.buildtype == 'debug' or self.buildtype == 'debugoptimized':
                 ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
                 ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreadedDebugDLL'
             else:
                 ET.SubElement(type_config, 'UseDebugLibraries').text = 'false'
                 ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreaded'
-        elif crtlib_type.value == 'mdd':
+        elif vscrt_type.value == 'mdd':
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
             ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreadedDebugDLL'
-        elif crtlib_type.value == 'mt':
+        elif vscrt_type.value == 'mt':
             # FIXME, wrong
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'false'
             ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreaded'
-        elif crtlib_type.value == 'mtd':
+        elif vscrt_type.value == 'mtd':
             # FIXME, wrong
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
             ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreadedDebug'

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -677,6 +677,7 @@ class Vs2010Backend(backends.Backend):
         compiler = self._get_cl_compiler(target)
         buildtype_args = compiler.get_buildtype_args(self.buildtype)
         buildtype_link_args = compiler.get_buildtype_linker_args(self.buildtype)
+        crtlib_type = self.environment.coredata.base_options['b_crtlib']
         project_name = target.name
         target_name = target.name
         root = ET.Element('Project', {'DefaultTargets': "Build",
@@ -730,9 +731,17 @@ class Vs2010Backend(backends.Backend):
         if '/INCREMENTAL:NO' in buildtype_link_args:
             ET.SubElement(type_config, 'LinkIncremental').text = 'false'
         # CRT type; debug or release
-        if '/MDd' in buildtype_args:
+        if crtlib_type == 'mdd' or (crtlib_type == 'from_buildtype' and self.buildtype == 'debug'):
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
             ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreadedDebugDLL'
+        elif crtlib_type == 'mt':
+            # FIXME, wrong
+            ET.SubElement(type_config, 'UseDebugLibraries').text = 'false'
+            ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreaded'
+        elif crtlib_type == 'mtd':
+            # FIXME, wrong
+            ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
+            ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreadedDebug'
         else:
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'false'
             ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreadedDLL'

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1211,7 +1211,7 @@ class VisualStudioCCompiler(CCompiler):
         self.warn_args = {'1': ['/W2'],
                           '2': ['/W3'],
                           '3': ['/W4']}
-        self.base_options = ['b_pch', 'b_ndebug', 'b_crtlib'] # FIXME add lto, pgo and the like
+        self.base_options = ['b_pch', 'b_ndebug', 'b_vscrt'] # FIXME add lto, pgo and the like
         self.is_64 = is_64
 
     # Override CCompiler.get_always_args

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1232,10 +1232,10 @@ class VisualStudioCCompiler(CCompiler):
         return ['/MDd']
 
     def get_buildtype_args(self, buildtype):
-        return compilers.compilers.msvc_buildtype_args[buildtype]
+        return compilers.msvc_buildtype_args[buildtype]
 
     def get_buildtype_linker_args(self, buildtype):
-        return compilers.compilers.msvc_buildtype_linker_args[buildtype]
+        return compilers.msvc_buildtype_linker_args[buildtype]
 
     def get_pch_suffix(self):
         return 'pch'
@@ -1266,10 +1266,10 @@ class VisualStudioCCompiler(CCompiler):
         return ['/Fo' + target]
 
     def get_optimization_args(self, optimization_level):
-        return msvc_optimization_args[optimization_level]
+        return compilers.msvc_optimization_args[optimization_level]
 
     def get_debug_args(self, is_debug):
-        return msvc_debug_args[is_debug]
+        return compilers.msvc_debug_args[is_debug]
 
     def get_dependency_gen_args(self, outtarget, outfile):
         return []
@@ -1458,7 +1458,7 @@ class VisualStudioCCompiler(CCompiler):
             return self.crt_args[crt_val]
         assert(crt_val == 'from_buildtype')
         # Match what build type flags used to do.
-        if builtype == 'plain':
+        if buildtype == 'plain':
             return []
         elif buildtype == 'debug':
             return self.crt_args['mdd']

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1225,10 +1225,10 @@ class VisualStudioCCompiler(CCompiler):
         return ['/MDd']
 
     def get_buildtype_args(self, buildtype):
-        return msvc_buildtype_args[buildtype]
+        return compilers.compilers.msvc_buildtype_args[buildtype]
 
     def get_buildtype_linker_args(self, buildtype):
-        return msvc_buildtype_linker_args[buildtype]
+        return compilers.compilers.msvc_buildtype_linker_args[buildtype]
 
     def get_pch_suffix(self):
         return 'pch'
@@ -1257,6 +1257,12 @@ class VisualStudioCCompiler(CCompiler):
         if target.endswith('.exe'):
             return ['/Fe' + target]
         return ['/Fo' + target]
+
+    def get_optimization_args(self, optimization_level):
+        return msvc_optimization_args[optimization_level]
+
+    def get_debug_args(self, is_debug):
+        return msvc_debug_args[is_debug]
 
     def get_dependency_gen_args(self, outtarget, outfile):
         return []

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -30,8 +30,6 @@ from .compilers import (
     GCC_MINGW,
     get_largefile_args,
     gnu_winlibs,
-    msvc_buildtype_args,
-    msvc_buildtype_linker_args,
     msvc_winlibs,
     vs32_instruction_set_args,
     vs64_instruction_set_args,

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -216,8 +216,8 @@ d_dmd_buildtype_args = {'plain': [],
                         }
 
 mono_buildtype_args = {'plain': [],
-                       'debug': ['-debug'],
-                       'debugoptimized': ['-debug', '-optimize+'],
+                       'debug': [],
+                       'debugoptimized': ['-optimize+'],
                        'release': ['-optimize+'],
                        'minsize': [],
                        }

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -188,8 +188,8 @@ java_buildtype_args = {'plain': [],
                        }
 
 rust_buildtype_args = {'plain': [],
-                       'debug': ['-C', 'debuginfo=2'],
-                       'debugoptimized': ['-C', 'debuginfo=2'],
+                       'debug': [],
+                       'debugoptimized': [],
                        'release': [],
                        'minsize': [],
                        }
@@ -268,14 +268,6 @@ msvc_optimization_args = {'0': [],
                           '2': ['/O2'],
                           '3': ['/O3'],
                           's': ['/Os'],
-                          }
-
-rust_optimization_args = {'0': [],
-                          'g': ['-C' ,'--opt-level=0'],
-                          '1': ['-C' ,'--opt-level=1'],
-                          '2': ['-C' ,'--opt-level=2'],
-                          '3': ['-C' ,'--opt-level=3'],
-                          's': ['-C' ,'--opt-level=s'],
                           }
 
 clike_debug_args = {False: [],

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -144,7 +144,7 @@ arm_buildtype_args = {'plain': [],
 
 msvc_buildtype_args = {'plain': [],
                        'debug': ["/ZI", "/Ob0", "/Od", "/RTC1"],
-                       'debugoptimized': ["/Zi", "/O2", "/Ob1"],
+                       'debugoptimized': ["/Zi", "/Ob1"],
                        'release': ["/Ob2"],
                        'minsize': ["/Zi", "/Ob1"],
                        }
@@ -310,6 +310,9 @@ base_options = {'b_pch': coredata.UserBooleanOption('b_pch', 'Use precompiled he
                 'b_bitcode': coredata.UserBooleanOption('b_bitcode',
                                                         'Generate and embed bitcode (only macOS and iOS)',
                                                         False),
+                'b_crtlib': coredata.UserComboOption('b_crtlib', 'C run-time library to use.',
+                                                     ['none', 'md', 'mdd', 'mt', 'mtd', 'from_buildtype'],
+                                                     'from_buildtype'),
                 }
 
 gnulike_instruction_set_args = {'mmx': ['-mmmx'],
@@ -417,6 +420,15 @@ def get_base_compile_args(options, compiler):
     # This does not need a try...except
     if option_enabled(compiler.base_options, options, 'b_bitcode'):
         args.append('-fembed-bitcode')
+    try:
+        crt_val = options['b_crtlib'].value
+        buildtype = options['buildtype'].value
+        try:
+            args += compiler.get_crt_compile_args(crt_val, buildtype)
+        except AttributeError:
+            pass
+    except KeyError:
+        pass
     return args
 
 def get_base_link_args(options, linker, is_shared_module):

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -273,10 +273,6 @@ msvc_optimization_args = {'0': [],
 clike_debug_args = {False: [],
                     True: ['-g']}
 
-# FIXME, MSVC's debug args are more complicated than this.
-msvc_debug_args = {False: ['/MD'],
-                   True: ['/MDd']}
-
 base_options = {'b_pch': coredata.UserBooleanOption('b_pch', 'Use precompiled headers', True),
                 'b_lto': coredata.UserBooleanOption('b_lto', 'Use link time optimization', False),
                 'b_sanitize': coredata.UserComboOption('b_sanitize',

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -195,22 +195,22 @@ rust_buildtype_args = {'plain': [],
                        }
 
 d_gdc_buildtype_args = {'plain': [],
-                        'debug': ['-g', '-O0'],
-                        'debugoptimized': ['-g', '-O'],
+                        'debug': [],
+                        'debugoptimized': ['-O'],
                         'release': ['-O3', '-frelease'],
                         'minsize': [],
                         }
 
 d_ldc_buildtype_args = {'plain': [],
-                        'debug': ['-g', '-O0'],
-                        'debugoptimized': ['-g', '-O'],
+                        'debug': [],
+                        'debugoptimized': ['-O'],
                         'release': ['-O3', '-release'],
                         'minsize': [],
                         }
 
 d_dmd_buildtype_args = {'plain': [],
-                        'debug': ['-g'],
-                        'debugoptimized': ['-g', '-O'],
+                        'debug': [],
+                        'debugoptimized': ['-O'],
                         'release': ['-O', '-release'],
                         'minsize': [],
                         }

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -301,9 +301,9 @@ base_options = {'b_pch': coredata.UserBooleanOption('b_pch', 'Use precompiled he
                 'b_bitcode': coredata.UserBooleanOption('b_bitcode',
                                                         'Generate and embed bitcode (only macOS and iOS)',
                                                         False),
-                'b_crtlib': coredata.UserComboOption('b_crtlib', 'C run-time library to use.',
-                                                     ['none', 'md', 'mdd', 'mt', 'mtd', 'from_buildtype'],
-                                                     'from_buildtype'),
+                'b_vscrt': coredata.UserComboOption('b_vscrt', 'VS run-time library type to use.',
+                                                    ['none', 'md', 'mdd', 'mt', 'mtd', 'from_buildtype'],
+                                                    'from_buildtype'),
                 }
 
 gnulike_instruction_set_args = {'mmx': ['-mmmx'],
@@ -412,7 +412,7 @@ def get_base_compile_args(options, compiler):
     if option_enabled(compiler.base_options, options, 'b_bitcode'):
         args.append('-fembed-bitcode')
     try:
-        crt_val = options['b_crtlib'].value
+        crt_val = options['b_vscrt'].value
         buildtype = options['buildtype'].value
         try:
             args += compiler.get_crt_compile_args(crt_val, buildtype)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -191,7 +191,7 @@ rust_buildtype_args = {'plain': [],
                        'debug': ['-C', 'debuginfo=2'],
                        'debugoptimized': ['-C', 'debuginfo=2'],
                        'release': [],
-                       'minsize': [], 
+                       'minsize': [],
                        }
 
 d_gdc_buildtype_args = {'plain': [],
@@ -246,15 +246,15 @@ clang_color_args = {'auto': ['-Xclang', '-fcolor-diagnostics'],
                     'never': ['-Xclang', '-fno-color-diagnostics'],
                     }
 
-clike_optimization_args = {'0': ['-O0'],
-                           'g': ['-O0'],
+clike_optimization_args = {'0': [],
+                           'g': [],
                            '1': ['-O1'],
                            '2': ['-O2'],
                            '3': ['-O3'],
                            's': ['-Os'],
                            }
 
-gnu_optimization_args = {'0': ['-O0'],
+gnu_optimization_args = {'0': [],
                          'g': ['-Og'],
                          '1': ['-O1'],
                          '2': ['-O2'],
@@ -262,7 +262,7 @@ gnu_optimization_args = {'0': ['-O0'],
                          's': ['-Os'],
                          }
 
-msvc_optimization_args = {'0': ['/O0'],
+msvc_optimization_args = {'0': [],
                           'g': ['/O0'],
                           '1': ['/O1'],
                           '2': ['/O2'],
@@ -270,7 +270,7 @@ msvc_optimization_args = {'0': ['/O0'],
                           's': ['/Os'],
                           }
 
-rust_optimization_args = {'0': ['-C' ,'--opt-level=0'],
+rust_optimization_args = {'0': [],
                           'g': ['-C' ,'--opt-level=0'],
                           '1': ['-C' ,'--opt-level=1'],
                           '2': ['-C' ,'--opt-level=2'],

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -124,12 +124,10 @@ def is_library(fname):
     return suffix in lib_suffixes
 
 gnulike_buildtype_args = {'plain': [],
-                          # -O0 is passed for improved debugging information with gcc
-                          # See https://github.com/mesonbuild/meson/pull/509
-                          'debug': ['-g'],
-                          'debugoptimized': ['-g'],
+                          'debug': [],
+                          'debugoptimized': [],
                           'release': [],
-                          'minsize': ['-g']}
+                          'minsize': []}
 
 armclang_buildtype_args = {'plain': [],
                            'debug': ['-O0', '-g'],
@@ -145,10 +143,10 @@ arm_buildtype_args = {'plain': [],
                       }
 
 msvc_buildtype_args = {'plain': [],
-                       'debug': ["/MDd", "/ZI", "/Ob0", "/Od", "/RTC1"],
-                       'debugoptimized': ["/MD", "/Zi", "/O2", "/Ob1"],
-                       'release': ["/MD", "/Ob2"],
-                       'minsize': ["/MD", "/Zi", "/Ob1"],
+                       'debug': ["/ZI", "/Ob0", "/Od", "/RTC1"],
+                       'debugoptimized': ["/Zi", "/O2", "/Ob1"],
+                       'release': ["/Ob2"],
+                       'minsize': ["/Zi", "/Ob1"],
                        }
 
 apple_buildtype_linker_args = {'plain': [],
@@ -191,9 +189,9 @@ java_buildtype_args = {'plain': [],
 
 rust_buildtype_args = {'plain': [],
                        'debug': ['-C', 'debuginfo=2'],
-                       'debugoptimized': ['-C', 'debuginfo=2', '-C', 'opt-level=2'],
-                       'release': ['-C', 'opt-level=3'],
-                       'minsize': [], # In a future release: ['-C', 'opt-level=s'],
+                       'debugoptimized': ['-C', 'debuginfo=2'],
+                       'release': [],
+                       'minsize': [], 
                        }
 
 d_gdc_buildtype_args = {'plain': [],
@@ -280,6 +278,12 @@ rust_optimization_args = {'0': ['-C' ,'--opt-level=0'],
                           's': ['-C' ,'--opt-level=s'],
                           }
 
+clike_debug_args = {False: [],
+                    True: ['-g']}
+
+# FIXME, MSVC's debug args are more complicated than this.
+msvc_debug_args = {False: ['/MD'],
+                   True: ['/MDd']}
 
 base_options = {'b_pch': coredata.UserBooleanOption('b_pch', 'Use precompiled headers', True),
                 'b_lto': coredata.UserBooleanOption('b_lto', 'Use link time optimization', False),
@@ -1285,6 +1289,9 @@ class GnuCompiler:
 
     def get_optimization_args(self, optimization_level):
         return gnu_optimization_args[optimization_level]
+
+    def get_debug_args(self, is_debug):
+        return clike_debug_args[is_debug]
 
     def get_buildtype_linker_args(self, buildtype):
         if self.gcc_type == GCC_OSX:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1426,6 +1426,12 @@ class ClangCompiler:
             return apple_buildtype_linker_args[buildtype]
         return gnulike_buildtype_linker_args[buildtype]
 
+    def get_optimization_args(self, optimization_level):
+        return clike_optimization_args[optimization_level]
+
+    def get_debug_args(self, is_debug):
+        return clike_debug_args[is_debug]
+
     def get_pch_suffix(self):
         return 'pch'
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -126,10 +126,10 @@ def is_library(fname):
 gnulike_buildtype_args = {'plain': [],
                           # -O0 is passed for improved debugging information with gcc
                           # See https://github.com/mesonbuild/meson/pull/509
-                          'debug': ['-O0', '-g'],
-                          'debugoptimized': ['-O2', '-g'],
-                          'release': ['-O3'],
-                          'minsize': ['-Os', '-g']}
+                          'debug': ['-g'],
+                          'debugoptimized': ['-g'],
+                          'release': [],
+                          'minsize': ['-g']}
 
 armclang_buildtype_args = {'plain': [],
                            'debug': ['-O0', '-g'],
@@ -147,8 +147,8 @@ arm_buildtype_args = {'plain': [],
 msvc_buildtype_args = {'plain': [],
                        'debug': ["/MDd", "/ZI", "/Ob0", "/Od", "/RTC1"],
                        'debugoptimized': ["/MD", "/Zi", "/O2", "/Ob1"],
-                       'release': ["/MD", "/O2", "/Ob2"],
-                       'minsize': ["/MD", "/Zi", "/Os", "/Ob1"],
+                       'release': ["/MD", "/Ob2"],
+                       'minsize': ["/MD", "/Zi", "/Ob1"],
                        }
 
 apple_buildtype_linker_args = {'plain': [],
@@ -247,6 +247,39 @@ clang_color_args = {'auto': ['-Xclang', '-fcolor-diagnostics'],
                     'always': ['-Xclang', '-fcolor-diagnostics'],
                     'never': ['-Xclang', '-fno-color-diagnostics'],
                     }
+
+clike_optimization_args = {'0': ['-O0'],
+                           'g': ['-O0'],
+                           '1': ['-O1'],
+                           '2': ['-O2'],
+                           '3': ['-O3'],
+                           's': ['-Os'],
+                           }
+
+gnu_optimization_args = {'0': ['-O0'],
+                         'g': ['-Og'],
+                         '1': ['-O1'],
+                         '2': ['-O2'],
+                         '3': ['-O3'],
+                         's': ['-Os'],
+                         }
+
+msvc_optimization_args = {'0': ['/O0'],
+                          'g': ['/O0'],
+                          '1': ['/O1'],
+                          '2': ['/O2'],
+                          '3': ['/O3'],
+                          's': ['/Os'],
+                          }
+
+rust_optimization_args = {'0': ['-C' ,'--opt-level=0'],
+                          'g': ['-C' ,'--opt-level=0'],
+                          '1': ['-C' ,'--opt-level=1'],
+                          '2': ['-C' ,'--opt-level=2'],
+                          '3': ['-C' ,'--opt-level=3'],
+                          's': ['-C' ,'--opt-level=s'],
+                          }
+
 
 base_options = {'b_pch': coredata.UserBooleanOption('b_pch', 'Use precompiled headers', True),
                 'b_lto': coredata.UserBooleanOption('b_lto', 'Use link time optimization', False),
@@ -1249,6 +1282,9 @@ class GnuCompiler:
 
     def get_buildtype_args(self, buildtype):
         return gnulike_buildtype_args[buildtype]
+
+    def get_optimization_args(self, optimization_level):
+        return gnu_optimization_args[optimization_level]
 
     def get_buildtype_linker_args(self, buildtype):
         if self.gcc_type == GCC_OSX:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -273,6 +273,9 @@ msvc_optimization_args = {'0': [],
 clike_debug_args = {False: [],
                     True: ['-g']}
 
+msvc_debug_args = {False: [],
+                   True: []} # Fixme!
+
 base_options = {'b_pch': coredata.UserBooleanOption('b_pch', 'Use precompiled headers', True),
                 'b_lto': coredata.UserBooleanOption('b_lto', 'Use link time optimization', False),
                 'b_sanitize': coredata.UserComboOption('b_sanitize',

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -223,9 +223,9 @@ mono_buildtype_args = {'plain': [],
                        }
 
 swift_buildtype_args = {'plain': [],
-                        'debug': ['-g'],
-                        'debugoptimized': ['-g', '-O'],
-                        'release': ['-O'],
+                        'debug': [],
+                        'debugoptimized': [],
+                        'release': [],
                         'minsize': [],
                         }
 

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -242,7 +242,7 @@ class VisualStudioCPPCompiler(VisualStudioCCompiler, CPPCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrap, is_64):
         CPPCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
         VisualStudioCCompiler.__init__(self, exelist, version, is_cross, exe_wrap, is_64)
-        self.base_options = ['b_pch'] # FIXME add lto, pgo and the like
+        self.base_options = ['b_pch', 'b_crtlib'] # FIXME add lto, pgo and the like
 
     def get_options(self):
         opts = CPPCompiler.get_options(self)

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -242,7 +242,7 @@ class VisualStudioCPPCompiler(VisualStudioCCompiler, CPPCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrap, is_64):
         CPPCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
         VisualStudioCCompiler.__init__(self, exelist, version, is_cross, exe_wrap, is_64)
-        self.base_options = ['b_pch', 'b_crtlib'] # FIXME add lto, pgo and the like
+        self.base_options = ['b_pch', 'b_vscrt'] # FIXME add lto, pgo and the like
 
     def get_options(self):
         opts = CPPCompiler.get_options(self)

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -19,6 +19,14 @@ from ..mesonlib import is_windows
 
 from .compilers import Compiler, mono_buildtype_args
 
+cs_optimization_args = {'0': [],
+                        'g': [],
+                        '1': ['-optimize+'],
+                        '2': ['-optimize+'],
+                        '3': ['-optimize+'],
+                        's': ['-optimize+'],
+                        }
+
 class CsCompiler(Compiler):
     def __init__(self, exelist, version, id, runner=None):
         self.language = 'cs'
@@ -118,6 +126,11 @@ class CsCompiler(Compiler):
     def get_buildtype_args(self, buildtype):
         return mono_buildtype_args[buildtype]
 
+    def get_debug_args(self, is_debug):
+        return ['-debug'] if is_debug else []
+
+    def get_optimization_args(self, optimization_level):
+        return cs_optimization_args[optimization_level]
 
 class MonoCompiler(CsCompiler):
     def __init__(self, exelist, version):

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -23,6 +23,8 @@ from .compilers import (
     d_ldc_buildtype_args,
     get_gcc_soname_args,
     gnu_color_args,
+    gnu_optimization_args,
+    clike_debug_args,
     Compiler,
     CompilerArgs,
 )
@@ -288,6 +290,11 @@ class GnuDCompiler(DCompiler):
     def build_rpath_args(self, build_dir, from_dir, rpath_paths, build_rpath, install_rpath):
         return self.build_unix_rpath_args(build_dir, from_dir, rpath_paths, build_rpath, install_rpath)
 
+    def get_optimization_args(self, optimization_level):
+        return gnu_optimization_args[optimization_level]
+
+    def get_debug_args(self, is_debug):
+        return clike_debug_args[is_debug]
 
 class LLVMDCompiler(DCompiler):
     def __init__(self, exelist, version, is_cross, **kwargs):

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -43,6 +43,22 @@ d_feature_args = {'gcc':  {'unittest': '-funittest',
                            }
                   }
 
+ldc_optimization_args = {'0': [],
+                         'g': [],
+                         '1': ['-O1'],
+                         '2': ['-O2'],
+                         '3': ['-O3'],
+                         's': ['-Os'],
+                         }
+
+dmd_optimization_args = {'0': [],
+                         'g': [],
+                         '1': ['-O1'],
+                         '2': ['-O2'],
+                         '3': ['-O3'],
+                         's': ['-Os'],
+                         }
+
 class DCompiler(Compiler):
     def __init__(self, exelist, version, is_cross, **kwargs):
         self.language = 'd'
@@ -240,6 +256,8 @@ class DCompiler(Compiler):
 
         return dcargs
 
+    def get_debug_args(self, is_debug):
+        return clike_debug_args[is_debug]
 
 class GnuDCompiler(DCompiler):
     def __init__(self, exelist, version, is_cross, **kwargs):
@@ -292,9 +310,6 @@ class GnuDCompiler(DCompiler):
 
     def get_optimization_args(self, optimization_level):
         return gnu_optimization_args[optimization_level]
-
-    def get_debug_args(self, is_debug):
-        return clike_debug_args[is_debug]
 
 class LLVMDCompiler(DCompiler):
     def __init__(self, exelist, version, is_cross, **kwargs):
@@ -349,6 +364,9 @@ class LLVMDCompiler(DCompiler):
     def unix_args_to_native(cls, args):
         return cls.translate_args_to_nongnu(args)
 
+    def get_optimization_args(self, optimization_level):
+        return ldc_optimization_args[optimization_level]
+
 
 class DmdDCompiler(DCompiler):
     def __init__(self, exelist, version, is_cross, **kwargs):
@@ -399,3 +417,6 @@ class DmdDCompiler(DCompiler):
     @classmethod
     def unix_args_to_native(cls, args):
         return cls.translate_args_to_nongnu(args)
+
+    def get_optimization_args(self, optimization_level):
+        return dmd_optimization_args[optimization_level]

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -15,6 +15,12 @@
 from .c import CCompiler
 from .compilers import (
     ICC_STANDARD,
+    apple_buildtype_linker_args,
+    get_gcc_soname_args,
+    gnulike_buildtype_args,
+    gnulike_buildtype_linker_args,
+    gnu_optimization_args,
+    clike_debug_args,
     Compiler,
     GnuCompiler,
     ElbrusCompiler,
@@ -60,6 +66,48 @@ class FortranCompiler(Compiler):
 
     def get_soname_args(self, *args):
         return CCompiler.get_soname_args(self, *args)
+
+    def sanity_check(self, work_dir, environment):
+        source_name = os.path.join(work_dir, 'sanitycheckf.f90')
+        binary_name = os.path.join(work_dir, 'sanitycheckf')
+        with open(source_name, 'w') as ofile:
+            ofile.write('''program prog
+     print *, "Fortran compilation is working."
+end program prog
+''')
+        extra_flags = self.get_cross_extra_flags(environment, link=True)
+        pc = subprocess.Popen(self.exelist + extra_flags + [source_name, '-o', binary_name])
+        pc.wait()
+        if pc.returncode != 0:
+            raise EnvironmentException('Compiler %s can not compile programs.' % self.name_string())
+        if self.is_cross:
+            if self.exe_wrapper is None:
+                # Can't check if the binaries run so we have to assume they do
+                return
+            cmdlist = self.exe_wrapper + [binary_name]
+        else:
+            cmdlist = [binary_name]
+        pe = subprocess.Popen(cmdlist, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        pe.wait()
+        if pe.returncode != 0:
+            raise EnvironmentException('Executables created by Fortran compiler %s are not runnable.' % self.name_string())
+
+    def get_std_warn_args(self, level):
+        return FortranCompiler.std_warn_args
+
+    def get_buildtype_args(self, buildtype):
+        return gnulike_buildtype_args[buildtype]
+
+    def get_optimization_args(self, optimization_level):
+        return gnu_optimization_args[optimization_level]
+
+    def get_debug_args(self, is_debug):
+        return clike_debug_args[is_debug]
+
+    def get_buildtype_linker_args(self, buildtype):
+        if is_osx():
+            return apple_buildtype_linker_args[buildtype]
+        return gnulike_buildtype_linker_args[buildtype]
 
     def split_shlib_to_parts(self, fname):
         return CCompiler.split_shlib_to_parts(self, fname)

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -16,7 +16,6 @@ from .c import CCompiler
 from .compilers import (
     ICC_STANDARD,
     apple_buildtype_linker_args,
-    get_gcc_soname_args,
     gnulike_buildtype_args,
     gnulike_buildtype_linker_args,
     gnu_optimization_args,
@@ -26,6 +25,9 @@ from .compilers import (
     ElbrusCompiler,
     IntelCompiler,
 )
+
+from mesonbuild.mesonlib import EnvironmentException, is_osx
+import subprocess, os
 
 class FortranCompiler(Compiler):
     library_dirs_cache = CCompiler.library_dirs_cache
@@ -198,13 +200,6 @@ end program prog
 
     def gen_import_library_args(self, implibname):
         return CCompiler.gen_import_library_args(self, implibname)
-
-    def sanity_check(self, work_dir, environment):
-        code = '''program main
-            integer :: ret = 0
-            call exit(ret)
-        end program main'''
-        return CCompiler.sanity_check_impl(self, work_dir, environment, 'sanitycheckf.f90', code)
 
     def _get_compiler_check_args(self, env, extra_args, dependencies, mode='compile'):
         return CCompiler._get_compiler_check_args(self, env, extra_args, dependencies, mode='compile')

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -16,7 +16,15 @@ import subprocess, os.path
 
 from ..mesonlib import EnvironmentException, Popen_safe
 
-from .compilers import Compiler, rust_buildtype_args
+from .compilers import Compiler, rust_buildtype_args, clike_debug_args
+
+rust_optimization_args = {'0': [],
+                          'g': ['-C' ,'--opt-level=0'],
+                          '1': ['-C' ,'--opt-level=1'],
+                          '2': ['-C' ,'--opt-level=2'],
+                          '3': ['-C' ,'--opt-level=3'],
+                          's': ['-C' ,'--opt-level=s'],
+                          }
 
 class RustCompiler(Compiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None):
@@ -68,3 +76,9 @@ class RustCompiler(Compiler):
         cmd = self.exelist + ['--print', 'sysroot']
         p, stdo, stde = Popen_safe(cmd)
         return stdo.split('\n')[0]
+
+    def get_debug_args(self, is_debug):
+        return clike_debug_args[is_debug]
+
+    def get_optimization_args(self, optimization_level):
+        return rust_optimization_args[optimization_level]

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -19,11 +19,11 @@ from ..mesonlib import EnvironmentException, Popen_safe
 from .compilers import Compiler, rust_buildtype_args, clike_debug_args
 
 rust_optimization_args = {'0': [],
-                          'g': ['-C' ,'--opt-level=0'],
-                          '1': ['-C' ,'--opt-level=1'],
-                          '2': ['-C' ,'--opt-level=2'],
-                          '3': ['-C' ,'--opt-level=3'],
-                          's': ['-C' ,'--opt-level=s'],
+                          'g': ['-C', '--opt-level=0'],
+                          '1': ['-C', '--opt-level=1'],
+                          '2': ['-C', '--opt-level=2'],
+                          '3': ['-C', '--opt-level=3'],
+                          's': ['-C', '--opt-level=s'],
                           }
 
 class RustCompiler(Compiler):

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -16,7 +16,15 @@ import subprocess, os.path
 
 from ..mesonlib import EnvironmentException
 
-from .compilers import Compiler, swift_buildtype_args
+from .compilers import Compiler, swift_buildtype_args, clike_debug_args
+
+swift_optimization_args = {'0': [],
+                           'g': [],
+                           '1': ['-O'],
+                           '2': ['-O'],
+                           '3': ['-O'],
+                           's': ['-O'],
+                           }
 
 class SwiftCompiler(Compiler):
     def __init__(self, exelist, version):
@@ -97,3 +105,9 @@ class SwiftCompiler(Compiler):
             raise EnvironmentException('Swift compiler %s can not compile programs.' % self.name_string())
         if subprocess.call(output_name) != 0:
             raise EnvironmentException('Executables created by Swift compiler %s are not runnable.' % self.name_string())
+
+    def get_debug_args(self, is_debug):
+        return clike_debug_args[is_debug]
+
+    def get_optimization_args(self, optimization_level):
+        return swift_optimization_args[optimization_level]

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -34,6 +34,12 @@ class ValaCompiler(Compiler):
     def needs_static_linker(self):
         return False # Because compiles into C.
 
+    def get_optimization_args(self, optimization_level):
+        return []
+
+    def get_debug_args(self, is_debug):
+        return ['--debug']
+
     def get_output_args(self, target):
         return [] # Because compiles into C.
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -544,7 +544,7 @@ def parse_cmd_line_options(args):
             delattr(args, name)
 
 builtin_options = {
-    'buildtype':  [UserComboOption, 'Build type to use.', ['plain', 'debug', 'debugoptimized', 'release', 'minsize'], 'debug'],
+    'buildtype':  [UserComboOption, 'Build type to use.', ['plain', 'debug', 'debugoptimized', 'release', 'minsize', 'custom'], 'debug'],
     'strip':      [UserBooleanOption, 'Strip targets on install.', False],
     'unity':      [UserComboOption, 'Unity build.', ['on', 'off', 'subprojects'], 'off'],
     'prefix':     [UserStringOption, 'Installation prefix.', default_prefix()],
@@ -569,6 +569,8 @@ builtin_options = {
     'errorlogs':       [UserBooleanOption, "Whether to print the logs from failing tests.", True],
     'install_umask':   [UserUmaskOption, 'Default umask to apply on permissions of installed files.', '022'],
     'auto_features':   [UserFeatureOption, "Override value of all 'auto' features.", 'auto'],
+    'optimization':    [UserComboOption, 'Optimization level', ['0', 'g', '1', '2', '3', 's'], '0'],
+    'debug':           [UserBooleanOption, 'Debug', True]
 }
 
 # Special prefix-dependent defaults for installation directories that reside in

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2552,6 +2552,41 @@ recommended as it is not supported on some platforms''')
                                    stdout=subprocess.DEVNULL,
                                    stderr=subprocess.DEVNULL)
 
+    def get_opts_as_dict(self):
+        result = {}
+        for i in self.introspect('--buildoptions'):
+            result[i['name']] = i['value']
+        return result
+
+    def test_buildtype_setting(self):
+        testdir = os.path.join(self.common_test_dir, '1 trivial')
+        self.init(testdir)
+        opts = self.get_opts_as_dict()
+        self.assertEqual(opts['buildtype'], 'debug')
+        self.assertEqual(opts['debug'], True)
+        self.setconf('-Ddebug=false')
+        opts = self.get_opts_as_dict()
+        self.assertEqual(opts['debug'], False)
+        self.assertEqual(opts['buildtype'], 'plain')
+        self.assertEqual(opts['optimization'], '0')
+
+        # Setting optimizations to 3 should cause buildtype
+        # to go to release mode.
+        self.setconf('-Doptimization=3')
+        opts = self.get_opts_as_dict()
+        self.assertEqual(opts['buildtype'], 'release')
+        self.assertEqual(opts['debug'], False)
+        self.assertEqual(opts['optimization'], '3')
+
+        # Going to debug build type should reset debugging
+        # and optimization
+        self.setconf('-Dbuildtype=debug')
+        opts = self.get_opts_as_dict()
+        self.assertEqual(opts['buildtype'], 'debug')
+        self.assertEqual(opts['debug'], True)
+        self.assertEqual(opts['optimization'], '0')
+
+
 class FailureTests(BasePlatformTests):
     '''
     Tests that test failure conditions. Build files here should be dynamically

--- a/test cases/common/126 llvm ir and assembly/meson.build
+++ b/test cases/common/126 llvm ir and assembly/meson.build
@@ -47,7 +47,7 @@ foreach lang : ['c', 'cpp']
     square_impl = custom_target(lang + square_impl,
         input : square_preproc,
         output : lang + square_base + '.obj',
-        command : [ml, '/Fo', '@OUTPUT@', '/c', '@INPUT@'])
+        command : [ml, '/safeseh', '/Fo', '@OUTPUT@', '/c', '@INPUT@'])
   endif
   if supported_cpus.contains(cpu)
     e = executable('square_asm_' + lang, square_impl, 'main.' + lang,


### PR DESCRIPTION
The current setup of a couple of different build types is a bit limiting. Ideally you'd want to toggle the optimization levels and "debugness" independent of each other. Some people might want to do releases with `-O2` and others with `-O3` for example.

This is a very rudimentary fix showing how a small fraction of this would be done. The full setup would go something like this:

 - optimization gets its own option, with values as shown in this MR
 - debug gets a boolean switch
 - buildtype gets a new value of `custom`
 - setting `buildtype` sets also the value of the other two to match current behaviour
 - optimization and debug can be set to any value combinations
 - if the combination exactly matches some current build type, the value of `builtype` is set to that, otherwise it is set to `custom`

Comments welcome.
