### PR TITLE
BUGFIX: Microsoft MPI is only compatible with Intel Fortran

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -212,6 +212,9 @@ class MPIDependency(ExternalDependency):
                     break
 
         if not self.is_found and mesonlib.is_windows():
+            # only Intel Fortran compiler is compatible with Microsoft MPI at this time.
+            if language == 'fortran' and environment.detect_fortran_compiler(False).name_string() != 'intel':
+                return
             result = self._try_msmpi()
             if result is not None:
                 self.is_found = True

--- a/test cases/frameworks/17 mpi/is_broken_ubuntu.py
+++ b/test cases/frameworks/17 mpi/is_broken_ubuntu.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-
-# Any exception causes return value to be not zero, which is sufficient.
-
-import sys
-
-fc = open('/etc/apt/sources.list').read()
-if 'artful' not in fc and 'bionic' not in fc and 'cosmic' not in fc:
-    sys.exit(1)

--- a/test cases/frameworks/17 mpi/main.f90
+++ b/test cases/frameworks/17 mpi/main.f90
@@ -1,21 +1,30 @@
-program mpitest
-  implicit none
-  include 'mpif.h'
-  logical :: flag
-  integer :: ier
-  call MPI_Init(ier)
-  if (ier /= 0) then
-    print *, 'Unable to initialize MPI: ', ier
-    stop 1
-  endif
-  call MPI_Initialized(flag, ier)
-  if (ier /= 0) then
-    print *, 'Unable to check MPI initialization state: ', ier
-    stop 1
-  endif
-  call MPI_Finalize(ier)
-  if (ier /= 0) then
-    print *, 'Unable to finalize MPI: ', ier
-    stop 1
-  endif
-end program mpitest
+use, intrinsic :: iso_fortran_env, only: stderr=>error_unit
+use mpi
+
+implicit none
+
+logical :: flag
+integer :: ier
+
+call MPI_Init(ier)
+
+if (ier /= 0) then
+  write(stderr,*) 'Unable to initialize MPI', ier
+  stop 1
+endif
+
+call MPI_Initialized(flag, ier)
+if (ier /= 0) then
+  write(stderr,*) 'Unable to check MPI initialization state: ', ier
+  stop 1
+endif
+
+call MPI_Finalize(ier)
+if (ier /= 0) then
+  write(stderr,*) 'Unable to finalize MPI: ', ier
+  stop 1
+endif
+
+print *, "OK: Fortran MPI"
+
+end program

--- a/test cases/frameworks/17 mpi/meson.build
+++ b/test cases/frameworks/17 mpi/meson.build
@@ -26,21 +26,15 @@ if build_machine.system() != 'windows'
   test('MPI C++', execpp)
 endif
 
-# OpenMPI is broken with Fortran on Ubuntu Artful.
-# Remove this once the following bug has been fixed:
-#
-# https://bugs.launchpad.net/ubuntu/+source/gcc-defaults/+bug/1727474
+# One of few feasible ways to use MPI for Fortran on Windows is via Intel compilers.
+if build_machine.system() != 'windows' or cc.get_id() == 'intel'
+  if add_languages('fortran', required : false)
+    mpifort = dependency('mpi', language : 'fortran')
 
-ubudetector = find_program('is_broken_ubuntu.py')
-uburesult = run_command(ubudetector)
-
-if uburesult.returncode() != 0 and add_languages('fortran', required : false)
-  mpifort = dependency('mpi', language : 'fortran')
-  # Mixing compilers (msvc/clang with gfortran) does not seem to work on Windows.
-  if build_machine.system() != 'windows' or cc.get_id() == 'gnu'
     exef = executable('exef',
-      'main.f90',
-      dependencies : [mpifort])
+    'main.f90',
+    dependencies : [mpifort])
+
     test('MPI Fortran', exef)
   endif
 endif


### PR DESCRIPTION
The MPI dependency() allows MSMPI with Fortran, which in general does not work, except for Intel Fortran. This PR enacts that restriction to avoid false-positive "MPI Found" on Windows with incompatible compiler+MPI.