### PR TITLE
interpreter: add 'name' method to BuildTargetHolder

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2268,6 +2268,8 @@ A build target is either an [executable](#executable),
   target, usually only needed if an another target needs to access
   some generated internal headers of this target
 
+- `name()` *Since 0.54.0*, returns the target name.
+
 
 ### `configuration` data object
 

--- a/docs/markdown/snippets/build_target_older_name.md
+++ b/docs/markdown/snippets/build_target_older_name.md
@@ -1,0 +1,2 @@
+## Added 'name' method
+Build target objects (as returned by executable(), library(), ...) now have a name() method.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -771,6 +771,7 @@ class BuildTargetHolder(TargetHolder):
         super().__init__(target, interp)
         self.methods.update({'extract_objects': self.extract_objects_method,
                              'extract_all_objects': self.extract_all_objects_method,
+                             'name': self.name_method,
                              'get_id': self.get_id_method,
                              'outdir': self.outdir_method,
                              'full_path': self.full_path_method,
@@ -824,6 +825,12 @@ class BuildTargetHolder(TargetHolder):
     @permittedKwargs({})
     def get_id_method(self, args, kwargs):
         return self.held_object.get_id()
+
+    @FeatureNew('name', '0.54.0')
+    @noPosargs
+    @permittedKwargs({})
+    def name_method(self, args, kwargs):
+        return self.held_object.name
 
 class ExecutableHolder(BuildTargetHolder):
     def __init__(self, target, interp):

--- a/test cases/common/1 trivial/meson.build
+++ b/test cases/common/1 trivial/meson.build
@@ -20,7 +20,7 @@ if meson.is_cross_build()
 endif
 
 exe = executable('trivialprog', sources : sources)
-
+assert(exe.name() == 'trivialprog')
 test('runtest', exe) # This is a comment
 
 has_not_changed = false

--- a/test cases/common/3 static/meson.build
+++ b/test cases/common/3 static/meson.build
@@ -2,7 +2,7 @@ project('static library test', 'c')
 
 lib = static_library('mylib', get_option('source'),
   link_args : '-THISMUSTNOBEUSED') # Static linker needs to ignore all link args.
-
+assert(lib.name() == 'mylib')
 has_not_changed = false
 if is_disabler(lib)
     has_not_changed = true


### PR DESCRIPTION
As any child of ObjectHolder might need the name of the object,
provides a method to get name.
This is useful in gst-build to display the plugin name and not
the filename.