### PR TITLE
Fixes meson test timeout on windows

### DIFF
--- a/test cases/frameworks/1 boost/meson.build
+++ b/test cases/frameworks/1 boost/meson.build
@@ -51,8 +51,8 @@ extralibexe = executable('extralibexe', 'extralib.cpp', dependencies : extralibd
 python2module = shared_library('python2_module', ['python_module.cpp'], dependencies: [python2dep, bpython2dep], name_prefix: '', cpp_args: ['-DMOD_NAME=python2_module'])
 python3module = shared_library('python3_module', ['python_module.cpp'], dependencies: [python3dep, bpython3dep], name_prefix: '', cpp_args: ['-DMOD_NAME=python3_module'])
 
-test('Boost linktest', linkexe)
-test('Boost UTF test', unitexe)
+test('Boost linktest', linkexe, timeout: 60)
+test('Boost UTF test', unitexe, timeout: 60)
 test('Boost nomod', nomodexe)
 if host_machine.system() != 'darwin' or s
   # Segfaults on macOS with dynamic linking since Boost 1.73


### PR DESCRIPTION
Used to fixes https://github.com/mesonbuild/meson/runs/1152511331
```
2020-09-23T01:25:14.7849070Z
2020-09-23T01:25:14.7849592Z 1/5 Boost linktest      TIMEOUT        30.16s
2020-09-23T01:25:14.7849811Z
2020-09-23T01:25:14.7850027Z --- command ---
2020-09-23T01:25:14.7850281Z 01:24:30 D:\a\1\s\b 125f976e40\linkedexe.exe
2020-09-23T01:25:14.7850561Z -------
2020-09-23T01:25:14.7850693Z
2020-09-23T01:25:14.7850947Z 2/5 Boost UTF test      TIMEOUT        31.15s
2020-09-23T01:25:14.7851141Z
2020-09-23T01:25:14.7851347Z --- command ---
2020-09-23T01:25:14.7851580Z 01:24:30 D:\a\1\s\b 125f976e40\utf.exe
2020-09-23T01:25:14.7851862Z --- stdout ---
2020-09-23T01:25:14.7852065Z Running 1 test case...
2020-09-23T01:25:14.7852441Z
```

Signed-off-by: Yonggang Luo <luoyonggang@gmail.com>