### PR TITLE
[WIP] mesonbuild: allow multiple build dirs via -C option

### DIFF
--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -68,10 +68,10 @@ def run(options: 'argparse.Namespace')-> int:
             ret += single_run(options, pathlib.Path(b))
         return ret
     else:
-        return single_run(options, pathlib.Path(b))
+        return single_run(options, options.builddir)
             
     
-def single_run(options: 'argparse.Namespace', bdir: ' ') -> int:
+def single_run(options: 'argparse.Namespace', bdir: 'pathlib.Path') -> int:
     if not bdir.exists():
         raise MesonException('Path to builddir {} does not exist!'.format(str(bdir.resolve())))
     if not bdir.is_dir():

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -60,8 +60,18 @@ def add_arguments(parser: 'argparse.ArgumentParser') -> None:
     )
 
 
-def run(options: 'argparse.Namespace') -> int:
-    bdir = options.builddir  # type: pathlib.Path
+def run(options: 'argparse.Namespace')-> int:
+    bdir = str(options.builddir).split(',')
+    if len(bdir) > 1:
+        ret = 0
+        for b in bdir:
+            ret += single_run(options, pathlib.Path(b))
+        return ret
+    else:
+        return single_run(options, pathlib.Path(b))
+            
+    
+def single_run(options: 'argparse.Namespace', bdir: ' ') -> int:
     if not bdir.exists():
         raise MesonException('Path to builddir {} does not exist!'.format(str(bdir.resolve())))
     if not bdir.is_dir():


### PR DESCRIPTION
It is common to have several `builddir`s set up for a project. This patch allows deploying the `builddir`s in one command
```
meson.py compile -C build-gcc,build-clang
```

it is just a proposal, if you like the feature I would like to extend it to the `meson test` command as well.