### PR TITLE
Base \MD[d] and \MT[d] off of 'debug' instead of 'buildtype'

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -125,24 +125,21 @@ platforms or with all compilers:
 | b_pgo       | off           | off, generate, use      | Use profile guided optimization |
 | b_sanitize  | none          | see below               | Code sanitizer to use |
 | b_staticpic | true          | true, false             | Build static libraries as position independent |
-| b_pie       | false         | true, false             | Build position-independent executables (since 0.49.0)|
-| b_vscrt     | from_buildtype| none, md, mdd, mt, mtd, from_buildtype, static_from_buildtype | VS runtime library to use (since 0.48.0) (static_from_buildtype since 0.56.0) |
+| b_pie       | false         | true, false             | Build position-independent executables (since 0.49.0) |
+| b_vscrt     | from_debug | none, md, mdd, mt, mtd, from_debug, static_from_debug | VS runtime library to use (since 0.48.0) (from_debug, static_from_debug since 0.57.0) |
 
 The value of `b_sanitize` can be one of: `none`, `address`, `thread`,
 `undefined`, `memory`, `address,undefined`.
 
-<a name="b_vscrt-from_buildtype"></a>
-The default value of `b_vscrt` is `from_buildtype`. The following table is used
-internally to pick the CRT compiler arguments for `from_buildtype` or
-`static_from_buildtype` *(since 0.56)* based on the value of the `buildtype` option:
+<a name="b_vscrt-from_debug"></a>
+*(since 0.57.0)* The default value of `b_vscrt` is `from_debug`. The following table is used
+internally to pick the CRT compiler arguments for `from_debug` or
+`static_from_debug` based on the value of the `debug` option:
 
-| buildtype      | from_buildtype | static_from_buildtype |
-| --------       | -------------- | --------------------- |
-| debug          | `/MDd`         | `/MTd`                |
-| debugoptimized | `/MD`          | `/MT`                 |
-| release        | `/MD`          | `/MT`                 |
-| minsize        | `/MD`          | `/MT`                 |
-| custom         | error!         | error!                |
+| debug      | from_debug | static_from_debug |
+| ---------- | -----------| ----------------- |
+| true       | `/MDd`     | `/MTd`            |
+| false      | `/MD`      | `/MT`             |
 
 ### Notes about Apple Bitcode support
 

--- a/docs/markdown/snippets/msvc_vscrt.md
+++ b/docs/markdown/snippets/msvc_vscrt.md
@@ -1,0 +1,10 @@
+## `b_vscrt` default is now `from_debug`, `from_buildtype`/`static_from_buildtype` replaced
+
+`b_vscrt` options `from_buildtype` and `static_from_buildtype` replaced with `from_debug` and `static_from_debug`.
+
+This behavior is to make debug information more consistent when building with `debug=true`.
+Previously, `debugoptimized` would enable `debug` but use `/MD` or `/MT` instead of `/MDd` and `/MTd`.
+
+Also, custom combinations of `optimization` and `debug` no longer throw meson configuration exceptions when `from_debug` and `static_form_debug` are used.
+
+The CRT behavior can still be controlled manually.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -831,14 +831,14 @@ class Vs2010Backend(backends.Backend):
         compiles = ET.SubElement(root, 'ItemDefinitionGroup')
         clconf = ET.SubElement(compiles, 'ClCompile')
         # CRT type; debug or release
-        if vscrt_type.value == 'from_buildtype':
+        if vscrt_type.value == 'from_debug':
             if self.buildtype == 'debug':
                 ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
                 ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDebugDLL'
             else:
                 ET.SubElement(type_config, 'UseDebugLibraries').text = 'false'
                 ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDLL'
-        elif vscrt_type.value == 'static_from_buildtype':
+        elif vscrt_type.value == 'static_from_debug':
             if self.buildtype == 'debug':
                 ET.SubElement(type_config, 'UseDebugLibraries').text = 'true'
                 ET.SubElement(clconf, 'RuntimeLibrary').text = 'MultiThreadedDebug'

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -285,8 +285,8 @@ base_options: 'KeyedOptionDictType' = {
     OptionKey('b_pie'): coredata.UserBooleanOption('Build executables as position independent', False),
     OptionKey('b_bitcode'): coredata.UserBooleanOption('Generate and embed bitcode (only macOS/iOS/tvOS)', False),
     OptionKey('b_vscrt'): coredata.UserComboOption('VS run-time library type to use.',
-                                                   ['none', 'md', 'mdd', 'mt', 'mtd', 'from_buildtype', 'static_from_buildtype'],
-                                                   'from_buildtype'),
+                                                   ['none', 'md', 'mdd', 'mt', 'mtd', 'from_debug', 'static_from_debug'],
+                                                   'from_debug'),
 }
 
 def option_enabled(boptions: T.Set[OptionKey], options: 'KeyedOptionDictType',
@@ -340,9 +340,9 @@ def get_base_compile_args(options: 'KeyedOptionDictType', compiler: 'Compiler') 
         args.append('-fembed-bitcode')
     try:
         crt_val = options[OptionKey('b_vscrt')].value
-        buildtype = options[OptionKey('buildtype')].value
+        debug = options[OptionKey('debug')].value
         try:
-            args += compiler.get_crt_compile_args(crt_val, buildtype)
+            args += compiler.get_crt_compile_args(crt_val, debug)
         except AttributeError:
             pass
     except KeyError:
@@ -397,9 +397,9 @@ def get_base_link_args(options: 'KeyedOptionDictType', linker: 'Compiler',
 
     try:
         crt_val = options[OptionKey('b_vscrt')].value
-        buildtype = options[OptionKey('buildtype')].value
+        debug = options[OptionKey('debug')].value
         try:
-            args += linker.get_crt_link_args(crt_val, buildtype)
+            args += linker.get_crt_link_args(crt_val, debug)
         except AttributeError:
             pass
     except KeyError:
@@ -985,10 +985,10 @@ class Compiler(metaclass=abc.ABCMeta):
     def get_disable_assert_args(self) -> T.List[str]:
         return []
 
-    def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:
+    def get_crt_compile_args(self, crt_val: str, debug: bool) -> T.List[str]:
         raise EnvironmentError('This compiler does not support Windows CRT selection')
 
-    def get_crt_link_args(self, crt_val: str, buildtype: str) -> T.List[str]:
+    def get_crt_link_args(self, crt_val: str, debug: bool) -> T.List[str]:
         raise EnvironmentError('This compiler does not support Windows CRT selection')
 
     def get_compile_only_args(self) -> T.List[str]:

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -316,17 +316,17 @@ class CudaCompiler(Compiler):
                      libtype: LibType = LibType.PREFER_SHARED) -> T.Optional[T.List[str]]:
         return ['-l' + libname] # FIXME
 
-    def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:
-        return self._to_host_flags(self.host_compiler.get_crt_compile_args(crt_val, buildtype))
+    def get_crt_compile_args(self, crt_val: str, debug: bool) -> T.List[str]:
+        return self._to_host_flags(self.host_compiler.get_crt_compile_args(crt_val, debug))
 
-    def get_crt_link_args(self, crt_val: str, buildtype: str) -> T.List[str]:
+    def get_crt_link_args(self, crt_val: str, debug: bool) -> T.List[str]:
         # nvcc defaults to static, release version of msvc runtime and provides no
         # native option to override it; override it with /NODEFAULTLIB
         host_link_arg_overrides = []
-        host_crt_compile_args = self.host_compiler.get_crt_compile_args(crt_val, buildtype)
+        host_crt_compile_args = self.host_compiler.get_crt_compile_args(crt_val, debug)
         if any(arg in ['/MDd', '/MD', '/MTd'] for arg in host_crt_compile_args):
             host_link_arg_overrides += ['/NODEFAULTLIB:LIBCMT.lib']
-        return self._cook_link_args(host_link_arg_overrides + self.host_compiler.get_crt_link_args(crt_val, buildtype))
+        return self._cook_link_args(host_link_arg_overrides + self.host_compiler.get_crt_link_args(crt_val, debug))
 
     def get_target_link_args(self, target: 'BuildTarget') -> T.List[str]:
         return self._cook_link_args(super().get_target_link_args(target))

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -395,8 +395,8 @@ class CLikeCompiler(Compiler):
             # us in that case and will error out asking us to pick one.
             try:
                 crt_val = env.coredata.options[OptionKey('b_vscrt')].value
-                buildtype = env.coredata.options[OptionKey('buildtype')].value
-                cargs += self.get_crt_compile_args(crt_val, buildtype)
+                debug = env.coredata.options[OptionKey('debug')].value
+                cargs += self.get_crt_compile_args(crt_val, debug)
             except (KeyError, AttributeError):
                 pass
 
@@ -1203,11 +1203,11 @@ class CLikeCompiler(Compiler):
             raise mesonlib.MesonException('Cannot find frameworks with non-clang compiler')
         return self._find_framework_impl(name, env, extra_dirs, allow_system)
 
-    def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:
+    def get_crt_compile_args(self, crt_val: str, debug: bool) -> T.List[str]:
         # TODO: does this belong here or in GnuLike or maybe PosixLike?
         return []
 
-    def get_crt_link_args(self, crt_val: str, buildtype: str) -> T.List[str]:
+    def get_crt_link_args(self, crt_val: str, debug: bool) -> T.List[str]:
         # TODO: does this belong here or in GnuLike or maybe PosixLike?
         return []
 

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -348,29 +348,16 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
             return []
         return os.environ['INCLUDE'].split(os.pathsep)
 
-    def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:
+    def get_crt_compile_args(self, crt_val: str, debug: bool) -> T.List[str]:
         if crt_val in self.crt_args:
             return self.crt_args[crt_val]
-        assert(crt_val in ['from_buildtype', 'static_from_buildtype'])
-        dbg = 'mdd'
-        rel = 'md'
-        if crt_val == 'static_from_buildtype':
-            dbg = 'mtd'
-            rel = 'mt'
-        # Match what build type flags used to do.
-        if buildtype == 'plain':
-            return []
-        elif buildtype == 'debug':
-            return self.crt_args[dbg]
-        elif buildtype == 'debugoptimized':
-            return self.crt_args[rel]
-        elif buildtype == 'release':
-            return self.crt_args[rel]
-        elif buildtype == 'minsize':
-            return self.crt_args[rel]
-        else:
-            assert(buildtype == 'custom')
-            raise mesonlib.EnvironmentException('Requested C runtime based on buildtype, but buildtype is "custom".')
+        assert(crt_val in ['from_debug', 'static_from_debug'])
+
+        if crt_val == 'static_from_debug':
+            return self.crt_args['mtd'] if debug else self.crt_args['mt']
+        
+        return self.crt_args['mdd'] if debug else self.crt_args['md']
+
 
     def has_func_attribute(self, name: str, env: 'Environment') -> T.Tuple[bool, bool]:
         # MSVC doesn't have __attribute__ like Clang and GCC do, so just return

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -154,7 +154,7 @@ class RustCompiler(Compiler):
             args.append('--edition=' + std.value)
         return args
 
-    def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:
+    def get_crt_compile_args(self, crt_val: str, debug: bool) -> T.List[str]:
         # Rust handles this for us, we don't need to do anything
         return []
 

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -582,8 +582,8 @@ class BoostDependency(ExternalDependency):
         vscrt = ''
         try:
             crt_val = self.env.coredata.options[mesonlib.OptionKey('b_vscrt')].value
-            buildtype = self.env.coredata.options[mesonlib.OptionKey('buildtype')].value
-            vscrt = self.clib_compiler.get_crt_compile_args(crt_val, buildtype)[0]
+            debug = self.env.coredata.options[mesonlib.OptionKey('debug')].value
+            vscrt = self.clib_compiler.get_crt_compile_args(crt_val, debug)[0]
         except (KeyError, IndexError, AttributeError):
             pass
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5819,7 +5819,7 @@ class WindowsTests(BasePlatformTests):
 
         self.new_builddir()
         self.init(testdir, extra_args=['-Dbuildtype=debugoptimized'])
-        sanitycheck_vscrt('/MD')
+        sanitycheck_vscrt('/MDd')
 
         self.new_builddir()
         self.init(testdir, extra_args=['-Dbuildtype=release'])


### PR DESCRIPTION
Currently, the msvc the automatic crt flag detection is based off of `buildtype`, this PR would change it to be based off of `debug` for the following reasons.

* The [d] suffix on either `\MD` or `\MT` directly correlates to whether or not `_DEBUG` is defined, and many projects depend on `_DEBUG` being defined by msvc when debug information is actually built. Currently, `buildtype` will turn off the debug information on `debugoptimized`.
* Mixing custom `optimization` and `debug` levels causes `buildtype=custom`, which throws the following exception:
`Requested C runtime based on buildtype, but buildtype is "custom".`
  * Current behavior requires a user to manually specify the vs crt in this case, which adds complexity
  * I do not believe a default option should cause exceptions to be thrown.