### PR TITLE
Add a mechanism for validating meson output in tests

### DIFF
--- a/data/test.schema.json
+++ b/data/test.schema.json
@@ -1,5 +1,6 @@
 {
   "type": "object",
+  "additionalProperties": false,
   "properties": {
     "env": {
       "type": "object",
@@ -98,6 +99,30 @@
         "enum": [
           "libdir",
           "prefix"
+        ]
+      }
+    },
+    "tools": {
+      "type": "object"
+    },
+    "stdout": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "line": {
+            "type": "string"
+          },
+          "match": {
+            "type": "string",
+            "enum": [
+              "literal",
+              "re"
+            ]
+          }
+        },
+        "required": [
+          "line"
         ]
       }
     }

--- a/docs/markdown/Contributing.md
+++ b/docs/markdown/Contributing.md
@@ -334,6 +334,27 @@ If a tool is specified, it has to be present in the environment, and the version
 requirement must be fulfilled match. Otherwise, the entire test is skipped
 (including every element in the test matrix).
 
+#### stdout
+
+The `stdout` key contains a list of dicts, describing the expected stdout.
+
+Each dict contains the following keys:
+
+- `line`
+- `match` (optional)
+
+Each item in the list is matched, in order, against the remaining actual stdout
+lines, after any previous matches. If the actual stdout is exhausted before
+every item in the list is matched, the expected output has not been seen, and
+the test has failed.
+
+The `match` element of the dict determines how the `line` element is matched:
+
+| Type      | Description             |
+| --------  | ----------------------- |
+| `literal` | Literal match (default) |
+| `re`      | regex match             |
+
 ### Skipping integration tests
 
 Meson uses several continuous integration testing systems that have slightly

--- a/docs/markdown/Contributing.md
+++ b/docs/markdown/Contributing.md
@@ -329,10 +329,10 @@ Currently supported values are:
 
 #### tools
 
-This section specifies a list of tool requirements in a simple key-value format.
+This section specifies a dict of tool requirements in a simple key-value format.
 If a tool is specified, it has to be present in the environment, and the version
-requirement must be fulfilled match. Otherwise, the entire test is skipped
-(including every element in the test matrix).
+requirement must be fulfilled. Otherwise, the entire test is skipped (including
+every element in the test matrix).
 
 #### stdout
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -531,6 +531,9 @@ class BuildTarget(Target):
         repr_str = "<{0} {1}: {2}>"
         return repr_str.format(self.__class__.__name__, self.get_id(), self.filename)
 
+    def __str__(self):
+        return "{}".format(self.name)
+
     def validate_install(self, environment):
         if self.for_machine is MachineChoice.BUILD and self.need_install:
             if environment.is_cross_build():
@@ -1104,7 +1107,7 @@ You probably should put it in link_with instead.''')
             if not isinstance(t, (Target, CustomTargetIndex)):
                 raise InvalidArguments('{!r} is not a target.'.format(t))
             if not t.is_linkable_target():
-                raise InvalidArguments('Link target {!r} is not linkable.'.format(t))
+                raise InvalidArguments("Link target '{!s}' is not linkable.".format(t))
             if isinstance(self, SharedLibrary) and isinstance(t, StaticLibrary) and not t.pic:
                 msg = "Can't link non-PIC static library {!r} into shared library {!r}. ".format(t.name, self.name)
                 msg += "Use the 'pic' option to static_library to build with PIC."

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -490,7 +490,7 @@ class CoreData:
             # commonpath will always return a path in the native format, so we
             # must use pathlib.PurePath to do the same conversion before
             # comparing.
-            msg = ('The value of the {!r} option is {!r} which must be a '
+            msg = ('The value of the {!r} option is \'{!s}\' which must be a '
                    'subdir of the prefix {!r}.\nNote that if you pass a '
                    'relative path, it is assumed to be a subdir of prefix.')
             # os.path.commonpath doesn't understand case-insensitive filesystems,

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -4220,8 +4220,9 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
 
         for a in incdir_strings:
             if a.startswith(src_root):
-                raise InvalidArguments('''Tried to form an absolute path to a source dir. You should not do that but use
-relative paths instead.
+                raise InvalidArguments('Tried to form an absolute path to a source dir. '
+                                       'You should not do that but use relative paths instead.'
+                                       '''
 
 To get include path to any directory relative to the current dir do
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3117,6 +3117,12 @@ external dependencies (including libraries) must go to "dependencies".''')
         return should
 
     def add_languages_for(self, args, required, for_machine: MachineChoice):
+        langs = set(self.coredata.compilers[for_machine].keys())
+        langs.update(args)
+        if 'vala' in langs:
+            if 'c' not in langs:
+                raise InterpreterException('Compiling Vala requires C. Add C to your project languages and rerun Meson.')
+
         success = True
         for lang in sorted(args, key=compilers.sort_clink):
             lang = lang.lower()
@@ -3153,11 +3159,6 @@ external dependencies (including libraries) must go to "dependencies".''')
                 logger_fun(comp.get_display_language(), 'linker for the', machine_name, 'machine:',
                            mlog.bold(' '.join(comp.linker.get_exelist())), comp.linker.id, comp.linker.version)
             self.build.ensure_static_linker(comp)
-
-        langs = self.coredata.compilers[for_machine].keys()
-        if 'vala' in langs:
-            if 'c' not in langs:
-                raise InterpreterException('Compiling Vala requires C. Add C to your project languages and rerun Meson.')
 
         return success
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3897,7 +3897,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         absname = os.path.join(self.environment.get_source_dir(), buildfilename)
         if not os.path.isfile(absname):
             self.subdir = prev_subdir
-            raise InterpreterException('Non-existent build file {!r}'.format(buildfilename))
+            raise InterpreterException("Non-existent build file '{!s}'".format(buildfilename))
         with open(absname, encoding='utf8') as f:
             code = f.read()
         assert(isinstance(code, str))
@@ -3945,7 +3945,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
             elif isinstance(s, str):
                 source_strings.append(s)
             else:
-                raise InvalidArguments('Argument {!r} must be string or file.'.format(s))
+                raise InvalidArguments('Argument must be string or file.')
         sources += self.source_strings_to_files(source_strings)
         install_dir = kwargs.get('install_dir', None)
         if not isinstance(install_dir, (str, type(None))):

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -341,19 +341,19 @@ def log_text_file(logfile, testdir, stdo, stde):
 
 
 def bold(text):
-    return mlog.bold(text).get_text(mlog.colorize_console)
+    return mlog.bold(text).get_text(mlog.colorize_console())
 
 
 def green(text):
-    return mlog.green(text).get_text(mlog.colorize_console)
+    return mlog.green(text).get_text(mlog.colorize_console())
 
 
 def red(text):
-    return mlog.red(text).get_text(mlog.colorize_console)
+    return mlog.red(text).get_text(mlog.colorize_console())
 
 
 def yellow(text):
-    return mlog.yellow(text).get_text(mlog.colorize_console)
+    return mlog.yellow(text).get_text(mlog.colorize_console())
 
 
 def _run_ci_include(args: T.List[str]) -> str:

--- a/run_tests.py
+++ b/run_tests.py
@@ -303,7 +303,7 @@ def run_configure(commandlist, env=None):
     return run_configure_inprocess(commandlist, env=env)
 
 def print_system_info():
-    print(mlog.bold('System information.').get_text(mlog.colorize_console))
+    print(mlog.bold('System information.').get_text(mlog.colorize_console()))
     print('Architecture:', platform.architecture())
     print('Machine:', platform.machine())
     print('Platform:', platform.system())
@@ -377,7 +377,7 @@ def main():
                 print(flush=True)
                 returncode = 0
             else:
-                print(mlog.bold('Running unittests.').get_text(mlog.colorize_console))
+                print(mlog.bold('Running unittests.').get_text(mlog.colorize_console()))
                 print(flush=True)
                 cmd = mesonlib.python_command + ['run_unittests.py', '-v']
                 if options.failfast:
@@ -390,7 +390,7 @@ def main():
         else:
             cross_test_args = mesonlib.python_command + ['run_cross_test.py']
             for cf in options.cross:
-                print(mlog.bold('Running {} cross tests.'.format(cf)).get_text(mlog.colorize_console))
+                print(mlog.bold('Running {} cross tests.'.format(cf)).get_text(mlog.colorize_console()))
                 print(flush=True)
                 cmd = cross_test_args + ['cross/' + cf]
                 if options.failfast:

--- a/test cases/failing/1 project not first/test.json
+++ b/test cases/failing/1 project not first/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "ERROR: First statement must be a call to project"
+    }
+  ]
+}

--- a/test cases/failing/10 out of bounds/test.json
+++ b/test cases/failing/10 out of bounds/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/10 out of bounds/meson.build:4:0: ERROR: Index 0 out of bounds of array of size 0."
+    }
+  ]
+}

--- a/test cases/failing/11 object arithmetic/test.json
+++ b/test cases/failing/11 object arithmetic/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+      "match": "re",
+      "line": "test cases/failing/11 object arithmetic/meson\\.build:3:0: ERROR: Invalid use of addition: .*"
+    }
+  ]
+}

--- a/test cases/failing/12 string arithmetic/test.json
+++ b/test cases/failing/12 string arithmetic/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+      "match": "re",
+      "line": "test cases/failing/12 string arithmetic/meson\\.build:3:0: ERROR: Invalid use of addition: .*"
+    }
+  ]
+}

--- a/test cases/failing/13 array arithmetic/test.json
+++ b/test cases/failing/13 array arithmetic/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/13 array arithmetic/meson.build:3:0: ERROR: Multiplication works only with integers."
+    }
+  ]
+}

--- a/test cases/failing/14 invalid option name/test.json
+++ b/test cases/failing/14 invalid option name/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/14 invalid option name/meson_options.txt:1:0: ERROR: Option names can only contain letters, numbers or dashes."
+    }
+  ]
+}

--- a/test cases/failing/15 kwarg before arg/test.json
+++ b/test cases/failing/15 kwarg before arg/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/15 kwarg before arg/meson.build:3:0: ERROR: All keyword arguments must be after positional arguments."
+    }
+  ]
+}

--- a/test cases/failing/16 extract from subproject/test.json
+++ b/test cases/failing/16 extract from subproject/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/16 extract from subproject/meson.build:6:0: ERROR: Tried to extract objects from a subproject target."
+    }
+  ]
+}

--- a/test cases/failing/17 same target/test.json
+++ b/test cases/failing/17 same target/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/17 same target/meson.build:4:0: ERROR: Tried to create target \"foo\", but a target of that name already exists."
+    }
+  ]
+}

--- a/test cases/failing/18 wrong plusassign/test.json
+++ b/test cases/failing/18 wrong plusassign/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/18 wrong plusassign/meson.build:3:0: ERROR: Plusassignment target must be an id."
+    }
+  ]
+}

--- a/test cases/failing/19 target clash/meson.build
+++ b/test cases/failing/19 target clash/meson.build
@@ -8,7 +8,7 @@ project('clash', 'c')
 # output location is redirected.
 
 if host_machine.system() == 'windows' or host_machine.system() == 'cygwin'
-  error('This is expected.')
+  error('MESON_SKIP_TEST test only works on platforms where executables have no suffix.')
 endif
 
 executable('clash', 'clash.c')

--- a/test cases/failing/19 target clash/test.json
+++ b/test cases/failing/19 target clash/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "ERROR: Multiple producers for Ninja target \"clash\". Please rename your targets."
+    }
+  ]
+}

--- a/test cases/failing/2 missing file/test.json
+++ b/test cases/failing/2 missing file/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/2 missing file/meson.build:3:0: ERROR: File missing.c does not exist."
+    }
+  ]
+}

--- a/test cases/failing/20 version/test.json
+++ b/test cases/failing/20 version/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+      "match": "re",
+      "line": "test cases/failing/20 version/meson\\.build:1:0: ERROR: Meson version is .* but project requires >100\\.0\\.0"
+    }
+  ]
+}

--- a/test cases/failing/21 subver/test.json
+++ b/test cases/failing/21 subver/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/21 subver/meson.build:3:0: ERROR: Subproject foo version is 1.0.0 but >1.0.0 required."
+    }
+  ]
+}

--- a/test cases/failing/22 assert/test.json
+++ b/test cases/failing/22 assert/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/22 assert/meson.build:3:0: ERROR: Assert failed: I am fail."
+    }
+  ]
+}

--- a/test cases/failing/23 rel testdir/test.json
+++ b/test cases/failing/23 rel testdir/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/23 rel testdir/meson.build:4:0: ERROR: Workdir keyword argument must be an absolute path."
+    }
+  ]
+}

--- a/test cases/failing/24 int conversion/test.json
+++ b/test cases/failing/24 int conversion/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/24 int conversion/meson.build:3:13: ERROR: String 'notanumber' cannot be converted to int"
+    }
+  ]
+}

--- a/test cases/failing/25 badlang/test.json
+++ b/test cases/failing/25 badlang/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/25 badlang/meson.build:3:0: ERROR: Tried to use unknown language \"nonexisting\"."
+    }
+  ]
+}

--- a/test cases/failing/26 output subdir/test.json
+++ b/test cases/failing/26 output subdir/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/26 output subdir/meson.build:3:0: ERROR: Output file name must not contain a subdirectory."
+    }
+  ]
+}

--- a/test cases/failing/27 noprog use/test.json
+++ b/test cases/failing/27 noprog use/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/27 noprog use/meson.build:5:0: ERROR: Tried to use not-found external program in \"command\""
+    }
+  ]
+}

--- a/test cases/failing/28 no crossprop/test.json
+++ b/test cases/failing/28 no crossprop/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/28 no crossprop/meson.build:3:0: ERROR: Unknown cross property: nonexisting."
+    }
+  ]
+}

--- a/test cases/failing/29 nested ternary/test.json
+++ b/test cases/failing/29 nested ternary/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/29 nested ternary/meson.build:3:12: ERROR: Nested ternary operators are not allowed."
+    }
+  ]
+}

--- a/test cases/failing/3 missing subdir/test.json
+++ b/test cases/failing/3 missing subdir/test.json
@@ -1,0 +1,9 @@
+{
+  "stdout": [
+    {
+        "comment": "'missing/meson.build' gets transformed with os.path.sep separators",
+        "match": "re",
+        "line": "test cases/failing/3 missing subdir/meson\\.build:3:0: ERROR: Non\\-existent build file 'missing[\\\\/]meson\\.build'"
+    }
+  ]
+}

--- a/test cases/failing/30 invalid man extension/test.json
+++ b/test cases/failing/30 invalid man extension/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/30 invalid man extension/meson.build:2:0: ERROR: Man file must have a file extension of a number between 1 and 8"
+    }
+  ]
+}

--- a/test cases/failing/31 no man extension/test.json
+++ b/test cases/failing/31 no man extension/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/31 no man extension/meson.build:2:0: ERROR: Man file must have a file extension of a number between 1 and 8"
+    }
+  ]
+}

--- a/test cases/failing/32 exe static shared/meson.build
+++ b/test cases/failing/32 exe static shared/meson.build
@@ -2,7 +2,7 @@ project('statchain', 'c')
 
 host_system = host_machine.system()
 if host_system == 'windows' or host_system == 'darwin'
-  error('Test only fails on Linux and BSD')
+  error('MESON_SKIP_TEST test only fails on Linux and BSD')
 endif
 
 statlib = static_library('stat', 'stat.c', pic : false)

--- a/test cases/failing/32 exe static shared/test.json
+++ b/test cases/failing/32 exe static shared/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/32 exe static shared/meson.build:9:0: ERROR: Can't link non-PIC static library 'stat' into shared library 'shr2'. Use the 'pic' option to static_library to build with PIC."
+    }
+  ]
+}

--- a/test cases/failing/33 non-root subproject/test.json
+++ b/test cases/failing/33 non-root subproject/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/33 non-root subproject/some/meson.build:1:0: ERROR: Subproject directory not found and someproj.wrap file not found"
+    }
+  ]
+}

--- a/test cases/failing/34 dependency not-required then required/test.json
+++ b/test cases/failing/34 dependency not-required then required/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+      "match": "re",
+      "line": "test cases/failing/34 dependency not\\-required then required/meson\\.build:4:0: ERROR: Dependency \"foo\\-bar\\-xyz\\-12\\.3\" not found, tried .*"
+    }
+  ]
+}

--- a/test cases/failing/35 project argument after target/test.json
+++ b/test cases/failing/35 project argument after target/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/35 project argument after target/meson.build:7:0: ERROR: Tried to use 'add_project_arguments' after a build target has been declared."
+    }
+  ]
+}

--- a/test cases/failing/36 pkgconfig dependency impossible conditions/meson.build
+++ b/test cases/failing/36 pkgconfig dependency impossible conditions/meson.build
@@ -1,3 +1,7 @@
 project('impossible-dep-test', 'c', version : '1.0')
 
+if not dependency('zlib', required: false).found()
+  error('MESON_SKIP_TEST test requires zlib')
+endif
+
 dependency('zlib', version : ['>=1.0', '<1.0'])

--- a/test cases/failing/37 has function external dependency/test.json
+++ b/test cases/failing/37 has function external dependency/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/37 has function external dependency/meson.build:8:3: ERROR: Dependencies must be external dependencies"
+    }
+  ]
+}

--- a/test cases/failing/38 libdir must be inside prefix/test.json
+++ b/test cases/failing/38 libdir must be inside prefix/test.json
@@ -1,3 +1,10 @@
 {
-  "do_not_set_opts": ["libdir"]
+  "do_not_set_opts": [
+    "libdir"
+  ],
+  "stdout": [
+    {
+      "line": "test cases/failing/38 libdir must be inside prefix/meson.build:1:0: ERROR: The value of the 'libdir' option is '/opt/lib' which must be a subdir of the prefix '/usr'."
+    }
+  ]
 }

--- a/test cases/failing/39 prefix absolute/test.json
+++ b/test cases/failing/39 prefix absolute/test.json
@@ -1,3 +1,11 @@
 {
-  "do_not_set_opts": ["prefix"]
+  "do_not_set_opts": [
+    "prefix"
+  ],
+  "stdout": [
+    {
+      "comment": "literal 'some/path/notabs' appears in output, irrespective of os.path.sep, as that's the prefix",
+      "line": "test cases/failing/39 prefix absolute/meson.build:1:0: ERROR: prefix value 'some/path/notabs' must be an absolute path"
+    }
+  ]
 }

--- a/test cases/failing/4 missing meson.build/test.json
+++ b/test cases/failing/4 missing meson.build/test.json
@@ -1,0 +1,9 @@
+{
+  "stdout": [
+    {
+      "match": "re",
+      "comment": "'subdir/meson.build' gets transformed with os.path.sep separators",
+      "line": "test cases/failing/4 missing meson\\.build/meson\\.build:3:0: ERROR: Non\\-existent build file 'subdir[\\\\/]meson\\.build'"
+    }
+  ]
+}

--- a/test cases/failing/40 kwarg assign/test.json
+++ b/test cases/failing/40 kwarg assign/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/40 kwarg assign/meson.build:3:0: ERROR: Tried to assign values inside an argument list."
+    }
+  ]
+}

--- a/test cases/failing/41 custom target plainname many inputs/test.json
+++ b/test cases/failing/41 custom target plainname many inputs/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/41 custom target plainname many inputs/meson.build:5:0: ERROR: Output cannot contain @PLAINNAME@ or @BASENAME@ when there is more than one input (we can't know which to use)"
+    }
+  ]
+}

--- a/test cases/failing/42 custom target outputs not matching install_dirs/meson.build
+++ b/test cases/failing/42 custom target outputs not matching install_dirs/meson.build
@@ -3,7 +3,7 @@ project('outputs not matching install_dirs', 'c')
 gen = find_program('generator.py')
 
 if meson.backend() != 'ninja'
-  error('Failing manually, test is only for the ninja backend')
+  error('MESON_SKIP_TEST test is only for the ninja backend')
 endif
 
 custom_target('too-few-install-dirs',

--- a/test cases/failing/42 custom target outputs not matching install_dirs/test.json
+++ b/test cases/failing/42 custom target outputs not matching install_dirs/test.json
@@ -1,10 +1,33 @@
 {
   "installed": [
-    {"type": "file", "file": "usr/include/diff.h"},
-    {"type": "file", "file": "usr/include/first.h"},
-    {"type": "file", "file": "usr/bin/diff.sh"},
-    {"type": "file", "file": "usr/bin/second.sh"},
-    {"type": "file", "file": "opt/same.h"},
-    {"type": "file", "file": "opt/same.sh"}
+    {
+      "type": "file",
+      "file": "usr/include/diff.h"
+    },
+    {
+      "type": "file",
+      "file": "usr/include/first.h"
+    },
+    {
+      "type": "file",
+      "file": "usr/bin/diff.sh"
+    },
+    {
+      "type": "file",
+      "file": "usr/bin/second.sh"
+    },
+    {
+      "type": "file",
+      "file": "opt/same.h"
+    },
+    {
+      "type": "file",
+      "file": "opt/same.sh"
+    }
+  ],
+  "stdout": [
+    {
+      "line": "ERROR: Target 'too-few-install-dirs' has 3 outputs: ['toofew.h', 'toofew.c', 'toofew.sh'], but only 2 \"install_dir\"s were found."
+    }
   ]
 }

--- a/test cases/failing/43 project name colon/test.json
+++ b/test cases/failing/43 project name colon/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/43 project name colon/meson.build:1:0: ERROR: Project name 'name with :' must not contain ':'"
+    }
+  ]
+}

--- a/test cases/failing/44 abs subdir/test.json
+++ b/test cases/failing/44 abs subdir/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/44 abs subdir/meson.build:5:0: ERROR: Subdir argument must be a relative path."
+    }
+  ]
+}

--- a/test cases/failing/45 abspath to srcdir/test.json
+++ b/test cases/failing/45 abspath to srcdir/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/45 abspath to srcdir/meson.build:3:0: ERROR: Tried to form an absolute path to a source dir. You should not do that but use relative paths instead."
+    }
+  ]
+}

--- a/test cases/failing/46 pkgconfig variables reserved/test.json
+++ b/test cases/failing/46 pkgconfig variables reserved/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/46 pkgconfig variables reserved/meson.build:8:5: ERROR: Variable \"prefix\" is reserved"
+    }
+  ]
+}

--- a/test cases/failing/47 pkgconfig variables zero length/test.json
+++ b/test cases/failing/47 pkgconfig variables zero length/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/47 pkgconfig variables zero length/meson.build:8:5: ERROR: Invalid variable \"=value\". Variables must be in 'name=value' format"
+    }
+  ]
+}

--- a/test cases/failing/48 pkgconfig variables zero length value/test.json
+++ b/test cases/failing/48 pkgconfig variables zero length value/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/48 pkgconfig variables zero length value/meson.build:8:5: ERROR: Invalid variable \"key=\". Variables must be in 'name=value' format"
+    }
+  ]
+}

--- a/test cases/failing/49 pkgconfig variables not key value/test.json
+++ b/test cases/failing/49 pkgconfig variables not key value/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/49 pkgconfig variables not key value/meson.build:8:5: ERROR: Invalid variable \"this_should_be_key_value\". Variables must be in 'name=value' format"
+    }
+  ]
+}

--- a/test cases/failing/5 misplaced option/test.json
+++ b/test cases/failing/5 misplaced option/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/5 misplaced option/meson.build:3:0: ERROR: Tried to call option() in build description file. All options must be in the option file."
+    }
+  ]
+}

--- a/test cases/failing/50 executable comparison/test.json
+++ b/test cases/failing/50 executable comparison/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/50 executable comparison/meson.build:6:0: ERROR: exe1 can only be compared for equality."
+    }
+  ]
+}

--- a/test cases/failing/51 inconsistent comparison/test.json
+++ b/test cases/failing/51 inconsistent comparison/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/51 inconsistent comparison/meson.build:5:0: ERROR: Values of different types (list, str) cannot be compared using <."
+    }
+  ]
+}

--- a/test cases/failing/52 slashname/test.json
+++ b/test cases/failing/52 slashname/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/52 slashname/meson.build:11:0: ERROR: Problem encountered: Re-enable me once slash in name is finally prohibited."
+    }
+  ]
+}

--- a/test cases/failing/53 reserved meson prefix/test.json
+++ b/test cases/failing/53 reserved meson prefix/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/53 reserved meson prefix/meson.build:3:0: ERROR: The \"meson-\" prefix is reserved and cannot be used for top-level subdir()."
+    }
+  ]
+}

--- a/test cases/failing/54 wrong shared crate type/meson.build
+++ b/test cases/failing/54 wrong shared crate type/meson.build
@@ -1,3 +1,7 @@
-project('test', 'rust')
+project('test')
+
+if not add_languages('rust', required: false)
+  error('MESON_SKIP_TEST test requires rust compiler')
+endif
 
 shared_library('test', 'foo.rs', rust_crate_type : 'staticlib')

--- a/test cases/failing/54 wrong shared crate type/test.json
+++ b/test cases/failing/54 wrong shared crate type/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/54 wrong shared crate type/meson.build:7:0: ERROR: Crate type \"staticlib\" invalid for dynamic libraries; must be \"dylib\" or \"cdylib\""
+    }
+  ]
+}

--- a/test cases/failing/55 wrong static crate type/meson.build
+++ b/test cases/failing/55 wrong static crate type/meson.build
@@ -1,3 +1,7 @@
-project('test', 'rust')
+project('test')
+
+if not add_languages('rust', required: false)
+  error('MESON_SKIP_TEST test requires rust compiler')
+endif
 
 static_library('test', 'foo.rs', rust_crate_type : 'cdylib')

--- a/test cases/failing/55 wrong static crate type/test.json
+++ b/test cases/failing/55 wrong static crate type/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/55 wrong static crate type/meson.build:7:0: ERROR: Crate type \"cdylib\" invalid for static libraries; must be \"rlib\" or \"staticlib\""
+    }
+  ]
+}

--- a/test cases/failing/56 or on new line/test.json
+++ b/test cases/failing/56 or on new line/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/56 or on new line/meson.build:4:8: ERROR: Invalid or clause."
+    }
+  ]
+}

--- a/test cases/failing/57 kwarg in module/test.json
+++ b/test cases/failing/57 kwarg in module/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/57 kwarg in module/meson.build:3:0: ERROR: Function does not take keyword arguments."
+    }
+  ]
+}

--- a/test cases/failing/58 link with executable/test.json
+++ b/test cases/failing/58 link with executable/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/58 link with executable/meson.build:4:0: ERROR: Link target 'prog' is not linkable."
+    }
+  ]
+}

--- a/test cases/failing/59 assign custom target index/test.json
+++ b/test cases/failing/59 assign custom target index/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/59 assign custom target index/meson.build:24:0: ERROR: Assignment target must be an id."
+    }
+  ]
+}

--- a/test cases/failing/6 missing incdir/test.json
+++ b/test cases/failing/6 missing incdir/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/6 missing incdir/meson.build:3:0: ERROR: Include dir nosuchdir does not exist."
+    }
+  ]
+}

--- a/test cases/failing/60 getoption prefix/test.json
+++ b/test cases/failing/60 getoption prefix/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/60 getoption prefix/meson.build:5:0: ERROR: Having a colon in option name is forbidden, projects are not allowed to directly access options of other subprojects."
+    }
+  ]
+}

--- a/test cases/failing/61 bad option argument/test.json
+++ b/test cases/failing/61 bad option argument/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/61 bad option argument/meson_options.txt:1:0: ERROR: Invalid kwargs for option \"name\": \"vaule\""
+    }
+  ]
+}

--- a/test cases/failing/62 subproj filegrab/test.json
+++ b/test cases/failing/62 subproj filegrab/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/62 subproj filegrab/subprojects/a/meson.build:3:0: ERROR: Sandbox violation: Tried to grab file prog.c from a different subproject."
+    }
+  ]
+}

--- a/test cases/failing/63 grab subproj/test.json
+++ b/test cases/failing/63 grab subproj/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/63 grab subproj/meson.build:7:0: ERROR: Sandbox violation: Tried to grab file sub.c from a different subproject."
+    }
+  ]
+}

--- a/test cases/failing/64 grab sibling/test.json
+++ b/test cases/failing/64 grab sibling/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/64 grab sibling/subprojects/a/meson.build:3:0: ERROR: Sandbox violation: Tried to grab file sneaky.c from a different subproject."
+    }
+  ]
+}

--- a/test cases/failing/65 string as link target/test.json
+++ b/test cases/failing/65 string as link target/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/65 string as link target/meson.build:2:0: ERROR: '' is not a target."
+    }
+  ]
+}

--- a/test cases/failing/66 dependency not-found and required/test.json
+++ b/test cases/failing/66 dependency not-found and required/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/66 dependency not-found and required/meson.build:2:0: ERROR: Dependency is both required and not-found"
+    }
+  ]
+}

--- a/test cases/failing/68 wrong boost module/meson.build
+++ b/test cases/failing/68 wrong boost module/meson.build
@@ -1,5 +1,9 @@
 project('boosttest', 'cpp',
   default_options : ['cpp_std=c++11'])
 
+if not dependency('boost', required: false).found()
+  error('MESON_SKIP_TEST test requires boost')
+endif
+
 # abc doesn't exist
 linkdep = dependency('boost', modules : ['thread', 'system', 'test', 'abc'])

--- a/test cases/failing/68 wrong boost module/test.json
+++ b/test cases/failing/68 wrong boost module/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/68 wrong boost module/meson.build:9:0: ERROR: Dependency \"boost\" not found"
+    }
+  ]
+}

--- a/test cases/failing/69 install_data rename bad size/test.json
+++ b/test cases/failing/69 install_data rename bad size/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/69 install_data rename bad size/meson.build:3:0: ERROR: Size of rename argument is different from number of sources"
+    }
+  ]
+}

--- a/test cases/failing/7 go to subproject/test.json
+++ b/test cases/failing/7 go to subproject/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/7 go to subproject/meson.build:3:0: ERROR: Must not go into subprojects dir with subdir(), use subproject() instead."
+    }
+  ]
+}

--- a/test cases/failing/70 skip only subdir/test.json
+++ b/test cases/failing/70 skip only subdir/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/70 skip only subdir/meson.build:8:0: ERROR: File main.cpp does not exist."
+    }
+  ]
+}

--- a/test cases/failing/71 dual override/test.json
+++ b/test cases/failing/71 dual override/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/71 dual override/meson.build:5:6: ERROR: Tried to override executable \"override\" which has already been overridden."
+    }
+  ]
+}

--- a/test cases/failing/72 override used/test.json
+++ b/test cases/failing/72 override used/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/72 override used/meson.build:5:6: ERROR: Tried to override finding of executable \"something.py\" which has already been found."
+    }
+  ]
+}

--- a/test cases/failing/73 run_command unclean exit/test.json
+++ b/test cases/failing/73 run_command unclean exit/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+      "match": "re",
+      "line": "test cases/failing/73 run_command unclean exit/meson\\.build:4:0: ERROR: Command \".*[\\\\/]test cases[\\\\/]failing[\\\\/]73 run_command unclean exit[\\\\/]\\.[\\\\/]returncode\\.py 1\" failed with status 1\\."
+    }
+  ]
+}

--- a/test cases/failing/74 int literal leading zero/test.json
+++ b/test cases/failing/74 int literal leading zero/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+      "comment": "this error message is not very informative",
+      "line": "test cases/failing/74 int literal leading zero/meson.build:5:13: ERROR: Expecting eof got number."
+    }
+  ]
+}

--- a/test cases/failing/75 configuration immutable/test.json
+++ b/test cases/failing/75 configuration immutable/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/75 configuration immutable/meson.build:12:16: ERROR: Can not set values on configuration object that has been used."
+    }
+  ]
+}

--- a/test cases/failing/76 link with shared module on osx/meson.build
+++ b/test cases/failing/76 link with shared module on osx/meson.build
@@ -1,7 +1,7 @@
 project('link with shared module', 'c')
 
 if host_machine.system() != 'darwin'
-  error('Test only fails on OSX')
+  error('MESON_SKIP_TEST test only fails on OSX')
 endif
 
 m = shared_module('mymodule', 'module.c')

--- a/test cases/failing/76 link with shared module on osx/test.json
+++ b/test cases/failing/76 link with shared module on osx/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/76 link with shared module on osx/meson.build:8:0: ERROR: target links against shared modules."
+    }
+  ]
+}

--- a/test cases/failing/77 non ascii in ascii encoded configure file/test.json
+++ b/test cases/failing/77 non ascii in ascii encoded configure file/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+      "match": "re",
+      "line": "test cases/failing/77 non ascii in ascii encoded configure file/meson\\.build:5:0: ERROR: Could not write output file .*[\\\\/]config9\\.h: 'ascii' codec can't encode character '\\\\u0434' in position 17: ordinal not in range\\(128\\)"
+    }
+  ]
+}

--- a/test cases/failing/78 subproj dependency not-found and required/test.json
+++ b/test cases/failing/78 subproj dependency not-found and required/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/78 subproj dependency not-found and required/meson.build:2:0: ERROR: Subproject directory not found and missing.wrap file not found"
+    }
+  ]
+}

--- a/test cases/failing/79 unfound run/test.json
+++ b/test cases/failing/79 unfound run/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/79 unfound run/meson.build:4:0: ERROR: Tried to use non-existing executable 'nonexisting_prog'"
+    }
+  ]
+}

--- a/test cases/failing/8 recursive/test.json
+++ b/test cases/failing/8 recursive/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/8 recursive/subprojects/b/meson.build:3:0: ERROR: Recursive include of subprojects: a => b => a."
+    }
+  ]
+}

--- a/test cases/failing/80 framework dependency with version/meson.build
+++ b/test cases/failing/80 framework dependency with version/meson.build
@@ -1,4 +1,8 @@
 project('framework dependency with version', 'c')
+
+if host_machine.system() != 'darwin'
+  error('MESON_SKIP_TEST test only applicable on darwin')
+endif
+
 # do individual frameworks have a meaningful version to test?  And multiple frameworks might be listed...
-# otherwise we're not on OSX and this will definitely fail
 dep = dependency('appleframeworks', modules: 'foundation', version: '>0')

--- a/test cases/failing/80 framework dependency with version/test.json
+++ b/test cases/failing/80 framework dependency with version/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/80 framework dependency with version/meson.build:8:0: ERROR: Unknown version of dependency 'appleframeworks', but need ['>0']."
+    }
+  ]
+}

--- a/test cases/failing/81 override exe config/test.json
+++ b/test cases/failing/81 override exe config/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/81 override exe config/meson.build:6:0: ERROR: Program 'bar' was overridden with the compiled executable 'foo' and therefore cannot be used during configuration"
+    }
+  ]
+}

--- a/test cases/failing/82 gl dependency with version/meson.build
+++ b/test cases/failing/82 gl dependency with version/meson.build
@@ -2,7 +2,7 @@ project('gl dependency with version', 'c')
 
 host_system = host_machine.system()
 if host_system != 'windows' and host_system != 'darwin'
-  error('Test only fails on Windows and OSX')
+  error('MESON_SKIP_TEST: test only fails on Windows and OSX')
 endif
 
 # gl dependency found via system method doesn't have a meaningful version to check

--- a/test cases/failing/82 gl dependency with version/test.json
+++ b/test cases/failing/82 gl dependency with version/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/82 gl dependency with version/meson.build:9:0: ERROR: Unknown version of dependency 'gl', but need ['>0']."
+    }
+  ]
+}

--- a/test cases/failing/83 threads dependency with version/test.json
+++ b/test cases/failing/83 threads dependency with version/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/83 threads dependency with version/meson.build:3:0: ERROR: Unknown version of dependency 'threads', but need ['>0']."
+    }
+  ]
+}

--- a/test cases/failing/84 gtest dependency with version/meson.build
+++ b/test cases/failing/84 gtest dependency with version/meson.build
@@ -1,3 +1,8 @@
 project('gtest dependency with version', ['c', 'cpp'])
+
+if not dependency('gtest', method: 'system', required: false).found()
+   error('MESON_SKIP_TEST test requires gtest')
+endif
+
 # discovering gtest version is not yet implemented
 dep = dependency('gtest', method: 'system', version: '>0')

--- a/test cases/failing/85 dub libray/meson.build
+++ b/test cases/failing/85 dub libray/meson.build
@@ -1,3 +1,11 @@
-project('dub', 'd')
+project('dub')
+
+if not add_languages('d', required: false)
+  error('MESON_SKIP_TEST test requires D compiler')
+endif
+
+if not find_program('dub', required: false).found()
+  error('MESON_SKIP_TEST test requires dub')
+endif
 
 dependency('dubtestproject', method: 'dub') # Not library (none)

--- a/test cases/failing/85 dub libray/test.json
+++ b/test cases/failing/85 dub libray/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/85 dub libray/meson.build:11:0: ERROR: Dependency \"dubtestproject\" not found"
+    }
+  ]
+}

--- a/test cases/failing/86 dub executable/meson.build
+++ b/test cases/failing/86 dub executable/meson.build
@@ -1,3 +1,11 @@
-project('dub', 'd')
+project('dub')
+
+if not add_languages('d', required: false)
+  error('MESON_SKIP_TEST test requires D compiler')
+endif
+
+if not find_program('dub', required: false).found()
+  error('MESON_SKIP_TEST test requires dub')
+endif
 
 dependency('dubtestproject:test1', method: 'dub') # Not library (executable)

--- a/test cases/failing/86 dub executable/test.json
+++ b/test cases/failing/86 dub executable/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/86 dub executable/meson.build:11:0: ERROR: Dependency \"dubtestproject:test1\" not found"
+    }
+  ]
+}

--- a/test cases/failing/87 dub compiler/meson.build
+++ b/test cases/failing/87 dub compiler/meson.build
@@ -1,9 +1,17 @@
-project('dub', 'd')
+project('dub')
+
+if not add_languages('d', required: false)
+  error('MESON_SKIP_TEST test requires D compiler')
+endif
 
 if meson.get_compiler('d').get_id() == 'dmd'
   if host_machine.system() == 'windows' or host_machine.system() == 'cygwin'
     error('MESON_SKIP_TEST Windows test environment lacks multiple D compilers.')
   endif
+endif
+
+if not find_program('dub', required: false).found()
+  error('MESON_SKIP_TEST test requires dub')
 endif
 
 dependency('dubtestproject:test2', method: 'dub') # Compiler mismatch

--- a/test cases/failing/87 dub compiler/test.json
+++ b/test cases/failing/87 dub compiler/test.json
@@ -2,8 +2,18 @@
   "matrix": {
     "options": {
       "warning_level": [
-        { "val": "1", "skip_on_env": [ "SINGLE_DUB_COMPILER" ] }
+        {
+          "val": "1",
+          "skip_on_env": [
+            "SINGLE_DUB_COMPILER"
+          ]
+        }
       ]
     }
-  }
+  },
+  "stdout": [
+    {
+      "line": "test cases/failing/87 dub compiler/meson.build:17:0: ERROR: Dependency \"dubtestproject:test2\" not found"
+    }
+  ]
 }

--- a/test cases/failing/88 subproj not-found dep/test.json
+++ b/test cases/failing/88 subproj not-found dep/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/88 subproj not-found dep/meson.build:2:0: ERROR: Could not find dependency notfound_dep in subproject somesubproj"
+    }
+  ]
+}

--- a/test cases/failing/89 invalid configure file/test.json
+++ b/test cases/failing/89 invalid configure file/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/89 invalid configure file/meson.build:3:0: ERROR: \"install_dir\" must be specified when \"install\" in a configure_file is true"
+    }
+  ]
+}

--- a/test cases/failing/9 missing extra file/test.json
+++ b/test cases/failing/9 missing extra file/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/9 missing extra file/meson.build:3:0: ERROR: File missing.txt does not exist."
+    }
+  ]
+}

--- a/test cases/failing/90 kwarg dupe/test.json
+++ b/test cases/failing/90 kwarg dupe/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/90 kwarg dupe/meson.build:5:0: ERROR: Entry \"install\" defined both as a keyword argument and in a \"kwarg\" entry."
+    }
+  ]
+}

--- a/test cases/failing/91 missing pch file/test.json
+++ b/test cases/failing/91 missing pch file/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+      "comment": "literal 'pch/prog.h' from meson.build appears in output, irrespective of os.path.sep",
+      "line": "test cases/failing/91 missing pch file/meson.build:2:0: ERROR: File pch/prog.h does not exist."
+    }
+  ]
+}

--- a/test cases/failing/92 pch source different folder/test.json
+++ b/test cases/failing/92 pch source different folder/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/92 pch source different folder/meson.build:4:0: ERROR: PCH files must be stored in the same folder."
+    }
+  ]
+}

--- a/test cases/failing/93 vala without c/test.json
+++ b/test cases/failing/93 vala without c/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/93 vala without c/meson.build:2:0: ERROR: Compiling Vala requires C. Add C to your project languages and rerun Meson."
+    }
+  ]
+}

--- a/test cases/failing/94 unknown config tool/test.json
+++ b/test cases/failing/94 unknown config tool/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/94 unknown config tool/meson.build:2:0: ERROR: Dependency \"no-such-config-tool\" not found"
+    }
+  ]
+}

--- a/test cases/failing/95 custom target install data/test.json
+++ b/test cases/failing/95 custom target install data/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/95 custom target install data/meson.build:11:0: ERROR: Argument must be string or file."
+    }
+  ]
+}

--- a/test cases/failing/96 add dict non string key/test.json
+++ b/test cases/failing/96 add dict non string key/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/96 add dict non string key/meson.build:9:0: ERROR: Key must be a string"
+    }
+  ]
+}

--- a/test cases/failing/97 add dict duplicate keys/test.json
+++ b/test cases/failing/97 add dict duplicate keys/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/97 add dict duplicate keys/meson.build:9:0: ERROR: Duplicate dictionary key: myKey"
+    }
+  ]
+}

--- a/test cases/failing/99 no native prop/test.json
+++ b/test cases/failing/99 no native prop/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/99 no native prop/meson.build:3:0: ERROR: Unknown native property: nonexisting."
+    }
+  ]
+}

--- a/test cases/warning/1 version for string div/test.json
+++ b/test cases/warning/1 version for string div/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+      "comment": "literal '/' appears in output, irrespective of os.path.sep, as that's the operator",
+      "line": "WARNING: Project targeting '>=0.48.0' but tried to use feature introduced in '0.49.0': / with string arguments"
+    }
+  ]
+}

--- a/test cases/warning/2 languages missing native/test.json
+++ b/test cases/warning/2 languages missing native/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/warning/2 languages missing native/meson.build:2: WARNING: add_languages is missing native:, assuming languages are wanted for both host and build."
+    }
+  ]
+}

--- a/tools/dircondenser.py
+++ b/tools/dircondenser.py
@@ -74,6 +74,10 @@ def condense(dirname: str):
             #print('git mv "%s" "%s"' % (old_name, new_name))
             subprocess.check_call(['git', 'mv', old_name, new_name])
             replacements.append((old_name, new_name))
+            # update any appearances of old_name in expected stdout in test.json
+            json = os.path.join(new_name, 'test.json')
+            if os.path.isfile(json):
+                replace_source(json, [(old_name, new_name)])
     os.chdir(curdir)
     replace_source('run_unittests.py', replacements)
     replace_source('run_project_tests.py', replacements)


### PR DESCRIPTION
Add a mechanism for validating meson output in tests.

In particular, this allows checking that `faiiling-meson` and `warning-meson` tests are actually exercising the intended code-paths and failing with the expected messages (_spoiler_: some of them aren't).

There's also some unit tests which just exist to verify the expected output occurs (e.g. `test_warning_location`), which could be moved to use this mechanism.
