### PR TITLE
Support multiple --cross-file options

### DIFF
--- a/docs/markdown/snippets/multiple-cross-files.md
+++ b/docs/markdown/snippets/multiple-cross-files.md
@@ -1,0 +1,3 @@
+## Multipe cross files can be specified
+
+`--cross-file` can be passed multiple times, with the configuration files overlaying the same way as `--native-file`.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -788,8 +788,7 @@ class Backend:
         deps = [os.path.join(self.build_to_src, df)
                 for df in self.interpreter.get_build_def_files()]
         if self.environment.is_cross_build():
-            deps.append(os.path.join(self.build_to_src,
-                                     self.environment.coredata.cross_file))
+            deps.extend(self.environment.coredata.cross_files)
         deps.append('meson-private/coredata.dat')
         if os.path.exists(os.path.join(self.environment.get_source_dir(), 'meson_options.txt')):
             deps.append(os.path.join(self.build_to_src, 'meson_options.txt'))

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -211,8 +211,8 @@ class UserFeatureOption(UserComboOption):
         return self.value == 'auto'
 
 
-def load_configs(filenames):
-    """Load native files."""
+def load_configs(filenames, subdir):
+    """Load configuration files from a named subdirectory."""
     def gen():
         for f in filenames:
             f = os.path.expanduser(os.path.expandvars(f))
@@ -225,7 +225,7 @@ def load_configs(filenames):
                     os.environ.get('XDG_DATA_HOME', os.path.expanduser('~/.local/share')),
                 ] + os.environ.get('XDG_DATA_DIRS', '/usr/local/share:/usr/share').split(':')
                 for path in paths:
-                    path_to_try = os.path.join(path, 'meson', 'native', f)
+                    path_to_try = os.path.join(path, 'meson', subdir, f)
                     if os.path.isfile(path_to_try):
                         yield path_to_try
                         break

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -265,7 +265,7 @@ class CoreData:
         self.compiler_options = PerMachine({}, {}, {})
         self.base_options = {}
         self.external_preprocess_args = PerMachine({}, {}, {}) # CPPFLAGS only
-        self.cross_file = self.__load_cross_file(options.cross_file)
+        self.cross_files = self.__load_config_files(options.cross_file)
         self.compilers = OrderedDict()
         self.cross_compilers = OrderedDict()
         self.deps = OrderedDict()
@@ -276,57 +276,19 @@ class CoreData:
 
     @staticmethod
     def __load_config_files(filenames):
+        # Need to try and make the passed filenames absolute because when the
+        # files are parsed later we'll have chdir()d.
         if not filenames:
             return []
         filenames = [os.path.abspath(os.path.expanduser(os.path.expanduser(f)))
                      for f in filenames]
         return filenames
 
-    @staticmethod
-    def __load_cross_file(filename):
-        """Try to load the cross file.
-
-        If the filename is None return None. If the filename is an absolute
-        (after resolving variables and ~), return that absolute path. Next,
-        check if the file is relative to the current source dir. If the path
-        still isn't resolved do the following:
-            Windows:
-                - Error
-            *:
-                - $XDG_DATA_HOME/meson/cross (or ~/.local/share/meson/cross if
-                  undefined)
-                - $XDG_DATA_DIRS/meson/cross (or
-                  /usr/local/share/meson/cross:/usr/share/meson/cross if undefined)
-                - Error
-
-        Non-Windows follows the Linux path and will honor XDG_* if set. This
-        simplifies the implementation somewhat.
-        """
-        if filename is None:
-            return None
-        filename = os.path.expanduser(os.path.expandvars(filename))
-        if os.path.isabs(filename):
-            return filename
-        path_to_try = os.path.abspath(filename)
-        if os.path.isfile(path_to_try):
-            return path_to_try
-        if sys.platform != 'win32':
-            paths = [
-                os.environ.get('XDG_DATA_HOME', os.path.expanduser('~/.local/share')),
-            ] + os.environ.get('XDG_DATA_DIRS', '/usr/local/share:/usr/share').split(':')
-            for path in paths:
-                path_to_try = os.path.join(path, 'meson', 'cross', filename)
-                if os.path.isfile(path_to_try):
-                    return path_to_try
-            raise MesonException('Cannot find specified cross file: ' + filename)
-
-        raise MesonException('Cannot find specified cross file: ' + filename)
-
     def libdir_cross_fixup(self):
         # By default set libdir to "lib" when cross compiling since
         # getting the "system default" is always wrong on multiarch
         # platforms as it gets a value like lib/x86_64-linux-gnu.
-        if self.cross_file is not None:
+        if self.cross_files:
             self.builtins['libdir'].value = 'lib'
 
     def sanitize_prefix(self, prefix):
@@ -642,8 +604,8 @@ def read_cmd_line_file(build_dir, options):
     options.cmd_line_options = d
 
     properties = config['properties']
-    if options.cross_file is None:
-        options.cross_file = properties.get('cross_file', None)
+    if not options.cross_file:
+        options.cross_file = ast.literal_eval(properties.get('cross_file', '[]'))
     if not options.native_file:
         # This will be a string in the form: "['first', 'second', ...]", use
         # literal_eval to get it into the list of strings.
@@ -654,7 +616,7 @@ def write_cmd_line_file(build_dir, options):
     config = CmdLineFileParser()
 
     properties = {}
-    if options.cross_file is not None:
+    if options.cross_file:
         properties['cross_file'] = options.cross_file
     if options.native_file:
         properties['native_file'] = options.native_file

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -408,7 +408,7 @@ class Environment:
 
         if self.coredata.config_files is not None:
             config = MesonConfigFile.from_config_parser(
-                coredata.load_configs(self.coredata.config_files))
+                coredata.load_configs(self.coredata.config_files, 'native'))
             self.binaries.build = BinaryTable(config.get('binaries', {}))
             self.paths.build = Directories(**config.get('paths', {}))
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -412,8 +412,9 @@ class Environment:
             self.binaries.build = BinaryTable(config.get('binaries', {}))
             self.paths.build = Directories(**config.get('paths', {}))
 
-        if self.coredata.cross_file is not None:
-            config = MesonConfigFile.parse_datafile(self.coredata.cross_file)
+        if self.coredata.cross_files:
+            config = MesonConfigFile.from_config_parser(
+                coredata.load_configs(self.coredata.cross_files, 'cross'))
             self.properties.host = Properties(config.get('properties', {}), False)
             self.binaries.host = BinaryTable(config.get('binaries', {}), False)
             if 'host_machine' in config:

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -29,7 +29,9 @@ from .mesonlib import MesonException
 
 def add_arguments(parser):
     coredata.register_builtin_arguments(parser)
-    parser.add_argument('--cross-file', default=None,
+    parser.add_argument('--cross-file',
+                        default=[],
+                        action='append',
                         help='File describing cross compilation environment.')
     parser.add_argument('--native-file',
                         default=[],

--- a/mesonbuild/munstable_coredata.py
+++ b/mesonbuild/munstable_coredata.py
@@ -81,8 +81,9 @@ def run(options):
             print('Last seen PKGCONFIG enviroment variable value: ' + v)
         elif k == 'version':
             print('Meson version: ' + v)
-        elif k == 'cross_file':
-            print('Cross File: ' + (v or 'None'))
+        elif k == 'cross_files':
+            if v:
+                print('Cross File: ' + ' '.join(v))
         elif k == 'config_files':
             if v:
                 print('Native File: ' + ' '.join(v))

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5871,6 +5871,25 @@ class CrossFileTests(BasePlatformTests):
                               '-Ddef_sharedstatedir=sharedstatebar',
                               '-Ddef_sysconfdir=sysconfbar'])
 
+    def test_cross_file_dirs_chain(self):
+        # crossfile2 overrides crossfile overrides nativefile
+        testcase = os.path.join(self.unit_test_dir, '57 native file override')
+        self.init(testcase, default_args=False,
+                  extra_args=['--native-file', os.path.join(testcase, 'nativefile'),
+                              '--cross-file', os.path.join(testcase, 'crossfile'),
+                              '--cross-file', os.path.join(testcase, 'crossfile2'),
+                              '-Ddef_bindir=binbar2',
+                              '-Ddef_datadir=databar',
+                              '-Ddef_includedir=includebar',
+                              '-Ddef_infodir=infobar',
+                              '-Ddef_libdir=libbar',
+                              '-Ddef_libexecdir=libexecbar',
+                              '-Ddef_localedir=localebar',
+                              '-Ddef_localstatedir=localstatebar',
+                              '-Ddef_mandir=manbar',
+                              '-Ddef_sbindir=sbinbar',
+                              '-Ddef_sharedstatedir=sharedstatebar',
+                              '-Ddef_sysconfdir=sysconfbar'])
 
 class TAPParserTests(unittest.TestCase):
     def assert_test(self, events, **kwargs):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -612,7 +612,7 @@ class InternalTests(unittest.TestCase):
         configfile.flush()
         configfile.close()
         opts = get_fake_options()
-        opts.cross_file = configfilename
+        opts.cross_file = (configfilename,)
         env = get_fake_env(opts=opts)
         detected_value = env.need_exe_wrapper()
         os.unlink(configfilename)
@@ -627,7 +627,7 @@ class InternalTests(unittest.TestCase):
         config.write(configfile)
         configfile.close()
         opts = get_fake_options()
-        opts.cross_file = configfilename
+        opts.cross_file = (configfilename,)
         env = get_fake_env(opts=opts)
         forced_value = env.need_exe_wrapper()
         os.unlink(configfilename)

--- a/test cases/unit/57 native file override/crossfile2
+++ b/test cases/unit/57 native file override/crossfile2
@@ -1,0 +1,4 @@
+[paths]
+bindir = 'binbar2'
+
+; vim: ft=dosini


### PR DESCRIPTION
Allow multiple --cross-file options, just like multiple --native-file options
are allowed.  The use-case for this is a centralised cross file for the
compiler, and then a cross file setting project-specific options.

Change coredata.cross_file (string) to coredata.cross_files (list of strings),
and update users appropriately.  Apart from the search path logic which is
untouched, the logic mostly mirrors coredata.config_files.

Also update run_unittests as it constructs a fake Environment so needs to set a
list-of-strings now.

Fixes #3518.