### PR TITLE
detect 'arm64' as aarch64 CPU family

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -215,6 +215,9 @@ def detect_cpu_family(compilers):
         trial = 'x86'
     elif trial == 'bepc':
         trial = 'x86'
+    # OpenBSD's 64 bit arm architecute identifies as 'arm64'
+    elif trial == 'arm64':
+        trial = 'aarch64'
     elif trial.startswith('arm'):
         trial = 'arm'
     elif trial.startswith('ppc64'):


### PR DESCRIPTION
OpenBSD uses arm64 as identifier for the 64-bit ARM architecture.
Refs #1578.

Hopefully fixes an OpenBSD build error in dav1d https://code.videolan.org/videolan/dav1d/issues/268. OpenBSD `uname -m` returns 'arm64'.