### PR TITLE
Script found by find_program() does not end up in dependencies

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1746,7 +1746,7 @@ rule FORTRAN_DEP_HACK%s
         exe_arr = self.exe_object_to_cmd_array(exe)
         infilelist = genlist.get_inputs()
         outfilelist = genlist.get_outputs()
-        extra_dependencies = [os.path.join(self.build_to_src, i) for i in genlist.extra_depends]
+        extra_dependencies = self.get_custom_target_depend_files(genlist)
         for i in range(len(infilelist)):
             curfile = infilelist[i]
             if len(generator.outputs) == 1:

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -122,6 +122,7 @@ class Vs2010Backend(backends.Backend):
                         sole_output = ''
                     curfile = infilelist[i]
                     infilename = os.path.join(down, curfile.rel_to_builddir(self.build_to_src))
+                    deps = self.get_custom_target_depend_files(genlist, True)
                     base_args = generator.get_arglist(infilename)
                     outfiles_rel = genlist.get_outputs_for(curfile)
                     outfiles = [os.path.join(target_private_dir, of) for of in outfiles_rel]
@@ -152,6 +153,8 @@ class Vs2010Backend(backends.Backend):
                     cbs = ET.SubElement(idgroup, 'CustomBuild', Include=infilename)
                     ET.SubElement(cbs, 'Command').text = ' '.join(self.quote_arguments(cmd))
                     ET.SubElement(cbs, 'Outputs').text = ';'.join(outfiles)
+                    if deps:
+                        ET.SubElement(cbs, 'AdditionalInputs').text = ';'.join(deps)
         return generator_output_files, custom_target_output_files, custom_target_include_dirs
 
     def generate(self, interp):

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -503,7 +503,6 @@ class Vs2010Backend(backends.Backend):
 
     def gen_run_target_vcxproj(self, target, ofname, guid):
         root = self.create_basic_crap(target, guid)
-        action = ET.SubElement(root, 'ItemDefinitionGroup')
         cmd_raw = [target.command] + target.args
         cmd = python_command + \
             [os.path.join(self.environment.get_script_dir(), 'commandrunner.py'),

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1340,8 +1340,17 @@ class GeneratedList:
         self.outfilelist = []
         self.outmap = {}
         self.extra_depends = []
+        self.depend_files = []
         self.preserve_path_from = preserve_path_from
         self.extra_args = extra_args
+        if isinstance(generator.exe, dependencies.ExternalProgram):
+            if not generator.exe.found():
+                raise InvalidArguments('Tried to use not-found external program as generator')
+            path = generator.exe.get_path()
+            if os.path.isabs(path):
+                # Can only add a dependency on an external program which we
+                # know the absolute path of
+                self.depend_files.append(File.from_absolute_file(path))
 
     def add_preserved_path_segment(self, infile, outfiles, state):
         result = []
@@ -1932,8 +1941,7 @@ class CustomTarget(Target):
                 final_cmd.append(c)
             elif isinstance(c, dependencies.ExternalProgram):
                 if not c.found():
-                    m = 'Tried to use not-found external program {!r} in "command"'
-                    raise InvalidArguments(m.format(c.name))
+                    raise InvalidArguments('Tried to use not-found external program in "command"')
                 path = c.get_path()
                 if os.path.isabs(path):
                     # Can only add a dependency on an external program which we

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2095,6 +2095,20 @@ class AllPlatformTests(BasePlatformTests):
             self.utime(os.path.join(testdir, f))
             self.assertRebuiltTarget('prog')
 
+    def test_source_generator_program_cause_rebuild(self):
+        '''
+        Test that changes to generator programs in the source tree cause
+        a rebuild.
+        '''
+        testdir = os.path.join(self.common_test_dir, '95 gen extra')
+        self.init(testdir)
+        self.build()
+        # Immediately rebuilding should not do anything
+        self.assertBuildIsNoop()
+        # Changing mtime of generator should rebuild the executable
+        self.utime(os.path.join(testdir, 'srcgen.py'))
+        self.assertRebuiltTarget('basic')
+
     def test_static_library_lto(self):
         '''
         Test that static libraries can be built with LTO and linked to


### PR DESCRIPTION
If find_program() returns a file from the source directory, anything that uses it should add the file to the dependencies, so that they are rebuilt whenever the script changes. Meson generally handles this right, but not in generators.