### PR TITLE
Allow passing an array to library(vs_module_defs)

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1461,9 +1461,13 @@ extra keyword arguments.
   or if it's not a list, the specified value will be used for setting
   both compatibility version and current version. If unspecified, the
   `soversion` will be used as per the aforementioned rules.
-- `vs_module_defs` a string, a File object, or Custom Target for a
-  Microsoft module definition file for controlling symbol exports,
-  etc., on platforms where that is possible (e.g. Windows).
+- `vs_module_defs` a string, a File object, Custom Target, or an array of
+  those for a Microsoft module definition file for controlling symbol
+  exports, etc., on platforms where that is possible (e.g. Windows). If a
+  an array is passed it should have a length of 1 or 0. An empty array may
+  used if module defs are only needed in some situations, such as not using
+  one with mingw.
+  *(new in 0.55.0)* Array options.
 
 ### shared_module()
 
@@ -1485,10 +1489,8 @@ you will need to set the `export_dynamic` argument of the executable to
 
 Supports the following extra keyword arguments:
 
-- `vs_module_defs`, *(Added 0.52.0)*, a string, a File object, or
-  Custom Target for a Microsoft module definition file for controlling
-  symbol exports, etc., on platforms where that is possible
-  (e.g. Windows).
+- `vs_module_defs`, *(Added 0.52.0)*, See the `vs_module_defs` entry of
+  [`shared_library`](#shared_library) for more information.
 
 **Note:** Linking to a shared module is not supported on some
 platforms, notably OSX.  Consider using a

--- a/docs/markdown/snippets/empty_vs_module_defs.md
+++ b/docs/markdown/snippets/empty_vs_module_defs.md
@@ -1,0 +1,9 @@
+## library vs_module_defs may be an array
+
+It is sometimes desirable to use a .def file only in some situations, such as
+with msvc, but now with mingw. Previously this meant defining a duplicate
+library() call with the `vs_module_defs` keyword argument added. Now an array
+may be passed, including an empty one, which acts like not passing the argument.
+
+Only the first member of the array will be used, the others will be discarded
+with a warning.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1900,6 +1900,14 @@ class SharedLibrary(BuildTarget):
         # Visual Studio module-definitions file
         if 'vs_module_defs' in kwargs:
             path = unholder(kwargs['vs_module_defs'])
+            if isinstance(path, list):
+                if path:
+                    if len(path) > 1:
+                        mlog.warning('"vs_module_defs" uses only the first file, additional files will be ignored')
+                    path = path[0]
+                else:
+                    path = None
+
             if isinstance(path, str):
                 if os.path.isabs(path):
                     self.vs_module_defs = File.from_absolute_file(path)
@@ -1915,7 +1923,7 @@ class SharedLibrary(BuildTarget):
                 path = File.from_built_file(path.subdir, path.get_filename())
                 self.vs_module_defs = path
                 self.link_depends.append(path)
-            else:
+            elif path is not None:
                 raise InvalidArguments(
                     'Shared library vs_module_defs must be either a string, '
                     'a file object or a Custom Target')

--- a/test cases/windows/6 vs module defs/subdir/meson.build
+++ b/test cases/windows/6 vs module defs/subdir/meson.build
@@ -1,1 +1,7 @@
 shlib = shared_library('somedll', 'somedll.c', vs_module_defs : 'somedll.def')
+
+# These don't need to be built, we're just testing the parser
+shared_library('some_unusable_dll', 'somedll.c', vs_module_defs : [],
+  build_by_default : false)
+shared_library('some_other_dll', 'somedll.c', vs_module_defs : ['somedll.def'],
+  build_by_default : false)


### PR DESCRIPTION
There are some cases where we want to use a def file with one compiler,
but not another. For example, you might want to use one with msvc,
clang-cl, and intel-cl, but not with mingw. Previously this required
duplicating the library call, one for the compilers with the def file,
and one without. This allows us to pass an array, possibly of zero
elements.