### PR TITLE
coredata: store cross/native files in the same form they will be used

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -422,13 +422,13 @@ class Environment:
 
         if self.coredata.config_files is not None:
             config = MesonConfigFile.from_config_parser(
-                coredata.load_configs(self.coredata.config_files, 'native'))
+                coredata.load_configs(self.coredata.config_files))
             self.binaries.build = BinaryTable(config.get('binaries', {}))
             self.paths.build = Directories(**config.get('paths', {}))
 
         if self.coredata.cross_files:
             config = MesonConfigFile.from_config_parser(
-                coredata.load_configs(self.coredata.cross_files, 'cross'))
+                coredata.load_configs(self.coredata.cross_files))
             self.properties.host = Properties(config.get('properties', {}), False)
             self.binaries.host = BinaryTable(config.get('binaries', {}), False)
             if 'host_machine' in config:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5862,6 +5862,21 @@ class NativeFileTests(BasePlatformTests):
                   extra_args=['--native-file', os.path.join(testcase, 'nativefile'),
                               '-Ddef_libdir=liblib', '-Dlibdir=liblib'])
 
+    def test_compile_sys_path(self):
+        """Compiling with a native file stored in a system path works.
+
+        There was a bug which caused the paths to be stored incorrectly and
+        would result in ninja invoking meson in an infinite loop. This tests
+        for that by actually invoking ninja.
+        """
+        testcase = os.path.join(self.common_test_dir, '1 trivial')
+
+        # It really doesn't matter what's in the native file, just that it exists
+        config = self.helper_create_native_file({'binaries': {'bash': 'false'}})
+
+        self.init(testcase, extra_args=['--native-file', config])
+        self.build()
+
 
 class CrossFileTests(BasePlatformTests):
 


### PR DESCRIPTION
Currently they're forced to absolute paths when they're stored in the
coredata datastructure, then when they're loaded we de-absolute path
them to check if they're in the system wide directories. This doesn't
work at all, since the ninja backend will generat a dependency on a
file that is in the source directory unless the path was already given
as absolute. This results in builds being retriggereed forever due to
a non-existant file.

The right way to do this is to figure out whether the file is in the
build directory, is absolute, or is in one of the system paths at
creation time, and store that path as absolute if it is outside the
build directory, or relative if it is within (so that a source
directory can be moved). Then the code that reads the file and the
code that generates the dependencies in the ninja backend just takes
the computed list and there is no mismatch between them.