### PR TITLE
modules/qt.py: friendlier "lrelease-qtN not found" error message

### DIFF
--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -206,6 +206,9 @@ class QtBaseModule(ExtensionModule):
         self._detect_tools(state.environment, kwargs.get('method', 'auto'))
         translations = []
         for ts in ts_files:
+            if not self.lrelease.found():
+                raise MesonException('qt.compile_translations: ' +
+                                     self.lrelease.name + ' not found')
             cmd = [self.lrelease, '@INPUT@', '-qm', '@OUTPUT@']
             lrelease_kwargs = {'output': '@BASENAME@.qm',
                                'input': ts,


### PR DESCRIPTION
When lrelease-qtN is missing, upgrade the error message from the
cryptic:

  meson.build:75:4: ERROR: Tried to use not-found external program in "command"

to the meaningful:

  meson.build:75:4: ERROR: qt.compile_translations: lrelease-qt5 not found

Issue found and tested with "test cases/frameworks/4 qt/"