### PR TITLE
This is the fork "sneyx1234/meson" of the current git "mesonbuild/mes…

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1291,6 +1291,9 @@ class Compiler:
                     paths = paths + ':' + padding
             args.append('-Wl,-rpath,' + paths)
 
+        if mesonlib.is_sunos():
+            return args
+
         if get_compiler_is_linuxlike(self):
             # Rpaths to use while linking must be absolute. These are not
             # written to the binary. Needed only with GNU ld:

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -346,6 +346,9 @@ class PerMachine(typing.Generic[_T]):
         }[machine]
         setattr(self, key, val)
 
+def is_sunos() -> bool:
+    return platform.system().lower() == 'sunos'
+
 def is_osx() -> bool:
     return platform.system().lower() == 'darwin'
 


### PR DESCRIPTION
…on" head to converge it to the solaris 11.4 platform based on the sparcv9 and i386 processor architecture.

The purpose is to complete the porting related to the fork "sneyx1234/ast" of "att/ast" the "AT&T kornshell".

Github history shows now problem oriented.