### PR TITLE
wrap: Add patch_directory support

### DIFF
--- a/docs/markdown/Wrap-dependency-system-manual.md
+++ b/docs/markdown/Wrap-dependency-system-manual.md
@@ -79,6 +79,9 @@ revision = head
 - `patch_fallback_url` - fallback URL to be used when download from `patch_url` fails *Since: 0.55.0*
 - `patch_filename` - filename of the downloaded overlay archive
 - `patch_hash` - sha256 checksum of the downloaded overlay archive
+- `patch_directory` - *Since 0.55.0* Overlay directory, alternative to `patch_filename` in the case
+  files are local instead of a downloaded archive. The directory must be placed in
+  `subprojects/packagefiles`.
 - `lead_directory_missing` - for `wrap-file` create the leading
   directory name. Needed when the source file does not have a leading
   directory.

--- a/docs/markdown/snippets/wrap_patch.md
+++ b/docs/markdown/snippets/wrap_patch.md
@@ -4,3 +4,11 @@ It is now possible to use the `patch_filename` and `source_filename` value in a
 `.wrap` file without `*_url` to specify a local source / patch file. All local
 files must be located in the `subprojects/packagefiles` directory. The `*_hash`
 entries are optional with this setup.
+
+## Local wrap patch directory
+
+Wrap files can now specify `patch_directory` instead of `patch_filename` in the
+case overlay files are local. Every files in that directory, and subdirectories,
+will be copied to the subproject directory. This can be used for example to add
+`meson.build` files to a project not using Meson build system upstream.
+The patch directory must be placed in `subprojects/packagefiles` directory.

--- a/test cases/common/157 wrap file should not failed/meson.build
+++ b/test cases/common/157 wrap file should not failed/meson.build
@@ -12,3 +12,5 @@ libbar = bar.get_variable('libbar')
 executable('grabprog', files('src/subprojects/prog.c'))
 executable('grabprog2', files('src/subprojects/foo/prog2.c'))
 subdir('src')
+
+subproject('patchdir')

--- a/test cases/common/157 wrap file should not failed/subprojects/packagefiles/foo-1.0/meson.build
+++ b/test cases/common/157 wrap file should not failed/subprojects/packagefiles/foo-1.0/meson.build
@@ -1,0 +1,2 @@
+project('static lib patchdir', 'c')
+libfoo = static_library('foo', 'foo.c')

--- a/test cases/common/157 wrap file should not failed/subprojects/patchdir.wrap
+++ b/test cases/common/157 wrap file should not failed/subprojects/patchdir.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = foo-1.0-patchdir
+
+source_url = http://something.invalid
+source_filename = foo-1.0.tar.xz
+source_hash = 9ed8f67d75e43d3be161efb6eddf30dd01995a958ca83951ea64234bac8908c1
+lead_directory_missing = true
+
+patch_directory = foo-1.0


### PR DESCRIPTION
I'm just wondering if we should force patch_directory inside `packagefiles` subdir?