### PR TITLE
unit tests: Don't use pytest when running single tests

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import typing as T
+import time
 import stat
 import subprocess
 import re
@@ -9052,4 +9052,8 @@ def main():
 
 if __name__ == '__main__':
     print('Meson build system', mesonbuild.coredata.version, 'Unit Tests')
-    raise SystemExit(main())
+    start = time.monotonic()
+    try:
+        raise SystemExit(main())
+    finally:
+        print('Total time: {:.3f} seconds'.format(time.monotonic() - start))


### PR DESCRIPTION
```
unit tests: Don't use pytest when running single tests

On my machine this spawns 24 processes and then runs like the single
test I asked it to run. With this change, running a single test goes
from 7 seconds to less than a second.
```

```
unit tests: Print total time taken for running tests

```

Split out from https://github.com/mesonbuild/meson/pull/7021.