### PR TITLE
use /bin/sh instead of /bin/bash

### DIFF
--- a/test cases/common/144 custom target multiple outputs/generator.py
+++ b/test cases/common/144 custom target multiple outputs/generator.py
@@ -11,4 +11,4 @@ odir = sys.argv[2]
 with open(os.path.join(odir, name + '.h'), 'w') as f:
     f.write('int func();\n')
 with open(os.path.join(odir, name + '.sh'), 'w') as f:
-    f.write('#!/bin/bash')
+    f.write('#!/bin/sh')

--- a/test cases/common/224 test priorities/test.sh
+++ b/test cases/common/224 test priorities/test.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "$1"

--- a/test cases/failing/42 custom target outputs not matching install_dirs/generator.py
+++ b/test cases/failing/42 custom target outputs not matching install_dirs/generator.py
@@ -13,4 +13,4 @@ with open(os.path.join(odir, name + '.h'), 'w') as f:
 with open(os.path.join(odir, name + '.c'), 'w') as f:
     f.write('int main(int argc, char *argv[]) { return 0; }')
 with open(os.path.join(odir, name + '.sh'), 'w') as f:
-    f.write('#!/bin/bash')
+    f.write('#!/bin/sh')


### PR DESCRIPTION
Although bash is almost always installed on Linux, it's not on other
Unicies. It also isn't guaranteed to be in /bin (it could be
/usr/bin/bash or /usr/local/bin/bash, for example). Fixes tests on
FreeBSD.