### PR TITLE
get_base_compile_args: Add -fprofile-correction to -fprofile-use

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -429,7 +429,7 @@ def get_base_compile_args(options, compiler):
         if pgo_val == 'generate':
             args.append('-fprofile-generate')
         elif pgo_val == 'use':
-            args.append('-fprofile-use')
+            args.extend(['-fprofile-use', '-fprofile-correction'])
     except KeyError:
         pass
     try:
@@ -475,7 +475,7 @@ def get_base_link_args(options, linker, is_shared_module):
         if pgo_val == 'generate':
             args.append('-fprofile-generate')
         elif pgo_val == 'use':
-            args.append('-fprofile-use')
+            args.extend(['-fprofile-use', '-fprofile-correction'])
     except KeyError:
         pass
     try:


### PR DESCRIPTION
This allows using the imperfect profiles generated by multithreaded
programs. Without the argument, GCC fails to load them.

Clang just ignores the argument AFAICT.

Fixes https://github.com/mesonbuild/meson/issues/2159