### PR TITLE
path() vs full_path() method

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2229,10 +2229,17 @@ A build target is either an [executable](#executable),
   some source files with custom flags. To use the object file(s)
   in another build target, use the `objects:` keyword argument.
 
-- `full_path()` returns a full path pointing to the result target file.
-  NOTE: In most cases using the object itself will do the same job as
+- `path()` returns a full path pointing to the result target file.
+  **NOTE:** In most cases using the object itself will do the same job as
   this and will also allow Meson to setup inter-target dependencies
   correctly. Please file a bug if that doesn't work for you.
+  One exception is explicitly concatenating the path with another
+  string; e.g., to set a var such as `shell_var = 'SHELL=' +
+  ksh.path()` that will be used to modify the environment of an external
+  program.
+
+- `full_path()` is an alias for `path()` but is deprecated and should not be
+  used. It may be removed at some future date.
 
 - `private_dir_include()` returns a opaque value that works like
   `include_directories` but points to the private directory of this
@@ -2283,10 +2290,17 @@ cause a syntax error.
 This object is returned by [`custom_target`](#custom_target) and
 contains a target with the following methods:
 
-- `full_path()` returns a full path pointing to the result target file
-  NOTE: In most cases using the object itself will do the same job as
+- `path()` returns a full path pointing to the result target file
+  **NOTE:** In most cases using the object itself will do the same job as
   this and will also allow Meson to setup inter-target dependencies
   correctly. Please file a bug if that doesn't work for you.
+  One exception is explicitly concatenating the path with another
+  string; e.g., to set a var such as `shell_var = 'SHELL=' +
+  ksh.path()` that will be used to modify the environment of an external
+  program.
+
+- `full_path()` is an alias for `path()` but is deprecated and should not be
+  used. It may be removed at some future date.
 
 - `[index]` returns an opaque object that references this target, and
   can be used as a source in other targets. When it is used as such it
@@ -2392,7 +2406,14 @@ and has the following methods:
 
 - `path()` which returns a string pointing to the script or executable
   **NOTE:** You should not need to use this method. Passing the object
-  itself should work in all cases. For example: `run_command(obj, arg1, arg2)`
+  itself should work in all cases. For example: `run_command(obj, arg1, arg2)`.
+  One exception is explicitly concatenating the path with another
+  string; e.g., to set a var such as `shell_var = 'SHELL=' +
+  ksh.path()` that will be used to modify the environment of an external
+  program.
+
+- `full_path()` is an alias for `path()` but is deprecated and should not be
+  used. It may be removed at some future date.
 
 ### `environment` object
 

--- a/docs/markdown/Release-notes.md
+++ b/docs/markdown/Release-notes.md
@@ -1,1 +1,9 @@
 # Release notes
+
+## find_program(), executable(), and custom_target() object methods
+
+The object returned by `find_program()` supported only a `path()`
+method while `executable()` and `custom_target()` supported only a
+`full_path()` method.  With this release all three objects support both
+methods; however, the `full_path()` method is deprecated and might be
+removed at some future date.  See issue #6375.

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -410,9 +410,9 @@ class BoostDependency(ExternalDependency):
                     self.libdir = libdir
                     break
                 if lib_sf:
-                    full_path = os.path.join(root, lib_sf)
-                    if os.path.isdir(full_path):
-                        self.libdir = full_path
+                    abs_path = os.path.join(root, lib_sf)
+                    if os.path.isdir(abs_path):
+                        self.libdir = abs_path
                         break
 
         if not self.libdir:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -510,7 +510,7 @@ class ExternalProgramHolder(InterpreterObject, ObjectHolder):
         InterpreterObject.__init__(self)
         ObjectHolder.__init__(self, ep)
         self.methods.update({'found': self.found_method,
-                             'path': self.path_method})
+                             'path': self.abs_path_method})
         self.cached_version = None
 
     @noPosargs
@@ -520,7 +520,7 @@ class ExternalProgramHolder(InterpreterObject, ObjectHolder):
 
     @noPosargs
     @permittedKwargs({})
-    def path_method(self, args, kwargs):
+    def abs_path_method(self, args, kwargs):
         return self.held_object.get_path()
 
     def found(self):
@@ -769,7 +769,8 @@ class BuildTargetHolder(TargetHolder):
                              'extract_all_objects': self.extract_all_objects_method,
                              'get_id': self.get_id_method,
                              'outdir': self.outdir_method,
-                             'full_path': self.full_path_method,
+                             'full_path': self.abs_path_method,  # deprecated
+                             'path': self.abs_path_method,
                              'private_dir_include': self.private_dir_include_method,
                              })
 
@@ -789,7 +790,7 @@ class BuildTargetHolder(TargetHolder):
 
     @noPosargs
     @permittedKwargs({})
-    def full_path_method(self, args, kwargs):
+    def abs_path_method(self, args, kwargs):
         return self.interpreter.backend.get_target_filename_abs(self.held_object)
 
     @noPosargs
@@ -878,7 +879,8 @@ class CustomTargetIndexHolder(InterpreterObject, ObjectHolder):
 class CustomTargetHolder(TargetHolder):
     def __init__(self, target, interp):
         super().__init__(target, interp)
-        self.methods.update({'full_path': self.full_path_method,
+        self.methods.update({'full_path': self.abs_path_method,  # deprecated
+                             'path': self.abs_path_method,
                              })
 
     def __repr__(self):
@@ -888,7 +890,7 @@ class CustomTargetHolder(TargetHolder):
 
     @noPosargs
     @permittedKwargs({})
-    def full_path_method(self, args, kwargs):
+    def abs_path_method(self, args, kwargs):
         return self.interpreter.backend.get_target_filename_abs(self.held_object)
 
     def __getitem__(self, index):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -510,6 +510,7 @@ class ExternalProgramHolder(InterpreterObject, ObjectHolder):
         InterpreterObject.__init__(self)
         ObjectHolder.__init__(self, ep)
         self.methods.update({'found': self.found_method,
+                             'full_path': self.abs_path_method,  # deprecated
                              'path': self.abs_path_method})
         self.cached_version = None
 

--- a/test cases/common/148 link depends custom target/meson.build
+++ b/test cases/common/148 link depends custom target/meson.build
@@ -13,7 +13,7 @@ dep_file = custom_target('gen_dep',
 
 exe = executable('foo', 'foo.c',
         link_depends: dep_file,
-        c_args: ['-DDEPFILE="' + dep_file.full_path()+ '"'])
+        c_args: ['-DDEPFILE="' + dep_file.path()+ '"'])
 
 # check that dep_file exists, which means that link_depends target ran
 test('runtest', exe)

--- a/test cases/common/152 shared module resolving symbol in executable/meson.build
+++ b/test cases/common/152 shared module resolving symbol in executable/meson.build
@@ -17,4 +17,4 @@ endif
 dl = meson.get_compiler('c').find_library('dl', required: false)
 e = executable('prog', 'prog.c', dependencies: dl, export_dynamic: true)
 m = shared_module('module', 'module.c', link_with: e)
-test('test', e, args: m.full_path())
+test('test', e, args: m.path())

--- a/test cases/common/162 external program shebang parsing/meson.build
+++ b/test cases/common/162 external program shebang parsing/meson.build
@@ -3,7 +3,7 @@ project('shebang parsing', 'c')
 interpreter = executable('aninterp', 'main.c', native : true)
 
 cdata = configuration_data()
-cdata.set('INTRP', interpreter.full_path())
+cdata.set('INTRP', interpreter.path())
 
 f = configure_file(input : 'script.int.in',
                    output : 'script.int',

--- a/test cases/common/163 disabler/meson.build
+++ b/test cases/common/163 disabler/meson.build
@@ -2,8 +2,8 @@ project('dolphin option', 'c')
 
 d = disabler()
 
-full_path = d.full_path()
-assert(is_disabler(full_path), 'Method call is not a disabler')
+abs_path = d.path()
+assert(is_disabler(abs_path), 'Method call is not a disabler')
 
 d2 = dependency(d)
 d3 = (d == d2)

--- a/test cases/common/191 test depends/meson.build
+++ b/test cases/common/191 test depends/meson.build
@@ -19,7 +19,7 @@ test('string dependencies', test_prog,
     # real use case might have some obscure method
     # to find these dependencies, e.g. automatic plugin loading.
     'custom_dep.txt',
-    exe_dep.full_path(),
+    exe_dep.path(),
   ],
   depends : [custom_dep, exe_dep],
   workdir : meson.current_build_dir(),

--- a/test cases/common/27 pipeline/depends/meson.build
+++ b/test cases/common/27 pipeline/depends/meson.build
@@ -4,7 +4,7 @@ copier = executable('copier', 'filecopier.c', native: true)
 
 cg = generator(runner,
     output: ['@BASENAME@.c'],
-    arguments: [copier.full_path(), '@INPUT@', '@OUTPUT@'],
+    arguments: [copier.path(), '@INPUT@', '@OUTPUT@'],
     depends: copier)
 
 test('generatordep',

--- a/test cases/common/54 run target/meson.build
+++ b/test cases/common/54 run target/meson.build
@@ -21,12 +21,12 @@ fakeburner = find_program('fakeburner.py')
 # These emulates the Arduino flasher application. It sandwiches the filename inside
 # a packed argument. Thus we need to declare it manually.
 run_target('upload',
-  command : [fakeburner, 'x:@0@:y'.format(exe.full_path())],
+  command : [fakeburner, 'x:@0@:y'.format(exe.path())],
   depends : exe,
 )
 
 run_target('upload2',
-  command : [fakeburner, 'x:@0@:y'.format(hex.full_path())],
+  command : [fakeburner, 'x:@0@:y'.format(hex.path())],
   depends : hex,
 )
 

--- a/test cases/failing test/3 ambiguous/meson.build
+++ b/test cases/failing test/3 ambiguous/meson.build
@@ -6,5 +6,5 @@ else
     exe = executable('main', 'main.c')
     test_runner = find_program('test_runner.sh')
 
-    test('My Ambiguous Status Test', test_runner, args : [exe.full_path()])
+    test('My Ambiguous Status Test', test_runner, args : [exe.path()])
 endif

--- a/test cases/frameworks/23 hotdoc/doc/meson.build
+++ b/test cases/frameworks/23 hotdoc/doc/meson.build
@@ -11,7 +11,7 @@ target = hotdoc.generate_doc(
   install: true,
 )
 
-assert(target.config_path() == target.full_path() + '.json',
+assert(target.config_path() == target.path() + '.json',
   'Hotdoc config paths do not match.'
 )
 

--- a/test cases/frameworks/4 qt/subfolder/meson.build
+++ b/test cases/frameworks/4 qt/subfolder/meson.build
@@ -9,7 +9,7 @@ txt_resource = custom_target('txt_resource',
 cfg = configuration_data()
 
 cfg.set('filepath', meson.current_source_dir()+'/../thing2.png')
-cfg.set('txt_resource', txt_resource.full_path())
+cfg.set('txt_resource', txt_resource.path())
 # here we abuse the system by guessing build dir layout
 cfg.set('txt_resource2', 'txt_resource.txt')
 

--- a/test cases/frameworks/7 gnome/gdbus/meson.build
+++ b/test cases/frameworks/7 gnome/gdbus/meson.build
@@ -7,8 +7,8 @@ gdbus_src = gnome.gdbus_codegen('generated-gdbus-no-docbook',
   ],
 )
 assert(gdbus_src.length() == 2, 'expected 2 targets')
-assert(gdbus_src[0].full_path().endswith('.c'), 'expected 1 c source file')
-assert(gdbus_src[1].full_path().endswith('.h'), 'expected 1 c header file')
+assert(gdbus_src[0].path().endswith('.c'), 'expected 1 c source file')
+assert(gdbus_src[1].path().endswith('.h'), 'expected 1 c header file')
 
 gdbus_src = gnome.gdbus_codegen('generated-gdbus',
   sources : files('data/com.example.Sample.xml'),
@@ -22,8 +22,8 @@ gdbus_src = gnome.gdbus_codegen('generated-gdbus',
   install_dir : get_option('includedir')
 )
 assert(gdbus_src.length() == 3, 'expected 3 targets')
-assert(gdbus_src[0].full_path().endswith('.c'), 'expected 1 c source file')
-assert(gdbus_src[1].full_path().endswith('.h'), 'expected 1 c header file')
+assert(gdbus_src[0].path().endswith('.c'), 'expected 1 c source file')
+assert(gdbus_src[1].path().endswith('.h'), 'expected 1 c header file')
 
 if not pretend_glib_old and glib.version().version_compare('>=2.51.3')
   includes = []

--- a/test cases/linuxlike/14 static dynamic linkage/meson.build
+++ b/test cases/linuxlike/14 static dynamic linkage/meson.build
@@ -29,8 +29,8 @@ test('test dynamic', exe_dynamic)
 
 if has_static
   test('verify static linking', find_program('verify_static.py'),
-      args: ['--platform=' + host_machine.system(), exe_static.full_path()])
+      args: ['--platform=' + host_machine.system(), exe_static.path()])
 endif
 test('verify dynamic linking', find_program('verify_static.py'),
-    args: ['--platform=' + host_machine.system(), exe_dynamic.full_path()],
+    args: ['--platform=' + host_machine.system(), exe_dynamic.path()],
     should_fail: true)

--- a/test cases/linuxlike/3 linker script/meson.build
+++ b/test cases/linuxlike/3 linker script/meson.build
@@ -31,7 +31,7 @@ m = custom_target(
   output : 'bob-ct.map',
   depend_files : 'bob.map',
 )
-vflag = '-Wl,--version-script,@0@'.format(m.full_path())
+vflag = '-Wl,--version-script,@0@'.format(m.path())
 
 l = shared_library('bob-ct', ['bob.c', m], link_args : vflag, link_depends : m)
 e = executable('prog-ct', 'prog.c', link_with : l)


### PR DESCRIPTION
I'm happy to also add a commit that explicitly issues a deprecation warning if the `full_path()` method is used. Conversely, the docs could simply document it is an alias of `path()` without the deprecation warning if the Meson devs feel that `full_path()` can never be removed but still value consistency among the three object types.

Resolves #6375