### PR TITLE
Added KDevelop to the docs [skip ci]

### DIFF
--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -258,5 +258,6 @@ This API can also work without a build directory for the `--projectinfo` command
 # Existing integrations
 
 - [Gnome Builder](https://wiki.gnome.org/Apps/Builder)
+- [KDevelop](https://www.kdevelop.org)
 - [Eclipse CDT](https://www.eclipse.org/cdt/) (experimental)
 - [Meson Cmake Wrapper](https://github.com/prozum/meson-cmake-wrapper) (for cmake IDEs)


### PR DESCRIPTION
The new meson plugin will be included in [KDevelop 5.4](https://www.kdevelop.org/news/kdevelop-5380-released), so adding it to the IDE-Integration docs.