### PR TITLE
Ninja backend: stop doubling backslashes

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -186,7 +186,6 @@ class NinjaBuildElement:
                     quoter = ninja_quote
                 else:
                     quoter = lambda x: ninja_quote(quote_func(x))
-                i = i.replace('\\', '\\\\')
                 if quote_func('') == '""':
                     i = i.replace('"', '\\"')
                 newelems.append(quoter(i))

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -20,6 +20,30 @@ from . import mlog
 
 # This is the regex for the supported escape sequences of a regular string
 # literal, like 'abc\x00'
+
+# Backslash escaping happens in several levels/places in Python and
+# works differently in each place. Survival skills:
+#
+# - By design, a backslash in a _raw_ string NEVER gets combined with
+#   the next character. Always use raw strings for regular
+#   expressions. Note even when never combined, it still has a bit of
+#   "escape power" as seen in: r'a\'b'
+#
+# - A regular expression ALWAYS combines a backslash with the next
+#   character. So finding a literal backslash requires doubling
+#   it. Starting with 3.6, sequences with an unknown letter (e.g: r'\z')
+#   fail to compile. Other unknown sequences discard the backslash as
+#   no-op, e.g: r'\=' matches exactly like r'='.
+#
+# - A backslash is treated the SAME inside vs outside a regex set [ ].
+#   However '\+' makes a difference outside [ ]\+, whereas the same
+#   backslash is discarded as a no-op inside [\+] because + is not
+#   special inside.
+#
+# - Regular, not-raw strings combine backslashes with the next character
+#   SOMETIMES and sometimes not; check the relevant documentation. In
+#   doubt try to use a raw string.
+
 ESCAPE_SEQUENCE_SINGLE_RE = re.compile(r'''
     ( \\U[A-Fa-f0-9]{8}   # 8-digit hex escapes
     | \\u[A-Fa-f0-9]{4}   # 4-digit hex escapes

--- a/test cases/common/111 spaces backslash/comparer-end-notstring.c
+++ b/test cases/common/111 spaces backslash/comparer-end-notstring.c
@@ -4,7 +4,7 @@
 #error "comparer.h not included"
 #endif
 
-/* This converts foo\\\\bar\\\\ to "foo\\bar\\" (string literal) */
+/* This converts foo\\bar\\ to "foo\\bar\\" (string literal) */
 #define Q(x) #x
 #define QUOTE(x) Q(x)
 

--- a/test cases/common/111 spaces backslash/meson.build
+++ b/test cases/common/111 spaces backslash/meson.build
@@ -16,13 +16,13 @@ endif
 # Path can contain \. Here we're sending `"foo\bar"`.
 test('backslash quoting',
      executable('comparer', 'comparer.c',
-                c_args : default_c_args + ['-DDEF_WITH_BACKSLASH="foo\\bar"']))
+                c_args : default_c_args + ['''-DDEF_WITH_BACKSLASH="foo\\bar"''']))
 # Path can end in \ without any special quoting. Here we send `"foo\bar\"`.
 test('backslash end quoting',
      executable('comparer-end', 'comparer-end.c',
-                c_args : default_c_args + ['-DDEF_WITH_BACKSLASH="foo\\bar\\"']))
+                c_args : default_c_args + ['''-DDEF_WITH_BACKSLASH="foo\\bar\\"''']))
 # Path can (really) end in \ if we're not passing a string literal without any
 # special quoting. Here we're sending `foo\bar\`.
 test('backslash end quoting when not a string literal',
      executable('comparer-end-notstring', 'comparer-end-notstring.c',
-                c_args : default_c_args + ['-DDEF_WITH_BACKSLASH=foo\\bar\\']))
+                c_args : default_c_args + ['''-DDEF_WITH_BACKSLASH=foo\\bar\\''']))

--- a/test cases/common/184 escape and unicode/meson.build
+++ b/test cases/common/184 escape and unicode/meson.build
@@ -34,5 +34,5 @@ malformed = [
 
 foreach m : malformed
   assert(m[0].endswith(m[1]), 'bad escape sequence had unexpected end')
-  assert(m[0].startswith('\\'), 'bad escape sequence had unexpected start')
+  assert(m[0].startswith('''\'''), 'bad escape sequence had unexpected start')
 endforeach

--- a/test cases/common/36 tryrun/meson.build
+++ b/test cases/common/36 tryrun/meson.build
@@ -14,10 +14,7 @@ endif
 ok_code = '''#include<stdio.h>
 int main(void) {
   printf("%s\n", "stdout");
-  fprintf(stderr, "%s\n", "stderr");
-  return 0;
-}
-'''
+''' + 'fprintf(stderr, "%s\\n", "stderr"); return 0; }'
 
 error_code = '''int main(void) {
   return 1;
@@ -66,13 +63,13 @@ foreach cc : compilers
     if ok.stdout().strip() == 'stdout'
       message(type + ' stdout ok.')
     else
-      message(type + ' bad stdout.')
+      error(type + ' bad stdout.')
     endif
 
     if ok.stderr().strip() == 'stderr'
       message(type + ' stderr ok.')
     else
-      message(type + ' bad stderr.')
+      error(type + ' bad stderr.')
     endif
   endforeach
 endforeach


### PR DESCRIPTION
Three commits in the same area that can be re-submitted independently depending on how the code review goes.

The first two commits are comments and cosmetic code changes. The last and definitely not least commit removes one line of code in the Ninja backend that systematically doubles backslashes. This change lets the user pass escape sequences to lower processes, for instance it makes this possible:
```
command : [ 'printf', '''%s\n''', 'hello world' ]
```
See commit messages for more specific details.

Submitted as a draft because this hasn't been tested on Windows at all.