### PR TITLE
CMake: try different dependency names

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -178,9 +178,10 @@ DC="dmd" meson builddir
 
 Some dependencies have specific detection logic.
 
-Generic dependency names are case-sensitive<sup>[1](#footnote1)</sup>,
-but these dependency names are matched case-insensitively.  The
-recommended style is to write them in all lower-case.
+Generic dependency names are case-sensitive<sup>[1](#footnote1)</sup>.
+The only exception to this rule are these dependencies with custom
+detection logic and CMake dependencies. The recommended style is to
+write them in all lower-case.
 
 In some cases, more than one detection method exists, and the `method` keyword
 may be used to select a detection method to use.  The `auto` method uses any

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -148,6 +148,11 @@ it automatically.
     cmake_dep = dependency('ZLIB', method : 'cmake', modules : ['ZLIB::ZLIB'])
 ```
 
+Meson will also attempt to case convert the dependency name if the original
+name could not be found. This is done because the names for the CMake and
+pkg-config dependencies can differ. For instance CMake can find the
+dependencies `ZLIB` and `Lua`, but pkg-config wants `zlib` and `lua`.
+
 ### Some notes on Dub
 
 Please understand that meson is only able to find dependencies that

--- a/mesonbuild/dependencies/data/CMakeLists.txt
+++ b/mesonbuild/dependencies/data/CMakeLists.txt
@@ -13,13 +13,29 @@ if(CMAKE_LIBRARY_ARCHITECTURE_REGEX)
   endif()
 endif()
 
-find_package("${NAME}" QUIET)
-
 set(PACKAGE_FOUND FALSE)
-set(_packageName "${NAME}")
-string(TOUPPER "${_packageName}" PACKAGE_NAME)
 
-if(${_packageName}_FOUND  OR  ${PACKAGE_NAME}_FOUND)
+string(TOUPPER "${NAME}" NAME_A)
+string(TOLOWER "${NAME}" NAME_B)
+string(SUBSTRING "${NAME}" 0 1  NAME_FIRST_CHAR)
+string(SUBSTRING "${NAME}" 1 -1 NAME_REMAINING)
+string(TOUPPER "${NAME_FIRST_CHAR}" NAME_FIRST_CHAR_UPPER)
+string(TOLOWER "${NAME_REMAINING}"  NAME_REMAINING_LOWER)
+
+set(NAMES_TO_TRY "${NAME}" "${NAME_A}" "${NAME_B}" "${NAME_FIRST_CHAR_UPPER}${NAME_REMAINING}" "${NAME_FIRST_CHAR_UPPER}${NAME_REMAINING_LOWER}")
+
+foreach(I IN LISTS NAMES_TO_TRY)
+  find_package("${I}" QUIET)
+
+  set(_packageName "${I}")
+  string(TOUPPER "${_packageName}" PACKAGE_NAME)
+
+  # Check if the package was NOT found, then continue with the next
+  if(NOT ${_packageName}_FOUND AND NOT ${PACKAGE_NAME}_FOUND)
+    continue()
+  endif()
+
+  # Package was found
   set(PACKAGE_FOUND TRUE)
 
   # Check the following variables:
@@ -90,4 +106,6 @@ if(${_packageName}_FOUND  OR  ${PACKAGE_NAME}_FOUND)
   set(PACKAGE_INCLUDE_DIRS "${${includes}}")
   set(PACKAGE_DEFINITIONS  "${${definitions}}")
   set(PACKAGE_LIBRARIES    "${${libs}}")
-endif()
+
+  break()
+endforeach()

--- a/test cases/linuxlike/13 cmake dependency/meson.build
+++ b/test cases/linuxlike/13 cmake dependency/meson.build
@@ -30,7 +30,12 @@ test('zlibtest2', exe2)
 depf1 = dependency('nvakuhrabnsdfasdf', required : false, method : 'cmake')
 depf2 = dependency('ZLIB', required : false, method : 'cmake', modules : 'dfggh::hgfgag')
 
+assert(depf1.found() == false, 'Nonexistent packages should fail')
 assert(depf2.found() == false, 'Invalid CMake targets should fail')
+
+# Try to find zlib with a different string
+depcs1 = dependency('zlib', method : 'cmake')
+depcs2 = dependency('zLiB', method : 'cmake')
 
 # Try to compile a test that takes a dep and an include_directories
 


### PR DESCRIPTION
With this pull request meson will also attempt to case convert the dependency name (for CMake) if the original name could not be found. This is useful because the names for the CMake and pkg-config dependencies can differ. For instance, CMake can find the dependencies `ZLIB` and `Lua`, but pkg-config wants `zlib` and `lua`.

This should improve the usefulness of CMake as a dependency backend since more dependency names between pkg-config and CMake overlap now.

This could also be useful for cases like #4553 since CMake has a FindLua.cmake and a `dependency('lua')` would thus always work (assuming CMake is installed).