### PR TITLE
Raises exception when using coverage with clang

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -320,6 +320,9 @@ int dummy;
             self.generate_dist()
             if 'b_coverage' in self.environment.coredata.base_options and \
                     self.environment.coredata.base_options['b_coverage'].value:
+                if 'clang' in repr(self.environment.coredata.compilers[MachineChoice['BUILD']]['c']):
+                    raise mesonlib.EnvironmentException(
+                            'Meson does not support coverage builds with Clang')
                 self.add_build_comment(NinjaComment('Coverage rules'))
                 self.generate_coverage_rules()
             self.add_build_comment(NinjaComment('Suffix'))

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -322,7 +322,7 @@ int dummy;
                     self.environment.coredata.base_options['b_coverage'].value:
                 if 'clang' in repr(self.environment.coredata.compilers[MachineChoice['BUILD']]['c']):
                     raise mesonlib.EnvironmentException(
-                            'Meson does not support coverage builds with Clang')
+                        'Meson does not support coverage builds with Clang')
                 self.add_build_comment(NinjaComment('Coverage rules'))
                 self.generate_coverage_rules()
             self.add_build_comment(NinjaComment('Suffix'))


### PR DESCRIPTION
Per #6160, it seems like meson does not actually support coverage builds with clang.  Currently, it fails in an unexpected way.  This causes it to raise an exception at configuration time, indicating to the user that clang is not supported with coverage builds.

Opening this as draft because the only way I found to check if meson is using clang is really janky.  What would be the "correct" way to do this?  Am I on the right path raising an exception here?  

I also understand I'll need to provide a test for this.  Currently, I'm using `meson init` to make a simple one test C project and the building with `CC=clang` and `-Db_coverage=true`.  Should I be adding that to the tests, or would we prefer just a unit test that proves the exception is raised?