### PR TITLE
docs: fix the docs for install_subdir's strip_directory

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1076,7 +1076,7 @@ The following keyword arguments are supported:
 - `install_mode`: the file mode in symbolic format and optionally
   the owner/uid and group/gid for the installed files. *(Added 0.47.0)*
 - `strip_directory`: install directory contents. `strip_directory=false` by default.
-  If `strip_directory=false` only last component of source path is used.
+  If `strip_directory=true` only the last component of the source path is used.
   Since 0.45.0
 
 For a given directory `foo`:


### PR DESCRIPTION
When set to **true** only the last component is used. And throw in two minor
grammatical fixes while we're there.