### PR TITLE
compilers: respect cross-file linker flags in sanity checks (fixes #5086)

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -321,6 +321,8 @@ class CCompiler(Compiler):
                 # a ton of compiler flags to differentiate between
                 # arm and x86_64. So just compile.
                 extra_flags += self.get_compile_only_args()
+            else:
+                extra_flags += environment.coredata.get_external_link_args(MachineChoice.HOST, self.language)
         # Is a valid executable output for all toolchains and platforms
         binname += '.exe'
         # Write binary check source


### PR DESCRIPTION
Builds with Meson 0.50.0 fail in this special case:

```
[binaries]
c = '.../arm-unknown-linux-uclibcgnueabi/bin/arm-unknown-linux-uclibcgnueabi-gcc'
...

[binaries]
exe_wrapper = 'qemu-arm-static'
...

[properties]
c_link_args = ['-static']
...
```

The sanity check output is not a static binary, as it used (and expected to be)
with Meson < 0.50.0. The crosstool-ng built uClibc is not present in the
build machine's /lib, so the sanity check fails.

This bug was introduced in d451a4.

Signed-off-by: Dima Krasner <dima@dimakrasner.com>

Relevant parts of the log:
```
Is cross compiler: True.
Sanity check compiler command line: .../arm-unknown-linux-uclibcgnueabi-gcc .../sanitycheckc.c -o .../meson-private/sanitycheckc_cross.exe
```
(notice the lack of `-static`)

The result of running the faulty executable:
```
.../meson-private/sanitycheckc_cross.exe
/lib/ld-uClibc.so.0: No such file or directory
```