### PR TITLE
Special case meson.version().version_compare() statement

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -30,7 +30,7 @@ from .interpreterbase import check_stringlist, flatten, noPosargs, noKwargs, str
 from .interpreterbase import InterpreterException, InvalidArguments, InvalidCode, SubdirDoneRequest
 from .interpreterbase import InterpreterObject, MutableInterpreterObject, Disabler, disablerIfNotFound
 from .interpreterbase import FeatureNew, FeatureDeprecated, FeatureNewKwargs, FeatureDeprecatedKwargs
-from .interpreterbase import ObjectHolder
+from .interpreterbase import ObjectHolder, MesonVersionString
 from .modules import ModuleReturnValue
 from .cmake import CMakeInterpreter
 from .backend.backends import TestProtocol
@@ -2172,7 +2172,7 @@ class MesonMain(InterpreterObject):
     @noPosargs
     @permittedKwargs({})
     def version_method(self, args, kwargs):
-        return coredata.version
+        return MesonVersionString(coredata.version)
 
     @noPosargs
     @permittedKwargs({})

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -458,7 +458,7 @@ class InterpreterBase:
         # meson.version().compare_version(version_string)
         # If it was part of a if-clause, it is used to temporally override the
         # current meson version target within that if-block.
-        self.tmp_meson_version = None # type: str
+        self.tmp_meson_version = None # type: T.Optional[str]
 
     def load_root_meson_file(self) -> None:
         mesonfile = os.path.join(self.source_root, self.subdir, environment.build_filename)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5094,6 +5094,11 @@ recommended as it is not supported on some platforms''')
         self.init(testdir)
         self.build()
 
+    def test_meson_version_compare(self):
+        testdir = os.path.join(self.unit_test_dir, '82 meson version compare')
+        out = self.init(testdir)
+        self.assertNotRegex(out, r'WARNING')
+
 class FailureTests(BasePlatformTests):
     '''
     Tests that test failure conditions. Build files here should be dynamically

--- a/test cases/unit/82 meson version compare/meson.build
+++ b/test cases/unit/82 meson version compare/meson.build
@@ -1,0 +1,17 @@
+project('version compare', meson_version: '>= 0.1')
+
+if meson.version().version_compare('>= 9999')
+  error('This should not be executed')
+elif meson.version().version_compare('>= 0.55') and false
+  error('This should not be executed')
+elif not meson.version().version_compare('>= 0.55')
+  error('This should not be executed')
+elif meson.version().version_compare('>= 0.55')
+  # This Should not produce warning even when using function not available in
+  # meson 0.1.
+  foo_dep = declare_dependency()
+  meson.override_dependency('foo', foo_dep)
+endif
+
+# This will error out if elif cause did not enter
+assert(foo_dep.found(), 'meson.version_compare did not work')


### PR DESCRIPTION
    when that statement gets evaluated, the interpreter remembers the
    version target and if it was part of the evaluation of a `if` condition
    then the target meson version is temporally overriden within that
    if-block.

Fixes: #7590