### PR TITLE
modules/python: Add a find_module method

### DIFF
--- a/docs/markdown/Python-module.md
+++ b/docs/markdown/Python-module.md
@@ -51,6 +51,8 @@ Keyword arguments are the following:
 - `disabler`: if `true` and no python installation can be found, return a
   [disabler object](Reference-manual.md#disabler-object) instead of a not-found object.
   *Since 0.49.0*
+- `modules`: a list of module names that this python installation must have.
+  *Since 0.51.0*
 
 **Returns**: a [python installation][`python_installation` object]
 

--- a/docs/markdown/snippets/python_find_installation_modules.md
+++ b/docs/markdown/snippets/python_find_installation_modules.md
@@ -1,0 +1,9 @@
+## New modules kwarg for python.find_installation
+
+This mirrors the modules argument that some kinds of dependencies (such as
+qt, llvm, and cmake based dependencies) take, allowing you to check that a
+particular module is available when getting a python version.
+
+```meson
+py = import('python').find_installation('python3', modules : ['numpy'])
+```

--- a/test cases/python/5 modules kwarg/meson.build
+++ b/test cases/python/5 modules kwarg/meson.build
@@ -1,0 +1,7 @@
+project('python kwarg')
+
+py = import('python')
+prog_python = py.find_installation('python3', modules : ['setuptools'])
+assert(prog_python.found() == true, 'python not found when should be')
+prog_python = py.find_installation('python3', modules : ['thisbetternotexistmod'], required : false)
+assert(prog_python.found() == false, 'python not found but reported as found')


### PR DESCRIPTION
This adds a new method for querying the availability of third party
python modules available. This is designed to provide information in
the configuraiton log while providing the familiar dependency
interface within meson itself.

Fixes #2377