### PR TITLE
Issue: 7009: CMake/Centos7 Unable to find CMake even though it is installed

### DIFF
--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -132,7 +132,7 @@ class CMakeExecutor:
                 msg += '\n\nOn Unix-like systems this is often caused by scripts that are not executable.'
             mlog.warning(msg)
             return None
-        cmvers = re.sub(r'\s*cmake version\s*', '', out.split('\n')[0]).strip()
+        cmvers = re.sub(r'\s*(cmake|cmake3) version\s*', '', out.split('\n')[0]).strip()
         return cmvers
 
     def set_exec_mode(self, print_cmout: T.Optional[bool] = None, always_capture_stderr: T.Optional[bool] = None) -> None:


### PR DESCRIPTION
On some systems the binary 'cmake' for version 3 is named 'cmake3',
therefor printing its version number prints:
'cmake3 version X.Y.Z' instead of 'cmake version X.Y.Z'
This '3' digit in the middle breaks the regular expression
extracting the version number.

The following fix permit both way to work and the regexp to
match the proper version number.

Signed-off-by: Alexandre Lavigne <alexandre.lavigne@scality.com>