### PR TITLE
Check for cl-like compilers in _detect_c_or_cpp_compiler doesn't cope with paths

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1094,7 +1094,7 @@ class Environment:
                 compiler = [compiler]
             compiler_name = os.path.basename(compiler[0])
 
-            if not set(['cl', 'cl.exe', 'clang-cl', 'clang-cl.exe']).isdisjoint(compiler):
+            if not set(['cl', 'cl.exe', 'clang-cl', 'clang-cl.exe']).isdisjoint([compiler_name]):
                 # Watcom C provides it's own cl.exe clone that mimics an older
                 # version of Microsoft's compiler. Since Watcom's cl.exe is
                 # just a wrapper, we skip using it if we detect its presence


### PR DESCRIPTION
Hello

I've been trying to get meson to build with msys2's clang-cl on Windows and failing. There's a few things going on, but the first seems to be that if a path is provided to the compiler (rather than just exe name), the check for something that behaves like cl.exe doesn't work.

E.g. with a native file like
```
[constants]
root_path = 'c:/tools/msys64/mingw64/bin/'

[binaries]
c = root_path + 'clang-cl.exe'
cpp = root_path + 'clang-cl.exe'
```

this check

`if not set(['cl', 'cl.exe', 'clang-cl', 'clang-cl.exe']).isdisjoint(compiler):` fails because `compiler` is the full path.

Simple fix in this PR but being new to meson I've no idea if it's the best way.

With it, the build attempt gets further but then fails at linker detection. Haven't looked into that yet, though.

Anyway, hope this is of some help.

Regards

Luke.
