### PR TITLE
Make string division do path joining

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1005,7 +1005,7 @@ the jar with `java -jar file.jar`.
 ### join_paths()
 
 ``` meson
-   string join_paths(string1, string2, ...)
+string join_paths(string1, string2, ...)
 ```
 
 Joins the given strings into a file system path segment. For example
@@ -1014,6 +1014,15 @@ individual segments is an absolute path, all segments before it are
 dropped. That means that `join_paths('foo', '/bar')` returns `/bar`.
 
 *Added 0.36.0*
+
+Since 0.49.0 using the`/` operator on strings is equivalent to calling
+`join_paths`.
+
+```meson
+# res1 and res2 will have identical values
+res1 = join_paths(foo, bar)
+res2 = foo / bar
+```
 
 ### library()
 

--- a/docs/markdown/snippets/pathdivision.md
+++ b/docs/markdown/snippets/pathdivision.md
@@ -1,0 +1,15 @@
+## Joining paths with /
+
+Joining two paths has traditionally been done with the `join_paths` function.
+
+```meson
+joined = join_paths('foo', 'bar')
+```
+
+Now you can use the simpler notation using the `/` operator.
+
+```meson
+joined = 'foo' / 'bar'
+```
+
+This only works for strings.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3810,7 +3810,7 @@ different subdirectory.
     @stringArgs
     @noKwargs
     def func_join_paths(self, node, args, kwargs):
-        return os.path.join(*args).replace('\\', '/')
+        return self.join_path_strings(args)
 
     def run(self):
         super().run()

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -382,6 +382,9 @@ class InterpreterBase:
             me.file = environment.build_filename
             raise me
 
+    def join_path_strings(self, args):
+        return os.path.join(*args).replace('\\', '/')
+
     def parse_project(self):
         """
         Parses project() and initializes languages, compilers etc. Do this
@@ -628,9 +631,13 @@ The result of this is undefined and will become a hard error in a future Meson r
                 raise InvalidCode('Multiplication works only with integers.')
             return l * r
         elif cur.operation == 'div':
-            if not isinstance(l, int) or not isinstance(r, int):
-                raise InvalidCode('Division works only with integers.')
-            return l // r
+            if isinstance(l, str) and isinstance(r, str):
+                return self.join_path_strings((l, r))
+            if isinstance(l, int) and isinstance(r, int):
+                if r == 0:
+                    raise InvalidCode('Division by zero.')
+                return l // r
+            raise InvalidCode('Division works only with strings or integers.')
         elif cur.operation == 'mod':
             if not isinstance(l, int) or not isinstance(r, int):
                 raise InvalidCode('Modulo works only with integers.')

--- a/test cases/common/116 pathjoin/meson.build
+++ b/test cases/common/116 pathjoin/meson.build
@@ -1,20 +1,20 @@
 project('pathjoin', 'c')
 
 # Test string-args form since that is the canonical way
-assert(join_paths('foo') == 'foo', 'Single argument join is broken')
-assert(join_paths('foo', 'bar') == 'foo/bar', 'Path joining is broken')
+assert(join_paths('foo')               == 'foo', 'Single argument join is broken')
+assert(join_paths('foo', 'bar')        == 'foo/bar', 'Path joining is broken')
 assert(join_paths('foo', 'bar', 'baz') == 'foo/bar/baz', 'Path joining is broken')
-assert(join_paths('/foo', 'bar') == '/foo/bar', 'Path joining is broken')
-assert(join_paths('foo', '/bar') == '/bar', 'Absolute path joining is broken')
-assert(join_paths('/foo', '/bar') == '/bar', 'Absolute path joining is broken')
+assert(join_paths('/foo', 'bar')       == '/foo/bar', 'Path joining is broken')
+assert(join_paths('foo', '/bar')       == '/bar', 'Absolute path joining is broken')
+assert(join_paths('/foo', '/bar')      == '/bar', 'Absolute path joining is broken')
 
 # Test array form since people are using that too
-assert(join_paths(['foo']) == 'foo', 'Single argument join is broken')
-assert(join_paths(['foo', 'bar']) == 'foo/bar', 'Path joining is broken')
+assert(join_paths(['foo'])               == 'foo', 'Single argument join is broken')
+assert(join_paths(['foo', 'bar'])        == 'foo/bar', 'Path joining is broken')
 assert(join_paths(['foo', 'bar', 'baz']) == 'foo/bar/baz', 'Path joining is broken')
-assert(join_paths(['/foo', 'bar']) == '/foo/bar', 'Path joining is broken')
-assert(join_paths(['foo', '/bar']) == '/bar', 'Absolute path joining is broken')
-assert(join_paths(['/foo', '/bar']) == '/bar', 'Absolute path joining is broken')
+assert(join_paths(['/foo', 'bar'])       == '/foo/bar', 'Path joining is broken')
+assert(join_paths(['foo', '/bar'])       == '/bar', 'Absolute path joining is broken')
+assert(join_paths(['/foo', '/bar'])      == '/bar', 'Absolute path joining is broken')
 
 # Division operator should do the same as join_paths
 assert('foo' / 'bar'       == 'foo/bar',     'Path division is broken')

--- a/test cases/common/116 pathjoin/meson.build
+++ b/test cases/common/116 pathjoin/meson.build
@@ -15,3 +15,10 @@ assert(join_paths(['foo', 'bar', 'baz']) == 'foo/bar/baz', 'Path joining is brok
 assert(join_paths(['/foo', 'bar']) == '/foo/bar', 'Path joining is broken')
 assert(join_paths(['foo', '/bar']) == '/bar', 'Absolute path joining is broken')
 assert(join_paths(['/foo', '/bar']) == '/bar', 'Absolute path joining is broken')
+
+# Division operator should do the same as join_paths
+assert('foo' / 'bar'       == 'foo/bar',     'Path division is broken')
+assert('foo' /'bar' /'baz' == 'foo/bar/baz', 'Path division is broken')
+assert('/foo' / 'bar'      == '/foo/bar',    'Path division is broken')
+assert('foo' / '/bar'      == '/bar',        'Absolute path division is broken')
+assert('/foo' / '/bar'     == '/bar',        'Absolute path division is broken')


### PR DESCRIPTION
Python pathlib does this as well as the C++ filesystem library. So why not us?

Division by zero error message improvement is complimentary.