### PR TITLE
Cache compilers.compile() in coredata

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -368,7 +368,7 @@ class CCompiler(Compiler):
         return self.compiles(code.format(**fargs), env, extra_args=extra_args,
                              dependencies=dependencies)
 
-    def has_header(self, hname, prefix, env, *, extra_args=None, dependencies=None):
+    def has_header(self, hname, prefix, env, *, extra_args=None, dependencies=None, disable_cache=False):
         fargs = {'prefix': prefix, 'header': hname}
         code = '''{prefix}
         #ifdef __has_include
@@ -379,7 +379,7 @@ class CCompiler(Compiler):
          #include <{header}>
         #endif'''
         return self.compiles(code.format(**fargs), env, extra_args=extra_args,
-                             dependencies=dependencies, mode='preprocess')
+                             dependencies=dependencies, mode='preprocess', disable_cache=disable_cache)
 
     def has_header_symbol(self, hname, symbol, prefix, env, *, extra_args=None, dependencies=None):
         fargs = {'prefix': prefix, 'header': hname, 'symbol': symbol}
@@ -641,7 +641,7 @@ class CCompiler(Compiler):
             raise EnvironmentException('Could not determine alignment of %s. Sorry. You might want to file a bug.' % typename)
         return align
 
-    def get_define(self, dname, prefix, env, extra_args, dependencies):
+    def get_define(self, dname, prefix, env, extra_args, dependencies, disable_cache=False):
         delim = '"MESON_GET_DEFINE_DELIMITER"'
         fargs = {'prefix': prefix, 'define': dname, 'delim': delim}
         code = '''
@@ -652,7 +652,7 @@ class CCompiler(Compiler):
         {delim}\n{define}'''
         args = self._get_compiler_check_args(env, extra_args, dependencies,
                                              mode='preprocess').to_native()
-        with self.compile(code.format(**fargs), args, 'preprocess', cdata=env.coredata) as p:
+        with self.compile(code.format(**fargs), args, 'preprocess', cdata=env.coredata if not disable_cache else None) as p:
             cached = p.cached
             if p.returncode != 0:
                 raise EnvironmentException('Could not get define {!r}'.format(dname))

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -763,7 +763,7 @@ class CCompiler(Compiler):
             val = env.properties.host.get(varname, None)
             if val is not None:
                 if isinstance(val, bool):
-                    return val, True
+                    return val, False
                 raise EnvironmentException('Cross variable {0} is not a boolean.'.format(varname))
 
         fargs = {'prefix': prefix, 'func': funcname}

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -450,7 +450,7 @@ class CCompiler(Compiler):
 
     def _build_wrapper(self, code, env, extra_args, dependencies=None, mode='compile', want_output=False):
         args = self._get_compiler_check_args(env, extra_args, dependencies, mode)
-        return self.compile(code, args, mode, want_output=want_output)
+        return self.compile(code, args, mode, want_output=want_output, cdata=env.coredata)
 
     def links(self, code, env, *, extra_args=None, dependencies=None):
         return self.compiles(code, env, extra_args=extra_args,
@@ -652,7 +652,7 @@ class CCompiler(Compiler):
         {delim}\n{define}'''
         args = self._get_compiler_check_args(env, extra_args, dependencies,
                                              mode='preprocess').to_native()
-        with self.compile(code.format(**fargs), args, 'preprocess') as p:
+        with self.compile(code.format(**fargs), args, 'preprocess', cdata=env.coredata) as p:
             if p.returncode != 0:
                 raise EnvironmentException('Could not get define {!r}'.format(dname))
         # Get the preprocessed value after the delimiter,

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -927,7 +927,7 @@ class Compiler:
     def get_default_suffix(self) -> str:
         return self.default_suffix
 
-    def get_define(self, dname, prefix, env, extra_args, dependencies) -> (str, bool):
+    def get_define(self, dname, prefix, env, extra_args, dependencies) -> Tuple[str, bool]:
         raise EnvironmentException('%s does not support get_define ' % self.get_id())
 
     def compute_int(self, expression, low, high, guess, prefix, env, extra_args, dependencies) -> int:
@@ -936,10 +936,10 @@ class Compiler:
     def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
         raise EnvironmentException('%s does not support compute_parameters_with_absolute_paths ' % self.get_id())
 
-    def has_members(self, typename, membernames, prefix, env, *, extra_args=None, dependencies=None) -> (bool, bool):
+    def has_members(self, typename, membernames, prefix, env, *, extra_args=None, dependencies=None) -> Tuple[bool, bool]:
         raise EnvironmentException('%s does not support has_member(s) ' % self.get_id())
 
-    def has_type(self, typename, prefix, env, extra_args, *, dependencies=None) -> (bool, bool):
+    def has_type(self, typename, prefix, env, extra_args, *, dependencies=None) -> Tuple[bool, bool]:
         raise EnvironmentException('%s does not support has_type ' % self.get_id())
 
     def symbols_have_underscore_prefix(self, env) -> bool:
@@ -1085,19 +1085,19 @@ class Compiler:
     def get_option_link_args(self, options):
         return []
 
-    def check_header(self, *args, **kwargs) -> (bool, bool):
+    def check_header(self, *args, **kwargs) -> Tuple[bool, bool]:
         raise EnvironmentException('Language %s does not support header checks.' % self.get_display_language())
 
-    def has_header(self, *args, **kwargs) -> (bool, bool):
+    def has_header(self, *args, **kwargs) -> Tuple[bool, bool]:
         raise EnvironmentException('Language %s does not support header checks.' % self.get_display_language())
 
-    def has_header_symbol(self, *args, **kwargs) -> (bool, bool):
+    def has_header_symbol(self, *args, **kwargs) -> Tuple[bool, bool]:
         raise EnvironmentException('Language %s does not support header symbol checks.' % self.get_display_language())
 
-    def compiles(self, *args, **kwargs) -> (bool, bool):
+    def compiles(self, *args, **kwargs) -> Tuple[bool, bool]:
         raise EnvironmentException('Language %s does not support compile checks.' % self.get_display_language())
 
-    def links(self, *args, **kwargs) -> (bool, bool):
+    def links(self, *args, **kwargs) -> Tuple[bool, bool]:
         raise EnvironmentException('Language %s does not support link checks.' % self.get_display_language())
 
     def run(self, *args, **kwargs) -> RunResult:
@@ -1109,7 +1109,7 @@ class Compiler:
     def alignment(self, *args, **kwargs) -> int:
         raise EnvironmentException('Language %s does not support alignment checks.' % self.get_display_language())
 
-    def has_function(self, *args, **kwargs) -> (bool, bool):
+    def has_function(self, *args, **kwargs) -> Tuple[bool, bool]:
         raise EnvironmentException('Language %s does not support function checks.' % self.get_display_language())
 
     @classmethod
@@ -1123,12 +1123,12 @@ class Compiler:
     def get_library_dirs(self, *args, **kwargs):
         return ()
 
-    def has_multi_arguments(self, args, env) -> (bool, bool):
+    def has_multi_arguments(self, args, env) -> Tuple[bool, bool]:
         raise EnvironmentException(
             'Language {} does not support has_multi_arguments.'.format(
                 self.get_display_language()))
 
-    def has_multi_link_arguments(self, args, env) -> (bool, bool):
+    def has_multi_link_arguments(self, args, env) -> Tuple[bool, bool]:
         raise EnvironmentException(
             'Language {} does not support has_multi_link_arguments.'.format(
                 self.get_display_language()))
@@ -1146,7 +1146,7 @@ class Compiler:
         return os.path.join(dirname, 'output.' + suffix)
 
     @contextlib.contextmanager
-    def compile(self, code, extra_args=None, mode='link', want_output=False, cdata: coredata.CoreData = None):
+    def compile(self, code, extra_args=None, mode='link', want_output=False, cdata: Optional[coredata.CoreData] = None):
         if extra_args is None:
             textra_args = None
             extra_args = []

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -901,7 +901,7 @@ class Compiler:
         return repr_str.format(self.__class__.__name__, self.version,
                                ' '.join(self.exelist))
 
-    def can_compile(self, src):
+    def can_compile(self, src) -> bool:
         if hasattr(src, 'fname'):
             src = src.fname
         suffix = os.path.splitext(src)[1].lower()
@@ -909,40 +909,40 @@ class Compiler:
             return True
         return False
 
-    def get_id(self):
+    def get_id(self) -> str:
         return self.id
 
-    def get_version_string(self):
+    def get_version_string(self) -> str:
         details = [self.id, self.version]
         if self.full_version:
             details += ['"%s"' % (self.full_version)]
         return '(%s)' % (' '.join(details))
 
-    def get_language(self):
+    def get_language(self) -> str:
         return self.language
 
-    def get_display_language(self):
+    def get_display_language(self) -> str:
         return self.language.capitalize()
 
-    def get_default_suffix(self):
+    def get_default_suffix(self) -> str:
         return self.default_suffix
 
-    def get_define(self, dname, prefix, env, extra_args, dependencies):
+    def get_define(self, dname, prefix, env, extra_args, dependencies) -> (str, bool):
         raise EnvironmentException('%s does not support get_define ' % self.get_id())
 
-    def compute_int(self, expression, low, high, guess, prefix, env, extra_args, dependencies):
+    def compute_int(self, expression, low, high, guess, prefix, env, extra_args, dependencies) -> int:
         raise EnvironmentException('%s does not support compute_int ' % self.get_id())
 
     def compute_parameters_with_absolute_paths(self, parameter_list, build_dir):
         raise EnvironmentException('%s does not support compute_parameters_with_absolute_paths ' % self.get_id())
 
-    def has_members(self, typename, membernames, prefix, env, *, extra_args=None, dependencies=None):
+    def has_members(self, typename, membernames, prefix, env, *, extra_args=None, dependencies=None) -> (bool, bool):
         raise EnvironmentException('%s does not support has_member(s) ' % self.get_id())
 
-    def has_type(self, typename, prefix, env, extra_args, *, dependencies=None):
+    def has_type(self, typename, prefix, env, extra_args, *, dependencies=None) -> (bool, bool):
         raise EnvironmentException('%s does not support has_type ' % self.get_id())
 
-    def symbols_have_underscore_prefix(self, env):
+    def symbols_have_underscore_prefix(self, env) -> bool:
         raise EnvironmentException('%s does not support symbols_have_underscore_prefix ' % self.get_id())
 
     def get_exelist(self):
@@ -1085,31 +1085,31 @@ class Compiler:
     def get_option_link_args(self, options):
         return []
 
-    def check_header(self, *args, **kwargs):
+    def check_header(self, *args, **kwargs) -> (bool, bool):
         raise EnvironmentException('Language %s does not support header checks.' % self.get_display_language())
 
-    def has_header(self, *args, **kwargs):
+    def has_header(self, *args, **kwargs) -> (bool, bool):
         raise EnvironmentException('Language %s does not support header checks.' % self.get_display_language())
 
-    def has_header_symbol(self, *args, **kwargs):
+    def has_header_symbol(self, *args, **kwargs) -> (bool, bool):
         raise EnvironmentException('Language %s does not support header symbol checks.' % self.get_display_language())
 
-    def compiles(self, *args, **kwargs):
+    def compiles(self, *args, **kwargs) -> (bool, bool):
         raise EnvironmentException('Language %s does not support compile checks.' % self.get_display_language())
 
-    def links(self, *args, **kwargs):
+    def links(self, *args, **kwargs) -> (bool, bool):
         raise EnvironmentException('Language %s does not support link checks.' % self.get_display_language())
 
-    def run(self, *args, **kwargs):
+    def run(self, *args, **kwargs) -> RunResult:
         raise EnvironmentException('Language %s does not support run checks.' % self.get_display_language())
 
-    def sizeof(self, *args, **kwargs):
+    def sizeof(self, *args, **kwargs) -> int:
         raise EnvironmentException('Language %s does not support sizeof checks.' % self.get_display_language())
 
-    def alignment(self, *args, **kwargs):
+    def alignment(self, *args, **kwargs) -> int:
         raise EnvironmentException('Language %s does not support alignment checks.' % self.get_display_language())
 
-    def has_function(self, *args, **kwargs):
+    def has_function(self, *args, **kwargs) -> (bool, bool):
         raise EnvironmentException('Language %s does not support function checks.' % self.get_display_language())
 
     @classmethod
@@ -1123,12 +1123,12 @@ class Compiler:
     def get_library_dirs(self, *args, **kwargs):
         return ()
 
-    def has_multi_arguments(self, args, env):
+    def has_multi_arguments(self, args, env) -> (bool, bool):
         raise EnvironmentException(
             'Language {} does not support has_multi_arguments.'.format(
                 self.get_display_language()))
 
-    def has_multi_link_arguments(self, args, env):
+    def has_multi_link_arguments(self, args, env) -> (bool, bool):
         raise EnvironmentException(
             'Language {} does not support has_multi_link_arguments.'.format(
                 self.get_display_language()))

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1156,6 +1156,7 @@ class Compiler:
         if not want_output:
             if cdata is not None and key in cdata.compiler_check_cache:
                 p = cdata.compiler_check_cache[key]
+                p.cached = True
                 mlog.debug('Using cached compile:')
                 mlog.debug('Cached command line: ', ' '.join(p.commands), '\n')
                 mlog.debug('Code:\n', code)
@@ -1213,6 +1214,7 @@ class Compiler:
                     for i in todel:
                         delattr(p, i)
                     cdata.compiler_check_cache[key] = p
+                p.cached = False
                 yield p
         except (PermissionError, OSError):
             # On Windows antivirus programs and the like hold on to files so

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -65,10 +65,11 @@ class CPPCompiler(CCompiler):
 
     def has_header_symbol(self, hname, symbol, prefix, env, *, extra_args=None, dependencies=None):
         # Check if it's a C-like symbol
-        if super().has_header_symbol(hname, symbol, prefix, env,
-                                     extra_args=extra_args,
-                                     dependencies=dependencies):
-            return True
+        found, cached = super().has_header_symbol(hname, symbol, prefix, env,
+                                                  extra_args=extra_args,
+                                                  dependencies=dependencies)
+        if found:
+            return True, cached
         # Check if it's a class or a template
         if extra_args is None:
             extra_args = []
@@ -264,7 +265,7 @@ class ElbrusCPPCompiler(GnuCPPCompiler, ElbrusCompiler):
     # So we should explicitly fail at this case.
     def has_function(self, funcname, prefix, env, *, extra_args=None, dependencies=None):
         if funcname == 'lchmod':
-            return False
+            return False, False
         else:
             return super().has_function(funcname, prefix, env,
                                         extra_args=extra_args,

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -146,8 +146,9 @@ class CudaCompiler(Compiler):
         return super().get_compiler_check_args() + []
 
     def has_header_symbol(self, hname, symbol, prefix, env, extra_args=None, dependencies=None):
-        if super().has_header_symbol(hname, symbol, prefix, env, extra_args, dependencies):
-            return True
+        result, cached = super().has_header_symbol(hname, symbol, prefix, env, extra_args, dependencies)
+        if result:
+            return True, cached
         if extra_args is None:
             extra_args = []
         fargs = {'prefix': prefix, 'header': hname, 'symbol': symbol}

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -326,7 +326,7 @@ class DCompiler(Compiler):
     def compiles(self, code, env, *, extra_args=None, dependencies=None, mode='compile'):
         args = self._get_compiler_check_args(env, extra_args, dependencies, mode)
 
-        with self.compile(code, args, mode) as p:
+        with self.compile(code, args, mode, cdata=env.coredata) as p:
             return p.returncode == 0
 
     def has_multi_arguments(self, args, env):

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -326,7 +326,7 @@ class DCompiler(Compiler):
     def compiles(self, code, env, *, extra_args=None, dependencies=None, mode='compile'):
         args = self._get_compiler_check_args(env, extra_args, dependencies, mode)
 
-        with self.compile(code, args, mode, cdata=env.coredata) as p:
+        with self.cached_compile(code, env.coredata, extra_args=args, mode=mode) as p:
             return p.returncode == 0, p.cached
 
     def has_multi_arguments(self, args, env):

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -327,7 +327,7 @@ class DCompiler(Compiler):
         args = self._get_compiler_check_args(env, extra_args, dependencies, mode)
 
         with self.compile(code, args, mode, cdata=env.coredata) as p:
-            return p.returncode == 0
+            return p.returncode == 0, p.cached
 
     def has_multi_arguments(self, args, env):
         return self.compiles('int i;\n', env, extra_args=args)

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -250,16 +250,16 @@ class FortranCompiler(Compiler):
     def _get_compiler_check_args(self, env, extra_args, dependencies, mode='compile'):
         return CCompiler._get_compiler_check_args(self, env, extra_args, dependencies, mode=mode)
 
-    def compiles(self, code, env, *, extra_args=None, dependencies=None, mode='compile'):
+    def compiles(self, code, env, *, extra_args=None, dependencies=None, mode='compile', disable_cache=False):
         return CCompiler.compiles(self, code, env, extra_args=extra_args,
-                                  dependencies=dependencies, mode=mode)
+                                  dependencies=dependencies, mode=mode, disable_cache=disable_cache)
 
-    def _build_wrapper(self, code, env, extra_args, dependencies=None, mode='compile', want_output=False):
-        return CCompiler._build_wrapper(self, code, env, extra_args, dependencies, mode, want_output)
+    def _build_wrapper(self, code, env, extra_args, dependencies=None, mode='compile', want_output=False, disable_cache=False):
+        return CCompiler._build_wrapper(self, code, env, extra_args, dependencies, mode, want_output, disable_cache=disable_cache)
 
-    def links(self, code, env, *, extra_args=None, dependencies=None):
+    def links(self, code, env, *, extra_args=None, dependencies=None, disable_cache=False):
         return CCompiler.links(self, code, env, extra_args=extra_args,
-                               dependencies=dependencies)
+                               dependencies=dependencies, disable_cache=disable_cache)
 
     def run(self, code, env, *, extra_args=None, dependencies=None):
         return CCompiler.run(self, code, env, extra_args=extra_args, dependencies=dependencies)

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -297,11 +297,11 @@ class FortranCompiler(Compiler):
     def has_multi_arguments(self, args, env):
         return CCompiler.has_multi_arguments(self, args, env)
 
-    def has_header(self, hname, prefix, env, *, extra_args=None, dependencies=None):
-        return CCompiler.has_header(self, hname, prefix, env, extra_args=extra_args, dependencies=dependencies)
+    def has_header(self, hname, prefix, env, *, extra_args=None, dependencies=None, disable_cache=False):
+        return CCompiler.has_header(self, hname, prefix, env, extra_args=extra_args, dependencies=dependencies, disable_cache=disable_cache)
 
-    def get_define(self, dname, prefix, env, extra_args, dependencies):
-        return CCompiler.get_define(self, dname, prefix, env, extra_args, dependencies)
+    def get_define(self, dname, prefix, env, extra_args, dependencies, disable_cache=False):
+        return CCompiler.get_define(self, dname, prefix, env, extra_args, dependencies, disable_cache=disable_cache)
 
     @classmethod
     def _get_trials_from_pattern(cls, pattern, directory, libname):

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -121,7 +121,7 @@ class ValaCompiler(Compiler):
             args = env.coredata.get_external_args(for_machine, self.language)
             vapi_args = ['--pkg', libname]
             args += vapi_args
-            with self.compile(code, args, 'compile') as p:
+            with self.compile(code, args, 'compile', cdata=env.coredata) as p:
                 if p.returncode == 0:
                     return vapi_args
         # Not found? Try to find the vapi file itself.

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -96,7 +96,7 @@ class ValaCompiler(Compiler):
             extra_flags += self.get_compile_only_args()
         else:
             extra_flags += environment.coredata.get_external_link_args(for_machine, self.language)
-        with self.compile(code, extra_flags, 'compile') as p:
+        with self.cached_compile(code, environment.coredata, extra_args=extra_flags, mode='compile') as p:
             if p.returncode != 0:
                 msg = 'Vala compiler {!r} can not compile programs' \
                       ''.format(self.name_string())
@@ -121,7 +121,7 @@ class ValaCompiler(Compiler):
             args = env.coredata.get_external_args(for_machine, self.language)
             vapi_args = ['--pkg', libname]
             args += vapi_args
-            with self.compile(code, args, 'compile', cdata=env.coredata) as p:
+            with self.cached_compile(code, env.coredata, extra_args=args, mode='compile') as p:
                 if p.returncode == 0:
                     return vapi_args
         # Not found? Try to find the vapi file itself.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -247,6 +247,7 @@ class CoreData:
         self.compilers = OrderedDict()
         self.cross_compilers = OrderedDict()
         self.deps = OrderedDict()
+        self.compiler_check_cache = OrderedDict()
         # Only to print a warning if it changes between Meson invocations.
         self.config_files = self.__load_config_files(options.native_file, 'native')
         self.libdir_cross_fixup()

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -250,7 +250,7 @@ class BoostDependency(ExternalDependency):
 
     def detect_headers_and_version(self):
         try:
-            version = self.clib_compiler.get_define('BOOST_LIB_VERSION', '#include <boost/version.hpp>', self.env, self.get_compile_args(), [])[0]
+            version = self.clib_compiler.get_define('BOOST_LIB_VERSION', '#include <boost/version.hpp>', self.env, self.get_compile_args(), [], disable_cache=True)[0]
         except mesonlib.EnvironmentException:
             return
         except TypeError:

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -250,7 +250,7 @@ class BoostDependency(ExternalDependency):
 
     def detect_headers_and_version(self):
         try:
-            version = self.clib_compiler.get_define('BOOST_LIB_VERSION', '#include <boost/version.hpp>', self.env, self.get_compile_args(), [])
+            version = self.clib_compiler.get_define('BOOST_LIB_VERSION', '#include <boost/version.hpp>', self.env, self.get_compile_args(), [])[0]
         except mesonlib.EnvironmentException:
             return
         except TypeError:

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -368,7 +368,7 @@ class OpenMPDependency(ExternalDependency):
         self.is_found = False
         try:
             openmp_date = self.clib_compiler.get_define(
-                '_OPENMP', '', self.env, self.clib_compiler.openmp_flags(), [self])[0]
+                '_OPENMP', '', self.env, self.clib_compiler.openmp_flags(), [self], disable_cache=True)[0]
         except mesonlib.EnvironmentException as e:
             mlog.debug('OpenMP support not available in the compiler')
             mlog.debug(e)
@@ -376,7 +376,7 @@ class OpenMPDependency(ExternalDependency):
 
         if openmp_date:
             self.version = self.VERSIONS[openmp_date]
-            if self.clib_compiler.has_header('omp.h', '', self.env, dependencies=[self])[0]:
+            if self.clib_compiler.has_header('omp.h', '', self.env, dependencies=[self], disable_cache=True)[0]:
                 self.is_found = True
                 self.compile_args = self.link_args = self.clib_compiler.openmp_flags()
             else:

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -376,7 +376,7 @@ class OpenMPDependency(ExternalDependency):
 
         if openmp_date:
             self.version = self.VERSIONS[openmp_date]
-            if self.clib_compiler.has_header('omp.h', '', self.env, dependencies=[self]):
+            if self.clib_compiler.has_header('omp.h', '', self.env, dependencies=[self])[0]:
                 self.is_found = True
                 self.compile_args = self.link_args = self.clib_compiler.openmp_flags()
             else:

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -368,7 +368,7 @@ class OpenMPDependency(ExternalDependency):
         self.is_found = False
         try:
             openmp_date = self.clib_compiler.get_define(
-                '_OPENMP', '', self.env, self.clib_compiler.openmp_flags(), [self])
+                '_OPENMP', '', self.env, self.clib_compiler.openmp_flags(), [self])[0]
         except mesonlib.EnvironmentException as e:
             mlog.debug('OpenMP support not available in the compiler')
             mlog.debug(e)

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -641,7 +641,7 @@ class VulkanDependency(ExternalDependency):
         else:
             # simply try to guess it, usually works on linux
             libs = self.clib_compiler.find_library('vulkan', environment, [])
-            if libs is not None and self.clib_compiler.has_header('vulkan/vulkan.h', '', environment):
+            if libs is not None and self.clib_compiler.has_header('vulkan/vulkan.h', '', environment)[0]:
                 self.type_name = 'system'
                 self.is_found = True
                 for lib in libs:

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -641,7 +641,7 @@ class VulkanDependency(ExternalDependency):
         else:
             # simply try to guess it, usually works on linux
             libs = self.clib_compiler.find_library('vulkan', environment, [])
-            if libs is not None and self.clib_compiler.has_header('vulkan/vulkan.h', '', environment)[0]:
+            if libs is not None and self.clib_compiler.has_header('vulkan/vulkan.h', '', environment, disable_cache=True)[0]:
                 self.type_name = 'system'
                 self.is_found = True
                 for lib in libs:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1196,8 +1196,8 @@ class CompilerHolder(InterpreterObject):
         extra_args = self.determine_args(kwargs)
         deps, msg = self.determine_dependencies(kwargs)
         had, cached = self.compiler.has_function(funcname, prefix, self.environment,
-                                         extra_args=extra_args,
-                                         dependencies=deps)
+                                                 extra_args=extra_args,
+                                                 dependencies=deps)
         cached = '(cached)' if cached else ''
         if had:
             hadtxt = mlog.green('YES')

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1309,10 +1309,11 @@ class CompilerHolder(InterpreterObject):
             raise InterpreterException('Prefix argument of get_define() must be a string.')
         extra_args = functools.partial(self.determine_args, kwargs)
         deps, msg = self.determine_dependencies(kwargs)
-        value = self.compiler.get_define(element, prefix, self.environment,
-                                         extra_args=extra_args,
-                                         dependencies=deps)
-        mlog.log('Fetching value of define', mlog.bold(element, True), msg, value)
+        value, cached = self.compiler.get_define(element, prefix, self.environment,
+                                                 extra_args=extra_args,
+                                                 dependencies=deps)
+        cached = '(cached)' if cached else ''
+        mlog.log('Fetching value of define', mlog.bold(element, True), msg, value, cached)
         return value
 
     @permittedKwargs({

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1134,16 +1134,17 @@ class CompilerHolder(InterpreterObject):
             raise InterpreterException('Prefix argument of has_member must be a string.')
         extra_args = functools.partial(self.determine_args, kwargs)
         deps, msg = self.determine_dependencies(kwargs)
-        had = self.compiler.has_members(typename, [membername], prefix,
-                                        self.environment,
-                                        extra_args=extra_args,
-                                        dependencies=deps)
+        had, cached = self.compiler.has_members(typename, [membername], prefix,
+                                                self.environment,
+                                                extra_args=extra_args,
+                                                dependencies=deps)
+        cached = '(cached)' if cached else ''
         if had:
             hadtxt = mlog.green('YES')
         else:
             hadtxt = mlog.red('NO')
         mlog.log('Checking whether type', mlog.bold(typename, True),
-                 'has member', mlog.bold(membername, True), msg, hadtxt)
+                 'has member', mlog.bold(membername, True), msg, hadtxt, cached)
         return had
 
     @permittedKwargs({
@@ -1163,17 +1164,18 @@ class CompilerHolder(InterpreterObject):
             raise InterpreterException('Prefix argument of has_members must be a string.')
         extra_args = functools.partial(self.determine_args, kwargs)
         deps, msg = self.determine_dependencies(kwargs)
-        had = self.compiler.has_members(typename, membernames, prefix,
-                                        self.environment,
-                                        extra_args=extra_args,
-                                        dependencies=deps)
+        had, cached = self.compiler.has_members(typename, membernames, prefix,
+                                                self.environment,
+                                                extra_args=extra_args,
+                                                dependencies=deps)
+        cached = '(cached)' if cached else ''
         if had:
             hadtxt = mlog.green('YES')
         else:
             hadtxt = mlog.red('NO')
         members = mlog.bold(', '.join(['"{}"'.format(m) for m in membernames]))
         mlog.log('Checking whether type', mlog.bold(typename, True),
-                 'has members', members, msg, hadtxt)
+                 'has members', members, msg, hadtxt, cached)
         return had
 
     @permittedKwargs({
@@ -1193,14 +1195,15 @@ class CompilerHolder(InterpreterObject):
             raise InterpreterException('Prefix argument of has_function must be a string.')
         extra_args = self.determine_args(kwargs)
         deps, msg = self.determine_dependencies(kwargs)
-        had = self.compiler.has_function(funcname, prefix, self.environment,
+        had, cached = self.compiler.has_function(funcname, prefix, self.environment,
                                          extra_args=extra_args,
                                          dependencies=deps)
+        cached = '(cached)' if cached else ''
         if had:
             hadtxt = mlog.green('YES')
         else:
             hadtxt = mlog.red('NO')
-        mlog.log('Checking for function', mlog.bold(funcname, True), msg, hadtxt)
+        mlog.log('Checking for function', mlog.bold(funcname, True), msg, hadtxt, cached)
         return had
 
     @permittedKwargs({
@@ -1220,13 +1223,14 @@ class CompilerHolder(InterpreterObject):
             raise InterpreterException('Prefix argument of has_type must be a string.')
         extra_args = functools.partial(self.determine_args, kwargs)
         deps, msg = self.determine_dependencies(kwargs)
-        had = self.compiler.has_type(typename, prefix, self.environment,
-                                     extra_args=extra_args, dependencies=deps)
+        had, cached = self.compiler.has_type(typename, prefix, self.environment,
+                                             extra_args=extra_args, dependencies=deps)
+        cached = '(cached)' if cached else ''
         if had:
             hadtxt = mlog.green('YES')
         else:
             hadtxt = mlog.red('NO')
-        mlog.log('Checking for type', mlog.bold(typename, True), msg, hadtxt)
+        mlog.log('Checking for type', mlog.bold(typename, True), msg, hadtxt, cached)
         return had
 
     @FeatureNew('compiler.compute_int', '0.40.0')
@@ -1332,15 +1336,16 @@ class CompilerHolder(InterpreterObject):
             raise InterpreterException('Testname argument must be a string.')
         extra_args = functools.partial(self.determine_args, kwargs)
         deps, msg = self.determine_dependencies(kwargs, endl=None)
-        result = self.compiler.compiles(code, self.environment,
-                                        extra_args=extra_args,
-                                        dependencies=deps)
+        result, cached = self.compiler.compiles(code, self.environment,
+                                                extra_args=extra_args,
+                                                dependencies=deps)
         if len(testname) > 0:
             if result:
                 h = mlog.green('YES')
             else:
                 h = mlog.red('NO')
-            mlog.log('Checking if', mlog.bold(testname, True), msg, 'compiles:', h)
+            cached = '(cached)' if cached else ''
+            mlog.log('Checking if', mlog.bold(testname, True), msg, 'compiles:', h, cached)
         return result
 
     @permittedKwargs({
@@ -1364,15 +1369,16 @@ class CompilerHolder(InterpreterObject):
             raise InterpreterException('Testname argument must be a string.')
         extra_args = functools.partial(self.determine_args, kwargs)
         deps, msg = self.determine_dependencies(kwargs, endl=None)
-        result = self.compiler.links(code, self.environment,
-                                     extra_args=extra_args,
-                                     dependencies=deps)
+        result, cached = self.compiler.links(code, self.environment,
+                                             extra_args=extra_args,
+                                             dependencies=deps)
+        cached = '(cached)' if cached else ''
         if len(testname) > 0:
             if result:
                 h = mlog.green('YES')
             else:
                 h = mlog.red('NO')
-            mlog.log('Checking if', mlog.bold(testname, True), msg, 'links:', h)
+            mlog.log('Checking if', mlog.bold(testname, True), msg, 'links:', h, cached)
         return result
 
     @FeatureNew('compiler.check_header', '0.47.0')
@@ -1392,16 +1398,17 @@ class CompilerHolder(InterpreterObject):
             return False
         extra_args = functools.partial(self.determine_args, kwargs)
         deps, msg = self.determine_dependencies(kwargs)
-        haz = self.compiler.check_header(hname, prefix, self.environment,
-                                         extra_args=extra_args,
-                                         dependencies=deps)
+        haz, cached = self.compiler.check_header(hname, prefix, self.environment,
+                                                 extra_args=extra_args,
+                                                 dependencies=deps)
+        cached = '(cached)' if cached else ''
         if required and not haz:
             raise InterpreterException('{} header {!r} not usable'.format(self.compiler.get_display_language(), hname))
         elif haz:
             h = mlog.green('YES')
         else:
             h = mlog.red('NO')
-        mlog.log('Check usable header', mlog.bold(hname, True), msg, h)
+        mlog.log('Check usable header', mlog.bold(hname, True), msg, h, cached)
         return haz
 
     @FeatureNewKwargs('compiler.has_header', '0.50.0', ['required'])
@@ -1420,15 +1427,16 @@ class CompilerHolder(InterpreterObject):
             return False
         extra_args = functools.partial(self.determine_args, kwargs)
         deps, msg = self.determine_dependencies(kwargs)
-        haz = self.compiler.has_header(hname, prefix, self.environment,
-                                       extra_args=extra_args, dependencies=deps)
+        haz, cached = self.compiler.has_header(hname, prefix, self.environment,
+                                               extra_args=extra_args, dependencies=deps)
+        cached = '(cached)' if cached else ''
         if required and not haz:
             raise InterpreterException('{} header {!r} not found'.format(self.compiler.get_display_language(), hname))
         elif haz:
             h = mlog.green('YES')
         else:
             h = mlog.red('NO')
-        mlog.log('Has header', mlog.bold(hname, True), msg, h)
+        mlog.log('Has header', mlog.bold(hname, True), msg, h, cached)
         return haz
 
     @FeatureNewKwargs('compiler.has_header_symbol', '0.50.0', ['required'])
@@ -1447,16 +1455,17 @@ class CompilerHolder(InterpreterObject):
             return False
         extra_args = functools.partial(self.determine_args, kwargs)
         deps, msg = self.determine_dependencies(kwargs)
-        haz = self.compiler.has_header_symbol(hname, symbol, prefix, self.environment,
-                                              extra_args=extra_args,
-                                              dependencies=deps)
+        haz, cached = self.compiler.has_header_symbol(hname, symbol, prefix, self.environment,
+                                                      extra_args=extra_args,
+                                                      dependencies=deps)
         if required and not haz:
             raise InterpreterException('{} symbol {} not found in header {}'.format(self.compiler.get_display_language(), symbol, hname))
         elif haz:
             h = mlog.green('YES')
         else:
             h = mlog.red('NO')
-        mlog.log('Header <{0}> has symbol'.format(hname), mlog.bold(symbol, True), msg, h)
+        cached = '(cached)' if cached else ''
+        mlog.log('Header <{0}> has symbol'.format(hname), mlog.bold(symbol, True), msg, h, cached)
         return haz
 
     def notfound_library(self, libname):
@@ -1518,15 +1527,16 @@ class CompilerHolder(InterpreterObject):
     @permittedKwargs({})
     def has_multi_arguments_method(self, args, kwargs):
         args = mesonlib.stringlistify(args)
-        result = self.compiler.has_multi_arguments(args, self.environment)
+        result, cached = self.compiler.has_multi_arguments(args, self.environment)
         if result:
             h = mlog.green('YES')
         else:
             h = mlog.red('NO')
+        cached = '(cached)' if cached else ''
         mlog.log(
             'Compiler for {} supports arguments {}:'.format(
                 self.compiler.get_display_language(), ' '.join(args)),
-            h)
+            h, cached)
         return result
 
     @FeatureNew('compiler.get_supported_arguments', '0.43.0')
@@ -1560,7 +1570,8 @@ class CompilerHolder(InterpreterObject):
     @permittedKwargs({})
     def has_multi_link_arguments_method(self, args, kwargs):
         args = mesonlib.stringlistify(args)
-        result = self.compiler.has_multi_link_arguments(args, self.environment)
+        result, cached = self.compiler.has_multi_link_arguments(args, self.environment)
+        cached = '(cached)' if cached else ''
         if result:
             h = mlog.green('YES')
         else:
@@ -1568,7 +1579,7 @@ class CompilerHolder(InterpreterObject):
         mlog.log(
             'Compiler for {} supports link arguments {}:'.format(
                 self.compiler.get_display_language(), ' '.join(args)),
-            h)
+            h, cached)
         return result
 
     @FeatureNew('compiler.get_supported_link_arguments_method', '0.46.0')
@@ -1597,9 +1608,10 @@ class CompilerHolder(InterpreterObject):
         args = mesonlib.stringlistify(args)
         if len(args) != 1:
             raise InterpreterException('has_func_attribute takes exactly one argument.')
-        result = self.compiler.has_func_attribute(args[0], self.environment)
+        result, cached = self.compiler.has_func_attribute(args[0], self.environment)
+        cached = '(cached)' if cached else ''
         h = mlog.green('YES') if result else mlog.red('NO')
-        mlog.log('Compiler for {} supports function attribute {}:'.format(self.compiler.get_display_language(), args[0]), h)
+        mlog.log('Compiler for {} supports function attribute {}:'.format(self.compiler.get_display_language(), args[0]), h, cached)
         return result
 
     @FeatureNew('compiler.get_supported_function_attributes', '0.48.0')

--- a/mesonbuild/modules/unstable_simd.py
+++ b/mesonbuild/modules/unstable_simd.py
@@ -66,7 +66,7 @@ class SimdModule(ExtensionModule):
                 mlog.log('Compiler supports %s:' % iset, mlog.red('NO'))
                 continue
             if args:
-                if not compiler.has_multi_arguments(args, state.environment):
+                if not compiler.has_multi_arguments(args, state.environment)[0]:
                     mlog.log('Compiler supports %s:' % iset, mlog.red('NO'))
                     continue
             mlog.log('Compiler supports %s:' % iset, mlog.green('YES'))


### PR DESCRIPTION
This patch caches the results of compilers.compile() in coredata instead of a class variable. This way, the cached values can be used during reconfiguration. This improves the reconfiguration time significantly (5 seconds on my system for gst-build).

Some changes to the internal API where necessary to print the `(cached)` string. In fact, this refactor makes up the vast majority of the changes. In case the user feedback (`(cached)`) is not necessary, these changes can be easily reverted.

(Re)configure times for gst-build with the current master:

```
../meson/meson.py build  15.99s user 4.40s system 106% cpu 19.216 total
../meson/meson.py --reconfigure build  13.14s user 3.22s system 106% cpu 15.426 total
```

And here are the times with this patch:

```
../meson/meson.py build  15.57s user 4.37s system 106% cpu 18.796 total
../meson/meson.py --reconfigure build  9.08s user 1.54s system 101% cpu 10.419 total
```