### PR TITLE
Remove uneeded `parse_cmd_line_options`

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1023,24 +1023,6 @@ def create_options_dict(options):
         result[key] = value
     return result
 
-def parse_cmd_line_options(args):
-    args.cmd_line_options = create_options_dict(args.projectoptions)
-
-    # Merge builtin options set with --option into the dict.
-    for name in chain(
-            builtin_options.keys(),
-            ('build.' + k for k in builtin_options_per_machine.keys()),
-            builtin_options_per_machine.keys(),
-    ):
-        value = getattr(args, name, None)
-        if value is not None:
-            if name in args.cmd_line_options:
-                cmdline_name = BuiltinOption.argparse_name_to_arg(name)
-                raise MesonException(
-                    'Got argument {0} as both -D{0} and {1}. Pick one.'.format(name, cmdline_name))
-            args.cmd_line_options[name] = value
-            delattr(args, name)
-
 
 _U = T.TypeVar('_U', bound=UserOption[_T])
 

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -243,7 +243,6 @@ class Conf:
             print_default_values_warning()
 
 def run(options):
-    coredata.parse_cmd_line_options(options)
     builddir = os.path.abspath(os.path.realpath(options.builddir))
     c = None
     try:

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -240,7 +240,6 @@ class MesonApp:
             raise
 
 def run(options) -> int:
-    coredata.parse_cmd_line_options(options)
     app = MesonApp(options)
     app.generate()
     return 0


### PR DESCRIPTION
The new way of doing things, thanks to @dcbaker, is making it so
`Environment` combines the command line options and config files, and
then coredata and just ingestion 1 source of raw data to initialize the
actual options. This dramatically simplifies things by making
information flow through one path not many.

`parse_cmd_line_options` is a vestige of the old way of coredata having
to crawl over a bunch of different sources of information and repeatedly
parse them, and is no longer needed.

CC @dcbaker @xclaesse 