### PR TITLE
Allow '//' as project function id due to git bash path conversion.

### DIFF
--- a/docs/markdown/Rewriter.md
+++ b/docs/markdown/Rewriter.md
@@ -97,6 +97,11 @@ Currently, only the following function types are supported:
 
 For more information see the help output of the rewrite kwargs command.
 
+Note msys bash may expand `/` to a path. Passing `//` will be converted to
+`/` by msys bash but in order to keep usage shell-agnostic, the rewrite command
+also allows `//` as the function ID such that it will work in both msys bash
+and other shells.
+
 ### Setting the project default options
 
 For setting and deleting default options, use the following command:

--- a/docs/markdown/snippets/rewrite_allow_double_slash_project_id.md
+++ b/docs/markdown/snippets/rewrite_allow_double_slash_project_id.md
@@ -1,0 +1,7 @@
+## `//` is now allowed as a function id for `meson rewrite`.
+
+msys bash may expand `/` to a path, breaking
+`meson rewrite kwargs set project / ...`. Passing `//` will be converted to
+`/` by msys bash but in order to keep usage shell-agnostic, also allow `//`
+as the id such that `meson rewrite kwargs set project // ...` will work in
+both msys bash and other shells.

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -500,8 +500,12 @@ class Rewriter:
         node = None
         arg_node = None
         if cmd['function'] == 'project':
-            if cmd['id'] != '/':
-                mlog.error('The ID for the function type project must be "/"', *self.on_error())
+            # msys bash may expand '/' to a path. It will mangle '//' to '/'
+            # but in order to keep usage shell-agnostic, also allow `//` as
+            # the function ID such that it will work in both msys bash and
+            # other shells.
+            if {'/', '//'}.isdisjoint({cmd['id']}):
+                mlog.error('The ID for the function type project must be "/" or "//" not "' + cmd['id'] + '"', *self.on_error())
                 return self.handle_error()
             node = self.interpreter.project_node
             arg_node = node.args

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -7917,7 +7917,7 @@ class RewriterTests(BasePlatformTests):
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
         expected = {
             'kwargs': {
-                'project#/': {'version': '0.0.1', 'license': ['GPL', 'MIT', 'BSD']},
+                'project#/': {'version': '0.0.1', 'license': ['GPL', 'MIT', 'BSD', 'Boost']},
                 'target#tgt1': {'build_by_default': True},
                 'dependency#dep1': {'required': False}
             }
@@ -7943,7 +7943,7 @@ class RewriterTests(BasePlatformTests):
         out = self.rewrite(self.builddir, os.path.join(self.builddir, 'info.json'))
         expected = {
             'kwargs': {
-                'project#/': {'version': '0.0.1', 'default_options': ['buildtype=release', 'debug=true']},
+                'project#/': {'version': '0.0.1', 'default_options': 'debug=true'},
                 'target#tgt1': {'build_by_default': True},
                 'dependency#dep1': {'required': False}
             }

--- a/test cases/rewrite/3 kwargs/add.json
+++ b/test cases/rewrite/3 kwargs/add.json
@@ -25,5 +25,14 @@
     "kwargs": {
       "license": "BSD"
     }
+  },
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "//",
+    "operation": "add",
+    "kwargs": {
+      "license": "Boost"
+    }
   }
 ]

--- a/test cases/rewrite/3 kwargs/remove.json
+++ b/test cases/rewrite/3 kwargs/remove.json
@@ -5,7 +5,7 @@
     "id": "/",
     "operation": "set",
     "kwargs": {
-      "license": ["GPL", "MIT", "BSD"]
+      "license": ["GPL", "MIT", "BSD", "Boost"]
     }
   },
   {
@@ -24,6 +24,15 @@
     "operation": "remove",
     "kwargs": {
       "license": "BSD"
+    }
+  },
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "//",
+    "operation": "remove",
+    "kwargs": {
+      "license": "Boost"
     }
   }
 ]

--- a/test cases/rewrite/3 kwargs/remove_regex.json
+++ b/test cases/rewrite/3 kwargs/remove_regex.json
@@ -16,5 +16,14 @@
     "kwargs": {
       "default_options": ["cpp_std=.*"]
     }
+  },
+  {
+    "type": "kwargs",
+    "function": "project",
+    "id": "//",
+    "operation": "remove_regex",
+    "kwargs": {
+      "default_options": ["buildtype=.*"]
+    }
   }
 ]

--- a/test cases/rewrite/3 kwargs/set.json
+++ b/test cases/rewrite/3 kwargs/set.json
@@ -2,7 +2,7 @@
   {
     "type": "kwargs",
     "function": "project",
-    "id": "/",
+    "id": "//",
     "operation": "set",
     "kwargs": {
       "version": "0.0.2",


### PR DESCRIPTION
See #8175
