### PR TITLE
sanitycheckc: avoid linking sanitycheckc when cross compiling

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1062,7 +1062,7 @@ You probably should put it in link_with instead.''')
                 msg += "Use the 'pic' option to static_library to build with PIC."
                 raise InvalidArguments(msg)
             if self.for_machine is not t.for_machine:
-                msg = 'Tried to mix libraries for machines {1} and {2} in target {!r}'.format(self.name, self.for_machine, t.for_machine)
+                msg = 'Tried to mix libraries for machines {} and {} in target {!r}'.format(self.for_machine, t.for_machine, self.name)
                 if self.environment.is_cross_build():
                     raise InvalidArguments(msg + ' This is not possible in a cross build.')
                 else:

--- a/mesonbuild/compilers/clike.py
+++ b/mesonbuild/compilers/clike.py
@@ -396,6 +396,8 @@ class CLikeCompiler:
         elif mode == 'link':
             # Add LDFLAGS from the env
             args += env.coredata.get_external_link_args(self.for_machine, self.language)
+
+        args += self.get_compiler_args_for_mode(mode)
         return args
 
     def _get_compiler_check_args(self, env, extra_args, dependencies, mode='compile'):

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1139,6 +1139,15 @@ class Compiler:
             suffix = 'obj'
         return os.path.join(dirname, 'output.' + suffix)
 
+    def get_compiler_args_for_mode(self, mode):
+        args = []
+        args += self.get_always_args()
+        if mode == 'compile':
+            args += self.get_compile_only_args()
+        if mode == 'preprocess':
+            args += self.get_preprocess_only_args()
+        return args
+
     @contextlib.contextmanager
     def compile(self, code, extra_args=None, *, mode='link', want_output=False):
         if extra_args is None:
@@ -1156,15 +1165,11 @@ class Compiler:
                 # Construct the compiler command-line
                 commands = CompilerArgs(self)
                 commands.append(srcname)
-                commands += self.get_always_args()
-                if mode == 'compile':
-                    commands += self.get_compile_only_args()
                 # Preprocess mode outputs to stdout, so no output args
-                if mode == 'preprocess':
-                    commands += self.get_preprocess_only_args()
-                else:
+                if mode != 'preprocess':
                     output = self._get_compile_output(tmpdirname, mode)
                     commands += self.get_output_args(output)
+                commands.extend(self.get_compiler_args_for_mode(mode))
                 # extra_args must be last because it could contain '/link' to
                 # pass args to VisualStudio's linker. In that case everything
                 # in the command line after '/link' is given to the linker.


### PR DESCRIPTION
Note: we should consider also disabling linking (and running) in this
case even if `exe_wrapper` is set as it's entirely possible that
additional source code from the project is needed for a link to succeed
even if `exe_wrapper` is set.

This comes down to `self._get_basic_compiler_args()` not including `self.get_compile_only_args()` and `sanity_test_impl()` not using `self.compile()` (which pulls in `self.get_compile_only_args()` based on mode).

Fixes #5496