### PR TITLE
tests: fix test_meson_installed after the recent appveyor image update

### DIFF
--- a/run_meson_command_tests.py
+++ b/run_meson_command_tests.py
@@ -123,7 +123,9 @@ class CommandTests(unittest.TestCase):
         pylibdir = prefix / get_pypath()
         bindir = prefix / get_pybindir()
         pylibdir.mkdir(parents=True)
-        os.environ['PYTHONPATH'] = str(pylibdir)
+        # XXX: join with empty name so it always ends with os.sep otherwise
+        # distutils complains that prefix isn't contained in PYTHONPATH
+        os.environ['PYTHONPATH'] = os.path.join(str(pylibdir), '')
         os.environ['PATH'] = str(bindir) + os.pathsep + os.environ['PATH']
         self._run(python_command + ['setup.py', 'install', '--prefix', str(prefix)])
         # Check that all the files were installed correctly


### PR DESCRIPTION
Since the last appveyor image update which also included a msys2 update
test_meson_installed() fails for the msys2 mingw jobs complaining that
the install path isn't included in PYTHONPATH.

It complains that "site-packages\" isn't included in "site-packages" ignoring
that the separator should be ignored here. Work around the issue by making
sure that the path set as PYTHONPATH always ends with os.sep.