### PR TITLE
compilers: Add logging for symbol prefix test

### DIFF
--- a/mesonbuild/compilers/clike.py
+++ b/mesonbuild/compilers/clike.py
@@ -870,9 +870,11 @@ class CLikeCompiler:
                     # Check if the underscore form of the symbol is somewhere
                     # in the output file.
                     if b'_' + symbol_name in line:
+                        mlog.debug("Symbols have underscore prefix: YES")
                         return True
                     # Else, check if the non-underscored form is present
                     elif symbol_name in line:
+                        mlog.debug("Symbols have underscore prefix: NO")
                         return False
         raise RuntimeError('BUG: {!r} check failed unexpectedly'.format(n))
 


### PR DESCRIPTION
Currently meson does not write the outcome of this test to the log
file which makes debugging wrong outcomes of this incredibly tedious.