### PR TITLE
Fix OpenMP on Visual Studio

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -992,23 +992,23 @@ class Vs2010Backend(backends.Backend):
             # Cflags required by external deps might have UNIX-specific flags,
             # so filter them out if needed
             if isinstance(d, dependencies.OpenMPDependency):
-                d_compile_args = compiler.openmp_flags()
+                ET.SubElement(clconf, 'OpenMPSupport').text = 'true'
             else:
                 d_compile_args = compiler.unix_args_to_native(d.get_compile_args())
-            for arg in d_compile_args:
-                if arg.startswith(('-D', '/D')):
-                    define = arg[2:]
-                    # De-dup
-                    if define in target_defines:
-                        target_defines.remove(define)
-                    target_defines.append(define)
-                elif arg.startswith(('-I', '/I')):
-                    inc_dir = arg[2:]
-                    # De-dup
-                    if inc_dir not in target_inc_dirs:
-                        target_inc_dirs.append(inc_dir)
-                else:
-                    target_args.append(arg)
+                for arg in d_compile_args:
+                    if arg.startswith(('-D', '/D')):
+                        define = arg[2:]
+                        # De-dup
+                        if define in target_defines:
+                            target_defines.remove(define)
+                        target_defines.append(define)
+                    elif arg.startswith(('-I', '/I')):
+                        inc_dir = arg[2:]
+                        # De-dup
+                        if inc_dir not in target_inc_dirs:
+                            target_inc_dirs.append(inc_dir)
+                    else:
+                        target_args.append(arg)
 
         languages += gen_langs
         if len(target_args) > 0:
@@ -1100,14 +1100,14 @@ class Vs2010Backend(backends.Backend):
                 # Extend without reordering or de-dup to preserve `-L -l` sets
                 # https://github.com/mesonbuild/meson/issues/1718
                 if isinstance(dep, dependencies.OpenMPDependency):
-                    extra_link_args.extend_direct(compiler.openmp_flags())
+                    ET.SubElement(clconf, 'OpenMPSuppport').text = 'true'
                 else:
                     extra_link_args.extend_direct(dep.get_link_args())
             for d in target.get_dependencies():
                 if isinstance(d, build.StaticLibrary):
                     for dep in d.get_external_deps():
                         if isinstance(dep, dependencies.OpenMPDependency):
-                            extra_link_args.extend_direct(compiler.openmp_flags())
+                            ET.SubElement(clconf, 'OpenMPSuppport').text = 'true'
                         else:
                             extra_link_args.extend_direct(dep.get_link_args())
         # Add link args for c_* or cpp_* build options. Currently this only

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1087,6 +1087,9 @@ class Compiler:
     def openmp_flags(self):
         raise EnvironmentException('Language %s does not support OpenMP flags.' % self.get_display_language())
 
+    def openmp_link_flags(self):
+        return self.openmp_flags()
+
     def language_stdlib_only_link_flags(self):
         return []
 

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -208,6 +208,9 @@ class VisualStudioLikeCompiler(metaclass=abc.ABCMeta):
     def openmp_flags(self) -> T.List[str]:
         return ['/openmp']
 
+    def openmp_link_flags(self) -> T.List[str]:
+        return []
+
     # FIXME, no idea what these should be.
     def thread_flags(self, env: 'Environment') -> T.List[str]:
         return []

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -97,7 +97,8 @@ class OpenMPDependency(ExternalDependency):
             for name in header_names:
                 if self.clib_compiler.has_header(name, '', self.env, dependencies=[self], disable_cache=True)[0]:
                     self.is_found = True
-                    self.compile_args = self.link_args = self.clib_compiler.openmp_flags()
+                    self.compile_args = self.clib_compiler.openmp_flags()
+                    self.link_args = self.clib_compiler.openmp_link_flags()
                     break
             if not self.is_found:
                 mlog.log(mlog.yellow('WARNING:'), 'OpenMP found but omp.h missing.')


### PR DESCRIPTION
Using --backend=ninja with Visual Studio results in many warnings (one for each static library included in an executable). Using --backend=vs2019 results in OpenMP not working.

Fix both of these issues.

Example meson.build file demonstrating these issues:
```meson
project('tmp', 'c')

openmp = dependency('openmp')

libone = static_library('libone', 'fileone.c', dependencies: openmp)
libtwo = static_library('libtwo', 'filetwo.c', dependencies: openmp)

executable('main', 'main.c', link_with: [libone, libtwo])
```