### PR TITLE
rewriter: Fix that default_options would not set the correct id

### DIFF
--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -447,7 +447,7 @@ class Rewriter:
         # First, remove the old values
         kwargs_cmd = {
             'function': 'project',
-            'id': "",
+            'id': "/",
             'operation': 'remove_regex',
             'kwargs': {
                 'default_options': ['{}=.*'.format(x) for x in cmd['options'].keys()]
@@ -502,7 +502,7 @@ class Rewriter:
         if cmd['function'] == 'project':
             if cmd['id'] != '/':
                 mlog.error('The ID for the function type project must be "/"', *self.on_error())
-                self.handle_error()
+                return self.handle_error()
             node = self.interpreter.project_node
             arg_node = node.args
         elif cmd['function'] == 'target':

--- a/test cases/rewrite/3 kwargs/delete.json
+++ b/test cases/rewrite/3 kwargs/delete.json
@@ -2,7 +2,7 @@
   {
     "type": "kwargs",
     "function": "project",
-    "id": "",
+    "id": "/",
     "operation": "delete",
     "kwargs": {
       "version": null


### PR DESCRIPTION
Currently, default_options uses "" for the kwargs id, however, this is incorrect and it must be "/". Additionally, this error won't be ignored in the future with "--skip" (this is why the tests were passing, and this wasn't detected earlier).