### PR TITLE
BUGFIX: Fortran openmp

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1898,7 +1898,7 @@ class IntelCompiler(GnuLikeCompiler):
     def get_optimization_args(self, optimization_level):
         return clike_optimization_args[optimization_level]
 
-    def get_pch_suffix(self):
+    def get_pch_suffix(self) -> str:
         return 'pchi'
 
     def get_pch_use_args(self, pch_dir, header):
@@ -1908,7 +1908,7 @@ class IntelCompiler(GnuLikeCompiler):
     def get_pch_name(self, header_name):
         return os.path.basename(header_name) + '.' + self.get_pch_suffix()
 
-    def openmp_flags(self):
+    def openmp_flags(self) -> List[str]:
         if version_compare(self.version, '>=15.0.0'):
             return ['-qopenmp']
         else:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -14,7 +14,7 @@
 
 import abc, contextlib, enum, os.path, re, tempfile, shlex
 import subprocess
-from typing import List
+from typing import List, Tuple
 
 from ..linkers import StaticLinker
 from .. import coredata
@@ -1602,18 +1602,18 @@ class GnuCompiler(GnuLikeCompiler):
     GnuCompiler represents an actual GCC in its many incarnations.
     Compilers imitating GCC (Clang/Intel) should use the GnuLikeCompiler ABC.
     """
-    def __init__(self, compiler_type, defines):
+    def __init__(self, compiler_type, defines: dict):
         super().__init__(compiler_type)
         self.id = 'gcc'
         self.defines = defines or {}
         self.base_options.append('b_colorout')
 
-    def get_colorout_args(self, colortype):
+    def get_colorout_args(self, colortype: str) -> List[str]:
         if mesonlib.version_compare(self.version, '>=4.9.0'):
             return gnu_color_args[colortype][:]
         return []
 
-    def get_warn_args(self, level):
+    def get_warn_args(self, level: str) -> list:
         args = super().get_warn_args(level)
         if mesonlib.version_compare(self.version, '<4.8.0') and '-Wpedantic' in args:
             # -Wpedantic was added in 4.8.0
@@ -1621,20 +1621,20 @@ class GnuCompiler(GnuLikeCompiler):
             args[args.index('-Wpedantic')] = '-pedantic'
         return args
 
-    def has_builtin_define(self, define):
+    def has_builtin_define(self, define: str) -> bool:
         return define in self.defines
 
     def get_builtin_define(self, define):
         if define in self.defines:
             return self.defines[define]
 
-    def get_optimization_args(self, optimization_level):
+    def get_optimization_args(self, optimization_level: str):
         return gnu_optimization_args[optimization_level]
 
-    def get_pch_suffix(self):
+    def get_pch_suffix(self) -> str:
         return 'gch'
 
-    def openmp_flags(self):
+    def openmp_flags(self) -> List[str]:
         return ['-fopenmp']
 
 
@@ -1648,7 +1648,7 @@ class PGICompiler:
                           '2': default_warn_args,
                           '3': default_warn_args}
 
-    def get_module_incdir_args(self) -> List[str]:
+    def get_module_incdir_args(self) -> Tuple[str]:
         return ('-module', )
 
     def get_no_warn_args(self) -> List[str]:
@@ -1663,10 +1663,10 @@ class PGICompiler:
     def get_buildtype_linker_args(self, buildtype: str) -> List[str]:
         return pgi_buildtype_linker_args[buildtype]
 
-    def get_optimization_args(self, optimization_level: str) -> List[str]:
+    def get_optimization_args(self, optimization_level: str):
         return clike_optimization_args[optimization_level]
 
-    def get_debug_args(self, is_debug: bool) -> List[str]:
+    def get_debug_args(self, is_debug: bool):
         return clike_debug_args[is_debug]
 
     def compute_parameters_with_absolute_paths(self, parameter_list: List[str], build_dir: str):

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -262,6 +262,12 @@ class FortranCompiler(Compiler):
     def has_multi_arguments(self, args, env):
         return CCompiler.has_multi_arguments(self, args, env)
 
+    def has_header(self, hname, prefix, env, *, extra_args=None, dependencies=None):
+        return CCompiler.has_header(self, hname, prefix, env, extra_args=extra_args, dependencies=dependencies)
+
+    def get_define(self, dname, prefix, env, extra_args, dependencies):
+        return CCompiler.get_define(self, dname, prefix, env, extra_args, dependencies)
+
     @classmethod
     def _get_trials_from_pattern(cls, pattern, directory, libname):
         return CCompiler._get_trials_from_pattern(pattern, directory, libname)

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -308,7 +308,7 @@ class OpenMPDependency(ExternalDependency):
             else:
                 mlog.log(mlog.yellow('WARNING:'), 'OpenMP found but omp.h missing.')
 
-    def need_openmp(self):
+    def need_openmp(self) -> bool:
         return True
 
 

--- a/test cases/common/190 openmp/main.f90
+++ b/test cases/common/190 openmp/main.f90
@@ -3,7 +3,7 @@ use omp_lib
 
 if (omp_get_max_threads() /= 2) then
   write(stderr, *) 'Max Fortran threads is', omp_get_max_threads(), 'not 2.'
-  error stop
+  stop 1
 endif
 
 end program

--- a/test cases/common/190 openmp/main.f90
+++ b/test cases/common/190 openmp/main.f90
@@ -1,8 +1,9 @@
-program main
-    if (omp_get_max_threads() .eq. 2) then
-        stop 0
-    else
-        print *, 'Max threads is', omp_get_max_threads(), 'not 2.'
-        stop 1
-    endif
-end program main
+use, intrinsic :: iso_fortran_env, only: stderr=>error_unit
+use omp_lib
+
+if (omp_get_max_threads() /= 2) then
+  write(stderr, *) 'Max Fortran threads is', omp_get_max_threads(), 'not 2.'
+  error stop
+endif
+
+end program

--- a/test cases/common/190 openmp/meson.build
+++ b/test cases/common/190 openmp/meson.build
@@ -43,7 +43,7 @@ if add_languages('fortran', required : false)
     exef = executable('exef',
       'main.f90',
       dependencies : [openmp])
-    test('OpenMP Fortran', execpp, env : env)
+    test('OpenMP Fortran', exef, env : env)
   endif
 endif
 

--- a/test cases/common/190 openmp/meson.build
+++ b/test cases/common/190 openmp/meson.build
@@ -44,6 +44,12 @@ if add_languages('fortran', required : false)
       'main.f90',
       dependencies : [openmp])
     test('OpenMP Fortran', exef, env : env)
+
+    openmp_f = dependency('openmp', language : 'fortran')
+    exe_f = executable('exe_f',
+      'main.f90',
+      dependencies : [openmp_f])
+    test('OpenMP Fortran-specific', exe_f, env : env)
   endif
 endif
 


### PR DESCRIPTION
The unit test for Fortran OpenMP was not actually run previously, and upon enabling, was failing due to omissions in Meson.

This is now corrected and tested.

also added some type hints.