### PR TITLE
mintro: use interpreter data for buildsystem-files (fixes #6390) 

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -24,6 +24,7 @@ from ..mesonlib import MachineChoice, MesonException, OrderedSet, OptionOverride
 from ..mesonlib import classify_unity_sources
 from ..mesonlib import File
 from ..compilers import CompilerArgs, VisualStudioLikeCompiler
+from ..interpreter import Interpreter
 from collections import OrderedDict
 import shlex
 from functools import lru_cache
@@ -106,40 +107,41 @@ class TestSerialisation:
         self.priority = priority
         self.needs_exe_wrapper = needs_exe_wrapper
 
-def get_backend_from_name(backend, build):
+def get_backend_from_name(backend: str, build: T.Optional[build.Build] = None, interpreter: T.Optional[Interpreter] = None) -> T.Optional['Backend']:
     if backend == 'ninja':
         from . import ninjabackend
-        return ninjabackend.NinjaBackend(build)
+        return ninjabackend.NinjaBackend(build, interpreter)
     elif backend == 'vs':
         from . import vs2010backend
-        return vs2010backend.autodetect_vs_version(build)
+        return vs2010backend.autodetect_vs_version(build, interpreter)
     elif backend == 'vs2010':
         from . import vs2010backend
-        return vs2010backend.Vs2010Backend(build)
+        return vs2010backend.Vs2010Backend(build, interpreter)
     elif backend == 'vs2015':
         from . import vs2015backend
-        return vs2015backend.Vs2015Backend(build)
+        return vs2015backend.Vs2015Backend(build, interpreter)
     elif backend == 'vs2017':
         from . import vs2017backend
-        return vs2017backend.Vs2017Backend(build)
+        return vs2017backend.Vs2017Backend(build, interpreter)
     elif backend == 'vs2019':
         from . import vs2019backend
-        return vs2019backend.Vs2019Backend(build)
+        return vs2019backend.Vs2019Backend(build, interpreter)
     elif backend == 'xcode':
         from . import xcodebackend
-        return xcodebackend.XCodeBackend(build)
+        return xcodebackend.XCodeBackend(build, interpreter)
     return None
 
 # This class contains the basic functionality that is needed by all backends.
 # Feel free to move stuff in and out of it as you see fit.
 class Backend:
-    def __init__(self, build):
+    def __init__(self, build: T.Optional[build.Build], interpreter: T.Optional[Interpreter]):
         # Make it possible to construct a dummy backend
         # This is used for introspection without a build directory
         if build is None:
             self.environment = None
             return
         self.build = build
+        self.interpreter = interpreter
         self.environment = build.environment
         self.processed_targets = {}
         self.build_dir = self.environment.get_build_dir()

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -789,12 +789,6 @@ class Backend:
             deps.extend(self.environment.coredata.cross_files)
         deps.extend(self.environment.coredata.config_files)
         deps.append('meson-private/coredata.dat')
-        if os.path.exists(os.path.join(self.environment.get_source_dir(), 'meson_options.txt')):
-            deps.append(os.path.join(self.build_to_src, 'meson_options.txt'))
-        for sp in self.build.subprojects.keys():
-            fname = os.path.join(self.environment.get_source_dir(), sp, 'meson_options.txt')
-            if os.path.isfile(fname):
-                deps.append(os.path.join(self.build_to_src, sp, 'meson_options.txt'))
         self.check_clock_skew(deps)
         return deps
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -37,6 +37,7 @@ from ..mesonlib import (
 from ..mesonlib import get_compiler_for_source, has_path_sep
 from .backends import CleanTrees
 from ..build import InvalidArguments
+from ..interpreter import Interpreter
 
 FORTRAN_INCLUDE_PAT = r"^\s*#?include\s*['\"](\w+\.\w+)['\"]"
 FORTRAN_MODULE_PAT = r"^\s*\bmodule\b\s+(\w+)\s*(?:!+.*)*$"
@@ -203,8 +204,8 @@ class NinjaBuildElement:
 
 class NinjaBackend(backends.Backend):
 
-    def __init__(self, build):
-        super().__init__(build)
+    def __init__(self, build: T.Optional[build.Build], interpreter: T.Optional[Interpreter]):
+        super().__init__(build, interpreter)
         self.name = 'ninja'
         self.ninja_filename = 'build.ninja'
         self.fortran_deps = {}
@@ -283,8 +284,7 @@ int dummy;
 
         raise MesonException('Could not determine vs dep dependency prefix string.')
 
-    def generate(self, interp):
-        self.interpreter = interp
+    def generate(self):
         ninja = environment.detect_ninja_command_and_version(log=True)
         if ninja is None:
             raise MesonException('Could not detect Ninja v1.5 or newer')

--- a/mesonbuild/backend/vs2015backend.py
+++ b/mesonbuild/backend/vs2015backend.py
@@ -14,11 +14,14 @@
 
 from .vs2010backend import Vs2010Backend
 from ..mesonlib import MesonException
+from ..interpreter import Interpreter
+from ..build import Build
+import typing as T
 
 
 class Vs2015Backend(Vs2010Backend):
-    def __init__(self, build):
-        super().__init__(build)
+    def __init__(self, build: T.Optional[Build], interpreter: T.Optional[Interpreter]):
+        super().__init__(build, interpreter)
         self.name = 'vs2015'
         self.vs_version = '2015'
         if self.environment is not None:

--- a/mesonbuild/backend/vs2017backend.py
+++ b/mesonbuild/backend/vs2017backend.py
@@ -13,15 +13,18 @@
 # limitations under the License.
 
 import os
+import typing as T
 import xml.etree.ElementTree as ET
 
 from .vs2010backend import Vs2010Backend
 from ..mesonlib import MesonException
+from ..interpreter import Interpreter
+from ..build import Build
 
 
 class Vs2017Backend(Vs2010Backend):
-    def __init__(self, build):
-        super().__init__(build)
+    def __init__(self, build: T.Optional[Build], interpreter: T.Optional[Interpreter]):
+        super().__init__(build, interpreter)
         self.name = 'vs2017'
         self.vs_version = '2017'
         # We assume that host == build

--- a/mesonbuild/backend/vs2019backend.py
+++ b/mesonbuild/backend/vs2019backend.py
@@ -13,14 +13,17 @@
 # limitations under the License.
 
 import os
+import typing as T
 import xml.etree.ElementTree as ET
 
 from .vs2010backend import Vs2010Backend
+from ..interpreter import Interpreter
+from ..build import Build
 
 
 class Vs2019Backend(Vs2010Backend):
-    def __init__(self, build):
-        super().__init__(build)
+    def __init__(self, build: T.Optional[Build], interpreter: T.Optional[Interpreter]):
+        super().__init__(build, interpreter)
         self.name = 'vs2019'
         if self.environment is not None:
             comps = self.environment.coredata.compilers.host

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -18,12 +18,14 @@ from .. import dependencies
 from .. import mesonlib
 from .. import mlog
 import uuid, os, operator
+import typing as T
 
 from ..mesonlib import MesonException
+from ..interpreter import Interpreter
 
 class XCodeBackend(backends.Backend):
-    def __init__(self, build):
-        super().__init__(build)
+    def __init__(self, build: T.Optional[build.Build], interpreter: T.Optional[Interpreter]):
+        super().__init__(build, interpreter)
         self.name = 'xcode'
         self.project_uid = self.environment.coredata.lang_guids['default'].replace('-', '')[:24]
         self.project_conflist = self.gen_id()
@@ -74,8 +76,7 @@ class XCodeBackend(backends.Backend):
         if not text.endswith('\n'):
             self.ofile.write('\n')
 
-    def generate(self, interp):
-        self.interpreter = interp
+    def generate(self):
         test_data = self.serialize_tests()[0]
         self.generate_filemap()
         self.generate_buildmap()

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2771,7 +2771,7 @@ external dependencies (including libraries) must go to "dependencies".''')
             return
         backend = self.coredata.get_builtin_option('backend')
         from .backend import backends
-        self.backend = backends.get_backend_from_name(backend, self.build)
+        self.backend = backends.get_backend_from_name(backend, self.build, self)
 
         if self.backend is None:
             raise InterpreterException('Unknown backend "%s".' % backend)

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2807,6 +2807,7 @@ external dependencies (including libraries) must go to "dependencies".''')
             oi = optinterpreter.OptionInterpreter(self.subproject)
             oi.process(self.option_file)
             self.coredata.merge_user_options(oi.options)
+            self.add_build_def_file(self.option_file)
 
         # Do not set default_options on reconfigure otherwise it would override
         # values previously set from command line. That means that changing

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -212,7 +212,7 @@ class MesonApp:
                 fname = os.path.join(self.build_dir, 'meson-private', fname)
                 profile.runctx('intr.backend.generate(intr)', globals(), locals(), filename=fname)
             else:
-                intr.backend.generate(intr)
+                intr.backend.generate()
             build.save(b, dumpfile)
             if env.first_invocation:
                 coredata.write_cmd_line_file(self.build_dir, self.options)


### PR DESCRIPTION
Use the already existing list of buildsystem files in the interpreter, instead of relying on `os.walk()`.

This PR also includes some slight refactoring, to set `self.interpreter` in the constructor of the Backend class.