### PR TITLE
Allow custom target output to be processed by generators

### DIFF
--- a/docs/markdown/snippets/permit_generator_customtarget.md
+++ b/docs/markdown/snippets/permit_generator_customtarget.md
@@ -1,0 +1,4 @@
+## Allow using generator with CustomTaget or Index of CustomTarget.
+
+Calling `generator.process()` with either a CustomTaget or Index of CustomTarget
+as files is now permitted.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -272,17 +272,25 @@ class Vs2010Backend(backends.Backend):
                         all_deps[ldep.get_id()] = ldep
                 for obj_id, objdep in self.get_obj_target_deps(target.objects):
                     all_deps[obj_id] = objdep
-                for gendep in target.get_generated_sources():
-                    if isinstance(gendep, build.CustomTarget):
-                        all_deps[gendep.get_id()] = gendep
-                    elif isinstance(gendep, build.CustomTargetIndex):
-                        all_deps[gendep.target.get_id()] = gendep.target
-                    else:
-                        gen_exe = gendep.generator.get_exe()
-                        if isinstance(gen_exe, build.Executable):
-                            all_deps[gen_exe.get_id()] = gen_exe
             else:
                 raise MesonException('Unknown target type for target %s' % target)
+
+            for gendep in target.get_generated_sources():
+                if isinstance(gendep, build.CustomTarget):
+                    all_deps[gendep.get_id()] = gendep
+                elif isinstance(gendep, build.CustomTargetIndex):
+                    all_deps[gendep.target.get_id()] = gendep.target
+                else:
+                    generator = gendep.get_generator()
+                    gen_exe = generator.get_exe()
+                    if isinstance(gen_exe, build.Executable):
+                        all_deps[gen_exe.get_id()] = gen_exe
+                    for d in generator.depends:
+                        if isinstance(d, build.CustomTargetIndex):
+                            all_deps[d.get_id()] = d.target
+                        else:
+                            all_deps[d.get_id()] = d
+
         if not t or not recursive:
             return all_deps
         ret = self.get_target_deps(all_deps, recursive)

--- a/test cases/common/106 generatorcustom/gen-resx.py
+++ b/test cases/common/106 generatorcustom/gen-resx.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import sys
+
+ofile = sys.argv[1]
+num = sys.argv[2]
+
+with open(ofile, 'w') as f:
+    f.write('res{}\n'.format(num))

--- a/test cases/common/106 generatorcustom/main.c
+++ b/test cases/common/106 generatorcustom/main.c
@@ -1,7 +1,8 @@
-#include<stdio.h>
+#include <stdio.h>
 
-#include"alltogether.h"
+#include "alltogether.h"
 
 int main(void) {
+    printf("%s - %s - %s - %s\n", res1, res2, res3, res4);
     return 0;
 }

--- a/test cases/common/106 generatorcustom/meson.build
+++ b/test cases/common/106 generatorcustom/meson.build
@@ -2,12 +2,21 @@ project('generatorcustom', 'c')
 
 creator = find_program('gen.py')
 catter = find_program('catter.py')
+gen_resx = find_program('gen-resx.py')
 
 gen = generator(creator,
   output: '@BASENAME@.h',
   arguments : ['@INPUT@', '@OUTPUT@'])
 
-hs = gen.process('res1.txt', 'res2.txt')
+res3 = custom_target('gen-res3',
+    output : 'res3.txt',
+    command : [gen_resx, '@OUTPUT@', '3'])
+
+res4 = custom_target('gen-res4',
+    output : 'res4.txt',
+    command : [gen_resx, '@OUTPUT@', '4'])
+
+hs = gen.process('res1.txt', 'res2.txt', res3, res4[0])
 
 allinone = custom_target('alltogether',
     input : hs,
@@ -17,4 +26,3 @@ allinone = custom_target('alltogether',
 proggie = executable('proggie', 'main.c', allinone)
 
 test('proggie', proggie)
-


### PR DESCRIPTION
Hi!
This change permits a `generator` to consume outputs by `custom_target` instead of failing.
This is needed to fix issues like #5693 where a generator created by the Qt module needs to process data that itself was produced in a custom target.
