### PR TITLE
Fix clang-cl not being detected properly if c contains a path

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1196,7 +1196,7 @@ class Environment:
                 compiler = [compiler]
             compiler_name = os.path.basename(compiler[0])
 
-            if not set(['cl', 'cl.exe', 'clang-cl', 'clang-cl.exe']).isdisjoint(compiler):
+            if not {'cl', 'cl.exe', 'clang-cl', 'clang-cl.exe'}.isdisjoint({compiler_name}):
                 # Watcom C provides it's own cl.exe clone that mimics an older
                 # version of Microsoft's compiler. Since Watcom's cl.exe is
                 # just a wrapper, we skip using it if we detect its presence


### PR DESCRIPTION
Fixes a small issue I came across when looking into making meson drive `clang-cl` properly on unix build machines. Previously if you supplied a full path to the `clang-cl` binary in a cross-file `_detect_c_or_cpp_compiler` would erroneously try to detect the compiler as a gnu-compatible `clang` instance as it missed the cl check and passed `--version` instead of `"/?"` which ends up not printing the cl compatibility string.

CC @dcbaker 