### PR TITLE
Allow File arguments in extract_objects() arguments

### DIFF
--- a/docs/markdown/snippets/extract_objects-file-arg.md
+++ b/docs/markdown/snippets/extract_objects-file-arg.md
@@ -1,0 +1,4 @@
+## `extract_objects` accepts `File` arguments
+
+The `extract_objects` function now supports File objects to tell it
+what to extract. Previously, file paths could only be passed as strings.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -722,9 +722,12 @@ class BuildTarget(Target):
     def extract_objects(self, srclist):
         obj_src = []
         for src in srclist:
-            if not isinstance(src, str):
-                raise MesonException('Object extraction arguments must be strings.')
-            src = File(False, self.subdir, src)
+            if isinstance(src, str):
+                src = File(False, self.subdir, src)
+            elif isinstance(src, File):
+                FeatureNew('File argument for extract_objects', '0.50.0').use(self.subproject)
+            else:
+                raise MesonException('Object extraction arguments must be strings or Files.')
             # FIXME: It could be a generated source
             if src not in self.sources:
                 raise MesonException('Tried to extract unknown source %s.' % src)

--- a/test cases/common/23 object extraction/meson.build
+++ b/test cases/common/23 object extraction/meson.build
@@ -8,10 +8,13 @@ else
 
   obj1 = lib1.extract_objects('src/lib.c')
   obj2 = lib2.extract_objects(['lib.c'])
+  obj3 = lib2.extract_objects(files('lib.c'))
 
   e1 = executable('main1', 'main.c', objects : obj1)
   e2 = executable('main2', 'main.c', objects : obj2)
+  e3 = executable('main3', 'main.c', objects : obj3)
 
   test('extraction test 1', e1)
   test('extraction test 2', e2)
+  test('extraction test 3', e3)
 endif


### PR DESCRIPTION
Passed strings are converted to Files, but passing a File directly wasn't supported yet. This PR adds that support.