### PR TITLE
Revert "really switch to qmake automatically if pkg-config fails"

### DIFF
--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -215,7 +215,7 @@ class QtBaseDependency(ExternalDependency):
         if DependencyMethods.PKGCONFIG in self.methods:
             self._pkgconfig_detect(mods, kwargs)
             methods.append('pkgconfig')
-        if not self.is_found or DependencyMethods.QMAKE in self.methods:
+        if not self.is_found and DependencyMethods.QMAKE in self.methods:
             from_text = self._qmake_detect(mods, kwargs)
             methods.append('qmake-' + self.name)
             methods.append('qmake')


### PR DESCRIPTION
This reverts commit 0045d95a16be18092adfb40a9a5df944bcb99aea.

`<jeandet>` nirbheek, it seems 0045d95a16be18092adfb40a9a5df944bcb99aea is really wrong, I've tested on Ubuntu.  While writing this line I was thinking that you can't have Qt without a working qmake in the path. On Ubuntu you have that qtchooser stuff which is misleading.