### PR TITLE
Do not test aarch64 as the assembly has not been written.

### DIFF
--- a/test cases/common/119 llvm ir and assembly/meson.build
+++ b/test cases/common/119 llvm ir and assembly/meson.build
@@ -1,7 +1,7 @@
 project('llvm-ir', 'c', 'cpp')
 
 cpu = host_machine.cpu_family()
-supported_cpus = ['arm', 'aarch64', 'x86', 'x86_64']
+supported_cpus = ['arm', 'x86', 'x86_64']
 
 foreach lang : ['c', 'cpp']
   cc = meson.get_compiler(lang)


### PR DESCRIPTION
Originally from Debian:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=975411