### PR TITLE
environment: Handle cases of no cs compiler being installed correctly

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1336,6 +1336,8 @@ class Environment:
                 cls = MonoCompiler
             elif "Visual C#" in out:
                 cls = VisualStudioCsCompiler
+            else:
+                continue
             self.coredata.add_lang_args(cls.language, cls, for_machine, self)
             return cls(comp, version, for_machine, info)
 


### PR DESCRIPTION
Otherwise there's a stack traced caused by use-before-assignment