### PR TITLE
prune nonexistent dirs from library search path

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -173,7 +173,7 @@ class CCompiler(Compiler):
         for line in stdo.split('\n'):
             if line.startswith('libraries:'):
                 libstr = line.split('=', 1)[1]
-                paths = [os.path.realpath(p) for p in libstr.split(':')]
+                paths = [os.path.realpath(p) for p in libstr.split(':') if os.path.exists(os.path.realpath(p))]
         return paths
 
     def get_library_dirs(self):


### PR DESCRIPTION
Rather than storing in the cache of search paths the full list returned
from the compiler and having each call ignore the non-existent ones, remove
from the list all non-existent ones before returning to the caching function.