### PR TITLE
Handle targets without 'compilers' attribute for coverage commands

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -972,19 +972,22 @@ int dummy;
         targets = self.build.get_targets().values()
         use_llvm_cov = False
         for target in targets:
-            for compiler in target.compilers.values():
-                if compiler.get_id() == 'clang' and not compiler.info.is_darwin():
-                    use_llvm_cov = True
-                    break
-        elem.add_item('COMMAND', self.environment.get_build_command() +
-                      ['--internal', 'coverage'] +
-                      outputs +
-                      [self.environment.get_source_dir(),
-                       os.path.join(self.environment.get_source_dir(),
-                                    self.build.get_subproject_dir()),
-                       self.environment.get_build_dir(),
-                       self.environment.get_log_dir()] +
-                      ['--use_llvm_cov'] if use_llvm_cov else [])
+            try:
+                for compiler in target.compilers.values():
+                    if compiler.get_id() == 'clang' and not compiler.info.is_darwin():
+                        use_llvm_cov = True
+                        break
+                        elem.add_item('COMMAND', self.environment.get_build_command() +
+                          ['--internal', 'coverage'] +
+                          outputs +
+                          [self.environment.get_source_dir(),
+                           os.path.join(self.environment.get_source_dir(),
+                                        self.build.get_subproject_dir()),
+                           self.environment.get_build_dir(),
+                           self.environment.get_log_dir()] +
+                          ['--use_llvm_cov'] if use_llvm_cov else [])
+            except AttributeError:
+                continue
 
     def generate_coverage_rules(self):
         e = NinjaBuildElement(self.all_outputs, 'meson-coverage', 'CUSTOM_COMMAND', 'PHONY')

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -977,17 +977,17 @@ int dummy;
                     if compiler.get_id() == 'clang' and not compiler.info.is_darwin():
                         use_llvm_cov = True
                         break
-                        elem.add_item('COMMAND', self.environment.get_build_command() +
-                          ['--internal', 'coverage'] +
-                          outputs +
-                          [self.environment.get_source_dir(),
-                           os.path.join(self.environment.get_source_dir(),
-                                        self.build.get_subproject_dir()),
-                           self.environment.get_build_dir(),
-                           self.environment.get_log_dir()] +
-                          ['--use_llvm_cov'] if use_llvm_cov else [])
             except AttributeError:
                 continue
+        elem.add_item('COMMAND', self.environment.get_build_command() +
+                      ['--internal', 'coverage'] +
+                      outputs +
+                      [self.environment.get_source_dir(),
+                       os.path.join(self.environment.get_source_dir(),
+                                    self.build.get_subproject_dir()),
+                       self.environment.get_build_dir(),
+                       self.environment.get_log_dir()] +
+                      ['--use_llvm_cov'] if use_llvm_cov else [])
 
     def generate_coverage_rules(self):
         e = NinjaBuildElement(self.all_outputs, 'meson-coverage', 'CUSTOM_COMMAND', 'PHONY')


### PR DESCRIPTION
When building a meson+ninja project and passing -Db_coverage=true to
the setup command, you may get a traceback like this:

    Found ninja-1.9.0 at /usr/bin/ninja
    Traceback (most recent call last):
      File "/usr/lib/python3.7/site-packages/mesonbuild/mesonmain.py", line 131, in run
        return options.run_func(options)
      File "/usr/lib/python3.7/site-packages/mesonbuild/msetup.py", line 245, in run
        app.generate()
      File "/usr/lib/python3.7/site-packages/mesonbuild/msetup.py", line 159, in generate
        self._generate(env)
      File "/usr/lib/python3.7/site-packages/mesonbuild/msetup.py", line 215, in _generate
        intr.backend.generate()
      File "/usr/lib/python3.7/site-packages/mesonbuild/backend/ninjabackend.py", line 518, in generate
        self.generate_coverage_rules()
      File "/usr/lib/python3.7/site-packages/mesonbuild/backend/ninjabackend.py", line 991, in generate_coverage_rules
        self.generate_coverage_command(e, [])
      File "/usr/lib/python3.7/site-packages/mesonbuild/backend/ninjabackend.py", line 975, in generate_coverage_command
        for compiler in target.compilers.values():
    AttributeError: 'RunTarget' object has no attribute 'compilers'

This patch skips over targets from self.build that lack a 'compilers'
attribute.

I am not sure if this is the correct approach, but inspecting the code I saw that the 'targets' that the for loop is iterating contains things like the meson command itself and some other information that is not strictly a compiler target.  So without digging further, I thought it would be fine to just skip over targets here that lack a compilers attribute since the function itself is only acting on a compilers attribute.

This problem showed up for me as of meson-0.55.0.  The patch fixes it for me locally.