### PR TITLE
ConfigToolDependency: Don't fallback to system tool when cross compiling

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -242,6 +242,9 @@ libgcrypt_dep = dependency('libgcrypt', version: '>= 1.8')
 gpgme_dep = dependency('gpgme', version: '>= 1.0')
 ```
 
+*Since 0.55.0* Meson won't search $PATH any more for a config tool binary when
+cross compiling if the config tool did not have an entry in the cross file.
+
 ## AppleFrameworks
 
 Use the `modules` keyword to list frameworks required, e.g.

--- a/docs/markdown/snippets/config_tool_no_cross_path.md
+++ b/docs/markdown/snippets/config_tool_no_cross_path.md
@@ -1,0 +1,7 @@
+## Config tool based dependencies no longer search PATH for cross compiling
+
+Before 0.55.0 config tool based dependencies (llvm-config, cups-config, etc),
+would search system $PATH if they weren't defined in the cross file. This has
+been a source of bugs and has been deprecated. It is now removed, config tool
+binaries must be specified in the cross file now or the dependency will not
+be found.

--- a/test cases/frameworks/21 libwmf/meson.build
+++ b/test cases/frameworks/21 libwmf/meson.build
@@ -1,7 +1,7 @@
 project('libwmf test', 'c')
 
 wm = find_program('libwmf-config', required : false)
-if not wm.found()
+if not wm.found() or meson.is_cross_build()
   error('MESON_SKIP_TEST: libwmf-config not installed')
 endif
 


### PR DESCRIPTION
The system tool is always the wrong thing to use and cause hard to debug
issues when trying to link system libraries with cross built binaries.

The ExternalDependency base class already had a method to deal with
this, used by PkgConfigDependency and QtBaseDependency, so it should
make things more consistent.