### PR TITLE
cmake: Fix empty -D due to empty strings (closes #5522)

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1299,6 +1299,9 @@ class CMakeDependency(ExternalDependency):
                 self.compile_args = list(map(lambda x: '-I{}'.format(x), incDirs)) + defs
                 self.link_args = libs
                 mlog.debug('using old-style CMake variables for dependency {}'.format(name))
+                mlog.debug('Include Dirs:         {}'.format(incDirs))
+                mlog.debug('Compiler Definitions: {}'.format(defs))
+                mlog.debug('Libraries:            {}'.format(libs))
                 return
 
             # Even the old-style approach failed. Nothing else we can do here

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1290,9 +1290,9 @@ class CMakeDependency(ExternalDependency):
 
         # Failed to guess a target --> try the old-style method
         if len(modules) == 0:
-            incDirs = self.traceparser.get_cmake_var('PACKAGE_INCLUDE_DIRS')
-            defs = self.traceparser.get_cmake_var('PACKAGE_DEFINITIONS')
-            libs = self.traceparser.get_cmake_var('PACKAGE_LIBRARIES')
+            incDirs = [x for x in self.traceparser.get_cmake_var('PACKAGE_INCLUDE_DIRS') if x]
+            defs = [x for x in self.traceparser.get_cmake_var('PACKAGE_DEFINITIONS') if x]
+            libs = [x for x in self.traceparser.get_cmake_var('PACKAGE_LIBRARIES') if x]
 
             # Try to use old style variables if no module is specified
             if len(libs) > 0:
@@ -1340,39 +1340,37 @@ class CMakeDependency(ExternalDependency):
                 mlog.debug(tgt)
 
                 if 'INTERFACE_INCLUDE_DIRECTORIES' in tgt.properies:
-                    incDirs += tgt.properies['INTERFACE_INCLUDE_DIRECTORIES']
+                    incDirs += [x for x in tgt.properies['INTERFACE_INCLUDE_DIRECTORIES'] if x]
 
                 if 'INTERFACE_COMPILE_DEFINITIONS' in tgt.properies:
-                    tempDefs = list(tgt.properies['INTERFACE_COMPILE_DEFINITIONS'])
-                    tempDefs = list(map(lambda x: '-D{}'.format(re.sub('^-D', '', x)), tempDefs))
-                    compileDefinitions += tempDefs
+                    compileDefinitions += ['-D' + re.sub('^-D', '', x) for x in tgt.properies['INTERFACE_COMPILE_DEFINITIONS'] if x]
 
                 if 'INTERFACE_COMPILE_OPTIONS' in tgt.properies:
-                    compileOptions += tgt.properies['INTERFACE_COMPILE_OPTIONS']
+                    compileOptions += [x for x in tgt.properies['INTERFACE_COMPILE_OPTIONS'] if x]
 
                 if 'IMPORTED_CONFIGURATIONS' in tgt.properies:
-                    cfgs = tgt.properies['IMPORTED_CONFIGURATIONS']
+                    cfgs = [x for x in tgt.properies['IMPORTED_CONFIGURATIONS'] if x]
                     cfg = cfgs[0]
 
                 if 'RELEASE' in cfgs:
                     cfg = 'RELEASE'
 
                 if 'IMPORTED_IMPLIB_{}'.format(cfg) in tgt.properies:
-                    libraries += tgt.properies['IMPORTED_IMPLIB_{}'.format(cfg)]
+                    libraries += [x for x in tgt.properies['IMPORTED_IMPLIB_{}'.format(cfg)] if x]
                 elif 'IMPORTED_IMPLIB' in tgt.properies:
-                    libraries += tgt.properies['IMPORTED_IMPLIB']
+                    libraries += [x for x in tgt.properies['IMPORTED_IMPLIB'] if x]
                 elif 'IMPORTED_LOCATION_{}'.format(cfg) in tgt.properies:
-                    libraries += tgt.properies['IMPORTED_LOCATION_{}'.format(cfg)]
+                    libraries += [x for x in tgt.properies['IMPORTED_LOCATION_{}'.format(cfg)] if x]
                 elif 'IMPORTED_LOCATION' in tgt.properies:
-                    libraries += tgt.properies['IMPORTED_LOCATION']
+                    libraries += [x for x in tgt.properies['IMPORTED_LOCATION'] if x]
 
                 if 'INTERFACE_LINK_LIBRARIES' in tgt.properies:
-                    otherDeps += tgt.properies['INTERFACE_LINK_LIBRARIES']
+                    otherDeps += [x for x in tgt.properies['INTERFACE_LINK_LIBRARIES'] if x]
 
                 if 'IMPORTED_LINK_DEPENDENT_LIBRARIES_{}'.format(cfg) in tgt.properies:
-                    otherDeps += tgt.properies['IMPORTED_LINK_DEPENDENT_LIBRARIES_{}'.format(cfg)]
+                    otherDeps += [x for x in tgt.properies['IMPORTED_LINK_DEPENDENT_LIBRARIES_{}'.format(cfg)] if x]
                 elif 'IMPORTED_LINK_DEPENDENT_LIBRARIES' in tgt.properies:
-                    otherDeps += tgt.properies['IMPORTED_LINK_DEPENDENT_LIBRARIES']
+                    otherDeps += [x for x in tgt.properies['IMPORTED_LINK_DEPENDENT_LIBRARIES'] if x]
 
                 for j in otherDeps:
                     if j in self.traceparser.targets:
@@ -1391,7 +1389,7 @@ class CMakeDependency(ExternalDependency):
         mlog.debug('Compiler Options:     {}'.format(compileOptions))
         mlog.debug('Libraries:            {}'.format(libraries))
 
-        self.compile_args = compileOptions + compileDefinitions + list(map(lambda x: '-I{}'.format(x), incDirs))
+        self.compile_args = compileOptions + compileDefinitions + ['-I{}'.format(x) for x in incDirs]
         self.link_args = libraries
 
     def _setup_cmake_dir(self, cmake_file: str) -> str:

--- a/test cases/linuxlike/13 cmake dependency/cmake/FindImportedTarget.cmake
+++ b/test cases/linuxlike/13 cmake dependency/cmake/FindImportedTarget.cmake
@@ -1,0 +1,13 @@
+find_package(ZLIB)
+
+if(ZLIB_FOUND OR ZLIB_Found)
+  set(ImportedTarget_FOUND ON)
+  add_library(mesonTestLibDefs UNKNOWN IMPORTED)
+  set_property(TARGET mesonTestLibDefs PROPERTY IMPORTED_LOCATION ${ZLIB_LIBRARY})
+  set_property(TARGET mesonTestLibDefs PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ZLIB_INCLUDE_DIR})
+  set_property(TARGET mesonTestLibDefs APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS REQUIRED_MESON_FLAG1)
+  set_property(TARGET mesonTestLibDefs APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS $<$<NOT:$<CONFIG:Debug>>:QT_NO_DEBUG>) # Error empty string
+  set_property(TARGET mesonTestLibDefs APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS REQUIRED_MESON_FLAG2)
+else()
+  set(ImportedTarget_FOUND OFF)
+endif()

--- a/test cases/linuxlike/13 cmake dependency/meson.build
+++ b/test cases/linuxlike/13 cmake dependency/meson.build
@@ -42,6 +42,12 @@ depm1 = dependency('SomethingLikeZLIB', required : true, method : 'cmake', cmake
 depm2 = dependency('SomethingLikeZLIB', required : true, method : 'cmake', cmake_module_path : ['cmake'])
 depm3 = dependency('SomethingLikeZLIB', required : true, cmake_module_path : 'cmake')
 
+# Test some edge cases with spaces, etc.
+
+testDep = dependency('ImportedTarget', required : true, method : 'cmake', cmake_module_path : 'cmake', modules: 'mesonTestLibDefs')
+testFlagSet = executable('testFlagSet', ['testFlagSet.c'], dependencies: [testDep])
+test('testFlagSetTest', testFlagSet)
+
 # Try to compile a test that takes a dep and an include_directories
 
 cc = meson.get_compiler('c')

--- a/test cases/linuxlike/13 cmake dependency/testFlagSet.c
+++ b/test cases/linuxlike/13 cmake dependency/testFlagSet.c
@@ -1,0 +1,18 @@
+#include<stdio.h>
+#include<zlib.h>
+
+#ifndef REQUIRED_MESON_FLAG1
+#error "REQUIRED_MESON_FLAG1 not set"
+#endif
+
+#ifndef REQUIRED_MESON_FLAG2
+#error "REQUIRED_MESON_FLAG2 not set"
+#endif
+
+int main(int argc, char *argv[]) {
+  printf("Hello World\n");
+  void * something = deflate;
+  if(something != 0)
+    return 0;
+  return 1;
+}


### PR DESCRIPTION
Fix that empty strings were processed in the dependency, due to generator expressions, etc.