### PR TITLE
WIP: Add support for building subprojects with other build systems

### DIFF
--- a/docs/markdown/External-Project-module.md
+++ b/docs/markdown/External-Project-module.md
@@ -1,0 +1,90 @@
+# External Project module
+
+*This is an experimental module, API could change.*
+
+This module allows building code that uses build systems other than Meson. This
+module is intended to be used to build Autotools subprojects as fallback if the
+dependency couldn't be found on the system (e.g. too old distro version).
+
+The project will be compiled out-of-tree inside Meson's build directory. The
+project will also be installed inside Meson's build directory using make's
+[`DESTDIR`](https://www.gnu.org/prep/standards/html_node/DESTDIR.html)
+feature, so no root permission is required even if the installation prefix is
+for example `/usr`.
+
+Known limitations:
+- Executables from external projects cannot be used uninstalled, because they
+  would need its libraries to be installed in the final location. This is why
+  there is no `find_program()` method.
+- The configure script must generate a `Makefile`, other build systems are not
+  yet supported.
+
+*Added 0.55.0*
+
+## Functions
+
+### `add_project()`
+
+This function should be called at the root directory of a project using another
+build system. Usually in a `meson.build` file placed in the top directory of a
+subproject, but could be also in any subdir.
+
+Its first positional argument is the name of the configure script to be
+executed (e.g. `configure` or `autogen.sh`), that file must be in the current
+directory and executable.
+
+Keyword arguments:
+- `options`: An array of strings to be passed as arguments to the configure
+  script. Some special tags will be replaced by Meson before passing them to
+  the configure script: `{prefix}`, `{libdir}` and `{includedir}`. Note that
+  `libdir` and `includedir` paths are relative to `prefix` in Meson but some
+  configure scripts requires absolute path, in that case they can be passed as
+  `'--libdir=' + join_paths('{prefix}', '{libdir}')`.
+- `cross_options`: Extra options appended to `options` only when cross compiling.
+  special tag `{host}` will be replaced by `'{}-{}-{}'.format(
+  host_machine.cpu_family(), build_machine.system(), host_machine.system()`. If
+  omitted it defaults to `['--host={host}']`.
+- `verbose`: If set to `true` the output of sub-commands ran to configure, build
+  and install the project will be printed onto Meson's stdout.
+
+Returns an [`ExternalProject`](#ExternalProject_object) object
+
+## `ExternalProject` object
+
+### Methods
+
+#### `dependency(libname)`
+
+
+Return a dependency object that can be used to build targets against a library
+from the external project.
+
+Keyword arguments:
+- `subdir` path relative to `includedir` to be added to the header search path.
+
+## Example `meson.build` file for a subproject
+
+```meson
+project('My Autotools Project', 'c',
+  meson_version : '>=0.55.0',
+)
+
+mod = import('unstable_external_project')
+
+p = mod.add_project('configure',
+  options : ['--prefix={prefix}',
+             '--libdir={libdir}',
+             '--incdir={includedir}',
+             '--enable-foo',
+            ],
+)
+
+mylib_dep = p.dependency('mylib')
+```
+
+## Using wrap file
+
+Most of the time the project will be built as a subproject, and fetched using
+a `.wrap` file. In that case the simple `meson.build` file needed to build the
+subproject can be provided by adding `meson_filename=path/to/meson.build` line
+in the wrap file, which is easier than providing a patch file.

--- a/docs/markdown/External-Project-module.md
+++ b/docs/markdown/External-Project-module.md
@@ -46,6 +46,8 @@ Keyword arguments:
   omitted it defaults to `['--host={host}']`.
 - `verbose`: If set to `true` the output of sub-commands ran to configure, build
   and install the project will be printed onto Meson's stdout.
+- `env` : environment variables to set, such as `['NAME1=value1', 'NAME2=value2']`,
+  a dictionary, or an [`environment()` object](Reference-manual.md#environment-object).
 
 Returns an [`ExternalProject`](#ExternalProject_object) object
 

--- a/docs/markdown/Wrap-dependency-system-manual.md
+++ b/docs/markdown/Wrap-dependency-system-manual.md
@@ -125,6 +125,11 @@ put them somewhere where you can download them.
 Meson build patches are only supported for wrap-file mode. When using
 wrap-git, the repository must contain all Meson build definitions.
 
+Since *0.49.0* `meson_filename` can be a the path relative to project's
+`subprojects` directory to a `meson.build` file that will be copied to the root
+of subproject's directory. This is easier than providing a patch in the case
+the build system consist of a single `meson.build` file.
+
 ## Using wrapped projects
 
 Wraps provide a convenient way of obtaining a project into your subproject directory. 

--- a/docs/sitemap.txt
+++ b/docs/sitemap.txt
@@ -49,6 +49,7 @@ index.md
 			Windows-module.md
 			Cuda-module.md
 			Kconfig-module.md
+			External-Project-module.md
 		Java.md
 		Vala.md
 		D.md

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1230,7 +1230,11 @@ class Backend:
 
     def generate_subdir_install(self, d):
         for sd in self.build.get_install_subdirs():
-            src_dir = os.path.join(self.environment.get_source_dir(),
+            if sd.from_source_dir:
+                from_dir = self.environment.get_source_dir()
+            else:
+                from_dir = self.environment.get_build_dir()
+            src_dir = os.path.join(from_dir,
                                    sd.source_subdir,
                                    sd.installable_subdir).rstrip('/')
             dst_dir = os.path.join(self.environment.get_prefix(),

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -103,6 +103,9 @@ unixy_compiler_internal_libs = ('m', 'c', 'pthread', 'dl', 'rt')
 if mesonlib.is_freebsd() or mesonlib.is_netbsd():
     unixy_compiler_internal_libs += ('execinfo',)
 
+cexe_mapping = {'c': 'CC',
+                'cpp': 'CXX'}
+
 # All these are only for C-linkable languages; see `clink_langs` above.
 
 def sort_clink(lang):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -717,7 +717,8 @@ class DataHolder(InterpreterObject, ObjectHolder):
         return self.held_object.install_dir
 
 class InstallDir(InterpreterObject):
-    def __init__(self, src_subdir, inst_subdir, install_dir, install_mode, exclude, strip_directory):
+    def __init__(self, src_subdir, inst_subdir, install_dir, install_mode,
+                 exclude, strip_directory, from_source_dir=True):
         InterpreterObject.__init__(self)
         self.source_subdir = src_subdir
         self.installable_subdir = inst_subdir
@@ -725,6 +726,7 @@ class InstallDir(InterpreterObject):
         self.install_mode = install_mode
         self.exclude = exclude
         self.strip_directory = strip_directory
+        self.from_source_dir = from_source_dir
 
 class Man(InterpreterObject):
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2372,6 +2372,8 @@ class Interpreter(InterpreterBase):
             return ExternalProgramHolder(item)
         elif hasattr(item, 'held_object'):
             return item
+        elif isinstance(item, InterpreterObject):
+            return item
         else:
             raise InterpreterException('Module returned a value of unknown type.')
 
@@ -2397,6 +2399,8 @@ class Interpreter(InterpreterBase):
                 # FIXME: This is special cased and not ideal:
                 # The first source is our new VapiTarget, the rest are deps
                 self.process_new_values(v.sources[0])
+            elif isinstance(v, InstallDir):
+                self.build.install_dirs.append(v)
             elif hasattr(v, 'held_object'):
                 pass
             elif isinstance(v, (int, str, bool)):

--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -1,0 +1,220 @@
+# Copyright 2020 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os, subprocess, shlex
+
+from . import ExtensionModule, ModuleReturnValue
+from .. import mlog, build
+from ..mesonlib import MesonException, Popen_safe, OrderedSet, is_windows, MachineChoice
+from ..interpreterbase import InterpreterObject, InterpreterException, FeatureNew
+from ..interpreterbase import noKwargs, noPosargs, stringArgs, permittedKwargs
+from ..interpreter import DependencyHolder, InstallDir
+from ..compilers.compilers import cflags_mapping, cexe_mapping
+from ..dependencies.base import InternalDependency, DependencyException
+
+class ExternalProject(InterpreterObject):
+    def __init__(self, subdir, project_version, subproject, environment, build_machine, host_machine,
+                 configure_command, configure_options, configure_cross_options,
+                 verbose):
+        InterpreterObject.__init__(self)
+        self.methods.update({'dependency': self.dependency_method,
+                             })
+
+        self.subdir = subdir
+        self.project_version = project_version
+        self.subproject = subproject
+        self.env = environment
+        self.build_machine = build_machine
+        self.host_machine = host_machine
+        self.configure_command = configure_command
+        self.configure_options = configure_options
+        self.configure_cross_options = configure_cross_options
+        self.verbose = verbose
+
+        self.name = os.path.basename(self.subdir)
+        self.src_dir = os.path.join(self.env.get_source_dir(), self.subdir)
+        self.build_dir = os.path.join(self.env.get_build_dir(), self.subdir, 'build')
+        self.install_dir = os.path.join(self.env.get_build_dir(), self.subdir, 'dist')
+        self.prefix = self.env.coredata.get_builtin_option('prefix')
+        self.libdir = self.env.coredata.get_builtin_option('libdir')
+        self.includedir = self.env.coredata.get_builtin_option('includedir')
+
+        # self.prefix is an absolute path, so we cannot use it in
+        # os.path.join(something, self.prefix). On Windows 'c:/some/path' is
+        # first split into ('c:', '/some/path') and then we keep only
+        # 'some/path'.
+        self.rel_prefix = os.path.splitdrive(self.prefix)[1][1:]
+
+        self._configure()
+
+    def _configure(self):
+        if not os.path.exists(self.build_dir):
+            os.makedirs(self.build_dir)
+
+        # Assume it's the name of a script in source dir, like 'configure',
+        # 'autogen.sh', etc).
+        configure_cmd = [os.path.join(self.src_dir, self.configure_command)]
+
+        d = {'prefix': self.prefix,
+             'libdir': self.libdir,
+             'includedir': self.includedir,
+             }
+        self._validate_configure_options(d.keys())
+        configure_cmd += [arg.format(**d) for arg in self.configure_options]
+
+        if self.env.is_cross_build():
+            host = '{}-{}-{}'.format(self.host_machine.cpu_family,
+                                     self.build_machine.system,
+                                     self.host_machine.system)
+            d = {'host': host}
+            configure_cmd += [arg.format(**d) for arg in self.configure_cross_options]
+
+        # Set common env variables like CFLAGS, CC, etc.
+        link_exelist = []
+        link_args = []
+        self.run_env = os.environ.copy()
+        for lang, compiler in self.env.coredata.compilers[MachineChoice.HOST].items():
+            if any(lang not in i for i in (cexe_mapping, cflags_mapping)):
+                continue
+            cargs = self.env.coredata.get_external_args(MachineChoice.HOST, lang)
+            self.run_env[cexe_mapping[lang]] = self._quote_and_join(compiler.get_exelist())
+            self.run_env[cflags_mapping[lang]] = self._quote_and_join(cargs)
+            if not link_exelist:
+                link_exelist = compiler.get_linker_exelist()
+                link_args = self.env.coredata.get_external_link_args(MachineChoice.HOST, lang)
+        if link_exelist:
+            self.run_env['LD'] = self._quote_and_join(link_exelist)
+        self.run_env['LDFLAGS'] = self._quote_and_join(link_args)
+        self._run('configure', configure_cmd)
+
+    def _quote_and_join(self, array):
+        return ' '.join([shlex.quote(i) for i in array])
+
+    def _validate_configure_options(self, required_keys):
+        # Ensure the user at least try to pass basic info to the build system,
+        # like the prefix, libdir, etc.
+        for key in required_keys:
+            key_format = '{%s}' % key
+            for option in self.configure_options:
+                if key_format in option:
+                    break
+            else:
+                m = 'At least one configure option must contain "{}" key'
+                raise InterpreterException(m.format(key_format))
+
+    def _run(self, step, command):
+        mlog.log('External project {}:'.format(self.name), mlog.bold(step))
+        if is_windows():
+            command = ['sh', '-c', self._quote_and_join(command)]
+        output = None if self.verbose else subprocess.DEVNULL
+        p, o, e = Popen_safe(command, cwd=self.build_dir, env=self.run_env,
+                                      stderr=subprocess.STDOUT,
+                                      stdout=output)
+        if p.returncode != 0:
+            m = '{} step failed:\n{}'.format(step, e)
+            raise MesonException(m)
+
+    def _get_targets(self):
+        cmd = self.env.get_build_command()
+        cmd += ['--internal', 'externalproject',
+                '--name', self.name,
+                '--srcdir', self.src_dir,
+                '--builddir', self.build_dir,
+                '--installdir', self.install_dir,
+                ]
+        if self.verbose:
+            cmd.append('--verbose')
+
+        target_kwargs = {'output': '{}.stamp'.format(self.name),
+                         'depfile': '{}.d'.format(self.name),
+                         'command': cmd + ['@OUTPUT@', '@DEPFILE@'],
+                         'console': True,
+                         }
+        self.target = build.CustomTarget(self.name,
+                                         self.subdir,
+                                         self.subproject,
+                                         target_kwargs)
+
+        idir = InstallDir(self.subdir,
+                          os.path.join('dist', self.rel_prefix),
+                          install_dir='.',
+                          install_mode=None,
+                          exclude=None,
+                          strip_directory=True,
+                          from_source_dir=False)
+
+        return [self.target, idir]
+
+    @stringArgs
+    @permittedKwargs({'subdir'})
+    def dependency_method(self, args, kwargs):
+        if len(args) != 1:
+            m = 'ExternalProject.dependency takes exactly 1 positional arguments'
+            raise InterpreterException(m)
+        libname = args[0]
+
+        subdir = kwargs.get('subdir', '')
+        if not isinstance(subdir, str):
+            m = 'ExternalProject.dependency subdir keyword argument must be string.'
+            raise InterpreterException(m)
+
+        abs_includedir = os.path.join(self.install_dir, self.rel_prefix, self.includedir)
+        if subdir:
+            abs_includedir = os.path.join(abs_includedir, subdir)
+        abs_libdir = os.path.join(self.install_dir, self.rel_prefix, self.libdir)
+
+        version = self.project_version['version']
+        incdir = []
+        compile_args = ['-I{}'.format(abs_includedir)]
+        link_args = ['-L{}'.format(abs_libdir), '-l{}'.format(libname)]
+        libs = []
+        libs_whole = []
+        sources = self.target
+        final_deps = []
+        variables = []
+        dep = InternalDependency(version, incdir, compile_args, link_args, libs,
+                                 libs_whole, sources, final_deps, variables)
+        return DependencyHolder(dep, self.subproject)
+
+
+class ExternalProjectModule(ExtensionModule):
+    @FeatureNew('External build system Module', '0.55.0')
+    def __init__(self, interpreter):
+        super().__init__(interpreter)
+
+    @stringArgs
+    @permittedKwargs({'options', 'cross_options', 'verbose'})
+    def add_project(self, state, args, kwargs):
+        if len(args) != 1:
+            raise InterpreterException('add_project takes exactly one positional argument')
+        configure_command = args[0]
+        configure_options = kwargs.get('options', [])
+        configure_cross_options = kwargs.get('cross_options', ['--host={host}'])
+        verbose = kwargs.get('verbose', False)
+        project = ExternalProject(state.subdir,
+                                  state.project_version,
+                                  state.subproject,
+                                  state.environment,
+                                  state.build_machine,
+                                  state.host_machine,
+                                  configure_command,
+                                  configure_options,
+                                  configure_cross_options,
+                                  verbose)
+        targets = project._get_targets()
+        return ModuleReturnValue(project, targets)
+
+
+def initialize(*args, **kwargs):
+    return ExternalProjectModule(*args, **kwargs)

--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -21,7 +21,7 @@ from ..interpreterbase import InterpreterObject, InterpreterException, FeatureNe
 from ..interpreterbase import noKwargs, noPosargs, stringArgs, permittedKwargs
 from ..interpreter import DependencyHolder, InstallDir
 from ..compilers.compilers import cflags_mapping, cexe_mapping
-from ..dependencies.base import InternalDependency, DependencyException
+from ..dependencies.base import InternalDependency, DependencyException, PkgConfigDependency
 
 class ExternalProject(InterpreterObject):
     def __init__(self, subdir, project_version, subproject, environment, build_machine, host_machine,
@@ -96,6 +96,8 @@ class ExternalProject(InterpreterObject):
         if link_exelist:
             self.run_env['LD'] = self._quote_and_join(link_exelist)
         self.run_env['LDFLAGS'] = self._quote_and_join(link_args)
+        PkgConfigDependency.setup_env(self.run_env, self.env, MachineChoice.HOST,
+                                      os.path.join(self.env.get_build_dir(), 'meson-uninstalled'))
         self._run('configure', configure_cmd)
 
     def _quote_and_join(self, array):

--- a/mesonbuild/scripts/externalproject.py
+++ b/mesonbuild/scripts/externalproject.py
@@ -1,0 +1,85 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import argparse
+import multiprocessing
+import subprocess
+
+from ..mesonlib import Popen_safe
+
+class ExternalProject:
+    def __init__(self, options):
+        self.name = options.name
+        self.src_dir = options.srcdir
+        self.build_dir = options.builddir
+        self.install_dir = options.installdir
+        self.verbose = options.verbose
+        self.stampfile = options.stampfile
+        self.depfile = options.depfile
+
+    def write_depfile(self):
+        with open(self.depfile, 'w') as f:
+            f.write('{}: \\\n'.format(self.stampfile))
+            for dirpath, dirnames, filenames in os.walk(self.src_dir):
+                dirnames[:] = [d for d in dirnames if not d.startswith('.')]
+                for fname in filenames:
+                    if fname.startswith('.'):
+                        continue
+                    path = os.path.join(dirpath, fname)
+                    f.write('  {} \\\n'.format(path.replace(' ', '\\ ')))
+
+    def write_stampfile(self):
+        with open(self.stampfile, 'w') as f:
+            pass
+
+    def build(self):
+        make_cmd = ['make', '-C', self.build_dir]
+        if not self.verbose:
+            make_cmd.append('--quiet')
+
+        build_cmd = make_cmd + ['-j%d' % multiprocessing.cpu_count()]
+        install_cmd = make_cmd + ['DESTDIR= ' + self.install_dir, 'install']
+
+        rc = self._run(build_cmd)
+        if rc != 0:
+            return rc
+
+        rc = self._run(install_cmd)
+        if rc != 0:
+            return rc
+
+        self.write_depfile()
+        self.write_stampfile()
+
+        return 0
+
+    def _run(self, command):
+        output = None if self.verbose else subprocess.DEVNULL
+        p, o, e = Popen_safe(command, stderr=subprocess.STDOUT, stdout=output)
+        return p.returncode
+
+def run(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--name')
+    parser.add_argument('--srcdir')
+    parser.add_argument('--builddir')
+    parser.add_argument('--installdir')
+    parser.add_argument('--verbose', action='store_true')
+    parser.add_argument('stampfile')
+    parser.add_argument('depfile')
+
+    options = parser.parse_args(args)
+    ep = ExternalProject(options)
+    return ep.build()

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -193,8 +193,15 @@ class Resolver:
                     raise WrapException('Unknown wrap type {!r}'.format(self.wrap.type))
 
         # A meson.build or CMakeLists.txt file is required in the directory
-        if method == 'meson' and not os.path.exists(meson_file):
-            raise WrapException('Subproject exists but has no meson.build file')
+        if method == 'meson':
+            if not os.path.exists(meson_file):
+                meson_filename = self.wrap.values.get('meson_filename')
+                if meson_filename:
+                    path = os.path.join(self.subdir_root, meson_filename)
+                    mlog.log('Using', mlog.bold(self.packagename), 'meson.build', 'from {}.'.format(meson_filename))
+                    shutil.copy2(path, meson_file)
+                else:
+                    raise WrapException('Subproject exists but has no meson.build file')
         if method == 'cmake' and not os.path.exists(cmake_file):
             raise WrapException('Subproject exists but has no CMakeLists.txt file')
 

--- a/test cases/common/205 external project/app.c
+++ b/test cases/common/205 external project/app.c
@@ -1,0 +1,7 @@
+#include <libfoo.h>
+
+int main()
+{
+    return call_foo() == 42 ? 0 : 1;
+}
+

--- a/test cases/common/205 external project/func.c
+++ b/test cases/common/205 external project/func.c
@@ -1,0 +1,5 @@
+int func()
+{
+    return 1;
+}
+

--- a/test cases/common/205 external project/installed_files.txt
+++ b/test cases/common/205 external project/installed_files.txt
@@ -1,0 +1,3 @@
+usr/include/libfoo.h
+usr/lib/pkgconfig/libfoo.pc
+usr/lib/libfoo.?libext

--- a/test cases/common/205 external project/libfoo/configure
+++ b/test cases/common/205 external project/libfoo/configure
@@ -1,0 +1,42 @@
+#! /bin/sh
+
+srcdir=$(dirname "$0")
+
+for i in "$@"
+do
+case $i in
+    --prefix=*)
+    PREFIX="${i#*=}"
+    shift
+    ;;
+    --libdir=*)
+    LIBDIR="${i#*=}"
+    shift
+    ;;
+    --includedir=*)
+    INCDIR="${i#*=}"
+    shift
+    ;;
+    --libext=*)
+    LIBEXT="${i#*=}"
+    shift
+    ;;
+    *)
+    shift
+    ;;
+esac
+done
+
+cat > Makefile << EOL
+all: libfoo.$LIBEXT
+
+libfoo.$LIBEXT:
+	\$(CC) "$srcdir/libfoo.c" -shared -o \$@
+
+install: libfoo.$LIBEXT
+	mkdir -p "\$(DESTDIR)$LIBDIR";
+	mkdir -p "\$(DESTDIR)$LIBDIR/pkgconfig";
+	mkdir -p "\$(DESTDIR)$INCDIR";
+	cp \$< "\$(DESTDIR)$LIBDIR";
+	cp "$srcdir/libfoo.h" "\$(DESTDIR)$INCDIR";
+EOL

--- a/test cases/common/205 external project/libfoo/configure
+++ b/test cases/common/205 external project/libfoo/configure
@@ -27,11 +27,13 @@ case $i in
 esac
 done
 
+DEP_ARGS=$(pkg-config somelib --cflags --libs)
+
 cat > Makefile << EOL
 all: libfoo.$LIBEXT
 
 libfoo.$LIBEXT:
-	\$(CC) "$srcdir/libfoo.c" -shared -o \$@
+	\$(CC) "$srcdir/libfoo.c" -shared $DEP_ARGS -o \$@
 
 install: libfoo.$LIBEXT
 	mkdir -p "\$(DESTDIR)$LIBDIR";

--- a/test cases/common/205 external project/libfoo/libfoo.c
+++ b/test cases/common/205 external project/libfoo/libfoo.c
@@ -1,6 +1,8 @@
 #include "libfoo.h"
 
+int func();
+
 int call_foo()
 {
-  return 42;
+  return func() == 1 ? 42 : 0;
 }

--- a/test cases/common/205 external project/libfoo/libfoo.c
+++ b/test cases/common/205 external project/libfoo/libfoo.c
@@ -1,0 +1,6 @@
+#include "libfoo.h"
+
+int call_foo()
+{
+  return 42;
+}

--- a/test cases/common/205 external project/libfoo/libfoo.h
+++ b/test cases/common/205 external project/libfoo/libfoo.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int call_foo();

--- a/test cases/common/205 external project/libfoo/meson.build
+++ b/test cases/common/205 external project/libfoo/meson.build
@@ -1,0 +1,33 @@
+mod = import('unstable_external_project')
+
+cc = meson.get_compiler('c')
+
+# The configure script is a bash script that requires msys2
+if cc.get_id() == 'msvc'
+  error('MESON_SKIP_TEST: This test does not work with MSVC')
+endif
+
+if not find_program('make', required : false).found()
+  error('MESON_SKIP_TEST: make not found')
+endif
+
+target_system = target_machine.system()
+if target_system in ['windows', 'cygwin']
+  libext = 'dll'
+elif target_system == 'darwin'
+  libext = 'dylib'
+else
+  libext = 'so'
+endif
+
+p = mod.add_project('configure',
+  options : [
+    '--prefix={prefix}',
+    '--libdir=' + join_paths('{prefix}', '{libdir}'),
+    '--includedir=' + join_paths('{prefix}', '{includedir}'),
+    '--libext=' + libext,
+  ],
+  verbose : true,
+)
+
+libfoo_dep = p.dependency('foo')

--- a/test cases/common/205 external project/libfoo/meson.build
+++ b/test cases/common/205 external project/libfoo/meson.build
@@ -30,4 +30,5 @@ p = mod.add_project('configure',
   verbose : true,
 )
 
-libfoo_dep = p.dependency('foo')
+libfoo_dep = declare_dependency(link_with : somelib,
+  dependencies : p.dependency('foo'))

--- a/test cases/common/205 external project/meson.build
+++ b/test cases/common/205 external project/meson.build
@@ -1,5 +1,10 @@
 project('test external project', 'c')
 
+pkg = import('pkgconfig')
+
+somelib = library('somelib', 'func.c')
+pkg.generate(somelib)
+
 subdir('libfoo')
 
 executable('test-find-library', 'app.c', dependencies : libfoo_dep)

--- a/test cases/common/205 external project/meson.build
+++ b/test cases/common/205 external project/meson.build
@@ -1,0 +1,5 @@
+project('test external project', 'c')
+
+subdir('libfoo')
+
+executable('test-find-library', 'app.c', dependencies : libfoo_dep)


### PR DESCRIPTION
This adds an experimental meson module to build projects with other
build systems (atm only configure/make). The project will be configured,
compiled and installed inside meson's build directory and during meson's
configuration phase.
