### PR TITLE
Various arch detection fixes.

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -252,13 +252,17 @@ def detect_cpu_family(compilers):
     elif trial in ('amd64', 'x64'):
         trial = 'x86_64'
 
-    # On Linux (and maybe others) there can be any mixture of 32/64 bit
-    # code in the kernel, Python, system etc. The only reliable way
-    # to know is to check the compiler defines.
+    # On Linux (and maybe others) there can be any mixture of 32/64 bit code in
+    # the kernel, Python, system, 32-bit chroot on 64-bit host, etc. The only
+    # reliable way to know is to check the compiler defines.
     if trial == 'x86_64':
         if any_compiler_has_define(compilers, '__i386__'):
             trial = 'x86'
-    # Add more quirks here as bugs are reported.
+    elif trial == 'aarch64':
+        if any_compiler_has_define(compilers, '__arm__'):
+            trial = 'arm'
+    # Add more quirks here as bugs are reported. Keep in sync with detect_cpu()
+    # below.
 
     if trial not in known_cpu_families:
         mlog.warning('Unknown CPU family {!r}, please report this at '
@@ -278,10 +282,15 @@ def detect_cpu(compilers):
         # Same check as above for cpu_family
         if any_compiler_has_define(compilers, '__i386__'):
             trial = 'i686' # All 64 bit cpus have at least this level of x86 support.
+    elif trial == 'aarch64':
+        # Same check as above for cpu_family
+        if any_compiler_has_define(compilers, '__arm__'):
+            trial = 'arm'
     elif trial == 'e2k':
         # Make more precise CPU detection for Elbrus platform.
         trial = platform.processor().lower()
-    # Add more quirks here as bugs are reported.
+    # Add more quirks here as bugs are reported. Keep in sync with
+    # detect_cpu_family() above.
     return trial
 
 def detect_system():

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -185,17 +185,23 @@ def detect_windows_arch(compilers):
             if float(compiler.get_toolset_version()) < 10.0:
                 # On MSVC 2008 and earlier, check 'BUILD_PLAT', where
                 # 'Win32' means 'x86'
-                platform = os.environ.get('BUILD_PLAT', 'x86')
+                platform = os.environ.get('BUILD_PLAT', os_arch)
                 if platform == 'Win32':
                     return 'x86'
             elif 'VSCMD_ARG_TGT_ARCH' in os.environ:
                 # On MSVC 2017 'Platform' is not set in VsDevCmd.bat
                 return os.environ['VSCMD_ARG_TGT_ARCH']
             else:
-                # On MSVC 2010 and later 'Platform' is only set when the
+                # Starting with VS 2017, `Platform` is not always set (f.ex.,
+                # if you use VsDevCmd.bat directly instead of vcvars*.bat), but
+                # `VSCMD_ARG_HOST_ARCH` is always set, so try that first.
+                if 'VSCMD_ARG_HOST_ARCH' in os.environ:
+                    platform = os.environ['VSCMD_ARG_HOST_ARCH'].lower()
+                # On VS 2010-2015, 'Platform' is only set when the
                 # target arch is not 'x86'.  It's 'x64' when targeting
                 # x86_64 and 'arm' when targeting ARM.
-                platform = os.environ.get('Platform', 'x86').lower()
+                else:
+                    platform = os.environ.get('Platform', 'x86').lower()
             if platform == 'x86':
                 return platform
         if compiler.id == 'clang-cl' and not compiler.is_64:


### PR DESCRIPTION
```
commit b2807e49e3915a3e43a48c4932798aa298fadf77

    Fix detection with VS 2017, and fix a bug in detection on VS 2008

    Starting with VS 2017, `Platform` is not always set (f.ex., if you use
    VsDevCmd.bat directly instead of vcvars*.bat), but `VSCMD_ARG_HOST_ARCH`
    is always set, so try that first.
```

This one should definitely go into 0.49.0.

```
commit 51abb4c6ff22c85a0dee050388f7d01d2c86b2a2

    Reorganize cpu detection code to be more consistent

    Use a single point of exit for the detect_cpu* functions, and factor
    out the compiler define code into a helper function.
```

```
commit 724aae5149096ded799d27ac7c41376c322e3ef7

    Correctly detect 32-bit arm userland on 64-bit arm

    This is the same case as 32-bit x86 on x86_64.

    Closes https://github.com/mesonbuild/meson/issues/4586
```

These two could optionally not go in, but would be nice to have too.