### PR TITLE
fix default library path handling on FreeBSD

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -680,6 +680,8 @@ def get_library_dirs() -> List[str]:
     # problematic, please raise the issue on the mailing list.
     unixdirs = ['/usr/local/lib', '/usr/lib', '/lib']
 
+    if is_freebsd():
+        return unixdirs
     # FIXME: this needs to be further genericized for aarch64 etc.
     machine = platform.machine()
     if machine in ('i386', 'i486', 'i586', 'i686'):

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -655,6 +655,8 @@ def default_libdir():
                 return 'lib/' + archpath
         except Exception:
             pass
+    if is_freebsd():
+        return 'lib'
     if os.path.isdir('/usr/lib64') and not os.path.islink('/usr/lib64'):
         return 'lib64'
     return 'lib'


### PR DESCRIPTION
Fix library directory detection on FreeBSD. FreeBSD uses /usr/local/lib, /usr/lib and /lib for libraries, regardless of architecture and platform. Ensure that even if, as an example, /usr/lib64 exists, don't use it as the default_libdir() and don't suggest it as a directory to look for shared libraries in.