### PR TITLE
Log when ignoring LLVM because dynamic was requested

### DIFF
--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -397,6 +397,7 @@ class LLVMDependencyCMake(CMakeDependency):
         # cmake if dynamic is required
         if not self.static:
             self.is_found = False
+            mlog.warning('Ignoring LLVM CMake dependency because dynamic was requested')
             return
 
         if self.traceparser is None:


### PR DESCRIPTION
Without this, there's tons of log output about finding LLVM, followed by "couldn't find LLVM."