### PR TITLE
RPM Macros: Use `meson test` for %meson_test

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -2,6 +2,12 @@
 %__meson_wrap_mode nodownload
 %__meson_auto_features enabled
 
+%_smp_mesonflags %([ -z "$MESON_BUILD_NCPUS" ] \\\
+	&& MESON_BUILD_NCPUS="`/usr/bin/getconf _NPROCESSORS_ONLN`"; \\\
+        ncpus_max=%{?_smp_ncpus_max}; \\\
+        if [ -n "$ncpus_max" ] && [ "$ncpus_max" -gt 0 ] && [ "$MESON_BUILD_NCPUS" -gt "$ncpus_max" ]; then MESON_BUILD_NCPUS="$ncpus_max"; fi; \\\
+        if [ "$MESON_BUILD_NCPUS" -gt 1 ]; then echo "--num-processes $MESON_BUILD_NCPUS"; fi)
+
 %meson \
     %set_build_flags \
     %{shrink:%{__meson} \
@@ -31,4 +37,8 @@
     %ninja_install -C %{_vpath_builddir}
 
 %meson_test \
-    %ninja_test -C %{_vpath_builddir}
+    %{shrink: %{__meson} test \
+        -C %{_vpath_builddir} \
+        %{?_smp_mesonflags} \
+        --print-errorlogs \
+    %{nil}}


### PR DESCRIPTION
Previously, this called out to the %ninja_test macro to run the
tests, but that limits us to only the arguments that ninja can
understand. In particular, it is not possible to add a test
timeout multiplier (such as is sometimes needed when building for
slow architectures such as armv7hl). With this patch, it will be
possible to specify `%meson_test -t 5` in the RPM spec file
without needing to patch the sources to extend the timeouts,
making life easier for packagers.

Related: https://github.com/mesonbuild/meson/issues/2037

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>