### PR TITLE
Overhaul pkg-config and CMake lookup, fixing the latter

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -433,6 +433,7 @@ class Environment:
         self.cuda_static_linker = ['nvlink']
         self.gcc_static_linker = ['gcc-ar']
         self.clang_static_linker = ['llvm-ar']
+        self.default_cmake = ['cmake']
         self.default_pkgconfig = ['pkg-config']
 
         # Various prefixes and suffixes for import libraries, shared libraries,
@@ -1503,6 +1504,7 @@ class BinaryTable:
         'ar': 'AR',
         'windres': 'WINDRES',
 
+        'cmake': 'CMAKE',
         'pkgconfig': 'PKG_CONFIG',
     }
 


### PR DESCRIPTION
First, I noticed there was a dangling use of now-removed cross_info in the CMake lookup. No tests had caught this, but it means that CMake deps were totally broken. \[It also meant that CMake could not be specified from a native file.]

In a previous of mine PR which removed cross_info, I overhauled finding pkg-config a bit so that the native and cross paths were shared. I noticed that the CMake code greatly resembled the pkg-config code, so I set about fixing it to match.

I then realized I could refactor things further, separating caching, finding alternatives, and validating them, while also making the validations less duplicated. So I ended up changing pkg config lookup a lot too (and CMake again, to keep matching).

Overall, I think I have the proper idiom for tool lookup now, repeated in two places. I think it would make sense next to share this logic between these two, compilers, static linkers, and any other tool similarly specifiable. Either the `BinaryTable` class in environment.py, or a new class for `Compiler` and friends to subclass, would be good candidates for this.

CC @dcbaker