### PR TITLE
has_function: Improve builtin detection

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -678,10 +678,7 @@ class CCompiler(Compiler):
             head, main = self._no_prototype_templ()
         templ = head + stubs_fail + main
 
-        # Don't run the ordinary test for functions that are known to be
-        # built-ins because it will always fail to detect them.
-        if not funcname.startswith('__builtin_') and \
-           self.links(templ.format(**fargs), env, extra_args, dependencies):
+        if self.links(templ.format(**fargs), env, extra_args, dependencies):
             return True
 
         # MSVC does not have compiler __builtin_-s.

--- a/test cases/common/43 has function/meson.build
+++ b/test cases/common/43 has function/meson.build
@@ -8,9 +8,11 @@ defines_has_builtin = '''#ifndef __has_builtin
 #error "no __has_builtin"
 #endif
 '''
-compilers = [meson.get_compiler('c'), meson.get_compiler('cpp')]
+langs = ['c', 'cpp']
 
-foreach cc : compilers
+foreach lang : langs
+  message('Running tests with @0@ compiler'.format(lang))
+  cc = meson.get_compiler(lang)
   if not cc.has_function('printf', prefix : '#include<stdio.h>',
                          args : unit_test_args)
     error('"printf" function not found (should always exist).')
@@ -71,10 +73,10 @@ foreach cc : compilers
            args : unit_test_args),
            'built-in alloca must be found with #include')
     if not cc.compiles(defines_has_builtin, args : unit_test_args)
-      assert(not cc.has_function('alloca',
+      assert(cc.has_function('alloca',
              prefix : '#include <alloca.h>\n#undef alloca',
              args : unit_test_args),
-             'built-in alloca must not be found with #include and #undef')
+             'built-in alloca must be found with #include and #undef')
     endif
   endif
 
@@ -87,5 +89,28 @@ foreach cc : compilers
     # We assume that if recvmmsg exists sendmmsg does too
     assert (cc.has_function('sendmmsg', args : unit_test_args),
             'Failed to detect function "sendmmsg" (should always exist).')
+  endif
+
+  # On MinGW, strndup was incorrectly detected as available with has_function
+  # even though it is not, so if it is detected by has_function, assert that it
+  # can actually be found by the linker.
+  if cc.has_function('strndup', args : unit_test_args)
+    assert(cc.has_function('strndup', prefix: '#include <string.h>', args : unit_test_args),
+           'strndup not found with prefix')
+    assert(cc.links('#include <string.h>\nint main() { char *s = strndup ("string", 1); }',
+                    args : unit_test_args),
+           'strndup incorrectly detected')
+  endif
+
+  # This is meant to be used as __builtin_smul_overflow, so we shouldn't find the unbuiltin version
+  if ['gcc', 'clang'].contains(cc.get_id())
+    assert(cc.has_function('__builtin_smul_overflow', args : unit_test_args),
+           '__builtin_smul_overflow must be found')
+    # FIXME: this fails on gcc, and we can't fix it without breaking builtin
+    # detection without headers for things like alloca()
+    if cc.get_id() == 'clang'
+      assert(not cc.has_function('smul_overflow', args : unit_test_args),
+             'smul_overflow is __builtin_smul_overflow and must not be found')
+    endif
   endif
 endforeach

--- a/test cases/common/43 has function/meson.build
+++ b/test cases/common/43 has function/meson.build
@@ -102,8 +102,9 @@ foreach lang : langs
            'strndup incorrectly detected')
   endif
 
-  # This is meant to be used as __builtin_smul_overflow, so we shouldn't find the unbuiltin version
+  # Test various builtins
   if ['gcc', 'clang'].contains(cc.get_id())
+    # This is meant to be used as __builtin_smul_overflow, so we shouldn't find the unbuiltin version
     assert(cc.has_function('__builtin_smul_overflow', args : unit_test_args),
            '__builtin_smul_overflow must be found')
     # FIXME: this fails on gcc, and we can't fix it without breaking builtin
@@ -112,5 +113,26 @@ foreach lang : langs
       assert(not cc.has_function('smul_overflow', args : unit_test_args),
              'smul_overflow is __builtin_smul_overflow and must not be found')
     endif
+    # Math builtins
+    if lang == 'c'
+      foreach bf: ['fpclassify', 'isfinite', 'isnormal', 'isgreater', 'isnan',
+                   'isgreaterequal', 'isless', 'islessequal', 'islessgreater',
+                   'isunordered']
+        assert(cc.has_function(bf, prefix : '#include <math.h>', args : unit_test_args),
+               '@0@ must be found'.format(bf))
+      endforeach
+    endif
+    # String builtins
+    foreach bf: ['strncpy', 'strncat', 'strcspn', 'strspn']
+      assert(cc.has_function(bf, args : unit_test_args),
+             '@0@ must be found'.format(bf))
+    endforeach
+    # Other builtins
+    assert(cc.has_function('offsetof', prefix : '#include <stddef.h>', args : unit_test_args),
+           'offsetof must be found')
+    foreach bf: ['va_start', 'va_end', 'va_arg']
+      assert(cc.has_function(bf, prefix : '#include <stdarg.h>', args : unit_test_args),
+             '@0@ must be found'.format(bf))
+    endforeach
   endif
 endforeach


### PR DESCRIPTION
* has_function: Improve built-in detection with headers

  - __has_builtin(foo) is more correct and more reliable than __has_builtin(__builtin_foo)
  - If detection of built-ins with headers fails in the first check because we can't take the address of a built-in, we can do an ordinary check.

We can't always do this ordinary check because clang on macOS ld removes the symbol when using -Wl,-no_weak_imports, which is needed for being able to target the correct platform with XCode 8 and newer.

Closes https://github.com/mesonbuild/meson/issues/3672

* has_function: Fix checking for __builtin_foo functions

Some functions are meant to be used only as compiler builtins, such as `__builtin_smul_overflow` and friends.

Detect this case and don't look for `__builtin_foo` because such a check will never include a header.

Fixes https://github.com/mesonbuild/meson/issues/3676
