### PR TITLE
D: fix include order

### DIFF
--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -19,6 +19,7 @@ from ..mesonlib import (
     EnvironmentException, MachineChoice, version_compare,
 )
 
+from ..arglist import CompilerArgs
 from .compilers import (
     d_dmd_buildtype_args,
     d_gdc_buildtype_args,
@@ -426,6 +427,9 @@ class DmdLikeCompilerMixin:
             args = [a.replace('-L=', '-Xcc=-Wl,') for a in args]
         return args
 
+class DCompilerArgs(CompilerArgs):
+    prepend_prefixes = ('-I', '-L')
+    dedup2_prefixes = ('-I')
 
 class DCompiler(Compiler):
     mscrt_args = {
@@ -598,6 +602,9 @@ class DCompiler(Compiler):
         # extra_args must override all other arguments, so we add them last
         args += extra_args
         return args
+
+    def compiler_args(self, args: T.Optional[T.Iterable[str]] = None) -> DCompilerArgs:
+        return DCompilerArgs(self, args)
 
     def compiles(self, code, env, *, extra_args=None, dependencies=None, mode='compile'):
         args = self._get_compiler_check_args(env, extra_args, dependencies, mode)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -376,6 +376,12 @@ class InternalTests(unittest.TestCase):
         a += ['-I.', '-I./tests2/']
         self.assertEqual(a, ['-I.', '-I./tests2/', '-I./tests/', '-I..'])
 
+    def test_compiler_args_class_d(self):
+        d = mesonbuild.compilers.DCompiler([], 'fake', MachineChoice.HOST, 'info', 'arch', False, None)
+        # check include order is kept when deduplicating
+        a = d.compiler_args(['-Ifirst', '-Isecond', '-Ithird'])
+        a += ['-Ifirst']
+        self.assertEqual(a, ['-Ifirst', '-Isecond', '-Ithird'])
 
     def test_compiler_args_class(self):
         cc = mesonbuild.compilers.CCompiler([], 'fake', False, MachineChoice.HOST, mock.Mock())


### PR DESCRIPTION
Commit 93c3ec7e introduced a new way to handle deduplication with
compiler args. This resulted in D includes to be reversed.

See #7654