### PR TITLE
Dedup `compiler_option` access

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -583,10 +583,10 @@ class Backend:
             for_machine = MachineChoice.BUILD
         else:
             for_machine = MachineChoice.HOST
-        if not target.is_cross:
-            # Compile args added from the env: CFLAGS/CXXFLAGS, etc. We want these
-            # to override all the defaults, but not the per-target compile args.
-            commands += self.environment.coredata.get_external_args(for_machine, compiler.get_language())
+        # Compile args added from the env: CFLAGS/CXXFLAGS, etc, or the cross
+        # file. We want these to override all the defaults, but not the
+        # per-target compile args.
+        commands += self.environment.coredata.get_external_args(for_machine, compiler.get_language())
         # Always set -fPIC for shared libraries
         if isinstance(target, build.SharedLibrary):
             commands += compiler.get_pic_args()

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1674,7 +1674,6 @@ rule FORTRAN_DEP_HACK%s
             crstr = ''
         rule = 'rule %s%s_PCH\n' % (langname, crstr)
         depargs = compiler.get_dependency_gen_args('$out', '$DEPFILE')
-        cross_args = []
 
         quoted_depargs = []
         for d in depargs:
@@ -1685,9 +1684,8 @@ rule FORTRAN_DEP_HACK%s
             output = ''
         else:
             output = ' '.join(compiler.get_output_args('$out'))
-        command = " command = {executable} $ARGS {cross_args} {dep_args} {output_args} {compile_only_args} $in\n".format(
+        command = " command = {executable} $ARGS {dep_args} {output_args} {compile_only_args} $in\n".format(
             executable=' '.join(compiler.get_exelist()),
-            cross_args=' '.join([quote_func(i) for i in cross_args]),
             dep_args=' '.join(quoted_depargs),
             output_args=output,
             compile_only_args=' '.join(compiler.get_compile_only_args())

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1455,20 +1455,18 @@ int dummy;
                         or langname == 'cs':
                     continue
                 crstr = ''
-                cross_args = self.environment.coredata.get_external_link_args(MachineChoice.HOST, langname)
                 if is_cross:
                     crstr = '_CROSS'
                 rule = 'rule %s%s_LINKER\n' % (langname, crstr)
                 if compiler.can_linker_accept_rsp():
                     command_template = ''' command = {executable} @$out.rsp
  rspfile = $out.rsp
- rspfile_content = $ARGS  {output_args} $in $LINK_ARGS {cross_args} $aliasing
+ rspfile_content = $ARGS  {output_args} $in $LINK_ARGS $aliasing
 '''
                 else:
-                    command_template = ' command = {executable} $ARGS {output_args} $in $LINK_ARGS {cross_args} $aliasing\n'
+                    command_template = ' command = {executable} $ARGS {output_args} $in $LINK_ARGS $aliasing\n'
                 command = command_template.format(
                     executable=' '.join(compiler.get_linker_exelist()),
-                    cross_args=' '.join([quote_func(i) for i in cross_args]),
                     output_args=' '.join(compiler.get_linker_output_args('$out'))
                 )
                 description = ' description = Linking target $out.\n'
@@ -2460,10 +2458,9 @@ rule FORTRAN_DEP_HACK%s
             # Add link args added using add_global_link_arguments()
             # These override per-project link arguments
             commands += self.build.get_global_link_args(linker, target.is_cross)
-            if not target.is_cross:
-                # Link args added from the env: LDFLAGS. We want these to
-                # override all the defaults but not the per-target link args.
-                commands += self.environment.coredata.get_external_link_args(for_machine, linker.get_language())
+            # Link args added from the env: LDFLAGS. We want these to override
+            # all the defaults but not the per-target link args.
+            commands += self.environment.coredata.get_external_link_args(for_machine, linker.get_language())
 
         # Now we will add libraries and library paths from various sources
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -350,11 +350,6 @@ int dummy;
             if isinstance(parameters, CompilerArgs):
                 parameters = parameters.to_native(copy=True)
             parameters = comp.compute_parameters_with_absolute_paths(parameters, self.build_dir)
-            if target.is_cross:
-                extra_parameters = comp.get_cross_extra_flags(self.environment, False)
-                if isinstance(parameters, CompilerArgs):
-                    extra_parameters = extra_parameters.to_native(copy=True)
-                parameters = extra_parameters + parameters
             # The new entry
             src_block = {
                 'language': lang,
@@ -1596,12 +1591,11 @@ rule FORTRAN_DEP_HACK%s
         if compiler.can_linker_accept_rsp():
             command_template = ' command = {executable} @$out.rsp\n' \
                                ' rspfile = $out.rsp\n' \
-                               ' rspfile_content =  $ARGS {cross_args} {output_args} {compile_only_args} $in\n'
+                               ' rspfile_content =  $ARGS {output_args} {compile_only_args} $in\n'
         else:
-            command_template = ' command = {executable} $ARGS {cross_args} {output_args} {compile_only_args} $in\n'
+            command_template = ' command = {executable} $ARGS {output_args} {compile_only_args} $in\n'
         command = command_template.format(
             executable=' '.join([ninja_quote(i) for i in compiler.get_exelist()]),
-            cross_args=' '.join([quote_func(i) for i in compiler.get_cross_extra_flags(self.environment, False)]) if is_cross else '',
             output_args=' '.join(compiler.get_output_args('$out')),
             compile_only_args=' '.join(compiler.get_compile_only_args())
         )
@@ -1646,20 +1640,15 @@ rule FORTRAN_DEP_HACK%s
                 d = quote_func(d)
             quoted_depargs.append(d)
 
-        if is_cross:
-            cross_args = compiler.get_cross_extra_flags(self.environment, False)
-        else:
-            cross_args = ''
         if compiler.can_linker_accept_rsp():
             command_template = ''' command = {executable} @$out.rsp
  rspfile = $out.rsp
- rspfile_content = $ARGS {cross_args} {dep_args} {output_args} {compile_only_args} $in
+ rspfile_content = $ARGS {dep_args} {output_args} {compile_only_args} $in
 '''
         else:
-            command_template = ' command = {executable} $ARGS {cross_args} {dep_args} {output_args} {compile_only_args} $in\n'
+            command_template = ' command = {executable} $ARGS {dep_args} {output_args} {compile_only_args} $in\n'
         command = command_template.format(
             executable=' '.join([ninja_quote(i) for i in compiler.get_exelist()]),
-            cross_args=' '.join([quote_func(i) for i in cross_args]),
             dep_args=' '.join(quoted_depargs),
             output_args=' '.join(compiler.get_output_args('$out')),
             compile_only_args=' '.join(compiler.get_compile_only_args())
@@ -1686,11 +1675,6 @@ rule FORTRAN_DEP_HACK%s
         rule = 'rule %s%s_PCH\n' % (langname, crstr)
         depargs = compiler.get_dependency_gen_args('$out', '$DEPFILE')
         cross_args = []
-        if is_cross:
-            try:
-                cross_args = compiler.get_cross_extra_flags(self.environment, False)
-            except KeyError:
-                pass
 
         quoted_depargs = []
         for d in depargs:

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -898,14 +898,12 @@ class Vs2010Backend(backends.Backend):
         for l, args in self.build.global_args.items():
             if l in file_args:
                 file_args[l] += args
-        if not target.is_cross:
-            # Compile args added from the env or cross file: CFLAGS/CXXFLAGS,
-            # etc. We want these to override all the defaults, but not the
-            # per-target compile args.
-            for key, opt in self.environment.coredata.compiler_options[for_machine].items():
-                l, suffix = key.split('_', 1)
-                if suffix == 'args' and l in file_args:
-                    file_args[l] += opt.value
+        # Compile args added from the env or cross file: CFLAGS/CXXFLAGS, etc. We want these
+        # to override all the defaults, but not the per-target compile args.
+        for key, opt in self.environment.coredata.compiler_options[for_machine].items():
+            l, suffix = key.split('_', 1)
+            if suffix == 'args' and l in file_args:
+                file_args[l] += opt.value
         for args in file_args.values():
             # This is where Visual Studio will insert target_args, target_defines,
             # etc, which are added later from external deps (see below).
@@ -1060,11 +1058,10 @@ class Vs2010Backend(backends.Backend):
             # Add link args added using add_global_link_arguments()
             # These override per-project link arguments
             extra_link_args += self.build.get_global_link_args(compiler, target.is_cross)
-            if not target.is_cross:
-                # Link args added from the env: LDFLAGS, or the cross file. We
-                # want these to override all the defaults but not the
-                # per-target link args.
-                extra_link_args += self.environment.coredata.get_external_link_args(for_machine, compiler.get_language())
+            # Link args added from the env: LDFLAGS, or the cross file. We want
+            # these to override all the defaults but not the per-target link
+            # args.
+            extra_link_args += self.environment.coredata.get_external_link_args(for_machine, compiler.get_language())
             # Only non-static built targets need link args and link dependencies
             extra_link_args += target.link_args
             # External deps must be last because target link libraries may depend on them.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1084,14 +1084,6 @@ class Compiler:
             'Language {} does not support has_multi_link_arguments.'.format(
                 self.get_display_language()))
 
-    def get_cross_extra_flags(self, environment, link):
-        extra_flags = []
-        if self.is_cross and environment:
-            extra_flags += environment.coredata.get_external_args(MachineChoice.HOST, self.language)
-            if link:
-                extra_flags += environment.coredata.get_external_link_args(MachineChoice.HOST, self.language)
-        return extra_flags
-
     def _get_compile_output(self, dirname, mode):
         # In pre-processor mode, the output is sent to stdout and discarded
         if mode == 'preprocess':

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -78,8 +78,7 @@ class FortranCompiler(Compiler):
         binary_name = os.path.join(work_dir, 'sanitycheckf')
         with open(source_name, 'w') as ofile:
             ofile.write('print *, "Fortran compilation is working."; end')
-        extra_flags = self.get_cross_extra_flags(environment, link=True)
-        pc = subprocess.Popen(self.exelist + extra_flags + [source_name, '-o', binary_name])
+        pc = subprocess.Popen(self.exelist + [source_name, '-o', binary_name])
         pc.wait()
         if pc.returncode != 0:
             raise EnvironmentException('Compiler %s can not compile programs.' % self.name_string())

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -31,7 +31,7 @@ class ObjCCompiler(CCompiler):
         # TODO try to use sanity_check_impl instead of duplicated code
         source_name = os.path.join(work_dir, 'sanitycheckobjc.m')
         binary_name = os.path.join(work_dir, 'sanitycheckobjc')
-        extra_flags = self.get_cross_extra_flags(environment, link=False)
+        extra_flags = []
         if self.is_cross:
             extra_flags += self.get_compile_only_args()
         with open(source_name, 'w') as ofile:

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -31,14 +31,11 @@ class ObjCPPCompiler(CPPCompiler):
         # TODO try to use sanity_check_impl instead of duplicated code
         source_name = os.path.join(work_dir, 'sanitycheckobjcpp.mm')
         binary_name = os.path.join(work_dir, 'sanitycheckobjcpp')
-        extra_flags = self.get_cross_extra_flags(environment, link=False)
-        if self.is_cross:
-            extra_flags += self.get_compile_only_args()
         with open(source_name, 'w') as ofile:
             ofile.write('#import<stdio.h>\n'
                         'class MyClass;'
                         'int main(int argc, char **argv) { return 0; }\n')
-        pc = subprocess.Popen(self.exelist + extra_flags + [source_name, '-o', binary_name])
+        pc = subprocess.Popen(self.exelist + [source_name, '-o', binary_name])
         pc.wait()
         if pc.returncode != 0:
             raise EnvironmentException('ObjC++ compiler %s can not compile programs.' % self.name_string())

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -105,8 +105,7 @@ class SwiftCompiler(Compiler):
         with open(source_name, 'w') as ofile:
             ofile.write('''print("Swift compilation is working.")
 ''')
-        extra_flags = self.get_cross_extra_flags(environment, link=True)
-        pc = subprocess.Popen(self.exelist + extra_flags + ['-emit-executable', '-o', output_name, src], cwd=work_dir)
+        pc = subprocess.Popen(self.exelist + ['-emit-executable', '-o', output_name, src], cwd=work_dir)
         pc.wait()
         if pc.returncode != 0:
             raise EnvironmentException('Swift compiler %s can not compile programs.' % self.name_string())

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -81,8 +81,7 @@ class ValaCompiler(Compiler):
 
     def sanity_check(self, work_dir, environment):
         code = 'class MesonSanityCheck : Object { }'
-        args = self.get_cross_extra_flags(environment, link=False)
-        with self.compile(code, args, 'compile') as p:
+        with self.compile(code, [], 'compile') as p:
             if p.returncode != 0:
                 msg = 'Vala compiler {!r} can not compile programs' \
                       ''.format(self.name_string())
@@ -101,9 +100,7 @@ class ValaCompiler(Compiler):
         if not extra_dirs:
             code = 'class MesonFindLibrary : Object { }'
             vapi_args = ['--pkg', libname]
-            args = self.get_cross_extra_flags(env, link=False)
-            args += vapi_args
-            with self.compile(code, args, 'compile') as p:
+            with self.compile(code, vapi_args, 'compile') as p:
                 if p.returncode == 0:
                     return vapi_args
         # Not found? Try to find the vapi file itself.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -20,7 +20,7 @@ from pathlib import PurePath
 from collections import OrderedDict
 from .mesonlib import (
     MesonException, MachineChoice, PerMachine,
-    default_libdir, default_libexecdir, default_prefix
+    default_libdir, default_libexecdir, default_prefix, stringlistify
 )
 from .wrap import WrapMode
 import ast
@@ -594,6 +594,12 @@ class CoreData:
             # Unlike compiler and linker flags, preprocessor flags are not in
             # compiler_options because they are not visible to user.
             preproc_flags = shlex.split(preproc_flags)
+            k = lang + '_args'
+            if lang in ('c', 'cpp', 'objc', 'objcpp') and k in env.properties[for_machine]:
+                # `c_args` in the cross file are used, like CPPFLAGS but *not*
+                # CFLAGS, for tests. this is weird, but how it was already
+                # implemented. Hopefully a new version of #3916 fixes it.
+                preproc_flags = stringlistify(env.properties[for_machine][k])
             self.external_preprocess_args[for_machine].setdefault(lang, preproc_flags)
 
         enabled_opts = []


### PR DESCRIPTION
After #4626, a bunch of cross-specific conditional code is no longer needed, and corresponding native-specific code always used. This PR removes the former and unconditions the latter. I made it a separate PR mainly for CI purposes, but also in case people prefer smaller changes at a time.

Also, there was a little kerfuffle around CPP flags. CPPFLAGS but not CFLAGS are used for some tests, but `<lang>_args` in the cross file is always used for tests, as if they were language-specific CPPFLAGS. We should resolve this, say in a newer version of #3916 that should delete code, but this PR sticks with the current behavior for now. 