### PR TITLE
add build option `pkg_config_static` to make dependency() default to static

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -840,7 +840,8 @@ class PkgConfigDependency(ExternalDependency):
     def _set_libs(self):
         env = None
         libcmd = [self.name, '--libs']
-        if self.static:
+        if self.static or \
+           (self.env.properties[self.for_machine].get('pkg_config_static', None) == 'true'):
             libcmd.append('--static')
         # Force pkg-config to output -L fields even if they are system
         # paths so we can do manual searching with cc.find_library() later.


### PR DESCRIPTION
Allow the user to always call pkg-config with --static when choosing to build a project as fully static, to prevent missing library errors when only static dependencies are available.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>