### PR TITLE
Update lcc support

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2418,7 +2418,7 @@ rule FORTRAN_DEP_HACK%s
         guessed_dependencies = []
         # TODO The get_library_naming requirement currently excludes link targets that use d or fortran as their main linker
         if hasattr(linker, 'get_library_naming'):
-            search_dirs = tuple(search_dirs) + linker.get_library_dirs(self.environment)
+            search_dirs = tuple(search_dirs) + tuple(linker.get_library_dirs(self.environment))
             static_patterns = linker.get_library_naming(self.environment, LibType.STATIC, strict=True)
             shared_patterns = linker.get_library_naming(self.environment, LibType.SHARED, strict=True)
             for libname in libs:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1736,7 +1736,7 @@ class ElbrusCompiler(GnuCompiler):
 
     # FIXME: use _build_wrapper to call this so that linker flags from the env
     # get applied
-    def get_library_dirs(self, env):
+    def get_library_dirs(self, env, elf_class = None):
         os_env = os.environ.copy()
         os_env['LC_ALL'] = 'C'
         stdo = Popen_safe(self.exelist + ['--print-search-dirs'], env=os_env)[1]

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -252,9 +252,9 @@ class ElbrusCPPCompiler(GnuCPPCompiler, ElbrusCompiler):
     def get_options(self):
         opts = CPPCompiler.get_options(self)
         opts.update({'cpp_std': coredata.UserComboOption('cpp_std', 'C++ language standard to use',
-                                                   ['none', 'c++98', 'c++03', 'c++0x', 'c++11', 'c++14', 'c++1y',
-                                                    'gnu++98', 'gnu++03', 'gnu++0x', 'gnu++11', 'gnu++14', 'gnu++1y'],
-                                                   'none'),
+                                                         ['none', 'c++98', 'c++03', 'c++0x', 'c++11', 'c++14', 'c++1y',
+                                                          'gnu++98', 'gnu++03', 'gnu++0x', 'gnu++11', 'gnu++14', 'gnu++1y'],
+                                                         'none'),
                      'cpp_debugstl': coredata.UserBooleanOption('cpp_debugstl',
                                                                 'STL debug mode',
                                                                 False)})

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -115,8 +115,8 @@ class CPPCompiler(CCompiler):
             'gnu++17': 'gnu++1z'
         }
 
-        # Currently, remapping is only supported for Clang and GCC
-        assert(self.id in frozenset(['clang', 'gcc']))
+        # Currently, remapping is only supported for Clang, Elbrus and GCC
+        assert(self.id in frozenset(['clang', 'lcc', 'gcc']))
 
         if cpp_std not in CPP_FALLBACKS:
             # 'c++03' and 'c++98' don't have fallback types

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -251,10 +251,13 @@ class ElbrusCPPCompiler(GnuCPPCompiler, ElbrusCompiler):
     # It does not support c++/gnu++ 17 and 1z, but still does support 0x, 1y, and gnu++98.
     def get_options(self):
         opts = CPPCompiler.get_options(self)
-        opts['cpp_std'] = coredata.UserComboOption('cpp_std', 'C++ language standard to use',
+        opts.update({'cpp_std': coredata.UserComboOption('cpp_std', 'C++ language standard to use',
                                                    ['none', 'c++98', 'c++03', 'c++0x', 'c++11', 'c++14', 'c++1y',
                                                     'gnu++98', 'gnu++03', 'gnu++0x', 'gnu++11', 'gnu++14', 'gnu++1y'],
-                                                   'none')
+                                                   'none'),
+                     'cpp_debugstl': coredata.UserBooleanOption('cpp_debugstl',
+                                                                'STL debug mode',
+                                                                False)})
         return opts
 
     # Elbrus C++ compiler does not have lchmod, but there is only linker warning, not compiler error.

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5841,7 +5841,11 @@ class NativeFileTests(BasePlatformTests):
     @skip_if_env_set('FC')
     def test_fortran_compiler(self):
         def cb(comp):
-            if comp.id == 'gcc':
+            if comp.id == 'lcc':
+                if shutil.which('lfortran'):
+                    return 'lfortran', 'lcc'
+                raise unittest.SkipTest('No alternate Fortran implementation.')
+            elif comp.id == 'gcc':
                 if shutil.which('ifort'):
                     return 'ifort', 'intel'
                 elif shutil.which('flang'):


### PR DESCRIPTION
A pack of updated to Elbrus compiler support (was broken since commit 386e5b8 and probably other commits).

Output of `./run_unittests.py`: 
```
kaguya /usr/src/meson # ./run_unittests.py
......s...............s......s.........................................................................s....s........../tmp/tmp_tgws5xi/meson-private/sanitycheckobjc.m: file not recognized: Формат файла не распознан
...ss.......s.s.s.s.......ss..sss......................................................s.....s.......s.s..s...........s......sssssssssssssss
----------------------------------------------------------------------
Ran 259 tests in 774.007s

OK (skipped=37)
kaguya /usr/src/meson #
```