### PR TITLE
Cmd line file fixes

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2018 The Meson development team
+# Copyright 2012-2019 The Meson development team
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -606,6 +606,11 @@ def load(build_dir):
             obj = pickle.load(f)
     except pickle.UnpicklingError:
         raise MesonException(load_fail_msg)
+    except AttributeError:
+        raise MesonException(
+            "Coredata file {!r} references functions or classes that don't "
+            "exist. This probably means that it was generated with an old "
+            "version of meson.".format(filename))
     if not isinstance(obj, CoreData):
         raise MesonException(load_fail_msg)
     if obj.version != version:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -604,7 +604,7 @@ def load(build_dir):
     try:
         with open(filename, 'rb') as f:
             obj = pickle.load(f)
-    except pickle.UnpicklingError:
+    except (pickle.UnpicklingError, EOFError):
         raise MesonException(load_fail_msg)
     except AttributeError:
         raise MesonException(

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -576,6 +576,10 @@ def read_cmd_line_file(build_dir, options):
     properties = config['properties']
     if options.cross_file is None:
         options.cross_file = properties.get('cross_file', None)
+    if not options.native_file:
+        # This will be a string in the form: "['first', 'second', ...]", use
+        # literal_eval to get it into the list of strings.
+        options.native_file = ast.literal_eval(properties.get('native_file', '[]'))
 
 def write_cmd_line_file(build_dir, options):
     filename = get_cmd_line_file(build_dir)
@@ -584,6 +588,8 @@ def write_cmd_line_file(build_dir, options):
     properties = {}
     if options.cross_file is not None:
         properties['cross_file'] = options.cross_file
+    if options.native_file:
+        properties['native_file'] = options.native_file
 
     config['options'] = options.cmd_line_options
     config['properties'] = properties


### PR DESCRIPTION
I noticed a couple of bugs in the wipe/reconfigure code, over the last couple of days. First I noticed that between 0.49 and now the code wouldn't function due to the removal of data structures from our internal representation. Then I noticed while trying to test a fix that of the coredata.dat file was empty (ie, created by touch) there would be an error. Then I noticed that native files are serialized into the cmd_line.txt either, when I was writing a script to convert cmd_line.txt into a command line that could be fed back to meson.