### PR TITLE
tests: Prevent multiple-definition of symbols

### DIFF
--- a/test cases/common/219 source set configuration_data/all.h
+++ b/test cases/common/219 source set configuration_data/all.h
@@ -3,5 +3,7 @@ extern void g(void);
 extern void h(void);
 extern void undefined(void);
 
-/* No extern here to get a common symbol */
-void (*p)(void);
+/* Defined in nope.c and f.c,
+ * value depends on the source set and configuration used.
+ */
+extern void (*p)(void);

--- a/test cases/common/219 source set configuration_data/f.c
+++ b/test cases/common/219 source set configuration_data/f.c
@@ -1,5 +1,7 @@
 #include "all.h"
 
+void (*p)(void) = (void *)0x12AB34CD;
+
 void f(void)
 {
 }

--- a/test cases/common/220 source set dictionary/all.h
+++ b/test cases/common/220 source set dictionary/all.h
@@ -3,5 +3,7 @@ extern void g(void);
 extern void h(void);
 extern void undefined(void);
 
-/* No extern here to get a common symbol */
-void (*p)(void);
+/* Defined in nope.c and f.c,
+ * value depends on the source set and configuration used.
+ */
+extern void (*p)(void);

--- a/test cases/common/220 source set dictionary/f.c
+++ b/test cases/common/220 source set dictionary/f.c
@@ -1,5 +1,7 @@
 #include "all.h"
 
+void (*p)(void) = (void *)0x1234ABCD;
+
 void f(void)
 {
 }

--- a/test cases/common/68 build always/version.h
+++ b/test cases/common/68 build always/version.h
@@ -1,3 +1,3 @@
 #pragma once
 
-const char *version_string;
+extern const char *version_string;

--- a/test cases/common/69 vcstag/tagprog.c
+++ b/test cases/common/69 vcstag/tagprog.c
@@ -1,6 +1,6 @@
 #include<stdio.h>
 
-const char *vcstag;
+extern const char *vcstag;
 
 int main(void) {
     printf("Version is %s\n", vcstag);


### PR DESCRIPTION
With GCC 10, -fno-common becomes default behavior, meaning that any
subtly-broken code will be broken not so subtly anymore.

This commit changes the linkage to variables declared in headers to
external and, where needed, adds additional definitions in other
compilation units.