### PR TITLE
Test meson wrappers on the CI, and test 32-bit VS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,8 +24,8 @@ jobs:
           compiler: msvc2017
           backend: ninja
           MESON_RSP_THRESHOLD: 0
-        vc2017x64vs:
-          arch: x64
+        vc2017x86vs:
+          arch: x86
           compiler: msvc2017
           backend: vs2017
         clangclx64ninja:


### PR DESCRIPTION
```
project tests: Test that the wrappers actually work

```

```
ci: Convert the vc2017 x64 job to x86

So we test the VS backend on 32-bit. Would've caught, f.ex.,
```
https://github.com/mesonbuild/meson/pull/7730
