### PR TITLE
pkgconfig: Document conflicts keyword

### DIFF
--- a/docs/markdown/Pkgconfig-module.md
+++ b/docs/markdown/Pkgconfig-module.md
@@ -58,6 +58,7 @@ keyword arguments.
   generating the uninstalled pkg-config file. Since *0.54.0*
 - `dataonly` field. (*since 0.54.0*) this is used for architecture-independent
    pkg-config files in projects which also have architecture-dependent outputs.
+- `conflicts` (*since 0.36.0, incorrectly issued a warning prior to 0.54.0*) list of strings to be put in the `Conflicts` field.
 
 Since 0.46 a `StaticLibrary` or `SharedLibrary` object can optionally be passed
 as first positional argument. If one is provided a default value will be

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -392,7 +392,7 @@ class PkgConfigModule(ExtensionModule):
     @permittedKwargs({'libraries', 'version', 'name', 'description', 'filebase',
                       'subdirs', 'requires', 'requires_private', 'libraries_private',
                       'install_dir', 'extra_cflags', 'variables', 'url', 'd_module_versions',
-                      'dataonly'})
+                      'dataonly', 'conflicts'})
     def generate(self, state, args, kwargs):
         if 'variables' in kwargs:
             FeatureNew('custom pkgconfig variables', '0.41.0').use(state.subproject)


### PR DESCRIPTION
[why]
Sometimes one want to set the 'Conflicts:' field in .pc files.

This is possible by using the 'conflicts' keyword argument in the
pkgconfig module. The feature is not documented on mesonbuild.org,
though.

But a warning is issued:
  WARNING: Passed invalid keyword argument "conflicts".
  WARNING: This will become a hard error in the future.

History:

It has been added along with kwarg 'url' with commit
  309041918 pkgconfig: Add missing 'URL' and 'Conflicts' entries

Later the kwargs check has been introduced with
  80d665e8d Converted some modules.
but both 'url' and 'conflicts' were missing.

With commit
   2acf737b pkgconfig: Document url keyword
the 'url' kwarg has been added to the checks, but not 'conflicts'.

[how]
Add 'conflicts' to the allowed kwargs.

Signed-off-by: Fini Jastrow <ulf.fini.jastrow@desy.de>