### PR TITLE
Change default pkgconfig directory on FreeBSD

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -394,7 +394,10 @@ class PkgConfigModule(ExtensionModule):
         pcfile = filebase + '.pc'
         pkgroot = kwargs.get('install_dir', default_install_dir)
         if pkgroot is None:
-            pkgroot = os.path.join(state.environment.coredata.get_builtin_option('libdir'), 'pkgconfig')
+            if mesonlib.is_freebsd():
+                pkgroot = os.path.join(state.environment.coredata.get_builtin_option('prefix'), 'libdata', 'pkgconfig')
+            else:
+                pkgroot = os.path.join(state.environment.coredata.get_builtin_option('libdir'), 'pkgconfig')
         if not isinstance(pkgroot, str):
             raise mesonlib.MesonException('Install_dir must be a string.')
         self.generate_pkgconfig_file(state, deps, subdirs, name, description, url,


### PR DESCRIPTION
Hey,

FreeBSD uses ${PREFIX}/libdata/pkgconfig as default pkgconf search path for non-base libraries, so I think it would be appropriate for Meson to default to that directory too. This commit makes necessary changes for this.