### PR TITLE
Add h5cc shlib argument to correctly link hdf5 libraries without pkg-config support

### DIFF
--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -105,7 +105,8 @@ class HDF5Dependency(ExternalDependency):
                 prog = ExternalProgram(wrappers[lang], silent=True)
                 if not prog.found():
                     return
-                cmd = prog.get_command() + ['-show']
+                shlib_arg = '-noshlib' if kwargs.get('static', False) else '-shlib'
+                cmd = prog.get_command() + [shlib_arg, '-show']
                 p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, timeout=15)
                 if p.returncode != 0:
                     mlog.debug('Command', mlog.bold(cmd), 'failed to run:')


### PR DESCRIPTION
Older versions of hdf5 (e.g. 1.8) don't have a pkg-config `hdf5.pc` file. Meson uses hdf5's `h5cc` binary for `DependencyMethods.AUTO`.

This PR adds the corresponding arguments to respect "static" key in the dependency function for hdf5:
`h5cc -shlib -show` for shared dependencies
`h5cc -noshlib -show` for static dependencies
Currently `-show` shows only static dependencies by default.

Partially addresses #7555. HDF5 static libraries are not distributed with `fPIC`.