### PR TITLE
WIP: ci: Automatically skip tests for docs-only changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,13 @@ matrix:
     env: RUN_TESTS_ARGS="--cross" MESON_ARGS="--unity=on"
 
 before_install:
-  - python ./skip_ci.py --base-branch-env=TRAVIS_BRANCH --is-pull-env=TRAVIS_PULL_REQUEST
+  - |
+    python ./skip_ci.py --base-branch-env=TRAVIS_BRANCH --is-pull-env=TRAVIS_PULL_REQUEST
+    if [[ $? != 0 ]]; then
+      # Skip data tests on non-Linux platforms
+      [[ "$TRAVIS_OS_NAME" != "linux" ]] && travis_terminate 0
+      ./run_unittests.py DataTests -v
+    fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt llvm; fi
     # # Run one macOS build without pkg-config available, and the other (unity=on) with pkg-config

--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -2,7 +2,8 @@ steps:
 - powershell: |
      python ./skip_ci.py --base-branch-env=SYSTEM_PULLREQUEST_TARGETBRANCH --is-pull-env=SYSTEM_PULLREQUEST_PULLREQUESTID --base-branch-origin
      if ($LastExitCode -ne 0) {
-        exit 0
+       # NOTE: Currently, data-only unit tests are only run on Travis Linux
+       exit 0
      }
 
      # remove MinGW from path, so we don't find gfortran and try to use it

--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Meson
 " Maintainer:	Nirbheek Chauhan <nirbheek.chauhan@gmail.com>
-" Last Change:	2016 Dec 7
+" Last Change:	2018 July 27
 " Credits:	Zvezdan Petkovic <zpetkovic@acm.org>
 "		Neil Schemenauer <nas@meson.ca>
 "		Dmitry Vasiliev

--- a/docs/markdown/Contributing.md
+++ b/docs/markdown/Contributing.md
@@ -156,19 +156,9 @@ subdirectory. They are not run as part of `./run_project_tests.py`.
 ### Skipping integration tests
 
 Meson uses several continuous integration testing systems that have slightly
-different interfaces for indicating a commit should be skipped.
-
-Continuous integration systems currently used:
-- [Travis-CI](https://docs.travis-ci.com/user/customizing-the-build#skipping-a-build)
-  allows `[skip ci]` anywhere in the commit messages.
-- [Azure Pipelines](https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/git-commands?view=vsts&tabs=yaml#how-do-i-avoid-triggering-a-ci-build-when-the-script-pushes)
-  allows `***NO_CI***` in the commit message.
-- [Sider](https://sider.review)
-  runs Flake8 ([see below](#python-coding-style))
-
-To promote consistent naming policy, use:
-
-   - `[skip ci]` in the commit title if you want to disable all integration tests
+different interfaces for indicating a commit should be skipped. The script
+`skip_ci.py` will automatically detect when a commit only changes documentation
+or data, and only run the `DataTests` category of unit tests.
 
 ## Documentation
 

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2014,7 +2014,9 @@ statement](Syntax.md#foreach-statements).
 Dictionaries are available since 0.47.0.
 
 Since 0.48.0 dictionaries can be added (e.g. `d1 = d2 + d3` and `d1 += d2`).
-Values from the second dictionary overrides values from the first.
+Values from the second dictionary overrides values from the first. Note that
+the `+=` operator does not edit the dictionary in-place; it will create a new
+object and assign it to the left-hand-side, i.e., dictionaries are immutable.
 
 ## Returned objects
 

--- a/skip_ci.py
+++ b/skip_ci.py
@@ -43,8 +43,8 @@ def get_git_files(base):
     return diff.strip().split(b'\n')
 
 
-def is_documentation(filename):
-    return filename.startswith(b'docs/')
+def is_documentation_or_data(filename):
+    return filename.startswith((b'docs/', b'data/'))
 
 
 def main():
@@ -61,9 +61,8 @@ def main():
         base = get_base_branch(args.base_branch_env)
         if args.base_branch_origin:
             base = 'origin/' + base
-        if all(is_documentation(f) for f in get_git_files(base)):
-            print("Don't run CI for documentation-only changes, add '[skip ci]' to commit title.")
-            print('See http://mesonbuild.com/Contributing.html#skipping-integration-tests')
+        if all(is_documentation_or_data(f) for f in get_git_files(base)):
+            print('Changeset only contains docs and/or data changes, should only run DataTests')
             sys.exit(1)
     except Exception:
         # If this script fails we want build to proceed.


### PR DESCRIPTION
Instead of requiring `skip ci` or similar in the commit title, detect such cases and only run the `DataTests` unit tests instead.

This was originally added because we wanted to avoid running slow AppVeyor tests and we had no way to detect when a changeset is docs-only. Now we don't use AppVeyor, and we have skip_ci.py.

Also this avoids false positives where we'd tell people to skip the CI even though they changed documentation that was tested by unit tests.