### PR TITLE
Fix path splitting in get_compiler_dirs() with GCC/clang on Windows. Fixes #5386

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1587,6 +1587,14 @@ class AllPlatformTests(BasePlatformTests):
                     self.assertEqual(value, expected[args][name])
             self.wipe()
 
+    def test_clike_get_library_dirs(self):
+        env = get_fake_env()
+        cc = env.detect_c_compiler(False)
+        for d in cc.get_library_dirs(env):
+            self.assertTrue(os.path.exists(d))
+            self.assertTrue(os.path.isdir(d))
+            self.assertTrue(os.path.isabs(d))
+
     def test_static_library_overwrite(self):
         '''
         Tests that static libraries are never appended to, always overwritten.


### PR DESCRIPTION
It was using ':' as a path separator while GCC uses ';' resulting in bogus
paths being returned. Instead assume that the compiler uses the platform native
separator.

The previous splitting code still worked sometimes because splitting
"C:/foo;C:/bar" resulted in the last part "/bar" being valid if "\<DriveOfCWD\>:/bar"
existed.

The fix also exposes a clang Windows bug where it uses the wrong separator:
https://reviews.llvm.org/D61121 . Use a regex to fix those first.

This resulted in linker errors when statically linking against a library which
had an external dependency linking against system libs.

Fixes #5386