### PR TITLE
Parsing of cross file upfront, and store in cross-agnostic data structures

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -343,7 +343,7 @@ class Backend:
                 exe_is_native = True
             is_cross_built = (not exe_is_native) and \
                 self.environment.is_cross_build() and \
-                self.environment.cross_info.need_exe_wrapper()
+                self.environment.need_exe_wrapper()
             if is_cross_built:
                 exe_wrapper = self.environment.get_exe_wrapper()
                 if not exe_wrapper.found():
@@ -639,11 +639,11 @@ class Backend:
     def get_mingw_extra_paths(self, target):
         paths = OrderedSet()
         # The cross bindir
-        root = self.environment.cross_info.get_root()
+        root = self.environment.properties.host.get_root()
         if root:
             paths.add(os.path.join(root, 'bin'))
         # The toolchain bindir
-        sys_root = self.environment.cross_info.get_sys_root()
+        sys_root = self.environment.properties.host.get_sys_root()
         if sys_root:
             paths.add(os.path.join(sys_root, 'bin'))
         # Get program and library dirs from all target compilers
@@ -692,7 +692,7 @@ class Backend:
             else:
                 cmd = [os.path.join(self.environment.get_build_dir(), self.get_target_filename(t.get_exe()))]
             is_cross = self.environment.is_cross_build() and \
-                self.environment.cross_info.need_exe_wrapper()
+                self.environment.need_exe_wrapper()
             if isinstance(exe, build.BuildTarget):
                 is_cross = is_cross and exe.is_cross
             if isinstance(exe, dependencies.ExternalProgram):
@@ -763,7 +763,7 @@ class Backend:
     def exe_object_to_cmd_array(self, exe):
         if self.environment.is_cross_build() and \
            isinstance(exe, build.BuildTarget) and exe.is_cross:
-            if self.environment.exe_wrapper is None and self.environment.cross_info.need_exe_wrapper():
+            if self.environment.exe_wrapper is None and self.environment.need_exe_wrapper():
                 s = textwrap.dedent('''
                     Can not use target {} as a generator because it is cross-built
                     and no exe wrapper is defined or needs_exe_wrapper is true.
@@ -977,15 +977,13 @@ class Backend:
     def create_install_data_files(self):
         install_data_file = os.path.join(self.environment.get_scratch_dir(), 'install.dat')
 
-        if self.environment.is_cross_build():
-            bins = self.environment.cross_info.config['binaries']
-            if 'strip' not in bins:
+        strip_bin = self.environment.binaries.host.lookup_entry('strip')
+        if strip_bin is None:
+            if self.environment.is_cross_build():
                 mlog.warning('Cross file does not specify strip binary, result will not be stripped.')
-                strip_bin = None
             else:
-                strip_bin = mesonlib.stringlistify(bins['strip'])
-        else:
-            strip_bin = self.environment.native_strip_bin
+                # TODO go through all candidates, like others
+                strip_bin = [self.environment.default_strip[0]]
         d = InstallData(self.environment.get_source_dir(),
                         self.environment.get_build_dir(),
                         self.environment.get_prefix(),

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -343,7 +343,6 @@ class Backend:
                 exe_is_native = True
             is_cross_built = (not exe_is_native) and \
                 self.environment.is_cross_build() and \
-                self.environment.cross_info.need_cross_compiler() and \
                 self.environment.cross_info.need_exe_wrapper()
             if is_cross_built:
                 exe_wrapper = self.environment.get_exe_wrapper()
@@ -693,7 +692,6 @@ class Backend:
             else:
                 cmd = [os.path.join(self.environment.get_build_dir(), self.get_target_filename(t.get_exe()))]
             is_cross = self.environment.is_cross_build() and \
-                self.environment.cross_info.need_cross_compiler() and \
                 self.environment.cross_info.need_exe_wrapper()
             if isinstance(exe, build.BuildTarget):
                 is_cross = is_cross and exe.is_cross

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -536,7 +536,6 @@ int dummy;
         # a serialized executable wrapper for that and check if the
         # CustomTarget command needs extra paths first.
         is_cross = self.environment.is_cross_build() and \
-            self.environment.cross_info.need_cross_compiler() and \
             self.environment.cross_info.need_exe_wrapper()
         if mesonlib.for_windows(is_cross, self.environment) or \
            mesonlib.for_cygwin(is_cross, self.environment):
@@ -1338,7 +1337,7 @@ int dummy;
             if not is_cross:
                 self.generate_java_link(outfile)
         if is_cross:
-            if self.environment.cross_info.need_cross_compiler():
+            if self.environment.cross_info.is_cross_build():
                 static_linker = self.build.static_cross_linker
             else:
                 static_linker = self.build.static_linker
@@ -1381,12 +1380,6 @@ int dummy;
         num_pools = self.environment.coredata.backend_options['backend_max_links'].value
         ctypes = [(self.build.compilers, False)]
         if self.environment.is_cross_build():
-            if self.environment.cross_info.need_cross_compiler():
-                ctypes.append((self.build.cross_compilers, True))
-            else:
-                # Native compiler masquerades as the cross compiler.
-                ctypes.append((self.build.compilers, True))
-        else:
             ctypes.append((self.build.cross_compilers, True))
         for (complist, is_cross) in ctypes:
             for langname, compiler in complist.items():
@@ -1667,12 +1660,7 @@ rule FORTRAN_DEP_HACK%s
             self.generate_compile_rule_for(langname, compiler, False, outfile)
             self.generate_pch_rule_for(langname, compiler, False, outfile)
         if self.environment.is_cross_build():
-            # In case we are going a target-only build, make the native compilers
-            # masquerade as cross compilers.
-            if self.environment.cross_info.need_cross_compiler():
-                cclist = self.build.cross_compilers
-            else:
-                cclist = self.build.compilers
+            cclist = self.build.cross_compilers
             for langname, compiler in cclist.items():
                 if compiler.get_id() == 'clang':
                     self.generate_llvm_ir_compile_rule(compiler, True, outfile)
@@ -2235,7 +2223,7 @@ rule FORTRAN_DEP_HACK%s
         targetdir = self.get_target_private_dir(target)
         symname = os.path.join(targetdir, target_name + '.symbols')
         elem = NinjaBuildElement(self.all_outputs, symname, 'SHSYM', target_file)
-        if self.environment.is_cross_build() and self.environment.cross_info.need_cross_compiler():
+        if self.environment.is_cross_build():
             elem.add_item('CROSS', '--cross-host=' + self.environment.cross_info.config['host_machine']['system'])
         elem.write(outfile)
 

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -757,7 +757,7 @@ class CCompiler(Compiler):
         varname = 'has function ' + funcname
         varname = varname.replace(' ', '_')
         if self.is_cross:
-            val = env.cross_info.config['properties'].get(varname, None)
+            val = env.properties.host.get(varname, None)
             if val is not None:
                 if isinstance(val, bool):
                     return val

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1045,13 +1045,10 @@ class Compiler:
     def get_cross_extra_flags(self, environment, link):
         extra_flags = []
         if self.is_cross and environment:
-            if 'properties' in environment.cross_info.config:
-                props = environment.cross_info.config['properties']
-                lang_args_key = self.language + '_args'
-                extra_flags += mesonlib.stringlistify(props.get(lang_args_key, []))
-                lang_link_args_key = self.language + '_link_args'
-                if link:
-                    extra_flags += mesonlib.stringlistify(props.get(lang_link_args_key, []))
+            props = environment.properties.host
+            extra_flags += props.get_external_args(self.language)
+            if link:
+                extra_flags += props.get_external_link_args(self.language)
         return extra_flags
 
     def _get_compile_output(self, dirname, mode):

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -231,42 +231,6 @@ def load_configs(filenames):
     return config
 
 
-def _get_section(config, section):
-    if config.has_section(section):
-        final = {}
-        for k, v in config.items(section):
-            # Windows paths...
-            v = v.replace('\\', '\\\\')
-            try:
-                final[k] = ast.literal_eval(v)
-            except SyntaxError:
-                raise MesonException(
-                    'Malformed value in native file variable: {}'.format(v))
-        return final
-    return {}
-
-
-class ConfigData:
-
-    """Contains configuration information provided by the user for the build."""
-
-    def __init__(self, config=None):
-        if config:
-            self.binaries = _get_section(config, 'binaries')
-            # global is a keyword and globals is a builtin, rather than mangle it,
-            # use a similar word
-            self.universal = _get_section(config, 'globals')
-            self.subprojects = {s: _get_section(config, s) for s in config.sections()
-                                if s not in {'binaries', 'globals'}}
-        else:
-            self.binaries = {}
-            self.universal = {}
-            self.subprojects = {}
-
-    def get_binaries(self, name):
-        return self.binaries.get(name, None)
-
-
 # This class contains all data that must persist over multiple
 # invocations of Meson. It is roughly the same thing as
 # cmakecache.

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1215,11 +1215,6 @@ class CrossBuildInfo:
     def get_sys_root(self):
         return self.get_properties().get('sys_root', None)
 
-    # When compiling a cross compiler we use the native compiler for everything.
-    # But not when cross compiling a cross compiler.
-    def need_cross_compiler(self):
-        return 'host_machine' in self.config
-
     def need_exe_wrapper(self):
         value = self.config['properties'].get('needs_exe_wrapper', None)
         if value is not None:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1175,21 +1175,14 @@ class MesonConfigFile:
                 except Exception:
                     raise EnvironmentException('Malformed value in cross file variable %s.' % entry)
 
-                if cls._ok_type(res):
-                    section[entry] = res
-                elif isinstance(res, list):
-                    for i in res:
-                        if not self._ok_type(i):
-                            raise EnvironmentException('Malformed value in cross file variable %s.' % entry)
-                    section[entry] = res
-                else:
-                    raise EnvironmentException('Malformed value in cross file variable %s.' % entry)
+                for i in (res if isinstance(res, list) else [res]):
+                    if not isinstance(i, (str, int, bool)):
+                        raise EnvironmentException('Malformed value in cross file variable %s.' % entry)
+
+                section[entry] = res
+
             out[s] = section
         return out
-
-    @classmethod
-    def _ok_type(cls, i):
-        return isinstance(i, (str, int, bool))
 
 class Properties:
     def __init__(self):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2685,7 +2685,7 @@ external dependencies (including libraries) must go to "dependencies".''')
 
     def add_languages(self, args, required):
         success = True
-        need_cross_compiler = self.environment.is_cross_build() and self.environment.cross_info.need_cross_compiler()
+        need_cross_compiler = self.environment.is_cross_build()
         for lang in sorted(args, key=compilers.sort_clink):
             lang = lang.lower()
             if lang in self.coredata.compilers:

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -532,7 +532,7 @@ class GnomeModule(ExtensionModule):
 
         for lang in langs:
             if state.environment.is_cross_build():
-                link_args = state.environment.cross_info.config["properties"].get(lang + '_link_args', "")
+                link_args = state.environment.properties.host.get_external_link_args(lang)
             else:
                 link_args = state.environment.coredata.get_external_link_args(lang)
 
@@ -715,7 +715,7 @@ class GnomeModule(ExtensionModule):
         ret = []
         for lang in langs:
             if state.environment.is_cross_build():
-                ret += state.environment.cross_info.config["properties"].get(lang + '_args', "")
+                ret += state.environment.properties.host.get_external_args(lang)
             else:
                 ret += state.environment.coredata.get_external_args(lang)
         return ret
@@ -1043,8 +1043,8 @@ This will become a hard error in the future.''')
         ldflags.update(external_ldflags)
 
         if state.environment.is_cross_build():
-            cflags.update(state.environment.cross_info.config["properties"].get('c_args', ""))
-            ldflags.update(state.environment.cross_info.config["properties"].get('c_link_args', ""))
+            cflags.update(state.environment.properties.host.get_external_args('c'))
+            ldflags.update(state.environment.properties.host.get_external_link_args('c'))
             compiler = state.environment.coredata.cross_compilers.get('c')
         else:
             cflags.update(state.environment.coredata.get_external_args('c'))

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -501,20 +501,17 @@ class PythonModule(ExtensionModule):
         if len(args) > 1:
             raise InvalidArguments('find_installation takes zero or one positional argument.')
 
-        if 'python' in state.environment.config_info.binaries:
-            name_or_path = state.environment.config_info.binaries['python']
-        elif args:
+        name_or_path = state.environment.binaries.host.lookup_entry('python')
+        if name_or_path is None and args:
             name_or_path = args[0]
             if not isinstance(name_or_path, str):
                 raise InvalidArguments('find_installation argument must be a string.')
-        else:
-            name_or_path = None
 
         if not name_or_path:
             mlog.log("Using meson's python {}".format(mesonlib.python_command))
             python = ExternalProgram('python3', mesonlib.python_command, silent=True)
         else:
-            python = ExternalProgram(name_or_path, silent = True)
+            python = ExternalProgram.from_entry('python3', name_or_path)
 
             if not python.found() and mesonlib.is_windows():
                 pythonpath = self._get_win_pythonpath(name_or_path)

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -48,10 +48,11 @@ class Python3Module(ExtensionModule):
 
     @noKwargs
     def find_python(self, state, args, kwargs):
-        options = [state.environment.config_info.binaries.get('python3')]
-        if not options[0]:  # because this would be [None]
-            options = ['python3', mesonlib.python_command]
-        py3 = dependencies.ExternalProgram(*options, silent=True)
+        command = state.environment.binaries.host.lookup_entry('python3')
+        if command is not None:
+            py3 = dependencies.ExternalProgram.from_entry('python3', command)
+        else:
+            py3 = dependencies.ExternalProgram('python3', mesonlib.python_command, silent=True)
         return ModuleReturnValue(py3, [py3])
 
     @noKwargs

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -41,29 +41,13 @@ class WindowsModule(ExtensionModule):
     def _find_resource_compiler(self, state):
         # FIXME: Does not handle `native: true` executables, see
         # See https://github.com/mesonbuild/meson/issues/1531
+        # But given a machine, we can un-hardcode `binaries.host` below.
 
         if hasattr(self, '_rescomp'):
             return self._rescomp
 
-        rescomp = None
-        if state.environment.is_cross_build():
-            # If cross compiling see if windres has been specified in the
-            # cross file before trying to find it another way.
-            bins = state.environment.cross_info.config['binaries']
-            rescomp = ExternalProgram.from_bin_list(bins, 'windres')
-
-        if not rescomp or not rescomp.found():
-            if 'WINDRES' in os.environ:
-                # Pick-up env var WINDRES if set. This is often used for
-                # specifying an arch-specific windres.
-                rescomp = ExternalProgram('windres', command=os.environ.get('WINDRES'), silent=True)
-
-        if not rescomp or not rescomp.found():
-            # Take windres from the config file after the environment, which is
-            # in keeping with the expectations on unix-like OSes that
-            # environment variables trump config files.
-            bins = state.environment.config_info.binaries
-            rescomp = ExternalProgram.from_bin_list(bins, 'windres')
+        # Will try cross / native file and then env var
+        rescomp = ExternalProgram.from_bin_list(state.environment.binaries.host, 'windres')
 
         if not rescomp or not rescomp.found():
             comp = self.detect_compiler(state.compilers)

--- a/run_tests.py
+++ b/run_tests.py
@@ -76,8 +76,10 @@ def get_fake_options(prefix):
     opts.native_file = []
     return opts
 
-def get_fake_env(sdir, bdir, prefix):
-    env = Environment(sdir, bdir, get_fake_options(prefix))
+def get_fake_env(sdir, bdir, prefix, opts = None):
+    if opts is None:
+        opts = get_fake_options(prefix)
+    env = Environment(sdir, bdir, opts)
     env.coredata.compiler_options['c_args'] = FakeCompilerOptions()
     return env
 


### PR DESCRIPTION
Continuing what #4338 started. ~~So ignore this until that is merged.~~

Simply put, this gets rid of `environment.cross_info`. Information is instead stored in `environment.binaries` (the `BinaryTable` class has instances now), `environment.machines` as was already done, and `environment.properties`. All of these are `PerMachine` containers, paving the way for a rebased #4010 completely merging cross and native code paths.

In particular the binary lookup code has begun to be consolidated with this, using the same function to assist with looking up in either the cross file or environment variables. There's a lot more consolidation to be done however, that this enables. More net-negative commits on the way!

N.B: `self.environment.is_cross_build() and self.environment.cross_info.need_cross_compiler()` becomes just `self.environment.is_cross_build()`.There's no point distinguishing target =?= build like this, because meson doesn't do anything with the target platform in it's own logic. It's purely there for user logic.

Finally, now that https://github.com/mesonbuild/meson/pull/4216 is merged, this can fold in that code too, and gets rid of `environment.config_info`.

Very close to closing #4332

