### PR TITLE
Fix git wraps with submodules

### DIFF
--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -92,7 +92,7 @@ def update_git(wrap, repo_dir, options):
                      '     To rebase your branch on top of', mlog.bold(revision), 'use', mlog.bold('--rebase'), 'option.')
             return
 
-    git(['submodule', 'update'], repo_dir)
+    git(['submodule', 'update', '--checkout', '--recursive'], repo_dir)
     git_show(repo_dir)
 
 def update_hg(wrap, repo_dir, options):

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -218,17 +218,16 @@ class Resolver:
 
     def get_git(self):
         revno = self.wrap.get('revision')
-        if self.wrap.values.get('clone-recursive', '').lower() == 'true':
-            subprocess.check_call(['git', 'clone', '--recursive', self.wrap.get('url'),
-                                   self.directory], cwd=self.subdir_root)
-        else:
-            subprocess.check_call(['git', 'clone', self.wrap.get('url'),
-                                   self.directory], cwd=self.subdir_root)
+        subprocess.check_call(['git', 'clone', self.wrap.get('url'),
+                               self.directory], cwd=self.subdir_root)
         if revno.lower() != 'head':
             if subprocess.call(['git', 'checkout', revno], cwd=self.dirname) != 0:
                 subprocess.check_call(['git', 'fetch', self.wrap.get('url'), revno], cwd=self.dirname)
-                subprocess.check_call(['git', 'checkout', revno],
-                                      cwd=self.dirname)
+                subprocess.check_call(['git', 'checkout', revno], cwd=self.dirname)
+        if self.wrap.values.get('clone-recursive', '').lower() == 'true':
+            subprocess.check_call(['git', 'submodule', 'update',
+                                   '--init', '--checkout', '--recursive'],
+                                  cwd=self.dirname)
         push_url = self.wrap.values.get('push-url')
         if push_url:
             subprocess.check_call(['git', 'remote', 'set-url',


### PR DESCRIPTION
* If clone-recursive is specified, populate submodules only after the specified revision/branch has been checked out. Fixes #4996
* Update submodules recursively on `meson subprojects update`