### PR TITLE
boost: Try finding libraries with the matching arch (fixes #7110)

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -1533,6 +1533,16 @@ def relpath(path: str, start: str) -> str:
     except (TypeError, ValueError):
         return path
 
+def path_is_in_root(path: Path, root: Path, resolve: bool = False) -> bool:
+    # Check wheter a path is within the root directory root
+    try:
+        if resolve:
+            path.resolve().relative_to(root.resolve())
+        else:
+            path.relative_to(root)
+    except ValueError:
+        return False
+    return True
 
 class LibType(Enum):
 


### PR DESCRIPTION
No test since this is highly system-specific. I will try to reproduce this with a Gentoo OS Comp test in the future.