### PR TITLE
Added workaround for Nvidia HPC SDK OpenMP support

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -82,6 +82,15 @@ class OpenMPDependency(ExternalDependency):
             self.is_found = True
             self.compile_args = self.link_args = self.clib_compiler.openmp_flags()
             return
+        elif self.clib_compiler.get_id() == 'nvidia_hpc':
+            # Nvidia HPC SDK compilers (rebranded from PGI) does not define the '_OPENMP' macro, but
+            # should support OpenMP according to their documentation
+            # (https://docs.nvidia.com/hpc-sdk/compilers/hpc-compilers-user-guide/index.html#openmp-use)
+            # (https://docs.nvidia.com/hpc-sdk/compilers/hpc-compilers-user-guide/index.html#standards)
+            self.version = '4.5'
+            self.is_found = True
+            self.compile_args = self.link_args = self.clib_compiler.openmp_flags()
+            return
         try:
             openmp_date = self.clib_compiler.get_define(
                 '_OPENMP', '', self.env, self.clib_compiler.openmp_flags(), [self], disable_cache=True)[0]


### PR DESCRIPTION
Tested with Nvidia HPC SDK `20.7`, `20.9` and `20.11` which all worked with this patch.

There also seems to be some confusion in the Nvidia documentation. Previous versions of the compiler suite only supported `OpenMP` version `4.5`, however, the [latest documentation](https://docs.nvidia.com/hpc-sdk/compilers/hpc-compilers-user-guide/index.html#openmp-use) talks about supporting some features of version `5.0` without further specification. This should not affect this change, but in the future updates to the hardcoded version could be added.

This should solve #8058. 