### PR TITLE
setup.cfg: Add pytest discovery args

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,3 +39,6 @@ progress =
 
 [tool:pytest]
 python_classes =
+python_files =
+    run_unittests.py
+


### PR DESCRIPTION
We have a single giant file for our tests, but a number of files that
match pytest's default discovery globs. To fix that, let's tell pytest
what to do.

This means you can just `pytest` and get the right results. It also
helps IDE's like vscode correctly identify tests.