### PR TITLE
Added basic detection for AIX linker

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -930,6 +930,8 @@ This is probably wrong, it should always point to the native compiler.''' % evar
                 return ArLinker(linker)
             if p.returncode == 1 and err.startswith('usage'): # OSX
                 return ArLinker(linker)
+            if p.returncode == 1 and err.startswith('Usage'): # AIX
+                return ArLinker(linker)
         self._handle_exceptions(popen_exceptions, linkers, 'linker')
         raise EnvironmentException('Unknown static linker "%s"' % ' '.join(linkers))
 


### PR DESCRIPTION
The AIX linker decided to have a capital `U` in the help message, but other than that for all intents and purposes it's just the same interface as the binutils ar.

I figured that this was better than a `err.lower().startswith('using')` and grouping it together with macOS.