### PR TITLE
Clarified error message for test().

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3761,7 +3761,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
 
     def add_test(self, node, args, kwargs, is_base_test):
         if len(args) != 2:
-            raise InterpreterException('test expects 2 arguments, {} given'.format(len(args))
+            raise InterpreterException('test expects 2 arguments, {} given'.format(len(args)))
         if not isinstance(args[0], str):
             raise InterpreterException('First argument of test must be a string.')
         exe = args[1]

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3761,7 +3761,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
 
     def add_test(self, node, args, kwargs, is_base_test):
         if len(args) != 2:
-            raise InterpreterException(r'test expects 2 arguments, only {len(args)} given')
+            raise InterpreterException('test expects 2 arguments, {} given'.format(len(args))
         if not isinstance(args[0], str):
             raise InterpreterException('First argument of test must be a string.')
         exe = args[1]

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3761,7 +3761,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
 
     def add_test(self, node, args, kwargs, is_base_test):
         if len(args) != 2:
-            raise InterpreterException('Incorrect number of arguments')
+            raise InterpreterException(r'test expects 2 arguments, only {len(args)} given')
         if not isinstance(args[0], str):
             raise InterpreterException('First argument of test must be a string.')
         exe = args[1]


### PR DESCRIPTION
Potential fix for: https://github.com/mesonbuild/meson/issues/7029#issue-606367289

Changes the error message for  `test()` so it now reports the expected and actual number of parameters.