### PR TITLE
Fix coverage generation with D compilers

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1201,6 +1201,9 @@ class Compiler:
         """
         return []
 
+    def get_coverage_link_args(self) -> T.List[str]:
+        return self.linker.get_coverage_args()
+
 
 def get_largefile_args(compiler):
     '''

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -105,6 +105,9 @@ class DmdLikeCompilerMixin:
     def get_coverage_args(self):
         return ['-cov']
 
+    def get_coverage_link_args(self):
+        return []
+
     def get_preprocess_only_args(self):
         return ['-E']
 

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -642,7 +642,7 @@ class GnuDCompiler(GnuCompiler, DCompiler):
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],
                           '3': default_warn_args + ['-Wextra', '-Wpedantic']}
-        self.base_options = ['b_colorout', 'b_sanitize', 'b_staticpic', 'b_vscrt']
+        self.base_options = ['b_colorout', 'b_sanitize', 'b_staticpic', 'b_vscrt', 'b_coverage']
 
         self._has_color_support = version_compare(self.version, '>=4.9')
         # dependencies were implemented before, but broken - support was fixed in GCC 7.1+
@@ -661,9 +661,6 @@ class GnuDCompiler(GnuCompiler, DCompiler):
 
     def get_warn_args(self, level):
         return self.warn_args[level]
-
-    def get_coverage_args(self):
-        return []
 
     def get_buildtype_args(self, buildtype):
         return d_gdc_buildtype_args[buildtype]

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -114,12 +114,6 @@ class CLikeCompiler:
     def get_output_args(self, target):
         return ['-o', target]
 
-    def get_coverage_args(self):
-        return ['--coverage']
-
-    def get_coverage_link_args(self) -> T.List[str]:
-        return self.linker.get_coverage_args()
-
     def get_werror_args(self):
         return ['-Werror']
 

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -312,6 +312,9 @@ class GnuLikeCompiler(metaclass=abc.ABCMeta):
                 'not {}.'.format(linker))
         return ['-fuse-ld={}'.format(linker)]
 
+    def get_coverage_args(self) -> T.List[str]:
+        return ['--coverage']
+
 
 class GnuCompiler(GnuLikeCompiler):
     """


### PR DESCRIPTION
This fixes two related bugs, the first is that GDC should support coverage through gcovr, since it's a GCC compiler. The second is that we don't pass the correct arguments to LDC and DMD to generate coverage. LDC and DMD still don't really work, as they don't generate a coverage format that meson understands, they use .lst files, and we need to pass additional arguments to the test binaries that the compilers add to them to set things like where to write the result files, and whether to merge or replace files.

related to #5669