### PR TITLE
More usable subproject error messages

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1792,7 +1792,7 @@ class CustomTarget(Target):
         if 'build_always' in kwargs and 'build_always_stale' in kwargs:
             raise InvalidArguments('build_always and build_always_stale are mutually exclusive. Combine build_by_default and build_always_stale.')
         elif 'build_always' in kwargs:
-            mlog.warning('build_always is deprecated. Combine build_by_default and build_always_stale instead.')
+            mlog.deprecation('build_always is deprecated. Combine build_by_default and build_always_stale instead.')
             if 'build_by_default' not in kwargs:
                 self.build_by_default = kwargs['build_always']
             self.build_always_stale = kwargs['build_always']

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -169,7 +169,7 @@ class UserArrayOption(UserOption):
         if len(set(newvalue)) != len(newvalue):
             msg = 'Duplicated values in array option "%s" is deprecated. ' \
                   'This will become a hard error in the future.' % (self.name)
-            mlog.log(mlog.red('DEPRECATION:'), msg)
+            mlog.deprecation(msg)
         for i in newvalue:
             if not isinstance(i, str):
                 raise MesonException('String array element "{0}" is not a string.'.format(str(newvalue)))

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -276,8 +276,9 @@ class ConfigurationDataHolder(MutableInterpreterObject, ObjectHolder):
 
     def validate_args(self, args, kwargs):
         if len(args) == 1 and isinstance(args[0], list) and len(args[0]) == 2:
-            mlog.deprecation('''Passing a list as the single argument to configuration_data.set is deprecated.
-This will become a hard error in the future''')
+            mlog.deprecation('Passing a list as the single argument to '
+                             'configuration_data.set is deprecated. This will '
+                             'become a hard error in the future.')
             args = args[0]
 
         if len(args) != 2:
@@ -286,6 +287,11 @@ This will become a hard error in the future''')
             raise InterpreterException("Can not set values on configuration object that has been used.")
         name = args[0]
         val = args[1]
+        if not isinstance(val, (int, str)):
+            msg = 'Setting a configuration data value to {!r} is invalid, ' \
+                  'and will fail at configure_file(). If you are using it ' \
+                  'just to store some values, please use a dict instead.'
+            mlog.deprecation(msg.format(val))
         desc = kwargs.get('description', None)
         if not isinstance(name, str):
             raise InterpreterException("First argument to set must be a string.")

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -36,6 +36,7 @@ import re, shlex
 import subprocess
 from collections import namedtuple
 from pathlib import PurePath
+import traceback
 
 import importlib
 
@@ -2960,9 +2961,14 @@ root and issuing %s.
         # If the subproject execution failed in a non-fatal way, don't raise an
         # exception; let the caller handle things.
         except Exception as e:
-            mlog.log('Couldn\'t use fallback subproject in',
-                     mlog.bold(os.path.join(self.subproject_dir, dirname)),
-                     'for the dependency', mlog.bold(display_name), '\nReason:', str(e))
+            msg = ['Couldn\'t use fallback subproject in',
+                   mlog.bold(os.path.join(self.subproject_dir, dirname)),
+                   'for the dependency', mlog.bold(display_name), '\nReason:']
+            if isinstance(e, mesonlib.MesonException):
+                msg.append(e.get_msg_with_context())
+            else:
+                msg.append(traceback.format_exc())
+            mlog.log(*msg)
             return None
         dep = self.get_subproject_dep(name, dirname, varname, kwargs.get('required', True))
         if not dep:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -276,8 +276,7 @@ class ConfigurationDataHolder(MutableInterpreterObject, ObjectHolder):
 
     def validate_args(self, args, kwargs):
         if len(args) == 1 and isinstance(args[0], list) and len(args[0]) == 2:
-            mlog.log(mlog.red('DEPRECATION:'),
-                     '''Passing a list as the single argument to configuration_data.set is deprecated.
+            mlog.deprecation('''Passing a list as the single argument to configuration_data.set is deprecated.
 This will become a hard error in the future''')
             args = args[0]
 

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -394,7 +394,7 @@ class InterpreterBase:
                 self.current_lineno = cur.lineno
                 self.evaluate_statement(cur)
             except Exception as e:
-                if not(hasattr(e, 'lineno')):
+                if not hasattr(e, 'lineno'):
                     e.lineno = cur.lineno
                     e.colno = cur.colno
                     e.file = os.path.join(self.subdir, 'meson.build')

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -243,8 +243,9 @@ class FeatureDeprecated(FeatureCheckBase):
         return 'Deprecated features used:'
 
     def log_usage_warning(self, tv):
-        mlog.warning('Project targetting \'{}\' but tried to use feature deprecated '
-                     'since \'{}\': {}'.format(tv, self.feature_version, self.feature_name))
+        mlog.deprecation('Project targetting \'{}\' but tried to use feature '
+                         'deprecated since \'{}\': {}'
+                         ''.format(tv, self.feature_version, self.feature_name))
 
 
 class FeatureCheckKwargsBase:

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -603,7 +603,9 @@ def do_replacement(regex, line, format, confdata):
                 elif isinstance(var, int):
                     var = str(var)
                 else:
-                    raise RuntimeError('Tried to replace a variable with something other than a string or int.')
+                    msg = 'Tried to replace variable {!r} value with ' \
+                          'something other than a string or int: {!r}'
+                    raise MesonException(msg.format(varname, var))
             else:
                 missing_variables.add(varname)
                 var = ''

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -83,6 +83,13 @@ an_unpicklable_object = threading.Lock()
 class MesonException(Exception):
     '''Exceptions thrown by Meson'''
 
+    def get_msg_with_context(self):
+        s = ''
+        if hasattr(self, 'lineno') and hasattr(self, 'file'):
+            s = get_error_location_string(self.file, self.lineno) + ' '
+        s += str(self)
+        return s
+
 class EnvironmentException(MesonException):
     '''Exceptions thrown while processing and creating the build environment'''
 
@@ -1046,6 +1053,9 @@ def detect_subprojects(spdir_name, current_dir='', result=None):
             else:
                 result[basename] = [trial]
     return result
+
+def get_error_location_string(fname, lineno):
+    return '{}:{}:'.format(fname, lineno)
 
 class OrderedSet(collections.MutableSet):
     """A set that preserves the order in which items are added, by first

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -140,7 +140,8 @@ def log(*args, **kwargs):
     force_print(*arr, **kwargs)
 
 def _log_error(severity, *args, **kwargs):
-    from . import environment
+    from .mesonlib import get_error_location_string
+    from .environment import build_filename
     if severity == 'warning':
         args = (yellow('WARNING:'),) + args
     elif severity == 'error':
@@ -152,9 +153,8 @@ def _log_error(severity, *args, **kwargs):
 
     location = kwargs.pop('location', None)
     if location is not None:
-        location_str = '{}:{}:'.format(os.path.join(location.subdir,
-                                                    environment.build_filename),
-                                       location.lineno)
+        location_file = os.path.join(location.subdir, build_filename)
+        location_str = get_error_location_string(location_file, location.lineno)
         args = (location_str,) + args
 
     log(*args, **kwargs)

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -145,6 +145,8 @@ def _log_error(severity, *args, **kwargs):
         args = (yellow('WARNING:'),) + args
     elif severity == 'error':
         args = (red('ERROR:'),) + args
+    elif severity == 'deprecation':
+        args = (red('DEPRECATION:'),) + args
     else:
         assert False, 'Invalid severity ' + severity
 
@@ -162,6 +164,9 @@ def error(*args, **kwargs):
 
 def warning(*args, **kwargs):
     return _log_error('warning', *args, **kwargs)
+
+def deprecation(*args, **kwargs):
+    return _log_error('deprecation', *args, **kwargs)
 
 def exception(e):
     log()

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -683,7 +683,7 @@ class GnomeModule(ExtensionModule):
 
         langs = mesonlib.stringlistify(kwargs.pop('languages', []))
         if langs:
-            mlog.log(mlog.red('DEPRECATION:'), '''The "languages" argument of gnome.yelp() is deprecated.
+            mlog.deprecation('''The "languages" argument of gnome.yelp() is deprecated.
 Use a LINGUAS file in the sources directory instead.
 This will become a hard error in the future.''')
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2300,6 +2300,7 @@ recommended as it is not supported on some platforms''')
             self.assertEqual(f.read().strip(), b'/* #undef FOO_BAR */')
         with open(os.path.join(self.builddir, 'nosubst-nocopy2.txt'), 'rb') as f:
             self.assertEqual(f.read().strip(), b'')
+        self.assertRegex(out, r"DEPRECATION:.*\['array'\] is invalid.*dict")
 
 
 class FailureTests(BasePlatformTests):

--- a/test cases/common/16 configure file/meson.build
+++ b/test cases/common/16 configure file/meson.build
@@ -211,3 +211,6 @@ test_file = configure_file(
 )
 
 test('configure-file', test_file)
+
+cdata = configuration_data()
+cdata.set('invalid_value', ['array'])


### PR DESCRIPTION
commit fbcf852f626ed10ae5060b3b9b55c626e72002e5

    Print a more usable message when a subproject fails to configure
    
    Instead of just printing the message in the exception, if it's
    a MesonException, also print the file and the line number. If it's an
    unknown exception, print the entire traceback so that we can pin-point
    what the Meson bug causing it is.

commit 6d57f131d5a42c92538c10fffacedebbe93c7c3b

    Raise a MesonException when substituting an invalid value
    
    Avoids throwing a traceback. Also, warn when setting such a value.

commit 3ea8d05ce8d568f813f6f7704d565727adf1c446

    Add new method: mlog.deprecation()
    
    Instead of constructing it manually, use a helper.
