### PR TITLE
syntax-highlighting: vim: set comment string

### DIFF
--- a/data/syntax-highlighting/vim/ftplugin/meson.vim
+++ b/data/syntax-highlighting/vim/ftplugin/meson.vim
@@ -8,6 +8,9 @@ let b:did_ftplugin = 1
 let s:keepcpo= &cpo
 set cpo&vim
 
+setlocal commentstring=#\ %s
+setlocal comments=:#
+
 setlocal shiftwidth=2
 setlocal softtabstop=2
 


### PR DESCRIPTION
Vim can automatically comment and format comments. Set the necessary
variable to enable that feature.

See `:help format-comments` for more information.