### PR TITLE
RFC: Add b_interposable to control interposition

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -112,7 +112,7 @@ platforms or with all compilers:
 | b_staticpic | true          | true, false             | Build static libraries as position independent |
 | b_pie       | false         | true, false             | Build position-independent executables (since 0.49.0)|
 | b_vscrt     | from_buildtype| none, md, mdd, mt, mtd, from_buildtype | VS runtime library to use (since 0.48.0) |
-| b_interposable | false      | true, false             | Make exported dynamic symbols interposable |
+| b_symbolic  | false         | true, false             | Use -Wl,-Bsymbolic-functions when linking |
 
 The value of `b_sanitize` can be one of: `none`, `address`, `thread`,
 `undefined`, `memory`, `address,undefined`.

--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -112,6 +112,7 @@ platforms or with all compilers:
 | b_staticpic | true          | true, false             | Build static libraries as position independent |
 | b_pie       | false         | true, false             | Build position-independent executables (since 0.49.0)|
 | b_vscrt     | from_buildtype| none, md, mdd, mt, mtd, from_buildtype | VS runtime library to use (since 0.48.0) |
+| b_interposable | false      | true, false             | Make exported dynamic symbols interposable |
 
 The value of `b_sanitize` can be one of: `none`, `address`, `thread`,
 `undefined`, `memory`, `address,undefined`.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -261,6 +261,8 @@ base_options = {'b_pch': coredata.UserBooleanOption('Use precompiled headers', T
                 'b_vscrt': coredata.UserComboOption('VS run-time library type to use.',
                                                     ['none', 'md', 'mdd', 'mt', 'mtd', 'from_buildtype'],
                                                     'from_buildtype'),
+                'b_interposable': coredata.UserBooleanOption('Make exported dynamic symbols interposable',
+                                                             False),
                 }
 
 def option_enabled(boptions, options, option):
@@ -276,6 +278,11 @@ def get_base_compile_args(options, compiler):
     try:
         if options['b_lto'].value:
             args.extend(compiler.get_lto_compile_args())
+    except KeyError:
+        pass
+    try:
+        interposable = options['b_interposable'].value
+        args += compiler.get_interposable_compile_args(interposable)
     except KeyError:
         pass
     try:
@@ -325,6 +332,11 @@ def get_base_link_args(options, linker, is_shared_module):
     try:
         if options['b_lto'].value:
             args.extend(linker.get_lto_link_args())
+    except KeyError:
+        pass
+    try:
+        interposable = options['b_interposable'].value
+        args += linker.get_interposable_link_args(interposable)
     except KeyError:
         pass
     try:
@@ -1066,6 +1078,12 @@ class Compiler:
 
     def get_lto_link_args(self) -> T.List[str]:
         return self.linker.get_lto_args()
+
+    def get_interposable_compile_args(self, value: bool) -> T.List[str]:
+        return []
+
+    def get_interposable_link_args(self, value: bool) -> T.List[str]:
+        return self.linker.get_interposable_args(value)
 
     def sanitizer_compile_args(self, value: str) -> T.List[str]:
         return []

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -261,8 +261,7 @@ base_options = {'b_pch': coredata.UserBooleanOption('Use precompiled headers', T
                 'b_vscrt': coredata.UserComboOption('VS run-time library type to use.',
                                                     ['none', 'md', 'mdd', 'mt', 'mtd', 'from_buildtype'],
                                                     'from_buildtype'),
-                'b_interposable': coredata.UserBooleanOption('Make exported dynamic symbols interposable',
-                                                             False),
+                'b_symbolic': coredata.UserBooleanOption('Use -Wl,-Bsymbolic-functions when linking', False),
                 }
 
 def option_enabled(boptions, options, option):
@@ -281,8 +280,8 @@ def get_base_compile_args(options, compiler):
     except KeyError:
         pass
     try:
-        interposable = options['b_interposable'].value
-        args += compiler.get_interposable_compile_args(interposable)
+        if options['b_symbolic'].value:
+            args.extend(compiler.get_symbolic_compile_args())
     except KeyError:
         pass
     try:
@@ -335,8 +334,8 @@ def get_base_link_args(options, linker, is_shared_module):
     except KeyError:
         pass
     try:
-        interposable = options['b_interposable'].value
-        args += linker.get_interposable_link_args(interposable)
+        if options['b_symbolic'].value:
+            args.extend(linker.get_symbolic_link_args())
     except KeyError:
         pass
     try:
@@ -1079,11 +1078,11 @@ class Compiler:
     def get_lto_link_args(self) -> T.List[str]:
         return self.linker.get_lto_args()
 
-    def get_interposable_compile_args(self, value: bool) -> T.List[str]:
+    def get_symbolic_compile_args(self) -> T.List[str]:
         return []
 
-    def get_interposable_link_args(self, value: bool) -> T.List[str]:
-        return self.linker.get_interposable_args(value)
+    def get_symbolic_link_args(self) -> T.List[str]:
+        return self.linker.get_symbolic_args()
 
     def sanitizer_compile_args(self, value: str) -> T.List[str]:
         return []

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -145,7 +145,7 @@ class GnuLikeCompiler(metaclass=abc.ABCMeta):
         if not (self.info.is_windows() or self.info.is_cygwin() or self.info.is_openbsd()):
             self.base_options.append('b_lundef')
         if not self.info.is_windows() or self.info.is_cygwin():
-            self.base_options.append('b_asneeded')
+            self.base_options.extend(['b_asneeded', 'b_interposable'])
         # All GCC-like backends can do assembly
         self.can_compile_suffixes.add('s')
 
@@ -342,6 +342,11 @@ class GnuCompiler(GnuLikeCompiler):
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         return gnu_optimization_args[optimization_level]
+
+    def get_interposable_compile_args(self, value: bool) -> T.List[str]:
+        if value:
+            return []
+        return ['-fno-semantic-interposition']
 
     def get_pch_suffix(self) -> str:
         return 'gch'

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -145,7 +145,7 @@ class GnuLikeCompiler(metaclass=abc.ABCMeta):
         if not (self.info.is_windows() or self.info.is_cygwin() or self.info.is_openbsd()):
             self.base_options.append('b_lundef')
         if not self.info.is_windows() or self.info.is_cygwin():
-            self.base_options.extend(['b_asneeded', 'b_interposable'])
+            self.base_options.extend(['b_asneeded', 'b_symbolic'])
         # All GCC-like backends can do assembly
         self.can_compile_suffixes.add('s')
 
@@ -343,9 +343,7 @@ class GnuCompiler(GnuLikeCompiler):
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         return gnu_optimization_args[optimization_level]
 
-    def get_interposable_compile_args(self, value: bool) -> T.List[str]:
-        if value:
-            return []
+    def get_symbolic_compile_args(self) -> T.List[str]:
         return ['-fno-semantic-interposition']
 
     def get_pch_suffix(self) -> str:

--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -78,7 +78,7 @@ class IntelGnuLikeCompiler(GnuLikeCompiler):
         # name of the output file) which break assumptions meson makes
         self.base_options = ['b_pch', 'b_lundef', 'b_asneeded', 'b_pgo',
                              'b_coverage', 'b_ndebug', 'b_staticpic', 'b_pie',
-                             'b_interposable']
+                             'b_symbolic']
         self.id = 'intel'
         self.lang_header = 'none'
 

--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -77,7 +77,8 @@ class IntelGnuLikeCompiler(GnuLikeCompiler):
         # there is an unfortunate rule for using IPO (you can't control the
         # name of the output file) which break assumptions meson makes
         self.base_options = ['b_pch', 'b_lundef', 'b_asneeded', 'b_pgo',
-                             'b_coverage', 'b_ndebug', 'b_staticpic', 'b_pie']
+                             'b_coverage', 'b_ndebug', 'b_staticpic', 'b_pie',
+                             'b_interposable']
         self.id = 'intel'
         self.lang_header = 'none'
 

--- a/mesonbuild/compilers/mixins/islinker.py
+++ b/mesonbuild/compilers/mixins/islinker.py
@@ -56,6 +56,12 @@ class BasicLinkerIsCompilerMixin:
     def get_lto_link_args(self) -> T.List[str]:
         return []
 
+    def get_interposable_link_args(self, value: bool) -> T.List[str]:
+        if value:
+            m = "Linker {} does not support interposition".format(self.id)
+            raise mesonlib.EnvironmentException(m)
+        return []
+
     def can_linker_accept_rsp(self) -> bool:
         return mesonlib.is_windows()
 

--- a/mesonbuild/compilers/mixins/islinker.py
+++ b/mesonbuild/compilers/mixins/islinker.py
@@ -56,10 +56,7 @@ class BasicLinkerIsCompilerMixin:
     def get_lto_link_args(self) -> T.List[str]:
         return []
 
-    def get_interposable_link_args(self, value: bool) -> T.List[str]:
-        if value:
-            m = "Linker {} does not support interposition".format(self.id)
-            raise mesonlib.EnvironmentException(m)
+    def get_symbolic_link_args(self, value: bool) -> T.List[str]:
         return []
 
     def can_linker_accept_rsp(self) -> bool:

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -330,10 +330,7 @@ class DynamicLinker(metaclass=abc.ABCMeta):
     def get_lto_args(self) -> T.List[str]:
         return []
 
-    def get_interposable_args(self, value: bool) -> T.List[str]:
-        if value:
-            m = "Linker {} does not support interposition".format(self.id)
-            raise mesonlib.EnvironmentException(m)
+    def get_symbolic_args(self) -> T.List[str]:
         return []
 
     def sanitizer_args(self, value: str) -> T.List[str]:
@@ -470,10 +467,8 @@ class GnuLikeDynamicLinkerMixin:
     def get_lto_args(self) -> T.List[str]:
         return ['-flto']
 
-    def get_interposable_args(self, value: bool) -> T.List[str]:
-        if value:
-            return []
-        return self._apply_prefix('-Bsymbolic')
+    def get_symbolic_args(self) -> T.List[str]:
+        return self._apply_prefix('-Bsymbolic-functions')
 
     def sanitizer_args(self, value: str) -> T.List[str]:
         if value == 'none':
@@ -602,11 +597,6 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
     def get_coverage_args(self) -> T.List[str]:
         return ['--coverage']
-
-    def get_interposable_args(self, value: bool) -> T.List[str]:
-        if value:
-            return ['-interposable']
-        return []
 
     def sanitizer_args(self, value: str) -> T.List[str]:
         if value == 'none':

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -330,6 +330,12 @@ class DynamicLinker(metaclass=abc.ABCMeta):
     def get_lto_args(self) -> T.List[str]:
         return []
 
+    def get_interposable_args(self, value: bool) -> T.List[str]:
+        if value:
+            m = "Linker {} does not support interposition".format(self.id)
+            raise mesonlib.EnvironmentException(m)
+        return []
+
     def sanitizer_args(self, value: str) -> T.List[str]:
         return []
 
@@ -464,6 +470,11 @@ class GnuLikeDynamicLinkerMixin:
     def get_lto_args(self) -> T.List[str]:
         return ['-flto']
 
+    def get_interposable_args(self, value: bool) -> T.List[str]:
+        if value:
+            return []
+        return self._apply_prefix('-Bsymbolic')
+
     def sanitizer_args(self, value: str) -> T.List[str]:
         if value == 'none':
             return []
@@ -591,6 +602,11 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
     def get_coverage_args(self) -> T.List[str]:
         return ['--coverage']
+
+    def get_interposable_args(self, value: bool) -> T.List[str]:
+        if value:
+            return ['-interposable']
+        return []
 
     def sanitizer_args(self, value: str) -> T.List[str]:
         if value == 'none':


### PR DESCRIPTION
Disallowing interposition of exported dynamic symbols opens up optimization opportunities and can increase performance. See [issue 3338][1].

Was named `b_symbolic` before I stumbled upon the `-interposable` option in Apple's linker, which makes more sense to me.

Defaults to False (disallow interposition). Current effects:

- False:
  - GnuCompiler: `-fno-semantic-interposition`
  - GnuLikeDynamicLinkerMixin: `-Wl,-Bsymbolic`

- True:
  - AppleDynamicLinker: `-interposable` (untested)

[1]: https://github.com/mesonbuild/meson/issues/3338

I applied this to a package of 0.53.1 for Arch Linux and the testsuite still passes, so that's encouraging.