### PR TITLE
Don't try to use build machine dependency finders for host

### DIFF
--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -75,7 +75,7 @@ class CMakeExecutor:
             mlog.debug('CMake binary for %s is not cached' % self.for_machine)
             for potential_cmakebin in find_external_program(
                     environment, self.for_machine, 'cmake', 'CMake',
-                    environment.default_cmake):
+                    environment.default_cmake, allow_default_for_cross=False):
                 version_if_ok = self.check_cmake(potential_cmakebin)
                 if not version_if_ok:
                     continue

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -436,13 +436,14 @@ class ConfigToolDependency(ExternalDependency):
             return m.group(0).rstrip('.')
         return version
 
-    def find_config(self, versions=None, returncode: int = 0):
+    def find_config(self, versions: T.Optional[T.List[str]] = None, returncode: int = 0) \
+            -> T.Tuple[T.Optional[str], T.Optional[str]]:
         """Helper method that searches for config tool binaries in PATH and
         returns the one that best matches the given version requirements.
         """
         if not isinstance(versions, list) and versions is not None:
             versions = listify(versions)
-        best_match = (None, None)
+        best_match = (None, None)  # type: T.Tuple[T.Optional[str], T.Optional[str]]
         for potential_bin in find_external_program(
                 self.env, self.for_machine, self.tool_name,
                 self.tool_name, self.tools, allow_default_for_cross=False):

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -77,7 +77,8 @@ class DependencyMethods(Enum):
 
 
 def find_external_program(env: Environment, for_machine: MachineChoice, name: str,
-                          display_name: str, default_names: T.List[str]) -> T.Generator['ExternalProgram', None, None]:
+                          display_name: str, default_names: T.List[str],
+                          allow_default_for_cross: bool = True) -> T.Generator['ExternalProgram', None, None]:
     """Find an external program, chcking the cross file plus any default options."""
     # Lookup in cross or machine file.
     potential_path = env.lookup_binary_entry(for_machine, name)
@@ -89,12 +90,14 @@ def find_external_program(env: Environment, for_machine: MachineChoice, name: st
         # stop returning options.
         return
     mlog.debug('{} binary missing from cross or native file, or env var undefined.'.format(display_name))
-    # Fallback on hard-coded defaults.
-    # TODO prefix this for the cross case instead of ignoring thing.
-    if env.machines.matches_build_machine(for_machine):
+    # Fallback on hard-coded defaults, if a default binary is allowed for use
+    # with cross targets, or if this is not a cross target
+    if allow_default_for_cross or not (for_machine is MachineChoice.HOST and env.is_cross_build(for_machine)):
         for potential_path in default_names:
             mlog.debug('Trying a default {} fallback at'.format(display_name), potential_path)
             yield ExternalProgram(potential_path, silent=True)
+    else:
+        mlog.debug('Default target is not allowed for cross use')
 
 
 class Dependency:

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -76,6 +76,27 @@ class DependencyMethods(Enum):
     DUB = 'dub'
 
 
+def find_external_program(env: Environment, for_machine: MachineChoice, name: str,
+                          display_name: str, default_names: T.List[str]) -> T.Generator['ExternalProgram', None, None]:
+    """Find an external program, chcking the cross file plus any default options."""
+    # Lookup in cross or machine file.
+    potential_path = env.lookup_binary_entry(for_machine, name)
+    if potential_path is not None:
+        mlog.debug('{} binary for {} specified from cross file, native file, '
+                    'or env var as {}'.format(display_name, for_machine, potential_path))
+        yield ExternalProgram.from_entry(name, potential_path)
+        # We never fallback if the user-specified option is no good, so
+        # stop returning options.
+        return
+    mlog.debug('{} binary missing from cross or native file, or env var undefined.'.format(display_name))
+    # Fallback on hard-coded defaults.
+    # TODO prefix this for the cross case instead of ignoring thing.
+    if env.machines.matches_build_machine(for_machine):
+        for potential_path in default_names:
+            mlog.debug('Trying a default {} fallback at'.format(display_name), potential_path)
+            yield ExternalProgram(potential_path, silent=True)
+
+
 class Dependency:
 
     @classmethod
@@ -352,25 +373,6 @@ class ExternalDependency(Dependency, HasNativeKwarg):
                         raise DependencyException(m.format(self.name, not_found, self.version))
                     return
 
-    # Create an iterator of options
-    def search_tool(self, name, display_name, default_names):
-        # Lookup in cross or machine file.
-        potential_path = self.env.lookup_binary_entry(self.for_machine, name)
-        if potential_path is not None:
-            mlog.debug('{} binary for {} specified from cross file, native file, '
-                       'or env var as {}'.format(display_name, self.for_machine, potential_path))
-            yield ExternalProgram.from_entry(name, potential_path)
-            # We never fallback if the user-specified option is no good, so
-            # stop returning options.
-            return
-        mlog.debug('{} binary missing from cross or native file, or env var undefined.'.format(display_name))
-        # Fallback on hard-coded defaults.
-        # TODO prefix this for the cross case instead of ignoring thing.
-        if self.env.machines.matches_build_machine(self.for_machine):
-            for potential_path in default_names:
-                mlog.debug('Trying a default {} fallback at'.format(display_name), potential_path)
-                yield ExternalProgram(potential_path, silent=True)
-
 
 class NotFoundDependency(Dependency):
     def __init__(self, environment):
@@ -438,7 +440,9 @@ class ConfigToolDependency(ExternalDependency):
         if not isinstance(versions, list) and versions is not None:
             versions = listify(versions)
         best_match = (None, None)
-        for potential_bin in self.search_tool(self.tool_name, self.tool_name, self.tools):
+        for potential_bin in find_external_program(
+                self.env, self.for_machine, self.tool_name,
+                self.tool_name, self.tools):
             if not potential_bin.found():
                 continue
             tool = potential_bin.get_command()
@@ -562,7 +566,7 @@ class PkgConfigDependency(ExternalDependency):
         else:
             assert PkgConfigDependency.class_pkgbin[self.for_machine] is None
             mlog.debug('Pkg-config binary for %s is not cached.' % self.for_machine)
-            for potential_pkgbin in self.search_tool('pkgconfig', 'Pkg-config', environment.default_pkgconfig):
+            for potential_pkgbin in find_external_program(self.env, self.for_machine, 'pkgconfig', 'Pkg-config', environment.default_pkgconfig):
                 mlog.debug('Trying pkg-config binary {} for machine {} at {}'
                            .format(potential_pkgbin.name, self.for_machine, potential_pkgbin.command))
                 version_if_ok = self.check_pkgconfig(potential_pkgbin)

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -445,7 +445,7 @@ class ConfigToolDependency(ExternalDependency):
         best_match = (None, None)
         for potential_bin in find_external_program(
                 self.env, self.for_machine, self.tool_name,
-                self.tool_name, self.tools):
+                self.tool_name, self.tools, allow_default_for_cross=False):
             if not potential_bin.found():
                 continue
             tool = potential_bin.get_command()
@@ -569,9 +569,9 @@ class PkgConfigDependency(ExternalDependency):
         else:
             assert PkgConfigDependency.class_pkgbin[self.for_machine] is None
             mlog.debug('Pkg-config binary for %s is not cached.' % self.for_machine)
-            for potential_pkgbin in find_external_program(self.env, self.for_machine, 'pkgconfig', 'Pkg-config', environment.default_pkgconfig):
-                mlog.debug('Trying pkg-config binary {} for machine {} at {}'
-                           .format(potential_pkgbin.name, self.for_machine, potential_pkgbin.command))
+            for potential_pkgbin in find_external_program(
+                    self.env, self.for_machine, 'pkgconfig', 'Pkg-config',
+                    environment.default_pkgconfig, allow_default_for_cross=False):
                 version_if_ok = self.check_pkgconfig(potential_pkgbin)
                 if not version_if_ok:
                     continue

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -31,9 +31,11 @@ from .base import DependencyException, DependencyMethods
 from .base import ExternalDependency, NonExistingExternalProgram
 from .base import ExtraFrameworkDependency, PkgConfigDependency
 from .base import ConfigToolDependency, DependencyFactory
+from .base import find_external_program
 
 if T.TYPE_CHECKING:
     from ..environment import Environment
+    from .base import ExternalProgram
 
 
 class GLDependencySystem(ExternalDependency):
@@ -324,10 +326,9 @@ class QtBaseDependency(ExternalDependency):
             if prefix:
                 self.bindir = os.path.join(prefix, 'bin')
 
-    def search_qmake(self):
+    def search_qmake(self) -> T.Generator['ExternalProgram', None, None]:
         for qmake in ('qmake-' + self.name, 'qmake'):
-            for potential_qmake in self.search_tool(qmake, 'QMake', [qmake]):
-                yield potential_qmake
+            yield from find_external_program(self.env, self.for_machine, qmake, 'QMake', [qmake])
 
     def _qmake_detect(self, mods, kwargs):
         for qmake in self.search_qmake():


### PR DESCRIPTION
Even if the build machine == host machine, we can't use dependencies from the build machine for the host machine. This can happen when using a system to build a new machine image. for example when compiling chromeos. It's completely possible to build an x86_64-linux host for an x86_64-linux build machine, but not have all of the same runtime dependencies. In particular, if meson tries to use cmake from the build machine for host dependencies it will result in trouble.

Fixes: #7276