### PR TITLE
dependencies/base: Remove config-tool fallback to path

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -225,10 +225,11 @@ wmf_dep = dependency('libwmf', method : 'config-tool')
 ## Dependencies using config tools
 
 [CUPS](#cups), [LLVM](#llvm), [pcap](#pcap), [WxWidgets](#wxwidgets),
-[libwmf](#libwmf), [GCrypt](#libgcrypt), [GPGME](#gpgme), and GnuStep either do not provide pkg-config
-modules or additionally can be detected via a config tool
-(cups-config, llvm-config, libgcrypt-config, etc). Meson has native support for these
-tools, and they can be found like other dependencies:
+[libwmf](#libwmf), [GCrypt](#libgcrypt), [GPGME](#gpgme), and GnuStep either
+do not provide pkg-config modules or additionally can be detected via a
+config tool (cups-config, llvm-config, libgcrypt-config, etc). Meson has
+native support for these tools, and they can be found like other
+dependencies:
 
 ```meson
 pcap_dep = dependency('pcap', version : '>=1.0')
@@ -237,6 +238,10 @@ llvm_dep = dependency('llvm', version : '>=4.0')
 libgcrypt_dep = dependency('libgcrypt', version: '>= 1.8')
 gpgme_dep = dependency('gpgme', version: '>= 1.0')
 ```
+
+*Changed in 0.54.0* Before 0.54.0 meson would search $PATH for a config tool
+binary when cross compiling if the config tool did not have an entry in the
+cross file.
 
 ## AppleFrameworks
 

--- a/docs/markdown/snippets/config_tool_no_cross_path.md
+++ b/docs/markdown/snippets/config_tool_no_cross_path.md
@@ -1,0 +1,7 @@
+## Config tool based dependencies no longer search PATH for cross compiling
+
+Before 0.54.0 config tool based dependencies (llvm-config, cups-config, etc),
+would search path if they weren't defined in the cross file. This has been a
+source of bugs and has been deprecated. It is now removed, config tool
+binaries must be specified in the cross file now or the dependency will not
+be found.

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -427,10 +427,7 @@ class ConfigToolDependency(ExternalDependency):
             tools = [tool]
         else:
             if not self.env.machines.matches_build_machine(self.for_machine):
-                mlog.deprecation('No entry for {0} specified in your cross file. '
-                                 'Falling back to searching PATH. This may find a '
-                                 'native version of {0}! This will become a hard '
-                                 'error in a future version of meson'.format(self.tool_name))
+                return ('', None)
             tools = [[t] for t in self.tools]
 
         best_match = (None, None)


### PR DESCRIPTION
This is conceptually similar to #6506, but covers all config tools
instead of qmake. As far as I'm aware there is no useful case for
picking a config-tool from path instead of from the cross file, and it's
the source of bugs more often than not, It's been marked deprecated for
a while, so lets remove it.