### PR TITLE
Remap -std=c++14 dialect names for older compilers

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -89,7 +89,11 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
         args = []
         std = options['cpp_std']
         if std.value != 'none':
-            args.append('-std=' + std.value)
+            cpp_std_value = std.value
+            # Clang 3.2, 3.3, 3.4 only understand -std={c,gnu}++1y and not -std={c,gnu}++14
+            if version_compare(self.version, '>=3.2') and version_compare(self.version, '<3.5'):
+                cpp_std_value = cpp_std_value.replace('++14', '++1y')
+            args.append('-std=' + cpp_std_value)
         return args
 
     def get_option_link_args(self, options):
@@ -155,7 +159,11 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
         args = []
         std = options['cpp_std']
         if std.value != 'none':
-            args.append('-std=' + std.value)
+            cpp_std_value = std.value
+            # GCC 4.8 only understands -std={c,gnu}++1y and not -std={c,gnu}++14
+            if version_compare(self.version, '>=4.8') and version_compare(self.version, '<4.9'):
+                cpp_std_value = cpp_std_value.replace('++14', '++1y')
+            args.append('-std=' + cpp_std_value)
         if options['cpp_debugstl'].value:
             args.append('-D_GLIBCXX_DEBUG=1')
         return args


### PR DESCRIPTION
* GCC 4.8 and Clang 3.2, 3.3, 3.4 only understand
  `-std={c,gnu}++1y` for enabling C++14 dialects.
  GCC 4.8 is especially important as it is the basis
  of RHEL/CentOS 7.

@nirbheek as discussed