### PR TITLE
use same code for printing options in mconf and msetup

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -43,6 +43,9 @@ class UserOption:
             raise MesonException('Value of "yielding" must be a boolean.')
         self.yielding = yielding
 
+    def printable_value(self):
+        return self.value
+
     # Check that the input is a valid value and return the
     # "cleaned" or "native" version. For example the Boolean
     # option could take the string "true" and return True.
@@ -113,6 +116,11 @@ class UserUmaskOption(UserIntegerOption):
     def __init__(self, name, description, value, yielding=None):
         super().__init__(name, description, 0, 0o777, value, yielding)
         self.choices = ['preserve', '0000-0777']
+
+    def printable_value(self):
+        if self.value == 'preserve':
+            return self.value
+        return format(self.value, '04o')
 
     def validate_value(self, value):
         if value is None or value == 'preserve':

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2034,7 +2034,7 @@ class Interpreter(InterpreterBase):
                 for cur_opt_name, cur_opt_value in option_type.items():
                     if (def_opt_name == cur_opt_name and
                             def_opt_value != cur_opt_value.value):
-                        yield (def_opt_name, def_opt_value, cur_opt_value.value)
+                        yield (def_opt_name, def_opt_value, cur_opt_value)
 
     def build_func_dict(self):
         self.funcs.update({'add_global_arguments': self.func_add_global_arguments,

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -23,6 +23,15 @@ def add_arguments(parser):
                         help='Clear cached state (e.g. found dependencies)')
 
 
+def make_lower_case(val):
+    if isinstance(val, bool):
+        return str(val).lower()
+    elif isinstance(val, list):
+        return [make_lower_case(i) for i in val]
+    else:
+        return str(val)
+
+
 class ConfException(mesonlib.MesonException):
     pass
 
@@ -50,14 +59,6 @@ class Conf:
 
     @staticmethod
     def print_aligned(arr):
-        def make_lower_case(val):
-            if isinstance(val, bool):
-                return str(val).lower()
-            elif isinstance(val, list):
-                return [make_lower_case(i) for i in val]
-            else:
-                return str(val)
-
         if not arr:
             return
 
@@ -104,10 +105,8 @@ class Conf:
         for k in sorted(options):
             o = options[k]
             d = o.description
-            v = o.value
+            v = o.printable_value()
             c = o.choices
-            if isinstance(o, coredata.UserUmaskOption):
-                v = v if isinstance(v, str) else format(v, '04o')
             arr.append({'name': k, 'descr': d, 'value': v, 'choices': c})
         self.print_aligned(arr)
 

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -24,6 +24,7 @@ from . import environment, interpreter, mesonlib
 from . import build
 from . import mlog, coredata
 from . import mintro
+from .mconf import make_lower_case
 from .mesonlib import MesonException
 
 def add_arguments(parser):
@@ -192,8 +193,8 @@ class MesonApp:
         # Print all default option values that don't match the current value
         for def_opt_name, def_opt_value, cur_opt_value in intr.get_non_matching_default_options():
             mlog.log('Option', mlog.bold(def_opt_name), 'is:',
-                     mlog.bold(str(cur_opt_value)),
-                     '[default: {}]'.format(str(def_opt_value)))
+                     mlog.bold(make_lower_case(cur_opt_value.printable_value())),
+                     '[default: {}]'.format(make_lower_case(def_opt_value)))
         try:
             dumpfile = os.path.join(env.get_scratch_dir(), 'build.dat')
             # We would like to write coredata as late as possible since we use the existence of


### PR DESCRIPTION
Also, options are now responsible for providing a suitable printable
representation of their value instead of handling this at the caller.