### PR TITLE
mtest: asynchronous TAP parsing, improved progress report

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1055,6 +1055,10 @@ class SingleTestRunner:
     def visible_name(self) -> str:
         return self.runobj.name
 
+    @property
+    def timeout(self) -> T.Optional[int]:
+        return self.runobj.timeout
+
     async def run(self) -> TestRun:
         cmd = self._get_cmd()
         self.runobj.start()
@@ -1314,9 +1318,10 @@ class TestHarness:
         middle = result.name + (' ' * max(1, extra_name_width))
 
         if right is None:
-            right = '{res} {dur:.2f}s'.format(
+            right = '{res} {dur:{durlen}.2f}s'.format(
                 res=result.res.get_text(colorize),
-                dur=result.duration)
+                dur=result.duration,
+                durlen=self.duration_max_len + 3)
             detail = result.detail
             if detail:
                 right += ' (' + detail + ')'
@@ -1360,6 +1365,8 @@ class TestHarness:
                 os.chdir(self.options.wd)
             self.build_data = build.load(os.getcwd())
             runners = [self.get_test_runner(test) for test in tests]
+            self.duration_max_len = max([len(str(int(runner.timeout or 99)))
+                                         for runner in runners])
             self.run_tests(runners)
         finally:
             os.chdir(startdir)

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -620,12 +620,13 @@ class JunitBuilder(TestLogger):
                 failures=str(sum(1 for r in test.results.values() if r in
                                  {TestResult.FAIL, TestResult.UNEXPECTEDPASS, TestResult.TIMEOUT})),
                 skipped=str(sum(1 for r in test.results.values() if r is TestResult.SKIP)),
+                time=str(test.duration),
             )
 
-            for i, result in test.results.items():
-                # Both name and classname are required. Set them both to the
-                # number of the test in a TAP test, as TAP doesn't give names.
-                testcase = et.SubElement(suite, 'testcase', name=i, classname=i)
+            for i, result in enumerate(test.results):
+                # Set the name to the number of the test in a TAP test, as we cannot
+                # access the name yet.
+                testcase = et.SubElement(suite, 'testcase', name=str(i))
                 if result is TestResult.SKIP:
                     et.SubElement(testcase, 'skipped')
                 elif result is TestResult.ERROR:
@@ -651,12 +652,13 @@ class JunitBuilder(TestLogger):
             if test.project not in self.suites:
                 suite = self.suites[test.project] = et.Element(
                     'testsuite', name=test.project, tests='1', errors='0',
-                    failures='0', skipped='0')
+                    failures='0', skipped='0', time=str(test.duration))
             else:
                 suite = self.suites[test.project]
                 suite.attrib['tests'] = str(int(suite.attrib['tests']) + 1)
 
-            testcase = et.SubElement(suite, 'testcase', name=test.name, classname=test.name)
+            testcase = et.SubElement(suite, 'testcase', name=test.name,
+                                     time=str(test.duration))
             if test.res is TestResult.SKIP:
                 et.SubElement(testcase, 'skipped')
                 suite.attrib['skipped'] = str(int(suite.attrib['skipped']) + 1)

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -770,7 +770,7 @@ class TestRun:
             res = TestResult.EXPECTEDFAIL if bool(returncode) else TestResult.UNEXPECTEDPASS
         else:
             res = TestResult.FAIL if bool(returncode) else TestResult.OK
-        self.complete(res, returncode, stdo, stde, cmd, **kwargs)
+        self.complete(returncode, res, stdo, stde, cmd, **kwargs)
 
     def parse_tap(self, lines: T.Iterator[str]) -> T.Tuple[TestResult, str]:
         res = None    # type: T.Optional[TestResult]
@@ -800,7 +800,7 @@ class TestRun:
             res = TestResult.ERROR
             stde += '\n(test program exited with status code {})'.format(returncode,)
 
-        self.complete(res, returncode, stdo, stde, cmd)
+        self.complete(returncode, res, stdo, stde, cmd)
 
     def complete_rust(self, returncode: int, stdo: str, stde: str, cmd: T.List[str]) -> None:
         self.results, result = parse_rust_test(stdo)
@@ -810,7 +810,7 @@ class TestRun:
         else:
             res = result
 
-        self.complete(res, returncode, stdo, stde, cmd)
+        self.complete(returncode, res, stdo, stde, cmd)
 
     @property
     def num(self) -> int:
@@ -819,7 +819,7 @@ class TestRun:
             self._num = TestRun.TEST_NUM
         return self._num
 
-    def complete(self, res: TestResult, returncode: int,
+    def complete(self, returncode: int, res: TestResult,
                  stdo: T.Optional[str], stde: T.Optional[str],
                  cmd: T.List[str], *, junit: T.Optional[et.ElementTree] = None) -> None:
         assert isinstance(res, TestResult)
@@ -967,7 +967,7 @@ class SingleTestRunner:
         self.runobj.start()
         if cmd is None:
             skip_stdout = 'Not run because can not execute cross compiled binaries.'
-            self.runobj.complete(TestResult.SKIP, GNU_SKIP_RETURNCODE, skip_stdout, None, None)
+            self.runobj.complete(GNU_SKIP_RETURNCODE, TestResult.SKIP, skip_stdout, None, None)
         else:
             wrap = TestHarness.get_wrapper(self.options)
             if self.options.gdb:
@@ -1138,7 +1138,7 @@ class SingleTestRunner:
             self.runobj.complete_tap(returncode, result or res, stdo, stde, cmd)
 
         elif result:
-            self.runobj.complete(result, returncode, stdo, stde, cmd)
+            self.runobj.complete(returncode, result, stdo, stde, cmd)
         elif self.test.protocol is TestProtocol.EXITCODE:
             self.runobj.complete_exitcode(returncode, stdo, stde, cmd)
         elif self.test.protocol is TestProtocol.RUST:

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -518,6 +518,10 @@ class ConsoleLogger(TestLogger):
 
     def log(self, harness: 'TestHarness', result: 'TestRun') -> None:
         self.running_tests.remove(result)
+        if result.res is TestResult.TIMEOUT and harness.options.verbose:
+            self.flush()
+            print('{} time out (After {} seconds)'.format(result.name, result.timeout))
+
         if not harness.options.quiet or not result.res.is_ok():
             self.flush()
             print(harness.format(result, mlog.colorize_console()), flush=True)

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -237,9 +237,6 @@ class TAPParser:
     state = _MAIN
     version = 12
 
-    def __init__(self, io: T.Iterator[str]):
-        self.io = io
-
     def parse_test(self, ok: bool, num: int, name: str, directive: T.Optional[str], explanation: T.Optional[str]) -> \
             T.Generator[T.Union['TAPParser.Test', 'TAPParser.Error'], None, None]:
         name = name.strip()
@@ -258,8 +255,8 @@ class TAPParser:
 
         yield self.Test(num, name, TestResult.OK if ok else TestResult.FAIL, explanation)
 
-    def parse(self) -> T.Iterator[TYPE_TAPResult]:
-        for line in self.io:
+    def parse(self, io: T.Iterator[str]) -> T.Iterator[TYPE_TAPResult]:
+        for line in io:
             yield from self.parse_line(line)
         yield from self.parse_line(None)
 
@@ -747,7 +744,7 @@ class TestRun:
         results = {}  # type: T.Dict[str, TestResult]
         failed = False
 
-        for n, i in enumerate(TAPParser(io.StringIO(stdo)).parse()):
+        for n, i in enumerate(TAPParser().parse(io.StringIO(stdo))):
             if isinstance(i, TAPParser.Bailout):
                 results[str(n)] = TestResult.ERROR
                 failed = True

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -8889,25 +8889,25 @@ class TAPParserTests(unittest.TestCase):
 
     def test_empty_plan(self):
         events = self.parse_tap('1..0')
-        self.assert_plan(events, count=0, late=False, skipped=True)
+        self.assert_plan(events, num_tests=0, late=False, skipped=True)
         self.assert_last(events)
 
     def test_plan_directive(self):
         events = self.parse_tap('1..0 # skipped for some reason')
-        self.assert_plan(events, count=0, late=False, skipped=True,
+        self.assert_plan(events, num_tests=0, late=False, skipped=True,
                          explanation='for some reason')
         self.assert_last(events)
 
         events = self.parse_tap('1..1 # skipped for some reason\nok 1')
         self.assert_error(events)
-        self.assert_plan(events, count=1, late=False, skipped=True,
+        self.assert_plan(events, num_tests=1, late=False, skipped=True,
                          explanation='for some reason')
         self.assert_test(events, number=1, name='', result=TestResult.OK)
         self.assert_last(events)
 
         events = self.parse_tap('1..1 # todo not supported here\nok 1')
         self.assert_error(events)
-        self.assert_plan(events, count=1, late=False, skipped=False,
+        self.assert_plan(events, num_tests=1, late=False, skipped=False,
                          explanation='not supported here')
         self.assert_test(events, number=1, name='', result=TestResult.OK)
         self.assert_last(events)
@@ -8953,7 +8953,7 @@ class TAPParserTests(unittest.TestCase):
 
     def test_many_early_plan(self):
         events = self.parse_tap('1..4\nok 1\nnot ok 2\nok 3\nnot ok 4')
-        self.assert_plan(events, count=4, late=False)
+        self.assert_plan(events, num_tests=4, late=False)
         self.assert_test(events, number=1, name='', result=TestResult.OK)
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
         self.assert_test(events, number=3, name='', result=TestResult.OK)
@@ -8966,7 +8966,7 @@ class TAPParserTests(unittest.TestCase):
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
         self.assert_test(events, number=3, name='', result=TestResult.OK)
         self.assert_test(events, number=4, name='', result=TestResult.FAIL)
-        self.assert_plan(events, count=4, late=True)
+        self.assert_plan(events, num_tests=4, late=True)
         self.assert_last(events)
 
     def test_directive_case(self):
@@ -8991,14 +8991,14 @@ class TAPParserTests(unittest.TestCase):
 
     def test_one_test_early_plan(self):
         events = self.parse_tap('1..1\nok')
-        self.assert_plan(events, count=1, late=False)
+        self.assert_plan(events, num_tests=1, late=False)
         self.assert_test(events, number=1, name='', result=TestResult.OK)
         self.assert_last(events)
 
     def test_one_test_late_plan(self):
         events = self.parse_tap('ok\n1..1')
         self.assert_test(events, number=1, name='', result=TestResult.OK)
-        self.assert_plan(events, count=1, late=True)
+        self.assert_plan(events, num_tests=1, late=True)
         self.assert_last(events)
 
     def test_out_of_order(self):
@@ -9010,14 +9010,14 @@ class TAPParserTests(unittest.TestCase):
     def test_middle_plan(self):
         events = self.parse_tap('ok 1\n1..2\nok 2')
         self.assert_test(events, number=1, name='', result=TestResult.OK)
-        self.assert_plan(events, count=2, late=True)
+        self.assert_plan(events, num_tests=2, late=True)
         self.assert_error(events)
         self.assert_test(events, number=2, name='', result=TestResult.OK)
         self.assert_last(events)
 
     def test_too_many_plans(self):
         events = self.parse_tap('1..1\n1..2\nok 1')
-        self.assert_plan(events, count=1, late=False)
+        self.assert_plan(events, num_tests=1, late=False)
         self.assert_error(events)
         self.assert_test(events, number=1, name='', result=TestResult.OK)
         self.assert_last(events)
@@ -9026,12 +9026,12 @@ class TAPParserTests(unittest.TestCase):
         events = self.parse_tap('ok 1\nnot ok 2\n1..1')
         self.assert_test(events, number=1, name='', result=TestResult.OK)
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
-        self.assert_plan(events, count=1, late=True)
+        self.assert_plan(events, num_tests=1, late=True)
         self.assert_error(events)
         self.assert_last(events)
 
         events = self.parse_tap('1..1\nok 1\nnot ok 2')
-        self.assert_plan(events, count=1, late=False)
+        self.assert_plan(events, num_tests=1, late=False)
         self.assert_test(events, number=1, name='', result=TestResult.OK)
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
         self.assert_error(events)
@@ -9041,12 +9041,12 @@ class TAPParserTests(unittest.TestCase):
         events = self.parse_tap('ok 1\nnot ok 2\n1..3')
         self.assert_test(events, number=1, name='', result=TestResult.OK)
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
-        self.assert_plan(events, count=3, late=True)
+        self.assert_plan(events, num_tests=3, late=True)
         self.assert_error(events)
         self.assert_last(events)
 
         events = self.parse_tap('1..3\nok 1\nnot ok 2')
-        self.assert_plan(events, count=3, late=False)
+        self.assert_plan(events, num_tests=3, late=False)
         self.assert_test(events, number=1, name='', result=TestResult.OK)
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
         self.assert_error(events)
@@ -9054,7 +9054,7 @@ class TAPParserTests(unittest.TestCase):
 
     def test_too_few_bailout(self):
         events = self.parse_tap('1..3\nok 1\nnot ok 2\nBail out! no third test')
-        self.assert_plan(events, count=3, late=False)
+        self.assert_plan(events, num_tests=3, late=False)
         self.assert_test(events, number=1, name='', result=TestResult.OK)
         self.assert_test(events, number=2, name='', result=TestResult.FAIL)
         self.assert_bailout(events, message='no third test')
@@ -9062,29 +9062,29 @@ class TAPParserTests(unittest.TestCase):
 
     def test_diagnostics(self):
         events = self.parse_tap('1..1\n# ignored\nok 1')
-        self.assert_plan(events, count=1, late=False)
+        self.assert_plan(events, num_tests=1, late=False)
         self.assert_test(events, number=1, name='', result=TestResult.OK)
         self.assert_last(events)
 
         events = self.parse_tap('# ignored\n1..1\nok 1\n# ignored too')
-        self.assert_plan(events, count=1, late=False)
+        self.assert_plan(events, num_tests=1, late=False)
         self.assert_test(events, number=1, name='', result=TestResult.OK)
         self.assert_last(events)
 
         events = self.parse_tap('# ignored\nok 1\n1..1\n# ignored too')
         self.assert_test(events, number=1, name='', result=TestResult.OK)
-        self.assert_plan(events, count=1, late=True)
+        self.assert_plan(events, num_tests=1, late=True)
         self.assert_last(events)
 
     def test_empty_line(self):
         events = self.parse_tap('1..1\n\nok 1')
-        self.assert_plan(events, count=1, late=False)
+        self.assert_plan(events, num_tests=1, late=False)
         self.assert_test(events, number=1, name='', result=TestResult.OK)
         self.assert_last(events)
 
     def test_unexpected(self):
         events = self.parse_tap('1..1\ninvalid\nok 1')
-        self.assert_plan(events, count=1, late=False)
+        self.assert_plan(events, num_tests=1, late=False)
         self.assert_error(events)
         self.assert_test(events, number=1, name='', result=TestResult.OK)
         self.assert_last(events)
@@ -9099,7 +9099,7 @@ class TAPParserTests(unittest.TestCase):
         self.assert_last(events)
 
         events = self.parse_tap('1..0\nTAP version 13\n')
-        self.assert_plan(events, count=0, late=False, skipped=True)
+        self.assert_plan(events, num_tests=0, late=False, skipped=True)
         self.assert_error(events)
         self.assert_last(events)
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -8875,8 +8875,8 @@ class TAPParserTests(unittest.TestCase):
             next(events)
 
     def parse_tap(self, s):
-        parser = TAPParser(io.StringIO(s))
-        return iter(parser.parse())
+        parser = TAPParser()
+        return iter(parser.parse(io.StringIO(s)))
 
     def parse_tap_v13(self, s):
         events = self.parse_tap('TAP version 13\n' + s)


### PR DESCRIPTION
The next part after #8001. Adds:
* to the progress report a clock and, for TAP tests, the number of passed+run subtests.
* to the final test report for TAP tests, the number of subtests that have passed.

[Demo available here](https://asciinema.org/a/LIimxKSIyh8TNwq9U076vq0WU).