### PR TITLE
cmake: Subprojects support CMAKE_PREFIX_PATH (fixes #7249)

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1086,21 +1086,7 @@ class CMakeDependency(ExternalDependency):
         if cm_path:
             cm_args.append('-DCMAKE_MODULE_PATH=' + ';'.join(cm_path))
 
-        pref_path = self.env.coredata.builtins_per_machine[self.for_machine]['cmake_prefix_path'].value
-        env_pref_path = get_env_var(
-            self.for_machine,
-            self.env.is_cross_build(),
-            'CMAKE_PREFIX_PATH')
-        if env_pref_path is not None:
-            env_pref_path = env_pref_path.split(os.pathsep)
-            env_pref_path = [x for x in env_pref_path if x]  # Filter out empty strings
-            if not pref_path:
-                pref_path = []
-            pref_path += env_pref_path
-        if pref_path:
-            cm_args.append('-DCMAKE_PREFIX_PATH={}'.format(';'.join(pref_path)))
-
-        if not self._preliminary_find_check(name, cm_path, pref_path, environment.machines[self.for_machine]):
+        if not self._preliminary_find_check(name, cm_path, self.cmakebin.get_cmake_prefix_paths(), environment.machines[self.for_machine]):
             mlog.debug('Preliminary CMake check failed. Aborting.')
             return
         self._detect_dep(name, modules, components, cm_args)

--- a/test cases/cmake/7 cmake options/subprojects/cmOpts/CMakeLists.txt
+++ b/test cases/cmake/7 cmake options/subprojects/cmOpts/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.7)
+project(testPro)
 
 if(NOT "${SOME_CMAKE_VAR}" STREQUAL "something")
   message(FATAL_ERROR "Setting the CMake var failed")
+endif()
+
+if(NOT "${CMAKE_PREFIX_PATH}" STREQUAL "val1;val2")
+  message(FATAL_ERROR "Setting the CMAKE_PREFIX_PATH failed '${CMAKE_PREFIX_PATH}'")
 endif()

--- a/test cases/cmake/7 cmake options/test.json
+++ b/test cases/cmake/7 cmake options/test.json
@@ -1,0 +1,9 @@
+{
+  "matrix": {
+    "options": {
+      "cmake_prefix_path": [
+        { "val": ["val1", "val2"] }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
fixes #7249