### PR TITLE
i18n: replace path separator with @

### DIFF
--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -94,7 +94,7 @@ class I18nModule(ExtensionModule):
             values = mesonlib.get_filenames_templates_dict([ifile_abs], None)
             outputs = mesonlib.substitute_values([output], values)
             output = outputs[0]
-            ct = build.CustomTarget(output + '_' + state.subdir + '_merge', state.subdir, state.subproject, kwargs)
+            ct = build.CustomTarget(output + '_' + state.subdir.replace('/', '@').replace('\\', '@') + '_merge', state.subdir, state.subproject, kwargs)
         return ModuleReturnValue(ct, [ct])
 
     @FeatureNewKwargs('i18n.gettext', '0.37.0', ['preset'])

--- a/test cases/frameworks/6 gettext/data/data3/meson.build
+++ b/test cases/frameworks/6 gettext/data/data3/meson.build
@@ -1,0 +1,9 @@
+# Use filename substitution
+i18n.merge_file(
+  input: 'test.desktop.in',
+  output: 'test4.desktop',
+  type: 'desktop',
+  po_dir: '../../po',
+  install: true,
+  install_dir: join_paths(get_option('datadir'), 'applications')
+)

--- a/test cases/frameworks/6 gettext/data/data3/test.desktop.in
+++ b/test cases/frameworks/6 gettext/data/data3/test.desktop.in
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Name=Test
+GenericName=Application
+Comment=Test Application
+Type=Application
+

--- a/test cases/frameworks/6 gettext/data/meson.build
+++ b/test cases/frameworks/6 gettext/data/meson.build
@@ -26,3 +26,5 @@ i18n.merge_file(
   install: true,
   install_dir: join_paths(get_option('datadir'), 'applications')
 )
+
+subdir('data3')

--- a/test cases/frameworks/6 gettext/installed_files.txt
+++ b/test cases/frameworks/6 gettext/installed_files.txt
@@ -4,3 +4,4 @@ usr/share/locale/fi/LC_MESSAGES/intltest.mo
 usr/share/applications/test.desktop
 usr/share/applications/test2.desktop
 usr/share/applications/test3.desktop
+usr/share/applications/test4.desktop


### PR DESCRIPTION
using state.subdir will cause / to be inserted into the target name.
Replace them with __ to future-proof it.

Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>