### PR TITLE
Add add_test_setup_default()

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -105,6 +105,9 @@ the following:
 - `exe_wrapper` a list containing the wrapper command or script followed by the arguments to it
 - `gdb` if `true`, the tests are also run under `gdb`
 - `timeout_multiplier` a number to multiply the test timeout with
+- `is_default` a bool to set whether this is the default test setup.
+  If `true`, the setup will be used whenever `meson test` is run
+  without the `--setup` option. Since 0.49.0
 
 To use the test setup, run `meson test --setup=*name*` inside the build dir.
 

--- a/docs/markdown/snippets/test_setup_is_default.md
+++ b/docs/markdown/snippets/test_setup_is_default.md
@@ -1,0 +1,14 @@
+## New keyword argument `is_default` to `add_test_setup()`
+
+The keyword argument `is_default` may be used to set whether the test
+setup should be used by default whenever `meson test` is run without
+the `--setup` option.
+
+```meson
+add_test_setup('default', is_default: true, env: 'G_SLICE=debug-blocks')
+add_test_setup('valgrind', env: 'G_SLICE=always-malloc', ...)
+test('mytest', exe)
+```
+
+For the example above, running `meson test` and `meson test
+--setup=default` is now equivalent.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -135,6 +135,7 @@ class Build:
         self.dep_manifest = {}
         self.cross_stdlibs = {}
         self.test_setups = {}
+        self.test_setup_default_name = None
         self.find_overrides = {}
         self.searched_programs = set() # The list of all programs that have been searched for.
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3733,6 +3733,14 @@ different subdirectory.
         timeout_multiplier = kwargs.get('timeout_multiplier', 1)
         if not isinstance(timeout_multiplier, int):
             raise InterpreterException('Timeout multiplier must be a number.')
+        is_default = kwargs.get('is_default', False)
+        if not isinstance(is_default, bool):
+            raise InterpreterException('is_default option must be a boolean')
+        if is_default:
+            if self.build.test_setup_default_name is not None:
+                raise InterpreterException('\'%s\' is already set as default. '
+                                           'is_default can be set to true only once' % self.build.test_setup_default_name)
+            self.build.test_setup_default_name = setup_name
         env = self.unpack_env_kwarg(kwargs)
         self.build.test_setups[setup_name] = build.TestSetup(exe_wrapper=exe_wrapper,
                                                              gdb=gdb,

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -450,6 +450,8 @@ class TestHarness:
 
     def get_test_runner(self, test):
         options = deepcopy(self.options)
+        if not options.setup:
+            options.setup = self.build_data.test_setup_default_name
         if options.setup:
             env = self.merge_suite_options(options, test)
         else:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1461,6 +1461,38 @@ class AllPlatformTests(BasePlatformTests):
         self.assertRaises(subprocess.CalledProcessError, self._run,
                           self.mtest_command + ['--setup=main:onlyinbar'])
 
+    def test_testsetup_default(self):
+        testdir = os.path.join(self.unit_test_dir, '47 testsetup default')
+        self.init(testdir)
+        self.build()
+
+        # Run tests without --setup will cause the default setup to be used
+        self.run_tests()
+        with open(os.path.join(self.logdir, 'testlog.txt')) as f:
+            default_log = f.read()
+
+        # Run tests with explicitly using the same setup that is set as default
+        self._run(self.mtest_command + ['--setup=mydefault'])
+        with open(os.path.join(self.logdir, 'testlog-mydefault.txt')) as f:
+            mydefault_log = f.read()
+
+        # Run tests with another setup
+        self._run(self.mtest_command + ['--setup=other'])
+        with open(os.path.join(self.logdir, 'testlog-other.txt')) as f:
+            other_log = f.read()
+
+        self.assertTrue('ENV_A is 1' in default_log)
+        self.assertTrue('ENV_B is 2' in default_log)
+        self.assertTrue('ENV_C is 2' in default_log)
+
+        self.assertTrue('ENV_A is 1' in mydefault_log)
+        self.assertTrue('ENV_B is 2' in mydefault_log)
+        self.assertTrue('ENV_C is 2' in mydefault_log)
+
+        self.assertTrue('ENV_A is 1' in other_log)
+        self.assertTrue('ENV_B is 3' in other_log)
+        self.assertTrue('ENV_C is 2' in other_log)
+
     def assertFailedTestCount(self, failure_count, command):
         try:
             self._run(command)

--- a/test cases/unit/47 testsetup default/envcheck.py
+++ b/test cases/unit/47 testsetup default/envcheck.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import os
+
+assert('ENV_A' in os.environ)
+assert('ENV_B' in os.environ)
+assert('ENV_C' in os.environ)
+
+print('ENV_A is', os.environ['ENV_A'])
+print('ENV_B is', os.environ['ENV_B'])
+print('ENV_C is', os.environ['ENV_C'])

--- a/test cases/unit/47 testsetup default/meson.build
+++ b/test cases/unit/47 testsetup default/meson.build
@@ -1,0 +1,23 @@
+project('testsetup default', 'c')
+
+envcheck = find_program('envcheck.py')
+
+# Defining ENV_A in test-env should overwrite ENV_A from test setup
+env_1 = environment()
+env_1.set('ENV_A', '1')
+test('test-env', envcheck, env: env_1)
+
+# Defining default env which is used unless --setup is given or the
+# env variable is defined in the test.
+env_2 = environment()
+env_2.set('ENV_A', '2')
+env_2.set('ENV_B', '2')
+env_2.set('ENV_C', '2')
+add_test_setup('mydefault', env: env_2, is_default: true)
+
+# Defining a test setup that will update some of the env variables
+# from the default test setup.
+env_3 = env_2
+env_3.set('ENV_A', '3')
+env_3.set('ENV_B', '3')
+add_test_setup('other', env: env_3)


### PR DESCRIPTION
add_test_setup_default() may be used to define a setup that will
be used by default unless another setup is specified with --setup.

Since the "test env" overwrites the "setup env", some environment
variables should be defined in the setup and not in the test. In such
cases the use of --setup becomes mandatory for setting up a correct
environment, which is a bit tidious. Allowing a setup to be used by
default makes this much more convenient.

See issue #4430