### PR TITLE
tests/common/227: don't have symlink in Git

### DIFF
--- a/test cases/common/227 fs module/a_symlink
+++ b/test cases/common/227 fs module/a_symlink
@@ -1,1 +1,0 @@
-meson.build

--- a/test cases/common/227 fs module/meson.build
+++ b/test cases/common/227 fs module/meson.build
@@ -18,7 +18,9 @@ assert(not fs.exists('nonexisting'), 'Nonexisting file was found.')
 is_git_checkout = fs.exists('../../../.git')
 
 if not is_windows and build_machine.system() != 'cygwin' and is_git_checkout
-  assert(fs.is_symlink('a_symlink'), 'Symlink not detected.')
+  symlink = meson.current_build_dir() / 'a_symlink'
+  run_command('ln', '-s', meson.current_source_dir() / 'meson.build', symlink)
+  assert(fs.is_symlink(symlink), 'Symlink not detected.')
   assert(not fs.is_symlink('meson.build'), 'Regular file detected as symlink.')
 endif
 
@@ -104,7 +106,7 @@ assert(not fs.is_samepath(f1, 'subdir/subdirfile.txt'), 'is_samepath known bad c
 assert(not fs.is_samepath('not-a-path', f2), 'is_samepath should not error if path(s) do not exist')
 
 if not is_windows and build_machine.system() != 'cygwin' and is_git_checkout
-  assert(fs.is_samepath('a_symlink', 'meson.build'), 'symlink is_samepath fail')
+  assert(fs.is_samepath(symlink, 'meson.build'), 'symlink is_samepath fail')
 endif
 
 # parts of path

--- a/test cases/common/227 fs module/meson.build
+++ b/test cases/common/227 fs module/meson.build
@@ -7,17 +7,11 @@ fs = import('fs')
 assert(fs.exists('meson.build'), 'Existing file reported as missing.')
 assert(not fs.exists('nonexisting'), 'Nonexisting file was found.')
 
-# When one creates a source release with sdist, Python
-# does not store symlinks in the archive as native symlinks.
-# Thus the extracted archive does not contain them either.
-# Sadly this means that we can only execute the symlink test when
-# running from a git checkout because otherwise we'd need to
-# do postprocessing on the generated archive before actual release.
-# That is both nonstandard an error prone and having symlinks in
-# the archive would probably break on Windows anyway.
-is_git_checkout = fs.exists('../../../.git')
-
-if not is_windows and build_machine.system() != 'cygwin' and is_git_checkout
+if not is_windows and build_machine.system() != 'cygwin'
+  # Symlinks on Windows have specific requirements including:
+  # * Meson running under Python >= 3.8
+  # * Windows user permissions to create symlinks, and/or Windows in Developer mode
+  # so at this time the symlink test is skipped for Windows.
   symlink = meson.current_build_dir() / 'a_symlink'
   run_command('ln', '-s', meson.current_source_dir() / 'meson.build', symlink)
   assert(fs.is_symlink(symlink), 'Symlink not detected.')
@@ -105,7 +99,7 @@ assert(fs.is_samepath(meson.source_root(), 'subdir/..'), 'is_samepath not detect
 assert(not fs.is_samepath(f1, 'subdir/subdirfile.txt'), 'is_samepath known bad comparison')
 assert(not fs.is_samepath('not-a-path', f2), 'is_samepath should not error if path(s) do not exist')
 
-if not is_windows and build_machine.system() != 'cygwin' and is_git_checkout
+if not is_windows and build_machine.system() != 'cygwin'
   assert(fs.is_samepath(symlink, 'meson.build'), 'symlink is_samepath fail')
 endif
 


### PR DESCRIPTION
Windows Git users with symlinks have a **constantly Git dirty Meson repo** from
this "a_symlink".  This is true even when the Windows install has Developer Mode and symlinks enabled via Windows group policy.

This change generates a symlink in the build directory when the test is run, instead of tracking the symlink in Git. 
Now, there is no longer a constantly Git dirty Meson project directory on Windows.

While CMake has the native capability to create symlinks, Meson doesn't have this (it's trivially easy to add, but I think I remember a discussion where it wasn't desired?)