### PR TITLE
Vs backend compiler selection

### DIFF
--- a/docs/markdown/Using-with-Visual-Studio.md
+++ b/docs/markdown/Using-with-Visual-Studio.md
@@ -4,20 +4,33 @@ short-description: How to use meson in Visual Studio
 
 # Using with Visual Studio
 
-In order to generate Visual Studio projects, Meson needs to know the settings of your installed version of Visual Studio. The only way to get this information is to run Meson under the Visual Studio Command Prompt. The steps to set it up are as follows:
+In order to generate Visual Studio projects, Meson needs to know the settings
+of your installed version of Visual Studio. The only way to get this
+information is to run Meson under the Visual Studio Command Prompt. The steps
+to set it up are as follows:
 
 1. Click on start menu and select "Visual Studio 2015 Command Prompt"
 1. cd into your source directory
 1. mkdir builddir
 1. python3 path/to/meson.py builddir --backend vs2015
 
-If you wish to use the Ninja backend instead of vs2015, pass `--backend ninja`. At the time of writing the Ninja backend is more mature than the VS backend so you might want to use it for serious work.
+If you wish to use the Ninja backend instead of vs2015, pass `--backend
+ninja`. At the time of writing the Ninja backend is more mature than the VS
+backend so you might want to use it for serious work.
 
 This assumes Python3 is in your `PATH`, which is highly recommended.
 
 # Using Clang-CL with Visual Studio
 
-You will first need to get a copy of llvm+clang for Windows, such versions are available from a number of sources, including the llvm website. Then you will need the [llvm toolset extension for visual studio](https://marketplace.visualstudio.com/items?itemName=LLVMExtensions.llvm-toolchain). You then need to either use a [native file](Native-environments.md#binaries) or `set CC=clang-cl`, and `set CXX=clang-cl` to use those compilers, meson will do the rest.
+*(new in 0.52.0)*
+
+You will first need to get a copy of llvm+clang for Windows, such versions
+are available from a number of sources, including the llvm website. Then you
+will need the [llvm toolset extension for visual
+studio](https://marketplace.visualstudio.com/items?itemName=LLVMExtensions.llvm-toolchain).
+You then need to either use a [native file](Native-environments.md#binaries)
+or `set CC=clang-cl`, and `set CXX=clang-cl` to use those compilers, meson
+will do the rest.
 
 This only works with visual studio 2017 and 2019.
 
@@ -25,4 +38,7 @@ There is currently no support in meson for clang/c2.
 
 # Using Intel-CL (ICL) with Visual Studio
 
-To use ICL you need only have ICL installed and launch an ICL development shell like you would for the ninja backend and meson will take care of it.
+*(new in 0.52.0)*
+
+To use ICL you need only have ICL installed and launch an ICL development
+shell like you would for the ninja backend and meson will take care of it.

--- a/docs/markdown/Using-with-Visual-Studio.md
+++ b/docs/markdown/Using-with-Visual-Studio.md
@@ -12,13 +12,13 @@ to set it up are as follows:
 1. Click on start menu and select "Visual Studio 2015 Command Prompt"
 1. cd into your source directory
 1. mkdir builddir
-1. python3 path/to/meson.py builddir --backend vs2015
+1. py -3 path/to/meson.py builddir --backend vs2015
 
 If you wish to use the Ninja backend instead of vs2015, pass `--backend
 ninja`. At the time of writing the Ninja backend is more mature than the VS
 backend so you might want to use it for serious work.
 
-This assumes Python3 is in your `PATH`, which is highly recommended.
+This assumes the py launcher is in your `PATH`, which is highly recommended.
 
 # Using Clang-CL with Visual Studio
 

--- a/docs/markdown/Using-with-Visual-Studio.md
+++ b/docs/markdown/Using-with-Visual-Studio.md
@@ -14,3 +14,15 @@ In order to generate Visual Studio projects, Meson needs to know the settings of
 If you wish to use the Ninja backend instead of vs2015, pass `--backend ninja`. At the time of writing the Ninja backend is more mature than the VS backend so you might want to use it for serious work.
 
 This assumes Python3 is in your `PATH`, which is highly recommended.
+
+# Using Clang-CL with Visual Studio
+
+You will first need to get a copy of llvm+clang for Windows, such versions are available from a number of sources, including the llvm website. Then you will need the [llvm toolset extension for visual studio](https://marketplace.visualstudio.com/items?itemName=LLVMExtensions.llvm-toolchain). You then need to either use a [native file](Native-environments.md#binaries) or `set CC=clang-cl`, and `set CXX=clang-cl` to use those compilers, meson will do the rest.
+
+This only works with visual studio 2017 and 2019.
+
+There is currently no support in meson for clang/c2.
+
+# Using Intel-CL (ICL) with Visual Studio
+
+To use ICL you need only have ICL installed and launch an ICL development shell like you would for the ninja backend and meson will take care of it.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -157,6 +157,7 @@ class Backend:
         # Make it possible to construct a dummy backend
         # This is used for introspection without a build directory
         if build is None:
+            self.environment = None
             return
         self.build = build
         self.environment = build.environment

--- a/mesonbuild/backend/vs2015backend.py
+++ b/mesonbuild/backend/vs2015backend.py
@@ -19,5 +19,6 @@ class Vs2015Backend(Vs2010Backend):
     def __init__(self, build):
         super().__init__(build)
         self.name = 'vs2015'
-        self.platform_toolset = 'v140'
         self.vs_version = '2015'
+        if self.platform_toolset is None:
+            self.platform_toolset = 'v140'

--- a/mesonbuild/backend/vs2015backend.py
+++ b/mesonbuild/backend/vs2015backend.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .vs2010backend import Vs2010Backend
+from ..mesonlib import MesonException
 
 
 class Vs2015Backend(Vs2010Backend):
@@ -20,5 +21,15 @@ class Vs2015Backend(Vs2010Backend):
         super().__init__(build)
         self.name = 'vs2015'
         self.vs_version = '2015'
-        if self.platform_toolset is None:
-            self.platform_toolset = 'v140'
+        if self.environment is not None:
+            # TODO: we assume host == build
+            comps = self.environment.coredata.compilers.host
+            if comps and all(c.id == 'intel-cl' for c in comps.values()):
+                c = list(comps.values())[0]
+                if c.version.startswith('19'):
+                    self.platform_toolset = 'Intel C++ Compiler 19.0'
+                else:
+                    # We don't have support for versions older than 2019 right now.
+                    raise MesonException('There is currently no support for ICL before 19, patches welcome.')
+            if self.platform_toolset is None:
+                self.platform_toolset = 'v140'

--- a/mesonbuild/backend/vs2017backend.py
+++ b/mesonbuild/backend/vs2017backend.py
@@ -22,8 +22,9 @@ class Vs2017Backend(Vs2010Backend):
     def __init__(self, build):
         super().__init__(build)
         self.name = 'vs2017'
-        self.platform_toolset = 'v141'
         self.vs_version = '2017'
+        if self.platform_toolset is None:
+            self.platform_toolset = 'v141'
         # WindowsSDKVersion should be set by command prompt.
         sdk_version = os.environ.get('WindowsSDKVersion', None)
         if sdk_version:

--- a/mesonbuild/backend/vs2017backend.py
+++ b/mesonbuild/backend/vs2017backend.py
@@ -30,6 +30,13 @@ class Vs2017Backend(Vs2010Backend):
             if comps:
                 if comps and all(c.id == 'clang-cl' for c in comps.values()):
                     self.platform_toolset = 'llvm'
+                elif comps and all(c.id == 'intel-cl' for c in comps.values()):
+                    c = list(comps.values())[0]
+                    if c.version.startswith('19'):
+                        self.platform_toolset = 'Intel C++ Compiler 19.0'
+                    else:
+                        # We don't have support for versions older than 2019 right now.
+                        raise MesonException('There is currently no support for ICL before 19, patches welcome.')
         if self.platform_toolset is None:
             self.platform_toolset = 'v141'
         # WindowsSDKVersion should be set by command prompt.

--- a/mesonbuild/backend/vs2017backend.py
+++ b/mesonbuild/backend/vs2017backend.py
@@ -16,6 +16,7 @@ import os
 import xml.etree.ElementTree as ET
 
 from .vs2010backend import Vs2010Backend
+from ..mesonlib import MesonException
 
 
 class Vs2017Backend(Vs2010Backend):
@@ -23,6 +24,12 @@ class Vs2017Backend(Vs2010Backend):
         super().__init__(build)
         self.name = 'vs2017'
         self.vs_version = '2017'
+        # We assume that host == build
+        if self.environment is not None:
+            comps = self.environment.coredata.compilers.host
+            if comps:
+                if comps and all(c.id == 'clang-cl' for c in comps.values()):
+                    self.platform_toolset = 'llvm'
         if self.platform_toolset is None:
             self.platform_toolset = 'v141'
         # WindowsSDKVersion should be set by command prompt.

--- a/mesonbuild/backend/vs2019backend.py
+++ b/mesonbuild/backend/vs2019backend.py
@@ -22,8 +22,13 @@ class Vs2019Backend(Vs2010Backend):
     def __init__(self, build):
         super().__init__(build)
         self.name = 'vs2019'
-        self.platform_toolset = 'v142'
-        self.vs_version = '2019'
+        if self.environment is not None:
+            comps = self.environment.coredata.compilers.host
+            if comps and all(c.id == 'clang-cl' for c in comps.values()):
+                self.platform_toolset = 'llvm'
+            if not self.platform_toolset:
+                self.platform_toolset = 'v142'
+            self.vs_version = '2019'
         # WindowsSDKVersion should be set by command prompt.
         sdk_version = os.environ.get('WindowsSDKVersion', None)
         if sdk_version:

--- a/mesonbuild/backend/vs2019backend.py
+++ b/mesonbuild/backend/vs2019backend.py
@@ -26,6 +26,11 @@ class Vs2019Backend(Vs2010Backend):
             comps = self.environment.coredata.compilers.host
             if comps and all(c.id == 'clang-cl' for c in comps.values()):
                 self.platform_toolset = 'llvm'
+            elif comps and all(c.id == 'intel-cl' for c in comps.values()):
+                c = list(comps.values())[0]
+                if c.version.startswith('19'):
+                    self.platform_toolset = 'Intel C++ Compiler 19.0'
+                # We don't have support for versions older than 2019 right now.
             if not self.platform_toolset:
                 self.platform_toolset = 'v142'
             self.vs_version = '2019'

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2710,7 +2710,6 @@ external dependencies (including libraries) must go to "dependencies".''')
         else:
             default_options = {}
         self.coredata.set_default_options(default_options, self.subproject, self.environment)
-        self.set_backend()
 
         if not self.is_subproject():
             self.build.project_name = proj_name
@@ -2745,6 +2744,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         mlog.log('Project name:', mlog.bold(proj_name))
         mlog.log('Project version:', mlog.bold(self.project_version))
         self.add_languages(proj_langs, True)
+        self.set_backend()
         if not self.is_subproject():
             self.check_stdlibs()
 


### PR DESCRIPTION
This little series fixes ICL (which was broken by a refactor), and adds support for using clang-cl and icl for the visual studio backend.

@jon-turney, don't know if you're interested or not.