### PR TITLE
run_*test.py: print meson version at start of test

### DIFF
--- a/run_cross_test.py
+++ b/run_cross_test.py
@@ -21,8 +21,9 @@ This is now just a wrapper around run_project_tests.py with specific arguments
 
 import argparse
 import subprocess
-import sys
 from mesonbuild import mesonlib
+from mesonbuild.coredata import version as meson_version
+
 
 def runtests(cross_file, failfast):
     tests = ['--only', 'common']
@@ -37,4 +38,5 @@ def main():
     return runtests(options.cross_file, options.failfast)
 
 if __name__ == '__main__':
-    sys.exit(main())
+    print('Meson build system', meson_version, 'Cross Tests')
+    raise SystemExit(main())

--- a/run_meson_command_tests.py
+++ b/run_meson_command_tests.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import os
 import tempfile
 import unittest
@@ -23,6 +22,8 @@ import zipapp
 from pathlib import Path
 
 from mesonbuild.mesonlib import windows_proof_rmtree, python_command, is_windows
+from mesonbuild.coredata import version as meson_version
+
 
 def get_pypath():
     import sysconfig
@@ -195,4 +196,5 @@ class CommandTests(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    sys.exit(unittest.main(buffer=True))
+    print('Meson build system', meson_version, ' Command Tests')
+    raise SystemExit(unittest.main(buffer=True))

--- a/run_meson_command_tests.py
+++ b/run_meson_command_tests.py
@@ -196,5 +196,5 @@ class CommandTests(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    print('Meson build system', meson_version, ' Command Tests')
+    print('Meson build system', meson_version, 'Command Tests')
     raise SystemExit(unittest.main(buffer=True))

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -42,7 +42,7 @@ from mesonbuild import mesonlib
 from mesonbuild import mlog
 from mesonbuild import mtest
 from mesonbuild.mesonlib import MachineChoice, Popen_safe
-from mesonbuild.coredata import backendlist
+from mesonbuild.coredata import backendlist, version as meson_version
 
 from run_tests import get_fake_options, run_configure, get_meson_script
 from run_tests import get_backend_commands, get_backend_args_for_dir, Backend
@@ -1245,6 +1245,7 @@ if __name__ == '__main__':
     if options.cross_file:
         options.extra_args += ['--cross-file', options.cross_file]
 
+    print('Meson build system', meson_version, 'Project Tests')
     setup_commands(options.backend)
     detect_system_compiler(options)
     print_tool_versions()

--- a/run_tests.py
+++ b/run_tests.py
@@ -33,7 +33,7 @@ from mesonbuild import mesonmain
 from mesonbuild import mtest
 from mesonbuild import mlog
 from mesonbuild.environment import Environment, detect_ninja
-from mesonbuild.coredata import backendlist
+from mesonbuild.coredata import backendlist, version as meson_version
 
 NINJA_1_9_OR_NEWER = False
 NINJA_CMD = None
@@ -401,4 +401,5 @@ def main():
     return returncode
 
 if __name__ == '__main__':
-    sys.exit(main())
+    print('Meson build system', meson_version, 'Project and Unit Tests')
+    raise SystemExit(main())

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -8162,4 +8162,5 @@ def main():
     return unittest.main(defaultTest=cases, buffer=True)
 
 if __name__ == '__main__':
+    print('Meson build system', mesonbuild.coredata.version, 'Unit Tests')
     raise SystemExit(main())


### PR DESCRIPTION
When building a general Meson project, the Meson version is printed first. I find this very handy, and it would be even more useful to have the Meson version printed at the start of Meson's own run_*test.py scripts, as they can take over an hour to run, so you want to be sure you're testing the intended Meson version. 

I also saw some PEP8 issues including missing import and unused variable that I fixed in the second commit.

## New functionality

* print Meson version at start of each Meson internal run_*tests.py execution.