### PR TITLE
Fix dependency('qt') crash with old Qt on OSX

### DIFF
--- a/.github/workflows/ci_frameworks.yml
+++ b/.github/workflows/ci_frameworks.yml
@@ -71,7 +71,7 @@ jobs:
     - run: brew install pkg-config ninja gcc
     - run: brew tap cartr/qt4
     - run: brew install qt@4
-    - run: meson setup "test cases/frameworks/4 qt" build
+    - run: meson setup "test cases/frameworks/4 qt" build -Drequired=qt4
     - run: ninja -C build
     - uses: actions/upload-artifact@v1
       if: failure()

--- a/.github/workflows/ci_frameworks.yml
+++ b/.github/workflows/ci_frameworks.yml
@@ -59,3 +59,28 @@ jobs:
       with:
         name: HDF5_Mac_test
         path: build/meson-logs/testlog.txt
+
+  Qt4macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - run: python -m pip install -e .
+    - run: brew install pkg-config ninja gcc
+    - run: brew tap cartr/qt4
+    - run: brew install qt@4
+    - run: meson setup "test cases/frameworks/4 qt" build
+    - run: ninja -C build
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: Qt4_Mac_build
+        path: build/meson-logs/meson-log.txt
+    - run: meson test -C build -v
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: Qt4_Mac_test
+        path: build/meson-logs/testlog.txt

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -373,7 +373,8 @@ class QtBaseDependency(ExternalDependency):
             (k, v) = tuple(line.split(':', 1))
             qvars[k] = v
         # Qt on macOS uses a framework, but Qt for iOS/tvOS does not
-        if self.env.machines.host.is_darwin() and 'ios' not in qvars['QMAKE_XSPEC'] and 'tvos' not in qvars['QMAKE_XSPEC']:
+        xspec = qvars.get('QMAKE_XSPEC', '')
+        if self.env.machines.host.is_darwin() and not any(s in xspec for s in ['ios', 'tvos']):
             mlog.debug("Building for macOS, looking for framework")
             self._framework_detect(qvars, mods, kwargs)
             return qmake

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -21,19 +21,25 @@ foreach qt : ['qt4', 'qt5']
     error('Invalid qt dep incorrectly found!')
   endif
 
-  # This test should be skipped if qt5 isn't found
-  if qt == 'qt5'
+  # This test should be skipped if the required version of Qt isn't found
+  #
+  # (In the CI environment, the specified version of Qt is definitely present.
+  # An unexpected skip here is treated as a failure, so we are testing that the
+  # detection mechanism is able to find Qt.)
+  needed_qt = get_option('required').to_lower()
+  required = (qt == needed_qt)
+  if required
     dep = dependency(qt, modules : ['Core'], required : false, method : get_option('method'))
     if not dep.found()
-      error('MESON_SKIP_TEST qt5 not found.')
+      error('MESON_SKIP_TEST @0@ not found.'.format(needed_qt))
     endif
   endif
 
   # Ensure that the "no-Core-module-specified" code branch is hit
-  nocoredep = dependency(qt, modules : ['Gui'], required : qt == 'qt5', method : get_option('method'))
+  nocoredep = dependency(qt, modules : ['Gui'], required : required, method : get_option('method'))
 
-  # If qt4 modules are found, test that. qt5 is required.
-  qtdep = dependency(qt, modules : qt_modules, main : true, private_headers: true, required : qt == 'qt5', method : get_option('method'))
+  # If 'qt' modules are found, test that.
+  qtdep = dependency(qt, modules : qt_modules, main : true, private_headers: true, required : required, method : get_option('method'))
   if qtdep.found()
     qtmodule = import(qt)
 

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -83,6 +83,7 @@ foreach qt : ['qt4', 'qt5']
     qtcore = dependency(qt, modules : 'Core', method : get_option('method'))
 
     qtcoreapp = executable(qt + 'core', 'q5core.cpp',
+      cpp_args: '-DQT="@0@"'.format(qt),
       dependencies : qtcore)
 
     test(qt + 'test', qtcoreapp)

--- a/test cases/frameworks/4 qt/meson_options.txt
+++ b/test cases/frameworks/4 qt/meson_options.txt
@@ -1,1 +1,2 @@
 option('method', type : 'string', value : 'auto', description : 'The method to use to find Qt')
+option('required', type : 'string', value : 'qt5', description : 'The version of Qt which is required to be present')

--- a/test cases/frameworks/4 qt/q5core.cpp
+++ b/test cases/frameworks/4 qt/q5core.cpp
@@ -15,7 +15,7 @@ int main(int argc, char **argv) {
   app.installTranslator(&qtTranslator);
 
   QTranslator myappTranslator;
-  if(!myappTranslator.load("qt5core_fr") )
+  if(!myappTranslator.load(QT "core_fr") )
     return 1;
 
   app.installTranslator(&myappTranslator);


### PR DESCRIPTION
Don't fail with 'KeyError: QMAKE_XSPEC' if `qmake -query` doesn't report QMAKE_XSPEC. (Seen with Qt 4.8.7)