### PR TITLE
Keep buildtype the same even if user changes debug and/or optimization.

### DIFF
--- a/docs/markdown/FAQ.md
+++ b/docs/markdown/FAQ.md
@@ -500,3 +500,36 @@ meson -Dcpp_eh=none -Dcpp_rtti=false <other options>
 ```
 
 The RTTI option is only available since Meson version 0.53.0.
+
+## Should I check for `buildtype` or individual options like `debug` in my build files?
+
+This depends highly on what you actually need to happen. The
+´buildtype` option is meant do describe the current build's
+_intent_. That is, what it will be used for. Individual options are
+for determining what the exact state is. This becomes clearer with a
+few examples.
+
+Suppose you have a source file that is known to miscompile when using
+`-O3` and requires a workaround. Then you'd write something like this:
+
+```meson
+if get_option('optimization') == '3'
+    add_project_arguments('-DOPTIMIZATION_WORKAROUND', ...)
+endif
+```
+
+On the other hand if your project has extra logging and sanity checks
+that you would like to be enabled during the day to day development
+work (which uses the `debug` buildtype), you'd do this instead:
+
+```meson
+if get_option('buildtype') == 'debug'
+    add_project_arguments('-DENABLE_EXTRA_CHECKS', ...)
+endif
+```
+
+In this way the extra options are automatically used during
+development but are not compiled in release builds. Note that (since
+Meson 0.57.0) you can set optimization to, say, 2 in your debug builds
+if you want to. If you tried to set this flag based on optimization
+level, it would fail in this case.

--- a/docs/markdown/snippets/buildtyperemains.md
+++ b/docs/markdown/snippets/buildtyperemains.md
@@ -1,0 +1,10 @@
+## Buildtype remains even if dependent options are changed
+
+Setting the `buildtype' option to a value sets the `debug` and
+`optimization` options to predefined values. Traditionally setting the
+options to other values would then change the buildtype to `custom`.
+This is confusing and means that you can't use, for example, debug
+level `g` in `debug` buildtype even though it would make sense under
+many circumstances. Starting with the buildtype is only changed when
+the user explicitly sets it. Setting the build type sets the other
+options to their default values as before.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -582,8 +582,35 @@ class CoreData:
 
         if key.name == 'buildtype':
             self._set_others_from_buildtype(value)
-        elif key.name in {'debug', 'optimization'}:
-            self._set_buildtype_from_others()
+
+    def get_nondefault_buildtype_args(self):
+        result= []
+        value = self.options[OptionKey('buildtype')].value
+        if value == 'plain':
+            opt = '0'
+            debug = False
+        elif value == 'debug':
+            opt = '0'
+            debug = True
+        elif value == 'debugoptimized':
+            opt = '2'
+            debug = True
+        elif value == 'release':
+            opt = '3'
+            debug = False
+        elif value == 'minsize':
+            opt = 's'
+            debug = True
+        else:
+            assert(value == 'custom')
+            return []
+        actual_opt = self.options[OptionKey('optimization')].value
+        actual_debug = self.options[OptionKey('debug')].value
+        if actual_opt != opt:
+            result.append(('optimization', actual_opt, opt))
+        if actual_debug != debug:
+            result.append(('debug', actual_debug, debug))
+        return result
 
     def _set_others_from_buildtype(self, value: str) -> None:
         if value == 'plain':
@@ -606,23 +633,6 @@ class CoreData:
             return
         self.options[OptionKey('optimization')].set_value(opt)
         self.options[OptionKey('debug')].set_value(debug)
-
-    def _set_buildtype_from_others(self) -> None:
-        opt = self.options[OptionKey('optimization')].value
-        debug = self.options[OptionKey('debug')].value
-        if opt == '0' and not debug:
-            mode = 'plain'
-        elif opt == '0' and debug:
-            mode = 'debug'
-        elif opt == '2' and debug:
-            mode = 'debugoptimized'
-        elif opt == '3' and not debug:
-            mode = 'release'
-        elif opt == 's' and debug:
-            mode = 'minsize'
-        else:
-            mode = 'custom'
-        self.options[OptionKey('buildtype')].set_value(mode)
 
     @staticmethod
     def is_per_machine_option(optname: OptionKey) -> bool:

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -243,6 +243,17 @@ class Conf:
             print('')
             print_default_values_warning()
 
+        self.print_nondefault_buildtype_options()
+
+    def print_nondefault_buildtype_options(self):
+        mismatching = self.coredata.get_nondefault_buildtype_args()
+        if not mismatching:
+            return
+        print("\nThe following option(s) have a different value than the build type default\n")
+        print(f'               current   default')
+        for m in mismatching:
+            print(f'{m[0]:21}{m[1]:10}{m[2]:10}')
+
 def run(options):
     coredata.parse_cmd_line_options(options)
     builddir = os.path.abspath(os.path.realpath(options.builddir))

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3923,51 +3923,13 @@ class AllPlatformTests(BasePlatformTests):
         self.setconf('-Ddebug=false')
         opts = self.get_opts_as_dict()
         self.assertEqual(opts['debug'], False)
-        self.assertEqual(opts['buildtype'], 'plain')
-        self.assertEqual(opts['optimization'], '0')
-
-        # Setting optimizations to 3 should cause buildtype
-        # to go to release mode.
-        self.setconf('-Doptimization=3')
-        opts = self.get_opts_as_dict()
-        self.assertEqual(opts['buildtype'], 'release')
-        self.assertEqual(opts['debug'], False)
-        self.assertEqual(opts['optimization'], '3')
-
-        # Going to debug build type should reset debugging
-        # and optimization
-        self.setconf('-Dbuildtype=debug')
-        opts = self.get_opts_as_dict()
         self.assertEqual(opts['buildtype'], 'debug')
-        self.assertEqual(opts['debug'], True)
         self.assertEqual(opts['optimization'], '0')
-
-        # Command-line parsing of buildtype settings should be the same as
-        # setting with `meson configure`.
-        #
-        # Setting buildtype should set optimization/debug
-        self.new_builddir()
-        self.init(testdir, extra_args=['-Dbuildtype=debugoptimized'])
+        self.setconf('-Doptimization=g')
         opts = self.get_opts_as_dict()
-        self.assertEqual(opts['debug'], True)
-        self.assertEqual(opts['optimization'], '2')
-        self.assertEqual(opts['buildtype'], 'debugoptimized')
-        # Setting optimization/debug should set buildtype
-        self.new_builddir()
-        self.init(testdir, extra_args=['-Doptimization=2', '-Ddebug=true'])
-        opts = self.get_opts_as_dict()
-        self.assertEqual(opts['debug'], True)
-        self.assertEqual(opts['optimization'], '2')
-        self.assertEqual(opts['buildtype'], 'debugoptimized')
-        # Setting both buildtype and debug on the command-line should work, and
-        # should warn not to do that. Also test that --debug is parsed as -Ddebug=true
-        self.new_builddir()
-        out = self.init(testdir, extra_args=['-Dbuildtype=debugoptimized', '--debug'])
-        self.assertRegex(out, 'Recommend using either.*buildtype.*debug.*redundant')
-        opts = self.get_opts_as_dict()
-        self.assertEqual(opts['debug'], True)
-        self.assertEqual(opts['optimization'], '2')
-        self.assertEqual(opts['buildtype'], 'debugoptimized')
+        self.assertEqual(opts['debug'], False)
+        self.assertEqual(opts['buildtype'], 'debug')
+        self.assertEqual(opts['optimization'], 'g')
 
     @skipIfNoPkgconfig
     @unittest.skipIf(is_windows(), 'Help needed with fixing this test on windows')


### PR DESCRIPTION
I have had an itch to do this for a long time but now it's finally done. Changing builtype automatically was originally my idea and it turned out not to be a great one. This should make it more sensible. In this way buildtype is more of an "intent for the build" but the exact details (e.g. -O3 instead of -O2) can still be tweaked.