### PR TITLE
avoid spurious warning from get_target_filename

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1955,9 +1955,11 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             source_target_dir = os.path.join(self.build_to_src, override_subdir)
         else:
             source_target_dir = self.get_target_source_dir(target)
-        relout = self.get_target_private_dir(target)
-        args = [x.replace("@SOURCE_DIR@", self.build_to_src).replace("@BUILD_DIR@", relout)
-                for x in args]
+        args = [x.replace("@SOURCE_DIR@", self.build_to_src) for x in args]
+        need_relout = any(("@BUILD_DIR@" in x for x in args))
+        if need_relout:
+            relout = self.get_target_private_dir(target)
+            args = [x.replace("@BUILD_DIR@", relout) for x in args]
         args = [x.replace("@CURRENT_SOURCE_DIR@", source_target_dir) for x in args]
         args = [x.replace("@SOURCE_ROOT@", self.build_to_src).replace("@BUILD_ROOT@", '.')
                 for x in args]

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4975,6 +4975,14 @@ recommended as it is not supported on some platforms''')
             self.build()
             self.run_tests()
 
+    def test_multi_output_custom_target_no_warning(self):
+        testdir = os.path.join(self.common_test_dir, '235 custom_target source')
+
+        out = self.init(testdir)
+        self.assertNotRegex(out, 'WARNING:.*Using the first one.')
+        self.build()
+        self.run_tests()
+
 class FailureTests(BasePlatformTests):
     '''
     Tests that test failure conditions. Build files here should be dynamically

--- a/test cases/common/235 custom_target source/meson.build
+++ b/test cases/common/235 custom_target source/meson.build
@@ -1,0 +1,5 @@
+project('a', ['c'])
+
+x = find_program('x.py')
+outs = custom_target('foo', output: ['x.c', 'y'], input: 'a', command: [x])
+executable('testprog', outs[0])

--- a/test cases/common/235 custom_target source/x.py
+++ b/test cases/common/235 custom_target source/x.py
@@ -1,0 +1,5 @@
+#! /usr/bin/env python3
+with open('x.c', 'w') as f:
+    print('int main(void) { return 0; }', file=f)
+with open('y', 'w'):
+    pass


### PR DESCRIPTION
In the situation covered by the new test case, get_target_filename is
invoked in the process of retrieving (via get_target_private_dir) the
custom target's @BUILD_DIR@; because the custom target has more than
one output, a spurious warning is printed.

However, that substitution is not used in the commands.  Avoid the
problem by not invoking get_target_private_dir.

This seems to be a regression from 0.54.3 to 0.55.0.

Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>