### PR TITLE
Qt: Pass include directories from dependency to moc compiler properly

### DIFF
--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -188,9 +188,22 @@ class QtBaseModule(ExtensionModule):
         compile_args = []
         for dep in unholder(dependencies):
             if isinstance(dep, Dependency):
+
+                if hasattr(dep, 'include_directories'):
+                    inc += get_include_args(include_dirs=dep.include_directories)
+
+                include_type_orig = dep.include_type
+
+                if dep.include_type == 'system':
+                    dep.include_type = 'non-system'
+
                 for arg in dep.get_compile_args():
-                    if arg.startswith('-I') or arg.startswith('-D'):
+                    if arg.startswith('-I'):
+                        inc.append(arg)
+                    if arg.startswith('-D'):
                         compile_args.append(arg)
+
+                dep.include_type = include_type_orig
             else:
                 raise MesonException('Argument is of an unacceptable type {!r}.\nMust be '
                                      'either an external dependency (returned by find_library() or '


### PR DESCRIPTION
#3998 allows us to propagate project's dependency to the moc compiler, but it somehow is incomplete. It passes compile definitions properly but it passes include directories only if 

1. dependency has include directories in result of get_compile_args() which is true for some object (ex. Qt5Dependency) but false for some (ex. InternalDependency)
2. include directory is specified with '-I' (not -isystem)

This patch completes flow described above.