### PR TITLE
pkgconfig: Define libdir and includedir in -uninstalled.pc files

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -329,18 +329,17 @@ class PkgConfigModule(ExtensionModule):
         else:
             outdir = state.environment.scratch_dir
             prefix = PurePath(coredata.get_builtin_option('prefix'))
-            # These always return paths relative to prefix
-            libdir = PurePath(coredata.get_builtin_option('libdir'))
-            incdir = PurePath(coredata.get_builtin_option('includedir'))
+        # These always return paths relative to prefix
+        libdir = PurePath(coredata.get_builtin_option('libdir'))
+        incdir = PurePath(coredata.get_builtin_option('includedir'))
         fname = os.path.join(outdir, pcfile)
         with open(fname, 'w', encoding='utf-8') as ofile:
             if not dataonly:
                 ofile.write('prefix={}\n'.format(self._escape(prefix)))
                 if uninstalled:
                     ofile.write('srcdir={}\n'.format(self._escape(srcdir)))
-                else:
-                    ofile.write('libdir={}\n'.format(self._escape('${prefix}' / libdir)))
-                    ofile.write('includedir={}\n'.format(self._escape('${prefix}' / incdir)))
+                ofile.write('libdir={}\n'.format(self._escape('${prefix}' / libdir)))
+                ofile.write('includedir={}\n'.format(self._escape('${prefix}' / incdir)))
             if variables:
                 ofile.write('\n')
             for k, v in variables:


### PR DESCRIPTION
This fixes glib-2.0-uninstalled.pc file.
GLib does `extra_cflags : ['-I${libdir}/glib-2.0/include']` because some
of its headers gets installed there. But when used uninstalled that path
makes no sense and pkg-config aborts because ${libdir} is not defined.
This cannot be worked around by GLib because Meson does not allow
setting different `extra_cflags` for -uninstalled.pc, and does not allow
setting libdir in `uninstalled_variables`.