### PR TITLE
Fixes for fortran: Include dirs for link_whole_targets and capital file suffix

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -45,6 +45,11 @@ if T.TYPE_CHECKING:
     InstallType = T.List[T.Tuple[str, str, T.Optional['FileMode']]]
     InstallSubdirsType = T.List[T.Tuple[str, str, T.Optional['FileMode'], T.Tuple[T.Set[str], T.Set[str]]]]
 
+# Languages that can mix with C or C++ but don't support unity builds yet
+# because the syntax we use for unity builds is specific to C/++/ObjC/++.
+# Assembly files cannot be unitified and neither can LLVM IR files
+LANGS_CANT_UNITY = ('d', 'fortran')
+
 class TestProtocol(enum.Enum):
 
     EXITCODE = 0
@@ -637,6 +642,9 @@ class Backend:
             unity_size = self.get_option_for_target(OptionKey('unity_size'), extobj.target)
 
             for comp, srcs in compsrcs.items():
+                if comp.language in LANGS_CANT_UNITY:
+                    sources += srcs
+                    continue
                 for i in range(len(srcs) // unity_size + 1):
                     osrc = self.get_unity_source_file(extobj.target,
                                                       comp.get_default_suffix(), i)

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -14,6 +14,7 @@
 
 from collections import OrderedDict
 from functools import lru_cache
+from itertools import chain
 from pathlib import Path
 import enum
 import json
@@ -767,7 +768,7 @@ class Backend:
             # pkg-config puts the thread flags itself via `Cflags:`
         # Fortran requires extra include directives.
         if compiler.language == 'fortran':
-            for lt in target.link_targets:
+            for lt in chain(target.link_targets, target.link_whole_targets):
                 priv_dir = self.get_target_private_dir(lt)
                 commands += compiler.get_include_args(priv_dir, False)
         return commands

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -637,7 +637,7 @@ int dummy;
         if self.environment.is_llvm_ir(source) or \
            self.environment.is_assembly(source):
             return False
-        suffix = os.path.splitext(source)[1][1:]
+        suffix = os.path.splitext(source)[1][1:].lower()
         for lang in self.langs_cant_unity:
             if lang not in target.compilers:
                 continue
@@ -925,7 +925,7 @@ int dummy;
         all_suffixes = set(compilers.lang_suffixes['cpp']) | set(compilers.lang_suffixes['fortran'])
         selected_sources = []
         for source in compiled_sources:
-            ext = os.path.splitext(source)[1][1:]
+            ext = os.path.splitext(source)[1][1:].lower()
             if ext in all_suffixes:
                 selected_sources.append(source)
         return selected_sources

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -626,11 +626,6 @@ int dummy;
             srcs[f] = s
         return srcs
 
-    # Languages that can mix with C or C++ but don't support unity builds yet
-    # because the syntax we use for unity builds is specific to C/++/ObjC/++.
-    # Assembly files cannot be unitified and neither can LLVM IR files
-    langs_cant_unity = ('d', 'fortran')
-
     def get_target_source_can_unity(self, target, source):
         if isinstance(source, File):
             source = source.fname
@@ -638,7 +633,7 @@ int dummy;
            self.environment.is_assembly(source):
             return False
         suffix = os.path.splitext(source)[1][1:].lower()
-        for lang in self.langs_cant_unity:
+        for lang in backends.LANGS_CANT_UNITY:
             if lang not in target.compilers:
                 continue
             if suffix in target.compilers[lang].file_suffixes:
@@ -769,7 +764,7 @@ int dummy;
         if is_unity:
             # Warn about incompatible sources if a unity build is enabled
             langs = set(target.compilers.keys())
-            langs_cant = langs.intersection(self.langs_cant_unity)
+            langs_cant = langs.intersection(backends.LANGS_CANT_UNITY)
             if langs_cant:
                 langs_are = langs = ', '.join(langs_cant).upper()
                 langs_are += ' are' if len(langs_cant) > 1 else ' is'

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2595,7 +2595,10 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
     def get_fortran_orderdeps(self, target, compiler):
         if compiler.language != 'fortran':
             return []
-        return [os.path.join(self.get_target_dir(lt), lt.get_filename()) for lt in target.link_targets]
+        return [
+            os.path.join(self.get_target_dir(lt), lt.get_filename())
+            for lt in itertools.chain(target.link_targets, target.link_whole_targets)
+        ]
 
     def generate_msvc_pch_command(self, target, compiler, pch):
         header = pch[0]

--- a/mesonbuild/scripts/depscan.py
+++ b/mesonbuild/scripts/depscan.py
@@ -46,7 +46,7 @@ class DependencyScanner:
         self.sources_with_exports = [] # type: T.List[str]
 
     def scan_file(self, fname: str) -> None:
-        suffix = os.path.splitext(fname)[1][1:]
+        suffix = os.path.splitext(fname)[1][1:].lower()
         if suffix in lang_suffixes['fortran']:
             self.scan_fortran_file(fname)
         elif suffix in lang_suffixes['cpp']:
@@ -131,7 +131,7 @@ class DependencyScanner:
         return objname
 
     def module_name_for(self, src: str) -> str:
-        suffix= os.path.splitext(src)[1][1:]
+        suffix = os.path.splitext(src)[1][1:].lower()
         if suffix in lang_suffixes['fortran']:
             exported = self.exports[src]
             # Module foo:bar goes to a file name foo@bar.smod

--- a/test cases/fortran/21 install static/main.f90
+++ b/test cases/fortran/21 install static/main.f90
@@ -1,0 +1,4 @@
+use main_lib
+implicit none
+call main_hello()
+end program

--- a/test cases/fortran/21 install static/main_lib.f90
+++ b/test cases/fortran/21 install static/main_lib.f90
@@ -1,0 +1,16 @@
+module main_lib
+    
+  use static_hello
+  implicit none
+
+  private
+  public :: main_hello
+
+  contains
+
+  subroutine main_hello
+    call static_say_hello()
+    print *, "Main hello routine finished."
+  end subroutine main_hello
+
+end module main_lib

--- a/test cases/fortran/21 install static/meson.build
+++ b/test cases/fortran/21 install static/meson.build
@@ -1,0 +1,20 @@
+# Based on 'fortran/5 static', but:
+#   - Uses a subproject dependency
+#   - Is an install:true static library to trigger certain codepath (promotion to link_whole)
+#   - Does fortran code 'generation' with configure_file
+#   - Uses .F90 ext (capital F typically denotes a dependence on preprocessor treatment, which however is not used)
+project('try-static-subproject-dependency', 'fortran', default_options: ['default_library=static'])
+
+static_dep = dependency('static_hello', fallback: ['static_hello', 'static_hello_dep'])
+
+mainsrc = 'main_lib.f90'
+mainsrc = configure_file(
+    command: [find_program('cp'), '@INPUT@', '@OUTPUT@'],
+    input: mainsrc,
+    output: 'main_lib_output.F90'
+)
+main_lib = library('mainstatic', mainsrc, dependencies: static_dep, install: true)
+main_dep = declare_dependency(link_with: main_lib)
+
+main_exe = executable('main_exe', 'main.f90', dependencies: main_dep)
+test('static_subproject_test', main_exe)

--- a/test cases/fortran/21 install static/subprojects/static_hello/meson.build
+++ b/test cases/fortran/21 install static/subprojects/static_hello/meson.build
@@ -1,0 +1,12 @@
+project('static-hello', 'fortran')
+
+# staticlibsource = 'static_hello.f90'
+staticlibsource = configure_file(
+    command: [find_program('cp'), '@INPUT@', '@OUTPUT@'],
+    input: 'static_hello.f90',
+    output: 'static_hello_output.F90'
+)
+
+static_hello_lib = static_library('static_hello', staticlibsource, install: false)
+
+static_hello_dep = declare_dependency(link_with: static_hello_lib)

--- a/test cases/fortran/21 install static/subprojects/static_hello/static_hello.f90
+++ b/test cases/fortran/21 install static/subprojects/static_hello/static_hello.f90
@@ -1,0 +1,17 @@
+module static_hello
+implicit none
+
+private
+public :: static_say_hello
+
+interface static_say_hello
+  module procedure say_hello
+end interface static_say_hello
+
+contains
+
+subroutine say_hello
+  print *, "Static library called."
+end subroutine say_hello
+
+end module static_hello

--- a/test cases/fortran/21 install static/test.json
+++ b/test cases/fortran/21 install static/test.json
@@ -1,0 +1,5 @@
+{
+    "installed": [
+        {"file": "usr/lib/libmainstatic.a", "type": "file"}
+    ]
+}


### PR DESCRIPTION
While working on some meson build systems for fortran projects, I've run into a few issues wrt dependency resolution. This PR should fix those issues I believe. There's a test too. 

Basically, some link targets were promoted to `link_whole_targets` when the build target had `install:true`, but `link_whole_targets` was not included in the loop that adds include directories for fortran static libraries. Further, some code-scanning code had file suffix checks that were case sensitive, but `.F90` is a common filename extension for fortran sources.

The projects that I work on make use of generated sources, so that's why the test does it too. This turned out not to be the source of the issues, but I left it in anyway. Hope it's fine.