### PR TITLE
Use global args in tests

### DIFF
--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -185,11 +185,11 @@ class FortranCompiler(Compiler):
     def find_library_impl(self, *args):
         return CCompiler.find_library_impl(self, *args)
 
-    def find_library(self, libname, env, extra_dirs, libtype='default'):
+    def find_library(self, libname, env, extra_dirs, extra_args, libtype='default'):
         code = '''program main
             call exit(0)
         end program main'''
-        return self.find_library_impl(libname, env, extra_dirs, code, libtype)
+        return self.find_library_impl(libname, env, extra_dirs, code, extra_args, libtype)
 
     def thread_flags(self, env):
         return CCompiler.thread_flags(self, env)

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -74,7 +74,7 @@ class ValaCompiler(Compiler):
             return ['--debug']
         return []
 
-    def find_library(self, libname, env, extra_dirs):
+    def find_library(self, libname, env, extra_dirs, extra_args):
         if extra_dirs and isinstance(extra_dirs, str):
             extra_dirs = [extra_dirs]
         # Valac always looks in the default vapi dir, so only search there if

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -634,7 +634,7 @@ class PkgConfigDependency(ExternalDependency):
                     continue
                 if self.clib_compiler:
                     args = self.clib_compiler.find_library(lib[2:], self.env,
-                                                           list(libpaths), libtype)
+                                                           list(libpaths), [], libtype)
                 # If the project only uses a non-clib language such as D, Rust,
                 # C#, Python, etc, all we can do is limp along by adding the
                 # arguments as-is and then adding the libpaths at the end.

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -352,7 +352,7 @@ class BoostDependency(ExternalDependency):
             return None
 
     def find_libraries_with_abi_tag(self, tag):
-
+        extra_args = []
         # All modules should have the same tag
         self.lib_modules = {}
 
@@ -361,7 +361,7 @@ class BoostDependency(ExternalDependency):
         for module in self.requested_modules:
             libname = 'boost_' + module + tag
 
-            args = self.clib_compiler.find_library(libname, self.env, self.extra_lib_dirs())
+            args = self.clib_compiler.find_library(libname, self.env, self.extra_lib_dirs(), extra_args)
             if args is None:
                 mlog.debug("Couldn\'t find library '{}' for boost module '{}'  (ABI tag = '{}')".format(libname, module, tag))
                 all_found = False

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -36,8 +36,8 @@ class GTestDependency(ExternalDependency):
 
     def detect(self):
         self.version = '1.something_maybe'
-        gtest_detect = self.clib_compiler.find_library("gtest", self.env, [])
-        gtest_main_detect = self.clib_compiler.find_library("gtest_main", self.env, [])
+        gtest_detect = self.clib_compiler.find_library("gtest", self.env, [], [])
+        gtest_main_detect = self.clib_compiler.find_library("gtest_main", self.env, [], [])
         if gtest_detect and (not self.main or gtest_main_detect):
             self.is_found = True
             self.compile_args = []
@@ -83,7 +83,7 @@ class GMockDependency(ExternalDependency):
         self.version = '1.something_maybe'
         # GMock may be a library or just source.
         # Work with both.
-        gmock_detect = self.clib_compiler.find_library("gmock", self.env, [])
+        gmock_detect = self.clib_compiler.find_library("gmock", self.env, [], [])
         if gmock_detect:
             self.is_found = True
             self.compile_args = []

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1443,7 +1443,8 @@ class CompilerHolder(InterpreterObject):
         for i in search_dirs:
             if not os.path.isabs(i):
                 raise InvalidCode('Search directory %s is not an absolute path.' % i)
-        linkargs = self.compiler.find_library(libname, self.environment, search_dirs)
+        extra_args = self.determine_args(kwargs)
+        linkargs = self.compiler.find_library(libname, self.environment, search_dirs, extra_args)
         if required and not linkargs:
             raise InterpreterException('{} library {!r} not found'.format(self.compiler.get_display_language(), libname))
         lib = dependencies.ExternalLibrary(libname, linkargs, self.environment,

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -123,7 +123,7 @@ class PythonDependency(ExternalDependency):
                 libname += self.variables['ABIFLAGS']
             libdirs = []
 
-        largs = self.clib_compiler.find_library(libname, environment, libdirs)
+        largs = self.clib_compiler.find_library(libname, environment, libdirs, [])
 
         self.is_found = largs is not None
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -542,7 +542,7 @@ class InternalTests(unittest.TestCase):
                 f.write('')
             with open(os.path.join(tmpdir, 'libfoo.so.70.0.so.1'), 'w') as f:
                 f.write('')
-            found = cc.find_library_real('foo', env, [tmpdir], '', 'default')
+            found = cc.find_library_real('foo', env, [tmpdir], '', [], 'default')
             self.assertEqual(os.path.basename(found[0]), 'libfoo.so.54.0')
 
     def test_find_library_patterns(self):


### PR DESCRIPTION
The `test test_preprocessor_checks_CPPFLAGS` will fail. However it does not seem to make any sense as a test. Why would you want to not use `CFLAGS` in compiler checks. Those matter a lot since they will be used for every compilation step so the thing you are testing for is different from usage.