### PR TITLE
-Wl,--as-needed seems to break easily with mpi/fortran

### DIFF
--- a/test cases/frameworks/17 mpi/meson.build
+++ b/test cases/frameworks/17 mpi/meson.build
@@ -1,4 +1,4 @@
-project('mpi', 'c', 'cpp')
+project('mpi', 'c', 'cpp', default_options: ['b_asneeded=false'])
 
 cc = meson.get_compiler('c')
 


### PR DESCRIPTION
While this isn't solved everywhere, this seems reasonable to disable it.

On Fedora 28 we get : 
```unresolvable R_X86_64_64 relocation against symbol `mpi_fortran_argv_null_'```