### PR TITLE
interpreter: raise Meson exception when non-found module is used anyway

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2388,6 +2388,8 @@ external dependencies (including libraries) must go to "dependencies".''')
                 msg = 'Program {!r} was overridden with the compiled executable {!r}'\
                       ' and therefore cannot be used during configuration'
                 raise InterpreterException(msg.format(progname, cmd.description()))
+            if not cmd.found():
+                raise InterpreterException('command {!r} not found or not executable'.format(cmd))
         elif isinstance(cmd, CompilerHolder):
             cmd = cmd.compiler.get_exelist()[0]
             prog = ExternalProgram(cmd, silent=True)

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -1389,13 +1389,13 @@ class BuildDirLock:
             msvcrt.locking(self.lockfile.fileno(), msvcrt.LK_UNLCK, 1)
         self.lockfile.close()
 
-def relpath(path, start):
+def relpath(path: str, start: str) -> str:
     # On Windows a relative path can't be evaluated for paths on two different
     # drives (i.e. c:\foo and f:\bar).  The only thing left to do is to use the
     # original absolute path.
     try:
         return os.path.relpath(path, start)
-    except ValueError:
+    except (TypeError, ValueError):
         return path
 
 


### PR DESCRIPTION
Fixes #5844

avoids spilling Python traceback by raising Meson exception.


meson.build MWE
```meson
project('test-npe')

pythonmod = import('python')

python = pythonmod.find_installation('NotAnExistingModuleABC123', required: false)

run_command(python, '-v')
```