### PR TITLE
environment.py: Detect all mips* architectures

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -378,7 +378,7 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
     elif trial in {'sun4u', 'sun4v'}:
         trial = 'sparc64'
     elif trial.startswith('mips'):
-        if not '64' in trial:
+        if '64' not in trial:
             trial = 'mips'
         else:
             trial = 'mips64'
@@ -436,7 +436,7 @@ def detect_cpu(compilers: CompilersDict):
         # Make more precise CPU detection for Elbrus platform.
         trial = platform.processor().lower()
     elif trial.startswith('mips'):
-        if not '64' in trial:
+        if '64' not in trial:
             trial = 'mips'
         else:
             trial = 'mips64'

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -377,8 +377,11 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
         trial = 'x86_64'
     elif trial in {'sun4u', 'sun4v'}:
         trial = 'sparc64'
-    elif trial in {'mipsel', 'mips64el'}:
-        trial = trial.rstrip('el')
+    elif trial.startswith('mips'):
+        if not '64' in trial:
+            trial = 'mips'
+        else:
+            trial = 'mips64'
     elif trial in {'ip30', 'ip35'}:
         trial = 'mips64'
 
@@ -433,7 +436,10 @@ def detect_cpu(compilers: CompilersDict):
         # Make more precise CPU detection for Elbrus platform.
         trial = platform.processor().lower()
     elif trial.startswith('mips'):
-        trial = trial.rstrip('el')
+        if not '64' in trial:
+            trial = 'mips'
+        else:
+            trial = 'mips64'
 
     # Add more quirks here as bugs are reported. Keep in sync with
     # detect_cpu_family() above.


### PR DESCRIPTION
We have more than those values, like:

mipsel
mipsel-nf
mips32el
mips33el-nf
mipsisa32r6
mipsisa32r6el

So lets just detect them all.

Sorry I forgot about 64bit and closed https://github.com/mesonbuild/meson/pull/8106

But now it even detects:

mipsisa64r6
mipsisa64r6el