### PR TITLE
Feature fixes

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -25,7 +25,7 @@ from .mesonlib import typeslistify, stringlistify, classify_unity_sources
 from .mesonlib import get_filenames_templates_dict, substitute_values
 from .mesonlib import for_windows, for_darwin, for_cygwin, for_android, has_path_sep
 from .compilers import is_object, clink_langs, sort_clink, lang_suffixes
-from .interpreterbase import FeatureNew, FeatureNewKwargs
+from .interpreterbase import FeatureNew
 
 pch_kwargs = set(['c_pch', 'cpp_pch'])
 
@@ -332,9 +332,6 @@ a hard error in the future.''' % name)
             myid = subdir_part + '@@' + myid
         return myid
 
-    @FeatureNewKwargs('build target', '0.42.0', ['rust_crate_type', 'build_rpath', 'implicit_include_directories'])
-    @FeatureNewKwargs('build target', '0.41.0', ['rust_args'])
-    @FeatureNewKwargs('build target', '0.40.0', ['build_by_default'])
     def process_kwargs(self, kwargs):
         if 'build_by_default' in kwargs:
             self.build_by_default = kwargs['build_by_default']
@@ -1095,7 +1092,6 @@ recommended as it is not supported on some platforms''')
                 return
 
 class Generator:
-    @FeatureNewKwargs('generator', '0.43.0', ['capture'])
     def __init__(self, args, kwargs):
         if len(args) != 1:
             raise InvalidArguments('Generator requires exactly one positional argument: the executable')

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -504,6 +504,7 @@ class ExternalLibraryHolder(InterpreterObject, ObjectHolder):
         return DependencyHolder(self.held_object.get_partial_dependency(**kwargs))
 
 class GeneratorHolder(InterpreterObject, ObjectHolder):
+    @FeatureNewKwargs('generator', '0.43.0', ['capture'])
     def __init__(self, interpreter, args, kwargs):
         InterpreterObject.__init__(self)
         self.interpreter = interpreter
@@ -3790,6 +3791,14 @@ Try setting b_lundef to false instead.''')
             raise InterpreterException('Unknown default_library value: %s.', default_library)
 
     def build_target(self, node, args, kwargs, targetholder):
+        @FeatureNewKwargs('build target', '0.42.0', ['rust_crate_type', 'build_rpath', 'implicit_include_directories'])
+        @FeatureNewKwargs('build target', '0.41.0', ['rust_args'])
+        @FeatureNewKwargs('build target', '0.40.0', ['build_by_default'])
+        def build_target_decorator_caller(self, node, args, kwargs):
+            return True
+
+        build_target_decorator_caller(self, node, args, kwargs)
+
         if not args:
             raise InterpreterException('Target does not have a name.')
         name = args[0]

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1697,7 +1697,7 @@ class MesonMain(InterpreterObject):
     @permittedKwargs({})
     def is_unity_method(self, args, kwargs):
         optval = self.interpreter.environment.coredata.get_builtin_option('unity')
-        if optval == 'on' or (optval == 'subprojects' and self.interpreter.subproject != ''):
+        if optval == 'on' or (optval == 'subprojects' and self.interpreter.is_subproject()):
             return True
         return False
 
@@ -3603,7 +3603,7 @@ different subdirectory.
         self.add_project_arguments(node, self.build.projects_link_args, args, kwargs)
 
     def add_global_arguments(self, node, argsdict, args, kwargs):
-        if self.subproject != '':
+        if self.is_subproject():
             msg = 'Function \'{}\' cannot be used in subprojects because ' \
                   'there is no way to make that reliable.\nPlease only call ' \
                   'this if is_subproject() returns false. Alternatively, ' \
@@ -3708,7 +3708,7 @@ Try setting b_lundef to false instead.''')
         (num_sps, sproj_name) = self.evaluate_subproject_info(norm, self.subproject_dir)
         plain_filename = os.path.basename(norm)
         if num_sps == 0:
-            if self.subproject == '':
+            if not self.is_subproject():
                 return
             raise InterpreterException('Sandbox violation: Tried to grab file %s from a different subproject.' % plain_filename)
         if num_sps > 1:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -328,7 +328,7 @@ This will become a hard error in the future''')
             return args[1]
         raise InterpreterException('Entry %s not in configuration data.' % name)
 
-    @FeatureNew('get_unquoted', '0.44.0')
+    @FeatureNew('configuration_data.get_unquoted', '0.44.0')
     def get_unquoted_method(self, args, kwargs):
         if len(args) < 1 or len(args) > 2:
             raise InterpreterException('Get method takes one or two arguments.')
@@ -401,7 +401,7 @@ class DependencyHolder(InterpreterObject, ObjectHolder):
             raise InterpreterException('Variable name must be a string.')
         return self.held_object.get_pkgconfig_variable(varname, kwargs)
 
-    @FeatureNew('get_configtool_variable', '0.44.0')
+    @FeatureNew('dep.get_configtool_variable', '0.44.0')
     @permittedKwargs({})
     def configtool_method(self, args, kwargs):
         args = listify(args)
@@ -1312,7 +1312,7 @@ class CompilerHolder(InterpreterObject):
             mlog.log('Checking if "', mlog.bold(testname), '" links: ', h, sep='')
         return result
 
-    @FeatureNew('check_header', '0.47.0')
+    @FeatureNew('compiler.check_header', '0.47.0')
     @permittedKwargs({
         'prefix',
         'no_builtin_args',
@@ -1461,7 +1461,7 @@ class CompilerHolder(InterpreterObject):
         mlog.log('First supported argument:', mlog.red('None'))
         return []
 
-    @FeatureNew('has_link_argument', '0.46.0')
+    @FeatureNew('compiler.has_link_argument', '0.46.0')
     @permittedKwargs({})
     def has_link_argument_method(self, args, kwargs):
         args = mesonlib.stringlistify(args)
@@ -1469,7 +1469,7 @@ class CompilerHolder(InterpreterObject):
             raise InterpreterException('has_link_argument takes exactly one argument.')
         return self.has_multi_link_arguments_method(args, kwargs)
 
-    @FeatureNew('has_multi_link_argument', '0.46.0')
+    @FeatureNew('compiler.has_multi_link_argument', '0.46.0')
     @permittedKwargs({})
     def has_multi_link_arguments_method(self, args, kwargs):
         args = mesonlib.stringlistify(args)
@@ -1484,7 +1484,7 @@ class CompilerHolder(InterpreterObject):
             h)
         return result
 
-    @FeatureNew('get_supported_link_arguments_method', '0.46.0')
+    @FeatureNew('compiler.get_supported_link_arguments_method', '0.46.0')
     @permittedKwargs({})
     def get_supported_link_arguments_method(self, args, kwargs):
         args = mesonlib.stringlistify(args)
@@ -1494,7 +1494,7 @@ class CompilerHolder(InterpreterObject):
                 supported_args.append(arg)
         return supported_args
 
-    @FeatureNew('first_supported_link_argument_method', '0.46.0')
+    @FeatureNew('compiler.first_supported_link_argument_method', '0.46.0')
     @permittedKwargs({})
     def first_supported_link_argument_method(self, args, kwargs):
         for i in mesonlib.stringlistify(args):
@@ -1714,7 +1714,7 @@ class MesonMain(InterpreterObject):
             raise InterpreterException('Argument must be a string.')
         self.build.dep_manifest_name = args[0]
 
-    @FeatureNew('override_find_program', '0.46.0')
+    @FeatureNew('meson.override_find_program', '0.46.0')
     @permittedKwargs({})
     def override_find_program_method(self, args, kwargs):
         if len(args) != 2:
@@ -2478,7 +2478,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         argstr = self.get_message_string_arg(node)
         mlog.log(mlog.bold('Message:'), argstr)
 
-    @FeatureNew('warning()', '0.44.0')
+    @FeatureNew('warning', '0.44.0')
     @noKwargs
     def func_warning(self, node, args, kwargs):
         argstr = self.get_message_string_arg(node)
@@ -2973,7 +2973,7 @@ root and issuing %s.
     def func_both_lib(self, node, args, kwargs):
         return self.build_both_libraries(node, args, kwargs)
 
-    @FeatureNew('Shared Modules', '0.37.0')
+    @FeatureNew('shared_module', '0.37.0')
     @permittedKwargs(permitted_kwargs['shared_module'])
     def func_shared_module(self, node, args, kwargs):
         return self.build_target(node, args, kwargs, SharedModuleHolder)

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -131,6 +131,8 @@ class permittedKwargs:
             return f(*wrapped_args, **wrapped_kwargs)
         return wrapped
 
+# TODO: Share code between FeatureNew, FeatureDeprecated, FeatureNewKwargs,
+# and FeatureDeprecatedKwargs
 class FeatureNew:
     """Checks for new features"""
     # Shared across all instances
@@ -149,12 +151,13 @@ class FeatureNew:
         self.feature_versions[self.feature_version].add(self.feature_name)
         return True
 
-    def called_features_report():
-        if not FeatureNew.feature_warnings:
+    @classmethod
+    def called_features_report(cls):
+        if not cls.feature_warnings:
             return
         warning_str = 'Invalid minimum meson_version \'{}\' conflicts with:'\
             .format(mesonlib.target_version)
-        fv = FeatureNew.feature_versions
+        fv = cls.feature_versions
         for version in sorted(fv.keys()):
             warning_str += '\n * {}: {}'.format(version, fv[version])
         mlog.warning(warning_str)
@@ -196,11 +199,12 @@ class FeatureDeprecated:
         self.feature_versions[self.feature_version].add(self.feature_name)
         return True
 
-    def called_features_report():
-        if not FeatureDeprecated.feature_warnings:
+    @classmethod
+    def called_features_report(cls):
+        if not cls.feature_warnings:
             return
         warning_str = 'Deprecated features used:'.format(mesonlib.target_version)
-        fv = FeatureDeprecated.feature_versions
+        fv = cls.feature_versions
         for version in sorted(fv.keys()):
             warning_str += '\n * {}: {}'.format(version, fv[version])
         mlog.warning(warning_str)

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -32,18 +32,26 @@ def check_stringlist(a, msg='Arguments must be strings.'):
         raise InvalidArguments(msg)
 
 def _get_callee_args(wrapped_args):
-    # Functions have 4 positional args and methods have 3.
     s = wrapped_args[0]
-    if len(wrapped_args) == 3:
+    n = len(wrapped_args)
+    if n == 3:
+        # Methods on objects (Holder, MesonMain, etc) have 3 args: self, args, kwargs
         node_or_state = None
         args = wrapped_args[1]
         kwargs = wrapped_args[2]
-    elif len(wrapped_args) == 4:
+    elif n == 4:
+        # Meson functions have 4 args: self, node, args, kwargs
+        # Module functions have 4 args: self, state, args, kwargs
         node_or_state = wrapped_args[1]
         args = wrapped_args[2]
         kwargs = wrapped_args[3]
+    elif n == 5:
+        # Module snippets have 5 args: self, interpreter, state, args, kwargs
+        node_or_state = wrapped_args[2]
+        args = wrapped_args[3]
+        kwargs = wrapped_args[4]
     else:
-        raise InvalidArguments('Expecting 3 or 4 args, got {}'.format(len(wrapped_args)))
+        raise AssertionError('Expecting 3, 4, or 5 args, got: {!r}'.format(wrapped_args))
 
     # Sometimes interpreter methods are called internally with None instead of
     # empty list/dict

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -396,6 +396,12 @@ def grab_leading_numbers(vstr, strict=False):
             break
     return result
 
+def make_same_len(listA, listB):
+    maxlen = max(len(listA), len(listB))
+    for i in listA, listB:
+        for n in range(len(i), maxlen):
+            i.append(0)
+
 numpart = re.compile('[0-9.]+')
 
 def version_compare(vstr1, vstr2, strict=False):
@@ -429,6 +435,7 @@ def version_compare(vstr1, vstr2, strict=False):
         cmpop = operator.eq
     varr1 = grab_leading_numbers(vstr1, strict)
     varr2 = grab_leading_numbers(vstr2, strict)
+    make_same_len(varr1, varr2)
     return cmpop(varr1, varr2)
 
 def version_compare_many(vstr1, conditions):
@@ -451,7 +458,7 @@ def version_compare_condition_with_min(condition, minimum):
         raise MesonException(msg.format(minimum))
     minimum = match.group(0)
     if condition.startswith('>='):
-        cmpop = operator.lt
+        cmpop = operator.le
         condition = condition[2:]
     elif condition.startswith('<='):
         return True
@@ -460,10 +467,10 @@ def version_compare_condition_with_min(condition, minimum):
         return True
         condition = condition[2:]
     elif condition.startswith('=='):
-        cmpop = operator.lt
+        cmpop = operator.le
         condition = condition[2:]
     elif condition.startswith('='):
-        cmpop = operator.lt
+        cmpop = operator.le
         condition = condition[1:]
     elif condition.startswith('>'):
         cmpop = operator.lt
@@ -472,9 +479,10 @@ def version_compare_condition_with_min(condition, minimum):
         return True
         condition = condition[2:]
     else:
-        cmpop = operator.eq
+        cmpop = operator.le
     varr1 = grab_leading_numbers(minimum, True)
     varr2 = grab_leading_numbers(condition, True)
+    make_same_len(varr1, varr2)
     return cmpop(varr1, varr2)
 
 def version_compare_condition_with_max(condition, maximum):
@@ -487,27 +495,28 @@ def version_compare_condition_with_max(condition, maximum):
         return False
         condition = condition[2:]
     elif condition.startswith('<='):
-        cmpop = operator.lt
+        cmpop = operator.ge
         condition = condition[2:]
     elif condition.startswith('!='):
         return False
         condition = condition[2:]
     elif condition.startswith('=='):
-        cmpop = operator.lt
+        cmpop = operator.ge
         condition = condition[2:]
     elif condition.startswith('='):
-        cmpop = operator.lt
+        cmpop = operator.ge
         condition = condition[1:]
     elif condition.startswith('>'):
         return False
         condition = condition[1:]
     elif condition.startswith('<'):
-        cmpop = operator.lt
+        cmpop = operator.gt
         condition = condition[2:]
     else:
-        cmpop = operator.eq
+        cmpop = operator.ge
     varr1 = grab_leading_numbers(maximum, True)
     varr2 = grab_leading_numbers(condition, True)
+    make_same_len(varr1, varr2)
     return cmpop(varr1, varr2)
 
 

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -3,19 +3,6 @@ import os
 from .. import build
 from .. import mlog
 
-class permittedSnippetKwargs:
-
-    def __init__(self, permitted):
-        self.permitted = permitted
-
-    def __call__(self, f):
-        def wrapped(s, interpreter, state, args, kwargs):
-            for k in kwargs:
-                if k not in self.permitted:
-                    mlog.warning('Passed invalid keyword argument "%s". This will become a hard error in the future.' % k)
-            return f(s, interpreter, state, args, kwargs)
-        return wrapped
-
 
 class ExtensionModule:
     def __init__(self, interpreter):

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from .. import mesonlib
 from . import ExtensionModule
 from mesonbuild.modules import ModuleReturnValue
-from . import permittedSnippetKwargs
 from ..interpreterbase import (
     noPosargs, noKwargs, permittedKwargs,
     InterpreterObject, InvalidArguments,
@@ -284,7 +283,7 @@ class PythonInstallation(ExternalProgramHolder, InterpreterObject):
         self.platform = run_command(python, "import sysconfig; print (sysconfig.get_platform())")
         self.is_pypy = json.loads(run_command(python, IS_PYPY_COMMAND))
 
-    @permittedSnippetKwargs(mod_kwargs)
+    @permittedKwargs(mod_kwargs)
     def extension_module(self, interpreter, state, args, kwargs):
         if 'subdir' in kwargs and 'install_dir' in kwargs:
             raise InvalidArguments('"subdir" and "install_dir" are mutually exclusive')
@@ -312,7 +311,7 @@ class PythonInstallation(ExternalProgramHolder, InterpreterObject):
         dep = PythonDependency(self, interpreter.environment, kwargs)
         return interpreter.holderify(dep)
 
-    @permittedSnippetKwargs(['pure', 'subdir'])
+    @permittedKwargs(['pure', 'subdir'])
     def install_sources(self, interpreter, state, args, kwargs):
         pure = kwargs.pop('pure', False)
         if not isinstance(pure, bool):
@@ -450,7 +449,7 @@ class PythonModule(ExtensionModule):
         else:
             return None
 
-    @permittedSnippetKwargs(['required'])
+    @permittedKwargs(['required'])
     def find_installation(self, interpreter, state, args, kwargs):
         required = kwargs.get('required', True)
         if not isinstance(required, bool):

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -50,7 +50,6 @@ def run_command(python, command):
 
 class PythonDependency(ExternalDependency):
 
-    @FeatureNew('Python Module', '0.46.0')
     def __init__(self, python_holder, environment, kwargs):
         super().__init__('python', environment, None, kwargs)
         self.name = 'python'
@@ -432,6 +431,8 @@ class PythonInstallation(ExternalProgramHolder, InterpreterObject):
 
 
 class PythonModule(ExtensionModule):
+
+    @FeatureNew('Python Module', '0.46.0')
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.snippets.add('find_installation')

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -17,8 +17,7 @@ from .. import mesonlib, dependencies
 
 from . import ExtensionModule
 from mesonbuild.modules import ModuleReturnValue
-from . import permittedSnippetKwargs
-from ..interpreterbase import noKwargs
+from ..interpreterbase import noKwargs, permittedKwargs
 from ..build import known_shmod_kwargs
 
 
@@ -27,7 +26,7 @@ class Python3Module(ExtensionModule):
         super().__init__(*args, **kwargs)
         self.snippets.add('extension_module')
 
-    @permittedSnippetKwargs(known_shmod_kwargs)
+    @permittedKwargs(known_shmod_kwargs)
     def extension_module(self, interpreter, state, args, kwargs):
         if 'name_prefix' in kwargs:
             raise mesonlib.MesonException('Name_prefix is set automatically, specifying it is forbidden.')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -37,7 +37,7 @@ from mesonbuild.interpreter import ObjectHolder
 from mesonbuild.mesonlib import (
     is_windows, is_osx, is_cygwin, is_dragonflybsd,
     windows_proof_rmtree, python_command, version_compare,
-    BuildDirLock
+    grab_leading_numbers, BuildDirLock
 )
 from mesonbuild.environment import Environment, detect_ninja
 from mesonbuild.mesonlib import MesonException, EnvironmentException
@@ -2303,21 +2303,34 @@ class FailureTests(BasePlatformTests):
             # Must run in-process or we'll get a generic CalledProcessError
             self.init(self.srcdir, extra_args=extra_args, inprocess=True)
 
-    def assertMesonOutputs(self, contents, match, extra_args=None, langs=None):
-        '''
-        Assert that running meson configure on the specified @contents outputs
-        something that matches regex @match.
-        '''
+    def obtainMesonOutput(self, contents, match, extra_args, langs, meson_version):
         if langs is None:
             langs = []
         with open(self.mbuild, 'w') as f:
-            f.write("project('output test', 'c', 'cpp')\n")
+            core_version = '.'.join([str(component) for component in grab_leading_numbers(mesonbuild.coredata.version)])
+            meson_version = meson_version or core_version
+            f.write("project('output test', 'c', 'cpp', meson_version: '{}')\n".format(meson_version))
             for lang in langs:
                 f.write("add_languages('{}', required : false)\n".format(lang))
             f.write(contents)
         # Run in-process for speed and consistency with assertMesonRaises
-        out = self.init(self.srcdir, extra_args=extra_args, inprocess=True)
+        return self.init(self.srcdir, extra_args=extra_args, inprocess=True)
+
+    def assertMesonOutputs(self, contents, match, extra_args=None, langs=None, meson_version=None):
+        '''
+        Assert that running meson configure on the specified @contents outputs
+        something that matches regex @match.
+        '''
+        out = self.obtainMesonOutput(contents, match, extra_args, langs, meson_version)
         self.assertRegex(out, match)
+
+    def assertMesonDoesNotOutput(self, contents, match, extra_args=None, langs=None, meson_version=None):
+        '''
+        Assert that running meson configure on the specified @contents does not output
+        something that matches regex @match.
+        '''
+        out = self.obtainMesonOutput(contents, match, extra_args, langs, meson_version)
+        self.assertNotRegex(out, match)
 
     @skipIfNoPkgconfig
     def test_dependency(self):
@@ -2461,6 +2474,18 @@ class FailureTests(BasePlatformTests):
     def test_dict_forbids_integer_key(self):
         self.assertMesonRaises("dict = {3: 'foo'}",
                                'Key must be a string.*')
+
+    def test_using_too_recent_feature(self):
+        # Here we use a dict, which was introduced in 0.47.0
+        self.assertMesonOutputs("dict = {}",
+                                ".*WARNING.*Project targetting.*but.*",
+                                meson_version='>= 0.46.0')
+
+    def test_using_recent_feature(self):
+        # Same as above, except the meson version is now appropriate
+        self.assertMesonDoesNotOutput("dict = {}",
+                                      ".*WARNING.*Project targetting.*but.*",
+                                      meson_version='>= 0.47.0')
 
 
 class WindowsTests(BasePlatformTests):


### PR DESCRIPTION
The decorators now handle correctly the kwargs.

I'm not really fond of the dummy function
```
 +        def build_target_decorator_caller(self, node, args, kwargs):
+            return True 
```
But it's required to comply to the `_get_callee_args`. Or else we should duplicate the `@FeatureNewKwargs` between all the build targets.