### PR TITLE
docs: Update documentation about linker selection

### DIFF
--- a/docs/markdown/Release-notes-for-0.53.0.md
+++ b/docs/markdown/Release-notes-for-0.53.0.md
@@ -74,13 +74,31 @@ flags passed via language flags and hoped things worked out. In meson 0.52.0
 meson started detecting the linker and making intelligent decisions about
 using it. Unfortunately this broke choosing a non-default linker.
 
-Now there is a generic mechanism for doing this, you may use the LD
-environment variable (with normal meson environment variable rules), or add
-the following to a cross or native file:
+Now there is a generic mechanism for doing this. In 0.53.0, you can use the `LD`
+environment variable. **In 0.53.1** this was changed to `<compiler_variable>_LD`,
+such as `CC_LD`, `CXX_LD`, `D_LD`, etc due to regressions. The usual meson
+[environment variable rules](https://mesonbuild.com/Running-Meson.html#environment-variables)
+apply. Alternatively, you can add the following to a cross or native file:
+
+In 0.53.0:
 
 ```ini
 [binaries]
 ld = 'gold'
+```
+
+**In 0.53.1 or newer**:
+
+```ini
+[binaries]
+c = 'gcc'
+c_ld = 'gold'
+```
+
+```ini
+[binaries]
+c = 'clang'
+c_ld = 'lld'
 ```
 
 And meson will select the linker if possible.

--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -31,11 +31,11 @@ native-files and the latter via the cross file only.
 *New in 0.53.0*
 
 Like the compiler, the linker is selected via the `<compiler variable>_LD`
-environment variable, or through the `<compiler entry>ld` entry in a native
+environment variable, or through the `<compiler entry>_ld` entry in a native
 or cross file. You must be aware of whether you're using a compiler that
 invokes the linker itself (most compilers including GCC and Clang) or a
 linker that is invoked directly (when using MSVC or compilers that act like
-it, including Clang-Cl). With the former `cld` or `CC_LD` should be the value
+it, including Clang-Cl). With the former `c_ld` or `CC_LD` should be the value
 to pass to the compiler's special argument (such as `-fuse-ld` with clang and
 gcc), with the latter it should be an executable, such as `lld-link.exe`.
 


### PR DESCRIPTION
We missed this in https://github.com/mesonbuild/meson/pull/6457

@jpakkane we will need to regenerate the website after merging this so that the incorrect documentation in the release notes is fixed: https://mesonbuild.com/Release-notes-for-0-53-0.html#generic-overrider-for-dynamic-linker-selection