### PR TITLE
cmake: Print supported stds when warning

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -290,10 +290,12 @@ class ConverterTarget:
                 m = ConverterTarget.std_regex.match(j)
                 if m:
                     std = m.group(2)
-                    if std not in self._all_lang_stds(i):
+                    supported = self._all_lang_stds(i)
+                    if std not in supported:
                         mlog.warning(
                             'Unknown {0}_std "{1}" -> Ignoring. Try setting the project-'
-                            'level {0}_std if build errors occur.'.format(i, std),
+                            'level {0}_std if build errors occur. Known '
+                            '{0}_stds are: {2}'.format(i, std, ' '.join(supported)),
                             once=True
                         )
                         continue


### PR DESCRIPTION
This was helpful while debugging CI failure on the 0.54 branch due to
a difference in the structure of self.env.coredata.compiler_options:

https://github.com/mesonbuild/meson/runs/674391139

https://travis-ci.org/github/mesonbuild/meson/jobs/686982807

The change that went into 0.54 was: https://github.com/mesonbuild/meson/commit/477947a53ac0d83532ac9cf42b850d321d5cf58b