### PR TITLE
Check for "compilers" attribute in generate_coverage_command

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -972,6 +972,8 @@ int dummy;
         targets = self.build.get_targets().values()
         use_llvm_cov = False
         for target in targets:
+            if not hasattr(target, "compilers"):
+                break
             for compiler in target.compilers.values():
                 if compiler.get_id() == 'clang' and not compiler.info.is_darwin():
                     use_llvm_cov = True


### PR DESCRIPTION
When building a meson project with Clang, if there is a "run_target" specified in the meson.build file it will enumerate as a target without a compiler when generate_coverage_command runs. Without this tweak, Meson will crash because it can't find the compiler of the run_target target.