### PR TITLE
man: Make argument order of setup command consistent with help message

### DIFF
--- a/man/meson.1
+++ b/man/meson.1
@@ -20,9 +20,9 @@ configure your build:
 .B meson setup [
 .I options
 .B ] [
-.I source directory
-.B ] [
 .I build directory
+.B ] [
+.I source directory
 .B ]
 
 Note that the build directory must be different from the source
@@ -48,9 +48,9 @@ like this:
 .B meson [
 .I options
 .B ] [
-.I source directory
-.B ] [
 .I build directory
+.B ] [
+.I source directory
 .B ]
 
 .SS "options:"


### PR DESCRIPTION
In msetup the two positional arguments build-dir and source-dir
are added to the argument parser in this order.

This also affects the help message.

This order is different from the order given in the man page.
Therefore it is switched around in the man page to make it consistent
with the help message.

As the code automatically decides which directory contains what, this
change is only cosmetic. Both argument orders should be valid.

Signed-off-by: Fabian Bläse <fabian@blaese.de>