### PR TITLE
compilers/c: don't return -pthread for MacOS with any compiler

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -986,12 +986,12 @@ class CCompiler(Compiler):
         return self.find_library_impl(libname, env, extra_dirs, code, libtype)
 
     def thread_flags(self, env):
-        if for_haiku(self.is_cross, env):
+        if for_haiku(self.is_cross, env) or for_darwin(self.is_cross, env):
             return []
         return ['-pthread']
 
     def thread_link_flags(self, env):
-        if for_haiku(self.is_cross, env):
+        if for_haiku(self.is_cross, env) or for_darwin(self.is_cross, env):
             return []
         return ['-pthread']
 
@@ -1075,16 +1075,6 @@ class ClangCCompiler(ClangCompiler, CCompiler):
                                                         'gnu89', 'gnu99', 'gnu11'],
                                                        'none')})
         return opts
-
-    def thread_flags(self, env):
-        if for_darwin(self.is_cross, env):
-            return []
-        return super().thread_flags()
-
-    def thread_link_flags(self, env):
-        if for_darwin(self.is_cross, env):
-            return []
-        return super().thread_link_flags()
 
     def get_option_compile_args(self, options):
         args = []

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -37,7 +37,7 @@ import mesonbuild.coredata
 import mesonbuild.modules.gnome
 from mesonbuild.interpreter import Interpreter, ObjectHolder
 from mesonbuild.mesonlib import (
-    is_windows, is_osx, is_cygwin, is_dragonflybsd, is_openbsd,
+    is_windows, is_osx, is_cygwin, is_dragonflybsd, is_openbsd, is_haiku,
     windows_proof_rmtree, python_command, version_compare,
     BuildDirLock, Version
 )
@@ -3260,7 +3260,7 @@ class LinuxlikeTests(BasePlatformTests):
         self.init(testdir)
         privatedir2 = self.privatedir
 
-        if is_osx():
+        if is_osx() or is_haiku():
             pthreads = []
         else:
             pthreads = ['-pthread']

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3260,6 +3260,11 @@ class LinuxlikeTests(BasePlatformTests):
         self.init(testdir)
         privatedir2 = self.privatedir
 
+        if is_osx():
+            pthreads = []
+        else:
+            pthreads = ['-pthread']
+
         os.environ['PKG_CONFIG_LIBDIR'] = os.pathsep.join([privatedir1, privatedir2])
         cmd = ['pkg-config', 'dependency-test']
 
@@ -3270,17 +3275,15 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertEqual(sorted(out), sorted(['libfoo >= 1.0']))
 
         out = self._run(cmd + ['--cflags-only-other']).strip().split()
-        self.assertEqual(sorted(out), sorted(['-pthread', '-DCUSTOM']))
+        self.assertEqual(sorted(out), sorted(pthreads + ['-DCUSTOM']))
 
         out = self._run(cmd + ['--libs-only-l', '--libs-only-other']).strip().split()
-        self.assertEqual(sorted(out), sorted(['-pthread', '-lcustom',
-                                              '-llibmain', '-llibexposed']))
+        self.assertEqual(sorted(out), sorted(pthreads + ['-lcustom', '-llibmain', '-llibexposed']))
 
         out = self._run(cmd + ['--libs-only-l', '--libs-only-other', '--static']).strip().split()
-        self.assertEqual(sorted(out), sorted(['-pthread', '-lcustom',
-                                              '-llibmain', '-llibexposed',
-                                              '-llibinternal', '-lcustom2',
-                                              '-lfoo']))
+        self.assertEqual(sorted(out), sorted(['-lcustom', '-llibmain',
+                                              '-llibexposed', '-llibinternal',
+                                              '-lcustom2', '-lfoo'] + pthreads))
 
         cmd = ['pkg-config', 'requires-test']
         out = self._run(cmd + ['--print-requires']).strip().split('\n')


### PR DESCRIPTION
With GCC, Clang, or ICC, and for C++

Fixes #2628 

#4268 Comes up a little short as the warning still appears for C++ code. Also, after some testing we decided that it's a platform rather than compiler issue, as GCC and ICC don't need -pthread or -lpthread either.