### PR TITLE
gtkdoc: Use find_program() to get gtkdoc tools

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -976,6 +976,11 @@ This will become a hard error in the future.''')
                 '--modulename=' + modulename,
                 '--moduleversion=' + moduleversion,
                 '--mode=' + mode]
+        for tool in ['scan', 'scangobj', 'mkdb', 'mkhtml', 'fixxref']:
+            program_name = 'gtkdoc-' + tool
+            program = self.interpreter.find_program_impl(program_name)
+            path = program.held_object.get_path()
+            args.append('--{}={}'.format(program_name, path))
         if namespace:
             args.append('--namespace=' + namespace)
         args += self._unpack_args('--htmlargs=', 'html_args', kwargs)

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -47,6 +47,9 @@ parser.add_argument('--namespace', dest='namespace', default='')
 parser.add_argument('--mode', dest='mode', default='')
 parser.add_argument('--installdir', dest='install_dir')
 parser.add_argument('--run', dest='run', default='')
+for tool in ['scan', 'scangobj', 'mkdb', 'mkhtml', 'fixxref']:
+    program_name = 'gtkdoc-' + tool
+    parser.add_argument('--' + program_name, dest=program_name.replace('-', '_'))
 
 def gtkdoc_run_check(cmd, cwd, library_paths=None):
     if library_paths is None:
@@ -78,7 +81,7 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
                  html_args, scan_args, fixxref_args, mkdb_args,
                  gobject_typesfile, scanobjs_args, run, ld, cc, ldflags, cflags,
                  html_assets, content_files, ignore_headers, namespace,
-                 expand_content_files, mode):
+                 expand_content_files, mode, options):
     print("Building documentation for %s" % module)
 
     src_dir_args = []
@@ -122,7 +125,7 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
         f_abs = os.path.join(doc_src, f)
         shutil.copyfile(f_abs, os.path.join(htmldir, os.path.basename(f_abs)))
 
-    scan_cmd = ['gtkdoc-scan', '--module=' + module] + src_dir_args
+    scan_cmd = [options.gtkdoc_scan, '--module=' + module] + src_dir_args
     if ignore_headers:
         scan_cmd.append('--ignore-headers=' + ' '.join(ignore_headers))
     # Add user-specified arguments
@@ -135,14 +138,15 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
         gobject_typesfile = os.path.join(abs_out, module + '.types')
 
     if gobject_typesfile:
-        scanobjs_cmd = ['gtkdoc-scangobj'] + scanobjs_args + ['--types=' + gobject_typesfile,
-                                                              '--module=' + module,
-                                                              '--run=' + run,
-                                                              '--cflags=' + cflags,
-                                                              '--ldflags=' + ldflags,
-                                                              '--cc=' + cc,
-                                                              '--ld=' + ld,
-                                                              '--output-dir=' + abs_out]
+        scanobjs_cmd = [options.gtkdoc_scangobj] + scanobjs_args
+        scanobjs_cmd += ['--types=' + gobject_typesfile,
+                         '--module=' + module,
+                         '--run=' + run,
+                         '--cflags=' + cflags,
+                         '--ldflags=' + ldflags,
+                         '--cc=' + cc,
+                         '--ld=' + ld,
+                         '--output-dir=' + abs_out]
 
         library_paths = []
         for ldflag in shlex.split(ldflags):
@@ -166,7 +170,7 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
     else: # none
         modeflag = None
 
-    mkdb_cmd = ['gtkdoc-mkdb',
+    mkdb_cmd = [options.gtkdoc_mkdb,
                 '--module=' + module,
                 '--output-format=xml',
                 '--expand-content-files=' + ' '.join(expand_content_files),
@@ -183,7 +187,7 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
     gtkdoc_run_check(mkdb_cmd, abs_out)
 
     # Make HTML documentation
-    mkhtml_cmd = ['gtkdoc-mkhtml',
+    mkhtml_cmd = [options.gtkdoc_mkhtml,
                   '--path=' + ':'.join((doc_src, abs_out)),
                   module,
                   ] + html_args
@@ -195,7 +199,7 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
     gtkdoc_run_check(mkhtml_cmd, htmldir)
 
     # Fix cross-references in HTML files
-    fixref_cmd = ['gtkdoc-fixxref',
+    fixref_cmd = [options.gtkdoc_fixxref,
                   '--module=' + module,
                   '--module-dir=html'] + fixxref_args
     gtkdoc_run_check(fixref_cmd, abs_out)
@@ -256,7 +260,8 @@ def run(args):
         options.ignore_headers.split('@@') if options.ignore_headers else [],
         options.namespace,
         options.expand_content_files.split('@@') if options.expand_content_files else [],
-        options.mode)
+        options.mode,
+        options)
 
     if 'MESON_INSTALL_PREFIX' in os.environ:
         destdir = os.environ.get('DESTDIR', '')


### PR DESCRIPTION
This will allow using gtk-doc as a subproject instead of having to
install it on the system. It also has the side effect of failing at
configuration time with a proper message if gtkdoc is not installed,
instead of failing at build time with a python backtrace.