### PR TITLE
Added docs for all meson commands + corresponding unit test

### DIFF
--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -14,6 +14,18 @@ The most common workflow is to run [`setup`](#setup), followed by [`compile`](#c
 For the full list of all available options for a specific command use the following syntax:
 `meson COMMAND --help`
 
+### configure
+
+Reconfigures existing meson project.
+
+Examples:
+- `meson configure builddir`: list all available options.
+- `meson configure builddir -Doption=new_value`: change a single option
+
+Most arguments are the same as in [`setup`](#setup).
+
+Note: reconfiguring project will not reset options to their default values (even if they were changed in `meson.build`).
+
 ### compile
 
 *(since 0.54.0)*

--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -79,7 +79,7 @@ Noteable options:
 
 *(since 0.45.0)*
 
-Generates a basic meson setup from the template.
+Creates a basic set of build files based on a template.
 
 Example: `meson init -C sourcedir`
 
@@ -103,11 +103,13 @@ Notable introspect commands:
 
 *(since 0.47.0)*
 
-Installs the project to the folder specified in `setup`.
+Installs the project to the prefix specified in `setup`.
 
-Example: `meson install -C builddir`
+Examples: 
+- `meson install -C builddir`
+- `DESTDIR=/path/to/staging/area meson install -C builddir`
 
-See [this page](Installing.md) for more info.
+See [the installation documentation](Installing.md) for more info.
 
 ### rewrite
 
@@ -115,7 +117,7 @@ See [this page](Installing.md) for more info.
 
 Modifies the meson project.
 
-See [this page](Rewriter.md) for more info.
+See [the meson file rewriter documentation](Rewriter.md) for more info.
 
 ### setup
 
@@ -125,7 +127,7 @@ Configures a build directory for the meson project.
 
 Example: `meson setup builddir`
 
-See [this page](Running-Meson.md#configuring-the-build-directory) for more info.
+See [meson introduction page](Running-Meson.md#configuring-the-build-directory) for more info.
 
 ### subprojects
 
@@ -147,10 +149,10 @@ Run tests for the configure meson project.
 
 Example: `meson test -C builddir`
 
-See [this page](Unit-tests.md) for more info.
+See [the unit test documentation](Unit-tests.md) for more info.
 
 ### wrap
 
 An utility to manage WrapDB dependencies.
 
-See [this page](Using-wraptool.md) for more info.
+See [the WrapDB tool documentation](Using-wraptool.md) for more info.

--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -1,0 +1,156 @@
+# Command-line commands
+
+There are two different ways of invoking Meson. First, you can run it directly
+from the source tree with the command `/path/to/source/meson.py`. Meson may
+also be installed in which case the command is simply `meson`. In this manual
+we only use the latter format for simplicity.
+
+Meson is invoked using the following syntax:
+`meson [COMMAND] [COMMAND_OPTIONS]`
+
+This section describes all available commands and some of their notable options.
+
+For full list of available options for a specific command use the following syntax:
+`meson COMMAND --help`
+
+### compile
+
+*(since 0.54.0)*
+
+Builds a default or specified target of a configured meson project.
+
+Syntax: `meson compile [TARGET [TARGET...]] [options]`  
+Eample: `meson compile -C builddir`
+
+Note: specifying a target is available since 0.55.0.
+
+`TARGET` has the following syntax: `[PATH/]NAME[:TYPE]`.
+`NAME`: name of the target from `meson.build` (e.g. `foo` from `executable('foo', ...)`).
+`PATH`: path to the target relative to the root `meson.build` file. Note: relative path for a target specified in the root `meson.build` is `./`.
+`TYPE`: type of the target (e.g. `shared_library`, `executable` and etc)
+
+`PATH` and/or `TYPE` can be ommited if the resulting `TARGET` can be used to uniquely identify the target in `meson.build`.
+
+For example targets from the following code:
+```meson
+shared_library('foo', ...)
+static_library('foo', ...)
+executable('bar', ...)
+```
+can be invoked with `meson compile foo:shared_library foo:static_library bar`.
+
+Note: the following limitations for backends apply:
+- `ninja`: `custom_target` is not supported.
+- `vs`: `run_target` is not supported.
+
+Notable options:
+- `--jobs JOBS`: The number of worker jobs to run (if supported). If the value is less
+                 than 1 the build program will guess.
+- `--clean`: Cleans the build directory.
+
+### dist
+
+*(since 0.52.0)*
+
+Generates a release archive from the current source tree.
+
+Example: `meson dist -C builddir`
+
+This creates a file called `projectname-version.tar.xz` in the build
+tree subdirectory `meson-dist`. This archive contains the full
+contents of the latest commit in revision control including all the
+submodules (recursively). All revision control metadata is removed.
+Meson then takes
+this archive and tests that it works by doing a full compile + test +
+install cycle. If all these pass, Meson will then create a SHA-256
+checksum file next to the archive.
+
+**Note**: Meson behaviour is different from Autotools. The Autotools
+"dist" target packages up the current source tree. Meson packages
+the latest revision control commit. The reason for this is that it
+prevents developers from doing accidental releases where the
+distributed archive does not match any commit in revision control
+(especially the one tagged for the release).
+
+Noteable options:
+- `--include-subprojects`: Include source code of subprojects that have been used for the build.
+
+### init
+
+*(since 0.45.0)*
+
+Generates a basic meson setup from the template.
+
+Example: `meson init -C sourcedir`
+
+Notable options:
+- `--name NAME`: project name. default: name of current directory.
+- `--deps DEPS`: list of project dependencies, comma-separated.
+
+### introspect
+
+Displays information about a configured meson project.
+
+Syntax: `meson introspect [builddir] INTROSPECT_COMMAND [introspect_command_options]`  
+Example: `meson introspect builddir`
+
+Notable introspect commands:
+- `--buildoptions`: List all build options.
+- `--dependencies`: List external dependencies.
+- `--targets`: List top level targets.
+
+### install
+
+*(since 0.47.0)*
+
+Installs the project to the folder specified in `setup`.
+
+Example: `meson install -C builddir`
+
+See [this page](Installing.md) for more info.
+
+### rewrite
+
+*(since 0.50.0)*
+
+Modifies the meson project.
+
+See [this page](Rewriter.md) for more info.
+
+### setup
+
+The default meson command (invoked if there was no COMMAND supplied).
+
+Configures a build directory for the meson project.
+
+Example: `meson setup builddir`
+
+See [this page](Running-Meson.md#configuring-the-build-directory) for more info.
+
+### subprojects
+
+*(since 0.49.0)*
+
+Manages subprojects of the meson project.
+
+Syntax: `meson subprojects SUBPROJECTS_COMMAND [subprojects_command_options]`
+
+Notable subprojects commands:
+- `download`: Ensure subprojects are fetched, even if not in use. Already downloaded subprojects
+              are not modified. This can be used to pre-fetch all subprojects and avoid
+              downloads during configure.
+- `foreach`: Execute a command in each subproject directory.
+
+### test
+
+Run tests for the configure meson project.
+
+Example: `meson test -C builddir`
+
+See [this page](Unit-tests.md) for more info.
+
+### wrap
+
+An utility to manage WrapDB dependencies.
+
+See [this page](Using-wraptool.md) for more info.

--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -8,7 +8,7 @@ we only use the latter format for simplicity.
 Meson is invoked using the following syntax:
 `meson [COMMAND] [COMMAND_OPTIONS]`
 
-This section describes all available commands and some of their notable options.
+This section describes all available commands and some of their Optional arguments.
 The most common workflow is to run [`setup`](#setup), followed by [`compile`](#compile), and then [`install`](#install).
 
 For the full list of all available options for a specific command use the following syntax:
@@ -56,7 +56,7 @@ Note: the following limitations for backends apply:
 - `ninja`: `custom_target` is not supported.
 - `vs`: `run_target` is not supported.
 
-Notable options:
+Optional arguments:
 - `--jobs JOBS`: The number of worker jobs to run (if supported). If the value is less
                  than 1 the build program will guess.
 - `--clean`: Cleans the build directory.
@@ -96,7 +96,7 @@ Creates a basic set of build files based on a template.
 
 Example: `meson init -C sourcedir`
 
-Notable options:
+Optional arguments:
 - `--name NAME`: project name. default: name of current directory.
 - `--deps DEPS`: list of project dependencies, comma-separated.
 

--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -9,8 +9,9 @@ Meson is invoked using the following syntax:
 `meson [COMMAND] [COMMAND_OPTIONS]`
 
 This section describes all available commands and some of their notable options.
+The most common workflow is to run [`setup`](#setup), followed by [`compile`](#compile), and then [`install`](#install).
 
-For full list of available options for a specific command use the following syntax:
+For the full list of all available options for a specific command use the following syntax:
 `meson COMMAND --help`
 
 ### compile

--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -22,6 +22,46 @@ Examples:
 - `meson configure builddir`: list all available options.
 - `meson configure builddir -Doption=new_value`: change a single option
 
+Positional arguments:
+- `builddir`: path to the configured build directory
+
+Optional arguments:
+- `--prefix PREFIX`: Installation prefix.
+- `--bindir BINDIR`: Executable directory.
+- `--datadir DATADIR`: Data file directory.
+- `--includedir INCLUDEDIR`: Header file directory.
+- `--infodir INFODIR`: Info page directory.
+- `--libdir LIBDIR`: Library directory.
+- `--libexecdir LIBEXECDIR`: Library executable directory.
+- `--localedir LOCALEDIR`: Locale data directory.
+- `--localstatedir LOCALSTATEDIR`: Localstate data directory.
+- `--mandir MANDIR`: Manual page directory.
+- `--sbindir SBINDIR`: System executable directory.
+- `--sharedstatedir SHAREDSTATEDIR`: Architecture-independent data directory.
+- `--sysconfdir SYSCONFDIR`: Sysconf data directory.
+- `--auto-features`: Override value of all 'auto' features.
+- `--backend`: Backend to use.
+- `--buildtype`: Build type to use.
+- `--debug`: Debug.
+- `--default-library`: Default library type.
+- `--errorlogs`: Whether to print the logs from failing tests.
+- `--install-umask INSTALL_UMASK`: Default umask to apply on permissions of installed files.
+- `--layout`: Build directory layout.
+- `--optimization`: Optimization level.
+- `--stdsplit`: Split stdout and stderr in test logs.
+- `--strip`: Strip targets on install.
+- `--unity`: Unity build.
+- `--unity-size UNITY_SIZE`: Unity block size.
+- `--warnlevel`: Compiler warning level to use.
+- `--werror`: Treat warnings as errors.
+- `--wrap-mode`: Wrap mode.
+- `--pkg-config-path PKG_CONFIG_PATH`: List of additional paths for pkg-config to search (just for host machine).
+- `--build.pkg-config-path BUILD.PKG_CONFIG_PATH`: List of additional paths for pkg-config to search (just for build machine).
+- `--cmake-prefix-path CMAKE_PREFIX_PATH`: List of additional prefixes for cmake to search (just for host machine).
+- `--build.cmake-prefix-path BUILD.CMAKE_PREFIX_PATH`: List of additional prefixes for cmake to search (just for build machine).
+- `-D option`: Set the value of an option, can be used several times to set multiple options.
+- `--clearcache`: Clear cached state (e.g. found dependencies)
+
 Most arguments are the same as in [`setup`](#setup).
 
 Note: reconfiguring project will not reset options to their default values (even if they were changed in `meson.build`).
@@ -32,34 +72,13 @@ Note: reconfiguring project will not reset options to their default values (even
 
 Builds a default or specified target of a configured meson project.
 
-Syntax: `meson compile [TARGET [TARGET...]] [options]`  
-Eample: `meson compile -C builddir`
-
-Note: specifying a target is available since 0.55.0.
-
-`TARGET` has the following syntax: `[PATH/]NAME[:TYPE]`.
-`NAME`: name of the target from `meson.build` (e.g. `foo` from `executable('foo', ...)`).
-`PATH`: path to the target relative to the root `meson.build` file. Note: relative path for a target specified in the root `meson.build` is `./`.
-`TYPE`: type of the target (e.g. `shared_library`, `executable` and etc)
-
-`PATH` and/or `TYPE` can be ommited if the resulting `TARGET` can be used to uniquely identify the target in `meson.build`.
-
-For example targets from the following code:
-```meson
-shared_library('foo', ...)
-static_library('foo', ...)
-executable('bar', ...)
-```
-can be invoked with `meson compile foo:shared_library foo:static_library bar`.
-
-Note: the following limitations for backends apply:
-- `ninja`: `custom_target` is not supported.
-- `vs`: `run_target` is not supported.
+Example: `meson compile -C builddir`
 
 Optional arguments:
-- `--jobs JOBS`: The number of worker jobs to run (if supported). If the value is less
-                 than 1 the build program will guess.
-- `--clean`: Cleans the build directory.
+- `-j JOBS, --jobs JOBS`: The number of worker jobs to run (if supported). If the value is less than 1 the build program will guess.
+- `-l LOAD_AVERAGE, --load-average LOAD_AVERAGE`: The system load average to try to maintain (if supported).
+- `--clean`: Clean the build directory.
+- `-C BUILDDIR`: The directory containing build files to be built.
 
 ### dist
 
@@ -68,6 +87,12 @@ Optional arguments:
 Generates a release archive from the current source tree.
 
 Example: `meson dist -C builddir`
+
+Optional arguments:
+- `-C WD`: directory to cd into before running.
+- `--formats FORMATS`: Comma separated list of archive types to create.
+- `--include-subprojects`: Include source code of subprojects that have been used for the build.
+- `--no-tests`: Do not build and test generated packages.
 
 This creates a file called `projectname-version.tar.xz` in the build
 tree subdirectory `meson-dist`. This archive contains the full
@@ -85,9 +110,6 @@ prevents developers from doing accidental releases where the
 distributed archive does not match any commit in revision control
 (especially the one tagged for the release).
 
-Noteable options:
-- `--include-subprojects`: Include source code of subprojects that have been used for the build.
-
 ### init
 
 *(since 0.45.0)*
@@ -96,9 +118,20 @@ Creates a basic set of build files based on a template.
 
 Example: `meson init -C sourcedir`
 
+Positional arguments:
+- `sourcefile`: source files. default: all recognized files in current directory.
+
 Optional arguments:
-- `--name NAME`: project name. default: name of current directory.
-- `--deps DEPS`: list of project dependencies, comma-separated.
+- `-C WD`: directory to cd into before running.
+- `-n NAME, --name NAME`: project name. default: name of current directory.
+- `-e EXECUTABLE, --executable EXECUTABLE`: executable name. default: project name.
+- `-d DEPS, --deps DEPS`: dependencies, comma-separated.
+- `-l`: project language. default: autodetected based on source files.
+- `-b, --build`: build after generation.
+- `--builddir BUILDDIR`: directory for build.
+- `-f, --force`: force overwrite of existing files and directories.
+- `--type`: project type. default: executable based project.
+- `--version VERSION`: project version. default: 0.1
 
 ### introspect
 
@@ -107,10 +140,24 @@ Displays information about a configured meson project.
 Syntax: `meson introspect [builddir] INTROSPECT_COMMAND [introspect_command_options]`  
 Example: `meson introspect builddir`
 
-Notable introspect commands:
+Positional arguments:
+- `builddir`: The build directory
+
+Optional arguments:
+- `--ast`: Dump the AST of the meson file.
+- `--benchmarks`: List all benchmarks.
 - `--buildoptions`: List all build options.
+- `--buildsystem-files`: List files that make up the build system.
 - `--dependencies`: List external dependencies.
+- `--scan-dependencies`: Scan for dependencies used in the meson.build file.
+- `--installed`: List all installed files and directories.
+- `--projectinfo`: Information about projects.
 - `--targets`: List top level targets.
+- `--tests`: List all unit tests.
+- `--backend`: The backend to use for the --buildoptions introspection.
+- `-a, --all`: Print all available information.
+- `-i, --indent`: Enable pretty printed JSON.
+- `-f, --force-object-output`: Always use the new JSON format for multiple entries (even for 0 and 1 introspection commands)
 
 ### install
 
@@ -119,8 +166,14 @@ Notable introspect commands:
 Installs the project to the prefix specified in `setup`.
 
 Examples: 
-- `meson install -C builddir`
+- `meson install -C builddir`.
 - `DESTDIR=/path/to/staging/area meson install -C builddir`
+
+Optional arguments:
+- `-C WD`: directory to cd into before running.
+- `--no-rebuild`: Do not rebuild before installing.
+- `--only-changed`: Only overwrite files that are older than the copied file.
+- `--quiet`: Do not print every file that was installed.
 
 See [the installation documentation](Installing.md) for more info.
 
@@ -129,6 +182,17 @@ See [the installation documentation](Installing.md) for more info.
 *(since 0.50.0)*
 
 Modifies the meson project.
+
+Optional arguments:
+- `-s SRCDIR, --sourcedir SRCDIR`: Path to source directory.
+- `-V, --verbose`: Enable verbose output.
+- `-S, --skip-errors`: Skip errors instead of aborting
+
+Commands:
+- `target`: Modify a target.
+- `kwargs`: Modify keyword arguments.
+- `default-options`: Modify the project default options.
+- `command`: Execute a JSON array of commands
 
 See [the meson file rewriter documentation](Rewriter.md) for more info.
 
@@ -140,6 +204,52 @@ Configures a build directory for the meson project.
 
 Example: `meson setup builddir`
 
+Positional arguments:
+- `builddir`: path to the build directory.
+- `sourcedir`: path to the directory containing the root `meson.build`.
+
+Optional arguments:
+- `--prefix PREFIX`: Installation prefix.
+- `--bindir BINDIR`: Executable directory.
+- `--datadir DATADIR`: Data file directory.
+- `--includedir INCLUDEDIR`: Header file directory.
+- `--infodir INFODIR`: Info page directory.
+- `--libdir LIBDIR`: Library directory.
+- `--libexecdir LIBEXECDIR`: Library executable directory.
+- `--localedir LOCALEDIR`: Locale data directory.
+- `--localstatedir LOCALSTATEDIR`: Localstate data directory.
+- `--mandir MANDIR`: Manual page directory.
+- `--sbindir SBINDIR`: System executable directory.
+- `--sharedstatedir SHAREDSTATEDIR`: Architecture-independent data directory.
+- `--sysconfdir SYSCONFDIR`: Sysconf data directory.
+- `--auto-features`: Override value of all 'auto' features.
+- `--backend`: Backend to use.
+- `--buildtype`: Build type to use.
+- `--debug`: Debug.
+- `--default-library`: Default library type.
+- `--errorlogs`: Whether to print the logs from failing tests.
+- `--install-umask INSTALL_UMASK`: Default umask to apply on permissions of installed files.
+- `--layout`: Build directory layout.
+- `--optimization`: Optimization level.
+- `--stdsplit`: Split stdout and stderr in test logs.
+- `--strip`: Strip targets on install.
+- `--unity`: Unity build.
+- `--unity-size UNITY_SIZE`: Unity block size.
+- `--warnlevel`: Compiler warning level to use.
+- `--werror`: Treat warnings as errors.
+- `--wrap-mode`: Wrap mode.
+- `--pkg-config-path PKG_CONFIG_PATH`: List of additional paths for pkg-config to search (just for host machine).
+- `--build.pkg-config-path BUILD.PKG_CONFIG_PATH`: List of additional paths for pkg-config to search (just for build machine).
+- `--cmake-prefix-path CMAKE_PREFIX_PATH`: List of additional prefixes for cmake to search (just for host machine).
+- `--build.cmake-prefix-path BUILD.CMAKE_PREFIX_PATH`: List of additional prefixes for cmake to search (just for build machine).
+- `-D option`: Set the value of an option, can be used several times to set multiple options.
+- `--native-file NATIVE_FILE`: File containing overrides for native compilation environment.
+- `--cross-file CROSS_FILE`: File describing cross compilation environment.
+- `-v, --version`: show program's version number and exit.
+- `--fatal-meson-warnings`: Make all Meson warnings fatal.
+- `--reconfigure`: Set options and reconfigure the project. Useful when new options have been added to the project and the default value is not working.
+- `--wipe`: Wipe build directory and reconfigure using previous command line options. Userful when build directory got corrupted, or when rebuilding with a newer version of meson.
+
 See [meson introduction page](Running-Meson.md#configuring-the-build-directory) for more info.
 
 ### subprojects
@@ -150,10 +260,10 @@ Manages subprojects of the meson project.
 
 Syntax: `meson subprojects SUBPROJECTS_COMMAND [subprojects_command_options]`
 
-Notable subprojects commands:
-- `download`: Ensure subprojects are fetched, even if not in use. Already downloaded subprojects
-              are not modified. This can be used to pre-fetch all subprojects and avoid
-              downloads during configure.
+Commands:
+- `update`: Update all subprojects from wrap files.
+- `checkout`: Checkout a branch (git only).
+- `download`: Ensure subprojects are fetched, even if not in use. Already downloaded subprojects are not modified. This can be used to pre-fetch all subprojects and avoid downloads during configure.
 - `foreach`: Execute a command in each subproject directory.
 
 ### test
@@ -162,10 +272,43 @@ Run tests for the configure meson project.
 
 Example: `meson test -C builddir`
 
+Positional arguments:
+- `args`: Optional list of tests to run
+
+Optional arguments:
+- `--repeat REPEAT`: Number of times to run the tests.
+- `--no-rebuild`: Do not rebuild before running tests.
+- `--gdb`: Run test under gdb.
+- `--gdb-path GDB_PATH`: Path to the gdb binary.
+- `--list`: List available tests.
+- `--wrapper WRAPPER`: wrapper to run tests with (e.g. Valgrind).
+- `-C WD`: directory to cd into before running.
+- `--suite SUITE`: Only run tests belonging to the given suite.
+- `--no-suite SUITE`: Do not run tests belonging to the given suite.
+- `--no-stdsplit`: Do not split stderr and stdout in test logs.
+- `--print-errorlogs`: Whether to print failing tests' logs.
+- `--benchmark`: Run benchmarks instead of tests.
+- `--logbase LOGBASE`: Base name for log file.
+- `--num-processes NUM_PROCESSES`: How many parallel processes to use.
+- `-v, --verbose`: Do not redirect stdout and stderr.
+- `-q, --quiet`: Produce less output to the terminal.
+- `-t TIMEOUT_MULTIPLIER, --timeout-multiplier TIMEOUT_MULTIPLIER`: Define a multiplier for test timeout, for example when running tests in particular conditions they might take more time to execute.
+- `--setup SETUP`: Which test setup to use.
+- `--test-args TEST_ARGS`: Arguments to pass to the specified test(s) or all tests
+
 See [the unit test documentation](Unit-tests.md) for more info.
 
 ### wrap
 
 An utility to manage WrapDB dependencies.
+
+Commands:
+- `list`: show all available projects.
+- `search`: search the db by name.
+- `install`: install the specified project.
+- `update`: update the project to its newest available release.
+- `info`: show available versions of a project.
+- `status`: show installed and available versions of your projects.
+- `promote`: bring a subsubproject up to the master project
 
 See [the WrapDB tool documentation](Using-wraptool.md) for more info.

--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -50,27 +50,19 @@ positional arguments:
 
 optional arguments:
   -h, --help                            show this help message and exit
-  --prefix PREFIX                       Installation prefix (default: c:/).
-  --bindir BINDIR                       Executable directory (default: bin).
-  --datadir DATADIR                     Data file directory (default: share).
-  --includedir INCLUDEDIR               Header file directory (default:
-                                        include).
-  --infodir INFODIR                     Info page directory (default:
-                                        share/info).
-  --libdir LIBDIR                       Library directory (default: lib).
-  --libexecdir LIBEXECDIR               Library executable directory (default:
-                                        libexec).
-  --localedir LOCALEDIR                 Locale data directory (default:
-                                        share/locale).
-  --localstatedir LOCALSTATEDIR         Localstate data directory (default:
-                                        var).
-  --mandir MANDIR                       Manual page directory (default:
-                                        share/man).
-  --sbindir SBINDIR                     System executable directory (default:
-                                        sbin).
-  --sharedstatedir SHAREDSTATEDIR       Architecture-independent data directory
-                                        (default: com).
-  --sysconfdir SYSCONFDIR               Sysconf data directory (default: etc).
+  --prefix PREFIX                       Installation prefix.
+  --bindir BINDIR                       Executable directory.
+  --datadir DATADIR                     Data file directory.
+  --includedir INCLUDEDIR               Header file directory.
+  --infodir INFODIR                     Info page directory.
+  --libdir LIBDIR                       Library directory.
+  --libexecdir LIBEXECDIR               Library executable directory.
+  --localedir LOCALEDIR                 Locale data directory.
+  --localstatedir LOCALSTATEDIR         Localstate data directory.
+  --mandir MANDIR                       Manual page directory.
+  --sbindir SBINDIR                     System executable directory.
+  --sharedstatedir SHAREDSTATEDIR       Architecture-independent data directory.
+  --sysconfdir SYSCONFDIR               Sysconf data directory.
   --auto-features {enabled,disabled,auto}
                                         Override value of all 'auto' features
                                         (default: auto).
@@ -408,27 +400,19 @@ positional arguments:
 
 optional arguments:
   -h, --help                            show this help message and exit
-  --prefix PREFIX                       Installation prefix (default: azaza:/).
-  --bindir BINDIR                       Executable directory (default: bin).
-  --datadir DATADIR                     Data file directory (default: share).
-  --includedir INCLUDEDIR               Header file directory (default:
-                                        include).
-  --infodir INFODIR                     Info page directory (default:
-                                        share/info).
-  --libdir LIBDIR                       Library directory (default: lib).
-  --libexecdir LIBEXECDIR               Library executable directory (default:
-                                        libexec).
-  --localedir LOCALEDIR                 Locale data directory (default:
-                                        share/locale).
-  --localstatedir LOCALSTATEDIR         Localstate data directory (default:
-                                        var).
-  --mandir MANDIR                       Manual page directory (default:
-                                        share/man).
-  --sbindir SBINDIR                     System executable directory (default:
-                                        sbin).
-  --sharedstatedir SHAREDSTATEDIR       Architecture-independent data directory
-                                        (default: com).
-  --sysconfdir SYSCONFDIR               Sysconf data directory (default: etc).
+  --prefix PREFIX                       Installation prefix.
+  --bindir BINDIR                       Executable directory.
+  --datadir DATADIR                     Data file directory.
+  --includedir INCLUDEDIR               Header file directory.
+  --infodir INFODIR                     Info page directory.
+  --libdir LIBDIR                       Library directory.
+  --libexecdir LIBEXECDIR               Library executable directory.
+  --localedir LOCALEDIR                 Locale data directory.
+  --localstatedir LOCALSTATEDIR         Localstate data directory.
+  --mandir MANDIR                       Manual page directory.
+  --sbindir SBINDIR                     System executable directory.
+  --sharedstatedir SHAREDSTATEDIR       Architecture-independent data directory.
+  --sysconfdir SYSCONFDIR               Sysconf data directory.
   --auto-features {enabled,disabled,auto}
                                         Override value of all 'auto' features
                                         (default: auto).

--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -123,9 +123,17 @@ Most arguments are the same as in [`setup`](#setup).
 
 Note: reconfiguring project will not reset options to their default values (even if they were changed in `meson.build`).
 
-Examples:
-- `meson configure builddir`: list all available options.
-- `meson configure builddir -Doption=new_value`: change a single option
+#### Examples:
+
+List all available options:
+```
+meson configure builddir
+```
+
+Change value of a single option:
+```
+meson configure builddir -Doption=new_value
+```
 
 ### compile
 
@@ -151,7 +159,12 @@ optional arguments:
                                         be built.
 ```
 
-Example: `meson compile -C builddir`
+#### Examples:
+
+Build the project:
+```
+meson compile -C builddir
+```
 
 ### dist
 
@@ -190,7 +203,12 @@ prevents developers from doing accidental releases where the
 distributed archive does not match any commit in revision control
 (especially the one tagged for the release).
 
-Example: `meson dist -C builddir`
+#### Examples:
+
+Create a release archive:
+```
+meson dist -C builddir
+```
 
 ### init
 
@@ -231,7 +249,12 @@ optional arguments:
   --version VERSION                     project version. default: 0.1
 ```
 
-Example: `meson init -C sourcedir`
+#### Examples:
+
+Create a project in `sourcedir`:
+```
+meson init -C sourcedir
+```
 
 ### introspect
 
@@ -276,7 +299,12 @@ optional arguments:
                                         introspection commands)
 ```
 
-Example: `meson introspect builddir`
+#### Examples:
+
+Display basic information about a configured project in `builddir`:
+```
+meson introspect builddir
+```
 
 ### install
 
@@ -299,9 +327,17 @@ optional arguments:
 
 See [the installation documentation](Installing.md) for more info.
 
-Examples: 
-- `meson install -C builddir`.
-- `DESTDIR=/path/to/staging/area meson install -C builddir`
+#### Examples:
+
+Install project to `prefix` (see [`setup`](#setup)):
+```
+meson install -C builddir
+```
+
+Install project to `$DESTDIR/prefix`:
+```
+DESTDIR=/path/to/staging/area meson install -C builddir
+```
 
 ### rewrite
 
@@ -456,7 +492,12 @@ optional arguments:
 
 See [meson introduction page](Running-Meson.md#configuring-the-build-directory) for more info.
 
-Example: `meson setup builddir`
+#### Examples:
+
+Configures `builddir` with default values:
+```
+meson setup builddir
+```
 
 ### subprojects
 
@@ -538,7 +579,17 @@ optional arguments:
 
 See [the unit test documentation](Unit-tests.md) for more info.
 
-Example: `meson test -C builddir`
+#### Examples:
+
+Run tests for the project:
+```
+meson test -C builddir
+```
+
+Run only `specific_test_1` and `specific_test_2`:
+```
+meson test -C builddir specific_test_1 specific_test_2
+```
 
 ### wrap
 

--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -16,51 +16,112 @@ For the full list of all available options for a specific command use the follow
 
 ### configure
 
+```
+$ meson configure [-h] [--prefix PREFIX] [--bindir BINDIR]
+                  [--datadir DATADIR] [--includedir INCLUDEDIR]
+                  [--infodir INFODIR] [--libdir LIBDIR]
+                  [--libexecdir LIBEXECDIR] [--localedir LOCALEDIR]
+                  [--localstatedir LOCALSTATEDIR] [--mandir MANDIR]
+                  [--sbindir SBINDIR] [--sharedstatedir SHAREDSTATEDIR]
+                  [--sysconfdir SYSCONFDIR]
+                  [--auto-features {enabled,disabled,auto}]
+                  [--backend {ninja,vs,vs2010,vs2015,vs2017,vs2019,xcode}]
+                  [--buildtype {plain,debug,debugoptimized,release,minsize,custom}]
+                  [--debug] [--default-library {shared,static,both}]
+                  [--errorlogs] [--install-umask INSTALL_UMASK]
+                  [--layout {mirror,flat}] [--optimization {0,g,1,2,3,s}]
+                  [--stdsplit] [--strip] [--unity {on,off,subprojects}]
+                  [--unity-size UNITY_SIZE] [--warnlevel {0,1,2,3}]
+                  [--werror]
+                  [--wrap-mode {default,nofallback,nodownload,forcefallback}]
+                  [--pkg-config-path PKG_CONFIG_PATH]
+                  [--build.pkg-config-path BUILD.PKG_CONFIG_PATH]
+                  [--cmake-prefix-path CMAKE_PREFIX_PATH]
+                  [--build.cmake-prefix-path BUILD.CMAKE_PREFIX_PATH]
+                  [-D option] [--clearcache]
+                  [builddir]
+```
+
 Reconfigures existing meson project.
 
 Examples:
 - `meson configure builddir`: list all available options.
 - `meson configure builddir -Doption=new_value`: change a single option
 
-Positional arguments:
-- `builddir`: path to the configured build directory
+```
+positional arguments:
+  builddir
 
-Optional arguments:
-- `--prefix PREFIX`: Installation prefix.
-- `--bindir BINDIR`: Executable directory.
-- `--datadir DATADIR`: Data file directory.
-- `--includedir INCLUDEDIR`: Header file directory.
-- `--infodir INFODIR`: Info page directory.
-- `--libdir LIBDIR`: Library directory.
-- `--libexecdir LIBEXECDIR`: Library executable directory.
-- `--localedir LOCALEDIR`: Locale data directory.
-- `--localstatedir LOCALSTATEDIR`: Localstate data directory.
-- `--mandir MANDIR`: Manual page directory.
-- `--sbindir SBINDIR`: System executable directory.
-- `--sharedstatedir SHAREDSTATEDIR`: Architecture-independent data directory.
-- `--sysconfdir SYSCONFDIR`: Sysconf data directory.
-- `--auto-features`: Override value of all 'auto' features.
-- `--backend`: Backend to use.
-- `--buildtype`: Build type to use.
-- `--debug`: Debug.
-- `--default-library`: Default library type.
-- `--errorlogs`: Whether to print the logs from failing tests.
-- `--install-umask INSTALL_UMASK`: Default umask to apply on permissions of installed files.
-- `--layout`: Build directory layout.
-- `--optimization`: Optimization level.
-- `--stdsplit`: Split stdout and stderr in test logs.
-- `--strip`: Strip targets on install.
-- `--unity`: Unity build.
-- `--unity-size UNITY_SIZE`: Unity block size.
-- `--warnlevel`: Compiler warning level to use.
-- `--werror`: Treat warnings as errors.
-- `--wrap-mode`: Wrap mode.
-- `--pkg-config-path PKG_CONFIG_PATH`: List of additional paths for pkg-config to search (just for host machine).
-- `--build.pkg-config-path BUILD.PKG_CONFIG_PATH`: List of additional paths for pkg-config to search (just for build machine).
-- `--cmake-prefix-path CMAKE_PREFIX_PATH`: List of additional prefixes for cmake to search (just for host machine).
-- `--build.cmake-prefix-path BUILD.CMAKE_PREFIX_PATH`: List of additional prefixes for cmake to search (just for build machine).
-- `-D option`: Set the value of an option, can be used several times to set multiple options.
-- `--clearcache`: Clear cached state (e.g. found dependencies)
+optional arguments:
+  -h, --help                            show this help message and exit
+  --prefix PREFIX                       Installation prefix (default: c:/).
+  --bindir BINDIR                       Executable directory (default: bin).
+  --datadir DATADIR                     Data file directory (default: share).
+  --includedir INCLUDEDIR               Header file directory (default:
+                                        include).
+  --infodir INFODIR                     Info page directory (default:
+                                        share/info).
+  --libdir LIBDIR                       Library directory (default: lib).
+  --libexecdir LIBEXECDIR               Library executable directory (default:
+                                        libexec).
+  --localedir LOCALEDIR                 Locale data directory (default:
+                                        share/locale).
+  --localstatedir LOCALSTATEDIR         Localstate data directory (default:
+                                        var).
+  --mandir MANDIR                       Manual page directory (default:
+                                        share/man).
+  --sbindir SBINDIR                     System executable directory (default:
+                                        sbin).
+  --sharedstatedir SHAREDSTATEDIR       Architecture-independent data directory
+                                        (default: com).
+  --sysconfdir SYSCONFDIR               Sysconf data directory (default: etc).
+  --auto-features {enabled,disabled,auto}
+                                        Override value of all 'auto' features
+                                        (default: auto).
+  --backend {ninja,vs,vs2010,vs2015,vs2017,vs2019,xcode}
+                                        Backend to use (default: ninja).
+  --buildtype {plain,debug,debugoptimized,release,minsize,custom}
+                                        Build type to use (default: debug).
+  --debug                               Debug
+  --default-library {shared,static,both}
+                                        Default library type (default: shared).
+  --errorlogs                           Whether to print the logs from failing
+                                        tests
+  --install-umask INSTALL_UMASK         Default umask to apply on permissions of
+                                        installed files (default: 022).
+  --layout {mirror,flat}                Build directory layout (default:
+                                        mirror).
+  --optimization {0,g,1,2,3,s}          Optimization level (default: 0).
+  --stdsplit                            Split stdout and stderr in test logs
+  --strip                               Strip targets on install
+  --unity {on,off,subprojects}          Unity build (default: off).
+  --unity-size UNITY_SIZE               Unity block size (default: (2, None,
+                                        4)).
+  --warnlevel {0,1,2,3}                 Compiler warning level to use (default:
+                                        1).
+  --werror                              Treat warnings as errors
+  --wrap-mode {default,nofallback,nodownload,forcefallback}
+                                        Wrap mode (default: default).
+  --pkg-config-path PKG_CONFIG_PATH     List of additional paths for pkg-config
+                                        to search (default: []). (just for host
+                                        machine)
+  --build.pkg-config-path BUILD.PKG_CONFIG_PATH
+                                        List of additional paths for pkg-config
+                                        to search (default: []). (just for build
+                                        machine)
+  --cmake-prefix-path CMAKE_PREFIX_PATH
+                                        List of additional prefixes for cmake to
+                                        search (default: []). (just for host
+                                        machine)
+  --build.cmake-prefix-path BUILD.CMAKE_PREFIX_PATH
+                                        List of additional prefixes for cmake to
+                                        search (default: []). (just for build
+                                        machine)
+  -D option                             Set the value of an option, can be used
+                                        several times to set multiple options.
+  --clearcache                          Clear cached state (e.g. found
+                                        dependencies)
+```
 
 Most arguments are the same as in [`setup`](#setup).
 
@@ -70,29 +131,50 @@ Note: reconfiguring project will not reset options to their default values (even
 
 *(since 0.54.0)*
 
+```
+$ meson compile [-h] [-j JOBS] [-l LOAD_AVERAGE] [--clean] [-C BUILDDIR]
+```
+
 Builds a default or specified target of a configured meson project.
 
 Example: `meson compile -C builddir`
 
-Optional arguments:
-- `-j JOBS, --jobs JOBS`: The number of worker jobs to run (if supported). If the value is less than 1 the build program will guess.
-- `-l LOAD_AVERAGE, --load-average LOAD_AVERAGE`: The system load average to try to maintain (if supported).
-- `--clean`: Clean the build directory.
-- `-C BUILDDIR`: The directory containing build files to be built.
+```
+optional arguments:
+  -h, --help                            show this help message and exit
+  -j JOBS, --jobs JOBS                  The number of worker jobs to run (if
+                                        supported). If the value is less than 1
+                                        the build program will guess.
+  -l LOAD_AVERAGE, --load-average LOAD_AVERAGE
+                                        The system load average to try to
+                                        maintain (if supported)
+  --clean                               Clean the build directory.
+  -C BUILDDIR                           The directory containing build files to
+                                        be built.
+```
 
 ### dist
 
 *(since 0.52.0)*
 
+```
+$ meson dist [-h] [-C WD] [--formats FORMATS] [--include-subprojects]
+             [--no-tests]
+```
+
 Generates a release archive from the current source tree.
 
 Example: `meson dist -C builddir`
 
-Optional arguments:
-- `-C WD`: directory to cd into before running.
-- `--formats FORMATS`: Comma separated list of archive types to create.
-- `--include-subprojects`: Include source code of subprojects that have been used for the build.
-- `--no-tests`: Do not build and test generated packages.
+```
+optional arguments:
+  -h, --help             show this help message and exit
+  -C WD                  directory to cd into before running
+  --formats FORMATS      Comma separated list of archive types to create.
+  --include-subprojects  Include source code of subprojects that have been used
+                         for the build.
+  --no-tests             Do not build and test generated packages.
+```
 
 This creates a file called `projectname-version.tar.xz` in the build
 tree subdirectory `meson-dist`. This archive contains the full
@@ -114,54 +196,95 @@ distributed archive does not match any commit in revision control
 
 *(since 0.45.0)*
 
+```
+$ meson init [-h] [-C WD] [-n NAME] [-e EXECUTABLE] [-d DEPS]
+             [-l {c,cpp,cs,cuda,d,fortran,java,objc,objcpp,rust}] [-b]
+             [--builddir BUILDDIR] [-f] [--type {executable,library}]
+             [--version VERSION]
+             [sourcefile [sourcefile ...]]
+```
+
 Creates a basic set of build files based on a template.
 
 Example: `meson init -C sourcedir`
 
-Positional arguments:
-- `sourcefile`: source files. default: all recognized files in current directory.
+```
+positional arguments:
+  sourcefile                            source files. default: all recognized
+                                        files in current directory
 
-Optional arguments:
-- `-C WD`: directory to cd into before running.
-- `-n NAME, --name NAME`: project name. default: name of current directory.
-- `-e EXECUTABLE, --executable EXECUTABLE`: executable name. default: project name.
-- `-d DEPS, --deps DEPS`: dependencies, comma-separated.
-- `-l`: project language. default: autodetected based on source files.
-- `-b, --build`: build after generation.
-- `--builddir BUILDDIR`: directory for build.
-- `-f, --force`: force overwrite of existing files and directories.
-- `--type`: project type. default: executable based project.
-- `--version VERSION`: project version. default: 0.1
+optional arguments:
+  -h, --help                            show this help message and exit
+  -C WD                                 directory to cd into before running
+  -n NAME, --name NAME                  project name. default: name of current
+                                        directory
+  -e EXECUTABLE, --executable EXECUTABLE
+                                        executable name. default: project name
+  -d DEPS, --deps DEPS                  dependencies, comma-separated
+  -l {c,cpp,cs,cuda,d,fortran,java,objc,objcpp,rust}, --language {c,cpp,cs,cuda,d,fortran,java,objc,objcpp,rust}
+                                        project language. default: autodetected
+                                        based on source files
+  -b, --build                           build after generation
+  --builddir BUILDDIR                   directory for build
+  -f, --force                           force overwrite of existing files and
+                                        directories.
+  --type {executable,library}           project type. default: executable based
+                                        project
+  --version VERSION                     project version. default: 0.1
+```
 
 ### introspect
 
+```
+$ meson introspect [-h] [--ast] [--benchmarks] [--buildoptions]
+                   [--buildsystem-files] [--dependencies]
+                   [--scan-dependencies] [--installed] [--projectinfo]
+                   [--targets] [--tests]
+                   [--backend {ninja,vs,vs2010,vs2015,vs2017,vs2019,xcode}]
+                   [-a] [-i] [-f]
+                   [builddir]
+```
+
 Displays information about a configured meson project.
 
-Syntax: `meson introspect [builddir] INTROSPECT_COMMAND [introspect_command_options]`  
 Example: `meson introspect builddir`
 
-Positional arguments:
-- `builddir`: The build directory
+```
+positional arguments:
+  builddir                              The build directory
 
-Optional arguments:
-- `--ast`: Dump the AST of the meson file.
-- `--benchmarks`: List all benchmarks.
-- `--buildoptions`: List all build options.
-- `--buildsystem-files`: List files that make up the build system.
-- `--dependencies`: List external dependencies.
-- `--scan-dependencies`: Scan for dependencies used in the meson.build file.
-- `--installed`: List all installed files and directories.
-- `--projectinfo`: Information about projects.
-- `--targets`: List top level targets.
-- `--tests`: List all unit tests.
-- `--backend`: The backend to use for the --buildoptions introspection.
-- `-a, --all`: Print all available information.
-- `-i, --indent`: Enable pretty printed JSON.
-- `-f, --force-object-output`: Always use the new JSON format for multiple entries (even for 0 and 1 introspection commands)
+optional arguments:
+  -h, --help                            show this help message and exit
+  --ast                                 Dump the AST of the meson file.
+  --benchmarks                          List all benchmarks.
+  --buildoptions                        List all build options.
+  --buildsystem-files                   List files that make up the build
+                                        system.
+  --dependencies                        List external dependencies.
+  --scan-dependencies                   Scan for dependencies used in the
+                                        meson.build file.
+  --installed                           List all installed files and
+                                        directories.
+  --projectinfo                         Information about projects.
+  --targets                             List top level targets.
+  --tests                               List all unit tests.
+  --backend {ninja,vs,vs2010,vs2015,vs2017,vs2019,xcode}
+                                        The backend to use for the
+                                        --buildoptions introspection.
+  -a, --all                             Print all available information.
+  -i, --indent                          Enable pretty printed JSON.
+  -f, --force-object-output             Always use the new JSON format for
+                                        multiple entries (even for 0 and 1
+                                        introspection commands)
+```
 
 ### install
 
 *(since 0.47.0)*
+
+```
+$ meson install [-h] [-C WD] [--no-rebuild] [--only-changed] [--quiet]
+```
 
 Installs the project to the prefix specified in `setup`.
 
@@ -169,11 +292,14 @@ Examples:
 - `meson install -C builddir`.
 - `DESTDIR=/path/to/staging/area meson install -C builddir`
 
-Optional arguments:
-- `-C WD`: directory to cd into before running.
-- `--no-rebuild`: Do not rebuild before installing.
-- `--only-changed`: Only overwrite files that are older than the copied file.
-- `--quiet`: Do not print every file that was installed.
+```
+optional arguments:
+  -h, --help      show this help message and exit
+  -C WD           directory to cd into before running
+  --no-rebuild    Do not rebuild before installing.
+  --only-changed  Only overwrite files that are older than the copied file.
+  --quiet         Do not print every file that was installed.
+```
 
 See [the installation documentation](Installing.md) for more info.
 
@@ -181,22 +307,59 @@ See [the installation documentation](Installing.md) for more info.
 
 *(since 0.50.0)*
 
+```
+$ meson rewrite [-h] [-s SRCDIR] [-V] [-S]
+                {target,kwargs,default-options,command} ...
+```
+
 Modifies the meson project.
 
-Optional arguments:
-- `-s SRCDIR, --sourcedir SRCDIR`: Path to source directory.
-- `-V, --verbose`: Enable verbose output.
-- `-S, --skip-errors`: Skip errors instead of aborting
+```
+optional arguments:
+  -h, --help                            show this help message and exit
+  -s SRCDIR, --sourcedir SRCDIR         Path to source directory.
+  -V, --verbose                         Enable verbose output
+  -S, --skip-errors                     Skip errors instead of aborting
 
-Commands:
-- `target`: Modify a target.
-- `kwargs`: Modify keyword arguments.
-- `default-options`: Modify the project default options.
-- `command`: Execute a JSON array of commands
+Rewriter commands:
+  Rewrite command to execute
+
+  {target,kwargs,default-options,command}
+    target                              Modify a target
+    kwargs                              Modify keyword arguments
+    default-options                     Modify the project default options
+    command                             Execute a JSON array of commands
+```
 
 See [the meson file rewriter documentation](Rewriter.md) for more info.
 
 ### setup
+
+```
+$ meson setup [-h] [--prefix PREFIX] [--bindir BINDIR] [--datadir DATADIR]
+              [--includedir INCLUDEDIR] [--infodir INFODIR]
+              [--libdir LIBDIR] [--libexecdir LIBEXECDIR]
+              [--localedir LOCALEDIR] [--localstatedir LOCALSTATEDIR]
+              [--mandir MANDIR] [--sbindir SBINDIR]
+              [--sharedstatedir SHAREDSTATEDIR] [--sysconfdir SYSCONFDIR]
+              [--auto-features {enabled,disabled,auto}]
+              [--backend {ninja,vs,vs2010,vs2015,vs2017,vs2019,xcode}]
+              [--buildtype {plain,debug,debugoptimized,release,minsize,custom}]
+              [--debug] [--default-library {shared,static,both}]
+              [--errorlogs] [--install-umask INSTALL_UMASK]
+              [--layout {mirror,flat}] [--optimization {0,g,1,2,3,s}]
+              [--stdsplit] [--strip] [--unity {on,off,subprojects}]
+              [--unity-size UNITY_SIZE] [--warnlevel {0,1,2,3}] [--werror]
+              [--wrap-mode {default,nofallback,nodownload,forcefallback}]
+              [--pkg-config-path PKG_CONFIG_PATH]
+              [--build.pkg-config-path BUILD.PKG_CONFIG_PATH]
+              [--cmake-prefix-path CMAKE_PREFIX_PATH]
+              [--build.cmake-prefix-path BUILD.CMAKE_PREFIX_PATH]
+              [-D option] [--native-file NATIVE_FILE]
+              [--cross-file CROSS_FILE] [-v] [--fatal-meson-warnings]
+              [--reconfigure] [--wipe]
+              [builddir] [sourcedir]
+```
 
 The default meson command (invoked if there was no COMMAND supplied).
 
@@ -204,51 +367,94 @@ Configures a build directory for the meson project.
 
 Example: `meson setup builddir`
 
-Positional arguments:
-- `builddir`: path to the build directory.
-- `sourcedir`: path to the directory containing the root `meson.build`.
+```
+positional arguments:
+  builddir
+  sourcedir
 
-Optional arguments:
-- `--prefix PREFIX`: Installation prefix.
-- `--bindir BINDIR`: Executable directory.
-- `--datadir DATADIR`: Data file directory.
-- `--includedir INCLUDEDIR`: Header file directory.
-- `--infodir INFODIR`: Info page directory.
-- `--libdir LIBDIR`: Library directory.
-- `--libexecdir LIBEXECDIR`: Library executable directory.
-- `--localedir LOCALEDIR`: Locale data directory.
-- `--localstatedir LOCALSTATEDIR`: Localstate data directory.
-- `--mandir MANDIR`: Manual page directory.
-- `--sbindir SBINDIR`: System executable directory.
-- `--sharedstatedir SHAREDSTATEDIR`: Architecture-independent data directory.
-- `--sysconfdir SYSCONFDIR`: Sysconf data directory.
-- `--auto-features`: Override value of all 'auto' features.
-- `--backend`: Backend to use.
-- `--buildtype`: Build type to use.
-- `--debug`: Debug.
-- `--default-library`: Default library type.
-- `--errorlogs`: Whether to print the logs from failing tests.
-- `--install-umask INSTALL_UMASK`: Default umask to apply on permissions of installed files.
-- `--layout`: Build directory layout.
-- `--optimization`: Optimization level.
-- `--stdsplit`: Split stdout and stderr in test logs.
-- `--strip`: Strip targets on install.
-- `--unity`: Unity build.
-- `--unity-size UNITY_SIZE`: Unity block size.
-- `--warnlevel`: Compiler warning level to use.
-- `--werror`: Treat warnings as errors.
-- `--wrap-mode`: Wrap mode.
-- `--pkg-config-path PKG_CONFIG_PATH`: List of additional paths for pkg-config to search (just for host machine).
-- `--build.pkg-config-path BUILD.PKG_CONFIG_PATH`: List of additional paths for pkg-config to search (just for build machine).
-- `--cmake-prefix-path CMAKE_PREFIX_PATH`: List of additional prefixes for cmake to search (just for host machine).
-- `--build.cmake-prefix-path BUILD.CMAKE_PREFIX_PATH`: List of additional prefixes for cmake to search (just for build machine).
-- `-D option`: Set the value of an option, can be used several times to set multiple options.
-- `--native-file NATIVE_FILE`: File containing overrides for native compilation environment.
-- `--cross-file CROSS_FILE`: File describing cross compilation environment.
-- `-v, --version`: show program's version number and exit.
-- `--fatal-meson-warnings`: Make all Meson warnings fatal.
-- `--reconfigure`: Set options and reconfigure the project. Useful when new options have been added to the project and the default value is not working.
-- `--wipe`: Wipe build directory and reconfigure using previous command line options. Userful when build directory got corrupted, or when rebuilding with a newer version of meson.
+optional arguments:
+  -h, --help                            show this help message and exit
+  --prefix PREFIX                       Installation prefix (default: c:/).
+  --bindir BINDIR                       Executable directory (default: bin).
+  --datadir DATADIR                     Data file directory (default: share).
+  --includedir INCLUDEDIR               Header file directory (default:
+                                        include).
+  --infodir INFODIR                     Info page directory (default:
+                                        share/info).
+  --libdir LIBDIR                       Library directory (default: lib).
+  --libexecdir LIBEXECDIR               Library executable directory (default:
+                                        libexec).
+  --localedir LOCALEDIR                 Locale data directory (default:
+                                        share/locale).
+  --localstatedir LOCALSTATEDIR         Localstate data directory (default:
+                                        var).
+  --mandir MANDIR                       Manual page directory (default:
+                                        share/man).
+  --sbindir SBINDIR                     System executable directory (default:
+                                        sbin).
+  --sharedstatedir SHAREDSTATEDIR       Architecture-independent data directory
+                                        (default: com).
+  --sysconfdir SYSCONFDIR               Sysconf data directory (default: etc).
+  --auto-features {enabled,disabled,auto}
+                                        Override value of all 'auto' features
+                                        (default: auto).
+  --backend {ninja,vs,vs2010,vs2015,vs2017,vs2019,xcode}
+                                        Backend to use (default: ninja).
+  --buildtype {plain,debug,debugoptimized,release,minsize,custom}
+                                        Build type to use (default: debug).
+  --debug                               Debug
+  --default-library {shared,static,both}
+                                        Default library type (default: shared).
+  --errorlogs                           Whether to print the logs from failing
+                                        tests
+  --install-umask INSTALL_UMASK         Default umask to apply on permissions of
+                                        installed files (default: 022).
+  --layout {mirror,flat}                Build directory layout (default:
+                                        mirror).
+  --optimization {0,g,1,2,3,s}          Optimization level (default: 0).
+  --stdsplit                            Split stdout and stderr in test logs
+  --strip                               Strip targets on install
+  --unity {on,off,subprojects}          Unity build (default: off).
+  --unity-size UNITY_SIZE               Unity block size (default: (2, None,
+                                        4)).
+  --warnlevel {0,1,2,3}                 Compiler warning level to use (default:
+                                        1).
+  --werror                              Treat warnings as errors
+  --wrap-mode {default,nofallback,nodownload,forcefallback}
+                                        Wrap mode (default: default).
+  --pkg-config-path PKG_CONFIG_PATH     List of additional paths for pkg-config
+                                        to search (default: []). (just for host
+                                        machine)
+  --build.pkg-config-path BUILD.PKG_CONFIG_PATH
+                                        List of additional paths for pkg-config
+                                        to search (default: []). (just for build
+                                        machine)
+  --cmake-prefix-path CMAKE_PREFIX_PATH
+                                        List of additional prefixes for cmake to
+                                        search (default: []). (just for host
+                                        machine)
+  --build.cmake-prefix-path BUILD.CMAKE_PREFIX_PATH
+                                        List of additional prefixes for cmake to
+                                        search (default: []). (just for build
+                                        machine)
+  -D option                             Set the value of an option, can be used
+                                        several times to set multiple options.
+  --native-file NATIVE_FILE             File containing overrides for native
+                                        compilation environment.
+  --cross-file CROSS_FILE               File describing cross compilation
+                                        environment.
+  -v, --version                         show program's version number and exit
+  --fatal-meson-warnings                Make all Meson warnings fatal
+  --reconfigure                         Set options and reconfigure the project.
+                                        Useful when new options have been added
+                                        to the project and the default value is
+                                        not working.
+  --wipe                                Wipe build directory and reconfigure
+                                        using previous command line options.
+                                        Useful when build directory got
+                                        corrupted, or when rebuilding with a
+                                        newer version of meson.
+```
 
 See [meson introduction page](Running-Meson.md#configuring-the-build-directory) for more info.
 
@@ -256,59 +462,108 @@ See [meson introduction page](Running-Meson.md#configuring-the-build-directory) 
 
 *(since 0.49.0)*
 
+```
+$ meson subprojects [-h] {update,checkout,download,foreach} ...
+```
+
 Manages subprojects of the meson project.
 
-Syntax: `meson subprojects SUBPROJECTS_COMMAND [subprojects_command_options]`
+```
+optional arguments:
+  -h, --help                          show this help message and exit
 
 Commands:
-- `update`: Update all subprojects from wrap files.
-- `checkout`: Checkout a branch (git only).
-- `download`: Ensure subprojects are fetched, even if not in use. Already downloaded subprojects are not modified. This can be used to pre-fetch all subprojects and avoid downloads during configure.
-- `foreach`: Execute a command in each subproject directory.
+  {update,checkout,download,foreach}
+    update                            Update all subprojects from wrap files
+    checkout                          Checkout a branch (git only)
+    download                          Ensure subprojects are fetched, even if
+                                      not in use. Already downloaded subprojects
+                                      are not modified. This can be used to pre-
+                                      fetch all subprojects and avoid downloads
+                                      during configure.
+    foreach                           Execute a command in each subproject
+                                      directory.
+```
 
 ### test
+
+```
+$ meson test [-h] [--repeat REPEAT] [--no-rebuild] [--gdb]
+             [--gdb-path GDB_PATH] [--list] [--wrapper WRAPPER] [-C WD]
+             [--suite SUITE] [--no-suite SUITE] [--no-stdsplit]
+             [--print-errorlogs] [--benchmark] [--logbase LOGBASE]
+             [--num-processes NUM_PROCESSES] [-v] [-q]
+             [-t TIMEOUT_MULTIPLIER] [--setup SETUP]
+             [--test-args TEST_ARGS]
+             [args [args ...]]
+```
 
 Run tests for the configure meson project.
 
 Example: `meson test -C builddir`
 
-Positional arguments:
-- `args`: Optional list of tests to run
+```
+positional arguments:
+  args                                  Optional list of tests to run
 
-Optional arguments:
-- `--repeat REPEAT`: Number of times to run the tests.
-- `--no-rebuild`: Do not rebuild before running tests.
-- `--gdb`: Run test under gdb.
-- `--gdb-path GDB_PATH`: Path to the gdb binary.
-- `--list`: List available tests.
-- `--wrapper WRAPPER`: wrapper to run tests with (e.g. Valgrind).
-- `-C WD`: directory to cd into before running.
-- `--suite SUITE`: Only run tests belonging to the given suite.
-- `--no-suite SUITE`: Do not run tests belonging to the given suite.
-- `--no-stdsplit`: Do not split stderr and stdout in test logs.
-- `--print-errorlogs`: Whether to print failing tests' logs.
-- `--benchmark`: Run benchmarks instead of tests.
-- `--logbase LOGBASE`: Base name for log file.
-- `--num-processes NUM_PROCESSES`: How many parallel processes to use.
-- `-v, --verbose`: Do not redirect stdout and stderr.
-- `-q, --quiet`: Produce less output to the terminal.
-- `-t TIMEOUT_MULTIPLIER, --timeout-multiplier TIMEOUT_MULTIPLIER`: Define a multiplier for test timeout, for example when running tests in particular conditions they might take more time to execute.
-- `--setup SETUP`: Which test setup to use.
-- `--test-args TEST_ARGS`: Arguments to pass to the specified test(s) or all tests
+optional arguments:
+  -h, --help                            show this help message and exit
+  --repeat REPEAT                       Number of times to run the tests.
+  --no-rebuild                          Do not rebuild before running tests.
+  --gdb                                 Run test under gdb.
+  --gdb-path GDB_PATH                   Path to the gdb binary (default: gdb).
+  --list                                List available tests.
+  --wrapper WRAPPER                     wrapper to run tests with (e.g.
+                                        Valgrind)
+  -C WD                                 directory to cd into before running
+  --suite SUITE                         Only run tests belonging to the given
+                                        suite.
+  --no-suite SUITE                      Do not run tests belonging to the given
+                                        suite.
+  --no-stdsplit                         Do not split stderr and stdout in test
+                                        logs.
+  --print-errorlogs                     Whether to print failing tests' logs.
+  --benchmark                           Run benchmarks instead of tests.
+  --logbase LOGBASE                     Base name for log file.
+  --num-processes NUM_PROCESSES         How many parallel processes to use.
+  -v, --verbose                         Do not redirect stdout and stderr
+  -q, --quiet                           Produce less output to the terminal.
+  -t TIMEOUT_MULTIPLIER, --timeout-multiplier TIMEOUT_MULTIPLIER
+                                        Define a multiplier for test timeout,
+                                        for example when running tests in
+                                        particular conditions they might take
+                                        more time to execute.
+  --setup SETUP                         Which test setup to use.
+  --test-args TEST_ARGS                 Arguments to pass to the specified
+                                        test(s) or all tests
+```
 
 See [the unit test documentation](Unit-tests.md) for more info.
 
 ### wrap
 
+```
+$ meson wrap [-h] {list,search,install,update,info,status,promote} ...
+```
+
 An utility to manage WrapDB dependencies.
 
+```
+optional arguments:
+  -h, --help                            show this help message and exit
+
 Commands:
-- `list`: show all available projects.
-- `search`: search the db by name.
-- `install`: install the specified project.
-- `update`: update the project to its newest available release.
-- `info`: show available versions of a project.
-- `status`: show installed and available versions of your projects.
-- `promote`: bring a subsubproject up to the master project
+  {list,search,install,update,info,status,promote}
+    list                                show all available projects
+    search                              search the db by name
+    install                             install the specified project
+    update                              update the project to its newest
+                                        available release
+    info                                show available versions of a project
+    status                              show installed and available versions of
+                                        your projects
+    promote                             bring a subsubproject up to the master
+                                        project
+```
 
 See [the WrapDB tool documentation](Using-wraptool.md) for more info.

--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -42,7 +42,7 @@ $ meson configure [-h] [--prefix PREFIX] [--bindir BINDIR]
                   [builddir]
 ```
 
-Reconfigures existing meson project.
+Changes options of a configured meson project.
 
 ```
 positional arguments:
@@ -135,7 +135,7 @@ meson configure builddir -Doption=new_value
 $ meson compile [-h] [-j JOBS] [-l LOAD_AVERAGE] [--clean] [-C BUILDDIR]
 ```
 
-Builds a default or specified target of a configured meson project.
+Builds a default or a specified target of a configured meson project.
 
 ```
 optional arguments:
@@ -389,9 +389,9 @@ $ meson setup [-h] [--prefix PREFIX] [--bindir BINDIR] [--datadir DATADIR]
               [builddir] [sourcedir]
 ```
 
-The default meson command (invoked if there was no COMMAND supplied).
-
 Configures a build directory for the meson project.
+
+This is the default meson command (invoked if there was no COMMAND supplied).
 
 ```
 positional arguments:

--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -44,10 +44,6 @@ $ meson configure [-h] [--prefix PREFIX] [--bindir BINDIR]
 
 Reconfigures existing meson project.
 
-Examples:
-- `meson configure builddir`: list all available options.
-- `meson configure builddir -Doption=new_value`: change a single option
-
 ```
 positional arguments:
   builddir
@@ -127,6 +123,10 @@ Most arguments are the same as in [`setup`](#setup).
 
 Note: reconfiguring project will not reset options to their default values (even if they were changed in `meson.build`).
 
+Examples:
+- `meson configure builddir`: list all available options.
+- `meson configure builddir -Doption=new_value`: change a single option
+
 ### compile
 
 *(since 0.54.0)*
@@ -136,8 +136,6 @@ $ meson compile [-h] [-j JOBS] [-l LOAD_AVERAGE] [--clean] [-C BUILDDIR]
 ```
 
 Builds a default or specified target of a configured meson project.
-
-Example: `meson compile -C builddir`
 
 ```
 optional arguments:
@@ -153,6 +151,8 @@ optional arguments:
                                         be built.
 ```
 
+Example: `meson compile -C builddir`
+
 ### dist
 
 *(since 0.52.0)*
@@ -163,8 +163,6 @@ $ meson dist [-h] [-C WD] [--formats FORMATS] [--include-subprojects]
 ```
 
 Generates a release archive from the current source tree.
-
-Example: `meson dist -C builddir`
 
 ```
 optional arguments:
@@ -192,6 +190,8 @@ prevents developers from doing accidental releases where the
 distributed archive does not match any commit in revision control
 (especially the one tagged for the release).
 
+Example: `meson dist -C builddir`
+
 ### init
 
 *(since 0.45.0)*
@@ -205,8 +205,6 @@ $ meson init [-h] [-C WD] [-n NAME] [-e EXECUTABLE] [-d DEPS]
 ```
 
 Creates a basic set of build files based on a template.
-
-Example: `meson init -C sourcedir`
 
 ```
 positional arguments:
@@ -233,6 +231,8 @@ optional arguments:
   --version VERSION                     project version. default: 0.1
 ```
 
+Example: `meson init -C sourcedir`
+
 ### introspect
 
 ```
@@ -246,8 +246,6 @@ $ meson introspect [-h] [--ast] [--benchmarks] [--buildoptions]
 ```
 
 Displays information about a configured meson project.
-
-Example: `meson introspect builddir`
 
 ```
 positional arguments:
@@ -278,6 +276,8 @@ optional arguments:
                                         introspection commands)
 ```
 
+Example: `meson introspect builddir`
+
 ### install
 
 *(since 0.47.0)*
@@ -287,10 +287,6 @@ $ meson install [-h] [-C WD] [--no-rebuild] [--only-changed] [--quiet]
 ```
 
 Installs the project to the prefix specified in `setup`.
-
-Examples: 
-- `meson install -C builddir`.
-- `DESTDIR=/path/to/staging/area meson install -C builddir`
 
 ```
 optional arguments:
@@ -302,6 +298,10 @@ optional arguments:
 ```
 
 See [the installation documentation](Installing.md) for more info.
+
+Examples: 
+- `meson install -C builddir`.
+- `DESTDIR=/path/to/staging/area meson install -C builddir`
 
 ### rewrite
 
@@ -364,8 +364,6 @@ $ meson setup [-h] [--prefix PREFIX] [--bindir BINDIR] [--datadir DATADIR]
 The default meson command (invoked if there was no COMMAND supplied).
 
 Configures a build directory for the meson project.
-
-Example: `meson setup builddir`
 
 ```
 positional arguments:
@@ -458,6 +456,8 @@ optional arguments:
 
 See [meson introduction page](Running-Meson.md#configuring-the-build-directory) for more info.
 
+Example: `meson setup builddir`
+
 ### subprojects
 
 *(since 0.49.0)*
@@ -500,8 +500,6 @@ $ meson test [-h] [--repeat REPEAT] [--no-rebuild] [--gdb]
 
 Run tests for the configure meson project.
 
-Example: `meson test -C builddir`
-
 ```
 positional arguments:
   args                                  Optional list of tests to run
@@ -539,6 +537,8 @@ optional arguments:
 ```
 
 See [the unit test documentation](Unit-tests.md) for more info.
+
+Example: `meson test -C builddir`
 
 ### wrap
 

--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -408,7 +408,7 @@ positional arguments:
 
 optional arguments:
   -h, --help                            show this help message and exit
-  --prefix PREFIX                       Installation prefix (default: c:/).
+  --prefix PREFIX                       Installation prefix (default: azaza:/).
   --bindir BINDIR                       Executable directory (default: bin).
   --datadir DATADIR                     Data file directory (default: share).
   --includedir INCLUDEDIR               Header file directory (default:

--- a/docs/sitemap.txt
+++ b/docs/sitemap.txt
@@ -5,6 +5,7 @@ index.md
 	Manual.md
 		Overview.md
 		Running-Meson.md
+		Commands.md
 		Builtin-options.md
 		Using-with-Visual-Studio.md
 		Meson-sample.md

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4716,7 +4716,7 @@ recommended as it is not supported on some platforms''')
         found_entries.add('help')
 
         help_output = self._run(self.meson_command + ['--help'])
-        help_commands = set(re.findall(r"usage:(?s:.+)?{((?:[a-z]+,*)+?)}", help_output, re.MULTILINE))
+        help_commands = set(c.strip() for c in re.findall(r"usage:(?s:.+)?{((?:[a-z]+,*)+?)}", help_output, re.MULTILINE)[0].split(','))
 
         self.assertEqual(found_entries, help_commands)
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4715,7 +4715,7 @@ recommended as it is not supported on some platforms''')
         # Help is not documented for obvious reasons =)
         found_entries.add('help')
 
-        help_output = self._run(self.mtest_command + ['--help'])
+        help_output = self._run(self.meson_command + ['--help'])
         help_commands = set(re.findall(r"usage:.+?{((?:[a-z]+,*)+?)}", help_output))
 
         self.assertEqual(found_entries, help_commands)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4716,7 +4716,7 @@ recommended as it is not supported on some platforms''')
         found_entries.add('help')
 
         help_output = self._run(self.meson_command + ['--help'])
-        help_commands = set(c.strip() for c in re.findall(r"usage:(?s:.+)?{((?:[a-z]+,*)+?)}", help_output, re.MULTILINE)[0].split(','))
+        help_commands = set(c.strip() for c in re.findall(r"usage:(?:.+)?{((?:[a-z]+,*)+?)}", help_output, re.MULTILINE|re.DOTALL)[0].split(','))
 
         self.assertEqual(found_entries, help_commands)
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1483,7 +1483,6 @@ class DataTests(unittest.TestCase):
         astint = AstInterpreter('.', '', '')
         self.assertEqual(set(interp.funcs.keys()), set(astint.funcs.keys()))
 
-
 class BasePlatformTests(unittest.TestCase):
     prefix = '/usr'
     libdir = 'lib'
@@ -4702,6 +4701,24 @@ recommended as it is not supported on some platforms''')
         self.assertRegex(contents, r'build main(\.exe)?.*: c_LINKER')
         self.assertRegex(contents, r'build (lib|cyg)?mylib.*: c_LINKER')
 
+    def test_commands_documented(self):
+        '''
+        Test that all listed meson commands are documented in Commands.md.
+        '''
+        from itertools import tee
+        md = None
+        with open('docs/markdown/Commands.md', encoding='utf-8') as f:
+            md = f.read()
+        self.assertIsNotNone(md)
+
+        found_entries = set(re.findall(r"^### (.+)$", md, re.MULTILINE))
+        # Help is not documented for obvious reasons =)
+        found_entries.add('help')
+
+        help_output = self._run(self.mtest_command + ['--help'])
+        help_commands = set(re.findall(r"usage:.+?{((?:[a-z]+,*)+?)}", help_output))
+
+        self.assertEqual(found_entries, help_commands)
 
 class FailureTests(BasePlatformTests):
     '''

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1483,6 +1483,7 @@ class DataTests(unittest.TestCase):
         astint = AstInterpreter('.', '', '')
         self.assertEqual(set(interp.funcs.keys()), set(astint.funcs.keys()))
 
+
 class BasePlatformTests(unittest.TestCase):
     prefix = '/usr'
     libdir = 'lib'
@@ -4704,8 +4705,7 @@ recommended as it is not supported on some platforms''')
     def test_commands_documented(self):
         '''
         Test that all listed meson commands are documented in Commands.md.
-        '''
-        from itertools import tee
+        '''        
         md = None
         with open('docs/markdown/Commands.md', encoding='utf-8') as f:
             md = f.read()
@@ -4716,7 +4716,7 @@ recommended as it is not supported on some platforms''')
         found_entries.add('help')
 
         help_output = self._run(self.meson_command + ['--help'])
-        help_commands = set(re.findall(r"usage:.+?{((?:[a-z]+,*)+?)}", help_output))
+        help_commands = set(re.findall(r"usage:(?s:.+)?{((?:[a-z]+,*)+?)}", help_output, re.MULTILINE))
 
         self.assertEqual(found_entries, help_commands)
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4749,6 +4749,7 @@ recommended as it is not supported on some platforms''')
             out = re.sub(r'\r\n+', r'\r', out, flags=re.MULTILINE)
             out = re.sub(r'(^ +| +$)', '', out, flags=re.MULTILINE)
             out = re.sub(r'(^\n)', '', out, flags=re.MULTILINE)
+            out = re.sub(r'(--prefix PREFIX Installation prefix) \(default: .+?\)', r'\1', out, flags=re.MULTILINE|re.DOTALL)
             return out
 
         ## Get command sections


### PR DESCRIPTION
- Added a commands page describing all listed top level meson commands.
- Added a unit-tests that checks that all commands were documented.

Some problems that might need to be solved in this PR or maybe a later PR:
- There's [a page](https://mesonbuild.com/Creating-releases.html#page-description) that describes `ninja dist` which basically does the same as `meson dist`. It can either be removed altogether or amended to use `meson dist` instead of `ninja`.
- This page should be probably integrated in the [overview](https://mesonbuild.com/Running-Meson.html). But I can't think of a good way to do that currently. Overview page also uses ninja as *the way*, should be probably amended.
- `meson install` command links to [a page](https://mesonbuild.com/Installing.html), which again uses `ninja` as *the way* to install. Should be probably amended to use `meson` command instead.