### PR TITLE
Solaris fixes

### DIFF
--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -1098,6 +1098,13 @@ class SolarisDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
             return args
         return self._apply_prefix('--whole-archive') + args + self._apply_prefix('--no-whole-archive')
 
+    def get_pie_args(self) -> T.List[str]:
+        # Available in Solaris 11.2 and later
+        return ['-z', 'type=pie']
+
+    def get_asneeded_args(self) -> T.List[str]:
+        return self._apply_prefix(['-z', 'ignore'])
+
     def no_undefined_args(self) -> T.List[str]:
         return ['-z', 'defs']
 

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -121,6 +121,13 @@ def gnu_syms(libfilename: str, outfilename: str):
         result += [' '.join(entry)]
     write_if_changed('\n'.join(result) + '\n', outfilename)
 
+def solaris_syms(libfilename: str, outfilename: str):
+    # gnu_syms() works with GNU nm & readelf, not Solaris nm & elfdump
+    origpath = os.environ['PATH']
+    os.environ['PATH'] = '/usr/gnu/bin:' + origpath
+    gnu_syms(libfilename, outfilename)
+    os.environ['PATH'] = origpath
+
 def osx_syms(libfilename: str, outfilename: str):
     # Get the name of the library
     output = call_tool('otool', ['-l', libfilename])
@@ -270,6 +277,8 @@ def gen_symbols(libfilename: str, impfilename: str, outfilename: str, cross_host
             # No import library. Not sure how the DLL is being used, so just
             # rebuild everything that links to it every time.
             dummy_syms(outfilename)
+    elif mesonlib.is_sunos():
+        solaris_syms(libfilename, outfilename)
     else:
         if not os.path.exists(TOOL_WARNING_FILE):
             mlog.warning('Symbol extracting has not been implemented for this '

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6772,6 +6772,11 @@ class LinuxlikeTests(BasePlatformTests):
         testdir = os.path.join(self.unit_test_dir, '52 ldflagdedup')
         if is_cygwin() or is_osx():
             raise unittest.SkipTest('Not applicable on Cygwin or OSX.')
+        env = get_fake_env()
+        cc = env.detect_c_compiler(MachineChoice.HOST)
+        linker = cc.linker
+        if not linker.export_dynamic_args(env):
+            raise unittest.SkipTest('Not applicable for linkers without --export-dynamic')
         self.init(testdir)
         build_ninja = os.path.join(self.builddir, 'build.ninja')
         max_count = 0

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2582,6 +2582,8 @@ class AllPlatformTests(BasePlatformTests):
                 self.assertIsInstance(linker, ar)
                 if is_osx():
                     self.assertIsInstance(cc.linker, mesonbuild.linkers.AppleDynamicLinker)
+                elif is_sunos():
+                    self.assertIsInstance(cc.linker, (mesonbuild.linkers.SolarisDynamicLinker, mesonbuild.linkers.GnuLikeDynamicLinkerMixin))
                 else:
                     self.assertIsInstance(cc.linker, mesonbuild.linkers.GnuLikeDynamicLinkerMixin)
             if isinstance(cc, clangcl):

--- a/test cases/common/125 object only target/obj_generator.py
+++ b/test cases/common/125 object only target/obj_generator.py
@@ -13,6 +13,8 @@ if __name__ == '__main__':
     ofile = sys.argv[3]
     if compiler.endswith('cl'):
         cmd = [compiler, '/nologo', '/MDd', '/Fo' + ofile, '/c', ifile]
+    elif sys.platform == 'sunos5':
+        cmd = [compiler, '-fpic', '-c', ifile, '-o', ofile]
     else:
         cmd = [compiler, '-c', ifile, '-o', ofile]
     sys.exit(subprocess.call(cmd))

--- a/test cases/linuxlike/3 linker script/meson.build
+++ b/test cases/linuxlike/3 linker script/meson.build
@@ -1,5 +1,11 @@
 project('linker script', 'c')
 
+# Solaris 11.4 ld supports --version-script only when you also specify
+# -z gnu-version-script-compat
+if meson.get_compiler('c').get_linker_id() == 'ld.solaris'
+  add_project_link_arguments('-Wl,-z,gnu-version-script-compat', language: 'C')
+endif
+
 # Static map file
 mapfile = 'bob.map'
 vflag = '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfile)

--- a/test cases/unit/61 identity cross/build_wrapper.py
+++ b/test cases/unit/61 identity cross/build_wrapper.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
-import subprocess, sys
+import subprocess, sys, platform
 
-subprocess.call(["cc", "-DEXTERNAL_BUILD"] + sys.argv[1:])
+# Meson does not yet support Studio cc on Solaris, only gcc or clang
+if platform.system() == 'SunOS':
+    cc = 'gcc'
+else:
+    cc = 'cc'
+
+subprocess.call([cc, "-DEXTERNAL_BUILD"] + sys.argv[1:])

--- a/test cases/unit/61 identity cross/host_wrapper.py
+++ b/test cases/unit/61 identity cross/host_wrapper.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
 
-import subprocess, sys
+import subprocess, sys, platform
 
-subprocess.call(["cc", "-DEXTERNAL_HOST"] + sys.argv[1:])
+# Meson does not yet support Studio cc on Solaris, only gcc or clang
+if platform.system() == 'SunOS':
+    cc = 'gcc'
+else:
+    cc = 'cc'
+
+subprocess.call([cc, "-DEXTERNAL_HOST"] + sys.argv[1:])


### PR DESCRIPTION
The primary changes are adding Solaris support to symbolextractor (by using the GNU binutils and wrapping the GNU version), and adding asneeded & pie support to the Solaris linker mixin.

The rest are fixing up various test cases to run correctly on Solaris.