### PR TITLE
qt module: add qresource support to compile_translations

### DIFF
--- a/docs/markdown/Qt5-module.md
+++ b/docs/markdown/Qt5-module.md
@@ -22,6 +22,12 @@ This method generates the necessary targets to build translation files with lrel
  - `install` when true, this target is installed during the install step (optional).
  - `install_dir` directory to install to (optional).
  - `build_by_default` when set to true, to have this target be built by default, that is, when invoking `meson compile`; the default value is false (optional).
+ - `qresource` rcc source file to extract ts_files from; cannot be used with ts_files kwarg. Available since v0.56.0.
+ - `rcc_extra_arguments`, any additional arguments to `rcc` (optional), when used with `qresource. Available since v0.56.0.
+
+Returns either: a list of custom targets for the compiled translations, or, if
+using a `qresource` file, a single custom target containing the processed
+source file, which should be passed to a main build target.
 
 ## has_tools
 
@@ -70,4 +76,15 @@ translations = qt5.compile_translations(ts_files : 'myTranslation_fr.ts', build_
 executable('myprog', 'main.cpp', 'myclass.cpp', moc_files,
            include_directories: inc,
            dependencies : qt5_dep)
+```
+
+Sometimes, translations are embedded inside the binary using qresource files.
+In this case the ts files do not need to be explicitly listed. For example:
+
+```meson
+qt5 = import('qt5')
+qt5_dep = dependency('qt5', modules: ['Core', 'Gui'])
+lang_cpp = qt5.compile_translations(qresource: 'lang.qrc')
+executable('myprog', 'main.cpp', lang_cpp,
+           dependencies: qt5_dep)
 ```

--- a/docs/markdown/snippets/qt_compile_translations_from_qrc.md
+++ b/docs/markdown/snippets/qt_compile_translations_from_qrc.md
@@ -1,0 +1,19 @@
+## Qt5 compile_translations now supports qresource preprocessing
+
+When using qtmod.preprocess() in combination with qtmod.compile_translations()
+to embed translations using rcc, it is no longer required to do this:
+
+```meson
+ts_files = ['list', 'of', 'files']
+qtmod.compile_translations(ts_files)
+# lang.qrc also contains the duplicated list of files
+lang_cpp = qtmod.preprocess(qresources: 'lang.qrc')
+```
+
+Instead, use:
+```meson
+lang_cpp = qtmod.compile_translations(qresource: 'lang.qrc')
+```
+
+which will automatically detect and generate the needed compile_translations
+targets.


### PR DESCRIPTION
A common pattern in Qt5 applications is to embed translations in the executable using the qresource system. In this case, the list of translation files is already available in the .qrc file and there's no good reason to duplicate this info in meson.build.

Let compile_translations optionally take a qrc input, in which case it will go straight to generating the relevant translations and rcc-generated .cpp, and directly return the thing users actually care about -- the .cpp for linking.