### PR TITLE
syntax-highlighting: vim: add license header

### DIFF
--- a/data/syntax-highlighting/vim/ftplugin/meson.vim
+++ b/data/syntax-highlighting/vim/ftplugin/meson.vim
@@ -1,5 +1,6 @@
 " Vim filetype plugin file
 " Language:	meson
+" License:	VIM License
 " Original Author:	Laurent Pinchart <laurent.pinchart@ideasonboard.com>
 " Last Change:		2018 Nov 27
 

--- a/data/syntax-highlighting/vim/indent/meson.vim
+++ b/data/syntax-highlighting/vim/indent/meson.vim
@@ -1,5 +1,6 @@
 " Vim indent file
 " Language:		Meson
+" License:		VIM License
 " Maintainer:		Nirbheek Chauhan <nirbheek.chauhan@gmail.com>
 " Original Authors:	David Bustos <bustos@caltech.edu>
 "			Bram Moolenaar <Bram@vim.org>

--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -1,5 +1,6 @@
 " Vim syntax file
 " Language:	Meson
+" License:	VIM License
 " Maintainer:	Nirbheek Chauhan <nirbheek.chauhan@gmail.com>
 " Last Change:	2016 Dec 7
 " Credits:	Zvezdan Petkovic <zpetkovic@acm.org>


### PR DESCRIPTION
Add a license header before getting them in the Vim runtime.