### PR TITLE
Fix naming of implib when name_prefix/suffix is used

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1547,13 +1547,9 @@ class SharedLibrary(BuildTarget):
         prefix = ''
         suffix = ''
         self.filename_tpl = self.basic_filename_tpl
-        # If the user already provided the prefix and suffix to us, we don't
-        # need to do any filename suffix/prefix detection.
         # NOTE: manual prefix/suffix override is currently only tested for C/C++
-        if self.prefix is not None and self.suffix is not None:
-            pass
         # C# and Mono
-        elif 'cs' in self.compilers:
+        if 'cs' in self.compilers:
             prefix = ''
             suffix = 'dll'
             self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}'

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1562,8 +1562,8 @@ class SharedLibrary(BuildTarget):
         # For all other targets/platforms import_filename stays None
         elif for_windows(is_cross, env):
             suffix = 'dll'
-            self.vs_import_filename = '{0}.lib'.format(self.name)
-            self.gcc_import_filename = 'lib{0}.dll.a'.format(self.name)
+            self.vs_import_filename = '{0}{1}.lib'.format(self.prefix if self.prefix is not None else '', self.name)
+            self.gcc_import_filename = '{0}{1}.dll.a'.format(self.prefix if self.prefix is not None else 'lib', self.name)
             if self.get_using_msvc():
                 # Shared library is of the form foo.dll
                 prefix = ''
@@ -1582,7 +1582,7 @@ class SharedLibrary(BuildTarget):
                 self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
         elif for_cygwin(is_cross, env):
             suffix = 'dll'
-            self.gcc_import_filename = 'lib{0}.dll.a'.format(self.name)
+            self.gcc_import_filename = '{0}{1}.dll.a'.format(self.prefix if self.prefix is not None else 'lib', self.name)
             # Shared library is of the form cygfoo.dll
             # (ld --dll-search-prefix=cyg is the default)
             prefix = 'cyg'

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -121,13 +121,16 @@ def platform_fix_name(fname, compiler, env):
     if '?lib' in fname:
         if mesonlib.for_windows(env.is_cross_build(), env) and compiler == 'msvc':
             fname = re.sub(r'lib/\?lib(.*)\.', r'bin/\1.', fname)
+            fname = re.sub(r'/\?lib/', r'/bin/', fname)
         elif mesonlib.for_windows(env.is_cross_build(), env):
             fname = re.sub(r'lib/\?lib(.*)\.', r'bin/lib\1.', fname)
             fname = re.sub(r'\?lib(.*)\.dll$', r'lib\1.dll', fname)
+            fname = re.sub(r'/\?lib/', r'/bin/', fname)
         elif mesonlib.for_cygwin(env.is_cross_build(), env):
             fname = re.sub(r'lib/\?lib(.*)\.so$', r'bin/cyg\1.dll', fname)
             fname = re.sub(r'lib/\?lib(.*)\.', r'bin/cyg\1.', fname)
             fname = re.sub(r'\?lib(.*)\.dll$', r'cyg\1.dll', fname)
+            fname = re.sub(r'/\?lib/', r'/bin/', fname)
         else:
             fname = re.sub(r'\?lib', 'lib', fname)
 

--- a/test cases/common/122 shared module/installed_files.txt
+++ b/test cases/common/122 shared module/installed_files.txt
@@ -1,2 +1,3 @@
 usr/lib/libnosyms.so
+?gcc:usr/lib/libnosyms?implib
 ?msvc:usr/lib/libnosyms.pdb

--- a/test cases/common/122 shared module/installed_files.txt
+++ b/test cases/common/122 shared module/installed_files.txt
@@ -1,3 +1,3 @@
-usr/lib/libnosyms.so
-?gcc:usr/lib/libnosyms?implib
-?msvc:usr/lib/libnosyms.pdb
+usr/lib/modules/libnosyms?so
+?gcc:usr/lib/modules/libnosyms?implib
+?msvc:usr/lib/modules/nosyms.pdb

--- a/test cases/common/122 shared module/installed_files.txt
+++ b/test cases/common/122 shared module/installed_files.txt
@@ -1,3 +1,3 @@
 usr/lib/modules/libnosyms?so
-?gcc:usr/lib/modules/libnosyms?implib
+usr/lib/modules/libnosyms?implibempty
 ?msvc:usr/lib/modules/nosyms.pdb

--- a/test cases/common/122 shared module/meson.build
+++ b/test cases/common/122 shared module/meson.build
@@ -13,8 +13,6 @@ e = executable('prog', 'prog.c',
 test('import test', e, args : m)
 
 # Shared module that does not export any symbols
-shared_module('nosyms', 'nosyms.c', install : true,
-              # Because we don't have cross-platform library support in
-              # installed_files.txt
-              name_suffix : 'so',
-              name_prefix : 'lib')
+shared_module('nosyms', 'nosyms.c',
+  install : true,
+  install_dir : join_paths(get_option('libdir'), 'modules'))

--- a/test cases/common/207 install name_prefix name_suffix/installed_files.txt
+++ b/test cases/common/207 install name_prefix name_suffix/installed_files.txt
@@ -1,0 +1,10 @@
+?msvc:usr/bin/baz.pdb
+?msvc:usr/bin/foo.pdb
+?msvc:usr/lib/baz.pdb
+?msvc:usr/lib/foo.pdb
+usr/lib/?libbaz.cheese
+usr/lib/bar.a
+usr/lib/foo?implib
+usr/lib/foo?so
+usr/lib/libbaz?implib
+usr/lib/libqux.cheese

--- a/test cases/common/207 install name_prefix name_suffix/installed_files.txt
+++ b/test cases/common/207 install name_prefix name_suffix/installed_files.txt
@@ -1,9 +1,14 @@
 ?msvc:usr/bin/baz.pdb
+?msvc:usr/bin/bowcorge.pdb
 ?msvc:usr/bin/foo.pdb
 ?msvc:usr/lib/baz.pdb
+?msvc:usr/lib/bowcorge.pdb
 ?msvc:usr/lib/foo.pdb
+usr/?lib/bowcorge.stern
 usr/lib/?libbaz.cheese
 usr/lib/bar.a
+usr/lib/bowcorge?implib
+usr/lib/bowgrault.stern
 usr/lib/foo?implib
 usr/lib/foo?so
 usr/lib/libbaz?implib

--- a/test cases/common/207 install name_prefix name_suffix/libfile.c
+++ b/test cases/common/207 install name_prefix name_suffix/libfile.c
@@ -1,0 +1,14 @@
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+int DLL_PUBLIC func() {
+    return 0;
+}

--- a/test cases/common/207 install name_prefix name_suffix/meson.build
+++ b/test cases/common/207 install name_prefix name_suffix/meson.build
@@ -1,0 +1,7 @@
+project('library with name_prefix name_suffix test', 'c')
+
+shared_library('foo', 'libfile.c', name_prefix: '', install : true)
+static_library('bar', 'libfile.c', name_prefix: '', install : true)
+
+shared_library('baz', 'libfile.c', name_suffix: 'cheese', install : true)
+static_library('qux', 'libfile.c', name_suffix: 'cheese', install : true)

--- a/test cases/common/207 install name_prefix name_suffix/meson.build
+++ b/test cases/common/207 install name_prefix name_suffix/meson.build
@@ -5,3 +5,6 @@ static_library('bar', 'libfile.c', name_prefix: '', install : true)
 
 shared_library('baz', 'libfile.c', name_suffix: 'cheese', install : true)
 static_library('qux', 'libfile.c', name_suffix: 'cheese', install : true)
+
+shared_library('corge', 'libfile.c', name_prefix: 'bow', name_suffix: 'stern', install : true)
+static_library('grault', 'libfile.c', name_prefix: 'bow', name_suffix: 'stern', install : true)

--- a/test cases/common/25 library versions/installed_files.txt
+++ b/test cases/common/25 library versions/installed_files.txt
@@ -1,2 +1,3 @@
 usr/lib/prefixsomelib.suffix
+usr/lib/prefixsomelib?implib
 ?msvc:usr/lib/prefixsomelib.pdb

--- a/test cases/common/25 library versions/lib.c
+++ b/test cases/common/25 library versions/lib.c
@@ -1,3 +1,14 @@
-int myFunc() {
+#if defined _WIN32 || defined __CYGWIN__
+  #define DLL_PUBLIC __declspec(dllexport)
+#else
+  #if defined __GNUC__
+    #define DLL_PUBLIC __attribute__ ((visibility("default")))
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+int DLL_PUBLIC myFunc() {
     return 55;
 }

--- a/test cases/windows/7 dll versioning/installed_files.txt
+++ b/test cases/windows/7 dll versioning/installed_files.txt
@@ -14,9 +14,9 @@
 ?msvc:usr/libexec/customdir.dll
 ?msvc:usr/libexec/customdir.lib
 ?msvc:usr/libexec/customdir.pdb
-?msvc:usr/lib/module.dll
-?msvc:usr/lib/module.lib
-?msvc:usr/lib/module.pdb
+?msvc:usr/lib/modules/module.dll
+?msvc:usr/lib/modules/module.lib
+?msvc:usr/lib/modules/module.pdb
 ?gcc:usr/bin/?libsome-0.dll
 ?gcc:usr/lib/libsome.dll.a
 ?gcc:usr/bin/?libnoversion.dll
@@ -27,5 +27,5 @@
 ?gcc:usr/lib/libonlysoversion.dll.a
 ?gcc:usr/libexec/?libcustomdir.dll
 ?gcc:usr/libexec/libcustomdir.dll.a
-?gcc:usr/lib/?libmodule.dll
-?gcc:usr/lib/libmodule.dll.a
+?gcc:usr/lib/modules/?libmodule.dll
+?gcc:usr/lib/modules/libmodule.dll.a

--- a/test cases/windows/7 dll versioning/meson.build
+++ b/test cases/windows/7 dll versioning/meson.build
@@ -49,4 +49,6 @@ shared_library('customdir', 'lib.c',
   install : true,
   install_dir : get_option('libexecdir'))
 
-shared_module('module', 'lib.c', install : true)
+shared_module('module', 'lib.c',
+  install : true,
+  install_dir: join_paths(get_option('libdir'), 'modules'))


### PR DESCRIPTION
Creating a PR as requested by https://github.com/mesonbuild/meson/pull/4436#issuecomment-435052937

This fixes:
* `name_prefix:` didn't effect the implib filename (causing the pkgconfig bug observed in #4436, and also potential implib filename collision if libraries which only differed in `name_prefix:` were used)
* no implib was generated if both `name_prefix:` and `name_suffix:` were specified

I think there's still a theoretical possibility of implib filename collision between libraries which only differ in having a `name_prefix:` matching the (platform-dependent) default and `name_prefix:` absent.

Unfortunately, writing tests involved (ab)using the `installed_files.txt` /`platform_fix_name` mechanism excessively, which I'm not very happy with.  Perhaps that needs to be extended in a different way.
