### PR TITLE
cmake: Read CMAKE_PREFIX_PATH environment variable (closes #5666)

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1035,6 +1035,12 @@ class CMakeDependency(ExternalDependency):
             cm_args.append('-DCMAKE_MODULE_PATH=' + ';'.join(cm_path))
 
         pref_path = self.env.coredata.builtins_per_machine[self.for_machine]['cmake_prefix_path'].value
+        if 'CMAKE_PREFIX_PATH' in os.environ:
+            env_pref_path = os.environ['CMAKE_PREFIX_PATH'].split(':')
+            env_pref_path = [x for x in env_pref_path if x]  # Filter out enpty strings
+            if not pref_path:
+                pref_path = []
+            pref_path += env_pref_path
         if pref_path:
             cm_args.append('-DCMAKE_PREFIX_PATH={}'.format(';'.join(pref_path)))
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -222,28 +222,33 @@ def clear_meson_configure_class_caches():
     mesonbuild.dependencies.PkgConfigDependency.pkgbin_cache = {}
     mesonbuild.dependencies.PkgConfigDependency.class_pkgbin = mesonlib.PerMachine(None, None)
 
-def run_configure_inprocess(commandlist):
+def run_configure_inprocess(commandlist, env=None):
     old_stdout = sys.stdout
     sys.stdout = mystdout = StringIO()
     old_stderr = sys.stderr
     sys.stderr = mystderr = StringIO()
+    old_environ = os.environ.copy()
+    if env is not None:
+        os.environ.update(env)
     try:
         returncode = mesonmain.run(commandlist, get_meson_script())
     finally:
         sys.stdout = old_stdout
         sys.stderr = old_stderr
         clear_meson_configure_class_caches()
+        os.environ.clear()
+        os.environ.update(old_environ)
     return returncode, mystdout.getvalue(), mystderr.getvalue()
 
-def run_configure_external(full_command):
-    pc, o, e = mesonlib.Popen_safe(full_command)
+def run_configure_external(full_command, env=None):
+    pc, o, e = mesonlib.Popen_safe(full_command, env=env)
     return pc.returncode, o, e
 
-def run_configure(commandlist):
+def run_configure(commandlist, env=None):
     global meson_exe
     if meson_exe:
-        return run_configure_external(meson_exe + commandlist)
-    return run_configure_inprocess(commandlist)
+        return run_configure_external(meson_exe + commandlist, env=env)
+    return run_configure_inprocess(commandlist, env=env)
 
 def print_system_info():
     print(mlog.bold('System information.').get_text(mlog.colorize_console))

--- a/test cases/linuxlike/13 cmake dependency/cmake_pref_env/lib/cmake/cmMesonTestDep/cmMesonTestDepConfig.cmake
+++ b/test cases/linuxlike/13 cmake dependency/cmake_pref_env/lib/cmake/cmMesonTestDep/cmMesonTestDepConfig.cmake
@@ -1,0 +1,9 @@
+find_package(ZLIB)
+
+if(ZLIB_FOUND OR ZLIB_Found)
+  set(cmMesonTestDep_FOUND        ON)
+  set(cmMesonTestDep_LIBRARIES    ${ZLIB_LIBRARY})
+  set(cmMesonTestDep_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR})
+else()
+  set(cmMesonTestDep_FOUND       OFF)
+endif()

--- a/test cases/linuxlike/13 cmake dependency/meson.build
+++ b/test cases/linuxlike/13 cmake dependency/meson.build
@@ -36,6 +36,10 @@ depf2 = dependency('ZLIB', required : false, method : 'cmake', modules : 'dfggh:
 
 assert(depf2.found() == false, 'Invalid CMake targets should fail')
 
+# Try to find cmMesonTestDep in a custom prefix
+
+depPrefEnv = dependency('cmMesonTestDep', required : true, method : 'cmake')
+
 # Try to find a dependency with a custom CMake module
 
 depm1 = dependency('SomethingLikeZLIB', required : true, method : 'cmake', cmake_module_path : 'cmake')

--- a/test cases/linuxlike/13 cmake dependency/setup_env.json
+++ b/test cases/linuxlike/13 cmake dependency/setup_env.json
@@ -1,0 +1,3 @@
+{
+  "CMAKE_PREFIX_PATH": "@ROOT@/cmake_pref_env"
+}


### PR DESCRIPTION
With this PR, the meson dependency backend reads the `CMAKE_PREFIX_PATH`, used internally by CMake and adds it to the CMake command line and the internal preliminary CMake search path.

This PR also includes a general update to `run_project_tests.py` to additional environment variables from an `setup_env.json` file.