### PR TITLE
Fix the subsystem options for lld in mingw mode

### DIFF
--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -668,6 +668,18 @@ class GnuLikeDynamicLinkerMixin:
 
         return (args, rpath_dirs_to_remove)
 
+    def get_win_subsystem_args(self, value: str) -> T.List[str]:
+        if 'windows' in value:
+            args = ['--subsystem,windows']
+        elif 'console' in value:
+            args = ['--subsystem,console']
+        else:
+            raise mesonlib.MesonException(f'Only "windows" and "console" are supported for win_subsystem with MinGW, not "{value}".')
+        if ',' in value:
+            args[-1] = args[-1] + ':' + value.split(',')[1]
+
+        return self._apply_prefix(args)
+
 
 class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
@@ -752,18 +764,6 @@ class GnuDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, Dynam
 
     """Representation of GNU ld.bfd and ld.gold."""
 
-    def get_win_subsystem_args(self, value: str) -> T.List[str]:
-        if 'windows' in value:
-            args = ['--subsystem,windows']
-        elif 'console' in value:
-            args = ['--subsystem,console']
-        else:
-            raise mesonlib.MesonException(f'Only "windows" and "console" are supported for win_subsystem with MinGW, not "{value}".')
-        if ',' in value:
-            args[-1] = args[-1] + ':' + value.split(',')[1]
-
-        return self._apply_prefix(args)
-
     def get_accepts_rsp(self) -> bool:
         return True
 
@@ -801,9 +801,6 @@ class LLVMDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, Dyna
         if self.has_allow_shlib_undefined:
             return self._apply_prefix('--allow-shlib-undefined')
         return []
-
-    def get_win_subsystem_args(self, value: str) -> T.List[str]:
-        return self._apply_prefix([f'-subsystem:{value}'])
 
 
 class WASMDynamicLinker(GnuLikeDynamicLinkerMixin, PosixDynamicLinkerMixin, DynamicLinker):


### PR DESCRIPTION
lld in gnu like mode (e.g. for mingw) needs these options in
the same for as gnu ld, thus remove the lld specific code bit
and move the code for gnu like options into GnuLikeDynamicLinkerMixin.

This unbreaks linking with lld for mingw targets after
2fb4d1f7512a4ec125883fd65115ab33a5b06b6f.

CC @dcbaker @e820 