### PR TITLE
interpreter: add to_array method for bool values

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1716,7 +1716,7 @@ are immutable, all operations return their results as a new string.
 
 ### `boolean` object
 
-A [boolean](Syntax.md#booleans) object has two simple methods:
+A [boolean](Syntax.md#booleans) object has three simple methods:
 
 - `to_int()` as above, but returns either `1` or `0`
 
@@ -1725,6 +1725,10 @@ A [boolean](Syntax.md#booleans) object has two simple methods:
   arguments to specify what to return for true/false. For instance,
   `bool.to_string('yes', 'no')` will return `yes` if the boolean is
   true and `no` if it is false.
+
+- `to_array(arg0, arg1, ...)` *(added 0.47.0)* places all the arguments
+  in array and returns it if the boolean is true, or returns an empty array
+  otherwise.
 
 ### `array` object
 

--- a/docs/markdown/snippets/bool_to_array.md
+++ b/docs/markdown/snippets/bool_to_array.md
@@ -1,0 +1,11 @@
+## New method `to_array` for bool
+
+This function provides a compact idiom to select optional sources or dependencies,
+as in the following example:
+
+```meson
+is_windows = host_machine.system() == 'windows'
+sources += is_windows.to_array('util-win32.c')
+sources += (!is_windows).to_array('util-posix.c')
+executable('prog', sources: sources)
+```

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -597,6 +597,11 @@ The result of this is undefined and will become a hard error in a future Meson r
                 return 1
             else:
                 return 0
+        elif method_name == 'to_array':
+            if obj:
+                return posargs
+            else:
+                return []
         else:
             raise InterpreterException('Unknown method "%s" for a boolean.' % method_name)
 

--- a/test cases/common/63 array methods/meson.build
+++ b/test cases/common/63 array methods/meson.build
@@ -44,3 +44,31 @@ endif
 if not combined.contains('ghi')
   error('Combined claims not to contain ghi.')
 endif
+
+if true.to_array() != empty
+  error('Incorrect value for true.to_array')
+endif
+
+if true.to_array(two) != [two]
+  error('Incorrect value for true.to_array')
+endif
+
+if true.to_array('def', 'ghi') != two
+  error('Incorrect value for true.to_array')
+endif
+
+if true.to_array(two) != [two]
+  error('Incorrect value for true.to_array')
+endif
+
+if false.to_array() != empty
+  error('Incorrect value for true.to_array')
+endif
+
+if false.to_array('def', 'ghi') != empty
+  error('Incorrect value for false.to_array')
+endif
+
+if false.to_array(two) != empty
+  error('Incorrect value for false.to_array')
+endif


### PR DESCRIPTION
This function enables a compact way to choose sources depending on configuration
options or on the build environment, like

    is_windows = host_machine.system() == 'windows'
    executable('prog', sources: [
        is_windows.to_array('util-win32.c'),
        (!is_windows).to_array('util-posix.c'),
        get_option('enable-foo').to_array('foo.c'),
        get_option('enable-bar').to_array('bar.c', 'bar-internal.c'),
        ...
    ])