### PR TITLE
CMake code refactor

### DIFF
--- a/mesonbuild/cmake/__init__.py
+++ b/mesonbuild/cmake/__init__.py
@@ -17,10 +17,12 @@
 
 __all__ = [
     'CMakeClient',
+    'CMakeExecutor',
     'CMakeException',
     'CMakeInterpreter',
 ]
 
 from .common import CMakeException
 from .client import CMakeClient
+from .executor import CMakeExecutor
 from .interpreter import CMakeInterpreter

--- a/mesonbuild/cmake/__init__.py
+++ b/mesonbuild/cmake/__init__.py
@@ -20,9 +20,13 @@ __all__ = [
     'CMakeExecutor',
     'CMakeException',
     'CMakeInterpreter',
+    'CMakeTarget',
+    'CMakeTraceLine',
+    'CMakeTraceParser',
 ]
 
 from .common import CMakeException
 from .client import CMakeClient
 from .executor import CMakeExecutor
 from .interpreter import CMakeInterpreter
+from .traceparser import CMakeTarget, CMakeTraceLine, CMakeTraceParser

--- a/mesonbuild/cmake/client.py
+++ b/mesonbuild/cmake/client.py
@@ -16,8 +16,8 @@
 # or an interpreter-based tool.
 
 from .common import CMakeException
+from .executor import CMakeExecutor
 from ..environment import Environment
-from ..dependencies.base import CMakeDependency, ExternalProgram
 from ..mesonlib import MachineChoice
 from .. import mlog
 from contextlib import contextmanager
@@ -475,14 +475,11 @@ class CMakeClient:
         if self.proc is not None:
             raise CMakeException('The CMake server was already started')
         for_machine = MachineChoice.HOST # TODO make parameter
-        cmake_exe, cmake_vers, _ = CMakeDependency.find_cmake_binary(self.env, for_machine)
-        if cmake_exe is None or cmake_exe is False:
-            raise CMakeException('Unable to find CMake')
-        assert(isinstance(cmake_exe, ExternalProgram))
+        cmake_exe = CMakeExecutor(self.env, '>=3.7', for_machine)
         if not cmake_exe.found():
             raise CMakeException('Unable to find CMake')
 
-        mlog.debug('Starting CMake server with CMake', mlog.bold(' '.join(cmake_exe.get_command())), 'version', mlog.cyan(cmake_vers))
+        mlog.debug('Starting CMake server with CMake', mlog.bold(' '.join(cmake_exe.get_command())), 'version', mlog.cyan(cmake_exe.version()))
         self.proc = Popen(cmake_exe.get_command() + ['-E', 'server', '--experimental', '--debug'], stdin=PIPE, stdout=PIPE)
 
     def shutdown(self) -> None:

--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -1,0 +1,215 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This class contains the basic functionality needed to run any interpreter
+# or an interpreter-based tool.
+
+from .. import mlog, mesonlib
+from ..mesonlib import PerMachine, Popen_safe, version_compare, MachineChoice
+from ..environment import Environment
+
+from typing import List, Tuple, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..dependencies.base import ExternalProgram
+
+import re, os, ctypes
+
+class CMakeExecutor:
+    # The class's copy of the CMake path. Avoids having to search for it
+    # multiple times in the same Meson invocation.
+    class_cmakebin = PerMachine(None, None)
+    class_cmakevers = PerMachine(None, None)
+    class_cmake_cache = {}
+
+    def __init__(self, environment: Environment, version: str, for_machine: MachineChoice, silent: bool = False):
+        self.min_version = version
+        self.environment = environment
+        self.for_machine = for_machine
+        self.cmakebin, self.cmakevers = self.find_cmake_binary(self.environment, silent=silent)
+        if self.cmakebin is False:
+            self.cmakebin = None
+            return
+
+        if not version_compare(self.cmakevers, self.min_version):
+            self.cmakebin = None
+            mlog.warning(
+                'The version of CMake', mlog.bold(self.cmakebin.get_path()),
+                'is', mlog.bold(self.cmakevers), 'but version', mlog.bold(self.min_version),
+                'is required')
+            return
+
+    def find_cmake_binary(self, environment: Environment, silent: bool = False) -> Tuple['ExternalProgram', str]:
+        from ..dependencies.base import ExternalProgram
+
+        # Create an iterator of options
+        def search():
+            # Lookup in cross or machine file.
+            potential_cmakepath = environment.binaries[self.for_machine].lookup_entry('cmake')
+            if potential_cmakepath is not None:
+                mlog.debug('CMake binary for %s specified from cross file, native file, or env var as %s.', self.for_machine, potential_cmakepath)
+                yield ExternalProgram.from_entry('cmake', potential_cmakepath)
+                # We never fallback if the user-specified option is no good, so
+                # stop returning options.
+                return
+            mlog.debug('CMake binary missing from cross or native file, or env var undefined.')
+            # Fallback on hard-coded defaults.
+            # TODO prefix this for the cross case instead of ignoring thing.
+            if environment.machines.matches_build_machine(self.for_machine):
+                for potential_cmakepath in environment.default_cmake:
+                    mlog.debug('Trying a default CMake fallback at', potential_cmakepath)
+                    yield ExternalProgram(potential_cmakepath, silent=True)
+
+        # Only search for CMake the first time and store the result in the class
+        # definition
+        if CMakeExecutor.class_cmakebin[self.for_machine] is False:
+            mlog.debug('CMake binary for %s is cached as not found' % self.for_machine)
+        elif CMakeExecutor.class_cmakebin[self.for_machine] is not None:
+            mlog.debug('CMake binary for %s is cached.' % self.for_machine)
+        else:
+            assert CMakeExecutor.class_cmakebin[self.for_machine] is None
+            mlog.debug('CMake binary for %s is not cached' % self.for_machine)
+            for potential_cmakebin in search():
+                mlog.debug('Trying CMake binary {} for machine {} at {}'
+                           .format(potential_cmakebin.name, self.for_machine, potential_cmakebin.command))
+                version_if_ok = self.check_cmake(potential_cmakebin)
+                if not version_if_ok:
+                    continue
+                if not silent:
+                    mlog.log('Found CMake:', mlog.bold(potential_cmakebin.get_path()),
+                             '(%s)' % version_if_ok)
+                CMakeExecutor.class_cmakebin[self.for_machine] = potential_cmakebin
+                CMakeExecutor.class_cmakevers[self.for_machine] = version_if_ok
+                break
+            else:
+                if not silent:
+                    mlog.log('Found CMake:', mlog.red('NO'))
+                # Set to False instead of None to signify that we've already
+                # searched for it and not found it
+                CMakeExecutor.class_cmakebin[self.for_machine] = False
+                CMakeExecutor.class_cmakevers[self.for_machine] = None
+
+        return CMakeExecutor.class_cmakebin[self.for_machine], CMakeExecutor.class_cmakevers[self.for_machine]
+
+    def check_cmake(self, cmakebin: 'ExternalProgram') -> Optional[str]:
+        if not cmakebin.found():
+            mlog.log('Did not find CMake {!r}'.format(cmakebin.name))
+            return None
+        try:
+            p, out = Popen_safe(cmakebin.get_command() + ['--version'])[0:2]
+            if p.returncode != 0:
+                mlog.warning('Found CMake {!r} but couldn\'t run it'
+                             ''.format(' '.join(cmakebin.get_command())))
+                return None
+        except FileNotFoundError:
+            mlog.warning('We thought we found CMake {!r} but now it\'s not there. How odd!'
+                         ''.format(' '.join(cmakebin.get_command())))
+            return None
+        except PermissionError:
+            msg = 'Found CMake {!r} but didn\'t have permissions to run it.'.format(' '.join(cmakebin.get_command()))
+            if not mesonlib.is_windows():
+                msg += '\n\nOn Unix-like systems this is often caused by scripts that are not executable.'
+            mlog.warning(msg)
+            return None
+        cmvers = re.sub(r'\s*cmake version\s*', '', out.split('\n')[0]).strip()
+        return cmvers
+
+    def _cache_key(self, args: List[str], build_dir: str, env):
+        fenv = frozenset(env.items()) if env is not None else None
+        targs = tuple(args)
+        return (self.cmakebin, targs, build_dir, fenv)
+
+    def _call_real(self, args: List[str], build_dir: str, env) -> Tuple[int, str, str]:
+        os.makedirs(build_dir, exist_ok=True)
+        cmd = self.cmakebin.get_command() + args
+        p, out, err = Popen_safe(cmd, env=env, cwd=build_dir)
+        rc = p.returncode
+        call = ' '.join(cmd)
+        mlog.debug("Called `{}` in {} -> {}".format(call, build_dir, rc))
+        return rc, out, err
+
+    def call(self, args: List[str], build_dir: str, env=None, disable_cache: bool = False):
+        if env is None:
+            env = os.environ
+
+        if disable_cache:
+            return self._call_real(args, build_dir, env)
+
+        # First check if cached, if not call the real cmake function
+        cache = CMakeExecutor.class_cmake_cache
+        key = self._cache_key(args, build_dir, env)
+        if key not in cache:
+            cache[key] = self._call_real(args, build_dir, env)
+        return cache[key]
+
+    def call_with_fake_build(self, args: List[str], build_dir: str, env=None):
+        # First check the cache
+        cache = CMakeExecutor.class_cmake_cache
+        key = self._cache_key(args, build_dir, env)
+        if key in cache:
+            return cache[key]
+
+        os.makedirs(build_dir, exist_ok=True)
+
+        # Reset the CMake cache
+        with open('{}/CMakeCache.txt'.format(build_dir), 'w') as fp:
+            fp.write('CMAKE_PLATFORM_INFO_INITIALIZED:INTERNAL=1\n')
+
+        # Fake the compiler files
+        comp_dir = '{}/CMakeFiles/{}'.format(build_dir, self.cmakevers)
+        os.makedirs(comp_dir, exist_ok=True)
+
+        c_comp = '{}/CMakeCCompiler.cmake'.format(comp_dir)
+        cxx_comp = '{}/CMakeCXXCompiler.cmake'.format(comp_dir)
+
+        if not os.path.exists(c_comp):
+            with open(c_comp, 'w') as fp:
+                fp.write('''# Fake CMake file to skip the boring and slow stuff
+set(CMAKE_C_COMPILER "{}") # Just give CMake a valid full path to any file
+set(CMAKE_C_COMPILER_ID "GNU") # Pretend we have found GCC
+set(CMAKE_COMPILER_IS_GNUCC 1)
+set(CMAKE_C_COMPILER_LOADED 1)
+set(CMAKE_C_COMPILER_WORKS TRUE)
+set(CMAKE_C_ABI_COMPILED TRUE)
+set(CMAKE_SIZEOF_VOID_P "{}")
+'''.format(os.path.realpath(__file__), ctypes.sizeof(ctypes.c_voidp)))
+
+        if not os.path.exists(cxx_comp):
+            with open(cxx_comp, 'w') as fp:
+                fp.write('''# Fake CMake file to skip the boring and slow stuff
+set(CMAKE_CXX_COMPILER "{}") # Just give CMake a valid full path to any file
+set(CMAKE_CXX_COMPILER_ID "GNU") # Pretend we have found GCC
+set(CMAKE_COMPILER_IS_GNUCXX 1)
+set(CMAKE_CXX_COMPILER_LOADED 1)
+set(CMAKE_CXX_COMPILER_WORKS TRUE)
+set(CMAKE_CXX_ABI_COMPILED TRUE)
+set(CMAKE_SIZEOF_VOID_P "{}")
+'''.format(os.path.realpath(__file__), ctypes.sizeof(ctypes.c_voidp)))
+
+        return self.call(args, build_dir, env)
+
+    def found(self) -> bool:
+        return self.cmakebin is not None
+
+    def version(self) -> str:
+        return self.cmakevers
+
+    def executable_path(self) -> str:
+        return self.cmakebin.get_path()
+
+    def get_command(self):
+        return self.cmakebin.get_command()
+
+    def machine_choice(self) -> MachineChoice:
+        return self.for_machine

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -1,0 +1,317 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This class contains the basic functionality needed to run any interpreter
+# or an interpreter-based tool.
+
+from .common import CMakeException
+
+from typing import List, Tuple
+import re
+
+class CMakeTraceLine:
+    def __init__(self, file, line, func, args):
+        self.file = file
+        self.line = line
+        self.func = func.lower()
+        self.args = args
+
+    def __repr__(self):
+        s = 'CMake TRACE: {0}:{1} {2}({3})'
+        return s.format(self.file, self.line, self.func, self.args)
+
+class CMakeTarget:
+    def __init__(self, name, target_type, properies=None):
+        if properies is None:
+            properies = {}
+        self.name = name
+        self.type = target_type
+        self.properies = properies
+
+    def __repr__(self):
+        s = 'CMake TARGET:\n  -- name:      {}\n  -- type:      {}\n  -- properies: {{\n{}     }}'
+        propSTR = ''
+        for i in self.properies:
+            propSTR += "      '{}': {}\n".format(i, self.properies[i])
+        return s.format(self.name, self.type, propSTR)
+
+class CMakeTraceParser:
+    def __init__(self):
+        # Dict of CMake variables: '<var_name>': ['list', 'of', 'values']
+        self.vars = {}
+
+        # Dict of CMakeTarget
+        self.targets = {}
+
+    def parse(self, trace: str) -> None:
+        # First parse the trace
+        lexer1 = self._lex_trace(trace)
+
+        # All supported functions
+        functions = {
+            'set': self._cmake_set,
+            'unset': self._cmake_unset,
+            'add_executable': self._cmake_add_executable,
+            'add_library': self._cmake_add_library,
+            'add_custom_target': self._cmake_add_custom_target,
+            'set_property': self._cmake_set_property,
+            'set_target_properties': self._cmake_set_target_properties
+        }
+
+        # Primary pass -- parse everything
+        for l in lexer1:
+            # "Execute" the CMake function if supported
+            fn = functions.get(l.func, None)
+            if(fn):
+                fn(l)
+
+    def get_first_cmake_var_of(self, var_list: List[str]) -> List[str]:
+        # Return the first found CMake variable in list var_list
+        for i in var_list:
+            if i in self.vars:
+                return self.vars[i]
+
+        return []
+
+    def get_cmake_var(self, var: str) -> List[str]:
+        # Return the value of the CMake variable var or an empty list if var does not exist
+        if var in self.vars:
+            return self.vars[var]
+
+        return []
+
+    def var_to_bool(self, var):
+        if var not in self.vars:
+            return False
+
+        if len(self.vars[var]) < 1:
+            return False
+
+        if self.vars[var][0].upper() in ['1', 'ON', 'TRUE']:
+            return True
+        return False
+
+    def _cmake_set(self, tline: CMakeTraceLine) -> None:
+        """Handler for the CMake set() function in all variaties.
+
+        comes in three flavors:
+        set(<var> <value> [PARENT_SCOPE])
+        set(<var> <value> CACHE <type> <docstring> [FORCE])
+        set(ENV{<var>} <value>)
+
+        We don't support the ENV variant, and any uses of it will be ignored
+        silently. the other two variates are supported, with some caveats:
+        - we don't properly handle scoping, so calls to set() inside a
+          function without PARENT_SCOPE set could incorrectly shadow the
+          outer scope.
+        - We don't honor the type of CACHE arguments
+        """
+        # DOC: https://cmake.org/cmake/help/latest/command/set.html
+
+        # 1st remove PARENT_SCOPE and CACHE from args
+        args = []
+        for i in tline.args:
+            if not i or i == 'PARENT_SCOPE':
+                continue
+
+            # Discard everything after the CACHE keyword
+            if i == 'CACHE':
+                break
+
+            args.append(i)
+
+        if len(args) < 1:
+            raise CMakeException('CMake: set() requires at least one argument\n{}'.format(tline))
+
+        # Now that we've removed extra arguments all that should be left is the
+        # variable identifier and the value, join the value back together to
+        # ensure spaces in the value are correctly handled. This assumes that
+        # variable names don't have spaces. Please don't do that...
+        identifier = args.pop(0)
+        value = ' '.join(args)
+
+        if not value:
+            # Same as unset
+            if identifier in self.vars:
+                del self.vars[identifier]
+        else:
+            self.vars[identifier] = value.split(';')
+
+    def _cmake_unset(self, tline: CMakeTraceLine):
+        # DOC: https://cmake.org/cmake/help/latest/command/unset.html
+        if len(tline.args) < 1:
+            raise CMakeException('CMake: unset() requires at least one argument\n{}'.format(tline))
+
+        if tline.args[0] in self.vars:
+            del self.vars[tline.args[0]]
+
+    def _cmake_add_executable(self, tline: CMakeTraceLine):
+        # DOC: https://cmake.org/cmake/help/latest/command/add_executable.html
+        args = list(tline.args) # Make a working copy
+
+        # Make sure the exe is imported
+        if 'IMPORTED' not in args:
+            raise CMakeException('CMake: add_executable() non imported executables are not supported\n{}'.format(tline))
+
+        args.remove('IMPORTED')
+
+        if len(args) < 1:
+            raise CMakeException('CMake: add_executable() requires at least 1 argument\n{}'.format(tline))
+
+        self.targets[args[0]] = CMakeTarget(args[0], 'EXECUTABLE', {})
+
+    def _cmake_add_library(self, tline: CMakeTraceLine):
+        # DOC: https://cmake.org/cmake/help/latest/command/add_library.html
+        args = list(tline.args) # Make a working copy
+
+        # Make sure the lib is imported
+        if 'IMPORTED' not in args:
+            raise CMakeException('CMake: add_library() non imported libraries are not supported\n{}'.format(tline))
+
+        args.remove('IMPORTED')
+
+        # No only look at the first two arguments (target_name and target_type) and ignore the rest
+        if len(args) < 2:
+            raise CMakeException('CMake: add_library() requires at least 2 arguments\n{}'.format(tline))
+
+        self.targets[args[0]] = CMakeTarget(args[0], args[1], {})
+
+    def _cmake_add_custom_target(self, tline: CMakeTraceLine):
+        # DOC: https://cmake.org/cmake/help/latest/command/add_custom_target.html
+        # We only the first parameter (the target name) is interesting
+        if len(tline.args) < 1:
+            raise CMakeException('CMake: add_custom_target() requires at least one argument\n{}'.format(tline))
+
+        self.targets[tline.args[0]] = CMakeTarget(tline.args[0], 'CUSTOM', {})
+
+    def _cmake_set_property(self, tline: CMakeTraceLine) -> None:
+        # DOC: https://cmake.org/cmake/help/latest/command/set_property.html
+        args = list(tline.args)
+
+        # We only care for TARGET properties
+        if args.pop(0) != 'TARGET':
+            return
+
+        append = False
+        targets = []
+        while args:
+            curr = args.pop(0)
+            # XXX: APPEND_STRING is specifically *not* supposed to create a
+            # list, is treating them as aliases really okay?
+            if curr == 'APPEND' or curr == 'APPEND_STRING':
+                append = True
+                continue
+
+            if curr == 'PROPERTY':
+                break
+
+            targets.append(curr)
+
+        if not args:
+            raise CMakeException('CMake: set_property() faild to parse argument list\n{}'.format(tline))
+
+        if len(args) == 1:
+            # Tries to set property to nothing so nothing has to be done
+            return
+
+        identifier = args.pop(0)
+        value = ' '.join(args).split(';')
+        if not value:
+            return
+
+        for i in targets:
+            if i not in self.targets:
+                raise CMakeException('CMake: set_property() TARGET {} not found\n{}'.format(i, tline))
+
+            if identifier not in self.targets[i].properies:
+                self.targets[i].properies[identifier] = []
+
+            if append:
+                self.targets[i].properies[identifier] += value
+            else:
+                self.targets[i].properies[identifier] = value
+
+    def _cmake_set_target_properties(self, tline: CMakeTraceLine) -> None:
+        # DOC: https://cmake.org/cmake/help/latest/command/set_target_properties.html
+        args = list(tline.args)
+
+        targets = []
+        while args:
+            curr = args.pop(0)
+            if curr == 'PROPERTIES':
+                break
+
+            targets.append(curr)
+
+        # Now we need to try to reconsitute the original quoted format of the
+        # arguments, as a property value could have spaces in it. Unlike
+        # set_property() this is not context free. There are two approaches I
+        # can think of, both have drawbacks:
+        #
+        #   1. Assume that the property will be capitalized, this is convention
+        #      but cmake doesn't require it.
+        #   2. Maintain a copy of the list here: https://cmake.org/cmake/help/latest/manual/cmake-properties.7.html#target-properties
+        #
+        # Neither of these is awesome for obvious reasons. I'm going to try
+        # option 1 first and fall back to 2, as 1 requires less code and less
+        # synchroniztion for cmake changes.
+
+        arglist = []  # type: List[Tuple[str, List[str]]]
+        name = args.pop(0)
+        values = []
+        for a in args:
+            if a.isupper():
+                if values:
+                    arglist.append((name, ' '.join(values).split(';')))
+                name = a
+                values = []
+            else:
+                values.append(a)
+        if values:
+            arglist.append((name, ' '.join(values).split(';')))
+
+        for name, value in arglist:
+            for i in targets:
+                if i not in self.targets:
+                    raise CMakeException('CMake: set_target_properties() TARGET {} not found\n{}'.format(i, tline))
+
+                self.targets[i].properies[name] = value
+
+    def _lex_trace(self, trace):
+        # The trace format is: '<file>(<line>):  <func>(<args -- can contain \n> )\n'
+        reg_tline = re.compile(r'\s*(.*\.(cmake|txt))\(([0-9]+)\):\s*(\w+)\(([\s\S]*?) ?\)\s*\n', re.MULTILINE)
+        reg_other = re.compile(r'[^\n]*\n')
+        reg_genexp = re.compile(r'\$<.*>')
+        loc = 0
+        while loc < len(trace):
+            mo_file_line = reg_tline.match(trace, loc)
+            if not mo_file_line:
+                skip_match = reg_other.match(trace, loc)
+                if not skip_match:
+                    print(trace[loc:])
+                    raise CMakeException('Failed to parse CMake trace')
+
+                loc = skip_match.end()
+                continue
+
+            loc = mo_file_line.end()
+
+            file = mo_file_line.group(1)
+            line = mo_file_line.group(3)
+            func = mo_file_line.group(4)
+            args = mo_file_line.group(5).split(' ')
+            args = list(map(lambda x: x.strip(), args))
+            args = list(map(lambda x: reg_genexp.sub('', x), args)) # Remove generator expressions
+
+            yield CMakeTraceLine(file, line, func, args)

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -418,8 +418,8 @@ class LLVMDependencyCMake(CMakeDependency):
         super().__init__(name='LLVM', environment=env, language='cpp', kwargs=kwargs)
 
         # Extract extra include directories and definitions
-        inc_dirs = self.get_cmake_var('PACKAGE_INCLUDE_DIRS')
-        defs = self.get_cmake_var('PACKAGE_DEFINITIONS')
+        inc_dirs = self.traceparser.get_cmake_var('PACKAGE_INCLUDE_DIRS')
+        defs = self.traceparser.get_cmake_var('PACKAGE_DEFINITIONS')
         temp = ['-I' + x for x in inc_dirs] + defs
         self.compile_args += [x for x in temp if x not in self.compile_args]
         self._add_sub_dependency(ThreadDependency, env, kwargs)
@@ -434,7 +434,7 @@ class LLVMDependencyCMake(CMakeDependency):
     def _map_module_list(self, modules: List[Tuple[str, bool]]) -> List[Tuple[str, bool]]:
         res = []
         for mod, required in modules:
-            cm_targets = self.get_cmake_var('MESON_LLVM_TARGETS_{}'.format(mod))
+            cm_targets = self.traceparser.get_cmake_var('MESON_LLVM_TARGETS_{}'.format(mod))
             if not cm_targets:
                 if required:
                     raise self._gen_exception('LLVM module {} was not found'.format(mod))
@@ -446,7 +446,7 @@ class LLVMDependencyCMake(CMakeDependency):
         return res
 
     def _original_module_name(self, module: str) -> str:
-        orig_name = self.get_cmake_var('MESON_TARGET_TO_LLVM_{}'.format(module))
+        orig_name = self.traceparser.get_cmake_var('MESON_TARGET_TO_LLVM_{}'.format(module))
         if orig_name:
             return orig_name[0]
         return module

--- a/test cases/cmake/1 basic/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/1 basic/subprojects/cmMod/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.5)
 project(cmMod)
 set (CMAKE_CXX_STANDARD 14)
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
 add_definitions("-DDO_NOTHING_JUST_A_FLAG=1")
 
 add_library(cmModLib SHARED cmMod.cpp)

--- a/test cases/cmake/2 advanced/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/2 advanced/subprojects/cmMod/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 14)
 
 find_package(ZLIB REQUIRED)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/lib)
 
 set(CONFIG_OPT 42)
 configure_file("config.h.in" "${CMAKE_CURRENT_BINARY_DIR}/config.h" @ONLY)

--- a/test cases/cmake/3 advanced no dep/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/3 advanced no dep/subprojects/cmMod/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 project(cmMod)
 set(CMAKE_CXX_STANDARD 14)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/lib)
 
 set(CONFIG_OPT 42)
 configure_file("config.h.in" "${CMAKE_CURRENT_BINARY_DIR}/config.h" @ONLY)


### PR DESCRIPTION
This PR basically moves most of the CMake detection/parsing code from the dependency module into the CMake module. This change reduces the complexity of the `CMakeDependency` class and makes reusing the parser in the future much easier.