### PR TITLE
add implib support for ArmclangCompiler

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1669,6 +1669,20 @@ class ArmclangCompiler:
     def get_debug_args(self, is_debug):
         return clike_debug_args[is_debug]
 
+    def gen_export_dynamic_link_args(self, env):
+        """
+        The args for export dynamic
+        """
+        return ['--export_dynamic']
+
+    def gen_import_library_args(self, implibname):
+        """
+        The args of the outputted import library
+
+        ArmLinker's symdefs output can be used as implib 
+        """
+        return ['--symdefs=' + implibname]
+
 
 # Tested on linux for ICC 14.0.3, 15.0.6, 16.0.4, 17.0.1
 class IntelCompiler(GnuLikeCompiler):

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1679,7 +1679,7 @@ class ArmclangCompiler:
         """
         The args of the outputted import library
 
-        ArmLinker's symdefs output can be used as implib 
+        ArmLinker's symdefs output can be used as implib
         """
         return ['--symdefs=' + implibname]
 


### PR DESCRIPTION
Armclang linker support output symdef file which containing the global symbol definitions from the output image that can be treat as static library and linked to other image.  Usually I use it to build BSP or redboot or sharelib image for bare metal MCU