### PR TITLE
NINJA environment variable

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -53,6 +53,7 @@ These are return values of the `get_linker_id` (Linker family) method in a compi
 | MESON_DIST_ROOT     | Points to the root of the staging directory, only set when running `dist` scripts |
 | MESON_SOURCE_ROOT   | Absolute path to the source dir |
 | MESON_SUBDIR        | Current subdirectory, only set for `run_command` |
+| NINJA               | Absolute path to ninja executable |
 
 ## CPU families
 


### PR DESCRIPTION
When ninja is installed in user environment with `python3 -m pip install ninja`, meson will fail to find ninja binary, even if `PATH` is set.

The reason is that in `environment.py`, the function `detect_ninja_command_and_version` checks the environment variable `NINJA`, not the `PATH`.