### PR TITLE
mtest: allow quickly interrupting the test run

### DIFF
--- a/docs/markdown/snippets/meson_test_interrupt.md
+++ b/docs/markdown/snippets/meson_test_interrupt.md
@@ -1,0 +1,5 @@
+## Ctrl-C behavior in `meson test`
+
+Starting from this version, sending a `SIGINT` signal (or pressing `Ctrl-C`)
+to `meson test` will interrupt the longest running test.  Pressing `Ctrl-C`
+three times within a second will exit `meson test`.

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1651,8 +1651,8 @@ def rebuild_deps(wd: str, tests: T.List[TestSerialisation]) -> bool:
     intro_targets = dict()     # type: T.Dict[str, T.List[str]]
     for target in load_info_file(get_infodir(wd), kind='targets'):
         intro_targets[target['id']] = [
-                os.path.relpath(f, wd)
-                for f in target['filename']]
+            os.path.relpath(f, wd)
+            for f in target['filename']]
     for t in tests:
         for d in t.depends:
             if d in depends:


### PR DESCRIPTION
The new behavior of interrupting the longest running test with Ctrl-C is useful when tests hang, but not when the run is completely broken for some reason. Psychology tells us that the user will compulsively spam Ctrl-C in this case, so exit if three Ctrl-C's are detected within a second.