### PR TITLE
Fix console log from generator with multiple output nodes

### DIFF
--- a/docs/markdown/snippets/generator_with_multiple_outputs_4760.md
+++ b/docs/markdown/snippets/generator_with_multiple_outputs_4760.md
@@ -1,0 +1,3 @@
+## Fix ninja console log from generators with multiple output nodes
+
+This resolves ticket #4760 where a generator w/ multiple output nodes printed an empty string to the console

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1748,11 +1748,11 @@ rule FORTRAN_DEP_HACK%s
         outfilelist = genlist.get_outputs()
         extra_dependencies = [os.path.join(self.build_to_src, i) for i in genlist.extra_depends]
         for i in range(len(infilelist)):
+            curfile = infilelist[i]
             if len(generator.outputs) == 1:
                 sole_output = os.path.join(self.get_target_private_dir(target), outfilelist[i])
             else:
-                sole_output = ''
-            curfile = infilelist[i]
+                sole_output = '{}'.format(curfile)
             infilename = curfile.rel_to_builddir(self.build_to_src)
             base_args = generator.get_arglist(infilename)
             outfiles = genlist.get_outputs_for(curfile)
@@ -1769,7 +1769,7 @@ rule FORTRAN_DEP_HACK%s
                     for x in args]
             args = self.replace_outputs(args, self.get_target_private_dir(target), outfilelist)
             # We have consumed output files, so drop them from the list of remaining outputs.
-            if sole_output == '':
+            if len(generator.outputs) > 1:
                 outfilelist = outfilelist[len(generator.outputs):]
             args = self.replace_paths(target, args, override_subdir=subdir)
             cmdlist = exe_arr + self.replace_extra_args(args, genlist)
@@ -1792,7 +1792,11 @@ rule FORTRAN_DEP_HACK%s
                 elem.add_item('DEPFILE', depfile)
             if len(extra_dependencies) > 0:
                 elem.add_dep(extra_dependencies)
-            elem.add_item('DESC', 'Generating {!r}.'.format(sole_output))
+            if len(generator.outputs) == 1:
+                elem.add_item('DESC', 'Generating {!r}.'.format(sole_output))
+            else:
+                # since there are multiple outputs, we log the source that caused the rebuild
+                elem.add_item('DESC', 'Generating source from {!r}.'.format(sole_output))
             if isinstance(exe, build.BuildTarget):
                 elem.add_dep(self.get_target_filename(exe))
             elem.add_item('COMMAND', cmd)


### PR DESCRIPTION
This resolves ticket #4760 where a generator w/ multiple output nodes printed an empty string to the console (i.e. `Generating ''.`). This issue can be seen in the existing `meson-test-run.xml` logs on master (`test cases/common/90 private include/`). The issue becomes apparent when the generator has many input files and may take several minutes to complete. During this time, the user has minimal feedback as to what the build system is doing.

This commit will log the input source file that triggered the ninja rule to be executed. The ninja rule executing the generator will now print `Generating from: '<input source file>'` when there are multiple outputs from a single generator rule.

Alternatively, we could log all of the source files being generated from each input source file or a subset of them (the first, for example). I chose not to go either of these routes as logging all of the generated source, will result in a very long output that clutters the console log while selecting the first (or any other single file) seemed arbitrary.