### PR TITLE
WIP: cmake: Boost CMake dependency backend and COMPONENTS support

### DIFF
--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -11,9 +11,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update -yq
-        sudo apt install -yq --no-install-recommends python3-setuptools python3-pip g++ gfortran gobjc gobjc++ zlib1g-dev python-dev python3-dev libboost-all-dev
-    - name: Remove GitHub boost version
-      run: sudo rm -rf /usr/local/share/boost
+        sudo apt install -yq --no-install-recommends python3-setuptools python3-pip g++ gfortran gobjc gobjc++ zlib1g-dev python-dev python3-dev
     - name: Install ninja-build tool
       uses: seanmiddleditch/gha-setup-ninja@v1
     - name: Python version
@@ -21,7 +19,7 @@ jobs:
     - name: Ninja version
       run: ninja --version
     - name: Run tests
-      run: python3 run_tests.py
+      run: LD_LIBRARY_PATH="${BOOST_ROOT}/lib:$LD_LIBRARY_PATH" python3 run_tests.py
       env:
         CI: '1'
         XENIAL: '1'

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -173,6 +173,10 @@ it automatically.
     cmake_dep = dependency('ZLIB', method : 'cmake', modules : ['ZLIB::ZLIB'])
 ```
 
+Support for adding additional `COMPONENTS` for the CMake `find_package` lookup
+is provided with the `components` kwarg (*introduced in 0.54.0*). All specified
+componets will be passed directly to `find_package(COMPONENTS)`.
+
 It is also possible to reuse existing `Find<name>.cmake` files with the
 `cmake_module_path` property. Using this property is equivalent to setting the
 `CMAKE_MODULE_PATH` variable in CMake. The path(s) given to `cmake_module_path`

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -479,7 +479,8 @@ arguments:
 - other
 [library-specific](Dependencies.md#dependencies-with-custom-lookup-functionality)
 keywords may also be accepted (e.g. `modules` specifies submodules to use for
-dependencies such as Qt5 or Boost. )
+dependencies such as Qt5 or Boost. `components` allows the user to manually
+add CMake `COMPONENTS` for the `find_package` lookup)
 - `disabler` if `true` and the dependency couldn't be found, return a
   [disabler object](#disabler-object) instead of a not-found dependency.
   *Since 0.49.0*

--- a/docs/markdown/snippets/cmake_comps.md
+++ b/docs/markdown/snippets/cmake_comps.md
@@ -1,0 +1,4 @@
+## CMake find_package COMPONENTS support
+
+It is now possible to pass components to the CMake dependency backend via the
+new `components` kwarg in the `dependency` function.

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -427,9 +427,8 @@ class CMakeTraceParser:
         values = []
         prop_regex = re.compile(r'^[A-Z_]+$')
         for a in args:
-            if prop_regex.match(a):
-                if values:
-                    arglist.append((name, ' '.join(values).split(';')))
+            if prop_regex.match(a) and values:
+                arglist.append((name, ' '.join(values).split(';')))
                 name = a
                 values = []
             else:

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .boost import BoostDependency
+from .boost import boost_factory
 from .cuda import CudaDependency
 from .hdf5 import HDF5Dependency
 from .base import (  # noqa: F401
@@ -45,7 +45,7 @@ packages.update({
     'llvm': llvm_factory,
     'valgrind': ValgrindDependency,
 
-    'boost': BoostDependency,
+    'boost': boost_factory,
     'cuda': CudaDependency,
 
     # per-file

--- a/mesonbuild/dependencies/data/CMakeLists.txt
+++ b/mesonbuild/dependencies/data/CMakeLists.txt
@@ -9,7 +9,11 @@ set(_packageName "${NAME}")
 string(TOUPPER "${_packageName}" PACKAGE_NAME)
 
 while(TRUE)
-  find_package("${NAME}" QUIET COMPONENTS ${COMPS})
+  if(MESON_REQUIRED)
+    find_package("${NAME}" COMPONENTS ${COMPS} REQUIRED)
+  else()
+    find_package("${NAME}" COMPONENTS ${COMPS})
+  endif()
 
   # ARCHS has to be set via the CMD interface
   if(${_packageName}_FOUND OR ${PACKAGE_NAME}_FOUND OR "${ARCHS}" STREQUAL "")

--- a/mesonbuild/dependencies/data/CMakeLists.txt
+++ b/mesonbuild/dependencies/data/CMakeLists.txt
@@ -9,7 +9,7 @@ set(_packageName "${NAME}")
 string(TOUPPER "${_packageName}" PACKAGE_NAME)
 
 while(TRUE)
-  find_package("${NAME}" QUIET)
+  find_package("${NAME}" QUIET COMPONENTS ${COMPS})
 
   # ARCHS has to be set via the CMD interface
   if(${_packageName}_FOUND OR ${PACKAGE_NAME}_FOUND OR "${ARCHS}" STREQUAL "")

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -416,7 +416,7 @@ class LLVMDependencyCMake(CMakeDependency):
     def _extra_cmake_opts(self) -> T.List[str]:
         return ['-DLLVM_MESON_MODULES={}'.format(';'.join(self.llvm_modules + self.llvm_opt_modules))]
 
-    def _map_module_list(self, modules: T.List[T.Tuple[str, bool]]) -> T.List[T.Tuple[str, bool]]:
+    def _map_module_list(self, modules: T.List[T.Tuple[str, bool]], components: T.List[T.Tuple[str, bool]]) -> T.List[T.Tuple[str, bool]]:
         res = []
         for mod, required in modules:
             cm_targets = self.traceparser.get_cmake_var('MESON_LLVM_TARGETS_{}'.format(mod))

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2120,6 +2120,7 @@ permitted_kwargs = {'add_global_arguments': {'language', 'native'},
                                    'main',
                                    'method',
                                    'modules',
+                                   'components',
                                    'cmake_module_path',
                                    'optional_modules',
                                    'native',
@@ -3281,6 +3282,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         elif name == 'openmp':
             FeatureNew('OpenMP Dependency', '0.46.0').use(self.subproject)
 
+    @FeatureNewKwargs('dependency', '0.54.0', ['components'])
     @FeatureNewKwargs('dependency', '0.52.0', ['include_type'])
     @FeatureNewKwargs('dependency', '0.50.0', ['not_found_message', 'cmake_module_path', 'cmake_args'])
     @FeatureNewKwargs('dependency', '0.49.0', ['disabler'])

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4456,13 +4456,13 @@ class FailureTests(BasePlatformTests):
     def test_boost_notfound_dependency(self):
         # Can be run even if Boost is found or not
         self.assertMesonRaises("dependency('boost', modules : 1)",
-                               "module.*not a string")
+                               "(module.*not a string|List item must be one of <class 'str'>)")
         self.assertMesonRaises("dependency('boost', modules : 'fail')",
                                "(fail.*not found|{})".format(self.dnf))
 
     def test_boost_BOOST_ROOT_dependency(self):
         # Test BOOST_ROOT; can be run even if Boost is found or not
-        self.assertMesonRaises("dependency('boost')",
+        self.assertMesonRaises("dependency('boost', method: 'system')",
                                "(BOOST_ROOT.*absolute|{})".format(self.dnf),
                                override_envvars = {'BOOST_ROOT': 'relative/path'})
 

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -21,7 +21,7 @@ endif
 # within one project. The need to be independent of each other.
 # Use one without a library dependency and one with it.
 
-linkdep = dependency('boost', modules : ['thread', 'system', 'test'])
+linkdep = dependency('boost', modules : ['thread', 'system'])
 staticdep = dependency('boost', modules : ['thread', 'system'], static : true)
 testdep = dependency('boost', modules : ['unit_test_framework'])
 nomoddep = dependency('boost')

--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -2,11 +2,17 @@
 project('boosttest', 'cpp',
   default_options : ['cpp_std=c++11'])
 
-add_project_arguments(['-DBOOST_LOG_DYN_LINK'],
-  language : 'cpp'
-)
+m = get_option('method')
+s = get_option('static')
 
-dep = dependency('boost', required: false)
+if s == false
+  # The system dependency does not know anything about the required boost defines
+  add_project_arguments(['-DBOOST_LOG_DYN_LINK', '-DBOOST_TEST_DYN_LINK'],
+    language : 'cpp'
+  )
+endif
+
+dep = dependency('boost', method: m, static: s, required: false)
 if not dep.found()
   error('MESON_SKIP_TEST boost not found.')
 endif
@@ -21,11 +27,13 @@ endif
 # within one project. The need to be independent of each other.
 # Use one without a library dependency and one with it.
 
-linkdep = dependency('boost', modules : ['thread', 'system'])
-staticdep = dependency('boost', modules : ['thread', 'system'], static : true)
-testdep = dependency('boost', modules : ['unit_test_framework'])
-nomoddep = dependency('boost')
-extralibdep = dependency('boost', modules : ['thread', 'system', 'log_setup', 'log'])
+linkdep     = dependency('boost', method: m, static: s, modules : ['thread', 'system'])
+testdep     = dependency('boost', method: m, static: s, modules : ['unit_test_framework'])
+nomoddep    = dependency('boost', method: m, static: s)
+extralibdep = dependency('boost', method: m, static: s, modules : ['thread', 'system', 'log_setup', 'log'])
+notfound    = dependency('boost', method: m, static: s, modules : ['this_should_not_exist_on_any_systen'], required: false)
+
+assert(not notfound.found())
 
 pymod = import('python')
 python2 = pymod.find_installation('python2', required: host_machine.system() == 'linux', disabler: true)
@@ -34,28 +42,28 @@ python2dep = python2.dependency(required: host_machine.system() == 'linux', embe
 python3dep = python3.dependency(required: host_machine.system() == 'linux', embed: true, disabler: true)
 
 # compile python 2/3 modules only if we found a corresponding python version
-if(python2dep.found() and host_machine.system() == 'linux')
+if(python2dep.found() and host_machine.system() == 'linux' and not s)
   if(dep.version().version_compare('>=1.67'))
     # if we have a new version of boost, we need to construct the module name based
     # on the installed version of python (and hope that they match the version boost
     # was compiled against)
     py2version_string = ''.join(python2dep.version().split('.'))
-    bpython2dep = dependency('boost', modules : ['python' + py2version_string], required: false, disabler: true)
+    bpython2dep = dependency('boost', method: m, static: s, modules : ['python' + py2version_string], required: false, disabler: true)
   else
     # if we have an older version of boost, we need to use the old module names
-    bpython2dep = dependency('boost', modules : ['python'], required: false, disabler: true)
+    bpython2dep = dependency('boost', method: m, static: s, modules : ['python'], required: false, disabler: true)
   endif
 else
   python2dep = disabler()
   bpython2dep = disabler()
 endif
 
-if(python3dep.found() and host_machine.system() == 'linux')
+if(python3dep.found() and host_machine.system() == 'linux' and not s)
   if(dep.version().version_compare('>=1.67'))
     py3version_string = ''.join(python3dep.version().split('.'))
-    bpython3dep = dependency('boost', modules : ['python' + py3version_string], required: false, disabler: true)
+    bpython3dep = dependency('boost', method: m, static: s, modules : ['python' + py3version_string], required: false, disabler: true)
   else
-    bpython3dep = dependency('boost', modules : ['python3'], required: false, disabler: true)
+    bpython3dep = dependency('boost', method: m, static: s, modules : ['python3'], required: false, disabler: true)
   endif
 else
   python3dep = disabler()
@@ -63,7 +71,6 @@ else
 endif
 
 linkexe = executable('linkedexe', 'linkexe.cc', dependencies : linkdep)
-staticexe = executable('staticlinkedexe', 'linkexe.cc', dependencies : staticdep)
 unitexe = executable('utf', 'unit_test.cpp', dependencies: testdep)
 nomodexe = executable('nomod', 'nomod.cpp', dependencies : nomoddep)
 extralibexe = executable('extralibexe', 'extralib.cpp', dependencies : extralibdep)
@@ -73,7 +80,6 @@ python2module = shared_library('python2_module', ['python_module.cpp'], dependen
 python3module = shared_library('python3_module', ['python_module.cpp'], dependencies: [python3dep, bpython3dep], name_prefix: '', cpp_args: ['-DMOD_NAME=python3_module'])
 
 test('Boost linktest', linkexe)
-test('Boost statictest', staticexe)
 test('Boost UTF test', unitexe)
 test('Boost nomod', nomodexe)
 test('Boost extralib test', extralibexe)
@@ -87,4 +93,4 @@ test('Boost Python3', python3interpreter, args: ['./test_python_module.py', meso
 subdir('partial_dep')
 
 # check we can apply a version constraint
-dependency('boost', version: '>=@0@'.format(dep.version()))
+dependency('boost', method: m, static: s, version: '>=@0@'.format(dep.version()))

--- a/test cases/frameworks/1 boost/meson_options.txt
+++ b/test cases/frameworks/1 boost/meson_options.txt
@@ -1,0 +1,2 @@
+option('method', type: 'combo', choices: ['auto', 'cmake', 'system'], value: 'cmake')
+option('static', type: 'boolean', value: false)

--- a/test cases/frameworks/1 boost/test_matrix.json
+++ b/test cases/frameworks/1 boost/test_matrix.json
@@ -8,5 +8,8 @@
       { "val": "true"  },
       { "val": "false" }
     ]
-  }
+  },
+  "exclude": [
+    { "method": "system", "static": "true" }
+  ]
 }

--- a/test cases/frameworks/1 boost/test_matrix.json
+++ b/test cases/frameworks/1 boost/test_matrix.json
@@ -1,0 +1,12 @@
+{
+  "options": {
+    "method": [
+      { "val": "cmake"                             },
+      { "val": "system", "skip_on_env": ["XENIAL"] }
+    ],
+    "static": [
+      { "val": "true"  },
+      { "val": "false" }
+    ]
+  }
+}

--- a/test cases/frameworks/1 boost/unit_test.cpp
+++ b/test cases/frameworks/1 boost/unit_test.cpp
@@ -1,4 +1,3 @@
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE "MesonTest"
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>

--- a/test cases/linuxlike/13 cmake dependency/cmake/FindSomethingLikeZLIB.cmake
+++ b/test cases/linuxlike/13 cmake dependency/cmake/FindSomethingLikeZLIB.cmake
@@ -38,6 +38,10 @@ if(NOT C_CODE_RAN)
   message(FATAL_ERROR "Running C source code failed")
 endif()
 
+if(NOT SomethingLikeZLIB_FIND_COMPONENTS STREQUAL "required_comp")
+  message(FATAL_ERROR "Component 'required_comp' was not specified")
+endif()
+
 find_dependency(Threads)
 
 if(ZLIB_FOUND OR ZLIB_Found)

--- a/test cases/linuxlike/13 cmake dependency/meson.build
+++ b/test cases/linuxlike/13 cmake dependency/meson.build
@@ -44,9 +44,9 @@ depPrefEnv = dependency('cmMesonTestDep', required : true, method : 'cmake')
 
 # Try to find a dependency with a custom CMake module
 
-depm1 = dependency('SomethingLikeZLIB', required : true, method : 'cmake', cmake_module_path : 'cmake')
-depm2 = dependency('SomethingLikeZLIB', required : true, method : 'cmake', cmake_module_path : ['cmake'])
-depm3 = dependency('SomethingLikeZLIB', required : true, cmake_module_path : 'cmake')
+depm1 = dependency('SomethingLikeZLIB', required : true, components : 'required_comp',   method : 'cmake', cmake_module_path : 'cmake')
+depm2 = dependency('SomethingLikeZLIB', required : true, components : 'required_comp',   method : 'cmake', cmake_module_path : ['cmake'])
+depm3 = dependency('SomethingLikeZLIB', required : true, components : ['required_comp'], cmake_module_path : 'cmake')
 
 # Test some edge cases with spaces, etc.
 


### PR DESCRIPTION
Adds the new boost CMake dependency backend. It is a lot smaller than the existing boost mechanism and should also be a lot more reliable due to the mature CMake ecosystem.

Additionally, support for specifying `find_package()` `COMPONENTS` is added. This new feature is required for the `BoostCMakeDependency`.