### PR TITLE
mcompile: Also support -v for verbose

### DIFF
--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -263,7 +263,7 @@ def add_arguments(parser: 'argparse.ArgumentParser') -> None:
         help='The system load average to try to maintain (if supported).'
     )
     parser.add_argument(
-        '--verbose',
+        '-v', '--verbose',
         action='store_true',
         help='Show more verbose output.'
     )


### PR DESCRIPTION
This matches `meson test`, and there's really no other meaning that could be attributed to this, since you would call `meson` to get the version, not the `compile` sub-command.