### PR TITLE
ninjabackend: fix no attribute 'compilers'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,7 +174,7 @@ jobs:
       displayName: Update MSYS2
     - script: |
         set PATH=%MSYS2_ROOT%\usr\bin;%SystemRoot%\system32;%SystemRoot%;%SystemRoot%\System32\Wbem
-        if %compiler%==gcc ( set "TOOLCHAIN=mingw-w64-$(MSYS2_ARCH)-toolchain" ) else ( set "TOOLCHAIN=mingw-w64-$(MSYS2_ARCH)-clang" )
+        if %compiler%==gcc ( set "TOOLCHAIN=mingw-w64-$(MSYS2_ARCH)-toolchain" ) else ( set "TOOLCHAIN=mingw-w64-$(MSYS2_ARCH)-clang mingw-w64-$(MSYS2_ARCH)-compiler-rt" )
         %MSYS2_ROOT%\usr\bin\pacman --noconfirm --needed -S ^
         base-devel ^
         git ^

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -972,6 +972,8 @@ int dummy;
         targets = self.build.get_targets().values()
         use_llvm_cov = False
         for target in targets:
+            if not hasattr(target, 'compilers'):
+                continue
             for compiler in target.compilers.values():
                 if compiler.get_id() == 'clang' and not compiler.info.is_darwin():
                     use_llvm_cov = True

--- a/test cases/common/154 reserved targets/meson.build
+++ b/test cases/common/154 reserved targets/meson.build
@@ -1,6 +1,5 @@
-project('reserved target names', 'c')
-        # FIXME: Setting this causes it to leak to all other tests
-        #default_options : ['b_coverage=true']
+project('reserved target names', 'c',
+        default_options : ['b_coverage=true'])
 
 subdir('all')
 subdir('benchmark')


### PR DESCRIPTION
When meson.build configure with run_target() there will be an error
mesonbuild/backend/ninjabackend.py", line 977, in generate_coverage_command
    for compiler in target.compilers.values():
AttributeError: 'RunTarget' object has no attribute 'compilers'

Add the check attribute for avoiding unexpected failure.