### PR TITLE
PGI:  cpp_pch precompiled headers functionality

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -274,7 +274,6 @@ class PGICPPCompiler(PGICompiler, CPPCompiler):
         CPPCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
         PGICompiler.__init__(self, compiler_type)
 
-
 class ElbrusCPPCompiler(GnuCPPCompiler, ElbrusCompiler):
     def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, defines=None, **kwargs):
         GnuCPPCompiler.__init__(self, exelist, version, compiler_type, for_machine, is_cross, exe_wrapper, defines, **kwargs)

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -16,6 +16,7 @@
 
 import typing
 import os
+from pathlib import Path
 
 from ..compilers import clike_debug_args, clike_optimization_args
 
@@ -42,8 +43,9 @@ pgi_buildtype_linker_args = {
 }  # type: typing.Dict[str, typing.List[str]]
 
 
-class PGICompiler:
+class PGICompiler():
     def __init__(self, compiler_type: 'CompilerType'):
+        self.base_options = ['b_pch']
         self.id = 'pgi'
         self.compiler_type = compiler_type
 
@@ -93,3 +95,17 @@ class PGICompiler:
 
     def get_always_args(self) -> typing.List[str]:
         return []
+
+    def get_pch_suffix(self) -> str:
+        # PGI defaults to .pch suffix for PCH on Linux and Windows with --pch option
+        return 'pch'
+
+    def get_pch_use_args(self, pch_dir: str, header: str) -> typing.List[str]:
+        # PGI supports PCH for C++ only.
+        hdr = Path(pch_dir).resolve().parent / header
+        if self.language == 'cpp':
+            return ['--pch',
+                    '--pch_dir', str(hdr.parent),
+                    '-I{}'.format(hdr.parent)]
+        else:
+            return []

--- a/test cases/common/13 pch/c/meson.build
+++ b/test cases/common/13 pch/c/meson.build
@@ -1,7 +1,13 @@
 cc = meson.get_compiler('c')
 cc_id = cc.get_id()
+
 if cc_id == 'lcc'
   error('MESON_SKIP_TEST: Elbrus compiler does not support PCH.')
+endif
+
+# PGI compiler only supports PCH for C++
+if cc_id == 'pgi'
+  subdir_done()
 endif
 
 exe = executable('prog', 'prog.c',

--- a/test cases/common/13 pch/cpp/prog.cc
+++ b/test cases/common/13 pch/cpp/prog.cc
@@ -1,4 +1,5 @@
-#include "prog.hh"
+// Note: if using PGI compilers, you will need to add #include "prog.hh"
+// even though you're using precompiled headers.
 void func() {
     std::cout << "This is a function that fails to compile if iostream is not included."
               << std::endl;

--- a/test cases/common/13 pch/cpp/prog.cc
+++ b/test cases/common/13 pch/cpp/prog.cc
@@ -1,8 +1,10 @@
+#include "prog.hh"
 void func() {
     std::cout << "This is a function that fails to compile if iostream is not included."
               << std::endl;
 }
 
 int main(int argc, char **argv) {
+    func();
     return 0;
 }

--- a/test cases/common/13 pch/generated/meson.build
+++ b/test cases/common/13 pch/generated/meson.build
@@ -1,7 +1,13 @@
 cc = meson.get_compiler('c')
 cc_id = cc.get_id()
+
 if cc_id == 'lcc'
   error('MESON_SKIP_TEST: Elbrus compiler does not support PCH.')
+endif
+
+# PGI compiler only supports PCH for C++
+if cc_id == 'pgi'
+  subdir_done()
 endif
 
 generated_customTarget = custom_target('makeheader',

--- a/test cases/common/13 pch/meson.build
+++ b/test cases/common/13 pch/meson.build
@@ -1,4 +1,12 @@
-project('pch test', 'c', 'cpp')
+project('pch test', 'c', 'cpp',
+  meson_version: '>= 0.46.0')
+
+cc = meson.get_compiler('c')
+cc_id = cc.get_id()
+
+if cc_id == 'pgi'
+  error('MESON_SKIP_TEST: PGI compiler does support PCH, however, PGI cannot tolerate spaces in the --pch_dir path and Meson run_project_tests.py uses spaces in temporary build path names. If this test is run individually with no spaces in build path, it will pass.')
+endif
 
 subdir('c')
 subdir('cpp')

--- a/test cases/common/13 pch/mixed/meson.build
+++ b/test cases/common/13 pch/mixed/meson.build
@@ -1,3 +1,11 @@
+cc = meson.get_compiler('c')
+cc_id = cc.get_id()
+
+# PGI compiler only supports PCH for C++
+if cc_id == 'pgi'
+  subdir_done()
+endif
+
 exe = executable(
   'prog',
   files('main.cc', 'func.c'),

--- a/test cases/common/13 pch/withIncludeDirectories/meson.build
+++ b/test cases/common/13 pch/withIncludeDirectories/meson.build
@@ -1,7 +1,13 @@
 cc = meson.get_compiler('c')
 cc_id = cc.get_id()
+
 if cc_id == 'lcc'
   error('MESON_SKIP_TEST: Elbrus compiler does not support PCH.')
+endif
+
+# PGI compiler only supports PCH for C++
+if cc_id == 'pgi'
+  subdir_done()
 endif
 
 exe = executable('prog', 'prog.c',


### PR DESCRIPTION
Precompiled headers (PCH) for PGI has not been working since I added PGI compilers.
I simply omitted this feature previously. 
his PR adds PCH for PGI C++ only (as that's all PGI works with for PCH).


PGI compilers support precompiled headers for C++ only.
The common/13 pch test passes if run manually with no spaces in the build path AND #include "prog.hh" is added to prog.cc.
This is distinctive from how other compilers work, and since PGI is not nearly as popular a compiler, I opted to simply skip the PCH test rather than rework the whole test system to accommodate PGI's less-robust PCH behavior.

However, since Meson run_project_tests.py makes temporary build directories
with spaces in each test, PGI --pch_dir can't handle this and fails.
So we **skip common/13 pch test** for PGI despite it working for usual case with no-spaces
in builddir.
Note: PGI is fine to have spaces in full path for sourcedir, but requires no spaces in
relative path to builddir.