### PR TITLE
mesonlib: use collections.abc for abc types

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -1062,7 +1062,7 @@ def substring_is_in_list(substr, strlist):
             return True
     return False
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(collections.abc.MutableSet):
     """A set that preserves the order in which items are added, by first
     insertion.
     """


### PR DESCRIPTION
The use of ABC classes (like MutableSet) directly from collections is 
deprecated and inpython 3.8 the aliases in collections will be dropped 
and only the ones in collections.abc will remain. collections.abc has 
existed since python 3.3, so there is no backwards compatibility risk.