### PR TITLE
environment: Fix detection of MSVC arch on arm64

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -853,7 +853,7 @@ class Environment:
                 else:
                     m = 'Failed to detect MSVC compiler version: stderr was\n{!r}'
                     raise EnvironmentException(m.format(err))
-                match = re.search('.*(x86|x64|ARM|ARM64).*', lookat.split('\n')[0])
+                match = re.search(' for .*(x86|x64|ARM|ARM64)$', lookat.split('\n')[0])
                 if match:
                     target = match.group(1)
                 else:


### PR DESCRIPTION
The regex was incorrect, so it was matching 'ARM64' with 'ARM'.
Make the regex more specific so that it matches:

```
Microsoft (R) C/C++ Optimizing Compiler Version 19.16.27031.1 for x64
Microsoft (R) C/C++ Optimizing Compiler Version 19.16.27031.1 for x86
Microsoft (R) C/C++ Optimizing Compiler Version 19.16.27031.1 for ARM64
Microsoft (R) 32-bit C/C++ Optimizing Compiler Version 16.00.30319.01 for 80x86
```
etc.