### PR TITLE
mtest: Allow filtering tests by subproject

### DIFF
--- a/docs/markdown/snippets/mtest_test_list_subprojects.md
+++ b/docs/markdown/snippets/mtest_test_list_subprojects.md
@@ -1,0 +1,18 @@
+## `meson test` can now filter tests by subproject
+
+You could always specify a list of tests to run by passing the names as
+arguments to `meson test`. If there were multiple tests with that name (in the
+same project or different subprojects), all of them would be run. Now you can:
+
+1. Run all tests with the specified name from a specific subproject: `meson test subprojname:testname`
+1. Run all tests defined in a specific subproject: `meson test subprojectname:`
+
+As before, these can all be specified multiple times and mixed:
+
+```sh
+# Run:
+# * All tests called 'name1' or 'name2' and
+# * All tests called 'name3' in subproject 'bar' and
+# * All tests in subproject 'foo'
+$ meson test name1 name2 bar:name3 foo:
+```

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -4074,8 +4074,13 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
     def add_test(self, node, args, kwargs, is_base_test):
         if len(args) != 2:
             raise InterpreterException('test expects 2 arguments, {} given'.format(len(args)))
-        if not isinstance(args[0], str):
+        name = args[0]
+        if not isinstance(name, str):
             raise InterpreterException('First argument of test must be a string.')
+        if ':' in name:
+            mlog.deprecation('":" is not allowed in test name "{}", it has been replaced with "_"'.format(name),
+                             location=node)
+            name = name.replace(':', '_')
         exe = args[1]
         if not isinstance(exe, (ExecutableHolder, JarHolder, ExternalProgramHolder)):
             if isinstance(exe, mesonlib.File):
@@ -4120,14 +4125,14 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         priority = kwargs.get('priority', 0)
         if not isinstance(priority, int):
             raise InterpreterException('Keyword argument priority must be an integer.')
-        t = Test(args[0], prj, suite, exe.held_object, depends, par, cmd_args,
+        t = Test(name, prj, suite, exe.held_object, depends, par, cmd_args,
                  env, should_fail, timeout, workdir, protocol, priority)
         if is_base_test:
             self.build.tests.append(t)
-            mlog.debug('Adding test', mlog.bold(args[0], True))
+            mlog.debug('Adding test', mlog.bold(name, True))
         else:
             self.build.benchmarks.append(t)
-            mlog.debug('Adding benchmark', mlog.bold(args[0], True))
+            mlog.debug('Adding benchmark', mlog.bold(name, True))
 
     @FeatureNewKwargs('install_headers', '0.47.0', ['install_mode'])
     @permittedKwargs(permitted_kwargs['install_headers'])


### PR DESCRIPTION
You could always specify a list of tests to run by passing the names as arguments to `meson test`. If there were multiple tests with that name (in the same project or different subprojects), all of them would be run. Now you can:

1. Run all tests with the specified name from a specific subproject: `meson test subprojname:testname`
1. Run all tests defined in a specific subproject: `meson test subprojectname:`

Also forbid ':' in test names. We already forbid this elsewhere, so should not be a big deal.