### PR TITLE
Fix build error in cuda compiler when werror=true

### DIFF
--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -46,6 +46,9 @@ class CudaCompiler(Compiler):
     def get_no_stdinc_args(self):
         return []
 
+    def get_cross_extra_flags(self, environment, link=False):
+        return []
+
     def sanity_check(self, work_dir, environment):
         source_name = os.path.join(work_dir, 'sanitycheckcuda.cu')
         binary_name = os.path.join(work_dir, 'sanitycheckcuda')
@@ -176,7 +179,7 @@ __global__ void kernel (void) {
         return cuda_debug_args[is_debug]
 
     def get_werror_args(self):
-        return ['-Werror']
+        return ['-Werror=cross-execution-space-call,deprecated-declarations,reorder']
 
     def get_linker_exelist(self):
         return self.exelist[:]

--- a/test cases/cuda/4 shared/meson.build
+++ b/test cases/cuda/4 shared/meson.build
@@ -1,4 +1,4 @@
-project('simple', 'cuda', version : '1.0.0')
+project('simple', 'cuda', version : '1.0.0', default_options: ['werror=true'])
 
 subdir('shared')
 


### PR DESCRIPTION
When werror is set to true, the cuda build fails for a missing method (`get_cross_extra_flags`). This also fixes missing arguments to `-Werror` for cuda

@jpakkane I'm not sure what this method should do and it is only referenced from the `sanity_check` method inside `cuda.py`. I provided an implementation that returns an empty list. Should I instead update the `sanity_check` to not call it or provide an empty method? 