### PR TITLE
Fix `build --backend=xcode`

### DIFF
--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -24,7 +24,7 @@ class XCodeBackend(backends.Backend):
     def __init__(self, build):
         super().__init__(build)
         self.name = 'xcode'
-        self.project_uid = self.environment.coredata.guid.replace('-', '')[:24]
+        self.project_uid = self.environment.coredata.lang_guids['default'].replace('-', '')[:24]
         self.project_conflist = self.gen_id()
         self.indent = '       '
         self.indent_level = 0

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -26,7 +26,7 @@ class XCodeBackend(backends.Backend):
         self.name = 'xcode'
         self.project_uid = self.environment.coredata.lang_guids['default'].replace('-', '')[:24]
         self.project_conflist = self.gen_id()
-        self.indent = '	' # tab
+        self.indent = '\t' # Recent versions of Xcode uses tabs
         self.indent_level = 0
         self.xcodetypemap = {'c': 'sourcecode.c.c',
                              'a': 'archive.ar',


### PR DESCRIPTION
Xcode now works for at least simple projects.
- Fixes exception when calling `meson build --backend=xcode`
- Fixes some typos and other minor indentation little issues when generating project.pbxproj file