### PR TITLE
Introduce dataonly for the pkgconfig module

### DIFF
--- a/docs/markdown/Pkgconfig-module.md
+++ b/docs/markdown/Pkgconfig-module.md
@@ -56,6 +56,8 @@ keyword arguments.
    D sources referred to by this pkg-config file
 - `uninstalled_variables` used instead of the `variables` keyword argument, when
   generating the uninstalled pkg-config file. Since *0.54.0*
+- `dataonly` field. (*since 0.54.0*) this is used for architecture-independent
+   pkg-config files in projects which also have architecture-dependent outputs.
 
 Since 0.46 a `StaticLibrary` or `SharedLibrary` object can optionally be passed
 as first positional argument. If one is provided a default value will be

--- a/docs/markdown/snippets/pkgconfig_dataonly.md
+++ b/docs/markdown/snippets/pkgconfig_dataonly.md
@@ -1,0 +1,15 @@
+## Introduce dataonly for the pkgconfig module
+This allows users to disable writing out the inbuilt variables to
+the pkg-config file as they might actualy not be required.
+
+One reason to have this is for architecture-independent pkg-config
+files in projects which also have architecture-dependent outputs.
+
+```
+pkgg.generate(
+  name : 'libhello_nolib',
+  description : 'A minimalistic pkgconfig file.',
+  version : libver,
+  dataonly: true
+)
+```

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4968,6 +4968,11 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertEqual(foo_dep.get_pkgconfig_variable('foo', {}), 'bar')
         self.assertPathEqual(foo_dep.get_pkgconfig_variable('datadir', {}), '/usr/data')
 
+        libhello_nolib = PkgConfigDependency('libhello_nolib', env, kwargs)
+        self.assertTrue(libhello_nolib.found())
+        self.assertEqual(libhello_nolib.get_link_args(), [])
+        self.assertEqual(libhello_nolib.get_compile_args(), [])
+
     def test_pkgconfig_gen_deps(self):
         '''
         Test that generated pkg-config files correctly handle dependencies

--- a/test cases/common/47 pkgconfig-gen/installed_files.txt
+++ b/test cases/common/47 pkgconfig-gen/installed_files.txt
@@ -2,3 +2,4 @@ usr/include/simple.h
 usr/lib/pkgconfig/simple.pc
 usr/lib/pkgconfig/libfoo.pc
 usr/lib/pkgconfig/libhello.pc
+usr/lib/pkgconfig/libhello_nolib.pc

--- a/test cases/common/47 pkgconfig-gen/meson.build
+++ b/test cases/common/47 pkgconfig-gen/meson.build
@@ -51,3 +51,10 @@ pkgg.generate(
   description : 'A minimalistic pkgconfig file.',
   version : libver,
 )
+
+pkgg.generate(
+  name : 'libhello_nolib',
+  description : 'A minimalistic pkgconfig file.',
+  version : libver,
+  dataonly: true
+)


### PR DESCRIPTION
This allows users to disable writing out the inbuilt variables to
the pkg-config file as they might actualy not be required.

https://gitlab.freedesktop.org/wayland/weston/issues/269 is a
great example of this.

Fixes #4011