### PR TITLE
i18n: respect variable substitution for the target name when merging translations

### DIFF
--- a/docs/markdown/snippets/i18n_variable_substitution.md
+++ b/docs/markdown/snippets/i18n_variable_substitution.md
@@ -1,0 +1,4 @@
+## i18n.merge_file() now fully supports variable substitutions defined in custom_target()
+
+Filename substitutions like @BASENAME@ and @PLAINNAME@ were previously accepted but the name of the build target wasn't altered leading to colliding target names when using the substitution twice.
+i18n.merge_file() now behaves as custom_target() in this regard.

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -80,7 +80,19 @@ class I18nModule(ExtensionModule):
             command.append(datadirs)
 
         kwargs['command'] = command
-        ct = build.CustomTarget(kwargs['output'] + '_merge', state.subdir, state.subproject, kwargs)
+
+        inputfile = kwargs['input']
+        if isinstance(inputfile, str):
+            inputfile = mesonlib.File.from_source_file(state.environment.source_dir,
+                                                       state.subdir, inputfile)
+        output = kwargs['output']
+        ifile_abs = inputfile.absolute_path(state.environment.source_dir,
+                                            state.environment.build_dir)
+        values = mesonlib.get_filenames_templates_dict([ifile_abs], None)
+        outputs = mesonlib.substitute_values([output], values)
+        output = outputs[0]
+
+        ct = build.CustomTarget(output + '_merge', state.subdir, state.subproject, kwargs)
         return ModuleReturnValue(ct, [ct])
 
     @FeatureNewKwargs('i18n.gettext', '0.37.0', ['preset'])

--- a/test cases/frameworks/6 gettext/data/meson.build
+++ b/test cases/frameworks/6 gettext/data/meson.build
@@ -1,6 +1,26 @@
+# Use filename substitution
 i18n.merge_file(
   input: 'test.desktop.in',
-  output: 'test.desktop',
+  output: '@BASENAME@',
+  type: 'desktop',
+  po_dir: '../po',
+  install: true,
+  install_dir: join_paths(get_option('datadir'), 'applications')
+)
+
+# Use filename substitution for another file
+i18n.merge_file(
+  input: 'test2.desktop.in',
+  output: '@BASENAME@',
+  type: 'desktop',
+  po_dir: '../po',
+  install: true,
+  install_dir: join_paths(get_option('datadir'), 'applications')
+)
+
+i18n.merge_file(
+  input: 'test.desktop.in',
+  output: 'test3.desktop',
   type: 'desktop',
   po_dir: '../po',
   install: true,

--- a/test cases/frameworks/6 gettext/data/test2.desktop.in
+++ b/test cases/frameworks/6 gettext/data/test2.desktop.in
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Test 2
+GenericName=Application
+Comment=Test Application
+Type=Application
+

--- a/test cases/frameworks/6 gettext/installed_files.txt
+++ b/test cases/frameworks/6 gettext/installed_files.txt
@@ -2,3 +2,5 @@ usr/bin/intlprog?exe
 usr/share/locale/de/LC_MESSAGES/intltest.mo
 usr/share/locale/fi/LC_MESSAGES/intltest.mo
 usr/share/applications/test.desktop
+usr/share/applications/test2.desktop
+usr/share/applications/test3.desktop


### PR DESCRIPTION
Previously it wasn't possible to use twice `@BASENAME@` as output in `i18n.merge_file` as the targets would then be named `@BASENAME@_merge`