### PR TITLE
Allow indexed custom target to be used in executable's depends.

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -729,7 +729,7 @@ class BuildTarget(Target):
                     File.from_source_file(environment.source_dir, self.subdir, s))
             elif hasattr(s, 'get_outputs'):
                 self.link_depends.extend(
-                    [File.from_built_file(s.subdir, p) for p in s.get_outputs()])
+                    [File.from_built_file(s.get_subdir(), p) for p in s.get_outputs()])
             else:
                 raise InvalidArguments(
                     'Link_depends arguments must be strings, Files, '

--- a/test cases/common/233 link depends indexed custom target/foo.c
+++ b/test cases/common/233 link depends indexed custom target/foo.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+int main(void) {
+  const char *fn = DEPFILE;
+  FILE *f = fopen(fn, "r");
+  if (!f) {
+    printf("could not open %s", fn);
+    return 1;
+  }
+  else {
+    printf("successfully opened %s", fn);
+  }
+
+  return 0;
+}

--- a/test cases/common/233 link depends indexed custom target/make_file.py
+++ b/test cases/common/233 link depends indexed custom target/make_file.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+import sys
+
+with open(sys.argv[1], 'w') as f:
+    print('# this file does nothing', file=f)
+
+with open(sys.argv[2], 'w') as f:
+    print('# this file does nothing', file=f)

--- a/test cases/common/233 link depends indexed custom target/meson.build
+++ b/test cases/common/233 link depends indexed custom target/meson.build
@@ -1,0 +1,19 @@
+project('link_depends_indexed_custom_target', 'c')
+
+if meson.backend().startswith('vs')
+  # FIXME: Broken on the VS backends
+  error('MESON_SKIP_TEST see https://github.com/mesonbuild/meson/issues/1799')
+endif
+
+cmd = find_program('make_file.py')
+
+dep_files = custom_target('gen_dep',
+        command: [cmd, '@OUTPUT@'],
+        output: ['dep_file1', 'dep_file2'])
+
+exe = executable('foo', 'foo.c',
+        link_depends: dep_files[1],
+        c_args: ['-DDEPFILE="' + dep_files[0].full_path()+ '"'])
+
+# check that dep_file1 exists, which means that link_depends target ran
+test('runtest', exe)


### PR DESCRIPTION
This change will allow indexed custom targets to be used in link_depends fields.