### PR TITLE
Extended test case for special characters in compiler arguments

### DIFF
--- a/test cases/common/145 special characters/arg-char-test.c
+++ b/test cases/common/145 special characters/arg-char-test.c
@@ -1,0 +1,6 @@
+#include <assert.h>
+
+int main(int argc, char **argv) {
+  char c = CHAR;
+  assert(c == argv[1][0]);
+}

--- a/test cases/common/145 special characters/arg-string-test.c
+++ b/test cases/common/145 special characters/arg-string-test.c
@@ -1,0 +1,8 @@
+#include <assert.h>
+#include <string.h>
+
+int main(int argc, char **argv) {
+  const char *s = CHAR;
+  assert(strlen(s) == 1);
+  assert(s[0] == argv[1][0]);
+}

--- a/test cases/common/145 special characters/arg-unquoted-test.c
+++ b/test cases/common/145 special characters/arg-unquoted-test.c
@@ -1,0 +1,13 @@
+#include <assert.h>
+#include <string.h>
+
+#define Q(x) #x
+#define QUOTE(x) Q(x)
+
+int main(int argc, char **argv) {
+  const char *s = QUOTE(CHAR);
+  assert(strlen(s) == 1);
+  assert(s[0] == argv[1][0]);
+  // There is no way to convert a macro argument into a character constant.
+  // Otherwise we'd test that as well
+}

--- a/test cases/common/145 special characters/meson.build
+++ b/test cases/common/145 special characters/meson.build
@@ -35,3 +35,36 @@ gen2 = custom_target('gen2',
   output : 'result2',
   install : true,
   install_dir : get_option('datadir'))
+
+# test that we can pass these special characters in compiler arguments
+#
+# (this part of the test is crafted so we don't try to use these special
+# characters in filenames or target names)
+#
+# TODO: similar tests needed for languages other than C
+
+special = [['dollar', '$'],
+           ['hash', '#'],
+           ['quote', '\''],
+           ['doublequote', '"'],
+           ['lt', '<'],
+           ['gt', '>'],
+           ['amp', '&'],
+           ['slash', '/'],
+           ['backslash', '\\']]
+
+foreach s : special
+  args = '-DCHAR="@0@"'.format(s[1])
+  e = executable('arg-string-' + s[0], 'arg-string-test.c', c_args: args)
+  test('arg-string-' + s[0], e, args: s[1])
+
+  args = '-DCHAR=@0@'.format(s[1])
+  e = executable('arg-unquoted-' + s[0], 'arg-unquoted-test.c', c_args: args)
+  test('arg-unquoted-' + s[0], e, args: s[1])
+endforeach
+
+foreach s : special
+  args = '-DCHAR=\'@0@\''.format(s[1])
+  e = executable('arg-char-' + s[0], 'arg-char-test.c', c_args: args)
+  test('arg-char-' + s[0], e, args: s[1])
+endforeach


### PR DESCRIPTION
This is a test case I wrote to explore some of the problems I saw while working on #5245.

This fails at the moment, but I'm not 100% sure this is valid meson. 

After #641, I think that the idea is that we can write compiler arguments without any quoting, and `backends.py:escape_extra_args()` will make things right, which it fails to do in this case.

(It's also worth comparing this with test case `112 spaces backslash`, which is focused on the case of a define being a Windows path, containing a `\`)