### PR TITLE
llvm: fix build flags with older llvm versions

### DIFF
--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -288,7 +288,7 @@ class LLVMDependency(ConfigToolDependency):
             libdir = self.get_config_value(['--libdir'], 'link_args')[0]
 
             expected_name = 'libLLVM-{}'.format(self.version)
-            re_name = re.compile(r'{}.(so|dll|dylib)'.format(expected_name))
+            re_name = re.compile(r'{}.(so|dll|dylib)$'.format(expected_name))
 
             for file_ in os.listdir(libdir):
                 if re_name.match(file_):


### PR DESCRIPTION
Fix fallback code for older (<= 3.8) llvm versions to not be dependent
on readdir() order.

Fixes #4102