### PR TITLE
Update Python2 syntax to Python3 syntax in Meson tools

### DIFF
--- a/tools/ac_converter.py
+++ b/tools/ac_converter.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-help_message = """Usage: %s <config.h.meson>
+help_message = """Usage: {} <config.h.meson>
 
 This script reads config.h.meson, looks for header
 checks and writes the corresponding meson declaration.
@@ -368,7 +368,7 @@ functions = []
 sizes = []
 
 if len(sys.argv) != 2:
-    print(help_message % sys.argv[0])
+    print(help_message.format(sys.argv[0]))
     sys.exit(0)
 
 with open(sys.argv[1]) as f:
@@ -414,7 +414,7 @@ cdata = configuration_data()''')
 
 print('check_headers = [')
 for token, hname in headers:
-    print("  ['%s', '%s']," % (token, hname))
+    print("  ['{}', '{}'],".format(token, hname))
 print(']\n')
 
 print('''foreach h : check_headers
@@ -430,7 +430,7 @@ print('check_functions = [')
 for tok in functions:
     if len(tok) == 3:
         tokstr, fdata0, fdata1 = tok
-        print("  ['%s', '%s', '#include<%s>']," % (tokstr, fdata0, fdata1))
+        print("  ['{}', '{}', '#include<{}>'],".format(tokstr, fdata0, fdata1))
     else:
         print('# check token', tok)
 print(']\n')
@@ -445,7 +445,7 @@ endforeach
 # Convert sizeof checks.
 
 for elem, typename in sizes:
-    print("cdata.set('%s', cc.sizeof('%s'))" % (elem, typename))
+    print("cdata.set('{}', cc.sizeof('{}'))".format(elem, typename))
 
 print('''
 configure_file(input : 'config.h.meson',

--- a/tools/ac_converter.py
+++ b/tools/ac_converter.py
@@ -14,11 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-help_message = """Usage: {} <config.h.meson>
-
+help_message = """Usage: %s <config.h.meson>
 This script reads config.h.meson, looks for header
 checks and writes the corresponding meson declaration.
-
 Copy config.h.in to config.h.meson, replace #undef
 with #mesondefine and run this. We can't do this automatically
 because some configure scripts have #undef statements
@@ -414,7 +412,7 @@ cdata = configuration_data()''')
 
 print('check_headers = [')
 for token, hname in headers:
-    print("  ['{}', '{}'],".format(token, hname))
+    print("  ['%s', '%s']," % (token, hname))
 print(']\n')
 
 print('''foreach h : check_headers
@@ -430,7 +428,7 @@ print('check_functions = [')
 for tok in functions:
     if len(tok) == 3:
         tokstr, fdata0, fdata1 = tok
-        print("  ['{}', '{}', '#include<{}>'],".format(tokstr, fdata0, fdata1))
+        print("  ['%s', '%s', '#include<%s>']," % (tokstr, fdata0, fdata1))
     else:
         print('# check token', tok)
 print(']\n')
@@ -445,7 +443,7 @@ endforeach
 # Convert sizeof checks.
 
 for elem, typename in sizes:
-    print("cdata.set('{}', cc.sizeof('{}'))".format(elem, typename))
+    print("cdata.set('%s', cc.sizeof('%s'))" % (elem, typename))
 
 print('''
 configure_file(input : 'config.h.meson',

--- a/tools/dircondenser.py
+++ b/tools/dircondenser.py
@@ -71,7 +71,7 @@ def condense(dirname: str):
         if e[0] != i:
             old_name = str(e[0]) + ' ' + e[1]
             new_name = str(i) + ' ' + e[1]
-            #print('git mv "%s" "%s"' % (old_name, new_name))
+            #print('git mv "{}" "{}"'.format(old_name, new_name))
             subprocess.check_call(['git', 'mv', old_name, new_name])
             replacements.append((old_name, new_name))
     os.chdir(curdir)


### PR DESCRIPTION
Simply update Python2 syntax to Python3 syntax in Meson tools, main benefit would be less %s symbols mixed in with {} and .format 