### PR TITLE
munstable_coredata: Adapt to coredata changes.

### DIFF
--- a/mesonbuild/munstable_coredata.py
+++ b/mesonbuild/munstable_coredata.py
@@ -31,9 +31,12 @@ def dump_compilers(compilers):
         print('  ' + lang + ':')
         print('      Id: ' + compiler.id)
         print('      Command: ' + ' '.join(compiler.exelist))
-        print('      Full version: ' + compiler.full_version)
-        print('      Detected version: ' + compiler.version)
-        print('      Detected type: ' + repr(compiler.compiler_type))
+        if compiler.full_version:
+            print('      Full version: ' + compiler.full_version)
+        if compiler.version:
+            print('      Detected version: ' + compiler.version)
+        if hasattr(compiler, 'compiler_type'):
+            print('      Detected type: ' + repr(compiler.compiler_type))
         #pprint.pprint(compiler.__dict__)
 
 
@@ -97,7 +100,7 @@ def run(options):
             native = []
             cross = []
             for dep_key, dep in sorted(v.items()):
-                if dep_key[2]:
+                if dep_key[1]:
                     cross.append((dep_key, dep))
                 else:
                     native.append((dep_key, dep))

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3629,6 +3629,12 @@ recommended as it is not supported on some platforms''')
         self.maxDiff = None
         self.assertListEqual(res_nb, expected)
 
+    def test_unstable_coredata(self):
+        testdir = os.path.join(self.common_test_dir, '1 trivial')
+        self.init(testdir)
+        # just test that the command does not fail (e.g. because it throws an exception)
+        self._run([*self.meson_command, 'unstable-coredata', self.builddir])
+
 class FailureTests(BasePlatformTests):
     '''
     Tests that test failure conditions. Build files here should be dynamically


### PR DESCRIPTION
On master `meson unstable-coredata` throws exceptions because the coredata format changed a bit. Fix that.

For 0.50 an additional fix is needed because `external_preprocess_args` was removed since then on master which also changed. See #5271 