### PR TITLE
Fix some build type option parsing bugs

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -87,6 +87,7 @@ Using the option as-is with no prefix affects all machines. For example:
 | werror                               | false         | Treat warnings as errors                                       | no             |
 | wrap_mode {default, nofallback,<br>nodownload, forcefallback} | default | Wrap mode to use                            | no             |
 
+<a name="build-type-options"></a>
 For setting optimization levels and toggling debug, you can either set the
 `buildtype` option, or you can set the `optimization` and `debug` options which
 give finer control over the same. Whichever you decide to use, the other will

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -718,6 +718,13 @@ class CoreData:
             self.copy_build_options_from_regular_ones()
 
     def set_default_options(self, default_options, subproject, env):
+        # Warn if the user is using two different ways of setting build-type
+        # options that override each other
+        if 'buildtype' in env.cmd_line_options and \
+           ('optimization' in env.cmd_line_options or 'debug' in env.cmd_line_options):
+            mlog.warning('Recommend using either -Dbuildtype or -Doptimization + -Ddebug. '
+                         'Using both is redundant since they override each other. '
+                         'See: https://mesonbuild.com/Builtin-options.html#build-type-options')
         cmd_line_options = OrderedDict()
         # Set project default_options as if they were passed to the cmdline.
         # Subprojects can only define default for user options and not yielding

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1001,9 +1001,10 @@ class BuiltinOption(T.Generic[_T, _U]):
         return self.opt_type(self.description, **keywords)
 
     def _argparse_action(self) -> T.Optional[str]:
-        if self.default is True:
-            return 'store_false'
-        elif self.default is False:
+        # If the type is a boolean, the presence of the argument in --foo form
+        # is to enable it. Disabling happens by using -Dfoo=false, which is
+        # parsed under `args.projectoptions` and does not hit this codepath.
+        if isinstance(self.default, bool):
             return 'store_true'
         return None
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -668,7 +668,7 @@ class CoreData:
         return len(self.cross_files) > 0
 
     def strip_build_option_names(self, options):
-        res = {}
+        res = OrderedDict()
         for k, v in options.items():
             if k.startswith('build.'):
                 k = k.split('.', 1)[1]
@@ -741,7 +741,7 @@ class CoreData:
         # Language and backend specific options will be set later when adding
         # languages and setting the backend (builtin options must be set first
         # to know which backend we'll use).
-        options = {}
+        options = OrderedDict()
 
         # Some options default to environment variables if they are
         # unset, set those now. These will either be overwritten
@@ -861,7 +861,7 @@ def write_cmd_line_file(build_dir, options):
     filename = get_cmd_line_file(build_dir)
     config = CmdLineFileParser()
 
-    properties = {}
+    properties = OrderedDict()
     if options.cross_file:
         properties['cross_file'] = options.cross_file
     if options.native_file:
@@ -941,7 +941,7 @@ def register_builtin_arguments(parser):
                         help='Set the value of an option, can be used several times to set multiple options.')
 
 def create_options_dict(options):
-    result = {}
+    result = OrderedDict()
     for o in options:
         try:
             (key, value) = o.split('=', 1)
@@ -1026,7 +1026,7 @@ class BuiltinOption(T.Generic[_T, _U]):
         return self.default
 
     def add_to_argparse(self, name: str, parser: argparse.ArgumentParser, prefix: str, help_suffix: str) -> None:
-        kwargs = {}
+        kwargs = OrderedDict()
 
         c = self._argparse_choices()
         b = self._argparse_action()

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3826,6 +3826,14 @@ recommended as it is not supported on some platforms''')
         self.assertEqual(opts['debug'], True)
         self.assertEqual(opts['optimization'], '2')
         self.assertEqual(opts['buildtype'], 'debugoptimized')
+        # Setting both buildtype and debug on the command-line should work
+        # Also test that --debug is parsed as -Ddebug=true
+        self.new_builddir()
+        self.init(testdir, extra_args=['-Dbuildtype=debugoptimized', '--debug'])
+        opts = self.get_opts_as_dict()
+        self.assertEqual(opts['debug'], True)
+        self.assertEqual(opts['optimization'], '2')
+        self.assertEqual(opts['buildtype'], 'debugoptimized')
 
     @skipIfNoPkgconfig
     @unittest.skipIf(is_windows(), 'Help needed with fixing this test on windows')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3809,6 +3809,24 @@ recommended as it is not supported on some platforms''')
         self.assertEqual(opts['debug'], True)
         self.assertEqual(opts['optimization'], '0')
 
+        # Command-line parsing of buildtype settings should be the same as
+        # setting with `meson configure`.
+        #
+        # Setting buildtype should set optimization/debug
+        self.new_builddir()
+        self.init(testdir, extra_args=['-Dbuildtype=debugoptimized'])
+        opts = self.get_opts_as_dict()
+        self.assertEqual(opts['debug'], True)
+        self.assertEqual(opts['optimization'], '2')
+        self.assertEqual(opts['buildtype'], 'debugoptimized')
+        # Setting optimization/debug should set buildtype
+        self.new_builddir()
+        self.init(testdir, extra_args=['-Doptimization=2', '-Ddebug=true'])
+        opts = self.get_opts_as_dict()
+        self.assertEqual(opts['debug'], True)
+        self.assertEqual(opts['optimization'], '2')
+        self.assertEqual(opts['buildtype'], 'debugoptimized')
+
     @skipIfNoPkgconfig
     @unittest.skipIf(is_windows(), 'Help needed with fixing this test on windows')
     def test_native_dep_pkgconfig(self):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3826,10 +3826,11 @@ recommended as it is not supported on some platforms''')
         self.assertEqual(opts['debug'], True)
         self.assertEqual(opts['optimization'], '2')
         self.assertEqual(opts['buildtype'], 'debugoptimized')
-        # Setting both buildtype and debug on the command-line should work
-        # Also test that --debug is parsed as -Ddebug=true
+        # Setting both buildtype and debug on the command-line should work, and
+        # should warn not to do that. Also test that --debug is parsed as -Ddebug=true
         self.new_builddir()
-        self.init(testdir, extra_args=['-Dbuildtype=debugoptimized', '--debug'])
+        out = self.init(testdir, extra_args=['-Dbuildtype=debugoptimized', '--debug'])
+        self.assertRegex(out, 'Recommend using either.*buildtype.*debug.*redundant')
         opts = self.get_opts_as_dict()
         self.assertEqual(opts['debug'], True)
         self.assertEqual(opts['optimization'], '2')

--- a/test cases/common/1 trivial/meson.build
+++ b/test cases/common/1 trivial/meson.build
@@ -1,7 +1,7 @@
 # Comment on the first line
 project('trivial test',
   # Comment inside a function call + array for language list
-  ['c'],
+  ['c'], default_options: ['buildtype=debug'],
   meson_version : '>=0.52.0')
 #this is a comment
 sources = 'trivial.c'


### PR DESCRIPTION
commit 7cd9fcef125a9ad6f7416f647e70155e205c1c9d:

```
coredata: Convert all option parsing to OrderedDict()
This ensures that options are always parsed in the order in which they
were specified on the command-line, even with Python 3.5, and
non-CPython implementations compatible with CPython 3.5 and 3.6.
```
Closes https://github.com/mesonbuild/meson/issues/6742


commit 6ee7450aaf99b24343eb3680457830dea718151b:

```
coredata: Set default options as cmdline args that override each other
The previous code was assuming that options do not depend on each
other, and that you can set defaults using `dict.setdefault()`. This
is not true for `buildtype` + `optimization`/`debug`, so we add
defaults + overrides in the right order and use the options parsing
code later to compute the values.

Includes a test.
```
Closes https://github.com/mesonbuild/meson/issues/6752


commit b52420cc4c292feeff710f56d1ea36bab3cea973:

```
coredata: Passing an option is supposed to set it, not flip the default
With the current logic passing `--debug` will actually be parsed as
`-Ddebug=false`, which is absolutely not what is expected.

There is no case in which the presence of a boolean option in `--foo`
form will mean 'I want feature foo disabled', regardless of the
*default* value of that option.

Also includes a test.
```
Closes https://github.com/mesonbuild/meson/issues/4686

commit 4dc0f5a1631d36cd015dc0071a3cd4730cb0aad8:

```
coredata: Warn on usage of both -Dbuildtype and -Doptimization/-Ddebug
It may not be obvious to users that these two ways to set build-types
override each other and specifying both is redundant, and conflicts
are resolved based on whichever is specified later.
```
Closes https://github.com/mesonbuild/meson/issues/6742