### PR TITLE
azure ci: Test x86 Visual Studio builds again

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,8 +18,8 @@ jobs:
 
   strategy:
     matrix:
-        vc2017x64ninja:
-          arch: x64
+        vc2017x86ninja:
+          arch: x86
           compiler: msvc2017
           backend: ninja
         vc2017x64vs:


### PR DESCRIPTION
This was dropped when the VS2015 images were removed from Azure.