### PR TITLE
docs: add run_project_tests.py --only example

### DIFF
--- a/docs/markdown/Contributing.md
+++ b/docs/markdown/Contributing.md
@@ -125,7 +125,8 @@ in problematic cases.
 The tests are split into two different parts: unit tests and full
 project tests. To run all tests, execute `./run_tests.py`. Unit tests
 can be run with `./run_unittests.py` and project tests with
-`./run_project_tests.py`.
+`./run_project_tests.py`. To run a single suite you can `cd 'test cases'`
+and `../run_project_tests.py --only fortran`.
 
 Each project test is a standalone project that can be compiled on its
 own. They are all in `test cases` subdirectory. The simplest way to


### PR DESCRIPTION
Running all the tests takes minutes which puts off potential "drive-by"
contributors. While we don't want to start duplicating
run_project_tests.py --help in Contributing.md, we want to spend at
least one line and provide a "gateway drug" that demonstrates how easy
it is to run a smaller set in seconds.

Change directory to 'test cases' so shell completion works.