### PR TITLE
Add blocks dependency

### DIFF
--- a/ciimage/Dockerfile
+++ b/ciimage/Dockerfile
@@ -24,6 +24,7 @@ RUN sed -i '/^#\sdeb-src /s/^#//' "/etc/apt/sources.list" \
 && apt-get -y install libgpgme-dev \
 && apt-get -y install libhdf5-dev \
 && apt-get -y install libboost-python-dev \
+&& apt-get -y install libblocksruntime-dev \
 && dub fetch urld && dub build urld --compiler=gdc \
 && dub fetch dubtestproject \
 && dub build dubtestproject:test1 --compiler=ldc2 \

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -246,6 +246,16 @@ dep = dependency('appleframeworks', modules : 'foundation')
 
 These dependencies can never be found for non-OSX hosts.
 
+## Blocks
+
+Enable support for Clang's blocks extension.
+
+```meson
+dep = dependency('blocks')
+```
+
+*(added 0.52.0)*
+
 ## Boost
 
 Boost is not a single dependency but rather a group of different

--- a/docs/markdown/Release-notes-for-0.52.0.md
+++ b/docs/markdown/Release-notes-for-0.52.0.md
@@ -9,3 +9,7 @@ short-description: Release notes for 0.52.0
 
 Added the function `is_disabler(var)`. Returns true if a variable is a disabler
 and false otherwise.
+
+## Add blocks dependency
+
+Add `dependency('blocks')` to use the Clang blocks extension.

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -18,7 +18,7 @@ from .base import (  # noqa: F401
     ExternalDependency, NotFoundDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
     PkgConfigDependency, CMakeDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language)
 from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDependency
-from .misc import (CoarrayDependency, HDF5Dependency, MPIDependency, NetCDFDependency, OpenMPDependency, Python3Dependency, ThreadDependency, PcapDependency, CupsDependency, LibWmfDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency)
+from .misc import (BlocksDependency, CoarrayDependency, HDF5Dependency, MPIDependency, NetCDFDependency, OpenMPDependency, Python3Dependency, ThreadDependency, PcapDependency, CupsDependency, LibWmfDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency)
 from .platform import AppleFrameworks
 from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, VulkanDependency
 
@@ -31,6 +31,7 @@ packages.update({
     'valgrind': ValgrindDependency,
 
     # From misc:
+    'blocks': BlocksDependency,
     'boost': BoostDependency,
     'coarray': CoarrayDependency,
     'mpi': MPIDependency,

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -412,6 +412,39 @@ class ThreadDependency(ExternalDependency):
             self.link_args = self.clib_compiler.thread_link_flags(environment)
 
 
+class BlocksDependency(ExternalDependency):
+    def __init__(self, environment, kwargs):
+        super().__init__('blocks', environment, None, kwargs)
+        self.name = 'blocks'
+        self.is_found = False
+
+        if self.env.machines[self.for_machine].is_darwin():
+            self.compile_args = []
+            self.link_args = []
+        else:
+            self.compile_args = ['-fblocks']
+            self.link_args = ['-lBlocksRuntime']
+
+            if not self.clib_compiler.has_header('Block.h', '', environment, disable_cache=True) or \
+               not self.clib_compiler.find_library('BlocksRuntime', environment, []):
+                mlog.log(mlog.red('ERROR:'), 'BlocksRuntime not found.')
+                return
+
+        source = '''
+            int main(int argc, char **argv)
+            {
+                int (^callback)(void) = ^ int (void) { return 0; };
+                return callback();
+            }'''
+
+        with self.clib_compiler.compile(source, extra_args=self.compile_args + self.link_args) as p:
+            if p.returncode != 0:
+                mlog.log(mlog.red('ERROR:'), 'Compiler does not support blocks extension.')
+                return
+
+            self.is_found = True
+
+
 class Python3Dependency(ExternalDependency):
     def __init__(self, environment, kwargs):
         super().__init__('python3', environment, None, kwargs)

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -523,6 +523,10 @@ def skippable(suite, test):
     if test.endswith('14 fortran links c'):
         return True
 
+    # Blocks are not supported on all compilers
+    if test.endswith('29 blocks'):
+        return True
+
     # No frameworks test should be skipped on linux CI, as we expect all
     # prerequisites to be installed
     if mesonlib.is_linux():

--- a/test cases/frameworks/29 blocks/main.c
+++ b/test cases/frameworks/29 blocks/main.c
@@ -1,0 +1,6 @@
+int main(int argc, char **argv)
+{
+    int (^callback)(void) = ^ int (void) { return 0; };
+
+    return callback();
+}

--- a/test cases/frameworks/29 blocks/meson.build
+++ b/test cases/frameworks/29 blocks/meson.build
@@ -1,0 +1,12 @@
+project('blocks-dependency', 'c')
+
+id = meson.get_compiler('c').get_id()
+if id != 'clang' or build_machine.system() == 'windows'
+  error('MESON_SKIP_TEST: Only clang on unix-like systems supports the blocks extension.')
+endif
+
+exe = executable('main', 'main.c',
+  dependencies: dependency('blocks')
+)
+
+test('test-blocks', exe)


### PR DESCRIPTION
This allows easily enabling the blocks clang extension.

libblocksruntime-dev will need to be added to CI.