### PR TITLE
Fix Issue 5020 With Verbose RE Definiton in search_version

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -324,8 +324,26 @@ def search_version(text):
     # This regex is reaching magic levels. If it ever needs
     # to be updated, do not complexify but convert to something
     # saner instead.
-    version_regex = r'(?<!(\d|\.))(\d{1,2}(\.\d+)+(-[a-zA-Z0-9]+)?)'
-    match = re.search(version_regex, text)
+    # We'll demystify it a bit with a verbose definition.
+    version_regex = re.compile(r"""
+    (?<!                # Zero-width negative lookbehind assertion
+        (
+            \d          # One digit
+            | \.        # Or one period
+        )               # One occurrence
+    )
+    # Following pattern must not follow a digit or period
+    (
+        \d{1,2}         # One or two digits
+        (
+            \.\d+       # Period and one or more digits
+        )+              # One or more occurrences
+        (
+            -[a-zA-Z0-9]+   # Hyphen and one or more alphanumeric
+        )?              # Zero or one occurrence
+    )                   # One occurrence
+    """, re.VERBOSE)
+    match = version_regex.search(text)
     if match:
         return match.group(0)
     return 'unknown version'


### PR DESCRIPTION
The purpose of this change is to improve the maintainability of Meson module mesonbuild/environment.py by defining the regular expression used in search_version()
with a compiled verbose regular expression with line comments. This change should not
affect Meson functionality in any way.

Note: This is my very first PR of any kind on Github. All constructive advice is welcome.