### PR TITLE
Fix yielding when subproject option type is different

### DIFF
--- a/test cases/common/175 yield/meson.build
+++ b/test cases/common/175 yield/meson.build
@@ -3,4 +3,5 @@ project('yield_options', 'c')
 subproject('sub')
 
 assert(get_option('unshared_option') == 'one', 'Unshared option has wrong value in superproject.')
-assert(get_option('shared_option') == 'two', 'Unshared option has wrong value in superproject..')
+assert(get_option('shared_option') == 'two', 'Shared option has wrong value in superproject..')
+assert(get_option('wrongtype_option') == 'three', 'Wrongtype option has wrong value in superproject..')

--- a/test cases/common/175 yield/meson_options.txt
+++ b/test cases/common/175 yield/meson_options.txt
@@ -1,2 +1,3 @@
 option('unshared_option', type : 'string', value : 'one')
 option('shared_option', type : 'string', value : 'two')
+option('wrongtype_option', type : 'string', value : 'three')

--- a/test cases/common/175 yield/subprojects/sub/meson.build
+++ b/test cases/common/175 yield/subprojects/sub/meson.build
@@ -2,3 +2,4 @@ project('subbie', 'c')
 
 assert(get_option('unshared_option') == 'three', 'Unshared option has wrong value in subproject.')
 assert(get_option('shared_option') == 'two', 'Shared option has wrong value in subproject.')
+assert(get_option('wrongtype_option') == true, 'Wrongtype option has wrong value in subproject.')

--- a/test cases/common/175 yield/subprojects/sub/meson_options.txt
+++ b/test cases/common/175 yield/subprojects/sub/meson_options.txt
@@ -1,2 +1,3 @@
 option('unshared_option', type : 'string', value : 'three', yield : false)
 option('shared_option', type : 'string', value : 'four', yield : true)
+option('wrongtype_option', type : 'boolean', value : true, yield : true)


### PR DESCRIPTION
Earlier, we would replace the subproject option with the parent
project's option, which is incorrect if the types are not the same.

Now we retain the subproject's option and print a warning. It's not
advisable to issue an error in this case because subproject option
yielding is involuntary for the parent project (option names can match
because of coincidences).