### PR TITLE
build: use PIE objects for non-PIC static libraries if b_pie=true

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -723,7 +723,7 @@ class Backend:
         # Set -fPIC for static libraries by default unless explicitly disabled
         if isinstance(target, build.StaticLibrary) and target.pic:
             commands += compiler.get_pic_args()
-        if isinstance(target, build.Executable) and target.pie:
+        elif isinstance(target, (build.StaticLibrary, build.Executable)) and target.pie:
             commands += compiler.get_pie_args()
         # Add compile args needed to find external dependencies. Link args are
         # added while generating the link command.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -993,13 +993,13 @@ This will become a hard error in a future Meson release.''')
             if m.is_darwin() or m.is_windows():
                 self.pic = True
             else:
-                self.pic = self._extract_pic_pie(kwargs, 'pic')
-        if isinstance(self, Executable):
+                self.pic = self._extract_pic_pie(kwargs, 'pic', environment, 'b_staticpic')
+        if isinstance(self, Executable) or (isinstance(self, StaticLibrary) and not self.pic):
             # Executables must be PIE on Android
             if self.environment.machines[self.for_machine].is_android():
                 self.pie = True
             else:
-                self.pie = self._extract_pic_pie(kwargs, 'pie')
+                self.pie = self._extract_pic_pie(kwargs, 'pie', environment, 'b_pie')
         self.implicit_include_directories = kwargs.get('implicit_include_directories', True)
         if not isinstance(self.implicit_include_directories, bool):
             raise InvalidArguments('Implicit_include_directories must be a boolean.')
@@ -1017,14 +1017,20 @@ This will become a hard error in a future Meson release.''')
             raise InvalidArguments('Invalid value for win_subsystem: {}.'.format(value))
         return value
 
-    def _extract_pic_pie(self, kwargs, arg):
+    def _extract_pic_pie(self, kwargs, arg, environment, option):
         # Check if we have -fPIC, -fpic, -fPIE, or -fpie in cflags
         all_flags = self.extra_args['c'] + self.extra_args['cpp']
         if '-f' + arg.lower() in all_flags or '-f' + arg.upper() in all_flags:
             mlog.warning("Use the '{}' kwarg instead of passing '{}' manually to {!r}".format(arg, '-f' + arg, self.name))
             return True
 
-        val = kwargs.get(arg, False)
+        if arg in kwargs:
+            val = kwargs[arg]
+        elif option in environment.coredata.base_options:
+            val = environment.coredata.base_options[option].value
+        else:
+            val = False
+
         if not isinstance(val, bool):
             raise InvalidArguments('Argument {} to {!r} must be boolean'.format(arg, self.name))
         return val
@@ -1631,8 +1637,6 @@ class StaticLibrary(BuildTarget):
 
     def __init__(self, name, subdir, subproject, for_machine: MachineChoice, sources, objects, environment, kwargs):
         self.typename = 'static library'
-        if 'pic' not in kwargs and 'b_staticpic' in environment.coredata.base_options:
-            kwargs['pic'] = environment.coredata.base_options['b_staticpic'].value
         super().__init__(name, subdir, subproject, for_machine, sources, objects, environment, kwargs)
         if 'cs' in self.compilers:
             raise InvalidArguments('Static libraries not supported for C#.')


### PR DESCRIPTION
If `static_library` is used for a convenience library (e.g. for link_whole), the library should in principle not need position independent code. However, if the executables that the libraries is linked to are PIE, the non-PIC objects in the static library will cause linker errors. To avoid this, obey `b_pie` for static libraries if either `b_staticpic=false` or they use `pic: false`.

Without this patch, a project that only uses static libraries as convenience libraries cannot use `b_staticpic=false`, because the correct setting would be, so to speak, `b_staticpic=$b_pie`. This causes a massive slowdown on some QEMU benchmarks (up to 20%). We can work it around for now while we still have wrappers upon wrappers around Meson, but in the long run this should be fixed.

But actually, this patch also provides a performance improvement if `b_pie=true`, because `b_staticpic=true b_pie=true` is also slower than the `b_staticpic=false b_pie=true` combo that is now fixed. This is because `-fPIC` produces worse code than `-fPIE`.  On the aforementioned benchmark:

    b_staticpic=false b_pie=false               0.5s
    b_staticpic=true b_pie=true                 0.6s
    ---
    b_staticpic=false b_pie=true unpatched      linking fails
    b_staticpic=false b_pie=true patched        0.53s
