### PR TITLE
Fix incorrect feature check warning

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -520,6 +520,7 @@ def version_compare_condition_with_min(condition, minimum):
     #
     # Map versions in the constraint of the form '0.46' to '0.46.0', to embed
     # this knowledge of the meson versioning scheme.
+    condition = condition.strip()
     if re.match('^\d+.\d+$', condition):
         condition += '.0'
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2973,7 +2973,7 @@ class FailureTests(BasePlatformTests):
         # Same as above, except the meson version is now appropriate
         self.assertMesonDoesNotOutput("dict = {}",
                                       ".*WARNING.*Project targetting.*but.*",
-                                      meson_version='>= 0.47.0')
+                                      meson_version='>= 0.47')
 
     def test_using_too_recent_feature_dependency(self):
         self.assertMesonOutputs("dependency('pcap', required: false)",


### PR DESCRIPTION
Fix the special handling of `>=0.nn` constraints in `project(meson_version:)` for feature checks when the constraint version contains spaces
