### PR TITLE
Fix glib build when using MSI installer. Closes #3762.

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -349,7 +349,11 @@ def run(original_args, mainfile):
 
 def main():
     # Always resolve the command path so Ninja can find it for regen, tests, etc.
-    launcher = os.path.realpath(sys.argv[0])
+    if 'meson.exe' in sys.executable:
+        assert(os.path.isabs(sys.executable))
+        launcher = sys.executable
+    else:
+        launcher = os.path.realpath(sys.argv[0])
     return run(sys.argv[1:], launcher)
 
 if __name__ == '__main__':

--- a/msi/createmsi.py
+++ b/msi/createmsi.py
@@ -85,6 +85,7 @@ class PackageGenerator:
         main_stage, ninja_stage = self.staging_dirs
         modules = [os.path.splitext(os.path.split(x)[1])[0] for x in glob(os.path.join('mesonbuild/modules/*'))]
         modules = ['mesonbuild.modules.' + x for x in modules if not x.startswith('_')]
+        modules += ['distutils.version']
         modulestr = ','.join(modules)
         python = shutil.which('python')
         cxfreeze = os.path.join(os.path.dirname(python), "Scripts", "cxfreeze")


### PR DESCRIPTION
Seems to work for me. I created an installer of this version, which [can be downloaded from here](https://www.dropbox.com/s/cv77i0l38ha8i88/meson-0.47.0.1-TRIAL-64.msi?dl=0). **Note**: use that only for testing this bug, it's not supported for any other use.