### PR TITLE
msvc: enable /std:c17 flag

### DIFF
--- a/test cases/unit/59 introspect buildoptions/meson.build
+++ b/test cases/unit/59 introspect buildoptions/meson.build
@@ -1,4 +1,4 @@
-project('introspect buildargs', ['c'], default_options: ['c_std=c11', 'cpp_std=c++14', 'buildtype=release'])
+project('introspect buildargs', ['c'], default_options: ['c_std=c99', 'cpp_std=c++14', 'buildtype=release'])
 
 subA = subproject('projectA')
 


### PR DESCRIPTION
MS blog post about improved C support: https://devblogs.microsoft.com/cppblog/c11-and-c17-standard-support-arriving-in-msvc/

I have tested this change against some C code that used static_assert, and did not compile previously.

Extends pattern laid out by #7556.