### PR TITLE
qt: dependency: Strip tool versions from newlines

### DIFF
--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -258,7 +258,7 @@ class QtBaseDependency(ExternalDependency):
                     care = out
                 else:
                     care = err
-                return care.split(' ')[-1].replace(')', '')
+                return care.split(' ')[-1].replace(')', '').strip()
 
             p = interp_obj.find_program_impl([b], required=False,
                                              version_func=get_version,


### PR DESCRIPTION
When finding the Qt compilation tools (moc, uic, rcc, lrelease), the
version strings contain a trailing newline character. This results in a
stray newline in the meson log:

Detecting Qt5 tools
Program /usr/lib64/qt5/bin/moc found: YES 5.14.2
 (/usr/lib64/qt5/bin/moc)
Program /usr/lib64/qt5/bin/uic found: YES 5.14.2
 (/usr/lib64/qt5/bin/uic)
Program /usr/lib64/qt5/bin/rcc found: YES 5.14.2
 (/usr/lib64/qt5/bin/rcc)
Program /usr/lib64/qt5/bin/lrelease found: YES 5.14.2
 (/usr/lib64/qt5/bin/lrelease)

Strip the version to avoid this, resulting in a cleaner log:

Detecting Qt5 tools
Program /usr/lib64/qt5/bin/moc found: YES 5.14.2 (/usr/lib64/qt5/bin/moc)
Program /usr/lib64/qt5/bin/uic found: YES 5.14.2 (/usr/lib64/qt5/bin/uic)
Program /usr/lib64/qt5/bin/rcc found: YES 5.14.2 (/usr/lib64/qt5/bin/rcc)
Program /usr/lib64/qt5/bin/lrelease found: YES 5.14.2 (/usr/lib64/qt5/bin/lrelease)

Signed-off-by: Laurent Pinchart <laurent.pinchart@ideasonboard.com>