### PR TITLE
macos: Remove framwork linkerlike args

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1136,7 +1136,7 @@ class Compiler:
     def remove_linkerlike_args(self, args):
         rm_exact = ('-headerpad_max_install_names',)
         rm_prefixes = ('-Wl,', '-L',)
-        rm_next = ('-L',)
+        rm_next = ('-L', '-framework',)
         ret = []
         iargs = iter(args)
         for arg in iargs:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5325,7 +5325,7 @@ class DarwinTests(BasePlatformTests):
 
     def test_removing_unused_linker_args(self):
         testdir = os.path.join(self.common_test_dir, '108 has arg')
-        env = {'CFLAGS': '-L/tmp -L /var/tmp -headerpad_max_install_names -Wl,-export_dynamic'}
+        env = {'CFLAGS': '-L/tmp -L /var/tmp -headerpad_max_install_names -Wl,-export_dynamic -framework Foundation'}
         self.init(testdir, override_envvars=env)
 
 


### PR DESCRIPTION
fixes-up 33fbc548ab74e79280d2f57b2cd499d14c1f1e91

fixes #6294