### PR TITLE
Fix searching of shared libraries on OpenBSD

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -28,7 +28,7 @@ from .. import build
 from .. import mlog
 from .. import dependencies
 from .. import compilers
-from ..compilers import CompilerArgs, get_macos_dylib_install_name
+from ..compilers import CompilerArgs, CCompiler, get_macos_dylib_install_name
 from ..linkers import ArLinker
 from ..mesonlib import File, MesonException, OrderedSet
 from ..mesonlib import get_compiler_for_source, has_path_sep
@@ -2484,10 +2484,10 @@ rule FORTRAN_DEP_HACK%s
     def guess_library_absolute_path(linker, libname, search_dirs, patterns):
         for d in search_dirs:
             for p in patterns:
-                trial = linker._get_trials_from_pattern(p, d, libname)
+                trial = CCompiler._get_trials_from_pattern(p, d, libname)
                 if not trial:
                     continue
-                trial = linker._get_file_from_list(trial)
+                trial = CCompiler._get_file_from_list(trial)
                 if not trial:
                     continue
                 # Return the first result

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2476,13 +2476,12 @@ rule FORTRAN_DEP_HACK%s
         target_args = self.build_target_link_arguments(linker, target.link_whole_targets)
         return linker.get_link_whole_for(target_args) if len(target_args) else []
 
-    def guess_library_absolute_path(self, libname, search_dirs, prefixes, suffixes):
-        for directory in search_dirs:
-            for suffix in suffixes:
-                for prefix in prefixes:
-                    trial = os.path.join(directory, prefix + libname + '.' + suffix)
-                    if os.path.isfile(trial):
-                        return trial
+    def guess_library_absolute_path(self, libname, search_dirs, patterns):
+        for d in search_dirs:
+            for p in patterns:
+                trial = os.path.join(d, p.format(libname))
+                if os.path.isfile(trial):
+                    return trial
 
     def guess_external_link_dependencies(self, linker, target, commands, internal):
         # Ideally the linker would generate dependency information that could be used.
@@ -2531,13 +2530,13 @@ rule FORTRAN_DEP_HACK%s
         # TODO The get_library_naming requirement currently excludes link targets that use d or fortran as their main linker
         if hasattr(linker, 'get_library_naming'):
             search_dirs = list(search_dirs) + linker.get_library_dirs()
-            prefixes_static, suffixes_static = linker.get_library_naming(self.environment, 'static', strict=True)
-            prefixes_shared, suffixes_shared = linker.get_library_naming(self.environment, 'shared', strict=True)
+            static_patterns = linker.get_library_naming(self.environment, 'static', strict=True)
+            shared_patterns = linker.get_library_naming(self.environment, 'shared', strict=True)
             for libname in libs:
                 # be conservative and record most likely shared and static resolution, because we don't know exactly
                 # which one the linker will prefer
-                static_resolution = self.guess_library_absolute_path(libname, search_dirs, prefixes_static, suffixes_static)
-                shared_resolution = self.guess_library_absolute_path(libname, search_dirs, prefixes_shared, suffixes_shared)
+                static_resolution = self.guess_library_absolute_path(libname, search_dirs, static_patterns)
+                shared_resolution = self.guess_library_absolute_path(libname, search_dirs, shared_patterns)
                 if static_resolution:
                     guessed_dependencies.append(os.path.realpath(static_resolution))
                 if shared_resolution:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os, pickle, re, shlex, subprocess
+import os
+import re
+import shlex
+import pickle
+import subprocess
 from collections import OrderedDict
 import itertools
 from pathlib import PurePath
@@ -2476,12 +2480,18 @@ rule FORTRAN_DEP_HACK%s
         target_args = self.build_target_link_arguments(linker, target.link_whole_targets)
         return linker.get_link_whole_for(target_args) if len(target_args) else []
 
-    def guess_library_absolute_path(self, libname, search_dirs, patterns):
+    @staticmethod
+    def guess_library_absolute_path(linker, libname, search_dirs, patterns):
         for d in search_dirs:
             for p in patterns:
-                trial = os.path.join(d, p.format(libname))
-                if os.path.isfile(trial):
-                    return trial
+                trial = linker._get_trials_from_pattern(p, d, libname)
+                if not trial:
+                    continue
+                trial = linker._get_file_from_list(trial)
+                if not trial:
+                    continue
+                # Return the first result
+                return trial
 
     def guess_external_link_dependencies(self, linker, target, commands, internal):
         # Ideally the linker would generate dependency information that could be used.
@@ -2535,12 +2545,14 @@ rule FORTRAN_DEP_HACK%s
             for libname in libs:
                 # be conservative and record most likely shared and static resolution, because we don't know exactly
                 # which one the linker will prefer
-                static_resolution = self.guess_library_absolute_path(libname, search_dirs, static_patterns)
-                shared_resolution = self.guess_library_absolute_path(libname, search_dirs, shared_patterns)
-                if static_resolution:
-                    guessed_dependencies.append(os.path.realpath(static_resolution))
-                if shared_resolution:
-                    guessed_dependencies.append(os.path.realpath(shared_resolution))
+                staticlibs = self.guess_library_absolute_path(linker, libname,
+                                                              search_dirs, static_patterns)
+                sharedlibs = self.guess_library_absolute_path(linker, libname,
+                                                              search_dirs, shared_patterns)
+                if staticlibs:
+                    guessed_dependencies.append(os.path.realpath(staticlibs))
+                if sharedlibs:
+                    guessed_dependencies.append(os.path.realpath(sharedlibs))
 
         return guessed_dependencies + absolute_libs
 

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -173,8 +173,11 @@ class FortranCompiler(Compiler):
     def run(self, code, env, extra_args=None, dependencies=None):
         return CCompiler.run(self, code, env, extra_args, dependencies)
 
-    def get_library_naming(self, env, libtype, strict=False):
-        return CCompiler.get_library_naming(self, env, libtype, strict)
+    def _get_patterns(self, *args, **kwargs):
+        return CCompiler._get_patterns(self, *args, **kwargs)
+
+    def get_library_naming(self, *args, **kwargs):
+        return CCompiler.get_library_naming(self, *args, **kwargs)
 
     def find_library_real(self, *args):
         return CCompiler.find_library_real(self, *args)

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -363,6 +363,18 @@ def for_haiku(is_cross, env):
         return env.cross_info.config['host_machine']['system'] == 'haiku'
     return False
 
+def for_openbsd(is_cross, env):
+    """
+    Host machine is OpenBSD?
+
+    Note: 'host' is the machine on which compiled binaries will run
+    """
+    if not is_cross:
+        return is_openbsd()
+    elif env.cross_info.has_host():
+        return env.cross_info.config['host_machine']['system'] == 'openbsd'
+    return False
+
 def exe_exists(arglist):
     try:
         p = subprocess.Popen(arglist, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
commit e75f43a87e86051f927c462dce30a31a189ecbc3

    find_library: Fix manual searching on OpenBSD
    
    On OpenBSD, shared libraries are called libfoo.so.X.Y where X is the
    major version and Y is the minor version. We were assuming that it's
    libfoo.so and not finding shared libraries at all while doing manual
    searching, which meant we'd link statically instead.
    
    See: https://www.openbsd.org/faq/ports/specialtopics.html#SharedLibs
    
    Now we use file globbing to do file searching, and pick the first one
    that's found.
    
    Closes https://github.com/mesonbuild/meson/issues/3844

commit 06e87d19bea88e5c74c9eec0e37d5b58d1321749

    get_library_naming: Use templates instead of suffix/prefix pairs
    
    This commit does not change functionality, and merely sets the
    groundwork for a more flexibly naming implementation.

@ajacoutot @kernigh: can you please test this? There's no CI for OpenBSD so we have no idea if this works there or not.