### PR TITLE
PGI: correct Fortran so that Fortran run_project_tests.py pass

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -209,25 +209,25 @@ class CLikeCompiler:
         '''
         return self.get_compiler_dirs(env, 'programs')
 
-    def get_pic_args(self):
+    def get_pic_args(self) -> typing.List[str]:
         return ['-fPIC']
 
-    def name_string(self):
+    def name_string(self) -> str:
         return ' '.join(self.exelist)
 
-    def get_pch_use_args(self, pch_dir, header):
+    def get_pch_use_args(self, pch_dir: str, header: str) -> typing.List[str]:
         return ['-include', os.path.basename(header)]
 
-    def get_pch_name(self, header_name):
+    def get_pch_name(self, header_name: str) -> str:
         return os.path.basename(header_name) + '.' + self.get_pch_suffix()
 
-    def get_linker_search_args(self, dirname):
+    def get_linker_search_args(self, dirname: str) -> typing.List[str]:
         return ['-L' + dirname]
 
     def get_default_include_dirs(self):
         return []
 
-    def gen_export_dynamic_link_args(self, env):
+    def gen_export_dynamic_link_args(self, env) -> typing.List[str]:
         m = env.machines[self.for_machine]
         if m.is_windows() or m.is_cygwin():
             return ['-Wl,--export-all-symbols']
@@ -236,7 +236,7 @@ class CLikeCompiler:
         else:
             return ['-Wl,-export-dynamic']
 
-    def gen_import_library_args(self, implibname):
+    def gen_import_library_args(self, implibname: str) -> typing.List[str]:
         """
         The name of the outputted import library
 

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -61,6 +61,9 @@ class PGICompiler():
     def get_no_warn_args(self) -> typing.List[str]:
         return ['-silent']
 
+    def gen_import_library_args(self, implibname: str) -> typing.List[str]:
+        return []
+
     def get_std_shared_lib_link_args(self) -> typing.List[str]:
         # PGI -shared is Linux only.
         if self.compiler_type.is_osx_compiler or self.compiler_type.is_windows_compiler:

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -66,9 +66,11 @@ class PGICompiler():
 
     def get_std_shared_lib_link_args(self) -> typing.List[str]:
         # PGI -shared is Linux only.
-        if self.compiler_type.is_osx_compiler or self.compiler_type.is_windows_compiler:
-            return []
-        return ['-shared']
+        if self.compiler_type.is_windows_compiler:
+            return ['-Bdynamic', '-Mmakedll']
+        elif not self.compiler_type.is_osx_compiler:
+            return ['-shared']
+        return []
 
     def get_pic_args(self) -> typing.List[str]:
         # PGI -fPIC is Linux only.

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -61,9 +61,16 @@ class PGICompiler():
     def get_no_warn_args(self) -> typing.List[str]:
         return ['-silent']
 
-    def get_pic_args(self) -> typing.List[str]:
+    def get_std_shared_lib_link_args(self) -> typing.List[str]:
+        # PGI -shared is Linux only.
         if self.compiler_type.is_osx_compiler or self.compiler_type.is_windows_compiler:
-            return [] # PGI -fPIC is Linux only.
+            return []
+        return ['-shared']
+
+    def get_pic_args(self) -> typing.List[str]:
+        # PGI -fPIC is Linux only.
+        if self.compiler_type.is_osx_compiler or self.compiler_type.is_windows_compiler:
+            return []
         return ['-fPIC']
 
     def openmp_flags(self) -> typing.List[str]:

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -374,9 +374,16 @@ class OpenMPDependency(ExternalDependency):
             openmp_date = self.clib_compiler.get_define(
                 '_OPENMP', '', self.env, self.clib_compiler.openmp_flags(), [self], disable_cache=True)[0]
         except mesonlib.EnvironmentException as e:
-            mlog.debug('OpenMP support not available in the compiler')
-            mlog.debug(e)
-            openmp_date = False
+            if self.clib_compiler.get_id() == 'pgi':
+                # through at least PGI 19.4, there is no macro defined for OpenMP, but OpenMP 3.1 is supported.
+                self.version = '3.1'
+                self.is_found = True
+                self.compile_args = self.link_args = self.clib_compiler.openmp_flags()
+                return
+            else:
+                mlog.debug('OpenMP support not available in the compiler')
+                mlog.debug(e)
+                openmp_date = None
 
         if openmp_date:
             self.version = self.VERSIONS[openmp_date]

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -370,20 +370,19 @@ class OpenMPDependency(ExternalDependency):
         language = kwargs.get('language')
         super().__init__('openmp', environment, language, kwargs)
         self.is_found = False
+        if self.clib_compiler.get_id() == 'pgi':
+            # through at least PGI 19.4, there is no macro defined for OpenMP, but OpenMP 3.1 is supported.
+            self.version = '3.1'
+            self.is_found = True
+            self.compile_args = self.link_args = self.clib_compiler.openmp_flags()
+            return
         try:
             openmp_date = self.clib_compiler.get_define(
                 '_OPENMP', '', self.env, self.clib_compiler.openmp_flags(), [self], disable_cache=True)[0]
         except mesonlib.EnvironmentException as e:
-            if self.clib_compiler.get_id() == 'pgi':
-                # through at least PGI 19.4, there is no macro defined for OpenMP, but OpenMP 3.1 is supported.
-                self.version = '3.1'
-                self.is_found = True
-                self.compile_args = self.link_args = self.clib_compiler.openmp_flags()
-                return
-            else:
-                mlog.debug('OpenMP support not available in the compiler')
-                mlog.debug(e)
-                openmp_date = None
+            mlog.debug('OpenMP support not available in the compiler')
+            mlog.debug(e)
+            openmp_date = None
 
         if openmp_date:
             self.version = self.VERSIONS[openmp_date]

--- a/test cases/common/190 openmp/meson.build
+++ b/test cases/common/190 openmp/meson.build
@@ -1,4 +1,4 @@
-project('openmp', 'c', 'cpp')
+project('openmp', 'c')
 
 cc = meson.get_compiler('c')
 if cc.get_id() == 'gcc' and cc.version().version_compare('<4.2.0')
@@ -21,21 +21,22 @@ if host_machine.system() == 'darwin'
 endif
 
 openmp = dependency('openmp')
+env = environment()
+env.set('OMP_NUM_THREADS', '2')
 
 exec = executable('exec',
   'main.c',
   dependencies : [openmp])
-
-execpp = executable('execpp',
-  'main.cpp',
-  dependencies : [openmp])
-
-env = environment()
-env.set('OMP_NUM_THREADS', '2')
-
 test('OpenMP C', exec, env : env)
-test('OpenMP C++', execpp, env : env)
 
+if not(build_machine.system() == 'windows' and cc.get_id() == 'pgi')
+  if add_languages('cpp', required : false)
+    execpp = executable('execpp',
+      'main.cpp',
+      dependencies : [openmp])
+    test('OpenMP C++', execpp, env : env)
+  endif
+endif
 
 if add_languages('fortran', required : false)
   # Mixing compilers (msvc/clang with gfortran) does not seem to work on Windows.

--- a/test cases/common/223 source set realistic example/meson.build
+++ b/test cases/common/223 source set realistic example/meson.build
@@ -2,6 +2,12 @@
 # modules, inspired by QEMU's build system
 
 project('sourceset-example', 'cpp')
+
+cppid = meson.get_compiler('cpp').get_id()
+if cppid == 'pgi'
+  error('MESON_SKIP_TEST: Even PGI 19.4 that claims C++17 full support, cannot handle auto x = y syntax used in this test.')
+endif
+
 ss = import('sourceset')
 kconfig = import('unstable-kconfig')
 

--- a/test cases/fortran/13 coarray/meson.build
+++ b/test cases/fortran/13 coarray/meson.build
@@ -4,8 +4,8 @@ project('Fortran coarray', 'fortran',
 fc = meson.get_compiler('fortran')
 fcid = fc.get_id()
 
-if fcid == 'pgi' or fcid == 'flang'
-  error('MESON_SKIP_TEST: At least through: PGI 19.4 and Flang 7.0 do not support Fortran Coarrays.')
+if ['pgi', 'flang'].contains(fcid)
+  error('MESON_SKIP_TEST: At least through PGI 19.4 and Flang 7.1 do not support Fortran Coarrays.')
 endif
 
 # coarray is required because single-image fallback is an intrinsic feature

--- a/test cases/fortran/14 fortran links c/meson.build
+++ b/test cases/fortran/14 fortran links c/meson.build
@@ -1,5 +1,6 @@
 project('Fortran calling C', 'fortran', 'c',
-  meson_version: '>= 0.51.0')
+  meson_version: '>= 0.51.0',
+  default_options : ['default_library=static'])
 
 ccid = meson.get_compiler('c').get_id()
 if ccid == 'msvc' or ccid == 'clang-cl'

--- a/test cases/fortran/6 dynamic/meson.build
+++ b/test cases/fortran/6 dynamic/meson.build
@@ -1,9 +1,11 @@
 project('dynamic_fortran', 'fortran')
 
-if meson.get_compiler('fortran').get_id() == 'intel-cl'
-  error('MESON_SKIP_TEST: Windows ifort does not use shared_library in a sane way')
+fcid = meson.get_compiler('fortran').get_id()
+if fcid == 'intel-cl' or (host_machine.system() == 'windows' and fcid == 'pgi')
+  error('MESON_SKIP_TEST: non-Gfortran Windows Fortran compilers do not do shared libraries in a Fortran standard way')
   # !DEC$ ATTRIBUTES DLLEXPORT must be used!
   # https://software.intel.com/en-us/node/535306
+  # https://www.pgroup.com/resources/docs/19.4/x86/pgi-user-guide/index.htm#lib-dynlnk-bld-dll-fort
 endif
 
 dynamic = shared_library('dynamic', 'dynamic.f90')


### PR DESCRIPTION
* Linux: all tests pass except the skipped "13 coarray"
* Windows: all tests pass except skipped: 6 (dynamic lib on non-Gfortran Windows takes peculiar non-standard Fortran syntax), 9 (can't mix compilers on Windows), 10 (zlib not on windows), 13 coarray

OpenMP is included right in the PGI compiler.

```sh
FC=pgfortran CC=pgcc CXX=pgc++ python run_project_tests.py --only fortran
```