### PR TITLE
rpm: Always set b_ndebug to true

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -21,6 +21,7 @@
         --sharedstatedir=%{_sharedstatedir} \
         --wrap-mode=%{__meson_wrap_mode} \
         --auto-features=%{__meson_auto_features} \
+        -Db_ndebug=true \
         %{_vpath_srcdir} %{_vpath_builddir} \
 	%{nil}}
 


### PR DESCRIPTION
'if-release' does not catch buildtype=plain, so we need to do this.

Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>