### PR TITLE
tests: add fortran-specific compiler checks

### DIFF
--- a/test cases/fortran/17 add_languages/meson.build
+++ b/test cases/fortran/17 add_languages/meson.build
@@ -1,0 +1,5 @@
+project('add_lang_fortran')
+
+# catch bug where Fortran compiler is found with project('foo', 'fortran') but
+# not by add_languages('fortran')
+assert(add_languages('fortran'), 'these tests assume Fortran compiler can be found')

--- a/test cases/fortran/18 first_arg/meson.build
+++ b/test cases/fortran/18 first_arg/meson.build
@@ -1,0 +1,26 @@
+project('fortran_args', 'fortran')
+
+fc = meson.get_compiler('fortran')
+
+if fc.get_id() == 'intel-cl'
+  is_arg = '/O2'
+  useless = '/DFOO'
+else
+  is_arg = '-O2'
+  useless = '-DFOO'
+endif
+
+isnt_arg = '-fiambroken'
+
+assert(fc.has_argument(is_arg), 'Arg that should have worked does not work.')
+assert(not fc.has_argument(isnt_arg), 'Arg that should be broken is not.')
+
+assert(fc.get_supported_arguments([is_arg, isnt_arg, useless]) == [is_arg, useless], 'Arg filtering returned different result.')
+
+# Have useless at the end to ensure that the search goes from front to back.
+l1 = fc.first_supported_argument([isnt_arg, is_arg, isnt_arg, useless])
+l2 = fc.first_supported_argument(isnt_arg, isnt_arg, isnt_arg)
+
+assert(l1.length() == 1, 'First supported returned wrong result.')
+assert(l1.get(0) == is_arg, 'First supported returned wrong argument.')
+assert(l2.length() == 0, 'First supported did not return empty array.')


### PR DESCRIPTION
Help ensure more of the core functional syntax of Meson is supported with a Fortran compiler.
For example, PGI is broken with regard to these tests.