### PR TITLE
mtest: allow test processes to react on termination

### DIFF
--- a/docs/markdown/snippets/termination_signal_for_tests.md
+++ b/docs/markdown/snippets/termination_signal_for_tests.md
@@ -1,0 +1,6 @@
+## Changed the signal used to terminate a test process (group)
+
+A test process (group) is now terminated via SIGTERM instead of SIGKILL
+allowing the signal to be handled. However, it is now the responsibility of
+the custom signal handler (if any) to ensure that any process spawned by the
+top-level test processes is correctly killed.


### PR DESCRIPTION
Since neither SIGKILL nor SIGSTOP can be caught nor ignored it could be useful to terminate a test process via another signal first. Allowing some additional cleanup of a test. 

As an example, I would like to report a backtrace of the current state of a test when it times out as it could help understand an underlying problem. Currently, because the process running the test is terminated via SIGKILL it is not possible to do this.