### PR TITLE
Autodetect subproject method

### DIFF
--- a/docs/markdown/CMake-module.md
+++ b/docs/markdown/CMake-module.md
@@ -79,6 +79,13 @@ It should be noted that not all projects are guaranteed to work. The
 safest approach would still be to create a `meson.build` for the
 subprojects in question.
 
+*Since 0.52.0* any subproject that has `CMakeLists.txt` file and not
+`meson.build` will transparently be configured using CMake. For example:
+```meson
+  sub_pro = subproject('libsimple_cmake')
+  dep = dependency('simple', fallback : ['libsimple_cmake', 'simplelib_dep'])
+```
+
 ### `subproject` object
 
 This object is returned by the `subproject` function described above

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -426,7 +426,9 @@ arguments:
   that override those set in the subproject's `meson_options.txt`
   (like `default_options` in [`project()`](#project), they only have
   effect when Meson is run for the first time, and command line
-  arguments override any default options in build files)
+  arguments override any default options in build files). *Since 0.52.0* if the
+  subproject is configured using cmake, this array is converted to
+  `[-Dkey=value, ...]` and passed to cmake invokation command.
 - `fallback` specifies a subproject fallback to use in case the
   dependency is not found in the system. The value is an array
   `['subproj_name', 'subproj_dep']` where the first value is the name
@@ -435,7 +437,9 @@ arguments:
   value of [`declare_dependency`](#declare_dependency) or
   [`dependency()`](#dependency), etc. Note that this means the
   fallback dependency may be a not-found dependency, in which
-  case the value of the `required:` kwarg will be obeyed.
+  case the value of the `required:` kwarg will be obeyed. *Since 0.52.0* if the
+  subproject source has `CMakeLists.txt` file and not `meson.build`, it will be
+  configured using CMake.
 - `language` *(added 0.42.0)* defines what language-specific
   dependency to find if it's available for multiple languages.
 - `method` defines the way the dependency is detected, the default is
@@ -1462,7 +1466,9 @@ arguments:
    that override those set in the subproject's `meson_options.txt`
    (like `default_options` in `project`, they only have effect when
    Meson is run for the first time, and command line arguments override
-   any default options in build files)
+   any default options in build files). *Since 0.52.0* if the
+   subproject is configured using cmake, this array is converted to
+   `[-Dkey=value, ...]` and passed to cmake invokation command.
  - `version` keyword argument that works just like the one in
    `dependency`. It specifies what version the subproject should be,
    as an example `>=1.0.1`
@@ -1480,6 +1486,9 @@ inside a subproject, an easier way is to use the `fallback:` keyword
 argument to [`dependency()`](#dependency).
 
 [See additional documentation](Subprojects.md).
+
+*Since 0.52.0* if the subproject source has `CMakeLists.txt` file and not
+`meson.build`, it will be configured using CMake.
 
 ### test()
 

--- a/docs/markdown/snippets/cmake_subproject.md
+++ b/docs/markdown/snippets/cmake_subproject.md
@@ -1,0 +1,8 @@
+## Autodetect CMake subproject
+
+Any subproject that has `CMakeLists.txt` file and not `meson.build` will
+transparently be configured using CMake. For example:
+```meson
+  sub_pro = subproject('libsimple_cmake')
+  dep = dependency('simple', fallback : ['libsimple_cmake', 'simplelib_dep'])
+```

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2426,7 +2426,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         if len(args) != 1:
             raise InterpreterException('Subproject takes exactly one argument')
         dirname = args[0]
-        return self.do_subproject(dirname, 'meson', kwargs)
+        return self.do_subproject(dirname, 'auto', kwargs)
 
     def disabled_subproject(self, dirname):
         self.subprojects[dirname] = SubprojectHolder(None, self.subproject_dir, dirname)
@@ -2465,7 +2465,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         subproject_dir_abs = os.path.join(self.environment.get_source_dir(), self.subproject_dir)
         r = wrap.Resolver(subproject_dir_abs, self.coredata.get_builtin_option('wrap_mode'))
         try:
-            resolved = r.resolve(dirname, method)
+            resolved, method = r.resolve(dirname, method)
         except wrap.WrapException as e:
             subprojdir = os.path.join(self.subproject_dir, r.directory)
             if isinstance(e, wrap.WrapNotFoundException):
@@ -2544,6 +2544,7 @@ external dependencies (including libraries) must go to "dependencies".''')
             new_build = self.build.copy()
             prefix = self.coredata.builtins['prefix'].value
             cmake_options = mesonlib.stringlistify(kwargs.get('cmake_options', []))
+            cmake_options += ['-D{}={}'.format(k, v) for k, v in default_options.items()]
             cm_int = CMakeInterpreter(new_build, subdir, subdir_abs, prefix, new_build.environment, self.backend)
             cm_int.initialise(cmake_options)
             cm_int.analyse()
@@ -3174,7 +3175,7 @@ external dependencies (including libraries) must go to "dependencies".''')
             'default_options': kwargs.get('default_options', []),
             'required': kwargs.get('required', True),
         }
-        self.do_subproject(dirname, 'meson', sp_kwargs)
+        self.do_subproject(dirname, 'auto', sp_kwargs)
         return self.get_subproject_dep(display_name, dirname, varname, kwargs)
 
     @FeatureNewKwargs('executable', '0.42.0', ['implib'])

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -163,7 +163,7 @@ def download(wrap, repo_dir, options):
         return
     try:
         r = Resolver(os.path.dirname(repo_dir))
-        r.resolve(wrap.name, 'meson')
+        r.resolve(wrap.name, 'auto')
         mlog.log('  -> done')
     except WrapException as e:
         mlog.log('  ->', mlog.red(str(e)))

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -126,14 +126,20 @@ class Resolver:
         meson_file = os.path.join(self.dirname, 'meson.build')
         cmake_file = os.path.join(self.dirname, 'CMakeLists.txt')
 
-        if method not in ['meson', 'cmake']:
-            raise WrapException('Only the methods "meson" and "cmake" are supported')
+        if method not in ['auto', 'meson', 'cmake']:
+            raise WrapException('Only the methods "auto", "meson" and "cmake" are supported')
+
+        def detect_method():
+            if method in ['auto', 'meson'] and os.path.exists(meson_file):
+                return 'meson'
+            elif method in ['auto', 'cmake'] and os.path.exists(cmake_file):
+                return 'cmake'
+            return None
 
         # The directory is there and has meson.build? Great, use it.
-        if method == 'meson' and os.path.exists(meson_file):
-            return self.directory
-        if method == 'cmake' and os.path.exists(cmake_file):
-            return self.directory
+        detected_method = detect_method()
+        if detected_method is not None:
+            return self.directory, detected_method
 
         # Check if the subproject is a git submodule
         self.resolve_git_submodule()
@@ -161,12 +167,11 @@ class Resolver:
                     raise WrapException('Unknown wrap type {!r}'.format(self.wrap.type))
 
         # A meson.build or CMakeLists.txt file is required in the directory
-        if method == 'meson' and not os.path.exists(meson_file):
-            raise WrapException('Subproject exists but has no meson.build file')
-        if method == 'cmake' and not os.path.exists(cmake_file):
-            raise WrapException('Subproject exists but has no CMakeLists.txt file')
+        detected_method = detect_method()
+        if detected_method is None:
+            raise WrapException('Subproject exists but has unknown build system')
 
-        return self.directory
+        return self.directory, detected_method
 
     def load_wrap(self):
         fname = os.path.join(self.subdir_root, self.packagename + '.wrap')

--- a/test cases/cmake/13 dependency fallback/main.cpp
+++ b/test cases/cmake/13 dependency fallback/main.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <cmMod.hpp>
+
+using namespace std;
+
+int main() {
+  cmModClass obj("Hello");
+  cout << obj.getStr() << endl;
+  return 0;
+}

--- a/test cases/cmake/13 dependency fallback/meson.build
+++ b/test cases/cmake/13 dependency fallback/meson.build
@@ -1,0 +1,5 @@
+project('cmakeSubTest', ['c', 'cpp'])
+
+sub_dep = dependency('', fallback : ['cmMod', 'cmModLib_dep'])
+exe1 = executable('main', ['main.cpp'], dependencies: [sub_dep])
+test('test1', exe1)

--- a/test cases/cmake/13 dependency fallback/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/13 dependency fallback/subprojects/cmMod/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(cmMod)
+set (CMAKE_CXX_STANDARD 14)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+add_definitions("-DDO_NOTHING_JUST_A_FLAG=1")
+
+add_library(cmModLib SHARED cmMod.cpp)
+include(GenerateExportHeader)
+generate_export_header(cmModLib)

--- a/test cases/cmake/13 dependency fallback/subprojects/cmMod/cmMod.cpp
+++ b/test cases/cmake/13 dependency fallback/subprojects/cmMod/cmMod.cpp
@@ -1,0 +1,11 @@
+#include "cmMod.hpp"
+
+using namespace std;
+
+cmModClass::cmModClass(string foo) {
+  str = foo + " World";
+}
+
+string cmModClass::getStr() const {
+  return str;
+}

--- a/test cases/cmake/13 dependency fallback/subprojects/cmMod/cmMod.hpp
+++ b/test cases/cmake/13 dependency fallback/subprojects/cmMod/cmMod.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+#include "cmmodlib_export.h"
+
+class CMMODLIB_EXPORT cmModClass {
+  private:
+    std::string str;
+  public:
+    cmModClass(std::string foo);
+
+    std::string getStr() const;
+};


### PR DESCRIPTION
When configuring a subproject that has no `meson.build` file, fallback
to cmake if `CMakeLists.txt` is found.

This makes `subproject()` and `dependency(..., fallback : [])` work with
cmake subprojects.