### PR TITLE
Return code 0 when builddir is already configured

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -113,7 +113,7 @@ class MesonApp:
                       '\nIf build failures persist, manually wipe your build directory to clear any\n'
                       'stored system data.\n'
                       '\nTo change option values, run "meson configure" instead.')
-                sys.exit(1)
+                sys.exit(0)
         else:
             if reconfigure:
                 print('Directory does not contain a valid build tree:\n{}'.format(build_dir))


### PR DESCRIPTION
This is a regression in Meson 0.48.0, commit 674ae46, Meson used to
exit(0) when running setup command in a builddir already configured.
Changing to exit(1) breaks some build tools that does "meson builddir
&& ninja -C builddir".

Closes #4247.