### PR TITLE
msubprojects: Ignore worktrees when checking out

### DIFF
--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -85,7 +85,7 @@ def git_reset(repo_dir, revision):
     return True
 
 def git_checkout(repo_dir, revision, create=False):
-    cmd = ['checkout', revision, '--']
+    cmd = ['checkout', '--ignore-other-worktrees', revision, '--']
     if create:
         cmd.insert('-b', 1)
     try:


### PR DESCRIPTION
Otherwise it's not possible to share git subprojects via worktrees when creating a worktree of a git repository that uses meson subprojects.

The downside is that the user needs to be careful while adding commits to each tree's index.