### PR TITLE
Describe syntax of `meson configure` in docs

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -17,7 +17,7 @@ by setting them inside `default_options` of `project()` in your `meson.build`.
 
 For legacy reasons `--warnlevel` is the cli argument for the `warning_level` option.
 
-They can also be edited after setup using `meson configure`.
+They can also be edited after setup using `meson configure -Doption=value`.
 
 Installation options are all relative to the prefix, except:
 


### PR DESCRIPTION
For some background, I was attempting to do `meson configure --key=value` and `meson configure key=value` (which it says works with `meson build`). I tried using `meson configure -h` but it's so large it's hard to spot the tiny spot at the bottom that mentions this. Finally, I went to Google, clicked a few pages and finally found the answer [at the bottom of this page](https://mesonbuild.com/Configuring-a-build-directory.html). Figured it be helpful to include it here as well to save people some searching.