### PR TITLE
gnome: Quote arguments passed to gtkdoc-scangobj

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -17,6 +17,7 @@ functionality such as gobject-introspection, gresources and gtk-doc'''
 
 import os
 import copy
+import shlex
 import subprocess
 
 from .. import build
@@ -1034,12 +1035,12 @@ This will become a hard error in the future.''')
         ldflags.update(compiler_flags[1])
         ldflags.update(compiler_flags[2])
         if compiler:
-            args += ['--cc=%s' % ' '.join(compiler.get_exelist())]
-            args += ['--ld=%s' % ' '.join(compiler.get_linker_exelist())]
+            args += ['--cc=%s' % ' '.join([shlex.quote(x) for x in compiler.get_exelist()])]
+            args += ['--ld=%s' % ' '.join([shlex.quote(x) for x in compiler.get_linker_exelist()])]
         if cflags:
-            args += ['--cflags=%s' % ' '.join(cflags)]
+            args += ['--cflags=%s' % ' '.join([shlex.quote(x) for x in cflags])]
         if ldflags:
-            args += ['--ldflags=%s' % ' '.join(ldflags)]
+            args += ['--ldflags=%s' % ' '.join([shlex.quote(x) for x in ldflags])]
 
         return args
 


### PR DESCRIPTION
It is possible for compiler flags to include special characters, such as
double quotes which are needed to define macros with -D options. Since
gtkdoc-scangobj uses shlex.split to split arguments passed to --cc,
--ld, --cflags, --ldflags into lists, we can safely use shlex.quote to
properly quote arguments for these options.

This fixes gtk-doc build failure for at-spi2-core.
```
Running custom install script '/home/lantw44/gnome/devinstall/bin/meson --internal gtkdoc --sourcedir=/home/lantw44/gnome/source/at-spi2-core --builddir=/home/lantw44/gnome/build/at-spi2-core --subdir=doc/libatspi --headerdirs=/home/lantw44/gnome/source/at-spi2-core/atspi@@/home/lantw44/gnome/build/at-spi2-core/atspi --mainfile=libatspi-docs.sgml --modulename=libatspi --mode=auto --scanargs=--rebuild-types --gobjects-types-file=/home/lantw44/gnome/source/at-spi2-core/doc/libatspi/libatspi.types --fixxrefargs=--html-dir=/home/lantw44/gnome/devinstall/share/gtk-doc/html@@--extra-dir=/home/lantw44/gnome/devinstall/share/gtk-doc/html/glib@@--extra-dir=/home/lantw44/gnome/devinstall/share/gtk-doc/html/gobject --mkdbargs=--sgml-mode@@--output-format=xml --content-files= --cc=clang -B/home/lantw44/.local/bin --ld=clang -B/home/lantw44/.local/bin --cflags=-I/home/lantw44/gnome/build/at-spi2-core/. -I/home/lantw44/gnome/source/at-spi2-core/. -I/usr/local/include/dbus-1.0 -I/usr/local/lib/dbus-1.0/include -I/home/lantw44/gnome/devinstall/include/glib-2.0 -I/home/lantw44/gnome/devinstall/lib/glib-2.0/include -I/usr/local/lib/libffi-3.2.1/include -DG_LOG_DOMAIN="dbind" -D_THREAD_SAFE -pthread -march=corei7 -B/home/lantw44/.local/bin -pipe -g3 -O0 -gz -fdebug-macro --ldflags=-L/home/lantw44/gnome/build/at-spi2-core/atspi -Wl,-rpath,/home/lantw44/gnome/build/at-spi2-core/atspi -latspi -L/usr/local/lib -ldbus-1 -L/home/lantw44/gnome/devinstall/lib -lgobject-2.0 -lglib-2.0 -lintl -lX11 -lXtst -lXi -march=corei7 -B/home/lantw44/.local/bin -pipe -g3 -O0 -gz -fdebug-macro -Wl,--compress-debug-sections=zlib'
Building documentation for libatspi
ERROR:
Error in gtkdoc helper script:

ERROR: 'gtkdoc-scangobj' failed with status 1
libatspi-scan.c:194:5: error: use of undeclared identifier 'dbind'
    g_warning ("Couldn't open output file: %s : %s", signals_filename, g_strerror(errno));
    ^
/home/lantw44/gnome/devinstall/include/glib-2.0/glib/gmessages.h:337:32: note: expanded from macro 'g_warning'
#define g_warning(...)  g_log (G_LOG_DOMAIN,         \
                               ^
<command line>:1:22: note: expanded from here
#define G_LOG_DOMAIN dbind
                     ^
libatspi-scan.c:462:5: error: use of undeclared identifier 'dbind'
    g_warning ("Couldn't open output file: %s : %s", hierarchy_filename, g_strerror(errno));
    ^
/home/lantw44/gnome/devinstall/include/glib-2.0/glib/gmessages.h:337:32: note: expanded from macro 'g_warning'
#define g_warning(...)  g_log (G_LOG_DOMAIN,         \
                               ^
<command line>:1:22: note: expanded from here
#define G_LOG_DOMAIN dbind
                     ^
libatspi-scan.c:521:5: error: use of undeclared identifier 'dbind'
    g_warning ("Couldn't open output file: %s : %s", interfaces_filename, g_strerror(errno));
    ^
/home/lantw44/gnome/devinstall/include/glib-2.0/glib/gmessages.h:337:32: note: expanded from macro 'g_warning'
#define g_warning(...)  g_log (G_LOG_DOMAIN,         \
                               ^
<command line>:1:22: note: expanded from here
#define G_LOG_DOMAIN dbind
                     ^
libatspi-scan.c:571:5: error: use of undeclared identifier 'dbind'
    g_warning ("Couldn't open output file: %s : %s", prerequisites_filename, g_strerror(errno));
    ^
/home/lantw44/gnome/devinstall/include/glib-2.0/glib/gmessages.h:337:32: note: expanded from macro 'g_warning'
#define g_warning(...)  g_log (G_LOG_DOMAIN,         \
                               ^
<command line>:1:22: note: expanded from here
#define G_LOG_DOMAIN dbind
                     ^
libatspi-scan.c:617:5: error: use of undeclared identifier 'dbind'
    g_warning ("Couldn't open output file: %s : %s", args_filename, g_strerror(errno));
    ^
/home/lantw44/gnome/devinstall/include/glib-2.0/glib/gmessages.h:337:32: note: expanded from macro 'g_warning'
#define g_warning(...)  g_log (G_LOG_DOMAIN,         \
                               ^
<command line>:1:22: note: expanded from here
#define G_LOG_DOMAIN dbind
                     ^
5 errors generated.
2018-10-08 23:39:47,935:scangobj.py:execute_command:1198:WARNING:Compiling scanner failed: 1, command: clang -B/home/lantw44/.local/bin -I/home/lantw44/gnome/build/at-spi2-core/. -I/home/lantw44/gnome/source/at-spi2-core/. -I/usr/local/include/dbus-1.0 -I/usr/local/lib/dbus-1.0/include -I/home/lantw44/gnome/devinstall/include/glib-2.0 -I/home/lantw44/gnome/devinstall/lib/glib-2.0/include -I/usr/local/lib/libffi-3.2.1/include -DG_LOG_DOMAIN=dbind -D_THREAD_SAFE -pthread -march=corei7 -B/home/lantw44/.local/bin -pipe -g3 -O0 -gz -fdebug-macro -c -o libatspi-scan.o libatspi-scan.c

FAILED: meson-install
/home/lantw44/gnome/devinstall/bin/meson install --no-rebuild
ninja: build stopped: subcommand failed.
```

This problem cannot be reproduced in meson 0.47 because it is commit d0a7ea5e6e44c88178c6e5f4b0b5df8d735cbf75 that introduces -D arguments into --cflags for at-spi2-core.