### PR TITLE
Fix CCRX linking external dependencies

### DIFF
--- a/mesonbuild/compilers/mixins/ccrx.py
+++ b/mesonbuild/compilers/mixins/ccrx.py
@@ -148,6 +148,8 @@ class CcrxCompiler:
                 continue
             elif i.startswith('-L'):
                 continue
+            elif not i.startswith('-lib=') and i.endswith(('.a', '.lib')):
+                i = '-lib=' + i
             result.append(i)
         return result
 


### PR DESCRIPTION
The CCRX linker requires libs to be linked with the `-lib=` prefix. This is working for internal static libraries but external dependencies go through a different code path.

I've added as part of the `unix_args_to_native`, I've added detection of libraries (`.lib` or `.a`) to prefix them with `-lib=` if they don't have it already.

Feel free to suggest a better way at fixing this if any 😃 