### PR TITLE
CMake subprojects add_custom_command support

### DIFF
--- a/mesonbuild/ast/printer.py
+++ b/mesonbuild/ast/printer.py
@@ -118,6 +118,7 @@ class AstPrinter(AstVisitor):
             self.newline()
 
     def visit_IndexNode(self, node: mparser.IndexNode):
+        node.iobject.accept(self)
         self.append('[', node)
         node.index.accept(self)
         self.append(']', node)
@@ -181,7 +182,7 @@ class AstPrinter(AstVisitor):
     def visit_ArgumentNode(self, node: mparser.ArgumentNode):
         break_args = (len(node.arguments) + len(node.kwargs)) > self.arg_newline_cutoff
         for i in node.arguments + list(node.kwargs.values()):
-            if not isinstance(i, mparser.ElementaryNode):
+            if not isinstance(i, (mparser.ElementaryNode, mparser.IndexNode)):
                 break_args = True
         if break_args:
             self.newline()

--- a/mesonbuild/ast/visitor.py
+++ b/mesonbuild/ast/visitor.py
@@ -84,6 +84,7 @@ class AstVisitor:
 
     def visit_IndexNode(self, node: mparser.IndexNode):
         self.visit_default_func(node)
+        node.iobject.accept(self)
         node.index.accept(self)
 
     def visit_MethodNode(self, node: mparser.MethodNode):

--- a/mesonbuild/cmake/data/run_ctgt.py
+++ b/mesonbuild/cmake/data/run_ctgt.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import shutil
+import os
+import sys
+
+commands = [[]]
+SEPERATOR = ';;;'
+
+# Generate CMD parameters
+parser = argparse.ArgumentParser(description='Wrapper for add_custom_command')
+parser.add_argument('-d', '--directory', type=str, metavar='D', required=True, help='Working directory to cwd to')
+parser.add_argument('-o', '--outputs', nargs='+', metavar='O', required=True, help='Expected output files')
+parser.add_argument('-O', '--original-outputs', nargs='+', metavar='O', required=True, help='Output files expected by CMake')
+parser.add_argument('commands', nargs=argparse.REMAINDER, help='A "{}" seperated list of commands'.format(SEPERATOR))
+
+# Parse
+args = parser.parse_args()
+
+if len(args.outputs) != len(args.original_outputs):
+    print('Length of output list and original output list differ')
+    sys.exit(1)
+
+for i in args.commands:
+    if i == SEPERATOR:
+        commands += [[]]
+        continue
+
+    commands[-1] += [i]
+
+# Execute
+for i in commands:
+    # Skip empty lists
+    if not i:
+        continue
+
+    subprocess.run(i, cwd=args.directory)
+
+# Copy outputs
+zipped_outputs = zip(args.outputs, args.original_outputs)
+for expected, generated in zipped_outputs:
+    do_copy = False
+    if not os.path.exists(expected):
+        if not os.path.exists(generated):
+            print('Unable to find generated file. This can cause the build to fail:')
+            print(generated)
+            do_copy = False
+        else:
+            do_copy = True
+    elif os.path.exists(generated):
+        if os.path.getmtime(generated) > os.path.getmtime(expected):
+            do_copy = True
+
+    if do_copy:
+        if os.path.exists(expected):
+            os.remove(expected)
+        shutil.copyfile(generated, expected)

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -403,7 +403,7 @@ class CMakeTraceParser:
     def _guess_files(self, broken_list: List[str]) -> List[str]:
         #Try joining file paths that contain spaces
 
-        reg_start = re.compile(r'^/.*/[^./]+$')
+        reg_start = re.compile(r'^([A-Za-z]:)?/.*/[^./]+$')
         reg_end = re.compile(r'^.*\.[a-zA-Z]+$')
 
         fixed_list = []  # type: List[str]

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -231,6 +231,8 @@ class CMakeTraceParser:
             target.outputs += [key]
 
         def handle_command(key: str, target: CMakeGeneratorTarget) -> None:
+            if key == 'ARGS':
+                return
             target.command[-1] += [key]
 
         def handle_depends(key: str, target: CMakeGeneratorTarget) -> None:

--- a/run_meson_command_tests.py
+++ b/run_meson_command_tests.py
@@ -142,6 +142,8 @@ class CommandTests(unittest.TestCase):
             s = p.as_posix()
             if 'mesonbuild' not in s:
                 continue
+            if '/data/' in s:
+                continue
             have.add(s[s.rfind('mesonbuild'):])
         self.assertEqual(have, expect)
         # Run `meson`

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,10 @@ packages = ['mesonbuild',
             'mesonbuild.modules',
             'mesonbuild.scripts',
             'mesonbuild.wrap']
-package_data = {'mesonbuild.dependencies': ['data/CMakeLists.txt', 'data/CMakeListsLLVM.txt', 'data/CMakePathInfo.txt']}
+package_data = {
+    'mesonbuild.dependencies': ['data/CMakeLists.txt', 'data/CMakeListsLLVM.txt', 'data/CMakePathInfo.txt'],
+    'mesonbuild.cmake': ['data/run_ctgt.py'],
+}
 data_files = []
 if sys.platform != 'win32':
     # Only useful on UNIX-like systems

--- a/test cases/cmake/8 custom command/main.cpp
+++ b/test cases/cmake/8 custom command/main.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+#include <cmMod.hpp>
+
+using namespace std;
+
+int main() {
+  cmModClass obj("Hello");
+  cout << obj.getStr() << endl;
+  cout << obj.getOther() << endl;
+  return 0;
+}

--- a/test cases/cmake/8 custom command/meson.build
+++ b/test cases/cmake/8 custom command/meson.build
@@ -1,0 +1,12 @@
+project('cmakeSubTest', ['c', 'cpp'])
+
+cm = import('cmake')
+
+sub_pro = cm.subproject('cmMod')
+sub_dep = sub_pro.dependency('cmModLib')
+
+assert(sub_pro.target_type('cmModLib') == 'shared_library', 'Target type should be shared_library')
+assert(sub_pro.target_type('gen') == 'executable', 'Target type should be executable')
+
+exe1 = executable('main', ['main.cpp'], dependencies: [sub_dep])
+test('test1', exe1)

--- a/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(cmMod)
+set (CMAKE_CXX_STANDARD 14)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+add_definitions("-DDO_NOTHING_JUST_A_FLAG=1")
+
+add_executable(gen main.cpp)
+add_executable(mycpy cp.cpp)
+
+add_custom_command(
+  OUTPUT  "${CMAKE_CURRENT_BINARY_DIR}/genTest.cpp" "${CMAKE_CURRENT_BINARY_DIR}/genTest.hpp"
+  COMMAND gen genTest
+)
+
+add_custom_command(
+  OUTPUT cpyBase.cpp
+  COMMAND mycpy "${CMAKE_CURRENT_SOURCE_DIR}/cpyBase.cpp.am" cpyBase.cpp.in
+  COMMAND mycpy cpyBase.cpp.in                               cpyBase.cpp.something
+  COMMAND mycpy cpyBase.cpp.something                        cpyBase.cpp.IAmRunningOutOfIdeas
+  COMMAND mycpy cpyBase.cpp.IAmRunningOutOfIdeas             cpyBase.cpp
+  DEPENDS cpyBase.cpp.am gen
+)
+
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cpyBase.hpp.in"
+  COMMAND mycpy "${CMAKE_CURRENT_SOURCE_DIR}/cpyBase.hpp.am" cpyBase.hpp.in
+  DEPENDS cpyBase.hpp.am
+)
+
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cpyBase.hpp.something"
+  COMMAND mycpy cpyBase.hpp.in                               cpyBase.hpp.something
+  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/cpyBase.hpp.in"
+)
+
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cpyBase.hpp"
+  COMMAND mycpy cpyBase.hpp.something                        cpyBase.hpp
+  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/cpyBase.hpp.something"
+)
+
+add_library(cmModLib SHARED cmMod.cpp genTest.cpp cpyBase.cpp cpyBase.hpp)
+include(GenerateExportHeader)
+generate_export_header(cmModLib)

--- a/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(mycpy cp.cpp)
 
 add_custom_command(
   OUTPUT  "${CMAKE_CURRENT_BINARY_DIR}/genTest.cpp" "${CMAKE_CURRENT_BINARY_DIR}/genTest.hpp"
-  COMMAND gen genTest
+  COMMAND gen ARGS genTest
 )
 
 add_custom_command(

--- a/test cases/cmake/8 custom command/subprojects/cmMod/cmMod.cpp
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/cmMod.cpp
@@ -1,0 +1,17 @@
+#include "cmMod.hpp"
+#include "genTest.hpp"
+#include "cpyBase.hpp"
+
+using namespace std;
+
+cmModClass::cmModClass(string foo) {
+  str = foo + " World";
+}
+
+string cmModClass::getStr() const {
+  return str;
+}
+
+string cmModClass::getOther() const {
+  return getStr() + "  --  " + getStrCpy();
+}

--- a/test cases/cmake/8 custom command/subprojects/cmMod/cmMod.hpp
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/cmMod.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+#include "cmmodlib_export.h"
+
+class CMMODLIB_EXPORT cmModClass {
+  private:
+    std::string str;
+  public:
+    cmModClass(std::string foo);
+
+    std::string getStr() const;
+    std::string getOther() const;
+};

--- a/test cases/cmake/8 custom command/subprojects/cmMod/cp.cpp
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/cp.cpp
@@ -1,0 +1,17 @@
+#include <iostream>
+#include <fstream>
+
+using namespace std;
+
+int main(int argc, char *argv[]) {
+  if(argc < 3) {
+    cerr << argv[0] << " requires an input and an output file!" << endl;
+    return 1;
+  }
+
+  ifstream src(argv[1]);
+  ofstream dst(argv[2]);
+
+  dst << src.rdbuf();
+  return 0;
+}

--- a/test cases/cmake/8 custom command/subprojects/cmMod/cpyBase.cpp.am
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/cpyBase.cpp.am
@@ -1,0 +1,5 @@
+#include "cpyBase.hpp"
+
+std::string getStrCpy() {
+  return "Hello Copied File";
+}

--- a/test cases/cmake/8 custom command/subprojects/cmMod/cpyBase.hpp.am
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/cpyBase.hpp.am
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string>
+
+std::string getStrCpy();

--- a/test cases/cmake/8 custom command/subprojects/cmMod/main.cpp
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/main.cpp
@@ -1,0 +1,30 @@
+#include <iostream>
+#include <fstream>
+
+using namespace std;
+
+int main(int argc, const char *argv[]) {
+  if(argc < 2) {
+    cerr << argv[0] << " requires an output file!" << endl;
+    return 1;
+  }
+  ofstream out1(string(argv[1]) + ".hpp");
+  ofstream out2(string(argv[1]) + ".cpp");
+  out1 << R"(
+#pragma once
+
+#include <string>
+
+std::string getStr();
+)";
+
+  out2 << R"(
+#include ")" << argv[1] << R"(.hpp"
+
+std::string getStr() {
+  return "Hello World";
+}
+)";
+
+  return 0;
+}


### PR DESCRIPTION
With this PR, most CMake subprojects that use `add_custom_command` are supported. Due to the limitations of the CMake introspection API, the CMake trace parser is used for extracting all the relevant information. To execute the actual commands a wrapper python script is used to replicate most of the `add_custom_command` functionality with `custom_target`.