### PR TITLE
do not include host environment in test/benchmark introspection data

### DIFF
--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -299,7 +299,7 @@ def get_test_list(testdata):
             fname = t.fname
         to['cmd'] = fname + t.cmd_args
         if isinstance(t.env, build.EnvironmentVariables):
-            to['env'] = t.env.get_env(os.environ)
+            to['env'] = t.env.get_env({})
         else:
             to['env'] = t.env
         to['name'] = t.name


### PR DESCRIPTION
The host environment could change between the time "meson setup" produces intro-tests.json, and the time "meson test" is run. Including it only adds clutter to the introspection data.