### PR TITLE
Fix handling of dependency('', fallback: ['subproject', 'dep'])

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2805,10 +2805,11 @@ external dependencies (including libraries) must go to "dependencies".''')
     def func_dependency(self, node, args, kwargs):
         self.validate_arguments(args, 1, [str])
         name = args[0]
+        display_name = name if name else '(anonymous)'
 
         disabled, required, feature = extract_required_kwarg(kwargs)
         if disabled:
-            mlog.log('Dependency', mlog.bold(name), 'skipped: feature', mlog.bold(feature), 'disabled')
+            mlog.log('Dependency', mlog.bold(display_name), 'skipped: feature', mlog.bold(feature), 'disabled')
             return DependencyHolder(NotFoundDependency(self.environment))
 
         # writing just "dependency('')" is an error, because it can only fail
@@ -2823,7 +2824,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         if cached_dep:
             if required and not cached_dep.found():
                 m = 'Dependency {!r} was already checked and was not found'
-                raise DependencyException(m.format(name))
+                raise DependencyException(m.format(display_name))
             dep = cached_dep
         else:
             # If the dependency has already been configured, possibly by
@@ -2905,17 +2906,18 @@ root and issuing %s.
         return fbinfo
 
     def dependency_fallback(self, name, kwargs):
+        display_name = name if name else '(anonymous)'
         if self.coredata.wrap_mode in (WrapMode.nofallback, WrapMode.nodownload):
             mlog.log('Not looking for a fallback subproject for the dependency',
-                     mlog.bold(name), 'because:\nUse of fallback'
+                     mlog.bold(display_name), 'because:\nUse of fallback'
                      'dependencies is disabled.')
             return None
         elif self.coredata.wrap_mode == WrapMode.forcefallback:
             mlog.log('Looking for a fallback subproject for the dependency',
-                     mlog.bold(name), 'because:\nUse of fallback dependencies is forced.')
+                     mlog.bold(display_name), 'because:\nUse of fallback dependencies is forced.')
         else:
             mlog.log('Looking for a fallback subproject for the dependency',
-                     mlog.bold(name))
+                     mlog.bold(display_name))
         dirname, varname = self.get_subproject_infos(kwargs)
         # Try to execute the subproject
         try:
@@ -2933,7 +2935,7 @@ root and issuing %s.
         except Exception as e:
             mlog.log('Couldn\'t use fallback subproject in',
                      mlog.bold(os.path.join(self.subproject_dir, dirname)),
-                     'for the dependency', mlog.bold(name), '\nReason:', str(e))
+                     'for the dependency', mlog.bold(display_name), '\nReason:', str(e))
             return None
         dep = self.get_subproject_dep(name, dirname, varname, kwargs.get('required', True))
         if not dep:
@@ -2945,10 +2947,10 @@ root and issuing %s.
             found = dep.version_method([], {})
             if not self.check_subproject_version(wanted, found):
                 mlog.log('Subproject', mlog.bold(subproj_path), 'dependency',
-                         mlog.bold(varname), 'version is', mlog.bold(found),
+                         mlog.bold(display_name), 'version is', mlog.bold(found),
                          'but', mlog.bold(wanted), 'is required.')
                 return None
-        mlog.log('Dependency', mlog.bold(name), 'from subproject',
+        mlog.log('Dependency', mlog.bold(display_name), 'from subproject',
                  mlog.bold(subproj_path), 'found:', mlog.green('YES'))
         return dep
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2841,7 +2841,7 @@ external dependencies (including libraries) must go to "dependencies".''')
 
             # Unless a fallback exists and is forced ...
             if self.coredata.wrap_mode == WrapMode.forcefallback and 'fallback' in kwargs:
-                exception = DependencyException("fallback for %s not found" % name)
+                pass
             # ... search for it outside the project
             elif name != '':
                 try:
@@ -2852,6 +2852,8 @@ external dependencies (including libraries) must go to "dependencies".''')
             # Search inside the projects list
             if not dep.found():
                 if 'fallback' in kwargs:
+                    if not exception:
+                        exception = DependencyException("fallback for %s not found" % display_name)
                     fallback_dep = self.dependency_fallback(name, kwargs)
                     if fallback_dep:
                         # Never add fallback deps to self.coredata.deps since we

--- a/test cases/common/171 not-found dependency/meson.build
+++ b/test cases/common/171 not-found dependency/meson.build
@@ -11,3 +11,4 @@ library('testlib', 'testlib.c', dependencies: [dep])
 subdir('sub', if_found: dep)
 
 subdep = dependency('', fallback: ['trivial', 'trivial_dep'])
+missing = dependency('', fallback: ['missing', 'missing_dep'], required: false)

--- a/test cases/common/171 not-found dependency/meson.build
+++ b/test cases/common/171 not-found dependency/meson.build
@@ -9,3 +9,5 @@ assert(dep.type_name() == 'not-found', 'dependency should be of type "not-found"
 
 library('testlib', 'testlib.c', dependencies: [dep])
 subdir('sub', if_found: dep)
+
+subdep = dependency('', fallback: ['trivial', 'trivial_dep'])

--- a/test cases/common/171 not-found dependency/subprojects/trivial/meson.build
+++ b/test cases/common/171 not-found dependency/subprojects/trivial/meson.build
@@ -1,0 +1,3 @@
+project('trivial subproject', 'c')
+trivial_lib = static_library('trivial', 'trivial.c', install: false)
+trivial_dep = declare_dependency(link_with: trivial_lib)

--- a/test cases/common/171 not-found dependency/subprojects/trivial/trivial.c
+++ b/test cases/common/171 not-found dependency/subprojects/trivial/trivial.c
@@ -1,0 +1,3 @@
+int subfunc() {
+    return 42;
+}

--- a/test cases/failing/80 subproj dependency not-found and required/meson.build
+++ b/test cases/failing/80 subproj dependency not-found and required/meson.build
@@ -1,0 +1,2 @@
+project('dep-test')
+missing = dependency('', fallback: ['missing', 'missing_dep'], required: true)


### PR DESCRIPTION
Also adjust documentation so we don't appear to recommend writing
dependency('', fallback: ['subproject', 'dep']) over
subproject('subproject').get_variable('dep').

Also extend a test case to cover this.