### PR TITLE
wrap: Add back filename member in PackageDefinition

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -103,6 +103,7 @@ class WrapNotFoundException(WrapException):
 
 class PackageDefinition:
     def __init__(self, fname: str):
+        self.filename = fname
         self.type = None
         self.values = {} # type: T.Dict[str, str]
         self.provided_deps = {} # type: T.Dict[str, T.Optional[str]]


### PR DESCRIPTION
It is still used by msubprojects.py and cause issues when updating
wrapdb.