### PR TITLE
Make meson recognize the Qualcomm LLVM toolchain

### DIFF
--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -113,6 +113,11 @@ class ClangCompiler(GnuLikeCompiler):
         # (and other gcc-like compilers) cannot. This is becuse clang (being
         # llvm based) is retargetable, while GCC is not.
         #
+
+        # qcld: Qualcomm Snapdragon linker, based on LLVM
+        if linker == 'qcld':
+            return  ['-fuse-ld=qcld']
+
         if shutil.which(linker):
             if not shutil.which(linker):
                 raise mesonlib.MesonException(

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -52,6 +52,7 @@ from .linkers import (
     GnuBFDDynamicLinker,
     GnuGoldDynamicLinker,
     LLVMDynamicLinker,
+    QualcommLLVMDynamicLinker,
     MSVCDynamicLinker,
     OptlinkDynamicLinker,
     PGIDynamicLinker,
@@ -888,9 +889,12 @@ class Environment:
             check_args += override
 
         _, o, e = Popen_safe(compiler + check_args)
-        v = search_version(o)
+        v = search_version(o + e)
         if o.startswith('LLD'):
             linker = LLVMDynamicLinker(
+                compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)  # type: DynamicLinker
+        elif 'Snapdragon' in e and 'LLVM' in e:
+            linker = QualcommLLVMDynamicLinker(
                 compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)  # type: DynamicLinker
         elif e.startswith('lld-link: '):
             # The LLD MinGW frontend didn't respond to --version before version 9.0.0,
@@ -1087,7 +1091,7 @@ class Environment:
                 return cls(
                     compiler, version, for_machine, is_cross, info, exe_wrap,
                     target, linker=linker)
-            if 'clang' in out:
+            if 'clang' in out or 'Clang' in out:
                 linker = None
 
                 defines = self.get_clang_compiler_defines(compiler)

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -927,6 +927,12 @@ class ArmClangDynamicLinker(ArmDynamicLinker):
     def import_library_args(self, implibname: str) -> T.List[str]:
         return ['--symdefs=' + implibname]
 
+class QualcommLLVMDynamicLinker(LLVMDynamicLinker):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # ARM Linker from Snapdragon LLVM ARM Compiler
+        self.id = 'ld.qcld'
 
 class PGIDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 


### PR DESCRIPTION
Meson calls `path/to/clang++ --version` to guess which build toolchain the
user has picked to build the source code. For the Qualcomm LLVM toolchain,
the output have an unusual output as shown below:

```
clang version 8.0.12
Snapdragon LLVM ARM Compiler 8.0.12 (based on llvm.org 7.0+)
Target: arm-unknown-linux-gnueabi
Thread model: posix
Repository: (ssh://git-hexagon-aus.qualcomm.com:...)
InstalledDir: /pkg/qct/software/llvm/release/arm/8.0.12/bin
```

Another unusual pattern is the output of `path/to/ld.qcld --version`:

```
ARM Linker from Snapdragon LLVM ARM Compiler Version 8.0.12
ARM Linker based on LLVM version: 8.0
```

The Meson logic is modified accordingly so that Meson can correctly
determine toolchain as "LLVM aarch64 cross-compiler on GNU/Linux64 OS".

This is the expected output of
`meson --native-file native_file.ini --cross-file cross_file.ini build/aarch64-debug/`:

```
...
C++ compiler for the host machine: ... (clang 8.0.12 "clang version 8.0.12")
C++ linker for the host machine: ... ld.lld 8.0.12
...
```

Reference: https://developer.qualcomm.com/software/snapdragon-llvm-compiler-android