### PR TITLE
added --clearcache to meson setup

### DIFF
--- a/docs/markdown/snippets/clearcache.md
+++ b/docs/markdown/snippets/clearcache.md
@@ -1,0 +1,4 @@
+## Added `--clearcache` to meson setup
+
+The new `--clearcache` behaves similar to `--reconfigure` it, however,
+clears internal meson cache for dependencies, etc.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -436,6 +436,11 @@ class CoreData:
             raise MesonException('Cannot find specified {} file: {}'.format(ftype, f))
         return real
 
+    def clear_cache(self):
+        self.deps.host.clear()
+        self.deps.build.clear()
+        self.compiler_check_cache.clear()
+
     def libdir_cross_fixup(self):
         # By default set libdir to "lib" when cross compiling since
         # getting the "system default" is always wrong on multiarch
@@ -839,7 +844,7 @@ def get_cmd_line_options(build_dir, options):
 def major_versions_differ(v1, v2):
     return v1.split('.')[0:2] != v2.split('.')[0:2]
 
-def load(build_dir):
+def load(build_dir: str) -> CoreData:
     filename = os.path.join(build_dir, 'meson-private', 'coredata.dat')
     load_fail_msg = 'Coredata file {!r} is corrupted. Try with a fresh build tree.'.format(filename)
     try:

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -70,8 +70,7 @@ class Conf:
             raise ConfException('Directory {} is neither a Meson build directory nor a project source directory.'.format(build_dir))
 
     def clear_cache(self):
-        self.coredata.deps.host.clear()
-        self.coredata.deps.build.clear()
+        self.coredata.clear_cache()
 
     def set_options(self, options):
         self.coredata.set_options(options)


### PR DESCRIPTION
This new flag behaves exactly like --reconfigure, but it also clears the dependency and compiler cache.

Related issues: #6180, #5849, #3794