### PR TITLE
D: Improve target architecture handling

### DIFF
--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -69,12 +69,12 @@ class DCompiler(Compiler):
         'mtd': ['-mscrtlib=libcmtd'],
     }
 
-    def __init__(self, exelist, version, is_cross, is_64, **kwargs):
+    def __init__(self, exelist, version, is_cross, arch, **kwargs):
         self.language = 'd'
         super().__init__(exelist, version, **kwargs)
         self.id = 'unknown'
         self.is_cross = is_cross
-        self.is_64 = is_64
+        self.arch = arch
 
     def sanity_check(self, work_dir, environment):
         source_name = os.path.join(work_dir, 'sanity.d')
@@ -275,7 +275,7 @@ class DCompiler(Compiler):
         # LDC2 on Windows targets to current OS architecture, but
         # it should follow the target specified by the MSVC toolchain.
         if is_windows():
-            if self.is_64:
+            if self.arch == 'x86_64':
                 return ['-m64']
             return ['-m32']
         return []
@@ -411,8 +411,8 @@ class DCompiler(Compiler):
         return []
 
 class GnuDCompiler(DCompiler):
-    def __init__(self, exelist, version, is_cross, is_64, **kwargs):
-        DCompiler.__init__(self, exelist, version, is_cross, is_64, **kwargs)
+    def __init__(self, exelist, version, is_cross, arch, **kwargs):
+        DCompiler.__init__(self, exelist, version, is_cross, arch, **kwargs)
         self.id = 'gcc'
         default_warn_args = ['-Wall', '-Wdeprecated']
         self.warn_args = {'1': default_warn_args,
@@ -466,8 +466,8 @@ class GnuDCompiler(DCompiler):
         return gnu_optimization_args[optimization_level]
 
 class LLVMDCompiler(DCompiler):
-    def __init__(self, exelist, version, is_cross, is_64, **kwargs):
-        DCompiler.__init__(self, exelist, version, is_cross, is_64, **kwargs)
+    def __init__(self, exelist, version, is_cross, arch, **kwargs):
+        DCompiler.__init__(self, exelist, version, is_cross, arch, **kwargs)
         self.id = 'llvm'
         self.base_options = ['b_coverage', 'b_colorout', 'b_vscrt']
 
@@ -502,11 +502,10 @@ class LLVMDCompiler(DCompiler):
 
 
 class DmdDCompiler(DCompiler):
-    def __init__(self, exelist, version, is_cross, is_64, **kwargs):
-        DCompiler.__init__(self, exelist, version, is_cross, is_64, **kwargs)
+    def __init__(self, exelist, version, is_cross, arch, **kwargs):
+        DCompiler.__init__(self, exelist, version, is_cross, arch, **kwargs)
         self.id = 'dmd'
         self.base_options = ['b_coverage', 'b_colorout', 'b_vscrt']
-        self.is_msvc = 'VCINSTALLDIR' in os.environ
 
     def get_colorout_args(self, colortype):
         if colortype == 'always':
@@ -522,9 +521,9 @@ class DmdDCompiler(DCompiler):
         if is_windows():
             # DMD links against D runtime only when main symbol is found,
             # so these needs to be inserted when linking static D libraries.
-            if self.is_64:
+            if self.arch == 'x86_64':
                 return ['phobos64.lib']
-            elif self.is_msvc:
+            elif self.arch == 'x86_mscoff':
                 return ['phobos32mscoff.lib']
             return ['phobos.lib']
         return []
@@ -537,9 +536,9 @@ class DmdDCompiler(DCompiler):
         # Force the target to 64-bit in order to stay consistent
         # across the different platforms.
         if is_windows():
-            if self.is_64:
+            if self.arch == 'x86_64':
                 return ['-m64']
-            elif self.is_msvc:
+            elif self.arch == 'x86_mscoff':
                 return ['-m32mscoff']
             return ['-m32']
         return []

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -905,7 +905,18 @@ class DubDependency(ExternalDependency):
 
                 self.module_path = self._find_right_lib_path(package['path'], comp, description, True, package['targetFileName'])
                 if not os.path.exists(self.module_path):
-                    mlog.error(mlog.bold(name), 'found but it wasn\'t compiled with', mlog.bold(comp))
+                    # check if the dependency was built for other archs
+                    archs = [['x86_64'], ['x86'], ['x86', 'x86_mscoff']]
+                    for a in archs:
+                        description_a = copy.deepcopy(description)
+                        description_a['architecture'] = a
+                        arch_module_path = self._find_right_lib_path(package['path'], comp, description_a, True, package['targetFileName'])
+                        if arch_module_path:
+                            mlog.error(mlog.bold(name), "found but it wasn't compiled for", mlog.bold(arch))
+                            self.is_found = False
+                            return
+
+                    mlog.error(mlog.bold(name), "found but it wasn't compiled with", mlog.bold(comp))
                     self.is_found = False
                     return
 

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -870,13 +870,8 @@ class DubDependency(ExternalDependency):
         mlog.debug('Determining dependency {!r} with DUB executable '
                    '{!r}'.format(name, self.dubbin.get_path()))
 
-        # we need to know the correct architecture on Windows
-        if self.compiler.is_64:
-            arch = 'x86_64'
-        elif self.compiler.is_msvc:
-            arch = 'x86_mscoff'
-        else:
-            arch = 'x86'
+        # we need to know the target architecture
+        arch = self.compiler.arch
 
         # Ask dub for the package
         ret, res = self._call_dubbin(['describe', name, '--arch=' + arch])

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -836,22 +836,22 @@ This is probably wrong, it should always point to the native compiler.''' % evar
         version = search_version(out)
         full_version = out.split('\n', 1)[0]
 
-        # Detect which MSVC build environment is currently active.
-        is_64 = False
+        # Detect the target architecture, required for proper architecture handling on Windows.
         c_compiler = {}
-        if mesonlib.is_windows() and 'VCINSTALLDIR' in os.environ:
-            # MSVC compiler is required for correct platform detection.
-            c_compiler = {'c': self.detect_c_compiler(want_cross)}
+        is_msvc = mesonlib.is_windows() and 'VCINSTALLDIR' in os.environ
+        if is_msvc:
+            c_compiler = {'c': self.detect_c_compiler(want_cross)} # MSVC compiler is required for correct platform detection.
 
-        if detect_cpu_family(c_compiler) == 'x86_64':
-            is_64 = True
+        arch = detect_cpu_family(c_compiler)
+        if is_msvc and arch == 'x86':
+            arch = 'x86_mscoff'
 
         if 'LLVM D compiler' in out:
-            return compilers.LLVMDCompiler(exelist, version, is_cross, is_64, full_version=full_version)
+            return compilers.LLVMDCompiler(exelist, version, is_cross, arch, full_version=full_version)
         elif 'gdc' in out:
-            return compilers.GnuDCompiler(exelist, version, is_cross, is_64, full_version=full_version)
+            return compilers.GnuDCompiler(exelist, version, is_cross, arch, full_version=full_version)
         elif 'The D Language Foundation' in out or 'Digital Mars' in out:
-            return compilers.DmdDCompiler(exelist, version, is_cross, is_64, full_version=full_version)
+            return compilers.DmdDCompiler(exelist, version, is_cross, arch, full_version=full_version)
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
 
     def detect_swift_compiler(self):


### PR DESCRIPTION
Windows 32-bit targets were handled incorrectly, as 'x86' has different meaning on DMD and DUB while building on Windows. This also improves the error messages in dependency detection for wrong architecture and when the dub package was not built.

This should fix the remaining issues detected in #4158 