### PR TITLE
pkgconfig.generate: add FeatureNew and documentation for implict version

### DIFF
--- a/docs/markdown/Pkgconfig-module.md
+++ b/docs/markdown/Pkgconfig-module.md
@@ -51,7 +51,7 @@ keyword arguments.
   e.g. `datadir=${prefix}/share`. The names `prefix`, `libdir` and
   `installdir` are reserved and may not be used.
 - `version` a string describing the version of this library, used to set the
-  `Version:` field. Defaults to the project version if unspecified.
+  `Version:` field. (*since 0.46.0*) Defaults to the project version if unspecified.
 - `d_module_versions` a list of module version flags used when compiling
    D sources referred to by this pkg-config file
 

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -353,7 +353,9 @@ class PkgConfigModule(ExtensionModule):
         default_description = None
         default_name = None
         mainlib = None
-        if len(args) == 1:
+        if not args and 'version' not in kwargs:
+            FeatureNew('pkgconfig.generate implicit version keyword', '0.46.0').use(state.subproject)
+        elif len(args) == 1:
             FeatureNew('pkgconfig.generate optional positional argument', '0.46.0').use(state.subproject)
             mainlib = getattr(args[0], 'held_object', args[0])
             if not isinstance(mainlib, (build.StaticLibrary, build.SharedLibrary)):


### PR DESCRIPTION
The documentation for this change was left out of its implementation in commit b4aee4675afd9f9f4a36aea628bab4249d7addbc and was later documented in commit f831c05b553d876a08dcf46478161b60b4e693c4 as if it had always existed.

This caught me out in https://github.com/linuxmint/cinnamon-menus/pull/27#issuecomment-470255359 as I tried to use "libraries" on its own to get around the lack of 0.46.0 availability, however that also meant "version" did not work either.