### PR TITLE
CFLAGS=-Werror=strict-prototypes throughout Meson

### DIFF
--- a/.github/workflows/unusedargs_missingreturn.yml
+++ b/.github/workflows/unusedargs_missingreturn.yml
@@ -1,5 +1,8 @@
 name: UnusedMissingReturn
-# this workflow checks for usused input arguments or missing return values in test cases.
+# this workflow checks for
+# * unused input arguments
+# * missing return values
+# * strict prototypes
 # some users have default configs that will needlessly fail Meson self-tests due to these syntax.
 
 on:
@@ -33,6 +36,6 @@ jobs:
         sudo apt install -yq --no-install-recommends g++ gfortran ninja-build
     - run: python run_project_tests.py --only cmake common fortran platform-linux
       env:
-        CFLAGS: "-Werror=unused-parameter -Werror=return-type"
+        CFLAGS: "-Werror=unused-parameter -Werror=return-type -Werror=strict-prototypes"
         CPPFLAGS: "-Werror=unused-parameter -Werror=return-type"
         FFLAGS: "-fimplicit-none"

--- a/manual tests/9 nostdlib/prog.c
+++ b/manual tests/9 nostdlib/prog.c
@@ -1,7 +1,7 @@
 
 #include<stdio.h>
 
-int main() {
+int main(void) {
   const char *message = "Hello without stdlib.\n";
   return simple_print(message, simple_strlen(message));
 }

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -59,14 +59,14 @@ class CCompiler(CLikeCompiler, Compiler):
         return ['-nostdinc']
 
     def sanity_check(self, work_dir, environment):
-        code = 'int main() { int class=0; return class; }\n'
+        code = 'int main(void) { int class=0; return class; }\n'
         return self.sanity_check_impl(work_dir, environment, 'sanitycheckc.c', code)
 
     def has_header_symbol(self, hname, symbol, prefix, env, *, extra_args=None, dependencies=None):
         fargs = {'prefix': prefix, 'header': hname, 'symbol': symbol}
         t = '''{prefix}
         #include <{header}>
-        int main () {{
+        int main(void) {{
             /* If it's not defined as a macro, try to use as a symbol */
             #ifndef {symbol}
                 {symbol};

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -73,7 +73,7 @@ class CPPCompiler(CLikeCompiler, Compiler):
         return ['-nostdinc++']
 
     def sanity_check(self, work_dir, environment):
-        code = 'class breakCCompiler;int main() { return 0; }\n'
+        code = 'class breakCCompiler;int main(void) { return 0; }\n'
         return self.sanity_check_impl(work_dir, environment, 'sanitycheckcpp.cc', code)
 
     def get_compiler_check_args(self):
@@ -96,7 +96,7 @@ class CPPCompiler(CLikeCompiler, Compiler):
         t = '''{prefix}
         #include <{header}>
         using {symbol};
-        int main () {{ return 0; }}'''
+        int main(void) {{ return 0; }}'''
         return self.compiles(t.format(**fargs), env, extra_args=extra_args,
                              dependencies=dependencies)
 

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -174,7 +174,7 @@ class CudaCompiler(Compiler):
         t = '''{prefix}
         #include <{header}>
         using {symbol};
-        int main () {{ return 0; }}'''
+        int main(void) {{ return 0; }}'''
         return self.compiles(t.format(**fargs), env, extra_args, dependencies)
 
     def get_options(self):

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -785,7 +785,7 @@ class CLikeCompiler:
         code = '''#ifdef __cplusplus
         extern "C" {
         #endif
-        void ''' + symbol_name.decode() + ''' () {}
+        void ''' + symbol_name.decode() + ''' (void) {}
         #ifdef __cplusplus
         }
         #endif

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -634,7 +634,7 @@ class CLikeCompiler:
         #ifdef __cplusplus
         extern "C"
         #endif
-        char {func} ();
+        char {func} (void);
         '''
         # The actual function call
         main = '''

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -258,7 +258,7 @@ class CLikeCompiler:
             raise mesonlib.EnvironmentException('Executables created by {0} compiler {1} are not runnable.'.format(self.language, self.name_string()))
 
     def sanity_check(self, work_dir, environment):
-        code = 'int main() { int class=0; return class; }\n'
+        code = 'int main(void) { int class=0; return class; }\n'
         return self.sanity_check_impl(work_dir, environment, 'sanitycheckc.c', code)
 
     def check_header(self, hname, prefix, env, *, extra_args=None, dependencies=None):
@@ -285,7 +285,7 @@ class CLikeCompiler:
         fargs = {'prefix': prefix, 'header': hname, 'symbol': symbol}
         t = '''{prefix}
         #include <{header}>
-        int main () {{
+        int main(void) {{
             /* If it's not defined as a macro, try to use as a symbol */
             #ifndef {symbol}
                 {symbol};
@@ -398,7 +398,7 @@ class CLikeCompiler:
         fargs = {'prefix': prefix, 'expression': expression}
         t = '''#include <stdio.h>
         {prefix}
-        int main() {{ static int a[1-2*!({expression})]; a[0]=0; return 0; }}'''
+        int main(void) {{ static int a[1-2*!({expression})]; a[0]=0; return 0; }}'''
         return self.compiles(t.format(**fargs), env, extra_args=extra_args,
                              dependencies=dependencies)[0]
 
@@ -458,7 +458,7 @@ class CLikeCompiler:
         fargs = {'prefix': prefix, 'expression': expression}
         t = '''#include<stdio.h>
         {prefix}
-        int main() {{
+        int main(void) {{
             printf("%ld\\n", (long)({expression}));
             return 0;
         }};'''
@@ -476,7 +476,7 @@ class CLikeCompiler:
         fargs = {'prefix': prefix, 'type': typename}
         t = '''#include <stdio.h>
         {prefix}
-        int main() {{
+        int main(void) {{
             {type} something;
             return 0;
         }}'''
@@ -494,7 +494,7 @@ class CLikeCompiler:
                                      dependencies=dependencies)
         t = '''#include<stdio.h>
         {prefix}
-        int main() {{
+        int main(void) {{
             printf("%ld\\n", (long)(sizeof({type})));
             return 0;
         }};'''
@@ -512,7 +512,7 @@ class CLikeCompiler:
         fargs = {'prefix': prefix, 'type': typename}
         t = '''#include <stdio.h>
         {prefix}
-        int main() {{
+        int main(void) {{
             {type} something;
             return 0;
         }}'''
@@ -541,7 +541,7 @@ class CLikeCompiler:
             char c;
             {type} target;
         }};
-        int main() {{
+        int main(void) {{
             printf("%d", (int)offsetof(struct tmp, target));
             return 0;
         }}'''
@@ -591,7 +591,7 @@ class CLikeCompiler:
         fargs = {'prefix': prefix, 'f': fname, 'cast': cast, 'fmt': fmt}
         code = '''{prefix}
         #include <stdio.h>
-        int main() {{
+        int main(void) {{
             printf ("{fmt}", {cast} {f}());
             return 0;
         }}'''.format(**fargs)
@@ -638,7 +638,7 @@ class CLikeCompiler:
         '''
         # The actual function call
         main = '''
-        int main () {{
+        int main(void) {{
           return {func} ();
         }}'''
         return head, main
@@ -657,7 +657,7 @@ class CLikeCompiler:
         # Just taking the address or comparing it to void is not enough because
         # compilers are smart enough to optimize it away. The resulting binary
         # is not run so we don't care what the return value is.
-        main = '''\nint main() {{
+        main = '''\nint main(void) {{
             void *a = (void*) &{func};
             long b = (long) a;
             return (int) b;
@@ -729,7 +729,7 @@ class CLikeCompiler:
         # can just directly use the __has_builtin() macro.
         fargs['no_includes'] = '#include' not in prefix
         t = '''{prefix}
-        int main() {{
+        int main(void) {{
         #ifdef __has_builtin
             #if !__has_builtin(__builtin_{func})
                 #error "__builtin_{func} not found"
@@ -761,7 +761,7 @@ class CLikeCompiler:
             members += '{}.{};\n'.format(fargs['name'], member)
         fargs['members'] = members
         t = '''{prefix}
-        void bar() {{
+        void bar(void) {{
             {type} {name};
             {members}
         }};'''
@@ -771,7 +771,7 @@ class CLikeCompiler:
     def has_type(self, typename, prefix, env, extra_args, dependencies=None):
         fargs = {'prefix': prefix, 'type': typename}
         t = '''{prefix}
-        void bar() {{
+        void bar(void) {{
             sizeof({type});
         }};'''
         return self.compiles(t.format(**fargs), env, extra_args=extra_args,
@@ -993,7 +993,7 @@ class CLikeCompiler:
         return value[:]
 
     def find_library(self, libname, env, extra_dirs, libtype: LibType = LibType.PREFER_SHARED):
-        code = 'int main() { return 0; }'
+        code = 'int main(void) { return 0; }'
         return self.find_library_impl(libname, env, extra_dirs, code, libtype)
 
     def find_framework_paths(self, env):
@@ -1023,7 +1023,7 @@ class CLikeCompiler:
         return paths
 
     def find_framework_real(self, name, env, extra_dirs, allow_system):
-        code = 'int main() { return 0; }'
+        code = 'int main(void) { return 0; }'
         link_args = []
         for d in extra_dirs:
             link_args += ['-F' + d]
@@ -1102,7 +1102,7 @@ class CLikeCompiler:
         # false positive.
         args = self.linker.fatal_warnings() + args
         args = self.linker_to_compiler_args(args)
-        code = 'int main() { return 0; }'
+        code = 'int main(void) { return 0; }'
         return self.has_arguments(args, env, code, mode='link')
 
     @staticmethod

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -48,7 +48,7 @@ class ObjCCompiler(CLikeCompiler, Compiler):
             extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)
         with open(source_name, 'w') as ofile:
             ofile.write('#import<stddef.h>\n'
-                        'int main() { return 0; }\n')
+                        'int main(void) { return 0; }\n')
         pc = subprocess.Popen(self.exelist + extra_flags + [source_name, '-o', binary_name])
         pc.wait()
         if pc.returncode != 0:

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -48,7 +48,7 @@ class ObjCPPCompiler(CLikeCompiler, Compiler):
         with open(source_name, 'w') as ofile:
             ofile.write('#import<stdio.h>\n'
                         'class MyClass;'
-                        'int main() { return 0; }\n')
+                        'int main(void) { return 0; }\n')
         pc = subprocess.Popen(self.exelist + extra_flags + [source_name, '-o', binary_name])
         pc.wait()
         if pc.returncode != 0:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3047,7 +3047,7 @@ int main(int argc, char **argv) {
             if lang in ('c', 'cpp'):
                 with tempfile.TemporaryDirectory() as tmpdir:
                     with open(os.path.join(tmpdir, 'foo.' + lang), 'w') as f:
-                        f.write('int main() {}')
+                        f.write('int main(void) {}')
                     self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
 
     # The test uses mocking and thus requires that
@@ -7006,4 +7006,4 @@ def main():
     return unittest.main(defaultTest=cases, buffer=True)
 
 if __name__ == '__main__':
-    sys.exit(main())
+    raise SystemExit(main())

--- a/test cases/cmake/1 basic/main.cpp
+++ b/test cases/cmake/1 basic/main.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-int main() {
+int main(void) {
   cmModClass obj("Hello");
   cout << obj.getStr() << endl;
   return 0;

--- a/test cases/cmake/10 header only/main.cpp
+++ b/test cases/cmake/10 header only/main.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-int main() {
+int main(void) {
   cmModClass obj("Hello");
   cout << obj.getStr() << endl;
   return 0;

--- a/test cases/cmake/12 generator expressions/main.cpp
+++ b/test cases/cmake/12 generator expressions/main.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-int main() {
+int main(void) {
   cmModClass obj("Hello");
   cout << obj.getStr() << endl;
   return 0;

--- a/test cases/cmake/13 system includes/main.cpp
+++ b/test cases/cmake/13 system includes/main.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-int main() {
+int main(void) {
   cmModClass obj("Hello");
   cout << obj.getStr() << endl;
   return 0;

--- a/test cases/cmake/2 advanced/main.cpp
+++ b/test cases/cmake/2 advanced/main.cpp
@@ -8,7 +8,7 @@
 
 using namespace std;
 
-int main() {
+int main(void) {
   cmModClass obj("Hello");
   cout << obj.getStr() << endl;
   return 0;

--- a/test cases/cmake/2 advanced/subprojects/cmMod/main.cpp
+++ b/test cases/cmake/2 advanced/subprojects/cmMod/main.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-int main() {
+int main(void) {
   cmModClass obj("Hello (LIB TEST)");
   cout << obj.getStr() << " ZLIB: " << zlibVersion() << endl;
   return 0;

--- a/test cases/cmake/3 advanced no dep/main.cpp
+++ b/test cases/cmake/3 advanced no dep/main.cpp
@@ -8,7 +8,7 @@
 
 using namespace std;
 
-int main() {
+int main(void) {
   cmModClass obj("Hello");
   cout << obj.getStr() << endl;
   return 0;

--- a/test cases/cmake/3 advanced no dep/subprojects/cmMod/main.cpp
+++ b/test cases/cmake/3 advanced no dep/subprojects/cmMod/main.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-int main() {
+int main(void) {
   cmModClass obj("Hello (LIB TEST)");
   cout << obj.getStr() << endl;
   return 0;

--- a/test cases/cmake/4 code gen/main.cpp
+++ b/test cases/cmake/4 code gen/main.cpp
@@ -3,6 +3,6 @@
 
 using namespace std;
 
-int main() {
+int main(void) {
   cout << getStr() << endl;
 }

--- a/test cases/cmake/5 object library/main.cpp
+++ b/test cases/cmake/5 object library/main.cpp
@@ -4,6 +4,6 @@
 
 using namespace std;
 
-int main() {
+int main(void) {
   cout << getLibStr() << " -- " << getZlibVers() << endl;
 }

--- a/test cases/cmake/6 object library no dep/main.cpp
+++ b/test cases/cmake/6 object library no dep/main.cpp
@@ -4,6 +4,6 @@
 
 using namespace std;
 
-int main() {
+int main(void) {
   cout << getLibStr() << " -- " << getZlibVers() << endl;
 }

--- a/test cases/cmake/8 custom command/main.cpp
+++ b/test cases/cmake/8 custom command/main.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-int main() {
+int main(void) {
   cmModClass obj("Hello");
   cout << obj.getStr() << endl;
   cout << obj.getOther() << endl;

--- a/test cases/common/102 subproject subdir/subprojects/sub/lib/sub.c
+++ b/test cases/common/102 subproject subdir/subprojects/sub/lib/sub.c
@@ -1,5 +1,5 @@
 #include "sub.h"
 
-int sub() {
+int sub(void) {
     return 0;
 }

--- a/test cases/common/102 subproject subdir/subprojects/sub/lib/sub.h
+++ b/test cases/common/102 subproject subdir/subprojects/sub/lib/sub.h
@@ -1,6 +1,6 @@
 #ifndef SUB_H
 #define SUB_H
 
-int sub();
+int sub(void);
 
 #endif

--- a/test cases/common/106 extract same name/lib.c
+++ b/test cases/common/106 extract same name/lib.c
@@ -1,3 +1,3 @@
-int func1() {
+int func1(void) {
     return 23;
 }

--- a/test cases/common/106 extract same name/main.c
+++ b/test cases/common/106 extract same name/main.c
@@ -1,5 +1,5 @@
-int func1();
-int func2();
+int func1(void);
+int func2(void);
 
 int main(void) {
     return !(func1() == 23 && func2() == 42);

--- a/test cases/common/106 extract same name/src/lib.c
+++ b/test cases/common/106 extract same name/src/lib.c
@@ -1,3 +1,3 @@
-int func2() {
+int func2(void) {
     return 42;
 }

--- a/test cases/common/114 allgenerate/foobar.cpp.in
+++ b/test cases/common/114 allgenerate/foobar.cpp.in
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int main() {
+int main(void) {
   printf("I am a program.\n");
   return 0;
 }

--- a/test cases/common/116 subdir subproject/subprojects/sub/sub.c
+++ b/test cases/common/116 subdir subproject/subprojects/sub/sub.c
@@ -1,5 +1,5 @@
 #include "sub.h"
 
-int sub() {
+int sub(void) {
     return 0;
 }

--- a/test cases/common/116 subdir subproject/subprojects/sub/sub.h
+++ b/test cases/common/116 subdir subproject/subprojects/sub/sub.h
@@ -1,6 +1,6 @@
 #ifndef SUB_H
 #define SUB_H
 
-int sub();
+int sub(void);
 
 #endif

--- a/test cases/common/119 subproject project arguments/exe.cpp
+++ b/test cases/common/119 subproject project arguments/exe.cpp
@@ -22,7 +22,7 @@
 #error
 #endif
 
-int main() {
+int main(void) {
     return 0;
 }
 

--- a/test cases/common/121 shared module/module.c
+++ b/test cases/common/121 shared module/module.c
@@ -71,7 +71,7 @@ fptr find_any_f (const char *name) {
 }
 #endif
 
-int DLL_PUBLIC func() {
+int DLL_PUBLIC func(void) {
     fptr f;
 
     f = find_any_f ("func_from_language_runtime");

--- a/test cases/common/121 shared module/module.c
+++ b/test cases/common/121 shared module/module.c
@@ -51,7 +51,7 @@ fptr find_any_f (const char *name) {
 
     snapshot = CreateToolhelp32Snapshot (TH32CS_SNAPMODULE, 0);
     if (snapshot == (HANDLE) -1) {
-        wchar_t *msg = win32_get_last_error ();
+        wchar_t *msg = win32_get_last_error();
         printf("Could not get snapshot: %S\n", msg);
         return 0;
     }
@@ -88,7 +88,7 @@ int DLL_PUBLIC func(void) {
  * dlopens it. We need to make sure that this works, i.e. that we do
  * not pass -Wl,--no-undefined when linking modules.
  */
-int func_from_language_runtime();
+int func_from_language_runtime(void);
 
 int DLL_PUBLIC func(void) {
     return func_from_language_runtime();

--- a/test cases/common/122 llvm ir and assembly/main.cpp
+++ b/test cases/common/122 llvm ir and assembly/main.cpp
@@ -4,7 +4,7 @@ extern "C" {
   unsigned square_unsigned (unsigned a);
 }
 
-int main ()
+int main (void)
 {
   unsigned int ret = square_unsigned (2);
   if (ret != 4) {

--- a/test cases/common/123 cpp and asm/trivial.cc
+++ b/test cases/common/123 cpp and asm/trivial.cc
@@ -4,7 +4,7 @@ extern "C" {
   int get_retval(void);
 }
 
-int main() {
+int main(void) {
   std::cout << "C++ seems to be working." << std::endl;
 #if defined(USE_ASM)
   return get_retval();

--- a/test cases/common/124 extract all shared library/extractor.h
+++ b/test cases/common/124 extract all shared library/extractor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-int func1();
-int func2();
-int func3();
-int func4();
+int func1(void);
+int func2(void);
+int func3(void);
+int func4(void);

--- a/test cases/common/124 extract all shared library/four.c
+++ b/test cases/common/124 extract all shared library/four.c
@@ -1,5 +1,5 @@
 #include"extractor.h"
 
-int func4() {
+int func4(void) {
     return 4;
 }

--- a/test cases/common/124 extract all shared library/one.c
+++ b/test cases/common/124 extract all shared library/one.c
@@ -1,5 +1,5 @@
 #include"extractor.h"
 
-int func1() {
+int func1(void) {
     return 1;
 }

--- a/test cases/common/124 extract all shared library/three.c
+++ b/test cases/common/124 extract all shared library/three.c
@@ -1,5 +1,5 @@
 #include"extractor.h"
 
-int func3() {
+int func3(void) {
     return 3;
 }

--- a/test cases/common/124 extract all shared library/two.c
+++ b/test cases/common/124 extract all shared library/two.c
@@ -1,5 +1,5 @@
 #include"extractor.h"
 
-int func2() {
+int func2(void) {
     return 2;
 }

--- a/test cases/common/125 object only target/prog.c
+++ b/test cases/common/125 object only target/prog.c
@@ -1,6 +1,6 @@
-int func1_in_obj();
-int func2_in_obj();
-int func3_in_obj();
+int func1_in_obj(void);
+int func2_in_obj(void);
+int func3_in_obj(void);
 
 int main(void) {
     return func1_in_obj() + func2_in_obj() + func3_in_obj();

--- a/test cases/common/125 object only target/source.c
+++ b/test cases/common/125 object only target/source.c
@@ -1,3 +1,3 @@
-int func1_in_obj() {
+int func1_in_obj(void) {
     return 0;
 }

--- a/test cases/common/125 object only target/source2.c
+++ b/test cases/common/125 object only target/source2.c
@@ -1,3 +1,3 @@
-int func2_in_obj() {
+int func2_in_obj(void) {
     return 0;
 }

--- a/test cases/common/125 object only target/source3.c
+++ b/test cases/common/125 object only target/source3.c
@@ -1,3 +1,3 @@
-int func3_in_obj() {
+int func3_in_obj(void) {
     return 0;
 }

--- a/test cases/common/126 no buildincdir/include/header.h
+++ b/test cases/common/126 no buildincdir/include/header.h
@@ -1,3 +1,3 @@
 #pragma once
 
-int foobar();
+int foobar(void);

--- a/test cases/common/13 pch/c/prog.c
+++ b/test cases/common/13 pch/c/prog.c
@@ -1,6 +1,6 @@
 // No includes here, they need to come from the PCH
 
-void func() {
+void func(void) {
     fprintf(stdout, "This is a function that fails if stdio is not #included.\n");
 }
 

--- a/test cases/common/13 pch/cpp/prog.cc
+++ b/test cases/common/13 pch/cpp/prog.cc
@@ -1,11 +1,11 @@
 // Note: if using PGI compilers, you will need to add #include "prog.hh"
 // even though you're using precompiled headers.
-void func() {
+void func(void) {
     std::cout << "This is a function that fails to compile if iostream is not included."
               << std::endl;
 }
 
-int main() {
+int main(void) {
     func();
     return 0;
 }

--- a/test cases/common/13 pch/mixed/func.c
+++ b/test cases/common/13 pch/mixed/func.c
@@ -1,7 +1,7 @@
-void tmp_func() {
+void tmp_func(void) {
     fprintf(stdout, "This is a function that fails if stdio is not #included.\n");
 }
 
-int cfunc() {
+int cfunc(void) {
     return 0;
 }

--- a/test cases/common/13 pch/mixed/main.cc
+++ b/test cases/common/13 pch/mixed/main.cc
@@ -1,10 +1,10 @@
 extern "C" int cfunc();
 
-void func() {
+void func(void) {
     std::cout << "This is a function that fails to compile if iostream is not included."
               << std::endl;
 }
 
-int main() {
+int main(void) {
     return cfunc();
 }

--- a/test cases/common/13 pch/userDefined/pch/pch.c
+++ b/test cases/common/13 pch/userDefined/pch/pch.c
@@ -1,5 +1,5 @@
 #include "pch.h"
 
-int foo() {
+int foo(void) {
     return 0;
 }

--- a/test cases/common/13 pch/withIncludeDirectories/prog.c
+++ b/test cases/common/13 pch/withIncludeDirectories/prog.c
@@ -1,6 +1,6 @@
 // No includes here, they need to come from the PCH
 
-void func() {
+void func(void) {
     fprintf(stdout, "This is a function that fails if stdio is not #included.\n");
 }
 

--- a/test cases/common/135 override options/four.c
+++ b/test cases/common/135 override options/four.c
@@ -1,6 +1,6 @@
-int func();
+int func(void);
 
-static int duplicate_func() {
+static int duplicate_func(void) {
     return -4;
 }
 

--- a/test cases/common/135 override options/one.c
+++ b/test cases/common/135 override options/one.c
@@ -1,3 +1,3 @@
-static int hidden_func() {
+static int hidden_func(void) {
     return 0;
 }

--- a/test cases/common/135 override options/three.c
+++ b/test cases/common/135 override options/three.c
@@ -1,7 +1,7 @@
-static int duplicate_func() {
+static int duplicate_func(void) {
     return 4;
 }
 
-int func() {
+int func(void) {
     return duplicate_func();
 }

--- a/test cases/common/137 c cpp and asm/main.cpp
+++ b/test cases/common/137 c cpp and asm/main.cpp
@@ -5,7 +5,7 @@ extern "C" {
   int get_cval(void);
 }
 
-int main() {
+int main(void) {
   std::cout << "C++ seems to be working." << std::endl;
   return get_retval();
 }

--- a/test cases/common/138 compute int/prog.c.in
+++ b/test cases/common/138 compute int/prog.c.in
@@ -4,7 +4,7 @@
 #include <limits.h>
 #include "foobar.h"
 
-int main() {
+int main(void) {
     if(INTSIZE != sizeof(int)) {
         fprintf(stderr, "Mismatch: computed int size %d, actual size %d.\n", INTSIZE, (int)sizeof(int));
         return 1;

--- a/test cases/common/139 custom target object output/objdir/source.c
+++ b/test cases/common/139 custom target object output/objdir/source.c
@@ -1,3 +1,3 @@
-int func1_in_obj() {
+int func1_in_obj(void) {
     return 0;
 }

--- a/test cases/common/139 custom target object output/progdir/prog.c
+++ b/test cases/common/139 custom target object output/progdir/prog.c
@@ -1,4 +1,4 @@
-int func1_in_obj();
+int func1_in_obj(void);
 
 int main(void) {
     return func1_in_obj();

--- a/test cases/common/141 whole archive/func1.c
+++ b/test cases/common/141 whole archive/func1.c
@@ -2,6 +2,6 @@
 
 #include<mylib.h>
 
-int func1() {
+int func1(void) {
     return 42;
 }

--- a/test cases/common/141 whole archive/func2.c
+++ b/test cases/common/141 whole archive/func2.c
@@ -2,6 +2,6 @@
 
 #include<mylib.h>
 
-int func2() {
+int func2(void) {
     return 42;
 }

--- a/test cases/common/141 whole archive/mylib.h
+++ b/test cases/common/141 whole archive/mylib.h
@@ -17,5 +17,5 @@
   #endif
 #endif
 
-int DLL_PUBLIC func1();
-int DLL_PUBLIC func2();
+int DLL_PUBLIC func1(void);
+int DLL_PUBLIC func2(void);

--- a/test cases/common/149 recursive linking/3rdorderdeps/main.c.in
+++ b/test cases/common/149 recursive linking/3rdorderdeps/main.c.in
@@ -4,7 +4,7 @@
 
 SYMBOL_IMPORT int get_@LIBTYPE@@DEPENDENCY@dep_value (void);
 
-int main() {
+int main(void) {
   int val;
 
   val = get_@LIBTYPE@@DEPENDENCY@dep_value ();

--- a/test cases/common/151 simd/simd_avx.c
+++ b/test cases/common/151 simd/simd_avx.c
@@ -10,7 +10,7 @@
 
 #ifdef _MSC_VER
 #include<intrin.h>
-int avx_available() {
+int avx_available(void) {
   return 1;
 }
 #else
@@ -23,10 +23,10 @@ int avx_available() {
  * some machines in the CI farm seem to be too
  * old to have AVX so just always return 0 here.
  */
-int avx_available() { return 0; }
+int avx_available(void) { return 0; }
 #else
 
-int avx_available() {
+int avx_available(void) {
     return __builtin_cpu_supports("avx");
 }
 #endif

--- a/test cases/common/151 simd/simd_avx2.c
+++ b/test cases/common/151 simd/simd_avx2.c
@@ -8,7 +8,7 @@
 
 #ifdef _MSC_VER
 #include<intrin.h>
-int avx2_available() {
+int avx2_available(void) {
     return 0;
 }
 #else
@@ -16,9 +16,9 @@ int avx2_available() {
 #include<cpuid.h>
 
 #if defined(__APPLE__)
-int avx2_available() { return 0; }
+int avx2_available(void) { return 0; }
 #else
-int avx2_available() {
+int avx2_available(void) {
     return __builtin_cpu_supports("avx2");
 }
 #endif

--- a/test cases/common/151 simd/simd_mmx.c
+++ b/test cases/common/151 simd/simd_mmx.c
@@ -5,7 +5,7 @@
 
 #ifdef _MSC_VER
 #include<intrin.h>
-int mmx_available() {
+int mmx_available(void) {
   return 1;
 }
 /* Contrary to MSDN documentation, MMX intrinsics
@@ -18,7 +18,7 @@ void increment_mmx(float arr[4]) {
   arr[3]++;
 }
 #elif defined(__MINGW32__)
-int mmx_available() {
+int mmx_available(void) {
   return 1;
 }
 /* MinGW does not seem to ship with MMX or it is broken.
@@ -34,9 +34,9 @@ void increment_mmx(float arr[4]) {
 #include<cpuid.h>
 
 #if defined(__APPLE__)
-int mmx_available() { return 1; }
+int mmx_available(void) { return 1; }
 #else
-int mmx_available() {
+int mmx_available(void) {
     return __builtin_cpu_supports("mmx");
 }
 #endif

--- a/test cases/common/151 simd/simd_neon.c
+++ b/test cases/common/151 simd/simd_neon.c
@@ -4,7 +4,7 @@
 #include<arm_neon.h>
 #include<stdint.h>
 
-int neon_available() {
+int neon_available(void) {
     return 1; /* Incorrect, but I don't know how to check this properly. */
 }
 

--- a/test cases/common/151 simd/simd_sse.c
+++ b/test cases/common/151 simd/simd_sse.c
@@ -3,7 +3,7 @@
 
 #ifdef _MSC_VER
 #include<intrin.h>
-int sse_available() {
+int sse_available(void) {
   return 1;
 }
 #else
@@ -13,9 +13,9 @@ int sse_available() {
 #include<stdint.h>
 
 #if defined(__APPLE__)
-int sse_available() { return 1; }
+int sse_available(void) { return 1; }
 #else
-int sse_available() {
+int sse_available(void) {
     return __builtin_cpu_supports("sse");
 }
 #endif

--- a/test cases/common/151 simd/simd_sse2.c
+++ b/test cases/common/151 simd/simd_sse2.c
@@ -3,7 +3,7 @@
 #include<emmintrin.h>
 
 #ifdef _MSC_VER
-int sse2_available() {
+int sse2_available(void) {
   return 1;
 }
 
@@ -12,9 +12,9 @@ int sse2_available() {
 #include<stdint.h>
 
 #if defined(__APPLE__)
-int sse2_available() { return 1; }
+int sse2_available(void) { return 1; }
 #else
-int sse2_available() {
+int sse2_available(void) {
     return __builtin_cpu_supports("sse2");
 }
 #endif

--- a/test cases/common/151 simd/simd_sse3.c
+++ b/test cases/common/151 simd/simd_sse3.c
@@ -3,7 +3,7 @@
 
 #ifdef _MSC_VER
 #include<intrin.h>
-int sse3_available() {
+int sse3_available(void) {
     return 1;
 }
 #else
@@ -13,9 +13,9 @@ int sse3_available() {
 #include<stdint.h>
 
 #if defined(__APPLE__)
-int sse3_available() { return 1; }
+int sse3_available(void) { return 1; }
 #else
-int sse3_available() {
+int sse3_available(void) {
     return __builtin_cpu_supports("sse3");
 }
 #endif

--- a/test cases/common/151 simd/simd_sse41.c
+++ b/test cases/common/151 simd/simd_sse41.c
@@ -6,7 +6,7 @@
 #ifdef _MSC_VER
 #include<intrin.h>
 
-int sse41_available() {
+int sse41_available(void) {
   return 1;
 }
 
@@ -15,9 +15,9 @@ int sse41_available() {
 #include<cpuid.h>
 
 #if defined(__APPLE__)
-int sse41_available() { return 1; }
+int sse41_available(void) { return 1; }
 #else
-int sse41_available() {
+int sse41_available(void) {
     return __builtin_cpu_supports("sse4.1");
 }
 #endif

--- a/test cases/common/151 simd/simd_sse42.c
+++ b/test cases/common/151 simd/simd_sse42.c
@@ -5,7 +5,7 @@
 #ifdef _MSC_VER
 #include<intrin.h>
 
-int sse42_available() {
+int sse42_available(void) {
   return 1;
 }
 
@@ -15,11 +15,11 @@ int sse42_available() {
 #include<cpuid.h>
 
 #ifdef __APPLE__
-int sse42_available() {
+int sse42_available(void) {
     return 1;
 }
 #else
-int sse42_available() {
+int sse42_available(void) {
     return __builtin_cpu_supports("sse4.2");
 }
 #endif

--- a/test cases/common/151 simd/simd_ssse3.c
+++ b/test cases/common/151 simd/simd_ssse3.c
@@ -7,7 +7,7 @@
 #ifdef _MSC_VER
 #include<intrin.h>
 
-int ssse3_available() {
+int ssse3_available(void) {
   return 1;
 }
 
@@ -16,7 +16,7 @@ int ssse3_available() {
 #include<cpuid.h>
 #include<stdint.h>
 
-int ssse3_available() {
+int ssse3_available(void) {
 #ifdef __APPLE__
     return 1;
 #elif defined(__clang__)

--- a/test cases/common/151 simd/simdfuncs.h
+++ b/test cases/common/151 simd/simdfuncs.h
@@ -18,57 +18,57 @@
 void increment_fallback(float arr[4]);
 
 #if HAVE_MMX
-int mmx_available();
+int mmx_available(void);
 void increment_mmx(float arr[4]);
 #endif
 
 #if HAVE_SSE
-int sse_available();
+int sse_available(void);
 void increment_sse(float arr[4]);
 #endif
 
 #if HAVE_SSE2
-int sse2_available();
+int sse2_available(void);
 void increment_sse2(float arr[4]);
 #endif
 
 #if HAVE_SSE3
-int sse3_available();
+int sse3_available(void);
 void increment_sse3(float arr[4]);
 #endif
 
 #if HAVE_SSSE3
-int ssse3_available();
+int ssse3_available(void);
 void increment_ssse3(float arr[4]);
 #endif
 
 #if HAVE_SSE41
-int sse41_available();
+int sse41_available(void);
 void increment_sse41(float arr[4]);
 #endif
 
 #if HAVE_SSE42
-int sse42_available();
+int sse42_available(void);
 void increment_sse42(float arr[4]);
 #endif
 
 #if HAVE_AVX
-int avx_available();
+int avx_available(void);
 void increment_avx(float arr[4]);
 #endif
 
 #if HAVE_AVX2
-int avx2_available();
+int avx2_available(void);
 void increment_avx2(float arr[4]);
 #endif
 
 #if HAVE_NEON
-int neon_available();
+int neon_available(void);
 void increment_neon(float arr[4]);
 #endif
 
 #if HAVE_ALTIVEC
-int altivec_available();
+int altivec_available(void);
 void increment_altivec(float arr[4]);
 #endif
 

--- a/test cases/common/157 wrap file should not failed/subprojects/foo-1.0/foo.c
+++ b/test cases/common/157 wrap file should not failed/subprojects/foo-1.0/foo.c
@@ -1,3 +1,3 @@
-int dummy_func() {
+int dummy_func(void) {
     return 42;
 }

--- a/test cases/common/157 wrap file should not failed/subprojects/zlib-1.2.8/foo.c
+++ b/test cases/common/157 wrap file should not failed/subprojects/zlib-1.2.8/foo.c
@@ -1,3 +1,3 @@
-int dummy_func() {
+int dummy_func(void) {
     return 42;
 }

--- a/test cases/common/159 subproject dir name collision/a.c
+++ b/test cases/common/159 subproject dir name collision/a.c
@@ -1,6 +1,6 @@
 #include<assert.h>
-char func_b();
-char func_c();
+char func_b(void);
+char func_c(void);
 
 int main(void) {
     if(func_b() != 'b') {

--- a/test cases/common/159 subproject dir name collision/custom_subproject_dir/B/b.c
+++ b/test cases/common/159 subproject dir name collision/custom_subproject_dir/B/b.c
@@ -1,5 +1,5 @@
 #include<stdlib.h>
-char func_c();
+char func_c(void);
 
 #if defined _WIN32 || defined __CYGWIN__
 #define DLL_PUBLIC __declspec(dllexport)
@@ -12,7 +12,7 @@ char func_c();
   #endif
 #endif
 
-char DLL_PUBLIC func_b() {
+char DLL_PUBLIC func_b(void) {
     if(func_c() != 'c') {
         exit(3);
     }

--- a/test cases/common/159 subproject dir name collision/custom_subproject_dir/C/c.c
+++ b/test cases/common/159 subproject dir name collision/custom_subproject_dir/C/c.c
@@ -9,6 +9,6 @@
   #endif
 #endif
 
-char DLL_PUBLIC func_c() {
+char DLL_PUBLIC func_c(void) {
     return 'c';
 }

--- a/test cases/common/159 subproject dir name collision/other_subdir/custom_subproject_dir/other.c
+++ b/test cases/common/159 subproject dir name collision/other_subdir/custom_subproject_dir/other.c
@@ -11,7 +11,7 @@
   #endif
 #endif
 
-char DLL_PUBLIC func_b() {
+char DLL_PUBLIC func_b(void) {
     if('c' != 'c') {
         exit(3);
     }

--- a/test cases/common/161 custom target subdir depend files/subdir/foo.c.in
+++ b/test cases/common/161 custom target subdir depend files/subdir/foo.c.in
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-int main() {
+int main(void) {
     printf("foo is working.\n");
     return 0;
 }

--- a/test cases/common/165 custom target template substitution/foo.c.in
+++ b/test cases/common/165 custom target template substitution/foo.c.in
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-int main() {
+int main(void) {
     printf("foo is working.\n");
     return 0;
 }

--- a/test cases/common/166 not-found dependency/subprojects/trivial/trivial.c
+++ b/test cases/common/166 not-found dependency/subprojects/trivial/trivial.c
@@ -1,3 +1,3 @@
-int subfunc() {
+int subfunc(void) {
     return 42;
 }

--- a/test cases/common/172 subproject nested subproject dirs/contrib/subprojects/alpha/a.c
+++ b/test cases/common/172 subproject nested subproject dirs/contrib/subprojects/alpha/a.c
@@ -1,4 +1,4 @@
-int func2();
+int func2(void);
 
 #if defined _WIN32 || defined __CYGWIN__
   #define DLL_PUBLIC __declspec(dllexport)
@@ -11,5 +11,5 @@ int func2();
   #endif
 #endif
 
-int DLL_PUBLIC func() { return func2(); }
+int DLL_PUBLIC func(void) { return func2(); }
 

--- a/test cases/common/172 subproject nested subproject dirs/contrib/subprojects/beta/b.c
+++ b/test cases/common/172 subproject nested subproject dirs/contrib/subprojects/beta/b.c
@@ -9,6 +9,6 @@
   #endif
 #endif
 
-int DLL_PUBLIC func2() {
+int DLL_PUBLIC func2(void) {
     return 42;
 }

--- a/test cases/common/172 subproject nested subproject dirs/prog.c
+++ b/test cases/common/172 subproject nested subproject dirs/prog.c
@@ -1,4 +1,4 @@
-int func();
+int func(void);
 
 int main(void) {
     return func() == 42 ? 0 : 1;

--- a/test cases/common/173 preserve gendir/genprog.py
+++ b/test cases/common/173 preserve gendir/genprog.py
@@ -4,12 +4,12 @@ import os, sys, argparse
 
 h_templ = '''#pragma once
 
-int %s();
+int %s(void);
 '''
 
 c_templ = '''#include"%s.h"
 
-int %s() {
+int %s(void) {
     return 0;
 }
 '''

--- a/test cases/common/174 source in dep/bar.cpp
+++ b/test cases/common/174 source in dep/bar.cpp
@@ -1,5 +1,5 @@
-extern "C" int foo();
+extern "C" int foo(void);
 
-int main(int, char**) {
+int main(void) {
     return foo() != 42;
 }

--- a/test cases/common/174 source in dep/foo.c
+++ b/test cases/common/174 source in dep/foo.c
@@ -1,3 +1,3 @@
-int foo() {
+int foo(void) {
     return 42;
 }

--- a/test cases/common/174 source in dep/generated/genheader.py
+++ b/test cases/common/174 source in dep/generated/genheader.py
@@ -7,7 +7,7 @@ ofile = sys.argv[2]
 
 templ = '''#pragma once
 
-int %s() {
+int %s(void) {
   return 42;
 }
 '''

--- a/test cases/common/175 generator link whole/generator.py
+++ b/test cases/common/175 generator link whole/generator.py
@@ -15,12 +15,12 @@ def main():
         hfile.write('''
 #pragma once
 #include "export.h"
-int DLL_PUBLIC {name}();
+int DLL_PUBLIC {name}(void);
 '''.format(name=name))
     with open(cname, 'w') as cfile:
         cfile.write('''
 #include "{name}.h"
-int {name}() {{
+int {name}(void) {{
     return {size};
 }}
 '''.format(name=name, size=len(name)))

--- a/test cases/common/175 generator link whole/pull_meson_test_function.c
+++ b/test cases/common/175 generator link whole/pull_meson_test_function.c
@@ -1,6 +1,6 @@
 #include "export.h"
 #include "meson_test_function.h"
 
-int DLL_PUBLIC function_puller() {
+int DLL_PUBLIC function_puller(void) {
     return meson_test_function();
 }

--- a/test cases/common/178 as-needed/main.cpp
+++ b/test cases/common/178 as-needed/main.cpp
@@ -2,6 +2,6 @@
 
 #include "libA.h"
 
-int main() {
+int main(void) {
   return !meson_test_as_needed::linked ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/test cases/common/18 array/func.c
+++ b/test cases/common/18 array/func.c
@@ -1,1 +1,1 @@
-int func() { return 0; }
+int func(void) { return 0; }

--- a/test cases/common/18 array/prog.c
+++ b/test cases/common/18 array/prog.c
@@ -1,3 +1,3 @@
-extern int func();
+extern int func(void);
 
 int main(void) { return func(); }

--- a/test cases/common/183 bothlibraries/libfile.c
+++ b/test cases/common/183 bothlibraries/libfile.c
@@ -2,6 +2,6 @@
 
 DO_EXPORT int retval = 42;
 
-DO_EXPORT int func() {
+DO_EXPORT int func(void) {
     return retval;
 }

--- a/test cases/common/183 bothlibraries/main.c
+++ b/test cases/common/183 bothlibraries/main.c
@@ -1,6 +1,6 @@
 #include "mylib.h"
 
-DO_IMPORT int func();
+DO_IMPORT int func(void);
 DO_IMPORT int retval;
 
 int main(void) {

--- a/test cases/common/184 escape and unicode/file.c.in
+++ b/test cases/common/184 escape and unicode/file.c.in
@@ -1,5 +1,5 @@
 #include<stdio.h>
-const char* does_it_work() {
+const char* does_it_work(void) {
     printf("{NAME}\n");
     return "yes it does";
 }

--- a/test cases/common/184 escape and unicode/fun.c
+++ b/test cases/common/184 escape and unicode/fun.c
@@ -1,3 +1,3 @@
-int a_fun() {
+int a_fun(void) {
     return 1;
 }

--- a/test cases/common/184 escape and unicode/main.c
+++ b/test cases/common/184 escape and unicode/main.c
@@ -1,6 +1,6 @@
 #include <string.h>
 
-const char* does_it_work();
+const char* does_it_work(void);
 
 int a_fun(void);
 

--- a/test cases/common/184 escape and unicode/main.c
+++ b/test cases/common/184 escape and unicode/main.c
@@ -2,7 +2,7 @@
 
 const char* does_it_work();
 
-int a_fun();
+int a_fun(void);
 
 int main(void) {
     if(strcmp(does_it_work(), "yes it does") != 0) {

--- a/test cases/common/187 find override/otherdir/main.c
+++ b/test cases/common/187 find override/otherdir/main.c
@@ -1,4 +1,4 @@
-int be_seeing_you();
+int be_seeing_you(void);
 
 int main(void) {
     return be_seeing_you() == 6 ? 0 : 1;

--- a/test cases/common/187 find override/otherdir/main2.c
+++ b/test cases/common/187 find override/otherdir/main2.c
@@ -1,4 +1,4 @@
-int number_returner();
+int number_returner(void);
 
 int main(void) {
     return number_returner() == 100 ? 0 : 1;

--- a/test cases/common/187 find override/subdir/converter.py
+++ b/test cases/common/187 find override/subdir/converter.py
@@ -5,7 +5,7 @@ import pathlib
 
 [ifilename, ofilename] = sys.argv[1:3]
 
-ftempl = '''int %s() {
+ftempl = '''int %s(void) {
     return 6;
 }
 '''

--- a/test cases/common/187 find override/subdir/gencodegen.py.in
+++ b/test cases/common/187 find override/subdir/gencodegen.py.in
@@ -5,7 +5,7 @@ import pathlib
 
 [ifilename, ofilename] = sys.argv[1:3]
 
-ftempl = '''int %s() {
+ftempl = '''int %s(void) {
     return @NUMBER@;
 }
 '''

--- a/test cases/common/19 includedir/include/func.h
+++ b/test cases/common/19 includedir/include/func.h
@@ -1,6 +1,6 @@
 #ifndef FUNC_H__
 #define FUNC_H__
 
-int func();
+int func(void);
 
 #endif

--- a/test cases/common/19 includedir/src/func.c
+++ b/test cases/common/19 includedir/src/func.c
@@ -1,5 +1,5 @@
 #include "func.h"
 
-int func() {
+int func(void) {
     return 0;
 }

--- a/test cases/common/190 same target name/file.c
+++ b/test cases/common/190 same target name/file.c
@@ -1,3 +1,3 @@
-int func() {
+int func(void) {
     return 0;
 }

--- a/test cases/common/190 same target name/sub/file2.c
+++ b/test cases/common/190 same target name/sub/file2.c
@@ -1,3 +1,3 @@
-int func() {
+int func(void) {
     return 5;
 }

--- a/test cases/common/195 install_mode/stat.c
+++ b/test cases/common/195 install_mode/stat.c
@@ -1,1 +1,1 @@
-int func() { return 933; }
+int func(void) { return 933; }

--- a/test cases/common/2 cpp/trivial.cc
+++ b/test cases/common/2 cpp/trivial.cc
@@ -1,6 +1,6 @@
 #include<iostream>
 
-int main() {
+int main(void) {
   std::cout << "C++ seems to be working." << std::endl;
   return 0;
 }

--- a/test cases/common/200 generator in subdir/com/mesonbuild/genprog.py
+++ b/test cases/common/200 generator in subdir/com/mesonbuild/genprog.py
@@ -4,12 +4,12 @@ import os, sys, argparse
 
 h_templ = '''#pragma once
 
-int %s();
+int %s(void);
 '''
 
 c_templ = '''#include"%s.h"
 
-int %s() {
+int %s(void) {
     return 0;
 }
 '''

--- a/test cases/common/202 subproject with features/subprojects/disabled_sub/lib/sub.c
+++ b/test cases/common/202 subproject with features/subprojects/disabled_sub/lib/sub.c
@@ -1,5 +1,5 @@
 #include "sub.h"
 
-int sub() {
+int sub(void) {
     return 0;
 }

--- a/test cases/common/202 subproject with features/subprojects/sub/lib/sub.c
+++ b/test cases/common/202 subproject with features/subprojects/sub/lib/sub.c
@@ -1,5 +1,5 @@
 #include "sub.h"
 
-int sub() {
+int sub(void) {
   return 0;
 }

--- a/test cases/common/202 subproject with features/subprojects/sub/lib/sub.h
+++ b/test cases/common/202 subproject with features/subprojects/sub/lib/sub.h
@@ -1,6 +1,6 @@
 #ifndef SUB_H
 #define SUB_H
 
-int sub();
+int sub(void);
 
 #endif

--- a/test cases/common/206 install name_prefix name_suffix/libfile.c
+++ b/test cases/common/206 install name_prefix name_suffix/libfile.c
@@ -9,6 +9,6 @@
   #endif
 #endif
 
-int DLL_PUBLIC func() {
+int DLL_PUBLIC func(void) {
     return 0;
 }

--- a/test cases/common/21 global arg/prog.c
+++ b/test cases/common/21 global arg/prog.c
@@ -38,6 +38,6 @@
   #endif
 #endif
 
-int main() {
+int main(void) {
     return 0;
 }

--- a/test cases/common/21 global arg/prog.cc
+++ b/test cases/common/21 global arg/prog.cc
@@ -10,6 +10,6 @@
 #error "Global argument not set"
 #endif
 
-int main() {
+int main(void) {
     return 0;
 }

--- a/test cases/common/212 native file path override/main.cpp
+++ b/test cases/common/212 native file path override/main.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
 
-int main() {
+int main(void) {
     std::cout << "Hello world!" << std::endl;
 }

--- a/test cases/common/215 link custom/custom_stlib.py
+++ b/test cases/common/215 link custom/custom_stlib.py
@@ -10,7 +10,7 @@ parser.add_argument('cmparr', nargs='+')
 
 contents = '''#include<stdio.h>
 
-void flob() {
+void flob(void) {
     printf("Now flobbing.\\n");
 }
 '''

--- a/test cases/common/215 link custom/prog.c
+++ b/test cases/common/215 link custom/prog.c
@@ -1,4 +1,4 @@
-void flob();
+void flob(void);
 
 int main(void) {
     flob();

--- a/test cases/common/216 link custom_i single from multiple/prog.c
+++ b/test cases/common/216 link custom_i single from multiple/prog.c
@@ -1,4 +1,4 @@
-int flob();
+int flob(void);
 
 int main(void) {
     return (flob() == 1 ? 0 : 1);

--- a/test cases/common/217 link custom_i multiple from multiple/prog.c
+++ b/test cases/common/217 link custom_i multiple from multiple/prog.c
@@ -1,5 +1,5 @@
-void flob_1();
-void flob_2();
+void flob_1(void);
+void flob_2(void);
 
 int main(void) {
     flob_1();

--- a/test cases/common/22 target arg/func.c
+++ b/test cases/common/22 target arg/func.c
@@ -6,4 +6,4 @@
 #error "Wrong local argument set"
 #endif
 
-int func() { return 0; }
+int func(void) { return 0; }

--- a/test cases/common/22 target arg/func2.c
+++ b/test cases/common/22 target arg/func2.c
@@ -6,4 +6,4 @@
 #error "Local CPP argument set in wrong target"
 #endif
 
-int func() { return 0; }
+int func(void) { return 0; }

--- a/test cases/common/22 target arg/prog.cc
+++ b/test cases/common/22 target arg/prog.cc
@@ -8,6 +8,6 @@
 
 extern "C" int func();
 
-int main() {
+int main(void) {
     return func();
 }

--- a/test cases/common/22 target arg/prog2.cc
+++ b/test cases/common/22 target arg/prog2.cc
@@ -8,6 +8,6 @@
 
 extern "C" int func();
 
-int main() {
+int main(void) {
     return func();
 }

--- a/test cases/common/222 source set realistic example/main.cc
+++ b/test cases/common/222 source set realistic example/main.cc
@@ -15,7 +15,7 @@ Device::~Device() {}
 Dependency::Dependency() { this->next = deps; deps = this; }
 Dependency::~Dependency() {}
 
-int main()
+int main(void)
 {
     some_random_function();
     for (auto d = deps; d; d = d->next)

--- a/test cases/common/223 custom target input extracted objects/libdir/source.c
+++ b/test cases/common/223 custom target input extracted objects/libdir/source.c
@@ -1,3 +1,3 @@
-int func1_in_obj() {
+int func1_in_obj(void) {
     return 0;
 }

--- a/test cases/common/23 object extraction/lib.c
+++ b/test cases/common/23 object extraction/lib.c
@@ -1,3 +1,3 @@
-int func() {
+int func(void) {
     return 42;
 }

--- a/test cases/common/23 object extraction/lib2.c
+++ b/test cases/common/23 object extraction/lib2.c
@@ -1,3 +1,3 @@
-int retval() {
+int retval(void) {
   return 43;
 }

--- a/test cases/common/23 object extraction/main.c
+++ b/test cases/common/23 object extraction/main.c
@@ -1,4 +1,4 @@
-int func();
+int func(void);
 
 int main(void) {
     return func() == 42 ? 0 : 1;

--- a/test cases/common/23 object extraction/src/lib.c
+++ b/test cases/common/23 object extraction/src/lib.c
@@ -1,3 +1,3 @@
-int func() {
+int func(void) {
     return 42;
 }

--- a/test cases/common/25 library versions/lib.c
+++ b/test cases/common/25 library versions/lib.c
@@ -9,6 +9,6 @@
   #endif
 #endif
 
-int DLL_PUBLIC myFunc() {
+int DLL_PUBLIC myFunc(void) {
     return 55;
 }

--- a/test cases/common/27 pipeline/depends/libsrc.c.in
+++ b/test cases/common/27 pipeline/depends/libsrc.c.in
@@ -1,3 +1,3 @@
-int func() {
+int func(void) {
     return 42;
 }

--- a/test cases/common/27 pipeline/depends/prog.c
+++ b/test cases/common/27 pipeline/depends/prog.c
@@ -1,4 +1,4 @@
-int func();
+int func(void);
 
 int main(void) {
     return func() != 42;

--- a/test cases/common/27 pipeline/input_src.dat
+++ b/test cases/common/27 pipeline/input_src.dat
@@ -1,1 +1,1 @@
-int func() { return 0; }
+int func(void) { return 0; }

--- a/test cases/common/27 pipeline/prog.c
+++ b/test cases/common/27 pipeline/prog.c
@@ -1,4 +1,4 @@
-int func();
+int func(void);
 
 int main(void) {
     return func();

--- a/test cases/common/28 find program/source.in
+++ b/test cases/common/28 find program/source.in
@@ -1,3 +1,3 @@
-int main() {
+int main(void) {
   return 0;
 }

--- a/test cases/common/29 multiline string/meson.build
+++ b/test cases/common/29 multiline string/meson.build
@@ -26,7 +26,7 @@ endif
 
 cc = meson.get_compiler('c')
 prog = '''
-int main() {
+int main(void) {
   int num = 1;
   printf("%d\n", num);
   return 0;

--- a/test cases/common/3 static/libfile.c
+++ b/test cases/common/3 static/libfile.c
@@ -1,3 +1,3 @@
-int libfunc() {
+int libfunc(void) {
     return 3;
 }

--- a/test cases/common/3 static/libfile2.c
+++ b/test cases/common/3 static/libfile2.c
@@ -1,3 +1,3 @@
-int libfunc2() {
+int libfunc2(void) {
     return 4;
 }

--- a/test cases/common/30 try compile/invalid.c
+++ b/test cases/common/30 try compile/invalid.c
@@ -1,2 +1,2 @@
 #include<nonexisting.h>
-void func() { printf("This won't work.\n"); }
+void func(void) { printf("This won't work.\n"); }

--- a/test cases/common/30 try compile/meson.build
+++ b/test cases/common/30 try compile/meson.build
@@ -1,11 +1,11 @@
 project('try compile', 'c', 'cpp')
 
 code = '''#include<stdio.h>
-void func() { printf("Something.\n"); }
+void func(void) { printf("Something.\n"); }
 '''
 
 breakcode = '''#include<nonexisting.h>
-void func() { printf("This won't work.\n"); }
+void func(void) { printf("This won't work.\n"); }
 '''
 
 foreach compiler : [meson.get_compiler('c'), meson.get_compiler('cpp')]

--- a/test cases/common/30 try compile/valid.c
+++ b/test cases/common/30 try compile/valid.c
@@ -1,2 +1,2 @@
 #include<stdio.h>
-void func() { printf("Something.\n"); }
+void func(void) { printf("Something.\n"); }

--- a/test cases/common/32 sizeof/prog.c.in
+++ b/test cases/common/32 sizeof/prog.c.in
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <wchar.h>
 
-int main() {
+int main(void) {
     if(INTSIZE != sizeof(int)) {
         fprintf(stderr, "Mismatch: detected int size %d, actual size %d.\n", INTSIZE, (int)sizeof(int));
         return 1;

--- a/test cases/common/36 tryrun/error.c
+++ b/test cases/common/36 tryrun/error.c
@@ -1,3 +1,3 @@
-int main() {
+int main(void) {
   return 1;
 }

--- a/test cases/common/36 tryrun/meson.build
+++ b/test cases/common/36 tryrun/meson.build
@@ -12,19 +12,19 @@ else
 endif
 
 ok_code = '''#include<stdio.h>
-int main() {
+int main(void) {
   printf("%s\n", "stdout");
   fprintf(stderr, "%s\n", "stderr");
   return 0;
 }
 '''
 
-error_code = '''int main() {
+error_code = '''int main(void) {
   return 1;
 }
 '''
 
-no_compile_code = '''int main() {
+no_compile_code = '''int main(void) {
 '''
 
 INPUTS = [

--- a/test cases/common/36 tryrun/no_compile.c
+++ b/test cases/common/36 tryrun/no_compile.c
@@ -1,1 +1,1 @@
-int main() {
+int main(void) {

--- a/test cases/common/4 shared/libfile.c
+++ b/test cases/common/4 shared/libfile.c
@@ -9,6 +9,6 @@
   #endif
 #endif
 
-int DLL_PUBLIC libfunc() {
+int DLL_PUBLIC libfunc(void) {
     return 3;
 }

--- a/test cases/common/42 library chain/main.c
+++ b/test cases/common/42 library chain/main.c
@@ -1,4 +1,4 @@
-int libfun();
+int libfun(void);
 
 int main(void) {
   return libfun();

--- a/test cases/common/42 library chain/subdir/lib1.c
+++ b/test cases/common/42 library chain/subdir/lib1.c
@@ -1,5 +1,5 @@
-int lib2fun();
-int lib3fun();
+int lib2fun(void);
+int lib3fun(void);
 
 #if defined _WIN32 || defined __CYGWIN__
   #define DLL_PUBLIC __declspec(dllexport)
@@ -12,6 +12,6 @@ int lib3fun();
   #endif
 #endif
 
-int DLL_PUBLIC libfun() {
+int DLL_PUBLIC libfun(void) {
   return lib2fun() + lib3fun();
 }

--- a/test cases/common/42 library chain/subdir/subdir2/lib2.c
+++ b/test cases/common/42 library chain/subdir/subdir2/lib2.c
@@ -9,6 +9,6 @@
   #endif
 #endif
 
-int DLL_PUBLIC lib2fun() {
+int DLL_PUBLIC lib2fun(void) {
   return 0;
 }

--- a/test cases/common/42 library chain/subdir/subdir3/lib3.c
+++ b/test cases/common/42 library chain/subdir/subdir3/lib3.c
@@ -9,6 +9,6 @@
   #endif
 #endif
 
-int DLL_PUBLIC lib3fun()  {
+int DLL_PUBLIC lib3fun(void)  {
   return 0;
 }

--- a/test cases/common/45 subproject/subprojects/sublib/include/subdefs.h
+++ b/test cases/common/45 subproject/subprojects/sublib/include/subdefs.h
@@ -16,6 +16,6 @@
   #endif
 #endif
 
-int DLL_PUBLIC subfunc();
+int DLL_PUBLIC subfunc(void);
 
 #endif

--- a/test cases/common/45 subproject/subprojects/sublib/sublib.c
+++ b/test cases/common/45 subproject/subprojects/sublib/sublib.c
@@ -1,5 +1,5 @@
 #include<subdefs.h>
 
-int DLL_PUBLIC subfunc() {
+int DLL_PUBLIC subfunc(void) {
     return 42;
 }

--- a/test cases/common/47 pkgconfig-gen/dependencies/custom.c
+++ b/test cases/common/47 pkgconfig-gen/dependencies/custom.c
@@ -1,3 +1,3 @@
-int custom_function() {
+int custom_function(void) {
     return 42;
 }

--- a/test cases/common/47 pkgconfig-gen/dependencies/exposed.c
+++ b/test cases/common/47 pkgconfig-gen/dependencies/exposed.c
@@ -1,3 +1,3 @@
-int exposed_function() {
+int exposed_function(void) {
     return 42;
 }

--- a/test cases/common/47 pkgconfig-gen/dependencies/internal.c
+++ b/test cases/common/47 pkgconfig-gen/dependencies/internal.c
@@ -1,3 +1,3 @@
-int internal_function() {
+int internal_function(void) {
     return 42;
 }

--- a/test cases/common/47 pkgconfig-gen/simple.c
+++ b/test cases/common/47 pkgconfig-gen/simple.c
@@ -1,5 +1,5 @@
 #include"simple.h"
 
-int simple_function() {
+int simple_function(void) {
     return 42;
 }

--- a/test cases/common/47 pkgconfig-gen/simple.h
+++ b/test cases/common/47 pkgconfig-gen/simple.h
@@ -1,6 +1,6 @@
 #ifndef SIMPLE_H_
 #define SIMPLE_H_
 
-int simple_function();
+int simple_function(void);
 
 #endif

--- a/test cases/common/49 subproject subproject/prog.c
+++ b/test cases/common/49 subproject subproject/prog.c
@@ -1,4 +1,4 @@
-int func();
+int func(void);
 
 int main(void) {
     return func() == 42 ? 0 : 1;

--- a/test cases/common/49 subproject subproject/subprojects/a/a.c
+++ b/test cases/common/49 subproject subproject/subprojects/a/a.c
@@ -1,4 +1,4 @@
-int func2();
+int func2(void);
 
 #if defined _WIN32 || defined __CYGWIN__
   #define DLL_PUBLIC __declspec(dllexport)
@@ -11,5 +11,5 @@ int func2();
   #endif
 #endif
 
-int DLL_PUBLIC func() { return func2(); }
+int DLL_PUBLIC func(void) { return func2(); }
 

--- a/test cases/common/49 subproject subproject/subprojects/b/b.c
+++ b/test cases/common/49 subproject subproject/subprojects/b/b.c
@@ -9,6 +9,6 @@
   #endif
 #endif
 
-int DLL_PUBLIC func2() {
+int DLL_PUBLIC func2(void) {
     return 42;
 }

--- a/test cases/common/5 linkstatic/libfile.c
+++ b/test cases/common/5 linkstatic/libfile.c
@@ -1,3 +1,3 @@
-int func() {
+int func(void) {
     return 0;
 }

--- a/test cases/common/5 linkstatic/libfile2.c
+++ b/test cases/common/5 linkstatic/libfile2.c
@@ -1,3 +1,3 @@
-int func2() {
+int func2(void) {
     return 2;
 }

--- a/test cases/common/5 linkstatic/libfile3.c
+++ b/test cases/common/5 linkstatic/libfile3.c
@@ -1,3 +1,3 @@
-int func3() {
+int func3(void) {
     return 3;
 }

--- a/test cases/common/5 linkstatic/libfile4.c
+++ b/test cases/common/5 linkstatic/libfile4.c
@@ -1,3 +1,3 @@
-int func4() {
+int func4(void) {
     return 4;
 }

--- a/test cases/common/5 linkstatic/main.c
+++ b/test cases/common/5 linkstatic/main.c
@@ -1,4 +1,4 @@
-int func();
+int func(void);
 
 int main(void) {
     return func();

--- a/test cases/common/50 same file name/d1/file.c
+++ b/test cases/common/50 same file name/d1/file.c
@@ -1,1 +1,1 @@
-int func1() { return 42; }
+int func1(void) { return 42; }

--- a/test cases/common/50 same file name/d2/file.c
+++ b/test cases/common/50 same file name/d2/file.c
@@ -1,1 +1,1 @@
-int func2() { return 42; }
+int func2(void) { return 42; }

--- a/test cases/common/50 same file name/prog.c
+++ b/test cases/common/50 same file name/prog.c
@@ -1,5 +1,5 @@
-int func1();
-int func2();
+int func1(void);
+int func2(void);
 
 int main(void) {
     return func1() - func2();

--- a/test cases/common/51 file grabber/a.c
+++ b/test cases/common/51 file grabber/a.c
@@ -1,1 +1,1 @@
-int funca() { return 0; }
+int funca(void) { return 0; }

--- a/test cases/common/51 file grabber/b.c
+++ b/test cases/common/51 file grabber/b.c
@@ -1,1 +1,1 @@
-int funcb() { return 0; }
+int funcb(void) { return 0; }

--- a/test cases/common/51 file grabber/c.c
+++ b/test cases/common/51 file grabber/c.c
@@ -1,1 +1,1 @@
-int funcc() { return 0; }
+int funcc(void) { return 0; }

--- a/test cases/common/51 file grabber/prog.c
+++ b/test cases/common/51 file grabber/prog.c
@@ -1,6 +1,6 @@
-int funca();
-int funcb();
-int funcc();
+int funca(void);
+int funcb(void);
+int funcc(void);
 
 int main(void) {
     return funca() + funcb() + funcc();

--- a/test cases/common/51 file grabber/subdir/suba.c
+++ b/test cases/common/51 file grabber/subdir/suba.c
@@ -1,1 +1,1 @@
-int funca() { return 0; }
+int funca(void) { return 0; }

--- a/test cases/common/51 file grabber/subdir/subb.c
+++ b/test cases/common/51 file grabber/subdir/subb.c
@@ -1,1 +1,1 @@
-int funcb() { return 0; }
+int funcb(void) { return 0; }

--- a/test cases/common/51 file grabber/subdir/subc.c
+++ b/test cases/common/51 file grabber/subdir/subc.c
@@ -1,1 +1,1 @@
-int funcc() { return 0; }
+int funcc(void) { return 0; }

--- a/test cases/common/51 file grabber/subdir/subprog.c
+++ b/test cases/common/51 file grabber/subdir/subprog.c
@@ -1,6 +1,6 @@
-int funca();
-int funcb();
-int funcc();
+int funca(void);
+int funcb(void);
+int funcc(void);
 
 int main(void) {
     return funca() + funcb() + funcc();

--- a/test cases/common/55 object generator/prog.c
+++ b/test cases/common/55 object generator/prog.c
@@ -1,6 +1,6 @@
-int func1_in_obj();
-int func2_in_obj();
-int func3_in_obj();
+int func1_in_obj(void);
+int func2_in_obj(void);
+int func3_in_obj(void);
 
 int main(void) {
     return func1_in_obj() + func2_in_obj() + func3_in_obj();

--- a/test cases/common/55 object generator/source.c
+++ b/test cases/common/55 object generator/source.c
@@ -1,3 +1,3 @@
-int func1_in_obj() {
+int func1_in_obj(void) {
     return 0;
 }

--- a/test cases/common/55 object generator/source2.c
+++ b/test cases/common/55 object generator/source2.c
@@ -1,3 +1,3 @@
-int func2_in_obj() {
+int func2_in_obj(void) {
     return 0;
 }

--- a/test cases/common/55 object generator/source3.c
+++ b/test cases/common/55 object generator/source3.c
@@ -1,3 +1,3 @@
-int func3_in_obj() {
+int func3_in_obj(void) {
     return 0;
 }

--- a/test cases/common/57 custom target source output/generator.py
+++ b/test cases/common/57 custom target source output/generator.py
@@ -8,9 +8,9 @@ if len(sys.argv) != 2:
 odir = sys.argv[1]
 
 with open(os.path.join(odir, 'mylib.h'), 'w') as f:
-    f.write('int func();\n')
+    f.write('int func(void);\n')
 with open(os.path.join(odir, 'mylib.c'), 'w') as f:
-    f.write('''int func() {
+    f.write('''int func(void) {
     return 0;
 }
 ''')

--- a/test cases/common/58 exe static shared/prog.c
+++ b/test cases/common/58 exe static shared/prog.c
@@ -1,5 +1,5 @@
-int shlibfunc2();
-int statlibfunc();
+int shlibfunc2(void);
+int statlibfunc(void);
 
 int main(void) {
     if (statlibfunc() != 42)

--- a/test cases/common/58 exe static shared/stat.c
+++ b/test cases/common/58 exe static shared/stat.c
@@ -1,7 +1,7 @@
 #include "subdir/exports.h"
 
-int shlibfunc();
+int shlibfunc(void);
 
-int DLL_PUBLIC statlibfunc() {
+int DLL_PUBLIC statlibfunc(void) {
     return shlibfunc();
 }

--- a/test cases/common/58 exe static shared/stat2.c
+++ b/test cases/common/58 exe static shared/stat2.c
@@ -1,3 +1,3 @@
-int statlibfunc2() {
+int statlibfunc2(void) {
     return 18;
 }

--- a/test cases/common/58 exe static shared/subdir/shlib.c
+++ b/test cases/common/58 exe static shared/subdir/shlib.c
@@ -1,5 +1,5 @@
 #include "exports.h"
 
-int DLL_PUBLIC shlibfunc() {
+int DLL_PUBLIC shlibfunc(void) {
     return 42;
 }

--- a/test cases/common/6 linkshared/cpplib.cpp
+++ b/test cases/common/6 linkshared/cpplib.cpp
@@ -4,6 +4,6 @@
     #define DLL_PUBLIC __attribute__ ((visibility ("default")))
 #endif
 
-int DLL_PUBLIC cppfunc() {
+int DLL_PUBLIC cppfunc(void) {
     return 42;
 }

--- a/test cases/common/6 linkshared/cppmain.cpp
+++ b/test cases/common/6 linkshared/cppmain.cpp
@@ -1,5 +1,5 @@
-int cppfunc();
+int cppfunc(void);
 
-int main() {
+int main(void) {
     return cppfunc() != 42;
 }

--- a/test cases/common/6 linkshared/libfile.c
+++ b/test cases/common/6 linkshared/libfile.c
@@ -9,6 +9,6 @@
   #endif
 #endif
 
-int DLL_PUBLIC func() {
+int DLL_PUBLIC func(void) {
     return 0;
 }

--- a/test cases/common/6 linkshared/main.c
+++ b/test cases/common/6 linkshared/main.c
@@ -4,7 +4,7 @@
   #define DLL_IMPORT
 #endif
 
-int DLL_IMPORT func();
+int DLL_IMPORT func(void);
 
 int main(void) {
     return func();

--- a/test cases/common/61 multiple generators/main.cpp
+++ b/test cases/common/61 multiple generators/main.cpp
@@ -1,6 +1,6 @@
 #include"source1.h"
 #include"source2.h"
 
-int main() {
+int main(void) {
     return func1() + func2();
 }

--- a/test cases/common/7 mixed/func.c
+++ b/test cases/common/7 mixed/func.c
@@ -1,4 +1,4 @@
-int func() {
+int func(void) {
     int class = 0;
     return class;
 }

--- a/test cases/common/7 mixed/main.cc
+++ b/test cases/common/7 mixed/main.cc
@@ -2,6 +2,6 @@ extern "C" int func();
 
 class BreakPlainCCompiler;
 
-int main() {
+int main(void) {
     return func();
 }

--- a/test cases/common/75 shared subproject/a.c
+++ b/test cases/common/75 shared subproject/a.c
@@ -1,6 +1,6 @@
 #include<assert.h>
-char func_b();
-char func_c();
+char func_b(void);
+char func_c(void);
 
 int main(void) {
     if(func_b() != 'b') {

--- a/test cases/common/75 shared subproject/subprojects/B/b.c
+++ b/test cases/common/75 shared subproject/subprojects/B/b.c
@@ -11,9 +11,9 @@
 #endif
 
 
-char func_c();
+char func_c(void);
 
-char DLL_PUBLIC func_b() {
+char DLL_PUBLIC func_b(void) {
     if(func_c() != 'c') {
         exit(3);
     }

--- a/test cases/common/75 shared subproject/subprojects/C/c.c
+++ b/test cases/common/75 shared subproject/subprojects/C/c.c
@@ -9,6 +9,6 @@
   #endif
 #endif
 
-char DLL_PUBLIC func_c() {
+char DLL_PUBLIC func_c(void) {
     return 'c';
 }

--- a/test cases/common/76 shared subproject 2/a.c
+++ b/test cases/common/76 shared subproject 2/a.c
@@ -1,6 +1,6 @@
 #include<assert.h>
-char func_b();
-char func_c();
+char func_b(void);
+char func_c(void);
 
 int main(void) {
     if(func_b() != 'b') {

--- a/test cases/common/76 shared subproject 2/subprojects/B/b.c
+++ b/test cases/common/76 shared subproject 2/subprojects/B/b.c
@@ -1,5 +1,5 @@
 #include<stdlib.h>
-char func_c();
+char func_c(void);
 
 #if defined _WIN32 || defined __CYGWIN__
 #define DLL_PUBLIC __declspec(dllexport)
@@ -12,7 +12,7 @@ char func_c();
   #endif
 #endif
 
-char DLL_PUBLIC func_b() {
+char DLL_PUBLIC func_b(void) {
     if(func_c() != 'c') {
         exit(3);
     }

--- a/test cases/common/76 shared subproject 2/subprojects/C/c.c
+++ b/test cases/common/76 shared subproject 2/subprojects/C/c.c
@@ -9,6 +9,6 @@
   #endif
 #endif
 
-char DLL_PUBLIC func_c() {
+char DLL_PUBLIC func_c(void) {
     return 'c';
 }

--- a/test cases/common/77 file object/lib.c
+++ b/test cases/common/77 file object/lib.c
@@ -1,3 +1,3 @@
-int func() {
+int func(void) {
     return 0;
 }

--- a/test cases/common/77 file object/prog.c
+++ b/test cases/common/77 file object/prog.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int func(); /* Files in different subdirs return different values. */
+int func(void); /* Files in different subdirs return different values. */
 
 int main(void) {
     if(func() == 0) {

--- a/test cases/common/77 file object/subdir1/lib.c
+++ b/test cases/common/77 file object/subdir1/lib.c
@@ -1,3 +1,3 @@
-int func() {
+int func(void) {
     return 1;
 }

--- a/test cases/common/77 file object/subdir1/prog.c
+++ b/test cases/common/77 file object/subdir1/prog.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int func();
+int func(void);
 
 int main(void) {
     if(func() == 1) {

--- a/test cases/common/77 file object/subdir2/lib.c
+++ b/test cases/common/77 file object/subdir2/lib.c
@@ -1,3 +1,3 @@
-int func() {
+int func(void) {
     return 2;
 }

--- a/test cases/common/77 file object/subdir2/prog.c
+++ b/test cases/common/77 file object/subdir2/prog.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-int func();
+int func(void);
 
 int main(void) {
     if(func() == 2) {

--- a/test cases/common/78 custom subproject dir/a.c
+++ b/test cases/common/78 custom subproject dir/a.c
@@ -1,6 +1,6 @@
 #include<assert.h>
-char func_b();
-char func_c();
+char func_b(void);
+char func_c(void);
 
 int main(void) {
     if(func_b() != 'b') {

--- a/test cases/common/78 custom subproject dir/custom_subproject_dir/B/b.c
+++ b/test cases/common/78 custom subproject dir/custom_subproject_dir/B/b.c
@@ -1,5 +1,5 @@
 #include<stdlib.h>
-char func_c();
+char func_c(void);
 
 #if defined _WIN32 || defined __CYGWIN__
 #define DLL_PUBLIC __declspec(dllexport)
@@ -12,7 +12,7 @@ char func_c();
   #endif
 #endif
 
-char DLL_PUBLIC func_b() {
+char DLL_PUBLIC func_b(void) {
     if(func_c() != 'c') {
         exit(3);
     }

--- a/test cases/common/78 custom subproject dir/custom_subproject_dir/C/c.c
+++ b/test cases/common/78 custom subproject dir/custom_subproject_dir/C/c.c
@@ -9,6 +9,6 @@
   #endif
 #endif
 
-char DLL_PUBLIC func_c() {
+char DLL_PUBLIC func_c(void) {
     return 'c';
 }

--- a/test cases/common/8 install/stat.c
+++ b/test cases/common/8 install/stat.c
@@ -1,1 +1,1 @@
-int func() { return 933; }
+int func(void) { return 933; }

--- a/test cases/common/80 extract from nested subdir/src/first/lib_first.c
+++ b/test cases/common/80 extract from nested subdir/src/first/lib_first.c
@@ -1,3 +1,3 @@
-int first() {
+int first(void) {
     return 1001;
 }

--- a/test cases/common/81 internal dependency/proj1/include/proj1.h
+++ b/test cases/common/81 internal dependency/proj1/include/proj1.h
@@ -1,5 +1,5 @@
 #pragma once
 
-void proj1_func1();
-void proj1_func2();
-void proj1_func3();
+void proj1_func1(void);
+void proj1_func2(void);
+void proj1_func3(void);

--- a/test cases/common/81 internal dependency/proj1/proj1f1.c
+++ b/test cases/common/81 internal dependency/proj1/proj1f1.c
@@ -1,6 +1,6 @@
 #include<proj1.h>
 #include<stdio.h>
 
-void proj1_func1() {
+void proj1_func1(void) {
     printf("In proj1_func1.\n");
 }

--- a/test cases/common/81 internal dependency/proj1/proj1f2.c
+++ b/test cases/common/81 internal dependency/proj1/proj1f2.c
@@ -1,6 +1,6 @@
 #include<proj1.h>
 #include<stdio.h>
 
-void proj1_func2() {
+void proj1_func2(void) {
     printf("In proj1_func2.\n");
 }

--- a/test cases/common/81 internal dependency/proj1/proj1f3.c
+++ b/test cases/common/81 internal dependency/proj1/proj1f3.c
@@ -1,6 +1,6 @@
 #include<proj1.h>
 #include<stdio.h>
 
-void proj1_func3() {
+void proj1_func3(void) {
     printf("In proj1_func3.\n");
 }

--- a/test cases/common/82 same basename/exe1.c
+++ b/test cases/common/82 same basename/exe1.c
@@ -1,4 +1,4 @@
-int func();
+int func(void);
 
 int main(void) {
     return func();

--- a/test cases/common/82 same basename/exe2.c
+++ b/test cases/common/82 same basename/exe2.c
@@ -1,4 +1,4 @@
-int func();
+int func(void);
 
 int main(void) {
     return func() == 1 ? 0 : 1;

--- a/test cases/common/82 same basename/lib.c
+++ b/test cases/common/82 same basename/lib.c
@@ -10,11 +10,11 @@
 #endif
 
 #if defined SHAR
-int DLL_PUBLIC func() {
+int DLL_PUBLIC func(void) {
     return 1;
 }
 #elif defined STAT
-int func() {
+int func(void) {
     return 0;
 }
 #else

--- a/test cases/common/83 declare dep/entity/entity.h
+++ b/test cases/common/83 declare dep/entity/entity.h
@@ -1,4 +1,4 @@
 #pragma once
 
-int entity_func1();
-int entity_func2();
+int entity_func1(void);
+int entity_func2(void);

--- a/test cases/common/83 declare dep/entity/entity1.c
+++ b/test cases/common/83 declare dep/entity/entity1.c
@@ -4,6 +4,6 @@
 #error "Entity use flag leaked into entity compilation."
 #endif
 
-int entity_func1() {
+int entity_func1(void) {
     return 5;
 }

--- a/test cases/common/83 declare dep/entity/entity2.c
+++ b/test cases/common/83 declare dep/entity/entity2.c
@@ -1,5 +1,5 @@
 #include<entity.h>
 
-int entity_func2() {
+int entity_func2(void) {
     return 9;
 }

--- a/test cases/common/84 extract all/extractor.h
+++ b/test cases/common/84 extract all/extractor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-int func1();
-int func2();
-int func3();
-int func4();
+int func1(void);
+int func2(void);
+int func3(void);
+int func4(void);

--- a/test cases/common/84 extract all/four.c
+++ b/test cases/common/84 extract all/four.c
@@ -1,5 +1,5 @@
 #include"extractor.h"
 
-int func4() {
+int func4(void) {
     return 4;
 }

--- a/test cases/common/84 extract all/one.c
+++ b/test cases/common/84 extract all/one.c
@@ -1,5 +1,5 @@
 #include"extractor.h"
 
-int func1() {
+int func1(void) {
     return 1;
 }

--- a/test cases/common/84 extract all/three.c
+++ b/test cases/common/84 extract all/three.c
@@ -1,5 +1,5 @@
 #include"extractor.h"
 
-int func3() {
+int func3(void) {
     return 3;
 }

--- a/test cases/common/84 extract all/two.c
+++ b/test cases/common/84 extract all/two.c
@@ -1,5 +1,5 @@
 #include"extractor.h"
 
-int func2() {
+int func2(void) {
     return 2;
 }

--- a/test cases/common/89 private include/stlib/compiler.py
+++ b/test cases/common/89 private include/stlib/compiler.py
@@ -5,12 +5,12 @@ import sys, os
 assert(len(sys.argv) == 3)
 
 h_templ = '''#pragma once
-unsigned int %s();
+unsigned int %s(void);
 '''
 
 c_templ = '''#include"%s.h"
 
-unsigned int %s() {
+unsigned int %s(void) {
   return 0;
 }
 '''

--- a/test cases/common/91 dep fallback/subprojects/boblib/bob.c
+++ b/test cases/common/91 dep fallback/subprojects/boblib/bob.c
@@ -3,6 +3,6 @@
 #ifdef _MSC_VER
 __declspec(dllexport)
 #endif
-const char* get_bob() {
+const char* get_bob(void) {
     return "bob";
 }

--- a/test cases/common/91 dep fallback/subprojects/boblib/bob.h
+++ b/test cases/common/91 dep fallback/subprojects/boblib/bob.h
@@ -3,4 +3,4 @@
 #ifdef _MSC_VER
 __declspec(dllimport)
 #endif
-const char* get_bob();
+const char* get_bob(void);

--- a/test cases/common/93 selfbuilt custom/mainprog.cpp
+++ b/test cases/common/93 selfbuilt custom/mainprog.cpp
@@ -1,5 +1,5 @@
 #include"data.h"
 
-int main() {
+int main(void) {
     return generated_function() != 52;
 }

--- a/test cases/common/94 gen extra/name.l
+++ b/test cases/common/94 gen extra/name.l
@@ -1,3 +1,3 @@
-int main() {
+int main(void) {
 return 0;
 }

--- a/test cases/common/94 gen extra/plain.c
+++ b/test cases/common/94 gen extra/plain.c
@@ -1,4 +1,4 @@
-int bob_mcbob();
+int bob_mcbob(void);
 
 int main(void) {
     return bob_mcbob();

--- a/test cases/common/94 gen extra/srcgen.py
+++ b/test cases/common/94 gen extra/srcgen.py
@@ -11,7 +11,7 @@ parser.add_argument('--output', dest='output',
 parser.add_argument('--upper', dest='upper', action='store_true', default=False,
                     help='Convert to upper case.')
 
-c_templ = '''int %s() {
+c_templ = '''int %s(void) {
     return 0;
 }
 '''

--- a/test cases/common/94 gen extra/upper.c
+++ b/test cases/common/94 gen extra/upper.c
@@ -1,4 +1,4 @@
-int BOB_MCBOB();
+int BOB_MCBOB(void);
 
 int main(void) {
     return BOB_MCBOB();

--- a/test cases/common/98 threads/threadprog.c
+++ b/test cases/common/98 threads/threadprog.c
@@ -3,7 +3,7 @@
 #include<windows.h>
 #include<stdio.h>
 
-DWORD WINAPI thread_func() {
+DWORD WINAPI thread_func(void) {
     printf("Printing from a thread.\n");
     return 0;
 }
@@ -22,7 +22,7 @@ int main(void) {
 #include<pthread.h>
 #include<stdio.h>
 
-void* main_func() {
+void* main_func(void) {
     printf("Printing from a thread.\n");
     return NULL;
 }

--- a/test cases/common/98 threads/threadprog.cpp
+++ b/test cases/common/98 threads/threadprog.cpp
@@ -14,7 +14,7 @@ DWORD WINAPI thread_func(LPVOID) {
     return 0;
 }
 
-int main() {
+int main(void) {
     printf("Starting thread.\n");
     HANDLE th;
     DWORD id;
@@ -28,11 +28,11 @@ int main() {
 #include<thread>
 #include<cstdio>
 
-void main_func() {
+void main_func(void) {
     printf("Printing from a thread.\n");
 }
 
-int main() {
+int main(void) {
     printf("Starting thread.\n");
     std::thread th(main_func);
     th.join();

--- a/test cases/common/99 manygen/subdir/manygen.py
+++ b/test cases/common/99 manygen/subdir/manygen.py
@@ -43,20 +43,20 @@ tmpo = 'diibadaaba' + objsuffix
 
 with open(outc, 'w') as f:
     f.write('''#include"%s.h"
-int %s_in_src() {
+int %s_in_src(void) {
   return 0;
 }
 ''' % (funcname, funcname))
 
 with open(outh, 'w') as f:
     f.write('''#pragma once
-int %s_in_lib();
-int %s_in_obj();
-int %s_in_src();
+int %s_in_lib(void);
+int %s_in_obj(void);
+int %s_in_src(void);
 ''' % (funcname, funcname, funcname))
 
 with open(tmpc, 'w') as f:
-    f.write('''int %s_in_obj() {
+    f.write('''int %s_in_obj(void) {
   return 0;
 }
 ''' % funcname)

--- a/test cases/cuda/10 cuda dependency/c/prog.c
+++ b/test cases/cuda/10 cuda dependency/c/prog.c
@@ -7,7 +7,7 @@ int cuda_devices() {
     return result;
 }
 
-int main() {
+int main(void) {
     int n = cuda_devices();
     if (n == 0) {
         printf("No CUDA hardware found. Exiting.\n");

--- a/test cases/cuda/10 cuda dependency/cpp/prog.cc
+++ b/test cases/cuda/10 cuda dependency/cpp/prog.cc
@@ -1,13 +1,13 @@
 #include <cuda_runtime.h>
 #include <iostream>
 
-int cuda_devices() {
+int cuda_devices(void) {
     int result = 0;
     cudaGetDeviceCount(&result);
     return result;
 }
 
-int main() {
+int main(void) {
     int n = cuda_devices();
     if (n == 0) {
         std::cout << "No CUDA hardware found. Exiting.\n";

--- a/test cases/cuda/10 cuda dependency/modules/prog.cc
+++ b/test cases/cuda/10 cuda dependency/modules/prog.cc
@@ -2,13 +2,13 @@
 #include <cublas_v2.h>
 #include <iostream>
 
-int cuda_devices() {
+int cuda_devices(void) {
     int result = 0;
     cudaGetDeviceCount(&result);
     return result;
 }
 
-int main() {
+int main(void) {
     int n = cuda_devices();
     if (n == 0) {
         std::cout << "No CUDA hardware found. Exiting.\n";
@@ -24,7 +24,7 @@ int main() {
     }
 
     std::cout << "Initialized cuBLAS\n";
-    if (cublasDestroy(handle) != CUBLAS_STATUS_SUCCESS) {        
+    if (cublasDestroy(handle) != CUBLAS_STATUS_SUCCESS) {
         std::cout << "cuBLAS de-initialization failed. Exiting.\n";
         return -1;
     }

--- a/test cases/cuda/10 cuda dependency/version_reqs/prog.cc
+++ b/test cases/cuda/10 cuda dependency/version_reqs/prog.cc
@@ -1,13 +1,13 @@
 #include <cuda_runtime.h>
 #include <iostream>
 
-int cuda_devices() {
+int cuda_devices(void) {
     int result = 0;
     cudaGetDeviceCount(&result);
     return result;
 }
 
-int main() {
+int main(void) {
     std::cout << "Compiled against CUDA version: " << CUDART_VERSION << "\n";
     int runtime_version = 0;
     cudaError_t r = cudaRuntimeGetVersion(&runtime_version);

--- a/test cases/cuda/12 cuda dependency (mixed)/prog.cpp
+++ b/test cases/cuda/12 cuda dependency (mixed)/prog.cpp
@@ -4,13 +4,13 @@
 
 void do_cuda_stuff();
 
-int cuda_devices() {
+int cuda_devices(void) {
     int result = 0;
     cudaGetDeviceCount(&result);
     return result;
 }
 
-int main() {
+int main(void) {
     int n = cuda_devices();
     if (n == 0) {
         std::cout << "No CUDA hardware found. Exiting.\n";
@@ -28,7 +28,7 @@ int main() {
     }
 
     std::cout << "Initialized cuBLAS\n";
-    if (cublasDestroy(handle) != CUBLAS_STATUS_SUCCESS) {        
+    if (cublasDestroy(handle) != CUBLAS_STATUS_SUCCESS) {
         std::cout << "cuBLAS de-initialization failed. Exiting.\n";
         return -1;
     }

--- a/test cases/failing/16 extract from subproject/main.c
+++ b/test cases/failing/16 extract from subproject/main.c
@@ -1,5 +1,5 @@
 int sub_lib_method(void);
 
-int main() {
+int main(void) {
     return 1337 - sub_lib_method();
 }

--- a/test cases/failing/93 pch source different folder/prog.c
+++ b/test cases/failing/93 pch source different folder/prog.c
@@ -1,1 +1,1 @@
-int main() {}
+int main(void) {}

--- a/test cases/fortran/9 cpp/main.cpp
+++ b/test cases/fortran/9 cpp/main.cpp
@@ -2,7 +2,7 @@
 
 extern "C" double fortran();
 
-int main() {
+int main(void) {
     std::cout << "FORTRAN gave us this number: " << fortran() << '\n';
     return 0;
 }

--- a/test cases/frameworks/1 boost/partial_dep/main.cpp
+++ b/test cases/frameworks/1 boost/partial_dep/main.cpp
@@ -18,7 +18,7 @@
 #include "foo.hpp"
 
 
-int main() {
+int main(void) {
     auto foo = Foo();
     vec v = foo.vector();
     std::cout << boost::fusion::at_c<0>(v) << std::endl;

--- a/test cases/frameworks/18 vulkan/vulkanprog.c
+++ b/test cases/frameworks/18 vulkan/vulkanprog.c
@@ -1,7 +1,7 @@
 #include <vulkan/vulkan.h>
 #include <stdio.h>
 
-int main()
+int main(void)
 {
     VkInstanceCreateInfo instance_create_info = {
             VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
@@ -21,6 +21,6 @@ int main()
     VkInstance instance;
     if(vkCreateInstance(&instance_create_info, NULL, &instance) == VK_SUCCESS)
         vkDestroyInstance(instance, NULL);
-        
-    return 0;    
+
+    return 0;
 }

--- a/test cases/frameworks/9 wxwidgets/wxstc.cpp
+++ b/test cases/frameworks/9 wxwidgets/wxstc.cpp
@@ -1,6 +1,6 @@
 #include <wx/stc/stc.h>
 
-int main() {
+int main(void) {
     wxStyledTextCtrl *canvas = new wxStyledTextCtrl();
     delete canvas;
 }

--- a/test cases/linuxlike/1 pkg-config/meson.build
+++ b/test cases/linuxlike/1 pkg-config/meson.build
@@ -39,7 +39,7 @@ cc = meson.get_compiler('c')
 zlibdep = cc.find_library('z')
 code = '''#include<myinc.h>
 
-int main() {
+int main(void) {
     void * something = deflate;
     if(something != 0)
         return 0;

--- a/test cases/linuxlike/1 pkg-config/prog-checkver.c
+++ b/test cases/linuxlike/1 pkg-config/prog-checkver.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int main() {
+int main(void) {
     void * something = deflate;
     if(strcmp(ZLIB_VERSION, FOUND_ZLIB) != 0) {
         printf("Meson found '%s' but zlib is '%s'\n", FOUND_ZLIB, ZLIB_VERSION);

--- a/test cases/linuxlike/1 pkg-config/prog.c
+++ b/test cases/linuxlike/1 pkg-config/prog.c
@@ -1,6 +1,6 @@
 #include<zlib.h>
 
-int main() {
+int main(void) {
     void * something = deflate;
     if(something != 0)
         return 0;

--- a/test cases/linuxlike/12 subprojects in subprojects/main.c
+++ b/test cases/linuxlike/12 subprojects in subprojects/main.c
@@ -2,7 +2,7 @@
 #include "a.h"
 #include "b.h"
 
-int main() {
+int main(void) {
     int life = a_fun() + b_fun();
     printf("%d\n", life);
     return 0;

--- a/test cases/linuxlike/12 subprojects in subprojects/subprojects/a/a.c
+++ b/test cases/linuxlike/12 subprojects in subprojects/subprojects/a/a.c
@@ -1,5 +1,5 @@
 #include "c.h"
 
-int a_fun() {
+int a_fun(void) {
     return c_fun();
 }

--- a/test cases/linuxlike/12 subprojects in subprojects/subprojects/a/a.h
+++ b/test cases/linuxlike/12 subprojects in subprojects/subprojects/a/a.h
@@ -1,1 +1,1 @@
-int a_fun();
+int a_fun(void);

--- a/test cases/linuxlike/12 subprojects in subprojects/subprojects/b/b.c
+++ b/test cases/linuxlike/12 subprojects in subprojects/subprojects/b/b.c
@@ -2,7 +2,7 @@
 #include "c.h"
 #endif
 
-int b_fun(){
+int b_fun(void){
 #if defined(WITH_C)
 return c_fun();
 #else

--- a/test cases/linuxlike/12 subprojects in subprojects/subprojects/b/b.h
+++ b/test cases/linuxlike/12 subprojects in subprojects/subprojects/b/b.h
@@ -1,1 +1,1 @@
-int b_fun();
+int b_fun(void);

--- a/test cases/linuxlike/12 subprojects in subprojects/subprojects/c/c.h
+++ b/test cases/linuxlike/12 subprojects in subprojects/subprojects/c/c.h
@@ -1,3 +1,3 @@
-static int c_fun(){
+static int c_fun(void){
     return 3;
 }

--- a/test cases/linuxlike/13 cmake dependency/meson.build
+++ b/test cases/linuxlike/13 cmake dependency/meson.build
@@ -61,7 +61,7 @@ cc = meson.get_compiler('c')
 zlibdep = cc.find_library('z')
 code = '''#include<myinc.h>
 
-int main() {
+int main(void) {
     void * something = deflate;
     if(something != 0)
         return 0;

--- a/test cases/linuxlike/13 cmake dependency/prog-checkver.c
+++ b/test cases/linuxlike/13 cmake dependency/prog-checkver.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int main() {
+int main(void) {
     void * something = deflate;
     if(strcmp(ZLIB_VERSION, FOUND_ZLIB) != 0) {
         printf("Meson found '%s' but zlib is '%s'\n", FOUND_ZLIB, ZLIB_VERSION);

--- a/test cases/linuxlike/13 cmake dependency/prog.c
+++ b/test cases/linuxlike/13 cmake dependency/prog.c
@@ -1,6 +1,6 @@
 #include<zlib.h>
 
-int main() {
+int main(void) {
     void * something = deflate;
     if(something != 0)
         return 0;

--- a/test cases/linuxlike/13 cmake dependency/testFlagSet.c
+++ b/test cases/linuxlike/13 cmake dependency/testFlagSet.c
@@ -9,7 +9,7 @@
 #error "REQUIRED_MESON_FLAG2 not set"
 #endif
 
-int main() {
+int main(void) {
   printf("Hello World\n");
   void * something = deflate;
   if(something != 0)

--- a/test cases/linuxlike/14 static dynamic linkage/main.c
+++ b/test cases/linuxlike/14 static dynamic linkage/main.c
@@ -1,7 +1,7 @@
 #include "stdio.h"
 #include "zlib.h"
 
-int main() {
+int main(void) {
     printf("%s\n", zlibVersion());
     return 0;
 }

--- a/test cases/linuxlike/2 external library/meson.build
+++ b/test cases/linuxlike/2 external library/meson.build
@@ -5,14 +5,14 @@ zlib = cc.find_library('z')
 
 # Verify that link testing works.
 linkcode = '''#include<zlib.h>
-int main() {
+int main(void) {
   void *ptr = (void*)(deflate);
   return ptr == 0;
 }
 '''
 
 nolinkcode='''int nonexisting();
-int main() {
+int main(void) {
   return nonexisting();
 }
 '''

--- a/test cases/linuxlike/2 external library/prog.c
+++ b/test cases/linuxlike/2 external library/prog.c
@@ -1,6 +1,6 @@
 #include<zlib.h>
 
-int main() {
+int main(void) {
     void * something = deflate;
     if(something != 0)
         return 0;

--- a/test cases/linuxlike/3 linker script/bob.c
+++ b/test cases/linuxlike/3 linker script/bob.c
@@ -1,9 +1,9 @@
 #include"bob.h"
 
-int hiddenFunction() {
+int hiddenFunction(void) {
     return 42;
 }
 
-int bobMcBob() {
+int bobMcBob(void) {
     return hiddenFunction();
 }

--- a/test cases/linuxlike/3 linker script/bob.h
+++ b/test cases/linuxlike/3 linker script/bob.h
@@ -1,6 +1,6 @@
 #ifndef BOB_H_
 #define BOB_H_
 
-int bobMcBob();
+int bobMcBob(void);
 
 #endif

--- a/test cases/linuxlike/3 linker script/prog.c
+++ b/test cases/linuxlike/3 linker script/prog.c
@@ -1,5 +1,5 @@
 #include"bob.h"
 
-int main() {
+int main(void) {
     return bobMcBob() != 42;
 }

--- a/test cases/linuxlike/4 extdep static lib/lib.c
+++ b/test cases/linuxlike/4 extdep static lib/lib.c
@@ -1,6 +1,6 @@
 #include<zlib.h>
 
-int statlibfunc() {
+int statlibfunc(void) {
     void * something = deflate;
     if(something != 0)
         return 0;

--- a/test cases/linuxlike/4 extdep static lib/prog.c
+++ b/test cases/linuxlike/4 extdep static lib/prog.c
@@ -1,5 +1,5 @@
-int statlibfunc();
+int statlibfunc(void);
 
-int main() {
+int main(void) {
     return statlibfunc();
 }

--- a/test cases/linuxlike/6 subdir include order/prog.c
+++ b/test cases/linuxlike/6 subdir include order/prog.c
@@ -4,4 +4,4 @@
 #error "Failed"
 #endif
 
-int main() { return 0; }
+int main(void) { return 0; }

--- a/test cases/linuxlike/7 library versions/exe.orig.c
+++ b/test cases/linuxlike/7 library versions/exe.orig.c
@@ -1,6 +1,6 @@
 int myFunc (void);
 
-int main()
+int main(void)
 {
   if (myFunc() == 55)
     return 0;

--- a/test cases/linuxlike/7 library versions/lib.c
+++ b/test cases/linuxlike/7 library versions/lib.c
@@ -1,3 +1,3 @@
-int myFunc() {
+int myFunc(void) {
     return 55;
 }

--- a/test cases/linuxlike/8 subproject library install/subprojects/sublib/include/subdefs.h
+++ b/test cases/linuxlike/8 subproject library install/subprojects/sublib/include/subdefs.h
@@ -16,6 +16,6 @@
   #endif
 #endif
 
-int DLL_PUBLIC subfunc();
+int DLL_PUBLIC subfunc(void);
 
 #endif

--- a/test cases/linuxlike/8 subproject library install/subprojects/sublib/sublib.c
+++ b/test cases/linuxlike/8 subproject library install/subprojects/sublib/sublib.c
@@ -1,5 +1,5 @@
 #include<subdefs.h>
 
-int DLL_PUBLIC subfunc() {
+int DLL_PUBLIC subfunc(void) {
     return 42;
 }

--- a/test cases/linuxlike/9 compiler checks with dependencies/meson.build
+++ b/test cases/linuxlike/9 compiler checks with dependencies/meson.build
@@ -10,7 +10,7 @@ if glib.found()
   assert (cc.has_member('GError', 'message', prefix : '#include <glib.h>', dependencies : glib), 'GError::message not found')
   assert (cc.has_header_symbol('glib.h', 'gint32', dependencies : glib), 'gint32 symbol not found')
   linkcode = '''#include <glib.h>
-int main () {
+int main (void) {
   GError *error = g_error_new_literal (0, 0, NULL);
   return error == NULL;
 }
@@ -34,5 +34,3 @@ assert(cc.has_function('pthread_create',
     dependencies : dependency('threads'),
     prefix : '#include <pthread.h>'),
   'Could not detect pthread_create with a thread dependency.')
-
-

--- a/test cases/linuxlike/9 compiler checks with dependencies/meson.build
+++ b/test cases/linuxlike/9 compiler checks with dependencies/meson.build
@@ -21,7 +21,7 @@ endif
 zlib = cc.find_library ('z')
 if zlib.found()
   linkcode = '''#include<zlib.h>
-int main() {
+int main(void) {
   void *ptr = (void*)(deflate);
   return ptr == 0;
 }

--- a/test cases/objc/4 c++ project objc subproject/master.cpp
+++ b/test cases/objc/4 c++ project objc subproject/master.cpp
@@ -4,7 +4,7 @@
 extern "C"
 int foo();
 
-int main() {
+int main(void) {
   std::cout << "Starting\n";
   std::cout << foo() << "\n";
   return 0;

--- a/test cases/rust/4 polyglot/prog.c
+++ b/test cases/rust/4 polyglot/prog.c
@@ -2,7 +2,7 @@
 
 void f();
 
-int main() {
+int main(void) {
     printf("Hello from C!\n");
     f();
 }

--- a/test cases/rust/5 polyglot static/prog.c
+++ b/test cases/rust/5 polyglot static/prog.c
@@ -2,7 +2,7 @@
 
 void f();
 
-int main() {
+int main(void) {
     printf("Hello from C!\n");
     f();
 }

--- a/test cases/unit/14 testsetup selection/main.c
+++ b/test cases/unit/14 testsetup selection/main.c
@@ -1,3 +1,3 @@
-int main() {
+int main(void) {
     return 0;
 }

--- a/test cases/unit/14 testsetup selection/subprojects/bar/bar.c
+++ b/test cases/unit/14 testsetup selection/subprojects/bar/bar.c
@@ -1,3 +1,3 @@
-int main() {
+int main(void) {
     return 0;
 }

--- a/test cases/unit/14 testsetup selection/subprojects/foo/foo.c
+++ b/test cases/unit/14 testsetup selection/subprojects/foo/foo.c
@@ -1,3 +1,3 @@
-int main() {
+int main(void) {
     return 0;
 }

--- a/test cases/unit/25 non-permitted kwargs/meson.build
+++ b/test cases/unit/25 non-permitted kwargs/meson.build
@@ -1,5 +1,5 @@
 project('non-permitted kwargs', 'c')
 cc = meson.get_compiler('c')
 cc.has_header_symbol('stdio.h', 'printf', prefixxx: '#define XXX')
-cc.links('int main(){}', argsxx: '')
+cc.links('int main(void){}', argsxx: '')
 cc.get_id(invalidxx: '')

--- a/test cases/unit/29 guessed linker dependencies/exe/app.c
+++ b/test cases/unit/29 guessed linker dependencies/exe/app.c
@@ -1,6 +1,6 @@
 void liba_func();
 
-int main() {
+int main(void) {
     liba_func();
     return 0;
 }

--- a/test cases/unit/32 pkgconfig use libraries/app/app.c
+++ b/test cases/unit/32 pkgconfig use libraries/app/app.c
@@ -1,6 +1,6 @@
 void libb_func();
 
-int main() {
+int main(void) {
     libb_func();
     return 0;
 }

--- a/test cases/unit/4 suite selection/failing_test.c
+++ b/test cases/unit/4 suite selection/failing_test.c
@@ -1,1 +1,1 @@
-int main() { return -1 ; }
+int main(void) { return -1 ; }

--- a/test cases/unit/4 suite selection/subprojects/subprjfail/failing_test.c
+++ b/test cases/unit/4 suite selection/subprojects/subprjfail/failing_test.c
@@ -1,1 +1,1 @@
-int main() { return -1 ; }
+int main(void) { return -1 ; }

--- a/test cases/unit/4 suite selection/subprojects/subprjmix/failing_test.c
+++ b/test cases/unit/4 suite selection/subprojects/subprjmix/failing_test.c
@@ -1,1 +1,1 @@
-int main() { return -1 ; }
+int main(void) { return -1 ; }

--- a/test cases/unit/4 suite selection/subprojects/subprjmix/successful_test.c
+++ b/test cases/unit/4 suite selection/subprojects/subprjmix/successful_test.c
@@ -1,1 +1,1 @@
-int main() { return 0 ; }
+int main(void) { return 0 ; }

--- a/test cases/unit/4 suite selection/subprojects/subprjsucc/successful_test.c
+++ b/test cases/unit/4 suite selection/subprojects/subprjsucc/successful_test.c
@@ -1,1 +1,1 @@
-int main() { return 0 ; }
+int main(void) { return 0 ; }

--- a/test cases/unit/4 suite selection/successful_test.c
+++ b/test cases/unit/4 suite selection/successful_test.c
@@ -1,1 +1,1 @@
-int main() { return 0 ; }
+int main(void) { return 0 ; }

--- a/test cases/unit/45 vscpp17/main.cpp
+++ b/test cases/unit/45 vscpp17/main.cpp
@@ -1,7 +1,7 @@
-[[nodiscard]] int foo() {
+[[nodiscard]] int foo(void) {
     return 0;
 }
 
-int main() {
+int main(void) {
     return foo();
 }

--- a/test cases/unit/57 introspection/t1.cpp
+++ b/test cases/unit/57 introspection/t1.cpp
@@ -1,6 +1,6 @@
 #include "sharedlib/shared.hpp"
 
-int main() {
+int main(void) {
   SharedClass cl1;
   if(cl1.getNumber() != 42) {
     return 1;

--- a/test cases/unit/57 introspection/t2.cpp
+++ b/test cases/unit/57 introspection/t2.cpp
@@ -1,6 +1,6 @@
 #include "staticlib/static.h"
 
-int main() {
+int main(void) {
   if(add_numbers(1, 2) != 3) {
     return 1;
   }

--- a/test cases/unit/57 introspection/t3.cpp
+++ b/test cases/unit/57 introspection/t3.cpp
@@ -1,7 +1,7 @@
 #include "sharedlib/shared.hpp"
 #include "staticlib/static.h"
 
-int main() {
+int main(void) {
   for(int i = 0; i < 1000; add_numbers(i, 1)) {
     SharedClass cl1;
     if(cl1.getNumber() != 42) {

--- a/test cases/unit/59 introspect buildoptions/main.c
+++ b/test cases/unit/59 introspect buildoptions/main.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 
-int main() {
+int main(void) {
   printf("Hello World");
   return 0;
 }

--- a/test cases/unit/68 static archive stripping/app/appA.c
+++ b/test cases/unit/68 static archive stripping/app/appA.c
@@ -1,4 +1,4 @@
 #include <stdio.h>
 #include <libA.h>
 
-int main() { printf("The answer is: %d\n", libA_func()); }
+int main(void) { printf("The answer is: %d\n", libA_func()); }

--- a/test cases/unit/68 static archive stripping/app/appB.c
+++ b/test cases/unit/68 static archive stripping/app/appB.c
@@ -1,4 +1,4 @@
 #include <stdio.h>
 #include <libB.h>
 
-int main() { printf("The answer is: %d\n", libB_func()); }
+int main(void) { printf("The answer is: %d\n", libB_func()); }

--- a/test cases/warning/1 version for string div/a/b.c
+++ b/test cases/warning/1 version for string div/a/b.c
@@ -1,3 +1,3 @@
-int main()
+int main(void)
 {
 }

--- a/test cases/wasm/1 basic/hello.cpp
+++ b/test cases/wasm/1 basic/hello.cpp
@@ -1,6 +1,6 @@
 #include<iostream>
 
-int main() {
+int main(void) {
   std::cout << "Hello World" << std::endl;
   return 0;
 }

--- a/test cases/windows/1 basic/prog.c
+++ b/test cases/windows/1 basic/prog.c
@@ -1,5 +1,5 @@
 #include <windows.h>
 
-int main() {
+int main(void) {
     return 0;
 }

--- a/test cases/windows/10 vs module defs generated custom target/prog.c
+++ b/test cases/windows/10 vs module defs generated custom target/prog.c
@@ -1,5 +1,5 @@
 int somedllfunc();
 
-int main() {
+int main(void) {
     return somedllfunc() == 42 ? 0 : 1;
 }

--- a/test cases/windows/16 gui app/console_prog.c
+++ b/test cases/windows/16 gui app/console_prog.c
@@ -1,3 +1,3 @@
-int main() {
+int main(void) {
     return 0;
 }

--- a/test cases/windows/6 vs module defs/prog.c
+++ b/test cases/windows/6 vs module defs/prog.c
@@ -1,5 +1,5 @@
 int somedllfunc();
 
-int main() {
+int main(void) {
     return somedllfunc() == 42 ? 0 : 1;
 }

--- a/test cases/windows/7 dll versioning/exe.orig.c
+++ b/test cases/windows/7 dll versioning/exe.orig.c
@@ -1,6 +1,6 @@
 int myFunc (void);
 
-int main()
+int main(void)
 {
   if (myFunc() == 55)
     return 0;

--- a/test cases/windows/9 vs module defs generated/prog.c
+++ b/test cases/windows/9 vs module defs generated/prog.c
@@ -1,5 +1,5 @@
 int somedllfunc();
 
-int main() {
+int main(void) {
     return somedllfunc() == 42 ? 0 : 1;
 }


### PR DESCRIPTION
ref #5879 

**[Please squash these commits on merge--I was just saving CI time to not merge now.]**

This fixes the internal Meson errors if `CFLAGS=-Werror=strict-prototypes` is used. Before this, it isn't possible to build a C project with Meson if those CFLAGS are enabled.

The remaining run_project_tests.py test cases errors are under common/{57,122,131,137,151,173}  (trivial to fix, just setting it aside for a bit).