### PR TITLE
interpreter: Fix bad command name on run_command error message

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2581,6 +2581,8 @@ external dependencies (including libraries) must go to "dependencies".''')
                       ' and therefore cannot be used during configuration'
                 raise InterpreterException(msg.format(progname, cmd.description()))
             if not cmd.found():
+                if isinstance(cmd, dependencies.ExternalProgram):
+                    raise InterpreterException('Tried to use not-found external program')
                 raise InterpreterException('command {!r} not found or not executable'.format(cmd))
         elif isinstance(cmd, CompilerHolder):
             exelist = cmd.compiler.get_exelist()


### PR DESCRIPTION
Calling run_command with a non-found program returned by find_program, returns an ugly error message. Fix this by improving the returned message for ExternalProgram.

See issue https://github.com/mesonbuild/meson/issues/6969