### PR TITLE
Always generate a new Product GUID. Closes #2485.  [skip ci]

### DIFF
--- a/msi/createmsi.py
+++ b/msi/createmsi.py
@@ -38,7 +38,7 @@ class PackageGenerator:
         self.product_name = 'Meson Build System'
         self.manufacturer = 'The Meson Development Team'
         self.version = coredata.version.replace('dev', '')
-        self.guid = 'DF5B3ECA-4A31-43E3-8CE4-97FC8A97212E'
+        self.guid = '*'
         self.update_guid = '141527EE-E28A-4D14-97A4-92E6075D28B2'
         self.main_xml = 'meson.wxs'
         self.main_o = 'meson.wixobj'


### PR DESCRIPTION
We are taking some shortcuts here. The WiX documentation says that you
should keep the Product GUID the same for "small and minor" upgrades
but change it for major ones. These are not defined in any way and a
change of version number might, or might not, warrant a guid
update. For simplicity we will always regenerate the Product GUID.

Again we find that naming things is difficult since "product" in
everyday language would mean "the application/library/software" and
all different versions of it. In MSI installer terminology it means
something vague between the two.

https://www.firegiant.com/wix/tutorial/upgrades-and-modularization/