### PR TITLE
Fix type annotations in linkers for python < 3.5.4

### DIFF
--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -664,7 +664,7 @@ class CcrxDynamicLinker(DynamicLinker):
     def get_output_args(self, outputname: str) -> typing.List[str]:
         return ['-output=%s' % outputname]
 
-    def get_search_args(self, dirname: str) -> typing.NoReturn:
+    def get_search_args(self, dirname: str) -> 'typing.NoReturn':
         raise EnvironmentError('rlink.exe does not have a search dir argument')
 
     def get_allow_undefined_args(self) -> typing.List[str]:
@@ -688,7 +688,7 @@ class ArmDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
     def get_accepts_rsp(self) -> bool:
         return False
 
-    def get_std_shared_lib_args(self) -> typing.NoReturn:
+    def get_std_shared_lib_args(self) -> 'typing.NoReturn':
         raise mesonlib.MesonException('The Arm Linkers do not support shared libraries')
 
     def get_allow_undefined_args(self) -> typing.List[str]:


### PR DESCRIPTION
Before python 3.5.4 typing didn't have the NoReturn type, use a string
to forward declare it.

aside: I can't wait to be able to use python 3.7's
__future__.annotations and not have to deal wit hthis anymore.

Fixes #5822