### PR TITLE
dependencies/ui.py: Fix Vulkan detection on Windows

### DIFF
--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -25,7 +25,7 @@ from .. import mesonlib
 from ..mesonlib import (
     MesonException, Popen_safe, extract_as_list, version_compare_many
 )
-from ..environment import detect_cpu
+from ..environment import detect_cpu_family
 
 from .base import DependencyException, DependencyMethods
 from .base import ExternalDependency, ExternalProgram, NonExistingExternalProgram
@@ -609,7 +609,7 @@ class VulkanDependency(ExternalDependency):
                 lib_name = 'vulkan-1'
                 lib_dir = 'Lib32'
                 inc_dir = 'Include'
-                if detect_cpu({}) == 'x86_64':
+                if detect_cpu_family(self.env.coredata.compilers.host) == 'x86_64':
                     lib_dir = 'Lib'
             else:
                 lib_name = 'vulkan'


### PR DESCRIPTION
Hi,

When building gtk master for 32-bit Windows using Visual Studio 2015, I found that Meson did not detect the correct arch for the Vulkan libraries as I am running a x64 version of Windows, which resulted in the result being 'x86_64' when passing an empty set into environment.depect_cpu(), which caused linking to fail due to mixing 32-bit object files with x64 .lib's.

To fix this, use environment.detect_cpu_family() on the self.env.coredata.compilers.host that we already have, so that we will link to the correct 32-bit Vulkan .lib.

Please note that this does not attempt to fix looking for Vulkan on ARM/ARM64 Windows as it seems that Microsoft does not allow Vulkan drivers on Windows-on-ARM systems, hence it seems that there is no Vulkan SDK that supports ARM/ARM64 development.

With blessings, thank you!