### PR TITLE
meson introspect: Fix --installed argument

### DIFF
--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -69,7 +69,7 @@ def determine_installed_path(target, installdata):
 def list_installed(installdata):
     res = {}
     if installdata is not None:
-        for path, installdir, aliases, unknown1, unknown2 in installdata.targets:
+        for path, installdir, aliases, *unknown in installdata.targets:
             res[os.path.join(installdata.build_dir, path)] = os.path.join(installdata.prefix, installdir, os.path.basename(path))
         for path, installpath, unused_prefix in installdata.data:
             res[path] = os.path.join(installdata.prefix, installpath)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2956,6 +2956,10 @@ class LinuxlikeTests(BasePlatformTests):
         env = os.environ.copy()
         env['LD_LIBRARY_PATH'] = installed_libdir
         self.assertEqual(subprocess.call(installed_exe, env=env), 0)
+        # Ensure that introspect --installed works
+        installed = self.introspect('--installed')
+        for v in installed.values():
+            self.assertTrue('prog' in v or 'foo' in v)
 
     def test_order_of_l_arguments(self):
         testdir = os.path.join(self.unit_test_dir, '9 -L -l order')
@@ -3014,7 +3018,6 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertIsInstance(docbook_target, dict)
         ifile = self.introspect(['--target-files', 'generated-gdbus-docbook@cus'])[0]
         self.assertEqual(t['filename'], 'gdbus/generated-gdbus-doc-' + ifile)
-
 
     def test_build_rpath(self):
         if is_cygwin():


### PR DESCRIPTION
```py
Traceback (most recent call last):
  File "meson.py", line 29, in <module>
    sys.exit(mesonmain.main())
  File "mesonbuild/mesonmain.py", line 411, in main
    return run(sys.argv[1:], launcher)
  File "mesonbuild/mesonmain.py", line 320, in run
    return mintro.run(remaining_args)
  File "mesonbuild/mintro.py", line 234, in run
    list_installed(installdata)
  File "mesonbuild/mintro.py", line 72, in list_installed
    for path, installdir, aliases, unknown1, unknown2 in installdata.targets:
ValueError: too many values to unpack (expected 5)
```