### PR TITLE
Avoid building tests by default (ninja only)

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -863,17 +863,11 @@ class Backend:
         # also be built by default. XXX: Sometime in the future these should be
         # built only before running tests.
         for t in self.build.get_tests():
-            exe = t.exe
-            if hasattr(exe, 'held_object'):
-                exe = exe.held_object
-            if isinstance(exe, (build.CustomTarget, build.BuildTarget)):
-                result[exe.get_id()] = exe
-            for arg in t.cmd_args:
+            for arg in [t.exe] + t.cmd_args:
                 if hasattr(arg, 'held_object'):
                     arg = arg.held_object
-                if not isinstance(arg, (build.CustomTarget, build.BuildTarget)):
-                    continue
-                result[arg.get_id()] = arg
+                if isinstance(arg, (build.CustomTarget, build.BuildTarget)):
+                    result[arg.get_id()] = arg
             for dep in t.depends:
                 assert isinstance(dep, (build.CustomTarget, build.BuildTarget))
                 result[dep.get_id()] = dep

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -859,9 +859,11 @@ class Backend:
         for name, t in self.build.get_targets().items():
             if t.build_by_default:
                 result[name] = t
-        # Get all targets used as test executables and arguments. These must
-        # also be built by default. XXX: Sometime in the future these should be
-        # built only before running tests.
+        return result
+
+    def get_test_targets(self):
+        result = OrderedDict()
+        # Get all targets used as test executables and arguments.
         for t in self.build.get_tests():
             for arg in [t.exe] + t.cmd_args:
                 if hasattr(arg, 'held_object'):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -823,7 +823,7 @@ int dummy;
             cmd += ['--no-stdsplit']
         if self.environment.coredata.get_builtin_option('errorlogs'):
             cmd += ['--print-errorlogs']
-        elem = NinjaBuildElement(self.all_outputs, 'meson-test', 'CUSTOM_COMMAND', ['all', 'PHONY'])
+        elem = NinjaBuildElement(self.all_outputs, 'meson-test', 'CUSTOM_COMMAND', ['all', 'tests', 'PHONY'])
         elem.add_item('COMMAND', cmd)
         elem.add_item('DESC', 'Running all tests.')
         elem.add_item('pool', 'console')
@@ -835,7 +835,7 @@ int dummy;
         cmd = self.environment.get_build_command(True) + [
             'test', '--benchmark', '--logbase',
             'benchmarklog', '--num-processes=1', '--no-rebuild']
-        elem = NinjaBuildElement(self.all_outputs, 'meson-benchmark', 'CUSTOM_COMMAND', ['all', 'PHONY'])
+        elem = NinjaBuildElement(self.all_outputs, 'meson-benchmark', 'CUSTOM_COMMAND', ['all', 'tests', 'PHONY'])
         elem.add_item('COMMAND', cmd)
         elem.add_item('DESC', 'Running benchmark suite.')
         elem.add_item('pool', 'console')
@@ -2684,14 +2684,23 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         self.create_target_alias('meson-uninstall')
 
     def generate_ending(self):
-        targetlist = []
+        default_targetlist = []
         for t in self.get_build_by_default_targets().values():
             # Add the first output of each target to the 'all' target so that
             # they are all built
-            targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
+            default_targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
 
-        elem = NinjaBuildElement(self.all_outputs, 'all', 'phony', targetlist)
-        self.add_build(elem)
+        default_elem = NinjaBuildElement(self.all_outputs, 'all', 'phony', default_targetlist)
+        self.add_build(default_elem)
+
+        test_targetlist = []
+        for t in self.get_test_targets().values():
+            # Add the first output of each target to the 'all' target so that
+            # they are all built
+            test_targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
+
+        test_elem = NinjaBuildElement(self.all_outputs, 'tests', 'phony', test_targetlist)
+        self.add_build(test_elem)
 
         elem = NinjaBuildElement(self.all_outputs, 'meson-clean', 'CUSTOM_COMMAND', 'PHONY')
         elem.add_item('COMMAND', [self.ninja_command, '-t', 'clean'])

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -301,6 +301,7 @@ class Vs2010Backend(backends.Backend):
 
     def generate_solution(self, sln_filename, projlist):
         default_projlist = self.get_build_by_default_targets()
+        default_projlist.update(self.get_test_targets())
         sln_filename_tmp = sln_filename + '~'
         with open(sln_filename_tmp, 'w', encoding='utf-8') as ofile:
             ofile.write('Microsoft Visual Studio Solution File, Format '

--- a/run_tests.py
+++ b/run_tests.py
@@ -192,17 +192,16 @@ def get_builddir_target_args(backend, builddir, target):
 def get_backend_commands(backend, debug=False):
     install_cmd = []
     uninstall_cmd = []
+    buildtests_cmd = []
     if backend is Backend.vs:
         cmd = ['msbuild']
         clean_cmd = cmd + ['/target:Clean']
-        buildtests_cmd = cmd + ['BUILD_TESTS.vcxproj']
         test_cmd = cmd + ['RUN_TESTS.vcxproj']
     elif backend is Backend.xcode:
         cmd = ['xcodebuild']
         # In Xcode9 new build system's clean command fails when using a custom build directory.
         # Maybe use it when CI uses Xcode10 we can remove '-UseNewBuildSystem=FALSE'
         clean_cmd = cmd + ['-alltargets', 'clean', '-UseNewBuildSystem=FALSE']
-        buildtests_cmd = cmd + ['-target', 'BUILD_TESTS']
         test_cmd = cmd + ['-target', 'RUN_TESTS']
     elif backend is Backend.ninja:
         global NINJA_1_9_OR_NEWER

--- a/run_tests.py
+++ b/run_tests.py
@@ -195,12 +195,14 @@ def get_backend_commands(backend, debug=False):
     if backend is Backend.vs:
         cmd = ['msbuild']
         clean_cmd = cmd + ['/target:Clean']
+        buildtests_cmd = cmd + ['BUILD_TESTS.vcxproj']
         test_cmd = cmd + ['RUN_TESTS.vcxproj']
     elif backend is Backend.xcode:
         cmd = ['xcodebuild']
         # In Xcode9 new build system's clean command fails when using a custom build directory.
         # Maybe use it when CI uses Xcode10 we can remove '-UseNewBuildSystem=FALSE'
         clean_cmd = cmd + ['-alltargets', 'clean', '-UseNewBuildSystem=FALSE']
+        buildtests_cmd = cmd + ['-target', 'BUILD_TESTS']
         test_cmd = cmd + ['-target', 'RUN_TESTS']
     elif backend is Backend.ninja:
         global NINJA_1_9_OR_NEWER
@@ -222,12 +224,13 @@ def get_backend_commands(backend, debug=False):
         if debug:
             cmd += ['-v']
         clean_cmd = cmd + ['clean']
+        buildtests_cmd = cmd + ['tests']
         test_cmd = cmd + ['test', 'benchmark']
         install_cmd = cmd + ['install']
         uninstall_cmd = cmd + ['uninstall']
     else:
         raise AssertionError('Unknown backend: {!r}'.format(backend))
-    return cmd, clean_cmd, test_cmd, install_cmd, uninstall_cmd
+    return cmd, clean_cmd, buildtests_cmd, test_cmd, install_cmd, uninstall_cmd
 
 def ensure_backend_detects_changes(backend):
     global NINJA_1_9_OR_NEWER

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1221,7 +1221,7 @@ class BasePlatformTests(unittest.TestCase):
         self.wrap_command = self.meson_command + ['wrap']
         self.rewrite_command = self.meson_command + ['rewrite']
         # Backend-specific build commands
-        self.build_command, self.clean_command, self.test_command, self.install_command, \
+        self.build_command, self.clean_command, self.buildtests_command, self.test_command, self.install_command, \
             self.uninstall_command = get_backend_commands(self.backend)
         # Test directories
         self.common_test_dir = os.path.join(src_root, 'test cases/common')
@@ -1372,6 +1372,7 @@ class BasePlatformTests(unittest.TestCase):
         self._run(self.clean_command + dir_args, workdir=self.builddir, override_envvars=override_envvars)
 
     def run_tests(self, *, inprocess=False, override_envvars=None):
+        self._run(self.buildtests_command, workdir=self.builddir, override_envvars=override_envvars)
         if not inprocess:
             self._run(self.test_command, workdir=self.builddir, override_envvars=override_envvars)
         else:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1372,7 +1372,8 @@ class BasePlatformTests(unittest.TestCase):
         self._run(self.clean_command + dir_args, workdir=self.builddir, override_envvars=override_envvars)
 
     def run_tests(self, *, inprocess=False, override_envvars=None):
-        self._run(self.buildtests_command, workdir=self.builddir, override_envvars=override_envvars)
+        if self.buildtests_command:
+            self._run(self.buildtests_command, workdir=self.builddir, override_envvars=override_envvars)
         if not inprocess:
             self._run(self.test_command, workdir=self.builddir, override_envvars=override_envvars)
         else:


### PR DESCRIPTION
For one of my projects, building the tests of a third party library causes tricky problems and is not worth the trouble. The easiest way to avoid this is to follow up a comment in the mesonbuild sources:

"XXX: Sometime in the future these should be built only before running tests."

This change achieves this for the ninja backend in a quite straightforward way, since most of the mechanism was already in place.

I did try hard to get it working for the Visual Studio / msbuild backend but ultimately gave up. All attempts to realize a separate meta-project for building the tests separately had side effects that broke CI and required a ever growing cascade of fixes in other places of the code. So ultimately I added a line to exactly preserve the behavior for Visual Studio.