### PR TITLE
Fix missing permitted kwarg

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -405,7 +405,7 @@ class DependencyHolder(InterpreterObject, ObjectHolder):
     def name_method(self, args, kwargs):
         return self.held_object.get_name()
 
-    @permittedKwargs({'define_variable'})
+    @permittedKwargs({'define_variable', 'default'})
     def pkgconfig_method(self, args, kwargs):
         args = listify(args)
         if len(args) != 1:


### PR DESCRIPTION
get_pkgconfig_variable() takes a 'default' keyword