### PR TITLE
summary: align left, not align middle

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1344,16 +1344,16 @@ Output:
 My Project 1.0
 
   Directories
-             prefix: /opt/gnome
-             bindir: bin
-             libdir: lib/x86_64-linux-gnu
-            datadir: share
+    prefix         : /opt/gnome
+    bindir         : bin
+    libdir         : lib/x86_64-linux-gnu
+    datadir        : share
 
   Configuration
-       Some boolean: False
+    Some boolean   : False
     Another boolean: True
-        Some string: Hello World
-             A list: string
+    Some string    : Hello World
+    A list         : string
                      1
                      True
 ```

--- a/docs/markdown/snippets/summary_alignment.md
+++ b/docs/markdown/snippets/summary_alignment.md
@@ -1,0 +1,4 @@
+## summary() now uses left alignment for all values
+
+Previously it aligned toward the center, but this was deemed harder to read
+than all left aligned.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1898,9 +1898,9 @@ class Summary:
                 mlog.log(' ', mlog.bold(section))
             for k, v in values.items():
                 v, list_sep = v
-                indent = self.max_key_len - len(k) + 3
+                padding = self.max_key_len - len(k)
                 end = ' ' if v else ''
-                mlog.log(' ' * indent, k + ':', end=end)
+                mlog.log(' ' * 3, k + ' ' * padding + ':', end=end)
                 indent = self.max_key_len + 6
                 self.dump_value(v, list_sep, indent)
         mlog.log('')  # newline

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4720,32 +4720,32 @@ class AllPlatformTests(BasePlatformTests):
         expected = textwrap.dedent(r'''
             Some Subproject 2.0
 
-                 string: bar
+                string : bar
                 integer: 1
                 boolean: True
 
             My Project 1.0
 
               Configuration
-                   Some boolean: False
+                Some boolean   : False
                 Another boolean: True
-                    Some string: Hello World
-                         A list: string
+                Some string    : Hello World
+                A list         : string
                                  1
                                  True
-                     empty list:
-                       A number: 1
-                            yes: YES
-                             no: NO
-                      coma list: a, b, c
+                empty list     :
+                A number       : 1
+                yes            : YES
+                no             : NO
+                coma list      : a, b, c
 
               Plugins
-                 long coma list: alpha, alphacolor, apetag, audiofx, audioparsers, auparse,
+                long coma list : alpha, alphacolor, apetag, audiofx, audioparsers, auparse,
                                  autodetect, avi
 
               Subprojects
-                            sub: YES
-                           sub2: NO Problem encountered: This subproject failed
+                sub            : YES
+                sub2           : NO Problem encountered: This subproject failed
             ''')
         expected_lines = expected.split('\n')[1:]
         out_start = out.find(expected_lines[0])


### PR DESCRIPTION
aligning along the left is, I think, what most projects want to do. Aligning along the middle looks subjectively ugly, and objectively prevents me from further indenting an element, e.g.

```
  Build information:
    prefix                : /usr
    sysconfdir            : /etc
        conf file         : /etc/myprogram.conf
```