### PR TITLE
Support a NINJA environment variable

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -111,7 +111,8 @@ def find_coverage_tools():
     return gcovr_exe, gcovr_new_rootdir, lcov_exe, genhtml_exe
 
 def detect_ninja(version='1.5', log=False):
-    for n in ['ninja', 'ninja-build', 'samu']:
+    env_ninja = os.environ.get('NINJA', None)
+    for n in [env_ninja] if env_ninja else ['ninja', 'ninja-build', 'samu']:
         try:
             p, found = Popen_safe([n, '--version'])[0:2]
         except (FileNotFoundError, PermissionError):
@@ -121,8 +122,9 @@ def detect_ninja(version='1.5', log=False):
         # Perhaps we should add a way for the caller to know the failure mode
         # (not found or too old)
         if p.returncode == 0 and mesonlib.version_compare(found, '>=' + version):
+            n = shutil.which(n)
             if log:
-                mlog.log('Found ninja-{} at {}'.format(found, shlex.quote(shutil.which(n))))
+                mlog.log('Found ninja-{} at {}'.format(found, shlex.quote(n)))
             return n
 
 def detect_native_windows_arch():

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -124,7 +124,14 @@ def detect_ninja(version='1.5', log=False):
         if p.returncode == 0 and mesonlib.version_compare(found, '>=' + version):
             n = shutil.which(n)
             if log:
-                mlog.log('Found ninja-{} at {}'.format(found, shlex.quote(n)))
+                name = os.path.basename(n)
+                if name.endswith('-' + found):
+                    name = name[0:-1 - len(found)]
+                if name == 'ninja-build':
+                    name = 'ninja'
+                if name == 'samu':
+                    name = 'samurai'
+                mlog.log('Found {}-{} at {}'.format(name, found, shlex.quote(n)))
             return n
 
 def detect_native_windows_arch():


### PR DESCRIPTION
I found this in issue #3405:

> We specify other program overrides with envvars (CC et al). I guess we would use NINJA for this at least until "native file" support materialises.

I am not sure what is "native file support", anyway this pull request adds support for NINJA.