### PR TITLE
bugfix: netcdf pkgconfig stop if found

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -61,6 +61,8 @@ class NetCDFDependency(ExternalDependency):
                     self.version = pkgdep.get_version()
                     self.is_found = True
                     self.pcdep.append(pkgdep)
+            if self.is_found:
+                return
 
         if set([DependencyMethods.AUTO, DependencyMethods.CMAKE]).intersection(methods):
             cmakedep = CMakeDependency('NetCDF', environment, kwargs, language=self.language)


### PR DESCRIPTION
late merge request: This fixes an obvious error I made in #6355 in the logic for finding NetCDF with PkgConfig--I didn't stop the search if NetCDF was found with PkgConfig. This causes intermittent failures in finding NetCDF for Fortran, and was probably behind the NetCDF CI failures.

i.e. without this simple fix, 0.53.0 is *worse* than 0.52 for NetCDF