### PR TITLE
Add ElementaryOS

### DIFF
--- a/docs/markdown/Users.md
+++ b/docs/markdown/Users.md
@@ -16,6 +16,7 @@ listed in the [`meson` GitHub topic](https://github.com/topics/meson).
  - [dbus-broker](https://github.com/bus1/dbus-broker), Linux D-Bus Message Broker
  - [Dpdk](http://dpdk.org/browse/dpdk), Data plane development kit, a set of libraries and drivers for fast packet processing
  - [DXVK](https://github.com/doitsujin/dxvk), a Vulkan-based Direct3D 11 implementation for Linux using Wine
+ - [ElementaryOS](https://github.com/elementary/), Linux desktop oriented distribution 
  - [Emeus](https://github.com/ebassi/emeus), Constraint based layout manager for GTK+
  - [ESP8266 Arduino sample project](https://github.com/trilader/arduino-esp8266-meson) Sample project for using the ESP8266 Arduino port with Meson
  - [Fractal](https://wiki.gnome.org/Apps/Fractal/), a Matrix messaging client for GNOME

--- a/docs/markdown/Users.md
+++ b/docs/markdown/Users.md
@@ -16,7 +16,7 @@ listed in the [`meson` GitHub topic](https://github.com/topics/meson).
  - [dbus-broker](https://github.com/bus1/dbus-broker), Linux D-Bus Message Broker
  - [Dpdk](http://dpdk.org/browse/dpdk), Data plane development kit, a set of libraries and drivers for fast packet processing
  - [DXVK](https://github.com/doitsujin/dxvk), a Vulkan-based Direct3D 11 implementation for Linux using Wine
- - [ElementaryOS](https://github.com/elementary/), Linux desktop oriented distribution 
+ - [elementary OS](https://github.com/elementary/), Linux desktop oriented distribution 
  - [Emeus](https://github.com/ebassi/emeus), Constraint based layout manager for GTK+
  - [ESP8266 Arduino sample project](https://github.com/trilader/arduino-esp8266-meson) Sample project for using the ESP8266 Arduino port with Meson
  - [Fractal](https://wiki.gnome.org/Apps/Fractal/), a Matrix messaging client for GNOME


### PR DESCRIPTION
Starting with Juno release, all native vala programs/libs use Meson as build system.
[See blog post](https://medium.com/elementaryos/all-aboard-the-meson-future-hype-train-2b6c478b6b9e) and [official docs](https://elementary.io/docs/code/getting-started#the-build-system).