### PR TITLE
tls_model function attribute support

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -155,54 +155,60 @@ which are supported by GCC, Clang, and other compilers.
 
 
 | Name                 |
-|----------------------|
-| alias                |
-| aligned              |
-| alloc_size           |
-| always_inline        |
-| artificial           |
-| cold                 |
-| const                |
-| constructor          |
-| constructor_priority |
-| deprecated           |
-| destructor           |
-| error                |
-| externally_visible   |
-| fallthrough          |
-| flatten              |
-| format               |
-| format_arg           |
-| gnu_inline           |
-| hot                  |
-| ifunc                |
-| malloc               |
-| noclone              |
-| noinline             |
-| nonnull              |
-| noreturn             |
-| nothrow              |
-| optimize             |
-| packed               |
-| pure                 |
-| returns_nonnull      |
-| unused               |
-| used                 |
-| visibility*          |
-| visibility:default†  |
-| visibility:hidden†   |
-| visibility:internal† |
-| visibility:protected†|
-| warning              |
-| warn_unused_result   |
-| weak                 |
-| weakreaf             |
+|------------------------------|
+| alias                        |
+| aligned                      |
+| alloc_size                   |
+| always_inline                |
+| artificial                   |
+| cold                         |
+| const                        |
+| constructor                  |
+| constructor_priority         |
+| deprecated                   |
+| destructor                   |
+| error                        |
+| externally_visible           |
+| fallthrough                  |
+| flatten                      |
+| format                       |
+| format_arg                   |
+| gnu_inline                   |
+| hot                          |
+| ifunc                        |
+| malloc                       |
+| noclone                      |
+| noinline                     |
+| nonnull                      |
+| noreturn                     |
+| nothrow                      |
+| optimize                     |
+| packed                       |
+| pure                         |
+| returns_nonnull              |
+| unused                       |
+| used                         |
+| visibility*                  |
+| visibility:default†          |
+| visibility:hidden†           |
+| visibility:internal†         |
+| visibility:protected†        |
+| warning                      |
+| warn_unused_result           |
+| weak                         |
+| weakreaf                     |
+| tls_model:global-dynamic‡    |
+| tls_model:local-dynamic‡     |
+| tls_model:initial-exec‡      |
+| tls_model:local-exec‡        |
 
 \* *Changed in 0.52.0* the "visibility" target no longer includes
 "protected", which is not present in Apple's clang.
 
 † *New in 0.52.0* These split visibility attributes are preferred to the plain
 "visibility" as they provide narrower checks.
+
+‡ *New in 0.53.0*
 
 ### MSVC __declspec
 

--- a/mesonbuild/compilers/c_function_attributes.py
+++ b/mesonbuild/compilers/c_function_attributes.py
@@ -111,6 +111,14 @@ C_FUNC_ATTRIBUTES = {
     'weakref': '''
         static int foo(void) { return 0; }
         static int var(void) __attribute__((weakref("foo")));''',
+    'tls_model:global-dynamic':
+        '__thread int i __attribute__((tls_model("global-dynamic")));',
+    'tls_model:local-dynamic':
+        '__thread int i __attribute__((tls_model("local-dynamic")));',
+    'tls_model:initial-exec':
+        '__thread int i __attribute__((tls_model("initial-exec")));',
+    'tls_model:local-exec':
+        '__thread int i __attribute__((tls_model("local-exec")));',
 }
 
 CXX_FUNC_ATTRIBUTES = {

--- a/test cases/common/203 function attributes/meson.build
+++ b/test cases/common/203 function attributes/meson.build
@@ -54,6 +54,9 @@ attributes = [
   'used',
   'warn_unused_result',
   'weak',
+  'visibility:default',
+  'visibility:hidden',
+  'visibility:internal',
 ]
 
 if c.get_id() != 'intel'
@@ -65,6 +68,7 @@ endif
 if host_machine.system() != 'darwin'
   attributes += 'alias'
   attributes += 'visibility'
+  attributes += 'visibility:protected'
 endif
 
 if ['gcc', 'intel'].contains(c.get_id())

--- a/test cases/common/203 function attributes/meson.build
+++ b/test cases/common/203 function attributes/meson.build
@@ -57,6 +57,10 @@ attributes = [
   'visibility:default',
   'visibility:hidden',
   'visibility:internal',
+  'tls_model:global-dynamic',
+  'tls_model:local-dynamic',
+  'tls_model:initial-exec',
+  'tls_model:local-exec',
 ]
 
 if c.get_id() != 'intel'


### PR DESCRIPTION
This adds new arguments to the `compiler.has_function_attribute` family for tls_model.