### PR TITLE
Don't make unactionable warnings fatal

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -862,8 +862,8 @@ class CoreData:
 
     def emit_base_options_warnings(self, enabled_opts: list):
         if 'b_bitcode' in enabled_opts:
-            mlog.warning('Base option \'b_bitcode\' is enabled, which is incompatible with many linker options. Incompatible options such as \'b_asneeded\' have been disabled.')
-            mlog.warning('Please see https://mesonbuild.com/Builtin-options.html#Notes_about_Apple_Bitcode_support for more details.')
+            mlog.warning('Base option \'b_bitcode\' is enabled, which is incompatible with many linker options. Incompatible options such as \'b_asneeded\' have been disabled.', fatal=False)
+            mlog.warning('Please see https://mesonbuild.com/Builtin-options.html#Notes_about_Apple_Bitcode_support for more details.', fatal=False)
 
 class CmdLineFileParser(configparser.ConfigParser):
     def __init__(self):

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -250,7 +250,7 @@ def get_error_location_string(fname: str, lineno: str) -> str:
     return '{}:{}:'.format(fname, lineno)
 
 def _log_error(severity: str, *rargs: T.Union[str, AnsiDecorator],
-               once: bool = False, **kwargs: T.Any) -> None:
+               once: bool = False, fatal: bool = True, **kwargs: T.Any) -> None:
     from .mesonlib import MesonException, relpath
 
     # The typing requirements here are non-obvious. Lists are invariant,
@@ -283,7 +283,7 @@ def _log_error(severity: str, *rargs: T.Union[str, AnsiDecorator],
     global log_warnings_counter
     log_warnings_counter += 1
 
-    if log_fatal_warnings:
+    if log_fatal_warnings and fatal:
         raise MesonException("Fatal warnings enabled, aborting")
 
 def error(*args: T.Union[str, AnsiDecorator], **kwargs: T.Any) -> None:

--- a/mesonbuild/modules/qt4.py
+++ b/mesonbuild/modules/qt4.py
@@ -24,5 +24,5 @@ class Qt4Module(QtBaseModule):
 
 def initialize(*args, **kwargs):
     mlog.warning('rcc dependencies will not work properly until this upstream issue is fixed:',
-                 mlog.bold('https://bugreports.qt.io/browse/QTBUG-45460'))
+                 mlog.bold('https://bugreports.qt.io/browse/QTBUG-45460'), fatal=False)
     return Qt4Module(*args, **kwargs)

--- a/mesonbuild/modules/qt5.py
+++ b/mesonbuild/modules/qt5.py
@@ -24,5 +24,5 @@ class Qt5Module(QtBaseModule):
 
 def initialize(*args, **kwargs):
     mlog.warning('rcc dependencies will not work reliably until this upstream issue is fixed:',
-                 mlog.bold('https://bugreports.qt.io/browse/QTBUG-45460'))
+                 mlog.bold('https://bugreports.qt.io/browse/QTBUG-45460'), fatal=False)
     return Qt5Module(*args, **kwargs)

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -107,7 +107,7 @@ class WindowsModule(ExtensionModule):
                 'a MinGW bug: https://sourceware.org/bugzilla/show_bug.cgi?id=4933'
             for arg in extra_args:
                 if ' ' in arg:
-                    mlog.warning(m.format(arg))
+                    mlog.warning(m.format(arg), fatal=False)
 
         res_targets = []
 


### PR DESCRIPTION
Some warnings are out of the user's control, such as the RCC QT bug, or the GNU windres bug, or our informational warning about auto-disabling of options when -Db_bitcode is enabled.

Such warnings should not be fatal when --fatal-meson-warnings is passed because there's no action that the user can take to fix it. The only purpose it serves is to prevent people who use those features from using --fatal-meson-warnings.