### PR TITLE
tests: add clues to find missing private/qtobject_p.h

### DIFF
--- a/test cases/frameworks/4 qt/main.cpp
+++ b/test cases/frameworks/4 qt/main.cpp
@@ -3,6 +3,10 @@
 
 #if QT_VERSION > 0x050000
 // include some random private headers
+// As you're not supposed to use it, your system may miss
+// qobject_p.h. To locate it try one of these commands:
+//  - dnf provides */private/qobject_p.h
+//  - apt-file search qobject_p.h
     #include <private/qobject_p.h>
 #endif
 


### PR DESCRIPTION
Finding all the dependencies missing from my Fedora system to run the whole
test suite was relatively quick - except for this one.