### PR TITLE
Make install doc less surprising for new users

### DIFF
--- a/docs/markdown/Running-Meson.md
+++ b/docs/markdown/Running-Meson.md
@@ -132,6 +132,9 @@ Installing the built software is just as simple.
 
     ninja install
 
+Note that Meson will only install build targets explicitly tagged as
+installable, as detailed in the [installing targets documentation](Installing.md).
+
 By default Meson installs to `/usr/local`. This can be changed by
 passing the command line argument `--prefix /your/prefix` to Meson
 during configure time. Meson also supports the `DESTDIR` variable used


### PR DESCRIPTION
When reading the docs, after the first tutorial, the "Running Meson" page explains how `ninja install` installs build targets.
It obviously doesn't work on the tutorial example since there is no target marked for installation. This can be a frustrating experience for new users not aware of Meson default install policy.

This pull request add a remark about tagging targets as installable and a link to the "Installing" doc.