### PR TITLE
Make language kwarg optional for add_*_link_arguments()

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -169,20 +169,21 @@ class Build:
         return self.global_args.get(compiler.get_language(), [])
 
     def get_project_args(self, compiler, project):
-        args = self.projects_args.get(project)
-        if not args:
-            return []
+        args = self.projects_args.get(project, {})
         return args.get(compiler.get_language(), [])
 
     def get_global_link_args(self, compiler):
-        return self.global_link_args.get(compiler.get_language(), [])
+        # Args with empty string key apply to all languages
+        args = self.global_link_args.get('', [])
+        args += self.global_link_args.get(compiler.get_language(), [])
+        return args
 
     def get_project_link_args(self, compiler, project):
-        link_args = self.projects_link_args.get(project)
-        if not link_args:
-            return []
-
-        return link_args.get(compiler.get_language(), [])
+        link_args = self.projects_link_args.get(project, {})
+        # Args with empty string key apply to all languages
+        args = link_args.get('', [])
+        args += link_args.get(compiler.get_language(), [])
+        return args
 
 class IncludeDirs:
     def __init__(self, curdir, dirs, is_system, extra_build_dirs=None):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -563,7 +563,7 @@ class BasePlatformTests(unittest.TestCase):
         if p.returncode != 0:
             if 'MESON_SKIP_TEST' in p.stdout:
                 raise unittest.SkipTest('Project requested skipping.')
-            raise subprocess.CalledProcessError(p.returncode, command)
+            raise subprocess.CalledProcessError(p.returncode, command, output=p.stdout)
         return p.stdout
 
     def init(self, srcdir, extra_args=None, default_args=True, inprocess=False):
@@ -2327,6 +2327,19 @@ class FailureTests(BasePlatformTests):
             self.init(tdir, inprocess=False)
         self.assertEqual(cm.exception.returncode, 2)
         self.wipe()
+
+    def test_add_link_arguments(self):
+        '''
+        Test flags added with add_project_link_arguments() are passed to the
+        linker. The test adds broken flags and check that it fails to link.
+        '''
+        testdir = os.path.join(self.unit_test_dir, '33 add link arguments')
+        self.init(testdir)
+        with self.assertRaises(subprocess.CalledProcessError) as cm:
+            self.build()
+        self.assertIn('broken1', cm.exception.output)
+        self.assertIn('broken2', cm.exception.output)
+        self.assertNotIn('broken3', cm.exception.output)
 
 
 class WindowsTests(BasePlatformTests):

--- a/test cases/unit/33 add link arguments/meson.build
+++ b/test cases/unit/33 add link arguments/meson.build
@@ -1,0 +1,7 @@
+project('add link arguments', 'c')
+
+add_project_link_arguments('-Wl,broken1')
+add_project_link_arguments('-Wl,broken2', language : 'c')
+add_project_link_arguments('-Wl,broken3', language : 'cpp')
+
+executable('testapp', 'test.c')

--- a/test cases/unit/33 add link arguments/test.c
+++ b/test cases/unit/33 add link arguments/test.c
@@ -1,0 +1,4 @@
+int main (int argc, char *argv[])
+{
+  return 0;
+}


### PR DESCRIPTION
When no language is given, it applies to all languages. This helps
solving the ambiguity when linking sources from multiple languages.

Closes #3585.