### PR TITLE
Consolidate reporting the result of a dependency check

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -392,8 +392,6 @@ class ConfigToolDependency(ExternalDependency):
                 mlog.log('Found', mlog.bold(self.tool_name), repr(req_version),
                          mlog.red('NO'))
             mlog.log('Dependency', mlog.bold(self.name), 'found:', mlog.red('NO'))
-            if self.required:
-                raise DependencyException('Dependency {} not found'.format(self.name))
             return False
         mlog.log('Found {}:'.format(self.tool_name), mlog.bold(shutil.which(self.config)),
                  '({})'.format(version))
@@ -475,9 +473,6 @@ class PkgConfigDependency(ExternalDependency):
                    '{!r}'.format(name, self.pkgbin.get_path()))
         ret, self.version = self._call_pkgbin(['--modversion', name])
         if ret != 0:
-            if self.required:
-                raise DependencyException('{} dependency {!r} not found'
-                                          ''.format(self.type_string, name))
             return
         found_msg = [self.type_string + ' dependency', mlog.bold(name), 'found:']
         if self.version_reqs is None:
@@ -826,8 +821,6 @@ class DubDependency(ExternalDependency):
         ret, res = self._call_dubbin(['describe', name])
 
         if ret != 0:
-            if self.required:
-                raise DependencyException('Dependency {!r} not found'.format(name))
             self.is_found = False
             mlog.log('Dependency', mlog.bold(name), 'found:', mlog.red('NO'))
             return
@@ -840,8 +833,6 @@ class DubDependency(ExternalDependency):
                     msg = ['Dependency', mlog.bold(name), 'found but it was compiled with']
                     msg += [mlog.bold(j['compiler']), 'and we are using', mlog.bold(comp)]
                     mlog.error(*msg)
-                    if self.required:
-                        raise DependencyException('Dependency {!r} not found'.format(name))
                     self.is_found = False
                     mlog.log('Dependency', mlog.bold(name), 'found:', mlog.red('NO'))
                     return
@@ -897,11 +888,9 @@ class DubDependency(ExternalDependency):
             self.link_args.append(file)
 
         if not found:
-            if self.required:
-                raise DependencyException('Dependency {!r} not found'.format(name))
-                self.is_found = False
-                mlog.log('Dependency', mlog.bold(name), 'found:', mlog.red('NO'))
-                return
+            self.is_found = False
+            mlog.log('Dependency', mlog.bold(name), 'found:', mlog.red('NO'))
+            return
 
         if not self.silent:
             mlog.log(*found_msg)
@@ -1249,8 +1238,6 @@ class ExtraFrameworkDependency(ExternalDependency):
                 self.name = d
                 self.is_found = True
                 return
-        if not self.found() and self.required:
-            raise DependencyException('Framework dependency %s not found.' % (name, ))
 
     def get_version(self):
         return 'unknown'

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1250,6 +1250,13 @@ def find_external_dependency(name, env, kwargs):
     if name.lower() not in _packages_accept_language and 'language' in kwargs:
         raise DependencyException('%s dependency does not accept "language" keyword argument' % (name, ))
 
+    # if this isn't a cross-build, it's uninteresting if native: is used or not
+    if not env.is_cross_build():
+        type_text = 'Dependency'
+    else:
+        type_text = 'Native' if kwargs.get('native', False) else 'Cross'
+        type_text += ' dependency'
+
     # build a list of dependency methods to try
     candidates = _build_external_dependency_list(name, env, kwargs)
 
@@ -1281,7 +1288,7 @@ def find_external_dependency(name, env, kwargs):
                 if info:
                     info = ', ' + info
 
-                mlog.log('Dependency', mlog.bold(name), details + 'found:', mlog.green('YES'), d.version + info)
+                mlog.log(type_text, mlog.bold(name), details + 'found:', mlog.green('YES'), d.version + info)
 
                 return d
 
@@ -1292,7 +1299,7 @@ def find_external_dependency(name, env, kwargs):
     else:
         tried = ''
 
-    mlog.log('Dependency', mlog.bold(name), details + 'found:', mlog.red('NO'),
+    mlog.log(type_text, mlog.bold(name), details + 'found:', mlog.red('NO'),
              '(tried {})'.format(tried) if tried else '')
 
     if required:

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1252,6 +1252,7 @@ display_name_map = {
 }
 
 def find_external_dependency(name, env, kwargs):
+    assert(name)
     required = kwargs.get('required', True)
     if not isinstance(required, bool):
         raise DependencyException('Keyword "required" must be a boolean.')

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1240,6 +1240,16 @@ def get_dep_identifier(name, kwargs, want_cross):
         identifier += (key, value)
     return identifier
 
+display_name_map = {
+    'boost': 'Boost',
+    'dub': 'DUB',
+    'gmock': 'GMock',
+    'gtest': 'GTest',
+    'llvm': 'LLVM',
+    'mpi': 'MPI',
+    'openmp': 'OpenMP',
+    'wxwidgets': 'WxWidgets',
+}
 
 def find_external_dependency(name, env, kwargs):
     required = kwargs.get('required', True)
@@ -1247,8 +1257,12 @@ def find_external_dependency(name, env, kwargs):
         raise DependencyException('Keyword "required" must be a boolean.')
     if not isinstance(kwargs.get('method', ''), str):
         raise DependencyException('Keyword "method" must be a string.')
-    if name.lower() not in _packages_accept_language and 'language' in kwargs:
+    lname = name.lower()
+    if lname not in _packages_accept_language and 'language' in kwargs:
         raise DependencyException('%s dependency does not accept "language" keyword argument' % (name, ))
+
+    # display the dependency name with correct casing
+    display_name = display_name_map.get(lname, lname)
 
     # if this isn't a cross-build, it's uninteresting if native: is used or not
     if not env.is_cross_build():
@@ -1288,7 +1302,7 @@ def find_external_dependency(name, env, kwargs):
                 if info:
                     info = ', ' + info
 
-                mlog.log(type_text, mlog.bold(name), details + 'found:', mlog.green('YES'), d.version + info)
+                mlog.log(type_text, mlog.bold(display_name), details + 'found:', mlog.green('YES'), d.version + info)
 
                 return d
 
@@ -1299,7 +1313,7 @@ def find_external_dependency(name, env, kwargs):
     else:
         tried = ''
 
-    mlog.log(type_text, mlog.bold(name), details + 'found:', mlog.red('NO'),
+    mlog.log(type_text, mlog.bold(display_name), details + 'found:', mlog.red('NO'),
              '(tried {})'.format(tried) if tried else '')
 
     if required:

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -947,7 +947,7 @@ class DubDependency(ExternalDependency):
 
     @staticmethod
     def get_methods():
-        return [DependencyMethods.PKGCONFIG, DependencyMethods.DUB]
+        return [DependencyMethods.DUB]
 
 class ExternalProgram:
     windows_exts = ('exe', 'msc', 'com', 'bat', 'cmd')

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -297,6 +297,8 @@ class ConfigToolDependency(ExternalDependency):
             self.config = None
             return
         self.version = version
+        if getattr(self, 'finish_init', None):
+            self.finish_init(self)
 
     def _sanitize_version(self, version):
         """Remove any non-numeric, non-point version suffixes."""
@@ -308,7 +310,7 @@ class ConfigToolDependency(ExternalDependency):
         return version
 
     @classmethod
-    def factory(cls, name, environment, language, kwargs, tools, tool_name):
+    def factory(cls, name, environment, language, kwargs, tools, tool_name, finish_init=None):
         """Constructor for use in dependencies that can be found multiple ways.
 
         In addition to the standard constructor values, this constructor sets
@@ -323,7 +325,7 @@ class ConfigToolDependency(ExternalDependency):
         def reduce(self):
             return (cls._unpickle, (), self.__dict__)
         sub = type('{}Dependency'.format(name.capitalize()), (cls, ),
-                   {'tools': tools, 'tool_name': tool_name, '__reduce__': reduce})
+                   {'tools': tools, 'tool_name': tool_name, '__reduce__': reduce, 'finish_init': staticmethod(finish_init)})
 
         return sub(name, environment, language, kwargs)
 

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -132,7 +132,6 @@ class BoostDependency(ExternalDependency):
                 self.incdir = self.detect_nix_incdir()
 
         if self.check_invalid_modules():
-            self.log_fail()
             return
 
         mlog.debug('Boost library root dir is', mlog.bold(self.boost_root))
@@ -145,12 +144,6 @@ class BoostDependency(ExternalDependency):
         if self.is_found:
             self.detect_lib_modules()
             mlog.debug('Boost library directory is', mlog.bold(self.libdir))
-
-        # 3. Report success or failure
-        if self.is_found:
-            self.log_success()
-        else:
-            self.log_fail()
 
     def check_invalid_modules(self):
         invalid_modules = [c for c in self.requested_modules if 'boost_' + c not in BOOST_LIBS]
@@ -172,17 +165,14 @@ class BoostDependency(ExternalDependency):
         else:
             return False
 
-    def log_fail(self):
+    def log_details(self):
         module_str = ', '.join(self.requested_modules)
-        mlog.log("Dependency Boost (%s) found:" % module_str, mlog.red('NO'))
+        return module_str
 
-    def log_success(self):
-        module_str = ', '.join(self.requested_modules)
+    def log_info(self):
         if self.boost_root:
-            info = self.version + ', ' + self.boost_root
-        else:
-            info = self.version
-        mlog.log('Dependency Boost (%s) found:' % module_str, mlog.green('YES'), info)
+            return self.boost_root
+        return ''
 
     def detect_nix_roots(self):
         return [os.path.abspath(os.path.join(x, '..'))

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -459,10 +459,7 @@ class PcapDependency(ExternalDependency):
 
     @staticmethod
     def get_methods():
-        if mesonlib.is_osx():
-            return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.EXTRAFRAMEWORK]
-        else:
-            return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL]
+        return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL]
 
     @staticmethod
     def get_pcap_lib_version(ctdep):
@@ -542,7 +539,4 @@ class LibWmfDependency(ExternalDependency):
 
     @staticmethod
     def get_methods():
-        if mesonlib.is_osx():
-            return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.EXTRAFRAMEWORK]
-        else:
-            return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL]
+        return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL]

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -14,6 +14,7 @@
 
 # This file contains the detection logic for miscellaneous external dependencies.
 
+import functools
 import os
 import re
 import shlex
@@ -436,26 +437,21 @@ class PcapDependency(ExternalDependency):
     @classmethod
     def _factory(cls, environment, kwargs):
         methods = cls._process_method_kw(kwargs)
-        if DependencyMethods.PKGCONFIG in methods:
-            try:
-                pcdep = PkgConfigDependency('pcap', environment, kwargs)
-                if pcdep.found():
-                    return pcdep
-            except Exception as e:
-                mlog.debug('Pcap not found via pkgconfig. Trying next, error was:', str(e))
-        if DependencyMethods.CONFIG_TOOL in methods:
-            try:
-                ctdep = ConfigToolDependency.factory(
-                    'pcap', environment, None, kwargs, ['pcap-config'], 'pcap-config')
-                if ctdep.found():
-                    ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
-                    ctdep.link_args = ctdep.get_config_value(['--libs'], 'link_args')
-                    ctdep.version = cls.get_pcap_lib_version(ctdep)
-                    return ctdep
-            except Exception as e:
-                mlog.debug('Pcap not found via pcap-config. Trying next, error was:', str(e))
+        candidates = []
 
-        return PcapDependency(environment, kwargs)
+        if DependencyMethods.PKGCONFIG in methods:
+            candidates.append(functools.partial(PkgConfigDependency, 'pcap', environment, kwargs))
+
+        if DependencyMethods.CONFIG_TOOL in methods:
+            candidates.append(functools.partial(ConfigToolDependency.factory,
+                    'pcap', environment, None, kwargs, ['pcap-config'], 'pcap-config'))
+#                if ctdep.found():
+#                    ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
+#                    ctdep.link_args = ctdep.get_config_value(['--libs'], 'link_args')
+#                    ctdep.version = cls.get_pcap_lib_version(ctdep)
+#                    return ctdep
+
+        return candidates
 
     @staticmethod
     def get_methods():
@@ -474,32 +470,27 @@ class CupsDependency(ExternalDependency):
     @classmethod
     def _factory(cls, environment, kwargs):
         methods = cls._process_method_kw(kwargs)
+        candidates = []
+
         if DependencyMethods.PKGCONFIG in methods:
-            try:
-                pcdep = PkgConfigDependency('cups', environment, kwargs)
-                if pcdep.found():
-                    return pcdep
-            except Exception as e:
-                mlog.debug('cups not found via pkgconfig. Trying next, error was:', str(e))
+            candidates.append(functools.partial(PkgConfigDependency, 'cups', environment, kwargs))
+
         if DependencyMethods.CONFIG_TOOL in methods:
-            try:
-                ctdep = ConfigToolDependency.factory(
-                    'cups', environment, None, kwargs, ['cups-config'], 'cups-config')
-                if ctdep.found():
-                    ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
-                    ctdep.link_args = ctdep.get_config_value(['--ldflags', '--libs'], 'link_args')
-                    return ctdep
-            except Exception as e:
-                mlog.debug('cups not found via cups-config. Trying next, error was:', str(e))
+            candidates.append(functools.partial(ConfigToolDependency.factory,
+                                                'cups', environment, None,
+                                                kwargs, ['cups-config'],
+                                                'cups-config'))
+#                if ctdep.found():
+#                    ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
+#                    ctdep.link_args = ctdep.get_config_value(['--ldflags', '--libs'], 'link_args')
+
         if DependencyMethods.EXTRAFRAMEWORK in methods:
             if mesonlib.is_osx():
-                fwdep = ExtraFrameworkDependency('cups', False, None, environment,
-                                                 kwargs.get('language', None), kwargs)
-                if fwdep.found():
-                    return fwdep
-        mlog.log('Dependency', mlog.bold('cups'), 'found:', mlog.red('NO'))
+                candidates.append(functools.partial(
+                    ExtraFrameworkDependency, 'cups', False, None, environment,
+                    kwargs.get('language', None), kwargs))
 
-        return CupsDependency(environment, kwargs)
+        return candidates
 
     @staticmethod
     def get_methods():
@@ -516,26 +507,21 @@ class LibWmfDependency(ExternalDependency):
     @classmethod
     def _factory(cls, environment, kwargs):
         methods = cls._process_method_kw(kwargs)
-        if DependencyMethods.PKGCONFIG in methods:
-            try:
-                kwargs['required'] = False
-                pcdep = PkgConfigDependency('libwmf', environment, kwargs)
-                if pcdep.found():
-                    return pcdep
-            except Exception as e:
-                mlog.debug('LibWmf not found via pkgconfig. Trying next, error was:', str(e))
-        if DependencyMethods.CONFIG_TOOL in methods:
-            try:
-                ctdep = ConfigToolDependency.factory(
-                    'libwmf', environment, None, kwargs, ['libwmf-config'], 'libwmf-config')
-                if ctdep.found():
-                    ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
-                    ctdep.link_args = ctdep.get_config_value(['--libs'], 'link_args')
-                    return ctdep
-            except Exception as e:
-                mlog.debug('cups not found via libwmf-config. Trying next, error was:', str(e))
+        candidates = []
 
-        return LibWmfDependency(environment, kwargs)
+        if DependencyMethods.PKGCONFIG in methods:
+            candidates.append(functools.partial(PkgConfigDependency, 'libwmf', environment, kwargs))
+
+        if DependencyMethods.CONFIG_TOOL in methods:
+            candidates.append(functools.partial(ConfigToolDependency.factory,
+                    'libwmf', environment, None, kwargs, ['libwmf-config'], 'libwmf-config'))
+
+#                if ctdep.found():
+#                    ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
+#                    ctdep.link_args = ctdep.get_config_value(['--libs'], 'link_args')
+#                    return ctdep
+
+        return candidates
 
     @staticmethod
     def get_methods():

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -103,11 +103,6 @@ class MPIDependency(ExternalDependency):
                 self.is_found = True
                 self.version, self.compile_args, self.link_args = result
 
-        if self.is_found:
-            mlog.log('Dependency', mlog.bold(self.name), 'for', self.language, 'found:', mlog.green('YES'), self.version)
-        else:
-            mlog.log('Dependency', mlog.bold(self.name), 'for', self.language, 'found:', mlog.red('NO'))
-
     def _filter_compile_args(self, args):
         """
         MPI wrappers return a bunch of garbage args.
@@ -265,10 +260,6 @@ class OpenMPDependency(ExternalDependency):
                 self.is_found = True
             else:
                 mlog.log(mlog.yellow('WARNING:'), 'OpenMP found but omp.h missing.')
-        if self.is_found:
-            mlog.log('Dependency', mlog.bold(self.name), 'found:', mlog.green('YES'), self.version)
-        else:
-            mlog.log('Dependency', mlog.bold(self.name), 'found:', mlog.red('NO'))
 
     def need_openmp(self):
         return True
@@ -324,10 +315,6 @@ class Python3Dependency(ExternalDependency):
                     self.compile_args = fw.get_compile_args()
                     self.link_args = fw.get_link_args()
                     self.is_found = True
-        if self.is_found:
-            mlog.log('Dependency', mlog.bold(self.name), 'found:', mlog.green('YES'))
-        else:
-            mlog.log('Dependency', mlog.bold(self.name), 'found:', mlog.red('NO'))
 
     @staticmethod
     def get_windows_python_arch():

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -38,7 +38,6 @@ class MPIDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
         language = kwargs.get('language', 'c')
         super().__init__('mpi', environment, language, kwargs)
-        required = kwargs.pop('required', True)
         kwargs['required'] = False
         kwargs['silent'] = True
         self.is_found = False
@@ -108,8 +107,6 @@ class MPIDependency(ExternalDependency):
             mlog.log('Dependency', mlog.bold(self.name), 'for', self.language, 'found:', mlog.green('YES'), self.version)
         else:
             mlog.log('Dependency', mlog.bold(self.name), 'for', self.language, 'found:', mlog.red('NO'))
-            if required:
-                raise DependencyException('MPI dependency {!r} not found'.format(self.name))
 
     def _filter_compile_args(self, args):
         """

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -444,14 +444,18 @@ class PcapDependency(ExternalDependency):
 
         if DependencyMethods.CONFIG_TOOL in methods:
             candidates.append(functools.partial(ConfigToolDependency.factory,
-                    'pcap', environment, None, kwargs, ['pcap-config'], 'pcap-config'))
-#                if ctdep.found():
-#                    ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
-#                    ctdep.link_args = ctdep.get_config_value(['--libs'], 'link_args')
-#                    ctdep.version = cls.get_pcap_lib_version(ctdep)
-#                    return ctdep
+                                                'pcap', environment, None,
+                                                kwargs, ['pcap-config'],
+                                                'pcap-config',
+                                                PcapDependency.tool_finish_init))
 
         return candidates
+
+    @staticmethod
+    def tool_finish_init(ctdep):
+        ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
+        ctdep.link_args = ctdep.get_config_value(['--libs'], 'link_args')
+        ctdep.version = PcapDependency.get_pcap_lib_version(ctdep)
 
     @staticmethod
     def get_methods():
@@ -479,10 +483,7 @@ class CupsDependency(ExternalDependency):
             candidates.append(functools.partial(ConfigToolDependency.factory,
                                                 'cups', environment, None,
                                                 kwargs, ['cups-config'],
-                                                'cups-config'))
-#                if ctdep.found():
-#                    ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
-#                    ctdep.link_args = ctdep.get_config_value(['--ldflags', '--libs'], 'link_args')
+                                                'cups-config', CupsDependency.tool_finish_init))
 
         if DependencyMethods.EXTRAFRAMEWORK in methods:
             if mesonlib.is_osx():
@@ -491,6 +492,11 @@ class CupsDependency(ExternalDependency):
                     kwargs.get('language', None), kwargs))
 
         return candidates
+
+    @staticmethod
+    def tool_finish_init(ctdep):
+        ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
+        ctdep.link_args = ctdep.get_config_value(['--ldflags', '--libs'], 'link_args')
 
     @staticmethod
     def get_methods():
@@ -514,14 +520,14 @@ class LibWmfDependency(ExternalDependency):
 
         if DependencyMethods.CONFIG_TOOL in methods:
             candidates.append(functools.partial(ConfigToolDependency.factory,
-                    'libwmf', environment, None, kwargs, ['libwmf-config'], 'libwmf-config'))
-
-#                if ctdep.found():
-#                    ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
-#                    ctdep.link_args = ctdep.get_config_value(['--libs'], 'link_args')
-#                    return ctdep
+                                                'libwmf', environment, None, kwargs, ['libwmf-config'], 'libwmf-config', LibWmfDependency.tool_finish_init))
 
         return candidates
+
+    @staticmethod
+    def tool_finish_init(ctdep):
+        ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
+        ctdep.link_args = ctdep.get_config_value(['--libs'], 'link_args')
 
     @staticmethod
     def get_methods():

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -227,10 +227,6 @@ class QtBaseDependency(ExternalDependency):
             self.link_args = []
             from_text = '(checked {})'.format(mlog.format_list(methods))
             self.version = 'none'
-            if self.required:
-                err_msg = '{} {} dependency not found {}' \
-                          ''.format(self.qtname, type_text, from_text)
-                raise DependencyException(err_msg)
             if not self.silent:
                 mlog.log(found_msg.format(from_text), mlog.red('NO'))
             return

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -464,10 +464,7 @@ class SDL2Dependency(ExternalDependency):
             candidates.append(functools.partial(ConfigToolDependency.factory,
                                                 'sdl2', environment, None,
                                                 kwargs, ['sdl2-config'],
-                                                'sdl2-config'))
-#                if ctdep.found():
-#                    ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
-#                    ctdep.link_args = ctdep.get_config_value(['--libs'], 'link_args')
+                                                'sdl2-config', SDL2Dependency.tool_finish_init))
 
         if DependencyMethods.EXTRAFRAMEWORK in methods:
             if mesonlib.is_osx():
@@ -476,6 +473,11 @@ class SDL2Dependency(ExternalDependency):
                                                     kwargs.get('language', None), kwargs))
                 # fwdep.version = '2'  # FIXME
         return candidates
+
+    @staticmethod
+    def tool_finish_init(ctdep):
+        ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
+        ctdep.link_args = ctdep.get_config_value(['--libs'], 'link_args')
 
     @staticmethod
     def get_methods():

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2939,11 +2939,12 @@ class LinuxlikeTests(BasePlatformTests):
             raise unittest.SkipTest('Qt not found with pkg-config')
         testdir = os.path.join(self.framework_test_dir, '4 qt')
         self.init(testdir, ['-Dmethod=pkg-config'])
-        # Confirm that the dependency was found with qmake
-        msg = 'Qt4 native `pkg-config` dependency (modules: Core, Gui) found: YES\n'
-        msg2 = 'Qt5 native `pkg-config` dependency (modules: Core, Gui) found: YES\n'
+        # Confirm that the dependency was found with pkg-config
         mesonlog = self.get_meson_log()
-        self.assertTrue(msg in mesonlog or msg2 in mesonlog)
+        self.assertRegex('\n'.join(mesonlog),
+                         r'Dependency qt4 \(modules: Core\) found: YES .*, `pkg-config`\n')
+        self.assertRegex('\n'.join(mesonlog),
+                         r'Dependency qt5 \(modules: Core\) found: YES .*, `pkg-config`\n')
 
     def test_qt5dependency_qmake_detection(self):
         '''
@@ -2961,10 +2962,9 @@ class LinuxlikeTests(BasePlatformTests):
         testdir = os.path.join(self.framework_test_dir, '4 qt')
         self.init(testdir, ['-Dmethod=qmake'])
         # Confirm that the dependency was found with qmake
-        msg = 'Qt5 native `qmake-qt5` dependency (modules: Core) found: YES\n'
-        msg2 = 'Qt5 native `qmake` dependency (modules: Core) found: YES\n'
         mesonlog = self.get_meson_log()
-        self.assertTrue(msg in mesonlog or msg2 in mesonlog)
+        self.assertRegex('\n'.join(mesonlog),
+                         r'Dependency qt5 \(modules: Core\) found: YES .*, `(qmake|qmake-qt5)`\n')
 
     def _test_soname_impl(self, libpath, install):
         if is_cygwin() or is_osx():


### PR DESCRIPTION
Motivated by the observation in #3095 that currently, we don't report if a dependency was not found before trying a fallback subproject.

(at the moment, if a dependency isn't found, `find_external_dependency()` either (i) logs that it wasn't found, if it is not required, or (ii) raises an exception, if it is required (that exception being held by `func_dependency()` while it checks if a workable fallback exists))
   
This is hard to fix straightforwardly because, at the moment, the `ExternalDependency`-derived constructor called by `find_external_dependency()` is responsible for reporting success or raising an exception if not found, but required.

This patch series consolidates that reporting and checking in `find_external_dependency()`.

This enables always logging the result of the dependency check, as well as removing some inconsistencies in how those checks are reported.

This might also help #3376 to simply report that "checking for dependency x was skipped, because the requirement for it was disabled"