### PR TITLE
run_project_tests: add ability to filter tests to run

### DIFF
--- a/docs/markdown/Contributing.md
+++ b/docs/markdown/Contributing.md
@@ -129,8 +129,8 @@ can be run with `./run_unittests.py` and project tests with
 
 Each project test is a standalone project that can be compiled on its
 own. They are all in `test cases` subdirectory. The simplest way to
-run a single project test is to do something like `./meson.py test\
-cases/common/1\ trivial builddir`. The one exception to this is `test
+run a single project test is to do something like `./run_project_tests.py -t test\
+cases/common/1\ trivial`. The one exception to this is `test
 cases/unit` directory discussed below.
 
 The test cases in the `common` subdirectory are meant to be run always

--- a/run_cross_test.py
+++ b/run_cross_test.py
@@ -30,8 +30,8 @@ import argparse
 from run_project_tests import gather_tests, run_tests, StopException, setup_commands
 from run_project_tests import failing_logs
 
-def runtests(cross_file, failfast):
-    commontests = [('common', gather_tests(Path('test cases', 'common')), False)]
+def runtests(cross_file, failfast, test_filter):
+    commontests = [('common', gather_tests(Path('test cases', 'common'), test_filter), False)]
     try:
         (passing_tests, failing_tests, skipped_tests) = \
             run_tests(commontests, 'meson-cross-test-run', failfast, ['--cross', cross_file])
@@ -49,10 +49,11 @@ def runtests(cross_file, failfast):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--failfast', action='store_true')
+    parser.add_argument('--testcase', default=None, dest='testcase')
     parser.add_argument('cross_file')
     options = parser.parse_args()
     setup_commands('ninja')
-    return runtests(options.cross_file, options.failfast)
+    return runtests(options.cross_file, options.failfast, options.testcase)
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
Passing the argument -t or --testcase allows to filter test cases to run,
instead of running them all.