### PR TITLE
Interpreter: Fix nested subsubproject detection

### DIFF
--- a/test cases/common/99 subproject subdir/subprojects/sub_implicit/subprojects/subsub/foo.h
+++ b/test cases/common/99 subproject subdir/subprojects/sub_implicit/subprojects/subsub/foo.h
@@ -1,0 +1,1 @@
+#define DUMMY 42

--- a/test cases/common/99 subproject subdir/subprojects/sub_implicit/subprojects/subsub/meson.build
+++ b/test cases/common/99 subproject subdir/subprojects/sub_implicit/subprojects/subsub/meson.build
@@ -1,3 +1,7 @@
 project('subsub')
 
 meson.override_dependency('subsub', declare_dependency())
+
+# Regression test: Installing a header from nested sub-subproject used to raise:
+# ERROR: Sandbox violation: Tried to grab file foo.h from a nested subproject.
+install_headers('foo.h')

--- a/test cases/common/99 subproject subdir/test.json
+++ b/test cases/common/99 subproject subdir/test.json
@@ -1,0 +1,5 @@
+{
+  "installed": [
+    { "type": "file", "file": "usr/include/foo.h" }
+  ]
+}

--- a/test cases/failing/62 subproj filegrab/test.json
+++ b/test cases/failing/62 subproj filegrab/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/62 subproj filegrab/subprojects/a/meson.build:3:0: ERROR: Sandbox violation: Tried to grab file prog.c from a different subproject."
+      "line": "test cases/failing/62 subproj filegrab/subprojects/a/meson.build:3:0: ERROR: Sandbox violation: Tried to grab file prog.c outside current (sub)project."
     }
   ]
 }

--- a/test cases/failing/63 grab subproj/test.json
+++ b/test cases/failing/63 grab subproj/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/63 grab subproj/meson.build:7:0: ERROR: Sandbox violation: Tried to grab file sub.c from a different subproject."
+      "line": "test cases/failing/63 grab subproj/meson.build:7:0: ERROR: Sandbox violation: Tried to grab file sub.c from a nested subproject."
     }
   ]
 }

--- a/test cases/failing/64 grab sibling/test.json
+++ b/test cases/failing/64 grab sibling/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/64 grab sibling/subprojects/a/meson.build:3:0: ERROR: Sandbox violation: Tried to grab file sneaky.c from a different subproject."
+      "line": "test cases/failing/64 grab sibling/subprojects/a/meson.build:3:0: ERROR: Sandbox violation: Tried to grab file sneaky.c outside current (sub)project."
     }
   ]
 }


### PR DESCRIPTION
A sub-subproject can be configured directly from
`subprojects/foo/subprojects/bar/` in the case `bar` is in the same git
repository as `foo` and not downloaded separately into the main
project's `subprojects/`. In that case the nested subproject violation
code was wrong because it is allowed to have more than one "subprojects"
in path (was not possible before Meson 0.56.0).

Example:
- self.environment.source_dir = '/home/user/myproject'
- self.root_subdir = 'subprojects/foo/subprojects/bar'
- project_root = '/home/user/myproject/subprojects/foo/subprojects/bar'
- norm = '/home/user/myproject/subprojects/foo/subprojects/bar/file.c'

We want `norm` path to have `project_root` in its parents and not have
`project_root / 'subprojects'` in its parents. In that case we are sure
`file.c` is within `bar` subproject.