### PR TITLE
typing: Fix compatibility with Python 3.5.2

### DIFF
--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -12,6 +12,7 @@ jobs:
       run: |
         sudo apt update -yq
         sudo apt install -yq --no-install-recommends python3-setuptools python3-pip g++ gfortran gobjc gobjc++ zlib1g-dev
+        sudo python3 -m pip install pytest-xdist pytest-forked pytest
     - name: Install ninja-build tool
       uses: seanmiddleditch/gha-setup-ninja@v1
     - name: Python version

--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -11,8 +11,9 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update -yq
-        sudo apt install -yq --no-install-recommends python3-setuptools python3-pip g++ gfortran gobjc gobjc++ zlib1g-dev
-        sudo python3 -m pip install pytest-xdist pytest-forked pytest
+        sudo apt install -yq --no-install-recommends python3-setuptools python3-pip g++ gfortran gobjc gobjc++ zlib1g-dev python-dev python3-dev libboost-all-dev
+    - name: Remove GitHub boost version
+      run: sudo rm -rf /usr/local/share/boost
     - name: Install ninja-build tool
       uses: seanmiddleditch/gha-setup-ninja@v1
     - name: Python version

--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update -yq
-        sudo apt install -yq --no-install-recommends g++ gfortran ninja-build gobjc gobjc++ zlib1g-dev
+        sudo apt install -yq --no-install-recommends python3-setuptools python3-pip g++ gfortran gobjc gobjc++ zlib1g-dev
     - name: Install ninja-build tool
       uses: seanmiddleditch/gha-setup-ninja@v1
     - name: Python version
@@ -22,3 +22,4 @@ jobs:
       run: python3 run_tests.py
       env:
         CI: '1'
+        XENIAL: '1'

--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -1,0 +1,24 @@
+name: OS Compatibility Tests
+
+on: [push, pull_request]
+
+jobs:
+  xenial:
+    name: Ubuntu 16.04 (xenial)
+    runs-on: ubuntu-16.04
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Dependencies
+      run: |
+        sudo apt update -yq
+        sudo apt install -yq --no-install-recommends g++ gfortran ninja-build gobjc gobjc++ zlib1g-dev
+    - name: Install ninja-build tool
+      uses: seanmiddleditch/gha-setup-ninja@v1
+    - name: Python version
+      run: python3 --version
+    - name: Ninja version
+      run: ninja --version
+    - name: Run tests
+      run: python3 run_tests.py
+      env:
+        CI: '1'

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -355,22 +355,22 @@ a hard error in the future.''' % name)
         if not hasattr(self, 'typename'):
             raise RuntimeError('Target type is not set for target class "{}". This is a bug'.format(type(self).__name__))
 
-    def __lt__(self, other: T.Any) -> T.Union[bool, 'NotImplemented']:
+    def __lt__(self, other: T.Any) -> T.Union[bool, type(NotImplemented)]:
         if not hasattr(other, 'get_id') and not callable(other.get_id):
             return NotImplemented
         return self.get_id() < other.get_id()
 
-    def __le__(self, other: T.Any) -> T.Union[bool, 'NotImplemented']:
+    def __le__(self, other: T.Any) -> T.Union[bool, type(NotImplemented)]:
         if not hasattr(other, 'get_id') and not callable(other.get_id):
             return NotImplemented
         return self.get_id() <= other.get_id()
 
-    def __gt__(self, other: T.Any) -> T.Union[bool, 'NotImplemented']:
+    def __gt__(self, other: T.Any) -> T.Union[bool, type(NotImplemented)]:
         if not hasattr(other, 'get_id') and not callable(other.get_id):
             return NotImplemented
         return self.get_id() > other.get_id()
 
-    def __ge__(self, other: T.Any) -> T.Union[bool, 'NotImplemented']:
+    def __ge__(self, other: T.Any) -> T.Union[bool, type(NotImplemented)]:
         if not hasattr(other, 'get_id') and not callable(other.get_id):
             return NotImplemented
         return self.get_id() >= other.get_id()

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -386,7 +386,7 @@ class RunResult:
         self.stdout = stdout
         self.stderr = stderr
 
-class CompilerArgs(T.MutableSequence[str]):
+class CompilerArgs(collections.abc.MutableSequence):
     '''
     List-like class that manages a list of compiler arguments. Should be used
     while constructing compiler arguments from various sources. Can be

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -655,7 +655,7 @@ class CompilerArgs(T.MutableSequence[str]):
         new += self
         return new
 
-    def __eq__(self, other: T.Any) -> T.Union[bool, 'NotImplemented']:
+    def __eq__(self, other: T.Any) -> T.Union[bool, type(NotImplemented)]:
         # Only allow equality checks against other CompilerArgs and lists instances
         if isinstance(other, CompilerArgs):
             return self.compiler == other.compiler and self.__container == other.__container

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -94,6 +94,7 @@ class AutoDeletedDir:
 failing_logs = []
 print_debug = 'MESON_PRINT_TEST_OUTPUT' in os.environ
 under_ci = 'CI' in os.environ
+under_xenial_ci = under_ci and ('XENIAL' in os.environ)
 do_debug = under_ci or print_debug
 no_meson_log_msg = 'No meson-log.txt found.'
 
@@ -539,7 +540,8 @@ def have_java():
     return False
 
 def skippable(suite, test):
-    if not under_ci:
+    # Everything is optional when not running on CI, or on Ubuntu 16.04 CI
+    if not under_ci or under_xenial_ci:
         return True
 
     if not suite.endswith('frameworks'):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1231,7 +1231,7 @@ class DataTests(unittest.TestCase):
         platform on the CI.
         '''
         md = None
-        with open('docs/markdown/Builtin-options.md') as f:
+        with open('docs/markdown/Builtin-options.md', encoding='utf-8') as f:
             md = f.read()
         self.assertIsNotNone(md)
         env = get_fake_env()
@@ -1251,7 +1251,7 @@ class DataTests(unittest.TestCase):
         Builtin-Options.md.
         '''
         md = None
-        with open('docs/markdown/Builtin-options.md') as f:
+        with open('docs/markdown/Builtin-options.md', encoding='utf-8') as f:
             md = f.read()
         self.assertIsNotNone(md)
 
@@ -1285,7 +1285,7 @@ class DataTests(unittest.TestCase):
         ]))
 
     def test_cpu_families_documented(self):
-        with open("docs/markdown/Reference-tables.md") as f:
+        with open("docs/markdown/Reference-tables.md", encoding='utf-8') as f:
             md = f.read()
         self.assertIsNotNone(md)
 
@@ -1304,7 +1304,7 @@ class DataTests(unittest.TestCase):
         '''
         Test that each markdown files in docs/markdown is referenced in sitemap.txt
         '''
-        with open("docs/sitemap.txt") as f:
+        with open("docs/sitemap.txt", encoding='utf-8') as f:
             md = f.read()
         self.assertIsNotNone(md)
         toc = list(m.group(1) for m in re.finditer(r"^\s*(\w.*)$", md, re.MULTILINE))
@@ -5982,8 +5982,8 @@ c = ['{0}']
         self._check_ld('ld.gold', 'gold', 'fortran', 'GNU ld.gold')
 
     def compute_sha256(self, filename):
-        with open(filename,"rb") as f:
-            return hashlib.sha256(f.read()).hexdigest();
+        with open(filename, 'rb') as f:
+            return hashlib.sha256(f.read()).hexdigest()
 
     def test_wrap_with_file_url(self):
         testdir = os.path.join(self.unit_test_dir, '73 wrap file url')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4219,13 +4219,20 @@ recommended as it is not supported on some platforms''')
                        A number: 1
                             yes: YES
                              no: NO
+
+              Subprojects
+                            sub: YES
+                           sub2: NO
             ''')
-        # Dict ordering is not guaranteed and an exact string comparison randomly
-        # fails on the CI because lines are reordered.
         expected_lines = expected.split('\n')[1:]
         out_start = out.find(expected_lines[0])
         out_lines = out[out_start:].split('\n')[:len(expected_lines)]
-        self.assertEqual(sorted(expected_lines), sorted(out_lines))
+        if sys.version_info < (3, 7, 0):
+            # Dictionary order is not stable in Python <3.7, so sort the lines
+            # while comparing
+            self.assertEqual(sorted(expected_lines), sorted(out_lines))
+        else:
+            self.assertEqual(expected_lines, out_lines)
 
 
 class FailureTests(BasePlatformTests):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1376,6 +1376,7 @@ class DataTests(unittest.TestCase):
 class BasePlatformTests(unittest.TestCase):
     def setUp(self):
         super().setUp()
+        self.maxDiff = None
         src_root = os.path.dirname(__file__)
         src_root = os.path.join(os.getcwd(), src_root)
         self.src_root = src_root
@@ -4194,9 +4195,6 @@ recommended as it is not supported on some platforms''')
         self.init(testdir)
         self._run(self.mconf_command + [self.builddir])
 
-    # FIXME: The test is failing on Windows CI even if the print looks good.
-    # Maybe encoding issue?
-    @unittest.skipIf(is_windows(), 'This test fails on Windows CI')
     def test_summary(self):
         testdir = os.path.join(self.unit_test_dir, '72 summary')
         out = self.init(testdir)

--- a/test cases/cmake/5 object library/main.cpp
+++ b/test cases/cmake/5 object library/main.cpp
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <iostream>
 #include "libA.hpp"
 #include "libB.hpp"

--- a/test cases/cmake/6 object library no dep/main.cpp
+++ b/test cases/cmake/6 object library no dep/main.cpp
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include <iostream>
 #include "libA.hpp"
 #include "libB.hpp"

--- a/test cases/common/222 source set realistic example/meson.build
+++ b/test cases/common/222 source set realistic example/meson.build
@@ -1,7 +1,7 @@
 # a sort-of realistic example that combines the sourceset and kconfig
 # modules, inspired by QEMU's build system
 
-project('sourceset-example', 'cpp')
+project('sourceset-example', 'cpp', default_options: ['cpp_std=c++11'])
 
 cppid = meson.get_compiler('cpp').get_id()
 if cppid == 'pgi'

--- a/test cases/fortran/12 submodule/meson.build
+++ b/test cases/fortran/12 submodule/meson.build
@@ -1,6 +1,11 @@
 project('submodule single level', 'fortran',
   meson_version: '>= 0.50.0')
 
+fortc = meson.get_compiler('fortran')
+if fortc.get_id() == 'gcc' and fortc.version().version_compare('<6.0')
+  error('MESON_SKIP_TEST need gfortran >= 6.0 for submodule support')
+endif
+
 hier2 = executable('single', 'parent.f90', 'child.f90')
 test('single-level hierarchy', hier2)
 

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -40,14 +40,10 @@ if(python2dep.found() and host_machine.system() == 'linux')
     # on the installed version of python (and hope that they match the version boost
     # was compiled against)
     py2version_string = ''.join(python2dep.version().split('.'))
-    bpython2dep = dependency('boost', modules : ['python' + py2version_string])
+    bpython2dep = dependency('boost', modules : ['python' + py2version_string], required: false, disabler: true)
   else
     # if we have an older version of boost, we need to use the old module names
-    bpython2dep = dependency('boost', modules : ['python'])
-  endif
-
-  if not (bpython2dep.found())
-    bpython2dep = disabler()
+    bpython2dep = dependency('boost', modules : ['python'], required: false, disabler: true)
   endif
 else
   python2dep = disabler()
@@ -57,13 +53,9 @@ endif
 if(python3dep.found() and host_machine.system() == 'linux')
   if(dep.version().version_compare('>=1.67'))
     py3version_string = ''.join(python3dep.version().split('.'))
-    bpython3dep = dependency('boost', modules : ['python' + py3version_string])
+    bpython3dep = dependency('boost', modules : ['python' + py3version_string], required: false, disabler: true)
   else
-    bpython3dep = dependency('boost', modules : ['python3'])
-  endif
-
-  if not (bpython3dep.found())
-    bpython3dep = disabler()
+    bpython3dep = dependency('boost', modules : ['python3'], required: false, disabler: true)
   endif
 else
   python3dep = disabler()

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -82,7 +82,7 @@ test('Boost extralib test', extralibexe)
 python2interpreter = find_program(python2.path(), required: false, disabler: true)
 test('Boost Python2', python2interpreter, args: ['./test_python_module.py', meson.current_build_dir()], workdir: meson.current_source_dir(), depends: python2module)
 python3interpreter = find_program(python3.path(), required: false, disabler: true)
-test('Boost Python3', python3interpreter, args: ['./test_python_module.py', meson.current_build_dir()], workdir: meson.current_source_dir(), depends: python2module)
+test('Boost Python3', python3interpreter, args: ['./test_python_module.py', meson.current_build_dir()], workdir: meson.current_source_dir(), depends: python3module)
 
 subdir('partial_dep')
 

--- a/test cases/frameworks/6 gettext/meson.build
+++ b/test cases/frameworks/6 gettext/meson.build
@@ -5,6 +5,11 @@ if not gettext.found()
   error('MESON_SKIP_TEST gettext not found.')
 endif
 
+xgettext = find_program('xgettext', required: false)
+if not xgettext.found()
+  error('MESON_SKIP_TEST xgettext not found.')
+endif
+
 if not meson.get_compiler('c').has_header('libintl.h')
   error('MESON_SKIP_TEST libintl.h not found.')
 endif

--- a/test cases/frameworks/7 gnome/meson.build
+++ b/test cases/frameworks/7 gnome/meson.build
@@ -5,6 +5,11 @@ if not glib.found()
   error('MESON_SKIP_TEST glib not found.')
 endif
 
+gir = dependency('gobject-introspection-1.0', required: false)
+if not gir.found()
+  error('MESON_SKIP_TEST gobject-introspection not found.')
+endif
+
 python3 = import('python3')
 py3 = python3.find_python()
 if run_command(py3, '-c', 'import gi;').returncode() != 0


### PR DESCRIPTION
Explicitly use the type instead of the string `'NotImplemented'` which still works with Python 3.5.2

Fixes https://github.com/mesonbuild/meson/issues/6427.