### PR TITLE
compilers: Fix C++ stdlib flags used for Apple's Clang

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -204,8 +204,8 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
 
 
 class AppleClangCPPCompiler(ClangCPPCompiler):
-
-    pass
+    def language_stdlib_only_link_flags(self):
+        return ['-lc++']
 
 
 class EmscriptenCPPCompiler(EmscriptenMixin, LinkerEnvVarsMixin, ClangCPPCompiler):


### PR DESCRIPTION
Should target libc++, not libstdc++.