### PR TITLE
mesonlib: Make typing.Type calls into strings

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -134,7 +134,7 @@ class Properties(HasEnvVarFallback):
     def get_sys_root(self) -> typing.Optional[typing.Union[str, typing.List[str]]]:
         return self.properties.get('sys_root', None)
 
-    def __eq__(self, other: typing.Any) -> typing.Union[bool, 'NotImplemented']:
+    def __eq__(self, other: typing.Any) -> 'typing.Union[bool, NotImplemented]':
         if isinstance(other, type(self)):
             return self.properties == other.properties
         return NotImplemented
@@ -159,7 +159,7 @@ class MachineInfo:
         self.endian = endian
         self.is_64_bit = cpu_family in CPU_FAMILES_64_BIT  # type: bool
 
-    def __eq__(self, other: typing.Any) -> typing.Union[bool, 'NotImplemented']:
+    def __eq__(self, other: typing.Any) -> 'typing.Union[bool, NotImplemented]':
         if self.__class__ is not other.__class__:
             return NotImplemented
         return \
@@ -168,7 +168,7 @@ class MachineInfo:
             self.cpu == other.cpu and \
             self.endian == other.endian
 
-    def __ne__(self, other: typing.Any) -> typing.Union[bool, 'NotImplemented']:
+    def __ne__(self, other: typing.Any) -> 'typing.Union[bool, NotImplemented]':
         if self.__class__ is not other.__class__:
             return NotImplemented
         return not self.__eq__(other)

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -922,7 +922,8 @@ def extract_as_list(dict_object, *keys, pop=False, **kwargs):
         result.append(listify(fetch(key, []), **kwargs))
     return result
 
-def typeslistify(item: typing.Union[_T, typing.List[_T]], types: typing.Union[typing.Type[_T], typing.Tuple[typing.Type[_T]]]) -> typing.List[_T]:
+def typeslistify(item: 'typing.Union[_T, typing.List[_T]]',
+                 types: 'typing.Union[typing.Type[_T], typing.Tuple[typing.Type[_T]]]') -> typing.List[_T]:
     '''
     Ensure that type(@item) is one of @types or a
     list of items all of which are of type @types


### PR DESCRIPTION
To (hopefully) work around a bug in old versions of python 3.5 (at least
as late as 3.5.2, but before 3.5.5).

Fixes #5326