### PR TITLE
Ensure that func dicts provide the same set of functions

### DIFF
--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -89,6 +89,16 @@ class AstInterpreter(interpreterbase.InterpreterBase):
                            'set_variable': self.func_do_nothing,
                            'get_variable': self.func_do_nothing,
                            'is_variable': self.func_do_nothing,
+                           'disabler': self.func_do_nothing,
+                           'gettext': self.func_do_nothing,
+                           'jar': self.func_do_nothing,
+                           'warning': self.func_do_nothing,
+                           'shared_module': self.func_do_nothing,
+                           'option': self.func_do_nothing,
+                           'both_libraries': self.func_do_nothing,
+                           'add_test_setup': self.func_do_nothing,
+                           'find_library': self.func_do_nothing,
+                           'subdir_done': self.func_do_nothing,
                            })
 
     def func_do_nothing(self, node, args, kwargs):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -42,6 +42,7 @@ import mesonbuild.mesonlib
 import mesonbuild.coredata
 import mesonbuild.modules.gnome
 from mesonbuild.interpreter import Interpreter, ObjectHolder
+from mesonbuild.ast import AstInterpreter
 from mesonbuild.mesonlib import (
     is_windows, is_osx, is_cygwin, is_dragonflybsd, is_openbsd, is_haiku,
     windows_proof_rmtree, python_command, version_compare,
@@ -1052,6 +1053,16 @@ class DataTests(unittest.TestCase):
             res = re.search(r'syn keyword mesonBuiltin(\s+\\\s\w+)+', f.read(), re.MULTILINE)
             defined = set([a.strip() for a in res.group().split('\\')][1:])
             self.assertEqual(defined, set(chain(interp.funcs.keys(), interp.builtin.keys())))
+
+    def test_all_functions_defined_in_ast_interpreter(self):
+        '''
+        Ensure that the all functions defined in the Interpreter are also defined
+        in the AstInterpreter (and vice versa).
+        '''
+        env = get_fake_env()
+        interp = Interpreter(FakeBuild(env), mock=True)
+        astint = AstInterpreter('.', '')
+        self.assertEqual(set(interp.funcs.keys()), set(astint.funcs.keys()))
 
 
 class BasePlatformTests(unittest.TestCase):


### PR DESCRIPTION
Simple test case to ensure that all functions in the real interpreter are also known to the "fake" interpreter. Also added the currently missing functions.