### PR TITLE
Try multiple CMAKE_LIBRARY_ARCHITECTURE (fixes #4812)

### DIFF
--- a/mesonbuild/dependencies/data/CMakeLists.txt
+++ b/mesonbuild/dependencies/data/CMakeLists.txt
@@ -18,8 +18,7 @@ string(TOUPPER "${_packageName}" PACKAGE_NAME)
 while(TRUE)
   find_package("${NAME}" QUIET)
 
-  list(LENGTH LIB_ARCH_LIST LIST_LEN)
-  if(${_packageName}_FOUND OR ${PACKAGE_NAME}_FOUND OR LIST_LEN LESS_EQUAL 0)
+  if(${_packageName}_FOUND OR ${PACKAGE_NAME}_FOUND OR "${LIB_ARCH_LIST}" STREQUAL "")
     break()
   endif()
 

--- a/mesonbuild/dependencies/data/CMakeLists.txt
+++ b/mesonbuild/dependencies/data/CMakeLists.txt
@@ -1,23 +1,31 @@
 cmake_minimum_required(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION} )
 
 # Inspired by CMakeDetermineCompilerABI.cmake to set CMAKE_LIBRARY_ARCHITECTURE
+set(LIB_ARCH_LIST)
 if(CMAKE_LIBRARY_ARCHITECTURE_REGEX)
-  if(NOT DEFINED CMAKE_LIBRARY_ARCHITECTURE)
-    file(GLOB implicit_dirs RELATIVE /lib /lib/*-linux-gnu* )
-    foreach(dir ${implicit_dirs})
-      if("${dir}" MATCHES "${CMAKE_LIBRARY_ARCHITECTURE_REGEX}")
-        set(CMAKE_LIBRARY_ARCHITECTURE "${dir}")
-        break()
-      endif()
-    endforeach()
-  endif()
+  file(GLOB implicit_dirs RELATIVE /lib /lib/*-linux-gnu* )
+  foreach(dir ${implicit_dirs})
+    if("${dir}" MATCHES "${CMAKE_LIBRARY_ARCHITECTURE_REGEX}")
+      list(APPEND LIB_ARCH_LIST "${dir}")
+    endif()
+  endforeach()
 endif()
-
-find_package("${NAME}" QUIET)
 
 set(PACKAGE_FOUND FALSE)
 set(_packageName "${NAME}")
 string(TOUPPER "${_packageName}" PACKAGE_NAME)
+
+while(TRUE)
+  find_package("${NAME}" QUIET)
+
+  list(LENGTH LIB_ARCH_LIST LIST_LEN)
+  if(${_packageName}_FOUND OR ${PACKAGE_NAME}_FOUND OR LIST_LEN LESS_EQUAL 0)
+    break()
+  endif()
+
+  list(GET       LIB_ARCH_LIST 0 CMAKE_LIBRARY_ARCHITECTURE)
+  list(REMOVE_AT LIB_ARCH_LIST 0)
+endwhile()
 
 if(${_packageName}_FOUND  OR  ${PACKAGE_NAME}_FOUND)
   set(PACKAGE_FOUND TRUE)


### PR DESCRIPTION
Since this fixes an Ubuntu / Debian specific issue related to multiple versions of the same library, it is almost impossible to make a test case for this. The only thing I can think of is installing `zlib1g:i386` in the docker image.