### PR TITLE
Fix tests: handle unresolved symbols with -fsanitize=*.

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -469,7 +469,7 @@ def sanitizer_compile_args(value):
 def sanitizer_link_args(value):
     if value == 'none':
         return []
-    args = ['-fsanitize=' + value]
+    args = ['-fsanitize=' + value, '-ldl', '-lrt', '-lm', '-lpthread']
     return args
 
 def option_enabled(boptions, options, option):


### PR DESCRIPTION
In combination with --Wl,-as-needed, there are unresolved symbols