### PR TITLE
[RFC] Fix cross-compilation of D programs

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2855,7 +2855,7 @@ external dependencies (including libraries) must go to "dependencies".''')
                        mlog.bold(' '.join(comp.get_exelist())), comp.get_version_string())
             if comp.linker is not None:
                 logger_fun(comp.get_display_language(), 'linker for the', machine_name, 'machine:',
-                           mlog.bold(comp.linker.id), comp.linker.version)
+                           mlog.bold(' '.join(comp.linker.get_exelist())), comp.linker.id, comp.linker.version)
             self.build.ensure_static_linker(comp)
 
         langs = self.coredata.compilers[for_machine].keys()


### PR DESCRIPTION
Since version 9.1, GCC provides support for the D programming language.
Thus it is easy to build a cross-compiler for D, such as aarch64-unknown-linux-gnu-gdc.

However to cross-compile a Meson project using D, using a cross build
definition such as the following is not enough:

```
[binaries]
d = '/path/to/aarch64-unknown-linux-gnu-gdc'
exe_wrapper = '/path/to/qemu-aarch64-static'

[properties]
needs_exe_wrapper = true

[host_machine]
system = 'linux'
cpu_family = 'aarch64'
cpu = 'cortex-a53'
endian = 'little'
```

Indeed, "exe_wrapper" is not be taken into account. Build will fail
with:

```
Executables created by D compiler /path/to/aarch64-uknown-linux-gnu-gdc are not runnable.
```

This patch fixes this by reworking:

- detect_d_compiler() to properly get exe_wrapper and D compilers and
detect the one available.
- Dcompiler to properly handle exe_wrapper.