### PR TITLE
Use os.path.normpath() for include paths

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2013,7 +2013,6 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             # own target build dir.
             if not isinstance(i, (build.CustomTarget, build.CustomTargetIndex)):
                 continue
-            # NOTE: if we want to use os.path.realpath() for include path only! CK
             idir = os.path.normpath(self.get_target_dir(i))
             if not idir:
                 idir = '.'
@@ -2028,11 +2027,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def generate_inc_dir(self, compiler, d, basedir, is_system):
         # Avoid superfluous '/.' at the end of paths when d is '.'
         if d not in ('', '.'):
-            # NOTE: if we want to use os.path.realpath() for include path only! CK
             expdir = os.path.normpath(os.path.join(basedir, d))
         else:
             expdir = basedir
-        # NOTE: if we want to use os.path.realpath() for include path only! CK
         srctreedir = os.path.normpath(os.path.join(self.build_to_src, expdir))
         sargs = compiler.get_include_args(srctreedir, is_system)
         # There may be include dirs where a build directory has not been

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2013,7 +2013,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             # own target build dir.
             if not isinstance(i, (build.CustomTarget, build.CustomTargetIndex)):
                 continue
-            idir = self.get_target_dir(i)
+            # NOTE: if we want to use os.path.realpath() for include path only! CK
+            idir = os.path.normpath(self.get_target_dir(i))
             if not idir:
                 idir = '.'
             if idir not in custom_target_include_dirs:
@@ -2027,10 +2028,12 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def generate_inc_dir(self, compiler, d, basedir, is_system):
         # Avoid superfluous '/.' at the end of paths when d is '.'
         if d not in ('', '.'):
-            expdir = os.path.join(basedir, d)
+            # NOTE: if we want to use os.path.realpath() for include path only! CK
+            expdir = os.path.normpath(os.path.join(basedir, d))
         else:
             expdir = basedir
-        srctreedir = os.path.join(self.build_to_src, expdir)
+        # NOTE: if we want to use os.path.realpath() for include path only! CK
+        srctreedir = os.path.normpath(os.path.join(self.build_to_src, expdir))
         sargs = compiler.get_include_args(srctreedir, is_system)
         # There may be include dirs where a build directory has not been
         # created for some source dir. For example if someone does this:

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -270,10 +270,8 @@ class File:
     def rel_to_builddir(self, build_to_src: str) -> str:
         if self.is_built:
             return self.relative_name()
-            #NO! return os.path.realpath(self.relative_name())
         else:
             return os.path.join(build_to_src, self.subdir, self.fname)
-            #NO! return os.path.realpath(os.path.join(build_to_src, self.subdir, self.fname))
 
     @lru_cache(maxsize=None)
     def absolute_path(self, srcdir: str, builddir: str) -> str:

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -270,8 +270,10 @@ class File:
     def rel_to_builddir(self, build_to_src: str) -> str:
         if self.is_built:
             return self.relative_name()
+            #NO! return os.path.realpath(self.relative_name())
         else:
             return os.path.join(build_to_src, self.subdir, self.fname)
+            #NO! return os.path.realpath(os.path.join(build_to_src, self.subdir, self.fname))
 
     @lru_cache(maxsize=None)
     def absolute_path(self, srcdir: str, builddir: str) -> str:

--- a/test cases/common/203 function attributes/meson.build
+++ b/test cases/common/203 function attributes/meson.build
@@ -31,7 +31,6 @@ expected_result = not ['msvc', 'clang-cl', 'intel-cl'].contains(c.get_id())
 #    figure that out except by running the code we're trying to test.
 attributes = [
   'aligned',
-  'alloc_size',
   'always_inline',
   'cold',
   'const',
@@ -65,6 +64,7 @@ endif
 if host_machine.system() != 'darwin'
   attributes += 'alias'
   attributes += 'visibility'
+  attributes += 'alloc_size'
 endif
 
 if ['gcc', 'intel'].contains(c.get_id())


### PR DESCRIPTION
This make relative pathes shorter an too give a chance to
de-duplicate -isystem flags just like -I flags.

Fix common test case 203 for OSX build host too.

Related to https://github.com/mesonbuild/meson/issues/2155