### PR TITLE
Fixes to doc generation and installation

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -36,7 +36,7 @@ documentation = hotdoc.generate_doc(meson.project_name(),
     default_license: 'CC-BY-SAv4.0',
     html_extra_theme: join_paths(cur_bdir, 'theme', 'extra'),
     git_upload_repository: 'git@github.com:jpakkane/jpakkane.github.io.git',
-    edit_on_github_repository: 'https://github.com/mesonbuild/meson/',
+    edit_on_github_repository: 'https://github.com/mesonbuild/meson',
     syntax_highlighting_activate: true,
 )
 

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -381,7 +381,7 @@ class Installer:
                     self.log('Preserved {} unchanged files, see {} for the full list'
                              .format(self.preserved_file_count, os.path.normpath(self.lf.name)))
         except PermissionError:
-            if shutil.which('pkexec') is not None and 'PKEXEC_UID' not in os.environ:
+            if shutil.which('pkexec') is not None and 'PKEXEC_UID' not in os.environ and d.destdir is None:
                 print('Installation failed due to insufficient permissions.')
                 print('Attempting to use polkit to gain elevated privileges...')
                 os.execlp('pkexec', 'pkexec', sys.executable, main_file, *sys.argv[1:],


### PR DESCRIPTION
* All the generated "Edit on GitHub" links have a spurious "/"  `https://github.com/mesonbuild/meson//edit/master/docs/builddir/markdown/index.md`
* Installation via pkexec ignores DESTDIR

More details in the commit messages.