### PR TITLE
Test if compiler supports get_define.

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -699,6 +699,9 @@ class Compiler:
     def get_default_suffix(self):
         return self.default_suffix
 
+    def get_define(self, dname, prefix, env, extra_args, dependencies):
+        raise EnvironmentException('%s does not support get_define ' % self.get_id())
+
     def get_exelist(self):
         return self.exelist[:]
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -702,6 +702,18 @@ class Compiler:
     def get_define(self, dname, prefix, env, extra_args, dependencies):
         raise EnvironmentException('%s does not support get_define ' % self.get_id())
 
+    def compute_int(self, expression, low, high, guess, prefix, env, extra_args, dependencies):
+        raise EnvironmentException('%s does not support compute_int ' % self.get_id())
+
+    def has_members(self, typename, membernames, prefix, env, extra_args=None, dependencies=None):
+        raise EnvironmentException('%s does not support has_member(s) ' % self.get_id())
+
+    def has_type(self, typename, prefix, env, extra_args, dependencies=None):
+        raise EnvironmentException('%s does not support has_type ' % self.get_id())
+
+    def symbols_have_underscore_prefix(self, env):
+        raise EnvironmentException('%s does not support symbols_have_underscore_prefix ' % self.get_id())
+
     def get_exelist(self):
         return self.exelist[:]
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1043,6 +1043,8 @@ class CompilerHolder(InterpreterObject):
         'dependencies',
     })
     def has_members_method(self, args, kwargs):
+        if len(args) < 2:
+            raise InterpreterException('Has_members needs at least two arguments.')
         check_stringlist(args)
         typename = args[0]
         membernames = args[1:]

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1185,10 +1185,7 @@ class CompilerHolder(InterpreterObject):
             raise InterpreterException('Prefix argument of get_define() must be a string.')
         extra_args = self.determine_args(kwargs)
         deps = self.determine_dependencies(kwargs)
-        if hasattr(self.compiler, 'get_define'):
-            value = self.compiler.get_define(element, prefix, self.environment, extra_args, deps)
-        else:
-            raise InterpreterException('get_define is not supported for compiler ' + self.compiler.language)
+        value = self.compiler.get_define(element, prefix, self.environment, extra_args, deps)
         mlog.log('Fetching value of define "%s": %s' % (element, value))
         return value
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1185,7 +1185,10 @@ class CompilerHolder(InterpreterObject):
             raise InterpreterException('Prefix argument of get_define() must be a string.')
         extra_args = self.determine_args(kwargs)
         deps = self.determine_dependencies(kwargs)
-        value = self.compiler.get_define(element, prefix, self.environment, extra_args, deps)
+        if hasattr(self.compiler, 'get_define'):
+            value = self.compiler.get_define(element, prefix, self.environment, extra_args, deps)
+        else:
+            raise InterpreterException('get_define is not supported for compiler ' + self.compiler.language)
         mlog.log('Fetching value of define "%s": %s' % (element, value))
         return value
 


### PR DESCRIPTION
Raise an InterpreterError for a clean error message if get_define is not supported by the compiler.

Fixes #3731