### PR TITLE
gnome: some gtk-doc and gdbus-codegen issues

### DIFF
--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -21,6 +21,7 @@ project files and don't need this info."""
 
 import json
 from . import build, mtest, coredata as cdata
+from . import mesonlib
 from .backend import ninjabackend
 import argparse
 import sys, os
@@ -118,8 +119,12 @@ def list_target_files(target_name, coredata, builddata):
     except KeyError:
         print("Unknown target %s." % target_name)
         sys.exit(1)
-    sources = [os.path.join(i.subdir, i.fname) for i in sources]
-    print(json.dumps(sources))
+    out = []
+    for i in sources:
+        if isinstance(i, mesonlib.File):
+            i = os.path.join(i.subdir, i.fname)
+        out.append(i)
+    print(json.dumps(out))
 
 def list_buildoptions(coredata, builddata):
     optlist = []

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -793,11 +793,13 @@ This will become a hard error in the future.''')
                 s = s.held_object
             if isinstance(s, (build.CustomTarget, build.CustomTargetIndex)):
                 depends.append(s)
-                content_files.append(os.path.join(state.environment.get_build_dir(),
-                                                  state.backend.get_target_dir(s),
-                                                  s.get_outputs()[0]))
+                for o in s.get_outputs():
+                    content_files.append(os.path.join(state.environment.get_build_dir(),
+                                                      state.backend.get_target_dir(s),
+                                                      o))
             elif isinstance(s, mesonlib.File):
-                content_files.append(os.path.join(state.environment.get_build_dir(), s.subdir, s.fname))
+                content_files.append(s.absolute_path(state.environment.get_source_dir(),
+                                                     state.environment.get_build_dir()))
             elif isinstance(s, build.GeneratedList):
                 depends.append(s)
                 for gen_src in s.get_outputs():

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -938,9 +938,13 @@ This will become a hard error in the future.''')
 
                 docbook_cmd = cmd + ['--output-directory', '@OUTDIR@', '--generate-docbook', docbook, '@INPUT@']
 
+                # The docbook output is always ${docbook}-${name_of_xml_file}
                 output = namebase + '-docbook'
+                outputs = []
+                for f in xml_files:
+                    outputs.append('{}-{}'.format(docbook, f))
                 custom_kwargs = {'input': xml_files,
-                                 'output': output,
+                                 'output': outputs,
                                  'command': docbook_cmd,
                                  'build_by_default': build_by_default
                                  }

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -881,7 +881,7 @@ This will become a hard error in the future.''')
         if len(args) not in (1, 2):
             raise MesonException('Gdbus_codegen takes at most two arguments, name and xml file.')
         namebase = args[0]
-        xml_files = [args[1:]]
+        xml_files = args[1:]
         target_name = namebase + '-gdbus'
         cmd = [self.interpreter.find_program_impl('gdbus-codegen')]
         if 'interface_prefix' in kwargs:

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -93,9 +93,12 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
 
     # Copy files to build directory
     for f in content_files:
-        f_abs = os.path.join(doc_src, f)
-        shutil.copyfile(f_abs, os.path.join(
-            abs_out, os.path.basename(f_abs)))
+        # FIXME: Use mesonlib.File objects so we don't need to do this
+        if not os.path.isabs(f):
+            f = os.path.join(doc_src, f)
+        elif os.path.commonpath([f, build_root]) == build_root:
+            continue
+        shutil.copyfile(f, os.path.join(abs_out, os.path.basename(f)))
 
     shutil.rmtree(htmldir, ignore_errors=True)
     try:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -688,8 +688,10 @@ class BasePlatformTests(unittest.TestCase):
         cmds = [l[len(prefix):].split() for l in log if l.startswith(prefix)]
         return cmds
 
-    def introspect(self, arg):
-        out = subprocess.check_output(self.mintro_command + [arg, self.builddir],
+    def introspect(self, args):
+        if isinstance(args, str):
+            args = [args]
+        out = subprocess.check_output(self.mintro_command + args + [self.builddir],
                                       universal_newlines=True)
         return json.loads(out)
 
@@ -2938,6 +2940,18 @@ class LinuxlikeTests(BasePlatformTests):
                 gobject_found = True
         self.assertTrue(glib_found)
         self.assertTrue(gobject_found)
+        if subprocess.call(['pkg-config', '--exists', 'glib-2.0 >= 2.56.2']) != 0:
+            raise unittest.SkipTest('glib >= 2.56.2 needed for the rest')
+        targets = self.introspect('--targets')
+        docbook_target = None
+        for t in targets:
+            if t['name'] == 'generated-gdbus-docbook':
+                docbook_target = t
+                break
+        self.assertIsInstance(docbook_target, dict)
+        ifile = self.introspect(['--target-files', 'generated-gdbus-docbook@cus'])[0]
+        self.assertEqual(t['filename'], 'gdbus/generated-gdbus-doc-' + ifile)
+
 
     def test_build_rpath(self):
         if is_cygwin():

--- a/test cases/frameworks/10 gtk-doc/doc/meson.build
+++ b/test cases/frameworks/10 gtk-doc/doc/meson.build
@@ -1,10 +1,11 @@
 cdata = configuration_data()
 cdata.set('VERSION', '1.0')
-configure_file(input : 'version.xml.in',
-  output : 'version.xml',
-  configuration : cdata)
+version_xml = configure_file(input : 'version.xml.in',
+                             output : 'version.xml',
+                             configuration : cdata)
 
 gnome.gtkdoc('foobar',
+  version_xml,
   src_dir : inc,
   main_sgml : 'foobar-docs.sgml',
   content_files : docbook,

--- a/test cases/frameworks/10 gtk-doc/doc/meson.build
+++ b/test cases/frameworks/10 gtk-doc/doc/meson.build
@@ -5,8 +5,7 @@ version_xml = configure_file(input : 'version.xml.in',
                              configuration : cdata)
 
 gnome.gtkdoc('foobar',
-  version_xml,
   src_dir : inc,
   main_sgml : 'foobar-docs.sgml',
-  content_files : docbook,
+  content_files : [docbook, version_xml],
   install : true)


### PR DESCRIPTION
commit 14a75d3a027c3337c35dae04831d686e715113c6:

gnome.gtkdoc: Allow passing file objects as xml_files
If we pass a source files() object, we will look for it in the build
directory, which is wrong. If we pass a build files() object (from
configure_file()), we will find it in the build directory, and then
try to copy it on top of itself in gtkdochelper.py getting a
SameFileError.

Add a test for it, and also properly iterate custom target outputs
when adding to content files.


commit ec7c87d2a487f727ec33c21edfd550e62e94ee6a:

gnome.gdbus_codegen: Fix output file list for docbook custom targets
We were setting it to a totally wrong name, while the output of gtkdoc
is very predictable.

Also add a test for it, and fix a bug in meson introspect found while
adding the test.

The test will only work with glib 2.56.2, so it will be skipped on the
CI. I ran it manually to verify that it works.

