### PR TITLE
add optional `--only test(s)` option to run_project_tests.py.

### DIFF
--- a/docs/markdown/snippets/select_run_project_tests.md
+++ b/docs/markdown/snippets/select_run_project_tests.md
@@ -1,0 +1,10 @@
+## added `--only test(s)` option to run_project_tests.py
+
+Individual tests or a list of tests from run_project_tests.py can be selected like:
+```
+python run_project_tests.py --only fortran
+
+python run_project_tests.py --only fortran python3
+```
+
+This assists Meson development by only running the tests for the portion of Meson being worked on during local development.

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import List, Tuple
 import itertools
 import os
 import subprocess
@@ -434,12 +435,12 @@ def _run_test(testdir, test_build_dir, install_dir, extra_args, compiler, backen
     return TestResult(validate_install(testdir, install_dir, compiler, builddata.environment),
                       BuildStep.validate, stdo, stde, mesonlog, gen_time, build_time, test_time)
 
-def gather_tests(testdir: Path):
-    tests = [t.name for t in testdir.glob('*')]
-    tests = [t for t in tests if not t.startswith('.')] # Filter non-tests files (dot files, etc)
-    testlist = [(int(t.split()[0]), t) for t in tests]
-    testlist.sort()
-    tests = [testdir / t[1] for t in testlist]
+def gather_tests(testdir: Path) -> List[Path]:
+    test_names = [t.name for t in testdir.glob('*') if t.is_dir()]
+    test_names = [t for t in test_names if not t.startswith('.')] # Filter non-tests files (dot files, etc)
+    test_nums = [(int(t.split()[0]), t) for t in test_names]
+    test_nums.sort()
+    tests = [testdir / t[1] for t in test_nums]
     return tests
 
 def have_d_compiler():
@@ -587,7 +588,18 @@ def should_skip_rust() -> bool:
             return True
     return False
 
-def detect_tests_to_run():
+def detect_tests_to_run(only: List[str]) -> List[Tuple[str, List[Path], bool]]:
+    """
+    Parameters
+    ----------
+    only: list of str, optional
+        specify names of tests to run
+
+    Returns
+    -------
+    gathered_tests: list of tuple of str, list of pathlib.Path, bool
+        tests to run
+    """
     # Name, subdirectory, skip condition.
     all_tests = [
         ('cmake', 'cmake', not shutil.which('cmake') or (os.environ.get('compiler') == 'msvc2015' and under_ci)),
@@ -618,6 +630,11 @@ def detect_tests_to_run():
         ('frameworks', 'frameworks', False),
         ('nasm', 'nasm', False),
     ]
+
+    if only:
+        names = [t[0] for t in all_tests]
+        ind = [names.index(o) for o in only]
+        all_tests = [all_tests[i] for i in ind]
     gathered_tests = [(name, gather_tests(Path('test cases', subdir)), skip) for name, subdir, skip in all_tests]
     return gathered_tests
 
@@ -846,6 +863,7 @@ if __name__ == '__main__':
                         choices=backendlist)
     parser.add_argument('--failfast', action='store_true',
                         help='Stop running if test case fails')
+    parser.add_argument('--only', help='name of test(s) to run', nargs='+')
     options = parser.parse_args()
     setup_commands(options.backend)
 
@@ -856,7 +874,7 @@ if __name__ == '__main__':
     check_format()
     check_meson_commands_work()
     try:
-        all_tests = detect_tests_to_run()
+        all_tests = detect_tests_to_run(options.only)
         (passing_tests, failing_tests, skipped_tests) = run_tests(all_tests, 'meson-test-run', options.failfast, options.extra_args)
     except StopException:
         pass
@@ -871,8 +889,8 @@ if __name__ == '__main__':
             except UnicodeError:
                 print(l.encode('ascii', errors='replace').decode(), '\n')
     for name, dirs, _ in all_tests:
-        dirs = (x.name for x in dirs)
-        for k, g in itertools.groupby(dirs, key=lambda x: x.split()[0]):
+        dir_names = (x.name for x in dirs)
+        for k, g in itertools.groupby(dir_names, key=lambda x: x.split()[0]):
             tests = list(g)
             if len(tests) != 1:
                 print('WARNING: The %s suite contains duplicate "%s" tests: "%s"' % (name, k, '", "'.join(tests)))


### PR DESCRIPTION
this PR adds an optional `--only test(s)` option to run_project_tests.py. 

Individual tests or a list of tests from run_project_tests.py can be selected like:
```
python run_project_tests.py --only fortran

python run_project_tests.py --only fortran python3
```

 This assists Meson development by only running the tests for the portion of Meson being worked on during local development, particularly with slow compilers like Intel.

Intel compilers take over 3 *hours* to run all Meson tests, while with this `run_project_tests.py --only fortran` the Fortran tests take just a couple *minutes*
---

Added type hinting relevant to this change

---

improved the `gather_tests()` [algorithm](https://github.com/mesonbuild/meson/compare/master...scivision:only_test#diff-d9f7c80135592b1a61e38f3133a89499R438) by only considering directories.

improved the code style by using more descriptive variable names, and by [not reassigning the value of an iterated value](https://github.com/mesonbuild/meson/compare/master...scivision:only_test#diff-d9f7c80135592b1a61e38f3133a89499R862)


---
It appears the Azure failure are unrelated to this PR, as other PRs are getting the same errors.

```
vc2017x64vs  ninja: error: remove("manyfiles.d"): Invalid argument

clangclx64ninja meson.build:1:0: ERROR: Rust compiler rustc can not compile programs.

vc2019x64ninja  PermissionError: [Errno 13] The process cannot access the file because it is being used by another process: 'D:\\a\\1\\s\\b 3734637e31\\meson-logs\\testlog.json'
```

---

(transferred from #5498 due to opening that PR from wrong branch)