### PR TITLE
Relative paths pkgconfig

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -684,7 +684,11 @@ class PkgConfigDependency(ExternalDependency):
         raw_link_args = self._convert_mingw_paths(shlex.split(out_raw))
         for arg in raw_link_args:
             if arg.startswith('-L') and not arg.startswith(('-L-l', '-L-L')):
-                prefix_libpaths.add(arg[2:])
+                path = arg[2:]
+                if not os.path.isabs(path):
+                    # Resolve the path as a compiler in the build directory would
+                    path = os.path.join(self.env.get_build_dir(), path)
+                prefix_libpaths.add(path)
         system_libpaths = OrderedSet()
         full_args = self._convert_mingw_paths(shlex.split(out))
         for arg in full_args:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4822,6 +4822,23 @@ endian = 'little'
             subprocess.check_call(test_exe, env=myenv)
 
     @skipIfNoPkgconfig
+    def test_pkgconfig_relative_paths(self):
+        testdir = os.path.join(self.unit_test_dir, '58 pkgconfig relative paths')
+        pkg_dir = os.path.join(testdir, 'pkgconfig')
+        self.assertTrue(os.path.exists(os.path.join(pkg_dir, 'librelativepath.pc')))
+        os.environ['PKG_CONFIG_PATH'] = pkg_dir
+
+        env = get_fake_env(testdir, self.builddir, self.prefix)
+        kwargs = {'required': True, 'silent': True}
+        relative_path_dep = PkgConfigDependency('librelativepath', env, kwargs)
+        self.assertTrue(relative_path_dep.found())
+
+        # Ensure link_args are properly quoted
+        libpath = Path(self.builddir) / '../relativepath/lib'
+        link_args = ['-L' + libpath.as_posix(), '-lrelativepath']
+        self.assertEqual(relative_path_dep.get_link_args(), link_args)
+
+    @skipIfNoPkgconfig
     def test_pkgconfig_internal_libraries(self):
         '''
         '''

--- a/test cases/unit/58 pkgconfig relative paths/pkgconfig/librelativepath.pc
+++ b/test cases/unit/58 pkgconfig relative paths/pkgconfig/librelativepath.pc
@@ -1,0 +1,9 @@
+prefix=../relativepath
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+
+Name: Relative path
+Description: Relative path library
+Version: 0.0.1
+Libs: -L${libdir} -lrelativepath
+Cflags:


### PR DESCRIPTION
This pull request adds a patch made by @nirbheek to handle relative paths in pkgconfig files and the specific unit test.