### PR TITLE
Add a way to select the dynamic linker meson uses

### DIFF
--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -166,9 +166,10 @@ steps:
 
 
      echo ""
-     echo "Locating cl, rc:"
+     echo "Locating cl, rc, link:"
      where.exe cl
      where.exe rc
+     where.exe link
 
      echo ""
      echo "=== Start running tests ==="

--- a/docs/markdown/Cross-compilation.md
+++ b/docs/markdown/Cross-compilation.md
@@ -87,6 +87,7 @@ this:
 [binaries]
 c = '/usr/bin/i586-mingw32msvc-gcc'
 cpp = '/usr/bin/i586-mingw32msvc-g++'
+ld = 'gold'
 ar = '/usr/i586-mingw32msvc/bin/ar'
 strip = '/usr/i586-mingw32msvc/bin/strip'
 pkgconfig = '/usr/bin/i586-mingw32msvc-pkg-config'
@@ -101,6 +102,12 @@ application with qemu or a hardware simulator. If you have this kind
 of a wrapper, these lines are all you need to write. Meson will
 automatically use the given wrapper when it needs to run host
 binaries. This happens e.g. when running the project's test suite.
+
+ld is special because it is compiler specific. For compilers like gcc and
+clang which are used to invoke the linker this is a value to pass to their
+"choose the linker" argument (-fuse-ld= in this case). For compilers like
+MSVC and Clang-Cl, this is the path to a linker for meson to invoke, such as
+`link.exe` or `lld-link.exe`. Support for ls is *new in 0.53.0*
 
 The next section lists properties of the cross compiler and its target
 system, and thus properties of host system of what we're building. It

--- a/docs/markdown/Native-environments.md
+++ b/docs/markdown/Native-environments.md
@@ -40,6 +40,7 @@ like `llvm-config`
 c = '/usr/local/bin/clang'
 cpp = '/usr/local/bin/clang++'
 rust = '/usr/local/bin/rust'
+ld = 'gold'
 llvm-config = '/usr/local/llvm-svn/bin/llvm-config'
 ```
 

--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -23,8 +23,29 @@ compilation is done by setting `CC` to point to the cross compiler
 that Meson supports natively the case where you compile helper tools
 (such as code generators) and use the results during the
 build. Because of this Meson needs to know both the native and the
-cross compiler. The former is set via the environment variables and
-the latter via the cross file only.
+cross compiler. The former is set via the environment variables or
+native-files and the latter via the cross file only.
+
+## Set dynamic linker
+
+```console
+$ CC=clang LD=lld meson <options>
+```
+
+or
+
+```console
+$ CC=clang-cl LD=link meson <options>
+```
+
+Like the compiler, the linker is selected via the LD environment variable, or
+through the `ld` entry in a native or cross file. You must be aware of
+whehter you're using a compiler that invokes the linker itself (most
+compilers including GCC and Clang) or a linker that is invoked directly (when
+using MSVC or compilers that act like it, including Clang-Cl). With the
+former `ld` or `LD` should be the value to pass to the compiler's special
+argument (such as `-fuse-ld` with clang and gcc), with the latter it should
+be an exectuable, such as `lld-link.exe`.
 
 ## Set default C/C++ language version
 

--- a/docs/markdown/snippets/linker_override.md
+++ b/docs/markdown/snippets/linker_override.md
@@ -1,0 +1,17 @@
+## Generic Overrider for Dynamic Linker selection
+
+Previous to meson 0.52.0 you set the dynamic linker using compiler specific
+flags passed via language flags and hoped things worked out. In meson 0.52.0
+meson started detecting the linker and making intelligent decisions about
+using it. Unfortunately this broke choosing a non-default linker.
+
+Now there is a generic mechanism for doing this, you may use the LD
+environment variable (with normal meson environment variable rules), or add
+the following to a cross or native file:
+
+```ini
+[binaries]
+ld = 'gold'
+```
+
+And meson will select the linker if possible.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1293,8 +1293,15 @@ int dummy;
         else:
             raise InvalidArguments('Unknown target type for rustc.')
         args.append(cratetype)
+
+        # If we're dynamically linking, add those arguments
+        #
+        # Rust is super annoying, calling -C link-arg foo does not work, it has
+        # to be -C link-arg=foo
         if cratetype in {'bin', 'dylib'}:
-            args += rustc.linker.get_always_args()
+            for a in rustc.linker.get_always_args():
+                args += ['-C', 'link-arg={}'.format(a)]
+
         args += ['--crate-name', target.name]
         args += rustc.get_buildtype_args(self.get_option_for_target('buildtype', target))
         args += rustc.get_debug_args(self.get_option_for_target('debug', target))

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1293,6 +1293,8 @@ int dummy;
         else:
             raise InvalidArguments('Unknown target type for rustc.')
         args.append(cratetype)
+        if cratetype in {'bin', 'dylib'}:
+            args += rustc.linker.get_always_args()
         args += ['--crate-name', target.name]
         args += rustc.get_buildtype_args(self.get_option_for_target('buildtype', target))
         args += rustc.get_debug_args(self.get_option_for_target('debug', target))

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1178,6 +1178,12 @@ class Compiler:
     def get_dependency_link_args(self, dep):
         return dep.get_link_args()
 
+    @classmethod
+    def use_linker_args(cls, linker: str) -> typing.List[str]:
+        """Get a list of arguments to pass to the compiler to set the linker.
+        """
+        return []
+
 
 def get_largefile_args(compiler):
     '''

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -299,6 +299,10 @@ class GnuLikeCompiler(metaclass=abc.ABCMeta):
             return ['-isystem' + path]
         return ['-I' + path]
 
+    @classmethod
+    def use_linker_args(cls, linker: str) -> typing.List[str]:
+        return ['-fuse-ld={}'.format(linker)]
+
 
 class GnuCompiler(GnuLikeCompiler):
     """

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -381,3 +381,7 @@ class VisualStudioLikeCompiler(metaclass=abc.ABCMeta):
 
     def get_argument_syntax(self) -> str:
         return 'msvc'
+
+    @classmethod
+    def use_linker_args(cls, linker: str) -> typing.List[str]:
+        return []

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -32,7 +32,7 @@ rust_optimization_args = {'0': [],
 
 class RustCompiler(Compiler):
 
-    LINKER_PREFIX = '-Wl,'
+    # rustc doesn't invoke the compiler itself, it doesn't need a LINKER_PREFIX
 
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross, info: 'MachineInfo', exe_wrapper=None, **kwargs):
@@ -109,3 +109,7 @@ class RustCompiler(Compiler):
 
     def get_std_exe_link_args(self):
         return []
+
+    # Rust does not have a use_linker_args because it dispatches to a gcc-like
+    # C compiler for dynamic linking, as such we invoke the C compiler's
+    # use_linker_args method instead.

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -309,7 +309,9 @@ class BinaryTable(HasEnvVarFallback):
         'strip': 'STRIP',
         'ar': 'AR',
         'windres': 'WINDRES',
+        'ld': 'LD',
 
+        # Other tools
         'cmake': 'CMAKE',
         'qmake': 'QMAKE',
         'pkgconfig': 'PKG_CONFIG',

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1418,8 +1418,7 @@ class Environment:
 
             if 'LLVM D compiler' in out:
                 # LDC seems to require a file
-                m = self.machines[for_machine]
-                if m.is_windows() or m.is_cygwin():
+                if info.is_windows() or info.is_cygwin():
                     # Getting LDC on windows to give useful linker output when
                     # not doing real work is painfully hard. It ships with a
                     # version of lld-link, so unless we think the user wants
@@ -1443,8 +1442,7 @@ class Environment:
                     full_version=full_version, linker=linker)
             elif 'The D Language Foundation' in out or 'Digital Mars' in out:
                 # DMD seems to require a file
-                m = self.machines[for_machine]
-                if m.is_windows() or m.is_cygwin():
+                if info.is_windows() or info.is_cygwin():
                     if is_msvc:
                         linker_cmd = ['link']
                     elif arch == 'x86':

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1339,10 +1339,11 @@ class Environment:
         info = self.machines[for_machine]
 
         # Detect the target architecture, required for proper architecture handling on Windows.
-        c_compiler = {}
-        is_msvc = mesonlib.is_windows() and 'VCINSTALLDIR' in os.environ
-        if is_msvc:
-            c_compiler = {'c': self.detect_c_compiler(for_machine)} # MSVC compiler is required for correct platform detection.
+        # MSVC compiler is required for correct platform detection.
+        c_compiler = {'c': self.detect_c_compiler(for_machine)}
+        is_msvc = isinstance(c_compiler['c'], VisualStudioCCompiler)
+        if not is_msvc:
+            c_compiler = {}
 
         arch = detect_cpu_family(c_compiler)
         if is_msvc and arch == 'x86':

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -781,6 +781,11 @@ class Environment:
                 for_machine, [], machine=target, exelist=compiler,
                 prefix=comp_class.LINKER_PREFIX if use_linker_prefix else [],
                 version=search_version(out))
+        elif 'GNU coreutils' in o:
+            raise EnvironmentException(
+                "Found GNU link.exe instead of MSVC link.exe. This link.exe "
+                "is not a linker. You may need to reorder entries to your "
+                "%PATH% variable to resolve this.")
         raise EnvironmentException('Unable to determine dynamic linker')
 
     def _guess_nix_linker(self, compiler: typing.List[str], comp_class: typing.Type[Compiler],

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -399,6 +399,11 @@ class DynamicLinker(metaclass=abc.ABCMeta):
                          install_rpath: str) -> typing.List[str]:
         return []
 
+    def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
+                        suffix: str, soversion: str, darwin_versions: typing.Tuple[str, str],
+                        is_shared_module: bool) -> typing.List[str]:
+        return []
+
 
 class PosixDynamicLinkerMixin:
 
@@ -423,8 +428,8 @@ class GnuLikeDynamicLinkerMixin:
 
     """Mixin class for dynamic linkers that provides gnu-like interface.
 
-    This acts as a base for the GNU linkers (bfd and gold), the Intel Xild
-    (which comes with ICC), LLVM's lld, and other linkers like GNU-ld.
+    This acts as a base for the GNU linkers (bfd and gold), LLVM's lld, and
+    other linkers like GNU-ld.
     """
 
     _BUILDTYPE_ARGS = {
@@ -655,26 +660,6 @@ class LLVMDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, Dyna
     """Representation of LLVM's lld (not lld-link) linker.
 
     This is only the posix-like linker.
-    """
-
-    pass
-
-
-class XildLinuxDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, DynamicLinker):
-
-    """Representation of Intel's Xild linker.
-
-    This is only the linux-like linker which dispatches to Gnu ld.
-    """
-
-    pass
-
-
-class XildAppleDynamicLinker(AppleDynamicLinker):
-
-    """Representation of Intel's Xild linker.
-
-    This is the apple linker, which dispatches to Apple's ld.
     """
 
     pass

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -845,9 +845,10 @@ class MSVCDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
     def __init__(self, for_machine: mesonlib.MachineChoice, always_args: typing.List[str], *,
                  exelist: typing.Optional[typing.List[str]] = None,
                  prefix: typing.Union[str, typing.List[str]] = '',
-                 machine: str = 'x86', version: str = 'unknown version'):
+                 machine: str = 'x86', version: str = 'unknown version',
+                 direct: bool = True):
         super().__init__(exelist or ['link.exe'], for_machine, 'link',
-                         prefix, always_args, machine=machine, version=version)
+                         prefix, always_args, machine=machine, version=version, direct=direct)
 
 
 class ClangClDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
@@ -857,9 +858,10 @@ class ClangClDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
     def __init__(self, for_machine: mesonlib.MachineChoice, always_args: typing.List[str], *,
                  exelist: typing.Optional[typing.List[str]] = None,
                  prefix: typing.Union[str, typing.List[str]] = '',
-                 version: str = 'unknown version'):
+                 machine: str = 'x86', version: str = 'unknown version',
+                 direct: bool = True):
         super().__init__(exelist or ['lld-link.exe'], for_machine, 'lld-link',
-                         prefix, always_args, version=version)
+                         prefix, always_args, machine=machine, version=version, direct=direct)
 
 
 class XilinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -595,7 +595,7 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
         return self._apply_prefix('-undefined,error')
 
     def get_always_args(self) -> typing.List[str]:
-        return self._apply_prefix('-headerpad_max_install_names')
+        return self._apply_prefix('-headerpad_max_install_names') + super().get_always_args()
 
     def bitcode_args(self) -> typing.List[str]:
         return self._apply_prefix('-bitcode_bundle')
@@ -818,7 +818,7 @@ class VisualStudioLikeLinkerMixin:
         return self._apply_prefix('/MACHINE:' + self.machine) + self._apply_prefix('/OUT:' + outputname)
 
     def get_always_args(self) -> typing.List[str]:
-        return self._apply_prefix('/nologo')
+        return self._apply_prefix('/nologo') + super().get_always_args()
 
     def get_search_args(self, dirname: str) -> typing.List[str]:
         return self._apply_prefix('/LIBPATH:' + dirname)

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -791,7 +791,7 @@ class VisualStudioLikeLinkerMixin:
         self.machine = machine
 
     def invoked_by_compiler(self) -> bool:
-        return self.direct
+        return not self.direct
 
     def get_debug_crt_args(self) -> typing.List[str]:
         """Arguments needed to select a debug crt for the linker.

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -616,14 +616,13 @@ def has_broken_rustc() -> bool:
     mesonlib.windows_proof_rmtree(dirname)
     return pc.returncode != 0
 
-def should_skip_rust() -> bool:
+def should_skip_rust(backend: Backend) -> bool:
     if not shutil.which('rustc'):
         return True
     if backend is not Backend.ninja:
         return True
-    if mesonlib.is_windows():
-        if has_broken_rustc():
-            return True
+    if mesonlib.is_windows() and has_broken_rustc():
+        return True
     return False
 
 def detect_tests_to_run(only: typing.List[str]) -> typing.List[typing.Tuple[str, typing.List[Path], bool]]:
@@ -659,7 +658,7 @@ def detect_tests_to_run(only: typing.List[str]) -> typing.List[typing.Tuple[str,
         ('java', 'java', backend is not Backend.ninja or mesonlib.is_osx() or not have_java()),
         ('C#', 'csharp', skip_csharp(backend)),
         ('vala', 'vala', backend is not Backend.ninja or not shutil.which(os.environ.get('VALAC', 'valac'))),
-        ('rust', 'rust', should_skip_rust()),
+        ('rust', 'rust', should_skip_rust(backend)),
         ('d', 'd', backend is not Backend.ninja or not have_d_compiler()),
         ('objective c', 'objc', backend not in (Backend.ninja, Backend.xcode) or not have_objc_compiler()),
         ('objective c++', 'objcpp', backend not in (Backend.ninja, Backend.xcode) or not have_objcpp_compiler()),

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -445,7 +445,7 @@ class InternalTests(unittest.TestCase):
     def test_compiler_args_class_gnuld(self):
         cargsfunc = mesonbuild.compilers.CompilerArgs
         ## Test --start/end-group
-        linker = mesonbuild.linkers.GnuDynamicLinker([], MachineChoice.HOST, 'fake', '-Wl,')
+        linker = mesonbuild.linkers.GnuDynamicLinker([], MachineChoice.HOST, 'fake', '-Wl,', [])
         gcc = mesonbuild.compilers.GnuCCompiler([], 'fake', False, MachineChoice.HOST, mock.Mock(), linker=linker)
         ## Ensure that the fake compiler is never called by overriding the relevant function
         gcc.get_default_include_dirs = lambda: ['/usr/include', '/usr/share/include', '/usr/local/include']
@@ -474,7 +474,7 @@ class InternalTests(unittest.TestCase):
     def test_compiler_args_remove_system(self):
         cargsfunc = mesonbuild.compilers.CompilerArgs
         ## Test --start/end-group
-        linker = mesonbuild.linkers.GnuDynamicLinker([], MachineChoice.HOST, 'fake', '-Wl,')
+        linker = mesonbuild.linkers.GnuDynamicLinker([], MachineChoice.HOST, 'fake', '-Wl,', [])
         gcc = mesonbuild.compilers.GnuCCompiler([], 'fake', False, MachineChoice.HOST, mock.Mock(), linker=linker)
         ## Ensure that the fake compiler is never called by overriding the relevant function
         gcc.get_default_include_dirs = lambda: ['/usr/include', '/usr/share/include', '/usr/local/include']

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -290,26 +290,6 @@ def no_pkgconfig():
         shutil.which = old_which
         ExternalProgram._search = old_search
 
-class PatchModule:
-    '''
-    Fancy monkey-patching! Whee! Can't use mock.patch because it only
-    patches in the local namespace.
-    '''
-
-    def __init__(self, func, name, impl):
-        self.func = func
-        assert(isinstance(name, str))
-        self.func_name = name
-        self.old_impl = None
-        self.new_impl = impl
-
-    def __enter__(self):
-        self.old_impl = self.func
-        exec('{} = self.new_impl'.format(self.func_name))
-
-    def __exit__(self, *args):
-        exec('{} = self.old_impl'.format(self.func_name))
-
 
 class InternalTests(unittest.TestCase):
 
@@ -5742,6 +5722,7 @@ c = ['{0}']
         self.init(testdir, extra_args=meson_args, override_envvars=env)
         self.build()
         self.run_tests()
+
 
 def should_run_cross_arm_tests():
     return shutil.which('arm-linux-gnueabihf-gcc') and not platform.machine().lower().startswith('arm')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2299,11 +2299,11 @@ class AllPlatformTests(BasePlatformTests):
             if isinstance(cc, intel):
                 self.assertIsInstance(linker, ar)
                 if is_osx():
-                    self.assertIsInstance(cc.linker, mesonbuild.linkers.XildAppleDynamicLinker)
+                    self.assertIsInstance(cc.linker, mesonbuild.linkers.AppleDynamicLinker)
                 elif is_windows():
                     self.assertIsInstance(cc.linker, mesonbuild.linkers.XilinkDynamicLinker)
                 else:
-                    self.assertIsInstance(cc.linker, mesonbuild.linkers.XildLinuxDynamicLinker)
+                    self.assertIsInstance(cc.linker, mesonbuild.linkers.GnuDynamicLinker)
             if isinstance(cc, msvc):
                 self.assertTrue(is_windows())
                 self.assertIsInstance(linker, lib)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4496,6 +4496,29 @@ class WindowsTests(BasePlatformTests):
 
         self.assertTrue('prog.pdb' in files)
 
+    def _check_ld(self, name: str, lang: str, expected: str) -> None:
+        if not shutil.which(name):
+            raise unittest.SkipTest('Could not find {}.'.format(name))
+        with mock.patch.dict(os.environ, {'LD': name}):
+            env = get_fake_env()
+            try:
+                comp = getattr(env, 'detect_{}_compiler'.format(lang))(MachineChoice.HOST)
+            except EnvironmentException:
+                raise unittest.SkipTest('Could not find a compiler for {}'.format(lang))
+            self.assertEqual(comp.linker.id, expected)
+
+    def test_link_environment_variable_lld_link(self):
+        self._check_ld('lld-link', 'c', 'lld-link')
+
+    def test_link_environment_variable_link(self):
+        self._check_ld('link', 'c', 'link')
+
+    def test_link_environment_variable_optlink(self):
+        self._check_ld('optlink', 'c', 'optlink')
+
+    def test_link_environment_variable_rust(self):
+        self._check_ld('link', 'rust', 'link')
+
 @unittest.skipUnless(is_osx(), "requires Darwin")
 class DarwinTests(BasePlatformTests):
     '''


### PR DESCRIPTION
This approach is a little different than the previous approach I used of trying to pass all of the arguments passed as <lang>flags to the linker invocation, instead it adds an LD environment variable and an `ld` entry in the cross/native files for setting the linker. This is nice because it allows us to abstract linker selection across different compilers, especially in cases were the compiler doesn't invoke the linker.

There is one drawback to this, which is it doesn't properly handle clang's `--target` argument. That is a much harder problem to solve (and worth solving I think). But will require reworking the way meson sets up compilers and adds command line interfaces. This provides a 99% solution, and doesn't require ripping up the guts of how we add compilers.

This PR still needs to be tested on mac and windows, more documentation changes, and needs some tests.

Fixes:  #3597