### PR TITLE
Fix clang-tidy return value reporting

### DIFF
--- a/mesonbuild/scripts/clangtidy.py
+++ b/mesonbuild/scripts/clangtidy.py
@@ -49,8 +49,7 @@ def clangformat(srcdir_name: str, builddir_name: str) -> int:
         return subprocess.run([run_clang_tidy, '-p', builddir_name, '^(?!' + re.escape(builddir_name + os.path.sep) +').*$']).returncode
     else:
         print('Could not find run-clang-tidy, running checks manually.')
-        manual_clangformat(srcdir_name, builddir_name)
-    return 0
+        return manual_clangformat(srcdir_name, builddir_name)
 
 def run(args: T.List[str]) -> int:
     srcdir_name = args[0]

--- a/mesonbuild/scripts/clangtidy.py
+++ b/mesonbuild/scripts/clangtidy.py
@@ -22,7 +22,7 @@ import typing as T
 
 from ..compilers import lang_suffixes
 
-def manual_clangformat(srcdir_name: str, builddir_name: str) -> int:
+def manual_clangtidy(srcdir_name: str, builddir_name: str) -> int:
     srcdir = pathlib.Path(srcdir_name)
     suffixes = set(lang_suffixes['c']).union(set(lang_suffixes['cpp']))
     suffixes.add('h')
@@ -39,7 +39,7 @@ def manual_clangformat(srcdir_name: str, builddir_name: str) -> int:
         [max(returncode, x.result().returncode) for x in futures]
     return returncode
 
-def clangformat(srcdir_name: str, builddir_name: str) -> int:
+def clangtidy(srcdir_name: str, builddir_name: str) -> int:
     run_clang_tidy = None
     for rct in ('run-clang-tidy', 'run-clang-tidy.py'):
         if shutil.which(rct):
@@ -49,9 +49,9 @@ def clangformat(srcdir_name: str, builddir_name: str) -> int:
         return subprocess.run([run_clang_tidy, '-p', builddir_name, '^(?!' + re.escape(builddir_name + os.path.sep) +').*$']).returncode
     else:
         print('Could not find run-clang-tidy, running checks manually.')
-        return manual_clangformat(srcdir_name, builddir_name)
+        return manual_clangtidy(srcdir_name, builddir_name)
 
 def run(args: T.List[str]) -> int:
     srcdir_name = args[0]
     builddir_name = args[1]
-    return clangformat(srcdir_name, builddir_name)
+    return clangtidy(srcdir_name, builddir_name)


### PR DESCRIPTION
In case clang-tidy is invoked manually, i.e. if run-clang-tidy(.py) is
not found, Meson would not report the return value. This is caused by
ignoring the return value of manual_clangformat() in clangformat()
within mesonbuild/scripts/clangtidy.py.

Even though only more recent-versions of clang-tidy actually report an
non-zero exit code if errors are found, there is no reason Meson
shouldn't simply report any error codes it received from clang-tidy.

Fixes #7948.