### PR TITLE
CCompiler: Add missing return statements in some compiled tests

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -288,6 +288,7 @@ class CCompiler(Compiler):
             #ifndef {symbol}
                 {symbol};
             #endif
+            return 0;
         }}'''
         return self.compiles(t.format(**fargs), env, extra_args, dependencies)
 
@@ -452,6 +453,7 @@ class CCompiler(Compiler):
         {prefix}
         int main(int argc, char **argv) {{
             {type} something;
+            return 0;
         }}'''
         if not self.compiles(t.format(**fargs), env, extra_args, dependencies):
             return -1
@@ -484,6 +486,7 @@ class CCompiler(Compiler):
         {prefix}
         int main(int argc, char **argv) {{
             {type} something;
+            return 0;
         }}'''
         if not self.compiles(t.format(**fargs), env, extra_args, dependencies):
             return -1
@@ -554,6 +557,7 @@ class CCompiler(Compiler):
         #include <stdio.h>
         int main(int argc, char *argv[]) {{
             printf ("{fmt}", {cast} {f}());
+            return 0;
         }}'''.format(**fargs)
         res = self.run(code, env, extra_args, dependencies)
         if not res.compiled:
@@ -704,6 +708,7 @@ class CCompiler(Compiler):
                 #error "No definition for __builtin_{func} found in the prefix"
             #endif
         #endif
+            return 0;
         }}'''
         return self.links(t.format(**fargs), env, extra_args, dependencies)
 


### PR DESCRIPTION
Several compiled tests were defining an int main(), but were not
returning a value from it. When compiling with -Werror, that would cause
the tests to spuriously fail.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

---

I haven’t tested several of these, due to not using them in my `meson.build`. The way to test is to simply set `CFLAGS=-Werror` in the environment before calling `meson`.