### PR TITLE
ninjabackend: fix matching of empty strings

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -266,7 +266,7 @@ class NinjaRule:
         # expand variables in command
         command = ' '.join([self._quoter(x) for x in self.command + self.args])
         estimate = len(command)
-        for m in re.finditer(r'(\${\w*}|\$\w*)?[^$]*', command):
+        for m in re.finditer(r'(\${\w+}|\$\w+)?[^$]*', command):
             if m.start(1) != -1:
                 estimate -= m.end(1) - m.start(1) + 1
                 chunk = m.group(1)


### PR DESCRIPTION
due to spaces in paths being escaped with `$ `
closes #7977