### PR TITLE
BUGFIX: handle Fortran 2003 "use" syntax

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1865,7 +1865,7 @@ rule FORTRAN_DEP_HACK%s
 
     def get_fortran_deps(self, compiler: FortranCompiler, src: str, target) -> List[str]:
         mod_files = []
-        usere = re.compile(r"\s*use\s+(\w+)", re.IGNORECASE)
+        usere = re.compile(r"\s*use,?\s*(?:non_intrinsic)?\s*(?:::)?\s*(\w+)", re.IGNORECASE)
         submodre = re.compile(r"\s*\bsubmodule\b\s+\((\w+:?\w+)\)\s+(\w+)\s*$", re.IGNORECASE)
         dirname = self.get_target_private_dir(target)
         tdeps = self.fortran_deps[target.get_basename()]
@@ -1874,6 +1874,8 @@ rule FORTRAN_DEP_HACK%s
                 usematch = usere.match(line)
                 if usematch is not None:
                     usename = usematch.group(1).lower()
+                    if usename == 'intrinsic':  # this keeps the regex simpler
+                        continue
                     if usename not in tdeps:
                         # The module is not provided by any source file. This
                         # is due to:


### PR DESCRIPTION
This PR handles the variety of `use` syntax defined by Fortran 2003.
Previously it handled only Fortran 90/95 `use` syntax, which I think is an unintentional bug because Fortran 2003 `use` syntax is widely used for some time.

reference: https://www.ibm.com/support/knowledgecenter/en/SS3KZ4_9.0.0/com.ibm.xlf111.bg.doc/xlflr/use.htm