### PR TITLE
Fix *.pdb files missing in meson introspect --installed output

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -460,11 +460,6 @@ class Installer:
                         print('Stdout:\n%s\n' % stdo)
                         print('Stderr:\n%s\n' % stde)
                         sys.exit(1)
-                pdb_filename = os.path.splitext(fname)[0] + '.pdb'
-                if not should_strip and os.path.exists(pdb_filename):
-                    pdb_outname = os.path.splitext(outname)[0] + '.pdb'
-                    self.do_copyfile(pdb_filename, pdb_outname)
-                    set_mode(pdb_outname, install_mode, d.install_umask)
                 if fname.endswith('.js'):
                     # Emscripten outputs js files and optionally a wasm file.
                     # If one was generated, install it as well.

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4424,6 +4424,20 @@ class WindowsTests(BasePlatformTests):
             return
         self.build()
 
+    def test_install_pdb_introspection(self):
+        testdir = os.path.join(self.platform_test_dir, '1 basic')
+
+        env = get_fake_env(testdir, self.builddir, self.prefix)
+        cc = env.detect_c_compiler(MachineChoice.HOST)
+        if cc.get_argument_syntax() != 'msvc':
+            raise unittest.SkipTest('Test only applies to MSVC-like compilers')
+
+        self.init(testdir)
+        installed = self.introspect('--installed')
+        files = [os.path.basename(path) for path in installed.values()]
+
+        self.assertTrue('prog.pdb' in files)
+
 @unittest.skipUnless(is_osx(), "requires Darwin")
 class DarwinTests(BasePlatformTests):
     '''

--- a/test cases/common/206 install name_prefix name_suffix/installed_files.txt
+++ b/test cases/common/206 install name_prefix name_suffix/installed_files.txt
@@ -1,9 +1,6 @@
 ?msvc:usr/bin/baz.pdb
 ?msvc:usr/bin/bowcorge.pdb
 ?msvc:usr/bin/foo.pdb
-?msvc:usr/lib/baz.pdb
-?msvc:usr/lib/bowcorge.pdb
-?msvc:usr/lib/foo.pdb
 usr/?lib/bowcorge.stern
 usr/lib/?libbaz.cheese
 usr/lib/bar.a

--- a/test cases/d/5 mixed/installed_files.txt
+++ b/test cases/d/5 mixed/installed_files.txt
@@ -5,4 +5,3 @@ usr/lib/libstuff.a
 ?msvc:usr/bin/stuff.dll
 ?msvc:usr/bin/stuff.pdb
 ?msvc:usr/lib/stuff.lib
-?msvc:usr/lib/stuff.pdb

--- a/test cases/windows/7 dll versioning/installed_files.txt
+++ b/test cases/windows/7 dll versioning/installed_files.txt
@@ -4,7 +4,6 @@
 ?msvc:usr/bin/noversion.dll
 ?msvc:usr/bin/noversion.pdb
 ?msvc:usr/lib/noversion.lib
-?msvc:usr/lib/noversion.pdb
 ?msvc:usr/bin/onlyversion-1.dll
 ?msvc:usr/bin/onlyversion-1.pdb
 ?msvc:usr/lib/onlyversion.lib


### PR DESCRIPTION
On Windows, make sure the introspect command lists all Program database
(PDB) files containing debugging information that Meson will install.