### PR TITLE
BUGFIX: typo from 32e827dcdc451e1c5 broke PGI compilers

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -910,7 +910,7 @@ class Environment:
                     return PathScaleFortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version)
 
                 if 'PGI Compilers' in out:
-                    if self.machine[for_machine].is_darwin():
+                    if self.machines[for_machine].is_darwin():
                         compiler_type = CompilerType.PGI_OSX
                     elif self.machines[for_machine].is_windows():
                         compiler_type = CompilerType.PGI_WIN


### PR DESCRIPTION
PGI compilers were broken by typo in 32e827dcdc451e1c5
