### PR TITLE
mesonbuild: Recognise risc-v architecture

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -53,6 +53,8 @@ set in the cross file.
 | ppc64               | 64 bit PPC processors |
 | e2k                 | MCST Elbrus processor |
 | parisc              | HP PA-RISC processor  |
+| riscv32             | 32 bit RISC-V Open ISA|
+| riscv64             | 64 bit RISC-V Open ISA|
 | sparc64             | SPARC v9 processor    |
 
 Any cpu family not listed in the above list is not guaranteed to

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -84,6 +84,8 @@ known_cpu_families = (
     'parisc',
     'ppc',
     'ppc64',
+    'riscv32',
+    'riscv64',
     'sparc64',
     'x86',
     'x86_64'


### PR DESCRIPTION
Signed-off-by: Khem Raj <raj.khem@gmail.com>