### PR TITLE
Use only basename part in test. Closes #4237.

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3794,7 +3794,7 @@ class LinuxlikeTests(BasePlatformTests):
                 break
         self.assertIsInstance(docbook_target, dict)
         ifile = self.introspect(['--target-files', 'generated-gdbus-docbook@cus'])[0]
-        self.assertEqual(t['filename'], 'gdbus/generated-gdbus-doc-' + ifile)
+        self.assertEqual(t['filename'], 'gdbus/generated-gdbus-doc-' + os.path.basename(ifile))
 
     def test_build_rpath(self):
         if is_cygwin():


### PR DESCRIPTION
This makes the error go away but not sure if it is the correct fix.