### PR TITLE
Prefer ext static libs when --default-library=static

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -858,6 +858,9 @@ class CLikeCompiler:
         elif env.machines[self.for_machine].is_cygwin():
             shlibext = ['dll', 'dll.a']
             prefixes = ['cyg'] + prefixes
+        elif env.coredata.get_builtin_option('default_library') == 'static':
+            # Linux/BSDs
+            shlibext = ['a']
         else:
             # Linux/BSDs
             shlibext = ['so']


### PR DESCRIPTION
This patch adds a case in the library pattern logic to prefer static
libraries when the Meson Core option for "default_library" is set to
solely static.

The existing library search order makes sense for cases of shared and
shared / static mixed. However if using a prebuilt cross-toolchain,
they usually provide both a static and shared version of sysroot
libraries. This presents a problem in a complete static build where
there won't be shared libraries at runtime and during build time there
are failures like "ld: attempted static link of dynamic object".

Bug:
https://github.com/mesonbuild/meson/issues/6108

Signed-off-by: Matthew Weber <matthew.weber@rockwellcollins.com>