### PR TITLE
Update Python2 syntax to Python3 syntax in genrelnotes.py

### DIFF
--- a/docs/genrelnotes.py
+++ b/docs/genrelnotes.py
@@ -13,7 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+'''
+  Generates release notes for new releases of Meson build system
+'''
 import subprocess
 import sys
 import os

--- a/docs/genrelnotes.py
+++ b/docs/genrelnotes.py
@@ -63,7 +63,7 @@ if __name__ == '__main__':
     if len(sys.argv) != 3:
         print(sys.argv[0], 'from_version to_version')
         sys.exit(1)
-    from_version = sys.argv[1]
-    to_version = sys.argv[2]
+    FROM_VERSION = sys.argv[1]
+    TO_VERSION = sys.argv[2]
     os.chdir('markdown')
-    generate(from_version, to_version)
+    generate(FROM_VERSION, TO_VERSION)

--- a/docs/genrelnotes.py
+++ b/docs/genrelnotes.py
@@ -17,7 +17,7 @@
 import sys, os, subprocess
 from glob import glob
 
-relnote_template = '''---
+RELNOTE_TEMPLATE = '''---
 title: Release {}
 short-description: Release notes for {}
 ...
@@ -28,10 +28,13 @@ short-description: Release notes for {}
 
 
 def add_to_sitemap(from_version, to_version):
+    '''
+       Adds release note entry to sitemap.txt.
+    '''
     sitemapfile = '../sitemap.txt'
-    sf = open(sitemapfile)
-    lines = sf.readlines()
-    sf.close()
+    s_f = open(sitemapfile)
+    lines = s_f.readlines()
+    s_f.close()
     with open(sitemapfile, 'w') as sf:
         for line in lines:
             if 'Release-notes' in line and from_version in line:
@@ -40,9 +43,12 @@ def add_to_sitemap(from_version, to_version):
             sf.write(line)
 
 def generate(from_version, to_version):
+    '''
+       Generate notes for Meson build next release.
+    '''
     ofilename = 'Release-notes-for-{}.md'.format(to_version)
     with open(ofilename, 'w') as ofile:
-        ofile.write(relnote_template.format(to_version, to_version))
+        ofile.write(RELNOTE_TEMPLATE.format(to_version, to_version))
         for snippetfile in glob('snippets/*.md'):
             snippet = open(snippetfile).read()
             ofile.write(snippet)

--- a/docs/genrelnotes.py
+++ b/docs/genrelnotes.py
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys, os, subprocess
+import subprocess
+import sys
+import os
 from glob import glob
 
 RELNOTE_TEMPLATE = '''---
@@ -35,12 +37,12 @@ def add_to_sitemap(from_version, to_version):
     s_f = open(sitemapfile)
     lines = s_f.readlines()
     s_f.close()
-    with open(sitemapfile, 'w') as sf:
+    with open(sitemapfile, 'w') as s_f:
         for line in lines:
             if 'Release-notes' in line and from_version in line:
                 new_line = line.replace(from_version, to_version)
-                sf.write(new_line)
-            sf.write(line)
+                s_f.write(new_line)
+            s_f.write(line)
 
 def generate(from_version, to_version):
     '''

--- a/docs/genrelnotes.py
+++ b/docs/genrelnotes.py
@@ -18,8 +18,8 @@ import sys, os, subprocess
 from glob import glob
 
 relnote_template = '''---
-title: Release %s
-short-description: Release notes for %s
+title: Release {}
+short-description: Release notes for {}
 ...
 
 # New features
@@ -40,9 +40,9 @@ def add_to_sitemap(from_version, to_version):
             sf.write(line)
 
 def generate(from_version, to_version):
-    ofilename = 'Release-notes-for-%s.md' % to_version
+    ofilename = 'Release-notes-for-{}.md'.format(to_version)
     with open(ofilename, 'w') as ofile:
-        ofile.write(relnote_template % (to_version, to_version))
+        ofile.write(relnote_template.format(to_version, to_version))
         for snippetfile in glob('snippets/*.md'):
             snippet = open(snippetfile).read()
             ofile.write(snippet)

--- a/tools/ac_converter.py
+++ b/tools/ac_converter.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-help_message = """Usage: %s <config.h.meson>
+help_message = """Usage: {} <config.h.meson>
 
 This script reads config.h.meson, looks for header
 checks and writes the corresponding meson declaration.
@@ -368,7 +368,7 @@ functions = []
 sizes = []
 
 if len(sys.argv) != 2:
-    print(help_message % sys.argv[0])
+    print(help_message.format(sys.argv[0]))
     sys.exit(0)
 
 with open(sys.argv[1]) as f:
@@ -414,7 +414,7 @@ cdata = configuration_data()''')
 
 print('check_headers = [')
 for token, hname in headers:
-    print("  ['%s', '%s']," % (token, hname))
+    print("  ['{}', '{}'],".format(token, hname))
 print(']\n')
 
 print('''foreach h : check_headers
@@ -430,7 +430,7 @@ print('check_functions = [')
 for tok in functions:
     if len(tok) == 3:
         tokstr, fdata0, fdata1 = tok
-        print("  ['%s', '%s', '#include<%s>']," % (tokstr, fdata0, fdata1))
+        print("  ['{}', '{}', '#include<{}>'],".format(tokstr, fdata0, fdata1))
     else:
         print('# check token', tok)
 print(']\n')
@@ -445,7 +445,7 @@ endforeach
 # Convert sizeof checks.
 
 for elem, typename in sizes:
-    print("cdata.set('%s', cc.sizeof('%s'))" % (elem, typename))
+    print("cdata.set('{}', cc.sizeof('{}'))".format(elem, typename))
 
 print('''
 configure_file(input : 'config.h.meson',


### PR DESCRIPTION
Simply update Python2 syntax to Python3 syntax in `genrelnotes.py`, main benefit would be less `%s` symbols mixed in with `{}` and `.format` 