### PR TITLE
travis/macos: Restore the old pkg-config behaviour

### DIFF
--- a/ci/travis_install.sh
+++ b/ci/travis_install.sh
@@ -7,9 +7,11 @@ msg() { echo -e "\x1b[1;32mINFO:  \x1b[37m$*\x1b[0m"; }
 if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
   msg "Running OSX setup"
   brew update
+  # Run one macOS build with pkg-config available (pulled in by qt), and the
+  # other (unity=on) without pkg-config
   brew install qt ldc llvm ninja
   if [[ "$MESON_ARGS" =~ .*unity=on.* ]]; then
-    which pkg-config || brew install pkg-config
+    which pkg-config && rm -f $(which pkg-config)
   fi
   python3 -m pip install jsonschema
 elif [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/test cases/failing/34 dependency not-required then required/test.json
+++ b/test cases/failing/34 dependency not-required then required/test.json
@@ -2,7 +2,7 @@
   "stdout": [
     {
       "match": "re",
-      "line": "test cases/failing/34 dependency not\\-required then required/meson\\.build:4:0: ERROR: Dependency \"foo\\-bar\\-xyz\\-12\\.3\" not found, tried .*"
+      "line": ".*/meson\\.build:4:0: ERROR: (Pkg-config binary for machine MachineChoice\\.HOST not found\\. Giving up\\.|Dependency \"foo\\-bar\\-xyz\\-12\\.3\" not found, tried .*)"
     }
   ]
 }


### PR DESCRIPTION
We need to test both "have pkg-config" and "don't have pkg-config" pathways on macOS, which is why pkg-config was only installed in one branch based on `--unity=on/off`.

This broke in https://github.com/mesonbuild/meson/pull/6913.