### PR TITLE
Don't accept an empty string for name_suffix:

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -789,6 +789,10 @@ This will become a hard error in a future Meson release.''')
             else:
                 if not isinstance(name_suffix, str):
                     raise InvalidArguments('name_suffix must be a string.')
+                if name_suffix == '':
+                    raise InvalidArguments('name_suffix should not be an empty string. '
+                                           'If you want meson to use the default behaviour '
+                                           'for each platform pass `[]` (empty array)')
                 self.suffix = name_suffix
                 self.name_suffix_set = True
         if isinstance(self, StaticLibrary):


### PR DESCRIPTION
This is never going to be useful, and the error message now points people to what they might be expecting: use the default value for this platform.