### PR TITLE
compilers: Reduce sizes of MSVC linked binaries

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1230,7 +1230,10 @@ class VisualStudioCCompiler(CCompiler):
         return ['/MDd']
 
     def get_buildtype_args(self, buildtype):
-        return compilers.msvc_buildtype_args[buildtype]
+        args = compilers.msvc_buildtype_args[buildtype]
+        if version_compare(self.version, '<18.0'):
+            args = [arg for arg in args if arg != '/Gw']
+        return args
 
     def get_buildtype_linker_args(self, buildtype):
         return compilers.msvc_buildtype_linker_args[buildtype]

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -145,8 +145,8 @@ arm_buildtype_args = {'plain': [],
 msvc_buildtype_args = {'plain': [],
                        'debug': ["/ZI", "/Ob0", "/Od", "/RTC1"],
                        'debugoptimized': ["/Zi", "/Ob1"],
-                       'release': ["/Ob2"],
-                       'minsize': ["/Zi", "/Ob1"],
+                       'release': ["/Ob2", "/Gw"],
+                       'minsize': ["/Zi", "/Gw"],
                        }
 
 apple_buildtype_linker_args = {'plain': [],
@@ -267,7 +267,7 @@ msvc_optimization_args = {'0': [],
                           '1': ['/O1'],
                           '2': ['/O2'],
                           '3': ['/O3'],
-                          's': ['/Os'],
+                          's': ['/O1'], # Implies /Os.
                           }
 
 clike_debug_args = {False: [],


### PR DESCRIPTION
- Use Maximum Optimization (Favor Size) for `minsize`.
- Enable Function-Level Linking so unused code can be omitted.

With `minsize` on x86 this reduces the size of a statically linked Vala
compiler binary from 5 MB down to just 2.3 MB.

The addition of `/O1` next to `/Os` is because these two options are
distinct in Visual Studio's GUI:

![msvs-options](https://user-images.githubusercontent.com/735197/44266779-20f52e80-a22c-11e8-85ab-834b8428fbbe.jpg)

I also verified the impact of different switches for `minsize`:

![switches](https://user-images.githubusercontent.com/735197/44266815-4124ed80-a22c-11e8-85fc-66142406b638.jpg)