### PR TITLE
meson_exe: Don't assert that we need an exe_wrapper when we say we do…

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -70,7 +70,7 @@ class TargetInstallData:
 
 class ExecutableSerialisation:
     def __init__(self, name, fname, cmd_args, env, is_cross, exe_wrapper,
-                 workdir, extra_paths, capture):
+                 workdir, extra_paths, capture, needs_exe_wrapper: bool):
         self.name = name
         self.fname = fname
         self.cmd_args = cmd_args
@@ -79,6 +79,7 @@ class ExecutableSerialisation:
         if exe_wrapper is not None:
             assert(isinstance(exe_wrapper, dependencies.ExternalProgram))
         self.exe_runner = exe_wrapper
+        self.needs_exe_wrapper = needs_exe_wrapper
         self.workdir = workdir
         self.extra_paths = extra_paths
         self.capture = capture
@@ -372,7 +373,8 @@ class Backend:
                 exe_wrapper = None
             es = ExecutableSerialisation(basename, exe_cmd, cmd_args, env,
                                          is_cross_built, exe_wrapper, workdir,
-                                         extra_paths, capture)
+                                         extra_paths, capture,
+                                         self.environment.need_exe_wrapper())
             pickle.dump(es, f)
         return exe_data
 

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -47,12 +47,12 @@ def run_exe(exe):
     elif not exe.is_cross and run_with_mono(exe.fname[0]):
         cmd = ['mono'] + exe.fname
     else:
-        if exe.is_cross:
+        if exe.is_cross and exe.needs_exe_wrapper:
             if exe.exe_runner is None:
-                raise AssertionError('BUG: Can\'t run cross-compiled exe {!r}'
+                raise AssertionError('BUG: Can\'t run cross-compiled exe {!r} '
                                      'with no wrapper'.format(exe.name))
             elif not exe.exe_runner.found():
-                raise AssertionError('BUG: Can\'t run cross-compiled exe {!r} with not-found'
+                raise AssertionError('BUG: Can\'t run cross-compiled exe {!r} with not-found '
                                      'wrapper {!r}'.format(exe.name, exe.exe_runner.get_path()))
             else:
                 cmd = exe.exe_runner.get_command() + exe.fname


### PR DESCRIPTION
…n't need one

Fixes cross compiling mesa from x86_64 -> x86 on an x86_64 system.

Fixes #5567