### PR TITLE
Put the Compiler standard option in the Language mixin

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -462,6 +462,25 @@ class ClangClCCompiler(ClangClCompiler, VisualStudioLikeCCompilerMixin, CCompile
                            full_version=full_version)
         ClangClCompiler.__init__(self, target)
 
+    def get_options(self) -> 'OptionDictType':
+        # Clang-cl can compile up to c99, but doesn't have a std-swtich for
+        # them. Unlike recent versions of MSVC it doesn't (as of 10.0.1)
+        # support c11
+        opts = super().get_options()
+        c_stds = ['none', 'c89', 'c99',
+                  # Need to have these to be compatible with projects
+                  # that set c_std to e.g. gnu99.
+                  # https://github.com/mesonbuild/meson/issues/7611
+                  'gnu89', 'gnu90', 'gnu9x', 'gnu99']
+        opts.update({
+            'std': coredata.UserComboOption(
+                'C language standard to use',
+                c_stds,
+                'none',
+            ),
+        })
+        return opts
+
 
 class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerMixin, CCompiler):
 

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -95,6 +95,17 @@ class CCompiler(CLikeCompiler, Compiler):
         return self.compiles(t.format(**fargs), env, extra_args=extra_args,
                              dependencies=dependencies)
 
+    def get_options(self) -> 'OptionDictType':
+        opts = super().get_options()
+        opts.update({
+            'std': coredata.UserComboOption(
+                'C langauge standard to use',
+                ['none'],
+                'none',
+            )
+        })
+        return opts
+
 
 class ClangCCompiler(ClangCompiler, CCompiler):
 
@@ -130,13 +141,7 @@ class ClangCCompiler(ClangCompiler, CCompiler):
         if version_compare(self.version, self._C2X_VERSION):
             c_stds += ['c2x']
             g_stds += ['gnu2x']
-        opts.update({
-            'std': coredata.UserComboOption(
-                'C language standard to use',
-                ['none'] + c_stds + g_stds,
-                'none',
-            ),
-        })
+        opts['std'].choices = ['none'] + c_stds + g_stds  # type: ignore
         if self.info.is_windows() or self.info.is_cygwin():
             opts.update({
                 'winlibs': coredata.UserArrayOption(
@@ -207,13 +212,7 @@ class ArmclangCCompiler(ArmclangCompiler, CCompiler):
 
     def get_options(self) -> 'OptionDictType':
         opts = CCompiler.get_options(self)
-        opts.update({
-            'std': coredata.UserComboOption(
-                'C language standard to use',
-                ['none', 'c90', 'c99', 'c11', 'gnu90', 'gnu99', 'gnu11'],
-                'none',
-            ),
-        })
+        opts['std'].choices = ['none', 'c90', 'c99', 'c11', 'gnu90', 'gnu99', 'gnu11']  # type: ignore
         return opts
 
     def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:
@@ -255,13 +254,7 @@ class GnuCCompiler(GnuCompiler, CCompiler):
         if version_compare(self.version, self._C2X_VERSION):
             c_stds += ['c2x']
             g_stds += ['gnu2x']
-        opts.update({
-            'std': coredata.UserComboOption(
-                'C language standard to use',
-                ['none'] + c_stds + g_stds,
-                'none',
-            ),
-        })
+        opts['std'].choices = ['none'] + c_stds + g_stds  # type: ignore
         if self.info.is_windows() or self.info.is_cygwin():
             opts.update({
                 'winlibs': coredata.UserArrayOption(
@@ -327,17 +320,11 @@ class ElbrusCCompiler(GnuCCompiler, ElbrusCompiler):
     # It does support some various ISO standards and c/gnu 90, 9x, 1x in addition to those which GNU CC supports.
     def get_options(self) -> 'OptionDictType':
         opts = CCompiler.get_options(self)
-        opts.update({
-            'std': coredata.UserComboOption(
-                'C language standard to use',
-                [
-                    'none', 'c89', 'c90', 'c9x', 'c99', 'c1x', 'c11',
-                    'gnu89', 'gnu90', 'gnu9x', 'gnu99', 'gnu1x', 'gnu11',
-                    'iso9899:2011', 'iso9899:1990', 'iso9899:199409', 'iso9899:1999',
-                ],
-                'none',
-            ),
-        })
+        opts['std'].choices = [  # type: ignore
+            'none', 'c89', 'c90', 'c9x', 'c99', 'c1x', 'c11',
+            'gnu89', 'gnu90', 'gnu9x', 'gnu99', 'gnu1x', 'gnu11',
+            'iso9899:2011', 'iso9899:1990', 'iso9899:199409', 'iso9899:1999',
+        ]
         return opts
 
     # Elbrus C compiler does not have lchmod, but there is only linker warning, not compiler error.
@@ -374,13 +361,7 @@ class IntelCCompiler(IntelGnuLikeCompiler, CCompiler):
         g_stds = ['gnu89', 'gnu99']
         if version_compare(self.version, '>=16.0.0'):
             c_stds += ['c11']
-        opts.update({
-            'std': coredata.UserComboOption(
-                'C language standard to use',
-                ['none'] + c_stds + g_stds,
-                'none',
-            ),
-        })
+        opts['std'].choices = ['none'] + c_stds + g_stds  # type: ignore
         return opts
 
     def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:
@@ -433,13 +414,7 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
                   # that set c_std to e.g. gnu99.
                   # https://github.com/mesonbuild/meson/issues/7611
                   'gnu89', 'gnu90', 'gnu9x', 'gnu99', 'gnu1x', 'gnu11']
-        opts.update({
-            'std': coredata.UserComboOption(
-                'C language standard to use',
-                c_stds,
-                'none',
-            ),
-        })
+        opts['std'].choices = c_stds  # type: ignore
         return opts
 
     def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:
@@ -472,13 +447,7 @@ class ClangClCCompiler(ClangClCompiler, VisualStudioLikeCCompilerMixin, CCompile
                   # that set c_std to e.g. gnu99.
                   # https://github.com/mesonbuild/meson/issues/7611
                   'gnu89', 'gnu90', 'gnu9x', 'gnu99']
-        opts.update({
-            'std': coredata.UserComboOption(
-                'C language standard to use',
-                c_stds,
-                'none',
-            ),
-        })
+        opts['std'].choices = c_stds  # type: ignore
         return opts
 
 
@@ -498,14 +467,7 @@ class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerM
 
     def get_options(self) -> 'OptionDictType':
         opts = super().get_options()
-        c_stds = ['none', 'c89', 'c99', 'c11']
-        opts.update({
-            'std': coredata.UserComboOption(
-                'C language standard to use',
-                c_stds,
-                'none',
-            ),
-        })
+        opts['std'].choices = ['none', 'c89', 'c99', 'c11']  # type: ignore
         return opts
 
     def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:
@@ -531,13 +493,7 @@ class ArmCCompiler(ArmCompiler, CCompiler):
 
     def get_options(self) -> 'OptionDictType':
         opts = CCompiler.get_options(self)
-        opts.update({
-            'std': coredata.UserComboOption(
-                'C language standard to use',
-                ['none', 'c90', 'c99'],
-                'none',
-            ),
-        })
+        opts['std'].choices = ['none', 'c89', 'c99', 'c11']  # type: ignore
         return opts
 
     def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:
@@ -564,13 +520,7 @@ class CcrxCCompiler(CcrxCompiler, CCompiler):
 
     def get_options(self) -> 'OptionDictType':
         opts = CCompiler.get_options(self)
-        opts.update({
-            'std': coredata.UserComboOption(
-                'C language standard to use',
-                ['none', 'c89', 'c99'],
-                'none',
-            ),
-        })
+        opts['std'].choices = ['none', 'c89', 'c99']  # type: ignore
         return opts
 
     def get_no_stdinc_args(self) -> T.List[str]:
@@ -615,9 +565,7 @@ class Xc16CCompiler(Xc16Compiler, CCompiler):
 
     def get_options(self) -> 'OptionDictType':
         opts = CCompiler.get_options(self)
-        opts.update({'std': coredata.UserComboOption('C language standard to use',
-                                                     ['none', 'c89', 'c99', 'gnu89', 'gnu99'],
-                                                     'none')})
+        opts['std'].choices = ['none', 'c89', 'c99', 'gnu89', 'gnu99']  # type: ignore
         return opts
 
     def get_no_stdinc_args(self) -> T.List[str]:
@@ -660,9 +608,7 @@ class CompCertCCompiler(CompCertCompiler, CCompiler):
 
     def get_options(self) -> 'OptionDictType':
         opts = CCompiler.get_options(self)
-        opts.update({'std': coredata.UserComboOption('C language standard to use',
-                                                     ['none', 'c89', 'c99'],
-                                                     'none')})
+        opts['std'].choices = ['none', 'c89', 'c99']  # type: ignore
         return opts
 
     def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:
@@ -698,9 +644,7 @@ class C2000CCompiler(C2000Compiler, CCompiler):
 
     def get_options(self) -> 'OptionDictType':
         opts = CCompiler.get_options(self)
-        opts.update({'std': coredata.UserComboOption('C language standard to use',
-                                                     ['none', 'c89', 'c99', 'c11'],
-                                                     'none')})
+        opts['std'].choices = ['none', 'c89', 'c99', 'c11']  # type: ignore
         return opts
 
     def get_no_stdinc_args(self) -> T.List[str]:

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -615,9 +615,9 @@ class Xc16CCompiler(Xc16Compiler, CCompiler):
 
     def get_options(self) -> 'OptionDictType':
         opts = CCompiler.get_options(self)
-        opts.update({'c_std': coredata.UserComboOption('C language standard to use',
-                                                       ['none', 'c89', 'c99', 'gnu89', 'gnu99'],
-                                                       'none')})
+        opts.update({'std': coredata.UserComboOption('C language standard to use',
+                                                     ['none', 'c89', 'c99', 'gnu89', 'gnu99'],
+                                                     'none')})
         return opts
 
     def get_no_stdinc_args(self) -> T.List[str]:
@@ -660,9 +660,9 @@ class CompCertCCompiler(CompCertCompiler, CCompiler):
 
     def get_options(self) -> 'OptionDictType':
         opts = CCompiler.get_options(self)
-        opts.update({'c_std': coredata.UserComboOption('C language standard to use',
-                                                       ['none', 'c89', 'c99'],
-                                                       'none')})
+        opts.update({'std': coredata.UserComboOption('C language standard to use',
+                                                     ['none', 'c89', 'c99'],
+                                                     'none')})
         return opts
 
     def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:
@@ -698,9 +698,9 @@ class C2000CCompiler(C2000Compiler, CCompiler):
 
     def get_options(self) -> 'OptionDictType':
         opts = CCompiler.get_options(self)
-        opts.update({'c_std': coredata.UserComboOption('C language standard to use',
-                                                       ['none', 'c89', 'c99', 'c11'],
-                                                       'none')})
+        opts.update({'std': coredata.UserComboOption('C language standard to use',
+                                                     ['none', 'c89', 'c99', 'c11'],
+                                                     'none')})
         return opts
 
     def get_no_stdinc_args(self) -> T.List[str]:

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -428,7 +428,11 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
 
     def get_options(self) -> 'OptionDictType':
         opts = super().get_options()
-        c_stds = ['none', 'c89', 'c99', 'c11']
+        c_stds = ['none', 'c89', 'c99', 'c11',
+                  # Need to have these to be compatible with projects
+                  # that set c_std to e.g. gnu99.
+                  # https://github.com/mesonbuild/meson/issues/7611
+                  'gnu89', 'gnu90', 'gnu9x', 'gnu99', 'gnu1x', 'gnu11']
         opts.update({
             'std': coredata.UserComboOption(
                 'C language standard to use',
@@ -442,8 +446,8 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
         args = []
         std = options['std']
         # As of MVSC 16.7, /std:c11 is the only valid C standard option.
-        if std.value in {'c11'}:
-            args.append('/std:' + std.value)
+        if std.value in {'c11', 'gnu11'}:
+            args.append('/std:c11')
         return args
 
 

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -167,6 +167,17 @@ class CPPCompiler(CLikeCompiler, Compiler):
 
         raise MesonException('C++ Compiler does not support -std={}'.format(cpp_std))
 
+    def get_options(self) -> 'OptionDictType':
+        opts = super().get_options()
+        opts.update({
+            'std': coredata.UserComboOption(
+                'C++ language standard to use',
+                ['none'],
+                'none',
+            ),
+        })
+        return opts
+
 
 class ClangCPPCompiler(ClangCompiler, CPPCompiler):
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
@@ -192,13 +203,11 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
                 'default',
             ),
             'rtti': coredata.UserBooleanOption('Enable RTTI', True),
-            'std': coredata.UserComboOption(
-                'C++ language standard to use',
-                ['none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z', 'c++2a',
-                 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++1z', 'gnu++2a'],
-                'none',
-            ),
         })
+        opts['std'].choices = [  # type: ignore
+            'none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z',
+            'c++2a', 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++1z', 'gnu++2a',
+        ]
         if self.info.is_windows() or self.info.is_cygwin():
             opts.update({
                 'winlibs': coredata.UserArrayOption(
@@ -283,15 +292,11 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
                 ['none', 'default', 'a', 's', 'sc'],
                 'default',
             ),
-            'std': coredata.UserComboOption(
-                'C++ language standard to use',
-                [
-                    'none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17',
-                    'gnu++98', 'gnu++03', 'gnu++11', 'gnu++14', 'gnu++17',
-                ],
-                'none',
-            ),
         })
+        opts['std'].choices = [  # type: ignore
+            'none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'gnu++98',
+            'gnu++03', 'gnu++11', 'gnu++14', 'gnu++17',
+        ]
         return opts
 
     def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:
@@ -332,17 +337,16 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
                 'default',
             ),
             'rtti': coredata.UserBooleanOption('Enable RTTI', True),
-            'std': coredata.UserComboOption(
-                'C++ language standard to use',
-                ['none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z', 'c++2a',
-                 'gnu++03', 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++1z', 'gnu++2a'],
-                'none',
-            ),
             'debugstl': coredata.UserBooleanOption(
                 'STL debug mode',
                 False,
             )
         })
+        opts['std'].choices = [  # type: ignore
+            'none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z',
+            'c++2a', 'gnu++03', 'gnu++11', 'gnu++14', 'gnu++17', 'gnu++1z',
+            'gnu++2a',
+        ]
         if self.info.is_windows() or self.info.is_cygwin():
             opts.update({
                 'winlibs': coredata.UserArrayOption(
@@ -437,16 +441,12 @@ class ElbrusCPPCompiler(GnuCPPCompiler, ElbrusCompiler):
                 ['none', 'default', 'a', 's', 'sc'],
                 'default',
             ),
-            'std': coredata.UserComboOption(
-                'C++ language standard to use',
-                cpp_stds,
-                'none',
-            ),
             'debugstl': coredata.UserBooleanOption(
                 'STL debug mode',
                 False,
             ),
         })
+        opts['std'].choices = cpp_stds  # type: ignore
         return opts
 
     # Elbrus C++ compiler does not have lchmod, but there is only linker warning, not compiler error.
@@ -515,13 +515,9 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
                 'default',
             ),
             'rtti': coredata.UserBooleanOption('Enable RTTI', True),
-            'std': coredata.UserComboOption(
-                'C++ language standard to use',
-                ['none'] + c_stds + g_stds,
-                'none',
-            ),
             'debugstl': coredata.UserBooleanOption('STL debug mode', False),
         })
+        opts['std'].choices = ['none'] + c_stds + g_stds  # type: ignore
         return opts
 
     def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:
@@ -573,16 +569,12 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
                 'default',
             ),
             'rtti': coredata.UserBooleanOption('Enable RTTI', True),
-            'std': coredata.UserComboOption(
-                'C++ language standard to use',
-                cpp_stds,
-                'none',
-            ),
             'winlibs': coredata.UserArrayOption(
                 'Windows libs to link against.',
                 msvc_winlibs,
             ),
         })
+        opts['std'].choices = cpp_stds  # type: ignore
         return opts
 
     def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:
@@ -726,13 +718,7 @@ class ArmCPPCompiler(ArmCompiler, CPPCompiler):
 
     def get_options(self) -> 'OptionDictType':
         opts = CPPCompiler.get_options(self)
-        opts.update({
-            'std': coredata.UserComboOption(
-                'C++ language standard to use',
-                ['none', 'c++03', 'c++11'],
-                'none',
-            ),
-        })
+        opts['std'].choices = ['none', 'c++03', 'c++11']  # type: ignore
         return opts
 
     def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:
@@ -790,9 +776,7 @@ class C2000CPPCompiler(C2000Compiler, CPPCompiler):
 
     def get_options(self) -> 'OptionDictType':
         opts = CPPCompiler.get_options(self)
-        opts.update({'std': coredata.UserComboOption('C++ language standard to use',
-                                                     ['none', 'c++03'],
-                                                     'none')})
+        opts['std'].choices = ['none', 'c++03']  # type: ignore
         return opts
 
     def get_always_args(self) -> T.List[str]:

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -790,9 +790,9 @@ class C2000CPPCompiler(C2000Compiler, CPPCompiler):
 
     def get_options(self) -> 'OptionDictType':
         opts = CPPCompiler.get_options(self)
-        opts.update({'cpp_std': coredata.UserComboOption('C++ language standard to use',
-                                                         ['none', 'c++03'],
-                                                         'none')})
+        opts.update({'std': coredata.UserComboOption('C++ language standard to use',
+                                                     ['none', 'c++03'],
+                                                     'none')})
         return opts
 
     def get_always_args(self) -> T.List[str]:

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -197,9 +197,9 @@ class CudaCompiler(Compiler):
 
     def get_options(self) -> 'OptionDictType':
         opts = super().get_options()
-        opts.update({'cuda_std': coredata.UserComboOption('C++ language standard to use',
-                                                          ['none', 'c++03', 'c++11', 'c++14'],
-                                                          'none')})
+        opts.update({'std': coredata.UserComboOption('C++ language standard to use with cuda',
+                                                     ['none', 'c++03', 'c++11', 'c++14'],
+                                                     'none')})
         return opts
 
     def _to_host_compiler_options(self, options: 'OptionDictType') -> 'OptionDictType':
@@ -212,7 +212,7 @@ class CudaCompiler(Compiler):
         # the combination of CUDA version and MSVC version; the --std= is thus ignored
         # and attempting to use it will result in a warning: https://stackoverflow.com/a/51272091/741027
         if not is_windows():
-            std = options['cuda_std']
+            std = options['std']
             if std.value != 'none':
                 args.append('--std=' + std.value)
 

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -150,6 +150,17 @@ class FortranCompiler(CLikeCompiler, Compiler):
     def has_multi_link_arguments(self, args: T.List[str], env: 'Environment') -> T.Tuple[bool, bool]:
         return self._has_multi_link_arguments(args, env, 'stop; end program')
 
+    def get_options(self) -> 'OptionDictType':
+        opts = super().get_options()
+        opts.update({
+            'std': coredata.UserComboOption(
+                'Fortran language standard to use',
+                ['none'],
+                'none',
+            ),
+        })
+        return opts
+
 
 class GnuFortranCompiler(GnuCompiler, FortranCompiler):
 
@@ -175,13 +186,7 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
             fortran_stds += ['f2008']
         if version_compare(self.version, '>=8.0.0'):
             fortran_stds += ['f2018']
-        opts.update({
-            'std': coredata.UserComboOption(
-                'Fortran language standard to use',
-                ['none'] + fortran_stds,
-                'none',
-            ),
-        })
+        opts['std'].choices = ['none'] + fortran_stds  # type: ignore
         return opts
 
     def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:
@@ -310,14 +315,7 @@ class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
 
     def get_options(self) -> 'OptionDictType':
         opts = FortranCompiler.get_options(self)
-        fortran_stds = ['legacy', 'f95', 'f2003', 'f2008', 'f2018']
-        opts.update({
-            'std': coredata.UserComboOption(
-                'Fortran language standard to use',
-                ['none'] + fortran_stds,
-                'none',
-            ),
-        })
+        opts['std'].choices = ['legacy', 'f95', 'f2003', 'f2008', 'f2018']  # type: ignore
         return opts
 
     def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:
@@ -367,14 +365,7 @@ class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
 
     def get_options(self) -> 'OptionDictType':
         opts = FortranCompiler.get_options(self)
-        fortran_stds = ['legacy', 'f95', 'f2003', 'f2008', 'f2018']
-        opts.update({
-            'std': coredata.UserComboOption(
-                'Fortran language standard to use',
-                ['none'] + fortran_stds,
-                'none',
-            ),
-        })
+        opts['std'].choices = ['legacy', 'f95', 'f2003', 'f2008', 'f2018']  # type: ignore
         return opts
 
     def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:


### PR DESCRIPTION
This has a nice effect on code duplication, plus ensures that all compilers expose the {lang}_std option, even if the only option is none. This prevents cases where a project says "I need gnu99" but the compiler doesn't support it, and meson acts like it does.

This also cleans up the options, as some use (incorrectly) `c_std`, when they should use just `std`