### PR TITLE
Report exit status or signal that killed the test

### DIFF
--- a/test cases/failing test/2 signal/main.c
+++ b/test cases/failing test/2 signal/main.c
@@ -1,0 +1,6 @@
+#include <signal.h>
+#include <unistd.h>
+
+int main(void) {
+    kill(getpid(), SIGSEGV);
+}

--- a/test cases/failing test/2 signal/meson.build
+++ b/test cases/failing test/2 signal/meson.build
@@ -1,0 +1,7 @@
+project('signal', 'c')
+
+if build_machine.system() == 'windows'
+    error('MESON_SKIP_TEST test is not compatible with MS Windows.')
+else
+    test('My Signal Test', executable('main', 'main.c'))
+endif

--- a/test cases/failing test/3 ambiguous/main.c
+++ b/test cases/failing test/3 ambiguous/main.c
@@ -1,0 +1,6 @@
+#include <signal.h>
+#include <unistd.h>
+
+int main(void) {
+    kill(getpid(), SIGSEGV);
+}

--- a/test cases/failing test/3 ambiguous/meson.build
+++ b/test cases/failing test/3 ambiguous/meson.build
@@ -1,0 +1,10 @@
+project('ambiguous', 'c')
+
+if build_machine.system() == 'windows'
+    error('MESON_SKIP_TEST test is not compatible with MS Windows.')
+else
+    exe = executable('main', 'main.c')
+    test_runner = find_program('test_runner.sh')
+
+    test('My Ambiguous Status Test', test_runner, args : [exe.full_path()])
+endif

--- a/test cases/failing test/3 ambiguous/test_runner.sh
+++ b/test cases/failing test/3 ambiguous/test_runner.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+#
+# This tests that using a shell as an intermediary between Meson and the
+# actual unit test which dies due to a signal is still recorded correctly.
+#
+# The quotes are because the path may contain spaces.
+"$1"


### PR DESCRIPTION
When a test fails due to a signal (e.g., SIGSEGV) it can be somewhat
mysterious why the test failed. Also, even when a test fails due to a
non-zero exit status it would help if the exit status was reported. This
augments the result string to include the non-zero exit status or
signal number and name.

Resolves #3642