### PR TITLE
gtkdochelper.py: Allow use on Windows cmd.exe consoles

### DIFF
--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -59,6 +59,7 @@ def gtkdoc_run_check(cmd, cwd, library_paths=None):
         if 'PATH' in env:
             library_paths.extend(env['PATH'].split(os.pathsep))
         env['PATH'] = os.pathsep.join(library_paths)
+        cmd.insert(0, sys.executable)
     else:
         if 'LD_LIBRARY_PATH' in env:
             library_paths.extend(env['LD_LIBRARY_PATH'].split(os.pathsep))

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -74,7 +74,14 @@ def gtkdoc_run_check(cmd, cwd, library_paths=None):
             err_msg.append(out)
         raise MesonException('\n'.join(err_msg))
     elif out:
-        print(out)
+        # Unfortunately Windows cmd.exe consoles may be using a codepage
+        # that might choke print() with a UnicodeEncodeError, so let's
+        # ignore such errors for now, as a compromise as we are outputting
+        # console output here...
+        try:
+            print(out)
+        except UnicodeEncodeError:
+            pass
 
 def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
                  main_file, module, module_version,


### PR DESCRIPTION
Hi,

This attempts to update gtkdochelper.py so that we might be able to use it to generate gtk-doc documentation on cmd.exe consoles (i.e. for Visual Studio builds).

This attempts to do so by:

*  Prepend the python executable in the command line to call the various gtk-doc tool scripts on Windows, since cmd.exe consoles do not support shebang lines.

* (suggestions welcome) The print() line at line 77 could choke with ```UnicodeEncodeError``` as Windows cmd.exe consoles may not be in a code page that does this encoding well.  Work around this by just ignoring this error.  Interestingly, if there is an error while running the tool scripts, the error output does work as expected.

With blessings, thank you!