### PR TITLE
Report an errror if glib-compile-resources is missing

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -227,7 +227,10 @@ class GnomeModule(ExtensionModule):
         for source_dir in source_dirs:
             cmd += ['--sourcedir', os.path.join(state.subdir, source_dir)]
 
-        pc, stdout, stderr = Popen_safe(cmd, cwd=state.environment.get_source_dir())
+        try:
+            pc, stdout, stderr = Popen_safe(cmd, cwd=state.environment.get_source_dir())
+        except (FileNotFoundError, PermissionError):
+            raise MesonException('Could not execute glib-compile-resources.')
         if pc.returncode != 0:
             m = 'glib-compile-resources failed to get dependencies for {}:\n{}'
             mlog.warning(m.format(cmd[1], stderr))

--- a/test cases/failing/102 no glib-compile-resources/meson.build
+++ b/test cases/failing/102 no glib-compile-resources/meson.build
@@ -1,0 +1,8 @@
+project('no glib-compile-resources')
+
+if find_program('glib-compile-resources', required: false).found()
+  error('MESON_SKIP_TEST test only applicable when glib-compile-resources is missing.')
+endif
+
+gnome = import('gnome')
+res = gnome.compile_resources('resources', 'trivial.gresource.xml')

--- a/test cases/failing/102 no glib-compile-resources/trivial.gresource.xml
+++ b/test cases/failing/102 no glib-compile-resources/trivial.gresource.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+</gresources>


### PR DESCRIPTION
Report an errror if `glib-compile-resources` is missing, rather than a python backtrace.

Before:
```
Program glib-compile-resources found: NO
Found pkg-config: /usr/bin/pkg-config (1.6.0)
Traceback (most recent call last):
  File "/wip/meson/mesonbuild/mesonmain.py", line 131, in run
    return options.run_func(options)
  File "/wip/meson/mesonbuild/msetup.py", line 245, in run
    app.generate()
  File "/wip/meson/mesonbuild/msetup.py", line 159, in generate
    self._generate(env)
  File "/wip/meson/mesonbuild/msetup.py", line 192, in _generate
    intr.run()
  File "/wip/meson/mesonbuild/interpreter.py", line 4359, in run
    super().run()
  File "/wip/meson/mesonbuild/interpreterbase.py", line 441, in run
    self.evaluate_codeblock(self.ast, start=1)
  File "/wip/meson/mesonbuild/interpreterbase.py", line 466, in evaluate_codeblock
    raise e
  File "/wip/meson/mesonbuild/interpreterbase.py", line 459, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "/wip/meson/mesonbuild/interpreterbase.py", line 474, in evaluate_statement
    self.assignment(cur)
  File "/wip/meson/mesonbuild/interpreterbase.py", line 1127, in assignment
    value = self.evaluate_statement(node.value)
  File "/wip/meson/mesonbuild/interpreterbase.py", line 476, in evaluate_statement
    return self.method_call(cur)
  File "/wip/meson/mesonbuild/interpreterbase.py", line 871, in method_call
    return obj.method_call(method_name, args, self.kwargs_string_keys(kwargs))
  File "/wip/meson/mesonbuild/interpreter.py", line 1788, in method_call
    value = fn(state, args, kwargs)
  File "/wip/meson/mesonbuild/interpreterbase.py", line 326, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "/wip/meson/mesonbuild/interpreterbase.py", line 212, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "/wip/meson/mesonbuild/modules/gnome.py", line 147, in compile_resources
    state, ifile, source_dirs, dependencies)
  File "/wip/meson/mesonbuild/modules/gnome.py", line 230, in _get_gresource_dependencies
    pc, stdout, stderr = Popen_safe(cmd, cwd=state.environment.get_source_dir())
  File "/wip/meson/mesonbuild/mesonlib.py", line 1154, in Popen_safe
    stdout=stdout, stderr=stderr, **kwargs)
  File "/usr/lib/python3.6/subprocess.py", line 729, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1364, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'glib-compile-resources': 'glib-compile-resources'
```
After:
```
Program glib-compile-resources found: NO
Found pkg-config: /usr/bin/pkg-config (1.6.0)

meson.build:8:0: ERROR: Could not execute glib-compile-resources.
```