### PR TITLE
Canonicalize target architectures aarch64/armv* into arm64/arm for MSVC tools

### DIFF
--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -131,6 +131,10 @@ class VisualStudioLikeCompiler(metaclass=abc.ABCMeta):
             self.machine = 'x64'
         elif '86' in target:
             self.machine = 'x86'
+        elif 'aarch64' in target:
+            self.machine = 'arm64'
+        elif 'arm' in target:
+            self.machine = 'arm'
         else:
             self.machine = target
         self.linker.machine = self.machine


### PR DESCRIPTION
If the architectures are taken from the output of "clang-cl --version",
we need to convert these names into names that the MSVC tools accept
as the -machine: parameter.