### PR TITLE
mintro: Bug fix for determine_installed_path for multiple target outputs

### DIFF
--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -51,17 +51,21 @@ def add_arguments(parser):
     parser.add_argument('builddir', nargs='?', default='.', help='The build directory')
 
 def determine_installed_path(target, installdata):
-    install_target = None
-    for i in installdata.targets:
-        if os.path.basename(i.fname) == target.get_filename(): # FIXME, might clash due to subprojects.
-            install_target = i
-            break
-    if install_target is None:
+    install_targets = []
+    for i in target.outputs:
+        for j in installdata.targets:
+            if os.path.basename(j.fname) == i: # FIXME, might clash due to subprojects.
+                install_targets += [j]
+                break
+    if len(install_targets) == 0:
         raise RuntimeError('Something weird happened. File a bug.')
-    outname = os.path.join(installdata.prefix, i.outdir, os.path.basename(i.fname))
+
     # Normalize the path by using os.path.sep consistently, etc.
     # Does not change the effective path.
-    return str(pathlib.PurePath(outname))
+    install_targets = list(map(lambda x: os.path.join(installdata.prefix, x.outdir, os.path.basename(x.fname)), install_targets))
+    install_targets = list(map(lambda x: str(pathlib.PurePath(x)), install_targets))
+
+    return install_targets
 
 
 def list_installed(installdata):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1462,8 +1462,25 @@ class AllPlatformTests(BasePlatformTests):
         intro = self.introspect('--targets')
         if intro[0]['type'] == 'executable':
             intro = intro[::-1]
-        self.assertPathEqual(intro[0]['install_filename'], '/usr/lib/libstat.a')
-        self.assertPathEqual(intro[1]['install_filename'], '/usr/bin/prog' + exe_suffix)
+        self.assertListEqual(intro[0]['install_filename'], ['/usr/lib/libstat.a'])
+        self.assertListEqual(intro[1]['install_filename'], ['/usr/bin/prog' + exe_suffix])
+
+    def test_install_introspection_multiple_outputs(self):
+        '''
+        Tests that the Meson introspection API exposes multiple install filenames correctly without crashing
+        https://github.com/mesonbuild/meson/pull/4555
+        '''
+        if self.backend is not Backend.ninja:
+            raise unittest.SkipTest('{!r} backend can\'t install files'.format(self.backend.name))
+        testdir = os.path.join(self.common_test_dir, '145 custom target multiple outputs')
+        self.init(testdir)
+        intro = self.introspect('--targets')
+        if intro[0]['type'] == 'executable':
+            intro = intro[::-1]
+        self.assertListEqual(intro[0]['install_filename'], ['/usr/include/diff.h', '/usr/bin/diff.sh'])
+        self.assertListEqual(intro[1]['install_filename'], ['/opt/same.h', '/opt/same.sh'])
+        self.assertListEqual(intro[2]['install_filename'], ['/usr/include/first.h'])
+        self.assertListEqual(intro[3]['install_filename'], ['/usr/bin/second.sh'])
 
     def test_uninstall(self):
         exename = os.path.join(self.installdir, 'usr/bin/prog' + exe_suffix)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1195,6 +1195,12 @@ class BasePlatformTests(unittest.TestCase):
         '''
         self.assertEqual(PurePath(path1), PurePath(path2))
 
+    def assertPathListEqual(self, pathlist1, pathlist2):
+        self.assertEquals(len(pathlist1), len(pathlist2))
+        worklist = list(zip(pathlist1, pathlist2))
+        for i in worklist:
+            self.assertPathEqual(i[0], i[1])
+
     def assertPathBasenameEqual(self, path, basename):
         msg = '{!r} does not end with {!r}'.format(path, basename)
         # We cannot use os.path.basename because it returns '' when the path
@@ -1462,8 +1468,8 @@ class AllPlatformTests(BasePlatformTests):
         intro = self.introspect('--targets')
         if intro[0]['type'] == 'executable':
             intro = intro[::-1]
-        self.assertListEqual(intro[0]['install_filename'], ['/usr/lib/libstat.a'])
-        self.assertListEqual(intro[1]['install_filename'], ['/usr/bin/prog' + exe_suffix])
+        self.assertPathListEqual(intro[0]['install_filename'], ['/usr/lib/libstat.a'])
+        self.assertPathListEqual(intro[1]['install_filename'], ['/usr/bin/prog' + exe_suffix])
 
     def test_install_introspection_multiple_outputs(self):
         '''
@@ -1477,10 +1483,10 @@ class AllPlatformTests(BasePlatformTests):
         intro = self.introspect('--targets')
         if intro[0]['type'] == 'executable':
             intro = intro[::-1]
-        self.assertListEqual(intro[0]['install_filename'], ['/usr/include/diff.h', '/usr/bin/diff.sh'])
-        self.assertListEqual(intro[1]['install_filename'], ['/opt/same.h', '/opt/same.sh'])
-        self.assertListEqual(intro[2]['install_filename'], ['/usr/include/first.h'])
-        self.assertListEqual(intro[3]['install_filename'], ['/usr/bin/second.sh'])
+        self.assertPathListEqual(intro[0]['install_filename'], ['/usr/include/diff.h', '/usr/bin/diff.sh'])
+        self.assertPathListEqual(intro[1]['install_filename'], ['/opt/same.h', '/opt/same.sh'])
+        self.assertPathListEqual(intro[2]['install_filename'], ['/usr/include/first.h'])
+        self.assertPathListEqual(intro[3]['install_filename'], ['/usr/bin/second.sh'])
 
     def test_uninstall(self):
         exename = os.path.join(self.installdir, 'usr/bin/prog' + exe_suffix)


### PR DESCRIPTION
This bug occurs for the project tests `test cases/common/145 custom target multiple outputs` and `test cases/vala/7 shared library`. Here targets with multiple outputs are generated, of which, not all are installed. This crashes the `--targets` introspector.

How to reproduce:
 - in meson root:
 - run `./meson.py "test cases/common/145 custom target multiple outputs" tmp`
 - then `./meson.py introspect --targets tmp` will crash