### PR TITLE
common/234: avoid intermittent failure by dynamic path length generation

### DIFF
--- a/test cases/common/234 very long commmand line/codegen.py
+++ b/test cases/common/234 very long commmand line/codegen.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+from pathlib import Path
 
-with open(sys.argv[2], 'w') as f:
-    print('int func{n}(void) {{ return {n}; }}'.format(n=sys.argv[1]), file=f)
+Path(sys.argv[2]).write_text(
+    'int func{n}(void) {{ return {n}; }}'.format(n=sys.argv[1]))

--- a/test cases/common/234 very long commmand line/main.c
+++ b/test cases/common/234 very long commmand line/main.c
@@ -1,5 +1,1 @@
-int main(int argc, char **argv) {
-  (void) argc;
-  (void) argv;
-  return 0;
-}
+int main(void) { return 0; }

--- a/test cases/common/234 very long commmand line/meson.build
+++ b/test cases/common/234 very long commmand line/meson.build
@@ -6,6 +6,10 @@ if build_machine.system() == 'windows'
   # cmd.exe: 8kb
   # CreateProcess: 32kb
   limit = 32767
+  # NOTE: filename limit is 260 characters unless
+  # 1. Python >= 3.6 is being used
+  # 2. Windows 10 registry has been edited to enable long pathnaems
+  # ninja backend uses absolute filenames, so we ensure they don't exceed 260.
 elif build_machine.system() == 'cygwin'
   # cygwin-to-win32: see above
   # cygwin-to-cygwin: no limit?
@@ -18,20 +22,21 @@ else
   limit = 131072
 endif
 # Now exceed that limit, but not so far that the test takes too long.
-name = 'ALongFilenameMuchLongerThanIsNormallySeenAndReallyHardToReadThroughToTheEndAMooseOnceBitMySisterSheNowWorksAtLLamaFreshFarmsThisHasToBeSoLongThatWeExceed128KBWithoutCompilingTooManyFiles'
-namelen = 187
+namelen = 260
 nfiles = 50 + limit / namelen
 message('Expected link commandline length is approximately ' + '@0@'.format((nfiles * (namelen+28))))
 
-seq = run_command('seq.py', '1', '@0@'.format(nfiles)).stdout().strip().split('\n')
+seq = run_command('name_gen.py', nfiles.to_string(), meson.build_root()).stdout().strip().split('\n')
 
 sources = []
 codegen = find_program('codegen.py')
 
-foreach i : seq
-  sources += custom_target('codegen' + i,
-                           command: [codegen, i, '@OUTPUT@'],
-                           output: name + i + '.c')
+i=0
+foreach name : seq
+  sources += custom_target('codegen' + i.to_string(),
+                           command: [codegen, i.to_string(), '@OUTPUT@'],
+                           output: name + '.c')
+  i+=1
 endforeach
 
 shared_library('sharedlib', sources)

--- a/test cases/common/234 very long commmand line/name_gen.py
+++ b/test cases/common/234 very long commmand line/name_gen.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""
+generate sequence of filename that does not exceed MAX_LEN=260
+for Python < 3.6 and Windows without modified registry
+"""
+
+import sys
+import string
+
+name_len = 260 - len(sys.argv[2]) - 4 - 39 - 4 - 2
+if name_len < 1:
+    raise ValueError('The meson build directory pathname is so long '
+                     'that we cannot generate filenames within 260 characters.')
+# leave room for suffix and file separators, and meson generated text
+# e.g. ".c.obj.d" and other decorators added by Meson at configuration
+# for intermediate files
+
+base = string.ascii_letters * 5  # 260 characters
+max_num_len = len(str(sys.argv[1]))
+base = base[: name_len - max_num_len]
+
+for i in range(int(sys.argv[1])):
+    print("{base}{i:0{max_num_len}d}".format(base=base, max_num_len=max_num_len, i=i))

--- a/test cases/common/234 very long commmand line/seq.py
+++ b/test cases/common/234 very long commmand line/seq.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python3
-
-import sys
-
-for i in range(int(sys.argv[1]), int(sys.argv[2])):
-    print(i)


### PR DESCRIPTION
This is needed to fix #7440 and in general to avoid shaky test failures because of exceeding 260 characters for full file name. This is not just for MSYS2, but also for MSVC and other Windows compilers.

260 character limit on Windows for Meson because:

1. Python < 3.6
2. need to modify Windows 10 registry to break 260 character full pathname limit
