### PR TITLE
Add boost_root kwarg support to `dependency('boost')`

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -289,7 +289,10 @@ use those to link against your targets.
 
 If your boost headers or libraries are in non-standard locations you
 can set the BOOST_ROOT, BOOST_INCLUDEDIR, and/or BOOST_LIBRARYDIR
-environment variables.
+environment variables. *(added in 0.55.0)* You can also set the argument
+`boost_root` to select a boost installation. BOOST_ROOT does not
+fall back to `boost_root` or system boost directories, however
+`boost_root` will fall back to system directories if not found.
 
 You can set the argument `threading` to `single` to use boost
 libraries that have been compiled for single-threaded use instead.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2254,6 +2254,7 @@ permitted_kwargs = {'add_global_arguments': {'language', 'native'},
                                    'private_headers',
                                    'cmake_args',
                                    'include_type',
+                                   'boost_root',
                                    },
                     'declare_dependency': {'include_directories',
                                            'link_with',
@@ -3478,6 +3479,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         elif name == 'openmp':
             FeatureNew('OpenMP Dependency', '0.46.0').use(self.subproject)
 
+    @FeatureNewKwargs('dependency', '0.55.0', ['boost_root'])
     @FeatureNewKwargs('dependency', '0.54.0', ['components'])
     @FeatureNewKwargs('dependency', '0.52.0', ['include_type'])
     @FeatureNewKwargs('dependency', '0.50.0', ['not_found_message', 'cmake_module_path', 'cmake_args'])


### PR DESCRIPTION
Resolves #249

This commit implements a `boost_root` kwarg for boost dependencies.

Systems I work on typically have several boost installations per user: one (old) system-wide version, and one or more with varying { versions x ABIs } installed by a user (e.g. by [spack](https://github.com/spack/spack)).

Meson (and CMake) will often result in the compiler picking up headers from a user-installed version, but libraries from the system, resulting in linker errors at the very end of a build and some frustration.
This PR allows `boost_root` to be specified inline or in a configuration file in a way that's persistent, which prevents these issues.

Outstanding questions:
1) I'm not familiar enough with how the testing (CI and regular) works to add tests for this functionality. Any ideas? I'm thinking I could symlink a boost install somewhere else in CI and look for it there. 
2) Is what I did with the new kwargs parameters correct?
    a) Can I add `boost_root` to `permitted_kwargs` for `dependency`? It's not clear to me how to add it for just the `dependency('boost')` case.
    b) What do I set the version in `@FeatureNewKwargs` to, in general? The next release number, as I've done here?
3) I'm trying to copy the `dirs` behavior from e.g. `find_program`, where `boost_root` will fall back to the system installation if not found. But, boost_root isn't plural. But, the env var BOOST_ROOT also can take multiple optional paths and also isn't plural. Any opinions here (or am I just overthinking things)?
4) I'm assuming that custom installs are generally not going to be split in ways that require use of BOOST_INCLUDEDIR + BOOST_LIBRARYDIR. (Certainly, I don't need them for the use case I have in mind). Should I just bite the bullet and implement them here too?