### PR TITLE
Use uname -p to detect x86_64 on QNX.

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -337,7 +337,7 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
     """
     if mesonlib.is_windows():
         trial = detect_windows_arch(compilers)
-    elif mesonlib.is_freebsd() or mesonlib.is_netbsd() or mesonlib.is_openbsd():
+    elif mesonlib.is_freebsd() or mesonlib.is_netbsd() or mesonlib.is_openbsd() or mesonlib.is_qnx():
         trial = platform.processor().lower()
     else:
         trial = platform.machine().lower()

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -527,6 +527,8 @@ def is_irix() -> bool:
 def is_hurd() -> bool:
     return platform.system().lower() == 'gnu'
 
+def is_qnx() -> bool:
+    return platform.system().lower() == 'qnx'
 
 def exe_exists(arglist: T.List[str]) -> bool:
     try:


### PR DESCRIPTION
On QNX/x86_64 "uname -m" reports "x86pc" (for both the 32- and 64 bit variants of x86). To see the actual architecture name we need to use "uname -p", like the *BSDs.