### PR TITLE
This is just a few small cleanups to the MachineInfo class

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -201,13 +201,13 @@ class MachineInfo:
         """
         Machine is windows?
         """
-        return self.system in {'windows', 'mingw'}
+        return self.system == 'windows' or 'mingw' in self.system
 
     def is_cygwin(self) -> bool:
         """
         Machine is cygwin?
         """
-        return self.system == 'cygwin'
+        return self.system.startswith('cygwin')
 
     def is_linux(self) -> bool:
         """

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -239,6 +239,19 @@ class MachineInfo:
         """
         return self.system == 'openbsd'
 
+    def is_dragonflybsd(self) -> bool:
+        """Machine is DragonflyBSD?"""
+        return self.system == 'dragonfly'
+
+    def is_freebsd(self) -> bool:
+        """Machine is FreeBSD?"""
+        return self.system == 'freebsd'
+
+    def is_sunos(self) -> bool:
+        """Machine is illumos or Solaris?"""
+        return self.system == 'sunos'
+
+
     # Various prefixes and suffixes for import libraries, shared libraries,
     # static libraries, and executables.
     # Versioning is added to these names in the backends as-needed.


### PR DESCRIPTION
These patches just make the MachineInfo.is_<os>() methods behave the same as the mesonlib.is_<os>() methods.

I think in the long term we should just do away with the mesonlib.is_<os> methods and use the MachineInfo classes, since they'll always be accurate for cross compiling.