### PR TITLE
Allow setting linker for GDC as well as LDC

### DIFF
--- a/docs/markdown/snippets/ldc_linker_override.md
+++ b/docs/markdown/snippets/ldc_linker_override.md
@@ -1,5 +1,7 @@
-## Support for overiding the linker with ldc
+## Support for overiding the linker with ldc and gdc
 
-LDC (the llvm D compiler) now honors D_LD linker variable (or d_ld in the cross
-file) and is able to pick differnt linkers. ld.bfd, ld.gold, ld.lld, ld64,
-link, and lld-link are currently supported.
+LDC (the llvm D compiler) and GDC (The Gnu D Compiler) now honor D_LD linker
+variable (or d_ld in the cross file) and is able to pick differnt linkers.
+
+GDC supports all of the same values as GCC, LDC supports ld.bfd, ld.gold,
+ld.lld, ld64, link, and lld-link.

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -627,7 +627,7 @@ class DCompiler(Compiler):
         return ' '.join(self.exelist)
 
 
-class GnuDCompiler(DCompiler, GnuCompiler):
+class GnuDCompiler(GnuCompiler, DCompiler):
 
     # we mostly want DCompiler, but that gives us the Compiler.LINKER_PREFIX instead
     LINKER_PREFIX = GnuCompiler.LINKER_PREFIX

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4994,6 +4994,14 @@ class WindowsTests(BasePlatformTests):
     def test_link_environment_variable_rust(self):
         self._check_ld('link', 'rust', 'link')
 
+    @skip_if_not_language('d')
+    def test_link_environment_variable_d(self):
+        env = get_fake_env()
+        comp = getattr(env, 'detect_d_compiler')(MachineChoice.HOST)
+        if comp.id == 'dmd':
+            raise unittest.SkipTest('meson cannot reliably make DMD use a different linker.')
+        self._check_ld('lld-link', 'd', 'lld-link')
+
     def test_pefile_checksum(self):
         try:
             import pefile
@@ -6361,6 +6369,12 @@ c = ['{0}']
     @skip_if_not_language('fortran')
     def test_ld_environment_variable_fortran(self):
         self._check_ld('ld.gold', 'gold', 'fortran', 'ld.gold')
+
+    @skip_if_not_language('d')
+    def test_ld_environment_variable_d(self):
+        # At least for me, ldc defaults to gold, and gdc defaults to bfd, so
+        # let's pick lld, which isn't the default for either (currently)
+        self._check_ld('ld.lld', 'lld', 'd', 'ld.lld')
 
     def compute_sha256(self, filename):
         with open(filename, 'rb') as f:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4990,6 +4990,7 @@ class WindowsTests(BasePlatformTests):
     def test_link_environment_variable_optlink(self):
         self._check_ld('optlink', 'c', 'optlink')
 
+    @skip_if_not_language('rust')
     def test_link_environment_variable_rust(self):
         self._check_ld('link', 'rust', 'link')
 
@@ -6342,20 +6343,22 @@ c = ['{0}']
     def test_ld_environment_variable_lld(self):
         self._check_ld('ld.lld', 'lld', 'c', 'ld.lld')
 
-    @skipIfNoExecutable('rustc')
+    @skip_if_not_language('rust')
     def test_ld_environment_variable_rust(self):
         self._check_ld('ld.gold', 'gold', 'rust', 'ld.gold')
 
     def test_ld_environment_variable_cpp(self):
         self._check_ld('ld.gold', 'gold', 'cpp', 'ld.gold')
 
+    @skip_if_not_language('objc')
     def test_ld_environment_variable_objc(self):
         self._check_ld('ld.gold', 'gold', 'objc', 'ld.gold')
 
+    @skip_if_not_language('objcpp')
     def test_ld_environment_variable_objcpp(self):
         self._check_ld('ld.gold', 'gold', 'objcpp', 'ld.gold')
 
-    @skipIfNoExecutable('gfortran')
+    @skip_if_not_language('fortran')
     def test_ld_environment_variable_fortran(self):
         self._check_ld('ld.gold', 'gold', 'fortran', 'ld.gold')
 


### PR DESCRIPTION
GDC uses the standard `-fuse-ld=` argument that most GCC derivatives do. This adds the necessary tests for the D language, as well as the changes for GDC. This contains the documentation for the ldc change as well, as I simply modified that snippet.