### PR TITLE
backends: do not look for extra paths unnecessarily

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -350,18 +350,11 @@ class Backend:
         return obj_list
 
     def as_meson_exe_cmdline(self, tname, exe, cmd_args, workdir=None,
-                             for_machine=MachineChoice.BUILD,
                              extra_bdeps=None, capture=None, force_serialize=False):
         '''
         Serialize an executable for running with a generator or a custom target
         '''
         import hashlib
-        machine = self.environment.machines[for_machine]
-        if machine.is_windows() or machine.is_cygwin():
-            extra_paths = self.determine_windows_extra_paths(exe, extra_bdeps or [])
-        else:
-            extra_paths = []
-
         if isinstance(exe, dependencies.ExternalProgram):
             exe_cmd = exe.get_command()
             exe_for_machine = exe.for_machine
@@ -371,6 +364,12 @@ class Backend:
         else:
             exe_cmd = [exe]
             exe_for_machine = MachineChoice.BUILD
+
+        machine = self.environment.machines[exe_for_machine]
+        if machine.is_windows() or machine.is_cygwin():
+            extra_paths = self.determine_windows_extra_paths(exe, extra_bdeps or [])
+        else:
+            extra_paths = []
 
         is_cross_built = not self.environment.machines.matches_build_machine(exe_for_machine)
         if is_cross_built and self.environment.need_exe_wrapper():

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -875,7 +875,6 @@ int dummy;
                 elem.add_dep(os.path.join(self.get_target_dir(d), output))
 
         meson_exe_cmd = self.as_meson_exe_cmdline(target.name, target.command[0], cmd[1:],
-                                                  for_machine=target.for_machine,
                                                   extra_bdeps=target.get_transitive_build_target_deps(),
                                                   capture=ofilenames[0] if target.capture else None)
         if meson_exe_cmd:


### PR DESCRIPTION
extra_paths only matter for the host machine if using an exe_wrapper.
However, because CustomTarget.for_machine is always MachineChoice.HOST,
they were computed unnecessarily in as_meson_exe_cmdline.

Defer computation of extra_paths until after we have found out if the
custom target executable is really for the host or the build machine,
so that we can use exe_for_machine; for_machine then becomes unused
and can be removed.

Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>