### PR TITLE
Reinstate "compilers/c: Fix allow undefined link arg for PE/COFF"

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1538,6 +1538,9 @@ class GnuLikeCompiler(abc.ABC):
         if self.compiler_type.is_osx_compiler:
             # Apple ld
             return ['-Wl,-undefined,dynamic_lookup']
+        elif self.compiler_type.is_windows_compiler:
+            # For PE/COFF this is impossible
+            return []
         else:
             # GNU ld and LLVM lld
             return ['-Wl,--allow-shlib-undefined']


### PR DESCRIPTION
This reinstates 2256e6314b610b8f6645d0c5384536001ddeccf9, which was
lost in refactoring in 9f9cfd21396db5cd5eb1711916c8b0c6e433c702.