### PR TITLE
Move the list of LLVM versions to a common place

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2657,9 +2657,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         self.create_target_alias('meson-scan-build')
 
     def generate_clangformat(self):
-        import shutil
         target_name = 'clang-format'
-        if shutil.which('clang-format') is None:
+        if not environment.detect_clangformat():
             return
         if not os.path.exists(os.path.join(self.environment.source_dir, '.clang-format')) and \
                 not os.path.exists(os.path.join(self.environment.source_dir, '_clang-format')):

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -22,6 +22,7 @@ import re
 
 from .. import mesonlib, mlog
 from ..mesonlib import version_compare, stringlistify, extract_as_list, MachineChoice
+from ..environment import get_llvm_tool_names
 from .base import (
     DependencyException, DependencyMethods, ExternalDependency, PkgConfigDependency,
     strip_system_libdirs, ConfigToolDependency, CMakeDependency, HasNativeKwarg
@@ -208,25 +209,7 @@ class LLVMDependencyConfigTool(ConfigToolDependency):
         # before `super().__init__` is called.
         HasNativeKwarg.__init__(self, kwargs)
 
-        # Ordered list of llvm-config binaries to try. Start with base, then try
-        # newest back to oldest (3.5 is arbitrary), and finally the devel version.
-        # Please note that llvm-config-6.0 is a development snapshot and it should
-        # not be moved to the beginning of the list.
-        self.tools = [
-            'llvm-config', # base
-            'llvm-config-8',   'llvm-config80',
-            'llvm-config-7',   'llvm-config70',
-            'llvm-config-6.0', 'llvm-config60',
-            'llvm-config-5.0', 'llvm-config50',
-            'llvm-config-4.0', 'llvm-config40',
-            'llvm-config-3.9', 'llvm-config39',
-            'llvm-config-3.8', 'llvm-config38',
-            'llvm-config-3.7', 'llvm-config37',
-            'llvm-config-3.6', 'llvm-config36',
-            'llvm-config-3.5', 'llvm-config35',
-            'llvm-config-9',     # Debian development snapshot
-            'llvm-config-devel', # FreeBSD development snapshot
-        ]
+        self.tools = get_llvm_tool_names('llvm-config')
 
         # Fedora starting with Fedora 30 adds a suffix of the number
         # of bits in the isa that llvm targets, for example, on x86_64

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -163,6 +163,32 @@ def detect_ninja(version: str = '1.5', log: bool = False) -> str:
                 mlog.log('Found {}-{} at {}'.format(name, found, quote_arg(n)))
             return n
 
+def get_llvm_tool_names(tool: str) -> typing.List[str]:
+    # Ordered list of possible suffixes of LLVM executables to try. Start with
+    # base, then try newest back to oldest (3.5 is arbitrary), and finally the
+    # devel version. Please note that the development snapshot in Debian does
+    # not have a distinct name. Do not move it to the beginning of the list
+    # unless it becomes a stable release.
+    suffixes = [
+        '', # base (no suffix)
+        '-8',   '80',
+        '-7',   '70',
+        '-6.0', '60',
+        '-5.0', '50',
+        '-4.0', '40',
+        '-3.9', '39',
+        '-3.8', '38',
+        '-3.7', '37',
+        '-3.6', '36',
+        '-3.5', '35',
+        '-9',     # Debian development snapshot
+        '-devel', # FreeBSD development snapshot
+    ]
+    names = []
+    for suffix in suffixes:
+        names.append(tool + suffix)
+    return names
+
 def detect_scanbuild():
     """ Look for scan-build binary on build platform
 
@@ -182,20 +208,7 @@ def detect_scanbuild():
         exelist = split_args(os.environ['SCANBUILD'])
 
     else:
-        tools = [
-            'scan-build',  # base
-            'scan-build-8',   'scan-build80',
-            'scan-build-7',   'scan-build70',
-            'scan-build-6.0', 'scan-build60',
-            'scan-build-5.0', 'scan-build50',
-            'scan-build-4.0', 'scan-build40',
-            'scan-build-3.9', 'scan-build39',
-            'scan-build-3.8', 'scan-build38',
-            'scan-build-3.7', 'scan-build37',
-            'scan-build-3.6', 'scan-build36',
-            'scan-build-3.5', 'scan-build35',
-            'scan-build-9',   'scan-build-devel',  # development snapshot
-        ]
+        tools = get_llvm_tool_names('scan-build')
         for tool in tools:
             if shutil.which(tool) is not None:
                 exelist = [shutil.which(tool)]

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -171,6 +171,7 @@ def get_llvm_tool_names(tool: str) -> typing.List[str]:
     # unless it becomes a stable release.
     suffixes = [
         '', # base (no suffix)
+        '-9',   '90',
         '-8',   '80',
         '-7',   '70',
         '-6.0', '60',
@@ -181,7 +182,7 @@ def get_llvm_tool_names(tool: str) -> typing.List[str]:
         '-3.7', '37',
         '-3.6', '36',
         '-3.5', '35',
-        '-9',     # Debian development snapshot
+        '-10',    # Debian development snapshot
         '-devel', # FreeBSD development snapshot
     ]
     names = []

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -189,7 +189,7 @@ def get_llvm_tool_names(tool: str) -> typing.List[str]:
         names.append(tool + suffix)
     return names
 
-def detect_scanbuild():
+def detect_scanbuild() -> typing.List[str]:
     """ Look for scan-build binary on build platform
 
     First, if a SCANBUILD env variable has been provided, give it precedence
@@ -218,6 +218,22 @@ def detect_scanbuild():
         tool = exelist[0]
         if os.path.isfile(tool) and os.access(tool, os.X_OK):
             return [tool]
+    return []
+
+def detect_clangformat() -> typing.List[str]:
+    """ Look for clang-format binary on build platform
+
+    Do the same thing as detect_scanbuild to find clang-format except it
+    currently does not check the environment variable.
+
+    Return: a single-element list of the found clang-format binary ready to be
+        passed to Popen()
+    """
+    tools = get_llvm_tool_names('clang-format')
+    for tool in tools:
+        path = shutil.which(tool)
+        if path is not None:
+            return [path]
     return []
 
 def detect_native_windows_arch():


### PR DESCRIPTION
This pull request depends on https://github.com/mesonbuild/meson/pull/5937.

Currently we have two copies of the list of LLVM versions in Meson: one is for `llvm-config` and the other one is for `scan-build`. It should be better to move them to a common place, so they won't become out of sync. This pull request also make `clang-format` use the list, so `clang-format` installed with alternative names can now be found.