### PR TITLE
gnome: fix generate_gir when linking with libasan

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -774,9 +774,9 @@ class GnomeModule(ExtensionModule):
         scan_command += ['--cflags-end']
         scan_command += get_include_args(inc_dirs)
         scan_command += get_include_args(list(gi_includes) + gir_inc_dirs + inc_dirs, prefix='--add-include-path=')
+        scan_command += list(internal_ldflags)
         scan_command += self._scan_gir_targets(state, girtargets)
         scan_command += self._scan_langs(state, [lc[0] for lc in langs_compilers])
-        scan_command += list(internal_ldflags)
         scan_command += list(external_ldflags)
 
         scan_target = self._make_gir_target(state, girfile, scan_command, depends, kwargs)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3236,6 +3236,14 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertRegex('\n'.join(mesonlog),
                          r'Dependency qt5 \(modules: Core\) found: YES .*, `pkg-config`\n')
 
+    def test_generate_gir_with_address_sanitizer(self):
+        if is_cygwin():
+            raise unittest.SkipTest('asan not available on Cygwin')
+
+        testdir = os.path.join(self.framework_test_dir, '7 gnome')
+        self.init(testdir, ['-Db_sanitize=address', '-Db_lundef=false'])
+        self.build()
+
     def test_qt5dependency_qmake_detection(self):
         '''
         Test that qt5 detection with qmake works. This can't be an ordinary


### PR DESCRIPTION
The regression was introduced in my recent refactoring of
that method (8377ea4).

This commit simply restores the ordering of the generated
scan_command, ensuring `-lasan` and other internal linker
flags come before `--library` or `--program`