### PR TITLE
mtest: refactor logging and add progress report

### DIFF
--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -1548,6 +1548,15 @@ class OrderedSet(T.MutableSet[_T]):
         if value in self.__container:
             del self.__container[value]
 
+    def move_to_end(self, value: _T, last: bool = True) -> None:
+        # Mypy does not know about move_to_end, because it is not part of MutableMapping
+        self.__container.move_to_end(value, last) # type: ignore
+
+    def pop(self, last: bool = True) -> _T:
+        # Mypy does not know about the last argument, because it is not part of MutableMapping
+        item, _ = self.__container.popitem(last)  # type: ignore
+        return item
+
     def update(self, iterable: T.Iterable[_T]) -> None:
         for item in iterable:
             self.__container[item] = None

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -480,7 +480,7 @@ class ConsoleLogger(TestLogger):
         self.running_tests.remove(result)
         if not harness.options.quiet or not result.res.is_ok():
             self.clear_progress()
-            print(harness.format(result, mlog.colorize_console()))
+            print(harness.format(result, mlog.colorize_console()), flush=True)
         self.request_update()
 
     async def finish(self, harness: 'TestHarness') -> None:

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1050,7 +1050,7 @@ class TestHarness:
                     try:
                         print(line)
                     except UnicodeEncodeError:
-                        line = line.encode('ascii', errors='replace').decode()
+                        line = line.encode('ascii', errors='backslashreplace').decode('ascii')
                         print(line)
 
     def total_failure_count(self) -> int:

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1058,6 +1058,11 @@ class TestHarness:
         else:
             sys.exit('Unknown test result encountered: {}'.format(result.res))
 
+        if result.res.is_bad():
+            self.collected_failures.append(result)
+        for l in self.loggers:
+            l.log(self, result)
+
     def format(self, result: TestRun, colorize: bool) -> str:
         result_str = '{num:{numlen}}/{testcount} {name:{name_max_len}} {res} {dur:.2f}s'.format(
             numlen=len(str(self.test_count)),
@@ -1070,12 +1075,6 @@ class TestHarness:
         if result.res is TestResult.FAIL:
             result_str += ' ' + returncode_to_status(result.returncode)
         return result_str
-
-    def print_stats(self, result: TestRun) -> None:
-        if result.res.is_bad():
-            self.collected_failures.append(result)
-        for l in self.loggers:
-            l.log(self, result)
 
     def summary(self) -> str:
         return textwrap.dedent('''
@@ -1269,7 +1268,6 @@ class TestHarness:
                     return
                 res = await test.run()
                 self.process_test_result(res)
-                self.print_stats(res)
 
         def test_done(f: asyncio.Future) -> None:
             if not f.cancelled():


### PR DESCRIPTION
This is the next step in the revamping of `mtest`. Taking advantage of asyncio, it adds a progress report that tells the user which tests are running. In order to get there, several preparatory changes are needed:
* a new `TestLogger` class is created, based on `JunitBuilder`, and used as the common superclass for all the available logging mechanisms (text, JSON, JUnit and console)
* the `TestRun` object is created at the time the test is scheduled, so that the same object can be passed to the (new) `TestLogger.start_test` method when the test starts, and to `TestLogger.log` when the test finishes