### PR TITLE
Support VS /MP option to speed up Visual Studio builds

### DIFF
--- a/docs/markdown/Build-options.md
+++ b/docs/markdown/Build-options.md
@@ -218,6 +218,9 @@ project('my_project', 'c', default_options: ['backend_startup_project=my_exe'])
 executable('my_exe', ...)
 ```
 
+The backend\_multithreaded option can be set to set the "multi-processor
+compilation" (`/MP`) option for visual studio targets to speed up builds.
+
 ### Ninja
 
 #### Max links

--- a/docs/markdown/snippets/visualstudio_multithreading.md
+++ b/docs/markdown/snippets/visualstudio_multithreading.md
@@ -1,0 +1,5 @@
+## Visual Studio Multiprocessor Compilation support
+
+The `backend_multithreaded` option can now be set for Visual Studio backends
+to set the `/MP` flag, speeding up compilation for targets with a lot of
+source files. Defaults to true.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -552,6 +552,10 @@ class CoreData:
                 UserStringOption(
                     'Default project to execute in Visual Studio',
                     '')
+            self.backend_options['backend_multithreaded'] = \
+                UserBooleanOption(
+                    'Use /MP switch for multithreaded compilation with cl.exe',
+                    True)
 
     def get_builtin_option(self, optname: str, subproject: str = '') -> T.Union[str, int, bool]:
         raw_optname = optname


### PR DESCRIPTION
Adds a b_vsmp option which defaults to true (hopefully I did this right). When set, it adds /MP to the cl.exe command line used by Visual Studio (via the MultiProcessorCompilation vcxproj).

In order for this to actually work, we also need to not override the output filename for compiled objects. Unfortunately, this can introduce name collisions for files with the same name coming from separate directories. To avoid this, leave the filename as just the output directory *only* when the input file is in the same directory as the build. This is good enough for most cases.

This speeds up build times significantly in most cases, though in some, it can slow things down (hence the option), due to multi-process parallelism both at the project level *and* the file level, resulting in too many processes to make sufficient forward progress. This is a very uncommon problem.