### PR TITLE
mtest: Check version in the test data after loading

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -121,8 +121,7 @@ class TestSerialisation:
                  env: build.EnvironmentVariables, should_fail: bool,
                  timeout: T.Optional[int], workdir: T.Optional[str],
                  extra_paths: T.List[str], protocol: TestProtocol, priority: int,
-                 cmd_is_built: bool,
-                 depends: T.List[str]):
+                 cmd_is_built: bool, depends: T.List[str], version: str):
         self.name = name
         self.project_name = project
         self.suite = suite
@@ -143,6 +142,7 @@ class TestSerialisation:
         self.needs_exe_wrapper = needs_exe_wrapper
         self.cmd_is_built = cmd_is_built
         self.depends = depends
+        self.version = version
 
 
 def get_backend_from_name(backend: str, build: T.Optional[build.Build] = None, interpreter: T.Optional['Interpreter'] = None) -> T.Optional['Backend']:
@@ -864,7 +864,8 @@ class Backend:
                                    t.should_fail, t.timeout, t.workdir,
                                    extra_paths, t.protocol, t.priority,
                                    isinstance(exe, build.Executable),
-                                   [x.get_id() for x in depends])
+                                   [x.get_id() for x in depends],
+                                   self.environment.coredata.version)
             arr.append(ts)
         return arr
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -46,10 +46,10 @@ default_yielding = False
 _T = T.TypeVar('_T')
 
 class MesonVersionMismatchException(MesonException):
-    '''Build directory generated with Meson version incompatible with current version'''
+    '''Build directory generated with Meson version is incompatible with current version'''
     def __init__(self, old_version: str, current_version: str) -> None:
         super().__init__('Build directory has been generated with Meson version {}, '
-                         'which is incompatible with current version {}.'
+                         'which is incompatible with the current version {}.'
                          .format(old_version, current_version))
         self.old_version = old_version
         self.current_version = current_version
@@ -977,7 +977,7 @@ def get_cmd_line_options(build_dir: str, options: argparse.Namespace) -> str:
         cmdline += ['--native-file {}'.format(f) for f in options.native_file]
     return ' '.join([shlex.quote(x) for x in cmdline])
 
-def major_versions_differ(v1, v2):
+def major_versions_differ(v1: str, v2: str) -> bool:
     return v1.split('.')[0:2] != v2.split('.')[0:2]
 
 def load(build_dir: str) -> CoreData:


### PR DESCRIPTION
Same as coredata.dat and build.dat loading

Fixes https://github.com/mesonbuild/meson/issues/7613