### PR TITLE
lint+mypy: move to github actions

### DIFF
--- a/.github/workflows/lint_mypy.yml
+++ b/.github/workflows/lint_mypy.yml
@@ -1,0 +1,33 @@
+name: LintMypy
+
+on:
+  push:
+    paths:
+    - "**.py"
+    - ".github/workflows/lint_mypy.yml"
+  pull_request:
+    paths:
+    - "**.py"
+    - ".github/workflows/lint_mypy.yml"
+
+jobs:
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - run: python -m pip install pylint
+    - run: pylint mesonbuild
+
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - run: python -m pip install mypy
+    - run: mypy --follow-imports=skip  mesonbuild/mtest.py mesonbuild/minit.py mesonbuild/msetup.py mesonbuild/wrap tools/ mesonbuild/modules/fs.py

--- a/.github/workflows/unusedargs_missingreturn.yml
+++ b/.github/workflows/unusedargs_missingreturn.yml
@@ -5,14 +5,14 @@ name: UnusedMissingReturn
 on:
   push:
     paths:
-    - "**.yml"
+    - ".github/workflows/unusedargs_missingreturn.yml"
     - "test cases/cmake/**"
     - "test cases/common/**"
     - "test cases/fortran/**"
     - "test cases/platform-linux/**"
   pull_request:
     paths:
-    - "**.yml"
+    - ".github/workflows/unusedargs_missingreturn.yml"
     - "test cases/cmake/**"
     - "test cases/common/**"
     - "test cases/fortran/**"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,21 +11,6 @@ variables:
   CI: 1
 
 jobs:
-- job: PylintMyPy
-  pool:
-    vmImage: ubuntu-latest
-
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.7'
-      addToPath: true
-  - script: python -m pip install pylint mypy
-    displayName: 'Install Pylint, MyPy'
-  - script: pylint mesonbuild
-    displayName: Lint Checks
-  - script: mypy --follow-imports=skip  mesonbuild/mtest.py mesonbuild/minit.py mesonbuild/msetup.py mesonbuild/wrap tools/ mesonbuild/modules/fs.py
-
 
 - job: vs2015
   pool:


### PR DESCRIPTION
Free up Azure resources and only run when Python code is changed for MyPy and Pylint, using GitHub Actions.  In general Actions will let us better cover Meson's particular features such as dependencies without overburdening general CI and the docker image.