### PR TITLE
Implement support of dlang -makedeps switch

### DIFF
--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os.path, subprocess
+import os.path, re, subprocess
 import typing as T
 
 from ..mesonlib import (
@@ -80,6 +80,9 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
     sharing between them as makes sense.
     """
 
+    def __init__(self, dmd_frontend_version: str):
+        self._frontend_version = dmd_frontend_version
+
     if T.TYPE_CHECKING:
         mscrt_args = {}  # type: T.Dict[str, T.List[str]]
 
@@ -130,6 +133,12 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
 
     def get_depfile_suffix(self) -> str:
         return 'deps'
+
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+        # -makedeps switch introduced in 2.096 frontend
+        if version_compare(self._frontend_version, ">=2.096"):
+            return [f'-makedeps={outfile}']
+        return []
 
     def get_pic_args(self) -> T.List[str]:
         if self.info.is_windows():
@@ -683,6 +692,17 @@ class GnuDCompiler(GnuCompiler, DCompiler):
     def get_disable_assert_args(self) -> T.List[str]:
         return ['-frelease']
 
+# LDC uses the DMD frontend code to parse and analyse the code.
+# It then uses LLVM for the binary code generation and optimizations.
+# This function retrieves the dmd frontend version, which determines
+# the common features between LDC and DMD.
+# We need the complete version text because the match is not on first line
+# of version_output
+def find_ldc_dmd_frontend_version(version_output: str):
+    version_regex = re.search(r'DMD v(\d+\.\d+\.\d+)', version_output)
+    if version_regex is not None and len(version_regex.groups()):
+        return version_regex.groups()[0]
+    return ''
 
 class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
 
@@ -691,10 +711,11 @@ class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
                  exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,
                  full_version: T.Optional[str] = None,
-                 is_cross: bool = False):
+                 is_cross: bool = False, version_output: str):
         DCompiler.__init__(self, exelist, version, for_machine, info, arch,
                            exe_wrapper=exe_wrapper, linker=linker,
                            full_version=full_version, is_cross=is_cross)
+        DmdLikeCompilerMixin.__init__(self, dmd_frontend_version=find_ldc_dmd_frontend_version(version_output))
         self.id = 'llvm'
         self.base_options = ['b_coverage', 'b_colorout', 'b_vscrt', 'b_ndebug']
 
@@ -752,6 +773,7 @@ class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
         DCompiler.__init__(self, exelist, version, for_machine, info, arch,
                            exe_wrapper=exe_wrapper, linker=linker,
                            full_version=full_version, is_cross=is_cross)
+        DmdLikeCompilerMixin.__init__(self, version)
         self.id = 'dmd'
         self.base_options = ['b_coverage', 'b_colorout', 'b_vscrt', 'b_ndebug']
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1788,7 +1788,7 @@ class Environment:
 
                 return compilers.LLVMDCompiler(
                     exelist, version, for_machine, info, arch,
-                    full_version=full_version, linker=linker)
+                    full_version=full_version, linker=linker, version_output=out)
             elif 'gdc' in out:
                 linker = self._guess_nix_linker(exelist, compilers.GnuDCompiler, for_machine)
                 return compilers.GnuDCompiler(


### PR DESCRIPTION
Fix #8118

If DMD version is `>=2.096`, `-makedeps` switch can be emitted.
For LDC, it checks that the DMD frontend is `>=2.096`.

Kind of difficult to have automated test at the moment because even the current development version of DMD does not yet advertize the `2.096` version.
But according [DMD release policy](https://dlang.org/changelog/release-schedule.html), the PR implementing the change (dlang/dmd#12011 - merged Dec. 2nd 2020) should be in the `2.096` version.

I could however test the feature by tricking the version comparison.