### PR TITLE
gnome.compile_resources: Put dependency directories before current source dir

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -154,10 +154,10 @@ class GnomeModule(ExtensionModule):
 
         # Make source dirs relative to build dir now
         source_dirs = [os.path.join(state.build_to_src, state.subdir, d) for d in source_dirs]
-        # Always include current directory, but after paths set by user
-        source_dirs.append(os.path.join(state.build_to_src, state.subdir))
         # Ensure build directories of generated deps are included
         source_dirs += subdirs
+        # Always include current directory, but after paths set by user
+        source_dirs.append(os.path.join(state.build_to_src, state.subdir))
 
         for source_dir in OrderedSet(source_dirs):
             cmd += ['--sourcedir', source_dir]

--- a/test cases/frameworks/7 gnome/resources/res3.txt
+++ b/test cases/frameworks/7 gnome/resources/res3.txt
@@ -1,0 +1,1 @@
+This file is from the wrong directory.


### PR DESCRIPTION
This avoids the problem of generated files with the same name as something in source
existing and using the wrong file.

May want to add a test for this.