### PR TITLE
wrap: Redirect git's stdin to DEVNULL

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -41,7 +41,7 @@ def build_ssl_context():
     return ctx
 
 def quiet_git(cmd, workingdir):
-    pc = subprocess.Popen(['git', '-C', workingdir] + cmd,
+    pc = subprocess.Popen(['git', '-C', workingdir] + cmd, stdin=subprocess.DEVNULL,
                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = pc.communicate()
     if pc.returncode != 0:


### PR DESCRIPTION
Otherwise, git fiddles with the cmd.exe console's color behaviour and disables it, which causes it to stop interpreting ANSI color codes outputted by meson for colored output.

Effectively, as soon as any subproject is initialized, cmd.exe goes nice coloured output to ugly raw ANSI codes. Example

```
The Meson build system
Version: 0.48.0.dev1
Source dir: C:\projects\repos\gst-build.git
Build dir: C:\projects\repos\gst-build.git\build
Build type: native build
Project name: All GStreamer modules
Project version: 1.15.0.1
Native C compiler: cl (msvc 19.00.24215.1)
Build machine cpu family: x86_64
Build machine cpu: x86_64
Program uname found: NO
Found pkg-config: C:\Python36-32\Scripts\pkg-config.EXE (0.28)
Dependency libavfilter found: NO
Looking for a fallback subproject for the dependency libavfilter
# Here, we run `git rev-parse`
Couldn't use fallback subproject in [1msubprojects\FFmpeg[0m for the dependency [1mlibavfilter[0m
Reason: Subproject directory 'subprojects\\FFmpeg' does not exist and cannot be downloaded:
No FFmpeg.wrap found for 'subprojects\\FFmpeg'
Compiler for language [1mcs[0m skipped: feature [1msharp[0m disabled
Dependency [1mpygobject-3.0[0m found: [1;31mNO[0m
Dependency [1mlibva[0m found: [1;31mNO[0m
Dependency [1mjson-glib-1.0[0m found: [1;31mNO[0m
Dependency [1mlibxml-2.0[0m found: [1;31mNO[0m
Program [1mflex[0m found: [1;31mNO[0m
Program [1mwin_flex[0m found: [1;31mNO[0m
Program [1mbison[0m found: [1;31mNO[0m
Program [1mwin_bison[0m found: [1;31mNO[0m
```