### PR TITLE
Have set() and set_quoted() of configuration object work with newlines.

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -342,6 +342,7 @@ class ConfigurationDataHolder(MutableInterpreterObject, ObjectHolder):
         if not isinstance(val, str):
             raise InterpreterException("Second argument to set_quoted must be a string.")
         escaped_val = '\\"'.join(val.split('"'))
+        escaped_val = '\\n'.join(escaped_val.split('\n'))
         self.held_object.values[name] = ('"' + escaped_val + '"', desc)
 
     def set10_method(self, args, kwargs):

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -956,6 +956,8 @@ def dump_conf_header(ofilename, cdata, output_format):
                 else:
                     ofile.write('%sundef %s\n\n' % (prefix, k))
             elif isinstance(v, (int, str)):
+                if isinstance(v, str):
+                    v = '\\\n'.join(v.rstrip().split('\n'))
                 ofile.write('%sdefine %s %s\n\n' % (prefix, k, v))
             else:
                 raise MesonException('Unknown data type in configuration file entry: ' + k)

--- a/test cases/common/14 configure file/dumpprog.c
+++ b/test cases/common/14 configure file/dumpprog.c
@@ -48,5 +48,13 @@ int main(void) {
         printf("Quoted number defined incorrectly.\n");
         return 1;
     }
+    if(MULTILINE != 3) {
+        printf("Multiline macro defined incorrectly.\n");
+        return 1;
+    }
+    if(strcmp(MULTILINE_STRING, "line1\nline2") != 0) {
+        printf("Quoted multiline macro defined incorrectly.\n");
+        return 1;
+    }
     SHOULD_BE_RETURN 0;
 }

--- a/test cases/common/14 configure file/meson.build
+++ b/test cases/common/14 configure file/meson.build
@@ -88,6 +88,10 @@ dump.set('SHOULD_BE_ONE', 1)
 dump.set('SHOULD_BE_ZERO', 0, description : 'Absolutely zero')
 dump.set('SHOULD_BE_QUOTED_ONE', '"1"')
 
+dump.set('MULTILINE', '1\n+2')
+dump.set_quoted('MULTILINE_STRING', '''line1
+line2''')
+
 dump.set_quoted('INTEGER_AS_STRING', '12')
 if dump.get_unquoted('INTEGER_AS_STRING').to_int() == 12
   dump.set('SHOULD_BE_UNQUOTED_STRING', dump.get_unquoted('SHOULD_BE_STRING'))


### PR DESCRIPTION
set_quoted() makes the value into a double-quoted string, so let's
assume C-style string, in particular with newlines as "\n".

Also take care of remaining newlines in dump_conf_header(). C or nasm
macros expect single-line values so if the value was multi-line, we
would end up with broken syntax. Appending a backslash at each end of
line make them concat into a single line in both C and nasm format
(note: multi-line macros in nasm are actually possible apparently but
use another format not outputted by current meson code). Also note that
the replacement is done at the end only when dumping the conf as a
header because we cannot assume anything about the format when replacing
variables from an input file (in this case, it should be the dev
responsibility).

----------

This was a result of discovering broken files when setting multi-line values to a conf variable:
```
conf.set('VAR', 'something
with newlines')
```
Of course my example seems weird because in real life, the value was simply the output of some command (which was multi-line and that was exactly what I wanted, not a bug).

Then when creating a `config.h`, it ended up broken (hence broke the build):
```
#define VAR something
with newlines
```

The solution is to append backslashes:
```
#define VAR something\
with newlines
```

Now actually I was using a set_quoted():
```
conf.set_quoted('VAR', 'something
with newlines')
```
In such case, it seems obvious we want to use this like a string, so let's replace newlines with `\n` directly to make sure this works well. In particular, we want to get:
```
#define VAR something\nwith newlines
```

This commit deals with all these cases.