### PR TITLE
ninjabackend: do not generate scan-build target if it cannnot be run

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2640,6 +2640,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         self.create_target_alias('meson-dist')
 
     def generate_scanbuild(self):
+        import shutil
+        if shutil.which('scan-build') is None:
+            return
         cmd = self.environment.get_build_command() + \
             ['--internal', 'scanbuild', self.environment.source_dir, self.environment.build_dir] + \
             self.environment.get_build_command() + self.get_user_option_args()


### PR DESCRIPTION
Hi,

This adds a small test for scan-build presence on the build machine before generating the scan-build target. I've taken the same approach as was done for the clang-format target.

This way, meson is not  proposing a target that cannot be run.

Best regards,