### PR TITLE
Add some missing functions to BasicLinkerIsCompilerMixin

### DIFF
--- a/mesonbuild/compilers/mixins/islinker.py
+++ b/mesonbuild/compilers/mixins/islinker.py
@@ -53,6 +53,15 @@ class BasicLinkerIsCompilerMixin:
     def sanitizer_link_args(self, value: str) -> typing.List[str]:
         return []
 
+    def get_asneeded_args(self) -> typing.List[str]:
+        return []
+
+    def get_linker_debug_crt_args(self) -> typing.List[str]:
+        return []
+
+    def get_buildtype_linker_args(self, buildtype: str) -> typing.List[str]:
+        return []
+
     def get_lto_link_args(self) -> typing.List[str]:
         return []
 
@@ -86,6 +95,9 @@ class BasicLinkerIsCompilerMixin:
     def get_std_shared_module_args(self, options: 'OptionDictType') -> typing.List[str]:
         return self.get_std_shared_lib_link_args()
 
+    def get_std_shared_module_link_args(self, options: 'OptionDictType') -> typing.List[str]:
+        return self.get_std_shared_module_args(options)
+
     def get_link_whole_for(self, args: typing.List[str]) -> typing.List[str]:
         raise mesonlib.EnvironmentException(
             'Linker {} does not support link_whole'.format(self.id))
@@ -93,6 +105,9 @@ class BasicLinkerIsCompilerMixin:
     def get_allow_undefined_args(self) -> typing.List[str]:
         raise mesonlib.EnvironmentException(
             'Linker {} does not support allow undefined'.format(self.id))
+
+    def get_allow_undefined_link_args(self) -> typing.List[str]:
+        return self.get_allow_undefined_args()
 
     def get_pie_link_args(self) -> typing.List[str]:
         m = 'Linker {} does not support position-independent executable'


### PR DESCRIPTION
This PR adds some functions to `BasicLinkerIsCompilerMixin`. Without this meson crashes with the `EmscriptenCCompiler`. Here specifically the `get_asneeded_args` method was missing.

Since I bisected the crash to 06dcbd50eea47b3182081527ea1c0ada01d4d847, ping @dcbaker.

The traceback I get without this PR for a dummy wasm project I was setting up:
```
Traceback (most recent call last):
  File "/home/daniel/projects/meson/mesonbuild/mesonmain.py", line 129, in run
    return options.run_func(options)
  File "/home/daniel/projects/meson/mesonbuild/msetup.py", line 245, in run
    app.generate()
  File "/home/daniel/projects/meson/mesonbuild/msetup.py", line 159, in generate
    self._generate(env)
  File "/home/daniel/projects/meson/mesonbuild/msetup.py", line 215, in _generate
    intr.backend.generate(intr)
  File "/home/daniel/projects/meson/mesonbuild/backend/ninjabackend.py", line 314, in generate
    self.generate_target(t)
  File "/home/daniel/projects/meson/mesonbuild/backend/ninjabackend.py", line 632, in generate_target
    elem = self.generate_link(target, outname, obj_list, linker, pch_objects, stdlib_args=stdlib_args)
  File "/home/daniel/projects/meson/mesonbuild/backend/ninjabackend.py", line 2466, in generate_link
    isinstance(target, build.SharedModule))
  File "/home/daniel/projects/meson/mesonbuild/compilers/compilers.py", line 354, in get_base_link_args
    args.extend(linker.get_asneeded_args())
  File "/home/daniel/projects/meson/mesonbuild/compilers/compilers.py", line 1152, in get_asneeded_args
    return self.linker.get_asneeded_args()
AttributeError: 'NoneType' object has no attribute 'get_asneeded_args'
```