### PR TITLE
Fix introspection test case for solaris (fixes #4866)

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3340,7 +3340,7 @@ recommended as it is not supported on some platforms''')
         # Check buildsystem_files
         bs_files = ['meson.build', 'sharedlib/meson.build', 'staticlib/meson.build']
         bs_files = [os.path.join(testdir, x) for x in bs_files]
-        self.assertPathListEqual(res['buildsystem_files'], bs_files)
+        self.assertPathListEqual(list(sorted(res['buildsystem_files'])), list(sorted(bs_files)))
 
         # Check dependencies
         dependencies_to_find = ['threads']


### PR DESCRIPTION
The order of the build system files is not important, so make sure that the lists are both sorted in the test case to avoid failures due to a different list order.