### PR TITLE
Corrected prefix path default in documentation.

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -43,7 +43,7 @@ Installation options are all relative to the prefix, except:
 | sysconfdir                           | etc           | Sysconf data directory |
 
 
-`prefix` defaults to `C:/` on Windows, and `/usr/local/` otherwise. You should always
+`prefix` defaults to `C:/` on Windows, and `/usr/local` otherwise. You should always
 override this value.
 
 `libdir` is automatically detected based on your platform, it should be


### PR DESCRIPTION
Using meson version `0.53.2` prefix defaulted to `/usr/local`, not `/usr/local/` (note the trailing slash)