### PR TITLE
coredata: Correctly handle receiving a pipe for native/cross files

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -403,6 +403,7 @@ class Environment:
                     raise e
         else:
             # Just create a fresh coredata in this case
+            self.scratch_dir = ''
             self.create_new_coredata(options)
 
         ## locally bind some unfrozen configuration
@@ -514,7 +515,7 @@ class Environment:
         # WARNING: Don't use any values from coredata in __init__. It gets
         # re-initialized with project options by the interpreter during
         # build file parsing.
-        self.coredata = coredata.CoreData(options)
+        self.coredata = coredata.CoreData(options, self.scratch_dir)
         # Used by the regenchecker script, which runs meson
         self.coredata.meson_command = mesonlib.meson_command
         self.first_invocation = True

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -29,6 +29,7 @@ import pickle
 import functools
 import io
 import operator
+import threading
 from itertools import chain
 from unittest import mock
 from configparser import ConfigParser
@@ -5739,9 +5740,9 @@ class NativeFileTests(BasePlatformTests):
                     f.write("{}='{}'\n".format(k, v))
         return filename
 
-    def helper_create_binary_wrapper(self, binary, **kwargs):
+    def helper_create_binary_wrapper(self, binary, dir_=None, **kwargs):
         """Creates a wrapper around a binary that overrides specific values."""
-        filename = os.path.join(self.builddir, 'binary_wrapper{}.py'.format(self.current_wrapper))
+        filename = os.path.join(dir_ or self.builddir, 'binary_wrapper{}.py'.format(self.current_wrapper))
         self.current_wrapper += 1
         if is_haiku():
             chbang = '#!/bin/env python3'
@@ -5814,6 +5815,28 @@ class NativeFileTests(BasePlatformTests):
         self.init(self.testcase, extra_args=[
             '--native-file', config, '--native-file', config2,
             '-Dcase=find_program'])
+
+    @unittest.skipIf(os.name != 'posix', 'Uses fifos, which are not available on non Unix OSes.')
+    def test_native_file_is_pipe(self):
+        fifo = os.path.join(self.builddir, 'native.file')
+        os.mkfifo(fifo)
+        with tempfile.TemporaryDirectory() as d:
+            wrapper = self.helper_create_binary_wrapper('bash', d, version='12345')
+
+            def filler():
+                with open(fifo, 'w') as f:
+                    f.write('[binaries]\n')
+                    f.write("bash = '{}'\n".format(wrapper))
+
+            thread = threading.Thread(target=filler)
+            thread.start()
+
+            self.init(self.testcase, extra_args=['--native-file', fifo, '-Dcase=find_program'])
+
+            thread.join()
+            os.unlink(fifo)
+
+            self.init(self.testcase, extra_args=['--wipe'])
 
     def test_multiple_native_files(self):
         wrapper = self.helper_create_binary_wrapper('bash', version='12345')


### PR DESCRIPTION
In some cases a cross/native file may be a pipe, such as when using bash
process replacement `meson --native-file
<([binaries]llvm-config='/opt/bin/llvm-config')`, for example. In this
case we copy the contents of the pipe into a file in the meson-private
directory so we can create a proper ninja dependency, and be able to
reload the file on --wipe/--reconfigure. This requires some extra
negotiation to preserve these native/cross files.

Fixes #5505