### PR TITLE
vala: Fix shared_module linking with export_dynamic executable

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1058,6 +1058,8 @@ int dummy;
         """
         result = OrderedSet()
         for dep in itertools.chain(target.link_targets, target.link_whole_targets):
+            if not dep.is_linkable_target():
+                continue
             for i in dep.sources:
                 if hasattr(i, 'fname'):
                     i = i.fname
@@ -1180,7 +1182,7 @@ int dummy;
         # found inside the build tree (generated sources).
         args += ['--directory', c_out_dir]
         args += ['--basedir', srcbasedir]
-        if not isinstance(target, build.Executable):
+        if target.is_linkable_target():
             # Library name
             args += ['--library', target.name]
             # Outputted header

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -698,7 +698,7 @@ just like those detected with the dependency() function.''')
         for key, value in compiler_args.items():
             self.add_compiler_args(key, value)
 
-        if not isinstance(self, Executable):
+        if not isinstance(self, Executable) or 'export_dynamic' in kwargs:
             self.vala_header = kwargs.get('vala_header', self.name + '.h')
             self.vala_vapi = kwargs.get('vala_vapi', self.name + '.vapi')
             self.vala_gir = kwargs.get('vala_gir', None)

--- a/test cases/vala/24 export dynamic shared module/app.vala
+++ b/test cases/vala/24 export dynamic shared module/app.vala
@@ -1,0 +1,21 @@
+const string MODULE_LIB = "libapp_module.so";
+
+delegate int ModuleFunc ();
+
+public int app_func () {
+  return 41;
+}
+
+int main () {
+  Module module;
+  void *func;
+  unowned ModuleFunc mfunc;
+
+  module = Module.open (MODULE_LIB, ModuleFlags.BIND_LAZY);
+  module.symbol ("module_func", out func);
+  mfunc = (ModuleFunc) func;
+
+  print ("%d\n", mfunc ());
+
+  return 0;
+}

--- a/test cases/vala/24 export dynamic shared module/meson.build
+++ b/test cases/vala/24 export dynamic shared module/meson.build
@@ -1,0 +1,20 @@
+project ('test', ['c', 'vala'], version: '0.1')
+
+deps = [
+  dependency ('glib-2.0'),
+  dependency ('gmodule-2.0'),
+]
+
+app = executable (
+  'app',
+  ['app.vala'],
+  dependencies: deps,
+  export_dynamic: true
+)
+
+shared_module (
+  'app_module',
+  ['module.vala'],
+  link_with: app,
+  dependencies : deps,
+)

--- a/test cases/vala/24 export dynamic shared module/module.vala
+++ b/test cases/vala/24 export dynamic shared module/module.vala
@@ -1,0 +1,3 @@
+public int module_func () {
+  return app_func() + 1;
+}


### PR DESCRIPTION
Need to generate a vapi and a header, and then use that in the shared module. Needed for GNOME games.

Closes https://github.com/mesonbuild/meson/issues/3538