### PR TITLE
Add Qt6 module

### DIFF
--- a/ci/ciimage/arch/install.sh
+++ b/ci/ciimage/arch/install.sh
@@ -12,7 +12,7 @@ pkgs=(
   itstool gtk3 java-environment=8 gtk-doc llvm clang sdl2 graphviz
   doxygen vulkan-validation-layers openssh mercurial gtk-sharp-2 qt5-tools
   libwmf valgrind cmake netcdf-fortran openmpi nasm gnustep-base gettext
-  python-lxml hotdoc rust-bindgen
+  python-lxml hotdoc rust-bindgen qt6-base qt6-tools
   # cuda
 )
 

--- a/docs/markdown/snippets/qt6_module.md
+++ b/docs/markdown/snippets/qt6_module.md
@@ -1,0 +1,8 @@
+## Qt6 module
+
+A module for Qt6 is now available with the same functionality as the Qt5
+module.
+
+Currently finding Qt6 is only available via `qmake` as pkg-config files aren't
+generated (see [QTBUG-86080](https://bugreports.qt.io/browse/QTBUG-86080)) and
+CMake support is not available for this module yet.

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -30,7 +30,7 @@ from .misc import (
     shaderc_factory, threads_factory,
 )
 from .platform import AppleFrameworks
-from .ui import GnuStepDependency, Qt4Dependency, Qt5Dependency, WxDependency, gl_factory, sdl2_factory, vulkan_factory
+from .ui import GnuStepDependency, Qt4Dependency, Qt5Dependency, Qt6Dependency, WxDependency, gl_factory, sdl2_factory, vulkan_factory
 
 
 # This is a dict where the keys should be strings, and the values must be one
@@ -77,6 +77,7 @@ packages.update({
     'gnustep': GnuStepDependency,
     'qt4': Qt4Dependency,
     'qt5': Qt5Dependency,
+    'qt6': Qt6Dependency,
     'sdl2': sdl2_factory,
     'wxwidgets': WxDependency,
     'vulkan': vulkan_factory,

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -544,6 +544,17 @@ class Qt5Dependency(QtBaseDependency):
         return _qt_get_private_includes(mod_inc_dir, module, self.version)
 
 
+class Qt6Dependency(QtBaseDependency):
+    def __init__(self, env, kwargs):
+        QtBaseDependency.__init__(self, 'qt6', env, kwargs)
+
+    def get_pkgconfig_host_bins(self, core):
+        return core.get_pkgconfig_variable('host_bins', {})
+
+    def get_private_includes(self, mod_inc_dir, module):
+        return _qt_get_private_includes(mod_inc_dir, module, self.version)
+
+
 class SDL2DependencyConfigTool(ConfigToolDependency):
 
     tools = ['sdl2-config']

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -17,7 +17,7 @@ import shutil
 from .. import mlog
 from .. import build
 from ..mesonlib import MesonException, extract_as_list, File, unholder, version_compare
-from ..dependencies import Dependency, Qt4Dependency, Qt5Dependency, NonExistingExternalProgram
+from ..dependencies import Dependency, Qt4Dependency, Qt5Dependency, Qt6Dependency, NonExistingExternalProgram
 import xml.etree.ElementTree as ET
 from . import ModuleReturnValue, get_include_args, ExtensionModule
 from ..interpreterbase import noPosargs, permittedKwargs, FeatureNew, FeatureNewKwargs
@@ -25,7 +25,8 @@ from ..interpreter import extract_required_kwarg
 
 _QT_DEPS_LUT = {
     4: Qt4Dependency,
-    5: Qt5Dependency
+    5: Qt5Dependency,
+    6: Qt6Dependency,
 }
 
 

--- a/mesonbuild/modules/qt6.py
+++ b/mesonbuild/modules/qt6.py
@@ -1,0 +1,25 @@
+# Copyright 2020 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .qt import QtBaseModule
+
+
+class Qt6Module(QtBaseModule):
+
+    def __init__(self, interpreter):
+        QtBaseModule.__init__(self, interpreter, qt_version=6)
+
+
+def initialize(*args, **kwargs):
+    return Qt6Module(*args, **kwargs)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6478,6 +6478,26 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertRegex('\n'.join(mesonlog),
                          r'Run-time dependency qt5 \(modules: Core\) found: YES .* \((qmake|qmake-qt5)\)\n')
 
+    def test_qt6dependency_qmake_detection(self):
+        '''
+        Test that qt6 detection with qmake works. This can't be an ordinary
+        test case because it involves setting the environment.
+        '''
+        # Verify that qmake is for Qt5
+        if not shutil.which('qmake-qt6'):
+            if not shutil.which('qmake'):
+                raise unittest.SkipTest('QMake not found')
+            output = subprocess.getoutput('qmake --version')
+            if 'Qt version 6' not in output:
+                raise unittest.SkipTest('Qmake found, but it is not for Qt 6.')
+        # Disable pkg-config codepath and force searching with qmake/qmake-qt6
+        testdir = os.path.join(self.framework_test_dir, '4 qt')
+        self.init(testdir, extra_args=['-Dmethod=qmake'])
+        # Confirm that the dependency was found with qmake
+        mesonlog = self.get_meson_log()
+        self.assertRegex('\n'.join(mesonlog),
+                         r'Run-time dependency qt6 \(modules: Core\) found: YES .* \((qmake|qmake-qt6)\)\n')
+
     def glob_sofiles_without_privdir(self, g):
         files = glob(g)
         return [f for f in files if not f.endswith('.p')]

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -3,10 +3,13 @@ project('qt4 and 5 build test', 'cpp',
   default_options : ['cpp_std=c++11'])
 
 qt5_modules = ['Widgets']
-foreach qt : ['qt4', 'qt5']
+qt6_modules = ['Widgets']
+foreach qt : ['qt4', 'qt5', 'qt6']
   qt_modules = ['Core', 'Gui']
   if qt == 'qt5'
     qt_modules += qt5_modules
+  elif qt == 'qt6'
+    qt_modules += qt6_modules
   endif
 
   # Test that invalid modules are indeed not found


### PR DESCRIPTION
This is basically a copy of the Qt5 module but from what I've tried (on 3 related but distinct projects) it seems to work properly.

```
Found qmake: /usr/bin/qmake-qt6 (6.0.0)
Run-time dependency qt6 (modules: Core, DBus, Gui, Network, Widgets) found: YES 6.0.0 (qmake-qt6)
```

Fixes #8056 

I'll see what I can do about tests & docs

edit: Tests are a bit difficult - e.g. `test_qtdependency_pkgconfig_detection` because no pkg-config files seem to be built for Qt6 (by default?). `test_qt5dependency_qmake_detection` could be copy-pasted for qt6.

`docs/markdown/Qt6-module.md` could be a stub referencing Qt5-module.md as everything's literally the same. `docs/markdown/Dependencies.md` can get the "Qt4 & Qt5" header expanded to include Qt6

edit 2: Qt should be found using CMake now as CMake is the primary build system for Qt6 now - qmake is deprecated and pkg-config as mentioned above isn't generated (at least right now in Arch Linux). This will have to be implemented still