### PR TITLE
Fix typo when fetching buildtype option for compiler checks

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -377,7 +377,7 @@ class CLikeCompiler:
             # us in that case and will error out asking us to pick one.
             try:
                 crt_val = env.coredata.base_options['b_vscrt'].value
-                buildtype = env.coredata.base_options['buildtype'].value
+                buildtype = env.coredata.builtins['buildtype'].value
                 cargs += self.get_crt_compile_args(crt_val, buildtype)
             except (KeyError, AttributeError):
                 pass

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1780,6 +1780,15 @@ class BasePlatformTests(unittest.TestCase):
         cmds = [l[len(prefix):].split() for l in log if l.startswith(prefix)]
         return cmds
 
+    def get_meson_log_sanitychecks(self):
+        '''
+        Same as above, but for the sanity checks that were run
+        '''
+        log = self.get_meson_log()
+        prefix = 'Sanity check compiler command line:'
+        cmds = [l[len(prefix):].split() for l in log if l.startswith(prefix)]
+        return cmds
+
     def introspect(self, args):
         if isinstance(args, str):
             args = [args]
@@ -5639,6 +5648,50 @@ class WindowsTests(BasePlatformTests):
             contents = f.read()
             m = re.search('build qt5core.exe: cpp_LINKER.*Qt5Cored.lib', contents)
         self.assertIsNotNone(m, msg=contents)
+
+    def test_compiler_checks_vscrt(self):
+        '''
+        Test that the correct VS CRT is used when running compiler checks
+        '''
+        # Verify that the `b_vscrt` option is available
+        env = get_fake_env()
+        cc = env.detect_c_compiler(MachineChoice.HOST)
+        if 'b_vscrt' not in cc.base_options:
+            raise unittest.SkipTest('Compiler does not support setting the VS CRT')
+
+        def sanitycheck_vscrt(vscrt):
+            checks = self.get_meson_log_sanitychecks()
+            self.assertTrue(len(checks) > 0)
+            for check in checks:
+                self.assertIn(vscrt, check)
+
+        testdir = os.path.join(self.common_test_dir, '1 trivial')
+        self.init(testdir)
+        sanitycheck_vscrt('/MDd')
+
+        self.new_builddir()
+        self.init(testdir, extra_args=['-Dbuildtype=debugoptimized'])
+        sanitycheck_vscrt('/MD')
+
+        self.new_builddir()
+        self.init(testdir, extra_args=['-Dbuildtype=release'])
+        sanitycheck_vscrt('/MD')
+
+        self.new_builddir()
+        self.init(testdir, extra_args=['-Db_vscrt=md'])
+        sanitycheck_vscrt('/MD')
+
+        self.new_builddir()
+        self.init(testdir, extra_args=['-Db_vscrt=mdd'])
+        sanitycheck_vscrt('/MDd')
+
+        self.new_builddir()
+        self.init(testdir, extra_args=['-Db_vscrt=mt'])
+        sanitycheck_vscrt('/MT')
+
+        self.new_builddir()
+        self.init(testdir, extra_args=['-Db_vscrt=mtd'])
+        sanitycheck_vscrt('/MTd')
 
 
 @unittest.skipUnless(is_osx(), "requires Darwin")


### PR DESCRIPTION
This typo happened in https://github.com/mesonbuild/meson/pull/7432 and wasn't noticed because I didn't add a test for it. Rectified now.

If we don't specify the CRT, MSVC will pick `/MT` by default (!?) and link to `libcmt.lib`. This actually *breaks* UWP because `libcmt.lib` is not available by default when building for UWP.

Was noticed here: https://github.com/cisco/libsrtp/pull/505