### PR TITLE
Add install_dir to i18n.gettext

### DIFF
--- a/docs/markdown/i18n-module.md
+++ b/docs/markdown/i18n-module.md
@@ -29,6 +29,7 @@ argument which is the name of the gettext module.
   [source](https://github.com/mesonbuild/meson/blob/master/mesonbuild/modules/i18n.py)
   for for their value
 * `install`: (*Added 0.43.0*) if false, do not install the built translations.
+* `install_dir`: (*Added 0.50.0*) override default install location, default is `localedir`
 
 This function also defines targets for maintainers to use:
 **Note**: These output to the source directory

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -102,7 +102,8 @@ class I18nModule(ExtensionModule):
         return ModuleReturnValue(ct, [ct])
 
     @FeatureNewKwargs('i18n.gettext', '0.37.0', ['preset'])
-    @permittedKwargs({'po_dir', 'data_dirs', 'type', 'languages', 'args', 'preset', 'install'})
+    @FeatureNewKwargs('i18n.gettext', '0.50.0', ['install_dir'])
+    @permittedKwargs({'po_dir', 'data_dirs', 'type', 'languages', 'args', 'preset', 'install', 'install_dir'})
     def gettext(self, state, args, kwargs):
         if len(args) != 1:
             raise coredata.MesonException('Gettext requires one positional argument (package name).')
@@ -151,10 +152,11 @@ class I18nModule(ExtensionModule):
 
         install = kwargs.get('install', True)
         if install:
+            install_dir = kwargs.get('install_dir', state.environment.coredata.get_builtin_option('localedir'))
             script = state.environment.get_build_command()
             args = ['--internal', 'gettext', 'install',
                     '--subdir=' + state.subdir,
-                    '--localedir=' + state.environment.coredata.get_builtin_option('localedir'),
+                    '--localedir=' + install_dir,
                     pkg_arg]
             if lang_arg:
                 args.append(lang_arg)


### PR DESCRIPTION
Feature requested in #2083, useful (for me atleast) for building gnome-shell extensions.

Note: I don't know what version I should specify in docs, currently it's `0.46.1`, tell me if this wrong.