### PR TITLE
RFC: logs: Prepend current subproject name to all messages

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2911,13 +2911,11 @@ external dependencies (including libraries) must go to "dependencies".''')
         os.makedirs(os.path.join(self.build.environment.get_build_dir(), subdir), exist_ok=True)
         self.global_args_frozen = True
 
-        mlog.log()
-        with mlog.nested(subp_name):
-            stack = ':'.join(self.subproject_stack + [subp_name])
-            m = ['Executing subproject', mlog.bold(stack)]
-            if method != 'meson':
-                m += ['method', mlog.bold(method)]
-            mlog.log(*m,'\n')
+        stack = ':'.join(self.subproject_stack + [subp_name])
+        m = ['\nExecuting subproject', mlog.bold(stack)]
+        if method != 'meson':
+            m += ['method', mlog.bold(method)]
+        mlog.log(*m,'\n', nested=False)
 
         try:
             if method == 'meson':

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2914,7 +2914,11 @@ external dependencies (including libraries) must go to "dependencies".''')
         mlog.log()
         with mlog.nested(subp_name):
             stack = ':'.join(self.subproject_stack + [subp_name])
-            mlog.log('Executing subproject', mlog.bold(stack), 'method', mlog.bold(method), '\n')
+            m = ['Executing subproject', mlog.bold(stack)]
+            if method != 'meson':
+                m += ['method', mlog.bold(method)]
+            mlog.log(*m,'\n')
+
         try:
             if method == 'meson':
                 return self._do_subproject_meson(subp_name, subdir, default_options, kwargs)

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2912,8 +2912,9 @@ external dependencies (including libraries) must go to "dependencies".''')
         self.global_args_frozen = True
 
         mlog.log()
-        with mlog.nested():
-            mlog.log('Executing subproject', mlog.bold(subp_name), 'method', mlog.bold(method), '\n')
+        with mlog.nested(subp_name):
+            stack = ':'.join(self.subproject_stack + [subp_name])
+            mlog.log('Executing subproject', mlog.bold(stack), 'method', mlog.bold(method), '\n')
         try:
             if method == 'meson':
                 return self._do_subproject_meson(subp_name, subdir, default_options, kwargs)
@@ -2926,7 +2927,7 @@ external dependencies (including libraries) must go to "dependencies".''')
             raise
         except Exception as e:
             if not required:
-                with mlog.nested():
+                with mlog.nested(subp_name):
                     # Suppress the 'ERROR:' prefix because this exception is not
                     # fatal and VS CI treat any logs with "ERROR:" as fatal.
                     mlog.exception(e, prefix=mlog.yellow('Exception:'))
@@ -2938,7 +2939,7 @@ external dependencies (including libraries) must go to "dependencies".''')
                              ast: T.Optional[mparser.CodeBlockNode] = None,
                              build_def_files: T.Optional[T.List[str]] = None,
                              is_translated: bool = False) -> SubprojectHolder:
-        with mlog.nested():
+        with mlog.nested(subp_name):
             new_build = self.build.copy()
             subi = Interpreter(new_build, self.backend, subp_name, subdir, self.subproject_dir,
                                self.modules, default_options, ast=ast, is_translated=is_translated)
@@ -2975,7 +2976,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         return self.subprojects[subp_name]
 
     def _do_subproject_cmake(self, subp_name, subdir, subdir_abs, default_options, kwargs):
-        with mlog.nested():
+        with mlog.nested(subp_name):
             new_build = self.build.copy()
             prefix = self.coredata.options[OptionKey('prefix')].value
 
@@ -2995,7 +2996,7 @@ external dependencies (including libraries) must go to "dependencies".''')
             ast = cm_int.pretend_to_be_meson(options.target_options)
 
             mlog.log()
-            with mlog.nested():
+            with mlog.nested('cmake-ast'):
                 mlog.log('Processing generated meson AST')
 
                 # Debug print the generated meson file

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -201,7 +201,7 @@ def process_markup(args: T.Sequence[T.Union[AnsiDecorator, str]], keep: bool) ->
             arr.append(str(arg))
     return arr
 
-def force_print(*args: str, **kwargs: T.Any) -> None:
+def force_print(*args: str, nested: str, **kwargs: T.Any) -> None:
     if log_disable_stdout:
         return
     iostr = io.StringIO()
@@ -210,7 +210,7 @@ def force_print(*args: str, **kwargs: T.Any) -> None:
 
     raw = iostr.getvalue()
     if log_depth:
-        prepend = log_depth[-1] + '| '
+        prepend = log_depth[-1] + '| ' if nested else ''
         lines = []
         for l in raw.split('\n'):
             l = l.strip()
@@ -250,6 +250,7 @@ def log(*args: T.Union[str, AnsiDecorator], is_error: bool = False,
 
 def _log(*args: T.Union[str, AnsiDecorator], is_error: bool = False,
         **kwargs: T.Any) -> None:
+    nested = kwargs.pop('nested', True)
     arr = process_markup(args, False)
     if log_file is not None:
         print(*arr, file=log_file, **kwargs)
@@ -257,7 +258,7 @@ def _log(*args: T.Union[str, AnsiDecorator], is_error: bool = False,
     if colorize_console():
         arr = process_markup(args, True)
     if not log_errors_only or is_error:
-        force_print(*arr, **kwargs)
+        force_print(*arr, nested=nested, **kwargs)
 
 def log_once(*args: T.Union[str, AnsiDecorator], is_error: bool = False,
              **kwargs: T.Any) -> None:

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -210,7 +210,7 @@ def force_print(*args: str, **kwargs: T.Any) -> None:
 
     raw = iostr.getvalue()
     if log_depth:
-        prepend = log_depth[-1] + '|'
+        prepend = log_depth[-1] + '| '
         raw = prepend + raw.replace('\n', '\n' + prepend, raw.count('\n') - 1)
 
     # _Something_ is going to get printed.

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -69,7 +69,7 @@ def setup_console() -> None:
 log_dir = None               # type: T.Optional[str]
 log_file = None              # type: T.Optional[T.TextIO]
 log_fname = 'meson-log.txt'  # type: str
-log_depth = 0                # type: int
+log_depth = []               # type: T.List[str]
 log_timestamp_start = None   # type: T.Optional[float]
 log_fatal_warnings = False   # type: bool
 log_disable_stdout = False   # type: bool
@@ -209,8 +209,8 @@ def force_print(*args: str, **kwargs: T.Any) -> None:
     print(*args, **kwargs)
 
     raw = iostr.getvalue()
-    if log_depth > 0:
-        prepend = '|' * log_depth
+    if log_depth:
+        prepend = log_depth[-1] + '|'
         raw = prepend + raw.replace('\n', '\n' + prepend, raw.count('\n') - 1)
 
     # _Something_ is going to get printed.
@@ -370,10 +370,10 @@ def format_list(input_list: T.List[str]) -> str:
         return ''
 
 @contextmanager
-def nested() -> T.Generator[None, None, None]:
+def nested(name: str = '') -> T.Generator[None, None, None]:
     global log_depth
-    log_depth += 1
+    log_depth.append(name)
     try:
         yield
     finally:
-        log_depth -= 1
+        log_depth.pop()

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -211,7 +211,11 @@ def force_print(*args: str, **kwargs: T.Any) -> None:
     raw = iostr.getvalue()
     if log_depth:
         prepend = log_depth[-1] + '| '
-        raw = prepend + raw.replace('\n', '\n' + prepend, raw.count('\n') - 1)
+        lines = []
+        for l in raw.split('\n'):
+            l = l.strip()
+            lines.append(prepend + l if l else '')
+        raw = '\n'.join(lines)
 
     # _Something_ is going to get printed.
     try:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4180,12 +4180,12 @@ class AllPlatformTests(BasePlatformTests):
         # Parent project warns correctly
         self.assertRegex(out, "WARNING: Project targeting '>=0.45'.*'0.47.0': dict")
         # Subprojects warn correctly
-        self.assertRegex(out, r"\|WARNING: Project targeting '>=0.40'.*'0.44.0': disabler")
-        self.assertRegex(out, r"\|WARNING: Project targeting '!=0.40'.*'0.44.0': disabler")
+        self.assertRegex(out, r"\| WARNING: Project targeting '>=0.40'.*'0.44.0': disabler")
+        self.assertRegex(out, r"\| WARNING: Project targeting '!=0.40'.*'0.44.0': disabler")
         # Subproject has a new-enough meson_version, no warning
         self.assertNotRegex(out, "WARNING: Project targeting.*Python")
         # Ensure a summary is printed in the subproject and the outer project
-        self.assertRegex(out, r"\|WARNING: Project specifies a minimum meson_version '>=0.40'")
+        self.assertRegex(out, r"\| WARNING: Project specifies a minimum meson_version '>=0.40'")
         self.assertRegex(out, r"\| \* 0.44.0: {'disabler'}")
         self.assertRegex(out, "WARNING: Project specifies a minimum meson_version '>=0.45'")
         self.assertRegex(out, " * 0.47.0: {'dict'}")


### PR DESCRIPTION
Meson used to prepend '|' for each nested subproject to distinguish in
the logs where a subproject start and ends. It is more useful to print
the current subproject name.

Also print the call stack when starting a new subproject to better see
which subproject chain leads to to.

--
This is an RFC, I'm not sure this should be the default output, or if we should have a command line option for that?