### PR TITLE
Avoid build.ninja changes due to order of hash table iteration

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -359,9 +359,9 @@ class NinjaBuildElement:
             rulename = self.rulename
         line = 'build {}{}: {} {}'.format(outs, implicit_outs, rulename, ins)
         if len(self.deps) > 0:
-            line += ' | ' + ' '.join([ninja_quote(x, True) for x in self.deps])
+            line += ' | ' + ' '.join([ninja_quote(x, True) for x in sorted(self.deps)])
         if len(self.orderdeps) > 0:
-            line += ' || ' + ' '.join([ninja_quote(x, True) for x in self.orderdeps])
+            line += ' || ' + ' '.join([ninja_quote(x, True) for x in sorted(self.orderdeps)])
         line += '\n'
         # This is the only way I could find to make this work on all
         # platforms including Windows command shell. Slash is a dir separator

--- a/mesonbuild/depfile.py
+++ b/mesonbuild/depfile.py
@@ -82,4 +82,4 @@ class DepFile:
         deps.update(target.deps)
         for dep in target.deps:
             deps.update(self.get_all_dependencies(dep, visited))
-        return deps
+        return sorted(deps)

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -823,7 +823,7 @@ The result of this is undefined and will become a hard error in a future Meson r
         elif isinstance(items, dict):
             if len(node.varnames) != 2:
                 raise InvalidArguments('Foreach on dict unpacks key and value')
-            for key, value in items.items():
+            for key, value in sorted(items.items()):
                 self.set_variable(node.varnames[0], key)
                 self.set_variable(node.varnames[1], value)
                 try:
@@ -1166,7 +1166,7 @@ The result of this is undefined and will become a hard error in a future Meson r
         if method_name == 'keys':
             if len(posargs) != 0:
                 raise InterpreterException('keys() takes no arguments.')
-            return list(obj.keys())
+            return sorted(obj.keys())
 
         raise InterpreterException('Dictionaries do not have a method called "%s".' % method_name)
 

--- a/mesonbuild/modules/sourceset.py
+++ b/mesonbuild/modules/sourceset.py
@@ -14,7 +14,7 @@
 
 from collections import namedtuple
 from .. import mesonlib
-from ..mesonlib import listify
+from ..mesonlib import listify, OrderedSet
 from . import ExtensionModule
 from ..interpreterbase import (
     noPosargs, noKwargs, permittedKwargs,
@@ -111,7 +111,7 @@ class SourceSetHolder(MutableInterpreterObject, ObjectHolder):
 
     def collect(self, enabled_fn, all_sources, into=None):
         if not into:
-            into = SourceFiles(set(), set())
+            into = SourceFiles(OrderedSet(), OrderedSet())
         for entry in self.held_object:
             if all(x.found() for x in entry.dependencies) and \
                all(enabled_fn(key) for key in entry.keys):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1187,7 +1187,7 @@ class InternalTests(unittest.TestCase):
         ]:
             d = mesonbuild.depfile.DepFile(f)
             deps = d.get_all_dependencies(target)
-            self.assertEqual(deps, expdeps)
+            self.assertEqual(sorted(deps), sorted(expdeps))
 
     def test_log_once(self):
         f = io.StringIO()


### PR DESCRIPTION
The ordering of elements in sets and of keys in dictionaries cannot be relied upon, because the hash values are randomized by Python.  Whenever the processing of `meson.build` or the operation of the backend is affected by this ordering, random changes in the command line can occur and cause ninja to rebuild a lot of files unnecessarily.

This pull request fixes the instances that affect QEMU, and which were causing about 40% of the build to be repeated after `touch ../meson.build` (most of them due to sourcesets).