### PR TITLE
Don't use host pkg-config for native dependencies

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -503,7 +503,6 @@ class PkgConfigDependency(ExternalDependency):
                 potential_pkgbin = ExternalProgram.from_cross_info(environment.cross_info, 'pkgconfig')
                 if potential_pkgbin.found():
                     self.pkgbin = potential_pkgbin
-                    PkgConfigDependency.class_pkgbin = self.pkgbin
                 else:
                     mlog.debug('Cross pkg-config %s not found.' % potential_pkgbin.name)
         # Only search for the native pkg-config the first time and

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2751,6 +2751,32 @@ recommended as it is not supported on some platforms''')
         self.assertEqual(opts['debug'], True)
         self.assertEqual(opts['optimization'], '0')
 
+    @skipIfNoPkgconfig
+    @unittest.skipIf(is_windows(), 'Help needed with fixing this test on windows')
+    def test_native_dep_pkgconfig(self):
+        testdir = os.path.join(self.unit_test_dir,
+                               '46 native dep pkgconfig var')
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as crossfile:
+            crossfile.write(textwrap.dedent(
+                '''[binaries]
+                pkgconfig = r'{0}'
+
+                [properties]
+
+                [host_machine]
+                system = 'linux'
+                cpu_family = 'arm'
+                cpu = 'armv7'
+                endian = 'little'
+                '''.format(os.path.join(testdir, 'cross_pkgconfig.py'))))
+            crossfile.flush()
+            self.meson_cross_file = crossfile.name
+
+        os.environ['PKG_CONFIG_LIBDIR'] = os.path.join(testdir,
+                                                       'native_pkgconfig')
+        self.init(testdir, extra_args=['-Dstart_native=false'])
+        self.wipe()
+        self.init(testdir, extra_args=['-Dstart_native=true'])
 
 class FailureTests(BasePlatformTests):
     '''

--- a/test cases/unit/46 native dep pkgconfig var/cross_pkgconfig.py
+++ b/test cases/unit/46 native dep pkgconfig var/cross_pkgconfig.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import subprocess
+
+environ = os.environ.copy()
+environ['PKG_CONFIG_LIBDIR'] = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), 'cross_pkgconfig')
+
+sys.exit(
+    subprocess.run(['pkg-config'] + sys.argv[1:], env=environ).returncode)

--- a/test cases/unit/46 native dep pkgconfig var/cross_pkgconfig/dep_tester.pc
+++ b/test cases/unit/46 native dep pkgconfig var/cross_pkgconfig/dep_tester.pc
@@ -1,0 +1,5 @@
+dep_type=cross
+
+Name: dependency() test
+Description: dependency() test
+Version: 0

--- a/test cases/unit/46 native dep pkgconfig var/meson.build
+++ b/test cases/unit/46 native dep pkgconfig var/meson.build
@@ -1,0 +1,15 @@
+project('native dep pkgconfig test')
+
+if get_option('start_native')
+  dep_native = dependency('dep_tester', native: true, method: 'pkg-config')
+  dep_cross = dependency('dep_tester', native: false, method: 'pkg-config')
+else
+  dep_cross = dependency('dep_tester', native: false, method: 'pkg-config')
+  dep_native = dependency('dep_tester', native: true, method: 'pkg-config')
+endif
+
+dep_type = dep_native.get_pkgconfig_variable('dep_type')
+assert(dep_type == 'native', 'Expected native')
+
+dep_type = dep_cross.get_pkgconfig_variable('dep_type')
+assert(dep_type == 'cross', 'Expected cross')

--- a/test cases/unit/46 native dep pkgconfig var/meson_options.txt
+++ b/test cases/unit/46 native dep pkgconfig var/meson_options.txt
@@ -1,0 +1,6 @@
+option(
+  'start_native',
+  type : 'boolean',
+  value : 'false',
+  description : 'Start by creating a dependency() with native : true',
+)

--- a/test cases/unit/46 native dep pkgconfig var/native_pkgconfig/dep_tester.pc
+++ b/test cases/unit/46 native dep pkgconfig var/native_pkgconfig/dep_tester.pc
@@ -1,0 +1,5 @@
+dep_type=native
+
+Name: dependency() test
+Description: dependency() test
+Version: 0


### PR DESCRIPTION
When trying to cross-compile mesa on an aarch64 system, I noticed some
strange behavior. Meson would only ever find the wayland-scanner binary
in my host machine's sysroot (/mnt/amethyst):

  Native dependency wayland-scanner found: YES 1.16.0
  Program /mnt/amethyst/usr/bin/wayland-scanner found: YES (/mnt/amethyst/usr/bin/wayland-scanner)

It should be finding /usr/bin/wayland-scanner instead, since the
wayland-scanner dependency is created as native. On closer inspection,
it turned out that meson was ignoring the native argument passed to
dependency(), and wuld always use the pkgconfig binary specified in my
toolchain instead of the native one (/usr/bin/pkg-config):

  Native dependency wayland-scanner found: YES 1.16.0
  Called `/home/lyudess/Projects/panfrost/scripts/amethyst-pkg-config
  --variable=wayland_scanner wayland-scanner` -> 0

Turns out that if we create a dependency() object with native:false, we
end up caching the pkg-config path for the host machine in
PkgConfigDependency.class_pkgbin, instead of the build machine's
pkg-config path. This results causing in all pkg-config invocations for
dependency() objects to use the host machine's pkg-config binary,
regardless of whether or not 'native: true' was specified when the
dependency() object was instantiated.

So, fix this by never setting PkgConfigDependency.class_pkgbin for cross
dependency() objects. Also, add some test cases for this. Since
triggering this bug can be avoided by creating a dependency() objects
with native:true before creating any with native:false, we make sure
that our test has two modes: one where it starts with a native
dependency first, and another where it starts with a cross dependency
first.

Signed-off-by: Lyude Paul <thatslyude@gmail.com>