### PR TITLE
compilers: Embed symbols in object files when using MSVC

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1387,18 +1387,7 @@ class VisualStudioCCompiler(CCompiler):
             return not(warning_text in p.stde or warning_text in p.stdo)
 
     def get_compile_debugfile_args(self, rel_obj, pch=False):
-        pdbarr = rel_obj.split('.')[:-1]
-        pdbarr += ['pdb']
-        args = ['/Fd' + '.'.join(pdbarr)]
-        # When generating a PDB file with PCH, all compile commands write
-        # to the same PDB file. Hence, we need to serialize the PDB
-        # writes using /FS since we do parallel builds. This slows down the
-        # build obviously, which is why we only do this when PCH is on.
-        # This was added in Visual Studio 2013 (MSVC 18.0). Before that it was
-        # always on: https://msdn.microsoft.com/en-us/library/dn502518.aspx
-        if pch and version_compare(self.version, '>=18.0'):
-            args = ['/FS'] + args
-        return args
+        return []
 
     def get_link_debugfile_args(self, targetfile):
         pdbarr = targetfile.split('.')[:-1]

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -143,10 +143,10 @@ arm_buildtype_args = {'plain': [],
                       }
 
 msvc_buildtype_args = {'plain': [],
-                       'debug': ["/ZI", "/Ob0", "/Od", "/RTC1"],
-                       'debugoptimized': ["/Zi", "/Ob1"],
+                       'debug': ["/Z7", "/Ob0", "/Od", "/RTC1"],
+                       'debugoptimized': ["/Z7", "/Ob1"],
                        'release': ["/Ob2"],
-                       'minsize': ["/Zi", "/Ob1"],
+                       'minsize': ["/Z7", "/Ob1"],
                        }
 
 apple_buildtype_linker_args = {'plain': [],


### PR DESCRIPTION
Otherwise each of any static library's object files will be referring to
its .pdb, making redistribution very impractical.

Executables and DLLs still get a .pdb each, though.

Other possible solutions:

- Merge each object-file's `.pdb` into one big one next to the `.a`.
  I'm not aware of any tool able to do this, so this might be a lot of
  work to implement.
- Feed the compiler with all of the C-files for the target being built,
  so it can output one `.pdb` for all of them. This breaks down when
  using `.extract_objects()`.

So bottom line is that I'm not happy with this solution, but I'm opening
this PR to start the brainstorming. Hopefully there's a better option I
haven't thought of.