### PR TITLE
Remove argv2, which is not supported by polkit. Closes #4758.

### DIFF
--- a/data/com.mesonbuild.install.policy
+++ b/data/com.mesonbuild.install.policy
@@ -17,7 +17,6 @@
     </defaults>
     <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/python3</annotate>
     <annotate key="org.freedesktop.policykit.exec.argv1">/usr/bin/meson</annotate>
-    <annotate key="org.freedesktop.policykit.exec.argv2">install</annotate>
   </action>
 
 </policyconfig>


### PR DESCRIPTION
According to the bug report, the `argv2` argument is never processed in Polkit. Thus removing it.

Ping @kirbyfan64 who seems to be the original creator of this file. Does this change seem reasonable to you?