### PR TITLE
Added reference to pkg-config module page in the docs.

### DIFF
--- a/docs/markdown/Pkg-config-files.md
+++ b/docs/markdown/Pkg-config-files.md
@@ -17,3 +17,5 @@ pkg.generate(libraries : libs,
 ```
 
 This causes a file called `simple.pc` to be created and placed into the install directory during the install phase.
+
+More infromation on the pkg-config module and the parameters can be found on the [pkgconfig-module](http://mesonbuild.com/Pkgconfig-module.html) page.


### PR DESCRIPTION
I had a hard time finding the pkg-config module page, as there is another page about the pkg-config file. 

I added a link from http://mesonbuild.com/Pkg-config-files.html to http://mesonbuild.com/Pkgconfig-module.html.

I hope its easier to find now.