### PR TITLE
Add Arduino ESP8266 sample project to Users.md [skip ci]

### DIFF
--- a/docs/markdown/Users.md
+++ b/docs/markdown/Users.md
@@ -17,6 +17,7 @@ listed in the [`meson` GitHub topic](https://github.com/topics/meson).
  - [Dpdk](http://dpdk.org/browse/dpdk), Data plane development kit, a set of libraries and drivers for fast packet processing
  - [DXVK](https://github.com/doitsujin/dxvk), a Vulkan-based Direct3D 11 implementation for Linux using Wine
  - [Emeus](https://github.com/ebassi/emeus), Constraint based layout manager for GTK+
+ - [ESP8266 Arduino sample project](https://github.com/trilader/arduino-esp8266-meson) Sample project for using the ESP8266 Arduino port with Meson
  - [Fractal](https://wiki.gnome.org/Apps/Fractal/), a Matrix messaging client for GNOME
  - [Frida](https://github.com/frida/frida-core), a dynamic binary instrumentation toolkit
  - [fwupd](https://github.com/hughsie/fwupd), a simple daemon to allow session software to update firmware


### PR DESCRIPTION
I've recently published some sample to to use the Arduino port for the ESP8266 microcontroller with Meson. 