### PR TITLE
Test that vim syntax highlighting is up-to-date

### DIFF
--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -69,6 +69,7 @@ syn keyword mesonBuiltin
   \ add_project_arguments
   \ add_project_link_arguments
   \ add_test_setup
+  \ assert
   \ benchmark
   \ both_libraries
   \ build_machine
@@ -102,6 +103,7 @@ syn keyword mesonBuiltin
   \ library
   \ meson
   \ message
+  \ option
   \ project
   \ run_command
   \ run_target
@@ -110,6 +112,7 @@ syn keyword mesonBuiltin
   \ shared_module
   \ static_library
   \ subdir
+  \ subdir_done
   \ subproject
   \ target_machine
   \ test

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1847,7 +1847,7 @@ permitted_kwargs = {'add_global_arguments': {'language'},
 class Interpreter(InterpreterBase):
 
     def __init__(self, build, backend=None, subproject='', subdir='', subproject_dir='subprojects',
-                 modules = None, default_project_options=None):
+                 modules = None, default_project_options=None, mock=False):
         super().__init__(build.environment.get_source_dir(), subdir)
         self.an_unpicklable_object = mesonlib.an_unpicklable_object
         self.build = build
@@ -1864,8 +1864,9 @@ class Interpreter(InterpreterBase):
         self.subproject_directory_name = subdir.split(os.path.sep)[-1]
         self.subproject_dir = subproject_dir
         self.option_file = os.path.join(self.source_root, self.subdir, 'meson_options.txt')
-        self.load_root_meson_file()
-        self.sanity_check_ast()
+        if not mock:
+            self.load_root_meson_file()
+            self.sanity_check_ast()
         self.builtin.update({'meson': MesonMain(build, self)})
         self.generators = []
         self.visited_subdirs = {}
@@ -1883,7 +1884,8 @@ class Interpreter(InterpreterBase):
         self.build_func_dict()
         # build_def_files needs to be defined before parse_project is called
         self.build_def_files = [os.path.join(self.subdir, environment.build_filename)]
-        self.parse_project()
+        if not mock:
+            self.parse_project()
         self.builtin['build_machine'] = BuildMachine(self.coredata.compilers)
         if not self.build.environment.is_cross_build():
             self.builtin['host_machine'] = self.builtin['build_machine']


### PR DESCRIPTION
Needs a `mock` kwarg to Interpreter to not do any parsing of build files, but only setup the builtins and functions.

Also consolidate the documentation and data tests into one class.

I noticed this a while ago, and decided to write a test for it while I was sufficiently annoyed by it :smile: 