### PR TITLE
Fix `-Dc_std=...` not affecting cross compilation. Closes #5097. [0.50.* only]

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -592,7 +592,13 @@ class CoreData:
                         k in env.cmd_line_options):
                     # TODO think about cross and command-line interface.
                     o.set_value(env.cmd_line_options[k])
-                self.compiler_options[for_machine].setdefault(k, o)
+                if k in ['c_std', 'cpp_std']:
+                    # These CLI options should affect all platforms
+                    for m in iter(MachineChoice):
+                        self.compiler_options[m].setdefault(k, o)
+                else:
+                    # By default, CLI options just affect the native platform
+                    self.compiler_options[for_machine].setdefault(k, o)
 
             # Unlike compiler and linker flags, preprocessor flags are not in
             # compiler_options because they are not visible to user.

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5043,6 +5043,14 @@ c = ['{0}']
         # TODO should someday be explicit about build platform only here
         self.init(testdir)
 
+    def test_std_remains(self):
+        # C_std defined in project options must be in effect also when native compiling.
+        testdir = os.path.join(self.unit_test_dir, '50 std remains')
+        self.init(testdir)
+        compdb = self.get_compdb()
+        self.assertRegex(compdb[0]['command'], '-std=c99')
+        self.build()
+
 def should_run_cross_arm_tests():
     return shutil.which('arm-linux-gnueabihf-gcc') and not platform.machine().lower().startswith('arm')
 
@@ -5093,6 +5101,14 @@ class LinuxCrossArmTests(BasePlatformTests):
                 self.assertEqual(i['value'], 'lib')
                 return
         self.assertTrue(False, 'Option libdir not in introspect data.')
+
+    def test_std_remains(self):
+        # C_std defined in project options must be in effect also when cross compiling.
+        testdir = os.path.join(self.unit_test_dir, '50 std remains')
+        self.init(testdir)
+        compdb = self.get_compdb()
+        self.assertRegex(compdb[0]['command'], '-std=c99')
+        self.build()
 
 
 def should_run_cross_mingw_tests():

--- a/test cases/unit/50 std remains/meson.build
+++ b/test cases/unit/50 std remains/meson.build
@@ -1,0 +1,2 @@
+project('std_remains', 'c', default_options: ['c_std=c99'])
+executable('prog', 'prog.c')

--- a/test cases/unit/50 std remains/prog.c
+++ b/test cases/unit/50 std remains/prog.c
@@ -1,0 +1,1 @@
+int main(int argc, char **argv) { return 0; }


### PR DESCRIPTION
Will make a `0.50` hotfix cherry-pick if this looks good. CC @jpakkane @dcbaker @nirbheek.