### PR TITLE
backends: allow running host arch binaries on compatible build machines

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os, pickle, re
+import textwrap
 from .. import build
 from .. import dependencies
 from .. import mesonlib
@@ -731,10 +732,11 @@ class Backend:
     def exe_object_to_cmd_array(self, exe):
         if self.environment.is_cross_build() and \
            isinstance(exe, build.BuildTarget) and exe.is_cross:
-            if self.environment.exe_wrapper is None:
-                s = 'Can not use target %s as a generator because it is cross-built\n'
-                s += 'and no exe wrapper is defined. You might want to set it to native instead.'
-                s = s % exe.name
+            if self.environment.exe_wrapper is None and self.environment.cross_info.need_exe_wrapper():
+                s = textwrap.dedent('''
+                    Can not use target {} as a generator because it is cross-built
+                    and no exe wrapper is defined or needs_exe_wrapper is true.
+                    You might want to set it to native instead.'''.format(exe.name))
                 raise MesonException(s)
         if isinstance(exe, build.BuildTarget):
             exe_arr = [os.path.join(self.environment.get_build_dir(), self.get_target_filename(exe))]


### PR DESCRIPTION
Meson 0.48.0 some validation for using compiled binaries in custom
targets and generators, which is nice. It didn't take into account
though that as long as the OS is the same, some architectures support
running a related architecture natively (x86_64 can run x86 natively,
for example).

This patch introduces a new method to the Backend base class,
can_execute_host_binaries. It attempts to check that the build machine
is capable of running binaries targeting the host architecture, and
allows them to be used in generators and custom targets.

Fixes #4254