### PR TITLE
project test junit schema + a few more uses

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,3 +23,5 @@ indent_size = 2
 [meson.build]
 indent_size = 2
 
+[*.json]
+indent_size = 2

--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt update -yq
-        sudo apt install -yq --no-install-recommends python3-setuptools python3-pip g++ gfortran gobjc gobjc++ zlib1g-dev python-dev python3-dev
+        sudo apt install -yq --no-install-recommends python3-setuptools python3-pip g++ gfortran gobjc gobjc++ zlib1g-dev python-dev python3-dev python3-jsonschema
     - name: Install ninja-build tool
       uses: seanmiddleditch/gha-setup-ninja@v1
     - name: Python version

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,8 +100,8 @@ jobs:
       displayName: Install Dependencies
     - script: |
         set PATH=%CYGWIN_ROOT%\bin;%SYSTEMROOT%\system32
-        env.exe -- python3 -m pip --disable-pip-version-check install pefile pytest-xdist
-      displayName: pip install pefile pytest-xdist
+        env.exe -- python3 -m pip --disable-pip-version-check install pefile pytest-xdist jsonschema
+      displayName: pip install pefile pytest-xdist jsonschema
     - script: |
         set BOOST_ROOT=
         set PATH=%CYGWIN_ROOT%\bin;%SYSTEMROOT%\system32
@@ -169,7 +169,7 @@ jobs:
         mingw-w64-$(MSYS2_ARCH)-python3-setuptools ^
         mingw-w64-$(MSYS2_ARCH)-python3-pip ^
         %TOOLCHAIN%
-        %MSYS2_ROOT%\usr\bin\bash -lc "python3 -m pip --disable-pip-version-check install pefile"
+        %MSYS2_ROOT%\usr\bin\bash -lc "python3 -m pip --disable-pip-version-check install pefile jsonschema"
       displayName: Install Dependencies
     - script: |
         set BOOST_ROOT=

--- a/ci/ciimage/arch/install.sh
+++ b/ci/ciimage/arch/install.sh
@@ -12,6 +12,7 @@ pkgs=(
   itstool gtk3 java-environment=8 gtk-doc llvm clang sdl2 graphviz
   doxygen vulkan-validation-layers openssh mercurial gtk-sharp-2 qt5-tools
   libwmf valgrind cmake netcdf-fortran openmpi nasm gnustep-base gettext
+  python-jsonschema
   # cuda
 )
 

--- a/ci/run.ps1
+++ b/ci/run.ps1
@@ -67,7 +67,7 @@ python --version
 
 # Needed for running unit tests in parallel.
 echo ""
-python -m pip --disable-pip-version-check install --upgrade pefile pytest-xdist
+python -m pip --disable-pip-version-check install --upgrade pefile pytest-xdist jsonschema
 
 echo ""
 echo "=== Start running tests ==="

--- a/ci/travis_install.sh
+++ b/ci/travis_install.sh
@@ -11,6 +11,7 @@ if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   if [[ "$MESON_ARGS" =~ .*unity=on.* ]]; then
     which pkg-config || brew install pkg-config
   fi
+  python3 -m pip install jsonschema
 elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
   msg "Running Linux setup"
   docker pull mesonbuild/eoan

--- a/data/test.schema.json
+++ b/data/test.schema.json
@@ -1,0 +1,105 @@
+{
+  "type": "object",
+  "properties": {
+    "env": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "installed": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "file",
+              "exe",
+              "shared_lib",
+              "pdb",
+              "implib",
+              "implibempty",
+              "expr"
+            ]
+          },
+          "platform": {
+            "type": "string",
+            "enum": [
+              "msvc",
+              "gcc",
+              "cygwin",
+              "!cygwin"
+            ]
+          },
+          "version": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "file",
+          "type"
+        ]
+      }
+    },
+    "matrix": {
+      "type": "object",
+      "additionalProperties": {
+        "properties": {
+          "options": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "val": {
+                  "type": "string"
+                },
+                "compilers": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "skip_on_env": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "val"
+              ]
+            }
+          },
+          "exclude": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "do_not_set_opts": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "libdir",
+          "prefix"
+        ]
+      }
+    }
+  }
+}

--- a/docs/markdown/Contributing.md
+++ b/docs/markdown/Contributing.md
@@ -294,9 +294,17 @@ Additionally, the `skip_on_env` key can be used to specify a list of environment
 variables. If at least one environment variable in `skip_on_env` is present, all
 matrix entries containing this value are skipped.
 
-Similarly, the `compilers` key can be used to define a set of compilers required
-for this value.
+Similarly, the `compilers` key can be used to define a mapping of compilers to languages that are required for this value.
 
+```json
+{
+  "compilers": {
+    "c": "gcc",
+    "cpp": "gcc",
+    "d": "gdc"
+  }
+}
+```
 
 Specific option combinations can be excluded with the `exclude` section. It should
 be noted that `exclude` does not require exact matches. Instead, any matrix entry

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -734,7 +734,11 @@ def skippable(suite, test):
 
     # Scientific libraries are skippable on certain systems
     # See the discussion here: https://github.com/mesonbuild/meson/pull/6562
-    if any([test.endswith(x) for x in ['17 mpi', '25 hdf5', '30 scalapack']]) and skip_scientific:
+    if any([x in test for x in ['17 mpi', '25 hdf5', '30 scalapack']]) and skip_scientific:
+        return True
+
+    # These create OS specific tests, and need to be skippable
+    if any([x in test for x in ['16 sdl', '17 mpi']]):
         return True
 
     # No frameworks test should be skipped on linux CI, as we expect all

--- a/test cases/frameworks/16 sdl2/meson.build
+++ b/test cases/frameworks/16 sdl2/meson.build
@@ -1,6 +1,8 @@
 project('sdl2 test', 'c')
 
-sdl2_dep = dependency('sdl2', version : '>=2.0.0', required: false)
+method = get_option('method')
+
+sdl2_dep = dependency('sdl2', version : '>=2.0.0', required : false, method : method)
 
 if not sdl2_dep.found()
   error('MESON_SKIP_TEST sdl2 not found.')
@@ -9,19 +11,3 @@ endif
 e = executable('sdl2prog', 'sdl2prog.c', dependencies : sdl2_dep)
 
 test('sdl2test', e)
-
-if sdl2_dep.type_name() == 'extraframeworks'
-  # The SDL OSX framework does not ship with detection executables
-  # so skip the remaining tests.
-  subdir_done()
-endif
-
-# Ensure that we can find it with sdl2-config too, using the legacy method name
-configdep = dependency('sdl2', method : 'sdlconfig')
-
-# And the modern method name
-configdep = dependency('sdl2', method : 'config-tool')
-
-# Check we can apply a version constraint
-dependency('sdl2', version: '>=@0@'.format(sdl2_dep.version()), method: 'pkg-config')
-dependency('sdl2', version: '>=@0@'.format(sdl2_dep.version()), method: 'config-tool')

--- a/test cases/frameworks/16 sdl2/meson_options.txt
+++ b/test cases/frameworks/16 sdl2/meson_options.txt
@@ -1,0 +1,6 @@
+option(
+    'method',
+    type : 'combo',
+    choices : ['auto', 'pkg-config', 'config-tool', 'sdlconfig', 'extraframework'],
+    value : 'auto',
+)

--- a/test cases/frameworks/16 sdl2/test.json
+++ b/test cases/frameworks/16 sdl2/test.json
@@ -1,0 +1,13 @@
+{
+  "matrix": {
+    "options": {
+      "method": [
+        { "val": "auto" },
+        { "val": "pkg-config" },
+        { "val": "config-tool" },
+        { "val": "sdlconfig" },
+        { "val": "extraframework" }
+      ]
+    }
+  }
+}

--- a/test cases/frameworks/17 mpi/test.json
+++ b/test cases/frameworks/17 mpi/test.json
@@ -1,0 +1,15 @@
+{
+  "matrix": {
+    "options": {
+      "method": [
+        { "val": "auto" },
+        { "val": "pkg-config" },
+        { "val": "config-tool" },
+        {
+          "val": "system",
+          "compilers": { "c" :"msvc", "cpp": "msvc" }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This adds a schema for the json format we use in the framework tests, and a unittest which runs the schema against the tests (using the jsonschema python module). This also adds a couple of matrix options for some of the framework tests so we can test all of the different methods of discovering those dependencies.

This schema is also useful for IDE users, as it can be used for error checking and auto completion. With VSCode for example, I can get both.

I suspect that this has a chicken and egg problem with the CI images.