### PR TITLE
flatten list to subprocess.Popen, necessary for Python 3.8

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -248,8 +248,8 @@ int dummy;
         # and locale dependent. Any attempt at converting it to
         # Python strings leads to failure. We _must_ do this detection
         # in raw byte mode and write the result in raw bytes.
-        pc = subprocess.Popen([compiler.get_exelist(),
-                               '/showIncludes', '/c', 'incdetect.c'],
+        pc = subprocess.Popen(compiler.get_exelist() +
+                              ['/showIncludes', '/c', 'incdetect.c'],
                               cwd=self.environment.get_scratch_dir(),
                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (stdout, stderr) = pc.communicate()


### PR DESCRIPTION
Python 3.8 requires a flattened list here, Python 3.8 does not like:

```python
subprocess.Popen([['foo'], 'bar'])
```

but is of course fine with 

```python
subprocess.Popen(['foo'] + ['bar'])
```

fixes #5831