### PR TITLE
RPM macros: Add *_no_vpath macros.

### DIFF
--- a/data/macros.meson
+++ b/data/macros.meson
@@ -8,7 +8,7 @@
         if [ -n "$ncpus_max" ] && [ "$ncpus_max" -gt 0 ] && [ "$MESON_BUILD_NCPUS" -gt "$ncpus_max" ]; then MESON_BUILD_NCPUS="$ncpus_max"; fi; \\\
         if [ "$MESON_BUILD_NCPUS" -gt 1 ]; then echo "--num-processes $MESON_BUILD_NCPUS"; fi)
 
-%meson \
+%meson_no_vpath \
     %set_build_flags \
     %{shrink:%{__meson} \
         --buildtype=plain \
@@ -27,18 +27,28 @@
         --sharedstatedir=%{_sharedstatedir} \
         --wrap-mode=%{__meson_wrap_mode} \
         --auto-features=%{__meson_auto_features} \
-        %{_vpath_srcdir} %{_vpath_builddir} \
 	%{nil}}
 
-%meson_build \
-    %ninja_build -C %{_vpath_builddir}
+%meson_build_no_vpath \
+    %ninja_build
 
-%meson_install \
-    %ninja_install -C %{_vpath_builddir}
+%meson_install_no_vpath \
+    %ninja_install
 
-%meson_test \
+%meson_test_no_vpath \
     %{shrink: %{__meson} test \
-        -C %{_vpath_builddir} \
         %{?_smp_mesonflags} \
         --print-errorlogs \
     %{nil}}
+
+%meson \
+    %{meson_no_vpath} %{_vpath_srcdir} %{_vpath_builddir}
+
+%meson_build \
+    %{meson_build_no_vpath} -C %{_vpath_builddir}
+
+%meson_install \
+    %{meson_install_no_vpath} -C %{_vpath_builddir}
+
+%meson_test \
+    %{meson_test_no_vpath} -C %{_vpath_builddir}


### PR DESCRIPTION
Some projects may need to be build in different configurations from the same source tree.  Having macros with a hardcoded vpath makes that rather inconvenient, as one would need reduplicate and update those macros by hand in the spec file.

Having reusable macros at hand makes it easy, for meson developers, as they just need to update the macros at the known location, and for package maintainers, as they can use the *_no_vpath macros and simply add their target build-dir for each different build config from the same source-tree.