### PR TITLE
scripts/gtkdochelper: add support for --run

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -848,20 +848,27 @@ This will become a hard error in the future.''')
             if not isinstance(incd.held_object, (str, build.IncludeDirs)):
                 raise MesonException(
                     'Gir include dirs should be include_directories().')
+
         cflags.update(get_include_args(inc_dirs))
-        cflags.update(state.environment.coredata.get_external_args('c'))
         ldflags = OrderedSet()
         ldflags.update(internal_ldflags)
-        ldflags.update(state.environment.coredata.get_external_link_args('c'))
         ldflags.update(external_ldflags)
+
+        if state.environment.is_cross_build():
+            compiler = state.environment.coredata.cross_compilers.get('c')
+        else:
+            cflags.update(state.environment.coredata.get_external_args('c'))
+            ldflags.update(state.environment.coredata.get_external_link_args('c'))
+            compiler = state.environment.coredata.compilers.get('c')
+
+        if compiler:
+            args += ['--cc=%s' % ' '.join(compiler.get_exelist())]
+            args += ['--ld=%s' % ' '.join(compiler.get_linker_exelist())]
         if cflags:
             args += ['--cflags=%s' % ' '.join(cflags)]
         if ldflags:
             args += ['--ldflags=%s' % ' '.join(ldflags)]
-        compiler = state.environment.coredata.compilers.get('c')
-        if compiler:
-            args += ['--cc=%s' % ' '.join(compiler.get_exelist())]
-            args += ['--ld=%s' % ' '.join(compiler.get_linker_exelist())]
+
 
         return args
 

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -45,6 +45,7 @@ parser.add_argument('--ignore-headers', dest='ignore_headers', default='')
 parser.add_argument('--namespace', dest='namespace', default='')
 parser.add_argument('--mode', dest='mode', default='')
 parser.add_argument('--installdir', dest='install_dir')
+parser.add_argument('--run', dest='run', default='')
 
 def gtkdoc_run_check(cmd, cwd, library_path=None):
     env = dict(os.environ)
@@ -64,7 +65,7 @@ def gtkdoc_run_check(cmd, cwd, library_path=None):
 def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
                  main_file, module,
                  html_args, scan_args, fixxref_args, mkdb_args,
-                 gobject_typesfile, scanobjs_args, ld, cc, ldflags, cflags,
+                 gobject_typesfile, scanobjs_args, run, ld, cc, ldflags, cflags,
                  html_assets, content_files, ignore_headers, namespace,
                  expand_content_files, mode):
     print("Building documentation for %s" % module)
@@ -125,6 +126,7 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
     if gobject_typesfile:
         scanobjs_cmd = ['gtkdoc-scangobj'] + scanobjs_args + ['--types=' + gobject_typesfile,
                                                               '--module=' + module,
+                                                              '--run=' + run,
                                                               '--cflags=' + cflags,
                                                               '--ldflags=' + ldflags,
                                                               '--cc=' + cc,
@@ -231,6 +233,7 @@ def run(args):
         mkdbargs,
         options.gobject_typesfile,
         scanobjsargs,
+        options.run,
         options.ld,
         options.cc,
         options.ldflags,


### PR DESCRIPTION
gtkdoc-scangobj has a --run argument that specifies a wrapper to be used when
executing the GObject scanner.  Typically this can be libtool but it is also
useful in cross-compilation environments.

This patch adds support for this argument to the gtkdochelper so that tools
using the helper can pass --run.