### PR TITLE
dependency: Add runtime cache

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -377,7 +377,13 @@ Finds an external dependency (usually a library installed on your
 system) with the given name with `pkg-config` and [with CMake](Dependencies.md#CMake)
 if `pkg-config` fails. Additionally, frameworks (OSX only) and
 [library-specific fallback detection logic](Dependencies.md#dependencies-with-custom-lookup-functionality)
-are also supported. This function supports the following keyword arguments:
+are also supported.
+
+Since *0.50.0* the return value is cached for consistency. See
+[release notes](Release-notes-for-0.50.0.md#Consistent return value of dependency())
+for more details about the implications.
+
+This function supports the following keyword arguments:
 
 - `default_options` *(added 0.37.0)* an array of default option values
   that override those set in the subproject's `meson_options.txt`

--- a/docs/markdown/snippets/dependency-cache.md
+++ b/docs/markdown/snippets/dependency-cache.md
@@ -1,0 +1,49 @@
+## Consistent return value of `dependency()`
+
+The return value of `dependency('somedep')` is now cached and the same value
+will always be returned, even in subprojects, regardless of the version required
+and the presence (or not) of the fallback keyword argument. However, if different
+calls to `dependency()` differs by the `module` keyword argument, they are cached
+separately and will not return the same value.
+
+### Implications
+
+Let's assume the system has `glib-2.0` version 2.40 installed with its pkg-config
+file, and we configure a project with multiple subprojects that all depends on
+different versions of glib.
+
+- If the first call is `dependency('glib-2.0', version : '>=2.40')`, the
+dependency will be satisfied by the system version found using pkg-config.
+If a 2nd call then does `dependency('glib-2.0', version : '>=2.50', fallback : ['glib', 'glib_dep'])`,
+Meson used to configure the fallback subproject because the system dependency does
+not satisfy the required version, leading to different parts of the project linking
+on different version of glib. Meson will now instead abort because the cached
+dependency object from the first call does not satisfy the requested version in
+the 2nd call for consistency.
+
+- If the first call is `dependency('glib-2.0', version : '>=2.50', fallback : ['glib', 'glib_dep'])`
+Meson will configure the fallback subproject because the system dependency does
+not satisfy the required version. If a 2nd call then does
+`dependency('glib-2.0', version : '>=2.40')`, Meson used to return the system
+dependency because it miss the fallback keyword argument. Meson will now instead
+return the glib subproject dependency instead for consistency. Likewise if the
+2nd call is `dependency('glib-2.0', version : '>=2.50')` Meson used to abort
+because the system dependency version is too old, but it will now instead return
+the dependency from glib subproject.
+
+- If the first call is `dependency('glib-2.0', version : '>=2.50', required : false)`
+it returns a not-found dependency object because the system version is too old
+and there is no fallback provided. If a 2nd call then does
+`dependency('glib-2.0', version : '>=2.50', fallback : ['glib', 'glib_dep'])`,
+Meson used to configure the fallback subproject, leading to some parts of
+the project to not enable their optional glib support even though we do have glib
+in the end. Meson will now instead return a not-found dependency in the 2nd call
+for consistency.
+
+- However, if the first call is `dependency('glib-2.0', required : get_option('glib_opt'))`,
+and `glib_opt` is a `disabled` feature option, the returned not-found dependency
+object is NOT cached. A 2nd call to `dependency('glib-2.0', version : '>=2.40')`
+will return the system dependency.
+
+It is parent project's responsability to ensure that the first lookup of a
+dependency has the proper `fallback` keyword argument.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -142,6 +142,7 @@ class Build:
         self.test_setup_default_name = None
         self.find_overrides = {}
         self.searched_programs = set() # The list of all programs that have been searched for.
+        self.deps = {}
 
     def copy(self):
         other = Build(self.environment)

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -2083,7 +2083,6 @@ def find_external_dependency(name, env, kwargs):
         # try this dependency method
         try:
             d = c()
-            d._check_version()
             pkgdep.append(d)
         except DependencyException as e:
             pkg_exc.append(e)

--- a/test cases/common/103 subproject subdir/meson.build
+++ b/test cases/common/103 subproject subdir/meson.build
@@ -4,3 +4,18 @@ libSub = dependency('sub', fallback: ['sub', 'libSub'])
 
 exe = executable('prog', 'prog.c', dependencies: libSub)
 test('subproject subdir', exe)
+
+# The dependency should be cached now, so should be found even without fallback
+dependency('sub')
+
+# Make sure we cannot override the special '' dependency
+dependency('', fallback: ['sub', 'libSub'])
+dep = dependency('', required : false)
+assert(not dep.found(), 'The not-found dependency should not get cached')
+
+# Make sure that if we first lookup for a dependency without fallback and the
+# dependency was not found, subsequent calls still return not-found even when
+# they provide a fallback
+dependency('sub2', required : false)
+dep = dependency('sub2', fallback: ['sub', 'libSub'], required : false)
+assert(not dep.found(), 'A not found dependency should stay not found')

--- a/test cases/linuxlike/5 dependency versions/meson.build
+++ b/test cases/linuxlike/5 dependency versions/meson.build
@@ -29,35 +29,39 @@ assert(zlibopt.found() == true, 'zlib not found')
 dependency('somebrokenlib', version : '>=2.0', required : false)
 dependency('somebrokenlib', version : '>=1.0', required : false)
 
-# Search for an external dependency that won't be found, but must later be
-# found via fallbacks
+# Search for an external dependency that won't be found, should stay not-found
+# later even when a fallback is then provided
 somelibnotfound = dependency('somelib', required : false)
 assert(somelibnotfound.found() == false, 'somelibnotfound was found?')
-# Find internal dependency without version
-somelibver = dependency('somelib',
+somelibnotfound = dependency('somelib',
+  fallback : ['somelibnover', 'some_dep'],
+  required : false)
+assert(somelibnotfound.found() == false, 'somelibnotfound was found?')
+# With another name it should configure the subproject
+somelib2 = dependency('somelib2',
   fallback : ['somelibnover', 'some_dep'])
-assert(somelibver.type_name() == 'internal', 'somelibver should be of type "internal", not ' + somelibver.type_name())
-# Find an internal dependency again with the same name and a specific version
-somelib = dependency('somelib',
+assert(somelib2.type_name() == 'internal', 'somelibver should be of type "internal", not ' + somelib2.type_name())
+# Find an internal dependency again with another name and a specific version
+somelib = dependency('somelib3',
   version : '== 0.1',
   fallback : ['somelib', 'some_dep'])
 # Find an internal dependency again even if required = false
-somelib_reqfalse = dependency('somelib',
+somelib_reqfalse = dependency('somelib4',
   required: false,
   fallback : ['somelib', 'some_dep'])
 assert(somelib_reqfalse.found(), 'somelib should have been found')
-# Find an internal dependency again with the same name and incompatible version
-somelibver = dependency('somelib',
+# Find an internal dependency again with an incompatible version
+somelibver = dependency('somelib5',
   version : '>= 0.3',
   fallback : ['somelibver', 'some_dep'])
 # Find somelib again, but with a fallback that will fail because subproject does not exist
-somelibfail = dependency('somelib',
+somelibfail = dependency('somelib6',
   version : '>= 0.2',
   required : false,
   fallback : ['somelibfail', 'some_dep'])
 assert(somelibfail.found() == false, 'somelibfail found via wrong fallback')
 # Find somelib again, but with a fallback that will fail because dependency does not exist
-somefail_dep = dependency('somelib',
+somefail_dep = dependency('somelib7',
   version : '>= 0.2',
   required : false,
   fallback : ['somelib', 'somefail_dep'])

--- a/test cases/unit/20 subproj dep variables/meson.build
+++ b/test cases/unit/20 subproj dep variables/meson.build
@@ -3,7 +3,7 @@ project('subproj found dep not found', 'c')
 dependency('somedep', required : false,
            fallback : ['nosubproj', 'dep_name'])
 
-dependency('somedep', required : false,
+dependency('somefailingdep', required : false,
            fallback : ['failingsubproj', 'dep_name'])
 
 dependency('somenotfounddep', required : false,
@@ -12,5 +12,5 @@ dependency('somenotfounddep', required : false,
 dependency('zlibproxy', required : true,
            fallback : ['somesubproj', 'zlibproxy_dep'])
 
-dependency('somedep', required : false,
+dependency('somenesteddep', required : false,
            fallback : ['nestedsubproj', 'nestedsubproj_dep'])


### PR DESCRIPTION
Dependencies found in a subproject fallback should always return the
same dependency object in subsequent calls even if fallback kwarg is
omitted. Likewise a not-found dependency should stay not-found even if
subsequent calls provide a fallback.

This avoids having parts of a project linking on a system library and
other parts linking on a subproject library.