### PR TITLE
Use DependencyFactory and ConfigToolDependency for MPI

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -411,7 +411,13 @@ not provide them, it will search for the standard wrapper executables,
 `mpic`, `mpicxx`, `mpic++`, `mpifort`, `mpif90`, `mpif77`. If these
 are not in your path, they can be specified by setting the standard
 environment variables `MPICC`, `MPICXX`, `MPIFC`, `MPIF90`, or
-`MPIF77`, during configuration.
+`MPIF77`, during configuration. It will also try to use the Microsoft
+implementation on windows via the `system` method.
+
+`method` may be `auto`, `config-tool`, `pkg-config` or `system`.
+
+*New in 0.54.0* The `config-tool` and `system` method values. Previous
+versions would always try `pkg-config`, then `config-tool`, then `system`.
 
 ## NetCDF
 

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -22,7 +22,7 @@ from .base import (  # noqa: F401
     DependencyFactory)
 from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory, zlib_factory
 from .coarrays import coarray_factory
-from .mpi import MPIDependency
+from .mpi import mpi_factory
 from .scalapack import scalapack_factory
 from .misc import (
     BlocksDependency, OpenMPDependency, cups_factory, curses_factory, gpgme_factory,
@@ -52,7 +52,7 @@ packages.update({
     # per-file
     'coarray': coarray_factory,
     'hdf5': HDF5Dependency,
-    'mpi': MPIDependency,
+    'mpi': mpi_factory,
     'scalapack': scalapack_factory,
 
     # From misc:

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -79,13 +79,13 @@ class GnuStepDependency(ConfigToolDependency):
             ['--gui-libs' if 'gui' in self.modules else '--base-libs'],
             'link_args'))
 
-    def find_config(self, versions=None):
+    def find_config(self, versions=None, returncode: int = 0):
         tool = [self.tools[0]]
         try:
             p, out = Popen_safe(tool + ['--help'])[:2]
         except (FileNotFoundError, PermissionError):
             return (None, None)
-        if p.returncode != 0:
+        if p.returncode != returncode:
             return (None, None)
         self.config = tool
         found_version = self.detect_version()

--- a/test cases/frameworks/17 mpi/meson.build
+++ b/test cases/frameworks/17 mpi/meson.build
@@ -1,7 +1,9 @@
 project('mpi', 'c', 'cpp', default_options: ['b_asneeded=false'])
 
+method = get_option('method')
+
 cc = meson.get_compiler('c')
-mpic = dependency('mpi', language : 'c', required : false)
+mpic = dependency('mpi', language : 'c', required : false, method : method)
 if not mpic.found()
   error('MESON_SKIP_TEST: MPI not found, skipping.')
 endif
@@ -14,7 +16,7 @@ test('MPI C', exec, timeout: 10)
 
 # C++ MPI not supported by MS-MPI
 cpp = meson.get_compiler('cpp')
-mpicpp = dependency('mpi', language : 'cpp', required: false)
+mpicpp = dependency('mpi', language : 'cpp', required: false, method : method)
 if not cpp.links('''
 #include <mpi.h>
 #include <stdio.h>
@@ -31,7 +33,7 @@ test('MPI C++', execpp, timeout: 10)
 
 if add_languages('fortran', required : false)
   fc = meson.get_compiler('fortran')
-  mpif = dependency('mpi', language : 'fortran', required: false)
+  mpif = dependency('mpi', language : 'fortran', required: false, method : method)
   if not fc.links('use mpi; end', dependencies: mpif, name: 'Fortran MPI')
     mpif = disabler()
   endif
@@ -46,5 +48,5 @@ endif
 
 # Check we can apply a version constraint
 if mpic.version() != 'unknown'
-  dependency('mpi', version: '>=@0@'.format(mpic.version()))
+  dependency('mpi', version: '>=@0@'.format(mpic.version()), method : method)
 endif

--- a/test cases/frameworks/17 mpi/meson_options.txt
+++ b/test cases/frameworks/17 mpi/meson_options.txt
@@ -1,0 +1,6 @@
+option(
+    'method',
+    type : 'combo',
+    choices : ['auto', 'pkg-config', 'config-tool', 'system'],
+    value : 'auto',
+)


### PR DESCRIPTION
The main code savings here is the use of the ConfigTool dependency, but this brings the MPI code in line with the way most other dependencies work, plus the code savings is nice.