### PR TITLE
Fix `compiler.get_linker_id` and documentation

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -33,16 +33,26 @@ These are return values of the `get_id` (Compiler family) and
 
 ## Linker ids
 
-These are return values of the `get_linker_id` (Linker family) method in a compiler object.
+These are return values of the `get_linker_id` method in a compiler object.
 
-| Value     | Linker family                              |
-| -----     | ---------------                            |
-| ld.bfd    | GNU Compiler Collection                    |
-| {ld.bfd,lld} | Clang non-Windows                       |
-| link      | MSVC, Clang-cl, clang Windows              |
-| pgi       | Portland/Nvidia PGI                        |
-| {ld.bfd,gold,xild}  | Intel compiler non-Windows       |
-| xilink    | Intel-cl Windows                           |
+| Value     | Linker family                               |
+| -----     | ---------------                             |
+| ld.bfd    | The GNU linker                              |
+| ld.gold   | The GNU linker                              |
+| lld       | The LLVM linker, with the GNU interface     |
+| link      | MSVC linker                                 |
+| pgi       | Portland/Nvidia PGI                         |
+| lld-link  | The LLVM linker, with the MSVC interface    |
+| xilink    | Used with Intel-cl only, MSVC like          |
+| rlink     | The Renesas linker, used with CCrx only     |
+| armlink   | The ARM linker (arm and armclang compilers) |
+| optlink   | optlink                                     |
+| APPLE ld  | Apple ld64                                  |
+| solaris   | Solaris and illumos                         |
+
+For languages that don't have separate dynamic linkers such as C# and Java, the
+`get_linker_id` will return the compiler name.
+
 
 ## Script environment variables
 

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -35,20 +35,21 @@ These are return values of the `get_id` (Compiler family) and
 
 These are return values of the `get_linker_id` method in a compiler object.
 
-| Value     | Linker family                               |
-| -----     | ---------------                             |
-| ld.bfd    | The GNU linker                              |
-| ld.gold   | The GNU linker                              |
-| lld       | The LLVM linker, with the GNU interface     |
-| link      | MSVC linker                                 |
-| pgi       | Portland/Nvidia PGI                         |
-| lld-link  | The LLVM linker, with the MSVC interface    |
-| xilink    | Used with Intel-cl only, MSVC like          |
-| rlink     | The Renesas linker, used with CCrx only     |
-| armlink   | The ARM linker (arm and armclang compilers) |
-| optlink   | optlink                                     |
-| APPLE ld  | Apple ld64                                  |
-| solaris   | Solaris and illumos                         |
+| Value      | Linker family                               |
+| -----      | ---------------                             |
+| ld.bfd     | The GNU linker                              | 
+| ld.gold    | The GNU gold linker                         |
+| ld.lld     | The LLVM linker, with the GNU interface     |
+| ld.solaris | Solaris and illumos                         |
+| ld64       | Apple ld64                                  |
+| link       | MSVC linker                                 |
+| lld-link   | The LLVM linker, with the MSVC interface    |
+| xilink     | Used with Intel-cl only, MSVC like          |
+| optlink    | optlink (used with DMD)                     |
+| rlink      | The Renesas linker, used with CCrx only     |
+| armlink    | The ARM linker (arm and armclang compilers) |
+| pgi        | Portland/Nvidia PGI                         |
+| nvlink     | Nvidia Linker used with cuda                |
 
 For languages that don't have separate dynamic linkers such as C# and Java, the
 `get_linker_id` will return the compiler name.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -724,7 +724,13 @@ class Compiler:
         return self.id
 
     def get_linker_id(self) -> str:
-        return self.linker.id
+        # There is not guarantee that we have a dynamic linker instance, as
+        # some languages don't have separate linkers and compilers. In those
+        # cases return the compiler id
+        try:
+            return self.linker.id
+        except AttributeError:
+            return self.id
 
     def get_version_string(self) -> str:
         details = [self.id, self.version]

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6056,30 +6056,30 @@ c = ['{0}']
             self.assertEqual(comp.linker.id, expected)
 
     def test_ld_environment_variable_bfd(self):
-        self._check_ld('ld.bfd', 'bfd', 'c', 'GNU ld.bfd')
+        self._check_ld('ld.bfd', 'bfd', 'c', 'ld.bfd')
 
     def test_ld_environment_variable_gold(self):
-        self._check_ld('ld.gold', 'gold', 'c', 'GNU ld.gold')
+        self._check_ld('ld.gold', 'gold', 'c', 'ld.gold')
 
     def test_ld_environment_variable_lld(self):
-        self._check_ld('ld.lld', 'lld', 'c', 'lld')
+        self._check_ld('ld.lld', 'lld', 'c', 'ld.lld')
 
     @skipIfNoExecutable('rustc')
     def test_ld_environment_variable_rust(self):
-        self._check_ld('ld.gold', 'gold', 'rust', 'GNU ld.gold')
+        self._check_ld('ld.gold', 'gold', 'rust', 'ld.gold')
 
     def test_ld_environment_variable_cpp(self):
-        self._check_ld('ld.gold', 'gold', 'cpp', 'GNU ld.gold')
+        self._check_ld('ld.gold', 'gold', 'cpp', 'ld.gold')
 
     def test_ld_environment_variable_objc(self):
-        self._check_ld('ld.gold', 'gold', 'objc', 'GNU ld.gold')
+        self._check_ld('ld.gold', 'gold', 'objc', 'ld.gold')
 
     def test_ld_environment_variable_objcpp(self):
-        self._check_ld('ld.gold', 'gold', 'objcpp', 'GNU ld.gold')
+        self._check_ld('ld.gold', 'gold', 'objcpp', 'ld.gold')
 
     @skipIfNoExecutable('gfortran')
     def test_ld_environment_variable_fortran(self):
-        self._check_ld('ld.gold', 'gold', 'fortran', 'GNU ld.gold')
+        self._check_ld('ld.gold', 'gold', 'fortran', 'ld.gold')
 
     def compute_sha256(self, filename):
         with open(filename, 'rb') as f:


### PR DESCRIPTION
The documentation leaves out a lot of possible values, and is wrong in a number of cases.

On the other end calling `meson.get_compiler('java').get_linker_id()` would cause an uncaught python exception.