### PR TITLE
Adjust regex to handle cases such as C:/Program Files/

### DIFF
--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -655,7 +655,7 @@ class CMakeTraceParser:
 
         # Try joining file paths that contain spaces
 
-        reg_start = re.compile(r'^([A-Za-z]:)?/.*/[^./]+$')
+        reg_start = re.compile(r'^([A-Za-z]:)?/(.*/)*[^./]+$')
         reg_end = re.compile(r'^.*\.[a-zA-Z]+$')
 
         fixed_list = []  # type: T.List[str]


### PR DESCRIPTION
I noticed the existing reg_start pattern wouldn't allow the following case to pass:

['C:/Program', 'Files', '(x86)/folder/include']

The new reg_start allows for spaces in the first folder, or in the first folder after the drive.