### PR TITLE
Fix cross compilation on OSX

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1050,7 +1050,7 @@ class Compiler:
         if not rpath_paths and not install_rpath and not build_rpath:
             return []
         args = []
-        if mesonlib.is_osx():
+        if get_compiler_is_osx_compiler(self):
             # Ensure that there is enough space for install_name_tool in-place editing of large RPATHs
             args.append('-Wl,-headerpad_max_install_names')
             # @loader_path is the equivalent of $ORIGIN on macOS
@@ -1078,7 +1078,7 @@ class Compiler:
             # linked against local libraries will fail to resolve them.
             args.append('-Wl,-z,origin')
 
-        if mesonlib.is_osx():
+        if get_compiler_is_osx_compiler(self):
             # macOS does not support colon-separated strings in LC_RPATH,
             # hence we have to pass each path component individually
             args += ['-Wl,-rpath,' + rp for rp in all_paths]
@@ -1233,6 +1233,10 @@ class CompilerType(enum.Enum):
 def get_compiler_is_linuxlike(compiler):
     compiler_type = getattr(compiler, 'compiler_type', None)
     return compiler_type and compiler_type.is_standard_compiler
+
+def get_compiler_is_osx_compiler(compiler):
+    compiler_type = getattr(compiler, 'compiler_type', None)
+    return compiler_type and compiler_type.is_osx_compiler
 
 def get_compiler_uses_gnuld(c):
     # FIXME: Perhaps we should detect the linker in the environment?


### PR DESCRIPTION
Do not set -Wl,-headerpad_max_install_names when compiling on OSX for
another platform. It causes linker issues.