### PR TITLE
Improve the output for meson wrapped commands

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -114,6 +114,7 @@ class ExecutableSerialisation:
         self.workdir = workdir
         self.extra_paths = extra_paths
         self.capture = capture
+        self.pickled = False
 
 class TestSerialisation:
     def __init__(self, name: str, project: str, suite: str, fname: T.List[str],

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -150,7 +150,7 @@ class Vs2010Backend(backends.Backend):
                     # Always use a wrapper because MSBuild eats random characters when
                     # there are many arguments.
                     tdir_abs = os.path.join(self.environment.get_build_dir(), self.get_target_dir(target))
-                    cmd = self.as_meson_exe_cmdline(
+                    cmd, _ = self.as_meson_exe_cmdline(
                         'generator ' + cmd[0],
                         cmd[0],
                         cmd[1:],
@@ -565,12 +565,12 @@ class Vs2010Backend(backends.Backend):
         # there are many arguments.
         tdir_abs = os.path.join(self.environment.get_build_dir(), self.get_target_dir(target))
         extra_bdeps = target.get_transitive_build_target_deps()
-        wrapper_cmd = self.as_meson_exe_cmdline(target.name, target.command[0], cmd[1:],
-                                                # All targets run from the target dir
-                                                workdir=tdir_abs,
-                                                extra_bdeps=extra_bdeps,
-                                                capture=ofilenames[0] if target.capture else None,
-                                                force_serialize=True)
+        wrapper_cmd, _ = self.as_meson_exe_cmdline(target.name, target.command[0], cmd[1:],
+                                                   # All targets run from the target dir
+                                                   workdir=tdir_abs,
+                                                   extra_bdeps=extra_bdeps,
+                                                   capture=ofilenames[0] if target.capture else None,
+                                                   force_serialize=True)
         if target.build_always_stale:
             # Use a nonexistent file to always consider the target out-of-date.
             ofilenames += [self.nonexistent_file(os.path.join(self.environment.get_scratch_dir(),

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -55,9 +55,12 @@ def run_exe(exe: ExecutableSerialisation) -> int:
                          stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()
 
+    if exe.pickled and p.returncode != 0:
+        print('while executing {!r}'.format(cmd_args))
+
     if p.returncode == 0xc0000135:
         # STATUS_DLL_NOT_FOUND on Windows indicating a common problem that is otherwise hard to diagnose
-        raise FileNotFoundError('Missing DLLs on calling {!r}'.format(cmd_args))
+        raise FileNotFoundError('due to missing DLLs')
 
     if exe.capture and p.returncode == 0:
         skip_write = False
@@ -90,6 +93,7 @@ def run(args: T.List[str]) -> int:
             parser.error('no other arguments can be used with --unpickle')
         with open(options.unpickle, 'rb') as f:
             exe = pickle.load(f)
+            exe.pickled = True
     else:
         exe = ExecutableSerialisation(cmd_args, capture=options.capture)
 

--- a/test cases/failing build/5 failed pickled/meson.build
+++ b/test cases/failing build/5 failed pickled/meson.build
@@ -1,0 +1,7 @@
+project('failed pickled command')
+
+custom_target('failure',
+  command: ['false', '\n'],
+  output: 'output.txt',
+  build_by_default: true,
+)


### PR DESCRIPTION
*  Improve the description used with ninja for meson wrapped custom commands
* Make `meson --internal exe --unpickle` report the actual command executed when it fails, which is otherwise invisible (e.g. https://github.com/mesonbuild/meson/pull/3716#issuecomment-395746838)

before
```
$ ninja -C _build
ninja: Entering directory `_build'
[1/1] Generating failure with a meson_exe.py custom command
FAILED: output.txt
/usr/bin/python3 /wip/meson/meson.py --internal exe --unpickle '/wip/meson/test cases/failing build/5 failed pickled/_build/meson-private/meson_exe_false_390bef2b03aeece2173ed5a4efdf9daddc71b21d.dat'
ninja: build stopped: subcommand failed.
```

after
```
$ ninja -C _build
ninja: Entering directory `_build'
[1/1] Generating failure with a custom command (wrapped by meson to capture output)
FAILED: output.txt
/usr/bin/python3 /wip/meson/meson.py --internal exe --unpickle '/wip/meson/test cases/failing build/5 failed pickled/_build/meson-private/meson_exe_false_390bef2b03aeece2173ed5a4efdf9daddc71b21d.dat'
while executing ['false']
ninja: build stopped: subcommand failed.

```
