### PR TITLE
Do not pass rpath flags to wasm-ld

### DIFF
--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -761,6 +761,11 @@ class WASMDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, Dyna
     def get_asneeded_args(self) -> T.List[str]:
         return []
 
+    def build_rpath_args(self, env: 'Environment', build_dir: str, from_dir: str,
+                         rpath_paths: str, build_rpath: str,
+                         install_rpath: str) -> T.List[str]:
+        return []
+
 
 class CcrxDynamicLinker(DynamicLinker):
 


### PR DESCRIPTION
They are not meaningful and cause emscripten to spew warnings. See also https://github.com/emscripten-core/emscripten/issues/11076