### PR TITLE
Add .found() method to cmakesubproject

### DIFF
--- a/docs/markdown/CMake-module.md
+++ b/docs/markdown/CMake-module.md
@@ -99,6 +99,8 @@ and supports the following methods:
  - `get_variable(name)` fetches the specified variable from inside
    the subproject. Usually `dependency()` or `target()` should be
    preferred to extract build targets.
+ - `found` returns true if the subproject is available, otherwise false
+   *new in in 0.53.2*
 
 ## CMake configuration files
 

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -66,6 +66,7 @@ class CMakeSubprojectHolder(InterpreterObject, ObjectHolder):
                              'target': self.target,
                              'target_type': self.target_type,
                              'target_list': self.target_list,
+                             'found': self.found_method,
                              })
 
     def _args_to_info(self, args):
@@ -109,6 +110,13 @@ class CMakeSubprojectHolder(InterpreterObject, ObjectHolder):
     @permittedKwargs({})
     def target_list(self, args, kwargs):
         return self.held_object.cm_interpreter.target_list()
+
+    @noPosargs
+    @permittedKwargs({})
+    @FeatureNew('CMakeSubproject.found()', '0.53.2')
+    def found_method(self, args, kwargs):
+        return self.held_object is not None
+
 
 class CmakeModule(ExtensionModule):
     cmake_detected = False

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -18,7 +18,7 @@ import shutil
 from . import ExtensionModule, ModuleReturnValue
 
 from .. import build, dependencies, mesonlib, mlog
-from ..interpreterbase import permittedKwargs, FeatureNew, stringArgs, InterpreterObject, ObjectHolder
+from ..interpreterbase import permittedKwargs, FeatureNew, stringArgs, InterpreterObject, ObjectHolder, noPosargs
 from ..interpreter import ConfigurationDataHolder, InterpreterException, SubprojectHolder
 
 
@@ -105,10 +105,9 @@ class CMakeSubprojectHolder(InterpreterObject, ObjectHolder):
         info = self._args_to_info(args)
         return info['func']
 
+    @noPosargs
     @permittedKwargs({})
     def target_list(self, args, kwargs):
-        if len(args) > 0:
-            raise InterpreterException('target_list does not take any parameters.')
         return self.held_object.cm_interpreter.target_list()
 
 class CmakeModule(ExtensionModule):

--- a/test cases/cmake/1 basic/meson.build
+++ b/test cases/cmake/1 basic/meson.build
@@ -5,6 +5,7 @@ cm = import('cmake')
 sub_pro = cm.subproject('cmMod')
 sub_dep = sub_pro.dependency('cmModLib++')
 
+assert(sub_pro.found(), 'found() method reports not found, but should be found')
 assert(sub_pro.target_list() == ['cmModLib++'], 'There should be exactly one target')
 assert(sub_pro.target_type('cmModLib++') == 'shared_library', 'Target type should be shared_library')
 

--- a/test cases/cmake/9 disabled subproject/meson.build
+++ b/test cases/cmake/9 disabled subproject/meson.build
@@ -3,3 +3,4 @@ project('cmakeSubTest', ['c', 'cpp'])
 cm = import('cmake')
 
 sub_pro = cm.subproject('nothinig', required: false)
+assert(not sub_pro.found(), 'subproject found() reports wrong value')


### PR DESCRIPTION
Otherwise it's impossible to figure out what happened with `cmake.subproject(..., required : false)`. Also, normal subprojects have this, so not having it is very strange.