### PR TITLE
(for 0.49) deps: Don't reject cross usage of extra frameworks

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1934,11 +1934,6 @@ class ExtraFrameworkDependency(ExternalDependency):
             self.link_args = ['-F' + self.path, '-framework', self.name.split('.')[0]]
 
     def detect(self, name, path):
-        # should use the compiler to look for frameworks, rather than peering at
-        # the filesystem, so we can also find them when cross-compiling
-        if self.want_cross:
-            return
-
         lname = name.lower()
         if path is None:
             paths = ['/System/Library/Frameworks', '/Library/Frameworks']


### PR DESCRIPTION
This is a regression from previous releases and breaks existing build files, such as GStreamer. The proper fix is in master (#4857), but we cannot backport that since it is a complete rewrite of the framework detection.