### PR TITLE
Fix .travis.yml for updated OSX image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,7 @@ matrix:
 before_install:
   - python ./skip_ci.py --base-branch-env=TRAVIS_BRANCH --is-pull-env=TRAVIS_PULL_REQUEST
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew uninstall python mercurial; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python@2 python@3 mercurial qt pkg-config; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt pkg-config; fi
   # Use a Ninja with QuLogic's patch: https://github.com/ninja-build/ninja/issues/1219
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir -p $HOME/tools; curl -L http://nirbheek.in/files/binaries/ninja/macos/ninja -o $HOME/tools/ninja; chmod +x $HOME/tools/ninja; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker pull jpakkane/mesonci:bionic; fi


### PR DESCRIPTION
Since [1], OSX builds on travis fail with:

Error: Refusing to uninstall /usr/local/Cellar/python/3.6.5_1
because it is required by gdal, numpy, postgis, which are currently installed.

Furthermore, python3 is now installed in the image.

Revise #3163

[1] https://blog.travis-ci.com/2018-07-19-xcode9-4-default-announce