### PR TITLE
Do not warn when -Wpedantic is added as a project argument.

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -4641,7 +4641,11 @@ different subdirectory.
         self.add_project_arguments(node, self.build.projects_link_args[for_machine], args, kwargs)
 
     def warn_about_builtin_args(self, args):
-        warnargs = ('/W1', '/W2', '/W3', '/W4', '/Wall', '-Wall', '-Wextra', '-Wpedantic')
+        # -Wpedantic is deliberately not included, since some people want to use it but not use -Wextra
+        # see e.g.
+        # https://github.com/mesonbuild/meson/issues/3275#issuecomment-641354956
+        # https://github.com/mesonbuild/meson/issues/3742
+        warnargs = ('/W1', '/W2', '/W3', '/W4', '/Wall', '-Wall', '-Wextra')
         optargs = ('-O0', '-O2', '-O3', '-Os', '/O1', '/O2', '/Os')
         for arg in args:
             if arg in warnargs:


### PR DESCRIPTION
The only way to add it via warning_level is top opt in to -Wextra too. But this is often not really desirable, since -Wextra is not stable -- it changes its meaning every compiler release, thus mysteriously adding new warnings. Furthermore, it's not really the same kind of warning -- a pedantic warning is always correct that your code is wrong, but defines wrongness as "not per the portable standard". Unlike -Wextra it doesn't try to judge your code to see if you're doing something that is "often not what you meant", but is prone to false positives.

Really, we need different *kinds* of warning levels, possibly as an array -- not just a monotonically increasing number. But since there's currently nothing flexible enough to specify -Wpedantic without -Wextra, we will just remove the warning for the former, and let people add it to their project arguments in peace.