### PR TITLE
CUDA fixes

### DIFF
--- a/docs/markdown/Cuda-module.md
+++ b/docs/markdown/Cuda-module.md
@@ -71,6 +71,14 @@ mixed with architecture names or compute capabilities. Their interpretation is:
 | `'Common'`        | Relatively common CCs supported by given NVCC compiler. Generally excludes Tegra and Tesla devices. |
 | `'Auto'`          | The CCs provided by the `detected:` keyword, filtered for support by given NVCC compiler. |
 
+As a special case, when `nvcc_arch_flags()` is invoked with
+
+- an NVCC `compiler` object `nvcc`,
+- `'Auto'` mode and
+- no `detected:` keyword,
+
+Meson uses `nvcc`'s architecture auto-detection results.
+
 The supported architecture names and their corresponding compute capabilities
 are:
 
@@ -85,7 +93,7 @@ are:
 | `'Pascal'`        | 6.0, 6.1           |
 | `'Pascal+Tegra'`  | 6.2                |
 | `'Volta'`         | 7.0                |
-| `'Volta+Tegra'`   | 7.2                |
+| `'Xavier'`        | 7.2                |
 | `'Turing'`        | 7.5                |
 
 

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -188,7 +188,7 @@ class CudaCompiler(Compiler):
         return cuda_debug_args[is_debug]
 
     def get_werror_args(self):
-        return ['-Werror']
+        return ['-Werror=cross-execution-space-call,deprecated-declarations,reorder']
 
     def get_linker_exelist(self):
         return self.exelist[:]

--- a/mesonbuild/modules/unstable_cuda.py
+++ b/mesonbuild/modules/unstable_cuda.py
@@ -158,7 +158,7 @@ class CudaModule(ExtensionModule):
                 cuda_limit_gpu_architecture    = '7.0'        # noqa: E221
 
         if version_compare(cuda_version, '>=9.0'):
-            cuda_known_gpu_architectures  += ['Volta', 'Volta+Tegra']              # noqa: E221
+            cuda_known_gpu_architectures  += ['Volta', 'Xavier']                   # noqa: E221
             cuda_common_gpu_architectures += ['7.0', '7.0+PTX']                    # noqa: E221
             cuda_all_gpu_architectures    += ['7.0', '7.0+PTX', '7.2', '7.2+PTX']  # noqa: E221
 
@@ -225,7 +225,7 @@ class CudaModule(ExtensionModule):
                     'Pascal':        (['6.0', '6.1'],      ['6.1']),
                     'Pascal+Tegra':  (['6.2'],             []),
                     'Volta':         (['7.0'],             ['7.0']),
-                    'Volta+Tegra':   (['7.2'],             []),
+                    'Xavier':        (['7.2'],             []),
                     'Turing':        (['7.5'],             ['7.5']),
                 }.get(arch_name, (None, None))
 


### PR DESCRIPTION
Assorted changes:

- Sanity check of NVCC compiler is modified to also detect and enumerate GPU compute capabilities, which the compiler collects and returns.
- Fixes for #4961, with credits to @jml1795 for `-Werror`'s solution.
- Rename `Volta+Tegra` to the apparently more-official `Xavier`.
- Updates to CUDA module documentation.
