### PR TITLE
check that compiler name is not blank or empty

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -341,8 +341,8 @@ This is probably wrong, it should always point to the native compiler.''' % evar
             if command is not None:
                 command = shlex.split(command)
 
-        # Do not return empty string entries
-        if command is not None and len(command) == 0:
+        # Do not return empty or blank string entries
+        if command is not None and (len(command) == 0 or len(command[0].strip()) == 0):
             return None
         return command
 


### PR DESCRIPTION
Handles additional cases from #5601 on Linux, Windows, etc.  For example, assuming environment variable CC is of interest:

```sh
CC=" "
CC=""
CC=''
CC="                          "
```

and the like are handled.

fixes #5451 