### PR TITLE
interpreter: Check the meson version before parsing options

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2575,6 +2575,12 @@ external dependencies (including libraries) must go to "dependencies".''')
         if ':' in proj_name:
             raise InvalidArguments("Project name {!r} must not contain ':'".format(proj_name))
 
+        if 'meson_version' in kwargs:
+            cv = coredata.version
+            pv = kwargs['meson_version']
+            if not mesonlib.version_compare(cv, pv):
+                raise InterpreterException('Meson version is %s but project requires %s' % (cv, pv))
+
         if os.path.exists(self.option_file):
             oi = optinterpreter.OptionInterpreter(self.subproject)
             oi.process(self.option_file)
@@ -2621,11 +2627,8 @@ external dependencies (including libraries) must go to "dependencies".''')
 
         mesonlib.project_meson_versions[self.subproject] = ''
         if 'meson_version' in kwargs:
-            cv = coredata.version
-            pv = kwargs['meson_version']
-            mesonlib.project_meson_versions[self.subproject] = pv
-            if not mesonlib.version_compare(cv, pv):
-                raise InterpreterException('Meson version is %s but project requires %s.' % (cv, pv))
+            mesonlib.project_meson_versions[self.subproject] = kwargs['meson_version']
+
         self.build.projects[self.subproject] = proj_name
         mlog.log('Project name:', mlog.bold(proj_name))
         mlog.log('Project version:', mlog.bold(self.project_version))

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3625,12 +3625,13 @@ class FailureTests(BasePlatformTests):
         super().setUp()
         self.srcdir = os.path.realpath(tempfile.mkdtemp())
         self.mbuild = os.path.join(self.srcdir, 'meson.build')
+        self.moptions = os.path.join(self.srcdir, 'meson_options.txt')
 
     def tearDown(self):
         super().tearDown()
         windows_proof_rmtree(self.srcdir)
 
-    def assertMesonRaises(self, contents, match, extra_args=None, langs=None, meson_version=None):
+    def assertMesonRaises(self, contents, match, extra_args=None, langs=None, meson_version=None, options=None):
         '''
         Assert that running meson configure on the specified @contents raises
         a error message matching regex @match.
@@ -3645,6 +3646,9 @@ class FailureTests(BasePlatformTests):
             for lang in langs:
                 f.write("add_languages('{}', required : false)\n".format(lang))
             f.write(contents)
+        if options is not None:
+            with open(self.moptions, 'w') as f:
+                f.write(options)
         # Force tracebacks so we can detect them properly
         os.environ['MESON_FORCE_BACKTRACE'] = '1'
         with self.assertRaisesRegex(MesonException, match, msg=contents):
@@ -3876,6 +3880,14 @@ class FailureTests(BasePlatformTests):
         self.assertMesonRaises("sub1 = subproject('not-found-subproject', required: false)\n" +
                                "sub1.get_variable('naaa')",
                                """Subproject "subprojects/not-found-subproject" disabled can't get_variable on it.""")
+
+    def test_version_checked_before_parsing_options(self):
+        '''
+        https://github.com/mesonbuild/meson/issues/5281
+        '''
+        options = "option('some-option', type: 'foo', value: '')"
+        match = 'Meson version is.*but project requires >=2000'
+        self.assertMesonRaises("", match, meson_version='>=2000', options=options)
 
 
 @unittest.skipUnless(is_windows() or is_cygwin(), "requires Windows (or Windows via Cygwin)")


### PR DESCRIPTION
Also add a test for it so we don't regress this in the future.

Closes https://github.com/mesonbuild/meson/issues/5281

Closes https://github.com/mesonbuild/meson/issues/3480

@jpakkane @ignatenkobrain do you think we can get this into old versions of Debian/Ubuntu/Fedora so that people get helpful error messages?