### PR TITLE
Custom target link

### DIFF
--- a/test cases/common/215 link custom/custom_target.c
+++ b/test cases/common/215 link custom/custom_target.c
@@ -1,0 +1,6 @@
+void outer_lib_func(void);
+
+int main(void) {
+    outer_lib_func();
+    return 0;
+}

--- a/test cases/common/215 link custom/custom_target.py
+++ b/test cases/common/215 link custom/custom_target.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import shutil, sys
+
+if __name__ == '__main__':
+    shutil.copyfile(sys.argv[1], sys.argv[2])

--- a/test cases/common/215 link custom/dummy.c
+++ b/test cases/common/215 link custom/dummy.c
@@ -1,0 +1,1 @@
+void inner_lib_func(void) {}

--- a/test cases/common/215 link custom/meson.build
+++ b/test cases/common/215 link custom/meson.build
@@ -57,3 +57,22 @@ d2_i = declare_dependency(link_whole: clib[0])
 
 exe4_i = executable('prog4_i', 'prog.c', dependencies: d2_i)
 test('linkwhole2_i', exe2_i)
+
+# Link with custom target
+
+dummy = static_library('dummy', 'dummy.c')
+
+custom_prog = find_program('custom_target.py')
+t = custom_target('custom', input: dummy, output: 'libcustom.a', command: [custom_prog, '@INPUT@', '@OUTPUT@'])
+
+dep1 = declare_dependency(link_with: t)
+dep2 = declare_dependency(link_with: t[0])
+
+lib1 = static_library('lib1', 'outerlib.c', dependencies: dep1)
+lib2 = static_library('lib2', 'outerlib.c', dependencies: dep2)
+
+exe1 = executable('exe1', 'custom_target.c', link_with: lib1)
+test('custom_target_1', exe1)
+
+exe1_2 = executable('exe1_2', 'custom_target.c', link_with: lib2)
+test('custom_target_2', exe2)

--- a/test cases/common/215 link custom/outerlib.c
+++ b/test cases/common/215 link custom/outerlib.c
@@ -1,0 +1,3 @@
+void inner_lib_func(void);
+
+void outer_lib_func(void) { inner_lib_func(); }


### PR DESCRIPTION
Continuation of #6367, fixes #6365.

I had to implement both `is_internal` and `extract_all_objects_recurse` in the end because they're needed later during execution. It works as is, but I'm not sure it's correct @nirbheek.

The test initially called `echo dummy` as an external command but this fails on windows, so I figured python should be OK instead.