### PR TITLE
vs: add reconfigure checks for each target

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -312,8 +312,6 @@ class Vs2010Backend(backends.Backend):
                     target_dict, recursive=True)
                 ofile.write('\tProjectSection(ProjectDependencies) = '
                             'postProject\n')
-                regen_guid = self.environment.coredata.regen_guid
-                ofile.write('\t\t{%s} = {%s}\n' % (regen_guid, regen_guid))
                 for dep in all_deps.keys():
                     guid = self.environment.coredata.target_guids[dep]
                     ofile.write('\t\t{%s} = {%s}\n' % (guid, guid))


### PR DESCRIPTION
Previously, this was only added to C/C++ targets, but not for others.
Thus, if you'd change a setting through `meson configure`, this was not picked up, e.g. the install target said it was up-to-date and when force rebuilding it, it also did not use the new settings until the build dir was manually reconfigured.

Note: This is not ready to be merged, yet. If you currently change a setting with `meson configure`, the REGEN target gets invalidated. However, the INSTALL target still says it's up-to-date and does not do anything. We probably have to add an internal file as input to the meta-targets to be sure they are run if REGEN was triggered.