### PR TITLE
environment: use ExternalProgram to find ninja

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -548,7 +548,7 @@ int dummy;
                 rules += [ "%s%s" % (rule, ext) for rule in [self.get_pch_rule_name(lang, for_machine)]
                                                 for ext in ['', '_RSP']]
         compdb_options = ['-x'] if mesonlib.version_compare(self.ninja_version, '>=1.9') else []
-        ninja_compdb = [self.ninja_command, '-t', 'compdb'] + compdb_options + rules
+        ninja_compdb = self.ninja_command + ['-t', 'compdb'] + compdb_options + rules
         builddir = self.environment.get_build_dir()
         try:
             jsondb = subprocess.check_output(ninja_compdb, cwd=builddir)
@@ -2964,7 +2964,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         self.add_build(elem)
 
         elem = NinjaBuildElement(self.all_outputs, 'meson-clean', 'CUSTOM_COMMAND', 'PHONY')
-        elem.add_item('COMMAND', [self.ninja_command, '-t', 'clean'])
+        elem.add_item('COMMAND', self.ninja_command + ['-t', 'clean'])
         elem.add_item('description', 'Cleaning')
         # Alias that runs the above-defined meson-clean target
         self.create_target_alias('meson-clean')

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -160,15 +160,19 @@ def find_coverage_tools():
 
     return gcovr_exe, gcovr_new_rootdir, lcov_exe, genhtml_exe, llvm_cov_exe
 
-def detect_ninja(version: str = '1.7', log: bool = False) -> str:
+def detect_ninja(version: str = '1.7', log: bool = False) -> T.List[str]:
     r = detect_ninja_command_and_version(version, log)
     return r[0] if r else None
 
-def detect_ninja_command_and_version(version: str = '1.7', log: bool = False) -> (str, str):
+def detect_ninja_command_and_version(version: str = '1.7', log: bool = False) -> (T.List[str], str):
+    from .dependencies.base import ExternalProgram
     env_ninja = os.environ.get('NINJA', None)
     for n in [env_ninja] if env_ninja else ['ninja', 'ninja-build', 'samu']:
+        prog = ExternalProgram(n, silent=True)
+        if not prog.found():
+            continue
         try:
-            p, found = Popen_safe([n, '--version'])[0:2]
+            p, found = Popen_safe(prog.command + ['--version'])[0:2]
         except (FileNotFoundError, PermissionError):
             # Doesn't exist in PATH or isn't executable
             continue
@@ -176,7 +180,6 @@ def detect_ninja_command_and_version(version: str = '1.7', log: bool = False) ->
         # Perhaps we should add a way for the caller to know the failure mode
         # (not found or too old)
         if p.returncode == 0 and mesonlib.version_compare(found, '>=' + version):
-            n = shutil.which(n)
             if log:
                 name = os.path.basename(n)
                 if name.endswith('-' + found):
@@ -185,8 +188,9 @@ def detect_ninja_command_and_version(version: str = '1.7', log: bool = False) ->
                     name = 'ninja'
                 if name == 'samu':
                     name = 'samurai'
-                mlog.log('Found {}-{} at {}'.format(name, found, quote_arg(n)))
-            return (n, found)
+                mlog.log('Found {}-{} at {}'.format(name, found,
+                         ' '.join([quote_arg(x) for x in prog.command])))
+            return (prog.command, found)
 
 def get_llvm_tool_names(tool: str) -> T.List[str]:
     # Ordered list of possible suffixes of LLVM executables to try. Start with

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -139,7 +139,7 @@ def get_parsed_args_ninja(options: 'argparse.Namespace', builddir: Path) -> T.Li
         raise MesonException('Cannot find ninja.')
     mlog.log('Found runner:', runner)
 
-    cmd = [runner, '-C', builddir.as_posix()]
+    cmd = runner + ['-C', builddir.as_posix()]
 
     if options.targets:
         intro_data = parse_introspect_data(builddir)

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -174,7 +174,7 @@ def run(options) -> int:
         ret = subprocess.run(cmd)
         if ret.returncode:
             raise SystemExit
-        cmd = [detect_ninja(), '-C', options.builddir]
+        cmd = detect_ninja() + ['-C', options.builddir]
         ret = subprocess.run(cmd)
         if ret.returncode:
             raise SystemExit

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1179,7 +1179,7 @@ def rebuild_all(wd: str) -> bool:
         print("Can't find ninja, can't rebuild test.")
         return False
 
-    ret = subprocess.run([ninja, '-C', wd]).returncode
+    ret = subprocess.run(ninja + ['-C', wd]).returncode
     if ret != 0:
         print('Could not rebuild {}'.format(wd))
         return False

--- a/mesonbuild/scripts/scanbuild.py
+++ b/mesonbuild/scripts/scanbuild.py
@@ -22,7 +22,7 @@ from ..environment import detect_ninja, detect_scanbuild
 def scanbuild(exelist, srcdir, blddir, privdir, logdir, args):
     with tempfile.TemporaryDirectory(dir=privdir) as scandir:
         meson_cmd = exelist + args
-        build_cmd = exelist + ['-o', logdir, detect_ninja(), '-C', scandir]
+        build_cmd = exelist + ['-o', logdir] + detect_ninja() + ['-C', scandir]
         rc = subprocess.call(meson_cmd + [srcdir, scandir])
         if rc != 0:
             return rc


### PR DESCRIPTION
This allows the NINJA environment variable to support all the Windows special
cases, especially allowing an absolute path without extension.

Based on a patch by Yonggang Luo.

Fixes: #7659