### PR TITLE
Document lack of clang support [skip-ci]

### DIFF
--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -118,6 +118,9 @@ $ ninja coverage-html (or coverage-xml)
 
 The coverage report can be found in the meson-logs subdirectory.
 
+Note: Currently, Meson does not support generating coverage reports 
+with Clang.
+
 ## Add some optimization to debug builds
 
 By default the debug build does not use any optimizations. This is the


### PR DESCRIPTION
Meson doesn't currently provide a very helpful message when trying to generate a coverage report with clang, and in fact just silently fails for 2 of the 3 reports.  Ideally Meson would support coverage with llvm-cov, or provide a more helpful error message.  Until then, it seems it would be helpful to at least put a warning in the documentation.