### PR TITLE
Fix __main__.py for zipapp to work

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import meson
+from mesonbuild import mesonmain
 import sys
 
-sys.exit(meson.main())
+sys.exit(mesonmain.main())

--- a/run_meson_command_tests.py
+++ b/run_meson_command_tests.py
@@ -18,6 +18,7 @@ import os
 import tempfile
 import unittest
 import subprocess
+import zipapp
 from pathlib import Path
 
 from mesonbuild.mesonlib import windows_proof_rmtree, python_command, is_windows
@@ -181,6 +182,14 @@ class CommandTests(unittest.TestCase):
 
     def test_meson_exe_windows(self):
         raise unittest.SkipTest('NOT IMPLEMENTED')
+
+    def test_meson_zipapp(self):
+        if is_windows():
+            raise unittest.SkipTest('NOT IMPLEMENTED')
+        source = Path(__file__).resolve().parent.as_posix()
+        target = self.tmpdir / 'meson.pyz'
+        zipapp.create_archive(source=source, target=target, interpreter=python_command[0], main=None)
+        self._run([target.as_posix(), '--help'])
 
 if __name__ == '__main__':
     unittest.main(buffer=True)


### PR DESCRIPTION
0a035de removed main from meson.py breaking the call from __main__.py.
This causes zipapps to fail, since the call to meson.main() obviously does not work.
Copy the invocation from meson.py fixes this issue.