### PR TITLE
Let .pc files provide rpaths.

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -59,12 +59,13 @@ class InstallData:
         self.mesonintrospect = mesonintrospect
 
 class TargetInstallData:
-    def __init__(self, fname, outdir, aliases, strip, install_name_mappings, install_rpath, install_mode, optional=False):
+    def __init__(self, fname, outdir, aliases, strip, install_name_mappings, build_rpath, install_rpath, install_mode, optional=False):
         self.fname = fname
         self.outdir = outdir
         self.aliases = aliases
         self.strip = strip
         self.install_name_mappings = install_name_mappings
+        self.build_rpath = build_rpath
         self.install_rpath = install_rpath
         self.install_mode = install_mode
         self.optional = optional
@@ -1109,7 +1110,7 @@ class Backend:
                     mappings = t.get_link_deps_mapping(d.prefix, self.environment)
                     i = TargetInstallData(self.get_target_filename(t), outdirs[0],
                                           t.get_aliases(), should_strip, mappings,
-                                          t.install_rpath, install_mode)
+                                          t.build_rpath, t.install_rpath, install_mode)
                     d.targets.append(i)
 
                     if isinstance(t, (build.SharedLibrary, build.SharedModule, build.Executable)):
@@ -1126,14 +1127,14 @@ class Backend:
                                 implib_install_dir = self.environment.get_import_lib_dir()
                             # Install the import library; may not exist for shared modules
                             i = TargetInstallData(self.get_target_filename_for_linking(t),
-                                                  implib_install_dir, {}, False, {}, '', install_mode,
+                                                  implib_install_dir, {}, False, {}, '', '', install_mode,
                                                   optional=isinstance(t, build.SharedModule))
                             d.targets.append(i)
 
                         if not should_strip and t.get_debug_filename():
                             debug_file = os.path.join(self.get_target_dir(t), t.get_debug_filename())
                             i = TargetInstallData(debug_file, outdirs[0],
-                                                  {}, False, {}, '',
+                                                  {}, False, {}, '', '',
                                                   install_mode, optional=True)
                             d.targets.append(i)
                 # Install secondary outputs. Only used for Vala right now.
@@ -1143,7 +1144,7 @@ class Backend:
                         if outdir is False:
                             continue
                         f = os.path.join(self.get_target_dir(t), output)
-                        i = TargetInstallData(f, outdir, {}, False, {}, None, install_mode)
+                        i = TargetInstallData(f, outdir, {}, False, {}, None, None, install_mode)
                         d.targets.append(i)
             elif isinstance(t, build.CustomTarget):
                 # If only one install_dir is specified, assume that all
@@ -1156,7 +1157,7 @@ class Backend:
                 if num_outdirs == 1 and num_out > 1:
                     for output in t.get_outputs():
                         f = os.path.join(self.get_target_dir(t), output)
-                        i = TargetInstallData(f, outdirs[0], {}, False, {}, None, install_mode,
+                        i = TargetInstallData(f, outdirs[0], {}, False, {}, None, None, install_mode,
                                               optional=not t.build_by_default)
                         d.targets.append(i)
                 else:
@@ -1165,7 +1166,7 @@ class Backend:
                         if outdir is False:
                             continue
                         f = os.path.join(self.get_target_dir(t), output)
-                        i = TargetInstallData(f, outdir, {}, False, {}, None, install_mode,
+                        i = TargetInstallData(f, outdir, {}, False, {}, None, None, install_mode,
                                               optional=not t.build_by_default)
                         d.targets.append(i)
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -810,7 +810,13 @@ class BuildTarget(Target):
     def get_link_dep_subdirs(self):
         result = OrderedSet()
         for i in self.link_targets:
-            result.add(i.get_subdir())
+            dir = i.get_subdir()
+            if dir:
+              # Mark this rpath entry as added by Meson for use during build,
+              # and to be removed by fix_rpathtype_entry() during install.
+              # ('test cases/fortran/6 dynamic' fails if done unconditionally?)
+              dir += '/./.'
+            result.add(dir)
             result.update(i.get_link_dep_subdirs())
         return result
 

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -563,7 +563,7 @@ class GnuLikeDynamicLinkerMixin:
         # Need to deduplicate rpaths, as macOS's install_name_tool
         # is *very* allergic to duplicate -delete_rpath arguments
         # when calling depfixer on installation.
-        all_paths = mesonlib.OrderedSet([os.path.join(origin_placeholder, p) for p in processed_rpaths])
+        all_paths = mesonlib.OrderedSet([os.path.join(origin_placeholder, p, './.') for p in processed_rpaths])
         # Build_rpath is used as-is (it is usually absolute).
         if build_rpath != '':
             all_paths.add(build_rpath)
@@ -579,6 +579,7 @@ class GnuLikeDynamicLinkerMixin:
 
         # In order to avoid relinking for RPATH removal, the binary needs to contain just
         # enough space in the ELF header to hold the final installation RPATH.
+        # FIXME: is this still correct?
         paths = ':'.join(all_paths)
         if len(paths) < len(install_rpath):
             padding = 'X' * (len(install_rpath) - len(paths))

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -512,7 +512,7 @@ class Installer:
             if file_copied:
                 self.did_install_something = True
                 try:
-                    depfixer.fix_rpath(outname, install_rpath, final_path,
+                    depfixer.fix_rpath(outname, t.build_rpath, install_rpath, final_path,
                                        install_name_mappings, verbose=False)
                 except SystemExit as e:
                     if isinstance(e.code, int) and e.code == 0:

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -290,13 +290,15 @@ class Elf(DataSizes):
                 self.bf.seek(offset)
                 self.bf.write(newname)
 
-    def fix_rpath(self, new_rpath):
+    def fix_rpath(self, build_rpath, new_rpath):
         # The path to search for can be either rpath or runpath.
         # Fix both of them to be sure.
-        self.fix_rpathtype_entry(new_rpath, DT_RPATH)
-        self.fix_rpathtype_entry(new_rpath, DT_RUNPATH)
+        self.fix_rpathtype_entry(build_rpath, new_rpath, DT_RPATH)
+        self.fix_rpathtype_entry(build_rpath, new_rpath, DT_RUNPATH)
 
-    def fix_rpathtype_entry(self, new_rpath, entrynum):
+    def fix_rpathtype_entry(self, build_rpath, new_rpath, entrynum):
+        if isinstance(build_rpath, str):
+            build_rpath = build_rpath.encode('utf8')
         if isinstance(new_rpath, str):
             new_rpath = new_rpath.encode('utf8')
         rp_off = self.get_entry_offset(entrynum)
@@ -305,15 +307,24 @@ class Elf(DataSizes):
                 print('File does not have rpath. It should be a fully static executable.')
             return
         self.bf.seek(rp_off)
-        old_rpath = self.read_str()
 
-        if old_rpath and not new_rpath:
-          # meson only wants to remove rpaths it added in e.g.
-          # get_link_dep_subdirs(), not ones added by external pkgconfig Libs flags.
-          # So get_link_dep_subdirs() marks the rpath entries it adds by
-          # appending /./. to them, which should not occur in the wild,
-          # but does not change their meaning.
-          new_rpath = b':'.join([dir for dir in old_rpath.split(b':') if not dir.endswith(b'/./.')])
+        old_rpath = self.read_str()
+        new_rpaths = []
+        if new_rpath:
+            new_rpaths.append(new_rpath)
+        if old_rpath:
+            # Filter out build-only rpath entries
+            # added by get_link_dep_subdirs() or
+            # specified by user with build_rpath.
+            build_rpaths = build_rpath.split(b':')
+            for dir in old_rpath.split(b':'):
+                if not (dir.endswith(b'/./.') or    # marked by get_link_dep_subdirs()
+                        dir in build_rpaths or
+                        dir == (b'X' * len(dir))):
+                    new_rpaths.append(dir)
+
+        # Prepend user-specified new entries while preserving the ones that came from pkgconfig etc.
+        new_rpath = b':'.join(new_rpaths)
 
         if len(old_rpath) < len(new_rpath):
             sys.exit("New rpath must not be longer than the old one.")
@@ -352,13 +363,13 @@ class Elf(DataSizes):
             entry.write(self.bf)
         return None
 
-def fix_elf(fname, new_rpath, verbose=True):
+def fix_elf(fname, build_rpath, new_rpath, verbose=True):
     with Elf(fname, verbose) as e:
         if new_rpath is None:
             e.print_rpath()
             e.print_runpath()
         else:
-            e.fix_rpath(new_rpath)
+            e.fix_rpath(build_rpath, new_rpath)
 
 def get_darwin_rpaths_to_remove(fname):
     out = subprocess.check_output(['otool', '-l', fname],
@@ -439,7 +450,7 @@ def fix_jar(fname):
         f.truncate()
     subprocess.check_call(['jar', 'ufm', fname, 'META-INF/MANIFEST.MF'])
 
-def fix_rpath(fname, new_rpath, final_path, install_name_mappings, verbose=True):
+def fix_rpath(fname, build_rpath, new_rpath, final_path, install_name_mappings, verbose=True):
     global INSTALL_NAME_TOOL
     # Static libraries, import libraries, debug information, headers, etc
     # never have rpaths
@@ -450,7 +461,7 @@ def fix_rpath(fname, new_rpath, final_path, install_name_mappings, verbose=True)
         if fname.endswith('.jar'):
             fix_jar(fname)
             return
-        fix_elf(fname, new_rpath, verbose)
+        fix_elf(fname, build_rpath, new_rpath, verbose)
         return
     except SystemExit as e:
         if isinstance(e.code, int) and e.code == 0:

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -306,6 +306,15 @@ class Elf(DataSizes):
             return
         self.bf.seek(rp_off)
         old_rpath = self.read_str()
+
+        if old_rpath and not new_rpath:
+          # meson only wants to remove rpaths it added in e.g.
+          # get_link_dep_subdirs(), not ones added by external pkgconfig Libs flags.
+          # So get_link_dep_subdirs() marks the rpath entries it adds by
+          # appending /./. to them, which should not occur in the wild,
+          # but does not change their meaning.
+          new_rpath = b':'.join([dir for dir in old_rpath.split(b':') if not dir.endswith(b'/./.')])
+
         if len(old_rpath) < len(new_rpath):
             sys.exit("New rpath must not be longer than the old one.")
         # The linker does read-only string deduplication. If there is a

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -56,7 +56,7 @@ from mesonbuild.mesonlib import (
     BuildDirLock, LibType, MachineChoice, PerMachine, Version, is_windows,
     is_osx, is_cygwin, is_dragonflybsd, is_openbsd, is_haiku, is_sunos,
     windows_proof_rmtree, python_command, version_compare, split_args,
-    quote_arg, relpath
+    quote_arg, relpath, is_linux
 )
 from mesonbuild.environment import detect_ninja
 from mesonbuild.mesonlib import MesonException, EnvironmentException
@@ -6372,13 +6372,15 @@ class LinuxlikeTests(BasePlatformTests):
         self.build(override_envvars=env)
         # test uninstalled
         self.run_tests(override_envvars=env)
-        if not is_osx():
-            # Rest of the workflow only works on macOS
+        if not (is_osx() or is_linux()):
             return
         # test running after installation
         self.install(use_destdir=False)
         prog = os.path.join(self.installdir, 'bin', 'prog')
         self._run([prog])
+        if not is_osx():
+            # Rest of the workflow only works on macOS
+            return
         out = self._run(['otool', '-L', prog])
         self.assertNotIn('@rpath', out)
         ## New builddir for testing that DESTDIR is not added to install_name

--- a/test cases/unit/40 external, internal library rpath/built library/meson.build
+++ b/test cases/unit/40 external, internal library rpath/built library/meson.build
@@ -15,7 +15,9 @@ l = shared_library('bar_built', 'bar.c',
                    install: true,
                    dependencies : [foo_system_dep, faa_pkg_dep])
 
-if host_machine.system() == 'darwin'
-  e = executable('prog', 'prog.c', link_with: l, install: true)
+if host_machine.system() == 'darwin' or host_machine.system() == 'linux'
+  e = executable('prog', 'prog.c', link_with: l, install: true,
+        install_rpath: '$ORIGIN/..' / get_option('libdir'),
+      )
   test('testprog', e)
 endif

--- a/test cases/unit/40 external, internal library rpath/external library/meson.build
+++ b/test cases/unit/40 external, internal library rpath/external library/meson.build
@@ -4,16 +4,16 @@ shared_library('foo_in_system', 'foo.c', install : true)
 l = shared_library('faa_pkg', 'faa.c', install: true)
 
 if host_machine.system() == 'darwin'
-  frameworks = ['-framework', 'CoreFoundation', '-framework', 'CoreMedia']
+  ldflags = ['-framework', 'CoreFoundation', '-framework', 'CoreMedia']
   allow_undef_args = ['-Wl,-undefined,dynamic_lookup']
 else
-  frameworks = []
+  ldflags = ['-Wl,-rpath,${libdir}']
   allow_undef_args = []
 endif
 
 pkg = import('pkgconfig')
 pkg.generate(name: 'faa_pkg',
-             libraries: [l] + frameworks,
+             libraries: [l] + ldflags,
              description: 'FAA, a pkg-config test library')
 
 # cygwin DLLs can't have undefined symbols

--- a/test cases/unit/75 pkgconfig prefixes/client/client.c
+++ b/test cases/unit/75 pkgconfig prefixes/client/client.c
@@ -1,0 +1,9 @@
+#include <val1.h>
+#include <val2.h>
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+  printf("%d\n", val1() + val2());
+  return 0;
+}

--- a/test cases/unit/75 pkgconfig prefixes/client/client.c
+++ b/test cases/unit/75 pkgconfig prefixes/client/client.c
@@ -1,9 +1,8 @@
-#include <val1.h>
 #include <val2.h>
 #include <stdio.h>
 
 int main(int argc, char **argv)
 {
-  printf("%d\n", val1() + val2());
+  printf("%d\n", val2());
   return 0;
 }

--- a/test cases/unit/75 pkgconfig prefixes/client/meson.build
+++ b/test cases/unit/75 pkgconfig prefixes/client/meson.build
@@ -1,0 +1,4 @@
+project('client', 'c')
+val1_dep = dependency('val1')
+val2_dep = dependency('val2')
+executable('client', 'client.c', dependencies : [val1_dep, val2_dep], install: true)

--- a/test cases/unit/75 pkgconfig prefixes/client/meson.build
+++ b/test cases/unit/75 pkgconfig prefixes/client/meson.build
@@ -1,4 +1,3 @@
 project('client', 'c')
-val1_dep = dependency('val1')
 val2_dep = dependency('val2')
-executable('client', 'client.c', dependencies : [val1_dep, val2_dep], install: true)
+executable('client', 'client.c', dependencies : [val2_dep], install: true)

--- a/test cases/unit/75 pkgconfig prefixes/test.sh
+++ b/test cases/unit/75 pkgconfig prefixes/test.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# Mimic the test harness in run_unittest.py for this test case
+# FIXME: delete this file once tests are passing
+set -ex
+meson=$HOME/src/meson/meson.py
+
+dir1="val1"
+prefix1="/tmp/xyzzy/$dir1/prefix"
+btmp1="/tmp/xyzzy/$dir1/btmp"
+cd "$dir1"
+   rm -rf "$btmp1" "$prefix1"
+   $meson --prefix="$prefix1" . "$btmp1"
+   ninja -v -C "$btmp1"
+   ninja -C "$btmp1" install
+cd ..
+
+arch=x86_64-linux-gnu
+if ! test -d /usr/lib/${arch}
+then
+  arch=.
+fi
+export PKG_CONFIG_PATH="${prefix1}/lib/$arch/pkgconfig:${prefix1}/lib/pkgconfig"
+#export LIBRARY_PATH="${prefix1}/lib/${arch}:${prefix1}/lib"
+
+dir2="val2"
+prefix2="/tmp/xyzzy/$dir2/prefix"
+btmp2="/tmp/xyzzy/$dir2/btmp"
+cd "$dir2"
+   rm -rf "$btmp2" "$prefix2"
+   $meson --prefix="$prefix2" . "$btmp2"
+   ninja -v -C "$btmp2"
+   ninja -C "$btmp2" install
+cd ..
+
+export PKG_CONFIG_PATH="${prefix2}/lib/$arch/pkgconfig:${prefix2}/lib/pkgconfig"
+#export LIBRARY_PATH="${prefix2}/lib/${arch}:${prefix2}/lib"
+dir3="client"
+prefix3="/tmp/xyzzy/$dir3/prefix"
+btmp3="/tmp/xyzzy/$dir3/btmp"
+cd "$dir3"
+   rm -rf "$btmp3" "$prefix3"
+   $meson --prefix="$prefix3" . "$btmp3"
+   ninja -v -C "$btmp3"
+   ninja -C "$btmp3" install
+cd ..
+
+case "$OS" in
+Windows_NT) ;;
+*)
+  # Show any RPATH entries
+  set +x
+  for file in "$btmp1"/*.so "$btmp2"/*.so "$btmp3"/client "$prefix2"/lib/$arch/*.so "$prefix1"/lib/$arch/*.so "$prefix3"/bin/client
+  do
+    echo -n "${file}: "
+    readelf -d "$file" | grep PATH || echo ""
+  done
+  set -x
+  ;;
+esac
+
+# Run the app
+export PATH="${prefix1}/bin:${prefix2}/bin:$PATH"
+"$prefix3"/bin/client
+
+rm -rf /tmp/xyzzy

--- a/test cases/unit/75 pkgconfig prefixes/val1/meson.build
+++ b/test cases/unit/75 pkgconfig prefixes/val1/meson.build
@@ -1,0 +1,7 @@
+project('val1', 'c')
+val1 = shared_library('val1', 'val1.c',
+  install_rpath : get_option('prefix') / get_option('libdir'),
+  install: true)
+install_headers('val1.h')
+pkgconfig = import('pkgconfig')
+pkgconfig.generate(val1, libraries : ['-Wl,-rpath,${libdir}'])

--- a/test cases/unit/75 pkgconfig prefixes/val1/meson.build
+++ b/test cases/unit/75 pkgconfig prefixes/val1/meson.build
@@ -1,5 +1,6 @@
 project('val1', 'c')
 val1 = shared_library('val1', 'val1.c',
+  build_rpath : '/XYZZYABCDE',
   install_rpath : get_option('prefix') / get_option('libdir'),
   install: true)
 install_headers('val1.h')

--- a/test cases/unit/75 pkgconfig prefixes/val1/val1.c
+++ b/test cases/unit/75 pkgconfig prefixes/val1/val1.c
@@ -1,0 +1,3 @@
+#include "val1.h"
+
+int val1(void) { return 1; }

--- a/test cases/unit/75 pkgconfig prefixes/val1/val1.h
+++ b/test cases/unit/75 pkgconfig prefixes/val1/val1.h
@@ -1,0 +1,1 @@
+int val1(void);

--- a/test cases/unit/75 pkgconfig prefixes/val2/meson.build
+++ b/test cases/unit/75 pkgconfig prefixes/val2/meson.build
@@ -1,0 +1,7 @@
+project('val2', 'c')
+val2 = shared_library('val2', 'val2.c',
+  install_rpath : get_option('prefix') / get_option('libdir'),
+  install: true)
+install_headers('val2.h')
+pkgconfig = import('pkgconfig')
+pkgconfig.generate(val2, libraries : ['-Wl,-rpath,${libdir}'])

--- a/test cases/unit/75 pkgconfig prefixes/val2/meson.build
+++ b/test cases/unit/75 pkgconfig prefixes/val2/meson.build
@@ -1,5 +1,7 @@
 project('val2', 'c')
+val1_dep = dependency('val1')
 val2 = shared_library('val2', 'val2.c',
+  dependencies : [val1_dep],
   install_rpath : get_option('prefix') / get_option('libdir'),
   install: true)
 install_headers('val2.h')

--- a/test cases/unit/75 pkgconfig prefixes/val2/val2.c
+++ b/test cases/unit/75 pkgconfig prefixes/val2/val2.c
@@ -1,0 +1,3 @@
+#include "val2.h"
+
+int val2(void) { return 2; }

--- a/test cases/unit/75 pkgconfig prefixes/val2/val2.c
+++ b/test cases/unit/75 pkgconfig prefixes/val2/val2.c
@@ -1,3 +1,4 @@
+#include "val1.h"
 #include "val2.h"
 
-int val2(void) { return 2; }
+int val2(void) { return val1() + 2; }

--- a/test cases/unit/75 pkgconfig prefixes/val2/val2.h
+++ b/test cases/unit/75 pkgconfig prefixes/val2/val2.h
@@ -1,0 +1,1 @@
+int val2(void);


### PR DESCRIPTION
Marks injected buildtime rpaths with the suffix /./., and then removes only those when installing.
