### PR TITLE
find_library: Add 'has_headers' kwarg

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1760,7 +1760,9 @@ the following methods:
   the `prefix` keyword. In order to look for headers in a specific
   directory you can use `args : '-I/extra/include/dir`, but this
   should only be used in exceptional cases for includes that can't be
-  detected via pkg-config and passed via `dependencies`.
+  detected via pkg-config and passed via `dependencies`. Since *0.50.0* the
+  `required` keyword argument can be used to abort if the header cannot be
+  found.
 
 - `has_header` returns true if the specified header *exists*, and is
   faster than `check_header()` since it only does a pre-processor check.
@@ -1769,13 +1771,16 @@ the following methods:
   the `prefix` keyword. In order to look for headers in a specific
   directory you can use `args : '-I/extra/include/dir`, but this
   should only be used in exceptional cases for includes that can't be
-  detected via pkg-config and passed via `dependencies`.
+  detected via pkg-config and passed via `dependencies`. Since *0.50.0* the
+  `required` keyword argument can be used to abort if the header cannot be
+  found.
 
 - `has_header_symbol(headername, symbolname)` allows one to detect
   whether a particular symbol (function, variable, #define, type
   definition, etc) is declared in the specified header, you can
   specify external dependencies to use with `dependencies` keyword
-  argument.
+  argument. Since *0.50.0* the `required` keyword argument can be used to abort
+  if the symbol cannot be found.
 
 - `has_member(typename, membername)` takes two arguments, type name
   and member name and returns true if the type has the specified

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1704,7 +1704,10 @@ the following methods:
   option can also be passed to the `required` keyword argument.
   *Since 0.49.0* if the keyword argument `disabler` is `true` and the
   dependency couldn't be found, return a [disabler object](#disabler-object)
-  instead of a not-found dependency.
+  instead of a not-found dependency. *Since 0.50.0* the `has_headers` keyword
+  argument can be a list of header files that must be found as well, using
+  `has_header()` method. All keyword arguments prefixed with `header_` will be
+  passed down to `has_header()` method with the prefix removed.
 
 - `first_supported_argument(list_of_strings)`, given a list of
   strings, returns the first argument that passes the `has_argument`

--- a/docs/markdown/snippets/find_library_header.md
+++ b/docs/markdown/snippets/find_library_header.md
@@ -1,0 +1,21 @@
+## Find library with its headers
+
+The `find_library()` method can now also verify if the library's headers are
+found in a single call, using the `has_header()` method internally.
+
+```meson
+# Aborts if the 'z' library is found but not its header file
+zlib = find_library('z', has_headers : 'zlib.h')
+# Returns not-found if the 'z' library is found but not its header file
+zlib = find_library('z', has_headers : 'zlib.h', required : false)
+```
+
+Any keyword argument with the `header_` prefix passed to `find_library()` will
+be passed to the `has_header()` method with the prefix removed.
+
+```meson
+libfoo = find_library('foo',
+  has_headers : ['foo.h', 'bar.h'],
+  header_prefix : '#include <baz.h>',
+  header_include_directories : include_directories('.'))
+```

--- a/test cases/common/209 find_library and headers/foo.h
+++ b/test cases/common/209 find_library and headers/foo.h
@@ -1,0 +1,1 @@
+#define VAL 42

--- a/test cases/common/209 find_library and headers/meson.build
+++ b/test cases/common/209 find_library and headers/meson.build
@@ -1,0 +1,23 @@
+project('find library and headers', 'c')
+
+cc = meson.get_compiler('c')
+
+if not cc.find_library('z', required : false).found()
+  error('MESON_SKIP_TEST: zlib not found.')
+endif
+
+lib = cc.find_library('z',
+  has_headers : 'foo.h',
+  required : false)
+assert(not lib.found(), 'Header should be missing')
+
+lib = cc.find_library('z',
+  has_headers : 'foo.h',
+  header_include_directories : include_directories('.'))
+assert(lib.found(), 'Header should be found')
+
+lib = cc.find_library('z',
+  has_headers : ['foo.h', 'bar.h'],
+  header_include_directories : include_directories('.'),
+  required : false)
+assert(not lib.found(), 'One header should be missing')


### PR DESCRIPTION
A library without its headers is often useless, so it is common to check them together.

This is based on top of PR https://github.com/mesonbuild/meson/pull/4658.