### PR TITLE
pkgconfig: Respect variable ordering when passed as list

### DIFF
--- a/docs/markdown/Pkgconfig-module.md
+++ b/docs/markdown/Pkgconfig-module.md
@@ -50,7 +50,8 @@ keyword arguments.
   reference other pkgconfig variables,
   e.g. `datadir=${prefix}/share`. The names `prefix`, `libdir` and
   `includedir` are reserved and may not be used. *Since 0.56.0* it can also be a
-  dictionary.
+  dictionary but ordering of Meson dictionaries are not guaranteed, which could
+  cause issues when some variables reference other variables.
 - `version` a string describing the version of this library, used to set the
   `Version:` field. (*since 0.46.0*) Defaults to the project version if unspecified.
 - `d_module_versions` a list of module version flags used when compiling

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2708,7 +2708,7 @@ class Interpreter(InterpreterBase):
             varlist = mesonlib.stringlistify(variables)
             if list_new:
                 FeatureNew.single_use('variables as list of strings', '0.56.0', self.subproject)
-            variables = {}
+            variables = collections.OrderedDict()
             for v in varlist:
                 try:
                     (key, value) = v.split('=', 1)


### PR DESCRIPTION
This fix a regression introduced in Meson 0.56.0 when using python 3.5.
Also mention in documentation that using a meson dict does not guarantee
ordering.

Fixes: #8074.