### PR TITLE
Add gnu hurd to *_machine information

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -84,6 +84,7 @@ These are provided by the `.system()` method call.
 | freebsd             | FreeBSD and its derivatives |
 | dragonfly           | DragonFly BSD |
 | netbsd              | |
+| gnu                 | GNU Hurd |
 
 Any string not listed above is not guaranteed to remain stable in
 future releases.

--- a/test cases/common/137 get define/meson.build
+++ b/test cases/common/137 get define/meson.build
@@ -32,6 +32,9 @@ foreach lang : ['c', 'cpp']
   elif host_system == 'netbsd'
     d = cc.get_define('__NetBSD__')
     assert(d == '1', '__NetBSD__ value is @0@ instead of 1'.format(d))
+  elif host_system == 'gnu'
+    d = cc.get_define('__GNU__')
+    assert(d == '1', '__GNU__ value is @0@ instead of 1'.format(d))
   else
     error('Please report a bug and help us improve support for this platform')
   endif


### PR DESCRIPTION
GNU hurd returns "GNU" as it's system, I think we should lower it, since
no other operating system uses capital letters, even though some of them
properly do (Linux, FreeBSD, etc).

Hurd can't run the project tests because it lacks the primitives to run `concurrent.futures`, half the tests that do run don't pass because `sendmmsg` is a stub, and I really don't care about the rest. This test does pass now. And hurd is in the system table. 