### PR TITLE
MSVC updated version to 1920 and VS 2017 point to 15.0

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1507,8 +1507,8 @@ class VisualStudioCCompiler(CCompiler):
             return '12.0' # (Visual Studio 2013)
         elif version < 1910:
             return '14.0' # (Visual Studio 2015)
-        elif version < 1920:
-            return '14.1' # (Visual Studio 2017)
+        elif version <= 1920:
+            return '15.0' # (Visual Studio 2017)
         return None
 
     def get_default_include_dirs(self):


### PR DESCRIPTION
Hello,

I am on the C++ team in Microsoft. We are testing https://github.com/anholt/libepoxy in an upcoming VS 2017 release. Libepoxy need **meson** source, so it failed with error like below in your source:
      **if float(compiler.get_toolset_version()) < 10.0:
     TypeError: float() argument must be a string or a number, not 'NoneType'**
This because MSVC version has updated to 1920, but get_toolset_version() is not support this version(out of checking). So could you please approve this now?

By the way, VS 2017 is point 15.0, so I also updated this from 14.1 to 15.0.

Thanks,
Larry 