### PR TITLE
Dependency fallbacks

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -439,6 +439,10 @@ arguments:
   [`dependency()`](#dependency), etc. Note that this means the
   fallback dependency may be a not-found dependency, in which
   case the value of the `required:` kwarg will be obeyed.
+  *Since 0.53.0* `'subproj_dep'` argument can be omitted in the case the
+  subproject used `meson.override_dependency('dependency_name', subproj_dep)`.
+  In that case, the `fallback` keyword argument can be a single string instead
+  of a list of 2 strings.
 - `language` *(added 0.42.0)* defines what language-specific
   dependency to find if it's available for multiple languages.
 - `method` defines the way the dependency is detected, the default is

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1725,7 +1725,10 @@ the following methods.
   0.53.0)*](Release-notes-for-0.50.0.md#can-override-dependency)
   specifies that whenever `dependency(name, ...)` is used, Meson should not
   look it up on the system but instead return `dep_object`, which may either be
-  the result of `dependency()` or `declare_dependency()`.
+  the result of `dependency()` or `declare_dependency()`. It takes optional
+  `native` keyword arguments. Doing this in a subproject allows the parent
+  project to retrieve the dependency without having to know the dependency
+  variable name: `dependency(name, fallback : subproject_name)`.
 
 - `project_version()` returns the version string specified in
   `project` function call.

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1711,11 +1711,17 @@ the following methods.
 - `override_find_program(progname, program)` [*(Added
   0.46.0)*](Release-notes-for-0.46.0.md#can-override-find_program)
   specifies that whenever `find_program` is used to find a program
-  named `progname`, Meson should not not look it up on the system but
+  named `progname`, Meson should not look it up on the system but
   instead return `program`, which may either be the result of
   `find_program`, `configure_file` or `executable`.
 
   If `program` is an `executable`, it cannot be used during configure.
+
+- `override_dependency(name, dep_object)` [*(Added
+  0.53.0)*](Release-notes-for-0.50.0.md#can-override-dependency)
+  specifies that whenever `dependency(name, ...)` is used, Meson should not
+  look it up on the system but instead return `dep_object`, which may either be
+  the result of `dependency()` or `declare_dependency()`.
 
 - `project_version()` returns the version string specified in
   `project` function call.

--- a/docs/markdown/snippets/override_dependency.md
+++ b/docs/markdown/snippets/override_dependency.md
@@ -1,0 +1,53 @@
+## `dependency()` consistency
+
+The first time a dependency is found, using `dependency('foo', ...)`, the return
+value is now cached. Any subsequent call will return the same value as long as
+version requested match, otherwise not-found dependency is returned. This means
+that if a system dependency is first found, it won't fallback to a subproject
+in a subsequent call any more and will rather return not-found instead if the
+system version does not match. Similarly, if the first call returns the subproject
+fallback dependency, it will also return the subproject dependency in a subsequent
+call even if no fallback is provided.
+
+For example, if the system has `foo` version 1.0:
+```meson
+# d2 is set to foo_dep and not the system dependency, even without fallback argument.
+d1 = dependency('foo', version : '>=2.0', required : false,
+                fallback : ['foo', 'foo_dep'])
+d2 = dependency('foo', version : '>=1.0', required : false)
+```
+```meson
+# d2 is not-found because the first call returned the system dependency, but its version is too old for 2nd call.
+d1 = dependency('foo', version : '>=1.0', required : false)
+d2 = dependency('foo', version : '>=2.0', required : false,
+                fallback : ['foo', 'foo_dep'])
+```
+
+## Override `dependency()`
+
+It is now possible to override the result of `dependency()` to point
+to any dependency object you want. The overriding is global and applies to
+every subproject from there on.
+
+For example, this subproject provides 2 libraries with version 2.0:
+
+```meson
+project(..., version : '2.0')
+
+libfoo = library('foo', ...)
+foo_dep = declare_dependency(link_with : libfoo)
+meson.override_dependency('foo', foo_dep)
+
+libbar = library('bar', ...)
+bar_dep = declare_dependency(link_with : libbar)
+meson.override_dependency('bar', bar_dep)
+```
+
+Assuming the system has `foo` and `bar` 1.0 installed, and master project does this:
+```meson
+foo_dep = dependency('foo', version : '>=2.0', fallback : ['foo', 'foo_dep'])
+bar_dep = dependency('bar')
+```
+
+This used to mix system 1.0 version and subproject 2.0 dependencies, but thanks
+to the override `bar_dep` is now set to the subproject's version instead.

--- a/docs/markdown/snippets/override_dependency.md
+++ b/docs/markdown/snippets/override_dependency.md
@@ -51,3 +51,9 @@ bar_dep = dependency('bar')
 
 This used to mix system 1.0 version and subproject 2.0 dependencies, but thanks
 to the override `bar_dep` is now set to the subproject's version instead.
+
+## Simplified `dependency()` fallback
+
+In the case a subproject `foo` calls `meson.override_dependency('foo-2.0', foo_dep)`,
+the parent project can omit the dependency variable name in fallback keyword
+argument: `dependency('foo-2.0', fallback : 'foo')`.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -141,6 +141,7 @@ class Build:
         self.test_setup_default_name = None
         self.find_overrides = {}
         self.searched_programs = set() # The list of all programs that have been searched for.
+        self.dependency_overrides = PerMachine({}, {})
 
     def copy(self):
         other = Build(self.environment)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -106,6 +106,12 @@ def get_target_macos_dylib_install_name(ld) -> str:
 class InvalidArguments(MesonException):
     pass
 
+class DependencyOverride:
+    def __init__(self, dep, node, explicit=True):
+        self.dep = dep
+        self.node = node
+        self.explicit = explicit
+
 class Build:
     """A class that holds the status of one build including
     all dependencies and so on.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -22,6 +22,7 @@ from . import compilers
 from .wrap import wrap, WrapMode
 from . import mesonlib
 from .mesonlib import FileMode, MachineChoice, Popen_safe, listify, extract_as_list, has_path_sep
+from .mesonlib import node_to_location_string
 from .dependencies import ExternalProgram
 from .dependencies import InternalDependency, Dependency, NotFoundDependency, DependencyException
 from .depfile import DepFile
@@ -1932,17 +1933,19 @@ class MesonMain(InterpreterObject):
         name = args[0]
         dep = args[1]
         if not isinstance(name, str) or not name:
-            raise InterpreterException('First argument must be not empty string')
+            raise InterpreterException('First argument must be a string and cannot be empty')
         if hasattr(dep, 'held_object'):
             dep = dep.held_object
         if not isinstance(dep, dependencies.Dependency):
             raise InterpreterException('Second argument must be a dependency object')
         identifier = dependencies.get_dep_identifier(name, kwargs)
         for_machine = self.interpreter.machine_from_native_kwarg(kwargs)
-        if identifier in self.build.dependency_overrides[for_machine]:
-            raise InterpreterException('Tried to override dependency "%s" which has already been overridden.'
-                                       % name)
-        self.build.dependency_overrides[for_machine][identifier] = dep
+        override = self.build.dependency_overrides[for_machine].get(identifier)
+        if override:
+            m = 'Tried to override dependency {!r} which has already been resolved or overridden at {}'
+            raise InterpreterException(m.format(name, node_to_location_string(override.node)))
+        self.build.dependency_overrides[for_machine][identifier] = \
+            build.DependencyOverride(dep, self.interpreter.current_node)
 
     @noPosargs
     @permittedKwargs({})
@@ -3034,14 +3037,16 @@ external dependencies (including libraries) must go to "dependencies".''')
         identifier = dependencies.get_dep_identifier(name, kwargs)
         wanted_vers = mesonlib.stringlistify(kwargs.get('version', []))
 
-        cached_dep = self.build.dependency_overrides[for_machine].get(identifier)
-        if cached_dep:
+        override = self.build.dependency_overrides[for_machine].get(identifier)
+        if override:
+            info = [mlog.blue('(overridden)' if override.explicit else '(cached)')]
+            cached_dep = override.dep
             # We don't implicitly override not-found dependencies, but user could
             # have explicitly called meson.override_dependency() with a not-found
             # dep.
             if not cached_dep.found():
                 mlog.log('Dependency', mlog.bold(name),
-                         'found:', mlog.red('NO'), mlog.blue('(cached)'))
+                         'found:', mlog.red('NO'), *info)
                 return identifier, cached_dep
             found_vers = cached_dep.get_version()
             if not self.check_version(wanted_vers, found_vers):
@@ -3049,9 +3054,10 @@ external dependencies (including libraries) must go to "dependencies".''')
                          'found:', mlog.red('NO'),
                          'found', mlog.normal_cyan(found_vers), 'but need:',
                          mlog.bold(', '.join(["'{}'".format(e) for e in wanted_vers])),
-                         mlog.blue('(cached)'))
+                         *info)
                 return identifier, NotFoundDependency(self.environment)
         else:
+            info = [mlog.blue('(cached)')]
             cached_dep = self.coredata.deps[for_machine].get(identifier)
             if cached_dep:
                 found_vers = cached_dep.get_version()
@@ -3059,7 +3065,6 @@ external dependencies (including libraries) must go to "dependencies".''')
                     return identifier, None
 
         if cached_dep:
-            info = [mlog.blue('(cached)')]
             if found_vers:
                 info = [mlog.normal_cyan(found_vers), *info]
             mlog.log('Dependency', mlog.bold(name),
@@ -3174,7 +3179,8 @@ external dependencies (including libraries) must go to "dependencies".''')
             for_machine = self.machine_from_native_kwarg(kwargs)
             identifier = dependencies.get_dep_identifier(name, kwargs)
             if identifier not in self.build.dependency_overrides[for_machine]:
-                self.build.dependency_overrides[for_machine][identifier] = d.held_object
+                self.build.dependency_overrides[for_machine][identifier] = \
+                    build.DependencyOverride(d.held_object, node, explicit=False)
         return d
 
     def dependency_impl(self, name, display_name, kwargs):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3036,6 +3036,13 @@ external dependencies (including libraries) must go to "dependencies".''')
 
         cached_dep = self.build.dependency_overrides[for_machine].get(identifier)
         if cached_dep:
+            # We don't implicitly override not-found dependencies, but user could
+            # have explicitly called meson.override_dependency() with a not-found
+            # dep.
+            if not cached_dep.found():
+                mlog.log('Dependency', mlog.bold(name),
+                         'found:', mlog.red('NO'), mlog.blue('(cached)'))
+                return identifier, cached_dep
             found_vers = cached_dep.get_version()
             if not self.check_version(wanted_vers, found_vers):
                 mlog.log('Dependency', mlog.bold(name),

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -1327,6 +1327,11 @@ def detect_subprojects(spdir_name, current_dir='', result=None):
 def get_error_location_string(fname: str, lineno: str) -> str:
     return '{}:{}:'.format(fname, lineno)
 
+def node_to_location_string(node) -> str:
+    from .environment import build_filename
+    location_file = os.path.join(node.subdir, build_filename)
+    return get_error_location_string(location_file, node.lineno)
+
 def substring_is_in_list(substr: str, strlist: typing.List[str]) -> bool:
     for s in strlist:
         if substr in s:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3675,7 +3675,7 @@ recommended as it is not supported on some platforms''')
                 {
                     'descriptive_name': 'sub',
                     'name': 'sub',
-                    'version': 'undefined'
+                    'version': '1.0'
                 }
             ]
         }
@@ -4189,7 +4189,7 @@ class FailureTests(BasePlatformTests):
             raise unittest.SkipTest('zlib not found with pkg-config')
         a = (("dependency('zlib', method : 'fail')", "'fail' is invalid"),
              ("dependency('zlib', static : '1')", "[Ss]tatic.*boolean"),
-             ("dependency('zlib', version : 1)", "[Vv]ersion.*string or list"),
+             ("dependency('zlib', version : 1)", "Item must be a list or one of <class 'str'>"),
              ("dependency('zlib', required : 1)", "[Rr]equired.*boolean"),
              ("dependency('zlib', method : 1)", "[Mm]ethod.*string"),
              ("dependency('zlibfail')", self.dnf),)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3676,10 +3676,16 @@ recommended as it is not supported on some platforms''')
                     'descriptive_name': 'sub',
                     'name': 'sub',
                     'version': '1.0'
-                }
+                },
+                {
+                    'descriptive_name': 'sub-novar',
+                    'name': 'sub_novar',
+                    'version': '1.0',
+                },
             ]
         }
-        self.assertDictEqual(res, expected)
+        res['subprojects'] = sorted(res['subprojects'], key=lambda i: i['name'])
+        self.assertDictEqual(expected, res)
 
     def test_introspection_target_subproject(self):
         testdir = os.path.join(self.common_test_dir, '45 subproject')

--- a/test cases/common/102 subproject subdir/meson.build
+++ b/test cases/common/102 subproject subdir/meson.build
@@ -4,3 +4,16 @@ libSub = dependency('sub', fallback: ['sub', 'libSub'])
 
 exe = executable('prog', 'prog.c', dependencies: libSub)
 test('subproject subdir', exe)
+
+# Verify the subproject has placed dependency override.
+dependency('sub-1.0')
+
+# Verify we can now take 'sub' dependency without fallback, but only version 1.0.
+dependency('sub')
+d = dependency('sub', version : '>=2.0', required : false)
+assert(not d.found(), 'version should not match')
+
+# Verify that not-found does not get cached, we can still fallback afterward.
+dependency('sub2', required : false)
+d = dependency('sub2', fallback: ['sub', 'libSub'])
+assert(d.found(), 'Should fallback even if a previous call returned not-found')

--- a/test cases/common/102 subproject subdir/meson.build
+++ b/test cases/common/102 subproject subdir/meson.build
@@ -17,3 +17,7 @@ assert(not d.found(), 'version should not match')
 dependency('sub2', required : false)
 d = dependency('sub2', fallback: ['sub', 'libSub'])
 assert(d.found(), 'Should fallback even if a previous call returned not-found')
+
+# Verify we can get a fallback dependency without specifying the variable name,
+# because the subproject overridden 'sub-novar'.
+dependency('sub-novar', fallback : 'sub_novar')

--- a/test cases/common/102 subproject subdir/meson.build
+++ b/test cases/common/102 subproject subdir/meson.build
@@ -21,3 +21,7 @@ assert(d.found(), 'Should fallback even if a previous call returned not-found')
 # Verify we can get a fallback dependency without specifying the variable name,
 # because the subproject overridden 'sub-novar'.
 dependency('sub-novar', fallback : 'sub_novar')
+
+# Verify a subproject can force a dependency to be not-found
+d = dependency('sub-notfound', fallback : 'sub_novar', required : false)
+assert(not d.found(), 'Dependency should be not-found')

--- a/test cases/common/102 subproject subdir/subprojects/sub/lib/meson.build
+++ b/test cases/common/102 subproject subdir/subprojects/sub/lib/meson.build
@@ -1,2 +1,3 @@
 lib = static_library('sub', 'sub.c')
 libSub = declare_dependency(include_directories: include_directories('.'), link_with: lib)
+meson.override_dependency('sub-1.0', libSub)

--- a/test cases/common/102 subproject subdir/subprojects/sub/meson.build
+++ b/test cases/common/102 subproject subdir/subprojects/sub/meson.build
@@ -1,2 +1,2 @@
-project('sub', 'c')
+project('sub', 'c', version : '1.0')
 subdir('lib')

--- a/test cases/common/102 subproject subdir/subprojects/sub_novar/meson.build
+++ b/test cases/common/102 subproject subdir/subprojects/sub_novar/meson.build
@@ -1,0 +1,3 @@
+project('sub-novar', 'c', version : '1.0')
+
+meson.override_dependency('sub-novar', declare_dependency())

--- a/test cases/common/102 subproject subdir/subprojects/sub_novar/meson.build
+++ b/test cases/common/102 subproject subdir/subprojects/sub_novar/meson.build
@@ -1,3 +1,4 @@
 project('sub-novar', 'c', version : '1.0')
 
 meson.override_dependency('sub-novar', declare_dependency())
+meson.override_dependency('sub-notfound', dependency('', required : false))

--- a/test cases/common/229 dependency fallbacks/meson.build
+++ b/test cases/common/229 dependency fallbacks/meson.build
@@ -1,0 +1,45 @@
+project('dependency fallbacks', 'c')
+
+cc = meson.get_compiler('c')
+
+# Use different dependency name for each case to bypass caching
+
+fallbacks = dependency_fallbacks()
+fallbacks.dependency('')
+d = dependency('test1', fallbacks, required: false)
+assert(not d.found(), 'Should not be found')
+
+fallbacks = dependency_fallbacks()
+fallbacks.dependency('zlib')
+d = dependency('test2', fallbacks)
+assert(d.found(), 'Should be found')
+
+fallbacks = dependency_fallbacks()
+fallbacks.has_function(cc, 'donotexist')
+d = dependency('test3', fallbacks, required: false)
+assert(not d.found(), 'Should not be found')
+
+fallbacks = dependency_fallbacks()
+fallbacks.has_function(cc, 'malloc')
+d = dependency('test4', fallbacks)
+assert(d.found(), 'Should be found')
+
+fallbacks = dependency_fallbacks()
+fallbacks.find_library(cc, 'z', has_headers: 'notfound.h')
+d = dependency('test5', fallbacks, required : false)
+assert(not d.found(), 'Should not be found')
+
+fallbacks = dependency_fallbacks()
+fallbacks.find_library(cc, 'z', has_headers: 'zlib.h')
+d = dependency('test6', fallbacks)
+assert(d.found(), 'Should be found')
+
+# Real-life case
+fallbacks = dependency_fallbacks()
+fallbacks.dependency('libxml2')
+fallbacks.dependency('libxml-2.0')
+fallbacks.find_library(cc, 'xml2', has_headers: 'libxml/tree.h')
+fallbacks.find_library(cc, 'libxml2', has_headers: 'libxml/tree.h')
+fallbacks.subproject('xml2', variable: 'xml2_dep')
+d = dependency('xml2', fallbacks)
+assert(d.found(), 'Should be found')

--- a/test cases/common/229 dependency fallbacks/subprojects/xml2/meson.build
+++ b/test cases/common/229 dependency fallbacks/subprojects/xml2/meson.build
@@ -1,0 +1,3 @@
+project('xml2')
+
+xml2_dep = declare_dependency()

--- a/test cases/linuxlike/5 dependency versions/meson.build
+++ b/test cases/linuxlike/5 dependency versions/meson.build
@@ -38,32 +38,32 @@ somelibver = dependency('somelib',
   fallback : ['somelibnover', 'some_dep'])
 assert(somelibver.type_name() == 'internal', 'somelibver should be of type "internal", not ' + somelibver.type_name())
 # Find an internal dependency again with the same name and a specific version
-somelib = dependency('somelib',
+somelib = dependency('somelib2',
   version : '== 0.1',
   fallback : ['somelib', 'some_dep'])
 # Find an internal dependency again even if required = false
-somelib_reqfalse = dependency('somelib',
+somelib_reqfalse = dependency('somelib3',
   required: false,
   fallback : ['somelib', 'some_dep'])
 assert(somelib_reqfalse.found(), 'somelib should have been found')
 # Find an internal dependency again with the same name and incompatible version
-somelibver = dependency('somelib',
+somelibver = dependency('somelib4',
   version : '>= 0.3',
   fallback : ['somelibver', 'some_dep'])
 # Find an internal dependency again with impossible multi-version
-somelibver = dependency('somelib',
+somelibver = dependency('somelib5',
   version : ['>= 0.3', '<0.3'],
   required : false,
   fallback : ['somelibver', 'some_dep'])
 assert(not somelibver.found(), 'Dependency should not be found')
 # Find somelib again, but with a fallback that will fail because subproject does not exist
-somelibfail = dependency('somelib',
+somelibfail = dependency('somelib6',
   version : '>= 0.2',
   required : false,
   fallback : ['somelibfail', 'some_dep'])
 assert(somelibfail.found() == false, 'somelibfail found via wrong fallback')
 # Find somelib again, but with a fallback that will fail because dependency does not exist
-somefail_dep = dependency('somelib',
+somefail_dep = dependency('somelib7',
   version : '>= 0.2',
   required : false,
   fallback : ['somelib', 'somefail_dep'])
@@ -78,6 +78,13 @@ assert(fallbackzlib_dep.type_name() == 'pkgconfig', 'fallbackzlib_dep should be 
 fakezlib_dep = dependency('fakezlib',
   fallback : ['somelib', 'fakezlib_dep'])
 assert(fakezlib_dep.type_name() == 'internal', 'fakezlib_dep should be of type "internal", not ' + fakezlib_dep.type_name())
+
+# Verify that once we got a system dependency, we won't fallback if a newer
+# version is requested.
+d = dependency('zlib', version: '>= 999',
+  fallback : ['somelib', 'some_dep'],
+  required: false)
+assert(not d.found(), 'version should not match and it should not fallback')
 
 # Check that you can find a dependency by not specifying a version after not
 # finding it by specifying a version. We add `static: true` here so that the


### PR DESCRIPTION
I had the crazy idea of using dict to create a list of dependency fallbacks:
```meson
cc = meson.get_compiler('c')
libfoo_fallbacks = [
  # Check for pkg-config name first
  'foo',
  # Check for an alternative pkg-config name
  'libfoo-1.0',
  # Check for a C library with headers
  {
    'compiler' : cc,
    'library' : 'foo',
    'headers' : ['foo.h']
  },
  # Check for an alternative library name
  {
    'compiler' : cc,
    'library' : 'libfoo-1.0',
    'headers' : ['foo.h']
  },
  # Fallback to a subproject
  {
    'subproject' : 'foo',
    'dependency' : 'libfoo_dep'
  },
]
libfoo_dep = dependecy(libfoo_fallbacks, required : get_option('some_feature'))
```