### PR TITLE
Don't raise StopIteration in generators, no longer allowed with Python 3.7. Fixes #3622

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -796,7 +796,7 @@ class Compiler:
                 mlog.debug('Cached compiler stdout:\n', p.stdo)
                 mlog.debug('Cached compiler stderr:\n', p.stde)
                 yield p
-                raise StopIteration
+                return
         try:
             with tempfile.TemporaryDirectory() as tmpdirname:
                 if isinstance(code, str):


### PR DESCRIPTION
Raising StopIteration from a generator has been deprecated with Python 3.5 and is now
an error with Python 3.7: https://docs.python.org/3.8/library/exceptions.html#StopIteration

Just use return instead.

Fixes #3622