### PR TITLE
failures are printed twice

### DIFF
--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -124,7 +124,7 @@ class AnsiDecorator:
 
     def get_text(self, with_codes: bool) -> str:
         text = self.text
-        if with_codes:
+        if with_codes and self.code:
             text = self.code + self.text + AnsiDecorator.plain_code
         if self.quoted:
             text = '"{}"'.format(text)
@@ -132,6 +132,9 @@ class AnsiDecorator:
 
 def bold(text: str, quoted: bool = False) -> AnsiDecorator:
     return AnsiDecorator(text, "\033[1m", quoted=quoted)
+
+def plain(text: str) -> AnsiDecorator:
+    return AnsiDecorator(text, "")
 
 def red(text: str) -> AnsiDecorator:
     return AnsiDecorator(text, "\033[1;31m")

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -918,20 +918,15 @@ class TestHarness:
             dur=result.duration)
         if result.res is TestResult.FAIL:
             result_str += ' ' + returncode_to_status(result.returncode)
+        if result.res in bad_statuses:
+            self.collected_failures.append(result_str)
         if not self.options.quiet or result.res not in ok_statuses:
-            if result.res not in ok_statuses:
-                self.collected_failures.append(result_str)
-                if mlog.colorize_console():
-                    if result.res in bad_statuses:
-                        self.collected_failures.append(result_str)
-                        decorator = mlog.red
-                    elif result.res is TestResult.SKIP:
-                        decorator = mlog.yellow
-                    else:
-                        sys.exit('Unreachable code was ... well ... reached.')
-                    print(decorator(result_str).get_text(True))
-            else:
-                print(result_str)
+            decorator = mlog.plain
+            if result.res in bad_statuses:
+                decorator = mlog.red
+            elif result.res is TestResult.SKIP:
+                decorator = mlog.yellow
+            print(decorator(result_str).get_text(mlog.colorize_console()))
         result_str += "\n\n" + result.get_log()
         if result.res in bad_statuses:
             if self.options.print_errorlogs:


### PR DESCRIPTION
Introduced by ba71fde18 ("mtest: collect failures regardless of colorized console", 2020-10-12) in 0.56.0:

```
$ ../../../../meson.py test
ninja: Entering directory `/home/pbonzini/work/upstream/meson/test cases/common/1 trivial/build'
[2/2] Linking target trivialprog
1/1 runtest FAIL           0.00s (exit status 1)

Summary of Failures:

1/1 runtest FAIL           0.00s (exit status 1)
1/1 runtest FAIL           0.00s (exit status 1)

Ok:                 0   
Expected Fail:      0   
Fail:               1   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0   

Full log written to /home/pbonzini/work/upstream/meson/test cases/common/1 trivial/build/meson-logs/testlog.txt
```