### PR TITLE
Add mesonbuild/ast to CODEOWNERS [skip ci]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
 * @jpakkane
 /mesonbuild/modules/pkgconfig.py @xclaesse
 /mesonbuild/modules/cmake.py @mensinda
+/mesonbuild/ast/* @mensinda
 /mesonbuild/cmake/* @mensinda


### PR DESCRIPTION
I volunteer to maintain the AST code.