### PR TITLE
add compiler.get_linker_id() method

### DIFF
--- a/docs/markdown/Compiler-properties.md
+++ b/docs/markdown/Compiler-properties.md
@@ -25,13 +25,16 @@ know the operating system your code will run on, issue this command:
 host_machine.system()
 ```
 
-Compiler id
-==
+## Compiler id
 
-The compiler object has a method called `get_id`, which returns a
-lower case string describing the "family" of the compiler.
+The compiler object method `get_id` returns a
+lower case string describing the "family" of the compiler. Since 0.53.0
+`get_linker_id` returns a lower case string with the linker name. Since
+compilers can often choose from multiple linkers depending on operating
+system, `get_linker_id` can be useful for handling or mitigating effects
+of particular linkers.
 
-The compiler object also has a method `get_argument_syntax` which 
+The compiler object also has a method `get_argument_syntax` which
 returns a lower case string of `gcc`, `msvc`, or another undefined string
 value; identifying whether the compiler arguments use the same syntax as
 either `gcc` or `msvc`, or that its arguments are not like either. This should
@@ -41,11 +44,14 @@ with `has_argument`.
 See [reference tables](Reference-tables.md#compiler-ids) for a list of supported compiler
 ids and their argument type.
 
-Does code compile?
-==
+## Does code compile?
 
 Sometimes the only way to test the system is to try to compile some
-sample code and see if it works. This is a two-phase operation. First
+sample code and see if it works. For example, this can test that a
+"C++17" compiler actually supports a particular C++17 feature,
+without resorting to maintaining a feature list vs. compiler vendor,
+compiler version and operating system.
+Testing that a code snippet runs is a two-phase operation. First
 we define some code using the multiline string operator:
 
 ```meson
@@ -65,8 +71,7 @@ depending on whether the compilation succeeded or not. The keyword
 argument `name` is optional. If it is specified, Meson will write the
 result of the check to its log.
 
-Does code compile and link?
-==
+## Does code compile and link?
 
 Sometimes it is necessary to check whether a certain code fragment not
 only compiles, but also links successfully, e.g. to check if a symbol
@@ -90,11 +95,11 @@ depending on whether the compilation and linking succeeded or not. The
 keyword argument `name` is optional. If it is specified, Meson will
 write the result of the check to its log.
 
-
-Compile and run test application
-==
+## Compile and run test application
 
 Here is how you would compile and run a small test application.
+Testing if a code snippets **runs** versus merely that it links
+is particularly important for some dependencies such as MPI.
 
 ```meson
 code = '''#include<stdio.h>
@@ -126,9 +131,7 @@ if result.stdout().strip() == 'some_value'
 endif
 ```
 
-
-Does a header exist?
-==
+## Does a header exist?
 
 Header files provided by different platforms vary quite a lot. Meson
 has functionality to detect whether a given header file is available
@@ -142,8 +145,7 @@ if compiler.has_header('sys/fstat.h')
 endif
 ```
 
-Expression size
-==
+## Expression size
 
 Often you need to determine the size of a particular element (such as
 `int`, `wchar_t` or `char*`). Using the `compiler` variable mentioned
@@ -163,8 +165,7 @@ In older versions (<= 0.30) meson would error out if the size could
 not be determined. Since version 0.31 it returns -1 if the size could
 not be determined.
 
-Does a function exist?
-==
+## Does a function exist?
 
 Just having a header doesn't say anything about its
 contents. Sometimes you need to explicitly check if some function
@@ -192,8 +193,7 @@ report the function as missing. Without the header however, it would lack
 the necessary availability information and incorrectly report the function
 as available.
 
-Does a structure contain a member?
-==
+## Does a structure contain a member?
 
 Some platforms have different standard structures. Here's how one
 would check if a struct called `mystruct` from header `myheader.h`
@@ -205,8 +205,7 @@ if compiler.has_member('struct mystruct', 'some_member', prefix : '#include<myhe
 endif
 ```
 
-Type alignment
-==
+## Type alignment
 
 Most platforms can't access some data types at any address. For
 example it is common that a `char` can be at any address but a 32 bit

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -6,7 +6,6 @@ The following functions are available in build files. Click on each to
 see the description and usage. The objects returned by them are [list
 afterwards](#returned-objects).
 
-
 ### add_global_arguments()
 
 ``` meson
@@ -2049,6 +2048,9 @@ the following methods:
   gcc or msvc, but use the same argument syntax as one of those two compilers
   such as clang or icc, especially when they use different syntax on different
   operating systems.
+
+- `get_linker_id()` *(added 0.53.0)* returns a string identifying the linker.
+   For example, `ld.bfd`, `link`, [and more](Reference-tables.md#linker-ids).
 
 - `get_supported_arguments(list_of_string)` *(added 0.43.0)* returns
   an array containing only the arguments supported by the compiler,

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -31,6 +31,19 @@ These are return values of the `get_id` (Compiler family) and
 | sun       | Sun Fortran compiler             |                 |
 | valac     | Vala compiler                    |                 |
 
+## Linker ids
+
+These are return values of the `get_linker_id` (Linker family) method in a compiler object.
+
+| Value     | Linker family                              |
+| -----     | ---------------                            |
+| ld.bfd    | GNU Compiler Collection                    |
+| {ld.bfd,lld} | Clang non-Windows                       |
+| link      | MSVC, Clang-cl, clang Windows              |
+| pgi       | Portland/Nvidia PGI                        |
+| {ld.bfd,gold,xild}  | Intel compiler non-Windows       |
+| xilink    | Intel-cl Windows                           |
+
 ## Script environment variables
 
 | Value               | Comment                         |
@@ -41,15 +54,14 @@ These are return values of the `get_id` (Compiler family) and
 | MESON_SOURCE_ROOT   | Absolute path to the source dir |
 | MESON_SUBDIR        | Current subdirectory, only set for `run_command` |
 
-
 ## CPU families
 
 These are returned by the `cpu_family` method of `build_machine`,
 `host_machine` and `target_machine`. For cross compilation they are
 set in the cross file.
 
-| Value               | Comment                         |
-| -----               | -------                         |
+| Value               | Comment               |
+| -----               | -------               |
 | aarch64             | 64 bit ARM processor  |
 | alpha               | DEC Alpha processor   |
 | arc                 | 32 bit ARC processor  |
@@ -103,7 +115,6 @@ These are provided by the `.system()` method call.
 
 Any string not listed above is not guaranteed to remain stable in
 future releases.
-
 
 ## Language arguments parameter names
 

--- a/docs/markdown/snippets/get_linker_id.md
+++ b/docs/markdown/snippets/get_linker_id.md
@@ -1,0 +1,5 @@
+## compiler.get_linker_id()
+
+since 0.53.0, `compiler.get_linker_id()` allows retrieving a lowercase name for the linker.
+Since each compiler family can typically use a variety of linkers depending on operating system,
+this helps users define logic for corner cases not otherwise easily handled.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -723,6 +723,9 @@ class Compiler:
     def get_id(self) -> str:
         return self.id
 
+    def get_linker_id(self) -> str:
+        return self.linker.id
+
     def get_version_string(self) -> str:
         details = [self.id, self.version]
         if self.full_version:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1007,6 +1007,7 @@ class CompilerHolder(InterpreterObject):
         self.methods.update({'compiles': self.compiles_method,
                              'links': self.links_method,
                              'get_id': self.get_id_method,
+                             'get_linker_id': self.get_linker_id_method,
                              'compute_int': self.compute_int_method,
                              'sizeof': self.sizeof_method,
                              'get_define': self.get_define_method,
@@ -1160,6 +1161,12 @@ class CompilerHolder(InterpreterObject):
     @permittedKwargs({})
     def get_id_method(self, args, kwargs):
         return self.compiler.get_id()
+
+    @noPosargs
+    @permittedKwargs({})
+    @FeatureNew('compiler.get_linker_id', '0.53.0')
+    def get_linker_id_method(self, args, kwargs):
+        return self.compiler.get_linker_id()
 
     @noPosargs
     @permittedKwargs({})

--- a/test cases/common/31 compiler id/meson.build
+++ b/test cases/common/31 compiler id/meson.build
@@ -1,7 +1,15 @@
-project('compiler id', 'c')
+project('compiler_id')
 
-comp = meson.get_compiler('c')
-str = comp.get_id()
+foreach lang : ['c', 'cpp', 'fortran', 'objc', 'objcpp']
 
-message('Compiler name is:')
-message(str)
+  if not add_languages(lang, required: false)
+    continue
+  endif
+
+  comp = meson.get_compiler(lang)
+
+  message(lang + ' compiler name is: ' + comp.get_id())
+
+  message(lang + ' linker name is: ' + comp.get_linker_id())
+
+endforeach


### PR DESCRIPTION
add method
```meson
meson.get_compiler(...).get_linker_id() 
```

this can be useful for if/elif where linker behaviors must be considered.
E.g. linking between languages where a particular linker may be known to fail,
rather than doing if/elif on operating system and compiler.get_id(), as in #6347

Since many compilers can choose from multiple linkers in an OS-dependent way, and linker errors can be confusing to end users, this allows program developers using Meson to handle corner cases in ways not previously possible, with more obvious if/elif.

instead of
```meson
if meson.host_machine() == 'windows' and comp.get_id() != 'gcc'
```
now:
```meson
if comp.get_linker_id() != 'link'
```
which signals to meson.build readers more specifically what the if/elif logic is at first glance.