### PR TITLE
Windows test cases and workaround for /LIBPATH: and  -LIBPATH: in .pc files

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -644,6 +644,9 @@ class PkgConfigDependency(ExternalDependency):
         rc, out = p.returncode, out.strip()
         call = ' '.join(cmd)
         mlog.debug("Called `{}` -> {}\n{}".format(call, rc, out))
+        # Hack to support alternate spelling of /LIBPATH:
+        out = out.replace('-LIBPATH:', '/LIBPATH:')
+        out = out.replace('-libpath:', '/libpath:')
         return rc, out
 
     def _call_pkgbin(self, args, env=None):
@@ -724,6 +727,7 @@ class PkgConfigDependency(ExternalDependency):
         Libraries that are provided by the toolchain or are not found by
         find_library() will be added with -L -l pairs.
         '''
+
         # Library paths should be safe to de-dup
         #
         # First, figure out what library paths to use. Originally, we were
@@ -846,6 +850,7 @@ class PkgConfigDependency(ExternalDependency):
         if ret != 0:
             raise DependencyException('Could not generate libs for %s:\n\n%s' %
                                       (self.name, out_raw))
+
         self.link_args, self.raw_link_args = self._search_libs(out, out_raw)
 
     def get_pkgconfig_variable(self, variable_name, kwargs):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4245,6 +4245,23 @@ class WindowsTests(BasePlatformTests):
             return
         self.build()
 
+    @skipIfNoPkgconfig
+    def test_pkgconfig_win_libpath(self):
+        testdir = os.path.join(self.unit_test_dir, '67 pkgconfig win libpath')
+        pkg_dir = os.path.join(testdir, 'pkgconfig')
+        self.assertTrue(os.path.exists(os.path.join(pkg_dir, 'libwinpath.pc')))
+
+        env = get_fake_env(testdir, self.builddir, self.prefix)
+        env.coredata.set_options({'pkg_config_path': pkg_dir}, subproject='')
+        kwargs = {'required': True, 'silent': True}
+        libwinpath_dep = PkgConfigDependency('libwinpath', env, kwargs)
+        self.assertTrue(libwinpath_dep.found())
+
+        # Ensure link_args are properly quoted
+        libpath = 'C:/opt/blort/lib'
+        link_args = ['/LIBPATH:' + libpath, '-lwinpath']
+        self.assertEqual(libwinpath_dep.get_link_args(), link_args)
+
 @unittest.skipUnless(is_osx(), "requires Darwin")
 class DarwinTests(BasePlatformTests):
     '''

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4257,9 +4257,24 @@ class WindowsTests(BasePlatformTests):
         libwinpath_dep = PkgConfigDependency('libwinpath', env, kwargs)
         self.assertTrue(libwinpath_dep.found())
 
-        # Ensure link_args are properly quoted
         libpath = 'C:/opt/blort/lib'
         link_args = ['/LIBPATH:' + libpath, '-lwinpath']
+        self.assertEqual(libwinpath_dep.get_link_args(), link_args)
+
+    @skipIfNoPkgconfig
+    def test_pkgconfig_alt_win_libpath(self):
+        testdir = os.path.join(self.unit_test_dir, '68 pkgconfig alt win libpath')
+        pkg_dir = os.path.join(testdir, 'pkgconfig')
+        self.assertTrue(os.path.exists(os.path.join(pkg_dir, 'libwinpath.pc')))
+
+        env = get_fake_env(testdir, self.builddir, self.prefix)
+        env.coredata.set_options({'pkg_config_path': pkg_dir}, subproject='')
+        kwargs = {'required': True, 'silent': True}
+        libwinpath_dep = PkgConfigDependency('libwinpath', env, kwargs)
+        self.assertTrue(libwinpath_dep.found())
+
+        libpath = 'C:/opt/blort/lib'
+        link_args = ['-LIBPATH:' + libpath, '-lwinpath']
         self.assertEqual(libwinpath_dep.get_link_args(), link_args)
 
 @unittest.skipUnless(is_osx(), "requires Darwin")

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4274,7 +4274,8 @@ class WindowsTests(BasePlatformTests):
         self.assertTrue(libwinpath_dep.found())
 
         libpath = 'C:/opt/blort/lib'
-        link_args = ['-LIBPATH:' + libpath, '-lwinpath']
+        # Hack: let meson munge -LIBPATH: to /LIBPATH:
+        link_args = ['/LIBPATH:' + libpath, '-lwinpath']
         self.assertEqual(libwinpath_dep.get_link_args(), link_args)
 
 @unittest.skipUnless(is_osx(), "requires Darwin")

--- a/test cases/unit/67 pkgconfig win libpath/pkgconfig/libwinpath.pc
+++ b/test cases/unit/67 pkgconfig win libpath/pkgconfig/libwinpath.pc
@@ -1,0 +1,9 @@
+prefix=C:/opt/blort
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+
+Name: Windows libpath
+Description: Windows libpath library
+Version: 0.0.1
+Libs: /LIBPATH:${libdir} -lwinpath
+Cflags:

--- a/test cases/unit/68 pkgconfig alt win libpath/pkgconfig/libwinpath.pc
+++ b/test cases/unit/68 pkgconfig alt win libpath/pkgconfig/libwinpath.pc
@@ -1,0 +1,9 @@
+prefix=C:/opt/blort
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+
+Name: Windows libpath
+Description: Windows libpath library
+Version: 0.0.1
+Libs: -LIBPATH:${libdir} -lwinpath
+Cflags:


### PR DESCRIPTION
On my system (which has a windows pkg-config installed), tests now pass.

To illustrate https://github.com/mesonbuild/meson/issues/5811 and provide a quick workaround if anyone else needs it.