### PR TITLE
d: Fix linker errors with shared libraries on Windows

### DIFF
--- a/ci/install-dmd.ps1
+++ b/ci/install-dmd.ps1
@@ -9,8 +9,8 @@ $ProgressPreference = "SilentlyContinue"
 $dmd_install = "C:\D"
 $dmd_version_file = "C:\cache\DMD_LATEST"
 
-#echo "Fetching latest DMD version..."
 if (!$Version) {
+    #echo "Fetching latest DMD version..."
     $dmd_latest_url = "http://downloads.dlang.org/releases/LATEST"
     $retries = 10
     for ($i = 1; $i -le $retries; $i++) {

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -622,7 +622,15 @@ class DmdDCompiler(DCompiler):
         return []
 
     def get_std_shared_lib_link_args(self):
-        return ['-shared', '-defaultlib=libphobos2.so']
+        libname = 'libphobos2.so'
+        if is_windows():
+            if self.arch == 'x86_64':
+                libname = 'phobos64.lib'
+            elif self.arch == 'x86_mscoff':
+                libname = 'phobos32mscoff.lib'
+            else:
+                libname = 'phobos.lib'
+        return ['-shared', '-defaultlib=' + libname]
 
     def get_target_arch_args(self):
         # DMD32 and DMD64 on 64-bit Windows defaults to 32-bit (OMF).

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -563,7 +563,7 @@ def detect_tests_to_run():
         ('C#', 'csharp', skip_csharp(backend)),
         ('vala', 'vala', backend is not Backend.ninja or not shutil.which('valac')),
         ('rust', 'rust', backend is not Backend.ninja or not shutil.which('rustc')),
-        ('d', 'd', backend is not Backend.ninja or not have_d_compiler() or mesonlib.is_windows()),
+        ('d', 'd', backend is not Backend.ninja or not have_d_compiler()),
         ('objective c', 'objc', backend not in (Backend.ninja, Backend.xcode) or mesonlib.is_windows() or not have_objc_compiler()),
         ('objective c++', 'objcpp', backend not in (Backend.ninja, Backend.xcode) or mesonlib.is_windows() or not have_objcpp_compiler()),
         ('fortran', 'fortran', backend is not Backend.ninja or not shutil.which('gfortran')),


### PR DESCRIPTION
Fixes the linker errors and re-enables the D tests for AppVeyor.