### PR TITLE
Go through coreutils.compiler_options.{build.host.target}

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -31,7 +31,7 @@ from .. import dependencies
 from .. import compilers
 from ..compilers import CompilerArgs, CCompiler, VisualStudioCCompiler
 from ..linkers import ArLinker
-from ..mesonlib import File, MesonException, OrderedSet
+from ..mesonlib import File, MachineChoice, MesonException, OrderedSet
 from ..mesonlib import get_compiler_for_source, has_path_sep
 from .backends import CleanTrees
 from ..build import InvalidArguments
@@ -1460,7 +1460,7 @@ int dummy;
                         or langname == 'cs':
                     continue
                 crstr = ''
-                cross_args = self.environment.properties.host.get_external_link_args(langname)
+                cross_args = self.environment.coredata.get_external_link_args(MachineChoice.HOST, langname)
                 if is_cross:
                     crstr = '_CROSS'
                 rule = 'rule %s%s_LINKER\n' % (langname, crstr)
@@ -2467,6 +2467,11 @@ rule FORTRAN_DEP_HACK%s
         if not isinstance(target, build.StaticLibrary):
             commands += self.get_link_whole_args(linker, target)
 
+        if self.environment.is_cross_build() and not target.is_cross:
+            for_machine = MachineChoice.BUILD
+        else:
+            for_machine = MachineChoice.HOST
+
         if not isinstance(target, build.StaticLibrary):
             # Add link args added using add_project_link_arguments()
             commands += self.build.get_project_link_args(linker, target.subproject, target.is_cross)
@@ -2476,7 +2481,7 @@ rule FORTRAN_DEP_HACK%s
             if not target.is_cross:
                 # Link args added from the env: LDFLAGS. We want these to
                 # override all the defaults but not the per-target link args.
-                commands += self.environment.coredata.get_external_link_args(linker.get_language())
+                commands += self.environment.coredata.get_external_link_args(for_machine, linker.get_language())
 
         # Now we will add libraries and library paths from various sources
 
@@ -2522,7 +2527,7 @@ rule FORTRAN_DEP_HACK%s
         # to be after all internal and external libraries so that unresolved
         # symbols from those can be found here. This is needed when the
         # *_winlibs that we want to link to are static mingw64 libraries.
-        commands += linker.get_option_link_args(self.environment.coredata.compiler_options)
+        commands += linker.get_option_link_args(self.environment.coredata.compiler_options[for_machine])
 
         dep_targets = []
         dep_targets.extend(self.guess_external_link_dependencies(linker, target, commands, internal))

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -25,7 +25,9 @@ from .. import dependencies
 from .. import mlog
 from .. import compilers
 from ..compilers import CompilerArgs
-from ..mesonlib import MesonException, File, python_command, replace_if_different
+from ..mesonlib import (
+    MesonException, MachineChoice, File, python_command, replace_if_different
+)
 from ..environment import Environment, build_filename
 
 def autodetect_vs_version(build):
@@ -878,10 +880,14 @@ class Vs2010Backend(backends.Backend):
         file_inc_dirs = dict((lang, []) for lang in target.compilers)
         # The order in which these compile args are added must match
         # generate_single_compile() and generate_basic_compiler_args()
+        if self.environment.is_cross_build() and not target.is_cross:
+            for_machine = MachineChoice.BUILD
+        else:
+            for_machine = MachineChoice.HOST
         for l, comp in target.compilers.items():
             if l in file_args:
                 file_args[l] += compilers.get_base_compile_args(self.get_base_options_for_target(target), comp)
-                file_args[l] += comp.get_option_compile_args(self.environment.coredata.compiler_options)
+                file_args[l] += comp.get_option_compile_args(self.environment.coredata.compiler_options[for_machine])
 
         # Add compile args added using add_project_arguments()
         for l, args in self.build.projects_args.get(target.subproject, {}).items():
@@ -893,9 +899,10 @@ class Vs2010Backend(backends.Backend):
             if l in file_args:
                 file_args[l] += args
         if not target.is_cross:
-            # Compile args added from the env: CFLAGS/CXXFLAGS, etc. We want these
-            # to override all the defaults, but not the per-target compile args.
-            for key, opt in self.environment.coredata.compiler_options.items():
+            # Compile args added from the env or cross file: CFLAGS/CXXFLAGS,
+            # etc. We want these to override all the defaults, but not the
+            # per-target compile args.
+            for key, opt in self.environment.coredata.compiler_options[for_machine].items():
                 l, suffix = key.split('_', 1)
                 if suffix == 'args' and l in file_args:
                     file_args[l] += opt.value
@@ -1054,9 +1061,10 @@ class Vs2010Backend(backends.Backend):
             # These override per-project link arguments
             extra_link_args += self.build.get_global_link_args(compiler, target.is_cross)
             if not target.is_cross:
-                # Link args added from the env: LDFLAGS. We want these to
-                # override all the defaults but not the per-target link args.
-                extra_link_args += self.environment.coredata.get_external_link_args(compiler.get_language())
+                # Link args added from the env: LDFLAGS, or the cross file. We
+                # want these to override all the defaults but not the
+                # per-target link args.
+                extra_link_args += self.environment.coredata.get_external_link_args(for_machine, compiler.get_language())
             # Only non-static built targets need link args and link dependencies
             extra_link_args += target.link_args
             # External deps must be last because target link libraries may depend on them.
@@ -1079,7 +1087,7 @@ class Vs2010Backend(backends.Backend):
         # to be after all internal and external libraries so that unresolved
         # symbols from those can be found here. This is needed when the
         # *_winlibs that we want to link to are static mingw64 libraries.
-        extra_link_args += compiler.get_option_link_args(self.environment.coredata.compiler_options)
+        extra_link_args += compiler.get_option_link_args(self.environment.coredata.compiler_options[for_machine])
         (additional_libpaths, additional_links, extra_link_args) = self.split_link_args(extra_link_args.to_native())
 
         # Add more libraries to be linked if needed

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -32,6 +32,7 @@ class CsCompiler(Compiler):
         self.language = 'cs'
         super().__init__(exelist, version)
         self.id = id
+        self.is_cross = False
         self.runner = runner
 
     def get_display_language(self):

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -14,7 +14,9 @@
 
 import os.path, subprocess
 
-from ..mesonlib import EnvironmentException, version_compare, is_windows, is_osx
+from ..mesonlib import (
+    EnvironmentException, MachineChoice, version_compare, is_windows, is_osx
+)
 
 from .compilers import (
     CompilerType,
@@ -306,12 +308,17 @@ class DCompiler(Compiler):
                 # Add link flags needed to find dependencies
                 args += d.get_link_args()
 
+        if env.is_cross_build() and not self.is_cross:
+            for_machine = MachineChoice.BUILD
+        else:
+            for_machine = MachineChoice.HOST
+
         if mode == 'compile':
             # Add DFLAGS from the env
-            args += env.coredata.get_external_args(self.language)
+            args += env.coredata.get_external_args(for_machine, self.language)
         elif mode == 'link':
             # Add LDFLAGS from the env
-            args += env.coredata.get_external_link_args(self.language)
+            args += env.coredata.get_external_link_args(for_machine, self.language)
         # extra_args must override all other arguments, so we add them last
         args += extra_args
         return args

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -23,6 +23,7 @@ class JavaCompiler(Compiler):
         self.language = 'java'
         super().__init__(exelist, version)
         self.id = 'unknown'
+        self.is_cross = False
         self.javarunner = 'java'
 
     def get_soname_args(self, *args):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import configparser, os, platform, re, sys, shlex, shutil, subprocess
+import configparser, os, platform, re, sys, shlex, shutil, subprocess, typing
 
 from . import coredata
 from .linkers import ArLinker, ArmarLinker, VisualStudioLinker, DLinker, CcrxLinker
@@ -1086,7 +1086,7 @@ class Environment:
     def detect_compilers(self, lang: str, need_cross_compiler: bool):
         (comp, cross_comp) = self.compilers_from_language(lang, need_cross_compiler)
         if comp is not None:
-            self.coredata.process_new_compilers(lang, comp, cross_comp, self.cmd_line_options)
+            self.coredata.process_new_compilers(lang, comp, cross_comp, self)
         return comp, cross_comp
 
     def detect_static_linker(self, compiler):
@@ -1268,14 +1268,10 @@ class MesonConfigFile:
         return out
 
 class Properties:
-    def __init__(self):
-        self.properties = {}
-
-    def get_external_args(self, language):
-        return mesonlib.stringlistify(self.properties.get(language + '_args', []))
-
-    def get_external_link_args(self, language):
-        return mesonlib.stringlistify(self.properties.get(language + '_link_args', []))
+    def __init__(
+            self,
+            properties: typing.Optional[typing.Dict[str, typing.Union[str, typing.List[str]]]] = None):
+        self.properties = properties or {}
 
     def has_stdlib(self, language):
         return language + '_stdlib' in self.properties
@@ -1288,6 +1284,11 @@ class Properties:
 
     def get_sys_root(self):
         return self.properties.get('sys_root', None)
+
+    def __eq__(self, other):
+        if isinstance(other, type(self)):
+            return self.properties == other.properties
+        return NotImplemented
 
     # TODO consider removing so Properties is less freeform
     def __getitem__(self, key):

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -139,7 +139,8 @@ class Conf:
         self.print_options('Core options', core_options)
         self.print_options('Backend options', self.coredata.backend_options)
         self.print_options('Base options', self.coredata.base_options)
-        self.print_options('Compiler options', self.coredata.compiler_options)
+        # TODO others
+        self.print_options('Compiler options', self.coredata.compiler_options.build)
         self.print_options('Directories', dir_options)
         self.print_options('Project options', self.coredata.user_options)
         self.print_options('Testing options', test_options)
@@ -154,6 +155,9 @@ def run(options):
         save = False
         if len(options.cmd_line_options) > 0:
             c.set_options(options.cmd_line_options)
+            if not c.build.environment.is_cross_build():
+                # TODO think about cross and command-line interface.
+                c.coredata.compiler_options.host = c.coredata.compiler_options.build
             coredata.update_cmd_line_file(builddir, options)
             save = True
         elif options.clearcache:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -204,7 +204,8 @@ def list_buildoptions(coredata: cdata.CoreData):
     add_keys(optlist, core_options, 'core')
     add_keys(optlist, coredata.backend_options, 'backend')
     add_keys(optlist, coredata.base_options, 'base')
-    add_keys(optlist, coredata.compiler_options, 'compiler')
+    # TODO others
+    add_keys(optlist, coredata.compiler_options.build, 'compiler')
     add_keys(optlist, dir_options, 'directory')
     add_keys(optlist, coredata.user_options, 'user')
     add_keys(optlist, test_options, 'test')

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -29,7 +29,9 @@ from . import GResourceTarget, GResourceHeaderTarget, GirTarget, TypelibTarget, 
 from . import get_include_args
 from . import ExtensionModule
 from . import ModuleReturnValue
-from ..mesonlib import MesonException, OrderedSet, Popen_safe, extract_as_list
+from ..mesonlib import (
+    MachineChoice, MesonException, OrderedSet, Popen_safe, extract_as_list
+)
 from ..dependencies import Dependency, PkgConfigDependency, InternalDependency
 from ..interpreterbase import noKwargs, permittedKwargs, FeatureNew, FeatureNewKwargs
 
@@ -531,11 +533,7 @@ class GnomeModule(ExtensionModule):
         ret = []
 
         for lang in langs:
-            if state.environment.is_cross_build():
-                link_args = state.environment.properties.host.get_external_link_args(lang)
-            else:
-                link_args = state.environment.coredata.get_external_link_args(lang)
-
+            link_args = state.environment.coredata.get_external_link_args(MachineChoice.HOST, lang)
             for link_arg in link_args:
                 if link_arg.startswith('-L'):
                     ret.append(link_arg)
@@ -720,10 +718,7 @@ class GnomeModule(ExtensionModule):
     def _get_external_args_for_langs(self, state, langs):
         ret = []
         for lang in langs:
-            if state.environment.is_cross_build():
-                ret += state.environment.properties.host.get_external_args(lang)
-            else:
-                ret += state.environment.coredata.get_external_args(lang)
+            ret += state.environment.coredata.get_external_args(MachineChoice.HOST, lang)
         return ret
 
     @staticmethod
@@ -1048,13 +1043,11 @@ This will become a hard error in the future.''')
         ldflags.update(internal_ldflags)
         ldflags.update(external_ldflags)
 
+        cflags.update(state.environment.coredata.get_external_args(MachineChoice.HOST, 'c'))
+        ldflags.update(state.environment.coredata.get_external_link_args(MachineChoice.HOST, 'c'))
         if state.environment.is_cross_build():
-            cflags.update(state.environment.properties.host.get_external_args('c'))
-            ldflags.update(state.environment.properties.host.get_external_link_args('c'))
             compiler = state.environment.coredata.cross_compilers.get('c')
         else:
-            cflags.update(state.environment.coredata.get_external_args('c'))
-            ldflags.update(state.environment.coredata.get_external_link_args('c'))
             compiler = state.environment.coredata.compilers.get('c')
 
         compiler_flags = self._get_langs_compilers_flags(state, [('c', compiler)])

--- a/run_tests.py
+++ b/run_tests.py
@@ -80,7 +80,7 @@ def get_fake_env(sdir='', bdir=None, prefix='', opts=None):
     if opts is None:
         opts = get_fake_options(prefix)
     env = Environment(sdir, bdir, opts)
-    env.coredata.compiler_options['c_args'] = FakeCompilerOptions()
+    env.coredata.compiler_options.host['c_args'] = FakeCompilerOptions()
     env.machines.host.cpu_family = 'x86_64' # Used on macOS inside find_library
     return env
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -798,7 +798,7 @@ class InternalTests(unittest.TestCase):
             env = get_fake_env()
             compiler = env.detect_c_compiler(False)
             env.coredata.compilers = {'c': compiler}
-            env.coredata.compiler_options['c_link_args'] = FakeCompilerOptions()
+            env.coredata.compiler_options.host['c_link_args'] = FakeCompilerOptions()
             p1 = Path(tmpdir) / '1'
             p2 = Path(tmpdir) / '2'
             p1.mkdir()
@@ -2937,10 +2937,10 @@ recommended as it is not supported on some platforms''')
         # c_args value should be parsed with shlex
         self.init(testdir, extra_args=['-Dc_args=foo bar "one two"'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.compiler_options['c_args'].value, ['foo', 'bar', 'one two'])
+        self.assertEqual(obj.compiler_options.host['c_args'].value, ['foo', 'bar', 'one two'])
         self.setconf('-Dc_args="foo bar" one two')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.compiler_options['c_args'].value, ['foo bar', 'one', 'two'])
+        self.assertEqual(obj.compiler_options.host['c_args'].value, ['foo bar', 'one', 'two'])
         self.wipe()
 
         # Setting a 2nd time the same option should override the first value
@@ -2953,7 +2953,7 @@ recommended as it is not supported on some platforms''')
             self.assertEqual(obj.builtins['bindir'].value, 'bar')
             self.assertEqual(obj.builtins['buildtype'].value, 'release')
             self.assertEqual(obj.base_options['b_sanitize'].value, 'thread')
-            self.assertEqual(obj.compiler_options['c_args'].value, ['bar'])
+            self.assertEqual(obj.compiler_options.host['c_args'].value, ['bar'])
             self.setconf(['--bindir=bar', '--bindir=foo',
                           '-Dbuildtype=release', '-Dbuildtype=plain',
                           '-Db_sanitize=thread', '-Db_sanitize=address',
@@ -2962,7 +2962,7 @@ recommended as it is not supported on some platforms''')
             self.assertEqual(obj.builtins['bindir'].value, 'foo')
             self.assertEqual(obj.builtins['buildtype'].value, 'plain')
             self.assertEqual(obj.base_options['b_sanitize'].value, 'address')
-            self.assertEqual(obj.compiler_options['c_args'].value, ['foo'])
+            self.assertEqual(obj.compiler_options.host['c_args'].value, ['foo'])
             self.wipe()
         except KeyError:
             # Ignore KeyError, it happens on CI for compilers that does not


### PR DESCRIPTION
Never access `environment.properties` downstream. Instead use coredata.compiler_options.<machine>. This brings the cross and native code paths closer together, since both now use that.

https://github.com/mesonbuild/meson/pull/4772 builds on this to further remove a bunch of conditional code now that the underlying mechanism is the same. It has some CI failures though hence why I didn't do that low-hanging fruit as part of this PR.

----

Command line options are interpreted just as before, for backwards compatibility. Doing so does introduce some funny conditionals to keep the `build` and `host` `compiler_options` in the native case. In the future, I'd like to change the interpretation of command line options so

 - The logic is cross-agnostic, i.e. there are no conditions affected by
   `is_cross_build()`.

 - Compiler args for both the build and host machines can always be
   controlled by the command line.

 - Compiler args for both machines can always be controlled separately.