### PR TITLE
Add AIX support

### DIFF
--- a/docs/markdown/snippets/aix.md
+++ b/docs/markdown/snippets/aix.md
@@ -1,0 +1,8 @@
+## Preliminary AIX support
+
+AIX is now supported when compiling with gcc. A number of features are not
+supported yet. For example, only gcc is supported (not xlC). Archives with both
+32-bit and 64-bit dynamic libraries are not generated automatically. The rpath
+includes both the build and install rpath, no attempt is made to change the
+rpath at install time. Most advanced features (eg. link\_whole) are not
+supported yet.

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -1033,7 +1033,7 @@ class CLikeCompiler:
         if ((not extra_dirs and libtype is LibType.PREFER_SHARED) or
                 libname in self.internal_libs):
             cargs = ['-l' + libname]
-            largs = self.get_allow_undefined_link_args()
+            largs = self.get_linker_always_args() + self.get_allow_undefined_link_args()
             extra_args = cargs + self.linker_to_compiler_args(largs)
 
             if self.links(code, env, extra_args=extra_args, disable_cache=True)[0]:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -337,7 +337,7 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
     """
     if mesonlib.is_windows():
         trial = detect_windows_arch(compilers)
-    elif mesonlib.is_freebsd() or mesonlib.is_netbsd() or mesonlib.is_openbsd() or mesonlib.is_qnx():
+    elif mesonlib.is_freebsd() or mesonlib.is_netbsd() or mesonlib.is_openbsd() or mesonlib.is_qnx() or mesonlib.is_aix():
         trial = platform.processor().lower()
     else:
         trial = platform.machine().lower()
@@ -377,6 +377,10 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
         # ATM there is no 64 bit userland for PA-RISC. Thus always
         # report it as 32 bit for simplicity.
         trial = 'parisc'
+    elif trial == 'ppc':
+        # AIX always returns powerpc, check here for 64-bit
+        if any_compiler_has_define(compilers, '__64BIT__'):
+            trial = 'ppc64'
 
     if trial not in known_cpu_families:
         mlog.warning('Unknown CPU family {!r}, please report this at '
@@ -388,7 +392,7 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
 def detect_cpu(compilers: CompilersDict):
     if mesonlib.is_windows():
         trial = detect_windows_arch(compilers)
-    elif mesonlib.is_freebsd() or mesonlib.is_netbsd() or mesonlib.is_openbsd():
+    elif mesonlib.is_freebsd() or mesonlib.is_netbsd() or mesonlib.is_openbsd() or mesonlib.is_aix():
         trial = platform.processor().lower()
     else:
         trial = platform.machine().lower()

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -19,7 +19,7 @@ import typing as T
 import collections
 
 from . import coredata
-from .linkers import ArLinker, ArmarLinker, VisualStudioLinker, DLinker, CcrxLinker, Xc16Linker, C2000Linker, IntelVisualStudioLinker
+from .linkers import ArLinker, ArmarLinker, VisualStudioLinker, DLinker, CcrxLinker, Xc16Linker, C2000Linker, IntelVisualStudioLinker, AIXArLinker
 from . import mesonlib
 from .mesonlib import (
     MesonException, EnvironmentException, MachineChoice, Popen_safe,
@@ -1940,7 +1940,7 @@ class Environment:
             if p.returncode == 1 and err.startswith('usage'): # OSX
                 return ArLinker(linker)
             if p.returncode == 1 and err.startswith('Usage'): # AIX
-                return ArLinker(linker)
+                return AIXArLinker(linker)
             if p.returncode == 1 and err.startswith('ar: bad option: --'): # Solaris
                 return ArLinker(linker)
         self._handle_exceptions(popen_exceptions, linkers, 'linker')

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -61,6 +61,7 @@ from .linkers import (
     PGIDynamicLinker,
     PGIStaticLinker,
     SolarisDynamicLinker,
+    AIXDynamicLinker,
     XilinkDynamicLinker,
     CudaLinker,
     VisualStudioLikeLinkerMixin,
@@ -1092,6 +1093,14 @@ class Environment:
             linker = SolarisDynamicLinker(
                 compiler, for_machine, comp_class.LINKER_PREFIX, override,
                 version=v)
+        elif 'ld: 0706-012 The -- flag is not recognized' in e:
+            if isinstance(comp_class.LINKER_PREFIX, str):
+                _, _, e = Popen_safe(compiler + [comp_class.LINKER_PREFIX + '-V'] + extra_args)
+            else:
+                _, _, e = Popen_safe(compiler + comp_class.LINKER_PREFIX + ['-V'] + extra_args)
+            linker = AIXDynamicLinker(
+                compiler, for_machine, comp_class.LINKER_PREFIX, override,
+                version=search_version(e))
         else:
             raise EnvironmentException('Unable to determine dynamic linker')
         return linker

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -247,6 +247,18 @@ class C2000Linker(StaticLinker):
         return ['-r']
 
 
+class AIXArLinker(ArLinker):
+
+    def __init__(self, exelist: T.List[str]):
+        StaticLinker.__init__(self, exelist)
+        self.id = 'aixar'
+        self.std_args = ['-csr', '-Xany']
+
+    def can_linker_accept_rsp(self) -> bool:
+        # AIXAr can't accept arguments using the @rsp syntax
+        return False
+
+
 def prepare_rpaths(raw_rpaths: str, build_dir: str, from_dir: str) -> T.List[str]:
     # The rpaths we write must be relative if they point to the build dir,
     # because otherwise they have different length depending on the build

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -1141,6 +1141,38 @@ class SolarisDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
         return self._apply_prefix('-soname,{}{}.{}{}'.format(prefix, shlib_name, suffix, sostr))
 
 
+class AIXDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
+
+    """Sys-V derived linker used on AIX"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__('ld.aix', *args, **kwargs)
+
+    def get_always_args(self) -> T.List[str]:
+        return self._apply_prefix(['-bsvr4', '-bnoipath', '-bbigtoc']) + super().get_always_args()
+
+    def no_undefined_args(self) -> T.List[str]:
+        return self._apply_prefix(['-z', 'defs'])
+
+    def get_allow_undefined_args(self) -> T.List[str]:
+        return self._apply_prefix(['-z', 'nodefs'])
+
+    def build_rpath_args(self, env: 'Environment', build_dir: str, from_dir: str,
+                         rpath_paths: str, build_rpath: str,
+                         install_rpath: str) -> T.Tuple[T.List[str], T.Set[bytes]]:
+        all_paths = mesonlib.OrderedSet(['/opt/freeware/lib']) # for libgcc_s.a
+        for p in rpath_paths:
+            all_paths.add(os.path.join(build_dir, p))
+        if build_rpath != '':
+            all_paths.add(build_rpath)
+        if install_rpath != '':
+            all_paths.add(install_rpath)
+        return (self._apply_prefix([x for p in all_paths for x in ('-R', p)]), set())
+
+    def thread_flags(self, env: 'Environment') -> T.List[str]:
+        return ['-pthread']
+
+
 class OptlinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
 
     """Digital Mars dynamic linker for windows."""

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -530,6 +530,9 @@ def is_hurd() -> bool:
 def is_qnx() -> bool:
     return platform.system().lower() == 'qnx'
 
+def is_aix() -> bool:
+    return platform.system().lower() == 'aix'
+
 def exe_exists(arglist: T.List[str]) -> bool:
     try:
         if subprocess.run(arglist, timeout=10).returncode == 0:


### PR DESCRIPTION
This patch series is enough to get simple AIX builds working with gcc. More complex builds (eg. link_whole) might not even exist in the AIX world, although I admit I didn't look too closely because I don't need those things myself. Support for the xlC compiler and AIX-style fat libraries are intentionally omitted. AIX intentionally not added to the documentation due to these omissions. I'm happy to add a patch that adds AIX to the docs if you like.

I baked both build_rpath and install_rpath in at build time because AIX uses XCOFF (not ELF), so I didn't know if the meson built-in rpath install adjustment would work.

Suggestions for improvement appreciated.