### PR TITLE
0.54.1 regression: add library() check for Fortran configure_file()

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -501,6 +501,12 @@ class Backend:
         target.rpath_dirs_to_remove.update([d.encode('utf8') for d in result])
         return tuple(result)
 
+    @staticmethod
+    def canonicalize_filename(fname):
+        for ch in ('/', '\\', ':'):
+            fname = fname.replace(ch, '_')
+        return fname
+
     def object_filename_from_source(self, target, source):
         assert isinstance(source, mesonlib.File)
         build_dir = self.environment.get_build_dir()
@@ -531,7 +537,7 @@ class Backend:
                 source = os.path.relpath(os.path.join(build_dir, rel_src),
                                          os.path.join(self.environment.get_source_dir(), target.get_subdir()))
         machine = self.environment.machines[target.for_machine]
-        return source.replace('/', '_').replace('\\', '_') + '.' + machine.get_object_suffix()
+        return self.canonicalize_filename(source) + '.' + machine.get_object_suffix()
 
     def determine_ext_objs(self, extobj, proj_dir_to_build_root):
         result = []

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2160,7 +2160,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             src_filename = os.path.basename(src)
         else:
             src_filename = src
-        obj_basename = src_filename.replace('/', '_').replace('\\', '_')
+        obj_basename = self.canonicalize_filename(src_filename)
         rel_obj = os.path.join(self.get_target_private_dir(target), obj_basename)
         rel_obj += '.' + self.environment.machines[target.for_machine].get_object_suffix()
         commands += self.get_compile_debugfile_args(compiler, target, rel_obj)

--- a/test cases/fortran/7 generated/meson.build
+++ b/test cases/fortran/7 generated/meson.build
@@ -10,6 +10,8 @@ conf_data.set('THREE', 3)
 
 outfile = configure_file(
       input : 'mod3.fpp', output : 'mod3.f90', configuration : conf_data)
+# Manually build absolute path to source file to test
+# https://github.com/mesonbuild/meson/issues/7265
 three = library('mod3', meson.current_build_dir() / 'mod3.f90')
 
 templates_basenames = ['mod2', 'mod1']

--- a/test cases/fortran/7 generated/meson.build
+++ b/test cases/fortran/7 generated/meson.build
@@ -6,6 +6,11 @@ project('generated', 'fortran')
 conf_data = configuration_data()
 conf_data.set('ONE', 1)
 conf_data.set('TWO', 2)
+conf_data.set('THREE', 3)
+
+outfile = configure_file(
+      input : 'mod3.fpp', output : 'mod3.f90', configuration : conf_data)
+three = library('mod3', meson.current_build_dir() / 'mod3.f90')
 
 templates_basenames = ['mod2', 'mod1']
 generated_sources = []
@@ -18,5 +23,5 @@ foreach template_basename : templates_basenames
 endforeach
 
 sources = ['prog.f90'] + generated_sources
-exe = executable('generated', sources)
+exe = executable('generated', sources, link_with: three)
 test('generated', exe)

--- a/test cases/fortran/7 generated/mod1.fpp
+++ b/test cases/fortran/7 generated/mod1.fpp
@@ -1,6 +1,6 @@
 module mod1
-  implicit none
+implicit none
 
-  integer, parameter :: modval1 = @ONE@
+integer, parameter :: modval1 = @ONE@
 
 end module mod1

--- a/test cases/fortran/7 generated/mod2.fpp
+++ b/test cases/fortran/7 generated/mod2.fpp
@@ -1,7 +1,7 @@
 module mod2
-  use mod1
-  implicit none
+use mod1, only : modval1
+implicit none
 
-  integer, parameter :: modval2 = @TWO@
+integer, parameter :: modval2 = @TWO@
 
 end module mod2

--- a/test cases/fortran/7 generated/mod3.fpp
+++ b/test cases/fortran/7 generated/mod3.fpp
@@ -1,0 +1,6 @@
+module mod3
+implicit none
+
+integer, parameter :: modval3 = @THREE@
+
+end module mod3

--- a/test cases/fortran/7 generated/prog.f90
+++ b/test cases/fortran/7 generated/prog.f90
@@ -1,7 +1,8 @@
-program prog
-use mod2
+program generated
+use mod2, only : modval1, modval2
+use mod3, only : modval3
 implicit none
 
-if (modval1 + modval2 /= 3) stop 1
+if (modval1 + modval2 + modval3 /= 6) error stop
 
-end program prog
+end program generated


### PR DESCRIPTION
Meson 0.54.1 has a regression noted in #7265. This additional test code reveals the issue, but does not fix the issue. This is an important use case that may only break on Windows, but it's good to add this test in general.