### PR TITLE
mtest: TAP: ignore unhandled input lines

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -299,6 +299,9 @@ class TAPParser:
                     yield self.Version(version=version)
                 continue
 
+            if len(line) == 0:
+                continue
+
             yield self.Error('unexpected input at line %d' % (lineno,))
 
         if state == self._YAML:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6730,6 +6730,12 @@ class TAPParserTests(unittest.TestCase):
         self.assert_plan(events, count=1, late=True)
         self.assert_last(events)
 
+    def test_empty_line(self):
+        events = self.parse_tap('1..1\n\nok 1')
+        self.assert_plan(events, count=1, late=False)
+        self.assert_test(events, number=1, name='', result=TestResult.OK)
+        self.assert_last(events)
+
     def test_unexpected(self):
         events = self.parse_tap('1..1\ninvalid\nok 1')
         self.assert_plan(events, count=1, late=False)


### PR DESCRIPTION
According to http://testanything.org/tap-specification.html

"Any output line that is not a version, a plan, a test line, a
diagnostic or a bail out is considered an “unknown” line. A TAP parser
is required to not consider an unknown line as an error"

(glib gtest can generate empty lines - we may want to ignore only
empty lines)

Signed-off-by: Marc-André Lureau <marcandre.lureau@redhat.com>