### PR TITLE
cmake: Fix crash when no C++ compiler is not installed (fixes #6559)

### DIFF
--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -23,6 +23,7 @@ import re
 import os
 import shutil
 import ctypes
+import textwrap
 
 from .. import mlog, mesonlib
 from ..mesonlib import PerMachine, Popen_safe, version_compare, MachineChoice
@@ -264,9 +265,12 @@ class CMakeExecutor:
             if lang in compilers:
                 exe_list = compilers[lang].get_exelist()
             else:
-                comp_obj = self.environment.compiler_from_language(lang, MachineChoice.BUILD)
-                if comp_obj is not None:
-                    exe_list = comp_obj.get_exelist()
+                try:
+                    comp_obj = self.environment.compiler_from_language(lang, MachineChoice.BUILD)
+                    if comp_obj is not None:
+                        exe_list = comp_obj.get_exelist()
+                except Exception:
+                    pass
 
             if len(exe_list) == 1:
                 return make_abs(exe_list[0], lang), ''
@@ -278,10 +282,7 @@ class CMakeExecutor:
 
         c_comp, c_launcher = choose_compiler('c')
         cxx_comp, cxx_launcher = choose_compiler('cpp')
-        try:
-            fortran_comp, fortran_launcher = choose_compiler('fortran')
-        except Exception:
-            fortran_comp = fortran_launcher = ''
+        fortran_comp, fortran_launcher = choose_compiler('fortran')
 
         # on Windows, choose_compiler returns path with \ as separator - replace by / before writing to CMAKE file
         c_comp = c_comp.replace('\\', '/')
@@ -302,47 +303,50 @@ class CMakeExecutor:
         cxx_comp_file = comp_dir / 'CMakeCXXCompiler.cmake'
         fortran_comp_file = comp_dir / 'CMakeFortranCompiler.cmake'
 
-        if not c_comp_file.is_file():
-            c_comp_file.write_text('''# Fake CMake file to skip the boring and slow stuff
-set(CMAKE_C_COMPILER "{}") # Should be a valid compiler for try_compile, etc.
-set(CMAKE_C_COMPILER_LAUNCHER "{}") # The compiler launcher (if presentt)
-set(CMAKE_C_COMPILER_ID "GNU") # Pretend we have found GCC
-set(CMAKE_COMPILER_IS_GNUCC 1)
-set(CMAKE_C_COMPILER_LOADED 1)
-set(CMAKE_C_COMPILER_WORKS TRUE)
-set(CMAKE_C_ABI_COMPILED TRUE)
-set(CMAKE_C_SOURCE_FILE_EXTENSIONS c;m)
-set(CMAKE_C_IGNORE_EXTENSIONS h;H;o;O;obj;OBJ;def;DEF;rc;RC)
-set(CMAKE_SIZEOF_VOID_P "{}")
-'''.format(c_comp, c_launcher, ctypes.sizeof(ctypes.c_voidp)))
+        if c_comp and not c_comp_file.is_file():
+            c_comp_file.write_text(textwrap.dedent('''\
+                # Fake CMake file to skip the boring and slow stuff
+                set(CMAKE_C_COMPILER "{}") # Should be a valid compiler for try_compile, etc.
+                set(CMAKE_C_COMPILER_LAUNCHER "{}") # The compiler launcher (if presentt)
+                set(CMAKE_C_COMPILER_ID "GNU") # Pretend we have found GCC
+                set(CMAKE_COMPILER_IS_GNUCC 1)
+                set(CMAKE_C_COMPILER_LOADED 1)
+                set(CMAKE_C_COMPILER_WORKS TRUE)
+                set(CMAKE_C_ABI_COMPILED TRUE)
+                set(CMAKE_C_SOURCE_FILE_EXTENSIONS c;m)
+                set(CMAKE_C_IGNORE_EXTENSIONS h;H;o;O;obj;OBJ;def;DEF;rc;RC)
+                set(CMAKE_SIZEOF_VOID_P "{}")
+            '''.format(c_comp, c_launcher, ctypes.sizeof(ctypes.c_voidp))))
 
-        if not cxx_comp_file.is_file():
-            cxx_comp_file.write_text('''# Fake CMake file to skip the boring and slow stuff
-set(CMAKE_CXX_COMPILER "{}") # Should be a valid compiler for try_compile, etc.
-set(CMAKE_CXX_COMPILER_LAUNCHER "{}") # The compiler launcher (if presentt)
-set(CMAKE_CXX_COMPILER_ID "GNU") # Pretend we have found GCC
-set(CMAKE_COMPILER_IS_GNUCXX 1)
-set(CMAKE_CXX_COMPILER_LOADED 1)
-set(CMAKE_CXX_COMPILER_WORKS TRUE)
-set(CMAKE_CXX_ABI_COMPILED TRUE)
-set(CMAKE_CXX_IGNORE_EXTENSIONS inl;h;hpp;HPP;H;o;O;obj;OBJ;def;DEF;rc;RC)
-set(CMAKE_CXX_SOURCE_FILE_EXTENSIONS C;M;c++;cc;cpp;cxx;mm;CPP)
-set(CMAKE_SIZEOF_VOID_P "{}")
-'''.format(cxx_comp, cxx_launcher, ctypes.sizeof(ctypes.c_voidp)))
+        if cxx_comp and not cxx_comp_file.is_file():
+            cxx_comp_file.write_text(textwrap.dedent('''\
+                # Fake CMake file to skip the boring and slow stuff
+                set(CMAKE_CXX_COMPILER "{}") # Should be a valid compiler for try_compile, etc.
+                set(CMAKE_CXX_COMPILER_LAUNCHER "{}") # The compiler launcher (if presentt)
+                set(CMAKE_CXX_COMPILER_ID "GNU") # Pretend we have found GCC
+                set(CMAKE_COMPILER_IS_GNUCXX 1)
+                set(CMAKE_CXX_COMPILER_LOADED 1)
+                set(CMAKE_CXX_COMPILER_WORKS TRUE)
+                set(CMAKE_CXX_ABI_COMPILED TRUE)
+                set(CMAKE_CXX_IGNORE_EXTENSIONS inl;h;hpp;HPP;H;o;O;obj;OBJ;def;DEF;rc;RC)
+                set(CMAKE_CXX_SOURCE_FILE_EXTENSIONS C;M;c++;cc;cpp;cxx;mm;CPP)
+                set(CMAKE_SIZEOF_VOID_P "{}")
+            '''.format(cxx_comp, cxx_launcher, ctypes.sizeof(ctypes.c_voidp))))
 
         if fortran_comp and not fortran_comp_file.is_file():
-            fortran_comp_file.write_text('''# Fake CMake file to skip the boring and slow stuff
-set(CMAKE_Fortran_COMPILER "{}") # Should be a valid compiler for try_compile, etc.
-set(CMAKE_Fortran_COMPILER_LAUNCHER "{}") # The compiler launcher (if presentt)
-set(CMAKE_Fortran_COMPILER_ID "GNU") # Pretend we have found GCC
-set(CMAKE_COMPILER_IS_GNUG77 1)
-set(CMAKE_Fortran_COMPILER_LOADED 1)
-set(CMAKE_Fortran_COMPILER_WORKS TRUE)
-set(CMAKE_Fortran_ABI_COMPILED TRUE)
-set(CMAKE_Fortran_IGNORE_EXTENSIONS h;H;o;O;obj;OBJ;def;DEF;rc;RC)
-set(CMAKE_Fortran_SOURCE_FILE_EXTENSIONS f;F;fpp;FPP;f77;F77;f90;F90;for;For;FOR;f95;F95)
-set(CMAKE_SIZEOF_VOID_P "{}")
-'''.format(fortran_comp, fortran_launcher, ctypes.sizeof(ctypes.c_voidp)))
+            fortran_comp_file.write_text(textwrap.dedent('''\
+                # Fake CMake file to skip the boring and slow stuff
+                set(CMAKE_Fortran_COMPILER "{}") # Should be a valid compiler for try_compile, etc.
+                set(CMAKE_Fortran_COMPILER_LAUNCHER "{}") # The compiler launcher (if presentt)
+                set(CMAKE_Fortran_COMPILER_ID "GNU") # Pretend we have found GCC
+                set(CMAKE_COMPILER_IS_GNUG77 1)
+                set(CMAKE_Fortran_COMPILER_LOADED 1)
+                set(CMAKE_Fortran_COMPILER_WORKS TRUE)
+                set(CMAKE_Fortran_ABI_COMPILED TRUE)
+                set(CMAKE_Fortran_IGNORE_EXTENSIONS h;H;o;O;obj;OBJ;def;DEF;rc;RC)
+                set(CMAKE_Fortran_SOURCE_FILE_EXTENSIONS f;F;fpp;FPP;f77;F77;f90;F90;for;For;FOR;f95;F95)
+                set(CMAKE_SIZEOF_VOID_P "{}")
+            '''.format(fortran_comp, fortran_launcher, ctypes.sizeof(ctypes.c_voidp))))
 
         return self.call(args, build_dir, env)
 


### PR DESCRIPTION
No test, since this would require the absence of a C++ compiler.