### PR TITLE
d: Don't fail if -link-defaultlib is manually added to the LDC link args

### DIFF
--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -212,6 +212,14 @@ class DCompiler(Compiler):
                 for la in linkargs:
                     dcargs.append('-L' + la.strip())
                 continue
+            elif arg.startswith('-link-defaultlib') or arg.startswith('-linker'):
+                # these are special arguments to the LDC linker call,
+                # arguments like "-link-defaultlib-shared" do *not*
+                # denote a library to be linked, but change the default
+                # Phobos/DRuntime linking behavior, while "-linker" sets the
+                # default linker.
+                dcargs.append(arg)
+                continue
             elif arg.startswith('-l'):
                 # translate library link flag
                 dcargs.append('-L' + arg)


### PR DESCRIPTION
Hi!
The comment in the patch describes the issue already, basically.
The LDC D compiler has a `-link-defaultlib*` flag to change standard library linking behavior, and users in some occasions want to add that flag manually to `link_args`. The automatic GCC/Clang --> LDC/DMD flag rewriting code thinks the defaultlib flag is for linking a library though (it starts with `-l` afterall...), so incorrectly prepends a `-L`.
This patch prevents the issue from happening and makes Meson not touch this special flag in case it gets passed to LDC.
