### PR TITLE
Fix regular expression for MSVC target arch detection

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -993,7 +993,7 @@ class Environment:
                     m = 'Failed to detect MSVC compiler version: stderr was\n{!r}'
                     raise EnvironmentException(m.format(err))
                 cl_signature = lookat.split('\n')[0]
-                match = re.search(' for .*(x86|x64|ARM|ARM64)$', cl_signature)
+                match = re.search('.*(x86|x64|ARM|ARM64)$', cl_signature)
                 if match:
                     target = match.group(1)
                 else:


### PR DESCRIPTION
Make it work regardless of MSVC output language

Fixes #6128