### PR TITLE
mcompile: Add some basic XCode support

### DIFF
--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -155,6 +155,8 @@ class MesonApp:
         mlog.initialize(env.get_log_dir(), self.options.fatal_warnings)
         if self.options.profile:
             mlog.set_timestamp_start(time.monotonic())
+        if env.coredata.builtins['backend'].value == 'xcode':
+            mlog.warning('xcode backend is currently unmaintained, patches welcome')
         with mesonlib.BuildDirLock(self.build_dir):
             self._generate(env)
 


### PR DESCRIPTION
I wrote this to convert `run_tests.get_backend_commands()` over to the new meson wrappers, but that turned out to be harder than I expected, so just splitting this out for now.