### PR TITLE
cmake: Use trace for missing link flags (fixes #6386)

### DIFF
--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -89,6 +89,7 @@ class CMakeTraceParser:
             'target_compile_definitions': self._cmake_target_compile_definitions,
             'target_compile_options': self._cmake_target_compile_options,
             'target_include_directories': self._cmake_target_include_directories,
+            'target_link_libraries': self._cmake_target_link_libraries,
             'target_link_options': self._cmake_target_link_options,
             'add_dependencies': self._cmake_add_dependencies,
         }
@@ -432,6 +433,10 @@ class CMakeTraceParser:
         # DOC: https://cmake.org/cmake/help/latest/command/target_link_options.html
         self._parse_common_target_options('target_link_options', 'LINK_OPTIONS', 'INTERFACE_LINK_OPTIONS', tline)
 
+    def _cmake_target_link_libraries(self, tline: CMakeTraceLine) -> None:
+        # DOC: https://cmake.org/cmake/help/latest/command/target_link_libraries.html
+        self._parse_common_target_options('target_link_options', 'LINK_LIBRARIES', 'INTERFACE_LINK_LIBRARIES', tline)
+
     def _parse_common_target_options(self, func: str, private_prop: str, interface_prop: str, tline: CMakeTraceLine, ignore: Optional[List[str]] = None, paths: bool = False):
         if ignore is None:
             ignore = ['BEFORE']
@@ -453,14 +458,14 @@ class CMakeTraceParser:
             if i in ignore:
                 continue
 
-            if i in ['INTERFACE', 'PUBLIC', 'PRIVATE']:
+            if i in ['INTERFACE', 'LINK_INTERFACE_LIBRARIES', 'PUBLIC', 'PRIVATE', 'LINK_PUBLIC', 'LINK_PRIVATE']:
                 mode = i
                 continue
 
-            if mode in ['INTERFACE', 'PUBLIC']:
+            if mode in ['INTERFACE', 'LINK_INTERFACE_LIBRARIES', 'PUBLIC', 'LINK_PUBLIC']:
                 interface += [i]
 
-            if mode in ['PUBLIC', 'PRIVATE']:
+            if mode in ['PUBLIC', 'PRIVATE', 'LINK_PRIVATE']:
                 private += [i]
 
         if paths:

--- a/test cases/cmake/16 threads/main.cpp
+++ b/test cases/cmake/16 threads/main.cpp
@@ -1,0 +1,9 @@
+#include "cmMod.hpp"
+
+#include <cstdlib>
+
+int main() {
+  CmMod cc;
+  cc.asyncIncrement();
+  return cc.getNum() == 1 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test cases/cmake/16 threads/meson.build
+++ b/test cases/cmake/16 threads/meson.build
@@ -1,0 +1,8 @@
+project('cmMod', ['c', 'cpp'])
+
+cm       = import('cmake')
+cmMod    = cm.subproject('cmMod')
+cmModDep = cmMod.dependency('cmModLib')
+
+exe1 = executable('exe1', ['main.cpp'], dependencies: [cmModDep])
+test('exe1_OK', exe1)

--- a/test cases/cmake/16 threads/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/16 threads/subprojects/cmMod/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(cmMod CXX)
+set (CMAKE_CXX_STANDARD 14)
+
+find_package(Threads)
+
+add_library(cmModLib STATIC cmMod.cpp)
+target_link_libraries(cmModLib PRIVATE Threads::Threads)

--- a/test cases/cmake/16 threads/subprojects/cmMod/cmMod.cpp
+++ b/test cases/cmake/16 threads/subprojects/cmMod/cmMod.cpp
@@ -1,0 +1,15 @@
+#include "cmMod.hpp"
+
+#include <chrono>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+void CmMod::asyncIncrement() {
+  std::thread t1([this]() {
+    std::this_thread::sleep_for(100ms);
+    num += 1;
+  });
+
+  t1.join();
+}

--- a/test cases/cmake/16 threads/subprojects/cmMod/cmMod.hpp
+++ b/test cases/cmake/16 threads/subprojects/cmMod/cmMod.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+class CmMod {
+private:
+  int num = 0;
+
+public:
+  inline int getNum() const { return num; }
+  void asyncIncrement();
+};

--- a/test cases/cmake/16 threads/subprojects/cmMod/main.cpp
+++ b/test cases/cmake/16 threads/subprojects/cmMod/main.cpp
@@ -1,0 +1,9 @@
+#include "cmMod.hpp"
+
+#include <cstdlib>
+
+int main() {
+  CmMod cc;
+  cc.asyncIncrement();
+  return cc.getNum() == 1 ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/test cases/cmake/2 advanced/meson.build
+++ b/test cases/cmake/2 advanced/meson.build
@@ -10,11 +10,14 @@ cm = import('cmake')
 # Test the "normal" subproject call
 sub_pro = cm.subproject('cmMod')
 sub_dep = sub_pro.dependency('cmModLib')
+sub_sta = sub_pro.dependency('cmModLibStatic')
 
 # Build some files
 exe1 = executable('main1', ['main.cpp'], dependencies: [sub_dep])
+exe2 = executable('main2', ['main.cpp'], dependencies: [sub_sta])
 test('test1', exe1)
+test('test2', exe2)
 
 # Test if we can also extract executables
 assert(sub_pro.target_type('testEXE') == 'executable', 'The type must be executable for obvious reasons')
-test('test2', sub_pro.target('testEXE'))
+test('test3', sub_pro.target('testEXE'))

--- a/test cases/cmake/2 advanced/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/2 advanced/subprojects/cmMod/CMakeLists.txt
@@ -10,7 +10,8 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR} ${CM
 set(CONFIG_OPT 42)
 configure_file("config.h.in" "${CMAKE_CURRENT_BINARY_DIR}/config.h" @ONLY)
 
-add_library(cmModLib SHARED lib/cmMod.cpp)
+add_library(cmModLib       SHARED lib/cmMod.cpp)
+add_library(cmModLibStatic STATIC lib/cmMod.cpp)
 include(GenerateExportHeader)
 generate_export_header(cmModLib)
 
@@ -18,7 +19,10 @@ set_target_properties(cmModLib PROPERTIES VERSION 1.0.1)
 
 add_executable(testEXE main.cpp)
 
-target_link_libraries(cmModLib ZLIB::ZLIB)
+target_link_libraries(cmModLib       ZLIB::ZLIB)
+target_link_libraries(cmModLibStatic ZLIB::ZLIB)
 target_link_libraries(testEXE cmModLib)
+
+target_compile_definitions(cmModLibStatic PUBLIC CMMODLIB_STATIC_DEFINE)
 
 install(TARGETS cmModLib testEXE LIBRARY DESTINATION lib RUNTIME DESTINATION bin)

--- a/test cases/cmake/3 advanced no dep/meson.build
+++ b/test cases/cmake/3 advanced no dep/meson.build
@@ -5,11 +5,14 @@ cm = import('cmake')
 # Test the "normal" subproject call
 sub_pro = cm.subproject('cmMod')
 sub_dep = sub_pro.dependency('cmModLib')
+sub_sta = sub_pro.dependency('cmModLibStatic')
 
 # Build some files
 exe1 = executable('main1', ['main.cpp'], dependencies: [sub_dep])
+exe2 = executable('main2', ['main.cpp'], dependencies: [sub_sta])
 test('test1', exe1)
+test('test2', exe2)
 
 # Test if we can also extract executables
 assert(sub_pro.target_type('testEXE') == 'executable', 'The type must be executable for obvious reasons')
-test('test2', sub_pro.target('testEXE'))
+test('test3', sub_pro.target('testEXE'))

--- a/test cases/cmake/3 advanced no dep/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/3 advanced no dep/subprojects/cmMod/CMakeLists.txt
@@ -8,7 +8,8 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR} ${CM
 set(CONFIG_OPT 42)
 configure_file("config.h.in" "${CMAKE_CURRENT_BINARY_DIR}/config.h" @ONLY)
 
-add_library(cmModLib SHARED lib/cmMod.cpp)
+add_library(cmModLib       SHARED lib/cmMod.cpp)
+add_library(cmModLibStatic STATIC lib/cmMod.cpp)
 include(GenerateExportHeader)
 generate_export_header(cmModLib)
 
@@ -17,5 +18,7 @@ set_target_properties(cmModLib PROPERTIES VERSION 1.0.1)
 add_executable(testEXE main.cpp)
 
 target_link_libraries(testEXE cmModLib)
+
+target_compile_definitions(cmModLibStatic PUBLIC CMMODLIB_STATIC_DEFINE)
 
 install(TARGETS cmModLib testEXE LIBRARY DESTINATION lib RUNTIME DESTINATION bin)


### PR DESCRIPTION
This is necessary for static libraries since the CMake file API does not add link flags here.