### PR TITLE
Allow U+000C FORM FEED as whitespace to ignore.

### DIFF
--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -94,7 +94,7 @@ class Lexer:
         self.future_keywords = {'continue', 'break', 'in', 'return'}
         self.token_specification = [
             # Need to be sorted longest to shortest.
-            ('ignore', re.compile(r'[ \t]')),
+            ('ignore', re.compile(r'[ \t\f]')),
             ('id', re.compile('[_a-zA-Z][_0-9a-zA-Z]*')),
             ('number', re.compile(r'0[bB][01]+|0[oO][0-7]+|0[xX][0-9a-fA-F]+|0|[1-9]\d*')),
             ('eol_cont', re.compile(r'\\\n')),

--- a/test cases/common/1 trivial/meson.build
+++ b/test cases/common/1 trivial/meson.build
@@ -18,4 +18,6 @@ endif
 
 exe = executable('trivialprog', sources : sources)
 
+# U+000C FORM FEED whitespace.
+
 test('runtest', exe) # This is a comment


### PR DESCRIPTION
It's [good enough for Python](https://docs.python.org/3/reference/lexical_analysis.html#blank-lines), so I reckon it should be allowed in Meson syntax also.
