### PR TITLE
qt: Only look for a framework on macOS if building for macOS

### DIFF
--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -362,7 +362,7 @@ class QtBaseDependency(ExternalDependency):
             return
         self.version = re.search(self.qtver + '(\.\d+)+', stdo).group(0)
         # Query library path, header path, and binary path
-        mlog.log("Found qmake:", mlog.bold(self.qmake.get_name()), '(%s)' % self.version)
+        mlog.log("Found qmake:", mlog.bold(self.qmake.get_path()), '(%s)' % self.version)
         stdo = Popen_safe(self.qmake.get_command() + ['-query'])[1]
         qvars = {}
         for line in stdo.split('\n'):

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -371,7 +371,8 @@ class QtBaseDependency(ExternalDependency):
                 continue
             (k, v) = tuple(line.split(':', 1))
             qvars[k] = v
-        if mesonlib.is_osx():
+        if self.env.machines.host.is_macos():
+            mlog.debug("Building for macOS, looking for framework")
             self._framework_detect(qvars, mods, kwargs)
             return qmake
         incdir = qvars['QT_INSTALL_HEADERS']

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1382,6 +1382,18 @@ class MachineInfo:
         """
         return self.system in ('darwin', 'ios')
 
+    def is_macos(self):
+        """
+        Machine is macOS (not iOS)
+        """
+        return self.system == 'darwin'
+
+    def is_ios(self):
+        """
+        Machine is iOS (not macOS)
+        """
+        return self.system == 'ios'
+
     def is_android(self):
         """
         Machine is Android?


### PR DESCRIPTION
When building for iOS, the Qt binaries only contain static libraries and headers. No framework.

With this, Meson can successfully compile and link to Qt on iOS.

Also, print the full path to qmake found.