### PR TITLE
mintro: Changes to the introspection API

### DIFF
--- a/docs/markdown/snippets/introspect_breaking_format.md
+++ b/docs/markdown/snippets/introspect_breaking_format.md
@@ -2,7 +2,10 @@
 
 All paths used in the meson introspection JSON format are now absolute. This
 affects the `filename` key in the targets introspection and the output of
-`--target-files` and `--buildsystem-files`.
+`--buildsystem-files`.
 
 Furthermore, the `filename` and `install_filename` keys in the targets
 introspection are now lists of strings with identical length.
+
+The `--traget-files` option is now deprecated, since the same information
+can be acquired from the `--tragets` introspection API.

--- a/docs/markdown/snippets/introspect_breaking_format.md
+++ b/docs/markdown/snippets/introspect_breaking_format.md
@@ -1,0 +1,8 @@
+## Changed the JSON format of the introspection
+
+All paths used in the meson introspection JSON format are now absolute. This
+affects the `filename` key in the targets introspection and the output of
+`--target-files` and `--buildsystem-files`.
+
+Furthermore, the `filename` and `install_filename` keys in the targets
+introspection are now lists of strings with identical length.

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2565,7 +2565,6 @@ int main(int argc, char **argv) {
         for t in t_intro:
             id = t['id']
             tf_intro = self.introspect(['--target-files', id])
-            tf_intro = list(map(lambda x: os.path.relpath(x, testdir), tf_intro))
             self.assertEqual(tf_intro, expected[id])
         self.wipe()
 
@@ -2580,7 +2579,6 @@ int main(int argc, char **argv) {
         for t in t_intro:
             id = t['id']
             tf_intro = self.introspect(['--target-files', id])
-            tf_intro = list(map(lambda x: os.path.relpath(x, testdir), tf_intro))
             self.assertEqual(tf_intro, expected[id])
         self.wipe()
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1439,7 +1439,7 @@ class AllPlatformTests(BasePlatformTests):
         # Get name of static library
         targets = self.introspect('--targets')
         self.assertEqual(len(targets), 1)
-        libname = targets[0]['filename'] # TODO Change filename back to a list again
+        libname = targets[0]['filename'][0]
         # Build and get contents of static library
         self.build()
         before = self._run(['ar', 't', os.path.join(self.builddir, libname)]).split()
@@ -1496,8 +1496,8 @@ class AllPlatformTests(BasePlatformTests):
         intro = self.introspect('--targets')
         if intro[0]['type'] == 'executable':
             intro = intro[::-1]
-        self.assertPathListEqual([intro[0]['install_filename']], ['/usr/lib/libstat.a'])
-        self.assertPathListEqual([intro[1]['install_filename']], ['/usr/bin/prog' + exe_suffix])
+        self.assertPathListEqual(intro[0]['install_filename'], ['/usr/lib/libstat.a'])
+        self.assertPathListEqual(intro[1]['install_filename'], ['/usr/bin/prog' + exe_suffix])
 
     def test_install_introspection_multiple_outputs(self):
         '''
@@ -1514,14 +1514,10 @@ class AllPlatformTests(BasePlatformTests):
         intro = self.introspect('--targets')
         if intro[0]['type'] == 'executable':
             intro = intro[::-1]
-        #self.assertPathListEqual(intro[0]['install_filename'], ['/usr/include/diff.h', '/usr/bin/diff.sh'])
-        #self.assertPathListEqual(intro[1]['install_filename'], ['/opt/same.h', '/opt/same.sh'])
-        #self.assertPathListEqual(intro[2]['install_filename'], ['/usr/include/first.h', None])
-        #self.assertPathListEqual(intro[3]['install_filename'], [None, '/usr/bin/second.sh'])
-        self.assertPathListEqual([intro[0]['install_filename']], ['/usr/include/diff.h'])
-        self.assertPathListEqual([intro[1]['install_filename']], ['/opt/same.h'])
-        self.assertPathListEqual([intro[2]['install_filename']], ['/usr/include/first.h'])
-        self.assertPathListEqual([intro[3]['install_filename']], [None])
+        self.assertPathListEqual(intro[0]['install_filename'], ['/usr/include/diff.h', '/usr/bin/diff.sh'])
+        self.assertPathListEqual(intro[1]['install_filename'], ['/opt/same.h', '/opt/same.sh'])
+        self.assertPathListEqual(intro[2]['install_filename'], ['/usr/include/first.h', None])
+        self.assertPathListEqual(intro[3]['install_filename'], [None, '/usr/bin/second.sh'])
 
     def test_uninstall(self):
         exename = os.path.join(self.installdir, 'usr/bin/prog' + exe_suffix)
@@ -2569,7 +2565,7 @@ int main(int argc, char **argv) {
         for t in t_intro:
             id = t['id']
             tf_intro = self.introspect(['--target-files', id])
-            #tf_intro = list(map(lambda x: os.path.relpath(x, testdir), tf_intro)) TODO make paths absolute in future PR
+            tf_intro = list(map(lambda x: os.path.relpath(x, testdir), tf_intro))
             self.assertEqual(tf_intro, expected[id])
         self.wipe()
 
@@ -2584,9 +2580,7 @@ int main(int argc, char **argv) {
         for t in t_intro:
             id = t['id']
             tf_intro = self.introspect(['--target-files', id])
-            print(tf_intro)
-            #tf_intro = list(map(lambda x: os.path.relpath(x, testdir), tf_intro)) TODO make paths absolute in future PR
-            print(tf_intro)
+            tf_intro = list(map(lambda x: os.path.relpath(x, testdir), tf_intro))
             self.assertEqual(tf_intro, expected[id])
         self.wipe()
 
@@ -3180,7 +3174,7 @@ recommended as it is not supported on some platforms''')
             ('name', str),
             ('id', str),
             ('type', str),
-            ('filename', str),
+            ('filename', list),
             ('build_by_default', bool),
             ('target_sources', list),
             ('installed', bool),
@@ -4417,7 +4411,7 @@ class LinuxlikeTests(BasePlatformTests):
                 break
         self.assertIsInstance(docbook_target, dict)
         ifile = self.introspect(['--target-files', 'generated-gdbus-docbook@cus'])[0]
-        self.assertListEqual([t['filename']], ['gdbus/generated-gdbus-doc-' + os.path.basename(ifile)])
+        self.assertListEqual(t['filename'], [os.path.join(self.builddir ,'gdbus/generated-gdbus-doc-' + os.path.basename(ifile))])
 
     def test_build_rpath(self):
         if is_cygwin():

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4413,7 +4413,7 @@ class LinuxlikeTests(BasePlatformTests):
                 break
         self.assertIsInstance(docbook_target, dict)
         ifile = self.introspect(['--target-files', 'generated-gdbus-docbook@cus'])[0]
-        self.assertListEqual(t['filename'], [os.path.join(self.builddir ,'gdbus/generated-gdbus-doc-' + os.path.basename(ifile))])
+        self.assertListEqual(t['filename'], [os.path.join(self.builddir, 'gdbus/generated-gdbus-doc-' + os.path.basename(ifile))])
 
     def test_build_rpath(self):
         if is_cygwin():

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3225,7 +3225,9 @@ recommended as it is not supported on some platforms''')
         self.assertDictEqual(buildopts_to_find, {})
 
         # Check buildsystem_files
-        self.assertPathListEqual(res['buildsystem_files'], ['meson.build', 'sharedlib/meson.build', 'staticlib/meson.build'])
+        bs_files = ['meson.build', 'sharedlib/meson.build', 'staticlib/meson.build']
+        bs_files = [os.path.join(testdir, x) for x in bs_files]
+        self.assertPathListEqual(res['buildsystem_files'], bs_files)
 
         # Check dependencies
         dependencies_to_find = ['threads']


### PR DESCRIPTION
This is a followup PR to #4547. This PR introduces the format changes to the introspection API discussed in the original PR.

Most notably the `filename` and `install_filename` keys in the targets introspection are now always lists and all file paths are now absolute.

cc: @textshell 