### PR TITLE
version parsing: match only when version starts with a number

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -388,7 +388,7 @@ class ConfigToolDependency(ExternalDependency):
 
     tools = None
     tool_name = None
-    __strip_version = re.compile(r'^[0-9.]*')
+    __strip_version = re.compile(r'^[0-9][0-9.]+')
 
     def __init__(self, name, environment, kwargs, language: T.Optional[str] = None):
         super().__init__('config-tool', environment, kwargs, language=language)

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1661,8 +1661,8 @@ class DubDependency(ExternalDependency):
             lib_file_name = os.path.basename(default_path)
         module_build_path = os.path.join(module_path, '.dub', 'build')
 
-        # If default_path is a path to lib file and 
-        # directory of lib don't have subdir '.dub/build' 
+        # If default_path is a path to lib file and
+        # directory of lib don't have subdir '.dub/build'
         if not os.path.isdir(module_build_path) and os.path.isfile(default_path):
             if folder_only:
                 return module_path

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -547,7 +547,7 @@ class ExternalProgramHolder(InterpreterObject, ObjectHolder):
             output = res.stdout.strip()
             if not output:
                 output = res.stderr.strip()
-            match = re.search(r'([0-9\.]+)', output)
+            match = re.search(r'([0-9][0-9\.]+)', output)
             if not match:
                 m = 'Could not find a version number in output of {!r}'
                 raise InterpreterException(m.format(raw_cmd))


### PR DESCRIPTION
This leads to better version parsing. An concrete example use case is
llc. When invoking llc with "--version", the output is
```
LLVM (http://llvm.org/):
  LLVM version 9.0.1
  ...
```
The old version parsing recognizes the dot in the first line as version.

This commit also tries to adapt the two regexes to each other.

Reported-by: Björn Fiedler <fiedler@sra.uni-hannover.de>