### PR TITLE
Revert cross fixup

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -385,6 +385,7 @@ class CoreData:
         # Only to print a warning if it changes between Meson invocations.
         self.config_files = self.__load_config_files(options, scratch_dir, 'native')
         self.init_builtins('')
+        self.libdir_cross_fixup()
 
     @staticmethod
     def __load_config_files(options: argparse.Namespace, scratch_dir: str, ftype: str) -> T.List[str]:
@@ -510,7 +511,6 @@ class CoreData:
         for for_machine in iter(MachineChoice):
             for key, opt in builtin_options_per_machine.items():
                 self.add_builtin_option(self.builtins_per_machine[for_machine], key, opt, subproject)
-        self.libdir_cross_fixup()
 
     def add_builtin_option(self, opts_map, key, opt, subproject):
         if subproject:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6683,6 +6683,17 @@ class LinuxCrossArmTests(BasePlatformTests):
                 return
         self.assertTrue(False, 'Option libdir not in introspect data.')
 
+    def test_cross_libdir_subproject(self):
+        # Guard against a regression where calling "subproject"
+        # would reset the value of libdir to its default value.
+        testdir = os.path.join(self.unit_test_dir, '75 subdir libdir')
+        self.init(testdir, extra_args=['--libdir=fuf'])
+        for i in self.introspect('--buildoptions'):
+            if i['name'] == 'libdir':
+                self.assertEqual(i['value'], 'fuf')
+                return
+        self.assertTrue(False, 'Libdir specified on command line gets reset.')
+
     def test_std_remains(self):
         # C_std defined in project options must be in effect also when cross compiling.
         testdir = os.path.join(self.unit_test_dir, '51 noncross options')

--- a/test cases/unit/75 subdir libdir/meson.build
+++ b/test cases/unit/75 subdir libdir/meson.build
@@ -1,0 +1,2 @@
+project('toplevel', 'c')
+subproject('flub')

--- a/test cases/unit/75 subdir libdir/subprojects/flub/meson.build
+++ b/test cases/unit/75 subdir libdir/subprojects/flub/meson.build
@@ -1,0 +1,1 @@
+project('subflub', 'c')


### PR DESCRIPTION
The original commit caused a regression: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=959708

This revert fixes the issue but brings back the original problem. If a proper fix is not made soon, this needs to go in.