### PR TITLE
ci: fix broken CI images

### DIFF
--- a/ci/ciimage/.gitignore
+++ b/ci/ciimage/.gitignore
@@ -1,2 +1,3 @@
 /build_*
 /test_*
+/user.sh

--- a/ci/ciimage/arch/install.sh
+++ b/ci/ciimage/arch/install.sh
@@ -26,7 +26,7 @@ PACMAN_OPTS='--needed --noprogressbar --noconfirm'
 # Patch config files
 sed -i 's/#Color/Color/g'                            /etc/pacman.conf
 sed -i 's,#MAKEFLAGS="-j2",MAKEFLAGS="-j$(nproc)",g' /etc/makepkg.conf
-sed -i "s,PKGEXT='.pkg.tar.xz',PKGEXT='.pkg.tar',g"  /etc/makepkg.conf
+sed -i "s,PKGEXT='.pkg.tar.zst',PKGEXT='.pkg.tar',g" /etc/makepkg.conf
 
 # Install packages
 pacman -Syu $PACMAN_OPTS "${pkgs[@]}"

--- a/ci/ciimage/build.py
+++ b/ci/ciimage/build.py
@@ -140,12 +140,13 @@ class ImageTester(BuilderBase):
             ignore=shutil.ignore_patterns(
                 '.git',
                 '*_cache',
-                'work area',
+                '__pycache__',
+                # 'work area',
                 self.temp_dir.name,
             )
         )
 
-    def do_test(self):
+    def do_test(self, tty: bool = False) -> None:
         self.copy_meson()
         self.gen_dockerfile()
 
@@ -158,11 +159,26 @@ class ImageTester(BuilderBase):
             if subprocess.run(build_cmd).returncode != 0:
                 raise RuntimeError('Failed to build the test docker image')
 
-            test_cmd = [
-                self.docker, 'run', '--rm', '-t', 'meson_test_image',
-                '/bin/bash', '-c', 'source /ci/env_vars.sh; cd meson; ./run_tests.py $CI_ARGS'
-            ]
-            if subprocess.run(test_cmd).returncode != 0:
+            test_cmd = []
+            if tty:
+                test_cmd = [
+                    self.docker, 'run', '--rm', '-t', '-i', 'meson_test_image',
+                    '/bin/bash', '-c', ''
+                    + 'cd meson;'
+                    + 'source /ci/env_vars.sh;'
+                    + f'echo -e "\\n\\nInteractive test shell in the {image_namespace}/{self.data_dir.name} container with the current meson tree";'
+                    + 'echo -e "The file ci/ciimage/user.sh will be sourced if it exists to enable user specific configurations";'
+                    + 'echo -e "Run the following command to run all CI tests: ./run_tests.py $CI_ARGS\\n\\n";'
+                    + '[ -f ci/ciimage/user.sh ] && exec /bin/bash --init-file ci/ciimage/user.sh;'
+                    + 'exec /bin/bash;'
+                ]
+            else:
+                test_cmd = [
+                    self.docker, 'run', '--rm', '-t', 'meson_test_image',
+                    '/bin/bash', '-c', 'source /ci/env_vars.sh; cd meson; ./run_tests.py $CI_ARGS'
+                ]
+
+            if subprocess.run(test_cmd).returncode != 0 and not tty:
                 raise RuntimeError('Running tests failed')
         finally:
             cleanup_cmd = [self.docker, 'rmi', '-f', 'meson_test_image']
@@ -171,7 +187,7 @@ class ImageTester(BuilderBase):
 def main() -> None:
     parser = argparse.ArgumentParser(description='Meson CI image builder')
     parser.add_argument('what', type=str, help='Which image to build / test')
-    parser.add_argument('-t', '--type', choices=['build', 'test'], help='What to do', required=True)
+    parser.add_argument('-t', '--type', choices=['build', 'test', 'testTTY'], help='What to do', required=True)
 
     args = parser.parse_args()
 
@@ -188,6 +204,9 @@ def main() -> None:
         elif args.type == 'test':
             tester = ImageTester(ci_data, ci_build, ci_root)
             tester.do_test()
+        elif args.type == 'testTTY':
+            tester = ImageTester(ci_data, ci_build, ci_root)
+            tester.do_test(tty=True)
 
 if __name__ == '__main__':
     main()

--- a/ci/ciimage/fedora/install.sh
+++ b/ci/ciimage/fedora/install.sh
@@ -3,17 +3,17 @@
 set -e
 
 pkgs=(
-  python python-setuptools python-wheel python-pip python-pytest-xdist pygobject3 python3-devel python2-devel
-  ninja-build make git autoconf automake patch python3-Cython python2-Cython python3-jsonschema
+  python python-setuptools python-wheel python-pip python-pytest-xdist python3-devel
+  ninja-build make git autoconf automake patch python3-Cython python3-jsonschema
   elfutils gcc gcc-c++ gcc-fortran gcc-objc gcc-objc++ vala rust bison flex ldc libasan libasan-static
   mono-core boost-devel gtkmm30 gtest-devel gmock-devel protobuf-devel wxGTK3-devel gobject-introspection
-  boost-python3-devel boost-python2-devel
+  boost-python3-devel
   itstool gtk3-devel java-latest-openjdk-devel gtk-doc llvm-devel clang-devel SDL2-devel graphviz-devel zlib zlib-devel zlib-static
   #hdf5-openmpi-devel hdf5-devel netcdf-openmpi-devel netcdf-devel netcdf-fortran-openmpi-devel netcdf-fortran-devel scalapack-openmpi-devel
   doxygen vulkan-devel vulkan-validation-layers-devel openssh mercurial gtk-sharp2-devel libpcap-devel gpgme-devel
   qt5-qtbase-devel qt5-qttools-devel qt5-linguist qt5-qtbase-private-devel
   libwmf-devel valgrind cmake openmpi-devel nasm gnustep-base-devel gettext-devel ncurses-devel
-  libxml2-devel libxslt-devel libyaml-devel glib2-devel json-glib-devel python3-lxml
+  libxml2-devel libxslt-devel libyaml-devel glib2-devel json-glib-devel python3-lxml libgcrypt-devel
 )
 
 # Sys update


### PR DESCRIPTION
Updates the install scripts to account for changes in Arch and Fedora.

Also fixes the CUDA version detection in absence of a `/path/to/cuda/version.txt` file by looking for `CUDART_VERSION` in `cuda_runtime_api.h`.

Generally, it should be checked before each release that the last scheduled (Sunday night) [CI image builder job](https://github.com/mesonbuild/meson/actions?query=workflow%3A%22CI+image+builder%22) is green. A red job could indicate a failed test run in an up-to-date system.