### PR TITLE
unit tests: correctly skip c++20 checks if the compiler doesn't support them

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,11 +6,13 @@ on:
       - "mesonbuild/**"
       - "test cases/**"
       - ".github/workflows/macos.yml"
+      - "run_unittests.py"
   pull_request:
     paths:
       - "mesonbuild/**"
       - "test cases/**"
       - ".github/workflows/macos.yml"
+      - "run_unittests.py"
 
 jobs:
   unittests-appleclang:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -6,11 +6,13 @@ on:
       - "mesonbuild/**"
       - "test cases/**"
       - ".github/workflows/msys2.yml"
+      - "run_unittests.py"
   pull_request:
     paths:
       - "mesonbuild/**"
       - "test cases/**"
       - ".github/workflows/msys2.yml"
+      - "run_unittests.py"
 
 jobs:
   test:


### PR DESCRIPTION
I can't find a supported version for AppleClang, and you need relatively
recent versions of GCC and Clang for -std=c++20 to work.