### PR TITLE
Feature/extend string checks with isupper islower functions

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2058,6 +2058,10 @@ are immutable, all operations return their results as a new string.
 
 - `to_upper()`: creates an upper case version of the string.
 
+- `is_lower()`: returns true if all characters in the string are lowercase.
+
+- `is_upper()`: returns true if all characters in the string are uppercase.
+
 - `underscorify()`: creates a string where every non-alphabetical
   non-number character is replaced with `_`.
 

--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -202,6 +202,14 @@ upper = target.to_upper() # t now has the value 'X86_FREEBSD'
 lower = target.to_lower() # t now has the value 'x86_freebsd'
 ```
 
+#### .is_upper(), .is_lower()
+
+```meson
+target = 'x86_freebsd'
+upper = target.is_upper() # boolean value 'false'
+lower = target.is_lower() # boolean value 'true'
+```
+
 #### .to_int()
 
 ```meson

--- a/docs/markdown/snippets/additional_string_checks.md
+++ b/docs/markdown/snippets/additional_string_checks.md
@@ -1,0 +1,4 @@
+## Additional checks for strings
+
+Strings can now be checked if they contain only uppercase or only lowercase
+letterss

--- a/docs/markdown/snippets/additional_string_checks.md
+++ b/docs/markdown/snippets/additional_string_checks.md
@@ -1,4 +1,4 @@
 ## Additional checks for strings
 
 Strings can now be checked if they contain only uppercase or only lowercase
-letterss
+letters

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -1019,6 +1019,10 @@ The result of this is undefined and will become a hard error in a future Meson r
             return obj.upper()
         elif method_name == 'to_lower':
             return obj.lower()
+        elif method_name == 'is_upper':
+            return obj.isupper()
+        elif method_name == 'is_lower':
+            return obj.islower()
         elif method_name == 'underscorify':
             return re.sub(r'[^a-zA-Z0-9]', '_', obj)
         elif method_name == 'split':

--- a/test cases/common/38 string operations/meson.build
+++ b/test cases/common/38 string operations/meson.build
@@ -39,6 +39,14 @@ assert(long.to_upper() == 'ABCDE', 'Broken to_upper')
 
 assert(long.to_upper().to_lower() == long, 'Broken to_lower')
 
+assert(long.is_lower(), 'Broken is_lower')
+
+assert(not long.to_upper().is_lower(), 'Broken is_lower')
+
+assert(long.to_upper().is_upper(), 'Broken is_upper')
+
+assert(not long.to_lower().is_upper(), 'Broken is_upper')
+
 assert('struct stat.st_foo'.underscorify() == 'struct_stat_st_foo', 'Broken underscorify')
 
 assert('#include <foo/bar.h>'.underscorify() == '_include__foo_bar_h_', 'Broken underscorify')
@@ -71,7 +79,7 @@ assert(version_number.version_compare('<2.0'), 'Version_compare major less broke
 assert(version_number.version_compare('>0.9'), 'Version_compare major greater broken')
 
 assert(' spaces	tabs	'.strip() == 'spaces	tabs', 'Spaces and tabs badly stripped')
-assert(''' 
+assert('''
 multiline string	'''.strip() == '''multiline string''', 'Newlines badly stripped')
 assert('"1.1.20"'.strip('"') == '1.1.20', '" badly stripped')
 assert('"1.1.20"'.strip('".') == '1.1.20', '". badly stripped')


### PR DESCRIPTION
As functions to convert strings to either upper or lower cases exist, there should also be a function to check whether a string is actually upper or lower case, as it is available in python.