### PR TITLE
Add test case to verify identity cross builds

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3687,6 +3687,16 @@ recommended as it is not supported on some platforms''')
         out = self.run_target('clang-tidy')
         self.assertIn('cttest.cpp:4:20', out)
 
+    def test_identity_cross(self):
+        testdir = os.path.join(self.unit_test_dir, '71 cross')
+        # Do a build to generate a cross file where the host is this target
+        self.init(testdir, extra_args=['-Dgenerate=true'])
+        self.meson_cross_file = os.path.join(self.builddir, "crossfile")
+        self.assertTrue(os.path.exists(self.meson_cross_file))
+        # Now verify that this is detected as cross
+        self.new_builddir()
+        self.init(testdir)
+
     def test_introspect_buildoptions_without_configured_build(self):
         testdir = os.path.join(self.unit_test_dir, '59 introspect buildoptions')
         testfile = os.path.join(testdir, 'meson.build')

--- a/test cases/unit/71 cross/crossfile.in
+++ b/test cases/unit/71 cross/crossfile.in
@@ -1,0 +1,5 @@
+[host_machine]
+system = '@system@'
+cpu_family = '@cpu_family@'
+cpu = '@cpu@'
+endian = '@endian@'

--- a/test cases/unit/71 cross/meson.build
+++ b/test cases/unit/71 cross/meson.build
@@ -1,0 +1,16 @@
+project('crosstest')
+
+if get_option('generate')
+    conf_data = configuration_data()
+    conf_data.set('system', build_machine.system())
+    conf_data.set('cpu', build_machine.cpu())
+    conf_data.set('cpu_family', build_machine.cpu_family())
+    conf_data.set('endian', build_machine.endian())
+
+    configure_file(input: 'crossfile.in',
+                output: 'crossfile',
+                configuration: conf_data)
+    message('Written cross file')
+else               
+    assert(meson.is_cross_build(), 'not setup as cross build')
+endif

--- a/test cases/unit/71 cross/meson_options.txt
+++ b/test cases/unit/71 cross/meson_options.txt
@@ -1,0 +1,1 @@
+option('generate', type : 'boolean', value : false)


### PR DESCRIPTION
A build with a cross file should always be identified as a cross build, even if
the host and build machine are identical.  This was the case in 0.50, regressed
in 0.51, and is fixed again in 0.52, so add a test case to ensure it doesn't
regress again.