### PR TITLE
add linker flag to handle $ORIGIN on OpenBSD

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -909,10 +909,10 @@ class Compiler:
             else:
                 paths = paths + ':' + padding
         args = []
-        if mesonlib.is_dragonflybsd():
+        if mesonlib.is_dragonflybsd() or mesonlib.is_openbsd():
             # This argument instructs the compiler to record the value of
             # ORIGIN in the .dynamic section of the elf. On Linux this is done
-            # by default, but is not on dragonfly for some reason. Without this
+            # by default, but is not on dragonfly/openbsd for some reason. Without this
             # $ORIGIN in the runtime path will be undefined and any binaries
             # linked against local libraries will fail to resolve them.
             args.append('-Wl,-z,origin')

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -308,6 +308,9 @@ def is_android():
 def is_haiku():
     return platform.system().lower() == 'haiku'
 
+def is_openbsd():
+    return platform.system().lower() == 'openbsd'
+
 def is_windows():
     platname = platform.system().lower()
     return platname == 'windows' or 'mingw' in platname


### PR DESCRIPTION
As originally discovered in [eog](https://bugzilla.gnome.org/show_bug.cgi?id=795546) we need to append an extra flag to correctly handle `$ORIGIN` on OpenBSD too.
