### PR TITLE
bugfix: fortran compiler assertionerror from 0c22798

### DIFF
--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -317,7 +317,7 @@ class PathScaleFortranCompiler(FortranCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross, info: 'MachineInfo', exe_wrapper=None,
                  **kwargs):
-        FortranCompiler.__init__(self, exelist, for_machine, version,
+        FortranCompiler.__init__(self, exelist, version, for_machine,
                                  is_cross, info, exe_wrapper, **kwargs)
         self.id = 'pathscale'
         default_warn_args = ['-fullwarn']
@@ -334,7 +334,7 @@ class PGIFortranCompiler(PGICompiler, FortranCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross, info: 'MachineInfo', exe_wrapper=None,
                  **kwargs):
-        FortranCompiler.__init__(self, exelist, for_machine, version,
+        FortranCompiler.__init__(self, exelist, version, for_machine,
                                  is_cross, info, exe_wrapper, **kwargs)
         PGICompiler.__init__(self)
 
@@ -346,7 +346,7 @@ class FlangFortranCompiler(ClangCompiler, FortranCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross, info: 'MachineInfo', exe_wrapper=None,
                  **kwargs):
-        FortranCompiler.__init__(self, exelist, for_machine, version,
+        FortranCompiler.__init__(self, exelist, version, for_machine,
                                  is_cross, info, exe_wrapper, **kwargs)
         ClangCompiler.__init__(self)
         self.id = 'flang'
@@ -363,7 +363,7 @@ class Open64FortranCompiler(FortranCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross, info: 'MachineInfo', exe_wrapper=None,
                  **kwargs):
-        FortranCompiler.__init__(self, exelist, for_machine, version,
+        FortranCompiler.__init__(self, exelist, version, for_machine,
                                  is_cross, info, exe_wrapper, **kwargs)
         self.id = 'open64'
         default_warn_args = ['-fullwarn']
@@ -380,7 +380,7 @@ class NAGFortranCompiler(FortranCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross, info: 'MachineInfo', exe_wrapper=None,
                  **kwargs):
-        FortranCompiler.__init__(self, exelist, for_machine, version,
+        FortranCompiler.__init__(self, exelist, version, for_machine,
                                  is_cross, info, exe_wrapper, **kwargs)
         self.id = 'nagfor'
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1504,7 +1504,7 @@ class Environment:
                 # Intel has it's own linker that acts like microsoft's lib
                 linkers = ['xilib']
             elif isinstance(compiler, (PGICCompiler, PGIFortranCompiler)) and mesonlib.is_windows():
-                linkers = [self.default_static_linker]  # this is just a wrapper calling link/lib on Windows, keeping things simple.
+                linkers = [['ar']]  # For PGI on Windows, "ar" is just a wrapper calling link/lib.
             else:
                 linkers = defaults
         popen_exceptions = {}

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1151,8 +1151,7 @@ class Environment:
                         compiler, for_machine, 'pgi',
                         PGIFortranCompiler.LINKER_PREFIX, version=version)
                     return PGIFortranCompiler(
-                        compiler, version, for_machine, is_cross,
-                        self.machines[for_machine], exe_wrap,
+                        compiler, version, for_machine, is_cross, info, exe_wrap,
                         full_version=full_version, linker=linker)
 
                 if 'flang' in out or 'clang' in out:


### PR DESCRIPTION
fixes several fortran compilers:

* PathScale
* PGI
* Flang
* Open64
* NAG

broke in commit 0c22798