### PR TITLE
environment: Don't make special case for scan-build on Linux

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -173,8 +173,6 @@ def detect_scanbuild():
     named "scan-build". However, some distribution's package manager (FreeBSD)
     don't. For those, loop through a list of candidates to see if one is
     available.
-    Since this is a costly operation, limit it to the impacted platforms
-    (currently all non-linux platforms)
 
     Return: a single-element list of the found scan-build binary ready to be
         passed to Popen()
@@ -183,14 +181,11 @@ def detect_scanbuild():
     if 'SCANBUILD' in os.environ:
         exelist = split_args(os.environ['SCANBUILD'])
 
-    elif shutil.which('scan-build') is not None:
-        exelist = [shutil.which('scan-build')]
-
-    elif platform.system() != 'Linux':
+    else:
         tools = [
             'scan-build',  # base
-            'scan-build-8.0', 'scan-build80',
-            'scan-build-7.0', 'scan-build70',
+            'scan-build-8',   'scan-build80',
+            'scan-build-7',   'scan-build70',
             'scan-build-6.0', 'scan-build60',
             'scan-build-5.0', 'scan-build50',
             'scan-build-4.0', 'scan-build40',
@@ -199,7 +194,7 @@ def detect_scanbuild():
             'scan-build-3.7', 'scan-build37',
             'scan-build-3.6', 'scan-build36',
             'scan-build-3.5', 'scan-build35',
-            'scan-build-9.0', 'scan-build-devel',  # development snapshot
+            'scan-build-9',   'scan-build-devel',  # development snapshot
         ]
         for tool in tools:
             if shutil.which(tool) is not None:


### PR DESCRIPTION
Versioning of executables is not related to the operating system kernel.
It is possible for a Linux distribution to support multiple versions of
LLVM in a way similar to FreeBSD. For example, on Debian, you can use
'apt install clang-tools-7' to install the versioned 'scan-build-7'
executable without bringing the unversioned 'scan-build' into the
environment. Therefore, we should not skip the version list on Linux.
It also makes it consistent with the behavior of llvm dependency, which
does not change the search list depending on the operating system.

This commit also fixes the version suffix for Debian. Debian stops using
the minor version number on the executable after version 7, so it should
be 'scan-build-7', not 'scan-build-7.0'.

This is a follow-up of https://github.com/mesonbuild/meson/pull/5918.