### PR TITLE
compilers: -fsanitize is not supported on OpenBSD (second pass)

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4697,6 +4697,8 @@ class LinuxlikeTests(BasePlatformTests):
     def test_pch_with_address_sanitizer(self):
         if is_cygwin():
             raise unittest.SkipTest('asan not available on Cygwin')
+        if is_openbsd():
+            raise unittest.SkipTest('-fsanitize=address is not supported on OpenBSD')
 
         testdir = os.path.join(self.common_test_dir, '13 pch')
         self.init(testdir, ['-Db_sanitize=address'])


### PR DESCRIPTION
Similar to https://github.com/mesonbuild/meson/pull/5067
This part was missed in my previous commit.