### PR TITLE
cmake: ignore CMAKE_TOOLCHAIN_FILE and CMAKE_PROJECT_INCLUDE

### DIFF
--- a/mesonbuild/cmake/__init__.py
+++ b/mesonbuild/cmake/__init__.py
@@ -31,9 +31,10 @@ __all__ = [
     'parse_generator_expressions',
     'language_map',
     'cmake_defines_to_args',
+    'check_cmake_args',
 ]
 
-from .common import CMakeException, SingleTargetOptions, TargetOptions, cmake_defines_to_args, language_map
+from .common import CMakeException, SingleTargetOptions, TargetOptions, cmake_defines_to_args, language_map, check_cmake_args
 from .client import CMakeClient
 from .executor import CMakeExecutor
 from .fileapi import CMakeFileAPI

--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -35,6 +35,15 @@ language_map = {
 blacklist_cmake_defs = [
     'CMAKE_TOOLCHAIN_FILE',
     'CMAKE_PROJECT_INCLUDE',
+    'MESON_PRELOAD_FILE',
+    'MESON_PS_CMAKE_CURRENT_BINARY_DIR',
+    'MESON_PS_CMAKE_CURRENT_SOURCE_DIR',
+    'MESON_PS_DELAYED_CALLS',
+    'MESON_PS_LOADED',
+    'MESON_FIND_ROOT_PATH',
+    'MESON_CMAKE_SYSROOT',
+    'MESON_PATHS_LIST',
+    'MESON_CMAKE_ROOT',
 ]
 
 class CMakeException(MesonException):

--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -32,6 +32,11 @@ language_map = {
     'swift': 'Swift',
 }
 
+blacklist_cmake_defs = [
+    'CMAKE_TOOLCHAIN_FILE',
+    'CMAKE_PROJECT_INCLUDE',
+]
+
 class CMakeException(MesonException):
     pass
 
@@ -83,6 +88,11 @@ def cmake_defines_to_args(raw: T.Any, permissive: bool = False) -> T.List[str]:
             raise MesonException('Invalid CMake defines. Expected a dict, but got a {}'.format(type(i).__name__))
         for key, val in i.items():
             assert isinstance(key, str)
+            if key in blacklist_cmake_defs:
+                mlog.warning('Setting', mlog.bold(key), 'is not supported. See the meson docs for cross compilation support:')
+                mlog.warning('  - URL: https://mesonbuild.com/CMake-module.html#cross-compilation')
+                mlog.warning('  --> Ignoring this option')
+                continue
             if isinstance(val, (str, int, float)):
                 res += ['-D{}={}'.format(key, val)]
             elif isinstance(val, bool):
@@ -91,6 +101,20 @@ def cmake_defines_to_args(raw: T.Any, permissive: bool = False) -> T.List[str]:
             else:
                 raise MesonException('Type "{}" of "{}" is not supported as for a CMake define value'.format(type(val).__name__, key))
 
+    return res
+
+# TODO: this functuin will become obsolete once the `cmake_args` kwarg is dropped
+def check_cmake_args(args: T.List[str]) -> T.List[str]:
+    res = []  # type: T.List[str]
+    dis = ['-D' + x for x in blacklist_cmake_defs]
+    assert dis  # Ensure that dis is not empty.
+    for i in args:
+        if any([i.startswith(x) for x in dis]):
+            mlog.warning('Setting', mlog.bold(i), 'is not supported. See the meson docs for cross compilation support:')
+            mlog.warning('  - URL: https://mesonbuild.com/CMake-module.html#cross-compilation')
+            mlog.warning('  --> Ignoring this option')
+            continue
+        res += [i]
     return res
 
 class CMakeInclude:

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -15,7 +15,7 @@
 # This class contains the basic functionality needed to run any interpreter
 # or an interpreter-based tool.
 
-from .common import CMakeException, CMakeTarget, TargetOptions, CMakeConfiguration, language_map
+from .common import CMakeException, CMakeTarget, TargetOptions, CMakeConfiguration, language_map, check_cmake_args
 from .client import CMakeClient, RequestCMakeInputs, RequestConfigure, RequestCompute, RequestCodeModel, ReplyCMakeInputs, ReplyCodeModel
 from .fileapi import CMakeFileAPI
 from .executor import CMakeExecutor
@@ -861,6 +861,9 @@ class CMakeInterpreter:
         preload_file = mesondata['cmake/data/preload.cmake'].write_to_private(self.env)
         toolchain = CMakeToolchain(self.env, self.for_machine, CMakeExecScope.SUBPROJECT, self.build_dir.parent, preload_file)
         toolchain_file = toolchain.write()
+
+        # TODO: drop this check once the deprecated `cmake_args` kwarg is removed
+        extra_cmake_options = check_cmake_args(extra_cmake_options)
 
         generator = backend_generator_map[self.backend_name]
         cmake_args = []

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -34,7 +34,7 @@ from .. import mesonlib
 from ..compilers import clib_langs
 from ..envconfig import get_env_var
 from ..environment import BinaryTable, Environment, MachineInfo
-from ..cmake import CMakeExecutor, CMakeTraceParser, CMakeException, CMakeToolchain, CMakeExecScope
+from ..cmake import CMakeExecutor, CMakeTraceParser, CMakeException, CMakeToolchain, CMakeExecScope, check_cmake_args
 from ..mesonlib import MachineChoice, MesonException, OrderedSet, PerMachine
 from ..mesonlib import Popen_safe, version_compare_many, version_compare, listify, stringlistify, extract_as_list, split_args
 from ..mesonlib import Version, LibType
@@ -1100,6 +1100,7 @@ class CMakeDependency(ExternalDependency):
         self.traceparser = CMakeTraceParser(self.cmakebin.version(), self._get_build_dir())
 
         cm_args = stringlistify(extract_as_list(kwargs, 'cmake_args'))
+        cm_args = check_cmake_args(cm_args)
         if CMakeDependency.class_cmakeinfo[self.for_machine] is None:
             CMakeDependency.class_cmakeinfo[self.for_machine] = self._get_cmake_info(cm_args)
         self.cmakeinfo = CMakeDependency.class_cmakeinfo[self.for_machine]


### PR DESCRIPTION
To avoid confilcts with the meson CMake logic (especially regarding the changes in #7816) some CMake variables should not be passed by the user (especially not in a `meson.build`). With this PR internally used CMake variables set by the user are ignored and a warning is printed.