### PR TITLE
Try to fix cross mingw travis failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ script:
   - |
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       ci_env=`bash <(curl -s https://codecov.io/env)`
-      docker run $ci_env -v ${PWD}/.coverage:/root/.coverage \
+      docker run --security-opt seccomp:unconfined $ci_env -v ${PWD}/.coverage:/root/.coverage \
         withgit \
           /bin/sh -c "cd /root && mkdir -p tools; wget -c http://nirbheek.in/files/binaries/ninja/linux-amd64/ninja -O /root/tools/ninja; chmod +x /root/tools/ninja; CC=$CC CXX=$CXX OBJC=$CC OBJCXX=$CXX PATH=/root/tools:$PATH MESON_FIXED_NINJA=1 ./run_tests.py $RUN_TESTS_ARGS -- $MESON_ARGS && chmod -R a+rwX .coverage"
     fi

--- a/test cases/common/122 shared module/module.c
+++ b/test cases/common/122 shared module/module.c
@@ -27,6 +27,19 @@ fptr find_any_f (const char *name) {
 #include <windows.h>
 #include <tlhelp32.h>
 
+static wchar_t*
+win32_get_last_error (void)
+{
+    wchar_t *msg = NULL;
+
+    FormatMessageW (FORMAT_MESSAGE_ALLOCATE_BUFFER
+                    | FORMAT_MESSAGE_IGNORE_INSERTS
+                    | FORMAT_MESSAGE_FROM_SYSTEM,
+                    NULL, GetLastError (), 0,
+                    (LPWSTR) &msg, 0, NULL);
+    return msg;
+}
+
 /* Unlike Linux and OS X, when a library is loaded, all the symbols aren't
  * loaded into a single namespace. You must fetch the symbol by iterating over
  * all loaded modules. Code for finding the function from any of the loaded
@@ -38,7 +51,8 @@ fptr find_any_f (const char *name) {
 
     snapshot = CreateToolhelp32Snapshot (TH32CS_SNAPMODULE, 0);
     if (snapshot == (HANDLE) -1) {
-        printf("Could not get snapshot\n");
+        wchar_t *msg = win32_get_last_error ();
+        printf("Could not get snapshot: %S\n", msg);
         return 0;
     }
 

--- a/test cases/common/122 shared module/prog.c
+++ b/test cases/common/122 shared module/prog.c
@@ -8,7 +8,7 @@ typedef int (*fptr) (void);
 
 #include <windows.h>
 
-wchar_t*
+static wchar_t*
 win32_get_last_error (void)
 {
     wchar_t *msg = NULL;


### PR DESCRIPTION
commit 676cc0934b75b9f428f86399d70a178aa31500d4:

```
.travis.yml: Fix cross-mingw test failures
Run docker with seccomp:unconfined, since otherwise we're blocked from
calling CreateToolhelp32Snapshot() inside the cross-mingw tests,
specifically `common/122 shared module`.
```

commit 539bdee7ec9bbb3e84b17c7f5fc431a8f8f27b7e:

```
tests/122 shared module: More verbose logging
So we know why the syscalls failed.
```
