### PR TITLE
Add a proper dependency factory API for dependencies with more than one discovery method

### DIFF
--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -24,7 +24,7 @@ from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory
 from .coarrays import CoarrayDependency
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
-from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, ThreadDependency, GpgmeDependency, ShadercDependency, cups_factory, libgcrypt_factory, libwmf_factory, pcap_factory, python3_factory)
+from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, ThreadDependency, ShadercDependency, cups_factory, gpgme_factory, libgcrypt_factory, libwmf_factory, pcap_factory, python3_factory)
 from .platform import AppleFrameworks
 from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, vulkan_factory
 
@@ -56,7 +56,7 @@ packages.update({
     'cups': cups_factory,
     'libwmf': libwmf_factory,
     'libgcrypt': libgcrypt_factory,
-    'gpgme': GpgmeDependency,
+    'gpgme': gpgme_factory,
     'shaderc': ShadercDependency,
 
     # From platform:

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -24,7 +24,7 @@ from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory
 from .coarrays import CoarrayDependency
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
-from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, Python3Dependency, ThreadDependency, CupsDependency, LibWmfDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency, pcap_factory)
+from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, ThreadDependency, CupsDependency, LibWmfDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency, pcap_factory, python3_factory)
 from .platform import AppleFrameworks
 from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, vulkan_factory
 
@@ -50,7 +50,7 @@ packages.update({
     'curses': CursesDependency,
     'netcdf': NetCDFDependency,
     'openmp': OpenMPDependency,
-    'python3': Python3Dependency,
+    'python3': python3_factory,
     'threads': ThreadDependency,
     'pcap': pcap_factory,
     'cups': CupsDependency,

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -24,7 +24,11 @@ from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory
 from .coarrays import coarray_factory
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
-from .misc import (BlocksDependency, CursesDependency, OpenMPDependency, cups_factory, gpgme_factory, libgcrypt_factory, libwmf_factory, netcdf_factory, pcap_factory, python3_factory, shaderc_factory, threads_factory)
+from .misc import (
+    BlocksDependency, OpenMPDependency, cups_factory, curses_factory, gpgme_factory,
+    libgcrypt_factory, libwmf_factory, netcdf_factory, pcap_factory, python3_factory,
+    shaderc_factory, threads_factory,
+)
 from .platform import AppleFrameworks
 from .ui import GnuStepDependency, Qt4Dependency, Qt5Dependency, WxDependency, gl_factory, sdl2_factory, vulkan_factory
 
@@ -47,7 +51,7 @@ packages.update({
 
     # From misc:
     'blocks': BlocksDependency,
-    'curses': CursesDependency,
+    'curses': curses_factory,
     'netcdf': netcdf_factory,
     'openmp': OpenMPDependency,
     'python3': python3_factory,

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -18,8 +18,9 @@ from .hdf5 import HDF5Dependency
 from .base import (  # noqa: F401
     Dependency, DependencyException, DependencyMethods, ExternalProgram, EmptyExternalProgram, NonExistingExternalProgram,
     ExternalDependency, NotFoundDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
-    PkgConfigDependency, CMakeDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language)
-from .dev import GMockDependency, GTestDependency, LLVMDependency, ValgrindDependency
+    PkgConfigDependency, CMakeDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language,
+    DependencyFactory)
+from .dev import GMockDependency, GTestDependency, ValgrindDependency, llvm_factory
 from .coarrays import CoarrayDependency
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
@@ -33,7 +34,7 @@ packages.update({
     # From dev:
     'gtest': GTestDependency,
     'gmock': GMockDependency,
-    'llvm': LLVMDependency,
+    'llvm': llvm_factory,
     'valgrind': ValgrindDependency,
 
     'boost': BoostDependency,

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -27,7 +27,7 @@ from .scalapack import ScalapackDependency
 from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, Python3Dependency, ThreadDependency,
                    PcapDependency, CupsDependency, LibWmfDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency)
 from .platform import AppleFrameworks
-from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, VulkanDependency
+from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, vulkan_factory
 
 
 packages.update({
@@ -70,7 +70,7 @@ packages.update({
     'qt5': Qt5Dependency,
     'sdl2': SDL2Dependency,
     'wxwidgets': WxDependency,
-    'vulkan': VulkanDependency,
+    'vulkan': vulkan_factory,
 })
 _packages_accept_language.update({
     'hdf5',

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -20,7 +20,7 @@ from .base import (  # noqa: F401
     ExternalDependency, NotFoundDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
     PkgConfigDependency, CMakeDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language,
     DependencyFactory)
-from .dev import GMockDependency, ValgrindDependency, gtest_factory, llvm_factory
+from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory
 from .coarrays import CoarrayDependency
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
@@ -33,7 +33,7 @@ from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, S
 packages.update({
     # From dev:
     'gtest': gtest_factory,
-    'gmock': GMockDependency,
+    'gmock': gmock_factory,
     'llvm': llvm_factory,
     'valgrind': ValgrindDependency,
 

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -20,7 +20,7 @@ from .base import (  # noqa: F401
     ExternalDependency, NotFoundDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
     PkgConfigDependency, CMakeDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language,
     DependencyFactory)
-from .dev import GMockDependency, GTestDependency, ValgrindDependency, llvm_factory
+from .dev import GMockDependency, ValgrindDependency, gtest_factory, llvm_factory
 from .coarrays import CoarrayDependency
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
@@ -32,7 +32,7 @@ from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, S
 
 packages.update({
     # From dev:
-    'gtest': GTestDependency,
+    'gtest': gtest_factory,
     'gmock': GMockDependency,
     'llvm': llvm_factory,
     'valgrind': ValgrindDependency,

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -26,7 +26,7 @@ from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
 from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, ThreadDependency, ShadercDependency, cups_factory, gpgme_factory, libgcrypt_factory, libwmf_factory, pcap_factory, python3_factory)
 from .platform import AppleFrameworks
-from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, vulkan_factory
+from .ui import GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, gl_factory, vulkan_factory
 
 
 packages.update({
@@ -63,7 +63,7 @@ packages.update({
     'appleframeworks': AppleFrameworks,
 
     # From ui:
-    'gl': GLDependency,
+    'gl': gl_factory,
     'gnustep': GnuStepDependency,
     'qt4': Qt4Dependency,
     'qt5': Qt5Dependency,

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -24,7 +24,7 @@ from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory
 from .coarrays import CoarrayDependency
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
-from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, ThreadDependency, LibWmfDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency, cups_factory, pcap_factory, python3_factory)
+from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, ThreadDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency, cups_factory, libwmf_factory, pcap_factory, python3_factory)
 from .platform import AppleFrameworks
 from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, vulkan_factory
 
@@ -54,7 +54,7 @@ packages.update({
     'threads': ThreadDependency,
     'pcap': pcap_factory,
     'cups': cups_factory,
-    'libwmf': LibWmfDependency,
+    'libwmf': libwmf_factory,
     'libgcrypt': LibGCryptDependency,
     'gpgme': GpgmeDependency,
     'shaderc': ShadercDependency,

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -24,7 +24,7 @@ from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory
 from .coarrays import CoarrayDependency
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
-from .misc import (BlocksDependency, CursesDependency, OpenMPDependency, ThreadDependency, cups_factory, gpgme_factory, libgcrypt_factory, libwmf_factory, netcdf_factory, pcap_factory, python3_factory, shaderc_factory)
+from .misc import (BlocksDependency, CursesDependency, OpenMPDependency, cups_factory, gpgme_factory, libgcrypt_factory, libwmf_factory, netcdf_factory, pcap_factory, python3_factory, shaderc_factory, threads_factory)
 from .platform import AppleFrameworks
 from .ui import GnuStepDependency, Qt4Dependency, Qt5Dependency, WxDependency, gl_factory, sdl2_factory, vulkan_factory
 
@@ -51,7 +51,7 @@ packages.update({
     'netcdf': netcdf_factory,
     'openmp': OpenMPDependency,
     'python3': python3_factory,
-    'threads': ThreadDependency,
+    'threads': threads_factory,
     'pcap': pcap_factory,
     'cups': cups_factory,
     'libwmf': libwmf_factory,

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -24,7 +24,7 @@ from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory
 from .coarrays import CoarrayDependency
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
-from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, ThreadDependency, ShadercDependency, cups_factory, gpgme_factory, libgcrypt_factory, libwmf_factory, pcap_factory, python3_factory)
+from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, ThreadDependency, cups_factory, gpgme_factory, libgcrypt_factory, libwmf_factory, pcap_factory, python3_factory, shaderc_factory)
 from .platform import AppleFrameworks
 from .ui import GnuStepDependency, Qt4Dependency, Qt5Dependency, WxDependency, gl_factory, sdl2_factory, vulkan_factory
 
@@ -57,7 +57,7 @@ packages.update({
     'libwmf': libwmf_factory,
     'libgcrypt': libgcrypt_factory,
     'gpgme': gpgme_factory,
-    'shaderc': ShadercDependency,
+    'shaderc': shaderc_factory,
 
     # From platform:
     'appleframeworks': AppleFrameworks,

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -24,7 +24,7 @@ from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory
 from .coarrays import CoarrayDependency
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
-from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, ThreadDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency, cups_factory, libwmf_factory, pcap_factory, python3_factory)
+from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, ThreadDependency, GpgmeDependency, ShadercDependency, cups_factory, libgcrypt_factory, libwmf_factory, pcap_factory, python3_factory)
 from .platform import AppleFrameworks
 from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, vulkan_factory
 
@@ -55,7 +55,7 @@ packages.update({
     'pcap': pcap_factory,
     'cups': cups_factory,
     'libwmf': libwmf_factory,
-    'libgcrypt': LibGCryptDependency,
+    'libgcrypt': libgcrypt_factory,
     'gpgme': GpgmeDependency,
     'shaderc': ShadercDependency,
 

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -24,8 +24,7 @@ from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory
 from .coarrays import CoarrayDependency
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
-from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, Python3Dependency, ThreadDependency,
-                   PcapDependency, CupsDependency, LibWmfDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency)
+from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, Python3Dependency, ThreadDependency, CupsDependency, LibWmfDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency, pcap_factory)
 from .platform import AppleFrameworks
 from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, vulkan_factory
 
@@ -53,7 +52,7 @@ packages.update({
     'openmp': OpenMPDependency,
     'python3': Python3Dependency,
     'threads': ThreadDependency,
-    'pcap': PcapDependency,
+    'pcap': pcap_factory,
     'cups': CupsDependency,
     'libwmf': LibWmfDependency,
     'libgcrypt': LibGCryptDependency,

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -21,7 +21,7 @@ from .base import (  # noqa: F401
     PkgConfigDependency, CMakeDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language,
     DependencyFactory)
 from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory
-from .coarrays import CoarrayDependency
+from .coarrays import coarray_factory
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
 from .misc import (BlocksDependency, CursesDependency, OpenMPDependency, cups_factory, gpgme_factory, libgcrypt_factory, libwmf_factory, netcdf_factory, pcap_factory, python3_factory, shaderc_factory, threads_factory)
@@ -40,7 +40,7 @@ packages.update({
     'cuda': CudaDependency,
 
     # per-file
-    'coarray': CoarrayDependency,
+    'coarray': coarray_factory,
     'hdf5': HDF5Dependency,
     'mpi': MPIDependency,
     'scalapack': ScalapackDependency,

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -26,7 +26,7 @@ from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
 from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, ThreadDependency, ShadercDependency, cups_factory, gpgme_factory, libgcrypt_factory, libwmf_factory, pcap_factory, python3_factory)
 from .platform import AppleFrameworks
-from .ui import GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, gl_factory, vulkan_factory
+from .ui import GnuStepDependency, Qt4Dependency, Qt5Dependency, WxDependency, gl_factory, sdl2_factory, vulkan_factory
 
 
 packages.update({
@@ -67,7 +67,7 @@ packages.update({
     'gnustep': GnuStepDependency,
     'qt4': Qt4Dependency,
     'qt5': Qt5Dependency,
-    'sdl2': SDL2Dependency,
+    'sdl2': sdl2_factory,
     'wxwidgets': WxDependency,
     'vulkan': vulkan_factory,
 })

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -33,6 +33,11 @@ from .platform import AppleFrameworks
 from .ui import GnuStepDependency, Qt4Dependency, Qt5Dependency, WxDependency, gl_factory, sdl2_factory, vulkan_factory
 
 
+# This is a dict where the keys should be strings, and the values must be one
+# of:
+# - An ExternalDependency subclass
+# - A DependencyFactory object
+# - A callable with a signature of (Environment, MachineChoice, Dict[str, Any]) -> List[Callable[[], DependencyType]]
 packages.update({
     # From dev:
     'gtest': gtest_factory,

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -24,7 +24,7 @@ from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory
 from .coarrays import CoarrayDependency
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
-from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, ThreadDependency, cups_factory, gpgme_factory, libgcrypt_factory, libwmf_factory, pcap_factory, python3_factory, shaderc_factory)
+from .misc import (BlocksDependency, CursesDependency, OpenMPDependency, ThreadDependency, cups_factory, gpgme_factory, libgcrypt_factory, libwmf_factory, netcdf_factory, pcap_factory, python3_factory, shaderc_factory)
 from .platform import AppleFrameworks
 from .ui import GnuStepDependency, Qt4Dependency, Qt5Dependency, WxDependency, gl_factory, sdl2_factory, vulkan_factory
 
@@ -48,7 +48,7 @@ packages.update({
     # From misc:
     'blocks': BlocksDependency,
     'curses': CursesDependency,
-    'netcdf': NetCDFDependency,
+    'netcdf': netcdf_factory,
     'openmp': OpenMPDependency,
     'python3': python3_factory,
     'threads': ThreadDependency,

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -24,7 +24,7 @@ from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory
 from .coarrays import CoarrayDependency
 from .mpi import MPIDependency
 from .scalapack import ScalapackDependency
-from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, ThreadDependency, CupsDependency, LibWmfDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency, pcap_factory, python3_factory)
+from .misc import (BlocksDependency, CursesDependency, NetCDFDependency, OpenMPDependency, ThreadDependency, LibWmfDependency, LibGCryptDependency, GpgmeDependency, ShadercDependency, cups_factory, pcap_factory, python3_factory)
 from .platform import AppleFrameworks
 from .ui import GLDependency, GnuStepDependency, Qt4Dependency, Qt5Dependency, SDL2Dependency, WxDependency, vulkan_factory
 
@@ -53,7 +53,7 @@ packages.update({
     'python3': python3_factory,
     'threads': ThreadDependency,
     'pcap': pcap_factory,
-    'cups': CupsDependency,
+    'cups': cups_factory,
     'libwmf': LibWmfDependency,
     'libgcrypt': LibGCryptDependency,
     'gpgme': GpgmeDependency,

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -195,8 +195,8 @@ class Dependency:
                 return True
         return False
 
-    def _add_sub_dependency(self, dep_type: T.Type['Dependency'], env: Environment,
-                            kwargs: T.Dict[str, T.Any], *,
+    def _add_sub_dependency(self, dep_type: T.Type['Dependency'], name: str,
+                            env: Environment, kwargs: T.Dict[str, T.Any], *,
                             method: DependencyMethods = DependencyMethods.AUTO) -> None:
         """Add an internal dependency of of the given type.
 
@@ -207,7 +207,7 @@ class Dependency:
         """
         kwargs = kwargs.copy()
         kwargs['method'] = method
-        self.ext_deps.append(dep_type(env, kwargs))
+        self.ext_deps.append(dep_type(name, env, kwargs))
 
     def get_variable(self, *, cmake: T.Optional[str] = None, pkgconfig: T.Optional[str] = None,
                      configtool: T.Optional[str] = None, internal: T.Optional[str] = None,

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -427,30 +427,6 @@ class ConfigToolDependency(ExternalDependency):
             return m.group(0).rstrip('.')
         return version
 
-    @classmethod
-    def factory(cls, name, environment, language, kwargs, tools, tool_name, finish_init=None):
-        """Constructor for use in dependencies that can be found multiple ways.
-
-        In addition to the standard constructor values, this constructor sets
-        the tool_name and tools values of the instance.
-        """
-        # This deserves some explanation, because metaprogramming is hard.
-        # This uses type() to create a dynamic subclass of ConfigToolDependency
-        # with the tools and tool_name class attributes set, this class is then
-        # instantiated and returned. The reduce function (method) is also
-        # attached, since python's pickle module won't be able to do anything
-        # with this dynamically generated class otherwise.
-        def reduce(self):
-            return (cls._unpickle, (), self.__dict__)
-        sub = type('{}Dependency'.format(name.capitalize()), (cls, ),
-                   {'tools': tools, 'tool_name': tool_name, '__reduce__': reduce, 'finish_init': staticmethod(finish_init)})
-
-        return sub(name, environment, kwargs, language=language)
-
-    @classmethod
-    def _unpickle(cls):
-        return cls.__new__(cls)
-
     def find_config(self, versions=None):
         """Helper method that searches for config tool binaries in PATH and
         returns the one that best matches the given version requirements.

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -180,7 +180,7 @@ class Dependency:
         """
         raise RuntimeError('Unreachable code in partial_dependency called')
 
-    def _add_sub_dependency2(self, deplist: T.List['DependencyType']) -> bool:
+    def _add_sub_dependency(self, deplist: T.List['DependencyType']) -> bool:
         """Add an internal depdency from a list of possible dependencies.
 
         This method is intended to make it easier to add additional
@@ -195,20 +195,6 @@ class Dependency:
                 self.ext_deps.append(dep)
                 return True
         return False
-
-    def _add_sub_dependency(self, dep_type: T.Type['Dependency'], name: str,
-                            env: Environment, kwargs: T.Dict[str, T.Any], *,
-                            method: DependencyMethods = DependencyMethods.AUTO) -> None:
-        """Add an internal dependency of of the given type.
-
-        This method is intended to simplify cases of adding a dependency on
-        another dependency type (such as threads). This will by default set
-        the method back to auto, but the 'method' keyword argument can be
-        used to overwrite this behavior.
-        """
-        kwargs = kwargs.copy()
-        kwargs['method'] = method
-        self.ext_deps.append(dep_type(name, env, kwargs))
 
     def get_variable(self, *, cmake: T.Optional[str] = None, pkgconfig: T.Optional[str] = None,
                      configtool: T.Optional[str] = None, internal: T.Optional[str] = None,

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -2212,6 +2212,7 @@ class DependencyFactory:
     """
 
     def __init__(self, name: str, methods: T.List[DependencyMethods], *,
+                 extra_kwargs: T.Optional[T.Dict[str, T.Any]] = None,
                  pkgconfig_name: T.Optional[str] = None,
                  pkgconfig_class: 'T.Type[PkgConfigDependency]' = PkgConfigDependency,
                  cmake_name: T.Optional[str] = None,
@@ -2224,6 +2225,7 @@ class DependencyFactory:
         if DependencyMethods.CONFIG_TOOL in methods and not configtool_class:
             raise DependencyException('A configtool must have a custom class')
 
+        self.extra_kwargs = extra_kwargs or {}
         self.methods = methods
         self.classes = {
             # Just attach the correct name right now, either the generic name
@@ -2256,8 +2258,10 @@ class DependencyFactory:
                  kwargs: T.Dict[str, T.Any]) -> T.List['DependencyType']:
         """Return a list of Dependencies with the arguments already attached."""
         methods = process_method_kw(self.methods, kwargs)
+        nwargs = self.extra_kwargs.copy()
+        nwargs.update(kwargs)
 
-        return [functools.partial(self.classes[m], env, kwargs) for m in methods
+        return [functools.partial(self.classes[m], env, nwargs) for m in methods
                 if self._process_method(m, env, for_machine)]
 
 

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -179,6 +179,22 @@ class Dependency:
         """
         raise RuntimeError('Unreachable code in partial_dependency called')
 
+    def _add_sub_dependency2(self, deplist: T.List['DependencyType']) -> bool:
+        """Add an internal depdency from a list of possible dependencies.
+
+        This method is intended to make it easier to add additional
+        dependencies to another dependency internally.
+
+        Returns true if the dependency was successfully added, false
+        otherwise.
+        """
+        for d in deplist:
+            dep = d()
+            if dep.is_found:
+                self.ext_deps.append(dep)
+                return True
+        return False
+
     def _add_sub_dependency(self, dep_type: T.Type['Dependency'], env: Environment,
                             kwargs: T.Dict[str, T.Any], *,
                             method: DependencyMethods = DependencyMethods.AUTO) -> None:

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -105,7 +105,7 @@ class BoostDependency(ExternalDependency):
 
         self.requested_modules = self.get_requested(kwargs)
         if 'thread' in self.requested_modules:
-            if not self._add_sub_dependency2(threads_factory(environment, self.for_machine, {})):
+            if not self._add_sub_dependency(threads_factory(environment, self.for_machine, {})):
                 self.is_found = False
                 return
 

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -22,7 +22,7 @@ from .. import mesonlib
 from ..environment import detect_cpu_family
 
 from .base import (DependencyException, ExternalDependency)
-from .misc import ThreadDependency
+from .misc import threads_factory
 
 # On windows 3 directory layouts are supported:
 # * The default layout (versioned) installed:
@@ -105,7 +105,9 @@ class BoostDependency(ExternalDependency):
 
         self.requested_modules = self.get_requested(kwargs)
         if 'thread' in self.requested_modules:
-            self._add_sub_dependency(ThreadDependency, environment, kwargs)
+            if not self._add_sub_dependency2(threads_factory(environment, self.for_machine, {})):
+                self.is_found = False
+                return
 
         self.boost_root = None
         self.boost_roots = []

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -97,7 +97,7 @@ from .misc import ThreadDependency
 
 class BoostDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
-        super().__init__('boost', environment, 'cpp', kwargs)
+        super().__init__('boost', environment, kwargs, language='cpp')
         self.need_static_link = ['boost_exception', 'boost_test_exec_monitor']
         self.is_debug = environment.coredata.get_builtin_option('buildtype').startswith('debug')
         threading = kwargs.get("threading", "multi")

--- a/mesonbuild/dependencies/coarrays.py
+++ b/mesonbuild/dependencies/coarrays.py
@@ -12,8 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..mesonlib import listify
-from .base import CMakeDependency, DependencyMethods, ExternalDependency, PkgConfigDependency
+import functools
+import typing as T
+
+from .base import CMakeDependency, DependencyMethods, ExternalDependency, PkgConfigDependency, detect_compiler, factory_methods
+
+if T.TYPE_CHECKING:
+    from . base import DependencyType
+    from ..environment import Environment, MachineChoice
+
+
+@factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.CMAKE, DependencyMethods.SYSTEM})
+def coarray_factory(env: 'Environment', for_machine: 'MachineChoice',
+                    kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> T.List['DependencyType']:
+    fcid = detect_compiler('coarray', env, for_machine, 'fortran').get_id()
+    candidates = []  # type: T.List[DependencyType]
+
+    if fcid == 'gcc':
+        # OpenCoarrays is the most commonly used method for Fortran Coarray with GCC
+        if DependencyMethods.PKGCONFIG in methods:
+            for pkg in ['caf-openmpi', 'caf']:
+                candidates.append(functools.partial(
+                    PkgConfigDependency, pkg, env, kwargs, language='fortran'))
+
+        if DependencyMethods.CMAKE in methods:
+            if 'modules' not in kwargs:
+                kwargs['modules'] = 'OpenCoarrays::caf_mpi'
+            candidates.append(functools.partial(
+                CMakeDependency, 'OpenCoarrays', env, kwargs, language='fortran'))
+
+    if DependencyMethods.SYSTEM in methods:
+        candidates.append(functools.partial(CoarrayDependency, env, kwargs))
+
+    return candidates
 
 
 class CoarrayDependency(ExternalDependency):
@@ -29,53 +60,24 @@ class CoarrayDependency(ExternalDependency):
         super().__init__('coarray', environment, kwargs, language='fortran')
         kwargs['required'] = False
         kwargs['silent'] = True
-        self.is_found = False
-        methods = listify(self.methods)
 
         cid = self.get_compiler().get_id()
         if cid == 'gcc':
-            """ OpenCoarrays is the most commonly used method for Fortran Coarray with GCC """
-
-            if set([DependencyMethods.AUTO, DependencyMethods.PKGCONFIG]).intersection(methods):
-                for pkg in ['caf-openmpi', 'caf']:
-                    pkgdep = PkgConfigDependency(pkg, environment, kwargs, language=self.language)
-                    if pkgdep.found():
-                        self.compile_args = pkgdep.get_compile_args()
-                        self.link_args = pkgdep.get_link_args()
-                        self.version = pkgdep.get_version()
-                        self.is_found = True
-                        self.pcdep = pkgdep
-                        return
-
-            if set([DependencyMethods.AUTO, DependencyMethods.CMAKE]).intersection(methods):
-                if not kwargs.get('modules'):
-                    kwargs['modules'] = 'OpenCoarrays::caf_mpi'
-                cmakedep = CMakeDependency('OpenCoarrays', environment, kwargs, language=self.language)
-                if cmakedep.found():
-                    self.compile_args = cmakedep.get_compile_args()
-                    self.link_args = cmakedep.get_link_args()
-                    self.version = cmakedep.get_version()
-                    self.is_found = True
-                    return
-
-            if DependencyMethods.AUTO in methods:
-                # fallback to single image
-                self.compile_args = ['-fcoarray=single']
-                self.version = 'single image (fallback)'
-                self.is_found = True
-                return
-
+            # Fallback to single image
+            self.compile_args = ['-fcoarray=single']
+            self.version = 'single image (fallback)'
+            self.is_found = True
         elif cid == 'intel':
-            """ Coarrays are built into Intel compilers, no external library needed """
+            # Coarrays are built into Intel compilers, no external library needed
             self.is_found = True
             self.link_args = ['-coarray=shared']
             self.compile_args = self.link_args
         elif cid == 'intel-cl':
-            """ Coarrays are built into Intel compilers, no external library needed """
+            # Coarrays are built into Intel compilers, no external library needed
             self.is_found = True
             self.compile_args = ['/Qcoarray:shared']
         elif cid == 'nagfor':
-            """ NAG doesn't require any special arguments for Coarray """
+            # NAG doesn't require any special arguments for Coarray
             self.is_found = True
 
     @staticmethod

--- a/mesonbuild/dependencies/coarrays.py
+++ b/mesonbuild/dependencies/coarrays.py
@@ -26,7 +26,7 @@ class CoarrayDependency(ExternalDependency):
     low-level MPI calls.
     """
     def __init__(self, environment, kwargs: dict):
-        super().__init__('coarray', environment, 'fortran', kwargs)
+        super().__init__('coarray', environment, kwargs, language='fortran')
         kwargs['required'] = False
         kwargs['silent'] = True
         self.is_found = False

--- a/mesonbuild/dependencies/cuda.py
+++ b/mesonbuild/dependencies/cuda.py
@@ -33,7 +33,7 @@ class CudaDependency(ExternalDependency):
         if language not in self.supported_languages:
             raise DependencyException('Language \'{}\' is not supported by the CUDA Toolkit. Supported languages are {}.'.format(language, self.supported_languages))
 
-        super().__init__('cuda', environment, language, kwargs)
+        super().__init__('cuda', environment, kwargs, language=language)
         self.requested_modules = self.get_requested(kwargs)
         if 'cudart' not in self.requested_modules:
             self.requested_modules = ['cudart'] + self.requested_modules

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -25,7 +25,7 @@ from ..mesonlib import version_compare, stringlistify, extract_as_list, MachineC
 from ..environment import get_llvm_tool_names
 from .base import (
     DependencyException, DependencyMethods, ExternalDependency, PkgConfigDependency,
-    strip_system_libdirs, ConfigToolDependency, CMakeDependency
+    strip_system_libdirs, ConfigToolDependency, CMakeDependency, process_method_kw
 )
 from .misc import ThreadDependency
 
@@ -100,7 +100,7 @@ class GTestDependency(ExternalDependency):
 
     @classmethod
     def _factory(cls, environment, kwargs):
-        methods = cls._process_method_kw(kwargs)
+        methods = process_method_kw(cls.get_methods(), kwargs)
         candidates = []
 
         if DependencyMethods.PKGCONFIG in methods:
@@ -179,7 +179,7 @@ class GMockDependency(ExternalDependency):
 
     @classmethod
     def _factory(cls, environment, kwargs):
-        methods = cls._process_method_kw(kwargs)
+        methods = process_method_kw(cls.get_methods(), kwargs)
         candidates = []
 
         if DependencyMethods.PKGCONFIG in methods:
@@ -439,7 +439,7 @@ class LLVMDependency(ExternalDependency):
 
     @classmethod
     def _factory(cls, env, kwargs):
-        methods = cls._process_method_kw(kwargs)
+        methods = process_method_kw(cls.get_methods(), kwargs)
         candidates = []
 
         if DependencyMethods.CONFIG_TOOL in methods:

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -50,7 +50,7 @@ class GTestDependencySystem(ExternalDependency):
         super().__init__(name, environment, kwargs, language='cpp')
         self.main = kwargs.get('main', False)
         self.src_dirs = ['/usr/src/gtest/src', '/usr/src/googletest/googletest/src']
-        if not self._add_sub_dependency2(threads_factory(environment, self.for_machine, {})):
+        if not self._add_sub_dependency(threads_factory(environment, self.for_machine, {})):
             self.is_found = False
             return
         self.detect()
@@ -119,7 +119,7 @@ class GMockDependencySystem(ExternalDependency):
     def __init__(self, name: str, environment, kwargs):
         super().__init__(name, environment, kwargs, language='cpp')
         self.main = kwargs.get('main', False)
-        if not self._add_sub_dependency2(threads_factory(environment, self.for_machine, {})):
+        if not self._add_sub_dependency(threads_factory(environment, self.for_machine, {})):
             self.is_found = False
             return
 
@@ -132,7 +132,7 @@ class GMockDependencySystem(ExternalDependency):
         # GMock without GTest is pretty much useless
         # this also mimics the structure given in WrapDB,
         # where GMock always pulls in GTest
-        found = self._add_sub_dependency2(gtest_factory(environment, self.for_machine, gtest_kwargs))
+        found = self._add_sub_dependency(gtest_factory(environment, self.for_machine, gtest_kwargs))
         if not found:
             self.is_found = False
             return
@@ -235,7 +235,7 @@ class LLVMDependencyConfigTool(ConfigToolDependency):
             self._set_old_link_args()
         self.link_args = strip_system_libdirs(environment, self.for_machine, self.link_args)
         self.link_args = self.__fix_bogus_link_args(self.link_args)
-        if not self._add_sub_dependency2(threads_factory(environment, self.for_machine, {})):
+        if not self._add_sub_dependency(threads_factory(environment, self.for_machine, {})):
             self.is_found = False
             return
 
@@ -400,7 +400,7 @@ class LLVMDependencyCMake(CMakeDependency):
         defs = self.traceparser.get_cmake_var('PACKAGE_DEFINITIONS')
         temp = ['-I' + x for x in inc_dirs] + defs
         self.compile_args += [x for x in temp if x not in self.compile_args]
-        if not self._add_sub_dependency2(threads_factory(env, self.for_machine, {})):
+        if not self._add_sub_dependency(threads_factory(env, self.for_machine, {})):
             self.is_found = False
             return
 

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -46,7 +46,7 @@ def get_shared_library_suffix(environment, for_machine: MachineChoice):
 
 class GTestDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
-        super().__init__('gtest', environment, 'cpp', kwargs)
+        super().__init__('gtest', environment, kwargs, language='cpp')
         self.main = kwargs.get('main', False)
         self.src_dirs = ['/usr/src/gtest/src', '/usr/src/googletest/googletest/src']
         self.detect()
@@ -119,7 +119,7 @@ class GTestDependency(ExternalDependency):
 
 class GMockDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
-        super().__init__('gmock', environment, 'cpp', kwargs)
+        super().__init__('gmock', environment, kwargs, language='cpp')
         self.main = kwargs.get('main', False)
         self._add_sub_dependency(ThreadDependency, environment, kwargs)
 
@@ -218,7 +218,7 @@ class LLVMDependencyConfigTool(ConfigToolDependency):
 
         # It's necessary for LLVM <= 3.8 to use the C++ linker. For 3.9 and 4.0
         # the C linker works fine if only using the C API.
-        super().__init__('LLVM', environment, 'cpp', kwargs)
+        super().__init__('LLVM', environment, kwargs, language='cpp')
         self.provided_modules = []
         self.required_modules = set()
         self.module_details = []
@@ -394,7 +394,7 @@ class LLVMDependencyCMake(CMakeDependency):
     def __init__(self, env, kwargs):
         self.llvm_modules = stringlistify(extract_as_list(kwargs, 'modules'))
         self.llvm_opt_modules = stringlistify(extract_as_list(kwargs, 'optional_modules'))
-        super().__init__(name='LLVM', environment=env, language='cpp', kwargs=kwargs)
+        super().__init__('LLVM', env, kwargs, language='cpp')
 
         if self.traceparser is None:
             return
@@ -435,7 +435,7 @@ class LLVMDependencyCMake(CMakeDependency):
 
 class LLVMDependency(ExternalDependency):
     def __init__(self, env, kwargs):
-        super().__init__('LLVM', env, 'cpp', kwargs)
+        super().__init__('LLVM', env, kwargs, language='cpp')
 
     @classmethod
     def _factory(cls, env, kwargs):

--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -27,7 +27,7 @@ class HDF5Dependency(ExternalDependency):
 
     def __init__(self, environment, kwargs):
         language = kwargs.get('language', 'c')
-        super().__init__('hdf5', environment, language, kwargs)
+        super().__init__('hdf5', environment, kwargs, language=language)
         kwargs['required'] = False
         kwargs['silent'] = True
         self.is_found = False

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -105,33 +105,17 @@ class OpenMPDependency(ExternalDependency):
 
 
 class ThreadDependency(ExternalDependency):
-    def __init__(self, environment, kwargs):
-        super().__init__('threads', environment, kwargs)
-        self.name = 'threads'
-        self.is_found = False
-        methods = listify(self.methods)
-        if DependencyMethods.AUTO in methods:
-            self.is_found = True
-            # Happens if you are using a language with threads
-            # concept without C, such as plain Cuda.
-            if self.clib_compiler is None:
-                self.compile_args = []
-                self.link_args = []
-            else:
-                self.compile_args = self.clib_compiler.thread_flags(environment)
-                self.link_args = self.clib_compiler.thread_link_flags(environment)
-            return
-
-        if DependencyMethods.CMAKE in methods:
-            # for unit tests and for those who simply want
-            # dependency('threads', method: 'cmake')
-            cmakedep = CMakeDependency('Threads', environment, kwargs)
-            if cmakedep.found():
-                self.compile_args = cmakedep.get_compile_args()
-                self.link_args = cmakedep.get_link_args()
-                self.version = cmakedep.get_version()
-                self.is_found = True
-                return
+    def __init__(self, name: str, environment, kwargs):
+        super().__init__(name, environment, kwargs)
+        self.is_found = True
+        # Happens if you are using a language with threads
+        # concept without C, such as plain Cuda.
+        if self.clib_compiler is None:
+            self.compile_args = []
+            self.link_args = []
+        else:
+            self.compile_args = self.clib_compiler.thread_flags(environment)
+            self.link_args = self.clib_compiler.thread_link_flags(environment)
 
     @staticmethod
     def get_methods():
@@ -507,4 +491,11 @@ python3_factory = DependencyFactory(
     # There is a python in /System/Library/Frameworks, but thats python 2.x,
     # Python 3 will always be in /Library
     extra_kwargs={'paths': ['/Library/Frameworks']},
+)
+
+threads_factory = DependencyFactory(
+    'threads',
+    [DependencyMethods.SYSTEM, DependencyMethods.CMAKE],
+    cmake_name='Threads',
+    system_class=ThreadDependency,
 )

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -27,7 +27,7 @@ from ..mesonlib import listify
 from .base import (
     DependencyException, DependencyMethods, ExternalDependency,
     ExtraFrameworkDependency, PkgConfigDependency,
-    CMakeDependency, ConfigToolDependency,
+    CMakeDependency, ConfigToolDependency, process_method_kw,
 )
 
 
@@ -205,7 +205,7 @@ class Python3Dependency(ExternalDependency):
 
     @classmethod
     def _factory(cls, environment, kwargs):
-        methods = cls._process_method_kw(kwargs)
+        methods = process_method_kw(cls.get_methods(), kwargs)
         candidates = []
 
         if DependencyMethods.PKGCONFIG in methods:
@@ -329,7 +329,7 @@ class PcapDependency(ExternalDependency):
 
     @classmethod
     def _factory(cls, environment, kwargs):
-        methods = cls._process_method_kw(kwargs)
+        methods = process_method_kw(cls.get_methods(), kwargs)
         candidates = []
 
         if DependencyMethods.PKGCONFIG in methods:
@@ -374,7 +374,7 @@ class CupsDependency(ExternalDependency):
 
     @classmethod
     def _factory(cls, environment, kwargs):
-        methods = cls._process_method_kw(kwargs)
+        methods = process_method_kw(cls.get_methods(), kwargs)
         candidates = []
 
         if DependencyMethods.PKGCONFIG in methods:
@@ -416,7 +416,7 @@ class LibWmfDependency(ExternalDependency):
 
     @classmethod
     def _factory(cls, environment, kwargs):
-        methods = cls._process_method_kw(kwargs)
+        methods = process_method_kw(cls.get_methods(), kwargs)
         candidates = []
 
         if DependencyMethods.PKGCONFIG in methods:
@@ -444,7 +444,7 @@ class LibGCryptDependency(ExternalDependency):
 
     @classmethod
     def _factory(cls, environment, kwargs):
-        methods = cls._process_method_kw(kwargs)
+        methods = process_method_kw(cls.get_methods(), kwargs)
         candidates = []
 
         if DependencyMethods.PKGCONFIG in methods:
@@ -475,7 +475,7 @@ class GpgmeDependency(ExternalDependency):
 
     @classmethod
     def _factory(cls, environment, kwargs):
-        methods = cls._process_method_kw(kwargs)
+        methods = process_method_kw(cls.get_methods(), kwargs)
         candidates = []
 
         if DependencyMethods.PKGCONFIG in methods:
@@ -530,7 +530,7 @@ class ShadercDependency(ExternalDependency):
 
     @classmethod
     def _factory(cls, environment, kwargs):
-        methods = cls._process_method_kw(kwargs)
+        methods = process_method_kw(cls.get_methods(), kwargs)
         candidates = []
 
         if DependencyMethods.PKGCONFIG in methods:

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -35,7 +35,7 @@ class NetCDFDependency(ExternalDependency):
 
     def __init__(self, environment, kwargs):
         language = kwargs.get('language', 'c')
-        super().__init__('netcdf', environment, language, kwargs)
+        super().__init__('netcdf', environment, kwargs, language=language)
         kwargs['required'] = False
         kwargs['silent'] = True
         self.is_found = False
@@ -94,7 +94,7 @@ class OpenMPDependency(ExternalDependency):
 
     def __init__(self, environment, kwargs):
         language = kwargs.get('language')
-        super().__init__('openmp', environment, language, kwargs)
+        super().__init__('openmp', environment, kwargs, language=language)
         self.is_found = False
         if self.clib_compiler.get_id() == 'pgi':
             # through at least PGI 19.4, there is no macro defined for OpenMP, but OpenMP 3.1 is supported.
@@ -125,7 +125,7 @@ class OpenMPDependency(ExternalDependency):
 
 class ThreadDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
-        super().__init__('threads', environment, None, kwargs)
+        super().__init__('threads', environment, kwargs)
         self.name = 'threads'
         self.is_found = False
         methods = listify(self.methods)
@@ -159,7 +159,7 @@ class ThreadDependency(ExternalDependency):
 
 class BlocksDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
-        super().__init__('blocks', environment, None, kwargs)
+        super().__init__('blocks', environment, kwargs)
         self.name = 'blocks'
         self.is_found = False
 
@@ -192,7 +192,7 @@ class BlocksDependency(ExternalDependency):
 
 class Python3Dependency(ExternalDependency):
     def __init__(self, environment, kwargs):
-        super().__init__('python3', environment, None, kwargs)
+        super().__init__('python3', environment, kwargs)
 
         if not environment.machines.matches_build_machine(self.for_machine):
             return
@@ -219,9 +219,10 @@ class Python3Dependency(ExternalDependency):
             # number in its name.
             # There is a python in /System/Library/Frameworks, but that's
             # python 2, Python 3 will always be in /Library
+            _kargs = kwargs.copy()
+            _kargs[paths] = ['/Library/Frameworks']
             candidates.append(functools.partial(
-                ExtraFrameworkDependency, 'Python', False, ['/Library/Frameworks'],
-                environment, kwargs.get('language', None), kwargs))
+                ExtraFrameworkDependency, 'Python', environment, _kargs))
 
         return candidates
 
@@ -325,7 +326,7 @@ class Python3Dependency(ExternalDependency):
 class PcapDependency(ExternalDependency):
 
     def __init__(self, environment, kwargs):
-        super().__init__('pcap', environment, None, kwargs)
+        super().__init__('pcap', environment, kwargs)
 
     @classmethod
     def _factory(cls, environment, kwargs):
@@ -370,7 +371,7 @@ class PcapDependency(ExternalDependency):
 
 class CupsDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
-        super().__init__('cups', environment, None, kwargs)
+        super().__init__('cups', environment, kwargs)
 
     @classmethod
     def _factory(cls, environment, kwargs):
@@ -389,8 +390,7 @@ class CupsDependency(ExternalDependency):
         if DependencyMethods.EXTRAFRAMEWORK in methods:
             if mesonlib.is_osx():
                 candidates.append(functools.partial(
-                    ExtraFrameworkDependency, 'cups', False, None, environment,
-                    kwargs.get('language', None), kwargs))
+                    ExtraFrameworkDependency, 'cups', environment, kwargs))
 
         if DependencyMethods.CMAKE in methods:
             candidates.append(functools.partial(CMakeDependency, 'Cups', environment, kwargs))
@@ -412,7 +412,7 @@ class CupsDependency(ExternalDependency):
 
 class LibWmfDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
-        super().__init__('libwmf', environment, None, kwargs)
+        super().__init__('libwmf', environment, kwargs)
 
     @classmethod
     def _factory(cls, environment, kwargs):
@@ -440,7 +440,7 @@ class LibWmfDependency(ExternalDependency):
 
 class LibGCryptDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
-        super().__init__('libgcrypt', environment, None, kwargs)
+        super().__init__('libgcrypt', environment, kwargs)
 
     @classmethod
     def _factory(cls, environment, kwargs):
@@ -471,7 +471,7 @@ class LibGCryptDependency(ExternalDependency):
 
 class GpgmeDependency(ExternalDependency):
     def __init__(self, environment, kwargs):
-        super().__init__('gpgme', environment, None, kwargs)
+        super().__init__('gpgme', environment, kwargs)
 
     @classmethod
     def _factory(cls, environment, kwargs):
@@ -503,7 +503,7 @@ class GpgmeDependency(ExternalDependency):
 class ShadercDependency(ExternalDependency):
 
     def __init__(self, environment, kwargs):
-        super().__init__('shaderc', environment, None, kwargs)
+        super().__init__('shaderc', environment, kwargs)
 
         static_lib = 'shaderc_combined'
         shared_lib = 'shaderc_shared'

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -362,28 +362,13 @@ class LibWmfDependencyConfigTool(ConfigToolDependency):
         return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL]
 
 
-class LibGCryptDependency(ExternalDependency):
-    def __init__(self, environment, kwargs):
-        super().__init__('libgcrypt', environment, kwargs)
+class LibGCryptDependencyConfigTool(ConfigToolDependency):
 
-    @classmethod
-    def _factory(cls, environment, kwargs):
-        methods = process_method_kw(cls.get_methods(), kwargs)
-        candidates = []
-
-        if DependencyMethods.PKGCONFIG in methods:
-            candidates.append(functools.partial(PkgConfigDependency, 'libgcrypt', environment, kwargs))
-
-        if DependencyMethods.CONFIG_TOOL in methods:
-            candidates.append(functools.partial(ConfigToolDependency.factory,
-                                                'libgcrypt', environment, None, kwargs, ['libgcrypt-config'],
-                                                'libgcrypt-config',
-                                                LibGCryptDependency.tool_finish_init))
-
-        return candidates
+    tools = ['libgcrypt-config']
+    tool_name = 'libgcrypt-config'
 
     @staticmethod
-    def tool_finish_init(ctdep):
+    def finish_init(ctdep):
         ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
         ctdep.link_args = ctdep.get_config_value(['--libs'], 'link_args')
         ctdep.version = ctdep.get_config_value(['--version'], 'version')[0]
@@ -512,6 +497,12 @@ cups_factory = DependencyFactory(
     [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.EXTRAFRAMEWORK, DependencyMethods.CMAKE],
     configtool_class=CupsDependencyConfigTool,
     cmake_name='Cups',
+)
+
+libgcrypt_factory = DependencyFactory(
+    'libgcrypt',
+    [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL],
+    configtool_class=LibGCryptDependencyConfigTool,
 )
 
 libwmf_factory = DependencyFactory(

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -378,28 +378,13 @@ class LibGCryptDependencyConfigTool(ConfigToolDependency):
         return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL]
 
 
-class GpgmeDependency(ExternalDependency):
-    def __init__(self, environment, kwargs):
-        super().__init__('gpgme', environment, kwargs)
+class GpgmeDependencyConfigTool(ConfigToolDependency):
 
-    @classmethod
-    def _factory(cls, environment, kwargs):
-        methods = process_method_kw(cls.get_methods(), kwargs)
-        candidates = []
-
-        if DependencyMethods.PKGCONFIG in methods:
-            candidates.append(functools.partial(PkgConfigDependency, 'gpgme', environment, kwargs))
-
-        if DependencyMethods.CONFIG_TOOL in methods:
-            candidates.append(functools.partial(ConfigToolDependency.factory,
-                                                'gpgme', environment, None, kwargs, ['gpgme-config'],
-                                                'gpgme-config',
-                                                GpgmeDependency.tool_finish_init))
-
-        return candidates
+    tools = ['gpgme-config']
+    tool_name = 'gpg-config'
 
     @staticmethod
-    def tool_finish_init(ctdep):
+    def finish_init(ctdep):
         ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
         ctdep.link_args = ctdep.get_config_value(['--libs'], 'link_args')
         ctdep.version = ctdep.get_config_value(['--version'], 'version')[0]
@@ -497,6 +482,12 @@ cups_factory = DependencyFactory(
     [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.EXTRAFRAMEWORK, DependencyMethods.CMAKE],
     configtool_class=CupsDependencyConfigTool,
     cmake_name='Cups',
+)
+
+gpgme_factory = DependencyFactory(
+    'gpgme',
+    [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL],
+    configtool_class=GpgmeDependencyConfigTool,
 )
 
 libgcrypt_factory = DependencyFactory(

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -347,26 +347,13 @@ class CupsDependencyConfigTool(ConfigToolDependency):
             return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.CMAKE]
 
 
-class LibWmfDependency(ExternalDependency):
-    def __init__(self, environment, kwargs):
-        super().__init__('libwmf', environment, kwargs)
+class LibWmfDependencyConfigTool(ConfigToolDependency):
 
-    @classmethod
-    def _factory(cls, environment, kwargs):
-        methods = process_method_kw(cls.get_methods(), kwargs)
-        candidates = []
-
-        if DependencyMethods.PKGCONFIG in methods:
-            candidates.append(functools.partial(PkgConfigDependency, 'libwmf', environment, kwargs))
-
-        if DependencyMethods.CONFIG_TOOL in methods:
-            candidates.append(functools.partial(ConfigToolDependency.factory,
-                                                'libwmf', environment, None, kwargs, ['libwmf-config'], 'libwmf-config', LibWmfDependency.tool_finish_init))
-
-        return candidates
+    tools = ['libwmf-config']
+    tool_name = 'libwmf-config'
 
     @staticmethod
-    def tool_finish_init(ctdep):
+    def finish_init(ctdep):
         ctdep.compile_args = ctdep.get_config_value(['--cflags'], 'compile_args')
         ctdep.link_args = ctdep.get_config_value(['--libs'], 'link_args')
 
@@ -525,6 +512,12 @@ cups_factory = DependencyFactory(
     [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.EXTRAFRAMEWORK, DependencyMethods.CMAKE],
     configtool_class=CupsDependencyConfigTool,
     cmake_name='Cups',
+)
+
+libwmf_factory = DependencyFactory(
+    'libwmf',
+    [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL],
+    configtool_class=LibWmfDependencyConfigTool,
 )
 
 pcap_factory = DependencyFactory(

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -29,7 +29,7 @@ class MPIDependency(ExternalDependency):
 
     def __init__(self, environment, kwargs: dict):
         language = kwargs.get('language', 'c')
-        super().__init__('mpi', environment, language, kwargs)
+        super().__init__('mpi', environment, kwargs, language=language)
         kwargs['required'] = False
         kwargs['silent'] = True
         self.is_found = False

--- a/mesonbuild/dependencies/platform.py
+++ b/mesonbuild/dependencies/platform.py
@@ -20,7 +20,7 @@ from ..mesonlib import MesonException
 
 class AppleFrameworks(ExternalDependency):
     def __init__(self, env, kwargs):
-        super().__init__('appleframeworks', env, None, kwargs)
+        super().__init__('appleframeworks', env, kwargs)
         modules = kwargs.get('modules', [])
         if isinstance(modules, str):
             modules = [modules]

--- a/mesonbuild/dependencies/scalapack.py
+++ b/mesonbuild/dependencies/scalapack.py
@@ -21,7 +21,7 @@ from .base import CMakeDependency, DependencyMethods, ExternalDependency, PkgCon
 
 class ScalapackDependency(ExternalDependency):
     def __init__(self, environment, kwargs: dict):
-        super().__init__('scalapack', environment, None, kwargs)
+        super().__init__('scalapack', environment, kwargs)
         kwargs['required'] = False
         kwargs['silent'] = True
         self.is_found = False

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -30,7 +30,7 @@ from ..environment import detect_cpu_family
 from .base import DependencyException, DependencyMethods
 from .base import ExternalDependency, ExternalProgram, NonExistingExternalProgram
 from .base import ExtraFrameworkDependency, PkgConfigDependency
-from .base import ConfigToolDependency
+from .base import ConfigToolDependency, process_method_kw
 
 
 class GLDependency(ExternalDependency):
@@ -52,7 +52,7 @@ class GLDependency(ExternalDependency):
 
     @classmethod
     def _factory(cls, environment, kwargs):
-        methods = cls._process_method_kw(kwargs)
+        methods = process_method_kw(cls.get_methods(), kwargs)
         candidates = []
 
         if DependencyMethods.PKGCONFIG in methods:
@@ -532,7 +532,7 @@ class SDL2Dependency(ExternalDependency):
 
     @classmethod
     def _factory(cls, environment, kwargs):
-        methods = cls._process_method_kw(kwargs)
+        methods = process_method_kw(cls.get_methods(), kwargs)
         candidates = []
 
         if DependencyMethods.PKGCONFIG in methods:
@@ -648,7 +648,7 @@ class VulkanDependency(ExternalDependency):
 
     @classmethod
     def _factory(cls, environment, kwargs):
-        methods = cls._process_method_kw(kwargs)
+        methods = process_method_kw(cls.get_methods(), kwargs)
         candidates = []
 
         if DependencyMethods.PKGCONFIG in methods:

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -34,9 +34,9 @@ from .base import ExtraFrameworkDependency, PkgConfigDependency
 from .base import ConfigToolDependency, process_method_kw, DependencyFactory
 
 
-class GLDependency(ExternalDependency):
-    def __init__(self, environment, kwargs):
-        super().__init__('gl', environment, kwargs)
+class GLDependencySystem(ExternalDependency):
+    def __init__(self, name: str, environment, kwargs):
+        super().__init__(name, environment, kwargs)
 
         if self.env.machines[self.for_machine].is_darwin():
             self.is_found = True
@@ -50,19 +50,6 @@ class GLDependency(ExternalDependency):
             self.link_args = ['-lopengl32']
             # FIXME: Detect version using self.clib_compiler
             return
-
-    @classmethod
-    def _factory(cls, environment, kwargs):
-        methods = process_method_kw(cls.get_methods(), kwargs)
-        candidates = []
-
-        if DependencyMethods.PKGCONFIG in methods:
-            candidates.append(functools.partial(PkgConfigDependency, 'gl', environment, kwargs))
-
-        if DependencyMethods.SYSTEM in methods:
-            candidates.append(functools.partial(GLDependency, environment, kwargs))
-
-        return candidates
 
     @staticmethod
     def get_methods():
@@ -652,6 +639,11 @@ class VulkanDependencySystem(ExternalDependency):
     def log_tried(self):
         return 'system'
 
+gl_factory = DependencyFactory(
+    'gl',
+    [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM],
+    system_class=GLDependencySystem,
+)
 
 vulkan_factory = DependencyFactory(
     'vulkan',

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -17,6 +17,7 @@ from pathlib import PurePath
 
 from .. import build
 from .. import dependencies
+from ..dependencies.misc import ThreadDependency
 from .. import mesonlib
 from .. import mlog
 from . import ModuleReturnValue
@@ -94,7 +95,7 @@ class DependenciesHelper:
                 self.add_version_reqs(name, version_req)
             elif isinstance(obj, dependencies.Dependency) and not obj.found():
                 pass
-            elif isinstance(obj, dependencies.ThreadDependency):
+            elif isinstance(obj, ThreadDependency):
                 pass
             else:
                 raise mesonlib.MesonException('requires argument not a string, '
@@ -125,9 +126,6 @@ class DependenciesHelper:
                 if obj.found():
                     processed_reqs.append(obj.name)
                     self.add_version_reqs(obj.name, obj.version_reqs)
-            elif isinstance(obj, dependencies.ThreadDependency):
-                processed_libs += obj.get_compiler().thread_link_flags(obj.env)
-                processed_cflags += obj.get_compiler().thread_flags(obj.env)
             elif isinstance(obj, dependencies.InternalDependency):
                 if obj.found():
                     processed_libs += obj.get_link_args()

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -44,7 +44,7 @@ mod_kwargs -= set(['name_prefix', 'name_suffix'])
 class PythonDependency(ExternalDependency):
 
     def __init__(self, python_holder, environment, kwargs):
-        super().__init__('python', environment, None, kwargs)
+        super().__init__('python', environment, kwargs)
         self.name = 'python'
         self.static = kwargs.get('static', False)
         self.embed = kwargs.get('embed', False)

--- a/test cases/frameworks/20 cups/meson.build
+++ b/test cases/frameworks/20 cups/meson.build
@@ -14,6 +14,7 @@ test('cupstest', e)
 # options
 dep = dependency('cups', version : '>=1.4', method : 'cups-config')
 dep = dependency('cups', version : '>=1.4', method : 'config-tool')
+dep = dependency('cups', version : '>=1.4', method : 'cmake')
 
 # check we can apply a version constraint
 dependency('cups', version: '>=@0@'.format(dep.version()), method: 'pkg-config', required: false)


### PR DESCRIPTION
This adds a more compact, explict method for dependencies with more than one way to be found, especially when one or more of those methods are standard, built in methods like cmake and pkg-config. Instead of having a special `_factory` method in the dependency, a new generic `DependencyFactory` has been added that can handle many cases, or a specific factory function can be written for more specialized cases. I've included a number of instances of both.

I've converted most instances that make sense, although there are a few more that could use conversion I haven't gotten to: Qt, scalapack, and mpi (maybe a couple of others I forgot about). I haven't had a chance to test this on mac or windows yet, so it may still have some problems.

@scivision, I've touched several of the dependencies you've added without any way to test them (I can' seem to get ifort set up correctly with MPI for some reason)