### PR TITLE
Correct format for meson dist checksum and don't print

### DIFF
--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -48,7 +48,9 @@ def create_hash(fname):
     m = hashlib.sha256()
     m.update(open(fname, 'rb').read())
     with open(hashname, 'w') as f:
-        f.write('{} {}\n'.format(m.hexdigest(), os.path.basename(fname)))
+        # A space and an asterisk because that is the format defined by GNU coreutils
+        # and accepted by busybox and the Perl shasum tool.
+        f.write('{} *{}\n'.format(m.hexdigest(), os.path.basename(fname)))
     print(os.path.relpath(fname), m.hexdigest())
 
 

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -51,7 +51,6 @@ def create_hash(fname):
         # A space and an asterisk because that is the format defined by GNU coreutils
         # and accepted by busybox and the Perl shasum tool.
         f.write('{} *{}\n'.format(m.hexdigest(), os.path.basename(fname)))
-    print(os.path.relpath(fname), m.hexdigest())
 
 
 def del_gitfiles(dirname):
@@ -284,4 +283,5 @@ def run(options):
     if rc == 0:
         for name in names:
             create_hash(name)
+            print('Created', os.path.relpath(name))
     return rc


### PR DESCRIPTION
The change makes `meson dist` follow the checksum format described at
https://www.gnu.org/software/coreutils/manual/html_node/md5sum-invocation.html#md5sum-invocation
and is compatible with busybox too.

I also removed the print since it doesn't make sense inside a function called
`create_hash`. It also contributes to the unnecessary output when a user runs
`meson dist`. [On my very simple project I get 55 lines of output and a few
warnings](https://0x0.st/iCOM.txt). There are other things we can do to improve
that (like calling `git` with `--quiet`) but this is a start.

I ran `AllPlatformTests.test_dist_git` and
`AllPlatformTests.test_dist_git_script` to test.