### PR TITLE
Add variables in native/cross files

### DIFF
--- a/docs/markdown/Cross-compilation.md
+++ b/docs/markdown/Cross-compilation.md
@@ -328,6 +328,21 @@ myvar = meson.get_cross_property('somekey')
 # myvar now has the value 'somevalue'
 ```
 
+## Constants
+
+Since *0.54.0* constants can be defined in the `[constants]` section and
+used in other sections as `@varname@`. If provided, it must be the first section
+in the file. Values must all be strings, integers, booleans and lists are not
+allowed.
+
+```ini
+[constants]
+somepath = '/path/to/toolchain'
+[binaries]
+c = '@somepath@/gcc'
+cpp = '@somepath@/g++'
+```
+
 ## Cross file locations
 
 As of version 0.44.0 meson supports loading cross files from system locations

--- a/docs/markdown/Native-environments.md
+++ b/docs/markdown/Native-environments.md
@@ -76,6 +76,11 @@ expressing all of these configurations in monolithic configurations would
 result in 81 different native files. By layering them, it can be expressed by
 just 12 native files.
 
+## Constants
+
+Since *0.54.0* constants can be defined in the `[constants]` section and
+used in other sections as `@varname@`. See [here](Cross-compilation.md#constants)
+for details.
 
 ## Native file locations
 

--- a/docs/markdown/snippets/cross_file_constants.md
+++ b/docs/markdown/snippets/cross_file_constants.md
@@ -1,0 +1,13 @@
+## Cross and native file constants
+
+Constants can be defined in the `[constants]` section and used in other
+sections as `@varname@`. See [here](Cross-compilation.md#constants)
+for details.
+
+```ini
+[constants]
+somepath = '/path/to/toolchain'
+[binaries]
+c = '@somepath@/gcc'
+cpp = '@somepath@/g++'
+```

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -230,6 +230,8 @@ class UserFeatureOption(UserComboOption):
 def load_configs(filenames: T.List[str]) -> configparser.ConfigParser:
     """Load configuration files from a named subdirectory."""
     config = configparser.ConfigParser(interpolation=None)
+    # Do not lowercase all keys
+    config.optionxform = str
     config.read(filenames)
     return config
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -542,7 +542,7 @@ class Environment:
         ## Read in native file(s) to override build machine configuration
 
         if self.coredata.config_files is not None:
-            config = MesonConfigFile.from_config_parser(
+            config = MesonConfigFile.from_config_parser('native',
                 coredata.load_configs(self.coredata.config_files))
             binaries.build = BinaryTable(config.get('binaries', {}))
             paths.build = Directories(**config.get('paths', {}))
@@ -551,7 +551,7 @@ class Environment:
         ## Read in cross file(s) to override host machine configuration
 
         if self.coredata.cross_files:
-            config = MesonConfigFile.from_config_parser(
+            config = MesonConfigFile.from_config_parser('cross',
                 coredata.load_configs(self.coredata.cross_files))
             properties.host = Properties(config.get('properties', {}), False)
             binaries.host = BinaryTable(config.get('binaries', {}), False)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5947,6 +5947,35 @@ class LinuxlikeTests(BasePlatformTests):
         self.meson_cross_file = crossfile.name
         self.init(testdir)
 
+    def test_cross_find_program_constants(self):
+        testdir = os.path.join(self.unit_test_dir, '11 cross prog')
+        crossfile = tempfile.NamedTemporaryFile(mode='w')
+        print(os.path.join(testdir, 'some_cross_tool.py'))
+        crossfile.write(textwrap.dedent('''\
+            [constants]
+            SOMEPATH = '{0}'
+            compiler = '{1}'
+
+            [binaries]
+            c = '/usr/bin/@compiler@'
+            ar = '/usr/bin/ar'
+            strip = '/usr/bin/strip'
+            sometool.py = ['@SOMEPATH@']
+            someothertool.py = '@SOMEPATH@'
+
+            [properties]
+
+            [host_machine]
+            system = 'linux'
+            cpu_family = 'arm'
+            cpu = 'armv7' # Not sure if correct.
+            endian = 'little'
+            ''').format(os.path.join(testdir, 'some_cross_tool.py'),
+                        'gcc' if is_sunos() else 'cc'))
+        crossfile.flush()
+        self.meson_cross_file = crossfile.name
+        self.init(testdir)
+
     def test_reconfigure(self):
         testdir = os.path.join(self.unit_test_dir, '13 reconfigure')
         self.init(testdir, extra_args=['-Db_coverage=true'], default_args=False)


### PR DESCRIPTION
This adds a new section `[variables]` to define variables that will be
replaced in other sections values using the @varname@ pattern.

Also:
- Removed type annotation for return value of from_config_parser()
  because it force values to be str, but could be lists too.
- It is an hard error to have an unknown section name, this should
  avoid hard to find mistake when there is a typo in a section name.
- Fix error messages saying 'cross file' when it's actually in the
  native file.
- Allow upper case in entries, by default configparser lowercase() them
  all, which makes impossible to have mixed case in binaries names, or
  upper case variables.

