### PR TITLE
Pay better attention to if cross-compiling in dependency detectors

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1319,6 +1319,11 @@ class ExtraFrameworkDependency(ExternalDependency):
             self.link_args = ['-F' + self.path, '-framework', self.name.split('.')[0]]
 
     def detect(self, name, path):
+        # should use the compiler to look for frameworks, rather than peering at
+        # the filesystem, so we can also find them when cross-compiling
+        if self.want_cross:
+            return
+
         lname = name.lower()
         if path is None:
             paths = ['/System/Library/Frameworks', '/Library/Frameworks']

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -278,11 +278,14 @@ class ThreadDependency(ExternalDependency):
 class Python3Dependency(ExternalDependency):
     def __init__(self, environment, kwargs):
         super().__init__('python3', environment, None, kwargs)
+
+        if self.want_cross:
+            return
+
         self.name = 'python3'
         self.static = kwargs.get('static', False)
         # We can only be sure that it is Python 3 at this point
         self.version = '3'
-        self.pkgdep = None
         self._find_libpy3_windows(environment)
 
     @classmethod
@@ -434,6 +437,11 @@ class PcapDependency(ExternalDependency):
 
     @staticmethod
     def get_pcap_lib_version(ctdep):
+        # Since we seem to need to run a program to discover the pcap version,
+        # we can't do that when cross-compiling
+        if ctdep.want_cross:
+            return None
+
         v = ctdep.clib_compiler.get_return_value('pcap_lib_version', 'string',
                                                  '#include <pcap.h>', ctdep.env, [], [ctdep])
         v = re.sub(r'libpcap version ', '', v)

--- a/mesonbuild/dependencies/platform.py
+++ b/mesonbuild/dependencies/platform.py
@@ -33,7 +33,7 @@ class AppleFrameworks(ExternalDependency):
         for f in self.frameworks:
             self.link_args += ['-framework', f]
 
-        self.is_found = mesonlib.is_osx()
+        self.is_found = mesonlib.for_darwin(self.want_cross, self.env)
 
     def log_tried(self):
         return 'framework'

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -39,13 +39,13 @@ class GLDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
         super().__init__('gl', environment, None, kwargs)
 
-        if mesonlib.is_osx():
+        if mesonlib.for_darwin(self.want_cross, self.env):
             self.is_found = True
             # FIXME: Use AppleFrameworks dependency
             self.link_args = ['-framework', 'OpenGL']
             # FIXME: Detect version using self.clib_compiler
             return
-        if mesonlib.is_windows():
+        if mesonlib.for_windows(self.want_cross, self.env):
             self.is_found = True
             # FIXME: Use self.clib_compiler.find_library()
             self.link_args = ['-lopengl32']


### PR DESCRIPTION
As noted in https://github.com/mesonbuild/meson/pull/3657#issuecomment-393964084, specialized dependency detectors often don't correctly consider if we are looking for a cross or native dependency.

Fix this in the obvious places I found in reviewing them.

