### PR TITLE
mintro: Save introspection to disk and --targets modifications

### DIFF
--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -40,7 +40,7 @@ The most important file for an IDE is probably `intro-targets.json`. Here each t
     "type": "<TYPE>",
     "filename": ["list", "of", "generated", "files"],
     "build_by_default": true / false,
-    "sources": [],
+    "target_sources": [],
     "installed": true / false,
 }
 ```
@@ -51,7 +51,7 @@ A target usually generates only one file. However, it is possible for custom tar
 
 ### Target sources
 
-The `intro-sources.json` file stores a list of all source objects of the target. With this information, an IDE can provide code completion for all source files.
+The `intro-targets.json` file also stores a list of all source objects of the target in the `target_sources`. With this information, an IDE can provide code completion for all source files.
 
 ```json
 {

--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -6,38 +6,32 @@ short-description: Meson's API to integrate Meson support into an IDE
 
 Meson has exporters for Visual Studio and XCode, but writing a custom backend for every IDE out there is not a scalable approach. To solve this problem, Meson provides an API that makes it easy for any IDE or build tools to integrate Meson builds and provide an experience comparable to a solution native to the IDE.
 
-The basic resource for this is the `meson-introspection.json` file in the build directory.
+All the resources required for such a IDE integration can be found in the `meson-info` directory in the build directory.
 
 The first thing to do when setting up a Meson project in an IDE is to select the source and build directories. For this example we assume that the source resides in an Eclipse-like directory called `workspace/project` and the build tree is nested inside it as `workspace/project/build`. First, we initialize Meson by running the following command in the source directory.
 
     meson builddir
 
-The `meson-introspection.json` can then be found in the root of this build directory. It will be automatically updated when meson is (re)configured, or the build options change. As a result, an IDE can watch for changes in this file to know when something changed.
+With this command meson will configure the project and also generate introspection information that is stored in `intro-*.json` files in the `meson-info` directory. All files will be automatically updated when meson is (re)configured, or the build options change. Thus, an IDE can watch for changes in this directory to know when something changed.
 
-The basic JSON format structure defined as follows:
+The `meson-info` directory should contain the following files:
 
-```json
-{
-    "benchmarks": [],
-    "buildoptions": [],
-    "buildsystem_files": ["just", "a", "list", "of", "meson", "files"],
-    "dependencies": [],
-    "installed": {},
-    "projectinfo": {
-        "version": "1.2.3",
-        "descriptive_name": "Project Name",
-        "subprojects": []
-    },
-    "targets": [],
-    "tests": []
-}
-```
+ File                            | Description
+ ------------------------------- | ---------------------------------------------------------------------
+ `intro-benchmarks.json`         | Lists all benchmarks
+ `intro-buildoptions.json`       | Contains a full list of meson configuration options for the project
+ `intro-buildsystem_files.json`  | Full list of all meson build files
+ `intro-dependencies.json`       | Lists all dependencies used in the project
+ `intro-installed.json`          | Contains mapping of files to their installed location
+ `intro-projectinfo.json`        | Stores basic information about the project (name, version, etc.)
+ `intro-targets.json`            | Full list of all build targets
+ `intro-tests.json`              | Lists all tests with instructions how to run them
 
-The content of each JSON entry in this format is further specified in the remainder of this document.
+The content of the JSON files is further specified in the remainder of this document.
 
 ## The `targets` section
 
-The most important entry for an IDE is probably the `targets` section. Here each target with its sources and compiler parameters is specified. The JSON format for one target is defined as follows:
+The most important file for an IDE is probably `intro-targets.json`. Here each target with its sources and compiler parameters is specified. The JSON format for one target is defined as follows:
 
 ```json
 {
@@ -57,7 +51,7 @@ A target usually generates only one file. However, it is possible for custom tar
 
 ### Target sources
 
-The `sources` entry stores a list of all source objects of the target. With this information, an IDE can provide code completion for all source files.
+The `intro-sources.json` file stores a list of all source objects of the target. With this information, an IDE can provide code completion for all source files.
 
 ```json
 {
@@ -83,7 +77,7 @@ The following table shows all valid types for a target.
 
 ## Build Options
 
-The list of all build options (build type, warning level, etc.) is stored in the `buildoptions` list. Here is the JSON format for each option.
+The list of all build options (build type, warning level, etc.) is stored in the `intro-buildoptions.json` file. Here is the JSON format for each option.
 
 ```json
 {

--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -128,7 +128,7 @@ Because of this options for the subprojects can differ.
 
 Compilation and unit tests are done as usual by running the `ninja` and `ninja test` commands. A JSON formatted result log can be found in `workspace/project/builddir/meson-logs/testlog.json`.
 
-When these tests fail, the user probably wants to run the failing test in a debugger. To make this as integrated as possible, extract the tests from the `tests` and `benchmarks` entries.
+When these tests fail, the user probably wants to run the failing test in a debugger. To make this as integrated as possible, extract the tests from the `intro-tests.json` and `intro-benchmarks.json` files.
 This provides you with all the information needed to run the test: what command to execute, command line arguments and environment variable settings.
 
 ```json

--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -59,7 +59,7 @@ The `intro-sources.json` file stores a list of all source objects of the target.
     "compiler": ["The", "compiler", "command"],
     "parameters": ["list", "of", "compiler", "parameters"],
     "sources": ["list", "of", "all", "source", "files", "for", "this", "language"],
-    "generated_sources": ["list", "of", "all", "soruce", "files", "that", "where", "generated", "somewhere", "else"]
+    "generated_sources": ["list", "of", "all", "source", "files", "that", "where", "generated", "somewhere", "else"]
 }
 ```
 

--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -58,7 +58,8 @@ The `intro-sources.json` file stores a list of all source objects of the target.
     "language": "language ID",
     "compiler": ["The", "compiler", "command"],
     "parameters": ["list", "of", "compiler", "parameters"],
-    "source_files": ["list", "of", "all", "source", "files", "for", "this", "language"]
+    "sources": ["list", "of", "all", "source", "files", "for", "this", "language"],
+    "generated_sources": ["list", "of", "all", "soruce", "files", "that", "where", "generated", "somewhere", "else"]
 }
 ```
 

--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -12,7 +12,7 @@ The first thing to do when setting up a Meson project in an IDE is to select the
 
     meson builddir
 
-With this command meson will configure the project and also generate introspection information that is stored in `intro-*.json` files in the `meson-info` directory. All files will be automatically updated when meson is (re)configured, or the build options change. Thus, an IDE can watch for changes in this directory to know when something changed.
+With this command meson will configure the project and also generate introspection information that is stored in `intro-*.json` files in the `meson-info` directory. The introspection dump will be automatically updated when meson is (re)configured, or the build options change. Thus, an IDE can watch for changes in this directory to know when something changed.
 
 The `meson-info` directory should contain the following files:
 

--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -4,15 +4,28 @@ short-description: Meson's API to integrate Meson support into an IDE
 
 # IDE integration
 
-Meson has exporters for Visual Studio and XCode, but writing a custom backend for every IDE out there is not a scalable approach. To solve this problem, Meson provides an API that makes it easy for any IDE or build tools to integrate Meson builds and provide an experience comparable to a solution native to the IDE.
+Meson has exporters for Visual Studio and XCode, but writing a custom backend
+for every IDE out there is not a scalable approach. To solve this problem,
+Meson provides an API that makes it easy for any IDE or build tools to
+integrate Meson builds and provide an experience comparable to a solution
+native to the IDE.
 
-All the resources required for such a IDE integration can be found in the `meson-info` directory in the build directory.
+All the resources required for such a IDE integration can be found in
+the `meson-info` directory in the build directory.
 
-The first thing to do when setting up a Meson project in an IDE is to select the source and build directories. For this example we assume that the source resides in an Eclipse-like directory called `workspace/project` and the build tree is nested inside it as `workspace/project/build`. First, we initialize Meson by running the following command in the source directory.
+The first thing to do when setting up a Meson project in an IDE is to select
+the source and build directories. For this example we assume that the source
+resides in an Eclipse-like directory called `workspace/project` and the build
+tree is nested inside it as `workspace/project/build`. First, we initialize
+Meson by running the following command in the source directory.
 
     meson builddir
 
-With this command meson will configure the project and also generate introspection information that is stored in `intro-*.json` files in the `meson-info` directory. The introspection dump will be automatically updated when meson is (re)configured, or the build options change. Thus, an IDE can watch for changes in this directory to know when something changed.
+With this command meson will configure the project and also generate
+introspection information that is stored in `intro-*.json` files in the
+`meson-info` directory. The introspection dump will be automatically updated
+when meson is (re)configured, or the build options change. Thus, an IDE can
+watch for changes in this directory to know when something changed.
 
 The `meson-info` directory should contain the following files:
 
@@ -31,7 +44,9 @@ The content of the JSON files is further specified in the remainder of this docu
 
 ## The `targets` section
 
-The most important file for an IDE is probably `intro-targets.json`. Here each target with its sources and compiler parameters is specified. The JSON format for one target is defined as follows:
+The most important file for an IDE is probably `intro-targets.json`. Here each
+target with its sources and compiler parameters is specified. The JSON format
+for one target is defined as follows:
 
 ```json
 {
@@ -45,13 +60,19 @@ The most important file for an IDE is probably `intro-targets.json`. Here each t
 }
 ```
 
-If the key `installed` is set to `true`, the key `install_filename` will also be present. It stores the installation location for each file in `filename`. If one file in `filename` is not installed, its corresponding install location is set to `null`.
+If the key `installed` is set to `true`, the key `install_filename` will also
+be present. It stores the installation location for each file in `filename`.
+If one file in `filename` is not installed, its corresponding install location
+is set to `null`.
 
-A target usually generates only one file. However, it is possible for custom targets to have multiple outputs.
+A target usually generates only one file. However, it is possible for custom
+targets to have multiple outputs.
 
 ### Target sources
 
-The `intro-targets.json` file also stores a list of all source objects of the target in the `target_sources`. With this information, an IDE can provide code completion for all source files.
+The `intro-targets.json` file also stores a list of all source objects of the
+target in the `target_sources`. With this information, an IDE can provide code
+completion for all source files.
 
 ```json
 {
@@ -62,6 +83,12 @@ The `intro-targets.json` file also stores a list of all source objects of the ta
     "generated_sources": ["list", "of", "all", "source", "files", "that", "where", "generated", "somewhere", "else"]
 }
 ```
+
+It should be noted that the compiler parameters stored in the `parameters`
+differ from the actual parameters used to compile the file. This is because
+the parameters are optimized for the usage in an IDE to provide autocompletion
+support, etc. It is thus not recommended to use this introspection information
+for actual compilation.
 
 ### Possible values for `type`
 
@@ -79,7 +106,8 @@ The following table shows all valid types for a target.
 
 ## Build Options
 
-The list of all build options (build type, warning level, etc.) is stored in the `intro-buildoptions.json` file. Here is the JSON format for each option.
+The list of all build options (build type, warning level, etc.) is stored in
+the `intro-buildoptions.json` file. Here is the JSON format for each option.
 
 ```json
 {
@@ -99,7 +127,8 @@ The supported types are:
  - integer
  - array
 
-For the type `combo` the key `choices` is also present. Here all valid values for the option are stored.
+For the type `combo` the key `choices` is also present. Here all valid values
+for the option are stored.
 
 The possible values for `section` are:
 
@@ -117,19 +146,24 @@ Since Meson 0.50.0 it is also possible to get the default buildoptions
 without a build directory by providing the root `meson.build` instead of a
 build directory to `meson introspect --buildoptions`.
 
-Running `--buildoptions` without a build directory produces the same output as running
-it with a freshly configured build directory.
+Running `--buildoptions` without a build directory produces the same output as
+running it with a freshly configured build directory.
 
-However, this behavior is not guaranteed if subprojects are present. Due to internal
-limitations all subprojects are processed even if they are never used in a real meson run.
-Because of this options for the subprojects can differ.
+However, this behavior is not guaranteed if subprojects are present. Due to
+internal limitations all subprojects are processed even if they are never used
+in a real meson run. Because of this options for the subprojects can differ.
 
 ## Tests
 
-Compilation and unit tests are done as usual by running the `ninja` and `ninja test` commands. A JSON formatted result log can be found in `workspace/project/builddir/meson-logs/testlog.json`.
+Compilation and unit tests are done as usual by running the `ninja` and
+`ninja test` commands. A JSON formatted result log can be found in
+`workspace/project/builddir/meson-logs/testlog.json`.
 
-When these tests fail, the user probably wants to run the failing test in a debugger. To make this as integrated as possible, extract the tests from the `intro-tests.json` and `intro-benchmarks.json` files.
-This provides you with all the information needed to run the test: what command to execute, command line arguments and environment variable settings.
+When these tests fail, the user probably wants to run the failing test in a
+debugger. To make this as integrated as possible, extract the tests from the
+`intro-tests.json` and `intro-benchmarks.json` files. This provides you with
+all the information needed to run the test: what command to execute, command
+line arguments and environment variable settings.
 
 ```json
 {
@@ -148,7 +182,8 @@ This provides you with all the information needed to run the test: what command 
 
 # Programmatic interface
 
-Meson also provides the `meson introspect` for project introspection via the command line. Use `meson introspect -h` to see all available options.
+Meson also provides the `meson introspect` for project introspection via the
+command line. Use `meson introspect -h` to see all available options.
 
 This API can also work without a build directory for the `--projectinfo` command.
 

--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -74,7 +74,8 @@ The following table shows all valid types for a target.
  `shared library` | Target for a shared library
  `shared module`  | A shared library that is meant to be used with dlopen rather than linking into something else
  `custom`         | A custom target
- `unknown target` | The current target format is unknown. This is probably a bug
+ `run`            | A Meson run target
+ `jar`            | A Java JAR target
 
 ## Build Options
 

--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -38,7 +38,7 @@ The most important file for an IDE is probably `intro-targets.json`. Here each t
     "name": "Name of the target",
     "id": "The internal ID meson uses",
     "type": "<TYPE>",
-    "filename": ["list", "of", "generate", "files"],
+    "filename": ["list", "of", "generated", "files"],
     "build_by_default": true / false,
     "sources": [],
     "installed": true / false,

--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -13,7 +13,8 @@ JSON output (the default is still compact JSON) and force use the new
 output format, even if only one introspection command was given.
 
 A complete introspection dump is also stored in the `meson-info`
-directory. This dump will be (re)generated each time meson updates the configuration of the build directory.
+directory. This dump will be (re)generated each time meson updates the
+configuration of the build directory.
 
 Additionlly the format of `meson introspect target` was changed:
 

--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -1,12 +1,13 @@
 ## Added option to introspect multiple parameters at once
 
-Meson introspect can now print the results of multiple parameters
-in a single call. The results are then printed as a single JSON
+Meson introspect can now print the results of multiple introspection
+commands in a single call. The results are then printed as a single JSON
 object.
 
 The format for a single command was not changed to keep backward
 compatibility.
 
-Furthermore the option `-a,--all` and `-i,--indent` was added to
-print all introspection information in one go and format the
-JSON output (the default is still compact JSON).
+Furthermore the option `-a,--all`, `-i,--indent` and `-f,--force-new`
+were added to print all introspection information in one go, format the
+JSON output (the default is still compact JSON) and foce use the new
+output format, even if only one introspection command was given.

--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -18,5 +18,5 @@ configuration of the build directory.
 
 Additionlly the format of `meson introspect target` was changed:
 
-  - New: the `sources` key. It stores the source files of a target and there compiler parameters
+  - New: the `sources` key. It stores the source files of a target and their compiler parameters
   - Added new target types (`jar`, `shared module`)

--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -13,7 +13,7 @@ JSON output (the default is still compact JSON) and foce use the new
 output format, even if only one introspection command was given.
 
 A complete introspection dump is also stored in the `meson-info`
-directory. This dump will alwys be (re)generated on every meson run.
+directory. This dump will be (re)generated each time meson updates the configuration of the build directory.
 
 Additionlly the format of target was changed:
   - `filename` is now a list of output filenames

--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -9,7 +9,7 @@ compatibility.
 
 Furthermore the option `-a,--all`, `-i,--indent` and `-f,--force-dict-output`
 were added to print all introspection information in one go, format the
-JSON output (the default is still compact JSON) and foce use the new
+JSON output (the default is still compact JSON) and force use the new
 output format, even if only one introspection command was given.
 
 A complete introspection dump is also stored in the `meson-info`

--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -15,7 +15,7 @@ output format, even if only one introspection command was given.
 A complete introspection dump is also stored in the `meson-info`
 directory. This dump will be (re)generated each time meson updates the configuration of the build directory.
 
-Additionlly the format of target was changed:
+Additionlly the format of `meson introspect target` was changed:
   - `filename` is now a list of output filenames
   - `install_filename` is now also a list of installed files
   - New: the `sources` key. It stores the source files of a target and there compiler parameters

--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -7,7 +7,7 @@ object.
 The format for a single command was not changed to keep backward
 compatibility.
 
-Furthermore the option `-a,--all`, `-i,--indent` and `-f,--force-dict-output`
+Furthermore the option `-a,--all`, `-i,--indent` and `-f,--force-object-output`
 were added to print all introspection information in one go, format the
 JSON output (the default is still compact JSON) and force use the new
 output format, even if only one introspection command was given.

--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -1,0 +1,12 @@
+## Added option to introspect multiple parameters at once
+
+Meson introspect can now print the results of multiple parameters
+in a single call. The results are then printed as a single JSON
+object.
+
+The format for a single command was not changed to keep backward
+compatibility.
+
+Furthermore the option `-a,--all` and `-i,--indent` was added to
+print all introspection information in one go and format the
+JSON output (the default is still compact JSON).

--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -18,3 +18,4 @@ directory. This dump will be (re)generated each time meson updates the configura
 Additionlly the format of `meson introspect target` was changed:
 
   - New: the `sources` key. It stores the source files of a target and there compiler parameters
+  - Added new target types (`jar`, `shared module`)

--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -16,6 +16,5 @@ A complete introspection dump is also stored in the `meson-info`
 directory. This dump will be (re)generated each time meson updates the configuration of the build directory.
 
 Additionlly the format of `meson introspect target` was changed:
-  - `filename` is now a list of output filenames
-  - `install_filename` is now also a list of installed files
+
   - New: the `sources` key. It stores the source files of a target and there compiler parameters

--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -18,5 +18,5 @@ configuration of the build directory.
 
 Additionlly the format of `meson introspect target` was changed:
 
-  - New: the `sources` key. It stores the source files of a target and their compiler parameters
-  - Added new target types (`jar`, `shared module`)
+  - New: the `sources` key. It stores the source files of a target and their compiler parameters.
+  - Added new target types (`jar`, `shared module`).

--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -11,3 +11,8 @@ Furthermore the option `-a,--all`, `-i,--indent` and `-f,--force-new`
 were added to print all introspection information in one go, format the
 JSON output (the default is still compact JSON) and foce use the new
 output format, even if only one introspection command was given.
+
+Additionlly the format of target was changed:
+  - `filename` is now a list of output filenames
+  - `install_filename` is now also a list of installed files
+  - New: the `sources` key. It stores the source files of a target and there compiler parameters

--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -7,7 +7,7 @@ object.
 The format for a single command was not changed to keep backward
 compatibility.
 
-Furthermore the option `-a,--all`, `-i,--indent` and `-f,--force-new`
+Furthermore the option `-a,--all`, `-i,--indent` and `-f,--force-dict-output`
 were added to print all introspection information in one go, format the
 JSON output (the default is still compact JSON) and foce use the new
 output format, even if only one introspection command was given.

--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -12,6 +12,9 @@ were added to print all introspection information in one go, format the
 JSON output (the default is still compact JSON) and foce use the new
 output format, even if only one introspection command was given.
 
+A complete introspection dump is also stored in the `meson-info`
+directory. This dump will alwys be (re)generated on every meson run.
+
 Additionlly the format of target was changed:
   - `filename` is now a list of output filenames
   - `install_filename` is now also a list of installed files

--- a/docs/markdown/snippets/introspect_target_new.md
+++ b/docs/markdown/snippets/introspect_target_new.md
@@ -1,7 +1,0 @@
-## New `include_directories` and `extra_args` keys for the target introspection
-
-Meson now also prints the include directories and extra compiler arguments for
-the target introspection (`meson introspect --targets`).
-
-The `include_directories` key stores a list of absolute paths and the `extra_args`
-key holds a dict of compiler arguments for each language.

--- a/docs/markdown/snippets/introspect_target_new.md
+++ b/docs/markdown/snippets/introspect_target_new.md
@@ -1,0 +1,7 @@
+## New `include_directories` and `extra_args` keys for the target introspection
+
+Meson now also prints the include directories and extra compiler arguments for
+the target introspection (`meson introspect --targets`).
+
+The `include_directories` key stores a list of absolute paths and the `extra_args`
+key holds a dict of compiler arguments for each language.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1177,9 +1177,15 @@ class Backend:
                     source_list += [os.path.join(self.environment.get_source_dir(), i)]
             source_list = list(map(lambda x: os.path.normpath(x), source_list))
 
+            compiler = []
+            if isinstance(target, build.CustomTarget):
+                compiler = target.command
+                if isinstance(compiler, str):
+                    compiler = [compiler]
+
             return [{
                 'language': 'unknown',
-                'compiler': [],
+                'compiler': compiler,
                 'parameters': [],
                 'sources': source_list,
                 'generated_sources': []

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -683,7 +683,7 @@ class Backend:
     def write_test_file(self, datafile):
         self.write_test_serialisation(self.build.get_tests(), datafile)
 
-    def write_test_serialisation(self, tests, datafile):
+    def create_test_serialisation(self, tests):
         arr = []
         for t in tests:
             exe = t.get_exe()
@@ -730,7 +730,10 @@ class Backend:
                                    exe_wrapper, t.is_parallel, cmd_args, t.env,
                                    t.should_fail, t.timeout, t.workdir, extra_paths)
             arr.append(ts)
-        pickle.dump(arr, datafile)
+        return arr
+
+    def write_test_serialisation(self, tests, datafile):
+        pickle.dump(self.create_test_serialisation(tests), datafile)
 
     def generate_depmf_install(self, d):
         if self.build.dep_manifest_name is None:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1158,7 +1158,8 @@ class Backend:
                 "language": "<LANG>",
                 "compiler": ["result", "of", "comp.get_exelist()"],
                 "parameters": ["list", "of", "compiler", "parameters],
-                "source_files": ["list", "of", "all", "<LANG>", "source", "files"]
+                "sources": ["list", "of", "all", "<LANG>", "source", "files"],
+                "generated_sources": ["list", "of", "generated", "source", "files"]
             }
         ]
 
@@ -1169,20 +1170,23 @@ class Backend:
             source_list = []
             for i in source_list_raw:
                 if isinstance(i, mesonlib.File):
-                    source_list += [os.path.join(i.subdir, i.fname)]
+                    source_list += [i.absolute_path(self.environment.get_source_dir(), self.environment.get_build_dir())]
                 elif isinstance(i, str):
-                    source_list += [i]
+                    source_list += [os.path.join(self.environment.get_source_dir(), i)]
+            source_list = list(map(lambda x: os.path.normpath(x), source_list))
 
             return [{
                 'language': 'unknown',
                 'compiler': [],
                 'parameters': [],
-                'source_files': source_list
+                'sources': source_list,
+                'generated_sources': []
             }]
 
         return [{
             'language': 'unknown',
             'compiler': [],
             'parameters': [],
-            'source_files': []
+            'sources': [],
+            'generated_sources': []
         }]

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1183,10 +1183,4 @@ class Backend:
                 'generated_sources': []
             }]
 
-        return [{
-            'language': 'unknown',
-            'compiler': [],
-            'parameters': [],
-            'sources': [],
-            'generated_sources': []
-        }]
+        return []

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1170,18 +1170,27 @@ class Backend:
         if isinstance(target, (build.CustomTarget, build.BuildTarget)):
             source_list_raw = target.sources + target.extra_files
             source_list = []
-            for i in source_list_raw:
-                if isinstance(i, mesonlib.File):
-                    source_list += [i.absolute_path(self.environment.get_source_dir(), self.environment.get_build_dir())]
-                elif isinstance(i, str):
-                    source_list += [os.path.join(self.environment.get_source_dir(), i)]
+            for j in source_list_raw:
+                if isinstance(j, mesonlib.File):
+                    source_list += [j.absolute_path(self.source_dir, self.build_dir)]
+                elif isinstance(j, str):
+                    source_list += [os.path.join(self.source_dir, j)]
             source_list = list(map(lambda x: os.path.normpath(x), source_list))
 
             compiler = []
             if isinstance(target, build.CustomTarget):
-                compiler = target.command
-                if isinstance(compiler, str):
-                    compiler = [compiler]
+                tmp_compiler = target.command
+                if not isinstance(compiler, list):
+                    tmp_compiler = [compiler]
+                for j in tmp_compiler:
+                    if isinstance(j, mesonlib.File):
+                        compiler += [j.absolute_path(self.source_dir, self.build_dir)]
+                    elif isinstance(j, str):
+                        compiler += [j]
+                    elif isinstance(j, (build.BuildTarget, build.CustomTarget)):
+                        compiler += j.get_outputs()
+                    else:
+                        raise RuntimeError('Type "{}" is not supported in get_introspection_data. This is a bug'.format(type(j).__name__))
 
             return [{
                 'language': 'unknown',

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -156,6 +156,8 @@ class Backend:
         self.build = build
         self.environment = build.environment
         self.processed_targets = {}
+        self.build_dir = self.environment.get_build_dir()
+        self.source_dir = self.environment.get_source_dir()
         self.build_to_src = mesonlib.relpath(self.environment.get_source_dir(),
                                              self.environment.get_build_dir())
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -974,9 +974,7 @@ class Backend:
             cmd = s['exe'] + s['args']
             subprocess.check_call(cmd, env=child_env)
 
-    def create_install_data_files(self):
-        install_data_file = os.path.join(self.environment.get_scratch_dir(), 'install.dat')
-
+    def create_install_data(self):
         strip_bin = self.environment.binaries.host.lookup_entry('strip')
         if strip_bin is None:
             if self.environment.is_cross_build():
@@ -997,8 +995,12 @@ class Backend:
         self.generate_data_install(d)
         self.generate_custom_install_script(d)
         self.generate_subdir_install(d)
+        return d
+
+    def create_install_data_files(self):
+        install_data_file = os.path.join(self.environment.get_scratch_dir(), 'install.dat')
         with open(install_data_file, 'wb') as ofile:
-            pickle.dump(d, ofile)
+            pickle.dump(self.create_install_data(), ofile)
 
     def generate_target_install(self, d):
         for t in self.build.get_targets().values():

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -343,7 +343,7 @@ int dummy;
         lang = comp.get_language()
         tgt = self.introspection_data[id]
         # Find an existing entry or create a new one
-        id_hash = (lang, parameters)
+        id_hash = (lang, tuple(parameters))
         src_block = tgt.get(id_hash, None)
         if src_block is None:
             # Convert parameters

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -351,7 +351,10 @@ int dummy;
                 parameters = parameters.to_native(copy=True)
             parameters = comp.compute_parameters_with_absolute_paths(parameters, self.build_dir)
             if target.is_cross:
-                parameters.insert(0, comp.get_cross_extra_flags(self.environment, False))
+                extra_parameters = comp.get_cross_extra_flags(self.environment, False)
+                if isinstance(parameters, CompilerArgs):
+                    extra_parameters = extra_parameters.to_native(copy=True)
+                parameters = extra_parameters + parameters
             # The new entry
             src_block = {
                 'language': lang,

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -29,7 +29,7 @@ from .. import build
 from .. import mlog
 from .. import dependencies
 from .. import compilers
-from ..compilers import CompilerArgs, CCompiler, VisualStudioCCompiler
+from ..compilers import CompilerArgs, CCompiler, VisualStudioCCompiler, Compiler
 from ..linkers import ArLinker
 from ..mesonlib import File, MesonException, OrderedSet
 from ..mesonlib import get_compiler_for_source, has_path_sep
@@ -322,7 +322,7 @@ int dummy;
                 return False
         return True
 
-    def create_target_source_introspection(self, target, comp, parameters, sources, generated_sources):
+    def create_target_source_introspection(self, target: build.Target, comp: compilers.Compiler, parameters, sources, generated_sources):
         '''
         Adds the source file introspection information for a language of a target
 
@@ -349,9 +349,7 @@ int dummy;
             # Convert parameters
             if isinstance(parameters, CompilerArgs):
                 parameters = parameters.to_native(copy=True)
-            for idx, i in enumerate(parameters):
-                if i[:2] == '-I' or i[:2] == '/I' or i[:2] == '-L':
-                    parameters[idx] = i[:2] + os.path.normpath(os.path.join(self.build_dir, i[2:]))
+            parameters = comp.compute_parameters_with_absolute_paths(parameters, self.build_dir)
             if target.is_cross:
                 parameters += comp.get_cross_extra_flags(self.environment, False)
             # The new entry

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -339,7 +339,6 @@ int dummy;
             }
         }
         '''
-        build_dir = self.environment.get_build_dir()
         id = target.get_id()
         lang = comp.get_language()
         tgt = self.introspection_data[id]
@@ -352,7 +351,7 @@ int dummy;
                 parameters = parameters.to_native(copy=True)
             for idx, i in enumerate(parameters):
                 if i[:2] == '-I' or i[:2] == '/I' or i[:2] == '-L':
-                    parameters[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
+                    parameters[idx] = i[:2] + os.path.normpath(os.path.join(self.build_dir, i[2:]))
             if target.is_cross:
                 parameters += comp.get_cross_extra_flags(self.environment, False)
             # The new entry
@@ -366,10 +365,10 @@ int dummy;
             self._intro_last_index = len(tgt)
             tgt[id_hash] = src_block
         # Make source files absolute
-        sources = [x.rel_to_builddir(self.build_to_src) if isinstance(x, File) else x for x in sources]
-        sources = [os.path.normpath(os.path.join(build_dir, x)) for x in sources]
-        generated_sources = [x.rel_to_builddir(self.build_to_src) if isinstance(x, File) else x for x in generated_sources]
-        generated_sources = [os.path.normpath(os.path.join(build_dir, x)) for x in generated_sources]
+        sources = [x.absolute_path(self.source_dir, self.build_dir) if isinstance(x, File) else os.path.normpath(os.path.join(self.build_dir, x))
+                   for x in sources]
+        generated_sources = [x.absolute_path(self.source_dir, self.build_dir) if isinstance(x, File) else os.path.normpath(os.path.join(self.build_dir, x))
+                             for x in generated_sources]
         # Add the source files
         src_block['sources'] += sources
         src_block['generated_sources'] += generated_sources

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -343,7 +343,7 @@ int dummy;
         lang = comp.get_language()
         tgt = self.introspection_data[id]
         # Find an existing entry or create a new one
-        id_hash = (lang, CompilerArgs)
+        id_hash = (lang, parameters)
         src_block = tgt.get(id_hash, None)
         if src_block is None:
             # Convert parameters
@@ -351,7 +351,7 @@ int dummy;
                 parameters = parameters.to_native(copy=True)
             parameters = comp.compute_parameters_with_absolute_paths(parameters, self.build_dir)
             if target.is_cross:
-                parameters += comp.get_cross_extra_flags(self.environment, False)
+                parameters.insert(0, comp.get_cross_extra_flags(self.environment, False))
             # The new entry
             src_block = {
                 'language': lang,
@@ -360,7 +360,6 @@ int dummy;
                 'sources': [],
                 'generated_sources': [],
             }
-            self._intro_last_index = len(tgt)
             tgt[id_hash] = src_block
         # Make source files absolute
         sources = [x.absolute_path(self.source_dir, self.build_dir) if isinstance(x, File) else os.path.normpath(os.path.join(self.build_dir, x))

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -29,7 +29,7 @@ from .. import build
 from .. import mlog
 from .. import dependencies
 from .. import compilers
-from ..compilers import CompilerArgs, CCompiler, VisualStudioCCompiler, Compiler
+from ..compilers import CompilerArgs, CCompiler, VisualStudioCCompiler
 from ..linkers import ArLinker
 from ..mesonlib import File, MesonException, OrderedSet
 from ..mesonlib import get_compiler_for_source, has_path_sep

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2120,6 +2120,9 @@ class RunTarget(Target):
     def get_filename(self):
         return self.name
 
+    def get_outputs(self):
+        return [self.name]
+
     def type_suffix(self):
         return "@run"
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2122,7 +2122,12 @@ class RunTarget(Target):
         return self.name
 
     def get_outputs(self):
-        return [self.name]
+        if isinstance(self.name, str):
+            return [self.name]
+        elif isinstance(self.name, list):
+            return self.name
+        else:
+            raise RuntimeError('RunTarget: self.name is neither a list nor a string. This is a bug')
 
     def type_suffix(self):
         return "@run"

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -345,6 +345,7 @@ a hard error in the future.''' % name)
         self.install = False
         self.build_always_stale = False
         self.option_overrides = {}
+        self.typename = 'unknown target'
 
     def get_install_dir(self, environment):
         # Find the installation directory.
@@ -365,6 +366,9 @@ a hard error in the future.''' % name)
 
     def get_subdir(self):
         return self.subdir
+
+    def get_typename(self):
+        return self.typename
 
     @staticmethod
     def _get_id_hash(target_id):
@@ -1364,6 +1368,7 @@ class Executable(BuildTarget):
         if 'pie' not in kwargs and 'b_pie' in environment.coredata.base_options:
             kwargs['pie'] = environment.coredata.base_options['b_pie'].value
         super().__init__(name, subdir, subproject, is_cross, sources, objects, environment, kwargs)
+        self.typename = 'executable'
         # Unless overridden, executables have no suffix or prefix. Except on
         # Windows and with C#/Mono executables where the suffix is 'exe'
         if not hasattr(self, 'prefix'):
@@ -1453,6 +1458,7 @@ class StaticLibrary(BuildTarget):
         if 'pic' not in kwargs and 'b_staticpic' in environment.coredata.base_options:
             kwargs['pic'] = environment.coredata.base_options['b_staticpic'].value
         super().__init__(name, subdir, subproject, is_cross, sources, objects, environment, kwargs)
+        self.typename = 'static library'
         if 'cs' in self.compilers:
             raise InvalidArguments('Static libraries not supported for C#.')
         if 'rust' in self.compilers:
@@ -1509,6 +1515,7 @@ class SharedLibrary(BuildTarget):
     known_kwargs = known_shlib_kwargs
 
     def __init__(self, name, subdir, subproject, is_cross, sources, objects, environment, kwargs):
+        self.typename = 'shared library'
         self.soversion = None
         self.ltversion = None
         # Max length 2, first element is compatibility_version, second is current_version
@@ -1817,6 +1824,7 @@ class SharedModule(SharedLibrary):
         if 'soversion' in kwargs:
             raise MesonException('Shared modules must not specify the soversion kwarg.')
         super().__init__(name, subdir, subproject, is_cross, sources, objects, environment, kwargs)
+        self.typename = 'shared module'
 
     def get_default_install_dir(self, environment):
         return environment.get_shared_module_dir()
@@ -1843,6 +1851,7 @@ class CustomTarget(Target):
 
     def __init__(self, name, subdir, subproject, kwargs, absolute_paths=False):
         super().__init__(name, subdir, subproject, False)
+        self.typename = 'custom'
         self.dependencies = []
         self.extra_depends = []
         self.depend_files = [] # Files that this target depends on but are not on the command line.
@@ -2084,6 +2093,7 @@ class CustomTarget(Target):
 class RunTarget(Target):
     def __init__(self, name, command, args, dependencies, subdir, subproject):
         super().__init__(name, subdir, subproject, False)
+        self.typename = 'run'
         self.command = command
         self.args = args
         self.dependencies = dependencies
@@ -2124,6 +2134,7 @@ class Jar(BuildTarget):
         for t in self.link_targets:
             if not isinstance(t, Jar):
                 raise InvalidArguments('Link target %s is not a jar target.' % t)
+        self.typename = 'jar'
         self.filename = self.name + '.jar'
         self.outputs = [self.filename]
         self.java_args = kwargs.get('java_args', [])
@@ -2160,6 +2171,7 @@ class CustomTargetIndex:
     """
 
     def __init__(self, target, output):
+        self.typename = 'custom'
         self.target = target
         self.output = output
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1515,7 +1515,6 @@ class SharedLibrary(BuildTarget):
     known_kwargs = known_shlib_kwargs
 
     def __init__(self, name, subdir, subproject, is_cross, sources, objects, environment, kwargs):
-        self.typename = 'shared library'
         self.soversion = None
         self.ltversion = None
         # Max length 2, first element is compatibility_version, second is current_version
@@ -1528,6 +1527,7 @@ class SharedLibrary(BuildTarget):
         # The import library that GCC would generate (and prefer)
         self.gcc_import_filename = None
         super().__init__(name, subdir, subproject, is_cross, sources, objects, environment, kwargs)
+        self.typename = 'shared library'
         if 'rust' in self.compilers:
             # If no crate type is specified, or it's the generic lib type, use dylib
             if not hasattr(self, 'rust_crate_type') or self.rust_crate_type == 'lib':

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -15,6 +15,7 @@
 # Public symbols for compilers sub-package when using 'from . import compilers'
 __all__ = [
     'CompilerType',
+    'Compiler',
 
     'all_languages',
     'base_options',
@@ -91,6 +92,7 @@ __all__ = [
 # Bring symbols from each module into compilers sub-package namespace
 from .compilers import (
     CompilerType,
+    Compiler,
     all_languages,
     base_options,
     clib_langs,

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1475,6 +1475,15 @@ class VisualStudioCCompiler(CCompiler):
         # msvc does not have a concept of system header dirs.
         return ['-I' + path]
 
+    def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
+        for idx, i in enumerate(parameter_list):
+            if i[:2] == '-I' or i[:2] == '/I':
+                parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
+            elif i[:9] == '/LIBPATH:':
+                parameter_list[idx] = i[:9] + os.path.normpath(os.path.join(build_dir, i[9:]))
+
+        return parameter_list
+
     # Visual Studio is special. It ignores some arguments it does not
     # understand and you can't tell it to error out on those.
     # http://stackoverflow.com/questions/15259720/how-can-i-make-the-microsoft-c-compiler-treat-unknown-flags-as-errors-rather-t

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -89,6 +89,12 @@ class CsCompiler(Compiler):
         return []
 
     def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
+        for idx, i in enumerate(parameter_list):
+            if i[:2] == '-L':
+                parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
+            if i[:5] == '-lib:':
+                parameter_list[idx] = i[:5] + os.path.normpath(os.path.join(build_dir, i[5:]))
+
         return parameter_list
 
     def name_string(self):

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -82,7 +82,7 @@ class CsCompiler(Compiler):
     def get_std_exe_link_args(self):
         return []
 
-    def get_include_args(self, path):
+    def get_include_args(self, path, is_system):
         return []
 
     def get_pic_args(self):

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -88,6 +88,9 @@ class CsCompiler(Compiler):
     def get_pic_args(self):
         return []
 
+    def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
+        return parameter_list
+
     def name_string(self):
         return ' '.join(self.exelist)
 

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -82,7 +82,7 @@ class CsCompiler(Compiler):
     def get_std_exe_link_args(self):
         return []
 
-    def get_include_args(self, path, is_system):
+    def get_include_args(self, path):
         return []
 
     def get_pic_args(self):

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -115,6 +115,12 @@ class DCompiler(Compiler):
         for idx, i in enumerate(parameter_list):
             if i[:3] == '-I=':
                 parameter_list[idx] = i[:3] + os.path.normpath(os.path.join(build_dir, i[3:]))
+            if i[:4] == '-L-L':
+                parameter_list[idx] = i[:4] + os.path.normpath(os.path.join(build_dir, i[4:]))
+            if i[:5] == '-L=-L':
+                parameter_list[idx] = i[:5] + os.path.normpath(os.path.join(build_dir, i[5:]))
+            if i[:6] == '-Wl,-L':
+                parameter_list[idx] = i[:6] + os.path.normpath(os.path.join(build_dir, i[6:]))
 
         return parameter_list
 
@@ -520,7 +526,7 @@ class GnuDCompiler(DCompiler):
 
     def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
         for idx, i in enumerate(parameter_list):
-            if i[:2] == '-I':
+            if i[:2] == '-I' or i[:2] == '-L':
                 parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
 
         return parameter_list

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -111,6 +111,13 @@ class DCompiler(Compiler):
     def get_include_args(self, path, is_system):
         return ['-I=' + path]
 
+    def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
+        for idx, i in enumerate(parameter_list):
+            if i[:3] == '-I=':
+                parameter_list[idx] = i[:3] + os.path.normpath(os.path.join(build_dir, i[3:]))
+
+        return parameter_list
+
     def get_warn_args(self, level):
         return ['-wi']
 
@@ -510,6 +517,13 @@ class GnuDCompiler(DCompiler):
 
     def get_buildtype_args(self, buildtype):
         return d_gdc_buildtype_args[buildtype]
+
+    def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
+        for idx, i in enumerate(parameter_list):
+            if i[:2] == '-I':
+                parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
+
+        return parameter_list
 
     def build_rpath_args(self, build_dir, from_dir, rpath_paths, build_rpath, install_rpath):
         return self.build_unix_rpath_args(build_dir, from_dir, rpath_paths, build_rpath, install_rpath)

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -171,6 +171,13 @@ end program prog
     def get_module_outdir_args(self, path):
         return ['-module', path]
 
+    def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
+        for idx, i in enumerate(parameter_list):
+            if i[:2] == '-I':
+                parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
+
+        return parameter_list
+
     def module_name_to_filename(self, module_name):
         return module_name.lower() + '.mod'
 

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -173,7 +173,7 @@ end program prog
 
     def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
         for idx, i in enumerate(parameter_list):
-            if i[:2] == '-I':
+            if i[:2] == '-I' or i[:2] == '-L':
                 parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
 
         return parameter_list

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -83,10 +83,10 @@ class JavaCompiler(Compiler):
 
     def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
         for idx, i in enumerate(parameter_list):
-            if i[:4] == '-cp:' or i[:4] == '-cp;':
-                parameter_list[idx] = i[:4] + os.path.normpath(os.path.join(build_dir, i[4:]))
-            if i[:11] == '-classpath:' or i[:11] == '-classpath;':
-                parameter_list[idx] = i[:11] + os.path.normpath(os.path.join(build_dir, i[11:]))
+            if i in ['-cp', '-classpath', '-sourcepath'] and idx + 1 < len(parameter_list):
+                path_list = parameter_list[idx + 1].replace(';', ':').split(':')
+                path_list = [os.path.normpath(os.path.join(build_dir, x)) for x in path_list]
+                parameter_list[idx + 1] = ':'.join(path_list)
 
         return parameter_list
 

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -63,7 +63,7 @@ class JavaCompiler(Compiler):
     def get_std_exe_link_args(self):
         return []
 
-    def get_include_args(self, path):
+    def get_include_args(self, path, is_system):
         return []
 
     def get_pic_args(self):

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -63,7 +63,7 @@ class JavaCompiler(Compiler):
     def get_std_exe_link_args(self):
         return []
 
-    def get_include_args(self, path, is_system):
+    def get_include_args(self, path):
         return []
 
     def get_pic_args(self):

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -82,6 +82,12 @@ class JavaCompiler(Compiler):
         return java_buildtype_args[buildtype]
 
     def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
+        for idx, i in enumerate(parameter_list):
+            if i[:4] == '-cp:' or i[:4] == '-cp;':
+                parameter_list[idx] = i[:4] + os.path.normpath(os.path.join(build_dir, i[4:]))
+            if i[:11] == '-classpath:' or i[:11] == '-classpath;':
+                parameter_list[idx] = i[:11] + os.path.normpath(os.path.join(build_dir, i[11:]))
+
         return parameter_list
 
     def sanity_check(self, work_dir, environment):

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -81,6 +81,9 @@ class JavaCompiler(Compiler):
     def get_buildtype_args(self, buildtype):
         return java_buildtype_args[buildtype]
 
+    def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
+        return parameter_list
+
     def sanity_check(self, work_dir, environment):
         src = 'SanityCheck.java'
         obj = 'SanityCheck'

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -84,7 +84,7 @@ class JavaCompiler(Compiler):
     def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
         for idx, i in enumerate(parameter_list):
             if i in ['-cp', '-classpath', '-sourcepath'] and idx + 1 < len(parameter_list):
-                path_list = parameter_list[idx + 1].replace(';', ':').split(':')
+                path_list = parameter_list[idx + 1].split(os.pathsep)
                 path_list = [os.path.normpath(os.path.join(build_dir, x)) for x in path_list]
                 parameter_list[idx + 1] = ':'.join(path_list)
 

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -86,7 +86,7 @@ class JavaCompiler(Compiler):
             if i in ['-cp', '-classpath', '-sourcepath'] and idx + 1 < len(parameter_list):
                 path_list = parameter_list[idx + 1].split(os.pathsep)
                 path_list = [os.path.normpath(os.path.join(build_dir, x)) for x in path_list]
-                parameter_list[idx + 1] = ':'.join(path_list)
+                parameter_list[idx + 1] = os.pathsep.join(path_list)
 
         return parameter_list
 

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -82,3 +82,6 @@ class RustCompiler(Compiler):
 
     def get_optimization_args(self, optimization_level):
         return rust_optimization_args[optimization_level]
+
+    def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
+        return parameter_list

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -84,4 +84,12 @@ class RustCompiler(Compiler):
         return rust_optimization_args[optimization_level]
 
     def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
+        for idx, i in enumerate(parameter_list):
+            if i[:2] == '-L':
+                for j in ['dependency', 'crate', 'native', 'framework', 'all']:
+                    combined_len = len(j) + 3
+                    if i[:combined_len] == '-L{}='.format(j):
+                        parameter_list[idx] = i[:combined_len] + os.path.normpath(os.path.join(build_dir, i[combined_len:]))
+                        break
+
         return parameter_list

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -91,6 +91,13 @@ class SwiftCompiler(Compiler):
     def get_compile_only_args(self):
         return ['-c']
 
+    def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
+        for idx, i in enumerate(parameter_list):
+            if i[:2] == '-I':
+                parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
+
+        return parameter_list
+
     def sanity_check(self, work_dir, environment):
         src = 'swifttest.swift'
         source_name = os.path.join(work_dir, src)

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -85,7 +85,7 @@ class SwiftCompiler(Compiler):
     def build_rpath_args(self, *args):
         return [] # FIXME
 
-    def get_include_args(self, dirname, is_system):
+    def get_include_args(self, dirname):
         return ['-I' + dirname]
 
     def get_compile_only_args(self):

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -85,7 +85,7 @@ class SwiftCompiler(Compiler):
     def build_rpath_args(self, *args):
         return [] # FIXME
 
-    def get_include_args(self, dirname):
+    def get_include_args(self, dirname, is_system):
         return ['-I' + dirname]
 
     def get_compile_only_args(self):

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -93,7 +93,7 @@ class SwiftCompiler(Compiler):
 
     def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
         for idx, i in enumerate(parameter_list):
-            if i[:2] == '-I':
+            if i[:2] == '-I' or i[:2] == '-L':
                 parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
 
         return parameter_list

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -67,6 +67,16 @@ class ValaCompiler(Compiler):
         return []
 
     def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
+        for idx, i in enumerate(parameter_list):
+            if i[:9] == '--girdir=':
+                parameter_list[idx] = i[:9] + os.path.normpath(os.path.join(build_dir, i[9:]))
+            if i[:10] == '--vapidir=':
+                parameter_list[idx] = i[:10] + os.path.normpath(os.path.join(build_dir, i[10:]))
+            if i[:13] == '--includedir=':
+                parameter_list[idx] = i[:13] + os.path.normpath(os.path.join(build_dir, i[13:]))
+            if i[:14] == '--metadatadir=':
+                parameter_list[idx] = i[:14] + os.path.normpath(os.path.join(build_dir, i[14:]))
+
         return parameter_list
 
     def sanity_check(self, work_dir, environment):

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -66,6 +66,9 @@ class ValaCompiler(Compiler):
             return ['--color=' + colortype]
         return []
 
+    def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
+        return parameter_list
+
     def sanity_check(self, work_dir, environment):
         code = 'class MesonSanityCheck : Object { }'
         args = self.get_cross_extra_flags(environment, link=False)

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -336,16 +336,8 @@ class Environment:
                     mlog.log('Reason:', mlog.red(str(e)))
                     coredata.read_cmd_line_file(self.build_dir, options)
                     self.create_new_coredata(options)
-                except MesonException as e:
-                    # If we stored previous command line options, we can recover from
-                    # a broken/outdated coredata.
-                    if os.path.isfile(coredata.get_cmd_line_file(self.build_dir)):
-                        mlog.warning('Regenerating configuration from scratch.')
-                        mlog.log('Reason:', mlog.red(str(e)))
-                        coredata.read_cmd_line_file(self.build_dir, options)
-                        self.create_new_coredata(options)
-                    else:
-                        raise e
+                else:
+                    raise e
         else:
             # Just create a fresh coredata in this case
             self.create_new_coredata(options)

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -308,6 +308,7 @@ def search_version(text):
 class Environment:
     private_dir = 'meson-private'
     log_dir = 'meson-logs'
+    info_dir = 'meson-info'
 
     def __init__(self, source_dir, build_dir, options):
         self.source_dir = source_dir
@@ -318,8 +319,10 @@ class Environment:
         if build_dir is not None:
             self.scratch_dir = os.path.join(build_dir, Environment.private_dir)
             self.log_dir = os.path.join(build_dir, Environment.log_dir)
+            self.info_dir = os.path.join(build_dir, Environment.info_dir)
             os.makedirs(self.scratch_dir, exist_ok=True)
             os.makedirs(self.log_dir, exist_ok=True)
+            os.makedirs(self.info_dir, exist_ok=True)
             try:
                 self.coredata = coredata.load(self.get_build_dir())
                 self.first_invocation = False
@@ -333,8 +336,16 @@ class Environment:
                     mlog.log('Reason:', mlog.red(str(e)))
                     coredata.read_cmd_line_file(self.build_dir, options)
                     self.create_new_coredata(options)
-                else:
-                    raise e
+                except MesonException as e:
+                    # If we stored previous command line options, we can recover from
+                    # a broken/outdated coredata.
+                    if os.path.isfile(coredata.get_cmd_line_file(self.build_dir)):
+                        mlog.warning('Regenerating configuration from scratch.')
+                        mlog.log('Reason:', mlog.red(str(e)))
+                        coredata.read_cmd_line_file(self.build_dir, options)
+                        self.create_new_coredata(options)
+                    else:
+                        raise e
         else:
             # Just create a fresh coredata in this case
             self.create_new_coredata(options)

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -163,7 +163,7 @@ def run(options):
             c.print_conf()
         if save:
             c.save()
-            mintro.update_build_options(c.coredata, builddir)
+            mintro.update_build_options(c.coredata, c.build.environment.info_dir)
     except ConfException as e:
         print('Meson configurator encountered an error:')
         raise e

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -14,6 +14,7 @@
 
 import os
 from . import (coredata, mesonlib, build)
+from . import mintro
 
 def add_arguments(parser):
     coredata.register_builtin_arguments(parser)
@@ -162,6 +163,7 @@ def run(options):
             c.print_conf()
         if save:
             c.save()
+            mintro.update_build_options(c.coredata, builddir)
     except ConfException as e:
         print('Meson configurator encountered an error:')
         raise e

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -268,10 +268,12 @@ class File:
     def relative_name(self):
         return os.path.join(self.subdir, self.fname)
 
-def get_compiler_for_source(compilers, src):
+def get_compiler_for_source(compilers, src, canfail=False):
     for comp in compilers:
         if comp.can_compile(src):
             return comp
+    if canfail:
+        return None
     raise MesonException('No specified compiler can handle file {!s}'.format(src))
 
 def classify_unity_sources(compilers, sources):

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -268,12 +268,10 @@ class File:
     def relative_name(self):
         return os.path.join(self.subdir, self.fname)
 
-def get_compiler_for_source(compilers, src, canfail=False):
+def get_compiler_for_source(compilers, src):
     for comp in compilers:
         if comp.can_compile(src):
             return comp
-    if canfail:
-        return None
     raise MesonException('No specified compiler can handle file {!s}'.format(src))
 
 def classify_unity_sources(compilers, sources):

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -56,8 +56,8 @@ def add_arguments(parser):
                         help='The backend to use for the --buildoptions introspection.')
     parser.add_argument('-a', '--all', action='store_true', dest='all', default=False,
                         help='Print all available information.')
-    parser.add_argument('-i', '--indent', dest='indent', type=int, default=0,
-                        help='Number of spaces used for indentation.')
+    parser.add_argument('-i', '--indent', action='store_true', dest='indent', default=False,
+                        help='Enable pretty printed JSON.')
     parser.add_argument('-f', '--force-object-output', action='store_true', dest='force_dict', default=False,
                         help='Always use the new JSON format for multiple entries (even for 0 and 1 introspection commands)')
     parser.add_argument('builddir', nargs='?', default='.', help='The build directory')
@@ -457,7 +457,7 @@ def list_projinfo_from_source(sourcedir, indent):
 def run(options):
     datadir = 'meson-private'
     infodir = 'meson-info'
-    indent = options.indent if options.indent > 0 else None
+    indent = 4 if options.indent else None
     if options.builddir is not None:
         datadir = os.path.join(options.builddir, datadir)
         infodir = os.path.join(options.builddir, infodir)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -663,4 +663,4 @@ def generate_introspection_file(coredata, builddata, testdata, benchmarkdata, in
     outfile = os.path.abspath(outfile)
 
     with open(outfile, 'w') as fp:
-        json.dump(outdict, fp, indent=2)
+        json.dump(outdict, fp)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -29,9 +29,7 @@ from . import mlog
 from . import compilers
 from . import optinterpreter
 from .interpreterbase import InvalidArguments
-from .backend import ninjabackend, backends
-from .dependencies import base
-from .compilers import compilers
+from .backend import backends
 import sys, os
 import pathlib
 

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -100,6 +100,13 @@ def list_installed(installdata):
 
 def list_targets(builddata: build.Build, installdata, backend: backends.Backend):
     tlist = []
+
+    # Fast lookup table for installation files
+    intall_lookuptable = {}
+    for i in installdata.targets:
+        outname = os.path.join(installdata.prefix, i.outdir, os.path.basename(i.fname))
+        intall_lookuptable[os.path.basename(i.fname)] = str(pathlib.PurePath(outname))
+
     for (idname, target) in builddata.get_targets().items():
         if not isinstance(target, build.Target):
             raise RuntimeError('Something weird happened. File a bug.')
@@ -121,7 +128,12 @@ def list_targets(builddata: build.Build, installdata, backend: backends.Backend)
 
         if installdata and target.should_install():
             t['installed'] = True
-            t['install_filename'] = determine_installed_path(target, installdata)
+            t['install_filename'] = []
+
+            for i in target.outputs:
+                fname = intall_lookuptable.get(i)
+                if i is not None:
+                    t['install_filename'] += [fname]
         else:
             t['installed'] = False
         tlist.append(t)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -62,7 +62,7 @@ def add_arguments(parser):
                         help='Print all available information.')
     parser.add_argument('-i', '--indent', dest='indent', type=int, default=0,
                         help='Number of spaces used for indentation.')
-    parser.add_argument('-f', '--force-new', action='store_true', dest='force_new', default=False,
+    parser.add_argument('-f', '--force-dict-output', action='store_true', dest='force_dict', default=False,
                         help='Always use the new JSON format for multiple entries (even for 0 and 1 introspection commands)')
     parser.add_argument('builddir', nargs='?', default='.', help='The build directory')
 
@@ -504,10 +504,10 @@ def run(options):
 
     indent = options.indent if options.indent > 0 else None
 
-    if len(results) == 0 and not options.force_new:
+    if len(results) == 0 and not options.force_dict:
         print('No command specified')
         return 1
-    elif len(results) == 1 and not options.force_new:
+    elif len(results) == 1 and not options.force_dict:
         # Make to keep the existing output format for a single option
         print(json.dumps(results[0][1], indent=indent))
     else:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -106,12 +106,7 @@ def list_targets(builddata: build.Build, installdata, backend: backends.Backend)
 
         if installdata and target.should_install():
             t['installed'] = True
-            t['install_filename'] = []
-
-            for i in target.outputs:
-                fname = intall_lookuptable.get(i)
-                if fname is not None:
-                    t['install_filename'] += [fname]
+            t['install_filename'] = [intall_lookuptable.get(x, None) for x in target.get_outputs()]
         else:
             t['installed'] = False
         tlist.append(t)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -104,37 +104,26 @@ def list_targets(builddata: build.Build, installdata, backend: backends.Backend)
         if not isinstance(target, build.Target):
             raise RuntimeError('Something weird happened. File a bug.')
 
-        if isinstance(backend, backends.Backend):
-            sources = backend.get_introspection_data(idname, target)
-        else:
-            raise RuntimeError('Parameter backend has an invalid type. This is a bug.')
-
-        t = {'name': target.get_basename(), 'id': idname, 'sources': sources}
         fname = target.get_filename()
         if isinstance(fname, list):
             fname = [os.path.join(target.subdir, x) for x in fname]
         else:
             fname = os.path.join(target.subdir, fname)
-        t['filename'] = fname
-        if isinstance(target, build.Executable):
-            typename = 'executable'
-        elif isinstance(target, build.SharedLibrary):
-            typename = 'shared library'
-        elif isinstance(target, build.StaticLibrary):
-            typename = 'static library'
-        elif isinstance(target, build.CustomTarget):
-            typename = 'custom'
-        elif isinstance(target, build.RunTarget):
-            typename = 'run'
-        else:
-            typename = 'unknown'
-        t['type'] = typename
+
+        t = {
+            'name': target.get_basename(),
+            'id': idname,
+            'type': target.get_typename(),
+            'filename': fname,
+            'build_by_default': target.build_by_default,
+            'sources': backend.get_introspection_data(idname, target)
+        }
+
         if installdata and target.should_install():
             t['installed'] = True
             t['install_filename'] = determine_installed_path(target, installdata)
         else:
             t['installed'] = False
-        t['build_by_default'] = target.build_by_default
         tlist.append(t)
     return ('targets', tlist)
 

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -487,8 +487,7 @@ def run(options):
     if options.all or options.benchmarks:
         toextract += ['benchmarks']
     if options.all or options.buildoptions:
-        coredata = cdata.load(options.builddir)
-        results += [list_buildoptions(coredata)]
+        toextract += ['buildoptions']
     if options.all or options.buildsystem_files:
         toextract += ['buildsystem_files']
     if options.all or options.dependencies:
@@ -547,6 +546,23 @@ def generate_introspection_file(builddata: build.Build, backend: backends.Backen
 
     outfile = os.path.join(builddata.environment.get_build_dir(), INTROSPECTION_OUTPUT_FILE)
     outfile = os.path.abspath(outfile)
+
+    with open(outfile, 'w') as fp:
+        json.dump(outdict, fp)
+
+def update_build_options(coredata, builddir):
+    outfile = os.path.join(builddir, INTROSPECTION_OUTPUT_FILE)
+    outfile = os.path.abspath(outfile)
+
+    with open(outfile, 'r') as fp:
+        outdict = json.load(fp)
+
+    intro_info = [
+        list_buildoptions(coredata)
+    ]
+
+    for i in intro_info:
+        outdict[i[0]] = i[1]
 
     with open(outfile, 'w') as fp:
         json.dump(outdict, fp)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -532,8 +532,11 @@ def run(options):
 def write_intro_info(intro_info, info_dir):
     for i in intro_info:
         out_file = os.path.join(info_dir, 'intro-{}.json'.format(i[0]))
-        with open(out_file, 'w') as fp:
+        tmp_file = os.path.join(info_dir, 'tmp_dump.json')
+        with open(tmp_file, 'w') as fp:
             json.dump(i[1], fp)
+            fp.flush() # Not sure if this is needed
+        os.replace(tmp_file, out_file)
 
 def generate_introspection_file(builddata: build.Build, backend: backends.Backend):
     coredata = builddata.environment.get_coredata()

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -147,13 +147,12 @@ def list_targets(coredata, builddata, installdata):
 
                 for i, comp in tgt.compilers.items():
                     if isinstance(comp, compilers.Compiler):
-                        lang = comp.get_language()
-                        if lang not in extra_args:
-                            extra_args[lang] = []
+                        if i not in extra_args:
+                            extra_args[i] = []
 
-                        extra_args[i] += tgt.get_extra_args(lang)
-                        extra_args[i] += builddata.get_global_args(comp, False)
-                        extra_args[i] += builddata.get_project_args(comp, tgt.subproject, False)
+                        extra_args[i] += tgt.get_extra_args(i)
+                        extra_args[i] += builddata.get_global_args(comp, tgt.is_cross)
+                        extra_args[i] += builddata.get_project_args(comp, tgt.subproject, tgt.is_cross)
 
                 for i in tgt.link_targets:
                     climb_stack(i, inc_dirs, extra_args, dep_args)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -61,6 +61,8 @@ def add_arguments(parser):
                         help='Print all available information.')
     parser.add_argument('-i', '--indent', dest='indent', type=int, default=0,
                         help='Number of spaces used for indentation.')
+    parser.add_argument('-f', '--force-new', action='store_true', dest='force_new', default=False,
+                        help='Always use the new JSON format for multiple entries (even for 0 and 1 introspection commands)')
     parser.add_argument('builddir', nargs='?', default='.', help='The build directory')
 
 def determine_installed_path(target, installdata):
@@ -620,10 +622,10 @@ def run(options):
 
     indent = options.indent if options.indent > 0 else None
 
-    if len(results) == 0:
+    if len(results) == 0 and not options.force_new:
         print('No command specified')
         return 1
-    elif len(results) == 1:
+    elif len(results) == 1 and not options.force_new:
         # Make to keep the existing output format for a single option
         print(json.dumps(results[0][1], indent=indent))
     else:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -472,8 +472,10 @@ def run(options):
             list_buildoptions_from_source(sourcedir, options.backend)
             return 0
     if not os.path.isdir(datadir) or not os.path.isdir(infodir):
-        print('Current directory is not a build dir. Please specify it or '
-              'change the working directory to it.')
+        print('Current directory is not a meson build directory.'
+              'Please specify a valid build dir or change the working directory to it.'
+              'It is also possible that the build directory was generated with an old'
+              'meson version. Please regenerate it in this case.')
         return 1
 
     results = []

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -645,14 +645,14 @@ def run(options):
 
 def generate_introspection_file(coredata, builddata, testdata, benchmarkdata, installdata):
     intro_info = [
-        #list_benchmarks(benchmarkdata),
+        list_benchmarks(benchmarkdata),
         list_buildoptions(coredata, builddata),
         list_buildsystem_files(builddata),
         list_deps(coredata),
         list_installed(installdata),
         list_projinfo(builddata),
         list_targets(coredata, builddata, installdata),
-        #list_tests(testdata)
+        list_tests(testdata)
     ]
 
     outdict = {}

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -66,24 +66,6 @@ def add_arguments(parser):
                         help='Always use the new JSON format for multiple entries (even for 0 and 1 introspection commands)')
     parser.add_argument('builddir', nargs='?', default='.', help='The build directory')
 
-def determine_installed_path(target, installdata):
-    install_targets = []
-    for i in target.outputs:
-        for j in installdata.targets:
-            if os.path.basename(j.fname) == i: # FIXME, might clash due to subprojects.
-                install_targets += [j]
-                break
-    if len(install_targets) == 0:
-        raise RuntimeError('Something weird happened. File a bug.')
-
-    # Normalize the path by using os.path.sep consistently, etc.
-    # Does not change the effective path.
-    install_targets = list(map(lambda x: os.path.join(installdata.prefix, x.outdir, os.path.basename(x.fname)), install_targets))
-    install_targets = list(map(lambda x: str(pathlib.PurePath(x)), install_targets))
-
-    return install_targets
-
-
 def list_installed(installdata):
     res = {}
     if installdata is not None:
@@ -132,7 +114,7 @@ def list_targets(builddata: build.Build, installdata, backend: backends.Backend)
 
             for i in target.outputs:
                 fname = intall_lookuptable.get(i)
-                if i is not None:
+                if fname is not None:
                     t['install_filename'] += [fname]
         else:
             t['installed'] = False

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -478,6 +478,10 @@ def run(options):
               'meson version. Please regenerate it in this case.')
         return 1
 
+    # Load build data to make sure that the version matches
+    # TODO Find a better solution for this
+    _ = cdata.load(options.builddir)
+
     results = []
     toextract = []
 

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -35,8 +35,6 @@ from .compilers import compilers
 import sys, os
 import pathlib
 
-INTROSPECTION_OUTPUT_FILE = 'meson-introspection.json'
-
 def add_arguments(parser):
     parser.add_argument('--targets', action='store_true', dest='list_targets', default=False,
                         help='List top level targets.')
@@ -62,7 +60,7 @@ def add_arguments(parser):
                         help='Print all available information.')
     parser.add_argument('-i', '--indent', dest='indent', type=int, default=0,
                         help='Number of spaces used for indentation.')
-    parser.add_argument('-f', '--force-dict-output', action='store_true', dest='force_dict', default=False,
+    parser.add_argument('-f', '--force-object-output', action='store_true', dest='force_dict', default=False,
                         help='Always use the new JSON format for multiple entries (even for 0 and 1 introspection commands)')
     parser.add_argument('builddir', nargs='?', default='.', help='The build directory')
 
@@ -104,7 +102,7 @@ def list_targets(builddata: build.Build, installdata, backend: backends.Backend)
             'type': target.get_typename(),
             'filename': fname,
             'build_by_default': target.build_by_default,
-            'sources': backend.get_introspection_data(idname, target)
+            'target_sources': backend.get_introspection_data(idname, target)
         }
 
         if installdata and target.should_install():
@@ -276,7 +274,7 @@ def list_target_files(target_name, targets, builddata: build.Build):
         print('Target with the ID "{}" could not be found'.format(target_name))
         sys.exit(1)
 
-    for i in tgt['sources']:
+    for i in tgt['target_sources']:
         result += i['sources'] + i['generated_sources']
 
     # TODO Remove this line in a future PR with other breaking changes

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -469,12 +469,12 @@ def find_buildsystem_files_list(src_dir):
         for f in files:
             if f == 'meson.build' or f == 'meson_options.txt':
                 filelist.append(os.path.relpath(os.path.join(root, f), src_dir))
-    return ('buildsystem_files', filelist)
+    return filelist
 
 def list_buildsystem_files(builddata):
     src_dir = builddata.environment.get_source_dir()
     filelist = find_buildsystem_files_list(src_dir)
-    return filelist
+    return ('buildsystem_files', filelist)
 
 def list_deps(coredata):
     result = []

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -84,14 +84,14 @@ def list_targets(builddata: build.Build, installdata, backend: backends.Backend)
     tlist = []
 
     # Fast lookup table for installation files
-    intall_lookuptable = {}
+    install_lookuptable = {}
     for i in installdata.targets:
         outname = os.path.join(installdata.prefix, i.outdir, os.path.basename(i.fname))
-        intall_lookuptable[os.path.basename(i.fname)] = str(pathlib.PurePath(outname))
+        install_lookuptable[os.path.basename(i.fname)] = str(pathlib.PurePath(outname))
 
     for (idname, target) in builddata.get_targets().items():
         if not isinstance(target, build.Target):
-            raise RuntimeError('Something weird happened. File a bug.')
+            raise RuntimeError('The target object in `builddata.get_targets()` is not of type `build.Target`. Please file a bug with this error message.')
 
         fname = [os.path.join(target.subdir, x) for x in target.get_outputs()]
 
@@ -107,7 +107,7 @@ def list_targets(builddata: build.Build, installdata, backend: backends.Backend)
         if installdata and target.should_install():
             t['installed'] = True
             # TODO Change this to the full list in a seperate PR
-            t['install_filename'] = [intall_lookuptable.get(x, None) for x in target.get_outputs()][0]
+            t['install_filename'] = [install_lookuptable.get(x, None) for x in target.get_outputs()][0]
         else:
             t['installed'] = False
         tlist.append(t)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -99,14 +99,15 @@ def list_targets(builddata: build.Build, installdata, backend: backends.Backend)
             'name': target.get_basename(),
             'id': idname,
             'type': target.get_typename(),
-            'filename': fname,
+            'filename': fname[0], # TODO Change this to the full list in a seperate PR
             'build_by_default': target.build_by_default,
             'sources': backend.get_introspection_data(idname, target)
         }
 
         if installdata and target.should_install():
             t['installed'] = True
-            t['install_filename'] = [intall_lookuptable.get(x, None) for x in target.get_outputs()]
+            # TODO Change this to the full list in a seperate PR
+            t['install_filename'] = [intall_lookuptable.get(x, None) for x in target.get_outputs()][0]
         else:
             t['installed'] = False
         tlist.append(t)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -93,11 +93,7 @@ def list_targets(builddata: build.Build, installdata, backend: backends.Backend)
         if not isinstance(target, build.Target):
             raise RuntimeError('Something weird happened. File a bug.')
 
-        fname = target.get_filename()
-        if isinstance(fname, list):
-            fname = [os.path.join(target.subdir, x) for x in fname]
-        else:
-            fname = os.path.join(target.subdir, fname)
+        fname = [os.path.join(target.subdir, x) for x in target.get_outputs()]
 
         t = {
             'name': target.get_basename(),

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -480,7 +480,7 @@ def run(options):
 
     # Load build data to make sure that the version matches
     # TODO Find a better solution for this
-    _ = cdata.load(options.builddir)
+    cdata.load(options.builddir)
 
     results = []
     toextract = []

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -272,7 +272,7 @@ def list_target_files(target_name, targets):
         raise RuntimeError('Target with the ID "{}" could not be found'.format(target_name))
 
     for i in tgt['sources']:
-        result += i['source_files']
+        result += i['sources'] + i['generated_sources']
 
     return ('target_files', result)
 

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -221,7 +221,11 @@ class MesonApp:
             intro_tests = intr.backend.create_test_serialisation(b.get_tests())
             intro_benchmarks = intr.backend.create_test_serialisation(b.get_benchmarks())
             intro_install = intr.backend.create_install_data()
-            mintro.generate_introspection_file(b, intr.backend)
+            if self.options.profile:
+                fname = os.path.join(self.build_dir, 'meson-private', 'profile-introspector.log')
+                profile.runctx('mintro.generate_introspection_file(b, intr.backend)', globals(), locals(), filename=fname)
+            else:
+                mintro.generate_introspection_file(b, intr.backend)
         except:
             if 'cdf' in locals():
                 old_cdf = cdf + '.prev'

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -217,8 +217,11 @@ class MesonApp:
             else:
                 coredata.update_cmd_line_file(self.build_dir, self.options)
 
-            # Generate an IDE introspection file with the exact same syntax as the introspection API defined in mintro
-            mintro.generate_introspection_file(b.environment.get_coredata(), b, b.get_tests(), b.get_benchmarks(), intr.backend.create_install_data())
+            # Generate an IDE introspection file with the same syntax as the already existing API
+            intro_tests = intr.backend.create_test_serialisation(b.get_tests())
+            intro_benchmarks = intr.backend.create_test_serialisation(b.get_benchmarks())
+            intro_install = intr.backend.create_install_data()
+            mintro.generate_introspection_file(b.environment.get_coredata(), b, intro_tests, intro_benchmarks, intro_install)
         except:
             if 'cdf' in locals():
                 old_cdf = cdf + '.prev'

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -218,9 +218,6 @@ class MesonApp:
                 coredata.update_cmd_line_file(self.build_dir, self.options)
 
             # Generate an IDE introspection file with the same syntax as the already existing API
-            intro_tests = intr.backend.create_test_serialisation(b.get_tests())
-            intro_benchmarks = intr.backend.create_test_serialisation(b.get_benchmarks())
-            intro_install = intr.backend.create_install_data()
             if self.options.profile:
                 fname = os.path.join(self.build_dir, 'meson-private', 'profile-introspector.log')
                 profile.runctx('mintro.generate_introspection_file(b, intr.backend)', globals(), locals(), filename=fname)

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -221,7 +221,7 @@ class MesonApp:
             intro_tests = intr.backend.create_test_serialisation(b.get_tests())
             intro_benchmarks = intr.backend.create_test_serialisation(b.get_benchmarks())
             intro_install = intr.backend.create_install_data()
-            mintro.generate_introspection_file(b.environment.get_coredata(), b, intro_tests, intro_benchmarks, intro_install)
+            mintro.generate_introspection_file(b, intr.backend)
         except:
             if 'cdf' in locals():
                 old_cdf = cdf + '.prev'

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -23,6 +23,7 @@ import argparse
 from . import environment, interpreter, mesonlib
 from . import build
 from . import mlog, coredata
+from . import mintro
 from .mesonlib import MesonException
 
 def add_arguments(parser):
@@ -215,6 +216,9 @@ class MesonApp:
                 coredata.write_cmd_line_file(self.build_dir, self.options)
             else:
                 coredata.update_cmd_line_file(self.build_dir, self.options)
+
+            # Generate an IDE introspection file with the exact same syntax as the introspection API defined in mintro
+            mintro.generate_introspection_file(b.environment.get_coredata(), b, b.get_tests(), b.get_benchmarks(), intr.backend.create_install_data())
         except:
             if 'cdf' in locals():
                 old_cdf = cdf + '.prev'

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3257,7 +3257,7 @@ recommended as it is not supported on some platforms''')
                 assertKeyTypes(targets_sources_typelist, j)
         self.assertDictEqual(targets_to_find, {})
 
-    def test_introspect_file_dump_eauals_all(self):
+    def test_introspect_file_dump_equals_all(self):
         testdir = os.path.join(self.unit_test_dir, '49 introspection')
         self.init(testdir)
         res_all = self.introspect('--all')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3116,10 +3116,8 @@ recommended as it is not supported on some platforms''')
     def test_introspect_json_dump(self):
         testdir = os.path.join(self.unit_test_dir, '49 introspection')
         self.init(testdir)
-        introfile = os.path.join(self.builddir, 'meson-introspection.json')
-        self.assertPathExists(introfile)
-        with open(introfile, 'r') as fp:
-            res = json.load(fp)
+        infodir = os.path.join(self.builddir, 'meson-info')
+        self.assertPathExists(infodir)
 
         def assertKeyTypes(key_type_list, obj):
             for i in key_type_list:
@@ -3183,6 +3181,14 @@ recommended as it is not supported on some platforms''')
             ('parameters', list),
             ('source_files', list),
         ]
+
+        # First load all files
+        res = {}
+        for i in root_keylist:
+            curr = os.path.join(infodir, 'intro-{}.json'.format(i[0]))
+            self.assertPathExists(curr)
+            with open(curr, 'r') as fp:
+                res[i[0]] = json.load(fp)
 
         assertKeyTypes(root_keylist, res)
 
@@ -3252,16 +3258,30 @@ recommended as it is not supported on some platforms''')
         res_all = self.introspect('--all')
         res_file = {}
 
-        introfile = os.path.join(self.builddir, 'meson-introspection.json')
-        self.assertPathExists(introfile)
-        with open(introfile, 'r') as fp:
-            res_file = json.load(fp)
+        root_keylist = [
+            'benchmarks',
+            'buildoptions',
+            'buildsystem_files',
+            'dependencies',
+            'installed',
+            'projectinfo',
+            'targets',
+            'tests',
+        ]
+
+        infodir = os.path.join(self.builddir, 'meson-info')
+        self.assertPathExists(infodir)
+        for i in root_keylist:
+            curr = os.path.join(infodir, 'intro-{}.json'.format(i))
+            self.assertPathExists(curr)
+            with open(curr, 'r') as fp:
+                res_file[i] = json.load(fp)
 
         self.assertEqual(res_all, res_file)
 
     def test_introspect_config_update(self):
         testdir = os.path.join(self.unit_test_dir, '49 introspection')
-        introfile = os.path.join(self.builddir, 'meson-introspection.json')
+        introfile = os.path.join(self.builddir, 'meson-info', 'intro-buildoptions.json')
         self.init(testdir)
         self.assertPathExists(introfile)
         with open(introfile, 'r') as fp:
@@ -3270,20 +3290,20 @@ recommended as it is not supported on some platforms''')
         self.setconf('-Dcpp_std=c++14')
         self.setconf('-Dbuildtype=release')
 
-        for idx, i in enumerate(res1['buildoptions']):
+        for idx, i in enumerate(res1):
             if i['name'] == 'cpp_std':
-                res1['buildoptions'][idx]['value'] = 'c++14'
+                res1[idx]['value'] = 'c++14'
             if i['name'] == 'buildtype':
-                res1['buildoptions'][idx]['value'] = 'release'
+                res1[idx]['value'] = 'release'
             if i['name'] == 'optimization':
-                res1['buildoptions'][idx]['value'] = '3'
+                res1[idx]['value'] = '3'
             if i['name'] == 'debug':
-                res1['buildoptions'][idx]['value'] = False
+                res1[idx]['value'] = False
 
         with open(introfile, 'r') as fp:
             res2 = json.load(fp)
 
-        self.assertDictEqual(res1, res2)
+        self.assertListEqual(res1, res2)
 
 class FailureTests(BasePlatformTests):
     '''

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2569,7 +2569,7 @@ int main(int argc, char **argv) {
         for t in t_intro:
             id = t['id']
             tf_intro = self.introspect(['--target-files', id])
-            tf_intro = list(map(lambda x: os.path.relpath(x, testdir), tf_intro))
+            #tf_intro = list(map(lambda x: os.path.relpath(x, testdir), tf_intro)) TODO make paths absolute in future PR
             self.assertEqual(tf_intro, expected[id])
         self.wipe()
 
@@ -2585,7 +2585,7 @@ int main(int argc, char **argv) {
             id = t['id']
             tf_intro = self.introspect(['--target-files', id])
             print(tf_intro)
-            tf_intro = list(map(lambda x: os.path.relpath(x, testdir), tf_intro))
+            #tf_intro = list(map(lambda x: os.path.relpath(x, testdir), tf_intro)) TODO make paths absolute in future PR
             print(tf_intro)
             self.assertEqual(tf_intro, expected[id])
         self.wipe()

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1221,7 +1221,7 @@ class BasePlatformTests(unittest.TestCase):
         self.assertEqual(PurePath(path1), PurePath(path2))
 
     def assertPathListEqual(self, pathlist1, pathlist2):
-        self.assertEquals(len(pathlist1), len(pathlist2))
+        self.assertEqual(len(pathlist1), len(pathlist2))
         worklist = list(zip(pathlist1, pathlist2))
         for i in worklist:
             self.assertPathEqual(i[0], i[1])

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3722,7 +3722,7 @@ class DarwinTests(BasePlatformTests):
         self.build()
         targets = {}
         for t in self.introspect('--targets'):
-            targets[t['name']] = t['filename']
+            targets[t['name']] = t['filename'][0]
         self.assertEqual(self._get_darwin_versions(targets['some']), ('7.0.0', '7.0.0'))
         self.assertEqual(self._get_darwin_versions(targets['noversion']), ('0.0.0', '0.0.0'))
         self.assertEqual(self._get_darwin_versions(targets['onlyversion']), ('1.0.0', '1.0.0'))

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1436,7 +1436,7 @@ class AllPlatformTests(BasePlatformTests):
         # Get name of static library
         targets = self.introspect('--targets')
         self.assertEqual(len(targets), 1)
-        libname = targets[0]['filename']
+        libname = targets[0]['filename'][0]
         # Build and get contents of static library
         self.build()
         before = self._run(['ar', 't', os.path.join(self.builddir, libname)]).split()
@@ -3168,7 +3168,7 @@ recommended as it is not supported on some platforms''')
             ('name', str),
             ('id', str),
             ('type', str),
-            ('filename', str),
+            ('filename', list),
             ('build_by_default', bool),
             ('sources', list),
             ('installed', bool),
@@ -4368,7 +4368,7 @@ class LinuxlikeTests(BasePlatformTests):
                 break
         self.assertIsInstance(docbook_target, dict)
         ifile = self.introspect(['--target-files', 'generated-gdbus-docbook@cus'])[0]
-        self.assertEqual(t['filename'], 'gdbus/generated-gdbus-doc-' + os.path.basename(ifile))
+        self.assertListEqual(t['filename'], ['gdbus/generated-gdbus-doc-' + os.path.basename(ifile)])
 
     def test_build_rpath(self):
         if is_cygwin():

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1224,7 +1224,7 @@ class BasePlatformTests(unittest.TestCase):
         self.assertEqual(len(pathlist1), len(pathlist2))
         worklist = list(zip(pathlist1, pathlist2))
         for i in worklist:
-            if i[0] == None:
+            if i[0] is None:
                 self.assertEqual(i[0], i[1])
             else:
                 self.assertPathEqual(i[0], i[1])

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2562,6 +2562,7 @@ int main(int argc, char **argv) {
         for t in t_intro:
             id = t['id']
             tf_intro = self.introspect(['--target-files', id])
+            tf_intro = list(map(lambda x: os.path.relpath(x, testdir), tf_intro))
             self.assertEqual(tf_intro, expected[id])
         self.wipe()
 
@@ -2576,6 +2577,9 @@ int main(int argc, char **argv) {
         for t in t_intro:
             id = t['id']
             tf_intro = self.introspect(['--target-files', id])
+            print(tf_intro)
+            tf_intro = list(map(lambda x: os.path.relpath(x, testdir), tf_intro))
+            print(tf_intro)
             self.assertEqual(tf_intro, expected[id])
         self.wipe()
 
@@ -3179,7 +3183,8 @@ recommended as it is not supported on some platforms''')
             ('language', str),
             ('compiler', list),
             ('parameters', list),
-            ('source_files', list),
+            ('sources', list),
+            ('generated_sources', list),
         ]
 
         # First load all files

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3182,7 +3182,7 @@ recommended as it is not supported on some platforms''')
             ('type', str),
             ('filename', str),
             ('build_by_default', bool),
-            ('sources', list),
+            ('target_sources', list),
             ('installed', bool),
         ]
 
@@ -3260,7 +3260,7 @@ recommended as it is not supported on some platforms''')
                 self.assertEqual(i['build_by_default'], tgt[1])
                 self.assertEqual(i['installed'], tgt[2])
                 targets_to_find.pop(i['name'], None)
-            for j in i['sources']:
+            for j in i['target_sources']:
                 assertKeyTypes(targets_sources_typelist, j)
         self.assertDictEqual(targets_to_find, {})
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3213,7 +3213,7 @@ recommended as it is not supported on some platforms''')
         self.assertDictEqual(buildopts_to_find, {})
 
         # Check buildsystem_files
-        self.assertListEqual(res['buildsystem_files'], ['meson.build', 'sharedlib/meson.build', 'staticlib/meson.build'])
+        self.assertPathListEqual(res['buildsystem_files'], ['meson.build', 'sharedlib/meson.build', 'staticlib/meson.build'])
 
         # Check dependencies
         dependencies_to_find = ['threads']

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1224,7 +1224,10 @@ class BasePlatformTests(unittest.TestCase):
         self.assertEqual(len(pathlist1), len(pathlist2))
         worklist = list(zip(pathlist1, pathlist2))
         for i in worklist:
-            self.assertPathEqual(i[0], i[1])
+            if i[0] == None:
+                self.assertEqual(i[0], i[1])
+            else:
+                self.assertPathEqual(i[0], i[1])
 
     def assertPathBasenameEqual(self, path, basename):
         msg = '{!r} does not end with {!r}'.format(path, basename)
@@ -1510,8 +1513,8 @@ class AllPlatformTests(BasePlatformTests):
             intro = intro[::-1]
         self.assertPathListEqual(intro[0]['install_filename'], ['/usr/include/diff.h', '/usr/bin/diff.sh'])
         self.assertPathListEqual(intro[1]['install_filename'], ['/opt/same.h', '/opt/same.sh'])
-        self.assertPathListEqual(intro[2]['install_filename'], ['/usr/include/first.h'])
-        self.assertPathListEqual(intro[3]['install_filename'], ['/usr/bin/second.sh'])
+        self.assertPathListEqual(intro[2]['install_filename'], ['/usr/include/first.h', None])
+        self.assertPathListEqual(intro[3]['install_filename'], [None, '/usr/bin/second.sh'])
 
     def test_uninstall(self):
         exename = os.path.join(self.installdir, 'usr/bin/prog' + exe_suffix)
@@ -3213,7 +3216,7 @@ recommended as it is not supported on some platforms''')
         self.assertListEqual(res['buildsystem_files'], ['meson.build', 'sharedlib/meson.build', 'staticlib/meson.build'])
 
         # Check dependencies
-        dependencies_to_find = ['zlib']
+        dependencies_to_find = ['threads']
         for i in res['dependencies']:
             assertKeyTypes(dependencies_typelist, i)
             if i['name'] in dependencies_to_find:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3256,6 +3256,32 @@ recommended as it is not supported on some platforms''')
 
         self.assertEqual(res_all, res_file)
 
+    def test_introspect_config_update(self):
+        testdir = os.path.join(self.unit_test_dir, '49 introspection')
+        introfile = os.path.join(self.builddir, 'meson-introspection.json')
+        self.init(testdir)
+        self.assertPathExists(introfile)
+        with open(introfile, 'r') as fp:
+            res1 = json.load(fp)
+
+        self.setconf('-Dcpp_std=c++14')
+        self.setconf('-Dbuildtype=release')
+
+        for idx, i in enumerate(res1['buildoptions']):
+            if i['name'] == 'cpp_std':
+                res1['buildoptions'][idx]['value'] = 'c++14'
+            if i['name'] == 'buildtype':
+                res1['buildoptions'][idx]['value'] = 'release'
+            if i['name'] == 'optimization':
+                res1['buildoptions'][idx]['value'] = '3'
+            if i['name'] == 'debug':
+                res1['buildoptions'][idx]['value'] = False
+
+        with open(introfile, 'r') as fp:
+            res2 = json.load(fp)
+
+        self.assertDictEqual(res1, res2)
+
 class FailureTests(BasePlatformTests):
     '''
     Tests that test failure conditions. Build files here should be dynamically

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3110,6 +3110,36 @@ recommended as it is not supported on some platforms''')
         self.maxDiff = None
         self.assertListEqual(res_nb, res_wb)
 
+    def test_introspect_all_command(self):
+        testdir = os.path.join(self.common_test_dir, '6 linkshared')
+        self.init(testdir)
+        res = self.introspect('--all')
+        keylist = [
+            'benchmarks',
+            'buildoptions',
+            'buildsystem_files',
+            'dependencies',
+            'installed',
+            'projectinfo',
+            'targets',
+            'tests'
+        ]
+
+        for i in keylist:
+            self.assertIn(i, res)
+
+    def test_introspect_file_dump_eauals_all(self):
+        testdir = os.path.join(self.common_test_dir, '6 linkshared')
+        self.init(testdir)
+        res_all = self.introspect('--all')
+        res_file = {}
+
+        introfile = os.path.join(self.builddir, 'meson-introspection.json')
+        self.assertPathExists(introfile)
+        with open(introfile, 'r') as fp:
+            res_file = json.load(fp)
+
+        self.assertEqual(res_all, res_file)
 
 class FailureTests(BasePlatformTests):
     '''

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1439,7 +1439,7 @@ class AllPlatformTests(BasePlatformTests):
         # Get name of static library
         targets = self.introspect('--targets')
         self.assertEqual(len(targets), 1)
-        libname = targets[0]['filename'][0]
+        libname = targets[0]['filename'] # TODO Change filename back to a list again
         # Build and get contents of static library
         self.build()
         before = self._run(['ar', 't', os.path.join(self.builddir, libname)]).split()
@@ -1496,13 +1496,16 @@ class AllPlatformTests(BasePlatformTests):
         intro = self.introspect('--targets')
         if intro[0]['type'] == 'executable':
             intro = intro[::-1]
-        self.assertPathListEqual(intro[0]['install_filename'], ['/usr/lib/libstat.a'])
-        self.assertPathListEqual(intro[1]['install_filename'], ['/usr/bin/prog' + exe_suffix])
+        self.assertPathListEqual([intro[0]['install_filename']], ['/usr/lib/libstat.a'])
+        self.assertPathListEqual([intro[1]['install_filename']], ['/usr/bin/prog' + exe_suffix])
 
     def test_install_introspection_multiple_outputs(self):
         '''
         Tests that the Meson introspection API exposes multiple install filenames correctly without crashing
         https://github.com/mesonbuild/meson/pull/4555
+
+        Reverted to the first file only because of https://github.com/mesonbuild/meson/pull/4547#discussion_r244173438
+        TODO Change the format to a list officialy in a followup PR
         '''
         if self.backend is not Backend.ninja:
             raise unittest.SkipTest('{!r} backend can\'t install files'.format(self.backend.name))
@@ -1511,10 +1514,14 @@ class AllPlatformTests(BasePlatformTests):
         intro = self.introspect('--targets')
         if intro[0]['type'] == 'executable':
             intro = intro[::-1]
-        self.assertPathListEqual(intro[0]['install_filename'], ['/usr/include/diff.h', '/usr/bin/diff.sh'])
-        self.assertPathListEqual(intro[1]['install_filename'], ['/opt/same.h', '/opt/same.sh'])
-        self.assertPathListEqual(intro[2]['install_filename'], ['/usr/include/first.h', None])
-        self.assertPathListEqual(intro[3]['install_filename'], [None, '/usr/bin/second.sh'])
+        #self.assertPathListEqual(intro[0]['install_filename'], ['/usr/include/diff.h', '/usr/bin/diff.sh'])
+        #self.assertPathListEqual(intro[1]['install_filename'], ['/opt/same.h', '/opt/same.sh'])
+        #self.assertPathListEqual(intro[2]['install_filename'], ['/usr/include/first.h', None])
+        #self.assertPathListEqual(intro[3]['install_filename'], [None, '/usr/bin/second.sh'])
+        self.assertPathListEqual([intro[0]['install_filename']], ['/usr/include/diff.h'])
+        self.assertPathListEqual([intro[1]['install_filename']], ['/opt/same.h'])
+        self.assertPathListEqual([intro[2]['install_filename']], ['/usr/include/first.h'])
+        self.assertPathListEqual([intro[3]['install_filename']], [None])
 
     def test_uninstall(self):
         exename = os.path.join(self.installdir, 'usr/bin/prog' + exe_suffix)
@@ -3173,7 +3180,7 @@ recommended as it is not supported on some platforms''')
             ('name', str),
             ('id', str),
             ('type', str),
-            ('filename', list),
+            ('filename', str),
             ('build_by_default', bool),
             ('sources', list),
             ('installed', bool),
@@ -4396,7 +4403,7 @@ class LinuxlikeTests(BasePlatformTests):
                 break
         self.assertIsInstance(docbook_target, dict)
         ifile = self.introspect(['--target-files', 'generated-gdbus-docbook@cus'])[0]
-        self.assertListEqual(t['filename'], ['gdbus/generated-gdbus-doc-' + os.path.basename(ifile)])
+        self.assertListEqual([t['filename']], ['gdbus/generated-gdbus-doc-' + os.path.basename(ifile)])
 
     def test_build_rpath(self):
         if is_cygwin():

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3754,7 +3754,7 @@ class DarwinTests(BasePlatformTests):
         self.build()
         targets = {}
         for t in self.introspect('--targets'):
-            targets[t['name']] = t['filename'][0]
+            targets[t['name']] = t['filename'][0] if isinstance(t['filename'], list) else t['filename']
         self.assertEqual(self._get_darwin_versions(targets['some']), ('7.0.0', '7.0.0'))
         self.assertEqual(self._get_darwin_versions(targets['noversion']), ('0.0.0', '0.0.0'))
         self.assertEqual(self._get_darwin_versions(targets['onlyversion']), ('1.0.0', '1.0.0'))

--- a/test cases/unit/49 introspection/meson.build
+++ b/test cases/unit/49 introspection/meson.build
@@ -1,4 +1,4 @@
-project('introspection', ['c', 'cpp'], version: '1.2.3', default_options: ['cpp_std=c++11'])
+project('introspection', ['c', 'cpp'], version: '1.2.3', default_options: ['cpp_std=c++11', 'buildtype=debug'])
 
 dep1 = dependency('zlib')
 

--- a/test cases/unit/49 introspection/meson.build
+++ b/test cases/unit/49 introspection/meson.build
@@ -1,0 +1,14 @@
+project('introspection', ['c', 'cpp'], version: '1.2.3', default_options: ['cpp_std=c++11'])
+
+dep1 = dependency('zlib')
+
+subdir('sharedlib')
+subdir('staticlib')
+
+t1 = executable('test1', 't1.cpp', link_with: [sharedlib], install: true)
+t2 = executable('test2', 't2.cpp', link_with: [staticlib])
+t3 = executable('test3', 't3.cpp', link_with: [sharedlib, staticlib], dependencies: [dep1])
+
+test('test case 1', t1)
+test('test case 2', t2)
+benchmark('benchmark 1', t3)

--- a/test cases/unit/49 introspection/meson.build
+++ b/test cases/unit/49 introspection/meson.build
@@ -1,6 +1,6 @@
 project('introspection', ['c', 'cpp'], version: '1.2.3', default_options: ['cpp_std=c++11', 'buildtype=debug'])
 
-dep1 = dependency('zlib')
+dep1 = dependency('threads')
 
 subdir('sharedlib')
 subdir('staticlib')

--- a/test cases/unit/49 introspection/sharedlib/meson.build
+++ b/test cases/unit/49 introspection/sharedlib/meson.build
@@ -1,0 +1,2 @@
+SRC_shared = ['shared.cpp']
+sharedlib = shared_library('sharedTestLib', SRC_shared)

--- a/test cases/unit/49 introspection/sharedlib/shared.cpp
+++ b/test cases/unit/49 introspection/sharedlib/shared.cpp
@@ -1,0 +1,9 @@
+#include "shared.hpp"
+
+void SharedClass::doStuff() {
+  number++;
+}
+
+int SharedClass::getNumber() const {
+  return number;
+}

--- a/test cases/unit/49 introspection/sharedlib/shared.hpp
+++ b/test cases/unit/49 introspection/sharedlib/shared.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+class SharedClass {
+  private:
+    int number = 42;
+  public:
+    SharedClass() = default;
+    void doStuff();
+    int getNumber() const;
+};

--- a/test cases/unit/49 introspection/staticlib/meson.build
+++ b/test cases/unit/49 introspection/staticlib/meson.build
@@ -1,0 +1,2 @@
+SRC_static = ['static.c']
+staticlib = static_library('staticTestLib', SRC_static)

--- a/test cases/unit/49 introspection/staticlib/static.c
+++ b/test cases/unit/49 introspection/staticlib/static.c
@@ -1,0 +1,5 @@
+#include "static.h"
+
+int add_numbers(int a, int b) {
+  return a + b;
+}

--- a/test cases/unit/49 introspection/staticlib/static.h
+++ b/test cases/unit/49 introspection/staticlib/static.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int add_numbers(int a, int b);

--- a/test cases/unit/49 introspection/t1.cpp
+++ b/test cases/unit/49 introspection/t1.cpp
@@ -1,0 +1,13 @@
+#include "sharedlib/shared.hpp"
+
+int main() {
+  SharedClass cl1;
+  if(cl1.getNumber() != 42) {
+    return 1;
+  }
+  cl1.doStuff();
+  if(cl1.getNumber() != 43) {
+    return 2;
+  }
+  return 0;
+}

--- a/test cases/unit/49 introspection/t2.cpp
+++ b/test cases/unit/49 introspection/t2.cpp
@@ -1,0 +1,8 @@
+#include "staticlib/static.h"
+
+int main() {
+  if(add_numbers(1, 2) != 3) {
+    return 1;
+  }
+  return 0;
+}

--- a/test cases/unit/49 introspection/t3.cpp
+++ b/test cases/unit/49 introspection/t3.cpp
@@ -1,0 +1,16 @@
+#include "sharedlib/shared.hpp"
+#include "staticlib/static.h"
+
+int main() {
+  for(int i = 0; i < 1000; add_numbers(i, 1)) {
+    SharedClass cl1;
+    if(cl1.getNumber() != 42) {
+      return 1;
+    }
+    cl1.doStuff();
+    if(cl1.getNumber() != 43) {
+      return 2;
+    }
+  }
+  return 0;
+}


### PR DESCRIPTION
This adds two new keys for each target returned by `meson introspect --targets`. The goal of this pull request is to provide a standard way for autocompletion support for IDEs. Being able to build the project with this information is _not_ the goal.

With this approach, the autocompletion support would also work when a `compile_commands.json` is not provided. As far as I know, only the `ninja` generator currently supports this.