### PR TITLE
docs/Users: update Mesa link [skip-ci]

### DIFF
--- a/docs/markdown/Users.md
+++ b/docs/markdown/Users.md
@@ -71,7 +71,7 @@ format files
  - [Libva](https://github.com/intel/libva), an implementation for the VA (VIdeo Acceleration) API
  - [Libzim](https://github.com/openzim/libzim), the reference implementation for the ZIM file format
  - [Marker](https://github.com/fabiocolacio/Marker), a GTK-3 markdown editor
- - [Mesa](https://cgit.freedesktop.org/mesa/mesa/), an open source graphics driver project
+ - [Mesa](https://gitlab.freedesktop.org/mesa/mesa/), an open source graphics driver project
  - [MiracleCast](https://github.com/albfan/miraclecast), connect external monitors to your system via Wifi-Display specification aka Miracast
  - [Nautilus](https://gitlab.gnome.org/GNOME/nautilus), the GNOME file manager
  - [Nemo](https://github.com/linuxmint/nemo), the file manager for the Cinnamon desktop environment


### PR DESCRIPTION
Mesa's primary home is now in the Freedesktop GitLab instance. The cgit repo is just a mirror.