### PR TITLE
Fix ExtraFrameworkDependency framework detection

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1003,7 +1003,7 @@ class ExtraFrameworkDependency(ExternalDependency):
         for p in paths:
             for d in os.listdir(p):
                 fullpath = os.path.join(p, d)
-                if lname != d.split('.')[0].lower():
+                if lname != d.rsplit('.', 1)[0].lower():
                     continue
                 if not stat.S_ISDIR(os.stat(fullpath).st_mode):
                     continue


### PR DESCRIPTION
The name splitting was wrong and would incorrectly handle folders
with two dots, like `Foo.framework.dSYM` and treat this as `Foo` instead
of `Foo.framework`, which would lead to meson detecting dSYM bundles
as frameworks and try to use those like a framework, which is wrong.

Fix #3793