### PR TITLE
ci: update to use latest recommendations

### DIFF
--- a/.github/workflows/ci_frameworks.yml
+++ b/.github/workflows/ci_frameworks.yml
@@ -17,14 +17,14 @@ jobs:
   scalapackMacOS:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     - run: python -m pip install -e .
     - run: brew install pkg-config ninja gcc openmpi lapack scalapack
     - run: meson setup "test cases/frameworks/30 scalapack" build
-    - run: ninja -C build
+    - run: meson compile -C build
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
@@ -40,14 +40,14 @@ jobs:
   HDF5macos:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     - run: python -m pip install -e .
     - run: brew install pkg-config ninja gcc hdf5
     - run: meson setup "test cases/frameworks/25 hdf5" build
-    - run: ninja -C build
+    - run: meson compile -C build
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
@@ -63,8 +63,8 @@ jobs:
   Qt4macos:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     - run: python -m pip install -e .
@@ -72,7 +72,7 @@ jobs:
     - run: brew tap cartr/qt4
     - run: brew install qt@4
     - run: meson setup "test cases/frameworks/4 qt" build -Drequired=qt4
-    - run: ninja -C build
+    - run: meson compile -C build
     - uses: actions/upload-artifact@v1
       if: failure()
       with:

--- a/.github/workflows/lint_mypy.yml
+++ b/.github/workflows/lint_mypy.yml
@@ -15,8 +15,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     # pylint version constraint can be removed when https://github.com/PyCQA/pylint/issues/3524 is resolved
@@ -26,8 +26,8 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     - run: python -m pip install mypy

--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -25,7 +25,6 @@ jobs:
     - name: Run tests
       run: LD_LIBRARY_PATH=/usr/local/share/boost/1.69.0/lib/:$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH python3 run_tests.py
       env:
-        CI: '1'
         XENIAL: '1'
 
   arch:


### PR DESCRIPTION
The "unused_args" CI .yml was updated in #7689

This just uses the latest Actions recommended by Github and removes redundant variables "CI" that are already global by default now.