### PR TITLE
interpreter: Allow specifying the `build_machine` explicitly---don't merge

### DIFF
--- a/docs/markdown/Cross-compilation.md
+++ b/docs/markdown/Cross-compilation.md
@@ -150,12 +150,14 @@ binaries are not actually compatible. In such cases you may use the
 needs_exe_wrapper = true
 ```
 
-The last bit is the definition of host and target machines. Every
-cross build definition must have one or both of them. If it had
-neither, the build would not be a cross build but a native build. You
-do not need to define the build machine, as all necessary information
-about it is extracted automatically. The definitions for host and
-target machines look the same. Here is a sample for host machine.
+The last bit is the definition of build, host, and target machines.
+Every cross build definition must have one or both of host and target.
+If it had neither, the build would not be a cross build but a native
+build. You do not need to define the build machine, as all necessary
+information about it is extracted automatically. But you may specify
+if you prefer to skip such environment inspection for some reason. The
+definitions for all three machines look the same. Here is a sample for
+host machine.
 
 ```ini
 [host_machine]

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1895,9 +1895,10 @@ class Interpreter(InterpreterBase):
         # Initialize machine descriptions. We can do a better job now because we
         # have the compilers needed to gain more knowledge, so wipe out old
         # inferrence and start over.
-        self.build.environment.machines.miss_defaulting()
-        self.build.environment.machines.detect_build(self.coredata.compilers)
-        self.build.environment.machines.default_missing()
+        if self.build.environment.machines.any_detected:
+            self.build.environment.machines.miss_defaulting()
+            self.build.environment.machines.detect_build(self.coredata.compilers)
+            self.build.environment.machines.default_missing()
         assert self.build.environment.machines.build.cpu is not None
         assert self.build.environment.machines.host.cpu is not None
         assert self.build.environment.machines.target.cpu is not None


### PR DESCRIPTION
Let's ignore this one until we decide on whether we want "machine files" per https://github.com/mesonbuild/meson/issues/3972

-----

N.B. I foreshadow supporting empty cross files both because it simplifies the downstream code, and because I hope to eventually allow using cross files with native builds too.

CC @eternaleye