### PR TITLE
Update Python2 syntax to Python3 syntax in ghwt.py

### DIFF
--- a/ghwt.py
+++ b/ghwt.py
@@ -40,7 +40,7 @@ def list_projects():
     return 0
 
 def unpack(sproj, branch, outdir):
-    subprocess.check_call(['git', 'clone', '-b', branch, 'https://github.com/mesonbuild/%s.git' % sproj, outdir])
+    subprocess.check_call(['git', 'clone', '-b', branch, 'https://github.com/mesonbuild/{}.git'.format(sproj), outdir])
     usfile = os.path.join(outdir, 'upstream.wrap')
     assert(os.path.isfile(usfile))
     config = configparser.ConfigParser()
@@ -82,7 +82,7 @@ def install(sproj):
     if os.path.isdir(sproj_dir):
         print('Subproject is already there. To update, nuke the dir and reinstall.')
         return 1
-    blist = gh_get('https://api.github.com/repos/mesonbuild/%s/branches' % sproj)
+    blist = gh_get('https://api.github.com/repos/mesonbuild/{}/branches'.format(sproj))
     blist = [b['name'] for b in blist]
     blist = [b for b in blist if b != 'master']
     blist.sort()

--- a/tools/ac_converter.py
+++ b/tools/ac_converter.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-help_message = """Usage: %s <config.h.meson>
+help_message = """Usage: {} <config.h.meson>
 
 This script reads config.h.meson, looks for header
 checks and writes the corresponding meson declaration.
@@ -368,7 +368,7 @@ functions = []
 sizes = []
 
 if len(sys.argv) != 2:
-    print(help_message % sys.argv[0])
+    print(help_message.format(sys.argv[0]))
     sys.exit(0)
 
 with open(sys.argv[1]) as f:
@@ -414,7 +414,7 @@ cdata = configuration_data()''')
 
 print('check_headers = [')
 for token, hname in headers:
-    print("  ['%s', '%s']," % (token, hname))
+    print("  ['{}', '{}'],".format(token, hname))
 print(']\n')
 
 print('''foreach h : check_headers
@@ -430,7 +430,7 @@ print('check_functions = [')
 for tok in functions:
     if len(tok) == 3:
         tokstr, fdata0, fdata1 = tok
-        print("  ['%s', '%s', '#include<%s>']," % (tokstr, fdata0, fdata1))
+        print("  ['{}', '{}', '#include<{}>'],".format(tokstr, fdata0, fdata1))
     else:
         print('# check token', tok)
 print(']\n')
@@ -445,7 +445,7 @@ endforeach
 # Convert sizeof checks.
 
 for elem, typename in sizes:
-    print("cdata.set('%s', cc.sizeof('%s'))" % (elem, typename))
+    print("cdata.set('{}', cc.sizeof('{}'))".format(elem, typename))
 
 print('''
 configure_file(input : 'config.h.meson',


### PR DESCRIPTION
Simply update Python2 syntax to Python3 syntax in `ghwt.py`, main benefit would be less %s symbols mixed in with {} and .format 