### PR TITLE
compilers/c: Fix allow undefined link arg for PE/COFF

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -164,6 +164,9 @@ class CCompiler(Compiler):
             if self.compiler_type.is_osx_compiler:
                 # Apple ld
                 return ['-Wl,-undefined,dynamic_lookup']
+            elif self.compiler_type.is_windows_compiler:
+                # For PE/COFF this is impossible
+                return []
             else:
                 # GNU ld and LLVM lld
                 return ['-Wl,--allow-shlib-undefined']


### PR DESCRIPTION
For PE/COFF it is not possible to allow undefined symbols, so do not
try to use the option to do so.

While gcc ld silently ignores it, this is not the case for the llvm
linker.

Fix #4415