### PR TITLE
D: Various improvements to argument translation

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -591,12 +591,12 @@ class Backend:
         for d in deps:
             if not (d.is_linkable_target()):
                 raise RuntimeError('Tried to link with a non-library target "%s".' % d.get_basename())
-            d_arg = self.get_target_filename_for_linking(d)
-            if not d_arg:
+            arg = self.get_target_filename_for_linking(d)
+            if not arg:
                 continue
-            if isinstance(compiler, (compilers.LLVMDCompiler, compilers.DmdDCompiler)):
-                d_arg = '-L' + d_arg
-            args.append(d_arg)
+            if compiler.get_language() == 'd':
+                arg = '-Wl,' + arg
+            args.append(arg)
         return args
 
     def get_mingw_extra_paths(self, target):

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -327,11 +327,6 @@ class DCompiler(Compiler):
                 # a linker search path.
                 dcargs.append('-L=' + arg)
                 continue
-            elif arg.startswith('/') or arg.startswith('./'):
-                # absolute (or relative) paths passed to the linker may be static libraries
-                # or other objects that we need to link.
-                dcargs.append('-L=' + arg)
-                continue
 
             dcargs.append(arg)
 

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -122,9 +122,8 @@ class DCompiler(Compiler):
 
     def get_linker_search_args(self, dirname):
         # -L is recognized as "add this to the search path" by the linker,
-        # while the compiler recognizes it as "pass to linker". So, the first
-        # -L is for the compiler, telling it to pass the second -L to the linker.
-        return ['-L=-L' + dirname]
+        # while the compiler recognizes it as "pass to linker".
+        return ['-Wl,-L' + dirname]
 
     def get_coverage_args(self):
         return ['-cov']
@@ -231,7 +230,7 @@ class DCompiler(Compiler):
                 paths = padding
             else:
                 paths = paths + ':' + padding
-        return ['-L=-rpath={}'.format(paths)]
+        return ['-Wl,-rpath={}'.format(paths)]
 
     def _get_compiler_check_args(self, env, extra_args, dependencies, mode='compile'):
         if extra_args is None:

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -150,12 +150,15 @@ class DCompiler(Compiler):
 
     def get_soname_args(self, *args):
         # FIXME: Make this work for cross-compiling
-        gcc_type = GCC_STANDARD
         if is_windows():
-            gcc_type = GCC_CYGWIN
-        if is_osx():
-            gcc_type = GCC_OSX
-        return get_gcc_soname_args(gcc_type, *args)
+            return []
+        elif is_osx():
+            soname_args = get_gcc_soname_args(GCC_OSX, *args)
+            if soname_args:
+                return ['-Wl,' + ','.join(soname_args)]
+            return []
+
+        return get_gcc_soname_args(GCC_STANDARD, *args)
 
     def get_feature_args(self, kwargs, build_to_src):
         res = []
@@ -230,7 +233,7 @@ class DCompiler(Compiler):
                 paths = padding
             else:
                 paths = paths + ':' + padding
-        return ['-Wl,-rpath={}'.format(paths)]
+        return ['-Wl,-rpath,{}'.format(paths)]
 
     def _get_compiler_check_args(self, env, extra_args, dependencies, mode='compile'):
         if extra_args is None:

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -328,6 +328,17 @@ class DCompiler(Compiler):
                 # compiler (pass flag through to the linker)
                 # Hence, we guess here whether the flag was intended to pass
                 # a linker search path.
+
+                # Make sure static library files are passed properly to the linker.
+                if arg.endswith('.a') or arg.endswith('.lib'):
+                    if arg.startswith('-L='):
+                        farg = arg[3:]
+                    else:
+                        farg = arg[2:]
+                    if len(farg) > 0 and not farg.startswith('-'):
+                        dcargs.append('-L=' + farg)
+                        continue
+
                 dcargs.append('-L=' + arg)
                 continue
 


### PR DESCRIPTION
All the linker related arguments are now handled via '-Wl,' in meson, so the argument translation function knows how to deal with those arguments properly. I also decided to split the OS specific translation logic to different functions, so it's more readable.

I also reverted the change related to static library handling introduced in #4084, because it also affects source and object files and not just library files, and provided alternative way to deal with this: static library files can also be passed to compiler without -L, but in case the user really wants to pass the files to linker, the extra -L is omitted. This should supersede the fix provided in #4080.

Thanks to @ljmf00 I also managed to fix the remaining OSX issues, which are also included here. Some of the test cases still fail, but only due to missing files in installed_files.txt, which doesn't seem to be solvable at this moment as there are no ways to handle OSX specific installation files at the moment.