### PR TITLE
Be stricter when detecting Windows/Cygwin

### DIFF
--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -211,13 +211,13 @@ class MachineInfo:
         """
         Machine is windows?
         """
-        return self.system == 'windows' or 'mingw' in self.system
+        return self.system == 'windows'
 
     def is_cygwin(self) -> bool:
         """
         Machine is cygwin?
         """
-        return self.system.startswith('cygwin')
+        return self.system == 'cygwin'
 
     def is_linux(self) -> bool:
         """

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -429,10 +429,9 @@ def detect_cpu(compilers: CompilersDict):
     return trial
 
 def detect_system():
-    system = platform.system().lower()
-    if system.startswith('cygwin'):
+    if sys.platform == 'cygwin':
         return 'cygwin'
-    return system
+    return platform.system().lower()
 
 def detect_msys2_arch():
     if 'MSYSTEM_CARCH' in os.environ:

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -502,11 +502,11 @@ def is_openbsd() -> bool:
 
 def is_windows() -> bool:
     platname = platform.system().lower()
-    return platname == 'windows' or 'mingw' in platname
+    return platname == 'windows'
 
 
 def is_cygwin() -> bool:
-    return platform.system().lower().startswith('cygwin')
+    return sys.platform == 'cygwin'
 
 
 def is_debianlike() -> bool:

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -58,11 +58,10 @@ GNU_ERROR_RETURNCODE = 99
 
 def is_windows() -> bool:
     platname = platform.system().lower()
-    return platname == 'windows' or 'mingw' in platname
+    return platname == 'windows'
 
 def is_cygwin() -> bool:
-    platname = platform.system().lower()
-    return 'cygwin' in platname
+    return sys.platform == 'cygwin'
 
 def determine_worker_count() -> int:
     varname = 'MESON_TESTTHREADS'

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -16,7 +16,6 @@ import os
 import sys
 import argparse
 import pickle
-import platform
 import subprocess
 
 from .. import mesonlib
@@ -29,14 +28,6 @@ def buildparser():
     parser.add_argument('--unpickle')
     parser.add_argument('--capture')
     return parser
-
-def is_windows():
-    platname = platform.system().lower()
-    return platname == 'windows' or 'mingw' in platname
-
-def is_cygwin():
-    platname = platform.system().lower()
-    return 'cygwin' in platname
 
 def run_exe(exe):
     if exe.exe_runner:

--- a/test cases/common/215 link custom/custom_stlib.py
+++ b/test cases/common/215 link custom/custom_stlib.py
@@ -18,7 +18,7 @@ void flob(void) {
 
 def get_pic_args():
     platname = platform.system().lower()
-    if platname in ['windows', 'mingw', 'darwin'] or platname.startswith('cygwin'):
+    if platname in ['windows', 'darwin'] or sys.platform == 'cygwin':
         return []
     return ['-fPIC']
 


### PR DESCRIPTION
This removes the check for "mingw" for platform.system(). The only case I know
where "mingw" is return is if using a msys Python under a msys2 mingw environment.
This combination is not really supported by meson and will result in weird errors,
so remove the check.

The second change is checking sys.platform for cygwin instead of platform.system().
The former is document to return "cygwin", while the latter is not and just
returns uname().

While under Cygwin it uname() always starts with "cygwin" it's not hardcoded in MSYS2
and starts with the environment name. Using sys.platform is safer here.

Fixes #7552