### PR TITLE
Fix pkgconfig error handling

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -649,6 +649,8 @@ class PkgConfigDependency(ExternalDependency):
         if ret != 0:
             return
 
+        self.is_found = True
+
         try:
             # Fetch cargs to be used while using this dependency
             self._set_cargs()
@@ -662,8 +664,6 @@ class PkgConfigDependency(ExternalDependency):
                 self.link_args = []
                 self.is_found = False
                 self.reason = e
-
-        self.is_found = True
 
     def __repr__(self):
         s = '<{0} {1}: {2} {3}>'

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -657,6 +657,7 @@ class PkgConfigDependency(ExternalDependency):
             # Fetch the libraries and library paths needed for using this
             self._set_libs()
         except DependencyException as e:
+            mlog.debug("pkg-config error with '%s': %s" % (name, e))
             if self.required:
                 raise
             else:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -860,13 +860,13 @@ class InternalTests(unittest.TestCase):
 
             def fake_call_pkgbin(self, args, env=None):
                 if '--libs' not in args:
-                    return 0, ''
+                    return 0, '', ''
                 if args[0] == 'foo':
-                    return 0, '-L{} -lfoo -L{} -lbar'.format(p2.as_posix(), p1.as_posix())
+                    return 0, '-L{} -lfoo -L{} -lbar'.format(p2.as_posix(), p1.as_posix()), ''
                 if args[0] == 'bar':
-                    return 0, '-L{} -lbar'.format(p2.as_posix())
+                    return 0, '-L{} -lbar'.format(p2.as_posix()), ''
                 if args[0] == 'internal':
-                    return 0, '-L{} -lpthread -lm -lc -lrt -ldl'.format(p1.as_posix())
+                    return 0, '-L{} -lpthread -lm -lc -lrt -ldl'.format(p1.as_posix()), ''
 
             old_call = PkgConfigDependency._call_pkgbin
             old_check = PkgConfigDependency.check_pkgconfig


### PR DESCRIPTION
Previously meson would incorrectly handle a dependency as found even though one of the calls to either `pkg-config --libs` or `pkg-config --cflags` failed, which can lead to surprising build failures.

Additionally the exception would use stdout which does not contain anything helpful about the failure.