### PR TITLE
Fix pkexec command for installation via polkit

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -306,7 +306,7 @@ class Installer:
                 print('Installation failed due to insufficient permissions.')
                 print('Attempting to use polkit to gain elevated privileges...')
                 os.execlp('pkexec', 'pkexec', sys.executable, main_file, *sys.argv[1:],
-                          os.getcwd())
+                          '-C', os.getcwd())
             else:
                 raise
 


### PR DESCRIPTION
If run `meson install` with an unprivillaged user, polkit will ask for password.  But then `meson` would complain:

    meson install: error: unrecognized arguments: /home/xry111/gnome-3.28/epiphany-3.28.1/build

Add `-C` option to the meson command with `pkexec` to fix this issue.