### PR TITLE
mintro: Fix introspecting installation paths

### DIFF
--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -73,9 +73,9 @@ def list_installed(installdata):
             res[os.path.join(installdata.build_dir, path)] = os.path.join(installdata.prefix, installdir, os.path.basename(path))
         for path, installpath, unused_prefix in installdata.data:
             res[path] = os.path.join(installdata.prefix, installpath)
-        for path, installdir in installdata.headers:
+        for path, installdir, unused_custom_install_mode in installdata.headers:
             res[path] = os.path.join(installdata.prefix, installdir, os.path.basename(path))
-        for path, installpath in installdata.man:
+        for path, installpath, unused_custom_install_mode in installdata.man:
             res[path] = os.path.join(installdata.prefix, installpath)
     print(json.dumps(res))
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2914,6 +2914,9 @@ class LinuxlikeTests(BasePlatformTests):
             self.assertEqual(want_mode, found_mode,
                              msg=('Expected file %s to have mode %s but found %s instead.' %
                                   (fsobj, want_mode, found_mode)))
+        # Ensure that introspect --installed works on all types of files
+        # FIXME: also verify the files list
+        self.introspect('--installed')
 
     def test_install_umask(self):
         '''


### PR DESCRIPTION
A new custom_install_mode element was added in 05c43cdcd

(It makes our meson build fail with meson master: https://ci.gstreamer.net/job/GStreamer-master-meson/2778/console)