### PR TITLE
compilers: Try harder to dedup builtin libs  

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -911,8 +911,10 @@ class CCompiler(Compiler):
         priority
         '''
         stlibext = ['a']
-        # We've always allowed libname to be both `foo` and `libfoo`,
-        # and now people depend on it
+        # We've always allowed libname to be both `foo` and `libfoo`, and now
+        # people depend on it. Also, some people use prebuilt `foo.so` instead
+        # of `libfoo.so` for unknown reasons, and may also want to create
+        # `foo.so` by setting name_prefix to ''
         if strict and not isinstance(self, VisualStudioCCompiler): # lib prefix is not usually used with msvc
             prefixes = ['lib']
         else:

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -35,6 +35,7 @@ from .compilers import (
     get_largefile_args,
     gnu_winlibs,
     msvc_winlibs,
+    unixy_compiler_internal_libs,
     vs32_instruction_set_args,
     vs64_instruction_set_args,
     ArmCompiler,
@@ -52,8 +53,6 @@ from .compilers import (
     CcrxCompiler,
 )
 
-gnu_compiler_internal_libs = ('m', 'c', 'pthread', 'dl', 'rt')
-
 
 class CCompiler(Compiler):
     # TODO: Replace this manual cache with functools.lru_cache
@@ -61,7 +60,7 @@ class CCompiler(Compiler):
     program_dirs_cache = {}
     find_library_cache = {}
     find_framework_cache = {}
-    internal_libs = gnu_compiler_internal_libs
+    internal_libs = unixy_compiler_internal_libs
 
     @staticmethod
     def attribute_check_func(name):
@@ -1375,7 +1374,7 @@ class IntelCCompiler(IntelCompiler, CCompiler):
 class VisualStudioCCompiler(CCompiler):
     std_warn_args = ['/W3']
     std_opt_args = ['/O2']
-    ignore_libs = gnu_compiler_internal_libs
+    ignore_libs = unixy_compiler_internal_libs
     internal_libs = ()
 
     crt_args = {'none': [],

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3893,7 +3893,7 @@ class WindowsTests(BasePlatformTests):
         if cc.get_argument_syntax() != 'msvc':
             raise unittest.SkipTest('Not using MSVC')
         # To force people to update this test, and also test
-        self.assertEqual(set(cc.ignore_libs), {'c', 'm', 'pthread', 'dl', 'rt'})
+        self.assertEqual(set(cc.ignore_libs), {'c', 'm', 'pthread', 'dl', 'rt', 'execinfo'})
         for l in cc.ignore_libs:
             self.assertEqual(cc.find_library(l, env, []), [])
 
@@ -5042,6 +5042,19 @@ endian = 'little'
             for line in f:
                 max_count = max(max_count, line.count(search_term))
         self.assertEqual(max_count, 1, 'Export dynamic incorrectly deduplicated.')
+
+    def test_compiler_libs_static_dedup(self):
+        testdir = os.path.join(self.unit_test_dir, '55 dedup compiler libs')
+        self.init(testdir)
+        build_ninja = os.path.join(self.builddir, 'build.ninja')
+        with open(build_ninja, 'r', encoding='utf-8') as f:
+            lines = f.readlines()
+        for lib in ('-ldl', '-lm', '-lc', '-lrt'):
+            for line in lines:
+                if lib not in line:
+                    continue
+                # Assert that
+                self.assertEqual(len(line.split(lib)), 2, msg=(lib, line))
 
 
 def should_run_cross_arm_tests():

--- a/test cases/unit/55 dedup compiler libs/app/app.c
+++ b/test cases/unit/55 dedup compiler libs/app/app.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <liba.h>
+#include <libb.h>
+
+int
+main(void)
+{
+  printf("start value = %d\n", liba_get());
+  liba_add(2);
+  libb_mul(5);
+  printf("end value = %d\n", liba_get());
+  return 0;
+}

--- a/test cases/unit/55 dedup compiler libs/app/meson.build
+++ b/test cases/unit/55 dedup compiler libs/app/meson.build
@@ -1,0 +1,2 @@
+executable('app', 'app.c',
+  dependencies: [liba_dep, libb_dep])

--- a/test cases/unit/55 dedup compiler libs/liba/liba.c
+++ b/test cases/unit/55 dedup compiler libs/liba/liba.c
@@ -1,0 +1,18 @@
+#include "liba.h"
+
+static int val;
+
+void liba_add(int x)
+{
+  val += x;
+}
+
+void liba_sub(int x)
+{
+  val -= x;
+}
+
+int liba_get(void)
+{
+  return val;
+}

--- a/test cases/unit/55 dedup compiler libs/liba/liba.h
+++ b/test cases/unit/55 dedup compiler libs/liba/liba.h
@@ -1,0 +1,8 @@
+#ifndef LIBA_H_
+#define LIBA_H_
+
+void liba_add(int x);
+void liba_sub(int x);
+int liba_get(void);
+
+#endif

--- a/test cases/unit/55 dedup compiler libs/liba/meson.build
+++ b/test cases/unit/55 dedup compiler libs/liba/meson.build
@@ -1,0 +1,8 @@
+deps = [dependency('threads'), cc.find_library('dl'), cc.find_library('m')]
+
+liba = library('a', 'liba.c',
+  dependencies: deps)
+
+liba_dep = declare_dependency(link_with: liba,
+  include_directories: include_directories('.'),
+  dependencies: deps)

--- a/test cases/unit/55 dedup compiler libs/libb/libb.c
+++ b/test cases/unit/55 dedup compiler libs/libb/libb.c
@@ -1,0 +1,7 @@
+#include <liba.h>
+#include "libb.h"
+
+void libb_mul(int x)
+{
+  liba_add(liba_get() * (x - 1));
+}

--- a/test cases/unit/55 dedup compiler libs/libb/libb.h
+++ b/test cases/unit/55 dedup compiler libs/libb/libb.h
@@ -1,0 +1,6 @@
+#ifndef _LIBB_H_
+#define _LIBB_H_
+
+void libb_mul(int x);
+
+#endif

--- a/test cases/unit/55 dedup compiler libs/libb/meson.build
+++ b/test cases/unit/55 dedup compiler libs/libb/meson.build
@@ -1,0 +1,6 @@
+libb = library('b', 'libb.c',
+  dependencies: liba_dep)
+
+libb_dep = declare_dependency(link_with: libb,
+  include_directories: include_directories('.'),
+  dependencies: liba_dep)

--- a/test cases/unit/55 dedup compiler libs/meson.build
+++ b/test cases/unit/55 dedup compiler libs/meson.build
@@ -1,0 +1,7 @@
+project('temp', 'c')
+
+cc = meson.get_compiler('c')
+
+subdir('liba')
+subdir('libb')
+subdir('app')


### PR DESCRIPTION
commit 8b065530f6aeebb8ad0af2c58a91c06db82d6491:
```
compilers: Try harder to dedup builtin libs
-ldl, -lm, -lpthread should always be de-duplicated, no matter what.
Closes https://github.com/mesonbuild/meson/issues/2150
```
commit a17ee513c46a1b6913c724a38504805e2a8e5f3b:
```
compilers: Update comment about library search patterns
```

Closes #2150 