### PR TITLE
Add support for the Xtensa toolchain

### DIFF
--- a/docs/markdown/snippets/xtensa-toolchain.md
+++ b/docs/markdown/snippets/xtensa-toolchain.md
@@ -1,0 +1,5 @@
+## Added basic support for the Xtensa CPU toolchain
+
+You can now use `xt-xcc`, `xt-xc++`, `xt-nm`, etc... on your cross compilation
+file and meson won't complain about an unknown toolchain.
+

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -689,7 +689,7 @@ class Environment:
             version = search_version(out)
 
             guess_gcc_or_lcc = False
-            if 'Free Software Foundation' in out:
+            if 'Free Software Foundation' in out or 'xt-' in out:
                 guess_gcc_or_lcc = 'gcc'
             if 'e2k' in out and 'lcc' in out:
                 guess_gcc_or_lcc = 'lcc'


### PR DESCRIPTION
From (almost) all points of view, the Xtensa toolchain can be treated as
a regular GCC toolchain.

This patch adds very basic support so that, at least, meson does not
fail when trying to use "xt-xcc" (which makes it possible to use it
without problems).