### PR TITLE
docs: Recommend to use SPDX license identifiers

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1398,13 +1398,14 @@ Project supports the following keyword arguments.
   specific options are used normally even in subprojects.
 
 
-- `license`: takes a string or array of strings describing the
-  license(s) the code is under. Usually this would be something like
-  `license : 'GPL2+'`, but if the code has multiple licenses you can
-  specify them as an array like this: `license : ['proprietary',
-  'GPL3']`. Note that the text is informal and is only written to
-  the dependency manifest. Meson does not do any license validation,
-  you are responsible for verifying that you abide by all licensing
+- `license`: takes a string or array of strings describing the license(s) the
+  code is under. To avoid ambiguity it is recommended to use a standardized
+  license identifier from the [SPDX license list](https://spdx.org/licenses/).
+  Usually this would be something like `license : 'GPL-2.0-or-later'`, but if
+  the code has multiple licenses you can specify them as an array like this:
+  `license : ['proprietary', 'GPL-3.0-only']`. Note that the text is informal
+  and is only written to the dependency manifest. Meson does not do any license
+  validation, you are responsible for verifying that you abide by all licensing
   terms. You can access the value in your Meson build files with
   `meson.project_license()`.
 

--- a/test cases/common/166 get project license/meson.build
+++ b/test cases/common/166 get project license/meson.build
@@ -1,8 +1,8 @@
-project('bar', 'c', license: 'Apache')
+project('bar', 'c', license: 'Apache-2.0')
 
 executable('bar', 'bar.c')
 
 license = meson.project_license()[0]
-if license != 'Apache'
-    error('The license should be Apache, but it is: ' + license)
+if license != 'Apache-2.0'
+    error('The license should be Apache-2.0, but it is: ' + license)
 endif


### PR DESCRIPTION
Some license identifiers are ambiguous (e.g. "GPL3"). The SPDX license
identifiers avoid this by providing standardized and unique identifiers
(e.g. "GPL-3.0-only" or "GPL-3.0-or-later" for the previous example).

Because SPDX short-form identifiers are also both human- and
machine-readable we should recommend them in the documentation.

More information (advantages, details, etc.) can be found here:
- https://spdx.dev/resources/use/#identifiers
- https://spdx.dev/ids/

Fix #7905.

---

I've also updated the test to ensure the "-2.0" suffix won't cause any issues though this is completely optional as I don't see why it should actually cause any issue (but it seemed like a good idea regardless).