### PR TITLE
split dynamic linker representations from compilers

### DIFF
--- a/docs/markdown/snippets/b_lundef_on_apple.md
+++ b/docs/markdown/snippets/b_lundef_on_apple.md
@@ -1,0 +1,5 @@
+## Meson's builtin b_lundef is now supported on macOS
+
+This has always been possible, but there are some addtional restrictions on
+macOS (mainly do to Apple only features). With the linker internal
+re-architecture this has become possible

--- a/docs/markdown/snippets/split-compiler-and-linker-representations.md
+++ b/docs/markdown/snippets/split-compiler-and-linker-representations.md
@@ -1,0 +1,6 @@
+## Compiler and dynamic linker representation split
+
+0.52.0 inclues a massive refactor of the representaitons of compilers to
+tease apart the representations of compilers and dynamic linkers (ld). This
+fixes a number of compiler/linker combinations. In particular this fixes
+use GCC and vanilla clang on macOS.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1327,7 +1327,8 @@ int dummy;
                                                                self.get_target_dir(target))
             else:
                 target_slashname_workaround_dir = self.get_target_dir(target)
-            rpath_args = rustc.build_rpath_args(self.environment.get_build_dir(),
+            rpath_args = rustc.build_rpath_args(self.environment,
+                                                self.environment.get_build_dir(),
                                                 target_slashname_workaround_dir,
                                                 self.determine_rpath_dirs(target),
                                                 target.build_rpath,
@@ -2324,9 +2325,10 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             # All shared libraries are PIC
             commands += linker.get_pic_args()
             # Add -Wl,-soname arguments on Linux, -install_name on OS X
-            commands += linker.get_soname_args(target.prefix, target.name, target.suffix,
-                                               target.soversion, target.darwin_versions,
-                                               isinstance(target, build.SharedModule))
+            commands += linker.get_soname_args(
+                self.environment, target.prefix, target.name, target.suffix,
+                target.soversion, target.darwin_versions,
+                isinstance(target, build.SharedModule))
             # This is only visited when building for Windows using either GCC or Visual Studio
             if target.vs_module_defs and hasattr(linker, 'gen_vs_module_defs_args'):
                 commands += linker.gen_vs_module_defs_args(target.vs_module_defs.rel_to_builddir(self.build_to_src))
@@ -2537,7 +2539,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 self.get_target_dir(target))
         else:
             target_slashname_workaround_dir = self.get_target_dir(target)
-        commands += linker.build_rpath_args(self.environment.get_build_dir(),
+        commands += linker.build_rpath_args(self.environment,
+                                            self.environment.get_build_dir(),
                                             target_slashname_workaround_dir,
                                             self.determine_rpath_dirs(target),
                                             target.build_rpath,

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -28,7 +28,7 @@ from .mesonlib import (
     extract_as_list, typeslistify, stringlistify, classify_unity_sources,
     get_filenames_templates_dict, substitute_values, has_path_sep,
 )
-from .compilers import Compiler, is_object, clink_langs, sort_clink, lang_suffixes, get_macos_dylib_install_name
+from .compilers import Compiler, is_object, clink_langs, sort_clink, lang_suffixes
 from .linkers import StaticLinker
 from .interpreterbase import FeatureNew
 
@@ -96,8 +96,12 @@ known_stlib_kwargs = known_build_target_kwargs | {'pic'}
 known_jar_kwargs = known_exe_kwargs | {'main_class'}
 
 @lru_cache(maxsize=None)
-def get_target_macos_dylib_install_name(ld):
-    return get_macos_dylib_install_name(ld.prefix, ld.name, ld.suffix, ld.soversion)
+def get_target_macos_dylib_install_name(ld) -> str:
+    name = ['@rpath/', ld.prefix, ld.name]
+    if ld.soversion is not None:
+        name.append('.' + ld.soversion)
+    name.append('.dylib')
+    return ''.join(name)
 
 class InvalidArguments(MesonException):
     pass

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -23,7 +23,6 @@ __all__ = [
     'clink_langs',
     'c_suffixes',
     'cpp_suffixes',
-    'get_macos_dylib_install_name',
     'get_base_compile_args',
     'get_base_link_args',
     'is_assembly',
@@ -185,6 +184,6 @@ from .rust import RustCompiler
 from .swift import SwiftCompiler
 from .vala import ValaCompiler
 from .mixins.visualstudio import VisualStudioLikeCompiler
-from .mixins.gnu import GnuCompiler, get_macos_dylib_install_name
+from .mixins.gnu import GnuCompiler
 from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -293,14 +293,14 @@ class VisualStudioLikeCCompilerMixin:
 
 class VisualStudioCCompiler(VisualStudioLikeCompiler, VisualStudioLikeCCompilerMixin, CCompiler):
 
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrap, target: str):
-        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrap)
+    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrap, target: str, **kwargs):
+        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrap, **kwargs)
         VisualStudioLikeCompiler.__init__(self, target)
         self.id = 'msvc'
 
 class ClangClCCompiler(VisualStudioLikeCompiler, VisualStudioLikeCCompilerMixin, CCompiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrap, target):
-        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrap)
+    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrap, target, **kwargs):
+        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrap, **kwargs)
         VisualStudioLikeCompiler.__init__(self, target)
         self.id = 'clang-cl'
 
@@ -311,8 +311,8 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
 
     __have_warned = False
 
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrap, target):
-        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrap)
+    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrap, target, **kwargs):
+        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrap, **kwargs)
         IntelVisualStudioLikeCompiler.__init__(self, target)
 
     def get_options(self):

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -27,6 +27,7 @@ from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler
 from .mixins.elbrus import ElbrusCompiler
 from .mixins.pgi import PGICompiler
+from .mixins.islinker import BasicLinkerIsCompilerMixin, LinkerEnvVarsMixin
 from .compilers import (
     gnu_winlibs,
     msvc_winlibs,
@@ -112,14 +113,8 @@ class ClangCCompiler(ClangCompiler, CCompiler):
     def get_option_link_args(self, options):
         return []
 
-    def get_linker_always_args(self):
-        basic = super().get_linker_always_args()
-        if self.compiler_type.is_osx_compiler:
-            return basic + ['-Wl,-headerpad_max_install_names']
-        return basic
 
-
-class EmscriptenCCompiler(ClangCCompiler):
+class EmscriptenCCompiler(LinkerEnvVarsMixin, BasicLinkerIsCompilerMixin, ClangCCompiler):
     def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
         if not is_cross:
             raise MesonException('Emscripten compiler can only be used for cross compilation.')
@@ -127,18 +122,6 @@ class EmscriptenCCompiler(ClangCCompiler):
         self.id = 'emscripten'
 
     def get_option_link_args(self, options):
-        return []
-
-    def get_linker_always_args(self):
-        return []
-
-    def get_asneeded_args(self):
-        return []
-
-    def get_lundef_args(self):
-        return []
-
-    def build_rpath_args(self, *args, **kwargs):
         return []
 
     def get_soname_args(self, *args, **kwargs):
@@ -387,9 +370,6 @@ class CcrxCCompiler(CcrxCompiler, CCompiler):
 
     def get_output_args(self, target):
         return ['-output=obj=%s' % target]
-
-    def get_linker_output_args(self, outputname):
-        return ['-output=%s' % outputname]
 
     def get_werror_args(self):
         return ['-change_message=error']

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -36,6 +36,7 @@ from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler
 from .mixins.elbrus import ElbrusCompiler
 from .mixins.pgi import PGICompiler
+from .mixins.islinker import BasicLinkerIsCompilerMixin, LinkerEnvVarsMixin
 
 
 def non_msvc_eh_options(eh, args):
@@ -183,7 +184,7 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
         return ['-lstdc++']
 
 
-class EmscriptenCPPCompiler(ClangCPPCompiler):
+class EmscriptenCPPCompiler(LinkerEnvVarsMixin, BasicLinkerIsCompilerMixin, ClangCPPCompiler):
     def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
         if not is_cross:
             raise MesonException('Emscripten compiler can only be used for cross compilation.')
@@ -198,18 +199,6 @@ class EmscriptenCPPCompiler(ClangCPPCompiler):
         return args
 
     def get_option_link_args(self, options):
-        return []
-
-    def get_linker_always_args(self):
-        return []
-
-    def get_asneeded_args(self):
-        return []
-
-    def get_lundef_args(self):
-        return []
-
-    def build_rpath_args(self, *args, **kwargs):
         return []
 
     def get_soname_args(self, *args, **kwargs):
@@ -573,9 +562,6 @@ class CcrxCPPCompiler(CcrxCompiler, CPPCompiler):
 
     def get_output_args(self, target):
         return ['-output=obj=%s' % target]
-
-    def get_linker_output_args(self, outputname):
-        return ['-output=%s' % outputname]
 
     def get_option_link_args(self, options):
         return []

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -473,8 +473,8 @@ class CPP11AsCPP14Mixin:
 
 
 class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixin, VisualStudioLikeCompiler, CPPCompiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross: bool, exe_wrap, target):
-        CPPCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrap)
+    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross: bool, exe_wrap, target, **kwargs):
+        CPPCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrap, **kwargs)
         VisualStudioLikeCompiler.__init__(self, target)
         self.base_options = ['b_pch', 'b_vscrt'] # FIXME add lto, pgo and the like
         self.id = 'msvc'
@@ -506,8 +506,8 @@ class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixi
         return args
 
 class ClangClCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixin, VisualStudioLikeCompiler, CPPCompiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrap, target):
-        CPPCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrap)
+    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrap, target, **kwargs):
+        CPPCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrap, **kwargs)
         VisualStudioLikeCompiler.__init__(self, target)
         self.id = 'clang-cl'
 
@@ -518,8 +518,8 @@ class ClangClCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixin, Vi
 
 class IntelClCPPCompiler(VisualStudioLikeCPPCompilerMixin, IntelVisualStudioLikeCompiler, CPPCompiler):
 
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrap, target):
-        CPPCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrap)
+    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrap, target, **kwargs):
+        CPPCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrap, **kwargs)
         IntelVisualStudioLikeCompiler.__init__(self, target)
 
     def get_options(self):

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -18,6 +18,7 @@ from ..mesonlib import EnvironmentException
 from ..mesonlib import is_windows
 
 from .compilers import Compiler, MachineChoice, mono_buildtype_args
+from .mixins.islinker import BasicLinkerIsCompilerMixin
 
 cs_optimization_args = {'0': [],
                         'g': [],
@@ -27,7 +28,7 @@ cs_optimization_args = {'0': [],
                         's': ['-optimize+'],
                         }
 
-class CsCompiler(Compiler):
+class CsCompiler(BasicLinkerIsCompilerMixin, Compiler):
     def __init__(self, exelist, version, for_machine: MachineChoice, comp_id, runner=None):
         self.language = 'cs'
         super().__init__(exelist, version, for_machine)
@@ -50,17 +51,11 @@ class CsCompiler(Compiler):
     def get_link_args(self, fname):
         return ['-r:' + fname]
 
-    def get_soname_args(self, *args):
-        return []
-
     def get_werror_args(self):
         return ['-warnaserror']
 
     def split_shlib_to_parts(self, fname):
         return None, fname
-
-    def build_rpath_args(self, build_dir, from_dir, rpath_paths, build_rpath, install_rpath):
-        return []
 
     def get_dependency_gen_args(self, outtarget, outfile):
         return []
@@ -71,13 +66,7 @@ class CsCompiler(Compiler):
     def get_compile_only_args(self):
         return []
 
-    def get_linker_output_args(self, outputname):
-        return []
-
     def get_coverage_args(self):
-        return []
-
-    def get_coverage_link_args(self):
         return []
 
     def get_std_exe_link_args(self):
@@ -141,6 +130,7 @@ class CsCompiler(Compiler):
 
     def get_optimization_args(self, optimization_level):
         return cs_optimization_args[optimization_level]
+
 
 class MonoCompiler(CsCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice):

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re, os.path
+import os.path
 
 from .. import mlog
 from ..mesonlib import EnvironmentException, MachineChoice, Popen_safe
 from .compilers import (Compiler, cuda_buildtype_args, cuda_optimization_args,
                         cuda_debug_args, CompilerType)
-from .mixins.gnu import get_gcc_soname_args
 
 class CudaCompiler(Compiler):
     def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrapper=None):
@@ -165,7 +164,7 @@ class CudaCompiler(Compiler):
         Converts GNU-style arguments -Wl,-arg,-arg
         to NVCC-style arguments -Xlinker=-arg,-arg
         """
-        return [re.sub('^-Wl,', '-Xlinker=', arg) for arg in args]
+        return [arg.replace('-Wl', '-Xlinker=', 1) if arg.startswith('-Wl') else arg for arg in args]
 
     def get_output_args(self, target):
         return ['-o', target]

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -20,10 +20,10 @@ from .compilers import (Compiler, cuda_buildtype_args, cuda_optimization_args,
                         cuda_debug_args, CompilerType)
 
 class CudaCompiler(Compiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrapper=None):
+    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
         if not hasattr(self, 'language'):
             self.language = 'cuda'
-        super().__init__(exelist, version, for_machine)
+        super().__init__(exelist, version, for_machine, **kwargs)
         self.is_cross = is_cross
         self.exe_wrapper = exe_wrapper
         self.id = 'nvcc'

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -27,7 +27,7 @@ from .compilers import (
     Compiler,
     CompilerArgs,
 )
-from .mixins.gnu import get_gcc_soname_args, gnu_color_args, gnu_optimization_args
+from .mixins.gnu import get_gcc_soname_args, GnuCompiler
 
 d_feature_args = {'gcc':  {'unittest': '-funittest',
                            'debug': '-fdebug',
@@ -62,44 +62,11 @@ dmd_optimization_args = {'0': [],
                          's': ['-O'],
                          }
 
-class DCompiler(Compiler):
-    mscrt_args = {
-        'none': ['-mscrtlib='],
-        'md': ['-mscrtlib=msvcrt'],
-        'mdd': ['-mscrtlib=msvcrtd'],
-        'mt': ['-mscrtlib=libcmt'],
-        'mtd': ['-mscrtlib=libcmtd'],
-    }
 
-    def __init__(self, exelist, version, for_machine: MachineChoice, arch, **kwargs):
-        self.language = 'd'
-        super().__init__(exelist, version, for_machine, **kwargs)
-        self.id = 'unknown'
-        self.arch = arch
-
-    def sanity_check(self, work_dir, environment):
-        source_name = os.path.join(work_dir, 'sanity.d')
-        output_name = os.path.join(work_dir, 'dtest')
-        with open(source_name, 'w') as ofile:
-            ofile.write('''void main() { }''')
-        pc = subprocess.Popen(self.exelist + self.get_output_args(output_name) + self.get_target_arch_args() + [source_name], cwd=work_dir)
-        pc.wait()
-        if pc.returncode != 0:
-            raise EnvironmentException('D compiler %s can not compile programs.' % self.name_string())
-        if subprocess.call(output_name) != 0:
-            raise EnvironmentException('Executables created by D compiler %s are not runnable.' % self.name_string())
-
-    def needs_static_linker(self):
-        return True
-
-    def name_string(self):
-        return ' '.join(self.exelist)
-
-    def get_exelist(self):
-        return self.exelist
+class DmdLikeCompilerMixin:
 
     def get_linker_exelist(self):
-        return self.exelist[:]
+        return self.get_exelist()
 
     def get_output_args(self, target):
         return ['-of=' + target]
@@ -147,20 +114,6 @@ class DCompiler(Compiler):
     def get_compile_only_args(self):
         return ['-c']
 
-    def depfile_for_object(self, objfile):
-        return objfile + '.' + self.get_depfile_suffix()
-
-    def get_depfile_suffix(self):
-        return 'deps'
-
-    def get_pic_args(self):
-        if is_windows():
-            return []
-        return ['-fPIC']
-
-    def get_std_shared_lib_link_args(self):
-        return ['-shared']
-
     def get_soname_args(self, *args):
         # FIXME: Make this work for cross-compiling
         if is_windows():
@@ -172,96 +125,6 @@ class DCompiler(Compiler):
             return []
 
         return get_gcc_soname_args(CompilerType.GCC_STANDARD, *args)
-
-    def get_feature_args(self, kwargs, build_to_src):
-        res = []
-        if 'unittest' in kwargs:
-            unittest = kwargs.pop('unittest')
-            unittest_arg = d_feature_args[self.id]['unittest']
-            if not unittest_arg:
-                raise EnvironmentException('D compiler %s does not support the "unittest" feature.' % self.name_string())
-            if unittest:
-                res.append(unittest_arg)
-
-        if 'debug' in kwargs:
-            debug_level = -1
-            debugs = kwargs.pop('debug')
-            if not isinstance(debugs, list):
-                debugs = [debugs]
-
-            debug_arg = d_feature_args[self.id]['debug']
-            if not debug_arg:
-                raise EnvironmentException('D compiler %s does not support conditional debug identifiers.' % self.name_string())
-
-            # Parse all debug identifiers and the largest debug level identifier
-            for d in debugs:
-                if isinstance(d, int):
-                    if d > debug_level:
-                        debug_level = d
-                elif isinstance(d, str) and d.isdigit():
-                    if int(d) > debug_level:
-                        debug_level = int(d)
-                else:
-                    res.append('{0}={1}'.format(debug_arg, d))
-
-            if debug_level >= 0:
-                res.append('{0}={1}'.format(debug_arg, debug_level))
-
-        if 'versions' in kwargs:
-            version_level = -1
-            versions = kwargs.pop('versions')
-            if not isinstance(versions, list):
-                versions = [versions]
-
-            version_arg = d_feature_args[self.id]['version']
-            if not version_arg:
-                raise EnvironmentException('D compiler %s does not support conditional version identifiers.' % self.name_string())
-
-            # Parse all version identifiers and the largest version level identifier
-            for v in versions:
-                if isinstance(v, int):
-                    if v > version_level:
-                        version_level = v
-                elif isinstance(v, str) and v.isdigit():
-                    if int(v) > version_level:
-                        version_level = int(v)
-                else:
-                    res.append('{0}={1}'.format(version_arg, v))
-
-            if version_level >= 0:
-                res.append('{0}={1}'.format(version_arg, version_level))
-
-        if 'import_dirs' in kwargs:
-            import_dirs = kwargs.pop('import_dirs')
-            if not isinstance(import_dirs, list):
-                import_dirs = [import_dirs]
-
-            import_dir_arg = d_feature_args[self.id]['import_dir']
-            if not import_dir_arg:
-                raise EnvironmentException('D compiler %s does not support the "string import directories" feature.' % self.name_string())
-            for idir_obj in import_dirs:
-                basedir = idir_obj.get_curdir()
-                for idir in idir_obj.get_incdirs():
-                    # Avoid superfluous '/.' at the end of paths when d is '.'
-                    if idir not in ('', '.'):
-                        expdir = os.path.join(basedir, idir)
-                    else:
-                        expdir = basedir
-                    srctreedir = os.path.join(build_to_src, expdir)
-                    res.append('{0}{1}'.format(import_dir_arg, srctreedir))
-
-        if kwargs:
-            raise EnvironmentException('Unknown D compiler feature(s) selected: %s' % ', '.join(kwargs.keys()))
-
-        return res
-
-    def get_buildtype_linker_args(self, buildtype):
-        if buildtype != 'plain':
-            return self.get_target_arch_args()
-        return []
-
-    def get_std_exe_link_args(self):
-        return []
 
     def gen_import_library_args(self, implibname):
         return ['-Wl,--out-implib=' + implibname]
@@ -284,54 +147,6 @@ class DCompiler(Compiler):
             else:
                 paths = paths + ':' + padding
         return ['-Wl,-rpath,{}'.format(paths)]
-
-    def _get_compiler_check_args(self, env, extra_args, dependencies, mode='compile'):
-        if callable(extra_args):
-            extra_args = extra_args(mode)
-        if extra_args is None:
-            extra_args = []
-        elif isinstance(extra_args, str):
-            extra_args = [extra_args]
-        if dependencies is None:
-            dependencies = []
-        elif not isinstance(dependencies, list):
-            dependencies = [dependencies]
-        # Collect compiler arguments
-        args = CompilerArgs(self)
-        for d in dependencies:
-            # Add compile flags needed by dependencies
-            args += d.get_compile_args()
-            if mode == 'link':
-                # Add link flags needed to find dependencies
-                args += d.get_link_args()
-
-        if mode == 'compile':
-            # Add DFLAGS from the env
-            args += env.coredata.get_external_args(self.for_machine, self.language)
-        elif mode == 'link':
-            # Add LDFLAGS from the env
-            args += env.coredata.get_external_link_args(self.for_machine, self.language)
-        # extra_args must override all other arguments, so we add them last
-        args += extra_args
-        return args
-
-    def compiles(self, code, env, *, extra_args=None, dependencies=None, mode='compile'):
-        args = self._get_compiler_check_args(env, extra_args, dependencies, mode)
-
-        with self.cached_compile(code, env.coredata, extra_args=args, mode=mode) as p:
-            return p.returncode == 0, p.cached
-
-    def has_multi_arguments(self, args, env):
-        return self.compiles('int i;\n', env, extra_args=args)
-
-    def get_target_arch_args(self):
-        # LDC2 on Windows targets to current OS architecture, but
-        # it should follow the target specified by the MSVC toolchain.
-        if is_windows():
-            if self.arch == 'x86_64':
-                return ['-m64']
-            return ['-m32']
-        return []
 
     @classmethod
     def translate_args_to_nongnu(cls, args):
@@ -480,6 +295,189 @@ class DCompiler(Compiler):
             assert(buildtype == 'custom')
             raise EnvironmentException('Requested C runtime based on buildtype, but buildtype is "custom".')
 
+
+class DCompiler(Compiler):
+    mscrt_args = {
+        'none': ['-mscrtlib='],
+        'md': ['-mscrtlib=msvcrt'],
+        'mdd': ['-mscrtlib=msvcrtd'],
+        'mt': ['-mscrtlib=libcmt'],
+        'mtd': ['-mscrtlib=libcmtd'],
+    }
+
+    def __init__(self, exelist, version, for_machine: MachineChoice, arch, **kwargs):
+        self.language = 'd'
+        super().__init__(exelist, version, for_machine, **kwargs)
+        self.id = 'unknown'
+        self.arch = arch
+
+    def sanity_check(self, work_dir, environment):
+        source_name = os.path.join(work_dir, 'sanity.d')
+        output_name = os.path.join(work_dir, 'dtest')
+        with open(source_name, 'w') as ofile:
+            ofile.write('''void main() { }''')
+        pc = subprocess.Popen(self.exelist + self.get_output_args(output_name) + self.get_target_arch_args() + [source_name], cwd=work_dir)
+        pc.wait()
+        if pc.returncode != 0:
+            raise EnvironmentException('D compiler %s can not compile programs.' % self.name_string())
+        if subprocess.call(output_name) != 0:
+            raise EnvironmentException('Executables created by D compiler %s are not runnable.' % self.name_string())
+
+    def needs_static_linker(self):
+        return True
+
+    def depfile_for_object(self, objfile):
+        return objfile + '.' + self.get_depfile_suffix()
+
+    def get_depfile_suffix(self):
+        return 'deps'
+
+    def get_pic_args(self):
+        if is_windows():
+            return []
+        return ['-fPIC']
+
+    def get_std_shared_lib_link_args(self):
+        return ['-shared']
+
+    def get_feature_args(self, kwargs, build_to_src):
+        res = []
+        if 'unittest' in kwargs:
+            unittest = kwargs.pop('unittest')
+            unittest_arg = d_feature_args[self.id]['unittest']
+            if not unittest_arg:
+                raise EnvironmentException('D compiler %s does not support the "unittest" feature.' % self.name_string())
+            if unittest:
+                res.append(unittest_arg)
+
+        if 'debug' in kwargs:
+            debug_level = -1
+            debugs = kwargs.pop('debug')
+            if not isinstance(debugs, list):
+                debugs = [debugs]
+
+            debug_arg = d_feature_args[self.id]['debug']
+            if not debug_arg:
+                raise EnvironmentException('D compiler %s does not support conditional debug identifiers.' % self.name_string())
+
+            # Parse all debug identifiers and the largest debug level identifier
+            for d in debugs:
+                if isinstance(d, int):
+                    if d > debug_level:
+                        debug_level = d
+                elif isinstance(d, str) and d.isdigit():
+                    if int(d) > debug_level:
+                        debug_level = int(d)
+                else:
+                    res.append('{0}={1}'.format(debug_arg, d))
+
+            if debug_level >= 0:
+                res.append('{0}={1}'.format(debug_arg, debug_level))
+
+        if 'versions' in kwargs:
+            version_level = -1
+            versions = kwargs.pop('versions')
+            if not isinstance(versions, list):
+                versions = [versions]
+
+            version_arg = d_feature_args[self.id]['version']
+            if not version_arg:
+                raise EnvironmentException('D compiler %s does not support conditional version identifiers.' % self.name_string())
+
+            # Parse all version identifiers and the largest version level identifier
+            for v in versions:
+                if isinstance(v, int):
+                    if v > version_level:
+                        version_level = v
+                elif isinstance(v, str) and v.isdigit():
+                    if int(v) > version_level:
+                        version_level = int(v)
+                else:
+                    res.append('{0}={1}'.format(version_arg, v))
+
+            if version_level >= 0:
+                res.append('{0}={1}'.format(version_arg, version_level))
+
+        if 'import_dirs' in kwargs:
+            import_dirs = kwargs.pop('import_dirs')
+            if not isinstance(import_dirs, list):
+                import_dirs = [import_dirs]
+
+            import_dir_arg = d_feature_args[self.id]['import_dir']
+            if not import_dir_arg:
+                raise EnvironmentException('D compiler %s does not support the "string import directories" feature.' % self.name_string())
+            for idir_obj in import_dirs:
+                basedir = idir_obj.get_curdir()
+                for idir in idir_obj.get_incdirs():
+                    # Avoid superfluous '/.' at the end of paths when d is '.'
+                    if idir not in ('', '.'):
+                        expdir = os.path.join(basedir, idir)
+                    else:
+                        expdir = basedir
+                    srctreedir = os.path.join(build_to_src, expdir)
+                    res.append('{0}{1}'.format(import_dir_arg, srctreedir))
+
+        if kwargs:
+            raise EnvironmentException('Unknown D compiler feature(s) selected: %s' % ', '.join(kwargs.keys()))
+
+        return res
+
+    def get_buildtype_linker_args(self, buildtype):
+        if buildtype != 'plain':
+            return self.get_target_arch_args()
+        return []
+
+    def get_std_exe_link_args(self):
+        return []
+
+    def _get_compiler_check_args(self, env, extra_args, dependencies, mode='compile'):
+        if callable(extra_args):
+            extra_args = extra_args(mode)
+        if extra_args is None:
+            extra_args = []
+        elif isinstance(extra_args, str):
+            extra_args = [extra_args]
+        if dependencies is None:
+            dependencies = []
+        elif not isinstance(dependencies, list):
+            dependencies = [dependencies]
+        # Collect compiler arguments
+        args = CompilerArgs(self)
+        for d in dependencies:
+            # Add compile flags needed by dependencies
+            args += d.get_compile_args()
+            if mode == 'link':
+                # Add link flags needed to find dependencies
+                args += d.get_link_args()
+
+        if mode == 'compile':
+            # Add DFLAGS from the env
+            args += env.coredata.get_external_args(self.for_machine, self.language)
+        elif mode == 'link':
+            # Add LDFLAGS from the env
+            args += env.coredata.get_external_link_args(self.for_machine, self.language)
+        # extra_args must override all other arguments, so we add them last
+        args += extra_args
+        return args
+
+    def compiles(self, code, env, *, extra_args=None, dependencies=None, mode='compile'):
+        args = self._get_compiler_check_args(env, extra_args, dependencies, mode)
+
+        with self.cached_compile(code, env.coredata, extra_args=args, mode=mode) as p:
+            return p.returncode == 0, p.cached
+
+    def has_multi_arguments(self, args, env):
+        return self.compiles('int i;\n', env, extra_args=args)
+
+    def get_target_arch_args(self):
+        # LDC2 on Windows targets to current OS architecture, but
+        # it should follow the target specified by the MSVC toolchain.
+        if is_windows():
+            if self.arch == 'x86_64':
+                return ['-m64']
+            return ['-m32']
+        return []
+
     def get_crt_compile_args(self, crt_val, buildtype):
         return []
 
@@ -489,7 +487,11 @@ class DCompiler(Compiler):
     def thread_link_flags(self, env):
         return ['-pthread']
 
-class GnuDCompiler(DCompiler):
+    def name_string(self):
+        return ' '.join(self.exelist)
+
+
+class GnuDCompiler(DCompiler, GnuCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice, arch, **kwargs):
         DCompiler.__init__(self, exelist, version, for_machine, arch, **kwargs)
         self.id = 'gcc'
@@ -507,31 +509,16 @@ class GnuDCompiler(DCompiler):
 
     def get_colorout_args(self, colortype):
         if self._has_color_support:
-            return gnu_color_args[colortype][:]
+            super().get_colorout_args(colortype)
         return []
 
     def get_dependency_gen_args(self, outtarget, outfile):
-        if not self._has_deps_support:
-            return []
-        return ['-MD', '-MQ', outtarget, '-MF', outfile]
-
-    def get_output_args(self, target):
-        return ['-o', target]
-
-    def get_linker_output_args(self, target):
-        return ['-o', target]
-
-    def get_include_args(self, path, is_system):
-        return ['-I' + path]
+        if self._has_deps_support:
+            return super().get_dependency_gen_args(outtarget, outfile)
+        return []
 
     def get_warn_args(self, level):
         return self.warn_args[level]
-
-    def get_werror_args(self):
-        return ['-Werror']
-
-    def get_linker_search_args(self, dirname):
-        return ['-L' + dirname]
 
     def get_coverage_args(self):
         return []
@@ -546,13 +533,8 @@ class GnuDCompiler(DCompiler):
 
         return parameter_list
 
-    def build_rpath_args(self, build_dir, from_dir, rpath_paths, build_rpath, install_rpath):
-        return self.build_unix_rpath_args(build_dir, from_dir, rpath_paths, build_rpath, install_rpath)
 
-    def get_optimization_args(self, optimization_level):
-        return gnu_optimization_args[optimization_level]
-
-class LLVMDCompiler(DCompiler):
+class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice, arch, **kwargs):
         DCompiler.__init__(self, exelist, version, for_machine, arch, **kwargs)
         self.id = 'llvm'
@@ -590,7 +572,7 @@ class LLVMDCompiler(DCompiler):
         return ldc_optimization_args[optimization_level]
 
 
-class DmdDCompiler(DCompiler):
+class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice, arch, **kwargs):
         DCompiler.__init__(self, exelist, version, for_machine, arch, **kwargs)
         self.id = 'dmd'

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from pathlib import Path
 from typing import List
 import subprocess, os
-from pathlib import Path
+import typing
 
 from .compilers import (
     CompilerType,
@@ -255,6 +257,10 @@ class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
 
     def language_stdlib_only_link_flags(self):
         return ['-lifcore', '-limf']
+
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> typing.List[str]:
+        return ['-gen-dep=' + outtarget, '-gen-depformat=make']
+
 
 class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
 

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -276,8 +276,8 @@ class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
         'custom': [],
     }
 
-    def __init__(self, exelist, for_machine: MachineChoice, version, is_cross, target: str, exe_wrapper=None):
-        FortranCompiler.__init__(self, exelist, for_machine, version, is_cross, exe_wrapper)
+    def __init__(self, exelist, for_machine: MachineChoice, version, is_cross, target: str, exe_wrapper=None, **kwargs):
+        FortranCompiler.__init__(self, exelist, for_machine, version, is_cross, exe_wrapper, **kwargs)
         IntelVisualStudioLikeCompiler.__init__(self, target)
 
         default_warn_args = ['/warn:general', '/warn:truncated_source']

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -24,8 +24,7 @@ from .compilers import (
 )
 from .mixins.clike import CLikeCompiler
 from .mixins.gnu import (
-    GnuCompiler, apple_buildtype_linker_args, gnulike_buildtype_args,
-    gnulike_buildtype_linker_args, gnu_optimization_args,
+    GnuCompiler, gnulike_buildtype_args, gnu_optimization_args,
 )
 from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler
@@ -100,11 +99,6 @@ class FortranCompiler(CLikeCompiler, Compiler):
 
     def get_debug_args(self, is_debug):
         return clike_debug_args[is_debug]
-
-    def get_buildtype_linker_args(self, buildtype):
-        if is_osx():
-            return apple_buildtype_linker_args[buildtype]
-        return gnulike_buildtype_linker_args[buildtype]
 
     def get_dependency_gen_args(self, outtarget, outfile):
         return []

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -17,8 +17,9 @@ import os.path, shutil, subprocess
 from ..mesonlib import EnvironmentException, MachineChoice
 
 from .compilers import Compiler, java_buildtype_args
+from .mixins.islinker import BasicLinkerIsCompilerMixin
 
-class JavaCompiler(Compiler):
+class JavaCompiler(BasicLinkerIsCompilerMixin, Compiler):
     def __init__(self, exelist, version, for_machine: MachineChoice):
         self.language = 'java'
         super().__init__(exelist, version, for_machine)
@@ -26,23 +27,14 @@ class JavaCompiler(Compiler):
         self.is_cross = False
         self.javarunner = 'java'
 
-    def get_soname_args(self, *args):
-        return []
-
     def get_werror_args(self):
         return ['-Werror']
 
     def split_shlib_to_parts(self, fname):
         return None, fname
 
-    def build_rpath_args(self, build_dir, from_dir, rpath_paths, build_rpath, install_rpath):
-        return []
-
     def get_dependency_gen_args(self, outtarget, outfile):
         return []
-
-    def get_linker_exelist(self):
-        return self.exelist[:]
 
     def get_compile_only_args(self):
         return []
@@ -52,13 +44,7 @@ class JavaCompiler(Compiler):
             subdir = './'
         return ['-d', subdir, '-s', subdir]
 
-    def get_linker_output_args(self, outputname):
-        return []
-
     def get_coverage_args(self):
-        return []
-
-    def get_coverage_link_args(self):
         return []
 
     def get_std_exe_link_args(self):

--- a/mesonbuild/compilers/mixins/arm.py
+++ b/mesonbuild/compilers/mixins/arm.py
@@ -35,15 +35,6 @@ arm_buildtype_args = {
     'custom': [],
 }  # type: typing.Dict[str, typing.List[str]]
 
-arm_buildtype_linker_args = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': [],
-    'release': [],
-    'minsize': [],
-    'custom': [],
-}  # type: typing.Dict[str, typing.List[str]]
-
 arm_optimization_args = {
     '0': ['-O0'],
     'g': ['-g'],
@@ -87,8 +78,6 @@ class ArmCompiler:
         # Assembly
         self.can_compile_suffixes.add('s')
 
-    def can_linker_accept_rsp(self) -> bool:
-        return False
 
     def get_pic_args(self) -> typing.List[str]:
         # FIXME: Add /ropi, /rwpi, /fpic etc. qualifiers to --apcs
@@ -97,19 +86,12 @@ class ArmCompiler:
     def get_buildtype_args(self, buildtype: str) -> typing.List[str]:
         return arm_buildtype_args[buildtype]
 
-    def get_buildtype_linker_args(self, buildtype: str) -> typing.List[str]:
-        return arm_buildtype_linker_args[buildtype]
-
     # Override CCompiler.get_always_args
     def get_always_args(self) -> typing.List[str]:
         return []
 
     # Override CCompiler.get_dependency_gen_args
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> typing.List[str]:
-        return []
-
-    # Override CCompiler.get_std_shared_lib_link_args
-    def get_std_shared_lib_link_args(self) -> typing.List[str]:
         return []
 
     def get_pch_use_args(self, pch_dir: str, header: str) -> typing.List[str]:
@@ -130,17 +112,7 @@ class ArmCompiler:
     def thread_flags(self, env: 'Environment') -> typing.List[str]:
         return []
 
-    def thread_link_flags(self, env: 'Environment') -> typing.List[str]:
-        return []
-
-    def get_linker_exelist(self) -> typing.List[str]:
-        args = ['armlink']
-        return args
-
     def get_coverage_args(self) -> typing.List[str]:
-        return []
-
-    def get_coverage_link_args(self) -> typing.List[str]:
         return []
 
     def get_optimization_args(self, optimization_level: str) -> typing.List[str]:
@@ -191,9 +163,6 @@ class ArmclangCompiler:
         # Assembly
         self.can_compile_suffixes.update('s')
 
-    def can_linker_accept_rsp(self) -> bool:
-        return False
-
     def get_pic_args(self) -> typing.List[str]:
         # PIC support is not enabled by default for ARM,
         # if users want to use it, they need to add the required arguments explicitly
@@ -204,13 +173,6 @@ class ArmclangCompiler:
 
     def get_buildtype_args(self, buildtype: str) -> typing.List[str]:
         return armclang_buildtype_args[buildtype]
-
-    def get_buildtype_linker_args(self, buildtype: str) -> typing.List[str]:
-        return arm_buildtype_linker_args[buildtype]
-
-    # Override CCompiler.get_std_shared_lib_link_args
-    def get_std_shared_lib_link_args(self) -> typing.List[str]:
-        return []
 
     def get_pch_suffix(self) -> str:
         return 'gch'
@@ -225,33 +187,11 @@ class ArmclangCompiler:
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> typing.List[str]:
         return []
 
-    # Override CCompiler.build_rpath_args
-    def build_rpath_args(self, build_dir: str, from_dir: str, rpath_paths: str,
-                         build_rpath: str, install_rpath: str) -> typing.List[str]:
-        return []
-
-    def get_linker_exelist(self) -> typing.List[str]:
-        return [self.linker_exe]
-
     def get_optimization_args(self, optimization_level: str) -> typing.List[str]:
         return armclang_optimization_args[optimization_level]
 
     def get_debug_args(self, is_debug: bool) -> typing.List[str]:
         return clike_debug_args[is_debug]
-
-    def gen_export_dynamic_link_args(self, env: 'Environment') -> typing.List[str]:
-        """
-        The args for export dynamic
-        """
-        return ['--export_dynamic']
-
-    def gen_import_library_args(self, implibname: str) -> typing.List[str]:
-        """
-        The args of the outputted import library
-
-        ArmLinker's symdefs output can be used as implib
-        """
-        return ['--symdefs=' + implibname]
 
     def compute_parameters_with_absolute_paths(self, parameter_list: typing.List[str], build_dir: str) -> typing.List[str]:
         for idx, i in enumerate(parameter_list):

--- a/mesonbuild/compilers/mixins/ccrx.py
+++ b/mesonbuild/compilers/mixins/ccrx.py
@@ -32,15 +32,6 @@ ccrx_buildtype_args = {
     'custom': [],
 }  # type: typing.Dict[str, typing.List[str]]
 
-ccrx_buildtype_linker_args = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': [],
-    'release': [],
-    'minsize': [],
-    'custom': [],
-}  # type: typing.Dict[str, typing.List[str]]
-
 ccrx_optimization_args = {
     '0': ['-optimize=0'],
     'g': ['-optimize=0'],
@@ -60,14 +51,6 @@ class CcrxCompiler:
     def __init__(self, compiler_type: 'CompilerType'):
         if not self.is_cross:
             raise EnvironmentException('ccrx supports only cross-compilation.')
-        # Check whether 'rlink.exe' is available in path
-        self.linker_exe = 'rlink.exe'
-        args = '--version'
-        try:
-            p, stdo, stderr = Popen_safe(self.linker_exe, args)
-        except OSError as e:
-            err_msg = 'Unknown linker\nRunning "{0}" gave \n"{1}"'.format(' '.join([self.linker_exe] + [args]), e)
-            raise EnvironmentException(err_msg)
         self.id = 'ccrx'
         self.compiler_type = compiler_type
         # Assembly
@@ -78,9 +61,6 @@ class CcrxCompiler:
                           '2': default_warn_args + [],
                           '3': default_warn_args + []}
 
-    def can_linker_accept_rsp(self) -> bool:
-        return False
-
     def get_pic_args(self) -> typing.List[str]:
         # PIC support is not enabled by default for CCRX,
         # if users want to use it, they need to add the required arguments explicitly
@@ -88,13 +68,6 @@ class CcrxCompiler:
 
     def get_buildtype_args(self, buildtype: str) -> typing.List[str]:
         return ccrx_buildtype_args[buildtype]
-
-    def get_buildtype_linker_args(self, buildtype: str) -> typing.List[str]:
-        return ccrx_buildtype_linker_args[buildtype]
-
-    # Override CCompiler.get_std_shared_lib_link_args
-    def get_std_shared_lib_link_args(self) -> typing.List[str]:
-        return []
 
     def get_pch_suffix(self) -> str:
         return 'pch'
@@ -106,26 +79,10 @@ class CcrxCompiler:
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> typing.List[str]:
         return []
 
-    # Override CCompiler.build_rpath_args
-    def build_rpath_args(self, build_dir: str, from_dir: str, rpath_paths: str, build_rpath: str, install_rpath: str) -> typing.List[str]:
-        return []
-
     def thread_flags(self, env: 'Environment') -> typing.List[str]:
         return []
 
-    def thread_link_flags(self, env: 'Environment') -> typing.List[str]:
-        return []
-
-    def get_linker_exelist(self) -> typing.List[str]:
-        return [self.linker_exe]
-
-    def get_linker_lib_prefix(self) -> str:
-        return '-lib='
-
     def get_coverage_args(self) -> typing.List[str]:
-        return []
-
-    def get_coverage_link_args(self) -> typing.List[str]:
         return []
 
     def get_optimization_args(self, optimization_level: str) -> typing.List[str]:

--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -133,8 +133,5 @@ class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
         version = int(v1 + v2)
         return self._calculate_toolset_version(version)
 
-    def get_linker_exelist(self) -> typing.List[str]:
-        return ['xilink']
-
     def openmp_flags(self) -> typing.List[str]:
         return ['/Qopenmp']

--- a/mesonbuild/compilers/mixins/islinker.py
+++ b/mesonbuild/compilers/mixins/islinker.py
@@ -1,0 +1,124 @@
+# Copyright 2019 The Meson development team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mixins for compilers that *are* linkers.
+
+While many compilers (such as gcc and clang) are used by meson to dispatch
+linker commands and other (like MSVC) are not, a few (such as DMD) actually
+are both the linker and compiler in one binary. This module provides mixin
+classes for those cases.
+"""
+
+import os
+import shlex
+import typing
+
+from ... import mesonlib
+
+if typing.TYPE_CHECKING:
+    from ...coredata import OptionDictType
+    from ...environment import Environment
+
+
+class LinkerEnvVarsMixin:
+
+    """Mixin reading LDFLAGS from the environment."""
+
+    def get_linker_args_from_envvars(self) -> typing.List[str]:
+        flags = os.environ.get('LDFLAGS')
+        if not flags:
+            return []
+        return shlex.split(flags)
+
+
+class BasicLinkerIsCompilerMixin:
+
+    """Provides a baseline of methods that a linker would implement.
+
+    In every case this provides a "no" or "empty" answer. If a compiler
+    implements any of these it needs a different mixin or to override that
+    functionality itself.
+    """
+
+    def sanitizer_link_args(self, value: str) -> typing.List[str]:
+        return []
+
+    def get_lto_link_args(self) -> typing.List[str]:
+        return []
+
+    def can_linker_accept_rsp(self) -> bool:
+        return mesonlib.is_windows()
+
+    def get_linker_exelist(self) -> typing.List[str]:
+        return self.exelist.copy()
+
+    def get_linker_output_args(self, output: str) -> typing.List[str]:
+        return []
+
+    def get_linker_always_args(self) -> typing.List[str]:
+        return []
+
+    def get_linker_lib_prefix(self) -> str:
+        return ''
+
+    def get_option_link_args(self, options: 'OptionDictType') -> typing.List[str]:
+        return []
+
+    def has_multi_link_args(self, args: typing.List[str], env: 'Environment') -> typing.Tuple[bool, bool]:
+        return False, False
+
+    def get_link_debugfile_args(self, targetfile: str) -> typing.List[str]:
+        return []
+
+    def get_std_shared_lib_link_args(self) -> typing.List[str]:
+        return []
+
+    def get_std_shared_module_args(self, options: 'OptionDictType') -> typing.List[str]:
+        return self.get_std_shared_lib_link_args()
+
+    def get_link_whole_for(self, args: typing.List[str]) -> typing.List[str]:
+        raise mesonlib.EnvironmentException(
+            'Linker {} does not support link_whole'.format(self.id))
+
+    def get_allow_undefined_args(self) -> typing.List[str]:
+        raise mesonlib.EnvironmentException(
+            'Linker {} does not support allow undefined'.format(self.id))
+
+    def get_pie_link_args(self) -> typing.List[str]:
+        m = 'Linker {} does not support position-independent executable'
+        raise mesonlib.EnvironmentException(m.format(self.id))
+
+    def get_undefined_link_args(self) -> typing.List[str]:
+        return []
+
+    def get_coverage_link_args(self) -> typing.List[str]:
+        m = "Linker {} doesn't implement coverage data generation.".format(self.id)
+        raise mesonlib.EnvironmentException(m)
+
+    def no_undefined_link_args(self) -> typing.List[str]:
+        return []
+
+    def bitcode_args(self) -> typing.List[str]:
+        raise mesonlib.MesonException("This linker doesn't support bitcode bundles")
+
+    def get_soname_args(self, for_machine: 'mesonlib.MachineChoice',
+                        prefix: str, shlib_name: str, suffix: str, soversion: str,
+                        darwin_versions: typing.Tuple[str, str],
+                        is_shared_module: bool) -> typing.List[str]:
+        raise mesonlib.MesonException("This linker doesn't support soname args")
+
+    def build_rpath_args(self, env: 'Environment', build_dir: str, from_dir: str,
+                         rpath_paths: str, build_rpath: str,
+                         install_rpath: str) -> typing.List[str]:
+        return []

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -74,9 +74,9 @@ class PGICompiler():
 
     def get_pic_args(self) -> typing.List[str]:
         # PGI -fPIC is Linux only.
-        if self.compiler_type.is_osx_compiler or self.compiler_type.is_windows_compiler:
-            return []
-        return ['-fPIC']
+        if self.compiler_type.is_linux_compiler():
+            return ['-fPIC']
+        return []
 
     def openmp_flags(self) -> typing.List[str]:
         return ['-mp']

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -33,17 +33,7 @@ pgi_buildtype_args = {
 }  # type: typing.Dict[str, typing.List[str]]
 
 
-pgi_buildtype_linker_args = {
-    'plain': [],
-    'debug': [],
-    'debugoptimized': [],
-    'release': [],
-    'minsize': [],
-    'custom': [],
-}  # type: typing.Dict[str, typing.List[str]]
-
-
-class PGICompiler():
+class PGICompiler:
     def __init__(self, compiler_type: 'CompilerType'):
         self.base_options = ['b_pch']
         self.id = 'pgi'
@@ -64,14 +54,6 @@ class PGICompiler():
     def gen_import_library_args(self, implibname: str) -> typing.List[str]:
         return []
 
-    def get_std_shared_lib_link_args(self) -> typing.List[str]:
-        # PGI -shared is Linux only.
-        if self.compiler_type.is_windows_compiler:
-            return ['-Bdynamic', '-Mmakedll']
-        elif not self.compiler_type.is_osx_compiler:
-            return ['-shared']
-        return []
-
     def get_pic_args(self) -> typing.List[str]:
         # PGI -fPIC is Linux only.
         if self.compiler_type.is_linux_compiler():
@@ -84,9 +66,6 @@ class PGICompiler():
     def get_buildtype_args(self, buildtype: str) -> typing.List[str]:
         return pgi_buildtype_args[buildtype]
 
-    def get_buildtype_linker_args(self, buildtype: str) -> typing.List[str]:
-        return pgi_buildtype_linker_args[buildtype]
-
     def get_optimization_args(self, optimization_level: str) -> typing.List[str]:
         return clike_optimization_args[optimization_level]
 
@@ -98,9 +77,6 @@ class PGICompiler():
             if i[:2] == '-I' or i[:2] == '-L':
                 parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
         return parameter_list
-
-    def get_allow_undefined_link_args(self) -> typing.List[str]:
-        return []
 
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> typing.List[str]:
         return []

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -23,9 +23,9 @@ from .mixins.gnu import GnuCompiler
 from .mixins.clang import ClangCompiler
 
 class ObjCCompiler(CLikeCompiler, Compiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross: bool, exe_wrap: typing.Optional[str]):
+    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross: bool, exe_wrap: typing.Optional[str], **kwargs):
         self.language = 'objc'
-        Compiler.__init__(self, exelist, version, for_machine)
+        Compiler.__init__(self, exelist, version, for_machine, **kwargs)
         CLikeCompiler.__init__(self, is_cross, exe_wrap)
 
     def get_display_language(self):
@@ -57,8 +57,8 @@ class ObjCCompiler(CLikeCompiler, Compiler):
 
 
 class GnuObjCCompiler(GnuCompiler, ObjCCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, defines=None):
-        ObjCCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper)
+    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, defines=None, **kwargs):
+        ObjCCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
         GnuCompiler.__init__(self, compiler_type, defines)
         default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'0': [],
@@ -68,8 +68,8 @@ class GnuObjCCompiler(GnuCompiler, ObjCCompiler):
 
 
 class ClangObjCCompiler(ClangCompiler, ObjCCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None):
-        ObjCCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper)
+    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
+        ObjCCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
         ClangCompiler.__init__(self, compiler_type)
         default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'0': [],

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -23,9 +23,9 @@ from .mixins.gnu import GnuCompiler
 from .mixins.clang import ClangCompiler
 
 class ObjCPPCompiler(CLikeCompiler, Compiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross: bool, exe_wrap: typing.Optional[str]):
+    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross: bool, exe_wrap: typing.Optional[str], **kwargs):
         self.language = 'objcpp'
-        Compiler.__init__(self, exelist, version, for_machine)
+        Compiler.__init__(self, exelist, version, for_machine, **kwargs)
         CLikeCompiler.__init__(self, is_cross, exe_wrap)
 
     def get_display_language(self):
@@ -58,8 +58,8 @@ class ObjCPPCompiler(CLikeCompiler, Compiler):
 
 
 class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, defines=None):
-        ObjCPPCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper)
+    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, defines=None, **kwargs):
+        ObjCPPCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
         GnuCompiler.__init__(self, compiler_type, defines)
         default_warn_args = ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor']
         self.warn_args = {'0': [],
@@ -69,8 +69,8 @@ class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):
 
 
 class ClangObjCPPCompiler(ClangCompiler, ObjCPPCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None):
-        ObjCPPCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper)
+    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
+        ObjCPPCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
         ClangCompiler.__init__(self, compiler_type)
         default_warn_args = ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor']
         self.warn_args = {'0': [],

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -27,9 +27,9 @@ rust_optimization_args = {'0': [],
                           }
 
 class RustCompiler(Compiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrapper=None):
+    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
         self.language = 'rust'
-        super().__init__(exelist, version, for_machine)
+        super().__init__(exelist, version, for_machine, **kwargs)
         self.exe_wrapper = exe_wrapper
         self.id = 'rustc'
         self.is_cross = is_cross

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 import subprocess, os.path
+import typing
 
 from ..mesonlib import EnvironmentException, MachineChoice, Popen_safe
-
 from .compilers import Compiler, rust_buildtype_args, clike_debug_args
+
+if typing.TYPE_CHECKING:
+    from ..environment import Environment  # noqa: F401
 
 rust_optimization_args = {'0': [],
                           'g': ['-C', '--opt-level=0'],
@@ -77,9 +80,6 @@ class RustCompiler(Compiler):
     def get_buildtype_args(self, buildtype):
         return rust_buildtype_args[buildtype]
 
-    def build_rpath_args(self, build_dir, from_dir, rpath_paths, build_rpath, install_rpath):
-        return self.build_unix_rpath_args(build_dir, from_dir, rpath_paths, build_rpath, install_rpath)
-
     def get_sysroot(self):
         cmd = self.exelist + ['--print', 'sysroot']
         p, stdo, stde = Popen_safe(cmd)
@@ -101,9 +101,6 @@ class RustCompiler(Compiler):
                         break
 
         return parameter_list
-
-    def get_buildtype_linker_args(self, build_type):
-        return []
 
     def get_std_exe_link_args(self):
         return []

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -27,9 +27,9 @@ swift_optimization_args = {'0': [],
                            }
 
 class SwiftCompiler(Compiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross):
+    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, **kwargs):
         self.language = 'swift'
-        super().__init__(exelist, version, for_machine)
+        super().__init__(exelist, version, for_machine, **kwargs)
         self.version = version
         self.id = 'llvm'
         self.is_cross = is_cross

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -34,9 +34,6 @@ class SwiftCompiler(Compiler):
         self.id = 'llvm'
         self.is_cross = is_cross
 
-    def get_linker_exelist(self):
-        return self.exelist[:]
-
     def name_string(self):
         return ' '.join(self.exelist)
 
@@ -58,9 +55,6 @@ class SwiftCompiler(Compiler):
     def get_output_args(self, target):
         return ['-o', target]
 
-    def get_linker_output_args(self, target):
-        return ['-o', target]
-
     def get_header_import_args(self, headername):
         return ['-import-objc-header', headername]
 
@@ -70,9 +64,6 @@ class SwiftCompiler(Compiler):
     def get_buildtype_args(self, buildtype):
         return swift_buildtype_args[buildtype]
 
-    def get_buildtype_linker_args(self, buildtype):
-        return []
-
     def get_std_exe_link_args(self):
         return ['-emit-executable']
 
@@ -81,9 +72,6 @@ class SwiftCompiler(Compiler):
 
     def get_mod_gen_args(self):
         return ['-emit-module']
-
-    def build_rpath_args(self, *args):
-        return [] # FIXME
 
     def get_include_args(self, dirname):
         return ['-I' + dirname]

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -956,14 +956,15 @@ class Environment:
                 version = self.get_gnu_version_from_defines(defines)
                 comp = GnuObjCCompiler if objc else GnuObjCPPCompiler
                 return comp(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, defines)
-            else:
+            if 'clang' in out:
                 comp = ClangObjCCompiler if objc else ClangObjCPPCompiler
-                if out.startswith('Apple LLVM') or out.startswith('Apple clang'):
-                    return comp(ccache + compiler, version, CompilerType.CLANG_OSX, for_machine, is_cross, exe_wrap)
-                if 'windows' in out:
-                    return comp(ccache + compiler, version, CompilerType.CLANG_MINGW, for_machine, is_cross, exe_wrap)
-                if out.startswith(('clang', 'OpenBSD clang')):
-                    return comp(ccache + compiler, version, CompilerType.CLANG_STANDARD, for_machine, is_cross, exe_wrap)
+                if 'Apple' in out or self.machines[for_machine].is_darwin():
+                    compiler_type = CompilerType.CLANG_OSX
+                elif 'windows' in out or self.machines[for_machine].is_windows():
+                    compiler_type = CompilerType.CLANG_MINGW
+                else:
+                    compiler_type = CompilerType.CLANG_STANDARD
+                return comp(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap)
         self._handle_exceptions(popen_exceptions, compilers)
 
     def detect_java_compiler(self, for_machine):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os, platform, re, sys, shlex, shutil, subprocess, typing
+import tempfile
 
 from . import coredata
 from .linkers import ArLinker, ArmarLinker, VisualStudioLinker, DLinker, CcrxLinker, IntelVisualStudioLinker
@@ -37,6 +38,23 @@ from .compilers import (
     is_llvm_ir,
     is_object,
     is_source,
+)
+from .linkers import (
+    AppleDynamicLinker,
+    ArmClangDynamicLinker,
+    ArmDynamicLinker,
+    CcrxDynamicLinker,
+    ClangClDynamicLinker,
+    DynamicLinker,
+    GnuDynamicLinker,
+    LLVMDynamicLinker,
+    MSVCDynamicLinker,
+    OptlinkDynamicLinker,
+    PGIDynamicLinker,
+    SolarisDynamicLinker,
+    XildAppleDynamicLinker,
+    XildLinuxDynamicLinker,
+    XilinkDynamicLinker,
 )
 from functools import lru_cache
 from .compilers import (
@@ -63,8 +81,8 @@ from .compilers import (
     EmscriptenCCompiler,
     EmscriptenCPPCompiler,
     IntelCCompiler,
-    IntelCPPCompiler,
     IntelClCCompiler,
+    IntelCPPCompiler,
     IntelClCPPCompiler,
     IntelFortranCompiler,
     IntelClFortranCompiler,
@@ -639,7 +657,57 @@ class Environment:
                 errmsg += '\nRunning "{0}" gave "{1}"'.format(c, e)
         raise EnvironmentException(errmsg)
 
-    def _detect_c_or_cpp_compiler(self, lang, for_machine):
+    @staticmethod
+    def _guess_nix_linker(compiler: typing.List[str], for_machine: MachineChoice, *,
+                          prefix: typing.Union[str, typing.List[str]] = '-Wl,',
+                          extra_args: typing.Optional[typing.List[str]] = None) -> 'DynamicLinker':
+        """Helper for guessing what linker to use on Unix-Like OSes.
+
+        :prefix: The prefix that the compiler uses to proxy arguments to the
+            linker, if required. This can be passed as a string or a list of
+            strings. If it is passed as a string then the arguments to be
+            proxied to the linker will be concatenated, if it is a list they
+            will be appended. This means that if a space is required (such as
+            with swift which wants `-Xlinker --version` and *not*
+            `-Xlinker=--version`) you must pass as a list.
+        :extra_args: Any addtional arguments rquired (such as a source file)
+        """
+        extra_args = typing.cast(typing.List[str], extra_args or [])
+        if isinstance(prefix, str):
+            check_args = [prefix + '--version'] + extra_args
+        else:
+            check_args = prefix + ['--version'] + extra_args
+        _, o, e = Popen_safe(compiler + check_args)
+        v = search_version(o)
+        if o.startswith('LLD'):
+            linker = LLVMDynamicLinker(compiler, for_machine, 'lld', version=v)  # type: DynamicLinker
+        # first is for apple clang, second is for real gcc
+        elif e.endswith('(use -v to see invocation)\n') or 'macosx_version' in e:
+            if isinstance(prefix, str):
+                _, _, e = Popen_safe(compiler + [prefix + '-v'] + extra_args)
+            else:
+                _, _, e = Popen_safe(compiler + prefix + ['-v'] + extra_args)
+            i = 'APPLE ld'
+            for line in e.split('\n'):
+                if 'PROJECT:ld' in line:
+                    v = line.split('-')[1]
+                    break
+            else:
+                v = 'unknown version'
+            linker = AppleDynamicLinker(compiler, for_machine, i, version=v)
+        elif 'GNU' in o:
+            if 'gold' in 'o':
+                i = 'GNU ld.gold'
+            else:
+                i = 'GNU ld.bfd'
+            linker = GnuDynamicLinker(compiler, for_machine, i, version=v)
+        elif 'Solaris' in e:
+            linker = SolarisDynamicLinker(compiler, for_machine, 'solaris', version=search_version(e))
+        else:
+            raise MesonException('Unable to determine dynamic linker.')
+        return linker
+
+    def _detect_c_or_cpp_compiler(self, lang: str, for_machine: MachineChoice) -> Compiler:
         popen_exceptions = {}
         compilers, ccache, exe_wrap = self._get_compilers(lang, for_machine)
         is_cross = not self.machines.matches_build_machine(for_machine)
@@ -701,13 +769,18 @@ class Environment:
                     popen_exceptions[' '.join(compiler)] = 'no pre-processor defines'
                     continue
                 compiler_type = self.get_gnu_compiler_type(defines)
+
+                linker = self._guess_nix_linker(compiler, for_machine)
+
                 if guess_gcc_or_lcc == 'lcc':
                     version = self.get_lcc_version_from_defines(defines)
                     cls = ElbrusCCompiler if lang == 'c' else ElbrusCPPCompiler
                 else:
                     version = self.get_gnu_version_from_defines(defines)
                     cls = GnuCCompiler if lang == 'c' else GnuCPPCompiler
-                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, defines, full_version=full_version)
+                return cls(ccache + compiler, version, compiler_type,
+                           for_machine, is_cross, exe_wrap, defines,
+                           full_version=full_version, linker=linker)
 
             if 'Emscripten' in out:
                 cls = EmscriptenCCompiler if lang == 'c' else EmscriptenCPPCompiler
@@ -730,7 +803,8 @@ class Environment:
                 full_version = arm_ver_str
                 compiler_type = CompilerType.ARM_WIN
                 cls = ArmclangCCompiler if lang == 'c' else ArmclangCPPCompiler
-                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version)
+                linker = ArmClangDynamicLinker(for_machine, version=version)
+                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
             if 'CL.EXE COMPATIBILITY' in out:
                 # if this is clang-cl masquerading as cl, detect it as cl, not
                 # clang
@@ -746,7 +820,8 @@ class Environment:
                 else:
                     target = 'unknown target'
                 cls = ClangClCCompiler if lang == 'c' else ClangClCPPCompiler
-                return cls(compiler, version, for_machine, is_cross, exe_wrap, target)
+                linker = ClangClDynamicLinker(for_machine, version=version)
+                return cls(compiler, version, for_machine, is_cross, exe_wrap, target, linker=linker)
             if 'clang' in out:
                 if 'Apple' in out or self.machines[for_machine].is_darwin():
                     compiler_type = CompilerType.CLANG_OSX
@@ -755,12 +830,15 @@ class Environment:
                 else:
                     compiler_type = CompilerType.CLANG_STANDARD
                 cls = ClangCCompiler if lang == 'c' else ClangCPPCompiler
-                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version)
+
+                linker = self._guess_nix_linker(compiler, for_machine)
+                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
             if 'Intel(R) C++ Intel(R)' in err:
                 version = search_version(err)
                 target = 'x86' if 'IA-32' in err else 'x86_64'
                 cls = IntelClCCompiler if lang == 'c' else IntelClCPPCompiler
-                return cls(compiler, version, for_machine, is_cross, exe_wrap, target)
+                linker = XilinkDynamicLinker(for_machine, version=version)
+                return cls(compiler, version, for_machine, is_cross, exe_wrap, target, linker=linker)
             if 'Microsoft' in out or 'Microsoft' in err:
                 # Latest versions of Visual Studio print version
                 # number to stderr but earlier ones print version
@@ -778,8 +856,9 @@ class Environment:
                     target = match.group(1)
                 else:
                     target = 'x86'
+                linker = MSVCDynamicLinker(for_machine, version=version)
                 cls = VisualStudioCCompiler if lang == 'c' else VisualStudioCPPCompiler
-                return cls(compiler, version, for_machine, is_cross, exe_wrap, target)
+                return cls(compiler, version, for_machine, is_cross, exe_wrap, target, linker=linker)
             if 'PGI Compilers' in out:
                 if self.machines[for_machine].is_darwin():
                     compiler_type = CompilerType.PGI_OSX
@@ -788,25 +867,27 @@ class Environment:
                 else:
                     compiler_type = CompilerType.PGI_STANDARD
                 cls = PGICCompiler if lang == 'c' else PGICPPCompiler
-                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap)
+                linker = PGIDynamicLinker(compiler, for_machine, 'pgi', version=version)
+                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, linker=linker)
             if '(ICC)' in out:
                 if self.machines[for_machine].is_darwin():
                     compiler_type = CompilerType.ICC_OSX
-                elif self.machines[for_machine].is_windows():
-                    # TODO: fix ICC on Windows
-                    compiler_type = CompilerType.ICC_WIN
+                    l = XildAppleDynamicLinker(compiler, for_machine, 'xild', version=version)
                 else:
                     compiler_type = CompilerType.ICC_STANDARD
+                    l = XildLinuxDynamicLinker(compiler, for_machine, 'xild', version=version)
                 cls = IntelCCompiler if lang == 'c' else IntelCPPCompiler
-                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version)
+                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version, linker=l)
             if 'ARM' in out:
                 compiler_type = CompilerType.ARM_WIN
                 cls = ArmCCompiler if lang == 'c' else ArmCPPCompiler
-                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version)
+                linker = ArmDynamicLinker(for_machine, version=version)
+                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
             if 'RX Family' in out:
                 compiler_type = CompilerType.CCRX_WIN
                 cls = CcrxCCompiler if lang == 'c' else CcrxCPPCompiler
-                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version)
+                linker = CcrxDynamicLinker(for_machine, version=version)
+                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
 
         self._handle_exceptions(popen_exceptions, compilers)
 
@@ -846,8 +927,8 @@ class Environment:
             # Luckily, the "V" also makes it very simple to extract
             # the full version:
             version = out.strip().split('V')[-1]
-            cls = CudaCompiler
-            return cls(ccache + compiler, version, for_machine, exe_wrap)
+            linker = self._guess_nix_linker(compiler, for_machine, prefix='-Xlinker=')
+            return CudaCompiler(ccache + compiler, version, for_machine, exe_wrap, linker=linker)
         raise EnvironmentException('Could not find suitable CUDA compiler: "' + ' '.join(compilers) + '"')
 
     def detect_fortran_compiler(self, for_machine: MachineChoice):
@@ -885,22 +966,27 @@ class Environment:
                     else:
                         version = self.get_gnu_version_from_defines(defines)
                         cls = GnuFortranCompiler
-                    return cls(compiler, version, compiler_type, for_machine, is_cross, exe_wrap, defines, full_version=full_version)
+                    linker = self._guess_nix_linker(compiler, for_machine)
+                    return cls(compiler, version, compiler_type, for_machine, is_cross, exe_wrap, defines, full_version=full_version, linker=linker)
 
                 if 'G95' in out:
-                    return G95FortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version)
+                    linker = self._guess_nix_linker(compiler, for_machine)
+                    return G95FortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
 
                 if 'Sun Fortran' in err:
                     version = search_version(err)
-                    return SunFortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version)
+                    linker = self._guess_nix_linker(compiler, for_machine)
+                    return SunFortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
 
                 if 'Intel(R) Visual Fortran' in err:
                     version = search_version(err)
                     target = 'x86' if 'IA-32' in err else 'x86_64'
-                    return IntelClFortranCompiler(compiler, version, for_machine, is_cross, target, exe_wrap)
+                    linker = XilinkDynamicLinker(for_machine, version=version)
+                    return IntelClFortranCompiler(compiler, version, for_machine, is_cross, target, exe_wrap, linker=linker)
 
                 if 'ifort (IFORT)' in out:
-                    return IntelFortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version)
+                    linker = XildLinuxDynamicLinker(compiler, for_machine, 'xild', version=version)
+                    return IntelFortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
 
                 if 'PathScale EKOPath(tm)' in err:
                     return PathScaleFortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version)
@@ -912,16 +998,20 @@ class Environment:
                         compiler_type = CompilerType.PGI_WIN
                     else:
                         compiler_type = CompilerType.PGI_STANDARD
-                    return PGIFortranCompiler(compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version)
+                    linker = PGIDynamicLinker(compiler, for_machine, 'pgi', version=version)
+                    return PGIFortranCompiler(compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
 
                 if 'flang' in out or 'clang' in out:
-                    return FlangFortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version)
+                    linker = self._guess_nix_linker(compiler, for_machine)
+                    return FlangFortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
 
                 if 'Open64 Compiler Suite' in err:
-                    return Open64FortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version)
+                    linker = self._guess_nix_linker(compiler, for_machine)
+                    return Open64FortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
 
                 if 'NAG Fortran' in err:
-                    return NAGFortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version)
+                    linker = self._guess_nix_linker(compiler, for_machine)
+                    return NAGFortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
         self._handle_exceptions(popen_exceptions, compilers)
 
     def get_scratch_dir(self):
@@ -955,7 +1045,8 @@ class Environment:
                 compiler_type = self.get_gnu_compiler_type(defines)
                 version = self.get_gnu_version_from_defines(defines)
                 comp = GnuObjCCompiler if objc else GnuObjCPPCompiler
-                return comp(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, defines)
+                linker = self._guess_nix_linker(compiler, for_machine)
+                return comp(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, defines, linker=linker)
             if 'clang' in out:
                 comp = ClangObjCCompiler if objc else ClangObjCPPCompiler
                 if 'Apple' in out or self.machines[for_machine].is_darwin():
@@ -964,7 +1055,8 @@ class Environment:
                     compiler_type = CompilerType.CLANG_MINGW
                 else:
                     compiler_type = CompilerType.CLANG_STANDARD
-                return comp(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap)
+                linker = self._guess_nix_linker(compiler, for_machine)
+                return comp(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, linker=linker)
         self._handle_exceptions(popen_exceptions, compilers)
 
     def detect_java_compiler(self, for_machine):
@@ -1039,7 +1131,18 @@ class Environment:
             version = search_version(out)
 
             if 'rustc' in out:
-                return RustCompiler(compiler, version, for_machine, is_cross, exe_wrap)
+                # Chalk up another quirk for rust. There is no way (AFAICT) to
+                # figure out what linker rustc is using for a non-nightly compiler
+                # (On nightly you can pass -Z print-link-args). So we're going to
+                # hard code the linker based on the platform.
+                # Currenty gnu ld is used for everything except apple by
+                # default, and apple ld is used on mac.
+                # TODO: find some better way to figure this out.
+                if self.machines[for_machine].is_darwin():
+                    linker = AppleDynamicLinker([], for_machine, 'Apple ld')
+                else:
+                    linker = GnuDynamicLinker([], for_machine, 'GNU ld')
+                return RustCompiler(compiler, version, for_machine, is_cross, exe_wrap, linker=linker)
 
         self._handle_exceptions(popen_exceptions, compilers)
 
@@ -1080,11 +1183,31 @@ class Environment:
             arch = 'x86_mscoff'
 
         if 'LLVM D compiler' in out:
-            return compilers.LLVMDCompiler(exelist, version, for_machine, arch, full_version=full_version)
+            # LDC seems to require a file
+            m = self.machines[for_machine]
+            if m.is_windows() or m.is_cygwin():
+                # Getting LDC on windows to give useful linker output when not
+                # doing real work is painfully hard. It ships with a verison of
+                # lld-link, so just assume that we're going to use lld-link
+                # with it.
+                _, o, _ = Popen_safe(['lld-link.exe', '--version'])
+                linker = ClangClDynamicLinker(for_machine, version=search_version(o))
+            else:
+                with tempfile.NamedTemporaryFile(suffix='.d') as f:
+                    linker = self._guess_nix_linker(exelist, for_machine, prefix='-L', extra_args=[f.name])
+            return compilers.LLVMDCompiler(exelist, version, for_machine, arch, full_version=full_version, linker=linker)
         elif 'gdc' in out:
-            return compilers.GnuDCompiler(exelist, version, for_machine, arch, full_version=full_version)
+            linker = self._guess_nix_linker(exelist, for_machine)
+            return compilers.GnuDCompiler(exelist, version, for_machine, arch, full_version=full_version, linker=linker)
         elif 'The D Language Foundation' in out or 'Digital Mars' in out:
-            return compilers.DmdDCompiler(exelist, version, for_machine, arch, full_version=full_version)
+            # DMD seems to require a file
+            m = self.machines[for_machine]
+            if m.is_windows() or m.is_cygwin():
+                linker = OptlinkDynamicLinker(for_machine, version=full_version)
+            else:
+                with tempfile.NamedTemporaryFile(suffix='.d') as f:
+                    linker = self._guess_nix_linker(exelist, for_machine, prefix='-L', extra_args=[f.name])
+            return compilers.DmdDCompiler(exelist, version, for_machine, arch, full_version=full_version, linker=linker)
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
 
     def detect_swift_compiler(self, for_machine):
@@ -1100,7 +1223,12 @@ class Environment:
             raise EnvironmentException('Could not execute Swift compiler "%s"' % ' '.join(exelist))
         version = search_version(err)
         if 'Swift' in err:
-            return compilers.SwiftCompiler(exelist, version, for_machine, is_cross)
+            # As for 5.0.1 swiftc *requires* a file to check the linker:
+            with tempfile.NamedTemporaryFile(suffix='.swift') as f:
+                linker = self._guess_nix_linker(
+                    exelist, for_machine, prefix=['-Xlinker'], extra_args=[f.name])
+            return compilers.SwiftCompiler(exelist, version, for_machine, is_cross, linker=linker)
+
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
 
     def compiler_from_language(self, lang: str, for_machine: MachineChoice):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2823,12 +2823,16 @@ external dependencies (including libraries) must go to "dependencies".''')
                         continue
                     else:
                         raise
+
             if for_machine == MachineChoice.HOST or self.environment.is_cross_build():
                 logger_fun = mlog.log
             else:
                 logger_fun = mlog.debug
             logger_fun(comp.get_display_language(), 'compiler for the', machine_name, 'machine:',
                        mlog.bold(' '.join(comp.get_exelist())), comp.get_version_string())
+            if comp.linker is not None:
+                logger_fun(comp.get_display_language(), 'linker for the', machine_name, 'machine:',
+                           mlog.bold(comp.linker.id), comp.linker.version)
             self.build.ensure_static_linker(comp)
 
         langs = self.coredata.compilers[for_machine].keys()

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -54,8 +54,9 @@ class StaticLinker:
     def get_coverage_link_args(self) -> typing.List[str]:
         return []
 
-    def build_rpath_args(self, build_dir: str, from_dir: str, rpath_paths: str,
-                         build_rpath: str, install_rpath: str) -> typing.List[str]:
+    def build_rpath_args(self, env: 'Environment', build_dir: str, from_dir: str,
+                         rpath_paths: str, build_rpath: str,
+                         install_rpath: str) -> typing.List[str]:
         return []
 
     def thread_link_flags(self, env: 'Environment') -> typing.List[str]:

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -544,3 +544,13 @@ class GnuDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, Dynam
     """Representation of GNU ld.bfd and ld.gold."""
 
     pass
+
+
+class LLVMDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, DynamicLinker):
+
+    """Representation of LLVM's lld (not lld-link) linker.
+
+    This is only the posix-like linker.
+    """
+
+    pass

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -620,3 +620,23 @@ class LLVMDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, Dyna
     """
 
     pass
+
+
+class XildLinuxDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, DynamicLinker):
+
+    """Representation of Intel's Xild linker.
+
+    This is only the linux-like linker which dispatches to Gnu ld.
+    """
+
+    pass
+
+
+class XildAppleDynamicLinker(AppleDynamicLinker):
+
+    """Representation of Intel's Xild linker.
+
+    This is the apple linker, which dispatches to Apple's ld.
+    """
+
+    pass

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -349,3 +349,22 @@ class DynamicLinker(metaclass=abc.ABCMeta):
                          rpath_paths: str, build_rpath: str,
                          install_rpath: str) -> typing.List[str]:
         return []
+
+
+class PosixDynamicLinkerMixin:
+
+    """Mixin class for POSIX-ish linkers.
+
+    This is obviously a pretty small subset of the linker interface, but
+    enough dynamic linkers that meson supports are POSIX-like but not
+    GNU-like that it makes sense to split this out.
+    """
+
+    def get_output_args(self, outname: str) -> typing.List[str]:
+        return ['-o', outname]
+
+    def get_std_shared_lib_args(self) -> typing.List[str]:
+        return ['-shared']
+
+    def get_search_args(self, dirname: str) -> typing.List[str]:
+        return ['-L', dirname]

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -692,3 +692,18 @@ class ArmDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
     def get_allow_undefined_args(self) -> typing.List[str]:
         return []
+
+
+class ArmClangDynamicLinker(ArmDynamicLinker):
+
+    """Linker used with ARM's clang fork.
+
+    The interface is similar enough to the old ARM ld that it inherits and
+    extends a few things as needed.
+    """
+
+    def export_dynamic_args(self, env: 'Environment') -> typing.List[str]:
+        return ['--export_dynamic']
+
+    def import_library_args(self, implibname: str) -> typing.List[str]:
+        return ['--symdefs=' + implibname]

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -673,3 +673,22 @@ class CcrxDynamicLinker(DynamicLinker):
                         suffix: str, soversion: str, darwin_versions: typing.Tuple[str, str],
                         is_shared_module: bool) -> typing.List[str]:
         return []
+
+
+class ArmDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
+
+    """Linker for the ARM compiler."""
+
+    def __init__(self, for_machine: mesonlib.MachineChoice,
+                 *, version: str = 'unknown version'):
+        super().__init__(['armlink'], for_machine, 'armlink',
+                         version=version)
+
+    def get_accepts_rsp(self) -> bool:
+        return False
+
+    def get_std_shared_lib_args(self) -> typing.NoReturn:
+        raise mesonlib.MesonException('The Arm Linkers do not support shared libraries')
+
+    def get_allow_undefined_args(self) -> typing.List[str]:
+        return []

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -868,3 +868,17 @@ class SolarisDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
                         is_shared_module: bool) -> typing.List[str]:
         sostr = '' if soversion is None else '.' + soversion
         return ['-Wl,-soname,{}{}.{}{}'.format(prefix, shlib_name, suffix, sostr)]
+
+
+class OptlinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
+
+    """Digital Mars dynamic linker for windows."""
+
+    def __init__(self, for_machine: mesonlib.MachineChoice,
+                 *, version: str = 'unknown version'):
+        # Use optlink instead of link so we don't interfer with other link.exe
+        # implementations.
+        super().__init__(['optlink.exe'], for_machine, 'optlink', version=version)
+
+    def get_allow_undefined_args(self) -> typing.List[str]:
+        return []

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -640,3 +640,36 @@ class XildAppleDynamicLinker(AppleDynamicLinker):
     """
 
     pass
+
+
+class CcrxDynamicLinker(DynamicLinker):
+
+    """Linker for Renesis CCrx compiler."""
+
+    def __init__(self, for_machine: mesonlib.MachineChoice,
+                 *, version: str = 'unknown version'):
+        super().__init__(['rlink.exe'], for_machine, 'rlink',
+                         version=version)
+
+    def get_accepts_rsp(self) -> bool:
+        return False
+
+    def get_lib_prefix(self) -> str:
+        return '-lib='
+
+    def get_std_shared_lib_args(self) -> typing.List[str]:
+        return []
+
+    def get_output_args(self, outputname: str) -> typing.List[str]:
+        return ['-output=%s' % outputname]
+
+    def get_search_args(self, dirname: str) -> typing.NoReturn:
+        raise EnvironmentError('rlink.exe does not have a search dir argument')
+
+    def get_allow_undefined_args(self) -> typing.List[str]:
+        return []
+
+    def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
+                        suffix: str, soversion: str, darwin_versions: typing.Tuple[str, str],
+                        is_shared_module: bool) -> typing.List[str]:
+        return []

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -813,3 +813,12 @@ class ClangClDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
                  *, version: str = 'unknown version'):
         super().__init__(['lld-link.exe'], for_machine, 'lld-link',
                          version=version)
+
+
+class XilinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
+
+    """Intel's Xilink.exe."""
+
+    def __init__(self, for_machine: mesonlib.MachineChoice,
+                 *, version: str = 'unknown version'):
+        super().__init__(['xilink.exe'], for_machine, 'xilink', version=version)

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -707,3 +707,31 @@ class ArmClangDynamicLinker(ArmDynamicLinker):
 
     def import_library_args(self, implibname: str) -> typing.List[str]:
         return ['--symdefs=' + implibname]
+
+
+class PGIDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
+
+    """PGI linker."""
+
+    def get_allow_undefined_args(self) -> typing.List[str]:
+        return []
+
+    def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
+                        suffix: str, soversion: str, darwin_versions: typing.Tuple[str, str],
+                        is_shared_module: bool) -> typing.List[str]:
+        return []
+
+    def get_std_shared_lib_args(self) -> typing.List[str]:
+        # PGI -shared is Linux only.
+        if mesonlib.is_windows():
+            return ['-Bdynamic', '-Mmakedll']
+        elif mesonlib.is_linux:
+            return ['-shared']
+        return []
+
+    def build_rpath_args(self, env: 'Environment', build_dir: str, from_dir: str,
+                         rpath_paths: str, build_rpath: str,
+                         install_rpath: str) -> typing.List[str]:
+        if env.machines[self.for_machine].is_windows():
+            return ['-R' + os.path.join(build_dir, p) for p in rpath_paths]
+        return []

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -636,6 +636,7 @@ def detect_tests_to_run(only: typing.List[str]) -> typing.List[typing.Tuple[str,
         ('fpga', 'fpga', shutil.which('yosys') is None),
         ('frameworks', 'frameworks', False),
         ('nasm', 'nasm', False),
+        ('wasm', 'wasm', shutil.which('emcc') is None or backend is not Backend.ninja),
     ]
 
     if only:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -444,7 +444,8 @@ class InternalTests(unittest.TestCase):
     def test_compiler_args_class_gnuld(self):
         cargsfunc = mesonbuild.compilers.CompilerArgs
         ## Test --start/end-group
-        gcc = mesonbuild.compilers.GnuCCompiler([], 'fake', mesonbuild.compilers.CompilerType.GCC_STANDARD, False, MachineChoice.HOST)
+        linker = mesonbuild.linkers.GnuDynamicLinker([], MachineChoice.HOST, 'fake')
+        gcc = mesonbuild.compilers.GnuCCompiler([], 'fake', mesonbuild.compilers.CompilerType.GCC_STANDARD, False, MachineChoice.HOST, linker=linker)
         ## Test that 'direct' append and extend works
         l = cargsfunc(gcc, ['-Lfoodir', '-lfoo'])
         self.assertEqual(l.to_native(copy=True), ['-Lfoodir', '-Wl,--start-group', '-lfoo', '-Wl,--end-group'])

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5950,9 +5950,10 @@ class NativeFileTests(BasePlatformTests):
                     f.write("{}='{}'\n".format(k, v))
         return filename
 
-    def helper_create_binary_wrapper(self, binary, dir_=None, **kwargs):
+    def helper_create_binary_wrapper(self, binary, dir_=None, extra_args=None, **kwargs):
         """Creates a wrapper around a binary that overrides specific values."""
         filename = os.path.join(dir_ or self.builddir, 'binary_wrapper{}.py'.format(self.current_wrapper))
+        extra_args = extra_args or {}
         self.current_wrapper += 1
         if is_haiku():
             chbang = '#!/bin/env python3'
@@ -5969,10 +5970,10 @@ class NativeFileTests(BasePlatformTests):
                 def main():
                     parser = argparse.ArgumentParser()
                 '''.format(chbang)))
-            for name in kwargs:
+            for name in chain(extra_args, kwargs):
                 f.write('    parser.add_argument("-{0}", "--{0}", action="store_true")\n'.format(name))
             f.write('    args, extra_args = parser.parse_known_args()\n')
-            for name, value in kwargs.items():
+            for name, value in chain(extra_args.items(), kwargs.items()):
                 f.write('    if args.{}:\n'.format(name))
                 f.write('        print("{}", file=sys.{})\n'.format(value, kwargs.get('outfile', 'stdout')))
                 f.write('        sys.exit(0)\n')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5032,7 +5032,7 @@ class LinuxlikeTests(BasePlatformTests):
             raise unittest.SkipTest('-fsanitize=address is not supported on OpenBSD')
 
         testdir = os.path.join(self.common_test_dir, '13 pch')
-        self.init(testdir, extra_args=['-Db_sanitize=address'])
+        self.init(testdir, extra_args=['-Db_sanitize=address', '-Db_lundef=false'])
         self.build()
         compdb = self.get_compdb()
         for i in compdb:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6224,7 +6224,8 @@ class NativeFileTests(BasePlatformTests):
     @skip_if_not_language('swift')
     def test_swift_compiler(self):
         wrapper = self.helper_create_binary_wrapper(
-            'swiftc', version='Swift 1.2345', outfile='stderr')
+            'swiftc', version='Swift 1.2345', outfile='stderr',
+            extra_args={'Xlinker': 'macosx_version. PROJECT:ld - 1.2.3'})
         env = get_fake_env()
         env.binaries.host.binaries['swift'] = wrapper
         compiler = env.detect_swift_compiler(MachineChoice.HOST)

--- a/test cases/common/152 shared module resolving symbol in executable/meson.build
+++ b/test cases/common/152 shared module resolving symbol in executable/meson.build
@@ -9,6 +9,11 @@ project('shared module resolving symbol in executable', 'c')
 # See testcase 125 for an example of the more complex portability gymnastics
 # required if we do not know (at link-time) what provides the symbol.
 
+cc = meson.get_compiler('c')
+if cc.get_id() == 'pgi'
+  error('MESON_SKIP_TEST PGI has its own unique set of macros that would need to be handled')
+endif
+
 dl = meson.get_compiler('c').find_library('dl', required: false)
 e = executable('prog', 'prog.c', dependencies: dl, export_dynamic: true)
 m = shared_module('module', 'module.c', link_with: e)

--- a/test cases/common/185 has link arg/meson.build
+++ b/test cases/common/185 has link arg/meson.build
@@ -8,8 +8,8 @@ if cc.get_argument_syntax() == 'msvc'
   useless = '/DEBUG'
   isnt_arg = '/iambroken'
 else
-  is_arg = '-Wl,-Lfoo'
-  useless = '-Wl,-Lbar'
+  is_arg = '-Wl,-L/tmp'
+  useless = '-Wl,-L/usr'
   isnt_arg = '-Wl,-iambroken'
 endif
 

--- a/test cases/common/185 has link arg/meson.build
+++ b/test cases/common/185 has link arg/meson.build
@@ -14,9 +14,10 @@ else
 endif
 
 assert(cc.has_link_argument(is_arg), 'Arg that should have worked does not work.')
-assert(not cc.has_link_argument(isnt_arg), 'Arg that should be broken is not.')
-
 assert(cpp.has_link_argument(is_arg), 'Arg that should have worked does not work.')
+
+if cc.get_id() != 'pgi'
+assert(not cc.has_link_argument(isnt_arg), 'Arg that should be broken is not.')
 assert(not cpp.has_link_argument(isnt_arg), 'Arg that should be broken is not.')
 
 assert(cc.get_supported_link_arguments([is_arg, isnt_arg, useless]) == [is_arg, useless], 'Arg filtering returned different result.')
@@ -38,7 +39,9 @@ assert(l1.get(0) == is_arg, 'First supported returned wrong argument.')
 assert(l2.length() == 0, 'First supported did not return empty array.')
 
 assert(not cc.has_multi_link_arguments([isnt_arg, is_arg]), 'Arg that should be broken is not.')
-assert(cc.has_multi_link_arguments(is_arg), 'Arg that should have worked does not work.')
-assert(cc.has_multi_link_arguments([useless, is_arg]), 'Arg that should have worked does not work.')
 
 assert(not cc.has_link_argument('-Wl,-z,nodelete42'), 'Did not detect wrong -z linker argument')
+endif
+
+assert(cc.has_multi_link_arguments(is_arg), 'Arg that should have worked does not work.')
+assert(cc.has_multi_link_arguments([useless, is_arg]), 'Arg that should have worked does not work.')

--- a/test cases/common/203 function attributes/meson.build
+++ b/test cases/common/203 function attributes/meson.build
@@ -19,6 +19,10 @@ project('gcc func attributes', ['c', 'cpp'])
 c = meson.get_compiler('c')
 cpp = meson.get_compiler('cpp')
 
+if c.get_id() == 'pgi'
+  error('MESON_SKIP_TEST: PGI supports its own set of features, will need a seperate list for PGI to test it.')
+endif
+
 expected_result = not ['msvc', 'clang-cl', 'intel-cl'].contains(c.get_id())
 
 # Q: Why is ifunc not in this list or any of the below lists?


### PR DESCRIPTION
This series is a start toward breaking the representations of the Compiler and Linker objects. It does this by creating a new `DynamicLinker` class and internally the compiler dispatches to it.

I have tested with all of the compilers I can, I need help from people with weird or proprietary compilers.

I have no way to test with a number of the proprietary compilers like PGI, ccrx, or cuda. I'll start pinging those people as we get closer to being able to merge this.

Fixes #4837 
Fixes #4784
Fixes #5595