### PR TITLE
compilers: -fsanitize is not supported on OpenBSD

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4230,6 +4230,8 @@ class LinuxlikeTests(BasePlatformTests):
     def test_generate_gir_with_address_sanitizer(self):
         if is_cygwin():
             raise unittest.SkipTest('asan not available on Cygwin')
+        if is_openbsd():
+            raise unittest.SkipTest('-fsanitize=address is not supported on OpenBSD')
 
         testdir = os.path.join(self.framework_test_dir, '7 gnome')
         self.init(testdir, ['-Db_sanitize=address', '-Db_lundef=false'])


### PR DESCRIPTION
OpenBSD doesn't have any support for the compiler sanitizers yet.
While this may change in the future, better fix test suite run in "failfast"
mode for now. This can be revisited once (if) we get support in the future.

* clang 7.0.1
$ make CFLAGS=-fsanitize=address foo
cc -fsanitize=address   -o foo foo.c
cc: error: unsupported option '-fsanitize=address' for target 'amd64-unknown-openbsd6.5'

* gcc 4.2.1
*** Error 1 in /tmp (<sys.mk>:85 'foo')
$ make CC=gcc CFLAGS=-fsanitize=address foo
gcc -fsanitize=address   -o foo foo.c
cc1: error: unrecognized command line option "-fsanitize=address"

* gcc 8.2.0
$ make CC=egcc CFLAGS=-fsanitize=address foo
egcc -fsanitize=address   -o foo foo.c
ld: error: unable to find library -lasan
collect2: error: ld returned 1 exit status