### PR TITLE
ArLinker: Use response files on Windows

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1526,14 +1526,10 @@ int dummy;
         if static_linker is None:
             return
         rule = 'rule STATIC%s_LINKER\n' % crstr
-        # We don't use @file.rsp on Windows with ArLinker because llvm-ar and
-        # gcc-ar blindly pass the --plugin argument to `ar` and you cannot pass
-        # options as arguments while using the @file.rsp syntax.
-        # See: https://github.com/mesonbuild/meson/issues/1646
         if static_linker.can_linker_accept_rsp():
-            command_template = ''' command = {executable} @$out.rsp
+            command_template = ''' command = {executable} $LINK_ARGS {output_args} @$out.rsp
  rspfile = $out.rsp
- rspfile_content = $LINK_ARGS {output_args} $in
+ rspfile_content = $in
 '''
         else:
             command_template = ' command = {executable} $LINK_ARGS {output_args} $in\n'

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -88,7 +88,7 @@ class ArLinker(StaticLinker):
             self.std_args = ['-csr']
 
     def can_linker_accept_rsp(self):
-        return False
+        return mesonlib.is_windows()
 
     def build_rpath_args(self, build_dir, from_dir, rpath_paths, build_rpath, install_rpath):
         return []


### PR DESCRIPTION
ninja chokes when building FFmpeg's static libraries, as the
command line can be larger than 32000.

This was disabled on purpose in #1649, but the rsp syntax was
different: this commit makes it so the options and output file
are still passed on the command line, gcc-ar didn't work
otherwise.

@nirbheek , no test was added as part of the commit that disabled this, can you maybe check whether this still breaks the original case? If so, we'll need to find another solution, incrementally building the archive file could be one but I'm wary of the potential performance hit.