### PR TITLE
envconfig: Always honor PKG_CONFIG_PATH

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -121,7 +121,7 @@ def get_env_var_pair(for_machine: MachineChoice,
         # ones.
         ([var_name + '_FOR_BUILD'] if is_cross else [var_name]),
         # Always just the unprefixed host verions
-        ([] if is_cross else [var_name]),
+        [var_name]
     )[for_machine]
     for var in candidates:
         value = os.environ.get(var)


### PR DESCRIPTION
The comment for this code is correct, but the code itself isn't. The way
it's implemented in a cross compile we don't look at PKG_CONFIG_PATH at
all.

Fixes: #7062