### PR TITLE
Correctly initialize command in EmptyExternalProgram

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1991,7 +1991,7 @@ class EmptyExternalProgram(ExternalProgram):  # lgtm [py/missing-call-to-init]
 
     def __init__(self):
         self.name = None
-        self.command = []
+        self.command = [None]
         self.path = None
 
     def __repr__(self):


### PR DESCRIPTION
set it to [None] like NonExistingExternalProgram does.

Otherwise self.exe_wrapper will be [] if no exe_wrapper is supplied.
And despite of cross compiling meson will try to run binaries because
exe_wrapper is [] instead of None.

I ran into that situation while cross compiling for ia32 on a
x64_64 host. The host had no ia32 userspace installed, so the
self test failed.

As workaround I currently set exe_wrapper to 'true'.

Signed-off-by: Richard Weinberger <richard@nod.at>