### PR TITLE
Qt5: Do not use system qmake if not specified in cross file

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -380,6 +380,25 @@ class ExternalDependency(Dependency, HasNativeKwarg):
                         raise DependencyException(m.format(self.name, not_found, self.version))
                     return
 
+    # Create an iterator of options
+    def search_tool(self, name, display_name, default_names):
+        # Lookup in cross or machine file.
+        potential_path = self.env.binaries[self.for_machine].lookup_entry(name)
+        if potential_path is not None:
+            mlog.debug('{} binary for {} specified from cross file, native file, '
+                       'or env var as {}'.format(display_name, self.for_machine, potential_path))
+            yield ExternalProgram.from_entry(name, potential_path)
+            # We never fallback if the user-specified option is no good, so
+            # stop returning options.
+            return
+        mlog.debug('{} binary missing from cross or native file, or env var undefined.'.format(display_name))
+        # Fallback on hard-coded defaults.
+        # TODO prefix this for the cross case instead of ignoring thing.
+        if self.env.machines.matches_build_machine(self.for_machine):
+            for potential_path in default_names:
+                mlog.debug('Trying a default {} fallback at'.format(display_name), potential_path)
+                yield ExternalProgram(potential_path, silent=True)
+
 
 class NotFoundDependency(Dependency):
     def __init__(self, environment):
@@ -589,25 +608,6 @@ class PkgConfigDependency(ExternalDependency):
         # stored in the pickled coredata and recovered.
         self.pkgbin = None
 
-        # Create an iterator of options
-        def search():
-            # Lookup in cross or machine file.
-            potential_pkgpath = environment.binaries[self.for_machine].lookup_entry('pkgconfig')
-            if potential_pkgpath is not None:
-                mlog.debug('Pkg-config binary for {} specified from cross file, native file, '
-                           'or env var as {}'.format(self.for_machine, potential_pkgpath))
-                yield ExternalProgram.from_entry('pkgconfig', potential_pkgpath)
-                # We never fallback if the user-specified option is no good, so
-                # stop returning options.
-                return
-            mlog.debug('Pkg-config binary missing from cross or native file, or env var undefined.')
-            # Fallback on hard-coded defaults.
-            # TODO prefix this for the cross case instead of ignoring thing.
-            if environment.machines.matches_build_machine(self.for_machine):
-                for potential_pkgpath in environment.default_pkgconfig:
-                    mlog.debug('Trying a default pkg-config fallback at', potential_pkgpath)
-                    yield ExternalProgram(potential_pkgpath, silent=True)
-
         # Only search for pkg-config for each machine the first time and store
         # the result in the class definition
         if PkgConfigDependency.class_pkgbin[self.for_machine] is False:
@@ -617,7 +617,7 @@ class PkgConfigDependency(ExternalDependency):
         else:
             assert PkgConfigDependency.class_pkgbin[self.for_machine] is None
             mlog.debug('Pkg-config binary for %s is not cached.' % self.for_machine)
-            for potential_pkgbin in search():
+            for potential_pkgbin in self.search_tool('pkgconfig', 'Pkg-config', environment.default_pkgconfig):
                 mlog.debug('Trying pkg-config binary {} for machine {} at {}'
                            .format(potential_pkgbin.name, self.for_machine, potential_pkgbin.command))
                 version_if_ok = self.check_pkgconfig(potential_pkgbin)

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -28,7 +28,7 @@ from ..mesonlib import (
 from ..environment import detect_cpu_family
 
 from .base import DependencyException, DependencyMethods
-from .base import ExternalDependency, ExternalProgram, NonExistingExternalProgram
+from .base import ExternalDependency, NonExistingExternalProgram
 from .base import ExtraFrameworkDependency, PkgConfigDependency
 from .base import ConfigToolDependency
 
@@ -334,28 +334,24 @@ class QtBaseDependency(ExternalDependency):
             if prefix:
                 self.bindir = os.path.join(prefix, 'bin')
 
-    def _qmake_detect(self, mods, kwargs):
+    def search_qmake(self):
         for qmake in ('qmake-' + self.name, 'qmake'):
-            self.qmake = ExternalProgram.from_bin_list(
-                self.env.binaries.host, qmake)
-            if not self.qmake.found():
-                # Even when cross-compiling, if a cross-info qmake is not
-                # specified, we fallback to using the qmake in PATH because
-                # that's what we used to do
-                self.qmake = ExternalProgram.from_bin_list(
-                    self.env.binaries.build, qmake)
-            if not self.qmake.found():
-                self.qmake = ExternalProgram(qmake, silent=True)
-            if not self.qmake.found():
+            for potential_qmake in self.search_tool(qmake, 'QMake', [qmake]):
+                yield potential_qmake
+
+    def _qmake_detect(self, mods, kwargs):
+        for qmake in self.search_qmake():
+            if not qmake.found():
                 continue
             # Check that the qmake is for qt5
-            pc, stdo = Popen_safe(self.qmake.get_command() + ['-v'])[0:2]
+            pc, stdo = Popen_safe(qmake.get_command() + ['-v'])[0:2]
             if pc.returncode != 0:
                 continue
             if not 'Qt version ' + self.qtver in stdo:
                 mlog.log('QMake is not for ' + self.qtname)
                 continue
             # Found qmake for Qt5!
+            self.qmake = qmake
             break
         else:
             # Didn't find qmake :(
@@ -377,7 +373,7 @@ class QtBaseDependency(ExternalDependency):
         if self.env.machines.host.is_darwin() and not any(s in xspec for s in ['ios', 'tvos']):
             mlog.debug("Building for macOS, looking for framework")
             self._framework_detect(qvars, mods, kwargs)
-            return qmake
+            return self.qmake.name
         incdir = qvars['QT_INSTALL_HEADERS']
         self.compile_args.append('-I' + incdir)
         libdir = qvars['QT_INSTALL_LIBS']
@@ -418,7 +414,7 @@ class QtBaseDependency(ExternalDependency):
             if not self._link_with_qtmain(is_debug, libdir):
                 self.is_found = False
 
-        return qmake
+        return self.qmake.name
 
     def _get_modules_lib_suffix(self, is_debug):
         suffix = ''


### PR DESCRIPTION
There is a comment saying we do it because we used to do it. But it's
wrong and lead to using system library when cross compiling.

Factor out the code we use to find pkg-config, because it is the same
use-case.