### PR TITLE
Remove redundant definition of `cflags_mapping`

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -101,17 +101,6 @@ known_cpu_families = (
     'x86_64'
 )
 
-# Environment variables that each lang uses.
-cflags_mapping = {'c': 'CFLAGS',
-                  'cpp': 'CXXFLAGS',
-                  'cu': 'CUFLAGS',
-                  'objc': 'OBJCFLAGS',
-                  'objcpp': 'OBJCXXFLAGS',
-                  'fortran': 'FFLAGS',
-                  'd': 'DFLAGS',
-                  'vala': 'VALAFLAGS'}
-
-
 def detect_gcovr(version='3.1', log=False):
     gcovr_exe = 'gcovr'
     try:


### PR DESCRIPTION
It seems this was erroneously coppied in `54b6afa67`.