### PR TITLE
Add CODEOWNERS file [skip ci]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+* @jpakkane
+/mesonbuild/modules/pkgconfig.py @xclaesse
+/mesonbuild/modules/cmake.py @mensinda
+/mesonbuild/cmake/* @mensinda


### PR DESCRIPTION
Following proposal in #6485 we would like to delegate maitainership
of parts of the Meson project (modules) to selected volunteers.