### PR TITLE
pkgconfig: do not generated dependency on itself

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -93,7 +93,7 @@ class DependenciesHelper:
                 for d in pcdeps:
                     processed_reqs.append(d.name)
                     self.add_version_reqs(d.name, obj.version_reqs)
-            elif hasattr(obj, 'generated_pc'):
+            elif hasattr(obj, 'generated_pc') and obj.generated_pc != self.name:
                 processed_reqs.append(obj.generated_pc)
             elif isinstance(obj, dependencies.PkgConfigDependency):
                 if obj.found():


### PR DESCRIPTION
If a project generates a single pc file but multiple shared libraries
with dependencies on each other, the generated pc name will be used to
generate a Requires.private dependency, which means the project will
depend on itself. This breaks at least some versions of pkg-config
(0.27 in RHEL7) which cannot handle the recursion and error out.

When adding the dependency using the pc name, check that it's not
on the project itself.

Fixes #4583