### PR TITLE
Add dependency('lapack') for several configurations

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -318,6 +318,10 @@ LAPACK95 adds convenient Fortran interfaces to the base LAPACK implementation:
 * Intel MKL: `dependency('lapack', modules: 'mkl95')`
 * Intel MKL: `dependency('lapack', modules: 'netlib95')`
 
+The default language is `c`, so Fortran targets will use:
+```meson
+lapack_f = dependency('lapack', ..., language: 'fortran')
+```
 
 Tested configurations include:
 

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -301,6 +301,48 @@ language-specific, you must specify the requested language using the
 Meson uses pkg-config to find HDF5. The standard low-level HDF5 function and the `HL` high-level HDF5 functions are linked for each language.
 
 
+## LAPACK
+
+*(added 0.51.0)*
+
+
+LAPACK is a widely used linear algebra library with numerous implementations.
+Meson can specify numerous LAPACK vendors and configurations.
+
+* Intel MKL: `dependency('lapack', modules: 'mkl')`
+* Atlas: `dependency('lapack', modules: 'atlas')`
+* Netlib (default): `dependency('lapack', modules: 'netlib')
+
+LAPACK95 adds convenient Fortran interfaces to the base LAPACK implementation:
+
+* Intel MKL: `dependency('lapack', modules: 'mkl95')`
+* Intel MKL: `dependency('lapack', modules: 'netlib95')`
+
+
+Tested configurations include:
+
+Windows:
+
+Compiler | Lapack
+---------|-------
+MSVC | Intel MKL
+PGI | Intel MKL
+
+
+Linux:
+
+Compiler | Lapack
+---------|-------
+gcc + gfortran | Netlib Lapack
+gcc + gfortran | Intel MKL
+gcc + gfortran | Atlas
+Clang + gfortran  | Netlib Lapack
+Clang + gfortran  | Intel MKL
+Clang + gfortran  | Atlas
+Clang + Flang | Netlib Lapack
+Clang + Flang | Intel MKL
+Clang + Flang | Atlas
+
 ## libwmf
 
 *(added 0.44.0)*

--- a/docs/markdown/snippets/lapack.md
+++ b/docs/markdown/snippets/lapack.md
@@ -1,0 +1,4 @@
+## Lapack
+
+LAPACK is a widely used linear algebra library with numerous implementations.
+Meson &ge; 0.51 can specify numerous LAPACK vendors and configurations.

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -18,7 +18,7 @@ from .base import (  # noqa: F401
     ExternalDependency, NotFoundDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
     PkgConfigDependency, CMakeDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language)
 from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDependency
-from .misc import (CoarrayDependency, HDF5Dependency, MPIDependency, NetCDFDependency, OpenMPDependency, Python3Dependency, ThreadDependency, PcapDependency, CupsDependency, LibWmfDependency, LibGCryptDependency)
+from .misc import (CoarrayDependency, HDF5Dependency, LapackDependency, MPIDependency, NetCDFDependency, OpenMPDependency, Python3Dependency, ThreadDependency, PcapDependency, CupsDependency, LibWmfDependency, LibGCryptDependency)
 from .platform import AppleFrameworks
 from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, VulkanDependency
 
@@ -34,6 +34,7 @@ packages.update({
     'boost': BoostDependency,
     'coarray': CoarrayDependency,
     'mpi': MPIDependency,
+    'lapack': LapackDependency,
     'hdf5': HDF5Dependency,
     'netcdf': NetCDFDependency,
     'openmp': OpenMPDependency,
@@ -58,6 +59,7 @@ packages.update({
 })
 _packages_accept_language.update({
     'hdf5',
+    'lapack',
     'mpi',
     'netcdf',
     'openmp',

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1813,7 +1813,7 @@ class DubDependency(ExternalDependency):
                 for lib in target['buildSettings'][field_name]:
                     if lib not in libs:
                         libs.append(lib)
-                        if os.name is not 'nt':
+                        if os.name != 'nt':
                             pkgdep = PkgConfigDependency(lib, environment, {'required': 'true', 'silent': 'true'})
                             for arg in pkgdep.get_compile_args():
                                 self.compile_args.append(arg)

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -42,6 +42,9 @@ class LapackDependency(ExternalDependency):
         kwargs['silent'] = True
         self.is_found = False
 
+        if language not in ('c', 'cpp', 'fortran'):
+            raise DependencyException('Language {} is not supported with Lapack.'.format(language))
+
         modules: List[str] = kwargs.get('modules', [])
 
         mkltype = 'static' if self.static else 'dynamic'
@@ -68,9 +71,6 @@ class LapackDependency(ExternalDependency):
             pkgconfig_files += ['lapack', 'blas']
         else:
             raise DependencyException('Unknown LAPACK module {}'.format(modules))
-
-        if language not in ('c', 'cpp', 'fortran'):
-            raise DependencyException('Language {} is not supported with Lapack.'.format(language))
 
         self.compile_args = []
         self.link_args = []

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -45,7 +45,7 @@ class LapackDependency(ExternalDependency):
         if language not in ('c', 'cpp', 'fortran'):
             raise DependencyException('Language {} is not supported with Lapack.'.format(language))
 
-        modules: List[str] = kwargs.get('modules', [])
+        modules = kwargs.get('modules', [])  # type: List[str]
 
         mkltype = 'static' if self.static else 'dynamic'
 

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -498,6 +498,10 @@ def skippable(suite, test):
     if test.endswith('10 gtk-doc'):
         return True
 
+    # LAPACK is not in the CI image
+    if test.endswith('lapack'):
+        return True
+
     # NetCDF is not in the CI image
     if test.endswith('netcdf'):
         return True

--- a/test cases/frameworks/27 lapack/main.c
+++ b/test cases/frameworks/27 lapack/main.c
@@ -1,0 +1,42 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#if USEMKL == 1
+#include "mkl_lapacke.h"
+#elif USEATLAS == 1
+#include "cblas.h"
+#include "clapack.h"
+#else
+#include "lapacke.h"
+#endif
+int main(void) {
+
+    int n, nrhs, lda, ldb, info;
+    double *A, *b;
+    int *ipiv;
+
+    n = 2; nrhs = 1;
+
+
+     lda=n, ldb=n;
+     A = (double *)malloc(n*n*sizeof(double));
+     b = (double *)malloc(n*nrhs*sizeof(double));
+     ipiv = (int *)malloc(n*sizeof(int)) ;
+
+
+     A[0] = 1.;
+     A[1] = 0.5;
+     A[2] = 0.5;
+     A[3] = 1./3.;
+
+#if USEATLAS==1
+     info = clapack_dgesv( 102, n, nrhs, A, lda, ipiv, b, ldb );
+#else
+     info = LAPACKE_dgesv( LAPACK_COL_MAJOR, n, nrhs, A, lda, ipiv, b, ldb );
+#endif
+
+     if (info != 0) return 1;
+
+     return 0;
+}

--- a/test cases/frameworks/27 lapack/main.cpp
+++ b/test cases/frameworks/27 lapack/main.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+
+#if USEMKL == 1
+#include "mkl_lapacke.h"
+#elif USEATLAS == 1
+#include "cblas.h"
+#include "clapack.h"
+#else
+#include "lapacke.h"
+#endif
+int main(void) {
+
+    int n, nrhs, lda, ldb, info;
+    double *A, *b;
+    int *ipiv;
+
+    n = 2; nrhs = 1;
+
+
+     lda=n, ldb=n;
+     A = (double *)malloc(n*n*sizeof(double));
+     b = (double *)malloc(n*nrhs*sizeof(double));
+     ipiv = (int *)malloc(n*sizeof(int)) ;
+
+
+     A[0] = 1.;
+     A[1] = 0.5;
+     A[2] = 0.5;
+     A[3] = 1./3.;
+
+
+#if USEATLAS==1
+     info = clapack_dgesv( 102, n, nrhs, A, lda, ipiv, b, ldb );
+#else
+     info = LAPACKE_dgesv( LAPACK_COL_MAJOR, n, nrhs, A, lda, ipiv, b, ldb );
+#endif
+
+     if (info != 0) return EXIT_FAILURE;
+
+     return EXIT_SUCCESS;
+}

--- a/test cases/frameworks/27 lapack/main.f90
+++ b/test cases/frameworks/27 lapack/main.f90
@@ -1,0 +1,56 @@
+module demo_svd
+use, intrinsic :: iso_fortran_env, only: stderr=>error_unit, sp=>real32
+implicit none
+
+integer, parameter :: LRATIO=8
+integer, parameter :: M=2, N=2
+
+integer, parameter :: Lwork = LRATIO*M !at least 5M for sgesvd
+
+real(sp) :: U(M,M), VT(N,N), errmag(N)
+real(sp) :: S(N), truthS(N), SWORK(LRATIO*M) !this Swork is real
+
+contains
+
+subroutine errchk(info)
+
+integer, intent(in) :: info
+
+if (info /= 0) then
+  write(stderr,*) 'SGESVD return code', info
+  if (info > 0) write(stderr,'(A,I3,A)') 'index #',info,' has sigma=0'
+  stop 1
+endif
+
+end subroutine errchk
+
+end module demo_svd
+
+
+program demo
+use demo_svd
+implicit none
+
+integer :: info
+real(sp) :: A(M, N)
+
+A = reshape([1., 1./2, &
+             1./2, 1./3], shape(A), order=[2,1])
+
+truthS = [1.267592, 0.065741]
+
+call sgesvd('A','N',M,N, A, M,S,U,M,VT, N, SWORK, LWORK, info)
+
+errmag = abs(s-truthS)
+if (any(errmag > 1e-3)) then
+  print *,'estimated singular values: ',S
+  print *,'true singular values: ',truthS
+  write(stderr,*) 'large error on singular values', errmag
+  stop 1
+endif
+
+call errchk(info)
+
+print *,'OK: Fortran SVD'
+
+end program

--- a/test cases/frameworks/27 lapack/meson.build
+++ b/test cases/frameworks/27 lapack/meson.build
@@ -1,0 +1,37 @@
+project('lapack_test', 'c', 'cpp')
+
+cc = meson.get_compiler('c')
+ccid = cc.get_id()
+
+# --- C tests
+lapack_c = dependency('lapack', required : false)
+if not lapack_c.found()
+  error('MESON_SKIP_TEST: LAPACK C library not found, skipping tests.')
+endif
+exec = executable('exec', 'main.c', dependencies : lapack_c)
+
+test('LAPACK C', exec)
+
+# --- C++ tests
+lapack_cpp = dependency('lapack', required : false)
+if lapack_cpp.found()
+  execpp = executable('execpp', 'main.cpp', dependencies : lapack_cpp)
+  test('LAPACK C++', execpp)
+endif
+
+# --- Fortran tests
+if ccid != 'msvc' and ccid != 'clang-cl'
+  add_languages('fortran')
+
+  lapack_f = dependency('lapack', required : false)
+  if lapack_f.found()
+    exef = executable('exef', 'main.f90', dependencies : lapack_f)
+
+    test('LAPACK Fortran', exef)
+  endif
+endif
+
+# Check we can apply a version constraint
+if lapack_c.version() != 'unknown'
+  dependency('lapack', version: '>=@0@'.format(lapack_c.version()))
+endif


### PR DESCRIPTION
LAPACK is one of the most widely used numerical libraries for linear algebra.
We use PkgConfig to find Lapack across operating systems, compiler vendors and lapack vendors.

This is a library where CMake often has trouble, leading users (including myself) to write their own [FindLapack.cmake](https://github.com/scivision/lapack-cmake/blob/master/cmake/Modules/FindLAPACK.cmake).