### PR TITLE
performance optimize meson

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -873,14 +873,22 @@ class Backend:
                 result[dep.get_id()] = dep
         return result
 
+    @lru_cache(maxsize=None)
+    def get_custom_target_provided_by_generated_source(self, generated_source):
+        libs = []
+        for f in generated_source.get_outputs():
+            if self.environment.is_library(f):
+                libs.append(os.path.join(self.get_target_dir(generated_source), f))
+        return libs
+
+    @lru_cache(maxsize=None)
     def get_custom_target_provided_libraries(self, target):
         libs = []
         for t in target.get_generated_sources():
             if not isinstance(t, build.CustomTarget):
                 continue
-            for f in t.get_outputs():
-                if self.environment.is_library(f):
-                    libs.append(os.path.join(self.get_target_dir(t), f))
+            l = self.get_custom_target_provided_by_generated_source(t)
+            libs = libs + l
         return libs
 
     def is_unity(self, target):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -38,6 +38,7 @@ from .compilers import (
     is_object,
     is_source,
 )
+from functools import lru_cache
 from .compilers import (
     ArmCCompiler,
     ArmCPPCompiler,
@@ -572,6 +573,7 @@ class Environment:
     def is_object(self, fname):
         return is_object(fname)
 
+    @lru_cache(maxsize=None)
     def is_library(self, fname):
         return is_library(fname)
 


### PR DESCRIPTION
Before this commit meson took on my laptop ~30-40 sec. now we are down to ~20-25 sec..
Those numbers are from building EFL with meson. We are working a lot with generated sources, which are added as source to dependencies, hence we have a big number of include directories, and custom targets.