### PR TITLE
Quality/test: OS-agnostic cmake_module_path unit test

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1397,18 +1397,14 @@ class CMakeDependency(ExternalDependency):
 
     def _setup_cmake_dir(self, cmake_file: str) -> str:
         # Setup the CMake build environment and return the "build" directory
-        build_dir = '{}/cmake_{}'.format(self.cmake_root_dir, self.name)
-        os.makedirs(build_dir, exist_ok=True)
+        build_dir = Path(self.cmake_root_dir) / 'cmake_{}'.format(self.name)
+        build_dir.mkdir(parents=True, exist_ok=True)
 
         # Copy the CMakeLists.txt
-        cmake_lists = '{}/CMakeLists.txt'.format(build_dir)
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        src_cmake = '{}/data/{}'.format(dir_path, cmake_file)
-        if os.path.exists(cmake_lists):
-            os.remove(cmake_lists)
-        shutil.copyfile(src_cmake, cmake_lists)
+        src_cmake = Path(__file__).parent / 'data' / cmake_file
+        shutil.copyfile(str(src_cmake), str(build_dir / 'CMakeLists.txt'))  # str() is for Python 3.5
 
-        return build_dir
+        return str(build_dir)
 
     def _call_cmake(self, args, cmake_file: str, env=None):
         build_dir = self._setup_cmake_dir(cmake_file)
@@ -1543,7 +1539,7 @@ class DubDependency(ExternalDependency):
                 for lib in target['buildSettings'][field_name]:
                     if lib not in libs:
                         libs.append(lib)
-                        if os.name is not 'nt':
+                        if os.name != 'nt':
                             pkgdep = PkgConfigDependency(lib, environment, {'required': 'true', 'silent': 'true'})
                             for arg in pkgdep.get_compile_args():
                                 self.compile_args.append(arg)

--- a/test cases/cmake/10 cmake_module_path/cmake/FindSomethingLikePython.cmake
+++ b/test cases/cmake/10 cmake_module_path/cmake/FindSomethingLikePython.cmake
@@ -1,0 +1,24 @@
+cmake_policy(VERSION 3.7)
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
+  find_package(Python COMPONENTS Interpreter)
+else()
+  find_package(PythonInterp)
+endif()
+
+if(Python_FOUND OR PYTHONINTERP_FOUND)
+  set(SomethingLikePython_FOUND      ON)
+  set(SomethingLikePython_EXECUTABLE ${Python_EXECUTABLE})
+
+  if(NOT DEFINED Python_VERSION)
+    set(Python_VERSION ${Python_VERSION_STRING})
+  endif()
+  if(NOT TARGET Python::Interpreter)
+    add_executable(Python::Interpreter IMPORTED)
+    set_target_properties(Python::Interpreter PROPERTIES
+                          IMPORTED_LOCATION ${Python_EXECUTABLE}
+                          VERSION ${Python_VERSION})
+  endif()
+else()
+  set(SomethingLikePython_FOUND OFF)
+endif()

--- a/test cases/cmake/10 cmake_module_path/meson.build
+++ b/test cases/cmake/10 cmake_module_path/meson.build
@@ -1,0 +1,17 @@
+# We use Python3 as it's the only thing guaranteed to be available on any platform Meson can run on (unlike Zlib in linuxlike/13 cmake dependency).
+
+project('user CMake find_package module using cmake_module_path',
+  meson_version: '>= 0.50.0')
+
+if not find_program('cmake', required: false).found()
+  error('MESON_SKIP_TEST cmake binary not available.')
+endif
+
+# NOTE: can't request Python3 via dependency('Python3', method: 'cmake')
+#  Meson intercepts and wants "method: auto"
+
+# Try to find a dependency with a custom CMake module
+
+dependency('SomethingLikePython', required : true, method : 'cmake', cmake_module_path : 'cmake', modules: 'Python::Interpreter')
+
+dependency('SomethingLikePython', method : 'cmake', cmake_module_path : ['doesNotExist', 'cmake'], modules: 'Python::Interpreter')


### PR DESCRIPTION
* the cmake_module_path test was only for Linux, now it is cross-platform, looking for Python3, which is inherently guaranteed to be available
* cleaned up CMakeLists.txt generation by using pathlib.Path instead of string, while staying Python 3.5 compatible