### PR TITLE
environment: do not raise exception in detect_cuda_compiler

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1383,8 +1383,6 @@ class Environment:
         for compiler in compilers:
             if isinstance(compiler, str):
                 compiler = [compiler]
-            else:
-                raise EnvironmentException()
             arg = '--version'
             try:
                 p, out, err = Popen_safe(compiler + [arg])

--- a/test cases/cuda/13 cuda compiler setting/meson.build
+++ b/test cases/cuda/13 cuda compiler setting/meson.build
@@ -1,0 +1,5 @@
+project('simple', 'cuda', version : '1.0.0')
+
+exe = executable('prog', 'prog.cu')
+test('cudatest', exe)
+

--- a/test cases/cuda/13 cuda compiler setting/nativefile.ini
+++ b/test cases/cuda/13 cuda compiler setting/nativefile.ini
@@ -1,0 +1,5 @@
+[binaries]
+
+cuda = 'nvcc'
+
+

--- a/test cases/cuda/13 cuda compiler setting/prog.cu
+++ b/test cases/cuda/13 cuda compiler setting/prog.cu
@@ -1,0 +1,30 @@
+#include <iostream>
+
+int main(void) {
+    int cuda_devices = 0;
+    std::cout << "CUDA version: " << CUDART_VERSION << "\n";
+    cudaGetDeviceCount(&cuda_devices);
+    if(cuda_devices == 0) {
+        std::cout << "No Cuda hardware found. Exiting.\n";
+        return 0;
+    }
+    std::cout << "This computer has " << cuda_devices << " Cuda device(s).\n";
+    cudaDeviceProp props;
+    cudaGetDeviceProperties(&props, 0);
+    std::cout << "Properties of device 0.\n\n";
+
+    std::cout << "  Name:            " << props.name << "\n";
+    std::cout << "  Global memory:   " << props.totalGlobalMem << "\n";
+    std::cout << "  Shared memory:   " << props.sharedMemPerBlock << "\n";
+    std::cout << "  Constant memory: " << props.totalConstMem << "\n";
+    std::cout << "  Block registers: " << props.regsPerBlock << "\n";
+
+    std::cout << "  Warp size:         " << props.warpSize << "\n";
+    std::cout << "  Threads per block: " << props.maxThreadsPerBlock << "\n";
+    std::cout << "  Max block dimensions: [ " << props.maxThreadsDim[0] << ", " << props.maxThreadsDim[1]  << ", " << props.maxThreadsDim[2] << " ]" << "\n";
+    std::cout << "  Max grid dimensions:  [ " << props.maxGridSize[0] << ", " << props.maxGridSize[1]  << ", " << props.maxGridSize[2] << " ]" << "\n";
+    std::cout << "\n";
+
+    return 0;
+}
+


### PR DESCRIPTION
This fixes the mystery `ERROR:` exception that gets raised when setting `cuda = ` in a cross configuration file.

This resolve the cross-build setup issue described [here](https://github.com/OE4T/meta-tegra/issues/409), and should resolve #5791.  With this change and appropriate flag settings in the CUFLAGS environment variable, cross-building CUDA applications works in a Yocto-based cross-build setup.