### PR TITLE
Add include() function

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -674,6 +674,23 @@ hypothetical `testmod` module.
     tmod.do_something()
 ```
 
+### include()
+
+``` meson
+    void include(file, ...)
+```
+
+Executes the `file`. Once that is done, it returns and execution continues on the
+line following this `include()` command. Variables defined in that
+`file` are then available for use in later parts of the
+current build file and in all subsequent build files executed with `subdir()`.
+
+This function has one keyword argument.
+
+ - `if_found` takes one or several dependency objects and will only
+   execute the file if they all return `true` when queried with
+   `.found()`
+
 ### include_directories()
 
 ``` meson
@@ -1165,7 +1182,7 @@ the invocation. All steps executed up to this point are valid and will
 be executed by meson. This means that all targets defined before the call
 of `subdir_done` will be build.
 
-If the current script was called by `subdir` the execution returns to the
+If the current script was called by `subdir` or `include` the execution returns to the
 calling directory and continues as if the script had reached the end.
 If the current script is the top level script meson configures the project
 as defined up to this point.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1666,6 +1666,7 @@ permitted_kwargs = {'add_global_arguments': {'language'},
                     'executable': build.known_exe_kwargs,
                     'find_program': {'required', 'native'},
                     'generator': {'arguments', 'output', 'depfile', 'capture', 'preserve_path_from'},
+                    'include': {'if_found'},
                     'include_directories': {'is_system'},
                     'install_data': {'install_dir', 'install_mode', 'rename', 'sources'},
                     'install_headers': {'install_dir', 'subdir'},
@@ -1711,6 +1712,7 @@ class Interpreter(InterpreterBase):
         self.builtin.update({'meson': MesonMain(build, self)})
         self.generators = []
         self.visited_subdirs = {}
+        self.included_files = set()
         self.project_args_frozen = False
         self.global_args_frozen = False  # implies self.project_args_frozen
         self.subprojects = {}
@@ -1761,6 +1763,7 @@ class Interpreter(InterpreterBase):
                            'files': self.func_files,
                            'find_library': self.func_find_library,
                            'find_program': self.func_find_program,
+                           'include': self.func_include,
                            'include_directories': self.func_include_directories,
                            'import': self.func_import,
                            'install_data': self.func_install_data,
@@ -3225,6 +3228,42 @@ root and issuing %s.
             cfile = mesonlib.File.from_built_file(ofile_path, ofile_fname)
             self.build.data.append(build.Data([cfile], idir))
         return mesonlib.File.from_built_file(self.subdir, output)
+
+    @permittedKwargs(permitted_kwargs['include'])
+    def func_include(self, node, args, kwargs):
+        self.validate_arguments(args, 1, [str])
+        mesonlib.check_direntry_issues(args)
+        for i in mesonlib.extract_as_list(kwargs, 'if_found'):
+            if not hasattr(i, 'found_method'):
+                raise InterpreterException('Object used in if_found does not have a found method.')
+            if not i.found_method([], {}):
+                return
+        if os.path.isabs(args[0]):
+            absname = os.path.abspath(args[0])
+        else:
+            absname = os.path.abspath(os.path.join(self.environment.get_source_dir(), args[0]))
+        if absname in self.included_files:
+            raise InvalidArguments('Tried to include file "%s", which has already been included.'
+                                   % absname)
+        self.included_files.add(absname)
+        if not absname in self.build_def_files:
+            self.build_def_files.append(absname)
+        if not os.path.isfile(absname):
+            raise InterpreterException('Non-existent build file {!r}'.format(absname))
+        with open(absname, encoding='utf8') as f:
+            code = f.read()
+        assert(isinstance(code, str))
+        try:
+            codeblock = mparser.Parser(code, self.subdir).parse()
+        except mesonlib.MesonException as me:
+            me.file = absname
+            raise me
+        try:
+            self.evaluate_codeblock(codeblock)
+        except mesonlib.MesonException as me:
+            me.file = absname
+            raise me
+        self.included_files.clear()
 
     @permittedKwargs(permitted_kwargs['include_directories'])
     @stringArgs

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3242,6 +3242,7 @@ root and issuing %s.
             absname = os.path.abspath(args[0])
         else:
             absname = os.path.abspath(os.path.join(self.environment.get_source_dir(), args[0]))
+        prev_current_file = self.current_file
         if absname in self.included_files:
             raise InvalidArguments('Tried to include file "%s", which has already been included.'
                                    % absname)
@@ -3256,14 +3257,16 @@ root and issuing %s.
         try:
             codeblock = mparser.Parser(code, self.subdir).parse()
         except mesonlib.MesonException as me:
-            me.file = absname
+            me.file = self.current_file
             raise me
+        self.current_file = absname
         try:
             self.evaluate_codeblock(codeblock)
         except mesonlib.MesonException as me:
-            me.file = absname
+            me.file = self.current_file
             raise me
         self.included_files.clear()
+        self.current_file = prev_current_file
 
     @permittedKwargs(permitted_kwargs['include_directories'])
     @stringArgs

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -181,12 +181,14 @@ class InterpreterBase:
         self.funcs = {}
         self.builtin = {}
         self.subdir = subdir
+        self.current_file = ''
         self.variables = {}
         self.argument_depth = 0
         self.current_lineno = -1
 
     def load_root_meson_file(self):
         mesonfile = os.path.join(self.source_root, self.subdir, environment.build_filename)
+        self.current_file = mesonfile
         if not os.path.isfile(mesonfile):
             raise InvalidArguments('Missing Meson file in %s' % mesonfile)
         with open(mesonfile, encoding='utf8') as mf:

--- a/test cases/common/199 include/included_file
+++ b/test cases/common/199 include/included_file
@@ -1,0 +1,2 @@
+executable('test_include', 'main.c')
+

--- a/test cases/common/199 include/incr_variable
+++ b/test cases/common/199 include/incr_variable
@@ -1,0 +1,1 @@
+variable += 1

--- a/test cases/common/199 include/main.c
+++ b/test cases/common/199 include/main.c
@@ -1,0 +1,5 @@
+int main(int argc, char **argv)
+{
+    return 0;
+}
+

--- a/test cases/common/199 include/meson.build
+++ b/test cases/common/199 include/meson.build
@@ -1,0 +1,7 @@
+# Should read instructions given in included_file
+
+project('example include', 'c')
+
+# An executable is declared in included_file
+include('included_file')
+

--- a/test cases/common/199 include/meson.build
+++ b/test cases/common/199 include/meson.build
@@ -2,6 +2,17 @@
 
 project('example include', 'c')
 
+variable = 1
+
+assert(variable == 1, 'variable doesn\'t have correct value')
+
+# Check whether it's possible to include the same file several times
+include('incr_variable')
+include('incr_variable')
+include('incr_variable')
+
+assert(variable == 4, 'variable doesn\'t have correct value')
+
 # An executable is declared in included_file
 include('included_file')
 

--- a/test cases/common/200 include if_found/included_file
+++ b/test cases/common/200 include if_found/included_file
@@ -1,0 +1,1 @@
+variable = 5

--- a/test cases/common/200 include if_found/meson.build
+++ b/test cases/common/200 include if_found/meson.build
@@ -1,0 +1,8 @@
+project('subdir if found', 'c')
+
+not_found_dep = dependency('nonexisting', required : false)
+
+variable = 3
+
+include('included_file', if_found : not_found_dep)
+assert(variable == 3, 'included_file was unexpectedly included.')

--- a/test cases/failing/75 missing included file/meson.build
+++ b/test cases/failing/75 missing included file/meson.build
@@ -1,0 +1,6 @@
+# Should fail because included_file is missing
+
+project('missing included file', 'c')
+
+include('included_file')
+

--- a/test cases/failing/76 included file detected cyclic dependency/included_file1
+++ b/test cases/failing/76 included file detected cyclic dependency/included_file1
@@ -1,0 +1,1 @@
+include('included_file2')

--- a/test cases/failing/76 included file detected cyclic dependency/included_file2
+++ b/test cases/failing/76 included file detected cyclic dependency/included_file2
@@ -1,0 +1,1 @@
+include('included_file1')

--- a/test cases/failing/76 included file detected cyclic dependency/meson.build
+++ b/test cases/failing/76 included file detected cyclic dependency/meson.build
@@ -1,0 +1,7 @@
+# Should fail because included_file1 includes included_file2 and
+# included_file2 includes included_file1
+
+project('included file detected cyclic dependency', 'c')
+
+include('included_file2')
+


### PR DESCRIPTION
Hello, here's a proposal to add an include() function in order to be able to parse other build files.

included file must be valid meson file.

It's like subdir() except that:
* It is not limited to relative path
* included file can have any name (not mandatory to be meson.build)

