### PR TITLE
Docs: Make the suggested use for the not-found dependency better

### DIFF
--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -271,6 +271,7 @@ This can be used in cases where you want a default value, but might override it
 later.
 
 ```meson
+# Not needed on Windows!
 my_dep = dependency('', required : false)
 if host_machine.system() in ['freebsd', 'netbsd', 'openbsd', 'dragonfly']
   my_dep = dependency('some dep', required : false)
@@ -278,8 +279,9 @@ elif host_machine.system() == 'linux'
   my_dep = dependency('some other dep', required : false)
 endif
 
-# Last ditch effort!
-if no my_dep.found()
-  my_dep = meson.get_compiler('c').find_library('dep')
-endif
+executable(
+  'myexe',
+  my_sources,
+  deps : [my_dep]
+)
 ```


### PR DESCRIPTION
@jon-turney suggested this, and it makes more sense to me as well.