### PR TITLE
Armclang cross test failure fixes

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -2184,7 +2184,7 @@ class ClangCompiler(GnuLikeCompiler):
 
 class ArmclangCompiler:
     def __init__(self, compiler_type):
-        if self.is_cross:
+        if not self.is_cross:
             raise EnvironmentException('armclang supports only cross-compilation.')
         # Check whether 'armlink.exe' is available in path
         self.linker_exe = 'armlink.exe'

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -196,8 +196,7 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
 
     def get_options(self):
         opts = CPPCompiler.get_options(self)
-        opts.update({'cpp_eh': coredata.UserComboOption('cpp_eh',
-                                                        'C++ exception handling type.',
+        opts.update({'cpp_eh': coredata.UserComboOption('C++ exception handling type.',
                                                         ['none', 'default', 'a', 's', 'sc'],
                                                         'default'),
                      'cpp_std': coredata.UserComboOption('C++ language standard to use',


### PR DESCRIPTION
Fixes the broken armclang cross tests,
- Reverts back the change done to Armclang compiler class as part of PR 4010. Armclang supports only cross-compilation.
- Removes the name field from Combo Option, 'cpp_eh', for Armclang Cpp compiler. Related to PR 5388.