### PR TITLE
mlog: Add a log_once method and start using it

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -326,8 +326,6 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
 
     """Intel "ICL" compiler abstraction."""
 
-    __have_warned = False
-
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross, info: 'MachineInfo', exe_wrap, target, **kwargs):
         CCompiler.__init__(self, exelist, version, for_machine, is_cross,
@@ -346,9 +344,7 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
         args = []
         std = options['c_std']
         if std.value == 'c89':
-            if not self.__have_warned:
-                self.__have_warned = True
-                mlog.warning("ICL doesn't explicitly implement c89, setting the standard to 'none', which is close.")
+            mlog.warning("ICL doesn't explicitly implement c89, setting the standard to 'none', which is close.", once=True)
         elif std.value != 'none':
             args.append('/Qstd:' + std.value)
         return args

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -484,7 +484,7 @@ class CPP11AsCPP14Mixin:
         # if one is using anything before that point, one cannot set the standard.
         if options['cpp_std'].value in {'vc++11', 'c++11'}:
             mlog.warning(self.id, 'does not support C++11;',
-                         'attempting best effort; setting the standard to C++14')
+                         'attempting best effort; setting the standard to C++14', once=True)
             # Don't mutate anything we're going to change, we need to use
             # deepcopy since we're messing with members, and we can't simply
             # copy the members because the option proxy doesn't support it.

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -160,7 +160,6 @@ def process_markup(args: Sequence[Union[AnsiDecorator, str]], keep: bool) -> Lis
     return arr
 
 def force_print(*args: str, **kwargs: Any) -> None:
-    global log_disable_stdout
     if log_disable_stdout:
         return
     iostr = io.StringIO()
@@ -197,7 +196,6 @@ def cmd_ci_include(file: str) -> None:
 
 def log(*args: Union[str, AnsiDecorator], is_error: bool = False,
         **kwargs: Any) -> None:
-    global log_errors_only
     arr = process_markup(args, False)
     if log_file is not None:
         print(*arr, file=log_file, **kwargs)

--- a/run_tests.py
+++ b/run_tests.py
@@ -211,7 +211,7 @@ def get_backend_commands(backend, debug=False):
                 if v == '1.9':
                     NINJA_1_9_OR_NEWER = True
                 else:
-                    print('Found ninja <1.9, tests will run slower')
+                    mlog.warning('Found ninja <1.9, tests will run slower', once=True)
                     if 'CI' in os.environ:
                         raise RuntimeError('Require ninja >= 1.9 when running on Meson CI')
                 break
@@ -238,12 +238,12 @@ def ensure_backend_detects_changes(backend):
     # XXX: Upgrade Travis image to Apple FS when that becomes available
     # TODO: Detect HFS+ vs APFS
     if mesonlib.is_osx():
-        print('Running on HFS+, enabling timestamp resolution workaround')
+        mlog.warning('Running on HFS+, enabling timestamp resolution workaround', once=True)
         need_workaround = True
     # We're using ninja >= 1.9 which has QuLogic's patch for sub-1s resolution
     # timestamps
     if not NINJA_1_9_OR_NEWER:
-        print('Don\'t have ninja >= 1.9, enabling timestamp resolution workaround')
+        mlog.warning('Don\'t have ninja >= 1.9, enabling timestamp resolution workaround', once=True)
         need_workaround = True
     # Increase the difference between build.ninja's timestamp and the timestamp
     # of whatever you changed: https://github.com/ninja-build/ninja/issues/371

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1141,6 +1141,35 @@ class InternalTests(unittest.TestCase):
             deps = d.get_all_dependencies(target)
             self.assertEqual(deps, expdeps)
 
+    def test_log_once(self):
+        f = io.StringIO()
+        with mock.patch('mesonbuild.mlog.log_file', f), \
+                mock.patch('mesonbuild.mlog._logged_once', set()):
+            mesonbuild.mlog.log_once('foo')
+            mesonbuild.mlog.log_once('foo')
+            actual = f.getvalue().strip()
+            self.assertEqual(actual, 'foo', actual)
+
+    def test_log_once_ansi(self):
+        f = io.StringIO()
+        with mock.patch('mesonbuild.mlog.log_file', f), \
+                mock.patch('mesonbuild.mlog._logged_once', set()):
+            mesonbuild.mlog.log_once(mesonbuild.mlog.bold('foo'))
+            mesonbuild.mlog.log_once(mesonbuild.mlog.bold('foo'))
+            actual = f.getvalue().strip()
+            self.assertEqual(actual.count('foo'), 1, actual)
+
+            mesonbuild.mlog.log_once('foo')
+            actual = f.getvalue().strip()
+            self.assertEqual(actual.count('foo'), 1, actual)
+
+            f.truncate()
+
+            mesonbuild.mlog.warning('bar', once=True)
+            mesonbuild.mlog.warning('bar', once=True)
+            actual = f.getvalue().strip()
+            self.assertEqual(actual.count('bar'), 1, actual)
+
 
 @unittest.skipIf(is_tarball(), 'Skipping because this is a tarball release')
 class DataTests(unittest.TestCase):


### PR DESCRIPTION
Mostly I hate that the CI log is completely full of "ninja < 1.9" warnings, but there's other cases where we messages multiple times when it's not useful. Adding a single tested method for this makes more sense than doing it ad hoc in multiple places.