### PR TITLE
Adding a new AR Linker Class for the ARM Compiler.

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -15,7 +15,7 @@
 import configparser, os, platform, re, shlex, shutil, subprocess
 
 from . import coredata
-from .linkers import ArLinker, VisualStudioLinker
+from .linkers import ArLinker, ArmarLinker, VisualStudioLinker
 from . import mesonlib
 from .mesonlib import EnvironmentException, Popen_safe
 from . import mlog
@@ -885,6 +885,8 @@ This is probably wrong, it should always point to the native compiler.''' % evar
                 continue
             if '/OUT:' in out or '/OUT:' in err:
                 return VisualStudioLinker(linker)
+            if p.returncode == 0 and ('armar' in linker or 'armar.exe' in linker):
+                return ArmarLinker(linker)
             if p.returncode == 0:
                 return ArLinker(linker)
             if p.returncode == 1 and err.startswith('usage'): # OSX

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -127,57 +127,6 @@ class ArLinker(StaticLinker):
     def get_link_debugfile_args(self, targetfile):
         return []
 
-class ArmarLinker(StaticLinker):
-
-    def __init__(self, exelist):
-        self.exelist = exelist
-        self.id = 'armar'
-        self.std_args = ['-csr']
-
-    def can_linker_accept_rsp(self):
-        # armar cann't accept arguments using the @rsp syntax
-        return False
-
-    def build_rpath_args(self, build_dir, from_dir, rpath_paths, build_rpath, install_rpath):
-        return []
-
-    def get_exelist(self):
-        return self.exelist[:]
-
-    def get_std_link_args(self):
-        return self.std_args
-
-    def get_output_args(self, target):
-        return [target]
-
-    def get_buildtype_linker_args(self, buildtype):
-        return []
-
-    def get_linker_always_args(self):
-        return []
-
-    def get_coverage_link_args(self):
-        return []
-
-    def get_always_args(self):
-        return []
-
-    def thread_link_flags(self, env):
-        return []
-
-    def openmp_flags(self):
-        return []
-
-    def get_option_link_args(self, options):
-        return []
-
-    @classmethod
-    def unix_args_to_native(cls, args):
-        return args[:]
-
-    def get_link_debugfile_args(self, targetfile):
-        return []
-
 class ArmarLinker(ArLinker):
 
     def __init__(self, exelist):

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -137,4 +137,3 @@ class ArmarLinker(ArLinker):
     def can_linker_accept_rsp(self):
         # armar cann't accept arguments using the @rsp syntax
         return False
-

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -83,12 +83,60 @@ class ArLinker(StaticLinker):
             self.std_args = ['csrD']
         else:
             self.std_args = ['csr']
-        # For 'armar' the options should be prefixed with '-'.
-        if 'armar' in stdo:
-            self.std_args = ['-csr']
 
     def can_linker_accept_rsp(self):
         return mesonlib.is_windows()
+
+    def build_rpath_args(self, build_dir, from_dir, rpath_paths, build_rpath, install_rpath):
+        return []
+
+    def get_exelist(self):
+        return self.exelist[:]
+
+    def get_std_link_args(self):
+        return self.std_args
+
+    def get_output_args(self, target):
+        return [target]
+
+    def get_buildtype_linker_args(self, buildtype):
+        return []
+
+    def get_linker_always_args(self):
+        return []
+
+    def get_coverage_link_args(self):
+        return []
+
+    def get_always_args(self):
+        return []
+
+    def thread_link_flags(self, env):
+        return []
+
+    def openmp_flags(self):
+        return []
+
+    def get_option_link_args(self, options):
+        return []
+
+    @classmethod
+    def unix_args_to_native(cls, args):
+        return args[:]
+
+    def get_link_debugfile_args(self, targetfile):
+        return []
+
+class ArmarLinker(StaticLinker):
+
+    def __init__(self, exelist):
+        self.exelist = exelist
+        self.id = 'armar'
+        self.std_args = ['-csr']
+
+    def can_linker_accept_rsp(self):
+        # armar cann't accept arguments using the @rsp syntax
+        return False
 
     def build_rpath_args(self, build_dir, from_dir, rpath_paths, build_rpath, install_rpath):
         return []

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -177,3 +177,15 @@ class ArmarLinker(StaticLinker):
 
     def get_link_debugfile_args(self, targetfile):
         return []
+
+class ArmarLinker(ArLinker):
+
+    def __init__(self, exelist):
+        self.exelist = exelist
+        self.id = 'armar'
+        self.std_args = ['-csr']
+
+    def can_linker_accept_rsp(self):
+        # armar cann't accept arguments using the @rsp syntax
+        return False
+


### PR DESCRIPTION
The ARM's AR linker does not support rsp files. So, a separate Linker class is added for ARM compiler.