### PR TITLE
do not duplicate external dependencies in list

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1030,8 +1030,9 @@ This will become a hard error in a future Meson release.''')
                 # Deps of deps.
                 self.add_deps(dep.ext_deps)
             elif isinstance(dep, dependencies.Dependency):
-                self.external_deps.append(dep)
-                self.process_sourcelist(dep.get_sources())
+                if dep not in self.external_deps:
+                    self.external_deps.append(dep)
+                    self.process_sourcelist(dep.get_sources())
             elif isinstance(dep, BuildTarget):
                 raise InvalidArguments('''Tried to use a build target as a dependency.
 You probably should put it in link_with instead.''')


### PR DESCRIPTION
Since the "-l<lib>" flags in the build.ninja file are passed in
"--start-group"/"--end-group" flags, there should be no need to have any
library listed twice, even if there are circular dependencies. Therefore we
can eliminate duplicates. For speed, rather than deduplicating at the end
of the process, it's faster to not add the duplicate flags in the first
place.

This should help fix #2150 

