### PR TITLE
docs: document that the .path() method for Python is new in 0.50 [skip ci]

### DIFF
--- a/docs/markdown/Python-module.md
+++ b/docs/markdown/Python-module.md
@@ -61,6 +61,17 @@ added methods.
 
 ### Methods
 
+#### `path()`
+
+```meson
+str py_installation.path()
+```
+
+*Added 0.50.0*
+
+Works like the path method of other `ExternalProgram` objects. Was not
+provided prior to 0.50.0 due to a bug.
+
 #### `extension_module()`
 
 ``` meson

--- a/docs/markdown/snippets/python-path-method.md
+++ b/docs/markdown/snippets/python-path-method.md
@@ -1,0 +1,5 @@
+## Added a .path() method to object return by python.find_installation()
+
+`ExternalProgram` objects as well as the object returned by the
+`python3` module provide this method, but the new python module did
+not.


### PR DESCRIPTION
Since this method was not included in 0.46-00.49 we should document that.