### PR TITLE
Add a test case for dependency(method:'config-tool') with an unknown name

### DIFF
--- a/test cases/failing/96 dependency not config-tool/96 unknown config tool/meson.build
+++ b/test cases/failing/96 dependency not config-tool/96 unknown config tool/meson.build
@@ -1,0 +1,2 @@
+project('no-such-config-tool')
+dependency('no-such-config-tool', method:'config-tool')


### PR DESCRIPTION
This failed with an exception with 0.49. Fixed by c0166355, but add a test case to ensure it doesn't regress.

Report on IRC:

> 2019-04-13 20:50:57     mitigate        I need to put a dependency on "ecl", which comes with /usr/bin/ecl-config. I tried putting in a: ecl_dep = dependency('ecl', method: 'config-tool').  but it with an index out of range error in pkg_exc dependencies/base.py. Is it expected to work out of the box like this?
