### PR TITLE
dependencies/shaderc: fix exception caused by typo

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -749,7 +749,7 @@ class ShadercDependency(ExternalDependency):
             else:
                 c = [functools.partial(PkgConfigDependency, name, environment, kwargs)
                      for name in shared_libs + static_libs]
-            candidates.exend(c)
+            candidates.extend(c)
 
         if DependencyMethods.SYSTEM in methods:
             candidates.append(functools.partial(ShadercDependency, environment, kwargs))


### PR DESCRIPTION
this is why static languages rock