### PR TITLE
compilers: Use /Od for no-optimisation flag for Intel windows compilers

### DIFF
--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -145,8 +145,8 @@ class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
     }  # type: T.Dict[str, T.List[str]]
 
     OPTIM_ARGS = {
-        '0': ['/O0'],
-        'g': ['/O0'],
+        '0': ['/Od'],
+        'g': ['/Od'],
         '1': ['/O1'],
         '2': ['/O2'],
         '3': ['/O3'],


### PR DESCRIPTION
Intel compilers on Windows (and the Microsoft C++ compiler) use /Od to disable optimisation, not /O0.