### PR TITLE
Small cleanups for the LLVM dependency class

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -370,6 +370,8 @@ As of 0.44.0 Meson supports the `static` keyword argument for
 LLVM. Before this LLVM >= 3.9 would always dynamically link, while
 older versions would statically link, due to a quirk in `llvm-config`.
 
+`method` may be `auto`, `config-tool`, or `cmake`.
+
 ### Modules, a.k.a. Components
 
 Meson wraps LLVM's concept of components in it's own modules concept.

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -218,7 +218,6 @@ class LLVMDependencyConfigTool(ConfigToolDependency):
         self.module_details = []
         if not self.is_found:
             return
-        self.static = kwargs.get('static', False)
 
         self.provided_modules = self.get_config_value(['--components'], 'modules')
         modules = stringlistify(extract_as_list(kwargs, 'modules'))

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -391,6 +391,12 @@ class LLVMDependencyCMake(CMakeDependency):
         self.llvm_opt_modules = stringlistify(extract_as_list(kwargs, 'optional_modules'))
         super().__init__(name, env, kwargs, language='cpp')
 
+        # Cmake will always create a statically linked binary, so don't use
+        # cmake if dynamic is required
+        if not self.static:
+            self.is_found = False
+            return
+
         if self.traceparser is None:
             return
 


### PR DESCRIPTION
These are just a few small things I noticed while doing the big dependency API refactor, but that didn't belong in that series.