### PR TITLE
Small fixup in dependency_fallback()

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3119,12 +3119,6 @@ external dependencies (including libraries) must go to "dependencies".''')
         if 'version' in kwargs:
             wanted = kwargs['version']
             found = dep.version_method([], {})
-            # Don't do a version check if the dependency is not found and not required
-            if not dep.found_method([], {}) and not required:
-                subproj_path = os.path.join(self.subproject_dir, dirname)
-                mlog.log('Dependency', mlog.bold(display_name), 'from subproject',
-                         mlog.bold(subproj_path), 'found:', mlog.red('NO'))
-                return dep
             if not self.check_subproject_version(wanted, found):
                 mlog.log('Subproject', mlog.bold(subproj_path), 'dependency',
                          mlog.bold(display_name), 'version is', mlog.bold(found),

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3110,10 +3110,9 @@ external dependencies (including libraries) must go to "dependencies".''')
                 msg.append(traceback.format_exc())
             mlog.log(*msg)
             return None
-        required = kwargs.get('required', True)
-        dep = self.get_subproject_dep(name, dirname, varname, required)
+        dep = self.get_subproject_dep(name, dirname, varname, required=False)
         if not dep.found():
-            return dep
+            return None
         subproj_path = os.path.join(self.subproject_dir, dirname)
         # Check if the version of the declared dependency matches what we want
         if 'version' in kwargs:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3075,7 +3075,7 @@ external dependencies (including libraries) must go to "dependencies".''')
 
     def dependency_fallback(self, name, kwargs):
         display_name = name if name else '(anonymous)'
-        if self.coredata.get_builtin_option('wrap_mode') in (WrapMode.nofallback, WrapMode.nodownload):
+        if self.coredata.get_builtin_option('wrap_mode') == WrapMode.nofallback:
             mlog.log('Not looking for a fallback subproject for the dependency',
                      mlog.bold(display_name), 'because:\nUse of fallback'
                      'dependencies is disabled.')


### PR DESCRIPTION
commit df8668a3215ff94b5f480d0235979412c40eeb9d
    dependency_fallback: Return None if the dep is not found
    
    All other places from that function return None, and the caller assumes
    if anything else than None is returned it must be a found dependency.
    The caller already handle the case if None is returned and
    required=True.

commit e6db7d154610d6fc00c729bbe75344277d40a53d
    dependency_fallback: Remove dead code
    
    It already early return if dep is not found.
