### PR TITLE
dependencies/base: Set PKG_CONFIG_SYSROOT_DIR from cross file

### DIFF
--- a/docs/markdown/Cross-compilation.md
+++ b/docs/markdown/Cross-compilation.md
@@ -120,6 +120,7 @@ has_function_printf = true
 
 c_args = ['-DCROSS=1', '-DSOMETHING=3']
 c_link_args = ['-some_link_arg']
+sys_root = '/some/path'
 ```
 
 In most cases you don't need the size and alignment settings, Meson
@@ -130,6 +131,12 @@ the issue. If you need extra compiler arguments to be used during
 cross compilation you can set them with `[langname]_args =
 [args]`. Just remember to specify the args as an array and not as a
 single string (i.e. not as `'-DCROSS=1 -DSOMETHING=3'`).
+
+*Since 0.52.0* The `sys_root` property may point to the root of the host
+system path (the system that will run the compiled binaries). This is used
+internally by meson to set the PKG_CONFIG_SYSROOT_DIR environment variable
+for pkg-config. If this is unset the host system is assumed to share a root
+with the build system.
 
 One important thing to note, if you did not define an `exe_wrapper` in
 the previous section, is that Meson will make a best-effort guess at

--- a/docs/markdown/snippets/pkg_config_enhancements.md
+++ b/docs/markdown/snippets/pkg_config_enhancements.md
@@ -1,0 +1,5 @@
+## Enhancements to the pkg_config_path argument
+
+Setting sys_root in the [properties] section of your cross file will now set
+PKG_CONFIG_SYSROOT_DIR automatically for host system dependencies when
+cross compiling.

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -655,9 +655,13 @@ class PkgConfigDependency(ExternalDependency):
             env = env.copy()
 
         extra_paths = self.env.coredata.builtins_per_machine[self.for_machine]['pkg_config_path'].value
+        sysroot = self.env.properties[self.for_machine].get_sys_root()
+        if sysroot:
+            env['PKG_CONFIG_SYSROOT_DIR'] = sysroot
         new_pkg_config_path = ':'.join([p for p in extra_paths])
         mlog.debug('PKG_CONFIG_PATH: ' + new_pkg_config_path)
         env['PKG_CONFIG_PATH'] = new_pkg_config_path
+
         fenv = frozenset(env.items())
         targs = tuple(args)
         cache = PkgConfigDependency.pkgbin_cache


### PR DESCRIPTION
In some cases it may be necessary to set PKG_CONFIG_SYSROOT_DIR, like
when you've mounted a host architecture system in an arbitrary path.
Meson will now check the cross files for a [properties]:sys_root
variable and set the PKG_CONFIG_SYSROOT_DIR environment variable based
on that variable.