### PR TITLE
fix meson configure exception when install_umask is not an int

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -116,7 +116,7 @@ class UserUmaskOption(UserIntegerOption):
 
     def validate_value(self, value):
         if value is None or value == 'preserve':
-            return None
+            return 'preserve'
         return super().validate_value(value)
 
     def toint(self, valuestring):

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -106,7 +106,7 @@ class Conf:
             v = o.value
             c = o.choices
             if isinstance(o, coredata.UserUmaskOption):
-                v = format(v, '04o')
+                v = v if isinstance(v, str) else format(v, '04o')
             arr.append({'name': k, 'descr': d, 'value': v, 'choices': c})
         self.print_aligned(arr)
 

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -106,7 +106,7 @@ def set_chmod(path, mode, dir_fd=None, follow_symlinks=True):
             os.chmod(path, mode, dir_fd=dir_fd)
 
 def sanitize_permissions(path, umask):
-    if umask is None:
+    if umask == 'preserve':
         return
     new_perms = 0o777 if is_executable(path, follow_symlinks=False) else 0o666
     new_perms &= ~umask
@@ -332,7 +332,7 @@ class Installer:
         d.destdir = os.environ.get('DESTDIR', '')
         d.fullprefix = destdir_join(d.destdir, d.prefix)
 
-        if d.install_umask is not None:
+        if d.install_umask != 'preserve':
             os.umask(d.install_umask)
 
         self.did_install_something = False


### PR DESCRIPTION
Without this, e.g. in test case `common/63 install subdir` it raised `TypeError: unsupported format string passed to NoneType.__format__` when using `meson configure` to list the configuration.

Do we need a test for this?