### PR TITLE
Update cross compilation documentation to reference new ld variables

### DIFF
--- a/docs/markdown/Cross-compilation.md
+++ b/docs/markdown/Cross-compilation.md
@@ -97,7 +97,8 @@ this:
 [binaries]
 c = '/usr/bin/i586-mingw32msvc-gcc'
 cpp = '/usr/bin/i586-mingw32msvc-g++'
-ld = 'gold'
+c_ld = 'gold'
+cpp_ld = 'gold'
 ar = '/usr/i586-mingw32msvc/bin/ar'
 strip = '/usr/i586-mingw32msvc/bin/strip'
 pkgconfig = '/usr/bin/i586-mingw32msvc-pkg-config'


### PR DESCRIPTION
As of Meson 0.53.1, this is out of date. Example has been updated.