### PR TITLE
BUGFIX: correct C, C++, Fortran compiler search order, add Intel

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -453,12 +453,13 @@ class Environment:
 
         # List of potential compilers.
         if mesonlib.is_windows():
-            self.default_c = ['cl', 'cc', 'gcc', 'clang', 'clang-cl', 'pgcc']
+            # Intel C and C++ compiler is icl on Windows, but icc and icpc elsewhere.
+            self.default_c = ['cl', 'cc', 'gcc', 'clang', 'clang-cl', 'pgcc', 'icl']
             # There is currently no pgc++ for Windows, only for  Mac and Linux.
-            self.default_cpp = ['cl', 'c++', 'g++', 'clang++', 'clang-cl']
+            self.default_cpp = ['cl', 'c++', 'g++', 'clang++', 'clang-cl', 'icl']
         else:
-            self.default_c = ['cc', 'gcc', 'clang', 'pgcc']
-            self.default_cpp = ['c++', 'g++', 'clang++', 'pgc++']
+            self.default_c = ['cc', 'gcc', 'clang', 'pgcc', 'icc']
+            self.default_cpp = ['c++', 'g++', 'clang++', 'pgc++', 'icpc']
         if mesonlib.is_windows():
             self.default_cs = ['csc', 'mcs']
         else:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -456,7 +456,8 @@ class Environment:
         # List of potential compilers.
         if mesonlib.is_windows():
             self.default_c = ['cl', 'cc', 'gcc', 'clang', 'clang-cl', 'pgcc']
-            self.default_cpp = ['cl', 'c++', 'g++', 'clang++', 'clang-cl', 'pgc++']
+            # There is currently no pgc++ for Windows, only for  Mac and Linux.
+            self.default_cpp = ['cl', 'c++', 'g++', 'clang++', 'clang-cl']
         else:
             self.default_c = ['cc', 'gcc', 'clang', 'pgcc']
             self.default_cpp = ['c++', 'g++', 'clang++', 'pgc++']
@@ -467,7 +468,7 @@ class Environment:
         self.default_objc = ['cc']
         self.default_objcpp = ['c++']
         self.default_d = ['ldc2', 'ldc', 'gdc', 'dmd']
-        self.default_fortran = ['gfortran', 'g95', 'f95', 'f90', 'f77', 'ifort', 'pgfortran']
+        self.default_fortran = ['gfortran', 'flang', 'pgfortran', 'ifort', 'g95']
         self.default_java = ['javac']
         self.default_cuda = ['nvcc']
         self.default_rust = ['rustc']
@@ -1035,7 +1036,7 @@ class Environment:
         # up to date language version at time (2016).
         if exelist is not None:
             if os.path.basename(exelist[-1]).startswith(('ldmd', 'gdmd')):
-                    raise EnvironmentException('Meson doesn\'t support %s as it\'s only a DMD frontend for another compiler. Please provide a valid value for DC or unset it so that Meson can resolve the compiler by itself.' % exelist[-1])
+                raise EnvironmentException('Meson doesn\'t support %s as it\'s only a DMD frontend for another compiler. Please provide a valid value for DC or unset it so that Meson can resolve the compiler by itself.' % exelist[-1])
         else:
             for d in self.default_d:
                 if shutil.which(d):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import configparser, os, platform, re, sys, shlex, shutil, subprocess
-import typing
+import os, platform, re, sys, shlex, shutil, subprocess
 
 from . import coredata
 from .linkers import ArLinker, ArmarLinker, VisualStudioLinker, DLinker, CcrxLinker
 from . import mesonlib
 from .mesonlib import (
-    MesonException, EnvironmentException, MachineChoice, PerMachine, Popen_safe,
+    MesonException, EnvironmentException, MachineChoice, Popen_safe,
 )
 from . import mlog
 
@@ -38,7 +37,6 @@ from .compilers import (
     is_source,
 )
 from .compilers import (
-    Compiler,
     ArmCCompiler,
     ArmCPPCompiler,
     ArmclangCCompiler,


### PR DESCRIPTION
* Remove F77 and F95 compilers that would actually not work due to mismatched options. Gfortran should be found just by Gfortran name
* Intel compiler was missing for C and C++. Note that it's named `icl` for Windows, but elsewhere `icc` and `icpc`.
* cleaned up unused imports for PEP8 (some of us use Git pre-commit hooks that block on PEP8 violations)

tdlr; Intel compilers did not work on Windows before this commit, and now they do.