### PR TITLE
coverage: Print summary after gcovr html generation

### DIFF
--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -104,13 +104,14 @@ def coverage(outputs, source_root, subproject_root, build_root, log_dir):
             subprocess.check_call([gcovr_exe,
                                    '--html',
                                    '--html-details',
+                                   '--print-summary',
                                    '-r', build_root,
                                    '-e', subproject_root,
                                    '-o', os.path.join(htmloutdir, 'index.html'),
                                    ])
             outfiles.append(('Html', pathlib.Path(htmloutdir, 'index.html')))
         elif outputs:
-            print('lcov/genhtml or gcovr >= 3.1 needed to generate Html coverage report')
+            print('lcov/genhtml or gcovr >= 3.2 needed to generate Html coverage report')
             exitcode = 1
 
     if not outputs and not outfiles:


### PR DESCRIPTION
summary from stdout is often used by Automated builds to show build details

The --print-summary option was added to gcovr in v3.2, since html output
was added only in 3.1, limitting support to 3.2 won’t be a big deal.

--print-summary is not enabled for text/xml report generation as it will
result in meson not supporting any gcovr version less than 3.2.