### PR TITLE
add mcompile command to build targets in a backend agnostic way

### DIFF
--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -1,0 +1,143 @@
+# Copyright 2016-2017 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A tool to build meson targets backend agnostic.
+import argparse
+from glob import glob
+from . import coredata
+from .environment import detect_ninja
+import os
+import subprocess
+
+from enum import Enum
+
+Backend = Enum('Backend', 'ninja vs xcode')
+
+def add_arguments(parser):
+    parser.add_argument('builddir', nargs='?', default='.')
+    parser.add_argument('-t', '--targets', nargs='*', default=['all'],
+                        help='Targets to build. Can include subdirectories.\n' +
+                        "If omitted, the 'all' target gets built.\n" +
+                        "Use 'clean' to clean the build directory.")
+
+def guess_backend(backend):
+    # Set backend arguments for Meson
+    if backend.startswith('vs'):
+        backend_flags = ['--backend=' + backend]
+        backend = Backend.vs
+    elif backend == 'xcode':
+        backend_flags = ['--backend=xcode']
+        backend = Backend.xcode
+    elif backend == 'ninja':
+        backend_flags = ['--backend=ninja']
+        backend = Backend.ninja
+    else:
+        raise RuntimeError('Unknown backend: {!r}'.format(backend))
+    return (backend, backend_flags)
+
+def get_backend_args_for_dir(backend, builddir):
+    '''
+    Visual Studio backend needs to be given the solution to build
+    '''
+    if backend is Backend.vs:
+        sln_name = glob(os.path.join(builddir, '*.sln'))[0]
+        return [os.path.split(sln_name)[-1]]
+    return []
+
+def find_vcxproj_with_target(builddir, target):
+    import re
+    subdir, target = os.path.split(target)
+    t, ext = os.path.splitext(target)
+    if ext:
+        p = r'<TargetName>{}</TargetName>\s*<TargetExt>\{}</TargetExt>'.format(t, ext)
+    else:
+        p = r'<TargetName>{}</TargetName>'.format(t)
+    for f in glob(os.path.join(builddir, subdir, '*.vcxproj')):
+        with open(f, 'r', encoding='utf-8') as o:
+            if re.search(p, o.read(), flags=re.MULTILINE):
+                return os.path.relpath(f, start=builddir)
+    raise RuntimeError('No vcxproj matching {!r} in {!r}'.format(p, builddir))
+
+def get_builddir_target_args(backend, builddir, target):
+    dir_args = []
+    if not target:
+        dir_args = get_backend_args_for_dir(backend, builddir)
+    if target is None:
+        return dir_args
+    if backend is Backend.vs:
+        vcxproj = find_vcxproj_with_target(builddir, target)
+        target_args = [vcxproj]
+    elif backend is Backend.xcode:
+        target_args = ['-target', target]
+    elif backend is Backend.ninja:
+        target_args = [target]
+    else:
+        raise AssertionError('Unknown backend: {!r}'.format(backend))
+    return target_args + dir_args
+
+def get_backend_commands(backend, ci=True, debug=False):
+    install_cmd = []
+    uninstall_cmd = []
+    if backend is Backend.vs:
+        cmd = ['msbuild']
+        clean_cmd = cmd + ['/target:Clean']
+        test_cmd = cmd + ['RUN_TESTS.vcxproj']
+    elif backend is Backend.xcode:
+        cmd = ['xcodebuild']
+        # In Xcode9 new build system's clean command fails when using a custom build directory.
+        # Maybe use it when CI uses Xcode10 we can remove '-UseNewBuildSystem=FALSE'
+        clean_cmd = cmd + ['-alltargets', 'clean', '-UseNewBuildSystem=FALSE']
+        test_cmd = cmd + ['-target', 'RUN_TESTS']
+    elif backend is Backend.ninja:
+        ninja_ver = '0.0'
+        cmd = []
+        if ci:
+            # We need at least 1.6 because of -w dupbuild=err
+            ninja_ver = '1.6'
+            cmd = ['-w', 'dupbuild=err', '-d', 'explain']
+        cmd = [detect_ninja(ninja_ver)] + cmd
+        if cmd[0] is None:
+            raise RuntimeError('Could not find Ninja v{} or newer'.format(ninja_ver))
+        if debug:
+            cmd += ['-v']
+        clean_cmd = cmd + ['clean']
+        test_cmd = cmd + ['test', 'benchmark']
+        install_cmd = cmd + ['install']
+        uninstall_cmd = cmd + ['uninstall']
+    else:
+        raise AssertionError('Unknown backend: {!r}'.format(backend))
+    return cmd, clean_cmd, test_cmd, install_cmd, uninstall_cmd
+
+def run(options):
+    build_dir = os.path.abspath(os.path.realpath(options.builddir))
+    backend, _ = guess_backend(coredata.load(build_dir).get_builtin_option('backend'))
+    build_command, clean_cmd, *_ = get_backend_commands(backend, ci=False)
+
+    failed = 0
+    for target in options.targets:
+        cmd = build_command
+        if target == 'all':
+            target = None
+        elif target == 'clean':
+            target = None
+            cmd = clean_cmd
+        args = get_builddir_target_args(backend, build_dir, target)
+        failed += subprocess.run(cmd + args, cwd=build_dir).returncode
+    return failed
+
+def run_with_args(args):
+    parser = argparse.ArgumentParser(prog='meson compile')
+    add_arguments(parser)
+    options = parser.parse_args(args)
+    return run(options)

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -21,7 +21,7 @@ import codecs
 
 from . import mesonlib
 from . import mlog
-from . import mconf, minit, minstall, mintro, msetup, mtest, rewriter, msubprojects, munstable_coredata
+from . import mcompile, mconf, minit, minstall, mintro, msetup, mtest, rewriter, msubprojects, munstable_coredata
 from .mesonlib import MesonException
 from .environment import detect_msys2_arch
 from .wrap import wraptool
@@ -36,6 +36,8 @@ class CommandLineParser:
                                                      description='If no command is specified it defaults to setup command.')
         self.add_command('setup', msetup.add_arguments, msetup.run,
                          help='Configure the project')
+        self.add_command('compile', mcompile.add_arguments, mcompile.run,
+                         help='Build targets')
         self.add_command('configure', mconf.add_arguments, mconf.run,
                          help='Change project options',)
         self.add_command('install', minstall.add_arguments, minstall.run,

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -39,7 +39,7 @@ import multiprocessing
 from concurrent.futures import ProcessPoolExecutor, CancelledError
 import re
 from run_tests import get_fake_options, run_configure, get_meson_script
-from run_tests import get_backend_commands, get_backend_args_for_dir, Backend
+from mesonbuild.mcompile import get_backend_commands, get_backend_args_for_dir, Backend
 from run_tests import ensure_backend_detects_changes
 from run_tests import guess_backend
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -35,6 +35,9 @@ from glob import glob
 from pathlib import (PurePath, Path)
 from distutils.dir_util import copy_tree
 
+from mesonbuild.mcompile import (
+    Backend, get_backend_commands, get_builddir_target_args
+)
 import mesonbuild.mlog
 import mesonbuild.compilers
 import mesonbuild.environment
@@ -55,9 +58,9 @@ from mesonbuild.build import Target
 import mesonbuild.modules.pkgconfig
 
 from run_tests import (
-    Backend, FakeBuild, FakeCompilerOptions,
-    ensure_backend_detects_changes, exe_suffix, get_backend_commands,
-    get_builddir_target_args, get_fake_env, get_fake_options, get_meson_script,
+    FakeBuild, FakeCompilerOptions,
+    ensure_backend_detects_changes, exe_suffix,
+    get_fake_env, get_fake_options, get_meson_script,
     run_configure_inprocess, run_mtest_inprocess
 )
 


### PR DESCRIPTION
Idea: use `meson build -t prog` to build the `prog` target.
Special targets: `all` and `clean`.

I refactored some stuff from meson's test suite into mbuild and probably missed a few usages where imports must be adjusted, which will make the CI fail.

This is a WIP until I get some feedback and can get reports from someone using the xcode backend, since I could only test it on ninja and vs. Also, I don't like that I have to check the `ci` variable to determine if ninja should use the `'-w', 'dupbuild=err', '-d', 'explain'` arguments. Is there a cleaner way to do this?

Todo:
- [ ] test on xcode backend
- [ ] add documentation
