### PR TITLE
Check if calls to configure_file write to the same output file.

### DIFF
--- a/docs/markdown/snippets/configure_file_overwrite_warning.md
+++ b/docs/markdown/snippets/configure_file_overwrite_warning.md
@@ -1,0 +1,39 @@
+## Meson warns if two calls to configure_file() write to the same file
+
+If two calls to [`configure_file()`](#Reference-manual.md#configure_file)
+write to the same file Meson will print a `WARNING:` message during
+configuration. For example:
+```meson
+project('configure_file', 'cpp')
+
+configure_file(
+      input: 'a.in',
+      output: 'out',
+      command: ['./foo.sh']
+    )
+configure_file(
+  input: 'a.in',
+  output: 'out',
+  command: ['./foo.sh']
+)
+
+```
+
+This will output:
+
+```
+The Meson build system
+Version: 0.47.0.dev1
+Source dir: /path/to/srctree
+Build dir: /path/to/buildtree
+Build type: native build
+Project name: configure_file
+Project version: undefined
+Build machine cpu family: x86_64
+Build machine cpu: x86_64
+Configuring out with command
+WARNING: Output file out for configure_file overwritten. First time written in line 3 now in line 8
+Configuring out with command
+Build targets in project: 0
+Found ninja-1.8.2 at /usr/bin/ninja
+```

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3452,10 +3452,10 @@ root and issuing %s.
         if not isinstance(output, str):
             raise InterpreterException('Output file name must be a string')
         if ofile_rpath in self.configure_file_outputs:
-            if len(self.subdir) > 0:
-                mlog.warning('Output file', mlog.bold(ofile_rpath), 'for configure_file overwritten. First time written in subdir', self.subdir, 'line', self.configure_file_outputs[ofile_rpath], 'now in line', self.current_lineno)
-            else:
-                mlog.warning('Output file', mlog.bold(ofile_rpath), 'for configure_file overwritten. First time written in line', self.configure_file_outputs[ofile_rpath], 'now in line', self.current_lineno)
+            mesonbuildfile = os.path.join(self.subdir, 'meson.build')
+            current_call = "{}:{}".format(mesonbuildfile, self.current_lineno)
+            first_call = "{}:{}".format(mesonbuildfile, self.configure_file_outputs[ofile_rpath])
+            mlog.warning('Output file', mlog.bold("'{}'".format(ofile_rpath)), 'for configure_file() at', current_call, 'overwrites configure_file() output at', first_call)
         else:
             self.configure_file_outputs[ofile_rpath] = self.current_lineno
         if ifile_abs:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3455,7 +3455,7 @@ root and issuing %s.
             mesonbuildfile = os.path.join(self.subdir, 'meson.build')
             current_call = "{}:{}".format(mesonbuildfile, self.current_lineno)
             first_call = "{}:{}".format(mesonbuildfile, self.configure_file_outputs[ofile_rpath])
-            mlog.warning('Output file', mlog.bold("'{}'".format(ofile_rpath)), 'for configure_file() at', current_call, 'overwrites configure_file() output at', first_call)
+            mlog.warning('Output file', mlog.bold(ofile_rpath, True), 'for configure_file() at', current_call, 'overwrites configure_file() output at', first_call)
         else:
             self.configure_file_outputs[ofile_rpath] = self.current_lineno
         if ifile_abs:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3451,9 +3451,9 @@ root and issuing %s.
         if not isinstance(output, str):
             raise InterpreterException('Output file name must be a string')
         if output in self.configure_file_outputs:
-            mlog.warning('Output file', mlog.bold(output), 'for configure_file overwritten.')
+            mlog.warning('Output file', mlog.bold(output), 'for configure_file overwritten. First time written in line', self.configure_file_outputs[output], 'now in line', self.current_lineno)
         else:
-            self.configure_file_outputs[output] = None
+            self.configure_file_outputs[output] = self.current_lineno
         if ifile_abs:
             values = mesonlib.get_filenames_templates_dict([ifile_abs], None)
             outputs = mesonlib.substitute_values([output], values)

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3448,12 +3448,16 @@ root and issuing %s.
             raise InterpreterException('@INPUT@ used as command argument, but no input file specified.')
         # Validate output
         output = kwargs['output']
+        ofile_rpath = os.path.join(self.subdir, output)
         if not isinstance(output, str):
             raise InterpreterException('Output file name must be a string')
-        if output in self.configure_file_outputs:
-            mlog.warning('Output file', mlog.bold(output), 'for configure_file overwritten. First time written in line', self.configure_file_outputs[output], 'now in line', self.current_lineno)
+        if ofile_rpath in self.configure_file_outputs:
+            if len(self.subdir) > 0:
+                mlog.warning('Output file', mlog.bold(ofile_rpath), 'for configure_file overwritten. First time written in subdir', self.subdir, 'line', self.configure_file_outputs[ofile_rpath], 'now in line', self.current_lineno)
+            else:
+                mlog.warning('Output file', mlog.bold(ofile_rpath), 'for configure_file overwritten. First time written in line', self.configure_file_outputs[ofile_rpath], 'now in line', self.current_lineno)
         else:
-            self.configure_file_outputs[output] = self.current_lineno
+            self.configure_file_outputs[ofile_rpath] = self.current_lineno
         if ifile_abs:
             values = mesonlib.get_filenames_templates_dict([ifile_abs], None)
             outputs = mesonlib.substitute_values([output], values)

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1862,6 +1862,7 @@ class Interpreter(InterpreterBase):
         self.global_args_frozen = False  # implies self.project_args_frozen
         self.subprojects = {}
         self.subproject_stack = []
+        self.configure_file_outputs = {}
         # Passed from the outside, only used in subprojects.
         if default_project_options:
             self.default_project_options = default_project_options.copy()
@@ -3449,6 +3450,10 @@ root and issuing %s.
         output = kwargs['output']
         if not isinstance(output, str):
             raise InterpreterException('Output file name must be a string')
+        if output in self.configure_file_outputs:
+            mlog.warning('Output file', mlog.bold(output), 'for configure_file overwritten.')
+        else:
+            self.configure_file_outputs[output] = None
         if ifile_abs:
             values = mesonlib.get_filenames_templates_dict([ifile_abs], None)
             outputs = mesonlib.substitute_values([output], values)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2294,8 +2294,8 @@ recommended as it is not supported on some platforms''')
         self.assertRegex(out, "WARNING:.*'empty'.*config.h.in.*not present.*")
         self.assertRegex(out, "WARNING:.*empty configuration_data.*test.py.in")
         # Warnings for configuration files that are overwritten.
-        self.assertRegex(out, "WARNING:.*double_output.txt.*overwrites")
-        self.assertRegex(out, "WARNING:.*subdir/double_output2.txt.*overwrites")
+        self.assertRegex(out, "WARNING:.*\"double_output.txt\".*overwrites")
+        self.assertRegex(out, "WARNING:.*\"subdir.double_output2.txt\".*overwrites")
         self.assertNotRegex(out, "WARNING:.*no_write_conflict.txt.*overwrites")
         # No warnings about empty configuration data objects passed to files with substitutions
         self.assertNotRegex(out, "WARNING:.*empty configuration_data.*nosubst-nocopy1.txt.in")

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2293,6 +2293,10 @@ recommended as it is not supported on some platforms''')
         self.assertRegex(out, "WARNING:.*'FOO_BAR'.*nosubst-nocopy2.txt.in.*not present.*")
         self.assertRegex(out, "WARNING:.*'empty'.*config.h.in.*not present.*")
         self.assertRegex(out, "WARNING:.*empty configuration_data.*test.py.in")
+        # Warnings for configuration files that are overwritten.
+        self.assertRegex(out, "WARNING:.*double_output.txt.*overwrites")
+        self.assertRegex(out, "WARNING:.*subdir/double_output2.txt.*overwrites")
+        self.assertNotRegex(out, "WARNING:.*no_write_conflict.txt.*overwrites")
         # No warnings about empty configuration data objects passed to files with substitutions
         self.assertNotRegex(out, "WARNING:.*empty configuration_data.*nosubst-nocopy1.txt.in")
         self.assertNotRegex(out, "WARNING:.*empty configuration_data.*nosubst-nocopy2.txt.in")

--- a/test cases/common/16 configure file/meson.build
+++ b/test cases/common/16 configure file/meson.build
@@ -193,21 +193,40 @@ configure_file(
   configuration : configuration_data()
 )
 
-# Test that passing an empty configuration_data() object to a file with
-# @FOO@ substitutions does not print the warning.
+# test that passing an empty configuration_data() object to a file with
+# @foo@ substitutions does not print the warning.
 configure_file(
   input: 'nosubst-nocopy2.txt.in',
   output: 'nosubst-nocopy2.txt',
   configuration : configuration_data()
 )
 
-# Test that passing a configured file object to test() works, and that passing
+# test that passing a configured file object to test() works, and that passing
 # an empty configuration_data() object to a file that leads to no substitutions
 # prints a warning (see unit tests)
 test_file = configure_file(
   input: 'test.py.in',
   output: 'test.py',
   configuration: configuration_data()
+)
+
+# Test that overwriting an existing file creates a warning.
+configure_file(
+  input: 'test.py.in',
+  output: 'double_output.txt',
+  configuration: conf
+)
+configure_file(
+  input: 'test.py.in',
+  output: 'double_output.txt',
+  configuration: conf
+)
+
+# Test that the same file name in a different subdir will not create a warning
+configure_file(
+  input: 'test.py.in',
+  output: 'no_write_conflict.txt',
+  configuration: conf
 )
 
 test('configure-file', test_file)

--- a/test cases/common/16 configure file/subdir/meson.build
+++ b/test cases/common/16 configure file/subdir/meson.build
@@ -17,3 +17,22 @@ configure_file(input : '../dummy.dat',
   output : 'config2-3.h',
   command : [found_script,  '@INPUT@', '@OUTPUT@'])
 run_command(check_file, join_paths(meson.current_build_dir(), 'config2-3.h'))
+
+# Test that overwriting an existing file creates a warning.
+configure_file(
+  input: '../test.py.in',
+  output: 'double_output2.txt',
+  configuration: conf
+)
+configure_file(
+  input: '../test.py.in',
+  output: 'double_output2.txt',
+  configuration: conf
+)
+
+# Test that the same file name in a different subdir will not create a warning
+configure_file(
+  input: '../test.py.in',
+  output: 'no_write_conflict.txt',
+  configuration: conf
+)


### PR DESCRIPTION
If two calls to configure_file write to the same output file, print a warning. The warning contains the line number of the first call and the line number of the current call.

Fixes: #3714