### PR TITLE
bugfix: sometimes test.fname is None in mtest.py

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -452,7 +452,7 @@ class SingleTestRunner:
         self.options = options
 
     def _get_cmd(self) -> typing.Optional[typing.List[str]]:
-        if self.test.fname[0].endswith('.jar'):
+        if self.test.fname and self.test.fname[0].endswith('.jar'):
             return ['java', '-jar'] + self.test.fname
         elif not self.test.is_cross_built and run_with_mono(self.test.fname[0]):
             return ['mono'] + self.test.fname


### PR DESCRIPTION
This allows for the case where TestRun.test.fname is None instead of List[str].
This seems to happen with meson.build test() that are defined at configure time depending on other conditions.  It seems this is intended for cross compiled binaries, which I am not using in the projects where this error shows up.

```
Traceback (most recent call last):
  File "/code/meson/mesonbuild/mesonmain.py", line 127, in run
    return options.run_func(options)
  File "/code/meson/mesonbuild/mtest.py", line 1034, in run
    return th.doit()
  File "/code/meson/mesonbuild/mtest.py", line 791, in doit
    self.run_tests(tests)
  File "/code/meson/mesonbuild/mtest.py", line 941, in run_tests
    self.drain_futures(futures)
  File "/code/meson/mesonbuild/mtest.py", line 957, in drain_futures
    self.process_test_result(result.result())
  File "/miniconda3/lib/python3.7/concurrent/futures/_base.py", line 425, in result
    return self.__get_result()
  File "/miniconda3/lib/python3.7/concurrent/futures/_base.py", line 384, in __get_result
    raise self._exception
  File "/miniconda3/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/code/meson/mesonbuild/mtest.py", line 475, in run
    cmd = self._get_cmd()
  File "/code/meson/mesonbuild/mtest.py", line 455, in _get_cmd
    if self.test.fname[0].endswith('.jar'):
AttributeError: 'NoneType' object has no attribute 'endswith'
```