### PR TITLE
Add newer C++ stds support for newer Elbrus compilers

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -365,9 +365,20 @@ class ElbrusCPPCompiler(GnuCPPCompiler, ElbrusCompiler):
                                 **kwargs)
         ElbrusCompiler.__init__(self)
 
-    # It does not support c++/gnu++ 17 and 1z, but still does support 0x, 1y, and gnu++98.
     def get_options(self):
         opts = CPPCompiler.get_options(self)
+
+        cpp_stds = [
+            'none', 'c++98', 'c++03', 'c++0x', 'c++11', 'c++14', 'c++1y',
+            'gnu++98', 'gnu++03', 'gnu++0x', 'gnu++11', 'gnu++14', 'gnu++1y',
+        ]
+
+        if version_compare(self.version, '>=1.24.00'):
+            cpp_stds += [ 'c++1z', 'c++17', 'gnu++1z', 'gnu++17' ]
+
+        if version_compare(self.version, '>=1.25.00'):
+            cpp_stds += [ 'c++2a', 'gnu++2a' ]
+
         opts.update({
             'eh': coredata.UserComboOption(
                 'C++ exception handling type.',
@@ -376,10 +387,7 @@ class ElbrusCPPCompiler(GnuCPPCompiler, ElbrusCompiler):
             ),
             'std': coredata.UserComboOption(
                 'C++ language standard to use',
-                [
-                    'none', 'c++98', 'c++03', 'c++0x', 'c++11', 'c++14', 'c++1y',
-                    'gnu++98', 'gnu++03', 'gnu++0x', 'gnu++11', 'gnu++14', 'gnu++1y',
-                ],
+                cpp_stds,
                 'none',
             ),
             'debugstl': coredata.UserBooleanOption(

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5054,7 +5054,8 @@ recommended as it is not supported on some platforms''')
         self.build()
         self.run_tests()
 
-    @unittest.skipUnless(is_linux(), 'Requires ASM compiler currently only available on Linux CI runners')
+    @unittest.skipUnless(is_linux() and (re.search('^i.86$|^x86$|^x64$|^x86_64$|^amd64$', platform.processor()) is not None),
+        'Requires ASM compiler for x86 or x86_64 platform currently only available on Linux CI runners')
     def test_nostdlib(self):
         testdir = os.path.join(self.unit_test_dir, '79 nostdlib')
         machinefile = os.path.join(self.builddir, 'machine.txt')


### PR DESCRIPTION
Since lcc support was introduced into meson, there were lcc 1.24 and lcc 1.25 major versions released, and they support newer C++ standards. This makes meson able to support them.

Also added a little hack that disables one of architecture dependent unit tests (it uses x86 assembler) on non-x86/x86_64 architectures.

`./run_unittests` produced the following results:
* Elbrus-8C, OS Elbrus 5.0-rc2, lcc:1.24.09: 311 passed, 57 skipped in 172.91s (0:02:52)
* i386, Ubuntu 18.04.4 LTS, gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0: 299 passed, 69 skipped in 1174.43s (0:19:34)
* x86_64, Ubuntu 18.04.5 LTS, gcc (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0: 320 passed, 48 skipped in 170.42 seconds
