### PR TITLE
Bare exceptions are no longer allowed [NFC]

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -24,8 +24,6 @@ ignore =
     E731,
     # E741: ambiguous variable name 'l'
     E741,
-    # E722: do not use bare except'
-    E722,
     # W504: line break after binary operator
     W504,
     # A003: builtin class attribute

--- a/.pylintrc
+++ b/.pylintrc
@@ -22,4 +22,5 @@ enable=
     singleton-comparison,
     too-many-function-args,
     unexpected-keyword-arg,
-    unreachable
+    unreachable,
+    bare-except


### PR DESCRIPTION
The last instances of

    try:
        ...
    except:
        ...

were removed in bf98ffca. The sideci.yml file was updated, but the
flake8 config still allows this. Ensure that flake8 tests fail if this
questionable construct appears again.