### PR TITLE
test_pkgconfig_gen_deps: set PKG_CONFIG_SYSTEM_LIBRARY_PATH=/usr/lib

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4832,7 +4832,10 @@ class LinuxlikeTests(BasePlatformTests):
         privatedir2 = self.privatedir
 
         os.environ
-        env = {'PKG_CONFIG_LIBDIR': os.pathsep.join([privatedir1, privatedir2])}
+        env = {
+            'PKG_CONFIG_LIBDIR': os.pathsep.join([privatedir1, privatedir2]),
+            'PKG_CONFIG_SYSTEM_LIBRARY_PATH': '/usr/lib',
+        }
         self._run(['pkg-config', 'dependency-test', '--validate'], override_envvars=env)
 
         # pkg-config strips some duplicated flags so we have to parse the


### PR DESCRIPTION
pkgconf automatically prunes "system library paths" from its output. The system library path defaults to the libdir passed to its configure script. On a 64-bit system, this is typically `/usr/lib64`. So, if `-L/usr/lib64` appears in the Libs section, it will be pruned from the output of pkg-config --libs.

The pc files generated for this test contain something like this:

libdir=/usr/lib
Libs: -L${libdir} ...

pkgconf may not consider /usr/lib to be a system library path, so it is not pruned as the test expects. To work around this, override the compiled-in list of paths via the PKG_CONFIG_SYSTEM_LIBRARY_PATH environment variable.

Note that the original `pkg-config` program from freedesktop.org includes `/usr/lib` as a system library path by default. The behavior of [pkgconf](https://git.sr.ht/~kaniini/pkgconf) differs in this regard.

Fixes: https://github.com/mesonbuild/meson/issues/6004