### PR TITLE
fs: rename samefile => is_samepath

### DIFF
--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -46,13 +46,13 @@ md5, sha1, sha224, sha256, sha384, sha512.
 The `fs.size(filename)` method returns the size of the file in integer bytes.
 Symlinks will be resolved if possible.
 
-### samefile
+### is_samepath
 
-The `fs.samefile(filename1, filename2)` returns boolean `true` if the input filenames refer to the same file.
-For example, suppose filename1 is a symlink and filename2 is a relative path.
-If filename1 can be resolved to a file that is the same file as filename2, then `true` is returned.
-If filename1 is not resolved to be the same as filename2, `false` is returned.
-If either filename does not exist, an error message is raised.
+The `fs.is_samepath(path1, path2)` returns boolean `true` if both paths resolve to the same path.
+For example, suppose path1 is a symlink and path2 is a relative path.
+If path1 can be resolved to path2, then `true` is returned.
+If path1 is not resolved to path2, `false` is returned.
+If path1 or path2 do not exist, `false` is returned.
 
 Examples:
 
@@ -60,9 +60,20 @@ Examples:
 x = 'foo.txt'
 y = 'sub/../foo.txt'
 z = 'bar.txt'  # a symlink pointing to foo.txt
+j = 'notafile.txt'  # non-existant file
 
-fs.samefile(x, y)  # true
-fs.samefile(x, z)  # true
+fs.is_samepath(x, y)  # true
+fs.is_samepath(x, z)  # true
+fs.is_samepath(x, j)  # false
+
+p = 'foo/bar'
+q = 'foo/bar/../baz'
+r = 'buz'  # a symlink pointing to foo/bar
+s = 'notapath'  # non-existant directory
+
+fs.is_samepath(p, q)  # true
+fs.is_samepath(p, r)  # true
+fs.is_samepath(p, s)  # false
 ```
 
 

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -95,19 +95,19 @@ class FSModule(ExtensionModule):
 
     @stringArgs
     @noKwargs
-    def samefile(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def is_samepath(self, state: 'ModuleState', args: typing.Sequence[str], kwargs: dict) -> ModuleReturnValue:
         if len(args) != 2:
-            raise MesonException('method takes exactly two arguments.')
+            raise MesonException('fs.is_samepath takes exactly two arguments.')
         file1 = self._resolve_dir(state, args[0])
         file2 = self._resolve_dir(state, args[1])
         if not file1.exists():
-            raise MesonException('{} is not a file, symlink or directory and therefore cannot be compared'.format(file1))
+            return ModuleReturnValue(False, [])
         if not file2.exists():
-            raise MesonException('{} is not a file, symlink or directory and therefore cannot be compared'.format(file2))
+            return ModuleReturnValue(False, [])
         try:
             return ModuleReturnValue(file1.samefile(file2), [])
         except OSError:
-            raise MesonException('{} could not be compared to {}'.format(file1, file2))
+            return ModuleReturnValue(False, [])
 
     @stringArgs
     @noKwargs

--- a/test cases/common/227 fs module/meson.build
+++ b/test cases/common/227 fs module/meson.build
@@ -62,11 +62,13 @@ assert(size == 19, 'file size not found correctly')
 # -- are filenames referring to the same file?
 f1 = 'meson.build'
 f2 = 'subdir/../meson.build'
-assert(fs.samefile(f1, f2), 'samefile not realized')
-assert(not fs.samefile(f1, 'subdir/subdirfile.txt'), 'samefile known bad comparison')
+assert(fs.is_samepath(f1, f2), 'is_samepath not detercting same files')
+assert(fs.is_samepath(meson.source_root(), 'subdir/..'), 'is_samepath not detecting same directory')
+assert(not fs.is_samepath(f1, 'subdir/subdirfile.txt'), 'is_samepath known bad comparison')
+assert(not fs.is_samepath('not-a-path', f2), 'is_samepath should not error if path(s) do not exist')
 
 if not is_windows and build_machine.system() != 'cygwin'
-  assert(fs.samefile('a_symlink', 'meson.build'), 'symlink samefile fail')
+  assert(fs.is_samepath('a_symlink', 'meson.build'), 'symlink is_samepath fail')
 endif
 
 assert(fs.parent('foo/bar') == 'foo', 'failed to get dirname')


### PR DESCRIPTION
is_samepath better reflects the nature of this function--that files
and directories can be compared.

Also, instead of raising exceptions, simply return False when one
or both .is_samepath(path1, path1) don't exist. This is more
intuitive behavior and avoids having an extra if fs.exist() to go
with every fs.is_samepath()