### PR TITLE
Add test case for generated headers used through a dependency.

### DIFF
--- a/test cases/common/179 source in dep/generated/funname
+++ b/test cases/common/179 source in dep/generated/funname
@@ -1,0 +1,1 @@
+my_wonderful_function

--- a/test cases/common/179 source in dep/generated/genheader.py
+++ b/test cases/common/179 source in dep/generated/genheader.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import sys
+
+ifile = sys.argv[1]
+ofile = sys.argv[2]
+
+templ = '''#pragma once
+
+int %s() {
+  return 42;
+}
+'''
+
+funname = open(ifile).readline().strip()
+
+open(ofile, 'w').write(templ % funname)

--- a/test cases/common/179 source in dep/generated/main.c
+++ b/test cases/common/179 source in dep/generated/main.c
@@ -1,0 +1,5 @@
+#include"funheader.h"
+
+int main(int argc, char **argv) {
+    return my_wonderful_function() != 42;
+}

--- a/test cases/common/179 source in dep/generated/meson.build
+++ b/test cases/common/179 source in dep/generated/meson.build
@@ -1,0 +1,12 @@
+fp = find_program('genheader.py')
+
+genh = custom_target('genh',
+  input : 'funname',
+  output : 'funheader.h',
+  command : [fp, '@INPUT@', '@OUTPUT@'])
+  
+dep = declare_dependency(sources : [genh])
+  
+e = executable('genuser', 'main.c',
+  dependencies : dep)
+test('genuser', e)

--- a/test cases/common/179 source in dep/meson.build
+++ b/test cases/common/179 source in dep/meson.build
@@ -4,3 +4,5 @@ dep = declare_dependency(sources : 'foo.c')
 
 executable('bar', 'bar.cpp',
   dependencies : dep)
+
+subdir('generated')


### PR DESCRIPTION
This was being debugged today. We did not have a test case for this particular set of steps so I created one to see if it works. It does. Since this is now written let's add it in to aid in future debugging steps.