### PR TITLE
Refactor CI cross-testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ matrix:
   # Test cross builds separately, they do not use the global compiler
   - os: linux
     compiler: gcc
-    env: RUN_TESTS_ARGS="--cross"
+    env: RUN_TESTS_ARGS="--cross ubuntu-armhf.txt --cross linux-mingw-w64-64bit.txt"
   - os: linux
     compiler: gcc
-    env: RUN_TESTS_ARGS="--cross" MESON_ARGS="--unity=on"
+    env: RUN_TESTS_ARGS="--cross ubuntu-armhf.txt --cross linux-mingw-w64-64bit.txt" MESON_ARGS="--unity=on"
 
 before_install:
   - python ./skip_ci.py --base-branch-env=TRAVIS_BRANCH --is-pull-env=TRAVIS_PULL_REQUEST

--- a/run_cross_test.py
+++ b/run_cross_test.py
@@ -15,43 +15,25 @@
 # limitations under the License.
 
 '''Runs the basic test suite through a cross compiler.
-Not part of the main test suite because of two reasons:
 
-1) setup of the cross build is platform specific
-2) it can be slow (e.g. when invoking test apps via wine)
+This is now just a wrapper around run_project_tests.py with specific arguments
+'''
 
-Eventually migrate to something fancier.'''
-
-import sys
-import os
-from pathlib import Path
 import argparse
-
-from run_project_tests import gather_tests, run_tests, StopException, setup_commands
-from run_project_tests import failing_logs
+import subprocess
+import sys
+from mesonbuild import mesonlib
 
 def runtests(cross_file, failfast):
-    commontests = [('common', gather_tests(Path('test cases', 'common')), False)]
-    try:
-        (passing_tests, failing_tests, skipped_tests) = \
-            run_tests(commontests, 'meson-cross-test-run', failfast, ['--cross-file', cross_file])
-    except StopException:
-        pass
-    print('\nTotal passed cross tests:', passing_tests)
-    print('Total failed cross tests:', failing_tests)
-    print('Total skipped cross tests:', skipped_tests)
-    if failing_tests > 0 and ('CI' in os.environ):
-        print('\nMesonlogs of failing tests\n')
-        for log in failing_logs:
-            print(log, '\n')
-    return failing_tests
+    tests = ['--only', 'common']
+    cmd = mesonlib.python_command + ['run_project_tests.py', '--backend', 'ninja'] + (['--failfast'] if failfast else []) + tests + ['--cross-file', cross_file]
+    return subprocess.call(cmd)
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--failfast', action='store_true')
     parser.add_argument('cross_file')
     options = parser.parse_args()
-    setup_commands('ninja')
     return runtests(options.cross_file, options.failfast)
 
 if __name__ == '__main__':

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -867,13 +867,13 @@ def check_format():
                     continue
                 check_file(root / file)
 
-def check_meson_commands_work():
+def check_meson_commands_work(options):
     global backend, compile_commands, test_commands, install_commands
     testdir = PurePath('test cases', 'common', '1 trivial').as_posix()
     meson_commands = mesonlib.python_command + [get_meson_script()]
     with AutoDeletedDir(tempfile.mkdtemp(prefix='b ', dir='.')) as build_dir:
         print('Checking that configuring works...')
-        gen_cmd = meson_commands + [testdir, build_dir] + backend_flags
+        gen_cmd = meson_commands + [testdir, build_dir] + backend_flags + options.extra_args
         pc, o, e = Popen_safe(gen_cmd)
         if pc.returncode != 0:
             raise RuntimeError('Failed to configure {!r}:\n{}\n{}'.format(testdir, e, o))
@@ -893,11 +893,14 @@ def check_meson_commands_work():
                 raise RuntimeError('Failed to install {!r}:\n{}\n{}'.format(testdir, e, o))
 
 
-def detect_system_compiler():
+def detect_system_compiler(options):
     global system_compiler
 
     with AutoDeletedDir(tempfile.mkdtemp(prefix='b ', dir='.')) as build_dir:
-        env = environment.Environment(None, build_dir, get_fake_options('/'))
+        fake_opts = get_fake_options('/')
+        if options.cross_file:
+            fake_opts.cross_file = [options.cross_file]
+        env = environment.Environment(None, build_dir, fake_opts)
         print()
         for lang in sorted(compilers.all_languages):
             try:
@@ -958,16 +961,19 @@ if __name__ == '__main__':
     parser.add_argument('--no-unittests', action='store_true',
                         help='Not used, only here to simplify run_tests.py')
     parser.add_argument('--only', help='name of test(s) to run', nargs='+', choices=ALL_TESTS)
+    parser.add_argument('--cross-file', action='store', help='File describing cross compilation environment.')
     options = parser.parse_args()
-    setup_commands(options.backend)
+    if options.cross_file:
+        options.extra_args += ['--cross-file', options.cross_file]
 
-    detect_system_compiler()
+    setup_commands(options.backend)
+    detect_system_compiler(options)
     print_tool_versions()
     script_dir = os.path.split(__file__)[0]
     if script_dir != '':
         os.chdir(script_dir)
     check_format()
-    check_meson_commands_work()
+    check_meson_commands_work(options)
     try:
         all_tests = detect_tests_to_run(options.only)
         (passing_tests, failing_tests, skipped_tests) = run_tests(all_tests, 'meson-test-run', options.failfast, options.extra_args)


### PR DESCRIPTION
Refactor and simplify cross-testing in CI:

* Make the crossfile selection part of the CI job configuration (so we can more easily add more CI jobs for different cross-toolchains)
* Make the `platform_fix_name()`  machinery for toolchains which don't have gcc-like filename conventions also apply to cross-toolchain testing