### PR TITLE
gnome.gtkdoc: Fix missing permitted `c_args` argument

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -914,7 +914,8 @@ This will become a hard error in the future.''')
                       'install_dir', 'scan_args', 'scanobjs_args', 'gobject_typesfile',
                       'fixxref_args', 'html_args', 'html_assets', 'content_files',
                       'mkdb_args', 'ignore_headers', 'include_directories',
-                      'namespace', 'mode', 'expand_content_files', 'module_version'})
+                      'namespace', 'mode', 'expand_content_files', 'module_version',
+                      'c_args'})
     def gtkdoc(self, state, args, kwargs):
         if len(args) != 1:
             raise MesonException('Gtkdoc must have one positional argument.')


### PR DESCRIPTION
Although `gtkdoc` [function has support for `c_args` argument](https://github.com/mesonbuild/meson/pull/4192), it produces warning messages due to missing string in the permitted arguments list.