### PR TITLE
Don't close fds when executing programs

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -953,7 +953,7 @@ def Popen_safe(args, write=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
     return p, o, e
 
 def Popen_safe_legacy(args, write=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs):
-    p = subprocess.Popen(args, universal_newlines=False,
+    p = subprocess.Popen(args, universal_newlines=False, close_fds=False,
                          stdout=stdout, stderr=stderr, **kwargs)
     if write is not None:
         write = write.encode('utf-8')


### PR DESCRIPTION
This is basically the same as #1612 just for new new Popen_safe_legacy().