### PR TITLE
mtest: only build what is needed for the tests

### DIFF
--- a/docs/markdown/snippets/meson_test_depends.md
+++ b/docs/markdown/snippets/meson_test_depends.md
@@ -1,0 +1,17 @@
+## `meson test` only rebuilds test dependencies
+
+Until now, `meson test` rebuilt the whole project independent of the
+requested tests and their dependencies.  With this release, `meson test`
+will only rebuild what is needed for the tests or suites that will be run.
+This feature can be used, for example, to speed up bisecting regressions
+using commands like the following:
+
+    git bisect start <broken commit> <working commit>
+    git bisect run meson test <failing test name>
+
+This would find the broken commit automatically while at each step
+rebuilding only those pieces of code needed to run the test.
+
+However, this change could cause failures if dependencies are not
+specified correctly in `meson.build`.
+

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -19,7 +19,6 @@ from glob import glob
 from .scripts import depfixer
 from .scripts import destdir_join
 from .mesonlib import is_windows, Popen_safe
-from .mtest import rebuild_all
 from .backend.backends import InstallData
 from .coredata import major_versions_differ, MesonVersionMismatchException
 from .coredata import version as coredata_version
@@ -531,6 +530,23 @@ class Installer:
                         pass
                     else:
                         raise
+
+def rebuild_all(wd: str) -> bool:
+    if not (Path(wd) / 'build.ninja').is_file():
+        print('Only ninja backend is supported to rebuild the project before installation.')
+        return True
+
+    ninja = environment.detect_ninja()
+    if not ninja:
+        print("Can't find ninja, can't rebuild test.")
+        return False
+
+    ret = subprocess.run(ninja + ['-C', wd]).returncode
+    if ret != 0:
+        print('Could not rebuild {}'.format(wd))
+        return False
+
+    return True
 
 def run(opts):
     datafilename = 'meson-private/install.dat'


### PR DESCRIPTION
It is a usual workflow to fix something and retest to see if it is fixed using a particular test.  When tests start to become numerous, it becomes time consuming for "meson test" to relink all of them (and in fact rebuild the whole project) where the user has already specified the tests they want to run, as well as the tests' dependencies.

Teach meson to be smart and only build what is needed for the test (or suite) that were specified.

Fixes: #7473
