### PR TITLE
Add support for composing properties with layering

### DIFF
--- a/docs/markdown/Native-environments.md
+++ b/docs/markdown/Native-environments.md
@@ -76,6 +76,15 @@ expressing all of these configurations in monolithic configurations would
 result in 81 different native files. By layering them, it can be expressed by
 just 12 native files.
 
+### Composing Properties With Layering
+
+Entries in the `properties` section allow *composition* by appending to a value:
+
+```
+my_prop += ['append_this']
+```
+
+If the property is not already defined, it will be created. You must honor the `+=` usage when layering multiple native files together. If you include three different files and the last one assigns (`=`) instead of composes (`+=`), the value will be overwritten.
 
 ## Native file locations
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -7348,6 +7348,28 @@ class CrossFileTests(BasePlatformTests):
                               '-Ddef_sharedstatedir=sharedstatebar',
                               '-Ddef_sysconfdir=sysconfbar'])
 
+    def test_cross_file_dirs_chain_composition_append(self):
+        # crossfile2 appends crossfile
+        testcase = os.path.join(self.unit_test_dir, '74 cross file properties composition')
+        self.init(testcase, default_args=False,
+                  extra_args=['--cross-file', os.path.join(testcase, 'crossfile_base'),
+                              '--cross-file', os.path.join(testcase, 'crossfile_append')])
+
+    def test_cross_file_dirs_chain_composition_append_without_previous_assign(self):
+        # crossfile2 appends crossfile
+        testcase = os.path.join(self.unit_test_dir, '74 cross file properties composition')
+        self.init(testcase, default_args=False,
+                  extra_args=['--cross-file', os.path.join(testcase, 'crossfile_append'),
+                              '-Dexpected_val=-DDEF=2'])
+
+    def test_cross_file_dirs_chain_composition_overwrite(self):
+        # crossfile2 appends crossfile
+        testcase = os.path.join(self.unit_test_dir, '74 cross file properties composition')
+        self.init(testcase, default_args=False,
+                  extra_args=['--cross-file', os.path.join(testcase, 'crossfile_base'),
+                              '--cross-file', os.path.join(testcase, 'crossfile_overwrite'),
+                              '-Dexpected_val=-DDEF=3'])
+
 class TAPParserTests(unittest.TestCase):
     def assert_test(self, events, **kwargs):
         if 'explanation' not in kwargs:

--- a/test cases/unit/74 cross file properties composition/crossfile_append
+++ b/test cases/unit/74 cross file properties composition/crossfile_append
@@ -1,0 +1,4 @@
+[properties]
+my_args += ['-DDEF=2']
+
+; vim: ft=dosini

--- a/test cases/unit/74 cross file properties composition/crossfile_base
+++ b/test cases/unit/74 cross file properties composition/crossfile_base
@@ -1,0 +1,4 @@
+[properties]
+my_args = ['-DDEF=1']
+
+; vim: ft=dosini

--- a/test cases/unit/74 cross file properties composition/crossfile_overwrite
+++ b/test cases/unit/74 cross file properties composition/crossfile_overwrite
@@ -1,0 +1,4 @@
+[properties]
+my_args = ['-DDEF=3']
+
+; vim: ft=dosini

--- a/test cases/unit/74 cross file properties composition/meson.build
+++ b/test cases/unit/74 cross file properties composition/meson.build
@@ -1,0 +1,7 @@
+project('cross/native property composition')
+
+expected = get_option('expected_val')
+actual = meson.get_cross_property('my_args')
+
+assert(expected == actual,
+         'my_args should have been @0@, but was @1@!'.format(expected, actual))

--- a/test cases/unit/74 cross file properties composition/meson_options.txt
+++ b/test cases/unit/74 cross file properties composition/meson_options.txt
@@ -1,0 +1,1 @@
+option('expected_val', type: 'array', value: ['-DDEF=1', '-DDEF=2'])


### PR DESCRIPTION
This commit adds support for using `+=` with properties to enable better composition with native/cross file properties. This can be used for layering compiler/linker arguments as described in the documentation.

Updates have been made to the native file + cross file documentation in the user manual.

Unit tests have been added to test three different cases:

- Define a property in a base, append with another file
- Define a property in a base, overwrite with another file
- Append a property that isn't defined yet

Fixes #6813