### PR TITLE
mdist: Don't delete temporary dist check dirs on failure

### DIFF
--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -177,6 +177,22 @@ def create_dist_hg(dist_name, archives, src_root, bld_root, dist_sub, dist_scrip
         output_names.append(zipname)
     return output_names
 
+def run_dist_steps(meson_command, unpacked_src_dir, builddir, installdir, ninja_bin):
+    if subprocess.call(meson_command + ['--backend=ninja', unpacked_src_dir, builddir]) != 0:
+        print('Running Meson on distribution package failed')
+        return 1
+    if subprocess.call([ninja_bin], cwd=builddir) != 0:
+        print('Compiling the distribution package failed')
+        return 1
+    if subprocess.call([ninja_bin, 'test'], cwd=builddir) != 0:
+        print('Running unit tests on the distribution package failed')
+        return 1
+    myenv = os.environ.copy()
+    myenv['DESTDIR'] = installdir
+    if subprocess.call([ninja_bin, 'install'], cwd=builddir, env=myenv) != 0:
+        print('Installing the distribution package failed')
+        return 1
+    return 0
 
 def check_dist(packagename, meson_command, extra_meson_args, bld_root, privdir):
     print('Testing distribution package %s' % packagename)
@@ -188,35 +204,24 @@ def check_dist(packagename, meson_command, extra_meson_args, bld_root, privdir):
             shutil.rmtree(p)
         os.mkdir(p)
     ninja_bin = detect_ninja()
-    try:
-        shutil.unpack_archive(packagename, unpackdir)
-        unpacked_files = glob(os.path.join(unpackdir, '*'))
-        assert(len(unpacked_files) == 1)
-        unpacked_src_dir = unpacked_files[0]
-        with open(os.path.join(bld_root, 'meson-info', 'intro-buildoptions.json')) as boptions:
-            meson_command += ['-D{name}={value}'.format(**o) for o in json.load(boptions)
-                              if o['name'] not in ['backend', 'install_umask']]
-        meson_command += extra_meson_args
-        if subprocess.call(meson_command + ['--backend=ninja', unpacked_src_dir, builddir]) != 0:
-            print('Running Meson on distribution package failed')
-            return 1
-        if subprocess.call([ninja_bin], cwd=builddir) != 0:
-            print('Compiling the distribution package failed')
-            return 1
-        if subprocess.call([ninja_bin, 'test'], cwd=builddir) != 0:
-            print('Running unit tests on the distribution package failed')
-            return 1
-        myenv = os.environ.copy()
-        myenv['DESTDIR'] = installdir
-        if subprocess.call([ninja_bin, 'install'], cwd=builddir, env=myenv) != 0:
-            print('Installing the distribution package failed')
-            return 1
-    finally:
+    shutil.unpack_archive(packagename, unpackdir)
+    unpacked_files = glob(os.path.join(unpackdir, '*'))
+    assert(len(unpacked_files) == 1)
+    unpacked_src_dir = unpacked_files[0]
+    with open(os.path.join(bld_root, 'meson-info', 'intro-buildoptions.json')) as boptions:
+        meson_command += ['-D{name}={value}'.format(**o) for o in json.load(boptions)
+                          if o['name'] not in ['backend', 'install_umask']]
+    meson_command += extra_meson_args
+
+    ret = run_dist_steps(meson_command, unpacked_src_dir, builddir, installdir, ninja_bin)
+    if ret > 0:
+        print('Dist check build directory was {}'.format(builddir))
+    else:
         shutil.rmtree(unpackdir)
         shutil.rmtree(builddir)
         shutil.rmtree(installdir)
-    print('Distribution package %s tested' % packagename)
-    return 0
+        print('Distribution package %s tested' % packagename)
+    return ret
 
 def determine_archives_to_generate(options):
     result = []

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -201,7 +201,7 @@ def check_dist(packagename, meson_command, extra_meson_args, bld_root, privdir):
     installdir = os.path.join(privdir, 'dist-install')
     for p in (unpackdir, builddir, installdir):
         if os.path.exists(p):
-            shutil.rmtree(p)
+            windows_proof_rmtree(p)
         os.mkdir(p)
     ninja_bin = detect_ninja()
     shutil.unpack_archive(packagename, unpackdir)
@@ -217,9 +217,9 @@ def check_dist(packagename, meson_command, extra_meson_args, bld_root, privdir):
     if ret > 0:
         print('Dist check build directory was {}'.format(builddir))
     else:
-        shutil.rmtree(unpackdir)
-        shutil.rmtree(builddir)
-        shutil.rmtree(installdir)
+        windows_proof_rmtree(unpackdir)
+        windows_proof_rmtree(builddir)
+        windows_proof_rmtree(installdir)
         print('Distribution package %s tested' % packagename)
     return ret
 


### PR DESCRIPTION
commit c90cdb1de238f6860688881256694a6a307ebcec:

```
mdist: Don't delete builddir on dist failure
```
Closes https://github.com/mesonbuild/meson/issues/1976

commit 4b0dae15a8ba679c447d94ff6195e837fa78c1a3:


```
mdist: Use windows_proof_rmtree when deleting
```

CC: @matthiasclasen, this is what you were seeing the other day.