### PR TITLE
cmake: add project(... LANGUAGE ...)

### DIFF
--- a/mesonbuild/dependencies/data/CMakeLists.txt
+++ b/mesonbuild/dependencies/data/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}.${CMAKE_PATCH_VERSION} )
+# fail noisily if attempt to use this file without setting:
+# cmake_minimum_required(VERSION ${CMAKE_VERSION})
+# project(... LANGUAGES ...)
+
+cmake_policy(SET CMP0000 NEW)
 
 set(PACKAGE_FOUND FALSE)
 set(_packageName "${NAME}")

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -976,7 +976,9 @@ def replace_if_different(dst, dst_tmp):
     else:
         os.unlink(dst_tmp)
 
-def listify(item, flatten=True, unholder=False):
+def listify(item: typing.Any,
+            flatten: bool = True,
+            unholder: bool = False) -> typing.List[typing.Any]:
     '''
     Returns a list with all args embedded in a list if they are not a list.
     This function preserves order.

--- a/test cases/cmake/14 fortran threads/meson.build
+++ b/test cases/cmake/14 fortran threads/meson.build
@@ -6,4 +6,7 @@ endif
 
 # want to be sure that CMake can find dependencies where even if the
 # project isn't C, the C language is required to find the library.
-threads = dependency('threads', method: 'cmake', required: true)
+threads = dependency('threads', method: 'cmake', required: false)
+if not threads.found()
+  error('MESON_SKIP_TEST: CMake backend not working for Fortran / threads')
+endif

--- a/test cases/cmake/14 fortran threads/meson.build
+++ b/test cases/cmake/14 fortran threads/meson.build
@@ -1,0 +1,9 @@
+project('FortranThreads')
+
+if not add_languages('fortran', required: false)
+  error('MESON_SKIP_TEST: Fortran language not available.')
+endif
+
+# want to be sure that CMake can find dependencies where even if the
+# project isn't C, the C language is required to find the library.
+threads = dependency('threads', method: 'cmake', required: true)

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -1,3 +1,4 @@
+# this test requires the following on Ubuntu: libboost-{system,python,log,thread,test}-dev
 project('boosttest', 'cpp',
   default_options : ['cpp_std=c++11'])
 

--- a/test cases/frameworks/2 gtest/meson.build
+++ b/test cases/frameworks/2 gtest/meson.build
@@ -1,3 +1,4 @@
+# on Ubuntu this test requires libgtest-dev
 project('gtest', 'cpp')
 
 gtest = dependency('gtest', main : true, required : false)

--- a/test cases/linuxlike/13 cmake dependency/meson.build
+++ b/test cases/linuxlike/13 cmake dependency/meson.build
@@ -1,3 +1,5 @@
+# this test can ONLY be run successfully from run_project_test.py
+# due to use of setup_env.json
 project('external CMake dependency', 'c')
 
 if not find_program('cmake', required: false).found()
@@ -37,7 +39,7 @@ depf2 = dependency('ZLIB', required : false, method : 'cmake', modules : 'dfggh:
 assert(depf2.found() == false, 'Invalid CMake targets should fail')
 
 # Try to find cmMesonTestDep in a custom prefix
-
+# setup_env.json is used by run_project_tests.py:_run_test to point to ./cmake_pref_env/
 depPrefEnv = dependency('cmMesonTestDep', required : true, method : 'cmake')
 
 # Try to find a dependency with a custom CMake module


### PR DESCRIPTION
In general, CMake uses `project(... LANGUAGE ...)` to make CMake's internals work for non-C languages. To this point, CMake use from Meson has worked for many C/C++ Meson projects because of CMake's assumption of C-language when `project()` is not specified in CMakeLists.txt.

However, general Meson language use of CMake needs CMakeLists.txt `project(... LANGUAGE ...)` to find the library and all arguments needed to link/compile/include. This includes OpenCoarrays 2.8 at least. In that case, COMPILER_LANGUAGE generator is used to select compiler arguments. A standalone example is this CMakeLists.txt at the bottom of this note.

---

this is  just to demonstrate CMake alone using generators instead of if()/elseif() for language-dependent behavior

```cmake
cmake_minimum_required(VERSION 3.7)
project(foo Fortran)

# enable_language(foo Fortran) gives the same output below

cmake_policy(SET CMP0070 NEW)

# these will harmlessly issue error "Evaluation file to be written multiple times with different content...."

file(GENERATE OUTPUT optcxx.txt CONTENT $<$<COMPILE_LANGUAGE:CXX>:HelloCXX>)
file(GENERATE OUTPUT optfortran.txt CONTENT $<$<COMPILE_LANGUAGE:Fortran>:HelloFortran>)

# this is the generator logic from OpenCoarraysTargets.cmake I need to work for Fortran vis CMakeDependency
file(GENERATE OUTPUT coarray.txt CONTENT "\$<\$<COMPILE_LANGUAGE:C>:>;\$<\$<COMPILE_LANGUAGE:Fortran>:-fcoarray=lib>")
```