### PR TITLE
Site-wide native file configuration

### DIFF
--- a/docs/markdown/Native-environments.md
+++ b/docs/markdown/Native-environments.md
@@ -25,6 +25,30 @@ persistent environment:
 All of the rules about cross files and changed settings apply to native files
 as well, see [here](Cross-compilation.md#changing-cross-file-settings)
 
+## Site local configuration
+
+*New in 0.54.0*
+
+Meson allows system administrators, OS distributions, and users to set
+default policy using a special native file, `siteconfig.ini`. This is looked
+up in all of the search paths meson searches. This applies to Unix-like OSes
+only.
+
+It is recommended that a minimal number of settings be put in this config. A
+good thing to put in this are non standard paths, for example, if a
+distribution uses Debian style libdirs (`/usr/lib/<host-triple>`) they could
+use this config for x86_64 Linux with glibc:
+
+```ini
+[paths]
+libdir = 'x64_64-linux-gnu'
+```
+
+Because normal search rules apply, if a user wants to disable this for
+themselves they could simply create an empty file in
+`$XDG_DATA_HOME/meson/native/siteconfig.ini`
+(`~/.local/share/meson/native/siteconfig.ini` if `$XDG_DATA_HOME` is unset),
+to disable this behavior.
 
 ## Defining the environment
 
@@ -79,7 +103,7 @@ just 12 native files.
 
 Like cross files, native files may be installed to user or system wide
 locations, defined as:
-  - $XDG_DATA_DIRS/meson/native 
+  - $XDG_DATA_DIRS/meson/native
     (/usr/local/share/meson/native:/usr/share/meson/native if $XDG_DATA_DIRS is
     undefined)
   - $XDG_DATA_HOME/meson/native ($HOME/.local/share/meson/native if

--- a/docs/markdown/snippets/siteconfig_native_file.md
+++ b/docs/markdown/snippets/siteconfig_native_file.md
@@ -1,0 +1,7 @@
+## Site-wide default configuration for build == host
+
+Meson now supports a `siteconfig.ini` file. This allows OS and company wide
+policy to be applied automatically. This has been added specifically to
+simplify cases of operating systems using non standard paths for library
+directories, as the `[paths]` section can be defined system wide. Please use
+responsibly.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -389,7 +389,7 @@ class CoreData:
         if ftype == 'cross':
             filenames = options.cross_file
         else:
-            filenames = options.native_file
+            filenames = ['siteconfig.ini'] + options.native_file
 
         if not filenames:
             return []
@@ -432,6 +432,11 @@ class CoreData:
                     missing.append(f)
             else:
                 missing.append(f)
+
+        # Siteconfig is optional, if it's in missing remove it so we don't get
+        # warnings/errors
+        if 'siteconfig.ini' in missing:
+            missing.remove('siteconfig.ini')
 
         if missing:
             if found_invalid:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -7269,6 +7269,64 @@ class NativeFileTests(BasePlatformTests):
         self.init(testcase, extra_args=['--native-file', config])
         self.build()
 
+    @unittest.skipIf(is_windows(), 'Test is not relavent on Windows.')
+    def test_siteconfig(self):
+        """Test that a siteconfig.ini is loaded correctly."""
+        testcase = os.path.join(self.common_test_dir, '1 trivial')
+
+        with tempfile.TemporaryDirectory() as d:
+            dpath = Path(d) / 'meson' / 'native'
+            dpath.mkdir(parents=True)
+            conf = ConfigParser()
+            conf['paths'] = {}
+            conf['paths']['bindir'] = "'sentinal value'"
+            with (dpath / 'siteconfig.ini').open('w') as f:
+                conf.write(f)
+
+            self.init(testcase, override_envvars={'XDG_DATA_HOME': d})
+            config = self.introspect(['--buildoptions'])
+            for opt in config:
+                if opt['name'] == 'bindir':
+                    self.assertEqual(opt['value'], 'sentinal value')
+                    break
+
+    @unittest.skipIf(is_windows(), 'Test is not relavent on Windows.')
+    def test_no_siteconfig(self):
+        """Test that not having a siteconfig.ini is okay."""
+        testcase = os.path.join(self.common_test_dir, '1 trivial')
+
+        with tempfile.TemporaryDirectory() as d:
+            self.init(testcase, override_envvars={'XDG_DATA_HOME': d, 'XDG_DATA_HOMES': d})
+
+    @unittest.skipIf(is_windows(), 'Test is not relavent on Windows.')
+    def test_siteconfig_order(self):
+        """Test that a siteconfig.ini is is loaded in the correct order."""
+        testcase = os.path.join(self.common_test_dir, '1 trivial')
+
+        with tempfile.TemporaryDirectory() as d:
+            dpath = Path(d) / 'meson' / 'native'
+            dpath.mkdir(parents=True)
+            conf = ConfigParser()
+            conf['paths'] = {}
+            conf['paths']['bindir'] = "'overriden value'"
+            conf['paths']['localstatedir'] = "'siteconfig value'"
+            with (dpath / 'siteconfig.ini').open('w') as f:
+                conf.write(f)
+
+            conf['paths']['bindir'] = "'sentinal value'"
+            with (dpath / 'override.ini').open('w') as f:
+                conf.write(f)
+
+            self.init(
+                testcase, extra_args=['--native-file', 'override.ini'],
+                override_envvars={'XDG_DATA_HOME': d})
+            config = self.introspect(['--buildoptions'])
+            for opt in config:
+                if opt['name'] == 'bindir':
+                    self.assertEqual(opt['value'], 'sentinal value')
+                elif opt['name'] == 'localstatedir':
+                    self.assertEqual(opt['value'], 'siteconfig value')
+
 
 class CrossFileTests(BasePlatformTests):
 


### PR DESCRIPTION
This allows a special native file called `siteconfig.ini` to be placed
in a user or system wide location on Unix systems for default
configuration. My initial thought of it's usefulness is to allow distros
that use non standard lib locations to set those system wide in
configuration rather than us having to fix up libdir paths.

Ideally this would be followed up by a similar cross configuration
setting, but I'm unsure of how to do that, given the complexities of
cross compilation.