### PR TITLE
dependency: add curses

### DIFF
--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -23,7 +23,8 @@ from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDepen
 from .coarrays import CoarrayDependency
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
-from .misc import (BlocksDependency, NetCDFDependency, OpenMPDependency, Python3Dependency, ThreadDependency, PcapDependency, CupsDependency, LibWmfDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency)
+from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, Python3Dependency, ThreadDependency,
+                   PcapDependency, CupsDependency, LibWmfDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency)
 from .platform import AppleFrameworks
 from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, VulkanDependency
 
@@ -46,6 +47,7 @@ packages.update({
 
     # From misc:
     'blocks': BlocksDependency,
+    'curses': CursesDependency,
     'netcdf': NetCDFDependency,
     'openmp': OpenMPDependency,
     'python3': Python3Dependency,

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -557,3 +557,26 @@ class ShadercDependency(ExternalDependency):
     @staticmethod
     def get_methods():
         return [DependencyMethods.SYSTEM, DependencyMethods.PKGCONFIG]
+
+class CursesDependency(ExternalDependency):
+    def __init__(self, environment, kwargs):
+        super().__init__('curses', environment, None, kwargs)
+        self.name = 'curses'
+        self.is_found = False
+        methods = listify(self.methods)
+
+        if set([DependencyMethods.AUTO, DependencyMethods.PKGCONFIG]).intersection(methods):
+            pkgconfig_files = ['ncurses', 'ncursesw']
+            for pkg in pkgconfig_files:
+                pkgdep = PkgConfigDependency(pkg, environment, kwargs)
+                if pkgdep.found():
+                    self.compile_args = pkgdep.get_compile_args()
+                    self.link_args = pkgdep.get_link_args()
+                    self.version = pkgdep.get_version()
+                    self.is_found = True
+                    self.pcdep = pkgdep
+                    return
+
+    @staticmethod
+    def get_methods():
+        return [DependencyMethods.AUTO, DependencyMethods.PKGCONFIG]

--- a/test cases/frameworks/31 curses/main.c
+++ b/test cases/frameworks/31 curses/main.c
@@ -1,0 +1,7 @@
+#include "curses.h"
+
+int main(void) {
+initscr();
+endwin();
+return 0;
+}

--- a/test cases/frameworks/31 curses/meson.build
+++ b/test cases/frameworks/31 curses/meson.build
@@ -1,0 +1,9 @@
+project('curses', 'c')
+
+curses = dependency('curses', required: false)
+if not curses.found()
+  error('MESON_SKIP_TEST: Curses library not found')
+endif
+
+exec = executable('basic', 'main.c', dependencies: curses)
+# didn't run the test because in general graphics fail on CI


### PR DESCRIPTION
fixes #6096.

Didn't use CMake because Curses is a real corner-case for CMake that
would require Curses-specific enhancements to Meson's CMake interface.