### PR TITLE
Add missing method on external library object: type_name()

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2045,6 +2045,9 @@ library. This object has the following methods:
 
  - `found` which returns whether the library was found.
 
+ - `type_name()` (*added 0.47.1*) which returns a string describing
+   the type of the dependency, which will be `library` in this case.
+
  - `partial_dependency(compile_args : false, link_args : false, links
    : false, includes : false, source : false)` (*added 0.46.0*) returns
    a new dependency object with the same name, version, found status,

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2045,7 +2045,7 @@ library. This object has the following methods:
 
  - `found` which returns whether the library was found.
 
- - `type_name()` (*added 0.47.1*) which returns a string describing
+ - `type_name()` (*added 0.48.0*) which returns a string describing
    the type of the dependency, which will be `library` in this case.
 
  - `partial_dependency(compile_args : false, link_args : false, links

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -995,7 +995,7 @@ class NonExistingExternalProgram(ExternalProgram):
 
 class ExternalLibrary(ExternalDependency):
     def __init__(self, name, link_args, environment, language, silent=False):
-        super().__init__('external', environment, language, {})
+        super().__init__('library', environment, language, {})
         self.name = name
         self.language = language
         self.is_found = False

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -477,11 +477,17 @@ class ExternalLibraryHolder(InterpreterObject, ObjectHolder):
         InterpreterObject.__init__(self)
         ObjectHolder.__init__(self, el, pv)
         self.methods.update({'found': self.found_method,
+                             'type_name': self.type_name_method,
                              'partial_dependency': self.partial_dependency_method,
                              })
 
     def found(self):
         return self.held_object.found()
+
+    @noPosargs
+    @permittedKwargs({})
+    def type_name_method(self, args, kwargs):
+        return self.held_object.type_name
 
     @noPosargs
     @permittedKwargs({})

--- a/test cases/common/146 C and CPP link/meson.build
+++ b/test cases/common/146 C and CPP link/meson.build
@@ -44,6 +44,8 @@ configure_file(
   command : stlib_cmd)
 
 libstcppext = cxx.find_library('stcppext', dirs : meson.current_build_dir())
+lib_type_name = libstcppext.type_name()
+assert(lib_type_name == 'library', 'type name is ' + lib_type_name)
 
 libfooext = shared_library(
   'fooext',


### PR DESCRIPTION
For some reason this was missing, but it should've always existed since `cc.find_library()` returns an object that is internally an ExternalDependency instance.

@jpakkane I'm thinking we should add this to the stable release even though it's a new feature because it's a really simple one that should've already existed. What do you think?