### PR TITLE
wrap: working to improve security

### DIFF
--- a/manual tests/1 wrap/main.c
+++ b/manual tests/1 wrap/main.c
@@ -1,7 +1,7 @@
 #include<sqlite3.h>
 #include<stdio.h>
 
-int main(int argc, char **argv) {
+int main(void) {
     sqlite3 *db;
     if(sqlite3_open(":memory:", &db) != SQLITE_OK) {
         printf("Sqlite failed.\n");

--- a/manual tests/10 svn wrap/prog.c
+++ b/manual tests/10 svn wrap/prog.c
@@ -1,6 +1,6 @@
 #include"subproj.h"
 
-int main(int argc, char **argv) {
+int main(void) {
     subproj_function();
     return 0;
 }

--- a/manual tests/11 wrap imposter/meson.build
+++ b/manual tests/11 wrap imposter/meson.build
@@ -1,0 +1,8 @@
+project('evil URL')
+# showing that new Meson wrap.py code tries to stop imposter WrapDB URLs
+# a WrapException is raised.
+#
+# ERROR: https://wrapdb.mesonbuild.com.invalid/v1/projects/zlib/1.2.11/4/get_zip may be a WrapDB-impersonating URL
+#
+
+subproject('zlib')

--- a/manual tests/11 wrap imposter/subprojects/zlib.wrap
+++ b/manual tests/11 wrap imposter/subprojects/zlib.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = zlib-1.2.8
+
+source_url = https://zlib.net/zlib-1.2.11.tar.gz
+source_filename = zlib-1.2.11.tar.gz
+source_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+
+patch_url = https://wrapdb.mesonbuild.com.invalid/v1/projects/zlib/1.2.11/4/get_zip
+patch_filename = zlib-1.2.11-4-wrap.zip
+patch_hash = 886b67480dbe73b406ad83a1dd6d9596f93089d90c220ccfc91944c95f1c68c4

--- a/manual tests/12 wrap mirror/meson.build
+++ b/manual tests/12 wrap mirror/meson.build
@@ -1,0 +1,4 @@
+project('downloader')
+# this test will timeout, showing that a subdomain isn't caught as masquarading url
+
+subproject('zlib')

--- a/manual tests/12 wrap mirror/subprojects/zlib.wrap
+++ b/manual tests/12 wrap mirror/subprojects/zlib.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = zlib-1.2.8
+
+source_url = https://zlib.net/zlib-1.2.11.tar.gz
+source_filename = zlib-1.2.11.tar.gz
+source_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+
+patch_url = https://mirror1.wrapdb.mesonbuild.com/v1/projects/zlib/1.2.11/4/get_zip
+patch_filename = zlib-1.2.11-4-wrap.zip
+patch_hash = 886b67480dbe73b406ad83a1dd6d9596f93089d90c220ccfc91944c95f1c68c4

--- a/manual tests/3 git wrap/prog.c
+++ b/manual tests/3 git wrap/prog.c
@@ -1,6 +1,6 @@
 #include"subproj.h"
 
-int main(int argc, char **argv) {
+int main(void) {
     subproj_function();
     return 0;
 }

--- a/manual tests/4 standalone binaries/myapp.cpp
+++ b/manual tests/4 standalone binaries/myapp.cpp
@@ -3,7 +3,7 @@
 #include<iostream>
 #include<string>
 
-int main(int argc, char *argv[]) {
+int main(void) {
   SDL_Surface *screenSurface;
   SDL_Event e;
   int keepGoing = 1;

--- a/manual tests/5 rpm/main.c
+++ b/manual tests/5 rpm/main.c
@@ -1,6 +1,6 @@
 #include<lib.h>
 #include<stdio.h>
-int main(int argc, char **argv)
+int main(void)
 {
   char *t = meson_print();
   printf("%s", t);

--- a/manual tests/6 hg wrap/prog.c
+++ b/manual tests/6 hg wrap/prog.c
@@ -1,6 +1,6 @@
 #include"subproj.h"
 
-int main(int argc, char **argv) {
+int main(void) {
     subproj_function();
     return 0;
 }

--- a/manual tests/8 timeout/sleepprog.c
+++ b/manual tests/8 timeout/sleepprog.c
@@ -1,6 +1,6 @@
 #include<unistd.h>
 
-int main(int argc, char **argv) {
+int main(void) {
     sleep(1000);
     return 0;
 }

--- a/mesonbuild/modules/rpm.py
+++ b/mesonbuild/modules/rpm.py
@@ -151,7 +151,7 @@ class RPMModule(ExtensionModule):
 
     def __get_required_compilers(self):
         required_compilers = set()
-        for compiler in self.coredata.compilers.values():
+        for compiler in self.coredata.environment.coredata.compilers.host.values():
             # Elbrus has one 'lcc' package for every compiler
             if isinstance(compiler, compilers.GnuCCompiler):
                 required_compilers.add('gcc')

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -46,6 +46,7 @@ except ImportError:
 req_timeout = 600.0
 ssl_warning_printed = False
 
+
 def quiet_git(cmd: typing.List[str], workingdir: str) -> typing.Tuple[bool, str]:
     try:
         pc = subprocess.run(['git', '-C', workingdir] + cmd, universal_newlines=True,
@@ -60,7 +61,7 @@ def open_wrapdburl(urlstring: str) -> 'http.client.HTTPResponse':
     global ssl_warning_printed
     if has_ssl:
         try:
-            return urllib.request.urlopen(urlstring, timeout=req_timeout)  # , context=ssl.create_default_context())
+            return urllib.request.urlopen(urlstring, timeout=req_timeout)
         except urllib.error.URLError:
             if not ssl_warning_printed:
                 print('SSL connection failed. Falling back to unencrypted connections.', file=sys.stderr)


### PR DESCRIPTION
### use WrapDB domain whitelist, don't fallback to non-SSL when SSL available

In my opinion, we should not fall back to http:// from the SSL HSTS WrapDB URL, **for systems that have Python SSL** as that is controverting the point of HSTS + SSL.

For systems that do not have Python SSL, they continue to work with a
colored mlog.warning instead of only a stderr console print.

Also, attempt to stop masquerade URLS containing wrapdb.mesonbuild.com.evil.stuff.com