### PR TITLE
gnome: Drop use of volatile in GLib type functions

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1430,7 +1430,7 @@ class GnomeModule(ExtensionModule):
 GType
 %s@enum_name@_get_type (void)
 {
-  static volatile gsize gtype_id = 0;
+  static gsize gtype_id = 0;
   static const G@Type@Value values[] = {''' % func_prefix
 
         c_file_kwargs['vprod'] = '    { C_@TYPE@(@VALUENAME@), "@VALUENAME@", "@valuenick@" },'

--- a/test cases/frameworks/7 gnome/mkenums/enums.c.in
+++ b/test cases/frameworks/7 gnome/mkenums/enums.c.in
@@ -13,9 +13,9 @@
 /*** BEGIN value-header ***/
 GType
 @enum_name@_get_type(void) {
-    static volatile gsize g_define_type_id__volatile = 0;
+    static gsize static_g_define_type_id = 0;
 
-    if(g_once_init_enter(&g_define_type_id__volatile)) {
+    if(g_once_init_enter(&static_g_define_type_id)) {
         static const G@Type@Value values [] = {
 /*** END value-header ***/
 
@@ -29,10 +29,10 @@ GType
 
         GType g_define_type_id =
             g_@type@_register_static(g_intern_static_string("@EnumName@"), values);
-        g_once_init_leave(&g_define_type_id__volatile, g_define_type_id);
+        g_once_init_leave(&static_g_define_type_id, g_define_type_id);
     }
 
-    return g_define_type_id__volatile;
+    return static_g_define_type_id;
 }
 
 /*** END value-tail ***/

--- a/test cases/frameworks/7 gnome/mkenums/enums2.c.in
+++ b/test cases/frameworks/7 gnome/mkenums/enums2.c.in
@@ -13,9 +13,9 @@
 /*** BEGIN value-header ***/
 GType
 @enum_name@_get_type(void) {
-    static volatile gsize g_define_type_id__volatile = 0;
+    static gsize static_g_define_type_id = 0;
 
-    if(g_once_init_enter(&g_define_type_id__volatile)) {
+    if(g_once_init_enter(&static_g_define_type_id)) {
         static const G@Type@Value values [] = {
 /*** END value-header ***/
 
@@ -29,10 +29,10 @@ GType
 
         GType g_define_type_id =
             g_@type@_register_static(g_intern_static_string("@EnumName@"), values);
-        g_once_init_leave(&g_define_type_id__volatile, g_define_type_id);
+        g_once_init_leave(&static_g_define_type_id, g_define_type_id);
     }
 
-    return g_define_type_id__volatile;
+    return static_g_define_type_id;
 }
 
 /*** END value-tail ***/

--- a/test cases/frameworks/7 gnome/mkenums/meson.build
+++ b/test cases/frameworks/7 gnome/mkenums/meson.build
@@ -89,9 +89,9 @@ enums_c3 = gnome.mkenums('enums3.c',
   vhead : '''
 GType
 @enum_name@_get_type(void) {
-    static volatile gsize g_define_type_id__volatile = 0;
+    static gsize static_g_define_type_id = 0;
 
-    if(g_once_init_enter(&g_define_type_id__volatile)) {
+    if(g_once_init_enter(&static_g_define_type_id)) {
         static const G@Type@Value values [] = {
 ''',
   vprod : '''            { @VALUENAME@, "@VALUENAME@", "@valuenick@" },''',
@@ -100,10 +100,10 @@ GType
 
         GType g_define_type_id =
             g_@type@_register_static(g_intern_static_string("@EnumName@"), values);
-        g_once_init_leave(&g_define_type_id__volatile, g_define_type_id);
+        g_once_init_leave(&static_g_define_type_id, g_define_type_id);
     }
 
-    return g_define_type_id__volatile;
+    return static_g_define_type_id;
 }
 ''')
 

--- a/test cases/vala/8 generated sources/dependency-generated/enum-types.c.template
+++ b/test cases/vala/8 generated sources/dependency-generated/enum-types.c.template
@@ -14,9 +14,9 @@
 GType
 @enum_name@_get_type (void)
 {
-  static volatile gsize g_define_type_id__volatile = 0;
+  static gsize static_g_define_type_id = 0;
  
-  if (g_once_init_enter (&g_define_type_id__volatile)) {
+  if (g_once_init_enter (&static_g_define_type_id)) {
     static const G@Type@Value values[] = {
 /*** END value-header ***/
 
@@ -30,10 +30,10 @@ GType
     GType g_define_type_id = 
        g_@type@_register_static (g_intern_static_string ("@EnumName@"), values);
       
-    g_once_init_leave (&g_define_type_id__volatile, g_define_type_id);
+    g_once_init_leave (&static_g_define_type_id, g_define_type_id);
   }
     
-  return g_define_type_id__volatile;
+  return static_g_define_type_id;
 }
 
 /*** END value-tail ***/


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/glib/-/issues/600

`volatile` was previously mistakenly used in GLib to indicate that a
variable was accessed atomically or otherwise multi-threaded. It’s not
meant for that, and up to date compilers (like gcc-11) will rightly warn
about it.

Drop the `volatile` qualifiers.

See also http://isvolatileusefulwiththreads.in/c/.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>