### PR TITLE
doc: fix typo [skip ci]

### DIFF
--- a/docs/markdown/Wrap-best-practices-and-tips.md
+++ b/docs/markdown/Wrap-best-practices-and-tips.md
@@ -48,7 +48,7 @@ optimization. However building both library types on all builds is
 slow and wasteful.
 
 Your project should use the `library` method that can be toggled
-between shared and static with the `defaul_library` builtin option.
+between shared and static with the `default_library` builtin option.
 
 
 ```meson


### PR DESCRIPTION
Error introduced in commit 8e403e08ac2907214c044c804ee5eef6a45e0ff9