### PR TITLE
syntax guide: move logical ops section beside if statement [skip ci]

### DIFF
--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -354,10 +354,33 @@ else
 endif
 
 opt = get_option('someoption')
-if opt == 'foo'
+if opt != 'foo'
   do_something()
 endif
 ```
+
+Logical operations
+--
+
+Meson has the standard range of logical operations which can be used in
+`if` statements.
+
+```meson
+if a and b
+  # do something
+endif
+if c or d
+  # do something
+endif
+if not e
+  # do something
+endif
+if not (f or g)
+  # do something
+endif
+```
+
+Logical operations work only on boolean values.
 
 ## Foreach statements
 
@@ -408,28 +431,6 @@ foreach name, sources : components
   endif
 endforeach
 ```
-
-Logical operations
---
-
-Meson has the standard range of logical operations.
-
-```meson
-if a and b
-  # do something
-endif
-if c or d
-  # do something
-endif
-if not e
-  # do something
-endif
-if not (f or g)
-  # do something
-endif
-```
-
-Logical operations work only on boolean values.
 
 Comments
 --


### PR DESCRIPTION
The "if" statement only covers a small set of the possible ways in
which conditionals can be written, since it leaves the use of
"and", "or" and "not" to the "Logical Operations" section. However,
this is likely to be of interest to those reading about "if" statments,
so move the "logical operations" section up to immediately follow it.
This change also puts in the use of the "!=" operator in the example
to widen the variety of combinations shown.