### PR TITLE
cmake: Fix dependencies with try_compile (closes #5605)

### DIFF
--- a/test cases/linuxlike/13 cmake dependency/cmake/FindSomethingLikeZLIB.cmake
+++ b/test cases/linuxlike/13 cmake dependency/cmake/FindSomethingLikeZLIB.cmake
@@ -1,5 +1,8 @@
 find_package(ZLIB)
 
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
 if(ZLIB_FOUND OR ZLIB_Found)
   set(SomethingLikeZLIB_FOUND        ON)
   set(SomethingLikeZLIB_LIBRARIES    ${ZLIB_LIBRARY})


### PR DESCRIPTION
Finding some CMake dependencies currently fails because the C and C++ compilers aren't set correctly (just a placeholder file is used). This works in most cases but fails as soon as the compiler is required in the dependency finding process (such as the CMake try_compile function).