### PR TITLE
Print user defined options in meson-log.txt

### DIFF
--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -161,6 +161,7 @@ class MesonApp:
     def _generate(self, env):
         mlog.debug('Build started at', datetime.datetime.now().isoformat())
         mlog.debug('Main binary:', sys.executable)
+        mlog.debug('Build Options:', coredata.get_cmd_line_options(self.build_dir, self.options))
         mlog.debug('Python system:', platform.system())
         mlog.log(mlog.bold('The Meson build system'))
         mlog.log('Version:', coredata.version)


### PR DESCRIPTION
It can be useful to know what options have been passed to the command
line, excluding default values.

Closes: #5956