### PR TITLE
environment: Replace LD with <LANG>LD

### DIFF
--- a/cross/linux-mingw-w64-32bit.txt
+++ b/cross/linux-mingw-w64-32bit.txt
@@ -6,6 +6,7 @@ strip = '/usr/bin/i686-w64-mingw32-strip'
 pkgconfig = '/usr/bin/i686-w64-mingw32-pkg-config'
 windres = '/usr/bin/i686-w64-mingw32-windres'
 exe_wrapper = 'wine'
+ld = '/usr/bin/i686-w64-mingw32-ld'
 
 [properties]
 # Directory that contains 'bin', 'lib', etc

--- a/cross/ubuntu-armhf.txt
+++ b/cross/ubuntu-armhf.txt
@@ -7,6 +7,7 @@ rust = ['rustc', '--target', 'arm-unknown-linux-gnueabihf', '-C', 'linker=/usr/b
 ar = '/usr/arm-linux-gnueabihf/bin/ar'
 strip = '/usr/arm-linux-gnueabihf/bin/strip'
 pkgconfig = '/usr/bin/arm-linux-gnueabihf-pkg-config'
+ld = '/usr/bin/arm-linux/gnueabihf-ld'
 
 [properties]
 root = '/usr/arm-linux-gnueabihf'

--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -28,24 +28,36 @@ native-files and the latter via the cross file only.
 
 ## Set dynamic linker
 
+Like the compiler, the linker is selected via the <compiler variable>_LD
+environment variable, or through the `<compiler entry>ld` entry in a native
+or cross file. You must be aware of whether you're using a compiler that
+invokes the linker itself (most compilers including GCC and Clang) or a
+linker that is invoked directly (when using MSVC or compilers that act like
+it, including Clang-Cl). With the former `cld` or `CC_LD` should be the value
+to pass to the compiler's special argument (such as `-fuse-ld` with clang and
+gcc), with the latter it should be an executable, such as `lld-link.exe`.
+
+*NOTE* In meson 0.53.0 the `ld` entry in the cross/native file and the `LD`
+environment variable was used, this resulted in a large number of regressions
+and was changed.
+
 ```console
-$ CC=clang LD=lld meson <options>
+$ CC=clang CC_LD=lld meson <options>
 ```
 
 or
 
 ```console
-$ CC=clang-cl LD=link meson <options>
+$ CC=clang-cl CC_LD=link meson <options>
 ```
 
-Like the compiler, the linker is selected via the LD environment variable, or
-through the `ld` entry in a native or cross file. You must be aware of
-whehter you're using a compiler that invokes the linker itself (most
-compilers including GCC and Clang) or a linker that is invoked directly (when
-using MSVC or compilers that act like it, including Clang-Cl). With the
-former `ld` or `LD` should be the value to pass to the compiler's special
-argument (such as `-fuse-ld` with clang and gcc), with the latter it should
-be an exectuable, such as `lld-link.exe`.
+or in a cross or native file:
+
+```ini
+[binaries]
+c = 'clang'
+c_ld = 'lld'
+```
 
 ## Set default C/C++ language version
 
@@ -139,7 +151,7 @@ $ ninja coverage-html (or coverage-xml)
 
 The coverage report can be found in the meson-logs subdirectory.
 
-Note: Currently, Meson does not support generating coverage reports 
+Note: Currently, Meson does not support generating coverage reports
 with Clang.
 
 ## Add some optimization to debug builds

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -305,11 +305,19 @@ class BinaryTable(HasEnvVarFallback):
         'rust': 'RUSTC',
         'vala': 'VALAC',
 
+        # Linkers
+        'c_ld': 'CC_LD',
+        'cpp_ld': 'CXX_LD',
+        'd_ld': 'D_LD',
+        'fortran_ld': 'F_LD',
+        'objc_ld': 'OBJC_LD',
+        'objcpp_ld': 'OBJCPP_LD',
+        'rust_ld': 'RUST_LD',
+
         # Binutils
         'strip': 'STRIP',
         'ar': 'AR',
         'windres': 'WINDRES',
-        'ld': 'LD',
 
         # Other tools
         'cmake': 'CMAKE',

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -749,7 +749,7 @@ class Environment:
         check_args += self.coredata.compiler_options[for_machine][comp_class.language + '_args'].value
 
         override = []  # type: T.List[str]
-        value = self.binaries[for_machine].lookup_entry(comp_class.language + 'ld')
+        value = self.binaries[for_machine].lookup_entry(comp_class.language + '_ld')
         if value is not None:
             override = comp_class.use_linker_args(value[0])
             check_args += override
@@ -812,7 +812,7 @@ class Environment:
             check_args = comp_class.LINKER_PREFIX + ['--version'] + extra_args
 
         override = []  # type: T.List[str]
-        value = self.binaries[for_machine].lookup_entry(comp_class.language + 'ld')
+        value = self.binaries[for_machine].lookup_entry(comp_class.language + '_ld')
         if value is not None:
             override = comp_class.use_linker_args(value[0])
             check_args += override
@@ -1355,7 +1355,7 @@ class Environment:
 
         cc = self.detect_c_compiler(for_machine)
         is_link_exe = isinstance(cc.linker, VisualStudioLikeLinkerMixin)
-        override = self.binaries[for_machine].lookup_entry('rustld')
+        override = self.binaries[for_machine].lookup_entry('rust_ld')
 
         for compiler in compilers:
             if isinstance(compiler, str):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4627,7 +4627,7 @@ class WindowsTests(BasePlatformTests):
     def _check_ld(self, name: str, lang: str, expected: str) -> None:
         if not shutil.which(name):
             raise unittest.SkipTest('Could not find {}.'.format(name))
-        envvar = mesonbuild.envconfig.BinaryTable.evarMap['{}ld'.format(lang)]
+        envvar = mesonbuild.envconfig.BinaryTable.evarMap['{}_ld'.format(lang)]
         with mock.patch.dict(os.environ, {envvar: name}):
             env = get_fake_env()
             try:
@@ -5880,7 +5880,7 @@ c = ['{0}']
             raise unittest.SkipTest('Solaris currently cannot override the linker.')
         if not shutil.which(check):
             raise unittest.SkipTest('Could not find {}.'.format(check))
-        envvar = mesonbuild.envconfig.BinaryTable.evarMap['{}ld'.format(lang)]
+        envvar = mesonbuild.envconfig.BinaryTable.evarMap['{}_ld'.format(lang)]
         with mock.patch.dict(os.environ, {envvar: name}):
             env = get_fake_env()
             comp = getattr(env, 'detect_{}_compiler'.format(lang))(MachineChoice.HOST)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -43,6 +43,7 @@ from distutils.dir_util import copy_tree
 import mesonbuild.mlog
 import mesonbuild.depfile
 import mesonbuild.compilers
+import mesonbuild.envconfig
 import mesonbuild.environment
 import mesonbuild.mesonlib
 import mesonbuild.coredata
@@ -4626,7 +4627,8 @@ class WindowsTests(BasePlatformTests):
     def _check_ld(self, name: str, lang: str, expected: str) -> None:
         if not shutil.which(name):
             raise unittest.SkipTest('Could not find {}.'.format(name))
-        with mock.patch.dict(os.environ, {'LD': name}):
+        envvar = mesonbuild.envconfig.BinaryTable.evarMap['{}ld'.format(lang)]
+        with mock.patch.dict(os.environ, {envvar: name}):
             env = get_fake_env()
             try:
                 comp = getattr(env, 'detect_{}_compiler'.format(lang))(MachineChoice.HOST)
@@ -5878,7 +5880,8 @@ c = ['{0}']
             raise unittest.SkipTest('Solaris currently cannot override the linker.')
         if not shutil.which(check):
             raise unittest.SkipTest('Could not find {}.'.format(check))
-        with mock.patch.dict(os.environ, {'LD': name}):
+        envvar = mesonbuild.envconfig.BinaryTable.evarMap['{}ld'.format(lang)]
+        with mock.patch.dict(os.environ, {envvar: name}):
             env = get_fake_env()
             comp = getattr(env, 'detect_{}_compiler'.format(lang))(MachineChoice.HOST)
             if lang != 'rust' and comp.use_linker_args('foo') == []:

--- a/test cases/linuxlike/15 ld binary/meson.build
+++ b/test cases/linuxlike/15 ld binary/meson.build
@@ -1,0 +1,4 @@
+project('ld binary')
+
+ld = find_program('ld')
+assert(run_command(ld, '--version').returncode() == 0)


### PR DESCRIPTION
The rust code is ugly, because rust is annoying. It doesn't invoke a
linker directly (unless that linker is link.exe or lld-link.exe),
instead it invokes the C compiler (gcc or clang usually) to do it's
linking. Meson doesn't have good abstractions for this, though we
probably should because some of the D compilers do the same thing.
Either that or we should just call the c compiler directly, like vala
does.

This changes the public interface for meson, which we don't do unless we
absolutely have to. In this case I think we need to do it. A fair number
of projects have already been using 'ld' in their cross/native files to
get the ld binary and call it directly in custom_targets or generators,
and we broke that. While we could hit this problem again names like
`cld` and `cppld` are far less likely to cause collisions than `ld`.
Additionally this gives a way to set the linker on a per-compiler basis,
which is probably in itself very useful.

Fixes #6442