### PR TITLE
 deps: Do not deepcopy internal libraries (fixes #7457) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ packagecache
 /docs/hotdoc-private*
 
 *.pyc
+/*venv*

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -252,6 +252,16 @@ class InternalDependency(Dependency):
         self.ext_deps = ext_deps
         self.variables = variables
 
+    def __deepcopy__(self, memo: dict) -> 'InternalDependency':
+        result = self.__class__.__new__(self.__class__)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            if k in ['libraries', 'whole_libraries']:
+                setattr(result, k, copy.copy(v))
+            else:
+                setattr(result, k, copy.deepcopy(v, memo))
+        return result
+
     def get_pkgconfig_variable(self, variable_name, kwargs):
         raise DependencyException('Method "get_pkgconfig_variable()" is '
                                   'invalid for an internal dependency')

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1115,16 +1115,15 @@ def check_format():
                       '.build',
                       '.md',
                       }
+    skip_dirs = {
+        '.dub',                         # external deps are here
+        '.pytest_cache',
+        'meson-logs', 'meson-private',
+        '.eggs', '_cache',              # e.g. .mypy_cache
+        'venv',                         # virtualenvs have DOS line endings
+    }
     for (root, _, filenames) in os.walk('.'):
-        if '.dub' in root: # external deps are here
-            continue
-        if '.pytest_cache' in root:
-            continue
-        if 'meson-logs' in root or 'meson-private' in root:
-            continue
-        if '__CMake_build' in root:
-            continue
-        if '.eggs' in root or '_cache' in root:  # e.g. .mypy_cache
+        if any([x in root for x in skip_dirs]):
             continue
         for fname in filenames:
             file = Path(fname)
@@ -1248,6 +1247,7 @@ if __name__ == '__main__':
         options.extra_args += ['--cross-file', options.cross_file]
 
     print('Meson build system', meson_version, 'Project Tests')
+    print('Using python', sys.version.split('\n')[0])
     setup_commands(options.backend)
     detect_system_compiler(options)
     print_tool_versions()


### PR DESCRIPTION
No test case, since the bug was not reproducible with any of our current CMake tests and I don't know what specifically with xerces-c caused the deep copy error.