### PR TITLE
Don't add rpath linker flags when building for MinGW

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -124,6 +124,8 @@ class CCompiler(Compiler):
         if getattr(self, 'compiler_type', False) and self.compiler_type.is_osx_compiler:
             # Clang, GCC and ICC on macOS all use the same rpath arguments
             return self.build_osx_rpath_args(build_dir, rpath_paths, build_rpath)
+        elif self.compiler_type.is_windows_compiler:
+            return []
         return self.build_unix_rpath_args(build_dir, from_dir, rpath_paths, build_rpath, install_rpath)
 
     def get_dependency_gen_args(self, outtarget, outfile):


### PR DESCRIPTION
GNU binutils ld silently ignores -rpath flags when targeting windows
(and it is already commented within ninjabackend.py that rpath as
concept doesn't exist on windows), and build_rpath_args in
VisualStudioCCompiler also returns an empty array. Therefore skip
this flag altogether.

This fixes linking with lld in MinGW mode, which doesn't support the
rpath flag.