### PR TITLE
Compiler options per lang

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2560,7 +2560,14 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # to be after all internal and external libraries so that unresolved
         # symbols from those can be found here. This is needed when the
         # *_winlibs that we want to link to are static mingw64 libraries.
-        commands += linker.get_option_link_args(self.environment.coredata.compiler_options[target.for_machine])
+        if hasattr(linker, 'get_language'):
+            # The static linker doesn't know what language it is building, so we
+            # don't know what option. Fortunately, it doesn't care to see the
+            # language-specific options either.
+            #
+            # We shouldn't check whether we are making a static library, because
+            # in the LTO case we do use a real compiler here.
+            commands += linker.get_option_link_args(self.environment.coredata.compiler_options[target.for_machine][linker.get_language()])
 
         dep_targets = []
         dep_targets.extend(self.guess_external_link_dependencies(linker, target, commands, internal))

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -892,8 +892,10 @@ class Vs2010Backend(backends.Backend):
         # generate_single_compile() and generate_basic_compiler_args()
         for l, comp in target.compilers.items():
             if l in file_args:
-                file_args[l] += compilers.get_base_compile_args(self.get_base_options_for_target(target), comp)
-                file_args[l] += comp.get_option_compile_args(self.environment.coredata.compiler_options[target.for_machine])
+                file_args[l] += compilers.get_base_compile_args(
+                        self.get_base_options_for_target(target), comp)
+                file_args[l] += comp.get_option_compile_args(
+                        self.environment.coredata.compiler_options[target.for_machine][comp.language])
 
         # Add compile args added using add_project_arguments()
         for l, args in self.build.projects_args[target.for_machine].get(target.subproject, {}).items():
@@ -906,10 +908,11 @@ class Vs2010Backend(backends.Backend):
                 file_args[l] += args
         # Compile args added from the env or cross file: CFLAGS/CXXFLAGS, etc. We want these
         # to override all the defaults, but not the per-target compile args.
-        for key, opt in self.environment.coredata.compiler_options[target.for_machine].items():
-            l, suffix = key.split('_', 1)
-            if suffix == 'args' and l in file_args:
-                file_args[l] += opt.value
+        for l in file_args.keys():
+            opts = self.environment.coredata.compiler_options[target.for_machine][l]
+            k = 'args'
+            if k in opts:
+                file_args[l] += opts[k].value
         for args in file_args.values():
             # This is where Visual Studio will insert target_args, target_defines,
             # etc, which are added later from external deps (see below).
@@ -1116,7 +1119,8 @@ class Vs2010Backend(backends.Backend):
         # to be after all internal and external libraries so that unresolved
         # symbols from those can be found here. This is needed when the
         # *_winlibs that we want to link to are static mingw64 libraries.
-        extra_link_args += compiler.get_option_link_args(self.environment.coredata.compiler_options[compiler.for_machine])
+        extra_link_args += compiler.get_option_link_args(
+                self.environment.coredata.compiler_options[compiler.for_machine][comp.language])
         (additional_libpaths, additional_links, extra_link_args) = self.split_link_args(extra_link_args.to_native())
 
         # Add more libraries to be linked if needed

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import copy, os, re
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 import itertools, pathlib
 import hashlib
 import pickle
@@ -28,7 +28,10 @@ from .mesonlib import (
     extract_as_list, typeslistify, stringlistify, classify_unity_sources,
     get_filenames_templates_dict, substitute_values, has_path_sep, unholder
 )
-from .compilers import Compiler, is_object, clink_langs, sort_clink, lang_suffixes, is_known_suffix
+from .compilers import (
+    Compiler, all_languages, is_object, clink_langs, sort_clink, lang_suffixes,
+    is_known_suffix
+)
 from .linkers import StaticLinker
 from .interpreterbase import FeatureNew
 
@@ -358,7 +361,8 @@ a hard error in the future.'''.format(name))
         self.for_machine = for_machine
         self.install = False
         self.build_always_stale = False
-        self.option_overrides = {}
+        self.option_overrides_base = {}
+        self.option_overrides_compiler = defaultdict(dict)
         if not hasattr(self, 'typename'):
             raise RuntimeError('Target type is not set for target class "{}". This is a bug'.format(type(self).__name__))
 
@@ -448,7 +452,15 @@ a hard error in the future.'''.format(name))
             # set, use the value of 'install' if it's enabled.
             self.build_by_default = True
 
-        self.option_overrides = self.parse_overrides(kwargs)
+        option_overrides = self.parse_overrides(kwargs)
+
+        for k, v in option_overrides.items():
+            if '_' in k:
+               lang, k2 = k.split('_', 1)
+               if lang in all_languages:
+                   self.option_overrides_compiler[lang][k2] = v
+                   continue
+            self.option_overrides_base[k] = v
 
     def parse_overrides(self, kwargs) -> dict:
         result = {}

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -107,25 +107,32 @@ class ClangCCompiler(ClangCompiler, CCompiler):
         if version_compare(self.version, self._C18_VERSION):
             c_stds += ['c18']
             g_stds += ['gnu18']
-        opts.update({'c_std': coredata.UserComboOption('C language standard to use',
-                                                       ['none'] + c_stds + g_stds,
-                                                       'none')})
+        opts.update({
+            'std': coredata.UserComboOption(
+                'C language standard to use',
+                ['none'] + c_stds + g_stds,
+                'none',
+            ),
+        })
         if self.info.is_windows() or self.info.is_cygwin():
             opts.update({
-                'c_winlibs': coredata.UserArrayOption('Standard Win libraries to link against',
-                                                      gnu_winlibs), })
+                'winlibs': coredata.UserArrayOption(
+                    'Standard Win libraries to link against',
+                    gnu_winlibs,
+                ),
+            })
         return opts
 
     def get_option_compile_args(self, options):
         args = []
-        std = options['c_std']
+        std = options['std']
         if std.value != 'none':
             args.append('-std=' + std.value)
         return args
 
     def get_option_link_args(self, options):
         if self.info.is_windows() or self.info.is_cygwin():
-            return options['c_winlibs'].value[:]
+            return options['winlibs'].value[:]
         return []
 
 
@@ -166,15 +173,18 @@ class ArmclangCCompiler(ArmclangCompiler, CCompiler):
 
     def get_options(self):
         opts = CCompiler.get_options(self)
-        opts.update({'c_std': coredata.UserComboOption('C language standard to use',
-                                                       ['none', 'c90', 'c99', 'c11',
-                                                        'gnu90', 'gnu99', 'gnu11'],
-                                                       'none')})
+        opts.update({
+            'std': coredata.UserComboOption(
+                'C language standard to use',
+                ['none', 'c90', 'c99', 'c11', 'gnu90', 'gnu99', 'gnu11'],
+                'none',
+            ),
+        })
         return opts
 
     def get_option_compile_args(self, options):
         args = []
-        std = options['c_std']
+        std = options['std']
         if std.value != 'none':
             args.append('-std=' + std.value)
         return args
@@ -204,25 +214,32 @@ class GnuCCompiler(GnuCompiler, CCompiler):
         if version_compare(self.version, v):
             c_stds += ['c17', 'c18']
             g_stds += ['gnu17', 'gnu18']
-        opts.update({'c_std': coredata.UserComboOption('C language standard to use',
-                                                       ['none'] + c_stds + g_stds,
-                                                       'none')})
+        opts.update({
+            'std': coredata.UserComboOption(
+                'C language standard to use',
+                ['none'] + c_stds + g_stds,
+                'none',
+            ),
+        })
         if self.info.is_windows() or self.info.is_cygwin():
             opts.update({
-                'c_winlibs': coredata.UserArrayOption('Standard Win libraries to link against',
-                                                      gnu_winlibs), })
+                'winlibs': coredata.UserArrayOption(
+                    'Standard Win libraries to link against',
+                    gnu_winlibs,
+                ),
+            })
         return opts
 
     def get_option_compile_args(self, options):
         args = []
-        std = options['c_std']
+        std = options['std']
         if std.value != 'none':
             args.append('-std=' + std.value)
         return args
 
     def get_option_link_args(self, options):
         if self.info.is_windows() or self.info.is_cygwin():
-            return options['c_winlibs'].value[:]
+            return options['winlibs'].value[:]
         return []
 
     def get_pch_use_args(self, pch_dir, header):
@@ -248,11 +265,17 @@ class ElbrusCCompiler(GnuCCompiler, ElbrusCompiler):
     # It does support some various ISO standards and c/gnu 90, 9x, 1x in addition to those which GNU CC supports.
     def get_options(self):
         opts = CCompiler.get_options(self)
-        opts.update({'c_std': coredata.UserComboOption('C language standard to use',
-                                                       ['none', 'c89', 'c90', 'c9x', 'c99', 'c1x', 'c11',
-                                                        'gnu89', 'gnu90', 'gnu9x', 'gnu99', 'gnu1x', 'gnu11',
-                                                        'iso9899:2011', 'iso9899:1990', 'iso9899:199409', 'iso9899:1999'],
-                                                       'none')})
+        opts.update({
+            'std': coredata.UserComboOption(
+                'C language standard to use',
+                [
+                    'none', 'c89', 'c90', 'c9x', 'c99', 'c1x', 'c11',
+                    'gnu89', 'gnu90', 'gnu9x', 'gnu99', 'gnu1x', 'gnu11',
+                    'iso9899:2011', 'iso9899:1990', 'iso9899:199409', 'iso9899:1999',
+                ],
+                'none',
+            ),
+        })
         return opts
 
     # Elbrus C compiler does not have lchmod, but there is only linker warning, not compiler error.
@@ -285,14 +308,18 @@ class IntelCCompiler(IntelGnuLikeCompiler, CCompiler):
         g_stds = ['gnu89', 'gnu99']
         if version_compare(self.version, '>=16.0.0'):
             c_stds += ['c11']
-        opts.update({'c_std': coredata.UserComboOption('C language standard to use',
-                                                       ['none'] + c_stds + g_stds,
-                                                       'none')})
+        opts.update({
+            'std': coredata.UserComboOption(
+                'C language standard to use',
+                ['none'] + c_stds + g_stds,
+                'none',
+            ),
+        })
         return opts
 
     def get_option_compile_args(self, options):
         args = []
-        std = options['c_std']
+        std = options['std']
         if std.value != 'none':
             args.append('-std=' + std.value)
         return args
@@ -304,12 +331,16 @@ class VisualStudioLikeCCompilerMixin:
 
     def get_options(self):
         opts = super().get_options()
-        opts.update({'c_winlibs': coredata.UserArrayOption('Windows libs to link against.',
-                                                           msvc_winlibs)})
+        opts.update({
+            'winlibs': coredata.UserArrayOption(
+                'Windows libs to link against.',
+                msvc_winlibs,
+            ),
+        })
         return opts
 
     def get_option_link_args(self, options):
-        return options['c_winlibs'].value[:]
+        return options['winlibs'].value[:]
 
 
 class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompiler):
@@ -343,14 +374,18 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
     def get_options(self):
         opts = super().get_options()
         c_stds = ['none', 'c89', 'c99', 'c11']
-        opts.update({'c_std': coredata.UserComboOption('C language standard to use',
-                                                       c_stds,
-                                                       'none')})
+        opts.update({
+            'std': coredata.UserComboOption(
+                'C language standard to use',
+                c_stds,
+                'none',
+            ),
+        })
         return opts
 
     def get_option_compile_args(self, options):
         args = []
-        std = options['c_std']
+        std = options['std']
         if std.value == 'c89':
             mlog.warning("ICL doesn't explicitly implement c89, setting the standard to 'none', which is close.", once=True)
         elif std.value != 'none':
@@ -367,14 +402,18 @@ class ArmCCompiler(ArmCompiler, CCompiler):
 
     def get_options(self):
         opts = CCompiler.get_options(self)
-        opts.update({'c_std': coredata.UserComboOption('C language standard to use',
-                                                       ['none', 'c90', 'c99'],
-                                                       'none')})
+        opts.update({
+            'std': coredata.UserComboOption(
+                'C language standard to use',
+                ['none', 'c90', 'c99'],
+                'none',
+            ),
+        })
         return opts
 
     def get_option_compile_args(self, options):
         args = []
-        std = options['c_std']
+        std = options['std']
         if std.value != 'none':
             args.append('--' + std.value)
         return args
@@ -393,9 +432,13 @@ class CcrxCCompiler(CcrxCompiler, CCompiler):
 
     def get_options(self):
         opts = CCompiler.get_options(self)
-        opts.update({'c_std': coredata.UserComboOption('C language standard to use',
-                                                       ['none', 'c89', 'c99'],
-                                                       'none')})
+        opts.update({
+            'std': coredata.UserComboOption(
+                'C language standard to use',
+                ['none', 'c89', 'c99'],
+                'none',
+            ),
+        })
         return opts
 
     def get_no_stdinc_args(self):
@@ -403,7 +446,7 @@ class CcrxCCompiler(CcrxCompiler, CCompiler):
 
     def get_option_compile_args(self, options):
         args = []
-        std = options['c_std']
+        std = options['std']
         if std.value == 'c89':
             args.append('-lang=c')
         elif std.value == 'c99':

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1260,10 +1260,10 @@ def get_global_options(lang: str,
     """Retreive options that apply to all compilers for a given language."""
     description = 'Extra arguments passed to the {}'.format(lang)
     opts = {
-        lang + '_args': coredata.UserArrayOption(
+        'args': coredata.UserArrayOption(
             description + ' compiler',
             [], split_args=True, user_input=True, allow_dups=True),
-        lang + '_link_args': coredata.UserArrayOption(
+        'link_args': coredata.UserArrayOption(
             description + ' linker',
             [], split_args=True, user_input=True, allow_dups=True),
     }
@@ -1276,12 +1276,13 @@ def get_global_options(lang: str,
         comp.INVOKES_LINKER)
 
     for k, o in opts.items():
-        if k in properties:
+        user_k = lang + '_' + k
+        if user_k in properties:
             # Get from configuration files.
-            o.set_value(properties[k])
-        elif k == lang + '_args':
+            o.set_value(properties[user_k])
+        elif k == 'args':
             o.set_value(compile_args)
-        elif k == lang + '_link_args':
+        elif k == 'link_args':
             o.set_value(link_args)
 
     return opts

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -167,36 +167,45 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
 
     def get_options(self):
         opts = CPPCompiler.get_options(self)
-        opts.update({'cpp_eh': coredata.UserComboOption('C++ exception handling type.',
-                                                        ['none', 'default', 'a', 's', 'sc'],
-                                                        'default'),
-                     'cpp_rtti': coredata.UserBooleanOption('Enable RTTI', True),
-                     'cpp_std': coredata.UserComboOption('C++ language standard to use',
-                                                         ['none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z', 'c++2a',
-                                                          'gnu++11', 'gnu++14', 'gnu++17', 'gnu++1z', 'gnu++2a'],
-                                                         'none')})
+        opts.update({
+            'eh': coredata.UserComboOption(
+                'C++ exception handling type.',
+                ['none', 'default', 'a', 's', 'sc'],
+                'default',
+            ),
+            'rtti': coredata.UserBooleanOption('Enable RTTI', True),
+            'std': coredata.UserComboOption(
+                'C++ language standard to use',
+                ['none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z', 'c++2a',
+                 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++1z', 'gnu++2a'],
+                'none',
+            ),
+        })
         if self.info.is_windows() or self.info.is_cygwin():
             opts.update({
-                'cpp_winlibs': coredata.UserArrayOption('Standard Win libraries to link against',
-                                                        gnu_winlibs), })
+                'winlibs': coredata.UserArrayOption(
+                    'Standard Win libraries to link against',
+                    gnu_winlibs,
+                ),
+            })
         return opts
 
     def get_option_compile_args(self, options):
         args = []
-        std = options['cpp_std']
+        std = options['std']
         if std.value != 'none':
             args.append(self._find_best_cpp_std(std.value))
 
-        non_msvc_eh_options(options['cpp_eh'].value, args)
+        non_msvc_eh_options(options['eh'].value, args)
 
-        if not options['cpp_rtti'].value:
+        if not options['rtti'].value:
             args.append('-fno-rtti')
 
         return args
 
     def get_option_link_args(self, options):
         if self.info.is_windows() or self.info.is_cygwin():
-            return options['cpp_winlibs'].value[:]
+            return options['winlibs'].value[:]
         return []
 
     def language_stdlib_only_link_flags(self):
@@ -220,7 +229,7 @@ class EmscriptenCPPCompiler(EmscriptenMixin, LinkerEnvVarsMixin, ClangCPPCompile
 
     def get_option_compile_args(self, options):
         args = []
-        std = options['cpp_std']
+        std = options['std']
         if std.value != 'none':
             args.append(self._find_best_cpp_std(std.value))
         return args
@@ -239,22 +248,30 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
 
     def get_options(self):
         opts = CPPCompiler.get_options(self)
-        opts.update({'cpp_eh': coredata.UserComboOption('C++ exception handling type.',
-                                                        ['none', 'default', 'a', 's', 'sc'],
-                                                        'default'),
-                     'cpp_std': coredata.UserComboOption('C++ language standard to use',
-                                                         ['none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17',
-                                                          'gnu++98', 'gnu++03', 'gnu++11', 'gnu++14', 'gnu++17'],
-                                                         'none')})
+        opts.update({
+            'eh': coredata.UserComboOption(
+                'C++ exception handling type.',
+                ['none', 'default', 'a', 's', 'sc'],
+                'default',
+            ),
+            'std': coredata.UserComboOption(
+                'C++ language standard to use',
+                [
+                    'none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17',
+                    'gnu++98', 'gnu++03', 'gnu++11', 'gnu++14', 'gnu++17',
+                ],
+                'none',
+            ),
+        })
         return opts
 
     def get_option_compile_args(self, options):
         args = []
-        std = options['cpp_std']
+        std = options['std']
         if std.value != 'none':
             args.append('-std=' + std.value)
 
-        non_msvc_eh_options(options['cpp_eh'].value, args)
+        non_msvc_eh_options(options['eh'].value, args)
 
         return args
 
@@ -275,40 +292,51 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
 
     def get_options(self):
         opts = CPPCompiler.get_options(self)
-        opts.update({'cpp_eh': coredata.UserComboOption('C++ exception handling type.',
-                                                        ['none', 'default', 'a', 's', 'sc'],
-                                                        'default'),
-                     'cpp_rtti': coredata.UserBooleanOption('Enable RTTI', True),
-                     'cpp_std': coredata.UserComboOption('C++ language standard to use',
-                                                         ['none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z', 'c++2a',
-                                                          'gnu++03', 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++1z', 'gnu++2a'],
-                                                         'none'),
-                     'cpp_debugstl': coredata.UserBooleanOption('STL debug mode',
-                                                                False)})
+        opts.update({
+            'eh': coredata.UserComboOption(
+                'C++ exception handling type.',
+                ['none', 'default', 'a', 's', 'sc'],
+                'default',
+            ),
+            'rtti': coredata.UserBooleanOption('Enable RTTI', True),
+            'std': coredata.UserComboOption(
+                'C++ language standard to use',
+                ['none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z', 'c++2a',
+                'gnu++03', 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++1z', 'gnu++2a'],
+                'none',
+            ),
+            'debugstl': coredata.UserBooleanOption(
+                'STL debug mode',
+                False,
+            )
+        })
         if self.info.is_windows() or self.info.is_cygwin():
             opts.update({
-                'cpp_winlibs': coredata.UserArrayOption('Standard Win libraries to link against',
-                                                        gnu_winlibs), })
+                'winlibs': coredata.UserArrayOption(
+                    'Standard Win libraries to link against',
+                    gnu_winlibs,
+                ),
+            })
         return opts
 
     def get_option_compile_args(self, options):
         args = []
-        std = options['cpp_std']
+        std = options['std']
         if std.value != 'none':
             args.append(self._find_best_cpp_std(std.value))
 
-        non_msvc_eh_options(options['cpp_eh'].value, args)
+        non_msvc_eh_options(options['eh'].value, args)
 
-        if not options['cpp_rtti'].value:
+        if not options['rtti'].value:
             args.append('-fno-rtti')
 
-        if options['cpp_debugstl'].value:
+        if options['debugstl'].value:
             args.append('-D_GLIBCXX_DEBUG=1')
         return args
 
     def get_option_link_args(self, options):
         if self.info.is_windows() or self.info.is_cygwin():
-            return options['cpp_winlibs'].value[:]
+            return options['winlibs'].value[:]
         return []
 
     def get_pch_use_args(self, pch_dir, header):
@@ -337,15 +365,25 @@ class ElbrusCPPCompiler(GnuCPPCompiler, ElbrusCompiler):
     # It does not support c++/gnu++ 17 and 1z, but still does support 0x, 1y, and gnu++98.
     def get_options(self):
         opts = CPPCompiler.get_options(self)
-        opts.update({'cpp_eh': coredata.UserComboOption('C++ exception handling type.',
-                                                        ['none', 'default', 'a', 's', 'sc'],
-                                                        'default'),
-                     'cpp_std': coredata.UserComboOption('C++ language standard to use',
-                                                         ['none', 'c++98', 'c++03', 'c++0x', 'c++11', 'c++14', 'c++1y',
-                                                          'gnu++98', 'gnu++03', 'gnu++0x', 'gnu++11', 'gnu++14', 'gnu++1y'],
-                                                         'none'),
-                     'cpp_debugstl': coredata.UserBooleanOption('STL debug mode',
-                                                                False)})
+        opts.update({
+            'eh': coredata.UserComboOption(
+                'C++ exception handling type.',
+                ['none', 'default', 'a', 's', 'sc'],
+                'default',
+            ),
+            'std': coredata.UserComboOption(
+                'C++ language standard to use',
+                [
+                    'none', 'c++98', 'c++03', 'c++0x', 'c++11', 'c++14', 'c++1y',
+                    'gnu++98', 'gnu++03', 'gnu++0x', 'gnu++11', 'gnu++14', 'gnu++1y',
+                ],
+                'none',
+            ),
+            'debugstl': coredata.UserBooleanOption(
+                'STL debug mode',
+                False,
+            ),
+        })
         return opts
 
     # Elbrus C++ compiler does not have lchmod, but there is only linker warning, not compiler error.
@@ -361,13 +399,13 @@ class ElbrusCPPCompiler(GnuCPPCompiler, ElbrusCompiler):
     # Elbrus C++ compiler does not support RTTI, so don't check for it.
     def get_option_compile_args(self, options):
         args = []
-        std = options['cpp_std']
+        std = options['std']
         if std.value != 'none':
             args.append(self._find_best_cpp_std(std.value))
 
-        non_msvc_eh_options(options['cpp_eh'].value, args)
+        non_msvc_eh_options(options['eh'].value, args)
 
-        if options['cpp_debugstl'].value:
+        if options['debugstl'].value:
             args.append('-D_GLIBCXX_DEBUG=1')
         return args
 
@@ -400,31 +438,36 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
             c_stds += ['c++17']
         if version_compare(self.version, '>=17.0.0'):
             g_stds += ['gnu++14']
-        opts.update({'cpp_eh': coredata.UserComboOption('C++ exception handling type.',
-                                                        ['none', 'default', 'a', 's', 'sc'],
-                                                        'default'),
-                     'cpp_rtti': coredata.UserBooleanOption('Enable RTTI', True),
-                     'cpp_std': coredata.UserComboOption('C++ language standard to use',
-                                                         ['none'] + c_stds + g_stds,
-                                                         'none'),
-                     'cpp_debugstl': coredata.UserBooleanOption('STL debug mode',
-                                                                False)})
+        opts.update({
+            'eh': coredata.UserComboOption(
+                'C++ exception handling type.',
+                ['none', 'default', 'a', 's', 'sc'],
+                'default',
+            ),
+            'rtti': coredata.UserBooleanOption('Enable RTTI', True),
+            'std': coredata.UserComboOption(
+                'C++ language standard to use',
+                ['none'] + c_stds + g_stds,
+                'none',
+            ),
+            'debugstl': coredata.UserBooleanOption('STL debug mode', False),
+        })
         return opts
 
     def get_option_compile_args(self, options):
         args = []
-        std = options['cpp_std']
+        std = options['std']
         if std.value != 'none':
             remap_cpp03 = {
                 'c++03': 'c++98',
                 'gnu++03': 'gnu++98'
             }
             args.append('-std=' + remap_cpp03.get(std.value, std.value))
-        if options['cpp_eh'].value == 'none':
+        if options['eh'].value == 'none':
             args.append('-fno-exceptions')
-        if not options['cpp_rtti'].value:
+        if not options['rtti'].value:
             args.append('-fno-rtti')
-        if options['cpp_debugstl'].value:
+        if options['debugstl'].value:
             args.append('-D_GLIBCXX_DEBUG=1')
         return args
 
@@ -449,24 +492,32 @@ class VisualStudioLikeCPPCompilerMixin:
     }
 
     def get_option_link_args(self, options):
-        return options['cpp_winlibs'].value[:]
+        return options['winlibs'].value[:]
 
     def _get_options_impl(self, opts, cpp_stds: T.List[str]):
-        opts.update({'cpp_eh': coredata.UserComboOption('C++ exception handling type.',
-                                                        ['none', 'default', 'a', 's', 'sc'],
-                                                        'default'),
-                     'cpp_rtti': coredata.UserBooleanOption('Enable RTTI', True),
-                     'cpp_std': coredata.UserComboOption('C++ language standard to use',
-                                                         cpp_stds,
-                                                         'none'),
-                     'cpp_winlibs': coredata.UserArrayOption('Windows libs to link against.',
-                                                             msvc_winlibs)})
+        opts.update({
+            'eh': coredata.UserComboOption(
+                'C++ exception handling type.',
+                ['none', 'default', 'a', 's', 'sc'],
+                'default',
+            ),
+            'rtti': coredata.UserBooleanOption('Enable RTTI', True),
+            'std': coredata.UserComboOption(
+                'C++ language standard to use',
+                cpp_stds,
+                'none',
+            ),
+            'winlibs': coredata.UserArrayOption(
+                'Windows libs to link against.',
+                msvc_winlibs,
+            ),
+        })
         return opts
 
     def get_option_compile_args(self, options):
         args = []
 
-        eh = options['cpp_eh']
+        eh = options['eh']
         if eh.value == 'default':
             args.append('/EHsc')
         elif eh.value == 'none':
@@ -474,10 +525,10 @@ class VisualStudioLikeCPPCompilerMixin:
         else:
             args.append('/EH' + eh.value)
 
-        if not options['cpp_rtti'].value:
+        if not options['rtti'].value:
             args.append('/GR-')
 
-        permissive, ver = self.VC_VERSION_MAP[options['cpp_std'].value]
+        permissive, ver = self.VC_VERSION_MAP[options['std'].value]
 
         if ver is not None:
             args.append('/std:c++{}'.format(ver))
@@ -504,17 +555,17 @@ class CPP11AsCPP14Mixin:
         # which means setting the C++ standard version to C++14, in compilers that support it
         # (i.e., after VS2015U3)
         # if one is using anything before that point, one cannot set the standard.
-        if options['cpp_std'].value in {'vc++11', 'c++11'}:
+        if options['std'].value in {'vc++11', 'c++11'}:
             mlog.warning(self.id, 'does not support C++11;',
                          'attempting best effort; setting the standard to C++14', once=True)
             # Don't mutate anything we're going to change, we need to use
             # deepcopy since we're messing with members, and we can't simply
             # copy the members because the option proxy doesn't support it.
             options = copy.deepcopy(options)
-            if options['cpp_std'].value == 'vc++11':
-                options['cpp_std'].value = 'vc++14'
+            if options['std'].value == 'vc++11':
+                options['std'].value = 'vc++14'
             else:
-                options['cpp_std'].value = 'c++14'
+                options['std'].value = 'c++14'
         return super().get_option_compile_args(options)
 
 
@@ -537,10 +588,10 @@ class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixi
         return self._get_options_impl(super().get_options(), cpp_stds)
 
     def get_option_compile_args(self, options):
-        if options['cpp_std'].value != 'none' and version_compare(self.version, '<19.00.24210'):
+        if options['std'].value != 'none' and version_compare(self.version, '<19.00.24210'):
             mlog.warning('This version of MSVC does not support cpp_std arguments')
             options = copy.copy(options)
-            options['cpp_std'].value = 'none'
+            options['std'].value = 'none'
 
         args = super().get_option_compile_args(options)
 
@@ -588,14 +639,18 @@ class ArmCPPCompiler(ArmCompiler, CPPCompiler):
 
     def get_options(self):
         opts = CPPCompiler.get_options(self)
-        opts.update({'cpp_std': coredata.UserComboOption('C++ language standard to use',
-                                                         ['none', 'c++03', 'c++11'],
-                                                         'none')})
+        opts.update({
+            'std': coredata.UserComboOption(
+                'C++ language standard to use',
+                ['none', 'c++03', 'c++11'],
+                'none',
+            ),
+        })
         return opts
 
     def get_option_compile_args(self, options):
         args = []
-        std = options['cpp_std']
+        std = options['std']
         if std.value == 'c++11':
             args.append('--cpp11')
         elif std.value == 'c++03':

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -184,14 +184,18 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
             fortran_stds += ['f2008']
         if version_compare(self.version, '>=8.0.0'):
             fortran_stds += ['f2018']
-        opts.update({'fortran_std': coredata.UserComboOption('Fortran language standard to use',
-                                                             ['none'] + fortran_stds,
-                                                             'none')})
+        opts.update({
+            'std': coredata.UserComboOption(
+                'Fortran language standard to use',
+                ['none'] + fortran_stds,
+                'none',
+            ),
+        })
         return opts
 
     def get_option_compile_args(self, options) -> T.List[str]:
         args = []
-        std = options['fortran_std']
+        std = options['std']
         if std.value != 'none':
             args.append('-std=' + std.value)
         return args
@@ -290,14 +294,18 @@ class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
     def get_options(self):
         opts = FortranCompiler.get_options(self)
         fortran_stds = ['legacy', 'f95', 'f2003', 'f2008', 'f2018']
-        opts.update({'fortran_std': coredata.UserComboOption('Fortran language standard to use',
-                                                             ['none'] + fortran_stds,
-                                                             'none')})
+        opts.update({
+            'std': coredata.UserComboOption(
+                'Fortran language standard to use',
+                ['none'] + fortran_stds,
+                'none',
+            ),
+        })
         return opts
 
     def get_option_compile_args(self, options) -> T.List[str]:
         args = []
-        std = options['fortran_std']
+        std = options['std']
         stds = {'legacy': 'none', 'f95': 'f95', 'f2003': 'f03', 'f2008': 'f08', 'f2018': 'f18'}
         if std.value != 'none':
             args.append('-stand=' + stds[std.value])
@@ -340,14 +348,18 @@ class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
     def get_options(self):
         opts = FortranCompiler.get_options(self)
         fortran_stds = ['legacy', 'f95', 'f2003', 'f2008', 'f2018']
-        opts.update({'fortran_std': coredata.UserComboOption('Fortran language standard to use',
-                                                             ['none'] + fortran_stds,
-                                                             'none')})
+        opts.update({
+            'std': coredata.UserComboOption(
+                'Fortran language standard to use',
+                ['none'] + fortran_stds,
+                'none',
+            ),
+        })
         return opts
 
     def get_option_compile_args(self, options) -> T.List[str]:
         args = []
-        std = options['fortran_std']
+        std = options['std']
         stds = {'legacy': 'none', 'f95': 'f95', 'f2003': 'f03', 'f2008': 'f08', 'f2018': 'f18'}
         if std.value != 'none':
             args.append('/stand:' + stds[std.value])

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -773,7 +773,7 @@ class Environment:
         elif isinstance(comp_class.LINKER_PREFIX, list):
             check_args = comp_class.LINKER_PREFIX + ['/logo'] + comp_class.LINKER_PREFIX + ['--version']
 
-        check_args += self.coredata.compiler_options[for_machine][comp_class.language + '_args'].value
+        check_args += self.coredata.compiler_options[for_machine][comp_class.language]['args'].value
 
         override = []  # type: T.List[str]
         value = self.lookup_binary_entry(for_machine, comp_class.language + '_ld')
@@ -835,7 +835,7 @@ class Environment:
         """
         self.coredata.add_lang_args(comp_class.language, comp_class, for_machine, self)
         extra_args = T.cast(T.List[str], extra_args or [])
-        extra_args += self.coredata.compiler_options[for_machine][comp_class.language + '_args'].value
+        extra_args += self.coredata.compiler_options[for_machine][comp_class.language]['args'].value
 
         if isinstance(comp_class.LINKER_PREFIX, str):
             check_args = [comp_class.LINKER_PREFIX + '--version'] + extra_args

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -97,9 +97,9 @@ class Conf:
             else:
                 print('{0:{width[0]}} {1:{width[1]}} {3}'.format(*line, width=col_widths))
 
-    def split_options_per_subproject(self, options):
+    def split_options_per_subproject(self, options_iter):
         result = {}
-        for k, o in options.items():
+        for k, o in options_iter:
             subproject = ''
             if ':' in k:
                 subproject, optname = k.split(':')
@@ -211,10 +211,15 @@ class Conf:
                 return 'build.' + k
             return k[:idx + 1] + 'build.' + k[idx + 1:]
 
-        core_options = self.split_options_per_subproject(core_options)
-        host_compiler_options = self.split_options_per_subproject(self.coredata.compiler_options.host)
-        build_compiler_options = self.split_options_per_subproject({insert_build_prefix(k): o for k, o in self.coredata.compiler_options.build.items()})
-        project_options = self.split_options_per_subproject(self.coredata.user_options)
+        core_options = self.split_options_per_subproject(core_options.items())
+        host_compiler_options = self.split_options_per_subproject(
+            self.coredata.flatten_lang_iterator(
+                self.coredata.compiler_options.host.items()))
+        build_compiler_options = self.split_options_per_subproject(
+            self.coredata.flatten_lang_iterator(
+                (insert_build_prefix(k), o)
+                for k, o in self.coredata.compiler_options.build.items()))
+        project_options = self.split_options_per_subproject(self.coredata.user_options.items())
         show_build_options = self.default_values_only or self.build.environment.is_cross_build()
 
         self.add_section('Main project options')

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -253,9 +253,16 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
     )
     add_keys(coredata.backend_options, 'backend')
     add_keys(coredata.base_options, 'base')
-    add_keys(coredata.compiler_options.host, 'compiler', machine='host')
     add_keys(
-        {'build.' + k: o for k, o in coredata.compiler_options.build.items()},
+        dict(coredata.flatten_lang_iterator(coredata.compiler_options.host.items())),
+        'compiler',
+        machine='host',
+    )
+    add_keys(
+        {
+            'build.' + k: o for k, o in
+            coredata.flatten_lang_iterator(coredata.compiler_options.build.items())
+        },
         'compiler',
         machine='build',
     )

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -469,8 +469,8 @@ class Rewriter:
             **{'build.' + k: o for k, o in cdata.builtins_per_machine.build.items()},
             **cdata.backend_options,
             **cdata.base_options,
-            **cdata.compiler_options.host,
-            **{'build.' + k: o for k, o in cdata.compiler_options.build.items()},
+            **(dict(cdata.flatten_lang_iterator(cdata.compiler_options.host.items()))),
+            **{'build.' + k: o for k, o in cdata.flatten_lang_iterator(cdata.compiler_options.build.items())},
             **cdata.user_options,
         }
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -126,7 +126,7 @@ def get_fake_env(sdir='', bdir=None, prefix='', opts=None):
     if opts is None:
         opts = get_fake_options(prefix)
     env = Environment(sdir, bdir, opts)
-    env.coredata.compiler_options.host['c_args'] = FakeCompilerOptions()
+    env.coredata.compiler_options.host['c']['args'] = FakeCompilerOptions()
     env.machines.host.cpu_family = 'x86_64' # Used on macOS inside find_library
     return env
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -836,7 +836,7 @@ class InternalTests(unittest.TestCase):
             env = get_fake_env()
             compiler = env.detect_c_compiler(MachineChoice.HOST)
             env.coredata.compilers.host = {'c': compiler}
-            env.coredata.compiler_options.host['c_link_args'] = FakeCompilerOptions()
+            env.coredata.compiler_options.host['c']['link_args'] = FakeCompilerOptions()
             p1 = Path(tmpdir) / '1'
             p2 = Path(tmpdir) / '2'
             p1.mkdir()
@@ -3671,11 +3671,11 @@ recommended as it is not supported on some platforms''')
         # c_args value should be parsed with split_args
         self.init(testdir, extra_args=['-Dc_args=-Dfoo -Dbar "-Dthird=one two"'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.compiler_options.host['c_args'].value, ['-Dfoo', '-Dbar', '-Dthird=one two'])
+        self.assertEqual(obj.compiler_options.host['c']['args'].value, ['-Dfoo', '-Dbar', '-Dthird=one two'])
 
         self.setconf('-Dc_args="foo bar" one two')
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.compiler_options.host['c_args'].value, ['foo bar', 'one', 'two'])
+        self.assertEqual(obj.compiler_options.host['c']['args'].value, ['foo bar', 'one', 'two'])
         self.wipe()
 
         self.init(testdir, extra_args=['-Dset_percent_opt=myoption%'])
@@ -3693,7 +3693,7 @@ recommended as it is not supported on some platforms''')
             self.assertEqual(obj.builtins['bindir'].value, 'bar')
             self.assertEqual(obj.builtins['buildtype'].value, 'release')
             self.assertEqual(obj.base_options['b_sanitize'].value, 'thread')
-            self.assertEqual(obj.compiler_options.host['c_args'].value, ['-Dbar'])
+            self.assertEqual(obj.compiler_options.host['c']['args'].value, ['-Dbar'])
             self.setconf(['--bindir=bar', '--bindir=foo',
                           '-Dbuildtype=release', '-Dbuildtype=plain',
                           '-Db_sanitize=thread', '-Db_sanitize=address',
@@ -3702,7 +3702,7 @@ recommended as it is not supported on some platforms''')
             self.assertEqual(obj.builtins['bindir'].value, 'foo')
             self.assertEqual(obj.builtins['buildtype'].value, 'plain')
             self.assertEqual(obj.base_options['b_sanitize'].value, 'address')
-            self.assertEqual(obj.compiler_options.host['c_args'].value, ['-Dfoo'])
+            self.assertEqual(obj.compiler_options.host['c']['args'].value, ['-Dfoo'])
             self.wipe()
         except KeyError:
             # Ignore KeyError, it happens on CI for compilers that does not
@@ -5486,8 +5486,6 @@ class LinuxlikeTests(BasePlatformTests):
             self.assertEqual(Oargs, [Oflag, '-O0'])
 
     def _test_stds_impl(self, testdir, compiler, p: str):
-        lang_std = p + '_std'
-
         has_cpp17 = (compiler.get_id() not in {'clang', 'gcc'} or
                      compiler.get_id() == 'clang' and _clang_at_least(compiler, '>=5.0.0', '>=9.1') or
                      compiler.get_id() == 'gcc' and version_compare(compiler.version, '>=5.0.0'))
@@ -5500,7 +5498,8 @@ class LinuxlikeTests(BasePlatformTests):
         # Check that all the listed -std=xxx options for this compiler work just fine when used
         # https://en.wikipedia.org/wiki/Xcode#Latest_versions
         # https://www.gnu.org/software/gcc/projects/cxx-status.html
-        for v in compiler.get_options()[lang_std].choices:
+        for v in compiler.get_options()['std'].choices:
+            lang_std = p + '_std'
             # we do it like this to handle gnu++17,c++17 and gnu17,c17 cleanly
             # thus, C++ first
             if '++17' in v and not has_cpp17:


### PR DESCRIPTION
A current rather untyped storage of options is one of the things that
contributes to the options code being so complex. This takes a small
step in synching down by storing the compiler options in dicts per
language.

Future work might be replacing the langauge strings with an enum, and
defaultdict with a custom struct, just like `PerMachine` and
`MachineChoice`.