### PR TITLE
Bug fixes in get_partial_dependency

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2148,6 +2148,9 @@ an external dependency with the following methods:
    dep3 will add `['-Werror=foo', '-Werror=bar']` to the compiler args
    of any target it is added to, but libfoo will not be added to the
    link_args.
+   
+   *Note*: A bug present until 0.51.0 results in the above behavior
+   not working correctly.
 
    The following arguments will add the following attributes:
 

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -161,8 +161,9 @@ class Dependency:
     def get_configtool_variable(self, variable_name):
         raise DependencyException('{!r} is not a config-tool dependency'.format(self.name))
 
-    def get_partial_dependency(self, *, compile_args=False, link_args=False,
-                               links=False, includes=False, sources=False):
+    def get_partial_dependency(self, *, compile_args: bool = False,
+                               link_args: bool = False, links: bool = False,
+                               includes: bool = False, sources: bool = False):
         """Create a new dependency that contains part of the parent dependency.
 
         The following options can be inherited:
@@ -200,8 +201,9 @@ class InternalDependency(Dependency):
         raise DependencyException('Method "get_configtool_variable()" is '
                                   'invalid for an internal dependency')
 
-    def get_partial_dependency(self, *, compile_args=False, link_args=False,
-                               links=False, includes=False, sources=False):
+    def get_partial_dependency(self, *, compile_args: bool = False,
+                               link_args: bool = False, links: bool = False,
+                               includes: bool = False, sources: bool = False):
         compile_args = self.compile_args.copy() if compile_args else []
         link_args = self.link_args.copy() if link_args else []
         libraries = self.libraries.copy() if links else []
@@ -262,8 +264,9 @@ class ExternalDependency(Dependency):
     def get_compiler(self):
         return self.clib_compiler
 
-    def get_partial_dependency(self, *, compile_args=False, link_args=False,
-                               links=False, includes=False, sources=False):
+    def get_partial_dependency(self, *, compile_args: bool = False,
+                               link_args: bool = False, links: bool = False,
+                               includes: bool = False, sources: bool = False):
         new = copy.copy(self)
         if not compile_args:
             new.compile_args = []
@@ -326,8 +329,9 @@ class NotFoundDependency(Dependency):
         self.name = 'not-found'
         self.is_found = False
 
-    def get_partial_dependency(self, *, compile_args=False, link_args=False,
-                               links=False, includes=False, sources=False):
+    def get_partial_dependency(self, *, compile_args: bool = False,
+                               link_args: bool = False, links: bool = False,
+                               includes: bool = False, sources: bool = False):
         return copy.copy(self)
 
 
@@ -2169,8 +2173,9 @@ class ExternalLibrary(ExternalDependency):
             return []
         return super().get_link_args(**kwargs)
 
-    def get_partial_dependency(self, *, compile_args=False, link_args=False,
-                               links=False, includes=False, sources=False):
+    def get_partial_dependency(self, *, compile_args: bool = False,
+                               link_args: bool = False, links: bool = False,
+                               includes: bool = False, sources: bool = False):
         # External library only has link_args, so ignore the rest of the
         # interface.
         new = copy.copy(self)

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -275,6 +275,10 @@ class ExternalDependency(Dependency):
             new.link_args = []
         if not sources:
             new.sources = []
+        if not includes:
+            new.include_directories = []
+        if not sources:
+            new.sources = []
 
         return new
 

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -204,18 +204,19 @@ class InternalDependency(Dependency):
     def get_partial_dependency(self, *, compile_args: bool = False,
                                link_args: bool = False, links: bool = False,
                                includes: bool = False, sources: bool = False):
-        compile_args = self.compile_args.copy() if compile_args else []
-        link_args = self.link_args.copy() if link_args else []
-        libraries = self.libraries.copy() if links else []
-        whole_libraries = self.whole_libraries.copy() if links else []
-        sources = self.sources.copy() if sources else []
-        includes = self.include_directories.copy() if includes else []
-        deps = [d.get_partial_dependency(
+        final_compile_args = self.compile_args.copy() if compile_args else []
+        final_link_args = self.link_args.copy() if link_args else []
+        final_libraries = self.libraries.copy() if links else []
+        final_whole_libraries = self.whole_libraries.copy() if links else []
+        final_sources = self.sources.copy() if sources else []
+        final_includes = self.include_directories.copy() if includes else []
+        final_deps = [d.get_partial_dependency(
             compile_args=compile_args, link_args=link_args, links=links,
             includes=includes, sources=sources) for d in self.ext_deps]
         return InternalDependency(
-            self.version, includes, compile_args, link_args, libraries,
-            whole_libraries, sources, deps)
+            self.version, final_includes, final_compile_args,
+            final_link_args, final_libraries, final_whole_libraries,
+            final_sources, final_deps)
 
 
 class ExternalDependency(Dependency):

--- a/test cases/common/189 partial dependency/declare_dependency/meson.build
+++ b/test cases/common/189 partial dependency/declare_dependency/meson.build
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+dec_sub_dep = declare_dependency(
+  include_directories : include_directories('headers'),
+)
+
 dec_dep = declare_dependency(
   sources : files('headers/foo.c'),
-  include_directories : include_directories('headers'),
+  dependencies : dec_sub_dep,
 )
 
 sub_dep = dec_dep.partial_dependency(includes : true)


### PR DESCRIPTION
There is a bug in the `partial_dependency` method of `declare_dependency` that manifests when a subdependency (one added through the `dependencies` keyword) has attributes that the parent doesn't. In these cases the partial dependency will not have the attributes from the subdependencies.

In looking at that I realized that the implementation for `dependency` ignores the `sources` and `includes` arguments, which it shouldn't.

Since the first bug would have been found by type annotations, I've added those as well.