### PR TITLE
ci: Skip some CMake tests on windows

### DIFF
--- a/test cases/cmake/2 advanced/meson.build
+++ b/test cases/cmake/2 advanced/meson.build
@@ -5,6 +5,10 @@ if not dep_test.found()
   error('MESON_SKIP_TEST: zlib is not installed')
 endif
 
+if build_machine.system() == 'windows'
+  error('MESON_SKIP_TEST: zlib on Azure is broken')
+endif
+
 cm = import('cmake')
 
 # Test the "normal" subproject call

--- a/test cases/cmake/5 object library/meson.build
+++ b/test cases/cmake/5 object library/meson.build
@@ -5,6 +5,10 @@ if not dep_test.found()
   error('MESON_SKIP_TEST: zlib is not installed')
 endif
 
+if build_machine.system() == 'windows'
+  error('MESON_SKIP_TEST: zlib on Azure is broken')
+endif
+
 cm = import('cmake')
 
 sub_pro = cm.subproject('cmObjLib')


### PR DESCRIPTION
The `5 object library` test fails because of an update
to the Azure image, which provides a broken zlib version.

The `2 advanced` test fails earlier because of some
path related issues, however, even if this is fixed would
the test fail for the same reason `5 object library` fails.

fixes #7307