### PR TITLE
Fix import dependency from dub

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1646,6 +1646,7 @@ class DubDependency(ExternalDependency):
                     if lib_path:
                         self.link_args.append(lib_path)
                     else:
+                        mlog.warning('Library not found: {}'.format(file))
                         self.is_found = False
 
     def get_compiler(self):

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1646,7 +1646,6 @@ class DubDependency(ExternalDependency):
                     if lib_path:
                         self.link_args.append(lib_path)
                     else:
-                        mlog.warning('Library not found: {}'.format(file))
                         self.is_found = False
 
     def get_compiler(self):
@@ -1661,6 +1660,14 @@ class DubDependency(ExternalDependency):
             module_path = os.path.dirname(default_path)
             lib_file_name = os.path.basename(default_path)
         module_build_path = os.path.join(module_path, '.dub', 'build')
+
+        # If default_path is a path to lib file and 
+        # directory of lib don't have subdir '.dub/build' 
+        if not os.path.isdir(module_build_path) and os.path.isfile(default_path):
+            if folder_only:
+                return module_path
+            else:
+                return default_path
 
         # Get D version implemented in the compiler
         # gdc doesn't support this


### PR DESCRIPTION
#6586 
fix DubDependency._find_right_lib_path
if default_path is path to library and directory  of lib don't have subdirectory '.dub/build' -> return default_path 