### PR TITLE
Fix plain clang on windows

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -650,6 +650,8 @@ class Compiler:
     # manually searched.
     internal_libs = ()
 
+    LINKER_PREFIX = None  # type: typing.Union[None, str, typing.List[str]]
+
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  linker: typing.Optional['DynamicLinker'] = None, **kwargs):
         if isinstance(exelist, str):

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -25,6 +25,9 @@ if typing.TYPE_CHECKING:
 
 
 class CudaCompiler(Compiler):
+
+    LINKER_PREFIX = '-Xlinker='
+
     def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
         if not hasattr(self, 'language'):
             self.language = 'cuda'
@@ -162,17 +165,8 @@ class CudaCompiler(Compiler):
 
     @staticmethod
     def _cook_link_args(args: typing.List[str]) -> typing.List[str]:
-        """
-        Converts GNU-style arguments -Wl,-arg,-arg
-        to NVCC-style arguments -Xlinker=-arg,-arg
-        """
-        cooked = []  # type: typing.List[str]
-        for arg in args:
-            if arg.startswith('-Wl,'):
-                arg = arg.replace('-Wl,', '-Xlinker=', 1)
-            arg = arg.replace(' ', '\\')
-            cooked.append(arg)
-        return cooked
+        """Fixup arguments."""
+        return [a.replace(' ', '\\') for a in args]
 
     def name_string(self):
         return ' '.join(self.exelist)

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -67,6 +67,8 @@ dmd_optimization_args = {'0': [],
 
 class DmdLikeCompilerMixin:
 
+    LINKER_PREFIX = '-L'
+
     def get_output_args(self, target):
         return ['-of=' + target]
 
@@ -577,6 +579,10 @@ class DCompiler(Compiler):
 
 
 class GnuDCompiler(DCompiler, GnuCompiler):
+
+    # we mostly want DCompiler, but that gives us the Compiler.LINKER_PREFIX instead
+    LINKER_PREFIX = GnuCompiler.LINKER_PREFIX
+
     def __init__(self, exelist, version, for_machine: MachineChoice, arch, **kwargs):
         DCompiler.__init__(self, exelist, version, for_machine, arch, **kwargs)
         self.id = 'gcc'

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -185,6 +185,9 @@ class ElbrusFortranCompiler(GnuFortranCompiler, ElbrusCompiler):
         ElbrusCompiler.__init__(self, compiler_type, defines)
 
 class G95FortranCompiler(FortranCompiler):
+
+    LINKER_PREFIX = '-Wl,'
+
     def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwags):
         FortranCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwags)
         self.id = 'g95'
@@ -203,6 +206,9 @@ class G95FortranCompiler(FortranCompiler):
 
 
 class SunFortranCompiler(FortranCompiler):
+
+    LINKER_PREFIX = '-Wl,'
+
     def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwags):
         FortranCompiler.__init__(self, exelist, version, for_machine, is_cross, exe_wrapper, **kwags)
         self.id = 'sun'

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -128,6 +128,9 @@ class GnuLikeCompiler(metaclass=abc.ABCMeta):
     and ICC. Certain functionality between them is different and requires
     that the actual concrete subclass define their own implementation.
     """
+
+    LINKER_PREFIX = '-Wl,'
+
     def __init__(self, compiler_type: 'CompilerType'):
         self.compiler_type = compiler_type
         self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage',
@@ -296,6 +299,7 @@ class GnuCompiler(GnuLikeCompiler):
     GnuCompiler represents an actual GCC in its many incarnations.
     Compilers imitating GCC (Clang/Intel) should use the GnuLikeCompiler ABC.
     """
+
     def __init__(self, compiler_type: 'CompilerType', defines: typing.Dict[str, str]):
         super().__init__(compiler_type)
         self.id = 'gcc'

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -27,6 +27,9 @@ swift_optimization_args = {'0': [],
                            }
 
 class SwiftCompiler(Compiler):
+
+    LINKER_PREFIX = ['-Xlinker']
+
     def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, **kwargs):
         self.language = 'swift'
         super().__init__(exelist, version, for_machine, **kwargs)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -444,7 +444,7 @@ class InternalTests(unittest.TestCase):
     def test_compiler_args_class_gnuld(self):
         cargsfunc = mesonbuild.compilers.CompilerArgs
         ## Test --start/end-group
-        linker = mesonbuild.linkers.GnuDynamicLinker([], MachineChoice.HOST, 'fake')
+        linker = mesonbuild.linkers.GnuDynamicLinker([], MachineChoice.HOST, 'fake', '-Wl,')
         gcc = mesonbuild.compilers.GnuCCompiler([], 'fake', mesonbuild.compilers.CompilerType.GCC_STANDARD, False, MachineChoice.HOST, linker=linker)
         ## Test that 'direct' append and extend works
         l = cargsfunc(gcc, ['-Lfoodir', '-lfoo'])


### PR DESCRIPTION
on Windows clang uses link.exe or lld-link.exe. It cannot (at least in my testing) use ld.lld (even though it installs it) because it has hardcoded arguments that ld.lld doesn't understand (-nologo, for example).

To fix this I've pulled `-Wl,` and similar out of the linkers as hardcoded values, and instead passed the value into the linkers at creation time. This has some additional nice affects like making the D and cuda compilers a little cleaner