### PR TITLE
Fix a comment in "test cases/frameworks/6 gettext"

### DIFF
--- a/test cases/frameworks/6 gettext/data/data3/meson.build
+++ b/test cases/frameworks/6 gettext/data/data3/meson.build
@@ -1,4 +1,4 @@
-# Use filename substitution
+# Target name will contain a path separator
 i18n.merge_file(
   input: 'test.desktop.in',
   output: 'test4.desktop',


### PR DESCRIPTION
File "data/data3/meson.build" makes Meson create a target
that contains a path separator.