### PR TITLE
PkgConfigDependency: Don't try to resolve internal compiler libs

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -661,6 +661,9 @@ class Compiler:
     # Libraries to ignore in find_library() since they are provided by the
     # compiler or the C library. Currently only used for MSVC.
     ignore_libs = ()
+    # Libraries that are internal compiler implementations, and must not be
+    # manually searched.
+    internal_libs = ()
     # Cache for the result of compiler checks which can be cached
     compiler_check_cache = {}
 

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -623,12 +623,16 @@ class PkgConfigDependency(ExternalDependency):
                 # arguments as-is and then adding the libpaths at the end.
                 else:
                     args = None
-                if args:
+                if args is not None:
                     libs_found.add(lib)
                     # Replace -l arg with full path to library if available
-                    # else, library is provided by the compiler and can't be resolved
-                    if not args[0].startswith('-l'):
-                        lib = args[0]
+                    # else, library is either to be ignored, or is provided by
+                    # the compiler, can't be resolved, and should be used as-is
+                    if args:
+                        if not args[0].startswith('-l'):
+                            lib = args[0]
+                    else:
+                        continue
                 else:
                     # Library wasn't found, maybe we're looking in the wrong
                     # places or the library will be provided with LDFLAGS or


### PR DESCRIPTION
`-lc` `-lm` and `-lpthread` are special linker arguments that should never
be resolved to on-disk libraries.

Closes https://github.com/mesonbuild/meson/issues/3879