### PR TITLE
[WIP] Make ninja backend only use response files when needed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,11 @@ jobs:
           arch: x64
           compiler: msvc2017
           backend: ninja
+        vc2017x64ninjarsp:
+          arch: x64
+          compiler: msvc2017
+          backend: ninja
+          MESON_RSP_THRESHOLD: 0
         vc2017x64vs:
           arch: x64
           compiler: msvc2017
@@ -143,6 +148,11 @@ jobs:
       gccx64ninja:
         MSYSTEM: MINGW64
         MSYS2_ARCH: x86_64
+        compiler: gcc
+      gccx64ninjarsp:
+        MSYSTEM: MINGW64
+        MSYS2_ARCH: x86_64
+        MESON_RSP_THRESHOLD: 0
         compiler: gcc
       clangx64ninja:
         MSYSTEM: MINGW64

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -23,7 +23,7 @@ import subprocess
 from ..mesonlib import MachineChoice, MesonException, OrderedSet
 from ..mesonlib import classify_unity_sources
 from ..mesonlib import File
-from ..compilers import CompilerArgs, VisualStudioLikeCompiler
+from ..compilers import CompilerArgs
 from collections import OrderedDict
 import shlex
 from functools import lru_cache
@@ -546,29 +546,13 @@ class Backend:
 
     @staticmethod
     def escape_extra_args(compiler, args):
-        # No extra escaping/quoting needed when not running on Windows
-        if not mesonlib.is_windows():
-            return args
+        # all backslashes in defines are doubly-escaped
         extra_args = []
-        # Compiler-specific escaping is needed for -D args but not for any others
-        if isinstance(compiler, VisualStudioLikeCompiler):
-            # MSVC needs escaping when a -D argument ends in \ or \"
-            for arg in args:
-                if arg.startswith('-D') or arg.startswith('/D'):
-                    # Without extra escaping for these two, the next character
-                    # gets eaten
-                    if arg.endswith('\\'):
-                        arg += '\\'
-                    elif arg.endswith('\\"'):
-                        arg = arg[:-2] + '\\\\"'
-                extra_args.append(arg)
-        else:
-            # MinGW GCC needs all backslashes in defines to be doubly-escaped
-            # FIXME: Not sure about Cygwin or Clang
-            for arg in args:
-                if arg.startswith('-D') or arg.startswith('/D'):
-                    arg = arg.replace('\\', '\\\\')
-                extra_args.append(arg)
+        for arg in args:
+            if arg.startswith('-D') or arg.startswith('/D'):
+                arg = arg.replace('\\', '\\\\')
+            extra_args.append(arg)
+
         return extra_args
 
     def generate_basic_compiler_args(self, target, compiler, no_warn_args=False):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -82,7 +82,7 @@ rsp_threshold = int(os.environ.get('MESON_RSP_THRESHOLD', '4096'))
 # variables (or variables we use them in) is interpreted directly by ninja
 # (e.g. the value of the depfile variable is a pathname that ninja will read
 # from, etc.), so it must not be shell quoted.
-raw_names = {'DEPFILE', 'DESC', 'pool', 'description'}
+raw_names = {'DEPFILE_UNQUOTED', 'DESC', 'pool', 'description'}
 
 def ninja_quote(text, is_build_line=False):
     if is_build_line:
@@ -168,6 +168,9 @@ class NinjaRule:
         self.refcount = 0
         self.rsprefcount = 0
         self.rspfile_quote_style = rspfile_quote_style  # rspfile quoting style is 'gcc' or 'cl'
+
+        if self.depfile == '$DEPFILE':
+            self.depfile += '_UNQUOTED'
 
     @staticmethod
     def _quoter(x, qf = quote_func):
@@ -269,6 +272,9 @@ class NinjaBuildElement:
         if isinstance(elems, str):
             elems = [elems]
         self.elems.append((name, elems))
+
+        if name == 'DEPFILE':
+            self.elems.append((name + '_UNQUOTED', elems))
 
     def _should_use_rspfile(self):
         # 'phony' is a rule built-in to ninja

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -359,9 +359,11 @@ int dummy;
 
     # http://clang.llvm.org/docs/JSONCompilationDatabase.html
     def generate_compdb(self):
+        # TODO: Rather than an explicit list here, rules could be marked in the
+        # rule store as being wanted in compdb
         pch_compilers = ['%s_PCH' % i for i in self.build.compilers]
-        native_compilers = ['%s_COMPILER' % i for i in self.build.compilers]
-        cross_compilers = ['%s_CROSS_COMPILER' % i for i in self.build.cross_compilers]
+        native_compilers = ['%s_COMPILER%s' % (i, ext) for i in self.build.compilers for ext in ['', '_RSP']]
+        cross_compilers = ['%s_CROSS_COMPILER%s' % (i, ext) for i in self.build.cross_compilers for ext in ['', '_RSP']]
         ninja_compdb = [self.ninja_command, '-t', 'compdb'] + pch_compilers + native_compilers + cross_compilers
         builddir = self.environment.get_build_dir()
         try:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -323,7 +323,6 @@ class NinjaBuildElement:
                     quoter = ninja_quote
                 else:
                     quoter = lambda x: ninja_quote(qf(x))
-                i = i.replace('\\', '\\\\')
                 newelems.append(quoter(i))
             line += ' '.join(newelems)
             line += '\n'

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -64,8 +64,9 @@ else:
     execute_wrapper = []
     rmfile_prefix = ['rm', '-f', '{}', '&&']
 
-# a conservative estimate of the command-line length limit on windows
-rsp_threshold = 4096
+# use a conservative estimate of the command-line length limit on windows
+# (but allow it to be overridden for testing purposes)
+rsp_threshold = int(os.environ.get('MESON_RSP_THRESHOLD', '4096'))
 
 # ninja variables whose value should remain unquoted. The value of these ninja
 # variables (or variables we use them in) is interpreted directly by ninja

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from enum import Enum, unique
 from typing import List
 import os
 import re
@@ -50,6 +52,12 @@ else:
 # a conservative estimate of the command-line length limit on windows
 rsp_threshold = 4096
 
+# ninja variables whose value should remain unquoted. The value of these ninja
+# variables (or variables we use them in) is interpreted directly by ninja
+# (e.g. the value of the depfile variable is a pathname that ninja will read
+# from, etc.), so it must not be shell quoted.
+raw_names = {'DEPFILE', 'DESC', 'pool', 'description'}
+
 def ninja_quote(text, is_build_line=False):
     if is_build_line:
         qcs = ('$', ' ', ':')
@@ -66,6 +74,25 @@ Please report this error with a test case to the Meson bug tracker.''' % text
         raise MesonException(errmsg)
     return text
 
+@unique
+class Quoting(Enum):
+    both = 0
+    notShell = 1
+    notNinja = 2
+    none = 3
+
+class NinjaCommandArg:
+    def __init__(self, s, quoting = Quoting.both):
+        self.s = s
+        self.quoting = quoting
+
+    def __str__(self):
+        return self.s
+
+    @staticmethod
+    def list(l, q):
+        return [NinjaCommandArg(i, q) for i in l]
+
 class NinjaComment:
     def __init__(self, comment):
         self.comment = comment
@@ -80,9 +107,32 @@ class NinjaComment:
 class NinjaRule:
     def __init__(self, rule, command, args, description,
                  rspable = False, deps = None, depfile = None, extra = None):
+
+        def strToCommandArg(c):
+            if isinstance(c, NinjaCommandArg):
+                return c
+
+            # deal with common cases here, so we don't have to explicitly
+            # annotate the required quoting everywhere
+            if c == '&&':
+                # shell constructs shouldn't be shell quoted
+                return NinjaCommandArg(c, Quoting.notShell)
+            if c.startswith('$'):
+                var = re.search(r'\$\{?(\w*)\}?', c).group(1)
+                if var not in raw_names:
+                    # ninja variables shouldn't be ninja quoted, and their value
+                    # is already shell quoted
+                    return NinjaCommandArg(c, Quoting.none)
+                else:
+                    # shell quote the use of ninja variables whose value must
+                    # not be shell quoted (as it also used by ninja)
+                    return NinjaCommandArg(c, Quoting.notNinja)
+
+            return NinjaCommandArg(c)
+
         self.name = rule
-        self.command = command  # includes args which never go into a rspfile
-        self.args = args  # args which will go into a rspfile, if used
+        self.command = list(map(strToCommandArg, command))  # includes args which never go into a rspfile
+        self.args = list(map(strToCommandArg, args))  # args which will go into a rspfile, if used
         self.description = description
         self.deps = deps  # depstyle 'gcc' or 'msvc'
         self.depfile = depfile
@@ -91,17 +141,28 @@ class NinjaRule:
         self.refcount = 0
         self.rsprefcount = 0
 
+    @staticmethod
+    def _quoter(x):
+        if isinstance(x, NinjaCommandArg):
+            if x.quoting == Quoting.none:
+                return x.s
+            elif x.quoting == Quoting.notNinja:
+                return quote_func(x.s)
+            elif x.quoting == Quoting.notShell:
+                return ninja_quote(x.s)
+            # fallthrough
+        return ninja_quote(quote_func(str(x)))
+
     def write(self, outfile):
         for rsp in ([''] if self.refcount else [] +
                     ['_RSP'] if self.rsprefcount else []):
-
             outfile.write('rule %s%s\n' % (self.name, rsp))
             if rsp:
-                outfile.write(' command = %s @$out.rsp\n' % ' '.join(self.command))
+                outfile.write(' command = %s @$out.rsp\n' % ' '.join([self._quoter(x) for x in self.command]))
                 outfile.write(' rspfile = $out.rsp\n')
-                outfile.write(' rspfile_content = %s\n' % ' '.join(self.args))
+                outfile.write(' rspfile_content = %s\n' % ' '.join([self._quoter(x) for x in self.args]))
             else:
-                outfile.write(' command = %s\n' % ' '.join(self.command + self.args))
+                outfile.write(' command = %s\n' % ' '.join([self._quoter(x) for x in (self.command + self.args)]))
             if self.deps:
                 outfile.write(' deps = %s\n' % self.deps)
             if self.depfile:
@@ -127,9 +188,8 @@ class NinjaRule:
         ninja_vars['in'] = infiles
         ninja_vars['out'] = outfiles
 
-        # expand variables in command (XXX: this ignores any escaping/quoting
-        # that NinjaBuildElement.write() might do)
-        command = ' '.join(self.command + self.args)
+        # expand variables in command
+        command = ' '.join([self._quoter(x) for x in self.command + self.args])
         expanded_command = ''
         for m in re.finditer(r'(\${\w*})|(\$\w*)|([^$]*)', command):
             chunk = m.group()
@@ -221,12 +281,6 @@ class NinjaBuildElement:
         # the csc compiler.
         line = line.replace('\\', '/')
         outfile.write(line)
-
-        # ninja variables whose value should remain unquoted. The value of these
-        # ninja variables (or variables we use them in) is interpreted directly
-        # by ninja (e.g. the value of the depfile variable is a pathname that
-        # ninja will read from, etc.), so it must not be shell quoted.
-        raw_names = {'DEPFILE', 'DESC', 'pool', 'description'}
 
         for e in self.elems:
             (name, elems) = e
@@ -917,13 +971,15 @@ int dummy;
                                 deps='gcc', depfile='$DEPFILE',
                                 extra='restat = 1'))
 
-        c = [ninja_quote(quote_func(x)) for x in self.environment.get_build_command()] + \
+        c = self.environment.get_build_command() + \
             ['--internal',
              'regenerate',
-             ninja_quote(quote_func(self.environment.get_source_dir())),
-             ninja_quote(quote_func(self.environment.get_build_dir()))]
+             self.environment.get_source_dir(),
+             self.environment.get_build_dir(),
+             '--backend',
+             'ninja']
         self.add_rule(NinjaRule('REGENERATE_BUILD',
-                                c + ['--backend', 'ninja'], [],
+                                c, [],
                                 'Regenerating build files.',
                                 extra='generator = 1'))
 
@@ -1582,7 +1638,7 @@ int dummy;
             cmdlist = execute_wrapper + [c.format('$out') for c in rmfile_prefix]
         cmdlist += static_linker.get_exelist()
         cmdlist += ['$LINK_ARGS']
-        cmdlist += static_linker.get_output_args('$out')
+        cmdlist += NinjaCommandArg.list(static_linker.get_output_args('$out'), Quoting.none)
         description = 'Linking static target $out.'
         if num_pools > 0:
             pool = 'pool = link_pool'
@@ -1611,7 +1667,7 @@ int dummy;
                     crstr = '_CROSS'
                 rule = '%s%s_LINKER' % (langname, crstr)
                 command = compiler.get_linker_exelist()
-                args = ['$ARGS'] + compiler.get_linker_output_args('$out') + ['$in', '$LINK_ARGS']
+                args = ['$ARGS'] + NinjaCommandArg.list(compiler.get_linker_output_args('$out'), Quoting.none) + ['$in', '$LINK_ARGS']
                 description = 'Linking target $out.'
                 if num_pools > 0:
                     pool = 'pool = link_pool'
@@ -1621,7 +1677,7 @@ int dummy;
                                         rspable=compiler.can_linker_accept_rsp(),
                                         extra=pool))
 
-        args = [ninja_quote(quote_func(x)) for x in self.environment.get_build_command()] + \
+        args = self.environment.get_build_command() + \
             ['--internal',
              'symbolextractor',
              '$in',
@@ -1634,15 +1690,13 @@ int dummy;
 
     def generate_java_compile_rule(self, compiler):
         rule = '%s_COMPILER' % compiler.get_language()
-        invoc = [ninja_quote(i) for i in compiler.get_exelist()]
-        command = invoc + ['$ARGS', '$in']
+        command = compiler.get_exelist() + ['$ARGS', '$in']
         description = 'Compiling Java object $in.'
         self.add_rule(NinjaRule(rule, command, [], description))
 
     def generate_cs_compile_rule(self, compiler):
         rule = '%s_COMPILER' % compiler.get_language()
-        invoc = [ninja_quote(i) for i in compiler.get_exelist()]
-        command = invoc
+        command = compiler.get_exelist()
         args = ['$ARGS', '$in']
         description = 'Compiling C Sharp target $out.'
         self.add_rule(NinjaRule(rule, command, args, description,
@@ -1650,8 +1704,7 @@ int dummy;
 
     def generate_vala_compile_rules(self, compiler):
         rule = '%s_COMPILER' % compiler.get_language()
-        invoc = [ninja_quote(i) for i in compiler.get_exelist()]
-        command = invoc + ['$ARGS', '$in']
+        command = compiler.get_exelist() + ['$ARGS', '$in']
         description = 'Compiling Vala source $in.'
         self.add_rule(NinjaRule(rule, command, [], description, extra='restat = 1'))
 
@@ -1660,8 +1713,7 @@ int dummy;
         if is_cross:
             crstr = '_CROSS'
         rule = '%s%s_COMPILER' % (compiler.get_language(), crstr)
-        invoc = [ninja_quote(i) for i in compiler.get_exelist()]
-        command = invoc + ['$ARGS', '$in']
+        command = compiler.get_exelist() + ['$ARGS', '$in']
         description = 'Compiling Rust source $in.'
         depfile = '$targetdep'
         depstyle = 'gcc'
@@ -1670,12 +1722,12 @@ int dummy;
 
     def generate_swift_compile_rules(self, compiler):
         rule = '%s_COMPILER' % compiler.get_language()
-        full_exe = [ninja_quote(x) for x in self.environment.get_build_command()] + [
+        full_exe = self.environment.get_build_command() + [
             '--internal',
             'dirchanger',
             '$RUNDIR',
         ]
-        invoc = full_exe + [ninja_quote(i) for i in compiler.get_exelist()]
+        invoc = full_exe + compiler.get_exelist()
         command = invoc + ['$ARGS', '$in']
         description = 'Compiling Swift source $in.'
         self.add_rule(NinjaRule(rule, command, [], description))
@@ -1695,8 +1747,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if getattr(self, 'created_llvm_ir_rule', False):
             return
         rule = 'llvm_ir{}_COMPILER'.format('_CROSS' if is_cross else '')
-        command = [ninja_quote(i) for i in compiler.get_exelist()]
-        args = ['$ARGS'] + compiler.get_output_args('$out') + compiler.get_compile_only_args() + ['$in']
+        command = compiler.get_exelist()
+        args = ['$ARGS'] + NinjaCommandArg.list(compiler.get_output_args('$out'), Quoting.none) + compiler.get_compile_only_args() + ['$in']
         description = 'Compiling LLVM IR object $in.'
         self.add_rule(NinjaRule(rule, command, args, description,
                                 rspable=compiler.can_linker_accept_rsp()))
@@ -1729,15 +1781,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         if langname == 'fortran':
             self.generate_fortran_dep_hack(crstr)
         rule = '%s%s_COMPILER' % (langname, crstr)
-        depargs = compiler.get_dependency_gen_args('$out', '$DEPFILE')
-        quoted_depargs = []
-        for d in depargs:
-            if d != '$out' and d != '$in':
-                d = quote_func(d)
-            quoted_depargs.append(d)
-
-        command = [ninja_quote(i) for i in compiler.get_exelist()]
-        args = ['$ARGS'] + quoted_depargs + compiler.get_output_args('$out') + compiler.get_compile_only_args() + ['$in']
+        depargs = NinjaCommandArg.list(compiler.get_dependency_gen_args('$out', '$DEPFILE'), Quoting.none)
+        command = compiler.get_exelist()
+        args = ['$ARGS'] + depargs + NinjaCommandArg.list(compiler.get_output_args('$out'), Quoting.none) + compiler.get_compile_only_args() + ['$in']
         description = 'Compiling %s object $out.' % compiler.get_display_language()
         if isinstance(compiler, VisualStudioLikeCompiler):
             deps = 'msvc'
@@ -1758,17 +1804,11 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             crstr = ''
         rule = '%s%s_PCH' % (langname, crstr)
         depargs = compiler.get_dependency_gen_args('$out', '$DEPFILE')
-
-        quoted_depargs = []
-        for d in depargs:
-            if d != '$out' and d != '$in':
-                d = quote_func(d)
-            quoted_depargs.append(d)
         if isinstance(compiler, VisualStudioLikeCompiler):
             output = []
         else:
-            output = compiler.get_output_args('$out')
-        command = compiler.get_exelist() + ['$ARGS'] + quoted_depargs + output + compiler.get_compile_only_args() + ['$in']
+            output = NinjaCommandArg.list(compiler.get_output_args('$out'), Quoting.none)
+        command = compiler.get_exelist() + ['$ARGS'] + depargs + output + compiler.get_compile_only_args() + ['$in']
         description = 'Precompiling header $in.'
         if isinstance(compiler, VisualStudioLikeCompiler):
             deps = 'msvc'

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -47,6 +47,9 @@ else:
     execute_wrapper = []
     rmfile_prefix = ['rm', '-f', '{}', '&&']
 
+# a conservative estimate of the command-line length limit on windows
+rsp_threshold = 4096
+
 def ninja_quote(text, is_build_line=False):
     if is_build_line:
         qcs = ('$', ' ', ':')
@@ -91,24 +94,54 @@ class NinjaRule:
         if not self.refcount:
             return
 
-        outfile.write('rule %s\n' % self.name)
-        if self.rspable:
-            outfile.write(' command = %s @$out.rsp\n' % ' '.join(self.command))
-            outfile.write(' rspfile = $out.rsp\n')
-            outfile.write(' rspfile_content = %s\n' % ' '.join(self.args))
-        else:
-            outfile.write(' command = %s\n' % ' '.join(self.command + self.args))
-        if self.deps:
-            outfile.write(' deps = %s\n' % self.deps)
-        if self.depfile:
-            outfile.write(' depfile = %s\n' % self.depfile)
-        outfile.write(' description = %s\n' % self.description)
-        if self.extra:
-            for l in self.extra.split('\n'):
-                outfile.write(' ')
-                outfile.write(l)
-                outfile.write('\n')
-        outfile.write('\n')
+        for rsp in [''] + (['_RSP'] if self.rspable else []):
+            outfile.write('rule %s%s\n' % (self.name, rsp))
+            if rsp:
+                outfile.write(' command = %s @$out.rsp\n' % ' '.join(self.command))
+                outfile.write(' rspfile = $out.rsp\n')
+                outfile.write(' rspfile_content = %s\n' % ' '.join(self.args))
+            else:
+                outfile.write(' command = %s\n' % ' '.join(self.command + self.args))
+            if self.deps:
+                outfile.write(' deps = %s\n' % self.deps)
+            if self.depfile:
+                outfile.write(' depfile = %s\n' % self.depfile)
+            outfile.write(' description = %s\n' % self.description)
+            if self.extra:
+                for l in self.extra.split('\n'):
+                    outfile.write(' ')
+                    outfile.write(l)
+                    outfile.write('\n')
+            outfile.write('\n')
+
+    def length_estimate(self, infiles, outfiles, elems):
+        # determine variables
+        # this order of actions only approximates ninja's scoping rules, as
+        # documented at: https://ninja-build.org/manual.html#ref_scope
+        ninja_vars = {}
+        for e in elems:
+            (name, value) = e
+            ninja_vars[name] = value
+        ninja_vars['deps'] = self.deps
+        ninja_vars['depfile'] = self.depfile
+        ninja_vars['in'] = infiles
+        ninja_vars['out'] = outfiles
+
+        # expand variables in command (XXX: this ignores any escaping/quoting
+        # that NinjaBuildElement.write() might do)
+        command = ' '.join(self.command + self.args)
+        expanded_command = ''
+        for m in re.finditer(r'(\${\w*})|(\$\w*)|([^$]*)', command):
+            chunk = m.group()
+            if chunk.startswith('$'):
+                chunk = chunk[1:]
+                chunk = re.sub(r'{(.*)}', r'\1', chunk)
+                chunk = ninja_vars.get(chunk, [])  # undefined ninja variables are empty
+                chunk = ' '.join(chunk)
+            expanded_command += chunk
+
+        # determine command length
+        return len(expanded_command)
 
 class NinjaBuildElement:
     def __init__(self, all_outputs, outfilenames, rulename, infilenames):
@@ -144,11 +177,27 @@ class NinjaBuildElement:
             elems = [elems]
         self.elems.append((name, elems))
 
+    def _should_use_rspfile(self, infiles, outfiles):
+        # 'phony' is a rule built-in to ninja
+        if self.rulename == 'phony':
+            return False
+
+        if not self.rule.rspable:
+            return False
+
+        return self.rule.length_estimate(infiles, outfiles,
+                                         self.elems) >= rsp_threshold
+
     def write(self, outfile):
         self.check_outputs()
-        line = 'build %s: %s %s' % (' '.join([ninja_quote(i, True) for i in self.outfilenames]),
-                                    self.rulename,
-                                    ' '.join([ninja_quote(i, True) for i in self.infilenames]))
+        infilenames = ' '.join([ninja_quote(i, True) for i in self.infilenames])
+        outfilenames = ' '.join([ninja_quote(i, True) for i in self.outfilenames])
+        if self._should_use_rspfile(infilenames, outfilenames):
+            rulename = self.rulename + '_RSP'
+            mlog.warning("Command line for building %s is long, using a response file" % self.outfilenames)
+        else:
+            rulename = self.rulename
+        line = 'build %s: %s %s' % (outfilenames, rulename, infilenames)
         if len(self.deps) > 0:
             line += ' | ' + ' '.join([ninja_quote(x, True) for x in self.deps])
         if len(self.orderdeps) > 0:
@@ -878,9 +927,12 @@ int dummy;
     def add_build(self, build):
         self.build_elements.append(build)
 
-        # increment rule refcount
         if build.rulename != 'phony':
+            # increment rule refcount
             self.ruledict[build.rulename].refcount += 1
+
+            # reference rule
+            build.rule = self.ruledict[build.rulename]
 
     def write_rules(self, outfile):
         for r in self.rules:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -111,13 +111,13 @@ class NinjaRule:
         outfile.write('\n')
 
 class NinjaBuildElement:
-    def __init__(self, all_outputs, outfilenames, rule, infilenames):
+    def __init__(self, all_outputs, outfilenames, rulename, infilenames):
         if isinstance(outfilenames, str):
             self.outfilenames = [outfilenames]
         else:
             self.outfilenames = outfilenames
-        assert(isinstance(rule, str))
-        self.rule = rule
+        assert(isinstance(rulename, str))
+        self.rulename = rulename
         if isinstance(infilenames, str):
             self.infilenames = [infilenames]
         else:
@@ -147,7 +147,7 @@ class NinjaBuildElement:
     def write(self, outfile):
         self.check_outputs()
         line = 'build %s: %s %s' % (' '.join([ninja_quote(i, True) for i in self.outfilenames]),
-                                    self.rule,
+                                    self.rulename,
                                     ' '.join([ninja_quote(i, True) for i in self.infilenames]))
         if len(self.deps) > 0:
             line += ' | ' + ' '.join([ninja_quote(x, True) for x in self.deps])
@@ -879,8 +879,8 @@ int dummy;
         self.build_elements.append(build)
 
         # increment rule refcount
-        if build.rule != 'phony':
-            self.ruledict[build.rule].refcount += 1
+        if build.rulename != 'phony':
+            self.ruledict[build.rulename].refcount += 1
 
     def write_rules(self, outfile):
         for r in self.rules:

--- a/test cases/common/217 very long commmand line/codegen.py
+++ b/test cases/common/217 very long commmand line/codegen.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import sys
+
+with open(sys.argv[2], 'w') as f:
+    print('int func{n}() {{ return {n}; }}'.format(n=sys.argv[1]), file=f)

--- a/test cases/common/217 very long commmand line/main.c
+++ b/test cases/common/217 very long commmand line/main.c
@@ -1,0 +1,3 @@
+int main(int argc, char **argv) {
+  return 0;
+}

--- a/test cases/common/217 very long commmand line/meson.build
+++ b/test cases/common/217 very long commmand line/meson.build
@@ -1,0 +1,16 @@
+project('very long command lines', 'c')
+
+seq = run_command('seq.py', '1', '256').stdout().strip().split('\n')
+
+sources = []
+codegen = find_program('codegen.py')
+
+foreach i : seq
+  sources += custom_target('codegen' + i,
+                           command: [codegen, i, '@OUTPUT@'],
+                           output: 'test' + i + '.c')
+endforeach
+
+shared_library('sharedlib', sources)
+static_library('staticlib', sources)
+executable('app', 'main.c', sources)

--- a/test cases/common/217 very long commmand line/seq.py
+++ b/test cases/common/217 very long commmand line/seq.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import sys
+
+for i in range(int(sys.argv[1]), int(sys.argv[2])):
+    print(i)


### PR DESCRIPTION
Make ninja backend only use response files when the command line is long enough to need them.

This makes the output of 'ninja -v' useful more often (something like `cl @exec@exe/main.c.obj.rsp` is not very useful if you don't have the response file to look at; this is helpful when the response file (and/or the VM containing it) has been deleted by the time you get to look at the error) (see also discussion in https://github.com/ninja-build/ninja/pull/1223)

Also, per https://github.com/mesonbuild/meson/issues/271#issuecomment-378998318, writing rsp files on Windows is moderately expensive.

This also prevents rules which aren't used by any build statement from being emitted in the `build.ninja` file.
