### PR TITLE
Disable extension module tests with Python 3.8 and VS2015.

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2497,6 +2497,8 @@ class AllPlatformTests(BasePlatformTests):
     def test_dist_git(self):
         if not shutil.which('git'):
             raise unittest.SkipTest('Git not found')
+        if self.backend is not Backend.ninja:
+            raise unittest.SkipTest('Dist is only supported with Ninja')
 
         try:
             self.dist_impl(_git_init)
@@ -2531,6 +2533,8 @@ class AllPlatformTests(BasePlatformTests):
     def test_dist_git_script(self):
         if not shutil.which('git'):
             raise unittest.SkipTest('Git not found')
+        if self.backend is not Backend.ninja:
+            raise unittest.SkipTest('Dist is only supported with Ninja')
 
         try:
             with tempfile.TemporaryDirectory() as tmpdir:

--- a/test cases/python/4 custom target depends extmodule/meson.build
+++ b/test cases/python/4 custom target depends extmodule/meson.build
@@ -6,6 +6,7 @@ project('Python extension module', 'c',
 py_mod = import('python')
 py3 = py_mod.find_installation()
 py3_dep = py3.dependency(required : false)
+cc = meson.get_compiler('c')
 
 # Copy to the builddir so that blaster.py can find the built tachyon module
 # FIXME: We should automatically detect this case and append the correct paths
@@ -20,6 +21,10 @@ with open(sys.argv[1], 'rb') as f:
   assert(f.read() == b'success')
 '''
 if py3_dep.found()
+  message('Detected Python version: ' + py3_dep.version())
+  if py3_dep.version().version_compare('>=3.8') and cc.get_id() == 'msvc' and cc.version().version_compare('<=19.00.24215.1')
+    error('MESON_SKIP_TEST: Python modules do not work with Python 3.8 and VS2015 or earlier.')
+  endif
   subdir('ext')
 
   out_txt = custom_target('tachyon flux',

--- a/test cases/python3/2 extmodule/meson.build
+++ b/test cases/python3/2 extmodule/meson.build
@@ -6,8 +6,17 @@ project('Python extension module', 'c',
 py3_mod = import('python3')
 py3 = py3_mod.find_python()
 py3_dep = dependency('python3', required : false)
+cc = meson.get_compiler('c')
 
 if py3_dep.found()
+  message('Detected Python version: ' + py3_dep.version())
+  # Building extensions for Python 3 using Visual Studio 2015
+  # no longer works (or, rather, they build but don't run).
+  # Disable the tests in this case.
+  if py3_dep.version().version_compare('>=3.8') and cc.get_id() == 'msvc' and cc.version().version_compare('<=19.00.24215.1')
+    error('MESON_SKIP_TEST: Python modules do not work with Python 3.8 and VS2015 or earlier.')
+  endif
+
   subdir('ext')
 
   test('extmod',

--- a/test cases/python3/4 custom target depends extmodule/meson.build
+++ b/test cases/python3/4 custom target depends extmodule/meson.build
@@ -6,6 +6,7 @@ project('Python extension module', 'c',
 py3_mod = import('python3')
 py3 = py3_mod.find_python()
 py3_dep = dependency('python3', required : false)
+cc = meson.get_compiler('c')
 
 # Copy to the builddir so that blaster.py can find the built tachyon module
 # FIXME: We should automatically detect this case and append the correct paths
@@ -20,6 +21,11 @@ with open(sys.argv[1], 'rb') as f:
   assert(f.read() == b'success')
 '''
 if py3_dep.found()
+  message('Detected Python version: ' + py3_dep.version())
+  if py3_dep.version().version_compare('>=3.8') and cc.get_id() == 'msvc' and cc.version().version_compare('<=19.00.24215.1')
+    error('MESON_SKIP_TEST: Python modules do not work with Python 3.8 and VS2015 or earlier.')
+  endif
+
   subdir('ext')
 
   out_txt = custom_target('tachyon flux',


### PR DESCRIPTION
I could not determine the cause or replicate it on my machine because VS2015 can't be obtained easily. :(