### PR TITLE
Support native armel/armhf builds on arm64 hosts.

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -449,7 +449,8 @@ def machine_info_can_run(machine_info: MachineInfo):
     true_build_cpu_family = detect_cpu_family({})
     return \
         (machine_info.cpu_family == true_build_cpu_family) or \
-        ((true_build_cpu_family == 'x86_64') and (machine_info.cpu_family == 'x86'))
+        ((true_build_cpu_family == 'x86_64') and (machine_info.cpu_family == 'x86')) or \
+        ((true_build_cpu_family == 'aarch64') and (machine_info.cpu_family == 'arm'))
 
 def search_version(text: str) -> str:
     # Usually of the type 4.1.4 but compiler output may contain


### PR DESCRIPTION
arm64 (aarch64) can natively build and run code for armel and armhf architectures (analagously to amd64 and i386). This patch add support for that.

Mark