### PR TITLE
coredata: Only reject a load if major version differs

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -598,6 +598,9 @@ def update_cmd_line_file(build_dir, options):
     with open(filename, 'w') as f:
         config.write(f)
 
+def major_versions_differ(v1, v2):
+    return v1.split('.')[0:2] != v2.split('.')[0:2]
+
 def load(build_dir):
     filename = os.path.join(build_dir, 'meson-private', 'coredata.dat')
     load_fail_msg = 'Coredata file {!r} is corrupted. Try with a fresh build tree.'.format(filename)
@@ -608,7 +611,7 @@ def load(build_dir):
         raise MesonException(load_fail_msg)
     if not isinstance(obj, CoreData):
         raise MesonException(load_fail_msg)
-    if obj.version != version:
+    if major_versions_differ(obj.version, version):
         raise MesonException('Build directory has been generated with Meson version %s, '
                              'which is incompatible with current version %s.\n' %
                              (obj.version, version))
@@ -618,7 +621,7 @@ def save(obj, build_dir):
     filename = os.path.join(build_dir, 'meson-private', 'coredata.dat')
     prev_filename = filename + '.prev'
     tempfilename = filename + '~'
-    if obj.version != version:
+    if major_versions_differ(obj.version, version):
         raise MesonException('Fatal version mismatch corruption.')
     if os.path.exists(filename):
         import shutil

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2983,12 +2983,16 @@ recommended as it is not supported on some platforms''')
         self.wipe()
         self.init(testdir, extra_args=['-Dstart_native=true'])
 
-    def __reconfigure(self):
+    def __reconfigure(self, change_minor=False):
         # Set an older version to force a reconfigure from scratch
         filename = os.path.join(self.privatedir, 'coredata.dat')
         with open(filename, 'rb') as f:
             obj = pickle.load(f)
-        obj.version = '0.47.0'
+        if change_minor:
+            v = mesonbuild.coredata.version.split('.')
+            obj.version = '.'.join(v[0:2] + [str(int(v[2]) + 1)])
+        else:
+            obj.version = '0.47.0'
         with open(filename, 'wb') as f:
             pickle.dump(obj, f)
 
@@ -3028,6 +3032,22 @@ recommended as it is not supported on some platforms''')
 
         with Path(self.builddir):
             self.init(testdir, extra_args=['--wipe'])
+
+    def test_minor_version_does_not_reconfigure_wipe(self):
+        testdir = os.path.join(self.unit_test_dir, '46 reconfigure')
+        self.init(testdir, extra_args=['-Dopt1=val1'])
+        self.setconf('-Dopt2=val2')
+
+        self.__reconfigure(change_minor=True)
+
+        out = self.init(testdir, extra_args=['--reconfigure', '-Dopt3=val3'])
+        self.assertNotRegex(out, 'WARNING:.*Regenerating configuration from scratch')
+        self.assertRegex(out, 'opt1 val1')
+        self.assertRegex(out, 'opt2 val2')
+        self.assertRegex(out, 'opt3 val3')
+        self.assertRegex(out, 'opt4 default4')
+        self.build()
+        self.run_tests()
 
     def test_target_construct_id_from_path(self):
         # This id is stable but not guessable.


### PR DESCRIPTION
Our builddir ABI is stable across minor (stable) releases, so there is no need to force a wipe. We already release pretty often, no need to force people to wipe twice as often.

We should definitely ship this change in the minor release.