### PR TITLE
Minit templates modularization

### DIFF
--- a/docs/markdown/snippets/new_meson_project_templates.md
+++ b/docs/markdown/snippets/new_meson_project_templates.md
@@ -1,5 +1,5 @@
 ## Added new Meson templates for `Dlang`, `Rust`, `Objective-C`
 
 Meson now ships with predefined project templates for `Dlang`,
-`Rust`, `Objective-C`, and by passing the associated flags `d`,
-`rust`, `objc`, to `--language`.
+`Fortran`, `Rust`, `Objective-C`, and by passing the associated flags `d`,
+`fortran`, `rust`, `objc` to `meson init --language`.

--- a/docs/markdown/snippets/new_meson_project_templates.md
+++ b/docs/markdown/snippets/new_meson_project_templates.md
@@ -1,0 +1,5 @@
+## Added new Meson templates for `Dlang`, `Rust`, `Objective-C`
+
+Meson now ships with predefined project templates for `Dlang`,
+`Rust`, `Objective-C`, and by passing the associated flags `d`,
+`rust`, `objc`, to `--language`.

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -92,8 +92,9 @@ def autodetect_options(options, sample=False):
     if not options.srcfiles:
         srcfiles = []
         for f in os.listdir():
-            if f.endswith('.cc') or f.endswith('.cpp') or f.endswith('.c') \
-              or f.startswith('.d') or f.startswith('.rs'):
+            if f.endswith('.cc') or f.endswith('.cpp') or f.endswith('.c'):
+                srcfiles.append(f)
+            elif f.startswith('.d') or f.startswith('.rs'):
                 srcfiles.append(f)
         if not srcfiles:
             print("No recognizable source files found.\n"

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -23,6 +23,7 @@ from mesonbuild.templates.ctemplates import (create_exe_c_sample, create_lib_c_s
 from mesonbuild.templates.cpptemplates import (create_exe_cpp_sample, create_lib_cpp_sample)
 from mesonbuild.templates.objctemplates import (create_exe_objc_sample, create_lib_objc_sample)
 from mesonbuild.templates.dlangtemplates import (create_exe_d_sample, create_lib_d_sample)
+from mesonbuild.templates.fortrantemplates import (create_exe_fortran_sample, create_lib_fortran_sample)
 from mesonbuild.templates.rusttemplates import (create_exe_rust_sample, create_lib_rust_sample)
 
 
@@ -53,6 +54,13 @@ def create_sample(options):
             create_exe_d_sample(options.name, options.version)
         elif options.type == 'library':
             create_lib_d_sample(options.name, options.version)
+        else:
+            raise RuntimeError('Unreachable code')
+    elif options.language == 'fortran':
+        if options.type == 'executable':
+            create_exe_fortran_sample(options.name, options.version)
+        elif options.type == 'library':
+            create_lib_fortran_sample(options.name, options.version)
         else:
             raise RuntimeError('Unreachable code')
     elif options.language == 'rust':
@@ -95,6 +103,8 @@ def autodetect_options(options, sample=False):
             if f.endswith('.cc') or f.endswith('.cpp') or f.endswith('.c'):
                 srcfiles.append(f)
             elif f.startswith('.d') or f.startswith('.rs'):
+                srcfiles.append(f)
+            elif f in ('.f', '.for', '.F', '.f90', '.F90'):  # Fortran
                 srcfiles.append(f)
         if not srcfiles:
             print("No recognizable source files found.\n"
@@ -170,7 +180,7 @@ def add_arguments(parser):
     parser.add_argument("-n", "--name", help="project name. default: name of current directory")
     parser.add_argument("-e", "--executable", help="executable name. default: project name")
     parser.add_argument("-d", "--deps", help="dependencies, comma-separated")
-    parser.add_argument("-l", "--language", choices=['c', 'cpp', 'd', 'rust', 'objc'],
+    parser.add_argument("-l", "--language", choices=['c', 'cpp', 'd', 'fortran', 'rust', 'objc'],
                         help="project language. default: autodetected based on source files")
     parser.add_argument("-b", "--build", help="build after generation", action='store_true')
     parser.add_argument("--builddir", help="directory for build", default='build')

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -19,236 +19,12 @@ from glob import glob
 from mesonbuild import mesonlib
 from mesonbuild.environment import detect_ninja
 
-lib_h_template = '''#pragma once
-#if defined _WIN32 || defined __CYGWIN__
-  #ifdef BUILDING_{utoken}
-    #define {utoken}_PUBLIC __declspec(dllexport)
-  #else
-    #define {utoken}_PUBLIC __declspec(dllimport)
-  #endif
-#else
-  #ifdef BUILDING_{utoken}
-      #define {utoken}_PUBLIC __attribute__ ((visibility ("default")))
-  #else
-      #define {utoken}_PUBLIC
-  #endif
-#endif
+from mesonbuild.templates.ctemplates import (create_exe_c_sample, create_lib_c_sample)
+from mesonbuild.templates.cpptemplates import (create_exe_cpp_sample, create_lib_cpp_sample)
+from mesonbuild.templates.objctemplates import (create_exe_objc_sample, create_lib_objc_sample)
+from mesonbuild.templates.dlangtemplates import (create_exe_d_sample, create_lib_d_sample)
+from mesonbuild.templates.rusttemplates import (create_exe_rust_sample, create_lib_rust_sample)
 
-int {utoken}_PUBLIC {function_name}();
-
-'''
-
-lib_c_template = '''#include <{header_file}>
-
-/* This function will not be exported and is not
- * directly callable by users of this library.
- */
-int internal_function() {{
-    return 0;
-}}
-
-int {function_name}() {{
-    return internal_function();
-}}
-'''
-
-lib_c_test_template = '''#include <{header_file}>
-#include <stdio.h>
-
-int main(int argc, char **argv) {{
-    if(argc != 1) {{
-        printf("%s takes no arguments.\\n", argv[0]);
-        return 1;
-    }}
-    return {function_name}();
-}}
-'''
-
-lib_c_meson_template = '''project('{project_name}', 'c',
-  version : '{version}',
-  default_options : ['warning_level=3'])
-
-# These arguments are only used to build the shared library
-# not the executables that use the library.
-lib_args = ['-DBUILDING_{utoken}']
-
-shlib = shared_library('{lib_name}', '{source_file}',
-  install : true,
-  c_args : lib_args,
-  gnu_symbol_visibility : 'hidden',
-)
-
-test_exe = executable('{test_exe_name}', '{test_source_file}',
-  link_with : shlib)
-test('{test_name}', test_exe)
-
-# Make this library usable as a Meson subproject.
-{ltoken}_dep = declare_dependency(
-  include_directories: include_directories('.'),
-  link_with : shlib)
-
-# Make this library usable from the system's
-# package manager.
-install_headers('{header_file}', subdir : '{header_dir}')
-
-pkg_mod = import('pkgconfig')
-pkg_mod.generate(
-  name : '{project_name}',
-  filebase : '{ltoken}',
-  description : 'Meson sample project.',
-  subdirs : '{header_dir}',
-  libraries : shlib,
-  version : '{version}',
-)
-'''
-
-hello_c_template = '''#include <stdio.h>
-
-#define PROJECT_NAME "{project_name}"
-
-int main(int argc, char **argv) {{
-    if(argc != 1) {{
-        printf("%s takes no arguments.\\n", argv[0]);
-        return 1;
-    }}
-    printf("This is project %s.\\n", PROJECT_NAME);
-    return 0;
-}}
-'''
-
-hello_c_meson_template = '''project('{project_name}', 'c',
-  version : '{version}',
-  default_options : ['warning_level=3'])
-
-exe = executable('{exe_name}', '{source_name}',
-  install : true)
-
-test('basic', exe)
-'''
-
-hello_cpp_template = '''#include <iostream>
-
-#define PROJECT_NAME "{project_name}"
-
-int main(int argc, char **argv) {{
-    if(argc != 1) {{
-        std::cout << argv[0] <<  "takes no arguments.\\n";
-        return 1;
-    }}
-    std::cout << "This is project " << PROJECT_NAME << ".\\n";
-    return 0;
-}}
-'''
-
-hello_cpp_meson_template = '''project('{project_name}', 'cpp',
-  version : '{version}',
-  default_options : ['warning_level=3',
-                     'cpp_std=c++14'])
-
-exe = executable('{exe_name}', '{source_name}',
-  install : true)
-
-test('basic', exe)
-'''
-
-lib_hpp_template = '''#pragma once
-#if defined _WIN32 || defined __CYGWIN__
-  #ifdef BUILDING_{utoken}
-    #define {utoken}_PUBLIC __declspec(dllexport)
-  #else
-    #define {utoken}_PUBLIC __declspec(dllimport)
-  #endif
-#else
-  #ifdef BUILDING_{utoken}
-      #define {utoken}_PUBLIC __attribute__ ((visibility ("default")))
-  #else
-      #define {utoken}_PUBLIC
-  #endif
-#endif
-
-namespace {namespace} {{
-
-class {utoken}_PUBLIC {class_name} {{
-
-public:
-  {class_name}();
-  int get_number() const;
-
-private:
-
-  int number;
-
-}};
-
-}}
-
-'''
-
-lib_cpp_template = '''#include <{header_file}>
-
-namespace {namespace} {{
-
-{class_name}::{class_name}() {{
-    number = 6;
-}}
-
-int {class_name}::get_number() const {{
-  return number;
-}}
-
-}}
-'''
-
-lib_cpp_test_template = '''#include <{header_file}>
-#include <iostream>
-
-int main(int argc, char **argv) {{
-    if(argc != 1) {{
-        std::cout << argv[0] << " takes no arguments.\\n";
-        return 1;
-    }}
-    {namespace}::{class_name} c;
-    return c.get_number() != 6;
-}}
-'''
-
-lib_cpp_meson_template = '''project('{project_name}', 'cpp',
-  version : '{version}',
-  default_options : ['warning_level=3', 'cpp_std=c++14'])
-
-# These arguments are only used to build the shared library
-# not the executables that use the library.
-lib_args = ['-DBUILDING_{utoken}']
-
-shlib = shared_library('{lib_name}', '{source_file}',
-  install : true,
-  cpp_args : lib_args,
-  gnu_symbol_visibility : 'hidden',
-)
-
-test_exe = executable('{test_exe_name}', '{test_source_file}',
-  link_with : shlib)
-test('{test_name}', test_exe)
-
-# Make this library usable as a Meson subproject.
-{ltoken}_dep = declare_dependency(
-  include_directories: include_directories('.'),
-  link_with : shlib)
-
-# Make this library usable from the system's
-# package manager.
-install_headers('{header_file}', subdir : '{header_dir}')
-
-pkg_mod = import('pkgconfig')
-pkg_mod.generate(
-  name : '{project_name}',
-  filebase : '{ltoken}',
-  description : 'Meson sample project.',
-  subdirs : '{header_dir}',
-  libraries : shlib,
-  version : '{version}',
-)
-'''
 
 info_message = '''Sample project created. To build it run the
 following commands:
@@ -256,76 +32,6 @@ following commands:
 meson builddir
 ninja -C builddir
 '''
-
-def create_exe_c_sample(project_name, project_version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    source_name = lowercase_token + '.c'
-    open(source_name, 'w').write(hello_c_template.format(project_name=project_name))
-    open('meson.build', 'w').write(hello_c_meson_template.format(project_name=project_name,
-                                                                 exe_name=lowercase_token,
-                                                                 source_name=source_name,
-                                                                 version=project_version))
-
-def create_lib_c_sample(project_name, version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    uppercase_token = lowercase_token.upper()
-    function_name = lowercase_token[0:3] + '_func'
-    lib_h_name = lowercase_token + '.h'
-    lib_c_name = lowercase_token + '.c'
-    test_c_name = lowercase_token + '_test.c'
-    kwargs = {'utoken': uppercase_token,
-              'ltoken': lowercase_token,
-              'header_dir': lowercase_token,
-              'function_name': function_name,
-              'header_file': lib_h_name,
-              'source_file': lib_c_name,
-              'test_source_file': test_c_name,
-              'test_exe_name': lowercase_token,
-              'project_name': project_name,
-              'lib_name': lowercase_token,
-              'test_name': lowercase_token,
-              'version': version,
-              }
-    open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
-    open(lib_c_name, 'w').write(lib_c_template.format(**kwargs))
-    open(test_c_name, 'w').write(lib_c_test_template.format(**kwargs))
-    open('meson.build', 'w').write(lib_c_meson_template.format(**kwargs))
-
-def create_exe_cpp_sample(project_name, project_version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    source_name = lowercase_token + '.cpp'
-    open(source_name, 'w').write(hello_cpp_template.format(project_name=project_name))
-    open('meson.build', 'w').write(hello_cpp_meson_template.format(project_name=project_name,
-                                                                   exe_name=lowercase_token,
-                                                                   source_name=source_name,
-                                                                   version=project_version))
-
-def create_lib_cpp_sample(project_name, version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    uppercase_token = lowercase_token.upper()
-    class_name = uppercase_token[0] + lowercase_token[1:]
-    namespace = lowercase_token
-    lib_h_name = lowercase_token + '.hpp'
-    lib_c_name = lowercase_token + '.cpp'
-    test_c_name = lowercase_token + '_test.cpp'
-    kwargs = {'utoken': uppercase_token,
-              'ltoken': lowercase_token,
-              'header_dir': lowercase_token,
-              'class_name': class_name,
-              'namespace': namespace,
-              'header_file': lib_h_name,
-              'source_file': lib_c_name,
-              'test_source_file': test_c_name,
-              'test_exe_name': lowercase_token,
-              'project_name': project_name,
-              'lib_name': lowercase_token,
-              'test_name': lowercase_token,
-              'version': version,
-              }
-    open(lib_h_name, 'w').write(lib_hpp_template.format(**kwargs))
-    open(lib_c_name, 'w').write(lib_cpp_template.format(**kwargs))
-    open(test_c_name, 'w').write(lib_cpp_test_template.format(**kwargs))
-    open('meson.build', 'w').write(lib_cpp_meson_template.format(**kwargs))
 
 def create_sample(options):
     if options.language == 'c':
@@ -340,6 +46,27 @@ def create_sample(options):
             create_exe_cpp_sample(options.name, options.version)
         elif options.type == 'library':
             create_lib_cpp_sample(options.name, options.version)
+        else:
+            raise RuntimeError('Unreachable code')
+    elif options.language == 'd':
+        if options.type == 'executable':
+            create_exe_d_sample(options.name, options.version)
+        elif options.type == 'library':
+            create_lib_d_sample(options.name, options.version)
+        else:
+            raise RuntimeError('Unreachable code')
+    elif options.language == 'rust':
+        if options.type == 'executable':
+            create_exe_rust_sample(options.name, options.version)
+        elif options.type == 'library':
+            create_lib_rust_sample(options.name, options.version)
+        else:
+            raise RuntimeError('Unreachable code')
+    elif options.language == 'objc':
+        if options.type == 'executable':
+            create_exe_objc_sample(options.name, options.version)
+        elif options.type == 'library':
+            create_lib_objc_sample(options.name, options.version)
         else:
             raise RuntimeError('Unreachable code')
     else:
@@ -365,7 +92,8 @@ def autodetect_options(options, sample=False):
     if not options.srcfiles:
         srcfiles = []
         for f in os.listdir():
-            if f.endswith('.cc') or f.endswith('.cpp') or f.endswith('.c'):
+            if f.endswith('.cc') or f.endswith('.cpp') or f.endswith('.c') \
+              or f.startswith('.d') or f.startswith('.rs'):
                 srcfiles.append(f)
         if not srcfiles:
             print("No recognizable source files found.\n"
@@ -381,10 +109,20 @@ def autodetect_options(options, sample=False):
             if f.endswith('.c'):
                 options.language = 'c'
                 break
+            if f.endswith('.d'):
+                options.language = 'd'
+                break
+            if f.endswith('.rs'):
+                options.language = 'rust'
+                break
+            if f.endswith('.m'):
+                options.language = 'objc'
+                break
         if not options.language:
             print("Can't autodetect language, please specify it with -l.")
             sys.exit(1)
         print("Detected language: " + options.language)
+
 
 meson_executable_template = '''project('{project_name}', '{language}',
   version : '{version}',
@@ -431,7 +169,7 @@ def add_arguments(parser):
     parser.add_argument("-n", "--name", help="project name. default: name of current directory")
     parser.add_argument("-e", "--executable", help="executable name. default: project name")
     parser.add_argument("-d", "--deps", help="dependencies, comma-separated")
-    parser.add_argument("-l", "--language", choices=['c', 'cpp'],
+    parser.add_argument("-l", "--language", choices=['c', 'cpp', 'd', 'rust', 'objc'],
                         help="project language. default: autodetected based on source files")
     parser.add_argument("-b", "--build", help="build after generation", action='store_true')
     parser.add_argument("--builddir", help="directory for build", default='build')

--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -144,9 +144,10 @@ def create_exe_cpp_sample(project_name, project_version):
     source_name = lowercase_token + '.cpp'
     open(source_name, 'w').write(hello_cpp_template.format(project_name=project_name))
     open('meson.build', 'w').write(hello_cpp_meson_template.format(project_name=project_name,
-                                                                   exe_name=lowercase_token,
-                                                                   source_name=source_name,
-                                                                   version=project_version))
+        exe_name=lowercase_token, 
+        source_name=source_name, 
+        version=project_version))
+
 
 def create_lib_cpp_sample(project_name, version):
     lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())

--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -1,0 +1,176 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+
+hello_cpp_template = '''#include <iostream>
+
+#define PROJECT_NAME "{project_name}"
+
+int main(int argc, char **argv) {{
+    if(argc != 1) {{
+        std::cout << argv[0] <<  "takes no arguments.\\n";
+        return 1;
+    }}
+    std::cout << "This is project " << PROJECT_NAME << ".\\n";
+    return 0;
+}}
+'''
+
+hello_cpp_meson_template = '''project('{project_name}', 'cpp',
+  version : '{version}',
+  default_options : ['warning_level=3',
+                     'cpp_std=c++14'])
+
+exe = executable('{exe_name}', '{source_name}',
+  install : true)
+
+test('basic', exe)
+'''
+
+lib_hpp_template = '''#pragma once
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef BUILDING_{utoken}
+    #define {utoken}_PUBLIC __declspec(dllexport)
+  #else
+    #define {utoken}_PUBLIC __declspec(dllimport)
+  #endif
+#else
+  #ifdef BUILDING_{utoken}
+      #define {utoken}_PUBLIC __attribute__ ((visibility ("default")))
+  #else
+      #define {utoken}_PUBLIC
+  #endif
+#endif
+
+namespace {namespace} {{
+
+class {utoken}_PUBLIC {class_name} {{
+
+public:
+  {class_name}();
+  int get_number() const;
+
+private:
+
+  int number;
+
+}};
+
+}}
+
+'''
+
+lib_cpp_template = '''#include <{header_file}>
+
+namespace {namespace} {{
+
+{class_name}::{class_name}() {{
+    number = 6;
+}}
+
+int {class_name}::get_number() const {{
+  return number;
+}}
+
+}}
+'''
+
+lib_cpp_test_template = '''#include <{header_file}>
+#include <iostream>
+
+int main(int argc, char **argv) {{
+    if(argc != 1) {{
+        std::cout << argv[0] << " takes no arguments.\\n";
+        return 1;
+    }}
+    {namespace}::{class_name} c;
+    return c.get_number() != 6;
+}}
+'''
+
+lib_cpp_meson_template = '''project('{project_name}', 'cpp',
+  version : '{version}',
+  default_options : ['warning_level=3', 'cpp_std=c++14'])
+
+# These arguments are only used to build the shared library
+# not the executables that use the library.
+lib_args = ['-DBUILDING_{utoken}']
+
+shlib = shared_library('{lib_name}', '{source_file}',
+  install : true,
+  cpp_args : lib_args,
+  gnu_symbol_visibility : 'hidden',
+)
+
+test_exe = executable('{test_exe_name}', '{test_source_file}',
+  link_with : shlib)
+test('{test_name}', test_exe)
+
+# Make this library usable as a Meson subproject.
+{ltoken}_dep = declare_dependency(
+  include_directories: include_directories('.'),
+  link_with : shlib)
+
+# Make this library usable from the system's
+# package manager.
+install_headers('{header_file}', subdir : '{header_dir}')
+
+pkg_mod = import('pkgconfig')
+pkg_mod.generate(
+  name : '{project_name}',
+  filebase : '{ltoken}',
+  description : 'Meson sample project.',
+  subdirs : '{header_dir}',
+  libraries : shlib,
+  version : '{version}',
+)
+'''
+
+
+def create_exe_cpp_sample(project_name, project_version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    source_name = lowercase_token + '.cpp'
+    open(source_name, 'w').write(hello_cpp_template.format(project_name=project_name))
+    open('meson.build', 'w').write(hello_cpp_meson_template.format(project_name=project_name,
+                                                                   exe_name=lowercase_token,
+                                                                   source_name=source_name,
+                                                                   version=project_version))
+
+def create_lib_cpp_sample(project_name, version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    uppercase_token = lowercase_token.upper()
+    class_name = uppercase_token[0] + lowercase_token[1:]
+    namespace = lowercase_token
+    lib_hpp_name = lowercase_token + '.hpp'
+    lib_cpp_name = lowercase_token + '.cpp'
+    test_cpp_name = lowercase_token + '_test.cpp'
+    kwargs = {'utoken': uppercase_token,
+              'ltoken': lowercase_token,
+              'header_dir': lowercase_token,
+              'class_name': class_name,
+              'namespace': namespace,
+              'header_file': lib_hpp_name,
+              'source_file': lib_cpp_name,
+              'test_source_file': test_cpp_name,
+              'test_exe_name': lowercase_token,
+              'project_name': project_name,
+              'lib_name': lowercase_token,
+              'test_name': lowercase_token,
+              'version': version,
+              }
+    open(lib_hpp_name, 'w').write(lib_hpp_template.format(**kwargs))
+    open(lib_cpp_name, 'w').write(lib_cpp_template.format(**kwargs))
+    open(test_cpp_name, 'w').write(lib_cpp_test_template.format(**kwargs))
+    open('meson.build', 'w').write(lib_cpp_meson_template.format(**kwargs))

--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -144,9 +144,9 @@ def create_exe_cpp_sample(project_name, project_version):
     source_name = lowercase_token + '.cpp'
     open(source_name, 'w').write(hello_cpp_template.format(project_name=project_name))
     open('meson.build', 'w').write(hello_cpp_meson_template.format(project_name=project_name,
-        exe_name=lowercase_token, 
-        source_name=source_name, 
-        version=project_version))
+                                                                   exe_name=lowercase_token,
+                                                                   source_name=source_name,
+                                                                   version=project_version))
 
 
 def create_lib_cpp_sample(project_name, version):

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -1,0 +1,156 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+
+lib_h_template = '''#pragma once
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef BUILDING_{utoken}
+    #define {utoken}_PUBLIC __declspec(dllexport)
+  #else
+    #define {utoken}_PUBLIC __declspec(dllimport)
+  #endif
+#else
+  #ifdef BUILDING_{utoken}
+      #define {utoken}_PUBLIC __attribute__ ((visibility ("default")))
+  #else
+      #define {utoken}_PUBLIC
+  #endif
+#endif
+
+int {utoken}_PUBLIC {function_name}();
+
+'''
+
+lib_c_template = '''#include <{header_file}>
+
+/* This function will not be exported and is not
+ * directly callable by users of this library.
+ */
+int internal_function() {{
+    return 0;
+}}
+
+int {function_name}() {{
+    return internal_function();
+}}
+'''
+
+lib_c_test_template = '''#include <{header_file}>
+#include <stdio.h>
+
+int main(int argc, char **argv) {{
+    if(argc != 1) {{
+        printf("%s takes no arguments.\\n", argv[0]);
+        return 1;
+    }}
+    return {function_name}();
+}}
+'''
+
+lib_c_meson_template = '''project('{project_name}', 'c',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+# These arguments are only used to build the shared library
+# not the executables that use the library.
+lib_args = ['-DBUILDING_{utoken}']
+
+shlib = shared_library('{lib_name}', '{source_file}',
+  install : true,
+  c_args : lib_args,
+  gnu_symbol_visibility : 'hidden',
+)
+
+test_exe = executable('{test_exe_name}', '{test_source_file}',
+  link_with : shlib)
+test('{test_name}', test_exe)
+
+# Make this library usable as a Meson subproject.
+{ltoken}_dep = declare_dependency(
+  include_directories: include_directories('.'),
+  link_with : shlib)
+
+# Make this library usable from the system's
+# package manager.
+install_headers('{header_file}', subdir : '{header_dir}')
+
+pkg_mod = import('pkgconfig')
+pkg_mod.generate(
+  name : '{project_name}',
+  filebase : '{ltoken}',
+  description : 'Meson sample project.',
+  subdirs : '{header_dir}',
+  libraries : shlib,
+  version : '{version}',
+)
+'''
+
+hello_c_template = '''#include <stdio.h>
+
+#define PROJECT_NAME "{project_name}"
+
+int main(int argc, char **argv) {{
+    if(argc != 1) {{
+        printf("%s takes no arguments.\\n", argv[0]);
+        return 1;
+    }}
+    printf("This is project %s.\\n", PROJECT_NAME);
+    return 0;
+}}
+'''
+
+hello_c_meson_template = '''project('{project_name}', 'c',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+exe = executable('{exe_name}', '{source_name}',
+  install : true)
+
+test('basic', exe)
+'''
+
+def create_exe_c_sample(project_name, project_version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    source_name = lowercase_token + '.c'
+    open(source_name, 'w').write(hello_c_template.format(project_name=project_name))
+    open('meson.build', 'w').write(hello_c_meson_template.format(project_name=project_name,
+                                                                 exe_name=lowercase_token,
+                                                                 source_name=source_name,
+                                                                 version=project_version))
+
+def create_lib_c_sample(project_name, version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    uppercase_token = lowercase_token.upper()
+    function_name = lowercase_token[0:3] + '_func'
+    lib_h_name = lowercase_token + '.h'
+    lib_c_name = lowercase_token + '.c'
+    test_c_name = lowercase_token + '_test.c'
+    kwargs = {'utoken': uppercase_token,
+              'ltoken': lowercase_token,
+              'header_dir': lowercase_token,
+              'function_name': function_name,
+              'header_file': lib_h_name,
+              'source_file': lib_c_name,
+              'test_source_file': test_c_name,
+              'test_exe_name': lowercase_token,
+              'project_name': project_name,
+              'lib_name': lowercase_token,
+              'test_name': lowercase_token,
+              'version': version,
+              }
+    open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
+    open(lib_c_name, 'w').write(lib_c_template.format(**kwargs))
+    open(test_c_name, 'w').write(lib_c_test_template.format(**kwargs))
+    open('meson.build', 'w').write(lib_c_meson_template.format(**kwargs))

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -126,9 +126,10 @@ def create_exe_c_sample(project_name, project_version):
     source_name = lowercase_token + '.c'
     open(source_name, 'w').write(hello_c_template.format(project_name=project_name))
     open('meson.build', 'w').write(hello_c_meson_template.format(project_name=project_name,
-                                                                 exe_name=lowercase_token,
-                                                                 source_name=source_name,
-                                                                 version=project_version))
+        exe_name=lowercase_token, 
+        source_name=source_name, 
+        version=project_version))                                                                 
+
 
 def create_lib_c_sample(project_name, version):
     lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -126,10 +126,9 @@ def create_exe_c_sample(project_name, project_version):
     source_name = lowercase_token + '.c'
     open(source_name, 'w').write(hello_c_template.format(project_name=project_name))
     open('meson.build', 'w').write(hello_c_meson_template.format(project_name=project_name,
-        exe_name=lowercase_token, 
-        source_name=source_name, 
-        version=project_version))                                                                 
-
+                                                                 exe_name=lowercase_token,
+                                                                 source_name=source_name,
+                                                                 version=project_version))
 
 def create_lib_c_sample(project_name, version):
     lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())

--- a/mesonbuild/templates/dlangtemplates.py
+++ b/mesonbuild/templates/dlangtemplates.py
@@ -30,7 +30,7 @@ int main(string[] args) {{
 '''
 
 hello_d_meson_template = '''project('{project_name}', 'd',
-    version : '{version}', 
+    version : '{version}',
     default_options: ['warning_level=3'])
 
 exe = executable('{exe_name}', '{source_name}',
@@ -102,9 +102,10 @@ def create_exe_d_sample(project_name, project_version):
     source_name = lowercase_token + '.d'
     open(source_name, 'w').write(hello_d_template.format(project_name=project_name))
     open('meson.build', 'w').write(hello_d_meson_template.format(project_name=project_name,
-                                                                 exe_name=lowercase_token,
-                                                                 source_name=source_name,
-                                                                 version=project_version))
+        exe_name=lowercase_token, 
+        source_name=source_name, 
+        version=project_version))
+
 
 def create_lib_d_sample(project_name, version):
     lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())

--- a/mesonbuild/templates/dlangtemplates.py
+++ b/mesonbuild/templates/dlangtemplates.py
@@ -102,9 +102,9 @@ def create_exe_d_sample(project_name, project_version):
     source_name = lowercase_token + '.d'
     open(source_name, 'w').write(hello_d_template.format(project_name=project_name))
     open('meson.build', 'w').write(hello_d_meson_template.format(project_name=project_name,
-        exe_name=lowercase_token, 
-        source_name=source_name, 
-        version=project_version))
+                                                                 exe_name=lowercase_token,
+                                                                 source_name=source_name,
+                                                                 version=project_version))
 
 
 def create_lib_d_sample(project_name, version):

--- a/mesonbuild/templates/dlangtemplates.py
+++ b/mesonbuild/templates/dlangtemplates.py
@@ -1,0 +1,131 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+
+hello_d_template = '''module main;
+import std.stdio;
+
+enum PROJECT_NAME = "{project_name}";
+
+int main(string[] args) {{
+    if (args.length != 1){{
+        writefln("%s takes no arguments.\\n", args[0]);
+        return 1;
+    }}
+    writefln("This is project %s.\\n", PROJECT_NAME);
+    return 0;
+}}
+'''
+
+hello_d_meson_template = '''project('{project_name}', 'd',
+    version : '{version}', 
+    default_options: ['warning_level=3'])
+
+exe = executable('{exe_name}', '{source_name}',
+  install : true)
+
+test('basic', exe)
+'''
+
+lib_d_template = '''module {module_file};
+
+/* This function will not be exported and is not
+ * directly callable by users of this library.
+ */
+int internal_function() {{
+    return 0;
+}}
+
+int {function_name}() {{
+    return internal_function();
+}}
+'''
+
+lib_d_test_template = '''module {module_file}_test;
+import std.stdio;
+import {module_file};
+
+
+int main(string[] args) {{
+    if (args.length != 1){{
+        writefln("%s takes no arguments.\\n", args[0]);
+        return 1;
+    }}
+    return {function_name}();
+}}
+'''
+
+lib_d_meson_template = '''project('{project_name}', 'd',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+stlib = static_library('{lib_name}', '{source_file}',
+  install : true,
+  gnu_symbol_visibility : 'hidden',
+)
+
+test_exe = executable('{test_exe_name}', '{test_source_file}',
+  link_with : stlib)
+test('{test_name}', test_exe)
+
+# Make this library usable as a Meson subproject.
+{ltoken}_dep = declare_dependency(
+  include_directories: include_directories('.'),
+  link_with : stlib)
+
+# Make this library usable from the Dlang
+# build system.
+dlang_mod = import('dlang')
+dlang_mod.generate_dub_file(meson.project_name().to_lower(), meson.source_root(),
+  name : meson.project_name(),
+  license: meson.project_license(),
+  sourceFiles : '{source_file}',
+  description : 'Meson sample project.',
+  version : '{version}',
+)
+'''
+
+def create_exe_d_sample(project_name, project_version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    source_name = lowercase_token + '.d'
+    open(source_name, 'w').write(hello_d_template.format(project_name=project_name))
+    open('meson.build', 'w').write(hello_d_meson_template.format(project_name=project_name,
+                                                                 exe_name=lowercase_token,
+                                                                 source_name=source_name,
+                                                                 version=project_version))
+
+def create_lib_d_sample(project_name, version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    uppercase_token = lowercase_token.upper()
+    function_name = lowercase_token[0:3] + '_func'
+    lib_m_name = lowercase_token
+    lib_d_name = lowercase_token + '.d'
+    test_d_name = lowercase_token + '_test.d'
+    kwargs = {'utoken': uppercase_token,
+              'ltoken': lowercase_token,
+              'header_dir': lowercase_token,
+              'function_name': function_name,
+              'module_file': lib_m_name,
+              'source_file': lib_d_name,
+              'test_source_file': test_d_name,
+              'test_exe_name': lowercase_token,
+              'project_name': project_name,
+              'lib_name': lowercase_token,
+              'test_name': lowercase_token,
+              'version': version,
+              }
+    open(lib_d_name, 'w').write(lib_d_template.format(**kwargs))
+    open(test_d_name, 'w').write(lib_d_test_template.format(**kwargs))
+    open('meson.build', 'w').write(lib_d_meson_template.format(**kwargs))

--- a/mesonbuild/templates/fortrantemplates.py
+++ b/mesonbuild/templates/fortrantemplates.py
@@ -1,0 +1,130 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+lib_fortran_template = '''
+! This procedure will not be exported and is not
+! directly callable by users of this library.
+
+module modfoo
+
+implicit none
+private
+public :: {function_name}
+
+contains
+
+integer function internal_function()
+    internal_function = 0
+end function internal_function
+
+integer function {function_name}()
+    {function_name} = internal_function()
+end function {function_name}
+
+end module modfoo
+'''
+
+lib_fortran_test_template = '''
+use modfoo
+
+print *,{function_name}()
+
+end program
+'''
+
+lib_fortran_meson_template = '''project('{project_name}', 'fortran',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+# These arguments are only used to build the shared library
+# not the executables that use the library.
+lib_args = ['-DBUILDING_{utoken}']
+
+shlib = shared_library('{lib_name}', '{source_file}',
+  install : true,
+  fortran_args : lib_args,
+  gnu_symbol_visibility : 'hidden',
+)
+
+test_exe = executable('{test_exe_name}', '{test_source_file}',
+  link_with : shlib)
+test('{test_name}', test_exe)
+
+# Make this library usable as a Meson subproject.
+{ltoken}_dep = declare_dependency(
+  include_directories: include_directories('.'),
+  link_with : shlib)
+
+pkg_mod = import('pkgconfig')
+pkg_mod.generate(
+  name : '{project_name}',
+  filebase : '{ltoken}',
+  description : 'Meson sample project.',
+  subdirs : '{header_dir}',
+  libraries : shlib,
+  version : '{version}',
+)
+'''
+
+hello_fortran_template = '''
+implicit none
+
+character(len=*), parameter :: PROJECT_NAME = "{project_name}"
+
+print *,"This is project ", PROJECT_NAME
+
+end program
+'''
+
+hello_fortran_meson_template = '''project('{project_name}', 'fortran',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+exe = executable('{exe_name}', '{source_name}',
+  install : true)
+
+test('basic', exe)
+'''
+
+def create_exe_fortran_sample(project_name, project_version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    source_name = lowercase_token + '.f90'
+    open(source_name, 'w').write(hello_fortran_template.format(project_name=project_name))
+    open('meson.build', 'w').write(hello_fortran_meson_template.format(project_name=project_name,
+                                                                       exe_name=lowercase_token,
+                                                                       source_name=source_name,
+                                                                       version=project_version))
+
+def create_lib_fortran_sample(project_name, version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    uppercase_token = lowercase_token.upper()
+    function_name = lowercase_token[0:3] + '_func'
+    lib_fortran_name = lowercase_token + '.f90'
+    test_fortran_name = lowercase_token + '_test.f90'
+    kwargs = {'utoken': uppercase_token,
+              'ltoken': lowercase_token,
+              'header_dir': lowercase_token,
+              'function_name': function_name,
+              'source_file': lib_fortran_name,
+              'test_source_file': test_fortran_name,
+              'test_exe_name': lowercase_token,
+              'project_name': project_name,
+              'lib_name': lowercase_token,
+              'test_name': lowercase_token,
+              'version': version,
+              }
+    open(lib_fortran_name, 'w').write(lib_fortran_template.format(**kwargs))
+    open(test_fortran_name, 'w').write(lib_fortran_test_template.format(**kwargs))
+    open('meson.build', 'w').write(lib_fortran_meson_template.format(**kwargs))

--- a/mesonbuild/templates/objctemplates.py
+++ b/mesonbuild/templates/objctemplates.py
@@ -1,0 +1,156 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+
+lib_h_template = '''#pragma once
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef BUILDING_{utoken}
+    #define {utoken}_PUBLIC __declspec(dllexport)
+  #else
+    #define {utoken}_PUBLIC __declspec(dllimport)
+  #endif
+#else
+  #ifdef BUILDING_{utoken}
+      #define {utoken}_PUBLIC __attribute__ ((visibility ("default")))
+  #else
+      #define {utoken}_PUBLIC
+  #endif
+#endif
+
+int {utoken}_PUBLIC {function_name}();
+
+'''
+
+lib_objc_template = '''#import <{header_file}>
+
+/* This function will not be exported and is not
+ * directly callable by users of this library.
+ */
+int internal_function() {{
+    return 0;
+}}
+
+int {function_name}() {{
+    return internal_function();
+}}
+'''
+
+lib_objc_test_template = '''#import <{header_file}>
+#import <stdio.h>
+
+int main(int argc, char **argv) {{
+    if(argc != 1) {{
+        printf("%s takes no arguments.\\n", argv[0]);
+        return 1;
+    }}
+    return {function_name}();
+}}
+'''
+
+lib_objc_meson_template = '''project('{project_name}', 'objc',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+# These arguments are only used to build the shared library
+# not the executables that use the library.
+lib_args = ['-DBUILDING_{utoken}']
+
+shlib = shared_library('{lib_name}', '{source_file}',
+  install : true,
+  objc_args : lib_args,
+  gnu_symbol_visibility : 'hidden',
+)
+
+test_exe = executable('{test_exe_name}', '{test_source_file}',
+  link_with : shlib)
+test('{test_name}', test_exe)
+
+# Make this library usable as a Meson subproject.
+{ltoken}_dep = declare_dependency(
+  include_directories: include_directories('.'),
+  link_with : shlib)
+
+# Make this library usable from the system's
+# package manager.
+install_headers('{header_file}', subdir : '{header_dir}')
+
+pkg_mod = import('pkgconfig')
+pkg_mod.generate(
+  name : '{project_name}',
+  filebase : '{ltoken}',
+  description : 'Meson sample project.',
+  subdirs : '{header_dir}',
+  libraries : shlib,
+  version : '{version}',
+)
+'''
+
+hello_objc_template = '''#import <stdio.h>
+
+#define PROJECT_NAME "{project_name}"
+
+int main(int argc, char **argv) {{
+    if(argc != 1) {{
+        printf("%s takes no arguments.\\n", argv[0]);
+        return 1;
+    }}
+    printf("This is project %s.\\n", PROJECT_NAME);
+    return 0;
+}}
+'''
+
+hello_objc_meson_template = '''project('{project_name}', 'objc',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+exe = executable('{exe_name}', '{source_name}',
+  install : true)
+
+test('basic', exe)
+'''
+
+def create_exe_objc_sample(project_name, project_version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    source_name = lowercase_token + '.m'
+    open(source_name, 'w').write(hello_objc_template.format(project_name=project_name))
+    open('meson.build', 'w').write(hello_objc_meson_template.format(project_name=project_name,
+                                                                 exe_name=lowercase_token,
+                                                                 source_name=source_name,
+                                                                 version=project_version))
+
+def create_lib_objc_sample(project_name, version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    uppercase_token = lowercase_token.upper()
+    function_name = lowercase_token[0:3] + '_func'
+    lib_h_name = lowercase_token + '.h'
+    lib_objc_name = lowercase_token + '.m'
+    test_objc_name = lowercase_token + '_test.m'
+    kwargs = {'utoken': uppercase_token,
+              'ltoken': lowercase_token,
+              'header_dir': lowercase_token,
+              'function_name': function_name,
+              'header_file': lib_h_name,
+              'source_file': lib_objc_name,
+              'test_source_file': test_objc_name,
+              'test_exe_name': lowercase_token,
+              'project_name': project_name,
+              'lib_name': lowercase_token,
+              'test_name': lowercase_token,
+              'version': version,
+              }
+    open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
+    open(lib_objc_name, 'w').write(lib_objc_template.format(**kwargs))
+    open(test_objc_name, 'w').write(lib_objc_test_template.format(**kwargs))
+    open('meson.build', 'w').write(lib_objc_meson_template.format(**kwargs))

--- a/mesonbuild/templates/objctemplates.py
+++ b/mesonbuild/templates/objctemplates.py
@@ -126,9 +126,7 @@ def create_exe_objc_sample(project_name, project_version):
     source_name = lowercase_token + '.m'
     open(source_name, 'w').write(hello_objc_template.format(project_name=project_name))
     open('meson.build', 'w').write(hello_objc_meson_template.format(project_name=project_name,
-                                                                 exe_name=lowercase_token,
-                                                                 source_name=source_name,
-                                                                 version=project_version))
+        exe_name=lowercase_token, source_name=source_name, version=project_version))
 
 def create_lib_objc_sample(project_name, version):
     lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())

--- a/mesonbuild/templates/objctemplates.py
+++ b/mesonbuild/templates/objctemplates.py
@@ -126,7 +126,9 @@ def create_exe_objc_sample(project_name, project_version):
     source_name = lowercase_token + '.m'
     open(source_name, 'w').write(hello_objc_template.format(project_name=project_name))
     open('meson.build', 'w').write(hello_objc_meson_template.format(project_name=project_name,
-        exe_name=lowercase_token, source_name=source_name, version=project_version))
+                                                                    exe_name=lowercase_token,
+                                                                    source_name=source_name,
+                                                                    version=project_version))
 
 def create_lib_objc_sample(project_name, version):
     lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())

--- a/mesonbuild/templates/rusttemplates.py
+++ b/mesonbuild/templates/rusttemplates.py
@@ -74,9 +74,7 @@ def create_exe_rust_sample(project_name, project_version):
     source_name = lowercase_token + '.rs'
     open(source_name, 'w').write(hello_rust_template.format(project_name=project_name))
     open('meson.build', 'w').write(hello_rust_meson_template.format(project_name=project_name,
-                                                                 exe_name=lowercase_token,
-                                                                 source_name=source_name,
-                                                                 version=project_version))
+        exe_name=lowercase_token, source_name=source_name, version=project_version))
 
 
 def create_lib_rust_sample(project_name, version):

--- a/mesonbuild/templates/rusttemplates.py
+++ b/mesonbuild/templates/rusttemplates.py
@@ -74,8 +74,9 @@ def create_exe_rust_sample(project_name, project_version):
     source_name = lowercase_token + '.rs'
     open(source_name, 'w').write(hello_rust_template.format(project_name=project_name))
     open('meson.build', 'w').write(hello_rust_meson_template.format(project_name=project_name,
-        exe_name=lowercase_token, source_name=source_name, version=project_version))
-
+                                                                    exe_name=lowercase_token,
+                                                                    source_name=source_name,
+                                                                    version=project_version))
 
 def create_lib_rust_sample(project_name, version):
     lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())

--- a/mesonbuild/templates/rusttemplates.py
+++ b/mesonbuild/templates/rusttemplates.py
@@ -1,0 +1,104 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+
+lib_rust_template = '''#![crate_name = "{crate_file}"]
+
+/* This function will not be exported and is not
+ * directly callable by users of this library.
+ */
+fn internal_function() -> i32 {{
+    return 0;
+}}
+
+pub fn {function_name}() -> i32 {{
+    return internal_function();
+}}
+'''
+
+lib_rust_test_template = '''extern crate {crate_file};
+
+fn main() {{
+    println!("printing: {{}}", {crate_file}::{function_name}());
+}}
+'''
+
+
+lib_rust_meson_template = '''project('{project_name}', 'rust',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+shlib = static_library('{lib_name}', '{source_file}', install : true)
+
+test_exe = executable('{test_exe_name}', '{test_source_file}',
+  link_with : shlib)
+test('{test_name}', test_exe)
+
+# Make this library usable as a Meson subproject.
+{ltoken}_dep = declare_dependency(
+  include_directories: include_directories('.'),
+  link_with : shlib)
+'''
+
+hello_rust_template = '''
+fn main() {{
+    let project_name = "{project_name}";
+    println!("This is project {{}}.\\n", project_name);
+}}
+'''
+
+hello_rust_meson_template = '''project('{project_name}', 'rust',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+exe = executable('{exe_name}', '{source_name}',
+  install : true)
+
+test('basic', exe)
+'''
+
+def create_exe_rust_sample(project_name, project_version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    source_name = lowercase_token + '.rs'
+    open(source_name, 'w').write(hello_rust_template.format(project_name=project_name))
+    open('meson.build', 'w').write(hello_rust_meson_template.format(project_name=project_name,
+                                                                 exe_name=lowercase_token,
+                                                                 source_name=source_name,
+                                                                 version=project_version))
+
+
+def create_lib_rust_sample(project_name, version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    uppercase_token = lowercase_token.upper()
+    function_name = lowercase_token[0:3] + '_func'
+    lib_crate_name = lowercase_token
+    lib_rs_name = lowercase_token + '.rs'
+    test_rs_name = lowercase_token + '_test.rs'
+    kwargs = {'utoken': uppercase_token,
+              'ltoken': lowercase_token,
+              'header_dir': lowercase_token,
+              'function_name': function_name,
+              'crate_file': lib_crate_name,
+              'source_file': lib_rs_name,
+              'test_source_file': test_rs_name,
+              'test_exe_name': lowercase_token,
+              'project_name': project_name,
+              'lib_name': lowercase_token,
+              'test_name': lowercase_token,
+              'version': version,
+              }
+    open(lib_rs_name, 'w').write(lib_rust_template.format(**kwargs))
+    open(test_rs_name, 'w').write(lib_rust_test_template.format(**kwargs))
+    open('meson.build', 'w').write(lib_rust_meson_template.format(**kwargs))

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3031,11 +3031,7 @@ int main(int argc, char **argv) {
             langs.append('objc')
         except EnvironmentException:
             pass
-        try:
-            env.detect_rust_compiler(MachineChoice.HOST)
-            langs.append('rust')
-        except EnvironmentException:
-            pass
+        # FIXME: omitting rust as Windows AppVeyor CI finds Rust but doesn't link correctly
 
         for lang in langs:
             for target_type in ('executable', 'library'):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3009,7 +3009,7 @@ int main(int argc, char **argv) {
         ninja = detect_ninja()
         if ninja is None:
             raise unittest.SkipTest('This test currently requires ninja. Fix this once "meson build" works.')
-        for lang in ('c', 'cpp'):
+        for lang in ('c', 'cpp', 'd', 'rust', 'objc'):
             for target_type in ('executable', 'library'):
                 with tempfile.TemporaryDirectory() as tmpdir:
                     self._run(self.meson_command + ['init', '--language', lang, '--type', target_type],

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3009,8 +3009,37 @@ int main(int argc, char **argv) {
         ninja = detect_ninja()
         if ninja is None:
             raise unittest.SkipTest('This test currently requires ninja. Fix this once "meson build" works.')
-        for lang in ('c', 'cpp', 'd', 'rust', 'objc'):
+        langs = ['c']
+        env = get_fake_env()
+        try:
+            env.detect_cpp_compiler(MachineChoice.HOST)
+            langs.append('cpp')
+        except EnvironmentException:
+            pass
+        try:
+            env.detect_d_compiler(MachineChoice.HOST)
+            langs.append('d')
+        except EnvironmentException:
+            pass
+        try:
+            env.detect_fortran_compiler(MachineChoice.HOST)
+            langs.append('fortran')
+        except EnvironmentException:
+            pass
+        try:
+            env.detect_objc_compiler(MachineChoice.HOST)
+            langs.append('objc')
+        except EnvironmentException:
+            pass
+        try:
+            env.detect_rust_compiler(MachineChoice.HOST)
+            langs.append('rust')
+        except EnvironmentException:
+            pass
+
+        for lang in langs:
             for target_type in ('executable', 'library'):
+                # test empty directory
                 with tempfile.TemporaryDirectory() as tmpdir:
                     self._run(self.meson_command + ['init', '--language', lang, '--type', target_type],
                               workdir=tmpdir)
@@ -3018,10 +3047,12 @@ int main(int argc, char **argv) {
                               workdir=tmpdir)
                     self._run(ninja,
                               workdir=os.path.join(tmpdir, 'builddir'))
-            with tempfile.TemporaryDirectory() as tmpdir:
-                with open(os.path.join(tmpdir, 'foo.' + lang), 'w') as f:
-                    f.write('int main() {}')
-                self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
+            # test directory with existing code file
+            if lang in ('c', 'cpp'):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    with open(os.path.join(tmpdir, 'foo.' + lang), 'w') as f:
+                        f.write('int main() {}')
+                    self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
 
     # The test uses mocking and thus requires that
     # the current process is the one to run the Meson steps.

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ packages = ['mesonbuild',
             'mesonbuild.dependencies',
             'mesonbuild.modules',
             'mesonbuild.scripts',
+            'mesonbuild.templates',
             'mesonbuild.wrap']
 package_data = {
     'mesonbuild.dependencies': ['data/CMakeLists.txt', 'data/CMakeListsLLVM.txt', 'data/CMakePathInfo.txt'],


### PR DESCRIPTION
built upon #6112 

Modularized internal implementation of `meson init` and adds Rust, Fortran, D, etc. and makes it easier to add more languages for templates

Modernizes the Python 2 style to Python3 in minit.py