### PR TITLE
Downgrade unknown option from exception to warning

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -407,7 +407,7 @@ class CoreData:
         if unknown_options:
             unknown_options = ', '.join(sorted(unknown_options))
             sub = 'In subproject {}: '.format(subproject) if subproject else ''
-            raise MesonException('{}Unknown options: "{}"'.format(sub, unknown_options))
+            mlog.warning('{}Unknown options: "{}"'.format(sub, unknown_options))
 
 def load(build_dir):
     filename = os.path.join(build_dir, 'meson-private', 'coredata.dat')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2142,11 +2142,9 @@ recommended as it is not supported on some platforms''')
             self.assertEqual(obj.builtins['default_library'].value, 'shared')
         self.wipe()
 
-        # Should fail on unknown options
-        with self.assertRaises(subprocess.CalledProcessError) as cm:
-            self.init(testdir, extra_args=['-Dbad=1', '-Dfoo=2', '-Dwrong_link_args=foo'])
-        self.assertNotEqual(0, cm.exception.returncode)
-        self.assertIn('Unknown options: "bad, foo, wrong_link_args"', cm.exception.output)
+        # Should warn on unknown options
+        out = self.init(testdir, extra_args=['-Dbad=1', '-Dfoo=2', '-Dwrong_link_args=foo'])
+        self.assertIn('Unknown options: "bad, foo, wrong_link_args"', out)
         self.wipe()
 
         # Should fail on malformed option


### PR DESCRIPTION
It used to be non-fatal warnings but recent command line refactor made
it fatal. It looks like GNOME continuous would break with this change.
To avoid delaying upcoming 0.47.0 release adoption, let's downgrade this
back to warning for now and reconsider after the release.