### PR TITLE
Try to fix cygwin timeouts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,7 +88,6 @@ jobs:
         gccx64ninja: {}
   variables:
     CYGWIN_ROOT: $(System.Workfolder)\cygwin
-    CYGWIN_CMAKE_LINK: http://cygwin.mirror.constant.com/x86_64/release/cmake/cmake-3.14.5-1.tar.xz
     CYGWIN_MIRROR: http://cygwin.mirror.constant.com
   steps:
     - script: |
@@ -112,12 +111,10 @@ jobs:
         python35-pip,^
         vala,^
         wget,^
+        cmake,^
         zlib-devel
       displayName: Install Dependencies
     - script: |
-        %CYGWIN_ROOT%\bin\bash.exe -cl "wget %CYGWIN_CMAKE_LINK% -O cmake.tar.xz"
-        %CYGWIN_ROOT%\bin\bash.exe -cl "tar -xf cmake.tar.xz -C /"
-      displayName: Manually install CMake
     - script: |
         set BOOST_ROOT=
         set PATH=%CYGWIN_ROOT%\bin;%SYSTEMROOT%\system32

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,9 +115,12 @@ jobs:
         zlib-devel
       displayName: Install Dependencies
     - script: |
+        %CYGWIN_ROOT%\bin\python3.5m.exe -m pip --disable-pip-version-check install pytest-xdist
+      displayName: pip install pytest-xdist
     - script: |
         set BOOST_ROOT=
         set PATH=%CYGWIN_ROOT%\bin;%SYSTEMROOT%\system32
+        # FIXME: we need to support systems without unversioned `python3`
         cp /usr/bin/python3.5 /usr/bin/python3
         env.exe -- python3 run_tests.py --backend=ninja
       displayName: Run Tests


### PR DESCRIPTION
commit 97103e4fb0735e7ad7e8e1a7ddef4d1fba6f947a:

```
ci/cygwin: Don't need a special step to install cmake
```

commit 956489d3399e3c7717360c0880eab29f8561e8c3:

```
ci/cygwin: Install pytest-xdist for unit tests
The job is taking too long and timing out, use pytest-xdist to speed
up unit tests. Speeds it up on my system from 20 min to 8 min.

Still much slower than native windows: vs2017-x64 takes 3.5 min with
pytest-xdist.
```
