### PR TITLE
Allow install_man to accept custom_targets

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -940,6 +940,7 @@ An example value could be `['rwxr-sr-x', 'root', 'root']`.
 *(Added 0.47.0)*.
 
 Since 0.49.0, [manpages are no longer compressed implicitly][install_man_49].
+Since 0.50.0, Custom Targets may be passed to `install_man`
 
 [install_man_49]: https://mesonbuild.com/Release-notes-for-0-49-0.html#manpages-are-no-longer-compressed-implicitly
 

--- a/docs/markdown/snippets/install_man_custom_target.md
+++ b/docs/markdown/snippets/install_man_custom_target.md
@@ -1,0 +1,13 @@
+## install_man now accepts custom targets
+
+The install_man function previously only accepted static files, it now accepts
+custom_targets as well.
+
+```meson
+c = custom_target(
+  'foo',
+  ...
+  output : 'foo.1',
+)
+install_man(c)
+```

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -833,6 +833,11 @@ class Backend:
             for dep in t.depends:
                 assert isinstance(dep, (build.CustomTarget, build.BuildTarget))
                 result[dep.get_id()] = dep
+        # Get all targets used by install_man
+        for t in self.build.get_man():
+            for dep in t.depends:
+                assert isinstance(dep, (build.CustomTarget, build.BuildTarget))
+                result[dep.get_id()] = dep
         return result
 
     def get_custom_target_provided_libraries(self, target):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -658,7 +658,16 @@ class Man(InterpreterObject):
 
     def __init__(self, sources, kwargs):
         InterpreterObject.__init__(self)
-        self.sources = sources
+        self.sources = []
+        self.depends = []
+        for s in sources:
+            if hasattr(s, 'held_object'):
+                self.sources.extend(
+                    [mesonlib.File.from_built_file(s.held_object.subdir, n)
+                     for n in s.held_object.get_outputs()])
+                self.depends.append(s.held_object)
+            else:
+                self.sources.append(s)
         self.validate_sources()
         self.custom_install_dir = kwargs.get('install_dir', None)
         self.custom_install_mode = kwargs.get('install_mode', None)

--- a/test cases/common/10 man install/copy.py
+++ b/test cases/common/10 man install/copy.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import argparse
+import shutil
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input')
+    parser.add_argument('output', nargs='+')
+    args = parser.parse_args()
+
+    for o in args.output:
+        shutil.copyfile(args.input, o)
+
+
+if __name__ == '__main__':
+    main()

--- a/test cases/common/10 man install/installed_files.txt
+++ b/test cases/common/10 man install/installed_files.txt
@@ -3,3 +3,6 @@ usr/share/man/man2/bar.2
 usr/share/man/man1/vanishing.1
 usr/share/man/man2/vanishing.2
 usr/share/man/man1/baz.1
+usr/share/man/man1/foo_copy.1
+usr/share/man/man2/bar_copy.2
+usr/share/man/man3/bar_copy.3

--- a/test cases/common/10 man install/meson.build
+++ b/test cases/common/10 man install/meson.build
@@ -11,3 +11,21 @@ b1 = configure_file(input : 'baz.1.in',
   configuration : cdata)
 
 install_man(b1)
+
+cp = files('copy.py')
+py3 = import('python').find_installation()
+copy = custom_target(
+  'copy',
+  input : 'foo.1',
+  output : 'foo_copy.1',
+  command : [py3, cp, '@INPUT@', '@OUTPUT@'],
+)
+install_man(copy)
+
+copy2 = custom_target(
+  'copy2',
+  input : 'bar.2',
+  output : ['bar_copy.2', 'bar_copy.3'],
+  command : [py3, cp, '@INPUT@', '@OUTPUT@'],
+)
+install_man(copy2)


### PR DESCRIPTION
It's much nicer to not have to manually compute the man paths for custom
targets, and instead let install_man handle it.

I'm pretty pleased with how little code was required.

Comes with two new test cases, one for a custom target with one output,
and a second test case for a custom target with two outputs.

Fixes #1550