### PR TITLE
Replace `dynamic linker` with `linker`

### DIFF
--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -25,7 +25,7 @@ for the host platform in cross builds can only be specified with a cross file.
 There is a table of all environment variables supported [Here](Reference-tables.md#compiler-and-linker-selection-variables)
 
 
-## Set dynamic linker
+## Set linker
 
 *New in 0.53.0*
 


### PR DESCRIPTION
This header erroneously referred to the dynamic linker while the paragraph talks about
the "link editor." Change the title to account for the difference.