### PR TITLE
coredata: add support for runstatedir

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -41,6 +41,7 @@ Installation options are all relative to the prefix, except:
 | sbindir                              | sbin          | System executable directory |
 | sharedstatedir                       | com           | Architecture-independent data directory |
 | sysconfdir                           | etc           | Sysconf data directory |
+| runstatedir                          | run           | Runtime data directory |
 
 
 `prefix` defaults to `C:/` on Windows, and `/usr/local/` otherwise. You should always

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1022,6 +1022,7 @@ builtin_options = OrderedDict([
     ('sbindir',         BuiltinOption(UserStringOption, 'System executable directory', 'sbin')),
     ('sharedstatedir',  BuiltinOption(UserStringOption, 'Architecture-independent data directory', 'com')),
     ('sysconfdir',      BuiltinOption(UserStringOption, 'Sysconf data directory', 'etc')),
+    ('runstatedir',     BuiltinOption(UserStringOption, 'Runtime data directory', 'run')),
     # Core options
     ('auto_features',   BuiltinOption(UserFeatureOption, "Override value of all 'auto' features", 'auto')),
     ('backend',         BuiltinOption(UserComboOption, 'Backend to use', 'ninja', choices=backendlist)),


### PR DESCRIPTION
/run is now part of the RFS3.0. Add support for it.
	http://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch03s15.html

Signed-off-by: Liam Beguin <liambeguin@gmail.com>

fixes https://github.com/mesonbuild/meson/issues/4141