### PR TITLE
Fix split -L argument

### DIFF
--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -930,7 +930,7 @@ class OptlinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
     def get_allow_undefined_args(self) -> typing.List[str]:
         return []
 
-class CudaLinker(DynamicLinker):
+class CudaLinker(PosixDynamicLinkerMixin, DynamicLinker):
     """Cuda linker (nvlink)"""
     @staticmethod
     def parse_version():
@@ -964,12 +964,6 @@ class CudaLinker(DynamicLinker):
         from .compilers import CudaCompiler
         return CudaCompiler.LINKER_PREFIX
 
-    def get_output_args(self, outname: str) -> typing.List[str]:
-        return ['-o', outname]
-
-    def get_search_args(self, dirname: str) -> typing.List[str]:
-        return ['-L', dirname]
-
     def fatal_warnings(self) -> typing.List[str]:
         return ['--warning-as-error']
 
@@ -980,6 +974,3 @@ class CudaLinker(DynamicLinker):
                         suffix: str, soversion: str, darwin_versions: typing.Tuple[str, str],
                         is_shared_module: bool) -> typing.List[str]:
         return []
-
-    def get_std_shared_lib_args(self) -> typing.List[str]:
-        return ['-shared']

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -412,7 +412,7 @@ class PosixDynamicLinkerMixin:
         return ['-shared']
 
     def get_search_args(self, dirname: str) -> typing.List[str]:
-        return ['-L', dirname]
+        return ['-L' + dirname]
 
 
 class GnuLikeDynamicLinkerMixin:


### PR DESCRIPTION
Pass search dirs as `['-L/some/path']` not `['-L', '/some/path']`