### PR TITLE
Generate a preprocessor depfile for Windows resource compilation

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -282,6 +282,8 @@ the following special string substitutions:
 - `@OUTPUT0@` `@OUTPUT1@` `...` the full path to the output with the specified array index in `output`
 - `@OUTDIR@` the full path to the directory where the output(s) must be written
 - `@DEPFILE@` the full path to the dependency file passed to `depfile`
+- `@PLAINNAME@`: the input filename, without a path
+- `@BASENAME@`: the input filename, with extension removed
 
 The returned object also has methods that are documented in the
 [object methods section](#custom-target-object) below.

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -285,6 +285,9 @@ the following special string substitutions:
 - `@PLAINNAME@`: the input filename, without a path
 - `@BASENAME@`: the input filename, with extension removed
 
+The `depfile` keyword argument also accepts the `@BASENAME@` and `@PLAINNAME@`
+substitutions. *(since 0.47)*
+
 The returned object also has methods that are documented in the
 [object methods section](#custom-target-object) below.
 

--- a/docs/markdown/snippets/custom-target-depends.md
+++ b/docs/markdown/snippets/custom-target-depends.md
@@ -1,0 +1,4 @@
+## Substitutions in `custom_target(depends:)`
+
+The `depfile` keyword argument to `custom_target` now accepts the `@BASENAME@`
+and `@PLAINNAME@` substitutions.

--- a/docs/markdown/snippets/windows-resources-dependencies.md
+++ b/docs/markdown/snippets/windows-resources-dependencies.md
@@ -2,3 +2,6 @@
 
 The `compile_resources()` function of the `windows` module now takes
 the `depend_files:` keyword.
+
+When using binutils's `windres`, dependencies on files `#include`'d by the
+preprocessor are now automatically tracked.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -546,7 +546,8 @@ int dummy;
         else:
             cmd_type = 'custom'
         if target.depfile is not None:
-            rel_dfile = os.path.join(self.get_target_dir(target), target.depfile)
+            depfile = target.get_dep_outname(elem.infilenames)
+            rel_dfile = os.path.join(self.get_target_dir(target), depfile)
             abs_pdir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(target))
             os.makedirs(abs_pdir, exist_ok=True)
             elem.add_item('DEPFILE', rel_dfile)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1835,6 +1835,18 @@ class CustomTarget(Target):
     def get_generated_sources(self):
         return self.get_generated_lists()
 
+    def get_dep_outname(self, infilenames):
+        if self.depfile is None:
+            raise InvalidArguments('Tried to get depfile name for custom_target that does not have depfile defined.')
+        if len(infilenames):
+            plainname = os.path.basename(infilenames[0])
+            basename = os.path.splitext(plainname)[0]
+            return self.depfile.replace('@BASENAME@', basename).replace('@PLAINNAME@', plainname)
+        else:
+            if '@BASENAME@' in self.depfile or '@PLAINNAME@' in self.depfile:
+                raise InvalidArguments('Substitution in depfile for custom_target that does not have an input file.')
+            return self.depfile
+
     def type_suffix(self):
         return "@cus"
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2939,6 +2939,8 @@ root and issuing %s.
     def func_custom_target(self, node, args, kwargs):
         if len(args) != 1:
             raise InterpreterException('custom_target: Only one positional argument is allowed, and it must be a string name')
+        if 'depfile' in kwargs and ('@BASENAME@' in kwargs['depfile'] or '@PLAINNAME@' in kwargs['depfile']):
+            FeatureNew('substitutions in custom_target depfile', '0.47.0').use()
         name = args[0]
         kwargs['install_mode'] = self._get_kwarg_install_mode(kwargs)
         tg = CustomTargetHolder(build.CustomTarget(name, self.subdir, self.subproject, kwargs), self)

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -100,6 +100,11 @@ class WindowsModule(ExtensionModule):
             # Path separators are not allowed in target names
             name = name.replace('/', '_').replace('\\', '_')
 
+            # instruct binutils windres to generate a preprocessor depfile
+            if comp.id != 'msvc':
+                res_kwargs['depfile'] = res_kwargs['output'] + '.d'
+                res_kwargs['command'] += ['--preprocessor-arg=-MD', '--preprocessor-arg=-MQ@OUTPUT@', '--preprocessor-arg=-MF@DEPFILE@']
+
             res_targets.append(build.CustomTarget('Windows resource for ' + name, state.subdir, state.subproject, res_kwargs))
 
         add_target(args)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2397,9 +2397,15 @@ class WindowsTests(BasePlatformTests):
         self.build()
         # Immediately rebuilding should not do anything
         self.assertBuildIsNoop()
-        # Changing mtime of sample.ico should rebuild everything
+        # Changing mtime of sample.ico should rebuild prog
         self.utime(os.path.join(testdir, 'res', 'sample.ico'))
         self.assertRebuiltTarget('prog')
+        # Changing mtime of resource.h should rebuild myres.rc and then prog
+        # (resource compiler depfile generation is not yet implemented for msvc)
+        env = Environment(testdir, self.builddir, get_fake_options(self.prefix), [])
+        if env.detect_c_compiler(False).get_id() != 'msvc':
+            self.utime(os.path.join(testdir, 'inc', 'resource', 'resource.h'))
+            self.assertRebuiltTarget('prog')
 
 
 class LinuxlikeTests(BasePlatformTests):

--- a/test cases/windows/13 resources with custom targets/res/meson.build
+++ b/test cases/windows/13 resources with custom targets/res/meson.build
@@ -10,9 +10,10 @@ foreach id : [1, 2]
         output : 'myres_@0@.rc'.format(id),
         command : [rc_writer, '@INPUT@', '@OUTPUT@', files('sample.ico')],
         install : false,
-        build_always : true)
+        build_always : false)
 endforeach
 
 rc_sources += files('myres_static.rc')
 
-res = win.compile_resources(rc_sources)
+res = win.compile_resources(rc_sources,
+    include_directories: include_directories('.'))

--- a/test cases/windows/13 resources with custom targets/res/myres.rc.in
+++ b/test cases/windows/13 resources with custom targets/res/myres.rc.in
@@ -1,3 +1,4 @@
 #include<windows.h>
+#include<resource.h>
 
 1 ICON "{icon}"

--- a/test cases/windows/5 resources/prog.c
+++ b/test cases/windows/5 resources/prog.c
@@ -1,5 +1,7 @@
 #include<windows.h>
 
+// deliberately don't get MY_ICON from resource.h so that depfile generation can
+// be exercised in the WindowsTests.test_rc_depends_files unit test
 #define MY_ICON 1
 
 int APIENTRY


### PR DESCRIPTION
As mused on in #2789, this enhances the custom target for invoking the Windows resource compiler so that a depfile is generated by the preprocessor.

This is currently only implemented when using binutils `windres` , and not when using MSVC's `RC`.
