### PR TITLE
Fix missing return statements that are seen with -Werror=return-type.

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -67,6 +67,7 @@ class CCompiler(CLikeCompiler, Compiler):
             #ifndef {symbol}
                 {symbol};
             #endif
+            return 0;
         }}'''
         return self.compiles(t.format(**fargs), env, extra_args=extra_args,
                              dependencies=dependencies)

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -332,6 +332,7 @@ class CLikeCompiler:
             #ifndef {symbol}
                 {symbol};
             #endif
+            return 0;
         }}'''
         return self.compiles(t.format(**fargs), env, extra_args=extra_args,
                              dependencies=dependencies)
@@ -555,6 +556,7 @@ class CLikeCompiler:
         {prefix}
         int main() {{
             {type} something;
+            return 0;
         }}'''
         if not self.compiles(t.format(**fargs), env, extra_args=extra_args,
                              dependencies=dependencies)[0]:
@@ -633,6 +635,7 @@ class CLikeCompiler:
         #include <stdio.h>
         int main() {{
             printf ("{fmt}", {cast} {f}());
+            return 0;
         }}'''.format(**fargs)
         res = self.run(code, env, extra_args=extra_args, dependencies=dependencies)
         if not res.compiled:
@@ -785,6 +788,7 @@ class CLikeCompiler:
                 #error "No definition for __builtin_{func} found in the prefix"
             #endif
         #endif
+        return 0;
         }}'''
         return self.links(t.format(**fargs), env, extra_args=extra_args,
                           dependencies=dependencies)


### PR DESCRIPTION
Error example:

```
Code:

        #include <locale.h>
        int main () {
            /* If it's not defined as a macro, try to use as a symbol */
            #ifndef LC_MESSAGES
                LC_MESSAGES;
            #endif
        }
Compiler stdout:

Compiler stderr:
 In file included from /usr/include/locale.h:25,
                 from /tmp/tmpep_i4iwg/testfile.c:2:
/usr/include/features.h:382:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
  382 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~
/tmp/tmpep_i4iwg/testfile.c: In function 'main':
/tmp/tmpep_i4iwg/testfile.c:8:9: error: control reaches end of non-void function [-Werror=return-type]
    8 |         }
      |         ^
cc1: some warnings being treated as errors
```