### PR TITLE
Always perform cross build if an exe wrapper is needed

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -734,7 +734,7 @@ class Backend:
                 # E.g. an external verifier or simulator program run on a generated executable.
                 # Can always be run without a wrapper.
                 test_for_machine = MachineChoice.BUILD
-            is_cross = not self.environment.machines.matches_build_machine(test_for_machine)
+            is_cross = not self.environment.machines.matches_build_machine(test_for_machine) or self.environment.need_exe_wrapper(test_for_machine)
             if is_cross and self.environment.need_exe_wrapper():
                 exe_wrapper = self.environment.get_exe_wrapper()
             else:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -899,7 +899,7 @@ class Environment:
     def _detect_c_or_cpp_compiler(self, lang: str, for_machine: MachineChoice) -> Compiler:
         popen_exceptions = {}
         compilers, ccache, exe_wrap = self._get_compilers(lang, for_machine)
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         info = self.machines[for_machine]
 
         for compiler in compilers:
@@ -1149,7 +1149,7 @@ class Environment:
 
     def detect_cuda_compiler(self, for_machine):
         popen_exceptions = {}
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         compilers, ccache, exe_wrap = self._get_compilers('cuda', for_machine)
         info = self.machines[for_machine]
         for compiler in compilers:
@@ -1189,7 +1189,7 @@ class Environment:
     def detect_fortran_compiler(self, for_machine: MachineChoice):
         popen_exceptions = {}
         compilers, ccache, exe_wrap = self._get_compilers('fortran', for_machine)
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         info = self.machines[for_machine]
         for compiler in compilers:
             if isinstance(compiler, str):
@@ -1308,7 +1308,7 @@ class Environment:
     def _detect_objc_or_objcpp_compiler(self, for_machine: MachineInfo, objc: bool) -> 'Compiler':
         popen_exceptions = {}
         compilers, ccache, exe_wrap = self._get_compilers('objc' if objc else 'objcpp', for_machine)
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         info = self.machines[for_machine]
 
         for compiler in compilers:
@@ -1399,7 +1399,7 @@ class Environment:
 
     def detect_vala_compiler(self, for_machine):
         exelist = self.lookup_binary_entry(for_machine, 'vala')
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         info = self.machines[for_machine]
         if exelist is None:
             # TODO support fallback
@@ -1419,7 +1419,7 @@ class Environment:
     def detect_rust_compiler(self, for_machine):
         popen_exceptions = {}
         compilers, ccache, exe_wrap = self._get_compilers('rust', for_machine)
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         info = self.machines[for_machine]
 
         cc = self.detect_c_compiler(for_machine)
@@ -1510,7 +1510,7 @@ class Environment:
             arch = 'x86_mscoff'
 
         popen_exceptions = {}
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         results, ccache, exe_wrap = self._get_compilers('d', for_machine)
         for exelist in results:
             # Search for a D compiler.
@@ -1601,7 +1601,7 @@ class Environment:
 
     def detect_swift_compiler(self, for_machine):
         exelist = self.lookup_binary_entry(for_machine, 'swift')
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         info = self.machines[for_machine]
         if exelist is None:
             # TODO support fallback


### PR DESCRIPTION
To revive support for cross-compiling x86_64 binaries for Apple's iOS
Simulator from a macOS build machine.

Seeing as the same assumption is made in other places, I also made the
same adjustments there.