### PR TITLE
Fix #mesondefine token error message formatting

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -604,7 +604,7 @@ def do_replacement(regex, line, format, confdata):
 def do_mesondefine(line, confdata):
     arr = line.split()
     if len(arr) != 2:
-        raise MesonException('#mesondefine does not contain exactly two tokens: %s', line.strip())
+        raise MesonException('#mesondefine does not contain exactly two tokens: %s' % line.strip())
     varname = arr[1]
     try:
         (v, desc) = confdata.get(varname)


### PR DESCRIPTION
Meson would return a message like:

```
ERROR:  ('#mesondefine does not contain exactly two tokens: %s', '#mesondefine _WIN32_WINNT /* Define for Windows 7 APIs. */')
```

which does not seem is intended. This PR corrects the string formatting used, so the error message now will look like:

```
ERROR:  #mesondefine does not contain exactly two tokens: #mesondefine _FILE_OFFSET_BITS 64
```