### PR TITLE
DOC: note that number can be converted to strings

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1794,6 +1794,7 @@ are immutable, all operations return their results as a new string.
 
  - `is_even()` returns true if the number is even
  - `is_odd()` returns true if the number is odd
+ - `to_string()` returns the value of the number as a string.
 
 ### `boolean` object
 

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -131,7 +131,7 @@ This function creates a new top-level target. Like all top-level targets, this
 integrates with the selected backend. For instance, with Ninja you can
 run it as `ninja target_name`. This is a dummy target that does not execute any
 command, but ensures that all dependencies are built. Dependencies can be any
-build target (e.g. return value of executable(), custom_target(), etc)
+build target (e.g. return value of [executable()](#executable), custom_target(), etc)
 
 ### assert()
 
@@ -2254,7 +2254,7 @@ and has the following methods:
 
 - `path()` which returns a string pointing to the script or executable
   **NOTE:** You should not need to use this method. Passing the object
-  itself should work in all cases. F.ex.: `run_command(obj, arg1, arg2)`
+  itself should work in all cases. For example: `run_command(obj, arg1, arg2)`
 
 ### `environment` object
 

--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -78,6 +78,13 @@ string_var = '42'
 num = string_var.to_int()
 ```
 
+Numbers can be converted to a string:
+
+```meson
+int_var = 42
+string_var = int_var.to_string()
+```
+
 Booleans
 --
 


### PR DESCRIPTION
I didn't see a documented method to convert integers to strings. Now this is documented.