### PR TITLE
windows run_project_test speedup by 2

### DIFF
--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -652,7 +652,8 @@ def _run_tests(all_tests, log_name_base, failfast, extra_args):
     #
     # Remove this once the following issue has been resolved:
     # https://github.com/mesonbuild/meson/pull/2082
-    num_workers *= 2
+    if not mesonlib.is_windows():  # twice as fast on Windows by *not* multiplying by 2.
+        num_workers *= 2
     executor = ProcessPoolExecutor(max_workers=num_workers)
 
     for name, test_cases, skipped in all_tests:


### PR DESCRIPTION
Using too many processes actually slows down the test. In this case, on WIndows the test wallclock time is faster by factor nearly 2, by not multiplying CPU count by 2 for max_workers in ProcessPoolExecutor.

The speedup is apparent with Ninja 1.8.2 and 1.9.0 at least