### PR TITLE
Flang: Fortran project_tests fixes

### DIFF
--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -321,6 +321,9 @@ class FlangFortranCompiler(ClangCompiler, FortranCompiler):
                           '2': default_warn_args,
                           '3': default_warn_args}
 
+    def language_stdlib_only_link_flags(self) -> List[str]:
+        return ['-lflang', '-lpgmath']
+
 class Open64FortranCompiler(FortranCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwags):
         FortranCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwags)

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -380,11 +380,14 @@ class OpenMPDependency(ExternalDependency):
 
         if openmp_date:
             self.version = self.VERSIONS[openmp_date]
-            if self.clib_compiler.has_header('omp.h', '', self.env, dependencies=[self], disable_cache=True)[0]:
-                self.is_found = True
-                self.compile_args = self.link_args = self.clib_compiler.openmp_flags()
-            else:
-                mlog.log(mlog.yellow('WARNING:'), 'OpenMP found but omp.h missing.')
+            # Flang has omp_lib.h
+            header_names = ('omp.h', 'omp_lib.h')
+            for name in header_names:
+                if self.clib_compiler.has_header(name, '', self.env, dependencies=[self], disable_cache=True)[0]:
+                    self.is_found = True
+                    self.compile_args = self.link_args = self.clib_compiler.openmp_flags()
+                else:
+                    mlog.log(mlog.yellow('WARNING:'), 'OpenMP found but omp.h missing.')
 
 
 class ThreadDependency(ExternalDependency):

--- a/test cases/fortran/13 coarray/meson.build
+++ b/test cases/fortran/13 coarray/meson.build
@@ -1,6 +1,13 @@
 project('Fortran coarray', 'fortran',
   meson_version: '>=0.50')
 
+fc = meson.get_compiler('fortran')
+fcid = fc.get_id()
+
+if fcid == 'pgi' or fcid == 'flang'
+  error('MESON_SKIP_TEST: At least through: PGI 19.4 and Flang 7.0 do not support Fortran Coarrays.')
+endif
+
 # coarray is required because single-image fallback is an intrinsic feature
 coarray = dependency('coarray', required : true)
 


### PR DESCRIPTION
This adds project_tests for Flang compiler that should have been added when it was originally added to Meson.
All Fortran project_tests now pass with Flang.
