### PR TITLE
add optional `--only test(s)` option to run_project_tests.py. 

### DIFF
--- a/docs/markdown/snippets/select_run_project_tests.md
+++ b/docs/markdown/snippets/select_run_project_tests.md
@@ -1,0 +1,10 @@
+## added `--only test(s)` option to run_project_tests.py
+
+Individual tests or a list of tests from run_project_tests.py can be selected like:
+```
+python run_project_tests.py --only fortran
+
+python run_project_tests.py --only fortran python3
+```
+
+This assists Meson development by only running the tests for the portion of Meson being worked on during local development.


### PR DESCRIPTION
this PR adds an optional `--only test(s)` option to run_project_tests.py. 

Individual tests or a list of tests from run_project_tests.py can be selected like:
```
python run_project_tests.py --only fortran

python run_project_tests.py --only fortran python3
```

 This assists Meson development by only running the tests for the portion of Meson being worked on during local development, particularly with slow compilers like Intel.

---

Added type hinting relevant to this change

---

improved the `gather_tests()` [algorithm](https://github.com/mesonbuild/meson/compare/master...scivision:master#diff-d9f7c80135592b1a61e38f3133a89499R438) by only considering directories.

improved the code style by using more descriptive variable names, and by [not reassigning the value of an iterated value](https://github.com/mesonbuild/meson/compare/master...scivision:master#diff-d9f7c80135592b1a61e38f3133a89499R862)