### PR TITLE
Add table entry for CUDA Toolkit 10.2.89.

### DIFF
--- a/mesonbuild/modules/unstable_cuda.py
+++ b/mesonbuild/modules/unstable_cuda.py
@@ -44,6 +44,7 @@ class CudaModule(ExtensionModule):
                 raise argerror
 
         driver_version_table = [
+            {'cuda_version': '>=10.2.89',  'windows': '441.22', 'linux': '440.33'},
             {'cuda_version': '>=10.1.105', 'windows': '418.96', 'linux': '418.39'},
             {'cuda_version': '>=10.0.130', 'windows': '411.31', 'linux': '410.48'},
             {'cuda_version': '>=9.2.148',  'windows': '398.26', 'linux': '396.37'},


### PR DESCRIPTION
CUDA Toolkit 10.2 was released. Add its corresponding table entry in the minimum driver version table.