### PR TITLE
environment: Fix detection of Microsoft cl.exe with non English locales

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -776,7 +776,7 @@ class Environment:
                 else:
                     m = 'Failed to detect MSVC compiler version: stderr was\n{!r}'
                     raise EnvironmentException(m.format(err))
-                match = re.search(' for (.*)$', lookat.split('\n')[0])
+                match = re.search('.*(x86|x64|ARM|ARM64).*', lookat.split('\n')[0])
                 if match:
                     target = match.group(1)
                 else:


### PR DESCRIPTION
This uses the fix as suggested in issue 5491, which it also fixes.

Fixes #5491