### PR TITLE
Update Python2 syntax to Python3 syntax in Wrap 

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -353,7 +353,7 @@ class Resolver:
             h.update(f.read())
         dhash = h.hexdigest()
         if dhash != expected:
-            raise WrapException('Incorrect hash for %s:\n %s expected\n %s actual.' % (what, expected, dhash))
+            raise WrapException('Incorrect hash for {}:\n {} expected\n {} actual.'.format(what, expected, dhash))
 
     def download(self, what: str, ofname: str) -> None:
         self.check_can_download()
@@ -363,7 +363,7 @@ class Resolver:
         expected = self.wrap.get(what + '_hash')
         if dhash != expected:
             os.remove(tmpfile)
-            raise WrapException('Incorrect hash for %s:\n %s expected\n %s actual.' % (what, expected, dhash))
+            raise WrapException('Incorrect hash for {}:\n {} expected\n {} actual.'.format(what, expected, dhash))
         os.rename(tmpfile, ofname)
 
     def get_file_internal(self, what: str) -> str:

--- a/mesonbuild/wrap/wraptool.py
+++ b/mesonbuild/wrap/wraptool.py
@@ -94,7 +94,7 @@ def install(options):
     if os.path.exists(wrapfile):
         raise SystemExit('Wrap file already exists.')
     (branch, revision) = get_latest_version(name)
-    u = open_wrapdburl(API_ROOT + 'projects/%s/%s/%s/get_wrap' % (name, branch, revision))
+    u = open_wrapdburl(API_ROOT + 'projects/{}/{}/{}/get_wrap'.format(name, branch, revision))
     data = u.read()
     with open(wrapfile, 'wb') as f:
         f.write(data)
@@ -113,7 +113,7 @@ def get_current_version(wrapfile):
     return branch, revision, cp['directory'], cp['source_filename'], cp['patch_filename']
 
 def update_wrap_file(wrapfile, name, new_branch, new_revision):
-    u = open_wrapdburl(API_ROOT + 'projects/%s/%s/%d/get_wrap' % (name, new_branch, new_revision))
+    u = open_wrapdburl(API_ROOT + 'projects/{}/{}/{}/get_wrap'.format(name, new_branch, new_revision))
     data = u.read()
     with open(wrapfile, 'wb') as f:
         f.write(data)
@@ -148,7 +148,7 @@ def info(options):
     versions = jd['versions']
     if not versions:
         raise SystemExit('No available versions of' + name)
-    print('Available versions of %s:' % name)
+    print('Available versions of {}:'.format(name))
     for v in versions:
         print(' ', v['branch'], v['revision'])
 
@@ -160,7 +160,7 @@ def do_promotion(from_path, spdir_name):
         sproj_name = os.path.basename(from_path)
         outputdir = os.path.join(spdir_name, sproj_name)
         if os.path.exists(outputdir):
-            raise SystemExit('Output dir %s already exists. Will not overwrite.' % outputdir)
+            raise SystemExit('Output dir {} already exists. Will not overwrite.'.format(outputdir))
         shutil.copytree(from_path, outputdir, ignore=shutil.ignore_patterns('subprojects'))
 
 def promote(options):
@@ -177,10 +177,10 @@ def promote(options):
 
     # otherwise the argument is just a subproject basename which must be unambiguous
     if argument not in sprojs:
-        raise SystemExit('Subproject %s not found in directory tree.' % argument)
+        raise SystemExit('Subproject {} not found in directory tree.'.format(argument))
     matches = sprojs[argument]
     if len(matches) > 1:
-        print('There is more than one version of %s in tree. Please specify which one to promote:\n' % argument, file=sys.stderr)
+        print('There is more than one version of {} in tree. Please specify which one to promote:\n'.format(argument, file=sys.stderr))
         for s in matches:
             print(s, file=sys.stderr)
         raise SystemExit(1)
@@ -201,9 +201,9 @@ def status(options):
             print('Wrap file not from wrapdb.', file=sys.stderr)
             continue
         if current_branch == latest_branch and current_revision == latest_revision:
-            print('', name, 'up to date. Branch %s, revision %d.' % (current_branch, current_revision))
+            print('', name, 'up to date. Branch {}, revision {}.'.format(current_branch, current_revision))
         else:
-            print('', name, 'not up to date. Have %s %d, but %s %d is available.' % (current_branch, current_revision, latest_branch, latest_revision))
+            print('', name, 'not up to date. Have {} {}, but {} {} is available.'.format(current_branch, current_revision, latest_branch, latest_revision))
 
 def run(options):
     options.wrap_func(options)

--- a/mesonbuild/wrap/wraptool.py
+++ b/mesonbuild/wrap/wraptool.py
@@ -180,7 +180,7 @@ def promote(options):
         raise SystemExit('Subproject {} not found in directory tree.'.format(argument))
     matches = sprojs[argument]
     if len(matches) > 1:
-        print('There is more than one version of {} in tree. Please specify which one to promote:\n'.format(argument, file=sys.stderr))
+        print('There is more than one version of {} in tree. Please specify which one to promote:\n'.format(argument), file=sys.stderr)
         for s in matches:
             print(s, file=sys.stderr)
         raise SystemExit(1)

--- a/tools/ac_converter.py
+++ b/tools/ac_converter.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-help_message = """Usage: %s <config.h.meson>
+help_message = """Usage: {} <config.h.meson>
 
 This script reads config.h.meson, looks for header
 checks and writes the corresponding meson declaration.
@@ -368,7 +368,7 @@ functions = []
 sizes = []
 
 if len(sys.argv) != 2:
-    print(help_message % sys.argv[0])
+    print(help_message.format(sys.argv[0]))
     sys.exit(0)
 
 with open(sys.argv[1]) as f:
@@ -414,7 +414,7 @@ cdata = configuration_data()''')
 
 print('check_headers = [')
 for token, hname in headers:
-    print("  ['%s', '%s']," % (token, hname))
+    print("  ['{}', '{}'],".format(token, hname))
 print(']\n')
 
 print('''foreach h : check_headers
@@ -430,7 +430,7 @@ print('check_functions = [')
 for tok in functions:
     if len(tok) == 3:
         tokstr, fdata0, fdata1 = tok
-        print("  ['%s', '%s', '#include<%s>']," % (tokstr, fdata0, fdata1))
+        print("  ['{}', '{}', '#include<{}>'],".format(tokstr, fdata0, fdata1))
     else:
         print('# check token', tok)
 print(']\n')
@@ -445,7 +445,7 @@ endforeach
 # Convert sizeof checks.
 
 for elem, typename in sizes:
-    print("cdata.set('%s', cc.sizeof('%s'))" % (elem, typename))
+    print("cdata.set('{}', cc.sizeof('{}'))".format(elem, typename))
 
 print('''
 configure_file(input : 'config.h.meson',


### PR DESCRIPTION
Simply update Python2 syntax to Python3 syntax in Wrap, main benefit would be less `%s` symbols mixed in with `{}` and `.format` 