### PR TITLE
Fix GCC & ICC on macOS

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1191,7 +1191,7 @@ class IntelCCompiler(IntelCompiler, CCompiler):
         default_warn_args = ['-Wall', '-w3', '-diag-disable:remark', '-Wpch-messages']
         self.warn_args = {'1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+                          '3': default_warn_args + ['-Wextra']}
 
     def get_options(self):
         opts = CCompiler.get_options(self)
@@ -1214,8 +1214,14 @@ class IntelCCompiler(IntelCompiler, CCompiler):
     def get_std_shared_lib_link_args(self):
         return ['-shared']
 
+    def get_std_shared_module_link_args(self, options):
+        if self.compiler_type.is_osx_compiler:
+            return ['-bundle', '-Wl,-undefined,dynamic_lookup']
+        return ['-shared']
+
     def has_arguments(self, args, env, code, mode):
-        return super().has_arguments(args + ['-diag-error', '10006'], env, code, mode)
+        # -diag-error 10148 is required to catch invalid -W options
+        return super().has_arguments(args + ['-diag-error', '10006', '-diag-error', '10148'], env, code, mode)
 
 
 class VisualStudioCCompiler(CCompiler):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -602,8 +602,13 @@ This is probably wrong, it should always point to the native compiler.''' % evar
                 cls = VisualStudioCCompiler if lang == 'c' else VisualStudioCPPCompiler
                 return cls(compiler, version, is_cross, exe_wrap, is_64)
             if '(ICC)' in out:
-                # TODO: add microsoft add check OSX
-                compiler_type = CompilerType.ICC_STANDARD
+                if mesonlib.for_darwin(want_cross, self):
+                    compiler_type = CompilerType.ICC_OSX
+                elif mesonlib.for_windows(want_cross, self):
+                    # TODO: fix ICC on Windows
+                    compiler_type = CompilerType.ICC_WIN
+                else:
+                    compiler_type = CompilerType.ICC_STANDARD
                 cls = IntelCCompiler if lang == 'c' else IntelCPPCompiler
                 return cls(ccache + compiler, version, compiler_type, is_cross, exe_wrap, full_version=full_version)
             if 'ARM' in out:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3111,6 +3111,10 @@ class DarwinTests(BasePlatformTests):
         testdir = os.path.join(self.common_test_dir, '4 shared')
         # Try with bitcode enabled
         out = self.init(testdir, extra_args='-Db_bitcode=true')
+        env = get_fake_env(testdir, self.builddir, self.prefix)
+        cc = env.detect_c_compiler(False)
+        if cc.id != 'clang':
+            raise unittest.SkipTest('Not using Clang on OSX')
         # Warning was printed
         self.assertRegex(out, 'WARNING:.*b_bitcode')
         # Compiler options were added

--- a/test cases/common/204 function attributes/meson.build
+++ b/test cases/common/204 function attributes/meson.build
@@ -50,8 +50,14 @@ attributes = [
   'used',
   'warn_unused_result',
   'weak',
-  'weakref',
 ]
+
+if c.get_id() != 'intel'
+  # not supported by icc as of 19.0.0
+  attributes += 'weakref'
+endif
+
+expected_result = c.get_id() != 'msvc'
 
 # These are unsupported on darwin with apple clang 9.1.0
 if host_machine.system() != 'darwin'

--- a/test cases/unit/6 std override/meson.build
+++ b/test cases/unit/6 std override/meson.build
@@ -1,10 +1,10 @@
 project('cpp std override', 'cpp',
-  default_options : ['cpp_std=c++03',
+  default_options : ['cpp_std=c++98',
                      'werror=true'])
 
 executable('plain', 'progp.cpp',
   override_options : 'cpp_std=none')
-executable('v03', 'prog03.cpp',
+executable('v98', 'prog98.cpp',
   override_options : 'werror=false')
 executable('v11', 'prog11.cpp',
   override_options : 'cpp_std=c++11')

--- a/test cases/unit/6 std override/prog98.cpp
+++ b/test cases/unit/6 std override/prog98.cpp
@@ -1,6 +1,6 @@
 #include<iostream>
 
 int main(int argc, char **argv) {
-    std::cout << "I am a c++03 test program.\n";
+    std::cout << "I am a c++98 test program.\n";
     return 0;
 }


### PR DESCRIPTION
@jpakkane @nirbheek this fixes most of the glaring bugs of GCC and ICC on macOS. The biggest problem is `has_function` on GCC, which still fails to find `alloca`, due to its tricky status as a compiler intrinsic.