### PR TITLE
ci: Try to fix Ubuntu 16.04 GitHub actions failure

### DIFF
--- a/test cases/java/3 args/meson.build
+++ b/test cases/java/3 args/meson.build
@@ -1,9 +1,9 @@
 project('simplejava', 'java')
 
-add_project_arguments('-target', '1.8', language : 'java')
+add_project_arguments('-target', '1.7', language : 'java')
 
 javaprog = jar('myprog', 'com/mesonbuild/Simple.java',
   main_class : 'com.mesonbuild.Simple',
-  java_args : ['-source', '1.8'])
+  java_args : ['-source', '1.7'])
 test('mytest', javaprog)
 


### PR DESCRIPTION
The Ubuntu 16.04 Github actions image now ships with javac 1.7.0. From the build log:

```
java   : [unknown]  javac (unknown 1.7.0)

...

javac -g -target 1.8 -source 1.8 <...>
javac: invalid target release: 1.8
Usage: javac <options> <source files>
use -help for a list of possible options
ninja: build stopped: subcommand failed.
```