### PR TITLE
dependencies/qt: fix debugoptimized builds with qt

### DIFF
--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -347,7 +347,7 @@ class QtBaseDependency(ExternalDependency):
                 for dir in priv_inc:
                     self.compile_args.append('-I' + dir)
             if for_windows(self.env.is_cross_build(), self.env):
-                is_debug = self.env.coredata.get_builtin_option('buildtype').startswith('debug')
+                is_debug = self.env.coredata.get_builtin_option('buildtype') == 'debug'
                 dbg = 'd' if is_debug else ''
                 if self.qtver == '4':
                     base_name = 'Qt' + module + dbg + '4'


### PR DESCRIPTION
debugoptimized builds building against Qt would ultimately link against
both the debug and non-debug msvcrt, ntdll, etc libraries which causes
crashes in weird places and is very much not recommended by Microsoft.

This changes the selected Qt library(ies) correctly to not uses the
debug variants for debugoptimized builds.

https://github.com/mesonbuild/meson/pull/3680