### PR TITLE
NotFoundDependency: Implement partial_dependency()

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -328,6 +328,10 @@ class NotFoundDependency(Dependency):
         self.name = 'not-found'
         self.is_found = False
 
+    def get_partial_dependency(self, *, compile_args=False, link_args=False,
+                               links=False, includes=False, sources=False):
+        return copy.copy(self)
+
 
 class ConfigToolDependency(ExternalDependency):
 


### PR DESCRIPTION
In recent change, dependency('foo') does not return a not-found
PkgConfigDependency any more, but a NotFoundDependency object. This
creates a regression in gst-build that does
dependency('foo').get_partial_dependency() causing Meson to raise an
exception.