### PR TITLE
Add --fatal-warnings command line option

### DIFF
--- a/docs/markdown/snippets/fatal_warnings.md
+++ b/docs/markdown/snippets/fatal_warnings.md
@@ -1,0 +1,6 @@
+## Fatal warnings
+
+A new command line option has been added: `--fatal-meson-warnings`. When enabled, any
+warning message printed by Meson will be fatal and raise an exception. It is
+intended to be used by developers and CIs to easily catch deprecation warnings,
+or any other potential issues.

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -41,6 +41,8 @@ def create_parser():
                    help='Special wrap mode to use')
     p.add_argument('--profile-self', action='store_true', dest='profile',
                    help=argparse.SUPPRESS)
+    p.add_argument('--fatal-meson-warnings', action='store_true', dest='fatal_warnings',
+                   help='Make all Meson warnings fatal')
     p.add_argument('builddir', nargs='?', default=None)
     p.add_argument('sourcedir', nargs='?', default=None)
     return p
@@ -110,7 +112,7 @@ class MesonApp:
 
     def generate(self):
         env = environment.Environment(self.source_dir, self.build_dir, self.options)
-        mlog.initialize(env.get_log_dir())
+        mlog.initialize(env.get_log_dir(), self.options.fatal_warnings)
         if self.options.profile:
             mlog.set_timestamp_start(time.monotonic())
         with mesonlib.BuildDirLock(self.build_dir):

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -46,11 +46,13 @@ log_file = None
 log_fname = 'meson-log.txt'
 log_depth = 0
 log_timestamp_start = None
+log_fatal_warnings = False
 
-def initialize(logdir):
-    global log_dir, log_file
+def initialize(logdir, fatal_warnings=False):
+    global log_dir, log_file, log_fatal_warnings
     log_dir = logdir
     log_file = open(os.path.join(logdir, log_fname), 'w', encoding='utf8')
+    log_fatal_warnings = fatal_warnings
 
 def set_timestamp_start(start):
     global log_timestamp_start
@@ -145,6 +147,7 @@ def log(*args, **kwargs):
 def _log_error(severity, *args, **kwargs):
     from .mesonlib import get_error_location_string
     from .environment import build_filename
+    from .mesonlib import MesonException
     if severity == 'warning':
         args = (yellow('WARNING:'),) + args
     elif severity == 'error':
@@ -161,6 +164,10 @@ def _log_error(severity, *args, **kwargs):
         args = (location_str,) + args
 
     log(*args, **kwargs)
+
+    global log_fatal_warnings
+    if log_fatal_warnings:
+        raise MesonException("Fatal warnings enabled, aborting")
 
 def error(*args, **kwargs):
     return _log_error('error', *args, **kwargs)


### PR DESCRIPTION
This makes any warning message printed by meson raise an exception,
intended to be used by CI and developpers to easily catch deprecation
warnings and other potential issues.