### PR TITLE
i18n: Use CustomTarget.known_kwargs at permittedKwargs()

### DIFF
--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -64,8 +64,7 @@ class I18nModule(ExtensionModule):
         return [path.join(src_dir, d) for d in dirs]
 
     @FeatureNew('i18n.merge_file', '0.37.0')
-    @permittedKwargs({'languages', 'data_dirs', 'preset', 'args', 'po_dir', 'type',
-                      'input', 'output', 'install', 'install_dir'})
+    @permittedKwargs(build.CustomTarget.known_kwargs | {'data_dirs', 'po_dir', 'type'})
     def merge_file(self, state, args, kwargs):
         podir = kwargs.pop('po_dir', None)
         if not podir:


### PR DESCRIPTION
@permittedKwargs() is basically copying the logic of CustomTarget,
but it is not actually up to date, leading to warnings on perfectly
valid values such as 'build_by_default'.

Use CustomTarget.known_kwargs instead, and only append the specific
kwargs of i18n.merge_file().

Fixes #5079