### PR TITLE
Fix #5492

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -970,9 +970,9 @@ def write_cmd_line_file(build_dir: str, options: argparse.Namespace) -> None:
 
     properties = OrderedDict()
     if options.cross_file:
-        properties['cross_file'] = options.cross_file
+        properties['cross_file'] = list(map(os.path.abspath, options.cross_file))
     if options.native_file:
-        properties['native_file'] = options.native_file
+        properties['native_file'] = list(map(os.path.abspath, options.native_file))
 
     config['options'] = cmd_line_options_to_string(options)
     config['properties'] = properties

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -970,9 +970,9 @@ def write_cmd_line_file(build_dir: str, options: argparse.Namespace) -> None:
 
     properties = OrderedDict()
     if options.cross_file:
-        properties['cross_file'] = list(map(os.path.abspath, options.cross_file))
+        properties['cross_file'] = [os.path.abspath(f) for f in options.cross_file]
     if options.native_file:
-        properties['native_file'] = list(map(os.path.abspath, options.native_file))
+        properties['native_file'] = [os.path.abspath(f) for f in options.native_file]
 
     config['options'] = cmd_line_options_to_string(options)
     config['properties'] = properties

--- a/mesonbuild/scripts/scanbuild.py
+++ b/mesonbuild/scripts/scanbuild.py
@@ -34,10 +34,11 @@ def scanbuild(exelist: T.List[str], srcdir: Path, blddir: Path, privdir: Path, l
 
 def run(args: T.List[str]) -> int:
     srcdir = Path(args[0])
-    blddir = Path(args[1])
+    bldpath = Path(args[1])
+    blddir = args[1]
     meson_cmd = args[2:]
-    privdir = blddir / 'meson-private'
-    logdir = blddir / 'meson-logs' / 'scanbuild'
+    privdir = bldpath / 'meson-private'
+    logdir = bldpath / 'meson-logs' / 'scanbuild'
     shutil.rmtree(str(logdir), ignore_errors=True)
 
     # if any cross or native files are specified we should use them
@@ -56,4 +57,4 @@ def run(args: T.List[str]) -> int:
         print('Could not execute scan-build "%s"' % ' '.join(exelist))
         return 1
 
-    return scanbuild(exelist, srcdir, blddir, privdir, logdir, meson_cmd)
+    return scanbuild(exelist, srcdir, bldpath, privdir, logdir, meson_cmd)

--- a/mesonbuild/scripts/scanbuild.py
+++ b/mesonbuild/scripts/scanbuild.py
@@ -21,7 +21,6 @@ from pathlib import Path
 import typing as T
 from ast import literal_eval
 import os
-import argparse
 
 def scanbuild(exelist: T.List[str], srcdir: Path, blddir: Path, privdir: Path, logdir: Path, args: T.List[str]) -> int:
     with tempfile.TemporaryDirectory(dir=str(privdir)) as scandir:


### PR DESCRIPTION
Fixes #5492 by storing the absolute paths to all cross and native files in `meson-private/cmd_line.txt` and then adding those to the temporary meson dir when executing a scan-build.