### PR TITLE
Quick Guide add step for python3-pip install

### DIFF
--- a/docs/markdown/Quick-guide.md
+++ b/docs/markdown/Quick-guide.md
@@ -23,7 +23,7 @@ generate native VS and XCode project files.
 On Ubuntu these can be easily installed with the following command:
 
 ```console
-$ sudo apt-get install python3 ninja-build
+$ sudo apt-get install python3 python3-pip ninja-build
 ```
 
 The best way to get Meson is to `pip install` it for your user


### PR DESCRIPTION
On Deban, and assuming now on Ubuntu as well, pip3 is only available after installing the python3-pip package. For that case explicitly specified the package during the system installation.