### PR TITLE
PGI compiler fixes

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -29,7 +29,8 @@ from .. import build
 from .. import mlog
 from .. import dependencies
 from .. import compilers
-from ..compilers import Compiler, CompilerArgs, CCompiler, VisualStudioLikeCompiler, FortranCompiler
+from ..compilers import (Compiler, CompilerArgs, CCompiler, FortranCompiler,
+                         PGICCompiler, VisualStudioLikeCompiler)
 from ..linkers import ArLinker
 from ..mesonlib import (
     File, LibType, MachineChoice, MesonException, OrderedSet, PerMachine, ProgressBar
@@ -232,6 +233,9 @@ class NinjaBackend(backends.Backend):
             # IFort on windows is MSVC like, but doesn't have /showincludes
             if isinstance(compiler, FortranCompiler):
                 continue
+            if isinstance(compiler, PGICCompiler) and mesonlib.is_windows():
+                # for the purpose of this function, PGI doesn't act enough like MSVC
+                return open(tempfilename, 'a', encoding='utf-8')
             if isinstance(compiler, VisualStudioLikeCompiler):
                 break
         else:

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -97,3 +97,7 @@ class PGICompiler:
                     '-I{}'.format(hdr.parent)]
         else:
             return []
+
+    def thread_flags(self, env):
+        # PGI cannot accept -pthread, it's already threaded
+        return []

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -56,7 +56,7 @@ class PGICompiler:
 
     def get_pic_args(self) -> typing.List[str]:
         # PGI -fPIC is Linux only.
-        if self.compiler_type.is_linux_compiler():
+        if self.compiler_type.is_standard_compiler:
             return ['-fPIC']
         return []
 

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -740,17 +740,29 @@ class PGIDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
         # PGI -shared is Linux only.
         if mesonlib.is_windows():
             return ['-Bdynamic', '-Mmakedll']
-        elif mesonlib.is_linux:
+        elif mesonlib.is_linux():
             return ['-shared']
         return []
 
     def build_rpath_args(self, env: 'Environment', build_dir: str, from_dir: str,
                          rpath_paths: str, build_rpath: str,
                          install_rpath: str) -> typing.List[str]:
-        if env.machines[self.for_machine].is_windows():
+        if not env.machines[self.for_machine].is_windows():
             return ['-R' + os.path.join(build_dir, p) for p in rpath_paths]
         return []
 
+
+class PGIStaticLinker(StaticLinker):
+    def __init__(self, exelist: typing.List[str]):
+        super().__init__(exelist)
+        self.id = 'ar'
+        self.std_args = ['-r']
+
+    def get_std_link_args(self) -> typing.List[str]:
+        return self.std_args
+
+    def get_output_args(self, target: str) -> typing.List[str]:
+        return [target]
 
 class VisualStudioLikeLinkerMixin:
 

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -114,7 +114,8 @@ def get_relative_files_list_from_dir(fromdir: Path) -> typing.List[Path]:
 
 def platform_fix_name(fname: str, compiler, env) -> str:
     # canonicalize compiler
-    if compiler in {'clang-cl', 'intel-cl'}:
+    if (compiler in {'clang-cl', 'intel-cl'} or
+       (env.machines.host.is_windows() and compiler == 'pgi')):
         canonical_compiler = 'msvc'
     else:
         canonical_compiler = compiler


### PR DESCRIPTION
The new linker layout by dcbaker made finding and fixing these issues easier--these issues generally existed since PGI was added months ago.
Before this, PGI Windows C programs were not buildable (I had previously focused on Fortran-only projects for PGI where these bugs were not invoked).

* corrected use of internal PGI-specific functions and methods (some bugfixes)
* added PGIStaticLinker
* added that PGI on Windows has an `ar`-like wrapper for Link/Lib

* allowed several `common` tests to Skip instead of Fail when C++ compiler not available, such as PGI for Windows

PGI's solution for those needing to use C++ with PGI on Windows appears to be to have the user convert C++ code to C (!)
PGI's Windows custom shell environment does not accommodate MSVC.

