### PR TITLE
tests: disable Dlang tests on windows

### DIFF
--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -559,7 +559,7 @@ def detect_tests_to_run():
         ('C#', 'csharp', skip_csharp(backend)),
         ('vala', 'vala', backend is not Backend.ninja or not shutil.which('valac')),
         ('rust', 'rust', backend is not Backend.ninja or not shutil.which('rustc')),
-        ('d', 'd', backend is not Backend.ninja or not have_d_compiler()),
+        ('d', 'd', backend is not Backend.ninja or not have_d_compiler() or mesonlib.is_windows()),
         ('objective c', 'objc', backend not in (Backend.ninja, Backend.xcode) or mesonlib.is_windows() or not have_objc_compiler()),
         ('objective c++', 'objcpp', backend not in (Backend.ninja, Backend.xcode) or mesonlib.is_windows() or not have_objcpp_compiler()),
         ('fortran', 'fortran', backend is not Backend.ninja or not shutil.which('gfortran')),


### PR DESCRIPTION
These don't work and no one has fixed them. When I've tried to
download dmd for windows I can't get a valid installer from their
website. Let's at least turn the CI green.