### PR TITLE
environment: Only check compiler basename for compiler name

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -838,6 +838,8 @@ class Environment:
         for compiler in compilers:
             if isinstance(compiler, str):
                 compiler = [compiler]
+            compiler_name = os.path.basename(compiler[0])
+
             if not set(['cl', 'cl.exe', 'clang-cl', 'clang-cl.exe']).isdisjoint(compiler):
                 # Watcom C provides it's own cl.exe clone that mimics an older
                 # version of Microsoft's compiler. Since Watcom's cl.exe is
@@ -858,11 +860,11 @@ class Environment:
                     if found_cl in watcom_cls:
                         continue
                 arg = '/?'
-            elif 'armcc' in compiler[0]:
+            elif 'armcc' in compiler_name:
                 arg = '--vsn'
-            elif 'ccrx' in compiler[0]:
+            elif 'ccrx' in compiler_name:
                 arg = '-v'
-            elif 'icl' in compiler[0]:
+            elif 'icl' in compiler_name:
                 # if you pass anything to icl you get stuck in a pager
                 arg = ''
             else:
@@ -874,7 +876,7 @@ class Environment:
                 popen_exceptions[' '.join(compiler + [arg])] = e
                 continue
 
-            if 'ccrx' in compiler[0]:
+            if 'ccrx' in compiler_name:
                 out = err
 
             full_version = out.split('\n', 1)[0]


### PR DESCRIPTION
Nix uses absolute paths to compilers in Nix store with Meson. Those store paths contain a hash, which can contain short strings like `icl`, resulting in incorrectly matching the compiler.

See https://github.com/NixOS/nixpkgs/issues/73417#issuecomment-554077964

cc @dcbaker who introduced `icl` in https://github.com/mesonbuild/meson/pull/5331, @Ericson2314