### PR TITLE
run_unittests: Use Python 3.5-compatible subprocess invocation

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5029,10 +5029,9 @@ class NativeFileTests(BasePlatformTests):
                     ret = subprocess.run(
                         ["{}"] + extra_args,
                         stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE,
-                        encoding='utf-8')
-                    print(ret.stdout)
-                    print(ret.stderr, file=sys.stderr)
+                        stderr=subprocess.PIPE)
+                    print(ret.stdout.decode('utf-8'))
+                    print(ret.stderr.decode('utf-8'), file=sys.stderr)
                     sys.exit(ret.returncode)
 
                 if __name__ == '__main__':


### PR DESCRIPTION
While backporting Meson to an embarrassingly old runtime environment using a backported Python 3.5, I found that some tests failed.

One failure mode that's easy to fix is that subprocess.run() didn't get the encoding parameter until 3.6.