### PR TITLE
Skip test_noncross_options and test_static_link if pkg-config is missing

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5643,6 +5643,7 @@ class LinuxlikeTests(BasePlatformTests):
                 # Assert that
                 self.assertEqual(len(line.split(lib)), 2, msg=(lib, line))
 
+    @skipIfNoPkgconfig
     def test_noncross_options(self):
         # C_std defined in project options must be in effect also when native compiling.
         testdir = os.path.join(self.unit_test_dir, '51 noncross options')
@@ -5665,6 +5666,7 @@ c = ['{0}']
         # TODO should someday be explicit about build platform only here
         self.init(testdir, override_envvars=env)
 
+    @skipIfNoPkgconfig
     def test_static_link(self):
         if is_cygwin():
             raise unittest.SkipTest("Cygwin doesn't support LD_LIBRARY_PATH.")


### PR DESCRIPTION
`pkg-config` is not installed on BSDs by default. If running within a clean environment:
```
==================================================== FAILURES ====================================================
______________________________________ LinuxlikeTests.test_noncross_options ______________________________________
[...]
The Meson build system
Version: 0.52.0
Source dir: /wrkdirs/usr/ports/devel/meson/work/meson-0.52.0/test cases/unit/51 noncross options
Build dir: /wrkdirs/usr/ports/devel/meson/work/meson-0.52.0/tmp5fv03k8_
Build type: native build
Project name: std_remains
Project version: undefined
C compiler for the host machine: clang (clang 9.0.0 "FreeBSD clang version 9.0.0 (tags/RELEASE_900/final 372316) (based on LLVM 9.0.0)")
C linker for the host machine: lld 9.0.0
Host machine cpu family: x86
Host machine cpu: i386
Did not find pkg-config by name 'pkg-config'
Found Pkg-config: NO
Run-time dependency ylib found: NO

meson.build:13:2: ERROR: Pkg-config binary for machine MachineChoice.HOST not found. Giving up.

________________________________________ LinuxlikeTests.test_static_link _________________________________________
[...]
The Meson build system
Version: 0.52.0
Source dir: /wrkdirs/usr/ports/devel/meson/work/meson-0.52.0/test cases/unit/69 static link
Build dir: /wrkdirs/usr/ports/devel/meson/work/meson-0.52.0/tmpcghl4439
Build type: native build
Project name: test static link
Project version: undefined
C compiler for the host machine: clang (clang 9.0.0 "FreeBSD clang version 9.0.0 (tags/RELEASE_900/final 372316) (based on LLVM 9.0.0)")
C linker for the host machine: lld 9.0.0
Host machine cpu family: x86
Host machine cpu: i386
Library func2 found: YES
Library func4 found: YES
Did not find pkg-config by name 'pkg-config'
Found Pkg-config: NO
Did not find CMake 'cmake'
Found CMake: NO
Run-time dependency func6 found: NO

meson.build:14:0: ERROR: Pkg-config binary for machine MachineChoice.HOST not found. Giving up.
```
