### PR TITLE
Redetect machines when languages change

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2216,7 +2216,9 @@ class Interpreter(InterpreterBase):
         self.build_def_files = [os.path.join(self.subdir, environment.build_filename)]
         if not mock:
             self.parse_project()
+        self._redetect_machines()
 
+    def _redetect_machines(self):
         # Re-initialize machine descriptions. We can do a better job now because we
         # have the compilers needed to gain more knowledge, so wipe out old
         # inference and start over.
@@ -3014,6 +3016,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         success &= self.add_languages_for(args, required, MachineChoice.HOST)
         if not self.coredata.is_cross_build():
             self.coredata.copy_build_options_from_regular_ones()
+        self._redetect_machines()
         return success
 
     def add_languages_for(self, args, required, for_machine: MachineChoice):

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -63,7 +63,7 @@ class BuildStep(Enum):
     validate = 6
 
 
-class TestResult:
+class TestResult(BaseException):
     def __init__(self, cicmds):
         self.msg = ''  # empty msg indicates test success
         self.stdo = ''
@@ -376,6 +376,8 @@ def run_test(test: TestDef, extra_args, compiler, backend, flags, commands, shou
         with AutoDeletedDir(tempfile.mkdtemp(prefix='i ', dir=os.getcwd())) as install_dir:
             try:
                 return _run_test(test, build_dir, install_dir, extra_args, compiler, backend, flags, commands, should_fail)
+            except TestResult as r:
+                return r
             finally:
                 mlog.shutdown() # Close the log file because otherwise Windows wets itself.
 
@@ -417,29 +419,39 @@ def _run_test(test: TestDef, test_build_dir: str, install_dir: str, extra_args, 
         testresult.fail('Generating the build system failed.')
         return testresult
     builddata = build.load(test_build_dir)
-    # Touch the meson.build file to force a regenerate so we can test that
-    # regeneration works before a build is run.
-    ensure_backend_detects_changes(backend)
-    os.utime(str(test.path / 'meson.build'))
-    # Build with subprocess
     dir_args = get_backend_args_for_dir(backend, test_build_dir)
-    build_start = time.time()
-    pc, o, e = Popen_safe(compile_commands + dir_args, cwd=test_build_dir)
-    testresult.add_step(BuildStep.build, o, e, '', time.time() - build_start)
-    if should_fail == 'build':
+
+    # Build with subprocess
+    def build_step():
+        build_start = time.time()
+        pc, o, e = Popen_safe(compile_commands + dir_args, cwd=test_build_dir)
+        testresult.add_step(BuildStep.build, o, e, '', time.time() - build_start)
+        if should_fail == 'build':
+            if pc.returncode != 0:
+                raise testresult
+            testresult.fail('Test that should have failed to build succeeded.')
+            raise testresult
         if pc.returncode != 0:
-            return testresult
-        testresult.fail('Test that should have failed to build succeeded.')
-        return testresult
-    if pc.returncode != 0:
-        testresult.fail('Compiling source code failed.')
-        return testresult
-    # Touch the meson.build file to force a regenerate so we can test that
-    # regeneration works after a build is complete.
-    ensure_backend_detects_changes(backend)
-    os.utime(str(test.path / 'meson.build'))
-    test_start = time.time()
+            testresult.fail('Compiling source code failed.')
+            raise testresult
+
+    # Touch the meson.build file to force a regenerate
+    def force_regenerate():
+        ensure_backend_detects_changes(backend)
+        os.utime(str(test.path / 'meson.build'))
+
+    # just test building
+    build_step()
+
+    # test that regeneration works for build step
+    force_regenerate()
+    build_step()  # TBD: assert nothing gets built after the regenerate?
+
+    # test that regeneration works for test step
+    force_regenerate()
+
     # Test in-process
+    test_start = time.time()
     (returncode, tstdo, tstde, test_log) = run_test_inprocess(test_build_dir)
     testresult.add_step(BuildStep.test, tstdo, tstde, test_log, time.time() - test_start)
     if should_fail == 'test':
@@ -450,6 +462,7 @@ def _run_test(test: TestDef, test_build_dir: str, install_dir: str, extra_args, 
     if returncode != 0:
         testresult.fail('Running unit tests failed.')
         return testresult
+
     # Do installation, if the backend supports it
     if install_commands:
         env = os.environ.copy()

--- a/test cases/common/123 cpp and asm/meson.build
+++ b/test cases/common/123 cpp and asm/meson.build
@@ -1,4 +1,5 @@
-project('c++ and assembly test', 'cpp')
+project('c++ and assembly test')
+add_languages('cpp')
 
 cpp = meson.get_compiler('cpp')
 cpu = host_machine.cpu_family()

--- a/test cases/common/127 custom target directory install/docgen.py
+++ b/test cases/common/127 custom target directory install/docgen.py
@@ -5,7 +5,10 @@ import sys
 
 out = sys.argv[1]
 
-os.mkdir(out)
+try:
+    os.mkdir(out)
+except FileExistsError:
+    pass
 
 for name in ('a', 'b', 'c'):
     with open(os.path.join(out, name + '.html'), 'w') as f:


### PR DESCRIPTION
A modification to `test cases/common/123 cpp and asm/meson.build` which demonstrates a problem with machine detection:

In the MSYS2 `MSYSTEM=MINGW32` environment (64-bit MSYS2 but with a `i686-w64-mingw32` targeted gcc as `gcc`)  this test fails, as it (incorrectly) tries to build retval-x86_64.S using an x86 compiler.

(See https://github.com/mesonbuild/meson/pull/6512/commits/4cd3015828766fb3bb297ea5a177de62889d7792 for discussion)

I was puzzled for a while why this only reproduced locally but not in CI, but this is due to the fact that it only configures incorrectly the *first* time (in CI, the `meson.build` is touched to force a reconfigure when building.  I assume some information is preserved in CoreData which causes the machine to be detected correctly when reconfiguring?)

I'm not suggesting the second commit here should be applied as is.  I guess we could always change from 'configure; reconfigure & build; reconfigure & test; install; clean' to something like  'configure; build; clean; reconfigure & build; reconfigure & test; install; clean', but doing that for all tests would make things even slower...
