### PR TITLE
allow meson setup --prefix=~

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -433,6 +433,7 @@ class CoreData:
             self.builtins['libdir'].value = 'lib'
 
     def sanitize_prefix(self, prefix):
+        prefix = os.path.expanduser(prefix)
         if not os.path.isabs(prefix):
             raise MesonException('prefix value {!r} must be an absolute path'
                                  ''.format(prefix))


### PR DESCRIPTION
allow the installation prefix to be specified with `~`, which is more OS-agnostic than users fiddling with $HOME, %userprofile% for `meson setup --prefix=~/.local` to work on Windows, Linux, etc.

CMake *et al* allow ~ in prefix.