### PR TITLE
gnome.compile_resources: Add ld binary method

### DIFF
--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -58,6 +58,10 @@ class GResourceHeaderTarget(build.CustomTarget):
     def __init__(self, name, subdir, subproject, kwargs):
         super().__init__(name, subdir, subproject, kwargs)
 
+class GResourceObjectTarget(build.CustomTarget):
+    def __init__(self, name, subdir, subproject, kwargs):
+        super().__init__(name, subdir, subproject, kwargs)
+
 class GirTarget(build.CustomTarget):
     def __init__(self, name, subdir, subproject, kwargs):
         super().__init__(name, subdir, subproject, kwargs)

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -181,7 +181,7 @@ class GnomeModule(ExtensionModule):
         cmd += mesonlib.stringlistify(kwargs.pop('extra_args', []))
 
         gresource_ld_binary = False
-        if mesonlib.is_linux() and mesonlib.version_compare(glib_version, gresource_ld_binary_needed_version):
+        if mesonlib.is_linux() and mesonlib.version_compare(glib_version, gresource_ld_binary_needed_version) and not state.environment.is_cross_build():
             ld_obj = self.interpreter.find_program_impl('ld', required=False)
             if ld_obj.found():
                 gresource_ld_binary = True

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -40,7 +40,7 @@ from ..interpreterbase import noKwargs, permittedKwargs, FeatureNew, FeatureNewK
 # https://bugzilla.gnome.org/show_bug.cgi?id=774368
 gresource_dep_needed_version = '>= 2.51.1'
 
-gresource_ld_binary_needed_version = '>= 2.60'
+gresource_ld_binary_needed_version = '>= 2.59'
 
 native_glib_version = None
 girwarning_printed = False
@@ -170,6 +170,7 @@ class GnomeModule(ExtensionModule):
             cmd += ['--c-name', c_name]
         else:
             c_name = os.path.basename(ifile).partition('.')[0]
+        c_name = c_name.replace('-', '_')
         c_name_no_underscores = c_name.replace('_', '')
         export = kwargs.pop('export', False)
         if not export:

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -230,7 +230,9 @@ class GnomeModule(ExtensionModule):
         else:
             depfile = kwargs['output'] + '.d'
             if gresource_ld_binary:
-                kwargs['command'] = copy.copy(cmd) + ['--external-data']
+                depfile2 = kwargs['output'] + '.2.d'
+                kwargs['depfile'] = depfile2
+                kwargs['command'] = copy.copy(cmd) + ['--external-data', '--dependency-file', '@DEPFILE@']
             else:
                 kwargs['depfile'] = depfile
                 kwargs['command'] = copy.copy(cmd) + ['--dependency-file', '@DEPFILE@']

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -187,9 +187,9 @@ class GnomeModule(ExtensionModule):
                 ld = ld_obj.get_command()
                 objcopy_object = self.interpreter.find_program_impl('objcopy', required=False)
                 if objcopy_object.found():
-                   objcopy = objcopy_object.get_command()
+                    objcopy = objcopy_object.get_command()
                 else:
-                   objcopy = None
+                    objcopy = None
 
         gresource = kwargs.pop('gresource_bundle', False)
         if gresource or gresource_ld_binary:
@@ -242,9 +242,9 @@ class GnomeModule(ExtensionModule):
             target_g = GResourceTarget(g_name, state.subdir, state.subproject, g_kwargs)
             if gresource: # Only one target for .gresource files
                 if target_g.get_id() not in self.interpreter.build.targets:
-                   return ModuleReturnValue(target_g, [target_g])
+                    return ModuleReturnValue(target_g, [target_g])
                 else:
-                   return ModuleReturnValue(target_g, [])
+                    return ModuleReturnValue(target_g, [])
 
         target_c = GResourceTarget(name, state.subdir, state.subproject, kwargs)
 
@@ -278,9 +278,9 @@ class GnomeModule(ExtensionModule):
             linkerscript_file = open(linkerscript_path, 'w')
 
             binary_name = os.path.join(state.subdir, g_output)
-            symbol_name = ''.join([ c if c.isalnum() else '_' for c in binary_name ])
+            symbol_name = ''.join([c if c.isalnum() else '_' for c in binary_name])
 
-            linkerscript_string =  'SECTIONS\n'
+            linkerscript_string = 'SECTIONS\n'
             linkerscript_string += '{\n'
             linkerscript_string += '  .gresource.' + c_name_no_underscores + ' : ALIGN(8)\n'
             linkerscript_string += '  {\n'
@@ -301,32 +301,32 @@ class GnomeModule(ExtensionModule):
             }
             target_o2 = GResourceObjectTarget(args[0] + '2_o', state.subdir, state.subproject, o2_kwargs)
 
-            if objcopy != None:
+            if objcopy is not None:
                 objcopy_cmd = [objcopy, '--set-section-flags', '.gresource.' + c_name + '=readonly,alloc,load,data']
                 objcopy_cmd += ['-N', '_binary_' + symbol_name + '_start']
                 objcopy_cmd += ['-N', '_binary_' + symbol_name + '_end']
                 objcopy_cmd += ['-N', '_binary_' + symbol_name + '_size']
-                objcopy_cmd += ['@INPUT@','@OUTPUT@']
+                objcopy_cmd += ['@INPUT@', '@OUTPUT@']
 
                 o3_kwargs = {
-                   'command': objcopy_cmd,
-                   'input': target_o2,
-                   'output': args[0] + '3.o'
+                    'command': objcopy_cmd,
+                    'input': target_o2,
+                    'output': args[0] + '3.o'
                 }
 
                 target_o3 = GResourceObjectTarget(args[0] + '3_o', state.subdir, state.subproject, o3_kwargs)
 
                 rv1 = [target_c, target_h, target_o3]
                 if target_g.get_id() not in self.interpreter.build.targets:
-                   rv2 = rv1 + [target_g, target_o, target_o2]
+                    rv2 = rv1 + [target_g, target_o, target_o2]
                 else:
-                   rv2 = rv1 + [target_o, target_o2]
+                    rv2 = rv1 + [target_o, target_o2]
             else:
                 rv1 = [target_c, target_h, target_o2]
                 if target_g.get_id() not in self.interpreter.build.targets:
-                   rv2 = rv1 + [target_g, target_o]
+                    rv2 = rv1 + [target_g, target_o]
                 else:
-                   rv2 = rv1 + [target_o]
+                    rv2 = rv1 + [target_o]
 
             return ModuleReturnValue(rv1, rv2)
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -42,7 +42,7 @@ from ..interpreterbase import noKwargs, permittedKwargs, FeatureNew, FeatureNewK
 # https://bugzilla.gnome.org/show_bug.cgi?id=774368
 gresource_dep_needed_version = '>= 2.51.1'
 
-gresource_ld_binary_needed_version = '>= 2.59'
+gresource_ld_binary_needed_version = '>= 2.60'
 
 native_glib_version = None
 girwarning_printed = False

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -170,8 +170,6 @@ class GnomeModule(ExtensionModule):
             cmd += ['--c-name', c_name]
         else:
             c_name = os.path.basename(ifile).partition('.')[0]
-        c_name = c_name.replace('-', '_')
-        c_name_no_underscores = c_name.replace('_', '')
         export = kwargs.pop('export', False)
         if not export:
             cmd += ['--internal']
@@ -185,12 +183,6 @@ class GnomeModule(ExtensionModule):
             ld_obj = self.interpreter.find_program_impl('ld', required=False)
             if ld_obj.found():
                 gresource_ld_binary = True
-                ld = ld_obj.get_command()
-                objcopy_object = self.interpreter.find_program_impl('objcopy', required=False)
-                if objcopy_object.found():
-                    objcopy = objcopy_object.get_command()
-                else:
-                    objcopy = None
 
         gresource = kwargs.pop('gresource_bundle', False)
         if gresource or gresource_ld_binary:
@@ -267,13 +259,22 @@ class GnomeModule(ExtensionModule):
         target_h = GResourceHeaderTarget(args[0] + '_h', state.subdir, state.subproject, h_kwargs)
 
         if gresource_ld_binary:
-            return self._create_gresource_ld_binary_targets(ld, target_g, args, state, g_output, c_name_no_underscores, c_name, objcopy, target_c, target_h)
+            return self._create_gresource_ld_binary_targets(args, state, ld_obj, c_name, target_g, g_output, target_c, target_h)
         else:
             rv = [target_c, target_h]
 
         return ModuleReturnValue(rv, rv)
 
-    def _create_gresource_ld_binary_targets(self, ld, target_g, args, state, g_output, c_name_no_underscores, c_name, objcopy, target_c, target_h):
+    def _create_gresource_ld_binary_targets(self, args, state, ld_obj, c_name, target_g, g_output, target_c, target_h):
+        c_name = c_name.replace('-', '_')
+        c_name_no_underscores = c_name.replace('_', '')
+
+        ld = ld_obj.get_command()
+        objcopy_object = self.interpreter.find_program_impl('objcopy', required=False)
+        if objcopy_object.found():
+            objcopy = objcopy_object.get_command()
+        else:
+            objcopy = None
 
         o_kwargs = {
             'command': [ld, '-r', '-b', 'binary', '@INPUT@', '-o', '@OUTPUT@'],

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -291,17 +291,17 @@ class GnomeModule(ExtensionModule):
         binary_name = os.path.join(state.subdir, g_output)
         symbol_name = ''.join([c if c.isalnum() else '_' for c in binary_name])
 
-        linkerscript_string = 'SECTIONS\n'
-        linkerscript_string += '{\n'
-        linkerscript_string += '  .gresource.' + c_name_no_underscores + ' : ALIGN(8)\n'
-        linkerscript_string += '  {\n'
-        linkerscript_string += '    ' + c_name + '_resource_data = _binary_' + symbol_name + '_start;\n'
-        linkerscript_string += '  }\n'
-        linkerscript_string += '  .data :\n'
-        linkerscript_string += '  {\n'
-        linkerscript_string += '    *(.data)\n'
-        linkerscript_string += '  }\n'
-        linkerscript_string += '}'
+        linkerscript_string = '''SECTIONS
+{{
+  .gresource.{} : ALIGN(8)
+  {{
+    {}_resource_data = _binary_{}_start;
+  }}
+  .data :
+  {{
+    *(.data)
+  }}
+}}'''.format(c_name_no_underscores, c_name, symbol_name)
 
         linkerscript_file.write(linkerscript_string)
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -220,7 +220,7 @@ class GnomeModule(ExtensionModule):
             # This will eventually go out of sync if dependencies are added
             kwargs['depend_files'] = depend_files
             if gresource_ld_binary:
-                kwargs['command'] = copy.copy(cmd) + ["--external-data"]
+                kwargs['command'] = copy.copy(cmd) + ['--external-data']
             else:
                 kwargs['command'] = cmd
             if gresource or gresource_ld_binary:
@@ -229,10 +229,10 @@ class GnomeModule(ExtensionModule):
                 g_kwargs['command'] = cmd
         else:
             depfile = kwargs['output'] + '.d'
-            kwargs['depfile'] = depfile
             if gresource_ld_binary:
-                kwargs['command'] = copy.copy(cmd) + ["--external-data", '--dependency-file', '@DEPFILE@']
+                kwargs['command'] = copy.copy(cmd) + ['--external-data']
             else:
+                kwargs['depfile'] = depfile
                 kwargs['command'] = copy.copy(cmd) + ['--dependency-file', '@DEPFILE@']
             if gresource or gresource_ld_binary:
                 g_kwargs['depfile'] = depfile


### PR DESCRIPTION
Instead of generating a c file that gets compiled,
directly create object file with ld.

See https://gitlab.gnome.org/GNOME/glib/issues/1489