### PR TITLE
Handle case of dependency('threads') in 'requires'

### DIFF
--- a/docs/markdown/Pkgconfig-module.md
+++ b/docs/markdown/Pkgconfig-module.md
@@ -85,7 +85,7 @@ previous versions might have slightly different behaviour.
 - Dependencies provided by pkg-config are added into `Requires:` or
   `Requires.private:`. If a version was specified when declaring that dependency
   it will be written into the generated file too.
-- The thread dependency (i.e. `dependency('thread')`) adds `-pthread` into
+- The threads dependency (i.e. `dependency('threads')`) adds `-pthread` into
   `Libs:` or `Libs.private:`.
 - Internal dependencies (i.e.
   `declare_dependency(compiler_args : '-DFOO', link_args : '-Wl,something', link_with : foo)`)

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -91,6 +91,8 @@ class DependenciesHelper:
                 self.add_version_reqs(name, version_req)
             elif isinstance(obj, dependencies.Dependency) and not obj.found():
                 pass
+            elif isinstance(obj, dependencies.ThreadDependency):
+                pass
             else:
                 raise mesonlib.MesonException('requires argument not a string, '
                                               'library with pkgconfig-generated file '


### PR DESCRIPTION
Without this, if one creates a 'threads' dependency and passes it to 'requires' in generate(), the else error clause will be executed.

The threads library (i.e: pthreads) is correctly added to libs.private already if it is a dependency of a built library.

Also fix typo.