### PR TITLE
Fix native builds on Windows ARM64 machines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ variables:
 jobs:
 
 - job: vs2017
+  timeoutInMinutes: 120
   pool:
     vmImage: VS2017-Win2016
 
@@ -41,6 +42,7 @@ jobs:
   - template: ci/azure-steps.yml
 
 - job: vs2019
+  timeoutInMinutes: 120
   pool:
     vmImage: windows-2019
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -854,9 +854,6 @@ class Compiler(metaclass=abc.ABCMeta):
     def bitcode_args(self) -> T.List[str]:
         return self.linker.bitcode_args()
 
-    def get_linker_debug_crt_args(self) -> T.List[str]:
-        return self.linker.get_debug_crt_args()
-
     def get_buildtype_linker_args(self, buildtype: str) -> T.List[str]:
         return self.linker.get_buildtype_args(buildtype)
 

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -263,9 +263,6 @@ class CudaCompiler(Compiler):
     def get_depfile_suffix(self):
         return 'd'
 
-    def get_linker_debug_crt_args(self) -> T.List[str]:
-        return self._cook_link_args(self.host_compiler.get_linker_debug_crt_args())
-
     def get_buildtype_linker_args(self, buildtype):
         return self._cook_link_args(self.host_compiler.get_buildtype_linker_args(buildtype))
 

--- a/mesonbuild/compilers/mixins/islinker.py
+++ b/mesonbuild/compilers/mixins/islinker.py
@@ -110,9 +110,6 @@ class BasicLinkerIsCompilerMixin:
                          install_rpath: str) -> T.Tuple[T.List[str], T.Set[bytes]]:
         return ([], set())
 
-    def get_linker_debug_crt_args(self) -> T.List[str]:
-        return []
-
     def get_asneeded_args(self) -> T.List[str]:
         return []
 

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -451,9 +451,6 @@ class DynamicLinker(LinkerEnvVarsMixin, metaclass=abc.ABCMeta):
     def bitcode_args(self) -> T.List[str]:
         raise mesonlib.MesonException('This linker does not support bitcode bundles')
 
-    def get_debug_crt_args(self) -> T.List[str]:
-        return []
-
     def build_rpath_args(self, env: 'Environment', build_dir: str, from_dir: str,
                          rpath_paths: str, build_rpath: str,
                          install_rpath: str) -> T.Tuple[T.List[str], T.Set[bytes]]:
@@ -997,16 +994,6 @@ class VisualStudioLikeLinkerMixin:
 
     def invoked_by_compiler(self) -> bool:
         return not self.direct
-
-    def get_debug_crt_args(self) -> T.List[str]:
-        """Arguments needed to select a debug crt for the linker.
-
-        Sometimes we need to manually select the CRT (C runtime) to use with
-        MSVC. One example is when trying to link with static libraries since
-        MSVC won't auto-select a CRT for us in that case and will error out
-        asking us to select one.
-        """
-        return self._apply_prefix('/MDd')
 
     def get_output_args(self, outputname: str) -> T.List[str]:
         return self._apply_prefix(['/MACHINE:' + self.machine, '/OUT:' + outputname])


### PR DESCRIPTION
I made the mistake of always selecting the debug CRT for compiler checks on Windows 4 years ago: https://github.com/mesonbuild/meson/pull/543 https://github.com/mesonbuild/meson/pull/614

The idea was to always build the tests with debugging enabled so that the compiler doesn't optimize the tests away. But we stopped doing that a while ago, and also the debug CRT has no relation to that.

We should select the CRT in the same way that we do for building targets: based on the options.

On Windows ARM64, the debug CRT for ARM64 isn't always available, and the release CRT is available only after installing the runtime package. Without this, we will always try to pick the debug CRT even when --buildtype=debugoptimized or release.