### PR TITLE
gnome.gtkdoc: Don't treat install_dir as a file option

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -831,7 +831,7 @@ This will become a hard error in the future.''')
 
         args += self._unpack_args('--expand-content-files=', 'expand_content_files', kwargs, state)
         args += self._unpack_args('--ignore-headers=', 'ignore_headers', kwargs)
-        args += self._unpack_args('--installdir=', 'install_dir', kwargs, state)
+        args += self._unpack_args('--installdir=', 'install_dir', kwargs)
         args += self._get_build_args(kwargs, state, depends)
         res = [build.RunTarget(targetname, command[0], command[1:] + args, depends, state.subdir, state.subproject)]
         if kwargs.get('install', True):

--- a/test cases/frameworks/10 gtk-doc/doc/meson.build
+++ b/test cases/frameworks/10 gtk-doc/doc/meson.build
@@ -9,3 +9,10 @@ gnome.gtkdoc('foobar',
   main_sgml : 'foobar-docs.sgml',
   content_files : [docbook, version_xml],
   install : true)
+
+gnome.gtkdoc('foobar2',
+  src_dir : inc,
+  main_sgml : 'foobar-docs.sgml',
+  content_files : [docbook, version_xml],
+  install : true,
+  install_dir : 'foobar2')

--- a/test cases/frameworks/10 gtk-doc/installed_files.txt
+++ b/test cases/frameworks/10 gtk-doc/installed_files.txt
@@ -13,3 +13,17 @@ usr/share/gtk-doc/html/foobar/right-insensitive.png
 usr/share/gtk-doc/html/foobar/style.css
 usr/share/gtk-doc/html/foobar/up.png
 usr/share/gtk-doc/html/foobar/up-insensitive.png
+usr/share/gtk-doc/html/foobar2/BAR.html
+usr/share/gtk-doc/html/foobar2/foobar2.devhelp2
+usr/share/gtk-doc/html/foobar2/foobar.html
+usr/share/gtk-doc/html/foobar2/foobar2-foo.html
+usr/share/gtk-doc/html/foobar2/foobar2-foo-version.html
+usr/share/gtk-doc/html/foobar2/home.png
+usr/share/gtk-doc/html/foobar2/index.html
+usr/share/gtk-doc/html/foobar2/left.png
+usr/share/gtk-doc/html/foobar2/left-insensitive.png
+usr/share/gtk-doc/html/foobar2/right.png
+usr/share/gtk-doc/html/foobar2/right-insensitive.png
+usr/share/gtk-doc/html/foobar2/style.css
+usr/share/gtk-doc/html/foobar2/up.png
+usr/share/gtk-doc/html/foobar2/up-insensitive.png


### PR DESCRIPTION
Causes the value to be expanded to current source directory.

Fixes https://github.com/mesonbuild/meson/issues/3829