### PR TITLE
Enable running tests that fail at 'meson test'

### DIFF
--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -505,7 +505,7 @@ def detect_tests_to_run():
         ('common', 'common', False),
         ('failing-meson', 'failing', False),
         ('failing-build', 'failing build', False),
-        ('failing-tests', 'failing tests', False),
+        ('failing-test',  'failing test', False),
 
         ('platform-osx', 'osx', not mesonlib.is_osx()),
         ('platform-windows', 'windows', not mesonlib.is_windows() and not mesonlib.is_cygwin()),

--- a/test cases/failing test/1 trivial/main.c
+++ b/test cases/failing test/1 trivial/main.c
@@ -1,0 +1,3 @@
+int main(void) {
+    return 1;
+}

--- a/test cases/failing test/1 trivial/meson.build
+++ b/test cases/failing test/1 trivial/meson.build
@@ -1,0 +1,3 @@
+project('trivial', 'c')
+
+test('My Test', executable('main', 'main.c'))


### PR DESCRIPTION
There was a bug when searching for tests that fail at `meson test`. I added a trivial test to prove that it works.