### PR TITLE
BUGFIX: Fortran: use, module, submodule with inline comment

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -38,8 +38,8 @@ from ..mesonlib import get_compiler_for_source, has_path_sep
 from .backends import CleanTrees
 from ..build import InvalidArguments
 
-FORTRAN_INCLUDE_PAT = r"#?include\s*['\"](\w+\.\w+)['\"]\s*$"
-FORTRAN_MODULE_PAT = r"\s*\bmodule\b\s+(\w+)"
+FORTRAN_INCLUDE_PAT = r"#?include\s*['\"](\w+\.\w+)['\"]"
+FORTRAN_MODULE_PAT = r"\s*\bmodule\b\s+(?!procedure)(\w+)"
 FORTRAN_SUBMOD_PAT = r"\s*submodule\s*\((\w+:?\w+)\)\s*(\w+)"
 FORTRAN_USE_PAT = r"\s*use,?\s*(?:non_intrinsic)?\s*(?:::)?\s*(\w+)"
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -38,7 +38,10 @@ from ..mesonlib import get_compiler_for_source, has_path_sep
 from .backends import CleanTrees
 from ..build import InvalidArguments
 
-FORTRAN_SUBMOD_PAT = r"\s*submodule\s*\((\w+:?\w+)\)\s*(\w+)\s*$"
+FORTRAN_INCLUDE_PAT = r"#?include\s*['\"](\w+\.\w+)['\"]\s*$"
+FORTRAN_MODULE_PAT = r"\s*\bmodule\b\s+(\w+)"
+FORTRAN_SUBMOD_PAT = r"\s*submodule\s*\((\w+:?\w+)\)\s*(\w+)"
+FORTRAN_USE_PAT = r"\s*use,?\s*(?:non_intrinsic)?\s*(?:::)?\s*(\w+)"
 
 if mesonlib.is_windows():
     quote_func = lambda s: '"{}"'.format(s)
@@ -1820,7 +1823,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             self.fortran_deps[target.get_basename()] = {}
             return
 
-        modre = re.compile(r"\s*\bmodule\b\s+(\w+)\s*$", re.IGNORECASE)
+        modre = re.compile(FORTRAN_MODULE_PAT, re.IGNORECASE)
         submodre = re.compile(FORTRAN_SUBMOD_PAT, re.IGNORECASE)
         module_files = {}
         submodule_files = {}
@@ -1860,7 +1863,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
 
         self.fortran_deps[target.get_basename()] = {**module_files, **submodule_files}
 
-    def get_fortran_deps(self, compiler: FortranCompiler, src: str, target) -> List[str]:
+    def get_fortran_deps(self, compiler: FortranCompiler, src: Path, target) -> List[str]:
         """
         Find all module and submodule needed by a Fortran target
         """
@@ -2750,7 +2753,7 @@ def load(build_dir):
     return obj
 
 
-def _scan_fortran_file_deps(src: str, srcdir: Path, dirname: Path, tdeps, compiler) -> List[str]:
+def _scan_fortran_file_deps(src: Path, srcdir: Path, dirname: Path, tdeps, compiler) -> List[str]:
     """
     scan a Fortran file for dependencies. Needs to be distinct from target
     to allow for recursion induced by `include` statements.er
@@ -2767,8 +2770,8 @@ def _scan_fortran_file_deps(src: str, srcdir: Path, dirname: Path, tdeps, compil
     * `submodre` is for Fortran >= 2008 `submodule`
     """
 
-    incre = re.compile(r"#?include\s*['\"](\w+\.\w+)['\"]\s*$", re.IGNORECASE)
-    usere = re.compile(r"\s*use,?\s*(?:non_intrinsic)?\s*(?:::)?\s*(\w+)", re.IGNORECASE)
+    incre = re.compile(FORTRAN_INCLUDE_PAT, re.IGNORECASE)
+    usere = re.compile(FORTRAN_USE_PAT, re.IGNORECASE)
     submodre = re.compile(FORTRAN_SUBMOD_PAT, re.IGNORECASE)
 
     mod_files = []
@@ -2816,7 +2819,7 @@ def _scan_fortran_file_deps(src: str, srcdir: Path, dirname: Path, tdeps, compil
                     parents = submodmatch.group(1).lower().split(':')
                     assert len(parents) in (1, 2), (
                         'submodule ancestry must be specified as'
-                        ' ancestor:parent but Meson found {}'.parents)
+                        ' ancestor:parent but Meson found {}'.format(parents))
 
                     ancestor_child = '_'.join(parents)
                     if ancestor_child not in tdeps:

--- a/test cases/fortran/12 submodule/a3.f90
+++ b/test cases/fortran/12 submodule/a3.f90
@@ -1,4 +1,4 @@
-submodule (a1:a2) a3
+submodule (a1:a2) a3  ! testing inline comment
 
 contains
 

--- a/test cases/fortran/15 include/inc1.f90
+++ b/test cases/fortran/15 include/inc1.f90
@@ -2,4 +2,4 @@
 real :: pi = 4.*atan(1.)
 real :: tau
 
-include "inc2.f90"
+include "inc2.f90"  ! testing inline comment

--- a/test cases/fortran/2 modules/comment_mod.f90
+++ b/test cases/fortran/2 modules/comment_mod.f90
@@ -1,4 +1,4 @@
-module line! inline comment
+module line ! inline comment
 implicit none
 
 real :: length

--- a/test cases/fortran/2 modules/comment_mod.f90
+++ b/test cases/fortran/2 modules/comment_mod.f90
@@ -1,0 +1,6 @@
+module line! inline comment
+implicit none
+
+real :: length
+
+end module line

--- a/test cases/fortran/2 modules/meson.build
+++ b/test cases/fortran/2 modules/meson.build
@@ -1,4 +1,4 @@
 project('modules', 'fortran')
 
-e = executable('modprog', 'stuff.f90', 'prog.f90')
+e = executable('modprog', 'mymod.f90', 'prog.f90', 'comment_mod.f90')
 test('moduletest', e)

--- a/test cases/fortran/2 modules/meson.build
+++ b/test cases/fortran/2 modules/meson.build
@@ -1,4 +1,7 @@
 project('modules', 'fortran')
 
-e = executable('modprog', 'mymod.f90', 'prog.f90', 'comment_mod.f90')
+commented = library('commented', 'comment_mod.f90')
+
+e = executable('modprog', 'mymod.f90', 'prog.f90',
+  link_with: commented)
 test('moduletest', e)

--- a/test cases/fortran/2 modules/mymod.f90
+++ b/test cases/fortran/2 modules/mymod.f90
@@ -1,0 +1,6 @@
+module circle
+implicit none
+
+real, parameter :: pi = 4.*atan(1.)
+real :: radius
+end module circle

--- a/test cases/fortran/2 modules/prog.f90
+++ b/test cases/fortran/2 modules/prog.f90
@@ -1,7 +1,11 @@
-PROGRAM prog
+use circle, only: pi
+use line, only: length
+implicit none
 
-use Circle
-IMPLICIT NONE
+print *,'pi=',pi
 
-END PROGRAM prog
+length = pi
+print *, length
+
+end program
 

--- a/test cases/fortran/2 modules/stuff.f90
+++ b/test cases/fortran/2 modules/stuff.f90
@@ -1,5 +1,0 @@
-MODULE Circle
-   REAL, PARAMETER :: Pi = 3.1415927
-   REAL :: radius
-END MODULE Circle
-

--- a/test cases/fortran/8 module names/test.f90
+++ b/test cases/fortran/8 module names/test.f90
@@ -1,5 +1,5 @@
 use mymod1
-use MyMod2
+use MyMod2  ! test inline comment
 
 implicit none
 


### PR DESCRIPTION
in response to #5513, tests for Fortran module name with inline comment.

The Fortran regex patterns for module, submodule and include were not correct--they could not tolerate inline comments.

1. apply fix to regex in ninjabackend.py
2. add inline comment tests for Fortran use, module, submodule, include
3. fix syntax error (unrelated, just saw it)
4. fix type hinting in the function (unrelated, just saw it)

Fixes #5513 