### PR TITLE
mcompile: replaced backend divination code + cleanup

### DIFF
--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -14,8 +14,6 @@
 
 """Entrypoint script for backend agnostic compile."""
 
-import os
-import shutil
 import sys
 import typing as T
 from pathlib import Path

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -24,6 +24,7 @@ from . import mlog
 from . import mesonlib
 from . import coredata
 from .mesonlib import MesonException
+from mesonbuild.environment import detect_ninja
 
 if T.TYPE_CHECKING:
     import argparse
@@ -42,15 +43,9 @@ def get_backend_from_coredata(builddir: Path) -> str:
     return coredata.load(str(builddir)).get_builtin_option('backend')
 
 def get_parsed_args_ninja(options: 'argparse.Namespace', builddir: Path):
-    runner = os.environ.get('NINJA')
-    if not runner:
-        if shutil.which('ninja'):
-            runner = 'ninja'
-        elif shutil.which('samu'):
-            runner = 'samu'
-
+    runner = detect_ninja()
     if runner is None:
-        raise MesonException('Cannot find either ninja or samu.')
+        raise MesonException('Cannot find ninja.')
     mlog.log('Found runner:', runner)
 
     cmd = [runner, '-C', builddir.as_posix()]

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -14,7 +14,6 @@
 
 """Entrypoint script for backend agnostic compile."""
 
-import json
 import os
 import shutil
 import sys
@@ -23,26 +22,70 @@ from pathlib import Path
 
 from . import mlog
 from . import mesonlib
+from . import coredata
 from .mesonlib import MesonException
 
 if T.TYPE_CHECKING:
     import argparse
+    
+def validate_builddir(builddir: Path):
+    if not (builddir / 'meson-private' / 'coredata.dat' ).is_file():
+        raise MesonException('Current directory is not a meson build directory: `{}`.\n'
+                             'Please specify a valid build dir or change the working directory to it.\n'
+                             'It is also possible that the build directory was generated with an old\n'
+                             'meson version. Please regenerate it in this case.'.format(builddir))
 
-def get_backend_from_introspect(builddir: Path) -> str:
+def get_backend_from_coredata(builddir: Path) -> str:
     """
-    Gets `backend` option value from introspection data
+    Gets `backend` option value from coredata
     """
-    path_to_intro = builddir / 'meson-info' / 'intro-buildoptions.json'
-    if not path_to_intro.exists():
-        raise MesonException('`{}` is missing! Directory is not configured yet?'.format(path_to_intro.name))
-    with (path_to_intro).open() as f:
-        schema = json.load(f)
+    return coredata.load(str(builddir)).get_builtin_option('backend')
 
-    for option in schema:
-        if option['name'] == 'backend':
-            return option['value']
-    raise MesonException('`{}` is missing `backend` option!'.format(path_to_intro.name))
+def get_parsed_args_ninja(options: 'argparse.Namespace', builddir: Path):
+    runner = os.environ.get('NINJA')
+    if not runner:
+        if shutil.which('ninja'):
+            runner = 'ninja'
+        elif shutil.which('samu'):
+            runner = 'samu'
 
+    if runner is None:
+        raise MesonException('Cannot find either ninja or samu.')
+    mlog.log('Found runner:', runner)
+
+    cmd = [runner, '-C', builddir.as_posix()]
+
+    # If the value is set to < 1 then don't set anything, which let's
+    # ninja/samu decide what to do.
+    if options.jobs > 0:
+        cmd.extend(['-j', str(options.jobs)])
+    if options.load_average > 0:
+        cmd.extend(['-l', str(options.load_average)])
+    if options.clean:
+        cmd.append('clean')
+    
+    return cmd
+
+def get_parsed_args_vs(options: 'argparse.Namespace', builddir: Path):
+    slns = list(builddir.glob('*.sln'))
+    assert len(slns) == 1, 'More than one solution in a project?'
+    
+    sln = slns[0]
+    cmd = ['msbuild', str(sln.resolve())]
+    
+    # In msbuild `-m` with no number means "detect cpus", the default is `-m1`
+    if options.jobs > 0:
+        cmd.append('-m{}'.format(options.jobs))
+    else:
+        cmd.append('-m')
+    
+    if options.load_average:
+        mlog.warning('Msbuild does not have a load-average switch, ignoring.')
+    if options.clean:
+        cmd.extend(['/t:Clean'])
+    
+    return cmd
+    
 def add_arguments(parser: 'argparse.ArgumentParser') -> None:
     """Add compile specific arguments."""
     parser.add_argument(
@@ -76,57 +119,17 @@ def add_arguments(parser: 'argparse.ArgumentParser') -> None:
 
 def run(options: 'argparse.Namespace') -> int:
     bdir = options.builddir  # type: Path
-    if not bdir.exists():
-        raise MesonException('Path to builddir {} does not exist!'.format(str(bdir.resolve())))
-    if not bdir.is_dir():
-        raise MesonException('builddir path should be a directory.')
+    validate_builddir(bdir.resolve())
 
     cmd = []  # type: T.List[str]
 
-    backend = get_backend_from_introspect(bdir)
+    backend = get_backend_from_coredata(bdir)
     if backend == 'ninja':
-        runner = os.environ.get('NINJA')
-        if not runner:
-            if shutil.which('ninja'):
-                runner = 'ninja'
-            elif shutil.which('samu'):
-                runner = 'samu'
-
-        if runner is None:
-            raise MesonException('Cannot find either ninja or samu.')
-        mlog.log('Found runner:', runner)
-
-        cmd = [runner, '-C', bdir.as_posix()]
-
-        # If the value is set to < 1 then don't set anything, which let's
-        # ninja/samu decide what to do.
-        if options.jobs > 0:
-            cmd.extend(['-j', str(options.jobs)])
-        if options.load_average > 0:
-            cmd.extend(['-l', str(options.load_average)])
-        if options.clean:
-            cmd.append('clean')
-
+        cmd = get_parsed_args_ninja(options, bdir)
     elif backend.startswith('vs'):
-        slns = list(bdir.glob('*.sln'))
-        assert len(slns) == 1, 'More than one solution in a project?'
-
-        sln = slns[0]
-        cmd = ['msbuild', str(sln.resolve())]
-
-        # In msbuild `-m` with no number means "detect cpus", the default is `-m1`
-        if options.jobs > 0:
-            cmd.append('-m{}'.format(options.jobs))
-        else:
-            cmd.append('-m')
-
-        if options.load_average:
-            mlog.warning('Msbuild does not have a load-average switch, ignoring.')
-        if options.clean:
-            cmd.extend(['/t:Clean'])
-
-    # TODO: xcode?
+        cmd = get_parsed_args_vs(options, bdir)
     else:
+        # TODO: xcode?
         raise MesonException(
             'Backend `{}` is not yet supported by `compile`. Use generated project files directly instead.'.format(backend))
 


### PR DESCRIPTION
- Replaced backend divination code with coredata parsing (`meson compile` should be used only with meson configured folders anyway).
- Extracted backend specific code to separate functions.
- Improved(?) error message when invoked on non-configured directory.