### PR TITLE
envconfig: Add MicroBlaze CPU family

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -54,6 +54,7 @@ set in the cross file.
 | arm                 | 32 bit ARM processor  |
 | e2k                 | MCST Elbrus processor |
 | ia64                | Itanium processor     |
+| microblaze          | MicroBlaze processor  |
 | mips                | 32 bit MIPS processor |
 | mips64              | 64 bit MIPS processor |
 | parisc              | HP PA-RISC processor  |

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -41,6 +41,7 @@ known_cpu_families = (
     'arm',
     'e2k',
     'ia64',
+    'microblaze',
     'mips',
     'mips64',
     'parisc',


### PR DESCRIPTION
Add the CPU family for the MicroBlaze processor.

Signed-off-by: Nathan Rossi <nathan@nathanrossi.com>