### PR TITLE
[skip ci] Update cpu families

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -45,6 +45,8 @@ set in the cross file.
 | x86_64              | 64 bit x86 processor  |
 | arm                 | 32 bit ARM processor  |
 | aarch64             | 64 bit ARM processor  |
+| ppc64               | 64 bit PPC processors (Big Endian) |
+| ppc64le             | 64 bit PPC processors (Little Endian) |
 | e2k                 | MCST Elbrus processor |
 
 Any cpu family not listed in the above list is not guaranteed to

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -49,6 +49,7 @@ set in the cross file.
 | ppc64               | 64 bit PPC processors (Big Endian) |
 | ppc64le             | 64 bit PPC processors (Little Endian) |
 | e2k                 | MCST Elbrus processor |
+| parisc              | HP PA-RISC processor  |
 
 Any cpu family not listed in the above list is not guaranteed to
 remain stable in future releases.

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -43,7 +43,8 @@ set in the cross file.
 | -----               | -------                         |
 | x86                 | 32 bit x86 processor  |
 | x86_64              | 64 bit x86 processor  |
-| arm                 | 32 bit ARM processor |
+| arm                 | 32 bit ARM processor  |
+| aarch64             | 64 bit ARM processor  |
 | e2k                 | MCST Elbrus processor |
 
 Any cpu family not listed in the above list is not guaranteed to

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -43,6 +43,7 @@ set in the cross file.
 | -----               | -------                         |
 | x86                 | 32 bit x86 processor  |
 | x86_64              | 64 bit x86 processor  |
+| ia64                | Itanium processor     |
 | arm                 | 32 bit ARM processor  |
 | aarch64             | 64 bit ARM processor  |
 | ppc64               | 64 bit PPC processors (Big Endian) |

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -50,6 +50,7 @@ set in the cross file.
 | ppc64le             | 64 bit PPC processors (Little Endian) |
 | e2k                 | MCST Elbrus processor |
 | parisc              | HP PA-RISC processor  |
+| sparc64             | SPARC v9 processor    |
 
 Any cpu family not listed in the above list is not guaranteed to
 remain stable in future releases.


### PR DESCRIPTION
this adds a few more architectures to the list we guarantee. This list was helpfully compiled by a few mesa and gentoo people for me. This should be helpful, particularly since I've seen builds using `arm64` instead of `aarch64` in the wild.