### PR TITLE
Fix meson not detecting dub packages with different compilers and arch

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1674,9 +1674,9 @@ class DubDependency(ExternalDependency):
             return ''
 
         # Ex.: library-debug-linux.posix-x86_64-ldc_2081-EF934983A3319F8F8FF2F0E107A363BA
-        build_name = 'library-{}-{}-{}-{}_{}'.format(description['buildType'], '.'.join(description['platform']), '.'.join(description['architecture']), comp, d_ver)
+        build_name = '-{}-{}-{}-{}_{}'.format(description['buildType'], '.'.join(description['platform']), '.'.join(description['architecture']), comp, d_ver)
         for entry in os.listdir(module_build_path):
-            if entry.startswith(build_name):
+            if build_name in entry:
                 for file in os.listdir(os.path.join(module_build_path, entry)):
                     if file == lib_file_name:
                         if folder_only:


### PR DESCRIPTION
Fixes #4886.

For example, some packages has some custom configurations on dub config, and instead of `library` its the configuration name:
![image](https://user-images.githubusercontent.com/5050669/52304779-61d43180-298b-11e9-8037-ba95e817c5fd.png)

(generated builds)
![image](https://user-images.githubusercontent.com/5050669/52304800-6e588a00-298b-11e9-895c-5b957baec84c.png)
