### PR TITLE
ICC fixes for Linux and MacOS

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -410,12 +410,12 @@ class CCompiler(Compiler):
                              dependencies=dependencies)
 
     def _get_compiler_check_args(self, env, extra_args, dependencies, mode='compile'):
-        if callable(extra_args):
-            extra_args = extra_args(mode)
         if extra_args is None:
             extra_args = []
-        elif isinstance(extra_args, str):
-            extra_args = [extra_args]
+        else:
+            extra_args = listify(extra_args)
+        extra_args = listify([e(mode) if callable(e) else e for e in extra_args])
+
         if dependencies is None:
             dependencies = []
         elif not isinstance(dependencies, list):

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -175,7 +175,11 @@ class CCompiler(Compiler):
             # link.exe
             return ['/FORCE:UNRESOLVED']
         elif self.id == 'intel':
-            return ['-Wl,--allow-shlib-undefined']
+            if self.compiler_type.is_osx_compiler:
+                # Apple ld
+                return ['-Wl,-undefined,dynamic_lookup']
+            else:
+                return ['-Wl,--allow-shlib-undefined']
         # FIXME: implement other linkers
         return []
 

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1245,7 +1245,7 @@ class IntelCCompiler(IntelCompiler, CCompiler):
         CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper, **kwargs)
         IntelCompiler.__init__(self, compiler_type)
         self.lang_header = 'c-header'
-        default_warn_args = ['-Wall', '-w3', '-diag-disable:remark', '-Wpch-messages']
+        default_warn_args = ['-Wall', '-w3', '-diag-disable:remark']
         self.warn_args = {'1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
                           '3': default_warn_args + ['-Wextra']}

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -157,32 +157,6 @@ class CCompiler(Compiler):
         '''
         return self.get_no_optimization_args()
 
-    def get_allow_undefined_link_args(self):
-        '''
-        Get args for allowing undefined symbols when linking to a shared library
-        '''
-        if self.id in ('clang', 'gcc'):
-            if self.compiler_type.is_osx_compiler:
-                # Apple ld
-                return ['-Wl,-undefined,dynamic_lookup']
-            elif self.compiler_type.is_windows_compiler:
-                # For PE/COFF this is impossible
-                return []
-            else:
-                # GNU ld and LLVM lld
-                return ['-Wl,--allow-shlib-undefined']
-        elif isinstance(self, VisualStudioCCompiler):
-            # link.exe
-            return ['/FORCE:UNRESOLVED']
-        elif self.id == 'intel':
-            if self.compiler_type.is_osx_compiler:
-                # Apple ld
-                return ['-Wl,-undefined,dynamic_lookup']
-            else:
-                return ['-Wl,--allow-shlib-undefined']
-        # FIXME: implement other linkers
-        return []
-
     def get_output_args(self, target):
         return ['-o', target]
 
@@ -1600,10 +1574,16 @@ class VisualStudioCCompiler(CCompiler):
     def get_argument_syntax(self):
         return 'msvc'
 
+    def get_allow_undefined_link_args(self):
+        # link.exe
+        return ['/FORCE:UNRESOLVED']
+
+
 class ClangClCCompiler(VisualStudioCCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrap, is_64):
         super().__init__(exelist, version, is_cross, exe_wrap, is_64)
         self.id = 'clang-cl'
+
 
 class ArmCCompiler(ArmCompiler, CCompiler):
     def __init__(self, exelist, version, compiler_type, is_cross, exe_wrapper=None, **kwargs):

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -174,6 +174,8 @@ class CCompiler(Compiler):
         elif isinstance(self, VisualStudioCCompiler):
             # link.exe
             return ['/FORCE:UNRESOLVED']
+        elif self.id == 'intel':
+            return ['-Wl,--allow-shlib-undefined']
         # FIXME: implement other linkers
         return []
 

--- a/mesonbuild/compilers/c_function_attributes.py
+++ b/mesonbuild/compilers/c_function_attributes.py
@@ -91,10 +91,10 @@ C_FUNC_ATTRIBUTES = {
     'used':
         'int foo(void) __attribute__((used));',
     'visibility': '''
-        int foo_def(void) __attribute__((visibility(("default"))));
-        int foo_hid(void) __attribute__((visibility(("hidden"))));
-        int foo_int(void) __attribute__((visibility(("internal"))));
-        int foo_pro(void) __attribute__((visibility(("protected"))));''',
+        int foo_def(void) __attribute__((visibility("default")));
+        int foo_hid(void) __attribute__((visibility("hidden")));
+        int foo_int(void) __attribute__((visibility("internal")));
+        int foo_pro(void) __attribute__((visibility("protected")));''',
     'warning':
         'int foo(void) __attribute__((warning("")));',
     'warn_unused_result':

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1731,10 +1731,17 @@ class ArmclangCompiler:
         return ['--symdefs=' + implibname]
 
 
-# Tested on linux for ICC 14.0.3, 15.0.6, 16.0.4, 17.0.1
+# Tested on linux for ICC 14.0.3, 15.0.6, 16.0.4, 17.0.1, 19.0.0
 class IntelCompiler(GnuLikeCompiler):
     def __init__(self, compiler_type):
         super().__init__(compiler_type)
+        # As of 19.0.0 ICC doesn't have sanitizer, color, or lto support.
+        #
+        # It does have IPO, which serves much the same purpose as LOT, but
+        # there is an unfortunate rule for using IPO (you can't control the
+        # name of the output file) which break assumptions meson makes
+        self.base_options = ['b_pch', 'b_lundef', 'b_asneeded', 'b_pgo',
+                             'b_coverage', 'b_ndebug', 'b_staticpic', 'b_pie']
         self.id = 'intel'
         self.lang_header = 'none'
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1265,6 +1265,12 @@ class Compiler:
         raise EnvironmentException(
             '%s does not support get_profile_use_args ' % self.get_id())
 
+    def get_undefined_link_args(self):
+        '''
+        Get args for allowing undefined symbols when linking to a shared library
+        '''
+        return []
+
 
 @enum.unique
 class CompilerType(enum.Enum):
@@ -1510,6 +1516,14 @@ class GnuLikeCompiler(abc.ABC):
 
     def get_profile_use_args(self):
         return ['-fprofile-use', '-fprofile-correction']
+
+    def get_allow_undefined_link_args(self):
+        if self.compiler_type.is_osx_compiler:
+            # Apple ld
+            return ['-Wl,-undefined,dynamic_lookup']
+        else:
+            # GNU ld and LLVM lld
+            return ['-Wl,--allow-shlib-undefined']
 
 
 class GnuCompiler(GnuLikeCompiler):

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1789,6 +1789,7 @@ class IntelCompiler(GnuLikeCompiler):
             extra_args,
             '-diag-error', '10006',  # ignoring unknown option
             '-diag-error', '10148',  # Option not supported
+            '-diag-error', '1292',   # unknown __attribute__
         ]
         return super().compiles(*args, **kwargs)
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -19,7 +19,10 @@ from ..linkers import StaticLinker
 from .. import coredata
 from .. import mlog
 from .. import mesonlib
-from ..mesonlib import EnvironmentException, MesonException, OrderedSet, version_compare, Popen_safe
+from ..mesonlib import (
+    EnvironmentException, MesonException, OrderedSet, version_compare,
+    Popen_safe
+)
 
 """This file contains the data files of all compilers Meson knows
 about. To support a new compiler, add its information below.
@@ -1733,6 +1736,7 @@ class ArmclangCompiler:
 
 # Tested on linux for ICC 14.0.3, 15.0.6, 16.0.4, 17.0.1, 19.0.0
 class IntelCompiler(GnuLikeCompiler):
+
     def __init__(self, compiler_type):
         super().__init__(compiler_type)
         # As of 19.0.0 ICC doesn't have sanitizer, color, or lto support.
@@ -1764,9 +1768,16 @@ class IntelCompiler(GnuLikeCompiler):
         else:
             return ['-openmp']
 
-    def has_arguments(self, args, env, code, mode):
-        # -diag-error 10148 is required to catch invalid -W options
-        return super().has_arguments(args + ['-diag-error', '10006', '-diag-error', '10148'], env, code, mode)
+    def compiles(self, *args, **kwargs):
+        # This covers a case that .get('foo', []) doesn't, that extra_args is
+        # defined and is None
+        extra_args = kwargs.get('extra_args') or []
+        kwargs['extra_args'] = [
+            extra_args,
+            '-diag-error', '10006',  # ignoring unknown option
+            '-diag-error', '10148',  # Option not supported
+        ]
+        return super().compiles(*args, **kwargs)
 
 
 class ArmCompiler:

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -169,7 +169,7 @@ end program prog
         return ('-I', )
 
     def get_module_outdir_args(self, path):
-        return ['-module' + path]
+        return ['-module', path]
 
     def module_name_to_filename(self, module_name):
         return module_name.lower() + '.mod'

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -342,6 +342,12 @@ class IntelFortranCompiler(IntelCompiler, FortranCompiler):
     def get_preprocess_only_args(self):
         return ['-cpp', '-EP']
 
+    def get_always_args(self):
+        """Ifort doesn't have -pipe."""
+        val = super().get_always_args()
+        val.remove('-pipe')
+        return val
+
 
 class PathScaleFortranCompiler(FortranCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwags):

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -345,6 +345,9 @@ class IntelFortranCompiler(IntelCompiler, FortranCompiler):
         val.remove('-pipe')
         return val
 
+    def language_stdlib_only_link_flags(self):
+        return ['-lifcore', '-limf']
+
 
 class PathScaleFortranCompiler(FortranCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwags):

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -144,9 +144,6 @@ end program prog
     def get_compiler_check_args(self):
         return CCompiler.get_compiler_check_args(self)
 
-    def get_allow_undefined_link_args(self):
-        return CCompiler.get_allow_undefined_link_args(self)
-
     def get_output_args(self, target):
         return CCompiler.get_output_args(self, target)
 

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -235,6 +235,7 @@ class OpenMPDependency(ExternalDependency):
     # Map date of specification release (which is the macro value) to a version.
     VERSIONS = {
         '201811': '5.0',
+        '201611': '5.0-revision1',  # This is supported by ICC 19.x
         '201511': '4.5',
         '201307': '4.0',
         '201107': '3.1',

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3918,7 +3918,7 @@ class LinuxlikeTests(BasePlatformTests):
         # when all tests are run (but works when only this test is run),
         # but doing this explicitly works.
         env = os.environ.copy()
-        env['LD_LIBRARY_PATH'] = installed_libdir
+        env['LD_LIBRARY_PATH'] = ':'.join([installed_libdir, env.get('LD_LIBRARY_PATH', '')])
         self.assertEqual(subprocess.call(installed_exe, env=env), 0)
         # Ensure that introspect --installed works
         installed = self.introspect('--installed')
@@ -4119,7 +4119,7 @@ endian = 'little'
             self.init(testdir2)
             self.build()
             myenv = os.environ.copy()
-            myenv['LD_LIBRARY_PATH'] = lib_dir
+            myenv['LD_LIBRARY_PATH'] = ':'.join([lib_dir, myenv.get('LD_LIBRARY_PATH', '')])
             if is_cygwin():
                 bin_dir = os.path.join(tempdirname, 'bin')
                 myenv['PATH'] = bin_dir + os.pathsep + myenv['PATH']

--- a/test cases/common/204 function attributes/meson.build
+++ b/test cases/common/204 function attributes/meson.build
@@ -63,7 +63,7 @@ if host_machine.system() != 'darwin'
   attributes += 'visibility'
 endif
 
-if c.get_id() == 'gcc'
+if ['gcc', 'intel'].contains(c.get_id())
   # not supported by clang as of 5.0.0 (at least up to 6.0.1)
   attributes += 'artificial'
   attributes += 'error'
@@ -73,7 +73,7 @@ if c.get_id() == 'gcc'
   attributes += 'optimize'
   attributes += 'warning'
 
-  if c.version().version_compare('>= 7.0.0')
+  if c.get_id() == 'gcc' and c.version().version_compare('>= 7.0.0')
     attributes += 'fallthrough'
   endif
 endif

--- a/test cases/fortran/9 cpp/meson.build
+++ b/test cases/fortran/9 cpp/meson.build
@@ -6,5 +6,16 @@ if cpp.get_id() == 'clang'
   error('MESON_SKIP_TEST Clang C++ does not find -lgfortran for some reason.')
 endif
 
-e = executable('cppfort', 'main.cpp', 'fortran.f')
+fc = meson.get_compiler('fortran')
+link_with = []
+if fc.get_id() == 'intel'
+  link_with += fc.find_library('ifport')
+endif
+
+e = executable(
+  'cppfort',
+  ['main.cpp', 'fortran.f'],
+  dependencies : [link_with],
+)
+
 test('C++ FORTRAN', e)


### PR DESCRIPTION
This not so little series goes a long way to getting ICC on Linux and MacOS up to snuff. On my local system there are only two tests left that don't pass in our test suit, the C++ and Fortran mixed test, and protocol buffers. Both of which are out of my depth to fix.

There are a few changes in this series that have bigger implications than it might first appear, one of those changes is the use of keyword only arguments, which solves a real problem in my series, but also is one that others will run into as meson's Compiler class hierarchy continues to become more complicated. The other is my attempt to fix the b_lundef option on Mac, which may or may not be completely correct.