### PR TITLE
Update native description to use the new LD variables

### DIFF
--- a/docs/markdown/Native-environments.md
+++ b/docs/markdown/Native-environments.md
@@ -40,7 +40,9 @@ like `llvm-config`
 c = '/usr/local/bin/clang'
 cpp = '/usr/local/bin/clang++'
 rust = '/usr/local/bin/rust'
-ld = 'gold'
+c_ld = 'gold'
+cpp_ld = 'gold'
+rust_ld = 'gold'
 llvm-config = '/usr/local/llvm-svn/bin/llvm-config'
 ```
 


### PR DESCRIPTION
With Meson 0.53.1, this is now out of date. Updating to use the proper ld variables.