### PR TITLE
linkers: Drop -pie on macOS

### DIFF
--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -676,7 +676,7 @@ class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
         return ['-bundle'] + self._apply_prefix('-undefined,dynamic_lookup')
 
     def get_pie_args(self) -> T.List[str]:
-        return ['-pie']
+        return []
 
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:
         result = []  # type: T.List[str]


### PR DESCRIPTION
Projects that specify b_pie=true clutter build logs with the warning:

  clang: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]

No option is needed to produce PIE binaries because ld64 is making PIE
executables on 10.7 and above by default, as documented in ld(1).

Signed-off-by: Roman Bolshakov <r.bolshakov@yadro.com>