### PR TITLE
Misc rpath bugfixes

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -355,17 +355,13 @@ class Backend:
 
     def determine_rpath_dirs(self, target):
         link_deps = target.get_all_link_deps()
-        result = []
+        result = set()
         for ld in link_deps:
             if ld is target:
                 continue
-            prospective = self.get_target_dir(ld)
-            if prospective not in result:
-                result.append(prospective)
-        for rp in self.rpaths_for_bundled_shared_libraries(target):
-            if rp not in result:
-                result += [rp]
-        return result
+            result.add(self.get_target_dir(ld))
+        result.update(self.rpaths_for_bundled_shared_libraries(target))
+        return list(result)
 
     def object_filename_from_source(self, target, source):
         assert isinstance(source, mesonlib.File)

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -344,7 +344,9 @@ class Backend:
             if libpath.startswith(('/usr/lib', '/lib')):
                 # No point in adding system paths.
                 continue
-            if os.path.splitext(libpath)[1] not in ['.dll', '.lib', '.so']:
+            # Windows doesn't support rpaths, but we use this function to
+            # emulate rpaths by setting PATH, so also accept DLLs here
+            if os.path.splitext(libpath)[1] not in ['.dll', '.lib', '.so', '.dylib']:
                 continue
             absdir = os.path.dirname(libpath)
             if absdir.startswith(self.environment.get_source_dir()):

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -334,23 +334,25 @@ class Backend:
     def rpaths_for_bundled_shared_libraries(self, target):
         paths = []
         for dep in target.external_deps:
-            if isinstance(dep, (dependencies.ExternalLibrary, dependencies.PkgConfigDependency)):
-                la = dep.link_args
-                if len(la) == 1 and os.path.isabs(la[0]):
-                    # The only link argument is an absolute path to a library file.
-                    libpath = la[0]
-                    if libpath.startswith(('/usr/lib', '/lib')):
-                        # No point in adding system paths.
-                        continue
-                    if os.path.splitext(libpath)[1] not in ['.dll', '.lib', '.so']:
-                        continue
-                    absdir = os.path.dirname(libpath)
-                    if absdir.startswith(self.environment.get_source_dir()):
-                        rel_to_src = absdir[len(self.environment.get_source_dir()) + 1:]
-                        assert not os.path.isabs(rel_to_src), 'rel_to_src: {} is absolute'.format(rel_to_src)
-                        paths.append(os.path.join(self.build_to_src, rel_to_src))
-                    else:
-                        paths.append(absdir)
+            if not isinstance(dep, (dependencies.ExternalLibrary, dependencies.PkgConfigDependency)):
+                continue
+            la = dep.link_args
+            if len(la) != 1 or not os.path.isabs(la[0]):
+                continue
+            # The only link argument is an absolute path to a library file.
+            libpath = la[0]
+            if libpath.startswith(('/usr/lib', '/lib')):
+                # No point in adding system paths.
+                continue
+            if os.path.splitext(libpath)[1] not in ['.dll', '.lib', '.so']:
+                continue
+            absdir = os.path.dirname(libpath)
+            if absdir.startswith(self.environment.get_source_dir()):
+                rel_to_src = absdir[len(self.environment.get_source_dir()) + 1:]
+                assert not os.path.isabs(rel_to_src), 'rel_to_src: {} is absolute'.format(rel_to_src)
+                paths.append(os.path.join(self.build_to_src, rel_to_src))
+            else:
+                paths.append(absdir)
         return paths
 
     def determine_rpath_dirs(self, target):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -652,10 +652,6 @@ class Environment:
     def get_scratch_dir(self):
         return self.scratch_dir
 
-    def get_depfixer(self):
-        path = os.path.dirname(__file__)
-        return os.path.join(path, 'depfixer.py')
-
     def detect_objc_compiler(self, want_cross):
         popen_exceptions = {}
         compilers, ccache, is_cross, exe_wrap = self._get_compilers('objc', 'OBJC', want_cross)

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -229,9 +229,6 @@ def run_script_command(args):
     elif cmdname == 'delsuffix':
         import mesonbuild.scripts.delwithsuffix as abc
         cmdfunc = abc.run
-    elif cmdname == 'depfixer':
-        import mesonbuild.scripts.depfixer as abc
-        cmdfunc = abc.run
     elif cmdname == 'dirchanger':
         import mesonbuild.scripts.dirchanger as abc
         cmdfunc = abc.run

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -372,8 +372,11 @@ def fix_darwin(fname, new_rpath):
         # non-executable target. Just return.
         return
     try:
-        for rp in rpaths:
-            subprocess.check_call(['install_name_tool', '-delete_rpath', rp, fname],
+        if rpaths:
+            args = []
+            for rp in rpaths:
+                args += ['-delete_rpath', rp]
+            subprocess.check_call(['install_name_tool', fname] + args,
                                   stdout=subprocess.DEVNULL,
                                   stderr=subprocess.DEVNULL)
         if new_rpath:

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -396,16 +396,3 @@ def fix_rpath(fname, new_rpath, verbose=True):
     if shutil.which('install_name_tool'):
         fix_darwin(fname, new_rpath)
     return 0
-
-def run(args):
-    if len(args) < 1 or len(args) > 2:
-        print('This application resets target rpath.')
-        print('Don\'t run this unless you know what you are doing.')
-        print('%s: <binary file> <prefix>' % sys.argv[0])
-        sys.exit(1)
-    fname = args[0]
-    new_rpath = None if len(args) == 1 else args[1]
-    return fix_rpath(fname, new_rpath)
-
-if __name__ == '__main__':
-    sys.exit(run(sys.argv[1:]))


### PR DESCRIPTION
commit 5e72325d698aeddef04202b92a5411498bef38e3:

depfixer: We no longer run this as a script


commit c404fc1a7881781a9b47aa5d687b74e43021426f:

depfixer: Run install_name_tool only once while deleting rpaths


commit cbf85c843b83698099001eb02fd9db5531ab37c1:

backends: Use a set while gathering RPATHs


commit 1677c61409b55fd80c499626cdedbfb568c70874:

backends: Simplify loop getting rpaths for bundled libs
No functionality changes

commit 102b86235440a049dc4fe0f605b78de046a05c31:

backends: Also accept dylibs while finding RPATHs
