### PR TITLE
Add suffix options to cross files: resurrection

### DIFF
--- a/docs/markdown/Cross-compilation.md
+++ b/docs/markdown/Cross-compilation.md
@@ -150,6 +150,19 @@ binaries are not actually compatible. In such cases you may use the
 needs_exe_wrapper = true
 ```
 
+If necessary, you can override the file suffixes used for the various
+target types. This is particularly useful for
+[Emscripten](https://emscripten.org/), whose compiler chooses the
+output format based on the file extension.
+
+```ini
+[properties]
+exe_suffix = 'js'
+static_library_suffix = 'la'
+shared_library_suffix = 'js'
+shared_module_suffix = 'js'
+```
+
 The next bit is the definition of host and target machines. Every
 cross build definition must have one or both of them. If it had
 neither, the build would not be a cross build but a native build. You

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1438,6 +1438,8 @@ class Executable(BuildTarget):
             elif ('c' in self.compilers and self.compilers['c'].get_id().startswith('ccrx') or
                   'cpp' in self.compilers and self.compilers['cpp'].get_id().startswith('ccrx')):
                 self.suffix = 'abs'
+            elif (environment.is_cross_build() and 'exe_suffix' in environment.properties[for_machine]):
+                self.suffix = environment.properties[for_machine]['exe_suffix']
             else:
                 self.suffix = environment.machines[for_machine].get_exe_suffix()
         self.filename = self.name
@@ -1540,6 +1542,8 @@ class StaticLibrary(BuildTarget):
                     self.suffix = 'rlib'
                 elif self.rust_crate_type == 'staticlib':
                     self.suffix = 'a'
+            elif (environment.is_cross_build() and 'static_library_suffix' in environment.properties[for_machine]):
+                self.suffix = environment.properties[for_machine]['static_library_suffix']
             else:
                 self.suffix = 'a'
         self.filename = self.prefix + self.name + '.' + self.suffix
@@ -1594,7 +1598,10 @@ class SharedLibrary(BuildTarget):
         if not hasattr(self, 'prefix'):
             self.prefix = None
         if not hasattr(self, 'suffix'):
-            self.suffix = None
+            if (environment.is_cross_build() and 'shared_library_suffix' in environment.properties[for_machine]):
+                self.suffix = environment.properties[for_machine]['shared_library_suffix']
+            else:
+                self.suffix = None
         self.basic_filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
         self.determine_filenames(environment)
 
@@ -1883,6 +1890,9 @@ class SharedModule(SharedLibrary):
             raise MesonException('Shared modules must not specify the version kwarg.')
         if 'soversion' in kwargs:
             raise MesonException('Shared modules must not specify the soversion kwarg.')
+        if not hasattr(self, 'suffix'):
+            if (environment.is_cross_build() and 'shared_module_suffix' in environment.properties[for_machine]):
+                self.suffix = environment.properties[for_machine]['shared_module_suffix']
         super().__init__(name, subdir, subproject, for_machine, sources, objects, environment, kwargs)
         self.typename = 'shared module'
 

--- a/mesonbuild/compilers/clike.py
+++ b/mesonbuild/compilers/clike.py
@@ -308,8 +308,14 @@ class CLikeCompiler:
                 mode = 'compile'
         extra_flags = self._get_basic_compiler_args(environment, mode)
 
-        # Is a valid executable output for all toolchains and platforms
-        binname += '.exe'
+        # Use explicit cross executable suffix if available, otherwise punt to .exe
+        # as a valid executable output for almost all toolchains and platforms.
+        # Emscripten is the pathological exception, compiling totally different
+        # results depending on the output file suffix with no override flag.
+        if self.is_cross:
+            binname += '.' + environment.properties[self.for_machine].get('exe_suffix', 'exe')
+        else:
+            binname += '.exe'
         # Write binary check source
         binary_name = os.path.join(work_dir, binname)
         with open(source_name, 'w') as ofile:

--- a/test cases/unit/62 cross file name suffixes/executable.c
+++ b/test cases/unit/62 cross file name suffixes/executable.c
@@ -1,0 +1,4 @@
+int main(void)
+{
+    return 0;
+}

--- a/test cases/unit/62 cross file name suffixes/library.c
+++ b/test cases/unit/62 cross file name suffixes/library.c
@@ -1,0 +1,4 @@
+int example(void)
+{
+    return 0;
+}

--- a/test cases/unit/62 cross file name suffixes/meson.build
+++ b/test cases/unit/62 cross file name suffixes/meson.build
@@ -1,0 +1,13 @@
+project('cross file name suffixes', 'c')
+
+exe = executable('executable', ['executable.c'])
+assert(exe.full_path().endswith('.exe_test'), 'exe_suffix is honored')
+
+static_lib = static_library('static_library', ['library.c'])
+assert(static_lib.full_path().endswith('.a_test'), 'static_lib_suffix is honored')
+
+shared_lib = shared_library('shared_library', ['library.c'])
+assert(shared_lib.full_path().endswith('.so_test'), 'shared_lib_suffix is honored')
+
+shared_mod = shared_module('shared_module', ['library.c'])
+assert(shared_mod.full_path().endswith('.sm_test'), 'shared_module_suffix is honored')


### PR DESCRIPTION
This adds the following options to cross file properties:

* exe_suffix
* static_library_suffix
* shared_library_suffix
* shared_module suffix

Documentation and a unit test is provided. The unit test is kinda weird though, it tricks Meson into thinking it's cross-compiling while it really isn't.

Does this need to be registered by a `FeatureNew` somewhere?

Fixes #1802 and takes over from where #3873 left off.