### PR TITLE
options: Handle updates to choices in options

### DIFF
--- a/test cases/unit/84 change option choices/meson.build
+++ b/test cases/unit/84 change option choices/meson.build
@@ -1,0 +1,1 @@
+project('change option choices')

--- a/test cases/unit/84 change option choices/meson_options.1.txt
+++ b/test cases/unit/84 change option choices/meson_options.1.txt
@@ -1,0 +1,13 @@
+option(
+    'combo',
+    type : 'combo',
+    choices : ['a', 'b', 'c'],
+    value : 'a',
+)
+
+option(
+    'array',
+    type : 'array',
+    choices : ['a', 'b', 'c'],
+    value : ['a'],
+)

--- a/test cases/unit/84 change option choices/meson_options.2.txt
+++ b/test cases/unit/84 change option choices/meson_options.2.txt
@@ -1,0 +1,13 @@
+option(
+    'combo',
+    type : 'combo',
+    choices : ['b', 'c', 'd'],
+    value : 'b',
+)
+
+option(
+    'array',
+    type : 'array',
+    choices : ['b', 'c', 'd'],
+    value : ['b'],
+)


### PR DESCRIPTION
Currently if you change the `choices` field in the meson_options.txt
file, no update will be done until `meson setup --wipe` is called. Now
if the choices change then the options will be properly merged.

If the currently select value is still valid it is guaranteed to be
kept, if it is now invalid the new default value will be used and a
warning will be printed.

Fixes #7386