### PR TITLE
Add a "system" dependency for zlib

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -572,6 +572,17 @@ that it is not possible to obtain the shaderc version using this method.
 
 `method` may be `auto`, `pkg-config` or `system`.
 
+## Zlib
+
+Zlib ships with pkg-config and cmake support, but on some operating systems
+(windows, macOs, FreeBSD, dragonflybsd), it is provided as part of the base
+operating system without pkg-config support. The new System finder can be used
+on these OSes to link with the bundled version.
+
+`method` may be `auto`, `pkg-config`, `cmake`, or `system`.
+
+*New in 0.54.0* the `system` method.
+
 <hr>
 <a name="footnote1">1</a>: They may appear to be case-insensitive, if the
     underlying file system happens to be case-insensitive.

--- a/docs/markdown/snippets/zlib_system_dependency.md
+++ b/docs/markdown/snippets/zlib_system_dependency.md
@@ -1,0 +1,8 @@
+## Add a system type dependency for zlib
+
+This allows zlib to be detected on macOS and FreeBSD without the use of
+pkg-config or cmake, neither of which are part of the base install on those
+OSes (but zlib is).
+
+A side effect of this change is that `dependency('zlib')` also works with
+cmake instead of requiring `dependency('ZLIB')`.

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -20,7 +20,7 @@ from .base import (  # noqa: F401
     ExternalDependency, NotFoundDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
     PkgConfigDependency, CMakeDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language,
     DependencyFactory)
-from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory
+from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory, zlib_factory
 from .coarrays import coarray_factory
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
@@ -44,6 +44,7 @@ packages.update({
     'gmock': gmock_factory,
     'llvm': llvm_factory,
     'valgrind': ValgrindDependency,
+    'zlib': zlib_factory,
 
     'boost': BoostDependency,
     'cuda': CudaDependency,

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -468,9 +468,27 @@ class ZlibSystemDependency(ExternalDependency):
             # No need to set includes,
             # on macos xcode/clang will do that for us.
             # on freebsd zlib.h is in /usr/include
+        elif m.is_windows():
+            if self.clib_compiler.get_argument_syntax() == 'msvc':
+                libs = ['zlib1' 'zlib']
+            else:
+                libs = ['z']
+            for lib in libs:
+                l = self.clib_compiler.find_library(lib, environment, [])
+                h = self.clib_compiler.has_header('zlib.h', '', environment, dependencies=[self])
+                if l and h:
+                    self.is_found = True
+                    self.link_args = l
+                    break
+            else:
+                return
+        else:
+            mlog.debug('Unsupported OS {}'.format(m.system))
+            return
 
-            v, _ = self.clib_compiler.get_define('ZLIB_VERSION', '#include <zlib.h>', self.env, [], [self])
-            self.version = v.strip('"')
+        v, _ = self.clib_compiler.get_define('ZLIB_VERSION', '#include <zlib.h>', self.env, [], [self])
+        self.version = v.strip('"')
+
 
     @staticmethod
     def get_methods():

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -28,6 +28,8 @@ from .base import (
     strip_system_libdirs, ConfigToolDependency, CMakeDependency, DependencyFactory,
 )
 from .misc import threads_factory
+from ..compilers.c import AppleClangCCompiler
+from ..compilers.cpp import AppleClangCPPCompiler
 
 if T.TYPE_CHECKING:
     from .. environment import Environment
@@ -449,6 +451,27 @@ class ValgrindDependency(PkgConfigDependency):
         return []
 
 
+class ZlibSystemDependency(ExternalDependency):
+
+    def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any]):
+        super().__init__(name, environment, kwargs)
+
+        # I'm not sure this is entirely correct. What if we're cross compiling
+        # from something to macOS?
+        if (self.env.machines[self.for_machine].is_darwin() and
+                isinstance(self.clib_compiler, (AppleClangCCompiler, AppleClangCPPCompiler))):
+            self.is_found = True
+            self.link_args = ['-lz']
+            # No need to set includes, xcode/clang will do that for us.
+
+            v, _ = self.clib_compiler.get_define('ZLIB_VERSION', '#include <zlib.h>', self.env, [], [self])
+            self.version = v.strip('"')
+
+    @staticmethod
+    def get_methods():
+        return [DependencyMethods.SYSTEM]
+
+
 llvm_factory = DependencyFactory(
     'LLVM',
     [DependencyMethods.CMAKE, DependencyMethods.CONFIG_TOOL],
@@ -468,4 +491,11 @@ gmock_factory = DependencyFactory(
     [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM],
     pkgconfig_class=GMockDependencyPC,
     system_class=GMockDependencySystem,
+)
+
+zlib_factory = DependencyFactory(
+    'zlib',
+    [DependencyMethods.PKGCONFIG, DependencyMethods.CMAKE, DependencyMethods.SYSTEM],
+    cmake_name='ZLIB',
+    system_class=ZlibSystemDependency,
 )

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -456,13 +456,18 @@ class ZlibSystemDependency(ExternalDependency):
     def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, environment, kwargs)
 
+        m = self.env.machines[self.for_machine]
+
         # I'm not sure this is entirely correct. What if we're cross compiling
         # from something to macOS?
-        if (self.env.machines[self.for_machine].is_darwin() and
-                isinstance(self.clib_compiler, (AppleClangCCompiler, AppleClangCPPCompiler))):
+        if ((m.is_darwin() and isinstance(self.clib_compiler, (AppleClangCCompiler, AppleClangCPPCompiler))) or
+                m.is_freebsd() or m.is_dragonflybsd()):
             self.is_found = True
             self.link_args = ['-lz']
-            # No need to set includes, xcode/clang will do that for us.
+
+            # No need to set includes,
+            # on macos xcode/clang will do that for us.
+            # on freebsd zlib.h is in /usr/include
 
             v, _ = self.clib_compiler.get_define('ZLIB_VERSION', '#include <zlib.h>', self.env, [], [self])
             self.version = v.strip('"')

--- a/test cases/common/228 zlib/meson.build
+++ b/test cases/common/228 zlib/meson.build
@@ -1,0 +1,23 @@
+project('zlib system dependency', 'c')
+
+if not ['darwin', 'freebsd', 'dragonfly', 'windows'].contains(host_machine.system())
+  error('MESON_SKIP_TEST only applicable on macOS, FreeBSD, DragonflyBSD, and Windows.')
+endif
+
+cc = meson.get_compiler('c')
+
+if host_machine.system() == 'darwin' and cc.get_id() != 'clang'
+  # this will only work on mac if using Apple's clang compiler, but there is no
+  # way in the meson source level to differentiate apple clang and llvm clang
+  # In the meson CI only apple clang is tested
+  error('MESON_SKIP_TEST on macOS only clang is supported.')
+endif
+
+if not (cc.find_library('z', required: false).found() or
+        cc.find_library('zlib', required : false).found() or
+        cc.find_library('zlib1', required : false).found())
+  error('MESON_SKIP_TEST Cannot seem to find zlib via find_library, this test will probably fail.')
+endif
+
+z = dependency('zlib', method : 'system')
+assert(z.version().version_compare('>= 1.2'), 'Version does not seem to have been detected correctly.')


### PR DESCRIPTION
This adds a system depenedency for zlib, so that platforms that ship zlib as part of the base os (macOS, FreeBSD, and probably other BSDs but I don't have VMs for all of them).  This allows zlib to be found without the use of cmake of pkg-config, which is especially helpful on macOS.

This has been updated on top of #6443

Fixes #2654