### PR TITLE
BUGFIX: Fortran module regex handle more edge cases

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -38,10 +38,10 @@ from ..mesonlib import get_compiler_for_source, has_path_sep
 from .backends import CleanTrees
 from ..build import InvalidArguments
 
-FORTRAN_INCLUDE_PAT = r"#?include\s*['\"](\w+\.\w+)['\"]"
-FORTRAN_MODULE_PAT = r"\s*\bmodule\b\s+(?!procedure)(\w+)"
-FORTRAN_SUBMOD_PAT = r"\s*submodule\s*\((\w+:?\w+)\)\s*(\w+)"
-FORTRAN_USE_PAT = r"\s*use,?\s*(?:non_intrinsic)?\s*(?:::)?\s*(\w+)"
+FORTRAN_INCLUDE_PAT = r"^\s*#?include\s*['\"](\w+\.\w+)['\"]"
+FORTRAN_MODULE_PAT = r"^\s*\bmodule\b\s+(\w+)\s*(?:!+.*)*$"
+FORTRAN_SUBMOD_PAT = r"^\s*\bsubmodule\b\s*\((\w+:?\w+)\)\s*(\w+)"
+FORTRAN_USE_PAT = r"^\s*use,?\s*(?:non_intrinsic)?\s*(?:::)?\s*(\w+)"
 
 if mesonlib.is_windows():
     quote_func = lambda s: '"{}"'.format(s)

--- a/test cases/fortran/12 submodule/child.f90
+++ b/test cases/fortran/12 submodule/child.f90
@@ -6,5 +6,9 @@ module procedure pi2tau
   pi2tau = 2*pi
 end procedure pi2tau
 
+module procedure good
+print *, 'Good!'
+end procedure good
+
 end submodule parent
 

--- a/test cases/fortran/12 submodule/parent.f90
+++ b/test cases/fortran/12 submodule/parent.f90
@@ -6,6 +6,9 @@ interface
 module elemental real function pi2tau(pi)
   real, intent(in) :: pi
 end function pi2tau
+
+module subroutine good()
+end subroutine good
 end interface
 
 end module parent
@@ -16,5 +19,7 @@ use parent
 tau = pi2tau(pi)
 
 print *,'pi=',pi, 'tau=', tau
+
+call good()
 
 end program

--- a/test cases/fortran/2 modules/mymod.f90
+++ b/test cases/fortran/2 modules/mymod.f90
@@ -1,3 +1,5 @@
+! module circle  to be sure module regex doesn't allow commented modules
+
 module circle
 implicit none
 


### PR DESCRIPTION
Due to the number of issues had with Fortran regex, I have created a repo just to test Fortran regex as used in Meson Ninja backend: https://github.com/scivision/fortran-parse-python

Based on that, these new regex handle more cases of interest for Fortran Meson users.