### PR TITLE
openbsd: execinfo is not a compiler lib

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -88,8 +88,10 @@ cflags_mapping = {'c': 'CFLAGS',
                   'vala': 'VALAFLAGS',
                   'rust': 'RUSTFLAGS'}
 
-# execinfo is a compiler lib on BSD
-unixy_compiler_internal_libs = ('m', 'c', 'pthread', 'dl', 'rt', 'execinfo')
+unixy_compiler_internal_libs = ('m', 'c', 'pthread', 'dl', 'rt')
+# execinfo is a compiler lib on FreeBSD and NetBSD
+if mesonlib.is_freebsd() or mesonlib.is_netbsd():
+  unixy_compiler_internal_libs += ('execinfo',)
 
 # All these are only for C-linkable languages; see `clink_langs` above.
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -91,7 +91,7 @@ cflags_mapping = {'c': 'CFLAGS',
 unixy_compiler_internal_libs = ('m', 'c', 'pthread', 'dl', 'rt')
 # execinfo is a compiler lib on FreeBSD and NetBSD
 if mesonlib.is_freebsd() or mesonlib.is_netbsd():
-  unixy_compiler_internal_libs += ('execinfo',)
+    unixy_compiler_internal_libs += ('execinfo',)
 
 # All these are only for C-linkable languages; see `clink_langs` above.
 


### PR DESCRIPTION
On OpenBSD, libexecinfo is not n internal library and should be
detected with find_library().
This should fix https://github.com/mesonbuild/meson/issues/5432