### PR TITLE
coredata: CmdLineFileParser no longer interpolates strings.

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -776,7 +776,7 @@ class CmdLineFileParser(configparser.ConfigParser):
     def __init__(self):
         # We don't want ':' as key delimiter, otherwise it would break when
         # storing subproject options like "subproject:option=value"
-        super().__init__(delimiters=['='])
+        super().__init__(delimiters=['='], interpolation=None)
 
 def get_cmd_line_file(build_dir):
     return os.path.join(build_dir, 'meson-private', 'cmd_line.txt')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3382,6 +3382,11 @@ recommended as it is not supported on some platforms''')
         self.assertEqual(obj.compiler_options.host['c_args'].value, ['foo bar', 'one', 'two'])
         self.wipe()
 
+        self.init(testdir, extra_args=['-Dset_percent_opt=myoption%'])
+        obj = mesonbuild.coredata.load(self.builddir)
+        self.assertEqual(obj.user_options['set_percent_opt'].value, 'myoption%')
+        self.wipe()
+
         # Setting a 2nd time the same option should override the first value
         try:
             self.init(testdir, extra_args=['--bindir=foo', '--bindir=bar',

--- a/test cases/unit/34 command line/meson_options.txt
+++ b/test cases/unit/34 command line/meson_options.txt
@@ -1,1 +1,2 @@
 option('set_sub_opt', type : 'boolean', value : false)
+option('set_percent_opt', type : 'string', value: 'not_set')


### PR DESCRIPTION
Previously if a user tried to pass a command line build
option that contained a '%' character the command line
parser assumed that there was string interpolation to be
done. As there is no sense in such a scenario no code
provides any input for the interpolation. This then leads to
a failure.

In this commit we specifically override the defaults in
ConfigParser and set interpolation to None, which disables
command line build option interpolation.

Fixes #6157