### PR TITLE
[RFC] mtest: use asyncio instead of concurrency.futures

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1186,16 +1186,6 @@ class TestHarness:
             self.process_test_result(result.result())
             self.print_stats(test_count, name_max_len, tests, name, result.result(), i)
 
-    def run_special(self) -> int:
-        '''Tests run by the user, usually something like "under gdb 1000 times".'''
-        if self.is_run:
-            raise RuntimeError('Can not use run_special after a full run.')
-        tests = self.get_tests()
-        if not tests:
-            return 0
-        self.run_tests(tests)
-        return self.total_failure_count()
-
 
 def list_tests(th: TestHarness) -> bool:
     tests = th.get_tests()
@@ -1256,9 +1246,7 @@ def run(options: argparse.Namespace) -> int:
         try:
             if options.list:
                 return list_tests(th)
-            if not options.args:
-                return th.doit()
-            return th.run_special()
+            return th.doit()
         except TestException as e:
             print('Meson test encountered an error:\n')
             if os.environ.get('MESON_FORCE_BACKTRACE'):

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1329,6 +1329,10 @@ def run(options: argparse.Namespace) -> int:
     if options.wrapper:
         check_bin = options.wrapper[0]
 
+    if sys.platform == 'win32':
+        loop = asyncio.ProactorEventLoop()
+        asyncio.set_event_loop(loop)
+
     if check_bin is not None:
         exe = ExternalProgram(check_bin, silent=True)
         if not exe.found():

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -326,7 +326,6 @@ class TAPParser:
                 yield self.Error('Too many tests run (expected {}, got {})'.format(plan.count, num_tests))
 
 
-
 class JunitBuilder:
 
     """Builder for Junit test results.
@@ -740,7 +739,7 @@ class SingleTestRunner:
                 subprocess.run(['taskkill', '/F', '/T', '/PID', str(p.pid)])
             else:
 
-                def _send_signal_to_process_group(pgid : int, signum : int) -> None:
+                def _send_signal_to_process_group(pgid: int, signum: int) -> None:
                     """ sends a signal to a process group """
                     try:
                         os.killpg(pgid, signum)
@@ -841,7 +840,7 @@ class TestHarness:
 
     def close_logfiles(self) -> None:
         for f in ['logfile', 'jsonlogfile']:
-            lfile =  getattr(self, f)
+            lfile = getattr(self, f)
             if lfile:
                 lfile.close()
                 setattr(self, f, None)
@@ -956,7 +955,7 @@ class TestHarness:
             Skipped:            {:<4}
             Timeout:            {:<4}
             ''').format(self.success_count, self.expectedfail_count, self.fail_count,
-           self.unexpectedpass_count, self.skip_count, self.timeout_count)
+                        self.unexpectedpass_count, self.skip_count, self.timeout_count)
         print(msg)
         if self.logfile:
             self.logfile.write(msg)


### PR DESCRIPTION
This pull request rewrites the SingleTestRunner and TestHarness to use asyncio for subprocesses.

The main advantage is better control on cancellation; with the current code, KeyboardInterrupt was never handled by the thread executor so the code that tried to handle it in SingleTestRunner only worked for non-parallel tests.  Likewise, SIGTERM was not handled and left tests running. (In addition, if the test exited with exit status 0 in response to SIGTERM, it was not marked as a failure).

With this pull request, mtest gains a new `INTERRUPT` TestResult and SIGINT will return it for the oldest-running test. SIGTERM instead will return it for all running tests and will not start any new test. Because a picture is worth a thousand works, here are some Asciinema recordings:
* [sending SIGINT to `meson test` (unpatched)](https://asciinema.org/a/QdFqzfET6mhxZk6BcokKo1pDx)
* [sending SIGINT to `meson test` (patched)](https://asciinema.org/a/TwPwquCNiZFtfB7SjOzrAm0K1)
* [sending SIGTERM to `meson test` (patched)](https://asciinema.org/a/WsK001eLfvPueEzz7PESSDq2G)

The pull request is split between a refactoring part and a new feature part, so it can be split easily if desired.