### PR TITLE
WIP: Simplify module API

### DIFF
--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -98,24 +98,17 @@ def _get_callee_args(wrapped_args, want_subproject: bool = False):
     elif n == 4:
         # Meson functions have 4 args: self, node, args, kwargs
         # Module functions have 4 args: self, state, args, kwargs
-        if isinstance(s, InterpreterBase):
-            node = wrapped_args[1]
+        if isinstance(s, ModuleObject):
+            state = wrapped_args[1]
+            node = state.current_node
+            subp = state.subproject
         else:
-            node = wrapped_args[1].current_node
+            node = wrapped_args[1]
+            subp = s.subproject
         args = wrapped_args[2]
         kwargs = wrapped_args[3]
         if want_subproject:
-            if isinstance(s, InterpreterBase):
-                subproject = s.subproject
-            else:
-                subproject = wrapped_args[1].subproject
-    elif n == 5:
-        # Module snippets have 5 args: self, interpreter, state, args, kwargs
-        node = wrapped_args[2].current_node
-        args = wrapped_args[3]
-        kwargs = wrapped_args[4]
-        if want_subproject:
-            subproject = wrapped_args[2].subproject
+            subproject = subp
     else:
         raise AssertionError('Unknown args: {!r}'.format(wrapped_args))
     # Sometimes interpreter methods are called internally with None instead of

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -30,7 +30,21 @@ class FSModule(ExtensionModule):
 
     def __init__(self, interpreter):
         super().__init__(interpreter)
-        self.snippets.add('generate_dub_file')
+        self.methods.update({'expanduser': self.expanduser_method,
+                             'is_absolute': self.is_absolute_method,
+                             'as_posix': self.as_posix_method,
+                             'exists': self.exists_method,
+                             'is_symlink': self.is_symlink_method,
+                             'is_file': self.is_file_method,
+                             'is_dir': self.is_dir_method,
+                             'hash': self.hash_method,
+                             'size': self.size_method,
+                             'is_samepath': self.is_samepath_method,
+                             'replace_suffix': self.replace_suffix_method,
+                             'parent': self.parent_method,
+                             'name': self.name_method,
+                             'stem': self.stem_method,
+                             })
 
     def _absolute_dir(self, state: 'ModuleState', arg: str) -> Path:
         """
@@ -52,68 +66,68 @@ class FSModule(ExtensionModule):
             pass
         return path
 
-    def _check(self, check: str, state: 'ModuleState', args: T.Sequence[str]) -> ModuleReturnValue:
+    def _check(self, check: str, state: 'ModuleState', args: T.Sequence[str]) -> str:
         if len(args) != 1:
             raise MesonException('fs.{} takes exactly one argument.'.format(check))
         test_file = self._resolve_dir(state, args[0])
         val = getattr(test_file, check)()
         if isinstance(val, Path):
             val = str(val)
-        return ModuleReturnValue(val, [])
+        return val
 
     @stringArgs
     @noKwargs
     @FeatureNew('fs.expanduser', '0.54.0')
-    def expanduser(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def expanduser_method(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> str:
         if len(args) != 1:
             raise MesonException('fs.expanduser takes exactly one argument.')
-        return ModuleReturnValue(str(Path(args[0]).expanduser()), [])
+        return str(Path(args[0]).expanduser())
 
     @stringArgs
     @noKwargs
     @FeatureNew('fs.is_absolute', '0.54.0')
-    def is_absolute(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def is_absolute_method(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> bool:
         if len(args) != 1:
             raise MesonException('fs.is_absolute takes exactly one argument.')
-        return ModuleReturnValue(PurePath(args[0]).is_absolute(), [])
+        return PurePath(args[0]).is_absolute()
 
     @stringArgs
     @noKwargs
     @FeatureNew('fs.as_posix', '0.54.0')
-    def as_posix(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def as_posix_method(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> str:
         """
         this function assumes you are passing a Windows path, even if on a Unix-like system
         and so ALL '\' are turned to '/', even if you meant to escape a character
         """
         if len(args) != 1:
             raise MesonException('fs.as_posix takes exactly one argument.')
-        return ModuleReturnValue(PureWindowsPath(args[0]).as_posix(), [])
+        return PureWindowsPath(args[0]).as_posix()
 
     @stringArgs
     @noKwargs
-    def exists(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def exists_method(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> str:
         return self._check('exists', state, args)
 
     @stringArgs
     @noKwargs
-    def is_symlink(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def is_symlink_method(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> bool:
         if len(args) != 1:
             raise MesonException('fs.is_symlink takes exactly one argument.')
-        return ModuleReturnValue(self._absolute_dir(state, args[0]).is_symlink(), [])
+        return self._absolute_dir(state, args[0]).is_symlink()
 
     @stringArgs
     @noKwargs
-    def is_file(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def is_file_method(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> str:
         return self._check('is_file', state, args)
 
     @stringArgs
     @noKwargs
-    def is_dir(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def is_dir_method(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> str:
         return self._check('is_dir', state, args)
 
     @stringArgs
     @noKwargs
-    def hash(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def hash_method(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> str:
         if len(args) != 2:
             raise MesonException('fs.hash takes exactly two arguments.')
         file = self._resolve_dir(state, args[0])
@@ -125,73 +139,73 @@ class FSModule(ExtensionModule):
             raise MesonException('hash algorithm {} is not available'.format(args[1]))
         mlog.debug('computing {} sum of {} size {} bytes'.format(args[1], file, file.stat().st_size))
         h.update(file.read_bytes())
-        return ModuleReturnValue(h.hexdigest(), [])
+        return h.hexdigest()
 
     @stringArgs
     @noKwargs
-    def size(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def size_method(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> int:
         if len(args) != 1:
             raise MesonException('fs.size takes exactly one argument.')
         file = self._resolve_dir(state, args[0])
         if not file.is_file():
             raise MesonException('{} is not a file and therefore cannot be sized'.format(file))
         try:
-            return ModuleReturnValue(file.stat().st_size, [])
+            return file.stat().st_size
         except ValueError:
             raise MesonException('{} size could not be determined'.format(args[0]))
 
     @stringArgs
     @noKwargs
-    def is_samepath(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def is_samepath_method(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> bool:
         if len(args) != 2:
             raise MesonException('fs.is_samepath takes exactly two arguments.')
         file1 = self._resolve_dir(state, args[0])
         file2 = self._resolve_dir(state, args[1])
         if not file1.exists():
-            return ModuleReturnValue(False, [])
+            return False
         if not file2.exists():
-            return ModuleReturnValue(False, [])
+            return False
         try:
-            return ModuleReturnValue(file1.samefile(file2), [])
+            return file1.samefile(file2)
         except OSError:
-            return ModuleReturnValue(False, [])
+            return False
 
     @stringArgs
     @noKwargs
-    def replace_suffix(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def replace_suffix_method(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> str:
         if len(args) != 2:
             raise MesonException('fs.replace_suffix takes exactly two arguments.')
         original = PurePath(args[0])
         new = original.with_suffix(args[1])
-        return ModuleReturnValue(str(new), [])
+        return str(new)
 
     @stringArgs
     @noKwargs
-    def parent(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def parent_method(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> str:
         if len(args) != 1:
             raise MesonException('fs.parent takes exactly one argument.')
         original = PurePath(args[0])
         new = original.parent
-        return ModuleReturnValue(str(new), [])
+        return str(new)
 
     @stringArgs
     @noKwargs
-    def name(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def name_method(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> str:
         if len(args) != 1:
             raise MesonException('fs.name takes exactly one argument.')
         original = PurePath(args[0])
         new = original.name
-        return ModuleReturnValue(str(new), [])
+        return str(new)
 
     @stringArgs
     @noKwargs
     @FeatureNew('fs.stem', '0.54.0')
-    def stem(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def stem_method(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> str:
         if len(args) != 1:
             raise MesonException('fs.stem takes exactly one argument.')
         original = PurePath(args[0])
         new = original.stem
-        return ModuleReturnValue(str(new), [])
+        return str(new)
 
 def initialize(*args, **kwargs) -> FSModule:
     return FSModule(*args, **kwargs)


### PR DESCRIPTION
Module API has a few issues:
- We can call any method not starting with underscore from meson.build.
While it is good practice, it is also little known trick. Over time a
few private methods have been added without underscore (e.g.
QtBaseModule.parse_qrc). Prevent this by making ExtensionModule a
subclass of InterpreterObject which has a 'methods' dictionary to make
its public API explicit. This is also more consistent with the rest of
Meson design.
- 'snippets' bypass the check that modules should not modify
internal state. It is also little known trick often misunderstood (e.g.
fs module has 'generate_dub_file' for no reason). It is useless because
it just pass interpreter object as argument which is already available as
attribute on ExtensionModule base class. This removes snippets methods
special case.
- ModuleReturnValue is rarely needed, we can just check the type of the
return value and special case them and allow all methods to directly
return a any type that we can holderify.
- Some modules export some InterpreterObject (e.g.
CMakeSubprojectHolder) which feels inconsistent because their main
ExtensionModule object is not an InterpreterObject (i.e. not using
self.methods dict) and they don't have the 'state' argument which is
essential to keep modules behind a common API. Fix this by adding
ModuleObject, subclass of InterpreterObject, that can be used for every
objects exported by modules, not only the main ExtensionModule.

--
I only ported the FS module as an example, until we agree on the API. All modules will need to be ported afterward.