### PR TITLE
Fix exe_wrapper usage in EmptyExternalProgram case

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -56,7 +56,7 @@ class CLikeCompiler:
         self.can_compile_suffixes.add('h')
         # If the exe wrapper was not found, pretend it wasn't set so that the
         # sanity check is skipped and compiler checks use fallbacks.
-        if not exe_wrapper or not exe_wrapper.found():
+        if not exe_wrapper or not exe_wrapper.found() or not exe_wrapper.get_command():
             self.exe_wrapper = None
         else:
             self.exe_wrapper = exe_wrapper.get_command()


### PR DESCRIPTION
If no exe_wrapper is set in the meson cross file the exe_wrapper
object will be an instance of EmptyExternalProgram.
So, found is True and prorgram is an empty list.

This will cause meson to tun the compiler sanity check because
it checks only for self.is_cross and self.exe_wrapper being
not None.

I ran into that situation while cross compiling for ia32 on a
x64_64 host. The host had no ia32 userspace installed, so the
self test failed.

As workaround I currently set exe_wrapper to 'true'.

Signed-off-by: Richard Weinberger <richard@nod.at>