### PR TITLE
Fix gtkdoc cflags

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -334,6 +334,7 @@ of the module.
 * `mkdb_args`: a list of arguments to pass to `gtkdoc-mkdb`
 * `scan_args`: a list of arguments to pass to `gtkdoc-scan`
 * `scanobjs_args`: a list of arguments to pass to `gtkdoc-scangobj`
+* `c_args`: (*Added 0.48.0*) additional compile arguments to pass
 * `src_dir`: include_directories to include
 
 This creates a `$module-doc` target that can be ran to build docs and

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -882,6 +882,7 @@ This will become a hard error in the future.''')
         rv = [inscript, pottarget, potarget]
         return ModuleReturnValue(None, rv)
 
+    @FeatureNewKwargs('gnome.gtkdoc', '0.48.0', ['c_args'])
     @FeatureNewKwargs('gnome.gtkdoc', '0.37.0', ['namespace', 'mode'])
     @permittedKwargs({'main_xml', 'main_sgml', 'src_dir', 'dependencies', 'install',
                       'install_dir', 'scan_args', 'scanobjs_args', 'gobject_typesfile',
@@ -989,7 +990,9 @@ This will become a hard error in the future.''')
     def _get_build_args(self, kwargs, state, depends):
         args = []
         deps = extract_as_list(kwargs, 'dependencies', unholder=True)
-        cflags, internal_ldflags, external_ldflags, gi_includes = \
+        cflags = OrderedSet()
+        cflags.update(mesonlib.stringlistify(kwargs.pop('c_args', [])))
+        deps_cflags, internal_ldflags, external_ldflags, gi_includes = \
             self._get_dependencies_flags(deps, state, depends, include_rpath=True)
         inc_dirs = mesonlib.extract_as_list(kwargs, 'include_directories')
         for incd in inc_dirs:
@@ -997,6 +1000,7 @@ This will become a hard error in the future.''')
                 raise MesonException(
                     'Gir include dirs should be include_directories().')
 
+        cflags.update(deps_cflags)
         cflags.update(get_include_args(inc_dirs))
         ldflags = OrderedSet()
         ldflags.update(internal_ldflags)

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -326,6 +326,7 @@ class GnomeModule(ExtensionModule):
 
         for dep in deps:
             if isinstance(dep, InternalDependency):
+                cflags.update(dep.compile_args)
                 cflags.update(get_include_args(dep.include_directories))
                 for lib in dep.libraries:
                     if hasattr(lib, 'held_object'):


### PR DESCRIPTION
There are two issues regarding compiler flags used in one of the steps of `gtkdoc` that executes `gtkdoc-scangobj`.

* compiler arguments from dependencies are ignored.
* there is no way to append custom compiler arguments.

These two commits fixes these both issues.