### PR TITLE
Add pkgconfig directory from $prefix/$libdir to PKG_CONFIG_LIBDIR

### DIFF
--- a/docs/markdown/snippets/search_pkgconfig_dependencies_in_install_prefix.md
+++ b/docs/markdown/snippets/search_pkgconfig_dependencies_in_install_prefix.md
@@ -1,0 +1,5 @@
+## Search for pkgconfig dependencies in the installation prefix
+
+Meson will now also search for pkg-config dependencies for the host machine under
+the installation prefix.
+

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -660,6 +660,14 @@ class PkgConfigDependency(ExternalDependency):
         env['PKG_CONFIG_PATH'] = new_pkg_config_path
 
         pkg_config_libdir_prop = environment.properties[for_machine].get_pkg_config_libdir()
+        # Add the pkgconfig directory from the installation prefix to PKG_CONFIG_LIBDIR:
+        if for_machine == MachineChoice.HOST:
+            if pkg_config_libdir_prop is None:
+                pkg_config_libdir_prop = []
+            pkg_config_libdir_prefix = os.path.join(
+                environment.get_prefix(), environment.get_libdir(), "pkgconfig")
+            if os.path.isdir(pkg_config_libdir_prefix):
+                pkg_config_libdir_prop.append(pkg_config_libdir_prefix)
         if pkg_config_libdir_prop:
             new_pkg_config_libdir = ':'.join([p for p in pkg_config_libdir_prop])
             env['PKG_CONFIG_LIBDIR'] = new_pkg_config_libdir

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6920,6 +6920,26 @@ class LinuxlikeTests(BasePlatformTests):
             self.build()
 
     @skipIfNoPkgconfig
+    def test_pkgconfig_in_prefix(self):
+        '''
+        '''
+        with tempfile.TemporaryDirectory() as temp_prefixdirname:
+            # build library
+            testdirbase = os.path.join(self.unit_test_dir, '85 pkg-config in prefix')
+            proj1dir = os.path.join(testdirbase, 'proj1')
+            self.init(proj1dir, extra_args=['--prefix=' + temp_prefixdirname,
+                                            ], default_args=False)
+            self.build()
+            self.install(use_destdir=False)
+
+            # build user of library
+            proj2dir = os.path.join(testdirbase, 'proj2')
+            self.new_builddir()
+            self.init(proj2dir, extra_args=['--prefix=' + temp_prefixdirname,
+                                            ], default_args=False)
+            self.build()
+
+    @skipIfNoPkgconfig
     def test_static_archive_stripping(self):
         '''
         Check that Meson produces valid static archives with --strip enabled

--- a/test cases/unit/85 pkg-config in prefix/proj1/meson.build
+++ b/test cases/unit/85 pkg-config in prefix/proj1/meson.build
@@ -1,0 +1,13 @@
+project('proj1', ['c'], version : '1.0.0')
+
+pkg = import('pkgconfig')
+
+pkg.generate(
+  name: meson.project_name(),
+  description: 'Project 1',
+  libraries: [],
+  subdirs: [],
+  version: meson.project_version(),
+  filebase : meson.project_name()
+)
+

--- a/test cases/unit/85 pkg-config in prefix/proj2/meson.build
+++ b/test cases/unit/85 pkg-config in prefix/proj2/meson.build
@@ -1,0 +1,3 @@
+project('proj2', ['c'], version : '1.0.0')
+
+dependency('proj1')


### PR DESCRIPTION
With this pull request, meson will now also search for pkg-config dependencies (for the host machine) under the installation prefix.

Closes #7814

So if this PR was accepted the following call:

    meson setup builddir -Dprefix=/tmp/install

Would behave like this call in previous meson versions:

    meson setup builddir -Dprefix=/tmp/install --pkg-config-path "/tmp/install/lib/x86_64-linux-gnu/pkgconfig/"

So with this PR, we would avoid typing `--pkg-config-path "/tmp/install/lib/x86_64-linux-gnu/pkgconfig/"`. 

When installing to a custom prefix, some pkg-config libraries may already exist there from other meson projects. It makes sense to me that meson looks by default for pkg-config entries where it may have installed them.

Asking the user to provide that path is unconvenient, especially because finding out the libdir used by meson (e.g. `lib/x86_64-linux-gnu/pkgconfig`, `lib/pkgconfig`) may not be straightforward.

Besides, I fail to see a reason why someone would *not* want to have the install prefix in the `PKG_CONFIG_PATH`.
