### PR TITLE
Accept vs_module_defs for modules

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1334,6 +1334,13 @@ variables defined in the [`executable`](#executable) it is loaded by,
 you will need to set the `export_dynamic` argument of the executable to
 `true`.
 
+Supports the following extra keyword arguments:
+
+- `vs_module_defs`, *(Added 0.52.0)*, a string, a File object, or
+  Custom Target for a Microsoft module definition file for controlling
+  symbol exports, etc., on platforms where that is possible
+  (e.g. Windows).
+
 **Note:** Linking to a shared module is not supported on some
 platforms, notably OSX.  Consider using a
 [`shared_library`](#shared_library) instead, if you need to both

--- a/docs/markdown/snippets/shared_module_defs.md
+++ b/docs/markdown/snippets/shared_module_defs.md
@@ -1,0 +1,4 @@
+## Added `vs_module_defs` to `shared_module()`
+
+Like `shared_library()`, `shared_module()` now accepts
+`vs_module_defs` argument for controlling symbol exports, etc.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -91,7 +91,7 @@ known_build_target_kwargs = (
 
 known_exe_kwargs = known_build_target_kwargs | {'implib', 'export_dynamic', 'link_language', 'pie'}
 known_shlib_kwargs = known_build_target_kwargs | {'version', 'soversion', 'vs_module_defs', 'darwin_versions'}
-known_shmod_kwargs = known_build_target_kwargs
+known_shmod_kwargs = known_build_target_kwargs | {'vs_module_defs'}
 known_stlib_kwargs = known_build_target_kwargs | {'pic'}
 known_jar_kwargs = known_exe_kwargs | {'main_class'}
 

--- a/test cases/windows/9 vs module defs generated/subdir/meson.build
+++ b/test cases/windows/9 vs module defs generated/subdir/meson.build
@@ -7,3 +7,4 @@ def_file = configure_file(
 )
 
 shlib = shared_library('somedll', 'somedll.c', vs_module_defs : def_file)
+shmod = shared_module('somemod', 'somedll.c', vs_module_defs : def_file)


### PR DESCRIPTION
Like shared libraries, modules may have vs_module_defs.

