### PR TITLE
find_library: Print type of library not found

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,8 +111,8 @@ jobs:
       displayName: Install Dependencies
     - script: |
         set PATH=%CYGWIN_ROOT%\bin;%SYSTEMROOT%\system32
-        env.exe -- python3 -m pip --disable-pip-version-check install gcovr pefile pytest-xdist jsonschema
-      displayName: pip install gcovr pefile pytest-xdist jsonschema
+        env.exe -- python3 -m pip --disable-pip-version-check install gcovr pefile jsonschema
+      displayName: "pip install gcovr pefile jsonschema (pytest-xdist broken, skipped: CHECK ME AGAIN)"
     - script: |
         set BOOST_ROOT=
         set PATH=%CYGWIN_ROOT%\bin;%SYSTEMROOT%\system32

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1637,8 +1637,13 @@ class CompilerHolder(InterpreterObject):
             libtype = mesonlib.LibType.STATIC if kwargs['static'] else mesonlib.LibType.SHARED
         linkargs = self.compiler.find_library(libname, self.environment, search_dirs, libtype)
         if required and not linkargs:
-            raise InterpreterException(
-                '{} library {!r} not found'.format(self.compiler.get_display_language(), libname))
+            if libtype == mesonlib.LibType.PREFER_SHARED:
+                libtype = 'shared or static'
+            else:
+                libtype = libtype.name.lower()
+            raise InterpreterException('{} {} library {!r} not found'
+                                       .format(self.compiler.get_display_language(),
+                                               libtype, libname))
         lib = dependencies.ExternalLibrary(libname, linkargs, self.environment,
                                            self.compiler.language)
         return ExternalLibraryHolder(lib, self.subproject)


### PR DESCRIPTION
If we can't find a static library, we should say that. It's confusing otherwise.