### PR TITLE
python.find_installation: only try to find python with the py launcher if it isn't in PATH

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -470,11 +470,14 @@ class PythonModule(ExtensionModule):
             mlog.log("Using meson's python {}".format(mesonlib.python_command))
             python = ExternalProgram('python3', mesonlib.python_command, silent=True)
         else:
-            if mesonlib.is_windows():
+            python = ExternalProgram(name_or_path, silent = True)
+
+            if not python.found() and mesonlib.is_windows():
                 pythonpath = self._get_win_pythonpath(name_or_path)
                 if pythonpath is not None:
                     name_or_path = pythonpath
-            python = ExternalProgram(name_or_path, silent = True)
+                    python = ExternalProgram(name_or_path, silent = True)
+
             # Last ditch effort, python2 or python3 can be named python
             # on various platforms, let's not give up just yet, if an executable
             # named python is available and has a compatible version, let's use


### PR DESCRIPTION
Meson tries to find the interpreter path through the "py" launcher on Windows in all
cases which breaks if meson is run under MSYS2 and an official CPython is installed as well.
MSYS2 Python doesn't install a py launcher which results in meson finding the system one instead
even though python2/python3 is in PATH.

Always check if the interpreter name is in PATH before falling back to checking the py launcher.