### PR TITLE
RFC: Add support for loading meson options from a cross/native file

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -527,7 +527,7 @@ class CoreData:
 
     def set_default_options(self, default_options, subproject, env):
         # Set defaults first from conf files (cross or native), then
-        # override them as nec as necessary.
+        # override them as necessary.
         for k, v in env.paths.host:
             if v is not None:
                 env.cmd_line_options.setdefault(k, v)

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -532,6 +532,10 @@ class CoreData:
             if v is not None:
                 env.cmd_line_options.setdefault(k, v)
 
+        # Do the same thing for meson level options
+        for k, v in env.meson_options.host.items():
+            env.cmd_line_options.setdefault(k, v)
+
         # Set default options as if they were passed to the command line.
         # Subprojects can only define default for user options.
         from . import optinterpreter

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -388,11 +388,16 @@ class Environment:
         # architecture, just the build and host architectures
         self.paths = PerMachineDefaultable()
 
+        # Store meson level options from the host/native files.
+        self.meson_options = PerMachineDefaultable()
+        self.meson_options.build = {}
+
         if self.coredata.config_files is not None:
             config = MesonConfigFile.from_config_parser(
                 coredata.load_configs(self.coredata.config_files))
             self.binaries.build = BinaryTable(config.get('binaries', {}))
             self.paths.build = Directories(**config.get('paths', {}))
+            self.meson_options.build = config.get('meson options', {})
 
         if self.coredata.cross_file is not None:
             config = MesonConfigFile.parse_datafile(self.coredata.cross_file)
@@ -403,11 +408,13 @@ class Environment:
             if 'target_machine' in config:
                 self.machines.target = MachineInfo.from_literal(config['target_machine'])
             self.paths.host = Directories(**config.get('paths', {}))
+            self.meson_options.host = config.get('meson options', {})
 
         self.machines.default_missing()
         self.binaries.default_missing()
         self.properties.default_missing()
         self.paths.default_missing()
+        self.meson_options.default_missing()
 
         exe_wrapper = self.binaries.host.lookup_entry('exe_wrapper')
         if exe_wrapper is not None:

--- a/test cases/common/216 meson options in file/meson.build
+++ b/test cases/common/216 meson options in file/meson.build
@@ -1,0 +1,15 @@
+project(
+  'native file install dir override',
+  default_options : ['default_library=static'],
+)
+
+if meson.is_cross_build()
+  error('MESON_SKIP_TEST cannot test native build rules in cross build')
+endif
+
+assert(get_option('buildtype') == 'release', 'buildtype not changed')
+assert(get_option('strip') == true, 'strip not changed')
+assert(get_option('unity') == 'on', 'unity not changed')
+assert(get_option('werror') == false, 'werror not changed')
+assert(get_option('default_library') == 'both', 'default_library not changed')
+assert(get_option('auto_features').disabled(), 'autofeatures not changed')

--- a/test cases/common/216 meson options in file/nativefile.ini
+++ b/test cases/common/216 meson options in file/nativefile.ini
@@ -1,0 +1,7 @@
+[meson options]
+buildtype = 'release'
+strip = 'true'
+unity = 'on'
+werror = 'false'
+default_library = 'both'
+auto_features = 'disabled'


### PR DESCRIPTION
This adds support to the native file and cross file for a `[meson options]` section, which allows any option that is a builtin meson option to be set. None of this allows project level arguments to be set, that'll come after this.

I've marked this RFC because I haven't gotten around to writing the snippet for the release yet.