### PR TITLE
Add support for custom dist scripts.

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1405,6 +1405,15 @@ The `meson` object allows you to introspect various properties of the
 system. This object is always mapped in the `meson` variable. It has
 the following methods.
 
+- `add_dist_script` causes the script given as argument to run during
+  `dist` operation after the distribution source has been generated
+  but before it is archived. Note that this runs the script file that
+  is in the _staging_ directory, not the one in the source
+  directory. If the script file can not be found in the staging
+  directory, it is a hard error. This command can only invoked from
+  the main project, calling it from a subproject is a hard
+  error. Available since 0.48.0.
+
 - `add_install_script(script_name, arg1, arg2, ...)` causes the script
   given as an argument to be run during the install step, this script
   will have the environment variables `MESON_SOURCE_ROOT`,

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -33,6 +33,8 @@ These are return values of the `get_id` method in a compiler object.
 | MESON_BUILD_ROOT    | Absolute path to the build dir  |
 | MESONINTROSPECT     | Command to run to run the introspection command, may be of the form `python /path/to/meson introspect`, user is responsible for splitting the path if necessary. |
 | MESON_SUBDIR        | Current subdirectory, only set for `run_command` |
+| MESON_DIST_ROOT     | Points to the root of the staging directory, only set when running `dist` scripts |
+
 
 ## CPU families
 

--- a/docs/markdown/snippets/distscript.md
+++ b/docs/markdown/snippets/distscript.md
@@ -1,0 +1,12 @@
+## Dist scripts
+
+You can now specify scripts that are run as part of the `dist`
+target. An example usage would go like this:
+
+```meson
+project('foo', 'c')
+
+# other stuff here
+
+meson.add_dist_script('dist_cleanup.py')
+```

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -119,6 +119,7 @@ class Build:
         self.subproject_dir = ''
         self.install_scripts = []
         self.postconf_scripts = []
+        self.dist_scripts = []
         self.install_dirs = []
         self.dep_manifest_name = None
         self.dep_manifest = {}

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1602,6 +1602,7 @@ class MesonMain(InterpreterObject):
                              'build_root': self.build_root_method,
                              'add_install_script': self.add_install_script_method,
                              'add_postconf_script': self.add_postconf_script_method,
+                             'add_dist_script': self.add_dist_script_method,
                              'install_dependency_manifest': self.install_dependency_manifest_method,
                              'override_find_program': self.override_find_program_method,
                              'project_version': self.project_version_method,
@@ -1643,6 +1644,15 @@ class MesonMain(InterpreterObject):
         check_stringlist(args, 'add_postconf_script arguments must be strings')
         script = self._find_source_script(args[0], args[1:])
         self.build.postconf_scripts.append(script)
+
+    @permittedKwargs({})
+    def add_dist_script_method(self, args, kwargs):
+        if len(args) != 1:
+            raise InterpreterException('add_dist_script takes exactly one argument')
+        check_stringlist(args, 'add_dist_script argument must be a string')
+        if self.interpreter.subproject != '':
+            raise InterpreterException('add_dist_script may not be used in a subproject.')
+        self.build.dist_scripts.append(os.path.join(self.interpreter.subdir, args[0]))
 
     @noPosargs
     @permittedKwargs({})

--- a/test cases/unit/35 dist script/meson.build
+++ b/test cases/unit/35 dist script/meson.build
@@ -1,0 +1,7 @@
+project('dist script', 'c',
+  version : '1.0.0')
+
+exe = executable('comparer', 'prog.c')
+test('compare', exe)
+
+meson.add_dist_script('replacer.py')

--- a/test cases/unit/35 dist script/prog.c
+++ b/test cases/unit/35 dist script/prog.c
@@ -1,0 +1,7 @@
+#include<string.h>
+
+#define REPLACEME "incorrect"
+
+int main(int argc, char **argv) {
+    return strcmp(REPLACEME, "correct");
+}

--- a/test cases/unit/35 dist script/replacer.py
+++ b/test cases/unit/35 dist script/replacer.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import os, sys
+import pathlib
+
+source_root = pathlib.Path(os.environ['MESON_DIST_ROOT'])
+
+modfile = source_root / 'prog.c'
+
+contents = modfile.read_text()
+contents = contents.replace('"incorrect"', '"correct"')
+modfile.write_text(contents)


### PR DESCRIPTION
The only open question here is subprojects. I made it a hard error currently for maximum future flexibility. But what should it do? For example if your subproject is not a part of the master project (i.e. a monorepo) then you don't want the scripts run. But if it is you do. 