### PR TITLE
Fix link_whole with a custom target

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1096,9 +1096,12 @@ You probably should put it in link_with instead.''')
                     raise InvalidArguments('Custom target {!r} is not linkable.'.format(t))
                 if not t.get_filename().endswith('.a'):
                     raise InvalidArguments('Can only link_whole custom targets that are .a archives.')
+                if isinstance(self, StaticLibrary):
+                    # FIXME: We could extract the .a archive to get object files
+                    raise InvalidArguments('Cannot link_whole a custom target into a static library')
             elif not isinstance(t, StaticLibrary):
                 raise InvalidArguments('{!r} is not a static library.'.format(t))
-            if isinstance(self, SharedLibrary) and not t.pic:
+            elif isinstance(self, SharedLibrary) and not t.pic:
                 msg = "Can't link non-PIC static library {!r} into shared library {!r}. ".format(t.name, self.name)
                 msg += "Use the 'pic' option to static_library to build with PIC."
                 raise InvalidArguments(msg)

--- a/test cases/common/215 link custom/custom_stlib.py
+++ b/test cases/common/215 link custom/custom_stlib.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import shutil, sys, subprocess, argparse, pathlib
+import platform
 
 parser = argparse.ArgumentParser()
 
@@ -15,6 +16,12 @@ void flob(void) {
 }
 '''
 
+def get_pic_args():
+    platname = platform.system().lower()
+    if platname in ['windows', 'mingw', 'darwin'] or platname.startswith('cygwin'):
+        return []
+    return ['-fPIC']
+
 def generate_lib_gnulike(outfile, c_file, private_dir, compiler_array):
     if shutil.which('ar'):
         static_linker = 'ar'
@@ -26,6 +33,7 @@ def generate_lib_gnulike(outfile, c_file, private_dir, compiler_array):
         sys.exit('Could not detect a static linker.')
     o_file = c_file.with_suffix('.o')
     compile_cmd = compiler_array + ['-c', '-g', '-O2', '-o', str(o_file), str(c_file)]
+    compile_cmd += get_pic_args()
     subprocess.check_call(compile_cmd)
     out_file = pathlib.Path(outfile)
     if out_file.exists():

--- a/test cases/common/215 link custom/lib.c
+++ b/test cases/common/215 link custom/lib.c
@@ -1,0 +1,7 @@
+void flob(void);
+
+int foo(void)
+{
+  flob();
+  return 0;
+}

--- a/test cases/common/215 link custom/meson.build
+++ b/test cases/common/215 link custom/meson.build
@@ -46,6 +46,8 @@ d_i = declare_dependency(link_with: clib[0])
 exe2_i = executable('prog2_i', 'prog.c', dependencies: d_i)
 test('linkcustom2_i', exe2_i)
 
+shared_library('lib1', 'lib.c', link_whole: clib)
+
 # Link whole tests
 
 exe3_i = executable('prog3_i', 'prog.c', link_whole: clib[0])


### PR DESCRIPTION
t.pic won't be defined. We can only hope it has been built with -fPIC.
Linker will complain otherwise any way.

t.extract_all_objects_recurse() won't be defined. We could support this
case by extracting the archive somewhere and pick object files.