### PR TITLE
Add support for the CompCert C Compiler

### DIFF
--- a/cross/ccomp-armv7a.txt
+++ b/cross/ccomp-armv7a.txt
@@ -1,0 +1,13 @@
+[binaries]
+c = 'ccomp'
+ar = 'ccomp'
+strip = 'strip'
+
+[built-in options]
+c_args      = ['-target armv7a-eabi', '-fall']
+
+[host_machine]
+system = 'bare metal'      # Update with your system name - bare metal/OS.
+cpu_family = 'arm'
+cpu = 'Cortex-A9'
+endian = 'little'

--- a/cross/ccomp-armv7a.txt
+++ b/cross/ccomp-armv7a.txt
@@ -4,7 +4,7 @@ ar = 'ccomp'
 strip = 'strip'
 
 [built-in options]
-c_args      = ['-target armv7a-eabi', '-fall']
+c_args      = ['-target', 'armv7a-eabi', '-fall']
 
 [host_machine]
 system = 'bare metal'      # Update with your system name - bare metal/OS.

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -10,6 +10,7 @@ These are return values of the `get_id` (Compiler family) and
 | arm       | ARM compiler                     |                 |
 | armclang  | ARMCLANG compiler                |                 |
 | c2000     | Texas Instruments C2000 compiler |                 |
+| ccomp     | The CompCert formally-verified C compiler |        |
 | ccrx      | Renesas RX Family C/C++ compiler |                 |
 | clang     | The Clang compiler               | gcc             |
 | clang-cl  | The Clang compiler (MSVC compatible driver) | msvc |
@@ -56,6 +57,7 @@ These are return values of the `get_linker_id` method in a compiler object.
 | armlink    | The ARM linker (arm and armclang compilers) |
 | pgi        | Portland/Nvidia PGI                         |
 | nvlink     | Nvidia Linker used with cuda                |
+| ccomp      | CompCert used as the linker driver          |
 
 For languages that don't have separate dynamic linkers such as C# and Java, the
 `get_linker_id` will return the compiler name.

--- a/docs/markdown/snippets/add_compcert_compiler.md
+++ b/docs/markdown/snippets/add_compcert_compiler.md
@@ -1,3 +1,3 @@
 ## Added CompCert C compiler
 
-Added support for the CompCert formally-verified C compiler (https://github.com/AbsInt/CompCert).
+Added experimental support for the [CompCert formally-verified C compiler](https://github.com/AbsInt/CompCert). The current state of the implementation is good enough to build the [picolibc project](https://github.com/picolibc/picolibc) with CompCert, but might still need additional adjustments for other projects.

--- a/docs/markdown/snippets/add_compcert_compiler.md
+++ b/docs/markdown/snippets/add_compcert_compiler.md
@@ -1,0 +1,3 @@
+## Added CompCert C compiler
+
+Added support for the CompCert formally-verified C compiler (https://github.com/AbsInt/CompCert).

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -97,6 +97,7 @@ __all__ = [
     'CcrxCCompiler',
     'CcrxCPPCompiler',
     'Xc16CCompiler',
+    'CompCertCCompiler',
     'C2000CCompiler',
     'C2000CPPCompiler',
     'SunFortranCompiler',
@@ -144,6 +145,7 @@ from .c import (
     PGICCompiler,
     CcrxCCompiler,
     Xc16CCompiler,
+    CompCertCCompiler,
     C2000CCompiler,
     VisualStudioCCompiler,
 )

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -576,7 +576,7 @@ class CompCertCCompiler(CompCertCompiler, CCompiler):
         return ['-O0']
 
     def get_output_args(self, target):
-        return ['-o%s' % target]
+        return ['-o{}'.format(target)]
 
     def get_werror_args(self):
         return ['-Werror']

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -22,6 +22,7 @@ from .c_function_attributes import C_FUNC_ATTRIBUTES
 from .mixins.clike import CLikeCompiler
 from .mixins.ccrx import CcrxCompiler
 from .mixins.xc16 import Xc16Compiler
+from .mixins.compcert import CompCertCompiler
 from .mixins.c2000 import C2000Compiler
 from .mixins.arm import ArmCompiler, ArmclangCompiler
 from .mixins.visualstudio import MSVCCompiler, ClangClCompiler
@@ -554,6 +555,36 @@ class Xc16CCompiler(Xc16Compiler, CCompiler):
             path = '.'
         return ['-I' + path]
 
+class CompCertCCompiler(CompCertCompiler, CCompiler):
+    def __init__(self, exelist, version, for_machine: MachineChoice,
+                 is_cross, info: 'MachineInfo', exe_wrapper=None, **kwargs):
+        CCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                           info, exe_wrapper, **kwargs)
+        CompCertCompiler.__init__(self)
+
+    def get_options(self):
+        opts = CCompiler.get_options(self)
+        opts.update({'c_std': coredata.UserComboOption('C language standard to use',
+                                                       ['none', 'c89', 'c99'],
+                                                       'none')})
+        return opts
+
+    def get_option_compile_args(self, options):
+        return []
+
+    def get_no_optimization_args(self):
+        return ['-O0']
+
+    def get_output_args(self, target):
+        return ['-o%s' % target]
+
+    def get_werror_args(self):
+        return ['-Werror']
+
+    def get_include_args(self, path, is_system):
+        if path == '':
+            path = '.'
+        return ['-I' + path]
 
 class C2000CCompiler(C2000Compiler, CCompiler):
     def __init__(self, exelist, version, for_machine: MachineChoice,

--- a/mesonbuild/compilers/mixins/compcert.py
+++ b/mesonbuild/compilers/mixins/compcert.py
@@ -18,8 +18,6 @@ import os
 import re
 import typing as T
 
-from ...mesonlib import EnvironmentException
-
 if T.TYPE_CHECKING:
     from ...environment import Environment
 
@@ -88,7 +86,7 @@ class CompCertCompiler:
     def get_pch_use_args(self, pch_dir: str, header: str) -> T.List[str]:
         return []
 
-    def unix_args_to_native(cls, args):
+    def unix_args_to_native(self, args):
         "Always returns a copy that can be independently mutated"
         patched_args = []
         for arg in args:

--- a/mesonbuild/compilers/mixins/compcert.py
+++ b/mesonbuild/compilers/mixins/compcert.py
@@ -82,11 +82,13 @@ class CompCertCompiler:
         "Always returns a copy that can be independently mutated"
         patched_args = []
         for arg in args:
+            added = 0
             for ptrn in ccomp_args_to_wul:
                 if re.match(ptrn, arg):
                     patched_args.append('-WUl,' + arg)
-                else:
-                    patched_args.append(arg)
+                    added = 1
+            if not added:
+                patched_args.append(arg)
         return patched_args
 
     # Override CCompiler.get_dependency_gen_args

--- a/mesonbuild/compilers/mixins/compcert.py
+++ b/mesonbuild/compilers/mixins/compcert.py
@@ -23,8 +23,8 @@ if T.TYPE_CHECKING:
 
 ccomp_buildtype_args = {
     'plain': [''],
-    'debug': ['-O0 -g'],
-    'debugoptimized': ['-O0 -g'],
+    'debug': ['-O0', '-g'],
+    'debugoptimized': ['-O0', '-g'],
     'release': ['-03'],
     'minsize': ['-Os'],
     'custom': ['-Obranchless'],

--- a/mesonbuild/compilers/mixins/compcert.py
+++ b/mesonbuild/compilers/mixins/compcert.py
@@ -82,11 +82,9 @@ class CompCertCompiler:
         "Always returns a copy that can be independently mutated"
         patched_args = []
         for arg in args:
-            do_not_add = 0
             for ptrn in ccomp_args_to_wul:
                 if re.match(ptrn, arg):
                     patched_args.append('-WUl,' + arg)
-                    do_not_add = 1
                 else:
                     patched_args.append(arg)
         return patched_args

--- a/mesonbuild/compilers/mixins/compcert.py
+++ b/mesonbuild/compilers/mixins/compcert.py
@@ -1,0 +1,145 @@
+# Copyright 2012-2019 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Representations specific to the CompCert C compiler family."""
+
+import os
+import re
+import typing as T
+
+from ...mesonlib import EnvironmentException
+
+if T.TYPE_CHECKING:
+    from ...environment import Environment
+
+ccomp_buildtype_args = {
+    'plain': [''],
+    'debug': ['-O0 -g'],
+    'debugoptimized': ['-O0 -g'],
+    'release': ['-03'],
+    'minsize': ['-Os'],
+    'custom': ['-Obranchless'],
+}  # type: T.Dict[str, T.List[str]]
+
+ccomp_optimization_args = {
+    '0': ['-O0'],
+    'g': ['-O0'],
+    '1': ['-O1'],
+    '2': ['-O2'],
+    '3': ['-O3'],
+    's': ['-Os']
+}  # type: T.Dict[str, T.List[str]]
+
+ccomp_debug_args = {
+    False: [],
+    True: ['-g']
+}  # type: T.Dict[bool, T.List[str]]
+
+# As of CompCert 20.04, these arguments should be passed to the underlying gcc linker (via -WUl,<arg>)
+# There are probably (many) more, but these are those used by picolibc
+ccomp_args_to_wul = [
+        r"^-ffreestanding$",
+        r"^-r$"
+] # type: T.List[str]
+
+# As of CompCert 20.04, these arguments can just be ignored
+# There are probably (many) more, but these are those used by picolibc
+ccomp_filter_args = [
+        r"^-fno-builtin.*",
+        r"^-ffunction-sections$",
+        r"^-ftls-model=.*"
+] # type: T.List[str]
+
+class CompCertCompiler:
+    def __init__(self):
+        self.id = 'ccomp'
+        # Assembly
+        self.can_compile_suffixes.add('s')
+        default_warn_args = []  # type: T.List[str]
+        self.warn_args = {'0': [],
+                          '1': default_warn_args,
+                          '2': default_warn_args + [],
+                          '3': default_warn_args + []}
+
+    def get_always_args(self) -> T.List[str]:
+        return []
+
+    def get_pic_args(self) -> T.List[str]:
+        # As of now, CompCert does not support PIC
+        return []
+
+    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
+        return ccomp_buildtype_args[buildtype]
+
+    def get_pch_suffix(self) -> str:
+        return 'pch'
+
+    def get_pch_use_args(self, pch_dir: str, header: str) -> T.List[str]:
+        return []
+
+    def unix_args_to_native(cls, args):
+        "Always returns a copy that can be independently mutated"
+        patched_args = []
+        for arg in args:
+            do_not_add = 0
+            for ptrn in ccomp_args_to_wul:
+                if re.match(ptrn, arg):
+                    patched_args.append('-WUl,' + arg)
+                    do_not_add = 1
+                    break
+
+            if do_not_add == 1:
+                continue
+            for ptrn in ccomp_filter_args:
+                if re.match(ptrn, arg):
+                    do_not_add = 1
+                    break
+            if do_not_add == 0:
+                patched_args.append(arg)
+        return patched_args
+
+    # Override CCompiler.get_dependency_gen_args
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+        return []
+
+    def thread_flags(self, env: 'Environment') -> T.List[str]:
+        return []
+
+    def get_preprocess_only_args(self) -> T.List[str]:
+        return ['-E']
+
+    def get_compile_only_args(self) -> T.List[str]:
+        return ['-c']
+
+    def get_coverage_args(self) -> T.List[str]:
+        return []
+
+    def get_no_stdinc_args(self) -> T.List[str]:
+        return ['-nostdinc']
+
+    def get_no_stdlib_link_args(self) -> T.List[str]:
+        return ['-nostdlib']
+
+    def get_optimization_args(self, optimization_level: str) -> T.List[str]:
+        return ccomp_optimization_args[optimization_level]
+
+    def get_debug_args(self, is_debug: bool) -> T.List[str]:
+        return ccomp_debug_args[is_debug]
+
+    def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str], build_dir: str) -> T.List[str]:
+        for idx, i in enumerate(parameter_list):
+            if i[:9] == '-I':
+                parameter_list[idx] = i[:9] + os.path.normpath(os.path.join(build_dir, i[9:]))
+
+        return parameter_list

--- a/mesonbuild/compilers/mixins/compcert.py
+++ b/mesonbuild/compilers/mixins/compcert.py
@@ -51,14 +51,6 @@ ccomp_args_to_wul = [
         r"^-r$"
 ] # type: T.List[str]
 
-# As of CompCert 20.04, these arguments can just be ignored
-# There are probably (many) more, but these are those used by picolibc
-ccomp_filter_args = [
-        r"^-fno-builtin.*",
-        r"^-ffunction-sections$",
-        r"^-ftls-model=.*"
-] # type: T.List[str]
-
 class CompCertCompiler:
     def __init__(self):
         self.id = 'ccomp'
@@ -95,16 +87,8 @@ class CompCertCompiler:
                 if re.match(ptrn, arg):
                     patched_args.append('-WUl,' + arg)
                     do_not_add = 1
-                    break
-
-            if do_not_add == 1:
-                continue
-            for ptrn in ccomp_filter_args:
-                if re.match(ptrn, arg):
-                    do_not_add = 1
-                    break
-            if do_not_add == 0:
-                patched_args.append(arg)
+                else:
+                    patched_args.append(arg)
         return patched_args
 
     # Override CCompiler.get_dependency_gen_args

--- a/mesonbuild/compilers/mixins/compcert.py
+++ b/mesonbuild/compilers/mixins/compcert.py
@@ -52,7 +52,7 @@ ccomp_args_to_wul = [
 ] # type: T.List[str]
 
 class CompCertCompiler:
-    def __init__(self):
+    def __init__(self) -> None:
         self.id = 'ccomp'
         # Assembly
         self.can_compile_suffixes.add('s')

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -230,6 +230,18 @@ class Xc16Linker(StaticLinker):
     def get_linker_always_args(self) -> T.List[str]:
         return ['rcs']
 
+class CompCertLinker(StaticLinker):
+
+    def __init__(self, exelist: T.List[str]):
+        super().__init__(exelist)
+        self.id = 'ccomp'
+
+    def can_linker_accept_rsp(self) -> bool:
+        return False
+
+    def get_output_args(self, target: str) -> T.List[str]:
+        return ['-o {}'.format(target)]
+
 
 class C2000Linker(StaticLinker):
 
@@ -869,6 +881,47 @@ class Xc16DynamicLinker(DynamicLinker):
                          install_rpath: str) -> T.Tuple[T.List[str], T.Set[bytes]]:
         return ([], set())
 
+class CompCertDynamicLinker(DynamicLinker):
+
+    """Linker for CompCert C compiler."""
+
+    def __init__(self, for_machine: mesonlib.MachineChoice,
+                 *, version: str = 'unknown version'):
+        super().__init__('ccomp', ['ccomp'], for_machine, '', [],
+                         version=version)
+
+    def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:
+        if not args:
+            return args
+        return self._apply_prefix('-WUl,--start-group') + args + self._apply_prefix('-WUl,--end-group')
+
+    def get_accepts_rsp(self) -> bool:
+        return False
+
+    def get_lib_prefix(self) -> str:
+        return '-l'
+
+    def get_std_shared_lib_args(self) -> T.List[str]:
+        return []
+
+    def get_output_args(self, outputname: str) -> T.List[str]:
+        return ['-o{}'.format(outputname)]
+
+    def get_search_args(self, dirname: str) -> T.List[str]:
+        return ['-L{}'.format(outputname)]
+
+    def get_allow_undefined_args(self) -> T.List[str]:
+        return []
+
+    def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
+                        suffix: str, soversion: str, darwin_versions: T.Tuple[str, str],
+                        is_shared_module: bool) -> T.List[str]:
+        raise mesonlib.MesonException('{} does not support shared libraries.'.format(self.id))
+
+    def build_rpath_args(self, env: 'Environment', build_dir: str, from_dir: str,
+                         rpath_paths: str, build_rpath: str,
+                         install_rpath: str) -> T.Tuple[T.List[str], T.Set[bytes]]:
+        return ([], set())
 
 class C2000DynamicLinker(DynamicLinker):
 

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -240,7 +240,7 @@ class CompCertLinker(StaticLinker):
         return False
 
     def get_output_args(self, target: str) -> T.List[str]:
-        return ['-o {}'.format(target)]
+        return ['-o{}'.format(target)]
 
 
 class C2000Linker(StaticLinker):


### PR DESCRIPTION
Hello Meson developers! I added some basic/preliminary support for the [CompCert C Compiler](https://github.com/AbsInt/CompCert).
The code is essentially a copy of the XC16 code, plus some adaptions.

From my perspective the most questionable behaviour is the automatic filtering of some GCC flags:
CompCert uses GCC as preprocessor, assembler and linker. Hence many GCC flags are supported, but need to be prefixed with a `-WUl,` [linker], `-Wp,` [preprocessor] or `-Wa,` [assembler] for CompCert's driver to pass them to the correct tool.
Since my current objective is to evaluate [picolibc](https://github.com/picolibc/picolibc), I automatically prefix those flags which are used by picolibc's build files.

Additionally, some GCC flags are safe to be ignored by CompCert (such as the `-fno-builtin`), so these are also filtered (again because picolibc has them hardcoded in its build files).

I suppose this isn't perfect on first try (plus I don't usually develop in python), so just let me know what to adapt :)

Best regards, Sebastian