### PR TITLE
[metadata]: ignore tests from Linguist stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,10 @@
 * text eol=lf
 *.png binary
 *.icns binary
+
+test?cases/* linguist-detectable=false
+manual?tests/* linguist-detectable=false
+data/* linguist-detectable=false
+mesonbuild/dependencies/data/* linguist-detectable=false
+ci/* linguist-detectable=false
+ciimage/* linguist-detectable=false


### PR DESCRIPTION
I tell people Meson is a pure Python program, but the Linguist language graph at the top of the GitHub repo seems to say otherwise from 
```
$ github-linguist
```

```
Python 78.68%
Meson 12.77%
C 5.43%
C++ 1.03%
Vala 0.35%
...
```

This metadata update rightfully omits test case data from the Linguist stats, reflecting that Meson truly is a pure Python program, making the bar graph at the top of the Meson GitHub repo look nice too!
```
Python 100.00%
````
