### PR TITLE
ui/qt: use new directory layout for qt on android

### DIFF
--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -440,6 +440,9 @@ class QtBaseDependency(ExternalDependency):
                     suffix += '_armeabi-v7a'
                 elif cpu_family == 'aarch64':
                     suffix += '_arm64-v8a'
+                else:
+                    mlog.warning('Android target arch {!r} for Qt5 is unknown, '
+                                 'module detection may not work'.format(cpu_family))
         return suffix
 
     def _link_with_qtmain(self, is_debug, libdir):

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -406,6 +406,9 @@ class QtBaseDependency(ExternalDependency):
             if libfile:
                 libfile = libfile[0]
             else:
+                mlog.log("Could not find:", module,
+                         self.qtpkgname + module + modules_lib_suffix,
+                         'in', libdir)
                 self.is_found = False
                 break
             self.link_args.append(libfile)
@@ -426,6 +429,17 @@ class QtBaseDependency(ExternalDependency):
         if self.env.machines[self.for_machine].is_darwin():
             if is_debug:
                 suffix += '_debug'
+        if mesonlib.version_compare(self.version, '>= 5.14.0'):
+            if self.env.machines[self.for_machine].is_android():
+                cpu_family = self.env.machines[self.for_machine].cpu_family
+                if cpu_family == 'x86':
+                    suffix += '_x86'
+                elif cpu_family == 'x86_64':
+                    suffix += '_x86_64'
+                elif cpu_family == 'arm':
+                    suffix += '_armeabi-v7a'
+                elif cpu_family == 'aarch64':
+                    suffix += '_arm64-v8a'
         return suffix
 
     def _link_with_qtmain(self, is_debug, libdir):


### PR DESCRIPTION
Now follows ios and other platform directory layouts.  Moves from
separate android_$arch directories to every library containing a _$arch
suffix.  e.g. libQt5Core_x86.a in a single directory.

cc @nirbheek 