### PR TITLE
compilers: respect cross-file flags in sanity checks [0.50.* only]

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -315,6 +315,7 @@ class CCompiler(Compiler):
         binname = sname.rsplit('.', 1)[0]
         if self.is_cross:
             binname += '_cross'
+            extra_flags += environment.coredata.get_external_args(MachineChoice.HOST, self.language)
             if self.exe_wrapper is None:
                 # Linking cross built apps is painful. You can't really
                 # tell if you should use -nostdlib or not and for example
@@ -322,6 +323,8 @@ class CCompiler(Compiler):
                 # a ton of compiler flags to differentiate between
                 # arm and x86_64. So just compile.
                 extra_flags += self.get_compile_only_args()
+            else:
+                extra_flags += environment.coredata.get_external_link_args(MachineChoice.HOST, self.language)
         # Is a valid executable output for all toolchains and platforms
         binname += '.exe'
         # Write binary check source

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -30,7 +30,7 @@ from .compilers import (
     PGICompiler
 )
 
-from mesonbuild.mesonlib import EnvironmentException, is_osx
+from mesonbuild.mesonlib import EnvironmentException, MachineChoice, is_osx
 
 
 class FortranCompiler(Compiler):
@@ -78,7 +78,10 @@ class FortranCompiler(Compiler):
         binary_name = os.path.join(work_dir, 'sanitycheckf')
         with open(source_name, 'w') as ofile:
             ofile.write('print *, "Fortran compilation is working."; end')
-        pc = subprocess.Popen(self.exelist + [source_name, '-o', binary_name])
+        if self.is_cross:
+            extra_flags = environment.coredata.get_external_args(MachineChoice.HOST, self.language)
+            extra_flags += environment.coredata.get_external_link_args(MachineChoice.HOST, self.language)
+        pc = subprocess.Popen(self.exelist + extra_flags + [source_name, '-o', binary_name])
         pc.wait()
         if pc.returncode != 0:
             raise EnvironmentException('Compiler %s can not compile programs.' % self.name_string())

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -14,7 +14,7 @@
 
 import os.path, subprocess
 
-from ..mesonlib import EnvironmentException
+from ..mesonlib import EnvironmentException, MachineChoice
 
 from .c import CCompiler
 from .compilers import ClangCompiler, GnuCompiler
@@ -33,6 +33,7 @@ class ObjCCompiler(CCompiler):
         binary_name = os.path.join(work_dir, 'sanitycheckobjc')
         extra_flags = []
         if self.is_cross:
+            extra_flags += environment.coredata.get_external_args(MachineChoice.HOST, self.language)
             extra_flags += self.get_compile_only_args()
         with open(source_name, 'w') as ofile:
             ofile.write('#import<stdio.h>\n'

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -14,7 +14,7 @@
 
 import subprocess, os.path
 
-from ..mesonlib import EnvironmentException
+from ..mesonlib import EnvironmentException, MachineChoice
 
 from .compilers import Compiler, swift_buildtype_args, clike_debug_args
 
@@ -105,7 +105,11 @@ class SwiftCompiler(Compiler):
         with open(source_name, 'w') as ofile:
             ofile.write('''print("Swift compilation is working.")
 ''')
-        pc = subprocess.Popen(self.exelist + ['-emit-executable', '-o', output_name, src], cwd=work_dir)
+        extra_flags = []
+        if self.is_cross:
+            extra_flags += environment.coredata.get_external_args(MachineChoice.HOST, self.language)
+            extra_flags += environment.coredata.get_external_link_args(MachineChoice.HOST, self.language)
+        pc = subprocess.Popen(self.exelist + extra_flags + ['-emit-executable', '-o', output_name, src], cwd=work_dir)
         pc.wait()
         if pc.returncode != 0:
             raise EnvironmentException('Swift compiler %s can not compile programs.' % self.name_string())

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -15,7 +15,7 @@
 import os.path
 
 from .. import mlog
-from ..mesonlib import EnvironmentException, version_compare
+from ..mesonlib import EnvironmentException, MachineChoice, version_compare
 
 from .compilers import Compiler
 
@@ -87,7 +87,10 @@ class ValaCompiler(Compiler):
 
     def sanity_check(self, work_dir, environment):
         code = 'class MesonSanityCheck : Object { }'
-        with self.compile(code, [], 'compile') as p:
+        args = []
+        if self.is_cross:
+            args += environment.coredata.get_external_args(MachineChoice.HOST, self.language)
+        with self.compile(code, args, 'compile') as p:
             if p.returncode != 0:
                 msg = 'Vala compiler {!r} can not compile programs' \
                       ''.format(self.name_string())
@@ -106,7 +109,11 @@ class ValaCompiler(Compiler):
         if not extra_dirs:
             code = 'class MesonFindLibrary : Object { }'
             vapi_args = ['--pkg', libname]
-            with self.compile(code, vapi_args, 'compile') as p:
+            args = []
+            if self.is_cross:
+                args += env.coredata.get_external_args(MachineChoice.HOST, self.language)
+            args += vapi_args
+            with self.compile(code, args, 'compile') as p:
                 if p.returncode == 0:
                     return vapi_args
         # Not found? Try to find the vapi file itself.


### PR DESCRIPTION
Builds with Meson 0.50.0 fail in this special case:

[binaries]
c = '.../arm-unknown-linux-uclibcgnueabi/bin/arm-unknown-linux-uclibcgnueabi-gcc'
...

[binaries]
exe_wrapper = 'qemu-arm-static'
...

[properties]
c_link_args = ['-static']
...

The sanity check output is not a static binary, as it used (and expected to be)
with Meson < 0.50.0. The crosstool-ng built uClibc is not present in the
build machine's /lib, so the sanity check fails.

This bug was introduced in d451a4bd97f827bb492fd0c0e357cb20b6056ed9.
This partially reverts that for `0.50.*`. master will instead always use
this flags in cross and native alike for consistency as per #5128.

Fixes #5086.