### PR TITLE
symbolextractor: Do not store the size of code objects

### DIFF
--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -113,7 +113,10 @@ def gnu_syms(libfilename: str, outfilename: str):
             continue
         line_split = line.split()
         entry = line_split[0:2]
-        if len(line_split) >= 4:
+        # Store the size of symbols pointing to data objects so we relink
+        # when those change, which is needed because of copy relocations
+        # https://github.com/mesonbuild/meson/pull/7132#issuecomment-628353702
+        if line_split[1].upper() in ('B', 'G', 'D') and len(line_split) >= 4:
             entry += [line_split[3]]
         result += [' '.join(entry)]
     write_if_changed('\n'.join(result) + '\n', outfilename)


### PR DESCRIPTION
This will almost always change and cause a relink of everything. Our
other symbol extractor implementations do not store this either. We
only need to store the size of data objects, since that necessitates
a relink due to copy relocations.

Drastically reduces the amount of relinking required in gstreamer and
gtk on Linux.

~~This is a very safe and obvious fix, so I'm marking it for the stable release.~~