### PR TITLE
Fix building a Windows console executable when main() comes from a library

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2234,9 +2234,9 @@ rule FORTRAN_DEP_HACK%s
         if isinstance(target, build.Executable):
             # Currently only used with the Swift compiler to add '-emit-executable'
             commands += linker.get_std_exe_link_args()
-            # If gui_app, and that's significant on this platform
-            if target.gui_app and hasattr(linker, 'get_gui_app_args'):
-                commands += linker.get_gui_app_args()
+            # If gui_app is significant on this platform
+            if hasattr(linker, 'get_gui_app_args'):
+                commands += linker.get_gui_app_args(target.gui_app)
             # If export_dynamic, add the appropriate linker arguments
             if target.export_dynamic:
                 commands += linker.gen_export_dynamic_link_args(self.environment)

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1276,8 +1276,13 @@ class VisualStudioCCompiler(CCompiler):
     def linker_to_compiler_args(self, args):
         return ['/link'] + args
 
-    def get_gui_app_args(self):
-        return ['/SUBSYSTEM:WINDOWS']
+    def get_gui_app_args(self, value):
+        # the default is for the linker to guess the subsystem based on presence
+        # of main or WinMain symbols, so always be explicit
+        if value:
+            return ['/SUBSYSTEM:WINDOWS']
+        else:
+            return ['/SUBSYSTEM:CONSOLE']
 
     def get_pic_args(self):
         return [] # PIC is handled by the loader on Windows

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1277,8 +1277,8 @@ class GnuCompiler:
         # For other targets, discard the .def file.
         return []
 
-    def get_gui_app_args(self):
-        if self.gcc_type in (GCC_CYGWIN, GCC_MINGW):
+    def get_gui_app_args(self, value):
+        if self.gcc_type in (GCC_CYGWIN, GCC_MINGW) and value:
             return ['-mwindows']
         return []
 

--- a/test cases/windows/17 gui app/console_prog.c
+++ b/test cases/windows/17 gui app/console_prog.c
@@ -1,0 +1,3 @@
+int main(int argc, char **argv) {
+    return 0;
+}

--- a/test cases/windows/17 gui app/gui_app_tester.py
+++ b/test cases/windows/17 gui app/gui_app_tester.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import re
+import subprocess
+import sys
+
+tool = sys.argv[1]
+executable = sys.argv[2]
+expected = int(sys.argv[3])
+actual = -1
+
+if 'objdump' in tool:
+    result = subprocess.check_output([tool, '-p', executable]).decode()
+    match = re.search(r'^Subsystem\s+(\d+)', result, re.MULTILINE)
+elif 'dumpbin' in tool:
+    result = subprocess.check_output([tool, '/headers', executable]).decode()
+    match = re.search(r'^\s*(\d+) subsystem(?! version)', result, re.MULTILINE)
+else:
+    print('unknown tool')
+    sys.exit(1)
+
+if match:
+    actual = int(match.group(1))
+
+print('subsystem expected: %d, actual: %d' % (expected, actual))
+sys.exit(0 if (expected == actual) else 1)

--- a/test cases/windows/17 gui app/gui_prog.c
+++ b/test cases/windows/17 gui app/gui_prog.c
@@ -1,0 +1,6 @@
+#include <windows.h>
+
+int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
+                   LPSTR lpCmdLine, int nCmdShow) {
+    return 0;
+}

--- a/test cases/windows/17 gui app/meson.build
+++ b/test cases/windows/17 gui app/meson.build
@@ -7,3 +7,16 @@ project('gui_app_test', 'c')
 
 console_lib = static_library('main', 'console_prog.c')
 executable('console', 'dummy.c', link_with: console_lib, gui_app: false)
+
+#
+# also verify that the correct subsystem is set by executable(gui_app:)
+#
+
+gui_prog = executable('gui_prog', 'gui_prog.c', gui_app: true)
+console_prog = executable('console_prog', 'console_prog.c', gui_app: false)
+
+tester = find_program('gui_app_tester.py')
+
+tool = find_program('objdump', 'dumpbin')
+test('is_gui', tester, args: [tool.path(), gui_prog, '2'])
+test('not_gui', tester, args: [tool.path(), console_prog, '3'])

--- a/test cases/windows/17 gui app/meson.build
+++ b/test cases/windows/17 gui app/meson.build
@@ -1,0 +1,9 @@
+project('gui_app_test', 'c')
+
+#
+# test that linking a Windows console applications with the main function in a
+# library is correctly instructed which entrypoint function to look for
+#
+
+console_lib = static_library('main', 'console_prog.c')
+executable('console', 'dummy.c', link_with: console_lib, gui_app: false)


### PR DESCRIPTION
Explicitly set the Windows subsystem when building with Visual C and the ninja backend.
Also add a test which dumps executable to verify gui_app: sets correct subsystem.
