### PR TITLE
Allow cross compiling for Windows under cmd.exe or Bash

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1413,7 +1413,7 @@ int dummy;
                     command_template = ' command = {executable} $ARGS {output_args} $in $LINK_ARGS {cross_args} $aliasing\n'
                 command = command_template.format(
                     executable=' '.join(compiler.get_linker_exelist()),
-                    cross_args=' '.join(cross_args),
+                    cross_args=' '.join([quote_func(i) for i in cross_args]),
                     output_args=' '.join(compiler.get_linker_output_args('$out'))
                 )
                 description = ' description = Linking target $out.\n'
@@ -1541,7 +1541,7 @@ rule FORTRAN_DEP_HACK%s
             command_template = ' command = {executable} $ARGS {cross_args} {output_args} {compile_only_args} $in\n'
         command = command_template.format(
             executable=' '.join([ninja_quote(i) for i in compiler.get_exelist()]),
-            cross_args=' '.join(compiler.get_cross_extra_flags(self.environment, False)) if is_cross else '',
+            cross_args=' '.join([quote_func(i) for i in compiler.get_cross_extra_flags(self.environment, False)]) if is_cross else '',
             output_args=' '.join(compiler.get_output_args('$out')),
             compile_only_args=' '.join(compiler.get_compile_only_args())
         )
@@ -1599,7 +1599,7 @@ rule FORTRAN_DEP_HACK%s
             command_template = ' command = {executable} $ARGS {cross_args} {dep_args} {output_args} {compile_only_args} $in\n'
         command = command_template.format(
             executable=' '.join([ninja_quote(i) for i in compiler.get_exelist()]),
-            cross_args=' '.join(cross_args),
+            cross_args=' '.join([quote_func(i) for i in cross_args]),
             dep_args=' '.join(quoted_depargs),
             output_args=' '.join(compiler.get_output_args('$out')),
             compile_only_args=' '.join(compiler.get_compile_only_args())
@@ -1643,7 +1643,7 @@ rule FORTRAN_DEP_HACK%s
             output = ' '.join(compiler.get_output_args('$out'))
         command = " command = {executable} $ARGS {cross_args} {dep_args} {output_args} {compile_only_args} $in\n".format(
             executable=' '.join(compiler.get_exelist()),
-            cross_args=' '.join(cross_args),
+            cross_args=' '.join([quote_func(i) for i in cross_args]),
             dep_args=' '.join(quoted_depargs),
             output_args=output,
             compile_only_args=' '.join(compiler.get_compile_only_args())


### PR DESCRIPTION
Since trying to use a Clang based -cross-file.txt for cross compiling Windows binaries from Linux I found that Meson was using `is_windows()` to imply that `cmd` should be used as the shell for ninja commands and also since many of the paths in the cross-file were something like:  `/mnt/c/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.15.26726/lib/x64` I also found some more places where Meson wasn't adding escape characters for the shell.