### PR TITLE
rewriter: Set and delete project default options

### DIFF
--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -213,7 +213,7 @@ class MTypeList(MTypeBase):
                 removed_list += [i]
         self.node.args.arguments = removed_list
 
-class MtypeStrList(MTypeList):
+class MTypeStrList(MTypeList):
     def __init__(self, node: mparser.BaseNode):
         super().__init__(node)
 
@@ -268,8 +268,8 @@ rewriter_func_kwargs = {
         'not_found_message': MTypeStr,
         'required': MTypeBool,
         'static': MTypeBool,
-        'version': MtypeStrList,
-        'modules': MtypeStrList
+        'version': MTypeStrList,
+        'modules': MTypeStrList
     },
     'target': {
         'build_by_default': MTypeBool,
@@ -285,8 +285,9 @@ rewriter_func_kwargs = {
         'pie': MTypeBool
     },
     'project': {
+        'default_options': MTypeStrList,
         'meson_version': MTypeStr,
-        'license': MtypeStrList,
+        'license': MTypeStrList,
         'subproject_dir': MTypeStr,
         'version': MTypeStr
     }

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5327,6 +5327,34 @@ class RewriterTests(BasePlatformTests):
         }
         self.assertDictEqual(out, expected)
 
+    def test_default_options_set(self):
+        self.prime('3 kwargs')
+        self.rewrite(self.builddir, os.path.join(self.builddir, 'defopts_set.json'))
+        out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
+        out = self.extract_test_data(out)
+        expected = {
+            'kwargs': {
+                'project#': {'version': '0.0.1', 'default_options': ['buildtype=release', 'debug=True', 'cpp_std=c++11']},
+                'target#tgt1': {'build_by_default': True},
+                'dependency#dep1': {'required': False}
+            }
+        }
+        self.assertDictEqual(out, expected)
+
+    def test_default_options_delete(self):
+        self.prime('3 kwargs')
+        self.rewrite(self.builddir, os.path.join(self.builddir, 'defopts_delete.json'))
+        out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
+        out = self.extract_test_data(out)
+        expected = {
+            'kwargs': {
+                'project#': {'version': '0.0.1', 'default_options': ['cpp_std=c++17', 'debug=true']},
+                'target#tgt1': {'build_by_default': True},
+                'dependency#dep1': {'required': False}
+            }
+        }
+        self.assertDictEqual(out, expected)
+
 class NativeFileTests(BasePlatformTests):
 
     def setUp(self):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5348,7 +5348,7 @@ class RewriterTests(BasePlatformTests):
         out = self.extract_test_data(out)
         expected = {
             'kwargs': {
-                'project#': {'version': '0.0.1', 'default_options': ['cpp_std=c++17', 'debug=true']},
+                'project#': {'version': '0.0.1', 'default_options': ['cpp_std=c++14', 'debug=true']},
                 'target#tgt1': {'build_by_default': True},
                 'dependency#dep1': {'required': False}
             }

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5299,6 +5299,20 @@ class RewriterTests(BasePlatformTests):
         }
         self.assertDictEqual(out, expected)
 
+    def test_kwargs_remove_regex(self):
+        self.prime('3 kwargs')
+        self.rewrite(self.builddir, os.path.join(self.builddir, 'remove_regex.json'))
+        out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
+        out = self.extract_test_data(out)
+        expected = {
+            'kwargs': {
+                'project#': {'version': '0.0.1', 'default_options': ['buildtype=release', 'debug=true']},
+                'target#tgt1': {'build_by_default': True},
+                'dependency#dep1': {'required': False}
+            }
+        }
+        self.assertDictEqual(out, expected)
+
     def test_kwargs_delete(self):
         self.prime('3 kwargs')
         self.rewrite(self.builddir, os.path.join(self.builddir, 'delete.json'))

--- a/test cases/rewrite/3 kwargs/defopts_delete.json
+++ b/test cases/rewrite/3 kwargs/defopts_delete.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "",
+    "operation": "set",
+    "kwargs": {
+      "default_options": ["cpp_std=c++17", "buildtype=release", "debug=true"]
+    }
+  },
+  {
+    "type": "default_options",
+    "operation": "delete",
+    "options": {
+      "buildtype": null
+    }
+  }
+]

--- a/test cases/rewrite/3 kwargs/defopts_delete.json
+++ b/test cases/rewrite/3 kwargs/defopts_delete.json
@@ -5,7 +5,7 @@
     "id": "",
     "operation": "set",
     "kwargs": {
-      "default_options": ["cpp_std=c++17", "buildtype=release", "debug=true"]
+      "default_options": ["cpp_std=c++14", "buildtype=release", "debug=true"]
     }
   },
   {

--- a/test cases/rewrite/3 kwargs/defopts_set.json
+++ b/test cases/rewrite/3 kwargs/defopts_set.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type": "default_options",
+    "operation": "set",
+    "options": {
+      "cpp_std": "c++17"
+    }
+  },
+  {
+    "type": "default_options",
+    "operation": "set",
+    "options": {
+      "buildtype": "release",
+      "debug": true
+    }
+  },
+  {
+    "type": "default_options",
+    "operation": "set",
+    "options": {
+      "cpp_std": "c++11"
+    }
+  }
+]

--- a/test cases/rewrite/3 kwargs/defopts_set.json
+++ b/test cases/rewrite/3 kwargs/defopts_set.json
@@ -3,7 +3,7 @@
     "type": "default_options",
     "operation": "set",
     "options": {
-      "cpp_std": "c++17"
+      "cpp_std": "c++14"
     }
   },
   {

--- a/test cases/rewrite/3 kwargs/remove_regex.json
+++ b/test cases/rewrite/3 kwargs/remove_regex.json
@@ -1,0 +1,20 @@
+[
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "",
+    "operation": "set",
+    "kwargs": {
+      "default_options": ["cpp_std=c++17", "buildtype=release", "debug=true"]
+    }
+  },
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "",
+    "operation": "remove_regex",
+    "kwargs": {
+      "default_options": ["cpp_std=.*"]
+    }
+  }
+]

--- a/test cases/rewrite/3 kwargs/remove_regex.json
+++ b/test cases/rewrite/3 kwargs/remove_regex.json
@@ -5,7 +5,7 @@
     "id": "",
     "operation": "set",
     "kwargs": {
-      "default_options": ["cpp_std=c++17", "buildtype=release", "debug=true"]
+      "default_options": ["cpp_std=c++14", "buildtype=release", "debug=true"]
     }
   },
   {


### PR DESCRIPTION
With this PR, it is possible to set and delete project default options from the `meson.build`.

Again, beta feature --> no docs 😃. I will do separate PR for docs and a sensible CLI.

With #4929 and this PR, all features I originally wanted to implement are implemented. Are there other obvious parts, where the rewriter could be useful (especially for IDE integration, cc @textshell)?