### PR TITLE
modules/python: Do not override link_args with None largs

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -151,8 +151,8 @@ class PythonDependency(ExternalDependency):
         largs = self.clib_compiler.find_library(libname, environment, libdirs)
 
         self.is_found = largs is not None
-
-        self.link_args = largs
+        if self.is_found:
+            self.link_args = largs
 
         inc_paths = mesonlib.OrderedSet([
             self.variables.get('INCLUDEPY'),


### PR DESCRIPTION
None is not iterable so it would trigger a TypeError later when link_args are
passed on to CompilerArgs.extend_direct().

I found this issue when using gst-build with Meson 0.48.2 installed for Python 3.7.