### PR TITLE
Fix underscore prefix check

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -944,9 +944,10 @@ class CLikeCompiler(Compiler):
                     if b'_' + symbol_name in line:
                         mlog.debug("Symbols have underscore prefix: YES")
                         return True
+                for line in o:
                     # Else, check if the non-underscored form is present
-                    elif symbol_name in line:
-                        mlog.debug("Symbols have underscore prefix: NO")
+                    if symbol_name in line:
+                        mlog.debug("Symbols have underscore prefix: NO {}", symbol_name)
                         return False
         raise RuntimeError('BUG: {!r} check failed unexpectedly'.format(n))
 


### PR DESCRIPTION
Possible fix for https://github.com/mesonbuild/meson/issues/8004.

Goes through entire file first to check for prefixed symbol. Otherwise if unprefixed symbol in debug info might get picked first.