### PR TITLE
Use release for dependencies if MSVC runtime is MD or MT

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -383,7 +383,9 @@ class ConverterTarget:
                     cfgs += [x for x in tgt.properties['CONFIGURATIONS'] if x]
                     cfg = cfgs[0]
 
-                is_debug = self.env.coredata.get_option(OptionKey('debug'));
+                is_debug = self.env.coredata.get_option(OptionKey('debug'))
+                if OptionKey('b_vscrt') in self.env.coredata.options:
+                    is_debug = self.env.coredata.options[OptionKey('b_vscrt')].value in {'mdd', 'mtd'}
                 if is_debug:
                     if 'DEBUG' in cfgs:
                         cfg = 'DEBUG'

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -1506,9 +1506,7 @@ class CMakeDependency(ExternalDependency):
                     cfg = cfgs[0]
 
                 if OptionKey('b_vscrt') in self.env.coredata.options:
-                    is_debug = self.env.coredata.get_option(OptionKey('buildtype')) == 'debug'
-                    if self.env.coredata.options[OptionKey('b_vscrt')].value in {'mdd', 'mtd'}:
-                        is_debug = True
+                    is_debug = self.env.coredata.options[OptionKey('b_vscrt')].value in {'mdd', 'mtd'}
                 else:
                     is_debug = self.env.coredata.get_option(OptionKey('debug'))
                 if is_debug:

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -23,7 +23,7 @@ from collections import OrderedDict
 from .. import mlog
 from .. import mesonlib
 from ..mesonlib import (
-    MesonException, Popen_safe, extract_as_list, version_compare_many
+    MesonException, OptionKey, Popen_safe, extract_as_list, version_compare_many
 )
 from ..environment import detect_cpu_family
 
@@ -380,12 +380,10 @@ class QtBaseDependency(ExternalDependency):
         self.bindir = self.get_qmake_host_bins(qvars)
         self.is_found = True
 
-        # Use the buildtype by default, but look at the b_vscrt option if the
-        # compiler supports it.
-        is_debug = self.env.coredata.get_option(mesonlib.OptionKey('buildtype')) == 'debug'
-        if mesonlib.OptionKey('b_vscrt') in self.env.coredata.options:
-            if self.env.coredata.options[mesonlib.OptionKey('b_vscrt')].value in {'mdd', 'mtd'}:
-                is_debug = True
+        if OptionKey('b_vscrt') in self.env.coredata.options:
+            is_debug = self.env.coredata.options[OptionKey('b_vscrt')].value in {'mdd', 'mtd'}
+        else:
+            is_debug = self.env.coredata.get_option(OptionKey('debug'))
         modules_lib_suffix = self._get_modules_lib_suffix(is_debug)
 
         for module in mods:


### PR DESCRIPTION
Specifying b_vscrt=MD should make dependencies use release build
even if buildtype is debug. The debug runtime in MSVC is much slower
and it is useful to be able to run own code in debug but the dependencies
are still in release. 

Before, using buildtype=debug, b_vscrt=MD with a cmake dependency caused
the debug version of dependency to be linked which will use MDd and which
could cause a runtime error.