### PR TITLE
simplify shutil usage by invoking copy2 where appropriate

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -4368,8 +4368,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
             if len(inputs_abs) != 1:
                 raise InterpreterException('Exactly one input file must be given in copy mode')
             os.makedirs(os.path.join(self.environment.build_dir, self.subdir), exist_ok=True)
-            shutil.copyfile(inputs_abs[0], ofile_abs)
-            shutil.copystat(inputs_abs[0], ofile_abs)
+            shutil.copy2(inputs_abs[0], ofile_abs)
         else:
             # Not reachable
             raise AssertionError

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -270,11 +270,9 @@ class Installer:
                 # Remove this entire branch when changing the behaviour to duplicate
                 # symlinks rather than copying what they point to.
                 print(symlink_warning)
-                shutil.copyfile(from_file, to_file)
-                shutil.copystat(from_file, to_file)
+                shutil.copy2(from_file, to_file)
         else:
-            shutil.copyfile(from_file, to_file)
-            shutil.copystat(from_file, to_file)
+            shutil.copy2(from_file, to_file)
         selinux_updates.append(to_file)
         append_to_log(self.lf, to_file)
         return True

--- a/mesonbuild/scripts/gettext.py
+++ b/mesonbuild/scripts/gettext.py
@@ -83,8 +83,7 @@ def do_install(src_sub, bld_sub, dest, pkgname, langs):
                                pkgname + '.mo')
         tempfile = outfile + '.tmp'
         os.makedirs(os.path.dirname(outfile), exist_ok=True)
-        shutil.copyfile(srcfile, tempfile)
-        shutil.copystat(srcfile, tempfile)
+        shutil.copy2(srcfile, tempfile)
         os.replace(tempfile, outfile)
         print('Installing %s to %s' % (srcfile, outfile))
     return 0

--- a/mesonbuild/scripts/yelphelper.py
+++ b/mesonbuild/scripts/yelphelper.py
@@ -68,8 +68,7 @@ def install_help(srcdir, blddir, sources, media, langs, install_dir, destdir, pr
             infile = os.path.join(srcdir if lang == 'C' else blddir, lang, source)
             outfile = os.path.join(indir, source)
             mlog.log('Installing %s to %s' % (infile, outfile))
-            shutil.copyfile(infile, outfile)
-            shutil.copystat(infile, outfile)
+            shutil.copy2(infile, outfile)
         for m in media:
             infile = os.path.join(srcdir, lang, m)
             outfile = os.path.join(indir, m)


### PR DESCRIPTION
It's equivalent to copyfile + copystat with the same arguments.

See https://github.com/mesonbuild/meson/pull/7442#discussion_r472228122