### PR TITLE
add testcase for issue #5182

### DIFF
--- a/test cases/common/23 object extraction/meson.build
+++ b/test cases/common/23 object extraction/meson.build
@@ -9,12 +9,15 @@ else
   obj1 = lib1.extract_objects('src/lib.c')
   obj2 = lib2.extract_objects(['lib.c'])
   obj3 = lib2.extract_objects(files('lib.c'))
+  obj4 = lib2.extract_objects(['lib.c', 'lib.c'])
 
   e1 = executable('main1', 'main.c', objects : obj1)
   e2 = executable('main2', 'main.c', objects : obj2)
   e3 = executable('main3', 'main.c', objects : obj3)
+  e4 = executable('main4', 'main.c', objects : obj4)
 
   test('extraction test 1', e1)
   test('extraction test 2', e2)
   test('extraction test 3', e3)
+  test('extraction test 4', e4)
 endif


### PR DESCRIPTION
Issue #5182 (" extract_objects returns duplicate objects") has been fixed.
Add a testcase to ensure it does not regress.