### PR TITLE
apple: -headerpad args are ignored when bitcode is enabled

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -377,9 +377,10 @@ def get_base_link_args(options, linker, is_shared_module):
         # -Wl,-dead_strip_dylibs is incompatible with bitcode
         args.extend(linker.get_asneeded_args())
 
-    # Apple's ld (the only one that supports bitcode) does not like any
-    # -undefined arguments at all, so don't pass these when using bitcode
+    # Apple's ld (the only one that supports bitcode) does not like -undefined
+    # arguments or -headerpad_max_install_names when bitcode is enabled
     if not bitcode:
+        args.extend(linker.headerpad_args())
         if (not is_shared_module and
                 option_enabled(linker.base_options, options, 'b_lundef')):
             args.extend(linker.no_undefined_link_args())
@@ -1202,6 +1203,9 @@ class Compiler:
 
     def get_asneeded_args(self) -> T.List[str]:
         return self.linker.get_asneeded_args()
+
+    def headerpad_args(self) -> T.List[str]:
+        return self.linker.headerpad_args()
 
     def bitcode_args(self) -> T.List[str]:
         return self.linker.bitcode_args()

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -870,7 +870,7 @@ class CoreData:
 
     def emit_base_options_warnings(self, enabled_opts: list):
         if 'b_bitcode' in enabled_opts:
-            mlog.warning('Base option \'b_bitcode\' is enabled, which is incompatible with many linker options. Incompatible options such as such as \'b_asneeded\' have been disabled.')
+            mlog.warning('Base option \'b_bitcode\' is enabled, which is incompatible with many linker options. Incompatible options such as \'b_asneeded\' have been disabled.')
             mlog.warning('Please see https://mesonbuild.com/Builtin-options.html#Notes_about_Apple_Bitcode_support for more details.')
 
 class CmdLineFileParser(configparser.ConfigParser):

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -440,6 +440,10 @@ class DynamicLinker(LinkerEnvVarsMixin, metaclass=abc.ABCMeta):
         """Arguments to make all warnings errors."""
         return []
 
+    def headerpad_args(self) -> T.List[str]:
+        # Only used by the Apple linker
+        return []
+
     def bitcode_args(self) -> T.List[str]:
         raise mesonlib.MesonException('This linker does not support bitcode bundles')
 
@@ -659,8 +663,8 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
     def no_undefined_args(self) -> T.List[str]:
         return self._apply_prefix('-undefined,error')
 
-    def get_always_args(self) -> T.List[str]:
-        return self._apply_prefix('-headerpad_max_install_names') + super().get_always_args()
+    def headerpad_args(self) -> T.List[str]:
+        return self._apply_prefix('-headerpad_max_install_names')
 
     def bitcode_args(self) -> T.List[str]:
         return self._apply_prefix('-bitcode_bundle')
@@ -688,9 +692,7 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
                          install_rpath: str) -> T.Tuple[T.List[str], T.Set[bytes]]:
         if not rpath_paths and not install_rpath and not build_rpath:
             return ([], set())
-        # Ensure that there is enough space for install_name_tool in-place
-        # editing of large RPATHs
-        args = self._apply_prefix('-headerpad_max_install_names')
+        args = []
         # @loader_path is the equivalent of $ORIGIN on macOS
         # https://stackoverflow.com/q/26280738
         origin_placeholder = '@loader_path'

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -8150,6 +8150,9 @@ def convert_args(argv):
     test_list = []
     for arg in argv:
         if arg.startswith('-'):
+            if arg in ('-f', '--failfast'):
+                arg = '--exitfirst'
+            pytest_args.append(arg)
             continue
         # ClassName.test_name => 'ClassName and test_name'
         if '.' in arg:


### PR DESCRIPTION
commit 7cc9039fc452fd89c686c5049b38da1e95cb447e:

```
Fix typo in bitcode message
```

commit 3cd2dacde9f4513d192d169e40b67a906df6c982:

```
apple: -headerpad args are ignored when bitcode is enabled
Causes spammy warnings from the linker:

ld: warning: -headerpad_max_install_names is ignored when used with -bitcode_bundle (Xcode setting ENABLE_BITCODE=YES)
```
