### PR TITLE
tests: Don't return an undefined value from main()

### DIFF
--- a/test cases/unit/17 prebuilt shared/patron.c
+++ b/test cases/unit/17 prebuilt shared/patron.c
@@ -5,4 +5,5 @@ int main(int argc, char **argv) {
     printf("You are standing outside the Great Library of Alexandria.\n");
     printf("You decide to go inside.\n\n");
     alexandria_visit();
+    return 0;
 }


### PR DESCRIPTION
This caused test failures while backporting meson to an old runtime environment.