### PR TITLE
Normalize some path to avoid failling at checking if a path is a system path

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -361,6 +361,7 @@ class Backend:
 
     @staticmethod
     def _libdir_is_system(libdir, compilers, env):
+        libdir = os.path.normpath(libdir)
         for cc in compilers.values():
             if libdir in cc.get_library_dirs(env):
                 return True


### PR DESCRIPTION
The end result of that was that when building some gir files in `gst-build` I was getting missing symbols because we were picking the system wide libgstXXX.so library:


```
# Pastebin QIb6LF8P
FAILED: subprojects/gst-plugins-base/gst-libs/gst/video/GstVideo-1.0.gir
/usr/bin/g-ir-scanner -I/usr/include/gobject-introspection-1.0 -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -pthread -I/usr/lib/libffi-3.2.1/include --no-libtool --namespace=GstVideo --nsversion=1.0 --warn-all --output subprojects/gst-plugins-base/gst-libs/gst/video/GstVideo-1.0.gir '--add-init-section=extern void gst_init(gint*,gchar**);g_setenv("GST_REGISTRY_DISABLE", "yes", TRUE);g_setenv("GST_REGISTRY_1.0", "/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gst-plugins-base/gir_empty_registry.reg", TRUE);g_setenv("GST_PLUGIN_PATH_1_0", "", TRUE);g_setenv("GST_PLUGIN_SYSTEM_PATH_1_0", "", TRUE);gst_init(NULL,NULL);' --c-include=gst/video/video.h -I/home/thiblahute/devel/hotdoc/gnome-devel-docs/subprojects/gst-plugins-base/gst-libs/gst/video -I/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gst-plugins-base/gst-libs/gst/video -I./subprojects/gst-plugins-base/. -I../subprojects/gst-plugins-base/. -I./subprojects/gst-plugins-base/gst-libs -I../subprojects/gst-plugins-base/gst-libs -I./subprojects/gstreamer/libs -I../subprojects/gstreamer/libs -I./subprojects/gstreamer/. -I../subprojects/gstreamer/. -I./subprojects/gstreamer/. -I../subprojects/gstreamer/. -I./subprojects/glib/. -I../subprojects/glib/. -I./subprojects/glib/glib -I../subprojects/glib/glib -I./subprojects/glib/gobject -I../subprojects/glib/gobject --filelist=/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gst-plugins-base/gst-libs/gst/video/subprojects@gst-plugins-base@gst-libs@gst@video@@gstvideo-1.0@sha/GstVideo_1.0_gir_filelist --include=Gst-1.0 --include=GstBase-1.0 --symbol-prefix=gst --identifier-prefix=Gst --pkg-export=gstreamer-video-1.0 --cflags-begin -fvisibility=hidden -fno-strict-aliasing -DG_DISABLE_DEPRECATED -Wmissing-declarations -Wredundant-decls -Wundef -Wwrite-strings -Wformat -Wformat-nonliteral -Wformat-security -Winit-self -Wmissing-include-dirs -Waddress -Wno-multichar -Wvla -Wpointer-arith -Wmissing-prototypes -Wdeclaration-after-statement -I./subprojects/gst-plugins-base/. -I../subprojects/gst-plugins-base/. -I./subprojects/gst-plugins-base/gst-libs -I../subprojects/gst-plugins-base/gst-libs -I./subprojects/gstreamer/libs -I../subprojects/gstreamer/libs -I./subprojects/gstreamer/. -I../subprojects/gstreamer/. -I./subprojects/glib/. -I../subprojects/glib/. -I./subprojects/glib/glib -I../subprojects/glib/glib -I./subprojects/glib/gobject -I../subprojects/glib/gobject -I./subprojects/gstreamer/gst/parse -I../subprojects/gstreamer/gst/parse -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/orc-0.4 -I/usr/lib/libffi-3.2.1/include --cflags-end --add-include-path=/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/gst --add-include-path=/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/libs/gst/base -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/libs/gst/base -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/gobject -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/glib -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/glib/libcharset -L/usr/lib/../lib -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/gst -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/gst/printf --extra-library=gstbase-1.0 --extra-library=gstreamer-1.0 --extra-library=glib-2.0 --extra-library=gobject-2.0 -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/libs/gst/base -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/gobject -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/glib -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/glib/libcharset -L/usr/lib/../lib -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/gst -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/gst/printf --library gstvideo-1.0 -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gst-plugins-base/gst-libs/gst/video --extra-library=gmodule-2.0 --extra-library=glib-2.0 --extra-library=m --extra-library=orc-0.4 --extra-library=dl --extra-library=unwind --extra-library=dw --extra-library=elf --extra-library=pcre -L/usr/lib/../lib --extra-library=ffi
g-ir-scanner: link: cc -o /home/thiblahute/devel/hotdoc/gnome-devel-docs/build/tmp-introspect0xvpeib7/GstVideo-1.0 /home/thiblahute/devel/hotdoc/gnome-devel-docs/build/tmp-introspect0xvpeib7/GstVideo-1.0.o -L. -Wl,-rpath,. -Wl,--no-as-needed -lgstvideo-1.0 -lgstbase-1.0 -lgstreamer-1.0 -lglib-2.0 -lgobject-2.0 -lgmodule-2.0 -lglib-2.0 -lm -lorc-0.4 -ldl -lunwind -ldw -lelf -lpcre -lffi -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/libs/gst/base -Wl,-rpath,/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/libs/gst/base -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/gobject -Wl,-rpath,/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/gobject -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/glib -Wl,-rpath,/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/glib -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/glib/libcharset -Wl,-rpath,/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/glib/libcharset -L/usr/lib/../lib -Wl,-rpath,/usr/lib/../lib -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/gst -Wl,-rpath,/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/gst -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/gst/printf -Wl,-rpath,/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/gst/printf -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/libs/gst/base -Wl,-rpath,/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/libs/gst/base -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/gobject -Wl,-rpath,/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/gobject -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/glib -Wl,-rpath,/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/glib -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/glib/libcharset -Wl,-rpath,/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/glib/glib/libcharset -L/usr/lib/../lib -Wl,-rpath,/usr/lib/../lib -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/gst -Wl,-rpath,/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/gst -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/gst/printf -Wl,-rpath,/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gstreamer/gst/printf -L/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gst-plugins-base/gst-libs/gst/video -Wl,-rpath,/home/thiblahute/devel/hotdoc/gnome-devel-docs/build/subprojects/gst-plugins-base/gst-libs/gst/video -L/usr/lib/../lib -Wl,-rpath,/usr/lib/../lib -lgio-2.0 -lgobject-2.0 -Wl,--export-dynamic -lgmodule-2.0 -pthread -lglib-2.0
/usr/bin/ld: /tmp/ccpTLlU4.ltrans0.ltrans.o:(.data.rel+0x38): undefined reference to `gst_video_ancillary_did_get_type'
/usr/bin/ld: /tmp/ccpTLlU4.ltrans0.ltrans.o:(.data.rel+0x40): undefined reference to `gst_video_ancillary_di_d16_get_type'
/usr/bin/ld: /tmp/ccpTLlU4.ltrans0.ltrans.o:(.data.rel+0x48): undefined reference to `gst_video_caption_type_get_type'
/usr/bin/ld: /tmp/ccpTLlU4.ltrans0.ltrans.o:(.data.rel+0x50): undefined reference to `gst_video_vbi_parser_result_get_type'
/usr/bin/ld: /tmp/ccpTLlU4.ltrans0.ltrans.o:(.data.rel+0x210): undefined reference to `gst_video_caption_meta_api_get_type'
/usr/bin/ld: /tmp/ccpTLlU4.ltrans0.ltrans.o:(.data.rel+0x218): undefined reference to `gst_video_vbi_parser_get_type'
collect2: error: ld returned 1 exit status
```