### PR TITLE
cmake2meson fix if nesting

### DIFF
--- a/tools/cmake2meson.py
+++ b/tools/cmake2meson.py
@@ -145,7 +145,7 @@ def token_or_group(arg):
     elif isinstance(arg, list):
         line = ' ('
         for a in arg:
-            line += ' ' + a.value
+            line += ' ' + token_or_group(a)
         line += ' )'
         return line
 

--- a/tools/cmake2meson.py
+++ b/tools/cmake2meson.py
@@ -139,6 +139,16 @@ class Parser:
         while not self.accept('eof'):
             yield(self.statement())
 
+def token_or_group(arg):
+    if isinstance(arg, Token):
+        return ' ' + arg.value
+    elif isinstance(arg, list):
+        line = ' ('
+        for a in arg:
+            line += ' ' + a.value
+        line += ' )'
+        return line
+
 class Converter:
     ignored_funcs = {'cmake_minimum_required': True,
                      'enable_testing': True,
@@ -237,13 +247,7 @@ class Converter:
             except AttributeError:  # complex if statements
                 line = t.name
                 for arg in t.args:
-                    if isinstance(arg, Token):
-                        line += ' ' + arg.value
-                    elif isinstance(arg, list):
-                        line += ' ('
-                        for a in arg:
-                            line += ' ' + a.value
-                        line += ' )'
+                    line += token_or_group(arg)
         elif t.name == 'elseif':
             preincrement = -1
             postincrement = 1

--- a/tools/cmake2meson.py
+++ b/tools/cmake2meson.py
@@ -251,7 +251,12 @@ class Converter:
         elif t.name == 'elseif':
             preincrement = -1
             postincrement = 1
-            line = 'elif %s' % self.convert_args(t.args, False)
+            try:
+                line = 'elif %s' % self.convert_args(t.args, False)
+            except AttributeError:  # complex if statements
+                line = t.name
+                for arg in t.args:
+                    line += token_or_group(arg)
         elif t.name == 'else':
             preincrement = -1
             postincrement = 1


### PR DESCRIPTION
cmake2meson would break with cmake statements like "if((A STREQUAL x) AND (NOT (B STREQUAL y)))" because it can't handle such nesting.  The "elseif" handling logic was even more simplistic, whereas it could reuse the if') logic.  This PR takes care of both problems.