### PR TITLE
find_library: Only run link test on system dirs

### DIFF
--- a/test cases/common/146 C and CPP link/foo.cpp
+++ b/test cases/common/146 C and CPP link/foo.cpp
@@ -16,6 +16,9 @@
 
 const int cnums[] = {0, 61};
 
+/* Provided by foobar.c */
+extern "C" int get_number_index (void);
+
 template<typename T, int N>
 std::vector<T> makeVector(const T (&data)[N])
 {
@@ -27,5 +30,5 @@ namespace {
 }
 
 extern "C" int six_one(void) {
-    return numbers[1];
+    return numbers[get_number_index ()];
 }

--- a/test cases/common/146 C and CPP link/foobar.c
+++ b/test cases/common/146 C and CPP link/foobar.c
@@ -17,6 +17,10 @@
 #include "foo.hpp"
 #include "foobar.h"
 
+int get_number_index (void) {
+  return 1;
+}
+
 void mynumbers(int nums[]) {
     nums[0] = forty_two();
     nums[1] = six_one();


### PR DESCRIPTION
Paths provided to us by the user or by pkg-config can be (and must be)
assumed to be usable since they might not be usable standalone.

Closes https://github.com/mesonbuild/meson/issues/3832