### PR TITLE
mesonlib: Set stdin to DEVNULL for all programs run by us

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -1084,10 +1084,15 @@ def Popen_safe(args: T.List[str], write: T.Optional[str] = None,
     if 'stdin' not in kwargs:
         kwargs['stdin'] = subprocess.DEVNULL
     if sys.version_info < (3, 6) or not sys.stdout.encoding or encoding.upper() != 'UTF-8':
-        return Popen_safe_legacy(args, write=write, stdout=stdout, stderr=stderr, **kwargs)
-    p = subprocess.Popen(args, universal_newlines=True, close_fds=False,
-                         stdout=stdout, stderr=stderr, **kwargs)
-    o, e = p.communicate(write)
+        p, o, e = Popen_safe_legacy(args, write=write, stdout=stdout, stderr=stderr, **kwargs)
+    else:
+        p = subprocess.Popen(args, universal_newlines=True, close_fds=False,
+                             stdout=stdout, stderr=stderr, **kwargs)
+        o, e = p.communicate(write)
+    # Sometimes the command that we run will call another command which will be
+    # without the above stdin workaround, so set the console mode again just in
+    # case.
+    mlog.setup_console()
     return p, o, e
 
 def Popen_safe_legacy(args: T.List[str], write: T.Optional[str] = None,

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -1080,6 +1080,10 @@ def Popen_safe(args: T.List[str], write: T.Optional[str] = None,
                **kwargs: T.Any) -> T.Tuple[subprocess.Popen, str, str]:
     import locale
     encoding = locale.getpreferredencoding()
+    # Redirect stdin to DEVNULL otherwise the command run by us here might mess
+    # up the console and ANSI colors will stop working on Windows.
+    if 'stdin' not in kwargs:
+        kwargs['stdin'] = subprocess.DEVNULL
     if sys.version_info < (3, 6) or not sys.stdout.encoding or encoding.upper() != 'UTF-8':
         return Popen_safe_legacy(args, write=write, stdout=stdout, stderr=stderr, **kwargs)
     p = subprocess.Popen(args, universal_newlines=True, close_fds=False,

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -65,8 +65,7 @@ def git(cmd: T.List[str], workingdir: str, **kwargs) -> subprocess.CompletedProc
     # Sometimes git calls git recursively, such as `git submodule update
     # --recursive` which will be without the above workaround, so set the
     # console mode again just in case.
-    if platform.system().lower() == 'windows':
-        mlog._windows_ansi()
+    mlog.setup_console()
     return pc
 
 

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -40,13 +40,15 @@ def _windows_ansi() -> bool:
     # original behavior
     return bool(kernel.SetConsoleMode(stdout, mode.value | 0x4) or os.environ.get('ANSICON'))
 
-try:
-    if platform.system().lower() == 'windows':
-        colorize_console = os.isatty(sys.stdout.fileno()) and _windows_ansi()  # type: bool
-    else:
-        colorize_console = os.isatty(sys.stdout.fileno()) and os.environ.get('TERM') != 'dumb'
-except Exception:
-    colorize_console = False
+def setup_console() -> bool:
+    try:
+        if platform.system().lower() == 'windows':
+            return os.isatty(sys.stdout.fileno()) and _windows_ansi()
+        return os.isatty(sys.stdout.fileno()) and os.environ.get('TERM') != 'dumb'
+    except Exception:
+        return False
+
+colorize_console = setup_console()
 log_dir = None               # type: T.Optional[str]
 log_file = None              # type: T.Optional[T.TextIO]
 log_fname = 'meson-log.txt'  # type: str


### PR DESCRIPTION
Otherwise there's a high likelihood that some program run by us will mess up the console settings and break ANSI colors. F.ex., running `uname` in the Visual Studio 2019 x86 developer prompt using `run_command()` does this.