### PR TITLE
Fix #5049

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -341,13 +341,13 @@ class GnomeModule(ExtensionModule):
 
             target_o3 = GResourceObjectTarget(args[0] + '3_o', state.subdir, state.subproject, o3_kwargs)
 
-            rv1 = [target_c, target_h, target_o3]
+            rv1 = [[target_c, target_o3], target_h]
             if target_g.get_id() not in self.interpreter.build.targets:
                 rv2 = rv1 + [target_g, target_o, target_o2]
             else:
                 rv2 = rv1 + [target_o, target_o2]
         else:
-            rv1 = [target_c, target_h, target_o2]
+            rv1 = [[target_c, target_o2], target_h]
             if target_g.get_id() not in self.interpreter.build.targets:
                 rv2 = rv1 + [target_g, target_o]
             else:


### PR DESCRIPTION
With https://github.com/mesonbuild/meson/pull/4222 compile_resources
returns `[c_file, header_file, object_file]` if glib version is >= 2.60
Which breaks for tracker, nautilus and gedit because they handle the
c file and header file separately and don't handle the object file at all. 
(See https://github.com/mesonbuild/meson/issues/5049)
With this commit it returns `[[c_file, object_file], header_file]` which works in these cases.