### PR TITLE
mesonbuild: Recognise ARC architecture

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -48,6 +48,7 @@ set in the cross file.
 | x86_64              | 64 bit x86 processor  |
 | ia64                | Itanium processor     |
 | arm                 | 32 bit ARM processor  |
+| arc                 | 32 bit ARC processor  |
 | aarch64             | 64 bit ARM processor  |
 | mips                | 32 bit MIPS processor |
 | mips64              | 64 bit MIPS processor |

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -69,6 +69,7 @@ build_filename = 'meson.build'
 
 known_cpu_families = (
     'aarch64',
+    'arc',
     'arm',
     'e2k',
     'ia64',


### PR DESCRIPTION
-------------------------->8-----------------------
root@nsimhs:~# python

Python 2.7.15 (default, Sep 20 2018, 21:44:15)
[GCC 8.2.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>>
>>> import platform
>>> print platform.machine()
arc
-------------------------->8-----------------------

Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>