### PR TITLE
GTest & GMock pkgconfig fallback

### DIFF
--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -104,17 +104,33 @@ class GMockDependency(ExternalDependency):
         super().__init__('gmock', environment, 'cpp', kwargs)
         self.main = kwargs.get('main', False)
 
+        # If we are getting main() from GMock, we definitely
+        # want to avoid linking in main() from GTest
+        gtest_kwargs = kwargs.copy()
+        if self.main:
+            gtest_kwargs['main'] = False
+
+        # GMock without GTest is pretty much useless
+        # this also mimics the structure given in WrapDB,
+        # where GMock always pulls in GTest
+        gtest_dep = GTestDependency(environment, gtest_kwargs)
+        if not gtest_dep.is_found:
+            self.is_found = False
+            return
+
+        self.compile_args = gtest_dep.compile_args
+        self.link_args = gtest_dep.link_args
+        self.sources = gtest_dep.sources
+
         # GMock may be a library or just source.
         # Work with both.
         gmock_detect = self.clib_compiler.find_library("gmock", self.env, [])
         gmock_main_detect = self.clib_compiler.find_library("gmock_main", self.env, [])
         if gmock_detect and (not self.main or gmock_main_detect):
             self.is_found = True
-            self.compile_args = []
-            self.link_args = gmock_detect
+            self.link_args += gmock_detect
             if self.main:
                 self.link_args += gmock_main_detect
-            self.sources = []
             self.prebuilt = True
             return
 
@@ -124,18 +140,20 @@ class GMockDependency(ExternalDependency):
                 # Yes, we need both because there are multiple
                 # versions of gmock that do different things.
                 d2 = os.path.normpath(os.path.join(d, '..'))
-                self.compile_args = ['-I' + d, '-I' + d2, '-I' + os.path.join(d2, 'include')]
-                self.link_args = []
+                self.compile_args += ['-I' + d, '-I' + d2, '-I' + os.path.join(d2, 'include')]
                 all_src = mesonlib.File.from_absolute_file(os.path.join(d, 'gmock-all.cc'))
                 main_src = mesonlib.File.from_absolute_file(os.path.join(d, 'gmock_main.cc'))
                 if self.main:
-                    self.sources = [all_src, main_src]
+                    self.sources += [all_src, main_src]
                 else:
-                    self.sources = [all_src]
+                    self.sources += [all_src]
                 self.prebuilt = False
                 return
 
         self.is_found = False
+
+    def need_threads(self):
+        return True
 
     def log_info(self):
         if self.prebuilt:


### PR DESCRIPTION
@jpakkane I've added pkg-config support to GTest and GMock over a year ago (https://github.com/google/googletest/commit/8604c4adac40573f806cfadae44e22f8dfaf212a). For our enterprise codebase and for distributions it makes building and CIs so much easier if we can just use GTest and GMock with pkg-config instead of a hard-coded source path and a raw `find_library` mechanism.