### PR TITLE
compilers: Fix bitcode and other options for objc code

### DIFF
--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -74,4 +74,3 @@ class ClangObjCCompiler(ClangCompiler, ObjCCompiler):
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
                           '3': default_warn_args + ['-Wextra', '-Wpedantic']}
-        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage']

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -75,4 +75,3 @@ class ClangObjCPPCompiler(ClangCompiler, ObjCPPCompiler):
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
                           '3': default_warn_args + ['-Wextra', '-Wpedantic']}
-        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage']

--- a/test cases/osx/7 bitcode/libbar.mm
+++ b/test cases/osx/7 bitcode/libbar.mm
@@ -1,0 +1,7 @@
+#import <stdio.h>
+#import "vis.h"
+
+int EXPORT_PUBLIC libbar(int arg) {
+  return 0;
+}
+

--- a/test cases/osx/7 bitcode/libfile.c
+++ b/test cases/osx/7 bitcode/libfile.c
@@ -1,0 +1,5 @@
+#include "vis.h"
+
+int EXPORT_PUBLIC libfunc() {
+    return 3;
+}

--- a/test cases/osx/7 bitcode/libfoo.m
+++ b/test cases/osx/7 bitcode/libfoo.m
@@ -1,0 +1,7 @@
+#import <stdio.h>
+#import "vis.h"
+
+int EXPORT_PUBLIC libfoo(int arg) {
+  return 0;
+}
+

--- a/test cases/osx/7 bitcode/meson.build
+++ b/test cases/osx/7 bitcode/meson.build
@@ -1,0 +1,10 @@
+project('bitcode test', 'c', 'objc', 'objcpp')
+
+both_libraries('alib', 'libfoo.m')
+shared_module('amodule', 'libfoo.m')
+
+both_libraries('blib', 'libbar.mm')
+shared_module('bmodule', 'libbar.mm')
+
+both_libraries('clib', 'libfile.c')
+shared_module('cmodule', 'libfile.c')

--- a/test cases/osx/7 bitcode/vis.h
+++ b/test cases/osx/7 bitcode/vis.h
@@ -1,0 +1,6 @@
+#if defined __GNUC__
+  #define EXPORT_PUBLIC __attribute__ ((visibility("default")))
+#else
+  #pragma message ("Compiler does not support symbol visibility.")
+  #define EXPORT_PUBLIC
+#endif


### PR DESCRIPTION
We were setting the base options for the Objective-C compiler manually, due to which options such as `b_bitcode` and `b_ndebug` were not getting set at all.

The base options here are the same as for C code with the Clang compiler, so just use the same inherited list.

Also expand the bitcode test to ObjC and ObjC++ so this doesn't happen again.