### PR TITLE
i18n: add an update-mini-po target

### DIFF
--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -160,7 +160,16 @@ class I18nModule(ExtensionModule):
             updatepoargs.append(extra_args)
         updatepotarget = build.RunTarget(packagename + '-update-po', updatepoargs[0], updatepoargs[1:], [], state.subdir, state.subproject)
 
-        targets = [pottarget, gmotarget, updatepotarget]
+        updatempoargs = state.environment.get_build_command() + ['--internal', 'gettext', 'update_mini_po', pkg_arg]
+        if lang_arg:
+            updatempoargs.append(lang_arg)
+        if datadirs:
+            updatempoargs.append(datadirs)
+        if extra_args:
+            updatempoargs.append(extra_args)
+        updatempotarget = build.RunTarget(packagename + '-update-mini-po', updatempoargs[0], updatempoargs[1:], [], state.subdir, state.subproject)
+
+        targets = [pottarget, gmotarget, updatepotarget, updatempotarget]
 
         install = kwargs.get('install', True)
         if install:


### PR DESCRIPTION
update-mini-po calls msgmerge with the '--for-msgfmt' and
'--sort-output' parameters, effectively stripping all untranslated and
fuzzy string from the po file and saving it to lang.mini.po, making it
much more effective for storage in git/etc.

The gmo target is adjusted to prefer use of mini.po files for
generation, and the update-po target checks for existance of mini.po
files for merging, then existing po files, then defaults to msginit.

Signed-off-by: Marty E. Plummer <hanetzer@startmail.com>