### PR TITLE
Adding more Meson sample templates.

### DIFF
--- a/docs/markdown/snippets/more_meson_sample_templates.md
+++ b/docs/markdown/snippets/more_meson_sample_templates.md
@@ -1,6 +1,6 @@
-## More new sample Meson templates (`Java`, `Cuda`, `Swift`, and more)
+## More new sample Meson templates for (`Java`, `Cuda`, and more)
 
 Meson now ships with predefined project templates for `Java`,
-`Cuda`, `Swift`, `Objective-C++`, and `C#`, we provide new values 
-associated with there corresponding languages `java`, `cuda`, 
-`swift`, `objcpp`, `cs` to `meson init --language`.
+`Cuda`, `Objective-C++`, and `C#`, we provided with associated
+values for corresponding languages, avalable for both library,
+and executable.

--- a/docs/markdown/snippets/more_meson_sample_templates.md
+++ b/docs/markdown/snippets/more_meson_sample_templates.md
@@ -1,0 +1,6 @@
+## More new sample Meson templates (`Java`, `Cuda`, `Swift`, and more)
+
+Meson now ships with predefined project templates for `Java`,
+`Cuda`, `Swift`, `Objective-C++`, and `C#`, we provide new values 
+associated with there corresponding languages `java`, `cuda`, 
+`swift`, `objcpp`, `cs` to `meson init --language`.

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -26,7 +26,6 @@ from mesonbuild.templates.cstemplates import (create_exe_cs_sample, create_lib_c
 from mesonbuild.templates.cudatemplates import (create_exe_cuda_sample, create_lib_cuda_sample)
 from mesonbuild.templates.objctemplates import (create_exe_objc_sample, create_lib_objc_sample)
 from mesonbuild.templates.objcpptemplates import (create_exe_objcpp_sample, create_lib_objcpp_sample)
-from mesonbuild.templates.swifttemplates import (create_exe_swift_sample, create_lib_swift_sample)
 from mesonbuild.templates.dlangtemplates import (create_exe_d_sample, create_lib_d_sample)
 from mesonbuild.templates.javatemplates import (create_exe_java_sample, create_lib_java_sample)
 from mesonbuild.templates.fortrantemplates import (create_exe_fortran_sample, create_lib_fortran_sample)
@@ -123,13 +122,6 @@ def create_sample(options):
             create_lib_java_sample(options.name, options.version)
         else:
             raise RuntimeError(UNREACHABLE_CODE)
-    elif options.language == 'swift':
-        if options.type == 'executable':
-            create_exe_swift_sample(options.name, options.version)
-        elif options.type == 'library':
-            create_lib_swift_sample(options.name, options.version)
-        else:
-            raise RuntimeError(UNREACHABLE_CODE)
     else:
         raise RuntimeError(UNREACHABLE_CODE)
     print(info_message)
@@ -156,7 +148,7 @@ def autodetect_options(options, sample: bool = False):
     if not options.srcfiles:
         srcfiles = []
         for f in (f for f in Path().iterdir() if f.is_file()):
-            if f.suffix in (['.c', '.cc', '.cpp', '.cs', '.cu', '.d', '.m', '.mm', '.swift', '.rs', '.java'] + FORTRAN_SUFFIXES):
+            if f.suffix in (['.c', '.cc', '.cpp', '.cs', '.cu', '.d', '.m', '.mm', '.rs', '.java'] + FORTRAN_SUFFIXES):
                 srcfiles.append(f)
         if not srcfiles:
             raise SystemExit('No recognizable source files found.\n'
@@ -196,9 +188,6 @@ def autodetect_options(options, sample: bool = False):
             if f.suffix == '.java':
                 options.language = 'java'
                 break
-            if f.suffix == '.swift':
-                options.language = 'swift'
-                break
         if not options.language:
             raise SystemExit("Can't autodetect language, please specify it with -l.")
         print("Detected language: " + options.language)
@@ -212,7 +201,7 @@ def add_arguments(parser):
     parser.add_argument("-n", "--name", help="project name. default: name of current directory")
     parser.add_argument("-e", "--executable", help="executable name. default: project name")
     parser.add_argument("-d", "--deps", help="dependencies, comma-separated")
-    parser.add_argument("-l", "--language", choices=['c', 'cpp', 'cs', 'cuda', 'd', 'fortran', 'java', 'rust', 'objc', 'objcpp', 'swift'],
+    parser.add_argument("-l", "--language", choices=['c', 'cpp', 'cs', 'cuda', 'd', 'fortran', 'java', 'rust', 'objc', 'objcpp'],
                         help="project language. default: autodetected based on source files")
     parser.add_argument("-b", "--build", help="build after generation", action='store_true')
     parser.add_argument("--builddir", help="directory for build", default='build')

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -22,6 +22,7 @@ from mesonbuild.environment import detect_ninja
 
 from mesonbuild.templates.ctemplates import (create_exe_c_sample, create_lib_c_sample)
 from mesonbuild.templates.cpptemplates import (create_exe_cpp_sample, create_lib_cpp_sample)
+from mesonbuild.templates.cstemplates import (create_exe_cs_sample, create_lib_cs_sample)
 from mesonbuild.templates.cudatemplates import (create_exe_cuda_sample, create_lib_cuda_sample)
 from mesonbuild.templates.objctemplates import (create_exe_objc_sample, create_lib_objc_sample)
 from mesonbuild.templates.objcpptemplates import (create_exe_objcpp_sample, create_lib_objcpp_sample)
@@ -64,6 +65,13 @@ def create_sample(options):
             create_exe_cpp_sample(options.name, options.version)
         elif options.type == 'library':
             create_lib_cpp_sample(options.name, options.version)
+        else:
+            raise RuntimeError(UNREACHABLE_CODE)
+    elif options.language == 'cs':
+        if options.type == 'executable':
+            create_exe_cs_sample(options.name, options.version)
+        elif options.type == 'library':
+            create_lib_cs_sample(options.name, options.version)
         else:
             raise RuntimeError(UNREACHABLE_CODE)
     elif options.language == 'cuda':
@@ -148,7 +156,7 @@ def autodetect_options(options, sample: bool = False):
     if not options.srcfiles:
         srcfiles = []
         for f in (f for f in Path().iterdir() if f.is_file()):
-            if f.suffix in (['.c', '.cc', '.cpp', '.cu', '.d', '.m', '.mm', '.swift', '.rs', 'java'] + FORTRAN_SUFFIXES):
+            if f.suffix in (['.c', '.cc', '.cpp', '.cs', '.cu', '.d', '.m', '.mm', '.swift', '.rs', '.java'] + FORTRAN_SUFFIXES):
                 srcfiles.append(f)
         if not srcfiles:
             raise SystemExit('No recognizable source files found.\n'
@@ -163,6 +171,9 @@ def autodetect_options(options, sample: bool = False):
                 break
             if f.suffix in ('.cc', '.cpp'):
                 options.language = 'cpp'
+                break
+            if f.suffix in '.cs':
+                options.language = 'cs'
                 break
             if f.suffix == '.cu':
                 options.language = 'cuda'
@@ -197,12 +208,11 @@ def add_arguments(parser):
     Here we add args for that the user can passed when making a new
     Meson project.
     '''
-    parser.add_argument("srcfiles", metavar="sourcefile", nargs="*",
-                        help="source files. default: all recognized files in current directory")
+    parser.add_argument("srcfiles", metavar="sourcefile", nargs="*", help="source files. default: all recognized files in current directory")
     parser.add_argument("-n", "--name", help="project name. default: name of current directory")
     parser.add_argument("-e", "--executable", help="executable name. default: project name")
     parser.add_argument("-d", "--deps", help="dependencies, comma-separated")
-    parser.add_argument("-l", "--language", choices=['c', 'cpp', 'cuda', 'd', 'fortran', 'java', 'rust', 'objc', 'objcpp', 'swift'],
+    parser.add_argument("-l", "--language", choices=['c', 'cpp', 'cs', 'cuda', 'd', 'fortran', 'java', 'rust', 'objc', 'objcpp', 'swift'],
                         help="project language. default: autodetected based on source files")
     parser.add_argument("-b", "--build", help="build after generation", action='store_true')
     parser.add_argument("--builddir", help="directory for build", default='build')

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -22,7 +22,7 @@ from mesonbuild.environment import detect_ninja
 
 from mesonbuild.templates.ctemplates import (create_exe_c_sample, create_lib_c_sample)
 from mesonbuild.templates.cpptemplates import (create_exe_cpp_sample, create_lib_cpp_sample)
-from mesonbuild.templates.cstemplates import (create_exe_cs_sample, create_lib_cs_sample)
+from mesonbuild.templates.cudatemplates import (create_exe_cuda_sample, create_lib_cuda_sample)
 from mesonbuild.templates.objctemplates import (create_exe_objc_sample, create_lib_objc_sample)
 from mesonbuild.templates.objcpptemplates import (create_exe_objcpp_sample, create_lib_objcpp_sample)
 from mesonbuild.templates.swifttemplates import (create_exe_swift_sample, create_lib_swift_sample)
@@ -66,11 +66,11 @@ def create_sample(options):
             create_lib_cpp_sample(options.name, options.version)
         else:
             raise RuntimeError(UNREACHABLE_CODE)
-    elif options.language == 'cs':
+    elif options.language == 'cuda':
         if options.type == 'executable':
-            create_exe_cs_sample(options.name, options.version)
+            create_exe_cuda_sample(options.name, options.version)
         elif options.type == 'library':
-            create_lib_cs_sample(options.name, options.version)
+            create_lib_cuda_sample(options.name, options.version)
         else:
             raise RuntimeError(UNREACHABLE_CODE)
     elif options.language == 'd':
@@ -148,7 +148,7 @@ def autodetect_options(options, sample: bool = False):
     if not options.srcfiles:
         srcfiles = []
         for f in (f for f in Path().iterdir() if f.is_file()):
-            if f.suffix in (['.cc', '.cpp', '.c', 'cs', '.d', '.m', '.mm', '.swift', '.rs', 'java'] + FORTRAN_SUFFIXES):
+            if f.suffix in (['.cc', '.cpp', '.cu', 'cs', '.d', '.m', '.mm', '.swift', '.rs', 'java'] + FORTRAN_SUFFIXES):
                 srcfiles.append(f)
         if not srcfiles:
             raise SystemExit('No recognizable source files found.\n'
@@ -164,8 +164,8 @@ def autodetect_options(options, sample: bool = False):
             if f.suffix in ('.cc', '.cpp'):
                 options.language = 'cpp'
                 break
-            if f.suffix == '.cs':
-                options.language = 'cs'
+            if f.suffix == '.cu':
+                options.language = 'cuda'
                 break
             if f.suffix == '.d':
                 options.language = 'd'
@@ -202,7 +202,7 @@ def add_arguments(parser):
     parser.add_argument("-n", "--name", help="project name. default: name of current directory")
     parser.add_argument("-e", "--executable", help="executable name. default: project name")
     parser.add_argument("-d", "--deps", help="dependencies, comma-separated")
-    parser.add_argument("-l", "--language", choices=['c', 'cpp', 'cs', 'd', 'fortran', 'java', 'rust', 'objc', 'objcpp', 'swift'],
+    parser.add_argument("-l", "--language", choices=['c', 'cpp', 'cuda', 'd', 'fortran', 'java', 'rust', 'objc', 'objcpp', 'swift'],
                         help="project language. default: autodetected based on source files")
     parser.add_argument("-b", "--build", help="build after generation", action='store_true')
     parser.add_argument("--builddir", help="directory for build", default='build')

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -148,7 +148,7 @@ def autodetect_options(options, sample: bool = False):
     if not options.srcfiles:
         srcfiles = []
         for f in (f for f in Path().iterdir() if f.is_file()):
-            if f.suffix in (['.cc', '.cpp', '.cu', 'cs', '.d', '.m', '.mm', '.swift', '.rs', 'java'] + FORTRAN_SUFFIXES):
+            if f.suffix in (['.c', '.cc', '.cpp', '.cu', '.d', '.m', '.mm', '.swift', '.rs', 'java'] + FORTRAN_SUFFIXES):
                 srcfiles.append(f)
         if not srcfiles:
             raise SystemExit('No recognizable source files found.\n'

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -206,8 +206,8 @@ def add_arguments(parser):
     parser.add_argument("-b", "--build", help="build after generation", action='store_true')
     parser.add_argument("--builddir", help="directory for build", default='build')
     parser.add_argument("-f", "--force", action="store_true", help="force overwrite of existing files and directories.")
-    parser.add_argument('--type', default='executable', choices=['executable', 'library'])
-    parser.add_argument('--version', default='0.1')
+    parser.add_argument('--type', default='executable', choices=['executable', 'library'], help="project type. default: executable based project")
+    parser.add_argument('--version', default='0.1', help="project version. default: 0.1")
 
 def run(options) -> int:
     '''

--- a/mesonbuild/templates/cstemplates.py
+++ b/mesonbuild/templates/cstemplates.py
@@ -20,8 +20,8 @@ public class {class_name} {{
     const String PROJECT_NAME = "{project_name}";
 
     static int Main(String[] args) {{
-      if (args.Length == 0) {{
-          System.Console.WriteLine(String.Format("{{0}} takes no arguments..", args[0]));
+      if (args.Length > 0) {{
+          System.Console.WriteLine(String.Format("{project_name} takes no arguments.."));
           return 1;
       }}
       Console.WriteLine(String.Format("This is project {{0}}.", PROJECT_NAME));
@@ -56,8 +56,8 @@ lib_cs_test_template = '''using System;
 
 public class {class_test} {{
     static int Main(String[] args) {{
-      if (args.Length == 0) {{
-          System.Console.WriteLine(String.Format("{{0}} takes no arguments..", args[0]));
+      if (args.Length > 0) {{
+          System.Console.WriteLine("{project_name} takes no arguments..");
           return 1;
       }}
       {class_name} c = new {class_name}();
@@ -72,7 +72,7 @@ lib_cs_meson_template = '''project('{project_name}', 'cs',
   version : '{version}',
   default_options : ['warning_level=3'])
 
-stlib = shared_library('{class_name}', '{source_file}',
+stlib = shared_library('{lib_name}', '{source_file}',
   install : true,
 )
 
@@ -96,7 +96,7 @@ def create_exe_cs_sample(project_name, project_version):
     open(source_name, 'w').write(hello_cs_template.format(project_name=project_name,
                                                           class_name=class_name))
     open('meson.build', 'w').write(hello_cs_meson_template.format(project_name=project_name,
-                                                                  exe_name=class_name,
+                                                                  exe_name=project_name,
                                                                   source_name=source_name,
                                                                   version=project_version))
 
@@ -106,6 +106,7 @@ def create_lib_cs_sample(project_name, version):
     uppercase_token = lowercase_token.upper()
     class_name = uppercase_token[0] + lowercase_token[1:]
     class_test = uppercase_token[0] + lowercase_token[1:] + '_test'
+    project_test = lowercase_token + '_test'
     lib_cs_name = uppercase_token[0] + lowercase_token[1:] + '.cs'
     test_cs_name = uppercase_token[0] + lowercase_token[1:] + '_test.cs'
     kwargs = {'utoken': uppercase_token,
@@ -114,7 +115,7 @@ def create_lib_cs_sample(project_name, version):
               'class_name': class_name,
               'source_file': lib_cs_name,
               'test_source_file': test_cs_name,
-              'test_exe_name': lowercase_token,
+              'test_exe_name': project_test,
               'project_name': project_name,
               'lib_name': lowercase_token,
               'test_name': lowercase_token,

--- a/mesonbuild/templates/cstemplates.py
+++ b/mesonbuild/templates/cstemplates.py
@@ -1,0 +1,125 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+
+hello_cs_template = '''using System;
+
+public class {class_name} {{
+    const String PROJECT_NAME = "{project_name}";
+
+    static int Main(String[] args) {{
+      if (args.Length == 0) {{
+          System.Console.WriteLine(String.Format("{{0}} takes no arguments..", args[0]));
+          return 1;
+      }}
+      Console.WriteLine(String.Format("This is project {{0}}.", PROJECT_NAME));
+      return 0;
+    }}
+}}
+
+'''
+
+hello_cs_meson_template = '''project('{project_name}', 'cs',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+exe = executable('{exe_name}', '{source_name}',
+  install : true)
+
+test('basic', exe)
+'''
+
+lib_cs_template = '''
+public class {class_name} {{
+    private const int number = 6;
+
+    public int get_number() {{
+      return number;
+    }}
+}}
+
+'''
+
+lib_cs_test_template = '''using System;
+
+public class {class_test} {{
+    static int Main(String[] args) {{
+      if (args.Length == 0) {{
+          System.Console.WriteLine(String.Format("{{0}} takes no arguments..", args[0]));
+          return 1;
+      }}
+      {class_name} c = new {class_name}();
+      Boolean result = true;
+      return result.CompareTo(c.get_number() != 6);
+    }}
+}}
+
+'''
+
+lib_cs_meson_template = '''project('{project_name}', 'cs',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+stlib = shared_library('{class_name}', '{source_file}',
+  install : true,
+)
+
+test_exe = executable('{test_exe_name}', '{test_source_file}',
+  link_with : stlib)
+test('{test_name}', test_exe)
+
+# Make this library usable as a Meson subproject.
+{ltoken}_dep = declare_dependency(
+  include_directories: include_directories('.'),
+  link_with : stlib)
+
+'''
+
+
+def create_exe_cs_sample(project_name, project_version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    uppercase_token = lowercase_token.upper()
+    class_name = uppercase_token[0] + lowercase_token[1:]
+    source_name = uppercase_token[0] + lowercase_token[1:] + '.cs'
+    open(source_name, 'w').write(hello_cs_template.format(project_name=project_name,
+                                                          class_name=class_name))
+    open('meson.build', 'w').write(hello_cs_meson_template.format(project_name=project_name,
+                                                                  exe_name=class_name,
+                                                                  source_name=source_name,
+                                                                  version=project_version))
+
+
+def create_lib_cs_sample(project_name, version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    uppercase_token = lowercase_token.upper()
+    class_name = uppercase_token[0] + lowercase_token[1:]
+    class_test = uppercase_token[0] + lowercase_token[1:] + '_test'
+    lib_cs_name = uppercase_token[0] + lowercase_token[1:] + '.cs'
+    test_cs_name = uppercase_token[0] + lowercase_token[1:] + '_test.cs'
+    kwargs = {'utoken': uppercase_token,
+              'ltoken': lowercase_token,
+              'class_test': class_test,
+              'class_name': class_name,
+              'source_file': lib_cs_name,
+              'test_source_file': test_cs_name,
+              'test_exe_name': lowercase_token,
+              'project_name': project_name,
+              'lib_name': lowercase_token,
+              'test_name': lowercase_token,
+              'version': version,
+              }
+    open(lib_cs_name, 'w').write(lib_cs_template.format(**kwargs))
+    open(test_cs_name, 'w').write(lib_cs_test_template.format(**kwargs))
+    open('meson.build', 'w').write(lib_cs_meson_template.format(**kwargs))

--- a/mesonbuild/templates/cudatemplates.py
+++ b/mesonbuild/templates/cudatemplates.py
@@ -1,0 +1,177 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+
+hello_cuda_template = '''#include <iostream>
+
+#define PROJECT_NAME "{project_name}"
+
+int main(int argc, char **argv) {{
+    if(argc != 1) {{
+        std::cout << argv[0] <<  "takes no arguments.\\n";
+        return 1;
+    }}
+    std::cout << "This is project " << PROJECT_NAME << ".\\n";
+    return 0;
+}}
+'''
+
+hello_cuda_meson_template = '''project('{project_name}', 'cpp',
+  version : '{version}',
+  default_options : ['warning_level=3',
+                     'cpp_std=c++14'])
+
+exe = executable('{exe_name}', '{source_name}',
+  install : true)
+
+test('basic', exe)
+'''
+
+lib_h_template = '''#pragma once
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef BUILDING_{utoken}
+    #define {utoken}_PUBLIC __declspec(dllexport)
+  #else
+    #define {utoken}_PUBLIC __declspec(dllimport)
+  #endif
+#else
+  #ifdef BUILDING_{utoken}
+      #define {utoken}_PUBLIC __attribute__ ((visibility ("default")))
+  #else
+      #define {utoken}_PUBLIC
+  #endif
+#endif
+
+namespace {namespace} {{
+
+class {utoken}_PUBLIC {class_name} {{
+
+public:
+  {class_name}();
+  int get_number() const;
+
+private:
+
+  int number;
+
+}};
+
+}}
+
+'''
+
+lib_cuda_template = '''#include <{header_file}>
+
+namespace {namespace} {{
+
+{class_name}::{class_name}() {{
+    number = 6;
+}}
+
+int {class_name}::get_number() const {{
+  return number;
+}}
+
+}}
+'''
+
+lib_cuda_test_template = '''#include <{header_file}>
+#include <iostream>
+
+int main(int argc, char **argv) {{
+    if(argc != 1) {{
+        std::cout << argv[0] << " takes no arguments.\\n";
+        return 1;
+    }}
+    {namespace}::{class_name} c;
+    return c.get_number() != 6;
+}}
+'''
+
+lib_cuda_meson_template = '''project('{project_name}', 'cuda',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+# These arguments are only used to build the shared library
+# not the executables that use the library.
+lib_args = ['-DBUILDING_{utoken}']
+
+shlib = shared_library('{lib_name}', '{source_file}',
+  install : true,
+  cpp_args : lib_args,
+  gnu_symbol_visibility : 'hidden',
+)
+
+test_exe = executable('{test_exe_name}', '{test_source_file}',
+  link_with : shlib)
+test('{test_name}', test_exe)
+
+# Make this library usable as a Meson subproject.
+{ltoken}_dep = declare_dependency(
+  include_directories: include_directories('.'),
+  link_with : shlib)
+
+# Make this library usable from the system's
+# package manager.
+install_headers('{header_file}', subdir : '{header_dir}')
+
+pkg_mod = import('pkgconfig')
+pkg_mod.generate(
+  name : '{project_name}',
+  filebase : '{ltoken}',
+  description : 'Meson sample project.',
+  subdirs : '{header_dir}',
+  libraries : shlib,
+  version : '{version}',
+)
+'''
+
+
+def create_exe_cuda_sample(project_name, project_version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    source_name = lowercase_token + '.cu'
+    open(source_name, 'w').write(hello_cuda_template.format(project_name=project_name))
+    open('meson.build', 'w').write(hello_cuda_meson_template.format(project_name=project_name,
+                                                                    exe_name=lowercase_token,
+                                                                    source_name=source_name,
+                                                                    version=project_version))
+
+
+def create_lib_cuda_sample(project_name, version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    uppercase_token = lowercase_token.upper()
+    class_name = uppercase_token[0] + lowercase_token[1:]
+    namespace = lowercase_token
+    lib_h_name = lowercase_token + '.h'
+    lib_cuda_name = lowercase_token + '.cu'
+    test_cuda_name = lowercase_token + '_test.cu'
+    kwargs = {'utoken': uppercase_token,
+              'ltoken': lowercase_token,
+              'header_dir': lowercase_token,
+              'class_name': class_name,
+              'namespace': namespace,
+              'header_file': lib_h_name,
+              'source_file': lib_cuda_name,
+              'test_source_file': test_cuda_name,
+              'test_exe_name': lowercase_token,
+              'project_name': project_name,
+              'lib_name': lowercase_token,
+              'test_name': lowercase_token,
+              'version': version,
+              }
+    open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
+    open(lib_cuda_name, 'w').write(lib_cuda_template.format(**kwargs))
+    open(test_cuda_name, 'w').write(lib_cuda_test_template.format(**kwargs))
+    open('meson.build', 'w').write(lib_cuda_meson_template.format(**kwargs))

--- a/mesonbuild/templates/javatemplates.py
+++ b/mesonbuild/templates/javatemplates.py
@@ -1,0 +1,129 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+
+hello_java_template = '''
+
+public class {class_name} {{
+    final static String PROJECT_NAME = "{project_name}";
+
+    public static void main (String args[]) {{
+        if(args.length != 0) {{
+            System.out.println(args + " takes no arguments.");
+            System.exit(0);
+        }}
+        System.out.println("This is project " + PROJECT_NAME + ".");
+        System.exit(0);
+    }}
+}}
+
+'''
+
+hello_java_meson_template = '''project('{project_name}', 'java',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+exe = jar('{exe_name}', '{source_name}',
+  main_class : '{exe_name}',
+  install : true)
+
+test('basic', exe)
+'''
+
+lib_java_template = '''
+
+public class {class_name} {{
+    final static int number = 6;
+
+    public final int get_number() {{
+      return number;
+    }}
+}}
+
+'''
+
+lib_java_test_template = '''
+
+public class {class_test} {{
+    public static void main (String args[]) {{
+        if(args.length != 0) {{
+            System.out.println(args + " takes no arguments.");
+            System.exit(1);
+        }}
+
+        {class_name} c = new {class_name}();
+        Boolean result = true;
+        System.exit(result.compareTo(c.get_number() != 6));
+    }}
+}}
+
+'''
+
+lib_java_meson_template = '''project('{project_name}', 'java',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+jarlib = jar('{class_name}', '{source_file}',
+  main_class : '{class_name}',
+  install : true,
+)
+
+test_jar = jar('{class_test}', '{test_source_file}',
+  main_class : '{class_test}',
+  link_with : jarlib)
+test('{test_name}', test_jar)
+
+# Make this library usable as a Meson subproject.
+{ltoken}_dep = declare_dependency(
+  include_directories: include_directories('.'),
+  link_with : jarlib)
+'''
+
+
+def create_exe_java_sample(project_name, project_version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    uppercase_token = lowercase_token.upper()
+    class_name = uppercase_token[0] + lowercase_token[1:]
+    source_name = uppercase_token[0] + lowercase_token[1:] + '.java'
+    open(source_name, 'w').write(hello_java_template.format(project_name=project_name,
+                                                            class_name=class_name))
+    open('meson.build', 'w').write(hello_java_meson_template.format(project_name=project_name,
+                                                                    exe_name=class_name,
+                                                                    source_name=source_name,
+                                                                    version=project_version))
+
+
+def create_lib_java_sample(project_name, version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    uppercase_token = lowercase_token.upper()
+    class_name = uppercase_token[0] + lowercase_token[1:]
+    class_test = uppercase_token[0] + lowercase_token[1:] + '_test'
+    lib_java_name = uppercase_token[0] + lowercase_token[1:] + '.java'
+    test_java_name = uppercase_token[0] + lowercase_token[1:] + '_test.java'
+    kwargs = {'utoken': uppercase_token,
+              'ltoken': lowercase_token,
+              'class_test': class_test,
+              'class_name': class_name,
+              'source_file': lib_java_name,
+              'test_source_file': test_java_name,
+              'test_exe_name': lowercase_token,
+              'project_name': project_name,
+              'lib_name': lowercase_token,
+              'test_name': lowercase_token,
+              'version': version,
+              }
+    open(lib_java_name, 'w').write(lib_java_template.format(**kwargs))
+    open(test_java_name, 'w').write(lib_java_test_template.format(**kwargs))
+    open('meson.build', 'w').write(lib_java_meson_template.format(**kwargs))

--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -1,0 +1,51 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+meson_executable_template = '''project('{project_name}', '{language}',
+  version : '{version}',
+  default_options : [{default_options}])
+
+executable('{executable}',
+           {sourcespec},{depspec}
+           install : true)
+'''
+
+def create_meson_build(options):
+    if options.type != 'executable':
+        raise SystemExit('\nGenerating a meson.build file from existing sources is\n'
+                         'supported only for project type "executable".\n'
+                         'Run meson init in an empty directory to create a sample project.')
+    default_options = ['warning_level=3']
+    if options.language == 'cpp':
+        # This shows how to set this very common option.
+        default_options += ['cpp_std=c++14']
+    # If we get a meson.build autoformatter one day, this code could
+    # be simplified quite a bit.
+    formatted_default_options = ', '.join("'{}'".format(x) for x in default_options)
+    sourcespec = ',\n           '.join("'{}'".format(x) for x in options.srcfiles)
+    depspec = ''
+    if options.deps:
+        depspec = '\n           dependencies : [\n              '
+        depspec += ',\n              '.join("dependency('{}')".format(x)
+                                            for x in options.deps.split(','))
+        depspec += '],'
+    content = meson_executable_template.format(project_name=options.name,
+                                               language=options.language,
+                                               version=options.version,
+                                               executable=options.executable,
+                                               sourcespec=sourcespec,
+                                               depspec=depspec,
+                                               default_options=formatted_default_options)
+    open('meson.build', 'w').write(content)
+    print('Generated meson.build file:\n\n' + content)

--- a/mesonbuild/templates/objcpptemplates.py
+++ b/mesonbuild/templates/objcpptemplates.py
@@ -1,0 +1,156 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+
+lib_h_template = '''#pragma once
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef BUILDING_{utoken}
+    #define {utoken}_PUBLIC __declspec(dllexport)
+  #else
+    #define {utoken}_PUBLIC __declspec(dllimport)
+  #endif
+#else
+  #ifdef BUILDING_{utoken}
+      #define {utoken}_PUBLIC __attribute__ ((visibility ("default")))
+  #else
+      #define {utoken}_PUBLIC
+  #endif
+#endif
+
+int {utoken}_PUBLIC {function_name}();
+
+'''
+
+lib_objcpp_template = '''#import <{header_file}>
+
+/* This function will not be exported and is not
+ * directly callable by users of this library.
+ */
+int internal_function() {{
+    return 0;
+}}
+
+int {function_name}() {{
+    return internal_function();
+}}
+'''
+
+lib_objcpp_test_template = '''#import <{header_file}>
+#import <iostream>
+
+int main(int argc, char **argv) {{
+    if(argc != 1) {{
+        std::cout << argv[0] << " takes no arguments." << std::endl;
+        return 1;
+    }}
+    return {function_name}();
+}}
+'''
+
+lib_objcpp_meson_template = '''project('{project_name}', 'objcpp',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+# These arguments are only used to build the shared library
+# not the executables that use the library.
+lib_args = ['-DBUILDING_{utoken}']
+
+shlib = shared_library('{lib_name}', '{source_file}',
+  install : true,
+  objcpp_args : lib_args,
+  gnu_symbol_visibility : 'hidden',
+)
+
+test_exe = executable('{test_exe_name}', '{test_source_file}',
+  link_with : shlib)
+test('{test_name}', test_exe)
+
+# Make this library usable as a Meson subproject.
+{ltoken}_dep = declare_dependency(
+  include_directories: include_directories('.'),
+  link_with : shlib)
+
+# Make this library usable from the system's
+# package manager.
+install_headers('{header_file}', subdir : '{header_dir}')
+
+pkg_mod = import('pkgconfig')
+pkg_mod.generate(
+  name : '{project_name}',
+  filebase : '{ltoken}',
+  description : 'Meson sample project.',
+  subdirs : '{header_dir}',
+  libraries : shlib,
+  version : '{version}',
+)
+'''
+
+hello_objcpp_template = '''#import <iostream>
+
+#define PROJECT_NAME "{project_name}"
+
+int main(int argc, char **argv) {{
+    if(argc != 1) {{
+        std::cout << argv[0] << " takes no arguments." << std::endl;
+        return 1;
+    }}
+    std::cout << "This is project " << PROJECT_NAME << "." << std::endl;
+    return 0;
+}}
+'''
+
+hello_objcpp_meson_template = '''project('{project_name}', 'objcpp',
+  version : '{version}',
+  default_options : ['warning_level=3'])
+
+exe = executable('{exe_name}', '{source_name}',
+  install : true)
+
+test('basic', exe)
+'''
+
+def create_exe_objcpp_sample(project_name, project_version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    source_name = lowercase_token + '.mm'
+    open(source_name, 'w').write(hello_objcpp_template.format(project_name=project_name))
+    open('meson.build', 'w').write(hello_objcpp_meson_template.format(project_name=project_name,
+                                                                      exe_name=lowercase_token,
+                                                                      source_name=source_name,
+                                                                      version=project_version))
+
+def create_lib_objcpp_sample(project_name, version):
+    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
+    uppercase_token = lowercase_token.upper()
+    function_name = lowercase_token[0:3] + '_func'
+    lib_h_name = lowercase_token + '.h'
+    lib_objcpp_name = lowercase_token + '.mm'
+    test_objcpp_name = lowercase_token + '_test.mm'
+    kwargs = {'utoken': uppercase_token,
+              'ltoken': lowercase_token,
+              'header_dir': lowercase_token,
+              'function_name': function_name,
+              'header_file': lib_h_name,
+              'source_file': lib_objcpp_name,
+              'test_source_file': test_objcpp_name,
+              'test_exe_name': lowercase_token,
+              'project_name': project_name,
+              'lib_name': lowercase_token,
+              'test_name': lowercase_token,
+              'version': version,
+              }
+    open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
+    open(lib_objcpp_name, 'w').write(lib_objcpp_template.format(**kwargs))
+    open(test_objcpp_name, 'w').write(lib_objcpp_test_template.format(**kwargs))
+    open('meson.build', 'w').write(lib_objcpp_meson_template.format(**kwargs))

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3081,8 +3081,23 @@ int main(int argc, char **argv) {
         except EnvironmentException:
             pass
         try:
+            env.detect_cs_compiler(MachineChoice.HOST)
+            langs.append('cs')
+        except EnvironmentException:
+            pass
+        try:
             env.detect_d_compiler(MachineChoice.HOST)
             langs.append('d')
+        except EnvironmentException:
+            pass
+        try:
+            env.detect_java_compiler(MachineChoice.HOST)
+            langs.append('java')
+        except EnvironmentException:
+            pass
+        try:
+            env.detect_cuda_compiler(MachineChoice.HOST)
+            langs.append('cuda')
         except EnvironmentException:
             pass
         try:
@@ -3093,6 +3108,11 @@ int main(int argc, char **argv) {
         try:
             env.detect_objc_compiler(MachineChoice.HOST)
             langs.append('objc')
+        except EnvironmentException:
+            pass
+        try:
+            env.detect_objcpp_compiler(MachineChoice.HOST)
+            langs.append('objcpp')
         except EnvironmentException:
             pass
         # FIXME: omitting rust as Windows AppVeyor CI finds Rust but doesn't link correctly


### PR DESCRIPTION
I have produced new templates for Meson build systems existing project template library. I also added a feature note, remembered to update test_templates, moved Meson specific generator into its template file and added docstrings in `minit.py`.  The programming languages I selected `java`, `Objective-C++`,  `C#`, and `Cuda`.

At some point, I will produce a final batch of templates for what I consider to be the hardest programming languages to write template definitions for, `Vala`, and  `Swift`.