### PR TITLE
Refine documentation for build_always [skip ci]

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -233,9 +233,10 @@ following.
   have this target be built by default, that is, when invoking plain
   `ninja`; the default value is false
 - `build_always` (deprecated) if `true` this target is always considered out of
-  date and is rebuilt every time, useful for things such as build
-  timestamps or revision control tags.
+  date and is rebuilt every time.  Equivalent to setting both
+  `build_always_stale` and `build_by_default` to true.
 - `build_always_stale` if `true` the target is always considered out of date.
+  Useful for things such as build timestamps or revision control tags.
   The associated command is run even if the outputs are up to date.
 - `capture`, there are some compilers that can't be told to write
   their output to a file but instead write it to standard output. When


### PR DESCRIPTION
We mention this is equivalent to setting both build_by_default and
build_always_stale in the release note, and in the warning emitted when it's
used, but not in the reference manual.