### PR TITLE
Update Built-in Option c_std for C17. Closes #4842

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -112,7 +112,7 @@ compiler being used:
 | ------       | ------------- | ---------------                          | ----------- |
 | c_args       |               | free-form comma-separated list           | C compile arguments to use |
 | c_link_args  |               | free-form comma-separated list           | C link arguments to use |
-| c_std        | none          | none, c89, c99, c11, gnu89, gnu99, gnu11 | C language standard to use |
+| c_std        | none          | none, c89, c99, c11, c17, c18, gnu89, gnu99, gnu11, gnu17, gnu18 | C language standard to use |
 | c_winlibs    | see below     | free-form comma-separated list           | Standard Windows libs to link against |
 | cpp_args     |               | free-form comma-separated list           | C++ compile arguments to use |
 | cpp_link_args|               | free-form comma-separated list           | C++ link arguments to use |

--- a/docs/markdown/Configuring-a-build-directory.md
+++ b/docs/markdown/Configuring-a-build-directory.md
@@ -60,7 +60,7 @@ sample output for a simple project.
       ------        ------------- ---------------                                                                                               -----------
       c_args        []                                                                                                                          Extra arguments passed to the C compiler
       c_link_args   []                                                                                                                          Extra arguments passed to the C linker
-      c_std         c99           [none, c89, c99, c11, gnu89, gnu99, gnu11]                                                                    C language standard to use
+      c_std         c99           [none, c89, c99, c11, c17, c18, gnu89, gnu99, gnu11, gnu17, gnu18]                                                                    C language standard to use
       cpp_args      []                                                                                                                          Extra arguments passed to the C++ compiler
       cpp_debugstl  false         [true, false]                                                                                                 STL debug mode
       cpp_link_args []                                                                                                                          Extra arguments passed to the C++ linker

--- a/docs/markdown/snippets/add_release_note_snippets_here
+++ b/docs/markdown/snippets/add_release_note_snippets_here
@@ -1,3 +1,6 @@
 ## Added `cpp_std` option for the Visual Studio C++ compiler
 Allows the use of C++17 features and experimental not-yet-standardized
 features. Valid options are `c++11`, `c++14`, `c++17`, and `c++latest`.
+## Added c_std values 'c17' and 'c18' for recent GCC and Clang versions
+For gcc >=8.0.0 allow c_std='c17' 'c18' 'gnu17' 'gnu18'.
+For clang >=7.0.0 allow c_std='c17' 'gnu17'.

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1220,9 +1220,13 @@ class ClangCCompiler(ClangCompiler, CCompiler):
 
     def get_options(self):
         opts = CCompiler.get_options(self)
+        c_stds = ['c89', 'c99', 'c11']
+        g_stds = ['gnu89', 'gnu99', 'gnu11']
+        if version_compare(self.version, '>=7.0.0'):
+            c_stds += ['c17']
+            g_stds += ['gnu17']
         opts.update({'c_std': coredata.UserComboOption('c_std', 'C language standard to use',
-                                                       ['none', 'c89', 'c99', 'c11',
-                                                        'gnu89', 'gnu99', 'gnu11'],
+                                                       ['none'] + c_stds + g_stds,
                                                        'none')})
         return opts
 
@@ -1284,9 +1288,13 @@ class GnuCCompiler(GnuCompiler, CCompiler):
 
     def get_options(self):
         opts = CCompiler.get_options(self)
+        c_stds = ['c89', 'c99', 'c11']
+        g_stds = ['gnu89', 'gnu99', 'gnu11']
+        if version_compare(self.version, '>=8.0.0'):
+            c_stds += ['c17','c18']
+            g_stds += ['gnu17','gnu18']
         opts.update({'c_std': coredata.UserComboOption('c_std', 'C language standard to use',
-                                                       ['none', 'c89', 'c99', 'c11',
-                                                        'gnu89', 'gnu99', 'gnu11'],
+                                                       ['none'] + c_stds + g_stds,
                                                        'none')})
         if self.compiler_type.is_windows_compiler:
             opts.update({

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1291,8 +1291,8 @@ class GnuCCompiler(GnuCompiler, CCompiler):
         c_stds = ['c89', 'c99', 'c11']
         g_stds = ['gnu89', 'gnu99', 'gnu11']
         if version_compare(self.version, '>=8.0.0'):
-            c_stds += ['c17','c18']
-            g_stds += ['gnu17','gnu18']
+            c_stds += ['c17', 'c18']
+            g_stds += ['gnu17', 'gnu18']
         opts.update({'c_std': coredata.UserComboOption('c_std', 'C language standard to use',
                                                        ['none'] + c_stds + g_stds,
                                                        'none')})

--- a/test cases/unit/59 add c17 to c_std/meson.build
+++ b/test cases/unit/59 add c17 to c_std/meson.build
@@ -1,0 +1,34 @@
+project('test_c_std','c')
+#
+# Test GCC or Clang for all values of c_std which
+# the native compiler version and Meson support.
+#
+co = meson.get_compiler('c')
+cid = co.get_id()
+c_version = co.version()
+message('Compiler is ' + cid + ' ' + c_version)
+c_stds = []
+g_stds = []
+if cid == 'gcc'
+    c_stds = ['c89','c99','c11']
+    g_stds = ['gnu89','gnu99','gnu11']
+    if c_version.version_compare('>=8.0.0')
+        c_stds += ['c17','c18']
+        g_stds += ['gnu17','gnu18']
+    endif
+elif cid == 'clang'
+    c_stds = ['c89','c99','c11']
+    g_stds = ['gnu89','gnu99','gnu11']
+    if c_version.version_compare('>=7.0.0')
+        c_stds += ['c17']
+        g_stds += ['gnu17']
+    endif
+endif
+stds = c_stds + g_stds
+foreach std : stds
+    message('Testing '+cid+' -std='+std)
+    e = executable('test-'+cid+'-'+std, 'read_env.c',
+        override_options : ['c_std='+std])
+    test('Test '+cid+' -std='+std, e,
+        env : ['_compiler='+cid,'_std='+std])
+endforeach

--- a/test cases/unit/59 add c17 to c_std/read_env.c
+++ b/test cases/unit/59 add c17 to c_std/read_env.c
@@ -1,0 +1,20 @@
+/* Print the values of environment variables _compiler and _std. */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc,char **argv) {
+    if (getenv("_compiler") == NULL || getenv("_std") == NULL) {
+        printf("ERROR   : Test failed\n");
+        exit(1);
+    } else {
+#if defined(__STDC_VERSION__)
+        printf("NOTICE  : Test using %s -std=%s passed, __STDC_VERSION__=%ldL\n",
+            getenv("_compiler"), getenv("_std"), __STDC_VERSION__);
+#else
+        printf("NOTICE  : Test using %s -std=%s passed, standard=%s\n",
+            getenv("_compiler"), getenv("_std"), "ANSI-X3.159-1989");
+#endif
+        exit(0);
+    }
+}


### PR DESCRIPTION
This change updates the allowed values for built-in compiler option c_std to add new C standards supported by recent versions of GCC and Clang. The change to functionality is in the mesonbuild/compilers/c.py module.

For clang >=7.0.0 allow new values 'c17' and 'gnu17'.
For gcc >=8.0.0 allow new values 'c17', 'c18', 'gnu17', and 'gnu18'.

Updates are made to the two relevant sections of the manual. A snippet for the release notes is added to add_release_note_snippets_here.  A unit test is added which demonstrates use of the new c_std values with Clang and GCC, assuming the test is run with recent enough compilers to enable them. To guard against regressions, the test also exercises the preexisting values of c_std.

The C17/C18 standard is a corrections-only update. In fact, according to the GCC 8 manual, specifying option -std=c17 doesn't provide anything more than -std=c11, since the C17/C18 corrections are applied for -std=c11 as well. However, there are going to be Meson users out there (I'm one) who want to "make sure" they're getting the latest standard support. This change will allow them to do so using the built-in c_std option.

I did a quick survey of other C compilers supported by Meson, and Clang and GCC appear to be the only ones that provide specification of the C17/C18 standard via a command-line option.

