### PR TITLE
mparser.py: actually check the type of key variable, not its value

### DIFF
--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -682,7 +682,7 @@ class Parser:
                         # + 1 to colno to point to the actual string, not the opening quote
                         raise ParseException('Duplicate dictionary key: {}'.format(s.value), self.getline(), s.lineno, s.colno + 1)
                     a.set_kwarg(s.value, key_value)
-                elif isinstance(s, IdNode) and isinstance(key_value, StringNode):
+                elif isinstance(s, IdNode) and isinstance(s.value, str):
                     for key in a.kwargs:
                         if s.value == key.value:
                             raise ParseException('Duplicate dictionary variable key: {}'.format(s.value), self.getline(), s.lineno, s.colno)

--- a/test cases/common/228 add dict variable key/meson.build
+++ b/test cases/common/228 add dict variable key/meson.build
@@ -1,12 +1,21 @@
 project('add dictionary entry using string variable as key', meson_version: '>=0.52')
 
-dict = {}
+dict1 = {}
 
 # A variable to be used as a key
-key = 'myKey'
+testkey1 = 'myKey1'
+testkey2 = 'myKey2'
 
 # Add new entry using the variable
-dict += {key : 'myValue'}
+dict1 += {testkey1 : 'myValue'}
+dict1 += {testkey2 : 42}
 
-# Test that the stored value is correct 
-assert(dict[key] == 'myValue', 'Incorrect value retrieved from dictionary')
+# Test that the stored values are correct
+assert(dict1[testkey1] == 'myValue',
+       'Incorrect string value retrieved from dictionary - variable key')
+assert(dict1['myKey1'] == 'myValue',
+       'Incorrect string value retrieved from dictionary - literal key')
+assert(dict1[testkey2] == 42,
+       'Incorrect int value retrieved from dictionary - variable key')
+assert(dict1['myKey2'] == 42,
+       'Incorrect int value retrieved from dictionary - literal key')


### PR DESCRIPTION
Fixes PR #6166 and more specifically commit 4e460f04f3b2 that tried to
make sure the type of a key variable is a string but checked the type of
the value instead. Extends test common/228's limited coverage,
its only test case had (surprise) a string value. Also avoid reserved
python keyword 'dict' and potentially confusing string 'key'.

Implements #5231 for real.