### PR TITLE
Extend the Curses dependency to use config tools and hand rolled search

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,15 +150,18 @@ jobs:
       gccx86ninja:
         MSYSTEM: MINGW32
         MSYS2_ARCH: i686
+        MSYS2_CURSES: ncurses
         compiler: gcc
       gccx64ninja:
         MSYSTEM: MINGW64
         MSYS2_ARCH: x86_64
+        MSYS2_CURSES: pdcurses
         MESON_RSP_THRESHOLD: 0
         compiler: gcc
       clangx64ninja:
         MSYSTEM: MINGW64
         MSYS2_ARCH: x86_64
+        MSYS2_CURSES:
         compiler: clang
   variables:
     MSYS2_ROOT: $(System.Workfolder)\msys64
@@ -184,6 +187,7 @@ jobs:
         mingw-w64-$(MSYS2_ARCH)-python3-setuptools ^
         mingw-w64-$(MSYS2_ARCH)-python3-pip ^
         %TOOLCHAIN%
+        if not "%MSYS2_CURSES%" == "" ( %MSYS2_ROOT%\usr\bin\pacman --noconfirm --needed -S mingw-w64-$(MSYS2_ARCH)-$(MSYS2_CURSES) )
         %MSYS2_ROOT%\usr\bin\bash -lc "python3 -m pip --disable-pip-version-check install gcovr jsonschema pefile"
       displayName: Install Dependencies
     - script: |

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -623,7 +623,9 @@ Curses (and ncurses) are a cross platform pain in the butt. Meson wraps up
 these dependencies in the `curses` dependency. This covers both `ncurses`
 (preferred) and other curses implementations.
 
-`method` may be `auto` or `pkg-config`
+`method` may be `auto`, `pkg-config`, or `config-tool`
+
+*New in 0.56.0* The `config-tool` method.
 
 <hr>
 <a name="footnote1">1</a>: They may appear to be case-insensitive, if the

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -615,6 +615,16 @@ on these OSes to link with the bundled version.
 
 *New in 0.54.0* the `system` method.
 
+## Curses
+
+*(Since 0.54.0)*
+
+Curses (and ncurses) are a cross platform pain in the butt. Meson wraps up
+these dependencies in the `curses` dependency. This covers both `ncurses`
+(preferred) and other curses implementations.
+
+`method` may be `auto` or `pkg-config`
+
 <hr>
 <a name="footnote1">1</a>: They may appear to be case-insensitive, if the
     underlying file system happens to be case-insensitive.

--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -623,9 +623,9 @@ Curses (and ncurses) are a cross platform pain in the butt. Meson wraps up
 these dependencies in the `curses` dependency. This covers both `ncurses`
 (preferred) and other curses implementations.
 
-`method` may be `auto`, `pkg-config`, or `config-tool`
+`method` may be `auto`, `pkg-config`, `config-tool`, or `system`.
 
-*New in 0.56.0* The `config-tool` method.
+*New in 0.56.0* The `config-tool` and `system` methods.
 
 <hr>
 <a name="footnote1">1</a>: They may appear to be case-insensitive, if the

--- a/docs/markdown/snippets/curses-dependency-improvements.md
+++ b/docs/markdown/snippets/curses-dependency-improvements.md
@@ -1,4 +1,4 @@
 ## Improvements for the builtin curses dependency
 
-This method has been extended to use config-tools for lookup as well as
-pkg-config.
+This method has been extended to use config-tools, and a fallback to
+find_library for lookup as well as pkg-config.

--- a/docs/markdown/snippets/curses-dependency-improvements.md
+++ b/docs/markdown/snippets/curses-dependency-improvements.md
@@ -1,0 +1,4 @@
+## Improvements for the builtin curses dependency
+
+This method has been extended to use config-tools for lookup as well as
+pkg-config.

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -480,7 +480,7 @@ class ZlibSystemDependency(ExternalDependency):
             for lib in libs:
                 l = self.clib_compiler.find_library(lib, environment, [])
                 h = self.clib_compiler.has_header('zlib.h', '', environment, dependencies=[self])
-                if l and h:
+                if l and h[0]:
                     self.is_found = True
                     self.link_args = l
                     break

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -410,7 +410,7 @@ def curses_factory(env: 'Environment', for_machine: 'MachineChoice',
     candidates = []  # type: T.List[T.Callable[[], Dependency]]
 
     if DependencyMethods.PKGCONFIG in methods:
-        pkgconfig_files = ['ncurses', 'ncursesw']
+        pkgconfig_files = ['ncursesw', 'ncurses', 'curses']
         for pkg in pkgconfig_files:
             candidates.append(functools.partial(PkgConfigDependency, pkg, env, kwargs))
 

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -489,11 +489,15 @@ def curses_factory(env: 'Environment', for_machine: 'MachineChoice',
         for pkg in pkgconfig_files:
             candidates.append(functools.partial(PkgConfigDependency, pkg, env, kwargs))
 
-    if DependencyMethods.CONFIG_TOOL in methods:
-        candidates.append(functools.partial(CursesConfigToolDependency, 'curses', env, kwargs))
+    # There are path handling problems with these methods on msys, and they
+    # don't apply to windows otherwise (cygwin is handled seperately from
+    # windows)
+    if not env.machines[for_machine].is_windows():
+        if DependencyMethods.CONFIG_TOOL in methods:
+            candidates.append(functools.partial(CursesConfigToolDependency, 'curses', env, kwargs))
 
-    if DependencyMethods.SYSTEM in methods:
-        candidates.append(functools.partial(CursesSystemDependency, 'curses', env, kwargs))
+        if DependencyMethods.SYSTEM in methods:
+            candidates.append(functools.partial(CursesSystemDependency, 'curses', env, kwargs))
 
     return candidates
 

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -433,6 +433,7 @@ class CursesSystemDependency(ExternalDependency):
         super().__init__(name, env, kwargs)
 
         candidates = [
+            ('pdcurses', ['pdcurses/curses.h']),
             ('ncursesw',  ['ncursesw/ncurses.h', 'ncurses.h']),
             ('ncurses',  ['ncurses/ncurses.h', 'ncurses/curses.h', 'ncurses.h']),
             ('curses',  ['curses.h']),
@@ -453,6 +454,10 @@ class CursesSystemDependency(ExternalDependency):
                         if lib.startswith('ncurses'):
                             v, _ = self.clib_compiler.get_define('NCURSES_VERSION', '#include <{}>'.format(header), env, [], [self])
                             self.version = v.strip('"')
+                        if lib.startswith('pdcurses'):
+                            v_major, _ = self.clib_compiler.get_define('PDC_VER_MAJOR', '#include <{}>'.format(header), env, [], [self])
+                            v_minor, _ = self.clib_compiler.get_define('PDC_VER_MINOR', '#include <{}>'.format(header), env, [], [self])
+                            self.version = '{}.{}'.format(v_major, v_minor)
 
                         # Check the version if possible, emit a wraning if we can't
                         req = kwargs.get('version')
@@ -480,7 +485,7 @@ def curses_factory(env: 'Environment', for_machine: 'MachineChoice',
     candidates = []  # type: T.List[T.Callable[[], Dependency]]
 
     if DependencyMethods.PKGCONFIG in methods:
-        pkgconfig_files = ['ncursesw', 'ncurses', 'curses']
+        pkgconfig_files = ['pdcurses', 'ncursesw', 'ncurses', 'curses']
         for pkg in pkgconfig_files:
             candidates.append(functools.partial(PkgConfigDependency, pkg, env, kwargs))
 

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -32,7 +32,7 @@ from .base import (
 
 if T.TYPE_CHECKING:
     from ..environment import Environment, MachineChoice
-    from .base import DependencyType  # noqa: F401
+    from .base import DependencyType, Dependency  # noqa: F401
 
 
 @factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.CMAKE})
@@ -406,8 +406,8 @@ class ShadercDependency(ExternalDependency):
 
 @factory_methods({DependencyMethods.PKGCONFIG})
 def curses_factory(env: 'Environment', for_machine: 'MachineChoice',
-                   kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> T.List['DependencyType']:
-    candidates = []  # type: T.List['DependencyType']
+                   kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> T.List[T.Callable[[], 'Dependency']]:
+    candidates = []  # type: T.List[T.Callable[[], Dependency]]
 
     if DependencyMethods.PKGCONFIG in methods:
         pkgconfig_files = ['ncurses', 'ncursesw']

--- a/test cases/frameworks/31 curses/meson.build
+++ b/test cases/frameworks/31 curses/meson.build
@@ -1,6 +1,6 @@
 project('curses', 'c')
 
-curses = dependency('curses', required: false)
+curses = dependency('curses', required: false, method : get_option('method'))
 if not curses.found()
   error('MESON_SKIP_TEST: Curses library not found')
 endif

--- a/test cases/frameworks/31 curses/meson.build
+++ b/test cases/frameworks/31 curses/meson.build
@@ -1,9 +1,13 @@
 project('curses', 'c')
 
-curses = dependency('curses', required: false, method : get_option('method'))
+curses = dependency('curses', required: false, method : get_option('method'), version : '>= 0')
 if not curses.found()
   error('MESON_SKIP_TEST: Curses library not found')
 endif
 
 exec = executable('basic', 'main.c', dependencies: curses)
 # didn't run the test because in general graphics fail on CI
+
+# this should fail
+not_found = dependency('curses', required: false, method : get_option('method'), version : '> 1000000')
+assert(not_found.found() == false)

--- a/test cases/frameworks/31 curses/meson_options.txt
+++ b/test cases/frameworks/31 curses/meson_options.txt
@@ -1,0 +1,6 @@
+option(
+    'method',
+    type : 'combo',
+    choices : ['pkg-config', 'config-tool'],
+    value : 'pkg-config',
+)

--- a/test cases/frameworks/31 curses/meson_options.txt
+++ b/test cases/frameworks/31 curses/meson_options.txt
@@ -1,6 +1,6 @@
 option(
     'method',
     type : 'combo',
-    choices : ['pkg-config', 'config-tool'],
+    choices : ['pkg-config', 'config-tool', 'system'],
     value : 'pkg-config',
 )

--- a/test cases/frameworks/31 curses/test.json
+++ b/test cases/frameworks/31 curses/test.json
@@ -1,0 +1,10 @@
+{
+  "matrix": {
+    "options": {
+      "method": [
+        { "val": "pkg-config" },
+        { "val": "config-tool" }
+      ]
+    }
+  }
+}

--- a/test cases/frameworks/31 curses/test.json
+++ b/test cases/frameworks/31 curses/test.json
@@ -3,7 +3,8 @@
     "options": {
       "method": [
         { "val": "pkg-config" },
-        { "val": "config-tool" }
+        { "val": "config-tool" },
+        { "val": "system" }
       ]
     }
   }


### PR DESCRIPTION
Like many other classic unix libraries curses is a portability pain, there's a bunch of slightly different implementations, that are found different ways. Meson already provides abstractions for making other widely available but not always easy to find libraries easier to use.

This adds all of the methods, and is tested on linux. I can test it on illumos/OpenIndiana and FreeBSD later if needed.

This doesn't resolve the fact that users will likely need to know which header they should `#include`. But that's a bigger change to dependencies.

Fixes #7693