### PR TITLE
msvc: enable /std:c17 flag

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -428,7 +428,7 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
 
     def get_options(self) -> 'OptionDictType':
         opts = super().get_options()
-        c_stds = ['none', 'c89', 'c99', 'c11']
+        c_stds = ['none', 'c89', 'c99', 'c11', 'c17']
         opts.update({
             'std': coredata.UserComboOption(
                 'C language standard to use',
@@ -441,8 +441,8 @@ class VisualStudioCCompiler(MSVCCompiler, VisualStudioLikeCCompilerMixin, CCompi
     def get_option_compile_args(self, options: 'OptionDictType') -> T.List[str]:
         args = []
         std = options['std']
-        # As of MVSC 16.7, /std:c11 is the only valid C standard option.
-        if std.value in {'c11'}:
+        # As of MVSC 16.8, /std:c11 and /std:c17 are the only valid C standard options.
+        if std.value in {'c11', 'c17'}:
             args.append('/std:' + std.value)
         return args
 


### PR DESCRIPTION
MS blog post about improved C support: https://devblogs.microsoft.com/cppblog/c11-and-c17-standard-support-arriving-in-msvc/

I have tested this change against some C code that used static_assert, and did not compile previously.

Extends pattern laid out by #7556.