### PR TITLE
compilers/mixins/clike.py: prefer .a shlibext when --default-library=static

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -857,6 +857,9 @@ class CLikeCompiler:
         elif env.machines[self.for_machine].is_cygwin():
             shlibext = ['dll', 'dll.a']
             prefixes = ['cyg'] + prefixes
+        elif env.coredata.get_builtin_option('default_library') == 'static':
+            # Linux/BSDs
+            shlibext = ['a']
         else:
             # Linux/BSDs
             shlibext = ['so']


### PR DESCRIPTION
The existing library search order makes sense for environments with shared or a
mix of shared and static libraries. However, in a cross-compile environment
with a prebuilt cross-toolchain, both static and shared versions of the sysroot
libraries.

This environment presents a problem when a user builds an entirely static build
where there won't be any shared libraries at runtime because ld throws
the error: "ld: attempted static link of a dynamic object."