### PR TITLE
pkgconfig: Fix linking to a custom target

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2588,13 +2588,12 @@ class CustomTarget(Target, CommandBase):
         return []
 
     def is_internal(self) -> bool:
-        if not self.should_install():
-            return True
-        for out in self.get_outputs():
-            # Can't check if this is a static library, so try to guess
-            if not out.endswith(('.a', '.lib')):
-                return False
-        return True
+        '''
+        Returns True iif this is a not installed static library.
+        '''
+        if len(self.outputs) != 1:
+            return False
+        return CustomTargetIndex(self, self.outputs[0]).is_internal()
 
     def extract_all_objects_recurse(self) -> T.List[T.Union[str, 'ExtractedObjects']]:
         return self.get_outputs()
@@ -2764,7 +2763,11 @@ class CustomTargetIndex(HoldableObject):
         return self.target.should_install()
 
     def is_internal(self) -> bool:
-        return self.target.is_internal()
+        '''
+        Returns True iif this is a not installed static library
+        '''
+        suf = os.path.splitext(self.output)[-1]
+        return suf in {'.a', '.lib'} and not self.should_install()
 
     def extract_all_objects_recurse(self) -> T.List[T.Union[str, 'ExtractedObjects']]:
         return self.target.extract_all_objects_recurse()

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -183,7 +183,8 @@ class DependenciesHelper:
         # lists in case a library is link_with and link_whole at the same time.
         # See remove_dups() below.
         self.link_whole_targets.append(t)
-        self._add_lib_dependencies(t.link_targets, t.link_whole_targets, t.external_deps, public)
+        if isinstance(t, build.BuildTarget):
+            self._add_lib_dependencies(t.link_targets, t.link_whole_targets, t.external_deps, public)
 
     def add_version_reqs(self, name, version_reqs):
         if version_reqs:

--- a/test cases/common/44 pkgconfig-gen/meson.build
+++ b/test cases/common/44 pkgconfig-gen/meson.build
@@ -18,6 +18,8 @@ if v.version_compare('<0.29')
   error('MESON_SKIP_TEST: pkg-config version \'' + v + '\' too old')
 endif
 
+python = import('python').find_installation()
+fs = import('fs')
 pkgg = import('pkgconfig')
 
 lib = shared_library('simple', 'simple.c')
@@ -124,3 +126,17 @@ if cc.get_id() in ['gcc', 'clang']
     description: 'custom target index'
   )
 endif
+
+# Regression test: A library linking to an uninstalled custom_target static
+# library used to crash when generating its pkgconfig file.
+# Copy libstat2.a to libstat3.a to have a static library as custom target.
+infile = stat2.full_path()
+outfile = meson.current_build_dir() / 'libstat3.a'
+script = 'import shutil ; shutil.copyfile("@0@", "@1@")'.format(infile, outfile)
+ct = custom_target('stat3',
+  input: stat2,
+  output: fs.name(outfile),
+  command: [python, '-c', script],
+)
+simple6 = library('simple6', link_with: ct)
+pkgg.generate(simple6)

--- a/test cases/common/44 pkgconfig-gen/test.json
+++ b/test cases/common/44 pkgconfig-gen/test.json
@@ -9,6 +9,7 @@
     {"type": "file", "file": "usr/lib/pkgconfig/simple2.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/simple3.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/simple5.pc"},
+    {"type": "file", "file": "usr/lib/pkgconfig/simple6.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/ct.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/ct0.pc"}
   ]


### PR DESCRIPTION
When generating pkgconfig file for a library that links to an
uninstalled static library built by custom_target() Meson was crashing
when trying to access some attributes that does not exist on that class.

Also fix is_internal() implementation, it only really make sense on a
CustomTargetIndex or if CustomTarget has only a single output.