### PR TITLE
Add meson.override_dependency()

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1590,6 +1590,12 @@ the following methods.
 
   If `program` is an `executable`, it cannot be used during configure.
 
+- `override_dependency(name, dep_object)` [*(Added
+  0.50.0)*](Release-notes-for-0.50.0.md#can-override-dependency)
+  specifies that whenever `dependency(name, ...)` is used, Meson should not not
+  look it up on the system but instead return `dep_object`, which may either be
+  the result of `dependency()` or `declare_dependency()`.
+
 - `project_version()` returns the version string specified in
   `project` function call.
 

--- a/docs/markdown/snippets/override_dependency.md
+++ b/docs/markdown/snippets/override_dependency.md
@@ -1,0 +1,28 @@
+## Can override `dependency()`
+
+It is now possible to override the result of `dependency()` to point
+to any dependency object you want. The overriding is global and applies to
+every subproject from there on. Here is how you would use it.
+
+In master project
+
+```meson
+subproject('glib')
+```
+
+In the called subproject:
+
+```meson
+libglib = library('glib-2.0', ...)
+glib_dep = declare_dependency(link_with : libglib)
+meson.override_dependency('glib-2.0', glib_dep)
+```
+
+In master project (or, in fact, any subproject):
+
+```meson
+glib_dep = dependency('glib-2.0')
+```
+
+Now `glib_dep` points to the internal dependency from the subproject, and not
+the external dependency from the system `glib-2.0.pc` pkg-config file.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -141,6 +141,8 @@ class Build:
         self.test_setup_default_name = None
         self.find_overrides = {}
         self.searched_programs = set() # The list of all programs that have been searched for.
+        self.dependency_overrides = {}
+        self.searched_dependencies = set()
 
     def copy(self):
         other = Build(self.environment)

--- a/test cases/common/103 subproject subdir/meson.build
+++ b/test cases/common/103 subproject subdir/meson.build
@@ -4,3 +4,7 @@ libSub = dependency('sub', fallback: ['sub', 'libSub'])
 
 exe = executable('prog', 'prog.c', dependencies: libSub)
 test('subproject subdir', exe)
+
+# Verify the subproject has placed dependency overrides
+dependency('sub')
+dependency('sub-1.0')

--- a/test cases/common/103 subproject subdir/subprojects/sub/lib/meson.build
+++ b/test cases/common/103 subproject subdir/subprojects/sub/lib/meson.build
@@ -1,2 +1,4 @@
 lib = static_library('sub', 'sub.c')
 libSub = declare_dependency(include_directories: include_directories('.'), link_with: lib)
+meson.override_dependency('sub-1.0', libSub)
+meson.override_dependency('sub', libSub)


### PR DESCRIPTION
Similar to meson.override_find_program() but overrides the result of the
dependency() function.