### PR TITLE
Fix introspection in postconf scripts

### DIFF
--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -209,8 +209,6 @@ class MesonApp:
             else:
                 intr.backend.generate(intr)
             build.save(b, dumpfile)
-            # Post-conf scripts must be run after writing coredata or else introspection fails.
-            intr.backend.run_postconf_scripts()
             if env.first_invocation:
                 coredata.write_cmd_line_file(self.build_dir, self.options)
             else:
@@ -223,6 +221,9 @@ class MesonApp:
             else:
                 mintro.generate_introspection_file(b, intr.backend)
             mintro.write_meson_info_file(b, [], True)
+
+            # Post-conf scripts must be run after writing coredata or else introspection fails.
+            intr.backend.run_postconf_scripts()
         except Exception as e:
             mintro.write_meson_info_file(b, [e])
             if 'cdf' in locals():

--- a/test cases/common/144 mesonintrospect from scripts/check_introspection.py
+++ b/test cases/common/144 mesonintrospect from scripts/check_introspection.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import os
+import shlex
+import subprocess
+
+
+if 'MESONINTROSPECT' not in os.environ:
+    raise RuntimeError('MESONINTROSPECT not found')
+if 'MESON_BUILD_ROOT' not in os.environ:
+    raise RuntimeError('MESON_BUILD_ROOT not found')
+
+mesonintrospect = os.environ['MESONINTROSPECT']
+introspect_arr = shlex.split(mesonintrospect)
+
+buildroot = os.environ['MESON_BUILD_ROOT']
+
+subprocess.check_output([*introspect_arr, '--all', buildroot])

--- a/test cases/common/144 mesonintrospect from scripts/meson.build
+++ b/test cases/common/144 mesonintrospect from scripts/meson.build
@@ -10,5 +10,5 @@ else
   message(ret.stderr())
 endif
 
-meson.add_postconf_script('check_env.py')
+meson.add_postconf_script('check_introspection.py')
 meson.add_install_script('check_env.py')


### PR DESCRIPTION
All files must be written before running postconf scripts or they can't do introspection. Also, update the test to _actually check_ that introspection is working.

This broke in 0.50.0 and should probably be backported. @nirbheek 