### PR TITLE
pkgconfig: Avoid deprecation warning when using new syntax

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -434,11 +434,12 @@ class PkgConfigModule(ExtensionModule):
                 mainlib.generated_pc = filebase
             else:
                 mlog.warning('Already generated a pkg-config file for', mlog.bold(mainlib.name))
-        for lib in deps.pub_libs:
-            if not isinstance(lib, str) and not hasattr(lib, 'generated_pc'):
-                lib.generated_pc = filebase
-                lib.generated_pc_warn = types.SimpleNamespace(subdir=state.subdir,
-                                                              lineno=state.current_lineno)
+        else:
+            for lib in deps.pub_libs:
+                if not isinstance(lib, str) and not hasattr(lib, 'generated_pc'):
+                    lib.generated_pc = filebase
+                    lib.generated_pc_warn = types.SimpleNamespace(subdir=state.subdir,
+                                                                  lineno=state.current_lineno)
         return ModuleReturnValue(res, [res])
 
 def initialize(*args, **kwargs):


### PR DESCRIPTION
When using pkg.generate(mylib, library : publicdep) it is pretty clear
we don't want to associate publicdep to this generated pkg-config file.

This fix unavoidable deprecation warning when glib is built as
subproject and the parent project (e.g. gst-build) generates a
pkg-config file that depends on glib-2.0.pc on a platform where libintl
is itself built as subproject (e.g. Android).