### PR TITLE
docs: Document when environment() was added

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -456,7 +456,8 @@ Print the argument string and halts the build process.
     environment_object environment()
 ```
 
-Returns an empty [environment variable object](#environment-object).
+Returns an empty [environment variable object](#environment-object). Added in
+0.35.0.
 
 ### executable()
 


### PR DESCRIPTION
The environment() function was added in 0.35.0 (which contains a2e7ebc5,
containing the actual addition)