### PR TITLE
mesonbuild: fix exception name.

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -371,7 +371,7 @@ class CLikeCompiler:
 
     def run(self, code: str, env, *, extra_args=None, dependencies=None):
         if self.is_cross and self.exe_wrapper is None:
-            raise mesonlib.CrossNoRunException('Can not run test applications in this cross environment.')
+            raise compilers.CrossNoRunException('Can not run test applications in this cross environment.')
         with self._build_wrapper(code, env, extra_args, dependencies, mode='link', want_output=True) as p:
             if p.returncode != 0:
                 mlog.debug('Could not compile test file %s: %d\n' % (


### PR DESCRIPTION
CrossNoRunException is in compilers module, not mesonlib.

How to reproduce: run a compiler object `.run()` object while cross-compiling and making sure you don't have a exe_wrapper set.

Result: you get a meson crash:

> [… some huge backtrace …]
>   File "/home/jehan/.local/lib/python3.7/site-packages/meson-0.51.999-py3.7.egg/mesonbuild/compilers/mixins/clike.py", line 374, in run
>    raise mesonlib.CrossNoRunException('Can not run test applications in this cross environment.')
> AttributeError: module 'mesonbuild.mesonlib' has no attribute 'CrossNoRunException'

This commit fixes it, and you get just a nice meaningful error as expected, instead:

> meson.build:365:0: ERROR: Can not run test applications in this cross environment.