### PR TITLE
Improve usability of get_option('buildtype')

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -91,19 +91,31 @@ Using the option as-is with no prefix affects all machines. For example:
 For setting optimization levels and toggling debug, you can either set the
 `buildtype` option, or you can set the `optimization` and `debug` options which
 give finer control over the same. Whichever you decide to use, the other will
-be deduced from it. For example, `-Dbuildtype=debugoptimized` is the same as
+be deduced from it. For example, `-Dbuildtype=debugoptimized` will also set
 `-Ddebug=true -Doptimization=2` and vice-versa. This table documents the
-two-way mapping:
+mapping from `buildtype` to `debug` and `optimization`:
 
 | buildtype      | debug | optimization |
 | ---------      | ----- | ------------ |
-| plain          | false | 0            |
 | debug          | true  | 0            |
+| minsize        | true  | s            |
 | debugoptimized | true  | 2            |
 | release        | false | 3            |
-| minsize        | true  | s            |
+| plain          | false | 0            |
 
-All other combinations of `debug` and `optimization` set `buildtype` to `'custom'`.
+This table documents the reverse mapping:
+
+| debug | optimization | buildtype      |
+| ----- | ------------ | ---------      |
+| true  | 0            | debug          |
+| true  | s            | minsize        |
+| true  | 2            | debugoptimized |
+| false | 0            | plain          |
+| false | s            | release *(since 0.54)* |
+| false | 2            | release *(since 0.54)* |
+| false | 3            | release        |
+
+All other combinations of `debug` and `optimization` set `buildtype` to `custom`.
 
 ## Base options
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -605,7 +605,7 @@ class CoreData:
             mode = 'debug'
         elif opt == '2' and debug:
             mode = 'debugoptimized'
-        elif opt == '3' and not debug:
+        elif opt in ('s', '2', '3') and not debug:
             mode = 'release'
         elif opt == 's' and debug:
             mode = 'minsize'

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2833,7 +2833,7 @@ external dependencies (including libraries) must go to "dependencies".''')
 
     @stringArgs
     @noKwargs
-    def func_get_option(self, nodes, args, kwargs):
+    def func_get_option(self, node, args, kwargs):
         if len(args) != 1:
             raise InterpreterException('Argument required for get_option.')
         optname = args[0]
@@ -2843,9 +2843,17 @@ external dependencies (including libraries) must go to "dependencies".''')
                                        'options of other subprojects.')
         opt = self.get_option_internal(optname)
         if isinstance(opt, coredata.UserFeatureOption):
-            return FeatureOptionHolder(self.environment, optname, opt)
+            opt = FeatureOptionHolder(self.environment, optname, opt)
         elif isinstance(opt, coredata.UserOption):
-            return opt.value
+            opt = opt.value
+        if optname == 'buildtype':
+            class BuildTypeString(str):
+                def startswith(self, token):
+                    if token == 'debug':
+                        mlog.warning("Use get_option('debug') to check whether debugging is enabled "
+                                     "instead of get_option('buildtype').startswith('debug')", location=node)
+                    super().startswith(token)
+            opt = BuildTypeString(opt)
         return opt
 
     @noKwargs

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4832,6 +4832,11 @@ class FailureTests(BasePlatformTests):
                                "meson.override_dependency('zlib', declare_dependency())",
                                """Tried to override dependency 'zlib' which has already been resolved or overridden""")
 
+    def test_buildtype_debug_warning(self):
+        self.assertMesonOutputs("get_option('buildtype').startswith('debug')\n",
+                                r"WARNING:.*get_option\('debug'\)")
+
+
 @unittest.skipUnless(is_windows() or is_cygwin(), "requires Windows (or Windows via Cygwin)")
 class WindowsTests(BasePlatformTests):
     '''


### PR DESCRIPTION
Alternative to https://github.com/mesonbuild/meson/pull/6774.

commit a18658d8e11ed3504aa700df6a9e78a3cd9460f4:

```
coredata: Set buildtype=release from others in more cases
`buildtype=release` has the semantic meaning 'release build' (f.ex.,
`b_ndebug=if-release`), and build files are using that to enable/disable
features.

However, that's broken when you want to set `-Doptimization` to
anything other than `3` for a 'release build', for example when
shipping for embedded or mobile, because build files will get
`custom`.

Setting `buildtype` to `release` when `optimization` is `2` or `s`
(and `debug=false`) is more useful than setting it to `custom`.
```

commit 3348a0fd1a09ab0768f487661ad1eabe295a6725:

```
Warn when detecting debug with get_option('buildtype')
Build files should always use `get_option('debug')` since `buildtype`
is set to `custom` in many cases.
```
