### PR TITLE
environment: Correctly detect arm64 as aarch64

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -341,6 +341,8 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
         trial = 'x86'
     elif trial == 'bepc':
         trial = 'x86'
+    elif trial == 'arm64':
+        trial = 'aarch64'
     elif trial.startswith('arm') or trial.startswith('earm'):
         trial = 'arm'
     elif trial.startswith(('powerpc64', 'ppc64')):


### PR DESCRIPTION
On some systems aarch64 is reported as arm64. Due to mesons
mangling of everything that starts with arm, it would end up being
detected as arm (which implies 32 bit) which is incorrect.