### PR TITLE
compiler: allow non-built internal dependencies as arguments

### DIFF
--- a/docs/markdown/snippets/compiler_method_internal_deps.md
+++ b/docs/markdown/snippets/compiler_method_internal_deps.md
@@ -1,0 +1,6 @@
+## Passing internal dependencies to the compiler object
+
+Methods on the compiler object (such as `compiles`, `links`, `has_header`)
+can be passed dependencies returned by `declare_dependency`, as long as they
+only specify compiler/linker arguments or other dependencies that satisfy
+the same requirements.

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -132,6 +132,9 @@ class Dependency:
         s = '<{0} {1}: {2}>'
         return s.format(self.__class__.__name__, self.name, self.is_found)
 
+    def is_built(self) -> bool:
+        return False
+
     def get_compile_args(self) -> T.List[str]:
         if self.include_type == 'system':
             converted = []
@@ -260,6 +263,11 @@ class InternalDependency(Dependency):
             else:
                 setattr(result, k, copy.deepcopy(v, memo))
         return result
+
+    def is_built(self) -> bool:
+        if self.sources or self.libraries or self.whole_libraries:
+            return True
+        return any(d.is_built() for d in self.ext_deps)
 
     def get_pkgconfig_variable(self, variable_name: str, kwargs: T.Dict[str, T.Any]) -> str:
         raise DependencyException('Method "get_pkgconfig_variable()" is '

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -33,7 +33,7 @@ from .. import mlog
 from .. import mesonlib
 from ..compilers import clib_langs
 from ..envconfig import get_env_var
-from ..environment import BinaryTable, Environment, MachineInfo
+from ..environment import Environment, MachineInfo
 from ..cmake import CMakeExecutor, CMakeTraceParser, CMakeException, CMakeToolchain, CMakeExecScope, check_cmake_args
 from ..mesonlib import MachineChoice, MesonException, OrderedSet, PerMachine
 from ..mesonlib import Popen_safe, version_compare_many, version_compare, listify, stringlistify, extract_as_list, split_args
@@ -84,7 +84,7 @@ def find_external_program(env: Environment, for_machine: MachineChoice, name: st
     potential_path = env.lookup_binary_entry(for_machine, name)
     if potential_path is not None:
         mlog.debug('{} binary for {} specified from cross file, native file, '
-                    'or env var as {}'.format(display_name, for_machine, potential_path))
+                   'or env var as {}'.format(display_name, for_machine, potential_path))
         yield ExternalProgram.from_entry(name, potential_path)
         # We never fallback if the user-specified option is no good, so
         # stop returning options.
@@ -664,7 +664,6 @@ class PkgConfigDependency(ExternalDependency):
             new_pkg_config_libdir = ':'.join([p for p in pkg_config_libdir_prop])
             env['PKG_CONFIG_LIBDIR'] = new_pkg_config_libdir
             mlog.debug('PKG_CONFIG_LIBDIR: ' + new_pkg_config_libdir)
-
 
     def _call_pkgbin(self, args, env=None):
         # Always copy the environment since we're going to modify it

--- a/test cases/linuxlike/2 external library/meson.build
+++ b/test cases/linuxlike/2 external library/meson.build
@@ -18,6 +18,12 @@ int main(void) {
 '''
 
 assert(cc.links(linkcode, args : '-lz', name : 'Test link against zlib'), 'Linking test failed.')
+d1 = declare_dependency(compile_args: '-DSOMETHING', link_args: '-lz')
+assert(cc.links(linkcode, dependencies : d1,
+                name : 'Test link against zlib via declare_dependency'), 'Linking test failed.')
+d2 = declare_dependency(dependencies: d1)
+assert(cc.links(linkcode, dependencies : d2,
+                name : 'Test link against zlib via indirect declare_dependency'), 'Linking test failed.')
 assert(not cc.links(nolinkcode, name : 'Failing link'), 'Linking succeeded when it should have failed.')
 
 e = executable('zprog', 'prog.c', dependencies : zlib)


### PR DESCRIPTION
Allow methods on the compiler object to receive internal dependencies, as long as they only specify compiler/linker arguments or other dependencies that satisfy the same requirements.

This is useful if you're using internal dependencies to add special "-D" flags such as -DNCURSES_WIDECHAR, -D_XOPEN_SOURCE_EXTENDED or -DGLIB_STATIC_COMPILATION.