### PR TITLE
Mesonlib type annotations

### DIFF
--- a/.github/workflows/lint_mypy.yml
+++ b/.github/workflows/lint_mypy.yml
@@ -30,4 +30,4 @@ jobs:
       with:
         python-version: '3.x'
     - run: python -m pip install mypy
-    - run: mypy --follow-imports=skip mesonbuild/interpreterbase.py mesonbuild/mtest.py mesonbuild/minit.py mesonbuild/mintro.py mesonbuild/mparser.py mesonbuild/msetup.py mesonbuild/ast mesonbuild/wrap tools/ mesonbuild/modules/fs.py mesonbuild/dependencies/boost.py mesonbuild/dependencies/mpi.py mesonbuild/dependencies/hdf5.py mesonbuild/compilers/mixins/intel.py mesonbuild/mlog.py mesonbuild/mcompile.py
+    - run: mypy --follow-imports=skip mesonbuild/interpreterbase.py mesonbuild/mtest.py mesonbuild/minit.py mesonbuild/mintro.py mesonbuild/mparser.py mesonbuild/msetup.py mesonbuild/ast mesonbuild/wrap tools/ mesonbuild/modules/fs.py mesonbuild/dependencies/boost.py mesonbuild/dependencies/mpi.py mesonbuild/dependencies/hdf5.py mesonbuild/compilers/mixins/intel.py mesonbuild/mlog.py mesonbuild/mcompile.py mesonbuild/mesonlib.py

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -101,8 +101,8 @@ class IntrospectionInterpreter(AstInterpreter):
             self.coredata.merge_user_options(oi.options)
 
         def_opts = self.flatten_args(kwargs.get('default_options', []))
-        self.project_default_options = mesonlib.stringlistify(def_opts)
-        self.project_default_options = cdata.create_options_dict(self.project_default_options)
+        _project_default_options = mesonlib.stringlistify(def_opts)
+        self.project_default_options = cdata.create_options_dict(_project_default_options)
         self.default_options.update(self.project_default_options)
         self.coredata.set_default_options(self.default_options, self.subproject, self.environment)
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -21,7 +21,7 @@ from .. import mlog
 import json
 import subprocess
 from ..mesonlib import MachineChoice, MesonException, OrderedSet, OptionOverrideProxy
-from ..mesonlib import classify_unity_sources
+from ..mesonlib import classify_unity_sources, unholder
 from ..mesonlib import File
 from ..compilers import CompilerArgs, VisualStudioLikeCompiler
 from ..interpreter import Interpreter
@@ -748,9 +748,7 @@ class Backend:
             else:
                 extra_paths = []
             cmd_args = []
-            for a in t.cmd_args:
-                if hasattr(a, 'held_object'):
-                    a = a.held_object
+            for a in unholder(t.cmd_args):
                 if isinstance(a, build.BuildTarget):
                     extra_paths += self.determine_windows_extra_paths(a, [])
                 if isinstance(a, mesonlib.File):
@@ -868,14 +866,10 @@ class Backend:
         # also be built by default. XXX: Sometime in the future these should be
         # built only before running tests.
         for t in self.build.get_tests():
-            exe = t.exe
-            if hasattr(exe, 'held_object'):
-                exe = exe.held_object
+            exe = unholder(t.exe)
             if isinstance(exe, (build.CustomTarget, build.BuildTarget)):
                 result[exe.get_id()] = exe
-            for arg in t.cmd_args:
-                if hasattr(arg, 'held_object'):
-                    arg = arg.held_object
+            for arg in unholder(t.cmd_args):
                 if not isinstance(arg, (build.CustomTarget, build.BuildTarget)):
                     continue
                 result[arg.get_id()] = arg
@@ -915,9 +909,7 @@ class Backend:
         Returns the path to them relative to the build root directory.
         '''
         srcs = []
-        for i in target.get_sources():
-            if hasattr(i, 'held_object'):
-                i = i.held_object
+        for i in unholder(target.get_sources()):
             if isinstance(i, str):
                 fname = [os.path.join(self.build_to_src, target.subdir, i)]
             elif isinstance(i, build.BuildTarget):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -32,7 +32,8 @@ from ..compilers import (Compiler, CompilerArgs, CCompiler, FortranCompiler,
                          PGICCompiler, VisualStudioLikeCompiler)
 from ..linkers import ArLinker
 from ..mesonlib import (
-    File, LibType, MachineChoice, MesonException, OrderedSet, PerMachine, ProgressBar, quote_arg
+    File, LibType, MachineChoice, MesonException, OrderedSet, PerMachine,
+    ProgressBar, quote_arg, unholder,
 )
 from ..mesonlib import get_compiler_for_source, has_path_sep
 from .backends import CleanTrees
@@ -648,9 +649,7 @@ int dummy;
                 self.generate_target(t)
 
     def custom_target_generator_inputs(self, target):
-        for s in target.sources:
-            if hasattr(s, 'held_object'):
-                s = s.held_object
+        for s in unholder(target.sources):
             if isinstance(s, build.GeneratedList):
                 self.generate_genlist_for_target(s, target)
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -827,8 +827,7 @@ just like those detected with the dependency() function.''')
             self.link_whole(linktarget)
 
         c_pchlist, cpp_pchlist, clist, cpplist, cudalist, cslist, valalist,  objclist, objcpplist, fortranlist, rustlist \
-            = extract_as_list(kwargs, 'c_pch', 'cpp_pch', 'c_args', 'cpp_args', 'cuda_args', 'cs_args', 'vala_args', 'objc_args',
-                              'objcpp_args', 'fortran_args', 'rust_args')
+            = [extract_as_list(kwargs, c) for c in ['c_pch', 'cpp_pch', 'c_args', 'cpp_args', 'cuda_args', 'cs_args', 'vala_args', 'objc_args', 'objcpp_args', 'fortran_args', 'rust_args']]
 
         self.add_pch('c', c_pchlist)
         self.add_pch('cpp', cpp_pchlist)
@@ -2161,7 +2160,7 @@ class CustomTarget(Target):
             self.build_always_stale = kwargs['build_always_stale']
         if not isinstance(self.build_always_stale, bool):
             raise InvalidArguments('Argument build_always_stale must be a boolean.')
-        extra_deps, depend_files = extract_as_list(kwargs, 'depends', 'depend_files', pop = False)
+        extra_deps, depend_files = [extract_as_list(kwargs, c, pop=False) for c in ['depends', 'depend_files']]
         for ed in extra_deps:
             while hasattr(ed, 'held_object'):
                 ed = ed.held_object

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2409,7 +2409,7 @@ class ConfigureFile:
         return self.targetname
 
 class ConfigurationData:
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.values = {}
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -35,6 +35,8 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..linkers import DynamicLinker  # noqa: F401
 
+    CompilerType = T.TypeVar('CompilerType', bound=Compiler)
+
 """This file contains the data files of all compilers Meson knows
 about. To support a new compiler, add its information below.
 Also add corresponding autodetection code in environment.py."""

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -38,7 +38,7 @@ from ..mesonlib import Popen_safe, version_compare_many, version_compare, listif
 from ..mesonlib import Version, LibType
 
 if T.TYPE_CHECKING:
-    from ..compilers.compilers import Compiler  # noqa: F401
+    from ..compilers.compilers import CompilerType  # noqa: F401
     DependencyType = T.TypeVar('DependencyType', bound='Dependency')
 
 # These must be defined in this file to avoid cyclical references.
@@ -2488,7 +2488,7 @@ def factory_methods(methods: T.Set[DependencyMethods]) -> 'FactoryType':
 
 
 def detect_compiler(name: str, env: Environment, for_machine: MachineChoice,
-                    language: T.Optional[str]) -> T.Optional['Compiler']:
+                    language: T.Optional[str]) -> T.Optional['CompilerType']:
     """Given a language and environment find the compiler used."""
     compilers = env.coredata.compilers[for_machine]
 

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -299,9 +299,9 @@ class BoostDependency(ExternalDependency):
             mlog.debug('  - BOOST_LIBRARYDIR = {}'.format(lib_dir))
 
             boost_inc_dir = None
-            for i in [inc_dir / 'version.hpp', inc_dir / 'boost' / 'version.hpp']:
-                if i.is_file():
-                    boost_inc_dir = self._include_dir_from_version_header(i)
+            for j in [inc_dir / 'version.hpp', inc_dir / 'boost' / 'version.hpp']:
+                if j.is_file():
+                    boost_inc_dir = self._include_dir_from_version_header(j)
                     break
             if not boost_inc_dir:
                 self.is_found = False
@@ -317,20 +317,20 @@ class BoostDependency(ExternalDependency):
         roots = list(mesonlib.OrderedSet(roots))
 
         # B) Foreach candidate
-        for i in roots:
+        for j in roots:
             #   1. Look for the boost headers (boost/version.pp)
-            mlog.debug('Checking potential boost root {}'.format(i.as_posix()))
-            inc_dirs = self.detect_inc_dirs(i)
+            mlog.debug('Checking potential boost root {}'.format(j.as_posix()))
+            inc_dirs = self.detect_inc_dirs(j)
             inc_dirs = sorted(inc_dirs, reverse=True)  # Prefer the newer versions
 
             # Early abort when boost is not found
             if not inc_dirs:
                 continue
 
-            lib_dirs = self.detect_lib_dirs(i)
+            lib_dirs = self.detect_lib_dirs(j)
             self.is_found = self.run_check(inc_dirs, lib_dirs)
             if self.is_found:
-                self.boost_root = i
+                self.boost_root = j
                 break
 
     def run_check(self, inc_dirs: T.List[BoostIncludeDir], lib_dirs: T.List[Path]) -> bool:

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -272,7 +272,7 @@ class BoostDependency(ExternalDependency):
         self.boost_root = None
 
         # Extract and validate modules
-        self.modules = mesonlib.extract_as_list(kwargs, 'modules')
+        self.modules = mesonlib.extract_as_list(kwargs, 'modules')  # type: T.List[str]
         for i in self.modules:
             if not isinstance(i, str):
                 raise DependencyException('Boost module argument is not a string.')

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -21,7 +21,7 @@ from . import optinterpreter
 from . import compilers
 from .wrap import wrap, WrapMode
 from . import mesonlib
-from .mesonlib import FileMode, MachineChoice, Popen_safe, listify, extract_as_list, has_path_sep
+from .mesonlib import FileMode, MachineChoice, Popen_safe, listify, extract_as_list, has_path_sep, unholder
 from .dependencies import ExternalProgram
 from .dependencies import InternalDependency, Dependency, NotFoundDependency, DependencyException
 from .depfile import DepFile
@@ -2460,11 +2460,11 @@ class Interpreter(InterpreterBase):
         if not isinstance(version, str):
             raise InterpreterException('Version must be a string.')
         incs = self.extract_incdirs(kwargs)
-        libs = extract_as_list(kwargs, 'link_with', unholder=True)
-        libs_whole = extract_as_list(kwargs, 'link_whole', unholder=True)
+        libs = unholder(extract_as_list(kwargs, 'link_with'))
+        libs_whole = unholder(extract_as_list(kwargs, 'link_whole'))
         sources = extract_as_list(kwargs, 'sources')
-        sources = listify(self.source_strings_to_files(sources), unholder=True)
-        deps = extract_as_list(kwargs, 'dependencies', unholder=True)
+        sources = unholder(listify(self.source_strings_to_files(sources)))
+        deps = unholder(extract_as_list(kwargs, 'dependencies'))
         compile_args = mesonlib.stringlistify(kwargs.get('compile_args', []))
         link_args = mesonlib.stringlistify(kwargs.get('link_args', []))
         variables = kwargs.get('variables', {})
@@ -3581,12 +3581,12 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
             if 'command' not in kwargs:
                 raise InterpreterException('Missing "command" keyword argument')
             all_args = extract_as_list(kwargs, 'command')
-            deps = extract_as_list(kwargs, 'depends', unholder=True)
+            deps = unholder(extract_as_list(kwargs, 'depends'))
         else:
             raise InterpreterException('Run_target needs at least one positional argument.')
 
         cleaned_args = []
-        for i in listify(all_args, unholder=True):
+        for i in unholder(listify(all_args)):
             if not isinstance(i, (str, build.BuildTarget, build.CustomTarget, dependencies.ExternalProgram, mesonlib.File)):
                 mlog.debug('Wrong type:', str(i))
                 raise InterpreterException('Invalid argument to run_target.')
@@ -3617,7 +3617,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         name = args[0]
         if not isinstance(name, str):
             raise InterpreterException('First argument must be a string.')
-        deps = listify(args[1:], unholder=True)
+        deps = unholder(listify(args[1:]))
         for d in deps:
             if not isinstance(d, (build.BuildTarget, build.CustomTarget)):
                 raise InterpreterException('Depends items must be build targets.')
@@ -3675,7 +3675,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         par = kwargs.get('is_parallel', True)
         if not isinstance(par, bool):
             raise InterpreterException('Keyword argument is_parallel must be a boolean.')
-        cmd_args = extract_as_list(kwargs, 'args', unholder=True)
+        cmd_args = unholder(extract_as_list(kwargs, 'args'))
         for i in cmd_args:
             if not isinstance(i, (str, mesonlib.File, build.Target)):
                 raise InterpreterException('Command line arguments must be strings, files or targets.')
@@ -3703,7 +3703,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
             if len(s) > 0:
                 s = ':' + s
             suite.append(prj.replace(' ', '_').replace(':', '_') + s)
-        depends = extract_as_list(kwargs, 'depends', unholder=True)
+        depends = unholder(extract_as_list(kwargs, 'depends'))
         for dep in depends:
             if not isinstance(dep, (build.CustomTarget, build.BuildTarget)):
                 raise InterpreterException('Depends items must be build targets.')
@@ -4066,7 +4066,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         return mesonlib.File.from_built_file(self.subdir, output)
 
     def extract_incdirs(self, kwargs):
-        prospectives = listify(kwargs.get('include_directories', []), unholder=True)
+        prospectives = unholder(extract_as_list(kwargs, 'include_directories'))
         result = []
         for p in prospectives:
             if isinstance(p, build.IncludeDirs):
@@ -4127,7 +4127,7 @@ different subdirectory.
         if ":" not in setup_name:
             setup_name = (self.subproject if self.subproject else self.build.project_name) + ":" + setup_name
         try:
-            inp = extract_as_list(kwargs, 'exe_wrapper', unholder=True)
+            inp = unholder(extract_as_list(kwargs, 'exe_wrapper'))
             exe_wrapper = []
             for i in inp:
                 if isinstance(i, str):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3087,9 +3087,7 @@ external dependencies (including libraries) must go to "dependencies".''')
 
     def program_from_file_for(self, for_machine, prognames, silent):
         bins = self.environment.binaries[for_machine]
-        for p in prognames:
-            if hasattr(p, 'held_object'):
-                p = p.held_object
+        for p in unholder(prognames):
             if isinstance(p, mesonlib.File):
                 continue # Always points to a local (i.e. self generated) file.
             if not isinstance(p, str):

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -446,7 +446,7 @@ class InterpreterBase:
                 self.current_lineno = cur.lineno
                 self.evaluate_statement(cur)
             except Exception as e:
-                if not hasattr(e, 'lineno'):
+                if getattr(e, 'lineno') is None:
                     # We are doing the equivalent to setattr here and mypy does not like it
                     e.lineno = cur.lineno                                                             # type: ignore
                     e.colno = cur.colno                                                               # type: ignore

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -24,6 +24,7 @@ from functools import lru_cache, update_wrapper
 from itertools import tee, filterfalse
 import typing as T
 import uuid
+import textwrap
 
 from mesonbuild import mlog
 
@@ -109,10 +110,12 @@ def check_direntry_issues(direntry_array):
         for de in direntry_array:
             if is_ascii_string(de):
                 continue
-            mlog.warning('''You are using {!r} which is not a Unicode-compatible '
-locale but you are trying to access a file system entry called {!r} which is
-not pure ASCII. This may cause problems.
-'''.format(e, de), file=sys.stderr)
+            mlog.warning(textwrap.dedent('''
+                You are using {!r} which is not a Unicode-compatible
+                locale but you are trying to access a file system entry called {!r} which is
+                not pure ASCII. This may cause problems.
+                '''.format(e, de)), file=sys.stderr)
+
 
 # Put this in objects that should not get dumped to pickle files
 # by accident.

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -273,6 +273,8 @@ class File:
         return self.fname.split(s)
 
     def __eq__(self, other) -> bool:
+        if not isinstance(other, File):
+            return NotImplemented
         return (self.fname, self.subdir, self.is_built) == (other.fname, other.subdir, other.is_built)
 
     def __hash__(self) -> int:

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -1058,34 +1058,25 @@ def unholder(item):
     return item
 
 
-def listify(item: T.Any,
-            flatten: bool = True,
-            unholder: bool = False) -> T.List[T.Any]:
+def listify(item: T.Any, flatten: bool = True) -> T.List[T.Any]:
     '''
     Returns a list with all args embedded in a list if they are not a list.
     This function preserves order.
     @flatten: Convert lists of lists to a flat list
-    @unholder: Replace each item with the object it holds, if required
-
-    Note: unholding only works recursively when flattening
     '''
     if not isinstance(item, list):
-        if unholder and hasattr(item, 'held_object'):
-            item = item.held_object
         return [item]
     result = []  # type: T.List[T.Any]
     for i in item:
-        if unholder and hasattr(i, 'held_object'):
-            i = i.held_object
         if flatten and isinstance(i, list):
-            result += listify(i, flatten=True, unholder=unholder)
+            result += listify(i, flatten=True)
         else:
             result.append(i)
     return result
 
 
 def extract_as_list(dict_object: T.Dict[_T, _U], *keys: _T, pop: bool = False,
-                    **kwargs: T.Any) -> T.List[T.Union[_U, T.List[_U]]]:
+                    flatten: bool = True) -> T.List[T.Union[_U, T.List[_U]]]:
     '''
     Extracts all values from given dict_object and listifies them.
     '''
@@ -1095,10 +1086,10 @@ def extract_as_list(dict_object: T.Dict[_T, _U], *keys: _T, pop: bool = False,
         fetch = dict_object.pop
     # If there's only one key, we don't return a list with one element
     if len(keys) == 1:
-        return listify(fetch(keys[0], []), **kwargs)
+        return listify(fetch(keys[0], []), flatten=True)
     # Return a list of values corresponding to *keys
     for key in keys:
-        result.append(listify(fetch(key, []), **kwargs))
+        result.append(listify(fetch(key, []), flatten=True))
     return result
 
 

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -1126,8 +1126,8 @@ def expand_arguments(args: T.Iterable[str]) -> T.Optional[T.List[str]]:
                 extended_args = f.read().split()
             expended_args += extended_args
         except Exception as e:
-            print('Error expanding command line arguments, %s not found' % args_file)
-            print(e)
+            mlog.error('Expanding command line arguments:',  args_file, 'not found')
+            mlog.exception(e)
             return None
     return expended_args
 

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -1075,22 +1075,15 @@ def listify(item: T.Any, flatten: bool = True) -> T.List[T.Any]:
     return result
 
 
-def extract_as_list(dict_object: T.Dict[_T, _U], *keys: _T, pop: bool = False,
-                    flatten: bool = True) -> T.List[T.Union[_U, T.List[_U]]]:
+def extract_as_list(dict_object: T.Dict[_T, _U], key: _T, pop: bool = False) -> T.List[_U]:
     '''
     Extracts all values from given dict_object and listifies them.
     '''
-    result = []  # type: T.List[T.Union[_U, T.List[_U]]]
     fetch = dict_object.get
     if pop:
         fetch = dict_object.pop
     # If there's only one key, we don't return a list with one element
-    if len(keys) == 1:
-        return listify(fetch(keys[0], []), flatten=True)
-    # Return a list of values corresponding to *keys
-    for key in keys:
-        result.append(listify(fetch(key, []), flatten=True))
-    return result
+    return listify(fetch(key, []), flatten=True)
 
 
 def typeslistify(item: 'T.Union[_T, T.Sequence[_T]]',

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -298,7 +298,7 @@ def exception(e: Exception, prefix: T.Optional[AnsiDecorator] = None) -> None:
         prefix = red('ERROR:')
     log()
     args = []  # type: T.List[T.Union[AnsiDecorator, str]]
-    if hasattr(e, 'file') and hasattr(e, 'lineno') and hasattr(e, 'colno'):
+    if getattr(e, 'file') is not None and getattr(e, 'lineno') is not None and getattr(e, 'colno') is not None:
         # Mypy doesn't follow hasattr, and it's pretty easy to visually inspect
         # that this is correct, so we'll just ignore it.
         path = get_relative_path(Path(e.file), Path(os.getcwd()))  # type: ignore

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -18,6 +18,7 @@
 import os
 
 from .. import build
+from ..mesonlib import unholder
 
 
 class ExtensionModule:
@@ -38,12 +39,7 @@ def get_include_args(include_dirs, prefix='-I'):
         return []
 
     dirs_str = []
-    for incdirs in include_dirs:
-        if hasattr(incdirs, "held_object"):
-            dirs = incdirs.held_object
-        else:
-            dirs = incdirs
-
+    for dirs in unholder(include_dirs):
         if isinstance(dirs, str):
             dirs_str += ['%s%s' % (prefix, dirs)]
             continue

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -83,11 +83,11 @@ class GnomeModule(ExtensionModule):
                          mlog.bold('https://bugzilla.gnome.org/show_bug.cgi?id=774368'))
 
     @staticmethod
-    @mesonlib.run_once
     def _print_gdbus_warning():
         mlog.warning('Code generated with gdbus_codegen() requires the root directory be added to\n'
                      '  include_directories of targets with GLib < 2.51.3:',
-                     mlog.bold('https://github.com/mesonbuild/meson/issues/1387'))
+                     mlog.bold('https://github.com/mesonbuild/meson/issues/1387'),
+                     once=True)
 
     @FeatureNewKwargs('gnome.compile_resources', '0.37.0', ['gresource_bundle', 'export', 'install_header'])
     @permittedKwargs({'source_dir', 'c_name', 'dependencies', 'export', 'gresource_bundle', 'install_header',

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -98,7 +98,7 @@ class GnomeModule(ExtensionModule):
 
         cmd = ['glib-compile-resources', '@INPUT@']
 
-        source_dirs, dependencies = mesonlib.extract_as_list(kwargs, 'source_dir', 'dependencies', pop=True)
+        source_dirs, dependencies = [mesonlib.extract_as_list(kwargs, c, pop=True) for c in  ['source_dir', 'dependencies']]
 
         if len(args) < 2:
             raise MesonException('Not enough arguments; the name of the resource '

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -316,7 +316,7 @@ class GnomeModule(ExtensionModule):
         # require two args in order, such as -framework AVFoundation
         external_ldflags_nodedup = []
         gi_includes = OrderedSet()
-        deps = mesonlib.listify(deps, unholder=True)
+        deps = mesonlib.unholder(mesonlib.listify(deps))
 
         for dep in deps:
             if isinstance(dep, InternalDependency):
@@ -776,7 +776,7 @@ class GnomeModule(ExtensionModule):
         langs_compilers = self._get_girtargets_langs_compilers(girtargets)
         cflags, internal_ldflags, external_ldflags = self._get_langs_compilers_flags(state, langs_compilers)
         deps = self._get_gir_targets_deps(girtargets)
-        deps += extract_as_list(kwargs, 'dependencies', pop=True, unholder=True)
+        deps += mesonlib.unholder(extract_as_list(kwargs, 'dependencies', pop=True))
         typelib_includes = self._gather_typelib_includes_and_update_depends(state, deps, depends)
         # ldflags will be misinterpreted by gir scanner (showing
         # spurious dependencies) but building GStreamer fails if they
@@ -1057,7 +1057,7 @@ This will become a hard error in the future.''')
 
     def _get_build_args(self, kwargs, state, depends):
         args = []
-        deps = extract_as_list(kwargs, 'dependencies', unholder=True)
+        deps = mesonlib.unholder(extract_as_list(kwargs, 'dependencies'))
         cflags = []
         cflags.extend(mesonlib.stringlistify(kwargs.pop('c_args', [])))
         deps_cflags, internal_ldflags, external_ldflags, gi_includes = \

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -16,7 +16,7 @@ import shutil
 
 from os import path
 from .. import coredata, mesonlib, build, mlog
-from ..mesonlib import MesonException, run_once
+from ..mesonlib import MesonException
 from . import ModuleReturnValue
 from . import ExtensionModule
 from ..interpreterbase import permittedKwargs, FeatureNew, FeatureNewKwargs
@@ -59,9 +59,8 @@ PRESET_ARGS = {
 class I18nModule(ExtensionModule):
 
     @staticmethod
-    @run_once
     def nogettext_warning():
-        mlog.warning('Gettext not found, all translation targets will be ignored.')
+        mlog.warning('Gettext not found, all translation targets will be ignored.', once=True)
         return ModuleReturnValue(None, [])
 
     @staticmethod

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -74,7 +74,7 @@ class DependenciesHelper:
     def _process_reqs(self, reqs):
         '''Returns string names of requirements'''
         processed_reqs = []
-        for obj in mesonlib.listify(reqs, unholder=True):
+        for obj in mesonlib.unholder(mesonlib.listify(reqs)):
             if not isinstance(obj, str):
                 FeatureNew('pkgconfig.generate requirement from non-string object', '0.46.0').use(self.state.subproject)
             if hasattr(obj, 'generated_pc'):
@@ -108,7 +108,7 @@ class DependenciesHelper:
         self.cflags += mesonlib.stringlistify(cflags)
 
     def _process_libs(self, libs, public):
-        libs = mesonlib.listify(libs, unholder=True)
+        libs = mesonlib.unholder(mesonlib.listify(libs))
         processed_libs = []
         processed_reqs = []
         processed_cflags = []

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -123,7 +123,7 @@ class QtBaseModule(ExtensionModule):
     @permittedKwargs({'moc_headers', 'moc_sources', 'uic_extra_arguments', 'moc_extra_arguments', 'rcc_extra_arguments', 'include_directories', 'dependencies', 'ui_files', 'qresources', 'method'})
     def preprocess(self, state, args, kwargs):
         rcc_files, ui_files, moc_headers, moc_sources, uic_extra_arguments, moc_extra_arguments, rcc_extra_arguments, sources, include_directories, dependencies \
-            = extract_as_list(kwargs, 'qresources', 'ui_files', 'moc_headers', 'moc_sources', 'uic_extra_arguments', 'moc_extra_arguments', 'rcc_extra_arguments', 'sources', 'include_directories', 'dependencies', pop = True)
+            = [extract_as_list(kwargs, c, pop=True) for c in ['qresources', 'ui_files', 'moc_headers', 'moc_sources', 'uic_extra_arguments', 'moc_extra_arguments', 'rcc_extra_arguments', 'sources', 'include_directories', 'dependencies']]
         sources += args[1:]
         method = kwargs.get('method', 'auto')
         self._detect_tools(state.environment, method)
@@ -202,7 +202,7 @@ class QtBaseModule(ExtensionModule):
     @FeatureNew('qt.compile_translations', '0.44.0')
     @permittedKwargs({'ts_files', 'install', 'install_dir', 'build_by_default', 'method'})
     def compile_translations(self, state, args, kwargs):
-        ts_files, install_dir = extract_as_list(kwargs, 'ts_files', 'install_dir', pop=True)
+        ts_files, install_dir = [extract_as_list(kwargs, c, pop=True) for c in  ['ts_files', 'install_dir']]
         self._detect_tools(state.environment, kwargs.get('method', 'auto'))
         translations = []
         for ts in ts_files:

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -15,7 +15,7 @@
 import os
 from .. import mlog
 from .. import build
-from ..mesonlib import MesonException, Popen_safe, extract_as_list, File
+from ..mesonlib import MesonException, Popen_safe, extract_as_list, File, unholder
 from ..dependencies import Dependency, Qt4Dependency, Qt5Dependency
 import xml.etree.ElementTree as ET
 from . import ModuleReturnValue, get_include_args, ExtensionModule
@@ -171,9 +171,7 @@ class QtBaseModule(ExtensionModule):
             sources.append(ui_output)
         inc = get_include_args(include_dirs=include_directories)
         compile_args = []
-        for dep in dependencies:
-            if hasattr(dep, 'held_object'):
-                dep = dep.held_object
+        for dep in unholder(dependencies):
             if isinstance(dep, Dependency):
                 for arg in dep.get_compile_args():
                     if arg.startswith('-I') or arg.startswith('-D'):

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -18,7 +18,7 @@ import re
 
 from .. import mlog
 from .. import mesonlib, build
-from ..mesonlib import MachineChoice, MesonException, extract_as_list
+from ..mesonlib import MachineChoice, MesonException, extract_as_list, unholder
 from . import get_include_args
 from . import ModuleReturnValue
 from . import ExtensionModule
@@ -116,9 +116,7 @@ class WindowsModule(ExtensionModule):
                 for subsrc in src:
                     add_target(subsrc)
                 return
-
-            if hasattr(src, 'held_object'):
-                src = src.held_object
+            src = unholder(src)
 
             if isinstance(src, str):
                 name_format = 'file {!r}'

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,3 +2,4 @@
 strict_optional = False
 show_error_context = False
 show_column_numbers = True
+ignore_missing_imports = True

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -706,17 +706,15 @@ class InternalTests(unittest.TestCase):
         self.assertEqual(kwargs, {'sources': [1, 2, 3]})
         self.assertEqual([1, 2, 3], extract(kwargs, 'sources', pop=True))
         self.assertEqual(kwargs, {})
+
         # Test unholding
         holder3 = ObjectHolder(3)
         kwargs = {'sources': [1, 2, holder3]}
         self.assertEqual(kwargs, {'sources': [1, 2, holder3]})
-        # Test listification
-        kwargs = {'sources': [1, 2, 3], 'pch_sources': [4, 5, 6]}
-        self.assertEqual([[1, 2, 3], [4, 5, 6]], extract(kwargs, 'sources', 'pch_sources'))
 
         # flatten nested lists
         kwargs = {'sources': [1, [2, [3]]]}
-        self.assertEqual([1, 2, 3], extract(kwargs, 'sources', flatten=True))
+        self.assertEqual([1, 2, 3], extract(kwargs, 'sources'))
 
     def test_pkgconfig_module(self):
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -686,12 +686,17 @@ class InternalTests(unittest.TestCase):
         self.assertEqual([holder1], listify([holder1]))
         self.assertEqual([holder1, 2], listify([holder1, 2]))
         self.assertEqual([holder1, 2, 3], listify([holder1, 2, [3]]))
-        self.assertEqual([1], listify(holder1, unholder=True))
-        self.assertEqual([1], listify([holder1], unholder=True))
-        self.assertEqual([1, 2], listify([holder1, 2], unholder=True))
-        self.assertEqual([1, 2, 3], listify([holder1, 2, [holder3]], unholder=True))
-        # Unholding doesn't work recursively when not flattening
-        self.assertEqual([1, [2], [holder3]], listify([holder1, [2], [holder3]], unholder=True, flatten=False))
+
+    def test_unholder(self):
+        unholder = mesonbuild.mesonlib.unholder
+
+        holder1 = ObjectHolder(1)
+        holder3 = ObjectHolder(3)
+        holders = [holder1, holder3]
+
+        self.assertEqual(1, unholder(holder1))
+        self.assertEqual([1], unholder([holder1]))
+        self.assertEqual([1, 3], unholder(holders))
 
     def test_extract_as_list(self):
         extract = mesonbuild.mesonlib.extract_as_list
@@ -704,13 +709,14 @@ class InternalTests(unittest.TestCase):
         # Test unholding
         holder3 = ObjectHolder(3)
         kwargs = {'sources': [1, 2, holder3]}
-        self.assertEqual([1, 2, 3], extract(kwargs, 'sources', unholder=True))
         self.assertEqual(kwargs, {'sources': [1, 2, holder3]})
-        self.assertEqual([1, 2, 3], extract(kwargs, 'sources', unholder=True, pop=True))
-        self.assertEqual(kwargs, {})
         # Test listification
         kwargs = {'sources': [1, 2, 3], 'pch_sources': [4, 5, 6]}
         self.assertEqual([[1, 2, 3], [4, 5, 6]], extract(kwargs, 'sources', 'pch_sources'))
+
+        # flatten nested lists
+        kwargs = {'sources': [1, [2, [3]]]}
+        self.assertEqual([1, 2, 3], extract(kwargs, 'sources', flatten=True))
 
     def test_pkgconfig_module(self):
 


### PR DESCRIPTION
This series is mainly aimed at adding type annotations to the mesonlib module, although it does have a few more fixups in it. The biggest change is splitting the unholder functionality out of listify, I've done this because listify is already basically impossible to correctly type, and splitting out the unholdering code makes it much easier.