### PR TITLE
Fix for issue #4499, multiple entries per file in install-log.txt

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -324,7 +324,6 @@ class Installer:
                 # FIXME: what about symlinks?
                 self.do_copyfile(abs_src, abs_dst)
                 set_mode(abs_dst, install_mode, data.install_umask)
-                append_to_log(self.lf, abs_dst)
 
     def do_install(self, datafilename):
         with open(datafilename, 'rb') as ifile:


### PR DESCRIPTION
This patch fixes an issue with multiple entries per installed file in the install-log.txt file. Multiple entries are annoying when running the uninstall target since they causes error messages, see issue #4499.

(This is my first contribution to an open source project, so please be gentle ;-))