### PR TITLE
Fix CUDA test without devices.

### DIFF
--- a/test cases/cuda/11 cuda dependency (nvcc)/version_reqs/prog.cu
+++ b/test cases/cuda/11 cuda dependency (nvcc)/version_reqs/prog.cu
@@ -9,20 +9,21 @@ int cuda_devices(void) {
 
 int main(void) {
     std::cout << "Compiled against CUDA version: " << CUDART_VERSION << "\n";
+
     int runtime_version = 0;
-    cudaError_t r = cudaRuntimeGetVersion(&runtime_version);
-    if (r != cudaSuccess) {
-        std::cout << "Couldn't obtain CUDA runtime version (error " << r << "). Exiting.\n";
-        return -1;
+    switch (cudaError_t r = cudaRuntimeGetVersion(&runtime_version)) {
+        case cudaSuccess:
+            std::cout << "CUDA runtime version: " << runtime_version << "\n";
+            break;
+        case cudaErrorNoDevice:
+            std::cout << "No CUDA hardware found. Exiting.\n";
+            return 0;
+        default:
+            std::cout << "Couldn't obtain CUDA runtime version (error " << r << "). Exiting.\n";
+            return -1;
     }
-    std::cout << "CUDA runtime version: " << runtime_version << "\n";
 
     int n = cuda_devices();
-    if (n == 0) {
-        std::cout << "No CUDA hardware found. Exiting.\n";
-        return 0;
-    }
-
     std::cout << "Found " << n << " CUDA devices.\n";
     return 0;
 }


### PR DESCRIPTION
Getting the runtime version fails when no devices are present.