### PR TITLE
ci: unused args for Windows, objc, objc++

### DIFF
--- a/.github/workflows/unusedargs_missingreturn.yml
+++ b/.github/workflows/unusedargs_missingreturn.yml
@@ -12,14 +12,17 @@ on:
     - "test cases/cmake/**"
     - "test cases/common/**"
     - "test cases/fortran/**"
-    - "test cases/platform-linux/**"
+    - "test cases/linuxlike/**"
+    - "test caes/windows/**"
+
   pull_request:
     paths:
     - ".github/workflows/unusedargs_missingreturn.yml"
     - "test cases/cmake/**"
     - "test cases/common/**"
     - "test cases/fortran/**"
-    - "test cases/platform-linux/**"
+    - "test cases/linuxlike/**"
+    - "test caes/windows/**"
 
 jobs:
 
@@ -39,3 +42,20 @@ jobs:
         CFLAGS: "-Werror=unused-parameter -Werror=return-type -Werror=strict-prototypes"
         CPPFLAGS: "-Werror=unused-parameter -Werror=return-type"
         FFLAGS: "-fimplicit-none"
+
+  windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - run: pip install ninja
+    - run: python run_project_tests.py --only platform-windows
+      env:
+        CFLAGS: "-Werror=unused-parameter -Werror=return-type -Werror=strict-prototypes"
+        CPPFLAGS: "-Werror=unused-parameter -Werror=return-type"
+        FFLAGS: "-fimplicit-none"
+        CC: gcc
+        CXX: g++
+        FC: gfortran

--- a/.github/workflows/unusedargs_missingreturn.yml
+++ b/.github/workflows/unusedargs_missingreturn.yml
@@ -13,6 +13,8 @@ on:
     - "test cases/common/**"
     - "test cases/fortran/**"
     - "test cases/linuxlike/**"
+    - "test cases/objc/**"
+    - "test cases/objcpp/**"
     - "test caes/windows/**"
 
   pull_request:
@@ -22,6 +24,8 @@ on:
     - "test cases/common/**"
     - "test cases/fortran/**"
     - "test cases/linuxlike/**"
+    - "test cases/objc/**"
+    - "test cases/objcpp/**"
     - "test caes/windows/**"
 
 jobs:
@@ -36,8 +40,8 @@ jobs:
     - name: Install Compilers
       run: |
         sudo apt update -yq
-        sudo apt install -yq --no-install-recommends g++ gfortran ninja-build
-    - run: python run_project_tests.py --only cmake common fortran platform-linux
+        sudo apt install -yq --no-install-recommends g++ gfortran ninja-build gobjc gobjc++
+    - run: python run_project_tests.py --only cmake common fortran platform-linux "objective c" "objective c++"
       env:
         CFLAGS: "-Werror=unused-parameter -Werror=return-type -Werror=strict-prototypes"
         CPPFLAGS: "-Werror=unused-parameter -Werror=return-type"

--- a/test cases/objc/1 simple/prog.m
+++ b/test cases/objc/1 simple/prog.m
@@ -1,5 +1,5 @@
 #import<stdio.h>
 
-int main(int argc, char **argv) {
+int main(void) {
     return 0;
 }

--- a/test cases/objc/2 nsstring/stringprog.m
+++ b/test cases/objc/2 nsstring/stringprog.m
@@ -1,6 +1,6 @@
 #import<Foundation/NSString.h>
 
-int main(int argc, char **argv) {
+int main(void) {
   int result;
   NSString *str = [NSString new];
   result = [str length];

--- a/test cases/objc/3 objc args/prog.m
+++ b/test cases/objc/3 objc args/prog.m
@@ -1,6 +1,6 @@
 #import<stdio.h>
 
-int main(int argc, char **argv)
+int main(void)
 {
 #ifdef MESON_TEST
   int x = 3;

--- a/test cases/objcpp/1 simple/prog.mm
+++ b/test cases/objcpp/1 simple/prog.mm
@@ -3,7 +3,7 @@
 class MyClass {
 };
 
-int main(int argc, char **argv) {
+int main(void) {
   return 0;
 }
 

--- a/test cases/objcpp/2 objc++ args/prog.mm
+++ b/test cases/objcpp/2 objc++ args/prog.mm
@@ -4,7 +4,7 @@ class TestClass
 {
 };
 
-int main(int argc, char **argv)
+int main(void)
 {
 #ifdef MESON_OBJCPP_TEST
 int x = 1;

--- a/test cases/osx/1 basic/main.c
+++ b/test cases/osx/1 basic/main.c
@@ -1,5 +1,5 @@
 #include <CoreFoundation/CoreFoundation.h>
 
-int main(int argc, char **argv) {
+int main(void) {
     return 0;
 }

--- a/test cases/osx/2 library versions/exe.orig.c
+++ b/test cases/osx/2 library versions/exe.orig.c
@@ -1,8 +1,6 @@
 int myFunc (void);
 
-int
-main (int argc, char *argv[])
-{
+int main (void) {
   if (myFunc() == 55)
     return 0;
   return 1;

--- a/test cases/osx/2 library versions/lib.c
+++ b/test cases/osx/2 library versions/lib.c
@@ -1,3 +1,3 @@
-int myFunc() {
+int myFunc(void) {
     return 55;
 }

--- a/test cases/osx/4 framework/prog.c
+++ b/test cases/osx/4 framework/prog.c
@@ -1,3 +1,3 @@
-int main(int argc, char **argv) {
+int main(void) {
     return 0;
 }

--- a/test cases/osx/4 framework/stat.c
+++ b/test cases/osx/4 framework/stat.c
@@ -1,1 +1,1 @@
-int func() { return 933; }
+int func(void) { return 933; }

--- a/test cases/osx/5 extra frameworks/prog.c
+++ b/test cases/osx/5 extra frameworks/prog.c
@@ -1,3 +1,3 @@
-int main(int argc, char **argv) {
+int main(void) {
     return 0;
 }

--- a/test cases/osx/5 extra frameworks/stat.c
+++ b/test cases/osx/5 extra frameworks/stat.c
@@ -1,1 +1,1 @@
-int func() { return 933; }
+int func(void) { return 933; }

--- a/test cases/osx/7 bitcode/libbar.mm
+++ b/test cases/osx/7 bitcode/libbar.mm
@@ -1,7 +1,7 @@
 #import <stdio.h>
 #import "vis.h"
 
-int EXPORT_PUBLIC libbar(int arg) {
+int EXPORT_PUBLIC libbar(void) {
   return 0;
 }
 

--- a/test cases/osx/7 bitcode/libfile.c
+++ b/test cases/osx/7 bitcode/libfile.c
@@ -1,5 +1,5 @@
 #include "vis.h"
 
-int EXPORT_PUBLIC libfunc() {
+int EXPORT_PUBLIC libfunc(void) {
     return 3;
 }

--- a/test cases/osx/7 bitcode/libfoo.m
+++ b/test cases/osx/7 bitcode/libfoo.m
@@ -1,7 +1,7 @@
 #import <stdio.h>
 #import "vis.h"
 
-int EXPORT_PUBLIC libfoo(int arg) {
+int EXPORT_PUBLIC libfoo(void) {
   return 0;
 }
 

--- a/test cases/osx/8 pie/main.c
+++ b/test cases/osx/8 pie/main.c
@@ -1,5 +1,5 @@
 #include <CoreFoundation/CoreFoundation.h>
 
-int main(int argc, char **argv) {
+int main(void) {
     return 0;
 }

--- a/test cases/windows/10 vs module defs generated custom target/prog.c
+++ b/test cases/windows/10 vs module defs generated custom target/prog.c
@@ -1,4 +1,4 @@
-int somedllfunc();
+int somedllfunc(void);
 
 int main(void) {
     return somedllfunc() == 42 ? 0 : 1;

--- a/test cases/windows/10 vs module defs generated custom target/subdir/somedll.c
+++ b/test cases/windows/10 vs module defs generated custom target/subdir/somedll.c
@@ -1,3 +1,3 @@
-int somedllfunc() {
+int somedllfunc(void) {
     return 42;
 }

--- a/test cases/windows/11 exe implib/prog.c
+++ b/test cases/windows/11 exe implib/prog.c
@@ -1,6 +1,6 @@
 #include <windows.h>
 
 int  __declspec(dllexport)
-main() {
+main(void) {
     return 0;
 }

--- a/test cases/windows/12 resources with custom targets/prog.c
+++ b/test cases/windows/12 resources with custom targets/prog.c
@@ -10,5 +10,10 @@ WinMain(
     int nCmdShow) {
     HICON hIcon;
     hIcon = LoadIcon(GetModuleHandle(NULL), MAKEINTRESOURCE(MY_ICON));
+    // avoid unused argument error while matching template
+    ((void)hInstance);
+    ((void)hPrevInstance);
+    ((void)lpszCmdLine);
+    ((void)nCmdShow);
     return hIcon ? 0 : 1;
 }

--- a/test cases/windows/13 test argument extra paths/exe/main.c
+++ b/test cases/windows/13 test argument extra paths/exe/main.c
@@ -1,5 +1,5 @@
 #include <foo.h>
 
-int main(int ac, char **av) {
+int main(void) {
   return foo_process();
 }

--- a/test cases/windows/14 resources with custom target depend_files/prog.c
+++ b/test cases/windows/14 resources with custom target depend_files/prog.c
@@ -10,5 +10,10 @@ WinMain(
     int nCmdShow) {
     HICON hIcon;
     hIcon = LoadIcon(GetModuleHandle(NULL), MAKEINTRESOURCE(MY_ICON));
+    // avoid unused argument error while matching template
+    ((void)hInstance);
+    ((void)hPrevInstance);
+    ((void)lpszCmdLine);
+    ((void)nCmdShow);
     return hIcon ? 0 : 1;
 }

--- a/test cases/windows/15 resource scripts with duplicate filenames/exe3/src_dll/main.c
+++ b/test cases/windows/15 resource scripts with duplicate filenames/exe3/src_dll/main.c
@@ -2,5 +2,9 @@
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
+  // avoid unused argument error while matching template
+    ((void)hinstDLL);
+    ((void)fdwReason);
+    ((void)lpvReserved);
   return TRUE;
 }

--- a/test cases/windows/15 resource scripts with duplicate filenames/exe3/src_exe/main.c
+++ b/test cases/windows/15 resource scripts with duplicate filenames/exe3/src_exe/main.c
@@ -1,3 +1,3 @@
-int main(int argc, char **argv) {
+int main(void) {
     return 0;
 }

--- a/test cases/windows/15 resource scripts with duplicate filenames/exe4/src_dll/main.c
+++ b/test cases/windows/15 resource scripts with duplicate filenames/exe4/src_dll/main.c
@@ -2,5 +2,9 @@
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
+  // avoid unused argument error while matching template
+    ((void)hinstDLL);
+    ((void)fdwReason);
+    ((void)lpvReserved);
   return TRUE;
 }

--- a/test cases/windows/15 resource scripts with duplicate filenames/exe4/src_exe/main.c
+++ b/test cases/windows/15 resource scripts with duplicate filenames/exe4/src_exe/main.c
@@ -1,3 +1,3 @@
-int main(int argc, char **argv) {
+int main(void) {
     return 0;
 }

--- a/test cases/windows/15 resource scripts with duplicate filenames/verify.c
+++ b/test cases/windows/15 resource scripts with duplicate filenames/verify.c
@@ -1,13 +1,15 @@
 #include <assert.h>
 #include <windows.h>
 
-int main(int arc, char *argv[])
+int main(int argc, char *argv[])
 {
   // verify that the expected resource exists and has the expected contents
   HRSRC hRsrc;
   unsigned int size;
   HGLOBAL hGlobal;
   void* data;
+
+  ((void)argc);
 
   hRsrc = FindResource(NULL, argv[1], RT_RCDATA);
   assert(hRsrc);

--- a/test cases/windows/16 gui app/gui_prog.c
+++ b/test cases/windows/16 gui app/gui_prog.c
@@ -2,5 +2,10 @@
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
                    LPSTR lpCmdLine, int nCmdShow) {
+    // avoid unused argument error while matching template
+    ((void)hInstance);
+    ((void)hPrevInstance);
+    ((void)lpCmdLine);
+    ((void)nCmdShow);
     return 0;
 }

--- a/test cases/windows/2 winmain/prog.c
+++ b/test cases/windows/2 winmain/prog.c
@@ -6,5 +6,10 @@ WinMain(
     HINSTANCE hPrevInstance,
     LPSTR lpszCmdLine,
     int nCmdShow) {
+// avoid unused argument error while matching template
+    ((void)hInstance);
+    ((void)hPrevInstance);
+    ((void)lpszCmdLine);
+    ((void)nCmdShow);
     return 0;
 }

--- a/test cases/windows/3 cpp/prog.cpp
+++ b/test cases/windows/3 cpp/prog.cpp
@@ -2,6 +2,6 @@
 
 class Foo;
 
-int main(int argc, char **argv) {
+int main(void) {
     return 0;
 }

--- a/test cases/windows/4 winmaincpp/prog.cpp
+++ b/test cases/windows/4 winmaincpp/prog.cpp
@@ -8,5 +8,10 @@ WinMain(
     HINSTANCE hPrevInstance,
     LPSTR lpszCmdLine,
     int nCmdShow) {
+// avoid unused argument error while matching template
+    ((void)hInstance);
+    ((void)hPrevInstance);
+    ((void)lpszCmdLine);
+    ((void)nCmdShow);
     return 0;
 }

--- a/test cases/windows/5 resources/prog.c
+++ b/test cases/windows/5 resources/prog.c
@@ -12,5 +12,10 @@ WinMain(
     int nCmdShow) {
     HICON hIcon;
     hIcon = LoadIcon(GetModuleHandle(NULL), MAKEINTRESOURCE(MY_ICON));
+// avoid unused argument error while matching template
+    ((void)hInstance);
+    ((void)hPrevInstance);
+    ((void)lpszCmdLine);
+    ((void)nCmdShow);
     return hIcon ? 0 : 1;
 }

--- a/test cases/windows/6 vs module defs/prog.c
+++ b/test cases/windows/6 vs module defs/prog.c
@@ -1,4 +1,4 @@
-int somedllfunc();
+int somedllfunc(void);
 
 int main(void) {
     return somedllfunc() == 42 ? 0 : 1;

--- a/test cases/windows/6 vs module defs/subdir/somedll.c
+++ b/test cases/windows/6 vs module defs/subdir/somedll.c
@@ -1,3 +1,3 @@
-int somedllfunc() {
+int somedllfunc(void) {
     return 42;
 }

--- a/test cases/windows/7 dll versioning/lib.c
+++ b/test cases/windows/7 dll versioning/lib.c
@@ -1,6 +1,6 @@
 #ifdef _WIN32
 __declspec(dllexport)
 #endif
-int myFunc() {
+int myFunc(void) {
     return 55;
 }

--- a/test cases/windows/9 vs module defs generated/prog.c
+++ b/test cases/windows/9 vs module defs generated/prog.c
@@ -1,4 +1,4 @@
-int somedllfunc();
+int somedllfunc(void);
 
 int main(void) {
     return somedllfunc() == 42 ? 0 : 1;

--- a/test cases/windows/9 vs module defs generated/subdir/somedll.c
+++ b/test cases/windows/9 vs module defs generated/subdir/somedll.c
@@ -1,3 +1,3 @@
-int somedllfunc() {
+int somedllfunc(void) {
     return 42;
 }


### PR DESCRIPTION
broader coverage with "no unused arguments" tests, for Windows and Objective C / Objective C++