### PR TITLE
mtest: collect failures regardless of colorized console

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -917,15 +917,17 @@ class TestHarness:
         if result.res is TestResult.FAIL:
             result_str += ' ' + returncode_to_status(result.returncode)
         if not self.options.quiet or result.res not in ok_statuses:
-            if result.res not in ok_statuses and mlog.colorize_console():
-                if result.res in bad_statuses:
-                    self.collected_failures.append(result_str)
-                    decorator = mlog.red
-                elif result.res is TestResult.SKIP:
-                    decorator = mlog.yellow
-                else:
-                    sys.exit('Unreachable code was ... well ... reached.')
-                print(decorator(result_str).get_text(True))
+            if result.res not in ok_statuses:
+                self.collected_failures.append(result_str)
+                if mlog.colorize_console():
+                    if result.res in bad_statuses:
+                        self.collected_failures.append(result_str)
+                        decorator = mlog.red
+                    elif result.res is TestResult.SKIP:
+                        decorator = mlog.yellow
+                    else:
+                        sys.exit('Unreachable code was ... well ... reached.')
+                    print(decorator(result_str).get_text(True))
             else:
                 print(result_str)
         result_str += "\n\n" + result.get_log()


### PR DESCRIPTION
First introduced here: 8da1b29899e795d87f0a4e51adb532119af48727