### PR TITLE
Add color output support to rust

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1494,6 +1494,10 @@ int dummy;
         # Rust compiler takes only the main file as input and
         # figures out what other files are needed via import
         # statements and magic.
+        base_proxy = self.get_base_options_for_target(target)
+        args = rustc.compiler_args()
+        # Compiler args for compiling this target
+        args += compilers.get_base_compile_args(base_proxy, rustc)
         main_rust_file = None
         for i in target.get_sources():
             if not rustc.can_compile(i):
@@ -1503,7 +1507,6 @@ int dummy;
         if main_rust_file is None:
             raise RuntimeError('A Rust target has no Rust sources. This is weird. Also a bug. Please report')
         target_name = os.path.join(target.subdir, target.get_filename())
-        args = ['--crate-type']
         if isinstance(target, build.Executable):
             cratetype = 'bin'
         elif hasattr(target, 'rust_crate_type'):
@@ -1514,7 +1517,7 @@ int dummy;
             cratetype = 'rlib'
         else:
             raise InvalidArguments('Unknown target type for rustc.')
-        args.append(cratetype)
+        args.extend(['--crate-type', cratetype])
 
         # If we're dynamically linking, add those arguments
         #

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -52,6 +52,8 @@ class RustCompiler(Compiler):
                          linker=linker)
         self.exe_wrapper = exe_wrapper
         self.id = 'rustc'
+        if 'link' in self.linker.id:
+            self.base_options.append('b_vscrt')
 
     def needs_static_linker(self) -> bool:
         return False
@@ -141,3 +143,7 @@ class RustCompiler(Compiler):
         if std.value != 'none':
             args.append('--edition=' + std.value)
         return args
+
+    def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:
+        # Rust handles this for us, we don't need to do anything
+        return []

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -17,7 +17,7 @@ import textwrap
 import typing as T
 
 from .. import coredata
-from ..mesonlib import EnvironmentException, MachineChoice, Popen_safe
+from ..mesonlib import EnvironmentException, MachineChoice, MesonException, Popen_safe
 from .compilers import Compiler, rust_buildtype_args, clike_debug_args
 
 if T.TYPE_CHECKING:
@@ -52,6 +52,7 @@ class RustCompiler(Compiler):
                          linker=linker)
         self.exe_wrapper = exe_wrapper
         self.id = 'rustc'
+        self.base_options.append('b_colorout')
         if 'link' in self.linker.id:
             self.base_options.append('b_vscrt')
 
@@ -147,3 +148,8 @@ class RustCompiler(Compiler):
     def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:
         # Rust handles this for us, we don't need to do anything
         return []
+
+    def get_colorout_args(self, colortype: str) -> T.List[str]:
+        if colortype in {'always', 'never', 'auto'}:
+            return [f'--color={colortype}']
+        raise MesonException(f'Invalid color type for rust {colortype}')


### PR DESCRIPTION
rustc has color output, although it's not documented in it's help section. It uses the same values every other compiler does. Also, apply base compiler options to rust targets.