### PR TITLE
Use relative build-tree RPATHs on macOS

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -121,10 +121,7 @@ class CCompiler(Compiler):
     # The default behavior is this, override in MSVC
     @functools.lru_cache(maxsize=None)
     def build_rpath_args(self, build_dir, from_dir, rpath_paths, build_rpath, install_rpath):
-        if getattr(self, 'compiler_type', False) and self.compiler_type.is_osx_compiler:
-            # Clang, GCC and ICC on macOS all use the same rpath arguments
-            return self.build_osx_rpath_args(build_dir, rpath_paths, build_rpath)
-        elif self.compiler_type.is_windows_compiler:
+        if self.compiler_type.is_windows_compiler:
             return []
         return self.build_unix_rpath_args(build_dir, from_dir, rpath_paths, build_rpath, install_rpath)
 


### PR DESCRIPTION
* This helps with reproducibility on macOS in the same way
  `$ORIGIN` improves reproducibility on Linux-like systems.
* This makes the build-tree more resilient to users injecting
  rpaths via `LDFLAGS`. Currently Meson on macOS crashes when
  a build-tree rpath and a user-provided `-Wl,-rpath` in
  LDFLAGS collide, leading to `install_name_tool` failures.
  While this still does not solve the root cause, it makes
  the occurrence much less likely, as users will generally
  pass absolute `-Wl,-rpath` arguments into Meson.