### PR TITLE
Always perform cross build if an exe wrapper is needed

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -734,7 +734,7 @@ class Backend:
                 # E.g. an external verifier or simulator program run on a generated executable.
                 # Can always be run without a wrapper.
                 test_for_machine = MachineChoice.BUILD
-            is_cross = not self.environment.machines.matches_build_machine(test_for_machine)
+            is_cross = not self.environment.machines.matches_build_machine(test_for_machine) or self.environment.need_exe_wrapper(test_for_machine)
             if is_cross and self.environment.need_exe_wrapper():
                 exe_wrapper = self.environment.get_exe_wrapper()
             else:

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -68,8 +68,11 @@ class CudaCompiler(Compiler):
         return self._to_host_flags(self.host_compiler.thread_link_flags(environment))
 
     def sanity_check(self, work_dir, environment):
+        need_exe_wrapper = self.is_cross and environment.need_exe_wrapper(self.for_machine)
+
         mlog.debug('Sanity testing ' + self.get_display_language() + ' compiler:', ' '.join(self.exelist))
         mlog.debug('Is cross compiler: %s.' % str(self.is_cross))
+        mlog.debug('Need exe wrapper: %s.' % str(need_exe_wrapper))
 
         sname = 'sanitycheckcuda.cu'
         code = r'''
@@ -112,7 +115,7 @@ class CudaCompiler(Compiler):
         # builds; For cross builds we must still use the exe_wrapper (if any).
         self.detected_cc = ''
         flags = ['-w', '-cudart', 'static', source_name]
-        if self.is_cross and self.exe_wrapper is None:
+        if need_exe_wrapper and self.exe_wrapper is None:
             # Linking cross built apps is painful. You can't really
             # tell if you should use -nostdlib or not and for example
             # on OSX the compiler binary is the same but you need
@@ -134,7 +137,7 @@ class CudaCompiler(Compiler):
             raise EnvironmentException('Compiler {0} can not compile programs.'.format(self.name_string()))
 
         # Run sanity check (if possible)
-        if self.is_cross:
+        if need_exe_wrapper:
             if self.exe_wrapper is None:
                 return
             else:

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -452,7 +452,7 @@ class DCompiler(Compiler):
         pc.wait()
         if pc.returncode != 0:
             raise EnvironmentException('D compiler %s can not compile programs.' % self.name_string())
-        if self.is_cross:
+        if self.is_cross and environment.need_exe_wrapper(self.for_machine):
             if self.exe_wrapper is None:
                 # Can't check if the binaries run so we have to assume they do
                 return

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -81,7 +81,7 @@ class FortranCompiler(CLikeCompiler, Compiler):
                                     cwd=str(work_dir)).returncode
         if returncode != 0:
             raise EnvironmentException('Compiler %s can not compile programs.' % self.name_string())
-        if self.is_cross:
+        if self.is_cross and environment.need_exe_wrapper(self.for_machine):
             if self.exe_wrapper is None:
                 # Can't check if the binaries run so we have to assume they do
                 return

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -46,7 +46,8 @@ class ObjCCompiler(CLikeCompiler, Compiler):
         binary_name = os.path.join(work_dir, 'sanitycheckobjc')
         extra_flags = []
         extra_flags += environment.coredata.get_external_args(self.for_machine, self.language)
-        if self.is_cross:
+        need_exe_wrapper = self.is_cross and environment.need_exe_wrapper(self.for_machine)
+        if need_exe_wrapper and self.exe_wrapper is None:
             extra_flags += self.get_compile_only_args()
         else:
             extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)
@@ -57,7 +58,7 @@ class ObjCCompiler(CLikeCompiler, Compiler):
         pc.wait()
         if pc.returncode != 0:
             raise EnvironmentException('ObjC compiler %s can not compile programs.' % self.name_string())
-        if self.is_cross:
+        if need_exe_wrapper:
             # Can't check if the binaries run so we have to assume they do
             return
         pe = subprocess.Popen(binary_name)

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -45,7 +45,8 @@ class ObjCPPCompiler(CLikeCompiler, Compiler):
         binary_name = os.path.join(work_dir, 'sanitycheckobjcpp')
         extra_flags = []
         extra_flags += environment.coredata.get_external_args(self.for_machine, self.language)
-        if self.is_cross:
+        need_exe_wrapper = self.is_cross and environment.need_exe_wrapper(self.for_machine)
+        if need_exe_wrapper and self.exe_wrapper is None:
             extra_flags += self.get_compile_only_args()
         else:
             extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)
@@ -57,7 +58,7 @@ class ObjCPPCompiler(CLikeCompiler, Compiler):
         pc.wait()
         if pc.returncode != 0:
             raise EnvironmentException('ObjC++ compiler %s can not compile programs.' % self.name_string())
-        if self.is_cross:
+        if need_exe_wrapper:
             # Can't check if the binaries run so we have to assume they do
             return
         pe = subprocess.Popen(binary_name)

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -67,7 +67,7 @@ class RustCompiler(Compiler):
                 self.name_string(),
                 stdo,
                 stde))
-        if self.is_cross:
+        if self.is_cross and environment.need_exe_wrapper(self.for_machine):
             if self.exe_wrapper is None:
                 # Can't check if the binaries run so we have to assume they do
                 return

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -100,7 +100,8 @@ class SwiftCompiler(Compiler):
         output_name = os.path.join(work_dir, 'swifttest')
         extra_flags = []
         extra_flags += environment.coredata.get_external_args(self.for_machine, self.language)
-        if self.is_cross:
+        need_exe_wrapper = self.is_cross and environment.need_exe_wrapper(self.for_machine)
+        if need_exe_wrapper:
             extra_flags += self.get_compile_only_args()
         else:
             extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)
@@ -111,7 +112,7 @@ class SwiftCompiler(Compiler):
         pc.wait()
         if pc.returncode != 0:
             raise EnvironmentException('Swift compiler %s can not compile programs.' % self.name_string())
-        if self.is_cross:
+        if need_exe_wrapper:
             # Can't check if the binaries run so we have to assume they do
             return
         if subprocess.call(output_name) != 0:

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -96,7 +96,7 @@ class ValaCompiler(Compiler):
         code = 'class MesonSanityCheck : Object { }'
         extra_flags = []
         extra_flags += environment.coredata.get_external_args(self.for_machine, self.language)
-        if self.is_cross:
+        if self.is_cross and environment.need_exe_wrapper(self.for_machine):
             extra_flags += self.get_compile_only_args()
         else:
             extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -899,7 +899,7 @@ class Environment:
     def _detect_c_or_cpp_compiler(self, lang: str, for_machine: MachineChoice) -> Compiler:
         popen_exceptions = {}
         compilers, ccache, exe_wrap = self._get_compilers(lang, for_machine)
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         info = self.machines[for_machine]
 
         for compiler in compilers:
@@ -1149,7 +1149,7 @@ class Environment:
 
     def detect_cuda_compiler(self, for_machine):
         popen_exceptions = {}
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         compilers, ccache, exe_wrap = self._get_compilers('cuda', for_machine)
         info = self.machines[for_machine]
         for compiler in compilers:
@@ -1189,7 +1189,7 @@ class Environment:
     def detect_fortran_compiler(self, for_machine: MachineChoice):
         popen_exceptions = {}
         compilers, ccache, exe_wrap = self._get_compilers('fortran', for_machine)
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         info = self.machines[for_machine]
         for compiler in compilers:
             if isinstance(compiler, str):
@@ -1308,7 +1308,7 @@ class Environment:
     def _detect_objc_or_objcpp_compiler(self, for_machine: MachineInfo, objc: bool) -> 'Compiler':
         popen_exceptions = {}
         compilers, ccache, exe_wrap = self._get_compilers('objc' if objc else 'objcpp', for_machine)
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         info = self.machines[for_machine]
 
         for compiler in compilers:
@@ -1399,7 +1399,7 @@ class Environment:
 
     def detect_vala_compiler(self, for_machine):
         exelist = self.lookup_binary_entry(for_machine, 'vala')
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         info = self.machines[for_machine]
         if exelist is None:
             # TODO support fallback
@@ -1419,7 +1419,7 @@ class Environment:
     def detect_rust_compiler(self, for_machine):
         popen_exceptions = {}
         compilers, ccache, exe_wrap = self._get_compilers('rust', for_machine)
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         info = self.machines[for_machine]
 
         cc = self.detect_c_compiler(for_machine)
@@ -1510,7 +1510,7 @@ class Environment:
             arch = 'x86_mscoff'
 
         popen_exceptions = {}
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         results, ccache, exe_wrap = self._get_compilers('d', for_machine)
         for exelist in results:
             # Search for a D compiler.
@@ -1601,7 +1601,7 @@ class Environment:
 
     def detect_swift_compiler(self, for_machine):
         exelist = self.lookup_binary_entry(for_machine, 'swift')
-        is_cross = not self.machines.matches_build_machine(for_machine)
+        is_cross = not self.machines.matches_build_machine(for_machine) or self.need_exe_wrapper(for_machine)
         info = self.machines[for_machine]
         if exelist is None:
             # TODO support fallback


### PR DESCRIPTION
To revive support for cross-compiling x86_64 binaries for Apple's iOS
Simulator from a macOS build machine.

(Second attempt, hoping I got the corner-cases figured out now 🤞)