### PR TITLE
introspect: add target ids for executable/args/depends to test and benchmark JSON

### DIFF
--- a/docs/markdown/IDE-integration.md
+++ b/docs/markdown/IDE-integration.md
@@ -247,12 +247,18 @@ line arguments, environment variable settings and how to process the output.
     "is_parallel": true / false,
     "protocol": "exitcode" / "tap",
     "cmd": ["command", "to", "run"],
+    "depends": ["target1-id", "target2-id"],
     "env": {
         "VARIABLE1": "value 1",
         "VARIABLE2": "value 2"
     }
 }
 ```
+
+The `depends` entry *(since 0.56.0)* contains target ids; they can be
+looked up in the targets introspection data.  The executable
+pointed to by `cmd` is also included in the entry, as are any
+arguments to the test that are build products.
 
 ## Build system files
 

--- a/docs/markdown/snippets/introspect_test_deps.md
+++ b/docs/markdown/snippets/introspect_test_deps.md
@@ -1,0 +1,5 @@
+## Dependencies listed in test and benchmark introspection
+
+The introspection data for tests and benchmarks now includes the target
+ids for executables and built files that are needed by the test.  IDEs can
+use this feature to update the build more quickly before running a test.

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -325,6 +325,7 @@ def get_test_list(testdata) -> T.List[T.Dict[str, T.Union[str, int, T.List[str],
         to['is_parallel'] = t.is_parallel
         to['priority'] = t.priority
         to['protocol'] = str(t.protocol)
+        to['depends'] = t.depends
         result.append(to)
     return result
 

--- a/test cases/unit/57 introspection/cp.py
+++ b/test cases/unit/57 introspection/cp.py
@@ -1,0 +1,5 @@
+#! /usr/bin/env python3
+
+import sys
+from shutil import copyfile
+copyfile(*sys.argv[1:])

--- a/test cases/unit/57 introspection/meson.build
+++ b/test cases/unit/57 introspection/meson.build
@@ -26,6 +26,9 @@ var1 = '1'
 var2 = 2.to_string()
 var3 = 'test3'
 
+cus = custom_target('custom target test', output: 'file2', input: 'cp.py',
+                    command: [find_program('cp.py'), '@INPUT@', '@OUTPUT@'])
+
 t1 = executable('test' + var1, ['t1.cpp'], link_with: [sharedlib], install: not false, build_by_default: get_option('test_opt2'))
 t2 = executable('test@0@'.format('@0@'.format(var2)), sources: ['t2.cpp'], link_with: [staticlib])
 t3 = executable(var3, 't3.cpp', link_with: [sharedlib, staticlib], dependencies: [dep1])
@@ -44,8 +47,8 @@ osmesa_lib_name = osmesa_lib_name + osmesa_bits
 message(osmesa_lib_name) # Infinite recursion gets triggered here when the parameter osmesa_lib_name is resolved
 
 test('test case 1', t1)
-test('test case 2', t2)
-benchmark('benchmark 1', t3)
+test('test case 2', t2, depends: t3)
+benchmark('benchmark 1', t3, args: cus)
 
 ### Stuff to test the AST JSON printer
 foreach x : ['a', 'b', 'c']


### PR DESCRIPTION
Add the paths to the dependencies, as computed by the backend, to the introspection data for tests and benchmarks.  Without this information, IDEs must update the entire build before running any test.  They can now instead selectively build the test executable itself and anything that is needed to run it.