### PR TITLE
Return zero in cross_sizeof

### DIFF
--- a/mesonbuild/compilers/clike.py
+++ b/mesonbuild/compilers/clike.py
@@ -550,6 +550,7 @@ class CLikeCompiler:
         {prefix}
         int main(int argc, char **argv) {{
             {type} something;
+            return 0;
         }}'''
         if not self.compiles(t.format(**fargs), env, extra_args=extra_args,
                              dependencies=dependencies)[0]:


### PR DESCRIPTION
There is an error when compiling with -Werror=return-type. Non void
functions must return valid values.