### PR TITLE
Make linker selection environment variables match docs

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -255,3 +255,22 @@ These are the values that can be passed to `dependency` function's
 | config-tool       | Use a custom dep tool such as `cups-config`  |
 | system            | System provided (e.g. OpenGL)                |
 | extraframework    | A macOS/iOS framework                        |
+
+
+## Compiler and Linker selection variables
+
+| Language      | Compiler | Linker    | Note                                        |
+|:-------------:|----------|-----------|---------------------------------------------|
+| C             | CC       | CC_LD     |                                             |
+| C++           | CXX      | CXX_LD    |                                             |
+| D             | DC       | DC_LD     | Before 0.54 D_LD*                           |
+| Fortran       | FC       | FC_LD     | Before 0.54 F_LD*                           |
+| Objective-C   | OBJC     | OBJC_LD   |                                             |
+| Objective-C++ | OBJCXX   | OBJCXX_LD | Before 0.54 OBJCPP_LD*                      |
+| Rust          | RUSTC    | RUSTC_LD  | Before 0.54 RUST_LD*                        |
+| Vala          | VALAC    |           | Use CC_LD. Vala transpiles to C             |
+| C#            | CSC      | CSC       | The linker is the compiler                  |
+
+*The old environment variales are still supported, but are deprecated and will
+be removed in a future version of meson.
+

--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -26,6 +26,9 @@ build. Because of this Meson needs to know both the native and the
 cross compiler. The former is set via the environment variables or
 native-files and the latter via the cross file only.
 
+There is a table of all environment variables supported [Here](Reference-tables.md#compiler-and-linker-selection-variables)
+
+
 ## Set dynamic linker
 
 *New in 0.53.0*
@@ -60,6 +63,9 @@ or in a cross or native file:
 c = 'clang'
 c_ld = 'lld'
 ```
+
+There is a table of all environment variables supported [Here](Reference-tables.md#compiler-and-linker-selection-variables)
+
 
 ## Set default C/C++ language version
 

--- a/docs/markdown/snippets/linker_environment_variables_match_docs.md
+++ b/docs/markdown/snippets/linker_environment_variables_match_docs.md
@@ -1,0 +1,7 @@
+## Dynamic Linker environment variables actually match docs
+
+The docs have always claimed that the Dynamic Linker environment variable
+should be `${COMPILER_VAR}_LD`, but that's only the case for about half of
+the variables. The other half are different. In 0.54.0 the variables match.
+The old variables are still supported, but are deprecated and raise a
+deprecation warning.

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -304,6 +304,10 @@ class GnuLikeCompiler(metaclass=abc.ABCMeta):
 
     @classmethod
     def use_linker_args(cls, linker: str) -> T.List[str]:
+        if linker not in {'gold', 'bfd', 'lld'}:
+            raise mesonlib.MesonException(
+                'Unsupported linker, only bfd, gold, and lld are supported, '
+                'not {}.'.format(linker))
         return ['-fuse-ld={}'.format(linker)]
 
 

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -366,10 +366,6 @@ class VisualStudioLikeCompiler(metaclass=abc.ABCMeta):
     def get_argument_syntax(self) -> str:
         return 'msvc'
 
-    @classmethod
-    def use_linker_args(cls, linker: str) -> T.List[str]:
-        return []
-
 
 class MSVCCompiler(VisualStudioLikeCompiler):
 

--- a/test cases/java/1 basic/meson.build
+++ b/test cases/java/1 basic/meson.build
@@ -5,3 +5,7 @@ javaprog = jar('myprog', 'com/mesonbuild/Simple.java',
   install : true,
   install_dir : get_option('bindir'))
 test('mytest', javaprog)
+
+jc = meson.get_compiler('java')
+message(jc.get_id())
+message(jc.get_linker_id())


### PR DESCRIPTION
Currently the linker environment variables only match the docs half the time. This series changes that to match the docs all the time, with the old variables still supported by deprecated.