### PR TITLE
Performance optimize the ninja generator another time

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -26,6 +26,7 @@ from ..mesonlib import File
 from ..compilers import CompilerArgs
 from collections import OrderedDict
 import shlex
+from functools import lru_cache
 
 
 class CleanTrees:
@@ -210,6 +211,7 @@ class Backend:
     def get_target_private_dir_abs(self, target):
         return os.path.join(self.environment.get_build_dir(), self.get_target_private_dir(target))
 
+    @lru_cache(maxsize=None)
     def get_target_generated_dir(self, target, gensrc, src):
         """
         Takes a BuildTarget, a generator source (CustomTarget or GeneratedList),

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -21,6 +21,7 @@ import time
 import platform, subprocess, operator, os, shutil, re
 import collections
 from enum import Enum
+from functools import lru_cache
 
 from mesonbuild import mlog
 
@@ -223,6 +224,7 @@ class File:
         return ret.format(self.relative_name())
 
     @staticmethod
+    @lru_cache(maxsize=None)
     def from_source_file(source_root, subdir, fname):
         if not os.path.isfile(os.path.join(source_root, subdir, fname)):
             raise MesonException('File %s does not exist.' % fname)
@@ -236,12 +238,14 @@ class File:
     def from_absolute_file(fname):
         return File(False, '', fname)
 
+    @lru_cache(maxsize=None)
     def rel_to_builddir(self, build_to_src):
         if self.is_built:
             return self.relative_name()
         else:
             return os.path.join(build_to_src, self.subdir, self.fname)
 
+    @lru_cache(maxsize=None)
     def absolute_path(self, srcdir, builddir):
         absdir = srcdir
         if self.is_built:
@@ -260,6 +264,7 @@ class File:
     def __hash__(self):
         return hash((self.fname, self.subdir, self.is_built))
 
+    @lru_cache(maxsize=None)
     def relative_name(self):
         return os.path.join(self.subdir, self.fname)
 


### PR DESCRIPTION
EFL has meanwhile grown into its almost final size. A few stats:
Targets: 1655 
Custom targets: 3678
Installed header files: 2736
With this patch it takes ~11 sec. on a laptop to configure. Which is great, autotools takes about 50 sec.

However there are 2 more things that can be done at some point. we spent about 2 sec. in `write` a cached string with the content that gets flushed into a file at once might be better here, and safe another second or so. Additionally there are a big number of calls to `get_target_dir` which could be optimized and investigated at some point.