### PR TITLE
dependencies: Convert ScaLAPACK to a dependency factory

### DIFF
--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -23,7 +23,7 @@ from .base import (  # noqa: F401
 from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory, zlib_factory
 from .coarrays import coarray_factory
 from .mpi import MPIDependency
-from .scalapack import ScalapackDependency
+from .scalapack import scalapack_factory
 from .misc import (
     BlocksDependency, OpenMPDependency, cups_factory, curses_factory, gpgme_factory,
     libgcrypt_factory, libwmf_factory, netcdf_factory, pcap_factory, python3_factory,
@@ -53,7 +53,7 @@ packages.update({
     'coarray': coarray_factory,
     'hdf5': HDF5Dependency,
     'mpi': MPIDependency,
-    'scalapack': ScalapackDependency,
+    'scalapack': scalapack_factory,
 
     # From misc:
     'blocks': BlocksDependency,


### PR DESCRIPTION
Basically this breaks down into three cases. An open source version with
compliant PkgConfig, valid CMake, and a Intel implementation that has
completely broken PkgConfig. For the first two cases we can use standard
classes, for the last we can make a subclass of PkgConfigDependency that
handles the special logic.

This doesn't change any of the logic, but it does re-organize it to be
clearer, and make use of the dependency factory API, which makes other
things (like Dependency.get_variable) work.

This is untested with Intel MKL.