### PR TITLE
Fix c_std breakage in 0.56 with msvc and clang-cl for 0.56.1

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -462,6 +462,25 @@ class ClangClCCompiler(ClangClCompiler, VisualStudioLikeCCompilerMixin, CCompile
                            full_version=full_version)
         ClangClCompiler.__init__(self, target)
 
+    def get_options(self) -> 'OptionDictType':
+        # Clang-cl can compile up to c99, but doesn't have a std-swtich for
+        # them. Unlike recent versions of MSVC it doesn't (as of 10.0.1)
+        # support c11
+        opts = super().get_options()
+        c_stds = ['none', 'c89', 'c99',
+                  # Need to have these to be compatible with projects
+                  # that set c_std to e.g. gnu99.
+                  # https://github.com/mesonbuild/meson/issues/7611
+                  'gnu89', 'gnu90', 'gnu9x', 'gnu99']
+        opts.update({
+            'std': coredata.UserComboOption(
+                'C language standard to use',
+                c_stds,
+                'none',
+            ),
+        })
+        return opts
+
 
 class IntelClCCompiler(IntelVisualStudioLikeCompiler, VisualStudioLikeCCompilerMixin, CCompiler):
 

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -428,7 +428,11 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
 
     def get_options(self) -> 'OptionDictType':
         opts = super().get_options()
-        c_stds = ['none', 'c89', 'c99', 'c11']
+        c_stds = ['none', 'c89', 'c99', 'c11',
+                  # Need to have these to be compatible with projects
+                  # that set c_std to e.g. gnu99.
+                  # https://github.com/mesonbuild/meson/issues/7611
+                  'gnu89', 'gnu90', 'gnu9x', 'gnu99', 'gnu1x', 'gnu11']
         opts.update({
             'std': coredata.UserComboOption(
                 'C language standard to use',
@@ -442,8 +446,8 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
         args = []
         std = options['std']
         # As of MVSC 16.7, /std:c11 is the only valid C standard option.
-        if std.value in {'c11'}:
-            args.append('/std:' + std.value)
+        if std.value in {'c11', 'gnu11'}:
+            args.append('/std:c11')
         return args
 
 


### PR DESCRIPTION
Contains commits cherry-picked from https://github.com/mesonbuild/meson/pull/7862 and https://github.com/mesonbuild/meson/pull/7866