### PR TITLE
Fix resource file finding

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -15,6 +15,8 @@
 # This class contains the basic functionality needed to run any interpreter
 # or an interpreter-based tool.
 
+import pkg_resources
+
 from .common import CMakeException, CMakeTarget
 from .client import CMakeClient, RequestCMakeInputs, RequestConfigure, RequestCompute, RequestCodeModel
 from .fileapi import CMakeFileAPI
@@ -779,7 +781,7 @@ class CMakeInterpreter:
             raise CMakeException('Unable to find CMake')
         self.trace = CMakeTraceParser(cmake_exe.version(), self.build_dir, permissive=True)
 
-        preload_file = Path(__file__).resolve().parent / 'data' / 'preload.cmake'
+        preload_file = pkg_resources.resource_filename('mesonbuild', 'cmake/data/preload.cmake')
 
         # Prefere CMAKE_PROJECT_INCLUDE over CMAKE_TOOLCHAIN_FILE if possible,
         # since CMAKE_PROJECT_INCLUDE was actually designed for code injection.
@@ -1024,7 +1026,7 @@ class CMakeInterpreter:
         root_cb.lines += [function('project', [self.project_name] + self.languages)]
 
         # Add the run script for custom commands
-        run_script = '{}/data/run_ctgt.py'.format(os.path.dirname(os.path.realpath(__file__)))
+        run_script = pkg_resources.resource_filename('mesonbuild', 'cmake/data/run_ctgt.py')
         run_script_var = 'ctgt_run_script'
         root_cb.lines += [assign(run_script_var, function('find_program', [[run_script]], {'required': True}))]
 

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -28,6 +28,8 @@ import typing as T
 from enum import Enum
 from pathlib import Path, PurePath
 
+import pkg_resources
+
 from .. import mlog
 from .. import mesonlib
 from ..compilers import clib_langs
@@ -1508,8 +1510,8 @@ class CMakeDependency(ExternalDependency):
         build_dir = self._get_build_dir()
 
         # Insert language parameters into the CMakeLists.txt and write new CMakeLists.txt
-        src_cmake = Path(__file__).parent / 'data' / cmake_file
-        cmake_txt = src_cmake.read_text()
+        # Per the warning in pkg_resources, this is *not* a path and os.path and Pathlib are *not* safe to use here.
+        cmake_txt = pkg_resources.resource_string('mesonbuild', 'dependencies/data/' + cmake_file).decode()
 
         # In general, some Fortran CMake find_package() also require C language enabled,
         # even if nothing from C is directly used. An easy Fortran example that fails

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,8 @@ long_description = Meson is a cross-platform build system designed to be both as
 
 [options]
 python_requires = >= 3.5.2
+setup_requires =
+  setuptools
 
 [options.extras_require]
 progress =


### PR DESCRIPTION
This is a small but significant change, in particular it changes meson to use setuptools pkg_resource for finding data files. This is important because pkg_resource understands all of the odd corner cases of where python might install data files in different cases (ziplib, wheel, egg, running from the directory, etc). We already have a dependency on setuptools for it's entrypoint functions (and to install meson at all), so this isn't a new dependency, but it is another place we depend on setuptools.

Fixes #6801