### PR TITLE
cmake: Detect custom command targets in compiler args

### DIFF
--- a/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
@@ -134,6 +134,16 @@ add_custom_target(args_test_cmd
 )
 add_custom_target(macro_name_cmd COMMAND macro_name)
 
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+  message(STATUS "Running the -include test case on macro_name")
+  add_custom_command(
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cpyInc.hpp"
+    COMMAND mycpy "${CMAKE_CURRENT_SOURCE_DIR}/cpyInc.hpp.am" "${CMAKE_CURRENT_BINARY_DIR}/cpyInc.hpp"
+    DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/cpyInc.hpp.am"
+  )
+  target_compile_options(macro_name PUBLIC -DTEST_CMD_INCLUDE -include "${CMAKE_CURRENT_BINARY_DIR}/cpyInc.hpp")
+endif()
+
 # Only executable targets are replaced in the command
 # all other target names are kept as is
 add_custom_target(clang-format COMMAND clang-format -i cmMod.cpp)

--- a/test cases/cmake/8 custom command/subprojects/cmMod/cpyInc.hpp.am
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/cpyInc.hpp.am
@@ -1,0 +1,3 @@
+#pragma once
+
+#define CPY_INC_WAS_INCLUDED 1

--- a/test cases/cmake/8 custom command/subprojects/cmMod/macro_name.cpp
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/macro_name.cpp
@@ -5,6 +5,12 @@
 
 using namespace std;
 
+#ifdef TEST_CMD_INCLUDE
+#if CPY_INC_WAS_INCLUDED != 1
+#error "cpyInc.hpp was not included"
+#endif
+#endif
+
 int main() {
   this_thread::sleep_for(chrono::seconds(1));
   ofstream out1("macro_name.txt");


### PR DESCRIPTION
This is required to make `-include /path/to/custom/target.hpp` work. This setup is used by wxWidgets and this PR is required to use wxWidgets as a CMake subproject.