### PR TITLE
fix conversion of hasattr to getattr

### DIFF
--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -446,7 +446,7 @@ class InterpreterBase:
                 self.current_lineno = cur.lineno
                 self.evaluate_statement(cur)
             except Exception as e:
-                if getattr(e, 'lineno') is None:
+                if getattr(e, 'lineno', None) is None:
                     # We are doing the equivalent to setattr here and mypy does not like it
                     e.lineno = cur.lineno                                                             # type: ignore
                     e.colno = cur.colno                                                               # type: ignore

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -298,7 +298,7 @@ def exception(e: Exception, prefix: T.Optional[AnsiDecorator] = None) -> None:
         prefix = red('ERROR:')
     log()
     args = []  # type: T.List[T.Union[AnsiDecorator, str]]
-    if getattr(e, 'file') is not None and getattr(e, 'lineno') is not None and getattr(e, 'colno') is not None:
+    if all(getattr(e, a, None) is not None for a in ['file', 'lineno', 'colno']):
         # Mypy doesn't follow hasattr, and it's pretty easy to visually inspect
         # that this is correct, so we'll just ignore it.
         path = get_relative_path(Path(e.file), Path(os.getcwd()))  # type: ignore


### PR DESCRIPTION
getattr() requires a default (return if missing) value or it raises an
AttributeError. In a few cases I changed hasattr to getattr and didn't
set a default value, so those cases could except. This corrects that.