### PR TITLE
syntax-highlighting: vim: fix setting cpo

### DIFF
--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -28,7 +28,7 @@ endif
 " We need nocompatible mode in order to continue lines with backslashes.
 " Original setting will be restored.
 let s:cpo_save = &cpo
-setlocal cpo&vim
+set cpo&vim
 
 " http://mesonbuild.com/Syntax.html
 syn keyword mesonConditional	elif else if endif


### PR DESCRIPTION
since 'cpo' is global, use `set` instead of `setlocal`.

Reported-By: Bram Moolenaar <Bram@vim.org>
Signed-off-by: Liam Beguin <liambeguin@gmail.com>