### PR TITLE
build: Skip rpath subdir if target is a static library

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -819,6 +819,8 @@ class BuildTarget(Target):
     def get_link_dep_subdirs(self):
         result = OrderedSet()
         for i in self.link_targets:
+            if isinstance(i, StaticLibrary):
+                continue
             result.add(i.get_subdir())
             result.update(i.get_link_dep_subdirs())
         return result


### PR DESCRIPTION
When building the list of rpaths from all targets in subdirs,
skip static libraries.
These libraries don't need a rpath and are often used to
organize a project.

This solution is taken from:
https://github.com/mesonbuild/meson/issues/5191
And authored by:
https://github.com/xphoenix

Signed-off-by: Richard Weinberger <richard@nod.at>