### PR TITLE
Add .wrap file syntax detection for vim

### DIFF
--- a/data/syntax-highlighting/vim/ftdetect/meson.vim
+++ b/data/syntax-highlighting/vim/ftdetect/meson.vim
@@ -1,2 +1,3 @@
 au BufNewFile,BufRead meson.build set filetype=meson
 au BufNewFile,BufRead meson_options.txt set filetype=meson
+au BufNewFile,BufRead *.wrap set filetype=dosini


### PR DESCRIPTION
wrap files are ini syntax, and vim has support for this via the `dosini`
syntax type.