### PR TITLE
Some fixes for Elbrus compiler

### DIFF
--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -42,9 +42,9 @@ class ElbrusCompiler(GnuCompiler):
         stdo = Popen_safe(self.exelist + ['--print-search-dirs'], env=os_env)[1]
         for line in stdo.split('\n'):
             if line.startswith('libraries:'):
-                # lcc does not include '=' in --print-search-dirs output.
+                # lcc does not include '=' in --print-search-dirs output. Also it could show nonexistent dirs.
                 libstr = line.split(' ', 1)[1]
-                return [os.path.realpath(p) for p in libstr.split(':')]
+                return [os.path.realpath(p) for p in libstr.split(':') if os.path.exists(p)]
         return []
 
     def get_program_dirs(self, env: 'Environment') -> typing.List[str]:

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -68,5 +68,5 @@ class ElbrusCompiler(GnuCompiler):
         includes = []
         for line in stderr.split('\n'):
             if line.lstrip().startswith('--sys_include'):
-                includes.append(re.sub('\s*\\\\$', '', re.sub('^\s*--sys_include\s*', '', line)))
+                includes.append(re.sub(r'\s*\\$', '', re.sub(r'^\s*--sys_include\s*', '', line)))
         return includes


### PR DESCRIPTION
Some new changes to keep Elbrus compiler support up to date (actually those of library and include file paths).

Unit tests are ok:
```reisen /usr/src/meson/meson # ./run_unittests.py
pytest-xdist not found, using unittest instead
........s...................s.......s...............................................................................s.....s........../usr/src/meson/meson/tmp3l8433aj/meson-private/sanitycheckobjc.m: file not recognized: Формат файла не распознан
/usr/src/meson/meson/tmp3l8433aj/meson-private/sanitycheckobjc.m: file not recognized: Формат файла не распознан
...ss.......s.s..sss............sss.......................................................s.....s........s..s..s..s........s........ssssssssssssssssss
----------------------------------------------------------------------
Ran 283 tests in 1224.390s

OK (skipped=40)
reisen /usr/src/meson/meson #```