### PR TITLE
dependencies: fix Python linking for windows+mingw

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -450,10 +450,14 @@ class Python3Dependency(ExternalDependency):
         if pyplat.startswith('win'):
             vernum = sysconfig.get_config_var('py_version_nodot')
             if self.static:
-                libname = 'libpython{}.a'.format(vernum)
+                libpath = Path('libs') / 'libpython{}.a'.format(vernum)
             else:
-                libname = 'python{}.lib'.format(vernum)
-            lib = Path(sysconfig.get_config_var('base')) / 'libs' / libname
+                comp = self.get_compiler()
+                if comp.id == "gcc":
+                    libpath = 'python{}.dll'.format(vernum)
+                else:
+                    libpath = Path('libs') / 'python{}.lib'.format(vernum)
+            lib = Path(sysconfig.get_config_var('base')) / libpath
         elif pyplat == 'mingw':
             if self.static:
                 libname = sysconfig.get_config_var('LIBRARY')

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -184,10 +184,14 @@ class PythonDependency(ExternalDependency):
         if self.platform.startswith('win'):
             vernum = self.variables.get('py_version_nodot')
             if self.static:
-                libname = 'libpython{}.a'.format(vernum)
+                libpath = Path('libs') / 'libpython{}.a'.format(vernum)
             else:
-                libname = 'python{}.lib'.format(vernum)
-            lib = Path(self.variables.get('base')) / 'libs' / libname
+                comp = self.get_compiler()
+                if comp.id == "gcc":
+                    libpath = 'python{}.dll'.format(vernum)
+                else:
+                    libpath = Path('libs') / 'python{}.lib'.format(vernum)
+            lib = Path(self.variables.get('base')) / libpath
         elif self.platform == 'mingw':
             if self.static:
                 libname = self.variables.get('LIBRARY')


### PR DESCRIPTION
For dynamic linking, some mingw releases don't link
correctly with pythonXX.lib in all cases.
This patch forces mingw to link against
pyhthonXX.dll instead of the .lib file, which has
a better compatiblity.

Note that msys 1.0 old platform is detected
as windows instead of 'mingw'