### PR TITLE
gtkdoc: Add missing permitted kwarg

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -918,7 +918,7 @@ This will become a hard error in the future.''')
                       'fixxref_args', 'html_args', 'html_assets', 'content_files',
                       'mkdb_args', 'ignore_headers', 'include_directories',
                       'namespace', 'mode', 'expand_content_files', 'module_version',
-                      'c_args'})
+                      'c_args', 'check'})
     def gtkdoc(self, state, args, kwargs):
         if len(args) != 1:
             raise MesonException('Gtkdoc must have one positional argument.')


### PR DESCRIPTION
The 'check' kwarg was added in Meson 0.52.0.