### PR TITLE
unit:cpp17: make C++17 test stricter check

### DIFF
--- a/test cases/unit/45 vscpp17/main.cpp
+++ b/test cases/unit/45 vscpp17/main.cpp
@@ -1,7 +1,29 @@
-[[nodiscard]] int foo(void) {
-    return 0;
-}
+#include <iostream>
 
-int main(void) {
-    return foo();
+#if __cpp_lib_filesystem || (defined(__cplusplus) && __cplusplus >= 201703L)
+#include <filesystem>
+#endif
+
+int main(){
+
+#if __cpp_lib_filesystem || (defined(__cplusplus) && __cplusplus >= 201703L)
+char fs = std::filesystem::path::preferred_separator;
+std::cout << "OK: C++17 filesystem enabled" << std::endl;
+#endif
+
+#if defined(_MSC_VER)
+#if _HAS_CXX17
+std::cout << "OK: MSVC has C++17 enabled" << std::endl;
+return EXIT_SUCCESS;
+#else
+std::cerr << "ERROR: MSVC does not have C++17 enabled" << std::endl;
+return EXIT_FAILURE;
+#endif
+#elif defined(__cplusplus) && __cplusplus >= 201703L
+std::cout << "OK: C++17 enabled" << std::endl;
+return EXIT_SUCCESS;
+#else
+std::cerr << "ERROR: C++17 not enabled" << std::endl;
+return EXIT_FAILURE;
+#endif
 }


### PR DESCRIPTION
many compilers allow "nodiscard" C++17 feature with pre-c++17 (or no) flags.
The C++17 filesystem typically actually does require -std=c++17 (or that compiler default).
This makes this unit test more representative of C++17 flag support.

We also test an MSVC macro for better coverage.