### PR TITLE
Add [options] section to native/cross files

### DIFF
--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -205,19 +205,13 @@ class Conf:
         test_options = {k: o for k, o in self.coredata.builtins.items() if k in test_option_names}
         core_options = {k: o for k, o in self.coredata.builtins.items() if k in core_option_names}
 
-        def insert_build_prefix(k):
-            idx = k.find(':')
-            if idx < 0:
-                return 'build.' + k
-            return k[:idx + 1] + 'build.' + k[idx + 1:]
-
         core_options = self.split_options_per_subproject(core_options.items())
         host_compiler_options = self.split_options_per_subproject(
             self.coredata.flatten_lang_iterator(
                 self.coredata.compiler_options.host.items()))
         build_compiler_options = self.split_options_per_subproject(
             self.coredata.flatten_lang_iterator(
-                (insert_build_prefix(k), o)
+                (coredata.insert_build_prefix(k), o)
                 for k, o in self.coredata.compiler_options.build.items()))
         project_options = self.split_options_per_subproject(self.coredata.user_options.items())
         show_build_options = self.default_values_only or self.build.environment.is_cross_build()
@@ -226,7 +220,7 @@ class Conf:
         self.print_options('Core options', core_options[''])
         self.print_options('', self.coredata.builtins_per_machine.host)
         if show_build_options:
-            self.print_options('', {insert_build_prefix(k): o for k, o in self.coredata.builtins_per_machine.build.items()})
+            self.print_options('', {coredata.insert_build_prefix(k): o for k, o in self.coredata.builtins_per_machine.build.items()})
         self.print_options('Backend options', self.coredata.backend_options)
         self.print_options('Base options', self.coredata.base_options)
         self.print_options('Compiler options', host_compiler_options.get('', {}))

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4683,6 +4683,45 @@ recommended as it is not supported on some platforms''')
         self.assertRegex(contents, r'build main(\.exe)?.*: c_LINKER')
         self.assertRegex(contents, r'build (lib|cyg)?mylib.*: c_LINKER')
 
+    def test_cross_file_options(self):
+        testdir = os.path.join(self.unit_test_dir,
+                               '78 config file options')
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            f.write(textwrap.dedent(
+                '''
+                [options]
+                default_library = 'static'
+                opt1 = false
+
+                c_args = ['-DNATIVE']
+                pkg_config_path = ['/native']
+                '''))
+            self.meson_native_file = f.name
+
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as f:
+            f.write(textwrap.dedent(
+                '''
+                [options]
+                default_library = 'both'
+                opt1 = true
+                opt2 = false
+                opt3 = 1
+                datadir = 'my_datadir'
+
+                c_args = ['-DCROSS']
+                pkg_config_path = ['/cross']
+
+                sub:sub_opt1 = true
+                sub:default_library = 'static'
+
+                [paths]
+                datadir = 'wrong_datadir'
+                '''))
+            self.meson_cross_file = f.name
+
+        # Verify that -Dopt2=true from command line overrides value from
+        # native file
+        self.init(testdir, extra_args=['-Dopt2=true'])
 
 class FailureTests(BasePlatformTests):
     '''

--- a/test cases/unit/78 config file options/meson.build
+++ b/test cases/unit/78 config file options/meson.build
@@ -1,0 +1,20 @@
+project('test', 'c')
+
+# Built-in options
+assert(get_option('default_library') == 'both')
+assert(get_option('datadir') == 'my_datadir')
+
+# Project options
+assert(get_option('opt1') == true)
+assert(get_option('opt2') == true)
+assert(get_option('opt3') == 1)
+
+# Per machine built-in options
+assert(get_option('pkg_config_path') == ['/cross'])
+assert(get_option('build.pkg_config_path') == ['/native'])
+
+# Per machine compiler options
+assert(get_option('c_args') == ['-DCROSS'])
+assert(get_option('build.c_args') == ['-DNATIVE'])
+
+subproject('sub')

--- a/test cases/unit/78 config file options/meson_options.txt
+++ b/test cases/unit/78 config file options/meson_options.txt
@@ -1,0 +1,3 @@
+option('opt1', type: 'boolean', value : false)
+option('opt2', type: 'boolean', value : false)
+option('opt3', type: 'integer', value : 0)

--- a/test cases/unit/78 config file options/subprojects/sub/meson.build
+++ b/test cases/unit/78 config file options/subprojects/sub/meson.build
@@ -1,0 +1,4 @@
+project('sub')
+
+assert(get_option('default_library') == 'static')
+assert(get_option('sub_opt1') == true)

--- a/test cases/unit/78 config file options/subprojects/sub/meson_options.txt
+++ b/test cases/unit/78 config file options/subprojects/sub/meson_options.txt
@@ -1,0 +1,1 @@
+option('sub_opt1', type: 'boolean', value : false)


### PR DESCRIPTION
This is a counter proposal for https://github.com/mesonbuild/meson/pull/6597. Since I had this code laying around, let's push it as PR for reference. The main advantage is the implementation is simpler. This also does not split project and built-in options in the machine file which is IMHO an arbitrary useless distinction.

Putting it here for reference, I'm not really expecting it to be merged but maybe it can help tackling the remaining issue for per machine compiler options.