### PR TITLE
Fix CUDA builds with external dependecies

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -650,7 +650,7 @@ class Backend:
                 elif isinstance(dep, dependencies.ExternalLibrary):
                     commands += dep.get_link_args('vala')
             else:
-                commands += dep.get_compile_args()
+                commands += compiler.prepare_compiler_args(dep.get_compile_args())
             # Qt needs -fPIC for executables
             # XXX: We should move to -fPIC for all executables
             if isinstance(target, build.Executable):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2510,11 +2510,13 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             for dep in target.get_external_deps():
                 # Extend without reordering or de-dup to preserve `-L -l` sets
                 # https://github.com/mesonbuild/meson/issues/1718
-                commands.extend_preserving_lflags(dep.get_link_args())
+                dep_link_args = linker.linker.prepare_linker_args(dep.get_link_args())
+                commands.extend_preserving_lflags(dep_link_args)
             for d in target.get_dependencies():
                 if isinstance(d, build.StaticLibrary):
                     for dep in d.get_external_deps():
-                        commands.extend_preserving_lflags(dep.get_link_args())
+                        dep_link_args = linker.linker.prepare_linker_args(dep.get_link_args())
+                        commands.extend_preserving_lflags(dep_link_args)
 
         # Add link args specific to this BuildTarget type that must not be overridden by dependencies
         commands += self.get_target_type_link_args_post_dependencies(target, linker)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -650,6 +650,7 @@ class Compiler:
     # manually searched.
     internal_libs = ()
 
+    COMPILER_PREFIX = None  # type: typing.Union[None, str, typing.List[str]]
     LINKER_PREFIX = None  # type: typing.Union[None, str, typing.List[str]]
 
     def __init__(self, exelist, version, for_machine: MachineChoice,
@@ -1143,6 +1144,9 @@ class Compiler:
         return self.linker.get_soname_args(
             env, prefix, shlib_name, suffix, soversion,
             darwin_versions, is_shared_module)
+
+    def prepare_compiler_args(self, args: typing.List[str]) -> typing.List[str]:
+        return args
 
 
 @enum.unique

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -26,6 +26,7 @@ if typing.TYPE_CHECKING:
 
 class CudaCompiler(Compiler):
 
+    COMPILER_PREFIX = '-Xcompiler='
     LINKER_PREFIX = '-Xlinker='
 
     def __init__(self, exelist, version, for_machine: MachineChoice, is_cross, exe_wrapper=None, **kwargs):
@@ -229,3 +230,6 @@ class CudaCompiler(Compiler):
 
     def get_std_exe_link_args(self) -> typing.List[str]:
         return []
+
+    def prepare_compiler_args(self, args: typing.List[str]) -> typing.List[str]:
+        return [CudaCompiler.COMPILER_PREFIX + arg for arg in args]

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -82,6 +82,9 @@ class StaticLinker:
     def get_linker_always_args(self) -> typing.List[str]:
         return []
 
+    def prepare_linker_args(self, args: typing.List[str]) -> typing.List[str]:
+        return args
+
 
 class VisualStudioLikeLinker:
     always_args = ['/NOLOGO']
@@ -386,6 +389,9 @@ class DynamicLinker(metaclass=abc.ABCMeta):
                          rpath_paths: str, build_rpath: str,
                          install_rpath: str) -> typing.List[str]:
         return []
+
+    def prepare_linker_args(self, args: typing.List[str]) -> typing.List[str]:
+        return args
 
 
 class PosixDynamicLinkerMixin:
@@ -943,3 +949,9 @@ class CudaLinker(DynamicLinker):
                         suffix: str, soversion: str, darwin_versions: typing.Tuple[str, str],
                         is_shared_module: bool) -> typing.List[str]:
         return []
+
+    def get_std_shared_lib_args(self) -> typing.List[str]:
+        return ['-shared']
+
+    def prepare_linker_args(self, args: typing.List[str]) -> typing.List[str]:
+        return [a.replace('-Wl,', self.prefix_arg) for a in args]


### PR DESCRIPTION
Wrap external dependencies compiler and linker flags with proper flags so that the CUDA compiler/linker will send then to the underlining compiler.

This fixes issue #5890 and enables meson top build projects in which CUDA compiled code has external dependencies.

I am fully aware that I might not have solved this issue in the most elegant and/or fool proof manner. Any suggestions/recommendations/anything would be appreciated.