### PR TITLE
Solaris fixes

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1978,6 +1978,8 @@ class GnuLikeCompiler(abc.ABC):
         elif self.compiler_type.is_windows_compiler:
             # For PE/COFF this is impossible
             return []
+        elif mesonlib.is_sunos():
+            return []
         else:
             # GNU ld and LLVM lld
             return ['-Wl,--allow-shlib-undefined']

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1245,6 +1245,8 @@ class Environment:
                 return ArLinker(linker)
             if p.returncode == 1 and err.startswith('Usage'): # AIX
                 return ArLinker(linker)
+            if p.returncode == 1 and err.startswith('ar: bad option: --'): # Solaris
+                return ArLinker(linker)
         self._handle_exceptions(popen_exceptions, linkers, 'linker')
         raise EnvironmentException('Unknown static linker "%s"' % ' '.join(linkers))
 


### PR DESCRIPTION
Fixes #5351

I make no promises this is the best way to make Meson work on Solaris (or, as in my case, OpenIndiana). However, this does work for me. You could argue the addition to *mesonbuild/environment.py* should also include a `is_sunos()` in the condition but I think that is being overly prescriptive.