### PR TITLE
cmake: Blacklist more compiler warning flags

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -82,7 +82,8 @@ target_type_requires_trace = ['INTERFACE_LIBRARY']
 skip_targets = ['UTILITY']
 
 blacklist_compiler_flags = [
-    '/W1', '/W2', '/W3', '/W4', '/Wall',
+    '-Wall', '-Wextra', '-Weverything', '-Werror', '-Wpedantic', '-pedantic', '-w',
+    '/W1', '/W2', '/W3', '/W4', '/Wall', '/WX', '/w',
     '/O1', '/O2', '/Ob', '/Od', '/Og', '/Oi', '/Os', '/Ot', '/Ox', '/Oy', '/Ob0',
     '/RTC1', '/RTCc', '/RTCs', '/RTCu',
     '/Z7', '/Zi', '/ZI',

--- a/test cases/cmake/13 system includes/main.cpp
+++ b/test cases/cmake/13 system includes/main.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <cmMod.hpp>
+
+using namespace std;
+
+int main() {
+  cmModClass obj("Hello");
+  cout << obj.getStr() << endl;
+  return 0;
+}

--- a/test cases/cmake/13 system includes/meson.build
+++ b/test cases/cmake/13 system includes/meson.build
@@ -1,0 +1,14 @@
+project(
+  'meson_cmake_system_include_bug', ['c', 'cpp'],
+  default_options: [
+    'warning_level=3',
+    #'werror=true', # TODO implement system includes
+  ],
+)
+
+cm = import('cmake')
+sub_pro = cm.subproject('cmMod')
+sub_dep = sub_pro.dependency('cmModLib')
+
+exe1 = executable('main1', ['main.cpp'], dependencies: [sub_dep])
+test('test1', exe1)

--- a/test cases/cmake/13 system includes/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/13 system includes/subprojects/cmMod/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(cmMod)
+set (CMAKE_CXX_STANDARD 14)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+add_definitions("-DDO_NOTHING_JUST_A_FLAG=1")
+
+add_library(cmModLib SHARED cmMod.cpp)
+include(GenerateExportHeader)
+generate_export_header(cmModLib)
+
+target_compile_options(cmModLib PRIVATE "-Wall" "-Werror")
+target_include_directories(cmModLib SYSTEM PRIVATE "sysInc")

--- a/test cases/cmake/13 system includes/subprojects/cmMod/cmMod.cpp
+++ b/test cases/cmake/13 system includes/subprojects/cmMod/cmMod.cpp
@@ -1,0 +1,12 @@
+#include "cmMod.hpp"
+#include "triggerWarn.hpp"
+
+using namespace std;
+
+cmModClass::cmModClass(string foo) {
+  str = foo + " World " + to_string(bar(World));
+}
+
+string cmModClass::getStr() const {
+  return str;
+}

--- a/test cases/cmake/13 system includes/subprojects/cmMod/cmMod.hpp
+++ b/test cases/cmake/13 system includes/subprojects/cmMod/cmMod.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+#include "cmmodlib_export.h"
+
+class CMMODLIB_EXPORT cmModClass {
+  private:
+    std::string str;
+  public:
+    cmModClass(std::string foo);
+
+    std::string getStr() const;
+};

--- a/test cases/cmake/13 system includes/subprojects/cmMod/sysInc/triggerWarn.hpp
+++ b/test cases/cmake/13 system includes/subprojects/cmMod/sysInc/triggerWarn.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+enum Foo {
+    Hello,
+    World
+};
+
+inline int bar( Foo foo ) {
+  switch(foo) {
+    case Hello: return 0;
+    // Warn because of missung case for World
+  }
+  return 1;
+}


### PR DESCRIPTION
Meson should override all common warning flags from CMake and rely on the project-wide warning settings instead. This way projects that add `-Werror` in the `CMakeLists.txt` won't trigger hard to fix compilation errors (see #6079).

Note: This is not a proper fix for #6079, since it doesn't solve the underlying problem of handling the system include directories.