### PR TITLE
msvc: enable /std:c11 flag

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -353,6 +353,26 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
                            info, exe_wrap, **kwargs)
         MSVCCompiler.__init__(self, target)
 
+    def get_options(self):
+        opts = super().get_options()
+        c_stds = ['none', 'c89', 'c99', 'c11']
+        opts.update({
+            'std': coredata.UserComboOption(
+                'C language standard to use',
+                c_stds,
+                'none',
+            ),
+        })
+        return opts
+
+    def get_option_compile_args(self, options):
+        args = []
+        std = options['std']
+        # As of MVSC 16.7, /std:c11 is the only valid C standard option.
+        if std.value in {'c11'}:
+            args.append('/std:' + std.value)
+        return args
+
 
 class ClangClCCompiler(ClangClCompiler, VisualStudioLikeCCompilerMixin, CCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,


### PR DESCRIPTION
fixes #7554

Dylan, should I be copying over the "winlibs" from get_options in VisualStudioLikeCCompilerMixin? 

Before this change, a trivial meson.build + main.c would issue:

```sh
[1/2] "cl" "-Imain.exe.p" "-I." "-I.." "/MDd" "/nologo" "/showIncludes" "/W2" "/ZI" "/Ob0" "/Od" "/RTC1" "/Fdmain.exe.p\main.c.pdb" /Fomain.exe.p/main.c.obj "/c" ../main.c
[2/2] "link"  /MACHINE:x64 /OUT:main.exe main.exe.p/main.c.obj "/nologo" "/release" "/nologo" "/DEBUG" "/PDB:main.pdb" "/SUBSYSTEM:CONSOLE" "kernel32.lib" "user32.lib" "gdi32.lib" "winspool.lib" "shell32.lib" "ole32.lib" "oleaut32.lib" "uuid.lib" "comdlg32.lib" "advapi32.lib"
````

with this change:

```sh
[1/2] "cl" "-Imain.exe.p" "-I." "-I.." "/MDd" "/nologo" "/showIncludes" "/W2" "/std:c11" "/ZI" "/Ob0" "/Od" "/RTC1" "/Fdmain.exe.p\main.c.pdb" /Fomain.exe.p/main.c.obj "/c" ../main.c
[2/2] "link"  /MACHINE:x64 /OUT:main.exe main.exe.p/main.c.obj "/nologo" "/release" "/nologo" "/DEBUG" "/PDB:main.pdb" "/SUBSYSTEM:CONSOLE" "kernel32.lib" "user32.lib" "gdi32.lib" "winspool.lib" "shell32.lib" "ole32.lib" "oleaut32.lib" "uuid.lib" "comdlg32.lib" "advapi32.lib"
```

Unlike other compilers, MSVC doesn't error when given an unknown option, so MSVC < 16.7 just ignores this option.

## Example

With MSVC 16.7, this fails to build without /std:c11 and works with it.

meson.build

```meson
project('vc11', 'c', default_options : ['c_std=c11'])

executable('main', 'main.c')
```

main.c

```c
// https://www.ibm.com/support/knowledgecenter/en/SSGH2K_13.1.2/com.ibm.xlc131.aix.doc/language_ref/genericselection.html
#include <stdio.h>

#define myfunction(X) _Generic((X), \
long double:myfunction_longdouble, \
default:myfunction_double, \
float:myfunction_float \
)(X)
void myfunction_longdouble(long double x){printf("calling %s\n",__func__);}
void myfunction_double(double x){printf("calling %s\n",__func__);}
void myfunction_float(float x){printf("calling %s\n",__func__);}

int main()
{
  long double ld;
  double d;
  float f;
  myfunction(ld);
  myfunction(d);
  myfunction(f);
}
```