### PR TITLE
path inclusion fix for windows

### DIFF
--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -28,7 +28,7 @@ import textwrap
 from .. import mlog, mesonlib
 from ..mesonlib import PerMachine, Popen_safe, version_compare, MachineChoice
 from ..environment import Environment
-from ..envconfig import get_env_var
+from ..envconfig import get_env_path
 
 if T.TYPE_CHECKING:
     from ..dependencies.base import ExternalProgram
@@ -64,13 +64,11 @@ class CMakeExecutor:
             return
 
         self.prefix_paths = self.environment.coredata.builtins_per_machine[self.for_machine]['cmake_prefix_path'].value
-        env_pref_path = get_env_var(
+        env_pref_path = get_env_path(
             self.for_machine,
             self.environment.is_cross_build(),
             'CMAKE_PREFIX_PATH')
         if env_pref_path is not None:
-            env_pref_path = re.split(r':|;', env_pref_path)
-            env_pref_path = [x for x in env_pref_path if x]  # Filter out empty strings
             if not self.prefix_paths:
                 self.prefix_paths = []
             self.prefix_paths += env_pref_path

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -145,6 +145,24 @@ def get_env_var(for_machine: MachineChoice,
         var, value = ret
         return value
 
+def get_env_path(for_machine: MachineChoice,
+                is_cross: bool,
+                var_name: str) -> T.Tuple[T.Optional[str], T.Optional[str]]:
+    ret = get_env_var_pair(for_machine, is_cross, var_name)
+    if ret is None:
+        return None
+    else:
+        var, value = ret
+        mlog.debug(ret)
+        # Filter based on path seperator
+        if value.find(';'):
+            value = value.split(r';')
+        else:
+            value = value.split(r':')
+        # Filter out empty strings
+        value = [x for x in value if x]
+        return value
+
 class Properties:
     def __init__(
             self,


### PR DESCRIPTION
Fixes an issue with path splitting on windows. whitespace is required in some default windows paths, but it is not escaped. to properly allow the whitespace to be included in the file path, the entire -DCMAKE_PREFIX_PATH value needs to be quoted ( with `"` ). this results in the correct path being passed. 

The command also split the values of CMAKE_PREFIX_PATH based on `:`, meaning it would break the full path extension. This causes problems if you are trying to include a prefix on a non-local disk drive (aka `D:\`).

another point to highlight is how setting environment variables works in windows.

if i was to:
`SET CMAKE_PREFIX_PATH=C:\Progam files\boost;C:\Program Files\zlib`

the resulting string that would be passed to cmake inside meson would be:

-DCMAKE_PREFIX_PATH=C:\Progam Files\boost;C:\Program Files\zlib`

which would cause an error, as you have not escaped the spaces.

if i was to:
`SET CMAKE_PREFIX_PATH="C:\Progam files\boost;C:\Program Files\zlib"`

meson would internally store this as:
`env_pref_path ['"C:\Progam Files\boost', 'C:\Program Files\zlib"']`

as `env_pref_path` is appended to `prefix_paths`, this could cause a runtime error.

say for example ;- 
`prefix_paths=['C:\Program Files']`

the `env_prev_path` append would result in the following being sent to cmake internally:
`-DCMAKE_PREFIX_PATH=C:\Progam Files\;"C:\Progam Files\boost;C:\Program Files\zlib"`

this also causes a runtime error.


these changes should fix this from happening, but ideally `"` should also be stripped 
from the paths, mayhaps other special characters along with it.