### PR TITLE
Fix emscripten C compiler initialization

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -133,11 +133,12 @@ class AppleClangCCompiler(ClangCCompiler):
 
 class EmscriptenCCompiler(LinkerEnvVarsMixin, BasicLinkerIsCompilerMixin, ClangCCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
-                 info: 'MachineInfo', is_cross, exe_wrapper=None, **kwargs):
+                 is_cross: bool, info: 'MachineInfo', exe_wrapper=None, **kwargs):
         if not is_cross:
             raise MesonException('Emscripten compiler can only be used for cross compilation.')
-        ClangCCompiler.__init__(self, exelist, version, for_machine,
-                                is_cross, info, exe_wrapper, **kwargs)
+        ClangCCompiler.__init__(self, exelist=exelist, version=version,
+                                for_machine=for_machine, is_cross=is_cross,
+                                info=info, exe_wrapper=exe_wrapper, **kwargs)
         self.id = 'emscripten'
 
     def get_option_link_args(self, options):

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -196,11 +196,12 @@ class AppleClangCPPCompiler(ClangCPPCompiler):
 
 class EmscriptenCPPCompiler(LinkerEnvVarsMixin, BasicLinkerIsCompilerMixin, ClangCPPCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
-                 is_cross, info: 'MachineInfo', exe_wrapper=None, **kwargs):
+                 is_cross: bool, info: 'MachineInfo', exe_wrapper=None, **kwargs):
         if not is_cross:
             raise MesonException('Emscripten compiler can only be used for cross compilation.')
-        ClangCPPCompiler.__init__(self, exelist, version, for_machine,
-                                  is_cross, info, exe_wrapper, **kwargs)
+        ClangCPPCompiler.__init__(self, exelist=exelist, version=version,
+                                  for_machine=for_machine, is_cross=is_cross,
+                                  info=info, exe_wrapper=exe_wrapper, **kwargs)
         self.id = 'emscripten'
 
     def get_option_compile_args(self, options):


### PR DESCRIPTION
Without the fix, this happens due to incorrect argument order:

```
Traceback (most recent call last):
  File "/data/git/meson/mesonbuild/mesonmain.py", line 129, in run
    return options.run_func(options)
  File "/data/git/meson/mesonbuild/msetup.py", line 245, in run
    app.generate()
  File "/data/git/meson/mesonbuild/msetup.py", line 159, in generate
    self._generate(env)
  File "/data/git/meson/mesonbuild/msetup.py", line 176, in _generate
    intr = interpreter.Interpreter(b)
  File "/data/git/meson/mesonbuild/interpreter.py", line 2110, in __init__
    self.parse_project()
  File "/data/git/meson/mesonbuild/interpreterbase.py", line 397, in parse_project
    self.evaluate_codeblock(self.ast, end=1)
  File "/data/git/meson/mesonbuild/interpreterbase.py", line 436, in evaluate_codeblock
    raise e
  File "/data/git/meson/mesonbuild/interpreterbase.py", line 430, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "/data/git/meson/mesonbuild/interpreterbase.py", line 441, in evaluate_statement
    return self.function_call(cur)
  File "/data/git/meson/mesonbuild/interpreterbase.py", line 776, in function_call
    return func(node, posargs, kwargs)
  File "/data/git/meson/mesonbuild/interpreterbase.py", line 143, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "/data/git/meson/mesonbuild/interpreterbase.py", line 174, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "/data/git/meson/mesonbuild/interpreter.py", line 2757, in func_project
    self.add_languages(proj_langs, True)
  File "/data/git/meson/mesonbuild/interpreter.py", line 2818, in add_languages
    success &= self.add_languages_for(args, required, MachineChoice.HOST)
  File "/data/git/meson/mesonbuild/interpreter.py", line 2833, in add_languages_for
    comp = self.environment.detect_compiler_for(lang, for_machine)
  File "/data/git/meson/mesonbuild/environment.py", line 1463, in detect_compiler_for
    comp = self.compiler_from_language(lang, for_machine)
  File "/data/git/meson/mesonbuild/environment.py", line 1435, in compiler_from_language
    comp = self.detect_c_compiler(for_machine)
  File "/data/git/meson/mesonbuild/environment.py", line 1030, in detect_c_compiler
    return self._detect_c_or_cpp_compiler('c', for_machine)
  File "/data/git/meson/mesonbuild/environment.py", line 905, in _detect_c_or_cpp_compiler
    exe_wrap, full_version=full_version)
  File "/data/git/meson/mesonbuild/compilers/c.py", line 140, in __init__
    is_cross, info, exe_wrapper, **kwargs)
  File "/data/git/meson/mesonbuild/compilers/c.py", line 87, in __init__
    ClangCompiler.__init__(self)
  File "/data/git/meson/mesonbuild/compilers/mixins/clang.py", line 38, in __init__
    super().__init__()
  File "/data/git/meson/mesonbuild/compilers/mixins/gnu.py", line 135, in __init__
    if not (self.info.is_windows() or self.info.is_cygwin() or self.info.is_openbsd()):
AttributeError: 'bool' object has no attribute 'is_windows'
```