### PR TITLE
mparser: fix precedence of arithmetic operators

### DIFF
--- a/test cases/common/230 arithmetic operators/meson.build
+++ b/test cases/common/230 arithmetic operators/meson.build
@@ -1,0 +1,8 @@
+project('arithmetic operators')
+assert(5 - 3 - 1 == 1)
+assert(5 - (3 - 1) == 3)
+assert(5 - 1 * 3 - 3 == -1)
+assert(420 - 300 - 51 == 69)
+assert(1000 / 2 / 2 / 2 == 125)
+assert(4 * 9 / 3 % 8 - 3 - 10 / 2 == -4)
+assert(94 - 30 + (2 - (40 - 6 + 7) - 9) - 10 == 6)


### PR DESCRIPTION
The arithmetic operators are now split into two groups:
* The add/sub group: `+`, `-`
* The mul/div group: `*`, `/`, `%`

All operators within the same group are left-associative and have equal precedence. The mul/div group has a higher precedence than the add/sub group, as one would expect.

Previously every operator had a different precedence and was right-associative, which resulted in surprising behavior.

This is a potentially breaking change for projects that relied on the old incorrect behavior.

Fixes #6870