### PR TITLE
Remove compiler type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .mypy_cache/
+.pytest_cache/
 /.project
 /.pydevproject
 /.settings

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -34,6 +34,8 @@ __all__ = [
     'lang_suffixes',
     'sort_clink',
 
+    'AppleClangCCompiler',
+    'AppleClangCPPCompiler',
     'ArmCCompiler',
     'ArmCPPCompiler',
     'ArmclangCCompiler',
@@ -119,6 +121,7 @@ from .compilers import (
 )
 from .c import (
     CCompiler,
+    AppleClangCCompiler,
     ArmCCompiler,
     ArmclangCCompiler,
     ClangCCompiler,
@@ -134,6 +137,7 @@ from .c import (
 )
 from .cpp import (
     CPPCompiler,
+    AppleClangCPPCompiler,
     ArmCPPCompiler,
     ArmclangCPPCompiler,
     ClangCPPCompiler,

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -14,7 +14,6 @@
 
 # Public symbols for compilers sub-package when using 'from . import compilers'
 __all__ = [
-    'CompilerType',
     'Compiler',
 
     'all_languages',
@@ -99,7 +98,6 @@ __all__ = [
 
 # Bring symbols from each module into compilers sub-package namespace
 from .compilers import (
-    CompilerType,
     Compiler,
     all_languages,
     base_options,

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -75,6 +75,10 @@ class CCompiler(CLikeCompiler, Compiler):
 
 
 class ClangCCompiler(ClangCompiler, CCompiler):
+
+    _C17_VERSION = '>=10.0.0'
+    _C18_VERSION = '>=11.0.0'
+
     def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
         CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
         ClangCompiler.__init__(self, compiler_type)
@@ -90,12 +94,10 @@ class ClangCCompiler(ClangCompiler, CCompiler):
         g_stds = ['gnu89', 'gnu99', 'gnu11']
         # https://releases.llvm.org/6.0.0/tools/clang/docs/ReleaseNotes.html
         # https://en.wikipedia.org/wiki/Xcode#Latest_versions
-        v = '>=10.0.0' if self.compiler_type is CompilerType.CLANG_OSX else '>=6.0.0'
-        if version_compare(self.version, v):
+        if version_compare(self.version, self._C17_VERSION):
             c_stds += ['c17']
             g_stds += ['gnu17']
-        v = '>=11.0.0' if self.compiler_type is CompilerType.CLANG_OSX else '>=8.0.0'
-        if version_compare(self.version, v):
+        if version_compare(self.version, self._C18_VERSION):
             c_stds += ['c18']
             g_stds += ['gnu18']
         opts.update({'c_std': coredata.UserComboOption('C language standard to use',
@@ -112,6 +114,18 @@ class ClangCCompiler(ClangCompiler, CCompiler):
 
     def get_option_link_args(self, options):
         return []
+
+
+class AppleClangCCompiler(ClangCCompiler):
+
+    """Handle the differences between Apple Clang and Vanilla Clang.
+    
+    Right now this just handles the differences between the versions that new
+    C standards were added.
+    """
+
+    _C17_VERSION = '>=6.0.0'
+    _C18_VERSION = '>=8.0.0'
 
 
 class EmscriptenCCompiler(LinkerEnvVarsMixin, BasicLinkerIsCompilerMixin, ClangCCompiler):

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -32,8 +32,10 @@ from .compilers import (
     gnu_winlibs,
     msvc_winlibs,
     Compiler,
-    CompilerType,
 )
+
+if typing.TYPE_CHECKING:
+    from ..envconfig import MachineInfo
 
 
 class CCompiler(CLikeCompiler, Compiler):
@@ -46,10 +48,10 @@ class CCompiler(CLikeCompiler, Compiler):
             raise MesonException('Unknown function attribute "{}"'.format(name))
 
     def __init__(self, exelist, version, for_machine: MachineChoice, is_cross: bool,
-                 exe_wrapper: typing.Optional[str] = None, **kwargs):
+                 info: 'MachineInfo', exe_wrapper: typing.Optional[str] = None, **kwargs):
         # If a child ObjC or CPP class has already set it, don't set it ourselves
         self.language = 'c'
-        Compiler.__init__(self, exelist, version, for_machine, **kwargs)
+        Compiler.__init__(self, exelist, version, for_machine, info, **kwargs)
         CLikeCompiler.__init__(self, is_cross, exe_wrapper)
 
     def get_no_stdinc_args(self):
@@ -79,9 +81,10 @@ class ClangCCompiler(ClangCompiler, CCompiler):
     _C17_VERSION = '>=10.0.0'
     _C18_VERSION = '>=11.0.0'
 
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
-        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
-        ClangCompiler.__init__(self, compiler_type)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrapper=None, **kwargs):
+        CCompiler.__init__(self, exelist, version, for_machine, is_cross, info, exe_wrapper, **kwargs)
+        ClangCompiler.__init__(self)
         default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -119,7 +122,7 @@ class ClangCCompiler(ClangCompiler, CCompiler):
 class AppleClangCCompiler(ClangCCompiler):
 
     """Handle the differences between Apple Clang and Vanilla Clang.
-    
+
     Right now this just handles the differences between the versions that new
     C standards were added.
     """
@@ -129,10 +132,12 @@ class AppleClangCCompiler(ClangCCompiler):
 
 
 class EmscriptenCCompiler(LinkerEnvVarsMixin, BasicLinkerIsCompilerMixin, ClangCCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 info: 'MachineInfo', is_cross, exe_wrapper=None, **kwargs):
         if not is_cross:
             raise MesonException('Emscripten compiler can only be used for cross compilation.')
-        ClangCCompiler.__init__(self, exelist, version, compiler_type, for_machine, is_cross, exe_wrapper, **kwargs)
+        ClangCCompiler.__init__(self, exelist, version, for_machine,
+                                is_cross, info, exe_wrapper, **kwargs)
         self.id = 'emscripten'
 
     def get_option_link_args(self, options):
@@ -142,9 +147,11 @@ class EmscriptenCCompiler(LinkerEnvVarsMixin, BasicLinkerIsCompilerMixin, ClangC
         raise MesonException('Emscripten does not support shared libraries.')
 
 class ArmclangCCompiler(ArmclangCompiler, CCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
-        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
-        ArmclangCompiler.__init__(self, compiler_type)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 info: 'MachineInfo', is_cross, exe_wrapper=None, **kwargs):
+        CCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                           info, exe_wrapper, **kwargs)
+        ArmclangCompiler.__init__(self)
         default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -171,9 +178,12 @@ class ArmclangCCompiler(ArmclangCompiler, CCompiler):
 
 
 class GnuCCompiler(GnuCompiler, CCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, defines=None, **kwargs):
-        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
-        GnuCompiler.__init__(self, compiler_type, defines)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrapper=None,
+                 defines=None, **kwargs):
+        CCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                           info, exe_wrapper, **kwargs)
+        GnuCompiler.__init__(self, defines)
         default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -191,7 +201,7 @@ class GnuCCompiler(GnuCompiler, CCompiler):
         opts.update({'c_std': coredata.UserComboOption('C language standard to use',
                                                        ['none'] + c_stds + g_stds,
                                                        'none')})
-        if self.compiler_type.is_windows_compiler:
+        if self.info.is_windows() or self.info.is_cygwin():
             opts.update({
                 'c_winlibs': coredata.UserArrayOption('Standard Win libraries to link against',
                                                       gnu_winlibs), })
@@ -205,7 +215,7 @@ class GnuCCompiler(GnuCompiler, CCompiler):
         return args
 
     def get_option_link_args(self, options):
-        if self.compiler_type.is_windows_compiler:
+        if self.info.is_windows() or self.info.is_cygwin():
             return options['c_winlibs'].value[:]
         return []
 
@@ -214,15 +224,19 @@ class GnuCCompiler(GnuCompiler, CCompiler):
 
 
 class PGICCompiler(PGICompiler, CCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
-        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
-        PGICompiler.__init__(self, compiler_type)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrapper=None, **kwargs):
+        CCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                           info, exe_wrapper, **kwargs)
+        PGICompiler.__init__(self)
 
 
 class ElbrusCCompiler(GnuCCompiler, ElbrusCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, defines=None, **kwargs):
-        GnuCCompiler.__init__(self, exelist, version, compiler_type, for_machine, is_cross, exe_wrapper, defines, **kwargs)
-        ElbrusCompiler.__init__(self, compiler_type, defines)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrapper=None, defines=None, **kwargs):
+        GnuCCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                              info, exe_wrapper, defines, **kwargs)
+        ElbrusCompiler.__init__(self, defines)
 
     # It does support some various ISO standards and c/gnu 90, 9x, 1x in addition to those which GNU CC supports.
     def get_options(self):
@@ -246,9 +260,11 @@ class ElbrusCCompiler(GnuCCompiler, ElbrusCompiler):
 
 
 class IntelCCompiler(IntelGnuLikeCompiler, CCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
-        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
-        IntelGnuLikeCompiler.__init__(self, compiler_type)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrapper=None, **kwargs):
+        CCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                           info, exe_wrapper, **kwargs)
+        IntelGnuLikeCompiler.__init__(self)
         self.lang_header = 'c-header'
         default_warn_args = ['-Wall', '-w3', '-diag-disable:remark']
         self.warn_args = {'0': [],
@@ -288,16 +304,23 @@ class VisualStudioLikeCCompilerMixin:
     def get_option_link_args(self, options):
         return options['c_winlibs'].value[:]
 
+
 class VisualStudioCCompiler(VisualStudioLikeCompiler, VisualStudioLikeCCompilerMixin, CCompiler):
 
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrap, target: str, **kwargs):
-        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrap, **kwargs)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrap, target: str,
+                 **kwargs):
+        CCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                           info, exe_wrap, **kwargs)
         VisualStudioLikeCompiler.__init__(self, target)
         self.id = 'msvc'
 
+
 class ClangClCCompiler(VisualStudioLikeCompiler, VisualStudioLikeCCompilerMixin, CCompiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrap, target, **kwargs):
-        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrap, **kwargs)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrap, target, **kwargs):
+        CCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                           info, exe_wrap, **kwargs)
         VisualStudioLikeCompiler.__init__(self, target)
         self.id = 'clang-cl'
 
@@ -308,8 +331,10 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
 
     __have_warned = False
 
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrap, target, **kwargs):
-        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrap, **kwargs)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrap, target, **kwargs):
+        CCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                           info, exe_wrap, **kwargs)
         IntelVisualStudioLikeCompiler.__init__(self, target)
 
     def get_options(self):
@@ -333,9 +358,11 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
 
 
 class ArmCCompiler(ArmCompiler, CCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
-        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
-        ArmCompiler.__init__(self, compiler_type)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrapper=None, **kwargs):
+        CCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                           info, exe_wrapper, **kwargs)
+        ArmCompiler.__init__(self)
 
     def get_options(self):
         opts = CCompiler.get_options(self)
@@ -351,10 +378,13 @@ class ArmCCompiler(ArmCompiler, CCompiler):
             args.append('--' + std.value)
         return args
 
+
 class CcrxCCompiler(CcrxCompiler, CCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
-        CCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
-        CcrxCompiler.__init__(self, compiler_type)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrapper=None, **kwargs):
+        CCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                           info, exe_wrapper, **kwargs)
+        CcrxCompiler.__init__(self)
 
     # Override CCompiler.get_always_args
     def get_always_args(self):

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -184,6 +184,11 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
         return ['-lstdc++']
 
 
+class AppleClangCPPCompiler(ClangCPPCompiler):
+
+    pass
+
+
 class EmscriptenCPPCompiler(LinkerEnvVarsMixin, BasicLinkerIsCompilerMixin, ClangCPPCompiler):
     def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
         if not is_cross:

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -13,12 +13,16 @@
 # limitations under the License.
 
 import os.path, subprocess
+import typing
 
 from ..mesonlib import EnvironmentException
 from ..mesonlib import is_windows
 
 from .compilers import Compiler, MachineChoice, mono_buildtype_args
 from .mixins.islinker import BasicLinkerIsCompilerMixin
+
+if typing.TYPE_CHECKING:
+    from ..envconfig import MachineInfo
 
 cs_optimization_args = {'0': [],
                         'g': [],
@@ -28,10 +32,12 @@ cs_optimization_args = {'0': [],
                         's': ['-optimize+'],
                         }
 
+
 class CsCompiler(BasicLinkerIsCompilerMixin, Compiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, comp_id, runner=None):
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 info: 'MachineInfo', comp_id, runner=None):
         self.language = 'cs'
-        super().__init__(exelist, version, for_machine)
+        super().__init__(exelist, version, for_machine, info)
         self.id = comp_id
         self.is_cross = False
         self.runner = runner
@@ -133,14 +139,16 @@ class CsCompiler(BasicLinkerIsCompilerMixin, Compiler):
 
 
 class MonoCompiler(CsCompiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice):
-        super().__init__(exelist, version, for_machine, 'mono',
-                         'mono')
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 info: 'MachineInfo'):
+        super().__init__(exelist, version, for_machine, info, 'mono',
+                         runner='mono')
 
 
 class VisualStudioCsCompiler(CsCompiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice):
-        super().__init__(exelist, version, for_machine, 'csc')
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 info: 'MachineInfo'):
+        super().__init__(exelist, version, for_machine, info, 'csc')
 
     def get_buildtype_args(self, buildtype):
         res = mono_buildtype_args[buildtype]

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -16,7 +16,6 @@ import os.path, subprocess
 import typing
 
 from ..mesonlib import EnvironmentException
-from ..mesonlib import is_windows
 
 from .compilers import Compiler, MachineChoice, mono_buildtype_args
 from .mixins.islinker import BasicLinkerIsCompilerMixin
@@ -152,7 +151,7 @@ class VisualStudioCsCompiler(CsCompiler):
 
     def get_buildtype_args(self, buildtype):
         res = mono_buildtype_args[buildtype]
-        if not is_windows():
+        if not self.info.is_windows():
             tmp = []
             for flag in res:
                 if flag == '-debug':

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -24,6 +24,7 @@ from .compilers import (Compiler, cuda_buildtype_args, cuda_optimization_args,
 
 if typing.TYPE_CHECKING:
     from ..environment import Environment  # noqa: F401
+    from ..envconfig import MachineInfo
 
 
 class CudaCompiler(Compiler):
@@ -32,10 +33,11 @@ class CudaCompiler(Compiler):
 
     _universal_flags = {'compiler': ['-I', '-D', '-U', '-E'], 'linker': ['-l', '-L']}
 
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrapper, host_compiler, **kwargs):
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, exe_wrapper, host_compiler, info: 'MachineInfo', **kwargs):
         if not hasattr(self, 'language'):
             self.language = 'cuda'
-        super().__init__(exelist, version, for_machine, **kwargs)
+        super().__init__(exelist, version, for_machine, info, **kwargs)
         self.is_cross = is_cross
         self.exe_wrapper = exe_wrapper
         self.host_compiler = host_compiler

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -20,7 +20,6 @@ from ..mesonlib import (
 )
 
 from .compilers import (
-    CompilerType,
     d_dmd_buildtype_args,
     d_gdc_buildtype_args,
     d_ldc_buildtype_args,
@@ -30,6 +29,9 @@ from .compilers import (
 )
 from .mixins.gnu import GnuCompiler
 from .mixins.islinker import LinkerEnvVarsMixin, BasicLinkerIsCompilerMixin
+
+if typing.TYPE_CHECKING:
+    from ..envconfig import MachineInfo
 
 d_feature_args = {'gcc':  {'unittest': '-funittest',
                            'debug': '-fdebug',
@@ -402,9 +404,10 @@ class DCompiler(Compiler):
         'mtd': ['-mscrtlib=libcmtd'],
     }
 
-    def __init__(self, exelist, version, for_machine: MachineChoice, arch, **kwargs):
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 info: 'MachineInfo', arch, **kwargs):
         self.language = 'd'
-        super().__init__(exelist, version, for_machine, **kwargs)
+        super().__init__(exelist, version, for_machine, info, **kwargs)
         self.id = 'unknown'
         self.arch = arch
 
@@ -590,8 +593,9 @@ class GnuDCompiler(DCompiler, GnuCompiler):
     # we mostly want DCompiler, but that gives us the Compiler.LINKER_PREFIX instead
     LINKER_PREFIX = GnuCompiler.LINKER_PREFIX
 
-    def __init__(self, exelist, version, for_machine: MachineChoice, arch, **kwargs):
-        DCompiler.__init__(self, exelist, version, for_machine, arch, **kwargs)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 info: 'MachineInfo', arch, **kwargs):
+        DCompiler.__init__(self, exelist, version, for_machine, info, arch, **kwargs)
         self.id = 'gcc'
         default_warn_args = ['-Wall', '-Wdeprecated']
         self.warn_args = {'0': [],
@@ -633,8 +637,10 @@ class GnuDCompiler(DCompiler, GnuCompiler):
 
 
 class LLVMDCompiler(DmdLikeCompilerMixin, LinkerEnvVarsMixin, BasicLinkerIsCompilerMixin, DCompiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, arch, **kwargs):
-        DCompiler.__init__(self, exelist, version, for_machine, arch, **kwargs)
+
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 info: 'MachineInfo', arch, **kwargs):
+        DCompiler.__init__(self, exelist, version, for_machine, info, arch, **kwargs)
         self.id = 'llvm'
         self.base_options = ['b_coverage', 'b_colorout', 'b_vscrt']
 
@@ -671,8 +677,10 @@ class LLVMDCompiler(DmdLikeCompilerMixin, LinkerEnvVarsMixin, BasicLinkerIsCompi
 
 
 class DmdDCompiler(DmdLikeCompilerMixin, LinkerEnvVarsMixin, BasicLinkerIsCompilerMixin, DCompiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, arch, **kwargs):
-        DCompiler.__init__(self, exelist, version, for_machine, arch, **kwargs)
+
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 info: 'MachineInfo', arch, **kwargs):
+        DCompiler.__init__(self, exelist, version, for_machine, info, arch, **kwargs)
         self.id = 'dmd'
         self.base_options = ['b_coverage', 'b_colorout', 'b_vscrt']
 

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -12,17 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os.path, shutil, subprocess
+import os.path
+import shutil
+import subprocess
+import typing
 
 from ..mesonlib import EnvironmentException, MachineChoice
-
 from .compilers import Compiler, java_buildtype_args
 from .mixins.islinker import BasicLinkerIsCompilerMixin
 
+if typing.TYPE_CHECKING:
+    from ..envconfig import MachineInfo
+
 class JavaCompiler(BasicLinkerIsCompilerMixin, Compiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice):
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 info: 'MachineInfo'):
         self.language = 'java'
-        super().__init__(exelist, version, for_machine)
+        super().__init__(exelist, version, for_machine, info)
         self.id = 'unknown'
         self.is_cross = False
         self.javarunner = 'java'

--- a/mesonbuild/compilers/mixins/arm.py
+++ b/mesonbuild/compilers/mixins/arm.py
@@ -23,7 +23,6 @@ from ..compilers import clike_debug_args
 from .clang import clang_color_args
 
 if typing.TYPE_CHECKING:
-    from ..compilers import CompilerType
     from ...environment import Environment
 
 arm_buildtype_args = {
@@ -65,11 +64,10 @@ armclang_optimization_args = {
 
 class ArmCompiler:
     # Functionality that is common to all ARM family compilers.
-    def __init__(self, compiler_type: 'CompilerType'):
+    def __init__(self):
         if not self.is_cross:
             raise mesonlib.EnvironmentException('armcc supports only cross-compilation.')
         self.id = 'arm'
-        self.compiler_type = compiler_type
         default_warn_args = []  # type: typing.List[str]
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -130,7 +128,7 @@ class ArmCompiler:
 
 
 class ArmclangCompiler:
-    def __init__(self, compiler_type: 'CompilerType'):
+    def __init__(self):
         if not self.is_cross:
             raise mesonlib.EnvironmentException('armclang supports only cross-compilation.')
         # Check whether 'armlink' is available in path
@@ -157,7 +155,6 @@ class ArmclangCompiler:
         if not mesonlib.version_compare(self.version, '==' + linker_ver):
             raise mesonlib.EnvironmentException('armlink version does not match with compiler version')
         self.id = 'armclang'
-        self.compiler_type = compiler_type
         self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage',
                              'b_ndebug', 'b_staticpic', 'b_colorout']
         # Assembly

--- a/mesonbuild/compilers/mixins/ccrx.py
+++ b/mesonbuild/compilers/mixins/ccrx.py
@@ -20,7 +20,6 @@ import typing
 from ...mesonlib import Popen_safe, EnvironmentException
 
 if typing.TYPE_CHECKING:
-    from ..compilers import CompilerType
     from ...environment import Environment
 
 ccrx_buildtype_args = {
@@ -48,11 +47,10 @@ ccrx_debug_args = {
 
 
 class CcrxCompiler:
-    def __init__(self, compiler_type: 'CompilerType'):
+    def __init__(self):
         if not self.is_cross:
             raise EnvironmentException('ccrx supports only cross-compilation.')
         self.id = 'ccrx'
-        self.compiler_type = compiler_type
         # Assembly
         self.can_compile_suffixes.update('s')
         default_warn_args = []  # type: typing.List[str]

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -21,15 +21,14 @@ from .gnu import GnuCompiler
 from ...mesonlib import Popen_safe
 
 if typing.TYPE_CHECKING:
-    from ..compilers import CompilerType
     from ...environment import Environment
 
 
 class ElbrusCompiler(GnuCompiler):
     # Elbrus compiler is nearly like GCC, but does not support
     # PCH, LTO, sanitizers and color output as of version 1.21.x.
-    def __init__(self, compiler_type: 'CompilerType', defines: typing.Dict[str, str]):
-        GnuCompiler.__init__(self, compiler_type, defines)
+    def __init__(self, defines: typing.Dict[str, str]):
+        GnuCompiler.__init__(self, defines)
         self.id = 'lcc'
         self.base_options = ['b_pgo', 'b_coverage',
                              'b_ndebug', 'b_staticpic',

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -26,7 +26,6 @@ from ... import mesonlib
 from ... import mlog
 
 if typing.TYPE_CHECKING:
-    from ..compilers import CompilerType
     from ...coredata import UserOption  # noqa: F401
     from ...environment import Environment
 
@@ -130,19 +129,18 @@ class GnuLikeCompiler(metaclass=abc.ABCMeta):
 
     LINKER_PREFIX = '-Wl,'
 
-    def __init__(self, compiler_type: 'CompilerType'):
-        self.compiler_type = compiler_type
+    def __init__(self):
         self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage',
                              'b_ndebug', 'b_staticpic', 'b_pie']
-        if not (self.compiler_type.is_windows_compiler or mesonlib.is_openbsd()):
+        if not (self.info.is_windows() or self.info.is_cygwin() or self.info.is_openbsd()):
             self.base_options.append('b_lundef')
-        if not self.compiler_type.is_windows_compiler:
+        if not self.info.is_windows() or self.info.is_cygwin():
             self.base_options.append('b_asneeded')
         # All GCC-like backends can do assembly
         self.can_compile_suffixes.add('s')
 
     def get_pic_args(self) -> typing.List[str]:
-        if self.compiler_type.is_osx_compiler or self.compiler_type.is_windows_compiler:
+        if self.info.is_windows() or self.info.is_cygwin() or self.info.is_darwin():
             return [] # On Window and OS X, pic is always on.
         return ['-fPIC']
 
@@ -184,7 +182,7 @@ class GnuLikeCompiler(metaclass=abc.ABCMeta):
             raise RuntimeError('Module definitions file should be str')
         # On Windows targets, .def files may be specified on the linker command
         # line like an object file.
-        if self.compiler_type.is_windows_compiler:
+        if self.info.is_windows() or self.info.is_cygwin():
             return [defsfile]
         # For other targets, discard the .def file.
         return []
@@ -199,7 +197,7 @@ class GnuLikeCompiler(metaclass=abc.ABCMeta):
         return ['-fprofile-use', '-fprofile-correction']
 
     def get_gui_app_args(self, value: bool) -> typing.List[str]:
-        if self.compiler_type.is_windows_compiler:
+        if self.info.is_windows() or self.info.is_cygwin():
             return ['-mwindows' if value else '-mconsole']
         return []
 
@@ -301,8 +299,8 @@ class GnuCompiler(GnuLikeCompiler):
     Compilers imitating GCC (Clang/Intel) should use the GnuLikeCompiler ABC.
     """
 
-    def __init__(self, compiler_type: 'CompilerType', defines: typing.Dict[str, str]):
-        super().__init__(compiler_type)
+    def __init__(self, defines: typing.Dict[str, str]):
+        super().__init__()
         self.id = 'gcc'
         self.defines = defines or {}
         self.base_options.append('b_colorout')

--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -22,7 +22,6 @@ import os
 import typing
 
 from ... import mesonlib
-from ..compilers import CompilerType
 from .gnu import GnuLikeCompiler
 from .visualstudio import VisualStudioLikeCompiler
 
@@ -44,8 +43,8 @@ clike_optimization_args = {
 # Tested on linux for ICC 14.0.3, 15.0.6, 16.0.4, 17.0.1, 19.0.0
 class IntelGnuLikeCompiler(GnuLikeCompiler):
 
-    def __init__(self, compiler_type: 'CompilerType'):
-        super().__init__(compiler_type)
+    def __init__(self):
+        super().__init__()
         # As of 19.0.0 ICC doesn't have sanitizer, color, or lto support.
         #
         # It does have IPO, which serves much the same purpose as LOT, but
@@ -104,7 +103,6 @@ class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
 
     def __init__(self, target: str):
         super().__init__(target)
-        self.compiler_type = CompilerType.ICC_WIN
         self.id = 'intel-cl'
 
     def compile(self, code, *, extra_args: typing.Optional[typing.List[str]] = None, **kwargs) -> typing.Iterator['subprocess.Popen']:

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -20,9 +20,6 @@ from pathlib import Path
 
 from ..compilers import clike_debug_args, clike_optimization_args
 
-if typing.TYPE_CHECKING:
-    from ..compilers import CompilerType
-
 pgi_buildtype_args = {
     'plain': [],
     'debug': [],
@@ -34,10 +31,9 @@ pgi_buildtype_args = {
 
 
 class PGICompiler:
-    def __init__(self, compiler_type: 'CompilerType'):
+    def __init__(self):
         self.base_options = ['b_pch']
         self.id = 'pgi'
-        self.compiler_type = compiler_type
 
         default_warn_args = ['-Minform=inform']
         self.warn_args = {'0': [],
@@ -56,7 +52,7 @@ class PGICompiler:
 
     def get_pic_args(self) -> typing.List[str]:
         # PGI -fPIC is Linux only.
-        if self.compiler_type.is_standard_compiler:
+        if self.info.is_linux():
             return ['-fPIC']
         return []
 

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -22,10 +22,16 @@ from .mixins.clike import CLikeCompiler
 from .mixins.gnu import GnuCompiler
 from .mixins.clang import ClangCompiler
 
+if typing.TYPE_CHECKING:
+    from ..envconfig import MachineInfo
+
+
 class ObjCCompiler(CLikeCompiler, Compiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross: bool, exe_wrap: typing.Optional[str], **kwargs):
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross: bool, info: 'MachineInfo',
+                 exe_wrap: typing.Optional[str], **kwargs):
         self.language = 'objc'
-        Compiler.__init__(self, exelist, version, for_machine, **kwargs)
+        Compiler.__init__(self, exelist, version, for_machine, info, **kwargs)
         CLikeCompiler.__init__(self, is_cross, exe_wrap)
 
     def get_display_language(self):
@@ -57,9 +63,12 @@ class ObjCCompiler(CLikeCompiler, Compiler):
 
 
 class GnuObjCCompiler(GnuCompiler, ObjCCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, defines=None, **kwargs):
-        ObjCCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
-        GnuCompiler.__init__(self, compiler_type, defines)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrapper=None,
+                 defines=None, **kwargs):
+        ObjCCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                              info, exe_wrapper, **kwargs)
+        GnuCompiler.__init__(self, defines)
         default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -68,9 +77,12 @@ class GnuObjCCompiler(GnuCompiler, ObjCCompiler):
 
 
 class ClangObjCCompiler(ClangCompiler, ObjCCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
-        ObjCCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
-        ClangCompiler.__init__(self, compiler_type)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrapper=None,
+                 **kwargs):
+        ObjCCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                              info, exe_wrapper, **kwargs)
+        ClangCompiler.__init__(self)
         default_warn_args = ['-Wall', '-Winvalid-pch']
         self.warn_args = {'0': [],
                           '1': default_warn_args,

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -22,10 +22,15 @@ from .compilers import Compiler
 from .mixins.gnu import GnuCompiler
 from .mixins.clang import ClangCompiler
 
+if typing.TYPE_CHECKING:
+    from ..envconfig import MachineInfo
+
 class ObjCPPCompiler(CLikeCompiler, Compiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross: bool, exe_wrap: typing.Optional[str], **kwargs):
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross: bool, info: 'MachineInfo',
+                 exe_wrap: typing.Optional[str], **kwargs):
         self.language = 'objcpp'
-        Compiler.__init__(self, exelist, version, for_machine, **kwargs)
+        Compiler.__init__(self, exelist, version, for_machine, info, **kwargs)
         CLikeCompiler.__init__(self, is_cross, exe_wrap)
 
     def get_display_language(self):
@@ -58,9 +63,11 @@ class ObjCPPCompiler(CLikeCompiler, Compiler):
 
 
 class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, defines=None, **kwargs):
-        ObjCPPCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
-        GnuCompiler.__init__(self, compiler_type, defines)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrapper=None,
+                 defines=None, **kwargs):
+        ObjCPPCompiler.__init__(self, exelist, version, for_machine, is_cross, info, exe_wrapper, **kwargs)
+        GnuCompiler.__init__(self, defines)
         default_warn_args = ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -69,9 +76,11 @@ class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):
 
 
 class ClangObjCPPCompiler(ClangCompiler, ObjCPPCompiler):
-    def __init__(self, exelist, version, compiler_type, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
-        ObjCPPCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwargs)
-        ClangCompiler.__init__(self, compiler_type)
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrapper=None,
+                 **kwargs):
+        ObjCPPCompiler.__init__(self, exelist, version, for_machine, is_cross, info, exe_wrapper, **kwargs)
+        ClangCompiler.__init__(self)
         default_warn_args = ['-Wall', '-Winvalid-pch', '-Wnon-virtual-dtor']
         self.warn_args = {'0': [],
                           '1': default_warn_args,

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -19,6 +19,7 @@ from ..mesonlib import EnvironmentException, MachineChoice, Popen_safe
 from .compilers import Compiler, rust_buildtype_args, clike_debug_args
 
 if typing.TYPE_CHECKING:
+    from ..envconfig import MachineInfo
     from ..environment import Environment  # noqa: F401
 
 rust_optimization_args = {'0': [],
@@ -30,9 +31,13 @@ rust_optimization_args = {'0': [],
                           }
 
 class RustCompiler(Compiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
+
+    LINKER_PREFIX = '-Wl,'
+
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrapper=None, **kwargs):
         self.language = 'rust'
-        super().__init__(exelist, version, for_machine, **kwargs)
+        super().__init__(exelist, version, for_machine, info, **kwargs)
         self.exe_wrapper = exe_wrapper
         self.id = 'rustc'
         self.is_cross = is_cross

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -13,10 +13,14 @@
 # limitations under the License.
 
 import subprocess, os.path
+import typing
 
 from ..mesonlib import EnvironmentException, MachineChoice
 
 from .compilers import Compiler, swift_buildtype_args, clike_debug_args
+
+if typing.TYPE_CHECKING:
+    from ..envconfig import MachineInfo
 
 swift_optimization_args = {'0': [],
                            'g': [],
@@ -30,9 +34,10 @@ class SwiftCompiler(Compiler):
 
     LINKER_PREFIX = ['-Xlinker']
 
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, **kwargs):
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', **kwargs):
         self.language = 'swift'
-        super().__init__(exelist, version, for_machine, **kwargs)
+        super().__init__(exelist, version, for_machine, info, **kwargs)
         self.version = version
         self.id = 'llvm'
         self.is_cross = is_cross

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -13,16 +13,21 @@
 # limitations under the License.
 
 import os.path
+import typing
 
 from .. import mlog
 from ..mesonlib import EnvironmentException, MachineChoice, version_compare
 
 from .compilers import Compiler
 
+if typing.TYPE_CHECKING:
+    from ..envconfig import MachineInfo
+
 class ValaCompiler(Compiler):
-    def __init__(self, exelist, version, for_machine: MachineChoice, is_cross):
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo'):
         self.language = 'vala'
-        super().__init__(exelist, version, for_machine)
+        super().__init__(exelist, version, for_machine, info)
         self.version = version
         self.is_cross = is_cross
         self.id = 'valac'

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -32,7 +32,6 @@ from .envconfig import (
 from . import compilers
 from .compilers import (
     Compiler,
-    CompilerType,
     is_assembly,
     is_header,
     is_library,
@@ -697,17 +696,6 @@ class Environment:
         minor = defines.get('__LCC_MINOR__', '0')
         return dot.join((generation, major, minor))
 
-    @staticmethod
-    def get_gnu_compiler_type(defines):
-        # Detect GCC type (Apple, MinGW, Cygwin, Unix)
-        if '__APPLE__' in defines:
-            return CompilerType.GCC_OSX
-        elif '__MINGW32__' in defines or '__MINGW64__' in defines:
-            return CompilerType.GCC_MINGW
-        elif '__CYGWIN__' in defines:
-            return CompilerType.GCC_CYGWIN
-        return CompilerType.GCC_STANDARD
-
     def _get_compilers(self, lang, for_machine):
         '''
         The list of compilers is detected in the exact same way for
@@ -836,6 +824,7 @@ class Environment:
         popen_exceptions = {}
         compilers, ccache, exe_wrap = self._get_compilers(lang, for_machine)
         is_cross = not self.machines.matches_build_machine(for_machine)
+        info = self.machines[for_machine]
 
         for compiler in compilers:
             if isinstance(compiler, str):
@@ -893,7 +882,6 @@ class Environment:
                 if not defines:
                     popen_exceptions[' '.join(compiler)] = 'no pre-processor defines'
                     continue
-                compiler_type = self.get_gnu_compiler_type(defines)
 
                 if guess_gcc_or_lcc == 'lcc':
                     version = self.get_lcc_version_from_defines(defines)
@@ -903,14 +891,16 @@ class Environment:
                     cls = GnuCCompiler if lang == 'c' else GnuCPPCompiler
 
                 linker = self._guess_nix_linker(compiler, for_machine, cls.LINKER_PREFIX)
-                return cls(ccache + compiler, version, compiler_type,
-                           for_machine, is_cross, exe_wrap, defines,
-                           full_version=full_version, linker=linker)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross,
+                    info, exe_wrap, defines, full_version=full_version,
+                    linker=linker)
 
             if 'Emscripten' in out:
                 cls = EmscriptenCCompiler if lang == 'c' else EmscriptenCPPCompiler
-                compiler_type = CompilerType.CLANG_EMSCRIPTEN
-                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross, info,
+                    exe_wrap, full_version=full_version)
 
             if 'armclang' in out:
                 # The compiler version is not present in the first line of output,
@@ -926,10 +916,11 @@ class Environment:
                 # Override previous values
                 version = search_version(arm_ver_str)
                 full_version = arm_ver_str
-                compiler_type = CompilerType.ARM_WIN
                 cls = ArmclangCCompiler if lang == 'c' else ArmclangCPPCompiler
                 linker = ArmClangDynamicLinker(for_machine, version=version)
-                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross, info,
+                    exe_wrap, full_version=full_version, linker=linker)
             if 'CL.EXE COMPATIBILITY' in out:
                 # if this is clang-cl masquerading as cl, detect it as cl, not
                 # clang
@@ -946,7 +937,9 @@ class Environment:
                     target = 'unknown target'
                 cls = ClangClCCompiler if lang == 'c' else ClangClCPPCompiler
                 linker = ClangClDynamicLinker(for_machine, version=version)
-                return cls(compiler, version, for_machine, is_cross, exe_wrap, target, linker=linker)
+                return cls(
+                    compiler, version, for_machine, is_cross, info, exe_wrap,
+                    target, linker=linker)
             if 'clang' in out:
                 linker = None
 
@@ -968,13 +961,17 @@ class Environment:
                 if linker is None:
                     linker = self._guess_nix_linker(compiler, for_machine, cls.LINKER_PREFIX)
 
-                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross, info,
+                    exe_wrap, full_version=full_version, linker=linker)
             if 'Intel(R) C++ Intel(R)' in err:
                 version = search_version(err)
                 target = 'x86' if 'IA-32' in err else 'x86_64'
                 cls = IntelClCCompiler if lang == 'c' else IntelClCPPCompiler
                 linker = XilinkDynamicLinker(for_machine, version=version)
-                return cls(compiler, version, for_machine, is_cross, exe_wrap, target, linker=linker)
+                return cls(
+                    compiler, version, for_machine, is_cross, exe_wrap,
+                    target, info, linker=linker)
             if 'Microsoft' in out or 'Microsoft' in err:
                 # Latest versions of Visual Studio print version
                 # number to stderr but earlier ones print version
@@ -994,36 +991,36 @@ class Environment:
                     target = 'x86'
                 linker = MSVCDynamicLinker(for_machine, version=version)
                 cls = VisualStudioCCompiler if lang == 'c' else VisualStudioCPPCompiler
-                return cls(compiler, version, for_machine, is_cross, exe_wrap, target, linker=linker)
+                return cls(
+                    compiler, version, for_machine, is_cross, info, exe_wrap,
+                    target, linker=linker)
             if 'PGI Compilers' in out:
-                if self.machines[for_machine].is_darwin():
-                    compiler_type = CompilerType.PGI_OSX
-                elif self.machines[for_machine].is_windows():
-                    compiler_type = CompilerType.PGI_WIN
-                else:
-                    compiler_type = CompilerType.PGI_STANDARD
                 cls = PGICCompiler if lang == 'c' else PGICPPCompiler
                 linker = PGIDynamicLinker(compiler, for_machine, 'pgi', cls.LINKER_PREFIX, version=version)
-                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, linker=linker)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross,
+                    info, exe_wrap, linker=linker)
             if '(ICC)' in out:
                 if self.machines[for_machine].is_darwin():
-                    compiler_type = CompilerType.ICC_OSX
-                    l = XildAppleDynamicLinker(compiler, for_machine, 'xild', '-Wl,', version=version)
+                    l = XildAppleDynamicLinker(compiler, for_machine, 'xild', cls.LINKER_PREFIX, version=version)
                 else:
-                    compiler_type = CompilerType.ICC_STANDARD
-                    l = XildLinuxDynamicLinker(compiler, for_machine, 'xild', '-Wl,', version=version)
+                    l = XildLinuxDynamicLinker(compiler, for_machine, 'xild', cls.LINKER_PREFIX, version=version)
                 cls = IntelCCompiler if lang == 'c' else IntelCPPCompiler
-                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version, linker=l)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross, info,
+                    exe_wrap, full_version=full_version, linker=l)
             if 'ARM' in out:
-                compiler_type = CompilerType.ARM_WIN
                 cls = ArmCCompiler if lang == 'c' else ArmCPPCompiler
                 linker = ArmDynamicLinker(for_machine, version=version)
-                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross,
+                    info, exe_wrap, full_version=full_version, linker=linker)
             if 'RX Family' in out:
-                compiler_type = CompilerType.CCRX_WIN
                 cls = CcrxCCompiler if lang == 'c' else CcrxCPPCompiler
                 linker = CcrxDynamicLinker(for_machine, version=version)
-                return cls(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross, info,
+                    exe_wrap, full_version=full_version, linker=linker)
 
         self._handle_exceptions(popen_exceptions, compilers)
 
@@ -1037,6 +1034,7 @@ class Environment:
         popen_exceptions = {}
         is_cross = not self.machines.matches_build_machine(for_machine)
         compilers, ccache, exe_wrap = self._get_compilers('cuda', for_machine)
+        info = self.machines[for_machine]
         for compiler in compilers:
             if isinstance(compiler, str):
                 compiler = [compiler]
@@ -1073,6 +1071,7 @@ class Environment:
         popen_exceptions = {}
         compilers, ccache, exe_wrap = self._get_compilers('fortran', for_machine)
         is_cross = not self.machines.matches_build_machine(for_machine)
+        info = self.machines[for_machine]
         for compiler in compilers:
             if isinstance(compiler, str):
                 compiler = [compiler]
@@ -1097,59 +1096,84 @@ class Environment:
                     if not defines:
                         popen_exceptions[' '.join(compiler)] = 'no pre-processor defines'
                         continue
-                    compiler_type = self.get_gnu_compiler_type(defines)
                     if guess_gcc_or_lcc == 'lcc':
                         version = self.get_lcc_version_from_defines(defines)
                         cls = ElbrusFortranCompiler
                     else:
                         version = self.get_gnu_version_from_defines(defines)
                         cls = GnuFortranCompiler
-                    linker = self._guess_nix_linker(compiler, for_machine, cls.LINKER_PREFIX)
-                    return cls(compiler, version, compiler_type, for_machine, is_cross, exe_wrap, defines, full_version=full_version, linker=linker)
+                    linker = self._guess_nix_linker(
+                        compiler, for_machine, cls.LINKER_PREFIX)
+                    return cls(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, defines, full_version=full_version,
+                        linker=linker)
 
                 if 'G95' in out:
-                    linker = self._guess_nix_linker(compiler, for_machine, G95FortranCompiler.LINKER_PREFIX)
-                    return G95FortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
+                    linker = self._guess_nix_linker(
+                        compiler, for_machine, cls.LINKER_PREFIX)
+                    return G95FortranCompiler(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, full_version=full_version, linker=linker)
 
                 if 'Sun Fortran' in err:
                     version = search_version(err)
-                    linker = self._guess_nix_linker(compiler, for_machine, SunFortranCompiler.LINKER_PREFIX)
-                    return SunFortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
+                    linker = self._guess_nix_linker(
+                        compiler, for_machine, cls.LINKER_PREFIX)
+                    return SunFortranCompiler(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, full_version=full_version, linker=linker)
 
                 if 'Intel(R) Visual Fortran' in err:
                     version = search_version(err)
                     target = 'x86' if 'IA-32' in err else 'x86_64'
                     linker = XilinkDynamicLinker(for_machine, version=version)
-                    return IntelClFortranCompiler(compiler, version, for_machine, is_cross, target, exe_wrap, linker=linker)
+                    return IntelClFortranCompiler(
+                        compiler, version, for_machine, is_cross, target,
+                        info, exe_wrap, linker=linker)
 
                 if 'ifort (IFORT)' in out:
-                    linker = XildLinuxDynamicLinker(compiler, for_machine, 'xild', '-Wl,', version=version)
-                    return IntelFortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
+                    linker = XildLinuxDynamicLinker(
+                        compiler, for_machine, 'xild', IntelFortranCompiler.LINKER_PREFIX, version=version)
+                    return IntelFortranCompiler(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, full_version=full_version, linker=linker)
 
                 if 'PathScale EKOPath(tm)' in err:
-                    return PathScaleFortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version)
+                    return PathScaleFortranCompiler(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, full_version=full_version)
 
                 if 'PGI Compilers' in out:
-                    if self.machines[for_machine].is_darwin():
-                        compiler_type = CompilerType.PGI_OSX
-                    elif self.machines[for_machine].is_windows():
-                        compiler_type = CompilerType.PGI_WIN
-                    else:
-                        compiler_type = CompilerType.PGI_STANDARD
-                    linker = PGIDynamicLinker(compiler, for_machine, 'pgi', PGIFortranCompiler.LINKER_PREFIX, version=version)
-                    return PGIFortranCompiler(compiler, version, compiler_type, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
+                    linker = PGIDynamicLinker(
+                        compiler, for_machine, 'pgi',
+                        PGIFortranCompiler.LINKER_PREFIX, version=version)
+                    return PGIFortranCompiler(
+                        compiler, version, for_machine, is_cross,
+                        self.machines[for_machine], exe_wrap,
+                        full_version=full_version, linker=linker)
 
                 if 'flang' in out or 'clang' in out:
-                    linker = self._guess_nix_linker(compiler, for_machine, FlangFortranCompiler.LINKER_PREFIX)
-                    return FlangFortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
+                    linker = self._guess_nix_linker(
+                        compiler, for_machine, FlangFortranCompiler.LINKER_PREFIX)
+                    return FlangFortranCompiler(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, full_version=full_version, linker=linker)
 
                 if 'Open64 Compiler Suite' in err:
-                    linker = self._guess_nix_linker(compiler, for_machine, Open64FortranCompiler.LINKER_PREFIX)
-                    return Open64FortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
+                    linker = self._guess_nix_linker(
+                        compiler, for_machine, Open64FortranCompiler.LINKER_PREFIX)
+                    return Open64FortranCompiler(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, full_version=full_version, linker=linker)
 
                 if 'NAG Fortran' in err:
-                    linker = self._guess_nix_linker(compiler, for_machine, NAGFortranCompiler.LINKER_PREFIX)
-                    return NAGFortranCompiler(compiler, version, for_machine, is_cross, exe_wrap, full_version=full_version, linker=linker)
+                    linker = self._guess_nix_linker(
+                        compiler, for_machine, NAGFortranCompiler.LINKER_PREFIX)
+                    return NAGFortranCompiler(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, full_version=full_version, linker=linker)
+
         self._handle_exceptions(popen_exceptions, compilers)
 
     def get_scratch_dir(self):
@@ -1165,6 +1189,8 @@ class Environment:
         popen_exceptions = {}
         compilers, ccache, exe_wrap = self._get_compilers('objc' if objc else 'objcpp', for_machine)
         is_cross = not self.machines.matches_build_machine(for_machine)
+        info = self.machines[for_machine]
+
         for compiler in compilers:
             if isinstance(compiler, str):
                 compiler = [compiler]
@@ -1180,32 +1206,33 @@ class Environment:
                 if not defines:
                     popen_exceptions[' '.join(compiler)] = 'no pre-processor defines'
                     continue
-                compiler_type = self.get_gnu_compiler_type(defines)
                 version = self.get_gnu_version_from_defines(defines)
                 comp = GnuObjCCompiler if objc else GnuObjCPPCompiler
                 linker = self._guess_nix_linker(compiler, for_machine, comp.LINKER_PREFIX)
-                return comp(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, defines, linker=linker)
+                return comp(
+                    ccache + compiler, version, for_machine, is_cross, info,
+                    exe_wrap, defines, linker=linker)
             if 'clang' in out:
                 linker = None
                 comp = ClangObjCCompiler if objc else ClangObjCPPCompiler
-                if 'Apple' in out or self.machines[for_machine].is_darwin():
-                    compiler_type = CompilerType.CLANG_OSX
-                elif 'windows' in out or self.machines[for_machine].is_windows():
-                    compiler_type = CompilerType.CLANG_MINGW
+                if 'windows' in out or self.machines[for_machine].is_windows():
                     # If we're in a MINGW context this actually will use a gnu style ld
                     try:
                         linker = self._guess_win_linker(compiler, for_machine, comp.LINKER_PREFIX)
                     except MesonException:
                         pass
-                else:
-                    compiler_type = CompilerType.CLANG_STANDARD
+
                 if not linker:
-                    linker = self._guess_nix_linker(compiler, for_machine, comp.LINKER_PREFIX)
-                return comp(ccache + compiler, version, compiler_type, for_machine, is_cross, exe_wrap, linker=linker)
+                    linker = self._guess_nix_linker(
+                        compiler, for_machine, comp.LINKER_PREFIX)
+                return comp(
+                    ccache + compiler, version, for_machine,
+                    is_cross, info, exe_wrap, linker=linker)
         self._handle_exceptions(popen_exceptions, compilers)
 
     def detect_java_compiler(self, for_machine):
         exelist = self.binaries.host.lookup_entry('java')
+        info = self.machines[for_machine]
         if exelist is None:
             # TODO support fallback
             exelist = [self.default_java[0]]
@@ -1220,12 +1247,13 @@ class Environment:
                 parts = (err if 'javac' in err else out).split()
                 if len(parts) > 1:
                     version = parts[1]
-            return JavaCompiler(exelist, version, for_machine)
+            return JavaCompiler(exelist, version, for_machine, info)
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
 
     def detect_cs_compiler(self, for_machine):
         compilers, ccache, exe_wrap = self._get_compilers('cs', for_machine)
         popen_exceptions = {}
+        info = self.machines[for_machine]
         for comp in compilers:
             if not isinstance(comp, list):
                 comp = [comp]
@@ -1237,15 +1265,17 @@ class Environment:
 
             version = search_version(out)
             if 'Mono' in out:
-                return MonoCompiler(comp, version, for_machine)
+                cls = MonoCompiler
             elif "Visual C#" in out:
-                return VisualStudioCsCompiler(comp, version, for_machine)
+                cls = VisualStudioCsCompiler
+            return cls(comp, version, for_machine, info)
 
         self._handle_exceptions(popen_exceptions, compilers)
 
     def detect_vala_compiler(self, for_machine):
         exelist = self.binaries.host.lookup_entry('vala')
         is_cross = not self.machines.matches_build_machine(for_machine)
+        info = self.machines[for_machine]
         if exelist is None:
             # TODO support fallback
             exelist = [self.default_vala[0]]
@@ -1256,13 +1286,14 @@ class Environment:
             raise EnvironmentException('Could not execute Vala compiler "%s"' % ' '.join(exelist))
         version = search_version(out)
         if 'Vala' in out:
-            return ValaCompiler(exelist, version, for_machine, is_cross)
+            return ValaCompiler(exelist, version, for_machine, info, is_cross)
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
 
     def detect_rust_compiler(self, for_machine):
         popen_exceptions = {}
         compilers, ccache, exe_wrap = self._get_compilers('rust', for_machine)
         is_cross = not self.machines.matches_build_machine(for_machine)
+        info = self.machines[for_machine]
         for compiler in compilers:
             if isinstance(compiler, str):
                 compiler = [compiler]
@@ -1284,14 +1315,19 @@ class Environment:
                 # default, and apple ld is used on mac.
                 # TODO: find some better way to figure this out.
                 if self.machines[for_machine].is_darwin():
-                    linker = AppleDynamicLinker([], for_machine, 'Apple ld', '-Wl,')
+                    linker = AppleDynamicLinker(
+                        [], for_machine, 'Apple ld', RustCompiler.LINKER_PREFIX)
                 else:
-                    linker = GnuDynamicLinker([], for_machine, 'GNU ld', '-Wl,')
-                return RustCompiler(compiler, version, for_machine, is_cross, exe_wrap, linker=linker)
+                    linker = GnuDynamicLinker(
+                        [], for_machine, 'GNU ld', RustCompiler.LINKER_PREFIX)
+                return RustCompiler(
+                    compiler, version, for_machine, is_cross, info, exe_wrap,
+                    linker=linker)
 
         self._handle_exceptions(popen_exceptions, compilers)
 
     def detect_d_compiler(self, for_machine: MachineChoice):
+        info = self.machines[for_machine]
         exelist = self.binaries[for_machine].lookup_entry('d')
         # Search for a D compiler.
         # We prefer LDC over GDC unless overridden with the DC
@@ -1343,10 +1379,14 @@ class Environment:
                         exelist, for_machine,
                         compilers.LLVMDCompiler.LINKER_PREFIX,
                         extra_args=[f.name])
-            return compilers.LLVMDCompiler(exelist, version, for_machine, arch, full_version=full_version, linker=linker)
+            return compilers.LLVMDCompiler(
+                exelist, version, for_machine, info, arch,
+                full_version=full_version, linker=linker)
         elif 'gdc' in out:
             linker = self._guess_nix_linker(exelist, for_machine, compilers.GnuDCompiler.LINKER_PREFIX)
-            return compilers.GnuDCompiler(exelist, version, for_machine, arch, full_version=full_version, linker=linker)
+            return compilers.GnuDCompiler(
+                exelist, version, for_machine, info, arch,
+                full_version=full_version, linker=linker)
         elif 'The D Language Foundation' in out or 'Digital Mars' in out:
             # DMD seems to require a file
             m = self.machines[for_machine]
@@ -1358,12 +1398,15 @@ class Environment:
                         exelist, for_machine,
                         compilers.LLVMDCompiler.LINKER_PREFIX,
                         extra_args=[f.name])
-            return compilers.DmdDCompiler(exelist, version, for_machine, arch, full_version=full_version, linker=linker)
+            return compilers.DmdDCompiler(
+                exelist, version, for_machine, info, arch,
+                full_version=full_version, linker=linker)
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
 
     def detect_swift_compiler(self, for_machine):
         exelist = self.binaries.host.lookup_entry('swift')
         is_cross = not self.machines.matches_build_machine(for_machine)
+        info = self.machines[for_machine]
         if exelist is None:
             # TODO support fallback
             exelist = [self.default_swift[0]]
@@ -1377,8 +1420,11 @@ class Environment:
             # As for 5.0.1 swiftc *requires* a file to check the linker:
             with tempfile.NamedTemporaryFile(suffix='.swift') as f:
                 linker = self._guess_nix_linker(
-                    exelist, for_machine, compilers.SwiftCompiler.LINKER_PREFIX, extra_args=[f.name])
-            return compilers.SwiftCompiler(exelist, version, for_machine, is_cross, linker=linker)
+                    exelist, for_machine,
+                    compilers.SwiftCompiler.LINKER_PREFIX,
+                    extra_args=[f.name])
+            return compilers.SwiftCompiler(
+                exelist, version, for_machine, info, is_cross, linker=linker)
 
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1034,7 +1034,6 @@ class Environment:
         popen_exceptions = {}
         is_cross = not self.machines.matches_build_machine(for_machine)
         compilers, ccache, exe_wrap = self._get_compilers('cuda', for_machine)
-        info = self.machines[for_machine]
         for compiler in compilers:
             if isinstance(compiler, str):
                 compiler = [compiler]

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -252,7 +252,7 @@ class DynamicLinker(metaclass=abc.ABCMeta):
         return self.prefix_arg + [arg]
 
     def __init__(self, exelist: typing.List[str], for_machine: mesonlib.MachineChoice,
-                 id_: str, prefix_arg: str, *, version: str = 'unknown version'):
+                 id_: str, prefix_arg: typing.Union[str, typing.List[str]], *, version: str = 'unknown version'):
         self.exelist = exelist
         self.for_machine = for_machine
         self.version = version

--- a/mesonbuild/munstable_coredata.py
+++ b/mesonbuild/munstable_coredata.py
@@ -36,9 +36,6 @@ def dump_compilers(compilers):
             print('      Full version: ' + compiler.full_version)
         if compiler.version:
             print('      Detected version: ' + compiler.version)
-        if hasattr(compiler, 'compiler_type'):
-            print('      Detected type: ' + repr(compiler.compiler_type))
-        #pprint.pprint(compiler.__dict__)
 
 
 def dump_guids(d):

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -628,7 +628,7 @@ def detect_tests_to_run(only: typing.List[str]) -> typing.List[typing.Tuple[str,
 
         ('java', 'java', backend is not Backend.ninja or mesonlib.is_osx() or not have_java()),
         ('C#', 'csharp', skip_csharp(backend)),
-        ('vala', 'vala', backend is not Backend.ninja or not shutil.which('valac')),
+        ('vala', 'vala', backend is not Backend.ninja or not shutil.which(os.environ.get('VALAC', 'valac'))),
         ('rust', 'rust', should_skip_rust()),
         ('d', 'd', backend is not Backend.ninja or not have_d_compiler()),
         ('objective c', 'objc', backend not in (Backend.ninja, Backend.xcode) or not have_objc_compiler()),

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -359,7 +359,7 @@ class InternalTests(unittest.TestCase):
 
     def test_compiler_args_class(self):
         cargsfunc = mesonbuild.compilers.CompilerArgs
-        cc = mesonbuild.compilers.CCompiler([], 'fake', False, MachineChoice.HOST)
+        cc = mesonbuild.compilers.CCompiler([], 'fake', False, MachineChoice.HOST, mock.Mock())
         # Test that bad initialization fails
         self.assertRaises(TypeError, cargsfunc, [])
         self.assertRaises(TypeError, cargsfunc, [], [])
@@ -446,7 +446,7 @@ class InternalTests(unittest.TestCase):
         cargsfunc = mesonbuild.compilers.CompilerArgs
         ## Test --start/end-group
         linker = mesonbuild.linkers.GnuDynamicLinker([], MachineChoice.HOST, 'fake', '-Wl,')
-        gcc = mesonbuild.compilers.GnuCCompiler([], 'fake', mesonbuild.compilers.CompilerType.GCC_STANDARD, False, MachineChoice.HOST, linker=linker)
+        gcc = mesonbuild.compilers.GnuCCompiler([], 'fake', False, MachineChoice.HOST, mock.Mock(), linker=linker)
         ## Ensure that the fake compiler is never called by overriding the relevant function
         gcc.get_default_include_dirs = lambda: ['/usr/include', '/usr/share/include', '/usr/local/include']
         ## Test that 'direct' append and extend works
@@ -475,7 +475,7 @@ class InternalTests(unittest.TestCase):
         cargsfunc = mesonbuild.compilers.CompilerArgs
         ## Test --start/end-group
         linker = mesonbuild.linkers.GnuDynamicLinker([], MachineChoice.HOST, 'fake', '-Wl,')
-        gcc = mesonbuild.compilers.GnuCCompiler([], 'fake', mesonbuild.compilers.CompilerType.GCC_STANDARD, False, MachineChoice.HOST, linker=linker)
+        gcc = mesonbuild.compilers.GnuCCompiler([], 'fake', False, MachineChoice.HOST, mock.Mock(), linker=linker)
         ## Ensure that the fake compiler is never called by overriding the relevant function
         gcc.get_default_include_dirs = lambda: ['/usr/include', '/usr/share/include', '/usr/local/include']
         ## Test that 'direct' append and extend works
@@ -2274,35 +2274,35 @@ class AllPlatformTests(BasePlatformTests):
             if isinstance(cc, gnu):
                 self.assertIsInstance(linker, ar)
                 if is_osx():
-                    self.assertEqual(cc.compiler_type, mesonbuild.compilers.CompilerType.GCC_OSX)
-                elif is_windows():
-                    self.assertEqual(cc.compiler_type, mesonbuild.compilers.CompilerType.GCC_MINGW)
-                elif is_cygwin():
-                    self.assertEqual(cc.compiler_type, mesonbuild.compilers.CompilerType.GCC_CYGWIN)
+                    self.assertIsInstance(cc.linker, mesonbuild.linkers.AppleDynamicLinker)
                 else:
-                    self.assertEqual(cc.compiler_type, mesonbuild.compilers.CompilerType.GCC_STANDARD)
+                    self.assertIsInstance(cc.linker, mesonbuild.linkers.GnuLikeDynamicLinkerMixin)
+            if isinstance(cc, clangcl):
+                self.assertIsInstance(linker, lib)
+                self.assertIsInstance(cc.linker, mesonbuild.linkers.ClangClDynamicLinker)
             if isinstance(cc, clang):
                 self.assertIsInstance(linker, ar)
                 if is_osx():
-                    self.assertEqual(cc.compiler_type, mesonbuild.compilers.CompilerType.CLANG_OSX)
+                    self.assertIsInstance(cc.linker, mesonbuild.linkers.AppleDynamicLinker)
                 elif is_windows():
-                    # Not implemented yet
-                    self.assertEqual(cc.compiler_type, mesonbuild.compilers.CompilerType.CLANG_MINGW)
+                    # This is clang, not clang-cl
+                    self.assertIsInstance(cc.linker, mesonbuild.linkers.MSVCDynamicLinker)
                 else:
-                    self.assertEqual(cc.compiler_type, mesonbuild.compilers.CompilerType.CLANG_STANDARD)
+                    self.assertIsInstance(cc.linker, mesonbuild.linkers.GnuLikeDynamicLinkerMixin)
             if isinstance(cc, intel):
                 self.assertIsInstance(linker, ar)
                 if is_osx():
-                    self.assertEqual(cc.compiler_type, mesonbuild.compilers.CompilerType.ICC_OSX)
+                    self.assertIsInstance(cc.linker, mesonbuild.linkers.XildAppleDynamicLinker)
                 elif is_windows():
-                    self.assertEqual(cc.compiler_type, mesonbuild.compilers.CompilerType.ICC_WIN)
+                    self.assertIsInstance(cc.linker, mesonbuild.linkers.XilinkDynamicLinker)
                 else:
-                    self.assertEqual(cc.compiler_type, mesonbuild.compilers.CompilerType.ICC_STANDARD)
+                    self.assertIsInstance(cc.linker, mesonbuild.linkers.XildLinuxDynamicLinker)
             if isinstance(cc, msvc):
                 self.assertTrue(is_windows())
                 self.assertIsInstance(linker, lib)
                 self.assertEqual(cc.id, 'msvc')
                 self.assertTrue(hasattr(cc, 'is_64'))
+                self.assertIsInstance(cc.linker, mesonbuild.linkers.MSVCDynamicLinker)
                 # If we're on Windows CI, we know what the compiler will be
                 if 'arch' in os.environ:
                     if os.environ['arch'] == 'x64':
@@ -2717,8 +2717,7 @@ int main(int argc, char **argv) {
                 '/NOLOGO', '/DLL', '/DEBUG', '/IMPLIB:' + impfile,
                 '/OUT:' + outfile, objectfile]
         else:
-            if not (compiler.compiler_type.is_windows_compiler or
-                    compiler.compiler_type.is_osx_compiler):
+            if not (compiler.info.is_windows() or compiler.info.is_cygwin() or compiler.info.is_darwin()):
                 extra_args += ['-fPIC']
             link_cmd = compiler.get_exelist() + ['-shared', '-o', outfile, objectfile]
             if not mesonbuild.mesonlib.is_osx():
@@ -6898,7 +6897,8 @@ def _clang_at_least(compiler, minver: str, apple_minver: str) -> bool:
     at_least: bool
         Clang is at least the specified version
     """
-    if compiler.compiler_type == mesonbuild.compilers.CompilerType.CLANG_OSX:
+    if isinstance(compiler, (mesonbuild.compilers.AppleClangCCompiler,
+                             mesonbuild.compilers.AppleClangCPPCompiler)):
         return version_compare(compiler.version, apple_minver)
     return version_compare(compiler.version, minver)
 


### PR DESCRIPTION
This series deletes the CompilerType enum, and replaces it with a reference of the relevant `MachineInfo`. This has a couple of nice properties, namely that the MachineInfo is more accurate than the CompilerType info is, and second that it allows us to use `MachineInfo.is_os()` instead of `mesonlib.is_os()`, the former is safe for cross compiles while the later isn't. 