### PR TITLE
Be more permissive about not-found exe_wrapper

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -72,6 +72,8 @@ class ExecutableSerialisation:
         self.cmd_args = cmd_args
         self.env = env
         self.is_cross = is_cross
+        if exe_wrapper is not None:
+            assert(isinstance(exe_wrapper, dependencies.ExternalProgram))
         self.exe_runner = exe_wrapper
         self.workdir = workdir
         self.extra_paths = extra_paths
@@ -85,6 +87,8 @@ class TestSerialisation:
         self.suite = suite
         self.fname = fname
         self.is_cross_built = is_cross_built
+        if exe_wrapper is not None:
+            assert(isinstance(exe_wrapper, dependencies.ExternalProgram))
         self.exe_runner = exe_wrapper
         self.is_parallel = is_parallel
         self.cmd_args = cmd_args
@@ -310,7 +314,7 @@ class Backend:
                 self.environment.cross_info.need_cross_compiler() and \
                 self.environment.cross_info.need_exe_wrapper()
             if is_cross_built:
-                exe_wrapper = self.environment.cross_info.config['binaries'].get('exe_wrapper', None)
+                exe_wrapper = self.environment.get_exe_wrapper()
             else:
                 exe_wrapper = None
             es = ExecutableSerialisation(basename, exe_cmd, cmd_args, env,
@@ -646,10 +650,10 @@ class Backend:
                 is_cross = is_cross and exe.is_cross
             if isinstance(exe, dependencies.ExternalProgram):
                 # E.g. an external verifier or simulator program run on a generated executable.
-                # Can always be run.
+                # Can always be run without a wrapper.
                 is_cross = False
             if is_cross:
-                exe_wrapper = self.environment.cross_info.config['binaries'].get('exe_wrapper', None)
+                exe_wrapper = self.environment.get_exe_wrapper()
             else:
                 exe_wrapper = None
             if mesonlib.for_windows(is_cross, self.environment) or \
@@ -711,9 +715,8 @@ class Backend:
 
     def exe_object_to_cmd_array(self, exe):
         if self.environment.is_cross_build() and \
-           self.environment.cross_info.need_exe_wrapper() and \
            isinstance(exe, build.BuildTarget) and exe.is_cross:
-            if 'exe_wrapper' not in self.environment.cross_info.config['binaries']:
+            if self.environment.exe_wrapper is None:
                 s = 'Can not use target %s as a generator because it is cross-built\n'
                 s += 'and no exe wrapper is defined. You might want to set it to native instead.'
                 s = s % exe.name

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -595,11 +595,10 @@ int dummy;
         if isinstance(texe, build.Executable):
             abs_exe = os.path.join(self.environment.get_build_dir(), self.get_target_filename(texe))
             deps.append(self.get_target_filename(texe))
-            if self.environment.is_cross_build() and \
-               self.environment.cross_info.need_exe_wrapper():
-                exe_wrap = self.environment.cross_info.config['binaries'].get('exe_wrapper', None)
-                if exe_wrap is not None:
-                    cmd += [exe_wrap]
+            if self.environment.is_cross_build():
+                exe_wrap = self.environment.get_exe_wrapper()
+                if exe_wrap:
+                    cmd += exe_wrap.get_command()
             cmd.append(abs_exe)
         elif isinstance(texe, dependencies.ExternalProgram):
             cmd += texe.get_command()

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -541,7 +541,7 @@ int dummy;
             if extra_paths:
                 serialize = True
         if serialize:
-            exe_data = self.serialize_executable(target.command[0], cmd[1:],
+            exe_data = self.serialize_executable(target.name, target.command[0], cmd[1:],
                                                  # All targets are built from the build dir
                                                  self.environment.get_build_dir(),
                                                  extra_paths=extra_paths,
@@ -598,6 +598,11 @@ int dummy;
             if self.environment.is_cross_build():
                 exe_wrap = self.environment.get_exe_wrapper()
                 if exe_wrap:
+                    if not exe_wrap.found():
+                        msg = 'The exe_wrapper {!r} defined in the cross file is ' \
+                              'needed by run target {!r}, but was not found. ' \
+                              'Please check the command and/or add it to PATH.'
+                        raise MesonException(msg.format(exe_wrap.name, target.name))
                     cmd += exe_wrap.get_command()
             cmd.append(abs_exe)
         elif isinstance(texe, dependencies.ExternalProgram):
@@ -1932,6 +1937,7 @@ rule FORTRAN_DEP_HACK%s
             cmdlist = exe_arr + self.replace_extra_args(args, genlist)
             if generator.capture:
                 exe_data = self.serialize_executable(
+                    'generator ' + cmdlist[0],
                     cmdlist[0],
                     cmdlist[1:],
                     self.environment.get_build_dir(),

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -133,6 +133,7 @@ class Vs2010Backend(backends.Backend):
                     cmd = exe_arr + self.replace_extra_args(args, genlist)
                     if generator.capture:
                         exe_data = self.serialize_executable(
+                            'generator ' + cmd[0],
                             cmd[0],
                             cmd[1:],
                             self.environment.get_build_dir(),
@@ -489,7 +490,7 @@ class Vs2010Backend(backends.Backend):
         tdir_abs = os.path.join(self.environment.get_build_dir(), self.get_target_dir(target))
         extra_bdeps = target.get_transitive_build_target_deps()
         extra_paths = self.determine_windows_extra_paths(target.command[0], extra_bdeps)
-        exe_data = self.serialize_executable(target.command[0], cmd[1:],
+        exe_data = self.serialize_executable(target.name, target.command[0], cmd[1:],
                                              # All targets run from the target dir
                                              tdir_abs,
                                              extra_paths=extra_paths,

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -57,9 +57,12 @@ class CCompiler(Compiler):
         self.id = 'unknown'
         self.is_cross = is_cross
         self.can_compile_suffixes.add('h')
-        self.exe_wrapper = exe_wrapper
-        if self.exe_wrapper:
-            self.exe_wrapper = self.exe_wrapper.get_command()
+        # If the exe wrapper was not found, pretend it wasn't set so that the
+        # sanity check is skipped and compiler checks use fallbacks.
+        if not exe_wrapper or not exe_wrapper.found():
+            self.exe_wrapper = None
+        else:
+            self.exe_wrapper = exe_wrapper.get_command()
 
         # Set to None until we actually need to check this
         self.has_fatal_warnings_link_arg = None
@@ -277,7 +280,7 @@ class CCompiler(Compiler):
             if self.exe_wrapper is None:
                 # Can't check if the binaries run so we have to assume they do
                 return
-            cmdlist = self.exe_wrapper.get_command() + [binary_name]
+            cmdlist = self.exe_wrapper + [binary_name]
         else:
             cmdlist = [binary_name]
         mlog.debug('Running test binary command: ' + ' '.join(cmdlist))

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -57,10 +57,9 @@ class CCompiler(Compiler):
         self.id = 'unknown'
         self.is_cross = is_cross
         self.can_compile_suffixes.add('h')
-        if isinstance(exe_wrapper, str):
-            self.exe_wrapper = [exe_wrapper]
-        else:
-            self.exe_wrapper = exe_wrapper
+        self.exe_wrapper = exe_wrapper
+        if self.exe_wrapper:
+            self.exe_wrapper = self.exe_wrapper.get_command()
 
         # Set to None until we actually need to check this
         self.has_fatal_warnings_link_arg = None
@@ -278,7 +277,7 @@ class CCompiler(Compiler):
             if self.exe_wrapper is None:
                 # Can't check if the binaries run so we have to assume they do
                 return
-            cmdlist = self.exe_wrapper + [binary_name]
+            cmdlist = self.exe_wrapper.get_command() + [binary_name]
         else:
             cmdlist = [binary_name]
         mlog.debug('Running test binary command: ' + ' '.join(cmdlist))

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -14,7 +14,7 @@
 
 from .boost import BoostDependency
 from .base import (  # noqa: F401
-    Dependency, DependencyException, DependencyMethods, ExternalProgram, NonExistingExternalProgram,
+    Dependency, DependencyException, DependencyMethods, ExternalProgram, EmptyExternalProgram, NonExistingExternalProgram,
     ExternalDependency, NotFoundDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
     PkgConfigDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language)
 from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDependency

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -981,10 +981,14 @@ class ExternalProgram:
     def get_name(self):
         return self.name
 
+
 class NonExistingExternalProgram(ExternalProgram):
+    "A program that will never exist"
 
     def __init__(self):
-        super().__init__(name = 'nonexistingprogram', silent = True)
+        self.name = 'nonexistingprogram'
+        self.command = [None]
+        self.path = None
 
     def __repr__(self):
         r = '<{} {!r} -> {!r}>'
@@ -992,6 +996,26 @@ class NonExistingExternalProgram(ExternalProgram):
 
     def found(self):
         return False
+
+
+class EmptyExternalProgram(ExternalProgram):
+    '''
+    A program object that returns an empty list of commands. Used for cases
+    such as a cross file exe_wrapper to represent that it's not required.
+    '''
+
+    def __init__(self):
+        self.name = None
+        self.command = []
+        self.path = None
+
+    def __repr__(self):
+        r = '<{} {!r} -> {!r}>'
+        return r.format(self.__class__.__name__, self.name, self.command)
+
+    def found(self):
+        return True
+
 
 class ExternalLibrary(ExternalDependency):
     def __init__(self, name, link_args, environment, language, silent=False):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1668,10 +1668,8 @@ class MesonMain(InterpreterObject):
     @permittedKwargs({})
     def has_exe_wrapper_method(self, args, kwargs):
         if self.is_cross_build_method(None, None) and \
-           'binaries' in self.build.environment.cross_info.config and \
            self.build.environment.cross_info.need_exe_wrapper():
-            exe_wrap = self.build.environment.cross_info.config['binaries'].get('exe_wrapper', None)
-            if exe_wrap is None:
+            if self.build.environment.exe_wrapper is None:
                 return False
         # We return True when exe_wrap is defined, when it's not needed, and
         # when we're compiling natively. The last two are semantically confusing.

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -1057,6 +1057,12 @@ def detect_subprojects(spdir_name, current_dir='', result=None):
 def get_error_location_string(fname, lineno):
     return '{}:{}:'.format(fname, lineno)
 
+def substring_is_in_list(substr, strlist):
+    for s in strlist:
+        if substr in s:
+            return True
+    return False
+
 class OrderedSet(collections.MutableSet):
     """A set that preserves the order in which items are added, by first
     insertion.

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -241,6 +241,7 @@ class SingleTestRunner:
                     return None
                 else:
                     return [self.test.exe_runner] + self.test.fname
+                    return self.test.exe_runner.get_command() + self.test.fname
             else:
                 return self.test.fname
 
@@ -257,19 +258,12 @@ class SingleTestRunner:
                 self.test.timeout = None
             return self._run_cmd(wrap + cmd + self.test.cmd_args + self.options.test_args)
 
-    @staticmethod
-    def _substring_in_list(substr, strlist):
-        for s in strlist:
-            if substr in s:
-                return True
-        return False
-
     def _run_cmd(self, cmd):
         starttime = time.time()
 
         if len(self.test.extra_paths) > 0:
             self.env['PATH'] = os.pathsep.join(self.test.extra_paths + ['']) + self.env['PATH']
-            if self._substring_in_list('wine', cmd):
+            if mesonlib.substring_is_in_list('wine', cmd):
                 wine_paths = ['Z:' + p for p in self.test.extra_paths]
                 wine_path = ';'.join(wine_paths)
                 # Don't accidentally end with an `;` because that will add the

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -19,6 +19,8 @@ import pickle
 import platform
 import subprocess
 
+from .. import mesonlib
+
 options = None
 
 def buildparser():
@@ -49,7 +51,7 @@ def run_exe(exe):
             if exe.exe_runner is None:
                 raise AssertionError('BUG: Trying to run cross-compiled exes with no wrapper')
             else:
-                cmd = [exe.exe_runner] + exe.fname
+                cmd = exe.exe_runner.get_command() + exe.fname
         else:
             cmd = exe.fname
     child_env = os.environ.copy()
@@ -57,7 +59,7 @@ def run_exe(exe):
     if len(exe.extra_paths) > 0:
         child_env['PATH'] = (os.pathsep.join(exe.extra_paths + ['']) +
                              child_env['PATH'])
-        if exe.exe_runner and 'wine' in exe.exe_runner:
+        if exe.exe_runner and mesonlib.substring_is_in_list('wine', exe.exe_runner.get_command()):
             wine_paths = ['Z:' + p for p in exe.extra_paths]
             wine_path = ';'.join(wine_paths)
             # Don't accidentally end with an `;` because that will add the

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -49,7 +49,11 @@ def run_exe(exe):
     else:
         if exe.is_cross:
             if exe.exe_runner is None:
-                raise AssertionError('BUG: Trying to run cross-compiled exes with no wrapper')
+                raise AssertionError('BUG: Can\'t run cross-compiled exe {!r}'
+                                     'with no wrapper'.format(exe.name))
+            elif not exe.exe_runner.found():
+                raise AssertionError('BUG: Can\'t run cross-compiled exe {!r} with not-found'
+                                     'wrapper {!r}'.format(exe.name, exe.exe_runner.get_path()))
             else:
                 cmd = exe.exe_runner.get_command() + exe.fname
         else:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -22,6 +22,7 @@ import textwrap
 import os
 import shutil
 import unittest
+import platform
 from unittest import mock
 from configparser import ConfigParser
 from glob import glob
@@ -47,7 +48,7 @@ import mesonbuild.modules.pkgconfig
 from run_tests import exe_suffix, get_fake_options, get_meson_script
 from run_tests import get_builddir_target_args, get_backend_commands, Backend
 from run_tests import ensure_backend_detects_changes, run_configure_inprocess
-from run_tests import should_run_linux_cross_tests
+from run_tests import run_mtest_inprocess
 
 
 def get_dynamic_section_entry(fname, entry):
@@ -641,8 +642,11 @@ class BasePlatformTests(unittest.TestCase):
         dir_args = get_builddir_target_args(self.backend, self.builddir, None)
         self._run(self.clean_command + dir_args, workdir=self.builddir)
 
-    def run_tests(self):
-        self._run(self.test_command, workdir=self.builddir)
+    def run_tests(self, inprocess=False):
+        if not inprocess:
+            self._run(self.test_command, workdir=self.builddir)
+        else:
+            run_mtest_inprocess(['-C', self.builddir])
 
     def install(self, *, use_destdir=True):
         if self.backend is not Backend.ninja:
@@ -3500,9 +3504,9 @@ endian = 'little'
             self.assertNotRegex(out, self.installdir + '.*dylib ')
 
 
-class LinuxArmCrossCompileTests(BasePlatformTests):
+class LinuxCrossArmTests(BasePlatformTests):
     '''
-    Tests that verify cross-compilation to Linux/ARM
+    Tests that cross-compilation to Linux/ARM works
     '''
     def setUp(self):
         super().setUp()
@@ -3535,6 +3539,45 @@ class LinuxArmCrossCompileTests(BasePlatformTests):
         compdb = self.get_compdb()
         self.assertRegex(compdb[0]['command'], '-D_FILE_OFFSET_BITS=64.*-U_FILE_OFFSET_BITS')
         self.build()
+
+class LinuxCrossMingwTests(BasePlatformTests):
+    '''
+    Tests that cross-compilation to Windows/MinGW works
+    '''
+    def setUp(self):
+        super().setUp()
+        src_root = os.path.dirname(__file__)
+        self.meson_cross_file = os.path.join(src_root, 'cross', 'linux-mingw-w64-64bit.txt')
+
+    def test_exe_wrapper_behaviour(self):
+        '''
+        Test that an exe wrapper that isn't found doesn't cause compiler sanity
+        checks and compiler checks to fail, but causes configure to fail if it
+        requires running a cross-built executable (custom_target or run_target)
+        and causes the tests to be skipped if they are run.
+        '''
+        testdir = os.path.join(self.unit_test_dir, '35 exe_wrapper behaviour')
+        # Configures, builds, and tests fine by default
+        self.init(testdir)
+        self.build()
+        self.run_tests()
+        self.wipe()
+        os.mkdir(self.builddir)
+        # Change cross file to use a non-existing exe_wrapper and it should fail
+        self.meson_cross_file = os.path.join(testdir, 'broken-cross.txt')
+        # Force tracebacks so we can detect them properly
+        os.environ['MESON_FORCE_BACKTRACE'] = '1'
+        with self.assertRaisesRegex(MesonException, 'exe_wrapper.*target.*use-exe-wrapper'):
+            # Must run in-process or we'll get a generic CalledProcessError
+            self.init(testdir, extra_args='-Drun-target=false', inprocess=True)
+        with self.assertRaisesRegex(MesonException, 'exe_wrapper.*run target.*run-prog'):
+            # Must run in-process or we'll get a generic CalledProcessError
+            self.init(testdir, extra_args='-Dcustom-target=false', inprocess=True)
+        self.init(testdir, extra_args=['-Dcustom-target=false', '-Drun-target=false'])
+        self.build()
+        with self.assertRaisesRegex(MesonException, 'exe_wrapper.*PATH'):
+            # Must run in-process or we'll get a generic CalledProcessError
+            self.run_tests(inprocess=True)
 
 
 class PythonTests(BasePlatformTests):
@@ -3669,13 +3712,21 @@ def unset_envs():
         if v in os.environ:
             del os.environ[v]
 
+def should_run_cross_arm_tests():
+    return shutil.which('arm-linux-gnueabihf-gcc') and not platform.machine().lower().startswith('arm')
+
+def should_run_cross_mingw_tests():
+    return shutil.which('x86_64-w64-mingw32-gcc') and not (is_windows() or is_cygwin())
+
 if __name__ == '__main__':
     unset_envs()
     cases = ['InternalTests', 'AllPlatformTests', 'FailureTests', 'PythonTests']
     if not is_windows():
         cases += ['LinuxlikeTests']
-        if should_run_linux_cross_tests():
-            cases += ['LinuxArmCrossCompileTests']
+        if should_run_cross_arm_tests():
+            cases += ['LinuxCrossArmTests']
+        if should_run_cross_mingw_tests():
+            cases += ['LinuxCrossMingwTests']
     if is_windows() or is_cygwin():
         cases += ['WindowsTests']
 

--- a/test cases/unit/35 exe_wrapper behaviour/broken-cross.txt
+++ b/test cases/unit/35 exe_wrapper behaviour/broken-cross.txt
@@ -1,0 +1,20 @@
+[binaries]
+c = '/usr/bin/x86_64-w64-mingw32-gcc'
+cpp = '/usr/bin/x86_64-w64-mingw32-g++'
+ar = '/usr/bin/x86_64-w64-mingw32-ar'
+strip = '/usr/bin/x86_64-w64-mingw32-strip'
+pkgconfig = '/usr/bin/x86_64-w64-mingw32-pkg-config'
+windres = '/usr/bin/x86_64-w64-mingw32-windres'
+exe_wrapper = 'broken'
+
+[properties]
+# Directory that contains 'bin', 'lib', etc
+root = '/usr/x86_64-w64-mingw32'
+# Directory that contains 'bin', 'lib', etc for the toolchain and system libraries
+sys_root = '/usr/x86_64-w64-mingw32/sys-root/mingw'
+
+[host_machine]
+system = 'windows'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'

--- a/test cases/unit/35 exe_wrapper behaviour/meson.build
+++ b/test cases/unit/35 exe_wrapper behaviour/meson.build
@@ -1,0 +1,19 @@
+project('exe wrapper behaviour', 'c')
+
+assert(meson.is_cross_build(), 'not setup as cross build')
+assert(meson.has_exe_wrapper(), 'exe wrapper not defined?')
+
+exe = executable('prog', 'prog.c')
+
+if get_option('custom-target')
+  custom_target('use-exe-wrapper',
+    build_by_default: true,
+    output: 'out.txt',
+    command: [exe, '@OUTPUT@'])
+endif
+
+test('test-prog', exe)
+
+if get_option('run-target')
+  run_target('run-prog', command : exe)
+endif

--- a/test cases/unit/35 exe_wrapper behaviour/meson_options.txt
+++ b/test cases/unit/35 exe_wrapper behaviour/meson_options.txt
@@ -1,0 +1,2 @@
+option('custom-target', type: 'boolean', value: true)
+option('run-target', type: 'boolean', value: true)

--- a/test cases/unit/35 exe_wrapper behaviour/prog.c
+++ b/test cases/unit/35 exe_wrapper behaviour/prog.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+int main (int argc, char * argv[])
+{
+  const char *out = "SUCCESS!";
+
+  if (argc != 2) {
+    printf ("%s\n", out);
+  } else {
+    int ret;
+    FILE *f = fopen (argv[1], "w");
+    ret = fwrite (out, sizeof (out), 1, f);
+    if (ret != 1)
+      return -1;
+  }
+  return 0;
+}


### PR DESCRIPTION
commit a4f729013c0eb4db1eb551046e74ed617c58717e

    cross: Be more permissive about not-found exe_wrapper
    
    We used to immediately try to use whatever exe_wrapper was defined in
    the cross file, but some people generate the cross file once and use
    it for several projects, most of which do not even need an exe wrapper
    to build.
    
    Now we're a bit more resilient. We quietly fall back to using
    non-exe-wrapper paths for compiler checks and skip the sanity check.
    However, if some code needs the exe wrapper, f.ex., if you run a built
    executable using custom_target() or run_target(), we will error out
    during setup.
    
    Tests will, of course, continue to error out when you run them if the
    exe wrapper was not found. We don't want people's tests to silently
    "pass" (aka skip) because of a bad CI setup.
    
    Closes https://github.com/mesonbuild/meson/issues/3562
    
    This commit also adds a test for the behaviour of exe_wrapper in these
    cases, and refactors the unit tests a bit for it.

commit 416a00308f5b0f228af3c93eb597eca8529fdbb0

    cross: Use ExternalProgram for cross-file exe_wrapper
    
    We already have code to fetch and find binaries specified in a cross
    file, so use the same code for exe_wrapper. This allows us to handle
    the same corner-cases that were fixed for other cross binaries.
