### PR TITLE
Fortran 2008/2018 Coarray support

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -257,7 +257,7 @@ libraries that have been compiled for single-threaded use instead.
 
 ## Fortran Coarrays
 
-Coarrays are a Fortran language intrinsic feature, enabled by
+As of 0.50.0 Coarrays are a Fortran language intrinsic feature, enabled by
 `dependency('coarray')`.
 
 GCC will use OpenCoarrays if present to implement coarrays, while Intel and NAG

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -258,7 +258,7 @@ libraries that have been compiled for single-threaded use instead.
 ## Fortran Coarrays
 
 Coarrays are a Fortran language intrinsic feature, enabled by 
-`dependency('Coarray')`.
+`dependency('coarray')`.
 GCC will use OpenCoarrays if present to implement coarrays, while Intel and NAG 
 use internal coarray support.
 

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -255,6 +255,13 @@ libraries that have been compiled for single-threaded use instead.
 
 `method` may be `auto`, `config-tool`, `pkg-config`, `cmake` or `extraframework`.
 
+## Fortran Coarrays
+
+Coarrays are a Fortran language intrinsic feature, enabled by 
+`dependency('Coarray')`.
+GCC will use OpenCoarrays if present to implement coarrays, while Intel and NAG 
+use internal coarray support.
+
 ## GL
 
 This finds the OpenGL library in a way appropriate to the platform.

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -257,9 +257,10 @@ libraries that have been compiled for single-threaded use instead.
 
 ## Fortran Coarrays
 
-Coarrays are a Fortran language intrinsic feature, enabled by 
+Coarrays are a Fortran language intrinsic feature, enabled by
 `dependency('coarray')`.
-GCC will use OpenCoarrays if present to implement coarrays, while Intel and NAG 
+
+GCC will use OpenCoarrays if present to implement coarrays, while Intel and NAG
 use internal coarray support.
 
 ## GL

--- a/docs/markdown/snippets/coarray.md
+++ b/docs/markdown/snippets/coarray.md
@@ -1,3 +1,3 @@
 ## Fortran Coarray
 
-Fortran 2008 / 2018 coarray support was added via `dependency('Coarray')`
+Fortran 2008 / 2018 coarray support was added via `dependency('coarray')`

--- a/docs/markdown/snippets/coarray.md
+++ b/docs/markdown/snippets/coarray.md
@@ -1,0 +1,3 @@
+## Fortran Coarray
+
+Fortran 2008 / 2018 coarray support was added via `dependency('Coarray')`

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -18,7 +18,7 @@ from .base import (  # noqa: F401
     ExternalDependency, NotFoundDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
     PkgConfigDependency, CMakeDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language)
 from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDependency
-from .misc import (HDF5Dependency, MPIDependency, OpenMPDependency, Python3Dependency, ThreadDependency, PcapDependency, CupsDependency, LibWmfDependency, LibGCryptDependency)
+from .misc import (CoarrayDependency, HDF5Dependency, MPIDependency, OpenMPDependency, Python3Dependency, ThreadDependency, PcapDependency, CupsDependency, LibWmfDependency, LibGCryptDependency)
 from .platform import AppleFrameworks
 from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, VulkanDependency
 
@@ -32,6 +32,7 @@ packages.update({
 
     # From misc:
     'boost': BoostDependency,
+    'coarray': CoarrayDependency,
     'mpi': MPIDependency,
     'hdf5': HDF5Dependency,
     'openmp': OpenMPDependency,

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -2200,7 +2200,7 @@ def find_external_dependency(name, env, kwargs):
     return NotFoundDependency(env)
 
 
-def _build_external_dependency_list(name, env: Environment, kwargs: Dict[str, Any]) -> List[functools.partial[DubDependency]]:
+def _build_external_dependency_list(name, env: Environment, kwargs: Dict[str, Any]) -> list:
     # First check if the method is valid
     if 'method' in kwargs and kwargs['method'] not in [e.value for e in DependencyMethods]:
         raise DependencyException('method {!r} is invalid'.format(kwargs['method']))

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -2200,7 +2200,7 @@ def find_external_dependency(name, env, kwargs):
     return NotFoundDependency(env)
 
 
-def _build_external_dependency_list(name, env, kwargs):
+def _build_external_dependency_list(name: str, env: Environment, kwargs: dict) -> list:
     # First check if the method is valid
     if 'method' in kwargs and kwargs['method'] not in [e.value for e in DependencyMethods]:
         raise DependencyException('method {!r} is invalid'.format(kwargs['method']))

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -14,7 +14,7 @@
 
 # This file contains the detection logic for external dependencies.
 # Custom logic for several other packages are in separate files.
-
+from typing import Dict, Any
 import copy
 import functools
 import os
@@ -2200,7 +2200,7 @@ def find_external_dependency(name, env, kwargs):
     return NotFoundDependency(env)
 
 
-def _build_external_dependency_list(name: str, env: Environment, kwargs: dict) -> list:
+def _build_external_dependency_list(name, env: Environment, kwargs: Dict[str, Any]) -> List[functools.partial[DubDependency]]:
     # First check if the method is valid
     if 'method' in kwargs and kwargs['method'] not in [e.value for e in DependencyMethods]:
         raise DependencyException('method {!r} is invalid'.format(kwargs['method']))

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -49,20 +49,22 @@ class CoarrayDependency(ExternalDependency):
         cid = self.get_compiler().get_id()
         if cid == 'gcc':
             """ OpenCoarrays is the most commonly used method for Fortran Coarray with GCC """
+            self.is_found = True
             kwargs['modules'] = 'OpenCoarrays::caf_mpi'
             cmakedep = CMakeDependency('OpenCoarrays', environment, kwargs)
             if not cmakedep.found():
+                self.compile_args = ['-fcoarray=single']
+                self.version = 'single image'
                 return
 
             self.compile_args = cmakedep.get_compile_args()
             self.link_args = cmakedep.get_link_args()
             self.version = cmakedep.get_version()
-            self.is_found = True
         elif cid == 'intel':
             """ Coarrays are built into Intel compilers, no external library needed """
+            self.is_found = True
             self.link_args = ['-coarray=shared']
             self.compile_args = self.link_args
-            self.is_found = True
         elif cid == 'nagfor':
             """ NAG doesn't require any special arguments for Coarray """
             self.is_found = True

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -35,6 +35,7 @@ from .base import (
 class CoarrayDependency(ExternalDependency):
     """
     Coarrays are a Fortran 2008 feature.
+
     Coarrays are sometimes implemented via external library (GCC+OpenCoarrays),
     while other compilers just build in support (Cray, IBM, Intel, NAG).
     Coarrays may be thought of as a high-level language abstraction of

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -32,6 +32,42 @@ from .base import (
 )
 
 
+class CoarrayDependency(ExternalDependency):
+    """
+    Coarrays are a Fortran 2008 feature.
+    Coarrays are sometimes implemented via external library (GCC+OpenCoarrays),
+    while other compilers just build in support (Cray, IBM, Intel, NAG).
+    Coarrays may be thought of as a high-level language abstraction of
+    low-level MPI calls.
+    """
+    def __init__(self, environment, kwargs):
+        super().__init__('coarray', environment, 'fortran', kwargs)
+        kwargs['required'] = False
+        kwargs['silent'] = True
+        self.is_found = False
+
+        cid = self.get_compiler().get_id()
+        if cid == 'gcc':
+            """ OpenCoarrays is the most commonly used method for Fortran Coarray with GCC """
+            kwargs['modules'] = 'OpenCoarrays::caf_mpi'
+            cmakedep = CMakeDependency('OpenCoarrays', environment, kwargs)
+            if not cmakedep.found():
+                return
+
+            self.compile_args = cmakedep.get_compile_args()
+            self.link_args = cmakedep.get_link_args()
+            self.version = cmakedep.get_version()
+            self.is_found = True
+        elif cid == 'intel':
+            """ Coarrays are built into Intel compilers, no external library needed """
+            self.link_args = ['-coarray=shared']
+            self.compile_args = self.link_args
+            self.is_found = True
+        elif cid == 'nagfor':
+            """ NAG doesn't require any special arguments for Coarray """
+            self.is_found = True
+
+
 class HDF5Dependency(ExternalDependency):
 
     def __init__(self, environment, kwargs):

--- a/test cases/fortran/13 coarray/main.f90
+++ b/test cases/fortran/13 coarray/main.f90
@@ -1,0 +1,9 @@
+implicit none
+
+if (this_image() == 1)  print *, 'number of Fortran coarray images:', num_images()
+
+sync all ! semaphore, ensures message above is printed at top.
+
+print *, 'Process ', this_image()
+
+end program

--- a/test cases/fortran/13 coarray/meson.build
+++ b/test cases/fortran/13 coarray/meson.build
@@ -1,0 +1,9 @@
+project('Fortran coarray', 'fortran')
+
+coarray = dependency('Coarray', required : false)
+
+exe = executable('hello', 'main.f90',
+  dependencies : coarray)
+
+test('Coarray hello world', exe)
+

--- a/test cases/fortran/13 coarray/meson.build
+++ b/test cases/fortran/13 coarray/meson.build
@@ -1,7 +1,7 @@
 project('Fortran coarray', 'fortran')
 
 # coarray is required because single-image fallback is an intrinsic feature
-coarray = dependency('Coarray', required : true)
+coarray = dependency('coarray', required : true)
 
 exe = executable('hello', 'main.f90',
   dependencies : coarray)

--- a/test cases/fortran/13 coarray/meson.build
+++ b/test cases/fortran/13 coarray/meson.build
@@ -1,6 +1,7 @@
 project('Fortran coarray', 'fortran')
 
-coarray = dependency('Coarray', required : false)
+# coarray is required because single-image fallback is an intrinsic feature
+coarray = dependency('Coarray', required : true)
 
 exe = executable('hello', 'main.f90',
   dependencies : coarray)


### PR DESCRIPTION
Another feature for HPC Fortran use cases that CMake does not yet have.
Enables Fortran 2008/2018 language intrinsic Coarray feature.

https://en.wikipedia.org/wiki/Coarray_Fortran#Examples