### PR TITLE
BUGFIX: detect PGI compiler operating system (Windows, Apple, Linux)

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1315,9 +1315,9 @@ class GnuCCompiler(GnuCompiler, CCompiler):
 
 
 class PGICCompiler(PGICompiler, CCompiler):
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwargs):
+    def __init__(self, exelist, version, compiler_type, is_cross, exe_wrapper=None, **kwargs):
         CCompiler.__init__(self, exelist, version, is_cross, exe_wrapper, **kwargs)
-        PGICompiler.__init__(self, CompilerType.PGI_STANDARD)
+        PGICompiler.__init__(self, compiler_type)
 
 
 class ElbrusCCompiler(GnuCCompiler, ElbrusCompiler):

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1374,18 +1374,20 @@ class CompilerType(enum.Enum):
     CCRX_WIN = 40
 
     PGI_STANDARD = 50
+    PGI_OSX = 51
+    PGI_WIN = 52
 
     @property
     def is_standard_compiler(self):
-        return self.name in ('GCC_STANDARD', 'CLANG_STANDARD', 'ICC_STANDARD')
+        return self.name in ('GCC_STANDARD', 'CLANG_STANDARD', 'ICC_STANDARD', 'PGI_STANDARD')
 
     @property
     def is_osx_compiler(self):
-        return self.name in ('GCC_OSX', 'CLANG_OSX', 'ICC_OSX')
+        return self.name in ('GCC_OSX', 'CLANG_OSX', 'ICC_OSX', 'PGI_OSX')
 
     @property
     def is_windows_compiler(self):
-        return self.name in ('GCC_MINGW', 'GCC_CYGWIN', 'CLANG_MINGW', 'ICC_WIN', 'ARM_WIN', 'CCRX_WIN')
+        return self.name in ('GCC_MINGW', 'GCC_CYGWIN', 'CLANG_MINGW', 'ICC_WIN', 'ARM_WIN', 'CCRX_WIN', 'PGI_WIN')
 
 
 def get_macos_dylib_install_name(prefix, shlib_name, suffix, soversion):
@@ -1682,6 +1684,11 @@ class PGICompiler:
 
     def get_no_warn_args(self) -> List[str]:
         return ['-silent']
+
+    def get_pic_args(self) -> List[str]:
+        if self.compiler_type.is_osx_compiler or self.compiler_type.is_windows_compiler:
+            return [] # PGI -fPIC is Linux only.
+        return ['-fPIC']
 
     def openmp_flags(self) -> List[str]:
         return ['-mp']

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -238,9 +238,9 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
 
 
 class PGICPPCompiler(PGICompiler, CPPCompiler):
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwargs):
+    def __init__(self, exelist, version, compiler_type, is_cross, exe_wrapper=None, **kwargs):
         CPPCompiler.__init__(self, exelist, version, is_cross, exe_wrapper, **kwargs)
-        PGICompiler.__init__(self, CompilerType.PGI_STANDARD)
+        PGICompiler.__init__(self, compiler_type)
 
 
 class ElbrusCPPCompiler(GnuCPPCompiler, ElbrusCompiler):

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -423,9 +423,9 @@ class PathScaleFortranCompiler(FortranCompiler):
 
 
 class PGIFortranCompiler(PGICompiler, FortranCompiler):
-    def __init__(self, exelist, version, is_cross, exe_wrapper=None, **kwags):
+    def __init__(self, exelist, version, compiler_type, is_cross, exe_wrapper=None, **kwags):
         FortranCompiler.__init__(self, exelist, version, is_cross, exe_wrapper, **kwags)
-        PGICompiler.__init__(self, CompilerType.PGI_STANDARD)
+        PGICompiler.__init__(self, compiler_type)
 
 
 class FlangFortranCompiler(ClangCompiler, FortranCompiler):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -467,7 +467,7 @@ class Environment:
         self.default_objc = ['cc']
         self.default_objcpp = ['c++']
         self.default_d = ['ldc2', 'ldc', 'gdc', 'dmd']
-        self.default_fortran = ['gfortran', 'g95', 'f95', 'f90', 'f77', 'ifort', 'pgfortran']
+        self.default_fortran = ['gfortran', 'flang', 'pgfortran', 'ifort', 'g95', 'f95', 'f90', 'f77']
         self.default_java = ['javac']
         self.default_cuda = ['nvcc']
         self.default_rust = ['rustc']


### PR DESCRIPTION
Like some other compilers in Meson, for PGI Meson didn't actually detect what target operating system was being used, which caused problems for Windows and OSX targets where `-fPIC` must not be used (it makes PGI error on compile).

This enables target operating system detection.

Also, reordered Fortran compiler search order to what would actually be desirable (putting obsolete compilers last, free and high performance first).