### PR TITLE
Fix "generator doesn't stop" on Windows

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -785,7 +785,7 @@ class Compiler(metaclass=abc.ABCMeta):
             # On Windows antivirus programs and the like hold on to files so
             # they can't be deleted. There's not much to do in this case. Also,
             # catch OSError because the directory is then no longer empty.
-            yield None
+            return
 
     @contextlib.contextmanager
     def cached_compile(self, code: str, cdata: coredata.CoreData, *,


### PR DESCRIPTION
When TemporaryDirectory() cleans up on __exit__ it sometimes throws
OSError noting that the dir isn't empty. This happens after the
first yield in this generator and leads to the exception being handled
which leads to a second yield.

contextlib.contextmanager() fails then since the function it wraps is only
allowed to yield once.

Fix this by not yielding again in the error case.

Fixes #7947