### PR TITLE
Test + fix for not-found dependency fallback version comparison

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -361,8 +361,11 @@ otherwise. This function supports the following keyword arguments:
   dependency is not found in the system. The value is an array
   `['subproj_name', 'subproj_dep']` where the first value is the name
   of the subproject and the second is the variable name in that
-  subproject that contains the value of
-  [`declare_dependency`](#declare_dependency).
+  subproject that contains a dependency object such as the return
+  value of [`declare_dependency`](#declare_dependency) or
+  [`dependency()`](#dependency), etc. Note that this means the
+  fallback dependency may be a not-found dependency, in which
+  case the value of the `required:` kwarg will be obeyed.
 - `language` *(added 0.42.0)* defines what language-specific
   dependency to find if it's available for multiple languages.
 - `method` defines the way the dependency is detected, the default is

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3065,7 +3065,8 @@ root and issuing %s.
                 msg.append(traceback.format_exc())
             mlog.log(*msg)
             return None
-        dep = self.get_subproject_dep(name, dirname, varname, kwargs.get('required', True))
+        required = kwargs.get('required', True)
+        dep = self.get_subproject_dep(name, dirname, varname, required)
         if not dep:
             return None
         subproj_path = os.path.join(self.subproject_dir, dirname)
@@ -3073,6 +3074,12 @@ root and issuing %s.
         if 'version' in kwargs:
             wanted = kwargs['version']
             found = dep.version_method([], {})
+            # Don't do a version check if the dependency is not found and not required
+            if not dep.found_method([], {}) and not required:
+                subproj_path = os.path.join(self.subproject_dir, dirname)
+                mlog.log('Dependency', mlog.bold(display_name), 'from subproject',
+                         mlog.bold(subproj_path), 'found:', mlog.red('NO'))
+                return dep
             if not self.check_subproject_version(wanted, found):
                 mlog.log('Subproject', mlog.bold(subproj_path), 'dependency',
                          mlog.bold(display_name), 'version is', mlog.bold(found),

--- a/test cases/common/50 subproject subproject/meson.build
+++ b/test cases/common/50 subproject subproject/meson.build
@@ -3,5 +3,9 @@ project('sub sub', 'c')
 a = subproject('a')
 lib = a.get_variable('l')
 
+dependency('not-found-dep', required : false,
+           version : '>=1',
+           fallback : ['c', 'notfound_dep'])
+
 exe = executable('prog', 'prog.c', link_with : lib)
 test('basic', exe)

--- a/test cases/common/50 subproject subproject/subprojects/c/meson.build
+++ b/test cases/common/50 subproject subproject/subprojects/c/meson.build
@@ -1,0 +1,3 @@
+project('not-found-dep-subproj', 'c', version : '1.0')
+
+notfound_dep = dependency('', required : false)


### PR DESCRIPTION
Fixes:
meson.build:6:0: ERROR:  Uncomparable version string 'unknown'.

This was previously partially fixed in a8694f4b, which only fixed it
for cached fallback dependencies.