### PR TITLE
LGTM fixes, round 2

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -355,6 +355,18 @@ a hard error in the future.''' % name)
         if not hasattr(self, 'typename'):
             raise RuntimeError('Target type is not set for target class "{}". This is a bug'.format(type(self).__name__))
 
+    def __lt__(self, other: object) -> bool:
+        return self.get_id() < other.get_id()
+
+    def __le__(self, other: object) -> bool:
+        return self.get_id() <= other.get_id()
+
+    def __gt__(self, other: object) -> bool:
+        return self.get_id() > other.get_id()
+
+    def __ge__(self, other: object) -> bool:
+        return self.get_id() >= other.get_id()
+
     def get_install_dir(self, environment):
         # Find the installation directory.
         default_install_dir = self.get_default_install_dir(environment)
@@ -487,9 +499,6 @@ class BuildTarget(Target):
         self.validate_sources()
         self.validate_install(environment)
         self.check_module_linking()
-
-    def __lt__(self, other):
-        return self.get_id() < other.get_id()
 
     def __repr__(self):
         repr_str = "<{0} {1}: {2}>"
@@ -2005,9 +2014,6 @@ class CustomTarget(Target):
     def get_default_install_dir(self, environment):
         return None
 
-    def __lt__(self, other):
-        return self.get_id() < other.get_id()
-
     def __repr__(self):
         repr_str = "<{0} {1}: {2}>"
         return repr_str.format(self.__class__.__name__, self.get_id(), self.command)
@@ -2244,9 +2250,6 @@ class RunTarget(Target):
         self.command = command
         self.args = args
         self.dependencies = dependencies
-
-    def __lt__(self, other):
-        return self.get_id() < other.get_id()
 
     def __repr__(self):
         repr_str = "<{0} {1}: {2}>"

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -645,14 +645,14 @@ class CompilerArgs(list):
         new += self
         return new
 
-    def __mul__(self, args):
-        raise TypeError("can't multiply compiler arguments")  # lgtm[py/unexpected-raise-in-special-method]
+    def __mul__(self, args):  # lgtm[py/unexpected-raise-in-special-method]
+        raise TypeError("can't multiply compiler arguments")
 
-    def __imul__(self, args):
-        raise TypeError("can't multiply compiler arguments")  # lgtm[py/unexpected-raise-in-special-method]
+    def __imul__(self, args):  # lgtm[py/unexpected-raise-in-special-method]
+        raise TypeError("can't multiply compiler arguments")
 
-    def __rmul__(self, args):
-        raise TypeError("can't multiply compiler arguments")  # lgtm[py/unexpected-raise-in-special-method]
+    def __rmul__(self, args):  # lgtm[py/unexpected-raise-in-special-method]
+        raise TypeError("can't multiply compiler arguments")
 
     def append(self, arg):
         self.__iadd__([arg])

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -645,6 +645,16 @@ class CompilerArgs(list):
         new += self
         return new
 
+    def __eq__(self, other: object) -> bool:
+        '''
+        Only checks for equalety of self.compilers if the attribute is present.
+        Use the default list equalety for the compiler args.
+        '''
+        comp_eq = True
+        if hasattr(other, 'compiler'):
+            comp_eq = self.compiler == other.compiler
+        return comp_eq and super().__eq__(other)
+
     def __mul__(self, args):  # lgtm[py/unexpected-raise-in-special-method]
         raise TypeError("can't multiply compiler arguments")
 

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -19,18 +19,18 @@ import typing
 import subprocess
 import re
 
-from .gnu import GnuCompiler
+from .gnu import GnuLikeCompiler
 from ...mesonlib import Popen_safe
 
 if typing.TYPE_CHECKING:
     from ...environment import Environment
 
 
-class ElbrusCompiler(GnuCompiler):
+class ElbrusCompiler(GnuLikeCompiler):
     # Elbrus compiler is nearly like GCC, but does not support
     # PCH, LTO, sanitizers and color output as of version 1.21.x.
     def __init__(self, defines: typing.Dict[str, str]):
-        GnuCompiler.__init__(self, defines)
+        super().__init__()
         self.id = 'lcc'
         self.base_options = ['b_pgo', 'b_coverage',
                              'b_ndebug', 'b_staticpic',

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -273,7 +273,10 @@ class InternalDependency(Dependency):
 
 class HasNativeKwarg:
     def __init__(self, kwargs):
-        self.for_machine = MachineChoice.BUILD if kwargs.get('native', False) else MachineChoice.HOST
+        self.for_machine = self.get_for_machine_from_kwargs(kwargs)
+
+    def get_for_machine_from_kwargs(self, kwargs):
+        return MachineChoice.BUILD if kwargs.get('native', False) else MachineChoice.HOST
 
 class ExternalDependency(Dependency, HasNativeKwarg):
     def __init__(self, type_name, environment, language, kwargs):

--- a/mesonbuild/dependencies/cuda.py
+++ b/mesonbuild/dependencies/cuda.py
@@ -20,7 +20,7 @@ from .. import mlog
 from .. import mesonlib
 from ..environment import detect_cpu_family
 
-from .base import (DependencyException, ExternalDependency, HasNativeKwarg)
+from .base import (DependencyException, ExternalDependency)
 
 
 class CudaDependency(ExternalDependency):
@@ -28,8 +28,7 @@ class CudaDependency(ExternalDependency):
     supported_languages = ['cuda', 'cpp', 'c'] # see also _default_language
 
     def __init__(self, environment, kwargs):
-        HasNativeKwarg.__init__(self, kwargs) # initialize self.for_machine
-        compilers = environment.coredata.compilers[self.for_machine]
+        compilers = environment.coredata.compilers[self.get_for_machine_from_kwargs(kwargs)]
         language = self._detect_language(compilers)
         if language not in self.supported_languages:
             raise DependencyException('Language \'{}\' is not supported by the CUDA Toolkit. Supported languages are {}.'.format(language, self.supported_languages))

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -25,7 +25,7 @@ from ..mesonlib import version_compare, stringlistify, extract_as_list, MachineC
 from ..environment import get_llvm_tool_names
 from .base import (
     DependencyException, DependencyMethods, ExternalDependency, PkgConfigDependency,
-    strip_system_libdirs, ConfigToolDependency, CMakeDependency, HasNativeKwarg
+    strip_system_libdirs, ConfigToolDependency, CMakeDependency
 )
 from .misc import ThreadDependency
 
@@ -205,17 +205,13 @@ class LLVMDependencyConfigTool(ConfigToolDependency):
     __cpp_blacklist = {'-DNDEBUG'}
 
     def __init__(self, environment, kwargs):
-        # Already called by `super().__init__`, but need `self.for_machine`
-        # before `super().__init__` is called.
-        HasNativeKwarg.__init__(self, kwargs)
-
         self.tools = get_llvm_tool_names('llvm-config')
 
         # Fedora starting with Fedora 30 adds a suffix of the number
         # of bits in the isa that llvm targets, for example, on x86_64
         # and aarch64 the name will be llvm-config-64, on x86 and arm
         # it will be llvm-config-32.
-        if environment.machines[self.for_machine].is_64_bit:
+        if environment.machines[self.get_for_machine_from_kwargs(kwargs)].is_64_bit:
             self.tools.append('llvm-config-64')
         else:
             self.tools.append('llvm-config-32')

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -882,11 +882,11 @@ class CustomTargetHolder(TargetHolder):
     def __getitem__(self, index):
         return CustomTargetIndexHolder(self.held_object[index])
 
-    def __setitem__(self, index, value):
-        raise InterpreterException('Cannot set a member of a CustomTarget')  # lgtm[py/unexpected-raise-in-special-method]
+    def __setitem__(self, index, value):  # lgtm[py/unexpected-raise-in-special-method]
+        raise InterpreterException('Cannot set a member of a CustomTarget')
 
-    def __delitem__(self, index):
-        raise InterpreterException('Cannot delete a member of a CustomTarget')  # lgtm[py/unexpected-raise-in-special-method]
+    def __delitem__(self, index):  # lgtm[py/unexpected-raise-in-special-method]
+        raise InterpreterException('Cannot delete a member of a CustomTarget')
 
     def outdir_include(self):
         return IncludeDirsHolder(build.IncludeDirs('', [], False,

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -1416,8 +1416,14 @@ class LibType(Enum):
     PREFER_STATIC = 3
 
 
-class ProgressBarFallback:
-    '''Fallback progress bar implementation when tqdm is not found'''
+class ProgressBarFallback:  # lgtm [py/iter-returns-non-self]
+    '''
+    Fallback progress bar implementation when tqdm is not found
+
+    Since this class is not an actual iterator, but only provides a minimal
+    fallback, it is safe to ignore the 'Iterator does not return self from
+    __iter__ method' warning.
+    '''
     def __init__(self, iterable=None, total=None, bar_type=None, desc=None):
         if iterable is not None:
             self.iterable = iter(iterable)

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -34,7 +34,9 @@ if typing.TYPE_CHECKING:
     import http.client
 
 try:
-    import ssl
+    # Importing is just done to check if SSL exists, so all warnings
+    # regarding 'imported but unused' can be safely ignored
+    import ssl  # noqa
     has_ssl = True
     API_ROOT = 'https://wrapdb.mesonbuild.com/v1/'
 except ImportError:
@@ -43,14 +45,6 @@ except ImportError:
 
 req_timeout = 600.0
 ssl_warning_printed = False
-
-def build_ssl_context() -> 'ssl.SSLContext':
-    ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-    ctx.options |= ssl.OP_NO_SSLv2
-    ctx.options |= ssl.OP_NO_SSLv3
-    ctx.verify_mode = ssl.CERT_REQUIRED
-    ctx.load_default_certs()
-    return ctx
 
 def quiet_git(cmd: typing.List[str], workingdir: str) -> typing.Tuple[bool, str]:
     try:
@@ -66,7 +60,7 @@ def open_wrapdburl(urlstring: str) -> 'http.client.HTTPResponse':
     global ssl_warning_printed
     if has_ssl:
         try:
-            return urllib.request.urlopen(urlstring, timeout=req_timeout)# , context=build_ssl_context())
+            return urllib.request.urlopen(urlstring, timeout=req_timeout)  # , context=ssl.create_default_context())
         except urllib.error.URLError:
             if not ssl_warning_printed:
                 print('SSL connection failed. Falling back to unencrypted connections.', file=sys.stderr)

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,3 +34,6 @@ python_requires = >= 3.5.2
 [options.extras_require]
 progress =
   tqdm
+
+[tool:pytest]
+python_classes =


### PR DESCRIPTION
This should eliminate all but 3 warning categories in LGTM (`Similar function`, `Conflicting attributes in base classes` and `__init__ method calls overridden method`).

As a bonus, the last commit fixes the pytest warning by ensuring that only classes derived from `unittest.TestCase` are considered test classes.