### PR TITLE
Python test upgrade

### DIFF
--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -361,11 +361,10 @@ def _run_ci_include(args: T.List[str]) -> str:
     if not args:
         return 'At least one parameter required'
     try:
-        file_path = Path(args[0])
-        data = file_path.open(errors='ignore', encoding='utf-8').read()
+        data = Path(args[0]).read_text(errors='ignore', encoding='utf-8')
         return 'Included file {}:\n{}\n'.format(args[0], data)
     except Exception:
-        return 'Failed to open {} ({})'.format(args[0])
+        return 'Failed to open {}'.format(args[0])
 
 ci_commands = {
     'ci_include': _run_ci_include

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -939,7 +939,7 @@ def detect_tests_to_run(only: T.List[str], use_tmp: bool) -> T.List[T.Tuple[str,
         # CUDA tests on Windows: use Ninja backend:  python run_project_tests.py --only cuda --backend ninja
         TestCategory('cuda', 'cuda', backend not in (Backend.ninja, Backend.xcode) or not shutil.which('nvcc')),
         TestCategory('python3', 'python3', backend is not Backend.ninja),
-        TestCategory('python', 'python', backend is not Backend.ninja),
+        TestCategory('python', 'python'),
         TestCategory('fpga', 'fpga', shutil.which('yosys') is None),
         TestCategory('frameworks', 'frameworks'),
         TestCategory('nasm', 'nasm'),

--- a/test cases/python/1 basic/meson.build
+++ b/test cases/python/1 basic/meson.build
@@ -1,4 +1,4 @@
-project('python sample', 'c')
+project('python sample')
 
 py_mod = import('python')
 py = py_mod.find_installation('python3')
@@ -12,6 +12,7 @@ py_purelib = py.get_path('purelib')
 if not py_purelib.endswith('site-packages')
   error('Python3 purelib path seems invalid? ' + py_purelib)
 endif
+message('Python purelib path:', py_purelib)
 
 # could be 'lib64' or 'Lib' on some systems
 py_platlib = py.get_path('platlib')

--- a/test cases/python/1 basic/prog.py
+++ b/test cases/python/1 basic/prog.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 
 from gluon import gluonator
-import sys
 
 print('Running mainprog from root dir.')
 
 if gluonator.gluoninate() != 42:
-    sys.exit(1)
+    raise ValueError("!= 42")

--- a/test cases/python/1 basic/subdir/subprog.py
+++ b/test cases/python/1 basic/subdir/subprog.py
@@ -4,9 +4,8 @@
 # point to source root.
 
 from gluon import gluonator
-import sys
 
 print('Running mainprog from subdir.')
 
 if gluonator.gluoninate() != 42:
-    sys.exit(1)
+    raise ValueError("!= 42")

--- a/test cases/python/2 extmodule/blaster.py
+++ b/test cases/python/2 extmodule/blaster.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python3
 
 import tachyon
-import sys
 
 result = tachyon.phaserize('shoot')
 
 if not isinstance(result, int):
-    print('Returned result not an integer.')
-    sys.exit(1)
+    raise SystemExit('Returned result not an integer.')
 
 if result != 1:
-    print('Returned result {} is not 1.'.format(result))
-    sys.exit(1)
+    raise SystemExit('Returned result {} is not 1.'.format(result))

--- a/test cases/python/2 extmodule/meson.build
+++ b/test cases/python/2 extmodule/meson.build
@@ -3,6 +3,10 @@ project('Python extension module', 'c',
 # Because Windows Python ships only with optimized libs,
 # we must build this project the same way.
 
+if meson.backend() != 'ninja'
+  error('MESON_SKIP_TEST: Ninja backend required')
+endif
+
 py_mod = import('python')
 py = py_mod.find_installation()
 py_dep = py.dependency()

--- a/test cases/python/2 extmodule/meson.build
+++ b/test cases/python/2 extmodule/meson.build
@@ -7,26 +7,29 @@ if meson.backend() != 'ninja'
   error('MESON_SKIP_TEST: Ninja backend required')
 endif
 
+
 py_mod = import('python')
 py = py_mod.find_installation()
-py_dep = py.dependency()
+py_dep = py.dependency(required: false)
 
-if py_dep.found()
-  subdir('ext')
-
-  test('extmod',
-    py,
-    args : files('blaster.py'),
-    env : ['PYTHONPATH=' + pypathdir])
-
-  # Check we can apply a version constraint
-  dependency('python3', version: '>=@0@'.format(py_dep.version()))
-
-else
-  error('MESON_SKIP_TEST: Python3 libraries not found, skipping test.')
+if not py_dep.found()
+  error('MESON_SKIP_TEST: Python libraries not found.')
 endif
+
+subdir('ext')
+
+test('extmod',
+  py,
+  args : files('blaster.py'),
+  env : ['PYTHONPATH=' + pypathdir])
+
 
 py3_pkg_dep = dependency('python3', method: 'pkg-config', required : false)
 if py3_pkg_dep.found()
   python_lib_dir = py3_pkg_dep.get_pkgconfig_variable('libdir')
+
+  # Check we can apply a version constraint
+  dependency('python3', version: '>=@0@'.format(py_dep.version()))
+else
+  message('Skipped python3 pkg-config test')
 endif

--- a/test cases/python/3 cython/cytest.py
+++ b/test cases/python/3 cython/cytest.py
@@ -1,23 +1,19 @@
 #!/usr/bin/env python3
 
 from storer import Storer
-import sys
 
 s = Storer()
 
 if s.get_value() != 0:
-    print('Initial value incorrect.')
-    sys.exit(1)
+    raise SystemExit('Initial value incorrect.')
 
 s.set_value(42)
 
 if s.get_value() != 42:
-    print('Setting value failed.')
-    sys.exit(1)
+    raise SystemExit('Setting value failed.')
 
 try:
     s.set_value('not a number')
-    print('Using wrong argument type did not fail.')
-    sys.exit(1)
+    raise SystemExit('Using wrong argument type did not fail.')
 except TypeError:
     pass

--- a/test cases/python/3 cython/meson.build
+++ b/test cases/python/3 cython/meson.build
@@ -1,20 +1,27 @@
 project('cython', 'c',
   default_options : ['warning_level=3'])
 
-cython = find_program('cython3', required : false)
-py3_dep = dependency('python3', required : false)
-
-if cython.found() and py3_dep.found()
-  py_mod = import('python')
-  py3 = py_mod.find_installation()
-  py3_dep = py3.dependency()
-  subdir('libdir')
-
-  test('cython tester',
-    py3,
-    args : files('cytest.py'),
-    env : ['PYTHONPATH=' + pydir]
-  )
-else
-  error('MESON_SKIP_TEST: Cython3 or Python3 libraries not found, skipping test.')
+if meson.backend() != 'ninja'
+  error('MESON_SKIP_TEST: Ninja backend required')
 endif
+
+cython = find_program('cython', required : false)
+if not cython.found()
+  error('MESON_SKIP_TEST: Cython3 not found.')
+endif
+
+py3_dep = dependency('python3', required : false)
+if not py3_dep.found()
+  error('MESON_SKIP_TEST: Python library not found.')
+endif
+
+py_mod = import('python')
+py3 = py_mod.find_installation()
+py3_dep = py3.dependency()
+subdir('libdir')
+
+test('cython tester',
+  py3,
+  args : files('cytest.py'),
+  env : ['PYTHONPATH=' + pydir]
+)

--- a/test cases/python/3 cython/meson.build
+++ b/test cases/python/3 cython/meson.build
@@ -10,14 +10,13 @@ if not cython.found()
   error('MESON_SKIP_TEST: Cython3 not found.')
 endif
 
-py3_dep = dependency('python3', required : false)
+py_mod = import('python')
+py3 = py_mod.find_installation()
+py3_dep = py3.dependency(required: false)
 if not py3_dep.found()
   error('MESON_SKIP_TEST: Python library not found.')
 endif
 
-py_mod = import('python')
-py3 = py_mod.find_installation()
-py3_dep = py3.dependency()
 subdir('libdir')
 
 test('cython tester',

--- a/test cases/python/4 custom target depends extmodule/blaster.py
+++ b/test cases/python/4 custom target depends extmodule/blaster.py
@@ -24,9 +24,7 @@ if options.output:
         f.write('success')
 
 if not isinstance(result, int):
-    print('Returned result not an integer.')
-    sys.exit(1)
+    raise SystemExit('Returned result not an integer.')
 
 if result != 1:
-    print('Returned result {} is not 1.'.format(result))
-    sys.exit(1)
+    raise SystemExit('Returned result {} is not 1.'.format(result))

--- a/test cases/python/4 custom target depends extmodule/meson.build
+++ b/test cases/python/4 custom target depends extmodule/meson.build
@@ -3,6 +3,10 @@ project('Python extension module', 'c',
 # Because Windows Python ships only with optimized libs,
 # we must build this project the same way.
 
+if meson.backend() != 'ninja'
+  error('MESON_SKIP_TEST: Ninja backend required')
+endif
+
 py_mod = import('python')
 py3 = py_mod.find_installation()
 py3_dep = py3.dependency(required : false)

--- a/test cases/python/4 custom target depends extmodule/meson.build
+++ b/test cases/python/4 custom target depends extmodule/meson.build
@@ -12,6 +12,10 @@ py3 = py_mod.find_installation()
 py3_dep = py3.dependency(required : false)
 cc = meson.get_compiler('c')
 
+if not py3_dep.found()
+  error('MESON_SKIP_TEST: Python3 libraries not found, skipping test.')
+endif
+
 # Copy to the builddir so that blaster.py can find the built tachyon module
 # FIXME: We should automatically detect this case and append the correct paths
 # to PYTHONLIBDIR
@@ -24,21 +28,18 @@ import os, sys
 with open(sys.argv[1], 'rb') as f:
   assert(f.read() == b'success')
 '''
-if py3_dep.found()
-  message('Detected Python version: ' + py3_dep.version())
-  if py3_dep.version().version_compare('>=3.8') and cc.get_id() == 'msvc' and cc.version().version_compare('<=19.00.24215.1')
-    error('MESON_SKIP_TEST: Python modules do not work with Python 3.8 and VS2015 or earlier.')
-  endif
-  subdir('ext')
 
-  out_txt = custom_target('tachyon flux',
-    input : blaster_py,
-    output : 'out.txt',
-    command : [py3, '@INPUT@', '-o', '@OUTPUT@'],
-    depends : pylib,
-    build_by_default: true)
-
-  test('flux', py3, args : ['-c', check_exists, out_txt])
-else
-  error('MESON_SKIP_TEST: Python3 libraries not found, skipping test.')
+message('Detected Python version: ' + py3_dep.version())
+if py3_dep.version().version_compare('>=3.8') and cc.get_id() == 'msvc' and cc.version().version_compare('<=19.00.24215.1')
+  error('MESON_SKIP_TEST: Python modules do not work with Python 3.8 and VS2015 or earlier.')
 endif
+subdir('ext')
+
+out_txt = custom_target('tachyon flux',
+  input : blaster_py,
+  output : 'out.txt',
+  command : [py3, '@INPUT@', '-o', '@OUTPUT@'],
+  depends : pylib,
+  build_by_default: true)
+
+test('flux', py3, args : ['-c', check_exists, out_txt])

--- a/test cases/python/5 modules kwarg/meson.build
+++ b/test cases/python/5 modules kwarg/meson.build
@@ -1,7 +1,7 @@
 project('python kwarg')
 
 py = import('python')
-prog_python = py.find_installation('python3', modules : ['setuptools'])
+prog_python = py.find_installation('python3', modules : ['distutils'])
 assert(prog_python.found() == true, 'python not found when should be')
 prog_python = py.find_installation('python3', modules : ['thisbetternotexistmod'], required : false)
 assert(prog_python.found() == false, 'python not found but reported as found')


### PR DESCRIPTION
The "test cases/python" tests were skipping all tests on MSVC.
Now with MSVC and Windows Store Python

```
Succeeded test (without install): test cases/python/1 basic
Skipping: test cases/python/2 extmodule
Skipping: test cases/python/3 cython
Skipping: test cases/python/4 custom target depends extmodule
Succeeded test (without install): test cases/python/5 modules kwarg
```

This is relevant for finding errors with MSVC, particularly for Windows Store Python as in #7400.

Also, tests 2 and 4 were failing with Anaconda Python on Ubuntu 20.04. Now, all 5 tests succeed for this setup.

Long, nested if statements were simplified for clarity.

Setuptools is not always present, but distutils is part of Python stdlib.

As usual, this can be quickly tested by:

```sh
python run_project_tests.py --only python
```