### PR TITLE
Allow fallback in nodownload mode

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3075,7 +3075,7 @@ external dependencies (including libraries) must go to "dependencies".''')
 
     def dependency_fallback(self, name, kwargs):
         display_name = name if name else '(anonymous)'
-        if self.coredata.get_builtin_option('wrap_mode') in (WrapMode.nofallback, WrapMode.nodownload):
+        if self.coredata.get_builtin_option('wrap_mode') == WrapMode.nofallback:
             mlog.log('Not looking for a fallback subproject for the dependency',
                      mlog.bold(display_name), 'because:\nUse of fallback'
                      'dependencies is disabled.')


### PR DESCRIPTION
It is possible that the subproject has been downloaded already, in that
case there is no reason to not use it. If the subproject has not been
downlaoded already it will fail do_subproject().