### PR TITLE
travis: do lint before tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ conditions: v1
 
 stages:
 - name: PEP8_lint
-- name: "Host Tests"
+- name: Host_Tests
   if: env(RUN_TESTS_ARGS) != "--cross"
-- name: "Cross Tests"
+- name: Cross_Tests
   if: os = linux AND env(CC) = gcc AND env(RUN_TESTS_ARGS) = "--cross"
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+language: python
 
 branches:
   only:
@@ -6,23 +6,24 @@ branches:
   # Release branches
   - /^[0-9]+\.[0-9]+$/
 
+stages:
+- lint
+- test
+
 os:
-  - linux
-  - osx
+- linux
+- osx
 
 compiler:
-  - gcc
-  - clang
+- gcc
+- clang
 
 env:
-  - MESON_ARGS=""
-  - RUN_TESTS_ARGS="--no-unittests" MESON_ARGS="--unity=on"
-
-language:
-  - cpp
+- MESON_ARGS=""
+- RUN_TESTS_ARGS="--no-unittests" MESON_ARGS="--unity=on"
 
 services:
-  - docker
+- docker
 
 matrix:
   exclude:
@@ -38,29 +39,38 @@ matrix:
     compiler: gcc
     env: RUN_TESTS_ARGS="--cross" MESON_ARGS="--unity=on"
 
+jobs:
+  include:
+  - stage: lint
+    before_install: skip
+    install: python -m pip install pylint flake8
+    script:
+    - flake8
+    - pylint mesonbuild
+
 before_install:
-  - python ./skip_ci.py --base-branch-env=TRAVIS_BRANCH --is-pull-env=TRAVIS_PULL_REQUEST
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt llvm; fi
-    # # Run one macOS build without pkg-config available, and the other (unity=on) with pkg-config
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && "$MESON_ARGS" =~ .*unity=on.* ]]; then brew install pkg-config; fi
-  # Use a Ninja with QuLogic's patch: https://github.com/ninja-build/ninja/issues/1219
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir -p $HOME/tools; curl -L http://nirbheek.in/files/binaries/ninja/macos/ninja -o $HOME/tools/ninja; chmod +x $HOME/tools/ninja; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker pull jpakkane/mesonci:cosmic; fi
+- python ./skip_ci.py --base-branch-env=TRAVIS_BRANCH --is-pull-env=TRAVIS_PULL_REQUEST
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt llvm; fi
+  # # Run one macOS build without pkg-config available, and the other (unity=on) with pkg-config
+- if [[ "$TRAVIS_OS_NAME" == "osx" && "$MESON_ARGS" =~ .*unity=on.* ]]; then brew install pkg-config; fi
+# Use a Ninja with QuLogic's patch: https://github.com/ninja-build/ninja/issues/1219
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir -p $HOME/tools; curl -L http://nirbheek.in/files/binaries/ninja/macos/ninja -o $HOME/tools/ninja; chmod +x $HOME/tools/ninja; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker pull jpakkane/mesonci:cosmic; fi
 
 # We need to copy the current checkout inside the Docker container,
 # because it has the MR id to be tested checked out.
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo FROM jpakkane/mesonci:cosmic > Dockerfile; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo ADD . /root >> Dockerfile; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build -t withgit .; fi
-  - |
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      ci_env=`bash <(curl -s https://codecov.io/env)`
-      docker run --security-opt seccomp:unconfined $ci_env -v ${PWD}/.coverage:/root/.coverage \
-        withgit \
-          /bin/sh -c "cd /root && mkdir -p tools; wget -c http://nirbheek.in/files/binaries/ninja/linux-amd64/ninja -O /root/tools/ninja; chmod +x /root/tools/ninja; CC=$CC CXX=$CXX OBJC=$CC OBJCXX=$CXX PATH=/root/tools:$PATH MESON_FIXED_NINJA=1 ./run_tests.py $RUN_TESTS_ARGS -- $MESON_ARGS && chmod -R a+rwX .coverage"
-    fi
-  # Ensure that llvm is added after $PATH, otherwise the clang from that llvm install will be used instead of the native apple clang.
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) CPPFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib OBJC=$CC OBJCXX=$CXX PATH=$HOME/tools:/usr/local/opt/qt/bin:$PATH:$(brew --prefix llvm)/bin MESON_FIXED_NINJA=1 ./run_tests.py $RUN_TESTS_ARGS --backend=ninja -- $MESON_ARGS ; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo FROM jpakkane/mesonci:cosmic > Dockerfile; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then echo ADD . /root >> Dockerfile; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker build -t withgit .; fi
+- |
+  if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    ci_env=`bash <(curl -s https://codecov.io/env)`
+    docker run --security-opt seccomp:unconfined $ci_env -v ${PWD}/.coverage:/root/.coverage \
+      withgit \
+        /bin/sh -c "cd /root && mkdir -p tools; wget -c http://nirbheek.in/files/binaries/ninja/linux-amd64/ninja -O /root/tools/ninja; chmod +x /root/tools/ninja; CC=$CC CXX=$CXX OBJC=$CC OBJCXX=$CXX PATH=/root/tools:$PATH MESON_FIXED_NINJA=1 ./run_tests.py $RUN_TESTS_ARGS -- $MESON_ARGS && chmod -R a+rwX .coverage"
+  fi
+# Ensure that llvm is added after $PATH, otherwise the clang from that llvm install will be used instead of the native apple clang.
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) CPPFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib OBJC=$CC OBJCXX=$CXX PATH=$HOME/tools:/usr/local/opt/qt/bin:$PATH:$(brew --prefix llvm)/bin MESON_FIXED_NINJA=1 ./run_tests.py $RUN_TESTS_ARGS --backend=ninja -- $MESON_ARGS ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ conditions: v1
 
 stages:
 - name: PEP8_lint
-- name: Host_Tests
+- name: test
   if: env(RUN_TESTS_ARGS) != "--cross"
 - name: Cross_Tests
   if: os = linux AND env(CC) = gcc AND env(RUN_TESTS_ARGS) = "--cross"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: minimal
 
 branches:
   only:
@@ -6,44 +6,38 @@ branches:
   # Release branches
   - /^[0-9]+\.[0-9]+$/
 
+# https://docs.travis-ci.com/user/conditions-v1
+conditions: v1
+
 stages:
-- lint
-- test
+- name: PEP8_lint
+- name: "Host Tests"
+  if: env(RUN_TESTS_ARGS) != "--cross"
+- name: "Cross Tests"
+  if: os = linux AND env(CC) = gcc AND env(RUN_TESTS_ARGS) = "--cross"
 
 os:
 - linux
 - osx
 
-compiler:
-- gcc
-- clang
-
 env:
-- MESON_ARGS=""
-- RUN_TESTS_ARGS="--no-unittests" MESON_ARGS="--unity=on"
+- MESON_ARGS="" CC=gcc CXX=g++
+- MESON_ARGS="" CC=clang CXX=clang++
+- RUN_TESTS_ARGS="--no-unittests" MESON_ARGS="--unity=on" CC=gcc CXX=g++
+- RUN_TESTS_ARGS="--no-unittests" MESON_ARGS="--unity=on" CC=clang CXX=clang++
+- RUN_TESTS_ARGS="--cross" CC=gcc CXX=g++
+- RUN_TESTS_ARGS="--cross" MESON_ARGS="--unity=on" CC=gcc CXX=g++
 
 services:
 - docker
 
-matrix:
-  exclude:
-  # On OS X gcc is just a wrapper around clang, so don't waste time testing that
-  - os: osx
-    compiler: gcc
-  include:
-  # Test cross builds separately, they do not use the global compiler
-  - os: linux
-    compiler: gcc
-    env: RUN_TESTS_ARGS="--cross"
-  - os: linux
-    compiler: gcc
-    env: RUN_TESTS_ARGS="--cross" MESON_ARGS="--unity=on"
 
 jobs:
   include:
-  - stage: lint
+  - stage: PEP8_lint
+    language: python
     before_install: skip
-    install: python -m pip install pylint flake8 flake8-blind-except flake8-builtins flake8-bugbear
+    install: python3 -m pip install pylint flake8 flake8-blind-except flake8-builtins flake8-bugbear
     script:
     - flake8
     - pylint mesonbuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,11 @@ jobs:
     - flake8
     - pylint mesonbuild
   - stage: test
+    before_install: ./before_install
+    script: ./script
   - stage: cross
+    before_install: ./before_install
+    script: ./script
 
 before_install:
 - python ./skip_ci.py --base-branch-env=TRAVIS_BRANCH --is-pull-env=TRAVIS_PULL_REQUEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
   include:
   - stage: lint
     before_install: skip
-    install: python -m pip install pylint flake8
+    install: python -m pip install pylint flake8 flake8-blind-except flake8-builtins flake8-bugbear
     script:
     - flake8
     - pylint mesonbuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ branches:
 conditions: v1
 
 stages:
-- name: PEP8_lint
+- name: lint
 - name: test
   if: env(RUN_TESTS_ARGS) != "--cross"
-- name: Cross_Tests
+- name: cross
   if: os = linux AND env(CC) = gcc AND env(RUN_TESTS_ARGS) = "--cross"
 
 os:
@@ -34,13 +34,15 @@ services:
 
 jobs:
   include:
-  - stage: PEP8_lint
+  - stage: lint
     language: python
     before_install: skip
     install: python3 -m pip install pylint flake8 flake8-blind-except flake8-builtins flake8-bugbear
     script:
     - flake8
     - pylint mesonbuild
+  - stage: test
+  - stage: cross
 
 before_install:
 - python ./skip_ci.py --base-branch-env=TRAVIS_BRANCH --is-pull-env=TRAVIS_PULL_REQUEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,9 @@ branches:
 conditions: v1
 
 stages:
-- name: lint
-- name: test
-  if: env(RUN_TESTS_ARGS) != "--cross"
-- name: cross
-  if: os = linux AND env(CC) = gcc AND env(RUN_TESTS_ARGS) = "--cross"
+- lint
+- test
+- cross
 
 os:
 - linux
@@ -42,9 +40,11 @@ jobs:
     - flake8
     - pylint mesonbuild
   - stage: test
+    if: env(RUN_TESTS_ARGS) != "--cross"
     before_install: ./before_install
     script: ./script
   - stage: cross
+    if: os = linux AND env(CC) = gcc AND env(RUN_TESTS_ARGS) = "--cross"
     before_install: ./before_install
     script: ./script
 

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -61,6 +61,8 @@ __all__ = [
     'GnuDCompiler',
     'GnuFortranCompiler',
     'ElbrusFortranCompiler',
+    'EmscriptenCCompiler',
+    'EmscriptenCPPCompiler',
     'FlangFortranCompiler',
     'GnuObjCCompiler',
     'GnuObjCPPCompiler',


### PR DESCRIPTION
Intent is to do fundamental checks (syntax errors, PEP8 fails) before running the full phalanx of tests. If this is successful, would do likewise for Azure (where it's easier to do).

Example: Meson failed PEP8 check, and so didn't run rest of Travis jobs: https://travis-ci.org/mesonbuild/meson/builds/568872730

Then, after correcting the PEP8 style, the Lint check once again runs first, then after passing PEP8, the concurrent test jobs start: https://travis-ci.org/mesonbuild/meson/builds/568881822