### PR TITLE
ninja: Always use to_native on CompilerArgs (fixes #7167)

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -151,6 +151,10 @@ class NinjaBuildElement:
             self.orderdeps.add(dep)
 
     def add_item(self, name, elems):
+        # Always convert from GCC-style argument naming to the naming used by the
+        # current compiler. Also filter system include paths, deduplicate, etc.
+        if isinstance(elems, CompilerArgs):
+            elems = elems.to_native()
         if isinstance(elems, str):
             elems = [elems]
         self.elems.append((name, elems))
@@ -1985,9 +1989,6 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # Write the Ninja build command
         compiler_name = self.get_compiler_rule_name('llvm_ir', compiler.for_machine)
         element = NinjaBuildElement(self.all_outputs, rel_obj, compiler_name, rel_src)
-        # Convert from GCC-style link argument naming to the naming used by the
-        # current compiler.
-        commands = commands.to_native()
         element.add_item('ARGS', commands)
         self.add_build(element)
         return rel_obj
@@ -2204,9 +2205,6 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 d = os.path.join(self.get_target_private_dir(target), d)
             element.add_orderdep(d)
         element.add_dep(pch_dep)
-        # Convert from GCC-style link argument naming to the naming used by the
-        # current compiler.
-        commands = commands.to_native()
         for i in self.get_fortran_orderdeps(target, compiler):
             element.add_orderdep(i)
         element.add_item('DEPFILE', dep_file)
@@ -2594,9 +2592,6 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         commands += extra_args
         commands += custom_target_libraries
         commands += stdlib_args # Standard library arguments go last, because they never depend on anything.
-        # Convert from GCC-style link argument naming to the naming used by the
-        # current compiler.
-        commands = commands.to_native()
         dep_targets.extend([self.get_dependency_filename(t) for t in dependencies])
         dep_targets.extend([self.get_dependency_filename(t)
                             for t in target.link_depends])

--- a/test cases/common/226 include_type dependency/main.cpp
+++ b/test cases/common/226 include_type dependency/main.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+#include <boost/graph/filtered_graph.hpp>
+
+using namespace std;
+
+int main(void) {
+  return 0;
+}

--- a/test cases/common/226 include_type dependency/meson.build
+++ b/test cases/common/226 include_type dependency/meson.build
@@ -4,8 +4,14 @@ project(
 )
 
 dep = dependency('zlib', method: 'pkg-config', required : false)
+boost_dep = dependency('boost', modules: ['graph'], include_type : 'system', required: false)
+
 if not dep.found()
   error('MESON_SKIP_TEST zlib was not found')
+endif
+
+if not boost_dep.found()
+  error('MESON_SKIP_TEST boost was not found')
 endif
 
 assert(dep.include_type() == 'preserve', 'include_type must default to "preserve"')
@@ -26,3 +32,7 @@ assert(sp_dep.include_type() == 'preserve', 'default is preserve')
 sp_dep_sys = sp_dep.as_system('system')
 assert(sp_dep_sys.include_type() == 'system', 'changing include_type works')
 assert(sp_dep.include_type() == 'preserve', 'as_system must not mutate the original object')
+
+# Check that PCH works with `include_type : 'system'` See https://github.com/mesonbuild/meson/issues/7167
+main_exe = executable('main_exe', 'main.cpp', cpp_pch: 'pch/test.hpp', dependencies: boost_dep)
+test('main_test', main_exe)

--- a/test cases/common/226 include_type dependency/pch/test.hpp
+++ b/test cases/common/226 include_type dependency/pch/test.hpp
@@ -1,0 +1,1 @@
+#include <boost/graph/filtered_graph.hpp>


### PR DESCRIPTION
Always convert `CompilerArgs` to the native in `add_item`. This should not hurt for compilers that don't need it and prevents bugs like #7167 in the future.