### PR TITLE
find_library: Check arch of libraries on Darwin

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2347,15 +2347,14 @@ rule FORTRAN_DEP_HACK%s
         target_args = self.build_target_link_arguments(linker, target.link_whole_targets)
         return linker.get_link_whole_for(target_args) if len(target_args) else []
 
-    @staticmethod
     @lru_cache(maxsize=None)
-    def guess_library_absolute_path(linker, libname, search_dirs, patterns):
+    def guess_library_absolute_path(self, linker, libname, search_dirs, patterns):
         for d in search_dirs:
             for p in patterns:
                 trial = CCompiler._get_trials_from_pattern(p, d, libname)
                 if not trial:
                     continue
-                trial = CCompiler._get_file_from_list(trial)
+                trial = CCompiler._get_file_from_list(self.environment, trial)
                 if not trial:
                     continue
                 # Return the first result

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1322,6 +1322,9 @@ class MachineInfo:
             return NotImplemented
         return not self.__eq__(other)
 
+    def __repr__(self):
+        return '<MachineInfo: {} {} ({})>'.format(self.system, self.cpu_family, self.cpu)
+
     @staticmethod
     def detect(compilers = None):
         """Detect the machine we're running on

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -468,10 +468,11 @@ def darwin_get_object_archs(objpath):
     to fetch the list of archs supported by it. Supports both thin objects and
     'fat' objects.
     '''
-    _, stdo, stderr = Popen_safe(['lipo', '-archs', objpath])
+    _, stdo, stderr = Popen_safe(['lipo', '-info', objpath])
     if not stdo:
         mlog.debug('lipo {}: {}'.format(objpath, stderr))
         return None
+    stdo = stdo.rsplit(': ', 1)[1]
     # Convert from lipo-style archs to meson-style CPUs
     stdo = stdo.replace('i386', 'x86')
     # Add generic name for armv7 and armv7s

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -461,6 +461,24 @@ def exe_exists(arglist):
         pass
     return False
 
+lru_cache(maxsize=None)
+def darwin_get_object_archs(objpath):
+    '''
+    For a specific object (executable, static library, dylib, etc), run `lipo`
+    to fetch the list of archs supported by it. Supports both thin objects and
+    'fat' objects.
+    '''
+    _, stdo, stderr = Popen_safe(['lipo', '-archs', objpath])
+    if not stdo:
+        mlog.debug('lipo {}: {}'.format(objpath, stderr))
+        return None
+    # Convert from lipo-style archs to meson-style CPUs
+    stdo = stdo.replace('i386', 'x86')
+    # Add generic name for armv7 and armv7s
+    if 'armv7' in stdo:
+        stdo += ' arm'
+    return stdo.split()
+
 def detect_vcs(source_dir):
     vcs_systems = [
         dict(name = 'git',        cmd = 'git', repo_dir = '.git', get_rev = 'git describe --dirty=+', rev_regex = '(.*)', dep = '.git/logs/HEAD'),

--- a/run_tests.py
+++ b/run_tests.py
@@ -81,6 +81,7 @@ def get_fake_env(sdir='', bdir=None, prefix='', opts=None):
         opts = get_fake_options(prefix)
     env = Environment(sdir, bdir, opts)
     env.coredata.compiler_options['c_args'] = FakeCompilerOptions()
+    env.machines.host.cpu_family = 'x86_64' # Used on macOS inside find_library
     return env
 
 


### PR DESCRIPTION
macOS provides the tool `lipo` to check the archs supported by an object (executable, static library, dylib, etc). This is especially useful for fat archives, but it also helps with thin archives.

Without this, the linker will fail to link to the library we mistakenly 'found' like so:

`ld: warning: ignoring file /path/to/libfoo.a, missing required architecture armv7 in file /path/to/libfoo.a`

~~Fixes a bunch of pkg-config related regressions on macOS, including https://github.com/mesonbuild/meson/issues/4728.~~