### PR TITLE
gnome.py: Determine g-ir-scanner and g-ir-compiler paths from pkgconfig

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -736,15 +736,30 @@ class GnomeModule(ExtensionModule):
         if kwargs.get('install_dir'):
             raise MesonException('install_dir is not supported with generate_gir(), see "install_dir_gir" and "install_dir_typelib"')
 
-        giscanner = self.interpreter.find_program_impl('g-ir-scanner')
-        gicompiler = self.interpreter.find_program_impl('g-ir-compiler')
-
         girtargets = [self._unwrap_gir_target(arg, state) for arg in args]
 
         if len(girtargets) > 1 and any([isinstance(el, build.Executable) for el in girtargets]):
             raise MesonException('generate_gir only accepts a single argument when one of the arguments is an executable')
 
         self.gir_dep, pkgargs = self._get_gir_dep(state)
+        # find_program is needed in the case g-i is built as subproject.
+        # In that case it uses override_find_program so the gobject utilities
+        # can be used from the build dir instead of from the system.
+        # However, GObject-introspection provides the appropriate paths to
+        # these utilities via pkg-config, so it would be best to use the
+        # results from pkg-config when possible.
+        gi_util_dirs_check = [state.environment.get_build_dir(), state.environment.get_source_dir()]
+        giscanner = self.interpreter.find_program_impl('g-ir-scanner')
+        if giscanner.found():
+            giscanner_path = giscanner.get_command()[0]
+            if not any(x in giscanner_path for x in gi_util_dirs_check):
+                giscanner = self.gir_dep.get_pkgconfig_variable('g_ir_scanner', {})
+
+        gicompiler = self.interpreter.find_program_impl('g-ir-compiler')
+        if gicompiler.found():
+            gicompiler_path = gicompiler.get_command()[0]
+            if not any(x in gicompiler_path for x in gi_util_dirs_check):
+                gicompiler = self.gir_dep.get_pkgconfig_variable('g_ir_compiler', {})
 
         ns = kwargs.pop('namespace')
         nsversion = kwargs.pop('nsversion')


### PR DESCRIPTION
Because GOI must first run and scan a binary when creating .gir files, cross-compilation is quite tricky! Mainly because if the binary is cross-compiled, you would not typically be able to run or scan a cross-compiled binary from the host system. Because of this significant limitation, both Buildroot and Openembedded have decided to use several wrappers of which runs the native scanner using qemu to create the binaries. These wrappers live in the staging directory.

Currently, meson hard-codes the paths of these utilities, which results in cross-compiled environments running the host versions of these tools instead of the wrappers installed in the staging directory.

GObject-introspection provides the appropriate paths to these utilities via pkg-config, so it would be best to use the results of pkg-config instead of hard coding these paths.