### PR TITLE
d: disallow dmd frontends (ldmd and gdc)

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -813,6 +813,12 @@ This is probably wrong, it should always point to the native compiler.''' % evar
         # up to date language version at time (2016).
         if 'DC' in os.environ:
             exelist = shlex.split(os.environ['DC'])
+            for dc in exelist[:]:
+                if os.path.basename(dc).startswith(('ldmd', 'gdmd')):
+                    mlog.log('Meson doesn\'t support', mlog.bold(dc), 'as it\'s only a DMD frontend for another compiler, skipping.')
+                    exelist.remove(dc)
+            if not exelist:
+                raise EnvironmentException('Couldn\'t find any compatible D compiler in the DC environment variable. Please provide a valid value for DC or unset it so that Meson resolve the compiler by itself.')
         elif self.is_cross_build() and want_cross:
             exelist = mesonlib.stringlistify(self.cross_info.config['binaries']['d'])
             is_cross = True


### PR DESCRIPTION
This will reject `ldmd` and `gdmd`. They are versions of `ldc` and `gdc`, respectively, that use `dmd`'s frontend. Right now they are being wrongly detected as `ldc`/`gdc`. Even if we fixed that, thay are not fully compatible with `DmdDCompiler` so that would need to be patched as well. As we discussed in the IRC, there's no point in adding support for them as they are simply frontends.