### PR TITLE
Make custom dist scripts accept arguments.

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1433,14 +1433,14 @@ The `meson` object allows you to introspect various properties of the
 system. This object is always mapped in the `meson` variable. It has
 the following methods.
 
-- `add_dist_script` causes the script given as argument to run during
+- `add_dist_script(script_name, arg1, arg, ...)` causes the script given as argument to run during
   `dist` operation after the distribution source has been generated
   but before it is archived. Note that this runs the script file that
   is in the _staging_ directory, not the one in the source
   directory. If the script file can not be found in the staging
   directory, it is a hard error. This command can only invoked from
   the main project, calling it from a subproject is a hard
-  error. Available since 0.48.0.
+  error. Available since 0.48.0. Before 0.49.0, the function only accepted a single argument.
 
 - `add_install_script(script_name, arg1, arg2, ...)` causes the script
   given as an argument to be run during the install step, this script

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1686,12 +1686,15 @@ class MesonMain(InterpreterObject):
 
     @permittedKwargs({})
     def add_dist_script_method(self, args, kwargs):
-        if len(args) != 1:
-            raise InterpreterException('add_dist_script takes exactly one argument')
+        if len(args) < 1:
+            raise InterpreterException('add_dist_script takes one or more arguments')
+        if len(args) > 1:
+            FeatureNew('Calling "add_dist_script" with multiple arguments', '0.49.0').use(self.interpreter.subproject)
         check_stringlist(args, 'add_dist_script argument must be a string')
         if self.interpreter.subproject != '':
             raise InterpreterException('add_dist_script may not be used in a subproject.')
-        self.build.dist_scripts.append(os.path.join(self.interpreter.subdir, args[0]))
+        script = self._find_source_script(args[0], args[1:])
+        self.build.dist_scripts.append(script)
 
     @noPosargs
     @permittedKwargs({})

--- a/mesonbuild/scripts/dist.py
+++ b/mesonbuild/scripts/dist.py
@@ -81,16 +81,17 @@ def run_dist_scripts(dist_root, dist_scripts):
     env = os.environ.copy()
     env['MESON_DIST_ROOT'] = dist_root
     for d in dist_scripts:
-        print('Processing dist script %s' % d)
-        ddir, dname = os.path.split(d)
-        ep = ExternalProgram(dname,
-                             search_dir=os.path.join(dist_root, ddir),
-                             silent=True)
-        if not ep.found():
-            sys.exit('Script %s could not be found in dist directory' % d)
-        pc = subprocess.run(ep.command, env=env)
-        if pc.returncode != 0:
-            sys.exit('Dist script errored out')
+        script = d['exe']
+        args = d['args']
+        name = ' '.join(script + args)
+        print('Running custom dist script {!r}'.format(name))
+        try:
+            rc = subprocess.call(script + args, env=env)
+            if rc != 0:
+                sys.exit('Dist script errored out')
+        except OSError:
+            print('Failed to run dist script {!r}'.format(name))
+            sys.exit(1)
 
 
 def git_have_dirty_index(src_root):

--- a/test cases/unit/35 dist script/meson.build
+++ b/test cases/unit/35 dist script/meson.build
@@ -4,4 +4,4 @@ project('dist script', 'c',
 exe = executable('comparer', 'prog.c')
 test('compare', exe)
 
-meson.add_dist_script('replacer.py')
+meson.add_dist_script('replacer.py', '"incorrect"', '"correct"')

--- a/test cases/unit/35 dist script/replacer.py
+++ b/test cases/unit/35 dist script/replacer.py
@@ -2,11 +2,15 @@
 
 import os
 import pathlib
+import sys
+
+if len(sys.argv) < 3:
+    sys.exit('usage: replacer.py <pattern> <replacement>')
 
 source_root = pathlib.Path(os.environ['MESON_DIST_ROOT'])
 
 modfile = source_root / 'prog.c'
 
 contents = modfile.read_text()
-contents = contents.replace('"incorrect"', '"correct"')
+contents = contents.replace(sys.argv[1], sys.argv[2])
 modfile.write_text(contents)


### PR DESCRIPTION
`meson.add_dist_script`, introduced in #3906, did not accept any arguments other than script name. Since all other `meson.add_*_script` methods do accept args, this makes the dist script accept them as well.

Closes: https://github.com/mesonbuild/meson/issues/4262