### PR TITLE
Allow passing dict to some library() args

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -479,7 +479,11 @@ be passed to [shared and static libraries](#library).
 
 - `<languagename>_pch` precompiled header file to use for the given language
 - `<languagename>_args` compiler flags to use for the given language;
-  eg: `cpp_args` for C++
+  eg: `cpp_args` for C++. Since *0.49.0* it can be a dictionary mapping target
+  type to an array of args, the value mapped to the current build type will be
+  used. For example passing `c_args: {'static_library': '-DSTATIC'}` means that
+  if a static library is built `STATIC` is defined, but not for shared
+  libraries, executables, etc.
 - `build_by_default` causes, when set to true, to have this target be
   built by default, that is, when invoking plain `ninja`, the default
   value is true for all built target types, since 0.38.0
@@ -563,6 +567,7 @@ creating the final list.
 
 The returned object also has methods that are documented in the
 [object methods section](#build-target-object) below.
+
 
 ### find_library()
 
@@ -1035,8 +1040,12 @@ The keyword arguments for this are the same as for
 - `name_prefix` the string that will be used as the prefix for the
   target output filename by overriding the default (only used for
   libraries). By default this is `lib` on all platforms and compilers
-  except with MSVC shared libraries where it is omitted to follow
-  convention.
+  except with MSVCshared libraries where it is omitted to follow
+  convention. Since *0.49.0* it can be a dictionary mapping target type to a
+  string, the value mapped to the current build type will be used. For example
+  passing `name_prefix: {'static_library': 'lib'}` means that if a static
+  library is built `name_prefix` is `lib`, but for shared library `name_prefix`
+  is undefined and thus the default value is used.
 - `name_suffix` the string that will be used as the suffix for the
   target output filename by overriding the default (see also:
   [executable()](#executable)). By default, for shared libraries this
@@ -1044,7 +1053,11 @@ The keyword arguments for this are the same as for
   For static libraries, it is `a` everywhere. By convention MSVC
   static libraries use the `lib` suffix, but we use `a` to avoid a
   potential name clash with shared libraries which also generate
-  `xxx.lib` import files.
+  `xxx.lib` import files. Since *0.49.0* it can be a dictionary mapping target
+  type to a string, the value mapped to the current build type will be used.
+  For example passing `name_suffix: {'static_library': 'a'}` means that if a
+  static library is built `name_suffix` is `a`, but for shared library
+  `name_suffix` is undefined and thus the default value is used.
 - `rust_crate_type` specifies the crate type for Rust
   libraries. Defaults to `dylib` for shared libraries and `rlib` for
   static libraries.

--- a/docs/markdown/snippets/target_type_dict.md
+++ b/docs/markdown/snippets/target_type_dict.md
@@ -1,0 +1,26 @@
+## Dictionary for `name_prefix`, `name_suffix` and `<lang>_args`
+
+`name_prefix`, `name_suffix` and `<lang>_args` keyword arguments of functions
+like `library()` and `build_target()` now accept a dictionary mapping the target
+type to the value. This is used when for example different c_args must be passed
+to the static and shared library built by `both_libraries()`.
+
+```meson
+cargs = {
+  'static_library': '-DSTATIC',
+  'shared_library': '-DSHARED',
+  'executable': ['-DEXECUTABLE', '-DMY_APP'],
+ }
+namesuffix = {
+  'static_library': 'a',
+  'shared_library': 'so',
+}
+# sources will be built twice with different cflags, the static library will
+# have .a extension on all platforms and the shared library will have the .so
+# extension on all platforms
+both_libraries('foo', sources, c_args: cargs, name_suffix: namesuffix)
+# EXECUTABLE and MY_APP will be defined when building sources, and it will use
+# the default extension on the current platform because 'executable' is not in
+# the namesuffix dictionary
+executable('app', c_args: cargs, name_suffix: namesuffix)
+```

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -849,8 +849,8 @@ This will become a hard error in a future Meson release.''')
             if not os.path.isfile(trial):
                 raise InvalidArguments('Tried to add non-existing resource %s.' % r)
         self.resources = resources
-        if 'name_prefix' in kwargs:
-            name_prefix = kwargs['name_prefix']
+        name_prefix = self.unwrap_target_dict(kwargs, 'name_prefix')
+        if name_prefix is not None:
             if isinstance(name_prefix, list):
                 if name_prefix:
                     raise InvalidArguments('name_prefix array must be empty to signify null.')
@@ -859,8 +859,8 @@ This will become a hard error in a future Meson release.''')
                     raise InvalidArguments('name_prefix must be a string.')
                 self.prefix = name_prefix
                 self.name_prefix_set = True
-        if 'name_suffix' in kwargs:
-            name_suffix = kwargs['name_suffix']
+        name_suffix = self.unwrap_target_dict(kwargs, 'name_suffix')
+        if name_suffix is not None:
             if isinstance(name_suffix, list):
                 if name_suffix:
                     raise InvalidArguments('name_suffix array must be empty to signify null.')
@@ -1073,6 +1073,13 @@ You probably should put it in link_with instead.''')
         for k in d.keys():
             if k not in known_build_targets:
                 raise MesonException('Dictionary keys must be in ' + str(known_build_targets))
+
+    def unwrap_target_dict(self, kwargs, key):
+        value = kwargs.get(key, None)
+        if isinstance(value, dict):
+            self.validate_target_dict(value)
+            value = value.get(self.target_type, None)
+        return value
 
     def validate_compiler_args(self, args):
         result = []

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1067,10 +1067,28 @@ You probably should put it in link_with instead.''')
             ids.append(a)
         self.include_dirs += ids
 
-    def add_compiler_args(self, language, args):
+    def validate_target_dict(self, d):
+        known_build_targets = ['static_library', 'shared_library',
+                               'shared_module', 'executable', 'jar']
+        for k in d.keys():
+            if k not in known_build_targets:
+                raise MesonException('Dictionary keys must be in ' + str(known_build_targets))
+
+    def validate_compiler_args(self, args):
+        result = []
         for a in args:
-            if not isinstance(a, (str, File)):
+            if isinstance(a, dict):
+                self.validate_target_dict(a)
+                l = extract_as_list(a, self.target_type)
+                result += self.validate_compiler_args(l)
+            elif isinstance(a, (str, File)):
+                result.append(a)
+            else:
                 raise InvalidArguments('A non-string passed to compiler args.')
+        return result
+
+    def add_compiler_args(self, language, args):
+        args = self.validate_compiler_args(args)
         if language in self.extra_args:
             self.extra_args[language] += args
         else:
@@ -1327,6 +1345,7 @@ class GeneratedList:
 
 class Executable(BuildTarget):
     known_kwargs = known_exe_kwargs
+    target_type = 'executable'
 
     def __init__(self, name, subdir, subproject, is_cross, sources, objects, environment, kwargs):
         if 'pie' not in kwargs and 'b_pie' in environment.coredata.base_options:
@@ -1414,6 +1433,7 @@ class Executable(BuildTarget):
 
 class StaticLibrary(BuildTarget):
     known_kwargs = known_stlib_kwargs
+    target_type = 'static_library'
 
     def __init__(self, name, subdir, subproject, is_cross, sources, objects, environment, kwargs):
         if 'pic' not in kwargs and 'b_staticpic' in environment.coredata.base_options:
@@ -1473,6 +1493,7 @@ class StaticLibrary(BuildTarget):
 
 class SharedLibrary(BuildTarget):
     known_kwargs = known_shlib_kwargs
+    target_type = 'shared_library'
 
     def __init__(self, name, subdir, subproject, is_cross, sources, objects, environment, kwargs):
         self.soversion = None
@@ -1780,6 +1801,7 @@ class SharedLibrary(BuildTarget):
 # into something else.
 class SharedModule(SharedLibrary):
     known_kwargs = known_shmod_kwargs
+    target_type = 'shared_module'
 
     def __init__(self, name, subdir, subproject, is_cross, sources, objects, environment, kwargs):
         if 'version' in kwargs:
@@ -2085,6 +2107,7 @@ class RunTarget(Target):
 
 class Jar(BuildTarget):
     known_kwargs = known_jar_kwargs
+    target_type = 'jar'
 
     def __init__(self, name, subdir, subproject, is_cross, sources, objects, environment, kwargs):
         super().__init__(name, subdir, subproject, is_cross, sources, objects, environment, kwargs)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -854,10 +854,11 @@ This will become a hard error in a future Meson release.''')
             if isinstance(name_prefix, list):
                 if name_prefix:
                     raise InvalidArguments('name_prefix array must be empty to signify null.')
-            elif not isinstance(name_prefix, str):
-                raise InvalidArguments('name_prefix must be a string.')
-            self.prefix = name_prefix
-            self.name_prefix_set = True
+            else:
+                if not isinstance(name_prefix, str):
+                    raise InvalidArguments('name_prefix must be a string.')
+                self.prefix = name_prefix
+                self.name_prefix_set = True
         if 'name_suffix' in kwargs:
             name_suffix = kwargs['name_suffix']
             if isinstance(name_suffix, list):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -765,25 +765,19 @@ just like those detected with the dependency() function.''')
         for linktarget in lwhole:
             self.link_whole(linktarget)
 
-        c_pchlist, cpp_pchlist, clist, cpplist, cslist, valalist,  objclist, objcpplist, fortranlist, rustlist \
-            = extract_as_list(kwargs, 'c_pch', 'cpp_pch', 'c_args', 'cpp_args', 'cs_args', 'vala_args', 'objc_args',
-                              'objcpp_args', 'fortran_args', 'rust_args')
+        for lang in ['c', 'cpp', 'cs', 'vala', 'objc', 'objcpp', 'fortran', 'rust', 'd']:
+            args = extract_as_list(kwargs, lang + '_args')
+            self.add_compiler_args(lang, args)
 
+        c_pchlist, cpp_pchlist = extract_as_list(kwargs, 'c_pch', 'cpp_pch')
         self.add_pch('c', c_pchlist)
         self.add_pch('cpp', cpp_pchlist)
-        compiler_args = {'c': clist, 'cpp': cpplist, 'cs': cslist, 'vala': valalist, 'objc': objclist, 'objcpp': objcpplist,
-                         'fortran': fortranlist, 'rust': rustlist
-                         }
-        for key, value in compiler_args.items():
-            self.add_compiler_args(key, value)
 
         if not isinstance(self, Executable) or 'export_dynamic' in kwargs:
             self.vala_header = kwargs.get('vala_header', self.name + '.h')
             self.vala_vapi = kwargs.get('vala_vapi', self.name + '.vapi')
             self.vala_gir = kwargs.get('vala_gir', None)
 
-        dlist = stringlistify(kwargs.get('d_args', []))
-        self.add_compiler_args('d', dlist)
         dfeatures = dict()
         dfeature_unittest = kwargs.get('d_unittest', False)
         if dfeature_unittest:
@@ -1073,7 +1067,6 @@ You probably should put it in link_with instead.''')
         self.include_dirs += ids
 
     def add_compiler_args(self, language, args):
-        args = listify(args)
         for a in args:
             if not isinstance(a, (str, File)):
                 raise InvalidArguments('A non-string passed to compiler args.')

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3932,7 +3932,18 @@ Try setting b_lundef to false instead.'''.format(self.coredata.base_options['b_s
         elif 'b_staticpic' in self.environment.coredata.base_options:
             pic = self.environment.coredata.base_options['b_staticpic'].value
 
-        if pic:
+        # Check if compiler args are the same for both libraries
+        def has_different_args():
+            for lang in shared_holder.held_object.compilers.keys():
+                args = extract_as_list(kwargs, lang + '_args')
+                for a in args:
+                    if not isinstance(a, dict):
+                        continue
+                    if 'static_library' in a or 'shared_library' in a:
+                        return True
+            return False
+
+        if pic and not has_different_args():
             # Exclude sources from args and kwargs to avoid building them twice
             static_args = [args[0]]
             static_kwargs = kwargs.copy()

--- a/test cases/common/184 bothlibraries/libfile.c
+++ b/test cases/common/184 bothlibraries/libfile.c
@@ -1,6 +1,10 @@
 #include "mylib.h"
 
+#ifdef STATIC_COMPILATION
 DO_EXPORT int retval = 42;
+#else
+DO_EXPORT int retval = 43;
+#endif
 
 DO_EXPORT int func() {
     return retval;

--- a/test cases/common/184 bothlibraries/main.c
+++ b/test cases/common/184 bothlibraries/main.c
@@ -1,8 +1,15 @@
+#include <stdlib.h>
 #include "mylib.h"
 
 DO_IMPORT int func();
 DO_IMPORT int retval;
 
-int main(int argc, char **arg) {
-    return func() == retval ? 0 : 1;
+int main(int argc, char *argv[]) {
+    if (func() != retval)
+        return 1;
+
+    if (argc > 1 && atoi(argv[1]) != retval)
+        return 1;
+
+    return 0;
 }

--- a/test cases/common/184 bothlibraries/meson.build
+++ b/test cases/common/184 bothlibraries/meson.build
@@ -10,3 +10,17 @@ exe_both = executable('prog-both', 'main.c', link_with : both_libs)
 test('runtest-shared', exe_shared)
 test('runtest-static', exe_static)
 test('runtest-both', exe_both)
+
+cargs = {
+  'static_library' : ['-DSTATIC_COMPILATION'],
+  'executable' : ['-DSTATIC_COMPILATION'],
+}
+both_libs = both_libraries('mylib-diffargs', 'libfile.c', c_args : cargs)
+exe_shared = executable('prog-shared-diffargs', 'main.c',
+                        link_with : both_libs.get_shared_lib())
+exe_static = executable('prog-static-diffargs', 'main.c',
+                        c_args : cargs,
+                        link_with : both_libs.get_static_lib())
+
+test('runtest-shared-diffargs', exe_shared, args : '43')
+test('runtest-static-diffargs', exe_static, args : '42')


### PR DESCRIPTION
There are currently 2 use cases where we want to pass different arguments to library() function if it's shared or static, see #4133 and #3304. A complete solution like the one proposed in https://github.com/mesonbuild/meson/issues/4019#issuecomment-419446523 is probably too complicated and controversial.

This PR allow syntax like this:
```meson
cargs = {
  'static_library' : ['-DSTATIC_COMPILATION']
}
suffix = {
  'static_library' : 'lib'
}
mylib = library('foo', sources, c_args : ['-DFOO', cargs], name_suffix : suffix)
```

This is very similar to my old PR #3320, but using a dict instead of a new object type.