### PR TITLE
ci: Bump the cygwin timeout to 120 minutes, workaround MSYS2 breakage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,6 +64,7 @@ jobs:
   - template: ci/azure-steps.yml
 
 - job: cygwin
+  timeoutInMinutes: 120
   pool:
     vmImage: VS2017-Win2016
   strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -161,7 +161,13 @@ jobs:
       displayName: Install MSYS2
     - script: |
         set PATH=%MSYS2_ROOT%\usr\bin;%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem
-        %MSYS2_ROOT%\usr\bin\pacman --noconfirm -Syyuu
+        # Remove this line when https://github.com/msys2/MSYS2-packages/pull/2022 is merged
+        %MSYS2_ROOT%\usr\bin\pacman --noconfirm -Sy dash
+        echo Updating msys2
+        %MSYS2_ROOT%\usr\bin\pacman --noconfirm -Syuu || echo system update failed, ignoring
+        echo Killing all msys2 processes
+        taskkill /F /FI "MODULES eq msys-2.0.dll"
+        echo Updating msys2 (again)
         %MSYS2_ROOT%\usr\bin\pacman --noconfirm -Syuu
       displayName: Update MSYS2
     - script: |


### PR DESCRIPTION
The default timeout is 60 min and we're timing out, but the maximum we can have is 6 hours. Bump it to 120 min for now.

Also workaround MSYS2 update breakage