### PR TITLE
meson: support multiple headers in has_header_symbol function

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -381,10 +381,11 @@ class CCompiler(Compiler):
         return self.compiles(code.format(**fargs), env, extra_args=extra_args,
                              dependencies=dependencies, mode='preprocess')
 
-    def has_header_symbol(self, hname, symbol, prefix, env, *, extra_args=None, dependencies=None):
-        fargs = {'prefix': prefix, 'header': hname, 'symbol': symbol}
+    def has_header_symbol(self, hnames, symbol, prefix, env, *, extra_args=None, dependencies=None):
+        h_includes = ['''#include<{}>'''.format(h) for h in hnames]
+        fargs = {'prefix': prefix, 'header_includes': '\n'.join(h_includes), 'symbol': symbol}
         t = '''{prefix}
-        #include <{header}>
+        {header_includes}
         int main () {{
             /* If it's not defined as a macro, try to use as a symbol */
             #ifndef {symbol}

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -63,18 +63,19 @@ class CPPCompiler(CCompiler):
         # too strict without this and always fails.
         return super().get_compiler_check_args() + ['-fpermissive']
 
-    def has_header_symbol(self, hname, symbol, prefix, env, *, extra_args=None, dependencies=None):
+    def has_header_symbol(self, hnames, symbol, prefix, env, *, extra_args=None, dependencies=None):
         # Check if it's a C-like symbol
-        if super().has_header_symbol(hname, symbol, prefix, env,
+        if super().has_header_symbol(hnames, symbol, prefix, env,
                                      extra_args=extra_args,
                                      dependencies=dependencies):
             return True
         # Check if it's a class or a template
         if extra_args is None:
             extra_args = []
-        fargs = {'prefix': prefix, 'header': hname, 'symbol': symbol}
+        h_includes = ['''#include<{}>'''.format(h) for h in hnames]
+        fargs = {'prefix': prefix, 'header_includes': '\n'.join(h_includes), 'symbol': symbol}
         t = '''{prefix}
-        #include <{header}>
+        {header_includes}
         using {symbol};
         int main () {{ return 0; }}'''
         return self.compiles(t.format(**fargs), env, extra_args=extra_args,

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -145,14 +145,15 @@ class CudaCompiler(Compiler):
     def get_compiler_check_args(self):
         return super().get_compiler_check_args() + []
 
-    def has_header_symbol(self, hname, symbol, prefix, env, extra_args=None, dependencies=None):
-        if super().has_header_symbol(hname, symbol, prefix, env, extra_args, dependencies):
+    def has_header_symbol(self, hnames, symbol, prefix, env, extra_args=None, dependencies=None):
+        if super().has_header_symbol(hnames, symbol, prefix, env, extra_args, dependencies):
             return True
         if extra_args is None:
             extra_args = []
-        fargs = {'prefix': prefix, 'header': hname, 'symbol': symbol}
+        h_includes = ['''#include<{}>'''.format(h) for h in hnames]
+        fargs = {'prefix': prefix, 'header_includes': '\n'.join(h_includes), 'symbol': symbol}
         t = '''{prefix}
-        #include <{header}>
+        {header_includes}
         using {symbol};
         int main () {{ return 0; }}'''
         return self.compiles(t.format(**fargs), env, extra_args, dependencies)

--- a/test cases/common/108 has header symbol/a.h
+++ b/test cases/common/108 has header symbol/a.h
@@ -1,0 +1,1 @@
+#define A

--- a/test cases/common/108 has header symbol/b.h
+++ b/test cases/common/108 has header symbol/b.h
@@ -1,0 +1,7 @@
+#define B
+
+#ifndef A
+#error THIS DID NOT WORK
+#endif
+
+void test_function(int a);

--- a/test cases/common/108 has header symbol/meson.build
+++ b/test cases/common/108 has header symbol/meson.build
@@ -12,6 +12,8 @@ foreach comp : [cc, cpp]
   assert (not comp.has_header_symbol('stdlib.h', 'FILE'), 'FILE structure is defined in stdio.h, not stdlib.h')
   assert (not comp.has_header_symbol('stdlol.h', 'printf'), 'stdlol.h shouldn\'t exist')
   assert (not comp.has_header_symbol('stdlol.h', 'int'), 'shouldn\'t be able to find "int" with invalid header')
+  assert (comp.has_header_symbol(['a.h', 'b.h'], 'test_function', args : '-I'+meson.current_source_dir()), 'double header include test failed')
+  assert (not comp.has_header_symbol(['asdfasdfasdfasdf', 'stdio.h'], 'int', args : '-I'+meson.current_source_dir()), 'Things with broken headers should not succeed')
 endforeach
 
 # This is available on Glibc, Solaris & the BSD's, so just test for _GNU_SOURCE


### PR DESCRIPTION
for example on bsd, there is the function kevent,
which is defined in sys/event.h. However, sys/event.h requires
sys/types.h to be included before. Which means, has_header_symbol is not
usefull here, and i have to write either my own compile statement, or my
own custom #include prefix.

With this commit in place the whole check would be:
cc.has_header_symbol(['sys/types.h', 'sys/event.h', 'sys/time.h'])
Which looks nicer.