### PR TITLE
gnome.yelp(): Fix media symlink fallback path

### DIFF
--- a/mesonbuild/scripts/yelphelper.py
+++ b/mesonbuild/scripts/yelphelper.py
@@ -73,8 +73,9 @@ def install_help(srcdir, blddir, sources, media, langs, install_dir, destdir, pr
         for m in media:
             infile = os.path.join(srcdir, lang, m)
             outfile = os.path.join(indir, m)
+            c_infile = os.path.join(srcdir, 'C', m)
             if not os.path.exists(infile):
-                if lang == 'C':
+                if not os.path.exists(c_infile):
                     mlog.warning('Media file "%s" did not exist in C directory' % m)
                     continue
                 elif symlinks:
@@ -91,9 +92,10 @@ def install_help(srcdir, blddir, sources, media, langs, install_dir, destdir, pr
                         continue
                     except (NotImplementedError, OSError):
                         mlog.warning('Symlinking not supported, falling back to copying')
+                        infile = c_infile
                 else:
                     # Lang doesn't have media file so copy it over 'C' one
-                    infile = os.path.join(srcdir, 'C', m)
+                    infile = c_infile
             mlog.log('Installing %s to %s' % (infile, outfile))
             if has_path_sep(m):
                 os.makedirs(os.path.dirname(outfile), exist_ok=True)


### PR DESCRIPTION
When the media file for a specific language doesn't exist we try to symlink
it to the C one. If symlinking fails we need to fall back to copying the C
one like in the non-symlink case.

The fallback code path didn't set the source so this always failed.

Also check if the C fallback exists before trying to symlink/copy, otherwise
we crash if C isn't the first lang we try.