### PR TITLE
gnome: Fix building gir with asan again

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -511,7 +511,7 @@ class GnomeModule(ExtensionModule):
                 sanitize = state.environment.coredata.base_options['b_sanitize'].value
                 cflags += compilers.sanitizer_compile_args(sanitize)
                 if 'address' in sanitize.split(','):
-                    external_ldflags += ['-lasan']
+                    internal_ldflags += ['-lasan']  # This must be first in ldflags
                 # FIXME: Linking directly to libasan is not recommended but g-ir-scanner
                 # does not understand -f LDFLAGS. https://bugzilla.gnome.org/show_bug.cgi?id=783892
                 # ldflags += compilers.sanitizer_link_args(sanitize)


### PR DESCRIPTION
asan must be first in ldflags and this order was lost in cb36add970d448f8b4ace7e4dc6028e5441bccd7

So this is the most simple solution of just putting it first in internal_ldflags (maybe not ideal).

See https://github.com/mesonbuild/meson/issues/2117#issuecomment-408560838