### PR TITLE
BuildTarget: Add ignore_project_(link_)args() kwarg

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -72,6 +72,9 @@ This function behaves in the same way as `add_global_arguments` except
 that the arguments are only used for the current project, they won't
 be used in any other subproject.
 
+Since 0.47.0 those flags can be ignored by by some targets by setting their
+`ignore_project_args` keyword argument to `true`.
+
 ### add_project_link_arguments()
 
 ``` meson
@@ -79,6 +82,9 @@ be used in any other subproject.
 ```
 
 Like `add_project_arguments` but the arguments are passed to the linker.
+
+Since 0.47.0 those flags can be ignored by by some targets by setting their
+`ignore_project_link_args` keyword argument to `true`.
 
 ### add_test_setup()
 
@@ -474,6 +480,10 @@ be passed to [shared and static libraries](#library).
   in the D programming language
 - `d_unittest`, when set to true, the D modules are compiled in debug mode
 - `d_module_versions` list of module versions set when compiling D sources
+- `ignore_project_args` Ignore arguments added via
+  [`add_project_arguments()`](#add_project_arguments)? Since 0.47.0.
+- `ignore_project_link_args` Ignore arguments added via
+  [`add_project_link_arguments()`](#add_project_link_arguments)? Since 0.47.0.
 
 The list of `sources`, `objects`, and `dependencies` is always
 flattened, which means you can freely nest and add lists while

--- a/docs/markdown/snippets/ignore_project_args.md
+++ b/docs/markdown/snippets/ignore_project_args.md
@@ -1,0 +1,6 @@
+## ignore project arguments in some targets
+
+All build targets now have `ignore_project_args` and `ignore_project_link_args`
+keyword arguments. When set to `true` those targets won't be using flags passed
+to `add_project_arguments()` or `add_project_link_arguments()`. This is useful
+when some flags are needed by most targets but with a few exceptions.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -503,7 +503,7 @@ class Backend:
         # Add buildtype args: optimization level, debugging, etc.
         commands += compiler.get_buildtype_args(self.get_option_for_target('buildtype', target))
         # Add compile args added using add_project_arguments()
-        commands += self.build.get_project_args(compiler, target.subproject)
+        commands += self.build.get_project_args(compiler, target)
         # Add compile args added using add_global_arguments()
         # These override per-project arguments
         commands += self.build.get_global_args(compiler)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1012,7 +1012,7 @@ int dummy;
 
         for dep in target.get_external_deps():
             commands.extend_direct(dep.get_link_args())
-        commands += self.build.get_project_args(compiler, target.subproject)
+        commands += self.build.get_project_args(compiler, target)
         commands += self.build.get_global_args(compiler)
 
         elem = NinjaBuildElement(self.all_outputs, outputs, 'cs_COMPILER', rel_srcs)
@@ -1026,7 +1026,7 @@ int dummy;
         args = []
         args += compiler.get_buildtype_args(self.get_option_for_target('buildtype', target))
         args += self.build.get_global_args(compiler)
-        args += self.build.get_project_args(compiler, target.subproject)
+        args += self.build.get_project_args(compiler, target)
         args += target.get_java_args()
         args += compiler.get_output_args(self.get_target_private_dir(target))
         for i in target.include_dirs:
@@ -1386,7 +1386,7 @@ int dummy;
         os.makedirs(self.get_target_private_dir_abs(target), exist_ok=True)
         compile_args = swiftc.get_compile_only_args()
         compile_args += swiftc.get_module_args(module_name)
-        compile_args += self.build.get_project_args(swiftc, target.subproject)
+        compile_args += self.build.get_project_args(swiftc, target)
         compile_args += self.build.get_global_args(swiftc)
         for i in reversed(target.get_include_dirs()):
             basedir = i.get_curdir()
@@ -1399,7 +1399,7 @@ int dummy;
                 sargs = swiftc.get_include_args(srctreedir)
                 compile_args += sargs
         link_args = swiftc.get_output_args(os.path.join(self.environment.get_build_dir(), self.get_target_filename(target)))
-        link_args += self.build.get_project_link_args(swiftc, target.subproject)
+        link_args += self.build.get_project_link_args(swiftc, target)
         link_args += self.build.get_global_link_args(swiftc)
         rundir = self.get_target_private_dir(target)
         out_module_name = self.swift_module_file_name(target)
@@ -2530,7 +2530,7 @@ rule FORTRAN_DEP_HACK%s
 
         if not isinstance(target, build.StaticLibrary):
             # Add link args added using add_project_link_arguments()
-            commands += self.build.get_project_link_args(linker, target.subproject)
+            commands += self.build.get_project_link_args(linker, target)
             # Add link args added using add_global_link_arguments()
             # These override per-project link arguments
             commands += self.build.get_global_link_args(linker)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -952,7 +952,7 @@ class Vs2010Backend(backends.Backend):
             if isinstance(target, build.SharedModule):
                 extra_link_args += compiler.get_std_shared_module_link_args()
             # Add link args added using add_project_link_arguments()
-            extra_link_args += self.build.get_project_link_args(compiler, target.subproject)
+            extra_link_args += self.build.get_project_link_args(compiler, target)
             # Add link args added using add_global_link_arguments()
             # These override per-project link arguments
             extra_link_args += self.build.get_global_link_args(compiler)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -58,6 +58,8 @@ buildtarget_kwargs = set([
     'link_whole',
     'link_args',
     'link_depends',
+    'ignore_project_args',
+    'ignore_project_link_args',
     'implicit_include_directories',
     'include_directories',
     'install',
@@ -168,20 +170,19 @@ class Build:
     def get_global_args(self, compiler):
         return self.global_args.get(compiler.get_language(), [])
 
-    def get_project_args(self, compiler, project):
-        args = self.projects_args.get(project)
-        if not args:
-            return []
-        return args.get(compiler.get_language(), [])
-
     def get_global_link_args(self, compiler):
         return self.global_link_args.get(compiler.get_language(), [])
 
-    def get_project_link_args(self, compiler, project):
-        link_args = self.projects_link_args.get(project)
-        if not link_args:
+    def get_project_args(self, compiler, target):
+        if target.ignore_project_args:
             return []
+        args = self.projects_args.get(target.subproject, {})
+        return args.get(compiler.get_language(), [])
 
+    def get_project_link_args(self, compiler, target):
+        if target.ignore_project_link_args:
+            return []
+        link_args = self.projects_link_args.get(target.subproject, {})
         return link_args.get(compiler.get_language(), [])
 
 class IncludeDirs:
@@ -807,6 +808,14 @@ This will become a hard error in a future Meson release.''')
         self.implicit_include_directories = kwargs.get('implicit_include_directories', True)
         if not isinstance(self.implicit_include_directories, bool):
             raise InvalidArguments('Implicit_include_directories must be a boolean.')
+
+        self.ignore_project_args = kwargs.get('ignore_project_args', False)
+        if not isinstance(self.ignore_project_args, bool):
+            raise InvalidArguments('ignore_project_args must be a boolean.')
+
+        self.ignore_project_link_args = kwargs.get('ignore_project_link_args', False)
+        if not isinstance(self.ignore_project_link_args, bool):
+            raise InvalidArguments('ignore_project_link_args must be a boolean.')
 
     def get_filename(self):
         return self.filename

--- a/test cases/common/198 ignore project args/main.c
+++ b/test cases/common/198 ignore project args/main.c
@@ -1,0 +1,4 @@
+int main(int argc, char *argv[])
+{
+  return 0;
+}

--- a/test cases/common/198 ignore project args/meson.build
+++ b/test cases/common/198 ignore project args/meson.build
@@ -1,0 +1,11 @@
+project('ignore project args', 'c')
+
+add_project_arguments('-broken', language : 'c')
+add_project_link_arguments('-Wl,-broken-link', language : 'c')
+
+app = executable('testapp', 'main.c',
+  ignore_project_args : true,
+  ignore_project_link_args : true,
+)
+
+test('test-ignore-project-args', app)


### PR DESCRIPTION
When all targets must use some args in a project with the exception of a
few, it's easier to use add_project_(link_)args() and flag only the few
exceptions instead of having to set link_args/c_args on all targets.