### PR TITLE
Don't collect preprocssor flags separately from compiler flags

### DIFF
--- a/docs/markdown/snippets/preproc-flags.md
+++ b/docs/markdown/snippets/preproc-flags.md
@@ -1,0 +1,12 @@
+## (C) Preprocessor flag handling
+
+Meson previously stored `CPPFLAGS` and per-language compilation flags
+separately. (That latter would come from `CFLAGS`, `CXXFLAGS`, etc., along with
+`<lang>_args` options whether specified no the command-line interface (`-D..`),
+`meson.build` (`default_options`), or cross file (`[properties]`).) This was
+mostly unobservable, except for certain preprocessor-only checks like
+`check_header` would only use the preprocessor flags, leading to confusion if
+some `-isystem` was in `CFLAGS` but not `CPPFLAGS`. Now, they are lumped
+together, and `CPPFLAGS`, for the languages which are deemed to care to about,
+is just another source of compilation flags along with the others already
+listed.

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -424,11 +424,8 @@ class CCompiler(Compiler):
             for_machine = MachineChoice.BUILD
         else:
             for_machine = MachineChoice.HOST
-        if mode == 'preprocess':
-            # Add CPPFLAGS from the env.
-            args += env.coredata.get_external_preprocess_args(for_machine, self.language)
-        elif mode == 'compile':
-            # Add CFLAGS/CXXFLAGS/OBJCFLAGS/OBJCXXFLAGS from the env
+        if mode in {'compile', 'preprocess'}:
+            # Add CFLAGS/CXXFLAGS/OBJCFLAGS/OBJCXXFLAGS and CPPFLAGS from the env
             sys_args = env.coredata.get_external_args(for_machine, self.language)
             # Apparently it is a thing to inject linker flags both
             # via CFLAGS _and_ LDFLAGS, even though the former are

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -971,11 +971,11 @@ class Compiler:
         """
         return []
 
-    def use_preproc_flags(self):
+    def use_preproc_flags(self) -> bool:
         """
         Whether the compiler (or processes it spawns) cares about CPPFLAGS
         """
-        return self.get_language() in ('c', 'cpp', 'objc', 'objcpp')
+        return self.get_language() in {'c', 'cpp', 'objc', 'objcpp'}
 
     def get_args_from_envvars(self):
         """

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -971,10 +971,11 @@ class Compiler:
         """
         return []
 
-    def get_preproc_flags(self):
-        if self.get_language() in ('c', 'cpp', 'objc', 'objcpp'):
-            return os.environ.get('CPPFLAGS', '')
-        return ''
+    def use_preproc_flags(self):
+        """
+        Whether the compiler (or processes it spawns) cares about CPPFLAGS
+        """
+        return self.get_language() in ('c', 'cpp', 'objc', 'objcpp')
 
     def get_args_from_envvars(self):
         """
@@ -1008,11 +1009,12 @@ class Compiler:
             # this when the linker is stand-alone such as with MSVC C/C++, etc.
             link_flags = compile_flags + link_flags
 
-        # Pre-processor flags (not for fortran or D)
-        preproc_flags = self.get_preproc_flags()
-        log_var('CPPFLAGS', preproc_flags)
-        preproc_flags = shlex.split(preproc_flags)
-        compile_flags += preproc_flags
+        # Pre-processor flags for certain languages
+        if self.use_preproc_flags():
+            preproc_flags = os.environ.get('CPPFLAGS', '')
+            log_var('CPPFLAGS', preproc_flags)
+            preproc_flags = shlex.split(preproc_flags)
+            compile_flags += preproc_flags
 
         return compile_flags, link_flags
 

--- a/mesonbuild/munstable_coredata.py
+++ b/mesonbuild/munstable_coredata.py
@@ -118,10 +118,6 @@ def run(options):
                 print('Cached dependencies:')
                 for dep_key, dep in cross:
                     print_dep(dep_key, dep)
-        elif k == 'external_preprocess_args':
-            for lang, opts in v.items():
-                if opts:
-                    print('Preprocessor args for ' + lang + ': ' + ' '.join(opts))
         else:
             print(k + ':')
             print(textwrap.indent(pprint.pformat(v), '  '))

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2041,7 +2041,8 @@ class AllPlatformTests(BasePlatformTests):
 
     def test_preprocessor_checks_CPPFLAGS(self):
         '''
-        Test that preprocessor compiler checks read CPPFLAGS but not CFLAGS
+        Test that preprocessor compiler checks read CPPFLAGS and also CFLAGS but
+        not LDFLAGS.
         '''
         testdir = os.path.join(self.common_test_dir, '137 get define')
         define = 'MESON_TEST_DEFINE_VALUE'
@@ -2051,9 +2052,10 @@ class AllPlatformTests(BasePlatformTests):
         # % and # confuse the MSVC preprocessor
         # !, ^, *, and < confuse lcc preprocessor
         value = 'spaces and fun@$&()-=_+{}[]:;>?,./~`'
-        os.environ['CPPFLAGS'] = '-D{}="{}"'.format(define, value)
-        os.environ['CFLAGS'] = '-DMESON_FAIL_VALUE=cflags-read'.format(define)
-        self.init(testdir, ['-D{}={}'.format(define, value)])
+        for env_var in ['CPPFLAGS', 'CFLAGS']:
+            os.environ[env_var] = '-D{}="{}"'.format(define, value)
+            os.environ['LDFLAGS'] = '-DMESON_FAIL_VALUE=cflags-read'.format(define)
+            self.init(testdir, ['-D{}={}'.format(define, value)])
 
     def test_custom_target_exe_data_deterministic(self):
         testdir = os.path.join(self.common_test_dir, '114 custom target capture')


### PR DESCRIPTION
I recall that @jpakkane never wanted this, but @nirbheek did, but then @nirbheek changed his mind.

I am fine either way except for the cross inconsistency that exists today: There is no `c_preproc_args` or similar one can put in the cross file, so no way to replicate the effect of `CPPFLAGS` during cross compilation.

Closes #4272

CC @dcbaker