### PR TITLE
coverage: Also remove source_root prefixes

### DIFF
--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -93,6 +93,7 @@ def coverage(outputs, source_root, subproject_root, build_root, log_dir):
                                    '--output-file', covinfo])
             subprocess.check_call([genhtml_exe,
                                    '--prefix', build_root,
+                                   '--prefix', source_root,
                                    '--output-directory', htmloutdir,
                                    '--title', 'Code coverage',
                                    '--legend',


### PR DESCRIPTION
The code our projects care about verifying coverage for mostly lives in
the source_root with the exception of the generated source files in
build_root. This change cleans up the output so we don't have prefixed
paths on our source files anymore.