### PR TITLE
[skip ci] Use more up-to-date wording regarding package managers

### DIFF
--- a/docs/markdown/Wrap-dependency-system-manual.md
+++ b/docs/markdown/Wrap-dependency-system-manual.md
@@ -1,10 +1,8 @@
 # Wrap dependency system manual
 
 One of the major problems of multiplatform development is wrangling
-all your dependencies. This is easy on Linux where you can use system
-packages (and happen to know that your target distribution provides a
-recent enough version of the dependency) but awkward on other
-platforms. Most of those do not have a package manager at all. This
+all your dependencies. This is awkward on many platforms, especially
+on ones that do not have a built-in package manager. The latter problem
 has been worked around by having third party package managers. They
 are not really a solution for end user deployment, because you can't
 tell them to install a package manager just to use your app. On these

--- a/docs/markdown/Wrap-dependency-system-manual.md
+++ b/docs/markdown/Wrap-dependency-system-manual.md
@@ -6,7 +6,9 @@ on ones that do not have a built-in package manager. The latter problem
 has been worked around by having third party package managers. They
 are not really a solution for end user deployment, because you can't
 tell them to install a package manager just to use your app. On these
-platforms you must produce self-contained applications.
+platforms you must produce self-contained applications. Same applies
+when destination platform is missing (up-to-date versions of) your
+application's dependencies.
 
 The traditional approach to this has been to bundle dependencies
 inside your own project. Either as prebuilt libraries and headers or


### PR DESCRIPTION
Most of the OSes (even counting all Linux distos as one) Meson supports actually do have package managers, and at least some of them are not harder (if not saying opposite) to use than Linux ones.

Here is the state of OSes mentioned on https://mesonbuild.com/Reference-tables.html:

| OS | has package manager? |
| -- | -------------------- |
| cygwin | yes |
| darwin | no |
| dragonfly | yes |
| emscripten | no |
| freebsd | yes |
| gnu | third-party |
| haiku |  no |
| linux |  yes/no |
| netbsd |  yes |
| openbsd |  yes |
| windows | no |
| sunos | yes |