### PR TITLE
Implement symbolextractor on windows + some cleanups/fixes

### DIFF
--- a/ci/azure-steps.yml
+++ b/ci/azure-steps.yml
@@ -114,8 +114,8 @@ steps:
        $env:Path = $origPath
 
        # install llvm for clang-cl builds
-       DownloadFile -Source 'http://releases.llvm.org/7.0.0/LLVM-7.0.0-win64.exe' -Destination LLVM-7.0.0-win64.exe
-       Start-Process .\LLVM-7.0.0-win64.exe -ArgumentList '/S' -Wait
+       DownloadFile -Source 'http://releases.llvm.org/9.0.0/LLVM-9.0.0-win64.exe' -Destination LLVM-9.0.0-win64.exe
+       Start-Process .\LLVM-9.0.0-win64.exe -ArgumentList '/S' -Wait
        $env:Path = "C:\Program Files\LLVM\bin;$env:Path"
        $env:CC = "clang-cl"
        $env:CXX = "clang-cl"

--- a/docs/markdown/snippets/ninja_version_bump.md
+++ b/docs/markdown/snippets/ninja_version_bump.md
@@ -1,0 +1,10 @@
+## Ninja version requirement bumped to 1.7
+
+Meson now uses the [Implicit outputs](https://ninja-build.org/manual.html#ref_outputs)
+feature of Ninja for some types of targets that have multiple outputs which may
+not be listed on the command-line. This feature requires Ninja 1.7+.
+
+Note that the latest version of [Ninja available in Ubuntu 16.04](https://packages.ubuntu.com/search?keywords=ninja-build&searchon=names&suite=xenial-backports&section=all)
+(the oldest Ubuntu LTS at the time of writing) is 1.7.1. If your distro does
+not ship with a new-enough Ninja, you can download the latest release from
+Ninja's GitHub page: https://github.com/ninja-build/ninja/releases

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -668,7 +668,7 @@ int dummy;
         (srcs, ofilenames, cmd) = self.eval_custom_target_command(target)
         deps = self.unwrap_dep_list(target)
         deps += self.get_custom_target_depend_files(target)
-        desc = 'Generating {0} with a {1} command.'
+        desc = 'Generating {0} with a {1} command'
         if target.build_always_stale:
             deps.append('PHONY')
         if target.depfile is None:
@@ -764,7 +764,7 @@ int dummy;
             target_name = 'meson-{}'.format(self.build_run_target_name(target))
             elem = NinjaBuildElement(self.all_outputs, target_name, 'CUSTOM_COMMAND', [])
             elem.add_item('COMMAND', cmd)
-            elem.add_item('description', 'Running external command %s.' % target.name)
+            elem.add_item('description', 'Running external command %s' % target.name)
             elem.add_item('pool', 'console')
             # Alias that runs the target defined above with the name the user specified
             self.create_target_alias(target_name)
@@ -789,7 +789,7 @@ int dummy;
     def generate_coverage_rules(self):
         e = NinjaBuildElement(self.all_outputs, 'meson-coverage', 'CUSTOM_COMMAND', 'PHONY')
         self.generate_coverage_command(e, [])
-        e.add_item('description', 'Generates coverage reports.')
+        e.add_item('description', 'Generates coverage reports')
         self.add_build(e)
         # Alias that runs the target defined above
         self.create_target_alias('meson-coverage')
@@ -798,21 +798,21 @@ int dummy;
     def generate_coverage_legacy_rules(self):
         e = NinjaBuildElement(self.all_outputs, 'meson-coverage-xml', 'CUSTOM_COMMAND', 'PHONY')
         self.generate_coverage_command(e, ['--xml'])
-        e.add_item('description', 'Generates XML coverage report.')
+        e.add_item('description', 'Generates XML coverage report')
         self.add_build(e)
         # Alias that runs the target defined above
         self.create_target_alias('meson-coverage-xml')
 
         e = NinjaBuildElement(self.all_outputs, 'meson-coverage-text', 'CUSTOM_COMMAND', 'PHONY')
         self.generate_coverage_command(e, ['--text'])
-        e.add_item('description', 'Generates text coverage report.')
+        e.add_item('description', 'Generates text coverage report')
         self.add_build(e)
         # Alias that runs the target defined above
         self.create_target_alias('meson-coverage-text')
 
         e = NinjaBuildElement(self.all_outputs, 'meson-coverage-html', 'CUSTOM_COMMAND', 'PHONY')
         self.generate_coverage_command(e, ['--html'])
-        e.add_item('description', 'Generates HTML coverage report.')
+        e.add_item('description', 'Generates HTML coverage report')
         self.add_build(e)
         # Alias that runs the target defined above
         self.create_target_alias('meson-coverage-html')
@@ -979,7 +979,7 @@ int dummy;
                 ofilename = os.path.join(self.get_target_private_dir(target), ofilebase)
                 elem = NinjaBuildElement(self.all_outputs, ofilename, "CUSTOM_COMMAND", rel_sourcefile)
                 elem.add_item('COMMAND', ['resgen', rel_sourcefile, ofilename])
-                elem.add_item('DESC', 'Compiling resource %s.' % rel_sourcefile)
+                elem.add_item('DESC', 'Compiling resource %s' % rel_sourcefile)
                 self.add_build(elem)
                 deps.append(ofilename)
                 a = '-resource:' + ofilename
@@ -1073,7 +1073,7 @@ int dummy;
     def generate_java_link(self):
         rule = 'java_LINKER'
         command = ['jar', '$ARGS']
-        description = 'Creating JAR $out.'
+        description = 'Creating JAR $out'
         self.add_rule(NinjaRule(rule, command, [], description))
 
     def determine_dep_vapis(self, target):
@@ -1554,7 +1554,7 @@ int dummy;
             cmdlist += static_linker.get_exelist()
             cmdlist += ['$LINK_ARGS']
             cmdlist += static_linker.get_output_args('$out')
-            description = 'Linking static target $out.'
+            description = 'Linking static target $out'
             if num_pools > 0:
                 pool = 'pool = link_pool'
             else:
@@ -1576,7 +1576,7 @@ int dummy;
                 rule = '%s_LINKER%s' % (langname, self.get_rule_suffix(for_machine))
                 command = compiler.get_linker_exelist()
                 args = ['$ARGS'] + compiler.get_linker_output_args('$out') + ['$in', '$LINK_ARGS']
-                description = 'Linking target $out.'
+                description = 'Linking target $out'
                 if num_pools > 0:
                     pool = 'pool = link_pool'
                 else:
@@ -1594,7 +1594,7 @@ int dummy;
              '$out']
         symrule = 'SHSYM'
         symcmd = args + ['$CROSS']
-        syndesc = 'Generating symbol file $out.'
+        syndesc = 'Generating symbol file $out'
         synstat = 'restat = 1'
         self.add_rule(NinjaRule(symrule, symcmd, [], syndesc, extra=synstat))
 
@@ -1602,7 +1602,7 @@ int dummy;
         rule = self.compiler_to_rule_name(compiler)
         invoc = [ninja_quote(i) for i in compiler.get_exelist()]
         command = invoc + ['$ARGS', '$in']
-        description = 'Compiling Java object $in.'
+        description = 'Compiling Java object $in'
         self.add_rule(NinjaRule(rule, command, [], description))
 
     def generate_cs_compile_rule(self, compiler):
@@ -1610,7 +1610,7 @@ int dummy;
         invoc = [ninja_quote(i) for i in compiler.get_exelist()]
         command = invoc
         args = ['$ARGS', '$in']
-        description = 'Compiling C Sharp target $out.'
+        description = 'Compiling C Sharp target $out'
         self.add_rule(NinjaRule(rule, command, args, description,
                                 rspable=mesonlib.is_windows()))
 
@@ -1618,14 +1618,14 @@ int dummy;
         rule = self.compiler_to_rule_name(compiler)
         invoc = [ninja_quote(i) for i in compiler.get_exelist()]
         command = invoc + ['$ARGS', '$in']
-        description = 'Compiling Vala source $in.'
+        description = 'Compiling Vala source $in'
         self.add_rule(NinjaRule(rule, command, [], description, extra='restat = 1'))
 
     def generate_rust_compile_rules(self, compiler):
         rule = self.compiler_to_rule_name(compiler)
         invoc = [ninja_quote(i) for i in compiler.get_exelist()]
         command = invoc + ['$ARGS', '$in']
-        description = 'Compiling Rust source $in.'
+        description = 'Compiling Rust source $in'
         depfile = '$targetdep'
         depstyle = 'gcc'
         self.add_rule(NinjaRule(rule, command, [], description, deps=depstyle,
@@ -1640,7 +1640,7 @@ int dummy;
         ]
         invoc = full_exe + [ninja_quote(i) for i in compiler.get_exelist()]
         command = invoc + ['$ARGS', '$in']
-        description = 'Compiling Swift source $in.'
+        description = 'Compiling Swift source $in'
         self.add_rule(NinjaRule(rule, command, [], description))
 
     def generate_fortran_dep_hack(self, crstr):
@@ -1660,7 +1660,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         rule = self.get_compiler_rule_name('llvm_ir', compiler.for_machine)
         command = [ninja_quote(i) for i in compiler.get_exelist()]
         args = ['$ARGS'] + compiler.get_output_args('$out') + compiler.get_compile_only_args() + ['$in']
-        description = 'Compiling LLVM IR object $in.'
+        description = 'Compiling LLVM IR object $in'
         self.add_rule(NinjaRule(rule, command, args, description,
                                 rspable=compiler.can_linker_accept_rsp()))
         self.created_llvm_ir_rule[compiler.for_machine] = True
@@ -1697,7 +1697,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
 
         command = [ninja_quote(i) for i in compiler.get_exelist()]
         args = ['$ARGS'] + quoted_depargs + compiler.get_output_args('$out') + compiler.get_compile_only_args() + ['$in']
-        description = 'Compiling %s object $out.' % compiler.get_display_language()
+        description = 'Compiling %s object $out' % compiler.get_display_language()
         if isinstance(compiler, VisualStudioLikeCompiler):
             deps = 'msvc'
             depfile = None
@@ -1724,7 +1724,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         else:
             output = compiler.get_output_args('$out')
         command = compiler.get_exelist() + ['$ARGS'] + quoted_depargs + output + compiler.get_compile_only_args() + ['$in']
-        description = 'Precompiling header $in.'
+        description = 'Precompiling header $in'
         if isinstance(compiler, VisualStudioLikeCompiler):
             deps = 'msvc'
             depfile = None
@@ -2628,7 +2628,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         d = CleanTrees(self.environment.get_build_dir(), trees)
         d_file = os.path.join(self.environment.get_scratch_dir(), 'cleantrees.dat')
         e.add_item('COMMAND', self.environment.get_build_command() + ['--internal', 'cleantrees', d_file])
-        e.add_item('description', 'Cleaning custom target directories.')
+        e.add_item('description', 'Cleaning custom target directories')
         self.add_build(e)
         # Alias that runs the target defined above
         self.create_target_alias('meson-clean-ctlist')
@@ -2642,7 +2642,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         script_root = self.environment.get_script_dir()
         clean_script = os.path.join(script_root, 'delwithsuffix.py')
         gcno_elem.add_item('COMMAND', mesonlib.python_command + [clean_script, '.', 'gcno'])
-        gcno_elem.add_item('description', 'Deleting gcno files.')
+        gcno_elem.add_item('description', 'Deleting gcno files')
         self.add_build(gcno_elem)
         # Alias that runs the target defined above
         self.create_target_alias('meson-clean-gcno')
@@ -2651,7 +2651,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         script_root = self.environment.get_script_dir()
         clean_script = os.path.join(script_root, 'delwithsuffix.py')
         gcda_elem.add_item('COMMAND', mesonlib.python_command + [clean_script, '.', 'gcda'])
-        gcda_elem.add_item('description', 'Deleting gcda files.')
+        gcda_elem.add_item('description', 'Deleting gcda files')
         self.add_build(gcda_elem)
         # Alias that runs the target defined above
         self.create_target_alias('meson-clean-gcda')
@@ -2762,7 +2762,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
 
         elem = NinjaBuildElement(self.all_outputs, 'meson-clean', 'CUSTOM_COMMAND', 'PHONY')
         elem.add_item('COMMAND', [self.ninja_command, '-t', 'clean'])
-        elem.add_item('description', 'Cleaning.')
+        elem.add_item('description', 'Cleaning')
         # Alias that runs the above-defined meson-clean target
         self.create_target_alias('meson-clean')
 

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2326,6 +2326,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             return []
         return linker.get_no_stdlib_link_args()
 
+    def get_import_filename(self, target):
+        return os.path.join(self.get_target_dir(target), target.import_filename)
+
     def get_target_type_link_args(self, target, linker):
         commands = []
         if isinstance(target, build.Executable):
@@ -2336,7 +2339,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 commands += linker.gen_export_dynamic_link_args(self.environment)
             # If implib, and that's significant on this platform (i.e. Windows using either GCC or Visual Studio)
             if target.import_filename:
-                commands += linker.gen_import_library_args(os.path.join(self.get_target_dir(target), target.import_filename))
+                commands += linker.gen_import_library_args(self.get_import_filename(target))
             if target.pie:
                 commands += linker.get_pie_link_args()
         elif isinstance(target, build.SharedLibrary):
@@ -2357,7 +2360,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 commands += linker.gen_vs_module_defs_args(target.vs_module_defs.rel_to_builddir(self.build_to_src))
             # This is only visited when building for Windows using either GCC or Visual Studio
             if target.import_filename:
-                commands += linker.gen_import_library_args(os.path.join(self.get_target_dir(target), target.import_filename))
+                commands += linker.gen_import_library_args(self.get_import_filename(target))
         elif isinstance(target, build.StaticLibrary):
             commands += linker.get_std_link_args()
         else:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1584,6 +1584,7 @@ int dummy;
         args = [ninja_quote(quote_func(x)) for x in self.environment.get_build_command()] + \
             ['--internal',
              'symbolextractor',
+             ninja_quote(quote_func(self.environment.get_build_dir())),
              '$in',
              '$out']
         symrule = 'SHSYM'

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -976,6 +976,9 @@ class Compiler:
     def get_compile_debugfile_args(self, rel_obj, **kwargs):
         return []
 
+    def get_link_debugfile_name(self, targetfile: str) -> str:
+        return self.linker.get_debugfile_name(targetfile)
+
     def get_link_debugfile_args(self, targetfile: str) -> T.List[str]:
         return self.linker.get_debugfile_args(targetfile)
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -140,11 +140,11 @@ def find_coverage_tools():
 
     return gcovr_exe, gcovr_new_rootdir, lcov_exe, genhtml_exe
 
-def detect_ninja(version: str = '1.5', log: bool = False) -> str:
+def detect_ninja(version: str = '1.7', log: bool = False) -> str:
     r = detect_ninja_command_and_version(version, log)
     return r[0] if r else None
 
-def detect_ninja_command_and_version(version: str = '1.5', log: bool = False) -> (str, str):
+def detect_ninja_command_and_version(version: str = '1.7', log: bool = False) -> (str, str):
     env_ninja = os.environ.get('NINJA', None)
     for n in [env_ninja] if env_ninja else ['ninja', 'ninja-build', 'samu']:
         try:

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -129,7 +129,7 @@ def osx_syms(libfilename: str, outfilename: str):
     result += [' '.join(x.split()[0:2]) for x in output.split('\n')]
     write_if_changed('\n'.join(result) + '\n', outfilename)
 
-def gen_symbols(libfilename: str, outfilename: str, cross_host: str):
+def gen_symbols(libfilename: str, impfilename: str, outfilename: str, cross_host: str):
     if cross_host is not None:
         # In case of cross builds just always relink. In theory we could
         # determine the correct toolset, but we would need to use the correct
@@ -151,14 +151,15 @@ def gen_symbols(libfilename: str, outfilename: str, cross_host: str):
 def run(args):
     global TOOL_WARNING_FILE
     options = parser.parse_args(args)
-    if len(options.args) != 3:
-        print('symbolextractor.py <shared library file> <output file>')
+    if len(options.args) != 4:
+        print('symbolextractor.py <shared library file> <import library> <output file>')
         sys.exit(1)
     privdir = os.path.join(options.args[0], 'meson-private')
     TOOL_WARNING_FILE = os.path.join(privdir, 'symbolextractor_tool_warning_printed')
     libfile = options.args[1]
-    outfile = options.args[2]
-    gen_symbols(libfile, outfile, options.cross_host)
+    impfile = options.args[2] # Only used on Windows
+    outfile = options.args[3]
+    gen_symbols(libfile, impfile, outfile, options.cross_host)
     return 0
 
 if __name__ == '__main__':

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -20,6 +20,7 @@
 # This file is basically a reimplementation of
 # http://cgit.freedesktop.org/libreoffice/core/commit/?id=3213cd54b76bc80a6f0516aac75a48ff3b2ad67c
 
+import typing as T
 import os, sys
 from .. import mesonlib
 from .. import mlog
@@ -35,12 +36,12 @@ parser.add_argument('args', nargs='+')
 TOOL_WARNING_FILE = None
 RELINKING_WARNING = 'Relinking will always happen on source changes.'
 
-def dummy_syms(outfilename):
+def dummy_syms(outfilename: str):
     """Just touch it so relinking happens always."""
     with open(outfilename, 'w'):
         pass
 
-def write_if_changed(text, outfilename):
+def write_if_changed(text: str, outfilename: str):
     try:
         with open(outfilename, 'r') as f:
             oldtext = f.read()
@@ -51,7 +52,7 @@ def write_if_changed(text, outfilename):
     with open(outfilename, 'w') as f:
         f.write(text)
 
-def print_tool_warning(tool, msg, stderr=None):
+def print_tool_warning(tool: list, msg: str, stderr: str = None):
     global TOOL_WARNING_FILE
     if os.path.exists(TOOL_WARNING_FILE):
         return
@@ -65,7 +66,7 @@ def print_tool_warning(tool, msg, stderr=None):
     with open(TOOL_WARNING_FILE, 'w'):
         pass
 
-def call_tool(name, args):
+def call_tool(name: str, args: T.List[str]) -> str:
     evar = name.upper()
     if evar in os.environ:
         import shlex
@@ -107,7 +108,7 @@ def linux_syms(libfilename: str, outfilename: str):
         result += [' '.join(entry)]
     write_if_changed('\n'.join(result) + '\n', outfilename)
 
-def osx_syms(libfilename, outfilename):
+def osx_syms(libfilename: str, outfilename: str):
     # Get the name of the library
     output = call_tool('otool', ['-l', libfilename])
     if not output:
@@ -128,7 +129,7 @@ def osx_syms(libfilename, outfilename):
     result += [' '.join(x.split()[0:2]) for x in output.split('\n')]
     write_if_changed('\n'.join(result) + '\n', outfilename)
 
-def gen_symbols(libfilename, outfilename, cross_host):
+def gen_symbols(libfilename: str, outfilename: str, cross_host: str):
     if cross_host is not None:
         # In case of cross builds just always relink. In theory we could
         # determine the correct toolset, but we would need to use the correct

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -92,10 +92,12 @@ def osx_syms(libfilename, outfilename):
             match = i
             break
     result = [arr[match + 2], arr[match + 5]] # Libreoffice stores all 5 lines but the others seem irrelevant.
-    pnm, output = Popen_safe(['nm', '-g', '-P', libfilename])[0:2]
+    pnm, output = Popen_safe(['nm', '--extern-only',
+                              '--defined-only', '--format=posix',
+                              libfilename])[0:2]
     if pnm.returncode != 0:
         raise RuntimeError('nm does not work.')
-    result += [' '.join(x.split()[0:2]) for x in output.split('\n') if x and not x.endswith('U')]
+    result += [' '.join(x.split()[0:2]) for x in output.split('\n')]
     write_if_changed('\n'.join(result) + '\n', outfilename)
 
 def gen_symbols(libfilename, outfilename, cross_host):

--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -153,6 +153,7 @@ def create_lib_cpp_sample(project_name, version):
     lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
     uppercase_token = lowercase_token.upper()
     class_name = uppercase_token[0] + lowercase_token[1:]
+    test_exe_name = lowercase_token + '_test'
     namespace = lowercase_token
     lib_hpp_name = lowercase_token + '.hpp'
     lib_cpp_name = lowercase_token + '.cpp'
@@ -165,7 +166,7 @@ def create_lib_cpp_sample(project_name, version):
               'header_file': lib_hpp_name,
               'source_file': lib_cpp_name,
               'test_source_file': test_cpp_name,
-              'test_exe_name': lowercase_token,
+              'test_exe_name': test_exe_name,
               'project_name': project_name,
               'lib_name': lowercase_token,
               'test_name': lowercase_token,

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -134,6 +134,7 @@ def create_lib_c_sample(project_name, version):
     lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
     uppercase_token = lowercase_token.upper()
     function_name = lowercase_token[0:3] + '_func'
+    test_exe_name = lowercase_token + '_test'
     lib_h_name = lowercase_token + '.h'
     lib_c_name = lowercase_token + '.c'
     test_c_name = lowercase_token + '_test.c'
@@ -144,7 +145,7 @@ def create_lib_c_sample(project_name, version):
               'header_file': lib_h_name,
               'source_file': lib_c_name,
               'test_source_file': test_c_name,
-              'test_exe_name': lowercase_token,
+              'test_exe_name': test_exe_name,
               'project_name': project_name,
               'lib_name': lowercase_token,
               'test_name': lowercase_token,

--- a/mesonbuild/templates/cudatemplates.py
+++ b/mesonbuild/templates/cudatemplates.py
@@ -153,6 +153,7 @@ def create_lib_cuda_sample(project_name, version):
     lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
     uppercase_token = lowercase_token.upper()
     class_name = uppercase_token[0] + lowercase_token[1:]
+    test_exe_name = lowercase_token + '_test'
     namespace = lowercase_token
     lib_h_name = lowercase_token + '.h'
     lib_cuda_name = lowercase_token + '.cu'
@@ -165,7 +166,7 @@ def create_lib_cuda_sample(project_name, version):
               'header_file': lib_h_name,
               'source_file': lib_cuda_name,
               'test_source_file': test_cuda_name,
-              'test_exe_name': lowercase_token,
+              'test_exe_name': test_exe_name,
               'project_name': project_name,
               'lib_name': lowercase_token,
               'test_name': lowercase_token,

--- a/mesonbuild/templates/dlangtemplates.py
+++ b/mesonbuild/templates/dlangtemplates.py
@@ -113,6 +113,7 @@ def create_lib_d_sample(project_name, version):
     lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
     uppercase_token = lowercase_token.upper()
     function_name = lowercase_token[0:3] + '_func'
+    test_exe_name = lowercase_token + '_test'
     lib_m_name = lowercase_token
     lib_d_name = lowercase_token + '.d'
     test_d_name = lowercase_token + '_test.d'
@@ -123,7 +124,7 @@ def create_lib_d_sample(project_name, version):
               'module_file': lib_m_name,
               'source_file': lib_d_name,
               'test_source_file': test_d_name,
-              'test_exe_name': lowercase_token,
+              'test_exe_name': test_exe_name,
               'project_name': project_name,
               'lib_name': lowercase_token,
               'test_name': lowercase_token,

--- a/mesonbuild/templates/fortrantemplates.py
+++ b/mesonbuild/templates/fortrantemplates.py
@@ -111,6 +111,7 @@ def create_lib_fortran_sample(project_name, version):
     lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
     uppercase_token = lowercase_token.upper()
     function_name = lowercase_token[0:3] + '_func'
+    test_exe_name = lowercase_token + '_test'
     lib_fortran_name = lowercase_token + '.f90'
     test_fortran_name = lowercase_token + '_test.f90'
     kwargs = {'utoken': uppercase_token,
@@ -119,7 +120,7 @@ def create_lib_fortran_sample(project_name, version):
               'function_name': function_name,
               'source_file': lib_fortran_name,
               'test_source_file': test_fortran_name,
-              'test_exe_name': lowercase_token,
+              'test_exe_name': test_exe_name,
               'project_name': project_name,
               'lib_name': lowercase_token,
               'test_name': lowercase_token,

--- a/mesonbuild/templates/javatemplates.py
+++ b/mesonbuild/templates/javatemplates.py
@@ -118,7 +118,6 @@ def create_lib_java_sample(project_name, version):
               'class_name': class_name,
               'source_file': lib_java_name,
               'test_source_file': test_java_name,
-              'test_exe_name': lowercase_token,
               'project_name': project_name,
               'lib_name': lowercase_token,
               'test_name': lowercase_token,

--- a/mesonbuild/templates/objcpptemplates.py
+++ b/mesonbuild/templates/objcpptemplates.py
@@ -134,6 +134,7 @@ def create_lib_objcpp_sample(project_name, version):
     lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
     uppercase_token = lowercase_token.upper()
     function_name = lowercase_token[0:3] + '_func'
+    test_exe_name = lowercase_token + '_test'
     lib_h_name = lowercase_token + '.h'
     lib_objcpp_name = lowercase_token + '.mm'
     test_objcpp_name = lowercase_token + '_test.mm'
@@ -144,7 +145,7 @@ def create_lib_objcpp_sample(project_name, version):
               'header_file': lib_h_name,
               'source_file': lib_objcpp_name,
               'test_source_file': test_objcpp_name,
-              'test_exe_name': lowercase_token,
+              'test_exe_name': test_exe_name,
               'project_name': project_name,
               'lib_name': lowercase_token,
               'test_name': lowercase_token,

--- a/mesonbuild/templates/objctemplates.py
+++ b/mesonbuild/templates/objctemplates.py
@@ -134,6 +134,7 @@ def create_lib_objc_sample(project_name, version):
     lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
     uppercase_token = lowercase_token.upper()
     function_name = lowercase_token[0:3] + '_func'
+    test_exe_name = lowercase_token + '_test'
     lib_h_name = lowercase_token + '.h'
     lib_objc_name = lowercase_token + '.m'
     test_objc_name = lowercase_token + '_test.m'
@@ -144,7 +145,7 @@ def create_lib_objc_sample(project_name, version):
               'header_file': lib_h_name,
               'source_file': lib_objc_name,
               'test_source_file': test_objc_name,
-              'test_exe_name': lowercase_token,
+              'test_exe_name': test_exe_name,
               'project_name': project_name,
               'lib_name': lowercase_token,
               'test_name': lowercase_token,

--- a/mesonbuild/templates/rusttemplates.py
+++ b/mesonbuild/templates/rusttemplates.py
@@ -82,6 +82,7 @@ def create_lib_rust_sample(project_name, version):
     lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
     uppercase_token = lowercase_token.upper()
     function_name = lowercase_token[0:3] + '_func'
+    test_exe_name = lowercase_token + '_test'
     lib_crate_name = lowercase_token
     lib_rs_name = lowercase_token + '.rs'
     test_rs_name = lowercase_token + '_test.rs'
@@ -92,7 +93,7 @@ def create_lib_rust_sample(project_name, version):
               'crate_file': lib_crate_name,
               'source_file': lib_rs_name,
               'test_source_file': test_rs_name,
-              'test_exe_name': lowercase_token,
+              'test_exe_name': test_exe_name,
               'project_name': project_name,
               'lib_name': lowercase_token,
               'test_name': lowercase_token,

--- a/run_tests.py
+++ b/run_tests.py
@@ -45,17 +45,15 @@ if 'CI' in os.environ:
     NINJA_CMD = 'ninja'
 else:
     # Look for 1.9 to see if https://github.com/ninja-build/ninja/issues/1219
-    # is fixed, else require 1.6 for -w dupbuild=err
-    for v in ('1.9', '1.6'):
-        NINJA_CMD = detect_ninja(v)
-        if NINJA_CMD is not None:
-            if mesonlib.version_compare(v, '>=1.9'):
-                NINJA_1_9_OR_NEWER = True
-            else:
-                mlog.warning('Found ninja <1.9, tests will run slower', once=True)
-            break
+    # is fixed
+    NINJA_CMD = detect_ninja('1.9')
+    if NINJA_CMD is not None:
+        NINJA_1_9_OR_NEWER = True
+    else:
+        mlog.warning('Found ninja <1.9, tests will run slower', once=True)
+        NINJA_CMD = detect_ninja()
 if NINJA_CMD is None:
-    raise RuntimeError('Could not find Ninja v1.6 or newer')
+    raise RuntimeError('Could not find Ninja v1.7 or newer')
 
 def guess_backend(backend, msbuild_exe: str):
     # Auto-detect backend if unspecified

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1706,15 +1706,15 @@ class BasePlatformTests(unittest.TestCase):
         if self.backend is Backend.ninja:
             self.assertIn(ret.split('\n')[-2], self.no_rebuild_stdout)
         elif self.backend is Backend.vs:
-            # Ensure that some target said that no rebuild was done
+            # Ensure that some target of each type said that no rebuild was done
+            # We always have at least one CustomBuild target for the regen checker
             self.assertIn('CustomBuild:\n  All outputs are up-to-date.', ret)
             self.assertIn('ClCompile:\n  All outputs are up-to-date.', ret)
             self.assertIn('Link:\n  All outputs are up-to-date.', ret)
             # Ensure that no targets were built
-            clre = re.compile('ClCompile:\n [^\n]*cl', flags=re.IGNORECASE)
-            linkre = re.compile('Link:\n [^\n]*link', flags=re.IGNORECASE)
-            self.assertNotRegex(ret, clre)
-            self.assertNotRegex(ret, linkre)
+            self.assertNotRegex(ret, re.compile('CustomBuild:\n [^\n]*cl', flags=re.IGNORECASE))
+            self.assertNotRegex(ret, re.compile('ClCompile:\n [^\n]*cl', flags=re.IGNORECASE))
+            self.assertNotRegex(ret, re.compile('Link:\n [^\n]*link', flags=re.IGNORECASE))
         elif self.backend is Backend.xcode:
             raise unittest.SkipTest('Please help us fix this test on the xcode backend')
         else:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -809,6 +809,7 @@ class InternalTests(unittest.TestCase):
             env.machines.host.system = 'windows'
             self._test_all_naming(cc, env, patterns, 'windows-mingw')
 
+    @skipIfNoPkgconfig
     def test_pkgconfig_parse_libs(self):
         '''
         Unit test for parsing of pkg-config output to search for libraries

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2591,6 +2591,8 @@ class AllPlatformTests(BasePlatformTests):
         Test that no-op changes to the build files such as mtime do not cause
         a rebuild of anything.
         '''
+        if is_cygwin():
+            raise unittest.SkipTest('symbolextractor has not been implemented for Cygwin yet')
         testdir = os.path.join(self.common_test_dir, '6 linkshared')
         self.init(testdir)
         self.build()

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1759,7 +1759,7 @@ class BasePlatformTests(unittest.TestCase):
     @staticmethod
     def get_target_from_filename(filename):
         base = os.path.splitext(filename)[0]
-        if base.startswith('lib'):
+        if base.startswith(('lib', 'cyg')):
             return base[3:]
         return base
 
@@ -2591,8 +2591,6 @@ class AllPlatformTests(BasePlatformTests):
         Test that no-op changes to the build files such as mtime do not cause
         a rebuild of anything.
         '''
-        if is_cygwin():
-            raise unittest.SkipTest('symbolextractor has not been implemented for Cygwin yet')
         testdir = os.path.join(self.common_test_dir, '6 linkshared')
         self.init(testdir)
         self.build()

--- a/test cases/common/149 recursive linking/3rdorderdeps/meson.build
+++ b/test cases/common/149 recursive linking/3rdorderdeps/meson.build
@@ -41,7 +41,7 @@ foreach dep2 : ['sh', 'st']
       main_c = configure_file(input : 'main.c.in',
                               output : name + '-main.c',
                               configuration : cdata)
-      dep3_bin = executable(name, main_c, link_with : dep3_lib,
+      dep3_bin = executable(name + '_test', main_c, link_with : dep3_lib,
                             c_args : build_args)
       test(name + 'test', dep3_bin)
     endforeach


### PR DESCRIPTION
commit 431283b35dff5b43ecc65fe19ae581b3c6d8b9be:

```
symbolextractor: Correctly filter undefined symbols on macOS
-g is --extern-only and -P is --format=posix. We were missing
--defined-only for some reason, which we pass to `nm` on Linux.
This avoids having to manually filter later.
```

commit 6fe7af58091f0cb9c7a4c41e6f714d5a8e9c9ad7:

```
symbolextractor: Print a warning if required tools not found
Also write out a dummy symbols file if the tool wasn't found or didn't
work instead of just spewing an exception.
```

commit 901bbc36d902c8146482295827e5464070bbf898:

```
symbolextractor: Support passing arguments to tools
This is how we parse all env vars for tools in Meson. Do the same here
too for consistency.
```

commit feb82e0f0f365d66199d697f1d99e109e2c6a700:

```
symbolextractor: Add typing hints
```

commit 5c0be89ba0ffb09e37d43f0e20fe180be39e3fe6:

```
ninjabackend: List PDBs in output list for targets
This is more correct, and forces the target(s) to be rebuilt if the
PDB files are missing. Increases the minimum required Ninja to 1.7,
which is available in Ubuntu 16.04 under backports.

We can't do the same for import libraries, because it is impossible
for us to know at configure time whether or not an import library will
be generated for a given DLL.
```

commit 0cbf397b4d3c03d2ad977c91ce3058b4cf96127a:

```
tests: Ensure that executable and library are named differently
On Windows, the basename is used to determine the name of the PDB
file. So for a project called myproject, we will create myproject.dll
and myproject.exe, both of which will have myproject.pdb. This is
a file collision. Instead, append `_test`, similar to the C# template.

Fixes AllPlatformTest.test_templates on MSVC. This became a hard error
when we started listing PDBs in the implicit outputs list of ninja
targets.

Do the same for a test that was making the same mistake.
```

commit 1c32a1f81ee5dbdbf519ddcd56c9b3753d158b99:

```
ninjabackend: Minor refactoring
```

commit 63c837fa669ea2917399ab1741a2f47744f511b4:

```
ninjabackend: Pass the import library to SHSYM
We actually use this while linking on Windows, and hence we need to
extract symbols from this file, and not the DLL.

However, we cannot pass it instead of the DLL because it's an optional
output of the compiler. It will not be written out at all if there are
no symbols in the DLL, and we cannot know that at configure time. This
means we cannot describe it as an output of any ninja target, or the
input of any ninja target. We must pass it as an argument without
semantic meaning.
```

commit 129ccd8469b97421ba1cd634911fd8b158281da5:

```
unit tests: Skip if pkg-config is not found
Of course, this does not skip on the CI, but helps on Windows.
```

commit b95dffc905ac1aade86bbf3749c5322156e9182e:

```
unit tests: Make assertBuildNoOp check stricter
We also need to verify that no CustomBuild targets were rebuilt.
```

commit f97ff1b901e3d1492e75232c1068e59d92dc009a:

```
unit tests: Add a test for reconfigure causing no-op build
meson setup && ninja && touch meson.build && ninja

should only reconfigure but not cause anything to be rebuilt.
```

commit 57b38563e92d69f9fbd7bee3dde54386f2146f3b:

```
unit tests: Add a test for the symbolchecker script
When a source file for a library is changed without adding new extern
symbols, only that library should be rebuilt. Nothing that uses it
should be relinked.

Along the way, also remove trailing `.` in all Ninja rule
descriptions. It's very confusing to see messages like:

    Linking target mylib.dll.

It's confusing that the period at the end of that is not part of the
filename. Instead of removing that period manually in the tests (which
feels wrong!) just don't print it at all.
```

commit fae49c582a93881e2b194eaf5f8679c3f02324e5:

```
symbolextractor: Add a Windows implementation
Supports both MSVC and MinGW toolchains. Checks for MSVC first, then
falls back to MinGW.
```

commit 6b8851776a39300b7414424466051b43bfa3a0a5:

```
symbolextractor: Add support for clang-cl
Requires the latest LLVm 9.0 release which implements the `-list`
argument to `llvm-lib` and ships with an implementation of `nm` called
`llvm-nm`.
```

commit 5ed20400b1d36448658e145c5ba947ae79a44bff:

```
symbolextractor: Add support for Cygwin
```
