### PR TITLE
pkgconfig: Also pull InternalDependency.libraries

### DIFF
--- a/docs/markdown/snippets/pkgconfig_break.md
+++ b/docs/markdown/snippets/pkgconfig_break.md
@@ -1,0 +1,34 @@
+## Deprecation warning in pkg-config generator
+
+All libraries passed to the `libraries` keyword argument of the `generate()`
+method used to be associated with that generated pkg-config file. That means
+that any subsequent call to `generate()` where those libraries appear would add
+the filebase of the `generate()` that first contained them into `Requires:` or
+`Requires.private:` field instead of adding an `-l` to `Libs:` or `Libs.private:`.
+
+This behaviour is now deprecated. The library that should be associated with
+the generated pkg-config file should be passed as first positional argument
+instead of in the `libraries` keyword argument. The previous behaviour is
+maintained but prints a deprecation warning and support for this will be removed
+in a future Meson release. If you can not create the needed pkg-config file
+without this warning, please file an issue with as much details as possible
+about the situation.
+
+For example this sample will write `Requires: liba` into `libb.pc` but print a
+deprecation warning:
+```meson
+liba = library(...)
+pkg.generate(libraries : liba)
+
+libb = library(...)
+pkg.generate(libraries : [liba, libb])
+```
+
+It can be fixed by passing `liba` as first positional argument::
+```meson
+liba = library(...)
+pkg.generate(liba)
+
+libb = library(...)
+pkg.generate(libb, libraries : [liba])
+```

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -479,7 +479,7 @@ class BuildTarget(Target):
         return repr_str.format(self.__class__.__name__, self.get_id(), self.filename)
 
     def validate_cross_install(self, environment):
-        if environment.is_cross_build() and not self.is_cross and self.install:
+        if environment.is_cross_build() and not self.is_cross and self.need_install:
             raise InvalidArguments('Tried to install a natively built target in a cross build.')
 
     def check_unknown_kwargs(self, kwargs):

--- a/test cases/common/48 pkgconfig-gen/dependencies/custom.c
+++ b/test cases/common/48 pkgconfig-gen/dependencies/custom.c
@@ -1,0 +1,3 @@
+int custom_function() {
+    return 42;
+}

--- a/test cases/common/48 pkgconfig-gen/dependencies/meson.build
+++ b/test cases/common/48 pkgconfig-gen/dependencies/meson.build
@@ -6,6 +6,7 @@ pkgg = import('pkgconfig')
 exposed_lib = shared_library('libexposed', 'exposed.c')
 internal_lib = shared_library('libinternal', 'internal.c')
 main_lib = both_libraries('libmain', link_with : [exposed_lib, internal_lib])
+custom_lib = shared_library('custom', 'custom.c')
 
 pkgg.generate(exposed_lib)
 
@@ -14,7 +15,7 @@ pc_dep = dependency('libfoo', version : '>=1.0')
 pc_dep_dup = dependency('libfoo', version : '>= 1.0')
 notfound_dep = dependency('notfound', required : false)
 threads_dep = dependency('threads')
-custom_dep = declare_dependency(link_args : ['-lcustom'], compile_args : ['-DCUSTOM'])
+custom_dep = declare_dependency(link_with : custom_lib, compile_args : ['-DCUSTOM'])
 custom2_dep = declare_dependency(link_args : ['-lcustom2'], compile_args : ['-DCUSTOM2'])
 
 # Generate a PC file:


### PR DESCRIPTION
When a library 'foo' has a public dependency 'bar', foo.pc will be
generated with something like this:
bar_dep = dependency('bar', fallback : ['bar', 'bar_dep'])
libfoo = library('foo', dependencies : bar_dep)
pkg.generate(libfoo, libraries : bar_dep)
    
In the subproject we will typically have this (not using pkg.generate):
libbar = library('bar')
bar_dep = declare_dependency(link_with : libbar)
configure_file(input : 'bar.pc.in', output : 'bar.pc', ...)
    
When the 'bar' dependency is built as subproject, libraries from
InternalDependency were not processed. If we process them,
then libbar.generated_pc is suddenly set to 'foo', which will cause any other
pc file generated to have 'Required : foo' for the 'bar' dependency. To
fix that 2nd issue, we set generated_pc only on the main lib passed a
positional argument, because in that case the intention is obvious. Libs
passed to "libraries" could be just public dependencies and not the
libraries for which we generate a pc file.
