### PR TITLE
Fix various small test failures on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,9 @@ matrix:
 before_install:
   - python ./skip_ci.py --base-branch-env=TRAVIS_BRANCH --is-pull-env=TRAVIS_PULL_REQUEST
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt pkg-config; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt; fi
+    # # Run one macOS build without pkg-config available, and the other (unity=on) with pkg-config
+  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$MESON_ARGS" =~ .*unity=on.* ]]; then brew install pkg-config; fi
   # Use a Ninja with QuLogic's patch: https://github.com/ninja-build/ninja/issues/1219
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir -p $HOME/tools; curl -L http://nirbheek.in/files/binaries/ninja/macos/ninja -o $HOME/tools/ninja; chmod +x $HOME/tools/ninja; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker pull jpakkane/mesonci:bionic; fi

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1191,7 +1191,7 @@ class ExternalLibrary(ExternalDependency):
 class ExtraFrameworkDependency(ExternalDependency):
     def __init__(self, name, required, path, env, lang, kwargs):
         super().__init__('extraframeworks', env, lang, kwargs)
-        self.name = None
+        self.name = name
         self.required = required
         self.detect(name, path)
         if self.found():


### PR DESCRIPTION
These weren't caught by the CI because we have pkg-config on it, and these were testing non-pkg-config codepaths. The unity build on macOS now doesn't have pkg-config to ensure that the codepath is tested.