### PR TITLE
Nirbheek/fix pkgconfig library dedup

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -170,16 +170,18 @@ class DependenciesHelper:
         return ', '.join(result)
 
     def remove_dups(self):
-        def _fn(xs):
+        def _fn(xs, libs=False):
             # Remove duplicates whilst preserving original order
             result = []
             for x in xs:
-                if x not in result:
+                # Don't de-dup unknown strings to avoid messing up arguments like:
+                # ['-framework', 'CoreAudio', '-framework', 'CoreMedia']
+                if x not in result or (libs and (isinstance(x, str) and not x.endswith(('-l', '-L')))):
                     result.append(x)
             return result
-        self.pub_libs = _fn(self.pub_libs)
+        self.pub_libs = _fn(self.pub_libs, True)
         self.pub_reqs = _fn(self.pub_reqs)
-        self.priv_libs = _fn(self.priv_libs)
+        self.priv_libs = _fn(self.priv_libs, True)
         self.priv_reqs = _fn(self.priv_reqs)
         self.cflags = _fn(self.cflags)
 

--- a/test cases/unit/33 external, internal library rpath/external library/meson.build
+++ b/test cases/unit/33 external, internal library rpath/external library/meson.build
@@ -5,5 +5,5 @@ l = shared_library('faa_pkg', 'faa.c', install: true)
 
 pkg = import('pkgconfig')
 pkg.generate(name: 'faa_pkg',
-             libraries: l,
+             libraries: [l, '-framework', 'CoreFoundation', '-framework', 'CoreMedia'],
              description: 'FAA, a pkg-config test library')


### PR DESCRIPTION
commit 405543f2b5b9f8676095bc3c016fe4342675e617

    pkgconfig module: Fix needlessly aggressive de-dup

commit db9ea8a2db97c09c5351b4ae64fba438451b4f91

    pkgconfig: Don't naively de-dup all arguments

    Honestly don't know what I was smoking. Of course the `Libs:` field in
    a pkg-config file can have arguments other than -l and -L

    Closes https://github.com/mesonbuild/meson/issues/3800

commit b90d03bf63ff6d94bc3af3abf6423193fc5ee9ee

    Add a test case for bad de-dup of -framework args

    https://github.com/mesonbuild/meson/issues/3800