### PR TITLE
Cope with initial Popen_safe() throwing in _guess_win_linker() such that an explicit ld is used.

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -950,16 +950,19 @@ class Environment:
         if extra_args is not None:
             check_args.extend(extra_args)
 
-        p, o, _ = Popen_safe(compiler + check_args)
-        if o.startswith('LLD'):
-            if '(compatible with GNU linkers)' in o:
-                return LLVMDynamicLinker(
-                    compiler, for_machine, comp_class.LINKER_PREFIX,
-                    override, version=search_version(o))
-            elif not invoked_directly:
-                return ClangClDynamicLinker(
-                    for_machine, override, exelist=compiler, prefix=comp_class.LINKER_PREFIX,
-                    version=search_version(o), direct=False, machine=None)
+        try:
+            p, o, _ = Popen_safe(compiler + check_args)
+            if o.startswith('LLD'):
+                if '(compatible with GNU linkers)' in o:
+                    return LLVMDynamicLinker(
+                        compiler, for_machine, comp_class.LINKER_PREFIX,
+                        override, version=search_version(o))
+                elif not invoked_directly:
+                    return ClangClDynamicLinker(
+                        for_machine, override, exelist=compiler, prefix=comp_class.LINKER_PREFIX,
+                        version=search_version(o), direct=False, machine=None)
+        except (FileNotFoundError, PermissionError):
+            pass
 
         if value is not None and invoked_directly:
             compiler = value


### PR DESCRIPTION
Hello

I've been trying to use clang-cl with explicit environment variables pointing at my binaries; e.g.:

```
CC=/c/tools/msys64/mingw64/bin/clang-cl.exe
CXX=/c/tools/msys64/mingw64/bin/clang-cl.exe
C_LD=/c/tools/msys64/mingw64/bin/lld-link.exe
CXX_LD=/c/tools/msys64/mingw64/bin/lld-link.exe
```

#8105 is required to get the compiler detected correctly; that's fine.

However, linker detection also fails because there is no exception handling in the initial `Popen_safe()` check (for `lld-link.exe`) in `_guess_win_linker()` such that the second  `Popen_safe()` using my explicit linker is never run.

Don't know if it's the right answer, but here's my quick workaround if it's of any use!

Regards