### PR TITLE
Print dependencies being used for compiler checks

### DIFF
--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -104,6 +104,8 @@ def process_markup(args, keep):
     if log_timestamp_start is not None:
         arr = ['[{:.3f}]'.format(time.monotonic() - log_timestamp_start)]
     for arg in args:
+        if arg is None:
+            continue
         if isinstance(arg, str):
             arr.append(arg)
         elif isinstance(arg, AnsiDecorator):


### PR DESCRIPTION
It is a common idiom to look for a function or a specific type or a header in various locations/libraries, and it can be confusing to see the (seemingly) identical compiler check being done multiple times.

Now we print the dependencies being used when a compiler check is run

Before:
Checking for function "fbGetDisplay": NO
Checking for type "GLeglImageOES": YES
Checking for function "asinh": YES

After:
Checking for function "fbGetDisplay" with dependency egl: NO
Checking for type "GLeglImageOES" with dependencies glesv2, gl: YES
Checking for function "asinh" with dependency -lm: YES