### PR TITLE
docs: Document that ldc now supports linker overriding [skip ci]

### DIFF
--- a/docs/markdown/snippets/ldc_linker_override.md
+++ b/docs/markdown/snippets/ldc_linker_override.md
@@ -1,0 +1,5 @@
+## Support for overiding the linker with ldc
+
+LDC (the llvm D compiler) now honors D_LD linker variable (or d_ld in the cross
+file) and is able to pick differnt linkers. ld.bfd, ld.gold, ld.lld, ld64,
+link, and lld-link are currently supported.


### PR DESCRIPTION
I forgot to put this in the d linker cleanups, as I implemented it.