### PR TITLE
Dictionary expansion for keyword arguments

### DIFF
--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -883,8 +883,7 @@ The result of this is undefined and will become a hard error in a future Meson r
             if not isinstance(reduced_dict, dict):
                 raise InvalidArguments("Keyword argument expansion is not a dictionary.")
 
-            for key, value in reduced_dict.items():
-                reduced_kw[key] = value
+            reduced_kw.update(reduced_dict)
 
         self.argument_depth -= 1
         return reduced_pos, reduced_kw

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -876,6 +876,16 @@ The result of this is undefined and will become a hard error in a future Meson r
                 raise InvalidArguments('Keyword argument name is not a string.')
             a = args.kwargs[key]
             reduced_kw[key] = self.evaluate_statement(a)
+
+        if args.kwargs_dict is not None:
+            reduced_dict = self.evaluate_statement(args.kwargs_dict)
+
+            if not isinstance(reduced_dict, dict):
+                raise InvalidArguments("Keyword argument expansion is not a dictionary.")
+
+            for key, value in reduced_dict.items():
+                reduced_kw[key] = value
+
         self.argument_depth -= 1
         return reduced_pos, reduced_kw
 

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -394,6 +394,7 @@ class ArgumentNode:
         self.arguments = []
         self.commas = []
         self.kwargs = {}
+        self.kwargs_dict = None
         self.order_error = False
 
     def prepend(self, statement):
@@ -663,6 +664,7 @@ class Parser:
 
         while not isinstance(s, EmptyNode):
             potential = self.current
+
             if self.accept('comma'):
                 a.commas.append(potential)
                 a.append(s)
@@ -678,6 +680,12 @@ class Parser:
             else:
                 a.append(s)
                 return a
+
+            if self.accept('star'):
+                dict_expr = self.statement()
+                a.kwargs_dict = dict_expr
+                return a
+
             s = self.statement()
         return a
 


### PR DESCRIPTION
This is a basic draft for an implementation of #3819. It should be considered an RFC more than anything.

A python-like syntax is chosen in this implementation:
```meson
project('kwargs', 'c')

opts = { 'install' : true }
exe = executable('foobar', 'foobar.c', *opts)
```

The above is equivalent to:
```meson
project('kwargs', 'c')

exe = executable('foobar', 'foobar.c', install : true)
```

Unlike Python, I went for a single asterisk. This is because Python has both positional and keyword arguments expansion (`*` and `**` respectively). The former does not make much sense for meson, and the single asterisk syntax is otherwise unambiguous.

As in Python, the expansion must be the last element in the argument list:
```meson
project('kwargs', 'c')

opts = { 'install' : true }
exe = executable('foobar', 'foobar.c', *opts, 'some_option' : 'some_value')
# Parse error
```

Keywords specified in the dictionary override those written directly in the call:
```meson
project('kwargs', 'c')

opts = { 'install' : true }
exe = executable('foobar', 'foobar.c', install : false, *opts)
# install is true
```

The expansion expression can be arbitrarily complex (at least, as far as meson's parser allows):
```meson
project('kwargs', 'c')

opts = { 'install' : true }
new_opts = { 'install' : false, 'super_install' : true }

exe = executable('foobar', 'foobar.c', 
    install : false,
    *(meson.version().version_compare('>0.99.0') ? new_opts : opts)
)
```

An implementation detail allows for a certain peculiarity with this syntax: the asterisk "operator" has the lowest precedence, so the parentheses are actually not necessary in the above example, which may not be obvious:
```meson
project('kwargs', 'c')

opts = { 'install' : true }
new_opts = { 'install' : false, 'super_install' : true }

exe = executable('foobar', 'foobar.c', 
    install : false,
    *meson.version().version_compare('>0.99.0') ? new_opts : opts
)
```
**EDIT**: Just checked, turns out Python handles it the same way.


As I mentioned on IRC earlier, this feature would be a lot more useful if we had some way of either modifying dictionaries, or creating a new one by merging two others. The later approach is consistent with the way arrays work.