### PR TITLE
wine: Try to get the short paths when generating WINEPATH

### DIFF
--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -52,14 +52,10 @@ def run_exe(exe):
         child_env['PATH'] = (os.pathsep.join(exe.extra_paths + ['']) +
                              child_env['PATH'])
         if exe.exe_runner and mesonlib.substring_is_in_list('wine', exe.exe_runner.get_command()):
-            wine_paths = ['Z:' + p for p in exe.extra_paths]
-            wine_path = ';'.join(wine_paths)
-            # Don't accidentally end with an `;` because that will add the
-            # current directory and might cause unexpected behaviour
-            if 'WINEPATH' in child_env:
-                child_env['WINEPATH'] = wine_path + ';' + child_env['WINEPATH']
-            else:
-                child_env['WINEPATH'] = wine_path
+            child_env['WINEPATH'] = mesonlib.get_wine_shortpath(
+                exe.exe_runner.get_command(),
+                ['Z:' + p for p in exe.extra_paths] + child_env.get('WINEPATH', '').split(';')
+            )
 
     p = subprocess.Popen(cmd_args, env=child_env, cwd=exe.workdir,
                          close_fds=False,


### PR DESCRIPTION
The size of WINEPATH is limited (1024 [until recently]), we
can very easily reach that limit, and even the new one (2048) so
try to keep path as small as possible by using the shortPath
version of paths.

Also assert that we do not reach the new hard limit.

And avoid having duplicates in the list of path.

[until recently]: https://bugs.winehq.org/show_bug.cgi?id=45810