### PR TITLE
Make Python 2 tests optional(er) to prepare for py2 purge in Debian.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,20 +122,21 @@ jobs:
         librhash0,^
         libuv1,^
         ninja,^
-        python35-pip,^
+        python2-devel,^
+        python3-devel,^
+        python36-pip,^
         vala,^
         wget,^
         cmake,^
         zlib-devel
       displayName: Install Dependencies
     - script: |
-        %CYGWIN_ROOT%\bin\python3.5m.exe -m pip --disable-pip-version-check install pytest-xdist
+        set PATH=%CYGWIN_ROOT%\bin;%SYSTEMROOT%\system32
+        env.exe -- python3 -m pip --disable-pip-version-check install pytest-xdist
       displayName: pip install pytest-xdist
     - script: |
         set BOOST_ROOT=
         set PATH=%CYGWIN_ROOT%\bin;%SYSTEMROOT%\system32
-        # FIXME: we need to support systems without unversioned `python3`
-        cp /usr/bin/python3.5 /usr/bin/python3
         env.exe -- python3 run_tests.py --backend=ninja
       displayName: Run Tests
     - task: CopyFiles@2

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -115,7 +115,6 @@ class PythonDependency(ExternalDependency):
                     self._find_libpy_windows(environment)
                 else:
                     self._find_libpy(python_holder, environment)
-
                 if self.is_found:
                     mlog.debug('Found "python-{}" via SYSCONFIG module'.format(self.version))
                     py_lookup_method = 'sysconfig'
@@ -123,7 +122,7 @@ class PythonDependency(ExternalDependency):
         if self.is_found:
             mlog.log('Dependency', mlog.bold(self.name), 'found:', mlog.green('YES ({})'.format(py_lookup_method)))
         else:
-            mlog.log('Dependency', mlog.bold(self.name), 'found:', [mlog.red('NO')])
+            mlog.log('Dependency', mlog.bold(self.name), 'found:', mlog.red('NO'))
 
     def _find_libpy(self, python_holder, environment):
         if python_holder.is_pypy:
@@ -145,7 +144,7 @@ class PythonDependency(ExternalDependency):
         if largs is not None:
             self.link_args = largs
 
-        self.is_found = largs is not None or not self.link_libpython
+        self.is_found = largs is not None or self.link_libpython
 
         inc_paths = mesonlib.OrderedSet([
             self.variables.get('INCLUDEPY'),

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6328,6 +6328,15 @@ class NativeFileTests(BasePlatformTests):
             # python module breaks. This is fine on other OSes because they
             # don't need the extra indirection.
             raise unittest.SkipTest('bat indirection breaks internal sanity checks.')
+        if os.path.exists('/etc/debian_version'):
+            rc = subprocess.call(['pkg-config', '--cflags', 'python2'],
+                                 stdout=subprocess.DEVNULL,
+                                 stderr=subprocess.DEVNULL)
+            if rc != 0:
+                # Python 2 will be removed in Debian Bullseye, thus we must
+                # remove the build dependency on python2-dev. Keep the tests
+                # but only run them if dev packages are available.
+                raise unittest.SkipTest('Not running Python 2 tests because dev packages not installed.')
         self._simple_test('python', 'python')
 
     @unittest.skipIf(is_windows(), 'Setting up multiple compilers on windows is hard')


### PR DESCRIPTION
This can't really be tested fully yet, because libboost-python depends on Python 2 dev packages. You can't install just the Python 3 version. The cleanups should be useful on their own, though, and the timeline should go roughly like:

- merge this for now, can remove explicit build-dep to `libpython2-dev`, though it will still be installed by the `libboost-python` package
- once Debian kills Python 2 support from `libboost-python`, update our setup to match
- delete py2 support (eventually, once all distros kill it)

Maybe we can delete py2 support sooner if nobody is using our Python build support any more, but I don't know how we could find that out other than breaking things and waiting for people to file bugs.