### PR TITLE
using urlopen() with explicit timeout

### DIFF
--- a/ghwt.py
+++ b/ghwt.py
@@ -22,10 +22,11 @@
 import urllib.request, json, sys, os, shutil, subprocess
 import configparser, hashlib
 
+req_timeout = 600.0
 private_repos = {'meson', 'wrapweb', 'meson-ci'}
 
 def gh_get(url):
-    r = urllib.request.urlopen(url)
+    r = urllib.request.urlopen(url, timeout=req_timeout)
     jd = json.loads(r.read().decode('utf-8'))
     return jd
 
@@ -45,7 +46,7 @@ def unpack(sproj, branch, outdir):
     config = configparser.ConfigParser()
     config.read(usfile)
     us_url = config['wrap-file']['source_url']
-    us = urllib.request.urlopen(us_url).read()
+    us = urllib.request.urlopen(us_url, timeout=req_timeout).read()
     h = hashlib.sha256()
     h.update(us)
     dig = h.hexdigest()

--- a/manual tests/4 standalone binaries/build_windows_package.py
+++ b/manual tests/4 standalone binaries/build_windows_package.py
@@ -11,7 +11,7 @@ shutil.rmtree('build', ignore_errors=True)
 os.mkdir('build')
 
 if not os.path.exists(sdl_filename):
-    response = urllib.request.urlopen(sdl_url)
+    response = urllib.request.urlopen(sdl_url, timeout=600.0)
     data = response.read()
     open(sdl_filename, 'wb').write(data)
 

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -29,6 +29,7 @@ except ImportError:
     has_ssl = False
     API_ROOT = 'http://wrapdb.mesonbuild.com/v1/'
 
+req_timeout = 600.0
 ssl_warning_printed = False
 
 def build_ssl_context():
@@ -51,7 +52,7 @@ def open_wrapdburl(urlstring):
     global ssl_warning_printed
     if has_ssl:
         try:
-            return urllib.request.urlopen(urlstring)# , context=build_ssl_context())
+            return urllib.request.urlopen(urlstring, timeout=req_timeout)# , context=build_ssl_context())
         except urllib.error.URLError:
             if not ssl_warning_printed:
                 print('SSL connection failed. Falling back to unencrypted connections.')
@@ -64,7 +65,7 @@ def open_wrapdburl(urlstring):
     # certificate is not known.
     if urlstring.startswith('https'):
         urlstring = 'http' + urlstring[5:]
-    return urllib.request.urlopen(urlstring)
+    return urllib.request.urlopen(urlstring, timeout=req_timeout)
 
 
 class PackageDefinition:
@@ -270,7 +271,7 @@ class Resolver:
         if url.startswith('https://wrapdb.mesonbuild.com'):
             resp = open_wrapdburl(url)
         else:
-            resp = urllib.request.urlopen(url)
+            resp = urllib.request.urlopen(url, timeout=req_timeout)
         with contextlib.closing(resp) as resp:
             try:
                 dlsize = int(resp.info()['Content-Length'])


### PR DESCRIPTION
a trivial patch for solving issue #4087 .

it would be better if we had using os.environ for setting thin behaviour details.

and it doesn't save from "Slow HTTP DoS attack".

but it's pretty better than nothing :-) ..