### PR TITLE
Do not specify `-pthread` on macOS

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -986,12 +986,12 @@ class CCompiler(Compiler):
         return self.find_library_impl(libname, env, extra_dirs, code, libtype)
 
     def thread_flags(self, env):
-        if for_haiku(self.is_cross, env):
+        if for_haiku(self.is_cross, env) or for_darwin(self.is_cross, env):
             return []
         return ['-pthread']
 
     def thread_link_flags(self, env):
-        if for_haiku(self.is_cross, env):
+        if for_haiku(self.is_cross, env) or for_darwin(self.is_cross, env):
             return []
         return ['-pthread']
 
@@ -1075,16 +1075,6 @@ class ClangCCompiler(ClangCompiler, CCompiler):
                                                         'gnu89', 'gnu99', 'gnu11'],
                                                        'none')})
         return opts
-
-    def thread_flags(self, env):
-        if for_darwin(self.is_cross, env):
-            return []
-        return super().thread_flags()
-
-    def thread_link_flags(self, env):
-        if for_darwin(self.is_cross, env):
-            return []
-        return super().thread_link_flags()
 
     def get_option_compile_args(self, options):
         args = []

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3270,17 +3270,16 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertEqual(sorted(out), sorted(['libfoo >= 1.0']))
 
         out = self._run(cmd + ['--cflags-only-other']).strip().split()
-        self.assertEqual(sorted(out), sorted(['-pthread', '-DCUSTOM']))
+        self.assertEqual(sorted(out), sorted(['-DCUSTOM'] + [] if is_osx() else ['-pthread']))
 
         out = self._run(cmd + ['--libs-only-l', '--libs-only-other']).strip().split()
-        self.assertEqual(sorted(out), sorted(['-pthread', '-lcustom',
-                                              '-llibmain', '-llibexposed']))
+        self.assertEqual(sorted(out), sorted(['-lcustom', '-llibmain', '-llibexposed'] +
+                                             [] if is_osx() else ['-pthread']))
 
         out = self._run(cmd + ['--libs-only-l', '--libs-only-other', '--static']).strip().split()
-        self.assertEqual(sorted(out), sorted(['-pthread', '-lcustom',
-                                              '-llibmain', '-llibexposed',
-                                              '-llibinternal', '-lcustom2',
-                                              '-lfoo']))
+        self.assertEqual(sorted(out), sorted(['-lcustom', '-llibmain', '-llibexposed',
+                                              '-llibinternal', '-lcustom2', '-lfoo'] +
+                                             [] if is_osx() else ['-pthread']))
 
         cmd = ['pkg-config', 'requires-test']
         out = self._run(cmd + ['--print-requires']).strip().split('\n')


### PR DESCRIPTION
* macOS includes pthread functionality in `libSystem.B.dylib`:
  https://discussions.apple.com/thread/613936?answerId=2982065022#2982065022
* Tested on Clang, GCC and ICC

Fixes #2628

@jpakkane @nirbheek @ePirat @dcbaker I think the test handling is cleaner here.