### PR TITLE
Add 'meson subprojects foreach' command

### DIFF
--- a/docs/markdown/Subprojects.md
+++ b/docs/markdown/Subprojects.md
@@ -235,7 +235,7 @@ To pull latest version of all your subprojects at once, just run the command:
 The command-line `meson subprojects checkout <branch_name>` will checkout a
 branch, or create one with `-b` argument, in every git subprojects. This is
 useful when starting local changes across multiple subprojects. It is still your
-responsability to commit and push in each repository where you made local
+responsibility to commit and push in each repository where you made local
 changes.
 
 To come back to the revision set in wrap file (i.e. master), just run

--- a/docs/markdown/Subprojects.md
+++ b/docs/markdown/Subprojects.md
@@ -241,6 +241,15 @@ changes.
 To come back to the revision set in wrap file (i.e. master), just run
 `meson subprojects checkout` with no branch name.
 
+## Execute a command on all subprojects
+
+*Since 0.51.0*
+
+The command-line `meson subprojects foreach <command> [...]` will
+execute a command in each subproject directory. For example this can be useful
+to check the status of subprojects (e.g. with `git status` or `git diff`) before
+performing other actions on them.
+
 ## Why must all subprojects be inside a single directory?
 
 There are several reasons.

--- a/docs/markdown/snippets/subproject-foreach.md
+++ b/docs/markdown/snippets/subproject-foreach.md
@@ -1,0 +1,7 @@
+## Add new `meson subprojects foreach` command
+
+`meson subprojects` has learned a new `foreach` command which accepts a command
+with arguments and executes it in each subproject directory.
+
+For example this can be useful to check the status of subprojects (e.g. with
+`git status` or `git diff`) before performing other actions on them.


### PR DESCRIPTION
Sometimes it is convenient to run an arbitrary command (e.g. 'git diff')
on all subprojects.

Add a 'meson subprojects foreach' command to take care of that.

For this command the common argument 'subprojects' does not make sense,
so only add '--sourcedir' and cover the case of a missing
options.subprojects in run().

If there is interest in this new command I will update the docs too.

The name `foreach` has been suggested by @xclaesse 

Thanks, Antonio