### PR TITLE
Build private directory name from output file name.

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -227,7 +227,7 @@ class Backend:
         return self.build_to_src
 
     def get_target_private_dir(self, target):
-        return os.path.join(self.get_target_dir(target), target.get_id())
+        return os.path.join(self.get_target_filename(target) + '.p')
 
     def get_target_private_dir_abs(self, target):
         return os.path.join(self.environment.get_build_dir(), self.get_target_private_dir(target))

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -98,6 +98,9 @@ class Vs2010Backend(backends.Backend):
         self.subdirs = {}
         self.handled_target_deps = {}
 
+    def get_target_private_dir(self, target):
+        return os.path.join(self.get_target_dir(target), target.get_id())
+
     def generate_custom_generator_commands(self, target, parent_node):
         generator_output_files = []
         custom_target_include_dirs = []


### PR DESCRIPTION
The output name is guaranteed to be unique already so use that for the priv dir. Originally I though about using `.priv` suffic, but this one is shorter. Collision probability is low, as `,p` is an uncommon thing to have in your output file name.