### PR TITLE
cmake: Make output_target_map more robust (fixes #6208)

### DIFF
--- a/mesonbuild/cmake/data/run_ctgt.py
+++ b/mesonbuild/cmake/data/run_ctgt.py
@@ -41,6 +41,7 @@ for i in commands:
         continue
 
     try:
+        os.makedirs(args.directory, exist_ok=True)
         subprocess.run(i, cwd=args.directory, check=True)
     except subprocess.CalledProcessError:
         exit(1)

--- a/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
@@ -10,6 +10,7 @@ add_definitions("-DDO_NOTHING_JUST_A_FLAG=1")
 add_executable(gen main.cpp)
 add_executable(mycpy cp.cpp)
 
+# cpyBase
 add_custom_command(
   OUTPUT  "${CMAKE_CURRENT_BINARY_DIR}/genTest.cpp" "${CMAKE_CURRENT_BINARY_DIR}/genTest.hpp"
   COMMAND gen ARGS genTest
@@ -42,7 +43,53 @@ add_custom_command(
   DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/cpyBase.hpp.something"
 )
 
-add_library(cmModLib SHARED cmMod.cpp genTest.cpp cpyBase.cpp cpyBase.hpp)
+# cpyNext (out of order is on purpose)
+# -- first copy round
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/s1_a_hpp/file.txt"
+  COMMAND mycpy "${CMAKE_CURRENT_SOURCE_DIR}/cpyNext.hpp.am" file.txt
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/cpyNext.hpp.am"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/s1_a_hpp"
+)
+
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/s1_b_cpp/file.txt"
+  COMMAND mycpy "${CMAKE_CURRENT_SOURCE_DIR}/cpyNext.cpp.am" file.txt
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/cpyNext.cpp.am"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/s1_b_cpp"
+)
+
+# -- final cpy round
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cpyNext.hpp"
+  COMMAND mycpy "${CMAKE_CURRENT_BINARY_DIR}/s2_b_hpp/file.txt" cpyNext.hpp
+  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/s2_b_hpp/file.txt"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cpyNext.cpp"
+  COMMAND mycpy "${CMAKE_CURRENT_BINARY_DIR}/s2_a_cpp/file.txt" cpyNext.cpp
+  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/s2_a_cpp/file.txt"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
+# -- second copy round
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/s2_b_hpp/file.txt"
+  COMMAND mycpy "${CMAKE_CURRENT_BINARY_DIR}/s1_a_hpp/file.txt" file.txt
+  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/s1_a_hpp/file.txt"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/s2_b_hpp"
+)
+
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/s2_a_cpp/file.txt"
+  COMMAND mycpy "${CMAKE_CURRENT_BINARY_DIR}/s1_b_cpp/file.txt" file.txt
+  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/s1_b_cpp/file.txt"
+  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/s2_a_cpp"
+)
+
+add_library(cmModLib SHARED cmMod.cpp genTest.cpp cpyBase.cpp cpyBase.hpp cpyNext.cpp cpyNext.hpp)
 include(GenerateExportHeader)
 generate_export_header(cmModLib)
 

--- a/test cases/cmake/8 custom command/subprojects/cmMod/cmMod.cpp
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/cmMod.cpp
@@ -1,6 +1,7 @@
 #include "cmMod.hpp"
 #include "genTest.hpp"
 #include "cpyBase.hpp"
+#include "cpyNext.hpp"
 #include "cmModLib.hpp"
 
 #ifndef FOO
@@ -18,5 +19,5 @@ string cmModClass::getStr() const {
 }
 
 string cmModClass::getOther() const {
-  return getStr() + "  --  " + getStrCpy();
+  return "Srings:\n - " + getStrCpy() + "\n - " + getStrNext();
 }

--- a/test cases/cmake/8 custom command/subprojects/cmMod/cp.cpp
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/cp.cpp
@@ -12,6 +12,11 @@ int main(int argc, char *argv[]) {
   ifstream src(argv[1]);
   ofstream dst(argv[2]);
 
+  if(!src.is_open()) {
+    cerr << "Failed to open " << argv[1] << endl;
+    return 2;
+  }
+
   dst << src.rdbuf();
   return 0;
 }

--- a/test cases/cmake/8 custom command/subprojects/cmMod/cpyNext.cpp.am
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/cpyNext.cpp.am
@@ -1,0 +1,5 @@
+#include "cpyNext.hpp"
+
+std::string getStrNext() {
+  return "Hello Copied File -- now even more convoluted!";
+}

--- a/test cases/cmake/8 custom command/subprojects/cmMod/cpyNext.hpp.am
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/cpyNext.hpp.am
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string>
+
+std::string getStrNext();


### PR DESCRIPTION
This PR refactors the old output_target_map, which was a
raw dict, into it's own class. This makes the access to
the map more uniform and robust (at the cost of more lines
of code).

Additionally relative paths to the build directory are
now also tracked for outputs. This is neccessary to
corretcly distingluish files with the same name, that are
in different directories.