### PR TITLE
Put native file before cross file in options list

### DIFF
--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -32,14 +32,14 @@ from .mesonlib import MesonException
 
 def add_arguments(parser):
     coredata.register_builtin_arguments(parser)
-    parser.add_argument('--cross-file',
-                        default=[],
-                        action='append',
-                        help='File describing cross compilation environment.')
     parser.add_argument('--native-file',
                         default=[],
                         action='append',
                         help='File containing overrides for native compilation environment.')
+    parser.add_argument('--cross-file',
+                        default=[],
+                        action='append',
+                        help='File describing cross compilation environment.')
     parser.add_argument('-v', '--version', action='version',
                         version=coredata.version)
     parser.add_argument('--profile-self', action='store_true', dest='profile',

--- a/run_tests.py
+++ b/run_tests.py
@@ -71,11 +71,11 @@ class FakeCompilerOptions:
 def get_fake_options(prefix=''):
     import argparse
     opts = argparse.Namespace()
+    opts.native_file = []
     opts.cross_file = None
     opts.wrap_mode = None
     opts.prefix = prefix
     opts.cmd_line_options = {}
-    opts.native_file = []
     return opts
 
 def get_fake_env(sdir='', bdir=None, prefix='', opts=None):


### PR DESCRIPTION
I think this makes more sense by matching how build comes before host.
Native builds are also more common than cross builds.