### PR TITLE
docs: Use modern shell constructs

### DIFF
--- a/docs/markdown/Continuous-Integration.md
+++ b/docs/markdown/Continuous-Integration.md
@@ -154,7 +154,7 @@ matrix:
     - os: osx
 
 install:
-  - export PATH="`pwd`/build:${PATH}"
+  - export PATH="$(pwd)/build:${PATH}"
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update && brew install python3 ninja; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip && unzip -q ninja-linux.zip -d build; fi
   - pip3 install meson

--- a/docs/markdown/Creating-Linux-binaries.md
+++ b/docs/markdown/Creating-Linux-binaries.md
@@ -119,7 +119,7 @@ with the following content:
 #!/bin/bash
 
 cd "${0%/*}"
-export LD_LIBRARY_PATH="`pwd`/lib"
+export LD_LIBRARY_PATH="$(pwd)/lib"
 bin/myapp
 ```
 


### PR DESCRIPTION
This replaces the use of the deprecated backtick syntax with the `$()` syntax.