### PR TITLE
dependencies/ui: Don't require lrelease for qt

### DIFF
--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -243,7 +243,7 @@ class QtBaseDependency(ExternalDependency):
                 if self.bindir:
                     yield os.path.join(self.bindir, b), b, False
                 yield '{}-{}'.format(b, self.name), b, False
-                yield b, b, self.required
+                yield b, b, self.required if b != 'lrelease' else False
 
         for b, name, required in gen_bins():
             if found[name].found():


### PR DESCRIPTION
We previously didn't require it so we shouldn't silently start doing so.

Fixes #4654