### PR TITLE
vala: fix extract_all_objects() result

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -49,9 +49,9 @@ cpp_suffixes = lang_suffixes['cpp'] + ('h',)
 c_suffixes = lang_suffixes['c'] + ('h',)
 # List of languages that can be linked with C code directly by the linker
 # used in build.py:process_compilers() and build.py:get_dynamic_linker()
-clike_langs = ('d', 'objcpp', 'cpp', 'objc', 'c', 'fortran',)
+clike_langs = ('d', 'objcpp', 'cpp', 'objc', 'c', 'fortran', )
 clike_suffixes = ()
-for _l in clike_langs:
+for _l in clike_langs + ('vala',):
     clike_suffixes += lang_suffixes[_l]
 clike_suffixes += ('h', 'll', 's')
 

--- a/test cases/vala/25 extract_all_objects/meson.build
+++ b/test cases/vala/25 extract_all_objects/meson.build
@@ -1,0 +1,11 @@
+project('valatest', 'vala', 'c')
+
+valadeps = [dependency('glib-2.0'), dependency('gobject-2.0')]
+
+# A dummy target, just so that we can check that extract_all_objects() works
+# properly for Vala sources.  Due to a bug, Vala's .c.o files weren't included
+# which would cause the "e" executable below to have no "main" and fail to link.
+dummy = executable('valaprog_dummy', 'prog.vala', dependencies : valadeps, build_by_default: false)
+
+objs = dummy.extract_all_objects()
+e = executable('valaprog', objects: objs, dependencies : valadeps)

--- a/test cases/vala/25 extract_all_objects/prog.vala
+++ b/test cases/vala/25 extract_all_objects/prog.vala
@@ -1,0 +1,7 @@
+class MainProg : GLib.Object {
+
+    public static int main(string[] args) {
+        stdout.printf("Vala is working.\n");
+        return 0;
+    }
+}

--- a/test cases/vala/26 vala and asm/meson.build
+++ b/test cases/vala/26 vala and asm/meson.build
@@ -1,0 +1,23 @@
+project('vala and asm', 'vala', 'c')
+
+cpu = host_machine.cpu_family()
+cc = meson.get_compiler('c')
+
+supported_cpus = ['arm', 'x86', 'x86_64']
+
+if not supported_cpus.contains(cpu)
+  error('MESON_SKIP_TEST unsupported cpu:' + cpu)
+endif
+
+if meson.get_compiler('c').get_id() == 'msvc'
+  error('MESON_SKIP_TEST MSVC can\'t compile assembly')
+endif
+
+if cc.symbols_have_underscore_prefix()
+  add_project_arguments('-DMESON_TEST__UNDERSCORE_SYMBOL', language: 'c')
+endif
+
+valadeps = [dependency('glib-2.0'), dependency('gobject-2.0')]
+e = executable('vala-asm', ['prog.vala', 'retval-' + cpu + '.S'],
+               dependencies: valadeps)
+test('test-vala-asm', e)

--- a/test cases/vala/26 vala and asm/prog.vala
+++ b/test cases/vala/26 vala and asm/prog.vala
@@ -1,0 +1,9 @@
+extern int get_retval();
+
+class MainProg : GLib.Object {
+
+    public static int main(string[] args) {
+        stdout.printf("Vala is working.\n");
+        return get_retval();
+    }
+}

--- a/test cases/vala/26 vala and asm/retval-arm.S
+++ b/test cases/vala/26 vala and asm/retval-arm.S
@@ -1,0 +1,11 @@
+#include "symbol-underscore.h"
+
+.text
+.globl SYMBOL_NAME(get_retval)
+# ifdef __linux__
+.type get_retval, %function
+#endif
+
+SYMBOL_NAME(get_retval):
+    mov	r0, #0
+    mov	pc, lr

--- a/test cases/vala/26 vala and asm/retval-x86.S
+++ b/test cases/vala/26 vala and asm/retval-x86.S
@@ -1,0 +1,12 @@
+#include "symbol-underscore.h"
+
+.text
+.globl SYMBOL_NAME(get_retval)
+/* Only supported on Linux with GAS */
+# ifdef __linux__
+.type get_retval, %function
+#endif
+
+SYMBOL_NAME(get_retval):
+    xorl	%eax, %eax
+    retl

--- a/test cases/vala/26 vala and asm/retval-x86_64.S
+++ b/test cases/vala/26 vala and asm/retval-x86_64.S
@@ -1,0 +1,11 @@
+#include "symbol-underscore.h"
+
+.text
+.globl SYMBOL_NAME(get_retval)
+# ifdef __linux__
+.type get_retval, %function
+#endif
+
+SYMBOL_NAME(get_retval):
+    xorl	%eax, %eax
+    retq

--- a/test cases/vala/26 vala and asm/symbol-underscore.h
+++ b/test cases/vala/26 vala and asm/symbol-underscore.h
@@ -1,0 +1,5 @@
+#if defined(MESON_TEST__UNDERSCORE_SYMBOL)
+# define SYMBOL_NAME(name) _##name
+#else
+# define SYMBOL_NAME(name) name
+#endif


### PR DESCRIPTION
Because vala is not listed in clike_langs, is_source(fname) is returning False for Vala source files.  Therefore, extract_all_objects() is completely empty for Vala programs.

This had been fixed before but it regressed, so I'm also adding a new testcase (slightly hackish, but effective).

Fixes #791 