### PR TITLE
Fix gir generation for static libraries

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -411,8 +411,10 @@ class GnomeModule(ExtensionModule):
     def _unwrap_gir_target(self, girtarget):
         while hasattr(girtarget, 'held_object'):
             girtarget = girtarget.held_object
-        if not isinstance(girtarget, (build.Executable, build.SharedLibrary)):
-            raise MesonException('Gir target must be an executable or shared library')
+        if not isinstance(girtarget, (build.Executable, build.SharedLibrary,
+                                      build.StaticLibrary)):
+            raise MesonException('Gir target must be an executable or library')
+
         return girtarget
 
     def _get_gir_dep(self, state):
@@ -537,7 +539,7 @@ class GnomeModule(ExtensionModule):
         for girtarget in girtargets:
             if isinstance(girtarget, build.Executable):
                 ret += ['--program', girtarget]
-            elif isinstance(girtarget, build.SharedLibrary):
+            else:
                 libname = girtarget.get_basename()
                 # Needed for the following binutils bug:
                 # https://github.com/mesonbuild/meson/issues/1911

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -540,7 +540,12 @@ class GnomeModule(ExtensionModule):
             if isinstance(girtarget, build.Executable):
                 ret += ['--program', girtarget]
             else:
-                libname = girtarget.get_basename()
+                # Because of https://gitlab.gnome.org/GNOME/gobject-introspection/merge_requests/72
+                # we can't use the full path until this is merged.
+                if isinstance(girtarget, build.SharedLibrary):
+                    libname = girtarget.get_basename()
+                else:
+                    libname = os.path.join("@PRIVATE_OUTDIR_ABS_%s@" % girtarget.get_id(), girtarget.get_filename())
                 # Needed for the following binutils bug:
                 # https://github.com/mesonbuild/meson/issues/1911
                 # However, g-ir-scanner does not understand -Wl,-rpath


### PR DESCRIPTION
Bad news, g-ir-scanner is completely broken for anyone not using libtool (not giving it a .la file)

1. It currently puts the "-L" after the "-l", so the paths are ignored. So currently, all ".gir" files generated by meson are built against the system library... unless the library is in the "root" of the build (it puts -L. as the first argument to gcc). The only reason that that this currently works is that the order of arguments is ignored for rpaths.

2. Enable it for static libraries, it's really not more broken than dynamic ones.

3. We should us the full path to avoid confusion, I made it for static libraires (as dynamic ones "work" with a little luck). 

4. But it should probably be done for all libraries once the below merge request is merged into g-i and a release is made and meson should just require it to avoid building broken things.

Merge request against gobject-introspection:
https://gitlab.gnome.org/GNOME/gobject-introspection/merge_requests/72