### PR TITLE
Add a depend_files: keyword to windows.compile_resources() 

### DIFF
--- a/docs/markdown/Windows-module.md
+++ b/docs/markdown/Windows-module.md
@@ -16,5 +16,6 @@ has the following keyword argument.
 - `depend_files` lists resource files that the resource script depends on
   (e.g. bitmap, cursor, font, html, icon, message table, binary data or manifest
   files referenced by the resource script) (*since 0.47.0*)
-- `include_directories` which does the same thing as it does on target
-  declarations: specifies header search directories
+- `include_directories` lists directories to be both searched by the resource
+  compiler for referenced resource files, and added to the preprocessor include
+  search path.

--- a/docs/markdown/Windows-module.md
+++ b/docs/markdown/Windows-module.md
@@ -12,6 +12,9 @@ arguments. Returns an opaque object that you put in the list of
 sources for the target you want to have the resources in. This method
 has the following keyword argument.
 
- - `args` lists extra arguments to pass to the resource compiler
+- `args` lists extra arguments to pass to the resource compiler
+- `depend_files` lists resource files that the resource script depends on
+  (e.g. bitmap, cursor, font, html, icon, message table, binary data or manifest
+  files referenced by the resource script) (*since 0.47.0*)
 - `include_directories` which does the same thing as it does on target
   declarations: specifies header search directories

--- a/docs/markdown/snippets/windows-resources-dependencies.md
+++ b/docs/markdown/snippets/windows-resources-dependencies.md
@@ -1,0 +1,4 @@
+## Windows resource files dependencies
+
+The `compile_resources()` function of the `windows` module now takes
+the `depend_files:` keyword.

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -30,11 +30,12 @@ class WindowsModule(ExtensionModule):
                 return compilers[l]
         raise MesonException('Resource compilation requires a C or C++ compiler.')
 
-    @permittedKwargs({'args', 'include_directories'})
+    @permittedKwargs({'args', 'include_directories', 'depend_files'})
     def compile_resources(self, state, args, kwargs):
         comp = self.detect_compiler(state.compilers)
 
         extra_args = mesonlib.stringlistify(kwargs.get('args', []))
+        wrc_deps = extract_as_list(kwargs, 'depend_files', pop = True)
         inc_dirs = extract_as_list(kwargs, 'include_directories', pop = True)
         for incd in inc_dirs:
             if not isinstance(incd.held_object, (str, build.IncludeDirs)):
@@ -83,6 +84,7 @@ class WindowsModule(ExtensionModule):
                 'output': '@BASENAME@.' + suffix,
                 'input': [src],
                 'command': [rescomp] + res_args,
+                'depend_files': wrc_deps,
             }
 
             if isinstance(src, (str, mesonlib.File)):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2337,6 +2337,7 @@ class WindowsTests(BasePlatformTests):
         super().setUp()
         self.platform_test_dir = os.path.join(self.src_root, 'test cases/windows')
 
+    @unittest.skipIf(is_cygwin(), 'Test only applicable to Windows')
     def test_find_program(self):
         '''
         Test that Windows-specific edge-cases in find_program are functioning
@@ -3314,7 +3315,7 @@ if __name__ == '__main__':
         cases += ['LinuxlikeTests']
         if should_run_linux_cross_tests():
             cases += ['LinuxArmCrossCompileTests']
-    elif is_windows():
+    if is_windows() or is_cygwin():
         cases += ['WindowsTests']
 
     unittest.main(defaultTest=cases, buffer=True)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -735,9 +735,7 @@ class BasePlatformTests(unittest.TestCase):
             self.assertIn('Linking target {}'.format(target), ret)
         elif self.backend is Backend.vs:
             # Ensure that this target was rebuilt
-            clre = re.compile('ClCompile:\n [^\n]*cl[^\n]*' + target, flags=re.IGNORECASE)
             linkre = re.compile('Link:\n [^\n]*link[^\n]*' + target, flags=re.IGNORECASE)
-            self.assertRegex(ret, clre)
             self.assertRegex(ret, linkre)
         elif self.backend is Backend.xcode:
             raise unittest.SkipTest('Please help us fix this test on the xcode backend')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2389,6 +2389,16 @@ class WindowsTests(BasePlatformTests):
         for l in cc.ignore_libs:
             self.assertEqual(cc.find_library(l, env, []), [])
 
+    def test_rc_depends_files(self):
+        testdir = os.path.join(self.platform_test_dir, '5 resources')
+        self.init(testdir)
+        self.build()
+        # Immediately rebuilding should not do anything
+        self.assertBuildIsNoop()
+        # Changing mtime of sample.ico should rebuild everything
+        self.utime(os.path.join(testdir, 'res', 'sample.ico'))
+        self.assertRebuiltTarget('prog')
+
 
 class LinuxlikeTests(BasePlatformTests):
     '''

--- a/test cases/windows/5 resources/res/meson.build
+++ b/test cases/windows/5 resources/res/meson.build
@@ -1,4 +1,5 @@
 win = import('windows')
 
 res = win.compile_resources('myres.rc',
+  depend_files: 'sample.ico',
   include_directories : inc)


### PR DESCRIPTION
This is the change suggested in #2815, with tests and documentation added.

Fixes #2789 (duplicate #2830)
