### PR TITLE
Parallelize compiler.get_supported_* functions

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1142,15 +1142,24 @@ class Compiler:
                 commands += extra_args
                 # Generate full command-line with the exelist
                 commands = self.get_exelist() + commands.to_native()
-                mlog.debug('Running compile:')
-                mlog.debug('Working directory: ', tmpdirname)
-                mlog.debug('Command line: ', ' '.join(commands), '\n')
-                mlog.debug('Code:\n', code)
+
+                log_messages = [
+                    ['Running compile:'],
+                    ['Working directory: ', tmpdirname],
+                    ['Command line: ', ' '.join(commands), '\n'],
+                    ['Code:\n', code],
+                ]
+
                 os_env = os.environ.copy()
                 os_env['LC_ALL'] = 'C'
                 p, p.stdo, p.stde = Popen_safe(commands, cwd=tmpdirname, env=os_env)
-                mlog.debug('Compiler stdout:\n', p.stdo)
-                mlog.debug('Compiler stderr:\n', p.stde)
+
+                with mlog.lock:
+                    for msg in log_messages:
+                        mlog.debug(*msg)
+                    mlog.debug('Compiler stdout:\n', p.stdo)
+                    mlog.debug('Compiler stderr:\n', p.stde)
+
                 p.commands = commands
                 p.input_name = srcname
                 if want_output:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1518,17 +1518,14 @@ class CompilerHolder(InterpreterObject):
         return result
 
     def _get_supported_args(self, predicate, args, kwargs):
-        supported_args = set()
+        supported_args = []
 
         with ThreadPoolExecutor() as ex:
-            def check_arg(arg):
-                if predicate(arg, kwargs):
-                    return arg
+            for arg, supported in zip(args, ex.map(lambda a: predicate(a, kwargs), args)):
+                if supported:
+                    supported_args.append(arg)
 
-            supported_args = set(ex.map(check_arg, set(args)))
-
-        # Preserve order and duplicates
-        return [arg for arg in args if arg in supported_args]
+        return supported_args
 
     @FeatureNew('compiler.get_supported_arguments', '0.43.0')
     @permittedKwargs({})

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -17,6 +17,7 @@ import io
 import sys
 import time
 import platform
+import threading
 from contextlib import contextmanager
 
 """This is (mostly) a standalone module used to write logging
@@ -48,6 +49,8 @@ log_depth = 0
 log_timestamp_start = None
 log_fatal_warnings = False
 log_disable_stdout = False
+
+lock = threading.Lock()
 
 def disable():
     global log_disable_stdout


### PR DESCRIPTION
I've taken the `concurrent.futures` approach because it required minimal changes to the code structure. I also had to introduce a lock object into `mlog` to prevent the debug log lines from different tests from interspersing.

Related to #3635