### PR TITLE
WIP: Change default missing to make copy

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -138,9 +138,14 @@ class Properties(HasEnvVarFallback):
         return self.properties.get('sys_root', None)
 
     def __eq__(self, other: typing.Any) -> 'typing.Union[bool, NotImplemented]':
-        if isinstance(other, type(self)):
-            return self.properties == other.properties
-        return NotImplemented
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.properties is other.properties
+
+    def __ne__(self, other: typing.Any) -> 'typing.Union[bool, NotImplemented]':
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return not self.__eq__(other)
 
     # TODO consider removing so Properties is less freeform
     def __getitem__(self, key: str) -> typing.Any:
@@ -163,7 +168,7 @@ class MachineInfo:
         self.is_64_bit = cpu_family in CPU_FAMILES_64_BIT  # type: bool
 
     def __eq__(self, other: typing.Any) -> 'typing.Union[bool, NotImplemented]':
-        if self.__class__ is not other.__class__:
+        if not isinstance(other, type(self)):
             return NotImplemented
         return \
             self.system == other.system and \
@@ -172,7 +177,7 @@ class MachineInfo:
             self.endian == other.endian
 
     def __ne__(self, other: typing.Any) -> 'typing.Union[bool, NotImplemented]':
-        if self.__class__ is not other.__class__:
+        if not isinstance(other, type(self)):
             return NotImplemented
         return not self.__eq__(other)
 
@@ -294,6 +299,16 @@ class BinaryTable(HasEnvVarFallback):
         'qmake': 'QMAKE',
         'pkgconfig': 'PKG_CONFIG',
     }  # type: typing.Dict[str, str]
+
+    def __eq__(self, other: typing.Any) -> 'typing.Union[bool, NotImplemented]':
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return self.binaries is other.binaries
+
+    def __ne__(self, other: typing.Any) -> 'typing.Union[bool, NotImplemented]':
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return not self.__eq__(other)
 
     @staticmethod
     def detect_ccache() -> typing.List[str]:

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -19,6 +19,7 @@ import stat
 import time
 import platform, subprocess, operator, os, shutil, re
 import collections
+import copy
 from enum import Enum
 from functools import lru_cache
 import typing
@@ -403,7 +404,7 @@ class PerMachineDefaultable(PerMachine[typing.Optional[_T]]):
         """
         freeze = PerMachine(self.build, self.host)
         if freeze.host is None:
-            freeze.host = freeze.build
+            freeze.host = copy.copy(freeze.build)
         return freeze
 
 
@@ -422,9 +423,9 @@ class PerThreeMachineDefaultable(PerMachineDefaultable, PerThreeMachine[typing.O
         """
         freeze = PerThreeMachine(self.build, self.host, self.target)
         if freeze.host is None:
-            freeze.host = freeze.build
+            freeze.host = copy.copy(freeze.build)
         if freeze.target is None:
-            freeze.target = freeze.host
+            freeze.target = copy.copy(freeze.host)
         return freeze
 
 


### PR DESCRIPTION
This, and good __eq__ along with, are needed for if the defaulted
configurations are mutated. A future PR in fact relies on that, but it's
probably good for robustness anyways.

Then again, check out https://github.com/mesonbuild/meson/issues/5792 . This sutbley changes the semantics and I'd like to be more explicit about the mandated (via files) vs inferred cases.

I'm at a loss debugging a few failures (and short on time), and would much appreciate a fresh set of eyes.

CC @dcbaker @TheQwertiest 