### PR TITLE
ci: Add Fedora and OpenSUSE images

### DIFF
--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -36,3 +36,27 @@ jobs:
       run: ./run_tests.py
       env:
         CI: '1'
+
+  fedora:
+    name: Fedora
+    runs-on: ubuntu-latest
+    container: mensinda/fedora:latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run tests
+      run: ./run_tests.py
+      env:
+        CI: '1'
+        SKIP_SCIENTIFIC: '1'
+
+  opensuse:
+    name: OpenSUSE
+    runs-on: ubuntu-latest
+    container: mensinda/opensuse:latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run tests
+      run: ./run_tests.py
+      env:
+        CI: '1'
+        SKIP_SCIENTIFIC: '1'

--- a/ci/ciimage/fedora/Dockerfile
+++ b/ci/ciimage/fedora/Dockerfile
@@ -1,0 +1,4 @@
+FROM fedora:latest
+
+ADD install.sh /usr/sbin/docker-fedora-install
+RUN docker-fedora-install

--- a/ci/ciimage/fedora/install.sh
+++ b/ci/ciimage/fedora/install.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+pkgs=(
+  python python-setuptools python-wheel python-pip python-pytest-xdist pygobject3 python3-devel python2-devel
+  ninja-build make git autoconf automake patch python3-Cython python2-Cython
+  elfutils gcc gcc-c++ gcc-fortran gcc-objc gcc-objc++ vala rust bison flex ldc libasan libasan-static
+  mono-core boost-devel gtkmm30 gtest-devel gmock-devel protobuf-devel wxGTK3-devel gobject-introspection
+  itstool gtk3-devel java-latest-openjdk-devel gtk-doc llvm-devel clang-devel SDL2-devel graphviz-devel zlib zlib-devel zlib-static
+  #hdf5-openmpi-devel hdf5-devel netcdf-openmpi-devel netcdf-devel netcdf-fortran-openmpi-devel netcdf-fortran-devel scalapack-openmpi-devel
+  doxygen vulkan-devel vulkan-validation-layers-devel openssh mercurial gtk-sharp2-devel libpcap-devel gpgme-devel
+  qt5-qtbase-devel qt5-qttools-devel qt5-linguist qt5-qtbase-private-devel
+  libwmf-devel valgrind cmake openmpi-devel nasm gnustep-base-devel gettext-devel ncurses-devel
+  libxml2-devel libxslt-devel libyaml-devel glib2-devel json-glib-devel
+)
+
+# Sys update
+dnf -y upgrade
+
+# Install deps
+dnf -y install "${pkgs[@]}"
+python3 -m pip install hotdoc gobject PyGObject
+
+# Cleanup
+dnf -y clean all

--- a/ci/ciimage/opensuse/Dockerfile
+++ b/ci/ciimage/opensuse/Dockerfile
@@ -1,0 +1,4 @@
+FROM opensuse/tumbleweed:latest
+
+ADD install.sh /usr/sbin/docker-opensuse-install
+RUN docker-opensuse-install

--- a/ci/ciimage/opensuse/install.sh
+++ b/ci/ciimage/opensuse/install.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+pkgs=(
+  python3-setuptools python3-wheel python3-pip python3-pytest-xdist python3 python2
+  ninja make git autoconf automake patch python3-Cython python2-Cython
+  elfutils gcc gcc-c++ gcc-fortran gcc-objc gcc-obj-c++ vala rust bison flex curl
+  mono-core gtkmm3-devel gtest gmock protobuf-devel wxGTK3-3_2-devel gobject-introspection-devel
+  itstool gtk3-devel java-13-openjdk-devel gtk-doc llvm-devel clang-devel libSDL2-devel graphviz-devel zlib-devel zlib-devel-static
+  #hdf5-devel netcdf-devel libscalapack2-openmpi3-devel libscalapack2-gnu-openmpi3-hpc-devel openmpi3-devel
+  doxygen vulkan-devel vulkan-validationlayers openssh mercurial gtk-sharp3-complete gtk-sharp2-complete libpcap-devel libgpgme-devel
+  libqt5-qtbase-devel libqt5-qttools-devel libqt5-linguist libqt5-qtbase-private-headers-devel
+  libwmf-devel valgrind cmake nasm gnustep-base-devel gettext-tools gettext-runtime gettext-csharp ncurses-devel
+  libxml2-devel libxslt-devel libyaml-devel glib2-devel json-glib-devel
+  boost-devel libboost_date_time-devel libboost_filesystem-devel libboost_locale-devel libboost_system-devel
+  libboost_test-devel libboost_log-devel libboost_regex-devel
+  libboost_python-devel libboost_python-py2_7-1_71_0-devel libboost_python-py3-1_71_0-devel libboost_regex-devel
+)
+
+# Sys update
+zypper patch --with-update --with-optional
+zypper update
+
+# Install deps
+zypper install -y "${pkgs[@]}"
+python3 -m pip install hotdoc gobject PyGObject
+
+echo 'export PKG_CONFIG_PATH="/usr/lib64/mpi/gcc/openmpi3/lib64/pkgconfig:$PKG_CONFIG_PATH"' >> ~/.bashrc
+
+# dmd is very special on OpenSUSE (as in the packages do not work)
+# see https://bugzilla.opensuse.org/show_bug.cgi?id=1162408
+curl -fsS https://dlang.org/install.sh | bash -s dmd | tee dmd_out.txt
+cat dmd_out.txt | grep source | sed 's/^[^`]*`//g' | sed 's/`.*//g' >> ~/.bashrc
+chmod +x ~/.bashrc
+
+source ~/.bashrc
+
+dub fetch urld
+dub build urld --compiler=dmd
+dub fetch dubtestproject
+dub build dubtestproject:test1 --compiler=dmd
+dub build dubtestproject:test2 --compiler=dmd
+
+# Cleanup
+zypper clean --all

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -118,6 +118,7 @@ failing_logs = []
 print_debug = 'MESON_PRINT_TEST_OUTPUT' in os.environ
 under_ci = 'CI' in os.environ
 under_xenial_ci = under_ci and ('XENIAL' in os.environ)
+skip_scientific = under_ci and ('SKIP_SCIENTIFIC' in os.environ)
 do_debug = under_ci or print_debug
 no_meson_log_msg = 'No meson-log.txt found.'
 
@@ -631,6 +632,11 @@ def skippable(suite, test):
 
     # Blocks are not supported on all compilers
     if test.endswith('29 blocks'):
+        return True
+
+    # Scientific libraries are skippable on certain systems
+    # See the discussion here: https://github.com/mesonbuild/meson/pull/6562
+    if any([test.endswith(x) for x in ['17 mpi', '25 hdf5', '30 scalapack']]) and skip_scientific:
         return True
 
     # No frameworks test should be skipped on linux CI, as we expect all

--- a/test cases/frameworks/20 cups/meson.build
+++ b/test cases/frameworks/20 cups/meson.build
@@ -12,10 +12,10 @@ test('cupstest', e)
 
 # ensure we can find the cups dependency via the legacy and modern config-tool
 # options
-dep = dependency('cups', version : '>=1.4', method : 'cups-config')
-dep = dependency('cups', version : '>=1.4', method : 'config-tool')
-dep = dependency('cups', version : '>=1.4', method : 'cmake')
+depCC = dependency('cups', version : '>=1.4', method : 'cups-config')
+depCT = dependency('cups', version : '>=1.4', method : 'config-tool')
+depCM = dependency('cups', version : '>=1.4', method : 'cmake')
 
 # check we can apply a version constraint
-dependency('cups', version: '>=@0@'.format(dep.version()), method: 'pkg-config', required: false)
-dependency('cups', version: '>=@0@'.format(dep.version()), method: 'config-tool')
+dependency('cups', version: '>=@0@'.format(depCT.version()), method: 'pkg-config', required: false)
+dependency('cups', version: '>=@0@'.format(depCT.version()), method: 'config-tool')


### PR DESCRIPTION
I have tried to fix as many test failures as possible on these images, however, I didn't manage to fix all of them. Specifically the `hdf5`, `netcdf`, `mpi` and `scalapack` tests just won't work on Fedora and OpenSUSE. Unfortunately, I don't know enough about these dependencies to fix them (ping @scivision, @dcbaker).

The docker images are hosted here: https://hub.docker.com/u/mensinda