### PR TITLE
fortran: parse OpenMP !$ lines

### DIFF
--- a/test cases/fortran/15 include/include_tests.f90
+++ b/test cases/fortran/15 include/include_tests.f90
@@ -7,6 +7,9 @@ y = 0
 
 ! include "timestwo.f90"
 
+!$ include "non-existentFile"
+! this is not an OpenMP project, so this !$ include should be ignored else configuration error
+
 ! double quote and inline comment check
 include "timestwo.f90"  ! inline comment check
 if (x/=2) error stop 'failed on first include'
@@ -16,7 +19,7 @@ if (x/=2) error stop 'failed on first include'
 if (x/=4) error stop 'failed on second include'
 
 ! Most Fortran compilers can't handle the non-standard #include,
-! including (ha!) Flang, Gfortran, Ifort and PGI.
+! including Flang, Gfortran, Ifort and PGI.
 ! #include "timestwo.f90"
 
 print *, 'OK: Fortran include tests: x=',x

--- a/test cases/fortran/15 include/meson.build
+++ b/test cases/fortran/15 include/meson.build
@@ -1,4 +1,4 @@
-project('Inclusive', 'fortran',
+project('IncludeStatements', 'fortran',
   meson_version: '>= 0.51.1')
 
 hier_exe = executable('include_hierarchy', 'include_hierarchy.f90')

--- a/test cases/fortran/16 openmp/main.f90
+++ b/test cases/fortran/16 openmp/main.f90
@@ -1,13 +1,37 @@
+ module Amod
+use, intrinsic :: iso_fortran_env, only : stderr=>error_unit
+interface
+module subroutine print_thread_count(N)
+integer, intent(in) :: N
+end subroutine print_thread_count
+end interface
+contains
+!$ include "mpstuff.f90"
+end module Amod
+
+submodule (Amod) Bfoo
+contains
+module procedure print_thread_count
+print '(A,I3,A)', 'You have', N, ' threads.'
+end procedure print_thread_count
+end submodule Bfoo
+
+program mpdemo
+
 use, intrinsic :: iso_fortran_env, only: stderr=>error_unit
+!$ use Amod, only : print_thread_count, print_result
 use omp_lib, only: omp_get_max_threads
 implicit none
 
 integer :: N, ierr
-character(80) :: buf  ! can't be allocatable in this use case. Just set arbitrarily large.
+character(80) :: buf  ! can't be allocatable even through Fortran 2018. Just set arbitrarily large.
 
 call get_environment_variable('OMP_NUM_THREADS', buf, status=ierr)
 if (ierr/=0) error stop 'environment variable OMP_NUM_THREADS could not be read'
 read(buf,*) N
+
+call print_thread_count(N)
+call print_result(N)
 
 if (omp_get_max_threads() /= N) then
   write(stderr, *) 'Max Fortran threads: ', omp_get_max_threads(), '!=', N

--- a/test cases/fortran/16 openmp/mpstuff.f90
+++ b/test cases/fortran/16 openmp/mpstuff.f90
@@ -1,0 +1,10 @@
+subroutine print_result(N)
+integer, intent(in) :: N
+
+if (N==2) then
+  print *, '2 threads is correct number.'
+else
+  write(stderr,'(i3,A)') N,' threads is not what this test expected.'
+endif
+
+end subroutine print_result


### PR DESCRIPTION
The [MUMPS library](https://github.com/group-gu/mumps/blob/master/src/cfac_front_aux.F) provides an important example of the *de facto* OpenMP Fortran syntax where lines starting with `!$` are statements executed only when OpenMP is used.

CMake and Meson currently ignore those lines starting with `!$`, causing failure to build due to missed intra-target dependencies. 

Example:

A.f90
```fortran
!$ use Bmod 
implicit none
call bar()
call foo()
contains
!$ include "C.f90"
end program
```

B.f90
```fortran
module Bmod
contains
subroutine bar()
end subroutine bar
end module Bmod
```

C.f90
```fortran
subroutine foo()
end subroutine foo
```

meson.build
```meson
openmp = dependency('openmp')

exe = executable('foo', 'A.f90, 'B.f90', dependencies: openmp)
```
will now work correctly, ensuring B.f90 and C.f90 build before A.f90. 
