### PR TITLE
tests/common/93: Fix cross building when no exe_wrapper is available

### DIFF
--- a/test cases/common/93 selfbuilt custom/meson.build
+++ b/test cases/common/93 selfbuilt custom/meson.build
@@ -17,7 +17,7 @@ test('maintest', main)
 
 lib = library('libtool', 'tool.cpp')
 
-checkarg = executable('checkarg', 'checkarg.cpp')
+checkarg = executable('checkarg', 'checkarg.cpp', native : true)
 
 ctlib = custom_target('ctlib',
   output : 'ctlib.out',
@@ -25,3 +25,15 @@ ctlib = custom_target('ctlib',
   command : [checkarg, lib],
   build_by_default : true,
 )
+
+if meson.is_cross_build() and meson.has_exe_wrapper()
+  checkarg_host = executable('checkarg_host', 'checkarg.cpp')
+
+  ctlib_host = custom_target(
+    'ctlib_host',
+    output : 'ctlib.host.out',
+    capture : true,
+    command : [checkarg_host, lib],
+    build_by_default : true,
+  )
+endif


### PR DESCRIPTION
By building the generator for the build machine always, and only for the
host machine if an exe_wrapper is available. This makes sense to me as
generally you are going to build the generator for the build machine,
not the host machine, but testing on the host machine makes sense too.