### PR TITLE
CMake: Basic generator expression support

### DIFF
--- a/mesonbuild/cmake/__init__.py
+++ b/mesonbuild/cmake/__init__.py
@@ -23,10 +23,12 @@ __all__ = [
     'CMakeTarget',
     'CMakeTraceLine',
     'CMakeTraceParser',
+    'parse_generator_expressions',
 ]
 
 from .common import CMakeException
 from .client import CMakeClient
 from .executor import CMakeExecutor
+from .generator import parse_generator_expressions
 from .interpreter import CMakeInterpreter
 from .traceparser import CMakeTarget, CMakeTraceLine, CMakeTraceParser

--- a/mesonbuild/cmake/generator.py
+++ b/mesonbuild/cmake/generator.py
@@ -1,0 +1,129 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .. import mesonlib
+
+def parse_generator_expressions(raw: str) -> str:
+    '''Parse CMake generator expressions
+
+    Most generator expressions are simply ignored for
+    simplicety, however some are required for some common
+    use cases.
+    '''
+
+    out = ''  # type: str
+    i = 0     # type: int
+
+    def equal(arg: str) -> str:
+        col_pos = arg.find(',')
+        if col_pos < 0:
+            return '0'
+        else:
+            return '1' if arg[:col_pos] == arg[col_pos + 1:] else '0'
+
+    def vers_comp(op: str, arg: str) -> str:
+        col_pos = arg.find(',')
+        if col_pos < 0:
+            return '0'
+        else:
+            return '1' if mesonlib.version_compare(arg[:col_pos], '{}{}'.format(op, arg[col_pos + 1:])) else '0'
+
+    supported = {
+        # Boolean functions
+        'BOOL': lambda x: '0' if x.upper() in ['0', 'FALSE', 'OFF', 'N', 'NO', 'IGNORE', 'NOTFOUND'] or x.endswith('-NOTFOUND') else '1',
+        'AND': lambda x: '1' if all([y == '1' for y in x.split(',')]) else '0',
+        'OR': lambda x: '1' if any([y == '1' for y in x.split(',')]) else '0',
+        'NOT': lambda x: '0' if x == '1' else '1',
+
+        '0': lambda x: '',
+        '1': lambda x: x,
+
+        # String operations
+        'STREQUAL': equal,
+        'EQUAL': equal,
+        'VERSION_LESS': lambda x: vers_comp('<', x),
+        'VERSION_GREATER': lambda x: vers_comp('>', x),
+        'VERSION_EQUAL': lambda x: vers_comp('=', x),
+        'VERSION_LESS_EQUAL': lambda x: vers_comp('<=', x),
+        'VERSION_GREATER_EQUAL': lambda x: vers_comp('>=', x),
+
+        # String modification
+        'LOWER_CASE': lambda x: x.lower(),
+        'UPPER_CASE': lambda x: x.upper(),
+
+        # Always assume the BUILD_INTERFACE is valid.
+        # INSTALL_INTERFACE is always invalid for subprojects and
+        # it should also never appear in CMake config files, used
+        # for dependencies
+        'INSTALL_INTERFACE': lambda x: '',
+        'BUILD_INTERFACE': lambda x: x,
+
+        # Constants
+        'ANGLE-R': lambda x: '>',
+        'COMMA': lambda x: ',',
+        'SEMICOLON': lambda x: ';',
+    }
+
+    # Recursively evaluate generator expressions
+    def eval_generator_expressions() -> str:
+        nonlocal i
+        i += 2
+
+        func = ''  # type: str
+        args = ''  # type: str
+        res = ''   # type: str
+        exp = ''   # type: str
+
+        # Determine the body of the expression
+        while i < len(raw):
+            if raw[i] == '>':
+                # End of the generator expression
+                break
+            elif i < len(raw) - 1 and raw[i] == '$' and raw[i + 1] == '<':
+                # Nested generator expression
+                exp += eval_generator_expressions()
+            else:
+                # Generator expression body
+                exp += raw[i]
+
+            i += 1
+
+        # Split the expression into a function and arguments part
+        col_pos = exp.find(':')
+        if col_pos < 0:
+            func = exp
+        else:
+            func = exp[:col_pos]
+            args = exp[col_pos + 1:]
+
+        func = func.strip()
+        args = args.strip()
+
+        # Evaluate the function
+        if func in supported:
+            res = supported[func](args)
+
+        return res
+
+    while i < len(raw):
+        if i < len(raw) - 1 and raw[i] == '$' and raw[i + 1] == '<':
+            # Generator expression detected --> try resolving it
+            out += eval_generator_expressions()
+        else:
+            # Normal string, leave unchanged
+            out += raw[i]
+
+        i += 1
+
+    return out

--- a/test cases/cmake/10 generator expressions/main.cpp
+++ b/test cases/cmake/10 generator expressions/main.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <cmMod.hpp>
+
+using namespace std;
+
+int main() {
+  cmModClass obj("Hello");
+  cout << obj.getStr() << endl;
+  return 0;
+}

--- a/test cases/cmake/10 generator expressions/meson.build
+++ b/test cases/cmake/10 generator expressions/meson.build
@@ -1,0 +1,12 @@
+project('cmakeSubTest', ['c', 'cpp'])
+
+cm = import('cmake')
+
+sub_pro = cm.subproject('cmMod')
+sub_dep = sub_pro.dependency('cmModLib')
+
+assert(sub_pro.target_list() == ['cmModLib'], 'There should be exactly one target')
+assert(sub_pro.target_type('cmModLib') == 'header_only', 'Target type should be header_only')
+
+exe1 = executable('main', ['main.cpp'], dependencies: [sub_dep])
+test('test1', exe1)

--- a/test cases/cmake/10 generator expressions/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/10 generator expressions/subprojects/cmMod/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(cmMod)
+set (CMAKE_CXX_STANDARD 14)
+
+include(GNUInstallDirs)
+
+add_library(cmModLib INTERFACE)
+
+target_compile_options(cmModLib
+  INTERFACE $<$<AND:$<CONFIG:Release>,$<CONFIG:Debug>>:-DCMAKE_FLAG_ERROR_A> # Check discard = false
+  INTERFACE "-DCMAKE_FLAG_REQUIRED_A"
+  INTERFACE $<$<AND:1,$<STREQUAL:asd,$<LOWER_CASE:AsD>>,$<NOT:$<EQUAL:4,2>>>:-DCMAKE_FLAG_REQUIRED_B>
+  INTERFACE $<$<VERSION_LESS:1.2.3,2.1.0>:-DCMAKE_FLAG_REQUIRED_C>
+)
+
+target_include_directories(cmModLib INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_compile_definitions(cmModLib INTERFACE -DCMAKE_COMPILER_DEFINE_STR="compDef")

--- a/test cases/cmake/10 generator expressions/subprojects/cmMod/include/cmMod.hpp
+++ b/test cases/cmake/10 generator expressions/subprojects/cmMod/include/cmMod.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string>
+
+#ifndef CMAKE_FLAG_REQUIRED_A
+#error "The flag CMAKE_FLAG_REQUIRED_A was not set"
+#endif
+
+#ifndef CMAKE_FLAG_REQUIRED_B
+#error "The flag CMAKE_FLAG_REQUIRED_B was not set"
+#endif
+
+#ifndef CMAKE_FLAG_REQUIRED_C
+#error "The flag CMAKE_FLAG_REQUIRED_C was not set"
+#endif
+
+#ifdef CMAKE_FLAG_ERROR_A
+#error "The flag CMAKE_FLAG_ERROR_A was set"
+#endif
+
+class cmModClass {
+  private:
+    std::string str;
+  public:
+    cmModClass(std::string foo) {
+      str = foo + " World ";
+      str += CMAKE_COMPILER_DEFINE_STR;
+    }
+
+    inline std::string getStr() const { return str; }
+};


### PR DESCRIPTION
Add support for a few select [generator expressions](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html) to handle some common cases (for instance in header-only libraries). This basic framework can be extended to implement even more functions in the future if necessary.