### PR TITLE
 mintro: Fix crash when required is a function (closes #5177)

### DIFF
--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -153,7 +153,19 @@ class AstInterpreter(interpreterbase.InterpreterBase):
         return True
 
     def evaluate_arithmeticstatement(self, cur):
+        self.evaluate_statement(cur.left)
+        self.evaluate_statement(cur.right)
         return 0
+
+    def evaluate_uminusstatement(self, cur):
+        self.evaluate_statement(cur.value)
+        return 0
+
+    def evaluate_ternary(self, node):
+        assert(isinstance(node, mparser.TernaryNode))
+        self.evaluate_statement(node.condition)
+        self.evaluate_statement(node.trueblock)
+        self.evaluate_statement(node.falseblock)
 
     def evaluate_plusassign(self, node):
         assert(isinstance(node, mparser.PlusAssignmentNode))
@@ -177,6 +189,18 @@ class AstInterpreter(interpreterbase.InterpreterBase):
         return args.arguments, args.kwargs
 
     def evaluate_comparison(self, node):
+        self.evaluate_statement(node.left)
+        self.evaluate_statement(node.right)
+        return False
+
+    def evaluate_andstatement(self, cur):
+        self.evaluate_statement(cur.left)
+        self.evaluate_statement(cur.right)
+        return False
+
+    def evaluate_orstatement(self, cur):
+        self.evaluate_statement(cur.left)
+        self.evaluate_statement(cur.right)
         return False
 
     def evaluate_foreach(self, node):

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -20,7 +20,7 @@ from .. import compilers, environment, mesonlib, optinterpreter
 from .. import coredata as cdata
 from ..interpreterbase import InvalidArguments
 from ..build import Executable, Jar, SharedLibrary, SharedModule, StaticLibrary
-from ..mparser import ArithmeticNode, ArrayNode, ElementaryNode, IdNode, FunctionNode, StringNode
+from ..mparser import BaseNode, ArithmeticNode, ArrayNode, ElementaryNode, IdNode, FunctionNode, StringNode
 import os
 
 build_target_functions = ['executable', 'jar', 'library', 'shared_library', 'shared_module', 'static_library', 'both_libraries']
@@ -191,6 +191,8 @@ class IntrospectionInterpreter(AstInterpreter):
 
         # Make sure nothing can crash when creating the build class
         kwargs_reduced = {k: v for k, v in kwargs.items() if k in targetclass.known_kwargs and k in ['install', 'build_by_default', 'build_always']}
+        kwargs_reduced = {k: v.value if isinstance(v, ElementaryNode) else v for k, v in kwargs_reduced.items()}
+        kwargs_reduced = {k: v for k, v in kwargs_reduced.items() if not isinstance(v, BaseNode)}
         is_cross = False
         objects = []
         empty_sources = [] # Passing the unresolved sources list causes errors

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -142,6 +142,8 @@ class IntrospectionInterpreter(AstInterpreter):
         condition_level = node.condition_level if hasattr(node, 'condition_level') else 0
         if isinstance(required, ElementaryNode):
             required = required.value
+        if not isinstance(required, bool):
+            required = False
         self.dependencies += [{
             'name': name,
             'required': required,

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3408,7 +3408,7 @@ recommended as it is not supported on some platforms''')
         self.assertDictEqual(buildopts_to_find, {})
 
         # Check buildsystem_files
-        bs_files = ['meson.build', 'sharedlib/meson.build', 'staticlib/meson.build']
+        bs_files = ['meson.build', 'meson_options.txt', 'sharedlib/meson.build', 'staticlib/meson.build']
         bs_files = [os.path.join(testdir, x) for x in bs_files]
         self.assertPathListEqual(list(sorted(res['buildsystem_files'])), list(sorted(bs_files)))
 
@@ -3555,6 +3555,12 @@ recommended as it is not supported on some platforms''')
             },
             {
                 'name': 'zlib',
+                'required': False,
+                'has_fallback': False,
+                'conditional': False
+            },
+            {
+                'name': 'bugDep1',
                 'required': False,
                 'has_fallback': False,
                 'conditional': False

--- a/test cases/unit/55 introspection/meson.build
+++ b/test cases/unit/55 introspection/meson.build
@@ -2,6 +2,7 @@ project('introspection', ['c', 'cpp'], version: '1.2.3', default_options: ['cpp_
 
 dep1 = dependency('threads')
 dep2 = dependency('zlib', required: false)
+dep3 = dependency('bugDep1', required: get_option('test_opt1'))
 
 if false
   dependency('somethingthatdoesnotexist', required: true)

--- a/test cases/unit/55 introspection/meson.build
+++ b/test cases/unit/55 introspection/meson.build
@@ -4,6 +4,11 @@ dep1 = dependency('threads')
 dep2 = dependency('zlib', required: false)
 dep3 = dependency('bugDep1', required: get_option('test_opt1'))
 
+b1 = get_option('test_opt1')
+b2 = get_option('test_opt2')
+test_bool = b1 or b2
+test_bool = b1 and b2
+
 if false
   dependency('somethingthatdoesnotexist', required: true)
   dependency('look_i_have_a_fallback', fallback: ['oh_no', 'the_subproject_does_not_exist'])
@@ -12,7 +17,7 @@ endif
 subdir('sharedlib')
 subdir('staticlib')
 
-t1 = executable('test1', 't1.cpp', link_with: [sharedlib], install: true)
+t1 = executable('test1', 't1.cpp', link_with: [sharedlib], install: true, build_by_default: get_option('test_opt2'))
 t2 = executable('test2', 't2.cpp', link_with: [staticlib])
 t3 = executable('test3', 't3.cpp', link_with: [sharedlib, staticlib], dependencies: [dep1])
 

--- a/test cases/unit/55 introspection/meson_options.txt
+++ b/test cases/unit/55 introspection/meson_options.txt
@@ -1,1 +1,2 @@
 option('test_opt1', type: 'boolean', value: false, description: 'simple boolean flag')
+option('test_opt2', type: 'boolean', value: true,  description: 'simple boolean flag')

--- a/test cases/unit/55 introspection/meson_options.txt
+++ b/test cases/unit/55 introspection/meson_options.txt
@@ -1,0 +1,1 @@
+option('test_opt1', type: 'boolean', value: false, description: 'simple boolean flag')


### PR DESCRIPTION
This PR fixes some introspection crashes related to unresolved function nodes. I think this should go into 0.50.1, since this a pure bugfix PR.