### PR TITLE
ci: lgtm: configure for Python 3

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  python:
+    python_setup:
+      version: 3


### PR DESCRIPTION
LGTM is currently giving spurious errors since LGTM is defaulting
to Python 2 for Meson.