### PR TITLE
Set the meson command to use when we know what it is

### DIFF
--- a/meson.py
+++ b/meson.py
@@ -14,13 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mesonbuild import mesonmain
-import sys, os
+import sys
+from pathlib import Path
 
-def main():
-    # Always resolve the command path so Ninja can find it for regen, tests, etc.
-    launcher = os.path.realpath(sys.argv[0])
-    return mesonmain.run(sys.argv[1:], launcher)
+# If we're run uninstalled, add the script directory to sys.path to ensure that
+# we always import the correct mesonbuild modules even if PYTHONPATH is mangled
+meson_exe = Path(sys.argv[0]).resolve()
+if (meson_exe.parent / 'mesonbuild').is_dir():
+    sys.path.insert(0, meson_exe.parent)
+
+from mesonbuild import mesonmain
 
 if __name__ == '__main__':
-    sys.exit(main())
+    sys.exit(mesonmain.main())

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -262,10 +262,9 @@ class Environment:
     private_dir = 'meson-private'
     log_dir = 'meson-logs'
 
-    def __init__(self, source_dir, build_dir, main_script_launcher, options, original_cmd_line_args):
+    def __init__(self, source_dir, build_dir, options, original_cmd_line_args):
         self.source_dir = source_dir
         self.build_dir = build_dir
-        self.meson_script_launcher = main_script_launcher
         self.scratch_dir = os.path.join(build_dir, Environment.private_dir)
         self.log_dir = os.path.join(build_dir, Environment.log_dir)
         os.makedirs(self.scratch_dir, exist_ok=True)
@@ -278,7 +277,8 @@ class Environment:
             # re-initialized with project options by the interpreter during
             # build file parsing.
             self.coredata = coredata.CoreData(options)
-            self.coredata.meson_script_launcher = self.meson_script_launcher
+            # Used by the regenchecker script, which runs meson
+            self.coredata.meson_command = mesonlib.meson_command
             self.first_invocation = True
         if self.coredata.cross_file:
             self.cross_info = CrossBuildInfo(self.coredata.cross_file)

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -38,58 +38,12 @@ except Exception:
 
 from glob import glob
 
-def detect_meson_py_location():
-    c = sys.argv[0]
-    c_dir, c_fname = os.path.split(c)
-
-    # get the absolute path to the <mesontool> folder
-    m_dir = None
-    if os.path.isabs(c):
-        # $ /foo/<mesontool>.py <args>
-        m_dir = c_dir
-    elif c_dir == '':
-        # $ <mesontool> <args> (gets run from /usr/bin/<mesontool>)
-        in_path_exe = shutil.which(c_fname)
-        if in_path_exe:
-            if not os.path.isabs(in_path_exe):
-                m_dir = os.getcwd()
-                c_fname = in_path_exe
-            else:
-                m_dir, c_fname = os.path.split(in_path_exe)
-    else:
-        m_dir = os.path.abspath(c_dir)
-
-    # find meson in m_dir
-    if m_dir is not None:
-        for fname in ['meson', 'meson.py']:
-            m_path = os.path.join(m_dir, fname)
-            if os.path.exists(m_path):
-                return m_path
-
-    # No meson found, which means that either:
-    # a) meson is not installed
-    # b) meson is installed to a non-standard location
-    # c) the script that invoked mesonlib is not the one of meson tools (e.g. run_unittests.py)
-    fname = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'meson.py'))
-    if os.path.exists(fname):
-        return fname
-    # If meson is still not found, we might be imported by out-of-source tests
-    # https://github.com/mesonbuild/meson/issues/3015
-    exe = shutil.which('meson')
-    if exe is None:
-        exe = shutil.which('meson.py')
-    if exe is not None:
-        return exe
-    # Give up.
-    raise RuntimeError('Could not determine how to run Meson. Please file a bug with details.')
-
 if os.path.basename(sys.executable) == 'meson.exe':
     # In Windows and using the MSI installed executable.
-    meson_command = [sys.executable]
     python_command = [sys.executable, 'runpython']
 else:
     python_command = [sys.executable]
-    meson_command = python_command + [detect_meson_py_location()]
+meson_command = None
 
 def is_ascii_string(astring):
     try:

--- a/mesonbuild/scripts/regen_checker.py
+++ b/mesonbuild/scripts/regen_checker.py
@@ -14,7 +14,6 @@
 
 import sys, os
 import pickle, subprocess
-from mesonbuild.mesonlib import meson_command
 
 # This could also be used for XCode.
 
@@ -32,7 +31,7 @@ def need_regen(regeninfo, regen_timestamp):
     Vs2010Backend.touch_regen_timestamp(regeninfo.build_dir)
     return False
 
-def regen(regeninfo, mesonscript, backend):
+def regen(regeninfo, meson_command, backend):
     cmd = meson_command + ['--internal',
                            'regenerate',
                            regeninfo.build_dir,
@@ -48,11 +47,10 @@ def run(args):
         regeninfo = pickle.load(f)
     with open(coredata, 'rb') as f:
         coredata = pickle.load(f)
-    mesonscript = coredata.meson_script_launcher
     backend = coredata.get_builtin_option('backend')
     regen_timestamp = os.stat(dumpfile).st_mtime
     if need_regen(regeninfo, regen_timestamp):
-        regen(regeninfo, mesonscript, backend)
+        regen(regeninfo, coredata.meson_command, backend)
     sys.exit(0)
 
 if __name__ == '__main__':

--- a/run_meson_command_tests.py
+++ b/run_meson_command_tests.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+
+# Copyright 2018 The Meson development team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+import unittest
+import subprocess
+from pathlib import Path
+
+from mesonbuild.mesonlib import windows_proof_rmtree, python_command, is_windows
+
+# Find the meson.py adjacent to us
+meson_py = Path(__file__).resolve().parent / 'meson.py'
+if not meson_py.is_file():
+    raise RuntimeError("meson.py not found: test must only run from git")
+
+def get_pypath():
+    import sysconfig
+    pypath = sysconfig.get_path('purelib', vars={'base': ''})
+    # Ensure that / is the path separator and not \, then strip /
+    return Path(pypath).as_posix().strip('/')
+
+def get_pybindir():
+    import sysconfig
+    # 'Scripts' on Windows and 'bin' on other platforms including MSYS
+    return sysconfig.get_path('scripts', vars={'base': ''}).strip('\\/')
+
+class CommandTests(unittest.TestCase):
+    '''
+    Test that running meson in various ways works as expected by checking the
+    value of mesonlib.meson_command that was set during configuration.
+    '''
+
+    def setUp(self):
+        super().setUp()
+        self.orig_env = os.environ.copy()
+        self.orig_dir = os.getcwd()
+        os.environ['MESON_COMMAND_TESTS'] = '1'
+        self.tmpdir = Path(tempfile.mkdtemp()).resolve()
+        self.src_root = Path(__file__).resolve().parent
+        self.testdir = str(self.src_root / 'test cases/common/1 trivial')
+        self.meson_args = ['--backend=ninja']
+
+    def tearDown(self):
+        try:
+            windows_proof_rmtree(str(self.tmpdir))
+        except FileNotFoundError:
+            pass
+        os.environ.clear()
+        os.environ.update(self.orig_env)
+        os.chdir(str(self.orig_dir))
+        super().tearDown()
+
+    def _run(self, command, workdir=None):
+        '''
+        Run a command while printing the stdout and stderr to stdout,
+        and also return a copy of it
+        '''
+        # If this call hangs CI will just abort. It is very hard to distinguish
+        # between CI issue and test bug in that case. Set timeout and fail loud
+        # instead.
+        p = subprocess.run(command, stdout=subprocess.PIPE,
+                           stderr=subprocess.STDOUT, env=os.environ.copy(),
+                           universal_newlines=True, cwd=workdir, timeout=60 * 5)
+        print(p.stdout)
+        if p.returncode != 0:
+            raise subprocess.CalledProcessError(p.returncode, command)
+        return p.stdout
+
+    def assertMesonCommandIs(self, line, cmd):
+        self.assertTrue(line.startswith('meson_command '), msg=line)
+        self.assertEqual(line, 'meson_command is {!r}'.format(cmd))
+
+    def test_meson_uninstalled(self):
+        # This is what the meson command must be for all these cases
+        resolved_meson_command = python_command + [str(self.src_root / 'meson.py')]
+        # Absolute path to meson.py
+        os.chdir('/')
+        builddir = str(self.tmpdir / 'build1')
+        meson_py = str(self.src_root / 'meson.py')
+        meson_setup = [meson_py, 'setup']
+        meson_command = python_command + meson_setup + self.meson_args
+        stdo = self._run(meson_command + [self.testdir, builddir])
+        self.assertMesonCommandIs(stdo.split('\n')[0], resolved_meson_command)
+        # ./meson.py
+        os.chdir(str(self.src_root))
+        builddir = str(self.tmpdir / 'build2')
+        meson_py = './meson.py'
+        meson_setup = [meson_py, 'setup']
+        meson_command = python_command + meson_setup + self.meson_args
+        stdo = self._run(meson_command + [self.testdir, builddir])
+        self.assertMesonCommandIs(stdo.split('\n')[0], resolved_meson_command)
+        # Symlink to meson.py
+        if is_windows():
+            # Symlinks require admin perms
+            return
+        os.chdir(str(self.src_root))
+        builddir = str(self.tmpdir / 'build3')
+        # Create a symlink to meson.py in bindir, and add it to PATH
+        bindir = (self.tmpdir / 'bin')
+        bindir.mkdir()
+        (bindir / 'meson').symlink_to(self.src_root / 'meson.py')
+        os.environ['PATH'] = str(bindir) + os.pathsep + os.environ['PATH']
+        # See if it works!
+        meson_py = 'meson'
+        meson_setup = [meson_py, 'setup']
+        meson_command = meson_setup + self.meson_args
+        stdo = self._run(meson_command + [self.testdir, builddir])
+        self.assertMesonCommandIs(stdo.split('\n')[0], resolved_meson_command)
+
+    def test_meson_installed(self):
+        # Install meson
+        prefix = self.tmpdir / 'prefix'
+        pylibdir = prefix / get_pypath()
+        bindir = prefix / get_pybindir()
+        pylibdir.mkdir(parents=True)
+        os.environ['PYTHONPATH'] = str(pylibdir)
+        os.environ['PATH'] = str(bindir) + os.pathsep + os.environ['PATH']
+        self._run(python_command + ['setup.py', 'install', '--prefix', str(prefix)])
+        self.assertTrue(pylibdir.is_dir())
+        self.assertTrue(bindir.is_dir())
+        # Run `meson`
+        os.chdir('/')
+        if is_windows():
+            resolved_meson_command = python_command + [str(bindir / 'meson.py')]
+        else:
+            resolved_meson_command = python_command + [str(bindir / 'meson')]
+            # The python configuration on appveyor does not register .py as
+            # a valid extension, so we cannot run `meson` on Windows.
+            builddir = str(self.tmpdir / 'build1')
+            meson_setup = ['meson', 'setup']
+            meson_command = meson_setup + self.meson_args
+            stdo = self._run(meson_command + [self.testdir, builddir])
+            self.assertMesonCommandIs(stdo.split('\n')[0], resolved_meson_command)
+        # Run `/path/to/meson`
+        builddir = str(self.tmpdir / 'build2')
+        if is_windows():
+            # Cannot run .py directly because of the appveyor configuration,
+            # and the script is named meson.py, not meson
+            meson_setup = python_command + [str(bindir / 'meson.py'), 'setup']
+        else:
+            meson_setup = [str(bindir / 'meson'), 'setup']
+        meson_command = meson_setup + self.meson_args
+        stdo = self._run(meson_command + [self.testdir, builddir])
+        self.assertMesonCommandIs(stdo.split('\n')[0], resolved_meson_command)
+        # Run `python3 -m mesonbuild.mesonmain`
+        resolved_meson_command = python_command + ['-m', 'mesonbuild.mesonmain']
+        builddir = str(self.tmpdir / 'build3')
+        meson_setup = ['-m', 'mesonbuild.mesonmain', 'setup']
+        meson_command = python_command + meson_setup + self.meson_args
+        stdo = self._run(meson_command + [self.testdir, builddir])
+        self.assertMesonCommandIs(stdo.split('\n')[0], resolved_meson_command)
+        if is_windows():
+            # Next part requires a shell
+            return
+        # `meson` is a wrapper to `meson.real`
+        resolved_meson_command = python_command + [str(bindir / 'meson.real')]
+        builddir = str(self.tmpdir / 'build4')
+        (bindir / 'meson').rename(bindir / 'meson.real')
+        wrapper = (bindir / 'meson')
+        with open(wrapper, 'w') as f:
+            f.write('#!/bin/sh\n\nmeson.real "$@"')
+        wrapper.chmod(0o755)
+        meson_setup = [str(wrapper), 'setup']
+        meson_command = meson_setup + self.meson_args
+        stdo = self._run(meson_command + [self.testdir, builddir])
+        self.assertMesonCommandIs(stdo.split('\n')[0], resolved_meson_command)
+
+    def test_meson_exe_windows(self):
+        raise unittest.SkipTest('NOT IMPLEMENTED')
+
+if __name__ == '__main__':
+    unittest.main(buffer=True)


### PR DESCRIPTION
Instead of using fragile guessing to figure out how to invoke meson, set the value when meson is run. Also rework how we pass of meson_script_launcher to regenchecker.py -- it wasn't even being used

With this change, we only need to guess the meson path when running the tests, and in that case:

1. If MESON_EXE is set in the env, we know how to run meson for project tests.
2. MESON_EXE is not set, which means we run the configure in-process for project tests and need to guess what meson to run, so either
   - meson.py is found next to run_tests.py, or
   - meson, meson.py, or meson.exe is in PATH

Normally you would invoke meson in the following ways:

1. meson is installed, and mesonbuild is available in PYTHONPATH:
   - meson, meson.py, meson.exe from PATH
   - python3 -m mesonbuild.mesonmain
   - python3 /path/to/meson.py
   - meson is a shell wrapper to meson.real
2. meson is not installed, and is run from git:
   - Absolute path to meson.py
   - Relative path to meson.py
   - Symlink to meson.py

All these are tested in test_meson_commands.py, except meson.exe

@martingkelly will this work for yocto? Please check `CommandTests.test_meson_installed()` in `run_meson_command_tests.py` which tests the wrapper meson case.