### PR TITLE
CMake module: Allow paths of generated CMake sources for include directories

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -433,8 +433,8 @@ class ConverterTarget:
                 x = os.path.normpath(os.path.join(self.src_dir, x))
             if not os.path.exists(x) and not any([x.endswith(y) for y in obj_suffixes]) and not is_generated:
                 if (
-                    any([os.path.commonpath([x, y]) == x for y in self.generated])
-                        and os.path.isabs(x)
+                    os.path.isabs(x)
+                        and any([(os.path.isabs(y) and os.path.commonpath([x, y]) == x) for y in self.generated])
                         and os.path.commonpath([x, self.env.get_build_dir()]) == self.env.get_build_dir()
                     ):
                     os.makedirs(x)

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -430,11 +430,11 @@ class ConverterTarget:
         # Make paths relative
         def rel_path(x: str, is_header: bool, is_generated: bool) -> T.Optional[str]:
             if not os.path.isabs(x):
-                x = os.path.normpath(os.path.join(self.src_dir, x))
+                x = os.path.join(self.src_dir, x)
+            x = os.path.normpath(x)
             if not os.path.exists(x) and not any([x.endswith(y) for y in obj_suffixes]) and not is_generated:
                 if (
-                    os.path.isabs(x)
-                        and any([(os.path.isabs(y) and os.path.commonpath([x, y]) == x) for y in self.generated])
+                    any([os.path.commonpath([x, os.path.normpath(os.path.join(root_src_dir, y))]) == x for y in self.generated])
                         and os.path.commonpath([x, self.env.get_build_dir()]) == self.env.get_build_dir()
                     ):
                     os.makedirs(x)
@@ -475,10 +475,10 @@ class ConverterTarget:
             return x
 
         build_dir_rel = os.path.relpath(self.build_dir, os.path.join(self.env.get_build_dir(), subdir))
+        self.generated = [rel_path(x, False, True) for x in self.generated]
         self.includes = list(OrderedSet([rel_path(x, True, False) for x in OrderedSet(self.includes)] + [build_dir_rel]))
         self.sys_includes = list(OrderedSet([rel_path(x, True, False) for x in OrderedSet(self.sys_includes)]))
         self.sources = [rel_path(x, False, False) for x in self.sources]
-        self.generated = [rel_path(x, False, True) for x in self.generated]
 
         # Resolve custom targets
         self.generated = [custom_target(x) for x in self.generated]

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -432,9 +432,17 @@ class ConverterTarget:
             if not os.path.isabs(x):
                 x = os.path.normpath(os.path.join(self.src_dir, x))
             if not os.path.exists(x) and not any([x.endswith(y) for y in obj_suffixes]) and not is_generated:
-                mlog.warning('CMake: path', mlog.bold(x), 'does not exist.')
-                mlog.warning(' --> Ignoring. This can lead to build errors.')
-                return None
+                if (
+                    any([os.path.commonpath([x, y]) == x for y in self.generated])
+                        and os.path.isabs(x)
+                        and os.path.commonpath([x, self.env.get_build_dir()]) == self.env.get_build_dir()
+                    ):
+                    os.makedirs(x)
+                    return os.path.relpath(x, os.path.join(self.env.get_build_dir(), subdir))
+                else:
+                    mlog.warning('CMake: path', mlog.bold(x), 'does not exist.')
+                    mlog.warning(' --> Ignoring. This can lead to build errors.')
+                    return None
             if Path(x) in trace.explicit_headers:
                 return None
             if (

--- a/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/CMakeLists.txt
@@ -120,7 +120,14 @@ add_custom_command(
 
 add_subdirectory(cpyTest ccppyyTTeesstt)
 
-add_library(cmModLib SHARED cmMod.cpp genTest.cpp cpyBase.cpp cpyBase.hpp cpyNext.cpp cpyNext.hpp cpyTest.cpp cpyTest.hpp cpyTest2.hpp cpyTest3.hpp)
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cpyTest/some/directory/cpyTest5.hpp"
+  COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_SOURCE_DIR}/cpyTest/cpyTest5.hpp" "${CMAKE_CURRENT_BINARY_DIR}/cpyTest/some/directory/cpyTest5.hpp"
+  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/cpyTest/cpyTest5.hpp"
+)
+include_directories("${CMAKE_CURRENT_BINARY_DIR}/cpyTest/some")
+
+add_library(cmModLib SHARED cmMod.cpp genTest.cpp cpyBase.cpp cpyBase.hpp cpyNext.cpp cpyNext.hpp cpyTest.cpp cpyTest.hpp cpyTest2.hpp cpyTest3.hpp cpyTest/some/directory/cpyTest5.hpp)
 include(GenerateExportHeader)
 generate_export_header(cmModLib)
 

--- a/test cases/cmake/8 custom command/subprojects/cmMod/cpyTest.cpp
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/cpyTest.cpp
@@ -2,7 +2,8 @@
 #include "cpyTest2.hpp"
 #include "cpyTest3.hpp"
 #include "ccppyyTTeesstt/cpyTest4.hpp"
+#include "directory/cpyTest5.hpp"
 
 std::string getStrCpyTest() {
-  return CPY_TEST_STR_2 CPY_TEST_STR_3 CPY_TEST_STR_4;
+  return CPY_TEST_STR_2 CPY_TEST_STR_3 CPY_TEST_STR_4 CPY_TEST_STR_5;
 }

--- a/test cases/cmake/8 custom command/subprojects/cmMod/cpyTest/cpyTest5.hpp
+++ b/test cases/cmake/8 custom command/subprojects/cmMod/cpyTest/cpyTest5.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#define CPY_TEST_STR_5 " test"


### PR DESCRIPTION
Fixes: https://github.com/mesonbuild/meson/issues/7666

Meson will then just assume directories of generated files will appear during build.