### PR TITLE
docs: Fix link to SourceSet module in the navbar

### DIFF
--- a/docs/theme/extra/templates/navbar_links.html
+++ b/docs/theme/extra/templates/navbar_links.html
@@ -13,6 +13,7 @@
 			     ("Qt4-module.html","Qt4"), \
 			     ("Qt5-module.html","Qt5"), \
 			     ("RPM-module.html","RPM"), \
+			     ("SourceSet-module.html","SourceSet"), \
 			     ("Windows-module.html","Windows"), \
 			     ("Hotdoc-module.html","Hotdoc")):
 			<li>


### PR DESCRIPTION
The link to the `SourceSet` module is missing in the navigation bar.