### PR TITLE
Fix git colors on windows again and again

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -56,6 +56,20 @@ else:
     python_command = [sys.executable]
 meson_command = None
 
+GIT = shutil.which('git')
+def git(cmd: T.List[str], workingdir: str, **kwargs) -> subprocess.CompletedProcess:
+    pc = subprocess.run([GIT, '-C', workingdir] + cmd,
+                        # Redirect stdin to DEVNULL otherwise git messes up the
+                        # console and ANSI colors stop working on Windows.
+                        stdin=subprocess.DEVNULL, **kwargs)
+    # Sometimes git calls git recursively, such as `git submodule update
+    # --recursive` which will be without the above workaround, so set the
+    # console mode again just in case.
+    if platform.system().lower() == 'windows':
+        mlog._windows_ansi()
+    return pc
+
+
 def set_meson_command(mainfile):
     global python_command
     global meson_command

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -2,7 +2,7 @@ import os, subprocess
 import argparse
 
 from . import mlog
-from .mesonlib import Popen_safe
+from .mesonlib import git, Popen_safe
 from .wrap.wrap import API_ROOT, PackageDefinition, Resolver, WrapException
 from .wrap import wraptool
 
@@ -40,12 +40,8 @@ def update_file(wrap, repo_dir, options):
                  '     In that case, delete', mlog.bold(repo_dir), 'and run', mlog.bold('meson --reconfigure'))
 
 def git_output(cmd, workingdir):
-    return subprocess.check_output(['git', '-C', workingdir] + cmd,
-                                   # Redirect stdin to DEVNULL otherwise git
-                                   # messes up the console and ANSI colors stop
-                                   # working on Windows.
-                                   stdin=subprocess.DEVNULL,
-                                   stderr=subprocess.STDOUT).decode()
+    return git(cmd, workingdir, check=True, universal_newlines=True,
+               stdout=subprocess.PIPE, stderr=subprocess.STDOUT).stdout
 
 def git_show(repo_dir):
     commit_message = git_output(['show', '--quiet', '--pretty=format:%h%n%d%n%s%n[%an]'], repo_dir)

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -18,7 +18,6 @@ import urllib.request
 import urllib.error
 import urllib.parse
 import os
-import platform
 import hashlib
 import shutil
 import tempfile
@@ -29,7 +28,7 @@ import configparser
 import typing as T
 
 from . import WrapMode
-from ..mesonlib import ProgressBar, MesonException
+from ..mesonlib import git, GIT, ProgressBar, MesonException
 
 if T.TYPE_CHECKING:
     import http.client
@@ -44,22 +43,9 @@ except ImportError:
     has_ssl = False
     API_ROOT = 'http://wrapdb.mesonbuild.com/v1/'
 
-GIT = shutil.which('git')
 REQ_TIMEOUT = 600.0
 SSL_WARNING_PRINTED = False
 WHITELIST_SUBDOMAIN = 'wrapdb.mesonbuild.com'
-
-def git(cmd: T.List[str], workingdir: str, **kwargs) -> subprocess.CompletedProcess:
-    pc = subprocess.run([GIT, '-C', workingdir] + cmd,
-                        # Redirect stdin to DEVNULL otherwise git messes up the
-                        # console and ANSI colors stop working on Windows.
-                        stdin=subprocess.DEVNULL, **kwargs)
-    # Sometimes git calls git recursively, such as `git submodule update
-    # --recursive` which will be without the above workaround, so set the
-    # console mode again just in case.
-    if platform.system().lower() == 'windows':
-        mlog._windows_ansi()
-    return pc
 
 def quiet_git(cmd: T.List[str], workingdir: str) -> T.Tuple[bool, str]:
     if not GIT:

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -18,6 +18,7 @@ import urllib.request
 import urllib.error
 import urllib.parse
 import os
+import platform
 import hashlib
 import shutil
 import tempfile
@@ -53,6 +54,11 @@ def git(cmd: T.List[str], workingdir: str, **kwargs) -> subprocess.CompletedProc
                         # Redirect stdin to DEVNULL otherwise git messes up the
                         # console and ANSI colors stop working on Windows.
                         stdin=subprocess.DEVNULL, **kwargs)
+    # Sometimes git calls git recursively, such as `git submodule update
+    # --recursive` which will be without the above workaround, so set the
+    # console mode again just in case.
+    if platform.system().lower() == 'windows':
+        mlog._windows_ansi()
     return pc
 
 def quiet_git(cmd: T.List[str], workingdir: str) -> T.Tuple[bool, str]:

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -49,7 +49,10 @@ SSL_WARNING_PRINTED = False
 WHITELIST_SUBDOMAIN = 'wrapdb.mesonbuild.com'
 
 def git(cmd: T.List[str], workingdir: str, **kwargs) -> subprocess.CompletedProcess:
-    pc = subprocess.run([GIT, '-C', workingdir] + cmd, **kwargs)
+    pc = subprocess.run([GIT, '-C', workingdir] + cmd,
+                        # Redirect stdin to DEVNULL otherwise git messes up the
+                        # console and ANSI colors stop working on Windows.
+                        stdin=subprocess.DEVNULL, **kwargs)
     return pc
 
 def quiet_git(cmd: T.List[str], workingdir: str) -> T.Tuple[bool, str]:


### PR DESCRIPTION
commit e1c0ee5ddbd6f0a9455bc98f10f5a1bfc6b98c78:

```
wrap: Use uppercase for global constants
This makes things much clearer and follows PEP8.
```

commit 10f205130e6d68c59e27b30326853c562296477e:

```
wrap: Look for git only once at startup
No need to repeatedly call `shutil.which`.
```

commit 1d366dace68ef241f42d3f6e01e6ca4f46f8efe9:

```
wrap: Always use a wrapper for running git
We need this for the next commit.
```

commit 793fa60f79e82f5fab6743bd96fcd71253484b5f:

```
wrap: Redirect stdin to DEVNULL when calling git
Without this git messes up the console and ANSI colors stop working on
Windows inside cmd.exe. Also add the same to all git calls. 
```

commit 8411b0559dc11fb55c18bcb0252b289b08f40bbe:

```
wrap: Re-set the console mode after calling git
`git submodule update --recursive` calls git clone recursively, and on
Windows it will undo the console mode we set in mlog and cause ANSI
colors to stop working. We could set it again only when we call that,
but we will definitely miss other instances where this could happen
in the future and regress.
```

commit 77f733daab6ffab07d8c7b50790a43371abd6018:

```
msubprojects: Rename 'git' to 'git_output'
No functional changes. Split out from the next commit for ease of
reading.
```

commit fca98e484f05b2f6d4b67c08aa8590b91a4ee0d9:

```
Move git helper out into mesonlib for reuse
Reuse the git helper for `meson wrap` and `meson subprojects` so we
don't need to maintain the same git-colors-on-windows workarounds in
multiple places.
```



This broke in https://github.com/mesonbuild/meson/pull/6139. Missed this when I opened https://github.com/mesonbuild/meson/pull/6255