### PR TITLE
Allow building with b_coverage set to true when clang is being used r…

### DIFF
--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -117,3 +117,6 @@ class ClangCompiler(GnuLikeCompiler):
         # Clang only warns about unknown or ignored attributes, so force an
         # error.
         return ['-Werror=attributes']
+
+    def get_coverage_link_args(self) -> T.List[str]:
+        return ['--coverage']


### PR DESCRIPTION
…egardless of linker selection.