### PR TITLE
Fix xcode subdir files

### DIFF
--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -264,7 +264,7 @@ class XCodeBackend(backends.Backend):
 
             for s in t.sources:
                 if isinstance(s, mesonlib.File):
-                    s = s.fname
+                    s = os.path.join(s.subdir, s.fname)
 
                 if isinstance(s, str):
                     s = os.path.join(t.subdir, s)

--- a/test cases/common/237 subdir files/meson.build
+++ b/test cases/common/237 subdir files/meson.build
@@ -1,0 +1,3 @@
+project('subdir files test', 'c')
+subdir('subdir')
+executable('prog', sources: subdir_sources)

--- a/test cases/common/237 subdir files/subdir/meson.build
+++ b/test cases/common/237 subdir files/subdir/meson.build
@@ -1,0 +1,1 @@
+subdir_sources = files(['prog.c'])

--- a/test cases/common/237 subdir files/subdir/prog.c
+++ b/test cases/common/237 subdir files/subdir/prog.c
@@ -1,0 +1,1 @@
+int main(void) { return 0; }


### PR DESCRIPTION
I ran into bug #589 recently, and I looked into it and the fix is simple enough: when converting from a `mesonlib.File` object to a string, it didn't take subdirs into account, which is fixed by doing a `os.path.join(s.subdir, s.fname)`. 

I looked through the test case folder and couldn't find anything in `common/` that specifically tested for this (though I might have just missed it, there's a lot of tests in there), so I added a new test for this specific bug. 

This is my first time contributing to meson, please let me know if I did anything wrong :) 