### PR TITLE
pkgconfig: InternalDependency's ext_deps should be private by default

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -173,7 +173,7 @@ class DependenciesHelper:
         for t in link_whole_targets:
             self._add_link_whole(t, public)
         # And finally its external dependencies
-        add_libs(external_deps)
+        self.add_priv_libs(external_deps)
 
     def _add_link_whole(self, t, public):
         # Don't include static libraries that we link_whole. But we still need to

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6026,7 +6026,8 @@ class LinuxlikeTests(BasePlatformTests):
         # See common/47 pkgconfig-gen/meson.build for description of the case this test
         with open(os.path.join(privatedir1, 'simple2.pc')) as f:
             content = f.read()
-            self.assertIn('Libs: -L${libdir} -lsimple2 -lz -lsimple1', content)
+            self.assertIn('Libs: -L${libdir} -lsimple2 -lsimple1', content)
+            self.assertIn('Libs.private: -lz', content)
 
         with open(os.path.join(privatedir1, 'simple3.pc')) as f:
             content = f.read()


### PR DESCRIPTION
This fixes a regression introduced by
https://github.com/mesonbuild/meson/pull/7488.

InternalDependency's ext_deps previously where simply ignored, but that
PR has effect to add many more public Requires in generated pc files.