### PR TITLE
interpreter: add "path" function

### DIFF
--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -104,6 +104,7 @@ syn keyword mesonBuiltin
   \ meson
   \ message
   \ option
+  \ path
   \ project
   \ run_command
   \ run_target

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -359,6 +359,7 @@ keyword arguments.
   - `dependencies`, other dependencies needed to use this dependency
   - `include_directories`, the directories to add to header search path,
     must be include_directories objects or, since 0.50.0, plain strings
+    and file objects
   - `link_args`, link arguments to use
   - `link_with`, libraries to link against
   - `link_whole`, libraries to link fully, same as [`executable`](#executable)
@@ -539,8 +540,8 @@ be passed to [shared and static libraries](#library).
   adds the current source and build directories to the include path,
   defaults to `true`, since 0.42.0
 - `include_directories` one or more objects created with the
-  `include_directories` function, or, since 0.50.0, strings, which
-  will be transparently expanded to include directory objects
+  `include_directories` function, or, since 0.50.0, strings and file
+   objects, which will be transparently expanded to include directory objects
 - `install`, when set to true, this executable should be installed
 - `install_dir` override install directory for this file. The value is
   relative to the `prefix` specified. F.ex, if you want to install
@@ -1123,7 +1124,23 @@ a file object.
 
 The argument must point to an existing directory; the returned object
 remembers the subdirectory it was defined in and can be used anywhere
-in the source tree.
+in the source tree.  As an example suppose you have a directory `include`
+in the toplevel directory and you would like to use `include/bar2` in
+`include_directories` from subdirectory `bar2`.  You can add the
+following to `meson.build`:
+
+```meson
+    incdir = path('include')
+```
+
+and use it in `bar2` like this:
+
+```meson
+    bar2_incdir = join_paths(incdir, 'bar2')
+    executable('myprog', 'myprog.cpp', include_directories: bar2_incdir, ...)
+```
+
+Meson will then do the right thing.
 
 *Added 0.50.0*
 

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1029,12 +1029,16 @@ the jar with `java -jar file.jar`.
 
 ``` meson
 string join_paths(string1, string2, ...)
+file join_paths(file, string1, ...)
 ```
 
 Joins the given strings into a file system path segment. For example
 `join_paths('foo', 'bar')` results in `foo/bar`. If any one of the
 individual segments is an absolute path, all segments before it are
 dropped. That means that `join_paths('foo', '/bar')` returns `/bar`.
+
+The first argument to join_paths can be a file object, returned by
+[`path`](#path).  `join_paths()` then returns another file object.
 
 **Warning** Don't use `join_paths()` for sources in [`library`](#library) and
 [`executable`](#executable), you should use [`files`](#files) instead.
@@ -1107,6 +1111,21 @@ This function prints its argument to stdout.
 This function prints its argument to stdout prefixed with WARNING:.
 
 *Added 0.44.0*
+
+### path()
+
+``` meson
+    file path([directory_name])
+```
+This command takes the string given to it in the argument, or the
+current directory if no argument is provided, and returns
+a file object.
+
+The argument must point to an existing directory; the returned object
+remembers the subdirectory it was defined in and can be used anywhere
+in the source tree.
+
+*Added 0.50.0*
 
 ### project()
 

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -82,6 +82,7 @@ class AstInterpreter(interpreterbase.InterpreterBase):
                            'add_languages': self.func_do_nothing,
                            'declare_dependency': self.func_do_nothing,
                            'files': self.func_do_nothing,
+                           'path': self.func_do_nothing,
                            'executable': self.func_do_nothing,
                            'static_library': self.func_do_nothing,
                            'shared_library': self.func_do_nothing,

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3639,10 +3639,15 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         for p in prospectives:
             if isinstance(p, build.IncludeDirs):
                 result.append(p)
+            elif isinstance(p, mesonlib.File):
+                if not os.path.isdir(p.absolute_path(self.environment.get_source_dir(),
+                                                     self.environment.get_build_dir())):
+                    raise InvalidArguments('Include dir %s does not exist.' % p)
+                result.append(build.IncludeDirs(p.subdir, [p.fname], False))
             elif isinstance(p, str):
                 result.append(self.build_incdir_object([p]).held_object)
             else:
-                raise InterpreterException('Include directory objects can only be created from strings or include directories.')
+                raise InterpreterException('Include directory objects can only be created from strings, files or include directories.')
         return result
 
     @permittedKwargs(permitted_kwargs['include_directories'])

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -632,6 +632,8 @@ The result of this is undefined and will become a hard error in a future Meson r
         elif cur.operation == 'div':
             if isinstance(l, str) and isinstance(r, str):
                 return self.join_path_strings((l, r))
+            if isinstance(l, mesonlib.File) and isinstance(r, str):
+                return l.join(self.environment.source_dir, r)
             if isinstance(l, int) and isinstance(r, int):
                 if r == 0:
                     raise InvalidCode('Division by zero.')

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -226,8 +226,8 @@ class File:
 
     @staticmethod
     @lru_cache(maxsize=None)
-    def from_source_file(source_root: str, subdir: str, fname: str):
-        if not os.path.isfile(os.path.join(source_root, subdir, fname)):
+    def from_source_file(source_root: str, subdir: str, fname: str, check=os.path.isfile):
+        if not check(os.path.join(source_root, subdir, fname)):
             raise MesonException('File %s does not exist.' % fname)
         return File(False, subdir, fname)
 
@@ -258,6 +258,13 @@ class File:
 
     def split(self, s: str) -> List[str]:
         return self.fname.split(s)
+
+    def join(self, source_root: str, s: str):
+        s = os.path.join(self.fname, s)
+        if self.is_built:
+            return File.from_built_file(self.subdir, s)
+        else:
+            return File.from_source_file(source_root, self.subdir, s, check=os.path.exists)
 
     def __eq__(self, other) -> bool:
         return (self.fname, self.subdir, self.is_built) == (other.fname, other.subdir, other.is_built)

--- a/test cases/common/78 file object/include/subdir2/foo.h
+++ b/test cases/common/78 file object/include/subdir2/foo.h
@@ -1,0 +1,1 @@
+/* empty file */

--- a/test cases/common/78 file object/meson.build
+++ b/test cases/common/78 file object/meson.build
@@ -1,9 +1,9 @@
 project('file object', 'c')
 
+top_dir = path()
 prog0 = files('prog.c')
 lib0 = files('lib.c')
 test('fobj', executable('fobj', prog0, lib0))
 
 subdir('subdir1')
 subdir('subdir2')
-

--- a/test cases/common/78 file object/meson.build
+++ b/test cases/common/78 file object/meson.build
@@ -1,6 +1,8 @@
 project('file object', 'c')
 
 top_dir = path()
+include_dir = path('include')
+
 prog0 = files('prog.c')
 lib0 = files('lib.c')
 test('fobj', executable('fobj', prog0, lib0))

--- a/test cases/common/78 file object/subdir1/meson.build
+++ b/test cases/common/78 file object/subdir1/meson.build
@@ -1,7 +1,7 @@
 prog1 = files('prog.c')
 lib1 = files('lib.c')
 
-test('subdir0', executable('subdir0', prog0, lib1), should_fail : true)
+test('subdir0', executable('subdir0', [top_dir / 'prog.c'], lib1), should_fail : true)
 test('subdir1', executable('subdir1', prog1, lib0), should_fail : true)
 
 test('subdir2', executable('subdir2', prog1, lib1))

--- a/test cases/common/78 file object/subdir2/meson.build
+++ b/test cases/common/78 file object/subdir2/meson.build
@@ -1,7 +1,9 @@
+my_include_dir = join_paths(include_dir, 'subdir2')
+
 prog2 = files('prog.c')
 lib2 = files('lib.c')
 
 test('subdir3', executable('subdir3', prog1, lib2), should_fail : true)
-test('subdir4', executable('subdir4', prog2, lib1), should_fail : true)
+test('subdir4', executable('subdir4', prog2, lib1, include_directories: my_include_dir), should_fail : true)
 
-test('subdir4', executable('subdir5', prog2, lib2))
+test('subdir4', executable('subdir5', prog2, lib2, include_directories: my_include_dir))

--- a/test cases/common/78 file object/subdir2/prog.c
+++ b/test cases/common/78 file object/subdir2/prog.c
@@ -1,4 +1,5 @@
 #include<stdio.h>
+#include "foo.h"
 
 int func();
 

--- a/test cases/failing/94 join_paths mixed args/meson.build
+++ b/test cases/failing/94 join_paths mixed args/meson.build
@@ -1,0 +1,4 @@
+project('join_paths mixed args')
+
+subdir_base = path()
+x = join_paths(meson.source_root(), subdir_base)


### PR DESCRIPTION
Meson has `files()` and `include_directories()` to deal with relative paths, but does not have a way to construct a relative path for use with `join_paths()`.  This is because `join_paths()` does not accept file objects, and also because anyway `files()` does not accept directory names.
    
If a parent meson.build wants to set `some_base = '.'` and a subdirectory two levels down wants to use `some_base/some_dir/mysource.c` then it must know its exact location in the tree.  Then it can either use `../../some_base/some_dir/mysource.c`, or use `some_base = join_paths(some_base, '../..')` though the latter pollutes the namespace and breaks other build files.
    
The parent build file cannot set the path because it must be a relative path, and the subdirectory doesn't want to know all details, just tell where the base is located.
    
The `path()` function, together with an extension to allow `join_paths()` to accept a file object as a base, solves this.  If the parent has:
    
      some_base = path('.')
    
then two levels down you do not need to know where you are located, the relative path to some_base is enough:

      my_src = join_paths(some_base, 'some_dir/my_source')

where `join_paths` can return a file object similar to what `files()` returns, because the first argument is a file object.  That is, `my_src` is valid everywhere in the build tree, just like some_base is.

Fixes #3344.