### PR TITLE
Read and store all environment variables up front

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -29,7 +29,7 @@ from .. import build
 from .. import dependencies
 from .. import mesonlib
 from .. import mlog
-from ..compilers import languages_using_ldflags
+from ..compilers import LANGUAGES_USING_LDFLAGS
 from ..mesonlib import (
     File, MachineChoice, MesonException, OptionType, OrderedSet, OptionOverrideProxy,
     classify_unity_sources, unholder, OptionKey
@@ -480,7 +480,7 @@ class Backend:
     def get_external_rpath_dirs(self, target):
         dirs = set()
         args = []
-        for lang in languages_using_ldflags:
+        for lang in LANGUAGES_USING_LDFLAGS:
             try:
                 args.extend(self.environment.coredata.get_external_link_args(target.for_machine, lang))
             except Exception:

--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -24,7 +24,6 @@ import os
 
 from .. import mlog
 from ..mesonlib import PerMachine, Popen_safe, version_compare, MachineChoice, is_windows, OptionKey
-from ..envconfig import get_env_var
 
 if T.TYPE_CHECKING:
     from ..environment import Environment
@@ -63,23 +62,6 @@ class CMakeExecutor:
             return
 
         self.prefix_paths = self.environment.coredata.options[OptionKey('cmake_prefix_path', machine=self.for_machine)].value
-        env_pref_path_raw = get_env_var(
-            self.for_machine,
-            self.environment.is_cross_build(),
-            'CMAKE_PREFIX_PATH')
-        if env_pref_path_raw is not None:
-            env_pref_path = []  # type: T.List[str]
-            if is_windows():
-                # Cannot split on ':' on Windows because its in the drive letter
-                env_pref_path = env_pref_path_raw.split(os.pathsep)
-            else:
-                # https://github.com/mesonbuild/meson/issues/7294
-                env_pref_path = re.split(r':|;', env_pref_path_raw)
-            env_pref_path = [x for x in env_pref_path if x]  # Filter out empty strings
-            if not self.prefix_paths:
-                self.prefix_paths = []
-            self.prefix_paths += env_pref_path
-
         if self.prefix_paths:
             self.extra_cmake_args += ['-DCMAKE_PREFIX_PATH={}'.format(';'.join(self.prefix_paths))]
 

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -127,7 +127,7 @@ from .compilers import (
     is_library,
     is_known_suffix,
     lang_suffixes,
-    languages_using_ldflags,
+    LANGUAGES_USING_LDFLAGS,
     sort_clink,
 )
 from .c import (

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -17,7 +17,6 @@ import typing as T
 
 from .. import coredata
 from ..mesonlib import MachineChoice, MesonException, mlog, version_compare, OptionKey
-from ..linkers import LinkerEnvVarsMixin
 from .c_function_attributes import C_FUNC_ATTRIBUTES
 from .mixins.clike import CLikeCompiler
 from .mixins.ccrx import CcrxCompiler
@@ -195,7 +194,7 @@ class AppleClangCCompiler(ClangCCompiler):
     _C2X_VERSION = '>=11.0.0'
 
 
-class EmscriptenCCompiler(EmscriptenMixin, LinkerEnvVarsMixin, ClangCCompiler):
+class EmscriptenCCompiler(EmscriptenMixin, ClangCCompiler):
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -85,9 +85,9 @@ clink_suffixes += ('h', 'll', 's')
 all_suffixes = set(itertools.chain(*lang_suffixes.values(), clink_suffixes))  # type: T.Set[str]
 
 # Languages that should use LDFLAGS arguments when linking.
-languages_using_ldflags = {'objcpp', 'cpp', 'objc', 'c', 'fortran', 'd', 'cuda'}  # type: T.Set[str]
+LANGUAGES_USING_LDFLAGS = {'objcpp', 'cpp', 'objc', 'c', 'fortran', 'd', 'cuda'}  # type: T.Set[str]
 # Languages that should use CPPFLAGS arguments when linking.
-languages_using_cppflags = {'c', 'cpp', 'objc', 'objcpp'}  # type: T.Set[str]
+LANGUAGES_USING_CPPFLAGS = {'c', 'cpp', 'objc', 'objcpp'}  # type: T.Set[str]
 soregex = re.compile(r'.*\.so(\.[0-9]+)?(\.[0-9]+)?(\.[0-9]+)?$')
 
 # Environment variables that each lang uses.
@@ -1222,7 +1222,7 @@ def get_args_from_envvars(lang: str,
         compile_flags += split_args(env_compile_flags)
 
     # Link flags (same for all languages)
-    if lang in languages_using_ldflags:
+    if lang in LANGUAGES_USING_LDFLAGS:
         link_flags += LinkerEnvVarsMixin.get_args_from_envvars(for_machine, is_cross)
     if use_linker_args:
         # When the compiler is used as a wrapper around the linker (such as
@@ -1232,7 +1232,7 @@ def get_args_from_envvars(lang: str,
         link_flags = compile_flags + link_flags
 
     # Pre-processor flags for certain languages
-    if lang in languages_using_cppflags:
+    if lang in LANGUAGES_USING_CPPFLAGS:
         env_preproc_flags = get_env_var(for_machine, is_cross, 'CPPFLAGS')
         if env_preproc_flags is not None:
             compile_flags += split_args(env_preproc_flags)

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -22,13 +22,9 @@ from functools import lru_cache
 from .. import coredata
 from .. import mlog
 from .. import mesonlib
-from ..linkers import LinkerEnvVarsMixin
 from ..mesonlib import (
     EnvironmentException, MachineChoice, MesonException,
-    Popen_safe, split_args, LibType, TemporaryDirectoryWinProof, OptionKey,
-)
-from ..envconfig import (
-    get_env_var
+    Popen_safe, LibType, TemporaryDirectoryWinProof, OptionKey,
 )
 
 from ..arglist import CompilerArgs
@@ -105,7 +101,7 @@ CFLAGS_MAPPING: T.Mapping[str, str] = {
 
 CEXE_MAPPING: T.Mapping = {
     'c': 'CC',
-   'cpp': 'CXX',
+    'cpp': 'CXX',
 }
 
 # All these are only for C-linkable languages; see `clink_langs` above.
@@ -590,11 +586,6 @@ class Compiler(metaclass=abc.ABCMeta):
         This currently means C, C++, Fortran.
         """
         return []
-
-    def get_linker_args_from_envvars(self,
-                                     for_machine: MachineChoice,
-                                     is_cross: bool) -> T.List[str]:
-        return self.linker.get_args_from_envvars(for_machine, is_cross)
 
     def get_options(self) -> 'KeyedOptionDictType':
         return {}
@@ -1203,68 +1194,32 @@ class Compiler(metaclass=abc.ABCMeta):
     def get_prelink_args(self, prelink_name: str, obj_list: T.List[str]) -> T.List[str]:
         raise EnvironmentException('{} does not know how to do prelinking.'.format(self.id))
 
-def get_args_from_envvars(lang: str,
-                          for_machine: MachineChoice,
-                          is_cross: bool,
-                          use_linker_args: bool) -> T.Tuple[T.List[str], T.List[str]]:
-    """
-    Returns a tuple of (compile_flags, link_flags) for the specified language
-    from the inherited environment
-    """
-    if lang not in CFLAGS_MAPPING:
-        return [], []
-
-    compile_flags = []  # type: T.List[str]
-    link_flags = []     # type: T.List[str]
-
-    env_compile_flags = get_env_var(for_machine, is_cross, CFLAGS_MAPPING[lang])
-    if env_compile_flags is not None:
-        compile_flags += split_args(env_compile_flags)
-
-    # Link flags (same for all languages)
-    if lang in LANGUAGES_USING_LDFLAGS:
-        link_flags += LinkerEnvVarsMixin.get_args_from_envvars(for_machine, is_cross)
-    if use_linker_args:
-        # When the compiler is used as a wrapper around the linker (such as
-        # with GCC and Clang), the compile flags can be needed while linking
-        # too. This is also what Autotools does. However, we don't want to do
-        # this when the linker is stand-alone such as with MSVC C/C++, etc.
-        link_flags = compile_flags + link_flags
-
-    # Pre-processor flags for certain languages
-    if lang in LANGUAGES_USING_CPPFLAGS:
-        env_preproc_flags = get_env_var(for_machine, is_cross, 'CPPFLAGS')
-        if env_preproc_flags is not None:
-            compile_flags += split_args(env_preproc_flags)
-
-    return compile_flags, link_flags
-
 
 def get_global_options(lang: str,
                        comp: T.Type[Compiler],
                        for_machine: MachineChoice,
-                       is_cross: bool) -> 'KeyedOptionDictType':
+                       env: 'Environment') -> 'KeyedOptionDictType':
     """Retreive options that apply to all compilers for a given language."""
     description = 'Extra arguments passed to the {}'.format(lang)
     argkey = OptionKey('args', lang=lang, machine=for_machine)
     largkey = argkey.evolve('link_args')
+
+    # We shouldn't need listify here, but until we have a separate
+    # linker-driver representation and can have that do the combine we have to
+    # do it htis way.
+    compile_args = mesonlib.listify(env.options.get(argkey, []))
+    link_args = mesonlib.listify(env.options.get(largkey, []))
+
+    if comp.INVOKES_LINKER:
+        link_args = compile_args + link_args
+
     opts: 'KeyedOptionDictType' = {
         argkey: coredata.UserArrayOption(
             description + ' compiler',
-            [], split_args=True, user_input=True, allow_dups=True),
+            compile_args, split_args=True, user_input=True, allow_dups=True),
         largkey: coredata.UserArrayOption(
             description + ' linker',
-            [], split_args=True, user_input=True, allow_dups=True),
+            link_args, split_args=True, user_input=True, allow_dups=True),
     }
-
-    # Get from env vars.
-    compile_args, link_args = get_args_from_envvars(
-        lang,
-        for_machine,
-        is_cross,
-        comp.INVOKES_LINKER)
-
-    opts[argkey].set_value(compile_args)
-    opts[largkey].set_value(link_args)
 
     return opts

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -91,18 +91,22 @@ languages_using_cppflags = {'c', 'cpp', 'objc', 'objcpp'}  # type: T.Set[str]
 soregex = re.compile(r'.*\.so(\.[0-9]+)?(\.[0-9]+)?(\.[0-9]+)?$')
 
 # Environment variables that each lang uses.
-cflags_mapping = {'c': 'CFLAGS',
-                  'cpp': 'CXXFLAGS',
-                  'cuda': 'CUFLAGS',
-                  'objc': 'OBJCFLAGS',
-                  'objcpp': 'OBJCXXFLAGS',
-                  'fortran': 'FFLAGS',
-                  'd': 'DFLAGS',
-                  'vala': 'VALAFLAGS',
-                  'rust': 'RUSTFLAGS'}  # type: T.Dict[str, str]
+CFLAGS_MAPPING: T.Mapping[str, str] = {
+    'c': 'CFLAGS',
+    'cpp': 'CXXFLAGS',
+    'cuda': 'CUFLAGS',
+    'objc': 'OBJCFLAGS',
+    'objcpp': 'OBJCXXFLAGS',
+    'fortran': 'FFLAGS',
+    'd': 'DFLAGS',
+    'vala': 'VALAFLAGS',
+    'rust': 'RUSTFLAGS',
+}
 
-cexe_mapping = {'c': 'CC',
-                'cpp': 'CXX'}
+CEXE_MAPPING: T.Mapping = {
+    'c': 'CC',
+   'cpp': 'CXX',
+}
 
 # All these are only for C-linkable languages; see `clink_langs` above.
 
@@ -1207,13 +1211,13 @@ def get_args_from_envvars(lang: str,
     Returns a tuple of (compile_flags, link_flags) for the specified language
     from the inherited environment
     """
-    if lang not in cflags_mapping:
+    if lang not in CFLAGS_MAPPING:
         return [], []
 
     compile_flags = []  # type: T.List[str]
     link_flags = []     # type: T.List[str]
 
-    env_compile_flags = get_env_var(for_machine, is_cross, cflags_mapping[lang])
+    env_compile_flags = get_env_var(for_machine, is_cross, CFLAGS_MAPPING[lang])
     if env_compile_flags is not None:
         compile_flags += split_args(env_compile_flags)
 

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -21,7 +21,6 @@ from .. import coredata
 from .. import mlog
 from ..mesonlib import MesonException, MachineChoice, version_compare, OptionKey
 
-from ..linkers import LinkerEnvVarsMixin
 from .compilers import (
     gnu_winlibs,
     msvc_winlibs,
@@ -256,7 +255,7 @@ class AppleClangCPPCompiler(ClangCPPCompiler):
         return ['-lc++']
 
 
-class EmscriptenCPPCompiler(EmscriptenMixin, LinkerEnvVarsMixin, ClangCPPCompiler):
+class EmscriptenCPPCompiler(EmscriptenMixin, ClangCPPCompiler):
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -759,7 +759,7 @@ class CoreData:
                       for_machine: MachineChoice, env: 'Environment') -> None:
         """Add global language arguments that are needed before compiler/linker detection."""
         from .compilers import compilers
-        options = compilers.get_global_options(lang, comp, for_machine, env.is_cross_build())
+        options = compilers.get_global_options(lang, comp, for_machine, env)
         self.add_compiler_options(options, lang, for_machine, env)
 
     def process_new_compiler(self, lang: str, comp: 'Compiler', env: 'Environment') -> None:

--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -30,8 +30,8 @@ import typing as T
 
 if T.TYPE_CHECKING:
     from .base import Dependency
-    from ..envconfig import MachineChoice
     from ..environment import Environment
+    from ..mesonlib import MachineChoice
 
 
 class HDF5PkgConfigDependency(PkgConfigDependency):

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -106,7 +106,7 @@ class _MPIConfigToolDependency(ConfigToolDependency):
         Drop -O2 and everything that is not needed.
         """
         result = []
-        multi_args = ('-I', )
+        multi_args: T.Tuple[str, ...] = ('-I', )
         if self.language == 'fortran':
             fc = self.env.coredata.compilers[self.for_machine]['fortran']
             multi_args += fc.get_module_incdir_args()

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -163,14 +163,6 @@ def get_env_var_pair(for_machine: MachineChoice,
     mlog.debug('Using {!r} from environment with value: {!r}'.format(var, value))
     return var, value
 
-def get_env_var(for_machine: MachineChoice,
-                is_cross: bool,
-                var_name: str) -> T.Optional[str]:
-    ret = get_env_var_pair(for_machine, is_cross, var_name)
-    if ret is None:
-        return None
-    return ret[1]
-
 class Properties:
     def __init__(
             self,

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -85,6 +85,49 @@ CPU_FAMILES_64_BIT = [
     'x86_64',
 ]
 
+# Map from language identifiers to environment variables.
+ENV_VAR_PROG_MAP: T.Mapping[str, str] = {
+    # Compilers
+    'c': 'CC',
+    'cpp': 'CXX',
+    'cs': 'CSC',
+    'd': 'DC',
+    'fortran': 'FC',
+    'objc': 'OBJC',
+    'objcpp': 'OBJCXX',
+    'rust': 'RUSTC',
+    'vala': 'VALAC',
+
+    # Linkers
+    'c_ld': 'CC_LD',
+    'cpp_ld': 'CXX_LD',
+    'd_ld': 'DC_LD',
+    'fortran_ld': 'FC_LD',
+    'objc_ld': 'OBJC_LD',
+    'objcpp_ld': 'OBJCXX_LD',
+    'rust_ld': 'RUSTC_LD',
+
+    # Binutils
+    'strip': 'STRIP',
+    'ar': 'AR',
+    'windres': 'WINDRES',
+
+    # Other tools
+    'cmake': 'CMAKE',
+    'qmake': 'QMAKE',
+    'pkgconfig': 'PKG_CONFIG',
+    'make': 'MAKE',
+}
+
+# Deprecated environment variables mapped from the new variable to the old one
+# Deprecated in 0.54.0
+DEPRECATED_ENV_PROG_MAP: T.Mapping[str, str] = {
+    'DC_LD': 'D_LD',
+    'FC_LD': 'F_LD',
+    'RUSTC_LD': 'RUST_LD',
+    'OBJCXX_LD': 'OBJCPP_LD',
+}
+
 class CMakeSkipCompilerTest(Enum):
     ALWAYS = 'always'
     NEVER = 'never'
@@ -363,49 +406,6 @@ class BinaryTable:
                     'Invalid type {!r} for binary {!r} in cross file'
                     ''.format(command, name))
 
-    # Map from language identifiers to environment variables.
-    evarMap = {
-        # Compilers
-        'c': 'CC',
-        'cpp': 'CXX',
-        'cs': 'CSC',
-        'd': 'DC',
-        'fortran': 'FC',
-        'objc': 'OBJC',
-        'objcpp': 'OBJCXX',
-        'rust': 'RUSTC',
-        'vala': 'VALAC',
-
-        # Linkers
-        'c_ld': 'CC_LD',
-        'cpp_ld': 'CXX_LD',
-        'd_ld': 'DC_LD',
-        'fortran_ld': 'FC_LD',
-        'objc_ld': 'OBJC_LD',
-        'objcpp_ld': 'OBJCXX_LD',
-        'rust_ld': 'RUSTC_LD',
-
-        # Binutils
-        'strip': 'STRIP',
-        'ar': 'AR',
-        'windres': 'WINDRES',
-
-        # Other tools
-        'cmake': 'CMAKE',
-        'qmake': 'QMAKE',
-        'pkgconfig': 'PKG_CONFIG',
-        'make': 'MAKE',
-    }  # type: T.Dict[str, str]
-
-    # Deprecated environment variables mapped from the new variable to the old one
-    # Deprecated in 0.54.0
-    DEPRECATION_MAP = {
-        'DC_LD': 'D_LD',
-        'FC_LD': 'F_LD',
-        'RUSTC_LD': 'RUST_LD',
-        'OBJCXX_LD': 'OBJCPP_LD',
-    }  # type: T.Dict[str, str]
-
     @staticmethod
     def detect_ccache() -> T.List[str]:
         try:
@@ -442,11 +442,11 @@ class BinaryTable:
             if raw_command is not None:
                 command = mesonlib.stringlistify(raw_command)
                 break # found
-            evar = self.evarMap.get(name)
+            evar = ENV_VAR_PROG_MAP.get(name)
             if evar is not None:
                 raw_command = get_env_var(for_machine, is_cross, evar)
                 if raw_command is None:
-                    deprecated = self.DEPRECATION_MAP.get(evar)
+                    deprecated = DEPRECATED_ENV_PROG_MAP.get(evar)
                     if deprecated is not None:
                         raw_command = get_env_var(for_machine, is_cross, deprecated)
                         if raw_command is not None:

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -12,19 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os, subprocess
+import subprocess
 import typing as T
 from enum import Enum
 
 from . import mesonlib
-from .mesonlib import EnvironmentException, MachineChoice, PerMachine, split_args
+from .mesonlib import EnvironmentException
 from . import mlog
 from pathlib import Path
-
-_T = T.TypeVar('_T')
-
-if T.TYPE_CHECKING:
-    from .environment import Environment
 
 
 # These classes contains all the data pulled from configuration files (native
@@ -135,33 +130,6 @@ class CMakeSkipCompilerTest(Enum):
     ALWAYS = 'always'
     NEVER = 'never'
     DEP_ONLY = 'dep_only'
-
-
-def get_env_var_pair(for_machine: MachineChoice,
-                     is_cross: bool,
-                     var_name: str) -> T.Optional[T.Tuple[str, str]]:
-    """
-    Returns the exact env var and the value.
-    """
-    candidates = PerMachine(
-        # The prefixed build version takes priority, but if we are native
-        # compiling we fall back on the unprefixed host version. This
-        # allows native builds to never need to worry about the 'BUILD_*'
-        # ones.
-        ([var_name + '_FOR_BUILD'] if is_cross else [var_name]),
-        # Always just the unprefixed host verions
-        [var_name]
-    )[for_machine]
-    for var in candidates:
-        value = os.environ.get(var)
-        if value is not None:
-            break
-    else:
-        formatted = ', '.join(['{!r}'.format(var) for var in candidates])
-        mlog.debug('None of {} are defined in the environment, not changing global flags.'.format(formatted))
-        return None
-    mlog.debug('Using {!r} from environment with value: {!r}'.format(var, value))
-    return var, value
 
 class Properties:
     def __init__(

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -640,7 +640,7 @@ class Environment:
             binaries.build = BinaryTable(config.get('binaries', {}))
             properties.build = Properties(config.get('properties', {}))
             cmakevars.build = CMakeVariables(config.get('cmake', {}))
-            self.load_machine_file_options(config, properties.build, MachineChoice.BUILD)
+            self._load_machine_file_options(config, properties.build, MachineChoice.BUILD)
 
         ## Read in cross file(s) to override host machine configuration
 
@@ -658,7 +658,7 @@ class Environment:
             for key, value in list(self.options.items()):
                 if self.coredata.is_per_machine_option(key):
                     self.options[key.as_build()] = value
-            self.load_machine_file_options(config, properties.host, MachineChoice.HOST)
+            self._load_machine_file_options(config, properties.host, MachineChoice.HOST)
         else:
             # IF we aren't cross compiling, but we hav ea native file, the
             # native file is for the host. This is due to an mismatch between
@@ -678,7 +678,7 @@ class Environment:
         self.options.update(options.cmd_line_options)
 
         # Take default value from env if not set in cross/native files or command line.
-        self.set_default_options_from_env()
+        self._set_default_options_from_env()
         self._set_default_binaries_from_env()
         self._set_default_properties_from_env()
 
@@ -746,7 +746,7 @@ class Environment:
         self.default_pkgconfig = ['pkg-config']
         self.wrap_resolver = None
 
-    def load_machine_file_options(self, config: 'ConfigParser', properties: Properties, machine: MachineChoice) -> None:
+    def _load_machine_file_options(self, config: 'ConfigParser', properties: Properties, machine: MachineChoice) -> None:
         """Read the contents of a Machine file and put it in the options store."""
         paths = config.get('paths')
         if paths:
@@ -777,7 +777,7 @@ class Environment:
                     key = OptionKey.from_string(k).evolve(subproject=subproject)
                     self.options[key] = v
 
-    def set_default_options_from_env(self) -> None:
+    def _set_default_options_from_env(self) -> None:
         opts: T.List[T.Tuple[str, str]] = (
             [(v, f'{k}_args') for k, v in compilers.compilers.CFLAGS_MAPPING.items()] +
             [

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -142,9 +142,7 @@ if T.TYPE_CHECKING:
     import argparse
 
 
-def get_env_var_pair(for_machine: MachineChoice,
-                     is_cross: bool,
-                     var_name: str) -> T.Optional[T.Tuple[str, str]]:
+def _get_env_var(for_machine: MachineChoice, is_cross: bool, var_name: str) -> T.Optional[str]:
     """
     Returns the exact env var and the value.
     """
@@ -166,7 +164,7 @@ def get_env_var_pair(for_machine: MachineChoice,
         mlog.debug('None of {} are defined in the environment, not changing global flags.'.format(formatted))
         return None
     mlog.debug('Using {!r} from environment with value: {!r}'.format(var, value))
-    return var, value
+    return value
 
 
 def detect_gcovr(min_version='3.3', new_rootdir_version='4.2', log=False):
@@ -791,10 +789,8 @@ class Environment:
         )
 
         for (evar, keyname), for_machine in itertools.product(opts, MachineChoice):
-            p_env_pair = get_env_var_pair(for_machine, self.is_cross_build(), evar)
-            if p_env_pair is not None:
-                _, p_env = p_env_pair
-
+            p_env = _get_env_var(for_machine, self.is_cross_build(), evar)
+            if p_env is not None:
                 # these may contain duplicates, which must be removed, else
                 # a duplicates-in-array-option warning arises.
                 if keyname == 'cmake_prefix_path':
@@ -843,9 +839,8 @@ class Environment:
                                envconfig.ENV_VAR_PROG_MAP.items())
 
         for (name, evar), for_machine in itertools.product(opts, MachineChoice):
-            p_env_pair = get_env_var_pair(for_machine, self.is_cross_build(), evar)
-            if p_env_pair is not None:
-                _, p_env = p_env_pair
+            p_env = _get_env_var(for_machine, self.is_cross_build(), evar)
+            if p_env is not None:
                 self.binaries[for_machine].binaries.setdefault(name, mesonlib.split_args(p_env))
 
     def _set_default_properties_from_env(self) -> None:
@@ -859,9 +854,8 @@ class Environment:
 
         for (name, evars, split), for_machine in itertools.product(opts, MachineChoice):
             for evar in evars:
-                p_env_pair = get_env_var_pair(for_machine, self.is_cross_build(), evar)
-                if p_env_pair is not None:
-                    _, p_env = p_env_pair
+                p_env = _get_env_var(for_machine, self.is_cross_build(), evar)
+                if p_env is not None:
                     if split:
                         self.properties[for_machine].properties.setdefault(name, p_env.split(os.pathsep))
                     else:

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -18,7 +18,6 @@ import typing as T
 
 from . import mesonlib
 from .arglist import CompilerArgs
-from .envconfig import get_env_var
 
 if T.TYPE_CHECKING:
     from .coredata import KeyedOptionDictType
@@ -301,21 +300,7 @@ def evaluate_rpath(p: str, build_dir: str, from_dir: str) -> str:
     else:
         return os.path.relpath(os.path.join(build_dir, p), os.path.join(build_dir, from_dir))
 
-
-class LinkerEnvVarsMixin(metaclass=abc.ABCMeta):
-
-    """Mixin reading LDFLAGS from the environment."""
-
-    @staticmethod
-    def get_args_from_envvars(for_machine: mesonlib.MachineChoice,
-                              is_cross: bool) -> T.List[str]:
-        raw_value = get_env_var(for_machine, is_cross, 'LDFLAGS')
-        if raw_value is not None:
-            return mesonlib.split_args(raw_value)
-        else:
-            return []
-
-class DynamicLinker(LinkerEnvVarsMixin, metaclass=abc.ABCMeta):
+class DynamicLinker(metaclass=abc.ABCMeta):
 
     """Base class for dynamic linkers."""
 

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -22,8 +22,8 @@ from .envconfig import get_env_var
 
 if T.TYPE_CHECKING:
     from .coredata import KeyedOptionDictType
-    from .envconfig import MachineChoice
     from .environment import Environment
+    from .mesonlib import MachineChoice
 
 
 class StaticLinker:

--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -23,7 +23,7 @@ from ..mesonlib import (MesonException, Popen_safe, MachineChoice,
 from ..interpreterbase import InterpreterObject, InterpreterException, FeatureNew
 from ..interpreterbase import stringArgs, permittedKwargs
 from ..interpreter import Interpreter, DependencyHolder, InstallDir
-from ..compilers.compilers import cflags_mapping, cexe_mapping
+from ..compilers.compilers import CFLAGS_MAPPING, CEXE_MAPPING
 from ..dependencies.base import InternalDependency, PkgConfigDependency
 from ..environment import Environment
 from ..mesonlib import OptionKey
@@ -110,11 +110,11 @@ class ExternalProject(InterpreterObject):
         link_args = []
         self.run_env = os.environ.copy()
         for lang, compiler in self.env.coredata.compilers[MachineChoice.HOST].items():
-            if any(lang not in i for i in (cexe_mapping, cflags_mapping)):
+            if any(lang not in i for i in (CEXE_MAPPING, CFLAGS_MAPPING)):
                 continue
             cargs = self.env.coredata.get_external_args(MachineChoice.HOST, lang)
-            self.run_env[cexe_mapping[lang]] = self._quote_and_join(compiler.get_exelist())
-            self.run_env[cflags_mapping[lang]] = self._quote_and_join(cargs)
+            self.run_env[CEXE_MAPPING[lang]] = self._quote_and_join(compiler.get_exelist())
+            self.run_env[CFLAGS_MAPPING[lang]] = self._quote_and_join(cargs)
             if not link_exelist:
                 link_exelist = compiler.get_linker_exelist()
                 link_args = self.env.coredata.get_external_link_args(MachineChoice.HOST, lang)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -9347,7 +9347,7 @@ def unset_envs():
     # For unit tests we must fully control all command lines
     # so that there are no unexpected changes coming from the
     # environment, for example when doing a package build.
-    varnames = ['CPPFLAGS', 'LDFLAGS'] + list(mesonbuild.compilers.compilers.cflags_mapping.values())
+    varnames = ['CPPFLAGS', 'LDFLAGS'] + list(mesonbuild.compilers.compilers.CFLAGS_MAPPING.values())
     for v in varnames:
         if v in os.environ:
             del os.environ[v]

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2606,8 +2606,10 @@ class AllPlatformTests(BasePlatformTests):
                 if is_osx():
                     self.assertIsInstance(cc.linker, mesonbuild.linkers.AppleDynamicLinker)
                 elif is_windows():
-                    # This is clang, not clang-cl
-                    self.assertIsInstance(cc.linker, mesonbuild.linkers.MSVCDynamicLinker)
+                    # This is clang, not clang-cl. This can be either an
+                    # ld-like linker of link.exe-like linker (usually the
+                    # former for msys2, the latter otherwise)
+                    self.assertIsInstance(cc.linker, (mesonbuild.linkers.MSVCDynamicLinker, mesonbuild.linkers.GnuLikeDynamicLinkerMixin))
                 else:
                     self.assertIsInstance(cc.linker, mesonbuild.linkers.GnuLikeDynamicLinkerMixin)
             if isinstance(cc, intel):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5689,12 +5689,12 @@ class WindowsTests(BasePlatformTests):
     def _check_ld(self, name: str, lang: str, expected: str) -> None:
         if not shutil.which(name):
             raise unittest.SkipTest('Could not find {}.'.format(name))
-        envvars = [mesonbuild.envconfig.BinaryTable.evarMap['{}_ld'.format(lang)]]
+        envvars = [mesonbuild.envconfig.ENV_VAR_PROG_MAP['{}_ld'.format(lang)]]
 
         # Also test a deprecated variable if there is one.
-        if envvars[0] in mesonbuild.envconfig.BinaryTable.DEPRECATION_MAP:
+        if envvars[0] in mesonbuild.envconfig.DEPRECATED_ENV_PROG_MAP:
             envvars.append(
-                mesonbuild.envconfig.BinaryTable.DEPRECATION_MAP[envvars[0]])
+                mesonbuild.envconfig.DEPRECATED_ENV_PROG_MAP[envvars[0]])
 
         for envvar in envvars:
             with mock.patch.dict(os.environ, {envvar: name}):
@@ -7293,7 +7293,7 @@ class LinuxlikeTests(BasePlatformTests):
             raise unittest.SkipTest('Solaris currently cannot override the linker.')
         if not shutil.which(check):
             raise unittest.SkipTest('Could not find {}.'.format(check))
-        envvars = [mesonbuild.envconfig.BinaryTable.evarMap['{}_ld'.format(lang)]]
+        envvars = [mesonbuild.envconfig.BinaryTable.ENV_VAR_PROG_MAP['{}_ld'.format(lang)]]
 
         # Also test a deprecated variable if there is one.
         if envvars[0] in mesonbuild.envconfig.BinaryTable.DEPRECATION_MAP:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5376,7 +5376,7 @@ class FailureTests(BasePlatformTests):
     def test_boost_BOOST_ROOT_dependency(self):
         # Test BOOST_ROOT; can be run even if Boost is found or not
         self.assertMesonRaises("dependency('boost')",
-                               "(BOOST_ROOT.*absolute|{})".format(self.dnf),
+                               "(boost_root.*absolute|{})".format(self.dnf),
                                override_envvars = {'BOOST_ROOT': 'relative/path'})
 
     def test_dependency_invalid_method(self):


### PR DESCRIPTION
Currently, meson reads environment variables in various places, sometimes at configure time, sometimes at runtime, with various behaviors. This series seeks to unify all environment variable handling into a single place, and store them so that they persist across reconfigures. There are a lot of cleanups in here as well, but the end result I think is much nicer than what we had before (and is less code).