### PR TITLE
Improve performance with windows defender ATP

### DIFF
--- a/mesonbuild/compilers/clike.py
+++ b/mesonbuild/compilers/clike.py
@@ -434,8 +434,8 @@ class CLikeCompiler:
     def _build_wrapper(self, code, env, extra_args, dependencies=None, mode='compile', want_output=False, disable_cache=False):
         args = self._get_compiler_check_args(env, extra_args, dependencies, mode)
         if disable_cache or want_output:
-            return self.compile(code, extra_args=args, mode=mode, want_output=want_output, temp_dir=env.temp_dir)
-        return self.cached_compile(code, env.coredata, extra_args=args, mode=mode, temp_dir=env.temp_dir)
+            return self.compile(code, extra_args=args, mode=mode, want_output=want_output, temp_dir=env.scratch_dir)
+        return self.cached_compile(code, env.coredata, extra_args=args, mode=mode, temp_dir=env.scratch_dir)
 
     def links(self, code, env, *, extra_args=None, dependencies=None, disable_cache=False):
         return self.compiles(code, env, extra_args=extra_args,
@@ -639,7 +639,7 @@ class CLikeCompiler:
                                              mode='preprocess').to_native()
         func = lambda: self.cached_compile(code.format(**fargs), env.coredata, extra_args=args, mode='preprocess')
         if disable_cache:
-            func = lambda: self.compile(code.format(**fargs), extra_args=args, mode='preprocess', temp_dir=env.temp_dir)
+            func = lambda: self.compile(code.format(**fargs), extra_args=args, mode='preprocess', temp_dir=env.scratch_dir)
         with func() as p:
             cached = p.cached
             if p.returncode != 0:
@@ -860,7 +860,7 @@ class CLikeCompiler:
         '''
         args = self.get_compiler_check_args()
         n = 'symbols_have_underscore_prefix'
-        with self.compile(code, extra_args=args, mode='compile', want_output=True, temp_dir=env.temp_dir) as p:
+        with self.compile(code, extra_args=args, mode='compile', want_output=True, temp_dir=env.scratch_dir) as p:
             if p.returncode != 0:
                 m = 'BUG: Unable to compile {!r} check: {}'
                 raise RuntimeError(m.format(n, p.stdo))

--- a/mesonbuild/compilers/clike.py
+++ b/mesonbuild/compilers/clike.py
@@ -639,7 +639,7 @@ class CLikeCompiler:
                                              mode='preprocess').to_native()
         func = lambda: self.cached_compile(code.format(**fargs), env.coredata, extra_args=args, mode='preprocess')
         if disable_cache:
-            func = lambda: self.compile(code.format(**fargs), extra_args=args, mode='preprocess', temp_dir=env.get_temp_dir)
+            func = lambda: self.compile(code.format(**fargs), extra_args=args, mode='preprocess', temp_dir=env.temp_dir)
         with func() as p:
             cached = p.cached
             if p.returncode != 0:

--- a/mesonbuild/compilers/clike.py
+++ b/mesonbuild/compilers/clike.py
@@ -434,8 +434,8 @@ class CLikeCompiler:
     def _build_wrapper(self, code, env, extra_args, dependencies=None, mode='compile', want_output=False, disable_cache=False):
         args = self._get_compiler_check_args(env, extra_args, dependencies, mode)
         if disable_cache or want_output:
-            return self.compile(code, extra_args=args, mode=mode, want_output=want_output)
-        return self.cached_compile(code, env.coredata, extra_args=args, mode=mode)
+            return self.compile(code, extra_args=args, mode=mode, want_output=want_output, temp_dir=env.temp_dir)
+        return self.cached_compile(code, env.coredata, extra_args=args, mode=mode, temp_dir=env.temp_dir)
 
     def links(self, code, env, *, extra_args=None, dependencies=None, disable_cache=False):
         return self.compiles(code, env, extra_args=extra_args,
@@ -639,7 +639,7 @@ class CLikeCompiler:
                                              mode='preprocess').to_native()
         func = lambda: self.cached_compile(code.format(**fargs), env.coredata, extra_args=args, mode='preprocess')
         if disable_cache:
-            func = lambda: self.compile(code.format(**fargs), extra_args=args, mode='preprocess')
+            func = lambda: self.compile(code.format(**fargs), extra_args=args, mode='preprocess', temp_dir=env.get_temp_dir)
         with func() as p:
             cached = p.cached
             if p.returncode != 0:
@@ -860,7 +860,7 @@ class CLikeCompiler:
         '''
         args = self.get_compiler_check_args()
         n = 'symbols_have_underscore_prefix'
-        with self.compile(code, extra_args=args, mode='compile', want_output=True) as p:
+        with self.compile(code, extra_args=args, mode='compile', want_output=True, temp_dir=env.temp_dir) as p:
             if p.returncode != 0:
                 m = 'BUG: Unable to compile {!r} check: {}'
                 raise RuntimeError(m.format(n, p.stdo))

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1152,11 +1152,11 @@ class Compiler:
         return args
 
     @contextlib.contextmanager
-    def compile(self, code, extra_args=None, *, mode='link', want_output=False):
+    def compile(self, code, extra_args=None, *, mode='link', want_output=False, temp_dir=None):
         if extra_args is None:
             extra_args = []
         try:
-            with tempfile.TemporaryDirectory() as tmpdirname:
+            with tempfile.TemporaryDirectory(dir=temp_dir) as tmpdirname:
                 if isinstance(code, str):
                     srcname = os.path.join(tmpdirname,
                                            'testfile.' + self.default_suffix)
@@ -1201,7 +1201,7 @@ class Compiler:
             pass
 
     @contextlib.contextmanager
-    def cached_compile(self, code, cdata: coredata.CoreData, *, extra_args=None, mode: str = 'link'):
+    def cached_compile(self, code, cdata: coredata.CoreData, *, extra_args=None, mode: str = 'link', temp_dir=None):
         assert(isinstance(cdata, coredata.CoreData))
 
         # Calculate the key
@@ -1210,7 +1210,7 @@ class Compiler:
 
         # Check if not cached
         if key not in cdata.compiler_check_cache:
-            with self.compile(code, extra_args=extra_args, mode=mode, want_output=False) as p:
+            with self.compile(code, extra_args=extra_args, mode=mode, want_output=False, temp_dir=temp_dir) as p:
                 # Remove all attributes except the following
                 # This way the object can be serialized
                 tokeep = ['args', 'commands', 'input_name', 'output_name',

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -372,6 +372,7 @@ class Environment:
     private_dir = 'meson-private'
     log_dir = 'meson-logs'
     info_dir = 'meson-info'
+    temp_dir = 'meson-temp'
 
     def __init__(self, source_dir, build_dir, options):
         self.source_dir = source_dir
@@ -383,9 +384,11 @@ class Environment:
             self.scratch_dir = os.path.join(build_dir, Environment.private_dir)
             self.log_dir = os.path.join(build_dir, Environment.log_dir)
             self.info_dir = os.path.join(build_dir, Environment.info_dir)
+            self.temp_dir = os.path.join(build_dir, Environment.temp_dir)
             os.makedirs(self.scratch_dir, exist_ok=True)
             os.makedirs(self.log_dir, exist_ok=True)
             os.makedirs(self.info_dir, exist_ok=True)
+            os.makedirs(self.temp_dir, exist_ok=True)
             try:
                 self.coredata = coredata.load(self.get_build_dir())
                 self.first_invocation = False

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -377,7 +377,7 @@ class Environment:
     def __init__(self, source_dir, build_dir, options):
         self.source_dir = source_dir
         self.build_dir = build_dir
-
+        self.temp_dir = None
         # Do not try to create build directories when build_dir is none.
         # This reduced mode is used by the --buildoptions introspector
         if build_dir is not None:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -386,7 +386,6 @@ class Environment:
             os.makedirs(self.scratch_dir, exist_ok=True)
             os.makedirs(self.log_dir, exist_ok=True)
             os.makedirs(self.info_dir, exist_ok=True)
-            os.makedirs(self.temp_dir, exist_ok=True)
             try:
                 self.coredata = coredata.load(self.get_build_dir())
                 self.first_invocation = False

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -372,7 +372,6 @@ class Environment:
     private_dir = 'meson-private'
     log_dir = 'meson-logs'
     info_dir = 'meson-info'
-    temp_dir = 'meson-temp'
 
     def __init__(self, source_dir, build_dir, options):
         self.source_dir = source_dir
@@ -384,7 +383,6 @@ class Environment:
             self.scratch_dir = os.path.join(build_dir, Environment.private_dir)
             self.log_dir = os.path.join(build_dir, Environment.log_dir)
             self.info_dir = os.path.join(build_dir, Environment.info_dir)
-            self.temp_dir = os.path.join(build_dir, Environment.temp_dir)
             os.makedirs(self.scratch_dir, exist_ok=True)
             os.makedirs(self.log_dir, exist_ok=True)
             os.makedirs(self.info_dir, exist_ok=True)

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -376,7 +376,6 @@ class Environment:
     def __init__(self, source_dir, build_dir, options):
         self.source_dir = source_dir
         self.build_dir = build_dir
-        self.temp_dir = None
         # Do not try to create build directories when build_dir is none.
         # This reduced mode is used by the --buildoptions introspector
         if build_dir is not None:


### PR DESCRIPTION
On my machine (where defender ATP is enabled and the meson build directory is excluded, but %TMP% is not) this PR improves glib configure performance by >5x (from 171.13 seconds to 29.71 seconds).

see #5418 for more details on the performance issues.