### PR TITLE
Nirbheek/fix featurenew subprojects

### DIFF
--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -78,6 +78,7 @@ syn keyword mesonBuiltin
   \ custom_target
   \ declare_dependency
   \ dependency
+  \ disabler
   \ environment
   \ error
   \ executable

--- a/docs/markdown/Contributing.md
+++ b/docs/markdown/Contributing.md
@@ -29,6 +29,20 @@ Do not merge head back to your branch. Any merge commits in your pull
 request make it not acceptable for merging into master and you must
 remove them.
 
+## Special procedure for new features
+
+Every new feature requires some extra steps, namely:
+
+ - Must include a project test under `test cases/`, or if that's not
+   possible or if the test requires a special environment, it must go
+   into `run_unittests.py`.
+ - Must be registered with the [FeatureChecks framework](Release-notes-for-0.47.0.md#Feature_detection_based_on_meson_version_in_project)
+   that will warn the user if they try to use a new feature while
+   targetting an older meson version.
+ - Needs a release note snippet inside `docs/markdown/snippets/` with
+   a heading and a brief paragraph explaining what the feature does
+   with an example.
+
 ## Acceptance and merging
 
 The kind of review and acceptance any merge proposal gets depends on

--- a/docs/markdown/snippets/feature_new.md
+++ b/docs/markdown/snippets/feature_new.md
@@ -24,9 +24,9 @@ Project name: featurenew
 Project version: undefined
 Build machine cpu family: x86_64
 Build machine cpu: x86_64
-WARNING: Project targetting '>=0.43' but tried to use feature introduced in '0.44.0': get_unquoted
+WARNING: Project targetting '>=0.43' but tried to use feature introduced in '0.44.0': configuration_data.get_unquoted()
 Message: bar
 Build targets in project: 0
-Minimum version of features used:
-0.44.0: {'get_unquoted'}
+WARNING: Project specifies a minimum meson_version '>=0.43' which conflicts with:
+ * 0.44.0: {'configuration_data.get_unquoted()'}
 ```

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1780,7 +1780,7 @@ class CustomTarget(Target):
                                            'when installing a target')
 
                 if isinstance(kwargs['install_dir'], list):
-                    FeatureNew('multiple install_dir for custom_target', '0.40.0').use()
+                    FeatureNew('multiple install_dir for custom_target', '0.40.0').use(self.subproject)
                 # If an item in this list is False, the output corresponding to
                 # the list index of that item will not be installed
                 self.install_dir = typeslistify(kwargs['install_dir'], (str, bool))

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -31,11 +31,9 @@ from .base import (
     ConfigToolDependency,
 )
 
-from ..interpreterbase import FeatureNew
 
 class MPIDependency(ExternalDependency):
 
-    @FeatureNew('MPI Dependency', '0.42.0')
     def __init__(self, environment, kwargs):
         language = kwargs.get('language', 'c')
         super().__init__('mpi', environment, language, kwargs)
@@ -252,7 +250,6 @@ class OpenMPDependency(ExternalDependency):
         '199810': '1.0',
     }
 
-    @FeatureNew('OpenMP Dependency', '0.46.0')
     def __init__(self, environment, kwargs):
         language = kwargs.get('language')
         super().__init__('openmp', environment, language, kwargs)
@@ -433,7 +430,6 @@ class Python3Dependency(ExternalDependency):
 
 class PcapDependency(ExternalDependency):
 
-    @FeatureNew('Pcap Dependency', '0.42.0')
     def __init__(self, environment, kwargs):
         super().__init__('pcap', environment, None, kwargs)
 
@@ -517,7 +513,6 @@ class CupsDependency(ExternalDependency):
 
 
 class LibWmfDependency(ExternalDependency):
-    @FeatureNew('LibWMF Dependency', '0.44.0')
     def __init__(self, environment, kwargs):
         super().__init__('libwmf', environment, None, kwargs)
 

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -33,7 +33,6 @@ from .base import ExternalDependency, ExternalProgram
 from .base import ExtraFrameworkDependency, PkgConfigDependency
 from .base import ConfigToolDependency
 
-from ..interpreterbase import FeatureNew
 
 class GLDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
@@ -516,7 +515,6 @@ class WxDependency(ConfigToolDependency):
 
 class VulkanDependency(ExternalDependency):
 
-    @FeatureNew('Vulkan Dependency', '0.42.0')
     def __init__(self, environment, kwargs):
         super().__init__('vulkan', environment, None, kwargs)
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -329,7 +329,7 @@ This will become a hard error in the future''')
             return args[1]
         raise InterpreterException('Entry %s not in configuration data.' % name)
 
-    @FeatureNew('configuration_data.get_unquoted', '0.44.0')
+    @FeatureNew('configuration_data.get_unquoted()', '0.44.0')
     def get_unquoted_method(self, args, kwargs):
         if len(args) < 1 or len(args) > 2:
             raise InterpreterException('Get method takes one or two arguments.')

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -23,8 +23,8 @@ from mesonbuild import mlog
 
 have_fcntl = False
 have_msvcrt = False
-# Used to report conflicts between meson_version and new features used
-target_version = ''
+# {subproject: project_meson_version}
+project_meson_versions = {}
 
 try:
     import fcntl

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -313,14 +313,14 @@ class PkgConfigModule(ExtensionModule):
                       'install_dir', 'extra_cflags', 'variables', 'url', 'd_module_versions'})
     def generate(self, state, args, kwargs):
         if 'variables' in kwargs:
-            FeatureNew('custom pkgconfig variables', '0.41.0').use()
+            FeatureNew('custom pkgconfig variables', '0.41.0').use(state.subproject)
         default_version = state.project_version['version']
         default_install_dir = None
         default_description = None
         default_name = None
         mainlib = None
         if len(args) == 1:
-            FeatureNew('pkgconfig.generate optional positional argument', '0.46.0').use()
+            FeatureNew('pkgconfig.generate optional positional argument', '0.46.0').use(state.subproject)
             mainlib = getattr(args[0], 'held_object', args[0])
             if not isinstance(mainlib, (build.StaticLibrary, build.SharedLibrary)):
                 raise mesonlib.MesonException('Pkgconfig_gen first positional argument must be a library object')

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -18,7 +18,6 @@ import functools
 from . import mparser
 from . import coredata
 from . import mesonlib
-from .interpreterbase import FeatureNew
 from . import compilers
 
 forbidden_option_names = coredata.get_builtin_options()
@@ -94,7 +93,9 @@ def IntegerParser(name, description, kwargs):
                                       kwargs['value'],
                                       kwargs.get('yield', coredata.default_yielding))
 
-@FeatureNew('array type option()', '0.44.0')
+# FIXME: Cannot use FeatureNew while parsing options because we parse it before
+# reading options in project(). See func_project() in interpreter.py
+#@FeatureNew('array type option()', '0.44.0')
 @permitted_kwargs({'value', 'yield', 'choices'})
 def string_array_parser(name, description, kwargs):
     if 'choices' in kwargs:
@@ -188,8 +189,11 @@ class OptionInterpreter:
             raise OptionException('Only calls to option() are allowed in option files.')
         (posargs, kwargs) = self.reduce_arguments(node.args)
 
-        if 'yield' in kwargs:
-            FeatureNew('option yield', '0.45.0').use()
+        # FIXME: Cannot use FeatureNew while parsing options because we parse
+        # it before reading options in project(). See func_project() in
+        # interpreter.py
+        #if 'yield' in kwargs:
+        #    FeatureNew('option yield', '0.45.0').use(self.subproject)
 
         if 'type' not in kwargs:
             raise OptionException('Option call missing mandatory "type" keyword argument')

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,8 @@ ignore =
     E251,
     # E261: at least two spaces before inline comment
     E261,
+    # E265: block comment should start with '# '
+    E265,
     # E501: line too long
     E501,
     # E302: expected 2 blank lines, found 1

--- a/test cases/common/174 dependency factory/meson.build
+++ b/test cases/common/174 dependency factory/meson.build
@@ -1,4 +1,4 @@
-project('dependency factory')
+project('dependency factory', meson_version : '>=0.40')
 
 dep = dependency('gl', method: 'pkg-config', required: false)
 if dep.found() and dep.type_name() == 'pkgconfig'

--- a/test cases/unit/34 featurenew subprojects/meson.build
+++ b/test cases/unit/34 featurenew subprojects/meson.build
@@ -1,0 +1,6 @@
+project('featurenew subproject', meson_version: '>=0.45')
+
+foo = {}
+
+subproject('foo')
+subproject('bar')

--- a/test cases/unit/34 featurenew subprojects/subprojects/bar/meson.build
+++ b/test cases/unit/34 featurenew subprojects/subprojects/bar/meson.build
@@ -1,0 +1,3 @@
+project('foo subproject', meson_version: '>=0.46')
+
+import('python')

--- a/test cases/unit/34 featurenew subprojects/subprojects/foo/meson.build
+++ b/test cases/unit/34 featurenew subprojects/subprojects/foo/meson.build
@@ -1,0 +1,3 @@
+project('foo subproject', meson_version: '>=0.40')
+
+disabler()


### PR DESCRIPTION
commit 3cf68dd6d3aec8080d6d69fb9ee052bb55610596

    Contributing.md: Document procedure for new features [skip ci]

commit f9341fe81422b8794d45c71a47f927799212750e

    FeatureNew: Make all checks subproject-specific

    We now pass the current subproject to every FeatureNew and
    FeatureDeprecated call. This requires a bunch of rework to:

    1. Ensure that we have access to the subproject in the list of
       arguments when used as a decorator (see _get_callee_args).
    2. Pass the subproject to .use() when it's called manually.
    3. We also can't do feature checks for new features in
       meson_options.txt because that's parsed before we know the
       meson_version from project()

commit 5714ba253467d84b9cd1003b99e6596b5d86f20a

    meson.vim: Add missing disabler() entry [skip ci]
