### PR TITLE
linkers: Pass /MACHINE to VS linker

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1202,7 +1202,7 @@ class VisualStudioCCompiler(CCompiler):
                 'mtd': ['/MTd'],
                 }
 
-    def __init__(self, exelist, version, is_cross, exe_wrap, is_64):
+    def __init__(self, exelist, version, is_cross, exe_wrap, machine):
         CCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
         self.id = 'msvc'
         # /showIncludes is needed for build dependency tracking in Ninja
@@ -1212,7 +1212,8 @@ class VisualStudioCCompiler(CCompiler):
                           '2': ['/W3'],
                           '3': ['/W4']}
         self.base_options = ['b_pch', 'b_ndebug', 'b_vscrt'] # FIXME add lto, pgo and the like
-        self.is_64 = is_64
+        self.is_64 = machine.endswith('64')
+        self.machine = machine
 
     # Override CCompiler.get_always_args
     def get_always_args(self):
@@ -1279,7 +1280,7 @@ class VisualStudioCCompiler(CCompiler):
         return ['/nologo']
 
     def get_linker_output_args(self, outputname):
-        return ['/OUT:' + outputname]
+        return ['/MACHINE:' + self.machine, '/OUT:' + outputname]
 
     def get_linker_search_args(self, dirname):
         return ['/LIBPATH:' + dirname]

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -247,9 +247,9 @@ class IntelCPPCompiler(IntelCompiler, CPPCompiler):
 
 
 class VisualStudioCPPCompiler(VisualStudioCCompiler, CPPCompiler):
-    def __init__(self, exelist, version, is_cross, exe_wrap, is_64):
+    def __init__(self, exelist, version, is_cross, exe_wrap, machine):
         CPPCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
-        VisualStudioCCompiler.__init__(self, exelist, version, is_cross, exe_wrap, is_64)
+        VisualStudioCCompiler.__init__(self, exelist, version, is_cross, exe_wrap, machine)
         self.base_options = ['b_pch', 'b_vscrt'] # FIXME add lto, pgo and the like
 
     def get_options(self):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -605,9 +605,9 @@ This is probably wrong, it should always point to the native compiler.''' % evar
                 if version == 'unknown version':
                     m = 'Failed to detect MSVC compiler arch: stderr was\n{!r}'
                     raise EnvironmentException(m.format(err))
-                is_64 = err.split('\n')[0].endswith(' x64')
+                machine = err.split('\n')[0].split(' ')[-1]
                 cls = VisualStudioCCompiler if lang == 'c' else VisualStudioCPPCompiler
-                return cls(compiler, version, is_cross, exe_wrap, is_64)
+                return cls(compiler, version, is_cross, exe_wrap, machine)
             if '(ICC)' in out:
                 # TODO: add microsoft add check OSX
                 inteltype = ICC_STANDARD
@@ -884,7 +884,7 @@ This is probably wrong, it should always point to the native compiler.''' % evar
                 popen_exceptions[' '.join(linker + [arg])] = e
                 continue
             if '/OUT:' in out or '/OUT:' in err:
-                return VisualStudioLinker(linker)
+                return VisualStudioLinker(linker, compiler.machine)
             if p.returncode == 0 and ('armar' in linker or 'armar.exe' in linker):
                 return ArmarLinker(linker)
             if p.returncode == 0:

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -26,8 +26,9 @@ class StaticLinker:
 class VisualStudioLinker(StaticLinker):
     always_args = ['/NOLOGO']
 
-    def __init__(self, exelist):
+    def __init__(self, exelist, machine):
         self.exelist = exelist
+        self.machine = machine
 
     def get_exelist(self):
         return self.exelist[:]
@@ -39,7 +40,7 @@ class VisualStudioLinker(StaticLinker):
         return []
 
     def get_output_args(self, target):
-        return ['/OUT:' + target]
+        return ['/MACHINE:' + self.machine, '/OUT:' + target]
 
     def get_coverage_link_args(self):
         return []


### PR DESCRIPTION
To fix warnings like this:

    LINK : warning LNK4068: /MACHINE not specified; defaulting to X64

Which actually become problematic when e.g. building 32-bit code on a
64-bit build machine:

    z@sta/adler32.c.obj : fatal error LNK1112: module machine type 'x86'
                          conflicts with target machine type 'x64'