### PR TITLE
ci fortran: add case where buildtype=release and warning_level=3

### DIFF
--- a/test cases/fortran/20 buildtype/main.f90
+++ b/test cases/fortran/20 buildtype/main.f90
@@ -1,0 +1,1 @@
+end program

--- a/test cases/fortran/20 buildtype/meson.build
+++ b/test cases/fortran/20 buildtype/meson.build
@@ -1,0 +1,5 @@
+# checks for unexpected behavior on non-default buildtype and warning_level
+project('build type Fortran', 'fortran',
+  default_options: ['buildtype=release', 'warning_level=3'])
+
+executable('main', 'main.f90')


### PR DESCRIPTION
this can find issues with non-default build options. 
Another PR will be forthcoming to fix what I discovered with this test.