### PR TITLE
Adapting Boost Python library detection to Boost >= 1.67

### DIFF
--- a/ciimage/Dockerfile
+++ b/ciimage/Dockerfile
@@ -23,6 +23,7 @@ RUN sed -i '/^#\sdeb-src /s/^#//' "/etc/apt/sources.list" \
 && apt-get -y install libgcrypt11-dev \
 && apt-get -y install libgpgme-dev \
 && apt-get -y install libhdf5-dev \
+&& apt-get -y install libboost-python-dev \
 && dub fetch urld && dub build urld --compiler=gdc \
 && dub fetch dubtestproject \
 && dub build dubtestproject:test1 --compiler=ldc2 \

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -146,8 +146,7 @@ class BoostDependency(ExternalDependency):
             mlog.debug('Boost library directory is', mlog.bold(self.libdir))
 
         # 3. check if requested modules are valid, that is, either found or in the list of known boost libraries
-        if self.check_invalid_modules():
-            return
+        self.check_invalid_modules()
 
         # 4. final check whether or not we find all requested and valid modules
         self.check_find_requested_modules()

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -140,10 +140,12 @@ class BoostDependency(ExternalDependency):
         # 1. check if we can find BOOST headers.
         self.detect_headers_and_version()
 
+        if not self.is_found:
+            return # if we can not find 'boost/version.hpp'
+
         # 2. check if we can find BOOST libraries.
-        if self.is_found:
-            self.detect_lib_modules()
-            mlog.debug('Boost library directory is', mlog.bold(self.libdir))
+        self.detect_lib_modules()
+        mlog.debug('Boost library directory is', mlog.bold(self.libdir))
 
         # 3. check if requested modules are valid, that is, either found or in the list of known boost libraries
         self.check_invalid_modules()

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -146,7 +146,7 @@ class BoostDependency(ExternalDependency):
         # 2. check if we can find BOOST libraries.
         self.detect_lib_modules()
         mlog.debug('Boost library directory is', mlog.bold(self.libdir))
-        mlog.debug('Installed Boost libraries are: ',str(self.lib_modules))
+        mlog.debug('Installed Boost libraries are: ', str(self.lib_modules))
 
         # 3. check if requested modules are valid, that is, either found or in the list of known boost libraries
         self.check_invalid_modules()

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -134,9 +134,6 @@ class BoostDependency(ExternalDependency):
             else:
                 self.incdir = self.detect_nix_incdir()
 
-        if self.check_invalid_modules():
-            return
-
         mlog.debug('Boost library root dir is', mlog.bold(self.boost_root))
         mlog.debug('Boost include directory is', mlog.bold(self.incdir))
 
@@ -148,8 +145,12 @@ class BoostDependency(ExternalDependency):
             self.detect_lib_modules()
             mlog.debug('Boost library directory is', mlog.bold(self.libdir))
 
+        # 3. check if requested modules are valid, that is, either found or in the list of known boost libraries
+        if self.check_invalid_modules():
+            return
+
     def check_invalid_modules(self):
-        invalid_modules = [c for c in self.requested_modules if 'boost_' + c not in BOOST_LIBS]
+        invalid_modules = [c for c in self.requested_modules if 'boost_' + c not in self.lib_modules and 'boost_' + c not in BOOST_LIBS]
 
         # previous versions of meson allowed include dirs as modules
         remove = []
@@ -491,7 +492,6 @@ class BoostDependency(ExternalDependency):
     def get_sources(self):
         return []
 
-
 # Generated with boost_names.py
 BOOST_LIBS = [
     'boost_atomic',
@@ -547,10 +547,6 @@ BOOST_LIBS = [
     'boost_math_c99l',
     'boost_mpi',
     'boost_program_options',
-    'boost_python',
-    'boost_python3',
-    'boost_numpy',
-    'boost_numpy3',
     'boost_random',
     'boost_regex',
     'boost_serialization',

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -146,7 +146,10 @@ class BoostDependency(ExternalDependency):
         # 2. check if we can find BOOST libraries.
         self.detect_lib_modules()
         mlog.debug('Boost library directory is', mlog.bold(self.libdir))
-        mlog.debug('Installed Boost libraries are: ', str(self.lib_modules))
+
+        mlog.debug('Installed Boost libraries: ')
+        for key in sorted(self.lib_modules.keys()):
+            mlog.debug(key, self.lib_modules[key])
 
         # 3. check if requested modules are valid, that is, either found or in the list of known boost libraries
         self.check_invalid_modules()

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -149,6 +149,9 @@ class BoostDependency(ExternalDependency):
         if self.check_invalid_modules():
             return
 
+        # 4. final check whether or not we find all requested and valid modules
+        self.check_find_requested_modules()
+
     def check_invalid_modules(self):
         invalid_modules = [c for c in self.requested_modules if 'boost_' + c not in self.lib_modules and 'boost_' + c not in BOOST_LIBS]
 
@@ -274,6 +277,7 @@ class BoostDependency(ExternalDependency):
             else:
                 self.detect_lib_modules_nix()
 
+    def check_find_requested_modules(self):
         # 3. Check if we can find the modules
         for m in self.requested_modules:
             if 'boost_' + m not in self.lib_modules:

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -146,6 +146,7 @@ class BoostDependency(ExternalDependency):
         # 2. check if we can find BOOST libraries.
         self.detect_lib_modules()
         mlog.debug('Boost library directory is', mlog.bold(self.libdir))
+        mlog.debug('Installed Boost libraries are: ',str(self.lib_modules))
 
         # 3. check if requested modules are valid, that is, either found or in the list of known boost libraries
         self.check_invalid_modules()

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -40,6 +40,10 @@ if(python2dep.found())
     # if we have an older version of boost, we need to use the old module names
     bpython2dep = dependency('boost', modules : ['python'])
   endif
+
+  if not (bpython2dep.found())
+    bpython2dep = disabler()
+  endif
 else
   python2dep = disabler()
   bpython2dep = disabler()
@@ -50,7 +54,11 @@ if(python3dep.found())
     py3version_string = ''.join(python3dep.version().split('.'))
     bpython3dep = dependency('boost', modules : ['python' + py3version_string])
   else
-    bpython3dep = dependency('boost', modules : ['python3'])
+    bpython3dep = dependency('boost', modules : ['python3'], required: false)
+  endif
+
+  if not (bpython3dep.found())
+    bpython3dep = disabler()
   endif
 else
   python3dep = disabler()
@@ -74,9 +82,12 @@ test('Boost nomod', nomodexe)
 test('Boost extralib test', extralibexe)
 
 # explicitly use the correct python interpreter so that we don't have to provide two different python scripts that have different shebang lines
-python2interpreter = find_program('python2', required: false)
+pymod = import('python')
+python2 = pymod.find_installation('python2', required: false, disabler: true)
+python2interpreter = find_program(python2.path(), required: false, disabler: true)
 test('Boost Python2', python2interpreter, args: ['./test_python_module.py', meson.current_build_dir()], workdir: meson.current_source_dir(), depends: python2module)
-python3interpreter = find_program('python3', required: false)
+python3 = pymod.find_installation('python3', required: false, disabler: true)
+python3interpreter = find_program(python3.path(), required: false, disabler: true)
 test('Boost Python3', python3interpreter, args: ['./test_python_module.py', meson.current_build_dir()], workdir: meson.current_source_dir(), depends: python2module)
 
 subdir('partial_dep')

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -39,10 +39,10 @@ if(python2dep.found())
     # on the installed version of python (and hope that they match the version boost
     # was compiled against)
     py2version_string = ''.join(python2dep.version().split('.'))
-    bpython2dep = dependency('boost', modules : ['python' + py2version_string], required: false)
+    bpython2dep = dependency('boost', modules : ['python' + py2version_string], required: host_machine.system() == 'linux')
   else
     # if we have an older version of boost, we need to use the old module names
-    bpython2dep = dependency('boost', modules : ['python'], required: false)
+    bpython2dep = dependency('boost', modules : ['python'], required: host_machine.system() == 'linux')
   endif
 
   if not (bpython2dep.found())
@@ -56,9 +56,9 @@ endif
 if(python3dep.found())
   if(dep.version().version_compare('>=1.67'))
     py3version_string = ''.join(python3dep.version().split('.'))
-    bpython3dep = dependency('boost', modules : ['python' + py3version_string], required: false)
+    bpython3dep = dependency('boost', modules : ['python' + py3version_string], required: host_machine.system() == 'linux')
   else
-    bpython3dep = dependency('boost', modules : ['python3'], required: false)
+    bpython3dep = dependency('boost', modules : ['python3'], required: host_machine.system() == 'linux')
   endif
 
   if not (bpython3dep.found())

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -25,8 +25,12 @@ staticdep = dependency('boost', modules : ['thread', 'system'], static : true)
 testdep = dependency('boost', modules : ['unit_test_framework'])
 nomoddep = dependency('boost')
 extralibdep = dependency('boost', modules : ['thread', 'system', 'log_setup', 'log'])
-python2dep = dependency('python', required: false)
-python3dep = dependency('python3', required: false)
+
+pymod = import('python')
+python2 = pymod.find_installation('python2', required: false, disabler: true)
+python3 = pymod.find_installation('python3', required: false, disabler: true)
+python2dep = python2.dependency(required: false, disabler: true)
+python3dep = python3.dependency(required: false, disabler: true)
 
 # compile python 2/3 modules only if we found a corresponding python version
 if(python2dep.found())
@@ -35,10 +39,10 @@ if(python2dep.found())
     # on the installed version of python (and hope that they match the version boost
     # was compiled against)
     py2version_string = ''.join(python2dep.version().split('.'))
-    bpython2dep = dependency('boost', modules : ['python' + py2version_string])
+    bpython2dep = dependency('boost', modules : ['python' + py2version_string], required: false)
   else
     # if we have an older version of boost, we need to use the old module names
-    bpython2dep = dependency('boost', modules : ['python'])
+    bpython2dep = dependency('boost', modules : ['python'], required: false)
   endif
 
   if not (bpython2dep.found())
@@ -52,7 +56,7 @@ endif
 if(python3dep.found())
   if(dep.version().version_compare('>=1.67'))
     py3version_string = ''.join(python3dep.version().split('.'))
-    bpython3dep = dependency('boost', modules : ['python' + py3version_string])
+    bpython3dep = dependency('boost', modules : ['python' + py3version_string], required: false)
   else
     bpython3dep = dependency('boost', modules : ['python3'], required: false)
   endif
@@ -82,11 +86,8 @@ test('Boost nomod', nomodexe)
 test('Boost extralib test', extralibexe)
 
 # explicitly use the correct python interpreter so that we don't have to provide two different python scripts that have different shebang lines
-pymod = import('python')
-python2 = pymod.find_installation('python2', required: false, disabler: true)
 python2interpreter = find_program(python2.path(), required: false, disabler: true)
 test('Boost Python2', python2interpreter, args: ['./test_python_module.py', meson.current_build_dir()], workdir: meson.current_source_dir(), depends: python2module)
-python3 = pymod.find_installation('python3', required: false, disabler: true)
 python3interpreter = find_program(python3.path(), required: false, disabler: true)
 test('Boost Python3', python3interpreter, args: ['./test_python_module.py', meson.current_build_dir()], workdir: meson.current_source_dir(), depends: python2module)
 

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -25,6 +25,37 @@ staticdep = dependency('boost', modules : ['thread', 'system'], static : true)
 testdep = dependency('boost', modules : ['unit_test_framework'])
 nomoddep = dependency('boost')
 extralibdep = dependency('boost', modules : ['thread', 'system', 'log_setup', 'log'])
+python2dep = dependency('python', required: false)
+python3dep = dependency('python3', required: false)
+
+# compile python 2/3 modules only if we found a corresponding python version
+if(python2dep.found())
+  if(dep.version().version_compare('>=1.67'))
+    # if we have a new version of boost, we need to construct the module name based
+    # on the installed version of python (and hope that they match the version boost
+    # was compiled against)
+    py2version_string = ''.join(python2dep.version().split('.'))
+    bpython2dep = dependency('boost', modules : ['python' + py2version_string])
+  else
+    # if we have an older version of boost, we need to use the old module names
+    bpython2dep = dependency('boost', modules : ['python'])
+  endif
+else
+  python2dep = disabler()
+  bpython2dep = disabler()
+endif
+
+if(python3dep.found())
+  if(dep.version().version_compare('>=1.67'))
+    py3version_string = ''.join(python3dep.version().split('.'))
+    bpython3dep = dependency('boost', modules : ['python' + py3version_string])
+  else
+    bpython3dep = dependency('boost', modules : ['python3'])
+  endif
+else
+  python3dep = disabler()
+  bpython3dep = disabler()
+endif
 
 linkexe = executable('linkedexe', 'linkexe.cc', dependencies : linkdep)
 staticexe = executable('staticlinkedexe', 'linkexe.cc', dependencies : staticdep)
@@ -32,11 +63,21 @@ unitexe = executable('utf', 'unit_test.cpp', dependencies: testdep)
 nomodexe = executable('nomod', 'nomod.cpp', dependencies : nomoddep)
 extralibexe = executable('extralibexe', 'extralib.cpp', dependencies : extralibdep)
 
+# python modules are shared libraries
+python2module = shared_library('python2_module', ['python_module.cpp'], dependencies: [python2dep, bpython2dep], name_prefix: '', cpp_args: ['-DMOD_NAME=python2_module'])
+python3module = shared_library('python3_module', ['python_module.cpp'], dependencies: [python3dep, bpython3dep], name_prefix: '', cpp_args: ['-DMOD_NAME=python3_module'])
+
 test('Boost linktest', linkexe)
 test('Boost statictest', staticexe)
 test('Boost UTF test', unitexe)
 test('Boost nomod', nomodexe)
 test('Boost extralib test', extralibexe)
+
+# explicitly use the correct python interpreter so that we don't have to provide two different python scripts that have different shebang lines
+python2interpreter = find_program('python2', required: false)
+test('Boost Python2', python2interpreter, args: ['./test_python_module.py', meson.current_build_dir()], workdir: meson.current_source_dir(), depends: python2module)
+python3interpreter = find_program('python3', required: false)
+test('Boost Python3', python3interpreter, args: ['./test_python_module.py', meson.current_build_dir()], workdir: meson.current_source_dir(), depends: python2module)
 
 subdir('partial_dep')
 

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -33,16 +33,16 @@ python2dep = python2.dependency(required: false, disabler: true)
 python3dep = python3.dependency(required: false, disabler: true)
 
 # compile python 2/3 modules only if we found a corresponding python version
-if(python2dep.found())
+if(python2dep.found() and host_machine.system() == 'linux')
   if(dep.version().version_compare('>=1.67'))
     # if we have a new version of boost, we need to construct the module name based
     # on the installed version of python (and hope that they match the version boost
     # was compiled against)
     py2version_string = ''.join(python2dep.version().split('.'))
-    bpython2dep = dependency('boost', modules : ['python' + py2version_string], required: host_machine.system() == 'linux')
+    bpython2dep = dependency('boost', modules : ['python' + py2version_string], required: false)
   else
     # if we have an older version of boost, we need to use the old module names
-    bpython2dep = dependency('boost', modules : ['python'], required: host_machine.system() == 'linux')
+    bpython2dep = dependency('boost', modules : ['python'], required: false)
   endif
 
   if not (bpython2dep.found())
@@ -53,12 +53,12 @@ else
   bpython2dep = disabler()
 endif
 
-if(python3dep.found())
+if(python3dep.found() and host_machine.system() == 'linux')
   if(dep.version().version_compare('>=1.67'))
     py3version_string = ''.join(python3dep.version().split('.'))
-    bpython3dep = dependency('boost', modules : ['python' + py3version_string], required: host_machine.system() == 'linux')
+    bpython3dep = dependency('boost', modules : ['python' + py3version_string], required: false)
   else
-    bpython3dep = dependency('boost', modules : ['python3'], required: host_machine.system() == 'linux')
+    bpython3dep = dependency('boost', modules : ['python3'], required: false)
   endif
 
   if not (bpython3dep.found())

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -27,10 +27,10 @@ nomoddep = dependency('boost')
 extralibdep = dependency('boost', modules : ['thread', 'system', 'log_setup', 'log'])
 
 pymod = import('python')
-python2 = pymod.find_installation('python2', required: false, disabler: true)
-python3 = pymod.find_installation('python3', required: false, disabler: true)
-python2dep = python2.dependency(required: false, disabler: true)
-python3dep = python3.dependency(required: false, disabler: true)
+python2 = pymod.find_installation('python2', required: host_machine.system() == 'linux', disabler: true)
+python3 = pymod.find_installation('python3', required: host_machine.system() == 'linux', disabler: true)
+python2dep = python2.dependency(required: host_machine.system() == 'linux', disabler: true)
+python3dep = python3.dependency(required: host_machine.system() == 'linux', disabler: true)
 
 # compile python 2/3 modules only if we found a corresponding python version
 if(python2dep.found() and host_machine.system() == 'linux')
@@ -39,10 +39,10 @@ if(python2dep.found() and host_machine.system() == 'linux')
     # on the installed version of python (and hope that they match the version boost
     # was compiled against)
     py2version_string = ''.join(python2dep.version().split('.'))
-    bpython2dep = dependency('boost', modules : ['python' + py2version_string], required: false)
+    bpython2dep = dependency('boost', modules : ['python' + py2version_string])
   else
     # if we have an older version of boost, we need to use the old module names
-    bpython2dep = dependency('boost', modules : ['python'], required: false)
+    bpython2dep = dependency('boost', modules : ['python'])
   endif
 
   if not (bpython2dep.found())
@@ -56,9 +56,9 @@ endif
 if(python3dep.found() and host_machine.system() == 'linux')
   if(dep.version().version_compare('>=1.67'))
     py3version_string = ''.join(python3dep.version().split('.'))
-    bpython3dep = dependency('boost', modules : ['python' + py3version_string], required: false)
+    bpython3dep = dependency('boost', modules : ['python' + py3version_string])
   else
-    bpython3dep = dependency('boost', modules : ['python3'], required: false)
+    bpython3dep = dependency('boost', modules : ['python3'])
   endif
 
   if not (bpython3dep.found())

--- a/test cases/frameworks/1 boost/python_module.cpp
+++ b/test cases/frameworks/1 boost/python_module.cpp
@@ -1,0 +1,22 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <boost/python.hpp>
+
+struct World
+{
+    void set(std::string msg) { this->msg = msg; }
+    std::string greet() { return msg; }
+    std::string version() { return std::to_string(PY_MAJOR_VERSION) + "." + std::to_string(PY_MINOR_VERSION); }
+    std::string msg;
+};
+
+
+BOOST_PYTHON_MODULE(MOD_NAME)
+{
+    using namespace boost::python;
+    class_<World>("World")
+        .def("greet", &World::greet)
+        .def("set", &World::set)
+        .def("version", &World::version)
+    ;
+}

--- a/test cases/frameworks/1 boost/python_module.cpp
+++ b/test cases/frameworks/1 boost/python_module.cpp
@@ -1,6 +1,14 @@
 #define PY_SSIZE_T_CLEAN
+#ifdef _DEBUG
+#undef _DEBUG
 #include <Python.h>
 #include <boost/python.hpp>
+#define _DEBUG
+#else
+#include <Python.h>
+#include <boost/python.hpp>
+#endif
+
 
 struct World
 {

--- a/test cases/frameworks/1 boost/python_module.cpp
+++ b/test cases/frameworks/1 boost/python_module.cpp
@@ -1,14 +1,6 @@
 #define PY_SSIZE_T_CLEAN
-#ifdef _DEBUG
-#undef _DEBUG
 #include <Python.h>
 #include <boost/python.hpp>
-#define _DEBUG
-#else
-#include <Python.h>
-#include <boost/python.hpp>
-#endif
-
 
 struct World
 {

--- a/test cases/frameworks/1 boost/test_python_module.py
+++ b/test cases/frameworks/1 boost/test_python_module.py
@@ -1,0 +1,22 @@
+import sys
+sys.path.append(sys.argv[1])
+
+# import compiled python module depending on version of python we are running with
+if sys.version_info[0] == 2:
+    import python2_module as pm
+
+if sys.version_info[0] == 3:
+    import python3_module as pm
+
+
+def run():
+    msg = 'howdy'
+    w = pm.World()
+    w.set(msg)
+
+    assert( msg == w.greet() )
+    version_string = str(sys.version_info[0]) + "." + str(sys.version_info[1])
+    assert( version_string == w.version())
+
+if __name__ == '__main__':
+    run()

--- a/test cases/frameworks/1 boost/test_python_module.py
+++ b/test cases/frameworks/1 boost/test_python_module.py
@@ -3,15 +3,20 @@ sys.path.append(sys.argv[1])
 
 # import compiled python module depending on version of python we are running with
 if sys.version_info[0] == 2:
-    import python2_module as pm
+    import python2_module
 
 if sys.version_info[0] == 3:
-    import python3_module as pm
+    import python3_module
 
 
 def run():
     msg = 'howdy'
-    w = pm.World()
+    if sys.version_info[0] == 2:
+        w = python2_module.World()
+
+    if sys.version_info[0] == 3:
+        w = python3_module.World()
+
     w.set(msg)
 
     assert(msg == w.greet())

--- a/test cases/frameworks/1 boost/test_python_module.py
+++ b/test cases/frameworks/1 boost/test_python_module.py
@@ -14,9 +14,9 @@ def run():
     w = pm.World()
     w.set(msg)
 
-    assert( msg == w.greet() )
+    assert(msg == w.greet())
     version_string = str(sys.version_info[0]) + "." + str(sys.version_info[1])
-    assert( version_string == w.version())
+    assert(version_string == w.version())
 
 if __name__ == '__main__':
     run()


### PR DESCRIPTION
This is an attempt to close #4288

As mentioned in #4288 Boost.Python libraries are not detected anymore as the version number of the python installation to which the boost libraries where compiled is included in the naming. Thus, we can not look for 'boost_python' or 'boost_python3' anymore, but need to include the major and minor python version number as a suffix. 

To make the detection of Boost Python libraries flexible, we now firstly look for available Boost modules and check afterwards whether or not the requested modules are (in-)valid. This enables us to check against detected and known modules.

However, as the version number of python is now included, one could think about introducing a version check here as well. 

I tested the patch on Fedora 30 with a custom installation of Boost 1.70