### PR TITLE
dependencies/llvm: Fixup bad output from llvm-config on windows

### DIFF
--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -260,19 +260,25 @@ class LLVMDependencyConfigTool(ConfigToolDependency):
         self.link_args = self.__fix_bogus_link_args(self.link_args)
         self._add_sub_dependency(ThreadDependency, environment, kwargs)
 
-    @staticmethod
-    def __fix_bogus_link_args(args):
+    def __fix_bogus_link_args(self, args):
         """This function attempts to fix bogus link arguments that llvm-config
         generates.
 
         Currently it works around the following:
             - FreeBSD: when statically linking -l/usr/lib/libexecinfo.so will
               be generated, strip the -l in cases like this.
+            - Windows: We may get -LIBPATH:... which is later interpreted as
+              "-L IBPATH:...", if we're using an msvc like compilers convert
+              that to "/LIBPATH", otherwise to "-L ..."
         """
+        cpp = self.env.coredata.compilers['cpp']
+
         new_args = []
         for arg in args:
             if arg.startswith('-l') and arg.endswith('.so'):
                 new_args.append(arg.lstrip('-l'))
+            elif arg.startswith('-LIBPATH:'):
+                new_args.extend(cpp.get_linker_search_args(arg.lstrip('-LIBPATH:')))
             else:
                 new_args.append(arg)
         return new_args


### PR DESCRIPTION
It turns out that llvm-config on windows can return such wonderful
output as `-LIBDIR:c:\\... c:\\abslute\\path\\to\\lib.lib`, which was
all fine and dandy when we were blindly passing it through, GCC/MinGW
ignored it and MSVC understood it meant `/LIBDIR:`; however, after we
added some code to validate linker arguments, and we have some code
before the validation that tries to remove posix style -L arguments,
resulting in IBDIR:..., which doesn't validate.

This patch fixes up the output of llvm-config so that -LIBDIR: is
replaced by the the link libdir argument of the compiler, via the
compiler/linker method for getting that.

Fixes #5419