### PR TITLE
ci: Fix failures in vs2019 jobs on Azure

### DIFF
--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -155,7 +155,7 @@ steps:
      python --version
 
      # Needed for running unit tests in parallel.
-     python -m pip install --upgrade pytest-xdist
+     python -m pip --disable-pip-version-check install --upgrade pytest-xdist
 
 
      echo ""


### PR DESCRIPTION
pip warns about being out of date and powershell interprets that as an error because reasons.

Found in https://github.com/mesonbuild/meson/pull/5687#issuecomment-514268525