### PR TITLE
build: always use lib prefix for GCC import libraries

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1743,7 +1743,7 @@ class SharedLibrary(BuildTarget):
         elif env.machines[self.for_machine].is_windows():
             suffix = 'dll'
             self.vs_import_filename = '{0}{1}.lib'.format(self.prefix if self.prefix is not None else '', self.name)
-            self.gcc_import_filename = '{0}{1}.dll.a'.format(self.prefix if self.prefix is not None else 'lib', self.name)
+            self.gcc_import_filename = 'lib{0}.dll.a'.format(self.name)
             if self.get_using_rustc():
                 # Shared library is of the form foo.dll
                 prefix = ''
@@ -1769,7 +1769,7 @@ class SharedLibrary(BuildTarget):
                 self.filename_tpl = '{0.prefix}{0.name}.{0.suffix}'
         elif env.machines[self.for_machine].is_cygwin():
             suffix = 'dll'
-            self.gcc_import_filename = '{0}{1}.dll.a'.format(self.prefix if self.prefix is not None else 'lib', self.name)
+            self.gcc_import_filename = 'lib{0}.dll.a'.format(self.name)
             # Shared library is of the form cygfoo.dll
             # (ld --dll-search-prefix=cyg is the default)
             prefix = 'cyg'


### PR DESCRIPTION
Even when name_prefix: '' is specified for Windows, the GCC import library should still have the customary 'lib' prefix, and if name_prefix: 'cyg' is for some reason specified for Cygwin, it should definitely not also apply to the import library.