### PR TITLE
tools/cmake2meson.py: allow nested/complex if statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.mypy_cache/
 /.project
 /.pydevproject
 /.settings


### PR DESCRIPTION
Many CMakeLists.txt have nested/complex if like
```cmake
if(A AND NOT(B OR C))
```
which with the current release `tools/cmake2meson.py` errors with:
```
  File "~/meson/tools/cmake2meson.py", line 306, in <module>
    c.convert()
  File "~/meson/tools/cmake2meson.py", line 273, in convert
    self.write_entry(outfile, t)
  File "~/meson/tools/cmake2meson.py", line 232, in write_entry
    line = 'if %s' % self.convert_args(t.args, False)
  File "~/meson/tools/cmake2meson.py", line 158, in convert_args
    if i.tid == 'id':
AttributeError: 'list' object has no attribute 'tid'
```

The changes in this PR allow such if statements to pass through to `meson.build` draft.

Also, I used Python &ge; 3.5 intrinsic `pathlib.Path` for cleaner code, and ability to specify paths with `~`, which is not possible in the current release.