### PR TITLE
dependency variable from subproject could be not-found

### DIFF
--- a/test cases/failing/90 subproj not-found dep/meson.build
+++ b/test cases/failing/90 subproj not-found dep/meson.build
@@ -1,0 +1,2 @@
+project('dep-test')
+missing = dependency('', fallback: ['somesubproj', 'notfound_dep'], required: true)

--- a/test cases/failing/90 subproj not-found dep/subprojects/somesubproj/meson.build
+++ b/test cases/failing/90 subproj not-found dep/subprojects/somesubproj/meson.build
@@ -1,0 +1,3 @@
+project('dep', 'c')
+
+notfound_dep = dependency('', required : false)


### PR DESCRIPTION
When using a subproject as fallback for a required dependency, we should
check if the dependency object we get from the subproject is found.