### PR TITLE
azure: ignore PRs which should be skipped for ci

### DIFF
--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -2,7 +2,7 @@ steps:
 - powershell: |
      python ./skip_ci.py --base-branch-env=SYSTEM_PULLREQUEST_TARGETBRANCH --is-pull-env=SYSTEM_PULLREQUEST_PULLREQUESTID --base-branch-origin
      if ($LastExitCode -ne 0) {
-        throw ('error in skip_ci.py')
+        exit 0
      }
 
      # remove MinGW from path, so we don't find gfortran and try to use it


### PR DESCRIPTION
azure doesn't support [skip ci], so do nothing, rather than failing when
we detect a PR which should have [skip ci], but didn't get skipped.