### PR TITLE
Intel-Cl tests: increase robustness of Windows Intel compilers detection

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -69,8 +69,8 @@ def _using_intelcl() -> bool:
     if not os.environ.get('MKLROOT', '').strip():
         return False
     if (os.environ.get('CC') == 'icl' or
-       os.environ.get('CXX') == 'icl' or
-       os.environ.get('FC') == 'ifort'):
+            os.environ.get('CXX') == 'icl' or
+            os.environ.get('FC') == 'ifort'):
         return True
     # Intel-Cl users might not have the CC,CXX,FC envvars set,
     # but because they're in Intel shell, the exe's below are on PATH

--- a/test cases/fortran/13 coarray/meson.build
+++ b/test cases/fortran/13 coarray/meson.build
@@ -9,10 +9,18 @@ if ['pgi', 'flang'].contains(fcid)
 endif
 
 # coarray is required because single-image fallback is an intrinsic feature
-coarray = dependency('coarray', required : true)
+coarray = dependency('coarray')
+
+# check coarray, because user might not have all the library stack installed correctly
+# for example, conflicting library/compiler versions on PATH
+# this has to invoke a run of "sync all" to verify the MPI stack is functioning,
+# particularly for dynamic linking
+coarray_ok = fc.run('sync all; end', dependencies: coarray, name: 'Coarray link & run').returncode() == 0
+if not coarray_ok
+  error('MESON_SKIP_TEST: The coarray stack (including MPI) did not link correctly so that a simple test could run.')
+endif
 
 exe = executable('hello', 'main.f90',
   dependencies : coarray)
 
 test('Coarray hello world', exe)
-


### PR DESCRIPTION
More robust detection of Intel compilers in Windows was needed, as provided in run_tests:_using_intelcl()

also, runtime check for test cases/fortran/13 coarray was added as in general, the MPI stack needs to be exercised to verify Fortran coarrays can be used, especially for dynamically linked MPI such as Intel-Cl