### PR TITLE
vs: add static_from_buildtype to b_vscrt

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -126,23 +126,23 @@ platforms or with all compilers:
 | b_sanitize  | none          | see below               | Code sanitizer to use |
 | b_staticpic | true          | true, false             | Build static libraries as position independent |
 | b_pie       | false         | true, false             | Build position-independent executables (since 0.49.0)|
-| b_vscrt     | from_buildtype| none, md, mdd, mt, mtd, from_buildtype | VS runtime library to use (since 0.48.0) |
+| b_vscrt     | from_buildtype| none, md, mdd, mt, mtd, from_buildtype, static_from_buildtype | VS runtime library to use (since 0.48.0) (static_from_buildtype since 0.56.0) |
 
 The value of `b_sanitize` can be one of: `none`, `address`, `thread`,
 `undefined`, `memory`, `address,undefined`.
 
 <a name="b_vscrt-from_buildtype"></a>
-The default value of `b_vscrt` is `from_buildtype`. In that case, the following
-table is used internally to pick the CRT compiler arguments based on the value
-of the `buildtype` option:
+The default value of `b_vscrt` is `from_buildtype`. The following table is used
+internally to pick the CRT compiler arguments for `from_buildtype` or
+`static_from_buildtype` *(since 0.56)* based on the value of the `buildtype` option:
 
-| buildtype      | Visual Studio CRT |
-| --------       | ----------------- |
-| debug          | `/MDd`            |
-| debugoptimized | `/MD`             |
-| release        | `/MD`             |
-| minsize        | `/MD`             |
-| custom         | error!            |
+| buildtype      | from_buildtype | static_from_buildtype |
+| --------       | -------------- | --------------------- |
+| debug          | `/MDd`         | `/MTd`                |
+| debugoptimized | `/MD`          | `/MT`                 |
+| release        | `/MD`          | `/MT`                 |
+| minsize        | `/MD`          | `/MT`                 |
+| custom         | error!         | error!                |
 
 ### Notes about Apple Bitcode support
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -838,6 +838,13 @@ class Vs2010Backend(backends.Backend):
             else:
                 ET.SubElement(type_config, 'UseDebugLibraries').text = 'false'
                 ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDLL'
+        elif vscrt_type.value == 'static_from_buildtype':
+            if self.buildtype == 'debug':
+                ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
+                ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDebug'
+            else:
+                ET.SubElement(type_config, 'UseDebugLibraries').text = 'false'
+                ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreaded'
         elif vscrt_type.value == 'mdd':
             ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
             ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDebugDLL'

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -289,7 +289,7 @@ base_options = {'b_pch': coredata.UserBooleanOption('Use precompiled headers', T
                 'b_bitcode': coredata.UserBooleanOption('Generate and embed bitcode (only macOS/iOS/tvOS)',
                                                         False),
                 'b_vscrt': coredata.UserComboOption('VS run-time library type to use.',
-                                                    ['none', 'md', 'mdd', 'mt', 'mtd', 'from_buildtype'],
+                                                    ['none', 'md', 'mdd', 'mt', 'mtd', 'from_buildtype', 'static_from_buildtype'],
                                                     'from_buildtype'),
                 }  # type: OptionDictType
 

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -389,19 +389,25 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
 
         if crt_val in self.mscrt_args:
             return self.mscrt_args[crt_val]
-        assert(crt_val == 'from_buildtype')
+        assert(crt_val in ['from_buildtype', 'static_from_buildtype'])
+
+        dbg = 'mdd'
+        rel = 'md'
+        if crt_val == 'static_from_buildtype':
+            dbg = 'mtd'
+            rel = 'mt'
 
         # Match what build type flags used to do.
         if buildtype == 'plain':
             return []
         elif buildtype == 'debug':
-            return self.mscrt_args['mdd']
+            return self.mscrt_args[dbg]
         elif buildtype == 'debugoptimized':
-            return self.mscrt_args['md']
+            return self.mscrt_args[rel]
         elif buildtype == 'release':
-            return self.mscrt_args['md']
+            return self.mscrt_args[rel]
         elif buildtype == 'minsize':
-            return self.mscrt_args['md']
+            return self.mscrt_args[rel]
         else:
             assert(buildtype == 'custom')
             raise EnvironmentException('Requested C runtime based on buildtype, but buildtype is "custom".')

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -362,18 +362,23 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:
         if crt_val in self.crt_args:
             return self.crt_args[crt_val]
-        assert(crt_val == 'from_buildtype')
+        assert(crt_val in ['from_buildtype', 'static_from_buildtype'])
+        dbg = 'mdd'
+        rel = 'md'
+        if crt_val == 'static_from_buildtype':
+            dbg = 'mtd'
+            rel = 'mt'
         # Match what build type flags used to do.
         if buildtype == 'plain':
             return []
         elif buildtype == 'debug':
-            return self.crt_args['mdd']
+            return self.crt_args[dbg]
         elif buildtype == 'debugoptimized':
-            return self.crt_args['md']
+            return self.crt_args[rel]
         elif buildtype == 'release':
-            return self.crt_args['md']
+            return self.crt_args[rel]
         elif buildtype == 'minsize':
-            return self.crt_args['md']
+            return self.crt_args[rel]
         else:
             assert(buildtype == 'custom')
             raise mesonlib.EnvironmentException('Requested C runtime based on buildtype, but buildtype is "custom".')


### PR DESCRIPTION
I compile my code with the static CRT, to simplify deployment.

I was using `b_vscrt=mt`. I recently tried to add `-D_DEBUG` to my debug builds, but my code failed to link because `mt` does not export all the required symbols. `from_buildtype` is almost what I wanted, except from_buildtype always links with the DLL CRT.

It's not clear if `static_from_buildtype` is the correct way to go about this, but it's a starting point for discussion.

(Note that I snuck in a fix for backend=vs when using `from_buildtype` and `buildtype=debugoptimized` -- meson previously generated MultiThreaded (non-dll), which did not match ninja or the documentation)