### PR TITLE
catch improper command line option

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -180,7 +180,10 @@ class UserArrayOption(UserOption[List[str]]):
 
         if isinstance(value, str):
             if value.startswith('['):
-                newvalue = ast.literal_eval(value)
+                try:
+                    newvalue = ast.literal_eval(value)
+                except ValueError:
+                    raise MesonException('malformed option {}'.format(value))
             elif value == '':
                 newvalue = []
             else:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -170,7 +170,7 @@ class UserArrayOption(UserOption[List[str]]):
         self.allow_dups = allow_dups
         self.value = self.validate_value(value, user_input=user_input)
 
-    def validate_value(self, value, user_input=True) -> List[str]:
+    def validate_value(self, value, user_input: bool = True) -> List[str]:
         # User input is for options defined on the command line (via -D
         # options). Users can put their input in as a comma separated
         # string, but for defining options in meson_options.txt the format
@@ -191,7 +191,7 @@ class UserArrayOption(UserOption[List[str]]):
         elif isinstance(value, list):
             newvalue = value
         else:
-            raise MesonException('"{0}" should be a string array, but it is not'.format(str(newvalue)))
+            raise MesonException('"{}" should be a string array, but it is not'.format(newvalue))
 
         if not self.allow_dups and len(set(newvalue)) != len(newvalue):
             msg = 'Duplicated values in array option is deprecated. ' \


### PR DESCRIPTION
Fixes #6291 by catching on bad option format

```sh
meson build -Darr=['a','b']
```

should be replaced by `-Darr=a,b`