### PR TITLE
Add optional progress bar when generating build.ninja

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -32,7 +32,7 @@ from .. import compilers
 from ..compilers import Compiler, CompilerArgs, CCompiler, VisualStudioLikeCompiler, FortranCompiler
 from ..linkers import ArLinker
 from ..mesonlib import (
-    File, LibType, MachineChoice, MesonException, OrderedSet, PerMachine
+    File, LibType, MachineChoice, MesonException, OrderedSet, PerMachine, ProgressBar
 )
 from ..mesonlib import get_compiler_for_source, has_path_sep
 from .backends import CleanTrees
@@ -294,7 +294,7 @@ int dummy;
             self.build_elements = []
             self.generate_phony()
             self.add_build_comment(NinjaComment('Build rules for targets'))
-            for t in self.build.get_targets().values():
+            for t in ProgressBar(self.build.get_targets().values(), desc='Generating targets'):
                 self.generate_target(t)
             self.add_build_comment(NinjaComment('Test rules'))
             self.generate_tests()
@@ -903,7 +903,7 @@ int dummy;
             r.write(outfile)
 
     def write_builds(self, outfile):
-        for b in self.build_elements:
+        for b in ProgressBar(self.build_elements, desc='Writing build.ninja'):
             b.write(outfile)
 
     def generate_phony(self):

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -574,9 +574,9 @@ class CompilerArgs(list):
 
     def append_direct(self, arg):
         '''
-        Append the specified argument without any reordering or de-dup
-        except for absolute paths where the order of include search directories
-        is not relevant
+        Append the specified argument without any reordering or de-dup except
+        for absolute paths to libraries, etc, which can always be de-duped
+        safely.
         '''
         if os.path.isabs(arg):
             self.append(arg)

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -18,8 +18,9 @@ import urllib.request, os, hashlib, shutil, tempfile, stat
 import subprocess
 import sys
 import configparser
+
 from . import WrapMode
-from ..mesonlib import MesonException
+from ..mesonlib import ProgressBar, MesonException
 
 try:
     import ssl
@@ -278,24 +279,17 @@ class Resolver:
                     tmpfile.write(block)
                 hashvalue = h.hexdigest()
                 return hashvalue, tmpfile.name
-            print('Download size:', dlsize)
-            print('Downloading: ', end='')
             sys.stdout.flush()
-            printed_dots = 0
-            downloaded = 0
+            progress_bar = ProgressBar(bar_type='download', total=dlsize,
+                                       desc='Downloading')
             while True:
                 block = resp.read(blocksize)
                 if block == b'':
                     break
-                downloaded += len(block)
                 h.update(block)
                 tmpfile.write(block)
-                ratio = int(downloaded / dlsize * 10)
-                while printed_dots < ratio:
-                    print('.', end='')
-                    sys.stdout.flush()
-                    printed_dots += 1
-            print('')
+                progress_bar.update(len(block))
+            progress_bar.close()
             hashvalue = h.hexdigest()
         return hashvalue, tmpfile.name
 

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ if sys.platform != 'win32':
 if __name__ == '__main__':
     setup(name='meson',
           version=version,
+          extras_require={'progress': ['tqdm']},
           packages=packages,
           package_data=package_data,
           entry_points=entries,


### PR DESCRIPTION
This is just something fun and small I wrote because people were complaining that meson took too long with GStreamer's thousands of targets on Windows.

commit e075ddca4af18ec90ddf5d6696679dd207abe49e:

```
ninja backend: Add optional progress bar in generate()

With, f.ex., gst-build, this step can take 8-20 seconds depending on
your CPU and disk speed. I was looking at speeding that up, but the
ways I could see would've involved heavy refactoring of the backend
generation, and would not have solved the core problem of no feedback.

Now we have pretty (optional) progress bars!
```

commit b1600771d90cf267503402d0fd57faad921a0532:

```
compilers: Clarify a docstring in CompilerArgs
```
