### PR TITLE
Add a summary() function for configuration summarization

### DIFF
--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -117,6 +117,7 @@ syn keyword mesonBuiltin
   \ subdir
   \ subdir_done
   \ subproject
+  \ summary
   \ target_machine
   \ test
   \ vcs_tag

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1206,6 +1206,58 @@ This function prints its argument to stdout prefixed with WARNING:.
 
 *Added 0.44.0*
 
+### summary()
+
+``` meson
+    void summary(section_name, dictionary)
+```
+
+This function is used to summarize build configuration at the end of the build
+process. This function provides a way for projects (and subprojects) to report
+this information in a clear way.
+
+The first argument is a section name, the second argument is a dictionary.
+`summary()` can be called multiple times as long as the same dict key doesn't
+appear twice in the same section. All sections will be collected and printed at
+the end of the configuration in the same order as they have been called.
+
+Dictionary values can only be lists, integers, booleans or strings.
+
+Example:
+```meson
+project('My Project', version : '1.0')
+summary('Directories', {'bindir': get_option('bindir'),
+                        'libdir': get_option('libdir'),
+                        'datadir': get_option('datadir'),
+                        })
+summary('Configuration', {'Some boolean': false,
+                          'Another boolean': true,
+                          'Some string': 'Hello World',
+                          'A list': ['string', 1, true],
+                          })
+```
+
+Output:
+```
+My Project 1.0
+
+  Directories
+             prefix: /opt/gnome
+             bindir: bin
+             libdir: lib/x86_64-linux-gnu
+            datadir: share
+
+  Configuration
+       Some boolean: False
+    Another boolean: True
+        Some string: Hello World
+             A list: string
+                     1
+                     True
+```
+
+*Added 0.53.0*
+
 ### project()
 
 ``` meson

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1209,6 +1209,9 @@ This function prints its argument to stdout prefixed with WARNING:.
 ### summary()
 
 ``` meson
+    void summary(key, value)
+    void summary(dictionary)
+    void summary(section_name, key, value)
     void summary(section_name, dictionary)
 ```
 
@@ -1216,12 +1219,16 @@ This function is used to summarize build configuration at the end of the build
 process. This function provides a way for projects (and subprojects) to report
 this information in a clear way.
 
-The first argument is a section name, the second argument is a dictionary.
-`summary()` can be called multiple times as long as the same dict key doesn't
-appear twice in the same section. All sections will be collected and printed at
-the end of the configuration in the same order as they have been called.
+The content is a serie of key/value pairs grouped into sections. If the section
+argument is omitted, those key/value pairs are implicitly grouped into a section
+with no title. key/value pairs can optionally be grouped into a dictionary,
+but keep in mind that dictionaries does not guarantee ordering.
+`section_name` and `key` must be strings, `value` can only be lists, integers,
+booleans or strings.
 
-Dictionary values can only be lists, integers, booleans or strings.
+`summary()` can be called multiple times as long as the same section_name/key
+pair doesn't appear twice. All sections will be collected and printed at
+the end of the configuration in the same order as they have been called.
 
 Example:
 ```meson

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1230,6 +1230,10 @@ booleans or strings.
 pair doesn't appear twice. All sections will be collected and printed at
 the end of the configuration in the same order as they have been called.
 
+Keyword arguments:
+- `bool_yn` if set to true, all boolean values will be replaced by green YES
+  or red NO.
+
 Example:
 ```meson
 project('My Project', version : '1.0')

--- a/docs/markdown/snippets/summary.md
+++ b/docs/markdown/snippets/summary.md
@@ -1,0 +1,37 @@
+## Add a new summary() function
+
+A new function [`summary()`](Reference-manual.md#summary) has been added to
+summarize build configuration at the end of the build process.
+
+Example:
+```meson
+project('My Project', version : '1.0')
+summary('Directories', {'bindir': get_option('bindir'),
+                        'libdir': get_option('libdir'),
+                        'datadir': get_option('datadir'),
+                        })
+summary('Configuration', {'Some boolean': false,
+                          'Another boolean': true,
+                          'Some string': 'Hello World',
+                          'A list': ['string', 1, true],
+                          })
+```
+
+Output:
+```
+My Project 1.0
+
+  Directories
+             prefix: /opt/gnome
+             bindir: bin
+             libdir: lib/x86_64-linux-gnu
+            datadir: share
+
+  Configuration
+       Some boolean: False
+    Another boolean: True
+        Some string: Hello World
+             A list: string
+                     1
+                     True
+```

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -119,6 +119,7 @@ class AstInterpreter(interpreterbase.InterpreterBase):
                            'find_library': self.func_do_nothing,
                            'subdir_done': self.func_do_nothing,
                            'alias_target': self.func_do_nothing,
+                           'summary': self.func_do_nothing,
                            })
 
     def func_do_nothing(self, node, args, kwargs):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1775,7 +1775,8 @@ class Summary:
         mlog.log(self.project_name, mlog.normal_cyan(self.project_version))
         for section, values in self.sections.items():
             mlog.log('')  # newline
-            mlog.log(' ', mlog.bold(section))
+            if section:
+                mlog.log(' ', mlog.bold(section))
             for k, v in values.items():
                 indent = self.max_key_len - len(k) + 3
                 mlog.log(' ' * indent, k + ':', v[0])
@@ -2871,13 +2872,28 @@ external dependencies (including libraries) must go to "dependencies".''')
     @noKwargs
     @FeatureNew('summary', '0.53.0')
     def func_summary(self, node, args, kwargs):
-        if len(args) != 2:
-            raise InterpreterException('Summary accepts exactly two arguments.')
-        section, values = args
-        if not isinstance(section, str):
-            raise InterpreterException('Argument 1 must be a string.')
-        if not isinstance(values, dict):
-            raise InterpreterException('Argument 2 must be a dictionary.')
+        if len(args) == 1:
+            if not isinstance(args[0], dict):
+                raise InterpreterException('Argument 1 must be a dictionary.')
+            section = ''
+            values = args[0]
+        elif len(args) == 2:
+            if not isinstance(args[0], str):
+                raise InterpreterException('Argument 1 must be a string.')
+            if isinstance(args[1], dict):
+                section, values = args
+            else:
+                section = ''
+                values = {args[0]: args[1]}
+        elif len(args) == 3:
+            if not isinstance(args[0], str):
+                raise InterpreterException('Argument 1 must be a string.')
+            if not isinstance(args[1], str):
+                raise InterpreterException('Argument 2 must be a string.')
+            section, key, value = args
+            values = {key: value}
+        else:
+            raise InterpreterException('Summary accepts at most 3 arguments.')
         if self.subproject not in self.summary:
             self.summary[self.subproject] = Summary(self.active_projectname, self.project_version)
         self.summary[self.subproject].add_section(section, values)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4136,6 +4136,8 @@ recommended as it is not supported on some platforms''')
                                  1
                                  True
                        A number: 1
+                            yes: YES
+                             no: NO
             ''')
         # Dict ordering is not guaranteed and an exact string comparison randomly
         # fails on the CI because lines are reordered.

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4113,6 +4113,41 @@ recommended as it is not supported on some platforms''')
         self.init(testdir)
         self._run(self.mconf_command + [self.builddir])
 
+    # FIXME: The test is failing on Windows CI even if the print looks good.
+    # Maybe encoding issue?
+    @unittest.skipIf(is_windows(), 'This test fails on Windows CI')
+    def test_summary(self):
+        testdir = os.path.join(self.unit_test_dir, '74 summary')
+        out = self.init(testdir)
+        expected = textwrap.dedent(r'''
+            Some Subproject 2.0
+
+              Features
+                foo: bar
+
+            My Project 1.0
+
+              Directories
+                         bindir: bin
+                         libdir: lib
+                        datadir: share
+
+              Configuration
+                   Some boolean: False
+                Another boolean: True
+                    Some string: Hello World
+                         A list: string
+                                 1
+                                 True
+            ''')
+        # Dict ordering is not guaranteed and an exact string comparison randomly
+        # fails on the CI because lines are reordered.
+        expected_lines = expected.split('\n')[1:]
+        out_start = out.find(expected_lines[0])
+        out_lines = out[out_start:].split('\n')[:len(expected_lines)]
+        self.assertEqual(sorted(expected_lines), sorted(out_lines))
+
+
 class FailureTests(BasePlatformTests):
     '''
     Tests that test failure conditions. Build files here should be dynamically

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4122,15 +4122,11 @@ recommended as it is not supported on some platforms''')
         expected = textwrap.dedent(r'''
             Some Subproject 2.0
 
-              Features
-                foo: bar
+                 string: bar
+                integer: 1
+                boolean: True
 
             My Project 1.0
-
-              Directories
-                         bindir: bin
-                         libdir: lib
-                        datadir: share
 
               Configuration
                    Some boolean: False
@@ -4139,6 +4135,7 @@ recommended as it is not supported on some platforms''')
                          A list: string
                                  1
                                  True
+                       A number: 1
             ''')
         # Dict ordering is not guaranteed and an exact string comparison randomly
         # fails on the CI because lines are reordered.

--- a/test cases/unit/74 summary/meson.build
+++ b/test cases/unit/74 summary/meson.build
@@ -9,3 +9,5 @@ summary('Configuration', {'Some boolean': false,
                           'A list': ['string', 1, true],
                           })
 summary('Configuration', 'A number', 1)
+summary('Configuration', 'yes', true, bool_yn : true)
+summary('Configuration', 'no', false, bool_yn : true)

--- a/test cases/unit/74 summary/meson.build
+++ b/test cases/unit/74 summary/meson.build
@@ -1,0 +1,15 @@
+project('My Project', version : '1.0')
+
+summary('Directories', {'bindir': get_option('bindir'),
+                        'libdir': get_option('libdir'),
+                        'datadir': get_option('datadir'),
+                        })
+
+subproject('sub')
+subproject('sub2', required : false)
+
+summary('Configuration', {'Some boolean': false,
+                          'Another boolean': true,
+                          'Some string': 'Hello World',
+                          'A list': ['string', 1, true],
+                          })

--- a/test cases/unit/74 summary/meson.build
+++ b/test cases/unit/74 summary/meson.build
@@ -1,10 +1,5 @@
 project('My Project', version : '1.0')
 
-summary('Directories', {'bindir': get_option('bindir'),
-                        'libdir': get_option('libdir'),
-                        'datadir': get_option('datadir'),
-                        })
-
 subproject('sub')
 subproject('sub2', required : false)
 
@@ -13,3 +8,4 @@ summary('Configuration', {'Some boolean': false,
                           'Some string': 'Hello World',
                           'A list': ['string', 1, true],
                           })
+summary('Configuration', 'A number', 1)

--- a/test cases/unit/74 summary/subprojects/sub/meson.build
+++ b/test cases/unit/74 summary/subprojects/sub/meson.build
@@ -1,0 +1,3 @@
+project('Some Subproject', version : '2.0')
+
+summary('Features', {'foo': 'bar'})

--- a/test cases/unit/74 summary/subprojects/sub/meson.build
+++ b/test cases/unit/74 summary/subprojects/sub/meson.build
@@ -1,3 +1,4 @@
 project('Some Subproject', version : '2.0')
 
-summary('Features', {'foo': 'bar'})
+summary('string', 'bar')
+summary({'integer': 1, 'boolean': true})

--- a/test cases/unit/74 summary/subprojects/sub2/meson.build
+++ b/test cases/unit/74 summary/subprojects/sub2/meson.build
@@ -1,0 +1,5 @@
+project('sub2')
+
+error('This subproject failed')
+
+summary('Section', 'Should not be seen')


### PR DESCRIPTION
This has been requested multiple times in the mesa/xorg community, and
apparently in the GStreamer community as well.

This allows a configuration summary to be printed at the end of the configuring phase.

For example:

```meson
sec1 = {'driver' : 'foobar', 'OS' : 'Linux', 'API' : 1.7}
...
sec2 = {'driver' : 'dive comp', 'OS' : 'Minix', 'API' : 1.1.2}
...
sec3 = {'with' : {'mesa' : true, 'gbm' : false}}

summary(
  {'Backend' : 'OpenGL'},
  'Server' : sec1,
  'Client' : sec2,
  'Misc' : sec3,
)
```

Which would print something like:

```txt
Configuration Summary:
  Backend = OpenGL
  Server:
    driver = foobar
    OS = Linux
    API = 1.7
  Client:
    driver = dive comp
    OS = Minix
    API = 1.1.2
  Misc:
    with = {'mesa : true, 'gbm' : false}
```

Fixes #757