### PR TITLE
Skip `196 install_mode` project test on Windows

### DIFF
--- a/test cases/common/196 install_mode/meson.build
+++ b/test cases/common/196 install_mode/meson.build
@@ -1,6 +1,10 @@
 project('install_mode test', 'c',
   default_options : ['install_umask=027', 'libdir=libtest'])
 
+if build_machine.system() == 'windows'
+  error('MESON_SKIP_TEST: install_mode test requires a Unix-like OS')
+endif
+
 # confirm no regressions in install_data
 install_data('runscript.sh',
   install_dir : get_option('bindir'),


### PR DESCRIPTION
The corresponding *unit tests* are already skipped because they've been placed in `LinuxlikeTests`, but the project test is currently failing for me on Windows due to a missing `cp` executable.