### PR TITLE
CMake: Added support for CMAKE_MODULE_PATH and extra CMake args (closes #4779)

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -148,6 +148,14 @@ it automatically.
     cmake_dep = dependency('ZLIB', method : 'cmake', modules : ['ZLIB::ZLIB'])
 ```
 
+It is also possible to reuse existing `Find<name>.cmake` files with the
+`module_path` property. Using this property is equivalent to setting the
+`CMAKE_MODULE_PATH` variable in CMake. The path(s) given to `module_path`
+should all be relative to the project source directory. Absolute paths
+should only be used if the CMake files are not stored in the project itself.
+
+Additional CMake parameters can be specified with the `cmake_args` property.
+
 ### Some notes on Dub
 
 Please understand that meson is only able to find dependencies that

--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -203,3 +203,20 @@ executable(..., dependencies : m_dep)
 ```meson
 executable(..., install : true, install_dir : get_option('libexecdir'))
 ```
+
+## Use existing `Find<name>.cmake` files
+
+Meson can use the CMake `find_package()` ecosystem if CMake is installed.
+To find a dependency with custom `Find<name>.cmake`, set the `module_path`
+property to the path in your project where the CMake scripts are stored.
+
+Example for a `FindCmakeOnlyDep.cmake` in a `cmake` subdirectory:
+
+```meson
+cm_dep = dependency('CmakeOnlyDep', module_path : 'cmake')
+```
+
+The `module_path` property is only needed for custom CMake scripts. System
+wide CMake scripts are found automatically.
+
+More information can be found [here](Dependencies.md#cmake)

--- a/docs/markdown/snippets/cmake_module_path.md
+++ b/docs/markdown/snippets/cmake_module_path.md
@@ -1,0 +1,9 @@
+## Added `module_path` and `cmake_args` to dependency
+
+The CMake dependency backend can now make use of existing `Find<name>.cmake`
+files by setting the `CMAKE_MODULE_PATH` with the new `dependency()` property
+`module_path`. The paths given to `module_path` should be relative to the
+project source directory.
+
+Furthermore the property `cmake_args` was added to give CMake additional
+parameters.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1926,6 +1926,7 @@ permitted_kwargs = {'add_global_arguments': {'language', 'native'},
                                    'main',
                                    'method',
                                    'modules',
+                                   'module_path',
                                    'optional_modules',
                                    'native',
                                    'not_found_message',
@@ -1933,6 +1934,7 @@ permitted_kwargs = {'add_global_arguments': {'language', 'native'},
                                    'static',
                                    'version',
                                    'private_headers',
+                                   'cmake_args',
                                    },
                     'declare_dependency': {'include_directories',
                                            'link_with',
@@ -2944,10 +2946,10 @@ external dependencies (including libraries) must go to "dependencies".''')
         elif name == 'openmp':
             FeatureNew('OpenMP Dependency', '0.46.0').use(self.subproject)
 
+    @FeatureNewKwargs('dependency', '0.50.0', ['not_found_message', 'module_path', 'cmake_args'])
     @FeatureNewKwargs('dependency', '0.49.0', ['disabler'])
     @FeatureNewKwargs('dependency', '0.40.0', ['method'])
     @FeatureNewKwargs('dependency', '0.38.0', ['default_options'])
-    @FeatureNewKwargs('dependency', '0.50.0', ['not_found_message'])
     @disablerIfNotFound
     @permittedKwargs(permitted_kwargs['dependency'])
     def func_dependency(self, node, args, kwargs):

--- a/test cases/linuxlike/13 cmake dependency/cmake/FindSomethingLikeZLIB.cmake
+++ b/test cases/linuxlike/13 cmake dependency/cmake/FindSomethingLikeZLIB.cmake
@@ -1,0 +1,9 @@
+find_package(ZLIB)
+
+if(ZLIB_FOUND OR ZLIB_Found)
+  set(SomethingLikeZLIB_FOUND        ON)
+  set(SomethingLikeZLIB_LIBRARIES    ${ZLIB_LIBRARY})
+  set(SomethingLikeZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR})
+else()
+  set(SomethingLikeZLIB_FOUND       OFF)
+endif()

--- a/test cases/linuxlike/13 cmake dependency/meson.build
+++ b/test cases/linuxlike/13 cmake dependency/meson.build
@@ -36,6 +36,12 @@ depf2 = dependency('ZLIB', required : false, method : 'cmake', modules : 'dfggh:
 
 assert(depf2.found() == false, 'Invalid CMake targets should fail')
 
+# Try to find a depndency with a custom CMake ndoule
+
+depm1 = dependency('SomethingLikeZLIB', required : true, method : 'cmake', module_path : 'cmake')
+depm2 = dependency('SomethingLikeZLIB', required : true, method : 'cmake', module_path : ['cmake'])
+depm3 = dependency('SomethingLikeZLIB', required : true, module_path : 'cmake')
+
 # Try to compile a test that takes a dep and an include_directories
 
 cc = meson.get_compiler('c')


### PR DESCRIPTION
This PR adds support for custom `Find<name>.cmake` scripts, by setting the new `module_path` property. Internally the CMake `CMAKE_MODULE_PATH` variable is set.

Additionally, the `cmake_args` property was added.