### PR TITLE
machinefiles: Allow keys to be stored case insensitive

### DIFF
--- a/docs/markdown/Machine-files.md
+++ b/docs/markdown/Machine-files.md
@@ -5,6 +5,9 @@ documentation on the common values used by both, for the specific values of
 one or the other see the [cross compilation](Cross-compilation.md) and [native
 environments](Native-environments.md).
 
+*Changed in 0.56.0* Keys within sections are now case sensitive. This is
+*required to make project options work correctly.
+
 ## Data Types
 
 There are four basic data types in a machine file:

--- a/docs/markdown/snippets/machine-files-case-insensitve.md
+++ b/docs/markdown/snippets/machine-files-case-insensitve.md
@@ -1,0 +1,6 @@
+## Machine file keys are stored case sensitive
+
+Previous the keys were always lowered, which worked fine for the values that
+were allowed in the machine files. With the addition of per-project options
+we need to make these sensitive to case, as the options in meson_options.txt
+are sensitive to case already.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -848,13 +848,17 @@ class CoreData:
             mlog.warning('Please see https://mesonbuild.com/Builtin-options.html#Notes_about_Apple_Bitcode_support for more details.', fatal=False)
 
 class CmdLineFileParser(configparser.ConfigParser):
-    def __init__(self):
+    def __init__(self) -> None:
         # We don't want ':' as key delimiter, otherwise it would break when
         # storing subproject options like "subproject:option=value"
         super().__init__(delimiters=['='], interpolation=None)
 
+    def optionxform(self, option: str) -> str:
+        # Don't call str.lower() on keys
+        return option
+
 class MachineFileParser():
-    def __init__(self, filenames: T.List[str]):
+    def __init__(self, filenames: T.List[str]) -> None:
         self.parser = CmdLineFileParser()
         self.constants = {'True': True, 'False': False}
         self.sections = {}

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -8179,7 +8179,9 @@ class NativeFileTests(BasePlatformTests):
         testcase = os.path.join(self.common_test_dir, '43 options')
         for opt, value in [('testoption', 'some other val'), ('other_one', True),
                            ('combo_opt', 'one'), ('array_opt', ['two']),
-                           ('integer_opt', 0)]:
+                           ('integer_opt', 0),
+                           ('CaseSenSiTivE', 'SOME other Value'),
+                           ('CASESENSITIVE', 'some other Value')]:
             config = self.helper_create_native_file({'project options': {opt: value}})
             with self.assertRaises(subprocess.CalledProcessError) as cm:
                 self.init(testcase, extra_args=['--native-file', config])

--- a/test cases/common/43 options/meson.build
+++ b/test cases/common/43 options/meson.build
@@ -34,4 +34,12 @@ if get_option('neg_int_opt') != -3
   error('Incorrect value in negative integer option.')
 endif
 
+if get_option('CaseSenSiTivE') != 'Some CAPS'
+  error('Incorrect value in mixed caps option.')
+endif
+
+if get_option('CASESENSITIVE') != 'ALL CAPS'
+  error('Incorrect value in all caps option.')
+endif
+
 assert(get_option('wrap_mode') == 'default', 'Wrap mode option is broken.')

--- a/test cases/common/43 options/meson_options.txt
+++ b/test cases/common/43 options/meson_options.txt
@@ -5,3 +5,5 @@ option('array_opt', type : 'array', choices : ['one', 'two', 'three'], value : [
 option('free_array_opt', type : 'array')
 option('integer_opt', type : 'integer', min : 0, max : -(-5), value : 3)
 option('neg' + '_' + 'int' + '_' + 'opt', type : 'integer', min : -5, max : 5, value : -3)
+option('CaseSenSiTivE', type : 'string', value: 'Some CAPS', description : 'An option with mixed capitaliziation')
+option('CASESENSITIVE', type : 'string', value: 'ALL CAPS', description : 'An option with all caps')


### PR DESCRIPTION
This is required to make the various keys in the [user options] section
work the same as they do in the meson_options.txt file, where we don't
have any rules about case sensitivity.

There is some risk here. Someone may be relying on this lower by default
behavior, and this could break their machine files.

Fixes #7731