### PR TITLE
compilers: Enable C++20 for Intel C++ Compiler.

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -505,6 +505,9 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
             c_stds += ['c++17']
         if version_compare(self.version, '>=17.0.0'):
             g_stds += ['gnu++14']
+        if version_compare(self.version, '>=19.1.0'):
+            c_stds += ['c++2a']
+            g_stds += ['gnu++2a']
         opts.update({
             'eh': coredata.UserComboOption(
                 'C++ exception handling type.',


### PR DESCRIPTION
Intel C++ Compiler 19.1 has C++20 features.

https://software.intel.com/content/www/us/en/develop/articles/intel-c-compiler-191-for-linux-release-notes-for-intel-parallel-studio-xe-2020.html

Signed-off-by: Vinson Lee <vlee@freedesktop.org>