### PR TITLE
path interpreter--silently discard invalid Unix relative paths on Windows

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1557,6 +1557,10 @@ class CompilerHolder(InterpreterObject):
         search_dirs = mesonlib.stringlistify(kwargs.get('dirs', []))
         search_dirs = [Path(d).expanduser() for d in search_dirs]
         for d in search_dirs:
+            if mesonlib.is_windows() and d.root.startswith('\\'):
+                # a Unix-path starting with `/` that is not absolute on Windows.
+                # discard without failing for end-user ease of cross-platform directory arrays
+                continue
             if not d.is_absolute():
                 raise InvalidCode('Search directory {} is not an absolute path.'.format(d))
         search_dirs = list(map(str, search_dirs))


### PR DESCRIPTION
fixes #6000 due to #5768 

The idea is that end-users want to specify an array of directories to search by default
without an if/elif stack. It's obvious that Unix absolute paths are not absolute on
Windows, so silently discard Unix absolute paths here for Windows instead of raising
exception.

As noted in #6000 discussion, Python on Windows has the errant behavior 
```python
os.path.isabs('/') == True  # incorrect but perhaps legacy-maintaining logic for Windows
```
when it should be  on Windows:

```python
pathlib.Path('/').is_absolute() == False
```
