### PR TITLE
Remove implicit compression of man pages

### DIFF
--- a/docs/markdown/Installing.md
+++ b/docs/markdown/Installing.md
@@ -26,7 +26,7 @@ Other install commands are the following.
 
 ```meson
 install_headers('header.h', subdir : 'projname') # -> include/projname/header.h
-install_man('foo.1') # -> share/man/man1/foo.1.gz
+install_man('foo.1') # -> share/man/man1/foo.1
 install_data('datafile.dat', install_dir : join_paths(get_option('datadir'), 'progname')) # -> share/progname/datafile.dat
 ```
 

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -908,8 +908,7 @@ An example value could be `['rwxr-sr-x', 'root', 'root']`.
 Installs the specified man files from the source tree into system's
 man directory during the install step. This directory can be
 overridden by specifying it with the `install_dir` keyword
-argument. All man pages are compressed during installation and
-installed with a `.gz` suffix.
+argument.
 
 The `install_mode` argument can be used to specify the file mode in symbolic
 format and optionally the owner/uid and group/gid for the installed files.

--- a/docs/markdown/snippets/manpage_compression.md
+++ b/docs/markdown/snippets/manpage_compression.md
@@ -1,0 +1,7 @@
+## Manpages are no longer compressed implicitly
+
+Earlier, the `install_man` command has automatically compressed installed
+manpages into `.gz` format. This collided with manpage compression hooks
+already used by various distributions. Now, manpages are installed uncompressed
+and distributors are expected to handle compressing them according to their own
+compression preferences.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1083,7 +1083,7 @@ class Backend:
                 if subdir is None:
                     subdir = os.path.join(manroot, 'man' + num)
                 srcabs = f.absolute_path(self.environment.get_source_dir(), self.environment.get_build_dir())
-                dstabs = os.path.join(subdir, os.path.basename(f.fname) + '.gz')
+                dstabs = os.path.join(subdir, os.path.basename(f.fname))
                 i = [srcabs, dstabs, m.get_custom_install_mode()]
                 d.man.append(i)
 

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -379,17 +379,7 @@ class Installer:
             outdir = os.path.dirname(outfilename)
             d.dirmaker.makedirs(outdir, exist_ok=True)
             install_mode = m[2]
-            if outfilename.endswith('.gz') and not full_source_filename.endswith('.gz'):
-                with open(outfilename, 'wb') as of:
-                    with open(full_source_filename, 'rb') as sf:
-                        # Set mtime and filename for reproducibility.
-                        with gzip.GzipFile(fileobj=of, mode='wb', filename='', mtime=0) as gz:
-                            gz.write(sf.read())
-                shutil.copystat(full_source_filename, outfilename)
-                print('Installing %s to %s' % (full_source_filename, outdir))
-                append_to_log(self.lf, outfilename)
-            else:
-                self.do_copyfile(full_source_filename, outfilename)
+            self.do_copyfile(full_source_filename, outfilename)
             set_mode(outfilename, install_mode, d.install_umask)
 
     def install_headers(self, d):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3621,7 +3621,7 @@ class LinuxlikeTests(BasePlatformTests):
                 ('share', 'drwxr-x---'),
                 ('share/man', 'drwxr-x---'),
                 ('share/man/man1', 'drwxr-x---'),
-                ('share/man/man1/foo.1.gz', '-r--r--r-T'),
+                ('share/man/man1/foo.1', '-r--r--r-T'),
                 ('share/sub1', 'drwxr-x---'),
                 ('share/sub1/second.dat', '-rwxr-x--t'),
                 ('subdir', 'drwxr-x---'),
@@ -3694,7 +3694,7 @@ class LinuxlikeTests(BasePlatformTests):
                 'include/sample.h',
                 'share/datafile.cat',
                 'share/file.dat',
-                'share/man/man1/prog.1.gz',
+                'share/man/man1/prog.1',
                 'share/subdir/datafile.dog',
         ]:
             f = os.path.join(self.installdir, 'usr', *datafile.split('/'))

--- a/test cases/common/10 man install/installed_files.txt
+++ b/test cases/common/10 man install/installed_files.txt
@@ -1,5 +1,5 @@
-usr/share/man/man1/foo.1.gz
-usr/share/man/man2/bar.2.gz
-usr/share/man/man1/vanishing.1.gz
-usr/share/man/man2/vanishing.2.gz
-usr/share/man/man1/baz.1.gz
+usr/share/man/man1/foo.1
+usr/share/man/man2/bar.2
+usr/share/man/man1/vanishing.1
+usr/share/man/man2/vanishing.2
+usr/share/man/man1/baz.1

--- a/test cases/common/196 install_mode/installed_files.txt
+++ b/test cases/common/196 install_mode/installed_files.txt
@@ -4,7 +4,7 @@ usr/bin/trivialprog?exe
 usr/include/config.h
 usr/include/rootdir.h
 usr/libtest/libstat.a
-usr/share/man/man1/foo.1.gz
+usr/share/man/man1/foo.1
 usr/share/sub1/second.dat
 usr/share/sub2/stub
 usr/subdir/data.dat

--- a/test cases/common/49 custom install dirs/installed_files.txt
+++ b/test cases/common/49 custom install dirs/installed_files.txt
@@ -4,8 +4,8 @@ usr/dib/dab/dub2/prog2?exe
 ?msvc:usr/dib/dab/dub2/prog2.pdb
 usr/some/dir/sample.h
 usr/some/dir2/sample.h
-usr/woman/prog.1.gz
-usr/woman2/prog.1.gz
+usr/woman/prog.1
+usr/woman2/prog.1
 usr/meow/datafile.cat
 usr/meow2/datafile.cat
 usr/woof/subdir/datafile.dog


### PR DESCRIPTION
Remove the code responsible for implicitly compressing manpages as .gz
files.  It has been established that manpage compression is a distro
packager's task, with existing distros already having their own
implementations of compression.

Fixes #4330