### PR TITLE
Fix #5049 properly

### DIFF
--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -62,6 +62,11 @@ class GResourceObjectTarget(build.CustomTarget):
     def __init__(self, name, subdir, subproject, kwargs):
         super().__init__(name, subdir, subproject, kwargs)
 
+class GResourceExternTarget(build.CustomTarget):
+    def __init__(self, name, resource_object, subdir, subproject, kwargs):
+        super().__init__(name, subdir, subproject, kwargs)
+        self.resource_object = resource_object
+
 class GirTarget(build.CustomTarget):
     def __init__(self, name, subdir, subproject, kwargs):
         super().__init__(name, subdir, subproject, kwargs)


### PR DESCRIPTION
With #4222 compile_resources
returns [c_file, header_file, object_file] if glib version is >= 2.60
Which breaks for tracker, nautilus and gedit because they handle the
c file and header file separately and don't handle the object file at all.
(See #5049)
With this commit it always returns [c_file, header_file] as the documentation says.
The object file is then added in the ninja backend.