### PR TITLE
Fix python2 rename

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6861,7 +6861,11 @@ class NativeFileTests(BasePlatformTests):
             # python module breaks. This is fine on other OSes because they
             # don't need the extra indirection.
             raise unittest.SkipTest('bat indirection breaks internal sanity checks.')
+        elif is_osx():
+            binary = 'python'
         else:
+            binary = 'python2'
+
             # We not have python2, check for it
             for v in ['2', '2.7', '-2.7']:
                 rc = subprocess.call(['pkg-config', '--cflags', 'python{}'.format(v)],
@@ -6871,7 +6875,7 @@ class NativeFileTests(BasePlatformTests):
                     break
             else:
                 raise unittest.SkipTest('Not running Python 2 tests because dev packages not installed.')
-        self._simple_test('python', 'python2', entry='python')
+        self._simple_test('python', binary, entry='python')
 
     @unittest.skipIf(is_windows(), 'Setting up multiple compilers on windows is hard')
     @skip_if_env_set('CC')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6861,14 +6861,15 @@ class NativeFileTests(BasePlatformTests):
             # python module breaks. This is fine on other OSes because they
             # don't need the extra indirection.
             raise unittest.SkipTest('bat indirection breaks internal sanity checks.')
-        if os.path.exists('/etc/debian_version'):
-            rc = subprocess.call(['pkg-config', '--cflags', 'python2'],
-                                 stdout=subprocess.DEVNULL,
-                                 stderr=subprocess.DEVNULL)
-            if rc != 0:
-                # Python 2 will be removed in Debian Bullseye, thus we must
-                # remove the build dependency on python2-dev. Keep the tests
-                # but only run them if dev packages are available.
+        else:
+            # We not have python2, check for it
+            for v in ['2', '2.7', '-2.7']:
+                rc = subprocess.call(['pkg-config', '--cflags', 'python{}'.format(v)],
+                                     stdout=subprocess.DEVNULL,
+                                     stderr=subprocess.DEVNULL)
+                if rc == 0:
+                    break
+            else:
                 raise unittest.SkipTest('Not running Python 2 tests because dev packages not installed.')
         self._simple_test('python', 'python2', entry='python')
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6836,9 +6836,9 @@ class NativeFileTests(BasePlatformTests):
             '--native-file', config, '--native-file', config2,
             '-Dcase=find_program'])
 
-    def _simple_test(self, case, binary):
+    def _simple_test(self, case, binary, entry=None):
         wrapper = self.helper_create_binary_wrapper(binary, version='12345')
-        config = self.helper_create_native_file({'binaries': {binary: wrapper}})
+        config = self.helper_create_native_file({'binaries': {entry or binary: wrapper}})
         self.init(self.testcase, extra_args=['--native-file', config, '-Dcase={}'.format(case)])
 
     def test_find_program(self):
@@ -6870,7 +6870,7 @@ class NativeFileTests(BasePlatformTests):
                 # remove the build dependency on python2-dev. Keep the tests
                 # but only run them if dev packages are available.
                 raise unittest.SkipTest('Not running Python 2 tests because dev packages not installed.')
-        self._simple_test('python', 'python')
+        self._simple_test('python', 'python2', entry='python')
 
     @unittest.skipIf(is_windows(), 'Setting up multiple compilers on windows is hard')
     @skip_if_env_set('CC')


### PR DESCRIPTION
The old guidance from the python foundation was that "python" should point to 2.x, and that when 2.x EOLs that "python" should go away, that guidance has changed to "python" should now point to either "python2" or "python3". Given that we need to update some tests. This is complicated by the fact that macOS hasn't been updated, it still only has a "python" binary that is python2

I've also tried to update some of the "do you have python2" checks to be more generic.