### PR TITLE
Do not use relative RPATH on macOS with GCC

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -121,7 +121,7 @@ class CCompiler(Compiler):
     # The default behavior is this, override in MSVC
     @functools.lru_cache(maxsize=None)
     def build_rpath_args(self, build_dir, from_dir, rpath_paths, build_rpath, install_rpath):
-        if self.id == 'clang' and self.clang_type == compilers.CLANG_OSX:
+        if (self.id == 'clang' and self.clang_type == compilers.CLANG_OSX) or (self.id == 'gcc' and self.gcc_type == compilers.GCC_OSX):
             return self.build_osx_rpath_args(build_dir, rpath_paths, build_rpath)
         return self.build_unix_rpath_args(build_dir, from_dir, rpath_paths, build_rpath, install_rpath)
 


### PR DESCRIPTION
* Currently, absolute rpaths on macOS are only used
  with Clang, which breaks Meson builds when using
  GCC from Homebrew or MacPorts.

@jpakkane @nirbheek can we still get this in for 0.48.0? This makes working on macOS unnecessarily hard, because I always have to use static libraries for the build tree to work.