### PR TITLE
Improve documentation about using shell in custom_target()  [skip ci]

### DIFF
--- a/docs/markdown/Custom-build-targets.md
+++ b/docs/markdown/Custom-build-targets.md
@@ -29,14 +29,15 @@ it does for source generation.
 
 See [Generating Sources](Generating-sources.md) for more information on this topic.
 
-## Details on compiler invocations
+## Details on command invocation
 
 Meson only permits you to specify one command to run. This is by
 design as writing shell pipelines into build definition files leads to
-code that is very hard to maintain. If your compilation requires
+code that is very hard to maintain. If your command requires
 multiple steps you need to write a wrapper script that does all the
-necessary work. When doing this you need to be mindful of the
-following issues:
+necessary work.
+
+When doing this you need to be mindful of the following issues:
 
 * do not assume that the command is invoked in any specific directory
 * a target called `target` file `outfile` defined in subdir `subdir`

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -397,6 +397,10 @@ the following special string substitutions:
 The returned object also has methods that are documented in the
 [object methods section](#custom-target-object) below.
 
+**Note:** Assuming that `command:` is executed by a POSIX `sh` shell is not
+portable, notably to Windows. Instead, consider using a `native: true`
+[executable()](#executable), or a python script.
+
 ### declare_dependency()
 
 ``` meson


### PR DESCRIPTION
Add a note about the portability of using shell constructs in the custom_target() command.

Even after this change, there's some conflict between these different parts of the documentation, and it's a bit unclear what the intent is.

We say only a single command is _permitted_, but don't do anything to enforce that, and take steps in the ninja backend to make `&&` work as expected (so of course, people end up using it).

https://github.com/mesonbuild/meson/blob/dff40ca259c396568eeb4d05c534781ca148f8e7/mesonbuild/backend/ninjabackend.py#L178-L180
