### PR TITLE
interpreter: obey to the install argument in configure_file

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -231,6 +231,11 @@ the `@variable@` syntax.
 - `input` the input file name. If it's not specified in configuration
   mode, all the variables in the `configuration:` object (see above)
   are written to the `output:` file.
+- `install` *(added 0.50.0)* When true, this generated file is installed during
+the install step, and `install_dir` must be set and not empty. When false, this
+generated file is not installed regardless of the value of `install_dir`.
+When omitted it defaults to true when `install_dir` is set and not empty,
+false otherwise.
 - `install_dir` the subdirectory to install the generated file to
   (e.g. `share/myproject`), if omitted or given the value of empty
   string, the file is not installed.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3532,6 +3532,7 @@ This will become a hard error in the future.''' % kwargs['input'])
     @FeatureNewKwargs('configure_file', '0.47.0', ['copy', 'output_format', 'install_mode', 'encoding'])
     @FeatureNewKwargs('configure_file', '0.46.0', ['format'])
     @FeatureNewKwargs('configure_file', '0.41.0', ['capture'])
+    @FeatureNewKwargs('configure_file', '0.50.0', ['install'])
     @permittedKwargs(permitted_kwargs['configure_file'])
     def func_configure_file(self, node, args, kwargs):
         if len(args) > 0:
@@ -3691,8 +3692,17 @@ This will become a hard error in the future.''' % kwargs['input'])
         # Install file if requested, we check for the empty string
         # for backwards compatibility. That was the behaviour before
         # 0.45.0 so preserve it.
-        idir = kwargs.get('install_dir', None)
-        if isinstance(idir, str) and idir:
+        idir = kwargs.get('install_dir', '')
+        if not isinstance(idir, str):
+            raise InterpreterException('"install_dir" must be a string')
+        install = kwargs.get('install', idir != '')
+        if not isinstance(install, bool):
+            raise InterpreterException('"install" must be a boolean')
+        if install:
+            if not idir:
+                raise InterpreterException('"install_dir" must be specified '
+                                           'when "install" in a configure_file '
+                                           'is true')
             cfile = mesonlib.File.from_built_file(ofile_path, ofile_fname)
             install_mode = self._get_kwarg_install_mode(kwargs)
             self.build.data.append(build.Data([cfile], idir, install_mode))

--- a/test cases/common/14 configure file/meson.build
+++ b/test cases/common/14 configure file/meson.build
@@ -141,6 +141,13 @@ cfile = configure_file(input : 'config.h.in',
   install_dir : '',
   configuration : conf)
 
+# test intsall_dir with install: false
+cfile = configure_file(input : 'config.h.in',
+  output : 'do_not_get_installed_in_install_dir.h',
+  install : false,
+  install_dir : 'share/appdir',
+  configuration : conf)
+
 # Test escaping with cmake format
 conf7 = configuration_data()
 conf7.set('var1', 'foo')

--- a/test cases/failing/91 invalid configure file/meson.build
+++ b/test cases/failing/91 invalid configure file/meson.build
@@ -1,0 +1,9 @@
+project('invalid configura file')
+
+configure_file(
+    configuration : configuration_data(),
+    input : 'input',
+    output : 'output',
+    install_dir : '',
+    install : true,
+)


### PR DESCRIPTION
If a configure_file has an install_dir set, the supported install
argument is ignored, while this should have actually higher priority
than the install_dir itself.

Add test to verify this.

Fixes #3983