### PR TITLE
better handle variable HDF5 setups, update Fortran compiler def, PEP8

### DIFF
--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -267,8 +267,8 @@ class FortranCompiler(Compiler):
         return CCompiler._get_trials_from_pattern(pattern, directory, libname)
 
     @staticmethod
-    def _get_file_from_list(files) -> List[str]:
-        return CCompiler._get_file_from_list(files)
+    def _get_file_from_list(env, files: List[str]) -> str:
+        return CCompiler._get_file_from_list(env, files)
 
 class GnuFortranCompiler(GnuCompiler, FortranCompiler):
     def __init__(self, exelist, version, compiler_type, is_cross, exe_wrapper=None, defines=None, **kwargs):

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -19,7 +19,6 @@ import copy
 import functools
 import os
 import re
-import stat
 import json
 import shlex
 import shutil

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -52,23 +52,25 @@ class HDF5Dependency(ExternalDependency):
                 if pkgdep.found():
                     self.compile_args = pkgdep.get_compile_args()
                     # derive needed libraries by language
-                    link_args = pkgdep.get_link_args()
-                    lang_link_args = []
-                    for larg in link_args:
+                    pd_link_args = pkgdep.get_link_args()
+                    link_args = []
+                    for larg in pd_link_args:
                         lpath = Path(larg)
                         if lpath.is_file():
                             if language == 'cpp':
-                                lang_link_args.append(str(lpath.parent / (lpath.stem + '_hl_cpp' + lpath.suffix)))
-                                lang_link_args.append(str(lpath.parent / (lpath.stem + '_cpp' + lpath.suffix)))
+                                link_args.append(str(lpath.parent / (lpath.stem + '_hl_cpp' + lpath.suffix)))
+                                link_args.append(str(lpath.parent / (lpath.stem + '_cpp' + lpath.suffix)))
                             elif language == 'fortran':
-                                lang_link_args.append(str(lpath.parent / (lpath.stem + 'hl_fortran' + lpath.suffix)))
-                                lang_link_args.append(str(lpath.parent / (lpath.stem + '_fortran' + lpath.suffix)))
+                                link_args.append(str(lpath.parent / (lpath.stem + 'hl_fortran' + lpath.suffix)))
+                                link_args.append(str(lpath.parent / (lpath.stem + '_fortran' + lpath.suffix)))
 
-                            # C is used by other languages
-                            lang_link_args.append(str(lpath.parent / (lpath.stem + '_hl' + lpath.suffix)))
-                            lang_link_args.append(larg)
+                            # HDF5 C libs are required by other HDF5 languages
+                            link_args.append(str(lpath.parent / (lpath.stem + '_hl' + lpath.suffix)))
+                            link_args.append(larg)
+                        else:
+                            link_args.append(larg)
 
-                    self.link_args = lang_link_args
+                    self.link_args = link_args
                     self.version = pkgdep.get_version()
                     self.is_found = True
                     self.pcdep = pkgdep

--- a/mesonbuild/dependencies/platform.py
+++ b/mesonbuild/dependencies/platform.py
@@ -15,8 +15,6 @@
 # This file contains the detection logic for external dependencies that are
 # platform-specific (generally speaking).
 
-from .. import mesonlib
-
 from .base import ExternalDependency, DependencyException
 
 

--- a/test cases/frameworks/25 hdf5/main.cpp
+++ b/test cases/frameworks/25 hdf5/main.cpp
@@ -9,7 +9,7 @@ unsigned maj, min, rel;
 
 ier = H5open();
 if (ier) {
-    std::cerr << "Unable to initialize HDF5: %d" << ier << std::endl;
+    std::cerr << "Unable to initialize HDF5: " << ier << std::endl;
     return EXIT_FAILURE;
 }
 
@@ -18,11 +18,11 @@ if (ier) {
     std::cerr << "HDF5 did not initialize!" << std::endl;
     return EXIT_FAILURE;
 }
-printf("C++ HDF5 version %d.%d.%d\n", maj, min, rel);
+std::cout << "C++ HDF5 version " << maj << "." << min << "." << rel << std::endl;
 
 ier = H5close();
 if (ier) {
-    std::cerr << "Unable to close HDF5: %d"  << ier << std::endl;
+    std::cerr << "Unable to close HDF5: " << ier << std::endl;
     return EXIT_FAILURE;
 }
 return EXIT_SUCCESS;

--- a/test cases/frameworks/25 hdf5/meson.build
+++ b/test cases/frameworks/25 hdf5/meson.build
@@ -12,30 +12,29 @@ endif
 # --- C tests
 h5c = dependency('hdf5', language : 'c', required : false)
 if not h5c.found()
-  error('MESON_SKIP_TEST: HDF5 not found, skipping.')
+  error('MESON_SKIP_TEST: HDF5 C library not found, skipping HDF5 framework tests.')
 endif
-exec = executable('exec', 'main.c',
-  dependencies : h5c)
+exec = executable('exec', 'main.c', dependencies : h5c)
 
 test('HDF5 C', exec)
 
 # --- C++ tests
-h5cpp = dependency('hdf5', language : 'cpp')
-execpp = executable('execpp', 'main.cpp',
-  dependencies : h5cpp)
-
-test('HDF5 C++', execpp)
-
+h5cpp = dependency('hdf5', language : 'cpp', required : false)
+if h5cpp.found()
+  execpp = executable('execpp', 'main.cpp', dependencies : h5cpp)
+  test('HDF5 C++', execpp)
+endif
 
 # --- Fortran tests
 if build_machine.system() != 'windows'
   add_languages('fortran')
 
-  h5f = dependency('hdf5', language : 'fortran')
-  exef = executable('exef', 'main.f90',
-    dependencies : h5f)
+  h5f = dependency('hdf5', language : 'fortran', required : false)
+  if h5f.found()
+    exef = executable('exef', 'main.f90', dependencies : h5f)
 
-  test('HDF5 Fortran', exef)
+    test('HDF5 Fortran', exef)
+  endif
 endif
 
 # Check we can apply a version constraint


### PR DESCRIPTION
In light of updates of #4860 revealing some deficiencies in the Fortran code in general, and HDF5 specifically here are fixes:

* update fortran.py to have correct arguments in function
* update HDF5 test case to allow missing C++ or Fortran, while C is required for both
* Python 3.7 PEP8 fixes (unused imports)