### PR TITLE
Add --cross-file-constant and --native-file-constant arguments

### DIFF
--- a/docs/markdown/Machine-files.md
+++ b/docs/markdown/Machine-files.md
@@ -128,6 +128,26 @@ b = a + 'World'
 a = 'Hello'
 ```
 
+*Since 0.60.0* The value in `[constants]` section of cross and native files can
+be overridden using `--cross-file-constant name=value` and `--native-file-constant name=value`
+command line arguments. Constants that don't have a default value must still be
+declared in the `[constants]` section with no value, user will have to set their
+value on the command line. This is intended to be used for example to set the path
+where user installed the toolchain or SDK. In the example below, user must pass
+`--cross-file-constant pkgconf=<value>`
+in the command line, and can pass `--cross-file-constant somepath=/other/path/to/toolchain`
+if they installed the toolchain in another location than the default.
+
+```ini
+[constants]
+pkgconf =
+somepath = '/default/path/to/toolchain'
+[binaries]
+c = somepath / 'gcc'
+cpp = somepath / 'g++'
+pkgconfig = pkgconf
+```
+
 ### Binaries
 
 The binaries section contains a list of binaries. These can be used

--- a/docs/markdown/snippets/cross_file_constants.md
+++ b/docs/markdown/snippets/cross_file_constants.md
@@ -1,0 +1,21 @@
+## Cross and native file constants
+
+The value in `[constants]` section of cross and native files can now be overridden
+using `--cross-file-constant name=value` and `--native-file-constant name=value`
+command line arguments. Constants that don't have a default value must still be
+declared in the `[constants]` section with no value, user will have to set their
+value on the command line. This is intended to be used for example to set the path
+where user installed the toolchain or SDK. In the example below, user must pass
+`--cross-file-constant pkgconf=<value>` in the command line, and can pass
+`--cross-file-constant somepath=/other/path/to/toolchain` if they installed the
+toolchain in another location than the default.
+
+```ini
+[constants]
+pkgconf =
+somepath = '/default/path/to/toolchain'
+[binaries]
+c = somepath / 'gcc'
+cpp = somepath / 'g++'
+pkgconfig = pkgconf
+```

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -34,9 +34,11 @@ class IntrospectionHelper(argparse.Namespace):
     # mimic an argparse namespace
     def __init__(self, cross_file: str):
         super().__init__()
-        self.cross_file = cross_file  # type: str
-        self.native_file = None       # type: str
-        self.cmd_line_options = {}    # type: T.Dict[str, str]
+        self.cross_file = cross_file     # type: str
+        self.cross_files_constants = {}  # type: T.Dict[str, str]
+        self.native_file = None          # type: str
+        self.native_files_constants = {} # type: T.Dict[str, str]
+        self.cmd_line_options = {}       # type: T.Dict[str, str]
 
     def __eq__(self, other: object) -> bool:
         return NotImplemented

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -429,6 +429,7 @@ class CoreData:
         self.version = version
         self.options: 'KeyedOptionDictType' = {}
         self.cross_files = self.__load_config_files(options, scratch_dir, 'cross')
+        self.cross_files_constants = options.cross_files_constants
         self.compilers = PerMachine(OrderedDict(), OrderedDict())  # type: PerMachine[T.Dict[str, Compiler]]
 
         # Set of subprojects that have already been initialized once, this is
@@ -449,6 +450,7 @@ class CoreData:
 
         # Only to print a warning if it changes between Meson invocations.
         self.config_files = self.__load_config_files(options, scratch_dir, 'native')
+        self.config_files_constants = options.native_files_constants
         self.builtin_options_libdir_cross_fixup()
         self.init_builtins('')
 
@@ -871,40 +873,51 @@ class CmdLineFileParser(configparser.ConfigParser):
         return option
 
 class MachineFileParser():
-    def __init__(self, filenames: T.List[str]) -> None:
+    def __init__(self, filenames: T.List[str], constants: T.Dict[str, str], kind: str)  -> None:
         self.parser = CmdLineFileParser()
         self.constants = {'True': True, 'False': False}
         self.sections = {}
+        self.kind = kind
 
         self.parser.read(filenames)
 
         # Parse [constants] first so they can be used in other sections
         if self.parser.has_section('constants'):
-            self.constants.update(self._parse_section('constants'))
+            self.constants.update(self._parse_section('constants', constants))
 
         for s in self.parser.sections():
             if s == 'constants':
                 continue
             self.sections[s] = self._parse_section(s)
 
-    def _parse_section(self, s):
+    def _parse_section(self, s, overrides=None):
         self.scope = self.constants.copy()
         section = {}
         for entry, value in self.parser.items(s):
             if ' ' in entry or '\t' in entry or "'" in entry or '"' in entry:
                 raise EnvironmentException(f'Malformed variable name {entry!r} in machine file.')
-            # Windows paths...
-            value = value.replace('\\', '\\\\')
-            try:
-                ast = mparser.Parser(value, 'machinefile').parse()
-                res = self._evaluate_statement(ast.lines[0])
-            except MesonException:
-                raise EnvironmentException(f'Malformed value in machine file variable {entry!r}.')
-            except KeyError as e:
-                raise EnvironmentException(f'Undefined constant {e.args[0]!r} in machine file variable {entry!r}.')
+            override = overrides.get(entry) if overrides else None
+            if override is not None:
+                res = override
+            elif value.strip():
+                res = self._evaluate_value(entry, value)
+            else:
+                m = f'Variable {entry} in machine file must be set with "--{self.kind}-file-constant {entry}=value"'
+                raise EnvironmentException(m)
             section[entry] = res
             self.scope[entry] = res
         return section
+
+    def _evaluate_value(self, entry, value):
+        # Windows paths...
+        value = value.replace('\\', '\\\\')
+        try:
+            ast = mparser.Parser(value, 'machinefile').parse()
+            return self._evaluate_statement(ast.lines[0])
+        except MesonException:
+            raise EnvironmentException(f'Malformed value in machine file variable {entry!r}.')
+        except KeyError as e:
+            raise EnvironmentException(f'Undefined constant {e.args[0]!r} in machine file variable {entry!r}.')
 
     def _evaluate_statement(self, node):
         if isinstance(node, (mparser.StringNode)):
@@ -929,8 +942,8 @@ class MachineFileParser():
                     return os.path.join(l, r)
         raise EnvironmentException('Unsupported node type')
 
-def parse_machine_files(filenames):
-    parser = MachineFileParser(filenames)
+def parse_machine_files(filenames, constants, kind):
+    parser = MachineFileParser(filenames, constants, kind)
     return parser.sections
 
 def get_cmd_line_file(build_dir: str) -> str:
@@ -949,6 +962,16 @@ def read_cmd_line_file(build_dir: str, options: argparse.Namespace) -> None:
     d = {OptionKey.from_string(k): v for k, v in config['options'].items()}
     d.update(options.cmd_line_options)
     options.cmd_line_options = d
+
+    if config.has_section('cross_files_constants'):
+        d = dict(config['cross_files_constants'])
+        d.update(options.cross_files_constants)
+        options.cross_files_constants = d
+
+    if config.has_section('native_files_constants'):
+        d = dict(config['native_files_constants'])
+        d.update(options.native_files_constants)
+        options.native_files_constants = d
 
     properties = config['properties']
     if not options.cross_file:
@@ -970,6 +993,8 @@ def write_cmd_line_file(build_dir: str, options: argparse.Namespace) -> None:
 
     config['options'] = {str(k): str(v) for k, v in options.cmd_line_options.items()}
     config['properties'] = properties
+    config['cross_files_constants'] = options.cross_files_constants
+    config['native_files_constants'] = options.native_files_constants
     with open(filename, 'w', encoding='utf-8') as f:
         config.write(f)
 
@@ -1052,6 +1077,8 @@ def create_options_dict(options: T.List[str], subproject: str = '') -> T.Dict[Op
 
 def parse_cmd_line_options(args: argparse.Namespace) -> None:
     args.cmd_line_options = create_options_dict(args.projectoptions)
+    args.native_files_constants = create_options_dict(args.native_file_constant)
+    args.cross_files_constants = create_options_dict(args.cross_file_constant)
 
     # Merge builtin options set with --option into the dict.
     for key in chain(

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -520,7 +520,9 @@ class Environment:
         ## Read in native file(s) to override build machine configuration
 
         if self.coredata.config_files is not None:
-            config = coredata.parse_machine_files(self.coredata.config_files)
+            config = coredata.parse_machine_files(self.coredata.config_files,
+                                                  self.coredata.config_files_constants,
+                                                  'native')
             binaries.build = BinaryTable(config.get('binaries', {}))
             properties.build = Properties(config.get('properties', {}))
             cmakevars.build = CMakeVariables(config.get('cmake', {}))
@@ -531,7 +533,9 @@ class Environment:
         ## Read in cross file(s) to override host machine configuration
 
         if self.coredata.cross_files:
-            config = coredata.parse_machine_files(self.coredata.cross_files)
+            config = coredata.parse_machine_files(self.coredata.cross_files,
+                                                  self.coredata.cross_files_constants,
+                                                  'cross')
             properties.host = Properties(config.get('properties', {}))
             binaries.host = BinaryTable(config.get('binaries', {}))
             cmakevars.host = CMakeVariables(config.get('cmake', {}))

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -303,6 +303,8 @@ class Conf:
             print(f'{m[0]:21}{m[1]:10}{m[2]:10}')
 
 def run(options):
+    options.cross_file_constant = []
+    options.native_file_constant = []
     coredata.parse_cmd_line_options(options)
     builddir = os.path.abspath(os.path.realpath(options.builddir))
     c = None

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -46,10 +46,20 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
                         default=[],
                         action='append',
                         help='File containing overrides for native compilation environment.')
+    parser.add_argument('--native-file-constant',
+                        default=[],
+                        action='append',
+                        metavar='name=value',
+                        help='Replace "name" with "value" in a native file')
     parser.add_argument('--cross-file',
                         default=[],
                         action='append',
                         help='File describing cross compilation environment.')
+    parser.add_argument('--cross-file-constant',
+                        default=[],
+                        action='append',
+                        metavar='name=value',
+                        help='Replace "name" with "value" in a cross file')
     parser.add_argument('-v', '--version', action='version',
                         version=coredata.version)
     parser.add_argument('--profile-self', action='store_true', dest='profile',

--- a/run_tests.py
+++ b/run_tests.py
@@ -127,7 +127,9 @@ class FakeCompilerOptions:
 def get_fake_options(prefix: str = '') -> argparse.Namespace:
     opts = argparse.Namespace()
     opts.native_file = []
+    opts.native_files_constants = {}
     opts.cross_file = None
+    opts.cross_files_constants = {}
     opts.wrap_mode = None
     opts.prefix = prefix
     opts.cmd_line_options = {}

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3484,6 +3484,8 @@ class AllPlatformTests(BasePlatformTests):
                     '''
                     [constants]
                     compiler = 'gcc'
+                    const_with_default = 'foo'
+                    const_without_default =
                     '''))
             with open(crossfile2, 'w', encoding='utf-8') as f:
                 f.write(textwrap.dedent(
@@ -3494,18 +3496,24 @@ class AllPlatformTests(BasePlatformTests):
 
                     [properties]
                     c_args = common_flags + ['-DSOMETHING']
-                    cpp_args = c_args + ['-DSOMETHING_ELSE']
+                    cpp_args = c_args + ['-DSOMETHING_ELSE', const_with_default, const_without_default]
 
                     [binaries]
                     c = toolchain / compiler
                     '''))
 
-            values = mesonbuild.coredata.parse_machine_files([crossfile1, crossfile2])
+            constants = {'const_with_default': 'v1',
+                         'const_without_default': 'v2'}
+            values = mesonbuild.coredata.parse_machine_files([crossfile1, crossfile2], constants, kind='cross')
             self.assertEqual(values['binaries']['c'], '/toolchain/gcc')
             self.assertEqual(values['properties']['c_args'],
                              ['--sysroot=/toolchain/sysroot', '-DSOMETHING'])
             self.assertEqual(values['properties']['cpp_args'],
-                             ['--sysroot=/toolchain/sysroot', '-DSOMETHING', '-DSOMETHING_ELSE'])
+                             ['--sysroot=/toolchain/sysroot', '-DSOMETHING', '-DSOMETHING_ELSE', 'v1', 'v2'])
+
+            m = 'Variable const_without_default in machine file must be set with "--cross-file-constant const_without_default=value"'
+            with self.assertRaisesRegex(EnvironmentException, m):
+                mesonbuild.coredata.parse_machine_files([crossfile1, crossfile2], {}, kind='cross')
 
     @skipIf(is_windows(), 'Directory cleanup fails for some reason')
     def test_wrap_git(self):


### PR DESCRIPTION
Config files already support interpolation, this allows setting
variables from the command line too. The common use-case is passing the
path the an SDK or toolchain.