### PR TITLE
Fix broken symlinks install when using install_umask or install_mode

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -69,9 +69,9 @@ class DirMaker:
         for d in self.dirs:
             append_to_log(self.lf, d)
 
-def is_executable(path):
+def is_executable(path, follow_symlinks=False):
     '''Checks whether any of the "x" bits are set in the source file mode.'''
-    return bool(os.stat(path).st_mode & 0o111)
+    return bool(os.stat(path, follow_symlinks=follow_symlinks).st_mode & 0o111)
 
 def append_to_log(lf, line):
     lf.write(line)
@@ -107,7 +107,7 @@ def set_chmod(path, mode, dir_fd=None, follow_symlinks=True):
 def sanitize_permissions(path, umask):
     if umask is None:
         return
-    new_perms = 0o777 if is_executable(path) else 0o666
+    new_perms = 0o777 if is_executable(path, follow_symlinks=False) else 0o666
     new_perms &= ~umask
     try:
         set_chmod(path, new_perms, follow_symlinks=False)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3779,31 +3779,41 @@ endian = 'little'
             # Ensure that the otool output does not contain self.installdir
             self.assertNotRegex(out, self.installdir + '.*dylib ')
 
-    def test_install_subdir_symlinks(self):
+    def install_subdir_invalid_symlinks(self, testdir, subdir_path):
         '''
         Test that installation of broken symlinks works fine.
         https://github.com/mesonbuild/meson/issues/3914
         '''
-        testdir = os.path.join(self.common_test_dir, '66 install subdir')
-        subdir = os.path.join(testdir, 'sub/sub1')
+        testdir = os.path.join(self.common_test_dir, testdir)
+        subdir = os.path.join(testdir, subdir_path)
         curdir = os.getcwd()
         os.chdir(subdir)
         # Can't distribute broken symlinks in the source tree because it breaks
         # the creation of zipapps. Create it dynamically and run the test by
         # hand.
         src = '../../nonexistent.txt'
-        os.symlink(src, 'test.txt')
+        os.symlink(src, 'invalid-symlink.txt')
         try:
             self.init(testdir)
             self.build()
             self.install()
-            link = os.path.join(self.installdir, 'usr', 'share', 'sub1', 'test.txt')
+            install_path = subdir_path.split(os.path.sep)[-1]
+            link = os.path.join(self.installdir, 'usr', 'share', install_path, 'invalid-symlink.txt')
             self.assertTrue(os.path.islink(link), msg=link)
             self.assertEqual(src, os.readlink(link))
             self.assertFalse(os.path.isfile(link), msg=link)
         finally:
-            os.remove(os.path.join(subdir, 'test.txt'))
+            os.remove(os.path.join(subdir, 'invalid-symlink.txt'))
             os.chdir(curdir)
+
+    def test_install_subdir_symlinks(self):
+        self.install_subdir_invalid_symlinks('66 install subdir', os.path.join('sub', 'sub1'))
+
+    def test_install_subdir_symlinks_with_default_umask(self):
+        self.install_subdir_invalid_symlinks('199 install_mode', 'sub2')
+
+    def test_install_subdir_symlinks_with_default_umask_and_mode(self):
+        self.install_subdir_invalid_symlinks('199 install_mode', 'sub1')
 
 
 class LinuxCrossArmTests(BasePlatformTests):

--- a/test cases/common/199 install_mode/installed_files.txt
+++ b/test cases/common/199 install_mode/installed_files.txt
@@ -5,4 +5,5 @@ usr/include/rootdir.h
 usr/libtest/libstat.a
 usr/share/man/man1/foo.1.gz
 usr/share/sub1/second.dat
+usr/share/sub2/stub
 usr/subdir/data.dat

--- a/test cases/common/199 install_mode/meson.build
+++ b/test cases/common/199 install_mode/meson.build
@@ -11,6 +11,9 @@ install_subdir('sub1',
   install_dir : 'share',
   install_mode : ['rwxr-x--t', 'root'])
 
+install_subdir('sub2',
+  install_dir : 'share')
+
 # test install_mode in configure_file
 conf = configuration_data()
 conf.set('var', 'mystring')


### PR DESCRIPTION
Other fixes for #3914 to ignore setting the ownership and mode for broken symlinks after install.

Unfortunately the best way to do this was to cause some stdlib code duplication, because we need to be able to use `os.chown` with `follow_symlinks` set to `False`, but `shutil.chown` does not support this.

In fact, in general I think we should just never to try to set the ownership of a linked file, as this might be pointing outside the install path (while it's correct to set it only to the link itself), and probably at the same time the same should be for the file-mode of linked files.

