### PR TITLE
cmake: some subproject related fixes

### DIFF
--- a/mesonbuild/cmake/data/preload.cmake
+++ b/mesonbuild/cmake/data/preload.cmake
@@ -4,6 +4,9 @@ endif()
 
 set(MESON_PS_LOADED ON)
 
+cmake_policy(PUSH)
+cmake_policy(SET CMP0054 NEW) # https://cmake.org/cmake/help/latest/policy/CMP0054.html
+
 # Dummy macros that have a special meaning in the meson code
 macro(meson_ps_execute_delayed_calls)
 endmacro()
@@ -75,3 +78,5 @@ endmacro()
 
 set(MESON_PS_DELAYED_CALLS add_custom_command;add_custom_target;set_property)
 meson_ps_reload_vars()
+
+cmake_policy(POP)

--- a/mesonbuild/cmake/data/preload.cmake
+++ b/mesonbuild/cmake/data/preload.cmake
@@ -11,6 +11,11 @@ endmacro()
 macro(meson_ps_reload_vars)
 endmacro()
 
+macro(meson_ps_disabled_function)
+  message(WARNING "The function '${ARGV0}' is disabled in the context of CMake subporjects.\n"
+                  "This should not be an issue but may lead to compilaton errors.")
+endmacro()
+
 # Helper macro to inspect the current CMake state
 macro(meson_ps_inspect_vars)
   set(MESON_PS_CMAKE_CURRENT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
@@ -62,6 +67,11 @@ function(set_source_files_properties)
     endif()
   endwhile()
 endfunction()
+
+# Disable some functions that would mess up the CMake meson integration
+macro(target_precompile_headers)
+  meson_ps_disabled_function(target_precompile_headers)
+endmacro()
 
 set(MESON_PS_DELAYED_CALLS add_custom_command;add_custom_target;set_property)
 meson_ps_reload_vars()

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -435,10 +435,7 @@ class ConverterTarget:
             x = x.resolve()
             assert x.is_absolute()
             if not x.exists() and not any([x.name.endswith(y) for y in obj_suffixes]) and not is_generated:
-                if (
-                    any([path_is_in_root(root_src_dir / y, x.resolve(), resolve=True) for y in self.generated_raw])
-                        and path_is_in_root(x, Path(self.env.get_build_dir()), resolve=True)
-                    ):
+                if path_is_in_root(x, Path(self.env.get_build_dir()), resolve=True):
                     x.mkdir(parents=True, exist_ok=True)
                     return x.relative_to(Path(self.env.get_build_dir()) / subdir)
                 else:

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -123,6 +123,7 @@ class CMakeTraceParser:
             # meaning here in the trace parser.
             'meson_ps_execute_delayed_calls': self._meson_ps_execute_delayed_calls,
             'meson_ps_reload_vars': self._meson_ps_reload_vars,
+            'meson_ps_disabled_function': self._meson_ps_disabled_function,
         }  # type: T.Dict[str, T.Callable[[CMakeTraceLine], None]]
 
     def trace_args(self) -> T.List[str]:
@@ -617,6 +618,13 @@ class CMakeTraceParser:
 
     def _meson_ps_reload_vars(self, tline: CMakeTraceLine) -> None:
         self.delayed_commands = self.get_cmake_var('MESON_PS_DELAYED_CALLS')
+
+    def _meson_ps_disabled_function(self, tline: CMakeTraceLine) -> None:
+        args = list(tline.args)
+        if not args:
+            mlog.error('Invalid preload.cmake script! At least one argument to `meson_ps_disabled_function` is expected')
+            return
+        mlog.warning('The CMake function "{}" was disabed to avoid compatibility issues with Meson.'.format(args[0]))
 
     def _lex_trace_human(self, trace: str) -> T.Generator[CMakeTraceLine, None, None]:
         # The trace format is: '<file>(<line>):  <func>(<args -- can contain \n> )\n'

--- a/mesonbuild/mesondata.py
+++ b/mesonbuild/mesondata.py
@@ -266,6 +266,9 @@ endif()
 
 set(MESON_PS_LOADED ON)
 
+cmake_policy(PUSH)
+cmake_policy(SET CMP0054 NEW) # https://cmake.org/cmake/help/latest/policy/CMP0054.html
+
 # Dummy macros that have a special meaning in the meson code
 macro(meson_ps_execute_delayed_calls)
 endmacro()
@@ -337,6 +340,8 @@ endmacro()
 
 set(MESON_PS_DELAYED_CALLS add_custom_command;add_custom_target;set_property)
 meson_ps_reload_vars()
+
+cmake_policy(POP)
 '''
 
 
@@ -379,7 +384,7 @@ mesondata = {
     ),
     'cmake/data/preload.cmake': DataFile(
         Path('cmake/data/preload.cmake'),
-        'bbc441ededf2c7da2d0e640038ccbf4e818b73a2ba75084e1b4dbf05d8bca865',
+        '2b4e632aeb74acb2b441880cf85c0b6fcab03e75b182d3077715a97e739a7918',
         file_3_data_preload_cmake,
     ),
 }

--- a/mesonbuild/mesondata.py
+++ b/mesonbuild/mesondata.py
@@ -19,6 +19,7 @@
 ####
 
 
+# TODO: Remember to remove this also from tools/gen_data.py
 from ._pathlib import Path
 import typing as T
 
@@ -272,6 +273,11 @@ endmacro()
 macro(meson_ps_reload_vars)
 endmacro()
 
+macro(meson_ps_disabled_function)
+  message(WARNING "The function '${ARGV0}' is disabled in the context of CMake subporjects.\n"
+                  "This should not be an issue but may lead to compilaton errors.")
+endmacro()
+
 # Helper macro to inspect the current CMake state
 macro(meson_ps_inspect_vars)
   set(MESON_PS_CMAKE_CURRENT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
@@ -324,6 +330,11 @@ function(set_source_files_properties)
   endwhile()
 endfunction()
 
+# Disable some functions that would mess up the CMake meson integration
+macro(target_precompile_headers)
+  meson_ps_disabled_function(target_precompile_headers)
+endmacro()
+
 set(MESON_PS_DELAYED_CALLS add_custom_command;add_custom_target;set_property)
 meson_ps_reload_vars()
 '''
@@ -368,7 +379,7 @@ mesondata = {
     ),
     'cmake/data/preload.cmake': DataFile(
         Path('cmake/data/preload.cmake'),
-        '064d047b18a5c919ad016b838bed50c5d40aebe9e53da0e70eff9d52a2c1ca1f',
+        'bbc441ededf2c7da2d0e640038ccbf4e818b73a2ba75084e1b4dbf05d8bca865',
         file_3_data_preload_cmake,
     ),
 }

--- a/test cases/cmake/1 basic/subprojects/cmMod/CMakeLists.txt
+++ b/test cases/cmake/1 basic/subprojects/cmMod/CMakeLists.txt
@@ -10,5 +10,11 @@ add_definitions("-DDO_NOTHING_JUST_A_FLAG=1")
 add_library(cmModLib++ SHARED cmMod.cpp)
 target_compile_definitions(cmModLib++ PRIVATE MESON_MAGIC_FLAG=21)
 target_compile_definitions(cmModLib++ INTERFACE MESON_MAGIC_FLAG=42)
+
+# Test PCH support
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")
+  target_precompile_headers(cmModLib++ PRIVATE "cpp_pch.hpp")
+endif()
+
 include(GenerateExportHeader)
 generate_export_header(cmModLib++)

--- a/test cases/cmake/1 basic/subprojects/cmMod/cpp_pch.hpp
+++ b/test cases/cmake/1 basic/subprojects/cmMod/cpp_pch.hpp
@@ -1,0 +1,2 @@
+#include <vector>
+#include <string>

--- a/tools/gen_data.py
+++ b/tools/gen_data.py
@@ -78,7 +78,8 @@ def main() -> int:
         ####
 
 
-        from pathlib import Path
+        # TODO: Remember to remove this also from tools/gen_data.py
+        from ._pathlib import Path
         import typing as T
 
         if T.TYPE_CHECKING:


### PR DESCRIPTION
Both commits don't add new functionality and should be OK for 0.56.0

---

cmake: Always create missing includes in build dir

There really isn't any reason to not always create missing
include directories inside the build dir. Just restricting
this to generate generated sources should work in an ideal
world, however, there exists lots of suboptimal CMake code
where this assumption is not always true.

---


cmake: Disable the new (CMake 3.16) PCH support

Subprojects that use the CMake PCH feature will cause
compilation/linker errors. The CMake PCH support
should thus be disabled until this can be properly
translated to meson.

