### PR TITLE
gnome.mkenums: Use rspfiles on Windows when possible

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -555,7 +555,7 @@ int dummy;
 
     def generate_custom_target(self, target, outfile):
         self.custom_target_generator_inputs(target, outfile)
-        (srcs, ofilenames, cmd) = self.eval_custom_target_command(target)
+        (srcs, ofilenames, exe_args, cmd_args) = self.eval_custom_target_command(target)
         deps = self.unwrap_dep_list(target)
         deps += self.get_custom_target_depend_files(target)
         desc = 'Generating {0} with a {1} command.'
@@ -579,7 +579,7 @@ int dummy;
             serialize = True
         # If the command line requires a newline, also use the wrapper, as
         # ninja does not support them in its build rule syntax.
-        if any('\n' in c for c in cmd):
+        if any('\n' in c for c in cmd_args):
             serialize = True
         # Windows doesn't have -rpath, so for EXEs that need DLLs built within
         # the project, we need to set PATH so the DLLs are found. We use
@@ -595,14 +595,16 @@ int dummy;
             if extra_paths:
                 serialize = True
         if serialize:
-            exe_data = self.serialize_executable(target.name, target.command[0], cmd[1:],
+            exe_data = self.serialize_executable(target.name, target.command[0], cmd_args,
                                                  # All targets are built from the build dir
                                                  self.environment.get_build_dir(),
                                                  extra_paths=extra_paths,
-                                                 capture=ofilenames[0] if target.capture else None)
+                                                 capture=ofilenames[0] if target.capture else None,
+                                                 can_rspfile=target.can_rspfile)
             cmd = self.environment.get_build_command() + ['--internal', 'exe', exe_data]
             cmd_type = 'meson_exe.py custom'
         else:
+            cmd = exe_args + cmd_args
             cmd_type = 'custom'
         if target.depfile is not None:
             depfile = target.get_dep_outname(elem.infilenames)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -534,14 +534,14 @@ class Vs2010Backend(backends.Backend):
         # We need to always use absolute paths because our invocation is always
         # from the target dir, not the build root.
         target.absolute_paths = True
-        (srcs, ofilenames, cmd) = self.eval_custom_target_command(target, True)
+        (srcs, ofilenames, _, cmd_args) = self.eval_custom_target_command(target, True)
         depend_files = self.get_custom_target_depend_files(target, True)
         # Always use a wrapper because MSBuild eats random characters when
         # there are many arguments.
         tdir_abs = os.path.join(self.environment.get_build_dir(), self.get_target_dir(target))
         extra_bdeps = target.get_transitive_build_target_deps()
         extra_paths = self.determine_windows_extra_paths(target.command[0], extra_bdeps)
-        exe_data = self.serialize_executable(target.name, target.command[0], cmd[1:],
+        exe_data = self.serialize_executable(target.name, target.command[0], cmd_args,
                                              # All targets run from the target dir
                                              tdir_abs,
                                              extra_paths=extra_paths,

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1868,6 +1868,7 @@ class CustomTarget(Target):
         self.extra_depends = []
         self.depend_files = [] # Files that this target depends on but are not on the command line.
         self.depfile = None
+        self.can_rspfile = False
         self.process_kwargs(kwargs)
         self.extra_files = []
         # Whether to use absolute paths for all files on the commandline
@@ -1936,7 +1937,7 @@ class CustomTarget(Target):
                     # Can only add a dependency on an external program which we
                     # know the absolute path of
                     self.depend_files.append(File.from_absolute_file(path))
-                final_cmd += c.get_command()
+                final_cmd.append(c)
             elif isinstance(c, (BuildTarget, CustomTarget)):
                 self.dependencies.append(c)
                 final_cmd.append(c)

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1581,8 +1581,7 @@ G_END_DECLS'''
 
         return ModuleReturnValue([c_file, h_file], [c_file, h_file])
 
-    @staticmethod
-    def _make_mkenum_custom_target(state, sources, output, cmd, kwargs):
+    def _make_mkenum_custom_target(self, state, sources, output, cmd, kwargs):
         custom_kwargs = {
             'input': sources,
             'output': output,
@@ -1590,9 +1589,14 @@ G_END_DECLS'''
             'command': cmd
         }
         custom_kwargs.update(kwargs)
-        return build.CustomTarget(output, state.subdir, state.subproject, custom_kwargs,
+        ct = build.CustomTarget(output, state.subdir, state.subproject, custom_kwargs,
                                   # https://github.com/mesonbuild/meson/issues/973
                                   absolute_paths=True)
+        # Use rspfiles on Windows to avoid exceeding the maximum commandline length limit
+        can_rspfile = mesonlib.version_compare(self._get_native_glib_version(state), '>= 2.59.1')
+        if state.build_machine.system == 'windows' and can_rspfile:
+            ct.can_rspfile = True
+        return ct
 
     @permittedKwargs({'sources', 'prefix', 'install_header', 'install_dir', 'stdinc',
                       'nostdinc', 'internal', 'skip_source', 'valist_marshallers',


### PR DESCRIPTION
This is needed on Windows where the argument list can exceed the maximum command-line length when lots of sources are passed to `glib-mkenums`.

Upstream changes: https://gitlab.gnome.org/GNOME/glib/merge_requests/489