### PR TITLE
qt module: rcc supports depfiles now, given a recent enough version of Qt5

### DIFF
--- a/mesonbuild/modules/qt4.py
+++ b/mesonbuild/modules/qt4.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .. import mlog
 from .qt import QtBaseModule
 
 
@@ -23,6 +22,4 @@ class Qt4Module(QtBaseModule):
 
 
 def initialize(*args, **kwargs):
-    mlog.warning('rcc dependencies will not work properly until this upstream issue is fixed:',
-                 mlog.bold('https://bugreports.qt.io/browse/QTBUG-45460'), fatal=False)
     return Qt4Module(*args, **kwargs)

--- a/mesonbuild/modules/qt5.py
+++ b/mesonbuild/modules/qt5.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .. import mlog
 from .qt import QtBaseModule
 
 
@@ -23,6 +22,4 @@ class Qt5Module(QtBaseModule):
 
 
 def initialize(*args, **kwargs):
-    mlog.warning('rcc dependencies will not work reliably until this upstream issue is fixed:',
-                 mlog.bold('https://bugreports.qt.io/browse/QTBUG-45460'), fatal=False)
     return Qt5Module(*args, **kwargs)


### PR DESCRIPTION
Add depfile support to generated targets for Qt >= 5.14.

Move warning into the module init itself, to check if the version is too old before issuing. Also tweak the wording itself, to advise upgrading to a suitable version of Qt5 instead of advising to wait for a Qt bug to be fixed.