### PR TITLE
Basic changes for the Hurd

### DIFF
--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -140,12 +140,14 @@ class GnuLikeCompiler(metaclass=abc.ABCMeta):
     LINKER_PREFIX = '-Wl,'
 
     def __init__(self):
-        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage',
+        self.base_options = ['b_pch', 'b_lto', 'b_pgo', 'b_coverage',
                              'b_ndebug', 'b_staticpic', 'b_pie']
         if not (self.info.is_windows() or self.info.is_cygwin() or self.info.is_openbsd()):
             self.base_options.append('b_lundef')
         if not self.info.is_windows() or self.info.is_cygwin():
             self.base_options.append('b_asneeded')
+        if not self.info.is_hurd():
+            self.base_options.append('b_sanitize')
         # All GCC-like backends can do assembly
         self.can_compile_suffixes.add('s')
 

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -292,6 +292,12 @@ class MachineInfo:
         """Machine is illumos or Solaris?"""
         return self.system == 'sunos'
 
+    def is_hurd(self) -> bool:
+        """
+        Machine is GNU/Hurd?
+        """
+        return self.system == 'gnu'
+
     # Various prefixes and suffixes for import libraries, shared libraries,
     # static libraries, and executables.
     # Versioning is added to these names in the backends as-needed.

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -508,6 +508,10 @@ def is_freebsd() -> bool:
     return platform.system().lower() == 'freebsd'
 
 
+def is_hurd() -> bool:
+    return platform.system().lower() == 'gnu'
+
+
 def exe_exists(arglist: T.List[str]) -> bool:
     try:
         if subprocess.run(arglist, timeout=10).returncode == 0:

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -94,7 +94,7 @@ def call_tool_nowarn(tool: T.List[str], **kwargs) -> T.Tuple[str, str]:
         return None, e
     return output, None
 
-def linux_syms(libfilename: str, outfilename: str):
+def gnu_syms(libfilename: str, outfilename: str):
     # Get the name of the library
     output = call_tool('readelf', ['-d', libfilename])
     if not output:
@@ -231,7 +231,7 @@ def gen_symbols(libfilename: str, impfilename: str, outfilename: str, cross_host
         # `nm`, `readelf`, etc, from the cross info which requires refactoring.
         dummy_syms(outfilename)
     elif mesonlib.is_linux():
-        linux_syms(libfilename, outfilename)
+        gnu_syms(libfilename, outfilename)
     elif mesonlib.is_osx():
         osx_syms(libfilename, outfilename)
     elif mesonlib.is_windows():

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -230,7 +230,7 @@ def gen_symbols(libfilename: str, impfilename: str, outfilename: str, cross_host
         # determine the correct toolset, but we would need to use the correct
         # `nm`, `readelf`, etc, from the cross info which requires refactoring.
         dummy_syms(outfilename)
-    elif mesonlib.is_linux():
+    elif mesonlib.is_linux() or mesonlib.is_hurd():
         gnu_syms(libfilename, outfilename)
     elif mesonlib.is_osx():
         osx_syms(libfilename, outfilename)


### PR DESCRIPTION
While meson generally works fine on the Hurd, there are few things that can be fixed/improved.\

This PR:
- adds `is_hurd` functions to be able to recognize when building on the Hurd
- adds Hurd support in symbolextractor, using the same Linux method
- disable the address sanitizer, as not supported there yet