### PR TITLE
doc: Add missing method arguments

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2155,27 +2155,27 @@ the following methods:
   `args` keyword, you can specify external dependencies to use with
   `dependencies` keyword argument.
 
-- `check_header(header_name)` *(since 0.47.0)*: returns true if the specified header is *usable* with
-  the specified prefix, dependencies, and arguments.
-  You can specify external dependencies to use with `dependencies`
-  keyword argument and extra code to put above the header test with
-  the `prefix` keyword. In order to look for headers in a specific
-  directory you can use `args : '-I/extra/include/dir`, but this
-  should only be used in exceptional cases for includes that can't be
-  detected via pkg-config and passed via `dependencies`. *(since 0.50.0)* The
-  `required` keyword argument can be used to abort if the header cannot be
-  found.
+- `check_header(header_name)` *(since 0.47.0)*: returns true if the
+  specified header is *usable* with the specified prefix,
+  dependencies, and arguments. You can specify external dependencies
+  to use with `dependencies` keyword argument and extra code to put
+  above the header test with the `prefix` keyword. In order to look
+  for headers in a specific directory you can use `args :
+  '-I/extra/include/dir`, but this should only be used in exceptional
+  cases for includes that can't be detected via pkg-config and passed
+  via `dependencies`. *(since 0.50.0)* The `required` keyword argument
+  can be used to abort if the header cannot be found.
 
-- `has_header(header_name)`: returns true if the specified header *exists*, and is
-  faster than `check_header()` since it only does a pre-processor check.
-  You can specify external dependencies to use with `dependencies`
-  keyword argument and extra code to put above the header test with
-  the `prefix` keyword. In order to look for headers in a specific
-  directory you can use `args : '-I/extra/include/dir`, but this
-  should only be used in exceptional cases for includes that can't be
-  detected via pkg-config and passed via `dependencies`. *(since 0.50.0)* The
-  `required` keyword argument can be used to abort if the header cannot be
-  found.
+- `has_header(header_name)`: returns true if the specified header
+  *exists*, and is faster than `check_header()` since it only does a
+  pre-processor check. You can specify external dependencies to use
+  with `dependencies` keyword argument and extra code to put above the
+  header test with the `prefix` keyword. In order to look for headers
+  in a specific directory you can use `args : '-I/extra/include/dir`,
+  but this should only be used in exceptional cases for includes that
+  can't be detected via pkg-config and passed via `dependencies`.
+  *(since 0.50.0)* The `required` keyword argument can be used to
+  abort if the header cannot be found.
 
 - `has_header_symbol(headername, symbolname)`: detects
   whether a particular symbol (function, variable, #define, type

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2155,7 +2155,7 @@ the following methods:
   `args` keyword, you can specify external dependencies to use with
   `dependencies` keyword argument.
 
-- `check_header` *(since 0.47.0)*: returns true if the specified header is *usable* with
+- `check_header(header_name)` *(since 0.47.0)*: returns true if the specified header is *usable* with
   the specified prefix, dependencies, and arguments.
   You can specify external dependencies to use with `dependencies`
   keyword argument and extra code to put above the header test with
@@ -2166,7 +2166,7 @@ the following methods:
   `required` keyword argument can be used to abort if the header cannot be
   found.
 
-- `has_header`: returns true if the specified header *exists*, and is
+- `has_header(header_name)`: returns true if the specified header *exists*, and is
   faster than `check_header()` since it only does a pre-processor check.
   You can specify external dependencies to use with `dependencies`
   keyword argument and extra code to put above the header test with


### PR DESCRIPTION
Documentation of most methods mentions method arguments enclosed in parentheses. Two methods are an exception and we fix them here to make the manual more consistent.
