### PR TITLE
configure_file: Also copy timestamps to avoid useless rebuilds

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -4006,7 +4006,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
                 raise InterpreterException('Exactly one input file must be given in copy mode')
             os.makedirs(os.path.join(self.environment.build_dir, self.subdir), exist_ok=True)
             shutil.copyfile(inputs_abs[0], ofile_abs)
-            shutil.copymode(inputs_abs[0], ofile_abs)
+            shutil.copystat(inputs_abs[0], ofile_abs)
         else:
             # Not reachable
             raise AssertionError

--- a/test cases/common/14 configure file/check_file.py
+++ b/test cases/common/14 configure file/check_file.py
@@ -6,9 +6,15 @@ import sys
 if len(sys.argv) == 2:
     assert(os.path.exists(sys.argv[1]))
 elif len(sys.argv) == 3:
-    f1 = open(sys.argv[1], 'rb').read()
-    f2 = open(sys.argv[2], 'rb').read()
-    if f1 != f2:
+    f1 = sys.argv[1]
+    f2 = sys.argv[2]
+    m1 = os.stat(f1).st_mtime_ns
+    m2 = os.stat(f2).st_mtime_ns
+    # Compare only os.stat()
+    if m1 != m2:
+        raise RuntimeError('mtime of {!r} () != mtime of {!r} ()'.format(f1, m1, f2, m2))
+    import filecmp
+    if not filecmp.cmp(f1, f2):
         raise RuntimeError('{!r} != {!r}'.format(f1, f2))
 else:
     raise AssertionError


### PR DESCRIPTION
If we always copy files over without timestamps, we're forcing a (probably unnecessary) rebuild. Also include a test for this.