### PR TITLE
Print default option values that don't match the current value

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -142,6 +142,11 @@ class MesonApp:
             profile.runctx('intr.run()', globals(), locals(), filename=fname)
         else:
             intr.run()
+        # Print all default option values that don't match the current value
+        for def_opt_name, def_opt_value, cur_opt_value in intr.get_non_matching_default_options():
+            mlog.log('Option', mlog.bold(def_opt_name), 'is:',
+                     mlog.bold(str(cur_opt_value)),
+                     '[default: {}]'.format(str(def_opt_value)))
         try:
             dumpfile = os.path.join(env.get_scratch_dir(), 'build.dat')
             # We would like to write coredata as late as possible since we use the existence of


### PR DESCRIPTION
This is my suggestion on how to make it more obvious that a change of the default value did not change the current value.

Prints something like below if cpp_std is changed to c++11 but was c++14 before.

```
Option cpp_std is: c++14 [default: c++11]
```

Fixes #3734