### PR TITLE
Add gtkdoc test covering gtkdoc-scangobj

### DIFF
--- a/test cases/frameworks/10 gtk-doc/doc/baz/baz-docs.xml
+++ b/test cases/frameworks/10 gtk-doc/doc/baz/baz-docs.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
+               "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
+<book id="index" xmlns:xi="http://www.w3.org/2003/XInclude">
+  <bookinfo>
+    <title>Baz Reference Manual</title>
+    <releaseinfo>for Baz 1.0</releaseinfo>
+    <authorgroup>
+      <author>
+        <firstname>Testy</firstname>
+        <surname>McTestFace</surname>
+        <affiliation>
+          <address>
+            <email>unknown@example.com</email>
+          </address>
+        </affiliation>
+      </author>
+    </authorgroup>
+    <copyright>
+      <year>2020</year>
+      <holder>The Baz Organization</holder>
+    </copyright>
+  </bookinfo>
+
+  <reference id="baz">
+    <title>Baz library</title>
+    <partintro>
+      <para>
+        This documents the Baz library.
+      </para>
+    </partintro>
+    <xi:include href="xml/baz_trivial.xml"/>
+  </reference>
+</book>

--- a/test cases/frameworks/10 gtk-doc/doc/baz/meson.build
+++ b/test cases/frameworks/10 gtk-doc/doc/baz/meson.build
@@ -1,0 +1,7 @@
+gnome.gtkdoc('baz',
+  src_dir : [],
+  main_xml : 'baz-docs.xml',
+  dependencies: libbaz_dep,
+  scan_args: '--rebuild-types',
+  check: true,
+  install : true)

--- a/test cases/frameworks/10 gtk-doc/doc/meson.build
+++ b/test cases/frameworks/10 gtk-doc/doc/meson.build
@@ -8,3 +8,5 @@ subdir('foobar1')
 subdir('foobar2')
 subdir('foobar3')
 subdir('foobar4')
+
+subdir('baz')

--- a/test cases/frameworks/10 gtk-doc/meson.build
+++ b/test cases/frameworks/10 gtk-doc/meson.build
@@ -12,6 +12,7 @@ assert(gnome.gtkdoc_html_dir('foobar') == 'share/gtk-doc/html/foobar', 'Gtkdoc i
 inc = include_directories('include')
 
 subdir('include')
+subdir('src')
 
 # disable this test unless a bug fix for spaces in pathnames is present
 # https://bugzilla.gnome.org/show_bug.cgi?id=753145

--- a/test cases/frameworks/10 gtk-doc/src/baz_trivial.c
+++ b/test cases/frameworks/10 gtk-doc/src/baz_trivial.c
@@ -1,0 +1,24 @@
+#include "baz_trivial.h"
+
+/* instance structure */
+struct _BazTrivial
+{
+  GObject parent_instance;
+};
+
+static void
+baz_trivial_init(BazTrivial *self)
+{
+}
+
+static void
+baz_trivial_class_init(BazTrivialClass *self)
+{
+}
+
+G_DEFINE_TYPE (BazTrivial, baz_trivial, G_TYPE_OBJECT)
+
+void
+baz_trivial_method(BazTrivial *self, GError **error)
+{
+}

--- a/test cases/frameworks/10 gtk-doc/src/baz_trivial.h
+++ b/test cases/frameworks/10 gtk-doc/src/baz_trivial.h
@@ -1,0 +1,35 @@
+/*
+  In the namespace 'Baz', 'Trivial' is a trivial Gobject-drived type
+*/
+
+/* inclusion guard */
+#ifndef __BAZ_TRIVIAL_H__
+#define __BAZ_TRIVIAL_H__
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+/*
+ * Type declaration.
+ */
+#define BAZ_TYPE_TRIVIAL baz_trivial_get_type ()
+G_DECLARE_FINAL_TYPE (BazTrivial, baz_trivial, BAZ, TRIVIAL, GObject)
+
+/*
+ * Method definitions.
+ */
+
+/**
+ * baz_trivial_method:
+ *
+ * This is a trivial method operating on a trivial object.
+ *
+ * It would be a mistake to call this expecting something useful to happen.
+ *
+ **/
+void baz_trivial_method(BazTrivial *self, GError **error);
+
+G_END_DECLS
+
+#endif /* __BAZ_TRIVIAL_H__ */

--- a/test cases/frameworks/10 gtk-doc/src/meson.build
+++ b/test cases/frameworks/10 gtk-doc/src/meson.build
@@ -1,0 +1,8 @@
+gobj = dependency('gobject-2.0')
+
+libbaz = shared_library('baz', 'baz_trivial.c', dependencies: gobj)
+incbaz = include_directories('.')
+
+libbaz_dep = declare_dependency(link_with: libbaz,
+                                dependencies: gobj,
+                                include_directories: incbaz)


### PR DESCRIPTION
Add a trivial GObject-derived class to the gtkdoc test.

This test adds coverage of `gtkdoc-scangobj` being invoked by gtkdochelper (because a typesfile exists, generated by `gtkdoc-scan --rebuild-types`)
