### PR TITLE
 Sanity check with external args

### DIFF
--- a/docs/markdown/snippets/sanity-check.md
+++ b/docs/markdown/snippets/sanity-check.md
@@ -1,0 +1,17 @@
+## Sanity checking compilers with user flags
+
+Sanity checks previously only used user-specified flags for cross compilers, but
+now do in all cases.
+
+All compilers meson might decide to use for the build are "sanity checked"
+before other tests are run. This usually involves building simple executable and
+trying to run it. Previously user flags (compilation and/or linking flags) were
+used for sanity checking cross compilers, but not native compilers.  This is
+because such flags might be essential for a cross binary to succeed, but usually
+aren't for a native compiler.
+
+In recent releases, there has been an effort to minimize the special-casing of
+cross or native builds so as to make building more predictable in less-tested
+cases. Since this the user flags are necessary for cross, but not harmful for
+native, it makes more sense to use them in all sanity checks than use them in no
+sanity checks, so this is what we now do.

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -14,7 +14,7 @@
 
 import os.path, subprocess
 
-from ..mesonlib import EnvironmentException
+from ..mesonlib import EnvironmentException, MachineChoice
 
 from .cpp import CPPCompiler
 from .compilers import ClangCompiler, GnuCompiler
@@ -31,11 +31,20 @@ class ObjCPPCompiler(CPPCompiler):
         # TODO try to use sanity_check_impl instead of duplicated code
         source_name = os.path.join(work_dir, 'sanitycheckobjcpp.mm')
         binary_name = os.path.join(work_dir, 'sanitycheckobjcpp')
+        if environment.is_cross_build() and not self.is_cross:
+            for_machine = MachineChoice.BUILD
+        else:
+            for_machine = MachineChoice.HOST
+        extra_flags = environment.coredata.get_external_args(for_machine, self.language)
+        if self.is_cross:
+            extra_flags += self.get_compile_only_args()
+        else:
+            extra_flags += environment.coredata.get_external_link_args(for_machine, self.language)
         with open(source_name, 'w') as ofile:
             ofile.write('#import<stdio.h>\n'
                         'class MyClass;'
                         'int main(int argc, char **argv) { return 0; }\n')
-        pc = subprocess.Popen(self.exelist + [source_name, '-o', binary_name])
+        pc = subprocess.Popen(self.exelist + extra_flags + [source_name, '-o', binary_name])
         pc.wait()
         if pc.returncode != 0:
             raise EnvironmentException('ObjC++ compiler %s can not compile programs.' % self.name_string())

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -460,6 +460,7 @@ def have_objc_compiler():
             return False
         if not objc_comp:
             return False
+        env.coredata.process_new_compilers('objc', objc_comp, None, env)
         try:
             objc_comp.sanity_check(env.get_scratch_dir(), env)
         except mesonlib.MesonException:
@@ -475,6 +476,7 @@ def have_objcpp_compiler():
             return False
         if not objcpp_comp:
             return False
+        env.coredata.process_new_compilers('objcpp', objcpp_comp, None, env)
         try:
             objcpp_comp.sanity_check(env.get_scratch_dir(), env)
         except mesonlib.MesonException:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4368,12 +4368,11 @@ class LinuxlikeTests(BasePlatformTests):
         cmd_std = '-std=FAIL'
         env_flags = p.upper() + 'FLAGS'
         os.environ[env_flags] = cmd_std
-        self.init(testdir)
-        cmd = self.get_compdb()[0]['command']
-        qcmd_std = " {} ".format(cmd_std)
-        self.assertIn(qcmd_std, cmd)
-        with self.assertRaises(subprocess.CalledProcessError,
-                               msg='{} should have failed'.format(qcmd_std)):
+        with self.assertRaises((subprocess.CalledProcessError, mesonbuild.mesonlib.EnvironmentException),
+                               msg='C compiler should have failed with -std=FAIL'):
+            self.init(testdir)
+            # ICC won't fail in the above because additional flags are needed to
+            # make unknown -std=... options errors.
             self.build()
 
     def test_compiler_c_stds(self):

--- a/test cases/common/177 initial c_args/meson.build
+++ b/test cases/common/177 initial c_args/meson.build
@@ -3,5 +3,5 @@ project('options', 'c')
 # Test passing c_args and c_link_args options from the command line.
 assert(get_option('c_args') == ['-funroll-loops'],
        'Incorrect value for c_args option.')
-assert(get_option('c_link_args') == ['-random_linker_option'],
+assert(get_option('c_link_args') == ['-Dtest_harmless_but_useless_link_arg'],
        'Incorrect value for c_link_args option.')

--- a/test cases/common/177 initial c_args/test_args.txt
+++ b/test cases/common/177 initial c_args/test_args.txt
@@ -1,4 +1,4 @@
 # This file is not read by meson itself, but by the test framework.
 # It is not possible to pass arguments to meson from a file.
 ['-Dc_args=-march=native', '-Dc_args=-funroll-loops',
- '-Dc_link_args=-random_linker_option']
+ '-Dc_link_args=-Dtest_harmless_but_useless_link_arg']


### PR DESCRIPTION
Previously cross, but not native, external args were used. Then in
d451a4b the cross special cases were
removed, so external args are never used.

This commit switches that so they are always used. Sanity checking works
just the same as compiler checks like has header / has library.

Fixes #5086 for master bug not suitable for 0.50.