### PR TITLE
add cpp_std support for MSVC

### DIFF
--- a/docs/markdown/snippets/add_release_note_snippets_here
+++ b/docs/markdown/snippets/add_release_note_snippets_here
@@ -1,0 +1,3 @@
+## Added `cpp_std` option for the Visual Studio C++ compiler
+Allows the use of C++17 features and experimental not-yet-standardized
+features. Valid options are `c++11`, `c++14`, `c++17`, and `c++latest`.

--- a/test cases/windows/17 cpp17/main.cpp
+++ b/test cases/windows/17 cpp17/main.cpp
@@ -1,0 +1,7 @@
+[[nodiscard]] int foo() {
+    return 0;
+}
+
+int main() {
+    return foo();
+}

--- a/test cases/windows/17 cpp17/meson.build
+++ b/test cases/windows/17 cpp17/meson.build
@@ -1,0 +1,9 @@
+project('msvc_cpp17', 'cpp', default_options: ['cpp_std=c++17'])
+
+compiler = meson.get_compiler('cpp')
+if compiler.get_id() != 'msvc' or compiler.version().version_compare('<19.11')
+    error('MESON_SKIP_TEST Visual Studio 2017 (version 15.3) or later is required for C++17 support')
+endif
+
+exe = executable('msvc_cpp17', 'main.cpp')
+test('msvc_cpp17', exe)


### PR DESCRIPTION
As of right now, we have to use this silly hack https://github.com/ubsan/ublib/blob/master/meson.build#L17, so I decided to add C++17 support.

Mostly based on #2836