### PR TITLE
Add LGTM code quality badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ build system.
 [![Travis](https://travis-ci.org/mesonbuild/meson.svg?branch=master)](https://travis-ci.org/mesonbuild/meson)
 [![Appveyor](https://ci.appveyor.com/api/projects/status/7jfaotriu8d8ncov?svg=true)](https://ci.appveyor.com/project/mesonbuild/meson)
 [![Codecov](https://codecov.io/gh/mesonbuild/meson/coverage.svg?branch=master)](https://codecov.io/gh/mesonbuild/meson/branch/master)
+[![Code Quality: Python](https://img.shields.io/lgtm/grade/python/g/mesonbuild/meson.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/mesonbuild/meson/context:python)
+[![Total Alerts](https://img.shields.io/lgtm/alerts/g/mesonbuild/meson.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/mesonbuild/meson/alerts)
 
 #### Dependencies
 


### PR DESCRIPTION
Hi there!

I thought you might be interested in adding these [LGTM code quality badges](https://lgtm.com/projects/g/mesonbuild/meson/ci/#badges) to your project, to show how you care about code quality and encourage contributors to do the same.
To get an idea of the analyses reflected by these grades, check the [alerts discovered by LGTM](https://lgtm.com/projects/g/mesonbuild/meson).

N.B.: I am on the team behind LGTM.com, I'd appreciate your feedback on this initiative, whether you're interested or not, if you find time to drop me a line. Thanks.
