### PR TITLE
Fix library(name_prefix: [])

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1191,9 +1191,9 @@ The keyword arguments for this are the same as for
 
 - `name_prefix` the string that will be used as the prefix for the
   target output filename by overriding the default (only used for
-  libraries). By default this is `lib` on all platforms and compilers
-  except with MSVC shared libraries where it is omitted to follow
-  convention.
+  libraries). By default this is `lib` on all platforms and compilers,
+  except for MSVC shared libraries where it is omitted to follow
+  convention, and Cygwin shared libraries where it is `cyg`.
 - `name_suffix` the string that will be used as the suffix for the
   target output filename by overriding the default (see also:
   [executable()](#executable)). By default, for shared libraries this
@@ -1201,7 +1201,7 @@ The keyword arguments for this are the same as for
   For static libraries, it is `a` everywhere. By convention MSVC
   static libraries use the `lib` suffix, but we use `a` to avoid a
   potential name clash with shared libraries which also generate
-  `xxx.lib` import files.
+  import libraries with a `lib` suffix.
 - `rust_crate_type` specifies the crate type for Rust
   libraries. Defaults to `dylib` for shared libraries and `rlib` for
   static libraries.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -922,16 +922,17 @@ This will become a hard error in a future Meson release.''')
             name_prefix = kwargs['name_prefix']
             if isinstance(name_prefix, list):
                 if name_prefix:
-                    raise InvalidArguments('name_prefix array must be empty to signify null.')
-            elif not isinstance(name_prefix, str):
-                raise InvalidArguments('name_prefix must be a string.')
-            self.prefix = name_prefix
-            self.name_prefix_set = True
+                    raise InvalidArguments('name_prefix array must be empty to signify default.')
+            else:
+                if not isinstance(name_prefix, str):
+                    raise InvalidArguments('name_prefix must be a string.')
+                self.prefix = name_prefix
+                self.name_prefix_set = True
         if 'name_suffix' in kwargs:
             name_suffix = kwargs['name_suffix']
             if isinstance(name_suffix, list):
                 if name_suffix:
-                    raise InvalidArguments('name_suffix array must be empty to signify null.')
+                    raise InvalidArguments('name_suffix array must be empty to signify default.')
             else:
                 if not isinstance(name_suffix, str):
                     raise InvalidArguments('name_suffix must be a string.')

--- a/test cases/common/206 install name_prefix name_suffix/meson.build
+++ b/test cases/common/206 install name_prefix name_suffix/meson.build
@@ -8,3 +8,6 @@ static_library('qux', 'libfile.c', name_suffix: 'cheese', install : true)
 
 shared_library('corge', 'libfile.c', name_prefix: 'bow', name_suffix: 'stern', install : true)
 static_library('grault', 'libfile.c', name_prefix: 'bow', name_suffix: 'stern', install : true)
+
+# exercise default name_prefix and name_suffix
+shared_library('garply', 'libfile.c', name_prefix: [], name_suffix: [], install : true)

--- a/test cases/common/206 install name_prefix name_suffix/test.json
+++ b/test cases/common/206 install name_prefix name_suffix/test.json
@@ -11,6 +11,9 @@
     {"type": "implib", "file": "usr/lib/foo"},
     {"type": "expr", "file": "usr/lib/foo?so"},
     {"type": "implib", "file": "usr/lib/libbaz"},
-    {"type": "file", "file": "usr/lib/libqux.cheese"}
+    {"type": "file", "file": "usr/lib/libqux.cheese"},
+    {"type": "expr", "file": "usr/?lib/libgarply?so"},
+    {"type": "implib", "file": "usr/lib/libgarply"},
+    {"type": "pdb", "file": "usr/bin/garply"}
   ]
 }


### PR DESCRIPTION
Fix handling of `library(name_prefix: [])`

c87c42b736197b726f3cca47e92bc836c773085e documents that this is a way to explicitly specify the default (rather than an empty) library name prefix.

I couldn't find any release in which this feature worked, so I'm not sure what the intended mechanism to achieve that was.

Fix it by matching the `name_suffix` behaviour of not setting the relevant attribute of the BuildTarget object in the empty list case, so the default is used.

Add a test.