### PR TITLE
CI: azure cygwin cmake 3.14.5

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,7 @@ jobs:
         gccx64ninja: {}
   variables:
     CYGWIN_ROOT: $(System.Workfolder)\cygwin
-    CYGWIN_CMAKE_LINK: http://cygwin.mirror.constant.com/x86_64/release/cmake/cmake-3.13.1-1.tar.xz
+    CYGWIN_CMAKE_LINK: http://cygwin.mirror.constant.com/x86_64/release/cmake/cmake-3.14.5-1.tar.xz
     CYGWIN_MIRROR: http://cygwin.mirror.constant.com
   steps:
     - script: |
@@ -117,7 +117,7 @@ jobs:
     - script: |
         %CYGWIN_ROOT%\bin\bash.exe -cl "wget %CYGWIN_CMAKE_LINK% -O cmake.tar.xz"
         %CYGWIN_ROOT%\bin\bash.exe -cl "tar -xf cmake.tar.xz -C /"
-      displayName: Manually install CMake 3.13.1
+      displayName: Manually install CMake
     - script: |
         set BOOST_ROOT=
         set PATH=%CYGWIN_ROOT%\bin;%SYSTEMROOT%\system32


### PR DESCRIPTION
CMake 3.13.1 isn't the latest point release for CMake 3.13, but 3.14.5 is the latest point release currently available in Cygwin for CMake. 
Since CMake server used to communicate with external programs like Meson changed in CMake 3.14 to file-based API, maybe good to keep beyond that in case we need to use it.