### PR TITLE
azure-pipelines: Fix cygwin and vs2015x86ninja CI failures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,13 +76,13 @@ jobs:
         libglib2.0-devel,^
         libgtk3-devel,^
         ninja,^
-        python3-pip,^
+        python35-pip,^
         vala,^
         zlib-devel
       displayName: Install Dependencies
     - script: |
         set PATH=%CYGWIN_ROOT%\bin;%SYSTEMROOT%\system32
-        env.exe -- python3 run_tests.py --backend=ninja
+        env.exe -- python3.5 run_tests.py --backend=ninja
       displayName: Run Tests
     - task: CopyFiles@2
       condition: not(canceled())

--- a/ci/install-dmd.ps1
+++ b/ci/install-dmd.ps1
@@ -68,4 +68,4 @@ $dmd_bin = Join-Path $dmd_install "dmd2\windows\bin"
 $Env:Path = $Env:Path + ";" + $dmd_bin
 
 #echo "Testing DMD..."
-& dmd.exe --version 2>&1>$null
+& dmd.exe --version


### PR DESCRIPTION
The package has been moved from python3-pip to python3N-pip where N is 5, 6, 7. We use Python 3.5, so let's use that.