### PR TITLE
Made install a top level Meson command.

### DIFF
--- a/data/com.mesonbuild.install.policy
+++ b/data/com.mesonbuild.install.policy
@@ -17,8 +17,7 @@
     </defaults>
     <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/python3</annotate>
     <annotate key="org.freedesktop.policykit.exec.argv1">/usr/bin/meson</annotate>
-    <annotate key="org.freedesktop.policykit.exec.argv2">--internal</annotate>
-    <annotate key="org.freedesktop.policykit.exec.argv3">install</annotate>
+    <annotate key="org.freedesktop.policykit.exec.argv2">install</annotate>
   </action>
 
 </policyconfig>

--- a/docs/markdown/Installing.md
+++ b/docs/markdown/Installing.md
@@ -4,7 +4,8 @@ short-description: Installing targets
 
 # Installing
 
-By default Meson will not install anything. Build targets can be installed by tagging them as installable in the definition.
+By default Meson will not install anything. Build targets can be
+installed by tagging them as installable in the definition.
 
 ```meson
 project('install', 'c')
@@ -14,8 +15,8 @@ shared_library('mylib', 'libfile.c', install : true)
 There is usually no need to specify install paths or the like. Meson
 will automatically install it to the standards-conforming location. In
 this particular case the executable is installed to the `bin`
-subdirectory of the install prefix. However if you wish to override the
-install dir, you can do that with the `install_dir` argument.
+subdirectory of the install prefix. However if you wish to override
+the install dir, you can do that with the `install_dir` argument.
 
 ```meson
 executable('prog', 'prog.c', install : true, install_dir : 'my/special/dir')
@@ -42,7 +43,9 @@ install_data(['file1.txt', 'file2.txt'],
              install_dir : 'share/myapp')
 ```
 
-Sometimes you want to copy an entire subtree directly. For this use case there is the `install_subdir` command, which can be used like this.
+Sometimes you want to copy an entire subtree directly. For this use
+case there is the `install_subdir` command, which can be used like
+this.
 
 ```meson
 install_subdir('mydir', install_dir : 'include') # mydir subtree -> include/mydir
@@ -59,7 +62,10 @@ install_data(sources : 'foo.dat', install_dir : '/etc') # -> /etc/foo.dat
 
 ## Custom install behavior
 
-Sometimes you need to do more than just install basic targets. Meson makes this easy by allowing you to specify a custom script to execute at install time. As an example, here is a script that generates an empty file in a custom directory.
+Sometimes you need to do more than just install basic targets. Meson
+makes this easy by allowing you to specify a custom script to execute
+at install time. As an example, here is a script that generates an
+empty file in a custom directory.
 
 ```bash
 #!/bin/sh
@@ -68,7 +74,10 @@ mkdir "${DESTDIR}/${MESON_INSTALL_PREFIX}/mydir"
 touch "${DESTDIR}/${MESON_INSTALL_PREFIX}/mydir/file.dat"
 ```
 
-As you can see, Meson sets up some environment variables to help you write your script (`DESTDIR` is not set by Meson, it is inherited from the outside environment). In addition to the install prefix, Meson also sets the variables `MESON_SOURCE_ROOT` and `MESON_BUILD_ROOT`.
+As you can see, Meson sets up some environment variables to help you
+write your script (`DESTDIR` is not set by Meson, it is inherited from
+the outside environment). In addition to the install prefix, Meson
+also sets the variables `MESON_SOURCE_ROOT` and `MESON_BUILD_ROOT`.
 
 Telling Meson to run this script at install time is a one-liner.
 
@@ -76,12 +85,32 @@ Telling Meson to run this script at install time is a one-liner.
 meson.add_install_script('myscript.sh')
 ```
 
-The argument is the name of the script file relative to the current subdirectory.
+The argument is the name of the script file relative to the current
+subdirectory.
 
 ## DESTDIR support
 
-Sometimes you need to install to a different directory than the install prefix. This is most common when building rpm or deb packages. This is done with the `DESTDIR` environment variable and it is used just like with other build systems:
+Sometimes you need to install to a different directory than the
+install prefix. This is most common when building rpm or deb
+packages. This is done with the `DESTDIR` environment variable and it
+is used just like with other build systems:
 
 ```console
 $ DESTDIR=/path/to/staging/area ninja install
+```
+
+## Custom install behaviour
+
+The default install target (executed via, e.g., `ninja install`) does
+installing with reasonable default options. More control over the
+install behaviour can be achieved with the `meson install` command,
+that has been available since 0.47.0.
+
+For example, if you wish to install the current setup without
+rebuilding the code (which the default install target always does) and
+only installing those files that have changed, you would run this
+command in the build tree:
+
+```console
+$ meson install --no-rebuild --only-changed
 ```

--- a/docs/markdown/snippets/install_command.md
+++ b/docs/markdown/snippets/install_command.md
@@ -1,0 +1,12 @@
+## Made install a top level Meson command
+
+You can now run `meson install` in your build directory and it will do
+the install. It has several command line options you can toggle the
+behaviour that is not in the default `ninja install` invocation. This
+is similar to how `meson test` already works.
+
+For example, to install only the files that have changed, you can do:
+
+```console
+meson install --only-changed
+```

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -683,7 +683,7 @@ int dummy;
         elem = NinjaBuildElement(self.all_outputs, 'meson-install', 'CUSTOM_COMMAND', 'PHONY')
         elem.add_dep('all')
         elem.add_item('DESC', 'Installing files.')
-        elem.add_item('COMMAND', self.environment.get_build_command() + ['--internal', 'install', install_data_file])
+        elem.add_item('COMMAND', self.environment.get_build_command() + ['install', '--no-rebuild'])
         elem.add_item('pool', 'console')
         self.generate_depmf_install(d)
         self.generate_target_install(d)

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -23,7 +23,7 @@ from . import build
 from . import mlog, coredata
 from .mesonlib import MesonException
 from .environment import detect_msys2_arch
-from .wrap import WrapMode, wraptool
+from .wrap import WrapMode
 
 default_warning = '1'
 

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -20,7 +20,6 @@ import cProfile as profile
 
 from . import environment, interpreter, mesonlib
 from . import build
-from . import mconf, mintro, mtest, rewriter, minit
 from . import mlog, coredata
 from .mesonlib import MesonException
 from .environment import detect_msys2_arch
@@ -178,9 +177,6 @@ def run_script_command(args):
     elif cmdname == 'cleantrees':
         import mesonbuild.scripts.cleantrees as abc
         cmdfunc = abc.run
-    elif cmdname == 'install':
-        import mesonbuild.scripts.meson_install as abc
-        cmdfunc = abc.run
     elif cmdname == 'commandrunner':
         import mesonbuild.scripts.commandrunner as abc
         cmdfunc = abc.run
@@ -270,23 +266,32 @@ def run(original_args, mainfile):
             args = remaining_args
             cmd_name = args[0]
         if cmd_name == 'test':
+            from . import mtest
             return mtest.run(remaining_args)
         elif cmd_name == 'setup':
             args = remaining_args
             # FALLTHROUGH like it's 1972.
+        elif cmd_name == 'install':
+            from . import minstall
+            return minstall.run(remaining_args)
         elif cmd_name == 'introspect':
+            from . import mintro
             return mintro.run(remaining_args)
         elif cmd_name == 'rewrite':
+            from . import rewriter
             return rewriter.run(remaining_args)
         elif cmd_name == 'configure':
             try:
+                from . import mconf
                 return mconf.run(remaining_args)
             except MesonException as e:
                 mlog.exception(e)
                 sys.exit(1)
         elif cmd_name == 'wrap':
+            from .wrap import wraptool
             return wraptool.run(remaining_args)
         elif cmd_name == 'init':
+            from . import minit
             return minit.run(remaining_args)
         elif cmd_name == 'runpython':
             import runpy

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -384,14 +384,15 @@ class Installer:
 
     def install_targets(self, d):
         for t in d.targets:
-            fname = check_for_stampfile(t[0])
-            outdir = get_destdir_path(d, t[1])
+            fname = check_for_stampfile(t.fname)
+            outdir = get_destdir_path(d, t.outdir)
             outname = os.path.join(outdir, os.path.basename(fname))
-            final_path = os.path.join(d.prefix, outname)
-            aliases = t[2]
-            should_strip = t[3]
-            install_rpath = t[4]
-            install_mode = t[5]
+            final_path = os.path.join(d.prefix, t.outdir, os.path.basename(fname))
+            aliases = t.aliases
+            should_strip = t.strip
+            install_rpath = t.install_rpath
+            install_name_mappings = t.install_name_mappings
+            install_mode = t.install_mode
             d.dirmaker.makedirs(outdir, exist_ok=True)
             if not os.path.exists(fname):
                 raise RuntimeError('File {!r} could not be found'.format(fname))
@@ -438,7 +439,7 @@ class Installer:
             if os.path.isfile(outname):
                 try:
                     depfixer.fix_rpath(outname, install_rpath, final_path,
-                                       verbose=False)
+                                       install_name_mappings, verbose=False)
                 except SystemExit as e:
                     if isinstance(e.code, int) and e.code == 0:
                         pass

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -22,7 +22,6 @@ from .mesonlib import is_windows, Popen_safe
 from .mtest import rebuild_all
 from __main__ import __file__ as main_file
 
-install_log_file = None
 selinux_updates = []
 
 def buildparser():
@@ -34,7 +33,8 @@ def buildparser():
     return parser
 
 class DirMaker:
-    def __init__(self):
+    def __init__(self, lf):
+        self.lf = lf
         self.dirs = []
 
     def makedirs(self, path, exist_ok=False):
@@ -60,11 +60,17 @@ class DirMaker:
     def __exit__(self, type, value, traceback):
         self.dirs.reverse()
         for d in self.dirs:
-            append_to_log(d)
+            append_to_log(self.lf, d)
 
 def is_executable(path):
     '''Checks whether any of the "x" bits are set in the source file mode.'''
     return bool(os.stat(path).st_mode & 0o111)
+
+def append_to_log(lf, line):
+    lf.write(line)
+    if not line.endswith('\n'):
+        lf.write('\n')
+    lf.flush()
 
 def sanitize_permissions(path, umask):
     if umask is None:
@@ -135,96 +141,6 @@ def restore_selinux_contexts():
                   'Standard output:', out.decode(),
                   'Standard error:', err.decode(), sep='\n')
 
-def append_to_log(line):
-    install_log_file.write(line)
-    if not line.endswith('\n'):
-        install_log_file.write('\n')
-    install_log_file.flush()
-
-def do_copyfile(from_file, to_file):
-    if not os.path.isfile(from_file):
-        raise RuntimeError('Tried to install something that isn\'t a file:'
-                           '{!r}'.format(from_file))
-    # copyfile fails if the target file already exists, so remove it to
-    # allow overwriting a previous install. If the target is not a file, we
-    # want to give a readable error.
-    if os.path.exists(to_file):
-        if not os.path.isfile(to_file):
-            raise RuntimeError('Destination {!r} already exists and is not '
-                               'a file'.format(to_file))
-        os.unlink(to_file)
-    shutil.copyfile(from_file, to_file)
-    shutil.copystat(from_file, to_file)
-    selinux_updates.append(to_file)
-    append_to_log(to_file)
-
-def do_copydir(data, src_dir, dst_dir, exclude, install_mode):
-    '''
-    Copies the contents of directory @src_dir into @dst_dir.
-
-    For directory
-        /foo/
-          bar/
-            excluded
-            foobar
-          file
-    do_copydir(..., '/foo', '/dst/dir', {'bar/excluded'}, None) creates
-        /dst/
-          dir/
-            bar/
-              foobar
-            file
-
-    Args:
-        src_dir: str, absolute path to the source directory
-        dst_dir: str, absolute path to the destination directory
-        exclude: (set(str), set(str)), tuple of (exclude_files, exclude_dirs),
-                 each element of the set is a path relative to src_dir.
-        install_mode: FileMode object, or None to use defaults.
-    '''
-    if not os.path.isabs(src_dir):
-        raise ValueError('src_dir must be absolute, got %s' % src_dir)
-    if not os.path.isabs(dst_dir):
-        raise ValueError('dst_dir must be absolute, got %s' % dst_dir)
-    if exclude is not None:
-        exclude_files, exclude_dirs = exclude
-    else:
-        exclude_files = exclude_dirs = set()
-    for root, dirs, files in os.walk(src_dir):
-        assert os.path.isabs(root)
-        for d in dirs[:]:
-            abs_src = os.path.join(root, d)
-            filepart = os.path.relpath(abs_src, start=src_dir)
-            abs_dst = os.path.join(dst_dir, filepart)
-            # Remove these so they aren't visited by os.walk at all.
-            if filepart in exclude_dirs:
-                dirs.remove(d)
-                continue
-            if os.path.isdir(abs_dst):
-                continue
-            if os.path.exists(abs_dst):
-                print('Tried to copy directory %s but a file of that name already exists.' % abs_dst)
-                sys.exit(1)
-            data.dirmaker.makedirs(abs_dst)
-            shutil.copystat(abs_src, abs_dst)
-            sanitize_permissions(abs_dst, data.install_umask)
-        for f in files:
-            abs_src = os.path.join(root, f)
-            filepart = os.path.relpath(abs_src, start=src_dir)
-            if filepart in exclude_files:
-                continue
-            abs_dst = os.path.join(dst_dir, filepart)
-            if os.path.isdir(abs_dst):
-                print('Tried to copy file %s but a directory of that name already exists.' % abs_dst)
-            if os.path.exists(abs_dst):
-                os.unlink(abs_dst)
-            parent_dir = os.path.dirname(abs_dst)
-            if not os.path.isdir(parent_dir):
-                os.mkdir(parent_dir)
-                shutil.copystat(os.path.dirname(abs_src), parent_dir)
-            shutil.copy2(abs_src, abs_dst, follow_symlinks=False)
-            set_mode(abs_dst, install_mode, data.install_umask)
-            append_to_log(abs_dst)
 
 def get_destdir_path(d, path):
     if os.path.isabs(path):
@@ -233,115 +149,6 @@ def get_destdir_path(d, path):
         output = os.path.join(d.fullprefix, path)
     return output
 
-def do_install(log_dir, datafilename):
-    global install_log_file
-
-    with open(datafilename, 'rb') as ifile:
-        d = pickle.load(ifile)
-    d.destdir = os.environ.get('DESTDIR', '')
-    d.fullprefix = destdir_join(d.destdir, d.prefix)
-
-    if d.install_umask is not None:
-        os.umask(d.install_umask)
-
-    with open(os.path.join(log_dir, 'install-log.txt'), 'w') as lf:
-        install_log_file = lf
-        append_to_log('# List of files installed by Meson')
-        append_to_log('# Does not contain files installed by custom scripts.')
-
-        try:
-            d.dirmaker = DirMaker()
-            with d.dirmaker:
-                install_subdirs(d) # Must be first, because it needs to delete the old subtree.
-                install_targets(d)
-                install_headers(d)
-                install_man(d)
-                install_data(d)
-                restore_selinux_contexts()
-                run_install_script(d)
-        except PermissionError:
-            if shutil.which('pkexec') is not None and 'PKEXEC_UID' not in os.environ:
-                print('Installation failed due to insufficient permissions.')
-                print('Attempting to use polkit to gain elevated privileges...')
-                os.execlp('pkexec', 'pkexec', sys.executable, main_file, *sys.argv[1:],
-                          os.getcwd())
-            else:
-                raise
-
-
-def install_subdirs(d):
-    for (src_dir, dst_dir, mode, exclude) in d.install_subdirs:
-        full_dst_dir = get_destdir_path(d, dst_dir)
-        print('Installing subdir %s to %s' % (src_dir, full_dst_dir))
-        d.dirmaker.makedirs(full_dst_dir, exist_ok=True)
-        do_copydir(d, src_dir, full_dst_dir, exclude, mode)
-
-def install_data(d):
-    for i in d.data:
-        fullfilename = i[0]
-        outfilename = get_destdir_path(d, i[1])
-        mode = i[2]
-        outdir = os.path.dirname(outfilename)
-        d.dirmaker.makedirs(outdir, exist_ok=True)
-        print('Installing %s to %s' % (fullfilename, outdir))
-        do_copyfile(fullfilename, outfilename)
-        set_mode(outfilename, mode, d.install_umask)
-
-def install_man(d):
-    for m in d.man:
-        full_source_filename = m[0]
-        outfilename = get_destdir_path(d, m[1])
-        outdir = os.path.dirname(outfilename)
-        d.dirmaker.makedirs(outdir, exist_ok=True)
-        install_mode = m[2]
-        print('Installing %s to %s' % (full_source_filename, outdir))
-        if outfilename.endswith('.gz') and not full_source_filename.endswith('.gz'):
-            with open(outfilename, 'wb') as of:
-                with open(full_source_filename, 'rb') as sf:
-                    # Set mtime and filename for reproducibility.
-                    with gzip.GzipFile(fileobj=of, mode='wb', filename='', mtime=0) as gz:
-                        gz.write(sf.read())
-            shutil.copystat(full_source_filename, outfilename)
-            append_to_log(outfilename)
-        else:
-            do_copyfile(full_source_filename, outfilename)
-        set_mode(outfilename, install_mode, d.install_umask)
-
-def install_headers(d):
-    for t in d.headers:
-        fullfilename = t[0]
-        fname = os.path.basename(fullfilename)
-        outdir = get_destdir_path(d, t[1])
-        outfilename = os.path.join(outdir, fname)
-        install_mode = t[2]
-        print('Installing %s to %s' % (fname, outdir))
-        d.dirmaker.makedirs(outdir, exist_ok=True)
-        do_copyfile(fullfilename, outfilename)
-        set_mode(outfilename, install_mode, d.install_umask)
-
-def run_install_script(d):
-    env = {'MESON_SOURCE_ROOT': d.source_dir,
-           'MESON_BUILD_ROOT': d.build_dir,
-           'MESON_INSTALL_PREFIX': d.prefix,
-           'MESON_INSTALL_DESTDIR_PREFIX': d.fullprefix,
-           'MESONINTROSPECT': ' '.join([shlex.quote(x) for x in d.mesonintrospect]),
-           }
-
-    child_env = os.environ.copy()
-    child_env.update(env)
-
-    for i in d.install_scripts:
-        script = i['exe']
-        args = i['args']
-        name = ' '.join(script + args)
-        print('Running custom install script {!r}'.format(name))
-        try:
-            rc = subprocess.call(script + args, env=child_env)
-            if rc != 0:
-                sys.exit(rc)
-        except OSError:
-            print('Failed to run install script {!r}'.format(name))
-            sys.exit(1)
 
 def check_for_stampfile(fname):
     '''Some languages e.g. Rust have output files
@@ -368,74 +175,263 @@ def check_for_stampfile(fname):
                 return files[0]
     return fname
 
-def install_targets(d):
-    for t in d.targets:
-        fname = check_for_stampfile(t.fname)
-        outdir = get_destdir_path(d, t.outdir)
-        outname = os.path.join(outdir, os.path.basename(fname))
-        final_path = os.path.join(d.prefix, t.outdir, os.path.basename(fname))
-        aliases = t.aliases
-        should_strip = t.strip
-        install_name_mappings = t.install_name_mappings
-        install_rpath = t.install_rpath
-        install_mode = t.install_mode
-        print('Installing %s to %s' % (fname, outname))
-        d.dirmaker.makedirs(outdir, exist_ok=True)
-        if not os.path.exists(fname):
-            raise RuntimeError('File {!r} could not be found'.format(fname))
-        elif os.path.isfile(fname):
-            do_copyfile(fname, outname)
-            set_mode(outname, install_mode, d.install_umask)
-            if should_strip and d.strip_bin is not None:
-                if fname.endswith('.jar'):
-                    print('Not stripping jar target:', os.path.basename(fname))
-                    continue
-                print('Stripping target {!r}'.format(fname))
-                ps, stdo, stde = Popen_safe(d.strip_bin + [outname])
-                if ps.returncode != 0:
-                    print('Could not strip file.\n')
-                    print('Stdout:\n%s\n' % stdo)
-                    print('Stderr:\n%s\n' % stde)
-                    sys.exit(1)
-            pdb_filename = os.path.splitext(fname)[0] + '.pdb'
-            if not should_strip and os.path.exists(pdb_filename):
-                pdb_outname = os.path.splitext(outname)[0] + '.pdb'
-                print('Installing pdb file %s to %s' % (pdb_filename, pdb_outname))
-                do_copyfile(pdb_filename, pdb_outname)
-                set_mode(pdb_outname, install_mode, d.install_umask)
-        elif os.path.isdir(fname):
-            fname = os.path.join(d.build_dir, fname.rstrip('/'))
-            outname = os.path.join(outdir, os.path.basename(fname))
-            do_copydir(d, fname, outname, None, install_mode)
+class Installer:
+
+    def __init__(self, lf):
+        self.lf = lf
+
+    def do_copyfile(self, from_file, to_file):
+        if not os.path.isfile(from_file):
+            raise RuntimeError('Tried to install something that isn\'t a file:'
+                               '{!r}'.format(from_file))
+        # copyfile fails if the target file already exists, so remove it to
+        # allow overwriting a previous install. If the target is not a file, we
+        # want to give a readable error.
+        if os.path.exists(to_file):
+            if not os.path.isfile(to_file):
+                raise RuntimeError('Destination {!r} already exists and is not '
+                                   'a file'.format(to_file))
+            os.unlink(to_file)
+        shutil.copyfile(from_file, to_file)
+        shutil.copystat(from_file, to_file)
+        selinux_updates.append(to_file)
+        append_to_log(self.lf, to_file)
+
+    def do_copydir(self, data, src_dir, dst_dir, exclude, install_mode):
+        '''
+        Copies the contents of directory @src_dir into @dst_dir.
+
+        For directory
+            /foo/
+              bar/
+                excluded
+                foobar
+              file
+        do_copydir(..., '/foo', '/dst/dir', {'bar/excluded'}) creates
+            /dst/
+              dir/
+                bar/
+                  foobar
+                file
+
+        Args:
+            src_dir: str, absolute path to the source directory
+            dst_dir: str, absolute path to the destination directory
+            exclude: (set(str), set(str)), tuple of (exclude_files, exclude_dirs),
+                     each element of the set is a path relative to src_dir.
+        '''
+        if not os.path.isabs(src_dir):
+            raise ValueError('src_dir must be absolute, got %s' % src_dir)
+        if not os.path.isabs(dst_dir):
+            raise ValueError('dst_dir must be absolute, got %s' % dst_dir)
+        if exclude is not None:
+            exclude_files, exclude_dirs = exclude
         else:
-            raise RuntimeError('Unknown file type for {!r}'.format(fname))
-        printed_symlink_error = False
-        for alias, to in aliases.items():
+            exclude_files = exclude_dirs = set()
+        for root, dirs, files in os.walk(src_dir):
+            assert os.path.isabs(root)
+            for d in dirs[:]:
+                abs_src = os.path.join(root, d)
+                filepart = os.path.relpath(abs_src, start=src_dir)
+                abs_dst = os.path.join(dst_dir, filepart)
+                # Remove these so they aren't visited by os.walk at all.
+                if filepart in exclude_dirs:
+                    dirs.remove(d)
+                    continue
+                if os.path.isdir(abs_dst):
+                    continue
+                if os.path.exists(abs_dst):
+                    print('Tried to copy directory %s but a file of that name already exists.' % abs_dst)
+                    sys.exit(1)
+                data.dirmaker.makedirs(abs_dst)
+                shutil.copystat(abs_src, abs_dst)
+                sanitize_permissions(abs_dst, data.install_umask)
+            for f in files:
+                abs_src = os.path.join(root, f)
+                filepart = os.path.relpath(abs_src, start=src_dir)
+                if filepart in exclude_files:
+                    continue
+                abs_dst = os.path.join(dst_dir, filepart)
+                if os.path.isdir(abs_dst):
+                    print('Tried to copy file %s but a directory of that name already exists.' % abs_dst)
+                if os.path.exists(abs_dst):
+                    os.unlink(abs_dst)
+                parent_dir = os.path.dirname(abs_dst)
+                if not os.path.isdir(parent_dir):
+                    os.mkdir(parent_dir)
+                    shutil.copystat(os.path.dirname(abs_src), parent_dir)
+                shutil.copy2(abs_src, abs_dst, follow_symlinks=False)
+                set_mode(abs_dst, install_mode, data.install_umask)
+                append_to_log(self.lf, abs_dst)
+
+    def do_install(self, datafilename):
+        with open(datafilename, 'rb') as ifile:
+            d = pickle.load(ifile)
+        d.destdir = os.environ.get('DESTDIR', '')
+        d.fullprefix = destdir_join(d.destdir, d.prefix)
+
+        if d.install_umask is not None:
+            os.umask(d.install_umask)
+
+        try:
+            d.dirmaker = DirMaker(self.lf)
+            with d.dirmaker:
+                self.install_subdirs(d) # Must be first, because it needs to delete the old subtree.
+                self.install_targets(d)
+                self.install_headers(d)
+                self.install_man(d)
+                self.install_data(d)
+                restore_selinux_contexts()
+                self.run_install_script(d)
+        except PermissionError:
+            if shutil.which('pkexec') is not None and 'PKEXEC_UID' not in os.environ:
+                print('Installation failed due to insufficient permissions.')
+                print('Attempting to use polkit to gain elevated privileges...')
+                os.execlp('pkexec', 'pkexec', sys.executable, main_file, *sys.argv[1:],
+                          os.getcwd())
+            else:
+                raise
+
+    def install_subdirs(self, d):
+        for (src_dir, dst_dir, mode, exclude) in d.install_subdirs:
+            full_dst_dir = get_destdir_path(d, dst_dir)
+            print('Installing subdir %s to %s' % (src_dir, full_dst_dir))
+            d.dirmaker.makedirs(full_dst_dir, exist_ok=True)
+            self.do_copydir(d, src_dir, full_dst_dir, exclude, mode)
+
+    def install_data(self, d):
+        for i in d.data:
+            fullfilename = i[0]
+            outfilename = get_destdir_path(d, i[1])
+            mode = i[2]
+            outdir = os.path.dirname(outfilename)
+            d.dirmaker.makedirs(outdir, exist_ok=True)
+            print('Installing %s to %s' % (fullfilename, outdir))
+            self.do_copyfile(fullfilename, outfilename)
+            set_mode(outfilename, mode, d.install_umask)
+
+    def install_man(self, d):
+        for m in d.man:
+            full_source_filename = m[0]
+            outfilename = get_destdir_path(d, m[1])
+            outdir = os.path.dirname(outfilename)
+            d.dirmaker.makedirs(outdir, exist_ok=True)
+            install_mode = m[2]
+            print('Installing %s to %s' % (full_source_filename, outdir))
+            if outfilename.endswith('.gz') and not full_source_filename.endswith('.gz'):
+                with open(outfilename, 'wb') as of:
+                    with open(full_source_filename, 'rb') as sf:
+                        # Set mtime and filename for reproducibility.
+                        with gzip.GzipFile(fileobj=of, mode='wb', filename='', mtime=0) as gz:
+                            gz.write(sf.read())
+                shutil.copystat(full_source_filename, outfilename)
+                append_to_log(self.lf, outfilename)
+            else:
+                self.do_copyfile(full_source_filename, outfilename)
+            set_mode(outfilename, install_mode, d.install_umask)
+
+    def install_headers(self, d):
+        for t in d.headers:
+            fullfilename = t[0]
+            fname = os.path.basename(fullfilename)
+            outdir = get_destdir_path(d, t[1])
+            outfilename = os.path.join(outdir, fname)
+            install_mode = t[2]
+            print('Installing %s to %s' % (fname, outdir))
+            d.dirmaker.makedirs(outdir, exist_ok=True)
+            self.do_copyfile(fullfilename, outfilename)
+            set_mode(outfilename, install_mode, d.install_umask)
+
+    def run_install_script(self, d):
+        env = {'MESON_SOURCE_ROOT': d.source_dir,
+               'MESON_BUILD_ROOT': d.build_dir,
+               'MESON_INSTALL_PREFIX': d.prefix,
+               'MESON_INSTALL_DESTDIR_PREFIX': d.fullprefix,
+               'MESONINTROSPECT': ' '.join([shlex.quote(x) for x in d.mesonintrospect]),
+               }
+
+        child_env = os.environ.copy()
+        child_env.update(env)
+
+        for i in d.install_scripts:
+            script = i['exe']
+            args = i['args']
+            name = ' '.join(script + args)
+            print('Running custom install script {!r}'.format(name))
             try:
-                symlinkfilename = os.path.join(outdir, alias)
+                rc = subprocess.call(script + args, env=child_env)
+                if rc != 0:
+                    sys.exit(rc)
+            except OSError:
+                print('Failed to run install script {!r}'.format(name))
+                sys.exit(1)
+
+    def install_targets(self, d):
+        for t in d.targets:
+            fname = check_for_stampfile(t[0])
+            outdir = get_destdir_path(d, t[1])
+            outname = os.path.join(outdir, os.path.basename(fname))
+            final_path = os.path.join(d.prefix, outname)
+            aliases = t[2]
+            should_strip = t[3]
+            install_rpath = t[4]
+            install_mode = t[5]
+            print('Installing %s to %s' % (fname, outname))
+            d.dirmaker.makedirs(outdir, exist_ok=True)
+            if not os.path.exists(fname):
+                raise RuntimeError('File {!r} could not be found'.format(fname))
+            elif os.path.isfile(fname):
+                self.do_copyfile(fname, outname)
+                set_mode(outname, install_mode, d.install_umask)
+                if should_strip and d.strip_bin is not None:
+                    if fname.endswith('.jar'):
+                        print('Not stripping jar target:', os.path.basename(fname))
+                        continue
+                    print('Stripping target {!r}'.format(fname))
+                    ps, stdo, stde = Popen_safe(d.strip_bin + [outname])
+                    if ps.returncode != 0:
+                        print('Could not strip file.\n')
+                        print('Stdout:\n%s\n' % stdo)
+                        print('Stderr:\n%s\n' % stde)
+                        sys.exit(1)
+                pdb_filename = os.path.splitext(fname)[0] + '.pdb'
+                if not should_strip and os.path.exists(pdb_filename):
+                    pdb_outname = os.path.splitext(outname)[0] + '.pdb'
+                    print('Installing pdb file %s to %s' % (pdb_filename, pdb_outname))
+                    self.do_copyfile(pdb_filename, pdb_outname)
+                    set_mode(pdb_outname, install_mode, d.install_umask)
+            elif os.path.isdir(fname):
+                fname = os.path.join(d.build_dir, fname.rstrip('/'))
+                outname = os.path.join(outdir, os.path.basename(fname))
+                self.do_copydir(d, fname, outname, None, install_mode)
+            else:
+                raise RuntimeError('Unknown file type for {!r}'.format(fname))
+            printed_symlink_error = False
+            for alias, to in aliases.items():
                 try:
-                    os.unlink(symlinkfilename)
-                except FileNotFoundError:
-                    pass
-                os.symlink(to, symlinkfilename)
-                append_to_log(symlinkfilename)
-            except (NotImplementedError, OSError):
-                if not printed_symlink_error:
-                    print("Symlink creation does not work on this platform. "
-                          "Skipping all symlinking.")
-                    printed_symlink_error = True
-        if os.path.isfile(outname):
-            try:
-                depfixer.fix_rpath(outname, install_rpath, final_path,
-                                   install_name_mappings, verbose=False)
-            except SystemExit as e:
-                if isinstance(e.code, int) and e.code == 0:
-                    pass
-                else:
-                    raise
+                    symlinkfilename = os.path.join(outdir, alias)
+                    try:
+                        os.unlink(symlinkfilename)
+                    except FileNotFoundError:
+                        pass
+                    os.symlink(to, symlinkfilename)
+                    append_to_log(self.lf, symlinkfilename)
+                except (NotImplementedError, OSError):
+                    if not printed_symlink_error:
+                        print("Symlink creation does not work on this platform. "
+                              "Skipping all symlinking.")
+                        printed_symlink_error = True
+            if os.path.isfile(outname):
+                try:
+                    depfixer.fix_rpath(outname, install_rpath, final_path,
+                                       verbose=False)
+                except SystemExit as e:
+                    if isinstance(e.code, int) and e.code == 0:
+                        pass
+                    else:
+                        raise
 
 def run(args):
-    global install_log_file
     parser = buildparser()
     opts = parser.parse_args(args)
     datafilename = 'meson-private/install.dat'
@@ -449,11 +445,10 @@ def run(args):
             sys.exit(-1)
     os.chdir(opts.wd)
     with open(os.path.join(log_dir, 'install-log.txt'), 'w') as lf:
-        install_log_file = lf
-        append_to_log('# List of files installed by Meson')
-        append_to_log('# Does not contain files installed by custom scripts.')
-        do_install(log_dir, datafilename)
-    install_log_file = None
+        installer = Installer(lf)
+        append_to_log(lf, '# List of files installed by Meson')
+        append_to_log(lf, '# Does not contain files installed by custom scripts.')
+        installer.do_install(datafilename)
     return 0
 
 if __name__ == '__main__':

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -14,14 +14,24 @@
 
 import sys, pickle, os, shutil, subprocess, gzip, errno
 import shlex
+import argparse
 from glob import glob
-from . import depfixer
-from . import destdir_join
-from ..mesonlib import is_windows, Popen_safe
+from .scripts import depfixer
+from .scripts import destdir_join
+from .mesonlib import is_windows, Popen_safe
+from .mtest import rebuild_all
 from __main__ import __file__ as main_file
 
 install_log_file = None
 selinux_updates = []
+
+def buildparser():
+    parser = argparse.ArgumentParser(prog='meson install')
+    parser.add_argument('-C', default='.', dest='wd',
+                        help='directory to cd into before running')
+    parser.add_argument('--no-rebuild', default=False, action='store_true',
+                        help='Do not rebuild before installing.')
+    return parser
 
 class DirMaker:
     def __init__(self):
@@ -425,15 +435,24 @@ def install_targets(d):
                     raise
 
 def run(args):
-    if len(args) != 1 and len(args) != 2:
-        print('Installer script for Meson. Do not run on your own, mmm\'kay?')
-        print('meson_install.py [install info file]')
-    datafilename = args[0]
+    global install_log_file
+    parser = buildparser()
+    opts = parser.parse_args(args)
+    datafilename = 'meson-private/install.dat'
     private_dir = os.path.dirname(datafilename)
     log_dir = os.path.join(private_dir, '../meson-logs')
-    if len(args) == 2:
-        os.chdir(args[1])
-    do_install(log_dir, datafilename)
+    if not os.path.exists(os.path.join(opts.wd, datafilename)):
+        sys.exit('Install data not found. Run this command in build directory root.')
+    log_dir = os.path.join(private_dir, '../meson-logs')
+    if not opts.no_rebuild:
+        if not rebuild_all(opts.wd):
+            sys.exit(-1)
+    os.chdir(opts.wd)
+    with open(os.path.join(log_dir, 'install-log.txt'), 'w') as lf:
+        install_log_file = lf
+        append_to_log('# List of files installed by Meson')
+        append_to_log('# Does not contain files installed by custom scripts.')
+        do_install(log_dir, datafilename)
     install_log_file = None
     return 0
 


### PR DESCRIPTION
*Not finished yet.*

Make installing a top level command that can be invoked with `meson install`. This allows us to add more functionality to the install command in the same way as we did to the test command. In a similar way you can tell the install command to not rebuild before running the install for those who really know what they are doing.

The primary use case is something like `meson install --only-changed` or something like that, which checks each file to be copied, and only does the copy if the target is either non-existing or is older than the file to be copied.