### PR TITLE
Add build target keyword parameter 'build_dir'

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -522,6 +522,8 @@ be passed to [shared and static libraries](#library).
   in the D programming language
 - `d_unittest`, when set to true, the D modules are compiled in debug mode
 - `d_module_versions` list of module versions set when compiling D sources
+- `build_dir` provides a subdirectory to place the built
+  target. Useful when building multiple targets with the same base filename.
 
 The list of `sources`, `objects`, and `dependencies` is always
 flattened, which means you can freely nest and add lists while

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -188,7 +188,9 @@ class Backend:
             dirname = target.get_subdir()
         else:
             dirname = 'meson-out'
-        return dirname
+        if target.build_dir == '':
+            return dirname
+        return os.path.join(dirname, target.build_dir)
 
     def get_target_dir_relative_to(self, t, o):
         '''Get a target dir relative to another target's directory'''

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -52,6 +52,7 @@ cs_kwargs = set(['resources', 'cs_args'])
 buildtarget_kwargs = set([
     'build_by_default',
     'build_rpath',
+    'build_dir',
     'dependencies',
     'extra_files',
     'gui_app',
@@ -306,6 +307,7 @@ class Target:
 This is not supported, it can cause unexpected failures and will become
 a hard error in the future.''' % name)
         self.name = name
+        self.build_dir = ''
         self.subdir = subdir
         self.subproject = subproject
         self.build_by_default = build_by_default
@@ -328,6 +330,8 @@ a hard error in the future.''' % name)
         name_part = self.name.replace('/', '@').replace('\\', '@')
         assert not has_path_sep(self.type_suffix())
         myid = name_part + self.type_suffix()
+        if self.build_dir:
+            myid = self.build_dir + '@@' + myid
         if self.subdir:
             subdir_part = self.subdir.replace('/', '@').replace('\\', '@')
             myid = subdir_part + '@@' + myid
@@ -339,6 +343,11 @@ a hard error in the future.''' % name)
             if not isinstance(self.build_by_default, bool):
                 raise InvalidArguments('build_by_default must be a boolean value.')
         self.option_overrides = self.parse_overrides(kwargs)
+        self.build_dir = kwargs.get('build_dir', '')
+        if not isinstance(self.build_dir, str):
+            raise InvalidArguments('Build_dir must be a string.')
+        if has_path_sep(self.build_dir):
+            raise InvalidArguments('Build_dir "%s" has a path separator in its name.' % self.build_dir)
 
     def parse_overrides(self, kwargs):
         result = {}


### PR DESCRIPTION
This allows the user to place the build products in a subdirectory of
the build directory, which is useful when multiple build products have
the same base filename.

Signed-off-by: Keith Packard <keithp@keithp.com>

Here's a possible solution to issue #4019 -- instead of a different base filename, this places the target in a subdirectory so that the basename remains the same in case that is required for the target to be generated correctly.