### PR TITLE
gettext: Install .mo files atomically

### DIFF
--- a/mesonbuild/scripts/gettext.py
+++ b/mesonbuild/scripts/gettext.py
@@ -81,9 +81,11 @@ def do_install(src_sub, bld_sub, dest, pkgname, langs):
         srcfile = os.path.join(bld_sub, l + '.gmo')
         outfile = os.path.join(dest, l, 'LC_MESSAGES',
                                pkgname + '.mo')
+        tempfile = outfile + '.tmp'
         os.makedirs(os.path.dirname(outfile), exist_ok=True)
-        shutil.copyfile(srcfile, outfile)
-        shutil.copystat(srcfile, outfile)
+        shutil.copyfile(srcfile, tempfile)
+        shutil.copystat(srcfile, tempfile)
+        os.replace(tempfile, outfile)
         print('Installing %s to %s' % (srcfile, outfile))
     return 0
 


### PR DESCRIPTION
Without this, building a module in a Flatpak app manifest that is a
newer version of a module already present in the Flatpak runtime will
fail. (The Flatpak file system is a bunch of hard links to readonly
files, which can be replaced but not written to.)

This instead creates a temporary file in the same directory as the
destination (to avoid cross-device renaming errors) and atomically
renames the temporary file to the destination, replacing it instead of
rewriting it as shutil.copyfile() would do.