### PR TITLE
interpretor: Do not add dependencies if we already have them

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -497,6 +497,7 @@ class BuildTarget(Target):
         self.link_targets = []
         self.link_whole_targets = []
         self.link_depends = []
+        self.added_deps = set()
         self.name_prefix_set = False
         self.name_suffix_set = False
         self.filename = 'no_name'
@@ -1053,6 +1054,8 @@ This will become a hard error in a future Meson release.''')
     def add_deps(self, deps):
         deps = listify(deps)
         for dep in unholder(deps):
+            if dep in self.added_deps:
+                continue
             if isinstance(dep, dependencies.InternalDependency):
                 # Those parts that are internal.
                 self.process_sourcelist(dep.sources)
@@ -1091,6 +1094,7 @@ You probably should put it in link_with instead.''')
                                        'either an external dependency (returned by find_library() or '
                                        'dependency()) or an internal dependency (returned by '
                                        'declare_dependency()).'.format(type(dep).__name__))
+            self.added_deps.add(dep)
 
     def get_external_deps(self):
         return self.external_deps


### PR DESCRIPTION
in tree like dep structures with a lot of source: declarations, this can
result in a lot of presure on the source list. this saves ~3s out of 9s
in the interpretor stage in efl build.