### PR TITLE
Fix cross-compile in Windows with MSVC and UWP

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -98,6 +98,8 @@ def get_env_var_pair(for_machine: MachineChoice,
         # Always just the unprefixed host verions
         [var_name]
     )[for_machine]
+    if not candidates:
+        return None
     for var in candidates:
         value = os.environ.get(var)
         if value is not None:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -9008,18 +9008,16 @@ def convert_args(argv):
         pytest_args += ['-k', ' or '.join(test_list)]
     return pytest_args
 
+def running_a_single_test(argv, cases):
+    'Check whether we got an argument for running an individual test'
+    for arg in argv:
+        for case in cases:
+            if arg.startswith(case) and '.' in arg and case in arg.split('.'):
+                return True
+    return False
+
 def main():
     unset_envs()
-    try:
-        import pytest # noqa: F401
-        # Need pytest-xdist for `-n` arg
-        import xdist # noqa: F401
-        pytest_args = ['-n', 'auto', './run_unittests.py']
-        pytest_args += convert_args(sys.argv[1:])
-        return subprocess.run(python_command + ['-m', 'pytest'] + pytest_args).returncode
-    except ImportError:
-        print('pytest-xdist not found, using unittest instead')
-    # All attempts at locating pytest failed, fall back to plain unittest.
     cases = ['InternalTests', 'DataTests', 'AllPlatformTests', 'FailureTests',
              'PythonTests', 'NativeFileTests', 'RewriterTests', 'CrossFileTests',
              'TAPParserTests',
@@ -9027,6 +9025,19 @@ def main():
              'LinuxlikeTests', 'LinuxCrossArmTests', 'LinuxCrossMingwTests',
              'WindowsTests', 'DarwinTests']
 
+    # Don't use pytest-xdist when running a single unit test since it wastes
+    # time spawning a lot of processes to distribute tests to, just for one job
+    if not running_a_single_test(sys.argv, cases):
+        try:
+            import pytest # noqa: F401
+            # Need pytest-xdist for `-n` arg
+            import xdist # noqa: F401
+            pytest_args = ['-n', 'auto', './run_unittests.py']
+            pytest_args += convert_args(sys.argv[1:])
+            return subprocess.run(python_command + ['-m', 'pytest'] + pytest_args).returncode
+        except ImportError:
+            print('pytest-xdist not found, using unittest instead')
+    # Fallback to plain unittest.
     return unittest.main(defaultTest=cases, buffer=True)
 
 if __name__ == '__main__':


### PR DESCRIPTION
So, configuration without a native compiler was supposed to work according to the 0.54 release notes, but it doesn't actually work for mandatory compilers. It only works for optional compilers added with `add_languages()`. This fixes that, and also fixes a bug in linker detection with MSVC.

I'd like to get this into the stable point release if possible.

commit e2fe0b1132b5567d35e50617cf92c1f182a0a722:

```
Allow cross-compile without a native compiler
```

commit 4112c37fd3f5608f2e522b9bb5c7fc82397c2014:

```
windows linker: Only guess if we don't know target cpu_family
Unlike `cl.exe, MSVC `link.exe` has a 'default' target machine, and
the actual target machine can be selected with `/MACHINE:`. The
'default' is `X86` if you use the x86 native or cross toolchain and
it's `X64` if you use the x64 native or cross toolchain.

So, if you call `vcvarsall.bat x86_arm64` which is the x86 cross
toolchain for arm64, `link.exe` will default to `X86`, not `ARM64`.
It has to be selected by the build system by passing `/MACHINE:ARM64`

So that's what we do now. In the native build case when a native file
is not passed, the auto-detect will always be correct, and in the
cross build case we will always know the `cpu_family`, so this fixes
it for all cases.
```

commit a54397746a1fb9c47ade7be8f47380606d5495aa:

```
envconfig: Don't log a useless message
When there's no env var candidates to check, we print a useless
message into the log.
```
