### PR TITLE
mconf: Fix meson configure crash (fixes #5909)

### DIFF
--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -181,7 +181,7 @@ class Conf:
         core_options = {k: o for k, o in self.coredata.builtins.items() if k in core_option_names}
 
         self.print_options('Core options', core_options)
-        if self.build.environment.is_cross_build():
+        if self.default_values_only or self.build.environment.is_cross_build():
             self.print_options('Core options (for host machine)', self.coredata.builtins_per_machine.host)
             self.print_options(
                 'Core options (for build machine)',
@@ -190,7 +190,7 @@ class Conf:
             self.print_options('Core options', self.coredata.builtins_per_machine.host)
         self.print_options('Backend options', self.coredata.backend_options)
         self.print_options('Base options', self.coredata.base_options)
-        if self.build.environment.is_cross_build():
+        if self.default_values_only or self.build.environment.is_cross_build():
             self.print_options('Compiler options (for host machine)', self.coredata.compiler_options.host)
             self.print_options(
                 'Compiler options (for build machine)',

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3624,6 +3624,10 @@ recommended as it is not supported on some platforms''')
         self.maxDiff = None
         self.assertListEqual(res_nb, res_wb)
 
+    def test_meson_configure_from_source_does_not_crash(self):
+        testdir = os.path.join(self.unit_test_dir, '59 introspect buildoptions')
+        self._run(self.mconf_command + [testdir])
+
     def test_introspect_json_dump(self):
         testdir = os.path.join(self.unit_test_dir, '57 introspection')
         self.init(testdir)


### PR DESCRIPTION
This fix also includes a small test to ensure that `meson configure` does not crash. The correctness of the build options is already checked with `test_introspect_buildoptions_without_configured_build`.