### PR TITLE
mtest: improvements to logging

### DIFF
--- a/docs/markdown/snippets/meson_test_logs.md
+++ b/docs/markdown/snippets/meson_test_logs.md
@@ -1,0 +1,29 @@
+## New logging format for `meson test`
+
+The console output format for `meson test` has changed in several ways.
+The major changes are:
+
+* if stdout is a tty, `meson` includes a progress report.
+
+* if `--print-errorlogs` is specified, the logs are printed as test runs
+rather than afterwards.  All the error logs are printed rather than only
+the first ten.
+
+* if `--verbose` is specified and `--num-processes` specifies more than
+one concurrent test, test output is buffered and printed after the
+test finishes
+
+* the console logs include a reproducer command.  If `--verbose` is
+specified, the command is printed for all tests at the time they starts;
+otherwise, it is printed for failing tests at the time the test finishes
+
+* for TAP tests, Meson is able to report individual subtests.  If
+`--verbose` is specified, all tests are reported.  If `--print-errorlogs`
+is specified, only failures are.
+
+In addition, if `--verbose` was specified, Meson used not to generate
+logs.  This limitation has now been removed.
+
+These changes make the default `ninja test` output more readable, while
+`--verbose` output is provides detailed but human-readable logs that
+are well suited to CI environments.

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1191,13 +1191,31 @@ class TestSubprocess:
 
 class SingleTestRunner:
 
-    def __init__(self, test: TestSerialisation, test_env: T.Dict[str, str],
-                 env: T.Dict[str, str], name: str,
+    def __init__(self, test: TestSerialisation, env: T.Dict[str, str], name: str,
                  options: argparse.Namespace):
         self.test = test
-        self.test_env = test_env
-        self.env = env
         self.options = options
+        self.cmd = self._get_cmd()
+
+        if self.cmd and self.test.extra_paths:
+            env['PATH'] = os.pathsep.join(self.test.extra_paths + ['']) + env['PATH']
+            winecmd = []
+            for c in self.cmd:
+                winecmd.append(c)
+                if os.path.basename(c).startswith('wine'):
+                    env['WINEPATH'] = get_wine_shortpath(
+                        winecmd,
+                        ['Z:' + p for p in self.test.extra_paths] + env.get('WINEPATH', '').split(';')
+                    )
+                    break
+
+        # If MALLOC_PERTURB_ is not set, or if it is set to an empty value,
+        # (i.e., the test or the environment don't explicitly set it), set
+        # it ourselves. We do this unconditionally for regular tests
+        # because it is extremely useful to have.
+        # Setting MALLOC_PERTURB_="0" will completely disable this feature.
+        if ('MALLOC_PERTURB_' not in env or not env['MALLOC_PERTURB_']) and not options.benchmark:
+            env['MALLOC_PERTURB_'] = str(random.randint(1, 255))
 
         if self.options.gdb or self.test.timeout is None:
             timeout = None
@@ -1206,7 +1224,7 @@ class SingleTestRunner:
         else:
             timeout = self.test.timeout
 
-        self.runobj = TestRun(test, test_env, name, timeout)
+        self.runobj = TestRun(test, env, name, timeout)
 
         if self.options.gdb:
             self.console_mode = ConsoleUser.GDB
@@ -1215,7 +1233,7 @@ class SingleTestRunner:
         else:
             self.console_mode = ConsoleUser.LOGGER
 
-    def _get_cmd(self) -> T.Optional[T.List[str]]:
+    def _get_test_cmd(self) -> T.Optional[T.List[str]]:
         if self.test.fname[0].endswith('.jar'):
             return ['java', '-jar'] + self.test.fname
         elif not self.test.is_cross_built and run_with_mono(self.test.fname[0]):
@@ -1235,6 +1253,12 @@ class SingleTestRunner:
                 return self.test.exe_runner.get_command() + self.test.fname
         return self.test.fname
 
+    def _get_cmd(self) -> T.Optional[T.List[str]]:
+        test_cmd = self._get_test_cmd()
+        if not test_cmd:
+            return None
+        return TestHarness.get_wrapper(self.options) + test_cmd
+
     @property
     def visible_name(self) -> str:
         return self.runobj.name
@@ -1244,13 +1268,11 @@ class SingleTestRunner:
         return self.runobj.timeout
 
     async def run(self) -> TestRun:
-        cmd = self._get_cmd()
-        if cmd is None:
+        if self.cmd is None:
             skip_stdout = 'Not run because can not execute cross compiled binaries.'
             self.runobj.complete_skip(skip_stdout)
         else:
-            wrap = TestHarness.get_wrapper(self.options)
-            await self._run_cmd(wrap + cmd + self.test.cmd_args + self.options.test_args)
+            await self._run_cmd(self.cmd + self.test.cmd_args + self.options.test_args)
         return self.runobj
 
     async def _run_subprocess(self, args: T.List[str], *,
@@ -1288,26 +1310,6 @@ class SingleTestRunner:
                               postwait_fn=postwait_fn if not is_windows() else None)
 
     async def _run_cmd(self, cmd: T.List[str]) -> None:
-        if self.test.extra_paths:
-            self.env['PATH'] = os.pathsep.join(self.test.extra_paths + ['']) + self.env['PATH']
-            winecmd = []
-            for c in cmd:
-                winecmd.append(c)
-                if os.path.basename(c).startswith('wine'):
-                    self.env['WINEPATH'] = get_wine_shortpath(
-                        winecmd,
-                        ['Z:' + p for p in self.test.extra_paths] + self.env.get('WINEPATH', '').split(';')
-                    )
-                    break
-
-        # If MALLOC_PERTURB_ is not set, or if it is set to an empty value,
-        # (i.e., the test or the environment don't explicitly set it), set
-        # it ourselves. We do this unconditionally for regular tests
-        # because it is extremely useful to have.
-        # Setting MALLOC_PERTURB_="0" will completely disable this feature.
-        if ('MALLOC_PERTURB_' not in self.env or not self.env['MALLOC_PERTURB_']) and not self.options.benchmark:
-            self.env['MALLOC_PERTURB_'] = str(random.randint(1, 255))
-
         self.runobj.start(cmd)
         if self.console_mode is ConsoleUser.GDB:
             stdout = None
@@ -1328,7 +1330,7 @@ class SingleTestRunner:
         p = await self._run_subprocess(cmd + extra_cmd,
                                        stdout=stdout,
                                        stderr=stderr,
-                                       env=self.env,
+                                       env=self.runobj.env,
                                        cwd=self.test.workdir)
 
         parse_task = None
@@ -1425,7 +1427,7 @@ class TestHarness:
         if (test.is_cross_built and test.needs_exe_wrapper and
                 test.exe_runner and test.exe_runner.found()):
             env['MESON_EXE_WRAPPER'] = join_args(test.exe_runner.get_command())
-        return SingleTestRunner(test, test_env, env, name, options)
+        return SingleTestRunner(test, env, name, options)
 
     def process_test_result(self, result: TestRun) -> None:
         if result.res is TestResult.TIMEOUT:

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -614,7 +614,9 @@ class ConsoleLogger(TestLogger):
             self.flush()
             print(harness.format(result, mlog.colorize_console(), max_left_width=self.max_left_width),
                   flush=True)
-            if result.res.is_bad():
+            if harness.options.verbose and harness.options.num_processes > 1:
+                self.print_log(result, result.get_log(mlog.colorize_console()))
+            elif result.res.is_bad():
                 self.print_log(result, '')
         self.request_update()
 
@@ -1235,7 +1237,8 @@ class SingleTestRunner:
 
         if self.options.gdb:
             self.console_mode = ConsoleUser.GDB
-        elif self.options.verbose and not self.runobj.needs_parsing:
+        elif self.options.verbose and self.options.num_processes == 1 and \
+                not self.runobj.needs_parsing:
             self.console_mode = ConsoleUser.STDOUT
         else:
             self.console_mode = ConsoleUser.LOGGER

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1578,7 +1578,7 @@ class TestHarness:
             l.flush()
 
     def open_logfiles(self) -> None:
-        if not self.options.logbase or self.options.verbose:
+        if not self.options.logbase or self.options.gdb:
             return
 
         namebase = None

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -442,7 +442,7 @@ class TestLogger:
     def start(self, harness: 'TestHarness') -> None:
         pass
 
-    def start_test(self, test: 'TestRun') -> None:
+    def start_test(self, harness: 'TestHarness', test: 'TestRun') -> None:
         pass
 
     def log(self, harness: 'TestHarness', result: 'TestRun') -> None:
@@ -578,7 +578,7 @@ class ConsoleLogger(TestLogger):
             self.max_left_width = 3 * len(str(self.test_count)) + 8
             self.progress_task = asyncio.ensure_future(report_progress())
 
-    def start_test(self, test: 'TestRun') -> None:
+    def start_test(self, harness: 'TestHarness', test: 'TestRun') -> None:
         self.started_tests += 1
         self.running_tests.add(test)
         self.running_tests.move_to_end(test, last=False)
@@ -1277,12 +1277,16 @@ class SingleTestRunner:
     def timeout(self) -> T.Optional[int]:
         return self.runobj.timeout
 
-    async def run(self) -> TestRun:
+    async def run(self, harness: 'TestHarness') -> TestRun:
         if self.cmd is None:
             skip_stdout = 'Not run because can not execute cross compiled binaries.'
+            harness.log_start_test(self.runobj)
             self.runobj.complete_skip(skip_stdout)
         else:
-            await self._run_cmd(self.cmd + self.test.cmd_args + self.options.test_args)
+            cmd = self.cmd + self.test.cmd_args + self.options.test_args
+            self.runobj.start(cmd)
+            harness.log_start_test(self.runobj)
+            await self._run_cmd(cmd)
         return self.runobj
 
     async def _run_subprocess(self, args: T.List[str], *,
@@ -1320,7 +1324,6 @@ class SingleTestRunner:
                               postwait_fn=postwait_fn if not is_windows() else None)
 
     async def _run_cmd(self, cmd: T.List[str]) -> None:
-        self.runobj.start(cmd)
         if self.console_mode is ConsoleUser.GDB:
             stdout = None
             stderr = None
@@ -1688,6 +1691,10 @@ class TestHarness:
         finally:
             self.close_logfiles()
 
+    def log_start_test(self, test: TestRun) -> None:
+        for l in self.loggers:
+            l.start_test(self, test)
+
     async def _run_tests(self, runners: T.List[SingleTestRunner]) -> None:
         semaphore = asyncio.Semaphore(self.options.num_processes)
         futures = deque()  # type: T.Deque[asyncio.Future]
@@ -1699,9 +1706,7 @@ class TestHarness:
             async with semaphore:
                 if interrupted or (self.options.repeat > 1 and self.fail_count):
                     return
-                for l in self.loggers:
-                    l.start_test(test.runobj)
-                res = await test.run()
+                res = await test.run(self)
                 self.process_test_result(res)
 
         def test_done(f: asyncio.Future) -> None:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1600,6 +1600,7 @@ class BasePlatformTests(unittest.TestCase):
 
         p = subprocess.run(command, stdout=subprocess.PIPE,
                            stderr=subprocess.STDOUT, env=env,
+                           encoding='utf-8',
                            universal_newlines=True, cwd=workdir, timeout=60 * 5)
         print(p.stdout)
         if p.returncode != 0:


### PR DESCRIPTION
This pull requests includes several improvements to logging. In particular:
* in --verbose mode, the JSON and text file logs now include the output of the tests
* also in --verbose mode, the console log (similar to ninja) does not mix the output of multiple tests that are being run in parallel
* the console log and the text file log employ slightly different formatting, so that each medium gets the best readability
* the error logs for --print-errorlogs are emitted during the first part of the output, and not limited to 10 tests anymore.