### PR TITLE
Intel compiler enhancements

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -347,7 +347,6 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
     elif trial in {'ip30', 'ip35'}:
         trial = 'mips64'
 
-
     # On Linux (and maybe others) there can be any mixture of 32/64 bit code in
     # the kernel, Python, system, 32-bit chroot on 64-bit host, etc. The only
     # reliable way to know is to check the compiler defines.
@@ -443,7 +442,7 @@ def machine_info_can_run(machine_info: MachineInfo):
         (machine_info.cpu_family == true_build_cpu_family) or \
         ((true_build_cpu_family == 'x86_64') and (machine_info.cpu_family == 'x86'))
 
-def search_version(text):
+def search_version(text: str) -> str:
     # Usually of the type 4.1.4 but compiler output may contain
     # stuff like this:
     # (Sourcery CodeBench Lite 2014.05-29) 4.8.3 20140320 (prerelease)
@@ -477,6 +476,13 @@ def search_version(text):
     match = version_regex.search(text)
     if match:
         return match.group(0)
+
+    # try a simpler regex that has like "blah 2020.01.100 foo" or "blah 2020.01 foo"
+    version_regex = re.compile(r"(\d{1,4}\.\d{1,4}\.?\d{0,4})")
+    match = version_regex.search(text)
+    if match:
+        return match.group(0)
+
     return 'unknown version'
 
 class Environment:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -40,7 +40,7 @@ from contextlib import contextmanager
 from glob import glob
 from pathlib import (PurePath, Path)
 from distutils.dir_util import copy_tree
-import typing
+import typing as T
 
 import mesonbuild.mlog
 import mesonbuild.depfile
@@ -312,8 +312,14 @@ class InternalTests(unittest.TestCase):
         self.assertEqual(searchfunc('1.2.3'), '1.2.3')
         self.assertEqual(searchfunc('foobar 2016.10.28 1.2.3'), '1.2.3')
         self.assertEqual(searchfunc('2016.10.28 1.2.3'), '1.2.3')
-        self.assertEqual(searchfunc('foobar 2016.10.128'), 'unknown version')
-        self.assertEqual(searchfunc('2016.10.128'), 'unknown version')
+        self.assertEqual(searchfunc('foobar 2016.10.128'), '2016.10.128')
+        self.assertEqual(searchfunc('2016.10.128'), '2016.10.128')
+        self.assertEqual(searchfunc('2016.10'), '2016.10')
+        self.assertEqual(searchfunc('2016.10 1.2.3'), '1.2.3')
+        self.assertEqual(searchfunc('oops v1.2.3'), '1.2.3')
+        self.assertEqual(searchfunc('2016.oops 1.2.3'), '1.2.3')
+        self.assertEqual(searchfunc('2016.x'), 'unknown version')
+
 
     def test_mode_symbolic_to_bits(self):
         modefunc = mesonbuild.mesonlib.FileMode.perms_s_to_bits
@@ -7655,7 +7661,7 @@ class CrossFileTests(BasePlatformTests):
     """
 
     def _cross_file_generator(self, *, needs_exe_wrapper: bool = False,
-                              exe_wrapper: typing.Optional[typing.List[str]] = None) -> str:
+                              exe_wrapper: T.Optional[T.List[str]] = None) -> str:
         if is_windows():
             raise unittest.SkipTest('Cannot run this test on non-mingw/non-cygwin windows')
         if is_sunos():

--- a/test cases/fortran/7 generated/meson.build
+++ b/test cases/fortran/7 generated/meson.build
@@ -1,15 +1,15 @@
 # Tests whether fortran sources files created during configuration are properly
 # scanned for dependency information
 
-project('generated', 'fortran')
+project('generated', 'fortran',
+  default_options : ['default_library=static'])
 
 conf_data = configuration_data()
 conf_data.set('ONE', 1)
 conf_data.set('TWO', 2)
 conf_data.set('THREE', 3)
 
-outfile = configure_file(
-      input : 'mod3.fpp', output : 'mod3.f90', configuration : conf_data)
+configure_file(input : 'mod3.fpp', output : 'mod3.f90', configuration : conf_data)
 # Manually build absolute path to source file to test
 # https://github.com/mesonbuild/meson/issues/7265
 three = library('mod3', meson.current_build_dir() / 'mod3.f90')


### PR DESCRIPTION
* allow testcases/fortran/7generated to pass with IntelCl on Windows--CL-based Windows Fortran compilers generally are easier to use with static linking as shared linking requires special non-standard Fortran syntax just for CL. So like other such Meson Fortran project tests, we default to static linking.

* add a fallback version-finding regex, as Intel has moved to four-digit year-based versions with their new, no-cost [oneAPI compilers](https://software.intel.com/content/www/us/en/develop/tools/oneapi/hpc-toolkit.html).

Example:
```sh
ifort /logo
```
```
Intel(R) Visual Fortran Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 2021.1 Beta Build 20200306
```

```sh
icl
```
```
Intel(R) C++ Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 2021.1 Beta Build 20200306
```