### PR TITLE
Adding dictionary entry using string variable as key.

### DIFF
--- a/docs/markdown/snippets/add_dictionary_variable_key.md
+++ b/docs/markdown/snippets/add_dictionary_variable_key.md
@@ -1,0 +1,17 @@
+## Adding dictionary entry using string variable as key
+
+New dictionary entry can now be added using string variable as key, 
+in addition to using string literal as key.
+
+```meson
+dict = {}
+
+# A variable to be used as a key
+key = 'myKey'
+
+# Add new entry using the variable
+dict += {key : 'myValue'}
+
+# Test that the stored value is correct 
+assert(dict[key] == 'myValue', 'Incorrect value retrieved from dictionary')
+```

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -735,7 +735,7 @@ The result of this is undefined and will become a hard error in a future Meson r
             for (key, value) in addition.items():
                 if isinstance(key, str):
                     new_addition[key] = value
-                elif isinstance(key, mparser.IdNode):
+                elif isinstance(key, mparser.IdNode) and isinstance(self.get_variable(key.value), str):
                     FeatureNew('Adding dictionary entry using string variable as key', '0.53.0').use(self.subproject)
                     new_addition[self.get_variable(key.value)] = value
                 else:

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -676,14 +676,18 @@ class Parser:
         while not isinstance(s, EmptyNode):
             potential = self.current
             if self.accept('colon'):
-                if not isinstance(s, StringNode):
-                    raise ParseException('Key must be a string.',
-                                         self.getline(), s.lineno, s.colno)
-                if s.value in a.kwargs:
-                    # + 1 to colno to point to the actual string, not the opening quote
-                    raise ParseException('Duplicate dictionary key: {}'.format(s.value),
-                                         self.getline(), s.lineno, s.colno + 1)
-                a.set_kwarg(s.value, self.statement())
+                if isinstance(s, StringNode):
+                    if s.value in a.kwargs:
+                        # + 1 to colno to point to the actual string, not the opening quote
+                        raise ParseException('Duplicate dictionary key: {}'.format(s.value), self.getline(), s.lineno, s.colno + 1)
+                    a.set_kwarg(s.value, self.statement())
+                elif isinstance(s, IdNode) and isinstance(s.value, str):
+                    for key in a.kwargs:
+                        if s.value == key.value:
+                            raise ParseException('Duplicate dictionary variable key: {}'.format(s.value), self.getline(), s.lineno, s.colno)
+                    a.set_kwarg(s, self.statement())
+                else:
+                    raise ParseException('Key must be a string or string variable', self.getline(), s.lineno, s.colno)
                 potential = self.current
                 if not self.accept('comma'):
                     return a

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -676,16 +676,17 @@ class Parser:
         while not isinstance(s, EmptyNode):
             potential = self.current
             if self.accept('colon'):
+                key_value = self.statement()
                 if isinstance(s, StringNode):
                     if s.value in a.kwargs:
                         # + 1 to colno to point to the actual string, not the opening quote
                         raise ParseException('Duplicate dictionary key: {}'.format(s.value), self.getline(), s.lineno, s.colno + 1)
-                    a.set_kwarg(s.value, self.statement())
-                elif isinstance(s, IdNode) and isinstance(s.value, str):
+                    a.set_kwarg(s.value, key_value)
+                elif isinstance(s, IdNode) and isinstance(key_value, StringNode):
                     for key in a.kwargs:
                         if s.value == key.value:
                             raise ParseException('Duplicate dictionary variable key: {}'.format(s.value), self.getline(), s.lineno, s.colno)
-                    a.set_kwarg(s, self.statement())
+                    a.set_kwarg(s, key_value)
                 else:
                     raise ParseException('Key must be a string or string variable', self.getline(), s.lineno, s.colno)
                 potential = self.current

--- a/test cases/common/228 add dict variable key/meson.build
+++ b/test cases/common/228 add dict variable key/meson.build
@@ -1,0 +1,12 @@
+project('add dictionary entry using string variable as key', meson_version: '>=0.52')
+
+dict = {}
+
+# A variable to be used as a key
+key = 'myKey'
+
+# Add new entry using the variable
+dict += {key : 'myValue'}
+
+# Test that the stored value is correct 
+assert(dict[key] == 'myValue', 'Incorrect value retrieved from dictionary')

--- a/test cases/failing/97 add dict non string key/meson.build
+++ b/test cases/failing/97 add dict non string key/meson.build
@@ -1,0 +1,9 @@
+project('add dictionary entry using non-string key')
+
+dict = {}
+
+# An integer variable to be used as a key
+key = 1
+
+# Add new entry using integer variable as key should fail
+dict += {key : 'myValue'}

--- a/test cases/failing/98 add dict duplicate keys/meson.build
+++ b/test cases/failing/98 add dict duplicate keys/meson.build
@@ -1,0 +1,9 @@
+project('add dictionary entries with duplicate keys')
+
+dict = {}
+
+# A variable to be used as a key
+key = 'myKey'
+
+# Add two entries with duplicate keys should fail
+dict += {key : 'myValue1', key : 'myValue2'}


### PR DESCRIPTION
Hi,
I'd like to contribute this change which allows adding a dictionary entry using string variable as key, in addition to using string literal as key.

Example:
dict = {}
key = 'myKey'
dict += {key : 'myValue'}