### PR TITLE
intel/intel-cl: bugfix: handle arguments in intel-specific way

### DIFF
--- a/.github/workflows/lint_mypy.yml
+++ b/.github/workflows/lint_mypy.yml
@@ -30,4 +30,4 @@ jobs:
       with:
         python-version: '3.x'
     - run: python -m pip install mypy
-    - run: mypy --follow-imports=skip  mesonbuild/mtest.py mesonbuild/minit.py mesonbuild/mintro.py mesonbuild/msetup.py mesonbuild/wrap tools/ mesonbuild/modules/fs.py mesonbuild/dependencies/mpi.py mesonbuild/dependencies/hdf5.py
+    - run: mypy --follow-imports=skip  mesonbuild/mtest.py mesonbuild/minit.py mesonbuild/mintro.py mesonbuild/msetup.py mesonbuild/wrap tools/ mesonbuild/modules/fs.py mesonbuild/dependencies/mpi.py mesonbuild/dependencies/hdf5.py mesonbuild/compilers/mixins/intel.py

--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -41,26 +41,32 @@ if typing.TYPE_CHECKING:
 # https://software.intel.com/en-us/fortran-compiler-developer-guide-and-reference-g
 # https://software.intel.com/en-us/fortran-compiler-developer-guide-and-reference-traceback
 # https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
-clike_optimization_args = {
-    '0': ['-O0'],
-    'g': ['-O0'],
-    '1': ['-O1'],
-    '2': ['-O2'],
-    '3': ['-O3'],
-    's': ['-Os'],
-}  # type: typing.Dict[str, typing.List[str]]
 
 
-# Tested on linux for ICC 14.0.3, 15.0.6, 16.0.4, 17.0.1, 19.0.0
 class IntelGnuLikeCompiler(GnuLikeCompiler):
+    """
+    Tested on linux for ICC 14.0.3, 15.0.6, 16.0.4, 17.0.1, 19.0
+    debugoptimized: -g -O2
+    release: -O3
+    minsize: -O2
+    """
 
     BUILD_ARGS = {
         'plain': [],
-        'debug': ["-g", "-O0", "-traceback"],
-        'debugoptimized': ["-g", "-O1", "-traceback"],
-        'release': ["-O2"],
-        'minsize': ["-Os"],
+        'debug': ["-g", "-traceback"],
+        'debugoptimized': ["-g", "-traceback"],
+        'release': [],
+        'minsize': [],
         'custom': [],
+    }  # type: typing.Dict[str, typing.List[str]]
+
+    OPTIM_ARGS = {
+        '0': ['-O0'],
+        'g': ['-O0'],
+        '1': ['-O1'],
+        '2': ['-O2'],
+        '3': ['-O3'],
+        's': ['-Os'],
     }
 
     def __init__(self):
@@ -74,9 +80,6 @@ class IntelGnuLikeCompiler(GnuLikeCompiler):
                              'b_coverage', 'b_ndebug', 'b_staticpic', 'b_pie']
         self.id = 'intel'
         self.lang_header = 'none'
-
-    def get_optimization_args(self, optimization_level: str) -> typing.List[str]:
-        return clike_optimization_args[optimization_level]
 
     def get_pch_suffix(self) -> str:
         return 'pchi'
@@ -119,6 +122,9 @@ class IntelGnuLikeCompiler(GnuLikeCompiler):
     def get_buildtype_args(self, buildtype: str) -> typing.List[str]:
         return self.BUILD_ARGS[buildtype]
 
+    def get_optimization_args(self, optimization_level: str) -> typing.List[str]:
+        return self.OPTIM_ARGS[optimization_level]
+
 
 class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
 
@@ -126,11 +132,20 @@ class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
 
     BUILD_ARGS = {
         'plain': [],
-        'debug': ["/Zi", "/Od", "/traceback"],
-        'debugoptimized': ["/Zi", "/O1", "/traceback"],
-        'release': ["/O2"],
-        'minsize': ["/Os"],
+        'debug': ["/Zi", "/traceback"],
+        'debugoptimized': ["/Zi", "/traceback"],
+        'release': [],
+        'minsize': [],
         'custom': [],
+    }  # type: typing.Dict[str, typing.List[str]]
+
+    OPTIM_ARGS = {
+        '0': ['/O0'],
+        'g': ['/O0'],
+        '1': ['/O1'],
+        '2': ['/O2'],
+        '3': ['/O3'],
+        's': ['/Os'],
     }
 
     def __init__(self, target: str):
@@ -168,3 +183,6 @@ class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
 
     def get_buildtype_args(self, buildtype: str) -> typing.List[str]:
         return self.BUILD_ARGS[buildtype]
+
+    def get_optimization_args(self, optimization_level: str) -> typing.List[str]:
+        return self.OPTIM_ARGS[optimization_level]


### PR DESCRIPTION
intel compiler's defaults are different enough from MSVC and GNU
that it's necessary to set specific defaults for Intel compilers.

This corrects/improves behaviors initially addressed in  #6275,
which introduced some duplicated/conflicting arguments.

Specifically, prior to this PR, unintended behavior included:

* Intel-Cl: optimization was still enabled on `debug` builds
* Intel: clashing -O2 -O3 release arguments unintentionally overriding and duplicated -O0 on debug

on this PR, I was more careful to manually inspect build.ninja across `buildtype` to verify the intended arguments were sent, considering the unique defaults of Intel compilers distinct from GNU/MSVC.