### PR TITLE
Skip if a suitable D alternative is not found.

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4816,7 +4816,9 @@ class NativeFileTests(BasePlatformTests):
                     return 'gdc', 'gdc'
                 else:
                     raise unittest.SkipTest('No alternative dlang compiler found.')
-            return 'dmd', 'dmd'
+            if shutil.which('dmd'):
+                return 'dmd', 'dmd'
+            raise unittest.SkipTest('No alternative dlang compiler found.')
         self.helper_for_compiler('d', cb)
 
     @skip_if_not_language('cs')


### PR DESCRIPTION
Dunno if this is the correct thing to do, but this error is blocking the 0.49.0 release.