### PR TITLE
Never run clang-format / clang-tidy against directories

### DIFF
--- a/mesonbuild/scripts/clangformat.py
+++ b/mesonbuild/scripts/clangformat.py
@@ -27,6 +27,8 @@ def clangformat(exelist: T.List[str], srcdir_name: str, builddir_name: str) -> i
     futures = []
     with ThreadPoolExecutor() as e:
         for f in (x for suff in suffixes for x in srcdir.glob('**/*.' + suff)):
+            if f.is_dir():
+                continue
             strf = str(f)
             if strf.startswith(builddir_name):
                 continue

--- a/mesonbuild/scripts/clangtidy.py
+++ b/mesonbuild/scripts/clangtidy.py
@@ -28,6 +28,8 @@ def manual_clangformat(srcdir_name: str, builddir_name: str) -> int:
     returncode = 0
     with ThreadPoolExecutor() as e:
         for f in (x for suff in suffixes for x in srcdir.glob('**/*.' + suff)):
+            if f.is_dir():
+                continue
             strf = str(f)
             if strf.startswith(builddir_name):
                 continue

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4212,9 +4212,11 @@ recommended as it is not supported on some platforms''')
         if is_osx():
             raise unittest.SkipTest('Apple ships a broken clang-tidy that chokes on -pipe.')
         testdir = os.path.join(self.unit_test_dir, '70 clang-tidy')
+        dummydir = os.path.join(testdir, 'dummydir.h')
         self.init(testdir, override_envvars={'CXX': 'c++'})
         out = self.run_target('clang-tidy')
         self.assertIn('cttest.cpp:4:20', out)
+        self.assertNotIn(dummydir, out)
 
     def test_identity_cross(self):
         testdir = os.path.join(self.unit_test_dir, '71 cross')

--- a/test cases/unit/54 clang-format/dummydir.h/dummy.dat
+++ b/test cases/unit/54 clang-format/dummydir.h/dummy.dat
@@ -1,0 +1,1 @@
+Placeholder to track enclosing directory in git. Not to be analyzed.

--- a/test cases/unit/70 clang-tidy/dummydir.h/dummy.dat
+++ b/test cases/unit/70 clang-tidy/dummydir.h/dummy.dat
@@ -1,0 +1,1 @@
+Placeholder to track enclosing directory in git. Not to be analyzed.


### PR DESCRIPTION
Currently the auto-generated `clang-format` target fails when the source directory contains a directory matching one of the `lang_suffixes`, e.g. a directory named `test.h/`. This is due to `pathlib.Path.glob()` not only returning files but also returning directories.

Both `clang-format` and `clang-tidy` fail when handed a directory. This PR explicitly checks if the "file" to check is actually a directory and skips calling `clang-format` and `clang-tidy` for those. Unit tests have been adapted accordingly.