### PR TITLE
Refactor getting the host system of a cross compiler

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -336,13 +336,11 @@ class Environment:
         # static libraries, and executables.
         # Versioning is added to these names in the backends as-needed.
         cross = self.is_cross_build()
-        if (not cross and mesonlib.is_windows()) \
-                or (cross and self.cross_info.has_host() and self.cross_info.config['host_machine']['system'] == 'windows'):
+        if mesonlib.for_windows(cross, self):
             self.exe_suffix = 'exe'
             self.object_suffix = 'obj'
             self.win_libdir_layout = True
-        elif (not cross and mesonlib.is_cygwin()) \
-                or (cross and self.cross_info.has_host() and self.cross_info.config['host_machine']['system'] == 'cygwin'):
+        elif mesonlib.for_cygwin(cross, self):
             self.exe_suffix = 'exe'
             self.object_suffix = 'o'
             self.win_libdir_layout = True
@@ -1023,6 +1021,13 @@ class CrossBuildInfo:
 
     def get_stdlib(self, language):
         return self.config['properties'][language + '_stdlib']
+
+    def get_host_system(self):
+        "Name of host system like 'linux', or None"
+        if self.has_host():
+            return self.config['host_machine']['system']
+        else:
+            return None
 
     def get_properties(self):
         return self.config['properties']

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -292,9 +292,8 @@ def for_windows(is_cross, env):
     """
     if not is_cross:
         return is_windows()
-    elif env.cross_info.has_host():
-        return env.cross_info.config['host_machine']['system'] == 'windows'
-    return False
+    else:
+        return env.cross_info.get_host_system() == 'windows'
 
 def for_cygwin(is_cross, env):
     """
@@ -304,9 +303,8 @@ def for_cygwin(is_cross, env):
     """
     if not is_cross:
         return is_cygwin()
-    elif env.cross_info.has_host():
-        return env.cross_info.config['host_machine']['system'] == 'cygwin'
-    return False
+    else:
+        return env.cross_info.get_host_system() == 'cygwin'
 
 def for_linux(is_cross, env):
     """
@@ -316,9 +314,8 @@ def for_linux(is_cross, env):
     """
     if not is_cross:
         return is_linux()
-    elif env.cross_info.has_host():
-        return env.cross_info.config['host_machine']['system'] == 'linux'
-    return False
+    else:
+        return env.cross_info.get_host_system() == 'linux'
 
 def for_darwin(is_cross, env):
     """
@@ -328,9 +325,8 @@ def for_darwin(is_cross, env):
     """
     if not is_cross:
         return is_osx()
-    elif env.cross_info.has_host():
-        return env.cross_info.config['host_machine']['system'] in ('darwin', 'ios')
-    return False
+    else:
+        return env.cross_info.get_host_system() in ('darwin', 'ios')
 
 def for_android(is_cross, env):
     """
@@ -340,9 +336,8 @@ def for_android(is_cross, env):
     """
     if not is_cross:
         return is_android()
-    elif env.cross_info.has_host():
-        return env.cross_info.config['host_machine']['system'] == 'android'
-    return False
+    else:
+        return env.cross_info.get_host_system() == 'android'
 
 def for_haiku(is_cross, env):
     """
@@ -352,9 +347,8 @@ def for_haiku(is_cross, env):
     """
     if not is_cross:
         return is_haiku()
-    elif env.cross_info.has_host():
-        return env.cross_info.config['host_machine']['system'] == 'haiku'
-    return False
+    else:
+        return env.cross_info.get_host_system() == 'haiku'
 
 def exe_exists(arglist):
     try:


### PR DESCRIPTION
Use mesonlib.for_windows or mesonlib.for_cygwin instead of
reimplementing them.

Add CrossBuildInfo.get_host_system to shorten the repeated the code in
the mesonlib.for_<platform> methods.