### PR TITLE
Add test priorities to force test start order

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1512,6 +1512,12 @@ Keyword arguments are the following:
   Protocol](https://www.testanything.org/)). For more on the Meson test
   harness protocol read [Unit Tests](Unit-tests.md). Since 0.50.0
 
+- `priority` specifies the priority of a test. Tests with a
+  higher priority are *started* before tests with a lower priority.
+  The starting order of tests with identical priorities is
+  implementation-defined. The default priority is 0, negative numbers are
+  permitted. Since 0.52.0
+
 Defined tests can be run in a backend-agnostic way by calling
 `meson test` inside the build dir, or by using backend-specific
 commands, such as `ninja test` or `msbuild RUN_TESTS.vcxproj`.

--- a/docs/markdown/Unit-tests.md
+++ b/docs/markdown/Unit-tests.md
@@ -51,6 +51,19 @@ By default Meson uses as many concurrent processes as there are cores on the tes
 $ MESON_TESTTHREADS=5 ninja test
 ```
 
+Priorities
+--
+
+Tests can be assigned a priority that determines when a test is *started*. Tests with higher priority are started first, tests with lower priority started later. The default priority is 0, meson makes no guarantee on the ordering of tests with identical priority.
+
+```meson
+test('started second', t, priority : 0)
+test('started third', t, priority : -50)
+test('started first', t, priority : 1000)
+```
+
+Note that the test priority only affects the starting order of tests and subsequent tests are affected by how long it takes previous tests to complete. It is thus possible that a higher-priority test is still running when lower-priority tests with a shorter runtime have completed.
+
 ## Skipped tests and hard errors
 
 Sometimes a test can only determine at runtime that it can not be run.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -727,7 +727,7 @@ class Backend:
 
     def create_test_serialisation(self, tests):
         arr = []
-        for t in tests:
+        for t in sorted(tests, key=lambda tst: -1 * tst.priority):
             exe = t.get_exe()
             if isinstance(exe, dependencies.ExternalProgram):
                 cmd = exe.get_command()

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -86,7 +86,7 @@ class TestSerialisation:
                  is_parallel: bool, cmd_args: typing.List[str],
                  env: build.EnvironmentVariables, should_fail: bool,
                  timeout: typing.Optional[int], workdir: typing.Optional[str],
-                 extra_paths: typing.List[str], protocol: str):
+                 extra_paths: typing.List[str], protocol: str, priority: int):
         self.name = name
         self.project_name = project
         self.suite = suite
@@ -103,6 +103,7 @@ class TestSerialisation:
         self.workdir = workdir
         self.extra_paths = extra_paths
         self.protocol = protocol
+        self.priority = priority
 
 class OptionProxy:
     def __init__(self, value):
@@ -769,7 +770,8 @@ class Backend:
                     raise MesonException('Bad object in test command.')
             ts = TestSerialisation(t.get_name(), t.project_name, t.suite, cmd, is_cross,
                                    exe_wrapper, t.is_parallel, cmd_args, t.env,
-                                   t.should_fail, t.timeout, t.workdir, extra_paths, t.protocol)
+                                   t.should_fail, t.timeout, t.workdir,
+                                   extra_paths, t.protocol, t.priority)
             arr.append(ts)
         return arr
 

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -321,6 +321,7 @@ def get_test_list(testdata):
         to['timeout'] = t.timeout
         to['suite'] = t.suite
         to['is_parallel'] = t.is_parallel
+        to['priority'] = t.priority
         result.append(to)
     return result
 

--- a/test cases/common/224 test priorities/meson.build
+++ b/test cases/common/224 test priorities/meson.build
@@ -1,0 +1,22 @@
+project('test priorities', 'c')
+
+test_prog = find_program('test.sh')
+
+test('priority 0', test_prog,
+     args : ['0'],
+)
+
+test('priority neg 10', test_prog,
+     args : ['-10'],
+     priority : -10
+)
+
+test('priority 1000', test_prog,
+     args : ['1000'],
+     priority : 1000
+)
+
+test('priority 50', test_prog,
+     args : ['50'],
+     priority : 50
+)

--- a/test cases/common/224 test priorities/test.sh
+++ b/test cases/common/224 test priorities/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "$1"


### PR DESCRIPTION
Tests are sorted by decreasing priority (default: 0) and started in that order. This enables us to start tests that should run before others even though they are specified later in the meson.build file.

Note that this only affects **start order**, everything else depends on how many tests are run in parallel and how long they take to finish.

There are two issues here:
- there's a test case, but I don't know how to check for the correct ordering of the tests.
- this was a bit too easy, so I'm wondering whether I forgot something crucial :) It does work with my libinput tests.

Fixes #5581 
