### PR TITLE
Rename has_exe_wrapper to can_run_host_binaries

### DIFF
--- a/docs/markdown/Cross-compilation.md
+++ b/docs/markdown/Cross-compilation.md
@@ -231,12 +231,9 @@ The main *meson* object provides two functions to determine cross
 compilation status.
 
 ```meson
-meson.is_cross_build()  # returns true when cross compiling
-meson.has_exe_wrapper() # returns true if an exe wrapper has been defined
+meson.is_cross_build()        # returns true when cross compiling
+meson.can_run_host_binaries() # returns true if the host binaries can be run, either with a wrapper or natively
 ```
-
-Note that the latter gives undefined return value when doing a native
-build.
 
 You can run system checks on both the system compiler or the cross
 compiler. You just have to specify which one to use.

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1836,10 +1836,14 @@ the following methods.
   If `native: false` or not specified, variable is retrieved from the
   cross-file if cross-compiling, and from the native-file when not cross-compiling.
 
-- `has_exe_wrapper()` returns true when doing a cross build if there
-  is a wrapper command that can be used to execute cross built
-  binaries (for example when cross compiling from Linux to Windows,
-  one can use `wine` as the wrapper).
+- `can_run_host_binaries()` returns true if the build machine can run
+  binaries compiled for the host. This returns true unless you are
+  cross compiling, need a helper to run host binaries, and don't have one.
+  For example when cross compiling from Linux to Windows, one can use `wine`
+  as the helper. *New in 0.55.0*
+
+- `has_exe_wrapper()` alias of `can_run_host_binaries`
+  *Deprecated since 0.55.0*
 
 - `install_dependency_manifest(output_name)` installs a manifest file
   containing a list of all subprojects, their versions and license

--- a/docs/markdown/snippets/can_run_host_binaries.md
+++ b/docs/markdown/snippets/can_run_host_binaries.md
@@ -1,0 +1,5 @@
+## Rename has_exe_wrapper -> can_run_host_binaries
+
+The old name was confusing as it didn't really match the behavior of the
+function. The old name remains as an alias (the behavior hasn't changed), but
+is now deprecated.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1873,6 +1873,7 @@ class MesonMain(InterpreterObject):
         self.methods.update({'get_compiler': self.get_compiler_method,
                              'is_cross_build': self.is_cross_build_method,
                              'has_exe_wrapper': self.has_exe_wrapper_method,
+                             'can_run_host_binaries': self.can_run_host_binaries_method,
                              'is_unity': self.is_unity_method,
                              'is_subproject': self.is_subproject_method,
                              'current_source_dir': self.current_source_dir_method,
@@ -2023,9 +2024,16 @@ class MesonMain(InterpreterObject):
 
     @noPosargs
     @permittedKwargs({})
-    def has_exe_wrapper_method(self, args, kwargs):
-        if self.is_cross_build_method(None, None) and \
-           self.build.environment.need_exe_wrapper():
+    @FeatureDeprecated('meson.has_exe_wrapper', '0.55.0', 'use meson.can_run_host_binaries instead.')
+    def has_exe_wrapper_method(self, args: T.Tuple[object, ...], kwargs: T.Dict[str, object]) -> bool:
+        return self.can_run_host_binaries_method(args, kwargs)
+
+    @noPosargs
+    @permittedKwargs({})
+    @FeatureNew('meson.can_run_host_binaries', '0.55.0')
+    def can_run_host_binaries_method(self, args: T.Tuple[object, ...], kwargs: T.Dict[str, object]) -> bool:
+        if (self.is_cross_build_method(None, None) and
+                self.build.environment.need_exe_wrapper()):
             if self.build.environment.exe_wrapper is None:
                 return False
         # We return True when exe_wrap is defined, when it's not needed, and

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -220,9 +220,10 @@ class FeatureCheckBase(metaclass=abc.ABCMeta):
     # This will be overwritten by the subclasses by necessity
     feature_registry = {}  # type: T.ClassVar[T.Dict[str, T.Dict[str, T.Set[str]]]]
 
-    def __init__(self, feature_name: str, version: str):
+    def __init__(self, feature_name: str, version: str, extra_message: T.Optional[str] = None):
         self.feature_name = feature_name  # type: str
         self.feature_version = version    # type: str
+        self.extra_message = extra_message or ''  # type: str
 
     @staticmethod
     def get_target_version(subproject: str) -> str:
@@ -302,8 +303,15 @@ class FeatureNew(FeatureCheckBase):
         return 'Project specifies a minimum meson_version \'{}\' but uses features which were added in newer versions:'.format(tv)
 
     def log_usage_warning(self, tv: str) -> None:
-        mlog.warning('Project targeting \'{}\' but tried to use feature introduced '
-                     'in \'{}\': {}'.format(tv, self.feature_version, self.feature_name))
+        args = [
+            'Project targeting', "'{}'".format(tv),
+            'but tried to use feature introduced in',
+            "'{}':".format(self.feature_version),
+            '{}.'.format(self.feature_name),
+        ]
+        if self.extra_message:
+            args.append(self.extra_message)
+        mlog.warning(*args)
 
 class FeatureDeprecated(FeatureCheckBase):
     """Checks for deprecated features"""
@@ -323,9 +331,15 @@ class FeatureDeprecated(FeatureCheckBase):
         return 'Deprecated features used:'
 
     def log_usage_warning(self, tv: str) -> None:
-        mlog.deprecation('Project targeting \'{}\' but tried to use feature '
-                         'deprecated since \'{}\': {}'
-                         ''.format(tv, self.feature_version, self.feature_name))
+        args = [
+            'Project targeting', "'{}'".format(tv),
+            'but tried to use feature deprecated since',
+            "'{}':".format(self.feature_version),
+            '{}.'.format(self.feature_name),
+        ]
+        if self.extra_message:
+            args.append(self.extra_message)
+        mlog.warning(*args)
 
 
 class FeatureCheckKwargsBase:

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -417,6 +417,7 @@ def _compare_output(expected: T.List[T.Dict[str, str]], output: str, desc: str) 
                     match = bool(re.match(expected, actual))
                 else:
                     match = (expected == actual)
+                    print(actual)
                 if match:
                     how, expected = next_expected(i)
 

--- a/test cases/common/36 tryrun/meson.build
+++ b/test cases/common/36 tryrun/meson.build
@@ -2,7 +2,7 @@ project('tryrun', 'c', 'cpp')
 
 # Complex to exercise all code paths.
 if meson.is_cross_build()
-  if meson.has_exe_wrapper()
+  if meson.can_run_host_binaries()
     compilers = [meson.get_compiler('c', native : false), meson.get_compiler('cpp', native : false)]
   else
     compilers = [meson.get_compiler('c', native : true), meson.get_compiler('cpp', native : true)]

--- a/test cases/common/93 selfbuilt custom/meson.build
+++ b/test cases/common/93 selfbuilt custom/meson.build
@@ -26,7 +26,7 @@ ctlib = custom_target('ctlib',
   build_by_default : true,
 )
 
-if meson.is_cross_build() and meson.has_exe_wrapper()
+if meson.is_cross_build() and meson.can_run_host_binaries()
   checkarg_host = executable('checkarg_host', 'checkarg.cpp')
 
   ctlib_host = custom_target(

--- a/test cases/unit/36 exe_wrapper behaviour/meson.build
+++ b/test cases/unit/36 exe_wrapper behaviour/meson.build
@@ -1,7 +1,7 @@
 project('exe wrapper behaviour', 'c')
 
 assert(meson.is_cross_build(), 'not setup as cross build')
-assert(meson.has_exe_wrapper(), 'exe wrapper not defined?')
+assert(meson.has_exe_wrapper(), 'exe wrapper not defined?')  # intentionally not changed to can_run_host_binaries,
 
 exe = executable('prog', 'prog.c')
 

--- a/test cases/warning/1 version for string div/test.json
+++ b/test cases/warning/1 version for string div/test.json
@@ -2,7 +2,7 @@
   "stdout": [
     {
       "comment": "literal '/' appears in output, irrespective of os.path.sep, as that's the operator",
-      "line": "WARNING: Project targeting '>=0.48.0' but tried to use feature introduced in '0.49.0': / with string arguments"
+      "line": "WARNING: Project targeting '>=0.48.0' but tried to use feature introduced in '0.49.0': / with string arguments."
     }
   ]
 }


### PR DESCRIPTION
the name `has_exe_wrapper` doesn't really describe what the function does, what it really does is check if an exe_wrapper is required, and if it is, whether there is one. `can_run_host_binaries` is much more descriptive of what the function actually checks. This doesn't remove has_exe_wrapper, just makes it an alias to can_run_host_binaries.

I've also made a small change to the semantics of the language, in that can_run_host_binaries is documented as returning `true` on host == build (native) compilation.

Related: https://github.com/mesonbuild/meson/issues/6865