### PR TITLE
gtkdochelper: pass CC to gtkdoc-scangobj

### DIFF
--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -122,6 +122,7 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
                                                               '--module=' + module,
                                                               '--cflags=' + cflags,
                                                               '--ldflags=' + ldflags,
+                                                              '--cc=' + cc,
                                                               '--ld=' + ld,
                                                               '--output-dir=' + abs_out]
 


### PR DESCRIPTION
The helper is told what CC to use already, but doesn't pass it to gtkdoc-scangobj.