### PR TITLE
Add symbol sizes to .symbols files

### DIFF
--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -68,7 +68,14 @@ def linux_syms(libfilename, outfilename):
                               libfilename])[0:2]
     if pnm.returncode != 0:
         raise RuntimeError('nm does not work.')
-    result += [' '.join(x.split()[0:2]) for x in output.split('\n') if len(x) > 0]
+    for line in output.split('\n'):
+        if len(line) == 0:
+            continue
+        line_split = line.split()
+        entry = line_split[0:2]
+        if len(line_split) >= 4:
+            entry += [line_split[3]]
+        result += [' '.join(entry)]
     write_if_changed('\n'.join(result) + '\n', outfilename)
 
 def osx_syms(libfilename, outfilename):


### PR DESCRIPTION
If we change a symbol size (e.g. array) in a .c file that is a part of
.so, executables that use it are not re-linked resulting in a runtime
error:

"Symbol xyz has different size in shared object, consider re-linking"

Adding symbol sizes to .symbol files fixes this issue.