### PR TITLE
Fix ternary in thing

### DIFF
--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -405,7 +405,8 @@ class IfNode(BaseNode):
         self.block = block
 
 class TernaryNode(BaseNode):
-    def __init__(self, lineno, colno, condition, trueblock, falseblock):
+    def __init__(self, subdir, lineno, colno, condition, trueblock, falseblock):
+        self.subdir = subdir
         self.lineno = lineno
         self.colno = colno
         self.condition = condition
@@ -540,7 +541,7 @@ class Parser:
             self.expect('colon')
             falseblock = self.e1()
             self.in_ternary = False
-            return TernaryNode(left.lineno, left.colno, left, trueblock, falseblock)
+            return TernaryNode(left.subdir, left.lineno, left.colno, left, trueblock, falseblock)
         return left
 
     def e2(self):

--- a/test cases/common/113 ternary/meson.build
+++ b/test cases/common/113 ternary/meson.build
@@ -1,7 +1,12 @@
 project('ternary operator', 'c')
 
+x = true
 one = true ? 1 : error('False branch should not be evaluated')
 two = false ? error('True branch should not be evaluated.') : 2
+three = '@0@'.format(x ? 'yes' : 'no')
+four = [x ? '0' : '1']
 
 assert(one == 1, 'Return value from ternary true is wrong.')
 assert(two == 2, 'Return value from ternary false is wrong.')
+assert(three == 'yes', 'Return value for ternary inside method call is wrong.')
+assert(four == ['0'], 'Return value for ternary inside of list is wrong.')


### PR DESCRIPTION
Currently there ar ea number of cases where a ternary cannot be used, as arguments to functions or in lists, for example. This is just because their representation in the parser doesn't fulfill all of the interfaces it needs to.

@jpakkane, I think it might be good to get this in 0.50 if possible.