### PR TITLE
modules/python: Do not error out if positional args are passed

### DIFF
--- a/docs/markdown/Python-module.md
+++ b/docs/markdown/Python-module.md
@@ -103,8 +103,9 @@ need to add `dependencies : py_installation.dependency()`, see [][`dependency()`
 python_dependency py_installation.dependency(...)
 ```
 
-This method accepts the same arguments as the standard [dependency] function and
-the following additional keyword arguments:
+This method accepts no positional arguments, and the same keyword arguments as
+the standard [dependency] function. It also supports the following keyword
+argument:
 
 - `embed`: *(since 0.53.0)* If true, meson will try to find a python dependency
   that can be used for embedding python into an application.

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -348,10 +348,14 @@ class PythonInstallation(ExternalProgramHolder):
 
         return self.interpreter.func_shared_module(None, args, kwargs)
 
-    @noPosargs
     @permittedKwargs(permitted_kwargs['dependency'])
     @FeatureNewKwargs('python_installation.dependency', '0.53.0', ['embed'])
     def dependency_method(self, args, kwargs):
+        if args:
+            mlog.warning('python_installation.dependency() does not take any '
+                         'positional arguments. It always returns a Python '
+                         'dependency. This will become an error in the future.',
+                         location=self.interpreter.current_node)
         dep = PythonDependency(self, self.interpreter.environment, kwargs)
         return self.interpreter.holderify(dep)
 


### PR DESCRIPTION
Also update the documentation.

Fixes https://github.com/mesonbuild/meson/issues/6470