### PR TITLE
Nirbheek/fix misc issues

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3098,7 +3098,7 @@ root and issuing %s.
              regex_selector] + vcs_cmd
         kwargs.setdefault('build_by_default', True)
         kwargs.setdefault('build_always_stale', True)
-        return self.func_custom_target(node, [kwargs['output']], kwargs)
+        return self._func_custom_target_impl(node, [kwargs['output']], kwargs)
 
     @FeatureNew('subdir_done', '0.46.0')
     @stringArgs
@@ -3119,6 +3119,10 @@ root and issuing %s.
             raise InterpreterException('custom_target: Only one positional argument is allowed, and it must be a string name')
         if 'depfile' in kwargs and ('@BASENAME@' in kwargs['depfile'] or '@PLAINNAME@' in kwargs['depfile']):
             FeatureNew('substitutions in custom_target depfile', '0.47.0').use(self.subproject)
+        return self._func_custom_target_impl(node, args, kwargs)
+
+    def _func_custom_target_impl(self, node, args, kwargs):
+        'Implementation-only, without FeatureNew checks, for internal use'
         name = args[0]
         kwargs['install_mode'] = self._get_kwarg_install_mode(kwargs)
         tg = CustomTargetHolder(build.CustomTarget(name, self.subdir, self.subproject, kwargs), self)

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -228,7 +228,7 @@ class FeatureNew(FeatureCheckBase):
 
     @staticmethod
     def get_warning_str_prefix(tv):
-        return 'Project specifies a minimum meson_version \'{}\' which conflicts with:'.format(tv)
+        return 'Project specifies a minimum meson_version \'{}\' but uses features which were added in newer versions:'.format(tv)
 
     def log_usage_warning(self, tv):
         mlog.warning('Project targetting \'{}\' but tried to use feature introduced '

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -172,6 +172,9 @@ class FeatureCheckBase:
 
     @staticmethod
     def get_target_version(subproject):
+        # Don't do any checks if project() has not been parsed yet
+        if subproject not in mesonlib.project_meson_versions:
+            return ''
         return mesonlib.project_meson_versions[subproject]
 
     def use(self, subproject):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2740,6 +2740,16 @@ class FailureTests(BasePlatformTests):
                                 ".*WARNING.*Project targetting.*but.*",
                                 meson_version='>= 0.41.0')
 
+    def test_vcs_tag_featurenew_build_always_stale(self):
+        'https://github.com/mesonbuild/meson/issues/3904'
+        vcs_tag = '''version_data = configuration_data()
+        version_data.set('PROJVER', '@VCS_TAG@')
+        vf = configure_file(output : 'version.h.in', configuration: version_data)
+        f = vcs_tag(input : vf, output : 'version.h')
+        '''
+        msg = '.*WARNING:.*feature.*build_always_stale.*custom_target.*'
+        self.assertMesonDoesNotOutput(vcs_tag, msg, meson_version='>=0.43')
+
 
 class WindowsTests(BasePlatformTests):
     '''

--- a/test cases/common/38 run program/get-version.py
+++ b/test cases/common/38 run program/get-version.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print('1.2')

--- a/test cases/common/38 run program/meson.build
+++ b/test cases/common/38 run program/meson.build
@@ -1,4 +1,4 @@
-project('run command', 'c')
+project('run command', version : run_command('get-version.py', check : true).stdout().strip())
 
 if build_machine.system() == 'windows'
   c = run_command('cmd', '/c', 'echo', 'hello')


### PR DESCRIPTION
commit 9d9ac033d931824b3aaf88da3db59fb6604d220f

> Clarify the FeatureNew summary message. Fixes https://github.com/mesonbuild/meson/issues/3858.

commit ebaea7d6a2457c1d1c901d560f99be952b8112c3

> Print only custom env vars in the test log for each test
> 
> We still print the inherited env at the top of the test log because it is useful when inspecting test results from a CI. Fixes https://github.com/mesonbuild/meson/issues/3924.

commit 138d7d6a72931c2fce1259186dbec14808da7bc3

> Skip FeatureNew checks when project() has not been parsed. Fixes https://github.com/mesonbuild/meson/issues/3944.

commit 5d8931a847a8a62cccd27501106655fc421eb902

> Fix FeatureNew false positive in vcs_tag. Fixes https://github.com/mesonbuild/meson/issues/3904.
