### PR TITLE
tell variable name when erroring on bad combo option

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -161,7 +161,9 @@ class UserComboOption(UserOption[str]):
     def validate_value(self, value):
         if value not in self.choices:
             optionsstring = ', '.join(['"%s"' % (item,) for item in self.choices])
-            raise MesonException('Value "%s" for combo option is not one of the choices. Possible choices are: %s.' % (value, optionsstring))
+            raise MesonException('Value "{}" for combo option "{}" is not one of the choices.'
+                                 ' Possible choices are: {}.'.format(
+                                     value, self.description, optionsstring))
         return value
 
 class UserArrayOption(UserOption[T.List[str]]):


### PR DESCRIPTION
fixes #7269

test by:

meson.build
```meson
project('foo')
message(get_option('m1'))
```

meson_options.txt
```meson
option('m1', type: 'combo', choices: ['a', 'b'])
```

then do

```sh
meson build -Dm1=c
```

now results in 

> meson.build:1:0: ERROR: Value "c" for combo option "m1" is not one of the choices. Possible choices are: "a", "b".