### PR TITLE
Disable failing cmake jobs on VS2017

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,8 @@ jobs:
 - job: vs2017
   pool:
     vmImage: VS2017-Win2016
+  variables:
+    CI_JOB_VS2017: 1
 
   strategy:
     matrix:

--- a/test cases/cmake/2 advanced/meson.build
+++ b/test cases/cmake/2 advanced/meson.build
@@ -5,6 +5,13 @@ if not dep_test.found()
   error('MESON_SKIP_TEST: zlib is not installed')
 endif
 
+py3 = import('python').find_installation('python3')
+get_envvar = '''import os, sys; print(os.environ.get('@0@', 0), end='')'''
+# Remove this env var from azure-pipelines.yml when fixed
+if run_command(py3, '-c', get_envvar.format('CI_JOB_VS2017')).stdout() == '1'
+  error('MESON_SKIP_TEST: broken for vs2017 jobs')
+endif
+
 cm = import('cmake')
 
 # Test the "normal" subproject call

--- a/test cases/cmake/5 object library/meson.build
+++ b/test cases/cmake/5 object library/meson.build
@@ -5,6 +5,13 @@ if not dep_test.found()
   error('MESON_SKIP_TEST: zlib is not installed')
 endif
 
+py3 = import('python').find_installation('python3')
+get_envvar = '''import os, sys; print(os.environ.get('@0@', 0), end='')'''
+# Remove this env var from azure-pipelines.yml when fixed
+if run_command(py3, '-c', get_envvar.format('CI_JOB_VS2017')).stdout() == '1'
+  error('MESON_SKIP_TEST: broken for vs2017 jobs')
+endif
+
 cm = import('cmake')
 
 sub_pro = cm.subproject('cmObjLib')


### PR DESCRIPTION
These only fail when building with msvc/clang-cl on the VS2017-Win2016
image. See: https://github.com/mesonbuild/meson/issues/7307

Attempt at making https://github.com/mesonbuild/meson/pull/7314 more specific.