### PR TITLE
Fix consistency in variables kwarg

### DIFF
--- a/docs/markdown/Pkgconfig-module.md
+++ b/docs/markdown/Pkgconfig-module.md
@@ -49,7 +49,8 @@ keyword arguments.
   generated file. The strings must be in the form `name=value` and may
   reference other pkgconfig variables,
   e.g. `datadir=${prefix}/share`. The names `prefix`, `libdir` and
-  `includedir` are reserved and may not be used.
+  `includedir` are reserved and may not be used. *Since 0.56.0* it can also be a
+  dictionary.
 - `version` a string describing the version of this library, used to set the
   `Version:` field. (*since 0.46.0*) Defaults to the project version if unspecified.
 - `d_module_versions` a list of module version flags used when compiling

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -427,7 +427,7 @@ keyword arguments:
 - `version`: the version of this dependency, such as `1.2.3`
 - `variables` *(since 0.54.0)*: a dictionary of arbitrary strings, this is meant to be used
   in subprojects where special variables would be provided via cmake or
-  pkg-config.
+  pkg-config. *since 0.56.0* it can also be a list of `'key=value'` strings.
 
 ### dependency()
 

--- a/docs/markdown/snippets/pkg_idep_variables.md
+++ b/docs/markdown/snippets/pkg_idep_variables.md
@@ -1,0 +1,12 @@
+## Consistency between `declare_dependency()` and `pkgconfig.generate()` variables
+
+The `variables` keyword argument in `declare_dependency()` used to only support
+dictionary and `pkgconfig.generate()` only list of strings. They now both support
+dictionary and list of strings in the format `'name=value'`. This makes easier
+to share a common set of variables for both:
+
+```meson
+vars = {'foo': 'bar'}
+dep = declare_dependency(..., variables: vars)
+pkg.generate(..., variables: vars)
+```

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6040,6 +6040,7 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertTrue(libhello_nolib.found())
         self.assertEqual(libhello_nolib.get_link_args(), [])
         self.assertEqual(libhello_nolib.get_compile_args(), [])
+        self.assertEqual(libhello_nolib.get_pkgconfig_variable('foo', {}), 'bar')
 
     def test_pkgconfig_gen_deps(self):
         '''

--- a/test cases/common/218 dependency get_variable method/meson.build
+++ b/test cases/common/218 dependency get_variable method/meson.build
@@ -59,3 +59,6 @@ idep = declare_dependency()
 assert(idep.get_variable(pkgconfig : 'foo', cmake : 'foo', configtool : 'foo',
                          default_value : default) == default,
        'something went wrong with an InternalDependency with no variables.')
+
+idep = declare_dependency(variables : ['foo=value'])
+assert(idep.get_variable(internal: 'foo') == 'value')

--- a/test cases/common/47 pkgconfig-gen/meson.build
+++ b/test cases/common/47 pkgconfig-gen/meson.build
@@ -64,7 +64,8 @@ pkgg.generate(
   name : 'libhello_nolib',
   description : 'A minimalistic pkgconfig file.',
   version : libver,
-  dataonly: true
+  dataonly: true,
+  variables : {'foo': 'bar'},
 )
 
 # Regression test for 2 cases:

--- a/test cases/failing/47 pkgconfig variables zero length/test.json
+++ b/test cases/failing/47 pkgconfig variables zero length/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/47 pkgconfig variables zero length/meson.build:8:5: ERROR: Invalid variable \"=value\". Variables must be in 'name=value' format"
+      "line": "test cases/failing/47 pkgconfig variables zero length/meson.build:8:5: ERROR: Empty variable name or value"
     }
   ]
 }

--- a/test cases/failing/48 pkgconfig variables zero length value/test.json
+++ b/test cases/failing/48 pkgconfig variables zero length value/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/48 pkgconfig variables zero length value/meson.build:8:5: ERROR: Invalid variable \"key=\". Variables must be in 'name=value' format"
+      "line": "test cases/failing/48 pkgconfig variables zero length value/meson.build:8:5: ERROR: Empty variable name or value"
     }
   ]
 }

--- a/test cases/failing/49 pkgconfig variables not key value/test.json
+++ b/test cases/failing/49 pkgconfig variables not key value/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/49 pkgconfig variables not key value/meson.build:8:5: ERROR: Invalid variable \"this_should_be_key_value\". Variables must be in 'name=value' format"
+      "line": "test cases/failing/49 pkgconfig variables not key value/meson.build:8:5: ERROR: Variable 'this_should_be_key_value' must have a value separated by equals sign."
     }
   ]
 }


### PR DESCRIPTION
Share common code to extract the `variables` kwarg in
declare_dependency() and pkg.generate().