### PR TITLE
CMake: Support INTERFACE libraries

### DIFF
--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -199,16 +199,23 @@ class CMakeTraceParser:
         args = list(tline.args) # Make a working copy
 
         # Make sure the lib is imported
-        if 'IMPORTED' not in args:
-            return self._gen_exception('add_library', 'non imported libraries are not supported', tline)
+        if 'INTERFACE' in args:
+            args.remove('INTERFACE')
 
-        args.remove('IMPORTED')
+            if len(args) < 1:
+                return self._gen_exception('add_library', 'interface library name not specified', tline)
 
-        # No only look at the first two arguments (target_name and target_type) and ignore the rest
-        if len(args) < 2:
-            return self._gen_exception('add_library', 'requires at least 2 arguments', tline)
+            self.targets[args[0]] = CMakeTarget(args[0], 'INTERFACE', {})
+        elif 'IMPORTED' in args:
+            args.remove('IMPORTED')
 
-        self.targets[args[0]] = CMakeTarget(args[0], args[1], {})
+            # No only look at the first two arguments (target_name and target_type) and ignore the rest
+            if len(args) < 2:
+                return self._gen_exception('add_library', 'requires at least 2 arguments', tline)
+
+            self.targets[args[0]] = CMakeTarget(args[0], args[1], {})
+        else:
+            return self._gen_exception('add_library', 'non imported / interface libraries are not supported', tline)
 
     def _cmake_add_custom_command(self, tline: CMakeTraceLine):
         # DOC: https://cmake.org/cmake/help/latest/command/add_custom_command.html

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -343,8 +343,8 @@ class CMakeTraceParser:
         # set_property() this is not context free. There are two approaches I
         # can think of, both have drawbacks:
         #
-        #   1. Assume that the property will be capitalized, this is convention
-        #      but cmake doesn't require it.
+        #   1. Assume that the property will be capitalized ([A-Z_]), this is
+        #      convention but cmake doesn't require it.
         #   2. Maintain a copy of the list here: https://cmake.org/cmake/help/latest/manual/cmake-properties.7.html#target-properties
         #
         # Neither of these is awesome for obvious reasons. I'm going to try
@@ -354,8 +354,9 @@ class CMakeTraceParser:
         arglist = []  # type: List[Tuple[str, List[str]]]
         name = args.pop(0)
         values = []
+        prop_regex = re.compile(r'^[A-Z_]+$')
         for a in args:
-            if a.isupper():
+            if prop_regex.match(a):
                 if values:
                     arglist.append((name, ' '.join(values).split(';')))
                 name = a

--- a/test cases/cmake/9 header only/main.cpp
+++ b/test cases/cmake/9 header only/main.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <cmMod.hpp>
+
+using namespace std;
+
+int main() {
+  cmModClass obj("Hello");
+  cout << obj.getStr() << endl;
+  return 0;
+}

--- a/test cases/cmake/9 header only/meson.build
+++ b/test cases/cmake/9 header only/meson.build
@@ -1,0 +1,12 @@
+project('cmakeSubTest', ['c', 'cpp'])
+
+cm = import('cmake')
+
+sub_pro = cm.subproject('cmMod')
+sub_dep = sub_pro.dependency('cmModLib')
+
+assert(sub_pro.target_list() == ['cmModLib'], 'There should be exactly one target')
+assert(sub_pro.target_type('cmModLib') == 'header_only', 'Target type should be header_only')
+
+exe1 = executable('main', ['main.cpp'], dependencies: [sub_dep])
+test('test1', exe1)

--- a/test cases/cmake/9 header only/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/9 header only/subprojects/cmMod/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(cmMod)
+set (CMAKE_CXX_STANDARD 14)
+
+add_definitions("-DDO_NOTHING_JUST_A_FLAG=1")
+
+add_library(cmModLib INTERFACE)
+set_target_properties(cmModLib PROPERTIES INTERFACE_COMPILE_OPTIONS "-DCMAKE_FLAG_MUST_BE_PRESENT")
+target_include_directories(cmModLib INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_compile_definitions(cmModLib INTERFACE -DCMAKE_COMPILER_DEFINE_STR="compDef")

--- a/test cases/cmake/9 header only/subprojects/cmMod/include/cmMod.hpp
+++ b/test cases/cmake/9 header only/subprojects/cmMod/include/cmMod.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+#ifndef CMAKE_FLAG_MUST_BE_PRESENT
+#error "The flag CMAKE_FLAG_MUST_BE_PRESENT was not set"
+#endif
+
+class cmModClass {
+  private:
+    std::string str;
+  public:
+    cmModClass(std::string foo) {
+      str = foo + " World ";
+      str += CMAKE_COMPILER_DEFINE_STR;
+    }
+
+    inline std::string getStr() const { return str; }
+};


### PR DESCRIPTION
This PR adds support for INTERFACE libraries for CMake subprojects by extending the trace parser.

However, since INTERFACE libraries regularly use generator expressions, this PR doesn't really fix #5634. CMake generator expressions will be handled in a separate PR.