### PR TITLE
RFC: Split dynamic linker representations from Compiler representations

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2458,7 +2458,9 @@ rule FORTRAN_DEP_HACK%s
         # Add linker args for linking this target derived from 'base' build
         # options passed on the command-line, in default_options, etc.
         # These have the lowest priority.
-        if not isinstance(target, build.StaticLibrary):
+        if isinstance(target, build.StaticLibrary):
+            commands += linker.get_base_link_args(self.get_base_options_for_target(target))
+        else:
             commands += compilers.get_base_link_args(self.get_base_options_for_target(target),
                                                      linker,
                                                      isinstance(target, build.SharedModule))

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -480,10 +480,9 @@ def option_enabled(boptions, options, option):
 
 def get_base_compile_args(options, compiler):
     args = []
-    # FIXME, gcc/clang specific.
     try:
         if options['b_lto'].value:
-            args.append('-flto')
+            args.extend(compiler.get_lto_compile_args())
     except KeyError:
         pass
     try:
@@ -530,10 +529,9 @@ def get_base_compile_args(options, compiler):
 
 def get_base_link_args(options, linker, is_shared_module):
     args = []
-    # FIXME, gcc/clang specific.
     try:
         if options['b_lto'].value:
-            args.append('-flto')
+            args.extend(linker.get_lto_link_args())
     except KeyError:
         pass
     try:
@@ -1352,6 +1350,12 @@ class Compiler:
     def remove_linkerlike_args(self, args):
         return [x for x in args if not x.startswith('-Wl')]
 
+    def get_lto_compile_args(self):
+        return []
+
+    def get_lto_link_args(self):
+        return []
+
 
 @enum.unique
 class CompilerType(enum.Enum):
@@ -1624,6 +1628,12 @@ class GnuLikeCompiler(abc.ABC):
                 parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
 
         return parameter_list
+
+    def get_lto_compile_args(self):
+        return ['-flto']
+
+    def get_lto_link_args(self):
+        return ['-flto']
 
 class GnuCompiler(GnuLikeCompiler):
     """
@@ -1907,6 +1917,12 @@ class ArmclangCompiler:
                 parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
 
         return parameter_list
+
+    def get_lto_compile_args(self):
+        return ['-flto']
+
+    def get_lto_link_args(self):
+        return ['-flto']
 
 
 # Tested on linux for ICC 14.0.3, 15.0.6, 16.0.4, 17.0.1, 19.0.0

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -562,7 +562,7 @@ def get_base_link_args(options, linker, is_shared_module):
         args.append('-Wl,-bitcode_bundle')
     elif as_needed:
         # -Wl,-dead_strip_dylibs is incompatible with bitcode
-        args.append(linker.get_asneeded_args())
+        args.extend(linker.get_asneeded_args())
     try:
         crt_val = options['b_vscrt'].value
         buildtype = options['buildtype'].value
@@ -1518,9 +1518,9 @@ class GnuLikeCompiler(abc.ABC):
         # Hence, we don't need to differentiate between OS and ld
         # for the sake of adding as-needed support
         if self.compiler_type.is_osx_compiler:
-            return '-Wl,-dead_strip_dylibs'
+            return ['-Wl,-dead_strip_dylibs']
         else:
-            return '-Wl,--as-needed'
+            return ['-Wl,--as-needed']
 
     def get_pic_args(self):
         if self.compiler_type.is_osx_compiler or self.compiler_type.is_windows_compiler:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -898,6 +898,12 @@ class Compiler:
         self.base_options = []
         self.dynamic_linker = dynamic_linker
 
+        # If the compiler is used to invoke the dynamic linker this is true.
+        # Though this seems like a linker property, it really is a compiler
+        # property because link.exe can be invoked by clang on
+        # windows, but MSVC is not used to invoke link.exe
+        self.invokes_linker = True
+
     def __repr__(self):
         repr_str = "<{0}: v{1} `{2}`>"
         return repr_str.format(self.__class__.__name__, self.version,

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -896,7 +896,7 @@ class Compiler:
         else:
             self.full_version = None
         self.base_options = []
-        self.dynamic_linker = dynamic_linker
+        self.linker = dynamic_linker
 
         # If the compiler is used to invoke the dynamic linker this is true.
         # Though this seems like a linker property, it really is a compiler
@@ -963,13 +963,13 @@ class Compiler:
         """
         Determines whether the linker can accept arguments using the @rsp syntax.
         """
-        return mesonlib.is_windows()
+        return self.linker.can_linker_accept_rsp()
 
-    def get_linker_always_args(self):
-        return []
+    def get_linker_always_args(self) -> List[str]:
+        return self.linker.get_linker_always_args()
 
-    def get_linker_lib_prefix(self):
-        return ''
+    def get_linker_search_args(self, dirname: str) -> List[str]:
+        return self.linker.get_linker_search_args(dirname)
 
     def gen_import_library_args(self, implibname):
         """
@@ -996,9 +996,6 @@ class Compiler:
                 mlog.debug('No {} in the environment, not changing global flags.'.format(var))
 
         lang = self.get_language()
-        compiler_is_linker = False
-        if hasattr(self, 'get_linker_exelist'):
-            compiler_is_linker = (self.get_exelist() == self.get_linker_exelist())
 
         if lang not in cflags_mapping:
             return [], []
@@ -1012,16 +1009,12 @@ class Compiler:
             compile_flags += shlex.split(env_compile_flags)
 
         # Link flags (same for all languages)
-        env_link_flags = os.environ.get('LDFLAGS')
-        log_var('LDFLAGS', env_link_flags)
-        if env_link_flags is not None:
-            link_flags += shlex.split(env_link_flags)
-        if compiler_is_linker:
-            # When the compiler is used as a wrapper around the linker (such as
-            # with GCC and Clang), the compile flags can be needed while linking
-            # too. This is also what Autotools does. However, we don't want to do
-            # this when the linker is stand-alone such as with MSVC C/C++, etc.
-            link_flags = compile_flags + link_flags
+        if self.linker:
+            link_flags = self.linker.get_args_from_envvars()
+            if self.invokes_linker:
+                link_flags += compile_flags
+        else:
+            link_flags = []
 
         # Pre-processor flags for certain languages
         if self.use_preproc_flags():
@@ -1076,7 +1069,7 @@ class Compiler:
         return []
 
     def get_option_link_args(self, options):
-        return []
+        return self.linker.get_option_link_args(options)
 
     def check_header(self, *args, **kwargs):
         raise EnvironmentException('Language %s does not support header checks.' % self.get_display_language())
@@ -1217,16 +1210,17 @@ class Compiler:
     def get_link_debugfile_args(self, rel_obj):
         return []
 
-    def get_std_shared_lib_link_args(self):
-        return []
+    def get_std_shared_lib_link_args(self) -> List[str]:
+        return self.linker.get_std_shared_lib_link_args()
 
-    def get_std_shared_module_link_args(self, options):
-        return self.get_std_shared_lib_link_args()
+    def get_std_shared_module_link_args(self, options) -> List[str]:
+        return self.linker.get_std_shared_module_link_args(options)
 
-    def get_link_whole_for(self, args):
-        if isinstance(args, list) and not args:
+    def get_link_whole_for(self, args: List[str]) -> List[str]:
+        if not args:
             return []
-        raise EnvironmentException('Language %s does not support linking whole archives.' % self.get_display_language())
+        return self.linker.get_link_whole_for(args)
+        # raise EnvironmentException('Language %s does not support linking whole archives.' % self.get_display_language())
 
     # Compiler arguments needed to enable the given instruction set.
     # May be [] meaning nothing needed or None meaning the given set
@@ -1329,8 +1323,10 @@ class Compiler:
         raise EnvironmentException(m.format(self.get_display_language()))
 
     def get_pie_link_args(self):
-        m = 'Language {} does not support position-independent executable'
-        raise EnvironmentException(m.format(self.get_display_language()))
+        return self.linker.get_pie_link_args()
+
+        # m = 'Language {} does not support position-independent executable'
+        # raise EnvironmentException(m.format(self.get_display_language()))
 
     def get_argument_syntax(self):
         """Returns the argument family type.
@@ -1351,20 +1347,44 @@ class Compiler:
         raise EnvironmentException(
             '%s does not support get_profile_use_args ' % self.get_id())
 
-    def get_undefined_link_args(self):
-        '''
-        Get args for allowing undefined symbols when linking to a shared library
-        '''
-        return []
-
     def remove_linkerlike_args(self, args):
         return [x for x in args if not x.startswith('-Wl')]
 
     def get_lto_compile_args(self):
         return []
 
-    def get_lto_link_args(self):
-        return []
+    def get_lto_link_args(self) -> List[str]:
+        return self.linker.get_lto_link_args()
+
+    def linker_to_compiler_args(self, args: List[str]) -> List[str]:
+        return self.linker.linker_to_compiler_args(args)
+
+    def get_allow_undefined_link_args(self) -> List[str]:
+        return self.linker.get_allow_undefined_link_args()
+
+    def get_buildtype_linker_args(self, buildtype):
+        return self.linker.get_buildtype_linker_args(buildtype)
+
+    def get_asneeded_args(self):
+        return self.linker.get_asneeded_args()
+
+    def get_linker_lib_prefix(self):
+        return self.linker.get_linker_lib_prefix()
+
+    def get_linker_debug_crt_args(self) -> List[str]:
+        return self.linker.get_linker_debug_crt_args()
+
+    def get_no_stdlib_link_args(self) -> List[str]:
+        return self.linker.get_no_stdlib_link_args()
+
+    def get_coverage_link_args(self) -> List[str]:
+        return self.linker.get_coverage_link_args()
+
+    def get_linker_exelist(self) -> List[str]:
+        return self.linker.get_linker_exelist()
+
+    def get_linker_output_args(self, outputname: str) -> List[str]:
+        return self.linker.get_linker_output_args(outputname)
 
 
 @enum.unique
@@ -1522,16 +1542,6 @@ class GnuLikeCompiler(abc.ABC):
         # All GCC-like backends can do assembly
         self.can_compile_suffixes.add('s')
 
-    def get_asneeded_args(self):
-        # GNU ld cannot be installed on macOS
-        # https://github.com/Homebrew/homebrew-core/issues/17794#issuecomment-328174395
-        # Hence, we don't need to differentiate between OS and ld
-        # for the sake of adding as-needed support
-        if self.compiler_type.is_osx_compiler:
-            return ['-Wl,-dead_strip_dylibs']
-        else:
-            return ['-Wl,--as-needed']
-
     def get_pic_args(self):
         if self.compiler_type.is_osx_compiler or self.compiler_type.is_windows_compiler:
             return [] # On Window and OS X, pic is always on.
@@ -1539,9 +1549,6 @@ class GnuLikeCompiler(abc.ABC):
 
     def get_pie_args(self):
         return ['-fPIE']
-
-    def get_pie_link_args(self):
-        return ['-pie']
 
     def get_buildtype_args(self, buildtype):
         return gnulike_buildtype_args[buildtype]
@@ -1553,11 +1560,6 @@ class GnuLikeCompiler(abc.ABC):
     def get_debug_args(self, is_debug):
         return clike_debug_args[is_debug]
 
-    def get_buildtype_linker_args(self, buildtype):
-        if self.compiler_type.is_osx_compiler:
-            return apple_buildtype_linker_args[buildtype]
-        return gnulike_buildtype_linker_args[buildtype]
-
     @abc.abstractmethod
     def get_pch_suffix(self):
         raise NotImplementedError("get_pch_suffix not implemented")
@@ -1567,22 +1569,6 @@ class GnuLikeCompiler(abc.ABC):
 
     def get_soname_args(self, *args):
         return get_gcc_soname_args(self.compiler_type, *args)
-
-    def get_std_shared_lib_link_args(self):
-        return ['-shared']
-
-    def get_std_shared_module_link_args(self, options):
-        if self.compiler_type.is_osx_compiler:
-            return ['-bundle', '-Wl,-undefined,dynamic_lookup']
-        return ['-shared']
-
-    def get_link_whole_for(self, args):
-        if self.compiler_type.is_osx_compiler:
-            result = []
-            for a in args:
-                result += ['-Wl,-force_load', a]
-            return result
-        return ['-Wl,--whole-archive'] + args + ['-Wl,--no-whole-archive']
 
     def get_instruction_set_args(self, instruction_set):
         return gnulike_instruction_set_args.get(instruction_set, None)
@@ -1616,17 +1602,6 @@ class GnuLikeCompiler(abc.ABC):
     def get_profile_use_args(self):
         return ['-fprofile-use', '-fprofile-correction']
 
-    def get_allow_undefined_link_args(self):
-        if self.compiler_type.is_osx_compiler:
-            # Apple ld
-            return ['-Wl,-undefined,dynamic_lookup']
-        elif self.compiler_type.is_windows_compiler:
-            # For PE/COFF this is impossible
-            return []
-        else:
-            # GNU ld and LLVM lld
-            return ['-Wl,--allow-shlib-undefined']
-
     def get_gui_app_args(self, value):
         if self.compiler_type.is_windows_compiler:
             return ['-mwindows' if value else '-mconsole']
@@ -1640,9 +1615,6 @@ class GnuLikeCompiler(abc.ABC):
         return parameter_list
 
     def get_lto_compile_args(self):
-        return ['-flto']
-
-    def get_lto_link_args(self):
         return ['-flto']
 
 class GnuCompiler(GnuLikeCompiler):
@@ -1710,9 +1682,6 @@ class PGICompiler:
     def get_buildtype_args(self, buildtype: str) -> List[str]:
         return pgi_buildtype_args[buildtype]
 
-    def get_buildtype_linker_args(self, buildtype: str) -> List[str]:
-        return pgi_buildtype_linker_args[buildtype]
-
     def get_optimization_args(self, optimization_level: str):
         return clike_optimization_args[optimization_level]
 
@@ -1723,9 +1692,6 @@ class PGICompiler:
         for idx, i in enumerate(parameter_list):
             if i[:2] == '-I' or i[:2] == '-L':
                 parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
-
-    def get_allow_undefined_link_args(self):
-        return []
 
     def get_dependency_gen_args(self, outtarget, outfile):
         return []
@@ -1861,9 +1827,6 @@ class ArmclangCompiler:
         # Assembly
         self.can_compile_suffixes.update('s')
 
-    def can_linker_accept_rsp(self):
-        return False
-
     def get_pic_args(self):
         # PIC support is not enabled by default for ARM,
         # if users want to use it, they need to add the required arguments explicitly
@@ -1874,13 +1837,6 @@ class ArmclangCompiler:
 
     def get_buildtype_args(self, buildtype):
         return armclang_buildtype_args[buildtype]
-
-    def get_buildtype_linker_args(self, buildtype):
-        return arm_buildtype_linker_args[buildtype]
-
-    # Override CCompiler.get_std_shared_lib_link_args
-    def get_std_shared_lib_link_args(self):
-        return []
 
     def get_pch_suffix(self):
         return 'gch'
@@ -1899,9 +1855,6 @@ class ArmclangCompiler:
     def build_rpath_args(self, build_dir, from_dir, rpath_paths, build_rpath, install_rpath):
         return []
 
-    def get_linker_exelist(self):
-        return [self.linker_exe]
-
     def get_optimization_args(self, optimization_level):
         return armclang_optimization_args[optimization_level]
 
@@ -1909,10 +1862,7 @@ class ArmclangCompiler:
         return clike_debug_args[is_debug]
 
     def gen_export_dynamic_link_args(self, env):
-        """
-        The args for export dynamic
-        """
-        return ['--export_dynamic']
+        return self.linker.gen_export_dynamic_link_args(env)
 
     def gen_import_library_args(self, implibname):
         """
@@ -2008,9 +1958,6 @@ class ArmCompiler:
         # Assembly
         self.can_compile_suffixes.add('s')
 
-    def can_linker_accept_rsp(self):
-        return False
-
     def get_pic_args(self):
         # FIXME: Add /ropi, /rwpi, /fpic etc. qualifiers to --apcs
         return []
@@ -2018,19 +1965,12 @@ class ArmCompiler:
     def get_buildtype_args(self, buildtype):
         return arm_buildtype_args[buildtype]
 
-    def get_buildtype_linker_args(self, buildtype):
-        return arm_buildtype_linker_args[buildtype]
-
     # Override CCompiler.get_always_args
     def get_always_args(self):
         return []
 
     # Override CCompiler.get_dependency_gen_args
     def get_dependency_gen_args(self, outtarget, outfile):
-        return []
-
-    # Override CCompiler.get_std_shared_lib_link_args
-    def get_std_shared_lib_link_args(self):
         return []
 
     def get_pch_use_args(self, pch_dir, header):
@@ -2059,9 +1999,6 @@ class ArmCompiler:
         return args
 
     def get_coverage_args(self):
-        return []
-
-    def get_coverage_link_args(self):
         return []
 
     def get_optimization_args(self, optimization_level):
@@ -2099,9 +2036,6 @@ class CcrxCompiler:
                           '2': default_warn_args + [],
                           '3': default_warn_args + []}
 
-    def can_linker_accept_rsp(self):
-        return False
-
     def get_pic_args(self):
         # PIC support is not enabled by default for CCRX,
         # if users want to use it, they need to add the required arguments explicitly
@@ -2109,13 +2043,6 @@ class CcrxCompiler:
 
     def get_buildtype_args(self, buildtype):
         return ccrx_buildtype_args[buildtype]
-
-    def get_buildtype_linker_args(self, buildtype):
-        return ccrx_buildtype_linker_args[buildtype]
-
-    # Override CCompiler.get_std_shared_lib_link_args
-    def get_std_shared_lib_link_args(self):
-        return []
 
     def get_pch_suffix(self):
         return 'pch'
@@ -2140,13 +2067,7 @@ class CcrxCompiler:
     def get_linker_exelist(self):
         return [self.linker_exe]
 
-    def get_linker_lib_prefix(self):
-        return '-lib='
-
     def get_coverage_args(self):
-        return []
-
-    def get_coverage_link_args(self):
         return []
 
     def get_optimization_args(self, optimization_level):

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -30,7 +30,7 @@ cs_optimization_args = {'0': [],
 class CsCompiler(Compiler):
     def __init__(self, exelist, version, id, runner=None):
         self.language = 'cs'
-        super().__init__(exelist, version)
+        super().__init__(exelist, version, None)  # TODO: is None really safe here?
         self.id = id
         self.is_cross = False
         self.runner = runner

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -13,17 +13,22 @@
 # limitations under the License.
 
 import re, os.path
+import typing
 
 from .. import mlog
 from ..mesonlib import EnvironmentException, Popen_safe
 from .compilers import (Compiler, cuda_buildtype_args, cuda_optimization_args,
                         cuda_debug_args, CompilerType, get_gcc_soname_args)
 
+if typing.TYPE_CHECKING:
+    from ..linkers import DynamicLinker
+
+
 class CudaCompiler(Compiler):
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None):
+    def __init__(self, exelist, version, is_cross, dynamic_linker: 'DynamicLinker', exe_wrapper=None):
         if not hasattr(self, 'language'):
             self.language = 'cuda'
-        super().__init__(exelist, version)
+        super().__init__(exelist, version, dynamic_linker)
         self.is_cross = is_cross
         self.exe_wrapper = exe_wrapper
         self.id = 'nvcc'

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os.path, subprocess
+import typing
 
 from ..mesonlib import (
     EnvironmentException, MachineChoice, version_compare, is_windows, is_osx
@@ -30,6 +31,9 @@ from .compilers import (
     Compiler,
     CompilerArgs,
 )
+
+if typing.TYPE_CHECKING:
+    from ..linkers import DynamicLinker
 
 d_feature_args = {'gcc':  {'unittest': '-funittest',
                            'debug': '-fdebug',
@@ -73,9 +77,9 @@ class DCompiler(Compiler):
         'mtd': ['-mscrtlib=libcmtd'],
     }
 
-    def __init__(self, exelist, version, is_cross, arch, **kwargs):
+    def __init__(self, exelist, version, is_cross, dynamic_linker: 'DynamicLinker', arch, **kwargs):
         self.language = 'd'
-        super().__init__(exelist, version, **kwargs)
+        super().__init__(exelist, version, dynamic_linker, **kwargs)
         self.id = 'unknown'
         self.is_cross = is_cross
         self.arch = arch
@@ -494,8 +498,8 @@ class DCompiler(Compiler):
         return ['-pthread']
 
 class GnuDCompiler(DCompiler):
-    def __init__(self, exelist, version, is_cross, arch, **kwargs):
-        DCompiler.__init__(self, exelist, version, is_cross, arch, **kwargs)
+    def __init__(self, exelist, version, is_cross, dynamic_linker: 'DynamicLinker', arch, **kwargs):
+        DCompiler.__init__(self, exelist, version, is_cross, dynamic_linker, arch, **kwargs)
         self.id = 'gcc'
         default_warn_args = ['-Wall', '-Wdeprecated']
         self.warn_args = {'0': [],
@@ -557,8 +561,8 @@ class GnuDCompiler(DCompiler):
         return gnu_optimization_args[optimization_level]
 
 class LLVMDCompiler(DCompiler):
-    def __init__(self, exelist, version, is_cross, arch, **kwargs):
-        DCompiler.__init__(self, exelist, version, is_cross, arch, **kwargs)
+    def __init__(self, exelist, version, is_cross, dynamic_linker: 'DynamicLinker', arch, **kwargs):
+        DCompiler.__init__(self, exelist, version, is_cross, dynamic_linker, arch, **kwargs)
         self.id = 'llvm'
         self.base_options = ['b_coverage', 'b_colorout', 'b_vscrt']
 
@@ -595,8 +599,8 @@ class LLVMDCompiler(DCompiler):
 
 
 class DmdDCompiler(DCompiler):
-    def __init__(self, exelist, version, is_cross, arch, **kwargs):
-        DCompiler.__init__(self, exelist, version, is_cross, arch, **kwargs)
+    def __init__(self, exelist, version, is_cross, dynamic_linker: 'DynamicLinker', arch, **kwargs):
+        DCompiler.__init__(self, exelist, version, is_cross, dynamic_linker, arch, **kwargs)
         self.id = 'dmd'
         self.base_options = ['b_coverage', 'b_colorout', 'b_vscrt']
 

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -319,8 +319,9 @@ class ElbrusFortranCompiler(GnuFortranCompiler, ElbrusCompiler):
         ElbrusCompiler.__init__(self, compiler_type, defines)
 
 class G95FortranCompiler(FortranCompiler):
-    def __init__(self, exelist, version, is_cross, dynamic_linker: 'DynamicLinker', exe_wrapper=None, **kwags):
+    def __init__(self, exelist, version, compiler_type, is_cross, dynamic_linker: 'DynamicLinker', exe_wrapper=None, **kwags):
         FortranCompiler.__init__(self, exelist, version, is_cross, dynamic_linker, exe_wrapper, **kwags)
+        self.compiler_type = compiler_type
         self.id = 'g95'
         default_warn_args = ['-Wall']
         self.warn_args = {'0': [],

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -21,7 +21,7 @@ from .compilers import Compiler, java_buildtype_args
 class JavaCompiler(Compiler):
     def __init__(self, exelist, version):
         self.language = 'java'
-        super().__init__(exelist, version)
+        super().__init__(exelist, version, None)
         self.id = 'unknown'
         self.is_cross = False
         self.javarunner = 'java'

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -13,16 +13,20 @@
 # limitations under the License.
 
 import os.path, subprocess
+import typing
 
 from ..mesonlib import EnvironmentException
 
 from .c import CCompiler
 from .compilers import ClangCompiler, GnuCompiler
 
+if typing.TYPE_CHECKING:
+    from ..linkers import DynamicLinker
+
 class ObjCCompiler(CCompiler):
-    def __init__(self, exelist, version, is_cross, exe_wrap):
+    def __init__(self, exelist, version, is_cross, dynamic_linker: 'DynamicLinker', exe_wrap):
         self.language = 'objc'
-        CCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
+        CCompiler.__init__(self, exelist, version, is_cross, dynamic_linker, exe_wrap)
 
     def get_display_language(self):
         return 'Objective-C'
@@ -51,9 +55,9 @@ class ObjCCompiler(CCompiler):
 
 
 class GnuObjCCompiler(GnuCompiler, ObjCCompiler):
-    def __init__(self, exelist, version, compiler_type, is_cross, exe_wrapper=None, defines=None):
-        ObjCCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
-        GnuCompiler.__init__(self, compiler_type, defines)
+    def __init__(self, exelist, version, compiler_type, is_cross, dynamic_linker: 'DynamicLinker', exe_wrapper=None, defines=None):
+        ObjCCompiler.__init__(self, exelist, version, is_cross, dynamic_linker, exe_wrapper)
+        GnuCompiler.__init__(self, compiler_type, dynamic_linker, defines)
         default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -62,8 +66,8 @@ class GnuObjCCompiler(GnuCompiler, ObjCCompiler):
 
 
 class ClangObjCCompiler(ClangCompiler, ObjCCompiler):
-    def __init__(self, exelist, version, compiler_type, is_cross, exe_wrapper=None):
-        ObjCCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
+    def __init__(self, exelist, version, compiler_type, is_cross, dynamic_linker: 'DynamicLinker', exe_wrapper=None):
+        ObjCCompiler.__init__(self, exelist, version, is_cross, dynamic_linker, exe_wrapper)
         ClangCompiler.__init__(self, compiler_type)
         default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'0': [],

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -13,16 +13,20 @@
 # limitations under the License.
 
 import os.path, subprocess
+import typing
 
 from ..mesonlib import EnvironmentException
 
 from .cpp import CPPCompiler
 from .compilers import ClangCompiler, GnuCompiler
 
+if typing.TYPE_CHECKING:
+    from ..linkers import DynamicLinker
+
 class ObjCPPCompiler(CPPCompiler):
-    def __init__(self, exelist, version, is_cross, exe_wrap):
+    def __init__(self, exelist, version, is_cross, dynamic_linker: 'DynamicLinker', exe_wrap):
         self.language = 'objcpp'
-        CPPCompiler.__init__(self, exelist, version, is_cross, exe_wrap)
+        CPPCompiler.__init__(self, exelist, version, is_cross, dynamic_linker, exe_wrap)
 
     def get_display_language(self):
         return 'Objective-C++'
@@ -49,9 +53,9 @@ class ObjCPPCompiler(CPPCompiler):
 
 
 class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):
-    def __init__(self, exelist, version, compiler_type, is_cross, exe_wrapper=None, defines=None):
-        ObjCPPCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
-        GnuCompiler.__init__(self, compiler_type, defines)
+    def __init__(self, exelist, version, compiler_type, is_cross, dynamic_linker: 'DynamicLinker', exe_wrapper=None, defines=None):
+        ObjCPPCompiler.__init__(self, exelist, version, is_cross, dynamic_linker, exe_wrapper)
+        GnuCompiler.__init__(self, compiler_type, dynamic_linker, defines)
         default_warn_args = ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -60,8 +64,8 @@ class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):
 
 
 class ClangObjCPPCompiler(ClangCompiler, ObjCPPCompiler):
-    def __init__(self, exelist, version, compiler_type, is_cross, exe_wrapper=None):
-        ObjCPPCompiler.__init__(self, exelist, version, is_cross, exe_wrapper)
+    def __init__(self, exelist, version, compiler_type, is_cross, dynamic_linker: 'DynamicLinker', exe_wrapper=None, defines=None):
+        ObjCPPCompiler.__init__(self, exelist, version, is_cross, dynamic_linker, exe_wrapper)
         ClangCompiler.__init__(self, compiler_type)
         default_warn_args = ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor']
         self.warn_args = {'0': [],

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -29,7 +29,7 @@ rust_optimization_args = {'0': [],
 class RustCompiler(Compiler):
     def __init__(self, exelist, version, is_cross, exe_wrapper=None):
         self.language = 'rust'
-        super().__init__(exelist, version)
+        super().__init__(exelist, version, None)
         self.is_cross = is_cross
         self.exe_wrapper = exe_wrapper
         self.id = 'rustc'

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -13,16 +13,20 @@
 # limitations under the License.
 
 import os.path
+import typing
 
 from .. import mlog
 from ..mesonlib import EnvironmentException, version_compare
 
 from .compilers import Compiler
 
+if typing.TYPE_CHECKING:
+    from ..linkers import DynamicLinker
+
 class ValaCompiler(Compiler):
-    def __init__(self, exelist, version):
+    def __init__(self, exelist, version, dynamic_linker: 'DynamicLinker'):
         self.language = 'vala'
-        super().__init__(exelist, version)
+        super().__init__(exelist, version, dynamic_linker)
         self.version = version
         self.id = 'valac'
         self.is_cross = False

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -95,6 +95,7 @@ from .linkers import (
     AppleDynamicLinker,
     ArmNixDynamicLinker,
     ArmclangNixDynamicLinker,
+    CcrxDynamicLinker,
     DMDDynamicLinker,
     PGIDynamiclinker,
 )
@@ -745,6 +746,8 @@ class Environment:
                 full_version = arm_ver_str
                 compiler_type = CompilerType.ARM_WIN
                 cls = ArmclangCCompiler if lang == 'c' else ArmclangCPPCompiler
+                # XXX: untested
+                linker = ArmclangNixDynamicLinker(compiler, compiler_type)
                 return cls(ccache + compiler, version, compiler_type, is_cross, linker, exe_wrap, full_version=full_version)
             if 'CL.EXE COMPATIBILITY' in out:
                 # if this is clang-cl masquerading as cl, detect it as cl, not
@@ -815,10 +818,14 @@ class Environment:
             if 'ARM' in out:
                 compiler_type = CompilerType.ARM_WIN
                 cls = ArmCCompiler if lang == 'c' else ArmCPPCompiler
+                # XXX: untested
+                linker = ArmNixDynamicLinker(compiler, compiler_type)
                 return cls(ccache + compiler, version, compiler_type, is_cross, linker, exe_wrap, full_version=full_version)
             if 'RX Family' in out:
                 compiler_type = CompilerType.CCRX_WIN
                 cls = CcrxCCompiler if lang == 'c' else CcrxCPPCompiler
+                # XXX: untested
+                linker = CcrxDynamicLinker(compiler, compiler_type)
                 return cls(ccache + compiler, version, compiler_type, is_cross, linker, exe_wrap, full_version=full_version)
 
         self._handle_exceptions(popen_exceptions, compilers)

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .mesonlib import Popen_safe, is_windows
 from . import mesonlib
 
 class StaticLinker:
@@ -86,7 +85,7 @@ class ArLinker(StaticLinker):
     def __init__(self, exelist):
         self.exelist = exelist
         self.id = 'ar'
-        pc, stdo = Popen_safe(self.exelist + ['-h'])[0:2]
+        pc, stdo = mesonlib.Popen_safe(self.exelist + ['-h'])[0:2]
         # Enable deterministic builds if they are available.
         if '[D]' in stdo:
             self.std_args = ['csrD']
@@ -172,7 +171,7 @@ class DLinker(StaticLinker):
         return []
 
     def get_linker_always_args(self):
-        if is_windows():
+        if mesonlib.is_windows():
             if self.arch == 'x86_64':
                 return ['-m64']
             elif self.arch == 'x86_mscoff' and self.id == 'dmd':

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2017 The Meson development team
+# Copyright 2012-2019 The Meson development team
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import shlex
+from typing import List, TYPE_CHECKING, Optional
+
 from . import mesonlib
+from . import mlog
+
+if TYPE_CHECKING:
+    from .compilers import compilers
+
 
 class StaticLinker:
     def can_linker_accept_rsp(self):
@@ -135,6 +144,7 @@ class ArLinker(StaticLinker):
     def get_link_debugfile_args(self, targetfile):
         return []
 
+
 class ArmarLinker(ArLinker):
 
     def __init__(self, exelist):
@@ -145,6 +155,7 @@ class ArmarLinker(ArLinker):
     def can_linker_accept_rsp(self):
         # armar cann't accept arguments using the @rsp syntax
         return False
+
 
 class DLinker(StaticLinker):
     def __init__(self, exelist, arch):
@@ -251,3 +262,362 @@ class CcrxLinker(StaticLinker):
 
     def get_link_debugfile_args(self, targetfile):
         return []
+
+
+class DynamicLinker:
+
+    """Base class for dynamic linkers."""
+
+    _buildtype_args = {
+        'plain': [],
+        'debug': [],
+        'debugoptimized': [],
+        'release': [],
+        'minsize': [],
+        'custom': [],
+    }
+
+    def __init__(self, id: str, exe: str, compiler_type: 'compilers.CompilerType'):
+        self.id = id
+        self.exe = exe
+        self.compiler_type = compiler_type
+
+    def can_linker_accept_rsp(self) -> bool:
+        """Determines whether the linker can accept arguments using the @rsp
+        syntax.
+        """
+        return mesonlib.is_windows()
+
+    def get_linker_always_args(self) -> List[str]:
+        """Get arguments always required by the linker."""
+        return []
+
+    def get_option_link_args(self, options) -> List[str]:
+        return []
+
+    def get_args_from_envvars(self) -> List[str]:
+        def log_var(var, val: Optional[str]) -> None:
+            if val:
+                mlog.log('Appending {} from environment: {!r}'.format(var, val))
+            else:
+                mlog.debug('No {} in the environment, not changing global flags.'.format(var))
+
+        link_flags = os.environ.get('LDFLAGS')
+        log_var('LDFLAGS', link_flags)
+        if link_flags:
+            return shlex.split(link_flags)
+        return []
+
+    def get_std_shared_lib_link_args(self) -> List[str]:
+        return []
+
+    def get_std_shared_module_link_args(self) -> List[str]:
+        return self.get_std_shared_lib_link_args()
+
+    def get_link_whole_for(self, args: List[str]) -> List[str]:
+        if isinstance(args, list) and not args:
+            return []
+        raise mesonlib.EnvironmentException('Language %s does not support linking whole archives.' % self.get_display_language())
+
+    def get_pie_link_args(self) -> List[str]:
+        """Arguments required by the dynamic linker for -fPIE executables."""
+        return []
+
+    def get_lto_link_args(self) -> List[str]:
+        """Arguments required by the dynamic linker for LTO/IPO."""
+        return []
+
+    def gen_export_dynamic_link_args(self, env) -> List[str]:
+        return []
+
+    def get_asneeded_args(self) -> List[str]:
+        return []
+
+    def get_buildtype_linker_args(self, buildtype: str) -> List[str]:
+        return self._buildtype_args[buildtype]
+
+    def get_linker_exelist(self) -> List[str]:
+        return self.exe.copy()
+
+    def get_allow_undefined_link_args(self) -> List[str]:
+        return []
+
+    def get_linker_lib_prefix(self) -> str:
+        return ''
+
+    def get_linker_search_args(self, dirname: str) -> List[str]:
+        return []
+
+    def get_linker_output_args(self, outputname: str) -> List[str]:
+        return []
+
+    def linker_to_compiler_args(self, args: List[str]) -> List[str]:
+        return args
+
+    def get_linker_debug_crt_args(self) -> List[str]:
+        """Arguments needed to select a debug crt for the linker.
+
+        This is only needed for MSVC
+
+        Sometimes we need to manually select the CRT (C runtime) to use with
+        MSVC. One example is when trying to link with static libraries since
+        MSVC won't auto-select a CRT for us in that case and will error out
+        asking us to select one.
+        """
+        # TODO: this really belongs in the static linker, no?
+        return []
+
+    def get_no_stdlib_link_args(self) -> List[str]:
+        return []
+
+    def get_coverage_link_args(self) -> List[str]:
+        return []
+
+
+class UnixLikeDynamicLinker(DynamicLinker):
+
+    def get_std_shared_lib_link_args(self):
+        return ['-shared']
+
+    def get_pie_link_args(self, buildtype):
+        return ['-pie']
+
+    def get_allow_undefined_link_args(self):
+        if self.compiler_type.is_windows_compiler:
+            return []
+        return ['-Wl,--allow-shlib-undefined']
+
+    def get_linker_output_args(self, outputname: str) -> List[str]:
+        return ['-o', outputname]
+
+    def get_linker_search_args(self, dirname: str) -> List[str]:
+        return ['-L' + dirname]
+
+
+class GNULikeDynamicLinker(UnixLikeDynamicLinker):
+
+    """Base class for GNU ld, gold, and llvm's lld when acting like GNU ld."""
+
+    _buildtype_args = {
+        'plain': [],
+        'debug': [],
+        'debugoptimized': [],
+        'release': ['-Wl,-O1'],
+        'minsize': [],
+        'custom': [],
+    }
+
+    def get_asneeded_args(self) -> List[str]:
+        return ['-Wl,--as-needed']
+
+    def get_std_shared_module_link_args(self, options) -> List[str]:
+        return ['-shared']
+
+    def get_link_whole_for(self, args: List[str]) -> List[str]:
+        return ['-Wl,--whole-archive'] + args + ['-Wl,--no-whole-archive']
+
+    def get_lto_link_args(self) -> List[str]:
+        return ['-flto']
+
+    def get_no_stdlib_link_args(self) -> List[str]:
+        return ['-nostdlib']
+
+    def get_option_link_args(self, options) -> List[str]:
+        if self.compiler_type.is_windows_compiler:
+            return options['c_winlibs'].value[:]
+        return []
+
+    def get_coverage_link_args(self):
+        # XXX: Is this really a gnuism?
+        return ['--coverage']
+
+
+class GNUBFDDynamicLinker(GNULikeDynamicLinker):
+
+    """Concrete implementation of ld.bfd."""
+
+    def __init__(self, exe: str, compiler_type: 'compilers.CompilerType'):
+        super().__init__('bfd', exe, compiler_type)
+
+
+class GNUGoldDDynamicLinker(GNULikeDynamicLinker):
+
+    """Concrete implementation of ld.gold."""
+
+    def __init__(self, exe: str, compiler_type: 'compilers.CompilerType'):
+        super().__init__('gold', exe, compiler_type)
+
+
+class LLDUnixDynamicLinker(GNULikeDynamicLinker):
+
+    """Concrete implementation of lld (Unix-like)."""
+
+    def __init__(self, exe: str, compiler_type: 'compilers.CompilerType'):
+        super().__init__('lld', exe, compiler_type)
+
+
+class MSVCLikeDynamicLinker(DynamicLinker):
+
+    """Shared base class for MSVC linke.exe and other linkers acting like it."""
+
+    _buildtype_args = {
+        'plain': [],
+        'debug': [],
+        'debugoptimized': [],
+        # The otherwise implicit REF and ICF linker optimisations are
+        # disabled by /DEBUG.  REF implies ICF.
+        'release': ['/OPT:REF'],
+        'minsize': ['/INCREMENTAL:NO', '/OPT:REF'],
+        'custom': [],
+    }
+
+    def get_allow_undefined_link_args(self) -> List[str]:
+        return ['/FORCE:UNRESOLVED']
+
+    def get_linker_always_args(self) -> List[str]:
+        return ['/nologo']
+
+    def get_linker_output_args(self, outputname: str) -> List[str]:
+        return ['/OUT:' + outputname]
+
+    def get_linker_search_args(self, dirname: str) -> List[str]:
+        return ['/LIBPATH:' + dirname]
+
+    def get_linker_output_args(self, outputname: str) -> List[str]:
+        return ['/MACHINE:' + self.machine, '/OUT:' + outputname]
+
+    def linker_to_compiler_args(self, args: List[str]) -> List[str]:
+        return ['/link'] + args
+
+    def get_option_link_args(self, options):
+        return options['c_winlibs'].value[:]
+
+    def get_std_shared_lib_link_args(self) -> List[str]:
+        return ['/DLL']
+
+    def get_link_whole_for(self, args) -> List[str]:
+        # Only since VS2015
+        args = mesonlib.listify(args)
+        return ['/WHOLEARCHIVE:' + x for x in args]
+
+    def get_linker_debug_crt_args(self) -> List[str]:
+        return ['/MDd']
+
+
+class MSVCDynamicLinker(MSVCLikeDynamicLinker):
+
+    """Concrete implementation of MSVC's link.exe."""
+
+    buildtype_args = {
+        'plain': [],
+        'debug': [],
+        'debugoptimized': [],
+        # The otherwise implicit REF and ICF linker optimisations are disabled
+        # by /DEBUG. REF implies ICF.
+        'release': ['/OPT:REF'],
+        'minsize': ['/INCREMENTAL:NO', '/OPT:REF'],
+        'custom': [],
+    }
+
+    def __init__(self, exe: str, compiler_type: 'compilers.CompilerType'):
+        super().__init__('link', exe, compiler_type)
+
+
+class LLDWinDynamicLinker(MSVCLikeDynamicLinker):
+
+    """Concrete implementation of LLVMs lld-link (link.exe like)."""
+
+    def __init__(self, exe: str, compiler_type: 'compilers.CompilerType'):
+        super().__init__('lld-link', exe, compiler_type)
+
+
+class AppleDynamicLinker(UnixLikeDynamicLinker):
+
+    """Concrete implementation of the Apple Linker."""
+
+    def __init__(self, exe: str, compiler_type: 'compilers.CompilerType'):
+        super().__init__('apple', exe, compiler_type)
+
+    def get_asneeded_args(self) -> List[str]:
+        return ['-Wl,-dead_strip_dylibs']
+
+    def get_std_shared_module_link_args(self, options) -> List[str]:
+        return ['-bundle', '-Wl,-undefined,dynamic_lookup']
+
+    def get_link_whole_for(self, args: List[str]) -> List[str]:
+        result = []
+        for a in args:
+            result.extend(['-Wl,-force_load', a])
+        return result
+
+    def get_allow_undefined_link_args(self) -> List[str]:
+        return ['-Wl,-undefined,dynamic_lookup']
+
+    def get_linker_always_args(self) -> List[str]:
+        return super().get_linker_always_args() + ['-Wl,-headerpad_max_install_names']
+
+
+class ArmNixBaseDynamicLinker(UnixLikeDynamicLinker):
+
+    """SHared base class for arm linkers on Unix-like systems."""
+
+    def get_std_shared_lib_link_args(self) -> List[str]:
+        return []
+
+    def get_linker_exelist(self) -> List[str]:
+        return ['armlink']
+
+
+class ArmNixDynamicLinker(ArmNixBaseDynamicLinker):
+
+    """Concrente implementation of the Arm linker for Unix-like systems."""
+
+    def __init__(self, exe: str, compiler_type: 'compilers.CompilerType'):
+        super().__init__('arm', exe, compiler_type)
+
+    def get_export_dynamic_link_args(self, env) -> List[str]:
+        return ['--export_dynamic']
+
+
+class ArmclangNixDynamicLinker(ArmNixBaseDynamicLinker):
+
+    """Concrete implementation of the Armclang linker for Unix-like systems."""
+
+    def __init__(self, exe: str, compiler_type: 'compilers.CompilerType'):
+        super().__init__('armclang', exe, compiler_type)
+
+
+class DMDDynamicLinker(DynamicLinker):
+
+    """Linker for DMD D language compiler."""
+
+    def __init__(self, exe: str, compiler_type: 'compilers.CompilerType'):
+        super().__init__('dmd', exe, compiler_type)
+
+    def std_shared_lib_link_args(self) -> List[str]:
+        return ['-shared', '-defaultlib=libphobos2.so']
+
+
+class CcrxDynamicLinker(DynamicLinker):
+
+    """Linker for Renesas CCRX."""
+
+    def __init__(self, exe: str, compiler_type: 'compilers.CompilerType'):
+        super().__init__('ccrx', exe, compiler_type)
+
+    def get_linker_lib_prefix(self) -> str:
+        return '-lib='
+
+    def get_linker_exelist(self) -> List[str]:
+        return ['rlink.exe']
+
+    def get_output_args(self, target: str) -> List[str]:
+        return ['-output={}'.format(target)]
+
+    def get_linker_output_args(self, outputname: str) -> List[str]:
+        return ['-output=' + outputname]
+
+
+class PGIDynamiclinker(DynamicLinker):
+
+    """PGI Linker."""

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -238,6 +238,7 @@ class CcrxLinker(StaticLinker):
     def get_buildtype_linker_args(self, buildtype):
         return []
 
+
     def get_linker_always_args(self):
         return ['-nologo', '-form=library']
 

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -22,6 +22,10 @@ class StaticLinker:
         """
         return mesonlib.is_windows()
 
+    def get_base_link_args(self, options):
+        """Like compilers.get_base_link_args, but for the static linker."""
+        return []
+
 
 class VisualStudioLinker(StaticLinker):
     always_args = ['/NOLOGO']

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -329,7 +329,7 @@ class InternalTests(unittest.TestCase):
 
     def test_compiler_args_class(self):
         cargsfunc = mesonbuild.compilers.CompilerArgs
-        cc = mesonbuild.compilers.CCompiler([], 'fake', False)
+        cc = mesonbuild.compilers.CCompiler([], 'fake', False, None)
         # Test that bad initialization fails
         self.assertRaises(TypeError, cargsfunc, [])
         self.assertRaises(TypeError, cargsfunc, [], [])
@@ -415,7 +415,7 @@ class InternalTests(unittest.TestCase):
     def test_compiler_args_class_gnuld(self):
         cargsfunc = mesonbuild.compilers.CompilerArgs
         ## Test --start/end-group
-        gcc = mesonbuild.compilers.GnuCCompiler([], 'fake', mesonbuild.compilers.CompilerType.GCC_STANDARD, False)
+        gcc = mesonbuild.compilers.GnuCCompiler([], 'fake', mesonbuild.compilers.CompilerType.GCC_STANDARD, False, None)
         ## Test that 'direct' append and extend works
         l = cargsfunc(gcc, ['-Lfoodir', '-lfoo'])
         self.assertEqual(l.to_native(copy=True), ['-Lfoodir', '-Wl,--start-group', '-lfoo', '-Wl,--end-group'])


### PR DESCRIPTION
This is the start of the work for splitting the representation of the compiler and the dynamic linker into separate classes. The goal of this is ultimately to allow us to use the correct linker in all cases, instead of assuming that Clang uses gnu-ld, or other cases.

This is currently not ready to merge. There are still a couple of regressions on Linux I need to fix, as well as a host of compilers that I don't have access to that need to be updated and tested, including PGI, flang, elbrus, the sun fortran compiler, pathscale, swift, the arm compilers, and ccrx. I also haven't tested this on Windows or MacOS yet. While I think this is the right set of changes for an initial pass of the idea, I'd like to make a couple more changes, but in separate series:

- Break the DynamicLinker out of the compiler as a peer object
- Add a generic way to change the linker, such as via an `LD` field in cross/native files
- Detect the linker in use and use the correct representation, like we do for compilers.

As long as this looks okay to people my next steps will be to test/fix windows and macos, and start pinging people who've added support for other compiler families to help with those.

Fixes #4837 
