### PR TITLE
dep: Fortran Coarrays-enhance finding by use Pkg-config & CMake

### DIFF
--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -19,7 +19,8 @@ from .base import (  # noqa: F401
     ExternalDependency, NotFoundDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
     PkgConfigDependency, CMakeDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language)
 from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDependency
-from .misc import (BlocksDependency, CoarrayDependency, HDF5Dependency, MPIDependency, NetCDFDependency, OpenMPDependency, Python3Dependency, ThreadDependency, PcapDependency, CupsDependency, LibWmfDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency)
+from .coarrays import CoarrayDependency
+from .misc import (BlocksDependency, HDF5Dependency, MPIDependency, NetCDFDependency, OpenMPDependency, Python3Dependency, ThreadDependency, PcapDependency, CupsDependency, LibWmfDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency)
 from .platform import AppleFrameworks
 from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, VulkanDependency
 

--- a/mesonbuild/dependencies/coarrays.py
+++ b/mesonbuild/dependencies/coarrays.py
@@ -1,0 +1,70 @@
+# Copyright 2013-2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .base import CMakeDependency, ExternalDependency, PkgConfigDependency
+
+
+class CoarrayDependency(ExternalDependency):
+    """
+    Coarrays are a Fortran 2008 feature.
+
+    Coarrays are sometimes implemented via external library (GCC+OpenCoarrays),
+    while other compilers just build in support (Cray, IBM, Intel, NAG).
+    Coarrays may be thought of as a high-level language abstraction of
+    low-level MPI calls.
+    """
+    def __init__(self, environment, kwargs: dict):
+        super().__init__('coarray', environment, 'fortran', kwargs)
+        kwargs['required'] = False
+        kwargs['silent'] = True
+        self.is_found = False
+
+        cid = self.get_compiler().get_id()
+        if cid == 'gcc':
+            """ OpenCoarrays is the most commonly used method for Fortran Coarray with GCC """
+            # first try pkg-config
+            for pkg in ['caf-openmpi', 'caf']:
+                pkgdep = PkgConfigDependency(pkg, environment, kwargs, language=self.language)
+                if pkgdep.found():
+                    self.compile_args = pkgdep.get_compile_args()
+                    self.link_args = pkgdep.get_link_args()
+                    self.version = pkgdep.get_version()
+                    self.is_found = True
+                    self.pcdep = pkgdep
+                    return
+            # second try CMake
+            kwargs['modules'] = 'OpenCoarrays::caf_mpi'
+            cmakedep = CMakeDependency('OpenCoarrays', environment, kwargs)
+            if cmakedep.found():
+                self.compile_args = cmakedep.get_compile_args()
+                self.link_args = cmakedep.get_link_args()
+                self.version = cmakedep.get_version()
+                self.is_found = True
+                return
+            # give up, just run as single image fallback
+            self.compile_args = ['-fcoarray=single']
+            self.version = 'single image'
+            self.is_found = True
+        elif cid == 'intel':
+            """ Coarrays are built into Intel compilers, no external library needed """
+            self.is_found = True
+            self.link_args = ['-coarray=shared']
+            self.compile_args = self.link_args
+        elif cid == 'intel-cl':
+            """ Coarrays are built into Intel compilers, no external library needed """
+            self.is_found = True
+            self.compile_args = ['/Qcoarray:shared']
+        elif cid == 'nagfor':
+            """ NAG doesn't require any special arguments for Coarray """
+            self.is_found = True

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2017 The Meson development team
+# Copyright 2013-2019 The Meson development team
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,49 +30,6 @@ from .base import (
     ExternalProgram, ExtraFrameworkDependency, PkgConfigDependency,
     CMakeDependency, ConfigToolDependency,
 )
-
-
-class CoarrayDependency(ExternalDependency):
-    """
-    Coarrays are a Fortran 2008 feature.
-
-    Coarrays are sometimes implemented via external library (GCC+OpenCoarrays),
-    while other compilers just build in support (Cray, IBM, Intel, NAG).
-    Coarrays may be thought of as a high-level language abstraction of
-    low-level MPI calls.
-    """
-    def __init__(self, environment, kwargs):
-        super().__init__('coarray', environment, 'fortran', kwargs)
-        kwargs['required'] = False
-        kwargs['silent'] = True
-        self.is_found = False
-
-        cid = self.get_compiler().get_id()
-        if cid == 'gcc':
-            """ OpenCoarrays is the most commonly used method for Fortran Coarray with GCC """
-            self.is_found = True
-            kwargs['modules'] = 'OpenCoarrays::caf_mpi'
-            cmakedep = CMakeDependency('OpenCoarrays', environment, kwargs)
-            if not cmakedep.found():
-                self.compile_args = ['-fcoarray=single']
-                self.version = 'single image'
-                return
-
-            self.compile_args = cmakedep.get_compile_args()
-            self.link_args = cmakedep.get_link_args()
-            self.version = cmakedep.get_version()
-        elif cid == 'intel':
-            """ Coarrays are built into Intel compilers, no external library needed """
-            self.is_found = True
-            self.link_args = ['-coarray=shared']
-            self.compile_args = self.link_args
-        elif cid == 'intel-cl':
-            """ Coarrays are built into Intel compilers, no external library needed """
-            self.is_found = True
-            self.compile_args = ['/Qcoarray:shared']
-        elif cid == 'nagfor':
-            """ NAG doesn't require any special arguments for Coarray """
-            self.is_found = True
 
 
 class HDF5Dependency(ExternalDependency):

--- a/test cases/fortran/13 coarray/meson.build
+++ b/test cases/fortran/13 coarray/meson.build
@@ -2,10 +2,9 @@ project('Fortran coarray', 'fortran',
   meson_version: '>=0.50')
 
 fc = meson.get_compiler('fortran')
-fcid = fc.get_id()
 
-if ['pgi', 'flang'].contains(fcid)
-  error('MESON_SKIP_TEST: At least through PGI 19.4 and Flang 7.1 do not support Fortran Coarrays.')
+if ['pgi', 'flang'].contains(fc.get_id())
+  error('MESON_SKIP_TEST: At least through PGI 19.10 and Flang 7.1 do not support Fortran Coarrays.')
 endif
 
 # coarray is required because single-image fallback is an intrinsic feature
@@ -15,12 +14,11 @@ coarray = dependency('coarray')
 # for example, conflicting library/compiler versions on PATH
 # this has to invoke a run of "sync all" to verify the MPI stack is functioning,
 # particularly for dynamic linking
-coarray_ok = fc.run('sync all; end', dependencies: coarray, name: 'Coarray link & run').returncode() == 0
-if not coarray_ok
-  error('MESON_SKIP_TEST: The coarray stack (including MPI) did not link correctly so that a simple test could run.')
+if fc.run('sync all; end', dependencies: coarray, name: 'Coarray link & run').returncode() != 0
+  error('The coarray stack (including MPI) did not link correctly so that a simple test could run.')
 endif
 
 exe = executable('hello', 'main.f90',
   dependencies : coarray)
 
-test('Coarray hello world', exe)
+test('Coarray hello world', exe, timeout: 10)


### PR DESCRIPTION
now the Fortran coarray dep finding uses pkg-config as well as cmake, since pkg-config was added to coarrays package opencoarrays.

Put dependency in its own file for clarity