### PR TITLE
Allow to cross-compile with C sharp

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1892,8 +1892,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 self.generate_java_compile_rule(compiler)
             return
         if langname == 'cs':
-            if self.environment.machines.matches_build_machine(compiler.for_machine):
-                self.generate_cs_compile_rule(compiler)
+            self.generate_cs_compile_rule(compiler)
             return
         if langname == 'vala':
             self.generate_vala_compile_rules(compiler)


### PR DESCRIPTION
When trying to cross-compile for ARM in Yocto with a C sharp compiler
one would get a KeyError: 'cs_COMPILER'. This can be fixed by creating
the C sharp compile rules for all machines, not just for the build machine.