### PR TITLE
Fix meson_jar_template

### DIFF
--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -27,8 +27,8 @@ meson_jar_template = '''project('{project_name}', '{language}',
   default_options : [{default_options}])
 
 jar('{executable}',
-    {sourcespec},{depspec},
-    main_class: {main_class},
+    {sourcespec},{depspec}
+    main_class: '{main_class}',
     install : true)
 '''
 


### PR DESCRIPTION
It was generating an extra comma.

    The Meson build system
    Version: 0.54.0
    Source dir: /tmp/tmp34halxhe
    Build dir: /tmp/tmp34halxhe/build
    Build type: native build

    meson.build:6:15: ERROR: Expecting rparen got comma.
        'Foo.java',,
                   ^
    For a block that started at 5,3
    jar('tmp34halxhe',
       ^

    A full log can be found at /tmp/tmp34halxhe/build/meson-logs/meson-log.txt
    Using "tmp34halxhe" (name of current directory) as project name.
    Using "tmp34halxhe" (project name) as name of executable to build.
    Detected source files: Foo.java
    Detected language: java
    Generated meson.build file:

    project('tmp34halxhe', 'java',
      version : '0.1',
      default_options : ['warning_level=3'])

    jar('tmp34halxhe',
        'Foo.java',,
        main_class: tmp34halxhe,
        install : true)

It was also missing quotes around the main class name.

    The Meson build system
    Version: 0.54.0
    Source dir: /tmp/tmpjm5cg44a
    Build dir: /tmp/tmpjm5cg44a/build
    Build type: native build
    Project name: tmpjm5cg44a
    Project version: 0.1
    Java compiler for the host machine: javac (unknown 1.8.0)
    Host machine cpu family: x86_64
    Host machine cpu: x86_64

    meson.build:5:0: ERROR: Unknown variable "tmpjm5cg44a".

    A full log can be found at /tmp/tmpjm5cg44a/build/meson-logs/meson-log.txt
    Using "tmpjm5cg44a" (name of current directory) as project name.
    Using "tmpjm5cg44a" (project name) as name of executable to build.
    Detected source files: Foo.java
    Detected language: java
    Generated meson.build file:

    project('tmpjm5cg44a', 'java',
      version : '0.1',
      default_options : ['warning_level=3'])

    jar('tmpjm5cg44a',
        'Foo.java',
        main_class: tmpjm5cg44a,
        install : true)