### PR TITLE
pkgconfig: Pull dependencies of static dependencies

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -120,8 +120,15 @@ class DependenciesHelper:
                 processed_reqs.append(obj.generated_pc)
             elif isinstance(obj, dependencies.PkgConfigDependency):
                 if obj.found():
-                    processed_reqs.append(obj.name)
-                    self.add_version_reqs(obj.name, obj.version_reqs)
+                    if obj.static:
+                        # in case of embedded static dependency
+                        for arg in obj.link_args:
+                            if not os.sep in arg:
+                                # pull external dependencies
+                                processed_reqs.append(arg)
+                    else:
+                        processed_reqs.append(obj.name)
+                        self.add_version_reqs(obj.name, obj.version_reqs)
             elif isinstance(obj, dependencies.ThreadDependency):
                 processed_libs += obj.get_compiler().thread_link_flags(obj.env)
                 processed_cflags += obj.get_compiler().thread_flags(obj.env)


### PR DESCRIPTION
If a dependency is statically linked (i.e. embedded),
it should be "transparent" from the pkg-config perspective.
Here "transparent" means that the dependency should not be visible
and its dependencies should appear in the private part
of the generated .pc file.

In current version of meson, such required static library is exposed
the same way as a shared library.

Such case of embedded dependency (with static linking)
is fixed by hiding the dependency ("else" clause) and adding
its dependencies as requirements.

The dependencies of the dependency are found by filtering link_args,
assuming path separator (in full path) is not present in such dependency.