### PR TITLE
Fix an assertion exception when misusing install_data

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3421,8 +3421,10 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         for s in raw_sources:
             if isinstance(s, mesonlib.File):
                 sources.append(s)
-            else:
+            elif isinstance(s, str):
                 source_strings.append(s)
+            else:
+                raise InvalidArguments('Argument {!r} must be string or file.'.format(s))
         sources += self.source_strings_to_files(source_strings)
         install_dir = kwargs.get('install_dir', None)
         if not isinstance(install_dir, (str, type(None))):

--- a/test cases/failing/97 custom target install data/Info.plist.cpp
+++ b/test cases/failing/97 custom target install data/Info.plist.cpp
@@ -1,0 +1,1 @@
+Some data which gets processed before installation

--- a/test cases/failing/97 custom target install data/meson.build
+++ b/test cases/failing/97 custom target install data/meson.build
@@ -1,0 +1,11 @@
+project('custom target install data')
+
+preproc = find_program('preproc.py')
+
+t = custom_target('Info.plist',
+    command: [preproc, '@INPUT@', '@OUTPUT@'],
+    input: 'Info.plist.cpp',
+    output: 'Info.plist',
+)
+
+install_data(t)

--- a/test cases/failing/97 custom target install data/preproc.py
+++ b/test cases/failing/97 custom target install data/preproc.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import sys
+
+if len(sys.argv) != 3:
+    print(sys.argv[0], '<input>', '<output>')
+
+inf = sys.argv[1]
+outf = sys.argv[2]
+
+with open(outf, 'wb') as o:
+    with open(inf, 'rb') as i:
+        o.write(i.read())


### PR DESCRIPTION
While converting something to meson, I (mistakenly) wrote something like:

```meson
preproc = find_program('preproc.py')

t = custom_target('Info.plist',
    command: [preproc, '@INPUT@', '@OUTPUT@'],
    input: 'Info.plist.cpp',
    output: 'Info.plist',
)

install_data(t)
```

and was rewarded with:

```
Traceback (most recent call last):
  File "/wip/meson/mesonbuild/mesonmain.py", line 127, in run
    return options.run_func(options)
  File "/wip/meson/mesonbuild/msetup.py", line 240, in run
    app.generate()
  File "/wip/meson/mesonbuild/msetup.py", line 158, in generate
    self._generate(env)
  File "/wip/meson/mesonbuild/msetup.py", line 187, in _generate
    intr.run()
  File "/wip/meson/mesonbuild/interpreter.py", line 3847, in run
    super().run()
  File "/wip/meson/mesonbuild/interpreterbase.py", line 407, in run
    self.evaluate_codeblock(self.ast, start=1)
  File "/wip/meson/mesonbuild/interpreterbase.py", line 431, in evaluate_codeblock
    raise e
  File "/wip/meson/mesonbuild/interpreterbase.py", line 425, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "/wip/meson/mesonbuild/interpreterbase.py", line 436, in evaluate_statement
    return self.function_call(cur)
  File "/wip/meson/mesonbuild/interpreterbase.py", line 773, in function_call
    return func(node, posargs, kwargs)
  File "/wip/meson/mesonbuild/interpreterbase.py", line 285, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "/wip/meson/mesonbuild/interpreterbase.py", line 285, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "/wip/meson/mesonbuild/interpreterbase.py", line 174, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "/wip/meson/mesonbuild/interpreter.py", line 3432, in func_install_data
    data = DataHolder(build.Data(sources, install_dir, install_mode, rename))
  File "/wip/meson/mesonbuild/build.py", line 2345, in __init__
    assert(isinstance(s, File))
AssertionError
```

Validate the type of the arguments to `install_data()` so we get an error message rather than a backtrace.