### PR TITLE
mintro: Add subproject_dir to --projectinfo

### DIFF
--- a/docs/markdown/snippets/introspect_projectinfo_subprojects_dir.md
+++ b/docs/markdown/snippets/introspect_projectinfo_subprojects_dir.md
@@ -1,0 +1,4 @@
+## Add subproject_dir to --projectinfo introspection output
+
+This allows applications interfacing with Meson (such as IDEs) to know about
+an overridden subproject directory.

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -96,8 +96,8 @@ class IntrospectionInterpreter(AstInterpreter):
 
         if not self.is_subproject() and 'subproject_dir' in kwargs:
             spdirname = kwargs['subproject_dir']
-            if isinstance(spdirname, str):
-                self.subproject_dir = spdirname
+            if isinstance(spdirname, mparser.ElementaryNode):
+                self.subproject_dir = spdirname.value
         if not self.is_subproject():
             self.project_data['subprojects'] = []
             subprojects_dir = os.path.join(self.source_root, self.subproject_dir)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -288,7 +288,8 @@ def list_benchmarks(benchdata):
 
 def list_projinfo(builddata: build.Build):
     result = {'version': builddata.project_version,
-              'descriptive_name': builddata.project_name}
+              'descriptive_name': builddata.project_name,
+              'subproject_dir': builddata.subproject_dir}
     subprojects = []
     for k, v in builddata.subprojects.items():
         c = {'name': k,
@@ -313,6 +314,7 @@ def list_projinfo_from_source(sourcedir, indent):
         files = [x for x in files if not x.startswith(basedir)]
 
     intr.project_data['buildsystem_files'] = files
+    intr.project_data['subproject_dir'] = intr.subproject_dir
     print(json.dumps(intr.project_data, indent=indent))
 
 def run(options):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3226,6 +3226,7 @@ recommended as it is not supported on some platforms''')
         expected = {
             'descriptive_name': 'proj',
             'version': 'undefined',
+            'subproject_dir': 'subprojects',
             'subprojects': [
                 {
                     'descriptive_name': 'sub',
@@ -3250,6 +3251,19 @@ recommended as it is not supported on some platforms''')
         for entry in res:
             name = entry['name']
             self.assertEquals(entry['subproject'], expected[name])
+
+    def test_introspect_projectinfo_subproject_dir(self):
+        testdir = os.path.join(self.common_test_dir, '79 custom subproject dir')
+        self.init(testdir)
+        res = self.introspect('--projectinfo')
+
+        self.assertEqual(res['subproject_dir'], 'custom_subproject_dir')
+
+    def test_introspect_projectinfo_subproject_dir_from_source(self):
+        testfile = os.path.join(self.common_test_dir, '79 custom subproject dir', 'meson.build')
+        res = self.introspect_directory(testfile, '--projectinfo')
+
+        self.assertEqual(res['subproject_dir'], 'custom_subproject_dir')
 
     @skipIfNoExecutable('clang-format')
     def test_clang_format(self):
@@ -3404,7 +3418,7 @@ recommended as it is not supported on some platforms''')
         self.assertListEqual(dependencies_to_find, [])
 
         # Check projectinfo
-        self.assertDictEqual(res['projectinfo'], {'version': '1.2.3', 'descriptive_name': 'introspection', 'subprojects': []})
+        self.assertDictEqual(res['projectinfo'], {'version': '1.2.3', 'descriptive_name': 'introspection', 'subproject_dir': 'subprojects', 'subprojects': []})
 
         # Check targets
         targets_to_find = {


### PR DESCRIPTION
This allows applications interfacing with Meson (such as IDEs) to know about an overridden subproject directory.