### PR TITLE
native file support

### DIFF
--- a/docs/markdown/Native-environments.md
+++ b/docs/markdown/Native-environments.md
@@ -1,0 +1,76 @@
+---
+short-description: Setting up native compilation
+...
+
+# Persistent native environments
+
+New in 0.49.0
+
+Meson has [cross files for describing cross compilation environments](Cross-compilation.md),
+for describing native environments it has equivalent "native files".
+
+Natives describe the *build machine*, and can be used to override properties of
+non-cross builds, as well as properties that are marked as "native" in a cross
+build.
+
+There are a couple of reasons you might want to use a native file to keep a
+persistent environment:
+
+* To build with a non-default native tool chain (such as clang instead of gcc)
+* To use a non-default version of another binary, such as yacc, or llvm-config
+
+
+## Changing native file settings
+
+All of the rules about cross files and changed settings apply to native files
+as well, see [here](Cross-compilation.md#Changing-cross-file-settings)
+
+
+## Defining the environment
+
+### Binaries
+
+Currently the only use of native files is to override native binaries. This
+includes the compilers and binaries collected with `find_program`, and those
+used by dependencies that use a config-tool instead of pkgconfig for detection,
+like `llvm-config`
+
+```ini
+[binaries]
+c = '/usr/local/bin/clang'
+cpp = '/usr/local/bin/clang++'
+rust = '/usr/local/bin/rust'
+llvm-conifg = '/usr/local/llvm-svn/bin/llvm-config'
+```
+
+## Loading multiple native files
+
+Unlike cross file, native files allow layering. More than one native file can be
+loaded, with values from a previous file being overridden by the next. The
+intention of this is not overriding, but to allow composing native files.
+
+For example, if there is a project using C and C++, python 3.4-3.7, and LLVM
+5-7, and it needs to build with clang 5, 6, and 7, and gcc 5.x, 6.x, and 7.x;
+expressing all of these configurations in monolithic configurations would
+result in 81 different native files. By layering them, it can be expressed by
+just 12 native files.
+
+
+## Native file locations
+
+Like cross files, native files may be installed to user or system wide
+locations, defined as:
+  - $XDG_DATA_DIRS/meson/native 
+    (/usr/local/share/meson/native:/usr/share/meson/native if $XDG_DATA_DIRS is
+    undefined)
+  - $XDG_DATA_HOME/meson/native ($HOME/.local/share/meson/native if
+    $XDG_DATA_HOME is undefined)
+
+The order of locations tried is as follows:
+ - A file relative to the local dir
+ - The user local location
+ - The system wide locations in order
+
+These files are not intended to be shipped by distributions, unless they are
+specifically for distribution packaging, they are mainly intended for
+developers.

--- a/docs/markdown/snippets/native_files.md
+++ b/docs/markdown/snippets/native_files.md
@@ -1,0 +1,15 @@
+## Native config files
+
+Native files are the counterpart to cross files, and allow specifying
+information about the build machine, both when cross compiling and when not.
+
+Currently the native files only allow specifying the names of binaries, similar
+to the cross file, for example:
+
+```ini
+[binaries]
+llvm-config = "/opt/llvm-custom/bin/llvm-config"
+```
+
+Will override the llvm-config used for *native* binaries. Targets for the host
+machine will continue to use the cross file.

--- a/docs/sitemap.txt
+++ b/docs/sitemap.txt
@@ -9,6 +9,7 @@ index.md
 		Using-with-Visual-Studio.md
 		Meson-sample.md
 		Syntax.md
+		Native-environments.md
 		Build-targets.md
 		Include-directories.md
 		Installing.md

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -399,6 +399,8 @@ class ConfigToolDependency(ExternalDependency):
                              'Falling back to searching PATH. This may find a '
                              'native version of {0}!'.format(self.tool_name))
                 tools = self.tools
+        elif self.tool_name in self.env.config_info.binaries:
+            tools = [self.env.config_info.binaries[self.tool_name]]
         else:
             tools = self.tools
 

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -500,7 +500,8 @@ class PkgConfigDependency(ExternalDependency):
                 if self.required:
                     raise DependencyException('Pkg-config binary missing from cross file')
             else:
-                potential_pkgbin = ExternalProgram.from_cross_info(environment.cross_info, 'pkgconfig')
+                potential_pkgbin = ExternalProgram.from_bin_list(
+                    environment.cross_info.config['binaries'], 'pkgconfig')
                 if potential_pkgbin.found():
                     self.pkgbin = potential_pkgbin
                 else:
@@ -1076,10 +1077,10 @@ class ExternalProgram:
         return ' '.join(self.command)
 
     @staticmethod
-    def from_cross_info(cross_info, name):
-        if name not in cross_info.config['binaries']:
+    def from_bin_list(bins, name):
+        if name not in bins:
             return NonExistingExternalProgram()
-        command = cross_info.config['binaries'][name]
+        command = bins[name]
         if not isinstance(command, (list, str)):
             raise MesonException('Invalid type {!r} for binary {!r} in cross file'
                                  ''.format(command, name))

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1241,8 +1241,8 @@ class ExternalProgram:
 class NonExistingExternalProgram(ExternalProgram):
     "A program that will never exist"
 
-    def __init__(self):
-        self.name = 'nonexistingprogram'
+    def __init__(self, name='nonexistingprogram'):
+        self.name = name
         self.command = [None]
         self.path = None
 

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -303,7 +303,7 @@ class QtBaseDependency(ExternalDependency):
         # Even when cross-compiling, if a cross-info qmake is not specified, we
         # fallback to using the qmake in PATH because that's what we used to do
         if self.env.is_cross_build() and 'qmake' in self.env.cross_info.config['binaries']:
-            return ExternalProgram.from_cross_info(self.env.cross_info, 'qmake')
+            return ExternalProgram.from_bin_list(self.env.cross_info.config['binaries'], 'qmake')
         return ExternalProgram(qmake, silent=True)
 
     def _qmake_detect(self, mods, kwargs):

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -30,7 +30,7 @@ from ..mesonlib import (
 from ..environment import detect_cpu
 
 from .base import DependencyException, DependencyMethods
-from .base import ExternalDependency, ExternalProgram
+from .base import ExternalDependency, ExternalProgram, NonExistingExternalProgram
 from .base import ExtraFrameworkDependency, PkgConfigDependency
 from .base import ConfigToolDependency
 
@@ -230,21 +230,46 @@ class QtBaseDependency(ExternalDependency):
             self.from_text = mlog.format_list(methods)
             self.version = None
 
-    def compilers_detect(self):
+    def compilers_detect(self, interp_obj):
         "Detect Qt (4 or 5) moc, uic, rcc in the specified bindir or in PATH"
-        if self.bindir or for_windows(self.env.is_cross_build(), self.env):
-            moc = ExternalProgram(os.path.join(self.bindir, 'moc'), silent=True)
-            uic = ExternalProgram(os.path.join(self.bindir, 'uic'), silent=True)
-            rcc = ExternalProgram(os.path.join(self.bindir, 'rcc'), silent=True)
-            lrelease = ExternalProgram(os.path.join(self.bindir, 'lrelease'), silent=True)
-        else:
-            # We don't accept unsuffixed 'moc', 'uic', and 'rcc' because they
-            # are sometimes older, or newer versions.
-            moc = ExternalProgram('moc-' + self.name, silent=True)
-            uic = ExternalProgram('uic-' + self.name, silent=True)
-            rcc = ExternalProgram('rcc-' + self.name, silent=True)
-            lrelease = ExternalProgram('lrelease-' + self.name, silent=True)
-        return moc, uic, rcc, lrelease
+        # It is important that this list does not change order as the order of
+        # the returned ExternalPrograms will change as well
+        bins = ['moc', 'uic', 'rcc', 'lrelease']
+        found = {b: NonExistingExternalProgram(name='{}-{}'.format(b, self.name))
+                 for b in bins}
+
+        def gen_bins():
+            for b in bins:
+                yield '{}-{}'.format(b, self.name), b, False
+                yield b, b, self.required
+
+        for b, name, required in gen_bins():
+            if found[name].found():
+                continue
+
+            # prefer the <tool>-qt<version> of the tool to the plain one, as we
+            # don't know what the unsuffixed one points to without calling it.
+            p = interp_obj.find_program_impl([b], silent=True, required=required).held_object
+            if not p.found():
+                continue
+
+            if b.startswith('lrelease'):
+                arg = ['-version']
+            elif mesonlib.version_compare(self.version, '>= 5'):
+                arg = ['--version']
+            else:
+                arg = ['-v']
+
+            # Ensure that the version of qt and each tool are the same
+            _, out, err = mesonlib.Popen_safe(p.get_command() + arg)
+            if b.startswith('lrelease') or not self.version.startswith('4'):
+                care = out
+            else:
+                care = err
+            if mesonlib.version_compare(self.version, '== {}'.format(care.split(' ')[-1])):
+                found[name] = p
+
+        return tuple([found[b] for b in bins])
 
     def _pkgconfig_detect(self, mods, kwargs):
         # We set the value of required to False so that we can try the
@@ -302,8 +327,15 @@ class QtBaseDependency(ExternalDependency):
     def _find_qmake(self, qmake):
         # Even when cross-compiling, if a cross-info qmake is not specified, we
         # fallback to using the qmake in PATH because that's what we used to do
-        if self.env.is_cross_build() and 'qmake' in self.env.cross_info.config['binaries']:
-            return ExternalProgram.from_bin_list(self.env.cross_info.config['binaries'], 'qmake')
+        if self.env.is_cross_build():
+            if 'qmake' in self.env.cross_info.config['binaries']:
+                return ExternalProgram.from_bin_list(self.env.cross_info.config['binaries'], 'qmake')
+        elif self.env.config_info:
+            # Prefer suffixed to unsuffixed version
+            p = ExternalProgram.from_bin_list(self.env.config_info.binaries, 'qmake-' + self.name)
+            if p.found():
+                return p
+            return ExternalProgram.from_bin_list(self.env.config_info.binaries, 'qmake')
         return ExternalProgram(qmake, silent=True)
 
     def _qmake_detect(self, mods, kwargs):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -352,6 +352,12 @@ class Environment:
             self.cross_info = None
         self.machines.default_missing()
 
+        if self.coredata.config_files:
+            self.config_info = coredata.ConfigData(
+                coredata.load_configs(self.coredata.config_files))
+        else:
+            self.config_info = coredata.ConfigData()
+
         self.cmd_line_options = options.cmd_line_options.copy()
 
         # List of potential compilers.

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -340,7 +340,8 @@ class Environment:
             self.cross_info = CrossBuildInfo(self.coredata.cross_file)
             if 'exe_wrapper' in self.cross_info.config['binaries']:
                 from .dependencies import ExternalProgram
-                self.exe_wrapper = ExternalProgram.from_cross_info(self.cross_info, 'exe_wrapper')
+                self.exe_wrapper = ExternalProgram.from_bin_list(
+                    self.cross_info.config['binaries'], 'exe_wrapper')
             if 'host_machine' in self.cross_info.config:
                 self.machines.host = MachineInfo.from_literal(
                     self.cross_info.config['host_machine'])

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2757,7 +2757,7 @@ external dependencies (including libraries) must go to "dependencies".''')
                 continue # Always points to a local (i.e. self generated) file.
             if not isinstance(p, str):
                 raise InterpreterException('Executable name must be a string')
-            prog = ExternalProgram.from_cross_info(cross_info, p)
+            prog = ExternalProgram.from_bin_list(bins, p)
             if prog.found():
                 return ExternalProgramHolder(prog)
         return None

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -480,7 +480,9 @@ class PythonModule(ExtensionModule):
         if len(args) > 1:
             raise InvalidArguments('find_installation takes zero or one positional argument.')
 
-        if args:
+        if 'python' in state.environment.config_info.binaries:
+            name_or_path = state.environment.config_info.binaries['python']
+        elif args:
             name_or_path = args[0]
             if not isinstance(name_or_path, str):
                 raise InvalidArguments('find_installation argument must be a string.')

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -48,7 +48,10 @@ class Python3Module(ExtensionModule):
 
     @noKwargs
     def find_python(self, state, args, kwargs):
-        py3 = dependencies.ExternalProgram('python3', mesonlib.python_command, silent=True)
+        options = [state.environment.config_info.binaries.get('python3')]
+        if not options[0]:  # because this would be [None]
+            options = ['python3', mesonlib.python_command]
+        py3 = dependencies.ExternalProgram(*options, silent=True)
         return ModuleReturnValue(py3, [py3])
 
     @noKwargs

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -18,7 +18,7 @@ from .. import build
 from ..mesonlib import MesonException, Popen_safe, extract_as_list, File
 from ..dependencies import Dependency, Qt4Dependency, Qt5Dependency
 import xml.etree.ElementTree as ET
-from . import ModuleReturnValue, get_include_args
+from . import ModuleReturnValue, get_include_args, ExtensionModule
 from ..interpreterbase import permittedKwargs, FeatureNewKwargs
 
 _QT_DEPS_LUT = {
@@ -27,10 +27,11 @@ _QT_DEPS_LUT = {
 }
 
 
-class QtBaseModule:
+class QtBaseModule(ExtensionModule):
     tools_detected = False
 
-    def __init__(self, qt_version=5):
+    def __init__(self, interpreter, qt_version=5):
+        ExtensionModule.__init__(self, interpreter)
         self.qt_version = qt_version
 
     def _detect_tools(self, env, method):
@@ -43,7 +44,7 @@ class QtBaseModule:
         kwargs = {'required': 'true', 'modules': 'Core', 'silent': 'true', 'method': method}
         qt = _QT_DEPS_LUT[self.qt_version](env, kwargs)
         # Get all tools and then make sure that they are the right version
-        self.moc, self.uic, self.rcc, self.lrelease = qt.compilers_detect()
+        self.moc, self.uic, self.rcc, self.lrelease = qt.compilers_detect(self.interpreter)
         # Moc, uic and rcc write their version strings to stderr.
         # Moc and rcc return a non-zero result when doing so.
         # What kind of an idiot thought that was a good idea?

--- a/mesonbuild/modules/qt4.py
+++ b/mesonbuild/modules/qt4.py
@@ -14,14 +14,13 @@
 
 from .. import mlog
 from .qt import QtBaseModule
-from . import ExtensionModule
 
 
-class Qt4Module(ExtensionModule, QtBaseModule):
+class Qt4Module(QtBaseModule):
 
     def __init__(self, interpreter):
-        QtBaseModule.__init__(self, qt_version=4)
-        ExtensionModule.__init__(self, interpreter)
+        QtBaseModule.__init__(self, interpreter, qt_version=4)
+
 
 def initialize(*args, **kwargs):
     mlog.warning('rcc dependencies will not work properly until this upstream issue is fixed:',

--- a/mesonbuild/modules/qt5.py
+++ b/mesonbuild/modules/qt5.py
@@ -14,14 +14,13 @@
 
 from .. import mlog
 from .qt import QtBaseModule
-from . import ExtensionModule
 
 
-class Qt5Module(ExtensionModule, QtBaseModule):
+class Qt5Module(QtBaseModule):
 
     def __init__(self, interpreter):
-        QtBaseModule.__init__(self, qt_version=5)
-        ExtensionModule.__init__(self, interpreter)
+        QtBaseModule.__init__(self, interpreter, qt_version=5)
+
 
 def initialize(*args, **kwargs):
     mlog.warning('rcc dependencies will not work reliably until this upstream issue is fixed:',

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -49,8 +49,8 @@ class WindowsModule(ExtensionModule):
         if state.environment.is_cross_build():
             # If cross compiling see if windres has been specified in the
             # cross file before trying to find it another way.
-            cross_info = state.environment.cross_info
-            rescomp = ExternalProgram.from_cross_info(cross_info, 'windres')
+            bins = state.environment.cross_info.config['binaries']
+            rescomp = ExternalProgram.from_bin_list(bins, 'windres')
 
         if not rescomp or not rescomp.found():
             if 'WINDRES' in os.environ:

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -59,6 +59,14 @@ class WindowsModule(ExtensionModule):
                 rescomp = ExternalProgram('windres', command=os.environ.get('WINDRES'), silent=True)
 
         if not rescomp or not rescomp.found():
+            # Take windres from the config file after the environment, which is
+            # in keeping with the expectations on unix-like OSes that
+            # environment variables trump config files.
+            _win = state.environment.config_info.binaries.get('windres')
+            if _win:
+                rescomp = ExternalProgram('windres', command=_win, silent=True)
+
+        if not rescomp or not rescomp.found():
             comp = self.detect_compiler(state.compilers)
             if comp.id == 'msvc' or comp.id == 'clang-cl':
                 rescomp = ExternalProgram('rc', silent=True)

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -62,9 +62,8 @@ class WindowsModule(ExtensionModule):
             # Take windres from the config file after the environment, which is
             # in keeping with the expectations on unix-like OSes that
             # environment variables trump config files.
-            _win = state.environment.config_info.binaries.get('windres')
-            if _win:
-                rescomp = ExternalProgram('windres', command=_win, silent=True)
+            bins = state.environment.config_info.binaries
+            rescomp = ExternalProgram.from_bin_list(bins, 'windres')
 
         if not rescomp or not rescomp.found():
             comp = self.detect_compiler(state.compilers)

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -29,6 +29,10 @@ def add_arguments(parser):
     coredata.register_builtin_arguments(parser)
     parser.add_argument('--cross-file', default=None,
                         help='File describing cross compilation environment.')
+    parser.add_argument('--native-file',
+                        default=[],
+                        action='append',
+                        help='File containing overrides for native compilation environment.')
     parser.add_argument('-v', '--version', action='version',
                         version=coredata.version)
     parser.add_argument('--profile-self', action='store_true', dest='profile',

--- a/run_tests.py
+++ b/run_tests.py
@@ -73,6 +73,7 @@ def get_fake_options(prefix):
     opts.wrap_mode = None
     opts.prefix = prefix
     opts.cmd_line_options = {}
+    opts.native_file = []
     return opts
 
 def get_fake_env(sdir, bdir, prefix):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4522,6 +4522,32 @@ class NativeFileTests(BasePlatformTests):
             f.write('py -3 {} %*'.format(filename))
         return batfile
 
+    def test_multiple_native_files_override(self):
+        wrapper = self.helper_create_binary_wrapper('bash', version='foo')
+        config = self.helper_create_native_file({'binaries': {'bash': wrapper}})
+        wrapper = self.helper_create_binary_wrapper('bash', version='12345')
+        config2 = self.helper_create_native_file({'binaries': {'bash': wrapper}})
+        self.init(self.testcase, extra_args=[
+            '--native-file', config, '--native-file', config2,
+            '-Dcase=find_program'])
+
+    def test_multiple_native_files(self):
+        wrapper = self.helper_create_binary_wrapper('bash', version='12345')
+        config = self.helper_create_native_file({'binaries': {'bash': wrapper}})
+        wrapper = self.helper_create_binary_wrapper('python')
+        config2 = self.helper_create_native_file({'binaries': {'python': wrapper}})
+        self.init(self.testcase, extra_args=[
+            '--native-file', config, '--native-file', config2,
+            '-Dcase=find_program'])
+
+    def _simple_test(self, case, binary):
+        wrapper = self.helper_create_binary_wrapper(binary, version='12345')
+        config = self.helper_create_native_file({'binaries': {binary: wrapper}})
+        self.init(self.testcase, extra_args=['--native-file', config, '-Dcase={}'.format(case)])
+
+    def test_find_program(self):
+        self._simple_test('find_program', 'bash')
+
 
 def unset_envs():
     # For unit tests we must fully control all command lines

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4554,6 +4554,9 @@ class NativeFileTests(BasePlatformTests):
             raise unittest.SkipTest('No llvm-installed, cannot test')
         self._simple_test('config_dep', 'llvm-config')
 
+    def test_python3_module(self):
+        self._simple_test('python3', 'python3')
+
 
 def unset_envs():
     # For unit tests we must fully control all command lines

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4548,6 +4548,12 @@ class NativeFileTests(BasePlatformTests):
     def test_find_program(self):
         self._simple_test('find_program', 'bash')
 
+    def test_config_tool_dep(self):
+        # Do the skip at this level to avoid screwing up the cache
+        if not shutil.which('llvm-config'):
+            raise unittest.SkipTest('No llvm-installed, cannot test')
+        self._simple_test('config_dep', 'llvm-config')
+
 
 def unset_envs():
     # For unit tests we must fully control all command lines

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4557,6 +4557,14 @@ class NativeFileTests(BasePlatformTests):
     def test_python3_module(self):
         self._simple_test('python3', 'python3')
 
+    def test_python_module(self):
+        if is_windows():
+            # Bat adds extra crap to stdout, so the version check logic in the
+            # python module breaks. This is fine on other OSes because they
+            # don't need the extra indirection.
+            raise unittest.SkipTest('bat indirection breaks internal sanity checks.')
+        self._simple_test('python', 'python')
+
 
 def unset_envs():
     # For unit tests we must fully control all command lines

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -26,6 +26,7 @@ import sys
 import unittest
 import platform
 import pickle
+import functools
 from itertools import chain
 from unittest import mock
 from configparser import ConfigParser
@@ -41,7 +42,7 @@ import mesonbuild.modules.gnome
 from mesonbuild.interpreter import Interpreter, ObjectHolder
 from mesonbuild.mesonlib import (
     is_windows, is_osx, is_cygwin, is_dragonflybsd, is_openbsd, is_haiku,
-    windows_proof_rmtree, python_command, version_compare,
+    is_linux, windows_proof_rmtree, python_command, version_compare,
     BuildDirLock, Version
 )
 from mesonbuild.environment import detect_ninja
@@ -108,11 +109,40 @@ def skipIfNoPkgconfig(f):
 
     Note: Yes, we provide pkg-config even while running Windows CI
     '''
+    @functools.wraps(f)
     def wrapped(*args, **kwargs):
         if not is_ci() and shutil.which('pkg-config') is None:
             raise unittest.SkipTest('pkg-config not found')
         return f(*args, **kwargs)
     return wrapped
+
+def skip_if_not_language(lang):
+    def wrapper(func):
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            try:
+                env = get_fake_env('', '', '')
+                f = getattr(env, 'detect_{}_compiler'.format(lang))
+                if lang in ['cs', 'vala', 'java', 'swift']:
+                    f()
+                else:
+                    f(False)
+            except EnvironmentException:
+                raise unittest.SkipTest('No {} compiler found.'.format(lang))
+            return func(*args, **kwargs)
+        return wrapped
+    return wrapper
+
+def skip_if_env_value(value):
+    def wrapper(func):
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            if value in os.environ:
+                raise unittest.SkipTest(
+                    'Environment variable "{}" set, skipping.'.format(value))
+            return func(*args, **kwargs)
+        return wrapped
+    return wrapper
 
 class PatchModule:
     '''
@@ -4481,7 +4511,6 @@ class NativeFileTests(BasePlatformTests):
         with open(filename, 'wt') as f:
             f.write(textwrap.dedent('''\
                 {}
-                #!/usr/bin/env python3
                 import argparse
                 import subprocess
                 import sys
@@ -4490,11 +4519,11 @@ class NativeFileTests(BasePlatformTests):
                     parser = argparse.ArgumentParser()
                 '''.format(chbang)))
             for name in kwargs:
-                f.write('    parser.add_argument("--{}", action="store_true")\n'.format(name))
+                f.write('    parser.add_argument("-{0}", "--{0}", action="store_true")\n'.format(name))
             f.write('    args, extra_args = parser.parse_known_args()\n')
             for name, value in kwargs.items():
                 f.write('    if args.{}:\n'.format(name))
-                f.write('        print({})\n'.format(value))
+                f.write('        print("{}", file=sys.{})\n'.format(value, kwargs.get('outfile', 'stdout')))
                 f.write('        sys.exit(0)\n')
             f.write(textwrap.dedent('''
                     ret = subprocess.run(
@@ -4521,6 +4550,20 @@ class NativeFileTests(BasePlatformTests):
         with open(batfile, 'wt') as f:
             f.write('py -3 {} %*'.format(filename))
         return batfile
+
+    def helper_for_compiler(self, lang, cb):
+        """Helper for generating tests for overriding compilers for langaugages
+        with more than one implementation, such as C, C++, ObjC, ObjC++, and D.
+        """
+        env = get_fake_env('', '', '')
+        getter = getattr(env, 'detect_{}_compiler'.format(lang))
+        if lang not in ['cs']:
+            getter = functools.partial(getter, False)
+        cc = getter()
+        binary, newid = cb(cc)
+        env.config_info.binaries = {lang: binary}
+        compiler = getter()
+        self.assertEqual(compiler.id, newid)
 
     def test_multiple_native_files_override(self):
         wrapper = self.helper_create_binary_wrapper('bash', version='foo')
@@ -4564,6 +4607,140 @@ class NativeFileTests(BasePlatformTests):
             # don't need the extra indirection.
             raise unittest.SkipTest('bat indirection breaks internal sanity checks.')
         self._simple_test('python', 'python')
+
+    @unittest.skipIf(is_windows(), 'Setting up multiple compilers on windows is hard')
+    @skip_if_env_value('CC')
+    def test_c_compiler(self):
+        def cb(comp):
+            if comp.id == 'gcc':
+                if not shutil.which('clang'):
+                    raise unittest.SkipTest('Only one compiler found, cannot test.')
+                return 'clang', 'clang'
+            if not shutil.which('gcc'):
+                raise unittest.SkipTest('Only one compiler found, cannot test.')
+            return 'gcc', 'gcc'
+        self.helper_for_compiler('c', cb)
+
+    @unittest.skipIf(is_windows(), 'Setting up multiple compilers on windows is hard')
+    @skip_if_env_value('CXX')
+    def test_cpp_compiler(self):
+        def cb(comp):
+            if comp.id == 'gcc':
+                if not shutil.which('clang++'):
+                    raise unittest.SkipTest('Only one compiler found, cannot test.')
+                return 'clang++', 'clang'
+            if not shutil.which('g++'):
+                raise unittest.SkipTest('Only one compiler found, cannot test.')
+            return 'g++', 'gcc'
+        self.helper_for_compiler('cpp', cb)
+
+    @skip_if_not_language('objc')
+    @skip_if_env_value('OBJC')
+    def test_objc_compiler(self):
+        def cb(comp):
+            if comp.id == 'gcc':
+                if not shutil.which('clang'):
+                    raise unittest.SkipTest('Only one compiler found, cannot test.')
+                return 'clang', 'clang'
+            if not shutil.which('gcc'):
+                raise unittest.SkipTest('Only one compiler found, cannot test.')
+            return 'gcc', 'gcc'
+        self.helper_for_compiler('objc', cb)
+
+    @skip_if_not_language('objcpp')
+    @skip_if_env_value('OBJCXX')
+    def test_objcpp_compiler(self):
+        def cb(comp):
+            if comp.id == 'gcc':
+                if not shutil.which('clang++'):
+                    raise unittest.SkipTest('Only one compiler found, cannot test.')
+                return 'clang++', 'clang'
+            if not shutil.which('g++'):
+                raise unittest.SkipTest('Only one compiler found, cannot test.')
+            return 'g++', 'gcc'
+        self.helper_for_compiler('objcpp', cb)
+
+    @skip_if_not_language('d')
+    @skip_if_env_value('DC')
+    def test_d_compiler(self):
+        def cb(comp):
+            if comp.id == 'dmd':
+                if shutil.which('ldc'):
+                    return 'ldc', 'ldc'
+                elif shutil.which('gdc'):
+                    return 'gdc', 'gdc'
+                else:
+                    raise unittest.SkipTest('No alternative dlang compiler found.')
+            return 'dmd', 'dmd'
+        self.helper_for_compiler('d', cb)
+
+    @skip_if_not_language('cs')
+    @skip_if_env_value('CSC')
+    def test_cs_compiler(self):
+        def cb(comp):
+            if comp.id == 'csc':
+                if not shutil.which('mcs'):
+                    raise unittest.SkipTest('No alternate C# implementation.')
+                return 'mcs', 'mcs'
+            if not shutil.which('csc'):
+                raise unittest.SkipTest('No alternate C# implementation.')
+            return 'csc', 'csc'
+        self.helper_for_compiler('cs', cb)
+
+    @skip_if_not_language('fortran')
+    @skip_if_env_value('FC')
+    def test_fortran_compiler(self):
+        def cb(comp):
+            if comp.id == 'gcc':
+                if shutil.which('ifort'):
+                    return 'ifort', 'intel'
+                # XXX: there are several other fortran compilers meson
+                # supports, but I don't have any of them to test with
+                raise unittest.SkipTest('No alternate Fortran implementation.')
+            if not shutil.which('gfortran'):
+                raise unittest.SkipTest('No alternate C# implementation.')
+            return 'gfortran', 'gcc'
+        self.helper_for_compiler('fortran', cb)
+
+    def _single_implementation_compiler(self, lang, binary, version_str, version):
+        """Helper for languages with a single (supported) implementation.
+
+        Builds a wrapper around the compiler to override the version.
+        """
+        wrapper = self.helper_create_binary_wrapper(binary, version=version_str)
+        env = get_fake_env('', '', '')
+        getter = getattr(env, 'detect_{}_compiler'.format(lang))
+        if lang in ['rust']:
+            getter = functools.partial(getter, False)
+        env.config_info.binaries = {lang: wrapper}
+        compiler = getter()
+        self.assertEqual(compiler.version, version)
+
+    @skip_if_not_language('vala')
+    @skip_if_env_value('VALAC')
+    def test_vala_compiler(self):
+        self._single_implementation_compiler(
+            'vala', 'valac', 'Vala 1.2345', '1.2345')
+
+    @skip_if_not_language('rust')
+    @skip_if_env_value('RUSTC')
+    def test_rust_compiler(self):
+        self._single_implementation_compiler(
+            'rust', 'rustc', 'rustc 1.2345', '1.2345')
+
+    @skip_if_not_language('java')
+    def test_java_compiler(self):
+        self._single_implementation_compiler(
+            'java', 'javac', 'javac 9.99.77', '9.99.77')
+
+    @skip_if_not_language('swift')
+    def test_swift_compiler(self):
+        wrapper = self.helper_create_binary_wrapper(
+            'swiftc', version='Swift 1.2345', outfile='stderr')
+        env = get_fake_env('', '', '')
+        env.config_info.binaries = {'swift': wrapper}
+        compiler = env.detect_swift_compiler()
+        self.assertEqual(compiler.version, '1.2345')
 
 
 def unset_envs():

--- a/test cases/unit/46 native file binary/meson.build
+++ b/test cases/unit/46 native file binary/meson.build
@@ -1,0 +1,3 @@
+project('test project')
+
+case = get_option('case')

--- a/test cases/unit/46 native file binary/meson.build
+++ b/test cases/unit/46 native file binary/meson.build
@@ -6,4 +6,8 @@ if case == 'find_program'
   prog = find_program('bash')
   result = run_command(prog, ['--version'])
   assert(result.stdout().strip().endswith('12345'), 'Didn\'t load bash from config file')
+elif case == 'config_dep'
+  add_languages('cpp')
+  dep = dependency('llvm')
+  assert(dep.get_configtool_variable('version').endswith('12345'), 'Didn\'t load llvm from config file')
 endif

--- a/test cases/unit/46 native file binary/meson.build
+++ b/test cases/unit/46 native file binary/meson.build
@@ -14,4 +14,8 @@ elif case == 'python3'
   prog = import('python3').find_python()
   result = run_command(prog, ['--version'])
   assert(result.stdout().strip().endswith('12345'), 'Didn\'t load python3 from config file')
+elif case == 'python'
+  prog = import('python').find_installation()
+  result = run_command(prog, ['--version'])
+  assert(result.stdout().strip().endswith('12345'), 'Didn\'t load python from config file')
 endif

--- a/test cases/unit/46 native file binary/meson.build
+++ b/test cases/unit/46 native file binary/meson.build
@@ -1,3 +1,9 @@
 project('test project')
 
 case = get_option('case')
+
+if case == 'find_program'
+  prog = find_program('bash')
+  result = run_command(prog, ['--version'])
+  assert(result.stdout().strip().endswith('12345'), 'Didn\'t load bash from config file')
+endif

--- a/test cases/unit/46 native file binary/meson.build
+++ b/test cases/unit/46 native file binary/meson.build
@@ -10,4 +10,8 @@ elif case == 'config_dep'
   add_languages('cpp')
   dep = dependency('llvm')
   assert(dep.get_configtool_variable('version').endswith('12345'), 'Didn\'t load llvm from config file')
+elif case == 'python3'
+  prog = import('python3').find_python()
+  result = run_command(prog, ['--version'])
+  assert(result.stdout().strip().endswith('12345'), 'Didn\'t load python3 from config file')
 endif

--- a/test cases/unit/46 native file binary/meson_options.txt
+++ b/test cases/unit/46 native file binary/meson_options.txt
@@ -1,5 +1,5 @@
 option(
   'case',
   type : 'combo',
-  choices : []
+  choices : ['find_program']
 )

--- a/test cases/unit/46 native file binary/meson_options.txt
+++ b/test cases/unit/46 native file binary/meson_options.txt
@@ -1,0 +1,5 @@
+option(
+  'case',
+  type : 'combo',
+  choices : []
+)

--- a/test cases/unit/46 native file binary/meson_options.txt
+++ b/test cases/unit/46 native file binary/meson_options.txt
@@ -1,5 +1,5 @@
 option(
   'case',
   type : 'combo',
-  choices : ['find_program']
+  choices : ['find_program', 'config_dep']
 )

--- a/test cases/unit/46 native file binary/meson_options.txt
+++ b/test cases/unit/46 native file binary/meson_options.txt
@@ -1,5 +1,5 @@
 option(
   'case',
   type : 'combo',
-  choices : ['find_program', 'config_dep']
+  choices : ['find_program', 'config_dep', 'python3']
 )

--- a/test cases/unit/46 native file binary/meson_options.txt
+++ b/test cases/unit/46 native file binary/meson_options.txt
@@ -1,5 +1,5 @@
 option(
   'case',
   type : 'combo',
-  choices : ['find_program', 'config_dep', 'python3']
+  choices : ['find_program', 'config_dep', 'python3', 'python']
 )


### PR DESCRIPTION
This is the start of adding config files to meson. I have to admit that I'm not horribly motivated to do anything beyond a binaries section, which would be analogous to the binaries section in a cross file, but for native builds. This is not complete, but I'm hoping to get some feedback on whether this looks like the approach we want to use or not. I really need this or something like it to have a good way to override which llvm-config binary to use in a given build, as it's one the of the few things holding up dropping autotools from mesa. If this looks good I'll keep overriding binaries and writing tests.