### PR TITLE
pkgconfig: Fix flag deduplication

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -192,7 +192,11 @@ class DependenciesHelper:
             for x in xs:
                 # Don't de-dup unknown strings to avoid messing up arguments like:
                 # ['-framework', 'CoreAudio', '-framework', 'CoreMedia']
-                if x not in result or (libs and (isinstance(x, str) and not x.endswith(('-l', '-L')))):
+                known_flags = ['-pthread']
+                cannot_dedup = libs and isinstance(x, str) and \
+                    not x.startswith(('-l', '-L')) and \
+                    x not in known_flags
+                if x not in result or cannot_dedup:
                     result.append(x)
             return result
         self.pub_libs = _fn(self.pub_libs, True)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3650,26 +3650,30 @@ class LinuxlikeTests(BasePlatformTests):
         privatedir2 = self.privatedir
 
         os.environ['PKG_CONFIG_LIBDIR'] = os.pathsep.join([privatedir1, privatedir2])
-        cmd = ['pkg-config', 'dependency-test']
+        self._run(['pkg-config', 'dependency-test', '--validate'])
 
-        out = self._run(cmd + ['--print-requires']).strip().split('\n')
-        self.assertEqual(sorted(out), sorted(['libexposed']))
-
-        out = self._run(cmd + ['--print-requires-private']).strip().split('\n')
-        self.assertEqual(sorted(out), sorted(['libfoo >= 1.0']))
-
-        out = self._run(cmd + ['--cflags-only-other']).strip().split()
-        self.check_pkg_flags_are_same(out, ['-pthread', '-DCUSTOM'])
-
-        out = self._run(cmd + ['--libs-only-l', '--libs-only-other']).strip().split()
-        self.check_pkg_flags_are_same(out, ['-pthread', '-lcustom',
-                                            '-llibmain', '-llibexposed'])
-
-        out = self._run(cmd + ['--libs-only-l', '--libs-only-other', '--static']).strip().split()
-        self.check_pkg_flags_are_same(out, ['-pthread', '-lcustom',
-                                            '-llibmain', '-llibexposed',
-                                            '-llibinternal', '-lcustom2',
-                                            '-lfoo'])
+        # pkg-config strips some duplicated flags so we have to parse the
+        # generated file ourself.
+        expected = {
+            'Requires': 'libexposed',
+            'Requires.private': 'libfoo >= 1.0',
+            'Libs': '-L${libdir} -llibmain -pthread -lcustom',
+            'Libs.private': '-lcustom2 -L${libdir} -llibinternal',
+            'Cflags': '-I${includedir} -pthread -DCUSTOM',
+        }
+        if is_osx() or is_haiku():
+            expected['Cflags'] = expected['Cflags'].replace('-pthread ', '')
+        with open(os.path.join(privatedir2, 'dependency-test.pc')) as f:
+            matched_lines = 0
+            for line in f:
+                parts = line.split(':', 1)
+                if parts[0] in expected:
+                    key = parts[0]
+                    val = parts[1].strip()
+                    expected_val = expected[key]
+                    self.assertEqual(expected_val, val)
+                    matched_lines += 1
+            self.assertEqual(len(expected), matched_lines)
 
         cmd = ['pkg-config', 'requires-test']
         out = self._run(cmd + ['--print-requires']).strip().split('\n')
@@ -3678,11 +3682,6 @@ class LinuxlikeTests(BasePlatformTests):
         cmd = ['pkg-config', 'requires-private-test']
         out = self._run(cmd + ['--print-requires-private']).strip().split('\n')
         self.assertEqual(sorted(out), sorted(['libexposed', 'libfoo >= 1.0', 'libhello']))
-
-    def check_pkg_flags_are_same(self, output, expected):
-        if is_osx() or is_haiku():
-            expected = [x for x in expected if x != '-pthread']
-        self.assertEqual(sorted(output), sorted(expected))
 
     def test_pkg_unfound(self):
         testdir = os.path.join(self.unit_test_dir, '23 unfound pkgconfig')

--- a/test cases/common/48 pkgconfig-gen/dependencies/meson.build
+++ b/test cases/common/48 pkgconfig-gen/dependencies/meson.build
@@ -28,8 +28,8 @@ custom2_dep = declare_dependency(link_args : ['-lcustom2'], compile_args : ['-DC
 # - Having pc_dep in libraries_private should add it in Requires.private
 # - pc_dep_dup is the same library and same version, should be ignored
 # - notfound_dep is not required so it shouldn't appear in the pc file.
-pkgg.generate(libraries : [main_lib, exposed_lib, threads_dep , custom_dep],
-  libraries_private : [custom_dep, custom2_dep, pc_dep, pc_dep_dup, notfound_dep],
+pkgg.generate(libraries : [main_lib, exposed_lib, threads_dep, threads_dep, custom_dep, custom_dep, '-pthread'],
+  libraries_private : [custom_dep, custom2_dep, custom2_dep, pc_dep, pc_dep_dup, notfound_dep],
   version : '1.0',
   name : 'dependency-test',
   filebase : 'dependency-test',


### PR DESCRIPTION
This is a regression introduced by 2cbf7caf5, generated pkg-config files
have many duplicated '-pthread' flags.