### PR TITLE
Allow `required : false` for OpenMP dependency

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -253,7 +253,13 @@ class OpenMPDependency(ExternalDependency):
         language = kwargs.get('language')
         super().__init__('openmp', environment, language, kwargs)
         self.is_found = False
-        openmp_date = self.compiler.get_define('_OPENMP', '', self.env, [], [self])
+        try:
+            openmp_date = self.compiler.get_define('_OPENMP', '', self.env, [], [self])
+        except mesonlib.EnvironmentException as e:
+            mlog.debug('OpenMP support not available in the compiler')
+            mlog.debug(e)
+            openmp_date = False
+
         if openmp_date:
             self.version = self.VERSIONS[openmp_date]
             if self.compiler.has_header('omp.h', '', self.env, dependencies=[self]):


### PR DESCRIPTION
* Currently `required : true` is implicitly assumed, making
  optional use of OpenMP not possible.

It would be nice if we could get this in for 0.46.1 as a bug fix.
@QuLogic 