### PR TITLE
mintro: include test protocol in introspection data

### DIFF
--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -235,7 +235,7 @@ When these tests fail, the user probably wants to run the failing test in a
 debugger. To make this as integrated as possible, extract the tests from the
 `intro-tests.json` and `intro-benchmarks.json` files. This provides you with
 all the information needed to run the test: what command to execute, command
-line arguments and environment variable settings.
+line arguments, environment variable settings and how to process the output.
 
 ```json
 {
@@ -244,6 +244,7 @@ line arguments and environment variable settings.
     "timeout": "the test timeout",
     "suite": ["list", "of", "test", "suites"],
     "is_parallel": true / false,
+    "protocol": "exitcode" / "tap",
     "cmd": ["command", "to", "run"],
     "env": {
         "VARIABLE1": "value 1",

--- a/docs/markdown/snippets/introspect.md
+++ b/docs/markdown/snippets/introspect.md
@@ -5,3 +5,7 @@ dependencies (--dependencies, intro-dependencies.json):
 
 scanning dependencies (--scan-dependencies):
 - added the `version` key containing the required dependency version
+
+tests and benchmarks (--tests, --benchmarks, intro-tests.json,
+intro-benchmarks.json):
+- added the `protocol` key

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -302,6 +302,7 @@ def get_test_list(testdata) -> List[Dict[str, Union[str, int, List[str], Dict[st
         to['suite'] = t.suite
         to['is_parallel'] = t.is_parallel
         to['priority'] = t.priority
+        to['protocol'] = t.protocol
         result.append(to)
     return result
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2620,7 +2620,6 @@ int main(int argc, char **argv) {
                                          'disttest-1.4.3/subprojects/vcssub/meson.build']),
                                  sorted(z.namelist()))
 
-
     def test_rpath_uses_ORIGIN(self):
         '''
         Test that built targets use $ORIGIN in rpath, which ensures that they

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3812,6 +3812,7 @@ recommended as it is not supported on some platforms''')
             ('timeout', int),
             ('suite', list),
             ('is_parallel', bool),
+            ('protocol', str),
         ]
 
         buildoptions_keylist = [


### PR DESCRIPTION
The protocol is needed for an external test runner to parse the output correctly.