### PR TITLE
BUGFIX: environment.py CudaCompiler and Intel-Cl

### DIFF
--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -32,7 +32,7 @@ from .mixins.pgi import PGICompiler
 from .. import mlog
 
 from mesonbuild.mesonlib import (
-    EnvironmentException, MachineChoice, is_osx, LibType
+    EnvironmentException, MachineChoice, LibType
 )
 
 if typing.TYPE_CHECKING:
@@ -296,7 +296,7 @@ class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross, target: str, info: 'MachineInfo', exe_wrapper=None,
                  **kwargs):
-        FortranCompiler.__init__(self, exelist, for_machine, version,
+        FortranCompiler.__init__(self, exelist, version, for_machine,
                                  is_cross, info, exe_wrapper, **kwargs)
         IntelVisualStudioLikeCompiler.__init__(self, target)
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -972,8 +972,8 @@ class Environment:
                 cls = IntelClCCompiler if lang == 'c' else IntelClCPPCompiler
                 linker = XilinkDynamicLinker(for_machine, version=version)
                 return cls(
-                    compiler, version, for_machine, is_cross, exe_wrap,
-                    target, info, linker=linker)
+                    compiler, version, for_machine, is_cross, info=info,
+                    exe_wrap=exe_wrap, target=target, linker=linker)
             if 'Microsoft' in out or 'Microsoft' in err:
                 # Latest versions of Visual Studio print version
                 # number to stderr but earlier ones print version

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1036,6 +1036,7 @@ class Environment:
         popen_exceptions = {}
         is_cross = not self.machines.matches_build_machine(for_machine)
         compilers, ccache, exe_wrap = self._get_compilers('cuda', for_machine)
+        info = self.machines[for_machine]
         for compiler in compilers:
             if isinstance(compiler, str):
                 compiler = [compiler]
@@ -1065,7 +1066,7 @@ class Environment:
             version = out.strip().split('V')[-1]
             cpp_compiler = self.detect_cpp_compiler(for_machine)
             linker = CudaLinker(compiler, for_machine, 'nvlink', CudaCompiler.LINKER_PREFIX, version=CudaLinker.parse_version())
-            return CudaCompiler(ccache + compiler, version, for_machine, is_cross, exe_wrap, host_compiler=cpp_compiler, linker=linker)
+            return CudaCompiler(ccache + compiler, version, for_machine, is_cross, exe_wrap, host_compiler=cpp_compiler, info=info, linker=linker)
         raise EnvironmentException('Could not find suitable CUDA compiler: "' + ' '.join(compilers) + '"')
 
     def detect_fortran_compiler(self, for_machine: MachineChoice):


### PR DESCRIPTION
fixes regression for systems with nvcc installed--perhaps why not previously caught on CI.
Just a simple typo--missing a positional argument to CudaCompiler()

0c22798b1ad4678abb205280060175678a790c4a is the first bad commit 

```sh
python run_project_tests.py
```

File "meson\mesonbuild\environment.py", line 1066, in detect_cuda_compiler
    return CudaCompiler(ccache + compiler, version, for_machine, is_cross, exe_wrap, host_compiler=cpp_compiler,
    linker=linker)
TypeError: __init__() missing 1 required positional argument: 'info'

## impacted configurations

* any system with Cuda / nvcc
* Intel-Cl