### PR TITLE
Fix _get_patterns on OpenBSD

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -902,7 +902,8 @@ class CCompiler(Compiler):
             # is expensive. It's wrong in many edge cases, but it will match
             # correctly-named libraries and hopefully no one on OpenBSD names
             # their files libfoo.so.9a.7b.1.0
-            patterns.append('lib{}.so.[0-9]*.[0-9]*')
+            for p in prefixes:
+                patterns.append(p + '{}.so.[0-9]*.[0-9]*')
         return patterns
 
     def get_library_naming(self, env, libtype, strict=False):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -734,7 +734,7 @@ class InternalTests(unittest.TestCase):
         unix_static = ('lib{}.a', '{}.a')
         msvc_static = ('lib{}.a', 'lib{}.lib', '{}.a', '{}.lib')
         # This is the priority list of pattern matching for library searching
-        patterns = {'openbsd': {'shared': ('lib{}.so', '{}.so', 'lib{}.so.[0-9]*.[0-9]*'),
+        patterns = {'openbsd': {'shared': ('lib{}.so', '{}.so', 'lib{}.so.[0-9]*.[0-9]*', '{}.so.[0-9]*.[0-9]*'),
                                 'static': unix_static},
                     'linux': {'shared': ('lib{}.so', '{}.so'),
                               'static': unix_static},
@@ -759,15 +759,13 @@ class InternalTests(unittest.TestCase):
                 self._test_all_naming(cc, env, patterns, 'windows-msvc')
             else:
                 self._test_all_naming(cc, env, patterns, 'windows-mingw')
+        elif is_openbsd():
+            self._test_all_naming(cc, env, patterns, 'openbsd')
         else:
             self._test_all_naming(cc, env, patterns, 'linux')
-            # Mock OpenBSD since we don't have tests for it
             true = lambda x, y: True
-            if not is_openbsd():
-                with PatchModule(mesonbuild.compilers.c.for_openbsd,
-                                 'mesonbuild.compilers.c.for_openbsd', true):
-                    self._test_all_naming(cc, env, patterns, 'openbsd')
-            else:
+            with PatchModule(mesonbuild.compilers.c.for_openbsd,
+                             'mesonbuild.compilers.c.for_openbsd', true):
                 self._test_all_naming(cc, env, patterns, 'openbsd')
             with PatchModule(mesonbuild.compilers.c.for_darwin,
                              'mesonbuild.compilers.c.for_darwin', true):


### PR DESCRIPTION
We need to account to the possible prefixes (empty or 'lib').
This allows both to work:
cc.find_library('foo')
cc.find_library('libfoo')