### PR TITLE
[skip ci] Document CFLAGS and friends in main docs

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -110,6 +110,19 @@ These are the parameter names for passing language specific arguments to your bu
 | Rust          | rust_args |
 | Vala          | vala_args |
 
+## Compiler and linker flag environment variables
+
+These environment variables will be used to modify the compiler and
+linker flags.
+
+| CFLAGS    | Flags for the C compiler                 |
+| CXXFLAGS  | Flags for the C++ compiler               |
+| OBJCFLAGS | Flags for the Objective C compiler       |
+| FFLAGS    | Flags for the Fortran compiler           |
+| DFLAGS    | Flags for the D compiler                 |
+| VALAFLAGS | Flags for the Vala compiler              |
+| RUSTFLAGS | Flags for the Rust compiler              |
+| LDFLAGS   | The linker flags, used for all languages |
 
 ## Function Attributes
 

--- a/docs/markdown/Running-Meson.md
+++ b/docs/markdown/Running-Meson.md
@@ -92,6 +92,22 @@ You can then open the generated solution with Visual Studio and
 compile it in the usual way. A list of backends can be obtained with
 `meson --help`.
 
+Environment Variables
+--
+
+Sometimes you want to add extra compiler flags, this can be done by
+passing them in environment variables when calling meson. See [the
+reference
+tables](Reference-tables.md#compiler-and-linker-flag-envrionment-variables)
+for a list of all the environment variables. Be aware however these
+environment variables are only used for the native compiler and will
+not affect the compiler used for cross-compiling, where the flags
+specified in the cross file will be used.
+
+Furthermore it is possible to stop meson from adding flags itself by
+using the `--buildtype=plain` option, in this case you must provide
+the full compiler and linker arguments needed.
+
 Building the source
 ==
 


### PR DESCRIPTION
Currently this is only partially documented in the quick-start guide,
include this in the main docs and document all the environment
argumens used.