### PR TITLE
Update to new ccache URL and preferred capitalization

### DIFF
--- a/docs/markdown/Feature-autodetection.md
+++ b/docs/markdown/Feature-autodetection.md
@@ -7,18 +7,18 @@ short-description: Auto-detection of features like ccache and code coverage
 Meson is designed for high productivity. It tries to do as many things
 automatically as it possibly can.
 
-CCache
+Ccache
 --
 
-[CCache](https://ccache.samba.org/) is a cache system designed to make
+[Ccache](https://ccache.dev/) is a cache system designed to make
 compiling faster. When you run Meson for the first time for a given
-project, it checks if CCache is installed. If it is, Meson will use it
+project, it checks if Ccache is installed. If it is, Meson will use it
 automatically.
 
-If you do not wish to use CCache for some reason, just specify your
+If you do not wish to use Ccache for some reason, just specify your
 compiler with environment variables `CC` and/or `CXX` when first
 running Meson (remember that once specified the compiler can not be
-changed). Meson will then use the specified compiler without CCache.
+changed). Meson will then use the specified compiler without Ccache.
 
 Coverage
 --

--- a/man/meson.1
+++ b/man/meson.1
@@ -6,7 +6,7 @@ meson - a high productivity build system
 Meson is a build system designed to optimize programmer
 productivity. It aims to do this by providing simple, out-of-the-box
 support for modern software development tools and practices, such as
-unit tests, coverage reports, Valgrind, CCache and the like.
+unit tests, coverage reports, Valgrind, Ccache and the like.
 
 The main Meson executable provides many subcommands to access all
 the functionality.

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -301,7 +301,7 @@ def parse_test_args(testdir):
         pass
     return args
 
-# Build directory name must be the same so CCache works over
+# Build directory name must be the same so Ccache works over
 # consecutive invocations.
 def create_deterministic_builddir(src_dir):
     import hashlib


### PR DESCRIPTION
ccache’s web site is now located at https://ccache.dev.

Bonus: Use the preferred capitalization “Ccache” instead of “CCache”.