### PR TITLE
Document formal Meson grammar

### DIFF
--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -603,40 +603,37 @@ assignment_expr: conditional_expr | (logical_or_expr assignment_op assignment_ex
 assignment_op: "=" | "*=" | "/=" | "%=" | "+=" | "-="
 boolean_literal: "true" | "false"
 call_expr: function_expr | method_expr
-char_seq: (string_char)* // TODO escapes,unicode
 condition: conditional_expr // TODO classic way would be condition = expression, but we cannot have assignments in conditions. Should that be covered by the grammar (syntax) or not
 conditional_expr: logical_or_expr | (logical_or_expr "?" expr ":" assignment_expr
-decimal_literal: nonzero_digit | (decimal_literal digit)
+decimal_literal: DECIMAL_NUMBER
+DECIMAL_NUMBER: /[1-9][0-9]*/
 dictionary_literal: "{" kv_pair_list "}"
-digit: DIGIT
 equality_expr: relational_expr | (equality_expr equality_op relational_expr)
 equality_op: "==" | "!="
 expr: assignment_expr
 expr_list: assignment_expr | (expr_list "," assignment_expr)
 expression_stmt: expr
-function_expr: identifier "(" parameter_list ")" // TODO actually, it is allowed to call a function like this (func)(param), but its still not a primary expression, because a function name cannot be a literal
-hex_digit: HEX_DIGIT
-hex_literal: "0x" (hex_digit)*
-id_expr: identifier
-identifier: nondigit | (identifier nondigit) | (identifier digit)
-identifier_list: identifier | (identifier_list "," identifier)
+function_expr: id_expr "(" parameter_list ")" // TODO actually, it is allowed to call a function like this (func)(param), but its still not a primary expression, because a function name cannot be a literal
+hex_literal: "0x" HEX_NUMBER
+HEX_NUMBER: /[a-fA-F0-9]+/
+id_expr: IDENTIFIER
+IDENTIFIER: /[a-zA-Z_][a-zA-Z_0-9]*/
+identifier_list: id_expr | (identifier_list "," id_expr)
 integer_literal: decimal_literal | octal_literal | hex_literal
-iteration_stmt: "foreach" identifier_list ":" identifier NEWLINE (stmt | jump_stmt)* "endforeach"
+iteration_stmt: "foreach" identifier_list ":" id_expr NEWLINE (stmt | jump_stmt)* "endforeach"
 jump_stmt: "break" | "continue"
 key_value_pair: expr ":" expr // TODO not any expression though. value could be conditional_expr, key could be additive_expr (because of string concatenation)
 kv_pair_list: key_value_pair | (kv_pair_list "," key_value_pair)
-kwarg: identifier ":" expr
+kwarg: id_expr ":" expr
 kwarg_list: kwarg | (kwarg_list "," kwarg)
-literal: integer_literal | character_literal | string_literal | boolean_literal | array_literal | dictionary_literal
+literal: integer_literal | string_literal | boolean_literal | array_literal | dictionary_literal
 logical_and_expr: equality_expr | (logical_and_expr "and" equality_expr)
 logical_or_expr: logical_and_expr | (logical_or_expr "or" logical_and_expr)
 method_expr: primary_expr "." function_expr
 multiplicative_expr: unary_expr | (multiplicative_expr multiplicative_op unary_expr)
 multiplicative_op: "*" | "/" | "%"
-nondigit: ALPHA_CHARACTER | "_"
-nonzero_digit: NON_ZERO_DIGIT
-octal_digit: OCTAL_DIGIT
-octal_literal: "0o" (octal_digit)*
+octal_literal: "0o" OCTAL_NUMBER
+OCTAL_NUMBER: /[0-7]+/
 parameter_list: [arg_list] | [kwarg_list] | (arg_list "," kwarg_list) // TODO could be more concise
 postfix_expr: primary_expr | subscript_expr | call_expr
 primary_expr: literal | ("(" expr ")") | id_expr
@@ -645,8 +642,10 @@ relational_expr: additive_expr | (relational_expr relational_op additive_expr)
 relational_op: ">" | "<" | ">=" | "<=" | "in" | ("not" "in")
 selection_stmt: "if" condition NEWLINE (stmt)* ("elif" condition NEWLINE (stmt)*)* ["else" (stmt)*] "endif"
 stmt: (expression_stmt | selection_stmt | iteration_stmt) NEWLINE
-string_literal: ("'" char_seq "'") | ("'''" char_seq "'''")
-subscript_expr: identifier "[" expr "]" // TODO not sure about the expr as index here
+string_literal: ("'" STRING_SIMPLE_VALUE "'") | ("'''" STRING_MULTILINE_VALUE "'''")
+STRING_MULTILINE_VALUE: \.*?(''')\
+STRING_SIMPLE_VALUE: \.*?(?<!\\)(\\\\)*?'\
+subscript_expr: id_expr "[" expr "]" // TODO not sure about the expr as index here // TODO could be func()[1] too if func returns array?
 unary_expr: postfix_expr | (unary_op unary_expr)
 unary_op: "not" | "+" | "-"
 ```

--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -597,7 +597,7 @@ This is the full Meson grammar, as it is used to parse Meson build definition fi
 ```
 additive_expr: multiplicative_expr | (additive_expr additive_op multiplicative_expr)
 additive_op: "+" | "-"
-arg_list: expr_list
+argument_list: positional_arguments ["," keyword_arguments] | keyword_arguments
 array_literal: "[" expr_list "]"
 assignment_expr: conditional_expr | (logical_or_expr assignment_op assignment_expr)
 assignment_op: "=" | "*=" | "/=" | "%=" | "+=" | "-="
@@ -612,7 +612,7 @@ equality_op: "==" | "!="
 expr: assignment_expr
 expr_list: assignment_expr | (expr_list "," assignment_expr)
 expression_stmt: expr
-function_expr: id_expr "(" parameter_list ")"
+function_expr: id_expr "(" [argument_list] ")"
 hex_literal: "0x" HEX_NUMBER
 HEX_NUMBER: /[a-fA-F0-9]+/
 id_expr: IDENTIFIER
@@ -622,9 +622,9 @@ integer_literal: decimal_literal | octal_literal | hex_literal
 iteration_stmt: "foreach" identifier_list ":" id_expr NEWLINE (stmt | jump_stmt)* "endforeach"
 jump_stmt: "break" | "continue"
 key_value_pair: expr ":" expr
+keyword_item: id_expr ":" expr
+keyword_arguments: keyword_item ("," keyword_item)*
 kv_pair_list: key_value_pair | (kv_pair_list "," key_value_pair)
-kwarg: id_expr ":" expr
-kwarg_list: kwarg | (kwarg_list "," kwarg)
 literal: integer_literal | string_literal | boolean_literal | array_literal | dictionary_literal
 logical_and_expr: equality_expr | (logical_and_expr "and" equality_expr)
 logical_or_expr: logical_and_expr | (logical_or_expr "or" logical_and_expr)
@@ -633,7 +633,7 @@ multiplicative_expr: unary_expr | (multiplicative_expr multiplicative_op unary_e
 multiplicative_op: "*" | "/" | "%"
 octal_literal: "0o" OCTAL_NUMBER
 OCTAL_NUMBER: /[0-7]+/
-parameter_list: [arg_list] | [kwarg_list] | (arg_list "," kwarg_list) // TODO could be more concise
+positional_arguments: expr ("," expr)*
 postfix_expr: primary_expr | subscript_expr | function_expr | method_expr
 primary_expr: literal | ("(" expr ")") | id_expr
 program: (NEWLINE | stmt)*

--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -629,10 +629,9 @@ kwarg: identifier ":" expr
 kwarg_list: kwarg | (kwarg_list "," kwarg)
 literal: integer_literal | character_literal | string_literal | boolean_literal | array_literal | dictionary_literal
 logical_and_expr: equality_expr | (logical_and_expr "and" equality_expr)
-logical_not_expr: postfix_expr | ("not" logical_not_expr)
 logical_or_expr: logical_and_expr | (logical_or_expr "or" logical_and_expr)
 method_expr: primary_expr "." function_expr
-multiplicative_expr: logical_not_expr | (multiplicative_expr multiplicative_op logical_not_expr)
+multiplicative_expr: unary_expr | (multiplicative_expr multiplicative_op unary_expr)
 multiplicative_op: "*" | "/" | "%"
 nondigit: ALPHA_CHARACTER | "_"
 nonzero_digit: NON_ZERO_DIGIT
@@ -648,4 +647,6 @@ selection_stmt: "if" condition NEWLINE (stmt)* ("elif" condition NEWLINE (stmt)*
 stmt: (expression_stmt | selection_stmt | iteration_stmt) NEWLINE
 string_literal: "'" char_seq "'" // TODO multiline strings
 subscript_expr: identifier "[" expr "]" // TODO not sure about the expr as index here
+unary_expr: postfix_expr | (unary_op unary_expr)
+unary_op: "not" | "+" | "-"
 ```

--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -645,7 +645,7 @@ relational_expr: additive_expr | (relational_expr relational_op additive_expr)
 relational_op: ">" | "<" | ">=" | "<=" | "in" | ("not" "in")
 selection_stmt: "if" condition NEWLINE (stmt)* ("elif" condition NEWLINE (stmt)*)* ["else" (stmt)*] "endif"
 stmt: (expression_stmt | selection_stmt | iteration_stmt) NEWLINE
-string_literal: "'" char_seq "'" // TODO multiline strings
+string_literal: ("'" char_seq "'") | ("'''" char_seq "'''")
 subscript_expr: identifier "[" expr "]" // TODO not sure about the expr as index here
 unary_expr: postfix_expr | (unary_op unary_expr)
 unary_op: "not" | "+" | "-"

--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -602,8 +602,7 @@ array_literal: "[" expr_list "]"
 assignment_expr: conditional_expr | (logical_or_expr assignment_op assignment_expr)
 assignment_op: "=" | "*=" | "/=" | "%=" | "+=" | "-="
 boolean_literal: "true" | "false"
-call_expr: function_expr | method_expr
-condition: conditional_expr // TODO classic way would be condition = expression, but we cannot have assignments in conditions. Should that be covered by the grammar (syntax) or not
+condition: expr
 conditional_expr: logical_or_expr | (logical_or_expr "?" expr ":" assignment_expr
 decimal_literal: DECIMAL_NUMBER
 DECIMAL_NUMBER: /[1-9][0-9]*/
@@ -613,7 +612,7 @@ equality_op: "==" | "!="
 expr: assignment_expr
 expr_list: assignment_expr | (expr_list "," assignment_expr)
 expression_stmt: expr
-function_expr: id_expr "(" parameter_list ")" // TODO actually, it is allowed to call a function like this (func)(param), but its still not a primary expression, because a function name cannot be a literal
+function_expr: id_expr "(" parameter_list ")"
 hex_literal: "0x" HEX_NUMBER
 HEX_NUMBER: /[a-fA-F0-9]+/
 id_expr: IDENTIFIER
@@ -622,20 +621,20 @@ identifier_list: id_expr | (identifier_list "," id_expr)
 integer_literal: decimal_literal | octal_literal | hex_literal
 iteration_stmt: "foreach" identifier_list ":" id_expr NEWLINE (stmt | jump_stmt)* "endforeach"
 jump_stmt: "break" | "continue"
-key_value_pair: expr ":" expr // TODO not any expression though. value could be conditional_expr, key could be additive_expr (because of string concatenation)
+key_value_pair: expr ":" expr
 kv_pair_list: key_value_pair | (kv_pair_list "," key_value_pair)
 kwarg: id_expr ":" expr
 kwarg_list: kwarg | (kwarg_list "," kwarg)
 literal: integer_literal | string_literal | boolean_literal | array_literal | dictionary_literal
 logical_and_expr: equality_expr | (logical_and_expr "and" equality_expr)
 logical_or_expr: logical_and_expr | (logical_or_expr "or" logical_and_expr)
-method_expr: primary_expr "." function_expr
+method_expr: postfix_expr "." function_expr
 multiplicative_expr: unary_expr | (multiplicative_expr multiplicative_op unary_expr)
 multiplicative_op: "*" | "/" | "%"
 octal_literal: "0o" OCTAL_NUMBER
 OCTAL_NUMBER: /[0-7]+/
 parameter_list: [arg_list] | [kwarg_list] | (arg_list "," kwarg_list) // TODO could be more concise
-postfix_expr: primary_expr | subscript_expr | call_expr
+postfix_expr: primary_expr | subscript_expr | function_expr | method_expr
 primary_expr: literal | ("(" expr ")") | id_expr
 program: (NEWLINE | stmt)*
 relational_expr: additive_expr | (relational_expr relational_op additive_expr)
@@ -645,7 +644,7 @@ stmt: (expression_stmt | selection_stmt | iteration_stmt) NEWLINE
 string_literal: ("'" STRING_SIMPLE_VALUE "'") | ("'''" STRING_MULTILINE_VALUE "'''")
 STRING_MULTILINE_VALUE: \.*?(''')\
 STRING_SIMPLE_VALUE: \.*?(?<!\\)(\\\\)*?'\
-subscript_expr: id_expr "[" expr "]" // TODO not sure about the expr as index here // TODO could be func()[1] too if func returns array?
+subscript_expr: postfix_expr "[" expr "]"
 unary_expr: postfix_expr | (unary_op unary_expr)
 unary_op: "not" | "+" | "-"
 ```

--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -595,56 +595,56 @@ Grammar
 This is the full Meson grammar, as it is used to parse Meson build definition files:
 
 ```
-additive_expr: multiplicative_expr | (additive_expr additive_op multiplicative_expr)
-additive_op: "+" | "-"
+additive_expression: multiplicative_expression | (additive_expression additive_operator multiplicative_expression)
+additive_operator: "+" | "-"
 argument_list: positional_arguments ["," keyword_arguments] | keyword_arguments
-array_literal: "[" expr_list "]"
-assignment_expr: conditional_expr | (logical_or_expr assignment_op assignment_expr)
-assignment_op: "=" | "*=" | "/=" | "%=" | "+=" | "-="
+array_literal: "[" [expression_list] "]"
+assignment_expression: conditional_expression | (logical_or_expression assignment_operator assignment_expression)
+assignment_operator: "=" | "*=" | "/=" | "%=" | "+=" | "-="
 boolean_literal: "true" | "false"
-condition: expr
-conditional_expr: logical_or_expr | (logical_or_expr "?" expr ":" assignment_expr
+build_definition: (NEWLINE | statement)*
+condition: expression
+conditional_expression: logical_or_expression | (logical_or_expression "?" expression ":" assignment_expression
 decimal_literal: DECIMAL_NUMBER
 DECIMAL_NUMBER: /[1-9][0-9]*/
-dictionary_literal: "{" kv_pair_list "}"
-equality_expr: relational_expr | (equality_expr equality_op relational_expr)
-equality_op: "==" | "!="
-expr: assignment_expr
-expr_list: assignment_expr | (expr_list "," assignment_expr)
-expression_stmt: expr
-function_expr: id_expr "(" [argument_list] ")"
+dictionary_literal: "{" [key_value_list] "}"
+equality_expression: relational_expression | (equality_expression equality_operator relational_expression)
+equality_operator: "==" | "!="
+expression: assignment_expression
+expression_list: expression ("," expression)*
+expression_statememt: expression 
+function_expression: id_expression "(" [argument_list] ")"
 hex_literal: "0x" HEX_NUMBER
 HEX_NUMBER: /[a-fA-F0-9]+/
-id_expr: IDENTIFIER
+id_expression: IDENTIFIER
 IDENTIFIER: /[a-zA-Z_][a-zA-Z_0-9]*/
-identifier_list: id_expr | (identifier_list "," id_expr)
+identifier_list: id_expression ("," id_expression)*
 integer_literal: decimal_literal | octal_literal | hex_literal
-iteration_stmt: "foreach" identifier_list ":" id_expr NEWLINE (stmt | jump_stmt)* "endforeach"
-jump_stmt: "break" | "continue"
-key_value_pair: expr ":" expr
-keyword_item: id_expr ":" expr
+iteration_statement: "foreach" identifier_list ":" id_expression NEWLINE (statement | jump_statement)* "endforeach"
+jump_statement: ("break" | "continue") NEWLINE
+key_value_item: expression ":" expression
+key_value_list: key_value_item ("," key_value_item)*
+keyword_item: id_expression ":" expression
 keyword_arguments: keyword_item ("," keyword_item)*
-kv_pair_list: key_value_pair | (kv_pair_list "," key_value_pair)
 literal: integer_literal | string_literal | boolean_literal | array_literal | dictionary_literal
-logical_and_expr: equality_expr | (logical_and_expr "and" equality_expr)
-logical_or_expr: logical_and_expr | (logical_or_expr "or" logical_and_expr)
-method_expr: postfix_expr "." function_expr
-multiplicative_expr: unary_expr | (multiplicative_expr multiplicative_op unary_expr)
-multiplicative_op: "*" | "/" | "%"
+logical_and_expression: equality_expression | (logical_and_expression "and" equality_expression)
+logical_or_expression: logical_and_expression | (logical_or_expression "or" logical_and_expression)
+method_expression: postfix_expression "." function_expression
+multiplicative_expression: unary_expression | (multiplicative_expression multiplicative_operator unary_expression)
+multiplicative_operator: "*" | "/" | "%"
 octal_literal: "0o" OCTAL_NUMBER
 OCTAL_NUMBER: /[0-7]+/
-positional_arguments: expr ("," expr)*
-postfix_expr: primary_expr | subscript_expr | function_expr | method_expr
-primary_expr: literal | ("(" expr ")") | id_expr
-program: (NEWLINE | stmt)*
-relational_expr: additive_expr | (relational_expr relational_op additive_expr)
-relational_op: ">" | "<" | ">=" | "<=" | "in" | ("not" "in")
-selection_stmt: "if" condition NEWLINE (stmt)* ("elif" condition NEWLINE (stmt)*)* ["else" (stmt)*] "endif"
-stmt: (expression_stmt | selection_stmt | iteration_stmt) NEWLINE
+positional_arguments: expression ("," expression)*
+postfix_expression: primary_expression | subscript_expression | function_expression | method_expression
+primary_expression: literal | ("(" expression ")") | id_expression
+relational_expression: additive_expression | (relational_expression relational_operator additive_expression)
+relational_operator: ">" | "<" | ">=" | "<=" | "in" | ("not" "in")
+selection_statement: "if" condition NEWLINE (statement)* ("elif" condition NEWLINE (statement)*)* ["else" (statement)*] "endif"
+statement: (expression_statement | selection_statement | iteration_statement) NEWLINE
 string_literal: ("'" STRING_SIMPLE_VALUE "'") | ("'''" STRING_MULTILINE_VALUE "'''")
 STRING_MULTILINE_VALUE: \.*?(''')\
 STRING_SIMPLE_VALUE: \.*?(?<!\\)(\\\\)*?'\
-subscript_expr: postfix_expr "[" expr "]"
-unary_expr: postfix_expr | (unary_op unary_expr)
-unary_op: "not" | "+" | "-"
+subscript_expression: postfix_expression "[" expression "]"
+unary_expression: postfix_expression | (unary_operator unary_expression)
+unary_operator: "not" | "+" | "-"
 ```

--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -595,60 +595,57 @@ Grammar
 This is the full Meson grammar, as it is used to parse Meson build definition files:
 
 ```
-program = (NEWLINE | stmt)*
-stmt = (expression_stmt | selection_stmt | iteration_stmt) NEWLINE
-selection_stmt = 'if' condition NEWLINE (stmt)* ('elif' condition NEWLINE (stmt)*)* ['else' (stmt)*] 'endif'
-iteration_stmt = 'foreach' identifier_list ':' identifier NEWLINE (stmt | jump_stmt)* 'endforeach'
-condition = conditional_expr // TODO classic way would be condition = expression, but we can't have assignments in conditions. Should that be covered by the grammar (syntax) or not
-identifier_list = identifier | (identifier_list ',' identifier)
-jump_stmt = 'break' | 'continue'
-parameter_list = [arg_list] | [kwarg_list] | (arg_list ',' kwarg_list) // TODO could be more concise
-arg_list = expr_list
-kwarg = identifier ':' expr
-kwarg_list = kwarg | (kwarg_list ',' kwarg)
-key_value_pair = expr ':' expr // TODO not any expression though. value could be conditional_expr, key could be additive_expr (because of string concatenation)
-kv_pair_list = key_value_pair | (kv_pair_list ',' key_value_pair)
-expression_stmt = expr
-expr_list = assignment_expr | (expr_list ',' assignment_expr)
-expr = assignment_expr
-expr_list = assignment_expr | expression_list ',' assignment_expr // TODO currently unused, do we need it somewhere?
-assignment_expr = conditional_expr | (logical_or_expr assignment_op assignment_expr)
-assignment_op = '=' | '*=' | '/=' | '%=' | '+=' | '-='
-conditional_expr = logical_or_expr | (logical_or_expr '?' expr ':' assignment_expr
-logical_or_expr = logical_and_expr | (logical_or_expr 'or' logical_and_expr')
-// FIXME in between here would be xor, if we had it
-logical_and_expr = equality_expr | (logical_and_expr 'and' equality_expr)
-equality_expr = relational_expr | (equality_expr equality_op relational_expr)
-equality_op = '==' | '!='
-relational_expr = additive_expr | (relational_expr relational_op additive_expr)
-relational_op = '>' | '<' | '>=' | '<=' | 'in' | ('not' 'in')
-additive_expr = multiplicative_expr | (additive_expr additive_op multiplicative_expr)
-additive_op = '+' | '-'
-multiplicative_expr = logical_not_expr | (multiplicative_expr multiplicative_op logical_not_expr)
-multiplicative_op = '*' | '/' | '%'
-logical_not_expr = postfix_expr | ('not' logical_not_expr)
-postfix_expr = primary_expr | subscript_expr | call_expr
-subscript_expr = identifier '[' expr ']' // TODO not sure about the expr as index here
-call_expr = function_expr | method_expr
-function_expr = identifier '(' parameter_list ')' // TODO actually, it is allowed to call a function like this (func)(param), but its still not a primary expression, because a function name cannot be a literal
-method_expr = primary_expr '.' function_expr
-primary_expr = literal | ('(' expr ')') | id_expr
-id_expr = identifier
-parameter_list = arg_list
-identifier = nondigit | (identifier nondigit) | (identifier digit)
-nondigit = ALPHA_CHARACTER | '_'
-digit = DIGIT
-literal = integer_literal | character_literal | string_literal | boolean_literal | array_literal | dictionary_literal
-integer_literal = decimal_literal | octal_literal | hex_literal
-decimal_literal = nonzero_digit | (decimal_literal digit)
-nonzero_digit = NON_ZERO_DIGIT
-octal_literal = '0o' (octal_digit)*
-octal_digit = OCTAL_DIGIT
-hex_literal = '0x' (hex_digit)*
-hex_digit = HEX_DIGIT
-string_literal = "'" char_seq "'" // TODO multiline strings
-char_seq = (string_char)* // FIXME escapes
-boolean_literal = 'true' | 'false'
-array_literal = '[' expr_list ']' // TODO not assignment expressions unfortunately
-dictionary_literal = '{' kv_pair_list '}'
+additive_expr: multiplicative_expr | (additive_expr additive_op multiplicative_expr)
+additive_op: "+" | "-"
+arg_list: expr_list
+array_literal: "[" expr_list "]"
+assignment_expr: conditional_expr | (logical_or_expr assignment_op assignment_expr)
+assignment_op: "=" | "*=" | "/=" | "%=" | "+=" | "-="
+boolean_literal: "true" | "false"
+call_expr: function_expr | method_expr
+char_seq: (string_char)* // TODO escapes,unicode
+condition: conditional_expr // TODO classic way would be condition = expression, but we cannot have assignments in conditions. Should that be covered by the grammar (syntax) or not
+conditional_expr: logical_or_expr | (logical_or_expr "?" expr ":" assignment_expr
+decimal_literal: nonzero_digit | (decimal_literal digit)
+dictionary_literal: "{" kv_pair_list "}"
+digit: DIGIT
+equality_expr: relational_expr | (equality_expr equality_op relational_expr)
+equality_op: "==" | "!="
+expr: assignment_expr
+expr_list: assignment_expr | (expr_list "," assignment_expr)
+expression_stmt: expr
+function_expr: identifier "(" parameter_list ")" // TODO actually, it is allowed to call a function like this (func)(param), but its still not a primary expression, because a function name cannot be a literal
+hex_digit: HEX_DIGIT
+hex_literal: "0x" (hex_digit)*
+id_expr: identifier
+identifier: nondigit | (identifier nondigit) | (identifier digit)
+identifier_list: identifier | (identifier_list "," identifier)
+integer_literal: decimal_literal | octal_literal | hex_literal
+iteration_stmt: "foreach" identifier_list ":" identifier NEWLINE (stmt | jump_stmt)* "endforeach"
+jump_stmt: "break" | "continue"
+key_value_pair: expr ":" expr // TODO not any expression though. value could be conditional_expr, key could be additive_expr (because of string concatenation)
+kv_pair_list: key_value_pair | (kv_pair_list "," key_value_pair)
+kwarg: identifier ":" expr
+kwarg_list: kwarg | (kwarg_list "," kwarg)
+literal: integer_literal | character_literal | string_literal | boolean_literal | array_literal | dictionary_literal
+logical_and_expr: equality_expr | (logical_and_expr "and" equality_expr)
+logical_not_expr: postfix_expr | ("not" logical_not_expr)
+logical_or_expr: logical_and_expr | (logical_or_expr "or" logical_and_expr)
+method_expr: primary_expr "." function_expr
+multiplicative_expr: logical_not_expr | (multiplicative_expr multiplicative_op logical_not_expr)
+multiplicative_op: "*" | "/" | "%"
+nondigit: ALPHA_CHARACTER | "_"
+nonzero_digit: NON_ZERO_DIGIT
+octal_digit: OCTAL_DIGIT
+octal_literal: "0o" (octal_digit)*
+parameter_list: [arg_list] | [kwarg_list] | (arg_list "," kwarg_list) // TODO could be more concise
+postfix_expr: primary_expr | subscript_expr | call_expr
+primary_expr: literal | ("(" expr ")") | id_expr
+program: (NEWLINE | stmt)*
+relational_expr: additive_expr | (relational_expr relational_op additive_expr)
+relational_op: ">" | "<" | ">=" | "<=" | "in" | ("not" "in")
+selection_stmt: "if" condition NEWLINE (stmt)* ("elif" condition NEWLINE (stmt)*)* ["else" (stmt)*] "endif"
+stmt: (expression_stmt | selection_stmt | iteration_stmt) NEWLINE
+string_literal: "'" char_seq "'" // TODO multiline strings
+subscript_expr: identifier "[" expr "]" // TODO not sure about the expr as index here
 ```

--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -589,6 +589,16 @@ because of this limitation you find yourself copying and pasting code
 a lot you may be able to use a [`foreach` loop
 instead](#foreach-statements).
 
+Stability Promises
+--
+
+Meson is very actively developed and continuously improved. There is a
+possibility that future enhancements to the Meson build system will require
+changes to the syntax. Such changes might be the addition of new reserved
+keywords, changing the meaning of existing keywords or additions around the
+basic building blocks like statements and fundamental types. It is planned
+to stabilize the syntax with the 1.0 release.
+
 Grammar
 --
 


### PR DESCRIPTION
My main motivation for this is that I wanted to lookup Meson grammar to use something similar for my own DSL project, but there was no formal definition to be found. I argue having such a formal definition could prove useful in the future as a reference when working on the parser component.

This is all still WIP, but I wanted to share the current status with you here to hopefully get some early feedback.

The grammar is expressed in EBNF, but I found there is no universally agreed upon syntax for EBNF, so here the same syntax Python uses for its grammar description is used.

Expression precedence was taken from C++ and I'm 99% sure that the same precedence rules apply in Meson, but that is a thing I have to check conclusively.

Most of the TODOs and FIXMEs are more hints to me, and will hopefully soon disappear, but if someone wants to voice his opinion on certain questions I'm happy for the input.