### PR TITLE
Allow override_find_program to use an executable.

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1502,7 +1502,9 @@ the following methods.
   specifies that whenever `find_program` is used to find a program
   named `progname`, Meson should not not look it up on the system but
   instead return `program`, which may either be the result of
-  `find_program` or `configure_file`.
+  `find_program`, `configure_file` or `executable`.
+
+  If `program` is an `executable`, it cannot be used during configure.
 
 - `project_version()` returns the version string specified in
   `project` function call.

--- a/docs/markdown/Release-notes-for-0.48.0.md
+++ b/docs/markdown/Release-notes-for-0.48.0.md
@@ -11,6 +11,15 @@ Notable new features should come with release note updates. This is
 done by creating a file snippet called `snippets/featurename.md` and
 whose contents should look like this:
 
+## More flexible `override_find_program()`.
+
+It is now possible to pass an `executable` to
+`override_find_program()` if the overridden program is not used during
+configure.
+
+This is particularly useful for fallback dependencies like protobuf
+that also provide a tool like protoc.
+
     ## Feature name
 
     A short description explaining the new feature and how it should be used.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1304,6 +1304,9 @@ class Executable(BuildTarget):
         # Only linkwithable if using export_dynamic
         self.is_linkwithable = self.export_dynamic
 
+    def __str__(self):
+        return self.name
+
     def type_suffix(self):
         return "@exe"
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1304,7 +1304,8 @@ class Executable(BuildTarget):
         # Only linkwithable if using export_dynamic
         self.is_linkwithable = self.export_dynamic
 
-    def desc(self):
+    def description(self):
+        '''Human friendly description of the executable'''
         return self.name
 
     def type_suffix(self):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1304,7 +1304,7 @@ class Executable(BuildTarget):
         # Only linkwithable if using export_dynamic
         self.is_linkwithable = self.export_dynamic
 
-    def __str__(self):
+    def desc(self):
         return self.name
 
     def type_suffix(self):

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -953,7 +953,7 @@ class ExternalProgram:
         r = '<{} {!r} -> {!r}>'
         return r.format(self.__class__.__name__, self.name, self.command)
 
-    def __str__(self):
+    def desc(self):
         return ' '.join(self.command)
 
     @staticmethod

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -953,6 +953,9 @@ class ExternalProgram:
         r = '<{} {!r} -> {!r}>'
         return r.format(self.__class__.__name__, self.name, self.command)
 
+    def __str__(self):
+        return ' '.join(self.command)
+
     @staticmethod
     def from_cross_info(cross_info, name):
         if name not in cross_info.config['binaries']:

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -953,7 +953,8 @@ class ExternalProgram:
         r = '<{} {!r} -> {!r}>'
         return r.format(self.__class__.__name__, self.name, self.command)
 
-    def desc(self):
+    def description(self):
+        '''Human friendly description of the command'''
         return ' '.join(self.command)
 
     @staticmethod

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -803,6 +803,9 @@ class ExecutableHolder(BuildTargetHolder):
     def __init__(self, target, interp):
         super().__init__(target, interp)
 
+    def found(self):
+        return True
+
 class StaticLibraryHolder(BuildTargetHolder):
     def __init__(self, target, interp):
         super().__init__(target, interp)
@@ -1753,7 +1756,7 @@ class MesonMain(InterpreterObject):
             if not os.path.exists(abspath):
                 raise InterpreterException('Tried to override %s with a file that does not exist.' % name)
             exe = dependencies.ExternalProgram(abspath)
-        if not isinstance(exe, dependencies.ExternalProgram):
+        if not isinstance(exe, (dependencies.ExternalProgram, build.Executable)):
             # FIXME, make this work if the exe is an Executable target.
             raise InterpreterException('Second argument must be an external program.')
         self.interpreter.add_find_program_override(name, exe)
@@ -2704,8 +2707,8 @@ external dependencies (including libraries) must go to "dependencies".''')
                 exe = self.build.find_overrides[name]
                 if not silent:
                     mlog.log('Program', mlog.bold(name), 'found:', mlog.green('YES'),
-                             '(overridden: %s)' % ' '.join(exe.command))
-                return ExternalProgramHolder(exe)
+                             '(overridden: %s)' % exe)
+                return self.holderify(exe)
         return None
 
     def store_name_lookups(self, command_names):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2152,7 +2152,10 @@ external dependencies (including libraries) must go to "dependencies".''')
         if isinstance(cmd, ExternalProgramHolder):
             cmd = cmd.held_object
             if isinstance(cmd, build.Executable):
-                raise InterpreterException('Cannot use an executable during configuration')
+                progname = node.args.arguments[0].value
+                msg = 'Program {!r} was overridden with the compiled executable {!r}'\
+                      ' and therefore cannot be used during configuration'
+                raise InterpreterException(msg.format(progname, cmd.description()))
         elif isinstance(cmd, CompilerHolder):
             cmd = cmd.compiler.get_exelist()[0]
             prog = ExternalProgram(cmd, silent=True)
@@ -2705,7 +2708,7 @@ external dependencies (including libraries) must go to "dependencies".''')
                 exe = self.build.find_overrides[name]
                 if not silent:
                     mlog.log('Program', mlog.bold(name), 'found:', mlog.green('YES'),
-                             '(overridden: %s)' % exe.desc())
+                             '(overridden: %s)' % exe.description())
                 return ExternalProgramHolder(exe)
         return None
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3777,6 +3777,17 @@ endian = 'little'
                     return
         raise RuntimeError('Could not find the rpath')
 
+    def test_override_with_exe_dep(self):
+        '''
+        Test that we produce the correct dependencies when a program is overridden with an executable.
+        '''
+        testdir = os.path.join(self.common_test_dir, '206 override with exe')
+        self.init(testdir)
+        with open(os.path.join(self.builddir, 'build.ninja')) as bfile:
+            for line in bfile:
+                if 'main1.c:' in line or 'main2.c:' in line:
+                    self.assertIn('| subprojects/sub/foobar', line)
+
     @skipIfNoPkgconfig
     def test_usage_external_library(self):
         '''

--- a/test cases/common/206 override with exe/meson.build
+++ b/test cases/common/206 override with exe/meson.build
@@ -1,8 +1,15 @@
 project('myexe', 'c')
 sub = subproject('sub')
 prog = find_program('foobar')
-custom_target('custom',
-              build_by_default : true,
-              input : [],
-              output : 'custom',
-              command : [prog, '@OUTPUT@'])
+custom1 = custom_target('custom1',
+                        build_by_default : true,
+                        input : [],
+                        output : 'main1.c',
+                        command : [prog, '@OUTPUT@'])
+gen = generator(prog,
+                output : '@BASENAME@.c',
+                arguments : ['@OUTPUT@'])
+custom2 = gen.process('main2.input')
+
+executable('e1', custom1)
+executable('e2', custom2)

--- a/test cases/common/206 override with exe/meson.build
+++ b/test cases/common/206 override with exe/meson.build
@@ -1,0 +1,8 @@
+project('myexe', 'c')
+sub = subproject('sub')
+prog = find_program('foobar')
+custom_target('custom',
+              build_by_default : true,
+              input : [],
+              output : 'custom',
+              command : [prog, '@OUTPUT@'])

--- a/test cases/common/206 override with exe/subprojects/sub/foobar.c
+++ b/test cases/common/206 override with exe/subprojects/sub/foobar.c
@@ -1,0 +1,12 @@
+#include <assert.h>
+#include <stdio.h>
+
+int main(int argc, char* argv[]) {
+  FILE *f = fopen(argv[1], "w");
+  const char msg[] = "foobar\n";
+  size_t w = fwrite(msg, 1, sizeof(msg), f);
+  assert(w == sizeof(msg));
+  int r = fclose(f);
+  assert(r == 0);
+  return 0;
+}

--- a/test cases/common/206 override with exe/subprojects/sub/foobar.c
+++ b/test cases/common/206 override with exe/subprojects/sub/foobar.c
@@ -3,9 +3,9 @@
 
 int main(int argc, char* argv[]) {
   FILE *f = fopen(argv[1], "w");
-  const char msg[] = "foobar\n";
-  size_t w = fwrite(msg, 1, sizeof(msg), f);
-  assert(w == sizeof(msg));
+  const char msg[] = "int main(void) {return 0;}\n";
+  size_t w = fwrite(msg, 1, sizeof(msg) - 1, f);
+  assert(w == sizeof(msg) - 1);
   int r = fclose(f);
   assert(r == 0);
   return 0;

--- a/test cases/common/206 override with exe/subprojects/sub/meson.build
+++ b/test cases/common/206 override with exe/subprojects/sub/meson.build
@@ -1,3 +1,3 @@
 project('sub', 'c')
-foobar = executable('foobar', 'foobar.c')
+foobar = executable('foobar', 'foobar.c',  native : true)
 meson.override_find_program('foobar', foobar)

--- a/test cases/common/206 override with exe/subprojects/sub/meson.build
+++ b/test cases/common/206 override with exe/subprojects/sub/meson.build
@@ -1,0 +1,3 @@
+project('sub', 'c')
+foobar = executable('foobar', 'foobar.c')
+meson.override_find_program('foobar', foobar)

--- a/test cases/failing/81 override exe config/foo.c
+++ b/test cases/failing/81 override exe config/foo.c
@@ -1,0 +1,3 @@
+int main(void) {
+  return 0;
+}

--- a/test cases/failing/81 override exe config/meson.build
+++ b/test cases/failing/81 override exe config/meson.build
@@ -1,0 +1,6 @@
+project('myexe', 'c')
+
+foo = executable('foo', 'foo.c')
+meson.override_find_program('bar', foo)
+bar = find_program('bar')
+run_command(bar)


### PR DESCRIPTION
With this it is now possible to do

foobar = executable('foobar', ...)
meson.override_find_program('foobar', foobar)

Which is convenient for a project like protobuf which produces both a
dependency and a tool. If protobuf is updated to use
override_find_program, it can be used as

protobuf_dep = dependency('protobuf', version : '>=3.3.1',
                          fallback : ['protobuf', 'protobuf_dep'])
protoc_prog = find_program('protoc')