### PR TITLE
Fix linking when cross-compiling and a windows resource is first object

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1302,6 +1302,13 @@ class VisualStudioCCompiler(CCompiler):
         self.base_options = ['b_pch', 'b_ndebug', 'b_vscrt'] # FIXME add lto, pgo and the like
         self.target = target
         self.is_64 = ('x64' in target) or ('x86_64' in target)
+        # do some canonicalization of target machine
+        if 'x86_64' in target:
+            self.machine = 'x64'
+        elif '86' in target:
+            self.machine = 'x86'
+        else:
+            self.machine = target
 
     # Override CCompiler.get_always_args
     def get_always_args(self):
@@ -1378,7 +1385,7 @@ class VisualStudioCCompiler(CCompiler):
         return ['/nologo']
 
     def get_linker_output_args(self, outputname):
-        return ['/OUT:' + outputname]
+        return ['/MACHINE:' + self.machine, '/OUT:' + outputname]
 
     def get_linker_search_args(self, dirname):
         return ['/LIBPATH:' + dirname]

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1050,7 +1050,7 @@ class Environment:
                 popen_exceptions[' '.join(linker + [arg])] = e
                 continue
             if '/OUT:' in out.upper() or '/OUT:' in err.upper():
-                return VisualStudioLinker(linker)
+                return VisualStudioLinker(linker, getattr(compiler, 'machine', None))
             if p.returncode == 0 and ('armar' in linker or 'armar.exe' in linker):
                 return ArmarLinker(linker)
             if 'DMD32 D Compiler' in out or 'DMD64 D Compiler' in out:

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -26,8 +26,9 @@ class StaticLinker:
 class VisualStudioLinker(StaticLinker):
     always_args = ['/NOLOGO']
 
-    def __init__(self, exelist):
+    def __init__(self, exelist, machine):
         self.exelist = exelist
+        self.machine = machine
 
     def get_exelist(self):
         return self.exelist[:]
@@ -39,7 +40,11 @@ class VisualStudioLinker(StaticLinker):
         return []
 
     def get_output_args(self, target):
-        return ['/OUT:' + target]
+        args = []
+        if self.machine:
+            args += ['/MACHINE:' + self.machine]
+        args += ['/OUT:' + target]
+        return args
 
     def get_coverage_link_args(self):
         return []

--- a/test cases/windows/5 resources/res/meson.build
+++ b/test cases/windows/5 resources/res/meson.build
@@ -3,3 +3,7 @@ win = import('windows')
 res = win.compile_resources('myres.rc',
   depend_files: 'sample.ico',
   include_directories : inc)
+
+# test that with MSVC tools, LIB/LINK invokes CVTRES with correct /MACHINE
+static_library('reslib', res, 'dummy.c')
+shared_library('shreslib', res, 'dummy.c')


### PR DESCRIPTION
Closes #4463.  Supersedes #4040.
