### PR TITLE
gnome: Handle libraries that are not in the current build dir

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -554,15 +554,16 @@ class GnomeModule(ExtensionModule):
             else:
                 # Because of https://gitlab.gnome.org/GNOME/gobject-introspection/merge_requests/72
                 # we can't use the full path until this is merged.
+                libpath = os.path.join(girtarget.get_subdir(), girtarget.get_filename())
                 if isinstance(girtarget, build.SharedLibrary):
+                    # need to put our output directory first as we need to use the
+                    # generated libraries instead of any possibly installed system/prefix
+                    # ones.
+                    ret += ["-L@BUILD_ROOT@/{}".format(os.path.dirname(libpath))]
                     libname = girtarget.get_basename()
                 else:
-                    libname = os.path.join("@PRIVATE_OUTDIR_ABS_%s@" % girtarget.get_id(), girtarget.get_filename())
+                    libname = os.path.join("@BUILD_ROOT@/{}".format(libpath))
                 ret += ['--library', libname]
-                # need to put our output directory first as we need to use the
-                # generated libraries instead of any possibly installed system/prefix
-                # ones.
-                ret += ["-L@PRIVATE_OUTDIR_ABS_%s@" % girtarget.get_id()]
                 # Needed for the following binutils bug:
                 # https://github.com/mesonbuild/meson/issues/1911
                 # However, g-ir-scanner does not understand -Wl,-rpath

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -870,6 +870,10 @@ def skippable(suite, test):
     if test.endswith('15 llvm'):
         return True
 
+    # This test breaks with gobject-introspection <= 1.58.1
+    if test.endswith('34 gir static lib'):
+        return True
+
     # No frameworks test should be skipped on linux CI, as we expect all
     # prerequisites to be installed
     if mesonlib.is_linux():

--- a/test cases/frameworks/34 gir static lib/meson.build
+++ b/test cases/frameworks/34 gir static lib/meson.build
@@ -1,0 +1,18 @@
+project('gobject-introspection-static-helper', 'c')
+
+gir = find_program('g-ir-scanner', required: false)
+if not gir.found()
+  error('MESON_SKIP_TEST g-ir-scanner not found.')
+endif
+
+gobject_introspection = dependency('gobject-introspection-1.0')
+# This won't work without https://gitlab.gnome.org/GNOME/gobject-introspection/merge_requests/72
+if gobject_introspection.version().version_compare('< 1.58.1')
+  error('MESON_SKIP_TEST gobject-introspection is too old to support static libraries')
+endif
+
+gnome = import('gnome')
+gobj = dependency('gobject-2.0')
+
+subdir('statichelper')
+subdir('subdir/gir')

--- a/test cases/frameworks/34 gir static lib/statichelper/meson-sample.c
+++ b/test cases/frameworks/34 gir static lib/statichelper/meson-sample.c
@@ -1,0 +1,126 @@
+#include "meson-sample.h"
+
+typedef struct _MesonSamplePrivate
+{
+  gchar *msg;
+} MesonSamplePrivate;
+
+
+G_DEFINE_TYPE_WITH_PRIVATE (MesonSample, meson_sample, G_TYPE_OBJECT)
+
+enum {
+  PROP_0,
+  PROP_MSG,
+  LAST_PROP
+};
+
+static GParamSpec *gParamSpecs [LAST_PROP];
+
+/**
+ * meson_sample_new:
+ * @msg: The message to set.
+ *
+ * Allocates a new #MesonSample.
+ *
+ * Returns: (transfer full): a #MesonSample.
+ */
+MesonSample *
+meson_sample_new (const gchar *msg)
+{
+  g_return_val_if_fail (msg != NULL, NULL);
+
+  return g_object_new (MESON_TYPE_SAMPLE,
+                       "message", msg,
+                       NULL);
+}
+
+static void
+meson_sample_finalize (GObject *object)
+{
+  MesonSamplePrivate *priv = meson_sample_get_instance_private ((MesonSample *) object);
+
+  g_clear_pointer (&priv->msg, g_free);
+
+  G_OBJECT_CLASS (meson_sample_parent_class)->finalize (object);
+}
+
+static void
+meson_sample_get_property (GObject    *object,
+                           guint       prop_id,
+                           GValue     *value,
+                           GParamSpec *pspec)
+{
+  MesonSamplePrivate *priv = meson_sample_get_instance_private ((MesonSample *) object);
+
+  switch (prop_id)
+    {
+    case PROP_MSG:
+      g_value_set_string (value, priv->msg);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+meson_sample_set_property (GObject      *object,
+                           guint         prop_id,
+                           const GValue *value,
+                           GParamSpec   *pspec)
+{
+  MesonSamplePrivate *priv = meson_sample_get_instance_private ((MesonSample *) object);
+
+  switch (prop_id)
+    {
+    case PROP_MSG:
+      priv->msg = g_value_dup_string (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+meson_sample_class_init (MesonSampleClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = meson_sample_finalize;
+  object_class->get_property = meson_sample_get_property;
+  object_class->set_property = meson_sample_set_property;
+
+  gParamSpecs [PROP_MSG] =
+    g_param_spec_string ("message",
+                         "Message",
+                         "The message to print.",
+                         NULL,
+                         (G_PARAM_READWRITE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_properties (object_class, LAST_PROP, gParamSpecs);
+}
+
+static void
+meson_sample_init (MesonSample *self)
+{
+}
+
+/**
+ * meson_sample_print_message:
+ * @self: a #MesonSample.
+ *
+ * Prints the message.
+ *
+ */
+void
+meson_sample_print_message (MesonSample *self)
+{
+  MesonSamplePrivate *priv;
+
+  g_return_if_fail (MESON_IS_SAMPLE (self));
+
+  priv = meson_sample_get_instance_private (self);
+
+  g_print ("Message: %s\n", priv->msg);
+}

--- a/test cases/frameworks/34 gir static lib/statichelper/meson-sample.h.in
+++ b/test cases/frameworks/34 gir static lib/statichelper/meson-sample.h.in
@@ -1,0 +1,22 @@
+#ifndef MESON_SAMPLE_H
+#define MESON_SAMPLE_H
+
+#include <@HEADER@>
+
+G_BEGIN_DECLS
+
+#define MESON_TYPE_SAMPLE (meson_sample_get_type())
+
+G_DECLARE_DERIVABLE_TYPE (MesonSample, meson_sample, MESON, SAMPLE, GObject)
+
+struct _MesonSampleClass {
+    GObjectClass parent_class;
+};
+
+
+MesonSample *meson_sample_new           (const gchar *msg);
+void         meson_sample_print_message (MesonSample *self);
+
+G_END_DECLS
+
+#endif /* MESON_SAMPLE_H */

--- a/test cases/frameworks/34 gir static lib/statichelper/meson.build
+++ b/test cases/frameworks/34 gir static lib/statichelper/meson.build
@@ -1,0 +1,22 @@
+conf = configuration_data()
+conf.set('HEADER', 'glib-object.h')
+
+meson_sample_header = configure_file(
+  input : 'meson-sample.h.in',
+  output : 'meson-sample.h',
+  configuration : conf)
+
+statichelper_sources = files('meson-sample.c') + [meson_sample_header]
+
+statichelper_lib = static_library(
+  'statichelper',
+  sources : statichelper_sources,
+  dependencies : gobj,
+)
+
+statichelper_inc = include_directories('.')
+statichelper_dep = declare_dependency(
+  link_with: statichelper_lib,
+  dependencies : gobj,
+  include_directories : [statichelper_inc],
+)

--- a/test cases/frameworks/34 gir static lib/subdir/gir/meson-subsample.c
+++ b/test cases/frameworks/34 gir static lib/subdir/gir/meson-subsample.c
@@ -1,0 +1,124 @@
+#include "meson-subsample.h"
+
+struct _MesonSubSample
+{
+  MesonSample parent_instance;
+
+  gchar *msg;
+};
+
+G_DEFINE_TYPE (MesonSubSample, meson_sub_sample, MESON_TYPE_SAMPLE)
+
+enum {
+  PROP_0,
+  PROP_MSG,
+  LAST_PROP
+};
+
+static GParamSpec *gParamSpecs [LAST_PROP];
+
+/**
+ * meson_sub_sample_new:
+ * @msg: The message to set.
+ *
+ * Allocates a new #MesonSubSample.
+ *
+ * Returns: (transfer full): a #MesonSubSample.
+ */
+MesonSubSample *
+meson_sub_sample_new (const gchar *msg)
+{
+  g_return_val_if_fail (msg != NULL, NULL);
+
+  return g_object_new (MESON_TYPE_SUB_SAMPLE,
+                       "message", msg,
+                       NULL);
+}
+
+static void
+meson_sub_sample_finalize (GObject *object)
+{
+  MesonSubSample *self = (MesonSubSample *)object;
+
+  g_clear_pointer (&self->msg, g_free);
+
+  G_OBJECT_CLASS (meson_sub_sample_parent_class)->finalize (object);
+}
+
+static void
+meson_sub_sample_get_property (GObject    *object,
+                           guint       prop_id,
+                           GValue     *value,
+                           GParamSpec *pspec)
+{
+  MesonSubSample *self = MESON_SUB_SAMPLE (object);
+
+  switch (prop_id)
+    {
+    case PROP_MSG:
+      g_value_set_string (value, self->msg);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+meson_sub_sample_set_property (GObject      *object,
+                           guint         prop_id,
+                           const GValue *value,
+                           GParamSpec   *pspec)
+{
+  MesonSubSample *self = MESON_SUB_SAMPLE (object);
+
+  switch (prop_id)
+    {
+    case PROP_MSG:
+      self->msg = g_value_dup_string (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+meson_sub_sample_class_init (MesonSubSampleClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = meson_sub_sample_finalize;
+  object_class->get_property = meson_sub_sample_get_property;
+  object_class->set_property = meson_sub_sample_set_property;
+
+  gParamSpecs [PROP_MSG] =
+    g_param_spec_string ("message",
+                         "Message",
+                         "The message to print.",
+                         NULL,
+                         (G_PARAM_READWRITE |
+                          G_PARAM_CONSTRUCT_ONLY |
+                          G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_properties (object_class, LAST_PROP, gParamSpecs);
+}
+
+static void
+meson_sub_sample_init (MesonSubSample *self)
+{
+}
+
+/**
+ * meson_sub_sample_print_message:
+ * @self: a #MesonSubSample.
+ *
+ * Prints the message.
+ *
+ * Returns: Nothing.
+ */
+void
+meson_sub_sample_print_message (MesonSubSample *self)
+{
+  g_return_if_fail (MESON_IS_SUB_SAMPLE (self));
+
+  g_print ("Message: %s\n", self->msg);
+}

--- a/test cases/frameworks/34 gir static lib/subdir/gir/meson-subsample.h
+++ b/test cases/frameworks/34 gir static lib/subdir/gir/meson-subsample.h
@@ -1,0 +1,17 @@
+#ifndef MESON_SUB_SAMPLE_H
+#define MESON_SUB_SAMPLE_H
+
+#include <glib-object.h>
+#include <meson-sample.h>
+
+G_BEGIN_DECLS
+
+#define MESON_TYPE_SUB_SAMPLE (meson_sub_sample_get_type())
+
+G_DECLARE_FINAL_TYPE (MesonSubSample, meson_sub_sample, MESON, SUB_SAMPLE, MesonSample)
+
+MesonSubSample *meson_sub_sample_new           (const gchar *msg);
+
+G_END_DECLS
+
+#endif /* MESON_SUB_SAMPLE_H */

--- a/test cases/frameworks/34 gir static lib/subdir/gir/meson.build
+++ b/test cases/frameworks/34 gir static lib/subdir/gir/meson.build
@@ -1,0 +1,28 @@
+libsources = ['meson-subsample.c', 'meson-subsample.h']
+
+girlib = shared_library(
+  'girlib',
+  sources : libsources,
+  dependencies : [gobj, statichelper_dep],
+  install : true
+)
+
+girexe = executable(
+  'girprog',
+  sources : 'prog.c',
+  dependencies : [gobj, statichelper_dep],
+  link_with : girlib
+)
+
+gnome.generate_gir(
+  girlib, statichelper_lib,
+  sources : [ libsources, statichelper_sources ],
+  nsversion : '1.0',
+  namespace : 'Meson',
+  symbol_prefix : 'meson_',
+  identifier_prefix : 'Meson',
+  includes : ['GObject-2.0'],
+  install : true
+)
+
+test('gobject introspection/subproject/c', girexe)

--- a/test cases/frameworks/34 gir static lib/subdir/gir/prog.c
+++ b/test cases/frameworks/34 gir static lib/subdir/gir/prog.c
@@ -1,0 +1,12 @@
+#include "meson-subsample.h"
+
+gint
+main (gint   argc,
+      gchar *argv[])
+{
+  MesonSample * i = (MesonSample*) meson_sub_sample_new ("Hello, sub/meson/c!");
+  meson_sample_print_message (i);
+  g_object_unref (i);
+
+  return 0;
+}

--- a/test cases/frameworks/34 gir static lib/test.json
+++ b/test cases/frameworks/34 gir static lib/test.json
@@ -1,0 +1,8 @@
+{
+  "installed": [
+    {"type": "file", "file": "usr/lib/girepository-1.0/Meson-1.0.typelib"},
+    {"type": "expr", "file": "usr/lib/?libgirlib.so"},
+    {"type": "file", "platform": "cygwin", "file": "usr/lib/libgirlib.dll.a"},
+    {"type": "file", "file": "usr/share/gir-1.0/Meson-1.0.gir"}
+  ]
+}


### PR DESCRIPTION
The generate_gir() function previously assumed all library
inputs were in the current build dir. This would fail if they
weren't.

My particular use case for this fix was porting Rhythmbox to Meson. (https://gitlab.gnome.org/GNOME/rhythmbox/-/merge_requests/86). The original build system generates GIR files in the `./bindings/gi` subdir, separately from the actual library files. That doesn't work with Meson. I can work around this by building GIR files along with the libraries but ... I don't see a reason that the other approach should be broken.