### PR TITLE
fs module; make more robust, dedupe code, add method, add type anno & check

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
     displayName: 'Install Pylint, MyPy'
   - script: pylint mesonbuild
     displayName: Lint Checks
-  - script: mypy --follow-imports=skip  mesonbuild/mtest.py mesonbuild/minit.py mesonbuild/msetup.py mesonbuild/wrap tools/
+  - script: mypy --follow-imports=skip  mesonbuild/mtest.py mesonbuild/minit.py mesonbuild/msetup.py mesonbuild/wrap tools/ mesonbuild/modules/fs.py
 
 
 - job: vs2015

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -8,7 +8,7 @@ available starting with version 0.53.0.
 Non-absolute paths are looked up relative to the directory where the
 current `meson.build` file is.
 
-If specified, `~` is expanded to the user home directory.
+If specified, a leading `~` is expanded to the user home directory.
 
 ### exists
 
@@ -36,20 +36,23 @@ by the string is a symbolic link.
 
 ### hash
 
-The `fs.hash(filename)` method computes the requested hash sum of a file.
-The available hash methods include: md5, sha1, sha224, sha256, sha384, sha512.
+The `fs.hash(filename, hash_algorithm)` method returns a string containing
+the hexidecimal `hash_algorithm` digest of a file.
+`hash_algorithm` is a string; the available hash algorithms include:
+md5, sha1, sha224, sha256, sha384, sha512.
 
 ### size
 
-The `fs.size(filename)` method returns the size of the file in bytes.
+The `fs.size(filename)` method returns the size of the file in integer bytes.
 Symlinks will be resolved if possible.
 
 ### samefile
 
-The `fs.samefile(filename1, filename2)` method allows determining if two filenames refer to the same file.
-Perhaps a meson.build file in one place refer to a symlink and in another place a
-relative path and/or absolute path. The `samefile` method allows determining if these
-are the same file.
+The `fs.samefile(filename1, filename2)` returns boolean `true` if the input filenames refer to the same file.
+For example, suppose filename1 is a symlink and filename2 is a relative path.
+If filename1 can be resolved to a file that is the same file as filename2, then `true` is returned.
+If filename1 is not resolved to be the same as filename2, `false` is returned.
+If either filename does not exist, an error message is raised.
 
 Examples:
 
@@ -65,37 +68,37 @@ fs.samefile(x, z)  # true
 
 ## Filename modification
 
-### with_suffix
+### replace_suffix
 
-The `with_suffix` method is a *string manipulation* convenient for filename modifications.
+The `replace_suffix` method is a *string manipulation* convenient for filename modifications.
 It allows changing the filename suffix like:
 
 ## swap suffix
 
 ```meson
 original = '/opt/foo.ini'
-new = fs.with_suffix(original, '.txt')  # /opt/foo.txt
+new = fs.replace_suffix(original, '.txt')  # /opt/foo.txt
 ```
 
 #### add suffix
 
 ```meson
 original = '/opt/foo'
-new = fs.with_suffix(original, '.txt')  # /opt/foo.txt
+new = fs.replace_suffix(original, '.txt')  # /opt/foo.txt
 ```
 
 #### compound suffix swap
 
 ```meson
 original = '/opt/foo.dll.a'
-new = fs.with_suffix(original, '.so')  # /opt/foo.dll.so
+new = fs.replace_suffix(original, '.so')  # /opt/foo.dll.so
 ```
 
 #### delete suffix
 
 ```meson
 original = '/opt/foo.dll.a'
-new = fs.with_suffix(original, '')  # /opt/foo.dll
+new = fs.replace_suffix(original, '')  # /opt/foo.dll
 ```
 
 The files need not actually exist yet for this method, as it's just string manipulation.

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -8,6 +8,8 @@ available starting with version 0.53.0.
 Non-absolute paths are looked up relative to the directory where the
 current `meson.build` file is.
 
+If specified, `~` is expanded to the user home directory.
+
 ### exists
 
 Takes a single string argument and returns true if an entity with that
@@ -29,3 +31,16 @@ name exists on the file system. This method follows symbolic links.
 
 Takes a single string argument and returns true if the path pointed to
 by the string is a symbolic link.
+
+## Filename modification
+
+### with_suffix
+
+The `with_suffix` method allows changing the filename suffix
+
+```meson
+original = '/opt/foo.ini'
+new = fs.with_suffix('.txt')
+```
+
+The files need not actually exist yet for this method.

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -32,6 +32,14 @@ name exists on the file system. This method follows symbolic links.
 Takes a single string argument and returns true if the path pointed to
 by the string is a symbolic link.
 
+## File Parameters
+
+### hash
+
+The `hash` method computes the requested hash sum of a file.
+The available hash methods include: md5, sha1, sha224, sha256, sha384, sha512.
+
+
 ## Filename modification
 
 ### with_suffix

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -69,28 +69,28 @@ It allows changing the filename suffix like:
 
 ```meson
 original = '/opt/foo.ini'
-new = fs.with_suffix('.txt')  # /opt/foo.txt
+new = fs.with_suffix(original, '.txt')  # /opt/foo.txt
 ```
 
 #### add suffix
 
 ```meson
 original = '/opt/foo'
-new = fs.with_suffix('.txt')  # /opt/foo.txt
+new = fs.with_suffix(original, '.txt')  # /opt/foo.txt
 ```
 
 #### compound suffix swap
 
 ```meson
 original = '/opt/foo.dll.a'
-new = fs.with_suffix('.so')  # /opt/foo.dll.so
+new = fs.with_suffix(original, '.so')  # /opt/foo.dll.so
 ```
 
 #### delete suffix
 
 ```meson
 original = '/opt/foo.dll.a'
-new = fs.with_suffix('')  # /opt/foo.dll
+new = fs.with_suffix(original, '')  # /opt/foo.dll
 ```
 
 The files need not actually exist yet for this method, as it's just string manipulation.

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -36,11 +36,35 @@ by the string is a symbolic link.
 
 ### with_suffix
 
-The `with_suffix` method allows changing the filename suffix
+The `with_suffix` method is a *string manipulation* convenient for filename modifications.
+It allows changing the filename suffix like:
+
+## swap suffix
 
 ```meson
 original = '/opt/foo.ini'
-new = fs.with_suffix('.txt')
+new = fs.with_suffix('.txt')  # /opt/foo.txt
 ```
 
-The files need not actually exist yet for this method.
+#### add suffix
+
+```meson
+original = '/opt/foo'
+new = fs.with_suffix('.txt')  # /opt/foo.txt
+```
+
+#### compound suffix swap
+
+```meson
+original = '/opt/foo.dll.a'
+new = fs.with_suffix('.so')  # /opt/foo.dll.so
+```
+
+#### delete suffix
+
+```meson
+original = '/opt/foo.dll.a'
+new = fs.with_suffix('')  # /opt/foo.dll
+```
+
+The files need not actually exist yet for this method, as it's just string manipulation.

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -36,8 +36,26 @@ by the string is a symbolic link.
 
 ### hash
 
-The `hash` method computes the requested hash sum of a file.
+The `fs.hash(filename)` method computes the requested hash sum of a file.
 The available hash methods include: md5, sha1, sha224, sha256, sha384, sha512.
+
+### samefile
+
+The `fs.samefile(filename1, filename2)` method allows determining if two filenames refer to the same file.
+Perhaps a meson.build file in one place refer to a symlink and in another place a
+relative path and/or absolute path. The `samefile` method allows determining if these
+are the same file.
+
+Examples:
+
+```meson
+x = 'foo.txt'
+y = 'sub/../foo.txt'
+z = 'bar.txt'  # a symlink pointing to foo.txt
+
+fs.samefile(x, y)  # true
+fs.samefile(x, z)  # true
+```
 
 
 ## Filename modification

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -39,6 +39,11 @@ by the string is a symbolic link.
 The `fs.hash(filename)` method computes the requested hash sum of a file.
 The available hash methods include: md5, sha1, sha224, sha256, sha384, sha512.
 
+### size
+
+The `fs.size(filename)` method returns the size of the file in bytes.
+Symlinks will be resolved if possible.
+
 ### samefile
 
 The `fs.samefile(filename1, filename2)` method allows determining if two filenames refer to the same file.

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -73,7 +73,7 @@ fs.samefile(x, z)  # true
 The `replace_suffix` method is a *string manipulation* convenient for filename modifications.
 It allows changing the filename suffix like:
 
-## swap suffix
+#### swap suffix
 
 ```meson
 original = '/opt/foo.ini'

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -31,10 +31,17 @@ class FSModule(ExtensionModule):
         super().__init__(interpreter)
         self.snippets.add('generate_dub_file')
 
+    def _resolve_dir(self, state: 'ModuleState', arg: str) -> Path:
+        """
+        resolves (makes absolute) a directory relative to calling meson.build,
+        if not already absolute
+        """
+        return Path(state.source_root) / state.subdir / Path(arg).expanduser()
+
     def _check(self, check: str, state: 'ModuleState', args: typing.Sequence[str]) -> ModuleReturnValue:
         if len(args) != 1:
             MesonException('fs.{} takes exactly one argument.'.format(check))
-        test_file = Path(state.source_root) / state.subdir / Path(args[0]).expanduser()
+        test_file = self._resolve_dir(state, args[0])
         return ModuleReturnValue(getattr(test_file, check)(), [])
 
     @stringArgs
@@ -62,7 +69,7 @@ class FSModule(ExtensionModule):
     def hash(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
         if len(args) != 2:
             MesonException('method takes exactly two arguments.')
-        file = Path(state.source_root) / state.subdir / Path(args[0]).expanduser()
+        file = self._resolve_dir(state, args[0])
         if not file.is_file():
             raise MesonException('{} is not a file and therefore cannot be hashed'.format(file))
         try:
@@ -72,6 +79,35 @@ class FSModule(ExtensionModule):
         mlog.debug('computing {} sum of {} size {} bytes'.format(args[1], file, file.stat().st_size))
         h.update(file.read_bytes())
         return ModuleReturnValue(h.hexdigest(), [])
+
+    @stringArgs
+    @noKwargs
+    def size(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+        if len(args) != 1:
+            MesonException('method takes exactly one argument.')
+        file = self._resolve_dir(state, args[0])
+        if not file.is_file():
+            raise MesonException('{} is not a file and therefore cannot be sized'.format(file))
+        try:
+            return ModuleReturnValue(file.stat().st_size, [])
+        except ValueError:
+            raise MesonException('{} size could not be determined'.format(args[0]))
+
+    @stringArgs
+    @noKwargs
+    def samefile(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+        if len(args) != 2:
+            MesonException('method takes exactly two arguments.')
+        file1 = self._resolve_dir(state, args[0])
+        file2 = self._resolve_dir(state, args[1])
+        if not file1.exists():
+            raise MesonException('{} is not a file, symlink or directory and therefore cannot be compared'.format(file1))
+        if not file2.exists():
+            raise MesonException('{} is not a file, symlink or directory and therefore cannot be compared'.format(file2))
+        try:
+            return ModuleReturnValue(file1.samefile(file2), [])
+        except OSError:
+            raise MesonException('{} could not be compared to {}'.format(file1, file2))
 
     @stringArgs
     @noKwargs

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -31,7 +31,7 @@ class FSModule(ExtensionModule):
 
     def _check(self, check: str, state: 'ModuleState', args: typing.Sequence[str]) -> ModuleReturnValue:
         if len(args) != 1:
-            MesonException('method takes exactly one argument.')
+            MesonException('fs.{} takes exactly one argument.'.format(check))
         test_file = Path(state.source_root) / state.subdir / Path(args[0]).expanduser()
         return ModuleReturnValue(getattr(test_file, check)(), [])
 

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import typing
-from pathlib import Path
+from pathlib import Path, PurePath
 
 from . import ExtensionModule
 from . import ModuleReturnValue
@@ -54,6 +54,16 @@ class FSModule(ExtensionModule):
     @noKwargs
     def is_dir(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
         return self._check('is_dir', state, args)
+
+    @stringArgs
+    @noKwargs
+    def with_suffix(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+        if len(args) != 2:
+            MesonException('method takes exactly two arguments.')
+        original = PurePath(state.source_root) / state.subdir / args[0]
+        new = original.with_suffix(args[1])
+        return ModuleReturnValue(str(new), [])
+
 
 def initialize(*args, **kwargs) -> FSModule:
     return FSModule(*args, **kwargs)

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -29,19 +29,16 @@ class FSModule(ExtensionModule):
         super().__init__(interpreter)
         self.snippets.add('generate_dub_file')
 
-    @stringArgs
-    @noKwargs
-    def exists(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
-        if len(args) != 1:
-            MesonException('method takes exactly one argument.')
-        test_file = Path(state.source_root) / state.subdir / args[0]
-        return ModuleReturnValue(test_file.exists(), [])
-
     def _check(self, check: str, state: 'ModuleState', args: typing.Sequence[str]) -> ModuleReturnValue:
         if len(args) != 1:
             MesonException('method takes exactly one argument.')
         test_file = Path(state.source_root) / state.subdir / args[0]
         return ModuleReturnValue(getattr(test_file, check)(), [])
+
+    @stringArgs
+    @noKwargs
+    def exists(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+        return self._check('exists', state, args)
 
     @stringArgs
     @noKwargs

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -114,7 +114,7 @@ class FSModule(ExtensionModule):
     def replace_suffix(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
         if len(args) != 2:
             MesonException('method takes exactly two arguments.')
-        original = PurePath(state.source_root) / state.subdir / args[0]
+        original = PurePath(args[0])
         new = original.with_suffix(args[1])
         return ModuleReturnValue(str(new), [])
 

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -32,7 +32,7 @@ class FSModule(ExtensionModule):
     def _check(self, check: str, state: 'ModuleState', args: typing.Sequence[str]) -> ModuleReturnValue:
         if len(args) != 1:
             MesonException('method takes exactly one argument.')
-        test_file = Path(state.source_root) / state.subdir / args[0]
+        test_file = Path(state.source_root) / state.subdir / Path(args[0]).expanduser()
         return ModuleReturnValue(getattr(test_file, check)(), [])
 
     @stringArgs

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -111,7 +111,7 @@ class FSModule(ExtensionModule):
 
     @stringArgs
     @noKwargs
-    def with_suffix(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def replace_suffix(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
         if len(args) != 2:
             MesonException('method takes exactly two arguments.')
         original = PurePath(state.source_root) / state.subdir / args[0]

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+import typing
+from pathlib import Path
 
 from . import ExtensionModule
 from . import ModuleReturnValue
 from ..mesonlib import MesonException
 
 from ..interpreterbase import stringArgs, noKwargs
+if typing.TYPE_CHECKING:
+    from ..interpreter import ModuleState
 
 class FSModule(ExtensionModule):
 
@@ -28,32 +31,32 @@ class FSModule(ExtensionModule):
 
     @stringArgs
     @noKwargs
-    def exists(self, state, args, kwargs):
+    def exists(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
         if len(args) != 1:
             MesonException('method takes exactly one argument.')
-        test_file = os.path.join(state.source_root, state.subdir, args[0])
-        return ModuleReturnValue(os.path.exists(test_file), [])
+        test_file = Path(state.source_root) / state.subdir / args[0]
+        return ModuleReturnValue(test_file.exists(), [])
 
-    def _check(self, check_fun, state, args):
+    def _check(self, check: str, state: 'ModuleState', args: typing.Sequence[str]) -> ModuleReturnValue:
         if len(args) != 1:
             MesonException('method takes exactly one argument.')
-        test_file = os.path.join(state.source_root, state.subdir, args[0])
-        return ModuleReturnValue(check_fun(test_file), [])
+        test_file = Path(state.source_root) / state.subdir / args[0]
+        return ModuleReturnValue(getattr(test_file, check)(), [])
 
     @stringArgs
     @noKwargs
-    def is_symlink(self, state, args, kwargs):
-        return self._check(os.path.islink, state, args)
+    def is_symlink(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+        return self._check('is_symlink', state, args)
 
     @stringArgs
     @noKwargs
-    def is_file(self, state, args, kwargs):
-        return self._check(os.path.isfile, state, args)
+    def is_file(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+        return self._check('is_file', state, args)
 
     @stringArgs
     @noKwargs
-    def is_dir(self, state, args, kwargs):
-        return self._check(os.path.isdir, state, args)
+    def is_dir(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+        return self._check('is_dir', state, args)
 
-def initialize(*args, **kwargs):
+def initialize(*args, **kwargs) -> FSModule:
     return FSModule(*args, **kwargs)

--- a/test cases/common/227 fs module/meson.build
+++ b/test cases/common/227 fs module/meson.build
@@ -24,28 +24,28 @@ assert(fs.is_dir('~'), 'expanduser not working')
 assert(not fs.is_file('~'), 'expanduser not working')
 
 original = 'foo.txt'
-new = fs.with_suffix(original, '.ini')
-assert(new.endswith('foo.ini') and not new.contains('.txt'), 'with_suffix failed')
+new = fs.replace_suffix(original, '.ini')
+assert(new.endswith('foo.ini') and not new.contains('.txt'), 'replace_suffix failed')
 
 original = 'foo'
-new = fs.with_suffix(original, '.ini')
-assert(new.endswith('foo.ini'), 'with_suffix did not add suffix to suffixless file')
+new = fs.replace_suffix(original, '.ini')
+assert(new.endswith('foo.ini'), 'replace_suffix did not add suffix to suffixless file')
 
 original = 'foo.dll.a'
-new = fs.with_suffix(original, '.so')
-assert(new.endswith('foo.dll.so'), 'with_suffix did not only modify last suffix')
+new = fs.replace_suffix(original, '.so')
+assert(new.endswith('foo.dll.so'), 'replace_suffix did not only modify last suffix')
 
 original = 'foo.dll'
-new = fs.with_suffix(original, '')
-assert(new.endswith('foo'), 'with_suffix did not only delete last suffix')
+new = fs.replace_suffix(original, '')
+assert(new.endswith('foo'), 'replace_suffix did not only delete last suffix')
 
 # `/` on windows is interpreted like `.drive` which in general may not be `c:/`
-# the files need not exist for fs.with_suffix()
+# the files need not exist for fs.replace_suffix()
 original = is_windows ? 'j:/foo/bar.txt' : '/foo/bar.txt'
 new_check = is_windows ? 'j:\\foo\\bar.ini' : '/foo/bar.ini'
 
-new = fs.with_suffix(original, '.ini')
-assert(new == new_check, 'absolute path with_suffix failed')
+new = fs.replace_suffix(original, '.ini')
+assert(new == new_check, 'absolute path replace_suffix failed')
 
 # -- hash
 

--- a/test cases/common/227 fs module/meson.build
+++ b/test cases/common/227 fs module/meson.build
@@ -1,11 +1,13 @@
 project('fs module test')
 
+is_windows = build_machine.system() == 'windows'
+
 fs = import('fs')
 
 assert(fs.exists('meson.build'), 'Existing file reported as missing.')
 assert(not fs.exists('nonexisting'), 'Nonexisting file was found.')
 
-if build_machine.system() != 'windows' and build_machine.system() != 'cygwin'
+if not is_windows and build_machine.system() != 'cygwin'
   assert(fs.is_symlink('a_symlink'), 'Symlink not detected.')
   assert(not fs.is_symlink('meson.build'), 'Regular file detected as symlink.')
 endif
@@ -25,13 +27,12 @@ original = 'foo.txt'
 new = fs.with_suffix(original, '.ini')
 assert(new.endswith('foo.ini') and not new.contains('.txt'), 'with_suffix failed')
 
-if build_machine.system() != 'windows'
-  # this feature works on Windows, but `/` on windows is interpreted like `.drive` which in general may not be `c:/`
-  # so we omit this from self-test on Windows
+# `/` on windows is interpreted like `.drive` which in general may not be `c:/`
+# the files need not exist for fs.with_suffix()
+original = is_windows ? 'j:/foo/bar.txt' : '/foo/bar.txt'
+new_check = is_windows ? 'j:\\foo\\bar.ini' : '/foo/bar.ini'
 
-  original = '/opt/foo.txt'
-  new = fs.with_suffix(original, '.ini')
-  assert(new == '/opt/foo.ini', 'absolute path with_suffix failed')
-endif
+new = fs.with_suffix(original, '.ini')
+assert(new == new_check, 'absolute path with_suffix failed')
 
 subdir('subdir')

--- a/test cases/common/227 fs module/meson.build
+++ b/test cases/common/227 fs module/meson.build
@@ -27,6 +27,18 @@ original = 'foo.txt'
 new = fs.with_suffix(original, '.ini')
 assert(new.endswith('foo.ini') and not new.contains('.txt'), 'with_suffix failed')
 
+original = 'foo'
+new = fs.with_suffix(original, '.ini')
+assert(new.endswith('foo.ini'), 'with_suffix did not add suffix to suffixless file')
+
+original = 'foo.dll.a'
+new = fs.with_suffix(original, '.so')
+assert(new.endswith('foo.dll.so'), 'with_suffix did not only modify last suffix')
+
+original = 'foo.dll'
+new = fs.with_suffix(original, '')
+assert(new.endswith('foo'), 'with_suffix did not only delete last suffix')
+
 # `/` on windows is interpreted like `.drive` which in general may not be `c:/`
 # the files need not exist for fs.with_suffix()
 original = is_windows ? 'j:/foo/bar.txt' : '/foo/bar.txt'

--- a/test cases/common/227 fs module/meson.build
+++ b/test cases/common/227 fs module/meson.build
@@ -54,5 +54,19 @@ sha256 = fs.hash('subdir/subdirfile.txt', 'sha256')
 assert(md5 == 'd0795db41614d25affdd548314b30b3b', 'md5sum did not match')
 assert(sha256 == 'be2170b0dae535b73f6775694fffa3fd726a43b5fabea11b7342f0605917a42a', 'sha256sum did not match')
 
+# -- size
+
+size = fs.size('subdir/subdirfile.txt')
+assert(size == 19, 'file size not found correctly')
+
+# -- are filenames referring to the same file?
+f1 = 'meson.build'
+f2 = 'subdir/../meson.build'
+assert(fs.samefile(f1, f2), 'samefile not realized')
+assert(not fs.samefile(f1, 'subdir/subdirfile.txt'), 'samefile known bad comparison')
+
+if not is_windows and build_machine.system() != 'cygwin'
+  assert(fs.samefile('a_symlink', 'meson.build'), 'symlink samefile fail')
+endif
 
 subdir('subdir')

--- a/test cases/common/227 fs module/meson.build
+++ b/test cases/common/227 fs module/meson.build
@@ -25,19 +25,19 @@ assert(not fs.is_file('~'), 'expanduser not working')
 
 original = 'foo.txt'
 new = fs.replace_suffix(original, '.ini')
-assert(new.endswith('foo.ini') and not new.contains('.txt'), 'replace_suffix failed')
+assert(new == 'foo.ini', 'replace_suffix failed')
 
 original = 'foo'
 new = fs.replace_suffix(original, '.ini')
-assert(new.endswith('foo.ini'), 'replace_suffix did not add suffix to suffixless file')
+assert(new == 'foo.ini', 'replace_suffix did not add suffix to suffixless file')
 
 original = 'foo.dll.a'
 new = fs.replace_suffix(original, '.so')
-assert(new.endswith('foo.dll.so'), 'replace_suffix did not only modify last suffix')
+assert(new == 'foo.dll.so', 'replace_suffix did not only modify last suffix')
 
 original = 'foo.dll'
 new = fs.replace_suffix(original, '')
-assert(new.endswith('foo'), 'replace_suffix did not only delete last suffix')
+assert(new == 'foo',  'replace_suffix did not only delete last suffix')
 
 # `/` on windows is interpreted like `.drive` which in general may not be `c:/`
 # the files need not exist for fs.replace_suffix()

--- a/test cases/common/227 fs module/meson.build
+++ b/test cases/common/227 fs module/meson.build
@@ -21,4 +21,17 @@ assert(not fs.is_dir('nonexisting'), 'Bad path detected as a dir.')
 assert(fs.is_dir('~'), 'expanduser not working')
 assert(not fs.is_file('~'), 'expanduser not working')
 
+original = 'foo.txt'
+new = fs.with_suffix(original, '.ini')
+assert(new.endswith('foo.ini') and not new.contains('.txt'), 'with_suffix failed')
+
+if build_machine.system() != 'windows'
+  # this feature works on Windows, but `/` on windows is interpreted like `.drive` which in general may not be `c:/`
+  # so we omit this from self-test on Windows
+
+  original = '/opt/foo.txt'
+  new = fs.with_suffix(original, '.ini')
+  assert(new == '/opt/foo.ini', 'absolute path with_suffix failed')
+endif
+
 subdir('subdir')

--- a/test cases/common/227 fs module/meson.build
+++ b/test cases/common/227 fs module/meson.build
@@ -18,4 +18,7 @@ assert(fs.is_dir('subprojects'), 'Dir not detected correctly.')
 assert(not fs.is_dir('meson.build'), 'File detected as a dir.')
 assert(not fs.is_dir('nonexisting'), 'Bad path detected as a dir.')
 
+assert(fs.is_dir('~'), 'expanduser not working')
+assert(not fs.is_file('~'), 'expanduser not working')
+
 subdir('subdir')

--- a/test cases/common/227 fs module/meson.build
+++ b/test cases/common/227 fs module/meson.build
@@ -47,4 +47,12 @@ new_check = is_windows ? 'j:\\foo\\bar.ini' : '/foo/bar.ini'
 new = fs.with_suffix(original, '.ini')
 assert(new == new_check, 'absolute path with_suffix failed')
 
+# -- hash
+
+md5 = fs.hash('subdir/subdirfile.txt', 'md5')
+sha256 = fs.hash('subdir/subdirfile.txt', 'sha256')
+assert(md5 == 'd0795db41614d25affdd548314b30b3b', 'md5sum did not match')
+assert(sha256 == 'be2170b0dae535b73f6775694fffa3fd726a43b5fabea11b7342f0605917a42a', 'sha256sum did not match')
+
+
 subdir('subdir')


### PR DESCRIPTION
* add type annotation and type checking for fs module
* use pathlib.Path instead of os.path for more robust, clear code
* deduplicate functions
* use *Path*.expanduser() to allow use of `~` for home directory
* add `fs.replace_suffix()` to modify filename suffix--file need not exist
* add `fs.hash()` to compute file hashs including MD5, SHA256, ...
* add `fs.samefile()` to determine if two filenames refer to the same file (incl. symlinks)