### PR TITLE
linkers: AppleDynamicLinker supports -pie.

### DIFF
--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -573,6 +573,9 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
     def get_std_shared_module_args(self, options: 'OptionDictType') -> typing.List[str]:
         return ['-bundle'] + self._apply_prefix('-undefined,dynamic_lookup')
 
+    def get_pie_args(self) -> typing.List[str]:
+        return ['-pie']
+
     def get_link_whole_for(self, args: typing.List[str]) -> typing.List[str]:
         result = []  # type: typing.List[str]
         for a in args:

--- a/test cases/osx/8 pie/main.c
+++ b/test cases/osx/8 pie/main.c
@@ -1,0 +1,5 @@
+#include <CoreFoundation/CoreFoundation.h>
+
+int main(int argc, char **argv) {
+    return 0;
+}

--- a/test cases/osx/8 pie/meson.build
+++ b/test cases/osx/8 pie/meson.build
@@ -1,0 +1,3 @@
+project('osx pie', 'c')
+e = executable('prog', 'main.c', pie : true)
+test('pie', e)


### PR DESCRIPTION
The linker implementation split up introduced a regression: since the
AppleDynamicLinker subclass doesn't expose PIE support, builds using
that feature just plainly fail.

Add back support for it using the default and supported -pie flag.