### PR TITLE
Add support for parsing rust unit tests

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1740,6 +1740,7 @@ test(..., env: nomalloc, ...)
     to record the outcome of the test).
   - `tap`: [Test Anything Protocol](https://www.testanything.org/).
   - `gtest` *(since 0.55.0)*: for Google Tests.
+  - `rust` *(since 0.56.0)*: for native rust tests
 
 - `priority` *(since 0.52.0)*:specifies the priority of a test. Tests with a
   higher priority are *started* before tests with a lower priority.

--- a/docs/markdown/snippets/rust_test_format_support.md
+++ b/docs/markdown/snippets/rust_test_format_support.md
@@ -1,0 +1,4 @@
+## Meson test() now accepts `protocol : 'rust'`
+
+This allows native rust tests to be run and parsed by meson, simply set the
+protocol to `rust` and meson takes care of the rest.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -44,6 +44,7 @@ class TestProtocol(enum.Enum):
     EXITCODE = 0
     TAP = 1
     GTEST = 2
+    RUST = 3
 
     @classmethod
     def from_str(cls, string: str) -> 'TestProtocol':
@@ -53,6 +54,8 @@ class TestProtocol(enum.Enum):
             return cls.TAP
         elif string == 'gtest':
             return cls.GTEST
+        elif string == 'rust':
+            return cls.RUST
         raise MesonException('unknown test format {}'.format(string))
 
     def __str__(self) -> str:
@@ -60,6 +63,8 @@ class TestProtocol(enum.Enum):
             return 'exitcode'
         elif self is self.GTEST:
             return 'gtest'
+        elif self is self.RUST:
+            return 'rust'
         return 'tap'
 
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -4080,6 +4080,8 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
     def func_test(self, node, args, kwargs):
         if kwargs.get('protocol') == 'gtest':
             FeatureNew.single_use('"gtest" protocol for tests', '0.55.0', self.subproject)
+        elif kwargs.get('protocol') == 'rust':
+            FeatureNew.single_use('"rust" protocol for tests', '0.56.0', self.subproject)
         self.add_test(node, args, kwargs, True)
 
     def unpack_env_kwarg(self, kwargs) -> build.EnvironmentVariables:
@@ -4136,8 +4138,8 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         if not isinstance(timeout, int):
             raise InterpreterException('Timeout must be an integer.')
         protocol = kwargs.get('protocol', 'exitcode')
-        if protocol not in {'exitcode', 'tap', 'gtest'}:
-            raise InterpreterException('Protocol must be "exitcode", "tap", or "gtest".')
+        if protocol not in {'exitcode', 'tap', 'gtest', 'rust'}:
+            raise InterpreterException('Protocol must be one of "exitcode", "tap", "gtest", or "rust".')
         suite = []
         prj = self.subproject if self.is_subproject() else self.build.project_name
         for s in mesonlib.stringlistify(kwargs.get('suite', '')):

--- a/test cases/rust/9 unit tests/meson.build
+++ b/test cases/rust/9 unit tests/meson.build
@@ -1,0 +1,32 @@
+project('rust unit tests', 'rust')
+
+t = executable(
+  'rust_test',
+  ['test.rs'],
+  rust_args : ['--test'],
+)
+
+test(
+  'rust test (should fail)',
+  t,
+  protocol : 'rust',
+  suite : ['foo'],
+  should_fail : true,
+)
+
+test(
+  'rust test (should pass)',
+  t,
+  args : ['--skip', 'test_add_intentional_fail'],
+  protocol : 'rust',
+  suite : ['foo'],
+)
+
+
+test(
+  'rust test (should skip)',
+  t,
+  args : ['--skip', 'test_add'],
+  protocol : 'rust',
+  suite : ['foo'],
+)

--- a/test cases/rust/9 unit tests/test.rs
+++ b/test cases/rust/9 unit tests/test.rs
@@ -1,0 +1,24 @@
+pub fn add(a: i32, b: i32) -> i32 {
+    return a + b;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add() {
+        assert_eq!(add(1, 2), 3);
+    }
+
+    #[test]
+    fn test_add_intentional_fail() {
+        assert_eq!(add(1, 2), 5);
+    }
+
+    #[test]
+    #[ignore]
+    fn test_add_intentional_fail2() {
+        assert_eq!(add(1, 7), 5);
+    }
+}


### PR DESCRIPTION
this is a pretty basic first step for rust testing. What I'd like to follow up with is a rust module method that can be passed a rust build target, and create a new executable and test target with thaat information. But for now getting support for getting the test outputs and putting them in the junit xml that meson test generates seems like a good start.