### PR TITLE
gnome: Handle overriden g-ir-scanner

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -62,6 +62,10 @@ def stringifyUserArguments(args):
     raise InvalidArguments('Function accepts only strings, integers, lists and lists thereof.')
 
 
+class OverrideProgram(dependencies.ExternalProgram):
+    pass
+
+
 class FeatureOptionHolder(InterpreterObject, ObjectHolder):
     def __init__(self, env, name, option):
         InterpreterObject.__init__(self)
@@ -1901,7 +1905,7 @@ class MesonMain(InterpreterObject):
                                         self.interpreter.environment.build_dir)
             if not os.path.exists(abspath):
                 raise InterpreterException('Tried to override %s with a file that does not exist.' % name)
-            exe = dependencies.ExternalProgram(abspath)
+            exe = OverrideProgram(abspath)
         if not isinstance(exe, (dependencies.ExternalProgram, build.Executable)):
             raise InterpreterException('Second argument must be an external program or executable.')
         self.interpreter.add_find_program_override(name, exe)

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -54,8 +54,14 @@ def gir_has_option(intr_obj, option):
 
     _gir_has_option[option] = False
     try:
-        g_ir_scanner = intr_obj.find_program_impl('g-ir-scanner').get_command()
-        opts = Popen_safe(g_ir_scanner + ['--help'], stderr=subprocess.STDOUT)[1]
+        g_ir_scanner = intr_obj.find_program_impl('g-ir-scanner')
+        # Handle overriden g-ir-scanner
+        if isinstance(getattr(g_ir_scanner, "held_object", g_ir_scanner), interpreter.OverrideProgram):
+            assert option in ['--extra-library', '--sources-top-dirs']
+            _gir_has_option[option] = True
+            return True
+
+        opts = Popen_safe(g_ir_scanner.get_command() + ['--help'], stderr=subprocess.STDOUT)[1]
         _gir_has_option[option] = option in opts
     except (MesonException, FileNotFoundError, subprocess.CalledProcessError):
         pass


### PR DESCRIPTION
When g-ir-scanner is overriden, we can't call it at configure time
but we know what options are avalaible (as it started using meson
after checked options where added) so do not try to call it to retrieve
the version as it will fail.

Also see https://github.com/mesonbuild/meson/issues/3442