### PR TITLE
add function get_all_user_options()

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1988,6 +1988,7 @@ class Interpreter(InterpreterBase):
                            'generator': self.func_generator,
                            'gettext': self.func_gettext,
                            'get_option': self.func_get_option,
+                           'get_all_user_options': self.get_all_user_options_internal,
                            'get_variable': self.func_get_variable,
                            'files': self.func_files,
                            'find_library': self.func_find_library,
@@ -2401,6 +2402,9 @@ external dependencies (including libraries) must go to "dependencies".''')
             pass
 
         raise InterpreterException('Tried to access unknown option "%s".' % optname)
+
+    def get_all_user_options_internal(self, *args):
+        return [d for d in self.coredata.user_options]
 
     @stringArgs
     @noKwargs

--- a/test cases/common/208 get all user options/config.h.in
+++ b/test cases/common/208 get all user options/config.h.in
@@ -1,0 +1,10 @@
+#ifndef __config__
+#define __config__
+
+#mesondefine string_opt
+#mesondefine true_opt
+#mesondefine false_opt
+#mesondefine combo_opt
+#mesondefine integer_opt
+
+#endif

--- a/test cases/common/208 get all user options/expected.h
+++ b/test cases/common/208 get all user options/expected.h
@@ -1,0 +1,10 @@
+#ifndef __config__
+#define __config__
+
+#define string_opt optval
+#define true_opt
+#undef false_opt
+#define combo_opt three
+#define integer_opt 3
+
+#endif

--- a/test cases/common/208 get all user options/meson.build
+++ b/test cases/common/208 get all user options/meson.build
@@ -1,0 +1,11 @@
+project('get_all_user_options','cpp')
+
+_cdata = configuration_data()
+
+foreach _opt : get_all_user_options()
+    _cdata.set(_opt, get_option(_opt))
+endforeach
+
+configure_file(output: 'config.h',
+               input: 'config.h.in',
+               configuration: _cdata)

--- a/test cases/common/208 get all user options/meson_options.txt
+++ b/test cases/common/208 get all user options/meson_options.txt
@@ -1,0 +1,7 @@
+option('string_opt', type : 'string', value : 'optval', description : 'An option')
+option('true_opt', type : 'boolean', value : true)
+option('false_opt', type : 'boolean', value : false)
+option('combo_opt', type : 'combo', choices : ['one', 'two', 'three'], value : 'three')
+option('integer_opt', type : 'integer', min : 0, max : 5, value : 3) # Since 0.45.0
+# option('some_feature', type : 'feature', value : 'enabled') # this will not work
+


### PR DESCRIPTION
It might be useful to get all the options defined in the file `meson_options.txt`. For example, if they are all suitable to be put in a `config.h` file, we could use something like
```
_cdata = configuration_data()

foreach _opt : get_all_user_options()
    _cdata.set(_opt, get_option(_opt))
endforeach
```

addresses #3422

I defined a function `get_all_user_options_internal` (you may suggest a more appropriate name) that returns a `list` with the option names. I had to add a `*args` after `self` even though I do not use `args`. How can I resolve this?

It might be useful tha the function `get_all_user_options()` returns a `dict` but the following implementation doesn't work

```
def get_all_user_options_internal(self, *args):
    return {d:self.get_option_internal(d) for d in self.coredata.user_options}
....
 # in the meson.build file
foreach k,v : get_all_user_options()  # this gives error
```
the output error is 
```
meson.build:48:8: ERROR:  Assigned value not of assignable type.
```
