### PR TITLE
for_darwin: Also accept system='ios' in cross files

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -373,7 +373,7 @@ def for_darwin(is_cross, env):
     if not is_cross:
         return is_osx()
     elif env.cross_info.has_host():
-        return env.cross_info.config['host_machine']['system'] == 'darwin'
+        return env.cross_info.config['host_machine']['system'] in ('darwin', 'ios')
     return False
 
 def for_android(is_cross, env):


### PR DESCRIPTION
The value in cross files is free-form, and people expect to be able to (correctly) set it to `ios`.

Our machinery treats `for_darwin()` to mean "for either ios or macos".