### PR TITLE
FeatureNew: fix and cleanup minimum version comparison.

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -451,26 +451,23 @@ def version_compare_condition_with_min(condition, minimum):
         raise MesonException(msg.format(minimum))
     minimum = match.group(0)
     if condition.startswith('>='):
-        cmpop = operator.lt
+        cmpop = operator.le
         condition = condition[2:]
     elif condition.startswith('<='):
         return True
-        condition = condition[2:]
     elif condition.startswith('!='):
         return True
-        condition = condition[2:]
     elif condition.startswith('=='):
-        cmpop = operator.lt
+        cmpop = operator.le
         condition = condition[2:]
     elif condition.startswith('='):
-        cmpop = operator.lt
+        cmpop = operator.le
         condition = condition[1:]
     elif condition.startswith('>'):
         cmpop = operator.lt
         condition = condition[1:]
     elif condition.startswith('<'):
         return True
-        condition = condition[2:]
     else:
         cmpop = operator.eq
     varr1 = grab_leading_numbers(minimum, True)


### PR DESCRIPTION
This could be probably be further cleaned up, as the code
was copy pasted from version_compare, but that would be more
intrusive.

For now simply fix the used comparison operator, along with a
test showing what is fixed (test_using_recent_feature), and
also remove dead code paths in the comparison function.