### PR TITLE
Refine cross file checking to ignore directories

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -236,7 +236,7 @@ class CoreData:
         if os.path.isabs(filename):
             return filename
         path_to_try = os.path.abspath(filename)
-        if os.path.exists(path_to_try):
+        if os.path.isfile(path_to_try):
             return path_to_try
         if sys.platform != 'win32':
             paths = [
@@ -244,7 +244,7 @@ class CoreData:
             ] + os.environ.get('XDG_DATA_DIRS', '/usr/local/share:/usr/share').split(':')
             for path in paths:
                 path_to_try = os.path.join(path, 'meson', 'cross', filename)
-                if os.path.exists(path_to_try):
+                if os.path.isfile(path_to_try):
                     return path_to_try
             raise MesonException('Cannot find specified cross file: ' + filename)
 


### PR DESCRIPTION
e.g. 'meson x86_64-w64-mingw32 --cross-file x86_64-w64-mingw32' currently
fails with an IsADirectoryError exception.

Cross files must be files, so when searching, only accept a candidate path
which is an existing file, not just an existing path.