### PR TITLE
Fix linker evn var tests

### DIFF
--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -58,6 +58,7 @@ __all__ = [
     'ElbrusCCompiler',
     'EmscriptenCCompiler',
     'GnuCompiler',
+    'GnuLikeCompiler',
     'GnuCPPCompiler',
     'ElbrusCPPCompiler',
     'EmscriptenCPPCompiler',
@@ -196,6 +197,6 @@ from .rust import RustCompiler
 from .swift import SwiftCompiler
 from .vala import ValaCompiler
 from .mixins.visualstudio import VisualStudioLikeCompiler
-from .mixins.gnu import GnuCompiler
+from .mixins.gnu import GnuCompiler, GnuLikeCompiler
 from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4989,14 +4989,24 @@ class WindowsTests(BasePlatformTests):
                 self.assertEqual(comp.linker.id, expected)
 
     def test_link_environment_variable_lld_link(self):
+        env = get_fake_env()
+        comp = getattr(env, 'detect_c_compiler')(MachineChoice.HOST)
+        if isinstance(comp, mesonbuild.compilers.GnuLikeCompiler):
+            raise unittest.SkipTest('GCC cannot be used with link compatible linkers.')
         self._check_ld('lld-link', 'c', 'lld-link')
 
     def test_link_environment_variable_link(self):
-        if shutil.which('gcc'):
-            raise unittest.SkipTest('GCC can not used with link.exe.')
+        env = get_fake_env()
+        comp = getattr(env, 'detect_c_compiler')(MachineChoice.HOST)
+        if isinstance(comp, mesonbuild.compilers.GnuLikeCompiler):
+            raise unittest.SkipTest('GCC cannot be used with link compatible linkers.')
         self._check_ld('link', 'c', 'link')
 
     def test_link_environment_variable_optlink(self):
+        env = get_fake_env()
+        comp = getattr(env, 'detect_c_compiler')(MachineChoice.HOST)
+        if isinstance(comp, mesonbuild.compilers.GnuLikeCompiler):
+            raise unittest.SkipTest('GCC cannot be used with link compatible linkers.')
         self._check_ld('optlink', 'c', 'optlink')
 
     @skip_if_not_language('rust')


### PR DESCRIPTION
Just because we are on windows doesn't mean we can use `link`.

This ought to be done better, but this will do for now.