### PR TITLE
typing: Strict type annotations

### DIFF
--- a/.github/workflows/lint_mypy.yml
+++ b/.github/workflows/lint_mypy.yml
@@ -31,4 +31,4 @@ jobs:
       with:
         python-version: '3.x'
     - run: python -m pip install mypy
-    - run: mypy --follow-imports=skip mesonbuild/interpreterbase.py mesonbuild/mtest.py mesonbuild/minit.py mesonbuild/mintro.py mesonbuild/mparser.py mesonbuild/msetup.py mesonbuild/ast mesonbuild/wrap tools/ mesonbuild/modules/fs.py mesonbuild/dependencies/boost.py mesonbuild/dependencies/mpi.py mesonbuild/dependencies/hdf5.py mesonbuild/compilers/mixins/intel.py mesonbuild/mlog.py mesonbuild/mcompile.py mesonbuild/mesonlib.py mesonbuild/arglist.py
+    - run: python run_mypy.py

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -4,7 +4,7 @@ show_error_context            = False
 show_column_numbers           = True
 ignore_missing_imports        = True
 
-follow_imports                = skip
+follow_imports                = silent
 warn_redundant_casts          = True
 warn_unused_ignores           = True
 warn_return_any               = True

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,5 +1,23 @@
 [mypy]
-strict_optional = False
-show_error_context = False
-show_column_numbers = True
-ignore_missing_imports = True
+strict_optional               = False
+show_error_context            = False
+show_column_numbers           = True
+ignore_missing_imports        = True
+
+follow_imports                = skip
+warn_redundant_casts          = True
+warn_unused_ignores           = True
+warn_return_any               = True
+# warn_unreachable            = True
+disallow_untyped_calls        = True
+disallow_untyped_defs         = True
+disallow_incomplete_defs      = True
+disallow_untyped_decorators   = True
+no_implicit_optional          = True
+strict_equality               = True
+check_untyped_defs            = True
+# disallow_any_expr           = True
+# disallow_any_decorated      = True
+# disallow_any_explicit       = True
+# disallow_any_generics       = True
+# disallow_subclassing_any    = True

--- a/mesonbuild/arglist.py
+++ b/mesonbuild/arglist.py
@@ -164,7 +164,7 @@ class CompilerArgs(collections.abc.MutableSequence):
     def __getitem__(self, index: slice) -> T.MutableSequence[str]:  # noqa: F811
         pass
 
-    def __getitem__(self, index):  # noqa: F811
+    def __getitem__(self, index):  # type: ignore  # noqa: F811
         self.flush_pre_post()
         return self._container[index]
 
@@ -176,7 +176,7 @@ class CompilerArgs(collections.abc.MutableSequence):
     def __setitem__(self, index: slice, value: T.Iterable[str]) -> None:  # noqa: F811
         pass
 
-    def __setitem__(self, index, value) -> None:  # noqa: F811
+    def __setitem__(self, index, value) -> None:  # type: ignore  # noqa: F811
         self.flush_pre_post()
         self._container[index] = value
 
@@ -242,7 +242,7 @@ class CompilerArgs(collections.abc.MutableSequence):
             new = self.copy()
         else:
             new = self
-        return self.compiler.unix_args_to_native(new._container)
+        return T.cast(T.List[str], self.compiler.unix_args_to_native(new._container))
 
     def append_direct(self, arg: str) -> None:
         '''

--- a/mesonbuild/arglist.py
+++ b/mesonbuild/arglist.py
@@ -164,7 +164,7 @@ class CompilerArgs(collections.abc.MutableSequence):
     def __getitem__(self, index: slice) -> T.MutableSequence[str]:  # noqa: F811
         pass
 
-    def __getitem__(self, index):  # type: ignore  # noqa: F811
+    def __getitem__(self, index: T.Union[int, slice]) -> T.Union[str, T.MutableSequence[str]]:  # noqa: F811
         self.flush_pre_post()
         return self._container[index]
 
@@ -176,9 +176,9 @@ class CompilerArgs(collections.abc.MutableSequence):
     def __setitem__(self, index: slice, value: T.Iterable[str]) -> None:  # noqa: F811
         pass
 
-    def __setitem__(self, index, value) -> None:  # type: ignore  # noqa: F811
+    def __setitem__(self, index: T.Union[int, slice], value: T.Union[str, T.Iterable[str]]) -> None:  # noqa: F811
         self.flush_pre_post()
-        self._container[index] = value
+        self._container[index] = value  # type: ignore  # TODO: fix 'Invalid index type' and 'Incompatible types in assignment' erros
 
     def __delitem__(self, index: T.Union[int, slice]) -> None:
         self.flush_pre_post()
@@ -314,7 +314,7 @@ class CompilerArgs(collections.abc.MutableSequence):
         new += self
         return new
 
-    def __eq__(self, other: T.Any) -> T.Union[bool]:
+    def __eq__(self, other: object) -> T.Union[bool]:
         self.flush_pre_post()
         # Only allow equality checks against other CompilerArgs and lists instances
         if isinstance(other, CompilerArgs):

--- a/mesonbuild/arglist.py
+++ b/mesonbuild/arglist.py
@@ -242,7 +242,7 @@ class CompilerArgs(collections.abc.MutableSequence):
             new = self.copy()
         else:
             new = self
-        return T.cast(T.List[str], self.compiler.unix_args_to_native(new._container))
+        return self.compiler.unix_args_to_native(new._container)
 
     def append_direct(self, arg: str) -> None:
         '''

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -38,7 +38,6 @@ from ..mparser import (
     NotNode,
     OrNode,
     PlusAssignmentNode,
-    StringNode,
     TernaryNode,
     UMinusNode,
 )
@@ -216,15 +215,16 @@ class AstInterpreter(interpreterbase.InterpreterBase):
     def unknown_function_called(self, func_name: str) -> None:
         pass
 
-    def reduce_arguments(self, args: ArgumentNode, resolve_key_nodes: bool = True) -> T.Tuple[T.List[TYPE_nvar], TYPE_nkwargs]:
+    def reduce_arguments(
+                self,
+                args: mparser.ArgumentNode,
+                key_resolver: T.Callable[[mparser.BaseNode], str] = interpreterbase.default_resolve_key,
+                duplicate_key_error: T.Optional[str] = None,
+            ) -> T.Tuple[T.List[TYPE_nvar], TYPE_nkwargs]:
         if isinstance(args, ArgumentNode):
-            kwargs = {}  # type: T.Dict[T.Union[str, BaseNode], TYPE_nvar]
+            kwargs = {}  # type: T.Dict[str, TYPE_nvar]
             for key, val in args.kwargs.items():
-                if resolve_key_nodes and isinstance(key, (StringNode, IdNode)):
-                    assert isinstance(key.value, str)
-                    kwargs[key.value] = val
-                else:
-                    kwargs[key] = val
+                kwargs[key_resolver(key)] = val
             if args.incorrect_order():
                 raise InvalidArguments('All keyword arguments must be after positional arguments.')
             return self.flatten_args(args.arguments), kwargs

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -192,7 +192,11 @@ class AstInterpreter(interpreterbase.InterpreterBase):
         self.evaluate_statement(node.falseblock)
 
     def evaluate_dictstatement(self, node: mparser.DictNode) -> TYPE_nkwargs:
-        (arguments, kwargs) = self.reduce_arguments(node.args, resolve_key_nodes=False)
+        def resolve_key(node: mparser.BaseNode) -> str:
+            if isinstance(node, mparser.StringNode):
+                return node.value
+            return '__AST_UNKNOWN__'
+        arguments, kwargs = self.reduce_arguments(node.args, key_resolver=resolve_key)
         assert (not arguments)
         self.argument_depth += 1
         for key, value in kwargs.items():

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -296,7 +296,7 @@ class IntrospectionInterpreter(AstInterpreter):
         return None
 
     def is_subproject(self) -> bool:
-        return str(self.subproject) != ''
+        return self.subproject != ''
 
     def analyze(self) -> None:
         self.load_root_meson_file()

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -25,10 +25,11 @@ from ..build import BuildTarget, Executable, Jar, SharedLibrary, SharedModule, S
 from ..mparser import BaseNode, ArithmeticNode, ArrayNode, ElementaryNode, IdNode, FunctionNode, StringNode
 import typing as T
 import os
+import argparse
 
 build_target_functions = ['executable', 'jar', 'library', 'shared_library', 'shared_module', 'static_library', 'both_libraries']
 
-class IntrospectionHelper:
+class IntrospectionHelper(argparse.Namespace):
     # mimic an argparse namespace
     def __init__(self, cross_file: str):
         self.cross_file = cross_file  # type: str

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -21,7 +21,7 @@ from .. import compilers, environment, mesonlib, optinterpreter
 from .. import coredata as cdata
 from ..mesonlib import MachineChoice
 from ..interpreterbase import InvalidArguments, TYPE_nvar
-from ..build import Executable, Jar, SharedLibrary, SharedModule, StaticLibrary
+from ..build import BuildTarget, Executable, Jar, SharedLibrary, SharedModule, StaticLibrary
 from ..mparser import BaseNode, ArithmeticNode, ArrayNode, ElementaryNode, IdNode, FunctionNode, StringNode
 import typing as T
 import os
@@ -173,7 +173,7 @@ class IntrospectionInterpreter(AstInterpreter):
             'node': node
         }]
 
-    def build_target(self, node: BaseNode, args: T.List[TYPE_nvar], kwargs_raw: T.Dict[str, TYPE_nvar], targetclass) -> T.Optional[T.Dict[str, T.Any]]:
+    def build_target(self, node: BaseNode, args: T.List[TYPE_nvar], kwargs_raw: T.Dict[str, TYPE_nvar], targetclass: T.Type[BuildTarget]) -> T.Optional[T.Dict[str, T.Any]]:
         args = self.flatten_args(args)
         if not args or not isinstance(args[0], str):
             return None
@@ -295,7 +295,7 @@ class IntrospectionInterpreter(AstInterpreter):
         return None
 
     def is_subproject(self) -> bool:
-        return self.subproject != ''
+        return str(self.subproject) != ''
 
     def analyze(self) -> None:
         self.load_root_meson_file()

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -32,9 +32,13 @@ build_target_functions = ['executable', 'jar', 'library', 'shared_library', 'sha
 class IntrospectionHelper(argparse.Namespace):
     # mimic an argparse namespace
     def __init__(self, cross_file: str):
+        super().__init__()
         self.cross_file = cross_file  # type: str
         self.native_file = None       # type: str
         self.cmd_line_options = {}    # type: T.Dict[str, str]
+
+    def __eq__(self, other: object) -> bool:
+        return NotImplemented
 
 class IntrospectionInterpreter(AstInterpreter):
     # Interpreter to detect the options without a build directory

--- a/mesonbuild/ast/postprocess.py
+++ b/mesonbuild/ast/postprocess.py
@@ -20,7 +20,7 @@ from .. import mparser
 import typing as T
 
 class AstIndentationGenerator(AstVisitor):
-    def __init__(self):
+    def __init__(self) -> None:
         self.level = 0
 
     def visit_default_func(self, node: mparser.BaseNode) -> None:
@@ -76,7 +76,7 @@ class AstIndentationGenerator(AstVisitor):
         self.level -= 1
 
 class AstIDGenerator(AstVisitor):
-    def __init__(self):
+    def __init__(self) -> None:
         self.counter = {}  # type: T.Dict[str, int]
 
     def visit_default_func(self, node: mparser.BaseNode) -> None:
@@ -87,7 +87,7 @@ class AstIDGenerator(AstVisitor):
         self.counter[name] += 1
 
 class AstConditionLevel(AstVisitor):
-    def __init__(self):
+    def __init__(self) -> None:
         self.condition_level = 0
 
     def visit_default_func(self, node: mparser.BaseNode) -> None:

--- a/mesonbuild/ast/visitor.py
+++ b/mesonbuild/ast/visitor.py
@@ -18,7 +18,7 @@
 from .. import mparser
 
 class AstVisitor:
-    def __init__(self):
+    def __init__(self) -> None:
         pass
 
     def visit_default_func(self, node: mparser.BaseNode) -> None:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2997,7 +2997,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         elem = NinjaBuildElement(self.all_outputs, deps, 'phony', '')
         self.add_build(elem)
 
-    def get_introspection_data(self, target_id, target):
+    def get_introspection_data(self, target_id: str, target: build.Target) -> T.List[T.Dict[str, T.Union[bool, str, T.List[T.Union[str, T.Dict[str, T.Union[str, T.List[str], bool]]]]]]]:
         if target_id not in self.introspection_data or len(self.introspection_data[target_id]) == 0:
             return super().get_introspection_data(target_id, target)
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -192,11 +192,11 @@ class Vs2010Backend(backends.Backend):
         Vs2010Backend.touch_regen_timestamp(self.environment.get_build_dir())
 
     @staticmethod
-    def get_regen_stampfile(build_dir):
+    def get_regen_stampfile(build_dir: str) -> None:
         return os.path.join(os.path.join(build_dir, Environment.private_dir), 'regen.stamp')
 
     @staticmethod
-    def touch_regen_timestamp(build_dir):
+    def touch_regen_timestamp(build_dir: str) -> None:
         with open(Vs2010Backend.get_regen_stampfile(build_dir), 'w'):
             pass
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -372,22 +372,22 @@ a hard error in the future.'''.format(name))
         if not hasattr(self, 'typename'):
             raise RuntimeError('Target type is not set for target class "{}". This is a bug'.format(type(self).__name__))
 
-    def __lt__(self, other: object) -> T.Union[bool, type(NotImplemented)]:
+    def __lt__(self, other: object) -> bool:
         if not hasattr(other, 'get_id') and not callable(other.get_id):
             return NotImplemented
         return self.get_id() < other.get_id()
 
-    def __le__(self, other: object) -> T.Union[bool, type(NotImplemented)]:
+    def __le__(self, other: object) -> bool:
         if not hasattr(other, 'get_id') and not callable(other.get_id):
             return NotImplemented
         return self.get_id() <= other.get_id()
 
-    def __gt__(self, other: object) -> T.Union[bool, type(NotImplemented)]:
+    def __gt__(self, other: object) -> bool:
         if not hasattr(other, 'get_id') and not callable(other.get_id):
             return NotImplemented
         return self.get_id() > other.get_id()
 
-    def __ge__(self, other: object) -> T.Union[bool, type(NotImplemented)]:
+    def __ge__(self, other: object) -> bool:
         if not hasattr(other, 'get_id') and not callable(other.get_id):
             return NotImplemented
         return self.get_id() >= other.get_id()

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -372,22 +372,22 @@ a hard error in the future.'''.format(name))
         if not hasattr(self, 'typename'):
             raise RuntimeError('Target type is not set for target class "{}". This is a bug'.format(type(self).__name__))
 
-    def __lt__(self, other: T.Any) -> T.Union[bool, type(NotImplemented)]:
+    def __lt__(self, other: object) -> T.Union[bool, type(NotImplemented)]:
         if not hasattr(other, 'get_id') and not callable(other.get_id):
             return NotImplemented
         return self.get_id() < other.get_id()
 
-    def __le__(self, other: T.Any) -> T.Union[bool, type(NotImplemented)]:
+    def __le__(self, other: object) -> T.Union[bool, type(NotImplemented)]:
         if not hasattr(other, 'get_id') and not callable(other.get_id):
             return NotImplemented
         return self.get_id() <= other.get_id()
 
-    def __gt__(self, other: T.Any) -> T.Union[bool, type(NotImplemented)]:
+    def __gt__(self, other: object) -> T.Union[bool, type(NotImplemented)]:
         if not hasattr(other, 'get_id') and not callable(other.get_id):
             return NotImplemented
         return self.get_id() > other.get_id()
 
-    def __ge__(self, other: T.Any) -> T.Union[bool, type(NotImplemented)]:
+    def __ge__(self, other: object) -> T.Union[bool, type(NotImplemented)]:
         if not hasattr(other, 'get_id') and not callable(other.get_id):
             return NotImplemented
         return self.get_id() >= other.get_id()

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -578,7 +578,7 @@ class Compiler(metaclass=abc.ABCMeta):
         raise EnvironmentException('Language %s does not support function checks.' % self.get_display_language())
 
     @classmethod
-    def unix_args_to_native(cls, args):
+    def unix_args_to_native(cls, args: T.List[str]) -> T.List[str]:
         "Always returns a copy that can be independently mutated"
         return args[:]
 

--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -69,7 +69,7 @@ class IntelGnuLikeCompiler(GnuLikeCompiler):
         's': ['-Os'],
     }
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         # As of 19.0.0 ICC doesn't have sanitizer, color, or lto support.
         #
@@ -152,7 +152,7 @@ class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
         super().__init__(target)
         self.id = 'intel-cl'
 
-    def compile(self, code, *, extra_args: T.Optional[T.List[str]] = None, **kwargs) -> T.Iterator['subprocess.Popen']:
+    def compile(self, code: str, *, extra_args: T.Optional[T.List[str]] = None, **kwargs) -> T.Iterator['subprocess.Popen']:
         # This covers a case that .get('foo', []) doesn't, that extra_args is
         if kwargs.get('mode', 'compile') != 'link':
             extra_args = extra_args.copy() if extra_args is not None else []

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -365,7 +365,7 @@ _V = T.TypeVar('_V')
 
 class CoreData:
 
-    def __init__(self, options: argparse.Namespace, scratch_dir: str):
+    def __init__(self, options: argparse.Namespace, scratch_dir: str, meson_command: T.List[str]):
         self.lang_guids = {
             'default': '8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942',
             'c': '8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942',
@@ -376,6 +376,7 @@ class CoreData:
         self.test_guid = str(uuid.uuid4()).upper()
         self.regen_guid = str(uuid.uuid4()).upper()
         self.install_guid = str(uuid.uuid4()).upper()
+        self.meson_command = meson_command
         self.target_guids = {}
         self.version = version
         self.builtins = {} # type: OptionDictType

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -114,11 +114,11 @@ class Dependency:
 
     def __init__(self, type_name, kwargs):
         self.name = "null"
-        self.version = None
+        self.version = None  # type: T.Optional[str]
         self.language = None # None means C-like
         self.is_found = False
         self.type_name = type_name
-        self.compile_args = []
+        self.compile_args = []  # type: T.List[str]
         self.link_args = []
         # Raw -L and -l arguments without manual library searching
         # If None, self.link_args will be used
@@ -132,7 +132,7 @@ class Dependency:
         s = '<{0} {1}: {2}>'
         return s.format(self.__class__.__name__, self.name, self.is_found)
 
-    def get_compile_args(self):
+    def get_compile_args(self) -> T.List[str]:
         if self.include_type == 'system':
             converted = []
             for i in self.compile_args:
@@ -156,7 +156,7 @@ class Dependency:
             return self.raw_link_args
         return self.link_args
 
-    def found(self):
+    def found(self) -> bool:
         return self.is_found
 
     def get_sources(self):
@@ -171,7 +171,7 @@ class Dependency:
     def get_name(self):
         return self.name
 
-    def get_version(self):
+    def get_version(self) -> str:
         if self.version:
             return self.version
         else:
@@ -183,7 +183,7 @@ class Dependency:
     def get_exe_args(self, compiler):
         return []
 
-    def get_pkgconfig_variable(self, variable_name, kwargs):
+    def get_pkgconfig_variable(self, variable_name: str, kwargs: T.Dict[str, T.Any]) -> str:
         raise DependencyException('{!r} is not a pkgconfig dependency'.format(self.name))
 
     def get_configtool_variable(self, variable_name):
@@ -261,7 +261,7 @@ class InternalDependency(Dependency):
                 setattr(result, k, copy.deepcopy(v, memo))
         return result
 
-    def get_pkgconfig_variable(self, variable_name, kwargs):
+    def get_pkgconfig_variable(self, variable_name: str, kwargs: T.Dict[str, T.Any]) -> str:
         raise DependencyException('Method "get_pkgconfig_variable()" is '
                                   'invalid for an internal dependency')
 
@@ -504,7 +504,7 @@ class ConfigToolDependency(ExternalDependency):
 
         return self.config is not None
 
-    def get_config_value(self, args, stage):
+    def get_config_value(self, args: T.List[str], stage: str) -> T.List[str]:
         p, out, err = Popen_safe(self.config + args)
         if p.returncode != 0:
             if self.required:
@@ -877,7 +877,7 @@ class PkgConfigDependency(ExternalDependency):
                                       (self.name, out_raw))
         self.link_args, self.raw_link_args = self._search_libs(out, out_raw)
 
-    def get_pkgconfig_variable(self, variable_name, kwargs):
+    def get_pkgconfig_variable(self, variable_name: str, kwargs: T.Dict[str, T.Any]) -> str:
         options = ['--variable=' + variable_name, self.name]
 
         if 'define_variable' in kwargs:
@@ -2037,7 +2037,7 @@ class ExternalProgram:
     def found(self) -> bool:
         return self.command[0] is not None
 
-    def get_command(self):
+    def get_command(self) -> T.List[str]:
         return self.command[:]
 
     def get_path(self):
@@ -2550,7 +2550,7 @@ def factory_methods(methods: T.Set[DependencyMethods]) -> T.Callable[['FactoryTy
 
     This helps to make factory functions self documenting
     >>> @factory_methods([DependencyMethods.PKGCONFIG, DependencyMethods.CMAKE])
-    >>> def factory(env: Environment, for_machine: MachineChoice, kwargs: T.Dict[str, T.Any], methods: T.Set[DependencyMethods]) -> T.List[DependencyType]:
+    >>> def factory(env: Environment, for_machine: MachineChoice, kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> T.List[T.Callable[[], 'Dependency']]:
     >>>     pass
     """
 

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -339,12 +339,12 @@ class BoostLibraryFile():
         return [self.path.as_posix()]
 
 class BoostDependency(ExternalDependency):
-    def __init__(self, environment: Environment, kwargs):
+    def __init__(self, environment: Environment, kwargs: T.Dict[str, T.Any]) -> None:
         super().__init__('boost', environment, kwargs, language='cpp')
         self.debug = environment.coredata.get_builtin_option('buildtype').startswith('debug')
         self.multithreading = kwargs.get('threading', 'multi') == 'multi'
 
-        self.boost_root = None
+        self.boost_root = None  # type: Path
         self.explicit_static = 'static' in kwargs
 
         # Extract and validate modules
@@ -385,7 +385,7 @@ class BoostDependency(ExternalDependency):
         # Finally, look for paths from .pc files and from searching the filesystem
         self.detect_roots()
 
-    def check_and_set_roots(self, roots) -> None:
+    def check_and_set_roots(self, roots: T.List[Path]) -> None:
         roots = list(mesonlib.OrderedSet(roots))
         for j in roots:
             #   1. Look for the boost headers (boost/version.hpp)
@@ -403,7 +403,7 @@ class BoostDependency(ExternalDependency):
                 self.boost_root = j
                 break
 
-    def detect_boost_machine_file(self, props) -> None:
+    def detect_boost_machine_file(self, props: T.Dict[str, str]) -> None:
         incdir = props.get('boost_includedir')
         libdir = props.get('boost_librarydir')
 
@@ -434,7 +434,7 @@ class BoostDependency(ExternalDependency):
 
         self.check_and_set_roots(paths)
 
-    def detect_boost_env(self):
+    def detect_boost_env(self) -> None:
         boost_includedir = get_env_var(self.for_machine, self.env.is_cross_build, 'BOOST_INCLUDEDIR')
         boost_librarydir = get_env_var(self.for_machine, self.env.is_cross_build, 'BOOST_LIBRARYDIR')
 
@@ -658,7 +658,7 @@ class BoostDependency(ExternalDependency):
             libs += [BoostLibraryFile(i)]
         return [x for x in libs if x.is_boost()]  # Filter out no boost libraries
 
-    def detect_split_root(self, inc_dir, lib_dir) -> None:
+    def detect_split_root(self, inc_dir: Path, lib_dir: Path) -> None:
         boost_inc_dir = None
         for j in [inc_dir / 'version.hpp', inc_dir / 'boost' / 'version.hpp']:
             if j.is_file():

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -95,7 +95,7 @@ class BoostIncludeDir():
     def __repr__(self) -> str:
         return '<BoostIncludeDir: {} -- {}>'.format(self.version, self.path)
 
-    def __lt__(self, other: T.Any) -> bool:
+    def __lt__(self, other: object) -> bool:
         if isinstance(other, BoostIncludeDir):
             return (self.version_int, self.path) < (other.version_int, other.path)
         return NotImplemented
@@ -187,7 +187,7 @@ class BoostLibraryFile():
     def __repr__(self) -> str:
         return '<LIB: {} {:<32} {}>'.format(self.abitag, self.mod_name, self.path)
 
-    def __lt__(self, other: T.Any) -> bool:
+    def __lt__(self, other: object) -> bool:
         if isinstance(other, BoostLibraryFile):
             return (
                 self.mod_name, self.static, self.version_lib, self.arch,
@@ -204,7 +204,7 @@ class BoostLibraryFile():
             )
         return NotImplemented
 
-    def __eq__(self, other: T.Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, BoostLibraryFile):
             return self.name == other.name
         return NotImplemented
@@ -346,7 +346,7 @@ class BoostDependency(ExternalDependency):
         self.debug = buildtype.startswith('debug')
         self.multithreading = kwargs.get('threading', 'multi') == 'multi'
 
-        self.boost_root = None  # type: Path
+        self.boost_root = None  # type: T.Optional[Path]
         self.explicit_static = 'static' in kwargs
 
         # Extract and validate modules

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -341,7 +341,9 @@ class BoostLibraryFile():
 class BoostDependency(ExternalDependency):
     def __init__(self, environment: Environment, kwargs: T.Dict[str, T.Any]) -> None:
         super().__init__('boost', environment, kwargs, language='cpp')
-        self.debug = environment.coredata.get_builtin_option('buildtype').startswith('debug')
+        buildtype = environment.coredata.get_builtin_option('buildtype')
+        assert isinstance(buildtype, str)
+        self.debug = buildtype.startswith('debug')
         self.multithreading = kwargs.get('threading', 'multi') == 'multi'
 
         self.boost_root = None  # type: Path

--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -22,10 +22,14 @@ from .. import mlog
 from ..mesonlib import split_args, listify
 from .base import (DependencyException, DependencyMethods, ExternalDependency, ExternalProgram,
                    PkgConfigDependency)
+import typing as T
+
+if T.TYPE_CHECKING:
+    from ..environment import Environment
 
 class HDF5Dependency(ExternalDependency):
 
-    def __init__(self, environment, kwargs):
+    def __init__(self, environment: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
         language = kwargs.get('language', 'c')
         super().__init__('hdf5', environment, kwargs, language=language)
         kwargs['required'] = False
@@ -127,5 +131,5 @@ class HDF5Dependency(ExternalDependency):
             return
 
     @staticmethod
-    def get_methods():
+    def get_methods() -> T.List[DependencyMethods]:
         return [DependencyMethods.AUTO, DependencyMethods.PKGCONFIG]

--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -113,7 +113,7 @@ class HDF5Dependency(ExternalDependency):
                 cmd = prog.get_command() + [shlib_arg, '-show']
                 p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, timeout=15)
                 if p.returncode != 0:
-                    mlog.debug('Command', mlog.bold(cmd), 'failed to run:')
+                    mlog.debug('Command', mlog.bold(str(cmd)), 'failed to run:')
                     mlog.debug(mlog.bold('Standard output\n'), p.stdout)
                     mlog.debug(mlog.bold('Standard error\n'), p.stderr)
                     return

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -24,10 +24,11 @@ from ..environment import detect_cpu_family
 if T.TYPE_CHECKING:
     from .base import Dependency
     from ..compilers import Compiler
+    from ..compilers.compiler import CompilerType
     from ..environment import Environment, MachineChoice
 
 
-@factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.SYSTEM})  # type: ignore
+@factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.SYSTEM})
 def mpi_factory(env: 'Environment', for_machine: 'MachineChoice',
                 kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> T.List[T.Callable[[], 'Dependency']]:
     language = kwargs.get('language', 'c')
@@ -36,7 +37,9 @@ def mpi_factory(env: 'Environment', for_machine: 'MachineChoice',
         return []
 
     candidates = []  # type: T.List[T.Callable[[], Dependency]]
-    compiler = detect_compiler('mpi', env, for_machine, language)
+    compiler = detect_compiler('mpi', env, for_machine, language)  # type: T.Optional['CompilerType']
+    if compiler is None:
+        return []
     compiler_is_intel = compiler.get_id() in {'intel', 'intel-cl'}
 
     # Only OpenMPI has pkg-config, and it doesn't work with the intel compilers

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -27,7 +27,7 @@ if T.TYPE_CHECKING:
     from ..environment import Environment, MachineChoice
 
 
-@factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.SYSTEM})
+@factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.SYSTEM})  # type: ignore
 def mpi_factory(env: 'Environment', for_machine: 'MachineChoice',
                 kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> T.List[T.Callable[[], 'Dependency']]:
     language = kwargs.get('language', 'c')

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -147,7 +147,7 @@ class Properties:
             return p
         return mesonlib.listify(p)
 
-    def __eq__(self, other: object) -> 'T.Union[bool, NotImplemented]':
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, type(self)):
             return self.properties == other.properties
         return NotImplemented
@@ -172,8 +172,8 @@ class MachineInfo:
         self.endian = endian
         self.is_64_bit = cpu_family in CPU_FAMILES_64_BIT  # type: bool
 
-    def __eq__(self, other: object) -> 'T.Union[bool, NotImplemented]':
-        if self.__class__ is not other.__class__ or not isinstance(other, MachineInfo):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, MachineInfo):
             return NotImplemented
         return \
             self.system == other.system and \
@@ -181,8 +181,8 @@ class MachineInfo:
             self.cpu == other.cpu and \
             self.endian == other.endian
 
-    def __ne__(self, other: object) -> 'T.Union[bool, NotImplemented]':
-        if self.__class__ is not other.__class__ or not isinstance(other, MachineInfo):
+    def __ne__(self, other: object) -> bool:
+        if not isinstance(other, MachineInfo):
             return NotImplemented
         return not self.__eq__(other)
 

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -111,7 +111,7 @@ def get_env_var_pair(for_machine: MachineChoice,
 
 def get_env_var(for_machine: MachineChoice,
                 is_cross: bool,
-                var_name: str) -> T.Tuple[T.Optional[str], T.Optional[str]]:
+                var_name: str) -> T.Optional[str]:
     ret = get_env_var_pair(for_machine, is_cross, var_name)
     if ret is None:
         return None

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -147,7 +147,7 @@ class Properties:
             return p
         return mesonlib.listify(p)
 
-    def __eq__(self, other: T.Any) -> 'T.Union[bool, NotImplemented]':
+    def __eq__(self, other: object) -> 'T.Union[bool, NotImplemented]':
         if isinstance(other, type(self)):
             return self.properties == other.properties
         return NotImplemented
@@ -172,8 +172,8 @@ class MachineInfo:
         self.endian = endian
         self.is_64_bit = cpu_family in CPU_FAMILES_64_BIT  # type: bool
 
-    def __eq__(self, other: T.Any) -> 'T.Union[bool, NotImplemented]':
-        if self.__class__ is not other.__class__:
+    def __eq__(self, other: object) -> 'T.Union[bool, NotImplemented]':
+        if self.__class__ is not other.__class__ or not isinstance(other, MachineInfo):
             return NotImplemented
         return \
             self.system == other.system and \
@@ -181,8 +181,8 @@ class MachineInfo:
             self.cpu == other.cpu and \
             self.endian == other.endian
 
-    def __ne__(self, other: T.Any) -> 'T.Union[bool, NotImplemented]':
-        if self.__class__ is not other.__class__:
+    def __ne__(self, other: object) -> 'T.Union[bool, NotImplemented]':
+        if self.__class__ is not other.__class__ or not isinstance(other, MachineInfo):
             return NotImplemented
         return not self.__eq__(other)
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -814,9 +814,8 @@ class Environment:
         # WARNING: Don't use any values from coredata in __init__. It gets
         # re-initialized with project options by the interpreter during
         # build file parsing.
-        self.coredata = coredata.CoreData(options, self.scratch_dir)
-        # Used by the regenchecker script, which runs meson
-        self.coredata.meson_command = mesonlib.meson_command
+        # meson_command is used by the regenchecker script, which runs meson
+        self.coredata = coredata.CoreData(options, self.scratch_dir, mesonlib.meson_command)
         self.first_invocation = True
 
     def is_cross_build(self, when_building_for: MachineChoice = MachineChoice.HOST) -> bool:
@@ -1038,7 +1037,7 @@ class Environment:
         :extra_args: Any additional arguments required (such as a source file)
         """
         self.coredata.add_lang_args(comp_class.language, comp_class, for_machine, self)
-        extra_args = T.cast(T.List[str], extra_args or [])
+        extra_args = extra_args or []
         extra_args += self.coredata.compiler_options[for_machine][comp_class.language]['args'].value
 
         if isinstance(comp_class.LINKER_PREFIX, str):

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -132,6 +132,9 @@ build_filename = 'meson.build'
 
 CompilersDict = T.Dict[str, Compiler]
 
+if T.TYPE_CHECKING:
+    import argparse
+
 def detect_gcovr(min_version='3.3', new_rootdir_version='4.2', log=False):
     gcovr_exe = 'gcovr'
     try:
@@ -153,7 +156,7 @@ def detect_llvm_cov():
             return tool
     return None
 
-def find_coverage_tools():
+def find_coverage_tools() -> T.Tuple[T.Optional[str], T.Optional[str], T.Optional[str], T.Optional[str], T.Optional[str]]:
     gcovr_exe, gcovr_new_rootdir = detect_gcovr()
 
     llvm_cov_exe = detect_llvm_cov()
@@ -522,7 +525,7 @@ class Environment:
     log_dir = 'meson-logs'
     info_dir = 'meson-info'
 
-    def __init__(self, source_dir, build_dir, options):
+    def __init__(self, source_dir: T.Optional[str], build_dir: T.Optional[str], options: 'argparse.Namespace') -> None:
         self.source_dir = source_dir
         self.build_dir = build_dir
         # Do not try to create build directories when build_dir is none.
@@ -535,7 +538,7 @@ class Environment:
             os.makedirs(self.log_dir, exist_ok=True)
             os.makedirs(self.info_dir, exist_ok=True)
             try:
-                self.coredata = coredata.load(self.get_build_dir())
+                self.coredata = coredata.load(self.get_build_dir())  # type: coredata.CoreData
                 self.first_invocation = False
             except FileNotFoundError:
                 self.create_new_coredata(options)
@@ -807,7 +810,7 @@ class Environment:
         self.default_pkgconfig = ['pkg-config']
         self.wrap_resolver = None
 
-    def create_new_coredata(self, options):
+    def create_new_coredata(self, options: 'argparse.Namespace') -> None:
         # WARNING: Don't use any values from coredata in __init__. It gets
         # re-initialized with project options by the interpreter during
         # build file parsing.
@@ -819,17 +822,17 @@ class Environment:
     def is_cross_build(self, when_building_for: MachineChoice = MachineChoice.HOST) -> bool:
         return self.coredata.is_cross_build(when_building_for)
 
-    def dump_coredata(self):
+    def dump_coredata(self) -> str:
         return coredata.save(self.coredata, self.get_build_dir())
 
-    def get_script_dir(self):
+    def get_script_dir(self) -> str:
         import mesonbuild.scripts
         return os.path.dirname(mesonbuild.scripts.__file__)
 
-    def get_log_dir(self):
+    def get_log_dir(self) -> str:
         return self.log_dir
 
-    def get_coredata(self):
+    def get_coredata(self) -> coredata.CoreData:
         return self.coredata
 
     def get_build_command(self, unbuffered=False):
@@ -1535,7 +1538,7 @@ class Environment:
 
         self._handle_exceptions(popen_exceptions, compilers)
 
-    def get_scratch_dir(self):
+    def get_scratch_dir(self) -> str:
         return self.scratch_dir
 
     def detect_objc_compiler(self, for_machine: MachineInfo) -> 'Compiler':
@@ -1974,10 +1977,10 @@ class Environment:
         self._handle_exceptions(popen_exceptions, linkers, 'linker')
         raise EnvironmentException('Unknown static linker "{}"'.format(' '.join(linkers)))
 
-    def get_source_dir(self):
+    def get_source_dir(self) -> str:
         return self.source_dir
 
-    def get_build_dir(self):
+    def get_build_dir(self) -> str:
         return self.build_dir
 
     def get_import_lib_dir(self) -> str:

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -454,7 +454,7 @@ def is_disabled(args: T.Sequence[T.Any], kwargs: T.Dict[str, T.Any]) -> bool:
 def default_resolve_key(key: mparser.BaseNode) -> str:
     if not isinstance(key, mparser.IdNode):
         raise InterpreterException('Invalid kwargs format.')
-    return T.cast(str, key.value)
+    return key.value
 
 class InterpreterBase:
     elementary_types = (int, float, str, bool, list)
@@ -552,9 +552,9 @@ class InterpreterBase:
         elif isinstance(cur, mparser.MethodNode):
             return self.method_call(cur)
         elif isinstance(cur, mparser.StringNode):
-            return T.cast(str, cur.value)
+            return cur.value
         elif isinstance(cur, mparser.BooleanNode):
-            return T.cast(bool, cur.value)
+            return cur.value
         elif isinstance(cur, mparser.IfClauseNode):
             return self.evaluate_if(cur)
         elif isinstance(cur, mparser.IdNode):
@@ -566,7 +566,7 @@ class InterpreterBase:
         elif isinstance(cur, mparser.DictNode):
             return self.evaluate_dictstatement(cur)
         elif isinstance(cur, mparser.NumberNode):
-            return T.cast(int, cur.value)
+            return cur.value
         elif isinstance(cur, mparser.AndNode):
             return self.evaluate_andstatement(cur)
         elif isinstance(cur, mparser.OrNode):

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -879,6 +879,7 @@ The result of this is undefined and will become a hard error in a future Meson r
             if not isinstance(index, str):
                 raise InterpreterException('Key is not a string')
             try:
+                # The cast is required because we don't have recursive types...
                 return T.cast(TYPE_var, iobject[index])
             except KeyError:
                 raise InterpreterException('Key %s is not in dict' % index)
@@ -1091,7 +1092,7 @@ The result of this is undefined and will become a hard error in a future Meson r
         raise InvalidCode('Unknown function "%s".' % func_name)
 
     @builtinMethodNoKwargs
-    def array_method_call(self, obj: list, method_name: str, posargs: T.List[TYPE_nvar], kwargs: T.Dict[str, T.Any]) -> TYPE_var:
+    def array_method_call(self, obj: T.List[TYPE_var], method_name: str, posargs: T.List[TYPE_nvar], kwargs: T.Dict[str, T.Any]) -> TYPE_var:
         if method_name == 'contains':
             def check_contains(el: list) -> bool:
                 if len(posargs) != 1:
@@ -1127,7 +1128,7 @@ The result of this is undefined and will become a hard error in a future Meson r
                 if isinstance(fallback, mparser.BaseNode):
                     return self.evaluate_statement(fallback)
                 return fallback
-            return T.cast(TYPE_var, obj[index])
+            return obj[index]
         m = 'Arrays do not have a method called {!r}.'
         raise InterpreterException(m.format(method_name))
 

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -245,7 +245,7 @@ class FeatureCheckBase(metaclass=abc.ABCMeta):
         # Don't do any checks if project() has not been parsed yet
         if subproject not in mesonlib.project_meson_versions:
             return ''
-        return T.cast(str, mesonlib.project_meson_versions[subproject])  # TODO: remove type cast when fully typing mesonlib
+        return mesonlib.project_meson_versions[subproject]
 
     @staticmethod
     @abc.abstractmethod
@@ -318,7 +318,7 @@ class FeatureNew(FeatureCheckBase):
 
     @staticmethod
     def check_version(target_version: str, feature_version: str) -> bool:
-        return T.cast(bool, mesonlib.version_compare_condition_with_min(target_version, feature_version))  # TODO: remove once mesonlib is annotated
+        return mesonlib.version_compare_condition_with_min(target_version, feature_version)
 
     @staticmethod
     def get_warning_str_prefix(tv: str) -> str:

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -32,7 +32,7 @@ if T.TYPE_CHECKING:
     import argparse
 
 def array_arg(value: str) -> T.List[str]:
-    return T.cast(T.List[str], UserArrayOption(None, value, allow_dups=True, user_input=True).value)
+    return UserArrayOption(None, value, allow_dups=True, user_input=True).value
 
 def validate_builddir(builddir: Path) -> None:
     if not (builddir / 'meson-private' / 'coredata.dat' ).is_file():
@@ -45,7 +45,9 @@ def get_backend_from_coredata(builddir: Path) -> str:
     """
     Gets `backend` option value from coredata
     """
-    return T.cast(str, coredata.load(str(builddir)).get_builtin_option('backend'))
+    backend = coredata.load(str(builddir)).get_builtin_option('backend')
+    assert isinstance(backend, str)
+    return backend
 
 def parse_introspect_data(builddir: Path) -> T.Dict[str, T.List[dict]]:
     """

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -32,7 +32,7 @@ if T.TYPE_CHECKING:
     import argparse
 
 def array_arg(value: str) -> T.List[str]:
-    return UserArrayOption(None, value, allow_dups=True, user_input=True).value
+    return T.cast(T.List[str], UserArrayOption(None, value, allow_dups=True, user_input=True).value)
 
 def validate_builddir(builddir: Path) -> None:
     if not (builddir / 'meson-private' / 'coredata.dat' ).is_file():
@@ -45,7 +45,7 @@ def get_backend_from_coredata(builddir: Path) -> str:
     """
     Gets `backend` option value from coredata
     """
-    return coredata.load(str(builddir)).get_builtin_option('backend')
+    return T.cast(str, coredata.load(str(builddir)).get_builtin_option('backend'))
 
 def parse_introspect_data(builddir: Path) -> T.Dict[str, T.List[dict]]:
     """
@@ -97,12 +97,12 @@ class ParsedTargetName:
         }
         return type in allowed_types
 
-def get_target_from_intro_data(target: ParsedTargetName, builddir: Path, introspect_data: dict) -> dict:
+def get_target_from_intro_data(target: ParsedTargetName, builddir: Path, introspect_data: T.Dict[str, T.Any]) -> T.Dict[str, T.Any]:
     if target.name not in introspect_data:
         raise MesonException('Can\'t invoke target `{}`: target not found'.format(target.full_name))
 
     intro_targets = introspect_data[target.name]
-    found_targets = []
+    found_targets = []  # type: T.List[T.Dict[str, T.Any]]
 
     resolved_bdir = builddir.resolve()
 
@@ -169,9 +169,9 @@ def generate_target_name_vs(target: ParsedTargetName, builddir: Path, introspect
 
     # Normalize project name
     # Source: https://docs.microsoft.com/en-us/visualstudio/msbuild/how-to-build-specific-targets-in-solutions-by-using-msbuild-exe
-    target_name = re.sub('[\%\$\@\;\.\(\)\']', '_', intro_target['id'])
+    target_name = re.sub('[\%\$\@\;\.\(\)\']', '_', intro_target['id'])  # type: str
     rel_path = Path(intro_target['filename'][0]).relative_to(builddir.resolve()).parent
-    if rel_path != '.':
+    if rel_path != Path('.'):
         target_name = str(rel_path / target_name)
     return target_name
 

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -139,7 +139,7 @@ def get_parsed_args_ninja(options: 'argparse.Namespace', builddir: Path) -> T.Li
     runner = detect_ninja()
     if runner is None:
         raise MesonException('Cannot find ninja.')
-    mlog.log('Found runner:', runner)
+    mlog.log('Found runner:', str(runner))
 
     cmd = runner + ['-C', builddir.as_posix()]
 

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -15,15 +15,19 @@
 import os
 from . import coredata, environment, mesonlib, build, mintro, mlog
 from .ast import AstIDGenerator
+import typing as T
 
-def add_arguments(parser):
+if T.TYPE_CHECKING:
+    import argparse
+
+def add_arguments(parser: 'argparse.ArgumentParser') -> None:
     coredata.register_builtin_arguments(parser)
     parser.add_argument('builddir', nargs='?', default='.')
     parser.add_argument('--clearcache', action='store_true', default=False,
                         help='Clear cached state (e.g. found dependencies)')
 
 
-def make_lower_case(val):
+def make_lower_case(val: T.Any) -> T.Union[str, T.List[T.Any]]:  # T.Any because of recursion...
     if isinstance(val, bool):
         return str(val).lower()
     elif isinstance(val, list):

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -289,7 +289,7 @@ class File:
     def split(self, s: str) -> T.List[str]:
         return self.fname.split(s)
 
-    def __eq__(self, other: T.Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, File):
             return NotImplemented
         if self.hash != other.hash:
@@ -327,23 +327,23 @@ class OrderedEnum(Enum):
     """
     An Enum which additionally offers homogeneous ordered comparison.
     """
-    def __ge__(self, other: T.Any) -> bool:
-        if self.__class__ is other.__class__ and isinstance(self.value, int) and isinstance(other.value, int):
+    def __ge__(self, other: object) -> bool:
+        if self.__class__ is other.__class__ and isinstance(other, OrderedEnum)and isinstance(self.value, int) and isinstance(other.value, int):
             return self.value >= other.value
         return NotImplemented
 
-    def __gt__(self, other: T.Any) -> bool:
-        if self.__class__ is other.__class__ and isinstance(self.value, int) and isinstance(other.value, int):
+    def __gt__(self, other: object) -> bool:
+        if self.__class__ is other.__class__ and isinstance(other, OrderedEnum)and isinstance(self.value, int) and isinstance(other.value, int):
             return self.value > other.value
         return NotImplemented
 
-    def __le__(self, other: T.Any) -> bool:
-        if self.__class__ is other.__class__ and isinstance(self.value, int) and isinstance(other.value, int):
+    def __le__(self, other: object) -> bool:
+        if self.__class__ is other.__class__ and isinstance(other, OrderedEnum)and isinstance(self.value, int) and isinstance(other.value, int):
             return self.value <= other.value
         return NotImplemented
 
-    def __lt__(self, other: T.Any) -> bool:
-        if self.__class__ is other.__class__ and isinstance(self.value, int) and isinstance(other.value, int):
+    def __lt__(self, other: object) -> bool:
+        if self.__class__ is other.__class__ and isinstance(other, OrderedEnum) and isinstance(self.value, int) and isinstance(other.value, int):
             return self.value < other.value
         return NotImplemented
 
@@ -609,32 +609,32 @@ class Version:
     def __repr__(self) -> str:
         return '<Version: {}>'.format(self._s)
 
-    def __lt__(self, other: T.Any) -> bool:
+    def __lt__(self, other: object) -> bool:
         if isinstance(other, Version):
             return self.__cmp(other, operator.lt)
         return NotImplemented
 
-    def __gt__(self, other: T.Any) -> bool:
+    def __gt__(self, other: object) -> bool:
         if isinstance(other, Version):
             return self.__cmp(other, operator.gt)
         return NotImplemented
 
-    def __le__(self, other: T.Any) -> bool:
+    def __le__(self, other: object) -> bool:
         if isinstance(other, Version):
             return self.__cmp(other, operator.le)
         return NotImplemented
 
-    def __ge__(self, other: T.Any) -> bool:
+    def __ge__(self, other: object) -> bool:
         if isinstance(other, Version):
             return self.__cmp(other, operator.ge)
         return NotImplemented
 
-    def __eq__(self, other: T.Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Version):
             return self._v == other._v
         return NotImplemented
 
-    def __ne__(self, other: T.Any) -> bool:
+    def __ne__(self, other: object) -> bool:
         if isinstance(other, Version):
             return self._v != other._v
         return NotImplemented
@@ -1115,7 +1115,7 @@ def unholder(item: T.List[_T]) -> T.List[_T]: ...
 @T.overload
 def unholder(item: T.List[T.Union[_T, 'ObjectHolder[_T]']]) -> T.List[_T]: ...
 
-def unholder(item):  # type: ignore  # TODO for some reason mypy throws the "Function is missing a type annotation" error
+def unholder(item):  # type: ignore  # TODO fix overload (somehow)
     """Get the held item of an object holder or list of object holders."""
     if isinstance(item, list):
         return [i.held_object if hasattr(i, 'held_object') else i for i in item]

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -947,7 +947,7 @@ def do_define(regex: T.Pattern[str], line: str, confdata: 'ConfigurationData', v
         for token in arr[2:]:
             try:
                 (v, desc) = confdata.get(token)
-                define_value += [v]
+                define_value += [str(v)]
             except KeyError:
                 define_value += [token]
         return ' '.join(define_value)

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -19,7 +19,7 @@ import stat
 import time
 import platform, subprocess, operator, os, shlex, shutil, re
 import collections
-from enum import Enum
+from enum import IntEnum
 from functools import lru_cache, wraps
 from itertools import tee, filterfalse
 import typing as T
@@ -323,32 +323,7 @@ def classify_unity_sources(compilers: T.Iterable['CompilerType'], sources: T.Ite
     return compsrclist
 
 
-class OrderedEnum(Enum):
-    """
-    An Enum which additionally offers homogeneous ordered comparison.
-    """
-    def __ge__(self, other: object) -> bool:
-        if self.__class__ is other.__class__ and isinstance(other, OrderedEnum)and isinstance(self.value, int) and isinstance(other.value, int):
-            return self.value >= other.value
-        return NotImplemented
-
-    def __gt__(self, other: object) -> bool:
-        if self.__class__ is other.__class__ and isinstance(other, OrderedEnum)and isinstance(self.value, int) and isinstance(other.value, int):
-            return self.value > other.value
-        return NotImplemented
-
-    def __le__(self, other: object) -> bool:
-        if self.__class__ is other.__class__ and isinstance(other, OrderedEnum)and isinstance(self.value, int) and isinstance(other.value, int):
-            return self.value <= other.value
-        return NotImplemented
-
-    def __lt__(self, other: object) -> bool:
-        if self.__class__ is other.__class__ and isinstance(other, OrderedEnum) and isinstance(self.value, int) and isinstance(other.value, int):
-            return self.value < other.value
-        return NotImplemented
-
-
-class MachineChoice(OrderedEnum):
+class MachineChoice(IntEnum):
 
     """Enum class representing one of the two abstract machine names used in
     most places: the build, and host, machines.
@@ -1572,7 +1547,7 @@ def path_is_in_root(path: Path, root: Path, resolve: bool = False) -> bool:
         return False
     return True
 
-class LibType(Enum):
+class LibType(IntEnum):
 
     """Enumeration for library types."""
 

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -25,6 +25,10 @@ from glob import glob
 from mesonbuild import mesonlib
 from mesonbuild.environment import detect_ninja
 from mesonbuild.templates.samplefactory import sameple_generator
+import typing as T
+
+if T.TYPE_CHECKING:
+    import argparse
 
 '''
 we currently have one meson template at this time.
@@ -49,7 +53,7 @@ meson compile -C builddir
 '''
 
 
-def create_sample(options) -> None:
+def create_sample(options: 'argparse.Namespace') -> None:
     '''
     Based on what arguments are passed we check for a match in language
     then check for project type and create new Meson samples project.
@@ -63,7 +67,7 @@ def create_sample(options) -> None:
         raise RuntimeError('Unreachable code')
     print(INFO_MESSAGE)
 
-def autodetect_options(options, sample: bool = False) -> None:
+def autodetect_options(options: 'argparse.Namespace', sample: bool = False) -> None:
     '''
     Here we autodetect options for args not passed in so don't have to
     think about it.
@@ -129,7 +133,7 @@ def autodetect_options(options, sample: bool = False) -> None:
             raise SystemExit("Can't autodetect language, please specify it with -l.")
         print("Detected language: " + options.language)
 
-def add_arguments(parser):
+def add_arguments(parser: 'argparse.ArgumentParser') -> None:
     '''
     Here we add args for that the user can passed when making a new
     Meson project.
@@ -146,7 +150,7 @@ def add_arguments(parser):
     parser.add_argument('--type', default=DEFAULT_PROJECT, choices=('executable', 'library'), help="project type. default: {} based project".format(DEFAULT_PROJECT))
     parser.add_argument('--version', default=DEFAULT_VERSION, help="project version. default: {}".format(DEFAULT_VERSION))
 
-def run(options) -> int:
+def run(options: 'argparse.Namespace') -> int:
     '''
     Here we generate the new Meson sample project.
     '''

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -30,7 +30,8 @@ from .mparser import BaseNode, FunctionNode, ArrayNode, ArgumentNode, StringNode
 from .interpreter import Interpreter
 from pathlib import PurePath
 import typing as T
-import os, argparse
+import os
+import argparse
 
 def get_meson_info_file(info_dir: str) -> str:
     return os.path.join(info_dir, 'meson-info.json')

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -254,11 +254,9 @@ def list_buildoptions(coredata: cdata.CoreData, subprojects: T.Optional[T.List[s
         'compiler',
         machine='host',
     )
+    tmp_dict = dict(coredata.flatten_lang_iterator(coredata.compiler_options.build.items()))  # type: T.Dict[str, cdata.UserOption]
     add_keys(
-        {
-            'build.' + k: o for k, o in
-            coredata.flatten_lang_iterator(coredata.compiler_options.build.items())
-        },
+        {'build.' + k: o for k, o in tmp_dict.items()},
         'compiler',
         machine='build',
     )
@@ -305,10 +303,10 @@ def list_deps(coredata: cdata.CoreData) -> T.List[T.Dict[str, T.Union[str, T.Lis
                         'link_args': d.get_link_args()}]
     return result
 
-def get_test_list(testdata: backends.TestSerialisation) -> T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]]:
+def get_test_list(testdata: T.List[backends.TestSerialisation]) -> T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]]:
     result = []  # type: T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]]
     for t in testdata:
-        to = {}
+        to = {}  # type: T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]
         if isinstance(t.fname, str):
             fname = [t.fname]
         else:
@@ -329,21 +327,21 @@ def get_test_list(testdata: backends.TestSerialisation) -> T.List[T.Dict[str, T.
         result.append(to)
     return result
 
-def list_tests(testdata: backends.TestSerialisation) -> T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]]:
+def list_tests(testdata: T.List[backends.TestSerialisation]) -> T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]]:
     return get_test_list(testdata)
 
-def list_benchmarks(benchdata: backends.TestSerialisation) -> T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]]:
+def list_benchmarks(benchdata: T.List[backends.TestSerialisation]) -> T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]]:
     return get_test_list(benchdata)
 
 def list_projinfo(builddata: build.Build) -> T.Dict[str, T.Union[str, T.List[T.Dict[str, str]]]]:
     result = {'version': builddata.project_version,
               'descriptive_name': builddata.project_name,
-              'subproject_dir': builddata.subproject_dir}
+              'subproject_dir': builddata.subproject_dir}    # type: T.Dict[str, T.Union[str, T.List[T.Dict[str, str]]]]
     subprojects = []
     for k, v in builddata.subprojects.items():
         c = {'name': k,
              'version': v,
-             'descriptive_name': builddata.projects.get(k)}
+             'descriptive_name': builddata.projects.get(k)}  # type: T.Dict[str, str]
         subprojects.append(c)
     result['subprojects'] = subprojects
     return result
@@ -391,6 +389,7 @@ def run(options: argparse.Namespace) -> int:
         # Make sure that log entries in other parts of meson don't interfere with the JSON output
         mlog.disable()
         backend = backends.get_backend_from_name(options.backend)
+        assert backend is not None
         intr = IntrospectionInterpreter(sourcedir, '', backend.name, visitors = [AstIDGenerator(), AstIndentationGenerator(), AstConditionLevel()])
         intr.analyze()
         # Re-enable logging just in case

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -56,7 +56,7 @@ def colorize_console() -> bool:
     sys.stdout.colorize_console = _colorize_console  # type: ignore[attr-defined]
     return _colorize_console
 
-def setup_console():
+def setup_console() -> None:
     # on Windows, a subprocess might call SetConsoleMode() on the console
     # connected to stdout and turn off ANSI escape processing. Call this after
     # running a subprocess to ensure we turn it on again.

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -19,14 +19,18 @@ import os
 
 from .. import build
 from ..mesonlib import unholder
+import typing as T
 
+if T.TYPE_CHECKING:
+    from ..interpreter import Interpreter
+    from ..interpreterbase import TYPE_var
 
 class ExtensionModule:
-    def __init__(self, interpreter):
+    def __init__(self, interpreter: 'Interpreter') -> None:
         self.interpreter = interpreter
-        self.snippets = set() # List of methods that operate only on the interpreter.
+        self.snippets = set()  # type: T.Set[str] # List of methods that operate only on the interpreter.
 
-    def is_snippet(self, funcname):
+    def is_snippet(self, funcname: str) -> bool:
         return funcname in self.snippets
 
 
@@ -69,7 +73,7 @@ def is_module_library(fname):
 
 
 class ModuleReturnValue:
-    def __init__(self, return_value, new_objects):
+    def __init__(self, return_value: 'TYPE_var', new_objects: T.List['TYPE_var']) -> None:
         self.return_value = return_value
         assert(isinstance(new_objects, list))
         self.new_objects = new_objects

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -24,11 +24,11 @@ from ..interpreterbase import FeatureNew
 
 from ..interpreterbase import stringArgs, noKwargs
 if T.TYPE_CHECKING:
-    from ..interpreter import ModuleState
+    from ..interpreter import Interpreter, ModuleState
 
 class FSModule(ExtensionModule):
 
-    def __init__(self, interpreter):
+    def __init__(self, interpreter: 'Interpreter') -> None:
         super().__init__(interpreter)
         self.snippets.add('generate_dub_file')
 
@@ -36,7 +36,7 @@ class FSModule(ExtensionModule):
         """
         make an absolute path from a relative path, WITHOUT resolving symlinks
         """
-        return Path(state.source_root) / state.subdir / Path(arg).expanduser()
+        return Path(state.source_root) / Path(state.subdir) / Path(arg).expanduser()
 
     def _resolve_dir(self, state: 'ModuleState', arg: str) -> Path:
         """
@@ -193,5 +193,5 @@ class FSModule(ExtensionModule):
         new = original.stem
         return ModuleReturnValue(str(new), [])
 
-def initialize(*args, **kwargs) -> FSModule:
+def initialize(*args: T.Any, **kwargs: T.Any) -> FSModule:
     return FSModule(*args, **kwargs)

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -35,25 +35,34 @@ ESCAPE_SEQUENCE_SINGLE_RE = re.compile(r'''
     )''', re.UNICODE | re.VERBOSE)
 
 class MesonUnicodeDecodeError(MesonException):
-    def __init__(self, match):
-        super().__init__("%s" % match)
+    def __init__(self, match: str) -> None:
+        super().__init__(match)
         self.match = match
 
-def decode_match(match):
+def decode_match(match: T.Match[str]) -> str:
     try:
-        return codecs.decode(match.group(0), 'unicode_escape')
+        return codecs.decode(match.group(0).encode(), 'unicode_escape')
     except UnicodeDecodeError:
         raise MesonUnicodeDecodeError(match.group(0))
 
 class ParseException(MesonException):
-    def __init__(self, text, line, lineno, colno):
+    def __init__(self, text: str, line: str, lineno: int, colno: int) -> None:
         # Format as error message, followed by the line with the error, followed by a caret to show the error column.
-        super().__init__("%s\n%s\n%s" % (text, line, '%s^' % (' ' * colno)))
+        super().__init__("{}\n{}\n{}".format(text, line, '{}^'.format(' ' * colno)))
         self.lineno = lineno
         self.colno = colno
 
 class BlockParseException(MesonException):
-    def __init__(self, text, line, lineno, colno, start_line, start_lineno, start_colno):
+    def __init__(
+                self,
+                text: str,
+                line: str,
+                lineno: int,
+                colno: int,
+                start_line: str,
+                start_lineno: int,
+                start_colno: int,
+            ) -> None:
         # This can be formatted in two ways - one if the block start and end are on the same line, and a different way if they are on different lines.
 
         if lineno == start_lineno:
@@ -88,10 +97,12 @@ class Token(T.Generic[TV_TokenTypes]):
         self.bytespan = bytespan      # type: T.Tuple[int, int]
         self.value = value            # type: TV_TokenTypes
 
-    def __eq__(self, other) -> bool:
+    def __eq__(self, other: T.Any) -> bool:
         if isinstance(other, str):
             return self.tid == other
-        return self.tid == other.tid
+        elif isinstance(other, Token):
+            return self.tid == other.tid
+        return NotImplemented
 
 class Lexer:
     def __init__(self, code: str):
@@ -261,7 +272,7 @@ class IdNode(ElementaryNode[str]):
         super().__init__(token)
         assert isinstance(self.value, str)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "Id node: '%s' (%d, %d)." % (self.value, self.lineno, self.colno)
 
 class NumberNode(ElementaryNode[int]):
@@ -274,7 +285,7 @@ class StringNode(ElementaryNode[str]):
         super().__init__(token)
         assert isinstance(self.value, str)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "String node: '%s' (%d, %d)." % (self.value, self.lineno, self.colno)
 
 class ContinueNode(ElementaryNode):
@@ -703,7 +714,7 @@ class Parser:
             s = self.statement()
         return a
 
-    def method_call(self, source_object) -> MethodNode:
+    def method_call(self, source_object: BaseNode) -> MethodNode:
         methodname = self.e9()
         if not(isinstance(methodname, IdNode)):
             raise ParseException('Method name must be plain id',
@@ -717,7 +728,7 @@ class Parser:
             return self.method_call(method)
         return method
 
-    def index_call(self, source_object) -> IndexNode:
+    def index_call(self, source_object: BaseNode) -> IndexNode:
         index_statement = self.statement()
         self.expect('rbracket')
         return IndexNode(source_object, index_statement)
@@ -750,7 +761,7 @@ class Parser:
         clause.elseblock = self.elseblock()
         return clause
 
-    def elseifblock(self, clause) -> None:
+    def elseifblock(self, clause: IfClauseNode) -> None:
         while self.accept('elif'):
             s = self.statement()
             self.expect('eol')

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -97,7 +97,7 @@ class Token(T.Generic[TV_TokenTypes]):
         self.bytespan = bytespan      # type: T.Tuple[int, int]
         self.value = value            # type: TV_TokenTypes
 
-    def __eq__(self, other: T.Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, str):
             return self.tid == other
         elif isinstance(other, Token):

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -178,12 +178,18 @@ class MesonApp:
             logger_fun = mlog.log
         else:
             logger_fun = mlog.debug
-        logger_fun('Build machine cpu family:', mlog.bold(intr.builtin['build_machine'].cpu_family_method([], {})))
-        logger_fun('Build machine cpu:', mlog.bold(intr.builtin['build_machine'].cpu_method([], {})))
-        mlog.log('Host machine cpu family:', mlog.bold(intr.builtin['host_machine'].cpu_family_method([], {})))
-        mlog.log('Host machine cpu:', mlog.bold(intr.builtin['host_machine'].cpu_method([], {})))
-        logger_fun('Target machine cpu family:', mlog.bold(intr.builtin['target_machine'].cpu_family_method([], {})))
-        logger_fun('Target machine cpu:', mlog.bold(intr.builtin['target_machine'].cpu_method([], {})))
+        build_machine = intr.builtin['build_machine']
+        host_machine = intr.builtin['build_machine']
+        target_machine = intr.builtin['target_machine']
+        assert isinstance(build_machine, interpreter.MachineHolder)
+        assert isinstance(host_machine, interpreter.MachineHolder)
+        assert isinstance(target_machine, interpreter.MachineHolder)
+        logger_fun('Build machine cpu family:', mlog.bold(build_machine.cpu_family_method([], {})))
+        logger_fun('Build machine cpu:', mlog.bold(build_machine.cpu_method([], {})))
+        mlog.log('Host machine cpu family:', mlog.bold(host_machine.cpu_family_method([], {})))
+        mlog.log('Host machine cpu:', mlog.bold(host_machine.cpu_method([], {})))
+        logger_fun('Target machine cpu family:', mlog.bold(target_machine.cpu_family_method([], {})))
+        logger_fun('Target machine cpu:', mlog.bold(target_machine.cpu_method([], {})))
         try:
             if self.options.profile:
                 fname = os.path.join(self.build_dir, 'meson-private', 'profile-interpreter.log')

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -31,7 +31,7 @@ from . import mintro
 from .mconf import make_lower_case
 from .mesonlib import MesonException
 
-def add_arguments(parser):
+def add_arguments(parser: argparse.ArgumentParser) -> None:
     coredata.register_builtin_arguments(parser)
     parser.add_argument('--native-file',
                         default=[],
@@ -59,7 +59,7 @@ def add_arguments(parser):
     parser.add_argument('sourcedir', nargs='?', default=None)
 
 class MesonApp:
-    def __init__(self, options):
+    def __init__(self, options: argparse.Namespace) -> None:
         (self.source_dir, self.build_dir) = self.validate_dirs(options.builddir,
                                                                options.sourcedir,
                                                                options.reconfigure,
@@ -150,7 +150,7 @@ class MesonApp:
                 raise SystemExit('Directory does not contain a valid build tree:\n{}'.format(build_dir))
         return src_dir, build_dir
 
-    def generate(self):
+    def generate(self) -> None:
         env = environment.Environment(self.source_dir, self.build_dir, self.options)
         mlog.initialize(env.get_log_dir(), self.options.fatal_warnings)
         if self.options.profile:
@@ -158,7 +158,7 @@ class MesonApp:
         with mesonlib.BuildDirLock(self.build_dir):
             self._generate(env)
 
-    def _generate(self, env):
+    def _generate(self, env: environment.Environment) -> None:
         mlog.debug('Build started at', datetime.datetime.now().isoformat())
         mlog.debug('Main binary:', sys.executable)
         mlog.debug('Build Options:', coredata.get_cmd_line_options(self.build_dir, self.options))
@@ -239,7 +239,7 @@ class MesonApp:
                     os.unlink(cdf)
             raise
 
-def run(options) -> int:
+def run(options: argparse.Namespace) -> int:
     coredata.parse_cmd_line_options(options)
     app = MesonApp(options)
     app.generate()

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -62,7 +62,6 @@ optname_regex = re.compile('[^a-zA-Z0-9_-]')
 def StringParser(description, kwargs):
     return coredata.UserStringOption(description,
                                      kwargs.get('value', ''),
-                                     kwargs.get('choices', []),
                                      kwargs.get('yield', coredata.default_yielding))
 
 @permitted_kwargs({'value', 'yield'})
@@ -134,11 +133,11 @@ option_types = {'string': StringParser,
                 } # type: T.Dict[str, T.Callable[[str, T.Dict], coredata.UserOption]]
 
 class OptionInterpreter:
-    def __init__(self, subproject):
+    def __init__(self, subproject: str) -> None:
         self.options = {}
         self.subproject = subproject
 
-    def process(self, option_file):
+    def process(self, option_file: str) -> None:
         try:
             with open(option_file, 'r', encoding='utf8') as f:
                 ast = mparser.Parser(f.read(), option_file).parse()
@@ -159,7 +158,7 @@ class OptionInterpreter:
                 e.file = option_file
                 raise e
 
-    def reduce_single(self, arg):
+    def reduce_single(self, arg: T.Union[str, mparser.BaseNode]) -> T.Union[str, int, bool]:
         if isinstance(arg, str):
             return arg
         elif isinstance(arg, (mparser.StringNode, mparser.BooleanNode,
@@ -189,7 +188,7 @@ class OptionInterpreter:
         else:
             raise OptionException('Arguments may only be string, int, bool, or array of those.')
 
-    def reduce_arguments(self, args):
+    def reduce_arguments(self, args: mparser.ArgumentNode) -> T.Tuple[T.List[T.Union[str, int, bool]], T.Dict[str, T.Union[str, int, bool]]]:
         assert(isinstance(args, mparser.ArgumentNode))
         if args.incorrect_order():
             raise OptionException('All keyword arguments must be after positional arguments.')
@@ -202,7 +201,7 @@ class OptionInterpreter:
             reduced_kw[key.value] = self.reduce_single(a)
         return reduced_pos, reduced_kw
 
-    def evaluate_statement(self, node):
+    def evaluate_statement(self, node: mparser.BaseNode) -> None:
         if not isinstance(node, mparser.FunctionNode):
             raise OptionException('Option file may only contain option definitions')
         func_name = node.func_name

--- a/mesonbuild/scripts/__init__.py
+++ b/mesonbuild/scripts/__init__.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def destdir_join(d1, d2):
+# TODO: consider switching to pathlib for this
+def destdir_join(d1: str, d2: str) -> str:
     # c:\destdir + c:\prefix must produce c:\destdir\prefix
     if len(d1) > 1 and d1[1] == ':' \
             and len(d2) > 1 and d2[1] == ':':

--- a/mesonbuild/scripts/clangformat.py
+++ b/mesonbuild/scripts/clangformat.py
@@ -18,8 +18,9 @@ from concurrent.futures import ThreadPoolExecutor
 
 from ..environment import detect_clangformat
 from ..compilers import lang_suffixes
+import typing as T
 
-def clangformat(exelist, srcdir_name, builddir_name):
+def clangformat(exelist: T.List[str], srcdir_name: str, builddir_name: str) -> int:
     srcdir = pathlib.Path(srcdir_name)
     suffixes = set(lang_suffixes['c']).union(set(lang_suffixes['cpp']))
     suffixes.add('h')
@@ -33,7 +34,7 @@ def clangformat(exelist, srcdir_name, builddir_name):
         [x.result() for x in futures]
     return 0
 
-def run(args):
+def run(args: T.List[str]) -> int:
     srcdir_name = args[0]
     builddir_name = args[1]
 

--- a/mesonbuild/scripts/clangtidy.py
+++ b/mesonbuild/scripts/clangtidy.py
@@ -16,10 +16,11 @@ import pathlib
 import subprocess
 import shutil
 from concurrent.futures import ThreadPoolExecutor
+import typing as T
 
 from ..compilers import lang_suffixes
 
-def manual_clangformat(srcdir_name, builddir_name):
+def manual_clangformat(srcdir_name: str, builddir_name: str) -> int:
     srcdir = pathlib.Path(srcdir_name)
     suffixes = set(lang_suffixes['c']).union(set(lang_suffixes['cpp']))
     suffixes.add('h')
@@ -34,7 +35,7 @@ def manual_clangformat(srcdir_name, builddir_name):
         [max(returncode, x.result().returncode) for x in futures]
     return returncode
 
-def clangformat(srcdir_name, builddir_name):
+def clangformat(srcdir_name: str, builddir_name: str) -> int:
     run_clang_tidy = None
     for rct in ('run-clang-tidy', 'run-clang-tidy.py'):
         if shutil.which(rct):
@@ -45,8 +46,9 @@ def clangformat(srcdir_name, builddir_name):
     else:
         print('Could not find run-clang-tidy, running checks manually.')
         manual_clangformat(srcdir_name, builddir_name)
+    return 0
 
-def run(args):
+def run(args: T.List[str]) -> int:
     srcdir_name = args[0]
     builddir_name = args[1]
     return clangformat(srcdir_name, builddir_name)

--- a/mesonbuild/scripts/cleantrees.py
+++ b/mesonbuild/scripts/cleantrees.py
@@ -16,8 +16,9 @@ import os
 import sys
 import shutil
 import pickle
+import typing as T
 
-def rmtrees(build_dir, trees):
+def rmtrees(build_dir: str, trees: T.List[str]) -> None:
     for t in trees:
         # Never delete trees outside of the builddir
         if os.path.isabs(t):
@@ -28,7 +29,7 @@ def rmtrees(build_dir, trees):
         if os.path.isdir(bt):
             shutil.rmtree(bt, ignore_errors=True)
 
-def run(args):
+def run(args: T.List[str]) -> int:
     if len(args) != 1:
         print('Cleaner script for Meson. Do not run on your own please.')
         print('cleantrees.py <data-file>')

--- a/mesonbuild/scripts/commandrunner.py
+++ b/mesonbuild/scripts/commandrunner.py
@@ -17,8 +17,9 @@ what to run, sets up the environment and executes the command."""
 
 import sys, os, subprocess, shutil, shlex
 import re
+import typing as T
 
-def run_command(source_dir, build_dir, subdir, meson_command, command, arguments):
+def run_command(source_dir: str, build_dir: str, subdir: str, meson_command: T.List[str], command: str, arguments: T.List[str]) -> subprocess.Popen:
     env = {'MESON_SOURCE_ROOT': source_dir,
            'MESON_BUILD_ROOT': build_dir,
            'MESON_SUBDIR': subdir,
@@ -50,24 +51,24 @@ def run_command(source_dir, build_dir, subdir, meson_command, command, arguments
         print('Could not execute command "{}": {}'.format(command, err))
         sys.exit(1)
 
-def is_python_command(cmdname):
+def is_python_command(cmdname: str) -> bool:
     end_py_regex = r'python(3|3\.\d+)?(\.exe)?$'
     return re.search(end_py_regex, cmdname) is not None
 
-def run(args):
+def run(args: T.List[str]) -> int:
     if len(args) < 4:
         print('commandrunner.py <source dir> <build dir> <subdir> <command> [arguments]')
         return 1
     src_dir = args[0]
     build_dir = args[1]
     subdir = args[2]
-    meson_command = args[3]
-    if is_python_command(meson_command):
-        meson_command = [meson_command, args[4]]
+    meson_bin = args[3]
+    if is_python_command(meson_bin):
+        meson_command = [meson_bin, args[4]]
         command = args[5]
         arguments = args[6:]
     else:
-        meson_command = [meson_command]
+        meson_command = [meson_bin]
         command = args[4]
         arguments = args[5:]
     pc = run_command(src_dir, build_dir, subdir, meson_command, command, arguments)

--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -15,8 +15,9 @@
 from mesonbuild import environment, mesonlib
 
 import argparse, sys, os, subprocess, pathlib, stat
+import typing as T
 
-def coverage(outputs, source_root, subproject_root, build_root, log_dir, use_llvm_cov):
+def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build_root: str, log_dir: str, use_llvm_cov: bool) -> int:
     outfiles = []
     exitcode = 0
 
@@ -146,7 +147,7 @@ def coverage(outputs, source_root, subproject_root, build_root, log_dir, use_llv
 
     return exitcode
 
-def run(args):
+def run(args: T.List[str]) -> int:
     if not os.path.isfile('build.ninja'):
         print('Coverage currently only works with the Ninja backend.')
         return 1

--- a/mesonbuild/scripts/delwithsuffix.py
+++ b/mesonbuild/scripts/delwithsuffix.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import os, sys
+import typing as T
 
-def run(args):
+def run(args: T.List[str]) -> int:
     if len(args) != 2:
         print('delwithsuffix.py <root of subdir to process> <suffix to delete>')
         sys.exit(1)

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -328,7 +328,7 @@ class Elf(DataSizes):
         new_rpath = b':'.join(new_rpaths)
 
         if len(old_rpath) < len(new_rpath):
-            msg = "New rpath must not be longer than the old one.\n Old: {!r}\n New: {!r}".format(old_rpath, new_rpath)
+            msg = "New rpath must not be longer than the old one.\n Old: {}\n New: {}".format(old_rpath.decode('utf-8'), new_rpath.decode('utf-8'))
             sys.exit(msg)
         # The linker does read-only string deduplication. If there is a
         # string that shares a suffix with the rpath, they might get

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -15,6 +15,7 @@
 
 import sys, struct
 import shutil, subprocess
+import typing as T
 
 from ..mesonlib import OrderedSet
 
@@ -30,7 +31,7 @@ DT_MIPS_RLD_MAP_REL = 1879048245
 INSTALL_NAME_TOOL = False
 
 class DataSizes:
-    def __init__(self, ptrsize, is_le):
+    def __init__(self, ptrsize: int, is_le: bool) -> None:
         if is_le:
             p = '<'
         else:
@@ -57,7 +58,7 @@ class DataSizes:
             self.OffSize = 4
 
 class DynamicEntry(DataSizes):
-    def __init__(self, ifile, ptrsize, is_le):
+    def __init__(self, ifile: T.BinaryIO, ptrsize: int, is_le: bool) -> None:
         super().__init__(ptrsize, is_le)
         self.ptrsize = ptrsize
         if ptrsize == 64:
@@ -67,7 +68,7 @@ class DynamicEntry(DataSizes):
             self.d_tag = struct.unpack(self.Sword, ifile.read(self.SwordSize))[0]
             self.val = struct.unpack(self.Word, ifile.read(self.WordSize))[0]
 
-    def write(self, ofile):
+    def write(self, ofile: T.BinaryIO) -> None:
         if self.ptrsize == 64:
             ofile.write(struct.pack(self.Sxword, self.d_tag))
             ofile.write(struct.pack(self.XWord, self.val))
@@ -76,7 +77,7 @@ class DynamicEntry(DataSizes):
             ofile.write(struct.pack(self.Word, self.val))
 
 class SectionHeader(DataSizes):
-    def __init__(self, ifile, ptrsize, is_le):
+    def __init__(self, ifile: T.BinaryIO, ptrsize: int, is_le: bool) -> None:
         super().__init__(ptrsize, is_le)
         if ptrsize == 64:
             is_64 = True
@@ -116,10 +117,12 @@ class SectionHeader(DataSizes):
             self.sh_entsize = struct.unpack(self.Word, ifile.read(self.WordSize))[0]
 
 class Elf(DataSizes):
-    def __init__(self, bfile, verbose=True):
+    def __init__(self, bfile: str, verbose: bool = True) -> None:
         self.bfile = bfile
         self.verbose = verbose
         self.bf = open(bfile, 'r+b')
+        self.sections = []  # type: T.List[SectionHeader]
+        self.dynamic = []   # type: T.List[DynamicEntry]
         try:
             (self.ptrsize, self.is_le) = self.detect_elf_type()
             super().__init__(self.ptrsize, self.is_le)
@@ -130,18 +133,18 @@ class Elf(DataSizes):
             self.bf.close()
             raise
 
-    def __enter__(self):
+    def __enter__(self) -> 'Elf':
         return self
 
-    def __del__(self):
+    def __del__(self) -> None:
         if self.bf:
             self.bf.close()
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type: T.Any, exc_value: T.Any, traceback: T.Any) -> None:
         self.bf.close()
         self.bf = None
 
-    def detect_elf_type(self):
+    def detect_elf_type(self) -> T.Tuple[int, bool]:
         data = self.bf.read(6)
         if data[1:4] != b'ELF':
             # This script gets called to non-elf targets too
@@ -163,7 +166,7 @@ class Elf(DataSizes):
             sys.exit('File "%s" has unknown ELF endianness.' % self.bfile)
         return ptrsize, is_le
 
-    def parse_header(self):
+    def parse_header(self) -> None:
         self.bf.seek(0)
         self.e_ident = struct.unpack('16s', self.bf.read(16))[0]
         self.e_type = struct.unpack(self.Half, self.bf.read(self.HalfSize))[0]
@@ -180,13 +183,12 @@ class Elf(DataSizes):
         self.e_shnum = struct.unpack(self.Half, self.bf.read(self.HalfSize))[0]
         self.e_shstrndx = struct.unpack(self.Half, self.bf.read(self.HalfSize))[0]
 
-    def parse_sections(self):
+    def parse_sections(self) -> None:
         self.bf.seek(self.e_shoff)
-        self.sections = []
         for _ in range(self.e_shnum):
             self.sections.append(SectionHeader(self.bf, self.ptrsize, self.is_le))
 
-    def read_str(self):
+    def read_str(self) -> bytes:
         arr = []
         x = self.bf.read(1)
         while x != b'\0':
@@ -196,17 +198,17 @@ class Elf(DataSizes):
                 raise RuntimeError('Tried to read past the end of the file')
         return b''.join(arr)
 
-    def find_section(self, target_name):
+    def find_section(self, target_name: bytes) -> T.Optional[SectionHeader]:
         section_names = self.sections[self.e_shstrndx]
         for i in self.sections:
             self.bf.seek(section_names.sh_offset + i.sh_name)
             name = self.read_str()
             if name == target_name:
                 return i
+        return None
 
-    def parse_dynamic(self):
+    def parse_dynamic(self) -> None:
         sec = self.find_section(b'.dynamic')
-        self.dynamic = []
         if sec is None:
             return
         self.bf.seek(sec.sh_offset)
@@ -216,14 +218,14 @@ class Elf(DataSizes):
             if e.d_tag == 0:
                 break
 
-    def print_section_names(self):
+    def print_section_names(self) -> None:
         section_names = self.sections[self.e_shstrndx]
         for i in self.sections:
             self.bf.seek(section_names.sh_offset + i.sh_name)
             name = self.read_str()
             print(name.decode())
 
-    def print_soname(self):
+    def print_soname(self) -> None:
         soname = None
         strtab = None
         for i in self.dynamic:
@@ -237,14 +239,16 @@ class Elf(DataSizes):
         self.bf.seek(strtab.val + soname.val)
         print(self.read_str())
 
-    def get_entry_offset(self, entrynum):
+    def get_entry_offset(self, entrynum: int) -> T.Optional[int]:
         sec = self.find_section(b'.dynstr')
         for i in self.dynamic:
             if i.d_tag == entrynum:
-                return sec.sh_offset + i.val
+                res = sec.sh_offset + i.val
+                assert isinstance(res, int)
+                return res
         return None
 
-    def print_rpath(self):
+    def print_rpath(self) -> None:
         offset = self.get_entry_offset(DT_RPATH)
         if offset is None:
             print("This file does not have an rpath.")
@@ -252,7 +256,7 @@ class Elf(DataSizes):
             self.bf.seek(offset)
             print(self.read_str())
 
-    def print_runpath(self):
+    def print_runpath(self) -> None:
         offset = self.get_entry_offset(DT_RUNPATH)
         if offset is None:
             print("This file does not have a runpath.")
@@ -260,7 +264,7 @@ class Elf(DataSizes):
             self.bf.seek(offset)
             print(self.read_str())
 
-    def print_deps(self):
+    def print_deps(self) -> None:
         sec = self.find_section(b'.dynstr')
         deps = []
         for i in self.dynamic:
@@ -272,7 +276,7 @@ class Elf(DataSizes):
             name = self.read_str()
             print(name)
 
-    def fix_deps(self, prefix):
+    def fix_deps(self, prefix: bytes) -> None:
         sec = self.find_section(b'.dynstr')
         deps = []
         for i in self.dynamic:
@@ -290,15 +294,13 @@ class Elf(DataSizes):
                 self.bf.seek(offset)
                 self.bf.write(newname)
 
-    def fix_rpath(self, rpath_dirs_to_remove, new_rpath):
+    def fix_rpath(self, rpath_dirs_to_remove: T.List[bytes], new_rpath: bytes) -> None:
         # The path to search for can be either rpath or runpath.
         # Fix both of them to be sure.
         self.fix_rpathtype_entry(rpath_dirs_to_remove, new_rpath, DT_RPATH)
         self.fix_rpathtype_entry(rpath_dirs_to_remove, new_rpath, DT_RUNPATH)
 
-    def fix_rpathtype_entry(self, rpath_dirs_to_remove, new_rpath, entrynum):
-        if isinstance(new_rpath, str):
-            new_rpath = new_rpath.encode('utf8')
+    def fix_rpathtype_entry(self, rpath_dirs_to_remove: T.List[bytes], new_rpath: bytes, entrynum: int) -> None:
         rp_off = self.get_entry_offset(entrynum)
         if rp_off is None:
             if self.verbose:
@@ -326,7 +328,7 @@ class Elf(DataSizes):
         new_rpath = b':'.join(new_rpaths)
 
         if len(old_rpath) < len(new_rpath):
-            msg = "New rpath must not be longer than the old one.\n Old: {}\n New: {}".format(old_rpath, new_rpath)
+            msg = "New rpath must not be longer than the old one.\n Old: {!r}\n New: {!r}".format(old_rpath, new_rpath)
             sys.exit(msg)
         # The linker does read-only string deduplication. If there is a
         # string that shares a suffix with the rpath, they might get
@@ -343,7 +345,7 @@ class Elf(DataSizes):
             self.bf.write(new_rpath)
             self.bf.write(b'\0')
 
-    def remove_rpath_entry(self, entrynum):
+    def remove_rpath_entry(self, entrynum: int) -> None:
         sec = self.find_section(b'.dynamic')
         if sec is None:
             return None
@@ -363,7 +365,7 @@ class Elf(DataSizes):
             entry.write(self.bf)
         return None
 
-def fix_elf(fname, rpath_dirs_to_remove, new_rpath, verbose=True):
+def fix_elf(fname: str, rpath_dirs_to_remove: T.List[bytes], new_rpath: T.Optional[bytes], verbose: bool = True) -> None:
     with Elf(fname, verbose) as e:
         if new_rpath is None:
             e.print_rpath()
@@ -371,7 +373,7 @@ def fix_elf(fname, rpath_dirs_to_remove, new_rpath, verbose=True):
         else:
             e.fix_rpath(rpath_dirs_to_remove, new_rpath)
 
-def get_darwin_rpaths_to_remove(fname):
+def get_darwin_rpaths_to_remove(fname: str) -> T.List[str]:
     out = subprocess.check_output(['otool', '-l', fname],
                                   universal_newlines=True,
                                   stderr=subprocess.DEVNULL)
@@ -389,7 +391,7 @@ def get_darwin_rpaths_to_remove(fname):
             result.append(rp)
     return result
 
-def fix_darwin(fname, new_rpath, final_path, install_name_mappings):
+def fix_darwin(fname: str, new_rpath: str, final_path: str, install_name_mappings: T.Dict[str, str]) -> None:
     try:
         rpaths = get_darwin_rpaths_to_remove(fname)
     except subprocess.CalledProcessError:
@@ -439,7 +441,7 @@ def fix_darwin(fname, new_rpath, final_path, install_name_mappings):
     except Exception as err:
         raise SystemExit(err)
 
-def fix_jar(fname):
+def fix_jar(fname: str) -> None:
     subprocess.check_call(['jar', 'xfv', fname, 'META-INF/MANIFEST.MF'])
     with open('META-INF/MANIFEST.MF', 'r+') as f:
         lines = f.readlines()
@@ -450,7 +452,7 @@ def fix_jar(fname):
         f.truncate()
     subprocess.check_call(['jar', 'ufm', fname, 'META-INF/MANIFEST.MF'])
 
-def fix_rpath(fname, rpath_dirs_to_remove, new_rpath, final_path, install_name_mappings, verbose=True):
+def fix_rpath(fname: str, rpath_dirs_to_remove: T.List[bytes], new_rpath: T.Union[str, bytes], final_path: str, install_name_mappings: T.Dict[str, str], verbose: bool = True) -> None:
     global INSTALL_NAME_TOOL
     # Static libraries, import libraries, debug information, headers, etc
     # never have rpaths
@@ -461,6 +463,8 @@ def fix_rpath(fname, rpath_dirs_to_remove, new_rpath, final_path, install_name_m
         if fname.endswith('.jar'):
             fix_jar(fname)
             return
+        if isinstance(new_rpath, str):
+            new_rpath = new_rpath.encode('utf8')
         fix_elf(fname, rpath_dirs_to_remove, new_rpath, verbose)
         return
     except SystemExit as e:
@@ -473,6 +477,8 @@ def fix_rpath(fname, rpath_dirs_to_remove, new_rpath, final_path, install_name_m
     # (upto 30ms), which is significant with --only-changed. For details, see:
     # https://github.com/mesonbuild/meson/pull/6612#discussion_r378581401
     if INSTALL_NAME_TOOL is False:
-        INSTALL_NAME_TOOL = shutil.which('install_name_tool')
+        INSTALL_NAME_TOOL = bool(shutil.which('install_name_tool'))
     if INSTALL_NAME_TOOL:
+        if isinstance(new_rpath, bytes):
+            new_rpath = new_rpath.decode('utf8')
         fix_darwin(fname, new_rpath, final_path, install_name_mappings)

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -311,7 +311,7 @@ class Elf(DataSizes):
         old_rpath = self.read_str()
         # Some rpath entries may come from multiple sources.
         # Only add each one once.
-        new_rpaths = OrderedSet()
+        new_rpaths = OrderedSet()  # type: OrderedSet[bytes]
         if new_rpath:
             new_rpaths.add(new_rpath)
         if old_rpath:

--- a/mesonbuild/scripts/dirchanger.py
+++ b/mesonbuild/scripts/dirchanger.py
@@ -16,8 +16,9 @@
 the command given in the rest of the arguments.'''
 
 import os, subprocess, sys
+import typing as T
 
-def run(args):
+def run(args: T.List[str]) -> int:
     dirname = args[0]
     command = args[1:]
 

--- a/mesonbuild/scripts/gettext.py
+++ b/mesonbuild/scripts/gettext.py
@@ -17,6 +17,7 @@ import shutil
 import argparse
 import subprocess
 from . import destdir_join
+import typing as T
 
 parser = argparse.ArgumentParser()
 parser.add_argument('command')
@@ -27,7 +28,7 @@ parser.add_argument('--localedir', default='')
 parser.add_argument('--subdir', default='')
 parser.add_argument('--extra-args', default='')
 
-def read_linguas(src_sub):
+def read_linguas(src_sub: str) -> T.List[str]:
     # Syntax of this file is documented here:
     # https://www.gnu.org/software/gettext/manual/html_node/po_002fLINGUAS.html
     linguas = os.path.join(src_sub, 'LINGUAS')
@@ -43,7 +44,7 @@ def read_linguas(src_sub):
         print('Could not find file LINGUAS in {}'.format(src_sub))
         return []
 
-def run_potgen(src_sub, pkgname, datadirs, args):
+def run_potgen(src_sub: str, pkgname: str, datadirs: str, args: T.List[str]) -> int:
     listfile = os.path.join(src_sub, 'POTFILES.in')
     if not os.path.exists(listfile):
         listfile = os.path.join(src_sub, 'POTFILES')
@@ -60,13 +61,13 @@ def run_potgen(src_sub, pkgname, datadirs, args):
                             '-D', os.environ['MESON_SOURCE_ROOT'], '-k_', '-o', ofile] + args,
                            env=child_env)
 
-def gen_gmo(src_sub, bld_sub, langs):
+def gen_gmo(src_sub: str, bld_sub: str, langs: T.List[str]) -> int:
     for l in langs:
         subprocess.check_call(['msgfmt', os.path.join(src_sub, l + '.po'),
                                '-o', os.path.join(bld_sub, l + '.gmo')])
     return 0
 
-def update_po(src_sub, pkgname, langs):
+def update_po(src_sub: str, pkgname: str, langs: T.List[str]) -> int:
     potfile = os.path.join(src_sub, pkgname + '.pot')
     for l in langs:
         pofile = os.path.join(src_sub, l + '.po')
@@ -76,7 +77,7 @@ def update_po(src_sub, pkgname, langs):
             subprocess.check_call(['msginit', '--input', potfile, '--output-file', pofile, '--locale', l, '--no-translator'])
     return 0
 
-def do_install(src_sub, bld_sub, dest, pkgname, langs):
+def do_install(src_sub: str, bld_sub: str, dest: str, pkgname: str, langs: T.List[str]) -> int:
     for l in langs:
         srcfile = os.path.join(bld_sub, l + '.gmo')
         outfile = os.path.join(dest, l, 'LC_MESSAGES',
@@ -88,7 +89,7 @@ def do_install(src_sub, bld_sub, dest, pkgname, langs):
         print('Installing %s to %s' % (srcfile, outfile))
     return 0
 
-def run(args):
+def run(args: T.List[str]) -> int:
     options = parser.parse_args(args)
     subcmd = options.command
     langs = options.langs.split('@@') if options.langs else None
@@ -120,3 +121,4 @@ def run(args):
     else:
         print('Unknown subcommand.')
         return 1
+    return 0

--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -18,6 +18,7 @@ import shutil
 import argparse
 from ..mesonlib import MesonException, Popen_safe, is_windows, is_cygwin, split_args
 from . import destdir_join
+import typing as T
 
 parser = argparse.ArgumentParser()
 
@@ -50,7 +51,7 @@ for tool in ['scan', 'scangobj', 'mkdb', 'mkhtml', 'fixxref']:
     program_name = 'gtkdoc-' + tool
     parser.add_argument('--' + program_name, dest=program_name.replace('-', '_'))
 
-def gtkdoc_run_check(cmd, cwd, library_paths=None):
+def gtkdoc_run_check(cmd: T.List[str], cwd: str, library_paths: T.Optional[T.List[str]] = None) -> None:
     if library_paths is None:
         library_paths = []
 
@@ -85,12 +86,12 @@ def gtkdoc_run_check(cmd, cwd, library_paths=None):
         except UnicodeEncodeError:
             pass
 
-def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
-                 main_file, module, module_version,
-                 html_args, scan_args, fixxref_args, mkdb_args,
-                 gobject_typesfile, scanobjs_args, run, ld, cc, ldflags, cflags,
-                 html_assets, content_files, ignore_headers, namespace,
-                 expand_content_files, mode, options):
+def build_gtkdoc(source_root: str, build_root: str, doc_subdir: str, src_subdirs: T.List[str],
+                 main_file: str, module: str, module_version: str,
+                 html_args: T.List[str], scan_args: T.List[str], fixxref_args: T.List[str], mkdb_args: T.List[str],
+                 gobject_typesfile: str, scanobjs_args: T.List[str], run: str, ld: str, cc: str, ldflags: str, cflags: str,
+                 html_assets: T.List[str], content_files: T.List[str], ignore_headers: T.List[str], namespace: str,
+                 expand_content_files: T.List[str], mode: str, options: argparse.Namespace) -> None:
     print("Building documentation for %s" % module)
 
     src_dir_args = []
@@ -217,13 +218,13 @@ def build_gtkdoc(source_root, build_root, doc_subdir, src_subdirs,
         shutil.move(os.path.join(htmldir, '{}.devhelp2'.format(module)),
                     os.path.join(htmldir, '{}-{}.devhelp2'.format(module, module_version)))
 
-def install_gtkdoc(build_root, doc_subdir, install_prefix, datadir, module):
+def install_gtkdoc(build_root: str, doc_subdir: str, install_prefix: str, datadir: str, module: str) -> None:
     source = os.path.join(build_root, doc_subdir, 'html')
     final_destination = os.path.join(install_prefix, datadir, module)
     shutil.rmtree(final_destination, ignore_errors=True)
     shutil.copytree(source, final_destination)
 
-def run(args):
+def run(args: T.List[str]) -> int:
     options = parser.parse_args(args)
     if options.htmlargs:
         htmlargs = options.htmlargs.split('@@')

--- a/mesonbuild/scripts/hotdochelper.py
+++ b/mesonbuild/scripts/hotdochelper.py
@@ -5,6 +5,7 @@ import subprocess
 from . import destdir_join
 
 import argparse
+import typing as T
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--install')
@@ -14,7 +15,7 @@ parser.add_argument('--builddir')
 parser.add_argument('--project-version')
 
 
-def run(argv):
+def run(argv: T.List[str]) -> int:
     options, args = parser.parse_known_args(argv)
     subenv = os.environ.copy()
 
@@ -23,7 +24,7 @@ def run(argv):
 
     res = subprocess.call(args, cwd=options.builddir, env=subenv)
     if res != 0:
-        exit(res)
+        return res
 
     if options.install:
         source_dir = os.path.join(options.builddir, options.install)
@@ -34,3 +35,4 @@ def run(argv):
 
         shutil.rmtree(installdir, ignore_errors=True)
         shutil.copytree(source_dir, installdir)
+    return 0

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -17,19 +17,20 @@ import sys
 import argparse
 import pickle
 import subprocess
+import typing as T
 
 from .. import mesonlib
 from ..backend.backends import ExecutableSerialisation
 
 options = None
 
-def buildparser():
+def buildparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description='Custom executable wrapper for Meson. Do not run on your own, mmm\'kay?')
     parser.add_argument('--unpickle')
     parser.add_argument('--capture')
     return parser
 
-def run_exe(exe):
+def run_exe(exe: ExecutableSerialisation) -> int:
     if exe.exe_runner:
         if not exe.exe_runner.found():
             raise AssertionError('BUG: Can\'t run cross-compiled exe {!r} with not-found '
@@ -74,7 +75,7 @@ def run_exe(exe):
         sys.stderr.buffer.write(stderr)
     return p.returncode
 
-def run(args):
+def run(args: T.List[str]) -> int:
     global options
     parser = buildparser()
     options, cmd_args = parser.parse_known_args(args)

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -57,7 +57,7 @@ def run_exe(exe: ExecutableSerialisation) -> int:
 
     if p.returncode == 0xc0000135:
         # STATUS_DLL_NOT_FOUND on Windows indicating a common problem that is otherwise hard to diagnose
-        raise FileNotFoundError('Missing DLLs on calling {!r}'.format(exe.name))
+        raise FileNotFoundError('Missing DLLs on calling {!r}'.format(cmd_args))
 
     if exe.capture and p.returncode == 0:
         skip_write = False

--- a/mesonbuild/scripts/msgfmthelper.py
+++ b/mesonbuild/scripts/msgfmthelper.py
@@ -15,6 +15,7 @@
 import argparse
 import subprocess
 import os
+import typing as T
 
 parser = argparse.ArgumentParser()
 parser.add_argument('input')
@@ -25,7 +26,7 @@ parser.add_argument('--datadirs', default='')
 parser.add_argument('args', default=[], metavar='extra msgfmt argument', nargs='*')
 
 
-def run(args):
+def run(args: T.List[str]) -> int:
     options = parser.parse_args(args)
     env = None
     if options.datadirs:

--- a/mesonbuild/scripts/regen_checker.py
+++ b/mesonbuild/scripts/regen_checker.py
@@ -14,10 +14,14 @@
 
 import sys, os
 import pickle, subprocess
+import typing as T
+
+if T.TYPE_CHECKING:
+    from ..backend.vs2010backend import RegenInfo
 
 # This could also be used for XCode.
 
-def need_regen(regeninfo, regen_timestamp):
+def need_regen(regeninfo: 'RegenInfo', regen_timestamp: float) -> bool:
     for i in regeninfo.depfiles:
         curfile = os.path.join(regeninfo.build_dir, i)
         curtime = os.stat(curfile).st_mtime
@@ -31,7 +35,7 @@ def need_regen(regeninfo, regen_timestamp):
     Vs2010Backend.touch_regen_timestamp(regeninfo.build_dir)
     return False
 
-def regen(regeninfo, meson_command, backend):
+def regen(regeninfo: 'RegenInfo', meson_command: T.List[str], backend: str) -> None:
     cmd = meson_command + ['--internal',
                            'regenerate',
                            regeninfo.build_dir,
@@ -39,19 +43,19 @@ def regen(regeninfo, meson_command, backend):
                            '--backend=' + backend]
     subprocess.check_call(cmd)
 
-def run(args):
+def run(args: T.List[str]) -> int:
     private_dir = args[0]
     dumpfile = os.path.join(private_dir, 'regeninfo.dump')
-    coredata = os.path.join(private_dir, 'coredata.dat')
+    coredata_file = os.path.join(private_dir, 'coredata.dat')
     with open(dumpfile, 'rb') as f:
-        regeninfo = pickle.load(f)
-    with open(coredata, 'rb') as f:
+        regeninfo = T.cast('RegenInfo', pickle.load(f))
+    with open(coredata_file, 'rb') as f:
         coredata = pickle.load(f)
     backend = coredata.get_builtin_option('backend')
     regen_timestamp = os.stat(dumpfile).st_mtime
     if need_regen(regeninfo, regen_timestamp):
         regen(regeninfo, coredata.meson_command, backend)
-    sys.exit(0)
+    return 0
 
 if __name__ == '__main__':
-    run(sys.argv[1:])
+    sys.exit(run(sys.argv[1:]))

--- a/mesonbuild/scripts/scanbuild.py
+++ b/mesonbuild/scripts/scanbuild.py
@@ -12,30 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import subprocess
 import shutil
 import tempfile
 from ..environment import detect_ninja, detect_scanbuild
+from pathlib import Path
+import typing as T
 
 
-def scanbuild(exelist, srcdir, blddir, privdir, logdir, args):
-    with tempfile.TemporaryDirectory(dir=privdir) as scandir:
+def scanbuild(exelist: T.List[str], srcdir: Path, blddir: Path, privdir: Path, logdir: Path, args: T.List[str]) -> int:
+    with tempfile.TemporaryDirectory(dir=str(privdir)) as scandir:
         meson_cmd = exelist + args
-        build_cmd = exelist + ['-o', logdir] + detect_ninja() + ['-C', scandir]
-        rc = subprocess.call(meson_cmd + [srcdir, scandir])
+        build_cmd = exelist + ['-o', str(logdir)] + detect_ninja() + ['-C', scandir]
+        rc = subprocess.call(meson_cmd + [str(srcdir), scandir])
         if rc != 0:
             return rc
         return subprocess.call(build_cmd)
 
 
-def run(args):
-    srcdir = args[0]
-    blddir = args[1]
+def run(args: T.List[str]) -> int:
+    srcdir = Path(args[0])
+    blddir = Path(args[1])
     meson_cmd = args[2:]
-    privdir = os.path.join(blddir, 'meson-private')
-    logdir = os.path.join(blddir, 'meson-logs/scanbuild')
-    shutil.rmtree(logdir, ignore_errors=True)
+    privdir = blddir / 'meson-private'
+    logdir = blddir / 'meson-logs' / 'scanbuild'
+    shutil.rmtree(str(logdir), ignore_errors=True)
 
     exelist = detect_scanbuild()
     if not exelist:

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -36,12 +36,12 @@ parser.add_argument('args', nargs='+')
 TOOL_WARNING_FILE = None
 RELINKING_WARNING = 'Relinking will always happen on source changes.'
 
-def dummy_syms(outfilename: str):
+def dummy_syms(outfilename: str) -> None:
     """Just touch it so relinking happens always."""
     with open(outfilename, 'w'):
         pass
 
-def write_if_changed(text: str, outfilename: str):
+def write_if_changed(text: str, outfilename: str) -> None:
     try:
         with open(outfilename, 'r') as f:
             oldtext = f.read()
@@ -52,13 +52,11 @@ def write_if_changed(text: str, outfilename: str):
     with open(outfilename, 'w') as f:
         f.write(text)
 
-def print_tool_warning(tool: list, msg: str, stderr: str = None):
+def print_tool_warning(tools: T.List[str], msg: str, stderr: T.Optional[str] = None) -> None:
     global TOOL_WARNING_FILE
     if os.path.exists(TOOL_WARNING_FILE):
         return
-    if len(tool) == 1:
-        tool = tool[0]
-    m = '{!r} {}. {}'.format(tool, msg, RELINKING_WARNING)
+    m = '{!r} {}. {}'.format(tools, msg, RELINKING_WARNING)
     if stderr:
         m += '\n' + stderr
     mlog.warning(m)
@@ -73,7 +71,7 @@ def get_tool(name: str) -> T.List[str]:
         return shlex.split(os.environ[evar])
     return [name]
 
-def call_tool(name: str, args: T.List[str], **kwargs) -> str:
+def call_tool(name: str, args: T.List[str], **kwargs: T.Any) -> str:
     tool = get_tool(name)
     try:
         p, output, e = Popen_safe(tool + args, **kwargs)
@@ -88,7 +86,7 @@ def call_tool(name: str, args: T.List[str], **kwargs) -> str:
         return None
     return output
 
-def call_tool_nowarn(tool: T.List[str], **kwargs) -> T.Tuple[str, str]:
+def call_tool_nowarn(tool: T.List[str], **kwargs: T.Any) -> T.Tuple[str, str]:
     try:
         p, output, e = Popen_safe(tool, **kwargs)
     except FileNotFoundError:
@@ -99,7 +97,7 @@ def call_tool_nowarn(tool: T.List[str], **kwargs) -> T.Tuple[str, str]:
         return None, e
     return output, None
 
-def gnu_syms(libfilename: str, outfilename: str):
+def gnu_syms(libfilename: str, outfilename: str) -> None:
     # Get the name of the library
     output = call_tool('readelf', ['-d', libfilename])
     if not output:
@@ -126,7 +124,7 @@ def gnu_syms(libfilename: str, outfilename: str):
         result += [' '.join(entry)]
     write_if_changed('\n'.join(result) + '\n', outfilename)
 
-def solaris_syms(libfilename: str, outfilename: str):
+def solaris_syms(libfilename: str, outfilename: str) -> None:
     # gnu_syms() works with GNU nm & readelf, not Solaris nm & elfdump
     origpath = os.environ['PATH']
     try:
@@ -135,7 +133,7 @@ def solaris_syms(libfilename: str, outfilename: str):
     finally:
         os.environ['PATH'] = origpath
 
-def osx_syms(libfilename: str, outfilename: str):
+def osx_syms(libfilename: str, outfilename: str) -> None:
     # Get the name of the library
     output = call_tool('otool', ['-l', libfilename])
     if not output:
@@ -156,7 +154,7 @@ def osx_syms(libfilename: str, outfilename: str):
     result += [' '.join(x.split()[0:2]) for x in output.split('\n')]
     write_if_changed('\n'.join(result) + '\n', outfilename)
 
-def openbsd_syms(libfilename: str, outfilename: str):
+def openbsd_syms(libfilename: str, outfilename: str) -> None:
     # Get the name of the library
     output = call_tool('readelf', ['-d', libfilename])
     if not output:
@@ -173,7 +171,7 @@ def openbsd_syms(libfilename: str, outfilename: str):
     result += [' '.join(x.split()[0:2]) for x in output.split('\n') if x and not x.endswith('U ')]
     write_if_changed('\n'.join(result) + '\n', outfilename)
 
-def cygwin_syms(impfilename: str, outfilename: str):
+def cygwin_syms(impfilename: str, outfilename: str) -> None:
     # Get the name of the library
     output = call_tool('dlltool', ['-I', impfilename])
     if not output:
@@ -242,23 +240,23 @@ def _get_implib_exports(impfilename: str) -> T.Tuple[T.List[str], str]:
         all_stderr += e
     return ([], all_stderr)
 
-def windows_syms(impfilename: str, outfilename: str):
+def windows_syms(impfilename: str, outfilename: str) -> None:
     # Get the name of the library
     result, e = _get_implib_dllname(impfilename)
     if not result:
-        print_tool_warning('lib, llvm-lib, dlltool', 'do not work or were not found', e)
+        print_tool_warning(['lib', 'llvm-lib', 'dlltool'], 'do not work or were not found', e)
         dummy_syms(outfilename)
         return
     # Get a list of all symbols exported
     symbols, e = _get_implib_exports(impfilename)
     if not symbols:
-        print_tool_warning('dumpbin, llvm-nm, nm', 'do not work or were not found', e)
+        print_tool_warning(['dumpbin', 'llvm-nm', 'nm'], 'do not work or were not found', e)
         dummy_syms(outfilename)
         return
     result += symbols
     write_if_changed('\n'.join(result) + '\n', outfilename)
 
-def gen_symbols(libfilename: str, impfilename: str, outfilename: str, cross_host: str):
+def gen_symbols(libfilename: str, impfilename: str, outfilename: str, cross_host: str) -> None:
     if cross_host is not None:
         # In case of cross builds just always relink. In theory we could
         # determine the correct toolset, but we would need to use the correct
@@ -295,7 +293,7 @@ def gen_symbols(libfilename: str, impfilename: str, outfilename: str, cross_host
                 pass
         dummy_syms(outfilename)
 
-def run(args):
+def run(args: T.List[str]) -> int:
     global TOOL_WARNING_FILE
     options = parser.parse_args(args)
     if len(options.args) != 4:

--- a/mesonbuild/scripts/tags.py
+++ b/mesonbuild/scripts/tags.py
@@ -48,4 +48,6 @@ def run(args: T.List[str]) -> int:
     srcdir_name = args[1]
     os.chdir(srcdir_name)
     assert tool_name in ['cscope', 'ctags', 'etags']
-    return T.cast(int, globals()[tool_name]())
+    res = globals()[tool_name]()
+    assert isinstance(res, int)
+    return res

--- a/mesonbuild/scripts/tags.py
+++ b/mesonbuild/scripts/tags.py
@@ -15,9 +15,9 @@
 import os
 import subprocess
 from pathlib import Path
+import typing as T
 
-
-def ls_as_bytestream():
+def ls_as_bytestream() -> bytes:
     if os.path.exists('.git'):
         return subprocess.run(['git', 'ls-tree', '-r', '--name-only', 'HEAD'],
                               stdout=subprocess.PIPE).stdout
@@ -28,24 +28,24 @@ def ls_as_bytestream():
     return '\n'.join(files).encode()
 
 
-def cscope():
+def cscope() -> int:
     ls = b'\n'.join([b'"%s"' % f for f in ls_as_bytestream().split()])
     return subprocess.run(['cscope', '-v', '-b', '-i-'], input=ls).returncode
 
 
-def ctags():
+def ctags() -> int:
     ls = ls_as_bytestream()
     return subprocess.run(['ctags', '-L-'], input=ls).returncode
 
 
-def etags():
+def etags() -> int:
     ls = ls_as_bytestream()
     return subprocess.run(['etags', '-'], input=ls).returncode
 
 
-def run(args):
+def run(args: T.List[str]) -> int:
     tool_name = args[0]
     srcdir_name = args[1]
     os.chdir(srcdir_name)
     assert tool_name in ['cscope', 'ctags', 'etags']
-    return globals()[tool_name]()
+    return T.cast(int, globals()[tool_name]())

--- a/mesonbuild/scripts/uninstall.py
+++ b/mesonbuild/scripts/uninstall.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import os
+import typing as T
 
 logfile = 'meson-logs/install-log.txt'
 
-def do_uninstall(log):
+def do_uninstall(log: str) -> None:
     failures = 0
     successes = 0
     for line in open(log):
@@ -38,7 +39,7 @@ def do_uninstall(log):
     print('Failed:', failures)
     print('\nRemember that files created by custom scripts have not been removed.')
 
-def run(args):
+def run(args: T.List[str]) -> int:
     if args:
         print('Weird error.')
         return 1

--- a/mesonbuild/scripts/vcstagger.py
+++ b/mesonbuild/scripts/vcstagger.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import sys, os, subprocess, re
+import typing as T
 
-
-def config_vcs_tag(infile, outfile, fallback, source_dir, replace_string, regex_selector, cmd):
+def config_vcs_tag(infile: str, outfile: str, fallback: str, source_dir: str, replace_string: str, regex_selector: str, cmd: T.List[str]) -> None:
     try:
         output = subprocess.check_output(cmd, cwd=source_dir)
         new_string = re.search(regex_selector, output.decode()).group(1).strip()
@@ -34,7 +34,7 @@ def config_vcs_tag(infile, outfile, fallback, source_dir, replace_string, regex_
             f.write(new_data)
 
 
-def run(args):
+def run(args: T.List[str]) -> int:
     infile, outfile, fallback, source_dir, replace_string, regex_selector = args[0:6]
     command = args[6:]
     config_vcs_tag(infile, outfile, fallback, source_dir, replace_string, regex_selector, command)

--- a/mesonbuild/scripts/yelphelper.py
+++ b/mesonbuild/scripts/yelphelper.py
@@ -20,6 +20,7 @@ from .. import mlog
 from ..mesonlib import has_path_sep
 from . import destdir_join
 from .gettext import read_linguas
+import typing as T
 
 parser = argparse.ArgumentParser()
 parser.add_argument('command')
@@ -31,19 +32,19 @@ parser.add_argument('--media', dest='media', default='')
 parser.add_argument('--langs', dest='langs', default='')
 parser.add_argument('--symlinks', type=bool, dest='symlinks', default=False)
 
-def build_pot(srcdir, project_id, sources):
+def build_pot(srcdir: str, project_id: str, sources: T.List[str]) -> None:
     # Must be relative paths
     sources = [os.path.join('C', source) for source in sources]
     outfile = os.path.join(srcdir, project_id + '.pot')
     subprocess.call(['itstool', '-o', outfile] + sources)
 
-def update_po(srcdir, project_id, langs):
+def update_po(srcdir: str, project_id: str, langs: T.List[str]) -> None:
     potfile = os.path.join(srcdir, project_id + '.pot')
     for lang in langs:
         pofile = os.path.join(srcdir, lang, lang + '.po')
         subprocess.call(['msgmerge', '-q', '-o', pofile, pofile, potfile])
 
-def build_translations(srcdir, blddir, langs):
+def build_translations(srcdir: str, blddir: str, langs: T.List[str]) -> None:
     for lang in langs:
         outdir = os.path.join(blddir, lang)
         os.makedirs(outdir, exist_ok=True)
@@ -52,14 +53,14 @@ def build_translations(srcdir, blddir, langs):
             '-o', os.path.join(outdir, lang + '.gmo')
         ])
 
-def merge_translations(blddir, sources, langs):
+def merge_translations(blddir: str, sources: T.List[str], langs: T.List[str]) -> None:
     for lang in langs:
         subprocess.call([
             'itstool', '-m', os.path.join(blddir, lang, lang + '.gmo'),
             '-o', os.path.join(blddir, lang)
         ] + sources)
 
-def install_help(srcdir, blddir, sources, media, langs, install_dir, destdir, project_id, symlinks):
+def install_help(srcdir: str, blddir: str, sources: T.List[str], media: T.List[str], langs: T.List[str], install_dir: str, destdir: str, project_id: str, symlinks: bool) -> None:
     c_install_dir = os.path.join(install_dir, 'C', project_id)
     for lang in langs + ['C']:
         indir = destdir_join(destdir, os.path.join(install_dir, lang, project_id))
@@ -101,7 +102,7 @@ def install_help(srcdir, blddir, sources, media, langs, install_dir, destdir, pr
             shutil.copyfile(infile, outfile)
             shutil.copystat(infile, outfile)
 
-def run(args):
+def run(args: T.List[str]) -> int:
     options = parser.parse_args(args)
     langs = options.langs.split('@@') if options.langs else []
     media = options.media.split('@@') if options.media else []
@@ -129,3 +130,4 @@ def run(args):
             merge_translations(build_subdir, abs_sources, langs)
         install_help(src_subdir, build_subdir, sources, media, langs, install_dir,
                      destdir, options.project_id, options.symlinks)
+    return 0

--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -146,7 +146,7 @@ class CppProject(SampleImpl):
         self.name = options.name
         self.version = options.version
 
-    def create_executable(self):
+    def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.cpp'
         open(source_name, 'w').write(hello_cpp_template.format(project_name=self.name))
@@ -155,7 +155,7 @@ class CppProject(SampleImpl):
                                                                        source_name=source_name,
                                                                        version=self.version))
 
-    def create_library(self):
+    def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         uppercase_token = lowercase_token.upper()
         class_name = uppercase_token[0] + lowercase_token[1:]

--- a/mesonbuild/templates/cstemplates.py
+++ b/mesonbuild/templates/cstemplates.py
@@ -95,7 +95,7 @@ class CSharpProject(SampleImpl):
         self.name = options.name
         self.version = options.version
 
-    def create_executable(self):
+    def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         uppercase_token = lowercase_token.upper()
         class_name = uppercase_token[0] + lowercase_token[1:]
@@ -107,7 +107,7 @@ class CSharpProject(SampleImpl):
                                                                       source_name=source_name,
                                                                       version=self.version))
 
-    def create_library(self):
+    def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         uppercase_token = lowercase_token.upper()
         class_name = uppercase_token[0] + lowercase_token[1:]

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -129,7 +129,7 @@ class CProject(SampleImpl):
         self.name = options.name
         self.version = options.version
 
-    def create_executable(self):
+    def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.c'
         open(source_name, 'w').write(hello_c_template.format(project_name=self.name))
@@ -138,7 +138,7 @@ class CProject(SampleImpl):
                                                                      source_name=source_name,
                                                                      version=self.version))
 
-    def create_library(self):
+    def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         uppercase_token = lowercase_token.upper()
         function_name = lowercase_token[0:3] + '_func'

--- a/mesonbuild/templates/cudatemplates.py
+++ b/mesonbuild/templates/cudatemplates.py
@@ -146,7 +146,7 @@ class CudaProject(SampleImpl):
         self.name = options.name
         self.version = options.version
 
-    def create_executable(self):
+    def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.cu'
         open(source_name, 'w').write(hello_cuda_template.format(project_name=self.name))
@@ -155,7 +155,7 @@ class CudaProject(SampleImpl):
                                                                         source_name=source_name,
                                                                         version=self.version))
 
-    def create_library(self):
+    def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         uppercase_token = lowercase_token.upper()
         class_name = uppercase_token[0] + lowercase_token[1:]

--- a/mesonbuild/templates/dlangtemplates.py
+++ b/mesonbuild/templates/dlangtemplates.py
@@ -107,7 +107,7 @@ class DlangProject(SampleImpl):
         self.name = options.name
         self.version = options.version
 
-    def create_executable(self):
+    def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.d'
         open(source_name, 'w').write(hello_d_template.format(project_name=self.name))
@@ -116,7 +116,7 @@ class DlangProject(SampleImpl):
                                                                      source_name=source_name,
                                                                      version=self.version))
 
-    def create_library(self):
+    def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         uppercase_token = lowercase_token.upper()
         function_name = lowercase_token[0:3] + '_func'

--- a/mesonbuild/templates/fortrantemplates.py
+++ b/mesonbuild/templates/fortrantemplates.py
@@ -106,7 +106,7 @@ class FortranProject(SampleImpl):
         self.name = options.name
         self.version = options.version
 
-    def create_executable(self):
+    def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.f90'
         open(source_name, 'w').write(hello_fortran_template.format(project_name=self.name))
@@ -115,7 +115,7 @@ class FortranProject(SampleImpl):
                                                                            source_name=source_name,
                                                                            version=self.version))
 
-    def create_library(self):
+    def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         uppercase_token = lowercase_token.upper()
         function_name = lowercase_token[0:3] + '_func'

--- a/mesonbuild/templates/javatemplates.py
+++ b/mesonbuild/templates/javatemplates.py
@@ -99,7 +99,7 @@ class JavaProject(SampleImpl):
         self.name = options.name
         self.version = options.version
 
-    def create_executable(self):
+    def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         uppercase_token = lowercase_token.upper()
         class_name = uppercase_token[0] + lowercase_token[1:]
@@ -111,7 +111,7 @@ class JavaProject(SampleImpl):
                                                                         source_name=source_name,
                                                                         version=self.version))
 
-    def create_library(self):
+    def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         uppercase_token = lowercase_token.upper()
         class_name = uppercase_token[0] + lowercase_token[1:]

--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
+
 meson_executable_template = '''project('{project_name}', '{language}',
   version : '{version}',
   default_options : [{default_options}])
@@ -33,7 +35,7 @@ jar('{executable}',
 '''
 
 
-def create_meson_build(options):
+def create_meson_build(options: argparse.Namespace) -> None:
     if options.type != 'executable':
         raise SystemExit('\nGenerating a meson.build file from existing sources is\n'
                          'supported only for project type "executable".\n'

--- a/mesonbuild/templates/objcpptemplates.py
+++ b/mesonbuild/templates/objcpptemplates.py
@@ -129,7 +129,7 @@ class ObjCppProject(SampleImpl):
         self.name = options.name
         self.version = options.version
 
-    def create_executable(self):
+    def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.mm'
         open(source_name, 'w').write(hello_objcpp_template.format(project_name=self.name))
@@ -138,7 +138,7 @@ class ObjCppProject(SampleImpl):
                                                                           source_name=source_name,
                                                                           version=self.version))
 
-    def create_library(self):
+    def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         uppercase_token = lowercase_token.upper()
         function_name = lowercase_token[0:3] + '_func'

--- a/mesonbuild/templates/objctemplates.py
+++ b/mesonbuild/templates/objctemplates.py
@@ -129,7 +129,7 @@ class ObjCProject(SampleImpl):
         self.name = options.name
         self.version = options.version
 
-    def create_executable(self):
+    def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.m'
         open(source_name, 'w').write(hello_objc_template.format(project_name=self.name))
@@ -138,7 +138,7 @@ class ObjCProject(SampleImpl):
                                                                         source_name=source_name,
                                                                         version=self.version))
 
-    def create_library(self):
+    def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         uppercase_token = lowercase_token.upper()
         function_name = lowercase_token[0:3] + '_func'

--- a/mesonbuild/templates/rusttemplates.py
+++ b/mesonbuild/templates/rusttemplates.py
@@ -77,7 +77,7 @@ class RustProject(SampleImpl):
         self.name = options.name
         self.version = options.version
 
-    def create_executable(self):
+    def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.rs'
         open(source_name, 'w').write(hello_rust_template.format(project_name=self.name))
@@ -86,7 +86,7 @@ class RustProject(SampleImpl):
                                                                         source_name=source_name,
                                                                         version=self.version))
 
-    def create_library(self):
+    def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         uppercase_token = lowercase_token.upper()
         function_name = lowercase_token[0:3] + '_func'

--- a/mesonbuild/templates/samplefactory.py
+++ b/mesonbuild/templates/samplefactory.py
@@ -21,9 +21,11 @@ from mesonbuild.templates.objctemplates import ObjCProject
 from mesonbuild.templates.cpptemplates import CppProject
 from mesonbuild.templates.cstemplates import CSharpProject
 from mesonbuild.templates.ctemplates import CProject
+from mesonbuild.templates.sampleimpl import SampleImpl
 
+import argparse
 
-def sameple_generator(options):
+def sameple_generator(options: argparse.Namespace) -> SampleImpl:
     return {
         'c': CProject,
         'cpp': CppProject,

--- a/mesonbuild/templates/sampleimpl.py
+++ b/mesonbuild/templates/sampleimpl.py
@@ -14,8 +14,8 @@
 
 
 class SampleImpl:
-    def create_executable(self):
+    def create_executable(self) -> None:
         raise NotImplementedError('Sample implementation for "executable" not implemented!')
 
-    def create_library(self):
+    def create_library(self) -> None:
         raise NotImplementedError('Sample implementation for "library" not implemented!')

--- a/mesonbuild/wrap/__init__.py
+++ b/mesonbuild/wrap/__init__.py
@@ -52,6 +52,6 @@ class WrapMode(Enum):
         return self.name
 
     @staticmethod
-    def from_string(mode_name: str):
+    def from_string(mode_name: str) -> 'WrapMode':
         g = string_to_value[mode_name]
         return WrapMode(g)

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -107,7 +107,7 @@ class WrapNotFoundException(WrapException):
 class PackageDefinition:
     def __init__(self, fname: str):
         self.filename = fname
-        self.type = None  # type: str
+        self.type = None  # type: T.Optional[str]
         self.values = {} # type: T.Dict[str, str]
         self.provided_deps = {} # type: T.Dict[str, T.Optional[str]]
         self.provided_programs = [] # type: T.List[str]

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -27,7 +27,7 @@ normal_modules = [
   'mesonbuild/mcompile.py',
   'mesonbuild/mesonlib.py',
   'mesonbuild/arglist.py',
-  # 'mesonbuild/envconfig.py',
+  'mesonbuild/envconfig.py',
 ]
 
 strict_modules = [

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -34,7 +34,7 @@ strict_modules = [
   'mesonbuild/mesonlib.py',
   'mesonbuild/mlog.py',
   'mesonbuild/ast',
-  # 'mesonbuild/wrap',
+  'mesonbuild/wrap',
   'run_mypy.py',
 ]
 

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+
+import sys
+import subprocess
+from pathlib import Path
+import typing as T
+
+normal_modules = [
+  'mesonbuild/interpreterbase.py',
+  'mesonbuild/mtest.py',
+  'mesonbuild/minit.py',
+  'mesonbuild/mintro.py',
+  'mesonbuild/mparser.py',
+  'mesonbuild/msetup.py',
+  'mesonbuild/ast',
+  'mesonbuild/wrap',
+  'tools',
+  'mesonbuild/modules/fs.py',
+  'mesonbuild/dependencies/boost.py',
+  'mesonbuild/dependencies/mpi.py',
+  'mesonbuild/dependencies/hdf5.py',
+  'mesonbuild/compilers/mixins/intel.py',
+  'mesonbuild/mlog.py',
+  'mesonbuild/mcompile.py',
+  'mesonbuild/mesonlib.py',
+  'mesonbuild/arglist.py',
+  # 'mesonbuild/envconfig.py',
+]
+
+strict_modules = [
+  'mesonbuild/interpreterbase.py',
+  # 'mesonbuild/mesonlib.py',
+  'mesonbuild/mlog.py',
+  'mesonbuild/ast',
+]
+
+normal_args = ['--follow-imports=skip']
+strict_args = normal_args + [
+  '--warn-redundant-casts',
+  '--warn-unused-ignores',
+  '--warn-return-any',
+  # '--warn-unreachable',
+  '--disallow-untyped-calls',
+  '--disallow-untyped-defs',
+  '--disallow-incomplete-defs',
+  '--disallow-untyped-decorators',
+  # '--disallow-any-expr',
+  # '--disallow-any-decorated',
+  # '--disallow-any-explicit',
+  # '--disallow-any-generics',
+  # '--disallow-subclassing-any',
+]
+
+def run_mypy(opts: T.List[str], modules: T.List[str]) -> int:
+  root = Path(__file__).absolute().parent
+  p = subprocess.run(
+    [sys.executable, '-m', 'mypy'] + opts + modules,
+    cwd=root,
+  )
+  return p.returncode
+
+def check_mypy() -> None:
+  try:
+    import mypy
+  except ImportError:
+    print('Failed import mypy')
+    sys.exit(1)
+
+def main() -> int:
+  res = 0
+  check_mypy()
+
+  print('Running normal mypy check...')
+  res += run_mypy(normal_args, normal_modules)
+
+  print('\n\nRunning struct mypy check...')
+  res += run_mypy(strict_args, strict_modules)
+
+  return res
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -18,6 +18,7 @@ normal_modules = [
   'mesonbuild/scripts',
   'tools',
   'mesonbuild/modules/fs.py',
+  # 'mesonbuild/dependencies/base.py',
   'mesonbuild/dependencies/boost.py',
   'mesonbuild/dependencies/mpi.py',
   'mesonbuild/dependencies/hdf5.py',
@@ -37,6 +38,8 @@ strict_modules = [
   'mesonbuild/ast',
   'mesonbuild/wrap',
   'mesonbuild/scripts',
+  'mesonbuild/dependencies/boost.py',
+  'mesonbuild/dependencies/hdf5.py',
   'run_mypy.py',
   'tools',
 ]

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -2,6 +2,7 @@
 
 import sys
 import subprocess
+import argparse
 from pathlib import Path
 import typing as T
 
@@ -29,9 +30,10 @@ normal_modules = [
 
 strict_modules = [
   'mesonbuild/interpreterbase.py',
-  # 'mesonbuild/mesonlib.py',
+  'mesonbuild/mesonlib.py',
   'mesonbuild/mlog.py',
   'mesonbuild/ast',
+  'run_mypy.py',
 ]
 
 normal_args = ['--follow-imports=skip']
@@ -44,6 +46,8 @@ strict_args = normal_args + [
   '--disallow-untyped-defs',
   '--disallow-incomplete-defs',
   '--disallow-untyped-decorators',
+  '--no-implicit-optional',
+  '--strict-equality',
   # '--disallow-any-expr',
   # '--disallow-any-decorated',
   # '--disallow-any-explicit',
@@ -69,6 +73,14 @@ def check_mypy() -> None:
 def main() -> int:
   res = 0
   check_mypy()
+
+  parser = argparse.ArgumentParser(description='Process some integers.')
+  parser.add_argument('-p', '--pretty', action='store_true', help='pretty print mypy errors')
+
+  args = parser.parse_args()
+  if args.pretty:
+    normal_args.append('--pretty')
+    strict_args.append('--pretty')
 
   print('Running normal mypy check...')
   res += run_mypy(normal_args, normal_modules)

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -6,78 +6,33 @@ import argparse
 from pathlib import Path
 import typing as T
 
-normal_modules = [
-  'mesonbuild/interpreterbase.py',
-  'mesonbuild/mtest.py',
-  'mesonbuild/minit.py',
-  'mesonbuild/mintro.py',
-  'mesonbuild/mparser.py',
-  'mesonbuild/msetup.py',
+modules = [
+  # fully typed submodules
   'mesonbuild/ast',
-  'mesonbuild/wrap',
   'mesonbuild/scripts',
-  'tools',
-  'mesonbuild/modules/fs.py',
-  # 'mesonbuild/dependencies/base.py',
+  'mesonbuild/wrap',
+
+  # specific files
+  'mesonbuild/arglist.py',
+  # 'mesonbuild/compilers/mixins/intel.py',
   'mesonbuild/dependencies/boost.py',
+  'mesonbuild/dependencies/hdf5.py',
   'mesonbuild/dependencies/mpi.py',
-  'mesonbuild/dependencies/hdf5.py',
-  'mesonbuild/compilers/mixins/intel.py',
-  'mesonbuild/mlog.py',
+  'mesonbuild/envconfig.py',
+  'mesonbuild/interpreterbase.py',
   'mesonbuild/mcompile.py',
   'mesonbuild/mesonlib.py',
-  'mesonbuild/arglist.py',
-  'mesonbuild/envconfig.py',
-]
-
-strict_modules = [
-  'mesonbuild/interpreterbase.py',
-  'mesonbuild/mtest.py',
   'mesonbuild/minit.py',
   'mesonbuild/mintro.py',
+  'mesonbuild/mlog.py',
+  'mesonbuild/modules/fs.py',
   'mesonbuild/mparser.py',
   'mesonbuild/msetup.py',
-  'mesonbuild/mcompile.py',
-  'mesonbuild/mesonlib.py',
-  'mesonbuild/mlog.py',
-  'mesonbuild/ast',
-  'mesonbuild/wrap',
-  'mesonbuild/scripts',
-  'mesonbuild/modules/fs.py',
-  'mesonbuild/dependencies/boost.py',
-  'mesonbuild/dependencies/hdf5.py',
-  'mesonbuild/compilers/mixins/intel.py',
-  'mesonbuild/arglist.py',
+  'mesonbuild/mtest.py',
+
   'run_mypy.py',
-  'tools',
+  'tools'
 ]
-
-normal_args = ['--follow-imports=skip']
-strict_args = normal_args + [
-  '--warn-redundant-casts',
-  '--warn-unused-ignores',
-  '--warn-return-any',
-  # '--warn-unreachable',
-  '--disallow-untyped-calls',
-  '--disallow-untyped-defs',
-  '--disallow-incomplete-defs',
-  '--disallow-untyped-decorators',
-  '--no-implicit-optional',
-  '--strict-equality',
-  # '--disallow-any-expr',
-  # '--disallow-any-decorated',
-  # '--disallow-any-explicit',
-  # '--disallow-any-generics',
-  # '--disallow-subclassing-any',
-]
-
-def run_mypy(opts: T.List[str], modules: T.List[str]) -> int:
-  root = Path(__file__).absolute().parent
-  p = subprocess.run(
-    [sys.executable, '-m', 'mypy'] + opts + modules,
-    cwd=root,
-  )
-  return p.returncode
 
 def check_mypy() -> None:
   try:
@@ -87,24 +42,23 @@ def check_mypy() -> None:
     sys.exit(1)
 
 def main() -> int:
-  res = 0
   check_mypy()
+
+  root = Path(__file__).absolute().parent
+  args = []  # type: T.List[str]
 
   parser = argparse.ArgumentParser(description='Process some integers.')
   parser.add_argument('-p', '--pretty', action='store_true', help='pretty print mypy errors')
 
-  args = parser.parse_args()
-  if args.pretty:
-    normal_args.append('--pretty')
-    strict_args.append('--pretty')
+  opts = parser.parse_args()
+  if opts.pretty:
+    args.append('--pretty')
 
-  print('Running normal mypy check...')
-  res += run_mypy(normal_args, normal_modules)
-
-  print('\n\nRunning struct mypy check...')
-  res += run_mypy(strict_args, strict_modules)
-
-  return res
+  p = subprocess.run(
+    [sys.executable, '-m', 'mypy'] + args + modules,
+    cwd=root,
+  )
+  return p.returncode
 
 if __name__ == '__main__':
   sys.exit(main())

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -40,6 +40,8 @@ strict_modules = [
   'mesonbuild/scripts',
   'mesonbuild/dependencies/boost.py',
   'mesonbuild/dependencies/hdf5.py',
+  'mesonbuild/compilers/mixins/intel.py',
+  'mesonbuild/arglist.py',
   'run_mypy.py',
   'tools',
 ]

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -32,7 +32,10 @@ normal_modules = [
 
 strict_modules = [
   'mesonbuild/interpreterbase.py',
+  'mesonbuild/minit.py',
   'mesonbuild/mparser.py',
+  'mesonbuild/msetup.py',
+  'mesonbuild/mcompile.py',
   'mesonbuild/mesonlib.py',
   'mesonbuild/mlog.py',
   'mesonbuild/ast',

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -36,6 +36,7 @@ strict_modules = [
   'mesonbuild/ast',
   'mesonbuild/wrap',
   'run_mypy.py',
+  'tools',
 ]
 
 normal_args = ['--follow-imports=skip']

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -15,6 +15,7 @@ modules = [
   # specific files
   'mesonbuild/arglist.py',
   # 'mesonbuild/compilers/mixins/intel.py',
+  # 'mesonbuild/coredata.py',
   'mesonbuild/dependencies/boost.py',
   'mesonbuild/dependencies/hdf5.py',
   'mesonbuild/dependencies/mpi.py',

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -30,9 +30,11 @@ normal_modules = [
 
 strict_modules = [
   'mesonbuild/interpreterbase.py',
+  'mesonbuild/mparser.py',
   'mesonbuild/mesonlib.py',
   'mesonbuild/mlog.py',
   'mesonbuild/ast',
+  # 'mesonbuild/wrap',
   'run_mypy.py',
 ]
 

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -15,6 +15,7 @@ normal_modules = [
   'mesonbuild/msetup.py',
   'mesonbuild/ast',
   'mesonbuild/wrap',
+  'mesonbuild/scripts',
   'tools',
   'mesonbuild/modules/fs.py',
   'mesonbuild/dependencies/boost.py',
@@ -35,6 +36,7 @@ strict_modules = [
   'mesonbuild/mlog.py',
   'mesonbuild/ast',
   'mesonbuild/wrap',
+  'mesonbuild/scripts',
   'run_mypy.py',
   'tools',
 ]

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -38,6 +38,7 @@ strict_modules = [
   'mesonbuild/ast',
   'mesonbuild/wrap',
   'mesonbuild/scripts',
+  'mesonbuild/modules/fs.py',
   'mesonbuild/dependencies/boost.py',
   'mesonbuild/dependencies/hdf5.py',
   'mesonbuild/compilers/mixins/intel.py',

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -32,7 +32,9 @@ normal_modules = [
 
 strict_modules = [
   'mesonbuild/interpreterbase.py',
+  'mesonbuild/mtest.py',
   'mesonbuild/minit.py',
+  'mesonbuild/mintro.py',
   'mesonbuild/mparser.py',
   'mesonbuild/msetup.py',
   'mesonbuild/mcompile.py',

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -216,7 +216,7 @@ class TestDef:
             return '{}   ({})'.format(self.path.as_posix(), self.name)
         return self.path.as_posix()
 
-    def __lt__(self, other: T.Any) -> bool:
+    def __lt__(self, other: object) -> bool:
         if isinstance(other, TestDef):
             # None is not sortable, so replace it with an empty string
             s_id = int(self.path.name.split(' ')[0])

--- a/run_tests.py
+++ b/run_tests.py
@@ -42,7 +42,7 @@ NINJA_CMD = None
 # test that we run.
 if 'CI' in os.environ:
     NINJA_1_9_OR_NEWER = True
-    NINJA_CMD = 'ninja'
+    NINJA_CMD = ['ninja']
 else:
     # Look for 1.9 to see if https://github.com/ninja-build/ninja/issues/1219
     # is fixed
@@ -221,7 +221,7 @@ def get_backend_commands(backend, debug=False):
         test_cmd = cmd + ['-target', 'RUN_TESTS']
     elif backend is Backend.ninja:
         global NINJA_CMD
-        cmd = [NINJA_CMD, '-w', 'dupbuild=err', '-d', 'explain']
+        cmd = NINJA_CMD + ['-w', 'dupbuild=err', '-d', 'explain']
         if debug:
             cmd += ['-v']
         clean_cmd = cmd + ['clean']

--- a/tools/boost_names.py
+++ b/tools/boost_names.py
@@ -48,12 +48,12 @@ class BoostLibrary():
         self.single = sorted(set(single))
         self.multi = sorted(set(multi))
 
-    def __lt__(self, other: T.Any) -> T.Union[bool, 'NotImplemented']:
+    def __lt__(self, other: object) -> T.Union[bool, 'NotImplemented']:
         if isinstance(other, BoostLibrary):
             return self.name < other.name
         return NotImplemented
 
-    def __eq__(self, other: T.Any) -> T.Union[bool, 'NotImplemented']:
+    def __eq__(self, other: object) -> T.Union[bool, 'NotImplemented']:
         if isinstance(other, BoostLibrary):
             return self.name == other.name
         elif isinstance(other, str):
@@ -71,7 +71,7 @@ class BoostModule():
         self.desc = desc
         self.libs = libs
 
-    def __lt__(self, other: T.Any) -> T.Union[bool, 'NotImplemented']:
+    def __lt__(self, other: object) -> T.Union[bool, 'NotImplemented']:
         if isinstance(other, BoostModule):
             return self.key < other.key
         return NotImplemented

--- a/tools/build_website.py
+++ b/tools/build_website.py
@@ -6,14 +6,14 @@ assert(os.getcwd() == '/home/jpakkane')
 
 from glob import glob
 
-def purge(fname):
+def purge(fname: str) -> None:
     if not os.path.exists(fname):
         return
     if os.path.isdir(fname):
         shutil.rmtree(fname)
     os.unlink(fname)
 
-def update():
+def update() -> None:
     webdir = 'mesonweb'
     repodir = 'mesonwebbuild'
     docdir = os.path.join(repodir, 'docs')

--- a/tools/cmake2meson.py
+++ b/tools/cmake2meson.py
@@ -34,7 +34,7 @@ class Statement:
         self.args = args
 
 class Lexer:
-    def __init__(self):
+    def __init__(self) -> None:
         self.token_specification = [
             # Need to be sorted longest to shortest.
             ('ignore', re.compile(r'[ \t]')),
@@ -87,11 +87,11 @@ class Lexer:
                 raise ValueError('Lexer got confused line %d column %d' % (lineno, col))
 
 class Parser:
-    def __init__(self, code: str):
+    def __init__(self, code: str) -> None:
         self.stream = Lexer().lex(code)
         self.getsym()
 
-    def getsym(self):
+    def getsym(self) -> None:
         try:
             self.current = next(self.stream)
         except StopIteration:
@@ -118,8 +118,8 @@ class Parser:
         self.expect('rparen')
         return Statement(cur.value, args)
 
-    def arguments(self) -> list:
-        args = []
+    def arguments(self) -> T.List[T.Union[Token, T.Any]]:
+        args = []  # type: T.List[T.Union[Token, T.Any]]
         if self.accept('lparen'):
             args.append(self.arguments())
             self.expect('rparen')
@@ -139,7 +139,7 @@ class Parser:
         while not self.accept('eof'):
             yield(self.statement())
 
-def token_or_group(arg):
+def token_or_group(arg: T.Union[Token, T.List[Token]]) -> str:
     if isinstance(arg, Token):
         return ' ' + arg.value
     elif isinstance(arg, list):
@@ -148,6 +148,7 @@ def token_or_group(arg):
             line += ' ' + token_or_group(a)
         line += ' )'
         return line
+    raise RuntimeError('Conversion error in token_or_group')
 
 class Converter:
     ignored_funcs = {'cmake_minimum_required': True,
@@ -183,7 +184,7 @@ class Converter:
             return res[0]
         return ''
 
-    def write_entry(self, outfile: T.TextIO, t: Statement):
+    def write_entry(self, outfile: T.TextIO, t: Statement) -> None:
         if t.name in Converter.ignored_funcs:
             return
         preincrement = 0
@@ -274,7 +275,7 @@ class Converter:
             outfile.write('\n')
         self.indent_level += postincrement
 
-    def convert(self, subdir: Path = None):
+    def convert(self, subdir: Path = None) -> None:
         if not subdir:
             subdir = self.cmake_root
         cfile = Path(subdir).expanduser() / 'CMakeLists.txt'
@@ -297,7 +298,7 @@ class Converter:
         if subdir == self.cmake_root and len(self.options) > 0:
             self.write_options()
 
-    def write_options(self):
+    def write_options(self) -> None:
         filename = self.cmake_root / 'meson_options.txt'
         with filename.open('w') as optfile:
             for o in self.options:

--- a/tools/dircondenser.py
+++ b/tools/dircondenser.py
@@ -53,7 +53,7 @@ def get_entries() -> T.List[T.Tuple[int, str]]:
     entries.sort()
     return entries
 
-def replace_source(sourcefile: str, replacements: T.List[T.Tuple[str, str]]):
+def replace_source(sourcefile: str, replacements: T.List[T.Tuple[str, str]]) -> None:
     with open(sourcefile, 'r') as f:
         contents = f.read()
     for old_name, new_name in replacements:
@@ -61,7 +61,7 @@ def replace_source(sourcefile: str, replacements: T.List[T.Tuple[str, str]]):
     with open(sourcefile, 'w') as f:
         f.write(contents)
 
-def condense(dirname: str):
+def condense(dirname: str) -> None:
     curdir = os.getcwd()
     os.chdir(dirname)
     entries = get_entries()

--- a/tools/regenerate_docs.py
+++ b/tools/regenerate_docs.py
@@ -31,21 +31,21 @@ from pathlib import Path
 
 PathLike = T.Union[Path,str]
 
-def _get_meson_output(root_dir: Path, args: T.List):
+def _get_meson_output(root_dir: Path, args: T.List) -> str:
     env = os.environ.copy()
     env['COLUMNS'] = '80'
     return subprocess.run([str(sys.executable), str(root_dir/'meson.py')] + args, check=True, capture_output=True, text=True, env=env).stdout.strip()
 
-def get_commands_data(root_dir: Path):
+def get_commands_data(root_dir: Path) -> T.Dict[str, T.Any]:
     usage_start_pattern = re.compile(r'^usage: ', re.MULTILINE)
     positional_start_pattern = re.compile(r'^positional arguments:[\t ]*[\r\n]+', re.MULTILINE)
     options_start_pattern = re.compile(r'^optional arguments:[\t ]*[\r\n]+', re.MULTILINE)
     commands_start_pattern = re.compile(r'^[A-Za-z ]*[Cc]ommands:[\t ]*[\r\n]+', re.MULTILINE)
 
-    def get_next_start(iterators, end):
+    def get_next_start(iterators: T.Sequence[T.Any], end: T.Optional[int]) -> int:
         return next((i.start() for i in iterators if i), end)
 
-    def normalize_text(text):
+    def normalize_text(text: str) -> str:
         # clean up formatting
         out = text
         out = re.sub(r'\r\n', r'\r', out, flags=re.MULTILINE) # replace newlines with a linux EOL
@@ -53,7 +53,7 @@ def get_commands_data(root_dir: Path):
         out = re.sub(r'(?:^\n+|\n+$)', '', out) # remove trailing empty lines
         return out
 
-    def parse_cmd(cmd):
+    def parse_cmd(cmd: str) -> T.Dict[str, str]:
         cmd_len = len(cmd)
         usage = usage_start_pattern.search(cmd)
         positionals = positional_start_pattern.search(cmd)
@@ -72,7 +72,7 @@ def get_commands_data(root_dir: Path):
             'arguments': normalize_text(cmd[arguments_start:cmd_len]),
         }
 
-    def clean_dir_arguments(text):
+    def clean_dir_arguments(text: str) -> str:
         # Remove platform specific defaults
         args = [
             'prefix',
@@ -127,7 +127,7 @@ def regenerate_docs(output_dir: PathLike,
                     dummy_output_file: T.Optional[PathLike]) -> None:
     if not output_dir:
         raise ValueError(f'Output directory value is not set')
-        
+
     output_dir = Path(output_dir).resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -143,7 +143,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Generate meson docs')
     parser.add_argument('--output-dir', required=True)
     parser.add_argument('--dummy-output-file', type=str)
-    
+
     args = parser.parse_args()
 
     regenerate_docs(output_dir=args.output_dir,


### PR DESCRIPTION
This PR adds the `run_mypy.py` script for easy local type checking. It runs mypy in 2 modes:

- the "normal" mode (which is currently used) with all the files and modules we currently check
- the "strict" mode with better type checking which (currently) only runs on a subset of modules

There is also some minor refactoring done in the first commit to make typing interpreter base a lot less painful and the code easier to reason about.

---

## Update:

all modules are now checked with the "strict" mode, "normal" mode is now gone.