### PR TITLE
D: Fix linking errors with static D libraries on Windows

### DIFF
--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -513,6 +513,17 @@ class DmdDCompiler(DCompiler):
             return self.get_target_arch_args() + d_dmd_buildtype_args[buildtype]
         return d_dmd_buildtype_args[buildtype]
 
+    def get_std_exe_link_args(self):
+        if is_windows():
+            # DMD links against D runtime only when main symbol is found,
+            # so these needs to be inserted when linking static D libraries.
+            if self.is_64:
+                return ['phobos64.lib']
+            elif self.is_msvc:
+                return ['phobos32mscoff.lib']
+            return ['phobos.lib']
+        return []
+
     def get_std_shared_lib_link_args(self):
         return ['-shared', '-defaultlib=libphobos2.so']
 


### PR DESCRIPTION
Fixes linking errors with DMD which slipped through the recent mixed D/C++ test change.