### PR TITLE
Update CI Continuous Integration page and add CircleCi example [skip ci]

### DIFF
--- a/docs/markdown/Continuous-Integration.md
+++ b/docs/markdown/Continuous-Integration.md
@@ -46,7 +46,7 @@ script:
 
 ## CircleCi for Linux (with Docker)
 
-[CircleCi](https://circleci.com/) is fantastic for spinning all of the Linux images you wish. 
+[CircleCi](https://circleci.com/) can work for spinning all of the Linux images you wish. 
 Here's a sample `yml` file for use with that.
 
 ```yaml

--- a/docs/markdown/Continuous-Integration.md
+++ b/docs/markdown/Continuous-Integration.md
@@ -32,8 +32,8 @@ services:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip3 install meson ninja; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3 ninja; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip3 install meson; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker pull YOUR/REPO:yakkety; fi
 
 script:

--- a/docs/markdown/Continuous-Integration.md
+++ b/docs/markdown/Continuous-Integration.md
@@ -132,7 +132,7 @@ install:
   - cmd: echo Using Python at %PYTHON_ROOT%
   # Add necessary paths to PATH variable
   - cmd: set PATH=%cd%;%PYTHON_ROOT%;%PYTHON_ROOT%\Scripts;%PATH%
-  # Install meson
+  # Install meson and ninja
   - cmd: pip install ninja meson
   # Set up the build environment
   - cmd: if %compiler%==msvc2015 ( call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %arch% )

--- a/docs/markdown/Continuous-Integration.md
+++ b/docs/markdown/Continuous-Integration.md
@@ -32,8 +32,8 @@ services:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja python3; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip3 install meson; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip3 install meson ninja; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then docker pull YOUR/REPO:yakkety; fi
 
 script:
@@ -67,9 +67,6 @@ platform:
   - x64
 
 install:
-  # Download ninja
-  - cmd: mkdir C:\ninja-build
-  - ps: (new-object net.webclient).DownloadFile('https://github.com/mesonbuild/cidata/raw/master/ninja.exe', 'C:\ninja-build\ninja.exe')
   # Set paths to dependencies (based on architecture)
   - cmd: if %arch%==x86 (set PYTHON_ROOT=C:\python37) else (set PYTHON_ROOT=C:\python37-x64)
   # Print out dependency paths
@@ -77,7 +74,7 @@ install:
   # Add necessary paths to PATH variable
   - cmd: set PATH=%cd%;C:\ninja-build;%PYTHON_ROOT%;%PYTHON_ROOT%\Scripts;%PATH%
   # Install meson
-  - cmd: pip install meson
+  - cmd: pip install ninja meson
   # Set up the build environment
   - cmd: if %compiler%==msvc2015 ( call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %arch% )
   - cmd: if %compiler%==msvc2017 ( call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %arch% )

--- a/docs/markdown/Continuous-Integration.md
+++ b/docs/markdown/Continuous-Integration.md
@@ -67,7 +67,6 @@ executors:
     docker:
       - image: your_dockerhub_username/fedora-sys
 
-
 jobs:
   meson_ubuntu_build:
     executor: meson_ubuntu_builder
@@ -92,7 +91,6 @@ jobs:
       - run: meson setup builddir --backend ninja
       - run: ninja -C builddir
       - run: meson test -C builddir
-
 
 workflows:
   version: 2

--- a/docs/markdown/Continuous-Integration.md
+++ b/docs/markdown/Continuous-Integration.md
@@ -73,7 +73,7 @@ jobs:
     executor: meson_ubuntu_builder
     steps:
       - checkout
-      - run: meson setup builddir --buildtype=minsize --backend ninja
+      - run: meson setup builddir --backend ninja
       - run: ninja -C builddir
       - run: meson test -C builddir
 
@@ -81,7 +81,7 @@ jobs:
     executor: meson_debain_builder
     steps:
       - checkout
-      - run: meson setup builddir --buildtype=minsize --backend ninja
+      - run: meson setup builddir --backend ninja
       - run: ninja -C builddir
       - run: meson test -C builddir
 
@@ -89,7 +89,7 @@ jobs:
     executor: meson_fedora_builder
     steps:
       - checkout
-      - run: meson setup builddir --buildtype=minsize --backend ninja
+      - run: meson setup builddir --backend ninja
       - run: ninja -C builddir
       - run: meson test -C builddir
 

--- a/docs/markdown/Continuous-Integration.md
+++ b/docs/markdown/Continuous-Integration.md
@@ -46,8 +46,8 @@ script:
 
 ## CircleCi for Linux (with Docker)
 
-For CI on Linux, [CircleCi](https://circleci.com/) is probably
-your best bet. Here's a sample `yml` file for use with that.
+[CircleCi](https://circleci.com/) is fantastic for spinning all of the Linux images you wish. 
+Here's a sample `yml` file for use with that.
 
 ```yaml
 version: 2.1

--- a/docs/markdown/Continuous-Integration.md
+++ b/docs/markdown/Continuous-Integration.md
@@ -131,7 +131,7 @@ install:
   # Print out dependency paths
   - cmd: echo Using Python at %PYTHON_ROOT%
   # Add necessary paths to PATH variable
-  - cmd: set PATH=%cd%;C:\ninja-build;%PYTHON_ROOT%;%PYTHON_ROOT%\Scripts;%PATH%
+  - cmd: set PATH=%cd%;%PYTHON_ROOT%;%PYTHON_ROOT%\Scripts;%PATH%
   # Install meson
   - cmd: pip install ninja meson
   # Set up the build environment

--- a/docs/markdown/Continuous-Integration.md
+++ b/docs/markdown/Continuous-Integration.md
@@ -44,6 +44,65 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) meson builddir && ninja -C builddir test; fi
 ```
 
+## CircleCi for Linux (with Docker)
+
+For CI on Linux, [CircleCi](https://circleci.com/) is probably
+your best bet. Here's a sample `yml` file for use with that.
+
+```yaml
+version: 2.1
+
+executors:
+  # Your dependencies would go in the docker images that represent
+  # the Linux distributions you are supporting
+  meson_ubuntu_builder:
+    docker:
+      - image: michaelbadcruble/ubuntu-sys
+
+  meson_debain_builder:
+    docker:
+      - image: michaelbadcruble/debian-sys
+
+  meson_fedora_builder:
+    docker:
+      - image: michaelbadcruble/fedora-sys
+
+
+jobs:
+  meson_ubuntu_build:
+    executor: meson_ubuntu_builder
+    steps:
+      - checkout
+      - run: meson setup builddir --buildtype=minsize --backend ninja
+      - run: ninja -C builddir
+      - run: meson test -C builddir
+
+  meson_debain_build:
+    executor: meson_debain_builder
+    steps:
+      - checkout
+      - run: meson setup builddir --buildtype=minsize --backend ninja
+      - run: ninja -C builddir
+      - run: meson test -C builddir
+
+  meson_fedora_build:
+    executor: meson_fedora_builder
+    steps:
+      - checkout
+      - run: meson setup builddir --buildtype=minsize --backend ninja
+      - run: ninja -C builddir
+      - run: meson test -C builddir
+
+
+workflows:
+  version: 2
+  linux_workflow:
+    jobs:
+      - meson_ubuntu_build
+      - meson_debain_build
+      - meson_fedora_build
+```
+
 ## AppVeyor for Windows
 
 For CI on Windows, [AppVeyor](https://www.appveyor.com/) is probably

--- a/docs/markdown/Continuous-Integration.md
+++ b/docs/markdown/Continuous-Integration.md
@@ -57,15 +57,15 @@ executors:
   # the Linux distributions you are supporting
   meson_ubuntu_builder:
     docker:
-      - image: michaelbadcruble/ubuntu-sys
+      - image: your_dockerhub_username/ubuntu-sys
 
   meson_debain_builder:
     docker:
-      - image: michaelbadcruble/debian-sys
+      - image: your_dockerhub_username/debian-sys
 
   meson_fedora_builder:
     docker:
-      - image: michaelbadcruble/fedora-sys
+      - image: your_dockerhub_username/fedora-sys
 
 
 jobs:


### PR DESCRIPTION
Just an update to CI Continuous Integration page because I think it would help people can install both Meson and Ninja using `pip install meson ninja`, this should make CI YAML files easier to read.

CircleCi example is added to provide a new option for Meson build projects when choosing a CI provider. 