### PR TITLE
Avoid accidental use of STANDALONE_WASM mode on compiler tests

### DIFF
--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -43,7 +43,7 @@ class EmscriptenMixin(Compiler):
         if mode == 'link':
             suffix = 'js'
         else:
-            suffix = 'wasm'
+            suffix = 'o'
         return os.path.join(dirname, 'output.' + suffix)
 
     def thread_flags(self, env: 'Environment') -> T.List[str]:


### PR DESCRIPTION
Compiler tests, such as checking for atomics support, could fail
when compiling to WebAssembly multithreaded targets because the
compiler tests got compiled to 'output.wasm'.

Using the '.wasm' suffix in recent versions of emscripten engages
STANDALONE_WASM mode, which disables features that require a JS
runtime like shared memory.

This created false negatives on support of those features when
building a library to be linked into an executable that is not
in STANDALONE_WASM mode.

Changing these to 'output.o' will continue to produce WebAssembly
object files, but they will no longer be configured for standalone
runtime mode.