### PR TITLE
docs: Add missing `namespace` parameter documentation

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -333,6 +333,7 @@ of the module.
 * `main_xml`: specifies the main XML file
 * `main_sgml`: equal to `main_xml`
 * `mkdb_args`: a list of arguments to pass to `gtkdoc-mkdb`
+* `namespace`: specifies the name space to pass to `gtkdoc-mkdb`
 * `module_version`: the version of the module, affects the installed location and the devhelp2 file location
 * `scan_args`: a list of arguments to pass to `gtkdoc-scan`
 * `scanobjs_args`: a list of arguments to pass to `gtkdoc-scangobj`


### PR DESCRIPTION
Although the `namespace` parameter was implemented in 0.37, its documentation is still missing.

It has been added to the `gtkdoc`'s  documentation.