### PR TITLE
Replacement of /ZI with /Zi on MSVC Debug

### DIFF
--- a/docs/markdown/snippets/msvc_no_zi.md
+++ b/docs/markdown/snippets/msvc_no_zi.md
@@ -1,0 +1,14 @@
+## "Edit and continue" (/ZI) is no longer used by default for Visual Studio
+
+Meson was adding the `/ZI` compiler argument as an argument for Visual Studio 
+in debug mode. This enables the `edit-and-continue` debugging in 
+Visual Studio IDE's.
+
+Unfortunately, it is also extremely expensive and breaks certain use cases such 
+as link time code generation. Edit and continue can be enabled by manually by 
+adding `/ZI` to compiler arguments.
+
+The `/ZI` argument has now been replaced by the `/Zi` argument for debug builds.
+
+If this is an important issue for you and would like a builtin toggle option, 
+please file an issue in the Meson bug tracker.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -709,15 +709,16 @@ class Backend:
         commands += compiler.get_buildtype_args(self.get_option_for_target(OptionKey('buildtype'), target))
         commands += compiler.get_optimization_args(self.get_option_for_target(OptionKey('optimization'), target))
         commands += compiler.get_debug_args(self.get_option_for_target(OptionKey('debug'), target))
-        # MSVC debug builds have /ZI argument by default and /Zi is added with debug flag
-        # /ZI needs to be removed in that case to avoid cl's warning to that effect (D9025 : overriding '/ZI' with '/Zi')
-        if ('/ZI' in commands) and ('/Zi' in commands):
-            commands.remove('/Zi')
         # Add compile args added using add_project_arguments()
         commands += self.build.get_project_args(compiler, target.subproject, target.for_machine)
         # Add compile args added using add_global_arguments()
         # These override per-project arguments
         commands += self.build.get_global_args(compiler, target.for_machine)
+        # Using both /ZI and /Zi at the same times produces a compiler warning.
+        # We do not add /ZI by default. If it is being used it is because the user has explicitly enabled it.
+        # /ZI needs to be removed in that case to avoid cl's warning to that effect (D9025 : overriding '/ZI' with '/Zi')
+        if ('/ZI' in commands) and ('/Zi' in commands):
+            commands.remove('/Zi')
         # Compile args added from the env: CFLAGS/CXXFLAGS, etc, or the cross
         # file. We want these to override all the defaults, but not the
         # per-target compile args.

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -62,14 +62,14 @@ vs64_instruction_set_args = {
 
 msvc_buildtype_args = {
     'plain': [],
-    'debug': ["/ZI", "/RTC1"],
+    'debug': ["/RTC1"],
     'debugoptimized': [],
     'release': [],
     'minsize': [],
     'custom': [],
 }  # type: T.Dict[str, T.List[str]]
 
-# Clang-cl doesn't have /ZI, and /Zi and /Z7 do the same thing
+# Clang-cl /Zi and /Z7 do the same thing
 # quoting the docs (https://clang.llvm.org/docs/MSVCCompatibility.html):
 #
 # Clang emits relatively complete CodeView debug information if /Z7 or /Zi is


### PR DESCRIPTION
The /ZI flag adds in "Edit and Continue" debug information, which will cause massive slowdowns. It is not a flag that should be added by default to debug builds. It is also incompatible with MSVC LTO.

/Zi will still be added.