### PR TITLE
add support for "target_type: 'shared_module'" in build_target()

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -158,7 +158,19 @@ library. In addition it supports the following extra methods:
 ### build_target()
 
 Creates a build target whose type can be set dynamically with the
-`target_type` keyword argument. This declaration:
+`target_type` keyword argument.
+
+`target_type` may be set to one of:
+
+- `executable`
+- `shared_library`
+- `shared_module`
+- `static_library`
+- `both_libraries`
+- `library`
+- `jar`
+
+This declaration:
 
 ```meson
 executable(<arguments and keyword arguments>)

--- a/docs/markdown/snippets/target-type-shared-module.md
+++ b/docs/markdown/snippets/target-type-shared-module.md
@@ -1,0 +1,16 @@
+## `target_type` in `build_targets` accepts the value 'shared_module'
+
+The `target_type` keyword argument in `build_target()` now accepts the
+value `'shared_module'`.
+
+The statement
+
+```meson
+build_target(..., target_type: 'shared_module')
+```
+
+is equivalent to this:
+
+```meson
+shared_module(...)
+```

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3117,6 +3117,8 @@ external dependencies (including libraries) must go to "dependencies".''')
         elif target_type == 'shared_library':
             return self.build_target(node, args, kwargs, SharedLibraryHolder)
         elif target_type == 'shared_module':
+            FeatureNew('build_target(target_type: \'shared_module\')',
+                       '0.51.0').use(self.subproject)
             return self.build_target(node, args, kwargs, SharedModuleHolder)
         elif target_type == 'static_library':
             return self.build_target(node, args, kwargs, StaticLibraryHolder)

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3116,6 +3116,8 @@ external dependencies (including libraries) must go to "dependencies".''')
             return self.build_target(node, args, kwargs, ExecutableHolder)
         elif target_type == 'shared_library':
             return self.build_target(node, args, kwargs, SharedLibraryHolder)
+        elif target_type == 'shared_module':
+            return self.build_target(node, args, kwargs, SharedModuleHolder)
         elif target_type == 'static_library':
             return self.build_target(node, args, kwargs, StaticLibraryHolder)
         elif target_type == 'both_libraries':

--- a/test cases/common/122 shared module/meson.build
+++ b/test cases/common/122 shared module/meson.build
@@ -12,6 +12,10 @@ e = executable('prog', 'prog.c',
   link_with : l, export_dynamic : true, dependencies : dl)
 test('import test', e, args : m)
 
+# Same as above, but module created with build_target()
+m2 = build_target('mymodule2', 'module.c', target_type: 'shared_module')
+test('import test 2', e, args : m2)
+
 # Shared module that does not export any symbols
 shared_module('nosyms', 'nosyms.c',
   install : true,

--- a/test cases/common/184 bothlibraries/meson.build
+++ b/test cases/common/184 bothlibraries/meson.build
@@ -10,3 +10,16 @@ exe_both = executable('prog-both', 'main.c', link_with : both_libs)
 test('runtest-shared', exe_shared)
 test('runtest-static', exe_static)
 test('runtest-both', exe_both)
+
+# Same as above, but using build_target()
+both_libs2 = build_target('mylib2', 'libfile.c', target_type: 'both_libraries')
+exe_shared2 = executable('prog-shared2', 'main.c',
+                         link_with : both_libs2.get_shared_lib())
+exe_static2 = executable('prog-static2', 'main.c',
+                         c_args : ['-DSTATIC_COMPILATION'],
+                         link_with : both_libs2.get_static_lib())
+exe_both2 = executable('prog-both2', 'main.c', link_with : both_libs2)
+
+test('runtest-shared-2', exe_shared2)
+test('runtest-static-2', exe_static2)
+test('runtest-both-2', exe_both2)

--- a/test cases/common/3 static/meson.build
+++ b/test cases/common/3 static/meson.build
@@ -2,4 +2,3 @@ project('static library test', 'c')
 
 lib = static_library('mylib', get_option('source'),
   link_args : '-THISMUSTNOBEUSED') # Static linker needs to ignore all link args.
-build_target('mylib2', get_option('source'), target_type: 'static_library')

--- a/test cases/common/3 static/meson.build
+++ b/test cases/common/3 static/meson.build
@@ -2,3 +2,4 @@ project('static library test', 'c')
 
 lib = static_library('mylib', get_option('source'),
   link_args : '-THISMUSTNOBEUSED') # Static linker needs to ignore all link args.
+build_target('mylib2', get_option('source'), target_type: 'static_library')

--- a/test cases/common/4 shared/meson.build
+++ b/test cases/common/4 shared/meson.build
@@ -1,2 +1,3 @@
 project('shared library test', 'c')
 lib = shared_library('mylib', 'libfile.c')
+build_target('mylib2', 'libfile.c', target_type: 'shared_library')

--- a/test cases/common/93 default library/meson.build
+++ b/test cases/common/93 default library/meson.build
@@ -3,3 +3,8 @@ project('default library', 'cpp')
 flib = library('ef', 'ef.cpp')
 exe = executable('eftest', 'eftest.cpp', link_with : flib)
 test('eftest', exe)
+
+# Same as above, but using build_target()
+flib2 = build_target('ef2', 'ef.cpp', target_type: 'library')
+exe2 = executable('eftest2', 'eftest.cpp', link_with : flib2)
+test('eftest2', exe2)


### PR DESCRIPTION
Allow `build_target()` to be called with `target_type: 'shared_module'`. Not having this looked like an oversight. 

Fixes https://github.com/mesonbuild/meson/issues/5342