### PR TITLE
Correct argument typo in partial_dependency Documentation

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2425,7 +2425,7 @@ an external dependency with the following methods:
    defaults to `'preserve'`.
 
  - `partial_dependency(compile_args : false, link_args : false, links
-   : false, includes : false, source : false)` *(Added 0.46.0)* returns
+   : false, includes : false, sources : false)` *(Added 0.46.0)* returns
    a new dependency object with the same name, version, found status,
    type name, and methods as the object that called it. This new
    object will only inherit other attributes from its parent as


### PR DESCRIPTION
Should be "sources" not "source"

```
../meson.build:162: WARNING: Passed invalid keyword argument "source".
WARNING: This will become a hard error in the future.
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/mesonmain.py", line 131, in run
    return options.run_func(options)
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/msetup.py", line 245, in run
    app.generate()
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/msetup.py", line 159, in generate
    self._generate(env)
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/msetup.py", line 192, in _generate
    intr.run()
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/interpreter.py", line 4359, in run
    super().run()
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/interpreterbase.py", line 465, in run
    self.evaluate_codeblock(self.ast, start=1)
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/interpreterbase.py", line 490, in evaluate_codeblock
    raise e
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/interpreterbase.py", line 483, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/interpreterbase.py", line 498, in evaluate_statement
    self.assignment(cur)
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/interpreterbase.py", line 1151, in assignment
    value = self.evaluate_statement(node.value)
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/interpreterbase.py", line 500, in evaluate_statement
    return self.method_call(cur)
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/interpreterbase.py", line 895, in method_call
    return obj.method_call(method_name, args, self.kwargs_string_keys(kwargs))
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/interpreterbase.py", line 39, in method_call
    return method(args, kwargs)
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/interpreterbase.py", line 285, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/interpreterbase.py", line 151, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/interpreterbase.py", line 213, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "/usr/local/lib/python3.7/site-packages/mesonbuild/interpreter.py", line 484, in partial_dependency_method
    pdep = self.held_object.get_partial_dependency(**kwargs)
TypeError: get_partial_dependency() got an unexpected keyword argument 'source'
FAILED: build.ninja
```