### PR TITLE
CompilerArgs: -Wl,-lfoo is also a valid way to pass a library

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -521,7 +521,7 @@ class CompilerArgs(list):
     dedup2_suffixes = ()
     dedup2_args = ()
     # Arg prefixes and args that must be de-duped by returning 1
-    dedup1_prefixes = ('-l',)
+    dedup1_prefixes = ('-l', '-Wl,-l')
     dedup1_suffixes = ('.lib', '.dll', '.so', '.dylib', '.a')
     # Match a .so of the form path/to/libfoo.so.0.1.0
     # Only UNIX shared libraries require this. Others have a fixed extension.
@@ -625,7 +625,7 @@ class CompilerArgs(list):
             group_start = -1
             group_end = -1
             for i, each in enumerate(new):
-                if not each.startswith('-l') and not each.endswith('.a') and \
+                if not each.startswith(('-Wl,-l', '-l')) and not each.endswith('.a') and \
                    not soregex.match(each):
                     continue
                 group_end = i

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -284,6 +284,9 @@ class InternalTests(unittest.TestCase):
         # Adding a non-library argument doesn't include it in the group
         l += ['-Lfoo', '-Wl,--export-dynamic']
         self.assertEqual(l.to_native(copy=True), ['-Lfoo', '-Lfoodir', '-Wl,--start-group', '-lfoo', '-Lbardir', '-lbar', '-lbar', '/libbaz.a', '-Wl,--end-group', '-Wl,--export-dynamic'])
+        # -Wl,-lfoo is detected as a library and gets added to the group
+        l.append('-Wl,-ldl')
+        self.assertEqual(l.to_native(copy=True), ['-Lfoo', '-Lfoodir', '-Wl,--start-group', '-lfoo', '-Lbardir', '-lbar', '-lbar', '/libbaz.a', '-Wl,--export-dynamic', '-Wl,-ldl', '-Wl,--end-group'])
 
     def test_string_templates_substitution(self):
         dictfunc = mesonbuild.mesonlib.get_filenames_templates_dict


### PR DESCRIPTION
Treat it the same as `-lfoo` by deduping and adding to `--start/end-group`

Reported at https://gitlab.gnome.org/GNOME/glib/issues/1496

We don't do any advanced transformation for MSVC or de-dup because this is a very rare syntax.