### PR TITLE
VS2019 backend uses wrong name for clang-cl toolset

### DIFF
--- a/mesonbuild/backend/vs2019backend.py
+++ b/mesonbuild/backend/vs2019backend.py
@@ -28,7 +28,7 @@ class Vs2019Backend(Vs2010Backend):
         if self.environment is not None:
             comps = self.environment.coredata.compilers.host
             if comps and all(c.id == 'clang-cl' for c in comps.values()):
-                self.platform_toolset = 'llvm'
+                self.platform_toolset = 'ClangCL'
             elif comps and all(c.id == 'intel-cl' for c in comps.values()):
                 c = list(comps.values())[0]
                 if c.version.startswith('19'):


### PR DESCRIPTION
It should be "ClangCL" rather than "llvm". Note sure about earlier VS versions, but if it's of any use here's the 1 liner patch I'm running locally.

Here's a snippet from a VS (not meson) created vcxproj with the correct value:

```
  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
    <ConfigurationType>Application</ConfigurationType>
    <UseDebugLibraries>true</UseDebugLibraries>
    <PlatformToolset>ClangCL</PlatformToolset>
    <CharacterSet>Unicode</CharacterSet>
  </PropertyGroup>
```

The toolset drop-down in the UI says "LLVM (clang-cl)" which is maybe where the confusion came from?

Anyway, HTH.

Regards