### PR TITLE
compilers: Add option for selecting MSVC C-runtime

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1197,7 +1197,7 @@ class VisualStudioCCompiler(CCompiler):
     ignore_libs = gnu_compiler_internal_libs
     internal_libs = ()
 
-    def __init__(self, exelist, version, is_cross, exe_wrap, is_64):
+    def __init__(self, exelist, version, is_cross, exe_wrap, is_64, runtime):
         CCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
         self.id = 'msvc'
         # /showIncludes is needed for build dependency tracking in Ninja
@@ -1208,6 +1208,7 @@ class VisualStudioCCompiler(CCompiler):
                           '3': ['/W4']}
         self.base_options = ['b_pch', 'b_ndebug'] # FIXME add lto, pgo and the like
         self.is_64 = is_64
+        self.runtime = runtime
 
     # Override CCompiler.get_always_args
     def get_always_args(self):
@@ -1225,7 +1226,10 @@ class VisualStudioCCompiler(CCompiler):
         return ['/MDd']
 
     def get_buildtype_args(self, buildtype):
-        return msvc_buildtype_args[buildtype]
+        args = msvc_buildtype_args[buildtype]
+        if self.runtime == 'static':
+            args = [arg.replace("/MD", "/MT") for arg in args]
+        return args
 
     def get_buildtype_linker_args(self, buildtype):
         return msvc_buildtype_linker_args[buildtype]

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -239,9 +239,9 @@ class IntelCPPCompiler(IntelCompiler, CPPCompiler):
 
 
 class VisualStudioCPPCompiler(VisualStudioCCompiler, CPPCompiler):
-    def __init__(self, exelist, version, is_cross, exe_wrap, is_64):
+    def __init__(self, exelist, version, is_cross, exe_wrap, is_64, runtime):
         CPPCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
-        VisualStudioCCompiler.__init__(self, exelist, version, is_cross, exe_wrap, is_64)
+        VisualStudioCCompiler.__init__(self, exelist, version, is_cross, exe_wrap, is_64, runtime)
         self.base_options = ['b_pch'] # FIXME add lto, pgo and the like
 
     def get_options(self):

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -545,6 +545,7 @@ def parse_cmd_line_options(args):
 
 builtin_options = {
     'buildtype':  [UserComboOption, 'Build type to use.', ['plain', 'debug', 'debugoptimized', 'release', 'minsize'], 'debug'],
+    'msvcrt':     [UserComboOption, 'MSVC C-runtime to target.', ['dynamic', 'static'], 'dynamic'],
     'strip':      [UserBooleanOption, 'Strip targets on install.', False],
     'unity':      [UserComboOption, 'Unity build.', ['on', 'off', 'subprojects'], 'off'],
     'prefix':     [UserStringOption, 'Installation prefix.', default_prefix()],

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -606,8 +606,9 @@ This is probably wrong, it should always point to the native compiler.''' % evar
                     m = 'Failed to detect MSVC compiler arch: stderr was\n{!r}'
                     raise EnvironmentException(m.format(err))
                 is_64 = err.split('\n')[0].endswith(' x64')
+                runtime = self.coredata.get_builtin_option('msvcrt')
                 cls = VisualStudioCCompiler if lang == 'c' else VisualStudioCPPCompiler
-                return cls(compiler, version, is_cross, exe_wrap, is_64)
+                return cls(compiler, version, is_cross, exe_wrap, is_64, runtime)
             if '(ICC)' in out:
                 # TODO: add microsoft add check OSX
                 inteltype = ICC_STANDARD


### PR DESCRIPTION
Some applications will want to target the static runtime.