### PR TITLE
Fix VS Intellisense for projects which depend on LLVM found via CMake.

### DIFF
--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -406,6 +406,9 @@ class LLVMDependencyCMake(CMakeDependency):
         # Extract extra include directories and definitions
         inc_dirs = self.traceparser.get_cmake_var('PACKAGE_INCLUDE_DIRS')
         defs = self.traceparser.get_cmake_var('PACKAGE_DEFINITIONS')
+        # LLVM explicitly uses space-separated variables rather than semicolon lists
+        if len(defs) == 1:
+            defs = defs[0].split(' ')
         temp = ['-I' + x for x in inc_dirs] + defs
         self.compile_args += [x for x in temp if x not in self.compile_args]
         if not self._add_sub_dependency(threads_factory(env, self.for_machine, {})):


### PR DESCRIPTION
Without this change, a VS project generated by Meson for a target which depends on LLVM, when LLVM was found via the CMake dependency, has broken intellisense. This is because the project-wide `ClCompile\PreprocessorDefinitions` node ends up with a set of space-separated preprocessor command line options (e.g. -Dkey=value except for the first entry), rather than a semicolon-separated list of key=value (or just key) entries.

I traced this back to the fact that LLVM sets its `LLVM_DEFINITIONS` variable explicitly to a space-separated list of defines:

> \# We don't want no semicolons on LLVM_DEFINITIONS:

Then CMake's module finder converts `LLVM_DEFINITIONS` to the `PACKAGE_DEFINITIONS` that Meson consumes, which gets parsed as a single command line switch.

The end result is that VS's command line to the Intellisense compiler has something like `-D"_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE"` on it, which breaks. Forcing spaces to be treated as a delimiter for LLVM's defines resolves the problem.