### PR TITLE
cmake: Uniform target name handling and custom target fixes

### DIFF
--- a/mesonbuild/cmake/data/run_ctgt.py
+++ b/mesonbuild/cmake/data/run_ctgt.py
@@ -28,6 +28,7 @@ for i in args.commands:
         commands += [[]]
         continue
 
+    i = i.replace('"', '')  # Remove lefover quotes
     commands[-1] += [i]
 
 # Execute

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -461,6 +461,8 @@ class ConverterCustomTarget:
             cmd = []
 
             for j in i:
+                if not j:
+                    continue
                 target_key = _target_key(j)
                 if target_key in output_target_map:
                     cmd += [output_target_map[target_key]]

--- a/test cases/cmake/2 advanced/installed_files.txt
+++ b/test cases/cmake/2 advanced/installed_files.txt
@@ -1,4 +1,4 @@
-usr/?lib/libcmModLib?so
-?cygwin:usr/lib/libcmModLib?implib
-?!cygwin:usr/bin/libcmModLib?implib
-usr/bin/testEXE?exe
+usr/?lib/libcm_cmModLib?so
+?cygwin:usr/lib/libcm_cmModLib?implib
+?!cygwin:usr/bin/libcm_cmModLib?implib
+usr/bin/cm_testEXE?exe

--- a/test cases/cmake/3 advanced no dep/installed_files.txt
+++ b/test cases/cmake/3 advanced no dep/installed_files.txt
@@ -1,6 +1,6 @@
-usr/?lib/libcmModLib?so
-?cygwin:usr/lib/libcmModLib?implib
-?!cygwin:usr/bin/libcmModLib?implib
-?msvc:usr/bin/cmModLib.pdb
-?msvc:usr/bin/testEXE.pdb
-usr/bin/testEXE?exe
+usr/?lib/libcm_cmModLib?so
+?cygwin:usr/lib/libcm_cmModLib?implib
+?!cygwin:usr/bin/libcm_cmModLib?implib
+?msvc:usr/bin/cm_cmModLib.pdb
+?msvc:usr/bin/cm_testEXE.pdb
+usr/bin/cm_testEXE?exe

--- a/test cases/cmake/5 object library/subprojects/cmObjLib/CMakeLists.txt
+++ b/test cases/cmake/5 object library/subprojects/cmObjLib/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.7)
+project(cmObject)
 
 find_package(ZLIB REQUIRED)
 

--- a/test cases/cmake/6 object library no dep/subprojects/cmObjLib/CMakeLists.txt
+++ b/test cases/cmake/6 object library no dep/subprojects/cmObjLib/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.7)
+project(cmObject)
 
 add_library(lib_obj OBJECT libA.cpp libB.cpp)
 add_library(lib_sha SHARED $<TARGET_OBJECTS:lib_obj>)


### PR DESCRIPTION
Better handle target names for the generated CMake subproject targets. Additionally, avoid conflicts in the outputs of custom targets.

Related issues: #6208