### PR TITLE
Reserve build_ prefix in option names.

### DIFF
--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -23,7 +23,7 @@ from . import compilers
 
 forbidden_option_names = set(coredata.builtin_options.keys())
 forbidden_prefixes = [lang + '_' for lang in compilers.all_languages] + ['b_', 'backend_']
-reserved_prefixes = ['cross_']
+reserved_prefixes = ['cross_', 'build_']
 
 def is_invalid_name(name: str, *, log: bool = True) -> bool:
     if name in forbidden_option_names:


### PR DESCRIPTION
Added to 0.50.2 just in case we get one.