### PR TITLE
wrap: Apply patch even in VCS cases

### DIFF
--- a/docs/markdown/Wrap-dependency-system-manual.md
+++ b/docs/markdown/Wrap-dependency-system-manual.md
@@ -70,11 +70,7 @@ revision = head
 ## Accepted configuration properties for wraps
 - `directory` - name of the subproject root directory, defaults to the name of the wrap.
 
-### Specific to wrap-file
-- `source_url` - download url to retrieve the wrap-file source archive
-- `source_fallback_url` - fallback URL to be used when download from `source_url` fails *Since: 0.55.0*
-- `source_filename` - filename of the downloaded source archive
-- `source_hash` - sha256 checksum of the downloaded source archive
+Since *0.55.0* those can be used in all wrap types, they were previously reserved to `wrap-file`:
 - `patch_url` - download url to retrieve an optional overlay archive
 - `patch_fallback_url` - fallback URL to be used when download from `patch_url` fails *Since: 0.55.0*
 - `patch_filename` - filename of the downloaded overlay archive
@@ -82,6 +78,12 @@ revision = head
 - `patch_directory` - *Since 0.55.0* Overlay directory, alternative to `patch_filename` in the case
   files are local instead of a downloaded archive. The directory must be placed in
   `subprojects/packagefiles`.
+
+### Specific to wrap-file
+- `source_url` - download url to retrieve the wrap-file source archive
+- `source_fallback_url` - fallback URL to be used when download from `source_url` fails *Since: 0.55.0*
+- `source_filename` - filename of the downloaded source archive
+- `source_hash` - sha256 checksum of the downloaded source archive
 - `lead_directory_missing` - for `wrap-file` create the leading
   directory name. Needed when the source file does not have a leading
   directory.

--- a/docs/markdown/snippets/wrap_patch.md
+++ b/docs/markdown/snippets/wrap_patch.md
@@ -12,3 +12,8 @@ case overlay files are local. Every files in that directory, and subdirectories,
 will be copied to the subproject directory. This can be used for example to add
 `meson.build` files to a project not using Meson build system upstream.
 The patch directory must be placed in `subprojects/packagefiles` directory.
+
+## Patch on all wrap types
+
+`patch_*` keys are not limited to `wrap-file` any more, they can be specified for
+all wrap types.

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -192,6 +192,7 @@ class Resolver:
                     self.get_svn()
                 else:
                     raise WrapException('Unknown wrap type {!r}'.format(self.wrap.type))
+            self.apply_patch()
 
         # A meson.build or CMakeLists.txt file is required in the directory
         if method == 'meson' and not os.path.exists(meson_file):
@@ -251,7 +252,6 @@ class Resolver:
             os.mkdir(self.dirname)
             extract_dir = self.dirname
         shutil.unpack_archive(path, extract_dir)
-        self.apply_patch()
 
     def get_git(self) -> None:
         if not GIT:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4999,6 +4999,25 @@ recommended as it is not supported on some platforms''')
             self.assertEqual(values['properties']['cpp_args'],
                              ['--sysroot=/toolchain/sysroot', '-DSOMETHING', '-DSOMETHING_ELSE'])
 
+    @unittest.skipIf(is_windows(), 'Directory cleanup fails for some reason')
+    def test_wrap_git(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            srcdir = os.path.join(tmpdir, 'src')
+            shutil.copytree(os.path.join(self.unit_test_dir, '78 wrap-git'), srcdir)
+            upstream = os.path.join(srcdir, 'subprojects', 'wrap_git_upstream')
+            upstream_uri = Path(upstream).as_uri()
+            _git_init(upstream)
+            with open(os.path.join(srcdir, 'subprojects', 'wrap_git.wrap'), 'w') as f:
+                f.write(textwrap.dedent('''
+                  [wrap-git]
+                  url = {}
+                  patch_directory = wrap_git_builddef
+                  revision = master
+                '''.format(upstream_uri)))
+            self.init(srcdir)
+            self.build()
+            self.run_tests()
+
 class FailureTests(BasePlatformTests):
     '''
     Tests that test failure conditions. Build files here should be dynamically

--- a/test cases/unit/78 wrap-git/meson.build
+++ b/test cases/unit/78 wrap-git/meson.build
@@ -1,0 +1,4 @@
+project('test-wrap-git')
+
+exe = subproject('wrap_git').get_variable('exe')
+test('test1', exe)

--- a/test cases/unit/78 wrap-git/subprojects/packagefiles/wrap_git_builddef/meson.build
+++ b/test cases/unit/78 wrap-git/subprojects/packagefiles/wrap_git_builddef/meson.build
@@ -1,0 +1,3 @@
+project('foo', 'c')
+
+exe = executable('app', 'main.c')

--- a/test cases/unit/78 wrap-git/subprojects/wrap_git_upstream/main.c
+++ b/test cases/unit/78 wrap-git/subprojects/wrap_git_upstream/main.c
@@ -1,0 +1,4 @@
+int main(void)
+{
+  return 0;
+}


### PR DESCRIPTION
It can be useful to have the wrap file track upstream master branch, and provide the meson build system as a patch on top. This avoids having to maintain a git clone.