### PR TITLE
cmake: switch to pathlib (fixes #7322)

### DIFF
--- a/meson.py
+++ b/meson.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import sys
-from pathlib import Path
+from mesonbuild._pathlib import Path
 
 # If we're run uninstalled, add the script directory to sys.path to ensure that
 # we always import the correct mesonbuild modules even if PYTHONPATH is mangled

--- a/mesonbuild/_pathlib.py
+++ b/mesonbuild/_pathlib.py
@@ -1,0 +1,49 @@
+# Copyright 2020 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import typing as T
+
+# Python 3.5 does not have the strict kwarg for resolve and always
+# behaves like calling resolve with strict=True in Python 3.6+
+#
+# This module emulates the behavior of Python 3.6+ by in Python 3.5 by
+# overriding the resolve method with a bit of custom logic
+#
+# TODO: Drop this module as soon as Python 3.5 support is dropped
+
+if T.TYPE_CHECKING:
+    from pathlib import Path
+else:
+    if sys.version_info.major <= 3 and sys.version_info.minor <= 5:
+
+        # Inspired by https://codereview.stackexchange.com/questions/162426/subclassing-pathlib-path
+        import pathlib
+        import os
+
+        # Can not directly inherit from pathlib.Path because the __new__
+        # operator of pathlib.Path() returns a {Posix,Windows}Path object.
+        class Path(type(pathlib.Path())):
+            def resolve(self, strict: bool = False) -> 'Path':
+                try:
+                    return super().resolve()
+                except FileNotFoundError:
+                    if strict:
+                        raise
+                    return Path(os.path.normpath(str(self)))
+
+    else:
+        from pathlib import Path
+
+from pathlib import PurePath, PureWindowsPath, PurePosixPath

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -14,7 +14,7 @@
 
 from collections import OrderedDict
 from functools import lru_cache
-from pathlib import Path
+from .._pathlib import Path
 import enum
 import json
 import os
@@ -917,7 +917,7 @@ class Backend:
     def get_regen_filelist(self):
         '''List of all files whose alteration means that the build
         definition needs to be regenerated.'''
-        deps = [os.path.join(self.build_to_src, df)
+        deps = [str(Path(self.build_to_src) / df)
                 for df in self.interpreter.get_build_def_files()]
         if self.environment.is_cross_build():
             deps.extend(self.environment.coredata.cross_files)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -20,7 +20,7 @@ import subprocess
 from collections import OrderedDict
 from enum import Enum, unique
 import itertools
-from pathlib import PurePath, Path
+from .._pathlib import PurePath, Path
 from functools import lru_cache
 
 from . import backends

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -19,7 +19,7 @@ import xml.dom.minidom
 import xml.etree.ElementTree as ET
 import uuid
 import typing as T
-from pathlib import Path, PurePath
+from .._pathlib import Path, PurePath
 
 from . import backends
 from .. import build
@@ -1000,7 +1000,7 @@ class Vs2010Backend(backends.Backend):
                     if inc_dir not in file_inc_dirs[l]:
                         file_inc_dirs[l].append(inc_dir)
                     # Add include dirs to target as well so that "Go to Document" works in headers
-                    if inc_dir not in target_inc_dirs: 
+                    if inc_dir not in target_inc_dirs:
                         target_inc_dirs.append(inc_dir)
 
         # Split compile args needed to find external dependencies

--- a/mesonbuild/cmake/client.py
+++ b/mesonbuild/cmake/client.py
@@ -21,7 +21,7 @@ from ..mesonlib import MachineChoice
 from .. import mlog
 from contextlib import contextmanager
 from subprocess import Popen, PIPE, TimeoutExpired
-from pathlib import Path
+from .._pathlib import Path
 import typing as T
 import json
 

--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -17,7 +17,7 @@
 
 from ..mesonlib import MesonException
 from .. import mlog
-from pathlib import Path
+from .._pathlib import Path
 import typing as T
 
 class CMakeException(MesonException):

--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -16,7 +16,7 @@
 # or an interpreter-based tool.
 
 import subprocess as S
-from pathlib import Path
+from .._pathlib import Path
 from threading import Thread
 import typing as T
 import re

--- a/mesonbuild/cmake/fileapi.py
+++ b/mesonbuild/cmake/fileapi.py
@@ -15,7 +15,7 @@
 from .common import CMakeException, CMakeBuildFile, CMakeConfiguration
 import typing as T
 from .. import mlog
-from pathlib import Path
+from .._pathlib import Path
 import json
 import re
 
@@ -74,6 +74,7 @@ class CMakeFileAPI:
 
         # Debug output
         debug_json = self.build_dir / '..' / 'fileAPI.json'
+        debug_json = debug_json.resolve()
         debug_json.write_text(json.dumps(index, indent=2))
         mlog.cmd_ci_include(debug_json.as_posix())
 

--- a/mesonbuild/cmake/fileapi.py
+++ b/mesonbuild/cmake/fileapi.py
@@ -15,21 +15,21 @@
 from .common import CMakeException, CMakeBuildFile, CMakeConfiguration
 import typing as T
 from .. import mlog
-import os
+from pathlib import Path
 import json
 import re
 
 STRIP_KEYS = ['cmake', 'reply', 'backtrace', 'backtraceGraph', 'version']
 
 class CMakeFileAPI:
-    def __init__(self, build_dir: str):
-        self.build_dir = build_dir
-        self.api_base_dir = os.path.join(self.build_dir, '.cmake', 'api', 'v1')
-        self.request_dir = os.path.join(self.api_base_dir, 'query', 'client-meson')
-        self.reply_dir = os.path.join(self.api_base_dir, 'reply')
-        self.cmake_sources = []          # type: T.List[CMakeBuildFile]
+    def __init__(self, build_dir: Path):
+        self.build_dir            = build_dir
+        self.api_base_dir         = self.build_dir / '.cmake' / 'api' / 'v1'
+        self.request_dir          = self.api_base_dir / 'query' / 'client-meson'
+        self.reply_dir            = self.api_base_dir / 'reply'
+        self.cmake_sources        = []   # type: T.List[CMakeBuildFile]
         self.cmake_configurations = []   # type: T.List[CMakeConfiguration]
-        self.kind_resolver_map = {
+        self.kind_resolver_map    = {
             'codemodel': self._parse_codemodel,
             'cmakeFiles': self._parse_cmakeFiles,
         }
@@ -41,7 +41,7 @@ class CMakeFileAPI:
         return self.cmake_configurations
 
     def setup_request(self) -> None:
-        os.makedirs(self.request_dir, exist_ok=True)
+        self.request_dir.mkdir(parents=True, exist_ok=True)
 
         query = {
             'requests': [
@@ -50,18 +50,17 @@ class CMakeFileAPI:
             ]
         }
 
-        with open(os.path.join(self.request_dir, 'query.json'), 'w') as fp:
-            json.dump(query, fp, indent=2)
+        query_file = self.request_dir / 'query.json'
+        query_file.write_text(json.dumps(query, indent=2))
 
     def load_reply(self) -> None:
-        if not os.path.isdir(self.reply_dir):
+        if not self.reply_dir.is_dir():
             raise CMakeException('No response from the CMake file API')
 
-        files = os.listdir(self.reply_dir)
         root = None
         reg_index = re.compile(r'^index-.*\.json$')
-        for i in files:
-            if reg_index.match(i):
+        for i in self.reply_dir.iterdir():
+            if reg_index.match(i.name):
                 root = i
                 break
 
@@ -74,10 +73,9 @@ class CMakeFileAPI:
         index = self._strip_data(index)          # Strip unused data (again for loaded files)
 
         # Debug output
-        debug_json = os.path.normpath(os.path.join(self.build_dir, '..', 'fileAPI.json'))
-        with open(debug_json, 'w') as fp:
-            json.dump(index, fp, indent=2)
-        mlog.cmd_ci_include(debug_json)
+        debug_json = self.build_dir / '..' / 'fileAPI.json'
+        debug_json.write_text(json.dumps(index, indent=2))
+        mlog.cmd_ci_include(debug_json.as_posix())
 
         # parse the JSON
         for i in index['objects']:
@@ -100,17 +98,17 @@ class CMakeFileAPI:
         # resolved and the resulting data structure is identical
         # to the CMake serve output.
 
-        def helper_parse_dir(dir_entry: T.Dict[str, T.Any]) -> T.Tuple[str, str]:
-            src_dir = dir_entry.get('source', '.')
-            bld_dir = dir_entry.get('build', '.')
-            src_dir = src_dir if os.path.isabs(src_dir) else os.path.join(source_dir, src_dir)
-            bld_dir = bld_dir if os.path.isabs(bld_dir) else os.path.join(source_dir, bld_dir)
-            src_dir = os.path.normpath(src_dir)
-            bld_dir = os.path.normpath(bld_dir)
+        def helper_parse_dir(dir_entry: T.Dict[str, T.Any]) -> T.Tuple[Path, Path]:
+            src_dir = Path(dir_entry.get('source', '.'))
+            bld_dir = Path(dir_entry.get('build', '.'))
+            src_dir = src_dir if src_dir.is_absolute() else source_dir / src_dir
+            bld_dir = bld_dir if bld_dir.is_absolute() else build_dir  / bld_dir
+            src_dir = src_dir.resolve()
+            bld_dir = bld_dir.resolve()
 
             return src_dir, bld_dir
 
-        def parse_sources(comp_group: T.Dict[str, T.Any], tgt: T.Dict[str, T.Any]) -> T.Tuple[T.List[str], T.List[str], T.List[int]]:
+        def parse_sources(comp_group: T.Dict[str, T.Any], tgt: T.Dict[str, T.Any]) -> T.Tuple[T.List[Path], T.List[Path], T.List[int]]:
             gen = []
             src = []
             idx = []
@@ -120,9 +118,9 @@ class CMakeFileAPI:
                 if i >= len(src_list_raw) or 'path' not in src_list_raw[i]:
                     continue
                 if src_list_raw[i].get('isGenerated', False):
-                    gen += [src_list_raw[i]['path']]
+                    gen += [Path(src_list_raw[i]['path'])]
                 else:
-                    src += [src_list_raw[i]['path']]
+                    src += [Path(src_list_raw[i]['path'])]
                 idx += [i]
 
             return src, gen, idx
@@ -133,8 +131,8 @@ class CMakeFileAPI:
             # Parse install paths (if present)
             install_paths = []
             if 'install' in tgt:
-                prefix = tgt['install']['prefix']['path']
-                install_paths = [os.path.join(prefix, x['path']) for x in tgt['install']['destinations']]
+                prefix = Path(tgt['install']['prefix']['path'])
+                install_paths = [prefix / x['path'] for x in tgt['install']['destinations']]
                 install_paths = list(set(install_paths))
 
             # On the first look, it looks really nice that the CMake devs have
@@ -160,7 +158,7 @@ class CMakeFileAPI:
             #      maybe we can make use of that in addition to the
             #      implicit dependency detection
             tgt_data = {
-                'artifacts': [x.get('path', '') for x in tgt.get('artifacts', [])],
+                'artifacts': [Path(x.get('path', '')) for x in tgt.get('artifacts', [])],
                 'sourceDirectory': src_dir,
                 'buildDirectory': bld_dir,
                 'name': tgt.get('name', ''),
@@ -269,14 +267,14 @@ class CMakeFileAPI:
             self.cmake_configurations += [CMakeConfiguration(cnf_data)]
 
     def _parse_cmakeFiles(self, data: T.Dict[str, T.Any]) -> None:
-        assert('inputs' in data)
-        assert('paths' in data)
+        assert 'inputs' in data
+        assert 'paths' in data
 
-        src_dir = data['paths']['source']
+        src_dir = Path(data['paths']['source'])
 
         for i in data['inputs']:
-            path = i['path']
-            path = path if os.path.isabs(path) else os.path.join(src_dir, path)
+            path = Path(i['path'])
+            path = path if path.is_absolute() else src_dir / path
             self.cmake_sources += [CMakeBuildFile(path, i.get('isCMake', False), i.get('isGenerated', False))]
 
     def _strip_data(self, data: T.Any) -> T.Any:
@@ -309,14 +307,13 @@ class CMakeFileAPI:
 
         return data
 
-    def _reply_file_content(self, filename: str) -> T.Dict[str, T.Any]:
-        real_path = os.path.join(self.reply_dir, filename)
-        if not os.path.exists(real_path):
+    def _reply_file_content(self, filename: Path) -> T.Dict[str, T.Any]:
+        real_path = self.reply_dir / filename
+        if not real_path.exists():
             raise CMakeException('File "{}" does not exist'.format(real_path))
 
-        with open(real_path, 'r') as fp:
-            data = json.load(fp)
-            assert isinstance(data, dict)
-            for i in data.keys():
-                assert isinstance(i, str)
-            return data
+        data = json.loads(real_path.read_text())
+        assert isinstance(data, dict)
+        for i in data.keys():
+            assert isinstance(i, str)
+        return data

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -26,7 +26,7 @@ from ..mesondata import mesondata
 from ..compilers.compilers import lang_suffixes, header_suffixes, obj_suffixes, lib_suffixes, is_header
 from enum import Enum
 from functools import lru_cache
-from pathlib import Path
+from .._pathlib import Path
 import typing as T
 import re
 from os import environ

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -21,7 +21,7 @@ from .. import mlog
 from ..mesonlib import version_compare
 
 import typing as T
-from pathlib import Path
+from .._pathlib import Path
 import re
 import json
 import textwrap

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
+from .._pathlib import Path
 import typing as T
 import subprocess, os
 

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -29,7 +29,7 @@ import os
 import re
 import subprocess
 import typing as T
-from pathlib import Path
+from ..._pathlib import Path
 
 from ... import arglist
 from ... import mesonlib

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -16,7 +16,7 @@
 
 import typing as T
 import os
-from pathlib import Path
+from ..._pathlib import Path
 
 from ..compilers import clike_debug_args, clike_optimization_args
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -16,7 +16,7 @@ from . import mlog, mparser
 import pickle, os, uuid
 import sys
 from itertools import chain
-from pathlib import PurePath
+from ._pathlib import PurePath
 from collections import OrderedDict, defaultdict
 from .mesonlib import (
     MesonException, EnvironmentException, MachineChoice, PerMachine,

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -27,7 +27,7 @@ import textwrap
 import platform
 import typing as T
 from enum import Enum
-from pathlib import Path, PurePath
+from .._pathlib import Path, PurePath
 
 from .. import mlog
 from .. import mesonlib

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1528,12 +1528,12 @@ class CMakeDependency(ExternalDependency):
         self.compile_args = compileOptions + compileDefinitions + ['-I{}'.format(x) for x in incDirs]
         self.link_args = libraries
 
-    def _get_build_dir(self) -> str:
+    def _get_build_dir(self) -> Path:
         build_dir = Path(self.cmake_root_dir) / 'cmake_{}'.format(self.name)
         build_dir.mkdir(parents=True, exist_ok=True)
-        return str(build_dir)
+        return build_dir
 
-    def _setup_cmake_dir(self, cmake_file: str) -> str:
+    def _setup_cmake_dir(self, cmake_file: str) -> Path:
         # Setup the CMake build environment and return the "build" directory
         build_dir = self._get_build_dir()
 
@@ -1557,7 +1557,7 @@ cmake_minimum_required(VERSION ${{CMAKE_VERSION}})
 project(MesonTemp LANGUAGES {})
 """.format(' '.join(cmake_language)) + cmake_txt
 
-        cm_file = Path(build_dir) / 'CMakeLists.txt'
+        cm_file = build_dir / 'CMakeLists.txt'
         cm_file.write_text(cmake_txt)
         mlog.cmd_ci_include(cm_file.absolute().as_posix())
 

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -16,7 +16,7 @@ import os
 import re
 import functools
 import typing as T
-from pathlib import Path
+from .._pathlib import Path
 
 from .. import mlog
 from .. import mesonlib

--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -19,7 +19,7 @@ import os
 import re
 import shutil
 import subprocess
-from pathlib import Path
+from .._pathlib import Path
 
 from ..mesonlib import OrderedSet, join_args
 from .base import (

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -14,7 +14,7 @@
 
 # This file contains the detection logic for miscellaneous external dependencies.
 
-from pathlib import Path
+from .._pathlib import Path
 import functools
 import re
 import sysconfig

--- a/mesonbuild/dependencies/scalapack.py
+++ b/mesonbuild/dependencies/scalapack.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pathlib import Path
+from .._pathlib import Path
 import functools
 import os
 import typing as T

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2983,7 +2983,7 @@ external dependencies (including libraries) must go to "dependencies".''')
 
             cmake_options = mesonlib.stringlistify(kwargs.get('cmake_options', []))
             cmake_options += options.cmake_options
-            cm_int = CMakeInterpreter(new_build, subdir, subdir_abs, prefix, new_build.environment, self.backend)
+            cm_int = CMakeInterpreter(new_build, Path(subdir), Path(subdir_abs), Path(prefix), new_build.environment, self.backend)
             cm_int.initialise(cmake_options)
             cm_int.analyse()
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -36,7 +36,7 @@ from .modules import ModuleReturnValue, ExtensionModule
 from .cmake import CMakeInterpreter
 from .backend.backends import TestProtocol, Backend
 
-from pathlib import Path, PurePath
+from ._pathlib import Path, PurePath
 import os
 import shutil
 import uuid

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -21,7 +21,7 @@ import sys
 import shutil
 import typing as T
 from collections import defaultdict
-from pathlib import Path
+from ._pathlib import Path
 
 from . import mlog
 from . import mesonlib

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -21,7 +21,7 @@ import subprocess
 import hashlib
 import json
 from glob import glob
-from pathlib import Path
+from ._pathlib import Path
 from mesonbuild.environment import detect_ninja
 from mesonbuild.mesonlib import windows_proof_rmtree, MesonException
 from mesonbuild.wrap import wrap

--- a/mesonbuild/mesondata.py
+++ b/mesonbuild/mesondata.py
@@ -19,7 +19,7 @@
 ####
 
 
-from pathlib import Path
+from ._pathlib import Path
 import typing as T
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -1570,6 +1570,15 @@ def path_is_in_root(path: Path, root: Path, resolve: bool = False) -> bool:
         return False
     return True
 
+def relative_to_if_possible(path: Path, root: Path, resolve: bool = False) -> Path:
+    try:
+        if resolve:
+            return path.resolve().relative_to(root.resolve())
+        else:
+            return path.relative_to(root)
+    except ValueError:
+        return path
+
 class LibType(IntEnum):
 
     """Enumeration for library types."""

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """A library of random helper functionality."""
-from pathlib import Path
+from ._pathlib import Path
 import sys
 import stat
 import time

--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -14,7 +14,7 @@
 
 """Code that creates simple startup projects."""
 
-from pathlib import Path
+from ._pathlib import Path
 from enum import Enum
 import subprocess
 import shutil

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -28,7 +28,7 @@ from . import mlog
 from .backend import backends
 from .mparser import BaseNode, FunctionNode, ArrayNode, ArgumentNode, StringNode
 from .interpreter import Interpreter
-from pathlib import PurePath
+from ._pathlib import PurePath
 import typing as T
 import os
 import argparse

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -19,7 +19,7 @@ import time
 import platform
 import typing as T
 from contextlib import contextmanager
-from pathlib import Path
+from ._pathlib import Path
 
 """This is (mostly) a standalone module used to write logging
 information about Meson runs. Some output goes to screen,

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -14,7 +14,7 @@
 
 import typing as T
 import hashlib
-from pathlib import Path, PurePath, PureWindowsPath
+from .._pathlib import Path, PurePath, PureWindowsPath
 
 from .. import mlog
 from . import ExtensionModule

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os, types
-from pathlib import PurePath
+from .._pathlib import PurePath
 
 from .. import build
 from .. import dependencies

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -17,7 +17,7 @@ import json
 import shutil
 import typing as T
 
-from pathlib import Path
+from .._pathlib import Path
 from .. import mesonlib
 from ..mesonlib import MachineChoice, MesonException
 from . import ExtensionModule

--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os, subprocess, shlex
-from pathlib import Path
+from .._pathlib import Path
 import typing as T
 
 from . import ExtensionModule, ModuleReturnValue

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -1,6 +1,6 @@
 import os, subprocess
 import argparse
-from pathlib import Path
+from ._pathlib import Path
 
 from . import mlog
 from .mesonlib import quiet_git, verbose_git, GitException, Popen_safe, MesonException

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -14,7 +14,7 @@
 
 # A tool to run tests in many different ways.
 
-from pathlib import Path
+from ._pathlib import Path
 from collections import namedtuple
 from copy import deepcopy
 import argparse

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -27,7 +27,7 @@ import sys
 import configparser
 import typing as T
 
-from pathlib import Path
+from .._pathlib import Path
 from . import WrapMode
 from .. import coredata
 from ..mesonlib import verbose_git, quiet_git, GIT, ProgressBar, MesonException

--- a/run_meson_command_tests.py
+++ b/run_meson_command_tests.py
@@ -19,7 +19,7 @@ import tempfile
 import unittest
 import subprocess
 import zipapp
-from pathlib import Path
+from mesonbuild._pathlib import Path
 
 from mesonbuild.mesonlib import windows_proof_rmtree, python_command, is_windows
 from mesonbuild.coredata import version as meson_version

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -15,6 +15,7 @@ modules = [
     'mesonbuild/wrap',
 
     # specific files
+    'mesonbuild/_pathlib.py',
     'mesonbuild/arglist.py',
     'mesonbuild/compilers/compilers.py',
     'mesonbuild/compilers/c_function_attributes.py',

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -17,7 +17,7 @@
 from concurrent.futures import ProcessPoolExecutor, CancelledError
 from enum import Enum
 from io import StringIO
-from pathlib import Path, PurePath
+from mesonbuild._pathlib import Path, PurePath
 import argparse
 import functools
 import itertools

--- a/run_tests.py
+++ b/run_tests.py
@@ -25,7 +25,7 @@ import argparse
 from io import StringIO
 from enum import Enum
 from glob import glob
-from pathlib import Path
+from mesonbuild._pathlib import Path
 from unittest import mock
 from mesonbuild import compilers
 from mesonbuild import dependencies

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -39,7 +39,7 @@ from unittest import mock
 from configparser import ConfigParser
 from contextlib import contextmanager
 from glob import glob
-from pathlib import (PurePath, Path)
+from mesonbuild._pathlib import (PurePath, Path)
 from distutils.dir_util import copy_tree
 import typing as T
 

--- a/test cases/cmake/2 advanced/test.json
+++ b/test cases/cmake/2 advanced/test.json
@@ -1,8 +1,7 @@
 {
   "installed": [
     {"type": "expr", "file": "usr/?lib/libcm_cmModLib?so"},
-    {"type": "implib", "platform": "cygwin", "file": "usr/lib/libcm_cmModLib"},
-    {"type": "implib", "platform": "!cygwin", "file": "usr/bin/libcm_cmModLib"},
+    {"type": "implib", "file": "usr/lib/libcm_cmModLib"},
     {"type": "exe", "file": "usr/bin/cm_testEXE"}
   ],
   "tools": {

--- a/test cases/cmake/3 advanced no dep/test.json
+++ b/test cases/cmake/3 advanced no dep/test.json
@@ -1,8 +1,7 @@
 {
   "installed": [
     {"type": "expr", "file": "usr/?lib/libcm_cmModLib?so"},
-    {"type": "implib", "platform": "cygwin", "file": "usr/lib/libcm_cmModLib"},
-    {"type": "implib", "platform": "!cygwin", "file": "usr/bin/libcm_cmModLib"},
+    {"type": "implib", "file": "usr/lib/libcm_cmModLib"},
     {"type": "pdb", "file": "usr/bin/cm_cmModLib"},
     {"type": "pdb", "file": "usr/bin/cm_testEXE"},
     {"type": "exe", "file": "usr/bin/cm_testEXE"},


### PR DESCRIPTION
This PR removes all `os.path.*` calls from `mesonbuild.cmake` and uses `Path` objects instead.

I have added this to `0.56.0` since #7322 should automatically be fixed with this.