### PR TITLE
Refactor dependency code

### DIFF
--- a/mesonbuild/astinterpreter.py
+++ b/mesonbuild/astinterpreter.py
@@ -15,7 +15,7 @@
 # This class contains the basic functionality needed to run any interpreter
 # or an interpreter-based tool.
 
-from . import interpreterbase, mlog, mparser, mesonlib
+from . import interpreterbase, mparser, mesonlib
 from . import environment
 
 from .interpreterbase import InterpreterException, InvalidArguments, BreakRequest, ContinueRequest

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -437,17 +437,21 @@ class ConfigToolDependency(ExternalDependency):
 
     def report_config(self, version, req_version):
         """Helper method to print messages about the tool."""
+
+        found_msg = [mlog.bold(self.tool_name), 'found:']
+
         if self.config is None:
-            if version is not None:
-                mlog.log('Found', mlog.bold(self.tool_name), repr(version),
-                         mlog.red('NO'), '(needed', req_version, ')')
-            else:
-                mlog.log('Found', mlog.bold(self.tool_name), repr(req_version),
-                         mlog.red('NO'))
-            return False
-        mlog.log('Found {}:'.format(self.tool_name), mlog.bold(shutil.which(self.config[0])),
-                 '({})'.format(version))
-        return True
+            found_msg.append(mlog.red('NO'))
+            if version is not None and req_version is not None:
+                found_msg.append('found {!r} but need {!r}'.format(version, req_version))
+            elif req_version:
+                found_msg.append('need {!r}'.format(req_version))
+        else:
+            found_msg += [mlog.green('YES'), '({})'.format(shutil.which(self.config[0])), version]
+
+        mlog.log(*found_msg)
+
+        return self.config is not None
 
     def get_config_value(self, args, stage):
         p, out, err = Popen_safe(self.config + args)
@@ -825,10 +829,10 @@ class PkgConfigDependency(ExternalDependency):
             pkgbin = False
         if not self.silent:
             if pkgbin:
-                mlog.log('Found pkg-config:', mlog.bold(pkgbin.get_path()),
-                         '(%s)' % out.strip())
+                mlog.log(mlog.bold('pkg-config'), 'found:', mlog.green('YES'), '({})'.format(pkgbin.get_path()),
+                         out.strip())
             else:
-                mlog.log('Found Pkg-config:', mlog.red('NO'))
+                mlog.log(mlog.bold('pkg-config'), 'found:', mlog.red('NO'))
         return pkgbin
 
     def extract_field(self, la_file, fieldname):

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1984,17 +1984,14 @@ class ExtraFrameworkDependency(ExternalDependency):
 
 
 def get_dep_identifier(name, kwargs, want_cross):
-    # Need immutable objects since the identifier will be used as a dict key
-    version_reqs = listify(kwargs.get('version', []))
-    if isinstance(version_reqs, list):
-        version_reqs = frozenset(version_reqs)
-    identifier = (name, version_reqs, want_cross)
+    identifier = (name, want_cross)
     for key, value in kwargs.items():
-        # 'version' is embedded above as the second element for easy access
+        # 'version' is irrelevant for caching; the caller must check version matches
         # 'native' is handled above with `want_cross`
         # 'required' is irrelevant for caching; the caller handles it separately
         # 'fallback' subprojects cannot be cached -- they must be initialized
-        if key in ('version', 'native', 'required', 'fallback',):
+        # 'default_options' is only used in fallback case
+        if key in ('version', 'native', 'required', 'fallback', 'default_options'):
             continue
         # All keyword arguments are strings, ints, or lists (or lists of lists)
         if isinstance(value, list):

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -2100,12 +2100,7 @@ def find_external_dependency(name, env, kwargs):
         raise DependencyException('Dependency "%s" not found' % (name) +
                                   (', tried %s' % (tried) if tried else ''))
 
-    # return the last failed dependency object
-    if pkgdep:
-        return pkgdep[-1]
-
-    # this should never happen
-    raise DependencyException('Dependency "%s" not found, but no dependency object to return' % (name))
+    return NotFoundDependency(env)
 
 
 def _build_external_dependency_list(name, env, kwargs):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -101,7 +101,7 @@ def extract_required_kwarg(kwargs, subproject, feature_check=None, default=True)
             disabled = True
         elif option.is_enabled():
             required = True
-    elif isinstance(required, bool):
+    elif isinstance(val, bool):
         required = val
     else:
         raise InterpreterException('required keyword argument must be boolean or a feature option')

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3013,7 +3013,7 @@ external dependencies (including libraries) must go to "dependencies".''')
                 if 'fallback' in kwargs:
                     if not exception:
                         exception = DependencyException("fallback for %s not found" % display_name)
-                    fallback_dep = self.dependency_fallback(name, kwargs)
+                    fallback_dep = self.dependency_fallback(display_name, kwargs)
                     if fallback_dep:
                         # Never add fallback deps to self.coredata.deps since we
                         # cannot cache them. They must always be evaluated else
@@ -3058,8 +3058,7 @@ external dependencies (including libraries) must go to "dependencies".''')
             raise InterpreterException('Fallback info must have exactly two items.')
         return fbinfo
 
-    def dependency_fallback(self, name, kwargs):
-        display_name = name if name else '(anonymous)'
+    def dependency_fallback(self, display_name, kwargs):
         if self.coredata.get_builtin_option('wrap_mode') == WrapMode.nofallback:
             mlog.log('Not looking for a fallback subproject for the dependency',
                      mlog.bold(display_name), 'because:\nUse of fallback'

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -37,7 +37,6 @@ import re, shlex
 import subprocess
 from collections import namedtuple
 from pathlib import PurePath
-import traceback
 import functools
 
 import importlib
@@ -3062,7 +3061,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         sp_kwargs = {
             'default_options': kwargs.get('default_options', []),
             'required': kwargs.get('required', True),
-            }
+        }
         self.do_subproject(dirname, sp_kwargs)
         return self.get_subproject_dep(display_name, dirname, varname, kwargs)
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2415,6 +2415,9 @@ external dependencies (including libraries) must go to "dependencies".''')
                 current_active = self.active_projectname
                 subi.run()
                 mlog.log('\nSubproject', mlog.bold(dirname), 'finished.')
+            # Invalid code is always an error
+            except InvalidCode:
+                raise
             except Exception as e:
                 if not required:
                     mlog.log(e)
@@ -3069,25 +3072,8 @@ external dependencies (including libraries) must go to "dependencies".''')
             mlog.log('Looking for a fallback subproject for the dependency',
                      mlog.bold(display_name))
         dirname, varname = self.get_subproject_infos(kwargs)
-        # Try to execute the subproject
-        try:
-            sp_kwargs = {'default_options': kwargs.get('default_options', [])}
-            self.do_subproject(dirname, sp_kwargs)
-        # Invalid code is always an error
-        except InvalidCode:
-            raise
-        # If the subproject execution failed in a non-fatal way, don't raise an
-        # exception; let the caller handle things.
-        except Exception as e:
-            msg = ['Couldn\'t use fallback subproject in',
-                   mlog.bold(os.path.join(self.subproject_dir, dirname)),
-                   'for the dependency', mlog.bold(display_name), '\nReason:']
-            if isinstance(e, mesonlib.MesonException):
-                msg.append(e.get_msg_with_context())
-            else:
-                msg.append(traceback.format_exc())
-            mlog.log(*msg)
-            return None
+        sp_kwargs = {'default_options': kwargs.get('default_options', [])}
+        self.do_subproject(dirname, sp_kwargs)
         return self.get_subproject_dep(display_name, dirname, varname, kwargs)
 
     @FeatureNewKwargs('executable', '0.42.0', ['implib'])

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3003,10 +3003,9 @@ external dependencies (including libraries) must go to "dependencies".''')
             # ... search for it outside the project
             elif name != '':
                 self._handle_featurenew_dependencies(name)
-                try:
-                    dep = dependencies.find_external_dependency(name, self.environment, kwargs)
-                except DependencyException:
-                    pass
+                kwargs['required'] = required and not has_fallback
+                dep = dependencies.find_external_dependency(name, self.environment, kwargs)
+                kwargs['required'] = required
 
             # Search inside the projects list
             if not dep.found():

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3071,11 +3071,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         dirname, varname = self.get_subproject_infos(kwargs)
         # Try to execute the subproject
         try:
-            sp_kwargs = {}
-            try:
-                sp_kwargs['default_options'] = kwargs['default_options']
-            except KeyError:
-                pass
+            sp_kwargs = {'default_options': kwargs.get('default_options', [])}
             self.do_subproject(dirname, sp_kwargs)
         # Invalid code is always an error
         except InvalidCode:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2968,11 +2968,12 @@ external dependencies (including libraries) must go to "dependencies".''')
             mlog.log('Dependency', mlog.bold(display_name), 'skipped: feature', mlog.bold(feature), 'disabled')
             return self.notfound_dependency()
 
-        if 'default_options' in kwargs and 'fallback' not in kwargs:
+        has_fallback = 'fallback' in kwargs
+        if 'default_options' in kwargs and not has_fallback:
             mlog.warning('The "default_options" keyworg argument does nothing without a "fallback" keyword argument.')
 
         # writing just "dependency('')" is an error, because it can only fail
-        if name == '' and required and 'fallback' not in kwargs:
+        if name == '' and required and not has_fallback:
             raise InvalidArguments('Dependency is both required and not-found')
 
         if '<' in name or '>' in name or '=' in name:
@@ -2988,7 +2989,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         else:
             # If the dependency has already been configured, possibly by
             # a higher level project, try to use it first.
-            if 'fallback' in kwargs:
+            if has_fallback:
                 dirname, varname = self.get_subproject_infos(kwargs)
                 if dirname in self.subprojects:
                     return self.get_subproject_dep(display_name, dirname, varname, kwargs)
@@ -2997,7 +2998,7 @@ external dependencies (including libraries) must go to "dependencies".''')
             dep = NotFoundDependency(self.environment)
 
             # Unless a fallback exists and is forced ...
-            if self.coredata.get_builtin_option('wrap_mode') == WrapMode.forcefallback and 'fallback' in kwargs:
+            if self.coredata.get_builtin_option('wrap_mode') == WrapMode.forcefallback and has_fallback:
                 pass
             # ... search for it outside the project
             elif name != '':
@@ -3009,7 +3010,7 @@ external dependencies (including libraries) must go to "dependencies".''')
 
             # Search inside the projects list
             if not dep.found():
-                if 'fallback' in kwargs:
+                if has_fallback:
                     return self.dependency_fallback(display_name, kwargs)
 
         # Only store found-deps in the cache

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -749,7 +749,6 @@ The result of this is undefined and will become a hard error in a future Meson r
             except IndexError:
                 raise InterpreterException('Index %d out of bounds of array of size %d.' % (index, len(iobject)))
 
-
     def function_call(self, node):
         func_name = node.func_name
         (posargs, kwargs) = self.reduce_arguments(node.args)

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -195,12 +195,15 @@ def warning(*args, **kwargs):
 def deprecation(*args, **kwargs):
     return _log_error('deprecation', *args, **kwargs)
 
-def exception(e):
+def exception(e, prefix=red('ERROR:')):
     log()
+    args = []
     if hasattr(e, 'file') and hasattr(e, 'lineno') and hasattr(e, 'colno'):
-        log('%s:%d:%d:' % (e.file, e.lineno, e.colno), red('ERROR: '), e)
-    else:
-        log(red('ERROR:'), e)
+        args.append('%s:%d:%d:' % (e.file, e.lineno, e.colno))
+    if prefix:
+        args.append(prefix)
+    args.append(e)
+    log(*args)
 
 # Format a list for logging purposes as a string. It separates
 # all but the last item with commas, and the last with 'and'.

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -23,11 +23,10 @@ from . import ExtensionModule
 from mesonbuild.modules import ModuleReturnValue
 from ..interpreterbase import (
     noPosargs, noKwargs, permittedKwargs,
-    InterpreterObject, InvalidArguments,
+    InvalidArguments,
     FeatureNew, FeatureNewKwargs, disablerIfNotFound
 )
 from ..interpreter import ExternalProgramHolder, extract_required_kwarg
-from ..interpreterbase import flatten
 from ..build import known_shmod_kwargs
 from .. import mlog
 from ..environment import detect_cpu_family

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3502,23 +3502,22 @@ class FailureTests(BasePlatformTests):
         Test that:
         1. The correct message is outputted when a not-required dep is not
            found and the fallback subproject is also not found.
-        2. A not-found not-required dep with a fallback subproject outputs the
+        2. A not-required fallback dependency is not found because the
+           subproject failed to parse.
+        3. A not-found not-required dep with a fallback subproject outputs the
            correct message when the fallback subproject is found but the
            variable inside it is not.
-        3. A fallback dependency is found from the subproject parsed in (2)
-        4. A not-required fallback dependency is not found because the
-           subproject failed to parse.
+        4. A fallback dependency is found from the subproject parsed in (3)
+        5. The correct message is outputted when the .wrap file is missing for
+           a sub-subproject.
         '''
         tdir = os.path.join(self.unit_test_dir, '20 subproj dep variables')
         out = self.init(tdir, inprocess=True)
-        self.assertRegex(out, r"Couldn't use fallback subproject "
-                         "in.*subprojects.*nosubproj.*for the dependency.*somedep")
-        self.assertRegex(out, r'Dependency.*somenotfounddep.*from subproject.*'
-                         'subprojects.*somesubproj.*found:.*NO')
-        self.assertRegex(out, r'Dependency.*zlibproxy.*from subproject.*'
-                         'subprojects.*somesubproj.*found:.*YES.*(cached)')
-        self.assertRegex(out, r'Couldn\'t use fallback subproject in '
-                         '.*subprojects.*failingsubproj.*for the dependency.*somedep')
+        self.assertRegex(out, r"Subproject directory not found and .*nosubproj.wrap.* file not found")
+        self.assertRegex(out, r'Function does not take positional arguments.')
+        self.assertRegex(out, r'WARNING:.* Dependency .*subsubproject.* not found but it is available in a sub-subproject.')
+        self.assertRegex(out, r'Subproject directory not found and .*subsubproject.wrap.* file not found')
+        self.assertRegex(out, r'Dependency .*zlibproxy.* from subproject .*subprojects.*somesubproj.* found: .*YES.*')
 
     def test_exception_exit_status(self):
         '''

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3471,7 +3471,7 @@ class FailureTests(BasePlatformTests):
         code = '''zlib_dep = dependency('zlib', required : false)
         zlib_dep.get_configtool_variable('foo')
         '''
-        self.assertMesonRaises(code, "'zlib' is not a config-tool dependency")
+        self.assertMesonRaises(code, ".* is not a config-tool dependency")
         code = '''zlib_dep = dependency('zlib', required : false)
         dep = declare_dependency(dependencies : zlib_dep)
         dep.get_pkgconfig_variable('foo')

--- a/test cases/common/170 dependency factory/meson.build
+++ b/test cases/common/170 dependency factory/meson.build
@@ -1,4 +1,4 @@
-project('dependency factory', meson_version : '>=0.40')
+project('dependency factory', 'c', meson_version : '>=0.40')
 
 dep = dependency('gl', method: 'pkg-config', required: false)
 if dep.found() and dep.type_name() == 'pkgconfig'

--- a/test cases/unit/20 subproj dep variables/meson.build
+++ b/test cases/unit/20 subproj dep variables/meson.build
@@ -11,3 +11,6 @@ dependency('somenotfounddep', required : false,
 
 dependency('zlibproxy', required : true,
            fallback : ['somesubproj', 'zlibproxy_dep'])
+
+dependency('somedep', required : false,
+           fallback : ['nestedsubproj', 'nestedsubproj_dep'])

--- a/test cases/unit/20 subproj dep variables/subprojects/nestedsubproj/meson.build
+++ b/test cases/unit/20 subproj dep variables/subprojects/nestedsubproj/meson.build
@@ -1,0 +1,3 @@
+project('dep', 'c')
+
+subproject('subsubproject')

--- a/test cases/unit/20 subproj dep variables/subprojects/nestedsubproj/subprojects/subsubproject.wrap
+++ b/test cases/unit/20 subproj dep variables/subprojects/nestedsubproj/subprojects/subsubproject.wrap
@@ -1,0 +1,1 @@
+[wrap-file]


### PR DESCRIPTION
While working on dependency fallbacks and overrides, I found that code should be cleaned first. This is a big PR, I tried to split in many small commits.