### PR TITLE
linkers: Remove get_allow_undefined_args from link.exe

### DIFF
--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -829,8 +829,7 @@ class VisualStudioLikeLinkerMixin:
         return l
 
     def get_allow_undefined_args(self) -> typing.List[str]:
-        # link.exe
-        return self._apply_prefix('/FORCE:UNRESOLVED')
+        return []
 
     def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
                         suffix: str, soversion: str, darwin_versions: typing.Tuple[str, str],


### PR DESCRIPTION
PE DLLs don't work like elf or mach-o, there's no way to define symbols
at run time, they must all be defined as import or export at link time.
As such there's no value in being able to have undefined symbols in
MSVC, nor does meson expose an option to change them

Fixes: #6342