### PR TITLE
Add meson version required to use option type

### DIFF
--- a/docs/markdown/Build-options.md
+++ b/docs/markdown/Build-options.md
@@ -17,9 +17,9 @@ option('someoption', type : 'string', value : 'optval', description : 'An option
 option('other_one', type : 'boolean', value : false)
 option('combo_opt', type : 'combo', choices : ['one', 'two', 'three'], value : 'three')
 option('integer_opt', type : 'integer', min : 0, max : 5, value : 3) # Since 0.45.0
-option('free_array_opt', type : 'array', value : ['one', 'two'])
+option('free_array_opt', type : 'array', value : ['one', 'two'])  # Since 0.44.0
 option('array_opt', type : 'array', choices : ['one', 'two', 'three'], value : ['one', 'two'])
-option('some_feature', type : 'feature', value : 'enabled')
+option('some_feature', type : 'feature', value : 'enabled')  # Since 0.47.0
 ```
 
 ## Build option types


### PR DESCRIPTION
So people could quickly see it without scrolling page.