### PR TITLE
Print "unsupported version" from sys before importing meson modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,12 @@
 
 import sys
 
-from mesonbuild.coredata import version
-
 if sys.version_info < (3, 5, 0):
     print('Tried to install with an unsupported version of Python. '
           'Meson requires Python 3.5.0 or greater')
     sys.exit(1)
 
+from mesonbuild.coredata import version
 from setuptools import setup
 
 # On windows, will create Scripts/meson.exe and Scripts/meson-script.py


### PR DESCRIPTION
When using an unsupported Python version such as 3.4 for building, an error is thrown instead of printing "unsupported version".  This is caused by the import of mesonbuild.coredata, and subsequent modules such as mesonlib, etc., between importing sys, and sys.exit() in setup.py

Example of the error as thrown:
```
$ python3.4 setup.py build
Traceback (most recent call last):
  File "setup.py", line 19, in <module>
    from mesonbuild.coredata import version
  File "/data/BUILD/meson-0.48.0/mesonbuild/coredata.py", line 20, in <module>
    from .mesonlib import MesonException
  File "/data/BUILD/meson-0.48.0/mesonbuild/mesonlib.py", line 1065, in <module>
    class OrderedSet(collections.abc.MutableSet):
AttributeError: 'module' object has no attribute 'abc'
```

The import of mesonbuild.coredata should occur after checking sys.version_info()
