### PR TITLE
compilers: Silence warning about gnu_inline with clang

### DIFF
--- a/mesonbuild/compilers/c_function_attributes.py
+++ b/mesonbuild/compilers/c_function_attributes.py
@@ -127,7 +127,4 @@ CXX_FUNC_ATTRIBUTES = {
          'static int (*resolve_foo(void))(void) { return my_foo; }'
          '}'
          'int foo(void) __attribute__((ifunc("resolve_foo")));'),
-    # Clang >= 10 requires the 'extern' keyword
-    'gnu_inline':
-        'extern inline __attribute__((gnu_inline)) int foo(void) { return 0; }',
 }

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -112,3 +112,8 @@ class ClangCompiler(GnuLikeCompiler):
                     'Cannot find linker {}.'.format(linker))
             return ['-fuse-ld={}'.format(linker)]
         return super().use_linker_args(linker)
+
+    def get_has_func_attribute_extra_args(self, name):
+        # Clang only warns about unknown or ignored attributes, so force an
+        # error.
+        return ['-Werror=attributes']

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -1115,6 +1115,12 @@ class CLikeCompiler:
             m = pattern.match(ret)
         return ret
 
+    def get_has_func_attribute_extra_args(self, name):
+        # Most compilers (such as GCC and Clang) only warn about unknown or
+        # ignored attributes, so force an error. Overriden in GCC and Clang
+        # mixins.
+        return ['-Werror']
+
     def has_func_attribute(self, name, env):
         # Just assume that if we're not on windows that dllimport and dllexport
         # don't work
@@ -1123,6 +1129,5 @@ class CLikeCompiler:
             if name in ['dllimport', 'dllexport']:
                 return False, False
 
-        # Clang and GCC both return warnings if the __attribute__ is undefined,
-        # so set -Werror
-        return self.compiles(self.attribute_check_func(name), env, extra_args='-Werror')
+        return self.compiles(self.attribute_check_func(name), env,
+                             extra_args=self.get_has_func_attribute_extra_args(name))

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -369,3 +369,8 @@ class GnuCompiler(GnuLikeCompiler):
             if self.language in {'c', 'objc'} and 'is valid for C++/ObjC++' in p.stde:
                 result = False
         return result, p.cached
+
+    def get_has_func_attribute_extra_args(self, name):
+        # GCC only warns about unknown or ignored attributes, so force an
+        # error.
+        return ['-Werror=attributes']


### PR DESCRIPTION
The warning is due to a change in behaviour in Clang 10 and newer:

https://releases.llvm.org/10.0.0/tools/clang/docs/ReleaseNotes.html#c-language-changes-in-clang

This was already fixed for clang++, but not for clang for some reason. It was also fixed incorrectly; by adding `extern` instead of moving from `-Werror` to `-Werror=attributes`.

Should fix the remaining failure in the CI (msys2 clangx64ninja):

```
Compiler stderr:
 D:\a\1\s\b 14fe268f30\meson-private\tmplco6n27n\testfile.cpp:1:23: error: 'gnu_inline' attribute without 'extern' in C++ treated as externally available, this changed in Clang 10 [-Werror,-Wgnu-inline-cpp-without-extern]
inline __attribute__((gnu_inline)) int foo(void) { return 0; }
                      ^
1 error generated.

Compiler for C++ supports function attribute gnu_inline: NO 

test cases\common\203 function attributes\meson.build:90:2: ERROR: Assert failed: clang: gnu_inline
```