### PR TITLE
test cases/python3/3 cython: fix dependency files

### DIFF
--- a/test cases/python3/3 cython/libdir/meson.build
+++ b/test cases/python3/3 cython/libdir/meson.build
@@ -1,6 +1,7 @@
 pyx_c = custom_target('storer_pyx',
   output : 'storer_pyx.c',
   input : 'storer.pyx',
+  depend_files : 'cstorer.pxd',
   command : [cython, '@INPUT@', '-o', '@OUTPUT@'],
 )
 


### PR DESCRIPTION
The Cython generation depends on cstorer.pxd as well, so add that as
dependency.

A detection by cython itself [does not exist](https://github.com/cython/cython/issues/1214).