### PR TITLE
Added 'section' key to buildoptions introspection

### DIFF
--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -30,11 +30,47 @@ In order to make code completion work, you need the compiler flags for each comp
 
 Note that if the target has dependencies (such as generated sources), then the commands for those show up in this list as well, so you need to do some filtering. Alternatively you can grab every command invocation in the [Clang tools db](https://clang.llvm.org/docs/JSONCompilationDatabase.html) format that is written to a file called `compile_commands.json` in the build directory.
 
+## Build Options
+
 The next thing to display is the list of options that can be set. These include build type and so on. Here's how to extract them.
 
     meson introspect --buildoptions
 
+This command returns a list of all supported buildoptions with the format:
+
+```json
+{
+    "name": "name of the option",
+    "description": "the description",
+    "type": "type ID",
+    "value": "value depends on type",
+    "section": "section ID"
+}
+```
+
+The supported types are:
+
+ - string
+ - boolean
+ - combo
+ - integer
+ - array
+
+For the type `combo` the key `choices` is also present. Here all valid values for the option are stored.
+
+The possible values for `section` are:
+
+ - core
+ - backend
+ - base
+ - compiler
+ - directory
+ - user
+ - test
+
 To set the options, use the `meson configure` command.
+
+## Tests
 
 Compilation and unit tests are done as usual by running the `ninja` and `ninja test` commands. A JSON formatted result log can be found in `workspace/project/builddir/meson-logs/testlog.json`.
 

--- a/docs/markdown/snippets/buildopts_section.md
+++ b/docs/markdown/snippets/buildopts_section.md
@@ -1,0 +1,14 @@
+## New `section` key for the buildoptions introspection
+
+Meson now has a new `section` key in each build option. This allows
+IDEs to group these options similar to `meson configure`.
+
+The possible values for `section` are:
+
+ - core
+ - backend
+ - base
+ - compiler
+ - directory
+ - user
+ - test

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -115,21 +115,21 @@ class Conf:
         print('  Source dir', self.build.environment.source_dir)
         print('  Build dir ', self.build.environment.build_dir)
 
-        dir_option_names = ['prefix',
+        dir_option_names = ['bindir',
+                            'datadir',
+                            'includedir',
+                            'infodir',
                             'libdir',
                             'libexecdir',
-                            'bindir',
-                            'sbindir',
-                            'includedir',
-                            'datadir',
-                            'mandir',
-                            'infodir',
                             'localedir',
-                            'sysconfdir',
                             'localstatedir',
-                            'sharedstatedir']
-        test_option_names = ['stdsplit',
-                             'errorlogs']
+                            'mandir',
+                            'prefix',
+                            'sbindir',
+                            'sharedstatedir',
+                            'sysconfdir']
+        test_option_names = ['errorlogs',
+                             'stdsplit']
         core_option_names = [k for k in self.coredata.builtins if k not in dir_option_names + test_option_names]
 
         dir_options = {k: o for k, o in self.coredata.builtins.items() if k in dir_option_names}

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -125,21 +125,21 @@ def list_target_files(target_name, coredata, builddata):
 def list_buildoptions(coredata, builddata):
     optlist = []
 
-    dir_option_names = ['prefix',
+    dir_option_names = ['bindir',
+                        'datadir',
+                        'includedir',
+                        'infodir',
                         'libdir',
                         'libexecdir',
-                        'bindir',
-                        'sbindir',
-                        'includedir',
-                        'datadir',
-                        'mandir',
-                        'infodir',
                         'localedir',
-                        'sysconfdir',
                         'localstatedir',
-                        'sharedstatedir']
-    test_option_names = ['stdsplit',
-                         'errorlogs']
+                        'mandir',
+                        'prefix',
+                        'sbindir',
+                        'sharedstatedir',
+                        'sysconfdir']
+    test_option_names = ['errorlogs',
+                         'stdsplit']
     core_option_names = [k for k in coredata.builtins if k not in dir_option_names + test_option_names]
 
     dir_options = {k: o for k, o in coredata.builtins.items() if k in dir_option_names}

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -124,18 +124,43 @@ def list_target_files(target_name, coredata, builddata):
 
 def list_buildoptions(coredata, builddata):
     optlist = []
-    add_keys(optlist, coredata.user_options)
-    add_keys(optlist, coredata.compiler_options)
-    add_keys(optlist, coredata.base_options)
-    add_keys(optlist, coredata.builtins)
+
+    dir_option_names = ['prefix',
+                        'libdir',
+                        'libexecdir',
+                        'bindir',
+                        'sbindir',
+                        'includedir',
+                        'datadir',
+                        'mandir',
+                        'infodir',
+                        'localedir',
+                        'sysconfdir',
+                        'localstatedir',
+                        'sharedstatedir']
+    test_option_names = ['stdsplit',
+                         'errorlogs']
+    core_option_names = [k for k in coredata.builtins if k not in dir_option_names + test_option_names]
+
+    dir_options = {k: o for k, o in coredata.builtins.items() if k in dir_option_names}
+    test_options = {k: o for k, o in coredata.builtins.items() if k in test_option_names}
+    core_options = {k: o for k, o in coredata.builtins.items() if k in core_option_names}
+
+    add_keys(optlist, core_options, 'core')
+    add_keys(optlist, coredata.backend_options, 'backend')
+    add_keys(optlist, coredata.base_options, 'base')
+    add_keys(optlist, coredata.compiler_options, 'compiler')
+    add_keys(optlist, dir_options, 'directory')
+    add_keys(optlist, coredata.user_options, 'user')
+    add_keys(optlist, test_options, 'test')
     print(json.dumps(optlist))
 
-def add_keys(optlist, options):
+def add_keys(optlist, options, section):
     keys = list(options.keys())
     keys.sort()
     for key in keys:
         opt = options[key]
-        optdict = {'name': key, 'value': opt.value}
+        optdict = {'name': key, 'value': opt.value, 'section': section}
         if isinstance(opt, cdata.UserStringOption):
             typestr = 'string'
         elif isinstance(opt, cdata.UserBooleanOption):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2253,6 +2253,7 @@ int main(int argc, char **argv) {
         expected = {
             'name': 'list',
             'description': 'list',
+            'section': 'user',
             'type': 'array',
             'value': ['foo', 'bar'],
         }
@@ -2277,6 +2278,7 @@ int main(int argc, char **argv) {
         expected = {
             'name': 'list',
             'description': 'list',
+            'section': 'user',
             'type': 'array',
             'value': ['foo', 'bar'],
         }
@@ -2301,6 +2303,7 @@ int main(int argc, char **argv) {
         expected = {
             'name': 'list',
             'description': 'list',
+            'section': 'user',
             'type': 'array',
             'value': [],
         }


### PR DESCRIPTION
This adds the new key `section` to each build option when running `meson introspect --buildoptions`. This allows IDEs to group the build options into the same sections as `meson configure`. This change should not break any existing code since only one key was added.