### PR TITLE
restore PGI Fortran compiler functioning

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1309,6 +1309,8 @@ class CompilerType(enum.Enum):
 
     CCRX_WIN = 40
 
+    PGI_STANDARD = 50
+
     @property
     def is_standard_compiler(self):
         return self.name in ('GCC_STANDARD', 'CLANG_STANDARD', 'ICC_STANDARD')
@@ -1597,6 +1599,25 @@ class GnuCompiler(GnuLikeCompiler):
     def openmp_flags(self):
         return ['-fopenmp']
 
+
+class PGICompiler:
+    def __init__(self, compiler_type):
+        self.id = 'pgi'
+        self.compiler_type = compiler_type
+
+        default_warn_args = ['-Minform=inform']
+        self.warn_args = {'1': default_warn_args,
+                          '2': default_warn_args,
+                          '3': default_warn_args}
+
+        def get_module_incdir_args(self):
+            return ('-module', )
+
+        def get_no_warn_args(self):
+            return ['-silent']
+
+        def openmp_flags(self):
+            return ['-fopenmp']
 
 class ElbrusCompiler(GnuCompiler):
     # Elbrus compiler is nearly like GCC, but does not support

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -24,6 +24,7 @@ from .compilers import (
     GnuCompiler,
     ElbrusCompiler,
     IntelCompiler,
+    PGICompiler
 )
 
 from mesonbuild.mesonlib import EnvironmentException, is_osx
@@ -372,20 +373,13 @@ class PathScaleFortranCompiler(FortranCompiler):
 class PGIFortranCompiler(FortranCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwags):
         FortranCompiler.__init__(self, exelist, version, is_cross, exe_wrapper, **kwags)
-        self.id = 'pgi'
-        default_warn_args = ['-Minform=inform']
-        self.warn_args = {'1': default_warn_args,
-                          '2': default_warn_args,
-                          '3': default_warn_args}
+        PGICompiler.__init__(self, CompilerType.PGI_STANDARD)
 
-    def get_module_incdir_args(self):
-        return ('-module', )
-
-    def get_no_warn_args(self):
-        return ['-silent']
-
-    def openmp_flags(self):
-        return ['-fopenmp']
+    def get_always_args(self):
+        """PGI doesn't have -pipe."""
+        val = super().get_always_args()
+        val.remove('-pipe')
+        return val
 
 
 class Open64FortranCompiler(FortranCompiler):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -404,7 +404,7 @@ class Environment:
         self.default_objc = ['cc']
         self.default_objcpp = ['c++']
         self.default_d = ['ldc2', 'ldc', 'gdc', 'dmd']
-        self.default_fortran = ['gfortran', 'g95', 'f95', 'f90', 'f77', 'ifort']
+        self.default_fortran = ['gfortran', 'g95', 'f95', 'f90', 'f77', 'ifort', 'pgfortran']
         self.default_java = ['javac']
         self.default_rust = ['rustc']
         self.default_swift = ['swiftc']


### PR DESCRIPTION
Previous changes left the PGI Fortran compiler not working.

Readded PGI Fortran compiler functionality in a forward-compatible way, for future enabling of the PGI C and C++ compilers.