### PR TITLE
Update appveyor example [skip ci]

### DIFF
--- a/docs/markdown/Continuous-Integration.md
+++ b/docs/markdown/Continuous-Integration.md
@@ -69,7 +69,7 @@ platform:
 install:
   # Download ninja
   - cmd: mkdir C:\ninja-build
-  - ps: (new-object net.webclient).DownloadFile('https://www.dropbox.com/s/cyghxjrvgplu7sy/ninja.exe?dl=1', 'C:\ninja-build\ninja.exe')
+  - ps: (new-object net.webclient).DownloadFile('https://github.com/mesonbuild/cidata/raw/master/ninja.exe', 'C:\ninja-build\ninja.exe')
   # Set paths to dependencies (based on architecture)
   - cmd: if %arch%==x86 (set PYTHON_ROOT=C:\python37) else (set PYTHON_ROOT=C:\python37-x64)
   # Print out dependency paths


### PR DESCRIPTION
Also add, how to make meson find Qt5 & Boost

Additional question: Should the `https://www.dropbox.com/s/cyghxjrvgplu7sy/ninja.exe?dl=1` link continue to be used or be replaced by `https://github.com/mesonbuild/cidata/raw/master/ninja.exe` which is used by the appveyor file of this repository?