### PR TITLE
compilers: convert unix include directory arg to msvc format

### DIFF
--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -246,6 +246,8 @@ class VisualStudioLikeCompiler(metaclass=abc.ABCMeta):
                 else:
                     i = '/I' + i[10:]
             # -pthread in link flags is only used on Linux
+            elif i.startswith('-I'):
+                result.append('/I' + i[2:])
             elif i == '-pthread':
                 continue
             result.append(i)


### PR DESCRIPTION
This change allows me to build gstreamer on windows using external dependency specified by .pc file.

cc @xclaesse 