### PR TITLE
Fix compiler flags not used for some tests

### DIFF
--- a/mesonbuild/compilers/clike.py
+++ b/mesonbuild/compilers/clike.py
@@ -431,11 +431,11 @@ class CLikeCompiler:
         with self._build_wrapper(code, env, extra_args, dependencies, mode, disable_cache=disable_cache) as p:
             return p.returncode == 0, p.cached
 
-    def _build_wrapper(self, code, env, extra_args, dependencies=None, mode='compile', want_output=False, disable_cache=False):
+    def _build_wrapper(self, code, env, extra_args, dependencies=None, mode='compile', want_output=False, disable_cache=False, temp_dir=None):
         args = self._get_compiler_check_args(env, extra_args, dependencies, mode)
         if disable_cache or want_output:
-            return self.compile(code, extra_args=args, mode=mode, want_output=want_output, temp_dir=env.scratch_dir)
-        return self.cached_compile(code, env.coredata, extra_args=args, mode=mode, temp_dir=env.scratch_dir)
+            return self.compile(code, extra_args=args, mode=mode, want_output=want_output, temp_dir=temp_dir)
+        return self.cached_compile(code, env.coredata, extra_args=args, mode=mode, temp_dir=temp_dir)
 
     def links(self, code, env, *, extra_args=None, dependencies=None, disable_cache=False):
         return self.compiles(code, env, extra_args=extra_args,
@@ -861,7 +861,7 @@ class CLikeCompiler:
         '''
         args = self.get_compiler_check_args()
         n = 'symbols_have_underscore_prefix'
-        with self.compile(code, extra_args=args, mode='compile', want_output=True, temp_dir=env.scratch_dir) as p:
+        with self._build_wrapper(code, env, extra_args=args, mode='compile', want_output=True, temp_dir=env.scratch_dir) as p:
             if p.returncode != 0:
                 m = 'BUG: Unable to compile {!r} check: {}'
                 raise RuntimeError(m.format(n, p.stdo))

--- a/mesonbuild/compilers/clike.py
+++ b/mesonbuild/compilers/clike.py
@@ -396,7 +396,10 @@ class CLikeCompiler:
 
         if mode == 'link':
             # Add LDFLAGS from the env
-            args += env.coredata.get_external_link_args(self.for_machine, self.language)
+            sys_ld_args = env.coredata.get_external_link_args(self.for_machine, self.language)
+            # CFLAGS and CXXFLAGS go to both linking and compiling, but we want them
+            # to only appear on the command line once. Remove dupes.
+            args += [x for x in sys_ld_args if x not in sys_args]
 
         args += self.get_compiler_args_for_mode(mode)
         return args

--- a/mesonbuild/compilers/clike.py
+++ b/mesonbuild/compilers/clike.py
@@ -384,16 +384,17 @@ class CLikeCompiler:
         # Select a CRT if needed since we're linking
         if mode == 'link':
             args += self.get_linker_debug_crt_args()
-        if mode in {'compile', 'preprocess'}:
-            # Add CFLAGS/CXXFLAGS/OBJCFLAGS/OBJCXXFLAGS and CPPFLAGS from the env
-            sys_args = env.coredata.get_external_args(self.for_machine, self.language)
-            # Apparently it is a thing to inject linker flags both
-            # via CFLAGS _and_ LDFLAGS, even though the former are
-            # also used during linking. These flags can break
-            # argument checks. Thanks, Autotools.
-            cleaned_sys_args = self.remove_linkerlike_args(sys_args)
-            args += cleaned_sys_args
-        elif mode == 'link':
+
+        # Add CFLAGS/CXXFLAGS/OBJCFLAGS/OBJCXXFLAGS and CPPFLAGS from the env
+        sys_args = env.coredata.get_external_args(self.for_machine, self.language)
+        # Apparently it is a thing to inject linker flags both
+        # via CFLAGS _and_ LDFLAGS, even though the former are
+        # also used during linking. These flags can break
+        # argument checks. Thanks, Autotools.
+        cleaned_sys_args = self.remove_linkerlike_args(sys_args)
+        args += cleaned_sys_args
+
+        if mode == 'link':
             # Add LDFLAGS from the env
             args += env.coredata.get_external_link_args(self.for_machine, self.language)
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3055,9 +3055,10 @@ recommended as it is not supported on some platforms''')
         self.wipe()
 
         # c_args value should be parsed with shlex
-        self.init(testdir, extra_args=['-Dc_args=foo bar "one two"'])
+        self.init(testdir, extra_args=['-Dc_args=-Dfoo -Dbar "-Dthird=one two"'])
         obj = mesonbuild.coredata.load(self.builddir)
-        self.assertEqual(obj.compiler_options.host['c_args'].value, ['foo', 'bar', 'one two'])
+        self.assertEqual(obj.compiler_options.host['c_args'].value, ['-Dfoo', '-Dbar', '-Dthird=one two'])
+
         self.setconf('-Dc_args="foo bar" one two')
         obj = mesonbuild.coredata.load(self.builddir)
         self.assertEqual(obj.compiler_options.host['c_args'].value, ['foo bar', 'one', 'two'])
@@ -3068,21 +3069,21 @@ recommended as it is not supported on some platforms''')
             self.init(testdir, extra_args=['--bindir=foo', '--bindir=bar',
                                            '-Dbuildtype=plain', '-Dbuildtype=release',
                                            '-Db_sanitize=address', '-Db_sanitize=thread',
-                                           '-Dc_args=foo', '-Dc_args=bar'])
+                                           '-Dc_args=-Dfoo', '-Dc_args=-Dbar'])
             obj = mesonbuild.coredata.load(self.builddir)
             self.assertEqual(obj.builtins['bindir'].value, 'bar')
             self.assertEqual(obj.builtins['buildtype'].value, 'release')
             self.assertEqual(obj.base_options['b_sanitize'].value, 'thread')
-            self.assertEqual(obj.compiler_options.host['c_args'].value, ['bar'])
+            self.assertEqual(obj.compiler_options.host['c_args'].value, ['-Dbar'])
             self.setconf(['--bindir=bar', '--bindir=foo',
                           '-Dbuildtype=release', '-Dbuildtype=plain',
                           '-Db_sanitize=thread', '-Db_sanitize=address',
-                          '-Dc_args=bar', '-Dc_args=foo'])
+                          '-Dc_args=-Dbar', '-Dc_args=-Dfoo'])
             obj = mesonbuild.coredata.load(self.builddir)
             self.assertEqual(obj.builtins['bindir'].value, 'foo')
             self.assertEqual(obj.builtins['buildtype'].value, 'plain')
             self.assertEqual(obj.base_options['b_sanitize'].value, 'address')
-            self.assertEqual(obj.compiler_options.host['c_args'].value, ['foo'])
+            self.assertEqual(obj.compiler_options.host['c_args'].value, ['-Dfoo'])
             self.wipe()
         except KeyError:
             # Ignore KeyError, it happens on CI for compilers that does not


### PR DESCRIPTION
This is #5483 with the unit tests fixed.

Fixing this uncovered a problem. If you do `-Dc_args=-Dfoo="bar"` the quote signs go away. Thus you can't pass string definitions through the command line. Dunno what should be done about it.