### PR TITLE
Don't call getpgid() when killing a test.

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -304,7 +304,8 @@ class SingleTestRunner:
                 subprocess.call(['taskkill', '/F', '/T', '/PID', str(p.pid)])
             else:
                 try:
-                    os.killpg(os.getpgid(p.pid), signal.SIGKILL)
+                    # Kill the process group that setsid() created.
+                    os.killpg(p.pid, signal.SIGKILL)
                 except ProcessLookupError:
                     # Sometimes (e.g. with Wine) this happens.
                     # There's nothing we can do (maybe the process


### PR DESCRIPTION
OpenBSD's getpgid(2) fails with EPERM (PermissionError) because the
test is in a different session: https://man.openbsd.org/getpgid

Use p.pid as the process group ID, because setsid() created a process
group with the same ID as the process.  See setsid(2) manuals:

 - FreeBSD: https://www.freebsd.org/cgi/man.cgi?query=setsid
 - illumos: https://illumos.org/man/setsid
 - Linux: http://man7.org/linux/man-pages/man2/setsid.2.html

This change fixes 'manual tests/8 timeout' on OpenBSD.  To verify this
change, one must run the manual test.  For example,

    $ cd 'manual tests/8 timeout'
    $ meson build
    $ ninja -C build test

It should report that the test timed out, and not show
PermissionError.

Fixes https://github.com/mesonbuild/meson/issues/3569