### PR TITLE
Update test_templates to add Dlang in sample create and build plus find Rust

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3228,6 +3228,12 @@ int main(int argc, char **argv) {
         except EnvironmentException:
             pass
         # FIXME: omitting rust as Windows AppVeyor CI finds Rust but doesn't link correctly
+        if not is_windows():
+            try:
+                env.detect_rust_compiler(MachineChoice.HOST)
+                langs.append('rust')
+            except EnvironmentException:
+                pass
 
         for lang in langs:
             for target_type in ('executable', 'library'):
@@ -3240,7 +3246,7 @@ int main(int argc, char **argv) {
                     self._run(ninja,
                               workdir=os.path.join(tmpdir, 'builddir'))
             # test directory with existing code file
-            if lang in ('c', 'cpp'):
+            if lang in ('c', 'cpp', 'd'):
                 with tempfile.TemporaryDirectory() as tmpdir:
                     with open(os.path.join(tmpdir, 'foo.' + lang), 'w') as f:
                         f.write('int main(void) {}')


### PR DESCRIPTION
This PR has the `d` language added to the sample create and run part of the test since it should be tested.  Also added `rust` in detection, and to defined against AppVeyor issues I check to see if the environment is Windows.