### PR TITLE
Fix has_function() for clang on 64bit Windows

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -658,7 +658,7 @@ class CLikeCompiler:
         # is not run so we don't care what the return value is.
         main = '''\nint main(void) {{
             void *a = (void*) &{func};
-            long b = (long) a;
+            long long b = (long long) a;
             return (int) b;
         }}'''
         return head, main


### PR DESCRIPTION
has_function() tries to link an example program using the function
to see if it is available, but with clang on 64bit Windows this
example always already failed at the compile step:

error: cast from pointer to smaller type 'long' loses information
            long b = (long) a;

This is due to long!=pointer with LLP64

Change from "long" to "long long" which is min 64bit and should always
fit a pointer. While "long long" is strictly a C99 feature every
non super ancient compiler should still support it.
