### PR TITLE
dependencies: Put pkgconfig options before operands

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -869,9 +869,13 @@ class PkgConfigDependency(ExternalDependency):
 
     def _set_libs(self):
         env = None
-        libcmd = [self.name, '--libs']
+        libcmd = ['--libs']
+
         if self.static:
             libcmd.append('--static')
+
+        libcmd.append(self.name)
+
         # Force pkg-config to output -L fields even if they are system
         # paths so we can do manual searching with cc.find_library() later.
         env = os.environ.copy()

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -885,11 +885,11 @@ class InternalTests(unittest.TestCase):
             def fake_call_pkgbin(self, args, env=None):
                 if '--libs' not in args:
                     return 0, '', ''
-                if args[0] == 'foo':
+                if args[-1] == 'foo':
                     return 0, '-L{} -lfoo -L{} -lbar'.format(p2.as_posix(), p1.as_posix()), ''
-                if args[0] == 'bar':
+                if args[-1] == 'bar':
                     return 0, '-L{} -lbar'.format(p2.as_posix()), ''
-                if args[0] == 'internal':
+                if args[-1] == 'internal':
                     return 0, '-L{} -lpthread -lm -lc -lrt -ldl'.format(p1.as_posix()), ''
 
             old_call = PkgConfigDependency._call_pkgbin

--- a/test cases/common/231 external project/libfoo/configure
+++ b/test cases/common/231 external project/libfoo/configure
@@ -27,7 +27,7 @@ case $i in
 esac
 done
 
-DEP_ARGS=$(pkg-config somelib --cflags --libs)
+DEP_ARGS=$(pkg-config --cflags --libs somelib)
 
 cat > Makefile << EOL
 all: libfoo.$LIBEXT


### PR DESCRIPTION
This fixes building with meson when the POSIX behavior of getopt is used (stopping at the first non-option), such as when GNU libc is used with `POSIXLY_CORRECT=1` defined.