### PR TITLE
fix find_library when cross-compiling 32-bit on 64-bit systems

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -863,7 +863,17 @@ class CCompiler(Compiler):
             for suffix in suffixes:
                 for prefix in prefixes:
                     trial = os.path.join(d, prefix + libname + '.' + suffix)
-                    if os.path.isfile(trial):
+                    # as well as checking the path, we need to check compilation
+                    # with link-whole, as static libs (.a) need to be checked
+                    # to ensure they are the right architecture, e.g. 32bit or
+                    # 64-bit. Just a normal test link won't work as the .a file
+                    # doesn't seem to be checked by linker if there are no
+                    # unresolved symbols from the main C file.
+                    extra_link_args = self.get_link_whole_for([trial])
+                    extra_link_args = self.linker_to_compiler_args(extra_link_args)
+                    if (os.path.isfile(trial) and
+                            self.links(code, env,
+                                       extra_args=extra_link_args)):
                         return [trial]
         # XXX: For OpenBSD and macOS we (may) need to search for libfoo.x.y.z.dylib
         return None


### PR DESCRIPTION
When find_library is used to find dependencies, meson checks all paths for
libraries with all prefixes that could match. This means that when we are
compiling with -m32 on a 64-bit system, meson will find 64-bit libraries and
assumes that they will work. Naturally that is not the case.

The obvious fix is to do a test link against those libraries, but the extra
wrinkle here is that we need to do a "whole link" so as to test the static
libs. A check with gcc+ld on linux shows that unless there are unresolved
symbols from the main.c file, the static library is never checked so we avoid
the error from an incompatible library.