### PR TITLE
Remove dependency to D runtime in mixed language tests

### DIFF
--- a/test cases/d/10 d cpp/libfile.d
+++ b/test cases/d/10 d cpp/libfile.d
@@ -1,5 +1,5 @@
-import std.stdio;
+import core.stdc.stdio;
 
 extern (C++) void print_hello(int i) {
-    writefln("Hello. Here is a number printed with D: %d", i);
+    printf("Hello. Here is a number printed with D: %d\n", i);
 }


### PR DESCRIPTION
It is undefined behaviour to call D I/O functions without initializing D runtime first. Simplify the test so it will work in all platforms.

Fixes #4049, also required for #3981.