### PR TITLE
Use python3 in some tests which were still using python

### DIFF
--- a/test cases/common/52 custom target/depfile/dep.py
+++ b/test cases/common/52 custom target/depfile/dep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys, os
 from glob import glob

--- a/test cases/common/53 custom target chain/my_compiler.py
+++ b/test cases/common/53 custom target chain/my_compiler.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test cases/common/53 custom target chain/my_compiler2.py
+++ b/test cases/common/53 custom target chain/my_compiler2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test cases/common/53 custom target chain/usetarget/subcomp.py
+++ b/test cases/common/53 custom target chain/usetarget/subcomp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/test cases/common/99 manygen/subdir/manygen.py
+++ b/test cases/common/99 manygen/subdir/manygen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/test cases/linuxlike/14 static dynamic linkage/verify_static.py
+++ b/test cases/linuxlike/14 static dynamic linkage/verify_static.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Test script that checks if zlib was statically linked to executable"""
 import subprocess
 import sys

--- a/test cases/unit/11 cross prog/some_cross_tool.py
+++ b/test cases/unit/11 cross prog/some_cross_tool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/test cases/unit/11 cross prog/sometool.py
+++ b/test cases/unit/11 cross prog/sometool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 

--- a/test cases/unit/39 python extmodule/blaster.py
+++ b/test cases/unit/39 python extmodule/blaster.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import tachyon

--- a/test cases/unit/61 identity cross/build_wrapper.py
+++ b/test cases/unit/61 identity cross/build_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import subprocess, sys
 

--- a/test cases/unit/61 identity cross/host_wrapper.py
+++ b/test cases/unit/61 identity cross/host_wrapper.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import subprocess, sys
 

--- a/test cases/windows/8 find program/test-script
+++ b/test cases/windows/8 find program/test-script
@@ -1,3 +1,3 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 print('1')


### PR DESCRIPTION
The unversioned command is deprecated and removed from some distributions