### PR TITLE
PEP8 for Python 3.7

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -798,7 +798,7 @@ class Backend:
 
     def replace_outputs(self, args, private_dir, output_list):
         newargs = []
-        regex = re.compile('@OUTPUT(\d+)@')
+        regex = re.compile(r'@OUTPUT(\d+)@')
         for arg in args:
             m = regex.search(arg)
             while m is not None:
@@ -938,7 +938,7 @@ class Backend:
                 dfilename = os.path.join(outdir, target.depfile)
                 i = i.replace('@DEPFILE@', dfilename)
             elif '@PRIVATE_OUTDIR_' in i:
-                match = re.search('@PRIVATE_OUTDIR_(ABS_)?([^/\s*]*)@', i)
+                match = re.search(r'@PRIVATE_OUTDIR_(ABS_)?([^/\s*]*)@', i)
                 if not match:
                     msg = 'Custom target {!r} has an invalid argument {!r}' \
                           ''.format(target.name, i)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -472,14 +472,14 @@ class Vs2010Backend(backends.Backend):
         pname.text = project_name
         if self.windows_target_platform_version:
             ET.SubElement(globalgroup, 'WindowsTargetPlatformVersion').text = self.windows_target_platform_version
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.Default.props')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.Default.props')
         type_config = ET.SubElement(root, 'PropertyGroup', Label='Configuration')
         ET.SubElement(type_config, 'ConfigurationType')
         ET.SubElement(type_config, 'CharacterSet').text = 'MultiByte'
         ET.SubElement(type_config, 'UseOfMfc').text = 'false'
         if self.platform_toolset:
             ET.SubElement(type_config, 'PlatformToolset').text = self.platform_toolset
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.props')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.props')
         direlem = ET.SubElement(root, 'PropertyGroup')
         fver = ET.SubElement(direlem, '_ProjectFileVersion')
         fver.text = self.project_file_version
@@ -517,7 +517,7 @@ class Vs2010Backend(backends.Backend):
         cmd_templ = '''"%s" ''' * len(cmd)
         ET.SubElement(customstep, 'Command').text = cmd_templ % tuple(cmd)
         ET.SubElement(customstep, 'Message').text = 'Running custom command.'
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.targets')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.targets')
         self._prettyprint_vcxproj_xml(ET.ElementTree(root), ofname)
 
     def gen_custom_target_vcxproj(self, target, ofname, guid):
@@ -543,7 +543,7 @@ class Vs2010Backend(backends.Backend):
         ET.SubElement(customstep, 'Command').text = ' '.join(self.quote_arguments(wrapper_cmd))
         ET.SubElement(customstep, 'Outputs').text = ';'.join(ofilenames)
         ET.SubElement(customstep, 'Inputs').text = ';'.join([exe_data] + srcs + depend_files)
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.targets')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.targets')
         self.generate_custom_generator_commands(target, root)
         self._prettyprint_vcxproj_xml(ET.ElementTree(root), ofname)
 
@@ -750,7 +750,7 @@ class Vs2010Backend(backends.Backend):
         pname.text = project_name
         if self.windows_target_platform_version:
             ET.SubElement(globalgroup, 'WindowsTargetPlatformVersion').text = self.windows_target_platform_version
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.Default.props')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.Default.props')
         # Start configuration
         type_config = ET.SubElement(root, 'PropertyGroup', Label='Configuration')
         ET.SubElement(type_config, 'ConfigurationType').text = conftype
@@ -823,7 +823,7 @@ class Vs2010Backend(backends.Backend):
         elif '/Od' in o_flags:
             ET.SubElement(type_config, 'Optimization').text = 'Disabled'
         # End configuration
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.props')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.props')
         generated_files, custom_target_output_files, generated_files_include_dirs = self.generate_custom_generator_commands(target, root)
         (gen_src, gen_hdrs, gen_objs, gen_langs) = self.split_sources(generated_files)
         (custom_src, custom_hdrs, custom_objs, custom_langs) = self.split_sources(custom_target_output_files)
@@ -1196,7 +1196,7 @@ class Vs2010Backend(backends.Backend):
                 ET.SubElement(inc_objs, 'Object', Include=s)
             self.add_generated_objects(inc_objs, gen_objs)
 
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.targets')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.targets')
         # Reference the regen target.
         regen_vcxproj = os.path.join(self.environment.get_build_dir(), 'REGEN.vcxproj')
         self.add_project_reference(root, regen_vcxproj, self.environment.coredata.regen_guid)
@@ -1224,14 +1224,14 @@ class Vs2010Backend(backends.Backend):
         pname.text = project_name
         if self.windows_target_platform_version:
             ET.SubElement(globalgroup, 'WindowsTargetPlatformVersion').text = self.windows_target_platform_version
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.Default.props')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.Default.props')
         type_config = ET.SubElement(root, 'PropertyGroup', Label='Configuration')
         ET.SubElement(type_config, 'ConfigurationType').text = "Utility"
         ET.SubElement(type_config, 'CharacterSet').text = 'MultiByte'
         ET.SubElement(type_config, 'UseOfMfc').text = 'false'
         if self.platform_toolset:
             ET.SubElement(type_config, 'PlatformToolset').text = self.platform_toolset
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.props')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.props')
         direlem = ET.SubElement(root, 'PropertyGroup')
         fver = ET.SubElement(direlem, '_ProjectFileVersion')
         fver.text = self.project_file_version
@@ -1276,7 +1276,7 @@ if %%errorlevel%% neq 0 goto :VCEnd'''
         ET.SubElement(custombuild, 'Outputs').text = Vs2010Backend.get_regen_stampfile(self.environment.get_build_dir())
         deps = self.get_regen_filelist()
         ET.SubElement(custombuild, 'AdditionalInputs').text = ';'.join(deps)
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.targets')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.targets')
         ET.SubElement(root, 'ImportGroup', Label='ExtensionTargets')
         self._prettyprint_vcxproj_xml(ET.ElementTree(root), ofname)
 
@@ -1303,14 +1303,14 @@ if %%errorlevel%% neq 0 goto :VCEnd'''
         pname.text = project_name
         if self.windows_target_platform_version:
             ET.SubElement(globalgroup, 'WindowsTargetPlatformVersion').text = self.windows_target_platform_version
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.Default.props')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.Default.props')
         type_config = ET.SubElement(root, 'PropertyGroup', Label='Configuration')
         ET.SubElement(type_config, 'ConfigurationType')
         ET.SubElement(type_config, 'CharacterSet').text = 'MultiByte'
         ET.SubElement(type_config, 'UseOfMfc').text = 'false'
         if self.platform_toolset:
             ET.SubElement(type_config, 'PlatformToolset').text = self.platform_toolset
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.props')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.props')
         direlem = ET.SubElement(root, 'PropertyGroup')
         fver = ET.SubElement(direlem, '_ProjectFileVersion')
         fver.text = self.project_file_version
@@ -1349,7 +1349,7 @@ if %%errorlevel%% neq 0 goto :VCEnd'''
         self.serialize_tests()
         ET.SubElement(postbuild, 'Command').text =\
             cmd_templ % ('" "'.join(test_command))
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.targets')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.targets')
         self._prettyprint_vcxproj_xml(ET.ElementTree(root), ofname)
 
     def gen_installproj(self, target_name, ofname):
@@ -1376,14 +1376,14 @@ if %%errorlevel%% neq 0 goto :VCEnd'''
         pname.text = project_name
         if self.windows_target_platform_version:
             ET.SubElement(globalgroup, 'WindowsTargetPlatformVersion').text = self.windows_target_platform_version
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.Default.props')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.Default.props')
         type_config = ET.SubElement(root, 'PropertyGroup', Label='Configuration')
         ET.SubElement(type_config, 'ConfigurationType')
         ET.SubElement(type_config, 'CharacterSet').text = 'MultiByte'
         ET.SubElement(type_config, 'UseOfMfc').text = 'false'
         if self.platform_toolset:
             ET.SubElement(type_config, 'PlatformToolset').text = self.platform_toolset
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.props')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.props')
         direlem = ET.SubElement(root, 'PropertyGroup')
         fver = ET.SubElement(direlem, '_ProjectFileVersion')
         fver.text = self.project_file_version
@@ -1417,7 +1417,7 @@ exit /b %%1
 if %%errorlevel%% neq 0 goto :VCEnd'''
         ET.SubElement(postbuild, 'Command').text =\
             cmd_templ % ('" "'.join(test_command))
-        ET.SubElement(root, 'Import', Project='$(VCTargetsPath)\Microsoft.Cpp.targets')
+        ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.targets')
         self._prettyprint_vcxproj_xml(ET.ElementTree(root), ofname)
 
     def generate_debug_information(self, link):

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -72,7 +72,7 @@ __all__ = [
     'JavaCompiler',
     'LLVMDCompiler',
     'MonoCompiler',
-    'NvidiaCudaCompiler',
+    'CudaCompiler',
     'VisualStudioCsCompiler',
     'NAGFortranCompiler',
     'ObjCCompiler',

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -150,7 +150,7 @@ cuda_buildtype_args = {'plain': [],
                        'debugoptimized': [],
                        'release': [],
                        'minsize': [],
-                      }
+                       }
 
 arm_buildtype_args = {'plain': [],
                       'debug': ['-O0', '--debug'],

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -176,7 +176,7 @@ class MPIDependency(ExternalDependency):
                 mlog.debug(mlog.bold('Standard output\n'), o)
                 mlog.debug(mlog.bold('Standard error\n'), e)
                 return
-            version = re.search('\d+.\d+.\d+', o)
+            version = re.search(r'\d+.\d+.\d+', o)
             if version:
                 version = version.group(0)
             else:

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -360,7 +360,7 @@ class QtBaseDependency(ExternalDependency):
             # Didn't find qmake :(
             self.is_found = False
             return
-        self.version = re.search(self.qtver + '(\.\d+)+', stdo).group(0)
+        self.version = re.search(self.qtver + r'(\.\d+)+', stdo).group(0)
         # Query library path, header path, and binary path
         mlog.log("Found qmake:", mlog.bold(self.qmake.get_name()), '(%s)' % self.version)
         stdo = Popen_safe(self.qmake.get_command() + ['-query'])[1]

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2853,7 +2853,7 @@ external dependencies (including libraries) must go to "dependencies".''')
             subproject = self.subprojects[dirname]
             if subproject.found():
                 dep = self.subprojects[dirname].get_variable_method([varname], {})
-        except InvalidArguments as e:
+        except InvalidArguments:
             pass
 
         if not isinstance(dep, DependencyHolder):

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -18,7 +18,7 @@
 from . import mparser, mesonlib, mlog
 from . import environment, dependencies
 
-import os, copy, re, types
+import os, copy, re
 from functools import wraps
 
 class ObjectHolder:

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -608,7 +608,7 @@ def version_compare_condition_with_min(condition, minimum):
     # Map versions in the constraint of the form '0.46' to '0.46.0', to embed
     # this knowledge of the meson versioning scheme.
     condition = condition.strip()
-    if re.match('^\d+.\d+$', condition):
+    if re.match(r'^\d+.\d+$', condition):
         condition += '.0'
 
     return cmpop(Version(minimum), Version(condition))

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -120,7 +120,7 @@ class CommandLineParser:
             if os.environ.get('MESON_FORCE_BACKTRACE'):
                 raise
             return 1
-        except Exception as e:
+        except Exception:
             if os.environ.get('MESON_FORCE_BACKTRACE'):
                 raise
             traceback.print_exc()

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -101,7 +101,7 @@ def set_chown(path, user=None, group=None, dir_fd=None, follow_symlinks=True):
 def set_chmod(path, mode, dir_fd=None, follow_symlinks=True):
     try:
         os.chmod(path, mode, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
-    except (NotImplementedError, OSError, SystemError) as e:
+    except (NotImplementedError, OSError, SystemError):
         if not os.path.islink(path):
             os.chmod(path, mode, dir_fd=dir_fd)
 
@@ -157,7 +157,7 @@ def restore_selinux_contexts():
     '''
     try:
         subprocess.check_call(['selinuxenabled'])
-    except (FileNotFoundError, PermissionError, subprocess.CalledProcessError) as e:
+    except (FileNotFoundError, PermissionError, subprocess.CalledProcessError):
         # If we don't have selinux or selinuxenabled returned 1, failure
         # is ignored quietly.
         return

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -239,7 +239,7 @@ class PkgConfigModule(ExtensionModule):
         # https://bugs.freedesktop.org/show_bug.cgi?id=103203
         if isinstance(value, PurePath):
             value = value.as_posix()
-        return value.replace(' ', '\ ')
+        return value.replace(' ', r'\ ')
 
     def _make_relative(self, prefix, subdir):
         if isinstance(prefix, PurePath):

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -37,7 +37,7 @@ class MesonUnicodeDecodeError(MesonException):
 def decode_match(match):
     try:
         return codecs.decode(match.group(0), 'unicode_escape')
-    except UnicodeDecodeError as err:
+    except UnicodeDecodeError:
         raise MesonUnicodeDecodeError(match.group(0))
 
 class ParseException(MesonException):

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -349,7 +349,7 @@ class Resolver:
                 if os.path.exists(dst_file):
                     try:
                         os.remove(dst_file)
-                    except PermissionError as exc:
+                    except PermissionError:
                         os.chmod(dst_file, stat.S_IWUSR)
                         os.remove(dst_file)
                 shutil.copy2(src_file, dst_dir)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4695,9 +4695,9 @@ endian = 'little'
         testdir = os.path.join(self.unit_test_dir, '42 rpath order')
         self.init(testdir)
         if is_osx():
-            rpathre = re.compile('-rpath,.*/subprojects/sub1.*-rpath,.*/subprojects/sub2')
+            rpathre = re.compile(r'-rpath,.*/subprojects/sub1.*-rpath,.*/subprojects/sub2')
         else:
-            rpathre = re.compile('-rpath,\$\$ORIGIN/subprojects/sub1:\$\$ORIGIN/subprojects/sub2')
+            rpathre = re.compile(r'-rpath,\$\$ORIGIN/subprojects/sub1:\$\$ORIGIN/subprojects/sub2')
         with open(os.path.join(self.builddir, 'build.ninja')) as bfile:
             for line in bfile:
                 if '-rpath' in line:

--- a/test cases/common/53 custom target/depfile/dep.py
+++ b/test cases/common/53 custom target/depfile/dep.py
@@ -7,7 +7,7 @@ _, srcdir, depfile, output = sys.argv
 
 depfiles = glob(os.path.join(srcdir, '*'))
 
-quoted_depfiles = [x.replace(' ', '\ ') for x in depfiles]
+quoted_depfiles = [x.replace(' ', r'\ ') for x in depfiles]
 
 with open(output, 'w') as f:
     f.write('I am the result of globbing.')


### PR DESCRIPTION
Python 3.7 throws numerous pep8 warnings due to Python 3.8 syntax deprecations.
These changes make a `flake8` run have zero warnings with Python 3.7 and flake8 3.6.0