### PR TITLE
dependencies/openmp: Don't special case OpenMP

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -641,8 +641,6 @@ class Backend:
             # pkg-config puts the thread flags itself via `Cflags:`
             if dep.need_threads():
                 commands += compiler.thread_flags(self.environment)
-            elif dep.need_openmp():
-                commands += compiler.openmp_flags()
         # Fortran requires extra include directives.
         if compiler.language == 'fortran':
             for lt in target.link_targets:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2494,7 +2494,6 @@ rule FORTRAN_DEP_HACK%s
             # For 'automagic' deps: Boost and GTest. Also dependency('threads').
             # pkg-config puts the thread flags itself via `Cflags:`
             need_threads = False
-            need_openmp = False
 
             commands += target.link_args
             # External deps must be last because target link libraries may depend on them.
@@ -2503,15 +2502,11 @@ rule FORTRAN_DEP_HACK%s
                 # https://github.com/mesonbuild/meson/issues/1718
                 commands.extend_preserving_lflags(dep.get_link_args())
                 need_threads |= dep.need_threads()
-                need_openmp |= dep.need_openmp()
             for d in target.get_dependencies():
                 if isinstance(d, build.StaticLibrary):
                     for dep in d.get_external_deps():
                         need_threads |= dep.need_threads()
-                        need_openmp |= dep.need_openmp()
                         commands.extend_preserving_lflags(dep.get_link_args())
-            if need_openmp:
-                commands += linker.openmp_flags()
             if need_threads:
                 commands += linker.thread_link_flags(self.environment)
 

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -410,8 +410,6 @@ class CCompiler(Compiler):
             args += d.get_compile_args()
             if d.need_threads():
                 args += self.thread_flags(env)
-            elif d.need_openmp():
-                args += self.openmp_flags()
             if mode == 'link':
                 # Add link flags needed to find dependencies
                 args += d.get_link_args()

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -152,9 +152,6 @@ class Dependency:
     def get_exe_args(self, compiler):
         return []
 
-    def need_openmp(self):
-        return False
-
     def need_threads(self):
         return False
 

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -363,7 +363,8 @@ class OpenMPDependency(ExternalDependency):
         super().__init__('openmp', environment, language, kwargs)
         self.is_found = False
         try:
-            openmp_date = self.clib_compiler.get_define('_OPENMP', '', self.env, [], [self])
+            openmp_date = self.clib_compiler.get_define(
+                '_OPENMP', '', self.env, self.clib_compiler.openmp_flags(), [self])
         except mesonlib.EnvironmentException as e:
             mlog.debug('OpenMP support not available in the compiler')
             mlog.debug(e)

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -374,11 +374,9 @@ class OpenMPDependency(ExternalDependency):
             self.version = self.VERSIONS[openmp_date]
             if self.clib_compiler.has_header('omp.h', '', self.env, dependencies=[self]):
                 self.is_found = True
+                self.compile_args = self.link_args = self.clib_compiler.openmp_flags()
             else:
                 mlog.log(mlog.yellow('WARNING:'), 'OpenMP found but omp.h missing.')
-
-    def need_openmp(self) -> bool:
-        return True
 
 
 class ThreadDependency(ExternalDependency):


### PR DESCRIPTION
Currently we specialcase OpenMP like we do threads, with a special
`need_openmp` method. This seems like a great idea, but doesn't work
out in practice, as well as it complicates the opemp
implementation. If GCC is built without opemp support for example, we
still add -fopenmp to the the command line, which results in
compilation errors.

This patch discards that and treats it like a normal dependency,
removes the need_openmp() method, and sets the compile_args attributes
from the compiler.

Fixes #5115