### PR TITLE
RFC: A way to instantiate custom "feature" objects

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2083,6 +2083,7 @@ class Interpreter(InterpreterBase):
                            'gettext': self.func_gettext,
                            'get_option': self.func_get_option,
                            'get_variable': self.func_get_variable,
+                           'feature': self.func_feature,
                            'files': self.func_files,
                            'find_library': self.func_find_library,
                            'find_program': self.func_find_program,
@@ -4160,3 +4161,25 @@ This will become a hard error in the future.''', location=self.current_node)
             raise InvalidCode('Is_variable takes two arguments.')
         varname = args[0]
         return varname in self.variables
+
+    @FeatureNew('feature()', '0.51.0')
+    @permittedKwargs({'name'})
+    def func_feature(self, node, args, kwargs):
+        if len(args) != 1:
+            raise InterpreterException('feature takes exactly one optional positional argument')
+
+        value = args[0]
+        name = 'internal'
+
+        if isinstance(value, bool):
+            value = 'enabled' if value else 'disabled'
+        elif isinstance(value, FeatureOptionHolder):
+            name = value.held_object.name
+            value = value.held_object.value
+
+        if value not in {'enabled', 'disabled', 'auto'}:
+            raise InterpreterException('Argument to feature must be one of: \'enabled\', \'disabled\', \'auto\', a boolean, or a feature object')
+
+        name = kwargs.get('name', name)
+        feature = coredata.UserFeatureOption(name, 'internal feature object', value)
+        return FeatureOptionHolder(self.environment, feature)


### PR DESCRIPTION
It is often useful to override the values of some build options. Sometimes you have options that depend on one another, or are incompatible with the target platform, etc. In Meson, this is usually accomplished with the use of variables:
```meson
opt_foobar = get_option('foobar')

if foobar_makes_no_sense
  opt_foobar = foobar_fallback
endif

# rest of the code only uses opt_foobar
```

However, there is one case where this pattern breaks: feature options. Every type of object that `get_option` may return can be declared in `meson.build`, except for these. That is rather unfortunate, because it is not trivial to replicate their semantics — in fact, it is impossible to do so accurately. Some fairly trivial cases can be worked around:
```meson
opt_video = get_option('use_video')

opt_video_x11 = get_option('use_video_x11')
opt_video_wayland = get_option('use_video_wayland')
opt_video_opengl = get_option('use_video_opengl')
opt_video_openglesv2 = get_option('use_video_openglesv2')
opt_video_vulkan = get_option('use_video_vulkan')

if opt_video.disabled()
    opt_video_x11 = opt_video
    opt_video_wayland = opt_video
    opt_video_opengl = opt_video
    opt_video_openglesv2 = opt_video
    opt_video_vulkan = opt_video
    opt_render = opt_video
endif
```
[(snippet source: my SDL2 meson port/wrap)](https://github.com/taisei-project/SDL-mirror/blob/2eb019d2b655c19e12b9d6967859f5305eae25ff/meson.build#L77)
In this case, I can get away with using `opt_video` when what I really mean is "a feature that is disabled".

Some hacks are uglier than others:
```meson
egl_dep = dependency('egl', required : opt_video_openglesv2)
if not egl_dep.found()
    egl_dep = dependency('egl', required : opt_video_wayland)
endif
```
[(snippet source: my SDL2 meson port/wrap)](https://github.com/taisei-project/SDL-mirror/blob/2eb019d2b655c19e12b9d6967859f5305eae25ff/meson.build#L134)
This one in particular isn't just inelegant, it can potentially degrade performance in case the `egl` dependency is not installed. Yet it is the most concise way to express that multiple features require the same dependency. The double look-up also makes the configuration log slightly more confusing.

There are also cases with no easy workarounds. Here's a paraphrased snippet from the Taisei build system that I'm currently refactoring:

```meson

opt_zip = get_option('zip_packages')
opt_package_data = get_option('package_data')

if opt_zip.disabled()
    # The game can't handle zip files, so we definitely shouldn't zip up the assets!
    # We can use the same trick as in the SDL example above here.
    opt_package_data = opt_zip
endif

if host_machine.platform() == 'emscripten'
    # We don't support zip packages on Emscripten — it makes no sense,
    # because we use its built-in packer there.
    opt_zip = ...  # Oops! What do we put here?
    opt_package_data = ...  # Oops! What do we put here?
endif

dep_zip = dependency('libzip', required : opt_zip)

# ...
# fast forward a few hundred lines, opt_package_data is tested in some subdir...
# ...
```

Fixing this one would devolve into a nasty bunch of boolean variables and re-implementing the conditional dependency look-up and logic that already exists in Meson for the feature tri-state — *precisely* so that people don't have to reinvent it in the build rules.

The solution I'm proposing is pretty simple: **let us instantiate custom "feature" objects, which behave exactly like ones returned by `get_option`**.

This draft implementation adds a single global function, `feature`. It accepts exactly 1 positional argument, and an optional keyword argument `name`. The positional argument defines the state of the returned feature object and must be one of the strings `enabled`, `disabled`, `auto`, or a boolean, or another Feature object. If the positional argument is a boolean, `true` means `enabled` and `false` means `disabled`. If the positional argument is a Feature, the state and the default name are copied from it. The name exists for logging purposes only; it is currently impossible to access it.

With this, fixing the Taisei example above is easy:
```meson
if host_machine.platform() == 'emscripten'
    opt_zip = feature('disabled', name : 'zip_packages')
else
    opt_zip = get_option('zip_packages')
endif

dep_zip = dependency('libzip', required : opt_zip)

if dep_zip.found()
    opt_package_data = get_option('package_data')
else
    opt_package_data = feature('disabled', name : 'package_data')
endif
```

The EGL example is little more involved, but the intent still becomes clearer, the performance pitfall is avoided, and the configuration log is less confusing:
```meson
if opt_video_openglesv2.enabled() or opt_video_wayland.enabled()
    opt_egl = feature('enabled', name : 'egl')
elif opt_video_openglesv2.auto() or opt_video_wayland.auto()
    opt_egl = feature('auto', name : 'egl')
else
    opt_egl = feature('disabled', name : 'egl')
endif

egl_dep = dependency('egl', required : opt_egl)
```

However, going a little beyond what is currently implemented, it can be useful to have this logic built-in:
```meson
opt_egl = opt_video_openglesv2.or(opt_video_wayland)
egl_dep = dependency('egl', required : opt_egl)
```

Perhaps even like this, if overloading boolean operators is not out of question:
```meson
opt_egl = opt_video_openglesv2 or opt_video_wayland
egl_dep = dependency('egl', required : opt_egl)
```

Another possible addition would be a convenience method to simplify the first example:
```meson
opt_video = get_option('use_video')

opt_video_x11 = get_option('use_video_x11').depends_on(opt_video)
opt_video_wayland = get_option('use_video_wayland').depends_on(opt_video)
opt_video_opengl = get_option('use_video_opengl').depends_on(opt_video)
opt_video_openglesv2 = get_option('use_video_openglesv2').depends_on(opt_video)
opt_video_vulkan = get_option('use_video_vulkan').depends_on(opt_video)
```
Mind that SDL2 actually has a lot more video backends and intertwined options than my build system currently supports.