### PR TITLE
Add depfile to configure_file()

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -260,6 +260,9 @@ These are all the supported keyword arguments:
   substitutions.
 - `copy` *(added 0.47.0)* as explained above, if specified Meson only
   copies the file from input to output.
+- `depfile` *(added 0.52.0)* is a dependency file that the command can write listing
+  all the additional files this target depends on. A change
+  in any one of these files triggers a reconfiguration.
 - `format` *(added 0.46.0)* the format of defines. It defaults to `meson`, and so substitutes
 `#mesondefine` statements and variables surrounded by `@` characters, you can also use `cmake`
 to replace `#cmakedefine` statements and variables with the `${variable}` syntax. Finally you can use

--- a/docs/markdown/snippets/configure_file_enhancements.md
+++ b/docs/markdown/snippets/configure_file_enhancements.md
@@ -1,3 +1,6 @@
 ## Enhancements to `configure_file()`
 
 `input:` now accepts multiple input file names for `command:`-configured file.
+
+`depfile:` keyword argument is now accepted. The dependency file can
+list all the additional files the configure target depends on.

--- a/mesonbuild/depfile.py
+++ b/mesonbuild/depfile.py
@@ -1,0 +1,85 @@
+# Copyright 2019 Red Hat, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import collections
+
+def parse(lines):
+    rules = []
+    targets = []
+    deps = []
+    in_deps = False
+    out = ''
+    for line in lines:
+        if not line.endswith('\n'):
+            line += '\n'
+        escape = None
+        for c in line:
+            if escape:
+                if escape == '$' and c != '$':
+                    out += '$'
+                if escape == '\\' and c == '\n':
+                    continue
+                out += c
+                escape = None
+                continue
+            if c == '\\' or c == '$':
+                escape = c
+                continue
+            elif c in (' ', '\n'):
+                if out != '':
+                    if in_deps:
+                        deps.append(out)
+                    else:
+                        targets.append(out)
+                out = ''
+                if c == '\n':
+                    rules.append((targets, deps))
+                    targets = []
+                    deps = []
+                    in_deps = False
+                continue
+            elif c == ':':
+                targets.append(out)
+                out = ''
+                in_deps = True
+                continue
+            out += c
+    return rules
+
+Target = collections.namedtuple('Target', ['deps'])
+
+class DepFile:
+    def __init__(self, lines):
+        rules = parse(lines)
+        depfile = {}
+        for (targets, deps) in rules:
+            for target in targets:
+                t = depfile.setdefault(target, Target(deps=set()))
+                for dep in deps:
+                    t.deps.add(dep)
+        self.depfile = depfile
+
+    def get_all_dependencies(self, target, visited=None):
+        deps = set()
+        if not visited:
+            visited = set()
+        if target in visited:
+            return set()
+        visited.add(target)
+        target = self.depfile.get(target)
+        if not target:
+            return set()
+        deps.update(target.deps)
+        for dep in target.deps:
+            deps.update(self.get_all_dependencies(dep, visited))
+        return deps

--- a/test cases/common/14 configure file/generator-deps.py
+++ b/test cases/common/14 configure file/generator-deps.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import sys, os
+from pathlib import Path
+
+if len(sys.argv) != 3:
+    print("Wrong amount of parameters.")
+
+build_dir = Path(os.environ['MESON_BUILD_ROOT'])
+subdir = Path(os.environ['MESON_SUBDIR'])
+outputf = Path(sys.argv[1])
+
+with outputf.open('w') as ofile:
+    ofile.write("#define ZERO_RESULT 0\n")
+
+depf = Path(sys.argv[2])
+if not depf.exists():
+    with depf.open('w') as ofile:
+        ofile.write("{}: depfile\n".format(outputf.name))

--- a/test cases/common/14 configure file/meson.build
+++ b/test cases/common/14 configure file/meson.build
@@ -57,6 +57,17 @@ if ret.returncode() != 0
   error('Error running command: @0@\n@1@'.format(ret.stdout(), ret.stderr()))
 endif
 
+genscript2deps = '@0@/generator-deps.py'.format(meson.current_source_dir())
+ofile2deps = '@0@/config2deps.h'.format(meson.current_build_dir())
+outf = configure_file(
+  output : 'config2deps.h',
+  depfile : 'depfile.d',
+  command : [genprog, genscript2deps, ofile2deps, '@DEPFILE@'])
+ret = run_command(check_file, outf)
+if ret.returncode() != 0
+  error('Error running command: @0@\n@1@'.format(ret.stdout(), ret.stderr()))
+endif
+
 found_script = find_program('generator.py')
 # More configure_file tests in here
 subdir('subdir')


### PR DESCRIPTION
In qemu, minikconf generates a depfile that meson could use to
automatically reconfigure on dependency change.

Note: someone clever can perhaps find a way to express this with a ninja rule & depfile=. I didn't manage, so I wrote a simple depfile parser.

