### PR TITLE
msubprojects: Rework update command

### DIFF
--- a/docs/markdown/Subprojects.md
+++ b/docs/markdown/Subprojects.md
@@ -264,10 +264,10 @@ the following command-line options:
 
 `meson subprojects` has various subcommands to manage all subprojects. If the
 subcommand fails on any subproject the execution continues with other subprojects.
-All subcommands accepts `--sourcedir` argument pointing to the root source dir
+All subcommands accept `--sourcedir` argument pointing to the root source dir
 of the main project.
 
-*Since 0.56.0* all subcommands accepts `--type <file,git,hg,svn>` argument to
+*Since 0.56.0* all subcommands accept `--type <file|git|hg|svn>` argument to
 run the subcommands only on subprojects of the given type.
 
 *Since 0.56.0* If the subcommand fails on any subproject an error code is returned

--- a/docs/markdown/Subprojects.md
+++ b/docs/markdown/Subprojects.md
@@ -267,8 +267,9 @@ subcommand fails on any subproject the execution continues with other subproject
 All subcommands accept `--sourcedir` argument pointing to the root source dir
 of the main project.
 
-*Since 0.56.0* all subcommands accept `--type <file|git|hg|svn>` argument to
-run the subcommands only on subprojects of the given type.
+*Since 0.56.0* all subcommands accept `--types <file|git|hg|svn>` argument to
+run the subcommands only on subprojects of the given types. Multiple types can
+be set as comma separated list e.g. `--types git,file`.
 
 *Since 0.56.0* If the subcommand fails on any subproject an error code is returned
 at the end instead of retuning success.

--- a/docs/markdown/Subprojects.md
+++ b/docs/markdown/Subprojects.md
@@ -258,7 +258,22 @@ the following command-line options:
     `glib-2.0` must also be forced to fallback, in this case with
     `--force-fallback-for=glib,gsteamer`.
 
-## Download subprojects
+## `meson subprojects` command
+
+*Since 0.49.0*
+
+`meson subprojects` has various subcommands to manage all subprojects. If the
+subcommand fails on any subproject the execution continues with other subprojects.
+All subcommands accepts `--sourcedir` argument pointing to the root source dir
+of the main project.
+
+*Since 0.56.0* all subcommands accepts `--type <file,git,hg,svn>` argument to
+run the subcommands only on subprojects of the given type.
+
+*Since 0.56.0* If the subcommand fails on any subproject an error code is returned
+at the end instead of retuning success.
+
+### Download subprojects
 
 *Since 0.49.0*
 
@@ -269,7 +284,7 @@ offline. The command-line `meson subprojects download` can be used for that, it
 will download all missing subprojects, but will not update already fetched
 subprojects.
 
-## Update subprojects
+### Update subprojects
 
 *Since 0.49.0*
 
@@ -282,15 +297,22 @@ To pull latest version of all your subprojects at once, just run the command:
   be pulled and used next time meson reconfigure the project. This can be
   triggered using `meson --reconfigure`. Previous source tree is not deleted, to
   prevent from any loss of local changes.
-- If the wrap file points to a git commit or tag, a checkout of that commit is
-  performed.
-- If the wrap file points to a git branch, and the current branch has the same
-  name, a `git pull` is performed.
-- If the wrap file points to a git branch, and the current branch is different,
-  it is skipped. Unless `--rebase` option is passed in which case
-  `git pull --rebase` is performed.
+- If subproject is currently in detached mode, a checkout of the revision from
+  wrap file is performed. *Since 0.56.0* a rebase is also performed in case the
+  revision already existed locally by was outdated. If `--reset` is specified,
+  a hard reset is performed instead of rebase.
+- If subproject is currently at the same branch as specified by the wrap file,
+  a rebase on `origin` commit is performed. *Since 0.56.0* If `--reset` is
+  specified, a hard reset is performed instead of rebase.
+- If subproject is currently in a different branch as specified by the wrap file,
+  it is skipped unless `--rebase` option is passed in which case a rebase on
+  `origin` commit is performed. *Since 0.56.0* the `--rebase` argument is
+  deprecated and has no effect. Instead, a checkout of the revision from wrap file
+  file is performed and a rebase is also performed in case the revision already
+  existed locally by was outdated. If `--reset` is specified, a hard reset is
+  performed instead of rebase.
 
-## Start a topic branch across all git subprojects
+### Start a topic branch across all git subprojects
 
 *Since 0.49.0*
 
@@ -303,7 +325,9 @@ changes.
 To come back to the revision set in wrap file (i.e. master), just run
 `meson subprojects checkout` with no branch name.
 
-## Execute a command on all subprojects
+*Since 0.56.0* any pending changes are now stashed before checkout a new branch.
+
+### Execute a command on all subprojects
 
 *Since 0.51.0*
 

--- a/docs/markdown/snippets/subprojects_update.md
+++ b/docs/markdown/snippets/subprojects_update.md
@@ -1,8 +1,9 @@
 ## `meson subprojects` command
 
-A new `--type` argument has been added to all subcommands to run the command only
-on wraps with the specified type. For example this command will only print `Hello`
-for each git subproject: `meson subprojects foreach --type git echo "Hello"`.
+A new `--types` argument has been added to all subcommands to run the command only
+on wraps with the specified types. For example this command will only print `Hello`
+for each git subproject: `meson subprojects foreach --types git echo "Hello"`.
+Multiple types can be set as comma separated list e.g. `--types git,file`.
 
 Subprojects with no wrap file are now taken into account as well. This happens
 for example for subprojects configured as git submodule, or downloaded manually

--- a/docs/markdown/snippets/subprojects_update.md
+++ b/docs/markdown/snippets/subprojects_update.md
@@ -1,0 +1,27 @@
+## `meson subprojects` command
+
+A new `--type` argument has been added to all subcommands to run the command only
+on wraps with the specified type. For example this command will only print `Hello`
+for each git subproject: `meson subprojects foreach --type git echo "Hello"`.
+
+Subprojects with no wrap file are now taken into account as well. This happens
+for example for subprojects configured as git submodule, or downloaded manually
+by the user and placed into the `subprojects/` directory.
+
+The `checkout` subcommand now always stash any pending changes before switching
+branch. Note that `update` subcommand was already stashing changes before updating
+the branch.
+
+If the command fails on any subproject the execution continues with other
+subprojects, but at the end an error code is now returned.
+
+The `update` subcommand has been reworked:
+- The `--rebase` behaviour is now the default for consistency: it was
+  already rebasing when current branch and revision are the same, it is
+  less confusing to rebase when they are different too.
+- Add `--reset` mode that checkout the new branch and hard reset that
+  branch to remote commit. This new mode guarantees that every
+  subproject are exactly at the wrap's revision.
+- Local changes are always stashed first to avoid any data loss. In the
+  worst case scenario the user can always check reflog and stash list to
+  rollback.

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -65,6 +65,17 @@ else:
     python_command = [sys.executable]
 meson_command = None
 
+class MesonException(Exception):
+    '''Exceptions thrown by Meson'''
+
+    file = None    # type: T.Optional[str]
+    lineno = None  # type: T.Optional[int]
+    colno = None   # type: T.Optional[int]
+
+
+class EnvironmentException(MesonException):
+    '''Exceptions thrown while processing and creating the build environment'''
+
 GIT = shutil.which('git')
 def git(cmd: T.List[str], workingdir: str, **kwargs: T.Any) -> subprocess.CompletedProcess:
     pc = subprocess.run([GIT, '-C', workingdir] + cmd,
@@ -131,19 +142,6 @@ def check_direntry_issues(direntry_array: T.Union[T.List[T.Union[str, bytes]], s
 # by accident.
 import threading
 an_unpicklable_object = threading.Lock()
-
-
-class MesonException(Exception):
-    '''Exceptions thrown by Meson'''
-
-    file = None    # type: T.Optional[str]
-    lineno = None  # type: T.Optional[int]
-    colno = None   # type: T.Optional[int]
-
-
-class EnvironmentException(MesonException):
-    '''Exceptions thrown while processing and creating the build environment'''
-
 
 class FileMode:
     # The first triad is for owner permissions, the second for group permissions,

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -88,6 +88,22 @@ def git(cmd: T.List[str], workingdir: str, **kwargs: T.Any) -> subprocess.Comple
     mlog.setup_console()
     return pc
 
+def quiet_git(cmd: T.List[str], workingdir: str) -> T.Tuple[bool, str]:
+    if not GIT:
+        return False, 'Git program not found.'
+    pc = git(cmd, workingdir, universal_newlines=True,
+             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if pc.returncode != 0:
+        return False, pc.stderr
+    return True, pc.stdout
+
+def verbose_git(cmd: T.List[str], workingdir: str, check: bool = False) -> bool:
+    if not GIT:
+        return False
+    try:
+        return git(cmd, workingdir, check=check).returncode == 0
+    except subprocess.CalledProcessError:
+        raise WrapException('Git command failed')
 
 def set_meson_command(mainfile: str) -> None:
     global python_command

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -45,7 +45,7 @@ def git_output(cmd, workingdir):
     return quiet_git(cmd, workingdir, check=True)[1]
 
 def git_stash(workingdir):
-    # Don't pipe stdout here because we want the user to see his changes have
+    # Don't pipe stdout here because we want the user to see their changes have
     # been saved.
     verbose_git(['stash'], workingdir, check=True)
 
@@ -118,7 +118,13 @@ def update_git(wrap, repo_dir, options):
         # It could be a detached git submodule for example.
         mlog.log('  -> No revision specified.')
         return True
-    branch = git_output(['branch', '--show-current'], repo_dir).strip()
+    try:
+        branch = git_output(['branch', '--show-current'], repo_dir).strip()
+    except GitException as e:
+        mlog.log('  -> Failed to determine current branch in', mlog.bold(repo_dir))
+        mlog.log(mlog.red(e.output))
+        mlog.log(mlog.red(str(e)))
+        return False
     # Fetch only the revision we need, this avoids fetching useless branches and
     # is needed for http case were new remote branches wouldn't be discovered
     # otherwise. After this command, FETCH_HEAD is the revision we want.

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -53,6 +53,10 @@ def update_git(wrap, repo_dir, options):
         mlog.log('  -> Not used.')
         return
     revision = wrap.get('revision')
+    if not revision:
+        # It could be a detached git submodule for example.
+        mlog.log('  -> No revision specified.')
+        return
     branch = git_output(['branch', '--show-current'], repo_dir).strip()
     if branch == '':
         try:
@@ -145,6 +149,9 @@ def checkout(wrap, repo_dir, options):
     if wrap.type != 'git' or not os.path.isdir(repo_dir):
         return
     branch_name = options.branch_name if options.branch_name else wrap.get('revision')
+    if not branch_name:
+        # It could be a detached git submodule for example.
+        return
     cmd = ['checkout', branch_name, '--']
     if options.b:
         cmd.insert(1, '-b')

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -189,6 +189,9 @@ def foreach(wrap, repo_dir, options):
 def add_common_arguments(p):
     p.add_argument('--sourcedir', default='.',
                    help='Path to source directory')
+    p.add_argument('--type', default='',
+                   choices=['file', 'git', 'hg', 'svn'],
+                   help='Only subprojects of given type (default: all)')
 
 def add_subprojects_argument(p):
     p.add_argument('subprojects', nargs='*',
@@ -245,6 +248,8 @@ def run(options):
     else:
         wraps = r.wraps.values()
     for wrap in wraps:
+        if options.type and wrap.type != options.type:
+            continue
         dirname = os.path.join(subprojects_dir, wrap.directory)
         options.subprojects_func(wrap, dirname, options)
     return 0

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -157,6 +157,9 @@ def checkout(wrap, repo_dir, options):
         cmd.insert(1, '-b')
     mlog.log('Checkout {} in {}...'.format(branch_name, wrap.name))
     try:
+        # Stash any pending changes. Don't use git_output() here because we want
+        # the user to see his changes have been saved.
+        git(['stash'], repo_dir, check=True, universal_newlines=True)
         git_output(cmd, repo_dir)
         git_show(repo_dir)
     except subprocess.CalledProcessError as e:

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -53,8 +53,8 @@ def update_git(wrap, repo_dir, options):
         mlog.log('  -> Not used.')
         return
     revision = wrap.get('revision')
-    ret = git_output(['rev-parse', '--abbrev-ref', 'HEAD'], repo_dir).strip()
-    if ret == 'HEAD':
+    branch = git_output(['branch', '--show-current'], repo_dir).strip()
+    if branch == '':
         try:
             # We are currently in detached mode, just checkout the new revision
             git_output(['fetch'], repo_dir)
@@ -65,7 +65,7 @@ def update_git(wrap, repo_dir, options):
             mlog.log(mlog.red(out))
             mlog.log(mlog.red(str(e)))
             return
-    elif ret == revision:
+    elif branch == revision:
         try:
             # We are in the same branch, pull latest commits
             git_output(['-c', 'rebase.autoStash=true', 'pull', '--rebase'], repo_dir)

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -30,7 +30,7 @@ import typing as T
 from pathlib import Path
 from . import WrapMode
 from .. import coredata
-from ..mesonlib import git, GIT, ProgressBar, MesonException
+from ..mesonlib import verbose_git, quiet_git, GIT, ProgressBar, MesonException
 
 if T.TYPE_CHECKING:
     import http.client
@@ -48,23 +48,6 @@ except ImportError:
 REQ_TIMEOUT = 600.0
 SSL_WARNING_PRINTED = False
 WHITELIST_SUBDOMAIN = 'wrapdb.mesonbuild.com'
-
-def quiet_git(cmd: T.List[str], workingdir: str) -> T.Tuple[bool, str]:
-    if not GIT:
-        return False, 'Git program not found.'
-    pc = git(cmd, workingdir, universal_newlines=True,
-             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    if pc.returncode != 0:
-        return False, pc.stderr
-    return True, pc.stdout
-
-def verbose_git(cmd: T.List[str], workingdir: str, check: bool = False) -> bool:
-    if not GIT:
-        return False
-    try:
-        return git(cmd, workingdir, check=check).returncode == 0
-    except subprocess.CalledProcessError:
-        raise WrapException('Git command failed')
 
 def whitelist_wrapdb(urlstr: str) -> urllib.parse.ParseResult:
     """ raises WrapException if not whitelisted subdomain """

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -49,6 +49,8 @@ REQ_TIMEOUT = 600.0
 SSL_WARNING_PRINTED = False
 WHITELIST_SUBDOMAIN = 'wrapdb.mesonbuild.com'
 
+ALL_TYPES = ['file', 'git', 'hg', 'svn']
+
 def whitelist_wrapdb(urlstr: str) -> urllib.parse.ParseResult:
     """ raises WrapException if not whitelisted subdomain """
     url = urllib.parse.urlparse(urlstr)
@@ -106,6 +108,8 @@ class PackageDefinition:
         self.directory = self.values.get('directory', self.name)
         if os.path.dirname(self.directory):
             raise WrapException('Directory key must be a name and not a path')
+        if self.type and self.type not in ALL_TYPES:
+            raise WrapException('Unknown wrap type {!r}'.format(self.type))
 
     def guess_type(self) -> None:
         if os.path.exists(os.path.join(self.filename, '.git')):

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -118,9 +118,21 @@ class PackageDefinition:
         self.provided_deps[self.name] = None
         if fname.endswith('.wrap'):
             self.parse_wrap(fname)
+        else:
+            self.guess_type();
         self.directory = self.values.get('directory', self.name)
         if os.path.dirname(self.directory):
             raise WrapException('Directory key must be a name and not a path')
+
+    def guess_type(self) -> None:
+        if os.path.exists(os.path.join(self.filename, '.git')):
+            # This is a git subproject without wrap file. Either the user cloned
+            # it manually, or it's a git submodule. The revision is used in
+            # msubprojects.py to update the git repo. If it's a submodule the repo
+            # is likely detached and revision will be empty.
+            res, stdout = quiet_git(['branch', '--show-current'], self.filename)
+            self.values['revision'] = stdout.strip()
+            self.type = 'git'
 
     def parse_wrap(self, fname: str) -> None:
         try:


### PR DESCRIPTION
    Besides refactoring code into smaller functions:
    - Makes the --rebase behaviour the default for consistency: it was
      already rebasing when current branch and revision are the same, it is
      less confusing to rebase when they are different too.
    - Add --reset mode that checkout the new branch and hard reset that
      branch to remote commit. This new mode guarantees that every
      subproject are exactly at the wrap's revision.
    - Local changes are always stashed first to avoid any data loss. In the
      worst case scenario the user can always check reflog and stash list to
      rollback.
    
    Fixes: #7526
