### PR TITLE
unittests: Remove double install for case 10

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6720,16 +6720,13 @@ class LinuxlikeTests(BasePlatformTests):
         testdir = os.path.join(self.unit_test_dir, '10 build_rpath')
         self.init(testdir)
         self.build()
-        # C program RPATH
         build_rpath = get_rpath(os.path.join(self.builddir, 'prog'))
+        self.assertEqual(build_rpath, '$ORIGIN/sub:/foo/bar')
+        build_rpath = get_rpath(os.path.join(self.builddir, 'progcxx'))
         self.assertEqual(build_rpath, '$ORIGIN/sub:/foo/bar')
         self.install()
         install_rpath = get_rpath(os.path.join(self.installdir, 'usr/bin/prog'))
         self.assertEqual(install_rpath, '/baz')
-        # C++ program RPATH
-        build_rpath = get_rpath(os.path.join(self.builddir, 'progcxx'))
-        self.assertEqual(build_rpath, '$ORIGIN/sub:/foo/bar')
-        self.install()
         install_rpath = get_rpath(os.path.join(self.installdir, 'usr/bin/progcxx'))
         self.assertEqual(install_rpath, 'baz')
 


### PR DESCRIPTION
**[why]**
In test case 10 the project is installed twice. This has been introduced
with commit
  55abe16 unit tests: Test that relative install_rpath works correctly
where the cxx tests where added by copy and paste.

**[how]**
First test all build rpaths, then after install all install rpaths.

**[note]**
The aforementioned commit is a bit strange in that it adds a tests with
a relative rpath with cxx files but not with c files.