### PR TITLE
add support for `/permissive-`

### DIFF
--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -10,6 +10,12 @@ if not dep.found()
   error('MESON_SKIP_TEST boost not found.')
 endif
 
+compiler = meson.get_compiler('cpp')
+if compiler.has_argument('-permissive')
+  # boost 1.64, the version we test against, doesn't work with -permissive
+  add_project_arguments('-permissive', language: 'cpp')
+endif
+
 # We want to have multiple separate configurations of Boost
 # within one project. The need to be independent of each other.
 # Use one without a library dependency and one with it.


### PR DESCRIPTION
We do this with `cpp_std=vc++NM` - `vc++` does not add `/permissive-`, while `cpp_std=c++NM` adds `/permissive-`.