### PR TITLE
cmake: Do not compile explicit header files

### DIFF
--- a/mesonbuild/cmake/data/preload.cmake
+++ b/mesonbuild/cmake/data/preload.cmake
@@ -31,5 +31,37 @@ macro(add_custom_target)
   _add_custom_target(${ARGV})
 endmacro()
 
-set(MESON_PS_DELAYED_CALLS add_custom_command;add_custom_target)
+macro(set_property)
+  meson_ps_inspect_vars()
+  _set_property(${ARGV})
+endmacro()
+
+function(set_source_files_properties)
+  set(FILES)
+  set(I 0)
+  set(PROPERTIES OFF)
+
+  while(I LESS ARGC)
+    if(NOT PROPERTIES)
+      if("${ARGV${I}}" STREQUAL "PROPERTIES")
+        set(PROPERTIES ON)
+      else()
+        list(APPEND FILES "${ARGV${I}}")
+      endif()
+
+      math(EXPR I "${I} + 1")
+    else()
+      set(ID_IDX ${I})
+      math(EXPR PROP_IDX "${ID_IDX} + 1")
+
+      set(ID   "${ARGV${ID_IDX}}")
+      set(PROP "${ARGV${PROP_IDX}}")
+
+      set_property(SOURCE ${FILES} PROPERTY "${ID}" "${PROP}")
+      math(EXPR I "${I} + 2")
+    endif()
+  endwhile()
+endfunction()
+
+set(MESON_PS_DELAYED_CALLS add_custom_command;add_custom_target;set_property)
 meson_ps_reload_vars()

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -411,6 +411,8 @@ class ConverterTarget:
                 mlog.warning('CMake: path', mlog.bold(x), 'does not exist.')
                 mlog.warning(' --> Ignoring. This can lead to build errors.')
                 return None
+            if Path(x) in trace.explicit_headers:
+                return None
             if (
                 os.path.isabs(x)
                     and os.path.commonpath([x, self.env.get_source_dir()]) == self.env.get_source_dir()

--- a/test cases/cmake/18 skip include files/main.cpp
+++ b/test cases/cmake/18 skip include files/main.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <cmMod.hpp>
+
+using namespace std;
+
+int main(void) {
+  cmModClass obj("Hello");
+  cout << obj.getStr() << endl;
+  return 0;
+}

--- a/test cases/cmake/18 skip include files/meson.build
+++ b/test cases/cmake/18 skip include files/meson.build
@@ -1,0 +1,9 @@
+project('cmakeSubTest', ['c', 'cpp'])
+
+cm = import('cmake')
+
+sub_pro = cm.subproject('cmMod')
+sub_dep = sub_pro.dependency('cmModLib++')
+
+exe1 = executable('main', ['main.cpp'], dependencies: [sub_dep])
+test('test1', exe1)

--- a/test cases/cmake/18 skip include files/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/18 skip include files/subprojects/cmMod/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(cmMod)
+set (CMAKE_CXX_STANDARD 14)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
+add_definitions("-DDO_NOTHING_JUST_A_FLAG=1")
+
+set(SRCS
+  ${CMAKE_CURRENT_LIST_DIR}/cmMod.hpp
+  ${CMAKE_CURRENT_LIST_DIR}/cmMod.cpp
+)
+
+add_subdirectory(fakeInc)

--- a/test cases/cmake/18 skip include files/subprojects/cmMod/cmMod.cpp
+++ b/test cases/cmake/18 skip include files/subprojects/cmMod/cmMod.cpp
@@ -1,0 +1,10 @@
+#include "cmMod.hpp"
+
+using namespace std;
+
+#define MESON_INCLUDE_IMPL
+#include "fakeInc/cmModInc1.cpp"
+#include "fakeInc/cmModInc2.cpp"
+#include "fakeInc/cmModInc3.cpp"
+#include "fakeInc/cmModInc4.cpp"
+#undef MESON_INCLUDE_IMPL

--- a/test cases/cmake/18 skip include files/subprojects/cmMod/cmMod.hpp
+++ b/test cases/cmake/18 skip include files/subprojects/cmMod/cmMod.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "cmmodlib++_export.h"
+#include <string>
+
+class CMMODLIB___EXPORT cmModClass {
+private:
+  std::string str;
+
+  std::string getStr1() const;
+  std::string getStr2() const;
+public:
+  cmModClass(std::string foo);
+
+  std::string getStr() const;
+};

--- a/test cases/cmake/18 skip include files/subprojects/cmMod/fakeInc/CMakeLists.txt
+++ b/test cases/cmake/18 skip include files/subprojects/cmMod/fakeInc/CMakeLists.txt
@@ -1,0 +1,30 @@
+list(APPEND SRCS
+  cmModInc1.cpp
+  cmModInc2.cpp
+  cmModInc3.cpp
+  cmModInc4.cpp
+)
+
+set(SRC_A
+  cmModInc1.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/cmModInc2.cpp
+)
+
+set_property(
+  SOURCE ${SRC_A}
+  PROPERTY
+    HEADER_FILE_ONLY ON
+)
+
+set_source_files_properties(
+  cmModInc3.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/cmModInc4.cpp
+  PROPERTIES
+    LABELS "CMake;Lists;are;fun"
+    HEADER_FILE_ONLY ON
+)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+add_library(cmModLib++ SHARED ${SRCS})
+include(GenerateExportHeader)
+generate_export_header(cmModLib++)

--- a/test cases/cmake/18 skip include files/subprojects/cmMod/fakeInc/cmModInc1.cpp
+++ b/test cases/cmake/18 skip include files/subprojects/cmMod/fakeInc/cmModInc1.cpp
@@ -1,0 +1,7 @@
+#ifndef MESON_INCLUDE_IMPL
+#error "MESON_INCLUDE_IMPL is not defined"
+#endif // !MESON_INCLUDE_IMPL
+
+cmModClass::cmModClass(string foo) {
+  str = foo + " World";
+}

--- a/test cases/cmake/18 skip include files/subprojects/cmMod/fakeInc/cmModInc2.cpp
+++ b/test cases/cmake/18 skip include files/subprojects/cmMod/fakeInc/cmModInc2.cpp
@@ -1,0 +1,7 @@
+#ifndef MESON_INCLUDE_IMPL
+#error "MESON_INCLUDE_IMPL is not defined"
+#endif // !MESON_INCLUDE_IMPL
+
+string cmModClass::getStr() const {
+  return getStr2();
+}

--- a/test cases/cmake/18 skip include files/subprojects/cmMod/fakeInc/cmModInc3.cpp
+++ b/test cases/cmake/18 skip include files/subprojects/cmMod/fakeInc/cmModInc3.cpp
@@ -1,0 +1,7 @@
+#ifndef MESON_INCLUDE_IMPL
+#error "MESON_INCLUDE_IMPL is not defined"
+#endif // !MESON_INCLUDE_IMPL
+
+string cmModClass::getStr1() const {
+  return getStr2();
+}

--- a/test cases/cmake/18 skip include files/subprojects/cmMod/fakeInc/cmModInc4.cpp
+++ b/test cases/cmake/18 skip include files/subprojects/cmMod/fakeInc/cmModInc4.cpp
@@ -1,0 +1,7 @@
+#ifndef MESON_INCLUDE_IMPL
+#error "MESON_INCLUDE_IMPL is not defined"
+#endif // !MESON_INCLUDE_IMPL
+
+string cmModClass::getStr2() const {
+  return str;
+}


### PR DESCRIPTION
With this change meson now supports the [`HEADER_FILE_ONLY`](https://cmake.org/cmake/help/latest/prop_sf/HEADER_FILE_ONLY.html) source file property. It was necessary to fall back to the CMake trace, since the old CMake server API does not expose this information.

Ping @line0