### PR TITLE
dependencies: account for frameworks without a Versions directory

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -2053,6 +2053,9 @@ class ExtraFrameworkDependency(ExternalDependency):
             if each.name.lower() == 'current':
                 continue
             versions.append(Version(each.name))
+        if len(versions) == 0:
+            # most system frameworks do not have a 'Versions' directory
+            return 'Headers'
         return 'Versions/{}/Headers'.format(sorted(versions)[-1]._s)
 
     def _get_framework_include_path(self, path):


### PR DESCRIPTION
Most iOS apple system frameworks do not have a Versions directory in them at all.

Fixes the following traceback:

```
...
  File "/Users/matt/Projects/cerbero/build/build-tools/lib/python3.7/site-packages/meson-0.51.999-py3.7.egg/mesonbuild/interpreter.py", line 3063, in func_dependency
    d = self.dependency_impl(name, display_name, kwargs)
  File "/Users/matt/Projects/cerbero/build/build-tools/lib/python3.7/site-packages/meson-0.51.999-py3.7.egg/mesonbuild/interpreter.py", line 3110, in dependency_impl
    dep = dependencies.find_external_dependency(name, self.environment, kwargs)
  File "/Users/matt/Projects/cerbero/build/build-tools/lib/python3.7/site-packages/meson-0.51.999-py3.7.egg/mesonbuild/dependencies/base.py", line 2142, in find_external_dependency
    d = c()
  File "/Users/matt/Projects/cerbero/build/build-tools/lib/python3.7/site-packages/meson-0.51.999-py3.7.egg/mesonbuild/dependencies/base.py", line 2004, in __init__
    self.detect(name, paths)
  File "/Users/matt/Projects/cerbero/build/build-tools/lib/python3.7/site-packages/meson-0.51.999-py3.7.egg/mesonbuild/dependencies/base.py", line 2035, in detect
    incdir = self._get_framework_include_path(framework_path)
  File "/Users/matt/Projects/cerbero/build/build-tools/lib/python3.7/site-packages/meson-0.51.999-py3.7.egg/mesonbuild/dependencies/base.py", line 2065, in _get_framework_include_path
    self._get_framework_latest_version(path))
  File "/Users/matt/Projects/cerbero/build/build-tools/lib/python3.7/site-packages/meson-0.51.999-py3.7.egg/mesonbuild/dependencies/base.py", line 2057, in _get_framework_latest_version
    return 'Versions/{}/Headers'.format(sorted(versions)[-1]._s)
IndexError: list index out of range
```