### PR TITLE
compile pch .h file as c++-header when building a c++ target

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2184,6 +2184,10 @@ rule FORTRAN_DEP_HACK%s
 
     def generate_gcc_pch_command(self, target, compiler, pch):
         commands = self._generate_single_compile(target, compiler)
+        if pch.split('.')[-1] == 'h' and compiler.language == 'cpp':
+            # Explicitly compile pch headers as C++. If Clang is invoked in C++ mode, it actually warns if
+            # this option is not set, and for gcc it also makes sense to use it.
+            commands += ['-x', 'c++-header']
         dst = os.path.join(self.get_target_private_dir(target),
                            os.path.basename(pch) + '.' + compiler.get_pch_suffix())
         dep = dst + '.' + compiler.get_depfile_suffix()


### PR DESCRIPTION
Fixes #3641.