### PR TITLE
Options: treat array option -Dopt= and -Dopt=[] as equivalent

### DIFF
--- a/docs/markdown/Build-options.md
+++ b/docs/markdown/Build-options.md
@@ -58,6 +58,9 @@ empty. The `value` parameter specifies the default value of the option
 and if it is unset then the values of `choices` will be used as the
 default.
 
+As of 0.47.0 -Dopt= and -Dopt=[] both pass an empty list, before this -Dopt=
+would pass a list with an empty string.
+
 This type is available since version 0.44.0
 
 

--- a/docs/markdown/snippets/empty-array-opts.md
+++ b/docs/markdown/snippets/empty-array-opts.md
@@ -1,0 +1,5 @@
+## Array options treat -Dopt= and -Dopt=[] as equivalent
+
+Prior to this change passing -Dopt= to an array opt would be interpreted as
+[''] (an array with an empty string), now -Dopt= is the same as -Dopt=[], an
+empty list.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -158,6 +158,8 @@ class UserArrayOption(UserOption):
             assert isinstance(value, str)
             if value.startswith('['):
                 newvalue = ast.literal_eval(value)
+            elif value == '':
+                newvalue = []
             else:
                 newvalue = [v.strip() for v in value.split(',')]
                 if len(set(newvalue)) != len(newvalue):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1768,6 +1768,26 @@ int main(int argc, char **argv) {
         changed = get_opt()
         self.assertDictEqual(changed, expected)
 
+    def test_array_option_empty_equivalents(self):
+        """Array options treat -Dopt=[] and -Dopt= as equivalent."""
+        def get_opt():
+            opts = self.introspect('--buildoptions')
+            for x in opts:
+                if x.get('name') == 'list':
+                    return x
+            raise Exception(opts)
+
+        expected = {
+            'name': 'list',
+            'description': 'list',
+            'type': 'array',
+            'value': [],
+        }
+        tdir = os.path.join(self.unit_test_dir, '18 array option')
+        self.init(tdir, extra_args='-Dlist=')
+        original = get_opt()
+        self.assertDictEqual(original, expected)
+
     def opt_has(self, name, value):
         res = self.introspect('--buildoptions')
         found = False


### PR DESCRIPTION
Currently the former will be parsed as `['']`, while the latter is parsed
as `[]` in python. This makes for some obnoxious special handling
depending on what the user passes. This is even more obnoxious since for
string type arguments this doesn't require special handling.