### PR TITLE
Regression fix: Don't try to import empty-string custom target include dirs

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1944,6 +1944,8 @@ rule FORTRAN_DEP_HACK%s
             if not isinstance(i, (build.CustomTarget, build.CustomTargetIndex)):
                 continue
             idir = self.get_target_dir(i)
+            if not idir:
+                continue
             if idir not in custom_target_include_dirs:
                 custom_target_include_dirs.append(idir)
         incs = []

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1945,7 +1945,7 @@ rule FORTRAN_DEP_HACK%s
                 continue
             idir = self.get_target_dir(i)
             if not idir:
-                continue
+                idir = '.'
             if idir not in custom_target_include_dirs:
                 custom_target_include_dirs.append(idir)
         incs = []


### PR DESCRIPTION
Hi!
Since Meson 0.48, any definition including e.g. a vcs_tag line like this:
`vcs_tag(command: ['git', 'describe', '--dirty=+', '--tags'], input: 'VERSION.in', output: 'VERSION')`
fails to build with errors like:
```
ldc2 -I=girtod@exe -I=. -I=.. -I=../source/ -I= -enable-color -wi -g -d-debug -of='girtod@exe/source_girtod.d.o' -c ../source/girtod.d
```
This bug has been in the code since forever, but is now exposed because for whatever reason, the LDC D compiler backend was changed to use `=` between a compiler flag and its value.

This results in build failures like https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=910443, but I have also seen this issue on other occasions.
This patch fixes the regression by testing whether the `target_dir` of a custom target is empty before including it (there might be a more sophisticated solution, but as a safeguard I think this patch should be included anyway).

Cheers,
    Matthias