### PR TITLE
Handle transitive links to 'threads' dependencies.

### DIFF
--- a/test cases/common/205 static threads/lib1.c
+++ b/test cases/common/205 static threads/lib1.c
@@ -1,0 +1,5 @@
+#include<pthread.h>
+
+void *f(void) {
+  return pthread_create;
+}

--- a/test cases/common/205 static threads/lib2.c
+++ b/test cases/common/205 static threads/lib2.c
@@ -1,0 +1,5 @@
+extern void *f(void);
+
+void *g(void) {
+  return f();
+}

--- a/test cases/common/205 static threads/meson.build
+++ b/test cases/common/205 static threads/meson.build
@@ -1,0 +1,13 @@
+project('threads', 'c')
+
+thread_dep = dependency('threads')
+
+
+lib1 = static_library('lib1', 'lib1.c',
+                      dependencies : thread_dep)
+
+lib2 = static_library('lib2', 'lib2.c',
+                       link_with : lib1)
+
+executable('prog', 'prog.c',
+           link_with : lib2)

--- a/test cases/common/205 static threads/prog.c
+++ b/test cases/common/205 static threads/prog.c
@@ -1,0 +1,6 @@
+extern void *g(void);
+
+int main(void) {
+  g();
+  return 0;
+}


### PR DESCRIPTION
Meson already had code to propagate link dependencies from static
libraries to programs that use those static libraries.

Unfortunately, it was not handling the special cases of 'threads' and
'openmp' dependencies.