### PR TITLE
Fix usage of uninstalled static libraries

### DIFF
--- a/docs/markdown/snippets/static_link.md
+++ b/docs/markdown/snippets/static_link.md
@@ -1,0 +1,34 @@
+## Improved support for static libraries
+
+Static libraries had numerous shortcomings in the past, especially when using
+uninstalled static libraries. This release brings many internal changes in the
+way they are handled, including:
+
+- `link_whole:` of static libraries. In the example below, lib2 used to miss
+  symbols from lib1 and was unusable.
+```meson
+lib1 = static_library(sources)
+lib2 = static_library(other_sources, link_whole : lib1, install : true)
+```
+- `link_with:` of a static library with an uninstalled static library. In the
+example below, lib2 now implicitly promote `link_with:` to `link_whole:` because
+the installed lib2 would oterhwise be unusable.
+```meson
+lib1 = static_library(sources, install : false)
+lib2 = static_library(sources, link_with : lib1, install : true)
+```
+- pkg-config generator do not include uninstalled static libraries. In the example
+  below, the generated `.pc` file used to be unusable because it contained
+  `Libs.private: -llib1` and `lib1.a` is not installed. `lib1` is now ommitted
+  from the `.pc` file because the `link_with:` has been promoted to
+  `link_whole:` (see above) and thus lib1 is not needed to use lib2.
+```meson
+lib1 = static_library(sources, install : false)
+lib2 = both_libraries(sources, link_with : lib1, install : true)
+pkg.generate(lib2)
+```
+
+Many projects have been using `extract_all_objects()` to work around those issues,
+and hopefully those hacks could now be removed. Since this is a pretty large
+change, please double check if your static libraries behave correctly, and
+report any regression.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1110,8 +1110,15 @@ You probably should put it in link_with instead.''')
             if isinstance(self, StaticLibrary):
                 # When we're a static library and we link_whole: to another static
                 # library, we need to add that target's objects to ourselves.
-                self.objects.append(t.extract_all_objects())
+                self.objects += t.extract_all_objects_recurse()
             self.link_whole_targets.append(t)
+
+    def extract_all_objects_recurse(self):
+        objs = [self.extract_all_objects()]
+        for t in self.link_targets:
+            if t.is_internal():
+                objs += t.extract_all_objects_recurse()
+        return objs
 
     def add_pch(self, language, pchlist):
         if not pchlist:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1062,8 +1062,15 @@ You probably should put it in link_with instead.''')
     def get_external_deps(self):
         return self.external_deps
 
+    def is_internal(self):
+        return isinstance(self, StaticLibrary) and not self.need_install
+
     def link(self, target):
         for t in listify(target, unholder=True):
+            if isinstance(self, StaticLibrary) and t.is_internal():
+                # When we're a static library and we link_with to an
+                # internal/convenience library, promote to link_whole.
+                return self.link_whole(t)
             if not isinstance(t, (Target, CustomTargetIndex)):
                 raise InvalidArguments('{!r} is not a target.'.format(t))
             if not t.is_linkable_target():

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1068,7 +1068,7 @@ You probably should put it in link_with instead.''')
 
     def link(self, target):
         for t in listify(target, unholder=True):
-            if isinstance(self, StaticLibrary) and t.is_internal():
+            if isinstance(self, StaticLibrary) and self.need_install and t.is_internal():
                 # When we're a static library and we link_with to an
                 # internal/convenience library, promote to link_whole.
                 return self.link_whole(t)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1099,7 +1099,15 @@ You probably should put it in link_with instead.''')
                     raise InvalidArguments(msg + ' This is not possible in a cross build.')
                 else:
                     mlog.warning(msg + ' This will fail in cross build.')
-            self.link_whole_targets.append(t)
+            if isinstance(self, StaticLibrary):
+                # When we're a static library and we link_whole: to another static
+                # library, we need to add that target's objects to ourselves.
+                self.objects.append(t.extract_all_objects())
+                # Add internal and external deps
+                self.external_deps += t.external_deps
+                self.link_targets += t.link_targets
+            else:
+                self.link_whole_targets.append(t)
 
     def add_pch(self, language, pchlist):
         if not pchlist:

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -148,10 +148,10 @@ class DependenciesHelper:
             elif isinstance(obj, (build.SharedLibrary, build.StaticLibrary)):
                 processed_libs.append(obj)
                 if isinstance(obj, build.StaticLibrary) and public:
-                    self.add_pub_libs(obj.get_dependencies(internal=False))
+                    self.add_pub_libs(obj.get_dependencies(for_pkgconfig=True))
                     self.add_pub_libs(obj.get_external_deps())
                 else:
-                    self.add_priv_libs(obj.get_dependencies(internal=False))
+                    self.add_priv_libs(obj.get_dependencies(for_pkgconfig=True))
                     self.add_priv_libs(obj.get_external_deps())
             elif isinstance(obj, str):
                 processed_libs.append(obj)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5637,6 +5637,9 @@ c = ['{0}']
         self.init(testdir, override_envvars=env)
 
     def test_static_link(self):
+        if is_cygwin():
+            raise unittest.SkipTest("Cygwin doesn't support LD_LIBRARY_PATH.")
+
         # Build some libraries and install them
         testdir = os.path.join(self.unit_test_dir, '69 static link/lib')
         libdir = os.path.join(self.installdir, self.prefix[1:], self.libdir)
@@ -5646,9 +5649,12 @@ c = ['{0}']
         # Test that installed libraries works
         self.new_builddir()
         testdir = os.path.join(self.unit_test_dir, '69 static link')
-        self.init(testdir, extra_args=['-Dc_link_args="-L{}"'.format(libdir)])
+        env = {'PKG_CONFIG_LIBDIR': os.path.join(libdir, 'pkgconfig')}
+        run_env = {'LD_LIBRARY_PATH': libdir}
+        self.init(testdir, extra_args=['-Dc_link_args="-L{}"'.format(libdir)],
+                  override_envvars=env)
         self.build()
-        self.run_tests()
+        self.run_tests(override_envvars=run_env)
 
 def should_run_cross_arm_tests():
     return shutil.which('arm-linux-gnueabihf-gcc') and not platform.machine().lower().startswith('arm')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5636,6 +5636,20 @@ c = ['{0}']
         # TODO should someday be explicit about build platform only here
         self.init(testdir, override_envvars=env)
 
+    def test_static_link(self):
+        # Build some libraries and install them
+        testdir = os.path.join(self.unit_test_dir, '69 static link/lib')
+        libdir = os.path.join(self.installdir, self.prefix[1:], self.libdir)
+        self.init(testdir)
+        self.install()
+
+        # Test that installed libraries works
+        self.new_builddir()
+        testdir = os.path.join(self.unit_test_dir, '69 static link')
+        self.init(testdir, extra_args=['-Dc_link_args="-L{}"'.format(libdir)])
+        self.build()
+        self.run_tests()
+
 def should_run_cross_arm_tests():
     return shutil.which('arm-linux-gnueabihf-gcc') and not platform.machine().lower().startswith('arm')
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5642,19 +5642,22 @@ c = ['{0}']
 
         # Build some libraries and install them
         testdir = os.path.join(self.unit_test_dir, '69 static link/lib')
-        libdir = os.path.join(self.installdir, self.prefix[1:], self.libdir)
+        libdir = os.path.join(self.installdir, self.libdir)
+        oldprefix = self.prefix
+        self.prefix = self.installdir
         self.init(testdir)
-        self.install()
+        self.install(use_destdir=False)
 
         # Test that installed libraries works
         self.new_builddir()
+        self.prefix = oldprefix
+        meson_args = ['-Dc_link_args=-L{}'.format(libdir),
+                      '--fatal-meson-warnings']
         testdir = os.path.join(self.unit_test_dir, '69 static link')
         env = {'PKG_CONFIG_LIBDIR': os.path.join(libdir, 'pkgconfig')}
-        run_env = {'LD_LIBRARY_PATH': libdir}
-        self.init(testdir, extra_args=['-Dc_link_args="-L{}"'.format(libdir)],
-                  override_envvars=env)
+        self.init(testdir, extra_args=meson_args, override_envvars=env)
         self.build()
-        self.run_tests(override_envvars=run_env)
+        self.run_tests()
 
 def should_run_cross_arm_tests():
     return shutil.which('arm-linux-gnueabihf-gcc') and not platform.machine().lower().startswith('arm')

--- a/test cases/unit/69 static link/lib/func1.c
+++ b/test cases/unit/69 static link/lib/func1.c
@@ -1,0 +1,9 @@
+int func1()
+{
+  return 1;
+}
+
+int func1b()
+{
+  return 1;
+}

--- a/test cases/unit/69 static link/lib/func10.c
+++ b/test cases/unit/69 static link/lib/func10.c
@@ -1,0 +1,4 @@
+int func10()
+{
+  return 1;
+}

--- a/test cases/unit/69 static link/lib/func11.c
+++ b/test cases/unit/69 static link/lib/func11.c
@@ -1,0 +1,6 @@
+int func10();
+
+int func11()
+{
+  return func10() + 1;
+}

--- a/test cases/unit/69 static link/lib/func12.c
+++ b/test cases/unit/69 static link/lib/func12.c
@@ -1,0 +1,7 @@
+int func10();
+int func11();
+
+int func12()
+{
+  return func10() + func11();
+}

--- a/test cases/unit/69 static link/lib/func14.c
+++ b/test cases/unit/69 static link/lib/func14.c
@@ -1,0 +1,4 @@
+int func14()
+{
+  return 1;
+}

--- a/test cases/unit/69 static link/lib/func15.c
+++ b/test cases/unit/69 static link/lib/func15.c
@@ -1,0 +1,6 @@
+int func14();
+
+int func15()
+{
+  return func14() + 1;
+}

--- a/test cases/unit/69 static link/lib/func16.c
+++ b/test cases/unit/69 static link/lib/func16.c
@@ -1,0 +1,6 @@
+int func15();
+
+int func16()
+{
+  return func15() + 1;
+}

--- a/test cases/unit/69 static link/lib/func2.c
+++ b/test cases/unit/69 static link/lib/func2.c
@@ -1,0 +1,6 @@
+int func1();
+
+int func2()
+{
+  return func1() + 1;
+}

--- a/test cases/unit/69 static link/lib/func3.c
+++ b/test cases/unit/69 static link/lib/func3.c
@@ -1,0 +1,4 @@
+int func3()
+{
+  return 1;
+}

--- a/test cases/unit/69 static link/lib/func4.c
+++ b/test cases/unit/69 static link/lib/func4.c
@@ -1,0 +1,6 @@
+int func3();
+
+int func4()
+{
+  return func3() + 1;
+}

--- a/test cases/unit/69 static link/lib/func5.c
+++ b/test cases/unit/69 static link/lib/func5.c
@@ -1,0 +1,4 @@
+int func5()
+{
+  return 1;
+}

--- a/test cases/unit/69 static link/lib/func6.c
+++ b/test cases/unit/69 static link/lib/func6.c
@@ -1,0 +1,6 @@
+int func5();
+
+int func6()
+{
+  return func5() + 1;
+}

--- a/test cases/unit/69 static link/lib/func7.c
+++ b/test cases/unit/69 static link/lib/func7.c
@@ -1,0 +1,4 @@
+int func7()
+{
+  return 1;
+}

--- a/test cases/unit/69 static link/lib/func8.c
+++ b/test cases/unit/69 static link/lib/func8.c
@@ -1,0 +1,6 @@
+int func7();
+
+int func8()
+{
+  return func7() + 1;
+}

--- a/test cases/unit/69 static link/lib/func9.c
+++ b/test cases/unit/69 static link/lib/func9.c
@@ -1,0 +1,6 @@
+int func8();
+
+int func9()
+{
+  return func8() + 1;
+}

--- a/test cases/unit/69 static link/lib/meson.build
+++ b/test cases/unit/69 static link/lib/meson.build
@@ -1,0 +1,8 @@
+project('test static link libs', 'c')
+
+# libfunc2 should contain both func1() and func2() symbols
+libfunc1 = static_library('func1', 'func1.c',
+  install : false)
+libfunc2 = static_library('func2', 'func2.c',
+  link_whole : libfunc1,
+  install : true)

--- a/test cases/unit/69 static link/lib/meson.build
+++ b/test cases/unit/69 static link/lib/meson.build
@@ -56,3 +56,13 @@ libfunc12 = static_library('func12', 'func12.c',
   link_with : [libfunc10, libfunc11],
   install : false)
 libfunc13 = shared_library('func13', link_whole : libfunc12)
+
+# libfunc16 should contain func14(), func15() and func16()
+libfunc14 = static_library('func14', 'func14.c',
+  install : false)
+libfunc15 = static_library('func15', 'func15.c',
+  link_with : libfunc14,
+  install : false)
+libfunc16 = static_library('func16', 'func16.c',
+  link_with : libfunc15,
+  install : true)

--- a/test cases/unit/69 static link/lib/meson.build
+++ b/test cases/unit/69 static link/lib/meson.build
@@ -26,3 +26,18 @@ libfunc6 = both_libraries('func6', 'func6.c',
   link_with : libfunc5,
   install : true)
 pkg.generate(libfunc6)
+
+# libfunc9 should contain both func8() and func9() but not func7() because that
+# one gets installed. Also test that link_with and link_whole works the same way
+# because libfunc8 is uninstalled.
+libfunc7 = static_library('func7', 'func7.c',
+  install : true)
+libfunc8 = static_library('func8', 'func8.c',
+  link_with : libfunc7,
+  install : false)
+libfunc9_linkwith = static_library('func9_linkwith', 'func9.c',
+  link_with : libfunc8,
+  install : true)
+libfunc9_linkwhole = static_library('func9_linkwhole', 'func9.c',
+  link_whole : libfunc8,
+  install : true)

--- a/test cases/unit/69 static link/lib/meson.build
+++ b/test cases/unit/69 static link/lib/meson.build
@@ -1,5 +1,7 @@
 project('test static link libs', 'c')
 
+pkg = import('pkgconfig')
+
 # libfunc2 should contain both func1() and func2() symbols
 libfunc1 = static_library('func1', 'func1.c',
   install : false)
@@ -14,3 +16,13 @@ libfunc3 = static_library('func3', 'func3.c',
 libfunc4 = static_library('func4', 'func4.c',
   link_with : libfunc3,
   install : true)
+
+# Same as above, but also generate an pkg-config file. Use both_libraries() to
+# make sure a complete .pc file gets generated. libfunc5 should not be mentioned
+# into the .pc file because it's not installed.
+libfunc5 = static_library('func5', 'func5.c',
+  install : false)
+libfunc6 = both_libraries('func6', 'func6.c',
+  link_with : libfunc5,
+  install : true)
+pkg.generate(libfunc6)

--- a/test cases/unit/69 static link/lib/meson.build
+++ b/test cases/unit/69 static link/lib/meson.build
@@ -6,3 +6,11 @@ libfunc1 = static_library('func1', 'func1.c',
 libfunc2 = static_library('func2', 'func2.c',
   link_whole : libfunc1,
   install : true)
+
+# Same as above, but with link_with instead of link_whole,
+# libfunc4 should contain both func3() and func4() symbols
+libfunc3 = static_library('func3', 'func3.c',
+  install : false)
+libfunc4 = static_library('func4', 'func4.c',
+  link_with : libfunc3,
+  install : true)

--- a/test cases/unit/69 static link/lib/meson.build
+++ b/test cases/unit/69 static link/lib/meson.build
@@ -41,3 +41,18 @@ libfunc9_linkwith = static_library('func9_linkwith', 'func9.c',
 libfunc9_linkwhole = static_library('func9_linkwhole', 'func9.c',
   link_whole : libfunc8,
   install : true)
+
+# Pattern found in mesa:
+# - libfunc11 uses func10()
+# - libfunc12 uses both func10() and func11()
+# When a shared library link_whole on libfunc12, we ensure we don't include
+# func10.c.o twice which would fail to link.
+libfunc10 = static_library('func10', 'func10.c',
+  install : false)
+libfunc11 = static_library('func11', 'func11.c',
+  link_with : libfunc10,
+  install : false)
+libfunc12 = static_library('func12', 'func12.c',
+  link_with : [libfunc10, libfunc11],
+  install : false)
+libfunc13 = shared_library('func13', link_whole : libfunc12)

--- a/test cases/unit/69 static link/meson.build
+++ b/test cases/unit/69 static link/meson.build
@@ -17,3 +17,12 @@ test('test3-static', executable('test3-static', 'test3.c',
 func6_shared_dep = dependency('func6', static : false)
 test('test3-shared', executable('test3-shared', 'test3.c',
     dependencies : func6_shared_dep))
+
+# Verify that installed libfunc9.a contains func8() and func8() but not func7()
+func7_dep = cc.find_library('func7')
+func9_linkwhole_dep = cc.find_library('func9_linkwhole')
+test('test4-linkwhole', executable('test4-linkwhole', 'test4.c',
+  dependencies : [func7_dep, func9_linkwhole_dep]))
+func9_linkwith_dep = cc.find_library('func9_linkwith')
+test('test4-linkwith', executable('test4-linkwith', 'test4.c',
+  dependencies : [func7_dep, func9_linkwith_dep]))

--- a/test cases/unit/69 static link/meson.build
+++ b/test cases/unit/69 static link/meson.build
@@ -5,3 +5,7 @@ cc = meson.get_compiler('c')
 # Verify that installed libfunc2.a is usable
 func2_dep = cc.find_library('func2')
 test('test1', executable('test1', 'test1.c', dependencies : func2_dep))
+
+# Verify that installed libfunc4.a is usable
+func4_dep = cc.find_library('func4')
+test('test2', executable('test2', 'test2.c', dependencies : func4_dep))

--- a/test cases/unit/69 static link/meson.build
+++ b/test cases/unit/69 static link/meson.build
@@ -9,3 +9,11 @@ test('test1', executable('test1', 'test1.c', dependencies : func2_dep))
 # Verify that installed libfunc4.a is usable
 func4_dep = cc.find_library('func4')
 test('test2', executable('test2', 'test2.c', dependencies : func4_dep))
+
+# Verify that installed pkg-config file is usable for both shared and static link
+func6_static_dep = dependency('func6', static : true)
+test('test3-static', executable('test3-static', 'test3.c',
+    dependencies : func6_static_dep))
+func6_shared_dep = dependency('func6', static : false)
+test('test3-shared', executable('test3-shared', 'test3.c',
+    dependencies : func6_shared_dep))

--- a/test cases/unit/69 static link/meson.build
+++ b/test cases/unit/69 static link/meson.build
@@ -26,3 +26,7 @@ test('test4-linkwhole', executable('test4-linkwhole', 'test4.c',
 func9_linkwith_dep = cc.find_library('func9_linkwith')
 test('test4-linkwith', executable('test4-linkwith', 'test4.c',
   dependencies : [func7_dep, func9_linkwith_dep]))
+
+# Verify that installed libfunc16.a is usable
+libfunc16_dep = cc.find_library('func16')
+test('test5', executable('test5', 'test5.c', dependencies: libfunc16_dep))

--- a/test cases/unit/69 static link/meson.build
+++ b/test cases/unit/69 static link/meson.build
@@ -1,0 +1,7 @@
+project('test static link', 'c')
+
+cc = meson.get_compiler('c')
+
+# Verify that installed libfunc2.a is usable
+func2_dep = cc.find_library('func2')
+test('test1', executable('test1', 'test1.c', dependencies : func2_dep))

--- a/test cases/unit/69 static link/test1.c
+++ b/test cases/unit/69 static link/test1.c
@@ -1,0 +1,7 @@
+int func1b();
+int func2();
+
+int main(int argc, char *argv[])
+{
+  return func2() + func1b() == 3 ? 0 : 1;
+}

--- a/test cases/unit/69 static link/test2.c
+++ b/test cases/unit/69 static link/test2.c
@@ -1,0 +1,6 @@
+int func4();
+
+int main(int argc, char *argv[])
+{
+  return func4() == 2 ? 0 : 1;
+}

--- a/test cases/unit/69 static link/test3.c
+++ b/test cases/unit/69 static link/test3.c
@@ -1,0 +1,6 @@
+int func6();
+
+int main(int argc, char *argv[])
+{
+  return func6() == 2 ? 0 : 1;
+}

--- a/test cases/unit/69 static link/test4.c
+++ b/test cases/unit/69 static link/test4.c
@@ -1,0 +1,6 @@
+int func9();
+
+int main(int argc, char *argv[])
+{
+  return func9() == 3 ? 0 : 1;
+}

--- a/test cases/unit/69 static link/test5.c
+++ b/test cases/unit/69 static link/test5.c
@@ -1,0 +1,6 @@
+int func16();
+
+int main(int argc, char *argv[])
+{
+  return func16() == 3 ? 0 : 1;
+}


### PR DESCRIPTION
This is a subset of https://github.com/mesonbuild/meson/pull/3939. I tried to split it in small commits with explicit test case. I also verified that this fix static link against glib when reverting the workaround they merged: https://gitlab.gnome.org/GNOME/glib/issues/1536.