### PR TITLE
Only autodetect 'vs' backend on windows

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -38,7 +38,7 @@ def guess_backend(backend, msbuild_exe):
     # Auto-detect backend if unspecified
     backend_flags = []
     if backend is None:
-        if msbuild_exe is not None:
+        if msbuild_exe is not None and mesonlib.is_windows():
             backend = 'vs' # Meson will auto-detect VS version to use
         else:
             backend = 'ninja'


### PR DESCRIPTION
Currently `run_tests.py` determines the backend to use only by checking if `msbuild` [is installed](https://github.com/mesonbuild/meson/blob/master/run_tests.py#L263). However, it is also possible to install `msbuild` [on Linux](https://aur.archlinux.org/packages/msbuild-stable/) to build VS C# projects (like KSP mods). In this case `run_tests.py` will try to use the `vs` backend, which always fails because visual studio itself is not installed.