### PR TITLE
syntax-highlighting: vim: Allow overriding shiftwidth and softtabstop

### DIFF
--- a/data/syntax-highlighting/vim/README
+++ b/data/syntax-highlighting/vim/README
@@ -1,3 +1,4 @@
 ftdetect sets the filetype
+ftplugin sets Meson indentation rules
+indent does Meson indentation
 syntax does Meson syntax highlighting
-plugin does Meson indentation

--- a/data/syntax-highlighting/vim/ftplugin/meson.vim
+++ b/data/syntax-highlighting/vim/ftplugin/meson.vim
@@ -1,0 +1,15 @@
+" Vim filetype plugin file
+" Language:	meson
+" Original Author:	Laurent Pinchart <laurent.pinchart@ideasonboard.com>
+" Last Change:		2018 Nov 27
+
+if exists("b:did_ftplugin") | finish | endif
+let b:did_ftplugin = 1
+let s:keepcpo= &cpo
+set cpo&vim
+
+setlocal shiftwidth=2
+setlocal softtabstop=2
+
+let &cpo = s:keepcpo
+unlet s:keepcpo

--- a/data/syntax-highlighting/vim/indent/meson.vim
+++ b/data/syntax-highlighting/vim/indent/meson.vim
@@ -29,10 +29,6 @@ setlocal cpo&vim
 
 let s:maxoff = 50	" maximum number of lines to look backwards for ()
 
-" Force sw=2 sts=2 because that's required by convention
-setlocal shiftwidth=2
-setlocal softtabstop=2 
-
 function GetMesonIndent(lnum)
   echom getline(line("."))
 


### PR DESCRIPTION
The vim syntax indentation rules stored in indent/meson.vim set the
local shiftwidth and softtabstop variables. As the file is loaded last,
after ~/.vim/after/ftplugin/meson.vim (when present), this prevents
overriding the default values for shiftwidth and softtabstop in a local
configuration.

Fix this by setting shiftwidth and softtabstop in ftplugin/meson.vim
instead (as done by the python indentiation rules in upstream vim for
instance) to allow local overrides.

Signed-off-by: Laurent Pinchart <laurent.pinchart@ideasonboard.com>