### PR TITLE
envconfig: mingw is also Windows

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -207,7 +207,7 @@ class MachineInfo:
         """
         Machine is windows?
         """
-        return self.system == 'windows'
+        return self.system in {'windows', 'mingw'}
 
     def is_cygwin(self):
         """
@@ -225,7 +225,7 @@ class MachineInfo:
         """
         Machine is Darwin (iOS/OS X)?
         """
-        return self.system in ('darwin', 'ios')
+        return self.system in {'darwin', 'ios'}
 
     def is_android(self):
         """


### PR DESCRIPTION
We're carrying this patch from when we were enabling running meson inside a MinGW environment.  I'd appreciate someone who actually uses Windows to verify this is correct!