### PR TITLE
build: Handle EOFError and AttributeError like coredata

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2307,8 +2307,13 @@ def load(build_dir):
             obj = pickle.load(f)
     except FileNotFoundError:
         raise MesonException(nonexisting_fail_msg)
-    except pickle.UnpicklingError:
+    except (pickle.UnpicklingError, EOFError):
         raise MesonException(load_fail_msg)
+    except AttributeError:
+        raise MesonException(
+            "Build data file {!r} references functions or classes that don't "
+            "exist. This probably means that it was generated with an old "
+            "version of meson. Try running meson {} --wipe".format(filename, build_dir))
     if not isinstance(obj, Build):
         raise MesonException(load_fail_msg)
     return obj


### PR DESCRIPTION
We've done this for coredata, just build builddata. There's some other data files, and really it would be nice to share a single serializer/deserializer pair for all of them.

This also doesn't cause an automatic rebuild, which should also be fixed, but it does

Fixes #5056