### PR TITLE
compilers: darwin_get_object_archs: fix type issue

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -919,7 +919,7 @@ class CLikeCompiler:
         for f in files:
             if not f.is_file():
                 continue
-            archs = mesonlib.darwin_get_object_archs(f)
+            archs = mesonlib.darwin_get_object_archs(str(f))
             if archs and env.machines.host.cpu_family in archs:
                 return f
             else:


### PR DESCRIPTION
`mesonlib.darwin_get_object_archs()` only accepts a string argument so convert it.

This is a showstopper on macOS because the call in `darwin_get_object_archs()` to [`Popen_safe`](https://github.com/mesonbuild/meson/blob/a33f20b9a4e2e0ecf08f251be290bffd0d31a92d/mesonbuild/mesonlib.py#L531) then fails with a `TypeError`.