### PR TITLE
gettext: prefer POTFILES.in if it exists

### DIFF
--- a/mesonbuild/scripts/gettext.py
+++ b/mesonbuild/scripts/gettext.py
@@ -44,9 +44,9 @@ def read_linguas(src_sub):
         return []
 
 def run_potgen(src_sub, pkgname, datadirs, args):
-    listfile = os.path.join(src_sub, 'POTFILES')
+    listfile = os.path.join(src_sub, 'POTFILES.in')
     if not os.path.exists(listfile):
-        listfile = os.path.join(src_sub, 'POTFILES.in')
+        listfile = os.path.join(src_sub, 'POTFILES')
         if not os.path.exists(listfile):
             print('Could not find file POTFILES in %s' % src_sub)
             return 1


### PR DESCRIPTION
If POTFILES.in exists, then it will have come from autotools, in which case it is explicitly the file passed to xgettext -f, and the POTFILES file itself is generated by autotools as a proxy file which eventually gets inlined into the final Makefile as a variable "POTFILES = ......"

In this case, attempting to use POTFILES as the input file will simply result in syntax errors and the inability to find files with a literal trailing " \" in the name. Usually POTFILES will not exist at all, and we would fallback on POTFILES.in, but if the source tree happens to be dirty, this would result in errors. Since it's never going to be right to use it, we can just do the right thing from the start and carry on.