### PR TITLE
module-qt: add rcc_extra_arguments to pass extra arguments to rcc

### DIFF
--- a/docs/markdown/Qt5-module.md
+++ b/docs/markdown/Qt5-module.md
@@ -10,6 +10,7 @@ This method takes the following keyword arguments:
  - `include_directories`, the directories to add to header search path for `moc` (optional)
  - `moc_extra_arguments`, any additional arguments to `moc` (optional). Available since v0.44.0.
  - `uic_extra_arguments`, any additional arguments to `uic` (optional). Available since v0.49.0.
+ - `rcc_extra_arguments`, any additional arguments to `rcc` (optional). Available since v0.49.0.
  - `dependencies`, dependency objects needed by moc. Available since v0.48.0.
 
 It returns an opaque object that should be passed to a main build target.

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -118,10 +118,11 @@ class QtBaseModule:
 
     @FeatureNewKwargs('qt.preprocess', '0.49.0', ['uic_extra_arguments'])
     @FeatureNewKwargs('qt.preprocess', '0.44.0', ['moc_extra_arguments'])
-    @permittedKwargs({'moc_headers', 'moc_sources', 'uic_extra_arguments', 'moc_extra_arguments', 'include_directories', 'dependencies', 'ui_files', 'qresources', 'method'})
+    @FeatureNewKwargs('qt.preprocess', '0.49.0', ['rcc_extra_arguments'])
+    @permittedKwargs({'moc_headers', 'moc_sources', 'uic_extra_arguments', 'moc_extra_arguments', 'rcc_extra_arguments', 'include_directories', 'dependencies', 'ui_files', 'qresources', 'method'})
     def preprocess(self, state, args, kwargs):
-        rcc_files, ui_files, moc_headers, moc_sources, uic_extra_arguments, moc_extra_arguments, sources, include_directories, dependencies \
-            = extract_as_list(kwargs, 'qresources', 'ui_files', 'moc_headers', 'moc_sources', 'uic_extra_arguments', 'moc_extra_arguments', 'sources', 'include_directories', 'dependencies', pop = True)
+        rcc_files, ui_files, moc_headers, moc_sources, uic_extra_arguments, moc_extra_arguments, rcc_extra_arguments, sources, include_directories, dependencies \
+            = extract_as_list(kwargs, 'qresources', 'ui_files', 'moc_headers', 'moc_sources', 'uic_extra_arguments', 'moc_extra_arguments', 'rcc_extra_arguments', 'sources', 'include_directories', 'dependencies', pop = True)
         sources += args[1:]
         method = kwargs.get('method', 'auto')
         self._detect_tools(state.environment, method)
@@ -140,7 +141,7 @@ class QtBaseModule:
                 name = args[0]
                 rcc_kwargs = {'input': rcc_files,
                               'output': name + '.cpp',
-                              'command': [self.rcc, '-name', name, '-o', '@OUTPUT@', '@INPUT@'],
+                              'command': [self.rcc, '-name', name, '-o', '@OUTPUT@', rcc_extra_arguments, '@INPUT@'],
                               'depend_files': qrc_deps}
                 res_target = build.CustomTarget(name, state.subdir, state.subproject, rcc_kwargs)
                 sources.append(res_target)
@@ -154,7 +155,7 @@ class QtBaseModule:
                     name = 'qt' + str(self.qt_version) + '-' + basename.replace('.', '_')
                     rcc_kwargs = {'input': rcc_file,
                                   'output': name + '.cpp',
-                                  'command': [self.rcc, '-name', '@BASENAME@', '-o', '@OUTPUT@', '@INPUT@'],
+                                  'command': [self.rcc, '-name', '@BASENAME@', '-o', '@OUTPUT@', rcc_extra_arguments, '@INPUT@'],
                                   'depend_files': qrc_deps}
                     res_target = build.CustomTarget(name, state.subdir, state.subproject, rcc_kwargs)
                     sources.append(res_target)

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -58,6 +58,10 @@ foreach qt : ['qt4', 'qt5']
     # Test that setting a unique name with a positional argument works
     qtmodule.preprocess(qt + 'teststuff', qresources : files(['stuff.qrc', 'stuff2.qrc']), method : get_option('method'))
 
+    # Test that passing extra arguments to rcc works
+    # qt4-rcc and qt5-rcc take different arguments, for example qt4: ['-compress', '3']; qt5: '--compress=3'
+    qtmodule.preprocess(qt + 'testrccarg', qresources : files(['stuff.qrc', 'stuff2.qrc']), rcc_extra_arguments : '--compress=3', method : get_option('method'))
+
     qexe = executable(qt + 'app',
       sources : ['main.cpp', 'mainWindow.cpp', # Sources that don't need preprocessing.
       prep, prep_rcc],


### PR DESCRIPTION
There's moc_extra_arguments for moc, and uic_extra_arguments for uic, but there isn't one for rcc.