### PR TITLE
main: warn in case meson is run with the C locale

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -165,6 +165,12 @@ def run(original_args, mainfile):
             mlog.error('Please download and use Python as detailed at: https://mesonbuild.com/Getting-meson.html')
         return 2
 
+    if os.name != 'nt' and sys.getfilesystemencoding() == 'ascii':
+        mlog.warning(
+            'Python is configured to use an ASCII encoding, which is not '
+            'supported. Try setting LANG to C.UTF-8 in your environment or '
+            'any other utf-8 locale listed by \'locale -a\'')
+
     # Set the meson command that will be used to run scripts and so on
     mesonlib.set_meson_command(mainfile)
 


### PR DESCRIPTION
With Python 3.5/6 running with the C locale the locale encoding is ascii and filenames are
decoded with ascii as well. This will lead to filenames with surrogate escapes for anything
outside ascii and will result in errors when passing those to API which expects unicode.
Similarly passing unicode to API which expects properly decoded filenames might also fail.

Since meson doesn't differentiate between text and filenames in many places this is hard to fix.

But in a properly configured environment with a utf-8 compatible locale this is hardly a problem
because all unicode is a valid filename and only filenames with an invalid encoding (which is rare)
can cause errors when passing them to unicode-only API.

This makes meson print a warning in case it detects the C locale and suggests using a utf-8 one instead.

This warning can be triggered with "LANG=C python3.6 meson.py"

See #4718