### PR TITLE
Add new meson.py unstable-coredata subcommand to show the hidden state.

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -20,7 +20,7 @@ import argparse
 
 from . import mesonlib
 from . import mlog
-from . import mconf, minit, minstall, mintro, msetup, mtest, rewriter, msubprojects
+from . import mconf, minit, minstall, mintro, msetup, mtest, rewriter, msubprojects, munstable_coredata
 from .mesonlib import MesonException
 from .environment import detect_msys2_arch
 from .wrap import wraptool
@@ -56,6 +56,8 @@ class CommandLineParser:
         self.add_command('rewrite', rewriter.add_arguments, rewriter.run,
                          help=argparse.SUPPRESS)
         self.add_command('runpython', self.add_runpython_arguments, self.run_runpython_command,
+                         help=argparse.SUPPRESS)
+        self.add_command('unstable-coredata', munstable_coredata.add_arguments, munstable_coredata.run,
                          help=argparse.SUPPRESS)
 
     def add_command(self, name, add_arguments_func, run_func, help):

--- a/mesonbuild/munstable_coredata.py
+++ b/mesonbuild/munstable_coredata.py
@@ -1,0 +1,126 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from . import coredata as cdata
+
+import os.path
+import pprint
+import textwrap
+
+def add_arguments(parser):
+    parser.add_argument('--all', action='store_true', dest='all', default=False,
+                        help='Show data not used by current backend.')
+
+    parser.add_argument('builddir', nargs='?', default='.', help='The build directory')
+
+
+def dump_compilers(compilers):
+    for lang, compiler in compilers.items():
+        print('  ' + lang + ':')
+        print('      Id: ' + compiler.id)
+        print('      Command: ' + ' '.join(compiler.exelist))
+        print('      Full version: ' + compiler.full_version)
+        print('      Detected version: ' + compiler.version)
+        print('      Detected type: ' + repr(compiler.compiler_type))
+        #pprint.pprint(compiler.__dict__)
+
+
+def dump_guids(d):
+    for name, value in d.items():
+        print('  ' + name + ': ' + value)
+
+
+def run(options):
+    datadir = 'meson-private'
+    if options.builddir is not None:
+        datadir = os.path.join(options.builddir, datadir)
+    if not os.path.isdir(datadir):
+        print('Current directory is not a build dir. Please specify it or '
+              'change the working directory to it.')
+        return 1
+
+    all = options.all
+
+    print('This is a dump of the internal unstable cache of meson. This is for debugging only.')
+    print('Do NOT parse, this will change from version to version in incompatible ways')
+    print('')
+
+    coredata = cdata.load(options.builddir)
+    backend = coredata.get_builtin_option('backend')
+    for k, v in sorted(coredata.__dict__.items()):
+        if k in ('backend_options', 'base_options', 'builtins', 'compiler_options', 'user_options'):
+            # use `meson configure` to view these
+            pass
+        elif k in ['install_guid', 'test_guid', 'regen_guid']:
+            if all or backend.startswith('vs'):
+                print(k + ': ' + v)
+        elif k == 'target_guids':
+            if all or backend.startswith('vs'):
+                print(k + ':')
+                dump_guids(v)
+        elif k in ['lang_guids']:
+            if all or backend.startswith('vs') or backend == 'xcode':
+                print(k + ':')
+                dump_guids(v)
+        elif k == 'meson_command':
+            if all or backend.startswith('vs'):
+                print('Meson command used in build file regeneration: ' + ' '.join(v))
+        elif k == 'pkgconf_envvar':
+            print('Last seen PKGCONFIG enviroment variable value: ' + v)
+        elif k == 'version':
+            print('Meson version: ' + v)
+        elif k == 'cross_file':
+            print('Cross File: ' + (v or 'None'))
+        elif k == 'config_files':
+            if v:
+                print('Native File: ' + ' '.join(v))
+        elif k == 'compilers':
+            print('Cached native compilers:')
+            dump_compilers(v)
+        elif k == 'cross_compilers':
+            print('Cached cross compilers:')
+            dump_compilers(v)
+        elif k == 'deps':
+            native = []
+            cross = []
+            for dep_key, dep in sorted(v.items()):
+                if dep_key[2]:
+                    cross.append((dep_key, dep))
+                else:
+                    native.append((dep_key, dep))
+
+            def print_dep(dep_key, dep):
+                print('  ' + dep_key[0] + ": ")
+                print('      compile args: ' + repr(dep.get_compile_args()))
+                print('      link args: ' + repr(dep.get_link_args()))
+                if dep.get_sources():
+                    print('      sources: ' + repr(dep.get_sources()))
+                print('      version: ' + repr(dep.get_version()))
+
+            if native:
+                print('Cached native dependencies:')
+                for dep_key, dep in native:
+                    print_dep(dep_key, dep)
+            if cross:
+                print('Cached dependencies:')
+                for dep_key, dep in cross:
+                    print_dep(dep_key, dep)
+        elif k == 'external_preprocess_args':
+            for lang, opts in v.items():
+                if opts:
+                    print('Preprocessor args for ' + lang + ': ' + ' '.join(opts))
+        else:
+            print(k + ':')
+            print(textwrap.indent(pprint.pformat(v), '  '))


### PR DESCRIPTION
This adds a hidden option to dump the current otherwise hidden peristant state in coredata.dat.

This interface is unstable as meson has no compatibility promises about coredata.dat and i tried to make sure that the interface says so both as text message and by nameing the option `unstable-coredata`.

Example output with ninja backend (vs backends have a lot of guids not shown in this case):
```
$ meson.py unstable-coredata _build
This is a dump of the internal unstable cache of meson. This is for debugging only.
Do NOT parse, this will change from version to version in incompatible ways

Cached native compilers:
  c:
      Id: gcc
      Command: ccache cc
      Full version: cc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516
      Detected version: 6.3.0
      Detected type: <CompilerType.GCC_STANDARD: 0>
  cpp:
      Id: gcc
      Command: ccache c++
      Full version: c++ (Debian 6.3.0-18+deb9u1) 6.3.0 20170516
      Detected version: 6.3.0
      Detected type: <CompilerType.GCC_STANDARD: 0>
Cached cross compilers:
Cross File: None
Cached native dependencies:
  qt5: 
      compile args: ['-I/usr/include/x86_64-linux-gnu/qt5/QtCore', '-I/usr/include/x86_64-linux-gnu/qt5']
      link args: ['-lQt5Core']
      version: '5.7.1'
  threads: 
      compile args: []
      link args: []
      version: 'unknown'
Last seen PKGCONFIG enviroment variable value: /path/to/some/wrapper-pkgconfig
Meson version: 0.49.999
```