### PR TITLE
Add a 32-bit visual studio CI job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,8 +24,8 @@ jobs:
           compiler: msvc2017
           backend: ninja
           MESON_RSP_THRESHOLD: 0
-        vc2017x64vs:
-          arch: x64
+        vc2017x86vs:
+          arch: x86
           compiler: msvc2017
           backend: vs2017
         clangclx64ninja:

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1177,7 +1177,7 @@ def check_format():
                 check_file(root / file)
 
 def check_meson_commands_work(options):
-    global backend, compile_commands, test_commands, install_commands
+    global install_commands, do_debug
     testdir = PurePath('test cases', 'common', '1 trivial').as_posix()
     meson_commands = mesonlib.python_command + [get_meson_script()]
     with AutoDeletedDir(tempfile.mkdtemp(prefix='b ', dir=None if options.use_tmpdir else '.')) as build_dir:
@@ -1192,17 +1192,22 @@ def check_meson_commands_work(options):
         if pc.returncode != 0:
             raise RuntimeError('Failed to introspect --targets {!r}:\n{}\n{}'.format(testdir, e, o))
         print('Checking that building works...')
-        dir_args = get_backend_args_for_dir(backend, build_dir)
-        pc, o, e = Popen_safe(compile_commands + dir_args, cwd=build_dir)
+        compile_cmd = meson_commands + ['compile']
+        if do_debug:
+            compile_cmd.append('-v')
+        pc, o, e = Popen_safe(compile_cmd, cwd=build_dir)
         if pc.returncode != 0:
             raise RuntimeError('Failed to build {!r}:\n{}\n{}'.format(testdir, e, o))
         print('Checking that testing works...')
-        pc, o, e = Popen_safe(test_commands, cwd=build_dir)
+        test_cmd = meson_commands + ['test']
+        if do_debug:
+            test_cmd.append('-v')
+        pc, o, e = Popen_safe(test_cmd, cwd=build_dir)
         if pc.returncode != 0:
             raise RuntimeError('Failed to test {!r}:\n{}\n{}'.format(testdir, e, o))
         if install_commands:
             print('Checking that installing works...')
-            pc, o, e = Popen_safe(install_commands, cwd=build_dir)
+            pc, o, e = Popen_safe(meson_commands + ['install'], cwd=build_dir)
             if pc.returncode != 0:
                 raise RuntimeError('Failed to install {!r}:\n{}\n{}'.format(testdir, e, o))
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1735,10 +1735,19 @@ class BasePlatformTests(unittest.TestCase):
 
     def run_target(self, target, *, override_envvars=None):
         '''
+        Run a build, custom, or run target while printing the stdout and stderr
+        to stdout, and also return a copy of it
+        '''
+        return self.build(target=target, override_envvars=override_envvars)
+
+    def run_ninja_target(self, target, *, override_envvars=None):
+        '''
         Run a Ninja target while printing the stdout and stderr to stdout,
         and also return a copy of it
         '''
-        return self.build(target=target, override_envvars=override_envvars)
+        if self.backend is not Backend.ninja:
+            raise unittest.SkipTest('Not using the ninja backend')
+        return self.build(extra_args=['--ninja-args', target], override_envvars=override_envvars)
 
     def setconf(self, arg, will_build=True):
         if not isinstance(arg, list):
@@ -4251,7 +4260,7 @@ recommended as it is not supported on some platforms''')
                                 Path(goodfile).read_text())
             self.assertNotEqual(Path(testheader).read_text(),
                                 Path(goodheader).read_text())
-            self.run_target('clang-format')
+            self.run_ninja_target('clang-format')
             self.assertEqual(Path(testheader).read_text(),
                              Path(goodheader).read_text())
         finally:
@@ -4271,7 +4280,7 @@ recommended as it is not supported on some platforms''')
         testdir = os.path.join(self.unit_test_dir, '70 clang-tidy')
         dummydir = os.path.join(testdir, 'dummydir.h')
         self.init(testdir, override_envvars={'CXX': 'c++'})
-        out = self.run_target('clang-tidy')
+        out = self.run_ninja_target('clang-tidy')
         self.assertIn('cttest.cpp:4:20', out)
         self.assertNotIn(dummydir, out)
 
@@ -5004,7 +5013,7 @@ recommended as it is not supported on some platforms''')
         self.init(testdir, extra_args=['-Db_coverage=true'])
         self.build()
         self.run_tests()
-        self.run_target('coverage')
+        self.run_ninja_target('coverage')
         self._check_coverage_files()
 
     def test_coverage_complex(self):
@@ -5024,7 +5033,7 @@ recommended as it is not supported on some platforms''')
         self.init(testdir, extra_args=['-Db_coverage=true'])
         self.build()
         self.run_tests()
-        self.run_target('coverage')
+        self.run_ninja_target('coverage')
         self._check_coverage_files()
 
     def test_coverage_html(self):
@@ -5044,7 +5053,7 @@ recommended as it is not supported on some platforms''')
         self.init(testdir, extra_args=['-Db_coverage=true'])
         self.build()
         self.run_tests()
-        self.run_target('coverage-html')
+        self.run_ninja_target('coverage-html')
         self._check_coverage_files(['html'])
 
     def test_coverage_text(self):
@@ -5064,7 +5073,7 @@ recommended as it is not supported on some platforms''')
         self.init(testdir, extra_args=['-Db_coverage=true'])
         self.build()
         self.run_tests()
-        self.run_target('coverage-text')
+        self.run_ninja_target('coverage-text')
         self._check_coverage_files(['text'])
 
     def test_coverage_xml(self):
@@ -5084,7 +5093,7 @@ recommended as it is not supported on some platforms''')
         self.init(testdir, extra_args=['-Db_coverage=true'])
         self.build()
         self.run_tests()
-        self.run_target('coverage-xml')
+        self.run_ninja_target('coverage-xml')
         self._check_coverage_files(['xml'])
 
     def test_cross_file_constants(self):


### PR DESCRIPTION
Split out from https://github.com/mesonbuild/meson/pull/7730.

Known issue remaining is that CI always shows one of these two:

```
6>CustomBuild:
         Traceback (most recent call last):
           File "D:\a\1\s\test cases\native\27 pipeline\depends\copyrunner.py", line 7, in <module>
             subprocess.check_call([prog, infile, outfile])
           File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\subprocess.py", line 358, in check_call
             retcode = call(*popenargs, **kwargs)
           File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\subprocess.py", line 339, in call
             with Popen(*popenargs, **kwargs) as p:
           File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\subprocess.py", line 800, in __init__
             restore_signals, start_new_session)
           File "C:\hostedtoolcache\windows\Python\3.7.9\x64\lib\subprocess.py", line 1207, in _execute_child
             startupinfo)
         PermissionError: [WinError 32] The process cannot access the file because it is being used by another process
```
```
8>CustomBuild:
         Traceback (most recent call last):
           File "D:\a\1\s\test cases\native\27 pipeline\depends\copyrunner.py", line 7, in <module>
             subprocess.check_call([prog, infile, outfile])
           File "C:\hostedtoolcache\windows\Python\3.5.4\x64\lib\subprocess.py", line 266, in check_call
             retcode = call(*popenargs, **kwargs)
           File "C:\hostedtoolcache\windows\Python\3.5.4\x64\lib\subprocess.py", line 247, in call
             with Popen(*popenargs, **kwargs) as p:
           File "C:\hostedtoolcache\windows\Python\3.5.4\x64\lib\subprocess.py", line 676, in __init__
             restore_signals, start_new_session)
           File "C:\hostedtoolcache\windows\Python\3.5.4\x64\lib\subprocess.py", line 957, in _execute_child
             startupinfo)
         FileNotFoundError: [WinError 2] The system cannot find the file specified
```

I can reproduce this locally too. I suspect dependencies aren't properly setup in the visual studio solution.
