### PR TITLE
Cmake lexer spaces in args

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1666,7 +1666,7 @@ class CMakeDependency(ExternalDependency):
             else:
                 self.targets[i].properies[propName] = propVal
 
-    def _cmake_set_target_properties(self, tline: CMakeTraceLine):
+    def _cmake_set_target_properties(self, tline: CMakeTraceLine) -> None:
         # DOC: https://cmake.org/cmake/help/latest/command/set_target_properties.html
         args = list(tline.args)
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3681,6 +3681,11 @@ recommended as it is not supported on some platforms''')
         testdir = os.path.join(self.unit_test_dir, '60 cmake_prefix_path')
         self.init(testdir, extra_args=['-Dcmake_prefix_path=' + os.path.join(testdir, 'prefix')])
 
+    @skip_if_no_cmake
+    def test_cmake_parser(self):
+        testdir = os.path.join(self.unit_test_dir, '61 cmake parser')
+        self.init(testdir, extra_args=['-Dcmake_prefix_path=' + os.path.join(testdir, 'prefix')])
+
 class FailureTests(BasePlatformTests):
     '''
     Tests that test failure conditions. Build files here should be dynamically

--- a/test cases/unit/61 cmake parser/meson.build
+++ b/test cases/unit/61 cmake parser/meson.build
@@ -1,0 +1,19 @@
+project('61 cmake parser')
+
+dep = dependency('mesontest')
+
+# Test a bunch of variations of the set() command
+assert(dep.get_variable(cmake : 'VAR_WITHOUT_SPACES') == 'NoSpaces', 'set() without spaces incorrect')
+#assert(dep.get_variable(cmake : 'VAR_WITH_SPACES') == 'With Spaces', 'set() with spaces incorrect')
+
+assert(dep.get_variable(cmake : 'VAR_WITHOUT_SPACES_PS') == 'NoSpaces', 'set(PARENT_SCOPE) without spaces incorrect')
+#assert(dep.get_variable(cmake : 'VAR_WITH_SPACES_PS') == 'With Spaces', 'set(PARENT_SCOPE) with spaces incorrect')
+
+assert(dep.get_variable(cmake : 'VAR_THAT_IS_UNSET', default_value : 'sentinal') == 'sentinal', 'set() to unset is incorrect')
+assert(dep.get_variable(cmake : 'CACHED_STRING_NS') == 'foo', 'set(CACHED) without spaces is incorrect')
+#assert(dep.get_variable(cmake : 'CACHED_STRING_WS') == 'foo bar', 'set(CACHED STRING) with spaces is incorrect')
+assert(dep.get_variable(cmake : 'CACHED_STRING_ARRAY_NS') == ['foo', 'bar'], 'set(CACHED STRING) without spaces is incorrect')
+#assert(dep.get_variable(cmake : 'CACHED_STRING_ARRAY_WS') == ['foo', 'foo bar', 'bar'], 'set(CACHED STRING[]) with spaces is incorrect')
+
+# We don't suppor this, so it should be unset.
+assert(dep.get_variable(cmake : 'ENV{var}', default_value : 'sentinal') == 'sentinal', 'set(ENV) should be ignored')

--- a/test cases/unit/61 cmake parser/meson.build
+++ b/test cases/unit/61 cmake parser/meson.build
@@ -4,16 +4,16 @@ dep = dependency('mesontest')
 
 # Test a bunch of variations of the set() command
 assert(dep.get_variable(cmake : 'VAR_WITHOUT_SPACES') == 'NoSpaces', 'set() without spaces incorrect')
-#assert(dep.get_variable(cmake : 'VAR_WITH_SPACES') == 'With Spaces', 'set() with spaces incorrect')
+assert(dep.get_variable(cmake : 'VAR_WITH_SPACES') == 'With Spaces', 'set() with spaces incorrect')
 
 assert(dep.get_variable(cmake : 'VAR_WITHOUT_SPACES_PS') == 'NoSpaces', 'set(PARENT_SCOPE) without spaces incorrect')
-#assert(dep.get_variable(cmake : 'VAR_WITH_SPACES_PS') == 'With Spaces', 'set(PARENT_SCOPE) with spaces incorrect')
+assert(dep.get_variable(cmake : 'VAR_WITH_SPACES_PS') == 'With Spaces', 'set(PARENT_SCOPE) with spaces incorrect')
 
 assert(dep.get_variable(cmake : 'VAR_THAT_IS_UNSET', default_value : 'sentinal') == 'sentinal', 'set() to unset is incorrect')
 assert(dep.get_variable(cmake : 'CACHED_STRING_NS') == 'foo', 'set(CACHED) without spaces is incorrect')
-#assert(dep.get_variable(cmake : 'CACHED_STRING_WS') == 'foo bar', 'set(CACHED STRING) with spaces is incorrect')
+assert(dep.get_variable(cmake : 'CACHED_STRING_WS') == 'foo bar', 'set(CACHED STRING) with spaces is incorrect')
 assert(dep.get_variable(cmake : 'CACHED_STRING_ARRAY_NS') == ['foo', 'bar'], 'set(CACHED STRING) without spaces is incorrect')
-#assert(dep.get_variable(cmake : 'CACHED_STRING_ARRAY_WS') == ['foo', 'foo bar', 'bar'], 'set(CACHED STRING[]) with spaces is incorrect')
+assert(dep.get_variable(cmake : 'CACHED_STRING_ARRAY_WS') == ['foo', 'foo bar', 'bar'], 'set(CACHED STRING[]) with spaces is incorrect')
 
 # We don't suppor this, so it should be unset.
 assert(dep.get_variable(cmake : 'ENV{var}', default_value : 'sentinal') == 'sentinal', 'set(ENV) should be ignored')

--- a/test cases/unit/61 cmake parser/prefix/lib/cmake/mesontest/mesontest-config.cmake
+++ b/test cases/unit/61 cmake parser/prefix/lib/cmake/mesontest/mesontest-config.cmake
@@ -1,0 +1,63 @@
+# This should be enough to satisfy the basic parser
+set(MESONTEST_VERSION "1.2.3")
+set(MESONTEST_LIBRARIES "foo.so")
+set(MESONTEST_INCLUDE_DIR "")
+set(MESONTEST_FOUND "TRUE")
+
+## Tests for set() in its various forms
+
+# Basic usage
+set(VAR_WITHOUT_SPACES "NoSpaces")
+set(VAR_WITH_SPACES "With Spaces")
+
+# test of PARENT_SCOPE, requires a function to have a parent scope obviously...
+function(foo)
+    set(VAR_WITHOUT_SPACES_PS "NoSpaces" PARENT_SCOPE)
+    set(VAR_WITH_SPACES_PS "With Spaces" PARENT_SCOPE)
+endfunction(foo)
+foo()
+
+# Using set() to unset values
+set(VAR_THAT_IS_UNSET "foo")
+set(VAR_THAT_IS_UNSET)
+
+# The more advanced form that uses CACHE
+# XXX: Why don't we read the type and use that instead of always treat things as strings?
+set(CACHED_STRING_NS "foo" CACHE STRING "docstring")
+set(CACHED_STRING_WS "foo bar" CACHE STRING "docstring")
+set(CACHED_STRING_ARRAY_NS "foo;bar" CACHE STRING "doc string")
+set(CACHED_STRING_ARRAY_WS "foo;foo bar;bar" CACHE STRING "stuff" FORCE)
+
+set(CACHED_BOOL ON CACHE BOOL "docstring")
+
+set(CACHED_PATH_NS "foo/bar" CACHE PATH "docstring")
+set(CACHED_PATH_WS "foo bar/fin" CACHE PATH "docstring")
+
+set(CACHED_FILEPATH_NS "foo/bar.txt" CACHE FILEPATH "docstring")
+set(CACHED_FILEPATH_WS "foo bar/fin.txt" CACHE FILEPATH "docstring")
+
+# Set ENV, we don't support this so it shouldn't be showing up
+set(ENV{var}, "foo")
+
+
+## Tests for set_properties()
+# We need something to attach properties too
+add_custom_target(MESONTEST_FOO ALL)
+
+set_property(TARGET MESONTEST_FOO PROPERTY FOLDER "value")
+set_property(TARGET MESONTEST_FOO APPEND PROPERTY FOLDER "name")
+set_property(TARGET MESONTEST_FOO PROPERTY FOLDER "value")
+set_property(TARGET MESONTEST_FOO APPEND_STRING PROPERTY FOLDER "name")
+
+set_property(TARGET MESONTEST_FOO PROPERTY FOLDER "value space")
+set_property(TARGET MESONTEST_FOO PROPERTY FOLDER "value space")
+set_property(TARGET MESONTEST_FOO APPEND PROPERTY FOLDER "name space")
+set_property(TARGET MESONTEST_FOO PROPERTY FOLDER "value space")
+set_property(TARGET MESONTEST_FOO APPEND_STRING PROPERTY FOLDER "name space")
+
+## Tests for set_target_properties()
+set_target_properties(MESONTEST_FOO PROPERTIES FOLDER "value")
+set_target_properties(MESONTEST_FOO PROPERTIES FOLDER "value space")
+set_target_properties(MESONTEST_FOO PROPERTIES FOLDER "value" OUTPUT_NAME "another value")
+set_target_properties(MESONTEST_FOO PROPERTIES FOLDER "value space" OUTPUT_NAME "another value")
+set_target_properties(MESONTEST_FOO PROPERTIES FOLDER "value space" OUTPUT_NAME "value")


### PR DESCRIPTION
There is a rather nasty/annoying bug in the cmake parser (described in the bug linked) that breaks using cmake on windows in basically every case. I've added a big mean test case and fixed at least enough to make this work for me (mesa + llvm on windows), however, there may be more cases that need fixing.

Fixes #5435