### PR TITLE
Properly handle the case of linking static library with custom targets

### DIFF
--- a/test cases/common/228 link with custom target/meson.build
+++ b/test cases/common/228 link with custom target/meson.build
@@ -1,0 +1,7 @@
+project('link with custom targets', 'c')
+t = custom_target('dummy', output: [ 'libdummy.a' ], command: [ 'echo', 'dummy' ])
+dep1 = declare_dependency(link_with: t)
+dep2 = declare_dependency(link_with: t[0])
+
+static_library('lib1', 'empty.c', dependencies: dep1, install: true)
+static_library('lib2', 'empty.c', dependencies: dep2, install: true)


### PR DESCRIPTION
To avoid reintroduce the problem fixed by 484b72136995, when a static
library is linked with a custom target that is not installed, we need to
use link_whole(). However link_whole() explicitly doesn't work with
custom targets.

So this commit instead generates a warning when such a case is detected.

This commit also avoids a call to is_internal() on
CustomTarget/CustomTargetIndex objects, thus fixes #6365.

Signed-off-by: Yuxuan Shui <yshuiv7@gmail.com>