### PR TITLE
compilers/c: fix clang-cl openmp

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -1721,6 +1721,10 @@ class ClangClCCompiler(VisualStudioCCompiler):
         super().__init__(exelist, version, is_cross, exe_wrap, target)
         self.id = 'clang-cl'
 
+    def openmp_flags(self) -> List[str]:
+        # clang-cl does not (as of 2019-04) accept /openmp as an argument
+        # See this llvm/clang bug: https://bugs.llvm.org/show_bug.cgi?id=31207
+        return ['-Xclang', '-fopenmp']
 
 class ArmCCompiler(ArmCompiler, CCompiler):
     def __init__(self, exelist, version, compiler_type, is_cross, exe_wrapper=None, **kwargs):

--- a/test cases/common/190 openmp/meson.build
+++ b/test cases/common/190 openmp/meson.build
@@ -10,9 +10,6 @@ endif
 if cc.get_id() == 'msvc' and cc.version().version_compare('<17')
   error('MESON_SKIP_TEST msvc is too old to support OpenMP.')
 endif
-if cc.get_id() == 'clang-cl'
-  error('MESON_SKIP_TEST clang-cl does not support OpenMP.')
-endif
 if cc.get_id() == 'clang' and host_machine.system() == 'windows'
   error('MESON_SKIP_TEST Windows clang does not support OpenMP.')
 endif


### PR DESCRIPTION
Clang-cl (the clang that behaves like msvc) doesn't accept /openmp like
msvc does (at least currently), instead it takes -Xclang -fopenmp, so do
that.

Fixes #5298