### PR TITLE
Fix clang-tidy return value reporting (Part Ⅱ)

### DIFF
--- a/mesonbuild/scripts/clangtidy.py
+++ b/mesonbuild/scripts/clangtidy.py
@@ -36,7 +36,7 @@ def manual_clangtidy(srcdir_name: str, builddir_name: str) -> int:
             if strf.startswith(builddir_name):
                 continue
             futures.append(e.submit(subprocess.run, ['clang-tidy', '-p', builddir_name, strf]))
-        [max(returncode, x.result().returncode) for x in futures]
+        returncode = max([x.result().returncode for x in futures])
     return returncode
 
 def clangtidy(srcdir_name: str, builddir_name: str) -> int:


### PR DESCRIPTION
It turns out my first attempt to fix this in 00d5ef3191e5 ("Fix
clang-tidy return value reporting (#7949)") is not sufficient: The
local variable returncode is never updated and stays at 0. This fixes
the returncode calculation.

Fixes: cce172432be3 ("Use run-clang-tidy when available.")