### PR TITLE
Add "broken" argument to test() and revise should_fail usage.

### DIFF
--- a/docs/markdown/snippets/xfail.md
+++ b/docs/markdown/snippets/xfail.md
@@ -1,0 +1,15 @@
+## Tests that should fail but did not are now errors
+
+You can tag a test as needing to fail like this:
+
+```meson
+test('shoulfail', exe, should_fail: true)
+```
+
+If the test passes the problem is reported in the error logs but due
+to a bug it was not reported in the test runner's exit code. Starting
+from this release the unexpected passes are properly reported in the
+test runner's exit code. This means that test runs that were passing
+in earlier versions of Meson will report failures with the current
+version. This is a good thing, though, since it reveals an error in
+your test suite that has, until now, gone unnoticed.

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -664,7 +664,6 @@ class TestHarness:
     def process_test_result(self, result):
         if result.res is TestResult.TIMEOUT:
             self.timeout_count += 1
-            self.fail_count += 1
         elif result.res is TestResult.SKIP:
             self.skip_count += 1
         elif result.res is TestResult.OK:
@@ -746,6 +745,9 @@ Timeout:            %4d
                         line = line.encode('ascii', errors='replace').decode()
                         print(line)
 
+    def total_failure_count(self):
+        return self.fail_count + self.unexpectedpass_count + self.timeout_count
+
     def doit(self):
         if self.is_run:
             raise RuntimeError('Test harness object can only be used once.')
@@ -754,7 +756,7 @@ Timeout:            %4d
         if not tests:
             return 0
         self.run_tests(tests)
-        return self.fail_count
+        return self.total_failure_count()
 
     @staticmethod
     def split_suite_string(suite):
@@ -939,7 +941,7 @@ Timeout:            %4d
         if not tests:
             return 0
         self.run_tests(tests)
-        return self.fail_count
+        return self.total_failure_count()
 
 
 def list_tests(th):

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -147,7 +147,7 @@ class TestException(MesonException):
 @enum.unique
 class TestResult(enum.Enum):
 
-    OK = 'OK'
+    PASS = 'PASS'
     TIMEOUT = 'TIMEOUT'
     SKIP = 'SKIP'
     FAIL = 'FAIL'
@@ -193,7 +193,7 @@ class TAPParser(object):
             else:
                 yield self.Error('invalid directive "%s"' % (directive,))
 
-        yield self.Test(num, name, TestResult.OK if ok else TestResult.FAIL, explanation)
+        yield self.Test(num, name, TestResult.PASS if ok else TestResult.FAIL, explanation)
 
     def parse(self):
         found_late_test = False
@@ -310,7 +310,7 @@ class TestRun:
         elif test.should_fail:
             res = TestResult.EXPECTEDFAIL if bool(returncode) else TestResult.UNEXPECTEDPASS
         else:
-            res = TestResult.FAIL if bool(returncode) else TestResult.OK
+            res = TestResult.FAIL if bool(returncode) else TestResult.PASS
         return TestRun(test, res, returncode, duration, stdo, stde, cmd)
 
     def make_tap(test, returncode, duration, stdo, stde, cmd):
@@ -344,7 +344,7 @@ class TestRun:
             elif test.should_fail:
                 res = TestResult.EXPECTEDFAIL if failed else TestResult.UNEXPECTEDPASS
             else:
-                res = TestResult.FAIL if failed else TestResult.OK
+                res = TestResult.FAIL if failed else TestResult.PASS
 
         return TestRun(test, res, returncode, duration, stdo, stde, cmd)
 
@@ -666,7 +666,7 @@ class TestHarness:
             self.timeout_count += 1
         elif result.res is TestResult.SKIP:
             self.skip_count += 1
-        elif result.res is TestResult.OK:
+        elif result.res is TestResult.PASS:
             self.success_count += 1
         elif result.res is TestResult.FAIL or result.res is TestResult.ERROR:
             self.fail_count += 1
@@ -689,7 +689,7 @@ class TestHarness:
         result_str = '%s %s  %s%s%s%5.2f s %s' % \
             (num, name, padding1, result.res.value, padding2, result.duration,
              status)
-        ok_statuses = (TestResult.OK, TestResult.EXPECTEDFAIL)
+        ok_statuses = (TestResult.PASS, TestResult.EXPECTEDFAIL)
         bad_statuses = (TestResult.FAIL, TestResult.TIMEOUT, TestResult.UNEXPECTEDPASS,
                         TestResult.ERROR)
         if not self.options.quiet or result.res not in ok_statuses:
@@ -714,7 +714,7 @@ class TestHarness:
 
     def print_summary(self):
         msg = '''
-Ok:                 %4d
+Pass:               %4d
 Expected Fail:      %4d
 Fail:               %4d
 Unexpected Pass:    %4d

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5981,29 +5981,29 @@ class TAPParserTests(unittest.TestCase):
         self.assert_error(events)
         self.assert_plan(events, count=1, late=False, skipped=True,
                          explanation='for some reason')
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_last(events)
 
         events = self.parse_tap('1..1 # todo not supported here\nok 1')
         self.assert_error(events)
         self.assert_plan(events, count=1, late=False, skipped=False,
                          explanation='not supported here')
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_last(events)
 
     def test_one_test_ok(self):
         events = self.parse_tap('ok')
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_last(events)
 
     def test_one_test_with_number(self):
         events = self.parse_tap('ok 1')
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_last(events)
 
     def test_one_test_with_name(self):
         events = self.parse_tap('ok 1 abc')
-        self.assert_test(events, number=1, name='abc', result=TestResult.OK)
+        self.assert_test(events, number=1, name='abc', result=TestResult.PASS)
         self.assert_last(events)
 
     def test_one_test_not_ok(self):
@@ -6033,17 +6033,17 @@ class TAPParserTests(unittest.TestCase):
     def test_many_early_plan(self):
         events = self.parse_tap('1..4\nok 1\nnot ok 2\nok 3\nnot ok 4')
         self.assert_plan(events, count=4, late=False)
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
-        self.assert_test(events, number=3, name='', result=TestResult.OK)
+        self.assert_test(events, number=3, name='', result=TestResult.PASS)
         self.assert_test(events, number=4, name='', result=TestResult.FAIL)
         self.assert_last(events)
 
     def test_many_late_plan(self):
         events = self.parse_tap('ok 1\nnot ok 2\nok 3\nnot ok 4\n1..4')
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
-        self.assert_test(events, number=3, name='', result=TestResult.OK)
+        self.assert_test(events, number=3, name='', result=TestResult.PASS)
         self.assert_test(events, number=4, name='', result=TestResult.FAIL)
         self.assert_plan(events, count=4, late=True)
         self.assert_last(events)
@@ -6071,39 +6071,39 @@ class TAPParserTests(unittest.TestCase):
     def test_one_test_early_plan(self):
         events = self.parse_tap('1..1\nok')
         self.assert_plan(events, count=1, late=False)
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_last(events)
 
     def test_one_test_late_plan(self):
         events = self.parse_tap('ok\n1..1')
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_plan(events, count=1, late=True)
         self.assert_last(events)
 
     def test_out_of_order(self):
         events = self.parse_tap('ok 2')
         self.assert_error(events)
-        self.assert_test(events, number=2, name='', result=TestResult.OK)
+        self.assert_test(events, number=2, name='', result=TestResult.PASS)
         self.assert_last(events)
 
     def test_middle_plan(self):
         events = self.parse_tap('ok 1\n1..2\nok 2')
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_plan(events, count=2, late=True)
         self.assert_error(events)
-        self.assert_test(events, number=2, name='', result=TestResult.OK)
+        self.assert_test(events, number=2, name='', result=TestResult.PASS)
         self.assert_last(events)
 
     def test_too_many_plans(self):
         events = self.parse_tap('1..1\n1..2\nok 1')
         self.assert_plan(events, count=1, late=False)
         self.assert_error(events)
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_last(events)
 
     def test_too_many(self):
         events = self.parse_tap('ok 1\nnot ok 2\n1..1')
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
         self.assert_plan(events, count=1, late=True)
         self.assert_error(events)
@@ -6111,14 +6111,14 @@ class TAPParserTests(unittest.TestCase):
 
         events = self.parse_tap('1..1\nok 1\nnot ok 2')
         self.assert_plan(events, count=1, late=False)
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
         self.assert_error(events)
         self.assert_last(events)
 
     def test_too_few(self):
         events = self.parse_tap('ok 1\nnot ok 2\n1..3')
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
         self.assert_plan(events, count=3, late=True)
         self.assert_error(events)
@@ -6126,7 +6126,7 @@ class TAPParserTests(unittest.TestCase):
 
         events = self.parse_tap('1..3\nok 1\nnot ok 2')
         self.assert_plan(events, count=3, late=False)
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
         self.assert_error(events)
         self.assert_last(events)
@@ -6134,7 +6134,7 @@ class TAPParserTests(unittest.TestCase):
     def test_too_few_bailout(self):
         events = self.parse_tap('1..3\nok 1\nnot ok 2\nBail out! no third test')
         self.assert_plan(events, count=3, late=False)
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
         self.assert_bailout(events, message='no third test')
         self.assert_last(events)
@@ -6142,16 +6142,16 @@ class TAPParserTests(unittest.TestCase):
     def test_diagnostics(self):
         events = self.parse_tap('1..1\n# ignored\nok 1')
         self.assert_plan(events, count=1, late=False)
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_last(events)
 
         events = self.parse_tap('# ignored\n1..1\nok 1\n# ignored too')
         self.assert_plan(events, count=1, late=False)
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_last(events)
 
         events = self.parse_tap('# ignored\nok 1\n1..1\n# ignored too')
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_plan(events, count=1, late=True)
         self.assert_last(events)
 
@@ -6159,7 +6159,7 @@ class TAPParserTests(unittest.TestCase):
         events = self.parse_tap('1..1\ninvalid\nok 1')
         self.assert_plan(events, count=1, late=False)
         self.assert_error(events)
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_last(events)
 
     def test_version(self):
@@ -6178,17 +6178,17 @@ class TAPParserTests(unittest.TestCase):
 
     def test_yaml(self):
         events = self.parse_tap_v13('ok\n ---\n foo: abc\n  bar: def\n ...\nok 2')
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
-        self.assert_test(events, number=2, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
+        self.assert_test(events, number=2, name='', result=TestResult.PASS)
         self.assert_last(events)
 
         events = self.parse_tap_v13('ok\n ---\n foo: abc\n  bar: def')
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_error(events)
         self.assert_last(events)
 
         events = self.parse_tap_v13('ok 1\n ---\n foo: abc\n  bar: def\nnot ok 2')
-        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_test(events, number=1, name='', result=TestResult.PASS)
         self.assert_error(events)
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
         self.assert_last(events)

--- a/test cases/failing test/6 xpass/meson.build
+++ b/test cases/failing test/6 xpass/meson.build
@@ -1,0 +1,4 @@
+project('unexpected pass', 'c')
+
+test('should_fail_but_does_not', executable('xpass', 'xpass.c'),
+     should_fail: true)

--- a/test cases/failing test/6 xpass/xpass.c
+++ b/test cases/failing test/6 xpass/xpass.c
@@ -1,0 +1,1 @@
+int main(int argc, char **argv) { return 0; }

--- a/test cases/linuxlike/14 static dynamic linkage/meson.build
+++ b/test cases/linuxlike/14 static dynamic linkage/meson.build
@@ -15,6 +15,7 @@ test('test default', exe_default)
 test('test static', exe_static)
 test('test dynamic', exe_dynamic)
 
-test('verify static linking', find_program('verify_static.py'), args:exe_static.full_path())
-test('verify dynamic linking', find_program('verify_static.py'), args:exe_dynamic.full_path(),
-     should_fail: true)
+test('verify static linking', find_program('verify_static.py'),
+  args: ['--platform=' + host_machine.system(), exe_static.full_path()])
+test('verify dynamic linking', find_program('verify_static.py'),
+  args: ['--platform=' + host_machine.system(), exe_dynamic.full_path()], should_fail: true)

--- a/test cases/linuxlike/14 static dynamic linkage/verify_static.py
+++ b/test cases/linuxlike/14 static dynamic linkage/verify_static.py
@@ -3,14 +3,27 @@
 import subprocess
 import sys
 
+def handle_common(path):
+    """Handle the common case."""
+    output = subprocess.check_output(['nm', path]).decode('utf-8')
+    if 'T zlibVersion' in output:
+        return 0
+    return 1
+
+def handle_cygwin(path):
+    """Handle the Cygwin case."""
+    output = subprocess.check_output(['nm', path]).decode('utf-8')
+    if 'I __imp_zlibVersion' in output:
+        return 1
+    return 0
+
 def main():
     """Main function"""
-    output = subprocess.check_output(['nm', sys.argv[1]]).decode('utf-8')
+    if len(sys.argv) > 2 and sys.argv[1] == '--platform=cygwin':
+        return handle_cygwin(sys.argv[2])
+    else:
+        return handle_common(sys.argv[2])
 
-    if 'T zlibVersion' in output:
-        sys.exit(0)
-
-    sys.exit(1)
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())


### PR DESCRIPTION
There are some issues with how executed tests are currently reported to the user. Pull request #4466 introduced the "expected fail" and "expected pass" test "categories" that come to play when the `should_fail` argument is given to `test()`. Unfortunately this doesn't really work as, unless I'm horribly mistaken, the `should_fail`'s usage up to that point had not been (only) to indicate broken/incomplete tests but rather just to reverse the outcome of the test from the executed program's return value.

I see the following issues with the current situation:

- The "expected fail" tests are not necessarily failing and should not be reported as such (e.g. a test can be made to ensure that a binary returns an error with invalid input). A non-zero exit code from the executed program doesn't mean that *test* has failed.

- An "unexpected pass" (a test that `should_fail` but didn't) doesn't necessarily indicate that something has been fixed but rather that something has broken.

- Tests that pass "unexpectedly" (i.e. `should_fail` but didn't) aren't considered as errors (by design if I have understood correctly) and the overall exit status of the executed tests is thus unaffected by them. This means that a test that `should_fail` can become broken and be completely missed in CI since its not a "real error".

If something like the XPASS/XFAIL feature is really needed (#3296) I believe it needs to be possible to differentiate them from the "regular" `should_fail` case. I thought about adding a keyword `expect_failure` to the `test()` function but as it would be so close to the `should_fail` argument I went with `broken` instead to make the difference to the `should_fail` argument more obvious. The `should_fail` argument could of course be renamed as well but that would break backwards compatibility.

TL;DR Implement XPASS/XFAIL feature with a new `broken` argument to `test()`.

And also, stop counting timed out tests in both timedout tests and failing tests in the test summary.