### PR TITLE
Remove stray print call.

### DIFF
--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -417,7 +417,6 @@ def _compare_output(expected: T.List[T.Dict[str, str]], output: str, desc: str) 
                     match = bool(re.match(expected, actual))
                 else:
                     match = (expected == actual)
-                    print(actual)
                 if match:
                     how, expected = next_expected(i)
 


### PR DESCRIPTION
The current logs are unreadable because all text printed by failing meson logs gets spammed to stdout.