### PR TITLE
Improve declare_dependency() example in Generating-sources.md [skip ci]

### DIFF
--- a/docs/markdown/Generating-sources.md
+++ b/docs/markdown/Generating-sources.md
@@ -111,10 +111,15 @@ and library dependency, especially if there are many generated headers:
 
 ```meson
 idep_foo = declare_dependency(
-    sources : [foo_h, bar_h],
+    include_directories : libfoo.private_dir_include(),
     link_with : [libfoo],
 )
 ```
+
+Adding the static library's private include directory to
+`include_directories` of `declare_dependency` will make sure all headers
+are generated before any sources of a target linking against libfoo are
+built.
 
 See [dependencies](Dependencies.md#declaring-your-own), and
 [reference](Reference-manual.md#decalre_dependency) for more information.


### PR DESCRIPTION
By using private_dir_include() instead of enumerating headers in sources
of declare_dependency. Much more convenient, especially when there are
many headers.

Found out about this by reading #4638. It is not documented anywhere as
far as I can tell.