### PR TITLE
Add support for uninstalled environment

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1731,6 +1731,16 @@ the following methods.
 
 - `version()` return a string with the version of Meson.
 
+- `add_uninstalled_environment()`  [*(Added
+  0.53.0)*](Release-notes-for-0.53.0.md#uninstalled-environment) add an
+  [`environment()`](#environment) object to the list of environments that will
+  be applied when using `meson uninstalled` command line. This is useful for
+  developpers who wish to use the project without installing it, it is often
+  needed to set for example the path to plugins directory, etc. Alternatively,
+  a list or dictionary can be passed as first argument, as well as optional
+  `method` and `separator` keyword arguments. `MESON_UNINSTALLED=1` will always
+  be set in the uninstalled environment.
+
 ### `build_machine` object
 
 Provides information about the build machine — the machine that is

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -516,6 +516,9 @@ Since *0.52.0* takes an optional dictionary as first argument. If
 provided, each key/value pair is added into the `environment_object`
 as if `set()` method was called for each of them.
 
+Since *0.53.0* it has `method` ('set', 'prepend' or 'append' strings) and
+`separator` keyword arguments to control how initial values are added.
+
 ### executable()
 
 ``` meson

--- a/docs/markdown/snippets/environment.md
+++ b/docs/markdown/snippets/environment.md
@@ -6,3 +6,28 @@ This is useful to control how initial values are added. `method` must be one of
 ```meson
 environment({'MY_VAR': ['a', 'b']}, method: 'prepend', separator=',')
 ```
+
+## Uninstalled environment
+
+It is often useful for developers to run the project without having to install it.
+But to work, many projects needs to set some environment variables, such as location
+in the build directory of plugins, or adding some built tools location to PATH.
+
+Meson makes it easy by allowing projects to define those variables directly from the
+build definition, using `meson.add_uninstalled_environment()` method. Developers
+can then run a command inside that environment using `meson uninstalled` command line.
+
+For example, if a project builds an executable that needs data files from source
+directory:
+```meson
+project(...)
+tool = executable('mytool', ...)
+meson.add_uninstalled_environment({
+    'PATH': meson.current_build_dir(),
+    'MYTOOL_DATA_DIR': meson.current_source_dir() / 'data',
+  },
+  method: 'prepend',
+)
+```
+
+Developers can then test it from the command line: `meson uninstalled -C builddir mytool`.

--- a/docs/markdown/snippets/environment.md
+++ b/docs/markdown/snippets/environment.md
@@ -1,0 +1,8 @@
+## environment() now had `separator` and `method` keyword arguments
+
+This is useful to control how initial values are added. `method` must be one of
+'set', 'prepend' or 'append' strings.
+
+```meson
+environment({'MY_VAR': ['a', 'b']}, method: 'prepend', separator=',')
+```

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -141,6 +141,9 @@ class Build:
         self.test_setup_default_name = None
         self.find_overrides = {}
         self.searched_programs = set() # The list of all programs that have been searched for.
+        env = EnvironmentVariables()
+        env.add_var(env.set, 'MESON_UNINSTALLED', ['1'], {})
+        self.uninstalled_envs = [env]
 
     def copy(self):
         other = Build(self.environment)

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1784,6 +1784,7 @@ class MesonMain(InterpreterObject):
                              'project_name': self.project_name_method,
                              'get_cross_property': self.get_cross_property_method,
                              'backend': self.backend_method,
+                             'add_uninstalled_environment': self.add_uninstalled_environment_method,
                              })
 
     def _find_source_script(self, name, args):
@@ -1968,6 +1969,18 @@ class MesonMain(InterpreterObject):
             if len(args) == 2:
                 return args[1]
             raise InterpreterException('Unknown cross property: %s.' % propname)
+
+    @FeatureNew('add_uninstalled_environment', '0.53.0')
+    @permittedKwargs({'method', 'separator'})
+    @noArgsFlattening
+    def add_uninstalled_environment_method(self, args, kwargs):
+        if len(args) != 1:
+            raise InterpreterException('add_uninstalled_environment takes exactly one argument')
+        if isinstance(args[0], EnvironmentVariablesHolder):
+            env = args[0]
+        else:
+            env = EnvironmentVariablesHolder(args[0], kwargs)
+        self.build.uninstalled_envs.append(env.held_object)
 
 
 known_library_kwargs = (

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -22,7 +22,7 @@ import shutil
 
 from . import mesonlib
 from . import mlog
-from . import mconf, mdist, minit, minstall, mintro, msetup, mtest, rewriter, msubprojects, munstable_coredata
+from . import mconf, mdist, minit, minstall, mintro, msetup, mtest, rewriter, msubprojects, muninstalled, munstable_coredata
 from .mesonlib import MesonException
 from .environment import detect_msys2_arch
 from .wrap import wraptool
@@ -58,6 +58,8 @@ class CommandLineParser:
                          help_msg='Wrap tools')
         self.add_command('subprojects', msubprojects.add_arguments, msubprojects.run,
                          help_msg='Manage subprojects')
+        self.add_command('uninstalled', muninstalled.add_arguments, muninstalled.run,
+                         help_msg='Run commands in uninstalled environment')
         self.add_command('help', self.add_help_arguments, self.run_help_command,
                          help_msg='Print help of a subcommand')
         self.add_command('rewrite', lambda parser: rewriter.add_arguments(parser, self.formatter), rewriter.run,

--- a/mesonbuild/muninstalled.py
+++ b/mesonbuild/muninstalled.py
@@ -1,0 +1,63 @@
+import os, subprocess
+import argparse
+import tempfile
+import shutil
+
+from pathlib import Path
+from . import build
+from .mesonlib import MesonException
+
+def get_windows_shell():
+    command = ['powershell.exe', '-noprofile', '-executionpolicy', 'bypass', '-file', 'cmd_or_ps.ps1']
+    result = subprocess.check_output(command)
+    return result.decode().strip()
+
+def add_arguments(parser):
+    parser.add_argument('-C', default='.', dest='wd',
+                        help='directory to cd into before running')
+    parser.add_argument('command', nargs=argparse.REMAINDER,
+                        help='Command to run in uninstalled environment (default: interactive shell)')
+
+def run(options):
+    options.wd = os.path.abspath(options.wd)
+    buildfile = Path(options.wd) / 'meson-private' / 'build.dat'
+    if not buildfile.is_file():
+        raise MesonException('Directory {!r} does not seem to be a Meson build directory.'.format(options.wd))
+    b = build.load(options.wd)
+    uninstalled_env = os.environ.copy()
+    for env in b.uninstalled_envs:
+        uninstalled_env = env.get_env(uninstalled_env)
+
+    args = options.command
+    if not args:
+        prompt_prefix = '[{}]'.format(b.project_name)
+        if os.name == 'nt':
+            shell = get_windows_shell()
+            if shell == 'powershell.exe':
+                args = ['powershell.exe']
+                args += ['-NoLogo', '-NoExit']
+                prompt = 'function global:prompt {  "{} PS " + $PWD + "> "}'.format(prompt_prefix)
+                args += ['-Command', prompt]
+            else:
+                args = [os.environ.get("COMSPEC", r"C:\WINDOWS\system32\cmd.exe")]
+                args += ['/k', 'prompt {} $P$G'.format(prompt_prefix)]
+        else:
+            args = [os.environ.get("SHELL", os.path.realpath("/bin/sh"))]
+        if "bash" in args[0] and not os.environ.get("MESON_DISABLE_PS1_OVERRIDE"):
+            tmprc = tempfile.NamedTemporaryFile(mode='w')
+            bashrc = os.path.expanduser('~/.bashrc')
+            if os.path.exists(bashrc):
+                with open(bashrc, 'r') as src:
+                    shutil.copyfileobj(src, tmprc)
+            tmprc.write('\nexport PS1="{} $PS1"'.format(prompt_prefix))
+            tmprc.flush()
+            # Let the GC remove the tmp file
+            args.append("--rcfile")
+            args.append(tmprc.name)
+
+    try:
+        return subprocess.call(args, close_fds=False,
+                               env=uninstalled_env,
+                               cwd=options.wd)
+    except subprocess.CalledProcessError as e:
+        return e.returncode

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1362,6 +1362,7 @@ class BasePlatformTests(unittest.TestCase):
         self.mintro_command = self.meson_command + ['introspect']
         self.wrap_command = self.meson_command + ['wrap']
         self.rewrite_command = self.meson_command + ['rewrite']
+        self.uninstalled_command = self.meson_command + ['uninstalled']
         # Backend-specific build commands
         self.build_command, self.clean_command, self.test_command, self.install_command, \
             self.uninstall_command = get_backend_commands(self.backend)
@@ -4096,6 +4097,13 @@ recommended as it is not supported on some platforms''')
         testdir = os.path.join(self.common_test_dir, '2 cpp')
         self.init(testdir)
         self._run(self.mconf_command + [self.builddir])
+
+    def test_uninstalled(self):
+        testdir = os.path.join(self.unit_test_dir, '72 uninstalled env')
+        self.init(testdir)
+
+        uninstalled_script = os.path.join(testdir, 'test-uninstalled.py')
+        self._run(self.uninstalled_command + ['-C', self.builddir] + python_command + [uninstalled_script])
 
 class FailureTests(BasePlatformTests):
     '''

--- a/test cases/unit/72 uninstalled env/meson.build
+++ b/test cases/unit/72 uninstalled env/meson.build
@@ -1,0 +1,6 @@
+project('uninstalled env')
+
+meson.add_uninstalled_environment('TEST_A=1')
+subproject('sub')
+meson.add_uninstalled_environment({'TEST_B': ['2', '3']}, method: 'append', separator:'+')
+meson.add_uninstalled_environment(environment('TEST_B=0', method: 'prepend', separator:'+'))

--- a/test cases/unit/72 uninstalled env/subprojects/sub/meson.build
+++ b/test cases/unit/72 uninstalled env/subprojects/sub/meson.build
@@ -1,0 +1,3 @@
+project('sub')
+
+meson.add_uninstalled_environment('TEST_B=1')

--- a/test cases/unit/72 uninstalled env/test-uninstalled.py
+++ b/test cases/unit/72 uninstalled env/test-uninstalled.py
@@ -1,0 +1,7 @@
+#! /usr/bin/python
+
+import os
+
+assert(os.environ['MESON_UNINSTALLED'] == '1')
+assert(os.environ['TEST_A'] == '1')
+assert(os.environ['TEST_B'] == '0+1+2+3')


### PR DESCRIPTION
    This adds meson.add_uninstalled_environment() that takes an
    environment() object and add it to a list of environments needed to be
    set to run the project uninstalled.
    
    A new command line tool `meson uninstalled -C builddir <command>` is
    also added to run a command with the uninstalled environment.
    
    This is useful for developpers who wish to use the project without
    installing it, it is often needed to set for example the path to plugins
    directory, etc.
    
    muninstalled.py is mostly copied from GStreamer's gst-env.py:
    https://gitlab.freedesktop.org/gstreamer/gst-build/blob/master/gst-env.py
