### PR TITLE
dependencies: Convert qt to DependencyFactory

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -505,7 +505,9 @@ include path of the given module(s) to the compiler flags.  (since v0.47.0)
 **Note** using private headers in your project is a bad idea, do so at your own
 risk.
 
-`method` may be `auto`, `pkg-config` or `qmake`.
+`method` may be `auto`, `pkg-config`, `qmake`, or `extraframework`.
+
+*New in 0.54.0* The `extraframework` method.
 
 ## SDL2
 

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -30,7 +30,7 @@ from .misc import (
     shaderc_factory, threads_factory,
 )
 from .platform import AppleFrameworks
-from .ui import GnuStepDependency, Qt4Dependency, Qt5Dependency, WxDependency, gl_factory, sdl2_factory, vulkan_factory
+from .ui import GnuStepDependency, WxDependency, gl_factory, sdl2_factory, vulkan_factory, qt4_factory, qt5_factory
 
 
 # This is a dict where the keys should be strings, and the values must be one
@@ -74,8 +74,8 @@ packages.update({
     # From ui:
     'gl': gl_factory,
     'gnustep': GnuStepDependency,
-    'qt4': Qt4Dependency,
-    'qt5': Qt5Dependency,
+    'qt4': qt4_factory,
+    'qt5': qt5_factory,
     'sdl2': sdl2_factory,
     'wxwidgets': WxDependency,
     'vulkan': vulkan_factory,

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -2165,10 +2165,15 @@ class DependencyFactory:
                  configtool_class: 'T.Optional[T.Type[ConfigToolDependency]]' = None,
                  framework_name: T.Optional[str] = None,
                  framework_class: 'T.Type[ExtraFrameworkDependency]' = ExtraFrameworkDependency,
-                 system_class: 'T.Type[ExternalDependency]' = ExternalDependency):
+                 system_class: 'T.Optional[T.Type[ExternalDependency]]' = None,
+                 qmake_class: 'T.Optional[T.Type[ExternalDependency]]' = None):
 
         if DependencyMethods.CONFIG_TOOL in methods and not configtool_class:
             raise DependencyException('A configtool must have a custom class')
+        if DependencyMethods.SYSTEM in methods and not system_class:
+            raise DependencyException('A system dependency must have a custom class')
+        if DependencyMethods.QMAKE in methods and not qmake_class:
+            raise DependencyException('A qmake dependency must have a custom class')
 
         self.extra_kwargs = extra_kwargs or {}
         self.methods = methods
@@ -2178,11 +2183,10 @@ class DependencyFactory:
             DependencyMethods.EXTRAFRAMEWORK: functools.partial(framework_class, framework_name or name),
             DependencyMethods.PKGCONFIG: functools.partial(pkgconfig_class, pkgconfig_name or name),
             DependencyMethods.CMAKE: functools.partial(cmake_class, cmake_name or name),
-            DependencyMethods.SYSTEM: functools.partial(system_class, name),
-            DependencyMethods.CONFIG_TOOL: None,
+            DependencyMethods.SYSTEM: functools.partial(system_class, name) if system_class else None,
+            DependencyMethods.CONFIG_TOOL: functools.partial(configtool_class, name) if configtool_class else None,
+            DependencyMethods.QMAKE: functools.partial(qmake_class, name) if qmake_class else None,
         }
-        if configtool_class is not None:
-            self.classes[DependencyMethods.CONFIG_TOOL] = functools.partial(configtool_class, name)
 
     @staticmethod
     def _process_method(method: DependencyMethods, env: Environment, for_machine: MachineChoice) -> bool:

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -15,16 +15,11 @@
 import os
 from .. import mlog
 from .. import build
-from ..mesonlib import MesonException, Popen_safe, extract_as_list, File
-from ..dependencies import Dependency, Qt4Dependency, Qt5Dependency
+from ..mesonlib import MesonException, Popen_safe, extract_as_list, File, MachineChoice
+from ..dependencies import Dependency, find_external_dependency
 import xml.etree.ElementTree as ET
 from . import ModuleReturnValue, get_include_args, ExtensionModule
 from ..interpreterbase import permittedKwargs, FeatureNew, FeatureNewKwargs
-
-_QT_DEPS_LUT = {
-    4: Qt4Dependency,
-    5: Qt5Dependency
-}
 
 
 class QtBaseModule(ExtensionModule):
@@ -41,8 +36,8 @@ class QtBaseModule(ExtensionModule):
         # FIXME: We currently require QtX to exist while importing the module.
         # We should make it gracefully degrade and not create any targets if
         # the import is marked as 'optional' (not implemented yet)
-        kwargs = {'required': 'true', 'modules': 'Core', 'silent': 'true', 'method': method}
-        qt = _QT_DEPS_LUT[self.qt_version](env, kwargs)
+        kwargs = {'required': True, 'modules': ['Core'], 'silent': True, 'method': method}
+        qt = find_external_dependency('qt{}'.format(self.qt_version), env, kwargs)
         # Get all tools and then make sure that they are the right version
         self.moc, self.uic, self.rcc, self.lrelease = qt.compilers_detect(self.interpreter)
         # Moc, uic and rcc write their version strings to stderr.


### PR DESCRIPTION
This splits the qt dependency into three separate dependencies: qmake,
pkg-config, and extra-frameworks.

This has an additional advantage that the qt module now uses the normal
find method, instead of creating a new dependency each time.