### PR TITLE
Fix symlink deletion with --wipe option

### DIFF
--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -86,7 +86,7 @@ class MesonApp:
                     # will cause a crash
                     for l in os.listdir(self.build_dir):
                         l = os.path.join(self.build_dir, l)
-                        if os.path.isdir(l):
+                        if os.path.isdir(l) and not os.path.islink(l):
                             mesonlib.windows_proof_rmtree(l)
                         else:
                             mesonlib.windows_proof_rm(l)


### PR DESCRIPTION
When wiping a build tree with --wipe, every entry in the build directory
is removed with mesonlib.windows_proof_rmtree() for directories and
mesonlib.windows_proof_rm() for other files. Symlinks to directories are
considered directories, resulting in the former being called. This
causes an exception to be raised, as the implementation calls
shutil.rmtree(), which isn't allowed on symlinks.

Fix this by using mesonlib.windows_proof_rm() for symlinks.

Signed-off-by: Laurent Pinchart <laurent.pinchart@ideasonboard.com>