### PR TITLE
VS: copy dll dependencies from import libraries next to executable

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -126,7 +126,8 @@ platforms or with all compilers:
 | b_sanitize  | none          | see below               | Code sanitizer to use |
 | b_staticpic | true          | true, false             | Build static libraries as position independent |
 | b_pie       | false         | true, false             | Build position-independent executables (since 0.49.0)|
-| b_vscrt     | from_buildtype| none, md, mdd, mt, mtd, from_buildtype, static_from_buildtype | VS runtime library to use (since 0.48.0) (static_from_buildtype since 0.56.0) |
+| b_vscrt     | from_buildtype| none, md, mdd, mt, mtd, from_buildtype, static_from_buildtype | VS runtime library to use (since 0.48.0) (static_from_buildtype since 0.56.
+| b_copy_deps | copy          | no, copy, symlink_or_copy | Copy VS run-time dependency dlls next to executable targets (since 0.57.0) |
 
 The value of `b_sanitize` can be one of: `none`, `address`, `thread`,
 `undefined`, `memory`, `address,undefined`.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -37,6 +37,7 @@ from ..compilers import (
     FortranCompiler, PGICCompiler,
     VisualStudioCsCompiler,
     VisualStudioLikeCompiler,
+    VisualStudioCPPCompiler,
 )
 from ..linkers import ArLinker, VisualStudioLinker
 from ..mesonlib import (
@@ -870,6 +871,12 @@ int dummy;
         elem = self.generate_link(target, outname, final_obj_list, linker, pch_objects, stdlib_args=stdlib_args)
         self.generate_dependency_scan_target(target, compiled_sources, source2object)
         self.generate_shlib_aliases(target, self.get_target_dir(target))
+
+        # Copy runtime dependency dlls next to executable
+        if 'cpp' in target.compilers:
+            if isinstance(target, build.Executable) and isinstance(target.compilers['cpp'], VisualStudioCPPCompiler):
+                self.copy_external_dep_dlls(target)
+        
         self.add_build(elem)
 
     def should_scan_target(self, target):

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1141,6 +1141,11 @@ class Vs2010Backend(backends.Backend):
                             ET.SubElement(clconf, 'OpenMPSuppport').text = 'true'
                         else:
                             extra_link_args.extend_direct(dep.get_link_args())
+
+        # Copy runtime dependency dlls next to executable
+        if isinstance(target, build.Executable):
+            self.copy_external_dep_dlls(target)
+
         # Add link args for c_* or cpp_* build options. Currently this only
         # adds c_winlibs and cpp_winlibs when building for Windows. This needs
         # to be after all internal and external libraries so that unresolved

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -291,6 +291,9 @@ base_options = {'b_pch': coredata.UserBooleanOption('Use precompiled headers', T
                 'b_vscrt': coredata.UserComboOption('VS run-time library type to use.',
                                                     ['none', 'md', 'mdd', 'mt', 'mtd', 'from_buildtype', 'static_from_buildtype'],
                                                     'from_buildtype'),
+                'b_copy_deps': coredata.UserComboOption('Copy VS run-time dependency dlls next to executable targets.',
+                                                    ['no', 'symlink_or_copy', 'copy'],
+                                                    'copy'),
                 }  # type: OptionDictType
 
 def option_enabled(boptions: T.List[str], options: 'OptionDictType',

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -644,7 +644,7 @@ class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixi
         CPPCompiler.__init__(self, exelist, version, for_machine, is_cross,
                              info, exe_wrapper, linker=linker, full_version=full_version)
         MSVCCompiler.__init__(self, target)
-        self.base_options = ['b_pch', 'b_vscrt', 'b_ndebug'] # FIXME add lto, pgo and the like
+        self.base_options = ['b_pch', 'b_vscrt', 'b_ndebug', 'b_copy_deps'] # FIXME add lto, pgo and the like
         self.id = 'msvc'
 
     def get_options(self) -> 'OptionDictType':


### PR DESCRIPTION
- Copy dependent dlls next to executable targets automatically. This allows
 executables that are linked with import libraries to be runnable automatically in
 the build directory. This makes it easier to use found libraries from e.g. conan
 or vcpkg.
- Add option "b_copy_deps" that by default copies the dlls but it has
 an option to use symlink in case there are many dependencies that copying
 the dlls would take needlessly much space when building multiple configurations.
 When installing the dlls are always copied to install dir.
Base options seems a bit wrong for this as this is not a flag for the compiler
but this is not backend specific either.

How can I implement tests for this? How to get an import library for linking
and test that trying to run the target does not work without this because
the dll is not found next to executable and it does not exist in PATH.