### PR TITLE
0.54 regression: cmake_traceparser: ignore trace parse error

### DIFF
--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -139,7 +139,7 @@ class CMakeTraceParser:
         if not self.requires_stderr():
             if not self.trace_file_path.exists and not self.trace_file_path.is_file():
                 raise CMakeException('CMake: Trace file "{}" not found'.format(str(self.trace_file_path)))
-            trace = self.trace_file_path.read_text()
+            trace = self.trace_file_path.read_text(errors='ignore')
         if not trace:
             raise CMakeException('CMake: The CMake trace was not provided or is empty')
 


### PR DESCRIPTION
Meson 0.54.0 introduced a regression from acc6dbfab7 that affects `dependency()` that uses CMake, even automatically--Meson crashes with traceback at the bottom of this post.

This "fix" has been previously applied in other PRs to other places Meson reads CMake trace--this was just the latest issue introduced.

```
Traceback (most recent call last):
  File "meson\mesonbuild\mesonmain.py", line 129, in run
    return options.run_func(options)
  File "meson\mesonbuild\msetup.py", line 245, in run
    app.generate()
  File "meson\mesonbuild\msetup.py", line 159, in generate
    self._generate(env)
  File "meson\mesonbuild\msetup.py", line 192, in _generate
    intr.run()
  File "meson\mesonbuild\interpreter.py", line 4169, in run
    super().run()
  File "meson\mesonbuild\interpreterbase.py", line 412, in run
    self.evaluate_codeblock(self.ast, start=1)
  File "meson\mesonbuild\interpreterbase.py", line 436, in evaluate_codeblock
    raise e
  File "meson\mesonbuild\interpreterbase.py", line 430, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "meson\mesonbuild\interpreterbase.py", line 441, in evaluate_statement
    return self.function_call(cur)
  File "meson\mesonbuild\interpreterbase.py", line 788, in function_call
    return func(node, posargs, kwargs)
  File "meson\mesonbuild\interpreterbase.py", line 285, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "meson\mesonbuild\interpreterbase.py", line 174, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "meson\mesonbuild\interpreter.py", line 3691, in func_subdir
    self.evaluate_codeblock(codeblock)
  File "meson\mesonbuild\interpreterbase.py", line 436, in evaluate_codeblock
    raise e
  File "meson\mesonbuild\interpreterbase.py", line 430, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "meson\mesonbuild\interpreterbase.py", line 451, in evaluate_statement
    return self.evaluate_if(cur)
  File "meson\mesonbuild\interpreterbase.py", line 530, in evaluate_if
    self.evaluate_codeblock(i.block)
  File "meson\mesonbuild\interpreterbase.py", line 436, in evaluate_codeblock
    raise e
  File "meson\mesonbuild\interpreterbase.py", line 430, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "meson\mesonbuild\interpreterbase.py", line 443, in evaluate_statement
    return self.assignment(cur)
  File "meson\mesonbuild\interpreterbase.py", line 1064, in assignment
    value = self.evaluate_statement(node.value)
  File "meson\mesonbuild\interpreterbase.py", line 441, in evaluate_statement
    return self.function_call(cur)
  File "meson\mesonbuild\interpreterbase.py", line 788, in function_call
    return func(node, posargs, kwargs)
  File "meson\mesonbuild\interpreterbase.py", line 285, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "meson\mesonbuild\interpreterbase.py", line 285, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "meson\mesonbuild\interpreterbase.py", line 285, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  [Previous line repeated 2 more times]
  File "meson\mesonbuild\interpreterbase.py", line 155, in wrapped
    ret = f(*wrapped_args, **wrapped_kwargs)
  File "meson\mesonbuild\interpreterbase.py", line 174, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "meson\mesonbuild\interpreter.py", line 3234, in func_dependency
    d = self.dependency_impl(name, display_name, kwargs)
  File "meson\mesonbuild\interpreter.py", line 3281, in dependency_impl
    dep = dependencies.find_external_dependency(name, self.environment, kwargs)
  File "meson\mesonbuild\dependencies\base.py", line 2248, in find_external_dependency
    d = c()
  File "meson\mesonbuild\dependencies\base.py", line 1141, in __init__
    self._detect_dep(name, modules, cm_args)
  File "meson\mesonbuild\dependencies\base.py", line 1360, in _detect_dep
    self.traceparser.parse(err1)
  File "meson\mesonbuild\cmake\traceparser.py", line 100, in parse
    trace = self.trace_file_path.read_text()
  File "C:\miniconda3\lib\pathlib.py", line 1217, in read_text
    return f.read()
  File "C:\miniconda3\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
```