### PR TITLE
No stdout from `meson --internal exe` generated by custom_target() when not in capture mode

### DIFF
--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -81,6 +81,8 @@ def run_exe(exe):
     if exe.capture and p.returncode == 0:
         with open(exe.capture, 'wb') as output:
             output.write(stdout)
+    else:
+        sys.stdout.buffer.write(stdout)
     if stderr:
         sys.stderr.buffer.write(stderr)
     return p.returncode


### PR DESCRIPTION
Fixed the lack of stdout being displayed when not in capture mode for meson_exe (meson --internal exe)

This was stopping me seeing important program output for a set of custom_target() steps on windows