### PR TITLE
Fix split of CMAKE_PREFIX_PATH under Windows

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1114,8 +1114,8 @@ class CMakeDependency(ExternalDependency):
 
         pref_path = self.env.coredata.builtins_per_machine[self.for_machine]['cmake_prefix_path'].value
         if 'CMAKE_PREFIX_PATH' in os.environ:
-            env_pref_path = os.environ['CMAKE_PREFIX_PATH'].split(':')
-            env_pref_path = [x for x in env_pref_path if x]  # Filter out enpty strings
+            env_pref_path = os.environ['CMAKE_PREFIX_PATH'].split(os.pathsep)
+            env_pref_path = [x for x in env_pref_path if x]  # Filter out empty strings
             if not pref_path:
                 pref_path = []
             pref_path += env_pref_path


### PR DESCRIPTION
Under Windows, the colon ':' is used after the drive letter.
So, the colon should not be used as a list separator or for splitting,
otherwise it could lead to paths in `CMAKE_PREFIX_PATH` with a
semicolon ';' between the drive letter and the rest of the path, e.g:
`-DCMAKE_PREFIX_PATH=C;/foo/bar`
instead of
`-DCMAKE_PREFIX_PATH=C:/foo/bar`
