### PR TITLE
RPATH fixes

### DIFF
--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -1260,8 +1260,13 @@ class SolarisDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
             return ([], set())
         processed_rpaths = prepare_rpaths(rpath_paths, build_dir, from_dir)
         all_paths = mesonlib.OrderedSet([os.path.join('$ORIGIN', p) for p in processed_rpaths])
+        rpath_dirs_to_remove = set()
+        for p in all_paths:
+            rpath_dirs_to_remove.add(p.encode('utf8'))
         if build_rpath != '':
             all_paths.add(build_rpath)
+            for p in build_rpath.split(':'):
+                rpath_dirs_to_remove.add(p.encode('utf8'))
 
         # In order to avoid relinking for RPATH removal, the binary needs to contain just
         # enough space in the ELF header to hold the final installation RPATH.
@@ -1272,7 +1277,7 @@ class SolarisDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
                 paths = padding
             else:
                 paths = paths + ':' + padding
-        return (self._apply_prefix('-rpath,{}'.format(paths)), set())
+        return (self._apply_prefix('-rpath,{}'.format(paths)), rpath_dirs_to_remove)
 
     def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
                         suffix: str, soversion: str, darwin_versions: T.Tuple[str, str],

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -313,7 +313,7 @@ class Elf(DataSizes):
         # Only add each one once.
         new_rpaths = OrderedSet()  # type: OrderedSet[bytes]
         if new_rpath:
-            new_rpaths.add(new_rpath)
+            new_rpaths.update(new_rpath.split(b':'))
         if old_rpath:
             # Filter out build-only rpath entries
             # added by get_link_dep_subdirs() or


### PR DESCRIPTION
Fixes issues with RPATH handling found when updating the Solaris meson packages to 0.56.0.

The first copies code from the GNU linker class to the equivalent code in the Solaris linker class.

The second makes the handling of old rpath entries match that of new rpath entries in depfixer (#8115)