### PR TITLE
Miscellaneous bugfixes

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -718,7 +718,13 @@ class CoreData:
         if env.first_invocation:
             p_env = os.environ.get('PKG_CONFIG_PATH')
             if p_env:
-                options['pkg_config_path'] = p_env.split(':')
+                # PKG_CONFIG_PATH may contain duplicates, which must be
+                # removed, else a duplicates-in-array-option warning arises.
+                pkg_config_paths = []
+                for k in p_env.split(':'):
+                    if k not in pkg_config_paths:
+                        pkg_config_paths.append(k)
+                options['pkg_config_path'] = pkg_config_paths
 
         for k, v in env.cmd_line_options.items():
             if subproject:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -817,7 +817,7 @@ class Environment:
                 v = 'unknown version'
             linker = AppleDynamicLinker(compiler, for_machine, i, prefix, version=v)
         elif 'GNU' in o:
-            if 'gold' in 'o':
+            if 'gold' in o:
                 i = 'GNU ld.gold'
             else:
                 i = 'GNU ld.bfd'


### PR DESCRIPTION
Solves two small problems:

- An always-false test that effectively disables the `gold` linker
- Deduplicates `PKG_CONFIG_PATH` entries before placing them into `pk_config_path` option, avoiding a deprecation warning related to duplicates in an array option.