### PR TITLE
Make `PerMachine` and `MachineChoice` have just `build` and `host`

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -241,7 +241,7 @@ class CoreData:
         self.init_builtins()
         self.backend_options = {}
         self.user_options = {}
-        self.compiler_options = PerMachine({}, {}, {})
+        self.compiler_options = PerMachine({}, {})
         self.base_options = {}
         self.cross_files = self.__load_config_files(options.cross_file, 'cross')
         self.compilers = OrderedDict()

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -522,7 +522,7 @@ class ConfigToolDependency(ExternalDependency):
 class PkgConfigDependency(ExternalDependency):
     # The class's copy of the pkg-config path. Avoids having to search for it
     # multiple times in the same Meson invocation.
-    class_pkgbin = PerMachine(None, None, None)
+    class_pkgbin = PerMachine(None, None)
     # We cache all pkg-config subprocess invocations to avoid redundant calls
     pkgbin_cache = {}
 
@@ -957,9 +957,9 @@ class CMakeTarget:
 class CMakeDependency(ExternalDependency):
     # The class's copy of the CMake path. Avoids having to search for it
     # multiple times in the same Meson invocation.
-    class_cmakebin = PerMachine(None, None, None)
-    class_cmakevers = PerMachine(None, None, None)
-    class_cmakeinfo = PerMachine(None, None, None)
+    class_cmakebin = PerMachine(None, None)
+    class_cmakevers = PerMachine(None, None)
+    class_cmakeinfo = PerMachine(None, None)
     # We cache all pkg-config subprocess invocations to avoid redundant calls
     cmake_cache = {}
     # Version string for the minimum CMake version

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -16,7 +16,7 @@ import configparser, os, shlex, subprocess
 import typing
 
 from . import mesonlib
-from .mesonlib import EnvironmentException, MachineChoice, PerMachine
+from .mesonlib import EnvironmentException
 from . import mlog
 
 _T = typing.TypeVar('_T')
@@ -254,40 +254,6 @@ class MachineInfo:
 
     def libdir_layout_is_win(self) -> bool:
         return self.is_windows() or self.is_cygwin()
-
-class PerMachineDefaultable(PerMachine[typing.Optional[_T]]):
-    """Extends `PerMachine` with the ability to default from `None`s.
-    """
-    def __init__(self) -> None:
-        super().__init__(None, None, None)
-
-    def default_missing(self) -> None:
-        """Default host to buid and target to host.
-
-        This allows just specifying nothing in the native case, just host in the
-        cross non-compiler case, and just target in the native-built
-        cross-compiler case.
-        """
-        if self.host is None:
-            self.host = self.build
-        if self.target is None:
-            self.target = self.host
-
-    def miss_defaulting(self) -> None:
-        """Unset definition duplicated from their previous to None
-
-        This is the inverse of ''default_missing''. By removing defaulted
-        machines, we can elaborate the original and then redefault them and thus
-        avoid repeating the elaboration explicitly.
-        """
-        if self.target == self.host:
-            self.target = None
-        if self.host == self.build:
-            self.host = None
-
-class MachineInfos(PerMachineDefaultable[MachineInfo]):
-    def matches_build_machine(self, machine: MachineChoice) -> bool:
-        return self.build == self[machine]
 
 class BinaryTable(HasEnvVarFallback):
     def __init__(

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2047,12 +2047,12 @@ class Interpreter(InterpreterBase):
         if not mock:
             self.parse_project()
 
-        # Initialize machine descriptions. We can do a better job now because we
+        # Re-initialize machine descriptions. We can do a better job now because we
         # have the compilers needed to gain more knowledge, so wipe out old
         # inferrence and start over.
-        self.build.environment.machines.miss_defaulting()
-        self.build.environment.detect_build_machine(self.coredata.compilers)
-        self.build.environment.machines.default_missing()
+        machines = self.build.environment.machines.miss_defaulting()
+        machines.build = environment.detect_machine_info(self.coredata.compilers)
+        self.build.environment.machines = machines.default_missing()
         assert self.build.environment.machines.build.cpu is not None
         assert self.build.environment.machines.host.cpu is not None
         assert self.build.environment.machines.target.cpu is not None

--- a/run_tests.py
+++ b/run_tests.py
@@ -220,7 +220,7 @@ def clear_meson_configure_class_caches():
     mesonbuild.compilers.CCompiler.find_library_cache = {}
     mesonbuild.compilers.CCompiler.find_framework_cache = {}
     mesonbuild.dependencies.PkgConfigDependency.pkgbin_cache = {}
-    mesonbuild.dependencies.PkgConfigDependency.class_pkgbin = mesonlib.PerMachine(None, None, None)
+    mesonbuild.dependencies.PkgConfigDependency.class_pkgbin = mesonlib.PerMachine(None, None)
 
 def run_configure_inprocess(commandlist):
     old_stdout = sys.stdout

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -848,7 +848,7 @@ class InternalTests(unittest.TestCase):
                 PkgConfigDependency.check_pkgconfig = old_check
                 # Reset dependency class to ensure that in-process configure doesn't mess up
                 PkgConfigDependency.pkgbin_cache = {}
-                PkgConfigDependency.class_pkgbin = PerMachine(None, None, None)
+                PkgConfigDependency.class_pkgbin = PerMachine(None, None)
 
     def test_version_compare(self):
         comparefunc = mesonbuild.mesonlib.version_compare_many


### PR DESCRIPTION
Meson itself *almost* only cares about the build and host platforms. The
exception is it takes a `target_machine` in the cross file and exposes
it to the user; but it doesn't do anything else with it. It's therefore
overkill to put target in `PerMachine` and `MachineChoice`. Instead, we
make a `PerThreeMachine` only for the machine infos.

Additionally fix a few other things that were bugging me in the process:

 - Get rid of `MachineInfos` class. Since `envconfig.py` was created, it
   has no methods that couldn't just got on `PerMachine`

 - Make `default_missing` and `miss_defaulting` work functionally. That
   means we can just locally bind rather than bind as class vars the
   "unfrozen" configuration. This helps prevent bugs where one forgets
   to freeze a configuration.

CC @dcbaker @jpakkane 