### PR TITLE
interpreter: Add get_keys function for configuration_data

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2408,8 +2408,11 @@ page](Configuration.md) It has three methods:
 
 - `has(varname)`: returns `true` if the specified variable is set
 
-- `keys()`*(since 0.57.0)*: returns all keys of the configuration data object
-  as an iteratable list.
+- `keys()`*(since 0.57.0)*: returns an alphabetically sorted array of keys of
+  the configuration data object.
+
+  You can iterate over this array with the [`foreach`
+  statement](Syntax.md#foreach-statements).
 
 - `merge_from(other)` *(since 0.42.0)*: takes as argument a different
   configuration data object and copies all entries from that object to

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2408,7 +2408,7 @@ page](Configuration.md) It has three methods:
 
 - `has(varname)`: returns `true` if the specified variable is set
 
-- `keys()`*(since 0.57.0)*: returns an alphabetically sorted array of keys of
+- `keys()`*(since 0.57.0)*: returns an array of keys of
   the configuration data object.
 
   You can iterate over this array with the [`foreach`

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2408,6 +2408,9 @@ page](Configuration.md) It has three methods:
 
 - `has(varname)`: returns `true` if the specified variable is set
 
+- `keys()`*(since 0.57.0)*: returns all keys of the configuration data object
+  as an iteratable list.
+
 - `merge_from(other)` *(since 0.42.0)*: takes as argument a different
   configuration data object and copies all entries from that object to
   the current.

--- a/docs/markdown/snippets/keys_of_configuration_data.md
+++ b/docs/markdown/snippets/keys_of_configuration_data.md
@@ -1,0 +1,5 @@
+## Get keys of configuration data object
+
+All keys of the `configuration_data` object can be obtained with the `keys()`
+method. It returns an iterable list of all keys in the configuration data
+object.

--- a/docs/markdown/snippets/keys_of_configuration_data.md
+++ b/docs/markdown/snippets/keys_of_configuration_data.md
@@ -1,5 +1,4 @@
 ## Get keys of configuration data object
 
 All keys of the `configuration_data` object can be obtained with the `keys()`
-method. It returns an iterable list of all keys in the configuration data
-object.
+method as an alphabetically sorted array.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -404,7 +404,7 @@ class ConfigurationDataHolder(MutableInterpreterObject, ObjectHolder):
 
     @FeatureNew('configuration_data.keys()', '0.57.0')
     def keys_method(self, args, kwargs):
-        return list(self.keys())
+        return sorted(self.keys())
 
     def keys(self):
         return self.held_object.values.keys()

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -308,7 +308,7 @@ class ConfigurationDataHolder(MutableInterpreterObject, ObjectHolder):
                              'set_quoted': self.set_quoted_method,
                              'has': self.has_method,
                              'get': self.get_method,
-                             'get_keys': self.get_keys_method,
+                             'keys': self.keys_method,
                              'get_unquoted': self.get_unquoted_method,
                              'merge_from': self.merge_from_method,
                              })
@@ -402,7 +402,8 @@ class ConfigurationDataHolder(MutableInterpreterObject, ObjectHolder):
     def get(self, name):
         return self.held_object.values[name] # (val, desc)
 
-    def get_keys_method(self, args, kwargs):
+    @FeatureNew('configuration_data.keys()', '0.57.0')
+    def keys_method(self, args, kwargs):
         return list(self.keys())
 
     def keys(self):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -308,6 +308,7 @@ class ConfigurationDataHolder(MutableInterpreterObject, ObjectHolder):
                              'set_quoted': self.set_quoted_method,
                              'has': self.has_method,
                              'get': self.get_method,
+                             'get_keys': self.get_keys_method,
                              'get_unquoted': self.get_unquoted_method,
                              'merge_from': self.merge_from_method,
                              })
@@ -400,6 +401,9 @@ class ConfigurationDataHolder(MutableInterpreterObject, ObjectHolder):
 
     def get(self, name):
         return self.held_object.values[name] # (val, desc)
+
+    def get_keys_method(self, args, kwargs):
+        return list(self.keys())
 
     def keys(self):
         return self.held_object.values.keys()

--- a/test cases/common/14 configure file/meson.build
+++ b/test cases/common/14 configure file/meson.build
@@ -10,6 +10,7 @@ conf.set('BE_TRUE', true)
 assert(conf.get('var') == 'mystring', 'Get function is not working.')
 assert(conf.get('var', 'default') == 'mystring', 'Get function is not working.')
 assert(conf.get('notthere', 'default') == 'default', 'Default value getting is not working.')
+assert(conf.keys() == ['var', 'other', 'second', 'BE_TRUE'], 'Keys function is not working')
 
 cfile = configure_file(input : 'config.h.in',
   output : 'config.h',

--- a/test cases/common/14 configure file/meson.build
+++ b/test cases/common/14 configure file/meson.build
@@ -10,7 +10,7 @@ conf.set('BE_TRUE', true)
 assert(conf.get('var') == 'mystring', 'Get function is not working.')
 assert(conf.get('var', 'default') == 'mystring', 'Get function is not working.')
 assert(conf.get('notthere', 'default') == 'default', 'Default value getting is not working.')
-assert(conf.keys() == ['var', 'other', 'second', 'BE_TRUE'], 'Keys function is not working')
+assert(conf.keys() == ['BE_TRUE', 'other', 'second', 'var'], 'Keys function is not working')
 
 cfile = configure_file(input : 'config.h.in',
   output : 'config.h',


### PR DESCRIPTION
would be beneficial to iterate over all configuration_data keys. getter function already exists, but not made available to the user