### PR TITLE
dist: copy URLs from main configuration to avoid issues with relative…

### DIFF
--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -60,6 +60,16 @@ def process_submodules(dirname):
     module_file = os.path.join(dirname, '.gitmodules')
     if not os.path.exists(module_file):
         return
+
+    # copy URLs from main configuration to avoid issues with relative paths
+    configs = subprocess.check_output(['git', 'config', '--get-regex', r'^submodule\..*\.url$'],
+                                      stderr=subprocess.STDOUT).decode()
+    configs = [s.strip() for s in configs.split('\n')]
+    for config in configs:
+        pair = config.split(' ', 1)
+        if len(pair) > 1:
+            subprocess.check_call(['git', 'config'] + pair, cwd=dirname)
+
     subprocess.check_call(['git', 'submodule', 'update', '--init', '--recursive'], cwd=dirname)
     for line in open(module_file):
         line = line.strip()


### PR DESCRIPTION
… paths

If the path in .gitmodules are specified using relative paths the
"dist" target can fail. This as the main repository is cloned
into a new directory so the new URLs of the sub-modules will be
relative to the new directory. However if the original URLs were
remote the new ones will be local and the clone will fail.

Signed-off-by: Frediano Ziglio <fziglio@redhat.com>