### PR TITLE
Add a variant of TemporaryDirectory that uses windows_proof_rmtree()

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import abc
-import contextlib, os.path, re, tempfile
+import contextlib, os.path, re
 import enum
 import itertools
 import typing as T
@@ -25,7 +25,7 @@ from .. import mesonlib
 from ..linkers import LinkerEnvVarsMixin
 from ..mesonlib import (
     EnvironmentException, MachineChoice, MesonException,
-    Popen_safe, split_args, LibType
+    Popen_safe, split_args, LibType, TemporaryDirectoryWinProof
 )
 from ..envconfig import (
     get_env_var
@@ -735,57 +735,52 @@ class Compiler(metaclass=abc.ABCMeta):
         # TODO: there isn't really any reason for this to be a contextmanager
         if extra_args is None:
             extra_args = []
-        try:
-            with tempfile.TemporaryDirectory(dir=temp_dir) as tmpdirname:
-                no_ccache = False
-                if isinstance(code, str):
-                    srcname = os.path.join(tmpdirname,
-                                           'testfile.' + self.default_suffix)
-                    with open(srcname, 'w') as ofile:
-                        ofile.write(code)
-                    # ccache would result in a cache miss
-                    no_ccache = True
-                    contents = code
-                elif isinstance(code, mesonlib.File):
-                    srcname = code.fname
-                    with open(code.fname, 'r') as f:
-                        contents = f.read()
 
-                # Construct the compiler command-line
-                commands = self.compiler_args()
-                commands.append(srcname)
-                # Preprocess mode outputs to stdout, so no output args
-                if mode != 'preprocess':
-                    output = self._get_compile_output(tmpdirname, mode)
-                    commands += self.get_output_args(output)
-                commands.extend(self.get_compiler_args_for_mode(CompileCheckMode(mode)))
-                # extra_args must be last because it could contain '/link' to
-                # pass args to VisualStudio's linker. In that case everything
-                # in the command line after '/link' is given to the linker.
-                commands += extra_args
-                # Generate full command-line with the exelist
-                command_list = self.get_exelist() + commands.to_native()
-                mlog.debug('Running compile:')
-                mlog.debug('Working directory: ', tmpdirname)
-                mlog.debug('Command line: ', ' '.join(command_list), '\n')
-                mlog.debug('Code:\n', contents)
-                os_env = os.environ.copy()
-                os_env['LC_ALL'] = 'C'
-                if no_ccache:
-                    os_env['CCACHE_DISABLE'] = '1'
-                p, stdo, stde = Popen_safe(command_list, cwd=tmpdirname, env=os_env)
-                mlog.debug('Compiler stdout:\n', stdo)
-                mlog.debug('Compiler stderr:\n', stde)
+        with TemporaryDirectoryWinProof(dir=temp_dir) as tmpdirname:
+            no_ccache = False
+            if isinstance(code, str):
+                srcname = os.path.join(tmpdirname,
+                                    'testfile.' + self.default_suffix)
+                with open(srcname, 'w') as ofile:
+                    ofile.write(code)
+                # ccache would result in a cache miss
+                no_ccache = True
+                contents = code
+            elif isinstance(code, mesonlib.File):
+                srcname = code.fname
+                with open(code.fname, 'r') as f:
+                    contents = f.read()
 
-                result = CompileResult(stdo, stde, list(commands), p.returncode, p.pid, input_name=srcname)
-                if want_output:
-                    result.output_name = output
-                yield result
-        except OSError:
-            # On Windows antivirus programs and the like hold on to files so
-            # they can't be deleted. There's not much to do in this case. Also,
-            # catch OSError because the directory is then no longer empty.
-            return
+            # Construct the compiler command-line
+            commands = self.compiler_args()
+            commands.append(srcname)
+            # Preprocess mode outputs to stdout, so no output args
+            if mode != 'preprocess':
+                output = self._get_compile_output(tmpdirname, mode)
+                commands += self.get_output_args(output)
+            commands.extend(self.get_compiler_args_for_mode(CompileCheckMode(mode)))
+            # extra_args must be last because it could contain '/link' to
+            # pass args to VisualStudio's linker. In that case everything
+            # in the command line after '/link' is given to the linker.
+            commands += extra_args
+            # Generate full command-line with the exelist
+            command_list = self.get_exelist() + commands.to_native()
+            mlog.debug('Running compile:')
+            mlog.debug('Working directory: ', tmpdirname)
+            mlog.debug('Command line: ', ' '.join(command_list), '\n')
+            mlog.debug('Code:\n', contents)
+            os_env = os.environ.copy()
+            os_env['LC_ALL'] = 'C'
+            if no_ccache:
+                os_env['CCACHE_DISABLE'] = '1'
+            p, stdo, stde = Popen_safe(command_list, cwd=tmpdirname, env=os_env)
+            mlog.debug('Compiler stdout:\n', stdo)
+            mlog.debug('Compiler stderr:\n', stde)
+
+            result = CompileResult(stdo, stde, list(commands), p.returncode, p.pid, input_name=srcname)
+            if want_output:
+                result.output_name = output
+            yield result
 
     @contextlib.contextmanager
     def cached_compile(self, code: str, cdata: coredata.CoreData, *,

--- a/mesonbuild/mesonlib.py
+++ b/mesonbuild/mesonlib.py
@@ -22,6 +22,7 @@ import collections
 from enum import IntEnum
 from functools import lru_cache, wraps
 from itertools import tee, filterfalse
+from tempfile import TemporaryDirectory
 import typing as T
 import uuid
 import textwrap
@@ -1450,6 +1451,25 @@ def windows_proof_rm(fpath: str) -> None:
         except OSError:
             time.sleep(d)
     os.unlink(fpath)
+
+
+class TemporaryDirectoryWinProof(TemporaryDirectory):
+    """
+    Like TemporaryDirectory, but cleans things up using
+    windows_proof_rmtree()
+    """
+
+    def __exit__(self, exc: T.Any, value: T.Any, tb: T.Any) -> None:
+        try:
+            super().__exit__(exc, value, tb)
+        except OSError:
+            windows_proof_rmtree(self.name)
+
+    def cleanup(self) -> None:
+        try:
+            super().cleanup()
+        except OSError:
+            windows_proof_rmtree(self.name)
 
 
 def detect_subprojects(spdir_name: str, current_dir: str = '',

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -42,7 +42,7 @@ from mesonbuild import mesonlib
 from mesonbuild import mlog
 from mesonbuild import mtest
 from mesonbuild.build import ConfigurationData
-from mesonbuild.mesonlib import MachineChoice, Popen_safe
+from mesonbuild.mesonlib import MachineChoice, Popen_safe, TemporaryDirectoryWinProof
 from mesonbuild.coredata import backendlist, version as meson_version
 
 from run_tests import get_fake_options, run_configure, get_meson_script
@@ -520,7 +520,7 @@ def run_test(test: TestDef, extra_args, compiler, backend, flags, commands, shou
     if test.skip:
         return None
     with AutoDeletedDir(create_deterministic_builddir(test, use_tmp)) as build_dir:
-        with AutoDeletedDir(tempfile.mkdtemp(prefix='i ', dir=None if use_tmp else os.getcwd())) as install_dir:
+        with TemporaryDirectoryWinProof(prefix='i ', dir=None if use_tmp else os.getcwd()) as install_dir:
             try:
                 return _run_test(test, build_dir, install_dir, extra_args, compiler, backend, flags, commands, should_fail)
             except TestResult as r:
@@ -790,7 +790,7 @@ def have_d_compiler():
     return False
 
 def have_objc_compiler(use_tmp: bool) -> bool:
-    with AutoDeletedDir(tempfile.mkdtemp(prefix='b ', dir=None if use_tmp else '.')) as build_dir:
+    with TemporaryDirectoryWinProof(prefix='b ', dir=None if use_tmp else '.') as build_dir:
         env = environment.Environment(None, build_dir, get_fake_options('/'))
         try:
             objc_comp = env.detect_objc_compiler(MachineChoice.HOST)
@@ -806,7 +806,7 @@ def have_objc_compiler(use_tmp: bool) -> bool:
     return True
 
 def have_objcpp_compiler(use_tmp: bool) -> bool:
-    with AutoDeletedDir(tempfile.mkdtemp(prefix='b ', dir=None if use_tmp else '.')) as build_dir:
+    with TemporaryDirectoryWinProof(prefix='b ', dir=None if use_tmp else '.') as build_dir:
         env = environment.Environment(None, build_dir, get_fake_options('/'))
         try:
             objcpp_comp = env.detect_objcpp_compiler(MachineChoice.HOST)
@@ -1190,7 +1190,7 @@ def check_meson_commands_work(options):
     global backend, compile_commands, test_commands, install_commands
     testdir = PurePath('test cases', 'common', '1 trivial').as_posix()
     meson_commands = mesonlib.python_command + [get_meson_script()]
-    with AutoDeletedDir(tempfile.mkdtemp(prefix='b ', dir=None if options.use_tmpdir else '.')) as build_dir:
+    with TemporaryDirectoryWinProof(prefix='b ', dir=None if options.use_tmpdir else '.') as build_dir:
         print('Checking that configuring works...')
         gen_cmd = meson_commands + [testdir, build_dir] + backend_flags + options.extra_args
         pc, o, e = Popen_safe(gen_cmd)
@@ -1220,7 +1220,7 @@ def check_meson_commands_work(options):
 def detect_system_compiler(options):
     global host_c_compiler, compiler_id_map
 
-    with AutoDeletedDir(tempfile.mkdtemp(prefix='b ', dir=None if options.use_tmpdir else '.')) as build_dir:
+    with TemporaryDirectoryWinProof(prefix='b ', dir=None if options.use_tmpdir else '.') as build_dir:
         fake_opts = get_fake_options('/')
         if options.cross_file:
             fake_opts.cross_file = [options.cross_file]


### PR DESCRIPTION
* Add a variant of TemporaryDirectory that uses windows_proof_rmtree()
* Replace various calls to AutoDeletedDir with TemporaryDirectoryWinProof
* Remove AutoDeletedDir

This was motivated by #7955