### PR TITLE
mintro: Added option to introspect multiple parameters at once

### DIFF
--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -1,0 +1,12 @@
+## Added option to introspect multiple parameters at once
+
+Meson introspect can now print the results of multiple parameters
+in a single call. The results are then printed as a single JSON
+object.
+
+The format for a single command was not changed to keep backward
+compatibility.
+
+Furthermore the option `-a,--all` and `-i,--indent` was added to
+print all introspection information in one go and format the
+JSON output (the default is still compact JSON).

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -659,7 +659,7 @@ class Backend:
     def write_test_file(self, datafile):
         self.write_test_serialisation(self.build.get_tests(), datafile)
 
-    def write_test_serialisation(self, tests, datafile):
+    def create_test_serialisation(self, tests):
         arr = []
         for t in tests:
             exe = t.get_exe()
@@ -707,7 +707,10 @@ class Backend:
                                    exe_wrapper, t.is_parallel, cmd_args, t.env,
                                    t.should_fail, t.timeout, t.workdir, extra_paths)
             arr.append(ts)
-        pickle.dump(arr, datafile)
+        return arr
+
+    def write_test_serialisation(self, tests, datafile):
+        pickle.dump(self.create_test_serialisation(tests), datafile)
 
     def generate_depmf_install(self, d):
         if self.build.dep_manifest_name is None:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -951,9 +951,7 @@ class Backend:
             cmd = s['exe'] + s['args']
             subprocess.check_call(cmd, env=child_env)
 
-    def create_install_data_files(self):
-        install_data_file = os.path.join(self.environment.get_scratch_dir(), 'install.dat')
-
+    def create_install_data(self):
         if self.environment.is_cross_build():
             bins = self.environment.cross_info.config['binaries']
             if 'strip' not in bins:
@@ -976,8 +974,12 @@ class Backend:
         self.generate_data_install(d)
         self.generate_custom_install_script(d)
         self.generate_subdir_install(d)
+        return d
+
+    def create_install_data_files(self):
+        install_data_file = os.path.join(self.environment.get_scratch_dir(), 'install.dat')
         with open(install_data_file, 'wb') as ofile:
-            pickle.dump(d, ofile)
+            pickle.dump(self.create_install_data(), ofile)
 
     def generate_target_install(self, d):
         for t in self.build.get_targets().values():

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -369,14 +369,14 @@ def run(options):
 
 def generate_introspection_file(coredata, builddata, testdata, benchmarkdata, installdata):
     intro_info = [
-        #list_benchmarks(benchmarkdata),
+        list_benchmarks(benchmarkdata),
         list_buildoptions(coredata, builddata),
         list_buildsystem_files(builddata),
         list_deps(coredata),
         list_installed(installdata),
         list_projinfo(builddata),
         list_targets(coredata, builddata, installdata),
-        #list_tests(testdata)
+        list_tests(testdata)
     ]
 
     outdict = {}

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -29,6 +29,8 @@ from .backend import ninjabackend
 import sys, os
 import pathlib
 
+INTROSPECTION_OUTPUT_FILE = 'meson-introspection.json'
+
 def add_arguments(parser):
     parser.add_argument('--targets', action='store_true', dest='list_targets', default=False,
                         help='List top level targets.')
@@ -82,7 +84,7 @@ def list_installed(installdata):
             res[path] = os.path.join(installdata.prefix, installdir, os.path.basename(path))
         for path, installpath, unused_custom_install_mode in installdata.man:
             res[path] = os.path.join(installdata.prefix, installpath)
-    return res
+    return ('installed', res)
 
 
 def list_targets(coredata, builddata, installdata):
@@ -115,7 +117,7 @@ def list_targets(coredata, builddata, installdata):
             t['installed'] = False
         t['build_by_default'] = target.build_by_default
         tlist.append(t)
-    return tlist
+    return ('targets', tlist)
 
 def list_target_files(target_name, coredata, builddata):
     try:
@@ -129,7 +131,7 @@ def list_target_files(target_name, coredata, builddata):
         if isinstance(i, mesonlib.File):
             i = os.path.join(i.subdir, i.fname)
         out.append(i)
-    return out
+    return ('target_files', out)
 
 def list_buildoptions(coredata, builddata):
     optlist = []
@@ -162,7 +164,7 @@ def list_buildoptions(coredata, builddata):
     add_keys(optlist, dir_options, 'directory')
     add_keys(optlist, coredata.user_options, 'user')
     add_keys(optlist, test_options, 'test')
-    return optlist
+    return ('buildoptions', optlist)
 
 def add_keys(optlist, options, section):
     keys = list(options.keys())
@@ -194,7 +196,7 @@ def find_buildsystem_files_list(src_dir):
         for f in files:
             if f == 'meson.build' or f == 'meson_options.txt':
                 filelist.append(os.path.relpath(os.path.join(root, f), src_dir))
-    return filelist
+    return ('buildsystem_files', filelist)
 
 def list_buildsystem_files(builddata):
     src_dir = builddata.environment.get_source_dir()
@@ -208,9 +210,9 @@ def list_deps(coredata):
             result += [{'name': d.name,
                         'compile_args': d.get_compile_args(),
                         'link_args': d.get_link_args()}]
-    return result
+    return ('dependencies', result)
 
-def list_tests(testdata):
+def get_test_list(testdata):
     result = []
     for t in testdata:
         to = {}
@@ -231,6 +233,12 @@ def list_tests(testdata):
         result.append(to)
     return result
 
+def list_tests(testdata):
+    return ('tests', get_test_list(testdata))
+
+def list_benchmarks(benchdata):
+    return ('benchmarks', get_test_list(benchdata))
+
 def list_projinfo(builddata):
     result = {'version': builddata.project_version,
               'descriptive_name': builddata.project_name}
@@ -241,7 +249,7 @@ def list_projinfo(builddata):
              'descriptive_name': builddata.projects.get(k)}
         subprojects.append(c)
     result['subprojects'] = subprojects
-    return result
+    return ('projectinfo', result)
 
 class ProjectInfoInterperter(astinterpreter.AstInterpreter):
     def __init__(self, source_root, subdir):
@@ -326,23 +334,23 @@ def run(options):
     results = []
 
     if options.all or options.list_targets:
-        results += [('targets', list_targets(coredata, builddata, installdata))]
+        results += [list_targets(coredata, builddata, installdata)]
     if options.all or options.list_installed:
-        results += [('installed', list_installed(installdata))]
+        results += [list_installed(installdata)]
     if options.target_files is not None:
-        results += [('target_files', list_target_files(options.target_files, coredata, builddata))]
+        results += [list_target_files(options.target_files, coredata, builddata)]
     if options.all or options.buildsystem_files:
-        results += [('buildsystem_files', list_buildsystem_files(builddata))]
+        results += [list_buildsystem_files(builddata)]
     if options.all or options.buildoptions:
-        results += [('buildoptions', list_buildoptions(coredata, builddata))]
+        results += [list_buildoptions(coredata, builddata)]
     if options.all or options.tests:
-        results += [('tests', list_tests(testdata))]
+        results += [list_tests(testdata)]
     if options.all or options.benchmarks:
-        results += [('benchmarks', list_tests(benchmarkdata))]
+        results += [list_benchmarks(benchmarkdata)]
     if options.all or options.dependencies:
-        results += [('dependencies', list_deps(coredata))]
+        results += [list_deps(coredata)]
     if options.all or options.projectinfo:
-        results += [('projectinfo', list_projinfo(builddata))]
+        results += [list_projinfo(builddata)]
 
     indent = options.indent if options.indent > 0 else None
 
@@ -358,3 +366,25 @@ def run(options):
             out[i[0]] = i[1]
         print(json.dumps(out, indent=indent))
     return 0
+
+def generate_introspection_file(coredata, builddata, testdata, benchmarkdata, installdata):
+    intro_info = [
+        #list_benchmarks(benchmarkdata),
+        list_buildoptions(coredata, builddata),
+        list_buildsystem_files(builddata),
+        list_deps(coredata),
+        list_installed(installdata),
+        list_projinfo(builddata),
+        list_targets(coredata, builddata, installdata),
+        #list_tests(testdata)
+    ]
+
+    outdict = {}
+    for i in intro_info:
+        outdict[i[0]] = i[1]
+
+    outfile = os.path.join(builddata.environment.get_build_dir(), INTROSPECTION_OUTPUT_FILE)
+    outfile = os.path.abspath(outfile)
+
+    with open(outfile, 'w') as fp:
+        json.dump(outdict, fp, indent=2)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -52,6 +52,8 @@ def add_arguments(parser):
                         help='Print all available information.')
     parser.add_argument('-i', '--indent', dest='indent', type=int, default=0,
                         help='Number of spaces used for indentation.')
+    parser.add_argument('-f', '--force-new', action='store_true', dest='force_new', default=False,
+                        help='Always use the new JSON format for multiple entries (even for 0 and 1 introspection commands)')
     parser.add_argument('builddir', nargs='?', default='.', help='The build directory')
 
 def determine_installed_path(target, installdata):
@@ -344,10 +346,10 @@ def run(options):
 
     indent = options.indent if options.indent > 0 else None
 
-    if len(results) == 0:
+    if len(results) == 0 and not options.force_new:
         print('No command specified')
         return 1
-    elif len(results) == 1:
+    elif len(results) == 1 and not options.force_new:
         # Make to keep the existing output format for a single option
         print(json.dumps(results[0][1], indent=indent))
     else:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -48,6 +48,10 @@ def add_arguments(parser):
                         help='List external dependencies.')
     parser.add_argument('--projectinfo', action='store_true', dest='projectinfo', default=False,
                         help='Information about projects.')
+    parser.add_argument('-a', '--all', action='store_true', dest='all', default=False,
+                        help='Print all available information.')
+    parser.add_argument('-i', '--indent', dest='indent', type=int, default=0,
+                        help='Number of spaces used for indentation.')
     parser.add_argument('builddir', nargs='?', default='.', help='The build directory')
 
 def determine_installed_path(target, installdata):
@@ -76,7 +80,7 @@ def list_installed(installdata):
             res[path] = os.path.join(installdata.prefix, installdir, os.path.basename(path))
         for path, installpath, unused_custom_install_mode in installdata.man:
             res[path] = os.path.join(installdata.prefix, installpath)
-    print(json.dumps(res))
+    return res
 
 
 def list_targets(coredata, builddata, installdata):
@@ -109,7 +113,7 @@ def list_targets(coredata, builddata, installdata):
             t['installed'] = False
         t['build_by_default'] = target.build_by_default
         tlist.append(t)
-    print(json.dumps(tlist))
+    return tlist
 
 def list_target_files(target_name, coredata, builddata):
     try:
@@ -123,7 +127,7 @@ def list_target_files(target_name, coredata, builddata):
         if isinstance(i, mesonlib.File):
             i = os.path.join(i.subdir, i.fname)
         out.append(i)
-    print(json.dumps(out))
+    return out
 
 def list_buildoptions(coredata, builddata):
     optlist = []
@@ -156,7 +160,7 @@ def list_buildoptions(coredata, builddata):
     add_keys(optlist, dir_options, 'directory')
     add_keys(optlist, coredata.user_options, 'user')
     add_keys(optlist, test_options, 'test')
-    print(json.dumps(optlist))
+    return optlist
 
 def add_keys(optlist, options, section):
     keys = list(options.keys())
@@ -193,7 +197,7 @@ def find_buildsystem_files_list(src_dir):
 def list_buildsystem_files(builddata):
     src_dir = builddata.environment.get_source_dir()
     filelist = find_buildsystem_files_list(src_dir)
-    print(json.dumps(filelist))
+    return filelist
 
 def list_deps(coredata):
     result = []
@@ -202,7 +206,7 @@ def list_deps(coredata):
             result += [{'name': d.name,
                         'compile_args': d.get_compile_args(),
                         'link_args': d.get_link_args()}]
-    print(json.dumps(result))
+    return result
 
 def list_tests(testdata):
     result = []
@@ -223,7 +227,7 @@ def list_tests(testdata):
         to['suite'] = t.suite
         to['is_parallel'] = t.is_parallel
         result.append(to)
-    print(json.dumps(result))
+    return result
 
 def list_projinfo(builddata):
     result = {'version': builddata.project_version,
@@ -235,7 +239,7 @@ def list_projinfo(builddata):
              'descriptive_name': builddata.projects.get(k)}
         subprojects.append(c)
     result['subprojects'] = subprojects
-    print(json.dumps(result))
+    return result
 
 class ProjectInfoInterperter(astinterpreter.AstInterpreter):
     def __init__(self, source_root, subdir):
@@ -317,25 +321,38 @@ def run(options):
     except FileNotFoundError:
         installdata = None
 
-    if options.list_targets:
-        list_targets(coredata, builddata, installdata)
-    elif options.list_installed:
-        list_installed(installdata)
-    elif options.target_files is not None:
-        list_target_files(options.target_files, coredata, builddata)
-    elif options.buildsystem_files:
-        list_buildsystem_files(builddata)
-    elif options.buildoptions:
-        list_buildoptions(coredata, builddata)
-    elif options.tests:
-        list_tests(testdata)
-    elif options.benchmarks:
-        list_tests(benchmarkdata)
-    elif options.dependencies:
-        list_deps(coredata)
-    elif options.projectinfo:
-        list_projinfo(builddata)
-    else:
+    results = []
+
+    if options.all or options.list_targets:
+        results += [('targets', list_targets(coredata, builddata, installdata))]
+    if options.all or options.list_installed:
+        results += [('installed', list_installed(installdata))]
+    if options.target_files is not None:
+        results += [('target_files', list_target_files(options.target_files, coredata, builddata))]
+    if options.all or options.buildsystem_files:
+        results += [('buildsystem_files', list_buildsystem_files(builddata))]
+    if options.all or options.buildoptions:
+        results += [('buildoptions', list_buildoptions(coredata, builddata))]
+    if options.all or options.tests:
+        results += [('tests', list_tests(testdata))]
+    if options.all or options.benchmarks:
+        results += [('benchmarks', list_tests(benchmarkdata))]
+    if options.all or options.dependencies:
+        results += [('dependencies', list_deps(coredata))]
+    if options.all or options.projectinfo:
+        results += [('projectinfo', list_projinfo(builddata))]
+
+    indent = options.indent if options.indent > 0 else None
+
+    if len(results) == 0:
         print('No command specified')
         return 1
+    elif len(results) == 1:
+        # Make to keep the existing output format for a single option
+        print(json.dumps(results[0][1], indent=indent))
+    else:
+        out = {}
+        for i in results:
+            out[i[0]] = i[1]
+        print(json.dumps(out, indent=indent))
     return 0

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -119,21 +119,22 @@ def list_targets(coredata, builddata, installdata):
         tlist.append(t)
     return ('targets', tlist)
 
-def list_target_files(target_name, coredata, builddata):
-    try:
-        t = builddata.targets[target_name]
-        sources = t.sources + t.extra_files
-    except KeyError:
-        print("Unknown target %s." % target_name)
-        sys.exit(1)
-    out = []
-    for i in sources:
-        if isinstance(i, mesonlib.File):
-            i = os.path.join(i.subdir, i.fname)
-        out.append(i)
-    return ('target_files', out)
+def list_target_files(target_name, targets):
+    return ('error: TODO implement', [])
+    #try:
+    #    t = builddata.targets[target_name]
+    #    sources = t.sources + t.extra_files
+    #except KeyError:
+    #    print("Unknown target %s." % target_name)
+    #    sys.exit(1)
+    #out = []
+    #for i in sources:
+    #    if isinstance(i, mesonlib.File):
+    #        i = os.path.join(i.subdir, i.fname)
+    #    out.append(i)
+    #return ('target_files', out)
 
-def list_buildoptions(coredata, builddata):
+def list_buildoptions(coredata):
     optlist = []
 
     dir_option_names = ['bindir',
@@ -308,49 +309,51 @@ def list_projinfo_from_source(sourcedir):
 
 def run(options):
     datadir = 'meson-private'
+    introfile = INTROSPECTION_OUTPUT_FILE
     if options.builddir is not None:
         datadir = os.path.join(options.builddir, datadir)
+        introfile = os.path.join(options.builddir, introfile)
     if options.builddir.endswith('/meson.build') or options.builddir.endswith('\\meson.build') or options.builddir == 'meson.build':
         if options.projectinfo:
             sourcedir = '.' if options.builddir == 'meson.build' else options.builddir[:-11]
             list_projinfo_from_source(sourcedir)
             return 0
-    if not os.path.isdir(datadir):
+    if not os.path.isdir(datadir) or not os.path.isfile(introfile):
         print('Current directory is not a build dir. Please specify it or '
               'change the working directory to it.')
         return 1
 
-    coredata = cdata.load(options.builddir)
-    builddata = build.load(options.builddir)
-    testdata = mtest.load_tests(options.builddir)
-    benchmarkdata = mtest.load_benchmarks(options.builddir)
-
-    # Install data is only available with the Ninja backend
-    try:
-        installdata = ninjabackend.load(options.builddir)
-    except FileNotFoundError:
-        installdata = None
+    rawdata = {}
+    with open(introfile, 'r') as fp:
+        rawdata = json.load(fp)
 
     results = []
+    toextract = []
 
-    if options.all or options.list_targets:
-        results += [list_targets(coredata, builddata, installdata)]
-    if options.all or options.list_installed:
-        results += [list_installed(installdata)]
-    if options.target_files is not None:
-        results += [list_target_files(options.target_files, coredata, builddata)]
-    if options.all or options.buildsystem_files:
-        results += [list_buildsystem_files(builddata)]
-    if options.all or options.buildoptions:
-        results += [list_buildoptions(coredata, builddata)]
-    if options.all or options.tests:
-        results += [list_tests(testdata)]
     if options.all or options.benchmarks:
-        results += [list_benchmarks(benchmarkdata)]
+        toextract += ['benchmarks']
+    if options.all or options.buildoptions:
+        coredata = cdata.load(options.builddir)
+        results += [list_buildoptions(coredata)]
+    if options.all or options.buildsystem_files:
+        toextract += ['buildsystem_files']
     if options.all or options.dependencies:
-        results += [list_deps(coredata)]
+        toextract += ['dependencies']
+    if options.all or options.list_installed:
+        toextract += ['installed']
     if options.all or options.projectinfo:
-        results += [list_projinfo(builddata)]
+        toextract += ['projectinfo']
+    if options.all or options.list_targets:
+        toextract += ['targets']
+    if options.target_files is not None:
+        results += [list_target_files(options.target_files, rawdata['targets'])]
+    if options.all or options.tests:
+        toextract += ['tests']
+
+    for i in toextract:
+        if i not in rawdata:
+            raise RuntimeError('Key "{}" missing in introspection file. Please report this a bug.'.format(i))
+        results += [(i, rawdata[i])]
 
     indent = options.indent if options.indent > 0 else None
 
@@ -370,7 +373,7 @@ def run(options):
 def generate_introspection_file(coredata, builddata, testdata, benchmarkdata, installdata):
     intro_info = [
         list_benchmarks(benchmarkdata),
-        list_buildoptions(coredata, builddata),
+        list_buildoptions(coredata),
         list_buildsystem_files(builddata),
         list_deps(coredata),
         list_installed(installdata),

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -196,12 +196,12 @@ def find_buildsystem_files_list(src_dir):
         for f in files:
             if f == 'meson.build' or f == 'meson_options.txt':
                 filelist.append(os.path.relpath(os.path.join(root, f), src_dir))
-    return ('buildsystem_files', filelist)
+    return filelist
 
 def list_buildsystem_files(builddata):
     src_dir = builddata.environment.get_source_dir()
     filelist = find_buildsystem_files_list(src_dir)
-    return filelist
+    return ('buildsystem_files', filelist)
 
 def list_deps(coredata):
     result = []

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -387,4 +387,4 @@ def generate_introspection_file(coredata, builddata, testdata, benchmarkdata, in
     outfile = os.path.abspath(outfile)
 
     with open(outfile, 'w') as fp:
-        json.dump(outdict, fp, indent=2)
+        json.dump(outdict, fp)

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -23,6 +23,7 @@ import argparse
 from . import environment, interpreter, mesonlib
 from . import build
 from . import mlog, coredata
+from . import mintro
 from .mesonlib import MesonException
 
 def add_arguments(parser):
@@ -202,6 +203,9 @@ class MesonApp:
                 coredata.write_cmd_line_file(self.build_dir, self.options)
             else:
                 coredata.update_cmd_line_file(self.build_dir, self.options)
+
+            # Generate an IDE introspection file with the exact same syntax as the introspection API defined in mintro
+            mintro.generate_introspection_file(b.environment.get_coredata(), b, b.get_tests(), b.get_benchmarks(), intr.backend.create_install_data())
         except:
             if 'cdf' in locals():
                 old_cdf = cdf + '.prev'

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -204,8 +204,11 @@ class MesonApp:
             else:
                 coredata.update_cmd_line_file(self.build_dir, self.options)
 
-            # Generate an IDE introspection file with the exact same syntax as the introspection API defined in mintro
-            mintro.generate_introspection_file(b.environment.get_coredata(), b, b.get_tests(), b.get_benchmarks(), intr.backend.create_install_data())
+            # Generate an IDE introspection file with the same syntax as the already existing API
+            intro_tests = intr.backend.create_test_serialisation(b.get_tests())
+            intro_benchmarks = intr.backend.create_test_serialisation(b.get_benchmarks())
+            intro_install = intr.backend.create_install_data()
+            mintro.generate_introspection_file(b.environment.get_coredata(), b, intro_tests, intro_benchmarks, intro_install)
         except:
             if 'cdf' in locals():
                 old_cdf = cdf + '.prev'

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2947,6 +2947,36 @@ recommended as it is not supported on some platforms''')
         self.assertEqual(res['subprojects'][0]['version'], 'undefined')
         self.assertEqual(res['subprojects'][0]['descriptive_name'], 'subproject')
 
+    def test_introspect_all_command(self):
+        testdir = os.path.join(self.common_test_dir, '6 linkshared')
+        self.init(testdir)
+        res = self.introspect('--all')
+        keylist = [
+            'benchmarks',
+            'buildoptions',
+            'buildsystem_files',
+            'dependencies',
+            'installed',
+            'projectinfo',
+            'targets',
+            'tests'
+        ]
+
+        for i in keylist:
+            self.assertIn(i, res)
+
+    def test_introspect_file_dump_eauals_all(self):
+        testdir = os.path.join(self.common_test_dir, '6 linkshared')
+        self.init(testdir)
+        res_all = self.introspect('--all')
+        res_file = {}
+
+        introfile = os.path.join(self.builddir, 'meson-introspection.json')
+        self.assertPathExists(introfile)
+        with open(introfile, 'r') as fp:
+            res_file = json.load(fp)
+
+        self.assertEqual(res_all, res_file)
 
 class FailureTests(BasePlatformTests):
     '''


### PR DESCRIPTION
This allows Meson to print the results of multiple introspection commands in a single call. This allows IDE's to reduce the number of meson calls, which simplifies things and should help with performance.

The format for a single command was not changed to keep backward compatibility. The output format for multiple introspection commands looks like this:

```json
{
  "targets": ["what", "meson introspect", "--targets", "returns"],
  "projectinfo": {"...": "stuff"}
}
```

Furthermore the option `-a,--all` and `-i,--indent` were added to print all introspection information in one go and format the JSON output (the default is still compact JSON).

## Update:
Also added the option `-f,--force-new` so that the format for multiple introspection commands can always be used. This makes IDE integration slightly easier since there is no longer a need for handling the special case for a single (or no) commands.

## Update2:
I have also added that meson will now automatically generate a `meson-introspection.json` file with the same content as the new `--all` option. See #4547 for the main discussion.