### PR TITLE
macOS: Remove more unused linkerlike args

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1059,7 +1059,25 @@ class Compiler:
         return self.linker.get_undefined_link_args()
 
     def remove_linkerlike_args(self, args):
-        return [x for x in args if not x.startswith('-Wl')]
+        rm_exact = ('-headerpad_max_install_names',)
+        rm_prefixes = ('-Wl,', '-L',)
+        rm_next = ('-L',)
+        ret = []
+        iargs = iter(args)
+        for arg in iargs:
+            # Remove this argument
+            if arg in rm_exact:
+                continue
+            # If the argument starts with this, but is not *exactly* this
+            # f.ex., '-L' should match ['-Lfoo'] but not ['-L', 'foo']
+            if arg.startswith(rm_prefixes) and arg not in rm_prefixes:
+                continue
+            # Ignore this argument and the one after it
+            if arg in rm_next:
+                next(iargs)
+                continue
+            ret.append(arg)
+        return ret
 
     def get_lto_compile_args(self) -> T.List[str]:
         return []

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4896,6 +4896,11 @@ class DarwinTests(BasePlatformTests):
         self.build()
         self.install()
 
+    def test_removing_unused_linker_args(self):
+        testdir = os.path.join(self.common_test_dir, '108 has arg')
+        env = {'CFLAGS': '-L/tmp -L /var/tmp -headerpad_max_install_names -Wl,-export_dynamic'}
+        self.init(testdir, override_envvars=env)
+
 
 @unittest.skipUnless(not is_windows(), "requires something Unix-like")
 class LinuxlikeTests(BasePlatformTests):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5939,7 +5939,6 @@ class LinuxlikeTests(BasePlatformTests):
         '''
         testdir = os.path.join(self.common_test_dir, testdir)
         subdir = os.path.join(testdir, subdir_path)
-        curdir = os.getcwd()
         with chdir(subdir):
             # Can't distribute broken symlinks in the source tree because it breaks
             # the creation of zipapps. Create it dynamically and run the test by


### PR DESCRIPTION
`-L` and `-headerpad_max_install_names` are both linker arguments that are commonly passed in CFLAGS too.

Closes https://github.com/mesonbuild/meson/issues/6294

Also remove an unused variable in the unit tests.