### PR TITLE
Dont use python 3.6 annotation syntax

### DIFF
--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -17,7 +17,7 @@ jobs:
         sudo apt update -yq
         sudo apt install -yq --no-install-recommends python3-setuptools python3-pip g++ gfortran gobjc gobjc++ zlib1g-dev python-dev python3-dev python3-jsonschema
     - name: Install ninja-build tool
-      uses: seanmiddleditch/gha-setup-ninja@v1
+      uses: seanmiddleditch/gha-setup-ninja@v3
     - name: Python version
       run: python3 --version
     - name: Ninja version

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -525,7 +525,7 @@ class ConverterTarget:
 
         # Handle OSX frameworks
         def handle_frameworks(flags: T.List[str]) -> T.List[str]:
-            res: T.List[str] = []
+            res = []  # type: T.List[str]
             for i in flags:
                 p = Path(i)
                 if not p.exists() or not p.name.endswith('.framework'):

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -187,12 +187,12 @@ def get_directory(subdir_root: str, packagename: str) -> str:
         return wrap.directory
     return packagename
 
-def verbose_git(*args, **kwargs):
+def verbose_git(cmd: T.List[str], workingdir: str, check: bool = False) -> bool:
     '''
     Wrapper to convert GitException to WrapException caught in interpreter.
     '''
     try:
-        return mesonlib.verbose_git(*args, **kwargs)
+        return mesonlib.verbose_git(cmd, workingdir, check=check)
     except mesonlib.GitException as e:
         raise WrapException(str(e))
 


### PR DESCRIPTION
Fixes: #8161

@nirbheek, @jpakkane: this was the only instance of the new syntax I could fine reviewing the history. It might be worth having a 0.56.2 release after this?