### PR TITLE
ninjabackend: add generated source files to jar compile target source list

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -767,6 +767,15 @@ int dummy;
         main_class = target.get_main_class()
         if main_class != '':
             e = 'e'
+
+        # Add possible java generated files to src list
+        generated_sources = self.get_target_generated_sources(target)
+        for rel_src, gensrc in generated_sources.items():
+            dirpart, fnamepart = os.path.split(rel_src)
+            raw_src = File(True, dirpart, fnamepart)
+            if rel_src.endswith('.java'):
+                src_list.append(raw_src)
+
         for src in src_list:
             plain_class_path = self.generate_single_java_compile(src, target, compiler, outfile)
             class_list.append(plain_class_path)

--- a/test cases/java/8 codegen custom target/com/mesonbuild/Config.java.in
+++ b/test cases/java/8 codegen custom target/com/mesonbuild/Config.java.in
@@ -1,0 +1,5 @@
+package com.mesonbuild;
+
+public class Config {
+    public static final boolean FOOBAR = true;
+}

--- a/test cases/java/8 codegen custom target/com/mesonbuild/Simple.java
+++ b/test cases/java/8 codegen custom target/com/mesonbuild/Simple.java
@@ -1,0 +1,12 @@
+package com.mesonbuild;
+
+import com.mesonbuild.Config;
+
+class Simple {
+    public static void main(String [] args) {
+        if (Config.FOOBAR) {
+            TextPrinter t = new TextPrinter("Printing from Java.");
+            t.print();
+        }
+    }
+}

--- a/test cases/java/8 codegen custom target/com/mesonbuild/TextPrinter.java
+++ b/test cases/java/8 codegen custom target/com/mesonbuild/TextPrinter.java
@@ -1,0 +1,14 @@
+package com.mesonbuild;
+
+class TextPrinter {
+
+    private String msg;
+
+    TextPrinter(String s) {
+        msg = s;
+    }
+
+    public void print() {
+        System.out.println(msg);
+    }
+}

--- a/test cases/java/8 codegen custom target/com/mesonbuild/meson.build
+++ b/test cases/java/8 codegen custom target/com/mesonbuild/meson.build
@@ -1,0 +1,8 @@
+python = import('python').find_installation('python3')
+
+config_file = custom_target('confgen',
+                            input : 'Config.java.in',
+                            output : 'Config.java',
+                            command : [python, '-c',
+                              'import shutil; import sys; shutil.copy(sys.argv[1], sys.argv[2])',
+                              '@INPUT@', '@OUTPUT@'])

--- a/test cases/java/8 codegen custom target/meson.build
+++ b/test cases/java/8 codegen custom target/meson.build
@@ -1,0 +1,15 @@
+# If we generate code under the build directory then the backend needs to add
+# the build directory to the -sourcepath passed to javac otherwise the compiler
+# won't be able to handle the -implicit:class behaviour of automatically
+# compiling dependency classes.
+
+project('codegenjava', 'java')
+
+subdir('com/mesonbuild')
+
+javaprog = jar('myprog',
+ config_file[0],
+ 'com/mesonbuild/Simple.java',
+ 'com/mesonbuild/TextPrinter.java',
+  main_class : 'com.mesonbuild.Simple')
+test('subdirtest', javaprog)


### PR DESCRIPTION
Otherwise, passing result of custom_target() to jar() target is ignored
and won't be compiled resulting in build fail.

The included test demonstrate the issue I faced and what I try to do. I just simplified the command used.