### PR TITLE
ci cmake: Windows link.exe skip due to symbol issues

### DIFF
--- a/test cases/cmake/5 object library/main.cpp
+++ b/test cases/cmake/5 object library/main.cpp
@@ -6,4 +6,5 @@ using namespace std;
 
 int main(void) {
   cout << getLibStr() << " -- " << getZlibVers() << endl;
+  return EXIT_SUCCESS;
 }

--- a/test cases/cmake/5 object library/meson.build
+++ b/test cases/cmake/5 object library/meson.build
@@ -1,12 +1,13 @@
-project('cmake_object_lib_test', ['c', 'cpp'])
+project('cmake_object_lib_test', 'cpp')
 
 dep_test = dependency('ZLIB', method: 'cmake', required: false)
 if not dep_test.found()
   error('MESON_SKIP_TEST: zlib is not installed')
 endif
 
-if build_machine.system() == 'windows'
-  error('MESON_SKIP_TEST: Windows is not supported because of symbol export problems')
+cpp = meson.get_compiler('cpp')
+if build_machine.system() == 'windows' and cpp.get_id() != 'gcc'
+  error('MESON_SKIP_TEST: Windows link.exe is not supported because of symbol export problems')
 endif
 
 cm = import('cmake')

--- a/test cases/cmake/5 object library/subprojects/cmObjLib/CMakeLists.txt
+++ b/test cases/cmake/5 object library/subprojects/cmObjLib/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.7)
-project(cmObject)
+project(cmObject CXX)
 
 find_package(ZLIB REQUIRED)
 

--- a/test cases/cmake/5 object library/subprojects/cmObjLib/libA.cpp
+++ b/test cases/cmake/5 object library/subprojects/cmObjLib/libA.cpp
@@ -1,5 +1,5 @@
 #include "libA.hpp"
 
-std::string getLibStr() {
+std::string getLibStr(void) {
   return "Hello World";
 }

--- a/test cases/cmake/5 object library/subprojects/cmObjLib/libB.cpp
+++ b/test cases/cmake/5 object library/subprojects/cmObjLib/libB.cpp
@@ -1,6 +1,6 @@
 #include "libB.hpp"
 #include <zlib.h>
 
-std::string getZlibVers() {
+std::string getZlibVers(void) {
   return zlibVersion();
 }

--- a/test cases/cmake/6 object library no dep/main.cpp
+++ b/test cases/cmake/6 object library no dep/main.cpp
@@ -6,4 +6,5 @@ using namespace std;
 
 int main(void) {
   cout << getLibStr() << " -- " << getZlibVers() << endl;
+  return EXIT_SUCCESS;
 }

--- a/test cases/cmake/6 object library no dep/meson.build
+++ b/test cases/cmake/6 object library no dep/meson.build
@@ -1,7 +1,8 @@
-project('cmake_object_lib_test', ['c', 'cpp'])
+project('cmake_object_lib_test', 'cpp')
 
-if build_machine.system() == 'windows'
-  error('MESON_SKIP_TEST: Windows is not supported because of symbol export problems')
+cpp = meson.get_compiler('cpp')
+if build_machine.system() == 'windows' and cpp.get_id() != 'gcc'
+  error('MESON_SKIP_TEST: Windows link.exe is not supported because of symbol export problems')
 endif
 
 cm = import('cmake')

--- a/test cases/cmake/6 object library no dep/subprojects/cmObjLib/CMakeLists.txt
+++ b/test cases/cmake/6 object library no dep/subprojects/cmObjLib/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.7)
-project(cmObject)
+project(cmObject CXX)
 
 add_library(lib_obj OBJECT libA.cpp libB.cpp)
 add_library(lib_sha SHARED $<TARGET_OBJECTS:lib_obj>)

--- a/test cases/cmake/6 object library no dep/subprojects/cmObjLib/libA.cpp
+++ b/test cases/cmake/6 object library no dep/subprojects/cmObjLib/libA.cpp
@@ -1,5 +1,5 @@
 #include "libA.hpp"
 
-std::string getLibStr() {
+std::string getLibStr(void) {
   return "Hello World";
 }

--- a/test cases/cmake/6 object library no dep/subprojects/cmObjLib/libB.cpp
+++ b/test cases/cmake/6 object library no dep/subprojects/cmObjLib/libB.cpp
@@ -1,5 +1,5 @@
 #include "libB.hpp"
 
-std::string getZlibVers() {
+std::string getZlibVers(void) {
   return "STUB";
 }


### PR DESCRIPTION
test cases/cmake/{5,6} are OK with Windows using GCC, since that doesn't link with link.exe, so don't skip that case. 

code quality edits to the tests themselves to avoid compile warnings or failures.

restarted this since #6324 got messed up re: Github, it kept wanting to include prior unrelated commits in the PR.