### PR TITLE
Validate cpu_family (#3751)

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -46,6 +46,9 @@ set in the cross file.
 | ia64                | Itanium processor     |
 | arm                 | 32 bit ARM processor  |
 | aarch64             | 64 bit ARM processor  |
+| mips                | 32 bit MIPS processor |
+| mips64              | 64 bit MIPS processor |
+| ppc                 | 32 bit PPC processors (Big Endian) |
 | ppc64               | 64 bit PPC processors (Big Endian) |
 | ppc64le             | 64 bit PPC processors (Little Endian) |
 | e2k                 | MCST Elbrus processor |

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -72,6 +72,22 @@ from .compilers import (
 
 build_filename = 'meson.build'
 
+known_cpu_families = (
+    'aarch64',
+    'arm',
+    'e2k',
+    'ia64',
+    'mips',
+    'mips64',
+    'parisc',
+    'ppc',
+    'ppc64',
+    'ppc64le',
+    'sparc64',
+    'x86',
+    'x86_64'
+)
+
 def detect_gcovr(version='3.1', log=False):
     gcovr_exe = 'gcovr'
     try:
@@ -953,6 +969,10 @@ class CrossBuildInfo:
                     res = eval(value, {'__builtins__': None}, {'true': True, 'false': False})
                 except Exception:
                     raise EnvironmentException('Malformed value in cross file variable %s.' % entry)
+
+                if entry == 'cpu_family' and res not in known_cpu_families:
+                    mlog.warning('Unknown CPU family %s, please report this at https://github.com/mesonbuild/meson/issues/new' % value)
+
                 if self.ok_type(res):
                     self.config[s][entry] = res
                 elif isinstance(res, list):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -225,6 +225,10 @@ def detect_cpu_family(compilers):
                 pass
         return 'x86_64'
     # Add fixes here as bugs are reported.
+
+    if trial not in known_cpu_families:
+        mlog.warning('Unknown CPU family %s, please report this at https://github.com/mesonbuild/meson/issues/new' % trial)
+
     return trial
 
 def detect_cpu(compilers):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2206,6 +2206,7 @@ recommended as it is not supported on some platforms''')
             # they used to fail this test with Meson 0.46 an earlier versions.
             pass
 
+    @unittest.skipIf(not os.path.isdir('docs'), 'Doc dir not found, presumably because this is a tarball release.')
     def test_compiler_options_documented(self):
         '''
         Test that C and C++ compiler options and base options are documented in

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2227,6 +2227,24 @@ recommended as it is not supported on some platforms''')
                 self.assertIn(opt, md)
         self.assertNotIn('b_unknown', md)
 
+    @unittest.skipIf(not os.path.isdir('docs'), 'Doc dir not found, presumably because this is a tarball release.')
+    def test_cpu_families_documented(self):
+        with open("docs/markdown/Reference-tables.md") as f:
+            md = f.read()
+        self.assertIsNotNone(md)
+
+        sections = list(re.finditer(r"^## (.+)$", md, re.MULTILINE))
+        for s1, s2 in zip(sections[::2], sections[1::2]):
+            if s1.group(1) == "CPU families":
+                # Extract the content for this section
+                content = md[s1.end():s2.start()]
+                # Find the list entries
+                arches = [m.group(1) for m in re.finditer(r"^\| (\w+) +\|", content, re.MULTILINE)]
+                # Drop the header
+                arches = set(arches[1:])
+                self.assertEqual(arches, set(mesonbuild.environment.known_cpu_families))
+
+
 class FailureTests(BasePlatformTests):
     '''
     Tests that test failure conditions. Build files here should be dynamically


### PR DESCRIPTION
A first draft for issue #3751.

Maintain a list in the source of known CPU families, and validate:

1. The documentation matches
2. The detected cpu_family is listed
3. The specified cpu_family in the cross file is listed

If (2) or (3) fail, warn the user.

The commit messages do need work, this is more for feedback that the direction is good.