### PR TITLE
Windows: Fix exception when windres is not found

### DIFF
--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -66,7 +66,7 @@ class WindowsModule(ExtensionModule):
             res_args = extra_args + ['@INPUT@', '@OUTPUT@']
             suffix = 'o'
         if not rescomp.found():
-            raise MesonException('Could not find Windows resource compiler %s.' % ' '.join(rescomp.get_command()))
+            raise MesonException('Could not find Windows resource compiler "%s".' % rescomp_name)
 
         res_targets = []
 


### PR DESCRIPTION
If rescomp is not found its command is None and that make meson print
backtrace instead of displaying the error message.