### PR TITLE
References-tables.md: repair broken table

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -266,7 +266,7 @@ These are the values that can be passed to `dependency` function's
 ## Compiler and Linker selection variables
 
 | Language      | Compiler | Linker    | Note                                        |
-|:-------------:|----------|-----------|---------------------------------------------|
+|---------------|----------|-----------|---------------------------------------------|
 | C             | CC       | CC_LD     |                                             |
 | C++           | CXX      | CXX_LD    |                                             |
 | D             | DC       | DC_LD     | Before 0.54 D_LD*                           |


### PR DESCRIPTION
At https://mesonbuild.com/Reference-tables.html#compiler-and-linker-selection-variables, the table is broken and it seems that the only difference with other well-working tables on this page is the semi-column ":" that are present under Language.