### PR TITLE
pkgconfig: add support for pkgconfig generation for c#

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -276,10 +276,16 @@ class PkgConfigModule(ExtensionModule):
                         install_dir = l.get_custom_install_dir()[0]
                         if install_dir is False:
                             continue
-                        if isinstance(install_dir, str):
-                            Lflag = '-L${prefix}/%s ' % self._escape(self._make_relative(prefix, install_dir))
-                        else:  # install_dir is True
-                            Lflag = '-L${libdir}'
+                        if 'cs' in l.compilers:
+                            if isinstance(install_dir, str):
+                                Lflag = '-r${prefix}/%s/%s ' % (self._escape(self._make_relative(prefix, install_dir)), l.filename)
+                            else:  # install_dir is True
+                                Lflag = '-r${libdir}/%s' % l.filename
+                        else:
+                            if isinstance(install_dir, str):
+                                Lflag = '-L${prefix}/%s ' % self._escape(self._make_relative(prefix, install_dir))
+                            else:  # install_dir is True
+                                Lflag = '-L${libdir}'
                         if Lflag not in Lflags:
                             Lflags.append(Lflag)
                             yield Lflag
@@ -288,7 +294,8 @@ class PkgConfigModule(ExtensionModule):
                         # find the library
                         if l.name_suffix_set:
                             mlog.warning(msg.format(l.name, 'name_suffix', lname, pcfile))
-                        yield '-l%s' % lname
+                        if 'cs' not in l.compilers:
+                            yield '-l%s' % lname
 
             if len(deps.pub_libs) > 0:
                 ofile.write('Libs: {}\n'.format(' '.join(generate_libs_flags(deps.pub_libs))))

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4162,6 +4162,17 @@ endian = 'little'
             deps.append(b'-lintl')
         self.assertEqual(set(deps), set(stdo.split()))
 
+    @skipIfNoPkgconfig
+    @skip_if_not_language('cs')
+    def test_pkgconfig_csharp_library(self):
+        testdir = os.path.join(self.unit_test_dir, '48 pkgconfig csharp library')
+        self.init(testdir)
+        myenv = os.environ.copy()
+        myenv['PKG_CONFIG_PATH'] = self.privatedir
+        stdo = subprocess.check_output(['pkg-config', '--libs', 'libsomething'], env=myenv)
+
+        self.assertEqual("-r/usr/lib/libsomething.dll", str(stdo.decode('ascii')).strip())
+
     def test_deterministic_dep_order(self):
         '''
         Test that the dependencies are always listed in a deterministic order.

--- a/test cases/unit/48 pkgconfig csharp library/meson.build
+++ b/test cases/unit/48 pkgconfig csharp library/meson.build
@@ -1,0 +1,10 @@
+project('pkgformat', 'cs',
+  version : '1.0')
+
+pkgg = import('pkgconfig')
+
+l = library('libsomething', 'somelib.cs')
+
+pkgg.generate(l,
+              version: '1.0',
+              description: 'A library that does something')

--- a/test cases/unit/48 pkgconfig csharp library/somelib.cs
+++ b/test cases/unit/48 pkgconfig csharp library/somelib.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Abc
+{
+    public static class Something
+    {
+        public static bool Api1(this String str)
+        {
+            return str == "foo";
+        }
+    }
+}


### PR DESCRIPTION
this adds support for generating pkgconfig files for c#.

The difference to c and cpp is that the -I flag is not known to the c#
compiler, but rather the -r flag which is used to link a .dll file into
the compiled library.

However this opens the question of validating which pkgconfig files can
be generated (depending on the language).

This implements #4409.