### PR TITLE
Remove "Found runner: " logging message from meson compile

### DIFF
--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -141,7 +141,6 @@ def get_parsed_args_ninja(options: 'argparse.Namespace', builddir: Path) -> T.Tu
     runner = detect_ninja()
     if runner is None:
         raise MesonException('Cannot find ninja.')
-    mlog.log('Found runner:', str(runner))
 
     cmd = runner + ['-C', builddir.as_posix()]
 


### PR DESCRIPTION
The ninja path is already logged as part of configure. Logging it
again every time when using meson compile is overly verbose and
doesn't add much value for the user.