### PR TITLE
clarify old behaviour of set_variable in documentation

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1172,6 +1172,9 @@ and subdirectory the target was defined in, respectively.
 Assigns a value to the given variable name. Calling
 `set_variable('foo', bar)` is equivalent to `foo = bar`.
 
+**Note:** Prior to v0.46.1, the `value` parameter could not be an
+array type, due to flattening of the function parameters.
+
 ### shared_library()
 
 ``` meson


### PR DESCRIPTION
Thanks to PR #3483, set_variable can be used to assign array values.
However, the fact that it cannot be used for arrays before 0.46.1 needs
a mention in the documentation, since otherwise users can get unexpected
dependencies on later meson versions.