### PR TITLE
Visual Studio: Write out DLL/EXE checksums

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,8 +124,8 @@ jobs:
       displayName: Install Dependencies
     - script: |
         set PATH=%CYGWIN_ROOT%\bin;%SYSTEMROOT%\system32
-        env.exe -- python3 -m pip --disable-pip-version-check install pytest-xdist
-      displayName: pip install pytest-xdist
+        env.exe -- python3 -m pip --disable-pip-version-check install pefile pytest-xdist
+      displayName: pip install pefile pytest-xdist
     - script: |
         set BOOST_ROOT=
         set PATH=%CYGWIN_ROOT%\bin;%SYSTEMROOT%\system32
@@ -188,7 +188,9 @@ jobs:
         mingw-w64-$(MSYS2_ARCH)-python2 ^
         mingw-w64-$(MSYS2_ARCH)-python3 ^
         mingw-w64-$(MSYS2_ARCH)-python3-setuptools ^
+        mingw-w64-$(MSYS2_ARCH)-python3-pip ^
         %TOOLCHAIN%
+        %MSYS2_ROOT%\usr\bin\bash -lc "python3 -m pip --disable-pip-version-check install pefile"
       displayName: Install Dependencies
     - powershell: |
         # https://github.com/mesonbuild/meson/issues/5807

--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -152,7 +152,7 @@ steps:
      python --version
 
      # Needed for running unit tests in parallel.
-     python -m pip --disable-pip-version-check install --upgrade pytest-xdist
+     python -m pip --disable-pip-version-check install --upgrade pefile pytest-xdist
 
 
      echo ""

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1191,6 +1191,10 @@ class Vs2010Backend(backends.Backend):
             targetmachine.text = 'MachineARM'
         else:
             raise MesonException('Unsupported Visual Studio target machine: ' + targetplatform)
+        # /nologo
+        ET.SubElement(link, 'SuppressStartupBanner').text = 'true'
+        # /release
+        ET.SubElement(link, 'SetChecksum').text = 'true'
 
         meson_file_group = ET.SubElement(root, 'ItemGroup')
         ET.SubElement(meson_file_group, 'None', Include=os.path.join(proj_to_src_dir, build_filename))

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -276,7 +276,8 @@ class DynamicLinker(metaclass=abc.ABCMeta):
         return self.exelist.copy()
 
     def get_accepts_rsp(self) -> bool:
-        # TODO: is it really a matter of is_windows or is it for_windows?
+        # rsp files are only used when building on Windows because we want to
+        # avoid issues with quoting and max argument length
         return mesonlib.is_windows()
 
     def get_always_args(self) -> T.List[str]:

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -845,6 +845,9 @@ class MSVCDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
         super().__init__(exelist or ['link.exe'], for_machine, 'link',
                          prefix, always_args, machine=machine, version=version, direct=direct)
 
+    def get_always_args(self) -> T.List[str]:
+        return self._apply_prefix(['/nologo', '/release']) + super().get_always_args()
+
 
 class ClangClDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4646,6 +4646,34 @@ class WindowsTests(BasePlatformTests):
     def test_link_environment_variable_rust(self):
         self._check_ld('link', 'rust', 'link')
 
+    def test_pefile_checksum(self):
+        try:
+            import pefile
+        except ImportError:
+            if is_ci():
+                raise
+            raise unittest.SkipTest('pefile module not found')
+        testdir = os.path.join(self.common_test_dir, '6 linkshared')
+        self.init(testdir)
+        self.build()
+        # Test that binaries have a non-zero checksum
+        env = get_fake_env()
+        cc = env.detect_c_compiler(MachineChoice.HOST)
+        cc_id = cc.get_id()
+        ld_id = cc.get_linker_id()
+        dll = glob(os.path.join(self.builddir, '*mycpplib.dll'))[0]
+        exe = os.path.join(self.builddir, 'cppprog.exe')
+        for f in (dll, exe):
+            pe = pefile.PE(f)
+            msg = 'PE file: {!r}, compiler: {!r}, linker: {!r}'.format(f, cc_id, ld_id)
+            if cc_id == 'clang-cl':
+                # Latest clang-cl tested (7.0) does not write checksums out
+                self.assertFalse(pe.verify_checksum(), msg=msg)
+            else:
+                # Verify that a valid checksum was written by all other compilers
+                self.assertTrue(pe.verify_checksum(), msg=msg)
+
+
 @unittest.skipUnless(is_osx(), "requires Darwin")
 class DarwinTests(BasePlatformTests):
     '''

--- a/test cases/windows/16 gui app/gui_app_tester.py
+++ b/test cases/windows/16 gui app/gui_app_tester.py
@@ -1,26 +1,19 @@
 #!/usr/bin/env python3
 
-import re
-import subprocess
+import os
 import sys
+try:
+    import pefile
+except ImportError:
+    if 'CI' in os.environ:
+        raise
+    # Skip the test if not on CI
+    sys.exit(77)
 
-tool = sys.argv[1]
-executable = sys.argv[2]
-expected = int(sys.argv[3])
-actual = -1
+executable = sys.argv[1]
+expected = int(sys.argv[2])
 
-if 'objdump' in tool:
-    result = subprocess.check_output([tool, '-p', executable]).decode()
-    match = re.search(r'^Subsystem\s+(\d+)', result, re.MULTILINE)
-elif 'dumpbin' in tool:
-    result = subprocess.check_output([tool, '/headers', executable]).decode()
-    match = re.search(r'^\s*(\d+) subsystem(?! version)', result, re.MULTILINE)
-else:
-    print('unknown tool')
-    sys.exit(1)
-
-if match:
-    actual = int(match.group(1))
+actual = pefile.PE(executable).dump_dict()['OPTIONAL_HEADER']['Subsystem']['Value']
 
 print('subsystem expected: %d, actual: %d' % (expected, actual))
 sys.exit(0 if (expected == actual) else 1)

--- a/test cases/windows/16 gui app/meson.build
+++ b/test cases/windows/16 gui app/meson.build
@@ -17,10 +17,5 @@ console_prog = executable('console_prog', 'console_prog.c', gui_app: false)
 
 tester = find_program('gui_app_tester.py')
 
-tool = find_program('objdump', 'dumpbin', required: false)
-# TODO: when 'llvm-objdump -f' emits the subsystem type, we could use that also
-
-if tool.found()
-  test('is_gui', tester, args: [tool.path(), gui_prog, '2'])
-  test('not_gui', tester, args: [tool.path(), console_prog, '3'])
-endif
+test('is_gui', tester, args: [gui_prog, '2'])
+test('not_gui', tester, args: [console_prog, '3'])


### PR DESCRIPTION
commit 12cb82307f2016e19a2634a2081a9723acd27319:

```
linkers: Clarify a comment about rspfiles
```

commit 3a05548cdd381b0ad99e29050f73337d8c2fcfb3:

```
linkers: Accept both str and List[str] for _apply_prefix
Simplifies some usage.
```

commit 360e1cdd2350182b0636d2251efe50291f8806dd:

```
vs: Write checksums in PE binaries (DLLs and EXEs)
This is needed for detecting data corruption, and its absence (or
an incorrect value) is also used as a hint by anti-viruses that the
binary may be malware.

Flag is only supported by MSVC `link.exe`, not `lld-link.exe`
```
https://docs.microsoft.com/en-us/cpp/build/reference/release-set-the-checksum

commit e017147d2199a85e1c6664fb8d8f39f32a389e8b:

```
tests: Add a unit test for checksums
Adds a CI dependency on the `pefile` python module.
```

commit 2c96569374cb8f87564c4fab2560b8aee4a4d263:

```
tests/windows/16: Use pefile module instead of objdump/dumpbin
The pefile module is a CI dependency now, so we can use that instead
of objdump/dumpbin which greatly simplifies the test. Of course, this
module is also cross-platform so it will work if we add cross-win32 CI
at some point.
```
