### PR TITLE
per-target manual specification of link_language

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -516,6 +516,8 @@ be passed to [shared and static libraries](#library).
   depends on such as a symbol visibility map. The purpose is to
   automatically trigger a re-link (but not a re-compile) of the target
   when this file changes.
+- `link_language` since 0.51.0 makes the linker for this target
+  be for the specified language. This is helpful for multi-language targets.
 - `link_whole` links all contents of the given static libraries
   whether they are used by not, equivalent to the
   `-Wl,--whole-archive` argument flag of GCC, available since
@@ -559,7 +561,7 @@ be passed to [shared and static libraries](#library).
   the keyword argument for the default behaviour.
 - `override_options` takes an array of strings in the same format as
   `project`'s `default_options` overriding the values of these options
-  for this target only, since 0.40.0
+  for this target only, since 0.40.0.
 - `gnu_symbol_visibility` specifies how symbols should be exported, see
   e.g [the GCC Wiki](https://gcc.gnu.org/wiki/Visibility) for more
   information. This value can either be an empty string or one of

--- a/docs/markdown/snippets/link_language.md
+++ b/docs/markdown/snippets/link_language.md
@@ -1,4 +1,4 @@
-## `link_language` target options
+## New target keyword argument: `link_language`
 There may be situations for which the user wishes to manually specify the linking language.
 For example, a C++ target may link C, Fortran, etc. and perhaps the automatic detection in Meson does not pick the desired compiler.
 The user can manually choose the linker by language per-target like this example of a target where one wishes to link with the Fortran compiler:
@@ -7,4 +7,4 @@ executable(..., link_language : 'fortran')
 ```
 
 A specific case this option fixes is where for example the main program is Fortran that calls C and/or C++ code.
-The automatic language detection of Meson prioritizes C/C++, and so an compile-time error results like `undefined reference to `main'`, because the linker is C or C++ instead of Fortran, which is fixed by this per-target override.
+The automatic language detection of Meson prioritizes C/C++, and so an compile-time error results like `undefined reference to main`, because the linker is C or C++ instead of Fortran, which is fixed by this per-target override.

--- a/docs/markdown/snippets/link_language.md
+++ b/docs/markdown/snippets/link_language.md
@@ -1,0 +1,10 @@
+## `link_language` target options
+There may be situations for which the user wishes to manually specify the linking language.
+For example, a C++ target may link C, Fortran, etc. and perhaps the automatic detection in Meson does not pick the desired compiler.
+The user can manually choose the linker by language per-target like this example of a target where one wishes to link with the Fortran compiler:
+```meson
+executable(..., link_language : 'fortran')
+```
+
+A specific case this option fixes is where for example the main program is Fortran that calls C and/or C++ code.
+The automatic language detection of Meson prioritizes C/C++, and so an compile-time error results like `undefined reference to `main'`, because the linker is C or C++ instead of Fortran, which is fixed by this per-target override.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -65,7 +65,6 @@ buildtarget_kwargs = set([
     'link_whole',
     'link_args',
     'link_depends',
-    'link_language',
     'implicit_include_directories',
     'include_directories',
     'install',
@@ -89,7 +88,7 @@ known_build_target_kwargs = (
     rust_kwargs |
     cs_kwargs)
 
-known_exe_kwargs = known_build_target_kwargs | {'implib', 'export_dynamic', 'pie'}
+known_exe_kwargs = known_build_target_kwargs | {'implib', 'export_dynamic', 'link_language', 'pie'}
 known_shlib_kwargs = known_build_target_kwargs | {'version', 'soversion', 'vs_module_defs', 'darwin_versions'}
 known_shmod_kwargs = known_build_target_kwargs
 known_stlib_kwargs = known_build_target_kwargs | {'pic'}
@@ -346,7 +345,6 @@ a hard error in the future.''' % name)
         self.install = False
         self.build_always_stale = False
         self.option_overrides = {}
-        self.link_language = None
         if not hasattr(self, 'typename'):
             raise RuntimeError('Target type is not set for target class "{}". This is a bug'.format(type(self).__name__))
 
@@ -447,6 +445,7 @@ class BuildTarget(Target):
         self.objects = []
         self.external_deps = []
         self.include_dirs = []
+        self.link_language = kwargs.get('link_language')
         self.link_targets = []
         self.link_whole_targets = []
         self.link_depends = []
@@ -565,9 +564,7 @@ class BuildTarget(Target):
             compilers = self.environment.coredata.compilers
 
         # did user override clink_langs for this target?
-        link_langs = self.link_language if self.link_language else clink_langs
-        # if self.link_language:
-            # link_langs.append(self.link_language)
+        link_langs = [self.link_language] if self.link_language else clink_langs
 
         # If this library is linked against another library we need to consider
         # the languages of those libraries as well.
@@ -1150,9 +1147,8 @@ You probably should put it in link_with instead.''')
         '''
         langs = []
 
-        # User specified link_langugage of target (for multi-language targets)
+        # User specified link_language of target (for multi-language targets)
         if self.link_language:
-            #langs.append(self.link_language)
             return [self.link_language]
 
         # Check if any of the external libraries were written in this language

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from typing import List
 import copy, os, re
 from collections import OrderedDict

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -298,7 +298,6 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
     def language_stdlib_only_link_flags(self):
         return ['-lgfortran', '-lm']
 
-
 class ElbrusFortranCompiler(GnuFortranCompiler, ElbrusCompiler):
     def __init__(self, exelist, version, compiler_type, is_cross, exe_wrapper=None, defines=None, **kwargs):
         GnuFortranCompiler.__init__(self, exelist, version, compiler_type, is_cross, exe_wrapper, defines, **kwargs)
@@ -392,6 +391,9 @@ class PGIFortranCompiler(PGICompiler, FortranCompiler):
         FortranCompiler.__init__(self, exelist, version, is_cross, exe_wrapper, **kwags)
         PGICompiler.__init__(self, CompilerType.PGI_STANDARD)
 
+    def language_stdlib_only_link_flags(self) -> List[str]:
+        return ['-lpgf90rtl', '-lpgf90', '-lpgf90_rpm1', '-lpgf902',
+                '-lpgf90rtl', '-lpgftnrtl', '-lrt']
 
 class FlangFortranCompiler(ClangCompiler, FortranCompiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwags):

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -502,6 +502,10 @@ def skippable(suite, test):
     if test.endswith('netcdf'):
         return True
 
+    # MSVC doesn't link with GFortran
+    if test.endswith('14 fortran links c'):
+        return True
+
     # No frameworks test should be skipped on linux CI, as we expect all
     # prerequisites to be installed
     if mesonlib.is_linux():

--- a/test cases/fortran/14 fortran links c/clib.c
+++ b/test cases/fortran/14 fortran links c/clib.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 
 void hello(void){
 

--- a/test cases/fortran/14 fortran links c/clib.c
+++ b/test cases/fortran/14 fortran links c/clib.c
@@ -1,0 +1,6 @@
+
+void hello(void){
+
+  printf("hello from C\n");
+
+}

--- a/test cases/fortran/14 fortran links c/f_call_c.f90
+++ b/test cases/fortran/14 fortran links c/f_call_c.f90
@@ -1,0 +1,10 @@
+implicit none
+
+interface
+subroutine hello()  bind (c)
+end subroutine hello
+end interface
+
+call hello()
+
+end program

--- a/test cases/fortran/14 fortran links c/meson.build
+++ b/test cases/fortran/14 fortran links c/meson.build
@@ -1,7 +1,7 @@
 project('Fortran calling C', 'fortran', 'c')
 
-cc = meson.get_compiler('c')
-if cc.get_id() == 'msvc'
+ccid = meson.get_compiler('c').get_id()
+if ccid == 'msvc' or ccid == 'clang-cl'
   error('MESON_SKIP_TEST: MSVC and GCC do not interoperate like this.')
 endif
 

--- a/test cases/fortran/14 fortran links c/meson.build
+++ b/test cases/fortran/14 fortran links c/meson.build
@@ -1,0 +1,8 @@
+project('Fortran calling C', 'fortran', 'c')
+
+c_lib = library('clib', 'clib.c')
+
+f_call_c = executable('f_call_c', 'f_call_c.f90',
+  link_with: c_lib,
+  link_language: 'fortran')
+test('Fortran calling C', f_call_c)

--- a/test cases/fortran/14 fortran links c/meson.build
+++ b/test cases/fortran/14 fortran links c/meson.build
@@ -1,5 +1,10 @@
 project('Fortran calling C', 'fortran', 'c')
 
+cc = meson.get_compiler('c')
+if cc.get_id() == 'msvc'
+  error('MESON_SKIP_TEST: MSVC and GCC do not interoperate like this.')
+endif
+
 c_lib = library('clib', 'clib.c')
 
 f_call_c = executable('f_call_c', 'f_call_c.f90',


### PR DESCRIPTION
As noted in the snippet, there are cases where there is a need to specify the language of the linker.
Meson's auto-detection doesn't always work, particularly where the main program is in Fortran.
A test case is added for this.

This works for GCC, Intel, Flang/Clang and PGI compilers at least for that test case.

I also added missing link argument for PGI compiler (BUGFIX)
