### PR TITLE
Add 'clone-recursive' option for git wraps (to handle submodules)

### DIFF
--- a/docs/markdown/Wrap-dependency-system-manual.md
+++ b/docs/markdown/Wrap-dependency-system-manual.md
@@ -109,6 +109,13 @@ the end of your wrap file:
 push-url=git@git.example.com:projects/someproject.git # Supported since version 0.37.0
 ```
 
+If the git repo contains submodules, you can tell Meson to clone them
+automatically by adding the following *(since 0.48.0)*:
+
+```ini
+clone-recursive=true
+```
+
 ## Using wrapped projects
 
 To use a subproject simply do this in your top level `meson.build`.

--- a/docs/markdown/snippets/wrap_clone_recursive.md
+++ b/docs/markdown/snippets/wrap_clone_recursive.md
@@ -1,0 +1,7 @@
+## Git wraps can now clone submodules automatically
+
+To enable this, the following needs to be added to the `.wrap` file:
+
+```ini
+clone-recursive=true
+```

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -208,8 +208,12 @@ class Resolver:
                     subprocess.check_call(['git', 'checkout', revno],
                                           cwd=checkoutdir)
         else:
-            subprocess.check_call(['git', 'clone', p.get('url'),
-                                   p.get('directory')], cwd=self.subdir_root)
+            if p.values.get('clone-recursive', '').lower() == 'true':
+                subprocess.check_call(['git', 'clone', '--recursive', p.get('url'),
+                                       p.get('directory')], cwd=self.subdir_root)
+            else:
+                subprocess.check_call(['git', 'clone', p.get('url'),
+                                       p.get('directory')], cwd=self.subdir_root)
             if revno.lower() != 'head':
                 if subprocess.call(['git', 'checkout', revno], cwd=checkoutdir) != 0:
                     subprocess.check_call(['git', 'fetch', p.get('url'), revno], cwd=checkoutdir)


### PR DESCRIPTION
This causes Meson to clone the repo with the `--recursive` flag, pulling all of the submodules automatically.