### PR TITLE
mconf: Fixed crash for variables in targets (closes #4960)

### DIFF
--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -142,10 +142,11 @@ class IntrospectionInterpreter(AstInterpreter):
         }]
 
     def build_target(self, node, args, kwargs, targetclass):
+        args = self.flatten_args(args)
         if not args:
             return
         kwargs = self.flatten_kwargs(kwargs, True)
-        name = self.flatten_args(args)[0]
+        name = args[0]
         srcqueue = [node]
         if 'sources' in kwargs:
             srcqueue += kwargs['sources']

--- a/test cases/unit/53 introspect buildoptions/main.c
+++ b/test cases/unit/53 introspect buildoptions/main.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main() {
+  printf("Hello World");
+  return 0;
+}

--- a/test cases/unit/53 introspect buildoptions/meson.build
+++ b/test cases/unit/53 introspect buildoptions/meson.build
@@ -2,6 +2,11 @@ project('introspect buildargs', ['c'], default_options: ['c_std=c11', 'cpp_std=c
 
 subA = subproject('projectA')
 
+target_name = 'MAIN'
+target_src = ['main.c']
+
+executable(target_name, target_src)
+
 r = run_command(find_program('c_compiler.py'))
 if r.returncode() != 0
   error('FAILED')


### PR DESCRIPTION
This fixes a crash in the introspection interpreter when a variable is provided for a target name. In this case, the name can not be resolved.