### PR TITLE
environment: Fix construction of CudaLinker

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1129,7 +1129,7 @@ class Environment:
             cpp_compiler = self.detect_cpp_compiler(for_machine)
             cls = CudaCompiler
             self.coredata.add_lang_args(cls.language, cls, for_machine, self)
-            linker = CudaLinker(compiler, for_machine, 'nvlink', CudaCompiler.LINKER_PREFIX, [], version=CudaLinker.parse_version())
+            linker = CudaLinker(compiler, for_machine, CudaCompiler.LINKER_PREFIX, [], version=CudaLinker.parse_version())
             return cls(ccache + compiler, version, for_machine, is_cross, exe_wrap, host_compiler=cpp_compiler, info=info, linker=linker)
         raise EnvironmentException('Could not find suitable CUDA compiler: "' + ' '.join(compilers) + '"')
 


### PR DESCRIPTION
The 0.53.2 test suite has a new failure:

    Traceback (most recent call last):
      File "run_project_tests.py", line 1024, in <module>
        detect_system_compiler()
      File "run_project_tests.py", line 964, in detect_system_compiler
        comp = env.compiler_from_language(lang, MachineChoice.HOST)
      File "/build/meson/src/meson-0.53.2/mesonbuild/environment.py", line 1565, in compiler_from_language
        comp = self.detect_cuda_compiler(for_machine)
      File "/build/meson/src/meson-0.53.2/mesonbuild/environment.py", line 1131, in detect_cuda_compiler
        linker = CudaLinker(compiler, for_machine, 'nvlink', CudaCompiler.LINKER_PREFIX, [], version=CudaLinker.parse_version())
      File "/build/meson/src/meson-0.53.2/mesonbuild/linkers.py", line 963, in __init__
        super().__init__('nvlink', *args, **kwargs)
    TypeError: __init__() takes 6 positional arguments but 7 positional arguments (and 1 keyword-only argument) were given

Fixes: c708c52ca225 ("linkers: Update the linker names to be more consistent")