### PR TITLE
mintro: AST JSON printer

### DIFF
--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -29,16 +29,16 @@ watch for changes in this directory to know when something changed.
 
 The `meson-info` directory should contain the following files:
 
-| File                            | Description                                                         |
-| ----                            | -----------                                                         |
-| `intro-benchmarks.json`         | Lists all benchmarks                                                |
-| `intro-buildoptions.json`       | Contains a full list of meson configuration options for the project |
-| `intro-buildsystem_files.json`  | Full list of all meson build files                                  |
-| `intro-dependencies.json`       | Lists all dependencies used in the project                          |
-| `intro-installed.json`          | Contains mapping of files to their installed location               |
-| `intro-projectinfo.json`        | Stores basic information about the project (name, version, etc.)    |
-| `intro-targets.json`            | Full list of all build targets                                      |
-| `intro-tests.json`              | Lists all tests with instructions how to run them                   |
+| File                           | Description                                                         |
+| ------------------------------ | ------------------------------------------------------------------- |
+| `intro-benchmarks.json`        | Lists all benchmarks                                                |
+| `intro-buildoptions.json`      | Contains a full list of meson configuration options for the project |
+| `intro-buildsystem_files.json` | Full list of all meson build files                                  |
+| `intro-dependencies.json`      | Lists all dependencies used in the project                          |
+| `intro-installed.json`         | Contains mapping of files to their installed location               |
+| `intro-projectinfo.json`       | Stores basic information about the project (name, version, etc.)    |
+| `intro-targets.json`           | Full list of all build targets                                      |
+| `intro-tests.json`             | Lists all tests with instructions how to run them                   |
 
 The content of the JSON files is further specified in the remainder of this document.
 
@@ -99,15 +99,15 @@ for actual compilation.
 
 The following table shows all valid types for a target.
 
-| value of `type`  | Description                                  |
-| ---------------  | -----------                                  |
-| `executable`     | This target will generate an executable file |
-| `static library` | Target for a static library                  |
-| `shared library` | Target for a shared library                  |
+| value of `type`  | Description                                                                                   |
+| ---------------- | --------------------------------------------------------------------------------------------- |
+| `executable`     | This target will generate an executable file                                                  |
+| `static library` | Target for a static library                                                                   |
+| `shared library` | Target for a shared library                                                                   |
 | `shared module`  | A shared library that is meant to be used with dlopen rather than linking into something else |
-| `custom`         | A custom target                              |
-| `run`            | A Meson run target                           |
-| `jar`            | A Java JAR target                            |
+| `custom`         | A custom target                                                                               |
+| `run`            | A Meson run target                                                                            |
+| `jar`            | A Java JAR target                                                                             |
 
 ### Using `--targets` without a build directory
 
@@ -274,6 +274,57 @@ Meson also provides the `meson introspect` for project introspection via the
 command line. Use `meson introspect -h` to see all available options.
 
 This API can also work without a build directory for the `--projectinfo` command.
+
+# AST of a `meson.build`
+
+Since meson *0.55.0* it is possible to dump the AST of a `meson.build` as a JSON
+object. The interface for this is `meson introspect --ast /path/to/meson.build`.
+
+Each node of the AST has at least the following entries:
+
+| Key          | Description                                             |
+| ------------ | ------------------------------------------------------- |
+| `node`       | Type of the node (see following table)                  |
+| `lineno`     | Line number of the node in the file                     |
+| `colno`      | Column number of the node in the file                   |
+| `end_lineno` | Marks the end of the node (may be the same as `lineno`) |
+| `end_colno`  | Marks the end of the node (may be the same as `colno`)  |
+
+Possible values for `node` with additional keys:
+
+| Node type            | Additional keys                                  |
+| -------------------- | ------------------------------------------------ |
+| `BooleanNode`        | `value`: bool                                    |
+| `IdNode`             | `value`: str                                     |
+| `NumberNode`         | `value`: int                                     |
+| `StringNode`         | `value`: str                                     |
+| `ContinueNode`       |                                                  |
+| `BreakNode`          |                                                  |
+| `ArgumentNode`       | `positional`: node list; `kwargs`: accept_kwargs |
+| `ArrayNode`          | `args`: node                                     |
+| `DictNode`           | `args`: node                                     |
+| `EmptyNode`          |                                                  |
+| `OrNode`             | `left`: node; `right`: node                      |
+| `AndNode`            | `left`: node; `right`: node                      |
+| `ComparisonNode`     | `left`: node; `right`: node; `ctype`: str        |
+| `ArithmeticNode`     | `left`: node; `right`: node; `op`: str           |
+| `NotNode`            | `right`: node                                    |
+| `CodeBlockNode`      | `lines`: node list                               |
+| `IndexNode`          | `object`: node; `index`: node                    |
+| `MethodNode`         | `object`: node; `args`: node; `name`: str        |
+| `FunctionNode`       | `args`: node; `name`: str                        |
+| `AssignmentNode`     | `value`: node; `var_name`: str                   |
+| `PlusAssignmentNode` | `value`: node; `var_name`: str                   |
+| `ForeachClauseNode`  | `items`: node; `block`: node; `varnames`: list   |
+| `IfClauseNode`       | `ifs`: node list; `else`: node                   |
+| `IfNode`             | `condition`: node; `block`: node                 |
+| `UMinusNode`         | `right`: node                                    |
+| `TernaryNode`        | `condition`: node; `true`: node; `false`: node   |
+
+We do not guarantee the stability of this format since it is heavily linked to
+the internal Meson AST. However, breaking changes (removal of a node type or the
+removal of a key) are unlikely and will be announced in the release notes.
+
 
 # Existing integrations
 

--- a/docs/markdown/snippets/introspect.md
+++ b/docs/markdown/snippets/introspect.md
@@ -1,0 +1,4 @@
+## Introspection API changes
+
+dumping the AST (--ast): **new in 0.55.0**
+- prints the AST of a meson.build as JSON

--- a/mesonbuild/ast/__init__.py
+++ b/mesonbuild/ast/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     'AstInterpreter',
     'AstIDGenerator',
     'AstIndentationGenerator',
+    'AstJSONPrinter',
     'AstVisitor',
     'AstPrinter',
     'IntrospectionInterpreter',
@@ -30,4 +31,4 @@ from .interpreter import AstInterpreter
 from .introspection import IntrospectionInterpreter, build_target_functions
 from .visitor import AstVisitor
 from .postprocess import AstConditionLevel, AstIDGenerator, AstIndentationGenerator
-from .printer import AstPrinter
+from .printer import AstPrinter, AstJSONPrinter

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -297,6 +297,11 @@ class AstInterpreter(interpreterbase.InterpreterBase):
         elif isinstance(node, ElementaryNode):
             result = node.value
 
+        elif isinstance(node, NotNode):
+            result = self.resolve_node(node.value, include_unknown_args, id_loop_detect)
+            if isinstance(result, bool):
+                result = not result
+
         elif isinstance(node, ArrayNode):
             result = [x for x in node.args.arguments]
 

--- a/mesonbuild/ast/visitor.py
+++ b/mesonbuild/ast/visitor.py
@@ -113,8 +113,7 @@ class AstVisitor:
         self.visit_default_func(node)
         for i in node.ifs:
             i.accept(self)
-        if node.elseblock:
-            node.elseblock.accept(self)
+        node.elseblock.accept(self)
 
     def visit_UMinusNode(self, node: mparser.UMinusNode) -> None:
         self.visit_default_func(node)

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -22,7 +22,7 @@ project files and don't need this info."""
 import json
 from . import build, coredata as cdata
 from . import mesonlib
-from .ast import IntrospectionInterpreter, build_target_functions, AstConditionLevel, AstIDGenerator, AstIndentationGenerator
+from .ast import IntrospectionInterpreter, build_target_functions, AstConditionLevel, AstIDGenerator, AstIndentationGenerator, AstJSONPrinter
 from . import mlog
 from .backend import backends
 from .mparser import BaseNode, FunctionNode, ArrayNode, ArgumentNode, StringNode
@@ -62,6 +62,7 @@ def get_meson_introspection_types(coredata: T.Optional[cdata.CoreData] = None,
         benchmarkdata = testdata = installdata = None
 
     return {
+        'ast': IntroCommand('Dump the AST of the meson file', no_bd=dump_ast),
         'benchmarks': IntroCommand('List all benchmarks', func=lambda: list_benchmarks(benchmarkdata)),
         'buildoptions': IntroCommand('List all build options', func=lambda: list_buildoptions(coredata), no_bd=list_buildoptions_from_source),
         'buildsystem_files': IntroCommand('List files that make up the build system', func=lambda: list_buildsystem_files(builddata, interpreter)),
@@ -88,6 +89,11 @@ def add_arguments(parser):
     parser.add_argument('-f', '--force-object-output', action='store_true', dest='force_dict', default=False,
                         help='Always use the new JSON format for multiple entries (even for 0 and 1 introspection commands)')
     parser.add_argument('builddir', nargs='?', default='.', help='The build directory')
+
+def dump_ast(intr: IntrospectionInterpreter) -> T.Dict[str, T.Any]:
+    printer = AstJSONPrinter()
+    intr.ast.accept(printer)
+    return printer.result
 
 def list_installed(installdata):
     res = {}

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -426,8 +426,8 @@ class IfNode(BaseNode):
 class IfClauseNode(BaseNode):
     def __init__(self, linenode: BaseNode):
         super().__init__(linenode.lineno, linenode.colno, linenode.filename)
-        self.ifs = []  # type: T.List[IfNode]
-        self.elseblock = EmptyNode(linenode.lineno, linenode.colno, linenode.filename)  # type: T.Union[EmptyNode, CodeBlockNode]
+        self.ifs = []          # type: T.List[IfNode]
+        self.elseblock = None  # type: T.Union[EmptyNode, CodeBlockNode]
 
 class UMinusNode(BaseNode):
     def __init__(self, current_location: Token, value: BaseNode):
@@ -747,9 +747,7 @@ class Parser:
         block = self.codeblock()
         clause.ifs.append(IfNode(clause, condition, block))
         self.elseifblock(clause)
-        elseblock = self.elseblock()
-        if elseblock:
-            clause.elseblock = elseblock
+        clause.elseblock = self.elseblock()
         return clause
 
     def elseifblock(self, clause) -> None:
@@ -759,11 +757,11 @@ class Parser:
             b = self.codeblock()
             clause.ifs.append(IfNode(s, s, b))
 
-    def elseblock(self) -> T.Optional[CodeBlockNode]:
+    def elseblock(self) -> T.Union[CodeBlockNode, EmptyNode]:
         if self.accept('else'):
             self.expect('eol')
             return self.codeblock()
-        return None
+        return EmptyNode(self.current.lineno, self.current.colno, self.current.filename)
 
     def line(self) -> BaseNode:
         block_start = self.current

--- a/test cases/unit/57 introspection/meson.build
+++ b/test cases/unit/57 introspection/meson.build
@@ -13,7 +13,7 @@ test_bool = not test_bool
 set_variable('list_test_plusassign', [])
 list_test_plusassign += ['bugs everywhere']
 
-if false
+if not true
   vers_str = '<=99.9.9'
   dependency('somethingthatdoesnotexist', required: true, version: '>=1.2.3')
   dependency('look_i_have_a_fallback', version: ['>=1.0.0', vers_str], fallback: ['oh_no', 'the_subproject_does_not_exist'])
@@ -26,7 +26,7 @@ var1 = '1'
 var2 = 2.to_string()
 var3 = 'test3'
 
-t1 = executable('test' + var1, ['t1.cpp'], link_with: [sharedlib], install: true, build_by_default: get_option('test_opt2'))
+t1 = executable('test' + var1, ['t1.cpp'], link_with: [sharedlib], install: not false, build_by_default: get_option('test_opt2'))
 t2 = executable('test@0@'.format('@0@'.format(var2)), sources: ['t2.cpp'], link_with: [staticlib])
 t3 = executable(var3, 't3.cpp', link_with: [sharedlib, staticlib], dependencies: [dep1])
 
@@ -46,3 +46,16 @@ message(osmesa_lib_name) # Infinite recursion gets triggered here when the param
 test('test case 1', t1)
 test('test case 2', t2)
 benchmark('benchmark 1', t3)
+
+### Stuff to test the AST JSON printer
+foreach x : ['a', 'b', 'c']
+  if x == 'a'
+    message('a')
+  elif x == 'b'
+    message('a')
+  else
+    continue
+  endif
+  break
+  continue
+endforeach


### PR DESCRIPTION
Adds the `--ast` command to `meson introspect` to dump the raw meson AST as JSON.