### PR TITLE
gnome: Disable usage of new --body and --header args

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -904,8 +904,10 @@ This will become a hard error in the future.''')
                 raise MesonException('Annotations must be made up of 3 strings for ELEMENT, KEY, and VALUE')
             cmd += ['--annotate'] + annotation
 
-        # https://git.gnome.org/browse/glib/commit/?id=e4d68c7b3e8b01ab1a4231bf6da21d045cb5a816
-        if mesonlib.version_compare(self._get_native_glib_version(state), '>= 2.55.2'):
+        # Added in https://gitlab.gnome.org/GNOME/glib/commit/e4d68c7b3e8b01ab1a4231bf6da21d045cb5a816 (2.55.2)
+        # --body | --header is broken: https://github.com/mesonbuild/meson/issues/3488
+        # Disabled till glib is fixed.
+        if mesonlib.version_compare(self._get_native_glib_version(state), '>= 9999'):
             targets = []
             install_header = kwargs.get('install_header', False)
             install_dir = kwargs.get('install_dir', state.environment.coredata.get_builtin_option('includedir'))
@@ -913,7 +915,7 @@ This will become a hard error in the future.''')
             output = namebase + '.c'
             custom_kwargs = {'input': xml_files,
                              'output': output,
-                             'command': cmd + ['--body', '--output', '@OUTDIR@/' + output, '@INPUT@'],
+                             'command': cmd + ['--body', '--output', '@OUTPUT@', '@INPUT@'],
                              'build_by_default': build_by_default
                              }
             targets.append(build.CustomTarget(output, state.subdir, state.subproject, custom_kwargs))
@@ -921,7 +923,7 @@ This will become a hard error in the future.''')
             output = namebase + '.h'
             custom_kwargs = {'input': xml_files,
                              'output': output,
-                             'command': cmd + ['--header', '--output', '@OUTDIR@/' + output, '@INPUT@'],
+                             'command': cmd + ['--header', '--output', '@OUTPUT@', '@INPUT@'],
                              'build_by_default': build_by_default,
                              'install': install_header,
                              'install_dir': install_dir

--- a/test cases/frameworks/7 gnome/gdbus/meson.build
+++ b/test cases/frameworks/7 gnome/gdbus/meson.build
@@ -20,9 +20,15 @@ gdbus_src = gnome.gdbus_codegen('generated-gdbus',
 )
 assert(gdbus_src.length() == 3, 'expected 3 targets')
 
+if not pretend_glib_old and glib.version().version_compare('>=2.51.3')
+  includes = []
+else
+  includes = include_directories('..')
+endif
+
 gdbus_exe = executable('gdbus-test', 'gdbusprog.c',
   gdbus_src,
-  include_directories : include_directories('..'),
+  include_directories : includes,
   dependencies : giounix)
 
 test('gdbus', gdbus_exe)


### PR DESCRIPTION
The new --body and --header args are broken because they do not allow the use of --output-directory to set the correct `#include "foo.h"` line in `foo.c`. The changes in the gdbus test case show this.

Disabled till this can be fixed in glib.

Closes https://github.com/mesonbuild/meson/issues/3488