### PR TITLE
Performance optimize mesons ninja generation

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -26,6 +26,12 @@ from ..mesonlib import File
 from ..compilers import CompilerArgs, get_macos_dylib_install_name
 from collections import OrderedDict
 import shlex
+from functools import lru_cache
+
+@lru_cache(maxsize=None)
+def get_target_macos_dylib_install_name(ld):
+    return get_macos_dylib_install_name(ld.prefix, ld.name, ld.suffix, ld.soversion)
+
 
 class CleanTrees:
     '''
@@ -1006,7 +1012,7 @@ class Backend:
         for ld in t.get_all_link_deps():
             if ld is t or not isinstance(ld, build.SharedLibrary):
                 continue
-            old = get_macos_dylib_install_name(ld.prefix, ld.name, ld.suffix, ld.soversion)
+            old = get_target_macos_dylib_install_name(ld)
             if old in result:
                 continue
             fname = ld.get_filename()

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -394,12 +394,11 @@ class Backend:
         return paths
 
     def determine_rpath_dirs(self, target):
-        link_deps = target.get_all_link_deps()
-        result = OrderedSet()
-        for ld in link_deps:
-            if ld is target:
-                continue
-            result.add(self.get_target_dir(ld))
+        if self.environment.coredata.get_builtin_option('layout') == 'mirror':
+            result = target.get_link_dep_subdirs()
+        else:
+            result = OrderedSet()
+            result.add('meson-out')
         result.update(self.rpaths_for_bundled_shared_libraries(target))
         return list(result)
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -21,7 +21,7 @@ from functools import lru_cache
 from . import environment
 from . import dependencies
 from . import mlog
-from .mesonlib import File, MesonException, listify, extract_as_list
+from .mesonlib import File, MesonException, listify, extract_as_list, OrderedSet
 from .mesonlib import typeslistify, stringlistify, classify_unity_sources
 from .mesonlib import get_filenames_templates_dict, substitute_values
 from .mesonlib import for_windows, for_darwin, for_cygwin, for_android, has_path_sep
@@ -674,6 +674,14 @@ class BuildTarget(Target):
         result = []
         for i in self.link_targets:
             result += i.get_all_link_deps()
+        return result
+
+    @lru_cache(maxsize=None)
+    def get_link_dep_subdirs(self):
+        result = OrderedSet()
+        for i in self.link_targets:
+            result.add(i.get_subdir())
+            result.update(i.get_link_dep_subdirs())
         return result
 
     def get_custom_install_dir(self):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -16,6 +16,7 @@ import copy, os, re
 from collections import OrderedDict
 import itertools, pathlib
 import pickle
+from functools import lru_cache
 
 from . import environment
 from . import dependencies
@@ -668,6 +669,7 @@ class BuildTarget(Target):
     def get_all_link_deps(self):
         return self.get_transitive_link_deps()
 
+    @lru_cache(maxsize=None)
     def get_transitive_link_deps(self):
         result = []
         for i in self.link_targets:
@@ -949,6 +951,7 @@ You probably should put it in link_with instead.''')
             if self.is_cross != t.is_cross:
                 raise InvalidArguments('Tried to mix cross built and native libraries in target {!r}'.format(self.name))
             self.link_targets.append(t)
+
 
     def link_whole(self, target):
         for t in listify(target, unholder=True):


### PR DESCRIPTION
EFL starts to use meson its main repository has 1037 build targets, and i giant list of generated files. The generation of the ninja files took about 1:10 min, after those three commits, we are down to 20 sec.