### PR TITLE
docs: Fix typo in link

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -142,7 +142,7 @@ linker flags.
 It is recommended that you **do not use these**. They are provided purely to
 for backwards compatibility with other build systems. There are many caveats to
 their use, especially when rebuilding the project. It is **highly** recommended
-that you use [the command line arguments](#language-arguments-parameters-names)
+that you use [the command line arguments](#language-arguments-parameter-names)
 instead.
 
 | Name      | Comment                                  |


### PR DESCRIPTION
Commit 1404f404 (#4744) introduced this typo, making the link not jump to the correct section when clicked.

(Perhaps there should be a script in CI that checks for dangling Markdown links?)