### PR TITLE
mintro: Fix section key in buildoptions

### DIFF
--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -143,7 +143,8 @@ the `intro-buildoptions.json` file. Here is the JSON format for each option.
     "description": "the description",
     "type": "type ID",
     "value": "value depends on type",
-    "section": "section ID"
+    "section": "section ID",
+    "machine": "machine ID"
 }
 ```
 
@@ -167,6 +168,13 @@ The possible values for `section` are:
  - directory
  - user
  - test
+
+The `machine` key specifies the machine configuration for the option. Possible
+values are:
+
+ - any
+ - host
+ - build
 
 To set the options, use the `meson configure` command.
 

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -229,31 +229,33 @@ def list_buildoptions(coredata: cdata.CoreData) -> List[dict]:
     core_options = {k: o for k, o in coredata.builtins.items() if k in core_option_names}
 
     add_keys(optlist, core_options, 'core')
-    add_keys(optlist, coredata.builtins_per_machine.host, 'core (for host machine)')
+    add_keys(optlist, coredata.builtins_per_machine.host, 'core', machine='host')
     add_keys(
         optlist,
         {'build.' + k: o for k, o in coredata.builtins_per_machine.build.items()},
-        'core (for build machine)',
+        'core',
+        machine='build',
     )
     add_keys(optlist, coredata.backend_options, 'backend')
     add_keys(optlist, coredata.base_options, 'base')
-    add_keys(optlist, coredata.compiler_options.host, 'compiler (for host machine)')
+    add_keys(optlist, coredata.compiler_options.host, 'compiler', machine='host')
     add_keys(
         optlist,
         {'build.' + k: o for k, o in coredata.compiler_options.build.items()},
-        'compiler (for build machine)',
+        'compiler',
+        machine='build',
     )
     add_keys(optlist, dir_options, 'directory')
     add_keys(optlist, coredata.user_options, 'user')
     add_keys(optlist, test_options, 'test')
     return optlist
 
-def add_keys(optlist, options: Dict[str, cdata.UserOption], section):
+def add_keys(optlist, options: Dict[str, cdata.UserOption], section: str, machine: str = 'any'):
     keys = list(options.keys())
     keys.sort()
     for key in keys:
         opt = options[key]
-        optdict = {'name': key, 'value': opt.value, 'section': section}
+        optdict = {'name': key, 'value': opt.value, 'section': section, 'machine': machine}
         if isinstance(opt, cdata.UserStringOption):
             typestr = 'string'
         elif isinstance(opt, cdata.UserBooleanOption):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2630,6 +2630,7 @@ int main(int argc, char **argv) {
             'section': 'user',
             'type': 'array',
             'value': ['foo', 'bar'],
+            'machine': 'any',
         }
         tdir = os.path.join(self.unit_test_dir, '19 array option')
         self.init(tdir)
@@ -2655,6 +2656,7 @@ int main(int argc, char **argv) {
             'section': 'user',
             'type': 'array',
             'value': ['foo', 'bar'],
+            'machine': 'any',
         }
         tdir = os.path.join(self.unit_test_dir, '19 array option')
         self.init(tdir)
@@ -2680,6 +2682,7 @@ int main(int argc, char **argv) {
             'section': 'user',
             'type': 'array',
             'value': [],
+            'machine': 'any',
         }
         tdir = os.path.join(self.unit_test_dir, '19 array option')
         self.init(tdir, extra_args='-Dlist=')
@@ -3496,6 +3499,7 @@ recommended as it is not supported on some platforms''')
             ('section', str),
             ('type', str),
             ('description', str),
+            ('machine', str),
         ]
 
         buildoptions_typelist = [
@@ -3505,6 +3509,9 @@ recommended as it is not supported on some platforms''')
             ('integer', int, []),
             ('array', list, []),
         ]
+
+        buildoptions_sections = ['core', 'backend', 'base', 'compiler', 'directory', 'user', 'test']
+        buildoptions_machines = ['any', 'build', 'host']
 
         dependencies_typelist = [
             ('name', str),
@@ -3561,6 +3568,8 @@ recommended as it is not supported on some platforms''')
                     valid_type = True
                     break
 
+            self.assertIn(i['section'], buildoptions_sections)
+            self.assertIn(i['machine'], buildoptions_machines)
             self.assertTrue(valid_type)
             if i['name'] in buildopts_to_find:
                 self.assertEqual(i['value'], buildopts_to_find[i['name']])


### PR DESCRIPTION
This reverts the changes to the `section` key for the
buildoptions and moves the machine choice into it's
own `machine` key.

With this commit the __undocumented__ breaking change
to the introspection format (introduced in 0.51.0) is
reverted and a new key is added instead.

cc: @textshell 