### PR TITLE
visualstudio: warning_level 0 should not map to /W1

### DIFF
--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -114,7 +114,7 @@ class VisualStudioLikeCompiler(metaclass=abc.ABCMeta):
     # See: https://ninja-build.org/manual.html#_deps
     always_args = ['/nologo', '/showIncludes']
     warn_args = {
-        '0': ['/W1'],
+        '0': [],
         '1': ['/W2'],
         '2': ['/W3'],
         '3': ['/W4'],


### PR DESCRIPTION
In every other compilers level 0 maps to no argument at all.