### PR TITLE
d: Allow static library to be passed with -L to dmd/ldc

### DIFF
--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -379,8 +379,12 @@ class DCompiler(Compiler):
 
                 dcargs.append('-L=' + arg)
                 continue
-
-            dcargs.append(arg)
+            elif not arg.startswith('-') and arg.endswith(('.a', '.lib')):
+                # ensure static libraries are passed through to the linker
+                dcargs.append('-L=' + arg)
+                continue
+            else:
+                dcargs.append(arg)
 
         return dcargs
 


### PR DESCRIPTION
As discussed on IRC.

Some people want to pass static libraries directly to the linker, which currently does not work for DMD and LDC due to the to-GNU flag translation.
This patch expands the translation list to accommodate for this scenario as well.