### PR TITLE
ci: Fix pip installation in Cygwin on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,7 +108,7 @@ jobs:
         python3-devel,^
         python3-libxml2,^
         python3-libxslt,^
-        python36-pip,^
+        python38-pip,^
         vala,^
         wget,^
         cmake,^


### PR DESCRIPTION
Python3 in Cygwin is now Python 3.8