### PR TITLE
mtest: add gdb_path option

### DIFF
--- a/docs/markdown/Unit-tests.md
+++ b/docs/markdown/Unit-tests.md
@@ -157,6 +157,12 @@ $ meson test --gdb --repeat=10000 testname
 
 This runs the test up to 10 000 times under GDB automatically. If the program crashes, GDB will halt and the user can debug the application. Note that testing timeouts are disabled in this case so `meson test` will not kill `gdb` while the developer is still debugging it. The downside is that if the test binary freezes, the test runner will wait forever.
 
+Sometimes, the GDB binary is not in the PATH variable or the user wants to use a GDB replacement. Therefore, the invoked GDB program can be specified *(added 0.52.0)*:
+
+```console
+$ meson test --gdb --gdb-path /path/to/gdb testname
+```
+
 ```console
 $ meson test --print-errorlogs
 ```

--- a/docs/markdown/snippets/add_gdb_path.md
+++ b/docs/markdown/snippets/add_gdb_path.md
@@ -1,0 +1,9 @@
+## The meson test program now accepts an additional "--gdb-path" argument to specify the GDB binary
+
+`meson test --gdb testname` invokes GDB with the specific test case. However, sometimes GDB is not in the path or a GDB replacement is wanted.
+Therefore, a `--gdb-path` argument was added to specify which binary is executed (per default `gdb`):
+
+```console
+$ meson test --gdb --gdb-path /my/special/location/for/gdb testname
+$ meson test --gdb --gdb-path cgdb testname
+```

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -85,6 +85,8 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
                         help='Do not rebuild before running tests.')
     parser.add_argument('--gdb', default=False, dest='gdb', action='store_true',
                         help='Run test under gdb.')
+    parser.add_argument('--gdb-path', default='gdb', dest='gdb_path',
+                        help='Path to the gdb binary (default: gdb).')
     parser.add_argument('--list', default=False, dest='list', action='store_true',
                         help='List available tests.')
     parser.add_argument('--wrapper', default=None, dest='wrapper', type=split_args,
@@ -892,7 +894,7 @@ Timeout:            %4d
     def get_wrapper(options: argparse.Namespace) -> typing.List[str]:
         wrap = []  # type: typing.List[str]
         if options.gdb:
-            wrap = ['gdb', '--quiet', '--nh']
+            wrap = [options.gdb_path, '--quiet', '--nh']
             if options.repeat > 1:
                 wrap += ['-ex', 'run', '-ex', 'quit']
             # Signal the end of arguments to gdb


### PR DESCRIPTION
When using the '--gdb' argument of meson test the executed binary can
now be specified with '--gdb-path'.

Closing: #4373