### PR TITLE
allow for meson.build to also be a patch file

### DIFF
--- a/manual tests/11 wrap local patch/meson.build
+++ b/manual tests/11 wrap local patch/meson.build
@@ -1,0 +1,11 @@
+project('multiwrap', 'c',
+  default_options : 'c_std=c99')
+
+# Using multiple downloaded projects for great justice.
+
+cc = meson.get_compiler('c')
+
+pngdep = dependency('external_libpng', fallback : ['external_libpng', 'png_dep'])
+
+executable('prog', 'prog.c',
+  dependencies : [pngdep])

--- a/manual tests/11 wrap local patch/prog.c
+++ b/manual tests/11 wrap local patch/prog.c
@@ -1,0 +1,34 @@
+#include<stdio.h>
+#include<stdlib.h>
+#include<png.h>
+#include<string.h>
+#if !defined(_MSC_VER)
+#include<unistd.h>
+#endif
+
+void open_image(const char *fname) {
+    png_image image;
+
+    memset(&image, 0, (sizeof image));
+    image.version = PNG_IMAGE_VERSION;
+
+    if(png_image_begin_read_from_file(&image, fname) != 0) {
+        png_bytep buffer;
+
+        image.format = PNG_FORMAT_RGBA;
+        buffer = malloc(PNG_IMAGE_SIZE(image));
+
+        if(png_image_finish_read(&image, NULL, buffer, 0, NULL) != 0) {
+            printf("Image %s read failed: %s\n", fname, image.message);
+        }
+//        png_free_image(&image);
+        free(buffer);
+    } else {
+        printf("Image %s open failed: %s", fname, image.message);
+    }
+}
+
+
+int main(int argc, char **argv) {
+    return 0;
+}

--- a/manual tests/11 wrap local patch/subprojects/external_libpng.wrap
+++ b/manual tests/11 wrap local patch/subprojects/external_libpng.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = libpng-1.6.34
+
+source_url = ftp://ftp-osl.osuosl.org/pub/libpng/src/libpng16/libpng-1.6.34.tar.xz
+source_filename = libpng-1.6.34.tar.xz
+source_hash = 2f1e960d92ce3b3abd03d06dfec9637dfbd22febf107a536b44f7a47c60659f6
+
+patch_url = https://github.com/glslang/meson/raw/local_multiwrap/manual%20tests/11%20wrap%20local%20patch/subprojects/libpng-meson.build
+patch_filename = libpng-1.6.34-1-meson.build
+patch_hash = 62a190ad73a1b5dd0ce9896e79b1a7efc515ece0b6fb4211aee439a53d52908b

--- a/manual tests/11 wrap local patch/subprojects/external_zlib.wrap
+++ b/manual tests/11 wrap local patch/subprojects/external_zlib.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = zlib-1.2.8
+
+source_url = http://zlib.net/fossils/zlib-1.2.8.tar.gz
+source_filename = zlib-1.2.8.tar.gz
+source_hash = 36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d
+
+patch_url = https://github.com/glslang/meson/raw/local_multiwrap/manual%20tests/11%20wrap%20local%20patch/subprojects/zlib-meson.build
+patch_filename = zlib-1.2.8-8-wrap-meson.build
+patch_hash = 50e2bf2250004a96c6249ca0664c9c2e93f81a5178dcb61bffbd36f9472d5c7a

--- a/manual tests/11 wrap local patch/subprojects/libpng-meson.build
+++ b/manual tests/11 wrap local patch/subprojects/libpng-meson.build
@@ -1,0 +1,44 @@
+project('libpng', 'c', license : 'libpng')
+
+cc = meson.get_compiler('c')
+
+include = include_directories('.')
+
+zlib_dep = dependency('external_zlib', fallback : ['external_zlib', 'zlib_dep'])
+
+libpng = library('png', [
+        'png.c',
+        'pngerror.c',
+        'pngget.c',
+        'pngmem.c',
+        'pngpread.c',
+        'pngread.c',
+        'pngrio.c',
+        'pngrtran.c',
+        'pngrutil.c',
+        'pngset.c',
+        'pngtrans.c',
+        'pngwio.c',
+        'pngwrite.c',
+        'pngwtran.c',
+        'pngwutil.c',
+    ],
+    dependencies : [
+        zlib_dep,
+        cc.find_library('m', required : false),
+    ],
+)
+
+configure_file(
+    configuration : configuration_data(),
+    input : 'scripts/pnglibconf.h.prebuilt',
+    output : 'pnglibconf.h',
+)
+
+png_dep = declare_dependency(
+    include_directories : include,
+    link_with : libpng,
+)
+
+png_test = executable('pngtest', 'pngtest.c', dependencies : png_dep)
+test('pngtest', png_test, args : files('pngtest.png'))

--- a/manual tests/11 wrap local patch/subprojects/zlib-meson.build
+++ b/manual tests/11 wrap local patch/subprojects/zlib-meson.build
@@ -1,0 +1,12 @@
+project('zlib', 'c', version : '1.2.8', license : 'zlib')
+
+src = ['adler32.c', 'crc32.c', 'deflate.c', 'infback.c', 'inffast.c', 'inflate.c',
+'inftrees.c', 'trees.c', 'zutil.c',
+'compress.c', 'uncompr.c', 'gzclose.c', 'gzlib.c', 'gzread.c', 'gzwrite.c']
+
+zlib = library('z', src)
+
+incdir = include_directories('.')
+
+zlib_dep = declare_dependency(link_with : zlib,
+  include_directories : incdir)

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -378,6 +378,12 @@ class Resolver:
         target_dir = os.path.join(self.subdir_root, package.get('directory'))
         if os.path.isdir(target_dir):
             return
+        try:
+            def copyfile(src, dst):
+                shutil.copyfile(src, os.path.join(target_dir, 'meson.build'))
+            shutil.register_unpack_format('meson', ['.build'], copyfile, [], "meson build file")
+        except shutil.RegistryError:
+            pass
         extract_dir = self.subdir_root
         # Some upstreams ship packages that do not have a leading directory.
         # Create one for them.
@@ -395,3 +401,4 @@ class Resolver:
                 with tempfile.TemporaryDirectory() as workdir:
                     shutil.unpack_archive(os.path.join(self.cachedir, package.get('patch_filename')), workdir)
                     self.copy_tree(workdir, self.subdir_root)
+        shutil.unregister_unpack_format('meson')


### PR DESCRIPTION
Hi,

I'd like to propose that a meson.build file to also be a valid patch file as opposed to assuming some sort of compressed directory structure.

I'm currently wrapping several projects and there's some complexity involved in either maintaining some compressed form (when upgrading) or simply having binary files in a repo.

I'm also patching their build systems for android/ios/osx/windows/linux but with the main project being based on meson, and I'd like to simply maintain meson.build files for all these dependencies.

Also, generating the third party structure on the fly is rather cumbersome and it's quite hard to make tar deterministic across versions and multiple build machines.

Alternatively, allow to disable the patch hash check if the wrap file has none.

I added a small test to demonstrate the functionality I'm aiming for.