### PR TITLE
ninjabackend: Fix coverage rule generation

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -986,7 +986,7 @@ int dummy;
                                     self.build.get_subproject_dir()),
                        self.environment.get_build_dir(),
                        self.environment.get_log_dir()] +
-                      ['--use_llvm_cov'] if use_llvm_cov else [])
+                       (['--use_llvm_cov'] if use_llvm_cov else []))
 
     def generate_coverage_rules(self):
         e = NinjaBuildElement(self.all_outputs, 'meson-coverage', 'CUSTOM_COMMAND', 'PHONY')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4885,6 +4885,18 @@ recommended as it is not supported on some platforms''')
             m = get_data_pattern(command).search(md, pos=md_command_sections[command][0], endpos=md_command_sections[command][1])
             self.assertIsNotNone(m, 'Command `{}` is missing placeholders for dynamic data. Doc file: `{}`'.format(command, doc_path))
 
+    def _check_coverage_files(self, types=('text', 'xml', 'html')):
+        covdir = Path(self.builddir) / 'meson-logs'
+        files = []
+        if 'text' in types:
+            files.append('coverage.txt')
+        if 'xml' in types:
+            files.append('coverage.xml')
+        if 'html' in types:
+            files.append('coveragereport/index.html')
+        for f in files:
+            self.assertTrue((covdir / f).is_file(), msg='{} is not a file'.format(f))
+
     def test_coverage(self):
         if mesonbuild.environment.detect_msys2_arch():
             raise unittest.SkipTest('Skipped due to problems with coverage on MSYS2')
@@ -4903,6 +4915,7 @@ recommended as it is not supported on some platforms''')
         self.build()
         self.run_tests()
         self.run_target('coverage')
+        self._check_coverage_files()
 
     def test_coverage_complex(self):
         if mesonbuild.environment.detect_msys2_arch():
@@ -4922,6 +4935,7 @@ recommended as it is not supported on some platforms''')
         self.build()
         self.run_tests()
         self.run_target('coverage')
+        self._check_coverage_files()
 
     def test_coverage_html(self):
         if mesonbuild.environment.detect_msys2_arch():
@@ -4941,6 +4955,7 @@ recommended as it is not supported on some platforms''')
         self.build()
         self.run_tests()
         self.run_target('coverage-html')
+        self._check_coverage_files(['html'])
 
     def test_coverage_text(self):
         if mesonbuild.environment.detect_msys2_arch():
@@ -4960,6 +4975,7 @@ recommended as it is not supported on some platforms''')
         self.build()
         self.run_tests()
         self.run_target('coverage-text')
+        self._check_coverage_files(['text'])
 
     def test_coverage_xml(self):
         if mesonbuild.environment.detect_msys2_arch():
@@ -4979,6 +4995,7 @@ recommended as it is not supported on some platforms''')
         self.build()
         self.run_tests()
         self.run_target('coverage-xml')
+        self._check_coverage_files(['xml'])
 
     def test_cross_file_constants(self):
         with temp_filename() as crossfile1, temp_filename() as crossfile2:


### PR DESCRIPTION
Without the parenthesis, the command evaluates to `[]` if `use_llvm_cov` is `False`.

Also fix tests to actually check whether or not coverage reports are generated.

Fixes https://github.com/mesonbuild/meson/issues/7553