### PR TITLE
Add fs.relative_to() function. Closes #2184

### DIFF
--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -243,8 +243,9 @@ fs.relative_to('/prefix/lib/foo', '/prefix')  # 'lib/foo'
   fallback.
 
 - `if_within`: A path. `relative_to(path1, path2, if_within: path3)` returns
-  the relative path of `path1 with respect to `path2` if `path1` is found in `path3`,
-  otherwise it returns `path1` unchanged.
+  the relative path of `path1` with respect to `path2` if `path1` is found in `path3`.
+  Otherwise, if `allow_absolute: True` and `path1` is an absolute path, `path1` is
+  returned. If neither of those conditions are fullfilled an error is raised.
 
 Examples: 
 

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -239,7 +239,8 @@ fs.relative_to('/prefix/lib/foo', '/prefix')  # 'lib/foo'
   following the rules of the build machine (native: `true`) or the host (native: `false`).
 
 - `allow_absolute`: If set to `true`, instead of giving an error, `relative_to()`
-  will return the original path. Useful as a fallback
+  will return the original path. Useful if an absolute path is a reasonable
+  fallback.
 
 - `if_within`: A path. `relative_to(path1, path2, within: path3)` returns
   the relative path of `path1 with respect to `path2` if `path1` is found in `path3`,

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -242,7 +242,7 @@ fs.relative_to('/prefix/lib/foo', '/prefix')  # 'lib/foo'
   will return the original path. Useful if an absolute path is a reasonable
   fallback.
 
-- `if_within`: A path. `relative_to(path1, path2, within: path3)` returns
+- `if_within`: A path. `relative_to(path1, path2, if_within: path3)` returns
   the relative path of `path1 with respect to `path2` if `path1` is found in `path3`,
   otherwise it returns `path1` unchanged.
 

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -220,12 +220,6 @@ fs.stem('foo/bar/baz.dll.a')  # baz.dll
 *since 0.64.0*
 
 Given two paths, returns a version of the first path relative to the second.
-If a path is given as the 'within' argument, the function will return the first path
-unchanged if it is not inside 'within'.
-
-The `relative_to` function is system dependent. It accepts the `native: true` argument
-to compute relative paths on the build system. Otherwise it uses the host system.
-
 
 Examples: 
 
@@ -233,13 +227,36 @@ Examples:
 # On windows:
 fs.relative_to('c:\\proj1\\foo', 'c:\\proj1\\bar')  # '..\\foo'
 fs.relative_to('c:\\proj1\\foo', 'd:\\proj1\\bar')  # ERROR, since the relative path does not exist
-fs.relative_to('c:\\proj1\\foo', 'd:\\proj1\\bar', within: 'd:\\')  # 'c:\\proj1\\foo', within allows to get an absolute path
 
 # On other systems:
 fs.relative_to('/prefix/lib', '/prefix/bin')  # '../lib'
 fs.relative_to('/prefix/lib/foo', '/prefix')  # 'lib/foo'
-fs.relative_to('/usr/lib/foo', '/usr/bin', within: '/usr')  # '../lib/foo'
-fs.relative_to('/usr/lib/foo', '/usr/bin', within: '/var')  # '/usr/lib/foo'
+```
+
+`relative_to` has some optional keyword arguments:
+
+- `native`: Can be set to `true` or `false`. Whether the relative paths are computed
+  following the rules of the build machine (native: `true`) or the host (native: `false`).
+
+- `allow_absolute`: If set to `true`, instead of giving an error, `relative_to()`
+  will return the original path. Useful as a fallback
+
+- `if_within`: A path. `relative_to(path1, path2, within: path3)` returns
+  the relative path of `path1 with respect to `path2` if `path1` is found in `path3`,
+  otherwise it returns `path1` unchanged.
+
+Examples: 
+
+```meson
+# On windows:
+fs.relative_to('c:\\proj1\\foo', 'c:\\proj2\\bar', if_within: 'c:\\proj2')  # ERROR, the relative path is outside the "within" argument
+fs.relative_to('c:\\proj1\\foo', 'c:\\proj2\\bar', if_within: 'c:\\proj2', allow_absolute: true)  # 'c:\\proj1\\foo'
+fs.relative_to('c:\\proj1\\foo', 'd:\\proj1\\bar', allow_absolute: true)  # 'c:\\proj1\\foo'
+
+# On other systems:
+fs.relative_to('/project1/lib/foo', '/usr/bin', if_within: '/usr')  # ERROR: '/project1/lib/foo' not in '/usr'
+fs.relative_to('/project1/lib/foo', '/usr/bin', if_within: '/usr', allow_absolute: 'true')  # '/project1/lib/foo'
+fs.relative_to('/usr/lib/foo', '/usr/bin', if_within: '/usr')  # '../lib/foo'
 ```
 
 

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -204,7 +204,6 @@ suffix
 fs.stem('foo/bar/baz.dll')  # baz
 fs.stem('foo/bar/baz.dll.a')  # baz.dll
 ```
-
 ### read
 - `read(path, encoding: 'utf-8')` *(since 0.57.0)*:
    return a [string](Syntax.md#strings) with the contents of the given `path`.
@@ -215,6 +214,21 @@ fs.stem('foo/bar/baz.dll.a')  # baz.dll
    specified by `path` changes, this will trigger Meson to reconfigure the
    project. If the file specified by `path` is a `files()` object it
    cannot refer to a built file.
+
+### relative_to
+
+*since 0.64.0*
+
+Given two absolute paths, returns a version of the first path relative to the second.
+If a path is given as the 'within' argument is specified, the function will return the
+first path unchanged if it is not inside 'within'.
+
+```meson
+fs.relative_to('/prefix/lib', '/prefix/bin')  # '../lib'
+fs.relative_to('/prefix/lib/foo', '/prefix')  # 'lib/foo'
+fs.relative_to('/usr/lib/foo', '/usr/bin', within: '/usr')  # '../lib/foo'
+fs.relative_to('/usr/lib/foo', '/usr/bin', within: '/var')  # '/usr/lib/foo'
+```
 
 
 ### copyfile

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -219,7 +219,7 @@ fs.stem('foo/bar/baz.dll.a')  # baz.dll
 
 *since 0.64.0*
 
-Given two absolute paths, returns a version of the first path relative to the second.
+Given two paths, returns a version of the first path relative to the second.
 If a path is given as the 'within' argument, the function will return the first path
 unchanged if it is not inside 'within'.
 

--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -220,10 +220,22 @@ fs.stem('foo/bar/baz.dll.a')  # baz.dll
 *since 0.64.0*
 
 Given two absolute paths, returns a version of the first path relative to the second.
-If a path is given as the 'within' argument is specified, the function will return the
-first path unchanged if it is not inside 'within'.
+If a path is given as the 'within' argument, the function will return the first path
+unchanged if it is not inside 'within'.
+
+The `relative_to` function is system dependent. It accepts the `native: true` argument
+to compute relative paths on the build system. Otherwise it uses the host system.
+
+
+Examples: 
 
 ```meson
+# On windows:
+fs.relative_to('c:\\proj1\\foo', 'c:\\proj1\\bar')  # '..\\foo'
+fs.relative_to('c:\\proj1\\foo', 'd:\\proj1\\bar')  # ERROR, since the relative path does not exist
+fs.relative_to('c:\\proj1\\foo', 'd:\\proj1\\bar', within: 'd:\\')  # 'c:\\proj1\\foo', within allows to get an absolute path
+
+# On other systems:
 fs.relative_to('/prefix/lib', '/prefix/bin')  # '../lib'
 fs.relative_to('/prefix/lib/foo', '/prefix')  # 'lib/foo'
 fs.relative_to('/usr/lib/foo', '/usr/bin', within: '/usr')  # '../lib/foo'

--- a/docs/markdown/snippets/fs-relative-to.md
+++ b/docs/markdown/snippets/fs-relative-to.md
@@ -1,0 +1,10 @@
+## Add fs.relative_to function to get a path relative to another path
+
+Finding what is the path to a directory relative to another directory is now possible.
+For instance to find the path to `/foo/lib` as if we were in `/foo/bin` we now can use:
+
+```meson
+fs = import('fs')
+fs.relative_to('/foo/lib', '/foo/bin')` #  '../lib'
+```
+

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -140,7 +140,8 @@ class FSModule(ExtensionModule):
         `native` controls whether paths use rules in the host or build environment
         `allow_absolute` will return the original path instead of returning an error when the relative path can't be computed
         `if_within` a third optional path. When it is given, if the path is within `if_within`, then the relative path is
-        computed as usual, however if it is not then the original path is returned
+        computed as usual. Otherwise, if `allow_absolute: True` and the first argument is an absolute path, the first 
+        argument is returned. If neither of those conditions are fullfilled an error is raised.
         """
         if len(args) != 2:
             raise MesonException('fs.relative_to takes two arguments and optionally a "within" and a "native" argument.')

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -146,23 +146,15 @@ class FSModule(ExtensionModule):
             path_class = PureWindowsPath  # type: T.Union[T.Type[PurePosixPath], T.Type[PureWindowsPath]]
         else:
             path_class = PurePosixPath
-        
         path_to = path_class(args[0])
-        if not path_to.is_absolute():
-            raise MesonException(f'The first argument ({path_to}) must be an absolute path.')
         path_from = path_class(args[1])
-        if not path_from.is_absolute():
-            raise MesonException(f'The second argument ({path_from}) must be an absolute path.')
         if "within" in kwargs:
             path_within = path_class(kwargs["within"])
-            if not path_within.is_absolute():
-                raise MesonException('The "within" argument ({path_within}) must be an absolute path.')
             # Return path_to if it is not relative to path_within
             try:
                 path_to.relative_to(path_within)
             except ValueError:
                 return ModuleReturnValue(str(path_to), [])
-        # If path_to starts with path_from, then .relative_to() provides a solution:
         try:
             x = os.path.relpath(path_to, path_from).replace('\\', '/')
         except ValueError:

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -164,31 +164,13 @@ class FSModule(ExtensionModule):
                 return ModuleReturnValue(str(path_to), [])
         # If path_to starts with path_from, then .relative_to() provides a solution:
         try:
-            x = path_to.relative_to(path_from)
+            x = os.path.relpath(path_to, path_from).replace('\\', '/')
         except ValueError:
-            pass
+            raise MesonException(f"{path_to} and {path_from} do not have a common root " +
+                                  "or one is absolute and the other one is relative." +
+                                 "Use the \"within\" argument if you want an absolute path instead of an error.")
         else:
             return ModuleReturnValue(str(x), [])
-
-        # Get the common root between the two paths:
-        parts_to = path_to.parts
-        parts_from = path_from.parts
-        if parts_to[0] != parts_from[0]:
-            raise MesonException(f"{path_to} and {path_from} do not have a common root." +
-                                 "Use the \"within\" argument if you want an absolute path instead of an error.")
-        parts_root = []
-        for part_to, part_from in zip(parts_to, parts_from):
-            if part_to != part_from:
-                break
-            parts_root.append(part_to)
-        root = path_class(parts_root[0]) / path_class("/".join(parts_root[1:]))
-
-        # Then find how many levels do we need to go from path_from to the root:
-        num_levels = len(path_from.parts) - len(root.parts)
-        # And build the final path, going from path_from to the root and then to path_to:
-        path = path_class("/".join(num_levels*['..'])) / path_to.relative_to(root)
-        return ModuleReturnValue(str(path), [])
-
 
     @stringArgs
     @noKwargs

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -131,9 +131,9 @@ class FSModule(ExtensionModule):
         'fs.relative_to',
         KwargInfo('native', bool, default=False),
         KwargInfo('allow_absolute', bool, default=False),
-        KwargInfo('if_within', (T.Optional[str], File)),
+        KwargInfo('if_within', (str, File, NoneType)),
     )
-    def relative_to(self, state: 'ModuleState', args: T.Sequence[str], kwargs: dict) -> ModuleReturnValue:
+    def relative_to(self, state: 'ModuleState', args: T.Sequence[str], kwargs: T.Dict[str, T.Any]) -> ModuleReturnValue:
         """
         this function returns a version of the path given by the first argument relative to
         the path given in the second argument.

--- a/test cases/common/260 relpath/meson.build
+++ b/test cases/common/260 relpath/meson.build
@@ -1,0 +1,12 @@
+project('relpath', 'c')
+
+fs = import('fs')
+
+assert(fs.relative_to('/prefix/lib/foo', '/prefix') == 'lib/foo', 'Path inside source is broken')
+assert(fs.relative_to('/prefix/lib', '/prefix/bin') == '../lib', 'Path with common prefix with source is broken')
+assert(fs.relative_to('/usr/lib/foo', '/usr/bin') == '../lib/foo', 'Path with common prefix with source is broken')
+
+assert(fs.relative_to('/usr/lib/foo', '/usr/bin', within: '/usr') == '../lib/foo', 'Path with common prefix with source within "within" is broken')
+assert(fs.relative_to('/usr/lib/foo', '/usr/bin', within: '/var') == '/usr/lib/foo', 'Path with common prefix with source outside "within" is broken')
+
+

--- a/test cases/common/260 relpath/meson.build
+++ b/test cases/common/260 relpath/meson.build
@@ -4,13 +4,16 @@ fs = import('fs')
 
 if host_machine.system() == 'windows'
   assert(fs.relative_to('c:\\proj1\\foo', 'c:\\proj1\\bar') == '..\\foo', 'Path with windows common prefix is broken')
-  assert(fs.relative_to('c:\\proj1\\foo', 'd:\\proj1\\bar', within: 'd:\\') == 'c:\\proj1\\foo', 'windows path source outside "within" is broken')
+  #expect_error(fs.relative_to('c:\\proj1\\foo', 'd:\\proj1\\bar') == 'c:\\proj1\\foo', 'Error was expected because relative path does not exist')
+  #expect_error(fs.relative_to('c:\\proj1\\foo', 'c:\\proj2\\bar', if_within: 'c:\\proj2'), 'Error expected, path1 is outside `if_within`)
+  assert(fs.relative_to('c:\\proj1\\foo', 'd:\\proj1\\bar', allow_absolute: true) == 'c:\\proj1\\foo', 'Path falls back if allow absolute is true')
+  assert(fs.relative_to('c:\\proj1\\foo', 'c:\\proj2\\bar', if_within: 'c:\\proj2', allow_absolute: true) == 'c:\\proj1\\foo', 'Path falls back to path1 if allow_absolute is True')
 else
   assert(fs.relative_to('/prefix/lib/foo', '/prefix') == 'lib/foo', 'Path inside source is broken')
   assert(fs.relative_to('/prefix/lib', '/prefix/bin') == '../lib', 'Path with common prefix with source is broken')
   assert(fs.relative_to('/usr/lib/foo', '/usr/bin') == '../lib/foo', 'Path with common prefix with source is broken')
-
-  assert(fs.relative_to('/usr/lib/foo', '/usr/bin', within: '/usr') == '../lib/foo', 'Path with common prefix with source within "within" is broken')
-  assert(fs.relative_to('/usr/lib/foo', '/usr/bin', within: '/var') == '/usr/lib/foo', 'Path with common prefix with source outside "within" is broken')
+  assert(fs.relative_to('/usr/lib/foo', '/usr/bin', if_within: '/usr') == '../lib/foo', 'Path with common prefix using `if_within` is broken')
+  #expect_error(fs.relative_to('/project1/lib/foo', '/usr/bin', if_within: '/usr'), 'Expected error because /project1 is not in /usr')  
+  assert(fs.relative_to('/project1/lib/foo', '/usr/bin', if_within: '/usr', allow_absolute: true) == '/project1/lib/foo', 'Expected path1 because allow_absolute is true')
 endif
 

--- a/test cases/common/260 relpath/meson.build
+++ b/test cases/common/260 relpath/meson.build
@@ -1,12 +1,16 @@
-project('relpath', 'c')
+project('relpath', [])
 
 fs = import('fs')
 
-assert(fs.relative_to('/prefix/lib/foo', '/prefix') == 'lib/foo', 'Path inside source is broken')
-assert(fs.relative_to('/prefix/lib', '/prefix/bin') == '../lib', 'Path with common prefix with source is broken')
-assert(fs.relative_to('/usr/lib/foo', '/usr/bin') == '../lib/foo', 'Path with common prefix with source is broken')
+if host_machine.system() == 'windows'
+  assert(fs.relative_to('c:\\proj1\\foo', 'c:\\proj1\\bar') == '..\\foo', 'Path with windows common prefix is broken')
+  assert(fs.relative_to('c:\\proj1\\foo', 'd:\\proj1\\bar', within: 'd:\\') == 'c:\\proj1\\foo', 'windows path source outside "within" is broken')
+else
+  assert(fs.relative_to('/prefix/lib/foo', '/prefix') == 'lib/foo', 'Path inside source is broken')
+  assert(fs.relative_to('/prefix/lib', '/prefix/bin') == '../lib', 'Path with common prefix with source is broken')
+  assert(fs.relative_to('/usr/lib/foo', '/usr/bin') == '../lib/foo', 'Path with common prefix with source is broken')
 
-assert(fs.relative_to('/usr/lib/foo', '/usr/bin', within: '/usr') == '../lib/foo', 'Path with common prefix with source within "within" is broken')
-assert(fs.relative_to('/usr/lib/foo', '/usr/bin', within: '/var') == '/usr/lib/foo', 'Path with common prefix with source outside "within" is broken')
-
+  assert(fs.relative_to('/usr/lib/foo', '/usr/bin', within: '/usr') == '../lib/foo', 'Path with common prefix with source within "within" is broken')
+  assert(fs.relative_to('/usr/lib/foo', '/usr/bin', within: '/var') == '/usr/lib/foo', 'Path with common prefix with source outside "within" is broken')
+endif
 

--- a/unittests/failuretests.py
+++ b/unittests/failuretests.py
@@ -390,3 +390,31 @@ class FailureTests(BasePlatformTests):
     def test_error_func(self):
         self.assertMesonRaises("error('a', 'b', ['c', ['d', {'e': 'f'}]], 'g')",
                                r"Problem encountered: a b \['c', \['d', {'e' : 'f'}\]\] g")
+
+    @unittest.skipIf(is_windows(), 'Windows is not POSIX')
+    def test_posix_relative_to_errors(self):
+        self.assertMesonRaises(
+            """
+            fs = import('fs')
+            fs.relative_to('/project1/lib/foo', '/usr/bin', if_within: '/usr')
+            """,
+            '/project1/lib/foo is not within /usr.*'
+        )
+
+    @unittest.skipIf(not is_windows(), 'POSIX is not Windows')
+    def test_windows_relative_to_errors(self):
+        self.assertMesonRaises(
+            """
+            fs = import('fs')
+            fs.relative_to('c:\\proj1\\foo', 'd:\\proj1\\bar')
+            """,
+            'c:\\proj1\\foo and d:\\proj1\\bar do not have a common root.*'
+        )
+        self.assertMesonRaises(
+            """
+            fs = import('fs')
+            fs.relative_to('c:\\proj1\\foo', 'c:\\proj2\\bar', if_within: 'c:\\proj2')
+            """,
+            'c:\\proj1\\foo is not within c:\\proj2.*'
+        )
+


### PR DESCRIPTION
The usefulness of a `rel_path()` function has been discussed on #2184.

I have a personal project where a binary installed at `$prefix/$bindir` would look for a file on `$prefix/$datadir/subdirectory`. With `rel_path()` I can compute `/../share/subdirectory` or whatever it is the path to `$prefix/$datadir/subdirectory` from `$prefix/$bindir` and pass that as a  `#define` variable to the `executable()`, avoiding hardcoding the prefix.