### PR TITLE
Improve windows resource compiler executable selection

### DIFF
--- a/docs/markdown/Windows-module.md
+++ b/docs/markdown/Windows-module.md
@@ -21,3 +21,10 @@ has the following keyword argument.
 - `include_directories` lists directories to be both searched by the resource
   compiler for referenced resource files, and added to the preprocessor include
   search path.
+
+The resource compiler executable used is the first which exists from the
+following list:
+
+1. The `windres` executable given in the `[binaries]` section of the cross-file
+2. The `WINDRES` environment variable
+3. The resource compiler which is part of the same toolset as the C or C++ compiler in use.


### PR DESCRIPTION
Always honour any windres setting in cross-file (we can't be compiling with
msvc, but this should apply when cross-compiling using gcc or clang)

Always honour WINDRES environment variable

Otherwise look for the resource compiler which is part of the same toolset
as the C or C++ compiler.

Add some commentary on why the conventions for compiled resource file
extensions differ between RC and windres

Also don't try to report non-existent path when we couldn't find the
resource compiler.