### PR TITLE
Fix Korean MSVC compiler target arch detection

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1311,7 +1311,7 @@ class Environment:
                     m = 'Failed to detect MSVC compiler version: stderr was\n{!r}'
                     raise EnvironmentException(m.format(err))
                 cl_signature = lookat.split('\n')[0]
-                match = re.search('.*(x86|x64|ARM|ARM64)( |$)', cl_signature)
+                match = re.search(r'.*(x86|x64|ARM|ARM64)([^_A-Za-z0-9]|$)', cl_signature)
                 if match:
                     target = match.group(1)
                 else:


### PR DESCRIPTION
This fixes an issue essentially identical to #6757, except affecting users of the Korean locale (and possibly a different version of MSVC, if the claim in sthagen/meson#64 is to be believed). The fix involves allowing closing parenthesis to terminate the architecture substring, beside space and EOL. The signature line this adds support for is:
```
Microsoft (R) C/C++ 최적화 컴파일러 버전 19.27.29111(x64)
```