### PR TITLE
find_program: Do not use fallback when before parsing project()

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -643,6 +643,7 @@ class Environment:
         self.clang_static_linker = ['llvm-ar']
         self.default_cmake = ['cmake']
         self.default_pkgconfig = ['pkg-config']
+        self.wrap_resolver = None
 
     def create_new_coredata(self, options):
         # WARNING: Don't use any values from coredata in __init__. It gets

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3360,7 +3360,7 @@ external dependencies (including libraries) must go to "dependencies".''')
 
         fallback = None
         wrap_mode = self.coredata.get_builtin_option('wrap_mode')
-        if wrap_mode != WrapMode.nofallback:
+        if wrap_mode != WrapMode.nofallback and self.environment.wrap_resolver:
             fallback = self.environment.wrap_resolver.find_program_provider(args)
         if fallback and wrap_mode == WrapMode.forcefallback:
             return self.find_program_fallback(fallback, args, required, extra_info)


### PR DESCRIPTION
Mesa is doing `project(... find_program() ...)` so
environment.wrap_resolver is not defined yet.