### PR TITLE
vs: fix PCH

### DIFF
--- a/test cases/common/13 pch/c/pch/prog.h
+++ b/test cases/common/13 pch/c/pch/prog.h
@@ -1,1 +1,6 @@
+#ifndef PROG_H
+// Header guards for PCH confuse msvc in some situations.
+// Using them here makes sure we handle this correctly.
+#define PROG_H
 #include<stdio.h>
+#endif


### PR DESCRIPTION
Somehow, the VS backend chokes when you add header guards to PCH files.
This can be fixed by always using the basename of the PCH header instead of the relative path, which is also what the ninja backend does.