### PR TITLE
Prints error message instead of backtrace on fail

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -247,7 +247,7 @@ def get_compiler_for_source(compilers, src):
     for comp in compilers:
         if comp.can_compile(src):
             return comp
-    raise RuntimeError('No specified compiler can handle file {!s}'.format(src))
+    raise MesonException('No specified compiler can handle file {!s}'.format(src))
 
 def classify_unity_sources(compilers, sources):
     compsrclist = {}


### PR DESCRIPTION
I got a backtrace when I had a cpp file in a c project. I think it is better to print a nice error message.

before:
```
Traceback (most recent call last):
  File "/home/niklas/git/meson/mesonbuild/mesonmain.py", line 351, in run
    app.generate()
  File "/home/niklas/git/meson/mesonbuild/mesonmain.py", line 117, in generate
    self._generate(env)
  File "/home/niklas/git/meson/mesonbuild/mesonmain.py", line 166, in _generate
    intr.backend.generate(intr)
  File "/home/niklas/git/meson/mesonbuild/backend/ninjabackend.py", line 224, in generate
    self.generate_target(t, outfile)
  File "/home/niklas/git/meson/mesonbuild/backend/ninjabackend.py", line 472, in generate_target
    obj_list.append(self.generate_single_compile(target, outfile, src, False, [], header_deps))
  File "/home/niklas/git/meson/mesonbuild/backend/ninjabackend.py", line 2042, in generate_single_compile
    compiler = get_compiler_for_source(target.compilers.values(), src)
  File "/home/niklas/git/meson/mesonbuild/mesonlib.py", line 250, in get_compiler_for_source
    raise RuntimeError('No specified compiler can handle file {!s}'.format(src))
RuntimeError: No specified compiler can handle file main.cpp
```
after:
```
ERROR: No specified compiler can handle file main.cpp
```