### PR TITLE
backends: do not use get_filename for customtarget

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -261,7 +261,10 @@ class Backend:
         return self.build_to_src
 
     def get_target_private_dir(self, target):
-        return os.path.join(self.get_target_filename(target) + '.p')
+        if isinstance(target, build.CustomTarget): #custom targets can have more than one output, do not call get target filename in order to prevent a warning
+            return os.path.join(self.get_target_dir(target), target.get_id() + '.p')
+        else:
+            return os.path.join(self.get_target_filename(target) + '.p')
 
     def get_target_private_dir_abs(self, target):
         return os.path.join(self.environment.get_build_dir(), self.get_target_private_dir(target))


### PR DESCRIPTION
a customtarget can have more than 1 output name, if thats the case, then
we are seeing a warning, which is probebly not what should be printed,
as using more than one output is totally legal.

This is an addition to #6944

I created this for now to mainly ask if this is okay this way, as i dont know what the initial idea behind the commit was.
This should fix #7466