### PR TITLE
compilers: Detect invalid command line options for intel windows compilers

### DIFF
--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -195,3 +195,11 @@ class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
 
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         return self.OPTIM_ARGS[optimization_level]
+
+    def has_arguments(self, args: T.List[str], env: 'Environment', code: str, mode: str) -> T.Tuple[bool, bool]:
+        warning_text = 'command line warning #10006'
+        with self._build_wrapper(code, env, extra_args=args, mode=mode) as p:
+            if p.returncode != 0:
+                return False, p.cached
+            return not(warning_text in p.stderr or warning_text in p.stdout), p.cached
+


### PR DESCRIPTION
Using has_arguments for msvc as a guide, add invalid argument detection to the intel windows compilers, based on the presence of diagnostic #10006 in stderr or stdout.

(The Intel compilers will continue to accept options with the same name that use the "-xx" form rather than "/xx".)