### PR TITLE
CODEOWNERS: don't use * [skip ci]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 /mesonbuild/modules/pkgconfig.py @xclaesse
 /mesonbuild/modules/cmake.py @mensinda
 /mesonbuild/modules/unstable_external_project.py @xclaesse
-/mesonbuild/ast/* @mensinda
-/mesonbuild/cmake/* @mensinda
-/mesonbuild/compilers/* @dcbaker
+/mesonbuild/ast/ @mensinda
+/mesonbuild/cmake/ @mensinda
+/mesonbuild/compilers/ @dcbaker
 /mesonbuild/linkers.py @dcbaker


### PR DESCRIPTION
strangely enough the syntax is:
/foo/* (files in foo, but not in foo/dir/)
/foo/ (files in foo and any subfolder of foo (recursively)