### PR TITLE
sourceset: add all_dependencies() method

### DIFF
--- a/mesonbuild/modules/sourceset.py
+++ b/mesonbuild/modules/sourceset.py
@@ -40,6 +40,7 @@ class SourceSetHolder(MutableInterpreterObject, ObjectHolder):
             'add': self.add_method,
             'add_all': self.add_all_method,
             'all_sources': self.all_sources_method,
+            'all_dependencies': self.all_dependencies_method,
             'apply': self.apply_method,
         })
 
@@ -129,6 +130,13 @@ class SourceSetHolder(MutableInterpreterObject, ObjectHolder):
         self.frozen = True
         files = self.collect(lambda x: True, True)
         return list(files.sources)
+
+    @noKwargs
+    @noPosargs
+    def all_dependencies_method(self, args, kwargs):
+        self.frozen = True
+        files = self.collect(lambda x: True, True)
+        return list(files.dependencies)
 
     @permittedKwargs(['strict'])
     def apply_method(self, args, kwargs):

--- a/test cases/common/223 source set realistic example/meson.build
+++ b/test cases/common/223 source set realistic example/meson.build
@@ -5,14 +5,14 @@ project('sourceset-example', 'cpp')
 ss = import('sourceset')
 kconfig = import('unstable-kconfig')
 
-zlib = dependency('zlib', version : '>=1.2.8', required: false)
+zlib = declare_dependency(compile_args: '-DZLIB=1')
 not_found = dependency('not-found', required: false)
 
 common = ss.source_set()
 specific = ss.source_set()
 
 common.add(files('main.cc'))
-common.add(when: zlib, if_true: files('zlib.cc'))
+common.add(when: zlib, if_true: [files('zlib.cc'), zlib])
 common.add(when: not_found,
            if_true: files('was-found.cc'),
            if_false: files('not-found.cc'))
@@ -25,7 +25,8 @@ if meson.is_unity()
   common = ss.source_set()
 endif
 
-common_lib = static_library('common', common.all_sources())
+common_lib = static_library('common', common.all_sources(),
+                            dependencies: common.all_dependencies())
 
 targets = [ 'arm', 'aarch64', 'x86' ]
 target_dirs = { 'arm' : 'arm', 'aarch64' : 'arm', 'x86': 'x86' }

--- a/test cases/common/223 source set realistic example/zlib.cc
+++ b/test cases/common/223 source set realistic example/zlib.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <cassert>
 #include "common.h"
 
 struct ZLibDependency : Dependency {
@@ -6,6 +7,7 @@ struct ZLibDependency : Dependency {
 };
 
 void ZLibDependency::initialize() {
+    assert(ZLIB);
     std::cout << ANSI_START << "hello from zlib"
               << ANSI_END << std::endl;
 }


### PR DESCRIPTION
'if_true' sources should be built with their dependencies, as
illustrated by test case change.

Ideally, I think we would want only the files with the dependencies to
be built with the flags, but that would probably change the way
sourceset are used.

@bonzini or, did I missed something?