### PR TITLE
mtest: Don't use thread executor when enabled gdb in test_setup

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -438,6 +438,8 @@ class TestHarness:
             current = self.build_data.test_setups[full_name]
         if not options.gdb:
             options.gdb = current.gdb
+        if options.gdb:
+            options.verbose = True
         if options.timeout_multiplier is None:
             options.timeout_multiplier = current.timeout_multiplier
     #    if options.env is None:
@@ -693,18 +695,17 @@ Timeout:            %4d
             for _ in range(self.options.repeat):
                 for i, test in enumerate(tests):
                     visible_name = self.get_pretty_suite(test)
+                    single_test = self.get_test_runner(test)
 
-                    if not test.is_parallel or self.options.gdb:
+                    if not test.is_parallel or single_test.options.gdb:
                         self.drain_futures(futures)
                         futures = []
-                        single_test = self.get_test_runner(test)
                         res = single_test.run()
                         self.process_test_result(res)
                         self.print_stats(numlen, tests, visible_name, res, i)
                     else:
                         if not executor:
                             executor = conc.ThreadPoolExecutor(max_workers=self.options.num_processes)
-                        single_test = self.get_test_runner(test)
                         f = executor.submit(single_test.run)
                         futures.append((f, numlen, tests, visible_name, i))
                     if self.options.repeat > 1 and self.fail_count:


### PR DESCRIPTION
If the global gdb option of mesontest is disabled (e.g. not set '--gdb') and the gdb option of test_setup is enabled (e.g. add_test_setup('mygdb', gdb : true) and use '--setup=mygdb'), an exception will be thrown.
```
Traceback (most recent call last):
  File "/home/jin/Downloads/meson/mesonbuild/mesonmain.py", line 114, in run
    return options.run_func(options)
  File "/home/jin/Downloads/meson/mesonbuild/mtest.py", line 805, in run
    return th.doit()
  File "/home/jin/Downloads/meson/mesonbuild/mtest.py", line 555, in doit
    self.run_tests(tests)
  File "/home/jin/Downloads/meson/mesonbuild/mtest.py", line 715, in run_tests
    self.drain_futures(futures)
  File "/home/jin/Downloads/meson/mesonbuild/mtest.py", line 731, in drain_futures
    self.process_test_result(result.result())
  File "/usr/lib/python3.5/concurrent/futures/_base.py", line 405, in result
    return self.__get_result()
  File "/usr/lib/python3.5/concurrent/futures/_base.py", line 357, in __get_result
    raise self._exception
  File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/jin/Downloads/meson/mesonbuild/mtest.py", line 267, in run
    return self._run_cmd(wrap + cmd + self.test.cmd_args + self.options.test_args)
  File "/home/jin/Downloads/meson/mesonbuild/mtest.py", line 302, in _run_cmd
    signal.signal(signal.SIGINT, signal.SIG_IGN)
  File "/usr/lib/python3.5/signal.py", line 47, in signal
    handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
ValueError: signal only works in main thread
```

Because signal.signal function can only be called from the main thread. If attempting to call it from other threads will cause a ValueError exception to be raised.