### PR TITLE
Sprinkle functools.lru_cache() in a few more places

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -17,7 +17,6 @@ from .. import build
 from .. import dependencies
 from .. import mesonlib
 from .. import mlog
-from .. import compilers
 import json
 import subprocess
 from ..mesonlib import MesonException, OrderedSet
@@ -400,7 +399,7 @@ class Backend:
             result = OrderedSet()
             result.add('meson-out')
         result.update(self.rpaths_for_bundled_shared_libraries(target))
-        return list(result)
+        return tuple(result)
 
     def object_filename_from_source(self, target, source):
         assert isinstance(source, mesonlib.File)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -923,7 +923,7 @@ class Compiler:
         raise EnvironmentException('Language {} does not support library finding.'.format(self.get_display_language()))
 
     def get_library_dirs(self, *args, **kwargs):
-        return []
+        return ()
 
     def has_multi_arguments(self, args, env):
         raise EnvironmentException(
@@ -1381,12 +1381,12 @@ class ElbrusCompiler(GnuCompiler):
         os_env = os.environ.copy()
         os_env['LC_ALL'] = 'C'
         stdo = Popen_safe(self.exelist + ['--print-search-dirs'], env=os_env)[1]
-        paths = []
+        paths = ()
         for line in stdo.split('\n'):
             if line.startswith('libraries:'):
                 # lcc does not include '=' in --print-search-dirs output.
                 libstr = line.split(' ', 1)[1]
-                paths = [os.path.realpath(p) for p in libstr.split(':')]
+                paths = (os.path.realpath(p) for p in libstr.split(':'))
                 break
         return paths
 
@@ -1394,12 +1394,12 @@ class ElbrusCompiler(GnuCompiler):
         os_env = os.environ.copy()
         os_env['LC_ALL'] = 'C'
         stdo = Popen_safe(self.exelist + ['--print-search-dirs'], env=os_env)[1]
-        paths = []
+        paths = ()
         for line in stdo.split('\n'):
             if line.startswith('programs:'):
                 # lcc does not include '=' in --print-search-dirs output.
                 libstr = line.split(' ', 1)[1]
-                paths = [os.path.realpath(p) for p in libstr.split(':')]
+                paths = (os.path.realpath(p) for p in libstr.split(':'))
                 break
         return paths
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -575,22 +575,22 @@ class InternalTests(unittest.TestCase):
         '''
         Unit test for the library search patterns used by find_library()
         '''
-        unix_static = ['lib{}.a', '{}.a']
-        msvc_static = ['lib{}.a', 'lib{}.lib', '{}.a', '{}.lib']
+        unix_static = ('lib{}.a', '{}.a')
+        msvc_static = ('lib{}.a', 'lib{}.lib', '{}.a', '{}.lib')
         # This is the priority list of pattern matching for library searching
-        patterns = {'openbsd': {'shared': ['lib{}.so', '{}.so', 'lib{}.so.[0-9]*.[0-9]*'],
+        patterns = {'openbsd': {'shared': ('lib{}.so', '{}.so', 'lib{}.so.[0-9]*.[0-9]*'),
                                 'static': unix_static},
-                    'linux': {'shared': ['lib{}.so', '{}.so'],
+                    'linux': {'shared': ('lib{}.so', '{}.so'),
                               'static': unix_static},
-                    'darwin': {'shared': ['lib{}.dylib', '{}.dylib'],
+                    'darwin': {'shared': ('lib{}.dylib', '{}.dylib'),
                                'static': unix_static},
-                    'cygwin': {'shared': ['cyg{}.dll', 'cyg{}.dll.a', 'lib{}.dll',
-                                          'lib{}.dll.a', '{}.dll', '{}.dll.a'],
-                               'static': ['cyg{}.a'] + unix_static},
-                    'windows-msvc': {'shared': ['lib{}.lib', '{}.lib'],
+                    'cygwin': {'shared': ('cyg{}.dll', 'cyg{}.dll.a', 'lib{}.dll',
+                                          'lib{}.dll.a', '{}.dll', '{}.dll.a'),
+                               'static': ('cyg{}.a',) + unix_static},
+                    'windows-msvc': {'shared': ('lib{}.lib', '{}.lib'),
                                      'static': msvc_static},
-                    'windows-mingw': {'shared': ['lib{}.dll.a', 'lib{}.lib', 'lib{}.dll',
-                                                 '{}.dll.a', '{}.lib', '{}.dll'],
+                    'windows-mingw': {'shared': ('lib{}.dll.a', 'lib{}.lib', 'lib{}.dll',
+                                                 '{}.dll.a', '{}.lib', '{}.dll'),
                                       'static': msvc_static}}
         env = get_fake_env('', '', '')
         cc = env.detect_c_compiler(False)


### PR DESCRIPTION
This improves the backend generation time for gst-build from 7.4s to 6.6s. This is probably all the low-hanging fruit we can get, further improvements will probably require refactoring, moving to `pathlib.Path` or reimplementing `CompilerArgs`:

```
   222045    0.551    0.000    1.324    0.000 compilers.py:666(__iadd__)
     3691    0.230    0.000    0.885    0.000 ninjabackend.py:99(write)
   233560    0.441    0.000    0.701    0.000 posixpath.py:75(join)
      882    0.141    0.000    0.636    0.001 backends.py:509(generate_basic_compiler_args)
   256301    0.248    0.000    0.576    0.000 compilers.py:562(_can_dedup)
    37369    0.035    0.000    0.466    0.000 compilers.py:652(extend_direct)
    74650    0.067    0.000    0.431    0.000 compilers.py:641(append_direct)
   158153    0.089    0.000    0.405    0.000 ninjabackend.py:129(<lambda>)
      845    0.064    0.000    0.391    0.000 ninjabackend.py:279(get_target_generated_sources)
    58161    0.070    0.000    0.317    0.000 backends.py:217(get_target_generated_dir)
   216825    0.175    0.000    0.275    0.000 ninjabackend.py:48(ninja_quote)
      845    0.058    0.000    0.255    0.000 ninjabackend.py:2289(guess_external_link_dependencies)
      845    0.068    0.000    0.239    0.000 backends.py:793(get_custom_target_provided_libraries)
    52101    0.030    0.000    0.237    0.000 compilers.py:716(append)
  1319326    0.231    0.000    0.231    0.000 {built-in method builtins.isinstance}
  1189117    0.229    0.000    0.229    0.000 {method 'startswith' of 'str' objects}
     3235    0.102    0.000    0.228    0.000 compilers.py:614(to_native)
```

Note: there are 845 build targets.