### PR TITLE
Always disable interpolation for ini parsers.

### DIFF
--- a/ghwt.py
+++ b/ghwt.py
@@ -43,7 +43,7 @@ def unpack(sproj, branch, outdir):
     subprocess.check_call(['git', 'clone', '-b', branch, 'https://github.com/mesonbuild/{}.git'.format(sproj), outdir])
     usfile = os.path.join(outdir, 'upstream.wrap')
     assert(os.path.isfile(usfile))
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
     config.read(usfile)
     us_url = config['wrap-file']['source_url']
     us = urllib.request.urlopen(us_url, timeout=req_timeout).read()

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -228,7 +228,7 @@ class UserFeatureOption(UserComboOption):
 
 def load_configs(filenames: T.List[str]) -> configparser.ConfigParser:
     """Load configuration files from a named subdirectory."""
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
     config.read(filenames)
     return config
 

--- a/mesonbuild/wrap/wraptool.py
+++ b/mesonbuild/wrap/wraptool.py
@@ -105,7 +105,7 @@ def parse_patch_url(patch_url):
     return arr[-3], int(arr[-2])
 
 def get_current_version(wrapfile):
-    cp = configparser.ConfigParser()
+    cp = configparser.ConfigParser(interpolation=None)
     cp.read(wrapfile)
     cp = cp['wrap-file']
     patch_url = cp['patch_url']


### PR DESCRIPTION
This is what the conceptual model we have always stated for "ini" files, so let's be explicit. The only breakage potential ties to #6517 but as trying to use interpolation does not currently work because of the quotes, this should not break anything that is not already broken.