### PR TITLE
types: Annotations for ast, mparser.py, interpreterbase.py

### DIFF
--- a/.github/workflows/lint_mypy.yml
+++ b/.github/workflows/lint_mypy.yml
@@ -30,4 +30,4 @@ jobs:
       with:
         python-version: '3.x'
     - run: python -m pip install mypy
-    - run: mypy --follow-imports=skip  mesonbuild/mtest.py mesonbuild/minit.py mesonbuild/mintro.py mesonbuild/mparser.py mesonbuild/msetup.py mesonbuild/wrap tools/ mesonbuild/modules/fs.py mesonbuild/dependencies/boost.py mesonbuild/dependencies/mpi.py mesonbuild/dependencies/hdf5.py mesonbuild/compilers/mixins/intel.py mesonbuild/mlog.py
+    - run: mypy --follow-imports=skip mesonbuild/interpreterbase.py mesonbuild/mtest.py mesonbuild/minit.py mesonbuild/mintro.py mesonbuild/mparser.py mesonbuild/msetup.py mesonbuild/ast mesonbuild/wrap tools/ mesonbuild/modules/fs.py mesonbuild/dependencies/boost.py mesonbuild/dependencies/mpi.py mesonbuild/dependencies/hdf5.py mesonbuild/compilers/mixins/intel.py mesonbuild/mlog.py

--- a/.github/workflows/lint_mypy.yml
+++ b/.github/workflows/lint_mypy.yml
@@ -30,4 +30,4 @@ jobs:
       with:
         python-version: '3.x'
     - run: python -m pip install mypy
-    - run: mypy --follow-imports=skip  mesonbuild/mtest.py mesonbuild/minit.py mesonbuild/mintro.py mesonbuild/msetup.py mesonbuild/wrap tools/ mesonbuild/modules/fs.py mesonbuild/dependencies/boost.py mesonbuild/dependencies/mpi.py mesonbuild/dependencies/hdf5.py mesonbuild/compilers/mixins/intel.py mesonbuild/mlog.py
+    - run: mypy --follow-imports=skip  mesonbuild/mtest.py mesonbuild/minit.py mesonbuild/mintro.py mesonbuild/mparser.py mesonbuild/msetup.py mesonbuild/wrap tools/ mesonbuild/modules/fs.py mesonbuild/dependencies/boost.py mesonbuild/dependencies/mpi.py mesonbuild/dependencies/hdf5.py mesonbuild/compilers/mixins/intel.py mesonbuild/mlog.py

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -19,7 +19,7 @@ from .visitor import AstVisitor
 from .. import interpreterbase, mparser, mesonlib
 from .. import environment
 
-from ..interpreterbase import InvalidArguments, BreakRequest, ContinueRequest, TYPE_nvar, TYPE_nkwargs
+from ..interpreterbase import InvalidArguments, BreakRequest, ContinueRequest, TYPE_nvar
 from ..mparser import (
     AndNode,
     ArgumentNode,
@@ -341,7 +341,7 @@ class AstInterpreter(interpreterbase.InterpreterBase):
 
         return result
 
-    def flatten_args(self, args_raw: T.Sequence[TYPE_nvar], include_unknown_args: bool = False, id_loop_detect: T.Optional[T.List[str]] = None) -> T.List[TYPE_nvar]:
+    def flatten_args(self, args_raw: T.Union[TYPE_nvar, T.Sequence[TYPE_nvar]], include_unknown_args: bool = False, id_loop_detect: T.Optional[T.List[str]] = None) -> T.List[TYPE_nvar]:
         # Make sure we are always dealing with lists
         if isinstance(args_raw, list):
             args = args_raw
@@ -362,17 +362,9 @@ class AstInterpreter(interpreterbase.InterpreterBase):
                 flattend_args += [i]
         return flattend_args
 
-    def flatten_kwargs(self, kwargs: TYPE_nkwargs, include_unknown_args: bool = False) -> T.Dict[str, TYPE_nvar]:
+    def flatten_kwargs(self, kwargs: T.Dict[str, TYPE_nvar], include_unknown_args: bool = False) -> T.Dict[str, TYPE_nvar]:
         flattend_kwargs = {}
-        for key_node, val in kwargs.items():
-            key = None  # type: str
-            if isinstance(key_node, str):
-                key = key_node
-            elif isinstance(key_node, StringNode):
-                assert isinstance(key_node.value, str)
-                key = key_node.value
-            else:
-                continue
+        for key, val in kwargs.items():
             if isinstance(val, BaseNode):
                 resolved = self.resolve_node(val, include_unknown_args)
                 if resolved is not None:

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -29,6 +29,7 @@ from ..mparser import (
     ElementaryNode,
     EmptyNode,
     IdNode,
+    StringNode,
     MethodNode,
     PlusAssignmentNode,
     TernaryNode,
@@ -201,9 +202,16 @@ class AstInterpreter(interpreterbase.InterpreterBase):
 
     def reduce_arguments(self, args):
         if isinstance(args, ArgumentNode):
+            kwargs = {}  # type: T.Dict[T.Union[str, BaseNode], BaseNode]
+            for key, val in args.kwargs.items():
+                if isinstance(key, (StringNode, IdNode)):
+                    assert isinstance(key.value, str)
+                    kwargs[key.value] = val
+                else:
+                    kwargs[key] = val
             if args.incorrect_order():
                 raise InvalidArguments('All keyword arguments must be after positional arguments.')
-            return self.flatten_args(args.arguments), args.kwargs
+            return self.flatten_args(args.arguments), kwargs
         else:
             return self.flatten_args(args), {}
 

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -190,7 +190,7 @@ class AstInterpreter(interpreterbase.InterpreterBase):
             self.assignments[node.var_name] = []
             self.assign_vals[node.var_name] = []
         self.assignments[node.var_name] += [node.value] # Save a reference to the value node
-        if hasattr(node.value, 'ast_id'):
+        if node.value.ast_id:
             self.reverse_assignment[node.value.ast_id] = node
         self.assign_vals[node.var_name] += [self.evaluate_statement(node.value)]
 
@@ -250,7 +250,7 @@ class AstInterpreter(interpreterbase.InterpreterBase):
     def assignment(self, node):
         assert(isinstance(node, AssignmentNode))
         self.assignments[node.var_name] = [node.value] # Save a reference to the value node
-        if hasattr(node.value, 'ast_id'):
+        if node.value.ast_id:
             self.reverse_assignment[node.value.ast_id] = node
         self.assign_vals[node.var_name] = [self.evaluate_statement(node.value)] # Evaluate the value just in case
 
@@ -274,7 +274,7 @@ class AstInterpreter(interpreterbase.InterpreterBase):
         if not isinstance(node, BaseNode):
             return None
 
-        assert(hasattr(node, 'ast_id'))
+        assert node.ast_id
         if node.ast_id in id_loop_detect:
             return None # Loop detected
         id_loop_detect += [node.ast_id]

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -67,7 +67,7 @@ ADD_SOURCE = 0
 REMOVE_SOURCE = 1
 
 class AstInterpreter(interpreterbase.InterpreterBase):
-    def __init__(self, source_root: str, subdir: str, subproject: str, visitors: T.Optional[T.List[AstVisitor]] = None) -> None:
+    def __init__(self, source_root: str, subdir: str, subproject: str, visitors: T.Optional[T.List[AstVisitor]] = None):
         super().__init__(source_root, subdir, subproject)
         self.visitors = visitors if visitors is not None else []
         self.visited_subdirs = {}     # type: T.Dict[str, bool]

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -19,7 +19,7 @@ from .visitor import AstVisitor
 from .. import interpreterbase, mparser, mesonlib
 from .. import environment
 
-from ..interpreterbase import InvalidArguments, BreakRequest, ContinueRequest, TYPE_nvar
+from ..interpreterbase import InvalidArguments, BreakRequest, ContinueRequest, TYPE_nvar, TYPE_nkwargs
 from ..mparser import (
     AndNode,
     ArgumentNode,
@@ -144,7 +144,7 @@ class AstInterpreter(interpreterbase.InterpreterBase):
             sys.stderr.write('Unable to evaluate subdir({}) in AstInterpreter --> Skipping\n'.format(args))
             return
 
-        prev_subdir = self.subdir  # type: str
+        prev_subdir = self.subdir
         subdir = os.path.join(prev_subdir, args[0])
         absdir = os.path.join(self.source_root, subdir)
         buildfilename = os.path.join(subdir, environment.build_filename)
@@ -194,7 +194,7 @@ class AstInterpreter(interpreterbase.InterpreterBase):
     def evaluate_plusassign(self, node: PlusAssignmentNode) -> None:
         assert(isinstance(node, PlusAssignmentNode))
         # Cheat by doing a reassignment
-        self.assignments[node.var_name] = node.value # Save a reference to the value node
+        self.assignments[node.var_name] = node.value  # Save a reference to the value node
         if node.value.ast_id:
             self.reverse_assignment[node.value.ast_id] = node
         self.assign_vals[node.var_name] = self.evaluate_statement(node.value)
@@ -205,9 +205,9 @@ class AstInterpreter(interpreterbase.InterpreterBase):
     def unknown_function_called(self, func_name: str) -> None:
         pass
 
-    def reduce_arguments(self, args: ArgumentNode, resolve_key_nodes: bool = True) -> T.Tuple[list, dict]:
+    def reduce_arguments(self, args: ArgumentNode, resolve_key_nodes: bool = True) -> T.Tuple[T.List[TYPE_nvar], TYPE_nkwargs]:
         if isinstance(args, ArgumentNode):
-            kwargs = {}  # type: T.Dict[T.Union[str, BaseNode], BaseNode]
+            kwargs = {}  # type: T.Dict[T.Union[str, BaseNode], TYPE_nvar]
             for key, val in args.kwargs.items():
                 if isinstance(key, (StringNode, IdNode)):
                     assert isinstance(key.value, str)

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -30,7 +30,7 @@ build_target_functions = ['executable', 'jar', 'library', 'shared_library', 'sha
 
 class IntrospectionHelper:
     # mimic an argparse namespace
-    def __init__(self, cross_file: str) -> None:
+    def __init__(self, cross_file: str):
         self.cross_file = cross_file  # type: str
         self.native_file = None       # type: str
         self.cmd_line_options = {}    # type: T.Dict[str, str]
@@ -46,7 +46,7 @@ class IntrospectionInterpreter(AstInterpreter):
                  cross_file: T.Optional[str] = None,
                  subproject: str = '',
                  subproject_dir: str = 'subprojects',
-                 env: T.Optional[environment.Environment] = None) -> None:
+                 env: T.Optional[environment.Environment] = None):
         visitors = visitors if visitors is not None else []
         super().__init__(source_root, subdir, subproject, visitors=visitors)
 

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -145,7 +145,6 @@ class IntrospectionInterpreter(AstInterpreter):
         version = kwargs.get('version', [])
         if not isinstance(version, list):
             version = [version]
-        condition_level = node.condition_level if hasattr(node, 'condition_level') else 0
         if isinstance(required, ElementaryNode):
             required = required.value
         if not isinstance(required, bool):
@@ -155,8 +154,8 @@ class IntrospectionInterpreter(AstInterpreter):
             'required': required,
             'version': version,
             'has_fallback': has_fallback,
-            'conditional': condition_level > 0,
-            'node': node,
+            'conditional': node.condition_level > 0,
+            'node': node
         }]
 
     def build_target(self, node, args, kwargs, targetclass):

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -38,7 +38,7 @@ class IntrospectionInterpreter(AstInterpreter):
     # Most of the code is stolen from interpreter.Interpreter
     def __init__(self, source_root, subdir, backend, visitors=None, cross_file=None, subproject='', subproject_dir='subprojects', env=None):
         visitors = visitors if visitors is not None else []
-        super().__init__(source_root, subdir, visitors=visitors)
+        super().__init__(source_root, subdir, subproject, visitors=visitors)
 
         options = IntrospectionHelper(cross_file)
         self.cross_file = cross_file
@@ -46,7 +46,6 @@ class IntrospectionInterpreter(AstInterpreter):
             self.environment = environment.Environment(source_root, None, options)
         else:
             self.environment = env
-        self.subproject = subproject
         self.subproject_dir = subproject_dir
         self.coredata = self.environment.get_coredata()
         self.option_file = os.path.join(self.source_root, self.subdir, 'meson_options.txt')
@@ -183,8 +182,8 @@ class IntrospectionInterpreter(AstInterpreter):
             elif isinstance(curr, IdNode):
                 # Try to resolve the ID and append the node to the queue
                 var_name = curr.value
-                if var_name in self.assignments and self.assignments[var_name]:
-                    tmp_node = self.assignments[var_name][0]
+                if var_name in self.assignments:
+                    tmp_node = self.assignments[var_name]
                     if isinstance(tmp_node, (ArrayNode, IdNode, FunctionNode)):
                         srcqueue += [tmp_node]
             elif isinstance(curr, ArithmeticNode):

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -23,7 +23,7 @@ from ..mesonlib import MachineChoice
 from ..interpreterbase import InvalidArguments, TYPE_nvar
 from ..build import Executable, Jar, SharedLibrary, SharedModule, StaticLibrary
 from ..mparser import BaseNode, ArithmeticNode, ArrayNode, ElementaryNode, IdNode, FunctionNode, StringNode
-from typing import Any, Dict, List, Optional
+import typing as T
 import os
 
 build_target_functions = ['executable', 'jar', 'library', 'shared_library', 'shared_module', 'static_library', 'both_libraries']
@@ -33,7 +33,7 @@ class IntrospectionHelper:
     def __init__(self, cross_file: str) -> None:
         self.cross_file = cross_file  # type: str
         self.native_file = None       # type: str
-        self.cmd_line_options = {}    # type: Dict[str, str]
+        self.cmd_line_options = {}    # type: T.Dict[str, str]
 
 class IntrospectionInterpreter(AstInterpreter):
     # Interpreter to detect the options without a build directory
@@ -42,11 +42,11 @@ class IntrospectionInterpreter(AstInterpreter):
                  source_root: str,
                  subdir: str,
                  backend: str,
-                 visitors: Optional[List[AstVisitor]] = None,
-                 cross_file: Optional[str] = None,
+                 visitors: T.Optional[T.List[AstVisitor]] = None,
+                 cross_file: T.Optional[str] = None,
                  subproject: str = '',
                  subproject_dir: str = 'subprojects',
-                 env: Optional[environment.Environment] = None) -> None:
+                 env: T.Optional[environment.Environment] = None) -> None:
         visitors = visitors if visitors is not None else []
         super().__init__(source_root, subdir, subproject, visitors=visitors)
 
@@ -61,9 +61,9 @@ class IntrospectionInterpreter(AstInterpreter):
         self.option_file = os.path.join(self.source_root, self.subdir, 'meson_options.txt')
         self.backend = backend
         self.default_options = {'backend': self.backend}
-        self.project_data = {}    # type: Dict[str, Any]
-        self.targets = []         # type: List[Dict[str, Any]]
-        self.dependencies = []    # type: List[Dict[str, Any]]
+        self.project_data = {}    # type: T.Dict[str, T.Any]
+        self.targets = []         # type: T.List[T.Dict[str, T.Any]]
+        self.dependencies = []    # type: T.List[T.Dict[str, T.Any]]
         self.project_node = None  # type: BaseNode
 
         self.funcs.update({
@@ -79,7 +79,7 @@ class IntrospectionInterpreter(AstInterpreter):
             'both_libraries': self.func_both_lib,
         })
 
-    def func_project(self, node: BaseNode, args: List[TYPE_nvar], kwargs: Dict[str, TYPE_nvar]) -> None:
+    def func_project(self, node: BaseNode, args: T.List[TYPE_nvar], kwargs: T.Dict[str, TYPE_nvar]) -> None:
         if self.project_node:
             raise InvalidArguments('Second call to project()')
         self.project_node = node
@@ -136,7 +136,7 @@ class IntrospectionInterpreter(AstInterpreter):
         except (mesonlib.MesonException, RuntimeError):
             return
 
-    def func_add_languages(self, node: BaseNode, args: List[TYPE_nvar], kwargs: Dict[str, TYPE_nvar]) -> None:
+    def func_add_languages(self, node: BaseNode, args: T.List[TYPE_nvar], kwargs: T.Dict[str, TYPE_nvar]) -> None:
         args = self.flatten_args(args)
         for for_machine in [MachineChoice.BUILD, MachineChoice.HOST]:
             for lang in sorted(args, key=compilers.sort_clink):
@@ -149,7 +149,7 @@ class IntrospectionInterpreter(AstInterpreter):
                 if lang not in self.coredata.compilers[for_machine]:
                     self.environment.detect_compiler_for(lang, for_machine)
 
-    def func_dependency(self, node: BaseNode, args: List[TYPE_nvar], kwargs: Dict[str, TYPE_nvar]) -> None:
+    def func_dependency(self, node: BaseNode, args: T.List[TYPE_nvar], kwargs: T.Dict[str, TYPE_nvar]) -> None:
         args = self.flatten_args(args)
         kwargs = self.flatten_kwargs(kwargs)
         if not args:
@@ -173,7 +173,7 @@ class IntrospectionInterpreter(AstInterpreter):
             'node': node
         }]
 
-    def build_target(self, node: BaseNode, args: List[TYPE_nvar], kwargs_raw: Dict[str, TYPE_nvar], targetclass) -> Optional[Dict[str, Any]]:
+    def build_target(self, node: BaseNode, args: T.List[TYPE_nvar], kwargs_raw: T.Dict[str, TYPE_nvar], targetclass) -> T.Optional[T.Dict[str, T.Any]]:
         args = self.flatten_args(args)
         if not args or not isinstance(args[0], str):
             return None
@@ -186,7 +186,7 @@ class IntrospectionInterpreter(AstInterpreter):
 
         kwargs = self.flatten_kwargs(kwargs_raw, True)
 
-        source_nodes = []  # type: List[BaseNode]
+        source_nodes = []  # type: T.List[BaseNode]
         while srcqueue:
             curr = srcqueue.pop(0)
             arg_node = None
@@ -221,8 +221,8 @@ class IntrospectionInterpreter(AstInterpreter):
         kwargs_reduced = {k: v.value if isinstance(v, ElementaryNode) else v for k, v in kwargs_reduced.items()}
         kwargs_reduced = {k: v for k, v in kwargs_reduced.items() if not isinstance(v, BaseNode)}
         for_machine = MachineChoice.HOST
-        objects = []        # type: List[Any]
-        empty_sources = []  # type: List[Any]
+        objects = []        # type: T.List[T.Any]
+        empty_sources = []  # type: T.List[T.Any]
         # Passing the unresolved sources list causes errors
         target = targetclass(name, self.subdir, self.subproject, for_machine, empty_sources, objects, self.environment, kwargs_reduced)
 
@@ -243,7 +243,7 @@ class IntrospectionInterpreter(AstInterpreter):
         self.targets += [new_target]
         return new_target
 
-    def build_library(self, node: BaseNode, args: List[TYPE_nvar], kwargs: Dict[str, TYPE_nvar]) -> Optional[Dict[str, Any]]:
+    def build_library(self, node: BaseNode, args: T.List[TYPE_nvar], kwargs: T.Dict[str, TYPE_nvar]) -> T.Optional[T.Dict[str, T.Any]]:
         default_library = self.coredata.get_builtin_option('default_library')
         if default_library == 'shared':
             return self.build_target(node, args, kwargs, SharedLibrary)
@@ -253,28 +253,28 @@ class IntrospectionInterpreter(AstInterpreter):
             return self.build_target(node, args, kwargs, SharedLibrary)
         return None
 
-    def func_executable(self, node: BaseNode, args: List[TYPE_nvar], kwargs: Dict[str, TYPE_nvar]) -> Optional[Dict[str, Any]]:
+    def func_executable(self, node: BaseNode, args: T.List[TYPE_nvar], kwargs: T.Dict[str, TYPE_nvar]) -> T.Optional[T.Dict[str, T.Any]]:
         return self.build_target(node, args, kwargs, Executable)
 
-    def func_static_lib(self, node: BaseNode, args: List[TYPE_nvar], kwargs: Dict[str, TYPE_nvar]) -> Optional[Dict[str, Any]]:
+    def func_static_lib(self, node: BaseNode, args: T.List[TYPE_nvar], kwargs: T.Dict[str, TYPE_nvar]) -> T.Optional[T.Dict[str, T.Any]]:
         return self.build_target(node, args, kwargs, StaticLibrary)
 
-    def func_shared_lib(self, node: BaseNode, args: List[TYPE_nvar], kwargs: Dict[str, TYPE_nvar]) -> Optional[Dict[str, Any]]:
+    def func_shared_lib(self, node: BaseNode, args: T.List[TYPE_nvar], kwargs: T.Dict[str, TYPE_nvar]) -> T.Optional[T.Dict[str, T.Any]]:
         return self.build_target(node, args, kwargs, SharedLibrary)
 
-    def func_both_lib(self, node: BaseNode, args: List[TYPE_nvar], kwargs: Dict[str, TYPE_nvar]) -> Optional[Dict[str, Any]]:
+    def func_both_lib(self, node: BaseNode, args: T.List[TYPE_nvar], kwargs: T.Dict[str, TYPE_nvar]) -> T.Optional[T.Dict[str, T.Any]]:
         return self.build_target(node, args, kwargs, SharedLibrary)
 
-    def func_shared_module(self, node: BaseNode, args: List[TYPE_nvar], kwargs: Dict[str, TYPE_nvar]) -> Optional[Dict[str, Any]]:
+    def func_shared_module(self, node: BaseNode, args: T.List[TYPE_nvar], kwargs: T.Dict[str, TYPE_nvar]) -> T.Optional[T.Dict[str, T.Any]]:
         return self.build_target(node, args, kwargs, SharedModule)
 
-    def func_library(self, node: BaseNode, args: List[TYPE_nvar], kwargs: Dict[str, TYPE_nvar]) -> Optional[Dict[str, Any]]:
+    def func_library(self, node: BaseNode, args: T.List[TYPE_nvar], kwargs: T.Dict[str, TYPE_nvar]) -> T.Optional[T.Dict[str, T.Any]]:
         return self.build_library(node, args, kwargs)
 
-    def func_jar(self, node: BaseNode, args: List[TYPE_nvar], kwargs: Dict[str, TYPE_nvar]) -> Optional[Dict[str, Any]]:
+    def func_jar(self, node: BaseNode, args: T.List[TYPE_nvar], kwargs: T.Dict[str, TYPE_nvar]) -> T.Optional[T.Dict[str, T.Any]]:
         return self.build_target(node, args, kwargs, Jar)
 
-    def func_build_target(self, node: BaseNode, args: List[TYPE_nvar], kwargs: Dict[str, TYPE_nvar]) -> Optional[Dict[str, Any]]:
+    def func_build_target(self, node: BaseNode, args: T.List[TYPE_nvar], kwargs: T.Dict[str, TYPE_nvar]) -> T.Optional[T.Dict[str, T.Any]]:
         if 'target_type' not in kwargs:
             return None
         target_type = kwargs.pop('target_type')

--- a/mesonbuild/ast/postprocess.py
+++ b/mesonbuild/ast/postprocess.py
@@ -17,7 +17,7 @@
 
 from . import AstVisitor
 from .. import mparser
-from typing import Dict
+import typing as T
 
 class AstIndentationGenerator(AstVisitor):
     def __init__(self) -> None:
@@ -77,7 +77,7 @@ class AstIndentationGenerator(AstVisitor):
 
 class AstIDGenerator(AstVisitor):
     def __init__(self) -> None:
-        self.counter = {}  # type: Dict[str, int]
+        self.counter = {}  # type: T.Dict[str, int]
 
     def visit_default_func(self, node: mparser.BaseNode) -> None:
         name = type(node).__name__

--- a/mesonbuild/ast/postprocess.py
+++ b/mesonbuild/ast/postprocess.py
@@ -17,48 +17,49 @@
 
 from . import AstVisitor
 from .. import mparser
+from typing import Dict
 
 class AstIndentationGenerator(AstVisitor):
-    def __init__(self):
+    def __init__(self) -> None:
         self.level = 0
 
-    def visit_default_func(self, node: mparser.BaseNode):
+    def visit_default_func(self, node: mparser.BaseNode) -> None:
         # Store the current level in the node
         node.level = self.level
 
-    def visit_ArrayNode(self, node: mparser.ArrayNode):
+    def visit_ArrayNode(self, node: mparser.ArrayNode) -> None:
         self.visit_default_func(node)
         self.level += 1
         node.args.accept(self)
         self.level -= 1
 
-    def visit_DictNode(self, node: mparser.DictNode):
+    def visit_DictNode(self, node: mparser.DictNode) -> None:
         self.visit_default_func(node)
         self.level += 1
         node.args.accept(self)
         self.level -= 1
 
-    def visit_MethodNode(self, node: mparser.MethodNode):
+    def visit_MethodNode(self, node: mparser.MethodNode) -> None:
         self.visit_default_func(node)
         node.source_object.accept(self)
         self.level += 1
         node.args.accept(self)
         self.level -= 1
 
-    def visit_FunctionNode(self, node: mparser.FunctionNode):
+    def visit_FunctionNode(self, node: mparser.FunctionNode) -> None:
         self.visit_default_func(node)
         self.level += 1
         node.args.accept(self)
         self.level -= 1
 
-    def visit_ForeachClauseNode(self, node: mparser.ForeachClauseNode):
+    def visit_ForeachClauseNode(self, node: mparser.ForeachClauseNode) -> None:
         self.visit_default_func(node)
         self.level += 1
         node.items.accept(self)
         node.block.accept(self)
         self.level -= 1
 
-    def visit_IfClauseNode(self, node: mparser.IfClauseNode):
+    def visit_IfClauseNode(self, node: mparser.IfClauseNode) -> None:
         self.visit_default_func(node)
         for i in node.ifs:
             i.accept(self)
@@ -67,7 +68,7 @@ class AstIndentationGenerator(AstVisitor):
             node.elseblock.accept(self)
             self.level -= 1
 
-    def visit_IfNode(self, node: mparser.IfNode):
+    def visit_IfNode(self, node: mparser.IfNode) -> None:
         self.visit_default_func(node)
         self.level += 1
         node.condition.accept(self)
@@ -75,10 +76,10 @@ class AstIndentationGenerator(AstVisitor):
         self.level -= 1
 
 class AstIDGenerator(AstVisitor):
-    def __init__(self):
-        self.counter = {}
+    def __init__(self) -> None:
+        self.counter = {}  # type: Dict[str, int]
 
-    def visit_default_func(self, node: mparser.BaseNode):
+    def visit_default_func(self, node: mparser.BaseNode) -> None:
         name = type(node).__name__
         if name not in self.counter:
             self.counter[name] = 0
@@ -86,20 +87,20 @@ class AstIDGenerator(AstVisitor):
         self.counter[name] += 1
 
 class AstConditionLevel(AstVisitor):
-    def __init__(self):
+    def __init__(self) -> None:
         self.condition_level = 0
 
-    def visit_default_func(self, node: mparser.BaseNode):
+    def visit_default_func(self, node: mparser.BaseNode) -> None:
         node.condition_level = self.condition_level
 
-    def visit_ForeachClauseNode(self, node: mparser.ForeachClauseNode):
+    def visit_ForeachClauseNode(self, node: mparser.ForeachClauseNode) -> None:
         self.visit_default_func(node)
         self.condition_level += 1
         node.items.accept(self)
         node.block.accept(self)
         self.condition_level -= 1
 
-    def visit_IfClauseNode(self, node: mparser.IfClauseNode):
+    def visit_IfClauseNode(self, node: mparser.IfClauseNode) -> None:
         self.visit_default_func(node)
         for i in node.ifs:
             i.accept(self)
@@ -108,7 +109,7 @@ class AstConditionLevel(AstVisitor):
             node.elseblock.accept(self)
             self.condition_level -= 1
 
-    def visit_IfNode(self, node: mparser.IfNode):
+    def visit_IfNode(self, node: mparser.IfNode) -> None:
         self.visit_default_func(node)
         self.condition_level += 1
         node.condition.accept(self)

--- a/mesonbuild/ast/postprocess.py
+++ b/mesonbuild/ast/postprocess.py
@@ -20,7 +20,7 @@ from .. import mparser
 import typing as T
 
 class AstIndentationGenerator(AstVisitor):
-    def __init__(self) -> None:
+    def __init__(self):
         self.level = 0
 
     def visit_default_func(self, node: mparser.BaseNode) -> None:
@@ -76,7 +76,7 @@ class AstIndentationGenerator(AstVisitor):
         self.level -= 1
 
 class AstIDGenerator(AstVisitor):
-    def __init__(self) -> None:
+    def __init__(self):
         self.counter = {}  # type: T.Dict[str, int]
 
     def visit_default_func(self, node: mparser.BaseNode) -> None:
@@ -87,7 +87,7 @@ class AstIDGenerator(AstVisitor):
         self.counter[name] += 1
 
 class AstConditionLevel(AstVisitor):
-    def __init__(self) -> None:
+    def __init__(self):
         self.condition_level = 0
 
     def visit_default_func(self, node: mparser.BaseNode) -> None:

--- a/mesonbuild/ast/printer.py
+++ b/mesonbuild/ast/printer.py
@@ -143,7 +143,7 @@ class AstPrinter(AstVisitor):
         node.value.accept(self)
 
     def visit_ForeachClauseNode(self, node: mparser.ForeachClauseNode):
-        varnames = [x.value for x in node.varnames]
+        varnames = [x for x in node.varnames]
         self.append_padded('foreach', node)
         self.append_padded(', '.join(varnames), node)
         self.append_padded(':', node)
@@ -192,10 +192,7 @@ class AstPrinter(AstVisitor):
             if break_args:
                 self.newline()
         for key, val in node.kwargs.items():
-            if isinstance(key, str):
-                self.append(key, node)
-            else:
-                key.accept(self)
+            key.accept(self)
             self.append_padded(':', node)
             val.accept(self)
             self.append(', ', node)

--- a/mesonbuild/ast/printer.py
+++ b/mesonbuild/ast/printer.py
@@ -28,7 +28,7 @@ arithmic_map = {
 }
 
 class AstPrinter(AstVisitor):
-    def __init__(self, indent: int = 2, arg_newline_cutoff: int = 5) -> None:
+    def __init__(self, indent: int = 2, arg_newline_cutoff: int = 5):
         self.result = ''
         self.indent = indent
         self.arg_newline_cutoff = arg_newline_cutoff

--- a/mesonbuild/ast/printer.py
+++ b/mesonbuild/ast/printer.py
@@ -28,7 +28,7 @@ arithmic_map = {
 }
 
 class AstPrinter(AstVisitor):
-    def __init__(self, indent: int = 2, arg_newline_cutoff: int = 5):
+    def __init__(self, indent: int = 2, arg_newline_cutoff: int = 5) -> None:
         self.result = ''
         self.indent = indent
         self.arg_newline_cutoff = arg_newline_cutoff
@@ -36,113 +36,110 @@ class AstPrinter(AstVisitor):
         self.is_newline = True
         self.last_level = 0
 
-    def post_process(self):
+    def post_process(self) -> None:
         self.result = re.sub(r'\s+\n', '\n', self.result)
 
-    def append(self, data: str, node: mparser.BaseNode):
-        level = 0
-        if node and hasattr(node, 'level'):
-            level = node.level
-        else:
-            level = self.last_level
-        self.last_level = level
+    def append(self, data: str, node: mparser.BaseNode) -> None:
+        self.last_level = node.level
         if self.is_newline:
-            self.result += ' ' * (level * self.indent)
+            self.result += ' ' * (node.level * self.indent)
         self.result += data
         self.is_newline = False
 
-    def append_padded(self, data: str, node: mparser.BaseNode):
+    def append_padded(self, data: str, node: mparser.BaseNode) -> None:
         if self.result[-1] not in [' ', '\n']:
             data = ' ' + data
         self.append(data + ' ', node)
 
-    def newline(self):
+    def newline(self) -> None:
         self.result += '\n'
         self.is_newline = True
 
-    def visit_BooleanNode(self, node: mparser.BooleanNode):
+    def visit_BooleanNode(self, node: mparser.BooleanNode) -> None:
         self.append('true' if node.value else 'false', node)
 
-    def visit_IdNode(self, node: mparser.IdNode):
+    def visit_IdNode(self, node: mparser.IdNode) -> None:
+        assert isinstance(node.value, str)
         self.append(node.value, node)
 
-    def visit_NumberNode(self, node: mparser.NumberNode):
+    def visit_NumberNode(self, node: mparser.NumberNode) -> None:
         self.append(str(node.value), node)
 
-    def visit_StringNode(self, node: mparser.StringNode):
+    def visit_StringNode(self, node: mparser.StringNode) -> None:
+        assert isinstance(node.value, str)
         self.append("'" + node.value + "'", node)
 
-    def visit_ContinueNode(self, node: mparser.ContinueNode):
+    def visit_ContinueNode(self, node: mparser.ContinueNode) -> None:
         self.append('continue', node)
 
-    def visit_BreakNode(self, node: mparser.BreakNode):
+    def visit_BreakNode(self, node: mparser.BreakNode) -> None:
         self.append('break', node)
 
-    def visit_ArrayNode(self, node: mparser.ArrayNode):
+    def visit_ArrayNode(self, node: mparser.ArrayNode) -> None:
         self.append('[', node)
         node.args.accept(self)
         self.append(']', node)
 
-    def visit_DictNode(self, node: mparser.DictNode):
+    def visit_DictNode(self, node: mparser.DictNode) -> None:
         self.append('{', node)
         node.args.accept(self)
         self.append('}', node)
 
-    def visit_OrNode(self, node: mparser.OrNode):
+    def visit_OrNode(self, node: mparser.OrNode) -> None:
         node.left.accept(self)
         self.append_padded('or', node)
         node.right.accept(self)
 
-    def visit_AndNode(self, node: mparser.AndNode):
+    def visit_AndNode(self, node: mparser.AndNode) -> None:
         node.left.accept(self)
         self.append_padded('and', node)
         node.right.accept(self)
 
-    def visit_ComparisonNode(self, node: mparser.ComparisonNode):
+    def visit_ComparisonNode(self, node: mparser.ComparisonNode) -> None:
         node.left.accept(self)
         self.append_padded(node.ctype, node)
         node.right.accept(self)
 
-    def visit_ArithmeticNode(self, node: mparser.ArithmeticNode):
+    def visit_ArithmeticNode(self, node: mparser.ArithmeticNode) -> None:
         node.left.accept(self)
         self.append_padded(arithmic_map[node.operation], node)
         node.right.accept(self)
 
-    def visit_NotNode(self, node: mparser.NotNode):
+    def visit_NotNode(self, node: mparser.NotNode) -> None:
         self.append_padded('not', node)
         node.value.accept(self)
 
-    def visit_CodeBlockNode(self, node: mparser.CodeBlockNode):
+    def visit_CodeBlockNode(self, node: mparser.CodeBlockNode) -> None:
         for i in node.lines:
             i.accept(self)
             self.newline()
 
-    def visit_IndexNode(self, node: mparser.IndexNode):
+    def visit_IndexNode(self, node: mparser.IndexNode) -> None:
         node.iobject.accept(self)
         self.append('[', node)
         node.index.accept(self)
         self.append(']', node)
 
-    def visit_MethodNode(self, node: mparser.MethodNode):
+    def visit_MethodNode(self, node: mparser.MethodNode) -> None:
         node.source_object.accept(self)
         self.append('.' + node.name + '(', node)
         node.args.accept(self)
         self.append(')', node)
 
-    def visit_FunctionNode(self, node: mparser.FunctionNode):
+    def visit_FunctionNode(self, node: mparser.FunctionNode) -> None:
         self.append(node.func_name + '(', node)
         node.args.accept(self)
         self.append(')', node)
 
-    def visit_AssignmentNode(self, node: mparser.AssignmentNode):
+    def visit_AssignmentNode(self, node: mparser.AssignmentNode) -> None:
         self.append(node.var_name + ' = ', node)
         node.value.accept(self)
 
-    def visit_PlusAssignmentNode(self, node: mparser.PlusAssignmentNode):
+    def visit_PlusAssignmentNode(self, node: mparser.PlusAssignmentNode) -> None:
         self.append(node.var_name + ' += ', node)
         node.value.accept(self)
 
-    def visit_ForeachClauseNode(self, node: mparser.ForeachClauseNode):
+    def visit_ForeachClauseNode(self, node: mparser.ForeachClauseNode) -> None:
         varnames = [x for x in node.varnames]
         self.append_padded('foreach', node)
         self.append_padded(', '.join(varnames), node)
@@ -152,7 +149,7 @@ class AstPrinter(AstVisitor):
         node.block.accept(self)
         self.append('endforeach', node)
 
-    def visit_IfClauseNode(self, node: mparser.IfClauseNode):
+    def visit_IfClauseNode(self, node: mparser.IfClauseNode) -> None:
         prefix = ''
         for i in node.ifs:
             self.append_padded(prefix + 'if', node)
@@ -163,23 +160,23 @@ class AstPrinter(AstVisitor):
             node.elseblock.accept(self)
         self.append('endif', node)
 
-    def visit_UMinusNode(self, node: mparser.UMinusNode):
+    def visit_UMinusNode(self, node: mparser.UMinusNode) -> None:
         self.append_padded('-', node)
         node.value.accept(self)
 
-    def visit_IfNode(self, node: mparser.IfNode):
+    def visit_IfNode(self, node: mparser.IfNode) -> None:
         node.condition.accept(self)
         self.newline()
         node.block.accept(self)
 
-    def visit_TernaryNode(self, node: mparser.TernaryNode):
+    def visit_TernaryNode(self, node: mparser.TernaryNode) -> None:
         node.condition.accept(self)
         self.append_padded('?', node)
         node.trueblock.accept(self)
         self.append_padded(':', node)
         node.falseblock.accept(self)
 
-    def visit_ArgumentNode(self, node: mparser.ArgumentNode):
+    def visit_ArgumentNode(self, node: mparser.ArgumentNode) -> None:
         break_args = (len(node.arguments) + len(node.kwargs)) > self.arg_newline_cutoff
         for i in node.arguments + list(node.kwargs.values()):
             if not isinstance(i, (mparser.ElementaryNode, mparser.IndexNode)):

--- a/mesonbuild/ast/visitor.py
+++ b/mesonbuild/ast/visitor.py
@@ -18,122 +18,123 @@
 from .. import mparser
 
 class AstVisitor:
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
-    def visit_default_func(self, node: mparser.BaseNode):
+    def visit_default_func(self, node: mparser.BaseNode) -> None:
         pass
 
-    def visit_BooleanNode(self, node: mparser.BooleanNode):
+    def visit_BooleanNode(self, node: mparser.BooleanNode) -> None:
         self.visit_default_func(node)
 
-    def visit_IdNode(self, node: mparser.IdNode):
+    def visit_IdNode(self, node: mparser.IdNode) -> None:
         self.visit_default_func(node)
 
-    def visit_NumberNode(self, node: mparser.NumberNode):
+    def visit_NumberNode(self, node: mparser.NumberNode) -> None:
         self.visit_default_func(node)
 
-    def visit_StringNode(self, node: mparser.StringNode):
+    def visit_StringNode(self, node: mparser.StringNode) -> None:
         self.visit_default_func(node)
 
-    def visit_ContinueNode(self, node: mparser.ContinueNode):
+    def visit_ContinueNode(self, node: mparser.ContinueNode) -> None:
         self.visit_default_func(node)
 
-    def visit_BreakNode(self, node: mparser.BreakNode):
+    def visit_BreakNode(self, node: mparser.BreakNode) -> None:
         self.visit_default_func(node)
 
-    def visit_ArrayNode(self, node: mparser.ArrayNode):
+    def visit_ArrayNode(self, node: mparser.ArrayNode) -> None:
         self.visit_default_func(node)
         node.args.accept(self)
 
-    def visit_DictNode(self, node: mparser.DictNode):
+    def visit_DictNode(self, node: mparser.DictNode) -> None:
         self.visit_default_func(node)
         node.args.accept(self)
 
-    def visit_EmptyNode(self, node: mparser.EmptyNode):
+    def visit_EmptyNode(self, node: mparser.EmptyNode) -> None:
         self.visit_default_func(node)
 
-    def visit_OrNode(self, node: mparser.OrNode):
-        self.visit_default_func(node)
-        node.left.accept(self)
-        node.right.accept(self)
-
-    def visit_AndNode(self, node: mparser.AndNode):
+    def visit_OrNode(self, node: mparser.OrNode) -> None:
         self.visit_default_func(node)
         node.left.accept(self)
         node.right.accept(self)
 
-    def visit_ComparisonNode(self, node: mparser.ComparisonNode):
+    def visit_AndNode(self, node: mparser.AndNode) -> None:
         self.visit_default_func(node)
         node.left.accept(self)
         node.right.accept(self)
 
-    def visit_ArithmeticNode(self, node: mparser.ArithmeticNode):
+    def visit_ComparisonNode(self, node: mparser.ComparisonNode) -> None:
         self.visit_default_func(node)
         node.left.accept(self)
         node.right.accept(self)
 
-    def visit_NotNode(self, node: mparser.NotNode):
+    def visit_ArithmeticNode(self, node: mparser.ArithmeticNode) -> None:
+        self.visit_default_func(node)
+        node.left.accept(self)
+        node.right.accept(self)
+
+    def visit_NotNode(self, node: mparser.NotNode) -> None:
         self.visit_default_func(node)
         node.value.accept(self)
 
-    def visit_CodeBlockNode(self, node: mparser.CodeBlockNode):
+    def visit_CodeBlockNode(self, node: mparser.CodeBlockNode) -> None:
         self.visit_default_func(node)
         for i in node.lines:
             i.accept(self)
 
-    def visit_IndexNode(self, node: mparser.IndexNode):
+    def visit_IndexNode(self, node: mparser.IndexNode) -> None:
         self.visit_default_func(node)
         node.iobject.accept(self)
         node.index.accept(self)
 
-    def visit_MethodNode(self, node: mparser.MethodNode):
+    def visit_MethodNode(self, node: mparser.MethodNode) -> None:
         self.visit_default_func(node)
         node.source_object.accept(self)
         node.args.accept(self)
 
-    def visit_FunctionNode(self, node: mparser.FunctionNode):
+    def visit_FunctionNode(self, node: mparser.FunctionNode) -> None:
         self.visit_default_func(node)
         node.args.accept(self)
 
-    def visit_AssignmentNode(self, node: mparser.AssignmentNode):
+    def visit_AssignmentNode(self, node: mparser.AssignmentNode) -> None:
         self.visit_default_func(node)
         node.value.accept(self)
 
-    def visit_PlusAssignmentNode(self, node: mparser.PlusAssignmentNode):
+    def visit_PlusAssignmentNode(self, node: mparser.PlusAssignmentNode) -> None:
         self.visit_default_func(node)
         node.value.accept(self)
 
-    def visit_ForeachClauseNode(self, node: mparser.ForeachClauseNode):
+    def visit_ForeachClauseNode(self, node: mparser.ForeachClauseNode) -> None:
         self.visit_default_func(node)
         node.items.accept(self)
         node.block.accept(self)
 
-    def visit_IfClauseNode(self, node: mparser.IfClauseNode):
+    def visit_IfClauseNode(self, node: mparser.IfClauseNode) -> None:
         self.visit_default_func(node)
         for i in node.ifs:
             i.accept(self)
         if node.elseblock:
             node.elseblock.accept(self)
 
-    def visit_UMinusNode(self, node: mparser.UMinusNode):
+    def visit_UMinusNode(self, node: mparser.UMinusNode) -> None:
         self.visit_default_func(node)
         node.value.accept(self)
 
-    def visit_IfNode(self, node: mparser.IfNode):
+    def visit_IfNode(self, node: mparser.IfNode) -> None:
         self.visit_default_func(node)
         node.condition.accept(self)
         node.block.accept(self)
 
-    def visit_TernaryNode(self, node: mparser.TernaryNode):
+    def visit_TernaryNode(self, node: mparser.TernaryNode) -> None:
         self.visit_default_func(node)
         node.condition.accept(self)
         node.trueblock.accept(self)
         node.falseblock.accept(self)
 
-    def visit_ArgumentNode(self, node: mparser.ArgumentNode):
+    def visit_ArgumentNode(self, node: mparser.ArgumentNode) -> None:
         self.visit_default_func(node)
         for i in node.arguments:
             i.accept(self)
-        for val in node.kwargs.values():
+        for key, val in node.kwargs.items():
+            key.accept(self)
             val.accept(self)

--- a/mesonbuild/ast/visitor.py
+++ b/mesonbuild/ast/visitor.py
@@ -18,7 +18,7 @@
 from .. import mparser
 
 class AstVisitor:
-    def __init__(self) -> None:
+    def __init__(self):
         pass
 
     def visit_default_func(self, node: mparser.BaseNode) -> None:

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -1002,7 +1002,7 @@ class CMakeInterpreter:
             if not isinstance(args, list):
                 args = [args]
             args_n.arguments = [nodeify(x) for x in args if x is not None]
-            args_n.kwargs = {k: nodeify(v) for k, v in kwargs.items() if v is not None}
+            args_n.kwargs = {id_node(k): nodeify(v) for k, v in kwargs.items() if v is not None}
             func_n = FunctionNode(self.subdir, 0, 0, 0, 0, name, args_n)
             return func_n
 
@@ -1013,7 +1013,7 @@ class CMakeInterpreter:
             if not isinstance(args, list):
                 args = [args]
             args_n.arguments = [nodeify(x) for x in args if x is not None]
-            args_n.kwargs = {k: nodeify(v) for k, v in kwargs.items() if v is not None}
+            args_n.kwargs = {id_node(k): nodeify(v) for k, v in kwargs.items() if v is not None}
             return MethodNode(self.subdir, 0, 0, obj, name, args_n)
 
         def assign(var_name: str, value: BaseNode) -> AssignmentNode:

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -978,7 +978,7 @@ class CMakeInterpreter:
             if isinstance(value, str):
                 return string(value)
             elif isinstance(value, bool):
-                return BooleanNode(token(), value)
+                return BooleanNode(token(val=value))
             elif isinstance(value, int):
                 return number(value)
             elif isinstance(value, list):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2182,13 +2182,12 @@ class Interpreter(InterpreterBase):
 
     def __init__(self, build, backend=None, subproject='', subdir='', subproject_dir='subprojects',
                  modules = None, default_project_options=None, mock=False, ast=None):
-        super().__init__(build.environment.get_source_dir(), subdir)
+        super().__init__(build.environment.get_source_dir(), subdir, subproject)
         self.an_unpicklable_object = mesonlib.an_unpicklable_object
         self.build = build
         self.environment = build.environment
         self.coredata = self.environment.get_coredata()
         self.backend = backend
-        self.subproject = subproject
         self.summary = {}
         if modules is None:
             self.modules = {}

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -4425,15 +4425,15 @@ Try setting b_lundef to false instead.'''.format(self.coredata.base_options['b_s
             ef = extract_as_list(kwargs, 'extra_files')
             kwargs['extra_files'] = self.source_strings_to_files(ef)
         self.check_sources_exist(os.path.join(self.source_root, self.subdir), sources)
-        if targetholder is ExecutableHolder:
+        if targetholder == ExecutableHolder:
             targetclass = build.Executable
-        elif targetholder is SharedLibraryHolder:
+        elif targetholder == SharedLibraryHolder:
             targetclass = build.SharedLibrary
-        elif targetholder is SharedModuleHolder:
+        elif targetholder == SharedModuleHolder:
             targetclass = build.SharedModule
-        elif targetholder is StaticLibraryHolder:
+        elif targetholder == StaticLibraryHolder:
             targetclass = build.StaticLibrary
-        elif targetholder is JarHolder:
+        elif targetholder == JarHolder:
             targetclass = build.Jar
         else:
             mlog.debug('Unknown target type:', str(targetholder))

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -4499,7 +4499,7 @@ This will become a hard error in the future.''', location=self.current_node)
                 raise InterpreterException('Tried to add non-existing source file %s.' % s)
 
     # Only permit object extraction from the same subproject
-    def validate_extraction(self, buildtarget):
+    def validate_extraction(self, buildtarget: InterpreterObject) -> None:
         if not self.subdir.startswith(self.subproject_dir):
             if buildtarget.subdir.startswith(self.subproject_dir):
                 raise InterpreterException('Tried to extract objects from a subproject target.')
@@ -4508,19 +4508,6 @@ This will become a hard error in the future.''', location=self.current_node)
                 raise InterpreterException('Tried to extract objects from the main project from a subproject.')
             if self.subdir.split('/')[1] != buildtarget.subdir.split('/')[1]:
                 raise InterpreterException('Tried to extract objects from a different subproject.')
-
-    def check_contains(self, obj, args):
-        if len(args) != 1:
-            raise InterpreterException('Contains method takes exactly one argument.')
-        item = args[0]
-        for element in obj:
-            if isinstance(element, list):
-                found = self.check_contains(element, args)
-                if found:
-                    return True
-            if element == item:
-                return True
-        return False
 
     def is_subproject(self):
         return self.subproject != ''

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -185,7 +185,7 @@ def disablerIfNotFound(f):
 
 class permittedKwargs:
 
-    def __init__(self, permitted: T.Set[str]) -> None:
+    def __init__(self, permitted: T.Set[str]):
         self.permitted = permitted  # type: T.Set[str]
 
     def __call__(self, f):
@@ -208,7 +208,7 @@ class FeatureCheckBase:
     # Format: {subproject: {feature_version: set(feature_names)}}
     feature_registry = {}  # type: T.ClassVar[T.Dict[str, T.Dict[str, T.Set[str]]]]
 
-    def __init__(self, feature_name: str, version: str) -> None:
+    def __init__(self, feature_name: str, version: str):
         self.feature_name = feature_name  # type: str
         self.feature_version = version    # type: str
 
@@ -293,7 +293,7 @@ class FeatureDeprecated(FeatureCheckBase):
 
 
 class FeatureCheckKwargsBase:
-    def __init__(self, feature_name: str, feature_version: str, kwargs: T.List[str]) -> None:
+    def __init__(self, feature_name: str, feature_version: str, kwargs: T.List[str]):
         self.feature_name = feature_name
         self.feature_version = feature_version
         self.kwargs = kwargs
@@ -375,7 +375,7 @@ def is_disabled(args, kwargs) -> bool:
 class InterpreterBase:
     elementary_types = (int, float, str, bool, list)
 
-    def __init__(self, source_root: str, subdir: str, subproject: str) -> None:
+    def __init__(self, source_root: str, subdir: str, subproject: str):
         self.source_root = source_root
         self.funcs = {}    # type: T.Dict[str, T.Callable[[mparser.BaseNode, T.List[TYPE_nvar], T.Dict[str, TYPE_nvar]], TYPE_var]]
         self.builtin = {}  # type: T.Dict[str, InterpreterObject]

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -19,8 +19,9 @@ from . import mparser, mesonlib, mlog
 from . import environment, dependencies
 
 import os, copy, re
+import collections.abc
 from functools import wraps
-from typing import Any, Callable, Dict, List, Set, Sequence, Tuple, Optional, Union
+from typing import Any, Callable, ClassVar, Dict, Generic, List, Set, Sequence, Tuple, TypeVar, Optional, Union
 
 class InterpreterObject:
     def __init__(self):
@@ -37,7 +38,9 @@ class InterpreterObject:
             return method(args, kwargs)
         raise InvalidCode('Unknown method "%s" in object.' % method_name)
 
-class ObjectHolder:
+TV_InterpreterObject = TypeVar('TV_InterpreterObject')
+
+class ObjectHolder(Generic[TV_InterpreterObject]):
     def __init__(self, obj: InterpreterObject, subproject: Optional[str] = None):
         self.held_object = obj        # type: InterpreterObject
         self.subproject = subproject  # type: str
@@ -125,7 +128,7 @@ def flatten(args: Union[TYPE_nvar, List[TYPE_nvar]]) -> List[TYPE_nvar]:
     if isinstance(args, mparser.StringNode):
         assert isinstance(args.value, str)
         return [args.value]
-    if isinstance(args, (int, float, bool, str, ObjectHolder, mparser.BaseNode, mesonlib.File, InterpreterObject)):
+    if not isinstance(args, collections.abc.Sequence):
         return [args]
     result = []  # type: List[TYPE_nvar]
     for a in args:
@@ -203,7 +206,7 @@ class FeatureCheckBase:
     # Class variable, shared across all instances
     #
     # Format: {subproject: {feature_version: set(feature_names)}}
-    feature_registry = {}  # type: Dict[str, Dict[str, Set[str]]]
+    feature_registry = {}  # type: ClassVar[Dict[str, Dict[str, Set[str]]]]
 
     def __init__(self, feature_name: str, version: str) -> None:
         self.feature_name = feature_name  # type: str

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -360,12 +360,12 @@ def is_disabled(args, kwargs) -> bool:
     return False
 
 class InterpreterBase:
-    def __init__(self, source_root, subdir):
+    def __init__(self, source_root: str, subdir: str, subproject: str) -> None:
         self.source_root = source_root
         self.funcs = {}
         self.builtin = {}
         self.subdir = subdir
-        self.variables = {}
+        self.subproject = subproject
         self.argument_depth = 0
         self.current_lineno = -1
         # Current node set during a function call. This can be used as location

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -400,7 +400,7 @@ class PerThreeMachine(PerMachine[_T]):
 class PerMachineDefaultable(PerMachine[T.Optional[_T]]):
     """Extends `PerMachine` with the ability to default from `None`s.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__(None, None)
 
     def default_missing(self) -> "PerMachine[T.Optional[_T]]":
@@ -418,7 +418,7 @@ class PerMachineDefaultable(PerMachine[T.Optional[_T]]):
 class PerThreeMachineDefaultable(PerMachineDefaultable, PerThreeMachine[T.Optional[_T]]):
     """Extends `PerThreeMachine` with the ability to default from `None`s.
     """
-    def __init__(self) -> None:
+    def __init__(self):
         PerThreeMachine.__init__(self, None, None, None)
 
     def default_missing(self) -> "PerThreeMachine[T.Optional[_T]]":

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -25,7 +25,7 @@ from . import mesonlib
 from .ast import IntrospectionInterpreter, build_target_functions, AstConditionLevel, AstIDGenerator, AstIndentationGenerator
 from . import mlog
 from .backend import backends
-from .mparser import FunctionNode, ArrayNode, ArgumentNode, StringNode
+from .mparser import BaseNode, FunctionNode, ArrayNode, ArgumentNode, StringNode
 from .interpreter import Interpreter
 from pathlib import PurePath
 import typing as T
@@ -110,7 +110,7 @@ def list_targets_from_source(intr: IntrospectionInterpreter) -> T.List[T.Dict[st
     for i in intr.targets:
         sources = []  # type: T.List[str]
         for n in i['sources']:
-            args = []  # type: T.List[T.Union[str, StringNode]]
+            args = []  # type: T.List[BaseNode]
             if isinstance(n, FunctionNode):
                 args = list(n.args.arguments)
                 if n.func_name in build_target_functions:
@@ -121,6 +121,7 @@ def list_targets_from_source(intr: IntrospectionInterpreter) -> T.List[T.Dict[st
                 args = n.arguments
             for j in args:
                 if isinstance(j, StringNode):
+                    assert isinstance(j.value, str)
                     sources += [j.value]
                 elif isinstance(j, str):
                     sources += [j]

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -232,6 +232,11 @@ class BaseNode:
         self.end_lineno = end_lineno if end_lineno is not None else self.lineno
         self.end_colno = end_colno if end_colno is not None else self.colno
 
+        # Attributes for the visitors
+        self.level = 0            # type: int
+        self.ast_id = ''          # type: str
+        self.condition_level = 0  # type: int
+
     def accept(self, visitor: 'AstVisitor') -> None:
         fname = 'visit_{}'.format(type(self).__name__)
         if hasattr(visitor, fname):

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -79,7 +79,7 @@ class BlockParseException(MesonException):
 TV_TokenTypes = T.TypeVar('TV_TokenTypes', int, str, bool)
 
 class Token(T.Generic[TV_TokenTypes]):
-    def __init__(self, tid: str, filename: str, line_start: int, lineno: int, colno: int, bytespan: T.Tuple[int, int], value: TV_TokenTypes) -> None:
+    def __init__(self, tid: str, filename: str, line_start: int, lineno: int, colno: int, bytespan: T.Tuple[int, int], value: TV_TokenTypes):
         self.tid = tid                # type: str
         self.filename = filename      # type: str
         self.line_start = line_start  # type: int
@@ -94,7 +94,7 @@ class Token(T.Generic[TV_TokenTypes]):
         return self.tid == other.tid
 
 class Lexer:
-    def __init__(self, code: str) -> None:
+    def __init__(self, code: str):
         self.code = code
         self.keywords = {'true', 'false', 'if', 'else', 'elif',
                          'endif', 'and', 'or', 'not', 'foreach', 'endforeach',
@@ -226,7 +226,7 @@ class Lexer:
                 raise ParseException('lexer', self.getline(line_start), lineno, col)
 
 class BaseNode:
-    def __init__(self, lineno: int, colno: int, filename: str, end_lineno: T.Optional[int] = None, end_colno: T.Optional[int] = None) -> None:
+    def __init__(self, lineno: int, colno: int, filename: str, end_lineno: T.Optional[int] = None, end_colno: T.Optional[int] = None):
         self.lineno = lineno      # type: int
         self.colno = colno        # type: int
         self.filename = filename  # type: str
@@ -246,18 +246,18 @@ class BaseNode:
                 func(self)
 
 class ElementaryNode(T.Generic[TV_TokenTypes], BaseNode):
-    def __init__(self, token: Token[TV_TokenTypes]) -> None:
+    def __init__(self, token: Token[TV_TokenTypes]):
         super().__init__(token.lineno, token.colno, token.filename)
         self.value = token.value        # type: TV_TokenTypes
         self.bytespan = token.bytespan  # type: T.Tuple[int, int]
 
 class BooleanNode(ElementaryNode[bool]):
-    def __init__(self, token: Token[bool]) -> None:
+    def __init__(self, token: Token[bool]):
         super().__init__(token)
         assert isinstance(self.value, bool)
 
 class IdNode(ElementaryNode[str]):
-    def __init__(self, token: Token[str]) -> None:
+    def __init__(self, token: Token[str]):
         super().__init__(token)
         assert isinstance(self.value, str)
 
@@ -265,12 +265,12 @@ class IdNode(ElementaryNode[str]):
         return "Id node: '%s' (%d, %d)." % (self.value, self.lineno, self.colno)
 
 class NumberNode(ElementaryNode[int]):
-    def __init__(self, token: Token[int]) -> None:
+    def __init__(self, token: Token[int]):
         super().__init__(token)
         assert isinstance(self.value, int)
 
 class StringNode(ElementaryNode[str]):
-    def __init__(self, token: Token[str]) -> None:
+    def __init__(self, token: Token[str]):
         super().__init__(token)
         assert isinstance(self.value, str)
 
@@ -284,7 +284,7 @@ class BreakNode(ElementaryNode):
     pass
 
 class ArgumentNode(BaseNode):
-    def __init__(self, token: Token[TV_TokenTypes]) -> None:
+    def __init__(self, token: Token[TV_TokenTypes]):
         super().__init__(token.lineno, token.colno, token.filename)
         self.arguments = []  # type: T.List[BaseNode]
         self.commas = []     # type: T.List[Token[TV_TokenTypes]]
@@ -325,64 +325,64 @@ class ArgumentNode(BaseNode):
         return self.num_args() # Fixme
 
 class ArrayNode(BaseNode):
-    def __init__(self, args: ArgumentNode, lineno: int, colno: int, end_lineno: int, end_colno: int) -> None:
+    def __init__(self, args: ArgumentNode, lineno: int, colno: int, end_lineno: int, end_colno: int):
         super().__init__(lineno, colno, args.filename, end_lineno=end_lineno, end_colno=end_colno)
         self.args = args              # type: ArgumentNode
 
 class DictNode(BaseNode):
-    def __init__(self, args: ArgumentNode, lineno: int, colno: int, end_lineno: int, end_colno: int) -> None:
+    def __init__(self, args: ArgumentNode, lineno: int, colno: int, end_lineno: int, end_colno: int):
         super().__init__(lineno, colno, args.filename, end_lineno=end_lineno, end_colno=end_colno)
         self.args = args
 
 class EmptyNode(BaseNode):
-    def __init__(self, lineno: int, colno: int, filename: str) -> None:
+    def __init__(self, lineno: int, colno: int, filename: str):
         super().__init__(lineno, colno, filename)
         self.value = None
 
 class OrNode(BaseNode):
-    def __init__(self, left: BaseNode, right: BaseNode) -> None:
+    def __init__(self, left: BaseNode, right: BaseNode):
         super().__init__(left.lineno, left.colno, left.filename)
         self.left = left    # type: BaseNode
         self.right = right  # type: BaseNode
 
 class AndNode(BaseNode):
-    def __init__(self, left: BaseNode, right: BaseNode) -> None:
+    def __init__(self, left: BaseNode, right: BaseNode):
         super().__init__(left.lineno, left.colno, left.filename)
         self.left = left    # type: BaseNode
         self.right = right  # type: BaseNode
 
 class ComparisonNode(BaseNode):
-    def __init__(self, ctype: str, left: BaseNode, right: BaseNode) -> None:
+    def __init__(self, ctype: str, left: BaseNode, right: BaseNode):
         super().__init__(left.lineno, left.colno, left.filename)
         self.left = left    # type: BaseNode
         self.right = right  # type: BaseNode
         self.ctype = ctype  # type: str
 
 class ArithmeticNode(BaseNode):
-    def __init__(self, operation: str, left: BaseNode, right: BaseNode) -> None:
+    def __init__(self, operation: str, left: BaseNode, right: BaseNode):
         super().__init__(left.lineno, left.colno, left.filename)
         self.left = left            # type: BaseNode
         self.right = right          # type: BaseNode
         self.operation = operation  # type: str
 
 class NotNode(BaseNode):
-    def __init__(self, token: Token[TV_TokenTypes], value: BaseNode) -> None:
+    def __init__(self, token: Token[TV_TokenTypes], value: BaseNode):
         super().__init__(token.lineno, token.colno, token.filename)
         self.value = value  # type: BaseNode
 
 class CodeBlockNode(BaseNode):
-    def __init__(self, token: Token[TV_TokenTypes]) -> None:
+    def __init__(self, token: Token[TV_TokenTypes]):
         super().__init__(token.lineno, token.colno, token.filename)
         self.lines = []  # type: T.List[BaseNode]
 
 class IndexNode(BaseNode):
-    def __init__(self, iobject: BaseNode, index: BaseNode) -> None:
+    def __init__(self, iobject: BaseNode, index: BaseNode):
         super().__init__(iobject.lineno, iobject.colno, iobject.filename)
         self.iobject = iobject  # type: BaseNode
         self.index = index      # type: BaseNode
 
 class MethodNode(BaseNode):
-    def __init__(self, filename: str, lineno: int, colno: int, source_object: BaseNode, name: str, args: ArgumentNode) -> None:
+    def __init__(self, filename: str, lineno: int, colno: int, source_object: BaseNode, name: str, args: ArgumentNode):
         super().__init__(lineno, colno, filename)
         self.source_object = source_object  # type: BaseNode
         self.name = name                    # type: str
@@ -390,28 +390,28 @@ class MethodNode(BaseNode):
         self.args = args                    # type: ArgumentNode
 
 class FunctionNode(BaseNode):
-    def __init__(self, filename: str, lineno: int, colno: int, end_lineno: int, end_colno: int, func_name: str, args: ArgumentNode) -> None:
+    def __init__(self, filename: str, lineno: int, colno: int, end_lineno: int, end_colno: int, func_name: str, args: ArgumentNode):
         super().__init__(lineno, colno, filename, end_lineno=end_lineno, end_colno=end_colno)
         self.func_name = func_name  # type: str
         assert(isinstance(func_name, str))
         self.args = args  # type: ArgumentNode
 
 class AssignmentNode(BaseNode):
-    def __init__(self, filename: str, lineno: int, colno: int, var_name: str, value: BaseNode) -> None:
+    def __init__(self, filename: str, lineno: int, colno: int, var_name: str, value: BaseNode):
         super().__init__(lineno, colno, filename)
         self.var_name = var_name  # type: str
         assert(isinstance(var_name, str))
         self.value = value  # type: BaseNode
 
 class PlusAssignmentNode(BaseNode):
-    def __init__(self, filename: str, lineno: int, colno: int, var_name: str, value: BaseNode) -> None:
+    def __init__(self, filename: str, lineno: int, colno: int, var_name: str, value: BaseNode):
         super().__init__(lineno, colno, filename)
         self.var_name = var_name  # type: str
         assert(isinstance(var_name, str))
         self.value = value  # type: BaseNode
 
 class ForeachClauseNode(BaseNode):
-    def __init__(self, token: Token, varnames: T.List[str], items: BaseNode, block: CodeBlockNode) -> None:
+    def __init__(self, token: Token, varnames: T.List[str], items: BaseNode, block: CodeBlockNode):
         super().__init__(token.lineno, token.colno, token.filename)
         self.varnames = varnames  # type: T.List[str]
         self.items = items        # type: BaseNode
@@ -424,7 +424,7 @@ class IfNode(BaseNode):
         self.block = block          # type: CodeBlockNode
 
 class IfClauseNode(BaseNode):
-    def __init__(self, linenode: BaseNode) -> None:
+    def __init__(self, linenode: BaseNode):
         super().__init__(linenode.lineno, linenode.colno, linenode.filename)
         self.ifs = []  # type: T.List[IfNode]
         self.elseblock = EmptyNode(linenode.lineno, linenode.colno, linenode.filename)  # type: T.Union[EmptyNode, CodeBlockNode]
@@ -467,7 +467,7 @@ comparison_map = {'equal': '==',
 # 9 plain token
 
 class Parser:
-    def __init__(self, code: str, filename: str) -> None:
+    def __init__(self, code: str, filename: str):
         self.lexer = Lexer(code)
         self.stream = self.lexer.lex(filename)
         self.current = Token('eof', '', 0, 0, 0, (0, 0), None)  # type: Token

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -176,10 +176,10 @@ class OptionInterpreter:
         reduced_pos = [self.reduce_single(arg) for arg in args.arguments]
         reduced_kw = {}
         for key in args.kwargs.keys():
-            if not isinstance(key, str):
+            if not isinstance(key, mparser.IdNode):
                 raise OptionException('Keyword argument name is not a string.')
             a = args.kwargs[key]
-            reduced_kw[key] = self.reduce_single(a)
+            reduced_kw[key.value] = self.reduce_single(a)
         return reduced_pos, reduced_kw
 
     def evaluate_statement(self, node):

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -414,10 +414,10 @@ class Rewriter:
         # Check the assignments
         tgt = None
         if target in self.interpreter.assignments:
-            node = self.interpreter.assignments[target][0]
+            node = self.interpreter.assignments[target]
             if isinstance(node, FunctionNode):
                 if node.func_name in ['executable', 'jar', 'library', 'shared_library', 'shared_module', 'static_library', 'both_libraries']:
-                    tgt = self.interpreter.assign_vals[target][0]
+                    tgt = self.interpreter.assign_vals[target]
 
         return tgt
 
@@ -434,7 +434,7 @@ class Rewriter:
 
         # Check the assignments
         if dependency in self.interpreter.assignments:
-            node = self.interpreter.assignments[dependency][0]
+            node = self.interpreter.assignments[dependency]
             if isinstance(node, FunctionNode):
                 if node.func_name in ['dependency']:
                     name = self.interpreter.flatten_args(node.args)[0]

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -113,7 +113,7 @@ class MTypeBase:
 
     def _new_node(self):
         # Overwrite in derived class
-        return BaseNode()
+        raise RewriterException('Internal error: _new_node of MTypeBase was called')
 
     def can_modify(self):
         return self.node_type is not None
@@ -189,7 +189,7 @@ class MTypeList(MTypeBase):
 
     def _new_element_node(self, value):
         # Overwrite in derived class
-        return BaseNode()
+        raise RewriterException('Internal error: _new_element_node of MTypeList was called')
 
     def _ensure_array_node(self):
         if not isinstance(self.node, ArrayNode):
@@ -522,6 +522,8 @@ class Rewriter:
             mlog.error('Unable to find the function node')
         assert(isinstance(node, FunctionNode))
         assert(isinstance(arg_node, ArgumentNode))
+        # Transform the key nodes to plain strings
+        arg_node.kwargs = {k.value: v for k, v in arg_node.kwargs.items()}
 
         # Print kwargs info
         if cmd['operation'] == 'info':
@@ -585,6 +587,8 @@ class Rewriter:
             arg_node.kwargs[key] = modifyer.get_node()
             num_changed += 1
 
+        # Convert the keys back to IdNode's
+        arg_node.kwargs = {IdNode(Token('', '', 0, 0, 0, None, k)): v for k, v in arg_node.kwargs.items()}
         if num_changed > 0 and node not in self.modefied_nodes:
             self.modefied_nodes += [node]
 

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -159,7 +159,7 @@ class MTypeBool(MTypeBase):
         super().__init__(node)
 
     def _new_node(self):
-        return StringNode(Token('', '', 0, 0, 0, None, False))
+        return BooleanNode(Token('', '', 0, 0, 0, None, False))
 
     def supported_nodes(self):
         return [BooleanNode]
@@ -172,7 +172,7 @@ class MTypeID(MTypeBase):
         super().__init__(node)
 
     def _new_node(self):
-        return StringNode(Token('', '', 0, 0, 0, None, ''))
+        return IdNode(Token('', '', 0, 0, 0, None, ''))
 
     def supported_nodes(self):
         return [IdNode]

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -593,7 +593,7 @@ class Rewriter:
             self.modefied_nodes += [node]
 
     def find_assignment_node(self, node: BaseNode) -> AssignmentNode:
-        if hasattr(node, 'ast_id') and node.ast_id in self.interpreter.reverse_assignment:
+        if node.ast_id and node.ast_id in self.interpreter.reverse_assignment:
             return self.interpreter.reverse_assignment[node.ast_id]
         return None
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1398,7 +1398,7 @@ class DataTests(unittest.TestCase):
         '''
         env = get_fake_env()
         interp = Interpreter(FakeBuild(env), mock=True)
-        astint = AstInterpreter('.', '')
+        astint = AstInterpreter('.', '', '')
         self.assertEqual(set(interp.funcs.keys()), set(astint.funcs.keys()))
 
 


### PR DESCRIPTION
I tried to keep this PR to mostly only adding type annotations and making mypy happy. However, there were some situations where blindly adding types didn't make any sense, and some slight code refactoring was necessary.

The biggest change is that the ArgumentNode now always uses nodes (instead of sometimes nodes and sometimes strings) as the key for kwargs. I wouldn't say that this is ideal, but it is now clearly documented in the type system and mypy will complain if you use it wrong (also I couldn't think of a better solution).