### PR TITLE
ghwt: allow user to specify branch

### DIFF
--- a/docs/markdown/fallback-wraptool.md
+++ b/docs/markdown/fallback-wraptool.md
@@ -17,10 +17,14 @@ To list all available wraps:
 To install a wrap, go to your source root, make sure that the
 `subprojects` directory exists and run this command:
 
-    ghwt.py install <projectname>
+    ghwt.py install <projectname> [<branchname>]
 
 This will stage the subproject ready to use. If you have multiple
 subprojects you need to download them all manually.
+
+Specifying branch name is optional. If not specified, the list
+of potential branches is sorted alphabetically and the last branch is 
+used.
 
 *Note* The tool was added in 0.32.0, for versions older than that you
 need to delete the `foo.wrap` file to work around this issue.

--- a/ghwt.py
+++ b/ghwt.py
@@ -53,8 +53,8 @@ def unpack(sproj, branch, outdir):
     should = config['wrap-file']['source_hash']
     if dig != should:
         print('Incorrect hash on download.')
-        print(' expected:', dig)
-        print(' obtained:', should)
+        print(' expected:', should)
+        print(' obtained:', dig)
         return 1
     spdir = os.path.dirname(outdir)
     ofilename = os.path.join(spdir, config['wrap-file']['source_filename'])

--- a/ghwt.py
+++ b/ghwt.py
@@ -81,7 +81,7 @@ def unpack(sproj, branch):
     shutil.rmtree(os.path.join(outdir, '.git'))
     os.unlink(ofilename)
 
-def install(sproj):
+def install(sproj, requested_branch=None):
     if not os.path.isdir(spdir):
         print('Run this in your source root and make sure there is a subprojects directory in it.')
         return 1
@@ -90,12 +90,25 @@ def install(sproj):
     blist = [b for b in blist if b != 'master']
     blist.sort()
     branch = blist[-1]
+    if requested_branch is not None:
+        if requested_branch in blist:
+            branch = requested_branch
+        else:
+            print('Could not find user-requested branch', requested_branch)
+            print('Available branches for', sproj, ':')
+            print(blist)
+            return 1
     print('Using branch', branch)
     return unpack(sproj, branch)
 
+def print_help():
+    print('Usage:')
+    print(sys.argv[0], 'list')
+    print(sys.argv[0], 'install', 'package_name', '[branch_name]')
+
 def run(args):
     if not args or args[0] == '-h' or args[0] == '--help':
-        print(sys.argv[0], 'list/install', 'package_name')
+        print_help()
         return 1
     command = args[0]
     args = args[1:]
@@ -103,10 +116,13 @@ def run(args):
         list_projects()
         return 0
     elif command == 'install':
-        if len(args) != 1:
-            print('Install requires exactly one argument.')
+        if len(args) == 1:
+            return install(args[0])
+        elif len(args) == 2:
+            return install(args[0], args[1])
+        else:
+            print_help()
             return 1
-        return install(args[0])
     else:
         print('Unknown command')
         return 1


### PR DESCRIPTION
New feature:
- Users may specify a branch to download a specific version of a project.  If a branch is not specified the original behavior remains.  If the specified branch does not exist, the script prints valid branch names and exits with an error.

Bug fixes:
- Subprojects now go to the subproject directory specified in the wrap file (if it exists) instead of always going to the default directory
- Fixed hash report swap if download did not match expected

 