### PR TITLE
Limit the filename length

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -86,7 +86,7 @@ Using the option as-is with no prefix affects all machines. For example:
 | warning_level {0, 1, 2, 3}           | 1             | Set the warning level. From 0 = none to 3 = highest            | no             |
 | werror                               | false         | Treat warnings as errors                                       | no             |
 | wrap_mode {default, nofallback,<br>nodownload, forcefallback} | default | Wrap mode to use                            | no             |
-| max_filename_len {>=65, <=250} | 155 | maximum object filename | no
+| max_filename_len {>=65, <=230} | 155 | maximum object filename | no
 
 <a name="build-type-options"></a>
 For setting optimization levels and toggling debug, you can either set the

--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -86,6 +86,7 @@ Using the option as-is with no prefix affects all machines. For example:
 | warning_level {0, 1, 2, 3}           | 1             | Set the warning level. From 0 = none to 3 = highest            | no             |
 | werror                               | false         | Treat warnings as errors                                       | no             |
 | wrap_mode {default, nofallback,<br>nodownload, forcefallback} | default | Wrap mode to use                            | no             |
+| max_filename_len {>=65, <=250} | 155 | maximum object filename | no
 
 <a name="build-type-options"></a>
 For setting optimization levels and toggling debug, you can either set the

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -364,7 +364,6 @@ class Backend:
         '''
         Serialize an executable for running with a generator or a custom target
         '''
-        import hashlib
         machine = self.environment.machines[for_machine]
         if machine.is_windows() or machine.is_cygwin():
             extra_paths = self.determine_windows_extra_paths(exe, extra_bdeps or [])

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1125,7 +1125,7 @@ builtin_options = OrderedDict([
     ('warning_level',   BuiltinOption(UserComboOption, 'Compiler warning level to use', '1', choices=['0', '1', '2', '3'])),
     ('werror',          BuiltinOption(UserBooleanOption, 'Treat warnings as errors', False, yielding=False)),
     ('wrap_mode',       BuiltinOption(UserComboOption, 'Wrap mode', 'default', choices=['default', 'nofallback', 'nodownload', 'forcefallback'])),
-    ('max_filename_len', BuiltinOption(UserIntegerOption, 'maximum filename length of object.', (65, 250, 155)))
+    ('max_filename_len', BuiltinOption(UserIntegerOption, 'maximum filename length of object.', (65, 230, 155)))
 ])
 
 builtin_options_per_machine = OrderedDict([

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1125,6 +1125,7 @@ builtin_options = OrderedDict([
     ('warning_level',   BuiltinOption(UserComboOption, 'Compiler warning level to use', '1', choices=['0', '1', '2', '3'])),
     ('werror',          BuiltinOption(UserBooleanOption, 'Treat warnings as errors', False, yielding=False)),
     ('wrap_mode',       BuiltinOption(UserComboOption, 'Wrap mode', 'default', choices=['default', 'nofallback', 'nodownload', 'forcefallback'])),
+    ('max_filename_len', BuiltinOption(UserIntegerOption, 'maximum filename length of object.', (65, 250, 155)))
 ])
 
 builtin_options_per_machine = OrderedDict([


### PR DESCRIPTION
try to fix #7159 
When the project has very deep folder, object_filename_from_source() tends to create very long filename exceeding linux filename limit of 255.  Here, I try to impose a max_filename_len to it. Once it exceed the length, it truncate the filename and add sha256 of the filename to the front to make sure the resulting length == max_filename_len. The hash value length is 64, thus the max_filename_len should at least 65 otherwise the filename length is actually increased. I also set the maximum value to 230 to give it some room for the postfix.