### PR TITLE
Allow kconfig to read from built files

### DIFF
--- a/docs/markdown/snippets/kconfig_enhancements.md
+++ b/docs/markdown/snippets/kconfig_enhancements.md
@@ -1,0 +1,3 @@
+## Enhancements to the kconfig module
+
+`kconfig.load()` may now accept a `configure_file()` as input file.

--- a/mesonbuild/modules/unstable_kconfig.py
+++ b/mesonbuild/modules/unstable_kconfig.py
@@ -54,15 +54,16 @@ class KconfigModule(ExtensionModule):
             raise InvalidCode('load takes only one file input.')
 
         s = sources[0]
+        is_built = False
         if isinstance(s, mesonlib.File):
-            # kconfig input is processed at "meson setup" time, not during
-            # the build, so it cannot reside in the build directory.
             if s.is_built:
-                raise InvalidCode('kconfig input must be a source file.')
-            s = s.relative_name()
+                FeatureNew('kconfig.load() of built files', '0.52.0').use(state.subproject)
+                is_built = True
+            s = s.absolute_path(interpreter.environment.source_dir, interpreter.environment.build_dir)
+        else:
+            s = os.path.join(interpreter.environment.source_dir, s)
 
-        s = os.path.join(interpreter.environment.source_dir, s)
-        if s not in interpreter.build_def_files:
+        if s not in interpreter.build_def_files and not is_built:
             interpreter.build_def_files.append(s)
 
         return self._load_file(s)

--- a/test cases/kconfig/4 load_config builddir/meson.build
+++ b/test cases/kconfig/4 load_config builddir/meson.build
@@ -2,8 +2,8 @@ project('kconfig builddir test')
 
 k = import('unstable-kconfig')
 
-configure_file(input: 'config', output: 'out-config', copy: true)
-conf = k.load(meson.build_root() / 'out-config')
+out_conf = configure_file(input: 'config', output: 'out-config', copy: true)
+conf = k.load(out_conf)
 
 if not conf.has_key('CONFIG_IS_SET')
   error('Expected CONFIG_IS_SET to be set, but it wasn\'t')


### PR DESCRIPTION
At configure time, kconfig should learn to read configure_file()

WIP until tests are added, and perhaps FeatureNew checks?