### PR TITLE
azure: Fix python3 in vs2017 tasks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,11 @@ jobs:
           backend: ninja
 
   steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.5'
+      addToPath: true
+      architecture: 'x64'
   - template: ci/azure-steps.yml
 
 - job: cygwin

--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -142,9 +142,16 @@ steps:
        MSBuild /version
      }
 
+     echo "=== PATH BEGIN ==="
+     echo ($env:Path).Replace(';',"`n")
+     echo "=== PATH END ==="
+     echo ""
+     echo "Locating Python:"
      where.exe python
      python --version
 
+     echo ""
+     echo "=== Start running tests ==="
      python run_tests.py --backend $(backend)
 
 - task: PublishTestResults@2


### PR DESCRIPTION
The CI currently fails for all `vs2017` jobs because Python 2 instead of Python 3 is used.