### PR TITLE
env: Do not return empty tool env vars

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -340,6 +340,10 @@ This is probably wrong, it should always point to the native compiler.''' % evar
             command = os.environ.get(evar)
             if command is not None:
                 command = shlex.split(command)
+
+        # Do not return empty string entries
+        if command is not None and len(command) == 0:
+            return None
         return command
 
 class Directories:


### PR DESCRIPTION
A compiler or other tool with an empty string as name does not make
sense as it anyway can not be used and causes a failure later in
parse_entry.

Fix #5451