### PR TITLE
help: Fix printing list of wrap mode

### DIFF
--- a/mesonbuild/wrap/__init__.py
+++ b/mesonbuild/wrap/__init__.py
@@ -33,4 +33,11 @@ from enum import Enum
 # Note that these options do not affect subprojects that
 # are git submodules since those are only usable in git
 # repositories, and you almost always want to download them.
-WrapMode = Enum('WrapMode', 'default nofallback nodownload forcefallback')
+class WrapMode(Enum):
+    default = 1
+    nofallback = 2
+    nodownload = 3
+    forcefallback = 4
+
+    def __str__(self):
+        return self.name


### PR DESCRIPTION
We where currently printing the list as WrapMode.<name>, while what we
wanted is just the name. This made --help slightly confusing.

This changes --help command from printing:
  --wrap-mode {WrapMode.default,WrapMode.nofallback,WrapMode.nodownload,WrapMode.forcefallback}
to:
  --wrap-mode {default,nofallback,nodownload,forcefallback}

Fixes issue #4067