### PR TITLE
docs: fix non-existent "meson rewriter" command in examples [skip ci]

### DIFF
--- a/docs/markdown/Rewriter.md
+++ b/docs/markdown/Rewriter.md
@@ -80,13 +80,13 @@ It is also possible to set kwargs of specific functions with the rewriter. The
 general command for setting or removing kwargs is:
 
 ```bash
-meson rewriter kwargs {set/delete} <function type> <function ID> <key1> <value1> <key2> <value2> ...
+meson rewrite kwargs {set/delete} <function type> <function ID> <key1> <value1> <key2> <value2> ...
 ```
 
 For instance, setting the project version can be achieved with this command:
 
 ```bash
-meson rewriter kwargs set project / version 1.0.0
+meson rewrite kwargs set project / version 1.0.0
 ```
 
 Currently, only the following function types are supported:
@@ -95,7 +95,7 @@ Currently, only the following function types are supported:
 - target (any build target, the function ID is the target name/ID)
 - project (the function ID must be `/` since project() can only be called once)
 
-For more information see the help output of the rewriter kwargs command.
+For more information see the help output of the rewrite kwargs command.
 
 ### Setting the project default options
 


### PR DESCRIPTION
Probably dating back to the former mesonrewriter command?

Fixes commit d4fe805a51d5

In some corner cases, "rewriter" could be mistaken as a positional
argument.