### PR TITLE
Fix bug and clarify error message in cross file validation

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -983,12 +983,10 @@ class CrossBuildInfo:
     def __init__(self, filename):
         self.config = {'properties': {}}
         self.parse_datafile(filename)
-        if 'target_machine' in self.config:
-            return
-        if 'host_machine' not in self.config:
+        if 'host_machine' not in self.config and 'target_machine' not in self.config:
             raise mesonlib.MesonException('Cross info file must have either host or a target machine.')
-        if 'binaries' not in self.config:
-            raise mesonlib.MesonException('Cross file is missing "binaries".')
+        if 'host_machine' in self.config and 'binaries' not in self.config:
+            raise mesonlib.MesonException('Cross file with "host_machine" is missing "binaries".')
 
     def ok_type(self, i):
         return isinstance(i, (str, int, bool))


### PR DESCRIPTION
I believe the intent (from 30d0c2292fee831d74f080e62c1c74990ea76abb) is that `[binaries]` isn't needed just for "target-only cross" (build == host != target). This fixes the code to match that, hopefully clarifying the control flow in the process, and also improves the message to make that clear.