### PR TITLE
mdist: Filter out buildtype to avoid warning

### DIFF
--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -213,7 +213,7 @@ def check_dist(packagename, meson_command, extra_meson_args, bld_root, privdir):
     unpacked_src_dir = unpacked_files[0]
     with open(os.path.join(bld_root, 'meson-info', 'intro-buildoptions.json')) as boptions:
         meson_command += ['-D{name}={value}'.format(**o) for o in json.load(boptions)
-                          if o['name'] not in ['backend', 'install_umask']]
+                          if o['name'] not in ['backend', 'install_umask', 'buildtype']]
     meson_command += extra_meson_args
 
     ret = run_dist_steps(meson_command, unpacked_src_dir, builddir, installdir, ninja_bin)


### PR DESCRIPTION
Since we parse `buildoptions.json` to pass options, we end up passing `-Dbuildtype` and also `-Doptimization` and `-Ddebug` which triggers the warning:

`WARNING: Recommend using either -Dbuildtype or -Doptimization + -Ddebug [...]`

Filter out buildtype. It is redundant.