### PR TITLE
Dont require implib for shared modules at install time

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -55,7 +55,7 @@ class InstallData:
         self.mesonintrospect = mesonintrospect
 
 class TargetInstallData:
-    def __init__(self, fname, outdir, aliases, strip, install_name_mappings, install_rpath, install_mode):
+    def __init__(self, fname, outdir, aliases, strip, install_name_mappings, install_rpath, install_mode, optional=False):
         self.fname = fname
         self.outdir = outdir
         self.aliases = aliases
@@ -63,6 +63,7 @@ class TargetInstallData:
         self.install_name_mappings = install_name_mappings
         self.install_rpath = install_rpath
         self.install_mode = install_mode
+        self.optional = optional
 
 class ExecutableSerialisation:
     def __init__(self, name, fname, cmd_args, env, is_cross, exe_wrapper,
@@ -1047,9 +1048,10 @@ class Backend:
                             implib_install_dir = outdirs[0]
                         else:
                             implib_install_dir = self.environment.get_import_lib_dir()
-                        # Install the import library.
+                        # Install the import library; may not exist for shared modules
                         i = TargetInstallData(self.get_target_filename_for_linking(t),
-                                              implib_install_dir, {}, False, {}, '', install_mode)
+                                              implib_install_dir, {}, False, {}, '', install_mode,
+                                              optional=isinstance(t, build.SharedModule))
                         d.targets.append(i)
                 # Install secondary outputs. Only used for Vala right now.
                 if num_outdirs > 1:

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1274,6 +1274,9 @@ class VisualStudioCCompiler(CCompiler):
     def get_pic_args(self):
         return [] # PIC is handled by the loader on Windows
 
+    def gen_export_dynamic_link_args(self, env):
+        return [] # Not applicable with MSVC
+
     def get_std_shared_lib_link_args(self):
         return ['/DLL']
 

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -384,6 +384,13 @@ class Installer:
 
     def install_targets(self, d):
         for t in d.targets:
+            if not os.path.exists(t.fname):
+                # For example, import libraries of shared modules are optional
+                if t.optional:
+                    print('File {!r} not found, skipping'.format(t.fname))
+                    continue
+                else:
+                    raise RuntimeError('File {!r} could not be found'.format(t.fname))
             fname = check_for_stampfile(t.fname)
             outdir = get_destdir_path(d, t.outdir)
             outname = os.path.join(outdir, os.path.basename(fname))

--- a/test cases/common/125 shared module/installed_files.txt
+++ b/test cases/common/125 shared module/installed_files.txt
@@ -1,0 +1,1 @@
+usr/lib/libnosyms.so

--- a/test cases/common/125 shared module/meson.build
+++ b/test cases/common/125 shared module/meson.build
@@ -11,3 +11,10 @@ m = shared_module('mymodule', 'module.c')
 e = executable('prog', 'prog.c',
   link_with : l, export_dynamic : true, dependencies : dl)
 test('import test', e, args : m)
+
+# Shared module that does not export any symbols
+shared_module('nosyms', 'nosyms.c', install : true,
+              # Because we don't have cross-platform library support in
+              # installed_files.txt
+              name_suffix : 'so',
+              name_prefix : 'lib')

--- a/test cases/common/125 shared module/nosyms.c
+++ b/test cases/common/125 shared module/nosyms.c
@@ -1,0 +1,4 @@
+static int
+func_not_exported (void) {
+    return 99;
+}


### PR DESCRIPTION
commit 9abbf2b37082435e1d176c260bdd278cf802e72a

    msvc: Don't add dynamic link args, they're ignored

    And they print a linker warning about unknown args.

commit 91a528ac19eb4cef48f7933ee7467a487adfb9f7

    Don't require an import library for shared modules

    Shared modules may be resource-only DLLs, or might automatically
    self-initialize using C constructors or WinMain at DLL load time.

    When an import library is not found for a shared module, just print
    a message about it instead of erroring out.
