### PR TITLE
Revert "azure: Don't try to publish logs from fork"

### DIFF
--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -172,5 +172,4 @@ steps:
 - task: PublishBuildArtifacts@1
   inputs:
     artifactName: $(System.JobName)
-  # publishing artifacts from PRs from a fork is currently blocked
-  condition: eq(variables['system.pullrequest.isfork'], false)
+  condition: not(canceled())


### PR DESCRIPTION
Following up on https://github.com/mesonbuild/meson/pull/4376#issuecomment-430021383, apparently the [fix has been deployed](https://developercommunity.visualstudio.com/content/problem/350007/build-from-github-pr-fork-error-tf400813-the-user-1.html), so PRs can now publish their logs as build artifacts.

