### PR TITLE
Fix MSVC /link argument ordering

### DIFF
--- a/mesonbuild/compilers/clike.py
+++ b/mesonbuild/compilers/clike.py
@@ -431,7 +431,12 @@ class CLikeCompiler:
         largs += la
 
         cargs += self.get_compiler_check_args()
-        # extra_args must override all other arguments, so we add them last
+
+        # on MSVC compiler and linker flags must be separated by the "/link" argument
+        # at this point, the '/link' argument may already be part of extra_args, otherwise, it is added here
+        if self.linker_to_compiler_args([]) == ['/link'] and not ('/link' in extra_args):
+            extra_args += ['/link']
+
         args = cargs + extra_args + largs
         return args
 

--- a/mesonbuild/compilers/clike.py
+++ b/mesonbuild/compilers/clike.py
@@ -434,7 +434,7 @@ class CLikeCompiler:
 
         # on MSVC compiler and linker flags must be separated by the "/link" argument
         # at this point, the '/link' argument may already be part of extra_args, otherwise, it is added here
-        if self.linker_to_compiler_args([]) == ['/link'] and not ('/link' in extra_args):
+        if self.linker_to_compiler_args([]) == ['/link'] and largs != [] and not ('/link' in extra_args):
             extra_args += ['/link']
 
         args = cargs + extra_args + largs

--- a/mesonbuild/compilers/clike.py
+++ b/mesonbuild/compilers/clike.py
@@ -317,7 +317,7 @@ class CLikeCompiler:
             ofile.write(code)
         # Compile sanity check
         # NOTE: extra_flags must be added at the end. On MSVC, it might contain a '/link' argument
-        # after which all further arguments will be passed directly to the linker        
+        # after which all further arguments will be passed directly to the linker
         cmdlist = self.exelist + [source_name] + self.get_output_args(binary_name) + extra_flags
         pc, stdo, stde = mesonlib.Popen_safe(cmdlist, cwd=work_dir)
         mlog.debug('Sanity check compiler command line:', ' '.join(cmdlist))

--- a/mesonbuild/compilers/clike.py
+++ b/mesonbuild/compilers/clike.py
@@ -316,6 +316,8 @@ class CLikeCompiler:
         with open(source_name, 'w') as ofile:
             ofile.write(code)
         # Compile sanity check
+        # NOTE: extra_flags must be added at the end. On MSVC, it might contain a '/link' argument
+        # after which all further arguments will be passed directly to the linker        
         cmdlist = self.exelist + [source_name] + self.get_output_args(binary_name) + extra_flags
         pc, stdo, stde = mesonlib.Popen_safe(cmdlist, cwd=work_dir)
         mlog.debug('Sanity check compiler command line:', ' '.join(cmdlist))


### PR DESCRIPTION
On MSCV, linker arguments must follow after compiler arguments, separated by /link. The routine VisualStudioLikeCompiler.linker_to_compiler_args did exist to handle this, but it was not used consistently. This patch addresses all missing cases that I encountered, specifically then use of LDFLAGS for find_library and for sanity_check (addresses #3629)