### PR TITLE
dist: recurse into git submodules

### DIFF
--- a/docs/markdown/Creating-releases.md
+++ b/docs/markdown/Creating-releases.md
@@ -17,7 +17,8 @@ single command:
 This creates a file called `projectname-version.tar.xz` in the build
 tree subdirectory `meson-dist`. This archive contains the full
 contents of the latest commit in revision control including all the
-submodules. All revision control metadata is removed. Meson then takes
+submodules (recursively). All revision control metadata is removed.
+Meson then takes
 this archive and tests that it works by doing a full compile + test +
 install cycle. If all these pass, Meson will then create a SHA-256
 checksum file next to the archive.

--- a/mesonbuild/scripts/dist.py
+++ b/mesonbuild/scripts/dist.py
@@ -62,7 +62,7 @@ def process_submodules(dirname):
     module_file = os.path.join(dirname, '.gitmodules')
     if not os.path.exists(module_file):
         return
-    subprocess.check_call(['git', 'submodule', 'update', '--init'], cwd=dirname)
+    subprocess.check_call(['git', 'submodule', 'update', '--init', '--recursive'], cwd=dirname)
     for line in open(module_file):
         line = line.strip()
         if '=' not in line:


### PR DESCRIPTION
This makes more sense as the default for me, as it's not half-way, but it might be personal.  I understand that recursive submodules only happen in a small fraction of projects.

Tested, seems to work for me, but I can't claim to understand meson well.