### PR TITLE
docs: Improve visibility for `.enabled()` etc., add example

### DIFF
--- a/docs/markdown/Build-options.md
+++ b/docs/markdown/Build-options.md
@@ -83,14 +83,29 @@ Currently supported in
 - `disabled` do not look for the dependency and always return 'not-found'.
 
 When getting the value of this type of option using `get_option()`, a special
-object is returned instead of the string representation of the option's value.
-That object has three methods returning boolean and taking no argument:
-`enabled()`, `disabled()`, and `auto()`.
+[feature option object](Reference-manual.md#feature-option-object)
+is returned instead of the string representation of the option's value.
+This object can be passed to `required`:
 
 ```meson
 d = dependency('foo', required : get_option('myfeature'))
 if d.found()
   app = executable('myapp', 'main.c', dependencies : [d])
+endif
+```
+
+To check the value of the feature, the object has three methods
+returning a boolean and taking no argument:
+
+- `.enabled()`
+- `.disabled()`
+- `.auto()`
+
+This is useful for custom code depending on the feature:
+
+```meson
+if get_option('myfeature').enabled()
+  # ...
 endif
 ```
 

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -846,8 +846,10 @@ configuration as-is, which may be absolute, or relative to `prefix`.
 if you need the absolute path to one of these e.g. to use in a define
 etc., you should use `get_option('prefix') / get_option('localstatedir')`
 
-For options of type `feature` a special object is returned instead of
-a string.  See [`feature` options](Build-options.md#features)
+For options of type `feature` a
+[feature option object](#feature-option-object)
+is returned instead of a string.
+See [`feature` options](Build-options.md#features)
 documentation for more details.
 
 ### get_variable()
@@ -2471,6 +2473,16 @@ library. This object has the following methods:
    type name, and methods as the object that called it. This new
    object will only inherit other attributes from its parent as
    controlled by keyword arguments.
+
+### Feature option object
+
+The following methods are defined for all [`feature` options](Build-options.md#features):
+
+- `enabled()` returns whether the feature was set to `'enabled'`
+- `disabled()` returns whether the feature was set to `'disabled'`
+- `auto()` returns whether the feature was set to `'auto'`
+
+Feature options are available since 0.47.0.
 
 ### `generator` object
 


### PR DESCRIPTION
Following discussion with @xclaesse on IRC.