### PR TITLE
ci: Remove PostgreSQL from PATH

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,6 @@ jobs:
 - job: vs2017
   pool:
     vmImage: VS2017-Win2016
-  variables:
-    CI_JOB_VS2017: 1
 
   strategy:
     matrix:

--- a/ci/run.ps1
+++ b/ci/run.ps1
@@ -4,7 +4,8 @@ if ($LastExitCode -ne 0) {
 }
 
 # remove Chocolately, MinGW, Strawberry Perl from path, so we don't find gcc/gfortran and try to use it
-$env:Path = ($env:Path.Split(';') | Where-Object { $_ -notmatch 'mingw|Strawberry|Chocolatey' }) -join ';'
+# remove PostgreSQL from path so we don't pickup a broken zlib from it
+$env:Path = ($env:Path.Split(';') | Where-Object { $_ -notmatch 'mingw|Strawberry|Chocolatey|PostgreSQL' }) -join ';'
 
 # Rust puts its shared stdlib in a secret place, but it is needed to run tests.
 $env:Path += ";$HOME/.rustup/toolchains/stable-x86_64-pc-windows-msvc/bin"

--- a/test cases/cmake/2 advanced/test.json
+++ b/test cases/cmake/2 advanced/test.json
@@ -1,9 +1,4 @@
 {
-  "matrix": {
-    "options": {
-      "_": [{"val": null, "skip_on_env": ["CI_JOB_VS2017"]}]
-    }
-  },
   "installed": [
     {"type": "expr", "file": "usr/?lib/libcm_cmModLib?so"},
     {"type": "implib", "platform": "cygwin", "file": "usr/lib/libcm_cmModLib"},

--- a/test cases/cmake/5 object library/test.json
+++ b/test cases/cmake/5 object library/test.json
@@ -1,7 +1,0 @@
-{
-  "matrix": {
-    "options": {
-      "_": [{"val": null, "skip_on_env": ["CI_JOB_VS2017"]}]
-    }
-  }
-}


### PR DESCRIPTION
It's one of the causes of the cmake test failures, and it's also plaguing the VS2019 jobs now because of the image update.