### PR TITLE
Save environment for REGEN project.

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -188,6 +188,9 @@ def detect_windows_arch(compilers):
                 platform = os.environ.get('BUILD_PLAT', 'x86')
                 if platform == 'Win32':
                     return 'x86'
+            elif 'VSCMD_ARG_TGT_ARCH' in os.environ:
+                # On MSVC 2017 'Platform' is not set in VsDevCmd.bat
+                return os.environ['VSCMD_ARG_TGT_ARCH']
             else:
                 # On MSVC 2010 and later 'Platform' is only set when the
                 # target arch is not 'x86'.  It's 'x64' when targeting


### PR DESCRIPTION
This was partially suggested in #3872.

This way complete set of environment variables is saved for the VS backend and used to call the regenerate script in the REGEN project. That fixes the problem, where we first run Meson from some VS command prompt and after regeneration of the solution the old values for Platform and SDK version are lost.

The suggestion in #3872 was "the current-best solution we've got is that we add support in Meson for automatically searching for VS installations and extracting the env: #2622".

But I can't see how this will help in case of using one of VS command prompts. I think that if you run Meson from some VS command prompt the next regenerations from the IDE should use the same environment.

Another approach would be to read only some env variables, like 'VCINSTALLDIR', 'VSCMD_ARG_HOST_ARCH', 'VSCMD_ARG_TGT_ARCH' and remember them, and then use them to call "vcvarsall.bat" with the appropriate arguments. I don't think this approach is better, because there could be other configured environments, that are not coming from "vcvarsall.bat", and it either won't work with them or could be broken (calling REGEN with not desired environment, like it does right now). For example there is "Developer Command Prompt for VS 2017", which for me looks similar to "x86 Native Tools Command Prompt for VS 2017", but uses different batch script "VsDevCmd.bat" to setup the environment and could have some different values. Or some custom environment or just slightly modified "vcvarsall.bat" environment could be used.