### PR TITLE
Emscripten: fix false positives in linking tests

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -28,6 +28,7 @@ from .mixins.clang import ClangCompiler
 from .mixins.elbrus import ElbrusCompiler
 from .mixins.pgi import PGICompiler
 from .mixins.islinker import BasicLinkerIsCompilerMixin, LinkerEnvVarsMixin
+from .mixins.emscripten import EmscriptenMixin
 from .compilers import (
     gnu_winlibs,
     msvc_winlibs,
@@ -131,7 +132,7 @@ class AppleClangCCompiler(ClangCCompiler):
     _C18_VERSION = '>=11.0.0'
 
 
-class EmscriptenCCompiler(LinkerEnvVarsMixin, BasicLinkerIsCompilerMixin, ClangCCompiler):
+class EmscriptenCCompiler(LinkerEnvVarsMixin, EmscriptenMixin, BasicLinkerIsCompilerMixin, ClangCCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross: bool, info: 'MachineInfo', exe_wrapper=None, **kwargs):
         if not is_cross:
@@ -140,18 +141,6 @@ class EmscriptenCCompiler(LinkerEnvVarsMixin, BasicLinkerIsCompilerMixin, ClangC
                                 for_machine=for_machine, is_cross=is_cross,
                                 info=info, exe_wrapper=exe_wrapper, **kwargs)
         self.id = 'emscripten'
-
-    def get_option_link_args(self, options):
-        return []
-
-    def get_soname_args(self, *args, **kwargs):
-        raise MesonException('Emscripten does not support shared libraries.')
-
-    def get_allow_undefined_link_args(self) -> typing.List[str]:
-        return ['-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0']
-
-    def get_linker_output_args(self, output: str) -> typing.List[str]:
-        return ['-o', output]
 
 
 class ArmclangCCompiler(ArmclangCompiler, CCompiler):

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -37,6 +37,7 @@ from .mixins.clang import ClangCompiler
 from .mixins.elbrus import ElbrusCompiler
 from .mixins.pgi import PGICompiler
 from .mixins.islinker import BasicLinkerIsCompilerMixin, LinkerEnvVarsMixin
+from .mixins.emscripten import EmscriptenMixin
 
 if typing.TYPE_CHECKING:
     from ..envconfig import MachineInfo
@@ -194,7 +195,7 @@ class AppleClangCPPCompiler(ClangCPPCompiler):
     pass
 
 
-class EmscriptenCPPCompiler(LinkerEnvVarsMixin, BasicLinkerIsCompilerMixin, ClangCPPCompiler):
+class EmscriptenCPPCompiler(LinkerEnvVarsMixin, EmscriptenMixin, BasicLinkerIsCompilerMixin, ClangCPPCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross: bool, info: 'MachineInfo', exe_wrapper=None, **kwargs):
         if not is_cross:
@@ -210,18 +211,6 @@ class EmscriptenCPPCompiler(LinkerEnvVarsMixin, BasicLinkerIsCompilerMixin, Clan
         if std.value != 'none':
             args.append(self._find_best_cpp_std(std.value))
         return args
-
-    def get_option_link_args(self, options):
-        return []
-
-    def get_soname_args(self, *args, **kwargs):
-        raise MesonException('Emscripten does not support shared libraries.')
-
-    def get_allow_undefined_link_args(self) -> typing.List[str]:
-        return ['-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0']
-
-    def get_linker_output_args(self, output: str) -> typing.List[str]:
-        return ['-o', output]
 
 
 class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -1,0 +1,33 @@
+# Copyright 2019 The meson development team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Provides a mixin for shared code between C and C++ Emscripten compilers."""
+
+import os.path
+import typing
+
+from ...mesonlib import MesonException
+
+class EmscriptenMixin:
+    def get_option_link_args(self, options):
+        return []
+
+    def get_soname_args(self, *args, **kwargs):
+        raise MesonException('Emscripten does not support shared libraries.')
+
+    def get_allow_undefined_link_args(self) -> typing.List[str]:
+        return ['-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0']
+
+    def get_linker_output_args(self, output: str) -> typing.List[str]:
+        return ['-o', output]

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -31,3 +31,16 @@ class EmscriptenMixin:
 
     def get_linker_output_args(self, output: str) -> typing.List[str]:
         return ['-o', output]
+
+    def _get_compile_output(self, dirname, mode):
+        # In pre-processor mode, the output is sent to stdout and discarded
+        if mode == 'preprocess':
+            return None
+        # Unlike sane toolchains, emcc infers the kind of output from its name.
+        # This is the only reason why this method is overriden; compiler tests
+        # do not work well with the default exe/obj suffices.
+        if mode == 'link':
+            suffix = 'js'
+        else:
+            suffix = 'wasm'
+        return os.path.join(dirname, 'output.' + suffix)


### PR DESCRIPTION
The problem here is that emcc is sensitive to the output suffix, so Meson's assumption that `exe`/`obj` is always fine doesn't hold up. In the case of unknown suffix it just emits a wasm object without linking. This makes stuff like `cc.has_function` return `true` for pretty much everything.

I also took the opportunity to move some copypasted code into a mixin.

This PR is based on #6042, so that should go in first.