### PR TITLE
Deduplicate build-tree RPATHs on macOS

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -19,7 +19,7 @@ from ..linkers import StaticLinker
 from .. import coredata
 from .. import mlog
 from .. import mesonlib
-from ..mesonlib import EnvironmentException, MesonException, version_compare, Popen_safe
+from ..mesonlib import EnvironmentException, MesonException, OrderedSet, version_compare, Popen_safe
 
 """This file contains the data files of all compilers Meson knows
 about. To support a new compiler, add its information below.
@@ -1064,7 +1064,9 @@ class Compiler:
             abs_rpaths.append(build_rpath)
         # Ensure that there is enough space for large RPATHs
         args = ['-Wl,-headerpad_max_install_names']
-        args += ['-Wl,-rpath,' + rp for rp in abs_rpaths]
+        # Need to deduplicate abs_rpaths, as rpath_paths and
+        # build_rpath are not guaranteed to be disjoint sets
+        args += ['-Wl,-rpath,' + rp for rp in OrderedSet(abs_rpaths)]
         return args
 
     def build_unix_rpath_args(self, build_dir, from_dir, rpath_paths, build_rpath, install_rpath):

--- a/test cases/osx/2 library versions/meson.build
+++ b/test cases/osx/2 library versions/meson.build
@@ -1,6 +1,12 @@
 project('library versions', 'c')
 
+zlib_dep = dependency('zlib')
+
 some = shared_library('some', 'lib.c',
+  # duplicate the rpath again, in order
+  # to test Meson's RPATH deduplication
+  build_rpath : zlib_dep.get_pkgconfig_variable('libdir'),
+  dependencies : zlib_dep,
   version : '1.2.3',
   soversion : '0',
   install : true)


### PR DESCRIPTION
* Currently, RPATHs coming from dependencies and
  `build_rpath` provided by the user might contain
  the same path. Apple's `install_name` tool is
  allergic to providing the same argument twice
  when removing RPATHs:

    `error: install_name_tool: "-delete_rpath /usr/lib" specified more than once`

@nirbheek