### PR TITLE
Allow command lists for find_program cross file overrides

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1713,7 +1713,11 @@ class CustomTarget(Target):
                 if not c.found():
                     m = 'Tried to use not-found external program {!r} in "command"'
                     raise InvalidArguments(m.format(c.name))
-                self.depend_files.append(File.from_absolute_file(c.get_path()))
+                path = c.get_path()
+                if os.path.isabs(path):
+                    # Can only add a dependency on an external program which we
+                    # know the absolute path of
+                    self.depend_files.append(File.from_absolute_file(path))
                 final_cmd += c.get_command()
             elif isinstance(c, (BuildTarget, CustomTarget)):
                 self.dependencies.append(c)

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -438,8 +438,7 @@ class PkgConfigDependency(ExternalDependency):
                 if self.required:
                     raise DependencyException('Pkg-config binary missing from cross file')
             else:
-                pkgname = environment.cross_info.config['binaries']['pkgconfig']
-                potential_pkgbin = ExternalProgram(pkgname, silent=True)
+                potential_pkgbin = ExternalProgram.from_cross_info(environment.cross_info, 'pkgconfig')
                 if potential_pkgbin.found():
                     self.pkgbin = potential_pkgbin
                     PkgConfigDependency.class_pkgbin = self.pkgbin
@@ -788,6 +787,24 @@ class ExternalProgram:
     def __repr__(self):
         r = '<{} {!r} -> {!r}>'
         return r.format(self.__class__.__name__, self.name, self.command)
+
+    @staticmethod
+    def from_cross_info(cross_info, name):
+        if name not in cross_info.config['binaries']:
+            return NonExistingExternalProgram()
+        command = cross_info.config['binaries'][name]
+        if not isinstance(command, (list, str)):
+            raise MesonException('Invalid type {!r} for binary {!r} in cross file'
+                                 ''.format(command, name))
+        if isinstance(command, list):
+            if len(command) == 1:
+                command = command[0]
+        # We cannot do any searching if the command is a list, and we don't
+        # need to search if the path is an absolute path.
+        if isinstance(command, list) or os.path.isabs(command):
+            return ExternalProgram(name, command=command, silent=True)
+        # Search for the command using the specified string!
+        return ExternalProgram(command, silent=True)
 
     @staticmethod
     def _shebang_to_cmd(script):

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -291,10 +291,10 @@ class QtBaseDependency(ExternalDependency):
                 self.bindir = os.path.join(prefix, 'bin')
 
     def _find_qmake(self, qmake):
-        # Even when cross-compiling, if we don't get a cross-info qmake, we
+        # Even when cross-compiling, if a cross-info qmake is not specified, we
         # fallback to using the qmake in PATH because that's what we used to do
-        if self.env.is_cross_build():
-            qmake = self.env.cross_info.config['binaries'].get('qmake', qmake)
+        if self.env.is_cross_build() and 'qmake' in self.env.cross_info.config['binaries']:
+            return ExternalProgram.from_cross_info(self.env.cross_info, 'qmake')
         return ExternalProgram(qmake, silent=True)
 
     def _qmake_detect(self, mods, kwargs):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2618,23 +2618,18 @@ external dependencies (including libraries) must go to "dependencies".''')
         self.emit_base_options_warnings(enabled_opts)
 
     def program_from_cross_file(self, prognames, silent=False):
-        bins = self.environment.cross_info.config['binaries']
+        cross_info = self.environment.cross_info
         for p in prognames:
             if hasattr(p, 'held_object'):
                 p = p.held_object
             if isinstance(p, mesonlib.File):
                 continue # Always points to a local (i.e. self generated) file.
             if not isinstance(p, str):
-                raise InterpreterException('Executable name must be a string.')
-            if p in bins:
-                command = bins[p]
-                if isinstance(command, (list, str)):
-                    extprog = dependencies.ExternalProgram(p, command=command, silent=silent)
-                else:
-                    raise InterpreterException('Invalid type {!r} for binary {!r} in cross file'
-                                               ''.format(command, p))
-                progobj = ExternalProgramHolder(extprog)
-                return progobj
+                raise InterpreterException('Executable name must be a string')
+            prog = ExternalProgram.from_cross_info(cross_info, p)
+            if prog.found():
+                return ExternalProgramHolder(prog)
+        return None
 
     def program_from_system(self, args, silent=False):
         # Search for scripts relative to current subdir.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2627,8 +2627,12 @@ external dependencies (including libraries) must go to "dependencies".''')
             if not isinstance(p, str):
                 raise InterpreterException('Executable name must be a string.')
             if p in bins:
-                exename = bins[p]
-                extprog = dependencies.ExternalProgram(exename, silent=silent)
+                command = bins[p]
+                if isinstance(command, (list, str)):
+                    extprog = dependencies.ExternalProgram(p, command=command, silent=silent)
+                else:
+                    raise InterpreterException('Invalid type {!r} for binary {!r} in cross file'
+                                               ''.format(command, p))
                 progobj = ExternalProgramHolder(extprog)
                 return progobj
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3207,7 +3207,8 @@ class LinuxlikeTests(BasePlatformTests):
 c = '/usr/bin/cc'
 ar = '/usr/bin/ar'
 strip = '/usr/bin/ar'
-sometool.py = '%s'
+sometool.py = ['{0}']
+someothertool.py = '{0}'
 
 [properties]
 
@@ -3216,7 +3217,7 @@ system = 'linux'
 cpu_family = 'arm'
 cpu = 'armv7' # Not sure if correct.
 endian = 'little'
-''' % os.path.join(testdir, 'some_cross_tool.py'))
+'''.format(os.path.join(testdir, 'some_cross_tool.py')))
         crossfile.flush()
         self.meson_cross_file = crossfile.name
         self.init(testdir)

--- a/test cases/unit/12 cross prog/meson.build
+++ b/test cases/unit/12 cross prog/meson.build
@@ -2,11 +2,15 @@ project('cross find program', 'c')
 
 native_exe = find_program('sometool.py', native : true)
 cross_exe = find_program('sometool.py')
+cross_other_exe = find_program('someothertool.py')
 
 native_out = run_command(native_exe).stdout().strip()
 cross_out = run_command(cross_exe).stdout().strip()
+cross_other_out = run_command(cross_other_exe).stdout().strip()
 
 assert(native_out == 'native',
   'Native output incorrect:' + native_out)
 assert(cross_out == 'cross',
   'Cross output incorrect:' + cross_out)
+assert(cross_out == cross_other_out,
+  'Cross output incorrect:' + cross_other_out)


### PR DESCRIPTION
This is accepted by all other binaries in the cross file. With this
change, we also don't check whether the specified command exists at
configure time, but that's probably a feature anyway.

Fixes https://github.com/mesonbuild/meson/issues/3737