### PR TITLE
Inline check_compilers

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1127,14 +1127,6 @@ class Environment:
 
         return comp, cross_comp
 
-    def check_compilers(self, lang: str, comp: Compiler, cross_comp: Compiler):
-        if comp is None:
-            raise EnvironmentException('Tried to use unknown language "%s".' % lang)
-
-        comp.sanity_check(self.get_scratch_dir(), self)
-        if cross_comp:
-            cross_comp.sanity_check(self.get_scratch_dir(), self)
-
     def detect_compilers(self, lang: str, need_cross_compiler: bool):
         (comp, cross_comp) = self.compilers_from_language(lang, need_cross_compiler)
         if comp is not None:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2700,7 +2700,11 @@ external dependencies (including libraries) must go to "dependencies".''')
             else:
                 try:
                     (comp, cross_comp) = self.environment.detect_compilers(lang, need_cross_compiler)
-                    self.environment.check_compilers(lang, comp, cross_comp)
+                    if comp is None:
+                        raise InvalidArguments('Tried to use unknown language "%s".' % lang)
+                    comp.sanity_check(self.environment.get_scratch_dir(), self.environment)
+                    if cross_comp:
+                        cross_comp.sanity_check(self.environment.get_scratch_dir(), self.environment)
                 except Exception:
                     if not required:
                         mlog.log('Compiler for language', mlog.bold(lang), 'not found.')


### PR DESCRIPTION
This function is used just once. It also seems all policy and no
mechanism (it raises, it calls the same function to do all the work
twice in an uninteresting way). This makes it seem to be as a good
candidate for inlining.

environment and coredata are woah fully intertwined and this doesn't fix
that, but at least it makes it easier to follow.