### PR TITLE
Use rsp files when linking many files with gnulike linker

### DIFF
--- a/docs/markdown/snippets/response_files.md
+++ b/docs/markdown/snippets/response_files.md
@@ -1,0 +1,2 @@
+To avoid commandline limits, meson now uses response
+files if the number of arguments to the linker is large.

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -704,6 +704,10 @@ class GnuDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, Dynam
 
     """Representation of GNU ld.bfd and ld.gold."""
 
+    def get_accepts_rsp(self) -> bool:
+        # rsp files should only be used if on windows or if # of args is huge,
+        # but we don't know # of args here, so let caller worry about that.
+        return True;
 
 class GnuGoldDynamicLinker(GnuDynamicLinker):
 


### PR DESCRIPTION
Even non-windows systems have commandline limits, so when linking
"too many" files, use a response file.  (Don't use them on normal-sized
link commands; they're obscure and would make developers unhappy.)

This patch uses a lame definition of "too many", and doesn't address static libraries,
but it may be enough for now.

Partially fixes #7212