### PR TITLE
cmake: Use new JSON trace format for CMake >= 3.17

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -24,7 +24,7 @@ from .. import mlog
 from ..environment import Environment
 from ..mesonlib import MachineChoice, version_compare
 from ..compilers.compilers import lang_suffixes, header_suffixes, obj_suffixes, lib_suffixes, is_header
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, STDOUT
 from typing import Any, List, Dict, Optional, Union, TYPE_CHECKING
 from threading import Thread
 from enum import Enum
@@ -634,7 +634,7 @@ class CMakeInterpreter:
         self.languages = []
         self.targets = []
         self.custom_targets = []  # type: List[ConverterCustomTarget]
-        self.trace = CMakeTraceParser()
+        self.trace = CMakeTraceParser('', '')  # Will be replaced in analyse
         self.output_target_map = OutputTargetMap(self.build_dir)
 
         # Generated meson data
@@ -647,10 +647,11 @@ class CMakeInterpreter:
         cmake_exe = CMakeExecutor(self.env, '>=3.7', for_machine)
         if not cmake_exe.found():
             raise CMakeException('Unable to find CMake')
+        self.trace = CMakeTraceParser(cmake_exe.version(), self.build_dir, permissive=True)
 
         generator = backend_generator_map[self.backend_name]
         cmake_args = cmake_exe.get_command()
-        trace_args = ['--trace', '--trace-expand', '--no-warn-unused-cli']
+        trace_args = self.trace.trace_args()
         cmcmp_args = ['-DCMAKE_POLICY_WARNING_{}=OFF'.format(x) for x in disable_policy_warnings]
 
         if version_compare(cmake_exe.version(), '>=3.14'):
@@ -688,9 +689,42 @@ class CMakeInterpreter:
             os_env = os.environ.copy()
             os_env['LC_ALL'] = 'C'
             final_command = cmake_args + trace_args + cmcmp_args + [self.src_dir]
-            proc = Popen(final_command, stdout=PIPE, stderr=PIPE, cwd=self.build_dir, env=os_env)
 
-            def print_stdout():
+            if self.trace.requires_stderr():
+                proc = Popen(final_command, stdout=PIPE, stderr=PIPE, cwd=self.build_dir, env=os_env)
+
+                def print_stdout():
+                    while True:
+                        line = proc.stdout.readline()
+                        if not line:
+                            break
+                        mlog.log(line.decode('utf-8').strip('\n'))
+                    proc.stdout.close()
+
+                t = Thread(target=print_stdout)
+                t.start()
+
+                # Read stderr line by line and log non trace lines
+                self.raw_trace = ''
+                tline_start_reg = re.compile(r'^\s*(.*\.(cmake|txt))\(([0-9]+)\):\s*(\w+)\(.*$')
+                inside_multiline_trace = False
+                while True:
+                    line = proc.stderr.readline()
+                    if not line:
+                        break
+                    line = line.decode('utf-8')
+                    if tline_start_reg.match(line):
+                        self.raw_trace += line
+                        inside_multiline_trace = not line.endswith(' )\n')
+                    elif inside_multiline_trace:
+                        self.raw_trace += line
+                    else:
+                        mlog.warning(line.strip('\n'))
+
+                proc.stderr.close()
+                t.join()
+            else:
+                proc = Popen(final_command, stdout=PIPE, stderr=STDOUT, cwd=self.build_dir, env=os_env)
                 while True:
                     line = proc.stdout.readline()
                     if not line:
@@ -698,31 +732,7 @@ class CMakeInterpreter:
                     mlog.log(line.decode('utf-8').strip('\n'))
                 proc.stdout.close()
 
-            t = Thread(target=print_stdout)
-            t.start()
-
-            # Read stderr line by line and log non trace lines
-            self.raw_trace = ''
-            tline_start_reg = re.compile(r'^\s*(.*\.(cmake|txt))\(([0-9]+)\):\s*(\w+)\(.*$')
-            inside_multiline_trace = False
-            while True:
-                line = proc.stderr.readline()
-                if not line:
-                    break
-                line = line.decode('utf-8')
-                if tline_start_reg.match(line):
-                    self.raw_trace += line
-                    inside_multiline_trace = not line.endswith(' )\n')
-                elif inside_multiline_trace:
-                    self.raw_trace += line
-                else:
-                    mlog.warning(line.strip('\n'))
-
-            proc.stderr.close()
-            proc.wait()
-
-            t.join()
-
+        proc.wait()
         mlog.log()
         h = mlog.green('SUCCEEDED') if proc.returncode == 0 else mlog.red('FAILED')
         mlog.log('CMake configuration:', h)
@@ -781,7 +791,6 @@ class CMakeInterpreter:
         self.languages = []
         self.targets = []
         self.custom_targets = []
-        self.trace = CMakeTraceParser(permissive=True)
 
         # Parse the trace
         self.trace.parse(self.raw_trace)

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -396,6 +396,9 @@ class LLVMDependencyCMake(CMakeDependency):
         self.llvm_opt_modules = stringlistify(extract_as_list(kwargs, 'optional_modules'))
         super().__init__(name='LLVM', environment=env, language='cpp', kwargs=kwargs)
 
+        if self.traceparser is None:
+            return
+
         # Extract extra include directories and definitions
         inc_dirs = self.traceparser.get_cmake_var('PACKAGE_INCLUDE_DIRS')
         defs = self.traceparser.get_cmake_var('PACKAGE_DEFINITIONS')

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -916,7 +916,7 @@ def print_tool_versions():
         {
             'tool': 'cmake',
             'args': ['--version'],
-            'regex': re.compile(r'^cmake version ([0-9]+(\.[0-9]+)*)$'),
+            'regex': re.compile(r'^cmake version ([0-9]+(\.[0-9]+)*(-[a-z0-9]+)?)$'),
             'match_group': 1,
         },
     ]


### PR DESCRIPTION
Add support for the new JSON trace format, which is easier to parse (it is just JSON) and there is no longer any ambiguity with spaces. So we no longer have to do arcane magic tricks to determine which space is part of a path and which space separates arguments (at least once we have 3.17 as the minimum CMake version).

CMake merge request: https://gitlab.kitware.com/cmake/cmake/merge_requests/4102 (**currently open**)

The merge request is still open, but it should be in the final phases of the review and I don't expect any changes to the actual format. I am opening this PR already in the hope of getting this change into 0.53.0 just in case the CMake MR is merged before 22/12.