### PR TITLE
Identify statically-linked symbols that are needed by modules

### DIFF
--- a/cross/linux-mingw-w64-32bit.txt
+++ b/cross/linux-mingw-w64-32bit.txt
@@ -2,6 +2,7 @@
 c = '/usr/bin/i686-w64-mingw32-gcc'
 cpp = '/usr/bin/i686-w64-mingw32-g++'
 ar = '/usr/bin/i686-w64-mingw32-ar'
+nm = '/usr/bin/i686-w64-mingw32-nm'
 strip = '/usr/bin/i686-w64-mingw32-strip'
 pkgconfig = '/usr/bin/i686-w64-mingw32-pkg-config'
 windres = '/usr/bin/i686-w64-mingw32-windres'

--- a/cross/linux-mingw-w64-64bit.txt
+++ b/cross/linux-mingw-w64-64bit.txt
@@ -2,6 +2,7 @@
 c = '/usr/bin/x86_64-w64-mingw32-gcc'
 cpp = '/usr/bin/x86_64-w64-mingw32-g++'
 ar = '/usr/bin/x86_64-w64-mingw32-ar'
+nm = '/usr/bin/x86_64-w64-mingw32-nm'
 strip = '/usr/bin/x86_64-w64-mingw32-strip'
 pkgconfig = '/usr/bin/x86_64-w64-mingw32-pkg-config'
 windres = '/usr/bin/x86_64-w64-mingw32-windres'

--- a/cross/ubuntu-armhf.txt
+++ b/cross/ubuntu-armhf.txt
@@ -5,6 +5,7 @@ c = '/usr/bin/arm-linux-gnueabihf-gcc'
 cpp = '/usr/bin/arm-linux-gnueabihf-g++'
 rust = ['rustc', '--target', 'arm-unknown-linux-gnueabihf', '-C', 'linker=/usr/bin/arm-linux-gnueabihf-gcc-7']
 ar = '/usr/arm-linux-gnueabihf/bin/ar'
+nm = '/usr/arm-linux-gnueabihf/bin/nm'
 strip = '/usr/arm-linux-gnueabihf/bin/strip'
 pkgconfig = '/usr/bin/arm-linux-gnueabihf-pkg-config'
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2342,9 +2342,10 @@ rule FORTRAN_DEP_HACK%s
             return []
         return linker.get_no_stdlib_link_args()
 
-    def get_undefsym_response_file_args(self, target):
+    def get_undefsym_response_file_args(self, target, linker):
         response_files = []
-        if isinstance(target, build.Executable):
+        if isinstance(target, build.Executable) and \
+                linker.options_support_undefsymbols_args(self.get_base_options_for_target(target)):
             for t in target.modules:
                 undefsym_filename = self.get_undefsym_filename(t)
                 response_files += ['@' + undefsym_filename]
@@ -2602,7 +2603,7 @@ rule FORTRAN_DEP_HACK%s
         dep_targets.extend([self.get_dependency_filename(t) for t in dependencies])
         dep_targets.extend([self.get_dependency_filename(t)
                             for t in target.link_depends])
-        undefsym_response_file_args = self.get_undefsym_response_file_args(target)
+        undefsym_response_file_args = self.get_undefsym_response_file_args(target, linker)
         dep_targets.extend([item[1:] for item in undefsym_response_file_args])
 
         elem = NinjaBuildElement(self.all_outputs, outname, linker_rule, obj_list)

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -298,6 +298,16 @@ class CCompiler(Compiler):
         else:
             return ['-Wl,-export-dynamic']
 
+    def get_undefsymbols_args(self, env):
+        nm_bin = env.binaries.host.lookup_entry('nm')
+        if nm_bin is None:
+            if env.is_cross_build():
+                mlog.warning('Cross file does not specify nm binary, symbols used by modules will not be added from static libraries.')
+            else:
+                # TODO go through all candidates, like others
+                nm_bin = [env.default_nm[0]]
+        return ['--prefix=-Wl,-u -Wl,', '--nm'] + nm_bin if nm_bin else []
+
     def gen_import_library_args(self, implibname):
         """
         The name of the outputted import library
@@ -1499,6 +1509,11 @@ class VisualStudioCCompiler(CCompiler):
     def gen_pch_args(self, header, source, pchname):
         objname = os.path.splitext(pchname)[0] + '.obj'
         return objname, ['/Yc' + header, '/Fp' + pchname, '/Fo' + objname]
+
+    def get_undefsymbols_args(self, env):
+        # Could be something like ['--dumpbin', '--prefix=/INCLUDE:'] if
+        # undefsymbols could parse dumpbin output.
+        return []
 
     def gen_import_library_args(self, implibname):
         "The name of the outputted import library"

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -955,6 +955,9 @@ class Compiler:
     def get_linker_lib_prefix(self):
         return ''
 
+    def options_support_undefsymbols_args(self, options):
+        return not option_enabled(self.base_options, options, 'b_bitcode')
+
     def get_undefsymbols_args(self, env):
         return []
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -955,6 +955,9 @@ class Compiler:
     def get_linker_lib_prefix(self):
         return ''
 
+    def get_undefsymbols_args(self, env):
+        return []
+
     def gen_import_library_args(self, implibname):
         """
         Used only on Windows for libraries that need an import library.

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -209,6 +209,9 @@ class FortranCompiler(Compiler):
     def gen_export_dynamic_link_args(self, env):
         return CCompiler.gen_export_dynamic_link_args(self, env)
 
+    def get_undefsymbols_args(self, env):
+        return CCompiler.get_undefsymbols_args(self, env)
+
     def gen_import_library_args(self, implibname):
         return CCompiler.gen_import_library_args(self, implibname)
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -428,6 +428,7 @@ class Environment:
         self.default_vala = ['valac']
         self.default_static_linker = ['ar']
         self.default_strip = ['strip']
+        self.default_nm = ['nm']
         self.vs_static_linker = ['lib']
         self.clang_cl_static_linker = ['llvm-lib']
         self.cuda_static_linker = ['nvlink']
@@ -1505,6 +1506,7 @@ class BinaryTable:
         # Binutils
         'strip': 'STRIP',
         'ar': 'AR',
+        'nm': 'NM',
         'windres': 'WINDRES',
 
         'cmake': 'CMAKE',

--- a/mesonbuild/scripts/undefsymbols.py
+++ b/mesonbuild/scripts/undefsymbols.py
@@ -1,0 +1,57 @@
+# Copyright 2013-2018 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script extracts undefined symbols of a given library
+# into a file. If the symbols have not changed, the file is not
+# touched. This information is used to include functions from static
+# libraries into the main program.
+
+import sys
+import argparse
+
+parser = argparse.ArgumentParser()
+
+parser.add_argument('--prefix', default='', dest='prefix', nargs=1,
+                    help='string to place before the symbol name')
+parser.add_argument('args', nargs='+')
+
+def write_if_changed(text, outfilename):
+    try:
+        with open(outfilename, 'r') as f:
+            oldtext = f.read()
+        if text == oldtext:
+            return
+    except FileNotFoundError:
+        pass
+    with open(outfilename, 'w') as f:
+        f.write(text)
+
+def dummy_syms(outfilename):
+    # Unlike symbolextractor.py, we want write_if_changed here.  That is
+    # because if nm is not available, the output file will be unused, but
+    # it will still be a dependency of the executable.  Using write_if_changed
+    # avoids unnecessary relinking.
+    write_if_changed('', outfilename)
+
+def run(args):
+    options = parser.parse_args(args)
+    if len(options.args) < 2:
+        print('undefsymbols.py <shared library file>... <output file> [--prefix <prefix>]')
+        sys.exit(1)
+    outfile = options.args[-1]
+    dummy_syms(outfile)
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(run(sys.argv[1:]))

--- a/test cases/common/212 shared module with static library/meson.build
+++ b/test cases/common/212 shared module with static library/meson.build
@@ -1,6 +1,8 @@
 project('shared module', 'c')
+backend = meson.backend()
 compiler = meson.get_compiler('c')
-have_undefsymbols = false
+cpp_id = compiler.get_id()
+have_undefsymbols = (backend == 'ninja') and (cpp_id == 'gcc' or cpp_id == 'clang')
 
 if not have_undefsymbols
   error('MESON_SKIP_TEST undefsymbols not supported on this platform.')

--- a/test cases/common/212 shared module with static library/meson.build
+++ b/test cases/common/212 shared module with static library/meson.build
@@ -1,0 +1,20 @@
+project('shared module', 'c')
+compiler = meson.get_compiler('c')
+have_undefsymbols = false
+
+if not have_undefsymbols
+  error('MESON_SKIP_TEST undefsymbols not supported on this platform.')
+endif
+
+# Link the static library with the executable only, and check that the
+# functions brought in by the module are included in the executable.
+l1 = static_library('runtime1', 'runtime1.c')
+l2 = shared_library('runtime2', 'runtime2.c')
+
+dl = compiler.find_library('dl', required : false)
+e = executable('prog', 'prog.c',
+  link_with : [l1, l2], implib: true, dependencies : dl)
+
+# For this test, we link the module with the runtime library.
+m = shared_module('mymodule', 'module.c', link_with: [e, l2])
+test('import test', e, args : m)

--- a/test cases/common/212 shared module with static library/module.c
+++ b/test cases/common/212 shared module with static library/module.c
@@ -1,0 +1,23 @@
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+/*
+ * Shared modules often have references to symbols that are not defined
+ * at link time, but which will be provided from deps of the executable that
+ * dlopens it. We need to make sure that this works, i.e. that we do
+ * not pass -Wl,--no-undefined when linking modules.
+ */
+int static_func_called_from_module();
+int shared_func_called_from_module();
+
+int DLL_PUBLIC func(void) {
+    return static_func_called_from_module() / shared_func_called_from_module();
+}

--- a/test cases/common/212 shared module with static library/prog.c
+++ b/test cases/common/212 shared module with static library/prog.c
@@ -1,0 +1,100 @@
+
+#include <stdio.h>
+
+int func_from_language_runtime(void);
+typedef int (*fptr) (void);
+
+#ifdef _WIN32
+
+#include <windows.h>
+
+wchar_t*
+win32_get_last_error (void)
+{
+    wchar_t *msg = NULL;
+
+    FormatMessageW (FORMAT_MESSAGE_ALLOCATE_BUFFER
+                    | FORMAT_MESSAGE_IGNORE_INSERTS
+                    | FORMAT_MESSAGE_FROM_SYSTEM,
+                    NULL, GetLastError (), 0,
+                    (LPWSTR) &msg, 0, NULL);
+    return msg;
+}
+
+int
+main (int argc, char **argv)
+{
+    HINSTANCE handle;
+    fptr importedfunc;
+    int expected, actual;
+    int ret = 1;
+
+    handle = LoadLibraryA (argv[1]);
+    if (!handle) {
+        wchar_t *msg = win32_get_last_error ();
+        printf ("Could not open %s: %S\n", argv[1], msg);
+        goto nohandle;
+    }
+
+    importedfunc = (fptr) GetProcAddress (handle, "func");
+    if (importedfunc == NULL) {
+        wchar_t *msg = win32_get_last_error ();
+        printf ("Could not find 'func': %S\n", msg);
+        goto out;
+    }
+
+    actual = importedfunc ();
+    expected = 86 / 2;
+    if (actual != expected) {
+        printf ("Got %i instead of %i\n", actual, expected);
+        goto out;
+    }
+
+    ret = 0;
+out:
+    FreeLibrary (handle);
+nohandle:
+    return ret;
+}
+
+#else
+
+#include<dlfcn.h>
+#include<assert.h>
+
+int main(int argc, char **argv) {
+    void *dl;
+    fptr importedfunc;
+    int expected, actual;
+    char *error;
+    int ret = 1;
+
+    dlerror();
+    dl = dlopen(argv[1], RTLD_LAZY);
+    error = dlerror();
+    if(error) {
+        printf("Could not open %s: %s\n", argv[1], error);
+        goto nodl;
+    }
+
+    importedfunc = (fptr) dlsym(dl, "func");
+    if (importedfunc == NULL) {
+        printf ("Could not find 'func'\n");
+        goto out;
+    }
+
+    actual = (*importedfunc)();
+    expected = 86 / 2;
+    if (actual != expected) {
+        printf ("Got %i instead of %i\n", actual, expected);
+        goto out;
+    }
+
+    ret = 0;
+out:
+    dlclose(dl);
+nodl:
+    return ret;
+}
+
+#endif

--- a/test cases/common/212 shared module with static library/runtime1.c
+++ b/test cases/common/212 shared module with static library/runtime1.c
@@ -1,0 +1,19 @@
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+/*
+ * This file pretends to be a language runtime that supports extension
+ * modules.
+ */
+
+int DLL_PUBLIC static_func_called_from_module(void) {
+    return 86;
+}

--- a/test cases/common/212 shared module with static library/runtime2.c
+++ b/test cases/common/212 shared module with static library/runtime2.c
@@ -1,0 +1,19 @@
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+/*
+ * This file pretends to be a language runtime that supports extension
+ * modules.
+ */
+
+int DLL_PUBLIC shared_func_called_from_module(void) {
+    return 2;
+}


### PR DESCRIPTION
Even though shared modules are more or less incompatible with statically linked binaries (glibc's support for libdl inside statically linked binaries, for example, is very limited), it is of course possible to link static libraries into a binary that uses shared modules. These could be either external packages, or libraries that are internal to the program being built.
    
Whenever an executable is statically linked with a library, the linker omits library functions that are not used by the executable.  However, some of these omitted library functions, while not used by the executable, might be needed by shared modules.  When this happens, the shared module will fail to load.

Because the library is statically linked, adding it to the module may not do the right thing. The most common workaround in that case is to use link_whole, but that might seriously bloat the executable and might not even always work. This pull request implements an alternative solution.  It is inspired by the operation of QEMU's Makefiles, which I'm looking at for a conversion to Meson.

Module object files are processed with "nm" to find undefined symbols, and the undefined symbols are included in the executable through the linker's "-u" option.  There exists equivalents in the MSVC world for both steps, but they are not implemented yet. The process is automatic and guided entirely by syntax that is already present in the Meson language.
    
Note that, unlike symbolextractor, this is not just an optimization. However, if for example nm is not found in the toolchain file for cross-compilation, behavior is unchanged compared to before this pull request: a module that has dependencies on a statically-linked library will fail to link, but apart from this special case everything will work normally.