### PR TITLE
gnome: Use the header basename for #include in mkenums_simple

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1129,7 +1129,7 @@ This will become a hard error in the future.''')
             fhead += '%s\n' % body_prefix
         fhead += '#include "%s"\n' % hdr_filename
         for hdr in sources:
-            fhead += '#include "%s"\n' % hdr
+            fhead += '#include "%s"\n' % os.path.basename(str(hdr))
         fhead += '''
 #define C_ENUM(v) ((gint) v)
 #define C_FLAGS(v) ((guint) v)

--- a/test cases/frameworks/7 gnome/mkenums/meson.build
+++ b/test cases/frameworks/7 gnome/mkenums/meson.build
@@ -118,7 +118,7 @@ enumexe3 = executable('enumprog3', main, enums_c3, enums_h3,
 dependencies : gobj)
 test('enum test 3', enumexe3)
 
-enums4 = gnome.mkenums_simple('enums4', sources : 'meson-sample.h',
+enums4 = gnome.mkenums_simple('enums4', sources : files('meson-sample.h'),
                               function_prefix : '_')
 enumexe4 = executable('enumprog4', 'main4.c', enums4, dependencies : gobj)
 


### PR DESCRIPTION
Otherwise, when you use a File target, the value will be the full path to the header from the build root, which is not what anyone wants.