### PR TITLE
meson: performance optimize

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -731,6 +731,7 @@ class Compiler:
         return repr_str.format(self.__class__.__name__, self.version,
                                ' '.join(self.exelist))
 
+    @lru_cache(maxsize=None)
     def can_compile(self, src) -> bool:
         if hasattr(src, 'fname'):
             src = src.fname


### PR DESCRIPTION
With this commit, 2 performance bottlenecks are resolved.
- Caching the result of can_compile removes 11s of efl configure time
- Using a lookup dict instead of a list is also speeding the ninja generation up by several seconds. Additionally, using the knowledge if this flag is in pre or post, is shaving off a few seconds of runtime.

Additionally, the usage of --profile-self is fixed in this commit.