### PR TITLE
Fix setup so test suite runs with rustc + MSVC. Closes: 5099

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -368,6 +368,13 @@ int dummy;
         src_block['sources'] += sources
         src_block['generated_sources'] += generated_sources
 
+    def is_rust_target(self, target):
+        if len(target.sources) > 0:
+            first_file = target.sources[0]
+            if first_file.fname.endswith('.rs'):
+                return True
+        return False
+
     def generate_target(self, target, outfile):
         if isinstance(target, build.CustomTarget):
             self.generate_custom_target(target, outfile)
@@ -386,7 +393,7 @@ int dummy;
         if isinstance(target, build.Jar):
             self.generate_jar_target(target, outfile)
             return
-        if 'rust' in target.compilers:
+        if self.is_rust_target(target):
             self.generate_rust_target(target, outfile)
             return
         if 'cs' in target.compilers:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1193,6 +1193,10 @@ You probably should put it in link_with instead.''')
         m = 'Could not get a dynamic linker for build target {!r}'
         raise AssertionError(m.format(self.name))
 
+    def get_using_rustc(self):
+        if len(self.sources) > 0 and self.sources[0].fname.endswith('.rs'):
+            return True
+
     def get_using_msvc(self):
         '''
         Check if the dynamic linker is MSVC. Used by Executable, StaticLibrary,
@@ -1610,7 +1614,12 @@ class SharedLibrary(BuildTarget):
             suffix = 'dll'
             self.vs_import_filename = '{0}{1}.lib'.format(self.prefix if self.prefix is not None else '', self.name)
             self.gcc_import_filename = '{0}{1}.dll.a'.format(self.prefix if self.prefix is not None else 'lib', self.name)
-            if self.get_using_msvc():
+            if self.get_using_rustc():
+                # Shared library is of the form foo.dll
+                prefix = ''
+                # Import library is called foo.dll.lib
+                self.import_filename = '{0}.dll.lib'.format(self.name)
+            elif self.get_using_msvc():
                 # Shared library is of the form foo.dll
                 prefix = ''
                 # Import library is called foo.lib

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -61,7 +61,6 @@ c_suffixes = lang_suffixes['c'] + ('h',)
 clib_langs = ('objcpp', 'cpp', 'objc', 'c', 'fortran',)
 # List of languages that can be linked with C code directly by the linker
 # used in build.py:process_compilers() and build.py:get_dynamic_linker()
-# XXX: Add Rust to this?
 clink_langs = ('d', 'cuda') + clib_langs
 clink_suffixes = ()
 for _l in clink_langs + ('vala',):

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -93,3 +93,9 @@ class RustCompiler(Compiler):
                         break
 
         return parameter_list
+
+    def get_buildtype_linker_args(self, build_type):
+        return []
+
+    def get_std_exe_link_args(self):
+        return []

--- a/test cases/rust/5 polyglot static/meson.build
+++ b/test cases/rust/5 polyglot static/meson.build
@@ -1,10 +1,16 @@
 project('static rust and c polyglot executable', 'c', 'rust')
 
 deps = [
-  meson.get_compiler('c').find_library('dl'),
+  meson.get_compiler('c').find_library('dl', required: false),
   dependency('threads'),
 ]
 
+extra_winlibs = meson.get_compiler('c').get_id() == 'msvc' ? ['userenv.lib', 'ws2_32.lib'] : []
+
 l = static_library('stuff', 'stuff.rs', rust_crate_type : 'staticlib', install : true)
-e = executable('prog', 'prog.c', dependencies: deps, link_with : l, install : true)
+e = executable('prog', 'prog.c',
+               dependencies: deps,
+               link_with : l,
+               link_args: extra_winlibs,
+               install : true)
 test('polyglottest', e)


### PR DESCRIPTION
One of the tests does not run because it ends up using Rust's stdlib dynamically and it is not in PATH by default. Instead it is hidden deep inside the `.rustup` dir somewhere. Copying it manually to the build dir makes it work but is an awful solution.