### PR TITLE
Fix ARMCC dependency generation.

### DIFF
--- a/mesonbuild/compilers/mixins/arm.py
+++ b/mesonbuild/compilers/mixins/arm.py
@@ -89,7 +89,7 @@ class ArmCompiler:
 
     # Override CCompiler.get_dependency_gen_args
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
-        return []
+        return ['--depend_target', outtarget, '--depend', outfile, '--depend_single_line']
 
     def get_pch_use_args(self, pch_dir: str, header: str) -> T.List[str]:
         # FIXME: Add required arguments


### PR DESCRIPTION
ARMCC dependencies are not generated by Meson at the moment causing it to miss changes in dependent files. Allow generation of standard dependency files by armcc.