### PR TITLE
args flattening: preserve configuration_data.set behaviour

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -211,6 +211,12 @@ class ConfigurationDataHolder(MutableInterpreterObject, ObjectHolder):
         self.used = True
 
     def validate_args(self, args, kwargs):
+        if len(args) == 1 and isinstance(args[0], list) and len(args[0]) == 2:
+            mlog.log(mlog.red('DEPRECATION:'),
+                     '''Passing a list as the single argument to configuration_data.set is deprecated.
+This will become a hard error in the future''')
+            args = args[0]
+
         if len(args) != 2:
             raise InterpreterException("Configuration set requires 2 arguments.")
         if self.used:

--- a/test cases/common/198 args flattening/meson.build
+++ b/test cases/common/198 args flattening/meson.build
@@ -21,3 +21,9 @@ assert(arr == ['bar', 'baz'], 'configuration_data.get with array fallback is bro
 arr = meson.get_cross_property('does-not-exist', ['bar', 'baz'])
 
 assert(arr == ['bar', 'baz'], 'meson.get_cross_property with array fallback is broken')
+
+# Test deprecated behaviour
+
+conf.set(['foo', 'bar'])
+
+message(conf.get('foo'))


### PR DESCRIPTION
It seems that some projects relied on the previously buggy
behaviour of accepting a 2-element list as the single argument
to configuration_data.set().

Special-case this behaviour, and emit a deprecation message.