### PR TITLE
gnome: Use find_program() to get glib-compile-resources

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -105,7 +105,8 @@ class GnomeModule(ExtensionModule):
         self.__print_gresources_warning(state)
         glib_version = self._get_native_glib_version(state)
 
-        cmd = ['glib-compile-resources', '@INPUT@']
+        glib_compile_resources = self.interpreter.find_program_impl('glib-compile-resources')
+        cmd = [glib_compile_resources, '@INPUT@']
 
         source_dirs, dependencies = mesonlib.extract_as_list(kwargs, 'source_dir', 'dependencies', pop=True)
 
@@ -151,7 +152,7 @@ class GnomeModule(ExtensionModule):
         else:
             raise MesonException('Invalid file argument: {!r}'.format(ifile))
 
-        depend_files, depends, subdirs = self._get_gresource_dependencies(
+        depend_files, depends, subdirs = self._get_gresource_dependencies(glib_compile_resources,
             state, ifile, source_dirs, dependencies)
 
         # Make source dirs relative to build dir now
@@ -224,9 +225,9 @@ class GnomeModule(ExtensionModule):
         rv = [target_c, target_h]
         return ModuleReturnValue(rv, rv)
 
-    def _get_gresource_dependencies(self, state, input_file, source_dirs, dependencies):
+    def _get_gresource_dependencies(self, glib_compile_resources, state, input_file, source_dirs, dependencies):
 
-        cmd = ['glib-compile-resources',
+        cmd = [glib_compile_resources.held_object.get_path(),
                input_file,
                '--generate-dependencies']
 


### PR DESCRIPTION
GLib does not currently use override_find_program() for this tool
because it is compiled and would not work in cross build. But this
prepares Meson for when/if GLib will rewrite it in Python.

See https://gitlab.gnome.org/GNOME/glib/issues/1859.