### PR TITLE
switch gui_app deprecation to FeatureDeprecatedKwargs

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -709,7 +709,7 @@ be passed to [shared and static libraries](#library).
 - `win_subsystem` *(since 0.56.0)* specifies the subsystem type to use
   on the Windows platform. Typical values include `console` for text
   mode programs and `windows` for gui apps. The value can also contain
-  version specification such as `windows,6.0'. See [MSDN
+  version specification such as `windows,6.0`. See [MSDN
   documentation](https://docs.microsoft.com/en-us/cpp/build/reference/subsystem-specify-subsystem)
   for the full list. The default value is `console`.
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -929,7 +929,6 @@ This will become a hard error in a future Meson release.''')
             # was not specified and win_subsystem should be used instead.
             self.gui_app = None
             if 'gui_app' in kwargs:
-                mlog.deprecation('The gui_app kwarg is deprecated, use win_subsystem instead.')
                 if 'win_subsystem' in kwargs:
                     raise InvalidArguments('Can specify only gui_app or win_subsystem for a target, not both.')
                 self.gui_app = kwargs['gui_app']

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3874,6 +3874,7 @@ external dependencies (including libraries) must go to "dependencies".''')
 
     @FeatureNewKwargs('executable', '0.42.0', ['implib'])
     @permittedKwargs(permitted_kwargs['executable'])
+    @FeatureDeprecatedKwargs('executable', '0.56.0', ['gui_app'], extra_message="Use 'win_subsystem' instead.")
     def func_executable(self, node, args, kwargs):
         return self.build_target(node, args, kwargs, ExecutableHolder)
 


### PR DESCRIPTION
The deprecation message for "gui_app" is appearing for every target
rather than just once, and even if the required version is older
than 0.56.0.  Use @FeatureDeprecatedKwargs to fix both issues.