### PR TITLE
Fix run_project_test.py when not under CI

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -42,7 +42,7 @@ NINJA_CMD = None
 # test that we run.
 if 'CI' in os.environ:
     NINJA_1_9_OR_NEWER = True
-    NINJA_CMD = 'ninja'
+    NINJA_CMD = ['ninja']
 else:
     # Look for 1.9 to see if https://github.com/ninja-build/ninja/issues/1219
     # is fixed
@@ -221,7 +221,7 @@ def get_backend_commands(backend, debug=False):
         test_cmd = cmd + ['-target', 'RUN_TESTS']
     elif backend is Backend.ninja:
         global NINJA_CMD
-        cmd = [NINJA_CMD, '-w', 'dupbuild=err', '-d', 'explain']
+        cmd = NINJA_CMD + ['-w', 'dupbuild=err', '-d', 'explain']
         if debug:
             cmd += ['-v']
         clean_cmd = cmd + ['clean']


### PR DESCRIPTION
Since 492afe50, detect_ninja() returns a List[str], not a str.

run_project_test.py still happens to work under CI, as we bypass detect_ninja(), but fails when run locally, as we try to exec() that list.

```
Checking that building works...
Traceback (most recent call last):
  File "./run_project_tests.py", line 1301, in <module>
    check_meson_commands_work(options)
  File "./run_project_tests.py", line 1190, in check_meson_commands_work
    pc, o, e = Popen_safe(compile_commands + dir_args, cwd=build_dir)
  File "/wip/meson/mesonbuild/mesonlib.py", line 1220, in Popen_safe
    stdout=stdout, stderr=stderr, **kwargs)
  File "/usr/lib/python3.6/subprocess.py", line 729, in __init__
    restore_signals, start_new_session)
  File "/usr/lib/python3.6/subprocess.py", line 1278, in _execute_child
    executable = os.fsencode(executable)
  File "/usr/lib/python3.6/os.py", line 800, in fsencode
    filename = fspath(filename)  # Does type-checking of `filename`.
TypeError: expected str, bytes or os.PathLike object, not list
```