### PR TITLE
backends: Make ninja not build test executables by default

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -854,15 +854,17 @@ class Backend:
         return newargs
 
     def get_build_by_default_targets(self):
+        """Get all build and custom targets that must be built by default."""
         result = OrderedDict()
-        # Get all build and custom targets that must be built by default
         for name, t in self.build.get_targets().items():
             if t.build_by_default:
                 result[name] = t
-        # Get all targets used as test executables and arguments. These must
-        # also be built by default. XXX: Sometime in the future these should be
-        # built only before running tests.
-        for t in self.build.get_tests():
+        return result
+
+    @staticmethod
+    def _get_targets(values):
+        result = OrderedDict()
+        for t in values:
             exe = t.exe
             if hasattr(exe, 'held_object'):
                 exe = exe.held_object
@@ -878,6 +880,14 @@ class Backend:
                 assert isinstance(dep, (build.CustomTarget, build.BuildTarget))
                 result[dep.get_id()] = dep
         return result
+
+    def get_test_targets(self):
+        """Get all targets used as test executables and arguments."""
+        return self._get_targets(self.build.get_tests())
+
+    def get_benchmark_targets(self):
+        """Get all targets used as test executables and arguments."""
+        return self._get_targets(self.build.get_benchmarks())
 
     @lru_cache(maxsize=None)
     def get_custom_target_provided_by_generated_source(self, generated_source):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -823,7 +823,15 @@ int dummy;
             cmd += ['--no-stdsplit']
         if self.environment.coredata.get_builtin_option('errorlogs'):
             cmd += ['--print-errorlogs']
-        elem = NinjaBuildElement(self.all_outputs, 'meson-test', 'CUSTOM_COMMAND', ['all', 'PHONY'])
+        tests = self.get_test_targets()
+
+        tests = [os.path.join(self.get_target_dir(t), t.get_outputs()[0])
+                 for t in self.get_test_targets().values()]
+        elem = NinjaBuildElement(self.all_outputs, 'meson-build-tests', 'CUSTOM_COMMAND', 'PHONY')
+        elem.add_dep(tests)
+        self.add_build(elem)
+
+        elem = NinjaBuildElement(self.all_outputs, 'meson-test', 'CUSTOM_COMMAND', ['meson-build-tests', 'PHONY'])
         elem.add_item('COMMAND', cmd)
         elem.add_item('DESC', 'Running all tests.')
         elem.add_item('pool', 'console')
@@ -835,7 +843,13 @@ int dummy;
         cmd = self.environment.get_build_command(True) + [
             'test', '--benchmark', '--logbase',
             'benchmarklog', '--num-processes=1', '--no-rebuild']
-        elem = NinjaBuildElement(self.all_outputs, 'meson-benchmark', 'CUSTOM_COMMAND', ['all', 'PHONY'])
+        elem = NinjaBuildElement(self.all_outputs, 'meson-build-benchmarks', 'CUSTOM_COMMAND', 'PHONY')
+        benches = [os.path.join(self.get_target_dir(t), t.get_outputs()[0])
+                   for t in self.get_benchmark_targets().values()]
+        elem.add_dep(benches)
+        self.add_build(elem)
+
+        elem = NinjaBuildElement(self.all_outputs, 'meson-benchmark', 'CUSTOM_COMMAND', ['meson-build-benchmarks', 'PHONY'])
         elem.add_item('COMMAND', cmd)
         elem.add_item('DESC', 'Running benchmark suite.')
         elem.add_item('pool', 'console')

--- a/run_tests.py
+++ b/run_tests.py
@@ -211,6 +211,8 @@ def get_backend_commands(backend, debug=False):
         test_cmd = cmd + ['test', 'benchmark']
         install_cmd = cmd + ['install']
         uninstall_cmd = cmd + ['uninstall']
+        # Because we use no-rebuild we need to build the test and benchmark targets explicitly
+        cmd.extend(['all', 'meson-build-tests', 'meson-build-benchmarks'])
     else:
         raise AssertionError('Unknown backend: {!r}'.format(backend))
     return cmd, clean_cmd, test_cmd, install_cmd, uninstall_cmd

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3ass
 # Copyright 2016-2017 The Meson development team
 
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -3840,6 +3840,20 @@ recommended as it is not supported on some platforms''')
         self.run_target('build-all')
         self.assertPathExists(os.path.join(self.builddir, 'prog' + exe_suffix))
         self.assertPathExists(os.path.join(self.builddir, 'hello.txt'))
+
+    def test_tests_not_default(self):
+        testdir = os.path.join(self.common_test_dir, '1 trivial')
+        self.init(testdir)
+        self.build()
+        self.assertBuildIsNoop()
+        self.run_tests()
+
+    def test_benchmark_not_default(self):
+        testdir = os.path.join(self.common_test_dir, '95 benchmark')
+        self.init(testdir)
+        self.build()
+        self.assertBuildIsNoop()
+
 
 class FailureTests(BasePlatformTests):
     '''

--- a/test cases/common/1 trivial/meson.build
+++ b/test cases/common/1 trivial/meson.build
@@ -19,7 +19,7 @@ if meson.is_cross_build()
   test('native exe in cross build', native_exe)
 endif
 
-exe = executable('trivialprog', sources : sources)
+exe = executable('trivialprog', sources : sources, build_by_default : false)
 
 test('runtest', exe) # This is a comment
 

--- a/test cases/common/95 benchmark/meson.build
+++ b/test cases/common/95 benchmark/meson.build
@@ -1,4 +1,4 @@
 project('benchmark', 'c')
 
-delayer = executable('delayer', 'delayer.c', c_args : '-D_GNU_SOURCE')
+delayer = executable('delayer', 'delayer.c', c_args : '-D_GNU_SOURCE', build_by_default : false)
 benchmark('delayer', delayer)


### PR DESCRIPTION
When they're marked `build_by_default : false`

This soles the easy part, which is making ninja not build test dependencies if they're explicitly marked `build_by_default : false`. A completely fix will require some deeper changes to not affect backwards compatibility, as currently all targets default to `build_by_default=True`.

This shouldn't affect the VSCode backend since tests are generated separately, but I could be wrong.

I'm thinking moving to a tri-state value equivalent to Always, If-not-test, never.

Fixes #2518
Fixes #1704