### PR TITLE
Fix most warnings and errors in LGTM

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -769,7 +769,6 @@ int dummy;
             elem = NinjaBuildElement(self.all_outputs, target_name, 'phony', [])
 
         elem.add_dep(deps)
-        cmd = self.replace_paths(target, cmd)
         self.add_build(elem)
         self.processed_targets[target.get_id()] = True
 
@@ -1018,7 +1017,6 @@ int dummy;
         generated_sources = self.get_target_generated_sources(target)
         generated_rel_srcs = []
         for rel_src in generated_sources.keys():
-            dirpart, fnamepart = os.path.split(rel_src)
             if rel_src.lower().endswith('.cs'):
                 generated_rel_srcs.append(os.path.normpath(rel_src))
             deps.append(os.path.normpath(rel_src))

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1106,7 +1106,7 @@ You probably should put it in link_with instead.''')
                 msg += "Use the 'pic' option to static_library to build with PIC."
                 raise InvalidArguments(msg)
             if self.for_machine is not t.for_machine:
-                msg = 'Tried to mix libraries for machines {1} and {2} in target {!r}'.format(self.name, self.for_machine, t.for_machine)
+                msg = 'Tried to mix libraries for machines {1} and {2} in target {0!r}'.format(self.name, self.for_machine, t.for_machine)
                 if self.environment.is_cross_build():
                     raise InvalidArguments(msg + ' This is not possible in a cross build.')
                 else:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -411,7 +411,7 @@ a hard error in the future.''' % name)
         return self.construct_id_from_path(
             self.subdir, self.name, self.type_suffix())
 
-    def process_kwargs(self, kwargs):
+    def process_kwargs_base(self, kwargs):
         if 'build_by_default' in kwargs:
             self.build_by_default = kwargs['build_by_default']
             if not isinstance(self.build_by_default, bool):
@@ -789,7 +789,7 @@ class BuildTarget(Target):
         return self.install_mode
 
     def process_kwargs(self, kwargs, environment):
-        super().process_kwargs(kwargs)
+        self.process_kwargs_base(kwargs)
         self.copy_kwargs(kwargs)
         kwargs.get('modules', [])
         self.need_install = kwargs.get('install', self.need_install)
@@ -2068,7 +2068,7 @@ class CustomTarget(Target):
         return final_cmd
 
     def process_kwargs(self, kwargs, backend):
-        super().process_kwargs(kwargs)
+        self.process_kwargs_base(kwargs)
         self.sources = extract_as_list(kwargs, 'input', unholder=True)
         if 'output' not in kwargs:
             raise InvalidArguments('Missing keyword argument "output".')
@@ -2251,6 +2251,9 @@ class RunTarget(Target):
     def __repr__(self):
         repr_str = "<{0} {1}: {2}>"
         return repr_str.format(self.__class__.__name__, self.get_id(), self.command)
+
+    def process_kwargs(self, kwargs):
+        return self.process_kwargs_base(kwargs)
 
     def get_dependencies(self):
         return self.dependencies

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -199,8 +199,6 @@ class OutputTargetMap:
         return '__art_{}__'.format(os.path.basename(fname))
 
 class ConverterTarget:
-    lang_cmake_to_meson = {val.lower(): key for key, val in language_map.items()}
-
     def __init__(self, target: CMakeTarget, env: Environment):
         self.env = env
         self.artifacts = target.artifacts
@@ -240,7 +238,8 @@ class ConverterTarget:
 
         for i in target.files:
             # Determine the meson language
-            lang = ConverterTarget.lang_cmake_to_meson.get(i.language.lower(), 'c')
+            lang_cmake_to_meson = {val.lower(): key for key, val in language_map.items()}
+            lang = lang_cmake_to_meson.get(i.language.lower(), 'c')
             if lang not in self.languages:
                 self.languages += [lang]
             if lang not in self.compile_opts:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -646,13 +646,13 @@ class CompilerArgs(list):
         return new
 
     def __mul__(self, args):
-        raise TypeError("can't multiply compiler arguments")
+        raise TypeError("can't multiply compiler arguments")  # lgtm[py/unexpected-raise-in-special-method]
 
     def __imul__(self, args):
-        raise TypeError("can't multiply compiler arguments")
+        raise TypeError("can't multiply compiler arguments")  # lgtm[py/unexpected-raise-in-special-method]
 
     def __rmul__(self, args):
-        raise TypeError("can't multiply compiler arguments")
+        raise TypeError("can't multiply compiler arguments")  # lgtm[py/unexpected-raise-in-special-method]
 
     def append(self, arg):
         self.__iadd__([arg])

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 import contextlib, os.path, re, tempfile
-import typing
-from typing import Optional, Tuple, List
+from typing import TYPE_CHECKING, Optional, Tuple, List, Union
 
 from ..linkers import StaticLinker, GnuLikeDynamicLinkerMixin, SolarisDynamicLinker
 from .. import coredata
@@ -28,7 +27,7 @@ from ..envconfig import (
     Properties,
 )
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from ..coredata import OptionDictType
     from ..envconfig import MachineInfo
     from ..environment import Environment
@@ -522,7 +521,7 @@ class CompilerArgs(list):
             return True
         return False
 
-    def to_native(self, copy: bool = False) -> typing.List[str]:
+    def to_native(self, copy: bool = False) -> List[str]:
         # Check if we need to add --start/end-group for circular dependencies
         # between static libraries, and for recursively searching for symbols
         # needed by static libraries that are provided by object files or
@@ -669,10 +668,10 @@ class Compiler:
     # manually searched.
     internal_libs = ()
 
-    LINKER_PREFIX = None  # type: typing.Union[None, str, typing.List[str]]
+    LINKER_PREFIX = None  # type: Union[None, str, List[str]]
 
     def __init__(self, exelist, version, for_machine: MachineChoice, info: 'MachineInfo',
-                 linker: typing.Optional['DynamicLinker'] = None, **kwargs):
+                 linker: Optional['DynamicLinker'] = None, **kwargs):
         if isinstance(exelist, str):
             self.exelist = [exelist]
         elif isinstance(exelist, list):
@@ -747,10 +746,10 @@ class Compiler:
     def get_exelist(self):
         return self.exelist[:]
 
-    def get_linker_exelist(self) -> typing.List[str]:
+    def get_linker_exelist(self) -> List[str]:
         return self.linker.get_exelist()
 
-    def get_linker_output_args(self, outputname: str) -> typing.List[str]:
+    def get_linker_output_args(self, outputname: str) -> List[str]:
         return self.linker.get_output_args(outputname)
 
     def get_builtin_define(self, *args, **kwargs):
@@ -793,10 +792,10 @@ class Compiler:
         """
         return self.get_language() in languages_using_ldflags
 
-    def get_linker_args_from_envvars(self) -> typing.List[str]:
+    def get_linker_args_from_envvars(self) -> List[str]:
         return self.linker.get_args_from_envvars()
 
-    def get_args_from_envvars(self) -> typing.Tuple[typing.List[str], typing.List[str]]:
+    def get_args_from_envvars(self) -> Tuple[List[str], List[str]]:
         """
         Returns a tuple of (compile_flags, link_flags) for the specified language
         from the inherited environment
@@ -813,8 +812,8 @@ class Compiler:
         if lang not in cflags_mapping:
             return [], []
 
-        compile_flags = []  # type: typing.List[str]
-        link_flags = []     # type: typing.List[str]
+        compile_flags = []  # type: List[str]
+        link_flags = []     # type: List[str]
 
         env_compile_flags = os.environ.get(cflags_mapping[lang])
         log_var(cflags_mapping[lang], env_compile_flags)
@@ -885,7 +884,7 @@ class Compiler:
     def get_option_compile_args(self, options):
         return []
 
-    def get_option_link_args(self, options: 'OptionDictType') -> typing.List[str]:
+    def get_option_link_args(self, options: 'OptionDictType') -> List[str]:
         return self.linker.get_option_args(options)
 
     def check_header(self, *args, **kwargs) -> Tuple[bool, bool]:
@@ -921,7 +920,7 @@ class Compiler:
         return args[:]
 
     @classmethod
-    def native_args_to_unix(cls, args: typing.List[str]) -> typing.List[str]:
+    def native_args_to_unix(cls, args: List[str]) -> List[str]:
         "Always returns a copy that can be independently mutated"
         return args[:]
 
@@ -939,7 +938,7 @@ class Compiler:
             'Language {} does not support has_multi_arguments.'.format(
                 self.get_display_language()))
 
-    def has_multi_link_arguments(self, args: typing.List[str], env: 'Environment') -> Tuple[bool, bool]:
+    def has_multi_link_arguments(self, args: List[str], env: 'Environment') -> Tuple[bool, bool]:
         return self.linker.has_multi_arguments(args, env)
 
     def _get_compile_output(self, dirname, mode):
@@ -1053,22 +1052,22 @@ class Compiler:
     def get_compile_debugfile_args(self, rel_obj, **kwargs):
         return []
 
-    def get_link_debugfile_args(self, targetfile: str) -> typing.List[str]:
+    def get_link_debugfile_args(self, targetfile: str) -> List[str]:
         return self.linker.get_debugfile_args(targetfile)
 
-    def get_std_shared_lib_link_args(self) -> typing.List[str]:
+    def get_std_shared_lib_link_args(self) -> List[str]:
         return self.linker.get_std_shared_lib_args()
 
-    def get_std_shared_module_link_args(self, options: 'OptionDictType') -> typing.List[str]:
+    def get_std_shared_module_link_args(self, options: 'OptionDictType') -> List[str]:
         return self.linker.get_std_shared_module_args(options)
 
-    def get_link_whole_for(self, args: typing.List[str]) -> typing.List[str]:
+    def get_link_whole_for(self, args: List[str]) -> List[str]:
         return self.linker.get_link_whole_for(args)
 
-    def get_allow_undefined_link_args(self) -> typing.List[str]:
+    def get_allow_undefined_link_args(self) -> List[str]:
         return self.linker.get_allow_undefined_args()
 
-    def no_undefined_link_args(self) -> typing.List[str]:
+    def no_undefined_link_args(self) -> List[str]:
         return self.linker.no_undefined_args()
 
     # Compiler arguments needed to enable the given instruction set.
@@ -1079,7 +1078,7 @@ class Compiler:
 
     def build_rpath_args(self, env: 'Environment', build_dir: str, from_dir: str,
                          rpath_paths: str, build_rpath: str,
-                         install_rpath: str) -> typing.List[str]:
+                         install_rpath: str) -> List[str]:
         return self.linker.build_rpath_args(
             env, build_dir, from_dir, rpath_paths, build_rpath, install_rpath)
 
@@ -1110,7 +1109,7 @@ class Compiler:
         m = 'Language {} does not support position-independent executable'
         raise EnvironmentException(m.format(self.get_display_language()))
 
-    def get_pie_link_args(self) -> typing.List[str]:
+    def get_pie_link_args(self) -> List[str]:
         return self.linker.get_pie_args()
 
     def get_argument_syntax(self):
@@ -1132,7 +1131,7 @@ class Compiler:
         raise EnvironmentException(
             '%s does not support get_profile_use_args ' % self.get_id())
 
-    def get_undefined_link_args(self) -> typing.List[str]:
+    def get_undefined_link_args(self) -> List[str]:
         return self.linker.get_undefined_link_args()
 
     def remove_linkerlike_args(self, args):
@@ -1150,21 +1149,21 @@ class Compiler:
     def sanitizer_link_args(self, value: str) -> List[str]:
         return self.linker.sanitizer_args(value)
 
-    def get_asneeded_args(self) -> typing.List[str]:
+    def get_asneeded_args(self) -> List[str]:
         return self.linker.get_asneeded_args()
 
-    def bitcode_args(self) -> typing.List[str]:
+    def bitcode_args(self) -> List[str]:
         return self.linker.bitcode_args()
 
-    def get_linker_debug_crt_args(self) -> typing.List[str]:
+    def get_linker_debug_crt_args(self) -> List[str]:
         return self.linker.get_debug_crt_args()
 
-    def get_buildtype_linker_args(self, buildtype: str) -> typing.List[str]:
+    def get_buildtype_linker_args(self, buildtype: str) -> List[str]:
         return self.linker.get_buildtype_args(buildtype)
 
     def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
-                        suffix: str, soversion: str, darwin_versions: typing.Tuple[str, str],
-                        is_shared_module: bool) -> typing.List[str]:
+                        suffix: str, soversion: str, darwin_versions: Tuple[str, str],
+                        is_shared_module: bool) -> List[str]:
         return self.linker.get_soname_args(
             env, prefix, shlib_name, suffix, soversion,
             darwin_versions, is_shared_module)

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -612,6 +612,7 @@ class GnuDCompiler(DCompiler, GnuCompiler):
 
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  info: 'MachineInfo', is_cross, exe_wrapper, arch, **kwargs):
+        GnuCompiler.__init__(self, {})
         DCompiler.__init__(self, exelist, version, for_machine, info, is_cross, exe_wrapper, arch, **kwargs)
         self.id = 'gcc'
         default_warn_args = ['-Wall', '-Wdeprecated']

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -612,8 +612,8 @@ class GnuDCompiler(DCompiler, GnuCompiler):
 
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  info: 'MachineInfo', is_cross, exe_wrapper, arch, **kwargs):
-        GnuCompiler.__init__(self, {})
         DCompiler.__init__(self, exelist, version, for_machine, info, is_cross, exe_wrapper, arch, **kwargs)
+        GnuCompiler.__init__(self, {})
         self.id = 'gcc'
         default_warn_args = ['-Wall', '-Wdeprecated']
         self.warn_args = {'0': [],

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 from pathlib import Path
-from typing import List
+from typing import TYPE_CHECKING, List
 import subprocess, os
-import typing
 
 from .. import coredata
 from .compilers import (
@@ -36,7 +35,7 @@ from mesonbuild.mesonlib import (
     version_compare, EnvironmentException, MesonException, MachineChoice, LibType
 )
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from ..envconfig import MachineInfo
 
 
@@ -192,7 +191,7 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
                                                              'none')})
         return opts
 
-    def get_option_compile_args(self, options) -> typing.List[str]:
+    def get_option_compile_args(self, options) -> List[str]:
         args = []
         std = options['fortran_std']
         if std.value != 'none':
@@ -297,7 +296,7 @@ class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
                                                              'none')})
         return opts
 
-    def get_option_compile_args(self, options) -> typing.List[str]:
+    def get_option_compile_args(self, options) -> List[str]:
         args = []
         std = options['fortran_std']
         stds = {'legacy': 'none', 'f95': 'f95', 'f2003': 'f03', 'f2008': 'f08', 'f2018': 'f18'}
@@ -317,7 +316,7 @@ class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
     def language_stdlib_only_link_flags(self):
         return ['-lifcore', '-limf']
 
-    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> typing.List[str]:
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> List[str]:
         return ['-gen-dep=' + outtarget, '-gen-depformat=make']
 
 
@@ -356,7 +355,7 @@ class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
                                                              'none')})
         return opts
 
-    def get_option_compile_args(self, options) -> typing.List[str]:
+    def get_option_compile_args(self, options) -> List[str]:
         args = []
         std = options['fortran_std']
         stds = {'legacy': 'none', 'f95': 'f95', 'f2003': 'f03', 'f2008': 'f08', 'f2018': 'f18'}

--- a/mesonbuild/compilers/mixins/arm.py
+++ b/mesonbuild/compilers/mixins/arm.py
@@ -143,7 +143,7 @@ class ArmclangCompiler:
         if ver_str:
             ver_str = ver_str.group(0)
         else:
-            mesonlib.EnvironmentException('armlink version string not found')
+            raise mesonlib.EnvironmentException('armlink version string not found')
         assert ver_str  # makes mypy happy
         # Using the regular expression from environment.search_version,
         # which is used for searching compiler version

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -167,7 +167,6 @@ class CLikeCompiler:
                     retval.append(d)
                 # at this point, it's an ELF file which doesn't match the
                 # appropriate elf_class, so skip this one
-                pass
         return tuple(retval)
 
     @functools.lru_cache()

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -618,8 +618,7 @@ class CoreData:
                 except MesonException as e:
                     raise type(e)(('Validation failed for option %s: ' % option_name) + str(e)) \
                         .with_traceback(sys.exc_info()[2])
-        else:
-            raise MesonException('Tried to validate unknown option %s.' % option_name)
+        raise MesonException('Tried to validate unknown option %s.' % option_name)
 
     def get_external_args(self, for_machine: MachineChoice, lang):
         return self.compiler_options[for_machine][lang + '_args'].value
@@ -659,7 +658,6 @@ class CoreData:
         if not self.is_cross_build():
             options = self.strip_build_option_names(options)
         # Set prefix first because it's needed to sanitize other options
-        prefix = self.builtins['prefix'].value
         if 'prefix' in options:
             prefix = self.sanitize_prefix(options['prefix'])
             self.builtins['prefix'].set_value(prefix)

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1714,7 +1714,9 @@ class ExternalProgram:
                 break
 
         if not silent:
-            if self.found():
+            # ignore the warning because derived classes never call this __init__
+            # method, and thus only the found() method of this class is ever executed
+            if self.found():  # lgtm [py/init-calls-subclass]
                 mlog.log('Program', mlog.bold(name), 'found:', mlog.green('YES'),
                          '(%s)' % ' '.join(self.command))
             else:

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -23,8 +23,7 @@ import shlex
 import shutil
 import textwrap
 import platform
-import typing
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 from enum import Enum
 from pathlib import Path, PurePath
 
@@ -208,8 +207,8 @@ class Dependency:
         """
         raise RuntimeError('Unreachable code in partial_dependency called')
 
-    def _add_sub_dependency(self, dep_type: typing.Type['Dependency'], env: Environment,
-                            kwargs: typing.Dict[str, typing.Any], *,
+    def _add_sub_dependency(self, dep_type: Type['Dependency'], env: Environment,
+                            kwargs: Dict[str, Any], *,
                             method: DependencyMethods = DependencyMethods.AUTO) -> None:
         """Add an internal dependency of of the given type.
 
@@ -222,14 +221,14 @@ class Dependency:
         kwargs['method'] = method
         self.ext_deps.append(dep_type(env, kwargs))
 
-    def get_variable(self, *, cmake: typing.Optional[str] = None, pkgconfig: typing.Optional[str] = None,
-                     configtool: typing.Optional[str] = None, default_value: typing.Optional[str] = None,
-                     pkgconfig_define: typing.Optional[typing.List[str]] = None) -> typing.Union[str, typing.List[str]]:
+    def get_variable(self, *, cmake: Optional[str] = None, pkgconfig: Optional[str] = None,
+                     configtool: Optional[str] = None, default_value: Optional[str] = None,
+                     pkgconfig_define: Optional[List[str]] = None) -> Union[str, List[str]]:
         if default_value is not None:
             return default_value
         raise DependencyException('No default provided for dependency {!r}, which is not pkg-config, cmake, or config-tool based.'.format(self))
 
-    def generate_system_dependency(self, include_type: str) -> typing.Type['Dependency']:
+    def generate_system_dependency(self, include_type: str) -> Type['Dependency']:
         new_dep = copy.deepcopy(self)
         new_dep.include_type = self._process_include_type_kw({'include_type': include_type})
         return new_dep
@@ -550,9 +549,9 @@ class ConfigToolDependency(ExternalDependency):
     def log_tried(self):
         return self.type_name
 
-    def get_variable(self, *, cmake: typing.Optional[str] = None, pkgconfig: typing.Optional[str] = None,
-                     configtool: typing.Optional[str] = None, default_value: typing.Optional[str] = None,
-                     pkgconfig_define: typing.Optional[typing.List[str]] = None) -> typing.Union[str, typing.List[str]]:
+    def get_variable(self, *, cmake: Optional[str] = None, pkgconfig: Optional[str] = None,
+                     configtool: Optional[str] = None, default_value: Optional[str] = None,
+                     pkgconfig_define: Optional[List[str]] = None) -> Union[str, List[str]]:
         if configtool:
             # In the not required case '' (empty string) will be returned if the
             # variable is not found. Since '' is a valid value to return we
@@ -984,9 +983,9 @@ class PkgConfigDependency(ExternalDependency):
     def log_tried(self):
         return self.type_name
 
-    def get_variable(self, *, cmake: typing.Optional[str] = None, pkgconfig: typing.Optional[str] = None,
-                     configtool: typing.Optional[str] = None, default_value: typing.Optional[str] = None,
-                     pkgconfig_define: typing.Optional[typing.List[str]] = None) -> typing.Union[str, typing.List[str]]:
+    def get_variable(self, *, cmake: Optional[str] = None, pkgconfig: Optional[str] = None,
+                     configtool: Optional[str] = None, default_value: Optional[str] = None,
+                     pkgconfig_define: Optional[List[str]] = None) -> Union[str, List[str]]:
         if pkgconfig:
             kwargs = {}
             if default_value is not None:
@@ -1479,9 +1478,9 @@ class CMakeDependency(ExternalDependency):
             return 'modules: ' + ', '.join(modules)
         return ''
 
-    def get_variable(self, *, cmake: typing.Optional[str] = None, pkgconfig: typing.Optional[str] = None,
-                     configtool: typing.Optional[str] = None, default_value: typing.Optional[str] = None,
-                     pkgconfig_define: typing.Optional[typing.List[str]] = None) -> typing.Union[str, typing.List[str]]:
+    def get_variable(self, *, cmake: Optional[str] = None, pkgconfig: Optional[str] = None,
+                     configtool: Optional[str] = None, default_value: Optional[str] = None,
+                     pkgconfig_define: Optional[List[str]] = None) -> Union[str, List[str]]:
         if cmake:
             try:
                 v = self.traceparser.vars[cmake]
@@ -1696,8 +1695,8 @@ class ExternalProgram:
     # An 'ExternalProgram' always runs on the build machine
     for_machine = MachineChoice.BUILD
 
-    def __init__(self, name: str, command: typing.Optional[typing.List[str]] = None,
-                 silent: bool = False, search_dir: typing.Optional[str] = None):
+    def __init__(self, name: str, command: Optional[List[str]] = None,
+                 silent: bool = False, search_dir: Optional[str] = None):
         self.name = name
         if command is not None:
             self.command = listify(command)

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1794,7 +1794,6 @@ class ExternalProgram:
                 return commands + [script]
         except Exception as e:
             mlog.debug(e)
-            pass
         mlog.debug('Unusable script {!r}'.format(script))
         return False
 

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1896,7 +1896,7 @@ class ExternalProgram:
         return self.name
 
 
-class NonExistingExternalProgram(ExternalProgram):
+class NonExistingExternalProgram(ExternalProgram):  # lgtm [py/missing-call-to-init]
     "A program that will never exist"
 
     def __init__(self, name='nonexistingprogram'):
@@ -1912,7 +1912,7 @@ class NonExistingExternalProgram(ExternalProgram):
         return False
 
 
-class EmptyExternalProgram(ExternalProgram):
+class EmptyExternalProgram(ExternalProgram):  # lgtm [py/missing-call-to-init]
     '''
     A program object that returns an empty list of commands. Used for cases
     such as a cross file exe_wrapper to represent that it's not required.

--- a/mesonbuild/dependencies/cuda.py
+++ b/mesonbuild/dependencies/cuda.py
@@ -94,7 +94,7 @@ class CudaDependency(ExternalDependency):
 
         defaults = [(path, version) for (path, version, default) in paths if default]
         if defaults:
-            return (*defaults[0], True)
+            return (defaults[0][0], defaults[0][1], True)
 
         platform_msg = 'set the CUDA_PATH environment variable' if self._is_windows() \
             else 'set the CUDA_PATH environment variable/create the \'/usr/local/cuda\' symbolic link'

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -605,16 +605,14 @@ class VulkanDependency(ExternalDependency):
             # TODO: this config might not work on some platforms, fix bugs as reported
             # we should at least detect other 64-bit platforms (e.g. armv8)
             lib_name = 'vulkan'
+            lib_dir = 'lib'
+            inc_dir = 'include'
             if mesonlib.is_windows():
                 lib_name = 'vulkan-1'
                 lib_dir = 'Lib32'
                 inc_dir = 'Include'
                 if detect_cpu_family(self.env.coredata.compilers.host) == 'x86_64':
                     lib_dir = 'Lib'
-            else:
-                lib_name = 'vulkan'
-                lib_dir = 'lib'
-                inc_dir = 'include'
 
             # make sure header and lib are valid
             inc_path = os.path.join(self.vulkan_sdk, inc_dir)

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -883,10 +883,10 @@ class CustomTargetHolder(TargetHolder):
         return CustomTargetIndexHolder(self.held_object[index])
 
     def __setitem__(self, index, value):
-        raise InterpreterException('Cannot set a member of a CustomTarget')
+        raise InterpreterException('Cannot set a member of a CustomTarget')  # lgtm[py/unexpected-raise-in-special-method]
 
     def __delitem__(self, index):
-        raise InterpreterException('Cannot delete a member of a CustomTarget')
+        raise InterpreterException('Cannot delete a member of a CustomTarget')  # lgtm[py/unexpected-raise-in-special-method]
 
     def outdir_include(self):
         return IncludeDirsHolder(build.IncludeDirs('', [], False,

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -137,7 +137,7 @@ class IntelVisualStudioLinker(VisualStudioLikeLinker, StaticLinker):
 class ArLinker(StaticLinker):
 
     def __init__(self, exelist: typing.List[str]):
-        super().__init__(exelist)
+        StaticLinker.__init__(self, exelist)
         self.id = 'ar'
         pc, stdo = mesonlib.Popen_safe(self.exelist + ['-h'])[0:2]
         # Enable deterministic builds if they are available.
@@ -153,7 +153,7 @@ class ArLinker(StaticLinker):
         return [target]
 
 
-class ArmarLinker(ArLinker):
+class ArmarLinker(ArLinker):  # lgtm [py/missing-call-to-init]
 
     def __init__(self, exelist: typing.List[str]):
         StaticLinker.__init__(self, exelist)
@@ -167,7 +167,7 @@ class ArmarLinker(ArLinker):
 
 class DLinker(StaticLinker):
     def __init__(self, exelist: typing.List[str], arch: str):
-        super().__init__(exelist)
+        StaticLinker.__init__(self, exelist)
         self.id = exelist[0]
         self.arch = arch
 
@@ -190,7 +190,7 @@ class DLinker(StaticLinker):
 class CcrxLinker(StaticLinker):
 
     def __init__(self, exelist: typing.List[str]):
-        super().__init__(exelist)
+        StaticLinker.__init__(self, exelist)
         self.id = 'rlink'
 
     def can_linker_accept_rsp(self) -> bool:
@@ -682,8 +682,8 @@ class CcrxDynamicLinker(DynamicLinker):
 
     def __init__(self, for_machine: mesonlib.MachineChoice,
                  *, version: str = 'unknown version'):
-        super().__init__(['rlink.exe'], for_machine, 'rlink', '',
-                         version=version)
+        DynamicLinker.__init__(self, ['rlink.exe'], for_machine, 'rlink', '',
+                               version=version)
 
     def get_accepts_rsp(self) -> bool:
         return False
@@ -715,8 +715,8 @@ class ArmDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
     def __init__(self, for_machine: mesonlib.MachineChoice,
                  *, version: str = 'unknown version'):
-        super().__init__(['armlink'], for_machine, 'armlink', '',
-                         version=version)
+        DynamicLinker.__init__(self, ['armlink'], for_machine, 'armlink', '',
+                               version=version)
 
     def get_accepts_rsp(self) -> bool:
         return False
@@ -773,7 +773,7 @@ class PGIDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
 class PGIStaticLinker(StaticLinker):
     def __init__(self, exelist: typing.List[str]):
-        super().__init__(exelist)
+        StaticLinker.__init__(self, exelist)
         self.id = 'ar'
         self.std_args = ['-r']
 
@@ -796,8 +796,7 @@ class VisualStudioLikeLinkerMixin:
         'custom': [],
     }  # type: typing.Dict[str, typing.List[str]]
 
-    def __init__(self, *args, direct: bool = True, machine: str = 'x86', **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, direct: bool = True, machine: str = 'x86'):
         self.direct = direct
         self.machine = machine
 
@@ -857,8 +856,9 @@ class MSVCDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
                  exelist: typing.Optional[typing.List[str]] = None,
                  prefix: typing.Union[str, typing.List[str]] = '',
                  machine: str = 'x86', version: str = 'unknown version'):
-        super().__init__(exelist or ['link.exe'], for_machine, 'link',
-                         prefix, machine=machine, version=version)
+        VisualStudioLikeLinkerMixin.__init__(self, machine=machine)
+        DynamicLinker.__init__(self, exelist or ['link.exe'], for_machine, 'link',
+                               prefix, version=version)
 
 
 class ClangClDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
@@ -869,8 +869,9 @@ class ClangClDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
                  exelist: typing.Optional[typing.List[str]] = None,
                  prefix: typing.Union[str, typing.List[str]] = '',
                  version: str = 'unknown version'):
-        super().__init__(exelist or ['lld-link.exe'], for_machine,
-                         'lld-link', prefix, version=version)
+        VisualStudioLikeLinkerMixin.__init__(self)
+        DynamicLinker.__init__(self, exelist or ['lld-link.exe'], for_machine,
+                               'lld-link', prefix, version=version)
 
 
 class XilinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
@@ -879,7 +880,8 @@ class XilinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
 
     def __init__(self, for_machine: mesonlib.MachineChoice,
                  *, version: str = 'unknown version'):
-        super().__init__(['xilink.exe'], for_machine, 'xilink', '', version=version)
+        VisualStudioLikeLinkerMixin.__init__(self)
+        DynamicLinker.__init__(self, ['xilink.exe'], for_machine, 'xilink', '', version=version)
 
 
 class SolarisDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
@@ -936,7 +938,8 @@ class OptlinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
                  *, version: str = 'unknown version'):
         # Use optlink instead of link so we don't interfer with other link.exe
         # implementations.
-        super().__init__(['optlink.exe'], for_machine, 'optlink', prefix_arg='', version=version)
+        VisualStudioLikeLinkerMixin.__init__(self)
+        DynamicLinker.__init__(self, ['optlink.exe'], for_machine, 'optlink', prefix_arg='', version=version)
 
     def get_allow_undefined_args(self) -> typing.List[str]:
         return []

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -503,7 +503,6 @@ def run(opts):
     log_dir = os.path.join(private_dir, '../meson-logs')
     if not os.path.exists(os.path.join(opts.wd, datafilename)):
         sys.exit('Install data not found. Run this command in build directory root.')
-    log_dir = os.path.join(private_dir, '../meson-logs')
     if not opts.no_rebuild:
         if not rebuild_all(opts.wd):
             sys.exit(-1)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -405,7 +405,6 @@ def run(options):
               'meson version. Please regenerate it in this case.')
         return 1
 
-    intro_vers = '0.0.0'
     with open(infofile, 'r') as fp:
         raw = json.load(fp)
         intro_vers = raw.get('introspection', {}).get('version', {}).get('full', '0.0.0')

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -18,8 +18,7 @@ import sys
 import time
 import platform
 from contextlib import contextmanager
-import typing
-from typing import Any, Generator, List, Optional, Sequence, TextIO, Union
+from typing import Any, Generator, List, Optional, Sequence, TextIO, Union, cast
 from pathlib import Path
 
 """This is (mostly) a standalone module used to write logging
@@ -232,7 +231,7 @@ def _log_error(severity: str, *rargs: Union[str, AnsiDecorator], **kwargs: Any) 
         location_str = get_error_location_string(location_file, location.lineno)
         # Unions are frankly awful, and we have to cast here to get mypy
         # to understand that the list concatenation is safe
-        location_list = typing.cast(List[Union[str, AnsiDecorator]], [location_str])
+        location_list = cast(List[Union[str, AnsiDecorator]], [location_str])
         args = location_list + args
 
     log(*args, **kwargs)

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -674,7 +674,6 @@ class Parser:
         a = ArgumentNode(s)
 
         while not isinstance(s, EmptyNode):
-            potential = self.current
             if self.accept('colon'):
                 key_value = self.statement()
                 if isinstance(s, StringNode):

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -854,7 +854,7 @@ class Rewriter:
                 while raw[end] in [' ', '\n', '\t']:
                     end += 1
 
-            raw = files[i['file']]['raw'] = raw[:start] + i['str'] + raw[end:]
+            files[i['file']]['raw'] = raw[:start] + i['str'] + raw[end:]
 
         for i in str_list:
             if i['action'] in ['modify', 'rm']:

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -103,11 +103,11 @@ class RequiredKeys:
 class MTypeBase:
     def __init__(self, node: Optional[BaseNode] = None):
         if node is None:
-            self.node = self._new_node()
+            self.node = self._new_node()  # lgtm [py/init-calls-subclass] (node creation does not depend on base class state)
         else:
             self.node = node
         self.node_type = None
-        for i in self.supported_nodes():
+        for i in self.supported_nodes():  # lgtm [py/init-calls-subclass] (listing nodes does not depend on base class state)
             if isinstance(self.node, i):
                 self.node_type = i
 

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -16,6 +16,7 @@ from .. import mlog
 import contextlib
 import urllib.request
 import urllib.error
+import urllib.parse
 import os
 import hashlib
 import shutil
@@ -310,7 +311,8 @@ class Resolver:
         blocksize = 10 * 1024
         h = hashlib.sha256()
         tmpfile = tempfile.NamedTemporaryFile(mode='wb', dir=self.cachedir, delete=False)
-        if url.startswith('https://wrapdb.mesonbuild.com'):
+        hostname = urllib.parse.urlparse(url).hostname
+        if hostname.endswith('wrapdb.mesonbuild.com'):
             resp = open_wrapdburl(url)
         else:
             try:

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -312,7 +312,7 @@ class Resolver:
         h = hashlib.sha256()
         tmpfile = tempfile.NamedTemporaryFile(mode='wb', dir=self.cachedir, delete=False)
         hostname = urllib.parse.urlparse(url).hostname
-        if hostname.endswith('wrapdb.mesonbuild.com'):
+        if hostname == 'wrapdb.mesonbuild.com' or hostname.endswith('.wrapdb.mesonbuild.com'):
             resp = open_wrapdburl(url)
         else:
             try:

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -282,7 +282,6 @@ def _run_ci_include(args: typing.List[str]) -> str:
         return 'Included file {}:\n{}\n'.format(args[0], data)
     except Exception:
         return 'Failed to open {} ({})'.format(args[0])
-    return 'Appended {} to the log'.format(args[0])
 
 ci_commands = {
     'ci_include': _run_ci_include

--- a/run_tests.py
+++ b/run_tests.py
@@ -26,7 +26,8 @@ from io import StringIO
 from enum import Enum
 from glob import glob
 from pathlib import Path
-import mesonbuild
+from mesonbuild import compilers
+from mesonbuild import dependencies
 from mesonbuild import mesonlib
 from mesonbuild import mesonmain
 from mesonbuild import mtest
@@ -95,7 +96,6 @@ class FakeCompilerOptions:
         self.value = []
 
 def get_fake_options(prefix=''):
-    import argparse
     opts = argparse.Namespace()
     opts.native_file = []
     opts.cross_file = None
@@ -135,7 +135,7 @@ def get_meson_script():
     running in-process (which is the default).
     '''
     # Is there a meson.py next to the mesonbuild currently in use?
-    mesonbuild_dir = Path(mesonbuild.__file__).resolve().parent.parent
+    mesonbuild_dir = Path(mesonmain.__file__).resolve().parent.parent
     meson_script = mesonbuild_dir / 'meson.py'
     if meson_script.is_file():
         return str(meson_script)
@@ -263,12 +263,12 @@ def run_mtest_inprocess(commandlist):
     return returncode, mystdout.getvalue(), mystderr.getvalue()
 
 def clear_meson_configure_class_caches():
-    mesonbuild.compilers.CCompiler.library_dirs_cache = {}
-    mesonbuild.compilers.CCompiler.program_dirs_cache = {}
-    mesonbuild.compilers.CCompiler.find_library_cache = {}
-    mesonbuild.compilers.CCompiler.find_framework_cache = {}
-    mesonbuild.dependencies.PkgConfigDependency.pkgbin_cache = {}
-    mesonbuild.dependencies.PkgConfigDependency.class_pkgbin = mesonlib.PerMachine(None, None)
+    compilers.CCompiler.library_dirs_cache = {}
+    compilers.CCompiler.program_dirs_cache = {}
+    compilers.CCompiler.find_library_cache = {}
+    compilers.CCompiler.find_framework_cache = {}
+    dependencies.PkgConfigDependency.pkgbin_cache = {}
+    dependencies.PkgConfigDependency.class_pkgbin = mesonlib.PerMachine(None, None)
 
 def run_configure_inprocess(commandlist, env=None):
     old_stdout = sys.stdout


### PR DESCRIPTION
As the title says, this should fix most warning categories in the LGTM code analysis. There are, however, some categories that are not as easy to eliminate.

Specifically getting rid of the [Conflicting attributes in base classes](https://lgtm.com/projects/g/mesonbuild/meson/alerts/?mode=tree&severity=warning&ruleFocus=7860084) warnings will take a lot more refactoring work (if this is even desired or we document that the inheritance oder of the classes is important and must not be changed).

@jpakkane Could we also enable the [Automated code review](https://lgtm.com/projects/g/mesonbuild/meson/ci/)? This would hopefully eliminate the need for another PR of this kind :)