### PR TITLE
d: Translate the -isystem flag for LDC and DMD

### DIFF
--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -380,6 +380,17 @@ class DCompiler(Compiler):
                 # translate library link flag
                 dcargs.append('-L=' + arg)
                 continue
+            elif arg.startswith('-isystem'):
+                # translate -isystem system include path
+                # this flag might sometimes be added by C library Cflags via
+                # pkg-config.
+                # NOTE: -isystem and -I are not 100% equivalent, so this is just
+                # a workaround for the most common cases.
+                if arg.startswith('-isystem='):
+                    dcargs.append('-I=' + arg[9:])
+                else:
+                    dcargs.append('-I')
+                continue
             elif arg.startswith('-L/') or arg.startswith('-L./'):
                 # we need to handle cases where -L is set by e.g. a pkg-config
                 # setting to select a linker search path. We can however not


### PR DESCRIPTION
Hi!
Apparently some pkg-config files use the GCC `-isystem` flag for their include directories (e.g. krb5-gssapi).
Since D code often links to C libraries, we need to translate this flag somehow if the DMD or LDC compiler is used, so the flag should either be dropped entirely, or translated.
This patch translates it to `-I`, which LDC and DMD can understand, and which is likely the less error-prone solution compared to just dropping the include directive entirely.