### PR TITLE
vala: Support position-independent executables

### DIFF
--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -49,6 +49,12 @@ class ValaCompiler(Compiler):
     def get_pic_args(self):
         return []
 
+    def get_pie_args(self):
+        return []
+
+    def get_pie_link_args(self):
+        return []
+
     def get_always_args(self):
         return ['-C']
 


### PR DESCRIPTION
Because Vala is only generating .c files, it's up to the C compiler to deal with this.