### PR TITLE
CI: Fortran-specific OpenMP tests

### DIFF
--- a/test cases/fortran/16 openmp/main.f90
+++ b/test cases/fortran/16 openmp/main.f90
@@ -1,0 +1,17 @@
+use, intrinsic :: iso_fortran_env, only: stderr=>error_unit
+use omp_lib, only: omp_get_max_threads
+implicit none
+
+integer :: N, ierr
+character(80) :: buf  ! can't be allocatable in this use case. Just set arbitrarily large.
+
+call get_environment_variable('OMP_NUM_THREADS', buf, status=ierr)
+if (ierr/=0) error stop 'environment variable OMP_NUM_THREADS could not be read'
+read(buf,*) N
+
+if (omp_get_max_threads() /= N) then
+  write(stderr, *) 'Max Fortran threads: ', omp_get_max_threads(), '!=', N
+  error stop
+endif
+
+end program

--- a/test cases/fortran/16 openmp/meson.build
+++ b/test cases/fortran/16 openmp/meson.build
@@ -1,0 +1,34 @@
+# This test is complementary to and extends "common/190 openmp" so that
+# we can examine more compilers and options than would be warranted in
+# the common test where C/C++ must also be handled.
+project('openmp', 'fortran',
+  meson_version: '>= 0.46')
+
+
+fc = meson.get_compiler('fortran')
+if fc.get_id() == 'gcc' and fc.version().version_compare('<4.2.0')
+  error('MESON_SKIP_TEST gcc is too old to support OpenMP.')
+endif
+if host_machine.system() == 'darwin'
+  error('MESON_SKIP_TEST macOS does not support OpenMP.')
+endif
+
+openmp = dependency('openmp')
+
+env = environment()
+env.set('OMP_NUM_THREADS', '2')
+
+exef = executable('exef',
+  'main.f90',
+  dependencies : [openmp])
+test('OpenMP Fortran', exef, env : env)
+
+openmp_f = dependency('openmp', language : 'fortran')
+exe_f = executable('exe_f',
+  'main.f90',
+  dependencies : [openmp_f])
+test('OpenMP Fortran-specific', exe_f, env : env)
+
+
+# Check we can apply a version constraint
+dependency('openmp', version: '>=@0@'.format(openmp.version()))


### PR DESCRIPTION
Unit tests specifically for Fortran OpenMP, adding / complementary to `common/190 openmp` but allowing use on Windows and with non-GNU compilers.
Enabling future more complete testing of non-GNU Fortran compilers with OpenMP, such as Flang that are targeting OpenMP to help ensure we have the correct compiler flags.

We may not want to do this in `common` because it encumbers testing with array of C / C++ compliers.

The distinction of these integration tests is:

* common: test OpenMP with as wide array as feasible of C / C++ / Fortran compilers, not testing Fortran on Windows because of usual inter-compiler difficulties on Windows
* fortran: test OpenMP with as wide array as feasible of Fortran compilers, including Windows, even more compilers than tested in common.

---

The underlying philosophy behind this and similar PRs is that as always for projects of Meson's scope, while there's a lot of green CI lights, there are important corner case configurations that CMake handles, that Meson will also need to handle to get into the HPC Fortran world. It is feasible to handle these cases since we know the problems are already solvable by CMake, but we will need to test for them on various HPC-relevant Fortran compilers.

This means that the lighter, broader tests we see in "common" are complemented by in-depth, more configuration/compiler-specific tests in "fortran" for example.