### PR TITLE
Handle bare "#define foo\n" in get_gnu_compiler_defines

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -679,7 +679,7 @@ class Environment:
             if d != '#define':
                 continue
             if len(rest) == 1:
-                defines[rest] = True
+                defines[rest[0]] = True
             if len(rest) == 2:
                 defines[rest[0]] = rest[1]
         return defines


### PR DESCRIPTION
Without this change, the code always fails with a type error because `rest` is a list, and thus unhashable. Upstream gcc does not trigger this condition, but wrappers that look like gcc (e.g., sparse https://sparse.wiki.kernel.org/) can.