### PR TITLE
xcode 64 bit for catalina

### DIFF
--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -634,7 +634,7 @@ class XCodeBackend(backends.Backend):
             self.write_line('isa = XCBuildConfiguration;')
             self.write_line('buildSettings = {')
             self.indent_level += 1
-            self.write_line('ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";')
+            self.write_line('ARCHS = "$(ARCHS_STANDARD_64_BIT)";')
             self.write_line('ONLY_ACTIVE_ARCH = YES;')
             self.write_line('SDKROOT = "macosx";')
             self.write_line('SYMROOT = "%s/build";' % self.environment.get_build_dir())


### PR DESCRIPTION
Fixes #6035 no 32-bit project warning in MacOS Catalina Xcode 11.1

Would like someone familiar with Xcode to verify nothing breaks by this slight change.