### PR TITLE
tests: Disable Boost extralib test on macOS

### DIFF
--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -54,7 +54,11 @@ python3module = shared_library('python3_module', ['python_module.cpp'], dependen
 test('Boost linktest', linkexe)
 test('Boost UTF test', unitexe)
 test('Boost nomod', nomodexe)
-test('Boost extralib test', extralibexe)
+if host_machine.system() != 'darwin' or s
+  # Segfaults on macOS with dynamic linking since Boost 1.73
+  # https://github.com/mesonbuild/meson/issues/7535
+  test('Boost extralib test', extralibexe)
+endif
 
 # explicitly use the correct python interpreter so that we don't have to provide two different python scripts that have different shebang lines
 python2interpreter = find_program(python2.path(), required: false, disabler: true)


### PR DESCRIPTION
Since upgrading Boost to version 1.73, this test segfaults on macOS
when dynamically linked. Disable it to keep the rest of the CI
reliable.

Mitigates: #7535

---

Obviously a better solution would be for someone who uses macOS and/or understands Boost to work out why the test is failing and fix it, but I don't fit that description, so this is the best I can do right now.