### PR TITLE
IntrospectInterpreter: allow dictionaries with nonconstant keys

### DIFF
--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -192,6 +192,16 @@ class AstInterpreter(interpreterbase.InterpreterBase):
         self.evaluate_statement(node.trueblock)
         self.evaluate_statement(node.falseblock)
 
+    def evaluate_dictstatement(self, node: mparser.DictNode) -> TYPE_nkwargs:
+        (arguments, kwargs) = self.reduce_arguments(node.args, resolve_key_nodes=False)
+        assert (not arguments)
+        self.argument_depth += 1
+        for key, value in kwargs.items():
+            if isinstance(key, BaseNode):
+                self.evaluate_statement(key)
+        self.argument_depth -= 1
+        return {}
+
     def evaluate_plusassign(self, node: PlusAssignmentNode) -> None:
         assert(isinstance(node, PlusAssignmentNode))
         # Cheat by doing a reassignment

--- a/test cases/unit/57 introspection/meson.build
+++ b/test cases/unit/57 introspection/meson.build
@@ -12,6 +12,7 @@ test_bool = not test_bool
 
 set_variable('list_test_plusassign', [])
 list_test_plusassign += ['bugs everywhere']
+dict_test = {list_test_plusassign[0]: 'even more bugs'}
 
 if not true
   vers_str = '<=99.9.9'


### PR DESCRIPTION
Something like {a: foo} currently stymies the IntrospectionInterpreter and breaks introspection of the source directory.  The fix is just to walk the keys and return a dummy dictionary.