### PR TITLE
wrap: Add support for applying a list of patch files

### DIFF
--- a/docs/markdown/Wrap-dependency-system-manual.md
+++ b/docs/markdown/Wrap-dependency-system-manual.md
@@ -247,6 +247,34 @@ With such wrap file, `find_program('myprog')` will automatically
 fallback to use the subproject, assuming it uses
 `meson.override_find_program('myprog')`.
 
+## Patch files
+
+*Since: 0.59.0*
+
+A list of local patch files can be provided in the `[patch-files]` section. They
+will be applied after the project has been extracted or cloned, and after the
+`patch_filename` has been applied. `git` or `patch` command-line tool must be
+available.
+
+The `[patch-files]` section is optional and might contain the following keys:
+- `strip`: Number of leading components from file names to strip. Defaults to 1
+  if omitted.
+- `patches`: A list of patch filenames relative to `subprojects/packagefiles`
+  directory. It must be in the python string list format (e.g. `['foo', 'bar']`).
+
+```ini
+[wrap-file]
+directory = libfoobar-1.0
+
+source_url = https://example.com/foobar-1.0.tar.gz
+source_filename = foobar-1.0.tar.gz
+source_hash = 5ebeea0dfb75d090ea0e7ff84799b2a7a1550db3fe61eb5f6f61c2e971e57663
+
+[patch-files]
+strip = 1
+patches = ['0001.patch', '0002.patch']
+```
+
 ## Using wrapped projects
 
 Wraps provide a convenient way of obtaining a project into your

--- a/docs/markdown/snippets/patch_files.md
+++ b/docs/markdown/snippets/patch_files.md
@@ -1,0 +1,18 @@
+## Wrap files can contain a list of patch files to apply
+
+A list of local patch files can be provided by the `.wrap` file and they will be
+applied after the subproject has been extracted or cloned from git. This requires
+the `patch` or `git` command-line tool.
+
+```ini
+[wrap-file]
+directory = libfoobar-1.0
+
+source_url = https://example.com/foobar-1.0.tar.gz
+source_filename = foobar-1.0.tar.gz
+source_hash = 5ebeea0dfb75d090ea0e7ff84799b2a7a1550db3fe61eb5f6f61c2e971e57663
+
+[patch-files]
+strip = 1
+patches = ['0001.patch', '0002.patch']
+```

--- a/test cases/common/153 wrap file should not failed/meson.build
+++ b/test cases/common/153 wrap file should not failed/meson.build
@@ -14,3 +14,8 @@ executable('grabprog2', files('src/subprojects/foo/prog2.c'))
 subdir('src')
 
 subproject('patchdir')
+
+if find_program('patch', required : false).found() or find_program('git', required : false).found()
+  exe = subproject('patchfile').get_variable('foo_exe')
+  test('test_foo', exe)
+endif

--- a/test cases/common/153 wrap file should not failed/subprojects/packagefiles/patchfile/0001-Change-foo-to-executable.patch
+++ b/test cases/common/153 wrap file should not failed/subprojects/packagefiles/patchfile/0001-Change-foo-to-executable.patch
@@ -1,0 +1,33 @@
+From b79f6cc4a096f6c2888f73b947b652491885896a Mon Sep 17 00:00:00 2001
+From: Xavier Claessens <xavier.claessens@collabora.com>
+Date: Fri, 30 Nov 2018 14:13:47 -0500
+Subject: [PATCH] Change foo to executable
+
+---
+ foo.c       | 4 ++++
+ meson.build | 2 +-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/foo.c b/foo.c
+index 54f9119..468f033 100644
+--- a/foo.c
++++ b/foo.c
+@@ -1,3 +1,7 @@
+ int dummy_func(void) {
+     return 44;
+ }
++
++int main(void) {
++    return dummy_func() == 44 ? 0 : 1;
++}
+diff --git a/meson.build b/meson.build
+index 318e81d..4a281d9 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1,2 +1,2 @@
+ project('static lib patchdir', 'c')
+-libfoo = static_library('foo', 'foo.c')
++foo_exe = executable('foo', 'foo.c')
+-- 
+2.17.1
+

--- a/test cases/common/153 wrap file should not failed/subprojects/packagefiles/patchfile/0001-Change-return-value-to-43.patch
+++ b/test cases/common/153 wrap file should not failed/subprojects/packagefiles/patchfile/0001-Change-return-value-to-43.patch
@@ -1,0 +1,21 @@
+From 7001dcc738e5ae7dfa8af20ed582b9a985804f72 Mon Sep 17 00:00:00 2001
+From: Xavier Claessens <xavier.claessens@collabora.com>
+Date: Fri, 30 Nov 2018 10:15:33 -0500
+Subject: [PATCH 1/2] Change return value to 43
+
+---
+ foo.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/foo.c b/foo.c
+index 019f2ba..e4577b8 100644
+--- a/foo.c
++++ b/foo.c
+@@ -1,3 +1,3 @@
+ int dummy_func(void) {
+-    return 42;
++    return 43;
+ }
+-- 
+2.17.1
+

--- a/test cases/common/153 wrap file should not failed/subprojects/packagefiles/patchfile/0002-Change-return-value-to-44.patch
+++ b/test cases/common/153 wrap file should not failed/subprojects/packagefiles/patchfile/0002-Change-return-value-to-44.patch
@@ -1,0 +1,21 @@
+From c2da2e490b09f2e251c7f4ef7c1240acee215fec Mon Sep 17 00:00:00 2001
+From: Xavier Claessens <xavier.claessens@collabora.com>
+Date: Fri, 30 Nov 2018 10:15:47 -0500
+Subject: [PATCH 2/2] Change return value to 44
+
+---
+ foo.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/foo.c b/foo.c
+index e4577b8..54f9119 100644
+--- a/foo.c
++++ b/foo.c
+@@ -1,3 +1,3 @@
+ int dummy_func(void) {
+-    return 43;
++    return 44;
+ }
+-- 
+2.17.1
+

--- a/test cases/common/153 wrap file should not failed/subprojects/patchfile.wrap
+++ b/test cases/common/153 wrap file should not failed/subprojects/patchfile.wrap
@@ -1,0 +1,15 @@
+[wrap-file]
+directory = foo-1.0-patchfile
+
+source_url = http://something.invalid
+source_filename = foo-1.0.tar.xz
+source_hash = 9ed8f67d75e43d3be161efb6eddf30dd01995a958ca83951ea64234bac8908c1
+lead_directory_missing = true
+
+patch_directory = foo-1.0
+
+[patch-files]
+patches = ['patchfile/0001-Change-return-value-to-43.patch',
+           'patchfile/0002-Change-return-value-to-44.patch',
+           'patchfile/0001-Change-foo-to-executable.patch',
+          ]


### PR DESCRIPTION
This replaces my previous idea from PR https://github.com/mesonbuild/meson/pull/4382.

Patch files are commonly used, that's what distro use and it makes sense to be able to just copy the patch file from distro for example. It does not replace the `patch_filename` tarball we already have because that one serve a different purpose, tailored for wrapdb (doesn't require external command-line tool, less subject to conflict when used to only drop meson.build files).