### PR TITLE
environment.py: Fix architecture detection on older MSVC

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -182,7 +182,7 @@ def detect_windows_arch(compilers):
     # 32-bit and pretend like we're running under WOW64. Else, return the
     # actual Windows architecture that we deduced above.
     for compiler in compilers.values():
-        if compiler.id == 'msvc' and compiler.target == 'x86':
+        if compiler.id == 'msvc' and (compiler.target == 'x86' or compiler.target == '80x86'):
             return 'x86'
         if compiler.id == 'clang-cl' and compiler.target == 'x86':
             return 'x86'


### PR DESCRIPTION
Hi,

From the commit message:

<i>The cl.exe from Visual Studio 2010 and earlier report '80x86', not 'x86', for the architecture that the compiler supports.  So, we ought to check for that as well to see whether we are building for 32-bit x86.</i>

This will fix issue #5189 when building GLib on Visual Studio 2010 and earlier.

With blessings, thank you!