### PR TITLE
vim: Drop backwards compatibility with Vim 5.

### DIFF
--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -17,11 +17,7 @@
 "   let meson_space_error_highlight = 1
 "
 
-" For version 5.x: Clear all syntax items.
-" For version 6.x: Quit when a syntax file was already loaded.
-if version < 600
-  syntax clear
-elseif exists("b:current_syntax")
+if exists("b:current_syntax")
   finish
 endif
 
@@ -132,31 +128,20 @@ if exists("meson_space_error_highlight")
   syn match   mesonSpaceError	display "\t\+ "
 endif
 
-if version >= 508 || !exists("did_meson_syn_inits")
-  if version <= 508
-    let did_meson_syn_inits = 1
-    command -nargs=+ HiLink hi link <args>
-  else
-    command -nargs=+ HiLink hi def link <args>
-  endif
-
-  " The default highlight links.  Can be overridden later.
-  HiLink mesonStatement		Statement
-  HiLink mesonConditional	Conditional
-  HiLink mesonRepeat		Repeat
-  HiLink mesonOperator		Operator
-  HiLink mesonComment		Comment
-  HiLink mesonTodo		Todo
-  HiLink mesonString		String
-  HiLink mesonEscape		Special
-  HiLink mesonNumber		Number
-  HiLink mesonBuiltin		Function
-  HiLink mesonConstant		Number
-  if exists("meson_space_error_highlight")
-    HiLink mesonSpaceError	Error
-  endif
-
-  delcommand HiLink
+" The default highlight links.  Can be overridden later.
+hi def link mesonStatement	Statement
+hi def link mesonConditional	Conditional
+hi def link mesonRepeat	Repeat
+hi def link mesonOperator	Operator
+hi def link mesonComment	Comment
+hi def link mesonTodo		Todo
+hi def link mesonString	String
+hi def link mesonEscape	Special
+hi def link mesonNumber	Number
+hi def link mesonBuiltin	Function
+hi def link mesonConstant	Number
+if exists("meson_space_error_higlight")
+  hi def link mesonSpaceError	Error
 endif
 
 let b:current_syntax = "meson"


### PR DESCRIPTION
We should do this because:

- Vim 5.8, the last minor release of Vim 5, came out in 2001.
- Even the runtime files maintained in the Vim repository, which are very careful about compatibility, removed Vim 5 support in 2016.
- It means less code paths and less lines of code.

Also I didn't keep the check for `did_meson_syn_inits` because I don't know what exactly that is referring to; there doesn't seem to be a variable with that name in any of the Vim scripts.