### PR TITLE
Prevent install_name_tool to run on EXE when cross compile on OSX

### DIFF
--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -431,8 +431,8 @@ def fix_rpath(fname, new_rpath, final_path, install_name_mappings, verbose=True)
     # Static libraries never have rpaths
     if fname.endswith('.a'):
         return
-    # DLLs never have rpaths
-    if fname.endswith('.dll'):
+    # DLLs and EXE never have rpaths
+    if fname.endswith('.dll') or fname.endswith('.exe'):
         return
     try:
         if fname.endswith('.jar'):


### PR DESCRIPTION
Meson should not try to fix rpath on both EXE and DLL when cross compile.