### PR TITLE
Add a new option for building with Apple bitcode support

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -1,0 +1,113 @@
+---
+short-description: Built-in options to configure project properties
+...
+
+# Built-in options
+
+Meson provides two kinds of options: [build options provided by the
+build files](Build-options.md) and built-in options that are either
+universal options, base options, compiler options.
+
+## Universal options
+
+A list of these options can be found by running `meson --help`. All
+these can be set by passing to `meson` (aka `meson setup`) in any of
+these ways:
+
+| --option=value |
+| --option value |
+| -Doption=value |
+
+They can also be edited after setup using `meson configure`.
+
+Installation options are all relative to the prefix, except:
+
+* When the prefix is `/usr`: `sysconfdir` defaults to `/etc`, `localstatedir` defaults to `/var`, and `sharedstatedir` defaults to `/var/lib`
+* When the prefix is `/usr/local`: `localstatedir` defaults to `/var/local`, and `sharedstatedir` defaults to `/var/local/lib`
+
+| Option         | Default value | Description
+| ------         | ------------- | -----------
+| prefix         | see below     | Installation prefix
+| libdir         | see below     | Library directory
+| libexecdir     | libexec       | Library executable directory
+| bindir         | bin           | Executable directory
+| sbindir        | sbin          | System executable directory
+| includedir     | include       | Header file directory
+| datadir        | share         | Data file directory
+| mandir         | share/man     | Manual page directory
+| infodir        | share/info    | Info page directory
+| localedir      | share/locale  | Locale data directory
+| sysconfdir     | etc           | Sysconf data directory
+| localstatedir  | var           | Localstate data directory
+| sharedstatedir | com           | Architecture-independent data directory
+
+`prefix` defaults to `C:/` on Windows, and `/usr/local/` otherwise. You should always
+override this value.
+
+`libdir` is automatically detected based on your platform, but the
+implementation is [currently buggy](https://github.com/mesonbuild/meson/issues/2038)
+on Linux platforms.
+
+There are various other options to set, for instance the backend to use and
+the path to the cross-file while cross compiling, which won't be repeated here.
+Please see the output of `meson --help`.
+
+## Base options
+
+These are set in the same way as universal options, but cannot be shown in the
+output of `meson --help` because they depend on both the current platform and
+the compiler that will be selected. The only way to see them is to setup
+a builddir and then run `meson configure` on it with no options.
+
+The following options are available. Note that they may not be available on all
+platforms or with all compilers:
+
+| Option      | Default value | Possible values         | Description
+| ----------- | ------------- | ---------------         | -----------
+| b_asneeded  | true          | true, false             | Use -Wl,--as-needed when linking
+| b_bitcode   | false         | true, false             | Embed Apple bitcode, see below
+| b_colorout  | always        | auto, always, never     | Use colored output
+| b_coverage  | false         | true, false             | Enable coverage tracking
+| b_lundef    | true          | true, false             | Don't allow undefined symbols when linking
+| b_lto       | false         | true, false             | Use link time optimization
+| b_ndebug    | false         | true, false, if-release | Disable asserts
+| b_pch       | true          | true, false             | Use precompiled headers
+| b_pgo       | off           | off, generate, use      | Use profile guided optimization
+| b_sanitize  | none          | see below               | Code sanitizer to use
+| b_staticpic | true          | true, false             | Build static libraries as position independent
+
+The value of `b_sanitize` can be one of: `none`, `address`, `thread`,
+`undefined`, `memory`, `address,undefined`.
+
+### Notes about Apple Bitcode support
+
+`b_bitcode` will pass `-fembed-bitcode` while compiling and will pass
+`-Wl,-bitcode_bundle` while linking. These options are incompatible with
+`b_asneeded`, so that option will be silently disabled.
+
+[Shared modules](#Reference-manual.md#shared_module) will not have bitcode
+embedded because `-Wl,-bitcode_bundle` is incompatible with both `-bundle` and
+`-Wl,-undefined,dynamic_lookup` which are necessary for shared modules to work.
+
+## Compiler options
+
+Same caveats as base options above.
+
+The following options are available. Note that both the options themselves and
+the possible values they can take will depend on the target platform or
+compiler being used:
+
+| Option       | Default value | Possible values                          | Description
+| ------       | ------------- | ---------------                          | -----------
+| c_args       |               | free-form comma-separated list           | C compile arguments to use
+| c_std        | none          | none, c89, c99, c11, gnu89, gnu99, gnu11 | C language standard to use
+| c_winlibs    | see below     | free-form comma-separated list           | Standard Windows libs to link against
+| cpp_args     |               | free-form comma-separated list           | C++ compile arguments to use
+| cpp_std      | none          | none, c++98, c++03, c++11, c++14, c++17, <br/>c++1z, gnu++03, gnu++11, gnu++14, gnu++17, gnu++1z | C++ language standard to use
+| cpp_debugstl | false         | true, false                              | C++ STL debug mode
+| cpp_eh       | sc            | none, a, s, sc                           | C++ exception handling type
+| cpp_winlibs  | see below     | free-form comma-separated list           | Standard Windows libs to link against
+
+The default values of `c_winlibs` and `cpp_winlibs` are in compiler-specific
+argument forms, but the libraries are: kernel32, user32, gdi32, winspool,
+shell32, ole32, oleaut32, uuid, comdlg32, advapi32

--- a/docs/markdown/snippets/bitcode_support.md
+++ b/docs/markdown/snippets/bitcode_support.md
@@ -1,0 +1,15 @@
+## New base build option for LLVM (Apple) bitcode support
+
+When building with clang on macOS, you can now build your static and shared
+binaries with embedded bitcode by enabling the `b_bitcode` [base
+option](Builtin-options.md#Base_options) by passing `-Db_bitcode=true` to
+Meson.
+
+This is better than passing the options manually in the environment since Meson
+will automatically disable conflicting options such as `b_asneeded`, and will
+disable bitcode support on targets that don't support it such as
+`shared_module()`.
+
+Since this requires support in the linker, it is currently only enabled when
+using Apple ld. In the future it can be extended to clang on other platforms
+too.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2397,7 +2397,8 @@ rule FORTRAN_DEP_HACK%s
                 commands += linker.gen_import_library_args(os.path.join(self.get_target_dir(target), target.import_filename))
         elif isinstance(target, build.SharedLibrary):
             if isinstance(target, build.SharedModule):
-                commands += linker.get_std_shared_module_link_args()
+                options = self.environment.coredata.base_options
+                commands += linker.get_std_shared_module_link_args(options)
             else:
                 commands += linker.get_std_shared_lib_link_args()
             # All shared libraries are PIC

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -950,7 +950,8 @@ class Vs2010Backend(backends.Backend):
             self.generate_debug_information(link)
         if not isinstance(target, build.StaticLibrary):
             if isinstance(target, build.SharedModule):
-                extra_link_args += compiler.get_std_shared_module_link_args()
+                options = self.environment.coredata.base_options
+                extra_link_args += compiler.get_std_shared_module_link_args(options)
             # Add link args added using add_project_link_arguments()
             extra_link_args += self.build.get_project_link_args(compiler, target.subproject)
             # Add link args added using add_global_link_arguments()

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -249,6 +249,9 @@ base_options = {'b_pch': coredata.UserBooleanOption('b_pch', 'Use precompiled he
                 'b_staticpic': coredata.UserBooleanOption('b_staticpic',
                                                           'Build static libraries as position independent',
                                                           True),
+                'b_bitcode': coredata.UserBooleanOption('b_bitcode',
+                                                        'Generate and embed bitcode (only macOS and iOS)',
+                                                        False),
                 }
 
 gnulike_instruction_set_args = {'mmx': ['-mmmx'],
@@ -287,7 +290,6 @@ vs64_instruction_set_args = {'mmx': ['/arch:AVX'],
                              'neon': None,
                              }
 
-
 def sanitizer_compile_args(value):
     if value == 'none':
         return []
@@ -301,6 +303,14 @@ def sanitizer_link_args(value):
         return []
     args = ['-fsanitize=' + value]
     return args
+
+def option_enabled(boptions, options, option):
+    try:
+        if option not in boptions:
+            return False
+        return options[option].value
+    except KeyError:
+        return False
 
 def get_base_compile_args(options, compiler):
     args = []
@@ -338,6 +348,9 @@ def get_base_compile_args(options, compiler):
             args += ['-DNDEBUG']
     except KeyError:
         pass
+    # This does not need a try...except
+    if option_enabled(compiler.base_options, options, 'b_bitcode'):
+        args.append('-fembed-bitcode')
     return args
 
 def get_base_link_args(options, linker, is_shared_module):
@@ -361,20 +374,22 @@ def get_base_link_args(options, linker, is_shared_module):
     except KeyError:
         pass
     try:
-        if not is_shared_module and 'b_lundef' in linker.base_options and options['b_lundef'].value:
-            args.append('-Wl,--no-undefined')
-    except KeyError:
-        pass
-    try:
-        if 'b_asneeded' in linker.base_options and options['b_asneeded'].value:
-            args.append(linker.get_asneeded_args())
-    except KeyError:
-        pass
-    try:
         if options['b_coverage'].value:
             args += linker.get_coverage_link_args()
     except KeyError:
         pass
+    # These do not need a try...except
+    if not is_shared_module and option_enabled(linker.base_options, options, 'b_lundef'):
+        args.append('-Wl,--no-undefined')
+    as_needed = option_enabled(linker.base_options, options, 'b_asneeded')
+    bitcode = option_enabled(linker.base_options, options, 'b_bitcode')
+    # Shared modules cannot be built with bitcode_bundle because
+    # -bitcode_bundle is incompatible with -undefined and -bundle
+    if bitcode and not is_shared_module:
+        args.append('-Wl,-bitcode_bundle')
+    elif as_needed:
+        # -Wl,-dead_strip_dylibs is incompatible with bitcode
+        args.append(linker.get_asneeded_args())
     return args
 
 class CrossNoRunException(MesonException):
@@ -859,7 +874,7 @@ class Compiler:
     def get_std_shared_lib_link_args(self):
         return []
 
-    def get_std_shared_module_link_args(self):
+    def get_std_shared_module_link_args(self, options):
         return self.get_std_shared_lib_link_args()
 
     def get_link_whole_for(self, args):
@@ -1068,7 +1083,9 @@ class GnuCompiler:
         self.defines = defines or {}
         self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage',
                              'b_colorout', 'b_ndebug', 'b_staticpic']
-        if self.gcc_type != GCC_OSX:
+        if self.gcc_type == GCC_OSX:
+            self.base_options.append('b_bitcode')
+        else:
             self.base_options.append('b_lundef')
         self.base_options.append('b_asneeded')
         # All GCC backends can do assembly
@@ -1184,7 +1201,9 @@ class ClangCompiler:
         self.clang_type = clang_type
         self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage',
                              'b_ndebug', 'b_staticpic', 'b_colorout']
-        if self.clang_type != CLANG_OSX:
+        if self.clang_type == CLANG_OSX:
+            self.base_options.append('b_bitcode')
+        else:
             self.base_options.append('b_lundef')
         self.base_options.append('b_asneeded')
         # All Clang backends can do assembly and LLVM IR
@@ -1253,7 +1272,7 @@ class ClangCompiler:
             extra_args.append('-Wl,-no_weak_imports')
         return super().has_function(funcname, prefix, env, extra_args, dependencies)
 
-    def get_std_shared_module_link_args(self):
+    def get_std_shared_module_link_args(self, options):
         if self.clang_type == CLANG_OSX:
             return ['-bundle', '-Wl,-undefined,dynamic_lookup']
         return ['-shared']

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2421,7 +2421,13 @@ to directly access options of other subprojects.''')
             self.add_base_options(comp)
         return success
 
+    def emit_base_options_warnings(self, enabled_opts):
+        if 'b_bitcode' in enabled_opts:
+            mlog.warning('Base option \'b_bitcode\' is enabled, which is incompatible with many linker options. Incompatible options such as such as \'b_asneeded\' have been disabled.')
+            mlog.warning('Please see https://mesonbuild.com/Builtin-options.html#Notes_about_Apple_Bitcode_support for more details.')
+
     def add_base_options(self, compiler):
+        enabled_opts = []
         proj_opt = self.environment.cmd_line_options.projectoptions
         for optname in compiler.base_options:
             if optname in self.coredata.base_options:
@@ -2429,9 +2435,13 @@ to directly access options of other subprojects.''')
             oobj = compilers.base_options[optname]
             for po in proj_opt:
                 if po.startswith(optname + '='):
-                    oobj.set_value(po.split('=', 1)[1])
+                    opt, value = po.split('=', 1)
+                    oobj.set_value(value)
+                    if oobj.value:
+                        enabled_opts.append(opt)
                     break
             self.coredata.base_options[optname] = oobj
+        self.emit_base_options_warnings(enabled_opts)
 
     def program_from_cross_file(self, prognames, silent=False):
         bins = self.environment.cross_info.config['binaries']

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3128,6 +3128,49 @@ endian = 'little'
             deps.append(b'-lintl')
         self.assertEqual(set(deps), set(stdo.split()))
 
+    def test_apple_bitcode(self):
+        '''
+        Test that -fembed-bitcode is correctly added while compiling and
+        -bitcode_bundle is added while linking when b_bitcode is true and not
+        when it is false.  This can't be an ordinary test case because we need
+        to inspect the compiler database.
+        '''
+        if not is_osx():
+            raise unittest.SkipTest('Apple bitcode not relevant')
+        testdir = os.path.join(self.common_test_dir, '4 shared')
+        # Try with bitcode enabled
+        self.init(testdir, extra_args='-Db_bitcode=true')
+        compdb = self.get_compdb()
+        self.assertIn('-fembed-bitcode', compdb[0]['command'])
+        build_ninja = os.path.join(self.builddir, 'build.ninja')
+        with open(build_ninja, 'r', encoding='utf-8') as f:
+            contents = f.read()
+            m = re.search('LINK_ARGS =.*-bitcode_bundle', contents)
+        self.assertIsNotNone(m, msg=contents)
+        # Try with bitcode disabled
+        self.setconf('-Db_bitcode=false')
+        # Regenerate build
+        self.build()
+        compdb = self.get_compdb()
+        self.assertNotIn('-fembed-bitcode', compdb[0]['command'])
+        build_ninja = os.path.join(self.builddir, 'build.ninja')
+        with open(build_ninja, 'r', encoding='utf-8') as f:
+            contents = f.read()
+            m = re.search('LINK_ARGS =.*-bitcode_bundle', contents)
+        self.assertIsNone(m, msg=contents)
+
+    def test_apple_bitcode_modules(self):
+        '''
+        Same as above, just for shared_module()
+        '''
+        if not is_osx():
+            raise unittest.SkipTest('Apple bitcode not relevant')
+        testdir = os.path.join(self.common_test_dir, '156 shared module resolving symbol in executable')
+        # Ensure that it builds even with bitcode enabled
+        self.init(testdir, extra_args='-Db_bitcode=true')
+        self.build()
+        self.run_tests()
+
 class LinuxArmCrossCompileTests(BasePlatformTests):
     '''
     Tests that verify cross-compilation to Linux/ARM

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3157,13 +3157,17 @@ endian = 'little'
         to inspect the compiler database.
         '''
         if not is_osx():
-            raise unittest.SkipTest('Apple bitcode not relevant')
+            raise unittest.SkipTest('Apple bitcode only works on macOS')
         testdir = os.path.join(self.common_test_dir, '4 shared')
         # Try with bitcode enabled
-        self.init(testdir, extra_args='-Db_bitcode=true')
+        out = self.init(testdir, extra_args='-Db_bitcode=true')
+        # Warning was printed
+        self.assertRegex(out, 'WARNING:.*b_bitcode')
+        # Compiler options were added
         compdb = self.get_compdb()
         self.assertIn('-fembed-bitcode', compdb[0]['command'])
         build_ninja = os.path.join(self.builddir, 'build.ninja')
+        # Linker options were added
         with open(build_ninja, 'r', encoding='utf-8') as f:
             contents = f.read()
             m = re.search('LINK_ARGS =.*-bitcode_bundle', contents)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2121,6 +2121,27 @@ recommended as it can lead to undefined behaviour on some platforms''')
         self.assertEqual(obj.builtins['default_library'].value, 'shared')
         self.wipe()
 
+    def test_compiler_options_documented(self):
+        '''
+        Test that C and C++ compiler options and base options are documented in
+        Builtin-Options.md. Only tests the default compiler for the current
+        platform on the CI.
+        '''
+        md = None
+        with open('docs/markdown/Builtin-options.md') as f:
+            md = f.read()
+        self.assertIsNotNone(md)
+        env = Environment('.', self.builddir, get_fake_options(self.prefix), [])
+        # FIXME: Support other compilers
+        cc = env.detect_c_compiler(False)
+        cpp = env.detect_cpp_compiler(False)
+        for comp in (cc, cpp):
+            for opt in comp.get_options().keys():
+                self.assertIn(opt, md)
+            for opt in comp.base_options:
+                self.assertIn(opt, md)
+        self.assertNotIn('b_unknown', md)
+
 
 class FailureTests(BasePlatformTests):
     '''


### PR DESCRIPTION
Normally, people would just pass `-fembed-bitcode` in `CFLAGS`, but this conflicts with `-Wl,-dead_strip_dylibs` and `-bundle`, so we need it as an option so that those can be quietly disabled.