### PR TITLE
Add a CUDA linker object

### DIFF
--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -18,7 +18,7 @@ import typing
 from .. import mlog
 from ..mesonlib import EnvironmentException, MachineChoice, Popen_safe
 from .compilers import (Compiler, cuda_buildtype_args, cuda_optimization_args,
-                        cuda_debug_args, CompilerType)
+                        cuda_debug_args)
 
 if typing.TYPE_CHECKING:
     from ..environment import Environment  # noqa: F401
@@ -34,17 +34,13 @@ class CudaCompiler(Compiler):
         super().__init__(exelist, version, for_machine, **kwargs)
         self.is_cross = is_cross
         self.exe_wrapper = exe_wrapper
-        self.id = CudaCompiler.cuda_id()
+        self.id = 'nvcc'
         default_warn_args = []
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Xcompiler=-Wextra'],
                           '3': default_warn_args + ['-Xcompiler=-Wextra',
                                                     '-Xcompiler=-Wpedantic']}
-
-    @staticmethod
-    def cuda_id():
-        return 'nvcc'
 
     def needs_static_linker(self):
         return False

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -34,13 +34,17 @@ class CudaCompiler(Compiler):
         super().__init__(exelist, version, for_machine, **kwargs)
         self.is_cross = is_cross
         self.exe_wrapper = exe_wrapper
-        self.id = 'nvcc'
+        self.id = CudaCompiler.cuda_id()
         default_warn_args = []
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Xcompiler=-Wextra'],
                           '3': default_warn_args + ['-Xcompiler=-Wextra',
                                                     '-Xcompiler=-Wpedantic']}
+
+    @staticmethod
+    def cuda_id():
+        return 'nvcc'
 
     def needs_static_linker(self):
         return False

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -697,9 +697,6 @@ class Environment:
             `-Xlinker=--version`) you must pass as a list.
         :extra_args: Any addtional arguments rquired (such as a source file)
         """
-        if CudaCompiler.cuda_id() in compiler:
-            return CudaLinker(compiler, for_machine, 'nvlink', prefix, version=CudaLinker.parse_version())
-
         extra_args = typing.cast(typing.List[str], extra_args or [])
         if isinstance(prefix, str):
             check_args = [prefix + '--version'] + extra_args
@@ -963,7 +960,7 @@ class Environment:
             # Luckily, the "V" also makes it very simple to extract
             # the full version:
             version = out.strip().split('V')[-1]
-            linker = self._guess_nix_linker(compiler, for_machine, CudaCompiler.LINKER_PREFIX)
+            linker = CudaLinker(compiler, for_machine, 'nvlink', CudaCompiler.LINKER_PREFIX, version=CudaLinker.parse_version())
             return CudaCompiler(ccache + compiler, version, for_machine, exe_wrap, linker=linker)
         raise EnvironmentException('Could not find suitable CUDA compiler: "' + ' '.join(compilers) + '"')
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -55,6 +55,7 @@ from .linkers import (
     XildAppleDynamicLinker,
     XildLinuxDynamicLinker,
     XilinkDynamicLinker,
+    CudaLinker,
 )
 from functools import lru_cache
 from .compilers import (
@@ -696,6 +697,9 @@ class Environment:
             `-Xlinker=--version`) you must pass as a list.
         :extra_args: Any addtional arguments rquired (such as a source file)
         """
+        if CudaCompiler.cuda_id() in compiler:
+            return CudaLinker(compiler, for_machine, 'nvlink', prefix, version=CudaLinker.parse_version())
+
         extra_args = typing.cast(typing.List[str], extra_args or [])
         if isinstance(prefix, str):
             check_args = [prefix + '--version'] + extra_args

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -909,3 +909,32 @@ class OptlinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
 
     def get_allow_undefined_args(self) -> typing.List[str]:
         return []
+
+class CudaLinker(DynamicLinker):
+    """Cuda linker (nvlink)"""
+    @staticmethod
+    def parse_version():
+        version_cmd = ['nvlink', '--version']
+        try:
+            _, out, _ = mesonlib.Popen_safe(version_cmd)
+        except OSError:
+            return 'unknown version'
+        # Output example:
+        # nvlink: NVIDIA (R) Cuda linker
+        # Copyright (c) 2005-2018 NVIDIA Corporation
+        # Built on Sun_Sep_30_21:09:22_CDT_2018
+        # Cuda compilation tools, release 10.0, V10.0.166
+        # we need the most verbose version output. Luckily starting with V
+        return out.strip().split('V')[-1]
+
+    def get_output_args(self, outname: str) -> typing.List[str]:
+        return ['-o', outname]
+
+    def get_search_args(self, dirname: str) -> typing.List[str]:
+        return ['-L', dirname]
+
+    def fatal_warnings(self) -> typing.List[str]:
+        return ['--warning-as-error']
+
+    def get_allow_undefined_args(self) -> typing.List[str]:
+        return []

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -938,3 +938,8 @@ class CudaLinker(DynamicLinker):
 
     def get_allow_undefined_args(self) -> typing.List[str]:
         return []
+
+    def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
+                        suffix: str, soversion: str, darwin_versions: typing.Tuple[str, str],
+                        is_shared_module: bool) -> typing.List[str]:
+        return []


### PR DESCRIPTION
CUDA compiling is currently broken since meson can't properly find the CUDA linker.
This adds a CUDA linker and a special case for determine the linker when we are using a CUDA compiler.
Fixes issue #5870