### PR TITLE
Don't build tests by default in ninja

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1002,6 +1002,20 @@ class Backend:
                 result[dep.get_id()] = dep
         return result
 
+    def get_benchmark_targets(self):
+        result = OrderedDict()
+        # Get all targets used as test executables and arguments.
+        for t in self.build.get_benchmarks():
+            for arg in [t.exe] + t.cmd_args:
+                if hasattr(arg, 'held_object'):
+                    arg = arg.held_object
+                if isinstance(arg, (build.CustomTarget, build.BuildTarget)):
+                    result[arg.get_id()] = arg
+            for dep in t.depends:
+                assert isinstance(dep, (build.CustomTarget, build.BuildTarget))
+                result[dep.get_id()] = dep
+        return result
+
     @lru_cache(maxsize=None)
     def get_custom_target_provided_by_generated_source(self, generated_source):
         libs = []

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -992,12 +992,9 @@ class Backend:
         # built only before running tests.
         for t in self.build.get_tests():
             exe = unholder(t.exe)
-            if isinstance(exe, (build.CustomTarget, build.BuildTarget)):
-                result[exe.get_id()] = exe
-            for arg in unholder(t.cmd_args):
-                if not isinstance(arg, (build.CustomTarget, build.BuildTarget)):
-                    continue
-                result[arg.get_id()] = arg
+            for arg in [exe] + unholder(t.cmd_args):
+                if isinstance(arg, (build.CustomTarget, build.BuildTarget)):
+                    result[arg.get_id()] = arg
             for dep in t.depends:
                 assert isinstance(dep, (build.CustomTarget, build.BuildTarget))
                 result[dep.get_id()] = dep

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -987,9 +987,11 @@ class Backend:
         for name, t in self.build.get_targets().items():
             if t.build_by_default:
                 result[name] = t
-        # Get all targets used as test executables and arguments. These must
-        # also be built by default. XXX: Sometime in the future these should be
-        # built only before running tests.
+        return result
+
+    def get_test_targets(self):
+        result = OrderedDict()
+        # Get all targets used as test executables and arguments.
         for t in self.build.get_tests():
             exe = unholder(t.exe)
             for arg in [exe] + unholder(t.cmd_args):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1046,7 +1046,7 @@ int dummy;
             cmd += ['--no-stdsplit']
         if self.environment.coredata.get_builtin_option('errorlogs'):
             cmd += ['--print-errorlogs']
-        elem = NinjaBuildElement(self.all_outputs, 'meson-test', 'CUSTOM_COMMAND', ['all', 'PHONY'])
+        elem = NinjaBuildElement(self.all_outputs, 'meson-test', 'CUSTOM_COMMAND', ['all', 'tests', 'PHONY'])
         elem.add_item('COMMAND', cmd)
         elem.add_item('DESC', 'Running all tests.')
         elem.add_item('pool', 'console')
@@ -1058,7 +1058,7 @@ int dummy;
         cmd = self.environment.get_build_command(True) + [
             'test', '--benchmark', '--logbase',
             'benchmarklog', '--num-processes=1', '--no-rebuild']
-        elem = NinjaBuildElement(self.all_outputs, 'meson-benchmark', 'CUSTOM_COMMAND', ['all', 'PHONY'])
+        elem = NinjaBuildElement(self.all_outputs, 'meson-benchmark', 'CUSTOM_COMMAND', ['all', 'tests', 'PHONY'])
         elem.add_item('COMMAND', cmd)
         elem.add_item('DESC', 'Running benchmark suite.')
         elem.add_item('pool', 'console')
@@ -2967,14 +2967,23 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         self.create_target_alias('meson-uninstall')
 
     def generate_ending(self):
-        targetlist = []
+        default_targetlist = []
         for t in self.get_build_by_default_targets().values():
             # Add the first output of each target to the 'all' target so that
             # they are all built
-            targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
+            default_targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
 
-        elem = NinjaBuildElement(self.all_outputs, 'all', 'phony', targetlist)
-        self.add_build(elem)
+        default_elem = NinjaBuildElement(self.all_outputs, 'all', 'phony', default_targetlist)
+        self.add_build(default_elem)
+
+        test_targetlist = []
+        for t in self.get_test_targets().values():
+            # Add the first output of each target to the 'all' target so that
+            # they are all built
+            test_targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
+
+        test_elem = NinjaBuildElement(self.all_outputs, 'tests', 'phony', test_targetlist)
+        self.add_build(test_elem)
 
         elem = NinjaBuildElement(self.all_outputs, 'meson-clean', 'CUSTOM_COMMAND', 'PHONY')
         elem.add_item('COMMAND', self.ninja_command + ['-t', 'clean'])

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1046,7 +1046,8 @@ int dummy;
             cmd += ['--no-stdsplit']
         if self.environment.coredata.get_builtin_option('errorlogs'):
             cmd += ['--print-errorlogs']
-        elem = NinjaBuildElement(self.all_outputs, 'meson-test', 'CUSTOM_COMMAND', ['all', 'tests', 'PHONY'])
+        elem = NinjaBuildElement(self.all_outputs, 'meson-test',
+                                 'CUSTOM_COMMAND', ['meson-build-tests', 'PHONY'])
         elem.add_item('COMMAND', cmd)
         elem.add_item('DESC', 'Running all tests.')
         elem.add_item('pool', 'console')
@@ -1058,7 +1059,8 @@ int dummy;
         cmd = self.environment.get_build_command(True) + [
             'test', '--benchmark', '--logbase',
             'benchmarklog', '--num-processes=1', '--no-rebuild']
-        elem = NinjaBuildElement(self.all_outputs, 'meson-benchmark', 'CUSTOM_COMMAND', ['all', 'tests', 'PHONY'])
+        elem = NinjaBuildElement(self.all_outputs, 'meson-benchmark',
+                                 'CUSTOM_COMMAND', ['meson-build-benchmarks', 'PHONY'])
         elem.add_item('COMMAND', cmd)
         elem.add_item('DESC', 'Running benchmark suite.')
         elem.add_item('pool', 'console')
@@ -2978,12 +2980,17 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
 
         test_targetlist = []
         for t in self.get_test_targets().values():
-            # Add the first output of each target to the 'all' target so that
-            # they are all built
             test_targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
 
-        test_elem = NinjaBuildElement(self.all_outputs, 'tests', 'phony', test_targetlist)
+        test_elem = NinjaBuildElement(self.all_outputs, 'meson-build-tests', 'phony', test_targetlist)
         self.add_build(test_elem)
+
+        benchmark_targetlist = []
+        for t in self.get_benchmark_targets().values():
+            benchmark_targetlist.append(os.path.join(self.get_target_dir(t), t.get_outputs()[0]))
+
+        benchmark_elem = NinjaBuildElement(self.all_outputs, 'meson-build-benchmarks', 'phony', benchmark_targetlist)
+        self.add_build(benchmark_elem)
 
         elem = NinjaBuildElement(self.all_outputs, 'meson-clean', 'CUSTOM_COMMAND', 'PHONY')
         elem.add_item('COMMAND', self.ninja_command + ['-t', 'clean'])

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -308,6 +308,7 @@ class Vs2010Backend(backends.Backend):
 
     def generate_solution(self, sln_filename, projlist):
         default_projlist = self.get_build_by_default_targets()
+        default_projlist.update(self.get_test_targets())
         sln_filename_tmp = sln_filename + '~'
         with open(sln_filename_tmp, 'w', encoding='utf-8') as ofile:
             ofile.write('Microsoft Visual Studio Solution File, Format '

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -539,7 +539,7 @@ def run(opts):
     if not os.path.exists(os.path.join(opts.wd, datafilename)):
         sys.exit('Install data not found. Run this command in build directory root.')
     if not opts.no_rebuild:
-        if not rebuild_all(opts.wd):
+        if not rebuild_all(opts.wd, 'all'):
             sys.exit(-1)
     os.chdir(opts.wd)
     with open(os.path.join(log_dir, 'install-log.txt'), 'w') as lf:

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1204,7 +1204,7 @@ def list_tests(th: TestHarness) -> bool:
         print(th.get_pretty_suite(t))
     return not tests
 
-def rebuild_all(wd: str) -> bool:
+def rebuild_all(wd: str, target: str) -> bool:
     if not (Path(wd) / 'build.ninja').is_file():
         print('Only ninja backend is supported to rebuild tests before running them.')
         return True
@@ -1214,7 +1214,7 @@ def rebuild_all(wd: str) -> bool:
         print("Can't find ninja, can't rebuild test.")
         return False
 
-    ret = subprocess.run(ninja + ['-C', wd]).returncode
+    ret = subprocess.run(ninja + ['-C', wd, target]).returncode
     if ret != 0:
         print('Could not rebuild {}'.format(wd))
         return False
@@ -1247,7 +1247,7 @@ def run(options: argparse.Namespace) -> int:
             return 1
 
     if not options.list and not options.no_rebuild:
-        if not rebuild_all(options.wd):
+        if not rebuild_all(options.wd, 'meson-build-benchmarks' if options.benchmark else 'meson-build-tests'):
             # We return 125 here in case the build failed.
             # The reason is that exit code 125 tells `git bisect run` that the current commit should be skipped.
             # Thus users can directly use `meson test` to bisect without needing to handle the does-not-build case separately in a wrapper script.

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1210,10 +1210,11 @@ def check_meson_commands_work(options):
         pc, o, e = Popen_safe(compile_commands + dir_args, cwd=build_dir)
         if pc.returncode != 0:
             raise RuntimeError('Failed to build {!r}:\n{}\n{}'.format(testdir, e, o))
-        print('Checking that building tests works...')
-        pc, o, e = Popen_safe(buildtests_commands, cwd=build_dir)
-        if pc.returncode != 0:
-            raise RuntimeError('Failed to build tests {!r}:\n{}\n{}'.format(testdir, e, o))
+        if buildtests_commands:
+            print('Checking that building tests works...')
+            pc, o, e = Popen_safe(buildtests_commands, cwd=build_dir)
+            if pc.returncode != 0:
+                raise RuntimeError('Failed to build tests {!r}:\n{}\n{}'.format(testdir, e, o))
         print('Checking that testing works...')
         pc, o, e = Popen_safe(test_commands, cwd=build_dir)
         if pc.returncode != 0:

--- a/run_tests.py
+++ b/run_tests.py
@@ -213,12 +213,14 @@ def get_backend_commands(backend, debug=False):
     if backend is Backend.vs:
         cmd = ['msbuild']
         clean_cmd = cmd + ['/target:Clean']
+        buildtests_cmd = cmd + ['BUILD_TESTS.vcxproj']
         test_cmd = cmd + ['RUN_TESTS.vcxproj']
     elif backend is Backend.xcode:
         cmd = ['xcodebuild']
         # In Xcode9 new build system's clean command fails when using a custom build directory.
         # Maybe use it when CI uses Xcode10 we can remove '-UseNewBuildSystem=FALSE'
         clean_cmd = cmd + ['-alltargets', 'clean', '-UseNewBuildSystem=FALSE']
+        buildtests_cmd = cmd + ['-target', 'BUILD_TESTS']
         test_cmd = cmd + ['-target', 'RUN_TESTS']
     elif backend is Backend.ninja:
         global NINJA_CMD
@@ -226,12 +228,13 @@ def get_backend_commands(backend, debug=False):
         if debug:
             cmd += ['-v']
         clean_cmd = cmd + ['clean']
+        buildtests_cmd = cmd + ['tests']
         test_cmd = cmd + ['test', 'benchmark']
         install_cmd = cmd + ['install']
         uninstall_cmd = cmd + ['uninstall']
     else:
         raise AssertionError('Unknown backend: {!r}'.format(backend))
-    return cmd, clean_cmd, test_cmd, install_cmd, uninstall_cmd
+    return cmd, clean_cmd, buildtests_cmd, test_cmd, install_cmd, uninstall_cmd
 
 def ensure_backend_detects_changes(backend):
     global NINJA_1_9_OR_NEWER

--- a/run_tests.py
+++ b/run_tests.py
@@ -210,17 +210,16 @@ def get_builddir_target_args(backend, builddir, target):
 def get_backend_commands(backend, debug=False):
     install_cmd = []
     uninstall_cmd = []
+    buildtests_cmd = []
     if backend is Backend.vs:
         cmd = ['msbuild']
         clean_cmd = cmd + ['/target:Clean']
-        buildtests_cmd = cmd + ['BUILD_TESTS.vcxproj']
         test_cmd = cmd + ['RUN_TESTS.vcxproj']
     elif backend is Backend.xcode:
         cmd = ['xcodebuild']
         # In Xcode9 new build system's clean command fails when using a custom build directory.
         # Maybe use it when CI uses Xcode10 we can remove '-UseNewBuildSystem=FALSE'
         clean_cmd = cmd + ['-alltargets', 'clean', '-UseNewBuildSystem=FALSE']
-        buildtests_cmd = cmd + ['-target', 'BUILD_TESTS']
         test_cmd = cmd + ['-target', 'RUN_TESTS']
     elif backend is Backend.ninja:
         global NINJA_CMD
@@ -228,7 +227,7 @@ def get_backend_commands(backend, debug=False):
         if debug:
             cmd += ['-v']
         clean_cmd = cmd + ['clean']
-        buildtests_cmd = cmd + ['tests']
+        buildtests_cmd = cmd + ['meson-build-tests', 'meson-build-benchmarks']
         test_cmd = cmd + ['test', 'benchmark']
         install_cmd = cmd + ['install']
         uninstall_cmd = cmd + ['uninstall']

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1563,11 +1563,11 @@ class BasePlatformTests(unittest.TestCase):
         # Misc stuff
         self.orig_env = os.environ.copy()
         if self.backend is Backend.ninja:
-            self.no_rebuild_stdout = ['ninja: no work to do.', 'samu: nothing to do']
+            self.no_rebuild_stdout = {'ninja: no work to do.', 'samu: nothing to do'}
         else:
             # VS doesn't have a stable output when no changes are done
             # XCode backend is untested with unit tests, help welcome!
-            self.no_rebuild_stdout = ['UNKNOWN BACKEND {!r}'.format(self.backend.name)]
+            self.no_rebuild_stdout = {'UNKNOWN BACKEND {!r}'.format(self.backend.name)}
 
         self.builddirs = []
         self.new_builddir()

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1551,7 +1551,7 @@ class BasePlatformTests(unittest.TestCase):
         self.wrap_command = self.meson_command + ['wrap']
         self.rewrite_command = self.meson_command + ['rewrite']
         # Backend-specific build commands
-        self.build_command, self.clean_command, self.test_command, self.install_command, \
+        self.build_command, self.clean_command, self.buildtests_command, self.test_command, self.install_command, \
             self.uninstall_command = get_backend_commands(self.backend)
         # Test directories
         self.common_test_dir = os.path.join(src_root, 'test cases/common')
@@ -1701,6 +1701,7 @@ class BasePlatformTests(unittest.TestCase):
         self._run(self.clean_command + dir_args, workdir=self.builddir, override_envvars=override_envvars)
 
     def run_tests(self, *, inprocess=False, override_envvars=None):
+        self._run(self.buildtests_command, workdir=self.builddir, override_envvars=override_envvars)
         if not inprocess:
             self._run(self.test_command, workdir=self.builddir, override_envvars=override_envvars)
         else:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4885,6 +4885,19 @@ recommended as it is not supported on some platforms''')
             self._run([*self.meson_command, 'compile', '-C', self.builddir, '--vs-args=-t:{}:Clean'.format(re.sub(r'[\%\$\@\;\.\(\)\']', '_', get_exe_name('trivialprog')))])
             self.assertPathDoesNotExist(os.path.join(self.builddir, get_exe_name('trivialprog')))
 
+    def test_tests_not_default(self):
+        testdir = os.path.join(self.common_test_dir, '132 build by default targets in tests')
+        self.init(testdir)
+        self.build()
+        self.assertBuildIsNoop()
+        self.run_tests()
+
+    def test_benchmark_not_default(self):
+        testdir = os.path.join(self.common_test_dir, '95 benchmark')
+        self.init(testdir)
+        self.build()
+        self.assertBuildIsNoop()
+
     def test_spurious_reconfigure_built_dep_file(self):
         testdir = os.path.join(self.unit_test_dir, '75 dep files')
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1858,7 +1858,7 @@ class BasePlatformTests(unittest.TestCase):
     def assertBuildIsNoop(self):
         ret = self.build()
         if self.backend is Backend.ninja:
-            self.assertIn(ret.split('\n')[-2], self.no_rebuild_stdout)
+            self.assertIn(ret.split('\n')[-2].rstrip(), self.no_rebuild_stdout)
         elif self.backend is Backend.vs:
             # Ensure that some target of each type said that no rebuild was done
             # We always have at least one CustomBuild target for the regen checker

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1701,7 +1701,8 @@ class BasePlatformTests(unittest.TestCase):
         self._run(self.clean_command + dir_args, workdir=self.builddir, override_envvars=override_envvars)
 
     def run_tests(self, *, inprocess=False, override_envvars=None):
-        self._run(self.buildtests_command, workdir=self.builddir, override_envvars=override_envvars)
+        if self.buildtests_command:
+            self._run(self.buildtests_command, workdir=self.builddir, override_envvars=override_envvars)
         if not inprocess:
             self._run(self.test_command, workdir=self.builddir, override_envvars=override_envvars)
         else:

--- a/test cases/common/1 trivial/meson.build
+++ b/test cases/common/1 trivial/meson.build
@@ -1,8 +1,7 @@
 # Comment on the first line
 project('trivial test',
   # Comment inside a function call + array for language list
-  ['c'], default_options: ['buildtype=debug'],
-  meson_version : '>=0.52.0')
+  ['c'], default_options: ['buildtype=debug'])
 #this is a comment
 sources = 'trivial.c'
 
@@ -16,6 +15,7 @@ endif
 
 exe = executable('trivialprog', sources : sources)
 assert(exe.name() == 'trivialprog')
+
 test('runtest', exe) # This is a comment
 
 has_not_changed = false

--- a/test cases/common/95 benchmark/meson.build
+++ b/test cases/common/95 benchmark/meson.build
@@ -1,4 +1,4 @@
 project('benchmark', 'c')
 
-delayer = executable('delayer', 'delayer.c', c_args : '-D_GNU_SOURCE')
+delayer = executable('delayer', 'delayer.c', c_args : '-D_GNU_SOURCE', build_by_default : false)
 benchmark('delayer', delayer)


### PR DESCRIPTION
This is a rebased version of #5728, with the changes I requested applied on top. The idea is that tests and benchmarks are removed from the all target, and are placed in their own `meson-build-tests` and `meson-build-benchmarks` targets, which the `test` and `benchmark` targets depend on. This allows us to avoid building test executables by default.

I'd like to follow this up with a change that allows targets that are not installed to not build by default.

Fixes #2518
Fixes #1704