### PR TITLE
pkgconfig: Fix ordering of public libraries

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -388,10 +388,15 @@ class PkgConfigModule(ExtensionModule):
             raise mesonlib.MesonException('URL is not a string.')
         conflicts = mesonlib.stringlistify(kwargs.get('conflicts', []))
 
-        deps = DependenciesHelper(filebase)
+        # Prepend the main library to public libraries list. This is required
+        # so dep.add_pub_libs() can handle dependency ordering correctly and put
+        # extra libraries after the main library.
+        libraries = mesonlib.extract_as_list(kwargs, 'libraries')
         if mainlib:
-            deps.add_pub_libs(mainlib)
-        deps.add_pub_libs(kwargs.get('libraries', []))
+            libraries = [mainlib] + libraries
+
+        deps = DependenciesHelper(filebase)
+        deps.add_pub_libs(libraries)
         deps.add_priv_libs(kwargs.get('libraries_private', []))
         deps.add_pub_reqs(kwargs.get('requires', []))
         deps.add_priv_reqs(kwargs.get('requires_private', []))

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4577,6 +4577,10 @@ class LinuxlikeTests(BasePlatformTests):
         else:
             self.assertEqual(sorted(out), sorted(['libexposed', 'libfoo>=1.0', 'libhello']))
 
+        cmd = ['pkg-config', 'pub-lib-order']
+        out = self._run(cmd + ['--libs'], override_envvars=env).strip().split()
+        self.assertEqual(out, ['-llibmain2', '-llibinternal'])
+
     def test_pkg_unfound(self):
         testdir = os.path.join(self.unit_test_dir, '23 unfound pkgconfig')
         self.init(testdir)

--- a/test cases/common/47 pkgconfig-gen/dependencies/meson.build
+++ b/test cases/common/47 pkgconfig-gen/dependencies/meson.build
@@ -49,3 +49,11 @@ pkgg.generate(
   description : 'Dependency Requires.private field test.',
   requires_private : [exposed_lib, pc_dep, 'libhello', notfound_dep],
 )
+
+# Verify that if we promote internal_lib as public dependency, it comes after
+# the main library.
+main_lib2 = both_libraries('libmain2', link_with : internal_lib)
+pkgg.generate(main_lib2,
+  libraries : internal_lib,
+  filebase : 'pub-lib-order',
+)


### PR DESCRIPTION
The main library must come before extra libraries, because they are
likely to be dependencies of the main library that get promoted from
private to public. This was causing static link issues with glib-2.0.pc.