### PR TITLE
envconfig: add pkg_config_libdir property

### DIFF
--- a/docs/markdown/Cross-compilation.md
+++ b/docs/markdown/Cross-compilation.md
@@ -138,6 +138,7 @@ has_function_printf = true
 c_args = ['-DCROSS=1', '-DSOMETHING=3']
 c_link_args = ['-some_link_arg']
 sys_root = '/some/path'
+pkg_config_libdir = '/some/path/lib/pkgconfig'
 ```
 
 In most cases you don't need the size and alignment settings, Meson
@@ -154,6 +155,10 @@ system path (the system that will run the compiled binaries). This is used
 internally by Meson to set the PKG_CONFIG_SYSROOT_DIR environment variable
 for pkg-config. If this is unset the host system is assumed to share a root
 with the build system.
+
+*Since 0.54.0* The pkg_config_libdir property may point to a list of path used
+internally by Meson to set the PKG_CONFIG_LIBDIR environment variable for pkg-config.
+This prevents pkg-config from searching cross dependencies in system directories.
 
 One important thing to note, if you did not define an `exe_wrapper` in
 the previous section, is that Meson will make a best-effort guess at

--- a/docs/markdown/snippets/pkg_config_libdir.md
+++ b/docs/markdown/snippets/pkg_config_libdir.md
@@ -1,0 +1,3 @@
+## Added 'pkg_config_libdir' property
+Allows to define a list of folders used by pkg-config for a cross build
+and avoid a system directories use.

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -697,6 +697,12 @@ class PkgConfigDependency(ExternalDependency):
         mlog.debug('PKG_CONFIG_PATH: ' + new_pkg_config_path)
         env['PKG_CONFIG_PATH'] = new_pkg_config_path
 
+        pkg_config_libdir_prop = self.env.properties[self.for_machine].get_pkg_config_libdir()
+        if pkg_config_libdir_prop:
+            new_pkg_config_libdir = ':'.join([p for p in pkg_config_libdir_prop])
+            env['PKG_CONFIG_LIBDIR'] = new_pkg_config_libdir
+            mlog.debug('PKG_CONFIG_LIBDIR: ' + new_pkg_config_libdir)
+
         fenv = frozenset(env.items())
         targs = tuple(args)
         cache = PkgConfigDependency.pkgbin_cache

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -140,6 +140,12 @@ class Properties(HasEnvVarFallback):
     def get_sys_root(self) -> T.Optional[T.Union[str, T.List[str]]]:
         return self.properties.get('sys_root', None)
 
+    def get_pkg_config_libdir(self) -> T.Optional[T.List[str]]:
+        p = self.properties.get('pkg_config_libdir', None)
+        if p is None:
+            return p
+        return mesonlib.listify(p)
+
     def __eq__(self, other: T.Any) -> 'T.Union[bool, NotImplemented]':
         if isinstance(other, type(self)):
             return self.properties == other.properties

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3620,6 +3620,34 @@ recommended as it is not supported on some platforms''')
         self.wipe()
         self.init(testdir, extra_args=['-Dstart_native=true'], override_envvars=env)
 
+    @skipIfNoPkgconfig
+    @unittest.skipIf(is_windows(), 'Help needed with fixing this test on windows')
+    def test_pkg_config_libdir(self):
+        testdir = os.path.join(self.unit_test_dir,
+                               '46 native dep pkgconfig var')
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as crossfile:
+            crossfile.write(textwrap.dedent(
+                '''[binaries]
+                pkgconfig = 'pkg-config'
+
+                [properties]
+                pkg_config_libdir = [r'{0}']
+
+                [host_machine]
+                system = 'linux'
+                cpu_family = 'arm'
+                cpu = 'armv7'
+                endian = 'little'
+                '''.format(os.path.join(testdir, 'cross_pkgconfig'))))
+            crossfile.flush()
+            self.meson_cross_file = crossfile.name
+
+        env = {'PKG_CONFIG_LIBDIR':  os.path.join(testdir,
+                                                  'native_pkgconfig')}
+        self.init(testdir, extra_args=['-Dstart_native=false'], override_envvars=env)
+        self.wipe()
+        self.init(testdir, extra_args=['-Dstart_native=true'], override_envvars=env)
+
     def __reconfigure(self, change_minor=False):
         # Set an older version to force a reconfigure from scratch
         filename = os.path.join(self.privatedir, 'coredata.dat')
@@ -6768,7 +6796,7 @@ class NativeFileTests(BasePlatformTests):
 
 class CrossFileTests(BasePlatformTests):
 
-    """Tests for cross file functioality not directly related to
+    """Tests for cross file functionality not directly related to
     cross compiling.
 
     This is mainly aimed to testing overrides from cross files.


### PR DESCRIPTION
In order to unify the use of sysroot in the cross-file,
the pkg_config_path can now be passed directly in the file.