### PR TITLE
dependency: log cached or skipped dependencies with reference to modules

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3406,7 +3406,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         display_name = name if name else '(anonymous)'
         mods = extract_as_list(kwargs, 'modules')
         if mods:
-            display_name += ' (modules: {})'.format(', '.join(mods))
+            display_name += ' (modules: {})'.format(', '.join(str(i) for i in mods))
         not_found_message = kwargs.get('not_found_message', '')
         if not isinstance(not_found_message, str):
             raise InvalidArguments('The not_found_message must be a string.')

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3261,7 +3261,7 @@ external dependencies (including libraries) must go to "dependencies".''')
                           'Look here for example: http://mesonbuild.com/howtox.html#add-math-library-lm-portably\n'
                           )
 
-    def _find_cached_dep(self, name, kwargs):
+    def _find_cached_dep(self, name, display_name, kwargs):
         # Check if we want this as a build-time / build machine or runt-time /
         # host machine dep.
         for_machine = self.machine_from_native_kwarg(kwargs)
@@ -3276,7 +3276,7 @@ external dependencies (including libraries) must go to "dependencies".''')
             # have explicitly called meson.override_dependency() with a not-found
             # dep.
             if not cached_dep.found():
-                mlog.log('Dependency', mlog.bold(name),
+                mlog.log('Dependency', mlog.bold(display_name),
                          'found:', mlog.red('NO'), *info)
                 return identifier, cached_dep
             found_vers = cached_dep.get_version()
@@ -3298,7 +3298,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         if cached_dep:
             if found_vers:
                 info = [mlog.normal_cyan(found_vers), *info]
-            mlog.log('Dependency', mlog.bold(name),
+            mlog.log('Dependency', mlog.bold(display_name),
                      'found:', mlog.green('YES'), *info)
             return identifier, cached_dep
 
@@ -3331,7 +3331,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         dep = self.notfound_dependency()
         try:
             subproject = self.subprojects[dirname]
-            _, cached_dep = self._find_cached_dep(name, kwargs)
+            _, cached_dep = self._find_cached_dep(name, display_name, kwargs)
             if varname is None:
                 # Assuming the subproject overriden the dependency we want
                 if cached_dep:
@@ -3404,6 +3404,9 @@ external dependencies (including libraries) must go to "dependencies".''')
         self.validate_arguments(args, 1, [str])
         name = args[0]
         display_name = name if name else '(anonymous)'
+        mods = extract_as_list(kwargs, 'modules')
+        if mods:
+            display_name += ' (modules: {})'.format(', '.join(mods))
         not_found_message = kwargs.get('not_found_message', '')
         if not isinstance(not_found_message, str):
             raise InvalidArguments('The not_found_message must be a string.')
@@ -3445,7 +3448,7 @@ external dependencies (including libraries) must go to "dependencies".''')
             raise InvalidArguments('Characters <, > and = are forbidden in dependency names. To specify'
                                    'version\n requirements use the \'version\' keyword argument instead.')
 
-        identifier, cached_dep = self._find_cached_dep(name, kwargs)
+        identifier, cached_dep = self._find_cached_dep(name, display_name, kwargs)
         if cached_dep:
             if has_fallback:
                 dirname, varname = self.get_subproject_infos(kwargs)


### PR DESCRIPTION
If the dependency is a special dependency which takes modules, the modules get cached separately and probably reference different pkg-config files. It's very plausible that we have multiple dependencies, using different modules. For example:

```
  Run-time dependency qt5 (modules: Core) found: YES 5.14.2 (pkg-config)
  Dependency qt5 skipped: feature gui disabled
```

Obviously this makes no sense, because of course we found qt5 and even used it. The second line is a lot more readable if it shows this:

```
  Dependency qt5 (modules: Widgets) skipped: feature gui disabled
```

Similar confusion abounds in the case where a module is found in the cache -- which module, exactly, has been found here:

```
  Dependency qt5 found: YES 5.14.2 (cached)
```

Rewrite the dependency function to *consistently* pass around (and use!) the display_name even in cases where we know it isn't anonymous (this is just more correct anyway), and make it serve a dual purpose by also appending the list of modules just like we do for pretty-printing that a dependency has just been found for the first time.