### PR TITLE
pkgconfig: Fix link order of library dependencies

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -35,13 +35,13 @@ class DependenciesHelper:
 
     def add_pub_libs(self, libs):
         libs, reqs, cflags = self._process_libs(libs, True)
-        self.pub_libs += libs
+        self.pub_libs = libs + self.pub_libs # prepend to preserve dependencies
         self.pub_reqs += reqs
         self.cflags += cflags
 
     def add_priv_libs(self, libs):
         libs, reqs, _ = self._process_libs(libs, False)
-        self.priv_libs += libs
+        self.priv_libs = libs + self.priv_libs
         self.priv_reqs += reqs
 
     def add_pub_reqs(self, reqs):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4274,6 +4274,19 @@ endian = 'little'
 
         self.assertEqual("-r/usr/lib/libsomething.dll", str(stdo.decode('ascii')).strip())
 
+    @skipIfNoPkgconfig
+    def test_pkgconfig_link_order(self):
+        '''
+        Test that libraries are listed before their dependencies.
+        '''
+        testdir = os.path.join(self.unit_test_dir, '50 pkgconfig static link order')
+        self.init(testdir)
+        myenv = os.environ.copy()
+        myenv['PKG_CONFIG_PATH'] = self.privatedir
+        stdo = subprocess.check_output(['pkg-config', '--libs', 'libsomething'], env=myenv)
+        deps = stdo.split()
+        self.assertTrue(deps.index(b'-lsomething') < deps.index(b'-ldependency'))
+
     def test_deterministic_dep_order(self):
         '''
         Test that the dependencies are always listed in a deterministic order.

--- a/test cases/unit/50 pkgconfig static link order/meson.build
+++ b/test cases/unit/50 pkgconfig static link order/meson.build
@@ -1,0 +1,11 @@
+project('link order test', 'c')
+
+dep = library('dependency', [])
+lib = static_library('something', [], link_with: dep)
+
+import('pkgconfig').generate(
+  name: 'libsomething',
+  description: 'test library',
+  libraries: lib,
+  version: '1'
+)


### PR DESCRIPTION
Since `_process_libs` appends the lib's dependencies this list already,
the final return value of `_process_libs` will end up after its
dependencies, which is the wrong way around. (The lib must come first,
then its dependencies)

The easiest solution is to simply pre-pend the return value of
`_process_libs` rather than appending it, so that its dependencies come
after the library itself.

Closes #4091.