### PR TITLE
Make win_subsystem a linker property

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2598,8 +2598,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             # If gui_app is significant on this platform, add the appropriate linker arguments.
             # Unfortunately this can't be done in get_target_type_link_args, because some misguided
             # libraries (such as SDL2) add -mwindows to their link flags.
+
             if target.gui_app is not None:
-                commands += linker.get_gui_app_args(target.gui_app)
+                commands += linker.get_gui_app_args(self.environment, target.gui_app)
             else:
                 commands += linker.get_win_subsystem_args(self.environment, target.win_subsystem)
         return commands

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2601,7 +2601,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             if target.gui_app is not None:
                 commands += linker.get_gui_app_args(target.gui_app)
             else:
-                commands += linker.get_win_subsystem_args(target.win_subsystem)
+                commands += linker.get_win_subsystem_args(self.environment, target.win_subsystem)
         return commands
 
     def get_link_whole_args(self, linker, target):

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2598,11 +2598,13 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             # If gui_app is significant on this platform, add the appropriate linker arguments.
             # Unfortunately this can't be done in get_target_type_link_args, because some misguided
             # libraries (such as SDL2) add -mwindows to their link flags.
+            m = self.environment.machines[target.for_machine]
 
-            if target.gui_app is not None:
-                commands += linker.get_gui_app_args(self.environment, target.gui_app)
-            else:
-                commands += linker.get_win_subsystem_args(self.environment, target.win_subsystem)
+            if m.is_windows() or m.is_cygwin():
+                if target.gui_app is not None:
+                    commands += linker.get_gui_app_args(target.gui_app)
+                else:
+                    commands += linker.get_win_subsystem_args(target.win_subsystem)
         return commands
 
     def get_link_whole_args(self, linker, target):

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -873,11 +873,11 @@ class Compiler(metaclass=abc.ABCMeta):
     def get_gui_app_args(self, value: bool) -> T.List[str]:
         return []
 
-    def get_win_subsystem_args(self, value: str) -> T.List[str]:
+    def get_win_subsystem_args(self, env: 'Environment', value: str) -> T.List[str]:
         # By default the dynamic linker is going to return an empty
         # array in case it either doesn't support Windows subsystems
         # or does not target Windows
-        return self.linker.get_win_subsystem_args(value)
+        return self.linker.get_win_subsystem_args(env, value)
 
     def has_func_attribute(self, name: str, env: 'Environment') -> T.Tuple[bool, bool]:
         raise EnvironmentException(

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -874,11 +874,10 @@ class Compiler(metaclass=abc.ABCMeta):
         return []
 
     def get_win_subsystem_args(self, value: str) -> T.List[str]:
-        # This returns an empty array rather than throws to simplify the code.
-        # Otherwise we would have to check whenever calling this function whether
-        # the target is for Windows. There are also many cases where this is
-        # a meaningless choice, such as with Jave or C#.
-        return []
+        # By default the dynamic linker is going to return an empty
+        # array in case it either doesn't support Windows subsystems
+        # or does not target Windows
+        return self.linker.get_win_subsystem_args(value)
 
     def has_func_attribute(self, name: str, env: 'Environment') -> T.Tuple[bool, bool]:
         raise EnvironmentException(

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -870,9 +870,9 @@ class Compiler(metaclass=abc.ABCMeta):
     def gnu_symbol_visibility_args(self, vistype: str) -> T.List[str]:
         return []
 
-    def get_gui_app_args(self, value: bool) -> T.List[str]:
+    def get_gui_app_args(self, env: 'Environment', value: bool) -> T.List[str]:
         # Only used on Windows
-        return self.linker.get_gui_app_args(value)
+        return self.linker.get_gui_app_args(env, value)
 
     def get_win_subsystem_args(self, env: 'Environment', value: str) -> T.List[str]:
         # By default the dynamic linker is going to return an empty

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -870,15 +870,15 @@ class Compiler(metaclass=abc.ABCMeta):
     def gnu_symbol_visibility_args(self, vistype: str) -> T.List[str]:
         return []
 
-    def get_gui_app_args(self, env: 'Environment', value: bool) -> T.List[str]:
+    def get_gui_app_args(self, value: bool) -> T.List[str]:
         # Only used on Windows
-        return self.linker.get_gui_app_args(env, value)
+        return self.linker.get_gui_app_args(value)
 
-    def get_win_subsystem_args(self, env: 'Environment', value: str) -> T.List[str]:
+    def get_win_subsystem_args(self, value: str) -> T.List[str]:
         # By default the dynamic linker is going to return an empty
         # array in case it either doesn't support Windows subsystems
         # or does not target Windows
-        return self.linker.get_win_subsystem_args(env, value)
+        return self.linker.get_win_subsystem_args(value)
 
     def has_func_attribute(self, name: str, env: 'Environment') -> T.Tuple[bool, bool]:
         raise EnvironmentException(

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -871,7 +871,8 @@ class Compiler(metaclass=abc.ABCMeta):
         return []
 
     def get_gui_app_args(self, value: bool) -> T.List[str]:
-        return []
+        # Only used on Windows
+        return self.linker.get_gui_app_args(value)
 
     def get_win_subsystem_args(self, env: 'Environment', value: str) -> T.List[str]:
         # By default the dynamic linker is going to return an empty

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -19,7 +19,7 @@ import shutil
 import typing as T
 
 from ... import mesonlib
-from ...linkers import AppleDynamicLinker, ClangClDynamicLinker
+from ...linkers import AppleDynamicLinker
 from ..compilers import CompileCheckMode
 from .gnu import GnuLikeCompiler
 

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -109,12 +109,6 @@ class ClangCompiler(GnuLikeCompiler):
             # Shouldn't work, but it'll be checked explicitly in the OpenMP dependency.
             return []
     
-    def get_win_subsystem_args(self, value: str) -> T.List[str]:
-        if self.info.is_windows() and not self.info.is_cygwin() and isinstance(self.linker, ClangClDynamicLinker):
-            return [f'-Wl,/subsystem:{value}']
-        
-        return super().get_win_subsystem_args(value)
-
     @classmethod
     def use_linker_args(cls, linker: str) -> T.List[str]:
         # Clang additionally can use a linker specified as a path, which GCC

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -219,20 +219,6 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
             return ['-mwindows' if value else '-mconsole']
         return []
 
-    def get_win_subsystem_args(self, value: str) -> T.List[str]:
-        args = []
-        if self.info.is_windows() or self.info.is_cygwin():
-            if 'windows' in value:
-                args = ['-Wl,--subsystem,windows']
-            elif 'console' in value:
-                args = ['-Wl,--subsystem,console']
-            else:
-                raise mesonlib.MesonException('Only "windows" and "console" are supported for win_subsystem with MinGW, not "{}".'.format(value))
-        if ',' in value:
-            args[-1] = args[-1] + ':' + value.split(',')[1]
-        return args
-
-
     def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str], build_dir: str) -> T.List[str]:
         for idx, i in enumerate(parameter_list):
             if i[:2] == '-I' or i[:2] == '-L':

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -214,10 +214,8 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     def get_profile_use_args(self) -> T.List[str]:
         return ['-fprofile-use', '-fprofile-correction']
 
-    def get_gui_app_args(self, env: 'Environment', value: bool) -> T.List[str]:
-        if self.info.is_windows() or self.info.is_cygwin():
-            return ['-mwindows' if value else '-mconsole']
-        return []
+    def get_gui_app_args(self, value: bool) -> T.List[str]:
+        return ['-mwindows' if value else '-mconsole']
 
     def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str], build_dir: str) -> T.List[str]:
         for idx, i in enumerate(parameter_list):

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -214,7 +214,7 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     def get_profile_use_args(self) -> T.List[str]:
         return ['-fprofile-use', '-fprofile-correction']
 
-    def get_gui_app_args(self, value: bool) -> T.List[str]:
+    def get_gui_app_args(self, env: 'Environment', value: bool) -> T.List[str]:
         if self.info.is_windows() or self.info.is_cygwin():
             return ['-mwindows' if value else '-mconsole']
         return []

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -205,9 +205,6 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         else:
             return ['/SUBSYSTEM:CONSOLE']
 
-    def get_win_subsystem_args(self, value: str) -> T.List[str]:
-        return ['/SUBSYSTEM:' + value.upper()]
-
     def get_pic_args(self) -> T.List[str]:
         return [] # PIC is handled by the loader on Windows
 

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -197,14 +197,6 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     def linker_to_compiler_args(self, args: T.List[str]) -> T.List[str]:
         return ['/link'] + args
 
-    def get_gui_app_args(self, value: bool) -> T.List[str]:
-        # the default is for the linker to guess the subsystem based on presence
-        # of main or WinMain symbols, so always be explicit
-        if value:
-            return ['/SUBSYSTEM:WINDOWS']
-        else:
-            return ['/SUBSYSTEM:CONSOLE']
-
     def get_pic_args(self) -> T.List[str]:
         return [] # PIC is handled by the loader on Windows
 

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -477,7 +477,7 @@ class DynamicLinker(LinkerEnvVarsMixin, metaclass=abc.ABCMeta):
         # Only used by the Apple linker
         return []
 
-    def get_gui_app_args(self, value: bool) -> T.List[str]:
+    def get_gui_app_args(self, env: 'Environment', value: bool) -> T.List[str]:
         # Only used by VisualStudioLikeLinkers
         return []
 
@@ -1154,11 +1154,11 @@ class VisualStudioLikeLinkerMixin:
     def get_allow_undefined_args(self) -> T.List[str]:
         return []
 
-    def get_gui_app_args(self, value: bool) -> T.List[str]:
+    def get_gui_app_args(self, env: 'Environment', value: bool) -> T.List[str]:
         if value:
-            return self.get_win_subsystem_args("windows")
+            return self.get_win_subsystem_args(env, "windows")
 
-        return self.get_win_subsystem_args("console")
+        return self.get_win_subsystem_args(env, "console")
 
     def get_win_subsystem_args(self, env: 'Environment', value: str) -> T.List[str]:
         return self._apply_prefix([f'/SUBSYSTEM:{value.upper()}'])

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -477,7 +477,7 @@ class DynamicLinker(LinkerEnvVarsMixin, metaclass=abc.ABCMeta):
         # Only used by the Apple linker
         return []
 
-    def get_win_subsystem_args(self, value: str) -> T.List[str]:
+    def get_win_subsystem_args(self, env: 'Environment', value: str) -> T.List[str]:
         # Only used if supported by the dynamic linker and
         # only when targeting Windows
         return []
@@ -748,7 +748,7 @@ class GnuDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, Dynam
 
     """Representation of GNU ld.bfd and ld.gold."""
 
-    def get_win_subsystem_args(self, value: str) -> T.List[str]:
+    def get_win_subsystem_args(self, env: 'Environment', value: str) -> T.List[str]:
         m = env.machines[self.for_machine]
         args = []
 
@@ -802,7 +802,7 @@ class LLVMDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, Dyna
             return self._apply_prefix('--allow-shlib-undefined')
         return []
 
-    def get_win_subsystem_args(self, value: str) -> T.List[str]:
+    def get_win_subsystem_args(self, env: 'Environment', value: str) -> T.List[str]:
         m = env.machines[self.for_machine]
         if not m.is_windows() or m.is_cygwin():
             return []

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -1146,12 +1146,6 @@ class VisualStudioLikeLinkerMixin:
     def get_allow_undefined_args(self) -> T.List[str]:
         return []
 
-    def get_gui_app_args(self, value: bool) -> T.List[str]:
-        return self.get_win_subsystem_args("windows" if value else "console")
-
-    def get_win_subsystem_args(self, value: str) -> T.List[str]:
-        return self._apply_prefix([f'/SUBSYSTEM:{value.upper()}'])
-
     def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
                         suffix: str, soversion: str, darwin_versions: T.Tuple[str, str],
                         is_shared_module: bool) -> T.List[str]:
@@ -1179,6 +1173,12 @@ class MSVCDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
     def get_always_args(self) -> T.List[str]:
         return self._apply_prefix(['/nologo', '/release']) + super().get_always_args()
 
+    def get_gui_app_args(self, value: bool) -> T.List[str]:
+        return self.get_win_subsystem_args("windows" if value else "console")
+
+    def get_win_subsystem_args(self, value: str) -> T.List[str]:
+        return self._apply_prefix([f'/SUBSYSTEM:{value.upper()}'])
+
 
 class ClangClDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
 
@@ -1201,6 +1201,12 @@ class ClangClDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
             return self._apply_prefix([f"/OUT:{outputname}"])
 
         return super().get_output_args(outputname)
+
+    def get_gui_app_args(self, value: bool) -> T.List[str]:
+        return self.get_win_subsystem_args("windows" if value else "console")
+
+    def get_win_subsystem_args(self, value: str) -> T.List[str]:
+        return self._apply_prefix([f'/SUBSYSTEM:{value.upper()}'])
 
 
 class XilinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -477,6 +477,10 @@ class DynamicLinker(LinkerEnvVarsMixin, metaclass=abc.ABCMeta):
         # Only used by the Apple linker
         return []
 
+    def get_gui_app_args(self, value: bool) -> T.List[str]:
+        # Only used by VisualStudioLikeLinkers
+        return []
+
     def get_win_subsystem_args(self, env: 'Environment', value: str) -> T.List[str]:
         # Only used if supported by the dynamic linker and
         # only when targeting Windows
@@ -1149,6 +1153,12 @@ class VisualStudioLikeLinkerMixin:
 
     def get_allow_undefined_args(self) -> T.List[str]:
         return []
+
+    def get_gui_app_args(self, value: bool) -> T.List[str]:
+        if value:
+            return self.get_win_subsystem_args("windows")
+
+        return self.get_win_subsystem_args("console")
 
     def get_win_subsystem_args(self, env: 'Environment', value: str) -> T.List[str]:
         return self._apply_prefix([f'/SUBSYSTEM:{value.upper()}'])

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -1150,7 +1150,7 @@ class VisualStudioLikeLinkerMixin:
     def get_allow_undefined_args(self) -> T.List[str]:
         return []
 
-    def get_win_subsystem_args(self, value: str) -> T.List[str]:
+    def get_win_subsystem_args(self, env: 'Environment', value: str) -> T.List[str]:
         return self._apply_prefix([f'/SUBSYSTEM:{value.upper()}'])
 
     def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,


### PR DESCRIPTION
This is more of a little cleanup amendment to #8071 which moves `get_win_subsystem_args` to the linker side
instead. `get_gui_app_args` is left mostly unchanged as both clang and gcc have special options to handle those two
subsystems directly from the compiler driver.