### PR TITLE
Avoid exception looking for python on windows if the launcher (py.exe…

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -14,6 +14,7 @@
 
 import os
 import json
+import shutil
 
 from pathlib import Path
 from .. import mesonlib
@@ -467,6 +468,9 @@ class PythonModule(ExtensionModule):
     # https://www.python.org/dev/peps/pep-0397/
     def _get_win_pythonpath(self, name_or_path):
         if name_or_path not in ['python2', 'python3']:
+            return None
+        if not shutil.which('py'):
+            # program not installed, return without an exception
             return None
         ver = {'python2': '-2', 'python3': '-3'}[name_or_path]
         cmd = ['py', ver, '-c', "import sysconfig; print(sysconfig.get_config_var('BINDIR'))"]


### PR DESCRIPTION
…) is not installed

We build the gtk stack on windows (wingtk/gvsbuild) with a python script that launches the single projects build, with a lot of them, now, using meson :).
We face an issue when the glib library was not built with an exception (file not found) on some machines and with the correct result on others and at the end, the reason was the missing of the pylauncher installation (py.exe).
With this modification we continue to try to find python even if the launcher is not installed, hoping to find it by name.
Even if this PR cannot be accepted as is I think that generating a clear error message ('Python launcher (py.exe) not found!') can be really useful.
