### PR TITLE
clang-cl with VS backend debug builds not very debuggable

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1159,7 +1159,8 @@ class Vs2010Backend(backends.Backend):
         # Size-preserving flags
         if '/Os' in o_flags:
             ET.SubElement(clconf, 'FavorSizeOrSpeed').text = 'Size'
-        else:
+        # Note: setting FavorSizeOrSpeed with clang-cl conflicts with /Od and can make debugging difficult, so don't.
+        elif '/Od' not in o_flags:
             ET.SubElement(clconf, 'FavorSizeOrSpeed').text = 'Speed'
         # Note: SuppressStartupBanner is /NOLOGO and is 'true' by default
         self.generate_lang_standard_info(file_args, clconf)


### PR DESCRIPTION
Looks like setting FavorSizeOrSpeed even with `/Od` means (some) optimization is taking place, making debugging problematic.

This is what I'm using locally to avoid setting FavorSizeOrSpeed with a debug build. Obviously my mod is not distinguishing between cl or clang-cl toolsets, but I suspect that's no bad thing!

Regards

Luke.
