### PR TITLE
WIP: Add support for linking against static Qt install

### DIFF
--- a/docs/markdown/Qt5-module.md
+++ b/docs/markdown/Qt5-module.md
@@ -1,7 +1,7 @@
 # Qt5 module
 
 The Qt5 module provides tools to automatically deal with the various
-tools and steps required for Qt. The module has two methods.
+tools and steps required for Qt. The module has several methods.
 
 ## preprocess
 
@@ -50,6 +50,29 @@ This method takes the following keyword arguments:
 - `method`: method used to find the Qt dependency (`auto` by default).
 
 *Since: 0.54.0*
+
+## is_static
+This method returnes `true` if the Qt install is statically built.
+
+*Since 0.56.0*
+
+## static_plugins_dep
+When linking against a statically built Qt installation, plugins also needs static linking. The `static_plugins_dep` return a dependecy object that holds the nessecary
+linker flags for static linking, and generates files that includes the plugins using Qt's `Q_IMPORT_PLUGIN`. Normal plugins (those found in the `plugins` folder) must
+needs to be specified manually, while QML plugins are automatically detected from QML and JavaScript files.
+
+The method takes the following keyword arguments:
+- `qresources`, rcc source file used for scanning for QML plugins
+- `plugins`, list of plugins to import
+
+```meson
+qt5 = import('qt5')
+if qt5.is_static()
+  plugins_dep = qt5.static_plugins_dep(plugins: ['qsqlite', 'qjpeg'], qresource: 'resources.qrc')
+endif
+```
+*Since 0.56.0*
+
 
 ## Dependencies
 

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
+import re
 import shutil
 from .. import mlog
 from .. import build
-from ..mesonlib import MesonException, extract_as_list, File, unholder, version_compare
-from ..dependencies import Dependency, Qt4Dependency, Qt5Dependency, NonExistingExternalProgram
+from ..mesonlib import MesonException, extract_as_list, File, unholder, version_compare, Popen_safe
+from ..dependencies import Dependency, Qt4Dependency, Qt5Dependency, NonExistingExternalProgram, ExternalDependency
 import xml.etree.ElementTree as ET
 from . import ModuleReturnValue, get_include_args, ExtensionModule
 from ..interpreterbase import noPosargs, permittedKwargs, FeatureNew, FeatureNewKwargs
@@ -59,6 +61,15 @@ class QtBaseModule(ExtensionModule):
             self.uic = NonExistingExternalProgram(name='uic' + suffix)
             self.rcc = NonExistingExternalProgram(name='rcc' + suffix)
             self.lrelease = NonExistingExternalProgram(name='lrelease' + suffix)
+
+
+    def _is_static(self, env, method, required=True):
+        kwargs = {'required': required, 'modules': 'Core', 'method': method}
+        qt = _QT_DEPS_LUT[self.qt_version](env, kwargs)
+        if qt.found():
+            return qt.static
+
+        return False
 
     def qrc_nodes(self, state, rcc_file):
         if type(rcc_file) is str:
@@ -263,3 +274,98 @@ class QtBaseModule(ExtensionModule):
             return ModuleReturnValue(results.return_value[0], [results.new_objects, translations])
         else:
             return ModuleReturnValue(translations, translations)
+
+    @noPosargs
+    @permittedKwargs({'method', 'required'})
+    @FeatureNew('qt.is_static', '0.55.0')
+    def is_static(self, state, args, kwargs):
+        method = kwargs.get('method', 'auto')
+        return ModuleReturnValue(self._is_static(state.environment, method, required=False), [])
+
+    @staticmethod
+    def _link_args(qt, prl):
+        archive = os.path.splitext(prl)[0] + '.a'
+        with open(prl) as prl:
+            re_libs = re.compile(r'^QMAKE_PRL_LIBS = (.*)$')
+            for line in prl.readlines():
+                line = line.rstrip()
+                raw_libs = re_libs.match(line)
+
+                if raw_libs:
+                    libs_str = raw_libs.groups()[0].replace('$$[QT_INSTALL_LIBS]', qt.libdir, -1)
+                    break
+        return [archive] + libs_str.split(' ')
+
+    @staticmethod
+    def _generate_importer(qt, state, classname):
+        script = '''print('#include <QtPlugin>')\nprint('Q_IMPORT_PLUGIN({})')'''.format(classname)
+        cmd = ['python3', '-c', script]
+        kwargs = {
+            'output': 'qt_plugin_{}_importer.cpp'.format(classname.lower()),
+            'capture': True,
+            'command': cmd,
+        }
+        return build.CustomTarget('qt-gen-plugin-import-{}'.format(classname.lower()), state.subdir, state.subproject, kwargs)
+
+    @staticmethod
+    def _parse_pri(pripath):
+        regex = re.compile(r'QT_PLUGIN.\S*.TYPE = (?P<type>\S*)\n.*\n.*\nQT_PLUGIN.\S*.CLASS_NAME = (?P<classname>\S*)\nQT_PLUGINS \+= (?P<name>\S*)')
+        with open(pripath) as pri:
+            match = regex.match(pri.read())
+        if match:
+            return match.groupdict()
+        raise MesonException('failed to parse pri file:', pripath)
+
+    def _get_qml(self, state, rcc):
+        nodes  = self.parse_qrc_deps(state, rcc)
+        return [x.fname for x in nodes if os.path.splitext(x.fname)[1] in ['.qml', '.js']]
+
+
+
+    @permittedKwargs({'method', 'qresources', 'plugins'})
+    @FeatureNew('qt.static_qml_plugins', '0.56.0')
+    def static_plugins_dep(self, state, args, kwargs):
+        method = kwargs.get('method', 'auto')
+
+        qt = _QT_DEPS_LUT[self.qt_version](state.environment, {'modules': 'Core', 'method': method})
+        if not qt.found():
+            raise MesonException('couldn\'t find qt')
+
+        link_args = []
+        sources = []
+
+        qresources = kwargs.get('qresources', None)
+        if qresources:
+            scanner = os.path.join(qt.bindir, 'qmlimportscanner')
+            if not os.path.isfile(scanner) or not os.access(scanner, os.X_OK):
+                raise MesonException('qmlimportscanner not found')
+            qmldir = os.path.join(qt.install_prefix, 'qml')
+
+
+            qml_files = self._get_qml(state, qresources)
+            cmd  = [scanner, '-qmlFiles'] + qml_files + ['-importPath', qmldir]
+            stdout = Popen_safe(cmd)[1]
+            added = set()
+            for plugin in json.loads(stdout):
+                if 'plugin' in plugin and plugin['classname'] not in added:
+                    prl = os.path.join(qmldir, plugin['relativePath'], 'lib{}.prl'.format(plugin['plugin']))
+                    link_args.extend(self._link_args(qt, prl))
+                    sources.append(self._generate_importer(qt, state, plugin['classname']))
+                    added.add(plugin['classname'])
+
+        cpp_plugins = extract_as_list(kwargs, 'plugins', pop=True)
+        if cpp_plugins:
+            pridir = os.path.join(qt.install_prefix, 'mkspecs', 'modules')
+            for cpp_plugin in cpp_plugins:
+                pripath = os.path.join(pridir, 'qt_plugin_{}.pri'.format(cpp_plugin))
+                plugin_data = self._parse_pri(pripath)
+                prl = os.path.join(qt.install_prefix, 'plugins', plugin_data['type'], 'lib{}.prl'.format(cpp_plugin))
+
+                link_args.extend(self._link_args(qt, prl))
+                sources.append(self._generate_importer(qt, state, plugin_data['classname']))
+
+        dep = ExternalDependency('qt-static-plugins', state.environment, {'static': True})
+        dep.link_args = link_args
+        dep.sources = sources
+        dep.is_found = link_args and sources
+        return ModuleReturnValue(dep, sources)


### PR DESCRIPTION
Linking against a statically built Qt installation is mostly the same as
the dynamic case, with the exception of plugins (both regular an QML-plugins),
which needs to be manually imported and require several extra linker flags.

Note: This lacks any test for this new functionality, as I assume I'd need a static Qt install to test against. Any pointers to how I can add tests for this?