### PR TITLE
compilers: n_debug=if-release and buildtype=plain should not enable a…

### DIFF
--- a/docs/markdown/snippets/debug-if-release-plain.md
+++ b/docs/markdown/snippets/debug-if-release-plain.md
@@ -1,0 +1,4 @@
+## n_debug=if-release and buildtype=plain means no asserts
+
+Previously if this combination was used then assertions were enabled,
+which is fairly surprising behavior.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -510,7 +510,7 @@ def get_base_compile_args(options, compiler):
     try:
         if (options['b_ndebug'].value == 'true' or
                 (options['b_ndebug'].value == 'if-release' and
-                 options['buildtype'].value == 'release')):
+                 options['buildtype'].value in {'release', 'plain'})):
             args += ['-DNDEBUG']
     except KeyError:
         pass


### PR DESCRIPTION
…ssertions

It's a bit odd that it doesn't, and has resulted in bugs in distro
packaging.

Fixes #5141