### PR TITLE
Elbrus support is broken in 0.53.0, so fixing it

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -231,9 +231,10 @@ class PGICCompiler(PGICompiler, CCompiler):
 
 class ElbrusCCompiler(GnuCCompiler, ElbrusCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
-                 is_cross, info: 'MachineInfo', exe_wrapper=None, **kwargs):
+                 is_cross, info: 'MachineInfo', exe_wrapper=None,
+                 defines=None, **kwargs):
         GnuCCompiler.__init__(self, exelist, version, for_machine, is_cross,
-                              info, exe_wrapper, **kwargs)
+                              info, exe_wrapper, defines, **kwargs)
         ElbrusCompiler.__init__(self)
 
     # It does support some various ISO standards and c/gnu 90, 9x, 1x in addition to those which GNU CC supports.

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -231,10 +231,10 @@ class PGICCompiler(PGICompiler, CCompiler):
 
 class ElbrusCCompiler(GnuCCompiler, ElbrusCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
-                 is_cross, info: 'MachineInfo', exe_wrapper=None, defines=None, **kwargs):
+                 is_cross, info: 'MachineInfo', exe_wrapper=None, **kwargs):
         GnuCCompiler.__init__(self, exelist, version, for_machine, is_cross,
-                              info, exe_wrapper, defines, **kwargs)
-        ElbrusCompiler.__init__(self, defines)
+                              info, exe_wrapper, **kwargs)
+        ElbrusCompiler.__init__(self)
 
     # It does support some various ISO standards and c/gnu 90, 9x, 1x in addition to those which GNU CC supports.
     def get_options(self):

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -351,6 +351,19 @@ class ElbrusCPPCompiler(GnuCPPCompiler, ElbrusCompiler):
                                         extra_args=extra_args,
                                         dependencies=dependencies)
 
+    # Elbrus C++ compiler does not support RTTI, so don't check for it.
+    def get_option_compile_args(self, options):
+        args = []
+        std = options['cpp_std']
+        if std.value != 'none':
+            args.append(self._find_best_cpp_std(std.value))
+
+        non_msvc_eh_options(options['cpp_eh'].value, args)
+
+        if options['cpp_debugstl'].value:
+            args.append('-D_GLIBCXX_DEBUG=1')
+        return args
+
 
 class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -325,7 +325,7 @@ class ElbrusCPPCompiler(GnuCPPCompiler, ElbrusCompiler):
         GnuCPPCompiler.__init__(self, exelist, version, for_machine,
                                 is_cross, info, exe_wrapper, defines,
                                 **kwargs)
-        ElbrusCompiler.__init__(self, defines)
+        ElbrusCompiler.__init__(self)
 
     # It does not support c++/gnu++ 17 and 1z, but still does support 0x, 1y, and gnu++98.
     def get_options(self):

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -215,7 +215,7 @@ class ElbrusFortranCompiler(GnuFortranCompiler, ElbrusCompiler):
         GnuFortranCompiler.__init__(self, exelist, version, for_machine,
                                     is_cross, info, exe_wrapper, defines,
                                     **kwargs)
-        ElbrusCompiler.__init__(self, defines)
+        ElbrusCompiler.__init__(self)
 
 class G95FortranCompiler(FortranCompiler):
 

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -29,7 +29,7 @@ if T.TYPE_CHECKING:
 class ElbrusCompiler(GnuLikeCompiler):
     # Elbrus compiler is nearly like GCC, but does not support
     # PCH, LTO, sanitizers and color output as of version 1.21.x.
-    def __init__(self, defines: T.Dict[str, str]):
+    def __init__(self):
         super().__init__()
         self.id = 'lcc'
         self.base_options = ['b_pgo', 'b_coverage',

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -20,6 +20,7 @@ import subprocess
 import re
 
 from .gnu import GnuLikeCompiler
+from .gnu import gnu_optimization_args
 from ...mesonlib import Popen_safe
 
 if T.TYPE_CHECKING:
@@ -80,4 +81,3 @@ class ElbrusCompiler(GnuLikeCompiler):
 
     def openmp_flags(self) -> T.List[str]:
         return ['-fopenmp']
-

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -70,3 +70,14 @@ class ElbrusCompiler(GnuLikeCompiler):
             if line.lstrip().startswith('--sys_include'):
                 includes.append(re.sub(r'\s*\\$', '', re.sub(r'^\s*--sys_include\s*', '', line)))
         return includes
+
+    def get_optimization_args(self, optimization_level: str) -> T.List[str]:
+        return gnu_optimization_args[optimization_level]
+
+    def get_pch_suffix(self) -> str:
+        # Actually it's not supported for now, but probably will be supported in future
+        return 'pch'
+
+    def openmp_flags(self) -> T.List[str]:
+        return ['-fopenmp']
+

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -948,16 +948,10 @@ class Environment:
 
                 linker = self._guess_nix_linker(compiler, cls, for_machine)
 
-                if lang == 'c':  # There's no 'defines' anymore in C Compiler classes.
-                    return cls(
-                        ccache + compiler, version, for_machine, is_cross,
-                        info, exe_wrap, full_version=full_version,
-                        linker=linker)
-                else:
-                    return cls(
-                        ccache + compiler, version, for_machine, is_cross,
-                        info, exe_wrap, defines, full_version=full_version,
-                        linker=linker)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross,
+                    info, exe_wrap, defines, full_version=full_version,
+                    linker=linker)
 
             if 'Emscripten' in out:
                 cls = EmscriptenCCompiler if lang == 'c' else EmscriptenCPPCompiler

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -939,10 +939,17 @@ class Environment:
                     cls = GnuCCompiler if lang == 'c' else GnuCPPCompiler
 
                 linker = self._guess_nix_linker(compiler, cls, for_machine)
-                return cls(
-                    ccache + compiler, version, for_machine, is_cross,
-                    info, exe_wrap, defines, full_version=full_version,
-                    linker=linker)
+
+                if lang == 'c':  # There's no 'defines' anymore in C Compiler classes.
+                    return cls(
+                        ccache + compiler, version, for_machine, is_cross,
+                        info, exe_wrap, full_version=full_version,
+                        linker=linker)
+                else:
+                    return cls(
+                        ccache + compiler, version, for_machine, is_cross,
+                        info, exe_wrap, defines, full_version=full_version,
+                        linker=linker)
 
             if 'Emscripten' in out:
                 cls = EmscriptenCCompiler if lang == 'c' else EmscriptenCPPCompiler

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -586,11 +586,19 @@ class Environment:
             self.default_objcpp = ['c++', 'g++']
             self.default_cs = ['csc', 'mcs']
         else:
-            self.default_c = ['cc', 'gcc', 'clang', 'pgcc', 'icc']
-            self.default_cpp = ['c++', 'g++', 'clang++', 'pgc++', 'icpc']
+            if platform.machine().lower() == 'e2k':
+                # There are no objc or objc++ compilers for Elbrus,
+                # and there's no clang which can build binaries for host.
+                self.default_c = ['cc', 'gcc', 'lcc']
+                self.default_cpp = ['c++', 'g++', 'l++']
+                self.default_objc = []
+                self.default_objcpp = []
+            else:
+                self.default_c = ['cc', 'gcc', 'clang', 'pgcc', 'icc']
+                self.default_cpp = ['c++', 'g++', 'clang++', 'pgc++', 'icpc']
+                self.default_objc = ['cc', 'gcc', 'clang']
+                self.default_objcpp = ['c++', 'g++', 'clang++']
             self.default_fortran = ['gfortran', 'flang', 'pgfortran', 'ifort', 'g95']
-            self.default_objc = ['cc', 'gcc', 'clang']
-            self.default_objcpp = ['c++', 'g++', 'clang++']
             self.default_cs = ['mcs', 'csc']
         self.default_d = ['ldc2', 'ldc', 'gdc', 'dmd']
         self.default_java = ['javac']
@@ -1265,7 +1273,7 @@ class Environment:
                 popen_exceptions[' '.join(compiler + arg)] = e
                 continue
             version = search_version(out)
-            if 'Free Software Foundation' in out or ('e2k' in out and 'lcc' in out):
+            if 'Free Software Foundation' in out:
                 defines = self.get_gnu_compiler_defines(compiler)
                 if not defines:
                     popen_exceptions[' '.join(compiler)] = 'no pre-processor defines'

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2290,7 +2290,7 @@ class AllPlatformTests(BasePlatformTests):
         ar = mesonbuild.linkers.ArLinker
         lib = mesonbuild.linkers.VisualStudioLinker
         langs = [('c', 'CC'), ('cpp', 'CXX')]
-        if not is_windows():
+        if not is_windows() and platform.machine().lower() != 'e2k':
             langs += [('objc', 'OBJC'), ('objcpp', 'OBJCXX')]
         testdir = os.path.join(self.unit_test_dir, '5 compiler detection')
         env = get_fake_env(testdir, self.builddir, self.prefix)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3087,7 +3087,9 @@ int main(int argc, char **argv) {
             pass
         try:
             env.detect_fortran_compiler(MachineChoice.HOST)
-            langs.append('fortran')
+            if is_windows() or platform.machine().lower() != 'e2k':
+                # Elbrus Fortran compiler can't generate debug information
+                langs.append('fortran')
         except EnvironmentException:
             pass
         try:


### PR DESCRIPTION
There were some code changes in class hierarchy and constructor arguments (e.g. missing `defines`), so support has to be updated.

I wonder, what is that `defines` argument for, and why it was removed from C compilers' constructors, but still remains in C++ compilers' constructors? Somehow it feels like breaking universality.

Also found some problems with ninja (see commit 51ac90a): sometimes subprojects summary goes before project summary, so this breaks that unit test. I have encountered it one time on Intel, and one time on Elbrus, but now everything seems to be ok.

Also I figured out that for successful pass of unit tests, the following stuff should be installed:
* pkg-config >= 0.29 (by default Elbrus has 0.22)
* libgirepository1.0-dev, rustc, gfortran, gobjc (on Ubuntu and other Debian-based distros)
Maybe add specific checks for skipping these tests, if requirements not met?

Also, if pytest-xdist is not installed, there are strange messages of "There is more than one version of <...> in tree", but all tests pass; I don't exactly know if this is the problem or not.

Unit tests passage report:
Intel (x86_64 + Ubuntu 18.04.3 + pytest-xdist)
```
flandre /usr/src/meson # ./run_unittests.py
==================================================================== test session starts ====================================================================
platform linux -- Python 3.6.9, pytest-3.3.2, py-1.5.2, pluggy-0.6.0
rootdir: /usr/src/meson, inifile: setup.cfg
plugins: xdist-1.22.1, forked-0.2
gw0 [301] / gw1 [301] / gw2 [301] / gw3 [301] / gw4 [301] / gw5 [301] / gw6 [301] / gw7 [301] / gw8 [301] / gw9 [301] / gw10 [301] / gw11 [301]
scheduling tests via LoadScheduling
.....................ss.s..................s..................................................................s...sssss.sssss....ss.ssss............. [ 49%]
.........s.................s.......s..s.........ss...ss..ss.....s.s.................s....s.........s.s.............s............s..............ss.... [ 99%]
...                                                                                                                                                   [100%]
========================================================== 260 passed, 41 skipped in 69.59 seconds ==========================================================
```
Intel (i686 + Ubuntu 18.04.3)
```
sunnymilk ~/meson # ./run_unittests.py
pytest-xdist not found, using unittest instead
..........s...........................ss.ss...............s.......................................................There is more than one version of scommon in                                                                                tree. Please specify which one to promote:

subprojects/s2/subprojects/scommon
subprojects/s1/subprojects/scommon
.There is more than one version of ambiguous in tree. Please specify which one to promote:

subprojects/s2/subprojects/ambiguous.wrap
subprojects/s1/subprojects/ambiguous
.......s.....s..............s.......s.ss.ssss.ss.....ss.s.ss.......................................................s...................s...........s.......ss.......ssssssssssssssssssssss
----------------------------------------------------------------------
Ran 301 tests in 445.141s

OK (skipped=50)
```
Elbrus (E8C + OSL 4.0-rc4)
```
sakuya /tmp/0/meson # ./run_unittests.py
pytest-xdist not found, using unittest instead
..........s....................s.......s..........................................................................There is more than one version of scommon in tree. Please specify which one to promote:

subprojects/s2/subprojects/scommon
subprojects/s1/subprojects/scommon
.There is more than one version of ambiguous in tree. Please specify which one to promote:

subprojects/s2/subprojects/ambiguous.wrap
subprojects/s1/subprojects/ambiguous
.......s.....s...............s.......s.s..s.s........ss..ss........................................................s.....s........s.sssssss..s..s..........s..........ssssssssssssssssssss
----------------------------------------------------------------------
Ran 301 tests in 1080.744s

OK (skipped=47)
```
Elbrus (E8CV + OSL 4.0-rc4)
```
marisa /usr/src/meson/retest/meson # ./run_unittests.py
pytest-xdist not found, using unittest instead
..........s....................s.......s..........................................................................There is more than one version of scommon in tree. Please specify which one to promote:

subprojects/s2/subprojects/scommon
subprojects/s1/subprojects/scommon
.There is more than one version of ambiguous in tree. Please specify which one to promote:

subprojects/s2/subprojects/ambiguous.wrap
subprojects/s1/subprojects/ambiguous
.......s.....s...............s.......s.s..sss........ss..ss........................................................s.....s........s.sssssss..s..s..s.......s..........ssssssssssssssssssss
----------------------------------------------------------------------
Ran 301 tests in 1163.454s

OK (skipped=49)
```