### PR TITLE
Adding -C to 'meson init' command

### DIFF
--- a/docs/markdown/snippets/cd_arguments_with_init_command.md
+++ b/docs/markdown/snippets/cd_arguments_with_init_command.md
@@ -1,0 +1,5 @@
+## Added `-C` argument to `meson init` command
+
+The meson init assumes that it is run inside the project
+root directory. If this isn't the case, you can now use
+`-C` to specify the actual project source directory.

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -228,7 +228,7 @@ def run(options) -> int:
     Here we generate the new Meson sample project.
     '''
     if not Path(options.wd).exists():
-        sys.exit('Project source root directory not found. Run this command in build directory root.')
+        sys.exit('Project source root directory not found. Run this command in source directory root.')
     os.chdir(options.wd)
 
     if not glob('*'):

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -18,6 +18,8 @@ from pathlib import Path
 from enum import Enum
 import subprocess
 import shutil
+import sys
+import os
 import re
 from glob import glob
 from mesonbuild import mesonlib
@@ -210,6 +212,7 @@ def add_arguments(parser):
     Meson project.
     '''
     parser.add_argument("srcfiles", metavar="sourcefile", nargs="*", help="source files. default: all recognized files in current directory")
+    parser.add_argument('-C', default='.', dest='wd', help='directory to cd into before running')
     parser.add_argument("-n", "--name", help="project name. default: name of current directory")
     parser.add_argument("-e", "--executable", help="executable name. default: project name")
     parser.add_argument("-d", "--deps", help="dependencies, comma-separated")
@@ -224,6 +227,10 @@ def run(options) -> int:
     '''
     Here we generate the new Meson sample project.
     '''
+    if not Path(options.wd).exists():
+        sys.exit('Project source root directory not found. Run this command in build directory root.')
+    os.chdir(options.wd)
+
     if not glob('*'):
         autodetect_options(options, sample=True)
         if not options.language:


### PR DESCRIPTION
Provided a `-C` argument so users can specify the root directory.