### PR TITLE
Detecting ninja as ninja_args for support python wrapper of ninja on …

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -548,7 +548,7 @@ int dummy;
                 rules += [ "%s%s" % (rule, ext) for rule in [self.get_pch_rule_name(lang, for_machine)]
                                                 for ext in ['', '_RSP']]
         compdb_options = ['-x'] if mesonlib.version_compare(self.ninja_version, '>=1.9') else []
-        ninja_compdb = [self.ninja_command, '-t', 'compdb'] + compdb_options + rules
+        ninja_compdb = self.ninja_command + ['-t', 'compdb'] + compdb_options + rules
         builddir = self.environment.get_build_dir()
         try:
             jsondb = subprocess.check_output(ninja_compdb, cwd=builddir)
@@ -2959,7 +2959,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         self.add_build(elem)
 
         elem = NinjaBuildElement(self.all_outputs, 'meson-clean', 'CUSTOM_COMMAND', 'PHONY')
-        elem.add_item('COMMAND', [self.ninja_command, '-t', 'clean'])
+        elem.add_item('COMMAND', self.ninja_command + ['-t', 'clean'])
         elem.add_item('description', 'Cleaning')
         # Alias that runs the above-defined meson-clean target
         self.create_target_alias('meson-clean')

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -174,8 +174,10 @@ def detect_ninja(version: str = '1.7', log: bool = False) -> str:
 def detect_ninja_command_and_version(version: str = '1.7', log: bool = False) -> (str, str):
     env_ninja = os.environ.get('NINJA', None)
     for n in [env_ninja] if env_ninja else ['ninja', 'ninja-build', 'samu']:
+        ninja_args = shlex.split(n)
+        ninja_version_args = ninja_args + ['--version']
         try:
-            p, found = Popen_safe([n, '--version'])[0:2]
+            p, found = Popen_safe(ninja_version_args)[0:2]
         except (FileNotFoundError, PermissionError):
             # Doesn't exist in PATH or isn't executable
             continue
@@ -183,7 +185,7 @@ def detect_ninja_command_and_version(version: str = '1.7', log: bool = False) ->
         # Perhaps we should add a way for the caller to know the failure mode
         # (not found or too old)
         if p.returncode == 0 and mesonlib.version_compare(found, '>=' + version):
-            n = shutil.which(n)
+            n = shutil.which(ninja_args[-1])
             if log:
                 name = os.path.basename(n)
                 if name.endswith('-' + found):
@@ -193,7 +195,7 @@ def detect_ninja_command_and_version(version: str = '1.7', log: bool = False) ->
                 if name == 'samu':
                     name = 'samurai'
                 mlog.log('Found {}-{} at {}'.format(name, found, quote_arg(n)))
-            return (n, found)
+            return (ninja_args, found)
 
 def get_llvm_tool_names(tool: str) -> T.List[str]:
     # Ordered list of possible suffixes of LLVM executables to try. Start with

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -139,7 +139,7 @@ def get_parsed_args_ninja(options: 'argparse.Namespace', builddir: Path) -> T.Li
         raise MesonException('Cannot find ninja.')
     mlog.log('Found runner:', runner)
 
-    cmd = [runner, '-C', builddir.as_posix()]
+    cmd = runner + ['-C', builddir.as_posix()]
 
     if options.targets:
         intro_data = parse_introspect_data(builddir)

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -174,7 +174,7 @@ def run(options) -> int:
         ret = subprocess.run(cmd)
         if ret.returncode:
             raise SystemExit
-        cmd = [detect_ninja(), '-C', options.builddir]
+        cmd = detect_ninja() + ['-C', options.builddir]
         ret = subprocess.run(cmd)
         if ret.returncode:
             raise SystemExit

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1179,7 +1179,7 @@ def rebuild_all(wd: str) -> bool:
         print("Can't find ninja, can't rebuild test.")
         return False
 
-    ret = subprocess.run([ninja, '-C', wd]).returncode
+    ret = subprocess.run(ninja + ['-C', wd]).returncode
     if ret != 0:
         print('Could not rebuild {}'.format(wd))
         return False

--- a/mesonbuild/scripts/scanbuild.py
+++ b/mesonbuild/scripts/scanbuild.py
@@ -22,7 +22,7 @@ from ..environment import detect_ninja, detect_scanbuild
 def scanbuild(exelist, srcdir, blddir, privdir, logdir, args):
     with tempfile.TemporaryDirectory(dir=privdir) as scandir:
         meson_cmd = exelist + args
-        build_cmd = exelist + ['-o', logdir, detect_ninja(), '-C', scandir]
+        build_cmd = exelist + ['-o', logdir] + detect_ninja() + ['-C', scandir]
         rc = subprocess.call(meson_cmd + [srcdir, scandir])
         if rc != 0:
             return rc


### PR DESCRIPTION
…Windows such as 'python3', '-B', 'E:/abspath/qemu.org-x64/ninjatool' This is used for fixing the building of qemu in msys2/mingw64/mingw32 on Windows.

QEMU need somethings like this
```
if [ "$MSYSTEM" = "MINGW64" -o  "$MSYSTEM" = "MINGW32" ]; then
PWD_WIN=`pwd -W`
NINJA_TOOL=$PWD_WIN/ninjatool
else
NINJA_TOOL=$PWD/ninjatool
fi
NINJA="$python $NINJA_TOOL" $meson setup \
        --prefix "${pre_prefix}$prefix" \
        --libdir "${pre_prefix}$libdir" \
        --libexecdir "${pre_prefix}$libexecdir" \
        --bindir "${pre_prefix}$bindir" \
        --includedir "${pre_prefix}$includedir" \
        --datadir "${pre_prefix}$datadir" \
        --mandir "${pre_prefix}$mandir" \
        --sysconfdir "${pre_prefix}$sysconfdir" \
        --localstatedir "${pre_prefix}$local_statedir" \
        -Doptimization=$(if test "$debug" = yes; then echo 0; else echo 2; fi) \
        -Ddebug=$(if test "$debug_info" = yes; then echo true; else echo false; fi) \
        -Dwerror=$(if test "$werror" = yes; then echo true; else echo false; fi) \
        -Dstrip=$(if test "$strip_opt" = yes; then echo true; else echo false; fi) \
        -Db_pie=$(if test "$pie" = yes; then echo true; else echo false; fi) \
        -Db_coverage=$(if test "$gcov" = yes; then echo true; else echo false; fi) \
	-Dsdl=$sdl -Dsdl_image=$sdl_image \
	-Dvnc=$vnc -Dvnc_sasl=$vnc_sasl -Dvnc_jpeg=$vnc_jpeg -Dvnc_png=$vnc_png \
	-Dgettext=$gettext \
        $cross_arg \
        "$PWD" "$source_path"

```