### PR TITLE
Better dependency logs

### DIFF
--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -192,8 +192,8 @@ in a real meson run. Because of this options for the subprojects can differ.
 ## The dependencies section
 
 The list of all _found_ dependencies can be acquired from
-`intro-dependencies.json`. Here, the name, compiler and linker arguments for
-a dependency are listed.
+`intro-dependencies.json`. Here, the name, version, compiler and linker
+arguments for a dependency are listed.
 
 ### Scanning for dependecie with `--scan-dependencies`
 

--- a/docs/markdown/snippets/introspect.md
+++ b/docs/markdown/snippets/introspect.md
@@ -1,0 +1,4 @@
+## Introspection API changes
+
+dependencies (--dependencies, intro-dependencies.json):
+- added the `version` key

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -2197,15 +2197,13 @@ def find_external_dependency(name, env, kwargs):
 
                 info = []
                 if d.version:
-                    info.append(d.version)
+                    info.append(mlog.normal_cyan(d.version))
 
                 log_info = d.log_info()
                 if log_info:
                     info.append('(' + log_info + ')')
 
-                info = ' '.join(info)
-
-                mlog.log(type_text, mlog.bold(display_name), details + 'found:', mlog.green('YES'), info)
+                mlog.log(type_text, mlog.bold(display_name), details + 'found:', mlog.green('YES'), *info)
 
                 return d
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1191,7 +1191,7 @@ class CompilerHolder(InterpreterObject):
                                                 self.environment,
                                                 extra_args=extra_args,
                                                 dependencies=deps)
-        cached = '(cached)' if cached else ''
+        cached = mlog.blue('(cached)') if cached else ''
         if had:
             hadtxt = mlog.green('YES')
         else:
@@ -1221,7 +1221,7 @@ class CompilerHolder(InterpreterObject):
                                                 self.environment,
                                                 extra_args=extra_args,
                                                 dependencies=deps)
-        cached = '(cached)' if cached else ''
+        cached = mlog.blue('(cached)') if cached else ''
         if had:
             hadtxt = mlog.green('YES')
         else:
@@ -1251,7 +1251,7 @@ class CompilerHolder(InterpreterObject):
         had, cached = self.compiler.has_function(funcname, prefix, self.environment,
                                                  extra_args=extra_args,
                                                  dependencies=deps)
-        cached = '(cached)' if cached else ''
+        cached = mlog.blue('(cached)') if cached else ''
         if had:
             hadtxt = mlog.green('YES')
         else:
@@ -1278,7 +1278,7 @@ class CompilerHolder(InterpreterObject):
         deps, msg = self.determine_dependencies(kwargs)
         had, cached = self.compiler.has_type(typename, prefix, self.environment,
                                              extra_args=extra_args, dependencies=deps)
-        cached = '(cached)' if cached else ''
+        cached = mlog.blue('(cached)') if cached else ''
         if had:
             hadtxt = mlog.green('YES')
         else:
@@ -1365,7 +1365,7 @@ class CompilerHolder(InterpreterObject):
         value, cached = self.compiler.get_define(element, prefix, self.environment,
                                                  extra_args=extra_args,
                                                  dependencies=deps)
-        cached = '(cached)' if cached else ''
+        cached = mlog.blue('(cached)') if cached else ''
         mlog.log('Fetching value of define', mlog.bold(element, True), msg, value, cached)
         return value
 
@@ -1398,7 +1398,7 @@ class CompilerHolder(InterpreterObject):
                 h = mlog.green('YES')
             else:
                 h = mlog.red('NO')
-            cached = '(cached)' if cached else ''
+            cached = mlog.blue('(cached)') if cached else ''
             mlog.log('Checking if', mlog.bold(testname, True), msg, 'compiles:', h, cached)
         return result
 
@@ -1426,7 +1426,7 @@ class CompilerHolder(InterpreterObject):
         result, cached = self.compiler.links(code, self.environment,
                                              extra_args=extra_args,
                                              dependencies=deps)
-        cached = '(cached)' if cached else ''
+        cached = mlog.blue('(cached)') if cached else ''
         if len(testname) > 0:
             if result:
                 h = mlog.green('YES')
@@ -1455,7 +1455,7 @@ class CompilerHolder(InterpreterObject):
         haz, cached = self.compiler.check_header(hname, prefix, self.environment,
                                                  extra_args=extra_args,
                                                  dependencies=deps)
-        cached = '(cached)' if cached else ''
+        cached = mlog.blue('(cached)') if cached else ''
         if required and not haz:
             raise InterpreterException('{} header {!r} not usable'.format(self.compiler.get_display_language(), hname))
         elif haz:
@@ -1483,7 +1483,7 @@ class CompilerHolder(InterpreterObject):
         deps, msg = self.determine_dependencies(kwargs)
         haz, cached = self.compiler.has_header(hname, prefix, self.environment,
                                                extra_args=extra_args, dependencies=deps)
-        cached = '(cached)' if cached else ''
+        cached = mlog.blue('(cached)') if cached else ''
         if required and not haz:
             raise InterpreterException('{} header {!r} not found'.format(self.compiler.get_display_language(), hname))
         elif haz:
@@ -1518,7 +1518,7 @@ class CompilerHolder(InterpreterObject):
             h = mlog.green('YES')
         else:
             h = mlog.red('NO')
-        cached = '(cached)' if cached else ''
+        cached = mlog.blue('(cached)') if cached else ''
         mlog.log('Header <{0}> has symbol'.format(hname), mlog.bold(symbol, True), msg, h, cached)
         return haz
 
@@ -1593,7 +1593,7 @@ class CompilerHolder(InterpreterObject):
             h = mlog.green('YES')
         else:
             h = mlog.red('NO')
-        cached = '(cached)' if cached else ''
+        cached = mlog.blue('(cached)') if cached else ''
         mlog.log(
             'Compiler for {} supports arguments {}:'.format(
                 self.compiler.get_display_language(), ' '.join(args)),
@@ -1632,7 +1632,7 @@ class CompilerHolder(InterpreterObject):
     def has_multi_link_arguments_method(self, args, kwargs):
         args = mesonlib.stringlistify(args)
         result, cached = self.compiler.has_multi_link_arguments(args, self.environment)
-        cached = '(cached)' if cached else ''
+        cached = mlog.blue('(cached)') if cached else ''
         if result:
             h = mlog.green('YES')
         else:
@@ -1670,7 +1670,7 @@ class CompilerHolder(InterpreterObject):
         if len(args) != 1:
             raise InterpreterException('has_func_attribute takes exactly one argument.')
         result, cached = self.compiler.has_func_attribute(args[0], self.environment)
-        cached = '(cached)' if cached else ''
+        cached = mlog.blue('(cached)') if cached else ''
         h = mlog.green('YES') if result else mlog.red('NO')
         mlog.log('Compiler for {} supports function attribute {}:'.format(self.compiler.get_display_language(), args[0]), h, cached)
         return result
@@ -2998,7 +2998,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         if cached_dep:
             if not cached_dep.found():
                 mlog.log('Dependency', mlog.bold(name),
-                         'found:', mlog.red('NO'), '(cached)')
+                         'found:', mlog.red('NO'), mlog.blue('(cached)'))
                 return identifier, cached_dep
 
             # Verify the cached dep version match
@@ -3059,12 +3059,13 @@ external dependencies (including libraries) must go to "dependencies".''')
                                           'dep {}'.format(found, dirname, wanted, display_name))
 
             mlog.log('Subproject', mlog.bold(subproj_path), 'dependency',
-                     mlog.bold(display_name), 'version is', mlog.bold(found),
+                     mlog.bold(display_name), 'version is', mlog.normal_cyan(found),
                      'but', mlog.bold(wanted), 'is required.')
             return self.notfound_dependency()
 
+        found = mlog.normal_cyan(found) if found else None
         mlog.log('Dependency', mlog.bold(display_name), 'from subproject',
-                 mlog.bold(subproj_path), 'found:', mlog.green('YES'))
+                 mlog.bold(subproj_path), 'found:', mlog.green('YES'), found)
         return dep
 
     def _handle_featurenew_dependencies(self, name):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3002,11 +3002,14 @@ external dependencies (including libraries) must go to "dependencies".''')
                 return identifier, cached_dep
 
             # Verify the cached dep version match
-            wanted = kwargs.get('version', [])
-            found = cached_dep.get_version()
-            if not wanted or mesonlib.version_compare_many(found, wanted)[0]:
+            wanted_vers = kwargs.get('version', [])
+            found_vers = cached_dep.get_version()
+            if not wanted_vers or mesonlib.version_compare_many(found_vers, wanted_vers)[0]:
+                info = [mlog.blue('(cached)')]
+                if found_vers:
+                    info = [mlog.normal_cyan(found_vers), *info]
                 mlog.log('Dependency', mlog.bold(name),
-                         'found:', mlog.green('YES'), '(cached)')
+                         'found:', mlog.green('YES'), *info)
                 return identifier, cached_dep
 
         return identifier, None

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -299,6 +299,7 @@ def list_deps(coredata: cdata.CoreData):
     for d in coredata.deps.host.values():
         if d.found():
             result += [{'name': d.name,
+                        'version': d.get_version(),
                         'compile_args': d.get_compile_args(),
                         'link_args': d.get_link_args()}]
     return result

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -127,6 +127,21 @@ def blue(text: str) -> AnsiDecorator:
 def cyan(text: str) -> AnsiDecorator:
     return AnsiDecorator(text, "\033[1;36m")
 
+def normal_red(text: str) -> AnsiDecorator:
+    return AnsiDecorator(text, "\033[31m")
+
+def normal_green(text: str) -> AnsiDecorator:
+    return AnsiDecorator(text, "\033[32m")
+
+def normal_yellow(text: str) -> AnsiDecorator:
+    return AnsiDecorator(text, "\033[33m")
+
+def normal_blue(text: str) -> AnsiDecorator:
+    return AnsiDecorator(text, "\033[34m")
+
+def normal_cyan(text: str) -> AnsiDecorator:
+    return AnsiDecorator(text, "\033[36m")
+
 # This really should be AnsiDecorator or anything that implements
 # __str__(), but that requires protocols from typing_extensions
 def process_markup(args: Sequence[Union[AnsiDecorator, str]], keep: bool) -> List[str]:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3820,6 +3820,7 @@ recommended as it is not supported on some platforms''')
 
         dependencies_typelist = [
             ('name', str),
+            ('version', str),
             ('compile_args', list),
             ('link_args', list),
         ]


### PR DESCRIPTION
With this PR, dependency versions are also logged for cached dependencies. Additionally, the `(cached)` and dependency version are now highlighted to help users identify potential caching issues.

The dependency version is now also visible in the introspection API.

This PR should resolve #6181.