### PR TITLE
Some fixes for CompCert

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from ... import arglist
 from ... import mesonlib
 from ... import mlog
-from ...linkers import GnuLikeDynamicLinkerMixin, SolarisDynamicLinker
+from ...linkers import GnuLikeDynamicLinkerMixin, SolarisDynamicLinker, CompCertDynamicLinker
 from ...mesonlib import LibType
 from .. import compilers
 from .visualstudio import VisualStudioLikeCompiler
@@ -67,7 +67,7 @@ class CLikeCompilerArgs(arglist.CompilerArgs):
         # This covers all ld.bfd, ld.gold, ld.gold, and xild on Linux, which
         # all act like (or are) gnu ld
         # TODO: this could probably be added to the DynamicLinker instead
-        if isinstance(self.compiler.linker, (GnuLikeDynamicLinkerMixin, SolarisDynamicLinker)):
+        if isinstance(self.compiler.linker, (GnuLikeDynamicLinkerMixin, SolarisDynamicLinker, CompCertDynamicLinker)):
             group_start = -1
             group_end = -1
             for i, each in enumerate(new):

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -900,13 +900,13 @@ class CompCertDynamicLinker(DynamicLinker):
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:
         if not args:
             return args
-        return self._apply_prefix('-WUl,--start-group') + args + self._apply_prefix('-WUl,--end-group')
+        return self._apply_prefix('-Wl,--whole-archive') + args + self._apply_prefix('-Wl,--no-whole-archive')
 
     def get_accepts_rsp(self) -> bool:
         return False
 
     def get_lib_prefix(self) -> str:
-        return '-l'
+        return ''
 
     def get_std_shared_lib_args(self) -> T.List[str]:
         return []


### PR DESCRIPTION
Some fixes for #7674:

1. Like with gcc's `ld`, also use the `group_start` code to create a
   `--start-group`/`--end-group`
2. xc16 tricked into believing the 'link_whole' was about `--*-group`,
   but it should use gcc's `--whole-archive` instead.
3. Not clear what the get_lib_prefix should really do, but for picolibc
   it seems I want just `''`.

The problem with picolibc was that the `-l` would be prefixed to a lib
like `picolib/libm/libm.a`. Though of course the `-l` would be necessary
for just a plain `m` (that's what I assumed this would be used for).
I think this might need some clarification from the meson devs ;-)