### PR TITLE
unit tests: Fix CI failures in NativeFileTests

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5881,7 +5881,7 @@ class NativeFileTests(BasePlatformTests):
             if mesonbuild.environment.detect_msys2_arch():
                 f.write(r'@python3 {} %*'.format(filename))
             else:
-                f.write('@py -3 {} %*'.format(filename))
+                f.write('@{} {} %*'.format(sys.executable, filename))
         return batfile
 
     def helper_for_compiler(self, lang, cb, for_machine = MachineChoice.HOST):


### PR DESCRIPTION
We can't rely on `py` always being available in `PATH`, use `sys.executable` which is the real path to Python 3.