### PR TITLE
mintro: Added `defined_in` key in the targets introspection

### DIFF
--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -53,6 +53,7 @@ for one target is defined as follows:
     "name": "Name of the target",
     "id": "The internal ID meson uses",
     "type": "<TYPE>",
+    "defined_in": "/Path/to/the/targets/meson.build",
     "filename": ["list", "of", "generated", "files"],
     "build_by_default": true / false,
     "target_sources": [],

--- a/docs/markdown/snippets/introspect_multiple.md
+++ b/docs/markdown/snippets/introspect_multiple.md
@@ -19,4 +19,5 @@ configuration of the build directory.
 Additionlly the format of `meson introspect target` was changed:
 
   - New: the `sources` key. It stores the source files of a target and their compiler parameters.
+  - New: the `defined_in` key. It stores the meson file where a target is defined
   - Added new target types (`jar`, `shared module`).

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -118,6 +118,7 @@ def list_installed(installdata):
 def list_targets(builddata: build.Build, installdata, backend: backends.Backend):
     tlist = []
     build_dir = builddata.environment.get_build_dir()
+    src_dir = builddata.environment.get_source_dir()
 
     # Fast lookup table for installation files
     install_lookuptable = {}
@@ -133,6 +134,7 @@ def list_targets(builddata: build.Build, installdata, backend: backends.Backend)
             'name': target.get_basename(),
             'id': idname,
             'type': target.get_typename(),
+            'defined_in': os.path.normpath(os.path.join(src_dir, target.subdir, 'meson.build')),
             'filename': [os.path.join(build_dir, target.subdir, x) for x in target.get_outputs()],
             'build_by_default': target.build_by_default,
             'target_sources': backend.get_introspection_data(idname, target)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3172,6 +3172,7 @@ recommended as it is not supported on some platforms''')
             ('name', str),
             ('id', str),
             ('type', str),
+            ('defined_in', str),
             ('filename', list),
             ('build_by_default', bool),
             ('target_sources', list),
@@ -3240,11 +3241,11 @@ recommended as it is not supported on some platforms''')
 
         # Check targets
         targets_to_find = {
-            'sharedTestLib': ('shared library', True, False),
-            'staticTestLib': ('static library', True, False),
-            'test1': ('executable', True, True),
-            'test2': ('executable', True, False),
-            'test3': ('executable', True, False),
+            'sharedTestLib': ('shared library', True, False, 'sharedlib/meson.build'),
+            'staticTestLib': ('static library', True, False, 'staticlib/meson.build'),
+            'test1': ('executable', True, True, 'meson.build'),
+            'test2': ('executable', True, False, 'meson.build'),
+            'test3': ('executable', True, False, 'meson.build'),
         }
         for i in res['targets']:
             assertKeyTypes(targets_typelist, i)
@@ -3253,6 +3254,7 @@ recommended as it is not supported on some platforms''')
                 self.assertEqual(i['type'], tgt[0])
                 self.assertEqual(i['build_by_default'], tgt[1])
                 self.assertEqual(i['installed'], tgt[2])
+                self.assertPathEqual(i['defined_in'], os.path.join(testdir, tgt[3]))
                 targets_to_find.pop(i['name'], None)
             for j in i['target_sources']:
                 assertKeyTypes(targets_sources_typelist, j)


### PR DESCRIPTION
This PR adds the `defined_in` key, which specifies in which meson file the target was defined. This is useful for IDE integration (at least KDevelop) where an entry for the target in a file/project explorer should be generated.

cc @textshell 