### PR TITLE
compilers: Link D runtime/libphobos dynamically on !Windows

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -842,7 +842,7 @@ class Compiler:
         """
         return self.linker.get_accepts_rsp()
 
-    def get_linker_always_args(self):
+    def get_linker_always_args(self) -> T.List[str]:
         return self.linker.get_always_args()
 
     def get_linker_lib_prefix(self):

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -678,6 +678,12 @@ class GnuDCompiler(GnuCompiler, DCompiler):
     def get_allow_undefined_link_args(self) -> T.List[str]:
         return self.linker.get_allow_undefined_args()
 
+    def get_linker_always_args(self) -> T.List[str]:
+        args = super().get_linker_always_args()
+        if self.info.is_windows():
+            return args
+        return args + ['-shared-libphobos']
+
 
 class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
 
@@ -720,6 +726,12 @@ class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
     @classmethod
     def use_linker_args(cls, linker: str) -> T.List[str]:
         return ['-linker={}'.format(linker)]
+
+    def get_linker_always_args(self) -> T.List[str]:
+        args = super().get_linker_always_args()
+        if self.info.is_windows():
+            return args
+        return args + ['-link-defaultlib-shared']
 
 
 class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
@@ -785,3 +797,9 @@ class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
 
     def can_linker_accept_rsp(self) -> bool:
         return False
+
+    def get_linker_always_args(self) -> T.List[str]:
+        args = super().get_linker_always_args()
+        if self.info.is_windows():
+            return args
+        return args + ['-defaultlib=phobos2', '-debuglib=phobos2']


### PR DESCRIPTION
It is expected that on Linux, MacOS, and other Unices that libphobos and the d runtime will be linked dynamically, but on windows they should be linked statically. A number of Linux distros patch the D compilers to do this automatically, but not all of them do, so we should emit the proper arguments.

Fixes: #6786