### PR TITLE
ninjabackend: check if target has compiler attribute

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -972,6 +972,8 @@ int dummy;
         targets = self.build.get_targets().values()
         use_llvm_cov = False
         for target in targets:
+            if not hasattr(target, 'compilers'):
+                continue
             for compiler in target.compilers.values():
                 if compiler.get_id() == 'clang' and not compiler.info.is_darwin():
                     use_llvm_cov = True

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1272,7 +1272,6 @@ class InternalTests(unittest.TestCase):
 
         self.assertFalse(errors)
 
-
 @unittest.skipIf(is_tarball(), 'Skipping because this is a tarball release')
 class DataTests(unittest.TestCase):
 
@@ -4857,6 +4856,25 @@ recommended as it is not supported on some platforms''')
         if not gcovr_exe:
             raise unittest.SkipTest('gcovr not found, or too old')
         testdir = os.path.join(self.common_test_dir, '1 trivial')
+        env = get_fake_env(testdir, self.builddir, self.prefix)
+        cc = env.detect_c_compiler(MachineChoice.HOST)
+        if cc.get_id() == 'clang':
+            if not mesonbuild.environment.detect_llvm_cov():
+                raise unittest.SkipTest('llvm-cov not found')
+        if cc.get_id() == 'msvc':
+            raise unittest.SkipTest('Test only applies to non-MSVC compilers')
+        self.init(testdir, extra_args=['-Db_coverage=true'])
+        self.build()
+        self.run_tests()
+        self.run_target('coverage')
+
+    def test_coverage_complex(self):
+        if mesonbuild.environment.detect_msys2_arch():
+            raise unittest.SkipTest('Skipped due to problems with coverage on MSYS2')
+        gcovr_exe, gcovr_new_rootdir = mesonbuild.environment.detect_gcovr()
+        if not gcovr_exe:
+            raise unittest.SkipTest('gcovr not found, or too old')
+        testdir = os.path.join(self.common_test_dir, '109 generatorcustom')
         env = get_fake_env(testdir, self.builddir, self.prefix)
         cc = env.detect_c_compiler(MachineChoice.HOST)
         if cc.get_id() == 'clang':

--- a/test cases/common/109 generatorcustom/meson.build
+++ b/test cases/common/109 generatorcustom/meson.build
@@ -14,5 +14,7 @@ allinone = custom_target('alltogether',
     output : 'alltogether.h',
     command : [catter, '@INPUT@', '@OUTPUT@'])
 
-executable('proggie', 'main.c', allinone)
+proggie = executable('proggie', 'main.c', allinone)
+
+test('proggie', proggie)
 


### PR DESCRIPTION
otherwise we are getting errors like:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/mesonbuild/mesonmain.py", line 131, in run
    return options.run_func(options)
  File "/usr/local/lib/python3.6/dist-packages/mesonbuild/msetup.py", line 245, in run
    app.generate()
  File "/usr/local/lib/python3.6/dist-packages/mesonbuild/msetup.py", line 159, in generate
    self._generate(env)
  File "/usr/local/lib/python3.6/dist-packages/mesonbuild/msetup.py", line 215, in _generate
    intr.backend.generate()
  File "/usr/local/lib/python3.6/dist-packages/mesonbuild/backend/ninjabackend.py", line 518, in generate
    self.generate_coverage_rules()
  File "/usr/local/lib/python3.6/dist-packages/mesonbuild/backend/ninjabackend.py", line 991, in generate_coverage_rules
    self.generate_coverage_command(e, [])
  File "/usr/local/lib/python3.6/dist-packages/mesonbuild/backend/ninjabackend.py", line 975, in generate_coverage_command
    for compiler in target.compilers.values():
AttributeError: 'RunTarget' object has no attribute 'compilers'
```
This also adds a custom target to the trivial project to showcase the
problem.