### PR TITLE
replace library type strings with an enum

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -31,7 +31,7 @@ from .. import dependencies
 from .. import compilers
 from ..compilers import CompilerArgs, CCompiler, VisualStudioCCompiler, FortranCompiler
 from ..linkers import ArLinker
-from ..mesonlib import File, MachineChoice, MesonException, OrderedSet
+from ..mesonlib import File, MachineChoice, MesonException, OrderedSet, LibType
 from ..mesonlib import get_compiler_for_source, has_path_sep
 from .backends import CleanTrees
 from ..build import InvalidArguments
@@ -2401,8 +2401,8 @@ rule FORTRAN_DEP_HACK%s
         # TODO The get_library_naming requirement currently excludes link targets that use d or fortran as their main linker
         if hasattr(linker, 'get_library_naming'):
             search_dirs = tuple(search_dirs) + linker.get_library_dirs(self.environment)
-            static_patterns = linker.get_library_naming(self.environment, 'static', strict=True)
-            shared_patterns = linker.get_library_naming(self.environment, 'shared', strict=True)
+            static_patterns = linker.get_library_naming(self.environment, LibType.STATIC, strict=True)
+            shared_patterns = linker.get_library_naming(self.environment, LibType.SHARED, strict=True)
             for libname in libs:
                 # be conservative and record most likely shared and static resolution, because we don't know exactly
                 # which one the linker will prefer

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -31,7 +31,7 @@ from .compilers import (
     PGICompiler
 )
 
-from mesonbuild.mesonlib import EnvironmentException, is_osx
+from mesonbuild.mesonlib import EnvironmentException, is_osx, LibType
 
 
 class FortranCompiler(Compiler):
@@ -241,7 +241,7 @@ class FortranCompiler(Compiler):
     def find_library_impl(self, *args):
         return CCompiler.find_library_impl(self, *args)
 
-    def find_library(self, libname, env, extra_dirs, libtype='shared-static'):
+    def find_library(self, libname, env, extra_dirs, libtype: LibType = LibType.PREFER_SHARED):
         code = '''program main
             call exit(0)
         end program main'''

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -36,7 +36,7 @@ from ..compilers import clib_langs
 from ..environment import BinaryTable, Environment, MachineInfo
 from ..mesonlib import MachineChoice, MesonException, OrderedSet, PerMachine
 from ..mesonlib import Popen_safe, version_compare_many, version_compare, listify
-from ..mesonlib import Version
+from ..mesonlib import Version, LibType
 
 # These must be defined in this file to avoid cyclical references.
 packages = {}
@@ -703,7 +703,7 @@ class PkgConfigDependency(ExternalDependency):
         libs_found = OrderedSet()
         # Track not-found libraries to know whether to add library paths
         libs_notfound = []
-        libtype = 'static' if self.static else 'shared-static'
+        libtype = LibType.STATIC if self.static else LibType.PREFER_SHARED
         # Generate link arguments for this library
         link_args = []
         for lib in full_args:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1493,11 +1493,11 @@ class CompilerHolder(InterpreterObject):
         for i in search_dirs:
             if not os.path.isabs(i):
                 raise InvalidCode('Search directory %s is not an absolute path.' % i)
-        libtype = 'shared-static'
+        libtype = mesonlib.LibType.PREFER_SHARED
         if 'static' in kwargs:
             if not isinstance(kwargs['static'], bool):
                 raise InterpreterException('static must be a boolean')
-            libtype = 'static' if kwargs['static'] else 'shared'
+            libtype = mesonlib.LibType.STATIC if kwargs['static'] else mesonlib.LibType.SHARED
         linkargs = self.compiler.find_library(libname, self.environment, search_dirs, libtype)
         if required and not linkargs:
             raise InterpreterException(

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -1274,3 +1274,13 @@ def relpath(path, start):
         return os.path.relpath(path, start)
     except ValueError:
         return path
+
+
+class LibType(Enum):
+
+    """Enumeration for library types."""
+
+    SHARED = 0
+    STATIC = 1
+    PREFER_SHARED = 2
+    PREFER_STATIC = 3

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -47,7 +47,7 @@ from mesonbuild.ast import AstInterpreter
 from mesonbuild.mesonlib import (
     is_windows, is_osx, is_cygwin, is_dragonflybsd, is_openbsd, is_haiku,
     windows_proof_rmtree, python_command, version_compare,
-    BuildDirLock, Version, PerMachine
+    BuildDirLock, Version, PerMachine, LibType
 )
 from mesonbuild.environment import detect_ninja
 from mesonbuild.mesonlib import MesonException, EnvironmentException
@@ -702,13 +702,13 @@ class InternalTests(unittest.TestCase):
         stc = patterns[platform]['static']
         shrstc = shr + tuple([x for x in stc if x not in shr])
         stcshr = stc + tuple([x for x in shr if x not in stc])
-        p = cc.get_library_naming(env, 'shared')
+        p = cc.get_library_naming(env, LibType.SHARED)
         self.assertEqual(p, shr)
-        p = cc.get_library_naming(env, 'static')
+        p = cc.get_library_naming(env, LibType.STATIC)
         self.assertEqual(p, stc)
-        p = cc.get_library_naming(env, 'static-shared')
+        p = cc.get_library_naming(env, LibType.PREFER_STATIC)
         self.assertEqual(p, stcshr)
-        p = cc.get_library_naming(env, 'shared-static')
+        p = cc.get_library_naming(env, LibType.PREFER_SHARED)
         self.assertEqual(p, shrstc)
         # Test find library by mocking up openbsd
         if platform != 'openbsd':
@@ -724,7 +724,7 @@ class InternalTests(unittest.TestCase):
                 f.write('')
             with open(os.path.join(tmpdir, 'libfoo.so.70.0.so.1'), 'w') as f:
                 f.write('')
-            found = cc.find_library_real('foo', env, [tmpdir], '', 'shared-static')
+            found = cc.find_library_real('foo', env, [tmpdir], '', LibType.PREFER_SHARED)
             self.assertEqual(os.path.basename(found[0]), 'libfoo.so.54.0')
 
     def test_find_library_patterns(self):


### PR DESCRIPTION
This patch creates an enum for selecting libtype as static, shared,
prefer-static, or prefer-shared. This also renames 'static-shared'
with 'prefer_static' and 'shared-static' with 'prefer_shared'. This is
just a refactor with no behavioral changes or user facing changes.