### PR TITLE
Moved RuntimeLibrary property to ItemDefinitionGroup/ClCompile

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -809,28 +809,32 @@ class Vs2010Backend(backends.Backend):
         # Incremental linking increases code size
         if '/INCREMENTAL:NO' in buildtype_link_args:
             ET.SubElement(type_config, 'LinkIncremental').text = 'false'
+
+        # Build information
+        compiles = ET.SubElement(root, 'ItemDefinitionGroup')
+        clconf = ET.SubElement(compiles, 'ClCompile')
         # CRT type; debug or release
         if vscrt_type.value == 'from_buildtype':
             if self.buildtype == 'debug' or self.buildtype == 'debugoptimized':
                 ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
-                ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreadedDebugDLL'
+                ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDebugDLL'
             else:
                 ET.SubElement(type_config, 'UseDebugLibraries').text = 'false'
-                ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreaded'
+                ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreaded'
         elif vscrt_type.value == 'mdd':
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
-            ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreadedDebugDLL'
+            ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDebugDLL'
         elif vscrt_type.value == 'mt':
             # FIXME, wrong
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'false'
-            ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreaded'
+            ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreaded'
         elif vscrt_type.value == 'mtd':
             # FIXME, wrong
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
-            ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreadedDebug'
+            ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDebug'
         else:
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'false'
-            ET.SubElement(type_config, 'RuntimeLibrary').text = 'MultiThreadedDLL'
+            ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDLL'
         # Debug format
         if '/ZI' in buildtype_args:
             ET.SubElement(type_config, 'DebugInformationFormat').text = 'EditAndContinue'
@@ -865,9 +869,6 @@ class Vs2010Backend(backends.Backend):
         ET.SubElement(direlem, 'TargetName').text = tfilename[0]
         ET.SubElement(direlem, 'TargetExt').text = tfilename[1]
 
-        # Build information
-        compiles = ET.SubElement(root, 'ItemDefinitionGroup')
-        clconf = ET.SubElement(compiles, 'ClCompile')
         # Arguments, include dirs, defines for all files in the current target
         target_args = []
         target_defines = []


### PR DESCRIPTION
The RuntimeLibrary (MT, MTd, MD, MDd) property was not set correctly in the project generated by the vs2010 backend. According to the [example file](https://docs.microsoft.com/en-us/cpp/build/reference/project-files?view=vs-2019) provided by Microsoft it should be in ItemDefinitionGroup/ClCompile and the examples are consistent from vs2015 to vs2019, I don't know about vs2010.