### PR TITLE
msetup: Fix wrong argument order

### DIFF
--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -54,13 +54,13 @@ def add_arguments(parser):
                         help='Wipe build directory and reconfigure using previous command line options. ' +
                              'Userful when build directory got corrupted, or when rebuilding with a ' +
                              'newer version of meson.')
-    parser.add_argument('builddir', nargs='?', default=None)
     parser.add_argument('sourcedir', nargs='?', default=None)
+    parser.add_argument('builddir', nargs='?', default=None)
 
 class MesonApp:
     def __init__(self, options):
-        (self.source_dir, self.build_dir) = self.validate_dirs(options.builddir,
-                                                               options.sourcedir,
+        (self.source_dir, self.build_dir) = self.validate_dirs(options.sourcedir,
+                                                               options.builddir,
                                                                options.reconfigure,
                                                                options.wipe)
         if options.wipe:


### PR DESCRIPTION
The man-page states that the positional arguments are in the order
sourcedir, builddir.

The argument parser did parse these values the other way round,
which also affected the help message.

As the arguments are passed to the validate_dirs function in the
wrong order, the program bahaves as stated in the man page.

Therefore the arguments are swapped in the parser and the function call
to fix the help message while keeping the current behaviour.