### PR TITLE
Fix legacy env var support with cross

### DIFF
--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -12,19 +12,15 @@ When first running Meson, set it in an environment variable.
 $ CC=mycc meson <options>
 ```
 
-Note that environment variables like `CC` _always_ refer to the native
-compiler. That is, the compiler used to compile programs that run on
-the current machine. The compiler used in cross compilation is set
-with the cross file.
+Note that environment variables like `CC` only works in native builds. The `CC`
+refers to the compiler for the host platform, that is the compiler used to
+compile programs that run on the machine we will eventually install the project
+on. The compiler used to build things that run on the machine we do the
+building can be specified with `CC_FOR_BUILD`. You can use it in cross builds.
 
-This behaviour is different from e.g. Autotools, where cross
-compilation is done by setting `CC` to point to the cross compiler
-(such as `/usr/bin/arm-linux-gnueabihf-gcc`). The reason for this is
-that Meson supports natively the case where you compile helper tools
-(such as code generators) and use the results during the
-build. Because of this Meson needs to know both the native and the
-cross compiler. The former is set via the environment variables or
-native-files and the latter via the cross file only.
+Note that environment variables are never the idiomatic way to do anything with
+Meson, however. It is better to use the native and cross files. And the tools
+for the host platform in cross builds can only be specified with a cross file.
 
 There is a table of all environment variables supported [Here](Reference-tables.md#compiler-and-linker-selection-variables)
 

--- a/docs/markdown/snippets/env_vars_and_cross.md
+++ b/docs/markdown/snippets/env_vars_and_cross.md
@@ -1,0 +1,12 @@
+## Environment Variables with Cross Builds
+
+Previously in Meson, variables like `CC` effected both the host and build
+platforms for native builds, but the just the build platform for cross builds.
+Now `CC_FOR_BUILD` is used for the build platform in cross builds.
+
+This old behavior is inconsistent with the way Autotools works, which
+undermines the purpose of distro-integration that is the only reason
+environment variables are supported at all in Meson. The new behavior is not
+quite the same, but doesn't conflict: meson doesn't always repond to an
+environment when Autoconf would, but when it does it interprets it as Autotools
+would.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1044,7 +1044,7 @@ class Backend:
             subprocess.check_call(cmd, env=child_env)
 
     def create_install_data(self):
-        strip_bin = self.environment.binaries.host.lookup_entry('strip')
+        strip_bin = self.environment.lookup_binary_entry(MachineChoice.HOST, 'strip')
         if strip_bin is None:
             if self.environment.is_cross_build():
                 mlog.warning('Cross file does not specify strip binary, result will not be stripped.')

--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -66,7 +66,7 @@ class CMakeExecutor:
         # Create an iterator of options
         def search():
             # Lookup in cross or machine file.
-            potential_cmakepath = environment.binaries[self.for_machine].lookup_entry('cmake')
+            potential_cmakepath = environment.lookup_binary_entry(self.for_machine, 'cmake')
             if potential_cmakepath is not None:
                 mlog.debug('CMake binary for %s specified from cross file, native file, or env var as %s.', self.for_machine, potential_cmakepath)
                 yield ExternalProgram.from_entry('cmake', potential_cmakepath)

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -17,6 +17,7 @@ import typing as T
 
 from .. import coredata
 from ..mesonlib import MachineChoice, MesonException, mlog, version_compare
+from ..linkers import LinkerEnvVarsMixin
 from .c_function_attributes import C_FUNC_ATTRIBUTES
 from .mixins.clike import CLikeCompiler
 from .mixins.ccrx import CcrxCompiler
@@ -29,7 +30,6 @@ from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler
 from .mixins.elbrus import ElbrusCompiler
 from .mixins.pgi import PGICompiler
-from .mixins.islinker import LinkerEnvVarsMixin
 from .mixins.emscripten import EmscriptenMixin
 from .compilers import (
     gnu_winlibs,

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -21,6 +21,7 @@ from .. import coredata
 from .. import mlog
 from ..mesonlib import MesonException, MachineChoice, version_compare
 
+from ..linkers import LinkerEnvVarsMixin
 from .compilers import (
     gnu_winlibs,
     msvc_winlibs,
@@ -37,7 +38,6 @@ from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler
 from .mixins.elbrus import ElbrusCompiler
 from .mixins.pgi import PGICompiler
-from .mixins.islinker import LinkerEnvVarsMixin
 from .mixins.emscripten import EmscriptenMixin
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/compilers/mixins/islinker.py
+++ b/mesonbuild/compilers/mixins/islinker.py
@@ -20,7 +20,6 @@ are both the linker and compiler in one binary. This module provides mixin
 classes for those cases.
 """
 
-import os
 import typing as T
 
 from ... import mesonlib
@@ -28,17 +27,6 @@ from ... import mesonlib
 if T.TYPE_CHECKING:
     from ...coredata import OptionDictType
     from ...environment import Environment
-
-
-class LinkerEnvVarsMixin:
-
-    """Mixin reading LDFLAGS from the environment."""
-
-    def get_linker_args_from_envvars(self) -> T.List[str]:
-        flags = os.environ.get('LDFLAGS')
-        if not flags:
-            return []
-        return mesonlib.split_args(flags)
 
 
 class BasicLinkerIsCompilerMixin:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3136,13 +3136,12 @@ external dependencies (including libraries) must go to "dependencies".''')
         return success
 
     def program_from_file_for(self, for_machine, prognames, silent):
-        bins = self.environment.binaries[for_machine]
         for p in unholder(prognames):
             if isinstance(p, mesonlib.File):
                 continue # Always points to a local (i.e. self generated) file.
             if not isinstance(p, str):
                 raise InterpreterException('Executable name must be a string')
-            prog = ExternalProgram.from_bin_list(bins, p)
+            prog = ExternalProgram.from_bin_list(self.environment, for_machine, p)
             if prog.found():
                 return ExternalProgramHolder(prog)
         return None

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -19,7 +19,7 @@ import typing as T
 
 from pathlib import Path
 from .. import mesonlib
-from ..mesonlib import MesonException
+from ..mesonlib import MachineChoice, MesonException
 from . import ExtensionModule
 from mesonbuild.modules import ModuleReturnValue
 from ..interpreterbase import (
@@ -506,7 +506,7 @@ class PythonModule(ExtensionModule):
         if len(args) > 1:
             raise InvalidArguments('find_installation takes zero or one positional argument.')
 
-        name_or_path = state.environment.binaries.host.lookup_entry('python')
+        name_or_path = state.environment.lookup_binary_entry(MachineChoice.HOST, 'python')
         if name_or_path is None and args:
             name_or_path = args[0]
             if not isinstance(name_or_path, str):

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -48,7 +48,7 @@ class Python3Module(ExtensionModule):
 
     @noKwargs
     def find_python(self, state, args, kwargs):
-        command = state.environment.binaries.host.lookup_entry('python3')
+        command = state.environment.lookup_binary_entry(mesonlib.MachineChoice.HOST, 'python3')
         if command is not None:
             py3 = dependencies.ExternalProgram.from_entry('python3', command)
         else:

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -48,7 +48,7 @@ class WindowsModule(ExtensionModule):
             return self._rescomp
 
         # Will try cross / native file and then env var
-        rescomp = ExternalProgram.from_bin_list(state.environment.binaries[for_machine], 'windres')
+        rescomp = ExternalProgram.from_bin_list(state.environment, for_machine, 'windres')
 
         if not rescomp or not rescomp.found():
             comp = self.detect_compiler(state.environment.coredata.compilers[for_machine])

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1454,6 +1454,7 @@ class BasePlatformTests(unittest.TestCase):
         # FIXME: Extract this from argv?
         self.backend = getattr(Backend, os.environ.get('MESON_UNIT_TEST_BACKEND', 'ninja'))
         self.meson_args = ['--backend=' + self.backend.name]
+        self.meson_native_file = None
         self.meson_cross_file = None
         self.meson_command = python_command + [get_meson_script()]
         self.setup_command = self.meson_command + self.meson_args
@@ -1563,6 +1564,8 @@ class BasePlatformTests(unittest.TestCase):
         if default_args:
             args += ['--prefix', self.prefix,
                      '--libdir', self.libdir]
+            if self.meson_native_file:
+                args += ['--native-file', self.meson_native_file]
             if self.meson_cross_file:
                 args += ['--cross-file', self.meson_cross_file]
         self.privatedir = os.path.join(self.builddir, 'meson-private')
@@ -6303,8 +6306,30 @@ class LinuxlikeTests(BasePlatformTests):
 
     def test_identity_cross(self):
         testdir = os.path.join(self.unit_test_dir, '61 identity cross')
+
+        nativefile = tempfile.NamedTemporaryFile(mode='w')
+        nativefile.write('''[binaries]
+c = ['{0}']
+'''.format(os.path.join(testdir, 'build_wrapper.py')))
+        nativefile.flush()
+        self.meson_native_file = nativefile.name
+
         crossfile = tempfile.NamedTemporaryFile(mode='w')
-        env = {'CC': '"' + os.path.join(testdir, 'build_wrapper.py') + '"'}
+        crossfile.write('''[binaries]
+c = ['{0}']
+'''.format(os.path.join(testdir, 'host_wrapper.py')))
+        crossfile.flush()
+        self.meson_cross_file = crossfile.name
+
+        # TODO should someday be explicit about build platform only here
+        self.init(testdir)
+
+    def test_identity_cross_env(self):
+        testdir = os.path.join(self.unit_test_dir, '61 identity cross')
+        env = {
+            'CC_FOR_BUILD': '"' + os.path.join(testdir, 'build_wrapper.py') + '"',
+        }
+        crossfile = tempfile.NamedTemporaryFile(mode='w')
         crossfile.write('''[binaries]
 c = ['{0}']
 '''.format(os.path.join(testdir, 'host_wrapper.py')))


### PR DESCRIPTION
This fixes us to match Autoconf's behavior; see [the issue](https://github.com/mesonbuild/meson/issues/3969). It does however still keep it so the cross is the only way to control the host platform in cross builds.

CC @dcbaker

Fixes #3969 