### PR TITLE
Freedesktop module

### DIFF
--- a/ci/ciimage/arch/install.sh
+++ b/ci/ciimage/arch/install.sh
@@ -12,6 +12,7 @@ pkgs=(
   itstool gtk3 java-environment=8 gtk-doc llvm clang sdl2 graphviz
   doxygen vulkan-validation-layers openssh mercurial gtk-sharp-2 qt5-tools
   libwmf valgrind cmake netcdf-fortran openmpi nasm gnustep-base gettext
+  desktop-file-utils
   # cuda
 )
 

--- a/ci/ciimage/arch/install.sh
+++ b/ci/ciimage/arch/install.sh
@@ -12,7 +12,7 @@ pkgs=(
   itstool gtk3 java-environment=8 gtk-doc llvm clang sdl2 graphviz
   doxygen vulkan-validation-layers openssh mercurial gtk-sharp-2 qt5-tools
   libwmf valgrind cmake netcdf-fortran openmpi nasm gnustep-base gettext
-  desktop-file-utils
+  desktop-file-utils appstream
   # cuda
 )
 

--- a/ci/ciimage/cuda/install.sh
+++ b/ci/ciimage/cuda/install.sh
@@ -4,7 +4,7 @@ set -e
 
 pkgs=(
   python python-setuptools python-wheel python-pytest-xdist python-jsonschema
-  ninja gcc gcc-objc git cmake desktop-file-utils
+  ninja gcc gcc-objc git cmake desktop-file-utils appstream
   cuda zlib pkgconf
 )
 

--- a/ci/ciimage/cuda/install.sh
+++ b/ci/ciimage/cuda/install.sh
@@ -4,7 +4,7 @@ set -e
 
 pkgs=(
   python python-setuptools python-wheel python-pytest-xdist python-jsonschema
-  ninja gcc gcc-objc git cmake
+  ninja gcc gcc-objc git cmake desktop-file-utils
   cuda zlib pkgconf
 )
 

--- a/ci/ciimage/eoan/install.sh
+++ b/ci/ciimage/eoan/install.sh
@@ -27,6 +27,7 @@ pkgs=(
   libblocksruntime-dev
   libperl-dev
   liblapack-dev libscalapack-mpi-dev
+  desktop-file-utils
 )
 
 sed -i '/^#\sdeb-src /s/^#//' "/etc/apt/sources.list"

--- a/ci/ciimage/eoan/install.sh
+++ b/ci/ciimage/eoan/install.sh
@@ -28,6 +28,7 @@ pkgs=(
   libperl-dev
   liblapack-dev libscalapack-mpi-dev
   desktop-file-utils
+  appstream
 )
 
 sed -i '/^#\sdeb-src /s/^#//' "/etc/apt/sources.list"

--- a/ci/ciimage/fedora/install.sh
+++ b/ci/ciimage/fedora/install.sh
@@ -13,7 +13,7 @@ pkgs=(
   doxygen vulkan-devel vulkan-validation-layers-devel openssh mercurial gtk-sharp2-devel libpcap-devel gpgme-devel
   qt5-qtbase-devel qt5-qttools-devel qt5-linguist qt5-qtbase-private-devel
   libwmf-devel valgrind cmake openmpi-devel nasm gnustep-base-devel gettext-devel ncurses-devel
-  libxml2-devel libxslt-devel libyaml-devel glib2-devel json-glib-devel
+  libxml2-devel libxslt-devel libyaml-devel glib2-devel json-glib-devel desktop-file-utils
 )
 
 # Sys update

--- a/ci/ciimage/fedora/install.sh
+++ b/ci/ciimage/fedora/install.sh
@@ -13,7 +13,7 @@ pkgs=(
   doxygen vulkan-devel vulkan-validation-layers-devel openssh mercurial gtk-sharp2-devel libpcap-devel gpgme-devel
   qt5-qtbase-devel qt5-qttools-devel qt5-linguist qt5-qtbase-private-devel
   libwmf-devel valgrind cmake openmpi-devel nasm gnustep-base-devel gettext-devel ncurses-devel
-  libxml2-devel libxslt-devel libyaml-devel glib2-devel json-glib-devel desktop-file-utils
+  libxml2-devel libxslt-devel libyaml-devel glib2-devel json-glib-devel desktop-file-utils appstream
 )
 
 # Sys update

--- a/ci/ciimage/opensuse/install.sh
+++ b/ci/ciimage/opensuse/install.sh
@@ -18,6 +18,7 @@ pkgs=(
   boost-devel libboost_date_time-devel libboost_filesystem-devel libboost_locale-devel libboost_system-devel
   libboost_test-devel libboost_log-devel libboost_regex-devel
   libboost_python-devel libboost_python-py3-1_71_0-devel libboost_regex-devel desktop-file-utils
+  AppStream
 )
 
 # Sys update

--- a/ci/ciimage/opensuse/install.sh
+++ b/ci/ciimage/opensuse/install.sh
@@ -17,7 +17,7 @@ pkgs=(
   libxml2-devel libxslt-devel libyaml-devel glib2-devel json-glib-devel
   boost-devel libboost_date_time-devel libboost_filesystem-devel libboost_locale-devel libboost_system-devel
   libboost_test-devel libboost_log-devel libboost_regex-devel
-  libboost_python-devel libboost_python-py3-1_71_0-devel libboost_regex-devel
+  libboost_python-devel libboost_python-py3-1_71_0-devel libboost_regex-devel desktop-file-utils
 )
 
 # Sys update

--- a/docs/markdown/Freedesktop-module.md
+++ b/docs/markdown/Freedesktop-module.md
@@ -1,0 +1,112 @@
+# Freedesktop Module
+
+This module provides helper functions for freedesktop standards used primarily on *nix systems.
+
+*New in 0.55.0*
+
+## File generators
+
+### desktop_file()
+
+```meson
+  custom_target desktop_file(exe, ...)
+```
+
+Helper for generating a [.desktop file](https://specifications.freedesktop.org/desktop-entry-spec/latest/index.html)
+
+Creates a custom_target that will be installed if the executable used to
+generate it is also installed. Takes one positional argument which is an
+executable or a disabler. If a disabler is passed or the executable is not
+going to be installed then nothing is returned.
+
+The `Exec` field is automatically populated with the installed path to the executable.
+
+The `Terminal` field is set based on the value of the Executable's `gui_app` field.
+
+This function has the following keyword arguments:
+
+- `name` The name of the program. This is the value of the `Name` field in
+  the .desktop file. If this field is not set then the name of the executable
+  is used.
+
+- `comment` The value of the `Comment` field in the .desktop file. If this
+  value is not provided then the field is unset.
+
+- `generic_name` is the `GenericName` in the .desktop file. If this value is
+  not provided then the field is unset.
+
+- `icon` is the `Icon` value in the .desktop file. Meson does not validate
+  this value in anyway. If not provided the field is unset.
+
+- `categories` a meson list of categories for this program. These values will
+  be joined into a single semicolon delimited string in the .desktop file.
+  Meson does not validate this value in any way. If not provided the field is
+  unset.
+
+- `install_name` The name of the .desktop file without the file extension. If
+  this is unset the name of the value of `name` or the name of the executable
+  will be used, in that order.
+
+- `mimetype` A meson list of mimetypes that this program handles. These
+  values will be joined into a single semicolon delimited string in the
+  .desktop file. Meson does not validate these values in any way. If not
+  provided the field is unset.
+
+- `dbus` A boolean that populates the `DBusActivatable` field in the .desktop
+file. Defaults to false
+
+- `no_display` A boolean for the `NoDisplay` field.
+
+- `only_show_in` A list of strings to populate the `OnlyShowIn` field.
+
+- `not_show_in` A list of strings to populate the `NotShowIn` field.
+
+- `startup_notify` A Boolean for to populate the `StartupNotify` field.
+
+- `startup_wm_class` A Boolean for to populate the `StartupWMClass` field.
+
+- `implements` A list of strings that will be `;` joined to populate the
+  `Implements` field.
+
+- `keywords` A list of strings that will be `;` joined to populate the
+  `Keywords` field.
+
+- `extra_args` A dict of string to string|list of string|boolean's for
+  extended attributes. The keys must start with `X-`. Lists will be converted
+  in `;` delimited strings. If a value needs to be formatted differently the
+  caller must format it themselves and pass the value as a string. Meson
+  validates only that all keys start with `X-`, it is up to the caller to
+  ensure that these keys are correctly formatted.
+
+- `test_target` A boolean. If this is set to true then a test target to
+  validate the .desktop file is also generated. If this is true then the
+  program `desktop-file-validate` is required
+
+- `actions` A list of dictionaries for additional actions for the .desktop
+  file. If this value is not provided then no additional actions are set.
+
+The actions dictionaries have the following signature:
+
+- `exec` Additional arguments to pass to the Executable. The path to the
+  executable is provided, these are treated as extra arguments. Required.
+
+- `name` the name of the action. Required.
+
+- `icon` Icon for the action, uses the same logic as the main `icon`
+  argument. Optional.
+
+```meson
+fdo = import('freedesktop')
+
+exe = executable(..., gui_app : true, install : true)
+fdo.desktop_file(
+  exe,
+  generic_name : 'IDE',
+  actions : [
+    {
+      name : 'Import',
+      exec : ['--import', '%f'],
+    }
+  ]
+)
+```

--- a/docs/markdown/snippets/freedesktop_module.md
+++ b/docs/markdown/snippets/freedesktop_module.md
@@ -1,0 +1,15 @@
+## A new freedesktop module for common freedesktop operations
+
+This module include useful functionality for projects that use freedesktop standards, such as .desktop files.
+
+```meson
+exe = executable(..., gui_app : true, install : true)
+
+fdo = import('freedesktop')
+exe_desktop = fdo.desktop_file(
+    exe,
+    name : 'UnicornAwesomeApp',
+    generic_name : 'Email',
+    ...
+)
+```

--- a/docs/sitemap.txt
+++ b/docs/sitemap.txt
@@ -49,6 +49,7 @@ index.md
 			Windows-module.md
 			Cuda-module.md
 			Kconfig-module.md
+			Freedesktop-module.md
 		Java.md
 		Vala.md
 		D.md

--- a/docs/theme/extra/templates/navbar_links.html
+++ b/docs/theme/extra/templates/navbar_links.html
@@ -10,6 +10,7 @@
 					 ("Cuda-module.html","CUDA"), \
            ("Dlang-module.html","Dlang"), \
            ("Fs-module.html","Filesystem"), \
+           ("Freedesktop-module.html","Freedesktop"), \
 					 ("Gnome-module.html","GNOME"), \
 					 ("Hotdoc-module.html","Hotdoc"), \
 					 ("i18n-module.html","i18n"), \

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -158,7 +158,7 @@ class Backend:
         elif isinstance(t, build.CustomTargetIndex):
             filename = t.get_outputs()[0]
         else:
-            assert(isinstance(t, build.BuildTarget))
+            assert isinstance(t, build.BuildTarget), t
             filename = t.get_filename()
         return os.path.join(self.get_target_dir(t), filename)
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2139,17 +2139,16 @@ class CustomTarget(Target):
             self.install = kwargs['install']
             if not isinstance(self.install, bool):
                 raise InvalidArguments('"install" must be boolean.')
-            if self.install:
-                if 'install_dir' not in kwargs:
-                    raise InvalidArguments('"install_dir" must be specified '
-                                           'when installing a target')
+            if 'install_dir' not in kwargs:
+                raise InvalidArguments('"install_dir" must be specified '
+                                        'when installing a target')
 
-                if isinstance(kwargs['install_dir'], list):
-                    FeatureNew('multiple install_dir for custom_target', '0.40.0').use(self.subproject)
-                # If an item in this list is False, the output corresponding to
-                # the list index of that item will not be installed
-                self.install_dir = typeslistify(kwargs['install_dir'], (str, bool))
-                self.install_mode = kwargs.get('install_mode', None)
+            if isinstance(kwargs['install_dir'], list):
+                FeatureNew('multiple install_dir for custom_target', '0.40.0').use(self.subproject)
+            # If an item in this list is False, the output corresponding to
+            # the list index of that item will not be installed
+            self.install_dir = typeslistify(kwargs['install_dir'], (str, bool))
+            self.install_mode = kwargs.get('install_mode', None)
         else:
             self.install = False
             self.install_dir = [None]

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -4450,12 +4450,12 @@ Try setting b_lundef to false instead.'''.format(self.coredata.base_options['b_s
             results.append(s)
         return results
 
-    def add_target(self, name, tobj):
+    def add_target(self, name: str, tobj: build.BuildTarget) -> None:
         if name == '':
             raise InterpreterException('Target name must not be empty.')
         if name.strip() == '':
             raise InterpreterException('Target name must not consist only of whitespace.')
-        if name.startswith('meson-'):
+        if not tobj.internal_target and name.startswith('meson-'):
             raise InvalidArguments("Target names starting with 'meson-' are reserved "
                                    "for Meson's internal use. Please rename.")
         if name in coredata.forbidden_target_names:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2352,7 +2352,7 @@ class Interpreter(InterpreterBase):
 
         if isinstance(item, build.CustomTarget):
             return CustomTargetHolder(item, self)
-        elif isinstance(item, (int, str, bool, Disabler)) or item is None:
+        elif isinstance(item, (int, str, bool, Disabler, mesonlib.File)) or item is None:
             return item
         elif isinstance(item, build.Executable):
             return ExecutableHolder(item, self)
@@ -2397,7 +2397,7 @@ class Interpreter(InterpreterBase):
                 self.process_new_values(v.sources[0])
             elif hasattr(v, 'held_object'):
                 pass
-            elif isinstance(v, (int, str, bool, Disabler)):
+            elif isinstance(v, (int, str, bool, Disabler, mesonlib.File)):
                 pass
             else:
                 raise InterpreterException('Module returned a value of unknown type.')

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2395,6 +2395,8 @@ class Interpreter(InterpreterBase):
                 # FIXME: This is special cased and not ideal:
                 # The first source is our new VapiTarget, the rest are deps
                 self.process_new_values(v.sources[0])
+            elif isinstance(v, Test):
+                self.build.tests.append(v)
             elif hasattr(v, 'held_object'):
                 pass
             elif isinstance(v, (int, str, bool, Disabler, mesonlib.File)):

--- a/mesonbuild/modules/freedesktop.py
+++ b/mesonbuild/modules/freedesktop.py
@@ -1,0 +1,267 @@
+# Copyright 2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for freedesktop related standards."""
+
+import argparse
+import configparser
+import json
+import os
+import sys
+import typing as T
+
+# These must be imported as absolute imports to make the __main__ thing work
+from mesonbuild.build import Executable, CustomTarget, EnvironmentVariables
+from mesonbuild.interpreter import Test, CustomTargetHolder
+from mesonbuild.interpreterbase import permittedKwargs
+from mesonbuild.mesonlib import (
+    FileMode,
+    MachineChoice,
+    MesonException,
+    listify,
+    stringlistify,
+    unholder,
+)
+from mesonbuild.modules import ExtensionModule, ModuleReturnValue, python
+
+if T.TYPE_CHECKING:
+    # This can be relative because they're only read by mypy
+    from ..interpreter import ModuleState, ExecutableHolder
+    from ..interpreterbase import Disabler
+
+    _T = T.TypeVar('_T')
+
+
+class FDOConfigParser(configparser.RawConfigParser):
+
+    """Special case config parser that doesn't muck with capitaliation."""
+
+    def __init__(self, *args, **kwargs):
+        # Turn off interpolation, it inteferes with the .desktop file's % syntax.
+        super().__init__(*args, interpolation=None, **kwargs)
+
+    def optionxform(self, value: '_T') -> '_T':
+        return value
+
+
+def optional_string_arg(kwargs: T.Dict[str, T.Any], kkey: str,
+                        values: T.Dict[str, T.Union[str, T.Dict[str, str]]], vkey: str, *,
+                        fallback: T.Optional[str] = None) -> None:
+    value = kwargs.get(kkey, fallback)
+    if value is not None:
+        if not isinstance(value, str):
+            raise MesonException('"{}" must be a string if defined'.format(kkey))
+        values[vkey] = value
+
+
+def optional_bool_arg(kwargs: T.Dict[str, T.Any], kkey: str,
+                      values: T.Dict[str, T.Union[str, T.Dict[str, str]]], vkey: str, *,
+                      fallback: T.Optional[bool] = None) -> None:
+    value = kwargs.get(kkey, fallback)
+    if value is not None:
+        if not isinstance(value, bool):
+            raise MesonException('"{}" must be a bool if defined'.format(kkey))
+        values[vkey] = str(value).lower()
+
+
+def optional_list_arg(kwargs: T.Dict[str, T.Any], kkey: str,
+                      values: T.Dict[str, T.Union[str, T.Dict[str, str]]], vkey: str) -> None:
+    value = stringlistify(kwargs.get(kkey, []))
+    if value:
+        values[vkey] = ';'.join(value)
+
+
+def generate_desktop_file(cmdline: T.List[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('json')
+    parser.add_argument('output')
+    args = parser.parse_args(cmdline)
+
+    commands = json.loads(args.json)
+    # The escaping has to be done in the generator function, as JSON doesn't
+    # like the escaping that desktop files use
+    commands['main']['Exec'] = '"{}"'.format(
+        ' '.join(escape_exec_arg(c) for c in commands['main']['Exec']))
+
+    config = FDOConfigParser()
+    config['Desktop Entry'] = commands['main']
+    for name, action in commands['actions'].items():
+        action['Exec'] = '"{}"'.format(
+            ' '.join(escape_exec_arg(c) for c in action['Exec']))
+        config['Desktop Action {}'.format(name)] = action
+
+    with open(args.output, 'w') as f:
+        config.write(f)
+
+    return 0
+
+
+def escape_exec_arg(arg: str) -> str:
+    final = []  # type: T.List[str]
+    for c in arg:
+        if c in {'`', '$', '\\'}:
+            final.append('\\')
+        final.append(c)
+    return "{}".format(''.join(final))
+
+
+class FreedesktopModule(ExtensionModule):
+
+    @permittedKwargs({'name', 'arguments', 'generic_name', 'icon',
+                      'categories', 'actions', 'install_name', 'mimetype', 'comment', 'dbus',
+                      'no_display', 'implements', 'keywords', 'startup_notify',
+                      'startup_wm_class', 'extra_args', 'test_target'})
+    def desktop_file(self, state: 'ModuleState',
+                     args: T.Tuple[T.Union['ExecutableHolder', 'Disabler']],
+                     kwargs: T.Dict[str, T.Any]) -> ModuleReturnValue:
+        if len(args) != 1:
+            raise MesonException('Only one positinal argument allowed.')
+
+        exe = args[0].held_object  # type: Executable
+        if not isinstance(exe, Executable):
+            raise MesonException('First argument must be an Executable')
+        test = kwargs.get('test_target', False)
+        if not isinstance(test, bool):
+            raise MesonException('"test_target" must be a bool if defined')
+
+        values = {}  # type: T.Dict[str, T.Union[str, T.Dict[str, str]]]
+
+        full_exe = os.path.join(exe.get_install_dir(state.environment)[0][0], exe.name)
+        arguments = stringlistify(kwargs.get('arguments', []))
+
+        optional_string_arg(kwargs, 'name', values, 'Name', fallback=exe.name)
+        values['Terminal'] = str(not exe.gui_app).lower()
+        values['Exec'] = [full_exe, *arguments]
+        values['TryExec'] = full_exe
+        values['Type'] = 'Application'
+        values['Version'] = '1.1'
+        optional_string_arg(kwargs, 'comment', values, 'Comment')
+        optional_string_arg(kwargs, 'generic_name', values, 'GenericName')
+        optional_string_arg(kwargs, 'icon', values, 'Icon')
+        optional_string_arg(kwargs, 'startup_wm_class', values, 'StartupWMClass')
+        optional_list_arg(kwargs, 'categories', values, 'Categories')
+        optional_list_arg(kwargs, 'mimetype', values, 'MimeType')
+        optional_list_arg(kwargs, 'not_show_in', values, 'NotShowIn')
+        optional_list_arg(kwargs, 'only_show_in', values, 'OnlyShowIn')
+        optional_list_arg(kwargs, 'implements', values, 'Implements')
+        optional_list_arg(kwargs, 'keywords', values, 'Keywords')
+        optional_bool_arg(kwargs, 'dbus', values,  'DBusActivatable')
+        optional_bool_arg(kwargs, 'no_display', values,  'NoDisplay')
+        optional_bool_arg(kwargs, 'startup_notify', values,  'StartupNotify')
+
+        extra_args = kwargs.get('extra_args', {})
+        for k, v in extra_args.items():
+            if not k.startswith('X-'):
+                raise MesonException('extra_args keys must start with "X-"')
+            if isinstance(v, str):
+                kwargs[k] = v
+            elif isinstance(v, bool):
+                kwargs[k] = str(v).lower()
+            else:
+                kwargs[k] = ';'.join(stringlistify(v))
+
+        all_actions = {}
+        actions = listify(kwargs.get('actions', []))
+        if actions:
+            for action in actions:
+                if not isinstance(action, dict):
+                    raise MesonException('"actions" must be a list of dicts if defined.')
+                if 'action' not in action:
+                    raise MesonException('missing required "action" entry in action "{}"'.format(action))
+                if not isinstance(action['action'], str):
+                    raise MesonException("Action key of actions must be a string")
+                if 'name' not in action:
+                    raise MesonException('missing required "name" entry in action "{}"'.format(action))
+                if not isinstance(action['name'], str):
+                    raise MesonException("Name key of actions must be a string")
+
+                avalues = {}
+                avalues['Name'] = action['name']
+
+                exec_ = stringlistify(action['exec'])
+                avalues['Exec'] =  [full_exe, *exec_]
+
+                optional_string_arg(action, 'icon', avalues, 'Icon')
+
+                all_actions[action['action']] = avalues
+
+        install_name = kwargs.get('install_name', values['Name'])
+        if not isinstance(install_name, str):
+            raise MesonException('install_name must be a string if provided')
+        if install_name.endswith('.desktop'):
+            raise MesonException('install_name must not include the .desktop '
+                                 'file extension.')
+
+        values['Actions'] = ';'.join(a['action'] for a in actions)
+
+        root = {'main': values, 'actions': all_actions}
+
+        py = python.PythonModule(self.interpreter).find_installation(
+            self.interpreter, state, ['python3'], {})
+        ct = CustomTarget(
+            'meson-freedesktop-{}'.format(install_name),
+            state.environment.get_scratch_dir(),
+            self.interpreter.subproject,
+            {
+                'output': '{}.desktop'.format(install_name),
+                'command': [
+                    py, __file__, 'desktop_file',
+                    json.dumps(root), '@OUTPUT@',
+                ],
+                'install': exe.should_install(),
+                'install_dir': os.path.join(state.environment.get_datadir(), 'applications'),
+                'install_mode': FileMode('rw-r--r--'),
+                'depends': args[0],
+            },
+            internal_target=True,
+        )
+
+        new_objs = [ct]
+
+        if test:
+            validator = self.interpreter.find_program_impl(
+                ['desktop-file-validate'], required=False, for_machine=MachineChoice.BUILD)
+            tt = Test(
+                'validate meson-freedesktop-{}'.format(install_name),
+                self.interpreter.subproject,
+                suite=['freedesktop-module'],
+                exe=validator.held_object,
+                depends=[],
+                is_parallel=True,
+                cmd_args=[ct],
+                env=EnvironmentVariables(),
+                should_fail=False,
+                timeout=30,
+                workdir=None,
+                protocol='exitcode',
+                priority=0,
+            )
+            new_objs.append(tt)
+
+        return ModuleReturnValue(ct, new_objs)
+
+
+def initialize(*args, **kwargs) -> FreedesktopModule:
+    return FreedesktopModule(*args, **kwargs)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('mode')
+    args, remaining = parser.parse_known_args()
+
+    if args.mode == 'desktop_file':
+        callable_ = generate_desktop_file
+
+    sys.exit(callable_(remaining))

--- a/test cases/common/232 freedesktop module/foo.c
+++ b/test cases/common/232 freedesktop module/foo.c
@@ -1,0 +1,3 @@
+int main(void) {
+    return 0;
+}

--- a/test cases/common/232 freedesktop module/meson.build
+++ b/test cases/common/232 freedesktop module/meson.build
@@ -1,4 +1,4 @@
-project('freedesktop module', 'c')
+project('freedesktop module', 'c', license : 'MIT')
 
 if ['darwin', 'windows', 'cygwin'].contains(host_machine.system())
   error('MESON_SKIP_TEST freedesktop module isn\'t relavent for this platform.')
@@ -38,3 +38,12 @@ exe_desktop = fdo.desktop_file(
 
 exe_desktop_all_default = fdo.desktop_file(exe, test_target : true)
 fdo.desktop_file(disabler(), test_target : true)
+
+appstream = fdo.appstream(
+  'com.example',
+  'foo',
+  summary : 'A foo',
+  description : '<p>A very foo program. This line needs to be fairly long, even longer than you expect.</p>',
+  desktop_file : exe_desktop,
+  test_target : true,
+)

--- a/test cases/common/232 freedesktop module/meson.build
+++ b/test cases/common/232 freedesktop module/meson.build
@@ -1,0 +1,40 @@
+project('freedesktop module', 'c')
+
+if ['darwin', 'windows', 'cygwin'].contains(host_machine.system())
+  error('MESON_SKIP_TEST freedesktop module isn\'t relavent for this platform.')
+endif
+
+fdo = import('freedesktop')
+
+exe = executable('foo', 'foo.c', install : true)
+
+exe_desktop = fdo.desktop_file(
+  exe,
+  name : 'customized',
+  generic_name : 'test program',
+  arguments : ['--argument=$', '%F'],
+  categories : ['Utility'],
+  install_name : 'com.example.foo',
+  icon : 'an.icon',
+  mimetype : ['image/tiff', 'image/png'],
+  dbus : true,
+  no_display : false,
+  startup_notify : true,
+  startup_wm_class : 'something',
+  # the validator mistakenly flags this as invalid:
+  # https://gitlab.freedesktop.org/xdg/desktop-file-utils/-/issues/55
+  # implements : ['test'],
+  keywords : ['a keyword'],
+  actions : [
+    {
+      'action' : 'Other',
+      'exec' : ['--flag'],
+      'name' : 'Something else!',
+      'icon' : '/a/different/icon',
+    }
+  ],
+  test_target : true,
+)
+
+exe_desktop_all_default = fdo.desktop_file(exe, test_target : true)
+fdo.desktop_file(disabler(), test_target : true)

--- a/test cases/common/232 freedesktop module/test.json
+++ b/test cases/common/232 freedesktop module/test.json
@@ -1,0 +1,8 @@
+{
+  "installed": [
+    { "type": "exe", "file": "usr/bin/foo" },
+    { "type": "pdb", "file": "usr/bin/foo" },
+    { "type": "file", "file": "usr/share/applications/com.example.foo.desktop" },
+    { "type": "file", "file": "usr/share/applications/foo.desktop" }
+  ]
+}

--- a/test cases/common/232 freedesktop module/test.json
+++ b/test cases/common/232 freedesktop module/test.json
@@ -3,6 +3,7 @@
     { "type": "exe", "file": "usr/bin/foo" },
     { "type": "pdb", "file": "usr/bin/foo" },
     { "type": "file", "file": "usr/share/applications/com.example.foo.desktop" },
-    { "type": "file", "file": "usr/share/applications/foo.desktop" }
+    { "type": "file", "file": "usr/share/applications/foo.desktop" },
+    { "type": "file", "file": "usr/share/metainfo/com.example.foo.metainfo.xml" }
   ]
 }


### PR DESCRIPTION
This is a work in process to add a module for creating freedesktop data files. There's a bunch of them, people need them, and providing a built-in method for generating and installing them to the correct place that is tested and validated seems pretty dang useful.

This is not completely as-is, the .desktop file is pretty complete I think, but the appstream generation is super limited still. The tests work on my system, but probably fail somewhere (windows?). There's also limited documentation. I've added automatic validation generation to the targets as well, which I think is pretty slick.

I'm mostly hoping to get some feedback before I spend too much more time on this.