### PR TITLE
ast: Add basic string operation support for AstInterpreter (fixes #5286)

### DIFF
--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -32,7 +32,6 @@ from ..mparser import (
     MethodNode,
     PlusAssignmentNode,
     TernaryNode,
-    StringNode,
 )
 
 import os, sys

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -243,8 +243,10 @@ class AstInterpreter(interpreterbase.InterpreterBase):
             self.reverse_assignment[node.value.ast_id] = node
         self.assign_vals[node.var_name] = [self.evaluate_statement(node.value)] # Evaluate the value just in case
 
-    def flatten_args(self, args: Any, include_unknown_args: bool = False, id_loop_detect: List[str] = []) -> List[str]:
-        def quick_resolve(n: BaseNode, loop_detect: List[str] = []) -> Any:
+    def flatten_args(self, args: Any, include_unknown_args: bool = False, id_loop_detect: Optional[List[str]] = None) -> List[str]:
+        def quick_resolve(n: BaseNode, loop_detect: Optional[List[str]] = None) -> Any:
+            if loop_detect is None:
+                loop_detect = []
             if isinstance(n, IdNode):
                 if n.value in loop_detect or n.value not in self.assignments:
                     return []
@@ -254,6 +256,8 @@ class AstInterpreter(interpreterbase.InterpreterBase):
             else:
                 return n
 
+        if id_loop_detect is None:
+            id_loop_detect = []
         flattend_args = []
 
         if isinstance(args, ArrayNode):
@@ -288,7 +292,7 @@ class AstInterpreter(interpreterbase.InterpreterBase):
                     args = [self.dict_method_call(src, args.name, margs)]
                 else:
                     return []
-            except Exception:
+            except mesonlib.MesonException:
                 return []
 
         # Make sure we are always dealing with lists

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -182,11 +182,12 @@ class IntrospectionInterpreter(AstInterpreter):
                 srcqueue += [curr.left, curr.right]
             if arg_node is None:
                 continue
-            elemetary_nodes = list(filter(lambda x: isinstance(x, (str, StringNode)), arg_node.arguments))
-            srcqueue += list(filter(lambda x: isinstance(x, (FunctionNode, ArrayNode, IdNode, ArithmeticNode)), arg_node.arguments))
+            arg_nodes = arg_node.arguments.copy()
             # Pop the first element if the function is a build target function
             if isinstance(curr, FunctionNode) and curr.func_name in build_target_functions:
-                elemetary_nodes.pop(0)
+                arg_nodes.pop(0)
+            elemetary_nodes = [x for x in arg_nodes if isinstance(x, (str, StringNode))]
+            srcqueue += [x for x in arg_nodes if isinstance(x, (FunctionNode, ArrayNode, IdNode, ArithmeticNode))]
             if elemetary_nodes:
                 source_nodes += [curr]
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -4076,24 +4076,6 @@ This will become a hard error in the future.''', location=self.current_node)
             if not os.path.isfile(fname):
                 raise InterpreterException('Tried to add non-existing source file %s.' % s)
 
-    def format_string(self, templ, args):
-        if isinstance(args, mparser.ArgumentNode):
-            args = args.arguments
-        arg_strings = []
-        for arg in args:
-            arg = self.evaluate_statement(arg)
-            if isinstance(arg, bool): # Python boolean is upper case.
-                arg = str(arg).lower()
-            arg_strings.append(str(arg))
-
-        def arg_replace(match):
-            idx = int(match.group(1))
-            if idx >= len(arg_strings):
-                raise InterpreterException('Format placeholder @{}@ out of range.'.format(idx))
-            return arg_strings[idx]
-
-        return re.sub(r'@(\d+)@', arg_replace, templ)
-
     # Only permit object extraction from the same subproject
     def validate_extraction(self, buildtarget):
         if not self.subdir.startswith(self.subproject_dir):

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -920,6 +920,24 @@ The result of this is undefined and will become a hard error in a future Meson r
             return mesonlib.version_compare(obj, cmpr)
         raise InterpreterException('Unknown method "%s" for a string.' % method_name)
 
+    def format_string(self, templ, args):
+        if isinstance(args, mparser.ArgumentNode):
+            args = args.arguments
+        arg_strings = []
+        for arg in args:
+            arg = self.evaluate_statement(arg)
+            if isinstance(arg, bool): # Python boolean is upper case.
+                arg = str(arg).lower()
+            arg_strings.append(str(arg))
+
+        def arg_replace(match):
+            idx = int(match.group(1))
+            if idx >= len(arg_strings):
+                raise InterpreterException('Format placeholder @{}@ out of range.'.format(idx))
+            return arg_strings[idx]
+
+        return re.sub(r'@(\d+)@', arg_replace, templ)
+
     def unknown_function_called(self, func_name):
         raise InvalidCode('Unknown function "%s".' % func_name)
 

--- a/test cases/unit/55 introspection/meson.build
+++ b/test cases/unit/55 introspection/meson.build
@@ -28,6 +28,20 @@ t1 = executable('test' + var1, ['t1.cpp'], link_with: [sharedlib], install: true
 t2 = executable('test@0@'.format('@0@'.format(var2)), 't2.cpp', link_with: [staticlib])
 t3 = executable(var3, 't3.cpp', link_with: [sharedlib, staticlib], dependencies: [dep1])
 
+### BEGIN: Test stolen from taisei: https://github.com/taisei-project/taisei/blob/master/meson.build#L293
+have_posix = true
+systype = (have_posix ? 'POSIX (@0@)' : '@0@').format(host_machine.system())
+systype = '@0@, @1@, @2@'.format(systype, host_machine.cpu_family(), host_machine.cpu())
+systype = '@0@ (cross-compiling)'.format(systype)
+summary = '''
+
+Summary:
+    System type:            @0@
+'''.format(systype)
+
+message(summary)
+### END: Test stolen from taisei
+
 test('test case 1', t1)
 test('test case 2', t2)
 benchmark('benchmark 1', t3)

--- a/test cases/unit/55 introspection/meson.build
+++ b/test cases/unit/55 introspection/meson.build
@@ -28,19 +28,11 @@ t1 = executable('test' + var1, ['t1.cpp'], link_with: [sharedlib], install: true
 t2 = executable('test@0@'.format('@0@'.format(var2)), 't2.cpp', link_with: [staticlib])
 t3 = executable(var3, 't3.cpp', link_with: [sharedlib, staticlib], dependencies: [dep1])
 
-### BEGIN: Test stolen from taisei: https://github.com/taisei-project/taisei/blob/master/meson.build#L293
-have_posix = true
-systype = (have_posix ? 'POSIX (@0@)' : '@0@').format(host_machine.system())
+### BEGIN: Test inspired by taisei: https://github.com/taisei-project/taisei/blob/master/meson.build#L293
+systype = '@0@'.format(host_machine.system())
 systype = '@0@, @1@, @2@'.format(systype, host_machine.cpu_family(), host_machine.cpu())
-systype = '@0@ (cross-compiling)'.format(systype)
-summary = '''
-
-Summary:
-    System type:            @0@
-'''.format(systype)
-
-message(summary)
-### END: Test stolen from taisei
+message(systype)
+### END: Test inspired by taisei
 
 test('test case 1', t1)
 test('test case 2', t2)

--- a/test cases/unit/55 introspection/meson.build
+++ b/test cases/unit/55 introspection/meson.build
@@ -20,9 +20,12 @@ endif
 subdir('sharedlib')
 subdir('staticlib')
 
+var1 = '1'
+var2 = '2'
 var3 = 'test3'
 
-t1 = executable('test1', 't1.cpp', link_with: [sharedlib], install: true, build_by_default: get_option('test_opt2'))
+t1 = executable('test' + var1, ['t1.cpp'], link_with: [sharedlib], install: true, build_by_default: get_option('test_opt2'))
+#t2 = executable('test@0@'.format('' + '@0@'.format(var2)), 't2.cpp', link_with: [staticlib])
 t2 = executable('test2', 't2.cpp', link_with: [staticlib])
 t3 = executable(var3, 't3.cpp', link_with: [sharedlib, staticlib], dependencies: [dep1])
 

--- a/test cases/unit/55 introspection/meson.build
+++ b/test cases/unit/55 introspection/meson.build
@@ -20,9 +20,11 @@ endif
 subdir('sharedlib')
 subdir('staticlib')
 
+var3 = 'test3'
+
 t1 = executable('test1', 't1.cpp', link_with: [sharedlib], install: true, build_by_default: get_option('test_opt2'))
 t2 = executable('test2', 't2.cpp', link_with: [staticlib])
-t3 = executable('test3', 't3.cpp', link_with: [sharedlib, staticlib], dependencies: [dep1])
+t3 = executable(var3, 't3.cpp', link_with: [sharedlib, staticlib], dependencies: [dep1])
 
 test('test case 1', t1)
 test('test case 2', t2)

--- a/test cases/unit/55 introspection/meson.build
+++ b/test cases/unit/55 introspection/meson.build
@@ -21,12 +21,11 @@ subdir('sharedlib')
 subdir('staticlib')
 
 var1 = '1'
-var2 = '2'
+var2 = 2.to_string()
 var3 = 'test3'
 
 t1 = executable('test' + var1, ['t1.cpp'], link_with: [sharedlib], install: true, build_by_default: get_option('test_opt2'))
-#t2 = executable('test@0@'.format('' + '@0@'.format(var2)), 't2.cpp', link_with: [staticlib])
-t2 = executable('test2', 't2.cpp', link_with: [staticlib])
+t2 = executable('test@0@'.format('@0@'.format(var2)), 't2.cpp', link_with: [staticlib])
 t3 = executable(var3, 't3.cpp', link_with: [sharedlib, staticlib], dependencies: [dep1])
 
 test('test case 1', t1)


### PR DESCRIPTION
This PR adds basic string processing functionality to the `AstInterpreter`. This should cover most use cases. This should also resolve #5286. I am not sure if this should go into 0.50.2 or 0.51.0.

PS: @Akaricchi your taisei project really is an excellent integration test 😄 