### PR TITLE
CMake llvm dependency backend

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1462,7 +1462,7 @@ class CMakeDependency(ExternalDependency):
         self.compile_args = compileOptions + compileDefinitions + list(map(lambda x: '-I{}'.format(x), incDirs))
         self.link_args = libraries
 
-    def get_first_cmake_var_of(self, var_list):
+    def get_first_cmake_var_of(self, var_list: List[str]) -> List[str]:
         # Return the first found CMake variable in list var_list
         for i in var_list:
             if i in self.vars:
@@ -1470,7 +1470,7 @@ class CMakeDependency(ExternalDependency):
 
         return []
 
-    def get_cmake_var(self, var):
+    def get_cmake_var(self, var: str) -> List[str]:
         # Return the value of the CMake variable var or an empty list if var does not exist
         if var in self.vars:
             return self.vars[var]
@@ -1779,6 +1779,7 @@ set(CMAKE_SIZEOF_VOID_P "{}")
 
     def log_details(self) -> str:
         modules = [self._original_module_name(x) for x in self.found_modules]
+        modules = sorted(set(modules))
         if modules:
             return 'modules: ' + ', '.join(modules)
         return ''

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -971,10 +971,10 @@ class CMakeDependency(ExternalDependency):
     def _gen_exception(self, msg):
         return DependencyException('Dependency {} not found: {}'.format(self.name, msg))
 
-    def _main_cmake_file(self):
+    def _main_cmake_file(self) -> str:
         return 'CMakeLists.txt'
 
-    def _extra_cmake_opts(self):
+    def _extra_cmake_opts(self) -> List[str]:
         return []
 
     def _map_module_list(self, modules: List[Tuple[str, bool]]) -> List[Tuple[str, bool]]:

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -35,7 +35,7 @@ from .. import mesonlib
 from ..compilers import clib_langs
 from ..environment import BinaryTable, Environment, MachineInfo
 from ..mesonlib import MachineChoice, MesonException, OrderedSet, PerMachine
-from ..mesonlib import Popen_safe, version_compare_many, version_compare, listify
+from ..mesonlib import Popen_safe, version_compare_many, version_compare, listify, stringlistify, extract_as_list
 from ..mesonlib import Version, LibType
 
 # These must be defined in this file to avoid cyclical references.
@@ -1074,16 +1074,10 @@ class CMakeDependency(ExternalDependency):
         if self.cmakeinfo is None:
             raise self._gen_exception('Unable to obtain CMake system information')
 
-        modules = [(x, True) for x in kwargs.get('modules', [])]
-        modules += [(x, False) for x in kwargs.get('optional_modules', [])]
-        cm_path = kwargs.get('cmake_module_path', [])
-        cm_args = kwargs.get('cmake_args', [])
-        if not isinstance(modules, list):
-            modules = [modules]
-        if not isinstance(cm_path, list):
-            cm_path = [cm_path]
-        if not isinstance(cm_args, list):
-            cm_args = [cm_args]
+        modules = [(x, True) for x in stringlistify(extract_as_list(kwargs, 'modules'))]
+        modules += [(x, False) for x in stringlistify(extract_as_list(kwargs, 'optional_modules'))]
+        cm_path = stringlistify(extract_as_list(kwargs, 'cmake_module_path'))
+        cm_args = stringlistify(extract_as_list(kwargs, 'cmake_args'))
         cm_path = [x if os.path.isabs(x) else os.path.join(environment.get_source_dir(), x) for x in cm_path]
         if cm_path:
             cm_args += ['-DCMAKE_MODULE_PATH={}'.format(';'.join(cm_path))]

--- a/mesonbuild/dependencies/data/CMakeListsLLVM.txt
+++ b/mesonbuild/dependencies/data/CMakeListsLLVM.txt
@@ -1,0 +1,70 @@
+cmake_minimum_required(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION} )
+
+set(PACKAGE_FOUND FALSE)
+
+while(TRUE)
+  find_package(LLVM REQUIRED CONFIG QUIET)
+
+  # ARCHS has to be set via the CMD interface
+  if(LLVM_FOUND OR "${ARCHS}" STREQUAL "")
+    break()
+  endif()
+
+  list(GET       ARCHS 0 CMAKE_LIBRARY_ARCHITECTURE)
+  list(REMOVE_AT ARCHS 0)
+endwhile()
+
+if(LLVM_FOUND)
+  set(PACKAGE_FOUND TRUE)
+
+  llvm_map_components_to_libnames(llvm_libs ${LLVM_MESON_MODULES})
+  set(MESON_RESOLVED_LLVM_MODULES ${llvm_libs})
+
+  # Check the following variables:
+  # LLVM_PACKAGE_VERSION
+  # LLVM_VERSION
+  # LLVM_VERSION_STRING
+  if(NOT DEFINED PACKAGE_VERSION)
+    if(DEFINED LLVM_PACKAGE_VERSION)
+      set(PACKAGE_VERSION "${LLVM_PACKAGE_VERSION}")
+    elseif(DEFINED LLVM_VERSION)
+      set(PACKAGE_VERSION "${LLVM_VERSION}")
+    elseif(DEFINED LLVM_VERSION_STRING)
+      set(PACKAGE_VERSION "${LLVM_VERSION_STRING}")
+    endif()
+  endif()
+
+  # Check the following variables:
+  # LLVM_LIBRARIES
+  # LLVM_LIBS
+  set(libs)
+  if(DEFINED LLVM_LIBRARIES)
+    set(libs LLVM_LIBRARIES)
+  elseif(DEFINED LLVM_LIBS)
+    set(libs LLVM_LIBS)
+  endif()
+
+  # Check the following variables:
+  # LLVM_INCLUDE_DIRS
+  # LLVM_INCLUDES
+  # LLVM_INCLUDE_DIR
+  set(includes)
+  if(DEFINED LLVM_INCLUDE_DIRS)
+    set(includes LLVM_INCLUDE_DIRS)
+  elseif(DEFINED LLVM_INCLUDES)
+    set(includes LLVM_INCLUDES)
+  elseif(DEFINED LLVM_INCLUDE_DIR)
+    set(includes LLVM_INCLUDE_DIR)
+  endif()
+
+  # Check the following variables:
+  # LLVM_DEFINITIONS
+  set(definitions)
+  if(DEFINED LLVM_DEFINITIONS)
+    set(definitions LLVM_DEFINITIONS)
+  endif()
+
+  set(PACKAGE_INCLUDE_DIRS "${${includes}}")
+  set(PACKAGE_DEFINITIONS  "${${definitions}}")
+  set(PACKAGE_LIBRARIES    "${${libs}}")
+endif()

--- a/mesonbuild/dependencies/data/CMakeListsLLVM.txt
+++ b/mesonbuild/dependencies/data/CMakeListsLLVM.txt
@@ -17,8 +17,10 @@ endwhile()
 if(LLVM_FOUND)
   set(PACKAGE_FOUND TRUE)
 
-  llvm_map_components_to_libnames(llvm_libs ${LLVM_MESON_MODULES})
-  set(MESON_RESOLVED_LLVM_MODULES ${llvm_libs})
+  llvm_map_components_to_libnames(llvm_libs     ${LLVM_MESON_MODULES})
+  llvm_map_components_to_libnames(llvm_libs_opt ${LLVM_MESON_OPT_MODULES})
+  set(MESON_RESOLVED_LLVM_MODULES     ${llvm_libs})
+  set(MESON_RESOLVED_LLVM_MODULES_OPT ${llvm_libs_opt})
 
   # Check the following variables:
   # LLVM_PACKAGE_VERSION

--- a/mesonbuild/dependencies/data/CMakeListsLLVM.txt
+++ b/mesonbuild/dependencies/data/CMakeListsLLVM.txt
@@ -17,10 +17,33 @@ endwhile()
 if(LLVM_FOUND)
   set(PACKAGE_FOUND TRUE)
 
-  llvm_map_components_to_libnames(llvm_libs     ${LLVM_MESON_MODULES})
-  llvm_map_components_to_libnames(llvm_libs_opt ${LLVM_MESON_OPT_MODULES})
-  set(MESON_RESOLVED_LLVM_MODULES     ${llvm_libs})
-  set(MESON_RESOLVED_LLVM_MODULES_OPT ${llvm_libs_opt})
+  foreach(mod IN LISTS LLVM_MESON_MODULES)
+    # Reset variables
+    set(out_mods)
+    set(real_mods)
+
+    # Generate a lower and upper case version
+    string(TOLOWER "${mod}" mod_L)
+    string(TOUPPER "${mod}" mod_U)
+
+    # Get the mapped components
+    llvm_map_components_to_libnames(out_mods ${mod} ${mod_L} ${mod_U})
+    list(SORT              out_mods)
+    list(REMOVE_DUPLICATES out_mods)
+
+    # Make sure that the modules exist
+    foreach(i IN LISTS out_mods)
+      if(TARGET ${i})
+        list(APPEND real_mods ${i})
+      endif()
+    endforeach()
+
+    # Set the output variables
+    set(MESON_LLVM_TARGETS_${mod} ${real_mods})
+    foreach(i IN LISTS real_mods)
+      set(MESON_TARGET_TO_LLVM_${i} ${mod})
+    endforeach()
+  endforeach()
 
   # Check the following variables:
   # LLVM_PACKAGE_VERSION

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -401,7 +401,8 @@ class LLVMDependencyConfigTool(ConfigToolDependency):
 
 class LLVMDependencyCMake(CMakeDependency):
     def __init__(self, env, kwargs):
-        self.llvm_modules = kwargs.get('modules', [])
+        self.llvm_modules = stringlistify(extract_as_list(kwargs, 'modules'))
+        self.llvm_opt_modules = stringlistify(extract_as_list(kwargs, 'optional_modules'))
         super().__init__(name='LLVM', environment=env, language='cpp', kwargs=kwargs)
 
         # Extract extra include directories and definitions
@@ -415,10 +416,13 @@ class LLVMDependencyCMake(CMakeDependency):
         return 'CMakeListsLLVM.txt'
 
     def _extra_cmake_opts(self):
-        return ['-DLLVM_MESON_MODULES={}'.format(';'.join(self.llvm_modules))]
+        return ['-DLLVM_MESON_MODULES={}'.format(';'.join(self.llvm_modules)),
+                '-DLLVM_MESON_OPT_MODULES={}'.format(';'.join(self.llvm_opt_modules))]
 
     def _map_module_list(self, modules):
-        return self.get_cmake_var('MESON_RESOLVED_LLVM_MODULES')
+        modules = [(x, True) for x in self.get_cmake_var('MESON_RESOLVED_LLVM_MODULES')]
+        modules += [(x, False) for x in self.get_cmake_var('MESON_RESOLVED_LLVM_MODULES_OPT')]
+        return modules
 
     def need_threads(self):
         return True

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -412,6 +412,7 @@ class LLVMDependencyCMake(CMakeDependency):
         defs = self.get_cmake_var('PACKAGE_DEFINITIONS')
         temp = ['-I' + x for x in inc_dirs] + defs
         self.compile_args += [x for x in temp if x not in self.compile_args]
+        self._add_sub_dependency(ThreadDependency, env, kwargs)
 
     def _main_cmake_file(self) -> str:
         # Use a custom CMakeLists.txt for LLVM
@@ -439,9 +440,6 @@ class LLVMDependencyCMake(CMakeDependency):
         if orig_name:
             return orig_name[0]
         return module
-
-    def need_threads(self) -> bool:
-        return True
 
 class LLVMDependency(ExternalDependency):
     def __init__(self, env, kwargs):

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -192,7 +192,7 @@ class GMockDependency(ExternalDependency):
         return [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM]
 
 
-class LLVMDependency(ConfigToolDependency):
+class LLVMDependencyConfigTool(ConfigToolDependency):
     """
     LLVM uses a special tool, llvm-config, which has arguments for getting
     c args, cxx args, and ldargs as well as version.
@@ -399,6 +399,23 @@ class LLVMDependency(ConfigToolDependency):
             return 'modules: ' + ', '.join(self.module_details)
         return ''
 
+class LLVMDependency(ExternalDependency):
+    def __init__(self, env, kwargs):
+        super().__init__('LLVM', env, 'cpp', kwargs)
+
+    @classmethod
+    def _factory(cls, env, kwargs):
+        methods = cls._process_method_kw(kwargs)
+        candidates = []
+
+        if DependencyMethods.CONFIG_TOOL in methods:
+            candidates.append(functools.partial(LLVMDependencyConfigTool, env, kwargs))
+
+        return candidates
+
+    @staticmethod
+    def get_methods():
+        return [DependencyMethods.CONFIG_TOOL]
 
 class ValgrindDependency(PkgConfigDependency):
     '''

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -28,6 +28,8 @@ from .base import (
 )
 from .misc import ThreadDependency
 
+from typing import List, Tuple
+
 
 def get_shared_library_suffix(environment, native):
     """This is only gauranteed to work for languages that compile to machine
@@ -406,28 +408,28 @@ class LLVMDependencyCMake(CMakeDependency):
         super().__init__(name='LLVM', environment=env, language='cpp', kwargs=kwargs)
 
         # Extract extra include directories and definitions
-        incDirs = self.get_cmake_var('PACKAGE_INCLUDE_DIRS')
+        inc_dirs = self.get_cmake_var('PACKAGE_INCLUDE_DIRS')
         defs = self.get_cmake_var('PACKAGE_DEFINITIONS')
-        temp = list(map(lambda x: '-I{}'.format(x), incDirs)) + defs
+        temp = ['-I' + x for x in inc_dirs] + defs
         self.compile_args += [x for x in temp if x not in self.compile_args]
 
-    def _main_cmake_file(self):
+    def _main_cmake_file(self) -> str:
         # Use a custom CMakeLists.txt for LLVM
         return 'CMakeListsLLVM.txt'
 
-    def _extra_cmake_opts(self):
+    def _extra_cmake_opts(self) -> List[str]:
         return ['-DLLVM_MESON_MODULES={}'.format(';'.join(self.llvm_modules)),
                 '-DLLVM_MESON_OPT_MODULES={}'.format(';'.join(self.llvm_opt_modules))]
 
-    def _map_module_list(self, modules):
+    def _map_module_list(self, modules: List[Tuple[str, bool]]) -> List[Tuple[str, bool]]:
         modules = [(x, True) for x in self.get_cmake_var('MESON_RESOLVED_LLVM_MODULES')]
         modules += [(x, False) for x in self.get_cmake_var('MESON_RESOLVED_LLVM_MODULES_OPT')]
         return modules
 
-    def need_threads(self):
+    def need_threads(self) -> bool:
         return True
 
-    def log_details(self):
+    def log_details(self) -> str:
         modules = self.get_cmake_var('MESON_RESOLVED_LLVM_MODULES')
         if modules:
             return 'modules: ' + ', '.join(modules)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ packages = ['mesonbuild',
             'mesonbuild.modules',
             'mesonbuild.scripts',
             'mesonbuild.wrap']
-package_data = {'mesonbuild.dependencies': ['data/CMakeLists.txt', 'data/CMakePathInfo.txt']}
+package_data = {'mesonbuild.dependencies': ['data/CMakeLists.txt', 'data/CMakeListsLLVM.txt', 'data/CMakePathInfo.txt']}
 data_files = []
 if sys.platform != 'win32':
     # Only useful on UNIX-like systems

--- a/test cases/common/161 config tool variable/meson.build
+++ b/test cases/common/161 config tool variable/meson.build
@@ -15,7 +15,7 @@
 project('config tool variable', 'cpp')
 
 
-dep_llvm = dependency('llvm', required : false)
+dep_llvm = dependency('llvm', method : 'config-tool', required : false)
 if not dep_llvm.found()
   error('MESON_SKIP_TEST LLVM not installed.')
 endif

--- a/test cases/frameworks/15 llvm/meson.build
+++ b/test cases/frameworks/15 llvm/meson.build
@@ -35,7 +35,7 @@ foreach static : [true, false]
   llvm_dep = dependency(
     'llvm',
     modules : ['bitwriter', 'asmprinter', 'executionengine', 'target',
-               'mcjit', 'nativecodegen'],
+               'mcjit', 'nativecodegen', 'amdgpu'],
     required : false,
     static : static,
   )

--- a/test cases/unit/47 native file binary/meson.build
+++ b/test cases/unit/47 native file binary/meson.build
@@ -8,7 +8,7 @@ if case == 'find_program'
   assert(result.stdout().strip().endswith('12345'), 'Didn\'t load bash from config file')
 elif case == 'config_dep'
   add_languages('cpp')
-  dep = dependency('llvm')
+  dep = dependency('llvm', method : 'config-tool')
   assert(dep.get_configtool_variable('version').endswith('12345'), 'Didn\'t load llvm from config file')
 elif case == 'python3'
   prog = import('python3').find_python()


### PR DESCRIPTION
This PR adds support for finding the LLVM framework with CMake. It also includes some generalizations for the base CMake dependency class to provide extensibility.

The `static` keyword isn't supported / is ignored because it is not really possible to tell CMake to find the static or shared version of a library.

This PR should fix #4861 and #4802

CC @dcbaker