### PR TITLE
Add libmodulemd to the Users list

### DIFF
--- a/docs/markdown/Users.md
+++ b/docs/markdown/Users.md
@@ -46,7 +46,7 @@ listed in the [`meson` GitHub topic](https://github.com/topics/meson).
  - [libfuse](https://github.com/libfuse/libfuse), the reference implementation of the Linux FUSE (Filesystem in Userspace) interface
  - [Libgit2-glib](https://git.gnome.org/browse/libgit2-glib), a GLib wrapper for libgit2
  - [Libhttpseverywhere](https://git.gnome.org/browse/libhttpseverywhere), a library to enable httpseverywhere on any desktop app
- - [libmodulemd](https://github.com/fedora-modularity/libmodulemd), C Library for manipulating module metadata files
+ - [libmodulemd](https://github.com/fedora-modularity/libmodulemd), a GObject Introspected library for managing [Fedora Project](https://getfedora.org/) module metadata.
  - [Libosmscout](https://github.com/Framstag/libosmscout), a C++ library for offline map rendering, routing and location  
 lookup based on OpenStreetMap data
  - [libspng](https://gitlab.com/randy408/libspng), a C library for reading and writing Portable Network Graphics (PNG) 


### PR DESCRIPTION
libmodulemd is a GObject Introspected C library using meson to build and generate gtk-doc HTML.