### PR TITLE
fix gpgme support by preferring pkg-config where possible

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -394,7 +394,7 @@ The `language` keyword may used.
 
 *(added 0.51.0)*
 
-`method` may be `auto` or `config-tool`.
+`method` may be `auto`, `config-tool` or `pkg-config`.
 
 ## Python3
 

--- a/docs/markdown/snippets/gpgme-config.md
+++ b/docs/markdown/snippets/gpgme-config.md
@@ -1,3 +1,3 @@
 ## gpgme dependency now supports gpgme-config
 
-Previously, we could only detect GPGME with custom invocations of `gpgme-config`. Now we added support to Meson allowing us to use `dependency('gpgme')` instead.
+Previously, we could only detect GPGME with custom invocations of `gpgme-config` or when the GPGME version was recent enough (>=1.13.0) to install pkg-config files. Now we added support to Meson allowing us to use `dependency('gpgme')` and fall back on `gpgme-config` parsing.

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -680,6 +680,9 @@ class GpgmeDependency(ExternalDependency):
         methods = cls._process_method_kw(kwargs)
         candidates = []
 
+        if DependencyMethods.PKGCONFIG in methods:
+            candidates.append(functools.partial(PkgConfigDependency, 'gpgme', environment, kwargs))
+
         if DependencyMethods.CONFIG_TOOL in methods:
             candidates.append(functools.partial(ConfigToolDependency.factory,
                                                 'gpgme', environment, None, kwargs, ['gpgme-config'],
@@ -696,7 +699,7 @@ class GpgmeDependency(ExternalDependency):
 
     @staticmethod
     def get_methods():
-        return [DependencyMethods.CONFIG_TOOL]
+        return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL]
 
 
 class ShadercDependency(ExternalDependency):

--- a/test cases/frameworks/27 gpgme/meson.build
+++ b/test cases/frameworks/27 gpgme/meson.build
@@ -19,3 +19,9 @@ dependency('gpgme', method: 'config-tool')
 
 # Check we can apply a version constraint
 dependency('gpgme', version: '>=@0@'.format(gpgme_dep.version()), method: 'config-tool')
+
+# If gpgme is new enough, make sure it picks up pkg-config by default:
+
+if gpgme_ver.version_compare('>=1.13.0')
+  assert(gpgme_dep.type_name() == 'pkgconfig', 'dependency found via pkg-config')
+endif


### PR DESCRIPTION
Since gpgme 1.13.0, pkg-config files are available and this is the preferred way to detect the dependency. Without this, projects that wish to generate pkg-config files that Requires.private on gpgme, now have their custom dependency() fallbacks overridden with an incorrect configtool dependency.