### PR TITLE
Updated boost discovery to handle version >= 1.65 for MSVC

### DIFF
--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -327,7 +327,7 @@ class BoostDependency(ExternalDependency):
 
     def debug_tag(self):
         return '-gd' if self.is_debug else ''
-		
+
     def arch_tag(self):
         # currently only applies to windows msvc installed binaries
         if self.env.detect_cpp_compiler(self.want_cross).get_id() != 'msvc':

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -63,6 +63,7 @@ from .base import (DependencyException, ExternalDependency)
 # Win   / Cygwin:   libboost_<module>.dll.a                                 (location = /usr/lib)
 #                   libboost_<module>.a
 #                   cygboost_<module>_1_64.dll                              (location = /usr/bin)
+# Win   / VS:       boost_<module>-vc<ver>-mt[-gd]-<arch>-1_67.dll          (location = C:/local/boost_1_67_0)
 # Mac   / homebrew: libboost_<module>.dylib + libboost_<module>-mt.dylib    (location = /usr/local/lib)
 # Mac   / macports: libboost_<module>.dylib + libboost_<module>-mt.dylib    (location = /opt/local/lib)
 #
@@ -269,7 +270,6 @@ class BoostDependency(ExternalDependency):
 
     def detect_lib_modules(self):
         self.lib_modules = {}
-
         # 1. Try to find modules using compiler.find_library( )
         if self.find_libraries_with_abi_tags(self.abi_tags()):
             pass
@@ -327,9 +327,23 @@ class BoostDependency(ExternalDependency):
 
     def debug_tag(self):
         return '-gd' if self.is_debug else ''
+		
+    def arch_tag(self):
+        # currently only applies to windows msvc installed binaries
+        if self.env.detect_cpp_compiler(self.want_cross).get_id() != 'msvc':
+            return ''
+        # pre-compiled binaries only added arch tag for versions > 1.64
+        if float(self.version) < 1.65:
+            return ''
+        arch = detect_cpu_family(self.env.coredata.compilers)
+        if arch == 'x86':
+            return '-x32'
+        elif arch == 'x86_64':
+            return '-x64'
+        return ''
 
     def versioned_abi_tag(self):
-        return self.compiler_tag() + self.threading_tag() + self.debug_tag() + self.version_tag()
+        return self.compiler_tag() + self.threading_tag() + self.debug_tag() + self.arch_tag() + self.version_tag()
 
     # FIXME - how to handle different distributions, e.g. for Mac? Currently we handle homebrew and macports, but not fink.
     def abi_tags(self):


### PR DESCRIPTION
Boost discovery for MSVC is unable to handle Boost versions >1.64. In Boost versions 1.65+, an architecture tag was added to the abi. This pull request checks for the special case of Boost >1.64 using MSVC compiler and then adds the appropriate arch tag to the abi.