### PR TITLE
Use a single ArgumentParser for all subcommands

### DIFF
--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -13,17 +13,13 @@
 # limitations under the License.
 
 import os
-import argparse
 from . import (coredata, mesonlib, build)
 
-def buildparser():
-    parser = argparse.ArgumentParser(prog='meson configure')
+def add_arguments(parser):
     coredata.register_builtin_arguments(parser)
-
     parser.add_argument('builddir', nargs='?', default='.')
     parser.add_argument('--clearcache', action='store_true', default=False,
                         help='Clear cached state (e.g. found dependencies)')
-    return parser
 
 
 class ConfException(mesonlib.MesonException):
@@ -149,9 +145,7 @@ class Conf:
         self.print_options('Testing options', test_options)
 
 
-def run(args):
-    args = mesonlib.expand_arguments(args)
-    options = buildparser().parse_args(args)
+def run(options):
     coredata.parse_cmd_line_options(options)
     builddir = os.path.abspath(os.path.realpath(options.builddir))
     try:

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -48,6 +48,23 @@ else:
     python_command = [sys.executable]
 meson_command = None
 
+def set_meson_command(mainfile):
+    global python_command
+    global meson_command
+    # On UNIX-like systems `meson` is a Python script
+    # On Windows `meson` and `meson.exe` are wrapper exes
+    if not mainfile.endswith('.py'):
+        meson_command = [mainfile]
+    elif os.path.isabs(mainfile) and mainfile.endswith('mesonmain.py'):
+        # Can't actually run meson with an absolute path to mesonmain.py, it must be run as -m mesonbuild.mesonmain
+        meson_command = python_command + ['-m', 'mesonbuild.mesonmain']
+    else:
+        # Either run uninstalled, or full path to meson-script.py
+        meson_command = python_command + [mainfile]
+    # We print this value for unit tests.
+    if 'MESON_COMMAND_TESTS' in os.environ:
+        mlog.log('meson_command is {!r}'.format(meson_command))
+
 def is_ascii_string(astring):
     try:
         if isinstance(astring, str):

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -253,21 +253,6 @@ def run_script_command(args):
         raise MesonException('Unknown internal command {}.'.format(cmdname))
     return cmdfunc(cmdargs)
 
-def set_meson_command(mainfile):
-    # On UNIX-like systems `meson` is a Python script
-    # On Windows `meson` and `meson.exe` are wrapper exes
-    if not mainfile.endswith('.py'):
-        mesonlib.meson_command = [mainfile]
-    elif os.path.isabs(mainfile) and mainfile.endswith('mesonmain.py'):
-        # Can't actually run meson with an absolute path to mesonmain.py, it must be run as -m mesonbuild.mesonmain
-        mesonlib.meson_command = mesonlib.python_command + ['-m', 'mesonbuild.mesonmain']
-    else:
-        # Either run uninstalled, or full path to meson-script.py
-        mesonlib.meson_command = mesonlib.python_command + [mainfile]
-    # We print this value for unit tests.
-    if 'MESON_COMMAND_TESTS' in os.environ:
-        mlog.log('meson_command is {!r}'.format(mesonlib.meson_command))
-
 def run(original_args, mainfile):
     if sys.version_info < (3, 5):
         print('Meson works correctly only with python 3.5+.')
@@ -284,7 +269,7 @@ def run(original_args, mainfile):
             mlog.error('Please download and use Python as detailed at: https://mesonbuild.com/Getting-meson.html')
         return 2
     # Set the meson command that will be used to run scripts and so on
-    set_meson_command(mainfile)
+    mesonlib.set_meson_command(mainfile)
     args = original_args[:]
     if len(args) > 0:
         # First check if we want to run a subcommand.

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -12,188 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
-import sys, stat, traceback, argparse
-import datetime
+import sys
 import os.path
-import platform
-import cProfile as profile
 
-from . import environment, interpreter, mesonlib
-from . import build
-from . import mlog, coredata
+from . import mesonlib
+from . import mlog
 from .mesonlib import MesonException
 from .environment import detect_msys2_arch
-from .wrap import WrapMode
-
-default_warning = '1'
-
-def create_parser():
-    p = argparse.ArgumentParser(prog='meson')
-    coredata.register_builtin_arguments(p)
-    p.add_argument('--cross-file', default=None,
-                   help='File describing cross compilation environment.')
-    p.add_argument('-v', '--version', action='version',
-                   version=coredata.version)
-    # See the mesonlib.WrapMode enum for documentation
-    p.add_argument('--wrap-mode', default=None,
-                   type=wrapmodetype, choices=WrapMode,
-                   help='Special wrap mode to use')
-    p.add_argument('--profile-self', action='store_true', dest='profile',
-                   help=argparse.SUPPRESS)
-    p.add_argument('--fatal-meson-warnings', action='store_true', dest='fatal_warnings',
-                   help='Make all Meson warnings fatal')
-    p.add_argument('--reconfigure', action='store_true',
-                   help='Set options and reconfigure the project. Useful when new ' +
-                        'options have been added to the project and the default value ' +
-                        'is not working.')
-    p.add_argument('builddir', nargs='?', default=None)
-    p.add_argument('sourcedir', nargs='?', default=None)
-    return p
-
-def wrapmodetype(string):
-    try:
-        return getattr(WrapMode, string)
-    except AttributeError:
-        msg = ', '.join([t.name.lower() for t in WrapMode])
-        msg = 'invalid argument {!r}, use one of {}'.format(string, msg)
-        raise argparse.ArgumentTypeError(msg)
-
-class MesonApp:
-
-    def __init__(self, options):
-        (self.source_dir, self.build_dir) = self.validate_dirs(options.builddir,
-                                                               options.sourcedir,
-                                                               options.reconfigure)
-        self.options = options
-
-    def has_build_file(self, dirname):
-        fname = os.path.join(dirname, environment.build_filename)
-        return os.path.exists(fname)
-
-    def validate_core_dirs(self, dir1, dir2):
-        if dir1 is None:
-            if dir2 is None:
-                if not os.path.exists('meson.build') and os.path.exists('../meson.build'):
-                    dir2 = '..'
-                else:
-                    raise MesonException('Must specify at least one directory name.')
-            dir1 = os.getcwd()
-        if dir2 is None:
-            dir2 = os.getcwd()
-        ndir1 = os.path.abspath(os.path.realpath(dir1))
-        ndir2 = os.path.abspath(os.path.realpath(dir2))
-        if not os.path.exists(ndir1):
-            os.makedirs(ndir1)
-        if not os.path.exists(ndir2):
-            os.makedirs(ndir2)
-        if not stat.S_ISDIR(os.stat(ndir1).st_mode):
-            raise MesonException('%s is not a directory' % dir1)
-        if not stat.S_ISDIR(os.stat(ndir2).st_mode):
-            raise MesonException('%s is not a directory' % dir2)
-        if os.path.samefile(dir1, dir2):
-            raise MesonException('Source and build directories must not be the same. Create a pristine build directory.')
-        if self.has_build_file(ndir1):
-            if self.has_build_file(ndir2):
-                raise MesonException('Both directories contain a build file %s.' % environment.build_filename)
-            return ndir1, ndir2
-        if self.has_build_file(ndir2):
-            return ndir2, ndir1
-        raise MesonException('Neither directory contains a build file %s.' % environment.build_filename)
-
-    def validate_dirs(self, dir1, dir2, reconfigure):
-        (src_dir, build_dir) = self.validate_core_dirs(dir1, dir2)
-        priv_dir = os.path.join(build_dir, 'meson-private/coredata.dat')
-        if os.path.exists(priv_dir):
-            if not reconfigure:
-                print('Directory already configured.\n'
-                      '\nJust run your build command (e.g. ninja) and Meson will regenerate as necessary.\n'
-                      'If ninja fails, run "ninja reconfigure" or "meson --reconfigure"\n'
-                      'to force Meson to regenerate.\n'
-                      '\nIf build failures persist, manually wipe your build directory to clear any\n'
-                      'stored system data.\n'
-                      '\nTo change option values, run "meson configure" instead.')
-                sys.exit(0)
-        else:
-            if reconfigure:
-                print('Directory does not contain a valid build tree:\n{}'.format(build_dir))
-                sys.exit(1)
-        return src_dir, build_dir
-
-    def check_pkgconfig_envvar(self, env):
-        curvar = os.environ.get('PKG_CONFIG_PATH', '')
-        if curvar != env.coredata.pkgconf_envvar:
-            mlog.warning('PKG_CONFIG_PATH has changed between invocations from "%s" to "%s".' %
-                         (env.coredata.pkgconf_envvar, curvar))
-            env.coredata.pkgconf_envvar = curvar
-
-    def generate(self):
-        env = environment.Environment(self.source_dir, self.build_dir, self.options)
-        mlog.initialize(env.get_log_dir(), self.options.fatal_warnings)
-        if self.options.profile:
-            mlog.set_timestamp_start(time.monotonic())
-        with mesonlib.BuildDirLock(self.build_dir):
-            self._generate(env)
-
-    def _generate(self, env):
-        mlog.debug('Build started at', datetime.datetime.now().isoformat())
-        mlog.debug('Main binary:', sys.executable)
-        mlog.debug('Python system:', platform.system())
-        mlog.log(mlog.bold('The Meson build system'))
-        self.check_pkgconfig_envvar(env)
-        mlog.log('Version:', coredata.version)
-        mlog.log('Source dir:', mlog.bold(self.source_dir))
-        mlog.log('Build dir:', mlog.bold(self.build_dir))
-        if env.is_cross_build():
-            mlog.log('Build type:', mlog.bold('cross build'))
-        else:
-            mlog.log('Build type:', mlog.bold('native build'))
-        b = build.Build(env)
-
-        intr = interpreter.Interpreter(b)
-        if env.is_cross_build():
-            mlog.log('Host machine cpu family:', mlog.bold(intr.builtin['host_machine'].cpu_family_method([], {})))
-            mlog.log('Host machine cpu:', mlog.bold(intr.builtin['host_machine'].cpu_method([], {})))
-            mlog.log('Target machine cpu family:', mlog.bold(intr.builtin['target_machine'].cpu_family_method([], {})))
-            mlog.log('Target machine cpu:', mlog.bold(intr.builtin['target_machine'].cpu_method([], {})))
-        mlog.log('Build machine cpu family:', mlog.bold(intr.builtin['build_machine'].cpu_family_method([], {})))
-        mlog.log('Build machine cpu:', mlog.bold(intr.builtin['build_machine'].cpu_method([], {})))
-        if self.options.profile:
-            fname = os.path.join(self.build_dir, 'meson-private', 'profile-interpreter.log')
-            profile.runctx('intr.run()', globals(), locals(), filename=fname)
-        else:
-            intr.run()
-        # Print all default option values that don't match the current value
-        for def_opt_name, def_opt_value, cur_opt_value in intr.get_non_matching_default_options():
-            mlog.log('Option', mlog.bold(def_opt_name), 'is:',
-                     mlog.bold(str(cur_opt_value)),
-                     '[default: {}]'.format(str(def_opt_value)))
-        try:
-            dumpfile = os.path.join(env.get_scratch_dir(), 'build.dat')
-            # We would like to write coredata as late as possible since we use the existence of
-            # this file to check if we generated the build file successfully. Since coredata
-            # includes settings, the build files must depend on it and appear newer. However, due
-            # to various kernel caches, we cannot guarantee that any time in Python is exactly in
-            # sync with the time that gets applied to any files. Thus, we dump this file as late as
-            # possible, but before build files, and if any error occurs, delete it.
-            cdf = env.dump_coredata()
-            if self.options.profile:
-                fname = 'profile-{}-backend.log'.format(intr.backend.name)
-                fname = os.path.join(self.build_dir, 'meson-private', fname)
-                profile.runctx('intr.backend.generate(intr)', globals(), locals(), filename=fname)
-            else:
-                intr.backend.generate(intr)
-            build.save(b, dumpfile)
-            # Post-conf scripts must be run after writing coredata or else introspection fails.
-            intr.backend.run_postconf_scripts()
-        except:
-            if 'cdf' in locals():
-                old_cdf = cdf + '.prev'
-                if os.path.exists(old_cdf):
-                    os.replace(old_cdf, cdf)
-                else:
-                    os.unlink(cdf)
-            raise
 
 def run_script_command(args):
     cmdname = args[0]
@@ -268,9 +93,28 @@ def run(original_args, mainfile):
         else:
             mlog.error('Please download and use Python as detailed at: https://mesonbuild.com/Getting-meson.html')
         return 2
+
     # Set the meson command that will be used to run scripts and so on
     mesonlib.set_meson_command(mainfile)
+
     args = original_args[:]
+
+    # Special handling of internal commands called from backends, they don't
+    # need to go through argparse.
+    if len(args) >= 2 and args[0] == '--internal':
+        if args[1] == 'regenerate':
+            # Rewrite "meson --internal regenerate" command line to
+            # "meson --reconfigure"
+            args = ['--reconfigure'] + args[2:]
+        else:
+            script = args[1]
+            try:
+                sys.exit(run_script_command(args[1:]))
+            except MesonException as e:
+                mlog.error('\nError in {} helper script:'.format(script))
+                mlog.exception(e)
+                sys.exit(1)
+
     if len(args) > 0:
         # First check if we want to run a subcommand.
         cmd_name = args[0]
@@ -285,9 +129,6 @@ def run(original_args, mainfile):
         if cmd_name == 'test':
             from . import mtest
             return mtest.run(remaining_args)
-        elif cmd_name == 'setup':
-            args = remaining_args
-            # FALLTHROUGH like it's 1972.
         elif cmd_name == 'install':
             from . import minstall
             return minstall.run(remaining_args)
@@ -316,54 +157,13 @@ def run(original_args, mainfile):
             sys.argv[1:] = remaining_args[1:]
             runpy.run_path(script_file, run_name='__main__')
             sys.exit(0)
-
-    # No special command? Do the basic setup/reconf.
-    if len(args) >= 2 and args[0] == '--internal':
-        if args[1] == 'regenerate':
-            # Rewrite "meson --internal regenerate" command line to
-            # "meson --reconfigure"
-            args = ['--reconfigure'] + args[2:]
         else:
-            script = args[1]
-            try:
-                sys.exit(run_script_command(args[1:]))
-            except MesonException as e:
-                mlog.error('\nError in {} helper script:'.format(script))
-                mlog.exception(e)
-                sys.exit(1)
-
-    parser = create_parser()
-
-    args = mesonlib.expand_arguments(args)
-    options = parser.parse_args(args)
-    coredata.parse_cmd_line_options(options)
-    try:
-        app = MesonApp(options)
-    except Exception as e:
-        # Log directory does not exist, so just print
-        # to stdout.
-        print('Error during basic setup:\n')
-        print(e)
-        return 1
-    try:
-        app.generate()
-    except Exception as e:
-        if isinstance(e, MesonException):
-            mlog.exception(e)
-            # Path to log file
-            mlog.shutdown()
-            logfile = os.path.join(app.build_dir, environment.Environment.log_dir, mlog.log_fname)
-            mlog.log("\nA full log can be found at", mlog.bold(logfile))
-            if os.environ.get('MESON_FORCE_BACKTRACE'):
-                raise
-            return 1
-        else:
-            if os.environ.get('MESON_FORCE_BACKTRACE'):
-                raise
-            traceback.print_exc()
-            return 2
-    finally:
-        mlog.shutdown()
+            # If cmd_name is not a known command, assume user wants to run the
+            # setup command.
+            from . import msetup
+            if cmd_name != 'setup':
+                remaining_args = args
+            return msetup.run(remaining_args)
 
     return 0
 

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -14,7 +14,7 @@
 
 """Code that creates simple startup projects."""
 
-import os, sys, argparse, re, shutil, subprocess
+import os, sys, re, shutil, subprocess
 from glob import glob
 from mesonbuild import mesonlib
 from mesonbuild.environment import detect_ninja
@@ -425,8 +425,7 @@ def create_meson_build(options):
     open('meson.build', 'w').write(content)
     print('Generated meson.build file:\n\n' + content)
 
-def run(args):
-    parser = argparse.ArgumentParser(prog='meson')
+def add_arguments(parser):
     parser.add_argument("srcfiles", metavar="sourcefile", nargs="*",
                         help="source files. default: all recognized files in current directory")
     parser.add_argument("-n", "--name", help="project name. default: name of current directory")
@@ -441,7 +440,8 @@ def run(args):
     parser.add_argument('--type', default='executable',
                         choices=['executable', 'library'])
     parser.add_argument('--version', default='0.1')
-    options = parser.parse_args(args)
+
+def run(options):
     if len(glob('*')) == 0:
         autodetect_options(options, sample=True)
         if not options.language:

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -14,7 +14,6 @@
 
 import sys, pickle, os, shutil, subprocess, gzip, errno
 import shlex
-import argparse
 from glob import glob
 from .scripts import depfixer
 from .scripts import destdir_join
@@ -33,15 +32,13 @@ build definitions so that it will not break when the change happens.'''
 
 selinux_updates = []
 
-def buildparser():
-    parser = argparse.ArgumentParser(prog='meson install')
+def add_arguments(parser):
     parser.add_argument('-C', default='.', dest='wd',
                         help='directory to cd into before running')
     parser.add_argument('--no-rebuild', default=False, action='store_true',
                         help='Do not rebuild before installing.')
     parser.add_argument('--only-changed', default=False, action='store_true',
                         help='Only overwrite files that are older than the copied file.')
-    return parser
 
 class DirMaker:
     def __init__(self, lf):
@@ -501,9 +498,7 @@ class Installer:
                     else:
                         raise
 
-def run(args):
-    parser = buildparser()
-    opts = parser.parse_args(args)
+def run(opts):
     datafilename = 'meson-private/install.dat'
     private_dir = os.path.dirname(datafilename)
     log_dir = os.path.join(private_dir, '../meson-logs')
@@ -520,6 +515,3 @@ def run(args):
         append_to_log(lf, '# Does not contain files installed by custom scripts.')
         installer.do_install(datafilename)
     return 0
-
-if __name__ == '__main__':
-    sys.exit(run(sys.argv[1:]))

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -23,12 +23,10 @@ import json
 from . import build, mtest, coredata as cdata
 from . import mesonlib
 from .backend import ninjabackend
-import argparse
 import sys, os
 import pathlib
 
-def buildparser():
-    parser = argparse.ArgumentParser(prog='meson introspect')
+def add_arguments(parser):
     parser.add_argument('--targets', action='store_true', dest='list_targets', default=False,
                         help='List top level targets.')
     parser.add_argument('--installed', action='store_true', dest='list_installed', default=False,
@@ -48,7 +46,6 @@ def buildparser():
     parser.add_argument('--projectinfo', action='store_true', dest='projectinfo', default=False,
                         help='Information about projects.')
     parser.add_argument('builddir', nargs='?', default='.', help='The build directory')
-    return parser
 
 def determine_installed_path(target, installdata):
     install_target = None
@@ -206,9 +203,8 @@ def list_projinfo(builddata):
     result['subprojects'] = subprojects
     print(json.dumps(result))
 
-def run(args):
+def run(options):
     datadir = 'meson-private'
-    options = buildparser().parse_args(args)
     if options.builddir is not None:
         datadir = os.path.join(options.builddir, datadir)
     if not os.path.isdir(datadir):

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -1,0 +1,227 @@
+# Copyright 2016-2018 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import sys, stat
+import datetime
+import os.path
+import platform
+import cProfile as profile
+import argparse
+import traceback
+
+from . import environment, interpreter, mesonlib
+from . import build
+from . import mlog, coredata
+from .mesonlib import MesonException
+from .wrap import WrapMode
+
+def buildparser():
+    parser = argparse.ArgumentParser(prog='meson')
+    coredata.register_builtin_arguments(parser)
+    parser.add_argument('--cross-file', default=None,
+                        help='File describing cross compilation environment.')
+    parser.add_argument('-v', '--version', action='version',
+                        version=coredata.version)
+    # See the mesonlib.WrapMode enum for documentation
+    parser.add_argument('--wrap-mode', default=None,
+                        type=wrapmodetype, choices=WrapMode,
+                        help='Special wrap mode to use')
+    parser.add_argument('--profile-self', action='store_true', dest='profile',
+                        help=argparse.SUPPRESS)
+    parser.add_argument('--fatal-meson-warnings', action='store_true', dest='fatal_warnings',
+                        help='Make all Meson warnings fatal')
+    parser.add_argument('--reconfigure', action='store_true',
+                        help='Set options and reconfigure the project. Useful when new ' +
+                             'options have been added to the project and the default value ' +
+                             'is not working.')
+    parser.add_argument('builddir', nargs='?', default=None)
+    parser.add_argument('sourcedir', nargs='?', default=None)
+    return parser
+
+def wrapmodetype(string):
+    try:
+        return getattr(WrapMode, string)
+    except AttributeError:
+        msg = ', '.join([t.name.lower() for t in WrapMode])
+        msg = 'invalid argument {!r}, use one of {}'.format(string, msg)
+        raise argparse.ArgumentTypeError(msg)
+
+class MesonApp:
+    def __init__(self, options):
+        (self.source_dir, self.build_dir) = self.validate_dirs(options.builddir,
+                                                               options.sourcedir,
+                                                               options.reconfigure)
+        self.options = options
+
+    def has_build_file(self, dirname):
+        fname = os.path.join(dirname, environment.build_filename)
+        return os.path.exists(fname)
+
+    def validate_core_dirs(self, dir1, dir2):
+        if dir1 is None:
+            if dir2 is None:
+                if not os.path.exists('meson.build') and os.path.exists('../meson.build'):
+                    dir2 = '..'
+                else:
+                    raise MesonException('Must specify at least one directory name.')
+            dir1 = os.getcwd()
+        if dir2 is None:
+            dir2 = os.getcwd()
+        ndir1 = os.path.abspath(os.path.realpath(dir1))
+        ndir2 = os.path.abspath(os.path.realpath(dir2))
+        if not os.path.exists(ndir1):
+            os.makedirs(ndir1)
+        if not os.path.exists(ndir2):
+            os.makedirs(ndir2)
+        if not stat.S_ISDIR(os.stat(ndir1).st_mode):
+            raise MesonException('%s is not a directory' % dir1)
+        if not stat.S_ISDIR(os.stat(ndir2).st_mode):
+            raise MesonException('%s is not a directory' % dir2)
+        if os.path.samefile(dir1, dir2):
+            raise MesonException('Source and build directories must not be the same. Create a pristine build directory.')
+        if self.has_build_file(ndir1):
+            if self.has_build_file(ndir2):
+                raise MesonException('Both directories contain a build file %s.' % environment.build_filename)
+            return ndir1, ndir2
+        if self.has_build_file(ndir2):
+            return ndir2, ndir1
+        raise MesonException('Neither directory contains a build file %s.' % environment.build_filename)
+
+    def validate_dirs(self, dir1, dir2, reconfigure):
+        (src_dir, build_dir) = self.validate_core_dirs(dir1, dir2)
+        priv_dir = os.path.join(build_dir, 'meson-private/coredata.dat')
+        if os.path.exists(priv_dir):
+            if not reconfigure:
+                print('Directory already configured.\n'
+                      '\nJust run your build command (e.g. ninja) and Meson will regenerate as necessary.\n'
+                      'If ninja fails, run "ninja reconfigure" or "meson --reconfigure"\n'
+                      'to force Meson to regenerate.\n'
+                      '\nIf build failures persist, manually wipe your build directory to clear any\n'
+                      'stored system data.\n'
+                      '\nTo change option values, run "meson configure" instead.')
+                sys.exit(0)
+        else:
+            if reconfigure:
+                print('Directory does not contain a valid build tree:\n{}'.format(build_dir))
+                sys.exit(1)
+        return src_dir, build_dir
+
+    def check_pkgconfig_envvar(self, env):
+        curvar = os.environ.get('PKG_CONFIG_PATH', '')
+        if curvar != env.coredata.pkgconf_envvar:
+            mlog.warning('PKG_CONFIG_PATH has changed between invocations from "%s" to "%s".' %
+                         (env.coredata.pkgconf_envvar, curvar))
+            env.coredata.pkgconf_envvar = curvar
+
+    def generate(self):
+        env = environment.Environment(self.source_dir, self.build_dir, self.options)
+        mlog.initialize(env.get_log_dir(), self.options.fatal_warnings)
+        if self.options.profile:
+            mlog.set_timestamp_start(time.monotonic())
+        with mesonlib.BuildDirLock(self.build_dir):
+            self._generate(env)
+
+    def _generate(self, env):
+        mlog.debug('Build started at', datetime.datetime.now().isoformat())
+        mlog.debug('Main binary:', sys.executable)
+        mlog.debug('Python system:', platform.system())
+        mlog.log(mlog.bold('The Meson build system'))
+        self.check_pkgconfig_envvar(env)
+        mlog.log('Version:', coredata.version)
+        mlog.log('Source dir:', mlog.bold(self.source_dir))
+        mlog.log('Build dir:', mlog.bold(self.build_dir))
+        if env.is_cross_build():
+            mlog.log('Build type:', mlog.bold('cross build'))
+        else:
+            mlog.log('Build type:', mlog.bold('native build'))
+        b = build.Build(env)
+
+        intr = interpreter.Interpreter(b)
+        if env.is_cross_build():
+            mlog.log('Host machine cpu family:', mlog.bold(intr.builtin['host_machine'].cpu_family_method([], {})))
+            mlog.log('Host machine cpu:', mlog.bold(intr.builtin['host_machine'].cpu_method([], {})))
+            mlog.log('Target machine cpu family:', mlog.bold(intr.builtin['target_machine'].cpu_family_method([], {})))
+            mlog.log('Target machine cpu:', mlog.bold(intr.builtin['target_machine'].cpu_method([], {})))
+        mlog.log('Build machine cpu family:', mlog.bold(intr.builtin['build_machine'].cpu_family_method([], {})))
+        mlog.log('Build machine cpu:', mlog.bold(intr.builtin['build_machine'].cpu_method([], {})))
+        if self.options.profile:
+            fname = os.path.join(self.build_dir, 'meson-private', 'profile-interpreter.log')
+            profile.runctx('intr.run()', globals(), locals(), filename=fname)
+        else:
+            intr.run()
+        # Print all default option values that don't match the current value
+        for def_opt_name, def_opt_value, cur_opt_value in intr.get_non_matching_default_options():
+            mlog.log('Option', mlog.bold(def_opt_name), 'is:',
+                     mlog.bold(str(cur_opt_value)),
+                     '[default: {}]'.format(str(def_opt_value)))
+        try:
+            dumpfile = os.path.join(env.get_scratch_dir(), 'build.dat')
+            # We would like to write coredata as late as possible since we use the existence of
+            # this file to check if we generated the build file successfully. Since coredata
+            # includes settings, the build files must depend on it and appear newer. However, due
+            # to various kernel caches, we cannot guarantee that any time in Python is exactly in
+            # sync with the time that gets applied to any files. Thus, we dump this file as late as
+            # possible, but before build files, and if any error occurs, delete it.
+            cdf = env.dump_coredata()
+            if self.options.profile:
+                fname = 'profile-{}-backend.log'.format(intr.backend.name)
+                fname = os.path.join(self.build_dir, 'meson-private', fname)
+                profile.runctx('intr.backend.generate(intr)', globals(), locals(), filename=fname)
+            else:
+                intr.backend.generate(intr)
+            build.save(b, dumpfile)
+            # Post-conf scripts must be run after writing coredata or else introspection fails.
+            intr.backend.run_postconf_scripts()
+        except:
+            if 'cdf' in locals():
+                old_cdf = cdf + '.prev'
+                if os.path.exists(old_cdf):
+                    os.replace(old_cdf, cdf)
+                else:
+                    os.unlink(cdf)
+            raise
+
+def run(args):
+    args = mesonlib.expand_arguments(args)
+    options = buildparser().parse_args(args)
+    coredata.parse_cmd_line_options(options)
+    try:
+        app = MesonApp(options)
+    except Exception as e:
+        # Log directory does not exist, so just print
+        # to stdout.
+        print('Error during basic setup:\n')
+        print(e)
+        return 1
+    try:
+        app.generate()
+    except Exception as e:
+        if isinstance(e, MesonException):
+            mlog.exception(e)
+            # Path to log file
+            mlog.shutdown()
+            logfile = os.path.join(app.build_dir, environment.Environment.log_dir, mlog.log_fname)
+            mlog.log("\nA full log can be found at", mlog.bold(logfile))
+            if os.environ.get('MESON_FORCE_BACKTRACE'):
+                raise
+            return 1
+        else:
+            if os.environ.get('MESON_FORCE_BACKTRACE'):
+                raise
+            traceback.print_exc()
+            return 2
+    finally:
+        mlog.shutdown()
+    return 0

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -60,8 +60,7 @@ def determine_worker_count():
             num_workers = 1
     return num_workers
 
-def buildparser():
-    parser = argparse.ArgumentParser(prog='meson test')
+def add_arguments(parser):
     parser.add_argument('--repeat', default=1, dest='repeat', type=int,
                         help='Number of times to run the tests.')
     parser.add_argument('--no-rebuild', default=False, action='store_true',
@@ -102,7 +101,6 @@ def buildparser():
                         help='Arguments to pass to the specified test(s) or all tests')
     parser.add_argument('args', nargs='*',
                         help='Optional list of tests to run')
-    return parser
 
 
 def returncode_to_status(retcode):
@@ -737,9 +735,7 @@ def rebuild_all(wd):
 
     return True
 
-def run(args):
-    options = buildparser().parse_args(args)
-
+def run(options):
     if options.benchmark:
         options.num_processes = 1
 
@@ -784,3 +780,9 @@ def run(args):
         else:
             print(e)
         return 1
+
+def run_with_args(args):
+    parser = argparse.ArgumentParser(prog='meson test')
+    add_arguments(parser)
+    options = parser.parse_args(args)
+    return run(options)

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -27,11 +27,8 @@ import mesonbuild.astinterpreter
 from mesonbuild.mesonlib import MesonException
 from mesonbuild import mlog
 import sys, traceback
-import argparse
 
-def buildparser():
-    parser = argparse.ArgumentParser(prog='meson rewrite')
-
+def add_arguments(parser):
     parser.add_argument('--sourcedir', default='.',
                         help='Path to source directory.')
     parser.add_argument('--target', default=None,
@@ -39,10 +36,8 @@ def buildparser():
     parser.add_argument('--filename', default=None,
                         help='Name of source file to add or remove to target.')
     parser.add_argument('commands', nargs='+')
-    return parser
 
-def run(args):
-    options = buildparser().parse_args(args)
+def run(options):
     if options.target is None or options.filename is None:
         sys.exit("Must specify both target and filename.")
     print('This tool is highly experimental, use with care.')

--- a/mesonbuild/wrap/wraptool.py
+++ b/mesonbuild/wrap/wraptool.py
@@ -16,7 +16,6 @@ import json
 import sys, os
 import configparser
 import shutil
-import argparse
 
 from glob import glob
 
@@ -208,9 +207,6 @@ def status(options):
         else:
             print('', name, 'not up to date. Have %s %d, but %s %d is available.' % (current_branch, current_revision, latest_branch, latest_revision))
 
-def run(args):
-    parser = argparse.ArgumentParser(prog='wraptool')
-    add_arguments(parser)
-    options = parser.parse_args(args)
+def run(options):
     options.wrap_func(options)
     return 0

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -247,12 +247,12 @@ def run_test_inprocess(testdir):
     os.chdir(testdir)
     test_log_fname = Path('meson-logs', 'testlog.txt')
     try:
-        returncode_test = mtest.run(['--no-rebuild'])
+        returncode_test = mtest.run_with_args(['--no-rebuild'])
         if test_log_fname.exists():
             test_log = test_log_fname.open(errors='ignore').read()
         else:
             test_log = ''
-        returncode_benchmark = mtest.run(['--no-rebuild', '--benchmark', '--logbase', 'benchmarklog'])
+        returncode_benchmark = mtest.run_with_args(['--no-rebuild', '--benchmark', '--logbase', 'benchmarklog'])
     finally:
         sys.stdout = old_stdout
         sys.stderr = old_stderr

--- a/run_tests.py
+++ b/run_tests.py
@@ -181,7 +181,7 @@ def run_mtest_inprocess(commandlist):
     old_stderr = sys.stderr
     sys.stderr = mystderr = StringIO()
     try:
-        returncode = mtest.run(commandlist)
+        returncode = mtest.run_with_args(commandlist)
     finally:
         sys.stdout = old_stdout
         sys.stderr = old_stderr


### PR DESCRIPTION
This has the adventage that "meson --help" shows a list of all commands,
making them discoverable. This also reduce the manual parsing of
arguments to the strict minimum needed for backward compatibility.