### PR TITLE
wrap: Add fallback urls

### DIFF
--- a/docs/markdown/Wrap-dependency-system-manual.md
+++ b/docs/markdown/Wrap-dependency-system-manual.md
@@ -72,9 +72,11 @@ revision = head
 
 ### Specific to wrap-file
 - `source_url` - download url to retrieve the wrap-file source archive
+- `source_fallback_url` - fallback URL to be used when download from `source_url` fails *Since: 0.55.0*
 - `source_filename` - filename of the downloaded source archive
 - `source_hash` - sha256 checksum of the downloaded source archive
 - `patch_url` - download url to retrieve an optional overlay archive
+- `patch_fallback_url` - fallback URL to be used when download from `patch_url` fails *Since: 0.55.0*
 - `patch_filename` - filename of the downloaded overlay archive
 - `patch_hash` - sha256 checksum of the downloaded overlay archive
 - `lead_directory_missing` - for `wrap-file` create the leading

--- a/docs/markdown/snippets/wrap_fallback.md
+++ b/docs/markdown/snippets/wrap_fallback.md
@@ -1,0 +1,4 @@
+## Wrap fallback URL
+
+Wrap files can now define `source_fallback_url` and `patch_fallback_url` to be
+used in case the main server is temporaly down.

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6469,11 +6469,13 @@ c = ['{0}']
             [wrap-file]
             directory = foo
 
-            source_url = file://{}
+            source_url = http://server.invalid/foo
+            source_fallback_url = file://{}
             source_filename = foo.tar.xz
             source_hash = {}
 
-            patch_url = file://{}
+            patch_url = http://server.invalid/foo
+            patch_fallback_url = file://{}
             patch_filename = foo-patch.tar.xz
             patch_hash = {}
             """.format(source_filename, source_hash, patch_filename, patch_hash))


### PR DESCRIPTION
It can happen that a server is temporaly down, tarballs often have
many mirrors available so we should be able to add at least one fallback
mirror in wrap files.