### PR TITLE
commandrunner: Forward KeyboardInterrupt to command

### DIFF
--- a/mesonbuild/scripts/commandrunner.py
+++ b/mesonbuild/scripts/commandrunner.py
@@ -71,7 +71,12 @@ def run(args):
         command = args[4]
         arguments = args[5:]
     pc = run_command(src_dir, build_dir, subdir, meson_command, command, arguments)
-    pc.wait()
+    while True:
+        try:
+            pc.wait()
+            break
+        except KeyboardInterrupt:
+            pass
     return pc.returncode
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some commands, notably gdb, use ctrl+c themselves to perform actions
without exiting. Instead of making meson exit and thus, kill the
subprocess, ignore the KeyboardInterrupt and continue waiting for
the child.