### PR TITLE
Fix setting c_args and friends from command line

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2386,24 +2386,21 @@ to directly access options of other subprojects.''')
             mlog.log('Native %s compiler: ' % comp.get_display_language(), mlog.bold(' '.join(comp.get_exelist())), version_string, sep='')
 
             # If <language>_args/_link_args settings are given on the
-            # command line, use them.
+            # command line, use them, otherwise take them from env.
+            (preproc_args, compile_args, link_args) = environment.get_args_from_envvars(comp)
             for optspec in self.build.environment.cmd_line_options.projectoptions:
                 (optname, optvalue) = optspec.split('=', maxsplit=1)
-                if optname.endswith('_link_args'):
-                    lang = optname[:-10]
-                    self.coredata.external_link_args.setdefault(lang, []).append(optvalue)
+                if optname == lang + '_link_args':
+                    link_args = shlex.split(optvalue)
                 elif optname.endswith('_args'):
-                    lang = optname[:-5]
-                    self.coredata.external_args.setdefault(lang, []).append(optvalue)
-            # Otherwise, look for definitions from environment
-            # variables such as CFLAGS.
-            (preproc_args, compile_args, link_args) = environment.get_args_from_envvars(comp)
-            if not comp.get_language() in self.coredata.external_preprocess_args:
-                self.coredata.external_preprocess_args[comp.get_language()] = preproc_args
-            if not comp.get_language() in self.coredata.external_args:
-                self.coredata.external_args[comp.get_language()] = compile_args
-            if not comp.get_language() in self.coredata.external_link_args:
-                self.coredata.external_link_args[comp.get_language()] = link_args
+                    compile_args = shlex.split(optvalue)
+            if lang not in self.coredata.external_preprocess_args:
+                self.coredata.external_preprocess_args[lang] = preproc_args
+            if lang not in self.coredata.external_args:
+                self.coredata.external_args[lang] = compile_args
+            if lang not in self.coredata.external_link_args:
+                self.coredata.external_link_args[lang] = link_args
+
             self.build.add_compiler(comp)
             if need_cross_compiler:
                 mlog.log('Cross %s compiler: ' % cross_comp.get_display_language(), mlog.bold(' '.join(cross_comp.get_exelist())), ' (%s %s)' % (cross_comp.id, cross_comp.version), sep='')

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -15,6 +15,7 @@
 import os
 import sys
 import argparse
+import shlex
 from . import (coredata, mesonlib, build)
 
 def buildparser():
@@ -119,14 +120,14 @@ class Conf:
                     raise ConfException('Unknown language %s in linkargs.' % lang)
                 # TODO, currently split on spaces, make it so that user
                 # can pass in an array string.
-                newvalue = v.split()
+                newvalue = shlex.split(v)
                 self.coredata.external_link_args[lang] = newvalue
             elif k.endswith('_args'):
                 lang = k[:-5]
                 if lang not in self.coredata.external_args:
                     raise ConfException('Unknown language %s in compile args' % lang)
                 # TODO same fix as above
-                newvalue = v.split()
+                newvalue = shlex.split(v)
                 self.coredata.external_args[lang] = newvalue
             else:
                 raise ConfException('Unknown option %s.' % k)

--- a/test cases/common/181 initial c_args/meson.build
+++ b/test cases/common/181 initial c_args/meson.build
@@ -1,7 +1,7 @@
 project('options', 'c')
 
 # Test passing c_args and c_link_args options from the command line.
-assert(get_option('c_args') == ['-march=native', '-funroll-loops'],
+assert(get_option('c_args') == ['-funroll-loops'],
        'Incorrect value for c_args option.')
 assert(get_option('c_link_args') == ['-random_linker_option'],
        'Incorrect value for c_link_args option.')


### PR DESCRIPTION
When passing more than one -Dc_args it should override the value
instead of appending. This is how all other options works.

Value should be split on spaces using shlex just like it does with
CFLAGS environment variable.

Fixes #3473.