### PR TITLE
cmake: fix detection of libraries with .so version

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -602,14 +602,9 @@ class CMakeInterpreter:
 
         # generate the output_target_map
         output_target_map = {}
+        output_target_map.update({x.full_name: x for x in self.targets})
+        output_target_map.update({_target_key(x.name): x for x in self.targets})
         for i in self.targets:
-            output_target_map[i.full_name] = i
-            output_target_map[_target_key(i.name)] = i
-            ttarget = self.trace.targets.get(i.name)
-            soversion = ttarget.properties.get('SOVERSION') if ttarget else None
-            if soversion:
-                k = '{}.{}'.format(i.full_name, soversion[0])
-                output_target_map[k] = i
             for j in i.artifacts:
                 output_target_map[os.path.basename(j)] = i
         for i in self.custom_targets:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -39,7 +39,7 @@ Also add corresponding autodetection code in environment.py."""
 
 header_suffixes = ('h', 'hh', 'hpp', 'hxx', 'H', 'ipp', 'moc', 'vapi', 'di')
 obj_suffixes = ('o', 'obj', 'res')
-lib_suffixes = ('a', 'lib', 'dll', 'dylib', 'so')
+lib_suffixes = ('a', 'lib', 'dll', 'dll.a', 'dylib', 'so')
 # Mapping of language to suffixes of files that should always be in that language
 # This means we can't include .h headers here since they could be C, C++, ObjC, etc.
 lang_suffixes = {

--- a/test cases/cmake/2 advanced/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/2 advanced/subprojects/cmMod/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(cmModLib SHARED lib/cmMod.cpp)
 include(GenerateExportHeader)
 generate_export_header(cmModLib)
 
+set_target_properties(cmModLib PROPERTIES VERSION 1.0.1)
+
 add_executable(testEXE main.cpp)
 
 target_link_libraries(cmModLib ZLIB::ZLIB)

--- a/test cases/cmake/3 advanced no dep/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/3 advanced no dep/subprojects/cmMod/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(cmModLib SHARED lib/cmMod.cpp)
 include(GenerateExportHeader)
 generate_export_header(cmModLib)
 
+set_target_properties(cmModLib PROPERTIES VERSION 1.0.1)
+
 add_executable(testEXE main.cpp)
 
 target_link_libraries(testEXE cmModLib)


### PR DESCRIPTION
Fixes that also "../libinternalLib.so.1.2.3" is detected and used with `link_with`.