### PR TITLE
Update minimum python version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ build system.
 
 #### Dependencies
 
- - [Python](http://python.org) (version 3.4 or newer)
+ - [Python](http://python.org) (version 3.5 or newer)
  - [Ninja](https://ninja-build.org) (version 1.5 or newer)
 
 #### Installing from source


### PR DESCRIPTION
Python 3.5 has been required since 0538009d30c0.