### PR TITLE
Fix CMake Windows system library deps

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1411,7 +1411,8 @@ class CMakeDependency(ExternalDependency):
                                       'Valid targets are:\n{}'.format(name, list(self.traceparser.targets.keys())))
 
         # Set dependencies with CMake targets
-        reg_is_lib = re.compile(r'^(-l[a-zA-Z0-9_]+|-pthread)$')
+        # recognise arguments we should pass directly to the linker
+        reg_is_lib = re.compile(r'^(-l[a-zA-Z0-9_]+|-pthread|-delayload:[a-zA-Z0-9_\.]+|[a-zA-Z0-9_]+\.lib)$')
         processed_targets = []
         incDirs = []
         compileDefinitions = []

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1481,7 +1481,9 @@ class CMakeDependency(ExternalDependency):
                 for j in otherDeps:
                     if j in self.traceparser.targets:
                         targets += [j]
-                    elif reg_is_lib.match(j) or os.path.exists(j):
+                    elif reg_is_lib.match(j):
+                        libraries += [j]
+                    elif os.path.isabs(j) and os.path.exists(j):
                         libraries += [j]
                     elif mesonlib.is_windows() and reg_is_maybe_bare_lib.match(j):
                         # On Windows, CMake library dependencies can be passed as bare library names,
@@ -1491,6 +1493,8 @@ class CMakeDependency(ExternalDependency):
                         # same, but must assume any bare argument passed which is not also a CMake
                         # target must be a system library we should try to link against
                         libraries += ["{}.lib".format(j)]
+                    else:
+                        mlog.warning('CMake: Dependency', mlog.bold(j), 'for', mlog.bold(name), 'target', mlog.bold(self._original_module_name(curr)), 'was not found')
 
                 processed_targets += [curr]
 


### PR DESCRIPTION
These three commits fix linking of system libraries when declared as dependencies of CMake targets we pick up as Meson dependencies. In particular, when linking Clang into Mesa via CMake, we were dropping all of the system library dependencies such as `ole32` and `uuid` … except if Meson was executed from the source directory, in which case we would retain `version` as a bare argument (since the Mesa source root has a file called `VERSION`), which would get passed through to the linker without a suffix qualification and fail the build.

This PR attempts to do something more reasonable with system-library dependencies under Windows.

cc @dcbaker @jenatali 