### PR TITLE
Replace surrogates with valid codepoints to print env

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -647,8 +647,8 @@ Timeout:            %4d
         self.logfilename = logfile_base + '.txt'
         self.jsonlogfilename = logfile_base + '.json'
 
-        self.jsonlogfile = open(self.jsonlogfilename, 'w', encoding='utf-8')
-        self.logfile = open(self.logfilename, 'w', encoding='utf-8')
+        self.jsonlogfile = open(self.jsonlogfilename, 'w', encoding='utf-8', errors='replace')
+        self.logfile = open(self.logfilename, 'w', encoding='utf-8', errors='surrogateescape')
 
         self.logfile.write('Log of Meson test suite run on %s\n\n'
                            % datetime.datetime.now().isoformat())


### PR DESCRIPTION
When python sees an invalid character in a filename for the current locale, instead of clobbering it, it saves is as an invalid codepoint called a surrogate.  We need to explicitly instruct the encoder to write those out as-is. In the JSON file, we replace them instead to produce valid json.

Fixes #4718 