### PR TITLE
ENH: metadata PEP390 setup.cfg

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -21,13 +21,13 @@ ignore =
     # E402: module level import not at top of file
     E402,
     # E731: do not assign a lambda expression, use a def (too many false positives)
-    E731
+    E731,
     # E741: ambiguous variable name 'l'
-    E741
+    E741,
     # E722: do not use bare except'
-    E722
+    E722,
     # W504: line break after binary operator
-    W504
+    W504,
     # A003: builtin class attribute
     A003
 max-line-length = 120

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,33 @@
+[flake8]
+ignore =
+    # E241: multiple spaces after ':'
+    E241,
+    # E251: unexpected spaces around keyword / parameter equals
+    E251,
+    # E261: at least two spaces before inline comment
+    E261,
+    # E265: block comment should start with '# '
+    E265,
+    # E501: line too long
+    E501,
+    # E302: expected 2 blank lines, found 1
+    E302,
+    # E305: expected 2 blank lines after class or function definition, found 1
+    E305,
+    # E401: multiple imports on one line
+    E401,
+    # E266: too many leading '#' for block comment
+    E266,
+    # E402: module level import not at top of file
+    E402,
+    # E731: do not assign a lambda expression, use a def (too many false positives)
+    E731
+    # E741: ambiguous variable name 'l'
+    E741
+    # E722: do not use bare except'
+    E722
+    # W504: line break after binary operator
+    W504
+    # A003: builtin class attribute
+    A003
+max-line-length = 120

--- a/docs/markdown/Contributing.md
+++ b/docs/markdown/Contributing.md
@@ -200,7 +200,7 @@ following:
   to avoid wasted effort
 
 Meson uses Flake8 for style guide enforcement. The Flake8 options for
-the project are contained in setup.cfg.
+the project are contained in .flake8.
 
 To run Flake8 on your local clone of Meson:
 

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -40,10 +40,13 @@ def _windows_ansi() -> bool:
     # original behavior
     return bool(kernel.SetConsoleMode(stdout, mode.value | 0x4) or os.environ.get('ANSICON'))
 
-if platform.system().lower() == 'windows':
-    colorize_console = os.isatty(sys.stdout.fileno()) and _windows_ansi()  # type: bool
-else:
-    colorize_console = os.isatty(sys.stdout.fileno()) and os.environ.get('TERM') != 'dumb'
+try:
+    if platform.system().lower() == 'windows':
+        colorize_console = os.isatty(sys.stdout.fileno()) and _windows_ansi()  # type: bool
+    else:
+        colorize_console = os.isatty(sys.stdout.fileno()) and os.environ.get('TERM') != 'dumb'
+except Exception:
+    colorize_console = False
 log_dir = None               # type: Optional[str]
 log_file = None              # type: Optional[TextIO]
 log_fname = 'meson-log.txt'  # type: str

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+strict_optional = False
+show_error_context = False
+show_column_numbers = True

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -766,19 +766,14 @@ def _run_tests(all_tests, log_name_base, failfast, extra_args):
     ET.ElementTree(element=junit_root).write(xmlname, xml_declaration=True, encoding='UTF-8')
     return passing_tests, failing_tests, skipped_tests
 
-def check_file(fname):
-    linenum = 1
-    with open(fname, 'rb') as f:
-        lines = f.readlines()
+def check_file(file: Path):
+    lines = file.read_bytes().split(b'\n')
     tabdetector = re.compile(br' *\t')
-    for line in lines:
+    for i, line in enumerate(lines):
         if re.match(tabdetector, line):
-            print("File %s contains a tab indent on line %d. Only spaces are permitted." % (fname, linenum))
-            sys.exit(1)
-        if b'\r' in line:
-            print("File %s contains DOS line ending on line %d. Only unix-style line endings are permitted." % (fname, linenum))
-            sys.exit(1)
-        linenum += 1
+            raise SystemExit("File {} contains a tab indent on line {:d}. Only spaces are permitted.".format(file, i + 1))
+        if line.endswith(b'\r'):
+            raise SystemExit("File {} contains DOS line ending on line {:d}. Only unix-style line endings are permitted.".format(file, i + 1))
 
 def check_format():
     check_suffixes = {'.c',
@@ -800,18 +795,19 @@ def check_format():
                       '.build',
                       '.md',
                       }
-    for (root, _, files) in os.walk('.'):
+    for (root, _, filenames) in os.walk('.'):
         if '.dub' in root: # external deps are here
             continue
         if 'meson-logs' in root or 'meson-private' in root:
             continue
-        for fname in files:
-            if os.path.splitext(fname)[1].lower() in check_suffixes:
-                bn = os.path.basename(fname)
-                if bn == 'sitemap.txt' or bn == 'meson-test-run.txt':
+        if '.eggs' in root or '_cache' in root:  # e.g. .mypy_cache
+            continue
+        for fname in filenames:
+            file = Path(fname)
+            if file.suffix.lower() in check_suffixes:
+                if file.name in ('sitemap.txt', 'meson-test-run.txt'):
                     continue
-                fullname = os.path.join(root, fname)
-                check_file(fullname)
+                check_file(root / file)
 
 def check_meson_commands_work():
     global backend, compile_commands, test_commands, install_commands
@@ -901,4 +897,4 @@ if __name__ == '__main__':
             tests = list(g)
             if len(tests) != 1:
                 print('WARNING: The %s suite contains duplicate "%s" tests: "%s"' % (name, k, '", "'.join(tests)))
-    sys.exit(failing_tests)
+    raise SystemExit(failing_tests)

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
 long_description = Meson is a cross-platform build system designed to be both as fast and as user friendly as possible. It supports many languages and compilers, including GCC, Clang, PGI, Intel, and Visual Studio. Its build definitions are written in a simple non-Turing complete DSL.
 
 [options]
-python_requires = >= 3.5
+python_requires = >= 3.5.2
 setup_requires =
   setuptools >= 30.3.0
   pip >= 10

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,3 @@ long_description = Meson is a cross-platform build system designed to be both as
 
 [options]
 python_requires = >= 3.5.2
-setup_requires =
-  setuptools >= 30.3.0
-  pip >= 10

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,33 +1,35 @@
-[flake8]
-ignore =
-    # E241: multiple spaces after ':'
-    E241,
-    # E251: unexpected spaces around keyword / parameter equals
-    E251,
-    # E261: at least two spaces before inline comment
-    E261,
-    # E265: block comment should start with '# '
-    E265,
-    # E501: line too long
-    E501,
-    # E302: expected 2 blank lines, found 1
-    E302,
-    # E305: expected 2 blank lines after class or function definition, found 1
-    E305,
-    # E401: multiple imports on one line
-    E401,
-    # E266: too many leading '#' for block comment
-    E266,
-    # E402: module level import not at top of file
-    E402,
-    # E731: do not assign a lambda expression, use a def (too many false positives)
-    E731
-    # E741: ambiguous variable name 'l'
-    E741
-    # E722: do not use bare except'
-    E722
-    # W504: line break after binary operator
-    W504
-    # A003: builtin class attribute
-    A003
-max-line-length = 120
+[metadata]
+description = A high performance build system
+author = Jussi Pakkanen
+author_email = jpakkane@gmail.com
+url = https://mesonbuild.com
+keywords =
+  meson
+  mesonbuild
+  build system
+  cmake
+license = Apache License, Version 2.0
+license_file = COPYING
+classifiers =
+  Development Status :: 5 - Production/Stable
+  Environment :: Console
+  Intended Audience :: Developers
+  License :: OSI Approved :: Apache Software License
+  Natural Language :: English
+  Operating System :: MacOS :: MacOS X
+  Operating System :: Microsoft :: Windows
+  Operating System :: POSIX :: BSD
+  Operating System :: POSIX :: Linux
+  Programming Language :: Python :: 3 :: Only
+  Programming Language :: Python :: 3.5
+  Programming Language :: Python :: 3.6
+  Programming Language :: Python :: 3.7
+  Programming Language :: Python :: 3.8
+  Topic :: Software Development :: Build Tools
+long_description = Meson is a cross-platform build system designed to be both as fast and as user friendly as possible. It supports many languages and compilers, including GCC, Clang, PGI, Intel, and Visual Studio. Its build definitions are written in a simple non-Turing complete DSL.
+
+[options]
+python_requires = >= 3.5
+setup_requires =
+  setuptools >= 30.3.0
+  pip >= 10

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,8 @@
 import sys
 
 if sys.version_info < (3, 5, 0):
-    print('Tried to install with an unsupported version of Python. '
-          'Meson requires Python 3.5.0 or greater')
-    sys.exit(1)
+    raise SystemExit('ERROR: Tried to install Meson with an unsupported Python version: \n{}'
+                     '\nMeson requires Python 3.5.0 or greater'.format(sys.version))
 
 from mesonbuild.coredata import version
 from setuptools import setup
@@ -46,29 +45,7 @@ if sys.platform != 'win32':
 if __name__ == '__main__':
     setup(name='meson',
           version=version,
-          description='A high performance build system',
-          author='Jussi Pakkanen',
-          author_email='jpakkane@gmail.com',
-          url='http://mesonbuild.com',
-          license=' Apache License, Version 2.0',
-          python_requires='>=3.5',
           packages=packages,
           package_data=package_data,
           entry_points=entries,
-          data_files=data_files,
-          classifiers=['Development Status :: 5 - Production/Stable',
-                       'Environment :: Console',
-                       'Intended Audience :: Developers',
-                       'License :: OSI Approved :: Apache Software License',
-                       'Natural Language :: English',
-                       'Operating System :: MacOS :: MacOS X',
-                       'Operating System :: Microsoft :: Windows',
-                       'Operating System :: POSIX :: BSD',
-                       'Operating System :: POSIX :: Linux',
-                       'Programming Language :: Python :: 3 :: Only',
-                       'Topic :: Software Development :: Build Tools',
-                       ],
-          long_description='''Meson is a cross-platform build system designed to be both as
-    fast and as user friendly as possible. It supports many languages and compilers, including
-    GCC, Clang and Visual Studio. Its build definitions are written in a simple non-turing
-    complete DSL.''')
+          data_files=data_files,)

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,9 @@
 
 import sys
 
-if sys.version_info < (3, 5, 0):
+if sys.version_info < (3, 5, 2):
     raise SystemExit('ERROR: Tried to install Meson with an unsupported Python version: \n{}'
-                     '\nMeson requires Python 3.5.0 or greater'.format(sys.version))
+                     '\nMeson requires Python 3.5.2 or greater'.format(sys.version))
 
 from mesonbuild.coredata import version
 from setuptools import setup


### PR DESCRIPTION
Helping modernize Meson packaging

* Begin modernizing Meson install metadata per PEP 390 [using `setup.cfg` with setup.py](https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files) (available since Dec 2016).
* Moved flake8 content to dedicated [standard .flake8 file](https://flake8.pycqa.org/en/latest/user/configuration.html#configuration-locations)
* added [mypy.ini](https://mypy.readthedocs.io/en/latest/config_file.html) for some good defaults as Meson continues to introduce type hint checks

setup.py can be reduced to 4 lines with future PRs--I thought I'd introduce gradually with "safe" metadata fields only in case of unexpected issues. 
I use setup.cfg on hundreds of repos with setup.py a one-liner: `import setuptools; setuptools.setup()`

---

Future: [Poetry](https://pypi.org/project/poetry/) is growing ~ 250K installs/month. May be nice to add pyproject.toml suitable for Poetry 

---

mlog.py: allowed ipython kernel to be used for debugging in say Spyder. In any case, having a universal fallback to non-colorized in case of unexpected issue seems good.

run_project_test.py: cleaned up syntax w.r.t. file checks by using pathlib.Path