### PR TITLE
Fix static archives stripping

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5331,6 +5331,33 @@ endian = 'little'
             self.build()
 
     @skipIfNoPkgconfig
+    def test_static_archive_stripping(self):
+        '''
+        Check that Meson produces valid static archives with --strip enabled
+        '''
+        with tempfile.TemporaryDirectory() as tempdirname:
+            testdirbase = os.path.join(self.unit_test_dir, '68 static archive stripping')
+
+            # build lib
+            self.new_builddir()
+            testdirlib = os.path.join(testdirbase, 'lib')
+            testlibprefix = os.path.join(tempdirname, 'libprefix')
+            self.init(testdirlib, extra_args=['--prefix=' + testlibprefix,
+                                              '--libdir=lib',
+                                              '--default-library=static',
+                                              '--buildtype=debug',
+                                              '--strip'], default_args=False)
+            self.build()
+            self.install(use_destdir=False)
+
+            # build executable (uses lib, fails if static archive has been stripped incorrectly)
+            pkg_dir = os.path.join(testlibprefix, 'lib/pkgconfig')
+            self.new_builddir()
+            self.init(os.path.join(testdirbase, 'app'),
+                      override_envvars={'PKG_CONFIG_PATH': pkg_dir})
+            self.build()
+
+    @skipIfNoPkgconfig
     def test_pkgconfig_formatting(self):
         testdir = os.path.join(self.unit_test_dir, '38 pkgconfig format')
         self.init(testdir)

--- a/test cases/unit/68 static archive stripping/app/appA.c
+++ b/test cases/unit/68 static archive stripping/app/appA.c
@@ -1,0 +1,4 @@
+#include <stdio.h>
+#include <libA.h>
+
+int main() { printf("The answer is: %d\n", libA_func()); }

--- a/test cases/unit/68 static archive stripping/app/appB.c
+++ b/test cases/unit/68 static archive stripping/app/appB.c
@@ -1,0 +1,4 @@
+#include <stdio.h>
+#include <libB.h>
+
+int main() { printf("The answer is: %d\n", libB_func()); }

--- a/test cases/unit/68 static archive stripping/app/meson.build
+++ b/test cases/unit/68 static archive stripping/app/meson.build
@@ -1,0 +1,7 @@
+project('app', ['c'])
+
+a = dependency('test-a')
+b = dependency('test-b')
+
+executable('appA', files('appA.c'), dependencies : a)
+executable('appB', files('appB.c'), dependencies : b)

--- a/test cases/unit/68 static archive stripping/lib/libA.c
+++ b/test cases/unit/68 static archive stripping/lib/libA.c
@@ -1,0 +1,5 @@
+#include <libA.h>
+
+static int libA_func_impl(void) { return 0; }
+
+int libA_func(void) { return libA_func_impl(); }

--- a/test cases/unit/68 static archive stripping/lib/libA.h
+++ b/test cases/unit/68 static archive stripping/lib/libA.h
@@ -1,0 +1,1 @@
+int libA_func(void);

--- a/test cases/unit/68 static archive stripping/lib/libB.c
+++ b/test cases/unit/68 static archive stripping/lib/libB.c
@@ -1,0 +1,5 @@
+#include <libB.h>
+
+static int libB_func_impl(void) { return 0; }
+
+int libB_func(void) { return libB_func_impl(); }

--- a/test cases/unit/68 static archive stripping/lib/libB.h
+++ b/test cases/unit/68 static archive stripping/lib/libB.h
@@ -1,0 +1,1 @@
+int libB_func(void);

--- a/test cases/unit/68 static archive stripping/lib/meson.build
+++ b/test cases/unit/68 static archive stripping/lib/meson.build
@@ -1,0 +1,23 @@
+project('lib', ['c'])
+
+pkg = import('pkgconfig')
+
+a = library('test-a', files('libA.c'), install: true)
+install_headers(files('libA.h'), subdir: 'libA')
+pkg.generate(
+    a,
+    version: '0.0',
+    description: 'test library libA',
+    filebase: 'test-a',
+    name: 'test library libA',
+    subdirs: 'libA')
+
+b = static_library('test-b', files('libB.c'), install: true)
+install_headers(files('libB.h'), subdir: 'libB')
+pkg.generate(
+    b,
+    version: '0.0',
+    description: 'test library libB',
+    filebase: 'test-b',
+    name: 'test library libB',
+    subdirs: 'libB')


### PR DESCRIPTION
Stripping static archives without more fine-grained options (e.g. `-g`) leads to failures such as

    ld: libfoo.a: error adding symbols: archive has no index; run ranlib to add one

because GNU strip removes *every* symbol in a static archive by default. Given that static archives are not final build artifacts (unlike executables and shared libraries), stripping them gains little and only causes more edge case failures.

* Gentoo's portage only strips debug information:
  https://github.com/gentoo/portage/blob/86f211e3a552753eb945670a39c1a3b14c3c3bd1/bin/estrip#L322
* Fedora also only strips debug information:
  https://github.com/rpm-software-management/rpm/blob/e9c13c6565cf4782d1f73255ee9144dd9bd2aca7/scripts/brp-strip-static-archive#L18
* Debian also only does some very light stripping:
  https://github.com/Debian/debhelper/blob/72ed1d3261730d56da6afde0ec7f52f32976e04d/dh_strip#L374

Fixes #4138