### PR TITLE
transitively pass compile flags for internal dependency

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -677,11 +677,12 @@ class Backend:
 
         return extra_args
 
-    def get_target_external_deps(self, target):
+    def get_target_external_deps(self, target, static_only):
         deps = target.get_external_deps()
         transitive_deps = OrderedSet()
         for d in target.get_dependencies():
-            if isinstance(d, build.StaticLibrary):
+            if isinstance(d, build.StaticLibrary) or \
+               (not static_only and isinstance(d, build.SharedLibrary)):
                 transitive_deps.update(d.get_external_deps())
         if transitive_deps:
             deps += list(transitive_deps)
@@ -744,7 +745,7 @@ class Backend:
         # added while generating the link command.
         # NOTE: We must preserve the order in which external deps are
         # specified, so we reverse the list before iterating over it.
-        for dep in reversed(target.get_external_deps()):
+        for dep in reversed(self.get_target_external_deps(target, static_only=False)):
             if not dep.found():
                 continue
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -677,6 +677,16 @@ class Backend:
 
         return extra_args
 
+    def get_target_external_deps(self, target):
+        deps = target.get_external_deps()
+        transitive_deps = OrderedSet()
+        for d in target.get_dependencies():
+            if isinstance(d, build.StaticLibrary):
+                transitive_deps.update(d.get_external_deps())
+        if transitive_deps:
+            deps += list(transitive_deps)
+        return deps
+
     def generate_basic_compiler_args(self, target: build.BuildTarget, compiler: 'Compiler', no_warn_args: bool = False) -> 'CompilerArgs':
         # Create an empty commands list, and start adding arguments from
         # various sources in the order in which they must override each other

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2915,14 +2915,10 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
 
             commands += linker.get_target_link_args(target)
             # External deps must be last because target link libraries may depend on them.
-            for dep in target.get_external_deps():
+            for dep in self.get_target_external_deps(target):
                 # Extend without reordering or de-dup to preserve `-L -l` sets
                 # https://github.com/mesonbuild/meson/issues/1718
                 commands.extend_preserving_lflags(linker.get_dependency_link_args(dep))
-            for d in target.get_dependencies():
-                if isinstance(d, build.StaticLibrary):
-                    for dep in d.get_external_deps():
-                        commands.extend_preserving_lflags(linker.get_dependency_link_args(dep))
 
         # Add link args specific to this BuildTarget type that must not be overridden by dependencies
         commands += self.get_target_type_link_args_post_dependencies(target, linker)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2915,7 +2915,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
 
             commands += linker.get_target_link_args(target)
             # External deps must be last because target link libraries may depend on them.
-            for dep in self.get_target_external_deps(target):
+            for dep in self.get_target_external_deps(target, static_only=True):
                 # Extend without reordering or de-dup to preserve `-L -l` sets
                 # https://github.com/mesonbuild/meson/issues/1718
                 commands.extend_preserving_lflags(linker.get_dependency_link_args(dep))

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1015,7 +1015,7 @@ class Vs2010Backend(backends.Backend):
 
         # Split compile args needed to find external dependencies
         # Link args are added while generating the link command
-        for d in reversed(target.get_external_deps()):
+        for d in reversed(self.get_target_external_deps(target, static_only=False)):
             # Cflags required by external deps might have UNIX-specific flags,
             # so filter them out if needed
             if isinstance(d, dependencies.OpenMPDependency):
@@ -1125,7 +1125,7 @@ class Vs2010Backend(backends.Backend):
             # Only non-static built targets need link args and link dependencies
             extra_link_args += target.link_args
             # External deps must be last because target link libraries may depend on them.
-            for dep in self.get_target_external_deps(target):
+            for dep in self.get_target_external_deps(target, static_only=True):
                 # Extend without reordering or de-dup to preserve `-L -l` sets
                 # https://github.com/mesonbuild/meson/issues/1718
                 if isinstance(dep, dependencies.OpenMPDependency):

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1125,20 +1125,13 @@ class Vs2010Backend(backends.Backend):
             # Only non-static built targets need link args and link dependencies
             extra_link_args += target.link_args
             # External deps must be last because target link libraries may depend on them.
-            for dep in target.get_external_deps():
+            for dep in self.get_target_external_deps(target):
                 # Extend without reordering or de-dup to preserve `-L -l` sets
                 # https://github.com/mesonbuild/meson/issues/1718
                 if isinstance(dep, dependencies.OpenMPDependency):
                     ET.SubElement(clconf, 'OpenMPSuppport').text = 'true'
                 else:
                     extra_link_args.extend_direct(dep.get_link_args())
-            for d in target.get_dependencies():
-                if isinstance(d, build.StaticLibrary):
-                    for dep in d.get_external_deps():
-                        if isinstance(dep, dependencies.OpenMPDependency):
-                            ET.SubElement(clconf, 'OpenMPSuppport').text = 'true'
-                        else:
-                            extra_link_args.extend_direct(dep.get_link_args())
         # Add link args for c_* or cpp_* build options. Currently this only
         # adds c_winlibs and cpp_winlibs when building for Windows. This needs
         # to be after all internal and external libraries so that unresolved

--- a/test cases/common/235 transitive compile args/dep.c
+++ b/test cases/common/235 transitive compile args/dep.c
@@ -1,0 +1,5 @@
+#include "dep.h"
+
+int func(void) {
+    return 0;
+}

--- a/test cases/common/235 transitive compile args/dep.h
+++ b/test cases/common/235 transitive compile args/dep.h
@@ -1,0 +1,10 @@
+#ifndef __FOOBAR_H__
+#define __FOOBAR_H__
+
+#ifndef FOO
+#error "FOO is not defined"
+#endif
+
+int func(void);
+
+#endif /* __FOOBAR_H__ */

--- a/test cases/common/235 transitive compile args/meson.build
+++ b/test cases/common/235 transitive compile args/meson.build
@@ -1,0 +1,17 @@
+project('Transitive flags', 'c')
+
+# In a more realistic case, this would be a -I option from an external dependency
+foo = declare_dependency(compile_args: '-DFOO=BAR')
+libstaticdep = static_library('staticdep', 'dep.c', dependencies: foo)
+executable('prog1', sources: files('prog.c'), link_with: libstaticdep)
+executable('prog2', sources: files('prog.c'), link_whole: libstaticdep)
+
+libshareddep = shared_library('shareddep', 'dep.c', dependencies: foo)
+executable('prog3', sources: files('prog.c'), link_with: libshareddep)
+
+staticdep = declare_dependency(link_with: libstaticdep)
+executable('prog4', sources: files('prog.c'), dependencies: staticdep)
+executable('prog5', sources: files('prog.c'), dependencies: staticdep.as_link_whole())
+
+shareddep = declare_dependency(link_with: libshareddep)
+executable('prog6', sources: files('prog.c'), dependencies: shareddep)

--- a/test cases/common/235 transitive compile args/prog.c
+++ b/test cases/common/235 transitive compile args/prog.c
@@ -1,0 +1,5 @@
+#include "dep.h"
+
+int main(void) {
+    return func();
+}


### PR DESCRIPTION
Currently, Meson passes link arguments from both direct and indirect indirect dependencies.  However, only direct dependencies are used for compiler arguments.  The common case is a header file that includes headers from an external source, where those headers require a -I option to be found.
    
This was reported for QEMU as https://bugs.launchpad.net/qemu/+bug/1909256.