### PR TITLE
Implement thread linker args for D compilers

### DIFF
--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -411,6 +411,9 @@ class DCompiler(Compiler):
     def get_crt_link_args(self, crt_val, buildtype):
         return []
 
+    def thread_link_flags(self, env):
+        return ['-pthread']
+
 class GnuDCompiler(DCompiler):
     def __init__(self, exelist, version, is_cross, is_64, **kwargs):
         DCompiler.__init__(self, exelist, version, is_cross, is_64, **kwargs)


### PR DESCRIPTION
D compilers are configured to have highest priority when chosing linker
for targets mixing C/C++/D code and before this change meson would fail
to configure gtest target that uses D library as a dependency.