### PR TITLE
Use .gitattributes to override autocrlf=true

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 .gitignore export-ignore
 .gitattributes export-ignore
+* text eol=lf
+*.png binary

--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -87,6 +87,8 @@ steps:
 - task: PublishBuildArtifacts@1
   inputs:
     artifactName: $(System.JobName)
+  # publishing artifacts from PRs from a fork is currently blocked
+  condition: eq(variables['system.pullrequest.isfork'], false)
 
 - powershell: |
      # after publishing test results, even if some failed


### PR DESCRIPTION
Avoid platform eol normalization as check_format() in project_tests checks
for unix-style line endings.

Indicate .png files are binary so we don't try to normalize them on
check-in.