### PR TITLE
find_program: Always use USERPROFILE instead of HOME

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1817,10 +1817,13 @@ class ExternalProgram:
     @staticmethod
     @functools.lru_cache(maxsize=None)
     def _windows_sanitize_path(path: str) -> str:
+        # Ensure that we use USERPROFILE even when inside MSYS, MSYS2, Cygwin, etc.
+        if 'USERPROFILE' not in os.environ:
+            return path
         # Ignore executables in the WindowsApps directory which are
         # zero-sized wrappers that magically open the Windows Store to
         # install the application.
-        appstore_dir = Path.home() / 'AppData' / 'Local' / 'Microsoft' / 'WindowsApps'
+        appstore_dir = Path(os.environ['USERPROFILE']) / 'AppData' / 'Local' / 'Microsoft' / 'WindowsApps'
         paths = []
         for each in path.split(os.pathsep):
             if Path(each) != appstore_dir:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4542,6 +4542,14 @@ class WindowsTests(BasePlatformTests):
         self.assertTrue(prog.found(), msg='test-script-ext.py not found in PATH')
         self.assertPathEqual(prog.get_command()[0], python_command[0])
         self.assertPathBasenameEqual(prog.get_path(), 'test-script-ext.py')
+        # Ensure that WindowsApps gets removed from PATH
+        path = os.environ['PATH']
+        if 'WindowsApps' not in path:
+            username = os.environ['USERNAME']
+            appstore_dir = r'C:\Users\{}\AppData\Local\Microsoft\WindowsApps'.format(username)
+            path = os.pathsep + appstore_dir
+        path = ExternalProgram._windows_sanitize_path(path)
+        self.assertNotIn('WindowsApps', path)
 
     def test_ignore_libs(self):
         '''


### PR DESCRIPTION
On MSYS2 and MSYS, Python reads HOME instead of USERPROFILE, which
gets the path wrong.

Serves me right for not writing a test!!