### PR TITLE
Meson should warn if b_lundef is mixed with any sanitizer with clang

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3818,11 +3818,10 @@ different subdirectory.
             return
         if 'b_sanitize' not in self.coredata.base_options:
             return
-        if 'address' in self.coredata.base_options['b_sanitize'].value:
-            if self.coredata.base_options['b_lundef'].value:
-                mlog.warning('''Trying to use address sanitizer on Clang with b_lundef.
+        if self.coredata.base_options['b_lundef'].value:
+            mlog.warning('''Trying to use {} sanitizer on Clang with b_lundef.
 This will probably not work.
-Try setting b_lundef to false instead.''')
+Try setting b_lundef to false instead.'''.format(self.coredata.base_options['b_sanitize'].value))
 
     def evaluate_subproject_info(self, path_from_source_root, subproject_dirname):
         depth = 0


### PR DESCRIPTION
PR #3770 only cares about address sanitizer while clang will fail with any sanitizer when linking a lib with b_lundef.