### PR TITLE
gtkdoc: Run gtkdoc-scangobj command from build directory

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -870,6 +870,8 @@ This will become a hard error in the future.''')
         for i in new_args:
             if expend_file_state and isinstance(i, mesonlib.File):
                 i = i.absolute_path(expend_file_state.environment.get_source_dir(), expend_file_state.environment.get_build_dir())
+            elif expend_file_state and isinstance(i, str):
+                i = os.path.join(expend_file_state.environment.get_source_dir(), expend_file_state.subdir, i)
             elif not isinstance(i, str):
                 raise MesonException(kwarg_name + ' values must be strings.')
             args.append(i)

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -122,7 +122,8 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
                                                               '--module=' + module,
                                                               '--cflags=' + cflags,
                                                               '--ldflags=' + ldflags,
-                                                              '--ld=' + ld]
+                                                              '--ld=' + ld,
+                                                              '--output-dir=' + abs_out]
 
         library_paths = []
         for ldflag in shlex.split(ldflags):
@@ -132,7 +133,7 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
             library_paths.append(os.environ['LD_LIBRARY_PATH'])
         library_path = ':'.join(library_paths)
 
-        gtkdoc_run_check(scanobjs_cmd, abs_out, library_path)
+        gtkdoc_run_check(scanobjs_cmd, build_root, library_path)
 
     # Make docbook files
     if mode == 'auto':


### PR DESCRIPTION
All paths in CFLAGS are relative to build_root, so current directory must be there when invoking gtkdoc-scangobj.

This seems to be enough to fix the build of gobject doc. The only side effect I know is `<module>-scan.c` file is created in `build_root` instead of `abs_out`, I don't think it's a big deal, but `gtkdoc-scangobj` could be modified to write that file in `output_dir`, I think it should like all other files it creates.

However, gio doc still fails, because it pass `gobject_typesfile : 'gio.types'` where gobject pass `gobject_typesfile : join_paths(meson.current_source_dir(), 'gobject.types')`. I think the correct syntax to use is `gobject_typesfile : files('gio.types')` and that works.



