### PR TITLE
BUGFIX for #5734 dfa52469d7dac6f: OpenMP: stop searching when openmp headers are first found

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -386,8 +386,9 @@ class OpenMPDependency(ExternalDependency):
                 if self.clib_compiler.has_header(name, '', self.env, dependencies=[self], disable_cache=True)[0]:
                     self.is_found = True
                     self.compile_args = self.link_args = self.clib_compiler.openmp_flags()
-                else:
-                    mlog.log(mlog.yellow('WARNING:'), 'OpenMP found but omp.h missing.')
+                    break
+            if not self.is_found:
+                mlog.log(mlog.yellow('WARNING:'), 'OpenMP found but omp.h missing.')
 
 
 class ThreadDependency(ExternalDependency):


### PR DESCRIPTION
A bug was accidentally introduced in #5734 dfa52469d7dac6f

The search for OpenMP header should stop on the first file found, or a spurious warning is emitted in general. 