### PR TITLE
mcompile: use -v instead of --verbose for ninja

### DIFF
--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -156,7 +156,7 @@ def get_parsed_args_ninja(options: 'argparse.Namespace', builddir: Path) -> T.Li
         cmd.extend(['-l', str(options.load_average)])
 
     if options.verbose:
-        cmd.append('--verbose')
+        cmd.append('-v')
 
     cmd += options.ninja_args
 


### PR DESCRIPTION
The `--verbose` has been added to ninja in 1.9.0 and we pretend that we have compatibility with Ninja 1.7+.

References: https://github.com/ninja-build/ninja/commit/bf7517505ad1def03e13bec2b4131399331bc5c4