### PR TITLE
OpenBSD: register machine cpu "macppc" as cpu_family "ppc"

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -220,6 +220,8 @@ def detect_cpu_family(compilers):
         trial = 'arm'
     elif trial.startswith('ppc64'):
         trial = 'ppc64'
+    elif trial == 'macppc':
+        trial = 'ppc'
     elif trial == 'powerpc':
         trial = 'ppc'
         # FreeBSD calls both ppc and ppc64 "powerpc".


### PR DESCRIPTION
On OpenBSD, the main PowerPC machine is known as macppc, while the processor
family is powerpc:
$ uname -{m,p}
macppc powerpc
$ echo 'import platform; print (platform.machine())' | python3
macppc
$ echo 'import platform; print (platform.processor())' | python3
powerpc

This allows for e.g. GLib configure to properly detect that cpu:
Build machine cpu family: ppc
Build machine cpu: macppc
While it failed before with: WARNING: Unknown CPU family 'macppc' <snip>