### PR TITLE
Fix linking of shared/static libs with static libs

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2412,7 +2412,7 @@ rule FORTRAN_DEP_HACK%s
             # line where the static library is used.
             dependencies = []
         else:
-            dependencies = target.get_dependencies()
+            dependencies = target.get_dependencies(link_whole=True)
         internal = self.build_target_link_arguments(linker, dependencies)
         commands += internal
         # Only non-static built targets need link args and link dependencies

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1032,7 +1032,7 @@ class Vs2010Backend(backends.Backend):
         (additional_libpaths, additional_links, extra_link_args) = self.split_link_args(extra_link_args.to_native())
 
         # Add more libraries to be linked if needed
-        for t in target.get_dependencies():
+        for t in target.get_dependencies(link_whole=True):
             lobj = self.build.targets[t.get_id()]
             linkname = os.path.join(down, self.get_target_filename_for_linking(lobj))
             if t in target.link_whole_targets:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -856,22 +856,43 @@ This will become a hard error in a future Meson release.''')
     def get_extra_args(self, language):
         return self.extra_args.get(language, [])
 
-    def get_dependencies(self, exclude=None, internal=True):
+    def is_internal(self):
+        if isinstance(self, StaticLibrary) and not self.need_install:
+            return True
+        return False
+
+    def get_dependencies(self, exclude=None, internal=True, link_whole=False):
         transitive_deps = []
         if exclude is None:
             exclude = []
-        if internal:
-            link_targets = itertools.chain(self.link_targets, self.link_whole_targets)
-        else:
-            # We don't want the 'internal' libraries when generating the
-            # `Libs:` and `Libs.private:` lists in pkg-config files.
-            link_targets = self.link_targets
-        for t in link_targets:
+        for t in self.link_targets:
             if t in transitive_deps or t in exclude:
+                continue
+            # When we don't want internal libraries, f.ex. when we're
+            # generating the list of private installed libraries for use in
+            # a pkg-config file, don't include static libraries that aren't
+            # installed because those get directly included in the static
+            # or shared library already. See: self.link()
+            if not internal and t.is_internal():
                 continue
             transitive_deps.append(t)
             if isinstance(t, StaticLibrary):
-                transitive_deps += t.get_dependencies(transitive_deps + exclude, internal)
+                transitive_deps += t.get_dependencies(transitive_deps + exclude,
+                                                      internal, link_whole)
+        for t in self.link_whole_targets:
+            if t in transitive_deps or t in exclude:
+                continue
+            if not internal and t.is_internal():
+                continue
+            # self.link_whole_targets are not included by default here because
+            # the objects from those will already be in the library. They are
+            # only needed while generating backend (ninja) target dependencies.
+            if link_whole:
+                transitive_deps.append(t)
+            # However, the transitive dependencies are still needed
+            if isinstance(t, StaticLibrary):
+                transitive_deps += t.get_dependencies(transitive_deps + exclude,
+                                                      internal, link_whole)
         return transitive_deps
 
     def get_source_subdir(self):
@@ -958,7 +979,17 @@ You probably should put it in link_with instead.''')
                 raise InvalidArguments(msg)
             if self.is_cross != t.is_cross:
                 raise InvalidArguments('Tried to mix cross built and native libraries in target {!r}'.format(self.name))
-            self.link_targets.append(t)
+            # When linking to a static library that's not installed, we
+            # transparently add that target's objects to ourselves.
+            # Static libraries that are installed will either be linked through
+            # self.link_targets or using the pkg-config file.
+            if isinstance(self, StaticLibrary) and isinstance(t, StaticLibrary) and not t.need_install:
+                self.objects.append(t.extract_all_objects())
+                # Add internal and external deps
+                self.external_deps += t.external_deps
+                self.link_targets += t.link_targets
+            else:
+                self.link_targets.append(t)
 
     def link_whole(self, target):
         for t in listify(target, unholder=True):
@@ -970,7 +1001,15 @@ You probably should put it in link_with instead.''')
                 raise InvalidArguments(msg)
             if self.is_cross != t.is_cross:
                 raise InvalidArguments('Tried to mix cross built and native libraries in target {!r}'.format(self.name))
-            self.link_whole_targets.append(t)
+            # When we're a static library and we link_whole: to another static
+            # library, we need to add that target's objects to ourselves.
+            if isinstance(self, StaticLibrary):
+                self.objects.append(t.extract_all_objects())
+                # Add internal and external deps
+                self.external_deps += t.external_deps
+                self.link_targets += t.link_targets
+            else:
+                self.link_whole_targets.append(t)
 
     def add_pch(self, language, pchlist):
         if not pchlist:

--- a/test cases/common/143 C and CPP link/meson.build
+++ b/test cases/common/143 C and CPP link/meson.build
@@ -15,8 +15,8 @@
 project('C and C++ static link test', ['c', 'cpp'])
 
 # Verify that adding link arguments works.
-add_global_link_arguments('', language : 'c')
-add_project_link_arguments('', language : 'c')
+add_global_link_arguments('-DMESON_UNUSED', language : 'c')
+add_project_link_arguments('-DMESON_UNUSED', language : 'c')
 
 libc = static_library('cfoo', ['foo.c', 'foo.h'])
 

--- a/test cases/unit/35 both library usability/consumer/meson.build
+++ b/test cases/unit/35 both library usability/consumer/meson.build
@@ -1,0 +1,11 @@
+project('both libraries consumer', 'c')
+
+d1 = dependency('whole-installed')
+d2 = dependency('whole-internal')
+d3 = dependency('with-installed')
+d4 = dependency('with-internal')
+
+test('both-whole-installed', executable('tester1', 'tester.c', dependencies : d1))
+test('both-whole-internal', executable('tester2', 'tester.c', dependencies : d2))
+test('both-with-installed', executable('tester3', 'tester.c', dependencies : d3))
+test('both-with-internal', executable('tester4', 'tester.c', dependencies : d4))

--- a/test cases/unit/35 both library usability/consumer/tester.c
+++ b/test cases/unit/35 both library usability/consumer/tester.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+#if defined(_MSC_VER) && !defined(PROVIDER_STATIC)
+__declspec(dllimport)
+#endif
+int both_get_dat_value (void);
+
+int main (int argc, char *argv[])
+{
+  int got = both_get_dat_value ();
+
+  if (got != 111) {
+    printf ("Got %i instead of 111\n", got);
+    return 2;
+  }
+  return 0;
+}

--- a/test cases/unit/35 both library usability/provider/both.c
+++ b/test cases/unit/35 both library usability/provider/both.c
@@ -1,0 +1,20 @@
+#if defined(_MSC_VER) && !defined(PROVIDER_STATIC)
+__declspec(dllimport)
+#endif
+int get_dat_value (void);
+
+#ifdef INSTALLED_LIBRARY
+  #define EXPECTED_VALUE 69
+#else
+  #define EXPECTED_VALUE 42
+#endif
+
+#if defined(_MSC_VER) && !defined(PROVIDER_STATIC)
+__declspec(dllexport)
+#endif
+int both_get_dat_value (void)
+{
+  if (get_dat_value () != EXPECTED_VALUE)
+    return 666;
+  return 111;
+}

--- a/test cases/unit/35 both library usability/provider/meson.build
+++ b/test cases/unit/35 both library usability/provider/meson.build
@@ -1,0 +1,36 @@
+project('both library provider', 'c')
+
+pkg = import('pkgconfig')
+
+subdir('otherlib')
+
+# Both libraries with a link_whole dependency on an installed static library
+l1 = library('whole-installed', 'both.c',
+            c_args : ['-DINSTALLED_LIBRARY'],
+            link_whole : installed_lib,
+            install: true)
+pkg.generate(l1)
+
+# Both libraries with a link_whole dependency on a not-installed static library
+l2 = library('whole-internal', 'both.c',
+            link_whole : internal_lib,
+            install: true)
+pkg.generate(l2)
+
+# Both libraries with a link_with dependency on an installed static library
+l3 = library('with-installed', 'both.c',
+            c_args : ['-DINSTALLED_LIBRARY'],
+            link_with : installed_lib,
+            install: true)
+pkg.generate(l3)
+
+# Both libraries with a link_with dependency on a not-installed static library
+l4 = library('with-internal', 'both.c',
+            link_with : internal_lib,
+            install: true)
+pkg.generate(l4)
+
+test('test-both-whole-installed', executable('tester1', 'tester.c', link_with : l1))
+test('test-both-whole-internal', executable('tester2', 'tester.c', link_with : l2))
+test('test-both-with-installed', executable('tester3', 'tester.c', link_with : l3))
+test('test-both-with-internal', executable('tester4', 'tester.c', link_with : l4))

--- a/test cases/unit/35 both library usability/provider/otherlib/installed.c
+++ b/test cases/unit/35 both library usability/provider/otherlib/installed.c
@@ -1,0 +1,7 @@
+#if defined(_MSC_VER) && !defined(PROVIDER_STATIC)
+__declspec(dllexport)
+#endif
+int get_dat_value (void)
+{
+  return 69;
+}

--- a/test cases/unit/35 both library usability/provider/otherlib/internal.c
+++ b/test cases/unit/35 both library usability/provider/otherlib/internal.c
@@ -1,0 +1,7 @@
+#if defined(_MSC_VER) && !defined(PROVIDER_STATIC)
+__declspec(dllexport)
+#endif
+int get_dat_value (void)
+{
+  return 42;
+}

--- a/test cases/unit/35 both library usability/provider/otherlib/meson.build
+++ b/test cases/unit/35 both library usability/provider/otherlib/meson.build
@@ -1,0 +1,3 @@
+internal_lib = static_library('internal-some', 'internal.c')
+
+installed_lib = static_library('installed-some', 'installed.c', install: true)

--- a/test cases/unit/35 both library usability/provider/tester.c
+++ b/test cases/unit/35 both library usability/provider/tester.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+int both_get_dat_value (void);
+
+int main (int argc, char *argv[])
+{
+  int got = both_get_dat_value ();
+
+  if (got != 111) {
+    printf ("Got %i instead of 111\n", got);
+    return 2;
+  }
+  return 0;
+}


### PR DESCRIPTION
This commit contains the following fixes:

1. When a shared library A does `link_with:` to static library B, the
   parts of B used by A will be added to A, and so we don't need to
   return B in A.get_dependencies() for targets that link to A. This
   already is the behaviour when a shared library A does `link_whole:`
   on B.

2. In situation (1), when generating a pkg-config file for A, we must
   also not add B to Libs.private for A. This already is the behaviour
   when a shared library A does `link_whole:` on B.

3. When a static library A does `link_whole:` to static library B, we
   must add the objects in B to A.

4. When a static library A does `link_with:` to static library B, and
   B is not installed (which makes it an internal static library), we
   must add the objects in B to A, otherwise nothing can use A.

5. In situation (4), when generating a pkg-config file for A, we must
   also not add B to Libs.private for A.

All these situations are tested by the unit test added in this commit.

Closes https://github.com/mesonbuild/meson/issues/3934
Closes https://github.com/mesonbuild/meson/issues/3937