### PR TITLE
nasm test: use -fno-pie -no-pie

### DIFF
--- a/test cases/nasm/1 configure file/meson.build
+++ b/test cases/nasm/1 configure file/meson.build
@@ -39,6 +39,11 @@ config_file = configure_file(
   output_format: 'nasm',
 )
 
-exe = executable('hello', asm_gen.process('hello.asm'))
+cc = meson.get_compiler('c')
+link_args = cc.get_supported_link_arguments(['-no-pie'])
+
+exe = executable('hello', asm_gen.process('hello.asm'),
+  link_args: link_args,
+)
 
 test('test-nasm-configure-file', exe)


### PR DESCRIPTION
We were hitting the problem described by:

https://stackoverflow.com/questions/43367427/32-bit-absolute-addresses-no-longer-allowed-in-x86-64-linux

See the first answer for a detailed explanation

Fixes https://github.com/mesonbuild/meson/issues/3707