### PR TITLE
compilers/cuda: Fix has_header_symbol check

### DIFF
--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -183,7 +183,7 @@ class CudaCompiler(Compiler):
             #endif
             return 0;
         }}'''
-        found, cached = self.compiles(t.format(**fargs), env, extra_args=extra_args, dependencies=dependencies)
+        found, cached = self.compiles(t.format_map(fargs), env, extra_args=extra_args, dependencies=dependencies)
         if found:
             return True, cached
         # Check if it's a class or a template
@@ -193,7 +193,7 @@ class CudaCompiler(Compiler):
         int main(void) {{
             return 0;
         }}'''
-        return self.compiles(t.format(**fargs), env, extra_args=extra_args, dependencies=dependencies)
+        return self.compiles(t.format_map(fargs), env, extra_args=extra_args, dependencies=dependencies)
 
     def get_options(self) -> 'OptionDictType':
         opts = super().get_options()

--- a/test cases/cuda/14 cuda has header symbol/meson.build
+++ b/test cases/cuda/14 cuda has header symbol/meson.build
@@ -1,0 +1,27 @@
+project('cuda has header symbol', 'cuda')
+
+cuda = meson.get_compiler('cuda')
+
+# C checks
+assert (cuda.has_header_symbol('stdio.h', 'int'), 'base types should always be available')
+assert (cuda.has_header_symbol('stdio.h', 'printf'), 'printf function not found')
+assert (cuda.has_header_symbol('stdio.h', 'FILE'), 'FILE structure not found')
+assert (cuda.has_header_symbol('limits.h', 'INT_MAX'), 'INT_MAX define not found')
+assert (not cuda.has_header_symbol('limits.h', 'guint64'), 'guint64 is not defined in limits.h')
+assert (not cuda.has_header_symbol('stdlib.h', 'FILE'), 'FILE structure is defined in stdio.h, not stdlib.h')
+assert (not cuda.has_header_symbol('stdlol.h', 'printf'), 'stdlol.h shouldn\'t exist')
+assert (not cuda.has_header_symbol('stdlol.h', 'int'), 'shouldn\'t be able to find "int" with invalid header')
+
+# C++ checks
+assert (cuda.has_header_symbol('iostream', 'std::iostream'), 'iostream not found in iostream.h')
+assert (cuda.has_header_symbol('vector', 'std::vector'), 'vector not found in vector.h')
+assert (not cuda.has_header_symbol('limits.h', 'std::iostream'), 'iostream should not be defined in limits.h')
+
+# CUDA checks
+assert (cuda.has_header_symbol('cuda.h', 'CUDA_VERSION'), 'CUDA_VERSION not found in cuda.h')
+assert (not cuda.has_header_symbol('cuda.h', 'cublasSaxpy'), 'cublasSaxpy is defined in cublas.h, not cuda.h')
+if cuda.version().version_compare('>=4.0')
+    assert (cuda.has_header_symbol('thrust/device_vector.h', 'thrust::device_vector'), 'thrust::device_vector not found')
+    assert (not cuda.has_header_symbol('thrust/fill.h', 'thrust::sort'), 'thrust::sort should not be defined in thrust/fill.h')
+endif
+


### PR DESCRIPTION
Header symbol checks for the CUDA compiler are broken (#7825) because the check was taken from the C++ compiler code. This doesn't work because `CPPCompiler` derives from `CLikeCompiler`, which implements C preprocessor checks in `has_header_symbol`, while `CudaCompiler` derives from `Compiler`, whose `has_header_symbol` throws.

This PR fixes these problems by:
- Not calling `super.has_header_symbol` anymore.
- Checking for C preprocessor macros. (with code copied from `CLikeCompiler`) 