### PR TITLE
cmake/traceparser: warn user for too old cmake

### DIFF
--- a/docs/markdown/CMake-module.md
+++ b/docs/markdown/CMake-module.md
@@ -237,3 +237,11 @@ myProject.cmake.in:
 
 set(MYVAR VAR)
 ```
+
+### Additional hints
+
+Meson needs to parse the CMake build files in certain cases to mimic its behaviour, for example for the CMake function: `add_custom_command`.
+It therefore executes CMake and interprets its output.
+Before CMake 3.17, this output is ambiguous in some cases.
+Meson therefore needs to guess the correct meaning and may fail in doing this.
+If you encounter this problem, the recommended way is to upgrade CMake to a minimum version of 3.17.

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -655,6 +655,12 @@ class CMakeTraceParser:
         if self.trace_format != 'human':
             return broken_list
 
+        mlog.log_once(
+            'Detected version of CMake',
+            mlog.bold(self.cmake_version), 'is below 3.17.',
+            'This can cause problems in the build, see https://mesonbuild.com/CMake-module.html#additional-hints.'
+        )
+
         # Try joining file paths that contain spaces
 
         reg_start = re.compile(r'^([A-Za-z]:)?/(.*/)*[^./]+$')


### PR DESCRIPTION
CMake <3.17 is error prone in some cases. Warn the user about that.

I'm not entirely happy with this commit, since it results in a lot of warnings, because `_guess_files` is often called multiple times.
However, `_guess_files` is the place, where the errors can occur and Meson needs to guess and the warning will appear less and less in the future.

See also: #7601