### PR TITLE
Update Python2 syntax to Python3 syntax in Compilers

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -410,7 +410,7 @@ class CcrxCCompiler(CcrxCompiler, CCompiler):
         return ['-optimize=0']
 
     def get_output_args(self, target):
-        return ['-output=obj=%s' % target]
+        return ['-output=obj={}'.format(target)]
 
     def get_werror_args(self):
         return ['-change_message=error']

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -605,7 +605,7 @@ class CcrxCPPCompiler(CcrxCompiler, CPPCompiler):
         return []
 
     def get_output_args(self, target):
-        return ['-output=obj=%s' % target]
+        return ['-output=obj={}'.format(target)]
 
     def get_option_link_args(self, options):
         return []

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -114,7 +114,7 @@ class CsCompiler(BasicLinkerIsCompilerMixin, Compiler):
         pc = subprocess.Popen(self.exelist + self.get_always_args() + [src], cwd=work_dir)
         pc.wait()
         if pc.returncode != 0:
-            raise EnvironmentException('Mono compiler %s can not compile programs.' % self.name_string())
+            raise EnvironmentException('Mono compiler {} can not compile programs.'.format(self.name_string()))
         if self.runner:
             cmdlist = [self.runner, obj]
         else:
@@ -122,7 +122,7 @@ class CsCompiler(BasicLinkerIsCompilerMixin, Compiler):
         pe = subprocess.Popen(cmdlist, cwd=work_dir)
         pe.wait()
         if pe.returncode != 0:
-            raise EnvironmentException('Executables created by Mono compiler %s are not runnable.' % self.name_string())
+            raise EnvironmentException('Executables created by Mono compiler {} are not runnable.'.format(self.name_string()))
 
     def needs_static_linker(self):
         return False

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -73,7 +73,7 @@ class CudaCompiler(Compiler):
 
     def sanity_check(self, work_dir, environment):
         mlog.debug('Sanity testing ' + self.get_display_language() + ' compiler:', ' '.join(self.exelist))
-        mlog.debug('Is cross compiler: %s.' % str(self.is_cross))
+        mlog.debug('Is cross compiler: {}.'.format(str(self.is_cross)))
 
         sname = 'sanitycheckcuda.cu'
         code = r'''

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -129,7 +129,7 @@ class DmdLikeCompilerMixin:
             unittest = kwargs.pop('unittest')
             unittest_arg = d_feature_args[self.id]['unittest']
             if not unittest_arg:
-                raise EnvironmentException('D compiler %s does not support the "unittest" feature.' % self.name_string())
+                raise EnvironmentException('D compiler {} does not support the "unittest" feature.'.format(self.name_string()))
             if unittest:
                 res.append(unittest_arg)
 
@@ -141,7 +141,7 @@ class DmdLikeCompilerMixin:
 
             debug_arg = d_feature_args[self.id]['debug']
             if not debug_arg:
-                raise EnvironmentException('D compiler %s does not support conditional debug identifiers.' % self.name_string())
+                raise EnvironmentException('D compiler {} does not support conditional debug identifiers.'.format(self.name_string()))
 
             # Parse all debug identifiers and the largest debug level identifier
             for d in debugs:
@@ -165,7 +165,7 @@ class DmdLikeCompilerMixin:
 
             version_arg = d_feature_args[self.id]['version']
             if not version_arg:
-                raise EnvironmentException('D compiler %s does not support conditional version identifiers.' % self.name_string())
+                raise EnvironmentException('D compiler {} does not support conditional version identifiers.'.format(self.name_string()))
 
             # Parse all version identifiers and the largest version level identifier
             for v in versions:
@@ -188,7 +188,7 @@ class DmdLikeCompilerMixin:
 
             import_dir_arg = d_feature_args[self.id]['import_dir']
             if not import_dir_arg:
-                raise EnvironmentException('D compiler %s does not support the "string import directories" feature.' % self.name_string())
+                raise EnvironmentException('D compiler {} does not support the "string import directories" feature.'.format(self.name_string()))
             for idir_obj in import_dirs:
                 basedir = idir_obj.get_curdir()
                 for idir in idir_obj.get_incdirs():
@@ -201,7 +201,7 @@ class DmdLikeCompilerMixin:
                     res.append('{0}{1}'.format(import_dir_arg, srctreedir))
 
         if kwargs:
-            raise EnvironmentException('Unknown D compiler feature(s) selected: %s' % ', '.join(kwargs.keys()))
+            raise EnvironmentException('Unknown D compiler feature(s) selected: {}'.format(', '.join(kwargs.keys())))
 
         return res
 
@@ -429,7 +429,7 @@ class DCompiler(Compiler):
         pc = subprocess.Popen(self.exelist + self.get_output_args(output_name) + self.get_target_arch_args() + [source_name], cwd=work_dir)
         pc.wait()
         if pc.returncode != 0:
-            raise EnvironmentException('D compiler %s can not compile programs.' % self.name_string())
+            raise EnvironmentException('D compiler {} can not compile programs.'.format(self.name_string()))
         if self.is_cross:
             if self.exe_wrapper is None:
                 # Can't check if the binaries run so we have to assume they do
@@ -438,7 +438,7 @@ class DCompiler(Compiler):
         else:
             cmdlist = [output_name]
         if subprocess.call(cmdlist) != 0:
-            raise EnvironmentException('Executables created by D compiler %s are not runnable.' % self.name_string())
+            raise EnvironmentException('Executables created by D compiler {} are not runnable.'.format(self.name_string()))
 
     def needs_static_linker(self):
         return True
@@ -460,7 +460,7 @@ class DCompiler(Compiler):
             unittest = kwargs.pop('unittest')
             unittest_arg = d_feature_args[self.id]['unittest']
             if not unittest_arg:
-                raise EnvironmentException('D compiler %s does not support the "unittest" feature.' % self.name_string())
+                raise EnvironmentException('D compiler {} does not support the "unittest" feature.'.format(self.name_string()))
             if unittest:
                 res.append(unittest_arg)
 
@@ -472,7 +472,7 @@ class DCompiler(Compiler):
 
             debug_arg = d_feature_args[self.id]['debug']
             if not debug_arg:
-                raise EnvironmentException('D compiler %s does not support conditional debug identifiers.' % self.name_string())
+                raise EnvironmentException('D compiler {} does not support conditional debug identifiers.'.format(self.name_string()))
 
             # Parse all debug identifiers and the largest debug level identifier
             for d in debugs:
@@ -496,7 +496,7 @@ class DCompiler(Compiler):
 
             version_arg = d_feature_args[self.id]['version']
             if not version_arg:
-                raise EnvironmentException('D compiler %s does not support conditional version identifiers.' % self.name_string())
+                raise EnvironmentException('D compiler {} does not support conditional version identifiers.'.format(self.name_string()))
 
             # Parse all version identifiers and the largest version level identifier
             for v in versions:
@@ -519,7 +519,7 @@ class DCompiler(Compiler):
 
             import_dir_arg = d_feature_args[self.id]['import_dir']
             if not import_dir_arg:
-                raise EnvironmentException('D compiler %s does not support the "string import directories" feature.' % self.name_string())
+                raise EnvironmentException('D compiler {} does not support the "string import directories" feature.'.format(self.name_string()))
             for idir_obj in import_dirs:
                 basedir = idir_obj.get_curdir()
                 for idir in idir_obj.get_incdirs():
@@ -532,7 +532,7 @@ class DCompiler(Compiler):
                     res.append('{0}{1}'.format(import_dir_arg, srctreedir))
 
         if kwargs:
-            raise EnvironmentException('Unknown D compiler feature(s) selected: %s' % ', '.join(kwargs.keys()))
+            raise EnvironmentException('Unknown D compiler feature(s) selected: {}'.format(', '.join(kwargs.keys())))
 
         return res
 

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -82,7 +82,7 @@ class FortranCompiler(CLikeCompiler, Compiler):
         returncode = subprocess.run(self.exelist + extra_flags + [str(source_name), '-o', str(binary_name)],
                                     cwd=str(work_dir)).returncode
         if returncode != 0:
-            raise EnvironmentException('Compiler %s can not compile programs.' % self.name_string())
+            raise EnvironmentException('Compiler {} can not compile programs.'.format(self.name_string()))
         if self.is_cross:
             if self.exe_wrapper is None:
                 # Can't check if the binaries run so we have to assume they do
@@ -94,9 +94,9 @@ class FortranCompiler(CLikeCompiler, Compiler):
         try:
             returncode = subprocess.run(cmdlist, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode
             if returncode != 0:
-                raise EnvironmentException('Executables created by Fortran compiler %s are not runnable.' % self.name_string())
+                raise EnvironmentException('Executables created by Fortran compiler {} are not runnable.'.format(self.name_string()))
         except OSError:
-            raise EnvironmentException('Executables created by Fortran compiler %s are not runnable.' % self.name_string())
+            raise EnvironmentException('Executables created by Fortran compiler {} are not runnable.'.format(self.name_string()))
 
     def get_std_warn_args(self, level):
         return FortranCompiler.std_warn_args

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -97,14 +97,14 @@ class JavaCompiler(BasicLinkerIsCompilerMixin, Compiler):
         pc = subprocess.Popen(self.exelist + [src], cwd=work_dir)
         pc.wait()
         if pc.returncode != 0:
-            raise EnvironmentException('Java compiler %s can not compile programs.' % self.name_string())
+            raise EnvironmentException('Java compiler {} can not compile programs.'.format(self.name_string()))
         runner = shutil.which(self.javarunner)
         if runner:
             cmdlist = [runner, obj]
             pe = subprocess.Popen(cmdlist, cwd=work_dir)
             pe.wait()
             if pe.returncode != 0:
-                raise EnvironmentException('Executables created by Java compiler %s are not runnable.' % self.name_string())
+                raise EnvironmentException('Executables created by Java compiler {} are not runnable.'.format(self.name_string()))
         else:
             m = "Java Virtual Machine wasn't found, but it's needed by Meson. " \
                 "Please install a JRE.\nIf you have specific needs where this " \

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -204,7 +204,7 @@ class CLikeCompiler:
 
     def sanity_check_impl(self, work_dir, environment, sname, code):
         mlog.debug('Sanity testing ' + self.get_display_language() + ' compiler:', ' '.join(self.exelist))
-        mlog.debug('Is cross compiler: %s.' % str(self.is_cross))
+        mlog.debug('Is cross compiler: {}.'.format(str(self.is_cross)))
 
         source_name = os.path.join(work_dir, sname)
         binname = sname.rsplit('.', 1)[0]
@@ -252,7 +252,7 @@ class CLikeCompiler:
         try:
             pe = subprocess.Popen(cmdlist)
         except Exception as e:
-            raise mesonlib.EnvironmentException('Could not invoke sanity test executable: %s.' % str(e))
+            raise mesonlib.EnvironmentException('Could not invoke sanity test executable: {}.'.format(str(e)))
         pe.wait()
         if pe.returncode != 0:
             raise mesonlib.EnvironmentException('Executables created by {0} compiler {1} are not runnable.'.format(self.language, self.name_string()))
@@ -374,7 +374,7 @@ class CLikeCompiler:
             raise compilers.CrossNoRunException('Can not run test applications in this cross environment.')
         with self._build_wrapper(code, env, extra_args, dependencies, mode='link', want_output=True) as p:
             if p.returncode != 0:
-                mlog.debug('Could not compile test file %s: %d\n' % (
+                mlog.debug('Could not compile test file {}: {}\n'.format(
                     p.input_name,
                     p.returncode))
                 return compilers.RunResult(False)
@@ -385,7 +385,7 @@ class CLikeCompiler:
             try:
                 pe, so, se = mesonlib.Popen_safe(cmdlist)
             except Exception as e:
-                mlog.debug('Could not run: %s (error: %s)\n' % (cmdlist, e))
+                mlog.debug('Could not run: {} (error: {})\n'.format(cmdlist, e))
                 return compilers.RunResult(False)
 
         mlog.debug('Program stdout:\n')
@@ -405,16 +405,16 @@ class CLikeCompiler:
     def cross_compute_int(self, expression, low, high, guess, prefix, env, extra_args, dependencies):
         # Try user's guess first
         if isinstance(guess, int):
-            if self._compile_int('%s == %d' % (expression, guess), prefix, env, extra_args, dependencies):
+            if self._compile_int('{} == {}'.format(expression, guess), prefix, env, extra_args, dependencies):
                 return guess
 
         # If no bounds are given, compute them in the limit of int32
         maxint = 0x7fffffff
         minint = -0x80000000
         if not isinstance(low, int) or not isinstance(high, int):
-            if self._compile_int('%s >= 0' % (expression), prefix, env, extra_args, dependencies):
+            if self._compile_int('{} >= 0'.format(expression), prefix, env, extra_args, dependencies):
                 low = cur = 0
-                while self._compile_int('%s > %d' % (expression, cur), prefix, env, extra_args, dependencies):
+                while self._compile_int('{} > {}'.format(expression, cur), prefix, env, extra_args, dependencies):
                     low = cur + 1
                     if low > maxint:
                         raise mesonlib.EnvironmentException('Cross-compile check overflowed')
@@ -424,7 +424,7 @@ class CLikeCompiler:
                 high = cur
             else:
                 high = cur = -1
-                while self._compile_int('%s < %d' % (expression, cur), prefix, env, extra_args, dependencies):
+                while self._compile_int('{} < {}'.format(expression, cur), prefix, env, extra_args, dependencies):
                     high = cur - 1
                     if high < minint:
                         raise mesonlib.EnvironmentException('Cross-compile check overflowed')
@@ -436,14 +436,14 @@ class CLikeCompiler:
             # Sanity check limits given by user
             if high < low:
                 raise mesonlib.EnvironmentException('high limit smaller than low limit')
-            condition = '%s <= %d && %s >= %d' % (expression, high, expression, low)
+            condition = '{} <= {} && {} >= {}'.format(expression, high, expression, low)
             if not self._compile_int(condition, prefix, env, extra_args, dependencies):
                 raise mesonlib.EnvironmentException('Value out of given range')
 
         # Binary search
         while low != high:
             cur = low + int((high - low) / 2)
-            if self._compile_int('%s <= %d' % (expression, cur), prefix, env, extra_args, dependencies):
+            if self._compile_int('{} <= {}'.format(expression, cur), prefix, env, extra_args, dependencies):
                 high = cur
             else:
                 low = cur + 1
@@ -483,7 +483,7 @@ class CLikeCompiler:
         if not self.compiles(t.format(**fargs), env, extra_args=extra_args,
                              dependencies=dependencies)[0]:
             return -1
-        return self.cross_compute_int('sizeof(%s)' % typename, None, None, None, prefix, env, extra_args, dependencies)
+        return self.cross_compute_int('sizeof({})'.format(typename), None, None, None, prefix, env, extra_args, dependencies)
 
     def sizeof(self, typename, prefix, env, *, extra_args=None, dependencies=None):
         if extra_args is None:
@@ -553,7 +553,7 @@ class CLikeCompiler:
             raise mesonlib.EnvironmentException('Could not run alignment test binary.')
         align = int(res.stdout)
         if align == 0:
-            raise mesonlib.EnvironmentException('Could not determine alignment of %s. Sorry. You might want to file a bug.' % typename)
+            raise mesonlib.EnvironmentException('Could not determine alignment of {}. Sorry. You might want to file a bug.'.format(typename))
         return align
 
     def get_define(self, dname, prefix, env, extra_args, dependencies, disable_cache=False):

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -52,14 +52,14 @@ class ObjCCompiler(CLikeCompiler, Compiler):
         pc = subprocess.Popen(self.exelist + extra_flags + [source_name, '-o', binary_name])
         pc.wait()
         if pc.returncode != 0:
-            raise EnvironmentException('ObjC compiler %s can not compile programs.' % self.name_string())
+            raise EnvironmentException('ObjC compiler {} can not compile programs.'.format(self.name_string()))
         if self.is_cross:
             # Can't check if the binaries run so we have to assume they do
             return
         pe = subprocess.Popen(binary_name)
         pe.wait()
         if pe.returncode != 0:
-            raise EnvironmentException('Executables created by ObjC compiler %s are not runnable.' % self.name_string())
+            raise EnvironmentException('Executables created by ObjC compiler {} are not runnable.'.format(self.name_string()))
 
 
 class GnuObjCCompiler(GnuCompiler, ObjCCompiler):

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -52,14 +52,14 @@ class ObjCPPCompiler(CLikeCompiler, Compiler):
         pc = subprocess.Popen(self.exelist + extra_flags + [source_name, '-o', binary_name])
         pc.wait()
         if pc.returncode != 0:
-            raise EnvironmentException('ObjC++ compiler %s can not compile programs.' % self.name_string())
+            raise EnvironmentException('ObjC++ compiler {} can not compile programs.'.format(self.name_string()))
         if self.is_cross:
             # Can't check if the binaries run so we have to assume they do
             return
         pe = subprocess.Popen(binary_name)
         pe.wait()
         if pe.returncode != 0:
-            raise EnvironmentException('Executables created by ObjC++ compiler %s are not runnable.' % self.name_string())
+            raise EnvironmentException('Executables created by ObjC++ compiler {} are not runnable.'.format(self.name_string()))
 
 
 class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -63,7 +63,7 @@ class RustCompiler(Compiler):
         stdo = stdo.decode('utf-8', errors='replace')
         stde = stde.decode('utf-8', errors='replace')
         if pc.returncode != 0:
-            raise EnvironmentException('Rust compiler %s can not compile programs.\n%s\n%s' % (
+            raise EnvironmentException('Rust compiler {} can not compile programs.\n{}\n{}'.format(
                 self.name_string(),
                 stdo,
                 stde))
@@ -77,7 +77,7 @@ class RustCompiler(Compiler):
         pe = subprocess.Popen(cmdlist, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         pe.wait()
         if pe.returncode != 0:
-            raise EnvironmentException('Executables created by Rust compiler %s are not runnable.' % self.name_string())
+            raise EnvironmentException('Executables created by Rust compiler {} are not runnable.'.format(self.name_string()))
 
     def get_dependency_gen_args(self, outfile):
         return ['--dep-info', outfile]

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -109,12 +109,12 @@ class SwiftCompiler(Compiler):
         pc = subprocess.Popen(self.exelist + extra_flags + ['-emit-executable', '-o', output_name, src], cwd=work_dir)
         pc.wait()
         if pc.returncode != 0:
-            raise EnvironmentException('Swift compiler %s can not compile programs.' % self.name_string())
+            raise EnvironmentException('Swift compiler {} can not compile programs.'.format(self.name_string()))
         if self.is_cross:
             # Can't check if the binaries run so we have to assume they do
             return
         if subprocess.call(output_name) != 0:
-            raise EnvironmentException('Executables created by Swift compiler %s are not runnable.' % self.name_string())
+            raise EnvironmentException('Executables created by Swift compiler {} are not runnable.'.format(self.name_string()))
 
     def get_debug_args(self, is_debug):
         return clike_debug_args[is_debug]

--- a/tools/ac_converter.py
+++ b/tools/ac_converter.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-help_message = """Usage: %s <config.h.meson>
+help_message = """Usage: {} <config.h.meson>
 
 This script reads config.h.meson, looks for header
 checks and writes the corresponding meson declaration.
@@ -368,7 +368,7 @@ functions = []
 sizes = []
 
 if len(sys.argv) != 2:
-    print(help_message % sys.argv[0])
+    print(help_message.format(sys.argv[0]))
     sys.exit(0)
 
 with open(sys.argv[1]) as f:
@@ -414,7 +414,7 @@ cdata = configuration_data()''')
 
 print('check_headers = [')
 for token, hname in headers:
-    print("  ['%s', '%s']," % (token, hname))
+    print("  ['{}', '{}'],".format(token, hname))
 print(']\n')
 
 print('''foreach h : check_headers
@@ -430,7 +430,7 @@ print('check_functions = [')
 for tok in functions:
     if len(tok) == 3:
         tokstr, fdata0, fdata1 = tok
-        print("  ['%s', '%s', '#include<%s>']," % (tokstr, fdata0, fdata1))
+        print("  ['{}', '{}', '#include<{}>'],".format(tokstr, fdata0, fdata1))
     else:
         print('# check token', tok)
 print(']\n')
@@ -445,7 +445,7 @@ endforeach
 # Convert sizeof checks.
 
 for elem, typename in sizes:
-    print("cdata.set('%s', cc.sizeof('%s'))" % (elem, typename))
+    print("cdata.set('{}', cc.sizeof('{}'))".format(elem, typename))
 
 print('''
 configure_file(input : 'config.h.meson',


### PR DESCRIPTION
Simply update Python2 syntax to Python3 syntax in Compilers, main benefit would be less `%s` symbols mixed in with `{}` and `.format` 