### PR TITLE
compilers: Update gnu_inline test to work correctly with Clang >= 10

### DIFF
--- a/mesonbuild/compilers/c_function_attributes.py
+++ b/mesonbuild/compilers/c_function_attributes.py
@@ -127,4 +127,7 @@ CXX_FUNC_ATTRIBUTES = {
          'static int (*resolve_foo(void))(void) { return my_foo; }'
          '}'
          'int foo(void) __attribute__((ifunc("resolve_foo")));'),
+    # Clang >= 10 requires the 'extern' keyword
+    'gnu_inline':
+        'extern inline __attribute__((gnu_inline)) int foo(void) { return 0; }',
 }

--- a/test cases/common/203 function attributes/meson.build
+++ b/test cases/common/203 function attributes/meson.build
@@ -82,30 +82,30 @@ if ['gcc', 'intel'].contains(c.get_id())
   endif
 endif
 
+if get_option('mode') == 'single'
+  foreach a : attributes
+    x = c.has_function_attribute(a)
+    assert(x == expected_result, '@0@: @1@'.format(c.get_id(), a))
+    x = cpp.has_function_attribute(a)
+    assert(x == expected_result, '@0@: @1@'.format(cpp.get_id(), a))
+  endforeach
 
-foreach a : attributes
-  x = c.has_function_attribute(a)
-  assert(x == expected_result, '@0@: @1@'.format(c.get_id(), a))
-  x = cpp.has_function_attribute(a)
-  assert(x == expected_result, '@0@: @1@'.format(cpp.get_id(), a))
-endforeach
-
-win_expect = ['windows', 'cygwin'].contains(host_machine.system())
-foreach a : ['dllexport', 'dllimport']
-  assert(c.has_function_attribute(a) == win_expect,
-         '@0@: @1@'.format(c.get_id(), a))
-  assert(cpp.has_function_attribute(a) == win_expect,
-         '@0@: @1@'.format(cpp.get_id(), a))
-endforeach
-
-message('checking get_supported_function_attributes')
-if not ['msvc', 'clang-cl', 'intel-cl'].contains(c.get_id())
-  multi_expected = attributes
+  win_expect = ['windows', 'cygwin'].contains(host_machine.system())
+  foreach a : ['dllexport', 'dllimport']
+    assert(c.has_function_attribute(a) == win_expect,
+          '@0@: @1@'.format(c.get_id(), a))
+    assert(cpp.has_function_attribute(a) == win_expect,
+          '@0@: @1@'.format(cpp.get_id(), a))
+  endforeach
 else
-  multi_expected = []
-endif
+  if not ['msvc', 'clang-cl', 'intel-cl'].contains(c.get_id())
+    multi_expected = attributes
+  else
+    multi_expected = []
+  endif
 
-multi_check = c.get_supported_function_attributes(attributes)
-assert(multi_check == multi_expected, 'get_supported_function_arguments works (C)')
-multi_check = cpp.get_supported_function_attributes(attributes)
-assert(multi_check == multi_expected, 'get_supported_function_arguments works (C++)')
+  multi_check = c.get_supported_function_attributes(attributes)
+  assert(multi_check == multi_expected, 'get_supported_function_arguments works (C)')
+  multi_check = cpp.get_supported_function_attributes(attributes)
+  assert(multi_check == multi_expected, 'get_supported_function_arguments works (C++)')
+endif

--- a/test cases/common/203 function attributes/meson_options.txt
+++ b/test cases/common/203 function attributes/meson_options.txt
@@ -1,0 +1,7 @@
+option(
+    'mode',
+    type : 'combo',
+    choices : ['single', 'parallel'],
+    value : 'single',
+    description : 'Test the one at a time function or many at a time function.'
+)

--- a/test cases/common/203 function attributes/test.json
+++ b/test cases/common/203 function attributes/test.json
@@ -1,0 +1,10 @@
+{
+  "matrix": {
+    "options": {
+      "mode": [
+        { "val": "single" },
+        { "val": "parallel" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Which has changed the way it handles gnu_inline in C++.