### PR TITLE
gnome: Tweak error message

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -487,7 +487,8 @@ class GnomeModule(ExtensionModule):
                     depends += [inc]
                 else:
                     raise MesonException(
-                        'Gir includes must be str, GirTarget, or list of them')
+                        'Gir includes must be str, GirTarget, or list of them. '
+                        'Got %s.' % type(inc).__name__)
 
         return ret
 


### PR DESCRIPTION
It's an easy mistake to do this:

    gir1 = gnome.generate_gir(...)
    gir2 = gnome.generate_gir(...
        includes: ['GObject-2.0', gir1])

This fails with an error:

    ERROR: Gir includes must be str, GirTarget, or list of them.

The issue is that the 'gir1[0]' should be passed instead of 'gir1'.
To make the problem slightly clearly, tweak the error message to be:

    ERROR: Gir includes must be str, GirTarget, or list of them. Got TypelibTarget.