### PR TITLE
doc: fix confusing use of "build" as a directory argument [skip ci]

### DIFF
--- a/docs/markdown/Continuous-Integration.md
+++ b/docs/markdown/Continuous-Integration.md
@@ -221,10 +221,10 @@ jobs:
       with:
         python-version: '3.x'
     - run: pip install meson ninja
-    - run: meson setup build
+    - run: meson setup builddir/
       env:
         CC: gcc
-    - run: meson test -C build -v
+    - run: meson test -C builddir/ -v
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
@@ -240,10 +240,10 @@ jobs:
         python-version: '3.x'
     - run: brew install gcc
     - run: pip install meson ninja
-    - run: meson setup build
+    - run: meson setup builddir/
       env:
         CC: gcc
-    - run: meson test -C build -v
+    - run: meson test -C builddir/ -v
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
@@ -258,10 +258,10 @@ jobs:
       with:
         python-version: '3.x'
     - run: pip install meson ninja
-    - run: meson setup build
+    - run: meson setup builddir/
       env:
         CC: gcc
-    - run: meson test -C build -v
+    - run: meson test -C builddir/ -v
     - uses: actions/upload-artifact@v1
       if: failure()
       with:

--- a/docs/markdown/Release-notes-for-0.55.0.md
+++ b/docs/markdown/Release-notes-for-0.55.0.md
@@ -238,7 +238,7 @@ force fallback for specific subprojects.
 Example:
 
 ```
-meson build --force-fallback-for=foo,bar
+meson builddir/ --force-fallback-for=foo,bar
 ```
 
 ## Implicit dependency fallback

--- a/docs/markdown/Release-notes-for-0.56.0.md
+++ b/docs/markdown/Release-notes-for-0.56.0.md
@@ -145,13 +145,13 @@ foo = 'other val'
 ```
 
 ```console
-meson build --native-file my.ini
+meson builddir/ --native-file my.ini
 ```
 
 Will result in the option foo having the value `other val`,
 
 ```console
-meson build --native-file my.ini -Dfoo='different val'
+meson builddir/ --native-file my.ini -Dfoo='different val'
 ```
 
 Will result in the option foo having the value `different val`,


### PR DESCRIPTION
In most places, we now refer to "builddir/" which is a lot less likely to make people think it is a subcommand which needs to be used
literally.

This is a regression since commit 276d342ebaf859dd53e145ead3e98e2cebb360ab due to the existence of new docs which were added later on, using the wrong form.