### PR TITLE
Cosmetic fix to failed required dependency reporting

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1459,7 +1459,8 @@ def find_external_dependency(name, env, kwargs):
 
         # we have a list of failed ExternalDependency objects, so we can report
         # the methods we tried to find the dependency
-        raise DependencyException('Dependency "%s" not found, tried %s' % (name, tried))
+        raise DependencyException('Dependency "%s" not found' % (name) +
+                                  (', tried %s' % (tried) if tried else ''))
 
     # return the last failed dependency object
     if pkgdep:


### PR DESCRIPTION
As mentioned in https://github.com/mesonbuild/meson/issues/4407#issuecomment-433107200, if `dependency('boost')` fails, the error message is 'Dependency "boost" not found, tried' (sic).

Similar to line 1451 above, suppress reporting the tried methods returned by `log_tried()`, if the list is empty (as is the case with boost)