### PR TITLE
python: install_sources() should default to pure, following the doc

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -361,7 +361,7 @@ class PythonInstallation(ExternalProgramHolder):
 
     @permittedKwargs(['pure', 'subdir'])
     def install_sources_method(self, args, kwargs):
-        pure = kwargs.pop('pure', False)
+        pure = kwargs.pop('pure', True)
         if not isinstance(pure, bool):
             raise InvalidArguments('"pure" argument must be a boolean.')
 


### PR DESCRIPTION
As stated by the doc, default to install python sources to purelib
location, as they should not depend on platform.

This also fixes discrepancy between get_install_dir() and
install_sources() locations.

