### PR TITLE
Don't fail in setup on azure when commit message contains an equals sign

### DIFF
--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -102,6 +102,10 @@ steps:
        $vcvars = "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvarsall.bat"
      }
 
+     ## A multiline commit message containing "=" can interact badly with this
+     ## hack to extract the environment from vcvarsall.bat
+     Remove-Item env:BUILD_SOURCEVERSIONMESSAGE
+
      ## ask cmd.exe to output the environment table after the batch file completes
      $tempFile = [IO.Path]::GetTempFileName()
      cmd /c " `"$vcvars`" $env:arch && set > `"$tempFile`" "


### PR DESCRIPTION
This fixes the azure failure seen for commit https://github.com/mesonbuild/meson/commit/15ab30383ecc3fe124f3aed8aa5b9ddb1b5bbbc7