### PR TITLE
Tests: py.dependency() now has required:true by default

### DIFF
--- a/test cases/unit/39 python extmodule/meson.build
+++ b/test cases/unit/39 python extmodule/meson.build
@@ -6,7 +6,7 @@ py_mod = import('python')
 py = py_mod.find_installation(get_option('python'), required : false)
 
 if py.found()
-  py_dep = py.dependency()
+  py_dep = py.dependency(required : false)
 
   if py_dep.found()
     subdir('ext')


### PR DESCRIPTION
It used to ignore the required argument and got fixed to be consistent
with dependency() function.