### PR TITLE
Fix failing rust CI

### DIFF
--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Ninja version
       run: ninja --version
     - name: Run tests
-      run: LD_LIBRARY_PATH=/usr/local/share/boost/1.69.0/lib/:$LD_LIBRARY_PATH python3 run_tests.py
+      run: LD_LIBRARY_PATH=/usr/local/share/boost/1.69.0/lib/:$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH python3 run_tests.py
       env:
         CI: '1'
         XENIAL: '1'


### PR DESCRIPTION
rustc 1.42 now dynamically link to libstd so its path is needed in
LD_LIBRARY_PATH.