### PR TITLE
Don't check version for fallback not-found dependency

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2814,6 +2814,12 @@ external dependencies (including libraries) must go to "dependencies".''')
         if not dep:
             return False
         found = dep.version_method([], {})
+        # Don't do a version check if the dependency is not found and not required
+        if found == 'none' and not required:
+            subproj_path = os.path.join(self.subproject_dir, dirname)
+            mlog.log('Dependency', mlog.bold(name), 'from subproject',
+                     mlog.bold(subproj_path), 'found:', mlog.red('NO'), '(cached)')
+            return dep
         if self.check_subproject_version(wanted, found):
             subproj_path = os.path.join(self.subproject_dir, dirname)
             mlog.log('Dependency', mlog.bold(name), 'from subproject',

--- a/test cases/common/176 subproject nested subproject dirs/contrib/subprojects/beta/meson.build
+++ b/test cases/common/176 subproject nested subproject dirs/contrib/subprojects/beta/meson.build
@@ -1,3 +1,4 @@
 project('beta project', 'c')
 
 lb = shared_library('b', 'b.c')
+notfound = dependency('', required : false)

--- a/test cases/common/176 subproject nested subproject dirs/meson.build
+++ b/test cases/common/176 subproject nested subproject dirs/meson.build
@@ -3,5 +3,9 @@ project('gamma project', 'c', subproject_dir: 'contrib/subprojects')
 a = subproject('alpha')
 lib = a.get_variable('l')
 
+# Ensure that the dependency version is not checked for a not-found dependency
+notfound = dependency('', version : '>=1.0', required : false,
+                      fallback : ['beta', 'notfound'])
+
 exe = executable('prog', 'prog.c', link_with : lib)
 test('basic', exe)


### PR DESCRIPTION
Otherwise we get an error while checking the subproject version:

  Uncomparable version string 'none'.

If the dependency was found as a not-found dependency in the
subproject and is not required, just take it.