### PR TITLE
Add support for null-coalescing condition

### DIFF
--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -560,6 +560,19 @@ The only exception is that nested ternary operators are forbidden to
 improve legibility. If your branching needs are more complex than this
 you need to write an `if/else` construct.
 
+Null-Coalescing operator
+--
+
+The null-coalescing operator works just like in C# language.
+
+```meson
+x = condition_value ?? false_value
+```
+
+The only exception is that null-coalescing operators are forbidden to
+improve legibility. If your branching needs are more complex than this
+you need to write an `if/else` construct or `ternary` operator.
+
 Includes
 --
 

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -32,6 +32,7 @@ from ..mparser import (
     MethodNode,
     PlusAssignmentNode,
     TernaryNode,
+    NullCoalescingNode,
 )
 
 import os, sys
@@ -182,6 +183,11 @@ class AstInterpreter(interpreterbase.InterpreterBase):
         self.evaluate_statement(node.condition)
         self.evaluate_statement(node.trueblock)
         self.evaluate_statement(node.falseblock)
+
+    def evaluate_nullcoalescing(self, node):
+        assert isinstance(node, NullCoalescingNode)
+        self.evaluate_statement(node.leftblock)
+        self.evaluate_statement(node.rightblock)
 
     def evaluate_plusassign(self, node):
         assert(isinstance(node, PlusAssignmentNode))

--- a/mesonbuild/ast/printer.py
+++ b/mesonbuild/ast/printer.py
@@ -179,6 +179,11 @@ class AstPrinter(AstVisitor):
         self.append_padded(':', node)
         node.falseblock.accept(self)
 
+    def visit_NullCoalescingNode(self, node: mparser.NullCoalescingNode):
+        node.left.accept(self)
+        self.append_padded('??', node)
+        node.right.accept(self)
+
     def visit_ArgumentNode(self, node: mparser.ArgumentNode):
         break_args = (len(node.arguments) + len(node.kwargs)) > self.arg_newline_cutoff
         for i in node.arguments + list(node.kwargs.values()):

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -477,6 +477,8 @@ class InterpreterBase:
             return self.evaluate_indexing(cur)
         elif isinstance(cur, mparser.TernaryNode):
             return self.evaluate_ternary(cur)
+        elif isinstance(cur, mparser.NullCoalescingNode):
+            return self.evaluate_nullcoalescing(cur)
         elif isinstance(cur, mparser.ContinueNode):
             raise ContinueRequest()
         elif isinstance(cur, mparser.BreakNode):
@@ -685,6 +687,16 @@ The result of this is undefined and will become a hard error in a future Meson r
             return self.evaluate_statement(node.trueblock)
         else:
             return self.evaluate_statement(node.falseblock)
+
+    def evaluate_nullcoalescing(self, node):
+        assert(isinstance(node, mparser.NullCoalescingNode))
+        result = self.evaluate_statement(node.left)
+        if is_disabler(result):
+            return result
+        if result:
+            return result
+        else:
+            return self.evaluate_statement(node.right)
 
     def evaluate_foreach(self, node):
         assert(isinstance(node, mparser.ForeachClauseNode))

--- a/test cases/common/228 null-coalescing/meson.build
+++ b/test cases/common/228 null-coalescing/meson.build
@@ -1,0 +1,15 @@
+project('null-coalescing', 'c')
+
+one = true ?? 'no'
+two = false ?? 'yes'
+three = '@0@'.format(true ?? 'yes')
+four = '@0@'.format(false ?? 'no')
+five = [true ?? '0']
+six = [false ?? '1']
+
+assert(one == true, 'Return value from null-coalescing true is wrong.')
+assert(two == 'yes', 'Return value from null-coalescing false is wrong.')
+assert(three == 'true', 'Return value from null-coalescing true inside method is wrong.')
+assert(four == 'no', 'Return value from null-coalescing false inside method is wrong.')
+assert(five == [true], 'Return value for null-coalescing true inside of list is wrong.')
+assert(six == ['1'], 'Return value for null-coalescing false inside of list is wrong.')

--- a/test cases/failing/99 nested null-coalescing/meson.build
+++ b/test cases/failing/99 nested null-coalescing/meson.build
@@ -1,0 +1,5 @@
+project('null-coalescing', 'c')
+
+one = true ?? (false ?? 1)
+two = false ?? (true ?? 1)
+three = false ?? (false ?? 1)


### PR DESCRIPTION
Code strongly based on:
- https://github.com/mesonbuild/meson/pull/605
- https://github.com/mesonbuild/meson/pull/5007

:)

EDIT:
That would be very useful for such case:
```
seven = dependency('luajit', version : '>=2.0.5', required : false) ?? dependency('lua', version : '>=2.0.5')
```

Currently, if `dependency` is not found, returns `DependencyHolder` with `not-found` in it, and that PR will obviously not work with such a case.

Am I allowed to do something like this ? (in https://github.com/TheAifam5/meson/blob/945acb5b7b0ffb1fad4abc23708ff6be877c7641/mesonbuild/ast/interpreter.py#L187)

Pseudocode:
```
if callable(getattr(result, 'found', None)):
    if result.found():
    	return result
	else:
		return False
```

Or someone have better idea?

My other idea is to extend `dependency`, to allow pass `fallback` with a string :)