### PR TITLE
Force pkgconfig to UTF-8

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -267,7 +267,7 @@ class PkgConfigModule(ExtensionModule):
         # These always return paths relative to prefix
         libdir = PurePath(coredata.get_builtin_option('libdir'))
         incdir = PurePath(coredata.get_builtin_option('includedir'))
-        with open(fname, 'w') as ofile:
+        with open(fname, 'w', encoding='utf-8') as ofile:
             ofile.write('prefix={}\n'.format(self._escape(prefix)))
             ofile.write('libdir={}\n'.format(self._escape('${prefix}' / libdir)))
             ofile.write('includedir={}\n'.format(self._escape('${prefix}' / incdir)))


### PR DESCRIPTION
Hello. I encountered a UnicodeEncodeError exception when I tried to build [```munit```](https://github.com/nemequ/munit/blob/master/meson.build) on my PC today:
```
Traceback (most recent call last):
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\mesonmain.py", line 122, in run
    return options.run_func(options)
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\msetup.py", line 245, in run
    app.generate()
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\msetup.py", line 163, in generate
    self._generate(env)
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\msetup.py", line 193, in _generate
    intr.run()
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\interpreter.py", line 3812, in run
    super().run()
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\interpreterbase.py", line 407, in run
    self.evaluate_codeblock(self.ast, start=1)
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\interpreterbase.py", line 431, in evaluate_codeblock
    raise e
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\interpreterbase.py", line 425, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\interpreterbase.py", line 446, in evaluate_statement
    return self.evaluate_if(cur)
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\interpreterbase.py", line 514, in evaluate_if
    self.evaluate_codeblock(node.elseblock)
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\interpreterbase.py", line 431, in evaluate_codeblock
    raise e
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\interpreterbase.py", line 425, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\interpreterbase.py", line 440, in evaluate_statement
    return self.method_call(cur)
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\interpreterbase.py", line 799, in method_call
    return obj.method_call(method_name, args, kwargs)
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\interpreter.py", line 1661, in method_call
    value = fn(state, args, kwargs)
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\interpreterbase.py", line 285, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\interpreterbase.py", line 285, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\interpreterbase.py", line 174, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\modules\pkgconfig.py", line 438, in generate
    version, pcfile, conflicts, variables)
  File "E:\vcpkg\downloads\tools\meson\meson-0.50.0\mesonbuild\modules\pkgconfig.py", line 282, in generate_pkgconfig_file
    ofile.write('Description: %s\n' % description)
UnicodeEncodeError: 'gbk' codec can't encode character '\xb5' in position 13: illegal multibyte sequence
```
`munit`'s package description contains a special character `µ` which can not be encoded by `GBK` codec(And my local language is Simplified Chinese):
```python
Python 3.6.3 |Anaconda custom (32-bit)| (default, Oct 15 2017, 07:29:16) [MSC v.1900 32 bit (Intel)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> 'µ'.encode('utf-8')
b'\xc2\xb5'
>>> 'µ'.encode('gbk')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeEncodeError: 'gbk' codec can't encode character '\xb5' in position 0: illegal multibyte sequence
```