### PR TITLE
Added .so to list possible darwin dynamic library suffixes

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -896,7 +896,7 @@ class CCompiler(Compiler):
             prefixes = ['lib', '']
         # Library suffixes and prefixes
         if for_darwin(env.is_cross_build(), env):
-            shlibext = ['dylib']
+            shlibext = ['dylib', 'so']
         elif for_windows(env.is_cross_build(), env):
             # FIXME: .lib files can be import or static so we should read the
             # file, figure out which one it is, and reject the wrong kind.

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -584,7 +584,7 @@ class InternalTests(unittest.TestCase):
                                 'static': unix_static},
                     'linux': {'shared': ('lib{}.so', '{}.so'),
                               'static': unix_static},
-                    'darwin': {'shared': ('lib{}.dylib', '{}.dylib'),
+                    'darwin': {'shared': ('lib{}.dylib', '{}.dylib', 'lib{}.so', '{}.so'),
                                'static': unix_static},
                     'cygwin': {'shared': ('cyg{}.dll', 'cyg{}.dll.a', 'lib{}.dll',
                                           'lib{}.dll.a', '{}.dll', '{}.dll.a'),

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -584,7 +584,7 @@ class InternalTests(unittest.TestCase):
                                 'static': unix_static},
                     'linux': {'shared': ('lib{}.so', '{}.so'),
                               'static': unix_static},
-                    'darwin': {'shared': ('lib{}.dylib', '{}.dylib', 'lib{}.so', '{}.so'),
+                    'darwin': {'shared': ('lib{}.dylib', 'lib{}.so', '{}.dylib', '{}.so'),
                                'static': unix_static},
                     'cygwin': {'shared': ('cyg{}.dll', 'cyg{}.dll.a', 'lib{}.dll',
                                           'lib{}.dll.a', '{}.dll', '{}.dll.a'),


### PR DESCRIPTION
Occasionally darwin libraries can be .so rather than .dylib e.g. tensorflow_cc.so