### PR TITLE
Implementation of meson.build jar template

### DIFF
--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -21,6 +21,18 @@ executable('{executable}',
            install : true)
 '''
 
+
+meson_jar_template = '''project('{project_name}', '{language}',
+  version : '{version}',
+  default_options : [{default_options}])
+
+jar('{executable}',
+    {sourcespec},{depspec},
+    main_class: {main_class},
+    install : true)
+'''
+
+
 def create_meson_build(options):
     if options.type != 'executable':
         raise SystemExit('\nGenerating a meson.build file from existing sources is\n'
@@ -40,12 +52,22 @@ def create_meson_build(options):
         depspec += ',\n              '.join("dependency('{}')".format(x)
                                             for x in options.deps.split(','))
         depspec += '],'
-    content = meson_executable_template.format(project_name=options.name,
-                                               language=options.language,
-                                               version=options.version,
-                                               executable=options.executable,
-                                               sourcespec=sourcespec,
-                                               depspec=depspec,
-                                               default_options=formatted_default_options)
+    if options.language != 'java':
+        content = meson_executable_template.format(project_name=options.name,
+                                                   language=options.language,
+                                                   version=options.version,
+                                                   executable=options.executable,
+                                                   sourcespec=sourcespec,
+                                                   depspec=depspec,
+                                                   default_options=formatted_default_options)
+    else:
+        content = meson_jar_template.format(project_name=options.name,
+                                            language=options.language,
+                                            version=options.version,
+                                            executable=options.executable,
+                                            main_class=options.name,
+                                            sourcespec=sourcespec,
+                                            depspec=depspec,
+                                            default_options=formatted_default_options)
     open('meson.build', 'w').write(content)
     print('Generated meson.build file:\n\n' + content)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3245,6 +3245,11 @@ int main(int argc, char **argv) {
                     with open(os.path.join(tmpdir, 'foo.' + lang), 'w') as f:
                         f.write('int main(void) {}')
                     self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
+            elif lang in ('java'):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    with open(os.path.join(tmpdir, 'Foo.' + lang), 'w') as f:
+                        f.write('public class Foo { public static void main() {} }')
+                    self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
 
     # The test uses mocking and thus requires that
     # the current process is the one to run the Meson steps.


### PR DESCRIPTION
Updated `meson.build` generator just in case the user is a Java developer.  Now we can create scripts for classic `executable` and `jar` projects.

Also, update the `test_templates` to reflect this change.