### PR TITLE
fs: add methods as_posix, is_absolute, expanduser, stem

### DIFF
--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -42,6 +42,8 @@ by the string is a symbolic link.
 
 ### is_absolute
 
+*since 0.54.0*
+
 Return a boolean indicating if the path string specified is absolute, WITHOUT expanding `~`.
 
 Examples:
@@ -104,17 +106,21 @@ The files need not actually exist yet for these path string manipulation methods
 
 ### expanduser
 
+*since 0.54.0*
+
 A path string with a leading `~` is expanded to the user home directory
 
 Examples:
 
 ```meson
-fs.expanduser('~')  # home directory
+fs.expanduser('~')  # user home directory
 
 fs.expanduser('~/foo')  # <homedir>/foo
 ```
 
 ### as_posix
+
+*since 0.54.0*
 
 `fs.as_posix(path)` assumes a Windows path, even if on a Unix-like system.
 Thus, all `'\'` or `'\\'` are turned to '/', even if you meant to escape a character.
@@ -179,6 +185,8 @@ fs.name('foo/bar/baz.dll.a')  # baz.dll.a
 ```
 
 ### stem
+
+*since 0.54.0*
 
 Returns the last component of the path, dropping the last part of the suffix
 

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -10,6 +10,8 @@ current `meson.build` file is.
 
 If specified, a leading `~` is expanded to the user home directory.
 
+Where possible, symlinks and parent directory notation are resolved to an absolute path.
+
 ### exists
 
 Takes a single string argument and returns true if an entity with that
@@ -19,13 +21,12 @@ special entry such as a device node.
 ### is_dir
 
 Takes a single string argument and returns true if a directory with
-that name exists on the file system. This method follows symbolic
-links.
+that name exists on the file system.
 
 ### is_file
 
 Takes a single string argument and returns true if an file with that
-name exists on the file system. This method follows symbolic links.
+name exists on the file system.
 
 ### is_symlink
 
@@ -33,6 +34,23 @@ Takes a single string argument and returns true if the path pointed to
 by the string is a symbolic link.
 
 ## File Parameters
+
+### is_absolute
+
+Return a boolean indicating if the path string specified is absolute for this computer, WITHOUT expanding `~`.
+
+Examples:
+
+```meson
+fs.is_absolute('~')   # false unless you literally have a path with string name `~`
+
+home = fs.expanduser('~')
+fs.is_absolute(home)  # true
+
+fs.is_absolute(home / 'foo')  # true, even if ~/foo doesn't exist
+
+fs.is_absolute('foo/bar')  # false, even if ./foo/bar exists
+```
 
 ### hash
 
@@ -44,7 +62,6 @@ md5, sha1, sha224, sha256, sha384, sha512.
 ### size
 
 The `fs.size(filename)` method returns the size of the file in integer bytes.
-Symlinks will be resolved if possible.
 
 ### is_samepath
 
@@ -79,7 +96,21 @@ fs.is_samepath(p, s)  # false
 
 ## Filename modification
 
-The files need not actually exist yet for this method, as it's just string manipulation.
+The files need not actually exist yet for these methods, as they are just string manipulation.
+
+### as_posix
+
+`fs.as_posix(path)` assumes a Windows path, even if on a Unix-like system.
+Thus, all `'\'` or `'\\'` are turned to '/', even if you meant to escape a character.
+
+Examples
+
+```meson
+fs.as_posix('\\') == '/'  # true
+fs.as_posix('\\\\') == '/'  # true
+
+fs.as_posix('foo\\bar/baz') == 'foo/bar/baz'  # true
+```
 
 ### replace_suffix
 

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -37,7 +37,7 @@ by the string is a symbolic link.
 
 ### is_absolute
 
-Return a boolean indicating if the path string specified is absolute for this computer, WITHOUT expanding `~`.
+Return a boolean indicating if the path string specified is absolute, WITHOUT expanding `~`.
 
 Examples:
 
@@ -96,7 +96,19 @@ fs.is_samepath(p, s)  # false
 
 ## Filename modification
 
-The files need not actually exist yet for these methods, as they are just string manipulation.
+The files need not actually exist yet for these path string manipulation methods.
+
+### expanduser
+
+A path string with a leading `~` is expanded to the user home directory
+
+Examples:
+
+```meson
+fs.expanduser('~')  # home directory
+
+fs.expanduser('~/foo')  # <homedir>/foo
+```
 
 ### as_posix
 

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -9,8 +9,13 @@ Non-absolute paths are looked up relative to the directory where the
 current `meson.build` file is.
 
 If specified, a leading `~` is expanded to the user home directory.
+Environment variables are not available as is the rule throughout Meson.
+That is, $HOME, %USERPROFILE%, $MKLROOT, etc. have no meaning to the Meson
+filesystem module. If needed, pass such variables into Meson via command
+line options in `meson_options.txt`, native-file or cross-file.
 
-Where possible, symlinks and parent directory notation are resolved to an absolute path.
+Where possible, symlinks and parent directory notation are resolved to an
+absolute path.
 
 ### exists
 
@@ -42,7 +47,7 @@ Return a boolean indicating if the path string specified is absolute, WITHOUT ex
 Examples:
 
 ```meson
-fs.is_absolute('~')   # false unless you literally have a path with string name `~`
+fs.is_absolute('~')   # false
 
 home = fs.expanduser('~')
 fs.is_absolute(home)  # true
@@ -84,7 +89,7 @@ fs.is_samepath(x, z)  # true
 fs.is_samepath(x, j)  # false
 
 p = 'foo/bar'
-q = 'foo/bar/../baz'
+q = 'foo/bar/baz/..'
 r = 'buz'  # a symlink pointing to foo/bar
 s = 'notapath'  # non-existant directory
 
@@ -92,7 +97,6 @@ fs.is_samepath(p, q)  # true
 fs.is_samepath(p, r)  # true
 fs.is_samepath(p, s)  # false
 ```
-
 
 ## Filename modification
 

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -165,6 +165,24 @@ new = fs.replace_suffix(original, '')  # /opt/foo.dll
 
 Returns the parent directory (i.e. dirname).
 
+```meson
+new = fs.parent('foo/bar')  # foo
+new = fs.parent('foo/bar/baz.dll')  # foo/bar
+```
+
 ### name
 
 Returns the last component of the path (i.e. basename).
+
+```meson
+fs.name('foo/bar/baz.dll.a')  # baz.dll.a
+```
+
+### stem
+
+Returns the last component of the path, dropping the last part of the suffix
+
+```meson
+fs.stem('foo/bar/baz.dll')  # baz
+fs.stem('foo/bar/baz.dll.a')  # baz.dll
+```

--- a/docs/theme/extra/templates/navbar_links.html
+++ b/docs/theme/extra/templates/navbar_links.html
@@ -1,22 +1,28 @@
 @require(page)
 
 <li class="dropdown">
-	<a class="dropdown-toggle" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-		Modules <span class="caret"></span>
-	</a>
-	<ul class="dropdown-menu" id="modules-menu">
-		@for tup in (("Fs-module.html","Filesystem"), \
-		       ("Gnome-module.html","GNOME"), \
-			     ("i18n-module.html","i18n"), \
-			     ("Pkgconfig-module.html","Pkgconfig"), \
-			     ("Python-module.html","Python"), \
-			     ("Python-3-module.html","Python 3"), \
-			     ("Qt4-module.html","Qt4"), \
-			     ("Qt5-module.html","Qt5"), \
-			     ("RPM-module.html","RPM"), \
-			     ("SourceSet-module.html","SourceSet"), \
-			     ("Windows-module.html","Windows"), \
-			     ("Hotdoc-module.html","Hotdoc")):
+  <a class="dropdown-toggle" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    Modules <span class="caret"></span>
+  </a>
+  <ul class="dropdown-menu" id="modules-menu">
+    @for tup in ( \
+					 ("CMake-module.html","CMake"), \
+					 ("Cuda-module.html","CUDA"), \
+           ("Dlang-module.html","Dlang"), \
+           ("Fs-module.html","Filesystem"), \
+					 ("Gnome-module.html","GNOME"), \
+					 ("Hotdoc-module.html","Hotdoc"), \
+					 ("i18n-module.html","i18n"), \
+					 ("Icestorm-module.html","Icestorm"), \
+					 ("Kconfig-module.html","kconfig"), \
+           ("Pkgconfig-module.html","Pkgconfig"), \
+           ("Python-module.html","Python"), \
+           ("Python-3-module.html","Python 3"), \
+           ("Qt4-module.html","Qt4"), \
+           ("Qt5-module.html","Qt5"), \
+           ("RPM-module.html","RPM"), \
+           ("SourceSet-module.html","SourceSet"), \
+           ("Windows-module.html","Windows")):
 			<li>
 				<a href="@tup[0]">@tup[1]</a>
 			</li>
@@ -30,11 +36,11 @@
 	</a>
 	<ul class="dropdown-menu" id="quick-refs-menu">
 		@for tup in (("Reference-manual.html", "Functions"), \
-			     ("Build-options.html", "Options"), \
-			     ("Configuration.html", "Configuration"), \
-			     ("Dependencies.html", "Dependencies"), \
-			     ("Unit-tests.html", "Tests"), \
-			     ("Syntax.html", "Syntax")):
+           ("Build-options.html", "Options"), \
+           ("Configuration.html", "Configuration"), \
+           ("Dependencies.html", "Dependencies"), \
+           ("Unit-tests.html", "Tests"), \
+           ("Syntax.html", "Syntax")):
 			<li>
 				<a href="@tup[0]">@tup[1]</a>
 			</li>

--- a/docs/theme/extra/templates/navbar_links.html
+++ b/docs/theme/extra/templates/navbar_links.html
@@ -5,7 +5,8 @@
 		Modules <span class="caret"></span>
 	</a>
 	<ul class="dropdown-menu" id="modules-menu">
-		@for tup in (("Gnome-module.html","GNOME"), \
+		@for tup in (("Fs-module.html","Filesystem"), \
+		       ("Gnome-module.html","GNOME"), \
 			     ("i18n-module.html","i18n"), \
 			     ("Pkgconfig-module.html","Pkgconfig"), \
 			     ("Python-module.html","Python"), \

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -20,6 +20,7 @@ from .. import mlog
 from . import ExtensionModule
 from . import ModuleReturnValue
 from ..mesonlib import MesonException
+from ..interpreterbase import FeatureNew
 
 from ..interpreterbase import stringArgs, noKwargs
 if T.TYPE_CHECKING:
@@ -62,6 +63,7 @@ class FSModule(ExtensionModule):
 
     @stringArgs
     @noKwargs
+    @FeatureNew('fs.expanduser', '0.54.0')
     def expanduser(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
         if len(args) != 1:
             raise MesonException('fs.expanduser takes exactly one argument.')
@@ -69,6 +71,7 @@ class FSModule(ExtensionModule):
 
     @stringArgs
     @noKwargs
+    @FeatureNew('fs.is_absolute', '0.54.0')
     def is_absolute(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
         if len(args) != 1:
             raise MesonException('fs.is_absolute takes exactly one argument.')
@@ -76,6 +79,7 @@ class FSModule(ExtensionModule):
 
     @stringArgs
     @noKwargs
+    @FeatureNew('fs.as_posix', '0.54.0')
     def as_posix(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
         """
         this function assumes you are passing a Windows path, even if on a Unix-like system
@@ -181,6 +185,7 @@ class FSModule(ExtensionModule):
 
     @stringArgs
     @noKwargs
+    @FeatureNew('fs.stem', '0.54.0')
     def stem(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
         if len(args) != 1:
             raise MesonException('fs.stem takes exactly one argument.')

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -14,7 +14,7 @@
 
 import typing as T
 import hashlib
-from pathlib import Path, PurePath
+from pathlib import Path, PurePath, PureWindowsPath
 
 from .. import mlog
 from . import ExtensionModule
@@ -59,6 +59,13 @@ class FSModule(ExtensionModule):
         if isinstance(val, Path):
             val = str(val)
         return ModuleReturnValue(val, [])
+
+    @stringArgs
+    @noKwargs
+    def expanduser(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+        if len(args) != 1:
+            raise MesonException('fs.expanduser takes exactly one argument.')
+        return ModuleReturnValue(str(Path(args[0]).expanduser()), [])
 
     @stringArgs
     @noKwargs

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -165,7 +165,7 @@ class FSModule(ExtensionModule):
     @noKwargs
     def parent(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
         if len(args) != 1:
-            raise MesonException('method takes exactly one argument.')
+            raise MesonException('fs.parent takes exactly one argument.')
         original = PurePath(args[0])
         new = original.parent
         return ModuleReturnValue(str(new), [])
@@ -174,9 +174,18 @@ class FSModule(ExtensionModule):
     @noKwargs
     def name(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
         if len(args) != 1:
-            raise MesonException('method takes exactly one argument.')
+            raise MesonException('fs.name takes exactly one argument.')
         original = PurePath(args[0])
         new = original.name
+        return ModuleReturnValue(str(new), [])
+
+    @stringArgs
+    @noKwargs
+    def stem(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+        if len(args) != 1:
+            raise MesonException('fs.stem takes exactly one argument.')
+        original = PurePath(args[0])
+        new = original.stem
         return ModuleReturnValue(str(new), [])
 
 def initialize(*args, **kwargs) -> FSModule:

--- a/test cases/common/227 fs module/meson.build
+++ b/test cases/common/227 fs module/meson.build
@@ -30,8 +30,12 @@ assert(fs.is_dir('subprojects'), 'Dir not detected correctly.')
 assert(not fs.is_dir('meson.build'), 'File detected as a dir.')
 assert(not fs.is_dir('nonexisting'), 'Bad path detected as a dir.')
 
-assert(fs.is_dir('~'), 'expanduser not working')
-assert(not fs.is_file('~'), 'expanduser not working')
+assert(fs.is_dir('~'), 'home directory not detected')
+assert(not fs.is_file('~'), 'home directory detected as file')
+
+# -- expanduser
+assert(fs.expanduser('~') != '~','expanduser failed')
+assert(fs.expanduser('~/foo').endswith('foo'), 'expanduser with tail failed')
 
 # -- as_posix
 assert(fs.as_posix('/') == '/', 'as_posix idempotent')

--- a/test cases/common/227 fs module/meson.build
+++ b/test cases/common/227 fs module/meson.build
@@ -107,7 +107,11 @@ if not is_windows and build_machine.system() != 'cygwin' and is_git_checkout
   assert(fs.is_samepath('a_symlink', 'meson.build'), 'symlink is_samepath fail')
 endif
 
+# parts of path
 assert(fs.parent('foo/bar') == 'foo', 'failed to get dirname')
 assert(fs.name('foo/bar') == 'bar', 'failed to get basename')
+assert(fs.name('foo/bar/baz.dll.a') == 'baz.dll.a', 'failed to get basename with compound suffix')
+assert(fs.stem('foo/bar/baz.dll') == 'baz', 'failed to get stem with suffix')
+assert(fs.stem('foo/bar/baz.dll.a') == 'baz.dll', 'failed to get stem with compound suffix')
 
 subdir('subdir')

--- a/test cases/common/227 fs module/meson.build
+++ b/test cases/common/227 fs module/meson.build
@@ -33,6 +33,28 @@ assert(not fs.is_dir('nonexisting'), 'Bad path detected as a dir.')
 assert(fs.is_dir('~'), 'expanduser not working')
 assert(not fs.is_file('~'), 'expanduser not working')
 
+# -- as_posix
+assert(fs.as_posix('/') == '/', 'as_posix idempotent')
+assert(fs.as_posix('\\') == '/', 'as_posix simple')
+assert(fs.as_posix('\\\\') == '/', 'as_posix simple')
+assert(fs.as_posix('foo\\bar/baz') == 'foo/bar/baz', 'as_posix mixed slash')
+
+# -- is_absolute
+winabs = 'q:/foo'
+unixabs = '/foo'
+if is_windows
+  assert(fs.is_absolute(winabs), 'is_absolute windows not detected')
+  assert(not fs.is_absolute(unixabs), 'is_absolute unix false positive')
+else
+  assert(fs.is_absolute(unixabs), 'is_absolute unix not detected')
+  assert(not fs.is_absolute(winabs), 'is_absolute windows false positive')
+endif
+
+# -- replace_suffix
+
+original = 'foo'
+assert(fs.replace_suffix(original, '') == original, 'replace_suffix idempotent')
+
 original = 'foo.txt'
 new = fs.replace_suffix(original, '.ini')
 assert(new == 'foo.ini', 'replace_suffix failed')


### PR DESCRIPTION
...more functions that those dev'ing on or for Windows can find handy.

These address issues for those needing to make complex library stacks just work on windows and unix-like systems without mucking around deep inside Meson. 

Specifically:

* expanduser: this allows users to in a cross-platform way specify directories under their home directory. Particularly important where admin/sudo access is not possible. Handy to use with #6161 for example.
* is_absolute: a lightweight check to see if meson.current_source_dir() or meson.source_root() should be prepended, if desired. 
* as_posix: facilitates comparing path strings in a cross platform way, and passing parameters to run_program() that need to be in posix-path forward slashes.
* stem: the last part of the path, dropping the last part of the suffix