### PR TITLE
mesonlib.split_args/quote_arg/join_args

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -14,7 +14,6 @@
 from typing import List
 import os
 import re
-import shlex
 import pickle
 import subprocess
 from collections import OrderedDict
@@ -32,7 +31,7 @@ from .. import compilers
 from ..compilers import Compiler, CompilerArgs, CCompiler, VisualStudioLikeCompiler, FortranCompiler
 from ..linkers import ArLinker
 from ..mesonlib import (
-    File, LibType, MachineChoice, MesonException, OrderedSet, PerMachine, ProgressBar
+    File, LibType, MachineChoice, MesonException, OrderedSet, PerMachine, ProgressBar, quote_arg
 )
 from ..mesonlib import get_compiler_for_source, has_path_sep
 from .backends import CleanTrees
@@ -44,11 +43,14 @@ FORTRAN_SUBMOD_PAT = r"^\s*\bsubmodule\b\s*\((\w+:?\w+)\)\s*(\w+)"
 FORTRAN_USE_PAT = r"^\s*use,?\s*(?:non_intrinsic)?\s*(?:::)?\s*(\w+)"
 
 if mesonlib.is_windows():
+    # FIXME: can't use quote_arg on Windows just yet; there are a number of existing workarounds
+    # throughout the codebase that cumulatively make the current code work (see, e.g. Backend.escape_extra_args
+    # and NinjaBuildElement.write below) and need to be properly untangled before attempting this
     quote_func = lambda s: '"{}"'.format(s)
     execute_wrapper = ['cmd', '/c']
     rmfile_prefix = ['del', '/f', '/s', '/q', '{}', '&&']
 else:
-    quote_func = shlex.quote
+    quote_func = quote_arg
     execute_wrapper = []
     rmfile_prefix = ['rm', '-f', '{}', '&&']
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib, enum, os.path, re, tempfile, shlex
+import contextlib, enum, os.path, re, tempfile
 import typing
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple, List
 
 from ..linkers import StaticLinker, GnuLikeDynamicLinkerMixin
 from .. import coredata
@@ -22,7 +22,7 @@ from .. import mlog
 from .. import mesonlib
 from ..mesonlib import (
     EnvironmentException, MachineChoice, MesonException, OrderedSet,
-    Popen_safe
+    Popen_safe, split_args
 )
 from ..envconfig import (
     Properties,
@@ -799,7 +799,7 @@ class Compiler:
         env_compile_flags = os.environ.get(cflags_mapping[lang])
         log_var(cflags_mapping[lang], env_compile_flags)
         if env_compile_flags is not None:
-            compile_flags += shlex.split(env_compile_flags)
+            compile_flags += split_args(env_compile_flags)
 
         # Link flags (same for all languages)
         if self.use_ldflags():
@@ -820,7 +820,7 @@ class Compiler:
             env_preproc_flags = os.environ.get('CPPFLAGS')
             log_var('CPPFLAGS', env_preproc_flags)
             if env_preproc_flags is not None:
-                compile_flags += shlex.split(env_preproc_flags)
+                compile_flags += split_args(env_preproc_flags)
 
         return compile_flags, link_flags
 
@@ -830,10 +830,10 @@ class Compiler:
         opts.update({
             self.language + '_args': coredata.UserArrayOption(
                 description + ' compiler',
-                [], shlex_split=True, user_input=True, allow_dups=True),
+                [], split_args=True, user_input=True, allow_dups=True),
             self.language + '_link_args': coredata.UserArrayOption(
                 description + ' linker',
-                [], shlex_split=True, user_input=True, allow_dups=True),
+                [], split_args=True, user_input=True, allow_dups=True),
         })
 
         return opts

--- a/mesonbuild/compilers/mixins/islinker.py
+++ b/mesonbuild/compilers/mixins/islinker.py
@@ -21,7 +21,6 @@ classes for those cases.
 """
 
 import os
-import shlex
 import typing
 
 from ... import mesonlib
@@ -39,7 +38,7 @@ class LinkerEnvVarsMixin:
         flags = os.environ.get('LDFLAGS')
         if not flags:
             return []
-        return shlex.split(flags)
+        return mesonlib.split_args(flags)
 
 
 class BasicLinkerIsCompilerMixin:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 from . import mlog
-import pickle, os, uuid, shlex
+import pickle, os, uuid
 import sys
 from itertools import chain
 from pathlib import PurePath
 from collections import OrderedDict
 from .mesonlib import (
     MesonException, MachineChoice, PerMachine,
-    default_libdir, default_libexecdir, default_prefix
+    default_libdir, default_libexecdir, default_prefix, split_args
 )
 from .wrap import WrapMode
 import ast
@@ -163,9 +163,9 @@ class UserComboOption(UserOption[str]):
         return value
 
 class UserArrayOption(UserOption[List[str]]):
-    def __init__(self, description, value, shlex_split=False, user_input=False, allow_dups=False, **kwargs):
+    def __init__(self, description, value, split_args=False, user_input=False, allow_dups=False, **kwargs):
         super().__init__(description, kwargs.get('choices', []), yielding=kwargs.get('yielding', None))
-        self.shlex_split = shlex_split
+        self.split_args = split_args
         self.allow_dups = allow_dups
         self.value = self.validate_value(value, user_input=user_input)
 
@@ -183,8 +183,8 @@ class UserArrayOption(UserOption[List[str]]):
             elif value == '':
                 newvalue = []
             else:
-                if self.shlex_split:
-                    newvalue = shlex.split(value)
+                if self.split_args:
+                    newvalue = split_args(value)
                 else:
                     newvalue = [v.strip() for v in value.split(',')]
         elif isinstance(value, list):

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -18,11 +18,11 @@ from pathlib import Path
 import functools
 import os
 import re
-import shlex
 import sysconfig
 
 from .. import mlog
 from .. import mesonlib
+from ..mesonlib import split_args
 from ..environment import detect_cpu_family
 
 from .base import (
@@ -277,7 +277,7 @@ class MPIDependency(ExternalDependency):
                 mlog.debug(mlog.bold('Standard output\n'), o)
                 mlog.debug(mlog.bold('Standard error\n'), e)
                 return
-            cargs = shlex.split(o)
+            cargs = split_args(o)
 
             cmd = prog.get_command() + ['--showme:link']
             p, o, e = mesonlib.Popen_safe(cmd)
@@ -287,7 +287,7 @@ class MPIDependency(ExternalDependency):
                 mlog.debug(mlog.bold('Standard output\n'), o)
                 mlog.debug(mlog.bold('Standard error\n'), e)
                 return
-            libs = shlex.split(o)
+            libs = split_args(o)
 
             cmd = prog.get_command() + ['--showme:version']
             p, o, e = mesonlib.Popen_safe(cmd)
@@ -316,7 +316,7 @@ class MPIDependency(ExternalDependency):
                 mlog.debug(mlog.bold('Standard output\n'), o)
                 mlog.debug(mlog.bold('Standard error\n'), e)
                 return
-            args = shlex.split(o)
+            args = split_args(o)
 
             version = None
 

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import configparser, os, shlex, subprocess
+import configparser, os, subprocess
 import typing
 
 from . import mesonlib
-from .mesonlib import EnvironmentException
+from .mesonlib import EnvironmentException, split_args
 from . import mlog
 
 _T = typing.TypeVar('_T')
@@ -361,7 +361,7 @@ This is probably wrong, it should always point to the native compiler.''' % evar
             evar = self.evarMap.get(name, "")
             command = os.environ.get(evar)
             if command is not None:
-                command = shlex.split(command)
+                command = split_args(command)
 
         # Do not return empty or blank string entries
         if command is not None and (len(command) == 0 or len(command[0].strip()) == 0):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os, platform, re, sys, shlex, shutil, subprocess, typing
+import os, platform, re, sys, shutil, subprocess, typing
 import tempfile
 
 from . import coredata
@@ -20,7 +20,7 @@ from .linkers import ArLinker, ArmarLinker, VisualStudioLinker, DLinker, CcrxLin
 from . import mesonlib
 from .mesonlib import (
     MesonException, EnvironmentException, MachineChoice, Popen_safe,
-    PerMachineDefaultable, PerThreeMachineDefaultable
+    PerMachineDefaultable, PerThreeMachineDefaultable, split_args, quote_arg
 )
 from . import mlog
 
@@ -119,7 +119,7 @@ def detect_gcovr(min_version='3.3', new_rootdir_version='4.2', log=False):
     found = search_version(found)
     if p.returncode == 0 and mesonlib.version_compare(found, '>=' + min_version):
         if log:
-            mlog.log('Found gcovr-{} at {}'.format(found, shlex.quote(shutil.which(gcovr_exe))))
+            mlog.log('Found gcovr-{} at {}'.format(found, quote_arg(shutil.which(gcovr_exe))))
         return gcovr_exe, mesonlib.version_compare(found, '>=' + new_rootdir_version)
     return None, None
 
@@ -157,7 +157,7 @@ def detect_ninja(version: str = '1.5', log: bool = False) -> str:
                     name = 'ninja'
                 if name == 'samu':
                     name = 'samurai'
-                mlog.log('Found {}-{} at {}'.format(name, found, shlex.quote(n)))
+                mlog.log('Found {}-{} at {}'.format(name, found, quote_arg(n)))
             return n
 
 def detect_native_windows_arch():
@@ -1321,7 +1321,7 @@ class Environment:
             if isinstance(compiler, compilers.CudaCompiler):
                 linkers = [self.cuda_static_linker, self.default_static_linker]
             elif evar in os.environ:
-                linkers = [shlex.split(os.environ[evar])]
+                linkers = [split_args(os.environ[evar])]
             elif isinstance(compiler, compilers.VisualStudioLikeCompiler):
                 linkers = [self.vs_static_linker, self.clang_cl_static_linker]
             elif isinstance(compiler, compilers.GnuCompiler):

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -14,7 +14,6 @@
 
 import abc
 import os
-import shlex
 import typing
 
 from . import mesonlib
@@ -279,7 +278,7 @@ class DynamicLinker(metaclass=abc.ABCMeta):
         flags = os.environ.get('LDFLAGS')
         if not flags:
             return []
-        return shlex.split(flags)
+        return mesonlib.split_args(flags)
 
     def get_option_args(self, options: 'OptionDictType') -> typing.List[str]:
         return []

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -17,7 +17,6 @@ functionality such as gobject-introspection, gresources and gtk-doc'''
 
 import os
 import copy
-import shlex
 import subprocess
 
 from .. import build
@@ -29,7 +28,7 @@ from . import get_include_args
 from . import ExtensionModule
 from . import ModuleReturnValue
 from ..mesonlib import (
-    MachineChoice, MesonException, OrderedSet, Popen_safe, extract_as_list
+    MachineChoice, MesonException, OrderedSet, Popen_safe, extract_as_list, join_args
 )
 from ..dependencies import Dependency, PkgConfigDependency, InternalDependency
 from ..interpreterbase import noKwargs, permittedKwargs, FeatureNew, FeatureNewKwargs
@@ -1079,12 +1078,12 @@ This will become a hard error in the future.''')
         ldflags.extend(compiler_flags[1])
         ldflags.extend(compiler_flags[2])
         if compiler:
-            args += ['--cc=%s' % ' '.join([shlex.quote(x) for x in compiler.get_exelist()])]
-            args += ['--ld=%s' % ' '.join([shlex.quote(x) for x in compiler.get_linker_exelist()])]
+            args += ['--cc=%s' % join_args(compiler.get_exelist())]
+            args += ['--ld=%s' % join_args(compiler.get_linker_exelist())]
         if cflags:
-            args += ['--cflags=%s' % ' '.join([shlex.quote(x) for x in cflags])]
+            args += ['--cflags=%s' % join_args(cflags)]
         if ldflags:
-            args += ['--ldflags=%s' % ' '.join([shlex.quote(x) for x in ldflags])]
+            args += ['--ldflags=%s' % join_args(ldflags)]
 
         return args
 

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -240,7 +240,7 @@ class PkgConfigModule(ExtensionModule):
 
     def _escape(self, value):
         '''
-        We cannot use shlex.quote because it quotes with ' and " which does not
+        We cannot use quote_arg because it quotes with ' and " which does not
         work with pkg-config and pkgconf at all.
         '''
         # We should always write out paths with / because pkg-config requires

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -29,7 +29,6 @@ import pickle
 import platform
 import random
 import re
-import shlex
 import signal
 import subprocess
 import sys
@@ -41,7 +40,7 @@ from . import build
 from . import environment
 from . import mlog
 from .dependencies import ExternalProgram
-from .mesonlib import MesonException, get_wine_shortpath
+from .mesonlib import MesonException, get_wine_shortpath, split_args
 
 if typing.TYPE_CHECKING:
     from .backend.backends import TestSerialisation
@@ -88,7 +87,7 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
                         help='Run test under gdb.')
     parser.add_argument('--list', default=False, dest='list', action='store_true',
                         help='List available tests.')
-    parser.add_argument('--wrapper', default=None, dest='wrapper', type=shlex.split,
+    parser.add_argument('--wrapper', default=None, dest='wrapper', type=split_args,
                         help='wrapper to run tests with (e.g. Valgrind)')
     parser.add_argument('-C', default='.', dest='wd',
                         help='directory to cd into before running')
@@ -116,7 +115,7 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
                         ' more time to execute.')
     parser.add_argument('--setup', default=None, dest='setup',
                         help='Which test setup to use.')
-    parser.add_argument('--test-args', default=[], type=shlex.split,
+    parser.add_argument('--test-args', default=[], type=split_args,
                         help='Arguments to pass to the specified test(s) or all tests')
     parser.add_argument('args', nargs='*',
                         help='Optional list of tests to run')

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -14,10 +14,9 @@
 
 import sys, os
 import subprocess
-import shlex
 import shutil
 import argparse
-from ..mesonlib import MesonException, Popen_safe, is_windows
+from ..mesonlib import MesonException, Popen_safe, is_windows, split_args
 from . import destdir_join
 
 parser = argparse.ArgumentParser()
@@ -149,7 +148,7 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
                          '--output-dir=' + abs_out]
 
         library_paths = []
-        for ldflag in shlex.split(ldflags):
+        for ldflag in split_args(ldflags):
             if ldflag.startswith('-Wl,-rpath,'):
                 library_paths.append(ldflag[11:])
 

--- a/mesonbuild/scripts/scanbuild.py
+++ b/mesonbuild/scripts/scanbuild.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 import os
-import shlex
 import subprocess
 import shutil
 import tempfile
 from ..environment import detect_ninja
-from ..mesonlib import Popen_safe
+from ..mesonlib import Popen_safe, split_args
 
 def scanbuild(exelist, srcdir, blddir, privdir, logdir, args):
     with tempfile.TemporaryDirectory(dir=privdir) as scandir:
@@ -63,7 +62,7 @@ def run(args):
             break
 
     if 'SCANBUILD' in os.environ:
-        exelist = shlex.split(os.environ['SCANBUILD'])
+        exelist = split_args(os.environ['SCANBUILD'])
     else:
         exelist = [toolname]
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -117,7 +117,7 @@ Backend = Enum('Backend', 'ninja vs xcode')
 
 if 'MESON_EXE' in os.environ:
     import shlex
-    meson_exe = shlex.split(os.environ['MESON_EXE'])
+    meson_exe = mesonlib.split_args(os.environ['MESON_EXE'])
 else:
     meson_exe = None
 


### PR DESCRIPTION
Closes #5726. Note that `shlex.quote`/`shlex.split` are still used for building/parsing `MESONINTROSPECT` path (it's [documented behavior](https://mesonbuild.com/Reference-manual.html) *and* `scripts/commandrunner.py` depends on it).