### PR TITLE
msvc: add prefix to build type arguments

### DIFF
--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -781,6 +781,9 @@ class VisualStudioLikeLinkerMixin:
         super().__init__(*args, **kwargs)
         self.machine = machine
 
+    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
+        return mesonlib.listify([self._apply_prefix(a) for a in self._BUILDTYPE_ARGS[buildtype]])
+
     def invoked_by_compiler(self) -> bool:
         return not self.direct
 


### PR DESCRIPTION
When using Clang compiler and MSVC linker (at least), linker arguments in compiler command-line must be passed via `-Wl`, otherwise Clang will reject the entire command with an error like this:

```
clang: @lib/XXX.rsp
clang: error: no such file or directory: '/OPT:REF'
```