### PR TITLE
Add support for driving lld-link indirectly through clang on Windows

### DIFF
--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -113,7 +113,7 @@ class ClangCompiler(GnuLikeCompiler):
         if self.info.is_windows() and not self.info.is_cygwin() and isinstance(self.linker, ClangClDynamicLinker):
             return [f'-Wl,/subsystem:{value}']
         else:
-            return super().get_win_subsystem_args()
+            return super().get_win_subsystem_args(value)
 
     @classmethod
     def use_linker_args(cls, linker: str) -> T.List[str]:

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -112,8 +112,8 @@ class ClangCompiler(GnuLikeCompiler):
     def get_win_subsystem_args(self, value: str) -> T.List[str]:
         if self.info.is_windows() and not self.info.is_cygwin() and isinstance(self.linker, ClangClDynamicLinker):
             return [f'-Wl,/subsystem:{value}']
-        else:
-            return super().get_win_subsystem_args(value)
+        
+        return super().get_win_subsystem_args(value)
 
     @classmethod
     def use_linker_args(cls, linker: str) -> T.List[str]:

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -19,7 +19,7 @@ import shutil
 import typing as T
 
 from ... import mesonlib
-from ...linkers import AppleDynamicLinker
+from ...linkers import AppleDynamicLinker, ClangClDynamicLinker
 from ..compilers import CompileCheckMode
 from .gnu import GnuLikeCompiler
 
@@ -108,6 +108,12 @@ class ClangCompiler(GnuLikeCompiler):
         else:
             # Shouldn't work, but it'll be checked explicitly in the OpenMP dependency.
             return []
+    
+    def get_win_subsystem_args(self, value: str) -> T.List[str]:
+        if self.info.is_windows() and not self.info.is_cygwin() and isinstance(self.linker, ClangClDynamicLinker):
+            return [f'-Wl,/subsystem:{value}']
+        else:
+            return super().get_win_subsystem_args()
 
     @classmethod
     def use_linker_args(cls, linker: str) -> T.List[str]:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -940,6 +940,10 @@ class Environment:
                 return LLVMDynamicLinker(
                     compiler, for_machine, comp_class.LINKER_PREFIX,
                     override, version=search_version(o))
+            else:
+                return ClangClDynamicLinker(
+                    for_machine, override, exelist=compiler, prefix=comp_class.LINKER_PREFIX,
+                    version=search_version(o), direct=False, machine=None)
 
         if value is not None and invoked_directly:
             compiler = value

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -940,7 +940,7 @@ class Environment:
                 return LLVMDynamicLinker(
                     compiler, for_machine, comp_class.LINKER_PREFIX,
                     override, version=search_version(o))
-            else:
+            elif not invoked_directly:
                 return ClangClDynamicLinker(
                     for_machine, override, exelist=compiler, prefix=comp_class.LINKER_PREFIX,
                     version=search_version(o), direct=False, machine=None)
@@ -1240,7 +1240,7 @@ class Environment:
                     # style ld, but for clang on "real" windows we'll use
                     # either link.exe or lld-link.exe
                     try:
-                        linker = self._guess_win_linker(compiler, cls, for_machine)
+                        linker = self._guess_win_linker(compiler, cls, for_machine, invoked_directly=False)
                     except MesonException:
                         pass
                 if linker is None:

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -1164,6 +1164,14 @@ class ClangClDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
         super().__init__(exelist or ['lld-link.exe'], for_machine,
                          prefix, always_args, machine=machine, version=version, direct=direct)
 
+    def get_output_args(self, outputname: str) -> T.List[str]:
+        # If we're being driven indirectly by clang just skip /MACHINE
+        # as clang's target triple will handle the machine selection
+        if self.machine is None:
+            return self._apply_prefix([f"/OUT:{outputname}"])
+        else:
+            return super().get_output_args(outputname)
+
 
 class XilinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
 

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -1169,8 +1169,8 @@ class ClangClDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
         # as clang's target triple will handle the machine selection
         if self.machine is None:
             return self._apply_prefix([f"/OUT:{outputname}"])
-        else:
-            return super().get_output_args(outputname)
+
+        return super().get_output_args(outputname)
 
 
 class XilinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):


### PR DESCRIPTION
Fixes #8064

This PR adds support for using clang with a non-GNU compatible `lld` instance, which results in correct
host machine identification in cross-compilation scenarios aswell as support for using `lld-link` indirectly
through `clang` by selecting `lld` through `c_ld`.