### PR TITLE
linker flags --as-needed and --no-undefined aren't meaningful for PE

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1298,9 +1298,11 @@ class GnuLikeCompiler(abc.ABC):
     def __init__(self, compiler_type):
         self.compiler_type = compiler_type
         self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage',
-                             'b_ndebug', 'b_staticpic', 'b_asneeded']
-        if not self.compiler_type.is_osx_compiler:
+                             'b_ndebug', 'b_staticpic']
+        if not self.compiler_type.is_osx_compiler and not self.compiler_type.is_windows_compiler:
             self.base_options.append('b_lundef')
+        if not self.compiler_type.is_windows_compiler:
+            self.base_options.append('b_asneeded')
         # All GCC-like backends can do assembly
         self.can_compile_suffixes.add('s')
 


### PR DESCRIPTION
--as-needed controls ELF-specific functionality (the emission of DT_NEEDED tags)

--no-undefined is effectively always on for PE/COFF, as the linkage model always requires symbols to be defined

binutils ld silently ignores these flags for PE targets, but lld warns that it's ignoring them, so just don't bother emitting them for PE targets.