### PR TITLE
Fix finding the static linker for native compiler in cross build

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1019,7 +1019,8 @@ class Environment:
         return comp, cross_comp
 
     def detect_static_linker(self, compiler):
-        linker = self.binaries.host.lookup_entry('ar')
+        for_machine = MachineChoice.HOST if compiler.is_cross else MachineChoice.BUILD
+        linker = self.binaries[for_machine].lookup_entry('ar')
         if linker is not None:
             linkers = [linker]
         else:


### PR DESCRIPTION
Native ar and cross ar are not the same!