### PR TITLE
Clarify version for check_header, fixes #3974

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1644,7 +1644,7 @@ the following methods:
   `args` keyword, you can specify external dependencies to use with
   `dependencies` keyword argument.
 
-- `check_header` returns true if the specified header is *usable* with
+- `check_header` *(added 0.47.0)* returns true if the specified header is *usable* with
   the specified prefix, dependencies, and arguments.
   You can specify external dependencies to use with `dependencies`
   keyword argument and extra code to put above the header test with


### PR DESCRIPTION
check_header method was added in compiler object in version 0.47. Documentation needs to be updated for this.