### PR TITLE
Workaround for expired SSL ceritificate

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -67,9 +67,12 @@ def open_wrapdburl(urlstring):
         ssl_warning_printed = True
     # Trying to open SSL connection to wrapdb fails because the
     # certificate is not known.
-    if urlstring.startswith('https'):
-        urlstring = 'http' + urlstring[5:]
-    return urllib.request.urlopen(urlstring, timeout=req_timeout)
+    # Use SSL context without checking certificate
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    return urllib.request.urlopen(urlstring, timeout=req_timeout, context=ctx)
 
 class WrapException(MesonException):
     pass


### PR DESCRIPTION
The SSL certificate for wrapdb.mesonbuild.com has expired, and because only HTTP is not allowed the fallback doesn't work.
My patch changes the fallback to a HTTPS request without checking the certificate.

May be not the safest way to do it, but not less safe than falling back to HTTP.