### PR TITLE
Emacs: correctly setup Emacs `comment-start` and `comment-end`

### DIFF
--- a/data/syntax-highlighting/emacs/meson.el
+++ b/data/syntax-highlighting/emacs/meson.el
@@ -27,3 +27,5 @@
   (setq-local comment-end ""))
 
 (add-to-list 'auto-mode-alist '("meson.build" . meson-mode))
+(provide 'meson)
+;;; meson.el ends here

--- a/data/syntax-highlighting/emacs/meson.el
+++ b/data/syntax-highlighting/emacs/meson.el
@@ -1,14 +1,3 @@
-;; command to comment/uncomment text
-(defun meson-comment-dwim (arg)
-  "Comment or uncomment current line or region in a smart way.
-For detail, see `comment-dwim'."
-  (interactive "*P")
-  (require 'newcomment)
-  (let (
-        (comment-start "#") (comment-end "")
-        )
-    (comment-dwim arg)))
-
 ;; keywords for syntax coloring
 (setq meson-keywords
       `(
@@ -34,9 +23,7 @@ For detail, see `comment-dwim'."
 
   (setq font-lock-defaults '(meson-keywords))
   (setq mode-name "meson")
-
-  ;; modify the keymap
-  (define-key meson-mode-map [remap comment-dwim] 'meson-comment-dwim)
-)
+  (setq-local comment-start "# ")
+  (setq-local comment-end ""))
 
 (add-to-list 'auto-mode-alist '("meson.build" . meson-mode))


### PR DESCRIPTION
I don't know what was the reasoning behind the creation of `meson-comment-dwim`.

The functionality is already provided/mapped by `comment-dwim` if you setup `comment-start` and `comment-end` correctly. Also other functions like `comment-kill` will work as expected instead of raising an error:

```
Debugger entered--Lisp error: (error "No comment syntax defined")
  signal(error ("No comment syntax defined"))
  error("No comment syntax defined")
  comment-normalize-vars()
  kill-comment(nil)
```

Also provide a `FEATURE`  footer to prevent:

```
(require 'meson)
*** Eval error ***  Loading file /usr/share/emacs/site-lisp/meson.el failed to provide feature ‘meson’
```