### PR TITLE
Show command line in `ninja -v` for `capture: true` custom targets and generators

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -69,17 +69,14 @@ class TargetInstallData:
         self.optional = optional
 
 class ExecutableSerialisation:
-    def __init__(self, name, fname, cmd_args, env=None, is_cross=False, exe_wrapper=None,
-                 workdir=None, extra_paths=None, capture=None, needs_exe_wrapper: bool = False):
-        self.name = name
+    def __init__(self, fname, cmd_args, env=None, exe_wrapper=None,
+                 workdir=None, extra_paths=None, capture=None):
         self.fname = fname
         self.cmd_args = cmd_args
         self.env = env or {}
-        self.is_cross = is_cross
         if exe_wrapper is not None:
             assert(isinstance(exe_wrapper, dependencies.ExternalProgram))
         self.exe_runner = exe_wrapper
-        self.needs_exe_wrapper = needs_exe_wrapper
         self.workdir = workdir
         self.extra_paths = extra_paths
         self.capture = capture
@@ -387,10 +384,9 @@ class Backend:
         scratch_file = 'meson_exe_{0}_{1}.dat'.format(basename, digest)
         exe_data = os.path.join(self.environment.get_scratch_dir(), scratch_file)
         with open(exe_data, 'wb') as f:
-            es = ExecutableSerialisation(basename, exe_cmd, cmd_args, env,
-                                         is_cross_built, exe_wrapper, workdir,
-                                         extra_paths, capture,
-                                         self.environment.need_exe_wrapper())
+            es = ExecutableSerialisation(exe_cmd, cmd_args, env,
+                                         exe_wrapper, workdir,
+                                         extra_paths, capture)
             pickle.dump(es, f)
         return self.environment.get_build_command() + ['--internal', 'exe', '--unpickle', exe_data]
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -69,9 +69,8 @@ class TargetInstallData:
         self.optional = optional
 
 class ExecutableSerialisation:
-    def __init__(self, fname, cmd_args, env=None, exe_wrapper=None,
+    def __init__(self, cmd_args, env=None, exe_wrapper=None,
                  workdir=None, extra_paths=None, capture=None):
-        self.fname = fname
         self.cmd_args = cmd_args
         self.env = env or {}
         if exe_wrapper is not None:
@@ -384,7 +383,7 @@ class Backend:
         scratch_file = 'meson_exe_{0}_{1}.dat'.format(basename, digest)
         exe_data = os.path.join(self.environment.get_scratch_dir(), scratch_file)
         with open(exe_data, 'wb') as f:
-            es = ExecutableSerialisation(exe_cmd, cmd_args, env,
+            es = ExecutableSerialisation(exe_cmd + cmd_args, env,
                                          exe_wrapper, workdir,
                                          extra_paths, capture)
             pickle.dump(es, f)

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -355,6 +355,10 @@ class Backend:
                       'check the command and/or add it to PATH.'
                 raise MesonException(msg.format(exe_wrapper.name, tname))
         else:
+            if exe_cmd[0].endswith('.jar'):
+                exe_cmd = ['java', '-jar'] + exe_cmd
+            elif exe_cmd[0].endswith('.exe') and not (mesonlib.is_windows() or mesonlib.is_cygwin()):
+                exe_cmd = ['mono'] + exe_cmd
             exe_wrapper = None
 
         force_serialize = force_serialize or extra_paths or workdir or \

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -323,7 +323,7 @@ class Backend:
                 raise MesonException('Unknown data type in object list.')
         return obj_list
 
-    def serialize_executable(self, tname, exe, cmd_args, workdir, env=None,
+    def as_meson_exe_cmdline(self, tname, exe, cmd_args, workdir, env=None,
                              extra_paths=None, capture=None):
         '''
         Serialize an executable for running with a generator or a custom target
@@ -376,7 +376,7 @@ class Backend:
                                          extra_paths, capture,
                                          self.environment.need_exe_wrapper())
             pickle.dump(es, f)
-        return exe_data
+        return self.environment.get_build_command() + ['--internal', 'exe', exe_data]
 
     def serialize_tests(self):
         test_data = os.path.join(self.environment.get_scratch_dir(), 'meson_test_setup.dat')

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -679,12 +679,11 @@ int dummy;
             if extra_paths:
                 serialize = True
         if serialize:
-            exe_data = self.serialize_executable(target.name, target.command[0], cmd[1:],
-                                                 # All targets are built from the build dir
-                                                 self.environment.get_build_dir(),
-                                                 extra_paths=extra_paths,
-                                                 capture=ofilenames[0] if target.capture else None)
-            cmd = self.environment.get_build_command() + ['--internal', 'exe', exe_data]
+            cmd = self.as_meson_exe_cmdline(target.name, target.command[0], cmd[1:],
+                                            # All targets are built from the build dir
+                                            self.environment.get_build_dir(),
+                                            extra_paths=extra_paths,
+                                            capture=ofilenames[0] if target.capture else None)
             cmd_type = 'meson_exe.py custom'
         else:
             cmd_type = 'custom'
@@ -1787,14 +1786,13 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             args = self.replace_paths(target, args, override_subdir=subdir)
             cmdlist = exe_arr + self.replace_extra_args(args, genlist)
             if generator.capture:
-                exe_data = self.serialize_executable(
+                cmd = self.as_meson_exe_cmdline(
                     'generator ' + cmdlist[0],
                     cmdlist[0],
                     cmdlist[1:],
                     self.environment.get_build_dir(),
                     capture=outfiles[0]
                 )
-                cmd = self.environment.get_build_command() + ['--internal', 'exe', exe_data]
                 abs_pdir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(target))
                 os.makedirs(abs_pdir, exist_ok=True)
             else:

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -150,8 +150,9 @@ class Vs2010Backend(backends.Backend):
                         'generator ' + cmd[0],
                         cmd[0],
                         cmd[1:],
-                        tdir_abs,
-                        capture=outfiles[0] if generator.capture else None
+                        workdir=tdir_abs,
+                        capture=outfiles[0] if generator.capture else None,
+                        force_serialize=True
                     )
                     deps = cmd[-1:] + deps
                     abs_pdir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(target))
@@ -559,12 +560,12 @@ class Vs2010Backend(backends.Backend):
         # there are many arguments.
         tdir_abs = os.path.join(self.environment.get_build_dir(), self.get_target_dir(target))
         extra_bdeps = target.get_transitive_build_target_deps()
-        extra_paths = self.determine_windows_extra_paths(target.command[0], extra_bdeps)
         wrapper_cmd = self.as_meson_exe_cmdline(target.name, target.command[0], cmd[1:],
                                                 # All targets run from the target dir
-                                                tdir_abs,
-                                                extra_paths=extra_paths,
-                                                capture=ofilenames[0] if target.capture else None)
+                                                workdir=tdir_abs,
+                                                extra_bdeps=extra_bdeps,
+                                                capture=ofilenames[0] if target.capture else None,
+                                                force_serialize=True)
         if target.build_always_stale:
             # Use a nonexistent file to always consider the target out-of-date.
             ofilenames += [self.nonexistent_file(os.path.join(self.environment.get_scratch_dir(),

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -144,14 +144,13 @@ class Vs2010Backend(backends.Backend):
                     args = [x.replace('\\', '/') for x in args]
                     cmd = exe_arr + self.replace_extra_args(args, genlist)
                     if generator.capture:
-                        exe_data = self.serialize_executable(
+                        cmd = self.as_meson_exe_cmdline(
                             'generator ' + cmd[0],
                             cmd[0],
                             cmd[1:],
                             self.environment.get_build_dir(),
                             capture=outfiles[0]
                         )
-                        cmd = self.environment.get_build_command() + ['--internal', 'exe', exe_data]
                         abs_pdir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(target))
                         os.makedirs(abs_pdir, exist_ok=True)
                     cbs = ET.SubElement(idgroup, 'CustomBuild', Include=infilename)
@@ -559,18 +558,17 @@ class Vs2010Backend(backends.Backend):
         tdir_abs = os.path.join(self.environment.get_build_dir(), self.get_target_dir(target))
         extra_bdeps = target.get_transitive_build_target_deps()
         extra_paths = self.determine_windows_extra_paths(target.command[0], extra_bdeps)
-        exe_data = self.serialize_executable(target.name, target.command[0], cmd[1:],
-                                             # All targets run from the target dir
-                                             tdir_abs,
-                                             extra_paths=extra_paths,
-                                             capture=ofilenames[0] if target.capture else None)
-        wrapper_cmd = self.environment.get_build_command() + ['--internal', 'exe', exe_data]
+        wrapper_cmd = self.as_meson_exe_cmdline(target.name, target.command[0], cmd[1:],
+                                                # All targets run from the target dir
+                                                tdir_abs,
+                                                extra_paths=extra_paths,
+                                                capture=ofilenames[0] if target.capture else None)
         if target.build_always_stale:
             # Use a nonexistent file to always consider the target out-of-date.
             ofilenames += [self.nonexistent_file(os.path.join(self.environment.get_scratch_dir(),
                                                  'outofdate.file'))]
         self.add_custom_build(root, 'custom_target', ' '.join(self.quote_arguments(wrapper_cmd)),
-                              deps=[exe_data] + srcs + depend_files, outputs=ofilenames)
+                              deps=wrapper_cmd[-1:] + srcs + depend_files, outputs=ofilenames)
         ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.targets')
         self.generate_custom_generator_commands(target, root)
         self.add_regen_dependency(root)

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -42,10 +42,10 @@ def run_exe(exe):
     if exe.exe_runner:
         if not exe.exe_runner.found():
             raise AssertionError('BUG: Can\'t run cross-compiled exe {!r} with not-found '
-                                 'wrapper {!r}'.format(exe.fname[0], exe.exe_runner.get_path()))
-        cmd = exe.exe_runner.get_command() + exe.fname
+                                 'wrapper {!r}'.format(exe.cmd_args[0], exe.exe_runner.get_path()))
+        cmd_args = exe.exe_runner.get_command() + exe.cmd_args
     else:
-        cmd = exe.fname
+        cmd_args = exe.cmd_args
     child_env = os.environ.copy()
     child_env.update(exe.env)
     if exe.extra_paths:
@@ -61,7 +61,7 @@ def run_exe(exe):
             else:
                 child_env['WINEPATH'] = wine_path
 
-    p = subprocess.Popen(cmd + exe.cmd_args, env=child_env, cwd=exe.workdir,
+    p = subprocess.Popen(cmd_args, env=child_env, cwd=exe.workdir,
                          close_fds=False,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE)
@@ -103,10 +103,7 @@ def run(args):
         with open(options.unpickle, 'rb') as f:
             exe = pickle.load(f)
     else:
-        exe_cmd = cmd_args[0]
-        cmd_args = cmd_args[1:]
-        exe = ExecutableSerialisation([exe_cmd], cmd_args,
-                                      capture=options.capture)
+        exe = ExecutableSerialisation(cmd_args, capture=options.capture)
 
     return run_exe(exe)
 

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -38,28 +38,18 @@ def is_cygwin():
     platname = platform.system().lower()
     return 'cygwin' in platname
 
-def run_with_mono(fname):
-    if fname.endswith('.exe') and not (is_windows() or is_cygwin()):
-        return True
-    return False
-
 def run_exe(exe):
-    if exe.fname[0].endswith('.jar'):
-        cmd = ['java', '-jar'] + exe.fname
-    elif not exe.is_cross and run_with_mono(exe.fname[0]):
-        cmd = ['mono'] + exe.fname
-    else:
-        if exe.is_cross and exe.needs_exe_wrapper:
-            if exe.exe_runner is None:
-                raise AssertionError('BUG: Can\'t run cross-compiled exe {!r} '
-                                     'with no wrapper'.format(exe.name))
-            elif not exe.exe_runner.found():
-                raise AssertionError('BUG: Can\'t run cross-compiled exe {!r} with not-found '
-                                     'wrapper {!r}'.format(exe.name, exe.exe_runner.get_path()))
-            else:
-                cmd = exe.exe_runner.get_command() + exe.fname
+    if exe.is_cross and exe.needs_exe_wrapper:
+        if exe.exe_runner is None:
+            raise AssertionError('BUG: Can\'t run cross-compiled exe {!r} '
+                                 'with no wrapper'.format(exe.name))
+        elif not exe.exe_runner.found():
+            raise AssertionError('BUG: Can\'t run cross-compiled exe {!r} with not-found '
+                                 'wrapper {!r}'.format(exe.name, exe.exe_runner.get_path()))
         else:
-            cmd = exe.fname
+            cmd = exe.exe_runner.get_command() + exe.fname
+    else:
+        cmd = exe.fname
     child_env = os.environ.copy()
     child_env.update(exe.env)
     if exe.extra_paths:

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -39,15 +39,11 @@ def is_cygwin():
     return 'cygwin' in platname
 
 def run_exe(exe):
-    if exe.is_cross and exe.needs_exe_wrapper:
-        if exe.exe_runner is None:
-            raise AssertionError('BUG: Can\'t run cross-compiled exe {!r} '
-                                 'with no wrapper'.format(exe.name))
-        elif not exe.exe_runner.found():
+    if exe.exe_runner:
+        if not exe.exe_runner.found():
             raise AssertionError('BUG: Can\'t run cross-compiled exe {!r} with not-found '
-                                 'wrapper {!r}'.format(exe.name, exe.exe_runner.get_path()))
-        else:
-            cmd = exe.exe_runner.get_command() + exe.fname
+                                 'wrapper {!r}'.format(exe.fname[0], exe.exe_runner.get_path()))
+        cmd = exe.exe_runner.get_command() + exe.fname
     else:
         cmd = exe.fname
     child_env = os.environ.copy()
@@ -109,8 +105,7 @@ def run(args):
     else:
         exe_cmd = cmd_args[0]
         cmd_args = cmd_args[1:]
-        basename = os.path.basename(exe_cmd)
-        exe = ExecutableSerialisation(basename, [exe_cmd], cmd_args,
+        exe = ExecutableSerialisation([exe_cmd], cmd_args,
                                       capture=options.capture)
 
     return run_exe(exe)

--- a/test cases/common/185 escape and unicode/file.py
+++ b/test cases/common/185 escape and unicode/file.py
@@ -6,5 +6,5 @@ import os
 with open(sys.argv[1]) as fh:
     content = fh.read().replace("{NAME}", sys.argv[2])
 
-with open(os.path.join(sys.argv[3]), 'w') as fh:
+with open(os.path.join(sys.argv[3]), 'w', errors='replace') as fh:
     fh.write(content)


### PR DESCRIPTION
Using `capture: true` with `custom_target` makes "ninja -v" less than useful since the command line is completely hidden from the user. It would be nice if `meson --internal exe` knew to print the command line itself; unfortunately support for a `NINJAFLAGS` command line variable, which would pass -v down to `meson --internal exe`, was rejected.

Instead, this pull request makes `meson_exe` able to create an `ExecutableSerialisation` object from the command line, and uses this new invocation method for the common case of `capture: true` in custom targets and generators.  The code around `ExecutableSerialisation` needs some refactoring in order to support this, which in turn enables simplification of the `meson_exe` script.
