### PR TITLE
Workaround msys2 azure PCH test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ script:
       ci_env=`bash <(curl -s https://codecov.io/env)`
       docker run --security-opt seccomp:unconfined $ci_env -v ${PWD}/.coverage:/root/.coverage \
         withgit \
-          /bin/sh -c "cd /root && mkdir -p tools; wget -c http://nirbheek.in/files/binaries/ninja/linux-amd64/ninja -O /root/tools/ninja; chmod +x /root/tools/ninja; CC=$CC CXX=$CXX OBJC=$CC OBJCXX=$CXX PATH=/root/tools:$PATH MESON_FIXED_NINJA=1 ./run_tests.py $RUN_TESTS_ARGS -- $MESON_ARGS && chmod -R a+rwX .coverage"
+          /bin/sh -c "cd /root && mkdir -p tools; wget -c https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-linux.zip -O /root/tools/ninja.zip; unzip -d /root/tools /root/tools/ninja.zip; chmod +x /root/tools/ninja; CC=$CC CXX=$CXX OBJC=$CC OBJCXX=$CXX PATH=/root/tools:$PATH ./run_tests.py $RUN_TESTS_ARGS -- $MESON_ARGS && chmod -R a+rwX .coverage"
     fi
   # Ensure that llvm is added after $PATH, otherwise the clang from that llvm install will be used instead of the native apple clang.
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) CPPFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib OBJC=$CC OBJCXX=$CXX PATH=$HOME/tools:/usr/local/opt/qt/bin:$PATH:$(brew --prefix llvm)/bin ./run_tests.py $RUN_TESTS_ARGS --backend=ninja -- $MESON_ARGS ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,9 @@ matrix:
 before_install:
   - python ./skip_ci.py --base-branch-env=TRAVIS_BRANCH --is-pull-env=TRAVIS_PULL_REQUEST
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt llvm; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install qt llvm ninja; fi
     # # Run one macOS build without pkg-config available, and the other (unity=on) with pkg-config
   - if [[ "$TRAVIS_OS_NAME" == "osx" && "$MESON_ARGS" =~ .*unity=on.* ]]; then brew install pkg-config; fi
-  # Use a Ninja with QuLogic's patch: https://github.com/ninja-build/ninja/issues/1219
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir -p $HOME/tools; curl -L http://nirbheek.in/files/binaries/ninja/macos/ninja -o $HOME/tools/ninja; chmod +x $HOME/tools/ninja; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker pull jpakkane/mesonci:cosmic; fi
 
 # We need to copy the current checkout inside the Docker container,
@@ -63,4 +61,4 @@ script:
           /bin/sh -c "cd /root && mkdir -p tools; wget -c http://nirbheek.in/files/binaries/ninja/linux-amd64/ninja -O /root/tools/ninja; chmod +x /root/tools/ninja; CC=$CC CXX=$CXX OBJC=$CC OBJCXX=$CXX PATH=/root/tools:$PATH MESON_FIXED_NINJA=1 ./run_tests.py $RUN_TESTS_ARGS -- $MESON_ARGS && chmod -R a+rwX .coverage"
     fi
   # Ensure that llvm is added after $PATH, otherwise the clang from that llvm install will be used instead of the native apple clang.
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) CPPFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib OBJC=$CC OBJCXX=$CXX PATH=$HOME/tools:/usr/local/opt/qt/bin:$PATH:$(brew --prefix llvm)/bin MESON_FIXED_NINJA=1 ./run_tests.py $RUN_TESTS_ARGS --backend=ninja -- $MESON_ARGS ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) CPPFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib OBJC=$CC OBJCXX=$CXX PATH=$HOME/tools:/usr/local/opt/qt/bin:$PATH:$(brew --prefix llvm)/bin ./run_tests.py $RUN_TESTS_ARGS --backend=ninja -- $MESON_ARGS ; fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -197,6 +197,20 @@ jobs:
         mingw-w64-$(MSYS2_ARCH)-python3-setuptools ^
         %TOOLCHAIN%
       displayName: Install Dependencies
+    - powershell: |
+        # https://github.com/mesonbuild/meson/issues/5807
+        # https://github.com/msys2/MINGW-packages/issues/5719#issuecomment-525845769
+        if ($env:compiler -eq 'gcc') {
+          (New-Object net.webclient).DownloadFile("https://github.com/mesonbuild/cidata/raw/master/win32/setdllcharacteristics.exe", "$(System.WorkFolder)\setdllcharacteristics.exe")
+          if ($env:MSYS2_ARCH -eq 'x86_64') {
+            $(System.WorkFolder)\setdllcharacteristics -d $env:MSYS2_ROOT\mingw64\lib\gcc\x86_64-w64-mingw32\9.2.0\cc1.exe
+            $(System.WorkFolder)\setdllcharacteristics -d $env:MSYS2_ROOT\mingw64\lib\gcc\x86_64-w64-mingw32\9.2.0\cc1plus.exe
+          } else {
+            $(System.WorkFolder)\setdllcharacteristics -d $env:MSYS2_ROOT\mingw32\lib\gcc\i686-w64-mingw32\9.2.0\cc1.exe
+            $(System.WorkFolder)\setdllcharacteristics -d $env:MSYS2_ROOT\mingw32\lib\gcc\i686-w64-mingw32\9.2.0\cc1plus.exe
+          }
+        }
+      displayName: MSYS2 PCH hack
     - script: |
         set BOOST_ROOT=
         set PATH=%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,6 @@ trigger:
     - '0.*'
 
 variables:
-  MESON_FIXED_NINJA: 1
   CI: 1
 
 jobs:

--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -28,7 +28,7 @@ steps:
      }
 
      DownloadFile -Source 'https://github.com/mesonbuild/cidata/raw/master/ninja.exe' -Destination $(System.WorkFolder)\ninja.exe
-     DownloadFile -Source 'http://nirbheek.in/files/binaries/pkg-config/win32/pkg-config.exe' -Destination $(System.WorkFolder)\pkg-config.exe
+     DownloadFile -Source 'https://github.com/mesonbuild/cidata/raw/master/win32/pkg-config.exe' -Destination $(System.WorkFolder)\pkg-config.exe
      DownloadFile -Source 'https://download.microsoft.com/download/D/B/B/DBB64BA1-7B51-43DB-8BF1-D1FB45EACF7A/msmpisdk.msi' -Destination msmpisdk.msi
      DownloadFile -Source 'https://download.microsoft.com/download/D/B/B/DBB64BA1-7B51-43DB-8BF1-D1FB45EACF7A/MSMpiSetup.exe' -Destination MSMpiSetup.exe
      if ($env:compiler -ne 'msvc2015') {

--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -27,7 +27,14 @@ steps:
           }
      }
 
-     DownloadFile -Source 'https://github.com/mesonbuild/cidata/raw/master/ninja.exe' -Destination $(System.WorkFolder)\ninja.exe
+     DownloadFile -Source 'https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-win.zip' -Destination $(System.WorkFolder)\ninja-win.zip
+     # ExpandArchive is only available in Powershell 5+
+     Add-Type -AssemblyName System.IO.Compression.FileSystem
+     function unzip {
+         param( [string]$ziparchive, [string]$extractpath )
+         [System.IO.Compression.ZipFile]::ExtractToDirectory( $ziparchive, $extractpath )
+     }
+     unzip $(System.WorkFolder)\ninja-win.zip $(System.WorkFolder)
      DownloadFile -Source 'https://github.com/mesonbuild/cidata/raw/master/win32/pkg-config.exe' -Destination $(System.WorkFolder)\pkg-config.exe
      DownloadFile -Source 'https://download.microsoft.com/download/D/B/B/DBB64BA1-7B51-43DB-8BF1-D1FB45EACF7A/msmpisdk.msi' -Destination msmpisdk.msi
      DownloadFile -Source 'https://download.microsoft.com/download/D/B/B/DBB64BA1-7B51-43DB-8BF1-D1FB45EACF7A/MSMpiSetup.exe' -Destination MSMpiSetup.exe

--- a/run_tests.py
+++ b/run_tests.py
@@ -233,7 +233,7 @@ def ensure_backend_detects_changes(backend):
     # timestamps and not running on HFS+ which only stores dates in seconds:
     # https://developer.apple.com/legacy/library/technotes/tn/tn1150.html#HFSPlusDates
     # FIXME: Upgrade Travis image to Apple FS when that becomes available
-    if (NINJA_1_9_OR_NEWER or ('MESON_FIXED_NINJA' in os.environ)) and not mesonlib.is_osx():
+    if NINJA_1_9_OR_NEWER and not mesonlib.is_osx():
         return
     # This is needed to increase the difference between build.ninja's
     # timestamp and the timestamp of whatever you changed due to a Ninja


### PR DESCRIPTION
Also move away from pkg-config and ninja hosted on my server. Will move ninja over once Ubuntu starts shipping 1.9.0

commit 2ce98516cb299b01412009ec13c8c6c4b3879226:

```
azure: Download pkg-config.exe from meson cidata
```

commit f0fb29c641a62a2bd0aef21f8d7bea2d07e91255:

```
azure: Bump to upstream ninja v1.9 release
```

commit 835178b170635f92a868e0ac4c16dc1581f0e598:

```
tests: Detect ninja v1.9 and disable timestamp hack
The high-res timestamp PR by QuLogic was merged in v1.9, so we can
switch back to upstream ninja.
```

commit 2d9848337f30f1407d52dfc66333cd7e277901fd:

```
travis/macos: Use brew ninja and upgrade to v1.9.0
```

commit 9875c4764e3779a306266b5b224bcc9e59662eba:

```
azure: Workaround MSYS2 PCH test failures
Compiler version is hard-coded so that we remember to revisit this
when the GCC version is updated.

Closes https://github.com/mesonbuild/meson/issues/5807
```

commit db386c2513d82ef400265c677d680ae4c9ac4cd7:

```
tests: Upgrade to ninja v1.9 for Linux
Also use the upstream release. This eliminates Meson CI's dependence
on my server.
```
commit 3af877a22ffa47ef14ed2ff10c772d0c454922f9:

```
tests: Require ninja 1.9 on CI
Also, print messages when we have to enable the timestamp resolution
workaround.
```
