### PR TITLE
Implementation template factory and add Java 'meson.build' for Java developers.

### DIFF
--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -33,8 +33,10 @@ FORTRAN_SUFFIXES = {'.f', '.for', '.F', '.f90', '.F90'}
 LANG_SUFFIXES = {'.c', '.cc', '.cpp', '.cs', '.cu', '.d', '.m', '.mm', '.rs', '.java'} | FORTRAN_SUFFIXES
 LANG_SUPPORTED = {'c', 'cpp', 'cs', 'cuda', 'd', 'fortran', 'java', 'rust', 'objc', 'objcpp'}
 
-DEFAULT_PROJECT = 'executable'
-DEFAULT_VERSION = '0.1'
+class DEFAULT_VALUES(Enum):
+    PROJECT = 'executable'
+    VERSION = '0.1'
+
 class DEFAULT_TYPES(Enum):
     EXE = 'executable'
     LIB = 'library'
@@ -130,29 +132,31 @@ def add_arguments(parser):
     """Here we add args for that the user can passed when making a new
     Meson project.
     """
-    parser.add_argument("srcfiles", metavar="sourcefile", nargs="*", help="source files. default: all recognized files in current directory")
-    parser.add_argument("-n", "--name", help="project name. default: name of current directory")
-    parser.add_argument("-e", "--executable", help="executable name. default: project name")
+    parser.add_argument("srcfiles", metavar="sourcefile", nargs="*", help="source files. DEFAULT_VALUES: all recognized files in current directory")
+    parser.add_argument("-n", "--name", help="project name. DEFAULT_VALUES: name of current directory")
+    parser.add_argument("-e", "--executable", help="executable name. DEFAULT_VALUES: project name")
     parser.add_argument("-d", "--deps", help="dependencies, comma-separated")
-    parser.add_argument("-l", "--language", choices=LANG_SUPPORTED, help="project language. default: autodetected based on source files")
+    parser.add_argument("-l", "--language", choices=LANG_SUPPORTED, help="project language. DEFAULT_VALUES: autodetected based on source files")
     parser.add_argument("-b", "--build", action='store_true', help="build after generation")
-    parser.add_argument("--builddir", default='build', help="directory for build")
+    parser.add_argument("--builddir", DEFAULT_VALUES='build', help="directory for build")
     parser.add_argument("-f", "--force", action="store_true", help="force overwrite of existing files and directories.")
-    parser.add_argument('--type', default=DEFAULT_PROJECT, choices=('executable', 'library'), help="project type. default: {} based project".format(DEFAULT_PROJECT))
-    parser.add_argument('--version', default=DEFAULT_VERSION, help="project version. default: {}".format(DEFAULT_VERSION))
+    parser.add_argument('--type', DEFAULT_VALUES=DEFAULT_VALUES['PROJECT'].value, choices=('executable', 'library'),
+                        help="project type. DEFAULT_VALUES: {} based project".format(DEFAULT_VALUES['PROJECT'].value))
+    parser.add_argument('--version', DEFAULT_VALUES=DEFAULT_VALUES['VERSION'].value,
+                        help="project version. DEFAULT_VALUES: {}".format(DEFAULT_VALUES['VERSION'].value))
 
 def run(options) -> int:
     """Generate the new Meson sample project.
 
     First case we determine what language to use for the sample
-    generator and if the user did not spiffy, we use the default
+    generator and if the user did not spiffy, we use the DEFAULT_VALUES
     value of 'c'.  Second case we generate a Meson build script
     for your project. 
     """
     if not glob('*'):
         autodetect_options(options, sample=True)
         if not options.language:
-            print('Defaulting to generating a C language project.')
+            print('DEFAULT_VALUESing to generating a C language project.')
             options.language = 'c'
         create_sample(options)
     else:

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -24,9 +24,9 @@ from mesonbuild import mesonlib
 from mesonbuild.environment import detect_ninja
 from mesonbuild.templates.samplefactory import SampleFactory
 
-'''
+"""
 we currently have one meson template at this time.
-'''
+"""
 from mesonbuild.templates.mesontemplates import create_meson_build
 
 FORTRAN_SUFFIXES = {'.f', '.for', '.F', '.f90', '.F90'}
@@ -48,10 +48,9 @@ ninja -C builddir
 
 
 def create_sample(options) -> None:
-    '''
-    Based on what arguments are passed we check for a match in language
+    """Based on what arguments are passed we check for a match in language
     then check for project type and create new Meson samples project.
-    '''
+    """
     generator = SampleFactory()
     sample_gen = generator.sameple_generator(options)
     if options.type == DEFAULT_TYPES['EXE'].value:
@@ -63,10 +62,9 @@ def create_sample(options) -> None:
     print(INFO_MESSAGE)
 
 def autodetect_options(options, sample: bool = False) -> None:
-    '''
-    Here we autodetect options for args not passed in so don't have to
+    """Autodetect options for args not passed in so don't have to
     think about it.
-    '''
+    """
     if not options.name:
         options.name = Path().resolve().stem
         if not re.match('[a-zA-Z_][a-zA-Z0-9]*', options.name) and sample:
@@ -129,10 +127,9 @@ def autodetect_options(options, sample: bool = False) -> None:
         print("Detected language: " + options.language)
 
 def add_arguments(parser):
-    '''
-    Here we add args for that the user can passed when making a new
+    """Here we add args for that the user can passed when making a new
     Meson project.
-    '''
+    """
     parser.add_argument("srcfiles", metavar="sourcefile", nargs="*", help="source files. default: all recognized files in current directory")
     parser.add_argument("-n", "--name", help="project name. default: name of current directory")
     parser.add_argument("-e", "--executable", help="executable name. default: project name")
@@ -145,9 +142,13 @@ def add_arguments(parser):
     parser.add_argument('--version', default=DEFAULT_VERSION, help="project version. default: {}".format(DEFAULT_VERSION))
 
 def run(options) -> int:
-    '''
-    Here we generate the new Meson sample project.
-    '''
+    """Generate the new Meson sample project.
+
+    First case we determine what language to use for the sample
+    generator and if the user did not spiffy, we use the default
+    value of 'c'.  Second case we generate a Meson build script
+    for your project. 
+    """
     if not glob('*'):
         autodetect_options(options, sample=True)
         if not options.language:

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -24,9 +24,7 @@ from mesonbuild import mesonlib
 from mesonbuild.environment import detect_ninja
 from mesonbuild.templates.samplefactory import SampleFactory
 
-"""
-we currently have one meson template at this time.
-"""
+"""we currently have one meson template at this time."""
 from mesonbuild.templates.mesontemplates import create_meson_build
 
 FORTRAN_SUFFIXES = {'.f', '.for', '.F', '.f90', '.F90'}

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -132,26 +132,26 @@ def add_arguments(parser):
     """Here we add args for that the user can passed when making a new
     Meson project.
     """
-    parser.add_argument("srcfiles", metavar="sourcefile", nargs="*", help="source files. DEFAULT_VALUES: all recognized files in current directory")
-    parser.add_argument("-n", "--name", help="project name. DEFAULT_VALUES: name of current directory")
-    parser.add_argument("-e", "--executable", help="executable name. DEFAULT_VALUES: project name")
+    parser.add_argument("srcfiles", metavar="sourcefile", nargs="*", help="source files. default: all recognized files in current directory")
+    parser.add_argument("-n", "--name", help="project name. default: name of current directory")
+    parser.add_argument("-e", "--executable", help="executable name. default: project name")
     parser.add_argument("-d", "--deps", help="dependencies, comma-separated")
-    parser.add_argument("-l", "--language", choices=LANG_SUPPORTED, help="project language. DEFAULT_VALUES: autodetected based on source files")
+    parser.add_argument("-l", "--language", choices=LANG_SUPPORTED, help="project language. default: autodetected based on source files")
     parser.add_argument("-b", "--build", action='store_true', help="build after generation")
-    parser.add_argument("--builddir", DEFAULT_VALUES='build', help="directory for build")
+    parser.add_argument("--builddir", default='build', help="directory for build")
     parser.add_argument("-f", "--force", action="store_true", help="force overwrite of existing files and directories.")
-    parser.add_argument('--type', DEFAULT_VALUES=DEFAULT_VALUES['PROJECT'].value, choices=('executable', 'library'),
-                        help="project type. DEFAULT_VALUES: {} based project".format(DEFAULT_VALUES['PROJECT'].value))
-    parser.add_argument('--version', DEFAULT_VALUES=DEFAULT_VALUES['VERSION'].value,
-                        help="project version. DEFAULT_VALUES: {}".format(DEFAULT_VALUES['VERSION'].value))
+    parser.add_argument('--type', default=DEFAULT_VALUES['PROJECT'].value, choices=('executable', 'library'),
+                        help="project type. default: {} based project".format(DEFAULT_VALUES['PROJECT'].value))
+    parser.add_argument('--version', default=DEFAULT_VALUES['VERSION'].value,
+                        help="project version. default: {}".format(DEFAULT_VALUES['VERSION'].value))
 
 def run(options) -> int:
     """Generate the new Meson sample project.
 
     First case we determine what language to use for the sample
-    generator and if the user did not spiffy, we use the DEFAULT_VALUES
+    generator and if the user did not spiffy, we use the default
     value of 'c'.  Second case we generate a Meson build script
-    for your project. 
+    for your project.
     """
     if not glob('*'):
         autodetect_options(options, sample=True)

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -156,7 +156,7 @@ def run(options) -> int:
     if not glob('*'):
         autodetect_options(options, sample=True)
         if not options.language:
-            print('DEFAULT_VALUESing to generating a C language project.')
+            print('defaulting to generating a C language project.')
             options.language = 'c'
         create_sample(options)
     else:

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -22,17 +22,7 @@ import re
 from glob import glob
 from mesonbuild import mesonlib
 from mesonbuild.environment import detect_ninja
-
-from mesonbuild.templates.fortrantemplates import (create_exe_fortran_sample, create_lib_fortran_sample)
-from mesonbuild.templates.objcpptemplates import (create_exe_objcpp_sample, create_lib_objcpp_sample)
-from mesonbuild.templates.dlangtemplates import (create_exe_d_sample, create_lib_d_sample)
-from mesonbuild.templates.rusttemplates import (create_exe_rust_sample, create_lib_rust_sample)
-from mesonbuild.templates.javatemplates import (create_exe_java_sample, create_lib_java_sample)
-from mesonbuild.templates.cudatemplates import (create_exe_cuda_sample, create_lib_cuda_sample)
-from mesonbuild.templates.objctemplates import (create_exe_objc_sample, create_lib_objc_sample)
-from mesonbuild.templates.cpptemplates import (create_exe_cpp_sample, create_lib_cpp_sample)
-from mesonbuild.templates.cstemplates import (create_exe_cs_sample, create_lib_cs_sample)
-from mesonbuild.templates.ctemplates import (create_exe_c_sample, create_lib_c_sample)
+from mesonbuild.templates.samplefactory import SampleFactory
 
 '''
 we currently have one meson template at this time.
@@ -49,8 +39,6 @@ class DEFAULT_TYPES(Enum):
     EXE = 'executable'
     LIB = 'library'
 
-UNREACHABLE_CODE_ERROR = 'Unreachable code'
-
 INFO_MESSAGE = '''Sample project created. To build it run the
 following commands:
 
@@ -64,78 +52,14 @@ def create_sample(options) -> None:
     Based on what arguments are passed we check for a match in language
     then check for project type and create new Meson samples project.
     '''
-    if options.language == 'c':
-        if options.type == DEFAULT_TYPES['EXE'].value:
-            create_exe_c_sample(options.name, options.version)
-        elif options.type == DEFAULT_TYPES['LIB'].value:
-            create_lib_c_sample(options.name, options.version)
-        else:
-            raise RuntimeError(UNREACHABLE_CODE_ERROR)
-    elif options.language == 'cpp':
-        if options.type == DEFAULT_TYPES['EXE'].value:
-            create_exe_cpp_sample(options.name, options.version)
-        elif options.type == DEFAULT_TYPES['LIB'].value:
-            create_lib_cpp_sample(options.name, options.version)
-        else:
-            raise RuntimeError(UNREACHABLE_CODE_ERROR)
-    elif options.language == 'cs':
-        if options.type == DEFAULT_TYPES['EXE'].value:
-            create_exe_cs_sample(options.name, options.version)
-        elif options.type == DEFAULT_TYPES['LIB'].value:
-            create_lib_cs_sample(options.name, options.version)
-        else:
-            raise RuntimeError(UNREACHABLE_CODE_ERROR)
-    elif options.language == 'cuda':
-        if options.type == DEFAULT_TYPES['EXE'].value:
-            create_exe_cuda_sample(options.name, options.version)
-        elif options.type == DEFAULT_TYPES['LIB'].value:
-            create_lib_cuda_sample(options.name, options.version)
-        else:
-            raise RuntimeError(UNREACHABLE_CODE_ERROR)
-    elif options.language == 'd':
-        if options.type == DEFAULT_TYPES['EXE'].value:
-            create_exe_d_sample(options.name, options.version)
-        elif options.type == DEFAULT_TYPES['LIB'].value:
-            create_lib_d_sample(options.name, options.version)
-        else:
-            raise RuntimeError(UNREACHABLE_CODE_ERROR)
-    elif options.language == 'fortran':
-        if options.type == DEFAULT_TYPES['EXE'].value:
-            create_exe_fortran_sample(options.name, options.version)
-        elif options.type == DEFAULT_TYPES['LIB'].value:
-            create_lib_fortran_sample(options.name, options.version)
-        else:
-            raise RuntimeError(UNREACHABLE_CODE_ERROR)
-    elif options.language == 'rust':
-        if options.type == DEFAULT_TYPES['EXE'].value:
-            create_exe_rust_sample(options.name, options.version)
-        elif options.type == DEFAULT_TYPES['LIB'].value:
-            create_lib_rust_sample(options.name, options.version)
-        else:
-            raise RuntimeError(UNREACHABLE_CODE_ERROR)
-    elif options.language == 'objc':
-        if options.type == DEFAULT_TYPES['EXE'].value:
-            create_exe_objc_sample(options.name, options.version)
-        elif options.type == DEFAULT_TYPES['LIB'].value:
-            create_lib_objc_sample(options.name, options.version)
-        else:
-            raise RuntimeError(UNREACHABLE_CODE_ERROR)
-    elif options.language == 'objcpp':
-        if options.type == DEFAULT_TYPES['EXE'].value:
-            create_exe_objcpp_sample(options.name, options.version)
-        elif options.type == DEFAULT_TYPES['LIB'].value:
-            create_lib_objcpp_sample(options.name, options.version)
-        else:
-            raise RuntimeError(UNREACHABLE_CODE_ERROR)
-    elif options.language == 'java':
-        if options.type == DEFAULT_TYPES['EXE'].value:
-            create_exe_java_sample(options.name, options.version)
-        elif options.type == DEFAULT_TYPES['LIB'].value:
-            create_lib_java_sample(options.name, options.version)
-        else:
-            raise RuntimeError(UNREACHABLE_CODE_ERROR)
+    generator = SampleFactory()
+    sample_gen = generator.sameple_generator(options)
+    if options.type == DEFAULT_TYPES['EXE'].value:
+        sample_gen.create_executable()
+    elif options.type == DEFAULT_TYPES['LIB'].value:
+        sample_gen.create_library()
     else:
-        raise RuntimeError(UNREACHABLE_CODE_ERROR)
+        raise RuntimeError('Unreachable code')
     print(INFO_MESSAGE)
 
 def autodetect_options(options, sample: bool = False) -> None:

--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -139,40 +139,45 @@ pkg_mod.generate(
 '''
 
 
-def create_exe_cpp_sample(project_name, project_version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    source_name = lowercase_token + '.cpp'
-    open(source_name, 'w').write(hello_cpp_template.format(project_name=project_name))
-    open('meson.build', 'w').write(hello_cpp_meson_template.format(project_name=project_name,
-                                                                   exe_name=lowercase_token,
-                                                                   source_name=source_name,
-                                                                   version=project_version))
+class CppProject(object):
+    def __init__(self, options):
+        super().__init__()
+        self.name = options.name
+        self.version = options.version
 
+    def create_executable(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        source_name = lowercase_token + '.cpp'
+        open(source_name, 'w').write(hello_cpp_template.format(project_name=self.name))
+        open('meson.build', 'w').write(hello_cpp_meson_template.format(project_name=self.name,
+                                                                       exe_name=lowercase_token,
+                                                                       source_name=source_name,
+                                                                       version=self.version))
 
-def create_lib_cpp_sample(project_name, version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    uppercase_token = lowercase_token.upper()
-    class_name = uppercase_token[0] + lowercase_token[1:]
-    test_exe_name = lowercase_token + '_test'
-    namespace = lowercase_token
-    lib_hpp_name = lowercase_token + '.hpp'
-    lib_cpp_name = lowercase_token + '.cpp'
-    test_cpp_name = lowercase_token + '_test.cpp'
-    kwargs = {'utoken': uppercase_token,
-              'ltoken': lowercase_token,
-              'header_dir': lowercase_token,
-              'class_name': class_name,
-              'namespace': namespace,
-              'header_file': lib_hpp_name,
-              'source_file': lib_cpp_name,
-              'test_source_file': test_cpp_name,
-              'test_exe_name': test_exe_name,
-              'project_name': project_name,
-              'lib_name': lowercase_token,
-              'test_name': lowercase_token,
-              'version': version,
-              }
-    open(lib_hpp_name, 'w').write(lib_hpp_template.format(**kwargs))
-    open(lib_cpp_name, 'w').write(lib_cpp_template.format(**kwargs))
-    open(test_cpp_name, 'w').write(lib_cpp_test_template.format(**kwargs))
-    open('meson.build', 'w').write(lib_cpp_meson_template.format(**kwargs))
+    def create_library(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        uppercase_token = lowercase_token.upper()
+        class_name = uppercase_token[0] + lowercase_token[1:]
+        test_exe_name = lowercase_token + '_test'
+        namespace = lowercase_token
+        lib_hpp_name = lowercase_token + '.hpp'
+        lib_cpp_name = lowercase_token + '.cpp'
+        test_cpp_name = lowercase_token + '_test.cpp'
+        kwargs = {'utoken': uppercase_token,
+                  'ltoken': lowercase_token,
+                  'header_dir': lowercase_token,
+                  'class_name': class_name,
+                  'namespace': namespace,
+                  'header_file': lib_hpp_name,
+                  'source_file': lib_cpp_name,
+                  'test_source_file': test_cpp_name,
+                  'test_exe_name': test_exe_name,
+                  'project_name': self.name,
+                  'lib_name': lowercase_token,
+                  'test_name': lowercase_token,
+                  'version': self.version,
+                  }
+        open(lib_hpp_name, 'w').write(lib_hpp_template.format(**kwargs))
+        open(lib_cpp_name, 'w').write(lib_cpp_template.format(**kwargs))
+        open(test_cpp_name, 'w').write(lib_cpp_test_template.format(**kwargs))
+        open('meson.build', 'w').write(lib_cpp_meson_template.format(**kwargs))

--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from mesonbuild.templates.sampleimpl import SampleImpl
 import re
 
 
@@ -139,7 +140,7 @@ pkg_mod.generate(
 '''
 
 
-class CppProject(object):
+class CppProject(SampleImpl):
     def __init__(self, options):
         super().__init__()
         self.name = options.name

--- a/mesonbuild/templates/cstemplates.py
+++ b/mesonbuild/templates/cstemplates.py
@@ -88,39 +88,44 @@ test('{test_name}', test_exe)
 '''
 
 
-def create_exe_cs_sample(project_name, project_version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    uppercase_token = lowercase_token.upper()
-    class_name = uppercase_token[0] + lowercase_token[1:]
-    source_name = uppercase_token[0] + lowercase_token[1:] + '.cs'
-    open(source_name, 'w').write(hello_cs_template.format(project_name=project_name,
-                                                          class_name=class_name))
-    open('meson.build', 'w').write(hello_cs_meson_template.format(project_name=project_name,
-                                                                  exe_name=project_name,
-                                                                  source_name=source_name,
-                                                                  version=project_version))
+class CSharpProject(object):
+    def __init__(self, options):
+        super().__init__()
+        self.name = options.name
+        self.version = options.version
 
+    def create_executable(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        uppercase_token = lowercase_token.upper()
+        class_name = uppercase_token[0] + lowercase_token[1:]
+        source_name = uppercase_token[0] + lowercase_token[1:] + '.cs'
+        open(source_name, 'w').write(hello_cs_template.format(project_name=self.name,
+                                                              class_name=class_name))
+        open('meson.build', 'w').write(hello_cs_meson_template.format(project_name=self.name,
+                                                                      exe_name=self.name,
+                                                                      source_name=source_name,
+                                                                      version=self.version))
 
-def create_lib_cs_sample(project_name, version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    uppercase_token = lowercase_token.upper()
-    class_name = uppercase_token[0] + lowercase_token[1:]
-    class_test = uppercase_token[0] + lowercase_token[1:] + '_test'
-    project_test = lowercase_token + '_test'
-    lib_cs_name = uppercase_token[0] + lowercase_token[1:] + '.cs'
-    test_cs_name = uppercase_token[0] + lowercase_token[1:] + '_test.cs'
-    kwargs = {'utoken': uppercase_token,
-              'ltoken': lowercase_token,
-              'class_test': class_test,
-              'class_name': class_name,
-              'source_file': lib_cs_name,
-              'test_source_file': test_cs_name,
-              'test_exe_name': project_test,
-              'project_name': project_name,
-              'lib_name': lowercase_token,
-              'test_name': lowercase_token,
-              'version': version,
-              }
-    open(lib_cs_name, 'w').write(lib_cs_template.format(**kwargs))
-    open(test_cs_name, 'w').write(lib_cs_test_template.format(**kwargs))
-    open('meson.build', 'w').write(lib_cs_meson_template.format(**kwargs))
+    def create_library(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        uppercase_token = lowercase_token.upper()
+        class_name = uppercase_token[0] + lowercase_token[1:]
+        class_test = uppercase_token[0] + lowercase_token[1:] + '_test'
+        project_test = lowercase_token + '_test'
+        lib_cs_name = uppercase_token[0] + lowercase_token[1:] + '.cs'
+        test_cs_name = uppercase_token[0] + lowercase_token[1:] + '_test.cs'
+        kwargs = {'utoken': uppercase_token,
+                  'ltoken': lowercase_token,
+                  'class_test': class_test,
+                  'class_name': class_name,
+                  'source_file': lib_cs_name,
+                  'test_source_file': test_cs_name,
+                  'test_exe_name': project_test,
+                  'project_name': self.name,
+                  'lib_name': lowercase_token,
+                  'test_name': lowercase_token,
+                  'version': self.version,
+                  }
+        open(lib_cs_name, 'w').write(lib_cs_template.format(**kwargs))
+        open(test_cs_name, 'w').write(lib_cs_test_template.format(**kwargs))
+        open('meson.build', 'w').write(lib_cs_meson_template.format(**kwargs))

--- a/mesonbuild/templates/cstemplates.py
+++ b/mesonbuild/templates/cstemplates.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from mesonbuild.templates.sampleimpl import SampleImpl
 import re
 
 
@@ -88,7 +89,7 @@ test('{test_name}', test_exe)
 '''
 
 
-class CSharpProject(object):
+class CSharpProject(SampleImpl):
     def __init__(self, options):
         super().__init__()
         self.name = options.name

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from mesonbuild.templates.sampleimpl import SampleImpl
 import re
 
 
@@ -122,7 +123,7 @@ test('basic', exe)
 '''
 
 
-class CProject(object):
+class CProject(SampleImpl):
     def __init__(self, options):
         super().__init__()
         self.name = options.name

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -121,37 +121,44 @@ exe = executable('{exe_name}', '{source_name}',
 test('basic', exe)
 '''
 
-def create_exe_c_sample(project_name, project_version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    source_name = lowercase_token + '.c'
-    open(source_name, 'w').write(hello_c_template.format(project_name=project_name))
-    open('meson.build', 'w').write(hello_c_meson_template.format(project_name=project_name,
-                                                                 exe_name=lowercase_token,
-                                                                 source_name=source_name,
-                                                                 version=project_version))
 
-def create_lib_c_sample(project_name, version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    uppercase_token = lowercase_token.upper()
-    function_name = lowercase_token[0:3] + '_func'
-    test_exe_name = lowercase_token + '_test'
-    lib_h_name = lowercase_token + '.h'
-    lib_c_name = lowercase_token + '.c'
-    test_c_name = lowercase_token + '_test.c'
-    kwargs = {'utoken': uppercase_token,
-              'ltoken': lowercase_token,
-              'header_dir': lowercase_token,
-              'function_name': function_name,
-              'header_file': lib_h_name,
-              'source_file': lib_c_name,
-              'test_source_file': test_c_name,
-              'test_exe_name': test_exe_name,
-              'project_name': project_name,
-              'lib_name': lowercase_token,
-              'test_name': lowercase_token,
-              'version': version,
-              }
-    open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
-    open(lib_c_name, 'w').write(lib_c_template.format(**kwargs))
-    open(test_c_name, 'w').write(lib_c_test_template.format(**kwargs))
-    open('meson.build', 'w').write(lib_c_meson_template.format(**kwargs))
+class CProject(object):
+    def __init__(self, options):
+        super().__init__()
+        self.name = options.name
+        self.version = options.version
+
+    def create_executable(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        source_name = lowercase_token + '.c'
+        open(source_name, 'w').write(hello_c_template.format(project_name=self.name))
+        open('meson.build', 'w').write(hello_c_meson_template.format(project_name=self.name,
+                                                                     exe_name=lowercase_token,
+                                                                     source_name=source_name,
+                                                                     version=self.version))
+
+    def create_library(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        uppercase_token = lowercase_token.upper()
+        function_name = lowercase_token[0:3] + '_func'
+        test_exe_name = lowercase_token + '_test'
+        lib_h_name = lowercase_token + '.h'
+        lib_c_name = lowercase_token + '.c'
+        test_c_name = lowercase_token + '_test.c'
+        kwargs = {'utoken': uppercase_token,
+                  'ltoken': lowercase_token,
+                  'header_dir': lowercase_token,
+                  'function_name': function_name,
+                  'header_file': lib_h_name,
+                  'source_file': lib_c_name,
+                  'test_source_file': test_c_name,
+                  'test_exe_name': test_exe_name,
+                  'project_name': self.name,
+                  'lib_name': lowercase_token,
+                  'test_name': lowercase_token,
+                  'version': self.version,
+                  }
+        open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
+        open(lib_c_name, 'w').write(lib_c_template.format(**kwargs))
+        open(test_c_name, 'w').write(lib_c_test_template.format(**kwargs))
+        open('meson.build', 'w').write(lib_c_meson_template.format(**kwargs))

--- a/mesonbuild/templates/cudatemplates.py
+++ b/mesonbuild/templates/cudatemplates.py
@@ -139,40 +139,45 @@ pkg_mod.generate(
 '''
 
 
-def create_exe_cuda_sample(project_name, project_version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    source_name = lowercase_token + '.cu'
-    open(source_name, 'w').write(hello_cuda_template.format(project_name=project_name))
-    open('meson.build', 'w').write(hello_cuda_meson_template.format(project_name=project_name,
-                                                                    exe_name=lowercase_token,
-                                                                    source_name=source_name,
-                                                                    version=project_version))
+class CudaProject(object):
+    def __init__(self, options):
+        super().__init__()
+        self.name = options.name
+        self.version = options.version
 
+    def create_executable(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        source_name = lowercase_token + '.cu'
+        open(source_name, 'w').write(hello_cuda_template.format(project_name=self.name))
+        open('meson.build', 'w').write(hello_cuda_meson_template.format(project_name=self.name,
+                                                                        exe_name=lowercase_token,
+                                                                        source_name=source_name,
+                                                                        version=self.version))
 
-def create_lib_cuda_sample(project_name, version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    uppercase_token = lowercase_token.upper()
-    class_name = uppercase_token[0] + lowercase_token[1:]
-    test_exe_name = lowercase_token + '_test'
-    namespace = lowercase_token
-    lib_h_name = lowercase_token + '.h'
-    lib_cuda_name = lowercase_token + '.cu'
-    test_cuda_name = lowercase_token + '_test.cu'
-    kwargs = {'utoken': uppercase_token,
-              'ltoken': lowercase_token,
-              'header_dir': lowercase_token,
-              'class_name': class_name,
-              'namespace': namespace,
-              'header_file': lib_h_name,
-              'source_file': lib_cuda_name,
-              'test_source_file': test_cuda_name,
-              'test_exe_name': test_exe_name,
-              'project_name': project_name,
-              'lib_name': lowercase_token,
-              'test_name': lowercase_token,
-              'version': version,
-              }
-    open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
-    open(lib_cuda_name, 'w').write(lib_cuda_template.format(**kwargs))
-    open(test_cuda_name, 'w').write(lib_cuda_test_template.format(**kwargs))
-    open('meson.build', 'w').write(lib_cuda_meson_template.format(**kwargs))
+    def create_library(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        uppercase_token = lowercase_token.upper()
+        class_name = uppercase_token[0] + lowercase_token[1:]
+        test_exe_name = lowercase_token + '_test'
+        namespace = lowercase_token
+        lib_h_name = lowercase_token + '.h'
+        lib_cuda_name = lowercase_token + '.cu'
+        test_cuda_name = lowercase_token + '_test.cu'
+        kwargs = {'utoken': uppercase_token,
+                  'ltoken': lowercase_token,
+                  'header_dir': lowercase_token,
+                  'class_name': class_name,
+                  'namespace': namespace,
+                  'header_file': lib_h_name,
+                  'source_file': lib_cuda_name,
+                  'test_source_file': test_cuda_name,
+                  'test_exe_name': test_exe_name,
+                  'project_name': self.name,
+                  'lib_name': lowercase_token,
+                  'test_name': lowercase_token,
+                  'version': self.version,
+                  }
+        open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
+        open(lib_cuda_name, 'w').write(lib_cuda_template.format(**kwargs))
+        open(test_cuda_name, 'w').write(lib_cuda_test_template.format(**kwargs))
+        open('meson.build', 'w').write(lib_cuda_meson_template.format(**kwargs))

--- a/mesonbuild/templates/cudatemplates.py
+++ b/mesonbuild/templates/cudatemplates.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from mesonbuild.templates.sampleimpl import SampleImpl
 import re
 
 
@@ -139,7 +140,7 @@ pkg_mod.generate(
 '''
 
 
-class CudaProject(object):
+class CudaProject(SampleImpl):
     def __init__(self, options):
         super().__init__()
         self.name = options.name

--- a/mesonbuild/templates/dlangtemplates.py
+++ b/mesonbuild/templates/dlangtemplates.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from mesonbuild.templates.sampleimpl import SampleImpl
 import re
 
 
@@ -100,7 +101,7 @@ endif
 '''
 
 
-class DlangProject(object):
+class DlangProject(SampleImpl):
     def __init__(self, options):
         super().__init__()
         self.name = options.name

--- a/mesonbuild/templates/dlangtemplates.py
+++ b/mesonbuild/templates/dlangtemplates.py
@@ -99,37 +99,43 @@ if find_program('dub', required: false).found()
 endif
 '''
 
-def create_exe_d_sample(project_name, project_version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    source_name = lowercase_token + '.d'
-    open(source_name, 'w').write(hello_d_template.format(project_name=project_name))
-    open('meson.build', 'w').write(hello_d_meson_template.format(project_name=project_name,
-                                                                 exe_name=lowercase_token,
-                                                                 source_name=source_name,
-                                                                 version=project_version))
 
+class DlangProject(object):
+    def __init__(self, options):
+        super().__init__()
+        self.name = options.name
+        self.version = options.version
 
-def create_lib_d_sample(project_name, version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    uppercase_token = lowercase_token.upper()
-    function_name = lowercase_token[0:3] + '_func'
-    test_exe_name = lowercase_token + '_test'
-    lib_m_name = lowercase_token
-    lib_d_name = lowercase_token + '.d'
-    test_d_name = lowercase_token + '_test.d'
-    kwargs = {'utoken': uppercase_token,
-              'ltoken': lowercase_token,
-              'header_dir': lowercase_token,
-              'function_name': function_name,
-              'module_file': lib_m_name,
-              'source_file': lib_d_name,
-              'test_source_file': test_d_name,
-              'test_exe_name': test_exe_name,
-              'project_name': project_name,
-              'lib_name': lowercase_token,
-              'test_name': lowercase_token,
-              'version': version,
-              }
-    open(lib_d_name, 'w').write(lib_d_template.format(**kwargs))
-    open(test_d_name, 'w').write(lib_d_test_template.format(**kwargs))
-    open('meson.build', 'w').write(lib_d_meson_template.format(**kwargs))
+    def create_executable(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        source_name = lowercase_token + '.d'
+        open(source_name, 'w').write(hello_d_template.format(project_name=self.name))
+        open('meson.build', 'w').write(hello_d_meson_template.format(project_name=self.name,
+                                                                     exe_name=lowercase_token,
+                                                                     source_name=source_name,
+                                                                     version=self.version))
+
+    def create_library(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        uppercase_token = lowercase_token.upper()
+        function_name = lowercase_token[0:3] + '_func'
+        test_exe_name = lowercase_token + '_test'
+        lib_m_name = lowercase_token
+        lib_d_name = lowercase_token + '.d'
+        test_d_name = lowercase_token + '_test.d'
+        kwargs = {'utoken': uppercase_token,
+                  'ltoken': lowercase_token,
+                  'header_dir': lowercase_token,
+                  'function_name': function_name,
+                  'module_file': lib_m_name,
+                  'source_file': lib_d_name,
+                  'test_source_file': test_d_name,
+                  'test_exe_name': test_exe_name,
+                  'project_name': self.name,
+                  'lib_name': lowercase_token,
+                  'test_name': lowercase_token,
+                  'version': self.version,
+                  }
+        open(lib_d_name, 'w').write(lib_d_template.format(**kwargs))
+        open(test_d_name, 'w').write(lib_d_test_template.format(**kwargs))
+        open('meson.build', 'w').write(lib_d_meson_template.format(**kwargs))

--- a/mesonbuild/templates/fortrantemplates.py
+++ b/mesonbuild/templates/fortrantemplates.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from mesonbuild.templates.sampleimpl import SampleImpl
 import re
 
 lib_fortran_template = '''
@@ -99,7 +100,7 @@ test('basic', exe)
 '''
 
 
-class FortranProject(object):
+class FortranProject(SampleImpl):
     def __init__(self, options):
         super().__init__()
         self.name = options.name

--- a/mesonbuild/templates/fortrantemplates.py
+++ b/mesonbuild/templates/fortrantemplates.py
@@ -98,34 +98,41 @@ exe = executable('{exe_name}', '{source_name}',
 test('basic', exe)
 '''
 
-def create_exe_fortran_sample(project_name, project_version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    source_name = lowercase_token + '.f90'
-    open(source_name, 'w').write(hello_fortran_template.format(project_name=project_name))
-    open('meson.build', 'w').write(hello_fortran_meson_template.format(project_name=project_name,
-                                                                       exe_name=lowercase_token,
-                                                                       source_name=source_name,
-                                                                       version=project_version))
 
-def create_lib_fortran_sample(project_name, version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    uppercase_token = lowercase_token.upper()
-    function_name = lowercase_token[0:3] + '_func'
-    test_exe_name = lowercase_token + '_test'
-    lib_fortran_name = lowercase_token + '.f90'
-    test_fortran_name = lowercase_token + '_test.f90'
-    kwargs = {'utoken': uppercase_token,
-              'ltoken': lowercase_token,
-              'header_dir': lowercase_token,
-              'function_name': function_name,
-              'source_file': lib_fortran_name,
-              'test_source_file': test_fortran_name,
-              'test_exe_name': test_exe_name,
-              'project_name': project_name,
-              'lib_name': lowercase_token,
-              'test_name': lowercase_token,
-              'version': version,
-              }
-    open(lib_fortran_name, 'w').write(lib_fortran_template.format(**kwargs))
-    open(test_fortran_name, 'w').write(lib_fortran_test_template.format(**kwargs))
-    open('meson.build', 'w').write(lib_fortran_meson_template.format(**kwargs))
+class FortranProject(object):
+    def __init__(self, options):
+        super().__init__()
+        self.name = options.name
+        self.version = options.version
+
+    def create_executable(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        source_name = lowercase_token + '.f90'
+        open(source_name, 'w').write(hello_fortran_template.format(project_name=self.name))
+        open('meson.build', 'w').write(hello_fortran_meson_template.format(project_name=self.name,
+                                                                           exe_name=lowercase_token,
+                                                                           source_name=source_name,
+                                                                           version=self.version))
+
+    def create_library(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        uppercase_token = lowercase_token.upper()
+        function_name = lowercase_token[0:3] + '_func'
+        test_exe_name = lowercase_token + '_test'
+        lib_fortran_name = lowercase_token + '.f90'
+        test_fortran_name = lowercase_token + '_test.f90'
+        kwargs = {'utoken': uppercase_token,
+                  'ltoken': lowercase_token,
+                  'header_dir': lowercase_token,
+                  'function_name': function_name,
+                  'source_file': lib_fortran_name,
+                  'test_source_file': test_fortran_name,
+                  'test_exe_name': test_exe_name,
+                  'project_name': self.name,
+                  'lib_name': lowercase_token,
+                  'test_name': lowercase_token,
+                  'version': self.version,
+                  }
+        open(lib_fortran_name, 'w').write(lib_fortran_template.format(**kwargs))
+        open(test_fortran_name, 'w').write(lib_fortran_test_template.format(**kwargs))
+        open('meson.build', 'w').write(lib_fortran_meson_template.format(**kwargs))

--- a/mesonbuild/templates/javatemplates.py
+++ b/mesonbuild/templates/javatemplates.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from mesonbuild.templates.sampleimpl import SampleImpl
 import re
 
 
@@ -92,7 +93,7 @@ test('{test_name}', test_jar)
 '''
 
 
-class JavaProject(object):
+class JavaProject(SampleImpl):
     def __init__(self, options):
         super().__init__()
         self.name = options.name

--- a/mesonbuild/templates/javatemplates.py
+++ b/mesonbuild/templates/javatemplates.py
@@ -92,37 +92,42 @@ test('{test_name}', test_jar)
 '''
 
 
-def create_exe_java_sample(project_name, project_version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    uppercase_token = lowercase_token.upper()
-    class_name = uppercase_token[0] + lowercase_token[1:]
-    source_name = uppercase_token[0] + lowercase_token[1:] + '.java'
-    open(source_name, 'w').write(hello_java_template.format(project_name=project_name,
-                                                            class_name=class_name))
-    open('meson.build', 'w').write(hello_java_meson_template.format(project_name=project_name,
-                                                                    exe_name=class_name,
-                                                                    source_name=source_name,
-                                                                    version=project_version))
+class JavaProject(object):
+    def __init__(self, options):
+        super().__init__()
+        self.name = options.name
+        self.version = options.version
 
+    def create_executable(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        uppercase_token = lowercase_token.upper()
+        class_name = uppercase_token[0] + lowercase_token[1:]
+        source_name = uppercase_token[0] + lowercase_token[1:] + '.java'
+        open(source_name, 'w').write(hello_java_template.format(project_name=self.name,
+                                                                class_name=class_name))
+        open('meson.build', 'w').write(hello_java_meson_template.format(project_name=self.name,
+                                                                        exe_name=class_name,
+                                                                        source_name=source_name,
+                                                                        version=self.version))
 
-def create_lib_java_sample(project_name, version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    uppercase_token = lowercase_token.upper()
-    class_name = uppercase_token[0] + lowercase_token[1:]
-    class_test = uppercase_token[0] + lowercase_token[1:] + '_test'
-    lib_java_name = uppercase_token[0] + lowercase_token[1:] + '.java'
-    test_java_name = uppercase_token[0] + lowercase_token[1:] + '_test.java'
-    kwargs = {'utoken': uppercase_token,
-              'ltoken': lowercase_token,
-              'class_test': class_test,
-              'class_name': class_name,
-              'source_file': lib_java_name,
-              'test_source_file': test_java_name,
-              'project_name': project_name,
-              'lib_name': lowercase_token,
-              'test_name': lowercase_token,
-              'version': version,
-              }
-    open(lib_java_name, 'w').write(lib_java_template.format(**kwargs))
-    open(test_java_name, 'w').write(lib_java_test_template.format(**kwargs))
-    open('meson.build', 'w').write(lib_java_meson_template.format(**kwargs))
+    def create_library(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        uppercase_token = lowercase_token.upper()
+        class_name = uppercase_token[0] + lowercase_token[1:]
+        class_test = uppercase_token[0] + lowercase_token[1:] + '_test'
+        lib_java_name = uppercase_token[0] + lowercase_token[1:] + '.java'
+        test_java_name = uppercase_token[0] + lowercase_token[1:] + '_test.java'
+        kwargs = {'utoken': uppercase_token,
+                  'ltoken': lowercase_token,
+                  'class_test': class_test,
+                  'class_name': class_name,
+                  'source_file': lib_java_name,
+                  'test_source_file': test_java_name,
+                  'project_name': self.name,
+                  'lib_name': lowercase_token,
+                  'test_name': lowercase_token,
+                  'version': self.version,
+                  }
+        open(lib_java_name, 'w').write(lib_java_template.format(**kwargs))
+        open(test_java_name, 'w').write(lib_java_test_template.format(**kwargs))
+        open('meson.build', 'w').write(lib_java_meson_template.format(**kwargs))

--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -57,7 +57,6 @@ def create_meson_build(options):
                                                    version=options.version,
                                                    executable=options.executable,
                                                    sourcespec=sourcespec,
-                                                   main_class=options.name,
                                                    depspec=depspec,
                                                    default_options=formatted_default_options)
     else:
@@ -65,6 +64,7 @@ def create_meson_build(options):
                                             language=options.language,
                                             version=options.version,
                                             executable=options.executable,
+                                            main_class=options.name,
                                             sourcespec=sourcespec,
                                             depspec=depspec,
                                             default_options=formatted_default_options)

--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -27,7 +27,7 @@ meson_jar_template = '''project('{project_name}', '{language}',
   default_options : [{default_options}])
 
 jar('{executable}',
-    {sourcespec},{depspec}
+    {sourcespec},{main_class},{depspec}
     install : true)
 '''
 
@@ -57,6 +57,7 @@ def create_meson_build(options):
                                                    version=options.version,
                                                    executable=options.executable,
                                                    sourcespec=sourcespec,
+                                                   main_class=options.name,
                                                    depspec=depspec,
                                                    default_options=formatted_default_options)
     else:

--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -21,6 +21,17 @@ executable('{executable}',
            install : true)
 '''
 
+
+meson_jar_template = '''project('{project_name}', '{language}',
+  version : '{version}',
+  default_options : [{default_options}])
+
+jar('{executable}',
+    {sourcespec},{depspec}
+    install : true)
+'''
+
+
 def create_meson_build(options):
     if options.type != 'executable':
         raise SystemExit('\nGenerating a meson.build file from existing sources is\n'
@@ -40,12 +51,21 @@ def create_meson_build(options):
         depspec += ',\n              '.join("dependency('{}')".format(x)
                                             for x in options.deps.split(','))
         depspec += '],'
-    content = meson_executable_template.format(project_name=options.name,
-                                               language=options.language,
-                                               version=options.version,
-                                               executable=options.executable,
-                                               sourcespec=sourcespec,
-                                               depspec=depspec,
-                                               default_options=formatted_default_options)
+    if options.language != 'java':
+        content = meson_executable_template.format(project_name=options.name,
+                                                   language=options.language,
+                                                   version=options.version,
+                                                   executable=options.executable,
+                                                   sourcespec=sourcespec,
+                                                   depspec=depspec,
+                                                   default_options=formatted_default_options)
+    else:
+        content = meson_jar_template.format(project_name=options.name,
+                                            language=options.language,
+                                            version=options.version,
+                                            executable=options.executable,
+                                            sourcespec=sourcespec,
+                                            depspec=depspec,
+                                            default_options=formatted_default_options)
     open('meson.build', 'w').write(content)
     print('Generated meson.build file:\n\n' + content)

--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -27,7 +27,8 @@ meson_jar_template = '''project('{project_name}', '{language}',
   default_options : [{default_options}])
 
 jar('{executable}',
-    {sourcespec},{main_class},{depspec}
+    {sourcespec},{depspec},
+    main_class: {main_class},
     install : true)
 '''
 

--- a/mesonbuild/templates/objcpptemplates.py
+++ b/mesonbuild/templates/objcpptemplates.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from mesonbuild.templates.sampleimpl import SampleImpl
 import re
 
 
@@ -122,7 +123,7 @@ test('basic', exe)
 '''
 
 
-class ObjCppProject(object):
+class ObjCppProject(SampleImpl):
     def __init__(self, options):
         super().__init__()
         self.name = options.name

--- a/mesonbuild/templates/objcpptemplates.py
+++ b/mesonbuild/templates/objcpptemplates.py
@@ -121,37 +121,45 @@ exe = executable('{exe_name}', '{source_name}',
 test('basic', exe)
 '''
 
-def create_exe_objcpp_sample(project_name, project_version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    source_name = lowercase_token + '.mm'
-    open(source_name, 'w').write(hello_objcpp_template.format(project_name=project_name))
-    open('meson.build', 'w').write(hello_objcpp_meson_template.format(project_name=project_name,
-                                                                      exe_name=lowercase_token,
-                                                                      source_name=source_name,
-                                                                      version=project_version))
 
-def create_lib_objcpp_sample(project_name, version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    uppercase_token = lowercase_token.upper()
-    function_name = lowercase_token[0:3] + '_func'
-    test_exe_name = lowercase_token + '_test'
-    lib_h_name = lowercase_token + '.h'
-    lib_objcpp_name = lowercase_token + '.mm'
-    test_objcpp_name = lowercase_token + '_test.mm'
-    kwargs = {'utoken': uppercase_token,
-              'ltoken': lowercase_token,
-              'header_dir': lowercase_token,
-              'function_name': function_name,
-              'header_file': lib_h_name,
-              'source_file': lib_objcpp_name,
-              'test_source_file': test_objcpp_name,
-              'test_exe_name': test_exe_name,
-              'project_name': project_name,
-              'lib_name': lowercase_token,
-              'test_name': lowercase_token,
-              'version': version,
-              }
-    open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
-    open(lib_objcpp_name, 'w').write(lib_objcpp_template.format(**kwargs))
-    open(test_objcpp_name, 'w').write(lib_objcpp_test_template.format(**kwargs))
-    open('meson.build', 'w').write(lib_objcpp_meson_template.format(**kwargs))
+class ObjCppProject(object):
+    def __init__(self, options):
+        super().__init__()
+        self.name = options.name
+        self.version = options.version
+
+    def create_executable(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        source_name = lowercase_token + '.mm'
+        open(source_name, 'w').write(hello_objcpp_template.format(project_name=self.name))
+        open('meson.build', 'w').write(hello_objcpp_meson_template.format(project_name=self.name,
+                                                                          exe_name=lowercase_token,
+                                                                          source_name=source_name,
+                                                                          version=self.version))
+
+    def create_library(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        uppercase_token = lowercase_token.upper()
+        function_name = lowercase_token[0:3] + '_func'
+        test_exe_name = lowercase_token + '_test'
+        lib_h_name = lowercase_token + '.h'
+        lib_objcpp_name = lowercase_token + '.mm'
+        test_objcpp_name = lowercase_token + '_test.mm'
+        kwargs = {'utoken': uppercase_token,
+                  'ltoken': lowercase_token,
+                  'header_dir': lowercase_token,
+                  'function_name': function_name,
+                  'header_file': lib_h_name,
+                  'source_file': lib_objcpp_name,
+                  'test_source_file': test_objcpp_name,
+                  'test_exe_name': test_exe_name,
+                  'project_name': self.name,
+                  'lib_name': lowercase_token,
+                  'test_name': lowercase_token,
+                  'version': self.version,
+                  }
+        open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
+        open(lib_objcpp_name, 'w').write(lib_objcpp_template.format(**kwargs))
+        open(test_objcpp_name, 'w').write(lib_objcpp_test_template.format(**kwargs))
+        open('meson.build', 'w').write(lib_objcpp_meson_template.format(**kwargs))
+

--- a/mesonbuild/templates/objctemplates.py
+++ b/mesonbuild/templates/objctemplates.py
@@ -121,37 +121,44 @@ exe = executable('{exe_name}', '{source_name}',
 test('basic', exe)
 '''
 
-def create_exe_objc_sample(project_name, project_version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    source_name = lowercase_token + '.m'
-    open(source_name, 'w').write(hello_objc_template.format(project_name=project_name))
-    open('meson.build', 'w').write(hello_objc_meson_template.format(project_name=project_name,
-                                                                    exe_name=lowercase_token,
-                                                                    source_name=source_name,
-                                                                    version=project_version))
 
-def create_lib_objc_sample(project_name, version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    uppercase_token = lowercase_token.upper()
-    function_name = lowercase_token[0:3] + '_func'
-    test_exe_name = lowercase_token + '_test'
-    lib_h_name = lowercase_token + '.h'
-    lib_objc_name = lowercase_token + '.m'
-    test_objc_name = lowercase_token + '_test.m'
-    kwargs = {'utoken': uppercase_token,
-              'ltoken': lowercase_token,
-              'header_dir': lowercase_token,
-              'function_name': function_name,
-              'header_file': lib_h_name,
-              'source_file': lib_objc_name,
-              'test_source_file': test_objc_name,
-              'test_exe_name': test_exe_name,
-              'project_name': project_name,
-              'lib_name': lowercase_token,
-              'test_name': lowercase_token,
-              'version': version,
-              }
-    open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
-    open(lib_objc_name, 'w').write(lib_objc_template.format(**kwargs))
-    open(test_objc_name, 'w').write(lib_objc_test_template.format(**kwargs))
-    open('meson.build', 'w').write(lib_objc_meson_template.format(**kwargs))
+class ObjCProject(object):
+    def __init__(self, options):
+        super().__init__()
+        self.name = options.name
+        self.version = options.version
+
+    def create_executable(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        source_name = lowercase_token + '.m'
+        open(source_name, 'w').write(hello_objc_template.format(project_name=self.name))
+        open('meson.build', 'w').write(hello_objc_meson_template.format(project_name=self.name,
+                                                                        exe_name=lowercase_token,
+                                                                        source_name=source_name,
+                                                                        version=self.version))
+
+    def create_library(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        uppercase_token = lowercase_token.upper()
+        function_name = lowercase_token[0:3] + '_func'
+        test_exe_name = lowercase_token + '_test'
+        lib_h_name = lowercase_token + '.h'
+        lib_objc_name = lowercase_token + '.m'
+        test_objc_name = lowercase_token + '_test.m'
+        kwargs = {'utoken': uppercase_token,
+                  'ltoken': lowercase_token,
+                  'header_dir': lowercase_token,
+                  'function_name': function_name,
+                  'header_file': lib_h_name,
+                  'source_file': lib_objc_name,
+                  'test_source_file': test_objc_name,
+                  'test_exe_name': test_exe_name,
+                  'project_name': self.name,
+                  'lib_name': lowercase_token,
+                  'test_name': lowercase_token,
+                  'version': self.version,
+                  }
+        open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
+        open(lib_objc_name, 'w').write(lib_objc_template.format(**kwargs))
+        open(test_objc_name, 'w').write(lib_objc_test_template.format(**kwargs))
+        open('meson.build', 'w').write(lib_objc_meson_template.format(**kwargs))

--- a/mesonbuild/templates/objctemplates.py
+++ b/mesonbuild/templates/objctemplates.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from mesonbuild.templates.sampleimpl import SampleImpl
 import re
 
 
@@ -122,7 +123,7 @@ test('basic', exe)
 '''
 
 
-class ObjCProject(object):
+class ObjCProject(SampleImpl):
     def __init__(self, options):
         super().__init__()
         self.name = options.name

--- a/mesonbuild/templates/rusttemplates.py
+++ b/mesonbuild/templates/rusttemplates.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from mesonbuild.templates.sampleimpl import SampleImpl
 import re
 
 
@@ -70,7 +71,7 @@ test('basic', exe)
 '''
 
 
-class RustProject(object):
+class RustProject(SampleImpl):
     def __init__(self, options):
         super().__init__()
         self.name = options.name

--- a/mesonbuild/templates/rusttemplates.py
+++ b/mesonbuild/templates/rusttemplates.py
@@ -69,36 +69,43 @@ exe = executable('{exe_name}', '{source_name}',
 test('basic', exe)
 '''
 
-def create_exe_rust_sample(project_name, project_version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    source_name = lowercase_token + '.rs'
-    open(source_name, 'w').write(hello_rust_template.format(project_name=project_name))
-    open('meson.build', 'w').write(hello_rust_meson_template.format(project_name=project_name,
-                                                                    exe_name=lowercase_token,
-                                                                    source_name=source_name,
-                                                                    version=project_version))
 
-def create_lib_rust_sample(project_name, version):
-    lowercase_token = re.sub(r'[^a-z0-9]', '_', project_name.lower())
-    uppercase_token = lowercase_token.upper()
-    function_name = lowercase_token[0:3] + '_func'
-    test_exe_name = lowercase_token + '_test'
-    lib_crate_name = lowercase_token
-    lib_rs_name = lowercase_token + '.rs'
-    test_rs_name = lowercase_token + '_test.rs'
-    kwargs = {'utoken': uppercase_token,
-              'ltoken': lowercase_token,
-              'header_dir': lowercase_token,
-              'function_name': function_name,
-              'crate_file': lib_crate_name,
-              'source_file': lib_rs_name,
-              'test_source_file': test_rs_name,
-              'test_exe_name': test_exe_name,
-              'project_name': project_name,
-              'lib_name': lowercase_token,
-              'test_name': lowercase_token,
-              'version': version,
-              }
-    open(lib_rs_name, 'w').write(lib_rust_template.format(**kwargs))
-    open(test_rs_name, 'w').write(lib_rust_test_template.format(**kwargs))
-    open('meson.build', 'w').write(lib_rust_meson_template.format(**kwargs))
+class RustProject(object):
+    def __init__(self, options):
+        super().__init__()
+        self.name = options.name
+        self.version = options.version
+
+    def create_executable(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        source_name = lowercase_token + '.rs'
+        open(source_name, 'w').write(hello_rust_template.format(project_name=self.name))
+        open('meson.build', 'w').write(hello_rust_meson_template.format(project_name=self.name,
+                                                                        exe_name=lowercase_token,
+                                                                        source_name=source_name,
+                                                                        version=self.version))
+
+    def create_library(self):
+        lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
+        uppercase_token = lowercase_token.upper()
+        function_name = lowercase_token[0:3] + '_func'
+        test_exe_name = lowercase_token + '_test'
+        lib_crate_name = lowercase_token
+        lib_rs_name = lowercase_token + '.rs'
+        test_rs_name = lowercase_token + '_test.rs'
+        kwargs = {'utoken': uppercase_token,
+                  'ltoken': lowercase_token,
+                  'header_dir': lowercase_token,
+                  'function_name': function_name,
+                  'crate_file': lib_crate_name,
+                  'source_file': lib_rs_name,
+                  'test_source_file': test_rs_name,
+                  'test_exe_name': test_exe_name,
+                  'project_name': self.name,
+                  'lib_name': lowercase_token,
+                  'test_name': lowercase_token,
+                  'version': self.version,
+                  }
+        open(lib_rs_name, 'w').write(lib_rust_template.format(**kwargs))
+        open(test_rs_name, 'w').write(lib_rust_test_template.format(**kwargs))
+        open('meson.build', 'w').write(lib_rust_meson_template.format(**kwargs))

--- a/mesonbuild/templates/samplefactory.py
+++ b/mesonbuild/templates/samplefactory.py
@@ -1,0 +1,50 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from mesonbuild.templates.fortrantemplates import FortranProject
+from mesonbuild.templates.objcpptemplates import ObjCppProject
+from mesonbuild.templates.dlangtemplates import DlangProject
+from mesonbuild.templates.rusttemplates import RustProject
+from mesonbuild.templates.javatemplates import JavaProject
+from mesonbuild.templates.cudatemplates import CudaProject
+from mesonbuild.templates.objctemplates import ObjCProject
+from mesonbuild.templates.cpptemplates import CppProject
+from mesonbuild.templates.cstemplates import CSharpProject
+from mesonbuild.templates.ctemplates import CProject
+
+
+class SampleFactory(object):
+    @staticmethod
+    def sameple_generator(options):
+        if options.language == 'c':
+            return CProject(options)
+        elif options.language == 'cpp':
+            return CppProject(options)
+        elif options.language == 'cs':
+            return CSharpProject(options)
+        elif options.language == 'objc':
+            return ObjCProject(options)
+        elif options.language == 'objcpp':
+            return ObjCppProject(options)
+        elif options.language == 'java':
+            return JavaProject(options)
+        elif options.language == 'd':
+            return DlangProject(options)
+        elif options.language == 'rust':
+            return RustProject(options)
+        elif options.language == 'cuda':
+            return CudaProject(options)
+        elif options.language == 'fortran':
+            return FortranProject(options)
+        else:
+            raise RuntimeError('Unreachable code')

--- a/mesonbuild/templates/sampleimpl.py
+++ b/mesonbuild/templates/sampleimpl.py
@@ -15,7 +15,7 @@
 
 class SampleImpl(object):
     def create_executable(self):
-        NotImplementedError('Sample implementation for "executable" not implemented!')
+        raise NotImplementedError('Sample implementation for "executable" not implemented!')
 
     def create_library(self):
-        NotImplementedError('Sample implementation for "library" not implemented!')
+        raise NotImplementedError('Sample implementation for "library" not implemented!')

--- a/mesonbuild/templates/sampleimpl.py
+++ b/mesonbuild/templates/sampleimpl.py
@@ -1,0 +1,21 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class SampleImpl(object):
+    def create_executable(self):
+        NotImplementedError('Sample implementation for "executable" not implemented!')
+
+    def create_library(self):
+        NotImplementedError('Sample implementation for "library" not implemented!')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3240,7 +3240,7 @@ int main(int argc, char **argv) {
                     self._run(ninja,
                               workdir=os.path.join(tmpdir, 'builddir'))
             # test directory with existing code file
-            if lang in ('c', 'cpp'):
+            if lang in ('c', 'cpp', 'd'):
                 with tempfile.TemporaryDirectory() as tmpdir:
                     with open(os.path.join(tmpdir, 'foo.' + lang), 'w') as f:
                         f.write('int main(void) {}')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3245,6 +3245,11 @@ int main(int argc, char **argv) {
                     with open(os.path.join(tmpdir, 'foo.' + lang), 'w') as f:
                         f.write('int main(void) {}')
                     self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
+            elif lang in ('java'):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    with open(os.path.join(tmpdir, 'Foo.' + lang), 'w') as f:
+                        f.write('public class Foo { public static void main() {} }')
+                    self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
 
     # The test uses mocking and thus requires that
     # the current process is the one to run the Meson steps.

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3228,6 +3228,12 @@ int main(int argc, char **argv) {
         except EnvironmentException:
             pass
         # FIXME: omitting rust as Windows AppVeyor CI finds Rust but doesn't link correctly
+        if not is_windows():
+            try:
+                env.detect_rust_compiler(MachineChoice.HOST)
+                langs.append('rust')
+            except EnvironmentException:
+                pass
 
         for lang in langs:
             for target_type in ('executable', 'library'):


### PR DESCRIPTION
I have implemented a Meson template factory so we can add more programming languages if needed. 
Any new programming languages must implement `create_library(self)` and `create_executable(self)` methods.

I also added a `meson.build` template for Java projects.