### PR TITLE
Gcovr 4.2

### DIFF
--- a/docs/markdown/Feature-autodetection.md
+++ b/docs/markdown/Feature-autodetection.md
@@ -16,4 +16,4 @@ If you do not wish to use CCache for some reason, just specify your compiler wit
 Coverage
 --
 
-When doing a code coverage build, Meson will check the existence of binaries `gcovr`, `lcov` and `genhtml`. If the first one is found, it will create targets called *coverage-text* and *coverage-xml*. If the latter two or a new enough `gcovr` is found, it generates the target *coverage-html*. You can then generate coverage reports just by calling e.g. `ninja coverage-xml`.
+When doing a code coverage build, Meson will check for existence of the binaries `gcovr`, `lcov` and `genhtml`. If version 3.3 or higher of the first is found, targets called *coverage-text*, *coverage-xml* and *coverage-html* are generated. Alternatively, if the latter two are found, only the target *coverage-html* is generated. Coverage reports can then be produced simply by calling e.g. `ninja coverage-xml`. As a convenience, a high-level *coverage* target is also generated which will produce all 3 coverage report types, if possible.

--- a/docs/markdown/Unit-tests.md
+++ b/docs/markdown/Unit-tests.md
@@ -30,7 +30,7 @@ Note how you need to specify multiple values as an array.
 Coverage
 --
 
-If you enable coverage measurements by giving Meson the command line flag `-Db_coverage=true`, you can generate coverage reports. Meson will autodetect what coverage generator tools you have installed and will generate the corresponding targets. These targets are `coverage-xml` and `coverage-text` which are both provided by [Gcovr](http://gcovr.com) and `coverage-html`, which requires [Lcov](https://ltp.sourceforge.io/coverage/lcov.php) and [GenHTML](https://linux.die.net/man/1/genhtml) or [Gcovr](http://gcovr.com) with html support.
+If you enable coverage measurements by giving Meson the command line flag `-Db_coverage=true`, you can generate coverage reports. Meson will autodetect what coverage generator tools you have installed and will generate the corresponding targets. These targets are `coverage-xml` and `coverage-text` which are both provided by [Gcovr](http://gcovr.com) (version 3.3 or higher) and `coverage-html`, which requires [Lcov](https://ltp.sourceforge.io/coverage/lcov.php) and [GenHTML](https://linux.die.net/man/1/genhtml) or [Gcovr](http://gcovr.com). As a convenience, a high-level `coverage` target is also generated which will produce all 3 coverage report types, if possible.
 
 The output of these commands is written to the log directory `meson-logs` in your build directory.
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -83,7 +83,7 @@ from .compilers import (
 
 build_filename = 'meson.build'
 
-def detect_gcovr(version='3.1', log=False):
+def detect_gcovr(min_version='3.3', new_rootdir_version='4.2', log=False):
     gcovr_exe = 'gcovr'
     try:
         p, found = Popen_safe([gcovr_exe, '--version'])[0:2]
@@ -91,10 +91,10 @@ def detect_gcovr(version='3.1', log=False):
         # Doesn't exist in PATH or isn't executable
         return None, None
     found = search_version(found)
-    if p.returncode == 0:
+    if p.returncode == 0 and mesonlib.version_compare(found, '>=' + min_version):
         if log:
             mlog.log('Found gcovr-{} at {}'.format(found, shlex.quote(shutil.which(gcovr_exe))))
-        return gcovr_exe, mesonlib.version_compare(found, '>=' + version)
+        return gcovr_exe, mesonlib.version_compare(found, '>=' + new_rootdir_version)
     return None, None
 
 def find_coverage_tools():


### PR DESCRIPTION
Updates the coverage script and the `detect_gcovr()` function to support gcovr 4.2 (if that's indeed what the next version will be). As the commit message says, while looking into the best solution I discovered that it seems gcovr versions older than 3.3 actually don't produce any usable output with Meson as the coverage seems to always be 0% (version 3.0 actually hangs, but that may be a different story). For this reason I decided to modify the code such that gcovr versions older than 3.3 simply aren't detected. This way the logic previously used to differentiate pre-3.1 versions could be re-purposed for handling the new syntax in 4.2. 

Let me know if I missed something or if there's anything else you want to know.

Cheers

Edit: As mentioned in the one of the commit messages, this closes #5089.