### PR TITLE
Added ability to pass arguments to backend in `meson compile`

### DIFF
--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -137,7 +137,7 @@ meson configure builddir -Doption=new_value
 
 ```
 $ meson compile [-h] [-j JOBS] [-l LOAD_AVERAGE] [--clean] [-C BUILDDIR]
-                [--verbose]
+                [--verbose] [--ninja-args NINJA_ARGS] [--vs-args VS_ARGS]
 ```
 
 Builds a default or a specified target of a configured meson project.
@@ -155,6 +155,30 @@ optional arguments:
   -C BUILDDIR                           The directory containing build files to
                                         be built.
   --verbose                             Show more verbose output.
+  --ninja-args NINJA_ARGS               Arguments to pass to `ninja` (applied
+                                        only on `ninja` backend).
+  --vs-args VS_ARGS                     Arguments to pass to `msbuild` (applied
+                                        only on `vs` backend).
+```
+
+#### Backend specific arguments
+
+*(since 0.55.0)*
+
+`BACKEND-args` use the following syntax:
+
+If you only pass a single string, then it is considered to have all values separated by commas. Thus invoking the following command:
+
+```
+$ meson compile --ninja-args=-n,-d,explain
+```
+
+would add `-n`, `-d` and `explain` arguments to ninja invocation.
+
+If you need to have commas or spaces in your string values, then you need to pass the value with proper shell quoting like this:
+
+```
+$ meson compile "--ninja-args=['a,b', 'c d']"
 ```
 
 #### Examples:
@@ -162,6 +186,11 @@ optional arguments:
 Build the project:
 ```
 meson compile -C builddir
+```
+
+Execute a dry run on ninja backend with additional debug info:
+```
+meson compile --ninja-args=-n,-d,explain
 ```
 
 ### dist

--- a/docs/markdown/snippets/add_compile_backend_arg.md
+++ b/docs/markdown/snippets/add_compile_backend_arg.md
@@ -1,0 +1,26 @@
+## Added ability to specify backend arguments in `meson compile`
+
+It's now possible to specify backend specific arguments in `meson compile`.
+
+Usage: `meson compile [--vs-args=args] [--ninja-args=args]`
+
+```
+  --ninja-args NINJA_ARGS    Arguments to pass to `ninja` (applied only on `ninja` backend).
+  --vs-args VS_ARGS          Arguments to pass to `msbuild` (applied only on `vs` backend).
+```
+
+These arguments use the following syntax:
+
+If you only pass a single string, then it is considered to have all values separated by commas. Thus invoking the following command:
+
+```
+$ meson compile --ninja-args=-n,-d,explain
+```
+
+would add `-n`, `-d` and `explain` arguments to ninja invocation.
+
+If you need to have commas or spaces in your string values, then you need to pass the value with proper shell quoting like this:
+
+```
+$ meson compile "--ninja-args=['a,b', 'c d']"
+```

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4637,12 +4637,27 @@ recommended as it is not supported on some platforms''')
 
         testdir = os.path.join(self.common_test_dir, '1 trivial')
         self.init(testdir)
+
         self._run([*self.meson_command, 'compile', '-C', self.builddir])
         # If compile worked then we should get a program
         self.assertPathExists(os.path.join(self.builddir, prog))
 
         self._run([*self.meson_command, 'compile', '-C', self.builddir, '--clean'])
         self.assertPathDoesNotExist(os.path.join(self.builddir, prog))
+
+        # `--$BACKEND-args`
+
+        if self.backend is Backend.ninja:
+            self.init(testdir, extra_args=['--wipe'])
+            # Dry run - should not create a program
+            self._run([*self.meson_command, 'compile', '-C', self.builddir, '--ninja-args=-n'])
+            self.assertPathDoesNotExist(os.path.join(self.builddir, prog))
+        elif self.backend is Backend.vs:
+            self.init(testdir, extra_args=['--wipe'])
+            self._run([*self.meson_command, 'compile', '-C', self.builddir])
+            # Explicitly clean the target through msbuild interface
+            self._run([*self.meson_command, 'compile', '-C', self.builddir, '--vs-args=-t:{}:Clean'.format(re.sub(r'[\%\$\@\;\.\(\)\']', '_', prog))])
+            self.assertPathDoesNotExist(os.path.join(self.builddir, prog))
 
     def test_spurious_reconfigure_built_dep_file(self):
         testdir = os.path.join(self.unit_test_dir, '75 dep files')


### PR DESCRIPTION
Adds ability to pass arguments directly to backend build tool:
```
usage: meson compile [--vs-args=args] [--ninja-args=args]
```

These arguments  use the following syntax:

If you only pass a single string, then it is considered to have all values separated by commas. Thus invoking the following command:

```
$ meson compile --ninja-args=foo,bar
```

would set the value to an array of two elements, foo and bar.

If you need to have commas in your string values, then you need to pass the value with proper shell quoting like this:

```
$ meson compile "--ninja-args=['a,b', 'c,d']"
```