### PR TITLE
Improve support for macOS dylib versioning

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1183,13 +1183,20 @@ extra keyword arguments.
   `soversion` is `4`, a Windows DLL will be called `foo-4.dll` and one
   of the aliases of the Linux shared library would be
   `libfoo.so.4`. If this is not specified, the first part of `version`
-  is used instead. For example, if `version` is `3.6.0` and
+  is used instead (see below). For example, if `version` is `3.6.0` and
   `soversion` is not defined, it is set to `3`.
 - `version` a string specifying the version of this shared library,
   such as `1.1.0`. On Linux and OS X, this is used to set the shared
   library version in the filename, such as `libfoo.so.1.1.0` and
   `libfoo.1.1.0.dylib`. If this is not specified, `soversion` is used
-  instead (see below).
+  instead (see above).
+- `darwin_versions` *(added 0.48)* an integer, string, or a list of
+  versions to use for setting dylib `compatibility version` and
+  `current version` on macOS. If a list is specified, it must be
+  either zero, one, or two elements. If only one element is specified
+  or if it's not a list, the specified value will be used for setting
+  both compatibility version and current version. If unspecified, the
+  `soversion` will be used as per the aforementioned rules.
 - `vs_module_defs` a string, a File object, or Custom Target for a
   Microsoft module definition file for controlling symbol exports,
   etc., on platforms where that is possible (e.g. Windows).

--- a/docs/markdown/snippets/shared_library_darwin_versions.md
+++ b/docs/markdown/snippets/shared_library_darwin_versions.md
@@ -1,0 +1,9 @@
+## `shared_library()` now supports setting dylib compatibility and current version
+
+Now, by default `shared_library()` sets `-compatibility_version` and
+`-current_version` of a macOS dylib using the `soversion`.
+
+This can be overriden by using the `darwin_versions:` kwarg to
+[`shared_library()`](Reference-manual.md#shared_library). As usual, you can
+also pass this kwarg to `library()` or `build_target()` and it will be used in
+the appropriate circumstances.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2257,7 +2257,8 @@ rule FORTRAN_DEP_HACK%s
             commands += linker.get_pic_args()
             # Add -Wl,-soname arguments on Linux, -install_name on OS X
             commands += linker.get_soname_args(target.prefix, target.name, target.suffix,
-                                               target.soversion, isinstance(target, build.SharedModule))
+                                               target.soversion, target.darwin_versions,
+                                               isinstance(target, build.SharedModule))
             # This is only visited when building for Windows using either GCC or Visual Studio
             if target.vs_module_defs and hasattr(linker, 'gen_vs_module_defs_args'):
                 commands += linker.gen_vs_module_defs_args(target.vs_module_defs.rel_to_builddir(self.build_to_src))

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -118,16 +118,14 @@ class DCompiler(Compiler):
     def get_std_shared_lib_link_args(self):
         return ['-shared']
 
-    def get_soname_args(self, prefix, shlib_name, suffix, soversion, is_shared_module):
+    def get_soname_args(self, *args):
         # FIXME: Make this work for cross-compiling
         gcc_type = GCC_STANDARD
         if is_windows():
             gcc_type = GCC_CYGWIN
         if is_osx():
             gcc_type = GCC_OSX
-
-        return get_gcc_soname_args(gcc_type, prefix, shlib_name, suffix, soversion, is_shared_module)
-
+        return get_gcc_soname_args(gcc_type, *args)
 
     def get_feature_args(self, kwargs, build_to_src):
         res = []

--- a/test cases/osx/2 library versions/installed_files.txt
+++ b/test cases/osx/2 library versions/installed_files.txt
@@ -1,5 +1,5 @@
 usr/lib/libsome.dylib
-usr/lib/libsome.0.dylib
+usr/lib/libsome.7.dylib
 usr/lib/libnoversion.dylib
 usr/lib/libonlyversion.dylib
 usr/lib/libonlyversion.1.dylib

--- a/test cases/osx/2 library versions/meson.build
+++ b/test cases/osx/2 library versions/meson.build
@@ -8,7 +8,7 @@ some = shared_library('some', 'lib.c',
   build_rpath : zlib_dep.get_pkgconfig_variable('libdir'),
   dependencies : zlib_dep,
   version : '1.2.3',
-  soversion : '0',
+  soversion : '7',
   install : true)
 
 noversion = shared_library('noversion', 'lib.c',
@@ -22,6 +22,21 @@ onlysoversion = shared_library('onlysoversion', 'lib.c',
   # Also test that int soversion is acceptable
   soversion : 5,
   install : true)
+
+shared_library('intver', 'lib.c',
+  darwin_versions : 2)
+
+shared_library('stringver', 'lib.c',
+  darwin_versions : '2.3')
+
+shared_library('stringlistver', 'lib.c',
+  darwin_versions : ['2.4'])
+
+shared_library('intstringver', 'lib.c',
+  darwin_versions : [1111, '2.5'])
+
+shared_library('stringlistvers', 'lib.c',
+  darwin_versions : ['2.6', '2.6.1'])
 
 # Hack to make the executables below depend on the shared libraries above
 # without actually adding them as `link_with` dependencies since we want to try


### PR DESCRIPTION
We now use the `soversion` to set `-compatibility_version` and `-current_version` by default. This is the only sane thing we can do by default because of the restrictions on the values that can be used for compatibility and current version. This is also what cmake does.

Users can override this value with the `darwin_versions:` kwarg, which can be a single value or a two-element list of values. The first one is the compatibility version and the second is the current version.

Fixes https://github.com/mesonbuild/meson/issues/3555
Fixes https://github.com/mesonbuild/meson/issues/1451

~~TODO: docs and tests~~

CCing @SoapGentoo @ePirat 