### PR TITLE
fail configuration if PCH files do not exist

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1082,6 +1082,9 @@ You probably should put it in link_with instead.''')
                 raise InvalidArguments('PCH argument %s is of unknown type.' % pchlist[0])
         elif len(pchlist) > 2:
             raise InvalidArguments('PCH definition may have a maximum of 2 files.')
+        for f in pchlist:
+            if not os.path.isfile(os.path.join(self.environment.source_dir, self.subdir, f)):
+                raise MesonException('File %s does not exist.' % f)
         self.pch[language] = pchlist
 
     def add_include_dirs(self, args):

--- a/test cases/failing/92 missing pch file/meson.build
+++ b/test cases/failing/92 missing pch file/meson.build
@@ -1,0 +1,3 @@
+project('pch test', 'c')
+exe = executable('prog', 'prog.c',
+c_pch : ['pch/prog_pch.c', 'pch/prog.h'])

--- a/test cases/failing/92 missing pch file/prog.c
+++ b/test cases/failing/92 missing pch file/prog.c
@@ -1,0 +1,3 @@
+int main(int argc, char **argv) {
+    return 0;
+}


### PR DESCRIPTION
Previously, the configuration worked fine, but the compiler raised an error. Now, we explicitly check for the existence of files and print a useful error message if they do not exist.

It would probably be cleaner if PCH files would be treated as `File` and not as `str`, but I didn't want to dig too deep into each backend and change this all over the place.