### PR TITLE
dist: Handle git worktrees, which have a .git file instead of dir

### DIFF
--- a/mesonbuild/scripts/dist.py
+++ b/mesonbuild/scripts/dist.py
@@ -188,7 +188,8 @@ def run(args):
 
     dist_name = build.project_name + '-' + build.project_version
 
-    if os.path.isdir(os.path.join(src_root, '.git')):
+    _git = os.path.join(src_root, '.git')
+    if os.path.isdir(_git) or os.path.isfile(_git):
         names = create_dist_git(dist_name, src_root, bld_root, dist_sub, build.dist_scripts)
     elif os.path.isdir(os.path.join(src_root, '.hg')):
         names = create_dist_hg(dist_name, src_root, bld_root, dist_sub, build.dist_scripts)


### PR DESCRIPTION
This is the second most straight forward stupid way of handling
this (with using os.path.exists as the most stupid obvious way). The
only advantage to this approach is that having .git as something other 
than a file or directory still doesn't register.

Fixes: #3378