### PR TITLE
Fix build = host cross builds for 0.50.*

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -477,7 +477,7 @@ class Environment:
         self.first_invocation = True
 
     def is_cross_build(self):
-        return not self.machines.matches_build_machine(MachineChoice.HOST)
+        return self.coredata.cross_file is not None
 
     def dump_coredata(self):
         return coredata.save(self.coredata, self.get_build_dir())

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5029,6 +5029,19 @@ endian = 'little'
                 max_count = max(max_count, line.count(search_term))
         self.assertEqual(max_count, 1, 'Export dynamic incorrectly deduplicated.')
 
+    def test_identity_cross(self):
+        testdir = os.path.join(self.unit_test_dir, '58 identity cross')
+        crossfile = tempfile.NamedTemporaryFile(mode='w')
+        print(os.path.join(testdir, 'build_wrapper.py'))
+        print(os.path.join(testdir, 'host_wrapper.py'))
+        os.environ['CC'] = '"' + os.path.join(testdir, 'build_wrapper.py') + '"'
+        crossfile.write('''[binaries]
+c = ['{0}']
+'''.format(os.path.join(testdir, 'host_wrapper.py')))
+        crossfile.flush()
+        self.meson_cross_file = crossfile.name
+        # TODO should someday be explicit about build platform only here
+        self.init(testdir)
 
 def should_run_cross_arm_tests():
     return shutil.which('arm-linux-gnueabihf-gcc') and not platform.machine().lower().startswith('arm')

--- a/test cases/unit/58 identity cross/build_wrapper.py
+++ b/test cases/unit/58 identity cross/build_wrapper.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+import subprocess, sys
+
+subprocess.call(["cc", "-DEXTERNAL_BUILD"] + sys.argv[1:])

--- a/test cases/unit/58 identity cross/host_wrapper.py
+++ b/test cases/unit/58 identity cross/host_wrapper.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+import subprocess, sys
+
+subprocess.call(["cc", "-DEXTERNAL_HOST"] + sys.argv[1:])

--- a/test cases/unit/58 identity cross/meson.build
+++ b/test cases/unit/58 identity cross/meson.build
@@ -1,0 +1,15 @@
+project('identity cross test', 'c')
+
+assert(meson.get_compiler('c', native: true).get_define(
+  'GOT',
+  args : [ '-DARG_BUILD' ],
+  prefix : '#include "stuff.h"',
+  include_directories: include_directories('.'),
+) == 'BUILD', 'did not get BUILD from native: true compiler')
+
+assert(meson.get_compiler('c', native: false).get_define(
+  'GOT',
+  args : [ '-DARG_HOST' ],
+  prefix : '#include "stuff.h"',
+  include_directories: include_directories('.'),
+) == 'HOST', 'did not get HOST from native: false compiler')

--- a/test cases/unit/58 identity cross/stuff.h
+++ b/test cases/unit/58 identity cross/stuff.h
@@ -1,0 +1,27 @@
+#ifdef EXTERNAL_BUILD
+  #ifndef ARG_BUILD
+    #error "External is build but arg_build is not set."
+  #elif defined(ARG_HOST)
+    #error "External is build but arg_host is set."
+  #else
+    #define GOT BUILD
+  #endif
+#endif
+
+#ifdef EXTERNAL_HOST
+  #ifndef ARG_HOST
+    #error "External is host but arg_host is not set."
+  #elif defined(ARG_BUILD)
+    #error "External is host but arg_build is set."
+  #else
+    #define GOT HOST
+  #endif
+#endif
+
+#if defined(EXTERNAL_BUILD) && defined(EXTERNAL_HOST)
+  #error "Both external build and external host set."
+#endif
+
+#if !defined(EXTERNAL_BUILD) && !defined(EXTERNAL_HOST)
+  #error "Neither external build nor external host is set."
+#endif


### PR DESCRIPTION
This defines 'is_cross_build()` in terms of whether we have a cross
file, not whether `build_machine == host_machine`.

This should only be used in 0.50.*. The better fix for master is #4010,
which keeps the existing `is_cross_build()`, but allows separate
compilers targetting the build and host machine in all cases. These
points in the direction of Meson being agnostic to whether the build is
a cross build, and `is_cross_build()` just being a convenience for the
user.

Fixes #5102