### PR TITLE
fortran: sync implicit-none args for intel,pgi,gfortran

### DIFF
--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -125,7 +125,7 @@ class FortranCompiler(CLikeCompiler, Compiler):
     def module_name_to_filename(self, module_name: str) -> str:
         if '_' in module_name:  # submodule
             s = module_name.lower()
-            if self.id in ('gcc', 'intel'):
+            if self.id in ('gcc', 'intel', 'intel-cl'):
                 filename = s.replace('_', '@') + '.smod'
             elif self.id in ('pgi', 'flang'):
                 filename = s.replace('_', '-') + '.mod'
@@ -171,7 +171,7 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
-                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic', '-fimplicit-none']}
 
     def get_dependency_gen_args(self, outtarget, outfile):
         # Disabled until this is fixed:
@@ -337,6 +337,12 @@ class PGIFortranCompiler(PGICompiler, FortranCompiler):
         FortranCompiler.__init__(self, exelist, version, for_machine,
                                  is_cross, info, exe_wrapper, **kwargs)
         PGICompiler.__init__(self)
+
+        default_warn_args = ['-Minform=inform']
+        self.warn_args = {'0': [],
+                          '1': default_warn_args,
+                          '2': default_warn_args,
+                          '3': default_warn_args + ['-Mdclchk']}
 
     def language_stdlib_only_link_flags(self) -> List[str]:
         return ['-lpgf90rtl', '-lpgf90', '-lpgf90_rpm1', '-lpgf902',


### PR DESCRIPTION
also, find intel-cl submodule .smod name pattern. this would fix
intermittent failures of ninja to resolve submodule file dependencies.

This makes for warning_level=3 that Intel, Gfortran and PGI all force `implicit none` on all source code, a good build practice (but not feasible for old legacy code).  Not every compiler can do this, so I just enabled it for those that can.