### PR TITLE
Store run target names in build.

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2648,6 +2648,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def generate_scanbuild(self):
         if not environment.detect_scanbuild():
             return
+        if ('', 'scan-build') in self.build.run_target_names:
+            return
         cmd = self.environment.get_build_command() + \
             ['--internal', 'scanbuild', self.environment.source_dir, self.environment.build_dir] + \
             self.environment.get_build_command() + self.get_user_option_args()
@@ -2664,6 +2666,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 not os.path.exists(os.path.join(self.environment.source_dir, '_clang-' + name)):
             return
         if target_name in self.all_outputs:
+            return
+        if ('', target_name) in self.build.run_target_names:
             return
         cmd = self.environment.get_build_command() + \
             ['--internal', 'clang' + name, self.environment.source_dir, self.environment.build_dir]
@@ -2687,6 +2691,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def generate_tags(self, tool, target_name):
         import shutil
         if not shutil.which(tool):
+            return
+        if ('', target_name) in self.build.run_target_names:
             return
         if target_name in self.all_outputs:
             return

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -117,6 +117,7 @@ class Build:
         self.environment = environment
         self.projects = {}
         self.targets = OrderedDict()
+        self.run_target_names = set() # type: typing.Set[typing.Tuple[str, str]]
         self.global_args = PerMachine({}, {})         # type: PerMachine[typing.Dict[str, typing.List[str]]]
         self.projects_args = PerMachine({}, {})       # type: PerMachine[typing.Dict[str, typing.List[str]]]
         self.global_link_args = PerMachine({}, {})    # type: PerMachine[typing.Dict[str, typing.List[str]]]

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3369,6 +3369,9 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         command, *cmd_args = cleaned_args
         tg = RunTargetHolder(build.RunTarget(name, command, cmd_args, cleaned_deps, self.subdir, self.subproject), self)
         self.add_target(name, tg.held_object)
+        full_name = (self.subproject, name)
+        assert(full_name not in self.build.run_target_names)
+        self.build.run_target_names.add(full_name)
         return tg
 
     @FeatureNew('alias_target', '0.52.0')

--- a/test cases/common/54 run target/meson.build
+++ b/test cases/common/54 run target/meson.build
@@ -65,3 +65,10 @@ conf = configure_file(
 run_target('configure_script',
   command : conf
 )
+
+# Target names that clash with potential builtin functionality.
+run_target('ctags',
+  command : converter)
+
+run_target('clang-format',
+  command : converter)


### PR DESCRIPTION
This way we can easily check that we only provide builtin targets such
as clang-format if the user has not provided their own.