### PR TITLE
interpreter: Don't used cache if fallback is forced

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3663,7 +3663,7 @@ external dependencies (including libraries) must go to "dependencies".''')
                                    'version\n requirements use the \'version\' keyword argument instead.')
 
         identifier, cached_dep = self._find_cached_dep(name, display_name, kwargs)
-        if cached_dep:
+        if cached_dep and name not in self.coredata.get_builtin_option('force_fallback_for'):
             if has_fallback:
                 dirname, varname = self.get_subproject_infos(kwargs)
                 self.verify_fallback_consistency(dirname, varname, cached_dep)


### PR DESCRIPTION
This PR fixes a bug where forcing fallback of dependencies doesn't work if that dependency is already cached.