### PR TITLE
New builtin-option to support partial linking for shared libraries

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -82,6 +82,7 @@ Using the option as-is with no prefix affects all machines. For example:
 | warning_level {0, 1, 2, 3}           | 1             | Set the warning level. From 0 = none to 3 = highest            | no             |
 | werror                               | false         | Treat warnings as errors                                       | no             |
 | wrap_mode {default, nofallback,<br>nodownload, forcefallback} | default | Wrap mode to use                            | no             |
+| sharedlib_linkmodel {standard, partial} | standard   | Shared library link model. standard linking or partial linking | no             |
 
 ## Base options
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -607,9 +607,10 @@ class Backend:
         # file. We want these to override all the defaults, but not the
         # per-target compile args.
         commands += self.environment.coredata.get_external_args(target.for_machine, compiler.get_language())
-        # Always set -fPIC for shared libraries
+        # Always set -fPIC for shared libraries unless partially linked
         if isinstance(target, build.SharedLibrary):
-            commands += compiler.get_pic_args()
+            if self.get_option_for_target('sharedlib_linkmodel', target) != 'partial':
+                commands += compiler.get_pic_args()
         # Set -fPIC for static libraries by default unless explicitly disabled
         if isinstance(target, build.StaticLibrary) and target.pic:
             commands += compiler.get_pic_args()

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2322,17 +2322,26 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             if target.pie:
                 commands += linker.get_pie_link_args()
         elif isinstance(target, build.SharedLibrary):
+            is_linkmodel_partial = (self.get_option_for_target('sharedlib_linkmodel', target) == 'partial')
             if isinstance(target, build.SharedModule):
                 options = self.environment.coredata.base_options
                 commands += linker.get_std_shared_module_link_args(options)
+            elif is_linkmodel_partial:
+                if hasattr(linker, 'get_std_partial_lib_link_args'):
+                    commands += linker.get_std_partial_lib_link_args()
+                else:
+                    mlog.warning('The sharedlib_linkmodel option is set to partial, '
+                                 'but %s does not have support for '
+                                 'shared library partial linking' % linker.get_id())
             else:
                 commands += linker.get_std_shared_lib_link_args()
-            # All shared libraries are PIC
-            commands += linker.get_pic_args()
-            # Add -Wl,-soname arguments on Linux, -install_name on OS X
-            commands += linker.get_soname_args(target.prefix, target.name, target.suffix,
-                                               target.soversion, target.darwin_versions,
-                                               isinstance(target, build.SharedModule))
+            if not is_linkmodel_partial:
+                # All shared libraries are PIC
+                commands += linker.get_pic_args()
+                # Add -Wl,-soname arguments on Linux, -install_name on OS X
+                commands += linker.get_soname_args(target.prefix, target.name, target.suffix,
+                                                   target.soversion, target.darwin_versions,
+                                                   isinstance(target, build.SharedModule))
             # This is only visited when building for Windows using either GCC or Visual Studio
             if target.vs_module_defs and hasattr(linker, 'gen_vs_module_defs_args'):
                 commands += linker.gen_vs_module_defs_args(target.vs_module_defs.rel_to_builddir(self.build_to_src))

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2326,15 +2326,16 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             if isinstance(target, build.SharedModule):
                 options = self.environment.coredata.base_options
                 commands += linker.get_std_shared_module_link_args(options)
-            elif is_linkmodel_partial:
-                if hasattr(linker, 'get_std_partial_lib_link_args'):
-                    commands += linker.get_std_partial_lib_link_args()
-                else:
-                    mlog.warning('The sharedlib_linkmodel option is set to partial, '
-                                 'but %s does not have support for '
-                                 'shared library partial linking' % linker.get_id())
             else:
-                commands += linker.get_std_shared_lib_link_args()
+                if is_linkmodel_partial:
+                    if hasattr(linker, 'get_std_partial_lib_link_args'):
+                        commands += linker.get_std_partial_lib_link_args()
+                    else:
+                        mlog.warning('The sharedlib_linkmodel option is set to partial, '
+                                     'but %s does not have support for '
+                                     'shared library partial linking' % linker.get_id())
+                else:
+                    commands += linker.get_std_shared_lib_link_args()
             if not is_linkmodel_partial:
                 # All shared libraries are PIC
                 commands += linker.get_pic_args()

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -2037,6 +2037,9 @@ class GnuCompiler(GnuLikeCompiler):
     def openmp_flags(self) -> List[str]:
         return ['-fopenmp']
 
+    def get_std_partial_lib_link_args(self):
+        return ['-Wl,-r', '-nostdlib']
+
 
 class PGICompiler:
     def __init__(self, compiler_type):

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -2238,6 +2238,9 @@ class ArmclangCompiler:
     def get_std_shared_lib_link_args(self):
         return []
 
+    def get_std_partial_lib_link_args(self):
+        return ['--partial']
+
     def get_pch_suffix(self):
         return 'gch'
 
@@ -2386,7 +2389,6 @@ class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
 
 
 class ArmCompiler:
-    # Functionality that is common to all ARM family compilers.
     def __init__(self, compiler_type):
         if not self.is_cross:
             raise EnvironmentException('armcc supports only cross-compilation.')
@@ -2424,6 +2426,9 @@ class ArmCompiler:
     # Override CCompiler.get_std_shared_lib_link_args
     def get_std_shared_lib_link_args(self):
         return []
+
+    def get_std_partial_lib_link_args(self):
+        return ['--partial']
 
     def get_pch_use_args(self, pch_dir, header):
         # FIXME: Add required arguments

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -945,6 +945,7 @@ builtin_options = OrderedDict([
     ('warning_level',   BuiltinOption(UserComboOption, 'Compiler warning level to use', '1', choices=['0', '1', '2', '3'])),
     ('werror',          BuiltinOption(UserBooleanOption, 'Treat warnings as errors', False)),
     ('wrap_mode',       BuiltinOption(UserComboOption, 'Wrap mode', 'default', choices=['default', 'nofallback', 'nodownload', 'forcefallback'])),
+    ('sharedlib_linkmodel', BuiltinOption(UserComboOption, 'Shared library link model', 'standard', choices=['standard', 'partial'])),
 ])
 
 builtin_options_per_machine = OrderedDict([


### PR DESCRIPTION
Added a new builtin-option called 'sharedlib-linkmodel' for being able to generate a partial linked object using a shared_library() target.
- when this option value is set to 'standard', the existing shared library linking method is used as is and is the default value.
- when this option value is set to 'partial', required compiler options for generating partial linked object will be selected and few of the 'standard' linking options are skipped.
Currently the support is added for armcc, armclang and gnu compilers, a warning will be generated if this option is set to 'partial' while using any other compilers.
