### PR TITLE
ninjabackend: do not use --internal exe for capturing custom target on Unix

### DIFF
--- a/test cases/common/224 generator capture/cat.py
+++ b/test cases/common/224 generator capture/cat.py
@@ -1,0 +1,6 @@
+#! /usr/bin/env python3
+
+import sys
+with open(sys.argv[1], 'r') as f:
+    for line in f:
+        print(line)

--- a/test cases/common/224 generator capture/meson.build
+++ b/test cases/common/224 generator capture/meson.build
@@ -1,0 +1,10 @@
+project('generator', 'c')
+
+cat = find_program('cat.py')
+generator = generator(cat,
+  arguments : [ '@INPUT@', '@OUTPUT@' ],
+  output : '@BASENAME@',
+  capture : true,
+)
+
+executable('exec', generator.process('source.c.txt'))

--- a/test cases/common/224 generator capture/source.c.txt
+++ b/test cases/common/224 generator capture/source.c.txt
@@ -1,0 +1,4 @@
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
Using `capture: true` with `custom_target` makes "ninja -v" less useful since the command line is completely hidden from the user. It would be nice if `meson --internal exe` knew to print the command line itself; unfortunately support for a `NINJAFLAGS` command line variable, which would pass -v down to `meson --internal exe`, was rejected (ninja-build/ninja#1543).

However, for Unix systems ninja sends commands to the shell, which can take care of capturing output from stdout.  Do not go through the serialized executables in that case. While it would be possible to use `execute_wrapper`, for simplicity this patch only "fixes" POSIX hosts.