### PR TITLE
`add_{global,project}_{,link_}arguments`: simply native flag behavior

### DIFF
--- a/docs/markdown/Release-notes-for-0.48.0.md
+++ b/docs/markdown/Release-notes-for-0.48.0.md
@@ -217,7 +217,7 @@ i18n.merge_file() now behaves as custom_target() in this regard.
 ## Projects args can be set separately for cross and native builds (potentially breaking change)
 
 It has been a longstanding bug (or let's call it a "delayed bug fix")
-that if yo do this:
+that if you do this:
 
 ```meson
 add_project_arguments('-DFOO', language : 'c')

--- a/docs/markdown/snippets/add_arguments_cross.md
+++ b/docs/markdown/snippets/add_arguments_cross.md
@@ -1,0 +1,16 @@
+## Projects args can be set separately for build and host machines (potentially breaking change)
+
+Simplify `native` flag behavior in `add_global_arguments`,
+`add_global_link_arguments`, `add_project_arguments` and
+`add_project_link_arguments`. The rules are now very simple:
+
+ - `native: true` affects `native: true` targets
+
+ - `native: false` affects `native: false` targets
+
+ - No native flag is the same as `native: false`
+
+This further simplifies behavior to match the "build vs host" decision done in
+last release with `c_args` vs `build_c_args`. The underlying motivation in both
+cases is to execute the same commands whether the overall build is native or
+cross.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3829,47 +3829,29 @@ different subdirectory.
         env = self.unpack_env_kwarg(kwargs)
         self.build.test_setups[setup_name] = build.TestSetup(exe_wrapper, gdb, timeout_multiplier, env)
 
-    # TODO make cross agnostic, just taking into account for_machine
-    # TODO PerMachine[T], Iterator[T]
-    def get_argdict_on_crossness(self, dicts_per_machine: PerMachine, kwargs) -> Iterator:
-        for_native = kwargs.get('native', not self.environment.is_cross_build())
-        if not isinstance(for_native, bool):
-            raise InterpreterException('Keyword native must be a boolean.')
-        if self.environment.is_cross_build():
-            if for_native:
-                return iter([dicts_per_machine[MachineChoice.BUILD]])
-            else:
-                return iter([dicts_per_machine[MachineChoice.HOST]])
-        else:
-            if for_native:
-                return iter([dicts_per_machine[MachineChoice.BUILD],
-                             dicts_per_machine[MachineChoice.HOST]])
-            else:
-                return iter([])
-
     @permittedKwargs(permitted_kwargs['add_global_arguments'])
     @stringArgs
     def func_add_global_arguments(self, node, args, kwargs):
-        for argdict in self.get_argdict_on_crossness(self.build.global_args, kwargs):
-            self.add_global_arguments(node, argdict, args, kwargs)
+        for_machine = self.machine_from_native_kwarg(kwargs)
+        self.add_global_arguments(node, self.build.global_args[for_machine], args, kwargs)
 
     @permittedKwargs(permitted_kwargs['add_global_link_arguments'])
     @stringArgs
     def func_add_global_link_arguments(self, node, args, kwargs):
-        for argdict in self.get_argdict_on_crossness(self.build.global_link_args, kwargs):
-            self.add_global_arguments(node, argdict, args, kwargs)
+        for_machine = self.machine_from_native_kwarg(kwargs)
+        self.add_global_arguments(node, self.build.global_link_args[for_machine], args, kwargs)
 
     @permittedKwargs(permitted_kwargs['add_project_arguments'])
     @stringArgs
     def func_add_project_arguments(self, node, args, kwargs):
-        for argdict in self.get_argdict_on_crossness(self.build.projects_args, kwargs):
-            self.add_project_arguments(node, argdict, args, kwargs)
+        for_machine = self.machine_from_native_kwarg(kwargs)
+        self.add_project_arguments(node, self.build.projects_args[for_machine], args, kwargs)
 
     @permittedKwargs(permitted_kwargs['add_project_link_arguments'])
     @stringArgs
     def func_add_project_link_arguments(self, node, args, kwargs):
-        for argdict in self.get_argdict_on_crossness(self.build.projects_link_args, kwargs):
-            self.add_project_arguments(node, argdict, args, kwargs)
+        for_machine = self.machine_from_native_kwarg(kwargs)
+        self.add_project_arguments(node, self.build.projects_link_args[for_machine], args, kwargs)
 
     def add_global_arguments(self, node, argsdict, args, kwargs):
         if self.is_subproject():

--- a/test cases/common/21 global arg/meson.build
+++ b/test cases/common/21 global arg/meson.build
@@ -1,22 +1,23 @@
 project('global arg test', 'cpp', 'c')
 
-add_global_arguments('-DMYTHING', language : 'c')
-add_global_arguments('-DMYCPPTHING', language : 'cpp')
+add_global_arguments('-DMYTHING', language : 'c', native : true)
+add_global_arguments('-DMYTHING', language : 'c', native : false)
+add_global_arguments('-DMYCPPTHING', language : 'cpp', native : true)
+add_global_arguments('-DMYCPPTHING', language : 'cpp', native : false)
 
-add_global_arguments('-DGLOBAL_NATIVE', language : 'c', native : true)
-add_global_arguments('-DGLOBAL_CROSS', language : 'c', native : false)
+add_global_arguments('-DGLOBAL_BUILD', language : 'c', native : true)
+add_global_arguments('-DGLOBAL_HOST', language : 'c', native : false)
 
-if meson.is_cross_build()
-  c_args = ['-DARG_CROSS']
-else
-  c_args = ['-DARG_NATIVE']
-endif
+build_c_args = ['-DARG_BUILD']
+c_args = ['-DARG_HOST']
 
-add_global_arguments('-DMYCANDCPPTHING', language: ['c', 'cpp'])
+add_global_arguments('-DMYCANDCPPTHING', language: ['c', 'cpp'], native: true)
+add_global_arguments('-DMYCANDCPPTHING', language: ['c', 'cpp'], native: false)
 
-exe1 = executable('prog', 'prog.c', c_args : c_args)
-exe2 = executable('prog2', 'prog.cc')
+exe1 = executable('prog1', 'prog.c', c_args : build_c_args, native : true)
+exe2 = executable('prog2', 'prog.c', c_args : c_args, native : false)
+exe3 = executable('prog3', 'prog.cc')
 
 test('prog1', exe1)
 test('prog2', exe2)
-
+test('prog3', exe3)

--- a/test cases/common/21 global arg/prog.c
+++ b/test cases/common/21 global arg/prog.c
@@ -1,48 +1,40 @@
 #ifndef MYTHING
-#error "Global argument not set"
+  #error "Global argument not set"
 #endif
 
 #ifdef MYCPPTHING
-#error "Wrong global argument set"
+  #error "Wrong global argument set"
 #endif
 
 #ifndef MYCANDCPPTHING
-#error "Global argument not set"
+  #error "Global argument not set"
 #endif
 
-#ifdef GLOBAL_NATIVE
-  #ifndef ARG_NATIVE
-    #error "Global is native but arg_native is not set."
+#if !defined(GLOBAL_HOST) && !defined(GLOBAL_BUILD)
+  #error "Neither global_host nor glogal_build is set."
+#endif
+
+#if defined(GLOBAL_HOST) && defined(GLOBAL_BUILD)
+  #error "Both global build and global host set."
+#endif
+
+#ifdef GLOBAL_BUILD
+  #ifndef ARG_BUILD
+    #error "Global is build but arg_build is not set."
   #endif
 
-  #ifdef GLOBAL_CROSS
-    #error "Both global native and global cross set."
-  #endif
-#else
-  #ifndef GLOBAL_CROSS
-    #error "Neither global_cross nor glogal_native is set."
-  #endif
-
-  #ifndef ARG_CROSS
-    #error "Global is cross but arg_cross is not set."
-  #endif
-
-  #ifdef ARG_NATIVE
-    #error "Global is cross but arg_native is set."
+  #ifdef ARG_HOST
+    #error "Global is build but arg host is set."
   #endif
 #endif
 
-#ifdef GLOBAL_CROSS
-  #ifndef ARG_CROSS
-    #error "Global is cross but arg_cross is not set."
-  #endif
-#else
-  #ifdef ARG_CROSS
-    #error "Global is cross but arg_native is set."
+#ifdef GLOBAL_HOST
+  #ifndef ARG_HOST
+    #error "Global is host but arg_host is not set."
   #endif
 
-  #ifdef ARG_CROSS
-    #error "Global is native but arg cross is set."
+  #ifdef ARG_BUILD
+    #error "Global is host but arg_build is set."
   #endif
 #endif
 


### PR DESCRIPTION
This further simplifies behavior to match the "build vs host" decision
we did with `c_args` vs `build_c_args`. The rules are now simply:

 - `native: true` affects `native: true` targets
 - `native: false` affects `native: false` targets
 - No native flag is the same as `native: false`

I like this because you don't even have to know what "build" and "host" mean to understand how it works, and it doesn't depend on whether the overall build is cross or not.

CC @dcbaker 

Fixes #4933