### PR TITLE
Pass options to linker detection

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -48,10 +48,11 @@ class CCompiler(CLikeCompiler, Compiler):
         except KeyError:
             raise MesonException('Unknown function attribute "{}"'.format(name))
 
+    language = 'c'
+
     def __init__(self, exelist, version, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: typing.Optional[str] = None, **kwargs):
         # If a child ObjC or CPP class has already set it, don't set it ourselves
-        self.language = 'c'
         Compiler.__init__(self, exelist, version, for_machine, info, **kwargs)
         CLikeCompiler.__init__(self, is_cross, exe_wrapper)
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -731,8 +731,9 @@ class Compiler:
     def get_language(self) -> str:
         return self.language
 
-    def get_display_language(self) -> str:
-        return self.language.capitalize()
+    @classmethod
+    def get_display_language(cls) -> str:
+        return cls.language.capitalize()
 
     def get_default_suffix(self) -> str:
         return self.default_suffix

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -681,6 +681,7 @@ class Compiler:
     internal_libs = ()
 
     LINKER_PREFIX = None  # type: typing.Union[None, str, typing.List[str]]
+    INVOKES_LINKER = True
 
     def __init__(self, exelist, version, for_machine: MachineChoice, info: 'MachineInfo',
                  linker: typing.Optional['DynamicLinker'] = None, **kwargs):
@@ -1175,7 +1176,8 @@ def get_args_from_envvars(lang: str, use_linker_args: bool) -> typing.Tuple[typi
     return compile_flags, link_flags
 
 
-def get_global_options(lang: str, properties: Properties) -> typing.Dict[str, coredata.UserOption]:
+def get_global_options(lang: str, comp: typing.Type[Compiler],
+                       properties: Properties) -> typing.Dict[str, coredata.UserOption]:
     """Retreive options that apply to all compilers for a given language."""
     description = 'Extra arguments passed to the {}'.format(lang)
     opts = {
@@ -1190,7 +1192,7 @@ def get_global_options(lang: str, properties: Properties) -> typing.Dict[str, co
     if properties.fallback:
         # Get from env vars.
         # XXX: True here is a hack
-        compile_args, link_args = get_args_from_envvars(lang, True)
+        compile_args, link_args = get_args_from_envvars(lang, comp.INVOKES_LINKER)
     else:
         compile_args = []
         link_args = []

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -59,10 +59,11 @@ class CPPCompiler(CLikeCompiler, Compiler):
         except KeyError:
             raise MesonException('Unknown function attribute "{}"'.format(name))
 
+    language = 'cpp'
+
     def __init__(self, exelist, version, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrap: typing.Optional[str] = None, **kwargs):
         # If a child ObjCPP class has already set it, don't set it ourselves
-        self.language = 'cpp'
         Compiler.__init__(self, exelist, version, for_machine, info, **kwargs)
         CLikeCompiler.__init__(self, is_cross, exe_wrap)
 

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -67,7 +67,8 @@ class CPPCompiler(CLikeCompiler, Compiler):
         Compiler.__init__(self, exelist, version, for_machine, info, **kwargs)
         CLikeCompiler.__init__(self, is_cross, exe_wrap)
 
-    def get_display_language(self):
+    @staticmethod
+    def get_display_language():
         return 'C++'
 
     def get_no_stdinc_args(self):

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -33,9 +33,11 @@ cs_optimization_args = {'0': [],
 
 
 class CsCompiler(BasicLinkerIsCompilerMixin, Compiler):
+
+    language = 'cs'
+
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  info: 'MachineInfo', comp_id, runner=None):
-        self.language = 'cs'
         super().__init__(exelist, version, for_machine, info)
         self.id = comp_id
         self.is_cross = False

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -43,7 +43,8 @@ class CsCompiler(BasicLinkerIsCompilerMixin, Compiler):
         self.is_cross = False
         self.runner = runner
 
-    def get_display_language(self):
+    @classmethod
+    def get_display_language(cls):
         return 'C sharp'
 
     def get_always_args(self):

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -30,13 +30,12 @@ if typing.TYPE_CHECKING:
 class CudaCompiler(Compiler):
 
     LINKER_PREFIX = '-Xlinker='
+    language = 'cuda'
 
     _universal_flags = {'compiler': ['-I', '-D', '-U', '-E'], 'linker': ['-l', '-L']}
 
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross, exe_wrapper, host_compiler, info: 'MachineInfo', **kwargs):
-        if not hasattr(self, 'language'):
-            self.language = 'cuda'
         super().__init__(exelist, version, for_machine, info, **kwargs)
         self.is_cross = is_cross
         self.exe_wrapper = exe_wrapper

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -61,9 +61,6 @@ class CudaCompiler(Compiler):
     def get_always_args(self):
         return []
 
-    def get_display_language(self):
-        return 'Cuda'
-
     def get_no_stdinc_args(self):
         return []
 

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -412,9 +412,10 @@ class DCompiler(Compiler):
         'mtd': ['-mscrtlib=libcmtd'],
     }
 
+    language = 'd'
+
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  info: 'MachineInfo', arch, is_cross, exe_wrapper, **kwargs):
-        self.language = 'd'
         super().__init__(exelist, version, for_machine, info, **kwargs)
         self.id = 'unknown'
         self.arch = arch

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -49,9 +49,6 @@ class FortranCompiler(CLikeCompiler, Compiler):
         CLikeCompiler.__init__(self, is_cross, exe_wrapper)
         self.id = 'unknown'
 
-    def get_display_language(self):
-        return 'Fortran'
-
     def has_function(self, funcname, prefix, env, *, extra_args=None, dependencies=None):
         raise MesonException('Fortran does not have "has_function" capability.\n'
                              'It is better to test if a Fortran capability is working like:\n\n'

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -41,9 +41,10 @@ if TYPE_CHECKING:
 
 class FortranCompiler(CLikeCompiler, Compiler):
 
+    language = 'fortran'
+
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross, info: 'MachineInfo', exe_wrapper=None, **kwargs):
-        self.language = 'fortran'
         Compiler.__init__(self, exelist, version, for_machine, info, **kwargs)
         CLikeCompiler.__init__(self, is_cross, exe_wrapper)
         self.id = 'unknown'

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -25,9 +25,11 @@ if typing.TYPE_CHECKING:
     from ..envconfig import MachineInfo
 
 class JavaCompiler(BasicLinkerIsCompilerMixin, Compiler):
+
+    language = 'java'
+
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  info: 'MachineInfo'):
-        self.language = 'java'
         super().__init__(exelist, version, for_machine, info)
         self.id = 'unknown'
         self.is_cross = False

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -111,6 +111,8 @@ class VisualStudioLikeCompiler(metaclass=abc.ABCMeta):
         '3': ['/W4'],
     }  # type: typing.Dict[str, typing.List[str]]
 
+    INVOKES_LINKER = False
+
     def __init__(self, target: str):
         self.base_options = ['b_pch', 'b_ndebug', 'b_vscrt'] # FIXME add lto, pgo and the like
         self.target = target

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -36,7 +36,8 @@ class ObjCCompiler(CLikeCompiler, Compiler):
         Compiler.__init__(self, exelist, version, for_machine, info, **kwargs)
         CLikeCompiler.__init__(self, is_cross, exe_wrap)
 
-    def get_display_language(self):
+    @staticmethod
+    def get_display_language():
         return 'Objective-C'
 
     def sanity_check(self, work_dir, environment):

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -27,10 +27,12 @@ if typing.TYPE_CHECKING:
 
 
 class ObjCCompiler(CLikeCompiler, Compiler):
+
+    language = 'objc'
+
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross: bool, info: 'MachineInfo',
                  exe_wrap: typing.Optional[str], **kwargs):
-        self.language = 'objc'
         Compiler.__init__(self, exelist, version, for_machine, info, **kwargs)
         CLikeCompiler.__init__(self, is_cross, exe_wrap)
 

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -35,7 +35,8 @@ class ObjCPPCompiler(CLikeCompiler, Compiler):
         Compiler.__init__(self, exelist, version, for_machine, info, **kwargs)
         CLikeCompiler.__init__(self, is_cross, exe_wrap)
 
-    def get_display_language(self):
+    @staticmethod
+    def get_display_language():
         return 'Objective-C++'
 
     def sanity_check(self, work_dir, environment):

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -26,10 +26,12 @@ if typing.TYPE_CHECKING:
     from ..envconfig import MachineInfo
 
 class ObjCPPCompiler(CLikeCompiler, Compiler):
+
+    language = 'objcpp'
+
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross: bool, info: 'MachineInfo',
                  exe_wrap: typing.Optional[str], **kwargs):
-        self.language = 'objcpp'
         Compiler.__init__(self, exelist, version, for_machine, info, **kwargs)
         CLikeCompiler.__init__(self, is_cross, exe_wrap)
 

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -33,10 +33,10 @@ rust_optimization_args = {'0': [],
 class RustCompiler(Compiler):
 
     # rustc doesn't invoke the compiler itself, it doesn't need a LINKER_PREFIX
+    language = 'rust'
 
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross, info: 'MachineInfo', exe_wrapper=None, **kwargs):
-        self.language = 'rust'
         super().__init__(exelist, version, for_machine, info, **kwargs)
         self.exe_wrapper = exe_wrapper
         self.id = 'rustc'

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -33,10 +33,10 @@ swift_optimization_args = {'0': [],
 class SwiftCompiler(Compiler):
 
     LINKER_PREFIX = ['-Xlinker']
+    language = 'swift'
 
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross, info: 'MachineInfo', **kwargs):
-        self.language = 'swift'
         super().__init__(exelist, version, for_machine, info, **kwargs)
         self.version = version
         self.id = 'llvm'

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -24,9 +24,11 @@ if typing.TYPE_CHECKING:
     from ..envconfig import MachineInfo
 
 class ValaCompiler(Compiler):
+
+    language = 'vala'
+
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross, info: 'MachineInfo'):
-        self.language = 'vala'
         super().__init__(exelist, version, for_machine, info)
         self.version = version
         self.is_cross = is_cross

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -35,7 +35,7 @@ import shlex
 
 if TYPE_CHECKING:
     from . import dependencies
-    from .compilers import Compiler
+    from .compilers import Compiler  # noqa: F401
     from .environment import Environment
 
     OptionDictType = Dict[str, 'UserOption[Any]']
@@ -744,12 +744,13 @@ class CoreData:
 
         self.set_options(options, subproject=subproject)
 
-    def add_lang_args(self, lang: str, for_machine: MachineChoice, env: 'Environment') -> None:
+    def add_lang_args(self, lang: str, comp: Type['Compiler'],
+                      for_machine: MachineChoice, env: 'Environment') -> None:
         """Add global language arguments that are needed before compiler/linker detection."""
         from .compilers import compilers
 
         optprefix = lang + '_'
-        for k, o in compilers.get_global_options(lang, env.properties[for_machine]).items():
+        for k, o in compilers.get_global_options(lang, comp, env.properties[for_machine]).items():
             if not k.startswith(optprefix):
                 raise MesonException('Internal error, %s has incorrect prefix.' % k)
             # prefixed compiler options affect just this machine

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -35,6 +35,8 @@ import shlex
 
 if TYPE_CHECKING:
     from . import dependencies
+    from .compilers import Compiler
+    from .environment import Environment
 
     OptionDictType = Dict[str, 'UserOption[Any]']
 
@@ -742,13 +744,28 @@ class CoreData:
 
         self.set_options(options, subproject=subproject)
 
-    def process_new_compiler(self, lang: str, comp, env):
+    def add_lang_args(self, lang: str, for_machine: MachineChoice, env: 'Environment') -> None:
+        """Add global language arguments that are needed before compiler/linker detection."""
+        from .compilers import compilers
+
+        optprefix = lang + '_'
+        for k, o in compilers.get_global_options(lang, env.properties[for_machine]).items():
+            if not k.startswith(optprefix):
+                raise MesonException('Internal error, %s has incorrect prefix.' % k)
+            # prefixed compiler options affect just this machine
+            opt_prefix = for_machine.get_prefix()
+            if opt_prefix + k in env.cmd_line_options:
+                o.set_value(env.cmd_line_options[opt_prefix + k])
+            self.compiler_options[for_machine].setdefault(k, o)
+
+    def process_new_compiler(self, lang: str, comp: Type['Compiler'], env: 'Environment') -> None:
         from . import compilers
 
         self.compilers[comp.for_machine][lang] = comp
+        enabled_opts = []
 
         optprefix = lang + '_'
-        for k, o in comp.get_and_default_options(env.properties[comp.for_machine]).items():
+        for k, o in comp.get_options().items():
             if not k.startswith(optprefix):
                 raise MesonException('Internal error, %s has incorrect prefix.' % k)
             # prefixed compiler options affect just this machine

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1538,6 +1538,7 @@ class Environment:
         return comp
 
     def detect_compiler_for(self, lang: str, for_machine: MachineChoice):
+        self.coredata.add_lang_args(lang, for_machine, self)
         comp = self.compiler_from_language(lang, for_machine)
         if comp is not None:
             assert comp.for_machine == for_machine

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -344,10 +344,6 @@ class DynamicLinker(metaclass=abc.ABCMeta):
         raise mesonlib.EnvironmentException(
             'Linker {} does not support allow undefined'.format(self.id))
 
-    def invoked_by_compiler(self) -> bool:
-        """True if meson uses the compiler to invoke the linker."""
-        return True
-
     @abc.abstractmethod
     def get_output_args(self, outname: str) -> typing.List[str]:
         pass
@@ -467,10 +463,6 @@ class GnuLikeDynamicLinkerMixin:
         if value == 'none':
             return []
         return ['-fsanitize=' + value]
-
-    def invoked_by_compiler(self) -> bool:
-        """True if meson uses the compiler to invoke the linker."""
-        return True
 
     def get_coverage_args(self) -> typing.List[str]:
         return ['--coverage']
@@ -787,7 +779,6 @@ class VisualStudioLikeLinkerMixin:
 
     def __init__(self, *args, direct: bool = True, machine: str = 'x86', **kwargs):
         super().__init__(*args, **kwargs)
-        self.direct = direct
         self.machine = machine
 
     def invoked_by_compiler(self) -> bool:


### PR DESCRIPTION
Here's a new version, built on top of #6207, because I need so much of the machinery to make this work anyway. It will have the same bugs as 6207 does for the moment but I have tested using both `-fuse-ld=gold` and `--target` with clang and that works.