### PR TITLE
mtest: print command line when invoked with -v

### DIFF
--- a/docs/markdown/snippets/meson-test-v.md
+++ b/docs/markdown/snippets/meson-test-v.md
@@ -1,0 +1,6 @@
+## `meson test -v` prints command lines
+
+When `meson test` is invoked with the `-v` command line options, for
+each test that it runs it will print the command line that was invoked.
+This makes it a bit easier to cut and paste from a failing test log into
+a terminal.

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -463,6 +463,12 @@ class SingleTestRunner:
                 self.test.timeout = None
             return self._run_cmd(wrap + cmd + self.test.cmd_args + self.options.test_args)
 
+    def get_cmdline(self, cmd):
+        test_only_env = sorted(set(self.env.items()) - set(os.environ.items()))
+        env = ' '.join(('%s=%s' % (k, shlex.quote(v)) for k, v in test_only_env))
+        cmdline = ' '.join((shlex.quote(x) for x in cmd))
+        return '%s %s' % (env, cmdline)
+
     def _run_cmd(self, cmd):
         starttime = time.time()
 
@@ -508,6 +514,9 @@ class SingleTestRunner:
                 # terminal in order to handle ^C and not show tcsetpgrp()
                 # errors avoid not being able to use the terminal.
                 os.setsid()
+
+        if self.options.verbose and not is_windows():
+            print(self.get_cmdline(cmd))
 
         p = subprocess.Popen(cmd,
                              stdout=stdout,


### PR DESCRIPTION
For easier reproducibility, when "meson test" is invoked with -v it will print the
command line that was invoked.  This makes it a bit easier to cut and paste
from a failing test log into a terminal, and when using --gdb it will also provide
a hint for how gdb was invoked.

This was requested by a developer on a project that I am converting.