### PR TITLE
minstall: Add version field to install data

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -74,7 +74,7 @@ class CleanTrees:
 
 class InstallData:
     def __init__(self, source_dir, build_dir, prefix, strip_bin,
-                 install_umask, mesonintrospect):
+                 install_umask, mesonintrospect, version):
         self.source_dir = source_dir
         self.build_dir = build_dir
         self.prefix = prefix
@@ -89,6 +89,7 @@ class InstallData:
         self.install_scripts = []
         self.install_subdirs = []
         self.mesonintrospect = mesonintrospect
+        self.version = version
 
 class TargetInstallData:
     def __init__(self, fname, outdir, aliases, strip, install_name_mappings, rpath_dirs_to_remove, install_rpath, install_mode, optional=False):
@@ -1158,7 +1159,8 @@ class Backend:
                         self.environment.get_prefix(),
                         strip_bin,
                         self.environment.coredata.get_builtin_option('install_umask'),
-                        self.environment.get_build_command() + ['introspect'])
+                        self.environment.get_build_command() + ['introspect'],
+                        self.environment.coredata.version)
         self.generate_depmf_install(d)
         self.generate_target_install(d)
         self.generate_header_install(d)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3009,12 +3009,6 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             result += [i]
         return result
 
-def load(build_dir):
-    filename = os.path.join(build_dir, 'meson-private', 'install.dat')
-    with open(filename, 'rb') as f:
-        obj = pickle.load(f)
-    return obj
-
 
 def _scan_fortran_file_deps(src: Path, srcdir: Path, dirname: Path, tdeps, compiler) -> T.List[str]:
     """


### PR DESCRIPTION
```
mtest: Refactor test data checking

```

```
minstall: Add version field to install data

And check the install data in the same way that mtest checks
serialisation data.
```
Fixes https://github.com/mesonbuild/meson/issues/2354
