### PR TITLE
Remove unnecessary -lquadmath from FORTRAN flags.

### DIFF
--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -275,7 +275,7 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
         return ['-J' + path]
 
     def language_stdlib_only_link_flags(self):
-        return ['-lgfortran', '-lm', '-lquadmath']
+        return ['-lgfortran', '-lm']
 
 
 class ElbrusFortranCompiler(GnuFortranCompiler, ElbrusCompiler):


### PR DESCRIPTION
Fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=907324.

Removing it did not seem to break anything. I don't actually even know why it's there. I probably copied it from somewhere without really understanding what it does.