### PR TITLE
 Add support for uic_extra_arguments to qt5

### DIFF
--- a/docs/markdown/Qt5-module.md
+++ b/docs/markdown/Qt5-module.md
@@ -9,8 +9,9 @@ This method takes the following keyword arguments:
  - `moc_headers`, `moc_sources`, `ui_files`, `qresources`, which define the files that require preprocessing with `moc`, `uic` and `rcc`
  - `include_directories`, the directories to add to header search path for `moc` (optional)
  - `moc_extra_arguments`, any additional arguments to `moc` (optional). Available since v0.44.0.
+ - `uic_extra_arguments`, any additional arguments to `uic` (optional). Available since v0.49.0.
  - `dependencies`, dependency objects needed by moc. Available since v0.48.0.
- 
+
 It returns an opaque object that should be passed to a main build target.
 
 ## compile_translations (since v0.44.0)

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -116,7 +116,7 @@ class QtBaseModule:
         except Exception:
             return []
 
-    @FeatureNewKwargs('qt.preprocess', '0.48.0', ['uic_extra_arguments'])
+    @FeatureNewKwargs('qt.preprocess', '0.49.0', ['uic_extra_arguments'])
     @FeatureNewKwargs('qt.preprocess', '0.44.0', ['moc_extra_arguments'])
     @permittedKwargs({'moc_headers', 'moc_sources', 'uic_extra_arguments', 'moc_extra_arguments', 'include_directories', 'dependencies', 'ui_files', 'qresources', 'method'})
     def preprocess(self, state, args, kwargs):

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -116,11 +116,12 @@ class QtBaseModule:
         except Exception:
             return []
 
+    @FeatureNewKwargs('qt.preprocess', '0.48.0', ['uic_extra_arguments'])
     @FeatureNewKwargs('qt.preprocess', '0.44.0', ['moc_extra_arguments'])
-    @permittedKwargs({'moc_headers', 'moc_sources', 'moc_extra_arguments', 'include_directories', 'dependencies', 'ui_files', 'qresources', 'method'})
+    @permittedKwargs({'moc_headers', 'moc_sources', 'uic_extra_arguments', 'moc_extra_arguments', 'include_directories', 'dependencies', 'ui_files', 'qresources', 'method'})
     def preprocess(self, state, args, kwargs):
-        rcc_files, ui_files, moc_headers, moc_sources, moc_extra_arguments, sources, include_directories, dependencies \
-            = extract_as_list(kwargs, 'qresources', 'ui_files', 'moc_headers', 'moc_sources', 'moc_extra_arguments', 'sources', 'include_directories', 'dependencies', pop = True)
+        rcc_files, ui_files, moc_headers, moc_sources, uic_extra_arguments, moc_extra_arguments, sources, include_directories, dependencies \
+            = extract_as_list(kwargs, 'qresources', 'ui_files', 'moc_headers', 'moc_sources', 'uic_extra_arguments', 'moc_extra_arguments', 'sources', 'include_directories', 'dependencies', pop = True)
         sources += args[1:]
         method = kwargs.get('method', 'auto')
         self._detect_tools(state.environment, method)
@@ -160,8 +161,9 @@ class QtBaseModule:
         if len(ui_files) > 0:
             if not self.uic.found():
                 raise MesonException(err_msg.format('UIC', 'uic-qt' + self.qt_version))
+            arguments = uic_extra_arguments + ['-o', '@OUTPUT@', '@INPUT@']
             ui_kwargs = {'output': 'ui_@BASENAME@.h',
-                         'arguments': ['-o', '@OUTPUT@', '@INPUT@']}
+                         'arguments': arguments}
             ui_gen = build.Generator([self.uic], ui_kwargs)
             ui_output = ui_gen.process_files('Qt{} ui'.format(self.qt_version), ui_files, state)
             sources.append(ui_output)


### PR DESCRIPTION
Just like https://github.com/mesonbuild/meson/pull/2529 adds moc_extra_arguments, ui_extra_arguments would be useful to override translator function (hello gettext/i18n).

Will close #4177 