### PR TITLE
Canonicalise 64-bit PowerPC CPU families to "ppc64"

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -49,9 +49,8 @@ set in the cross file.
 | aarch64             | 64 bit ARM processor  |
 | mips                | 32 bit MIPS processor |
 | mips64              | 64 bit MIPS processor |
-| ppc                 | 32 bit PPC processors (Big Endian) |
-| ppc64               | 64 bit PPC processors (Big Endian) |
-| ppc64le             | 64 bit PPC processors (Little Endian) |
+| ppc                 | 32 bit PPC processors |
+| ppc64               | 64 bit PPC processors |
 | e2k                 | MCST Elbrus processor |
 | parisc              | HP PA-RISC processor  |
 | sparc64             | SPARC v9 processor    |

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -84,7 +84,6 @@ known_cpu_families = (
     'parisc',
     'ppc',
     'ppc64',
-    'ppc64le',
     'sparc64',
     'x86',
     'x86_64'
@@ -212,6 +211,8 @@ def detect_cpu_family(compilers):
         return 'x86'
     if trial.startswith('arm'):
         return 'arm'
+    if trial.startswith('ppc64'):
+        return 'ppc64'
     if trial in ('amd64', 'x64'):
         trial = 'x86_64'
     if trial == 'x86_64':

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -230,7 +230,9 @@ def detect_cpu_family(compilers):
     # Add fixes here as bugs are reported.
 
     if trial not in known_cpu_families:
-        mlog.warning('Unknown CPU family %s, please report this at https://github.com/mesonbuild/meson/issues/new' % trial)
+        mlog.warning('Unknown CPU family {!r}, please report this at '
+                     'https://github.com/mesonbuild/meson/issues/new with the'
+                     'output of `uname -a` and `cat /proc/cpuinfo`'.format(trial))
 
     return trial
 


### PR DESCRIPTION
Instead of exposing the endianness in the CPU family, canonicalise the CPU
family to just "ppc64" to match MIPS (which is also bi-endian).

Part of the work for #3842.