### PR TITLE
find_program: use Meson's Python3 for non-executable Python scripts

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1993,6 +1993,12 @@ class ExternalProgram:
                     # We know what python3 is, we're running on it
                     if len(commands) > 0 and commands[0] == 'python3':
                         commands = mesonlib.python_command + commands[1:]
+                else:
+                    # Replace python3 with the actual python3 that we are using
+                    if commands[0] == '/usr/bin/env' and commands[1] == 'python3':
+                        commands = mesonlib.python_command + commands[2:]
+                    elif commands[0].split('/')[-1] == 'python3':
+                        commands = mesonlib.python_command + commands[1:]
                 return commands + [script]
         except Exception as e:
             mlog.debug(e)


### PR DESCRIPTION
Whenever a non-executable Python script is found by find_program, currently Haiku and Windows replace a python3 from the shebang line with the one that was used by Meson.  Extend this behavior to POSIX systems so that it is easy to test a program with multiple Python versions.

Currently this is particularly important for generators, because they don't allow files in the arguments and thus you cannot do something like `generator(pymod.find_installation(), ..., arguments: [files('myscript.py'), ...])`. With this patch you can just do `generator(find_program('myscript.py'), ...`.