### PR TITLE
MPI: don't excessively skip Windows test cases, which can hide real problems

### DIFF
--- a/test cases/frameworks/17 mpi/main.cpp
+++ b/test cases/frameworks/17 mpi/main.cpp
@@ -1,4 +1,5 @@
 #include <mpi.h>
+#include <stdio.h>
 
 int main(int argc, char **argv)
 {

--- a/test cases/frameworks/17 mpi/meson.build
+++ b/test cases/frameworks/17 mpi/meson.build
@@ -1,11 +1,6 @@
 project('mpi', 'c', 'cpp', default_options: ['b_asneeded=false'])
 
 cc = meson.get_compiler('c')
-
-if build_machine.system() == 'windows' and cc.get_id() != 'msvc'
-  error('MESON_SKIP_TEST: MPI not available on Windows without MSVC.')
-endif
-
 mpic = dependency('mpi', language : 'c', required : false)
 if not mpic.found()
   error('MESON_SKIP_TEST: MPI not found, skipping.')
@@ -14,30 +9,40 @@ exec = executable('exec',
   'main.c',
   dependencies : [mpic])
 
-test('MPI C', exec)
+test('MPI C', exec, timeout: 10)
 
-if build_machine.system() != 'windows'
-  # C++ MPI not supported by MS-MPI
-  mpicpp = dependency('mpi', language : 'cpp')
-  execpp = executable('execpp',
-    'main.cpp',
-    dependencies : [mpicpp])
 
-  test('MPI C++', execpp)
+# C++ MPI not supported by MS-MPI
+cpp = meson.get_compiler('cpp')
+mpicpp = dependency('mpi', language : 'cpp', required: false)
+if not cpp.links('''
+#include <mpi.h>
+#include <stdio.h>
+int main(int argc, char **argv) {MPI::Init(argc, argv);}
+''', dependencies: mpicpp, name: 'C++ MPI')
+  mpicpp = disabler()
 endif
+execpp = executable('execpp',
+  'main.cpp',
+  dependencies : [mpicpp])
 
-# One of few feasible ways to use MPI for Fortran on Windows is via Intel compilers.
-if build_machine.system() != 'windows' or cc.get_id() == 'intel'
-  if add_languages('fortran', required : false)
-    mpifort = dependency('mpi', language : 'fortran')
+test('MPI C++', execpp, timeout: 10)
 
-    exef = executable('exef',
-    'main.f90',
-    dependencies : [mpifort])
 
-    test('MPI Fortran', exef)
+if add_languages('fortran', required : false)
+  fc = meson.get_compiler('fortran')
+  mpif = dependency('mpi', language : 'fortran', required: false)
+  if not fc.links('use mpi; end', dependencies: mpif, name: 'Fortran MPI')
+    mpif = disabler()
   endif
+
+  exef = executable('exef',
+  'main.f90',
+  dependencies : mpif)
+
+  test('MPI Fortran', exef, timeout: 10)
 endif
+
 
 # Check we can apply a version constraint
 if mpic.version() != 'unknown'


### PR DESCRIPTION
The MPI test logic was a bit excessive about skipping, especially for Windows as it was before Intel-Cl was supported in Meson.

Instead of *carte blanche* skipping most Windows tests, we check if MPI `links()`.