### PR TITLE
wrap: Add support do download into a destination directory

### DIFF
--- a/docs/markdown/Subprojects.md
+++ b/docs/markdown/Subprojects.md
@@ -313,6 +313,13 @@ configure can be performed offline. The command-line `meson
 subprojects download` can be used for that, it will download all
 missing subprojects, but will not update already fetched subprojects.
 
+*Since 1.2.0* `--dest` argument can be used to specify in which directory
+subprojects should be downloaded. The destination directory will contain only
+the `packagecache` directory for `wrap-file` and their patches (they are not extracted),
+and complete checkout for other wrap types. This is used to store a cache of
+subprojects (e.g. in CI docker images) that can then be copied into project's
+`subprojects/` directory to build offline (i.e. with `--wrap-mode=nodownload`).
+
 ### Update subprojects
 
 *Since 0.49.0*

--- a/docs/markdown/snippets/wrap_download.md
+++ b/docs/markdown/snippets/wrap_download.md
@@ -1,0 +1,9 @@
+## New `--dest` argument to `meson subprojects download`
+
+`meson subprojects download --dest /cache` can be used to specify in which directory
+subprojects should be downloaded. The destination directory will contain only
+`packagecache` directory for `wrap-file` and their patches (they are not extracted),
+and complete checkout for other wrap types. This is used to store a cache of
+subprojects (e.g. in CI docker images) that can then be copied into project's
+`subprojects/` directory to build offline (i.e. with `--wrap-mode=nodownload`).
+


### PR DESCRIPTION
It is common for projects to want to run their CI in offline mode, or at
least reduce as much as possible download time during each job. Some
projects uses `meson subprojects download` during docker image
generation and store the `subprojects/` directory directly into the
docker image. When a job is run, the cache is copied back into
subprojects/ directory.

One difficulty with that workflow is to exclude
subprojects that are part of the main project's git repository. Keeping
only tarballs for wrap-file also helps reducing docker image size.