### PR TITLE
add files() support for directories

### DIFF
--- a/docs/markdown/snippets/file_as_dir.md
+++ b/docs/markdown/snippets/file_as_dir.md
@@ -1,0 +1,3 @@
+## files() supports directories
+
+files() can now be used on directories, instead of erroring out with "File does not exist".

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -197,7 +197,7 @@ class File:
 
     @staticmethod
     def from_source_file(source_root, subdir, fname):
-        if not os.path.isfile(os.path.join(source_root, subdir, fname)):
+        if not os.path.exists(os.path.join(source_root, subdir, fname)):
             raise MesonException('File %s does not exist.' % fname)
         return File(False, subdir, fname)
 

--- a/test cases/common/205 directory as file/bar.c
+++ b/test cases/common/205 directory as file/bar.c
@@ -1,0 +1,6 @@
+#include<stdio.h>
+
+int main(int argc, char **argv) {
+    printf("I'm a main project bar.\n");
+    return 0;
+}

--- a/test cases/common/205 directory as file/meson.build
+++ b/test cases/common/205 directory as file/meson.build
@@ -1,0 +1,7 @@
+project('bar', 'c', license: 'Apache')
+
+executable('bar', 'bar.c')
+
+d = files('testdir')[0]
+# Print the directory to force it to be evaluated, just in case.
+message('test dir is @@0@@'.format(d))

--- a/test cases/common/205 directory as file/testdir/foo
+++ b/test cases/common/205 directory as file/testdir/foo
@@ -1,0 +1,1 @@
+This file exists only so that git will let us checkin an empty directory.


### PR DESCRIPTION
Currently, passing in a directory to files() fails with a message that
the file does not exist. However, there is no reason this should not
work, and it's perfectly valid to do. Add support for it.

Please note that I will be on vacation until July 9, but I wanted to get this out so I don't forget. I will fix up any issues when I get back.