### PR TITLE
MSVC and Clang-Cl Compiler Argument Cleanup

### DIFF
--- a/docs/markdown/snippets/msvc_argument_changes.md
+++ b/docs/markdown/snippets/msvc_argument_changes.md
@@ -1,0 +1,16 @@
+## MSVC/Clang-Cl Argument Changes/Cleanup
+
+* "Disable Debug" (`/Od`) is no longer manually specified for optimization levels {`0`,`g`} (it is already the default for MSVC).
+* "Run Time Checking" (`/RTC1`) removed from `debug` buildtype by default
+* Clang-CL `debug` buildtype arguments now match MSVC arguments
+* There is now no difference between `buildtype` flags and `debug` + `optimization` flags
+
+The /Od flag has been removed, as it is already the default in the MSVC compilers, and conflicts with other user options.
+
+/RTC1 conflicts with other RTC argument types as there are many different options, and has been removed by default.
+Run Time Checking can be enabled by manually adding `/RTC1` or other RTC flags of your choice.
+
+The `debug` buildtype for clang-cl added additional arguments compared to MSVC, which had more to do with optimization than debug. The arguments removed are `/Ob0`, `/Od`, `/RTC1`. (`/Zi` was also removed, but it is already added by default when debug is enabled.)
+
+If these are important issues for you and would like builtin toggle options, 
+please file an issue in the Meson bug tracker.

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -60,31 +60,13 @@ vs64_instruction_set_args = {
     'neon': None,
 }  # T.Dicst[str, T.Optional[T.List[str]]]
 
-msvc_buildtype_args = {
-    'plain': [],
-    'debug': ["/RTC1"],
-    'debugoptimized': [],
-    'release': [],
-    'minsize': [],
-    'custom': [],
-}  # type: T.Dict[str, T.List[str]]
-
-# Clang-cl /Zi and /Z7 do the same thing
-# quoting the docs (https://clang.llvm.org/docs/MSVCCompatibility.html):
-#
-# Clang emits relatively complete CodeView debug information if /Z7 or /Zi is
-# passed. Microsoft’s link.exe will transform the CodeView debug information
-# into a PDB
-clangcl_buildtype_args = msvc_buildtype_args.copy()
-clangcl_buildtype_args['debug'] = ['/Zi', '/Ob0', '/Od', '/RTC1']
-
 msvc_optimization_args = {
-    '0': ['/Od', '/Ob0'],
-    'g': ['/O0'],
+    '0': [], # /Od is default in msvc, no need to specify it
+    'g': [], # No specific flag to optimize debugging, /Zi or /ZI will create debug information
     '1': ['/O1'],
-    '2': ['/O2', '/Ob1'],
-    '3': ['/O2', '/Ob2', '/Gw'],
-    's': ['/O1', '/Gw'], # Implies /Os.
+    '2': ['/O2'],
+    '3': ['/O2', '/Gw'],
+    's': ['/O1', '/Gw'],
 }  # type: T.Dict[str, T.List[str]]
 
 msvc_debug_args = {
@@ -183,7 +165,7 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         return ['/Fo' + target]
 
     def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return msvc_buildtype_args[buildtype]
+        return []
 
     def get_debug_args(self, is_debug: bool) -> T.List[str]:
         return msvc_debug_args[is_debug]
@@ -432,6 +414,3 @@ class ClangClCompiler(VisualStudioLikeCompiler):
 
     def get_pch_base_name(self, header: str) -> str:
         return header
-
-    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
-        return clangcl_buildtype_args[buildtype]


### PR DESCRIPTION
This PR performs some cleanup for the msvc and clang-cl arguments.

* "Disable Debug" (`/Od`) is no longer manually specified for optimization levels {`0`,`g`} (it is already the default for MSVC).
* "Run Time Checking" (`/RTC1`) removed from `debug` buildtype by default
  * Maybe an option can be added for msvc-like compilers?
* Clang-CL `debug` buildtype arguments now match MSVC arguments
* There is now no difference between `buildtype` flags and `debug` + `optimization` flags

I removed some redundancy that was in the compile args (`\Od` is used by default, and `\O2` implies `\Ob2`)