### PR TITLE
interpreter: add support for --force-fallback-for

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -86,6 +86,7 @@ Using the option as-is with no prefix affects all machines. For example:
 | warning_level {0, 1, 2, 3}           | 1             | Set the warning level. From 0 = none to 3 = highest            | no             |
 | werror                               | false         | Treat warnings as errors                                       | no             |
 | wrap_mode {default, nofallback,<br>nodownload, forcefallback} | default | Wrap mode to use                            | no             |
+| force_fallback_for                   | []            | Force fallback for those dependencies                          | no             |
 
 <a name="build-type-options"></a>
 For setting optimization levels and toggling debug, you can either set the

--- a/docs/markdown/Subprojects.md
+++ b/docs/markdown/Subprojects.md
@@ -212,6 +212,9 @@ the following command-line options:
     calls, and those are meant to be used for sources that cannot be
     provided by the system, such as copylibs.
 
+    This option may be overriden by `--force-fallback-for` for specific
+    dependencies.
+
 * **--wrap-mode=forcefallback**
 
     Meson will not look at the system for any dependencies which have
@@ -219,6 +222,19 @@ the following command-line options:
     them. This is useful when you want to test your fallback setup, or
     want to specifically build against the library sources provided by
     your subprojects.
+
+* **--force-fallback-for=list,of,dependencies**
+
+    Meson will not look at the system for any dependencies listed there,
+    provided a fallback was supplied when the dependency was declared.
+
+    This option takes precedence over `--wrap-mode=nofallback`, and when
+    used in combination with `--wrap-mode=nodownload` will only work
+    if the dependency has already been downloaded.
+
+    This is useful when your project has many fallback dependencies,
+    but you only want to build against the library sources for a few
+    of them.
 
 ## Download subprojects
 

--- a/docs/markdown/snippets/force_fallback_for.md
+++ b/docs/markdown/snippets/force_fallback_for.md
@@ -1,0 +1,10 @@
+## Force fallback for
+
+A newly-added `--force-fallback-for` command line option can now be used to
+force fallback for specific subprojects.
+
+Example:
+
+```
+meson build --force-fallback-for=foo,bar
+```

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1127,6 +1127,7 @@ builtin_options = OrderedDict([
     ('warning_level',   BuiltinOption(UserComboOption, 'Compiler warning level to use', '1', choices=['0', '1', '2', '3'])),
     ('werror',          BuiltinOption(UserBooleanOption, 'Treat warnings as errors', False, yielding=False)),
     ('wrap_mode',       BuiltinOption(UserComboOption, 'Wrap mode', 'default', choices=['default', 'nofallback', 'nodownload', 'forcefallback'])),
+    ('force_fallback_for', BuiltinOption(UserArrayOption, 'Force fallback for those subprojects', [])),
 ])
 
 builtin_options_per_machine = OrderedDict([

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3555,7 +3555,8 @@ external dependencies (including libraries) must go to "dependencies".''')
                 return self.get_subproject_dep(name, display_name, dirname, varname, kwargs)
 
         wrap_mode = self.coredata.get_builtin_option('wrap_mode')
-        forcefallback = wrap_mode == WrapMode.forcefallback and has_fallback
+        force_fallback_for = self.coredata.get_builtin_option('force_fallback_for')
+        forcefallback = (wrap_mode == WrapMode.forcefallback or name in force_fallback_for) and has_fallback
         if name != '' and not forcefallback:
             self._handle_featurenew_dependencies(name)
             kwargs['required'] = required and not has_fallback
@@ -3609,7 +3610,13 @@ external dependencies (including libraries) must go to "dependencies".''')
 
     def dependency_fallback(self, name, display_name, kwargs):
         required = kwargs.get('required', True)
-        if self.coredata.get_builtin_option('wrap_mode') == WrapMode.nofallback:
+
+        # Explicitly listed fallback preferences for specific subprojects
+        # take precedence over wrap-mode
+        if name in self.coredata.get_builtin_option('force_fallback_for'):
+            mlog.log('Looking for a fallback subproject for the dependency',
+                     mlog.bold(display_name), 'because:\nUse of fallback was forced for that specific subproject')
+        elif self.coredata.get_builtin_option('wrap_mode') == WrapMode.nofallback:
             mlog.log('Not looking for a fallback subproject for the dependency',
                      mlog.bold(display_name), 'because:\nUse of fallback '
                      'dependencies is disabled.')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2261,6 +2261,12 @@ class AllPlatformTests(BasePlatformTests):
         self.build()
         self.run_tests()
 
+    def test_force_fallback_for(self):
+        testdir = os.path.join(self.unit_test_dir, '31 forcefallback')
+        self.init(testdir, extra_args=['--force-fallback-for=zlib,foo'])
+        self.build()
+        self.run_tests()
+
     def test_env_ops_dont_stack(self):
         '''
         Test that env ops prepend/append do not stack, and that this usage issues a warning


### PR DESCRIPTION
This new command line option allows specifying dependencies for
which to force fallback.

See the documentation for more information

Fixes: #7218