### PR TITLE
New compiler method: check_header

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1567,8 +1567,18 @@ the following methods:
   `args` keyword, you can specify external dependencies to use with
   `dependencies` keyword argument.
 
-- `has_header` returns true if the specified header can be included,
-  you can specify external dependencies to use with `dependencies`
+- `check_header` returns true if the specified header is *usable* with
+  the specified prefix, dependencies, and arguments.
+  You can specify external dependencies to use with `dependencies`
+  keyword argument and extra code to put above the header test with
+  the `prefix` keyword. In order to look for headers in a specific
+  directory you can use `args : '-I/extra/include/dir`, but this
+  should only be used in exceptional cases for includes that can't be
+  detected via pkg-config and passed via `dependencies`.
+
+- `has_header` returns true if the specified header *exists*, and is
+  faster than `check_header()` since it only does a pre-processor check.
+  You can specify external dependencies to use with `dependencies`
   keyword argument and extra code to put above the header test with
   the `prefix` keyword. In order to look for headers in a specific
   directory you can use `args : '-I/extra/include/dir`, but this
@@ -1651,7 +1661,7 @@ The following keyword arguments can be used:
   some symbols to be exposed on Linux, and it should be passed via
   `args` keyword argument, see below). Supported by the methods
   `sizeof`, `has_type`, `has_function`, `has_member`, `has_members`,
-  `has_header_symbol`.
+  `check_header`, `has_header`, `has_header_symbol`.
 
 **Note:** These compiler checks do not use compiler arguments added with 
 `add_*_arguments()`, via `-Dlang_args` on the command-line, or through

--- a/docs/markdown/snippets/compiler_check_header.md
+++ b/docs/markdown/snippets/compiler_check_header.md
@@ -1,0 +1,12 @@
+## New compiler check: check_header()
+
+The existing compiler check `has_header()` only checks if the header exists,
+either with the `__has_include` C++11 builtin, or by running the pre-processor.
+
+However, sometimes the header you are looking for is unusable on some platforms
+or with some compilers in a way that is only detectable at compile-time. For
+such cases, you should use `check_header()` which will include the header and
+run a full compile.
+
+Note that `has_header()` is much faster than `check_header()`, so it should be
+used whenever possible.

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -266,6 +266,12 @@ class CCompiler(Compiler):
         code = 'int main(int argc, char **argv) { int class=0; return class; }\n'
         return self.sanity_check_impl(work_dir, environment, 'sanitycheckc.c', code)
 
+    def check_header(self, hname, prefix, env, extra_args=None, dependencies=None):
+        fargs = {'prefix': prefix, 'header': hname}
+        code = '''{prefix}
+        #include <{header}>'''
+        return self.compiles(code.format(**fargs), env, extra_args, dependencies)
+
     def has_header(self, hname, prefix, env, extra_args=None, dependencies=None):
         fargs = {'prefix': prefix, 'header': hname}
         code = '''{prefix}

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -710,6 +710,9 @@ class Compiler:
     def get_option_link_args(self, options):
         return []
 
+    def check_header(self, *args, **kwargs):
+        raise EnvironmentException('Language %s does not support header checks.' % self.get_display_language())
+
     def has_header(self, *args, **kwargs):
         raise EnvironmentException('Language %s does not support header checks.' % self.get_display_language())
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -843,6 +843,7 @@ class CompilerHolder(InterpreterObject):
                              'compute_int': self.compute_int_method,
                              'sizeof': self.sizeof_method,
                              'get_define': self.get_define_method,
+                             'check_header': self.check_header_method,
                              'has_header': self.has_header_method,
                              'has_header_symbol': self.has_header_symbol_method,
                              'run': self.run_method,
@@ -1228,6 +1229,31 @@ class CompilerHolder(InterpreterObject):
                 h = mlog.red('NO')
             mlog.log('Checking if "', mlog.bold(testname), '" links: ', h, sep='')
         return result
+
+    @permittedKwargs({
+        'prefix',
+        'no_builtin_args',
+        'include_directories',
+        'args',
+        'dependencies',
+    })
+    def check_header_method(self, args, kwargs):
+        if len(args) != 1:
+            raise InterpreterException('check_header method takes exactly one argument.')
+        check_stringlist(args)
+        hname = args[0]
+        prefix = kwargs.get('prefix', '')
+        if not isinstance(prefix, str):
+            raise InterpreterException('Prefix argument of has_header must be a string.')
+        extra_args = self.determine_args(kwargs)
+        deps = self.determine_dependencies(kwargs)
+        haz = self.compiler.check_header(hname, prefix, self.environment, extra_args, deps)
+        if haz:
+            h = mlog.green('YES')
+        else:
+            h = mlog.red('NO')
+        mlog.log('Check usable header "%s":' % hname, h)
+        return haz
 
     @permittedKwargs({
         'prefix',

--- a/test cases/common/200 check header/meson.build
+++ b/test cases/common/200 check header/meson.build
@@ -1,0 +1,48 @@
+project('check header', 'c', 'cpp')
+
+host_system = host_machine.system()
+
+non_existant_header = 'ouagadougou.h'
+
+# Copy it into the builddir to ensure that it isn't found even if it's there
+configure_file(input : non_existant_header,
+  output : non_existant_header,
+  copy: true)
+
+fallback = ''
+
+foreach comp : [meson.get_compiler('c'), meson.get_compiler('cpp')]
+  assert(comp.check_header('stdio.h', prefix : fallback), 'Stdio missing.')
+
+  # stdio.h doesn't actually need stdlib.h, but just test that setting the
+  # prefix does not result in an error.
+  assert(comp.check_header('stdio.h', prefix : '#include <stdlib.h>' + fallback),
+         'Stdio missing.')
+
+  # Test that check_header behaves differently than has_header. The second
+  # check without windows.h will fail with check_header.
+  # We only do this check on MSVC because MinGW often defines its own wrappers
+  # that pre-include windows.h
+  if comp.get_id() == 'msvc'
+    assert(comp.check_header('XInput.h', prefix : '#include <windows.h>' + fallback),
+           'XInput.h should not be missing on Windows')
+    assert(not comp.check_header('XInput.h'), 'XInput.h needs windows.h')
+  endif
+
+  # Test that the following GCC bug doesn't happen:
+  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80005
+  # https://github.com/mesonbuild/meson/issues/1458
+  if host_system == 'linux'
+    assert(comp.check_header('linux/if.h', prefix : fallback),
+           'Could not find <linux/if.h>')
+    if comp.has_header('intrin.h', prefix : fallback)
+      assert(not comp.check_header('intrin.h'),
+             'intrin.h should not be usable on linux')
+    endif
+  endif
+
+  # This header exists in the source and the builddir, but we still must not
+  # find it since we are looking in the system directories.
+  assert(not comp.check_header(non_existant_header, prefix : fallback),
+         'Found non-existant header.')
+endforeach

--- a/test cases/common/200 check header/ouagadougou.h
+++ b/test cases/common/200 check header/ouagadougou.h
@@ -1,0 +1,1 @@
+#define OMG_THIS_SHOULDNT_BE_FOUND


### PR DESCRIPTION
This checks not only for existence, but also for usability of the header, which means it does a full compilation and not just pre-processing or __has_include.

Fixes https://github.com/mesonbuild/meson/issues/2246

The tests are copied from the `has_header()` checks (and modified for usability checks, which means some tests are now false instead of true), and also add the clang `intrin.h` header check reported in the original issue.