### PR TITLE
cmake: Use the DEBUG config when linking to the debug CRT

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1450,7 +1450,10 @@ class CMakeDependency(ExternalDependency):
                     cfgs = [x for x in tgt.properties['IMPORTED_CONFIGURATIONS'] if x]
                     cfg = cfgs[0]
 
-                is_debug = self.env.coredata.get_builtin_option('debug');
+                is_debug = self.env.coredata.get_builtin_option('buildtype') == 'debug'
+                if 'b_vscrt' in self.env.coredata.base_options:
+                    if self.env.coredata.base_options['b_vscrt'].value in ('mdd', 'mtd'):
+                        is_debug = True
                 if is_debug:
                     if 'DEBUG' in cfgs:
                         cfg = 'DEBUG'


### PR DESCRIPTION
The `debug` builtin option does not control whether or not the debug CRT is used. Without this fix, when `buildtype=debugoptimized` or when `debug=true` + `b_vscrt=md`, we will try to link to the debug libraries found via cmake while linking with `/release`, which will cause a link failure.

CC: @mensinda 