### PR TITLE
Add aarch64 assembly test

### DIFF
--- a/test cases/common/119 llvm ir and assembly/square-aarch64.S
+++ b/test cases/common/119 llvm ir and assembly/square-aarch64.S
@@ -15,6 +15,15 @@ SYMBOL_NAME(square_unsigned) ENDP
 
 #else
 
-#error gas syntax assembly for this test needs to be written
+.text
+.globl SYMBOL_NAME(square_unsigned)
+# ifdef __linux__
+.type square_unsigned, %function
+#endif
+
+SYMBOL_NAME(square_unsigned):
+    mul x1, x0, x0
+    mov x0, x1
+    ret
 
 #endif


### PR DESCRIPTION
Tested on a Raspberry pi 4 running `2020-08-20-raspios-buster-arm64-lite`.