### PR TITLE
Fix option handling in machine files

### DIFF
--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -28,7 +28,6 @@ import textwrap
 from .. import mlog, mesonlib
 from ..mesonlib import PerMachine, Popen_safe, version_compare, MachineChoice
 from ..environment import Environment
-from ..envconfig import get_env_var
 
 if T.TYPE_CHECKING:
     from ..dependencies.base import ExternalProgram
@@ -89,21 +88,6 @@ class CMakeExecutor:
             return
 
         self.prefix_paths = self.environment.coredata.builtins_per_machine[self.for_machine]['cmake_prefix_path'].value
-        env_pref_path = get_env_var(
-            self.for_machine,
-            self.environment.is_cross_build(),
-            'CMAKE_PREFIX_PATH')
-        if env_pref_path is not None:
-            if mesonlib.is_windows():
-                # Cannot split on ':' on Windows because its in the drive letter
-                env_pref_path = env_pref_path.split(os.pathsep)
-            else:
-                # https://github.com/mesonbuild/meson/issues/7294
-                env_pref_path = re.split(r':|;', env_pref_path)
-            env_pref_path = [x for x in env_pref_path if x]  # Filter out empty strings
-            if not self.prefix_paths:
-                self.prefix_paths = []
-            self.prefix_paths += env_pref_path
 
         if self.prefix_paths:
             self.extra_cmake_args += ['-DCMAKE_PREFIX_PATH={}'.format(';'.join(self.prefix_paths))]

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -17,7 +17,6 @@ import typing as T
 
 from .. import coredata
 from ..mesonlib import MachineChoice, MesonException, mlog, version_compare
-from ..linkers import LinkerEnvVarsMixin
 from .c_function_attributes import C_FUNC_ATTRIBUTES
 from .mixins.clike import CLikeCompiler
 from .mixins.ccrx import CcrxCompiler
@@ -149,7 +148,7 @@ class AppleClangCCompiler(ClangCCompiler):
     _C18_VERSION = '>=11.0.0'
 
 
-class EmscriptenCCompiler(EmscriptenMixin, LinkerEnvVarsMixin, ClangCCompiler):
+class EmscriptenCCompiler(EmscriptenMixin, ClangCCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross: bool, info: 'MachineInfo', exe_wrapper=None, **kwargs):
         if not is_cross:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -892,10 +892,8 @@ def get_global_options(lang: str, comp: T.Type[Compiler], for_machine: MachineCh
     return {
         'args': coredata.UserArrayOption(
             description + ' compiler',
-            env.compiler_options[for_machine][lang].get('args', []),
-            split_args=True, user_input=True, allow_dups=True),
+            [], split_args=True, user_input=True, allow_dups=True),
         'link_args': coredata.UserArrayOption(
             description + ' linker',
-            env.compiler_options[for_machine][lang].get('link_args', []),
-            split_args=True, user_input=True, allow_dups=True),
+            [], split_args=True, user_input=True, allow_dups=True),
     }

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -21,7 +21,6 @@ from .. import coredata
 from .. import mlog
 from ..mesonlib import MesonException, MachineChoice, version_compare
 
-from ..linkers import LinkerEnvVarsMixin
 from .compilers import (
     gnu_winlibs,
     msvc_winlibs,
@@ -218,7 +217,7 @@ class AppleClangCPPCompiler(ClangCPPCompiler):
         return ['-lc++']
 
 
-class EmscriptenCPPCompiler(EmscriptenMixin, LinkerEnvVarsMixin, ClangCPPCompiler):
+class EmscriptenCPPCompiler(EmscriptenMixin, ClangCPPCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,
                  is_cross: bool, info: 'MachineInfo', exe_wrapper=None, **kwargs):
         if not is_cross:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -800,9 +800,11 @@ class CoreData:
                 # We don't honor subproject options from one subproject to
                 # another, only from the superproject
                 if subproject:
+                    mlog.debug('Ignoring options for a subproject set in a different subproject.')
                     continue
 
                 subp, k = k.split(':')
+                mlog.deprecation('Setting subproject options in a super project\'s default options.', once=True)
             for machine in MachineChoice:
                 if machine is MachineChoice.BUILD and not self.is_cross_build():
                     continue

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -805,12 +805,7 @@ class CoreData:
         """Add global language arguments that are needed before compiler/linker detection."""
         from .compilers import compilers
 
-        for k, o in compilers.get_global_options(
-                lang,
-                comp,
-                for_machine,
-                env.is_cross_build(),
-                env.properties[for_machine]).items():
+        for k, o in compilers.get_global_options(lang, comp, for_machine, env).items():
             # prefixed compiler options affect just this machine
             if k in env.compiler_options[for_machine].get(lang, {}):
                 o.set_value(env.compiler_options[for_machine][lang][k])

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -763,7 +763,9 @@ class CoreData:
         # split arguments that can be set now, and those that cannot so they
         # can be set later, when they've been initialized.
         for k, v in default_options.items():
-            if k.startswith(lang_prefixes):
+            if ':' in k:
+                continue
+            elif k.startswith(lang_prefixes):
                 lang, key = k.split('_', 1)
                 for machine in MachineChoice:
                     if key not in env.compiler_options[machine][lang]:
@@ -792,11 +794,20 @@ class CoreData:
         for k, v in default_options.items():
             if k in BUILTIN_OPTIONS and not BUILTIN_OPTIONS[k].yielding:
                 continue
+
+            subp = subproject
+            if ':' in k:
+                # We don't honor subproject options from one subproject to
+                # another, only from the superproject
+                if subproject:
+                    continue
+
+                subp, k = k.split(':')
             for machine in MachineChoice:
                 if machine is MachineChoice.BUILD and not self.is_cross_build():
                     continue
-                if k not in env.meson_options[machine][subproject]:
-                    env.meson_options[machine][subproject][k] = v
+                if k not in env.meson_options[machine][subp]:
+                    env.meson_options[machine][subp][k] = v
 
         self.set_options(options, subproject=subproject)
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -139,6 +139,7 @@ COMPILER_OPTS_TO_ENV = {
 
 OTHER_OPTS_TO_ENV = {
     'pkg_config_path': 'PKG_CONFIG_PATH',
+    'cmake_prefix_path': 'CMAKE_PREFIX_PATH',
 }  # type: T.Dict[str, str]
 
 def detect_gcovr(min_version='3.3', new_rootdir_version='4.2', log=False):
@@ -649,9 +650,13 @@ class Environment:
                 if p_env_pair is not None:
                     p_env_var, p_env = p_env_pair
 
+                    if mesonlib.is_windows():
+                        splitter = lambda p: p.split(';')
+                    else:
+                        splitter = lambda p: re.split(r':|;', p)
                     # PKG_CONFIG_PATH may contain duplicates, which must be
                     # removed, else a duplicates-in-array-option warning arises.
-                    p_list = list(mesonlib.OrderedSet(p_env.split(':')))
+                    p_list = list(mesonlib.OrderedSet(splitter(p_env)))
 
                     # Environment variables override config
                     meson_options[for_machine][''][key] = p_list

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -18,7 +18,6 @@ import typing as T
 
 from . import mesonlib
 from .arglist import CompilerArgs
-from .envconfig import get_env_var
 
 if T.TYPE_CHECKING:
     from .coredata import OptionDictType
@@ -276,21 +275,7 @@ def evaluate_rpath(p: str, build_dir: str, from_dir: str) -> str:
     else:
         return os.path.relpath(os.path.join(build_dir, p), os.path.join(build_dir, from_dir))
 
-
-class LinkerEnvVarsMixin(metaclass=abc.ABCMeta):
-
-    """Mixin reading LDFLAGS from the environment."""
-
-    @staticmethod
-    def get_args_from_envvars(for_machine: mesonlib.MachineChoice,
-                              is_cross: bool) -> T.List[str]:
-        raw_value = get_env_var(for_machine, is_cross, 'LDFLAGS')
-        if raw_value is not None:
-            return mesonlib.split_args(raw_value)
-        else:
-            return []
-
-class DynamicLinker(LinkerEnvVarsMixin, metaclass=abc.ABCMeta):
+class DynamicLinker(metaclass=abc.ABCMeta):
 
     """Base class for dynamic linkers."""
 

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -431,8 +431,8 @@ class PerThreeMachine(PerMachine[_T]):
 class PerMachineDefaultable(PerMachine[T.Optional[_T]]):
     """Extends `PerMachine` with the ability to default from `None`s.
     """
-    def __init__(self):
-        super().__init__(None, None)
+    def __init__(self, build: T.Optional[_T] = None, host: T.Optional[_T] = None):
+        super().__init__(build, host)
 
     def default_missing(self) -> "PerMachine[T.Optional[_T]]":
         """Default host to build

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -8119,7 +8119,7 @@ class NativeFileTests(BasePlatformTests):
         else:
             self.fail('Did not find werror in build options?')
 
-    def test_builtin_options_env_overrides_conf(self):
+    def test_builtin_options_conf_overrides_env(self):
         testcase = os.path.join(self.common_test_dir, '2 cpp')
         config = self.helper_create_native_file({'built-in options': {'pkg_config_path': '/foo'}})
 
@@ -8127,7 +8127,7 @@ class NativeFileTests(BasePlatformTests):
         configuration = self.introspect('--buildoptions')
         for each in configuration:
             if each['name'] == 'pkg_config_path':
-                self.assertEqual(each['value'], ['/bar'])
+                self.assertEqual(each['value'], ['/foo'])
                 break
         else:
             self.fail('Did not find pkg_config_path in build options?')
@@ -8532,7 +8532,7 @@ class CrossFileTests(BasePlatformTests):
                 break
         self.assertEqual(found, 4, 'Did not find all sections.')
 
-    def test_builtin_options_env_overrides_conf(self):
+    def test_builtin_options_conf_overrides_env(self):
         testcase = os.path.join(self.common_test_dir, '2 cpp')
         config = self.helper_create_cross_file({'built-in options': {'pkg_config_path': '/foo'}})
         cross = self.helper_create_cross_file({'built-in options': {'pkg_config_path': '/foo'}})
@@ -8543,10 +8543,10 @@ class CrossFileTests(BasePlatformTests):
         found = 0
         for each in configuration:
             if each['name'] == 'pkg_config_path':
-                self.assertEqual(each['value'], ['/bar'])
+                self.assertEqual(each['value'], ['/foo'])
                 found += 1
             elif each['name'] == 'build.pkg_config_path':
-                self.assertEqual(each['value'], ['/dir'])
+                self.assertEqual(each['value'], ['/foo'])
                 found += 1
             if found == 2:
                 break
@@ -8854,7 +8854,7 @@ def unset_envs():
     # For unit tests we must fully control all command lines
     # so that there are no unexpected changes coming from the
     # environment, for example when doing a package build.
-    varnames = ['CPPFLAGS', 'LDFLAGS'] + list(mesonbuild.compilers.compilers.cflags_mapping.values())
+    varnames = ['CPPFLAGS', 'LDFLAGS'] + list(mesonbuild.environment.COMPILER_OPTS_TO_ENV.values())
     for v in varnames:
         if v in os.environ:
             del os.environ[v]

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -8538,8 +8538,8 @@ class CrossFileTests(BasePlatformTests):
 
     def test_builtin_options_conf_overrides_env(self):
         testcase = os.path.join(self.common_test_dir, '2 cpp')
-        config = self.helper_create_cross_file({'built-in options': {'pkg_config_path': '/foo', 'cpp_args': ['-Wno-foo']}})
-        cross = self.helper_create_cross_file({'built-in options': {'pkg_config_path': '/foo', 'cpp_args': ['-Wno-bar']}})
+        config = self.helper_create_cross_file({'built-in options': {'pkg_config_path': '/foo', 'cpp_args': ['-W']}})
+        cross = self.helper_create_cross_file({'built-in options': {'pkg_config_path': '/foo', 'cpp_args': ['-W']}})
 
         self.init(testcase, extra_args=['--native-file', config, '--cross-file', cross],
                   override_envvars={'PKG_CONFIG_PATH': '/bar', 'PKG_CONFIG_PATH_FOR_BUILD': '/dir',
@@ -8554,10 +8554,10 @@ class CrossFileTests(BasePlatformTests):
                 self.assertEqual(each['value'], ['/foo'])
                 found += 1
             elif each['name'] == 'cpp_args':
-                self.assertEqual(each['value'], ['-Wno-bar'])
+                self.assertEqual(each['value'], ['-W'])
                 found += 1
             elif each['name'] == 'build.cpp_args':
-                self.assertEqual(each['value'], ['-Wno-foo'])
+                self.assertEqual(each['value'], ['-W'])
                 found += 1
             if found == 4:
                 break

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -8907,12 +8907,11 @@ def _clang_at_least(compiler, minver: str, apple_minver: str) -> bool:
     return version_compare(compiler.version, minver)
 
 
-def unset_envs():
+def unset_envs() -> None:
     # For unit tests we must fully control all command lines
     # so that there are no unexpected changes coming from the
     # environment, for example when doing a package build.
-    varnames = ['CPPFLAGS', 'LDFLAGS'] + list(mesonbuild.environment.COMPILER_OPTS_TO_ENV.values())
-    for v in varnames:
+    for v in (e[0] for e in mesonbuild.environment.COMPILER_OPTS_TO_ENV):
         if v in os.environ:
             del os.environ[v]
 

--- a/test cases/common/230 persubproject options/meson.build
+++ b/test cases/common/230 persubproject options/meson.build
@@ -1,6 +1,7 @@
 project('persubproject options', 'c',
   default_options : ['default_library=both',
                      'werror=true',
+                     'sub1:werror=false',
                      'warning_level=3'])
 
 assert(get_option('default_library') == 'both', 'Parent default_library should be "both"')

--- a/test cases/common/230 persubproject options/subprojects/sub1/meson.build
+++ b/test cases/common/230 persubproject options/subprojects/sub1/meson.build
@@ -3,6 +3,7 @@ project('sub1', 'c',
 
 assert(get_option('default_library') == 'both', 'Should inherit parent project default_library')
 assert(get_option('warning_level') == '0')
+assert(get_option('werror') == false)
 
 # Check it build both by calling a method only both_libraries target implement
 lib = library('lib1', 'foo.c')


### PR DESCRIPTION
There are two distinct problems I'm aiming to fix:
1) environment variables vs config files

Currently this is handled rather haphazardly, resulting in environment variables overriding config in some, but not all cases. It should be this order (environment variables overriding config files) because that's the unix tradition, and doing anything else would violate the principle of least surprise)

2) Setting subproject options in the superproject default_options

I don't think we meant to allow this, but we did and it should continue to work. I've marked it for deprecation because we already have a documented way to do this via `subproject(..., default_options : ...)`, which is nicer anyway because you can control that in the flow of the program.

This is an alternative proposal to #7574

