### PR TITLE
find_program: Fixes when the program has been overriden by executable

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1846,7 +1846,9 @@ the following methods.
   specifies that whenever `find_program` is used to find a program
   named `progname`, Meson should not look it up on the system but
   instead return `program`, which may either be the result of
-  `find_program`, `configure_file` or `executable`.
+  `find_program`, `configure_file` or `executable`. *Since 0.55.0* if a version
+  check is passed to `find_program` for a program that has been overridden with
+  an executable, the current project version is used.
 
   If `program` is an `executable`, it cannot be used during configure.
 
@@ -2460,6 +2462,12 @@ and has the following methods:
 - `path()` which returns a string pointing to the script or executable
   **NOTE:** You should not need to use this method. Passing the object
   itself should work in all cases. For example: `run_command(obj, arg1, arg2)`
+  *Since 0.55.0* this method has been deprecated in favor of `full_path()` for
+  consistency with other returned objects.
+
+- `full_path()` *Since 0.55.0* which returns a string pointing to the script or
+  executable **NOTE:** You should not need to use this method. Passing the object
+  itself should work in all cases. For example: `run_command(obj, arg1, arg2)`.
 
 ### `environment` object
 

--- a/docs/markdown/snippets/find_program.md
+++ b/docs/markdown/snippets/find_program.md
@@ -1,0 +1,20 @@
+## find_program: Fixes when the program has been overridden by executable
+
+When a program has been overridden by an executable, the returned object of
+find_program() had some issues:
+
+```meson
+# In a subproject:
+exe = executable('foo', ...)
+meson.override_find_program('foo', exe)
+
+# In main project:
+# The version check was crashing meson.
+prog = find_program('foo', version : '>=1.0')
+
+# This was crashing meson.
+message(prog.path())
+
+# New method to be consistent with built objects.
+message(prog.full_path())
+```

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -285,7 +285,7 @@ print (json.dumps ({
 
 class PythonInstallation(ExternalProgramHolder):
     def __init__(self, interpreter, python, info):
-        ExternalProgramHolder.__init__(self, python)
+        ExternalProgramHolder.__init__(self, python, interpreter.subproject)
         self.interpreter = interpreter
         self.subproject = self.interpreter.subproject
         prefix = self.interpreter.environment.coredata.get_builtin_option('prefix')
@@ -514,7 +514,7 @@ class PythonModule(ExtensionModule):
 
         if disabled:
             mlog.log('Program', name_or_path or 'python', 'found:', mlog.red('NO'), '(disabled by:', mlog.bold(feature), ')')
-            return ExternalProgramHolder(NonExistingExternalProgram())
+            return ExternalProgramHolder(NonExistingExternalProgram(), state.subproject)
 
         if not name_or_path:
             python = ExternalProgram('python3', mesonlib.python_command, silent=True)
@@ -561,11 +561,11 @@ class PythonModule(ExtensionModule):
         if not python.found():
             if required:
                 raise mesonlib.MesonException('{} not found'.format(name_or_path or 'python'))
-            res = ExternalProgramHolder(NonExistingExternalProgram())
+            res = ExternalProgramHolder(NonExistingExternalProgram(), state.subproject)
         elif missing_modules:
             if required:
                 raise mesonlib.MesonException('{} is missing modules: {}'.format(name_or_path or 'python', ', '.join(missing_modules)))
-            res = ExternalProgramHolder(NonExistingExternalProgram())
+            res = ExternalProgramHolder(NonExistingExternalProgram(), state.subproject)
         else:
             # Sanity check, we expect to have something that at least quacks in tune
             try:
@@ -583,7 +583,7 @@ class PythonModule(ExtensionModule):
             if isinstance(info, dict) and 'version' in info and self._check_version(name_or_path, info['version']):
                 res = PythonInstallation(interpreter, python, info)
             else:
-                res = ExternalProgramHolder(NonExistingExternalProgram())
+                res = ExternalProgramHolder(NonExistingExternalProgram(), state.subproject)
                 if required:
                     raise mesonlib.MesonException('{} is not a valid python or it is missing setuptools'.format(python))
 

--- a/test cases/common/201 override with exe/meson.build
+++ b/test cases/common/201 override with exe/meson.build
@@ -1,6 +1,10 @@
 project('myexe', 'c')
 sub = subproject('sub')
-prog = find_program('foobar')
+
+prog = find_program('foobar', version : '>= 2.0', required : false)
+assert(not prog.found())
+
+prog = find_program('foobar', version : '>= 1.0')
 custom1 = custom_target('custom1',
                         build_by_default : true,
                         input : [],
@@ -10,6 +14,8 @@ gen = generator(prog,
                 output : '@BASENAME@.c',
                 arguments : ['@OUTPUT@'])
 custom2 = gen.process('main2.input')
+
+message(prog.full_path())
 
 executable('e1', custom1)
 executable('e2', custom2)

--- a/test cases/common/201 override with exe/subprojects/sub/meson.build
+++ b/test cases/common/201 override with exe/subprojects/sub/meson.build
@@ -1,3 +1,3 @@
-project('sub', 'c')
+project('sub', 'c', version : '1.0')
 foobar = executable('foobar', 'foobar.c',  native : true)
 meson.override_find_program('foobar', foobar)


### PR DESCRIPTION
- ExternalProgramHolder has path() method while CustomTargetHolder and
  BuildTargetHolder have full_path().
- The returned ExternalProgramHolder's path() method was broken, because
  build.Executable object has no get_path() method, it needs the
  backend.
- find_program('overriden_prog', version : '>=1.0') was broken because
  it needs to execute the exe that is not yet built. Now assume the
  program has the (sub)project version.
- If the version check fails, interpreter uses
  ExternalProgramHolder.get_name() for the error message but
  build.Executable does not implement get_name() method.