### PR TITLE
Link with runtimeobject.lib by default with MSVC

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -251,7 +251,7 @@ gnu_winlibs = ['-lkernel32', '-luser32', '-lgdi32', '-lwinspool', '-lshell32',
 
 msvc_winlibs = ['kernel32.lib', 'user32.lib', 'gdi32.lib',
                 'winspool.lib', 'shell32.lib', 'ole32.lib', 'oleaut32.lib',
-                'uuid.lib', 'comdlg32.lib', 'advapi32.lib']
+                'uuid.lib', 'comdlg32.lib', 'advapi32.lib', 'runtimeobject.lib']
 
 gnu_color_args = {'auto': ['-fdiagnostics-color=auto'],
                   'always': ['-fdiagnostics-color=always'],


### PR DESCRIPTION
This is necessary when building within UWP environments.