### PR TITLE
quality/test: remove unused arguments, add Werror for GCC on unused args

### DIFF
--- a/.github/workflows/unusedargs_missingreturn.yml
+++ b/.github/workflows/unusedargs_missingreturn.yml
@@ -1,0 +1,38 @@
+name: UnusedMissingReturn
+# this workflow checks for usused input arguments or missing return values in test cases.
+# some users have default configs that will needlessly fail Meson self-tests due to these syntax.
+
+on:
+  push:
+    paths:
+    - "**.yml"
+    - "test cases/cmake/**"
+    - "test cases/common/**"
+    - "test cases/fortran/**"
+    - "test cases/platform-linux/**"
+  pull_request:
+    paths:
+    - "**.yml"
+    - "test cases/cmake/**"
+    - "test cases/common/**"
+    - "test cases/fortran/**"
+    - "test cases/platform-linux/**"
+
+jobs:
+
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install Compilers
+      run: |
+        sudo apt update -yq
+        sudo apt install -yq --no-install-recommends g++ gfortran ninja-build
+    - run: python run_project_tests.py --only cmake common fortran platform-linux
+      env:
+        CFLAGS: "-Werror=unused-parameter -Werror=return-type"
+        CPPFLAGS: "-Werror=unused-parameter -Werror=return-type"
+        FFLAGS: "-fimplicit-none"

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -651,14 +651,18 @@ def detect_tests_to_run(only: typing.List[str]) -> typing.List[typing.Tuple[str,
     gathered_tests = [(name, gather_tests(Path('test cases', subdir)), skip) for name, subdir, skip in all_tests]
     return gathered_tests
 
-def run_tests(all_tests, log_name_base, failfast: bool, extra_args):
+def run_tests(all_tests: typing.List[typing.Tuple[str, typing.List[Path], bool]],
+              log_name_base: str, failfast: bool,
+              extra_args: typing.List[str]) -> typing.Tuple[int, int, int]:
     global logfile
     txtname = log_name_base + '.txt'
     with open(txtname, 'w', encoding='utf-8', errors='ignore') as lf:
         logfile = lf
         return _run_tests(all_tests, log_name_base, failfast, extra_args)
 
-def _run_tests(all_tests, log_name_base, failfast: bool, extra_args):
+def _run_tests(all_tests: typing.List[typing.Tuple[str, typing.List[Path], bool]],
+               log_name_base: str, failfast: bool,
+               extra_args: typing.List[str]) -> typing.Tuple[int, int, int]:
     global stop, executor, futures, system_compiler
     xmlname = log_name_base + '.xml'
     junit_root = ET.Element('testsuites')
@@ -707,6 +711,7 @@ def _run_tests(all_tests, log_name_base, failfast: bool, extra_args):
             if name.startswith('warning'):
                 suite_args = ['--fatal-meson-warnings']
                 should_fail = name.split('warning-')[1]
+
             result = executor.submit(run_test, skipped, t.as_posix(), extra_args + suite_args,
                                      system_compiler, backend, backend_flags, commands, should_fail)
             futures.append((testname, t, result))

--- a/test cases/common/1 trivial/trivial.c
+++ b/test cases/common/1 trivial/trivial.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("Trivial test is working.\n");
     return 0;
 }

--- a/test cases/common/100 stringdef/stringdef.c
+++ b/test cases/common/100 stringdef/stringdef.c
@@ -1,7 +1,7 @@
 #include<stdio.h>
 #include<string.h>
 
-int main(int argc, char **argv) {
+int main() {
     if(strcmp(FOO, "bar")) {
         printf("FOO is misquoted: %s\n", FOO);
         return 1;

--- a/test cases/common/103 postconf/prog.c
+++ b/test cases/common/103 postconf/prog.c
@@ -1,5 +1,5 @@
 #include"generated.h"
 
-int main(int argc, char **argv) {
+int main() {
     return THE_NUMBER != 9;
 }

--- a/test cases/common/104 postconf with args/prog.c
+++ b/test cases/common/104 postconf with args/prog.c
@@ -1,5 +1,5 @@
 #include"generated.h"
 
-int main(int argc, char **argv) {
+int main() {
     return THE_NUMBER != 9 || THE_ARG1 != 5 || THE_ARG2 != 33;
 }

--- a/test cases/common/106 extract same name/main.c
+++ b/test cases/common/106 extract same name/main.c
@@ -1,6 +1,6 @@
 int func1();
 int func2();
 
-int main(int argc, char **argv) {
+int main() {
     return !(func1() == 23 && func2() == 42);
 }

--- a/test cases/common/109 generatorcustom/main.c
+++ b/test cases/common/109 generatorcustom/main.c
@@ -2,6 +2,6 @@
 
 #include"alltogether.h"
 
-int main(int argc, char **argv) {
+int main() {
     return 0;
 }

--- a/test cases/common/11 subdir/subdir/prog.c
+++ b/test cases/common/11 subdir/subdir/prog.c
@@ -1,1 +1,1 @@
-int main(int argc, char **argv) { return 0; }
+int main() { return 0; }

--- a/test cases/common/111 spaces backslash/comparer-end-notstring.c
+++ b/test cases/common/111 spaces backslash/comparer-end-notstring.c
@@ -10,7 +10,7 @@
 
 #define COMPARE_WITH "foo\\bar\\" /* This is the literal `foo\bar\` */
 
-int main(int argc, char **argv) {
+int main() {
     if(strcmp(QUOTE(DEF_WITH_BACKSLASH), COMPARE_WITH)) {
         printf("Arg string is quoted incorrectly: %s instead of %s\n",
                QUOTE(DEF_WITH_BACKSLASH), COMPARE_WITH);

--- a/test cases/common/111 spaces backslash/comparer-end.c
+++ b/test cases/common/111 spaces backslash/comparer-end.c
@@ -6,7 +6,7 @@
 
 #define COMPARE_WITH "foo\\bar\\" /* This is `foo\bar\` */
 
-int main (int argc, char **argv) {
+int main () {
     if (strcmp (DEF_WITH_BACKSLASH, COMPARE_WITH)) {
         printf ("Arg string is quoted incorrectly: %s vs %s\n",
                 DEF_WITH_BACKSLASH, COMPARE_WITH);

--- a/test cases/common/111 spaces backslash/comparer.c
+++ b/test cases/common/111 spaces backslash/comparer.c
@@ -6,7 +6,7 @@
 
 #define COMPARE_WITH "foo\\bar" /* This is the literal `foo\bar` */
 
-int main (int argc, char **argv) {
+int main () {
     if (strcmp (DEF_WITH_BACKSLASH, COMPARE_WITH)) {
         printf ("Arg string is quoted incorrectly: %s instead of %s\n",
                 DEF_WITH_BACKSLASH, COMPARE_WITH);

--- a/test cases/common/114 allgenerate/foobar.cpp.in
+++ b/test cases/common/114 allgenerate/foobar.cpp.in
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
   printf("I am a program.\n");
   return 0;
 }

--- a/test cases/common/119 subproject project arguments/exe.c
+++ b/test cases/common/119 subproject project arguments/exe.c
@@ -22,6 +22,6 @@
 #error
 #endif
 
-int main(int argc, char **argv) {
+int main() {
     return 0;
 }

--- a/test cases/common/119 subproject project arguments/exe.cpp
+++ b/test cases/common/119 subproject project arguments/exe.cpp
@@ -22,7 +22,7 @@
 #error
 #endif
 
-int main(int argc, char **argv) {
+int main() {
     return 0;
 }
 

--- a/test cases/common/119 subproject project arguments/subprojects/subexe/subexe.c
+++ b/test cases/common/119 subproject project arguments/subprojects/subexe/subexe.c
@@ -22,6 +22,6 @@
 #error
 #endif
 
-int main(int argc, char **argv) {
+int main() {
     return 0;
 }

--- a/test cases/common/120 test skip/test_skip.c
+++ b/test cases/common/120 test skip/test_skip.c
@@ -1,3 +1,3 @@
-int main(int argc, char *argv[]) {
+int main() {
     return 77;
 }

--- a/test cases/common/121 shared module/prog.c
+++ b/test cases/common/121 shared module/prog.c
@@ -21,13 +21,13 @@ win32_get_last_error (void)
     return msg;
 }
 
-int
-main (int argc, char **argv)
+int main(int argc, char **argv)
 {
     HINSTANCE handle;
     fptr importedfunc;
     int expected, actual;
     int ret = 1;
+    if(argc==0) {};
 
     handle = LoadLibraryA (argv[1]);
     if (!handle) {
@@ -68,6 +68,7 @@ int main(int argc, char **argv) {
     int expected, actual;
     char *error;
     int ret = 1;
+    if(argc==0) {};
 
     dlerror();
     dl = dlopen(argv[1], RTLD_LAZY);

--- a/test cases/common/122 llvm ir and assembly/main.c
+++ b/test cases/common/122 llvm ir and assembly/main.c
@@ -2,8 +2,7 @@
 
 unsigned square_unsigned (unsigned a);
 
-int
-main (int argc, char * argv[])
+int main ()
 {
   unsigned int ret = square_unsigned (2);
   if (ret != 4) {

--- a/test cases/common/122 llvm ir and assembly/main.cpp
+++ b/test cases/common/122 llvm ir and assembly/main.cpp
@@ -4,8 +4,7 @@ extern "C" {
   unsigned square_unsigned (unsigned a);
 }
 
-int
-main (int argc, char * argv[])
+int main ()
 {
   unsigned int ret = square_unsigned (2);
   if (ret != 4) {

--- a/test cases/common/123 cpp and asm/trivial.cc
+++ b/test cases/common/123 cpp and asm/trivial.cc
@@ -4,7 +4,7 @@ extern "C" {
   int get_retval(void);
 }
 
-int main(int argc, char **argv) {
+int main() {
   std::cout << "C++ seems to be working." << std::endl;
 #if defined(USE_ASM)
   return get_retval();

--- a/test cases/common/124 extract all shared library/prog.c
+++ b/test cases/common/124 extract all shared library/prog.c
@@ -1,7 +1,7 @@
 #include"extractor.h"
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     if((1+2+3+4) != (func1() + func2() + func3() + func4())) {
         printf("Arithmetic is fail.\n");
         return 1;

--- a/test cases/common/125 object only target/prog.c
+++ b/test cases/common/125 object only target/prog.c
@@ -2,6 +2,6 @@ int func1_in_obj();
 int func2_in_obj();
 int func3_in_obj();
 
-int main(int argc, char **argv) {
+int main() {
     return func1_in_obj() + func2_in_obj() + func3_in_obj();
 }

--- a/test cases/common/126 no buildincdir/prog.c
+++ b/test cases/common/126 no buildincdir/prog.c
@@ -1,5 +1,5 @@
 #include"header.h"
 
-int main(int argc, char **argv) {
+int main() {
     return 0;
 }

--- a/test cases/common/128 dependency file generation/main .c
+++ b/test cases/common/128 dependency file generation/main .c
@@ -1,3 +1,3 @@
-int main(int argc, char *argv[]) {
+int main() {
   return 0;
 }

--- a/test cases/common/129 configure file in generator/src/main.c
+++ b/test cases/common/129 configure file in generator/src/main.c
@@ -12,6 +12,6 @@
 #error Source RESULT is not defined correctly
 #endif
 
-int main(int argc, char **argv) {
+int main() {
     return 0;
 }

--- a/test cases/common/13 pch/c/prog.c
+++ b/test cases/common/13 pch/c/prog.c
@@ -4,7 +4,7 @@ void func() {
     fprintf(stdout, "This is a function that fails if stdio is not #included.\n");
 }
 
-int main(int argc, char **argv) {
+int main() {
     return 0;
 }
 

--- a/test cases/common/13 pch/cpp/prog.cc
+++ b/test cases/common/13 pch/cpp/prog.cc
@@ -5,7 +5,7 @@ void func() {
               << std::endl;
 }
 
-int main(int argc, char **argv) {
+int main() {
     func();
     return 0;
 }

--- a/test cases/common/13 pch/generated/prog.c
+++ b/test cases/common/13 pch/generated/prog.c
@@ -1,6 +1,6 @@
 // No includes here, they need to come from the PCH
 
-int main(int argc, char **argv) {
+int main() {
     return FOO + BAR;
 }
 

--- a/test cases/common/13 pch/mixed/main.cc
+++ b/test cases/common/13 pch/mixed/main.cc
@@ -5,6 +5,6 @@ void func() {
               << std::endl;
 }
 
-int main(int argc, char **argv) {
+int main() {
     return cfunc();
 }

--- a/test cases/common/13 pch/userDefined/prog.c
+++ b/test cases/common/13 pch/userDefined/prog.c
@@ -1,6 +1,6 @@
 // No includes here, they need to come from the PCH
 
-int main(int argc, char **argv) {
+int main() {
     // Method is implemented in pch.c.
     // This makes sure that we can properly handle user defined
     // pch implementation files and not only auto-generated ones.

--- a/test cases/common/13 pch/withIncludeDirectories/prog.c
+++ b/test cases/common/13 pch/withIncludeDirectories/prog.c
@@ -4,7 +4,7 @@ void func() {
     fprintf(stdout, "This is a function that fails if stdio is not #included.\n");
 }
 
-int main(int argc, char **argv) {
+int main() {
     return 0;
 }
 

--- a/test cases/common/130 generated llvm ir/main.c
+++ b/test cases/common/130 generated llvm ir/main.c
@@ -2,8 +2,7 @@
 
 unsigned square_unsigned (unsigned a);
 
-int
-main (int argc, char * argv[])
+int main ()
 {
   unsigned int ret = square_unsigned (2);
   if (ret != 4) {

--- a/test cases/common/131 generated assembly/main.c
+++ b/test cases/common/131 generated assembly/main.c
@@ -5,8 +5,7 @@
 #endif
 unsigned square_unsigned (unsigned a);
 
-int
-main (int argc, char * argv[])
+int main ()
 {
   unsigned int ret = square_unsigned (2);
   if (ret != 4) {

--- a/test cases/common/132 build by default targets in tests/main.c
+++ b/test cases/common/132 build by default targets in tests/main.c
@@ -1,3 +1,3 @@
-int main (int argc, char *argv[]) {
+int main () {
   return 0;
 }

--- a/test cases/common/133 build by default/foo.c
+++ b/test cases/common/133 build by default/foo.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("Existentialism.\n");
     return 0;
 }

--- a/test cases/common/134 include order/ordertest.c
+++ b/test cases/common/134 include order/ordertest.c
@@ -4,8 +4,7 @@
 #error "Should have picked up hdr.h from inc1/hdr.h"
 #endif
 
-int
-main (int c, char ** argv)
+int main ()
 {
   return 0;
 }

--- a/test cases/common/134 include order/sub4/main.c
+++ b/test cases/common/134 include order/sub4/main.c
@@ -1,7 +1,7 @@
 /* Use the <> include notation to force searching in include directories */
 #include <main.h>
 
-int main(int argc, char *argv[]) {
+int main() {
   if (somefunc() == 1984)
     return 0;
   return 1;

--- a/test cases/common/135 override options/four.c
+++ b/test cases/common/135 override options/four.c
@@ -4,6 +4,6 @@ static int duplicate_func() {
     return -4;
 }
 
-int main(int argc, char **argv) {
+int main() {
     return duplicate_func() + func();
 }

--- a/test cases/common/135 override options/two.c
+++ b/test cases/common/135 override options/two.c
@@ -1,6 +1,6 @@
 /*
  * Requires a Unity build. Otherwise hidden_func is not specified.
  */
-int main(int argc, char **argv) {
+int main() {
     return hidden_func();
 }

--- a/test cases/common/137 c cpp and asm/main.c
+++ b/test cases/common/137 c cpp and asm/main.c
@@ -2,7 +2,7 @@
 
 int get_retval(void);
 
-int main(int argc, char **argv) {
+int main() {
   printf("C seems to be working.\n");
   return get_retval();
 }

--- a/test cases/common/137 c cpp and asm/main.cpp
+++ b/test cases/common/137 c cpp and asm/main.cpp
@@ -5,7 +5,7 @@ extern "C" {
   int get_cval(void);
 }
 
-int main(int argc, char **argv) {
+int main() {
   std::cout << "C++ seems to be working." << std::endl;
   return get_retval();
 }

--- a/test cases/common/138 compute int/prog.c.in
+++ b/test cases/common/138 compute int/prog.c.in
@@ -4,7 +4,7 @@
 #include <limits.h>
 #include "foobar.h"
 
-int main(int argc, char **argv) {
+int main() {
     if(INTSIZE != sizeof(int)) {
         fprintf(stderr, "Mismatch: computed int size %d, actual size %d.\n", INTSIZE, (int)sizeof(int));
         return 1;

--- a/test cases/common/139 custom target object output/progdir/prog.c
+++ b/test cases/common/139 custom target object output/progdir/prog.c
@@ -1,5 +1,5 @@
 int func1_in_obj();
 
-int main(int argc, char **argv) {
+int main() {
     return func1_in_obj();
 }

--- a/test cases/common/14 configure file/dumpprog.c
+++ b/test cases/common/14 configure file/dumpprog.c
@@ -15,7 +15,7 @@
 #define stringify(s) str(s)
 #define str(s) #s
 
-int main(int argc, char **argv) {
+int main() {
 #if !(SHOULD_BE_UNQUOTED_STRING == string)
         printf("String token (unquoted) defined wrong.\n");
         return 1;

--- a/test cases/common/14 configure file/prog.c
+++ b/test cases/common/14 configure file/prog.c
@@ -8,7 +8,7 @@
 #error "FAIL!"
 #endif
 
-int main(int argc, char **argv) {
+int main() {
 #ifndef BE_TRUE
     return 1;
 #else

--- a/test cases/common/14 configure file/prog2.c
+++ b/test cases/common/14 configure file/prog2.c
@@ -1,5 +1,5 @@
 #include<config2.h>
 
-int main(int argc, char **argv) {
+int main() {
     return ZERO_RESULT;
 }

--- a/test cases/common/14 configure file/prog4.c
+++ b/test cases/common/14 configure file/prog4.c
@@ -1,6 +1,6 @@
 #include <config4a.h>
 #include <config4b.h>
 
-int main(int argc, char **argv) {
+int main() {
     return RESULTA + RESULTB;
 }

--- a/test cases/common/14 configure file/prog5.c
+++ b/test cases/common/14 configure file/prog5.c
@@ -1,6 +1,6 @@
 #include <string.h>
 #include <config5.h>
 
-int main(int argc, char **argv) {
+int main() {
     return strcmp(MESSAGE, "@var2@");
 }

--- a/test cases/common/14 configure file/prog6.c
+++ b/test cases/common/14 configure file/prog6.c
@@ -1,7 +1,7 @@
 #include <string.h>
 #include <config6.h>
 
-int main(int argc, char **argv) {
+int main() {
     return strcmp(MESSAGE1, "foo")
         || strcmp(MESSAGE2, "@var1@")
         || strcmp(MESSAGE3, "\\foo")

--- a/test cases/common/14 configure file/prog7.c
+++ b/test cases/common/14 configure file/prog7.c
@@ -1,7 +1,7 @@
 #include <string.h>
 #include <config7.h>
 
-int main(int argc, char **argv) {
+int main() {
     return strcmp(MESSAGE1, "foo")
         || strcmp(MESSAGE2, "${var1}")
         || strcmp(MESSAGE3, "\\foo")

--- a/test cases/common/14 configure file/prog9.c
+++ b/test cases/common/14 configure file/prog9.c
@@ -10,7 +10,7 @@
 #error "Should be defined"
 #endif
 
-int main(int argc, char **argv) {
+int main() {
     return strcmp(A_STRING, "foo")
         || strcmp(B_STRING, "foo")
         || A_INT != 42

--- a/test cases/common/141 whole archive/prog.c
+++ b/test cases/common/141 whole archive/prog.c
@@ -1,5 +1,5 @@
 #include<mylib.h>
 
-int main(int argc, char **argv) {
+int main() {
     return func1() - func2();
 }

--- a/test cases/common/149 recursive linking/3rdorderdeps/main.c.in
+++ b/test cases/common/149 recursive linking/3rdorderdeps/main.c.in
@@ -4,7 +4,7 @@
 
 SYMBOL_IMPORT int get_@LIBTYPE@@DEPENDENCY@dep_value (void);
 
-int main(int argc, char *argv[]) {
+int main() {
   int val;
 
   val = get_@LIBTYPE@@DEPENDENCY@dep_value ();

--- a/test cases/common/149 recursive linking/circular/main.c
+++ b/test cases/common/149 recursive linking/circular/main.c
@@ -6,7 +6,7 @@ int get_st1_value (void);
 int get_st2_value (void);
 int get_st3_value (void);
 
-int main(int argc, char *argv[]) {
+int main() {
   int val;
 
   val = get_st1_value ();

--- a/test cases/common/149 recursive linking/edge-cases/shstmain.c
+++ b/test cases/common/149 recursive linking/edge-cases/shstmain.c
@@ -4,7 +4,7 @@
 
 int get_stshdep_value (void);
 
-int main(int argc, char *argv[]) {
+int main() {
   int val;
 
   val = get_stshdep_value ();

--- a/test cases/common/149 recursive linking/edge-cases/stomain.c
+++ b/test cases/common/149 recursive linking/edge-cases/stomain.c
@@ -4,7 +4,7 @@
 
 int get_stodep_value (void);
 
-int main(int argc, char *argv[]) {
+int main() {
   int val;
 
   val = get_stodep_value ();

--- a/test cases/common/149 recursive linking/main.c
+++ b/test cases/common/149 recursive linking/main.c
@@ -9,7 +9,7 @@ SYMBOL_IMPORT int get_shnodep_value (void);
 SYMBOL_IMPORT int get_shshdep_value (void);
 SYMBOL_IMPORT int get_shstdep_value (void);
 
-int main(int argc, char *argv[]) {
+int main() {
   int val;
 
   val = get_shnodep_value ();

--- a/test cases/common/15 if/prog.c
+++ b/test cases/common/15 if/prog.c
@@ -1,1 +1,1 @@
-int main(int argc, char **argv) { return 0; }
+int main() { return 0; }

--- a/test cases/common/151 simd/simdchecker.c
+++ b/test cases/common/151 simd/simdchecker.c
@@ -23,7 +23,7 @@ int check_simd_implementation(float *four,
     return rv;
 }
 
-int main(int argc, char **argv) {
+int main() {
     static const float four_initial[4] = {2.0, 3.0, 4.0, 5.0};
     ALIGN_16 float four[4];
     const float expected[4] = {3.0, 4.0, 5.0, 6.0};

--- a/test cases/common/152 shared module resolving symbol in executable/prog.c
+++ b/test cases/common/152 shared module resolving symbol in executable/prog.c
@@ -25,11 +25,12 @@ func_from_executable(void)
   return 42;
 }
 
-int
-main (int argc, char **argv)
+int main(int argc, char **argv)
 {
   int expected, actual;
   fptr importedfunc;
+
+  if (argc=0) {};  // noop
 
 #ifdef _WIN32
   HMODULE h = LoadLibraryA(argv[1]);

--- a/test cases/common/153 dotinclude/dotproc.c
+++ b/test cases/common/153 dotinclude/dotproc.c
@@ -4,7 +4,7 @@
 #error The wrapper stdio.h was not included.
 #endif
 
-int main(int argc, char **argv) {
+int main() {
     printf("Eventually I got printed.\n");
     return 0;
 }

--- a/test cases/common/154 reserved targets/test.c
+++ b/test cases/common/154 reserved targets/test.c
@@ -1,3 +1,3 @@
-int main(int argc, char *argv[]) {
+int main() {
   return 0;
 }

--- a/test cases/common/157 wrap file should not failed/src/subprojects/foo/prog2.c
+++ b/test cases/common/157 wrap file should not failed/src/subprojects/foo/prog2.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("Do not have a file layout like this in your own projects.\n");
     printf("This is only to test that this works.\n");
     return 0;

--- a/test cases/common/157 wrap file should not failed/src/subprojects/prog.c
+++ b/test cases/common/157 wrap file should not failed/src/subprojects/prog.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("Do not have a file layout like this in your own projects.\n");
     printf("This is only to test that this works.\n");
     return 0;

--- a/test cases/common/158 includedir subproj/prog.c
+++ b/test cases/common/158 includedir subproj/prog.c
@@ -1,4 +1,4 @@
 
-int main(int argc, char **argv) {
+int main() {
   return 0;
 }

--- a/test cases/common/159 subproject dir name collision/a.c
+++ b/test cases/common/159 subproject dir name collision/a.c
@@ -2,7 +2,7 @@
 char func_b();
 char func_c();
 
-int main(int argc, char **argv) {
+int main() {
     if(func_b() != 'b') {
         return 1;
     }

--- a/test cases/common/16 else/prog.c
+++ b/test cases/common/16 else/prog.c
@@ -1,1 +1,1 @@
-int main(int argc, char **argv) { return 0; }
+int main() { return 0; }

--- a/test cases/common/17 comparison/prog.c
+++ b/test cases/common/17 comparison/prog.c
@@ -1,1 +1,1 @@
-int main(int argc, char **argv) { return 0; }
+int main() { return 0; }

--- a/test cases/common/170 get project license/bar.c
+++ b/test cases/common/170 get project license/bar.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("I'm a main project bar.\n");
     return 0;
 }

--- a/test cases/common/172 subproject nested subproject dirs/prog.c
+++ b/test cases/common/172 subproject nested subproject dirs/prog.c
@@ -1,5 +1,5 @@
 int func();
 
-int main(int argc, char **argv) {
+int main() {
     return func() == 42 ? 0 : 1;
 }

--- a/test cases/common/173 preserve gendir/testprog.c
+++ b/test cases/common/173 preserve gendir/testprog.c
@@ -1,6 +1,6 @@
 #include"base.h"
 #include"com/mesonbuild/subbie.h"
 
-int main(int argc, char **argv) {
+int main() {
     return base() + subbie();
 }

--- a/test cases/common/174 source in dep/generated/main.c
+++ b/test cases/common/174 source in dep/generated/main.c
@@ -1,5 +1,5 @@
 #include"funheader.h"
 
-int main(int argc, char **argv) {
+int main() {
     return my_wonderful_function() != 42;
 }

--- a/test cases/common/18 array/prog.c
+++ b/test cases/common/18 array/prog.c
@@ -1,3 +1,3 @@
 extern int func();
 
-int main(int argc, char **argv) { return func(); }
+int main() { return func(); }

--- a/test cases/common/183 bothlibraries/main.c
+++ b/test cases/common/183 bothlibraries/main.c
@@ -3,6 +3,6 @@
 DO_IMPORT int func();
 DO_IMPORT int retval;
 
-int main(int argc, char **arg) {
+int main() {
     return func() == retval ? 0 : 1;
 }

--- a/test cases/common/187 find override/otherdir/main.c
+++ b/test cases/common/187 find override/otherdir/main.c
@@ -1,5 +1,5 @@
 int be_seeing_you();
 
-int main(int argc, char **argv) {
+int main() {
     return be_seeing_you() == 6 ? 0 : 1;
 }

--- a/test cases/common/187 find override/otherdir/main2.c
+++ b/test cases/common/187 find override/otherdir/main2.c
@@ -1,5 +1,5 @@
 int number_returner();
 
-int main(int argc, char **argv) {
+int main() {
     return number_returner() == 100 ? 0 : 1;
 }

--- a/test cases/common/19 includedir/src/prog.c
+++ b/test cases/common/19 includedir/src/prog.c
@@ -1,5 +1,5 @@
 #include "func.h"
 
-int main(int argc, char **argv) {
+int main() {
     return func();
 }

--- a/test cases/common/195 install_mode/trivial.c
+++ b/test cases/common/195 install_mode/trivial.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("Trivial test is working.\n");
     return 0;
 }

--- a/test cases/common/2 cpp/trivial.cc
+++ b/test cases/common/2 cpp/trivial.cc
@@ -1,6 +1,6 @@
 #include<iostream>
 
-int main(int argc, char **argv) {
+int main() {
   std::cout << "C++ seems to be working." << std::endl;
   return 0;
 }

--- a/test cases/common/20 header in file list/prog.c
+++ b/test cases/common/20 header in file list/prog.c
@@ -1,3 +1,3 @@
 #include "header.h"
 
-int main(int argc, char **argv) { return 0; }
+int main() { return 0; }

--- a/test cases/common/200 generator in subdir/com/mesonbuild/testprog.c
+++ b/test cases/common/200 generator in subdir/com/mesonbuild/testprog.c
@@ -1,5 +1,5 @@
 #include"subbie.h"
 
-int main(int argc, char **argv) {
+int main() {
     return subbie();
 }

--- a/test cases/common/201 override with exe/subprojects/sub/foobar.c
+++ b/test cases/common/201 override with exe/subprojects/sub/foobar.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 
 int main(int argc, char* argv[]) {
+  assert(argc == 2);
   FILE *f = fopen(argv[1], "w");
   const char msg[] = "int main(void) {return 0;}\n";
   size_t w = fwrite(msg, 1, sizeof(msg) - 1, f);

--- a/test cases/common/202 subproject with features/nothing.c
+++ b/test cases/common/202 subproject with features/nothing.c
@@ -1,4 +1,4 @@
-int main(int argc, char const *argv[])
+int main()
 {
     return 0;
 }

--- a/test cases/common/207 kwarg entry/prog.c
+++ b/test cases/common/207 kwarg entry/prog.c
@@ -1,7 +1,7 @@
 #include<prog.h>
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf(MESSAGE);
     return 0;
 }

--- a/test cases/common/21 global arg/prog.c
+++ b/test cases/common/21 global arg/prog.c
@@ -38,6 +38,6 @@
   #endif
 #endif
 
-int main(int argc, char **argv) {
+int main() {
     return 0;
 }

--- a/test cases/common/21 global arg/prog.cc
+++ b/test cases/common/21 global arg/prog.cc
@@ -10,6 +10,6 @@
 #error "Global argument not set"
 #endif
 
-int main(int argc, char **argv) {
+int main() {
     return 0;
 }

--- a/test cases/common/215 link custom/prog.c
+++ b/test cases/common/215 link custom/prog.c
@@ -1,6 +1,6 @@
 void flob();
 
-int main(int argc, char **argv) {
+int main() {
     flob();
     return 0;
 }

--- a/test cases/common/216 link custom_i single from multiple/prog.c
+++ b/test cases/common/216 link custom_i single from multiple/prog.c
@@ -1,5 +1,5 @@
 int flob();
 
-int main(int argc, char **argv) {
+int main() {
     return (flob() == 1 ? 0 : 1);
 }

--- a/test cases/common/217 link custom_i multiple from multiple/prog.c
+++ b/test cases/common/217 link custom_i multiple from multiple/prog.c
@@ -1,7 +1,7 @@
 void flob_1();
 void flob_2();
 
-int main(int argc, char **argv) {
+int main() {
     flob_1();
     flob_2();
     return 0;

--- a/test cases/common/22 target arg/prog.cc
+++ b/test cases/common/22 target arg/prog.cc
@@ -8,6 +8,6 @@
 
 extern "C" int func();
 
-int main(int argc, char **argv) {
+int main() {
     return func();
 }

--- a/test cases/common/22 target arg/prog2.cc
+++ b/test cases/common/22 target arg/prog2.cc
@@ -8,6 +8,6 @@
 
 extern "C" int func();
 
-int main(int argc, char **argv) {
+int main() {
     return func();
 }

--- a/test cases/common/23 object extraction/main.c
+++ b/test cases/common/23 object extraction/main.c
@@ -1,5 +1,5 @@
 int func();
 
-int main(int argc, char **argv) {
+int main() {
     return func() == 42 ? 0 : 1;
 }

--- a/test cases/common/24 endian/prog.c
+++ b/test cases/common/24 endian/prog.c
@@ -8,7 +8,7 @@ int is_big_endian(void) {
 }
 
 
-int main(int argc, char **argv) {
+int main() {
     int is_be_check = is_big_endian();
     int is_be;
 #ifdef IS_BE

--- a/test cases/common/26 config subdir/src/prog.c
+++ b/test cases/common/26 config subdir/src/prog.c
@@ -1,5 +1,5 @@
 #include "config.h"
 
-int main(int argc, char **argv) {
+int main() {
     return RETURN_VALUE;
 }

--- a/test cases/common/27 pipeline/depends/filecopier.c
+++ b/test cases/common/27 pipeline/depends/filecopier.c
@@ -9,6 +9,7 @@ int main(int argc, char **argv) {
     size_t num_written;
     FILE *fin = fopen(argv[1], "rb");
     FILE *fout;
+    assert(argc>0);
     assert(fin);
     num_read = fread(buffer, 1, BUFSIZE, fin);
     assert(num_read > 0);

--- a/test cases/common/27 pipeline/depends/prog.c
+++ b/test cases/common/27 pipeline/depends/prog.c
@@ -1,5 +1,5 @@
 int func();
 
-int main(int argc, char **argv) {
+int main() {
     return func() != 42;
 }

--- a/test cases/common/27 pipeline/prog.c
+++ b/test cases/common/27 pipeline/prog.c
@@ -1,5 +1,5 @@
 int func();
 
-int main(int argc, char **argv) {
+int main() {
     return func();
 }

--- a/test cases/common/27 pipeline/src/prog.c
+++ b/test cases/common/27 pipeline/src/prog.c
@@ -1,6 +1,6 @@
 #include"input_src.h"
 
-int main(int argc, char **argv) {
+int main() {
     void *foo = printf;
     if(foo) {
         return 0;

--- a/test cases/common/28 find program/source.in
+++ b/test cases/common/28 find program/source.in
@@ -1,3 +1,3 @@
-int main(int argc, char **argv) {
+int main() {
   return 0;
 }

--- a/test cases/common/29 multiline string/meson.build
+++ b/test cases/common/29 multiline string/meson.build
@@ -26,7 +26,7 @@ endif
 
 cc = meson.get_compiler('c')
 prog = '''
-int main(int argc, char **argv) {
+int main() {
   int num = 1;
   printf("%d\n", num);
   return 0;

--- a/test cases/common/32 sizeof/prog.c.in
+++ b/test cases/common/32 sizeof/prog.c.in
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <wchar.h>
 
-int main(int argc, char **argv) {
+int main() {
     if(INTSIZE != sizeof(int)) {
         fprintf(stderr, "Mismatch: detected int size %d, actual size %d.\n", INTSIZE, (int)sizeof(int));
         return 1;

--- a/test cases/common/33 define10/prog.c
+++ b/test cases/common/33 define10/prog.c
@@ -1,7 +1,7 @@
 #include<stdio.h>
 #include"config.h"
 
-int main(int argc, char **argv) {
+int main() {
     if(ONE != 1) {
         fprintf(stderr, "ONE is not 1.\n");
         return 1;

--- a/test cases/common/36 tryrun/error.c
+++ b/test cases/common/36 tryrun/error.c
@@ -1,3 +1,3 @@
-int main(int argc, char **argv) {
+int main() {
   return 1;
 }

--- a/test cases/common/36 tryrun/meson.build
+++ b/test cases/common/36 tryrun/meson.build
@@ -12,19 +12,19 @@ else
 endif
 
 ok_code = '''#include<stdio.h>
-int main(int argc, char **argv) {
+int main() {
   printf("%s\n", "stdout");
   fprintf(stderr, "%s\n", "stderr");
   return 0;
 }
 '''
 
-error_code = '''int main(int argc, char **argv) {
+error_code = '''int main() {
   return 1;
 }
 '''
 
-no_compile_code = '''int main(int argc, char **argv) {
+no_compile_code = '''int main() {
 '''
 
 INPUTS = [

--- a/test cases/common/36 tryrun/no_compile.c
+++ b/test cases/common/36 tryrun/no_compile.c
@@ -1,1 +1,1 @@
-int main(int argc, char **argv) {
+int main() {

--- a/test cases/common/36 tryrun/ok.c
+++ b/test cases/common/36 tryrun/ok.c
@@ -1,5 +1,5 @@
 #include<stdio.h>
-int main(int argc, char **argv) {
+int main() {
   printf("%s\n", "stdout");
   fprintf(stderr, "%s\n", "stderr");
   return 0;

--- a/test cases/common/44 test args/env2vars.c
+++ b/test cases/common/44 test args/env2vars.c
@@ -2,7 +2,7 @@
 #include<string.h>
 #include<stdlib.h>
 
-int main(int argc, char **argv) {
+int main() {
     if(strcmp(getenv("first"), "something-else") != 0) {
         fprintf(stderr, "First envvar is wrong. %s\n", getenv("first"));
         return 1;

--- a/test cases/common/44 test args/envvars.c
+++ b/test cases/common/44 test args/envvars.c
@@ -2,7 +2,7 @@
 #include<string.h>
 #include<stdlib.h>
 
-int main(int argc, char **argv) {
+int main() {
     if(strcmp(getenv("first"), "val1") != 0) {
         fprintf(stderr, "First envvar is wrong. %s\n", getenv("first"));
         return 1;

--- a/test cases/common/45 subproject/subprojects/sublib/simpletest.c
+++ b/test cases/common/45 subproject/subprojects/sublib/simpletest.c
@@ -1,5 +1,5 @@
 #include<subdefs.h>
 
-int main(int argc, char **argv) {
+int main() {
     return subfunc() == 42 ? 0 : 1;
 }

--- a/test cases/common/45 subproject/user.c
+++ b/test cases/common/45 subproject/user.c
@@ -2,7 +2,7 @@
 #include<stdio.h>
 
 
-int main(int argc, char **argv) {
+int main() {
     int res;
     printf("Calling into sublib now.\n");
     res = subfunc();

--- a/test cases/common/48 custom install dirs/prog.c
+++ b/test cases/common/48 custom install dirs/prog.c
@@ -1,3 +1,3 @@
-int main(int argc, char **arv) {
+int main() {
     return 0;
 }

--- a/test cases/common/49 subproject subproject/prog.c
+++ b/test cases/common/49 subproject subproject/prog.c
@@ -1,5 +1,5 @@
 int func();
 
-int main(int argc, char **argv) {
+int main() {
     return func() == 42 ? 0 : 1;
 }

--- a/test cases/common/5 linkstatic/main.c
+++ b/test cases/common/5 linkstatic/main.c
@@ -1,5 +1,5 @@
 int func();
 
-int main(int argc, char **arg) {
+int main() {
     return func();
 }

--- a/test cases/common/50 same file name/prog.c
+++ b/test cases/common/50 same file name/prog.c
@@ -1,6 +1,6 @@
 int func1();
 int func2();
 
-int main(int argc, char **argv) {
+int main() {
     return func1() - func2();
 }

--- a/test cases/common/51 file grabber/prog.c
+++ b/test cases/common/51 file grabber/prog.c
@@ -2,6 +2,6 @@ int funca();
 int funcb();
 int funcc();
 
-int main(int argc, char **argv) {
+int main() {
     return funca() + funcb() + funcc();
 }

--- a/test cases/common/51 file grabber/subdir/subprog.c
+++ b/test cases/common/51 file grabber/subdir/subprog.c
@@ -2,6 +2,6 @@ int funca();
 int funcb();
 int funcc();
 
-int main(int argc, char **argv) {
+int main() {
     return funca() + funcb() + funcc();
 }

--- a/test cases/common/53 custom target chain/usetarget/myexe.c
+++ b/test cases/common/53 custom target chain/usetarget/myexe.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("I am myexe.\n");
     return 0;
 }

--- a/test cases/common/55 object generator/prog.c
+++ b/test cases/common/55 object generator/prog.c
@@ -2,6 +2,6 @@ int func1_in_obj();
 int func2_in_obj();
 int func3_in_obj();
 
-int main(int argc, char **argv) {
+int main() {
     return func1_in_obj() + func2_in_obj() + func3_in_obj();
 }

--- a/test cases/common/56 install script/prog.c
+++ b/test cases/common/56 install script/prog.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("This is text.\n");
     return 0;
 }

--- a/test cases/common/57 custom target source output/main.c
+++ b/test cases/common/57 custom target source output/main.c
@@ -1,5 +1,5 @@
 #include"mylib.h"
 
-int main(int argc, char **argv) {
+int main() {
     return func();
 }

--- a/test cases/common/58 exe static shared/prog.c
+++ b/test cases/common/58 exe static shared/prog.c
@@ -1,7 +1,7 @@
 int shlibfunc2();
 int statlibfunc();
 
-int main(int argc, char **argv) {
+int main() {
     if (statlibfunc() != 42)
         return 1;
     if (shlibfunc2() != 24)

--- a/test cases/common/6 linkshared/cppmain.cpp
+++ b/test cases/common/6 linkshared/cppmain.cpp
@@ -1,5 +1,5 @@
 int cppfunc();
 
-int main(int argc, char **argv) {
+int main() {
     return cppfunc() != 42;
 }

--- a/test cases/common/6 linkshared/main.c
+++ b/test cases/common/6 linkshared/main.c
@@ -6,6 +6,6 @@
 
 int DLL_IMPORT func();
 
-int main(int argc, char **arg) {
+int main() {
     return func();
 }

--- a/test cases/common/60 custom header generator/prog.c
+++ b/test cases/common/60 custom header generator/prog.c
@@ -1,5 +1,5 @@
 #include"myheader.lh"
 
-int main(int argc, char **argv) {
+int main() {
     return RET_VAL;
 }

--- a/test cases/common/61 multiple generators/main.cpp
+++ b/test cases/common/61 multiple generators/main.cpp
@@ -1,6 +1,6 @@
 #include"source1.h"
 #include"source2.h"
 
-int main(int argc, char **argv) {
+int main() {
     return func1() + func2();
 }

--- a/test cases/common/63 foreach/prog1.c
+++ b/test cases/common/63 foreach/prog1.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("This is test #1.\n");
     return 0;
 }

--- a/test cases/common/63 foreach/prog2.c
+++ b/test cases/common/63 foreach/prog2.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("This is test #2.\n");
     return 0;
 }

--- a/test cases/common/63 foreach/prog3.c
+++ b/test cases/common/63 foreach/prog3.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("This is test #3.\n");
     return 0;
 }

--- a/test cases/common/68 build always/main.c
+++ b/test cases/common/68 build always/main.c
@@ -1,7 +1,7 @@
 #include<stdio.h>
 #include"version.h"
 
-int main(int argc, char **argv) {
+int main() {
     printf("Version is %s.\n", version_string);
     return 0;
 }

--- a/test cases/common/69 vcstag/tagprog.c
+++ b/test cases/common/69 vcstag/tagprog.c
@@ -2,7 +2,7 @@
 
 const char *vcstag;
 
-int main(int argc, char **argv) {
+int main() {
     printf("Version is %s\n", vcstag);
     return 0;
 }

--- a/test cases/common/7 mixed/main.cc
+++ b/test cases/common/7 mixed/main.cc
@@ -2,6 +2,6 @@ extern "C" int func();
 
 class BreakPlainCCompiler;
 
-int main(int argc, char **argv) {
+int main() {
     return func();
 }

--- a/test cases/common/71 should fail/failing.c
+++ b/test cases/common/71 should fail/failing.c
@@ -1,3 +1,3 @@
-int main(int argc, char **argv) {
+int main() {
     return 1;
 }

--- a/test cases/common/75 shared subproject/a.c
+++ b/test cases/common/75 shared subproject/a.c
@@ -2,7 +2,7 @@
 char func_b();
 char func_c();
 
-int main(int argc, char **argv) {
+int main() {
     if(func_b() != 'b') {
         return 1;
     }

--- a/test cases/common/76 shared subproject 2/a.c
+++ b/test cases/common/76 shared subproject 2/a.c
@@ -2,7 +2,7 @@
 char func_b();
 char func_c();
 
-int main(int argc, char **argv) {
+int main() {
     if(func_b() != 'b') {
         return 1;
     }

--- a/test cases/common/77 file object/prog.c
+++ b/test cases/common/77 file object/prog.c
@@ -2,7 +2,7 @@
 
 int func(); /* Files in different subdirs return different values. */
 
-int main(int argc, char **argv) {
+int main() {
     if(func() == 0) {
         printf("Iz success.\n");
     } else {

--- a/test cases/common/77 file object/subdir1/prog.c
+++ b/test cases/common/77 file object/subdir1/prog.c
@@ -2,7 +2,7 @@
 
 int func();
 
-int main(int argc, char **argv) {
+int main() {
     if(func() == 1) {
         printf("Iz success.\n");
     } else {

--- a/test cases/common/77 file object/subdir2/prog.c
+++ b/test cases/common/77 file object/subdir2/prog.c
@@ -2,7 +2,7 @@
 
 int func();
 
-int main(int argc, char **argv) {
+int main() {
     if(func() == 2) {
         printf("Iz success.\n");
     } else {

--- a/test cases/common/78 custom subproject dir/a.c
+++ b/test cases/common/78 custom subproject dir/a.c
@@ -2,7 +2,7 @@
 char func_b();
 char func_c();
 
-int main(int argc, char **argv) {
+int main() {
     if(func_b() != 'b') {
         return 1;
     }

--- a/test cases/common/8 install/prog.c
+++ b/test cases/common/8 install/prog.c
@@ -1,3 +1,3 @@
-int main(int argc, char **argv) {
+int main() {
     return 0;
 }

--- a/test cases/common/81 internal dependency/src/main.c
+++ b/test cases/common/81 internal dependency/src/main.c
@@ -1,7 +1,7 @@
 #include<stdio.h>
 #include<proj1.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("Now calling into library.\n");
     proj1_func1();
     proj1_func2();

--- a/test cases/common/82 same basename/exe1.c
+++ b/test cases/common/82 same basename/exe1.c
@@ -1,5 +1,5 @@
 int func();
 
-int main(int argc, char **argv) {
+int main() {
     return func();
 }

--- a/test cases/common/82 same basename/exe2.c
+++ b/test cases/common/82 same basename/exe2.c
@@ -1,5 +1,5 @@
 int func();
 
-int main(int argc, char **argv) {
+int main() {
     return func() == 1 ? 0 : 1;
 }

--- a/test cases/common/83 declare dep/main.c
+++ b/test cases/common/83 declare dep/main.c
@@ -5,7 +5,7 @@
 #error "Entity use flag not used for compilation."
 #endif
 
-int main(int argc, char **argv) {
+int main() {
     if(entity_func1() != 5) {
         printf("Error in func1.\n");
         return 1;

--- a/test cases/common/84 extract all/prog.c
+++ b/test cases/common/84 extract all/prog.c
@@ -1,7 +1,7 @@
 #include"extractor.h"
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     if((1+2+3+4) != (func1() + func2() + func3() + func4())) {
         printf("Arithmetic is fail.\n");
         return 1;

--- a/test cases/common/85 add language/prog.c
+++ b/test cases/common/85 add language/prog.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("I am plain C.\n");
     return 0;
 }

--- a/test cases/common/86 identical target name in subproject/bar.c
+++ b/test cases/common/86 identical target name in subproject/bar.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("I'm a main project bar.\n");
     return 0;
 }

--- a/test cases/common/86 identical target name in subproject/subprojects/foo/bar.c
+++ b/test cases/common/86 identical target name in subproject/subprojects/foo/bar.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("I'm a subproject bar.\n");
     return 0;
 }

--- a/test cases/common/89 private include/user/libuser.c
+++ b/test cases/common/89 private include/user/libuser.c
@@ -1,6 +1,6 @@
 #include"foo1.h"
 #include"foo2.h"
 
-int main(int argc, char **argv) {
+int main() {
     return foo1() + foo2();
 }

--- a/test cases/common/93 selfbuilt custom/mainprog.cpp
+++ b/test cases/common/93 selfbuilt custom/mainprog.cpp
@@ -1,5 +1,5 @@
 #include"data.h"
 
-int main(int, char **) {
+int main() {
     return generated_function() != 52;
 }

--- a/test cases/common/94 gen extra/plain.c
+++ b/test cases/common/94 gen extra/plain.c
@@ -1,5 +1,5 @@
 int bob_mcbob();
 
-int main(int argc, char **argv) {
+int main() {
     return bob_mcbob();
 }

--- a/test cases/common/94 gen extra/upper.c
+++ b/test cases/common/94 gen extra/upper.c
@@ -1,5 +1,5 @@
 int BOB_MCBOB();
 
-int main(int argc, char **argv) {
+int main() {
     return BOB_MCBOB();
 }

--- a/test cases/common/95 benchmark/delayer.c
+++ b/test cases/common/95 benchmark/delayer.c
@@ -6,7 +6,7 @@
 #include<windows.h>
 #endif
 
-int main(int argc, char **argv) {
+int main() {
     srand(time(NULL));
 #if !defined(_WIN32)
     struct timespec t;

--- a/test cases/common/96 test workdir/opener.c
+++ b/test cases/common/96 test workdir/opener.c
@@ -2,7 +2,7 @@
 
 #include<stdio.h>
 
-int main(int arg, char **argv) {
+int main() {
     FILE *f = fopen("opener.c", "r");
     if(f) {
         fclose(f);

--- a/test cases/common/97 suites/exe1.c
+++ b/test cases/common/97 suites/exe1.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("I am test exe1.\n");
     return 0;
 }

--- a/test cases/common/97 suites/exe2.c
+++ b/test cases/common/97 suites/exe2.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("I am test exe2.\n");
     return 0;
 }

--- a/test cases/common/97 suites/subprojects/sub/sub1.c
+++ b/test cases/common/97 suites/subprojects/sub/sub1.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("I am test sub1.\n");
     return 0;
 }

--- a/test cases/common/97 suites/subprojects/sub/sub2.c
+++ b/test cases/common/97 suites/subprojects/sub/sub2.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main() {
     printf("I am test sub2.\n");
     return 0;
 }

--- a/test cases/common/98 threads/threadprog.c
+++ b/test cases/common/98 threads/threadprog.c
@@ -3,12 +3,12 @@
 #include<windows.h>
 #include<stdio.h>
 
-DWORD WINAPI thread_func(LPVOID ignored) {
+DWORD WINAPI thread_func() {
     printf("Printing from a thread.\n");
     return 0;
 }
 
-int main(int argc, char **argv) {
+int main() {
     DWORD id;
     HANDLE th;
     printf("Starting thread.\n");
@@ -22,12 +22,12 @@ int main(int argc, char **argv) {
 #include<pthread.h>
 #include<stdio.h>
 
-void* main_func(void* ignored) {
+void* main_func() {
     printf("Printing from a thread.\n");
     return NULL;
 }
 
-int main(int argc, char** argv) {
+int main() {
     pthread_t thread;
     int rc;
     printf("Starting thread.\n");

--- a/test cases/common/98 threads/threadprog.cpp
+++ b/test cases/common/98 threads/threadprog.cpp
@@ -14,7 +14,7 @@ DWORD WINAPI thread_func(LPVOID) {
     return 0;
 }
 
-int main(int, char**) {
+int main() {
     printf("Starting thread.\n");
     HANDLE th;
     DWORD id;
@@ -32,7 +32,7 @@ void main_func() {
     printf("Printing from a thread.\n");
 }
 
-int main(int, char**) {
+int main() {
     printf("Starting thread.\n");
     std::thread th(main_func);
     th.join();

--- a/test cases/common/99 manygen/depuser.c
+++ b/test cases/common/99 manygen/depuser.c
@@ -1,6 +1,6 @@
 #include"gen_func.h"
 
-int main(int argc, char **argv) {
+int main() {
     unsigned int i = (unsigned int) gen_func_in_lib();
     unsigned int j = (unsigned int) gen_func_in_obj();
     unsigned int k = (unsigned int) gen_func_in_src();

--- a/test cases/fortran/1 basic/simple.f90
+++ b/test cases/fortran/1 basic/simple.f90
@@ -1,3 +1,2 @@
-program prog
-     print *, "Fortran compilation is working."
-end program prog
+print *, "Fortran compilation is working."
+end program

--- a/test cases/fortran/12 submodule/a1.f90
+++ b/test cases/fortran/12 submodule/a1.f90
@@ -15,6 +15,7 @@ end module a1
 program hierN
 
 use a1
+real :: tau, pi
 
 pi = get_pi()
 

--- a/test cases/fortran/9 cpp/main.cpp
+++ b/test cases/fortran/9 cpp/main.cpp
@@ -2,7 +2,7 @@
 
 extern "C" double fortran();
 
-int main(int, char**) {
+int main() {
     std::cout << "FORTRAN gave us this number: " << fortran() << '\n';
     return 0;
 }

--- a/test cases/linuxlike/1 pkg-config/meson.build
+++ b/test cases/linuxlike/1 pkg-config/meson.build
@@ -39,7 +39,7 @@ cc = meson.get_compiler('c')
 zlibdep = cc.find_library('z')
 code = '''#include<myinc.h>
 
-int main(int argc, char **argv) {
+int main() {
     void * something = deflate;
     if(something != 0)
         return 0;

--- a/test cases/linuxlike/1 pkg-config/prog-checkver.c
+++ b/test cases/linuxlike/1 pkg-config/prog-checkver.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int main(int argc, char **argv) {
+int main() {
     void * something = deflate;
     if(strcmp(ZLIB_VERSION, FOUND_ZLIB) != 0) {
         printf("Meson found '%s' but zlib is '%s'\n", FOUND_ZLIB, ZLIB_VERSION);

--- a/test cases/linuxlike/1 pkg-config/prog.c
+++ b/test cases/linuxlike/1 pkg-config/prog.c
@@ -1,6 +1,6 @@
 #include<zlib.h>
 
-int main(int argc, char **argv) {
+int main() {
     void * something = deflate;
     if(something != 0)
         return 0;

--- a/test cases/linuxlike/11 runpath rpath ldlibrarypath/main.c
+++ b/test cases/linuxlike/11 runpath rpath ldlibrarypath/main.c
@@ -2,7 +2,7 @@
 
 int some_symbol (void);
 
-int main (int argc, char *argv[]) {
+int main () {
   int ret = some_symbol ();
   if (ret == 1)
     return 0;

--- a/test cases/linuxlike/12 subprojects in subprojects/main.c
+++ b/test cases/linuxlike/12 subprojects in subprojects/main.c
@@ -2,7 +2,7 @@
 #include "a.h"
 #include "b.h"
 
-int main(int argc, char **argv) {
+int main() {
     int life = a_fun() + b_fun();
     printf("%d\n", life);
     return 0;

--- a/test cases/linuxlike/13 cmake dependency/meson.build
+++ b/test cases/linuxlike/13 cmake dependency/meson.build
@@ -61,7 +61,7 @@ cc = meson.get_compiler('c')
 zlibdep = cc.find_library('z')
 code = '''#include<myinc.h>
 
-int main(int argc, char **argv) {
+int main() {
     void * something = deflate;
     if(something != 0)
         return 0;

--- a/test cases/linuxlike/13 cmake dependency/prog-checkver.c
+++ b/test cases/linuxlike/13 cmake dependency/prog-checkver.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int main(int argc, char **argv) {
+int main() {
     void * something = deflate;
     if(strcmp(ZLIB_VERSION, FOUND_ZLIB) != 0) {
         printf("Meson found '%s' but zlib is '%s'\n", FOUND_ZLIB, ZLIB_VERSION);

--- a/test cases/linuxlike/13 cmake dependency/prog.c
+++ b/test cases/linuxlike/13 cmake dependency/prog.c
@@ -1,6 +1,6 @@
 #include<zlib.h>
 
-int main(int argc, char **argv) {
+int main() {
     void * something = deflate;
     if(something != 0)
         return 0;

--- a/test cases/linuxlike/13 cmake dependency/testFlagSet.c
+++ b/test cases/linuxlike/13 cmake dependency/testFlagSet.c
@@ -9,7 +9,7 @@
 #error "REQUIRED_MESON_FLAG2 not set"
 #endif
 
-int main(int argc, char *argv[]) {
+int main() {
   printf("Hello World\n");
   void * something = deflate;
   if(something != 0)

--- a/test cases/linuxlike/2 external library/meson.build
+++ b/test cases/linuxlike/2 external library/meson.build
@@ -5,14 +5,14 @@ zlib = cc.find_library('z')
 
 # Verify that link testing works.
 linkcode = '''#include<zlib.h>
-int main(int argc, char **argv) {
+int main() {
   void *ptr = (void*)(deflate);
   return ptr == 0;
 }
 '''
 
 nolinkcode='''int nonexisting();
-int main(int argc, char **argv) {
+int main() {
   return nonexisting();
 }
 '''

--- a/test cases/linuxlike/2 external library/prog.c
+++ b/test cases/linuxlike/2 external library/prog.c
@@ -1,6 +1,6 @@
 #include<zlib.h>
 
-int main(int argc, char **argv) {
+int main() {
     void * something = deflate;
     if(something != 0)
         return 0;

--- a/test cases/linuxlike/3 linker script/prog.c
+++ b/test cases/linuxlike/3 linker script/prog.c
@@ -1,5 +1,5 @@
 #include"bob.h"
 
-int main(int argc, char **argv) {
+int main() {
     return bobMcBob() != 42;
 }

--- a/test cases/linuxlike/4 extdep static lib/prog.c
+++ b/test cases/linuxlike/4 extdep static lib/prog.c
@@ -1,5 +1,5 @@
 int statlibfunc();
 
-int main(int argc, char **argv) {
+int main() {
     return statlibfunc();
 }

--- a/test cases/linuxlike/7 library versions/exe.orig.c
+++ b/test cases/linuxlike/7 library versions/exe.orig.c
@@ -1,7 +1,6 @@
 int myFunc (void);
 
-int
-main (int argc, char *argv[])
+int main()
 {
   if (myFunc() == 55)
     return 0;

--- a/test cases/linuxlike/9 compiler checks with dependencies/meson.build
+++ b/test cases/linuxlike/9 compiler checks with dependencies/meson.build
@@ -10,7 +10,7 @@ if glib.found()
   assert (cc.has_member('GError', 'message', prefix : '#include <glib.h>', dependencies : glib), 'GError::message not found')
   assert (cc.has_header_symbol('glib.h', 'gint32', dependencies : glib), 'gint32 symbol not found')
   linkcode = '''#include <glib.h>
-int main (int argc, char *argv[]) {
+int main () {
   GError *error = g_error_new_literal (0, 0, NULL);
   return error == NULL;
 }
@@ -21,7 +21,7 @@ endif
 zlib = cc.find_library ('z')
 if zlib.found()
   linkcode = '''#include<zlib.h>
-int main(int argc, char *argv[]) {
+int main() {
   void *ptr = (void*)(deflate);
   return ptr == 0;
 }

--- a/test cases/windows/1 basic/prog.c
+++ b/test cases/windows/1 basic/prog.c
@@ -1,5 +1,5 @@
 #include <windows.h>
 
-int main(int argc, char **argv) {
+int main() {
     return 0;
 }

--- a/test cases/windows/10 vs module defs generated custom target/prog.c
+++ b/test cases/windows/10 vs module defs generated custom target/prog.c
@@ -1,5 +1,5 @@
 int somedllfunc();
 
-int main(int argc, char **argv) {
+int main() {
     return somedllfunc() == 42 ? 0 : 1;
 }

--- a/test cases/windows/11 exe implib/prog.c
+++ b/test cases/windows/11 exe implib/prog.c
@@ -1,6 +1,6 @@
 #include <windows.h>
 
 int  __declspec(dllexport)
-main(int argc, char **argv) {
+main() {
     return 0;
 }

--- a/test cases/windows/16 gui app/console_prog.c
+++ b/test cases/windows/16 gui app/console_prog.c
@@ -1,3 +1,3 @@
-int main(int argc, char **argv) {
+int main() {
     return 0;
 }

--- a/test cases/windows/6 vs module defs/prog.c
+++ b/test cases/windows/6 vs module defs/prog.c
@@ -1,5 +1,5 @@
 int somedllfunc();
 
-int main(int argc, char **argv) {
+int main() {
     return somedllfunc() == 42 ? 0 : 1;
 }

--- a/test cases/windows/7 dll versioning/exe.orig.c
+++ b/test cases/windows/7 dll versioning/exe.orig.c
@@ -1,7 +1,6 @@
 int myFunc (void);
 
-int
-main (int argc, char *argv[])
+int main()
 {
   if (myFunc() == 55)
     return 0;

--- a/test cases/windows/9 vs module defs generated/prog.c
+++ b/test cases/windows/9 vs module defs generated/prog.c
@@ -1,5 +1,5 @@
 int somedllfunc();
 
-int main(int argc, char **argv) {
+int main() {
     return somedllfunc() == 42 ? 0 : 1;
 }


### PR DESCRIPTION
When GCC or Clang used for C project tests, ensure that no unused arguments to functions are present.

Likewise for Fortran and GCC, enforce Implicit None