### PR TITLE
Fixed MacOS dylib custom targets not marked as linkable

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2245,7 +2245,7 @@ class CustomTarget(Target):
         if len(self.outputs) != 1:
             return False
         suf = os.path.splitext(self.outputs[0])[-1]
-        if suf == '.a' or suf == '.dll' or suf == '.lib' or suf == '.so':
+        if suf == '.a' or suf == '.dll' or suf == '.lib' or suf == '.so' or suf == '.dylib':
             return True
 
     def get_link_deps_mapping(self, prefix, environment):


### PR DESCRIPTION
[This commit (from Aug 2019)](https://github.com/pexip/meson/commit/a58ae49b5fa67a22d4861439db034b03e29b675b#diff-8298ed52ef750c466e88a3a6708d3586R2101) introduced a fix where it's possible to link with custom targets having one of a limited set of file extensions, covering the standard file extensions used by ELF static and dynamic link libraries, PE static and dynamic libs, and Mach-O static libraries.

This PR adds the extension used by MacOS for Mach-O dynamic link libraries (`.dylib`) to the allowed link list; in this way it's possible to link to a custom step producing a dynamic link library on MacOS.

*(PR opened in draft in order to check CI)*