### PR TITLE
include_type fixup

### DIFF
--- a/docs/markdown/CMake-module.md
+++ b/docs/markdown/CMake-module.md
@@ -133,7 +133,10 @@ kept for compatibility. It will not work together with the `options` kwarg.
 This object is returned by the `subproject` function described above
 and supports the following methods:
 
- - `dependency(target)` returns a dependency object for any CMake target.
+ - `dependency(target)` returns a dependency object for any CMake target. The
+   `include_type` kwarg *(new in 0.56.0)* controls the include type of the
+   returned dependency object similar to the same kwarg in the
+   [`dependency()`](Reference-manual.md#dependency) function.
  - `include_directories(target)` returns a meson `include_directories()`
    object for the specified target. Using this function is not necessary
    if the dependency object is used.

--- a/docs/markdown/snippets/cmake_include_type.md
+++ b/docs/markdown/snippets/cmake_include_type.md
@@ -1,0 +1,5 @@
+## `include_type` support for the CMake subproject object dependency method
+
+The `dependency()` method of the CMake subproject object now also supports the
+`include_type` kwarg which is similar to the sane kwarg in the `dependency()`
+function.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3687,9 +3687,17 @@ external dependencies (including libraries) must go to "dependencies".''')
             if not_found_message:
                 self.message_impl([not_found_message])
             raise
+        assert isinstance(d, DependencyHolder)
         if not d.found() and not_found_message:
             self.message_impl([not_found_message])
             self.message_impl([not_found_message])
+        # Ensure the correct include type
+        if 'include_type' in kwargs:
+            wanted = kwargs['include_type']
+            actual = d.include_type_method([], {})
+            if wanted != actual:
+                mlog.debug('Current include type of {} is {}. Converting to requested {}'.format(name, actual, wanted))
+                d = d.as_system_method([wanted], {})
         # Override this dependency to have consistent results in subsequent
         # dependency lookups.
         if name and d.found():

--- a/test cases/cmake/1 basic/meson.build
+++ b/test cases/cmake/1 basic/meson.build
@@ -3,11 +3,12 @@ project('cmakeSubTest', ['c', 'cpp'])
 cm = import('cmake')
 
 sub_pro = cm.subproject('cmMod')
-sub_dep = sub_pro.dependency('cmModLib++')
+sub_dep = sub_pro.dependency('cmModLib++', include_type: 'system')
 
 assert(sub_pro.found(), 'found() method reports not found, but should be found')
 assert(sub_pro.target_list() == ['cmModLib++'], 'There should be exactly one target')
 assert(sub_pro.target_type('cmModLib++') == 'shared_library', 'Target type should be shared_library')
+assert(sub_dep.include_type() == 'system', 'the include_type kwarg of dependency() works')
 
 exe1 = executable('main', ['main.cpp'], dependencies: [sub_dep])
 test('test1', exe1)

--- a/test cases/common/226 include_type dependency/meson.build
+++ b/test cases/common/226 include_type dependency/meson.build
@@ -33,6 +33,9 @@ sp_dep_sys = sp_dep.as_system('system')
 assert(sp_dep_sys.include_type() == 'system', 'changing include_type works')
 assert(sp_dep.include_type() == 'preserve', 'as_system must not mutate the original object')
 
+fallback = dependency('sdffgagf_does_not_exist', include_type: 'system', fallback: ['subDep', 'subDep_dep'])
+assert(fallback.include_type() == 'system', 'include_type works with dependency fallback')
+
 # Check that PCH works with `include_type : 'system'` See https://github.com/mesonbuild/meson/issues/7167
 main_exe = executable('main_exe', 'main.cpp', cpp_pch: 'pch/test.hpp', dependencies: boost_dep)
 test('main_test', main_exe)


### PR DESCRIPTION
Fixes that `include_type` is ignored for dependency fallbacks and adds the `include_type` kwarg to the CMake subproject `dependency()` method.