### PR TITLE
Compilers: Add support for b_sanitize to the ClangCL compilers

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -29,6 +29,7 @@ from .mixins.elbrus import ElbrusCompiler
 from .mixins.pgi import PGICompiler
 from .mixins.islinker import BasicLinkerIsCompilerMixin, LinkerEnvVarsMixin
 from .mixins.emscripten import EmscriptenMixin
+from .mixins.misc import SanitizerMixin
 from .compilers import (
     gnu_winlibs,
     msvc_winlibs,
@@ -314,12 +315,13 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
         MSVCCompiler.__init__(self, target)
 
 
-class ClangClCCompiler(ClangClCompiler, VisualStudioLikeCCompilerMixin, CCompiler):
+class ClangClCCompiler(SanitizerMixin, ClangClCompiler, VisualStudioLikeCCompilerMixin, CCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross, info: 'MachineInfo', exe_wrap, target, **kwargs):
         CCompiler.__init__(self, exelist, version, for_machine, is_cross,
                            info, exe_wrap, **kwargs)
         ClangClCompiler.__init__(self, target)
+        SanitizerMixin.__init__(self)
 
 
 class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerMixin, CCompiler):

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -283,10 +283,6 @@ def get_base_compile_args(options, compiler):
     except KeyError:
         pass
     try:
-        args += compiler.sanitizer_compile_args(options['b_sanitize'].value)
-    except KeyError:
-        pass
-    try:
         pgo_val = options['b_pgo'].value
         if pgo_val == 'generate':
             args.extend(compiler.get_profile_generate_args())
@@ -318,6 +314,14 @@ def get_base_compile_args(options, compiler):
             pass
     except KeyError:
         pass
+
+    # For clang-cl, which currently (2019.08.27) doesn't support linking
+    # sanitizers with debug CRTs.
+    if {'/MDd', '/MTd'}.isdisjoint(set(args)):
+        try:
+            args += compiler.sanitizer_compile_args(options['b_sanitize'].value)
+        except KeyError:
+            pass
     return args
 
 def get_base_link_args(options, linker, is_shared_module):

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -38,6 +38,7 @@ from .mixins.elbrus import ElbrusCompiler
 from .mixins.pgi import PGICompiler
 from .mixins.islinker import BasicLinkerIsCompilerMixin, LinkerEnvVarsMixin
 from .mixins.emscripten import EmscriptenMixin
+from .mixins.misc import SanitizerMixin
 
 if T.TYPE_CHECKING:
     from ..envconfig import MachineInfo
@@ -545,12 +546,13 @@ class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixi
             del args[i]
         return args
 
-class ClangClCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixin, ClangClCompiler, CPPCompiler):
+class ClangClCPPCompiler(SanitizerMixin, CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixin, ClangClCompiler, CPPCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross, info: 'MachineInfo', exe_wrap, target, **kwargs):
         CPPCompiler.__init__(self, exelist, version, for_machine, is_cross,
                              info, exe_wrap, **kwargs)
         ClangClCompiler.__init__(self, target)
+        SanitizerMixin.__init__(self)
         self.id = 'clang-cl'
 
     def get_options(self):

--- a/mesonbuild/compilers/mixins/misc.py
+++ b/mesonbuild/compilers/mixins/misc.py
@@ -1,0 +1,29 @@
+# Copyright 2019 The Meson development team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A collection of small unrelated mixins for Compilers."""
+
+import typing as T
+
+
+class SanitizerMixin:
+
+    def __init__(self):
+        if 'b_sanitize' not in self.base_options:
+            self.base_options.append('b_sanitize')
+
+    def sanitizer_compile_args(self, value: str) -> T.List[str]:
+        if value == 'none':
+            return []
+        return ['-fsanitize=' + value]


### PR DESCRIPTION
Everything works on the meson side, but the programs immediately crash,
at least with the address sanitizer.

Closes  #5845