### PR TITLE
run_tests: Run all cross tests together

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,16 +33,10 @@ matrix:
   # Test cross builds separately, they do not use the global compiler
   - os: linux
     compiler: gcc
-    env: RUN_TESTS_ARGS="--cross=arm"
+    env: RUN_TESTS_ARGS="--cross"
   - os: linux
     compiler: gcc
-    env: RUN_TESTS_ARGS="--cross=arm" MESON_ARGS="--unity=on"
-  - os: linux
-    compiler: gcc
-    env: RUN_TESTS_ARGS="--cross=mingw"
-  - os: linux
-    compiler: gcc
-    env: RUN_TESTS_ARGS="--cross=mingw" MESON_ARGS="--unity=on"
+    env: RUN_TESTS_ARGS="--cross" MESON_ARGS="--unity=on"
 
 before_install:
   - python ./skip_ci.py --base-branch-env=TRAVIS_BRANCH --is-pull-env=TRAVIS_PULL_REQUEST

--- a/run_tests.py
+++ b/run_tests.py
@@ -211,12 +211,7 @@ if __name__ == '__main__':
             elif arg == '--backend=xcode':
                 backend = Backend.xcode
         if arg.startswith('--cross'):
-            if arg == '--cross=arm':
-                cross = 'arm'
-            elif arg == '--cross=mingw':
-                cross = 'mingw'
-            else:
-                raise RuntimeError('Unknown cross tests selected')
+            cross = True
     # Running on a developer machine? Be nice!
     if not mesonlib.is_windows() and not mesonlib.is_haiku() and 'TRAVIS' not in os.environ:
         os.nice(20)
@@ -254,12 +249,10 @@ if __name__ == '__main__':
             returncode += subprocess.call(mesonlib.python_command + ['run_project_tests.py'] + sys.argv[1:], env=env)
         else:
             cross_test_args = mesonlib.python_command + ['run_cross_test.py']
-            if cross == 'arm':
-                print(mlog.bold('Running armhf cross tests.').get_text(mlog.colorize_console))
-                print()
-                returncode += subprocess.call(cross_test_args + ['cross/ubuntu-armhf.txt'], env=env)
-            elif cross == 'mingw':
-                print(mlog.bold('Running mingw-w64 64-bit cross tests.').get_text(mlog.colorize_console))
-                print()
-                returncode += subprocess.call(cross_test_args + ['cross/linux-mingw-w64-64bit.txt'], env=env)
+            print(mlog.bold('Running armhf cross tests.').get_text(mlog.colorize_console))
+            print()
+            returncode += subprocess.call(cross_test_args + ['cross/ubuntu-armhf.txt'], env=env)
+            print(mlog.bold('Running mingw-w64 64-bit cross tests.').get_text(mlog.colorize_console))
+            print()
+            returncode += subprocess.call(cross_test_args + ['cross/linux-mingw-w64-64bit.txt'], env=env)
     sys.exit(returncode)


### PR DESCRIPTION
There is a lot of overhead for each travis job, because docker pull
takes 3 minutes. Each cross test takes 3-4 minutes.

To make things worse, sometimes Dockerhub is slow and docker pull takes
longer than 3 minutes.