### PR TITLE
Add support for `depth` option in wrap-git

### DIFF
--- a/docs/markdown/Wrap-dependency-system-manual.md
+++ b/docs/markdown/Wrap-dependency-system-manual.md
@@ -143,6 +143,14 @@ automatically by adding the following *(since 0.48.0)*:
 clone-recursive = true
 ```
 
+Setting the clone depth is supported using the `depth` directive *(since 0.52.0)*.
+Note that git always allow shallowly cloning branches, but in order to clone commit ids
+shallowly, the server must support `uploadpack.allowReachableSHA1InWant=true`.
+
+```ini
+depth = 1
+```
+
 ## Using wrapped projects
 
 Wraps provide a convenient way of obtaining a project into your subproject directory. 

--- a/docs/markdown/snippets/depth.md
+++ b/docs/markdown/snippets/depth.md
@@ -1,0 +1,7 @@
+## Add `depth` option to `wrap-git`
+
+To allow shallow cloning, an option `depth` has been added to `wrap-git`.
+This applies recursively to submodules when `clone-recursive` is set to `true`.
+
+Note that the git server may have to be configured to support shallow cloning
+not only for branches but also for tags.


### PR DESCRIPTION
This allows cloning subprojects shallowly.  It works recursively for a
subproject's submodules in case `clone-recursive` is set to `true`.