### PR TITLE
rewriter: Add support for kwargs modification

### DIFF
--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -103,7 +103,7 @@ class AstInterpreter(interpreterbase.InterpreterBase):
         prev_subdir = self.subdir
         subdir = os.path.join(prev_subdir, args[0])
         absdir = os.path.join(self.source_root, subdir)
-        buildfilename = os.path.join(self.subdir, environment.build_filename)
+        buildfilename = os.path.join(subdir, environment.build_filename)
         absname = os.path.join(self.source_root, buildfilename)
         symlinkless_dir = os.path.realpath(absdir)
         if symlinkless_dir in self.visited_subdirs:
@@ -118,7 +118,7 @@ class AstInterpreter(interpreterbase.InterpreterBase):
             code = f.read()
         assert(isinstance(code, str))
         try:
-            codeblock = mparser.Parser(code, self.subdir).parse()
+            codeblock = mparser.Parser(code, subdir).parse()
         except mesonlib.MesonException as me:
             me.file = buildfilename
             raise me

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -51,6 +51,7 @@ class IntrospectionInterpreter(AstInterpreter):
         self.default_options = {'backend': self.backend}
         self.project_data = {}
         self.targets = []
+        self.project_node = None
 
         self.funcs.update({
             'add_languages': self.func_add_languages,
@@ -65,6 +66,9 @@ class IntrospectionInterpreter(AstInterpreter):
         })
 
     def func_project(self, node, args, kwargs):
+        if self.project_node:
+            raise InvalidArguments('Second call to project()')
+        self.project_node = node
         if len(args) < 1:
             raise InvalidArguments('Not enough arguments to project(). Needs at least the project name.')
 

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -163,10 +163,8 @@ class IntrospectionInterpreter(AstInterpreter):
             if elemetary_nodes:
                 source_nodes += [curr]
 
-        # Filter out kwargs from other target types. For example 'soversion'
-        # passed to library() when default_library == 'static'.
-        kwargs = {k: v for k, v in kwargs.items() if k in targetclass.known_kwargs}
-
+        # Make sure nothing can crash when creating the build class
+        kwargs = {}
         is_cross = False
         objects = []
         empty_sources = [] # Passing the unresolved sources list causes errors

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -51,10 +51,12 @@ class IntrospectionInterpreter(AstInterpreter):
         self.default_options = {'backend': self.backend}
         self.project_data = {}
         self.targets = []
+        self.dependencies = []
         self.project_node = None
 
         self.funcs.update({
             'add_languages': self.func_add_languages,
+            'dependency': self.func_dependency,
             'executable': self.func_executable,
             'jar': self.func_jar,
             'library': self.func_library,
@@ -128,6 +130,16 @@ class IntrospectionInterpreter(AstInterpreter):
             lang = lang.lower()
             if lang not in self.coredata.compilers:
                 self.environment.detect_compilers(lang, need_cross_compiler)
+
+    def func_dependency(self, node, args, kwargs):
+        args = self.flatten_args(args)
+        if not args:
+            return
+        name = args[0]
+        self.dependencies += [{
+            'name': name,
+            'node': node
+        }]
 
     def build_target(self, node, args, kwargs, targetclass):
         if not args:

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -345,6 +345,27 @@ class Rewriter:
 
         return tgt
 
+    def find_dependency(self, dependency: str):
+        def check_list(name: str):
+            for i in self.interpreter.dependencies:
+                if name == i['name']:
+                    return i
+            return None
+
+        dep = check_list(dependency)
+        if dep is not None:
+            return dep
+
+        # Check the assignments
+        if dependency in self.interpreter.assignments:
+            node = self.interpreter.assignments[dependency][0]
+            if isinstance(node, mparser.FunctionNode):
+                if node.func_name in ['dependency']:
+                    name = self.interpreter.flatten_args(node.args)[0]
+                    dep = check_list(name)
+
+        return dep
+
     @RequiredKeys(rewriter_keys['kwargs'])
     def process_kwargs(self, cmd):
         mlog.log('Processing function type', mlog.bold(cmd['function']), 'with id', mlog.cyan("'" + cmd['id'] + "'"))
@@ -361,6 +382,11 @@ class Rewriter:
             arg_node = node.args
         elif cmd['function'] == 'target':
             tmp = self.find_target(cmd['id'])
+            if tmp:
+                node = tmp['node']
+                arg_node = node.args
+        elif cmd['function'] == 'dependency':
+            tmp = self.find_dependency(cmd['id'])
             if tmp:
                 node = tmp['node']
                 arg_node = node.args

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -71,7 +71,7 @@ class RequiredKeys:
 
         return wrapped
 
-class MesonBaseType:
+class MTypeBase:
     def __init__(self, node: mparser.BaseNode):
         if node is None:
             self.node = self._new_node()
@@ -108,7 +108,7 @@ class MesonBaseType:
         # Overwrite in derived class
         mlog.warning('Cannot remove a value of type', mlog.bold(type(self).__name__), '--> skipping')
 
-class MesonStr(MesonBaseType):
+class MTypeStr(MTypeBase):
     def __init__(self, node: mparser.BaseNode):
         super().__init__(node)
 
@@ -121,7 +121,7 @@ class MesonStr(MesonBaseType):
     def set_value(self, value):
         self.node.value = str(value)
 
-class MesonBool(MesonBaseType):
+class MTypeBool(MTypeBase):
     def __init__(self, node: mparser.BaseNode):
         super().__init__(node)
 
@@ -134,7 +134,7 @@ class MesonBool(MesonBaseType):
     def set_value(self, value):
         self.node.value = bool(value)
 
-class MesonID(MesonBaseType):
+class MTypeID(MTypeBase):
     def __init__(self, node: mparser.BaseNode):
         super().__init__(node)
 
@@ -147,7 +147,7 @@ class MesonID(MesonBaseType):
     def set_value(self, value):
         self.node.value = str(value)
 
-class MesonList(MesonBaseType):
+class MTypeList(MTypeBase):
     def __init__(self, node: mparser.BaseNode):
         super().__init__(node)
 
@@ -212,7 +212,7 @@ class MesonList(MesonBaseType):
                 removed_list += [i]
         self.node.args.arguments = removed_list
 
-class MesonStrList(MesonList):
+class MtypeStrList(MTypeList):
     def __init__(self, node: mparser.BaseNode):
         super().__init__(node)
 
@@ -227,7 +227,7 @@ class MesonStrList(MesonList):
     def supported_element_nodes(self):
         return [mparser.StringNode]
 
-class MesonIDList(MesonList):
+class MTypeIDList(MTypeList):
     def __init__(self, node: mparser.BaseNode):
         super().__init__(node)
 
@@ -259,33 +259,33 @@ rewriter_keys = {
 
 rewriter_func_kwargs = {
     'dependency': {
-        'language': MesonStr,
-        'method': MesonStr,
-        'native': MesonBool,
-        'not_found_message': MesonStr,
-        'required': MesonBool,
-        'static': MesonBool,
-        'version': MesonStrList,
-        'modules': MesonStrList
+        'language': MTypeStr,
+        'method': MTypeStr,
+        'native': MTypeBool,
+        'not_found_message': MTypeStr,
+        'required': MTypeBool,
+        'static': MTypeBool,
+        'version': MtypeStrList,
+        'modules': MtypeStrList
     },
     'target': {
-        'build_by_default': MesonBool,
-        'build_rpath': MesonStr,
-        'dependencies': MesonIDList,
-        'gui_app': MesonBool,
-        'link_with': MesonIDList,
-        'export_dynamic': MesonBool,
-        'implib': MesonBool,
-        'install': MesonBool,
-        'install_dir': MesonStr,
-        'install_rpath': MesonStr,
-        'pie': MesonBool
+        'build_by_default': MTypeBool,
+        'build_rpath': MTypeStr,
+        'dependencies': MTypeIDList,
+        'gui_app': MTypeBool,
+        'link_with': MTypeIDList,
+        'export_dynamic': MTypeBool,
+        'implib': MTypeBool,
+        'install': MTypeBool,
+        'install_dir': MTypeStr,
+        'install_rpath': MTypeStr,
+        'pie': MTypeBool
     },
     'project': {
-        'meson_version': MesonStr,
-        'license': MesonStrList,
-        'subproject_dir': MesonStr,
-        'version': MesonStr
+        'meson_version': MTypeStr,
+        'license': MtypeStrList,
+        'subproject_dir': MTypeStr,
+        'version': MTypeStr
     }
 }
 

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -251,7 +251,7 @@ rewriter_keys = {
     },
     'target': {
         'target': (str, None, None),
-        'operation': (str, None, ['src_add', 'src_rm', 'test']),
+        'operation': (str, None, ['src_add', 'src_rm', 'info']),
         'sources': (list, [], None),
         'debug': (bool, False, None)
     }
@@ -493,7 +493,7 @@ class Rewriter:
                 if root not in self.modefied_nodes:
                     self.modefied_nodes += [root]
 
-        elif cmd['operation'] == 'test':
+        elif cmd['operation'] == 'info':
             # List all sources in the target
             src_list = []
             for i in target['sources']:

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -99,10 +99,26 @@ class Rewriter:
         self.interpreter.ast.accept(self.id_generator)
 
     def find_target(self, target: str):
-        for i in self.interpreter.targets:
-            if target == i['name'] or target == i['id']:
-                return i
-        return None
+        def check_list(name: str):
+            for i in self.interpreter.targets:
+                if name == i['name'] or name == i['id']:
+                    return i
+            return None
+
+        tgt = check_list(target)
+        if tgt is not None:
+            return tgt
+
+        # Check the assignments
+        if target in self.interpreter.assignments:
+            node = self.interpreter.assignments[target][0]
+            print(node)
+            if isinstance(node, mparser.FunctionNode):
+                if node.func_name in ['executable', 'jar', 'library', 'shared_library', 'shared_module', 'static_library', 'both_libraries']:
+                    name = self.interpreter.flatten_args(node.args)[0]
+                    tgt = check_list(name)
+
+        return tgt
 
     @RequiredKeys(rewriter_keys['target'])
     def process_target(self, cmd):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5137,7 +5137,8 @@ class RewriterTests(BasePlatformTests):
         expected = {
             'kwargs': {
                 'project#': {'version': '0.0.1'},
-                'target#tgt1': {'build_by_default': True}
+                'target#tgt1': {'build_by_default': True},
+                'dependency#dep1': {'required': False}
             }
         }
         self.assertDictEqual(out, expected)
@@ -5150,7 +5151,8 @@ class RewriterTests(BasePlatformTests):
         expected = {
             'kwargs': {
                 'project#': {'version': '0.0.2', 'meson_version': '0.50.0', 'license': ['GPL', 'MIT']},
-                'target#tgt1': {'build_by_default': False, 'build_rpath': '/usr/local', 'dependencies': 'dep1'}
+                'target#tgt1': {'build_by_default': False, 'build_rpath': '/usr/local', 'dependencies': 'dep1'},
+                'dependency#dep1': {'required': True, 'method': 'cmake'}
             }
         }
         self.assertDictEqual(out, expected)
@@ -5163,7 +5165,8 @@ class RewriterTests(BasePlatformTests):
         expected = {
             'kwargs': {
                 'project#': {'version': '0.0.1', 'license': ['GPL', 'MIT', 'BSD']},
-                'target#tgt1': {'build_by_default': True}
+                'target#tgt1': {'build_by_default': True},
+                'dependency#dep1': {'required': False}
             }
         }
         self.assertDictEqual(out, expected)
@@ -5176,7 +5179,8 @@ class RewriterTests(BasePlatformTests):
         expected = {
             'kwargs': {
                 'project#': {'version': '0.0.1', 'license': 'GPL'},
-                'target#tgt1': {'build_by_default': True}
+                'target#tgt1': {'build_by_default': True},
+                'dependency#dep1': {'required': False}
             }
         }
         self.assertDictEqual(out, expected)
@@ -5189,7 +5193,8 @@ class RewriterTests(BasePlatformTests):
         expected = {
             'kwargs': {
                 'project#': {},
-                'target#tgt1': {}
+                'target#tgt1': {},
+                'dependency#dep1': {'required': False}
             }
         }
         self.assertDictEqual(out, expected)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5130,6 +5130,70 @@ class RewriterTests(BasePlatformTests):
         out = self.extract_test_data(out)
         self.assertDictEqual(list(out['target'].values())[0], expected)
 
+    def test_kwargs_info(self):
+        self.prime('3 kwargs')
+        out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
+        out = self.extract_test_data(out)
+        expected = {
+            'kwargs': {
+                'project#': {'version': '0.0.1'},
+                'target#tgt1': {'build_by_default': True}
+            }
+        }
+        self.assertDictEqual(out, expected)
+
+    def test_kwargs_set(self):
+        self.prime('3 kwargs')
+        self.rewrite(self.builddir, os.path.join(self.builddir, 'set.json'))
+        out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
+        out = self.extract_test_data(out)
+        expected = {
+            'kwargs': {
+                'project#': {'version': '0.0.2', 'meson_version': '0.50.0', 'license': ['GPL', 'MIT']},
+                'target#tgt1': {'build_by_default': False, 'build_rpath': '/usr/local', 'dependencies': 'dep1'}
+            }
+        }
+        self.assertDictEqual(out, expected)
+
+    def test_kwargs_add(self):
+        self.prime('3 kwargs')
+        self.rewrite(self.builddir, os.path.join(self.builddir, 'add.json'))
+        out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
+        out = self.extract_test_data(out)
+        expected = {
+            'kwargs': {
+                'project#': {'version': '0.0.1', 'license': ['GPL', 'MIT', 'BSD']},
+                'target#tgt1': {'build_by_default': True}
+            }
+        }
+        self.assertDictEqual(out, expected)
+
+    def test_kwargs_remove(self):
+        self.prime('3 kwargs')
+        self.rewrite(self.builddir, os.path.join(self.builddir, 'remove.json'))
+        out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
+        out = self.extract_test_data(out)
+        expected = {
+            'kwargs': {
+                'project#': {'version': '0.0.1', 'license': 'GPL'},
+                'target#tgt1': {'build_by_default': True}
+            }
+        }
+        self.assertDictEqual(out, expected)
+
+    def test_kwargs_delete(self):
+        self.prime('3 kwargs')
+        self.rewrite(self.builddir, os.path.join(self.builddir, 'delete.json'))
+        out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
+        out = self.extract_test_data(out)
+        expected = {
+            'kwargs': {
+                'project#': {},
+                'target#tgt1': {}
+            }
+        }
+        self.assertDictEqual(out, expected)
+
 class NativeFileTests(BasePlatformTests):
 
     def setUp(self):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5022,7 +5022,7 @@ class PythonTests(BasePlatformTests):
 
 
 class RewriterTests(BasePlatformTests):
-    data_regex = re.compile(r'^\s*!!\s*(\w+)\s+([^=]+)=(.*)$')
+    data_regex = re.compile(r'.*\n!!==JSON DUMP: BEGIN==!!\n(.*)\n!!==JSON DUMP: END==!!\n', re.MULTILINE | re.DOTALL)
 
     def setUp(self):
         super().setUp()
@@ -5045,17 +5045,10 @@ class RewriterTests(BasePlatformTests):
         return p.stdout
 
     def extract_test_data(self, out):
-        lines = out.split('\n')
+        match = RewriterTests.data_regex.match(out)
         result = {}
-        for i in lines:
-            match = RewriterTests.data_regex.match(i)
-            if match:
-                typ = match.group(1)
-                id = match.group(2)
-                data = json.loads(match.group(3))
-                if typ not in result:
-                    result[typ] = {}
-                result[typ][id] = data
+        if match:
+            result = json.loads(match.group(1))
         return result
 
     def test_target_source_list(self):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5034,9 +5034,15 @@ class RewriterTests(BasePlatformTests):
     def rewrite(self, directory, args):
         if isinstance(args, str):
             args = [args]
-        out = subprocess.check_output(self.rewrite_command + ['--sourcedir', directory] + args,
-                                      universal_newlines=True)
-        return out
+        command = self.rewrite_command + ['--sourcedir', directory] + args
+        p = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                           universal_newlines=True, timeout=60)
+        print(p.stdout)
+        if p.returncode != 0:
+            if 'MESON_SKIP_TEST' in p.stdout:
+                raise unittest.SkipTest('Project requested skipping.')
+            raise subprocess.CalledProcessError(p.returncode, command, output=p.stdout)
+        return p.stdout
 
     def extract_test_data(self, out):
         lines = out.split('\n')

--- a/test cases/rewrite/1 basic/addSrc.json
+++ b/test cases/rewrite/1 basic/addSrc.json
@@ -44,46 +44,46 @@
   {
     "type": "target",
     "target": "trivialprog1",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog2",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog3",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog4",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog5",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog6",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog7",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog8",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog9",
-    "operation": "test"
+    "operation": "info"
   }
 ]

--- a/test cases/rewrite/1 basic/info.json
+++ b/test cases/rewrite/1 basic/info.json
@@ -2,46 +2,46 @@
   {
     "type": "target",
     "target": "trivialprog1",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "exe2",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog3",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "exe4",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog5",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "exe6",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog7",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "exe8",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog9",
-    "operation": "test"
+    "operation": "info"
   }
 ]

--- a/test cases/rewrite/1 basic/info.json
+++ b/test cases/rewrite/1 basic/info.json
@@ -6,7 +6,7 @@
   },
   {
     "type": "target",
-    "target": "trivialprog2",
+    "target": "exe2",
     "operation": "test"
   },
   {
@@ -16,7 +16,7 @@
   },
   {
     "type": "target",
-    "target": "trivialprog4",
+    "target": "exe4",
     "operation": "test"
   },
   {
@@ -26,7 +26,7 @@
   },
   {
     "type": "target",
-    "target": "trivialprog6",
+    "target": "exe6",
     "operation": "test"
   },
   {
@@ -36,7 +36,7 @@
   },
   {
     "type": "target",
-    "target": "trivialprog8",
+    "target": "exe8",
     "operation": "test"
   },
   {

--- a/test cases/rewrite/1 basic/rmSrc.json
+++ b/test cases/rewrite/1 basic/rmSrc.json
@@ -38,46 +38,46 @@
   {
     "type": "target",
     "target": "trivialprog1",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog2",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog3",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog4",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog5",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog6",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog7",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog8",
-    "operation": "test"
+    "operation": "info"
   },
   {
     "type": "target",
     "target": "trivialprog9",
-    "operation": "test"
+    "operation": "info"
   }
 ]

--- a/test cases/rewrite/2 subdirs/addSrc.json
+++ b/test cases/rewrite/2 subdirs/addSrc.json
@@ -8,6 +8,6 @@
   {
     "type": "target",
     "target": "something",
-    "operation": "test"
+    "operation": "info"
   }
 ]

--- a/test cases/rewrite/2 subdirs/info.json
+++ b/test cases/rewrite/2 subdirs/info.json
@@ -2,6 +2,6 @@
   {
     "type": "target",
     "target": "something",
-    "operation": "test"
+    "operation": "info"
   }
 ]

--- a/test cases/rewrite/3 kwargs/add.json
+++ b/test cases/rewrite/3 kwargs/add.json
@@ -1,0 +1,29 @@
+[
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "",
+    "operation": "set",
+    "kwargs": {
+      "license": "GPL"
+    }
+  },
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "",
+    "operation": "add",
+    "kwargs": {
+      "license": ["MIT"]
+    }
+  },
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "",
+    "operation": "add",
+    "kwargs": {
+      "license": "BSD"
+    }
+  }
+]

--- a/test cases/rewrite/3 kwargs/delete.json
+++ b/test cases/rewrite/3 kwargs/delete.json
@@ -1,0 +1,20 @@
+[
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "",
+    "operation": "delete",
+    "kwargs": {
+      "version": null
+    }
+  },
+  {
+    "type": "kwargs",
+    "function": "target",
+    "id": "helloWorld",
+    "operation": "delete",
+    "kwargs": {
+      "build_by_default": false
+    }
+  }
+]

--- a/test cases/rewrite/3 kwargs/info.json
+++ b/test cases/rewrite/3 kwargs/info.json
@@ -10,5 +10,11 @@
     "function": "target",
     "id": "tgt1",
     "operation": "info"
+  },
+  {
+    "type": "kwargs",
+    "function": "dependency",
+    "id": "dep1",
+    "operation": "info"
   }
 ]

--- a/test cases/rewrite/3 kwargs/info.json
+++ b/test cases/rewrite/3 kwargs/info.json
@@ -1,0 +1,14 @@
+[
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "",
+    "operation": "info"
+  },
+  {
+    "type": "kwargs",
+    "function": "target",
+    "id": "tgt1",
+    "operation": "info"
+  }
+]

--- a/test cases/rewrite/3 kwargs/meson.build
+++ b/test cases/rewrite/3 kwargs/meson.build
@@ -1,5 +1,7 @@
 project('rewritetest', 'cpp', version: '0.0.1')
 
+# Find ZLIB
 dep1 = dependency('zlib', required: false)
 
+# Make a test exe
 tgt1 = executable('helloWorld', 'main.cpp', build_by_default: true)

--- a/test cases/rewrite/3 kwargs/meson.build
+++ b/test cases/rewrite/3 kwargs/meson.build
@@ -1,0 +1,5 @@
+project('rewritetest', 'cpp', version: '0.0.1')
+
+dep1 = dependency('zlib', required: false)
+
+tgt1 = executable('helloWorld', 'main.cpp', build_by_default: true)

--- a/test cases/rewrite/3 kwargs/remove.json
+++ b/test cases/rewrite/3 kwargs/remove.json
@@ -1,0 +1,29 @@
+[
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "",
+    "operation": "set",
+    "kwargs": {
+      "license": ["GPL", "MIT", "BSD"]
+    }
+  },
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "",
+    "operation": "remove",
+    "kwargs": {
+      "license": ["MIT"]
+    }
+  },
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "",
+    "operation": "remove",
+    "kwargs": {
+      "license": "BSD"
+    }
+  }
+]

--- a/test cases/rewrite/3 kwargs/set.json
+++ b/test cases/rewrite/3 kwargs/set.json
@@ -20,5 +20,15 @@
       "build_rpath": "/usr/local",
       "dependencies": "dep1"
     }
+  },
+  {
+    "type": "kwargs",
+    "function": "dependency",
+    "id": "zlib",
+    "operation": "set",
+    "kwargs": {
+      "required": true,
+      "method": "cmake"
+    }
   }
 ]

--- a/test cases/rewrite/3 kwargs/set.json
+++ b/test cases/rewrite/3 kwargs/set.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "",
+    "operation": "set",
+    "kwargs": {
+      "version": "0.0.2",
+      "meson_version": "0.50.0",
+      "license": ["GPL", "MIT"]
+    }
+  },
+  {
+    "type": "kwargs",
+    "function": "target",
+    "id": "helloWorld",
+    "operation": "set",
+    "kwargs": {
+      "build_by_default": false,
+      "build_rpath": "/usr/local",
+      "dependencies": "dep1"
+    }
+  }
+]


### PR DESCRIPTION
This PR adds support for rewriting select `kwargs` of the `project()`, `dependency()` and build target functions (`executable()`, `library()`, etc.).

Kwargs of these functions can be set and removed. If the kwarg is a list, elements can also be added and removed.

Again, no docs because this feature is still in beta :smiley:  