### PR TITLE
Misc library search fixes

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -338,7 +338,7 @@ class Backend:
                 return True
         return False
 
-    def rpaths_for_bundled_shared_libraries(self, target):
+    def rpaths_for_bundled_shared_libraries(self, target, exclude_system=True):
         paths = []
         for dep in target.external_deps:
             if not isinstance(dep, (dependencies.ExternalLibrary, dependencies.PkgConfigDependency)):
@@ -349,7 +349,7 @@ class Backend:
             # The only link argument is an absolute path to a library file.
             libpath = la[0]
             libdir = os.path.dirname(libpath)
-            if self._libdir_is_system(libdir, target.compilers):
+            if exclude_system and self._libdir_is_system(libdir, target.compilers):
                 # No point in adding system paths.
                 continue
             # Windows doesn't support rpaths, but we use this function to
@@ -601,7 +601,7 @@ class Backend:
         if isinstance(target, build.BuildTarget):
             prospectives.update(target.get_transitive_link_deps())
             # External deps
-            for deppath in self.rpaths_for_bundled_shared_libraries(target):
+            for deppath in self.rpaths_for_bundled_shared_libraries(target, exclude_system=False):
                 result.add(os.path.normpath(os.path.join(self.environment.get_build_dir(), deppath)))
         for bdep in extra_bdeps:
             prospectives.update(bdep.get_transitive_link_deps())

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -23,6 +23,8 @@ from .compilers import (
 
 class FortranCompiler(Compiler):
     library_dirs_cache = CCompiler.library_dirs_cache
+    program_dirs_cache = CCompiler.library_dirs_cache
+    find_library_cache = CCompiler.library_dirs_cache
 
     def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwargs):
         self.language = 'fortran'
@@ -174,11 +176,17 @@ class FortranCompiler(Compiler):
     def get_library_naming(self, env, libtype, strict=False):
         return CCompiler.get_library_naming(self, env, libtype, strict)
 
+    def find_library_real(self, *args):
+        return CCompiler.find_library_real(self, *args)
+
+    def find_library_impl(self, *args):
+        return CCompiler.find_library_impl(self, *args)
+
     def find_library(self, libname, env, extra_dirs, libtype='default'):
         code = '''program main
             call exit(0)
         end program main'''
-        return CCompiler.find_library_impl(self, libname, env, extra_dirs, code, libtype)
+        return self.find_library_impl(libname, env, extra_dirs, code, libtype)
 
     def thread_flags(self, env):
         return CCompiler.thread_flags(self, env)


### PR DESCRIPTION
These are also in https://github.com/mesonbuild/meson/pull/3691, but do not depend on it.

commit c9e1fb2e96f22e8f0cef538be76372599a8d415c (HEAD -> nirbheek/find_library_fixes, origin/nirbheek/find_library_fixes)
Author: Nirbheek Chauhan <nirbheek@centricular.com>
Date:   Tue Jun 5 17:54:45 2018 +0530

    find_library: Add a cache for library searching
    
    Otherwise we can end up searching for the same library tens of times,
    because pkg-config does not de-duplicate -lfoo args before returning
    them.
    
    We use -Wl,--start-group/end-group, so we do not need to worry about
    ordering issues in static libraries.

commit 39da01cc3ce1915afe0baa3435a35dd89dc68f53
Author: Nirbheek Chauhan <nirbheek@centricular.com>
Date:   Tue Jun 5 17:50:12 2018 +0530

    backends: Don't hardcode system library paths
    
    Lookup the library paths using the available compilers instead.
    
    This makes the code work on non-Linux platforms too.
