### PR TITLE
rust: implement support for --edition

### DIFF
--- a/docs/markdown/snippets/rust_std_option.md
+++ b/docs/markdown/snippets/rust_std_option.md
@@ -1,0 +1,5 @@
+## Rust now has a a standard option
+
+Rust calls these `editions`, however, meson generally refers to such language
+versions as "standards", or "std" for short. Rust uses "std" to keep normalize
+it with other languages.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1524,10 +1524,13 @@ int dummy;
             for a in rustc.linker.get_always_args():
                 args += ['-C', 'link-arg={}'.format(a)]
 
+        opt_proxy = self.get_compiler_options_for_target(target)[rustc.language]
+
         args += ['--crate-name', target.name]
         args += rustc.get_buildtype_args(self.get_option_for_target('buildtype', target))
         args += rustc.get_debug_args(self.get_option_for_target('debug', target))
         args += rustc.get_optimization_args(self.get_option_for_target('optimization', target))
+        args += rustc.get_option_compile_args(opt_proxy)
         args += self.build.get_global_args(rustc, target.for_machine)
         args += self.build.get_project_args(rustc, target.subproject, target.for_machine)
         depfile = os.path.join(target.subdir, target.name + '.d')

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -16,14 +16,17 @@ import subprocess, os.path
 import textwrap
 import typing as T
 
+from .. import coredata
 from ..mesonlib import EnvironmentException, MachineChoice, Popen_safe
 from .compilers import Compiler, rust_buildtype_args, clike_debug_args
 
 if T.TYPE_CHECKING:
+    from ..coredata import OptionDictType
     from ..dependencies import ExternalProgram
     from ..envconfig import MachineInfo
     from ..environment import Environment  # noqa: F401
     from ..linkers import DynamicLinker
+
 
 rust_optimization_args = {
     '0': [],
@@ -122,3 +125,19 @@ class RustCompiler(Compiler):
     # Rust does not have a use_linker_args because it dispatches to a gcc-like
     # C compiler for dynamic linking, as such we invoke the C compiler's
     # use_linker_args method instead.
+
+    def get_options(self) -> 'OptionDictType':
+        return {
+            'std': coredata.UserComboOption(
+                'Rust Eddition to use',
+                ['none', '2015', '2018'],
+                'none',
+            ),
+        }
+
+    def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:
+        args = []
+        std = options['std']
+        if std.value != 'none':
+            args.append('--edition=' + std.value)
+        return args

--- a/test cases/rust/10 language stds/2015.rs
+++ b/test cases/rust/10 language stds/2015.rs
@@ -1,0 +1,3 @@
+trait Foo {
+    fn foo(&self, Box<dyn Foo>);
+}

--- a/test cases/rust/10 language stds/2018.rs
+++ b/test cases/rust/10 language stds/2018.rs
@@ -1,0 +1,9 @@
+const fn foo(x: i32) -> i32 {
+    return x + 1;
+}
+
+const VALUE: i32 = foo(-1);
+
+pub fn main() {
+    std::process::exit(VALUE);
+}

--- a/test cases/rust/10 language stds/meson.build
+++ b/test cases/rust/10 language stds/meson.build
@@ -1,0 +1,18 @@
+project('rust std options', 'rust')
+
+# this only works in 2018
+new = executable(
+  'new',
+  '2018.rs',
+  override_options : ['rust_std=2018'],
+)
+
+# this only works in 2015
+old = static_library(
+  'old',
+  '2015.rs',
+  override_options : ['rust_std=2015'],
+)
+
+
+test('2018 std', new)


### PR DESCRIPTION
Using the std option, so now `rust_std=..` will work. I've chosen to use
"std" even though rust calls these "editions", as meson refers to
language versions as "standards", which makes meson feel more uniform.

Fixes: #5100