### PR TITLE
ValaCompiler: only emit '--debug' in debug build.

### DIFF
--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -38,7 +38,7 @@ class ValaCompiler(Compiler):
         return []
 
     def get_debug_args(self, is_debug):
-        return ['--debug']
+        return ['--debug'] if is_debug else []
 
     def get_output_args(self, target):
         return [] # Because compiles into C.


### PR DESCRIPTION
Currently '--debug' is always emitted for Vala regardless of the build type.

From what I can see this has been introduced by https://github.com/mesonbuild/meson/pull/3489 and it does not look like the intended behavior (I could be wrong of course).