### PR TITLE
azure: Unset BOOST_ROOT for Cygwin, MSYS2 and clang-cl

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,6 +86,7 @@ jobs:
         zlib-devel
       displayName: Install Dependencies
     - script: |
+        set BOOST_ROOT=
         set PATH=%CYGWIN_ROOT%\bin;%SYSTEMROOT%\system32
         cp /usr/bin/python3.5 /usr/bin/python3
         env.exe -- python3 run_tests.py --backend=ninja
@@ -150,6 +151,7 @@ jobs:
         %TOOLCHAIN%
       displayName: Install Dependencies
     - script: |
+        set BOOST_ROOT=
         set PATH=%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem
         set PATHEXT=%PATHEXT%;.py
         if %compiler%==clang ( set CC=clang && set CXX=clang++ )

--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -71,6 +71,8 @@ steps:
        Start-Process "boost_$boost_filename-msvc-$boost_abi_tag-$boost_bitness.exe" -ArgumentList "/dir=$(System.WorkFolder)\boost_$boost_filename /silent" -Wait
        $env:BOOST_ROOT = "$(System.WorkFolder)\boost_$boost_filename"
        $env:Path = "$env:Path;$env:BOOST_ROOT\lib$boost_bitness-msvc-$boost_abi_tag"
+     } else {
+       $env:BOOST_ROOT = ""
      }
 
      # install D compiler and dub packages


### PR DESCRIPTION
It looks like BOOST_ROOT is now set in the azure v2017 image (relevant change seems to be [1], pre-installing boost)

Remove BOOST_ROOT from the environment to prevent attempting to use a boost which is incompatible with the compiler.

[1] https://github.com/Microsoft/azure-pipelines-image-generation/pull/732
