### PR TITLE
Fix Renesas Compiler

### DIFF
--- a/cross/ccrx.txt
+++ b/cross/ccrx.txt
@@ -10,11 +10,13 @@ strip = 'rlink'
 [properties]
 # The '--cpu' option with the appropriate target type should be mentioned
 # to cross compile c/c++ code with ccrx,.
-c_args      = ['--cpu=rx600']
-cpp_args    = ['--cpu=rx600']
+c_args      = ['-cpu=rx600']
+cpp_args    = ['-cpu=rx600']
+c_link_args = []
+cpp_link_args = []
 
 [host_machine]
-system = 'bare metal'      # Update with your system name - bare metal/OS.
+system = 'bare metal'
 cpu_family = 'rx'
 cpu = 'rx600'
 endian = 'little'

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -390,6 +390,9 @@ class CcrxCCompiler(CcrxCompiler, CCompiler):
                                                        'none')})
         return opts
 
+    def get_no_stdinc_args(self):
+        return []
+
     def get_option_compile_args(self, options):
         args = []
         std = options['c_std']

--- a/mesonbuild/compilers/mixins/arm.py
+++ b/mesonbuild/compilers/mixins/arm.py
@@ -157,7 +157,7 @@ class ArmclangCompiler:
         self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage',
                              'b_ndebug', 'b_staticpic', 'b_colorout']
         # Assembly
-        self.can_compile_suffixes.update('s')
+        self.can_compile_suffixes.add('s')
 
     def get_pic_args(self) -> T.List[str]:
         # PIC support is not enabled by default for ARM,

--- a/mesonbuild/compilers/mixins/ccrx.py
+++ b/mesonbuild/compilers/mixins/ccrx.py
@@ -52,7 +52,7 @@ class CcrxCompiler:
             raise EnvironmentException('ccrx supports only cross-compilation.')
         self.id = 'ccrx'
         # Assembly
-        self.can_compile_suffixes.update('s')
+        self.can_compile_suffixes.add('src')
         default_warn_args = []  # type: T.List[str]
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -81,6 +81,12 @@ class CcrxCompiler:
         return []
 
     def get_coverage_args(self) -> T.List[str]:
+        return []
+
+    def get_no_stdinc_args(self) -> T.List[str]:
+        return []
+
+    def get_no_stdlib_link_args(self) -> T.List[str]:
         return []
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -668,7 +668,7 @@ class CcrxDynamicLinker(DynamicLinker):
 
     def __init__(self, for_machine: mesonlib.MachineChoice,
                  *, version: str = 'unknown version'):
-        super().__init__(['rlink.exe'], for_machine, 'rlink', '',
+        super().__init__(['rlink.exe'], for_machine, 'rlink', '', [],
                          version=version)
 
     def get_accepts_rsp(self) -> bool:
@@ -768,6 +768,7 @@ class PGIStaticLinker(StaticLinker):
 
     def get_output_args(self, target: str) -> T.List[str]:
         return [target]
+
 
 class VisualStudioLikeLinkerMixin:
 


### PR DESCRIPTION
Fixed Renesas RX Family compiler to work with latest meson, updated cross-file, fixed assembly file use