### PR TITLE
custom_target: do not let install override build_by_default

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -261,6 +261,9 @@ following.
 - `build_by_default` *(added 0.38)* causes, when set to true, to
   have this target be built by default, that is, when invoking plain
   `ninja`; the default value is false
+  *(changed in 0.50)* if `build_by_default` is explicitly set to false, `install`
+  will no longer override it. If `build_by_default` is not set, `install` will
+  still determine its default.
 - `build_always` (deprecated) if `true` this target is always considered out of
   date and is rebuilt every time.  Equivalent to setting both
   `build_always_stale` and `build_by_default` to true.

--- a/docs/markdown/Release-notes-for-0.50.0.md
+++ b/docs/markdown/Release-notes-for-0.50.0.md
@@ -15,3 +15,11 @@ whose contents should look like this:
 
     A short description explaining the new feature and how it should be used.
 
+## custom_target: install no longer overrides build_by_default
+
+Earlier, if `build_by_default` was set to false and `install` was set to true in
+a `custom_target`, `install` would override it and the `custom_target` would
+always be built by default.
+Now if `build_by_default` is explicitly set to false it will no longer be
+overridden. If `build_by_default` is not set, its default will still be
+determined by the value of `install` for greater backward compatibility.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -778,7 +778,7 @@ class Backend:
         result = OrderedDict()
         # Get all build and custom targets that must be built by default
         for name, t in self.build.get_targets().items():
-            if t.build_by_default or t.install:
+            if t.build_by_default:
                 result[name] = t
         # Get all targets used as test executables and arguments. These must
         # also be built by default. XXX: Sometime in the future these should be
@@ -1039,7 +1039,8 @@ class Backend:
                 if num_outdirs == 1 and num_out > 1:
                     for output in t.get_outputs():
                         f = os.path.join(self.get_target_dir(t), output)
-                        i = TargetInstallData(f, outdirs[0], {}, False, {}, None, install_mode)
+                        i = TargetInstallData(f, outdirs[0], {}, False, {}, None, install_mode,
+                                              optional=not t.build_by_default)
                         d.targets.append(i)
                 else:
                     for output, outdir in zip(t.get_outputs(), outdirs):
@@ -1047,7 +1048,8 @@ class Backend:
                         if outdir is False:
                             continue
                         f = os.path.join(self.get_target_dir(t), output)
-                        i = TargetInstallData(f, outdir, {}, False, {}, None, install_mode)
+                        i = TargetInstallData(f, outdir, {}, False, {}, None, install_mode,
+                                              optional=not t.build_by_default)
                         d.targets.append(i)
 
     def generate_custom_install_script(self, d):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -404,6 +404,11 @@ a hard error in the future.''' % name)
             self.build_by_default = kwargs['build_by_default']
             if not isinstance(self.build_by_default, bool):
                 raise InvalidArguments('build_by_default must be a boolean value.')
+        elif kwargs.get('install', False):
+            # For backward compatibility, if build_by_default is not explicitly
+            # set, use the value of 'install' if it's enabled.
+            self.build_by_default = True
+
         self.option_overrides = self.parse_overrides(kwargs)
 
     def parse_overrides(self, kwargs):

--- a/test cases/common/209 custom target build by default/docgen.py
+++ b/test cases/common/209 custom target build by default/docgen.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+out = sys.argv[1]
+
+os.mkdir(out)
+
+for name in ('a', 'b', 'c'):
+    with open(os.path.join(out, name + '.txt'), 'w') as f:
+        f.write(name)

--- a/test cases/common/209 custom target build by default/meson.build
+++ b/test cases/common/209 custom target build by default/meson.build
@@ -1,0 +1,10 @@
+project('custom-target-dir-install', 'c')
+
+docgen = find_program('docgen.py')
+
+custom_target('docgen',
+  output : 'html',
+  command : [docgen, '@OUTPUT@'],
+  install : true,
+  build_by_default : false,
+  install_dir : join_paths(get_option('datadir'), 'doc/testpkgname'))


### PR DESCRIPTION
A custom_target, if install is set to true, will always be built by
default even if build_by_default is explicitly set to false.
Ensure that this does not happen if it's set explicitly. To keep
backward compatibility, if build_by_default is not set explicitly and
install is true, set build_by_default to true.

Fixes #4107