### PR TITLE
rpm: remove manual printing of error logs on failure

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -31,9 +31,4 @@
     %ninja_install -C %{_vpath_builddir}
 
 %meson_test \
-    %ninja_test -C %{_vpath_builddir} || \
-    ( rc=$?; \
-      echo "-----BEGIN TESTLOG-----"; \
-      cat %{_vpath_builddir}/meson-logs/testlog.txt; \
-      echo "-----END TESTLOG-----"; \
-      exit $rc; )
+    %ninja_test -C %{_vpath_builddir}


### PR DESCRIPTION
This effectively reverts 92219a2739ea69fa617cca74517b68ed5e1bcb7d.
Back in the day, meson test would not print the logs on failure. But it now
does that automatically, for the failed test. Printing all logs is annoying because
it results in exteremely long output in some packages.

Example output:
```
+ /usr/bin/ninja test -v -j4 -C x86_64-redhat-linux-gnu
ninja: Entering directory `x86_64-redhat-linux-gnu'
[0/1] /usr/bin/meson test --no-rebuild --print-errorlogs
 1/16 test-script.sh                          OK      46.23 s
...
14/16 test-casync                             FAIL     1.17 s (exit status 1)
15/16 test-cautil                             OK       0.00 s
16/16 test-util                               OK       0.01 s

Ok:                   15
Expected Fail:         0
Fail:                  1
Unexpected Pass:       0
Skipped:               0
Timeout:               0

The output from the failed tests:

14/16 test-casync                             FAIL     1.17 s (exit status 1)

--- command ---
/home/zbyszek/fedora/casync/casync-2/x86_64-redhat-linux-gnu/test-casync
--- stdout ---
error
-------
```

/cc @ignatenkobrain 