### PR TITLE
parser: Fix line continuation outside of (), [] or {}

### DIFF
--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -190,7 +190,11 @@ This will become a hard error in a future Meson release.""", self.getline(line_s
                             line_start = mo.end() - len(lines[-1])
                     elif tid == 'number':
                         value = int(match_text, base=0)
-                    elif tid == 'eol' or tid == 'eol_cont':
+                    elif tid == 'eol_cont':
+                        lineno += 1
+                        line_start = loc
+                        break
+                    elif tid == 'eol':
                         lineno += 1
                         line_start = loc
                         if par_count > 0 or bracket_count > 0 or curl_count > 0:

--- a/test cases/common/210 line continuation/meson.build
+++ b/test cases/common/210 line continuation/meson.build
@@ -1,0 +1,17 @@
+project('line continuation')
+
+a = 1
+b = 2
+
+c = a \
++b
+assert(c == 3, 'Line continuation is not working')
+
+d = a + \
+  b
+assert(d == 3, 'Line continuation is not working')
+
+if a == 1 and \
+   b == 3
+  error('Line continuation in "if" condition is not working')
+endif


### PR DESCRIPTION
The documentation states: "In other cases you can get multi-line
statements by ending the line with a \." but that seems to never have
worked.

Closes: #4720