### PR TITLE
minstall: Print a big FAILED when a script fails

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -437,11 +437,13 @@ class Installer:
             self.log('Running custom install script {!r}'.format(name))
             try:
                 rc = subprocess.call(script + args, env=child_env)
-                if rc != 0:
-                    sys.exit(rc)
             except OSError:
-                print('Failed to run install script {!r}'.format(name))
-                sys.exit(1)
+                print('FAILED: install script \'{}\' could not be run, stopped'.format(name))
+                # POSIX shells return 127 when a command could not be found
+                sys.exit(127)
+            if rc != 0:
+                print('FAILED: install script \'{}\' exit code {}, stopped'.format(name, rc))
+                sys.exit(rc)
 
     def install_targets(self, d):
         for t in d.targets:


### PR DESCRIPTION
We don't run any further scripts when this happens, so we need to print a big error. The exit code was already correct.

Fixes https://github.com/mesonbuild/meson/issues/7627

The output now looks like:

```
$ /c/projects/meson/meson.git/meson.py install -C _build
ninja: Entering directory `_build'
ninja: no work to do.
Running custom install script 'bash C:/projects/tmp/install-script-subdir/main/subdir/my_module/scripts/install.sh'
I WAS RUN
FAILED: install script 'bash C:/projects/tmp/install-script-subdir/main/subdir/my_module/scripts/install.sh' exit code 1, stopped
```