### PR TITLE
Allow passing external program and dependency objects to summary()

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1313,7 +1313,11 @@ The content is a series of key/value pairs grouped into sections. If the section
 keyword argument is omitted, those key/value pairs are implicitly grouped into a section
 with no title. key/value pairs can optionally be grouped into a dictionary,
 but keep in mind that dictionaries does not guarantee ordering. `key` must be string,
-`value` can only be integer, boolean, string, or a list of those.
+`value` can be:
+
+- an integer, boolean or string
+- *since 0.57.0* an external program or a dependency
+- a list of those.
 
 `summary()` can be called multiple times as long as the same section/key
 pair doesn't appear twice. All sections will be collected and printed at

--- a/docs/markdown/snippets/summary_prog_dep.md
+++ b/docs/markdown/snippets/summary_prog_dep.md
@@ -1,0 +1,4 @@
+## `summary()` accepts external programs or dependencies
+
+External program objects and dependency objects can be passed to
+`summary()` as the value to be printed.

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -134,6 +134,13 @@ class Dependency:
     def is_built(self) -> bool:
         return False
 
+    def summary_value(self) -> T.Union[str, mlog.AnsiDecorator, mlog.AnsiText]:
+        if not self.found():
+            return mlog.red('NO')
+        if not self.version:
+            return mlog.green('YES')
+        return mlog.AnsiText(mlog.green('YES'), ' ', mlog.cyan(self.version))
+
     def get_compile_args(self) -> T.List[str]:
         if self.include_type == 'system':
             converted = []
@@ -262,6 +269,11 @@ class InternalDependency(Dependency):
             else:
                 setattr(result, k, copy.deepcopy(v, memo))
         return result
+
+    def summary_value(self) -> mlog.AnsiDecorator:
+        # Omit the version.  Most of the time it will be just the project
+        # version, which is uninteresting in the summary.
+        return mlog.green('YES')
 
     def is_built(self) -> bool:
         if self.sources or self.libraries or self.whole_libraries:
@@ -1887,6 +1899,11 @@ class ExternalProgram:
                          '(%s)' % ' '.join(self.command))
             else:
                 mlog.log('Program', mlog.bold(name), 'found:', mlog.red('NO'))
+
+    def summary_value(self) -> T.Union[str, mlog.AnsiDecorator]:
+        if not self.found():
+            return mlog.red('NO')
+        return self.path
 
     def __repr__(self) -> str:
         r = '<{} {!r} -> {!r}>'

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1876,14 +1876,6 @@ class Summary:
             self.sections[section][k] = (formatted_values, list_sep)
             self.max_key_len = max(self.max_key_len, len(k))
 
-    def text_len(self, v):
-        if isinstance(v, str):
-            return len(v)
-        elif isinstance(v, mlog.AnsiDecorator):
-            return len(v.text)
-        else:
-            raise RuntimeError('Expecting only strings or AnsiDecorator')
-
     def dump(self):
         mlog.log(self.project_name, mlog.normal_cyan(self.project_version))
         for section, values in self.sections.items():
@@ -1909,7 +1901,7 @@ class Summary:
         line_len = indent
         lines_sep = list_sep.rstrip() + lines_sep
         for v in arr:
-            v_len = self.text_len(v) + len(list_sep)
+            v_len = len(v) + len(list_sep)
             if line and line_len + v_len > max_len:
                 mlog.log(*line, sep=list_sep, end=lines_sep)
                 line_len = indent

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -136,6 +136,18 @@ class AnsiDecorator:
     def __str__(self) -> str:
         return self.get_text(colorize_console())
 
+
+class AnsiText:
+    def __init__(self, *args: T.List[T.Union[str, AnsiDecorator]]):
+        self.args = args
+
+    def __len__(self) -> int:
+        return sum((len(x) for x in self.args))
+
+    def __str__(self) -> str:
+        return ''.join((str(x) for x in self.args))
+
+
 def bold(text: str, quoted: bool = False) -> AnsiDecorator:
     return AnsiDecorator(text, "\033[1m", quoted=quoted)
 

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -130,6 +130,9 @@ class AnsiDecorator:
             text = '"{}"'.format(text)
         return text
 
+    def __str__(self) -> str:
+        return self.get_text(colorize_console())
+
 def bold(text: str, quoted: bool = False) -> AnsiDecorator:
     return AnsiDecorator(text, "\033[1m", quoted=quoted)
 

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -130,6 +130,9 @@ class AnsiDecorator:
             text = '"{}"'.format(text)
         return text
 
+    def __len__(self) -> int:
+        return len(self.text)
+
     def __str__(self) -> str:
         return self.get_text(colorize_console())
 

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -43,6 +43,7 @@ from mesonbuild import mlog
 from mesonbuild import mtest
 from mesonbuild.build import ConfigurationData
 from mesonbuild.mesonlib import MachineChoice, Popen_safe, TemporaryDirectoryWinProof
+from mesonbuild.mlog import bold, green, red, yellow
 from mesonbuild.coredata import backendlist, version as meson_version
 
 from run_tests import get_fake_options, run_configure, get_meson_script
@@ -343,22 +344,6 @@ def log_text_file(logfile, testdir, stdo, stde):
             f[2].cancel()
         executor.shutdown()
         raise StopException()
-
-
-def bold(text):
-    return mlog.bold(text).get_text(mlog.colorize_console())
-
-
-def green(text):
-    return mlog.green(text).get_text(mlog.colorize_console())
-
-
-def red(text):
-    return mlog.red(text).get_text(mlog.colorize_console())
-
-
-def yellow(text):
-    return mlog.yellow(text).get_text(mlog.colorize_console())
 
 
 def _run_ci_include(args: T.List[str]) -> str:

--- a/run_tests.py
+++ b/run_tests.py
@@ -290,7 +290,7 @@ def run_configure(commandlist, env=None):
     return run_configure_inprocess(commandlist, env=env)
 
 def print_system_info():
-    print(mlog.bold('System information.').get_text(mlog.colorize_console()))
+    print(mlog.bold('System information.'))
     print('Architecture:', platform.architecture())
     print('Machine:', platform.machine())
     print('Platform:', platform.system())
@@ -364,7 +364,7 @@ def main():
                 print(flush=True)
                 returncode = 0
             else:
-                print(mlog.bold('Running unittests.').get_text(mlog.colorize_console()))
+                print(mlog.bold('Running unittests.'))
                 print(flush=True)
                 cmd = mesonlib.python_command + ['run_unittests.py', '-v']
                 if options.failfast:
@@ -377,7 +377,7 @@ def main():
         else:
             cross_test_args = mesonlib.python_command + ['run_cross_test.py']
             for cf in options.cross:
-                print(mlog.bold('Running {} cross tests.'.format(cf)).get_text(mlog.colorize_console()))
+                print(mlog.bold('Running {} cross tests.'.format(cf)))
                 print(flush=True)
                 cmd = cross_test_args + ['cross/' + cf]
                 if options.failfast:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4745,6 +4745,12 @@ class AllPlatformTests(BasePlatformTests):
                 no             : NO
                 coma list      : a, b, c
 
+              Stuff
+                missing prog   : NO
+                existing prog  : ''' + sys.executable + '''
+                missing dep    : NO
+                internal dep   : YES
+
               Plugins
                 long coma list : alpha, alphacolor, apetag, audiofx, audioparsers, auparse,
                                  autodetect, avi

--- a/test cases/unit/73 summary/meson.build
+++ b/test cases/unit/73 summary/meson.build
@@ -9,6 +9,11 @@ summary({'Some boolean': false,
          'A list': ['string', 1, true],
          'empty list': [],
         }, section: 'Configuration')
+summary({'missing prog': find_program('xyzzy', required: false),
+         'existing prog': import('python').find_installation(),
+         'missing dep': dependency('', required: false),
+         'internal dep': declare_dependency(),
+        }, section: 'Stuff')
 summary('A number', 1, section: 'Configuration')
 summary('yes', true, bool_yn : true, section: 'Configuration')
 summary('no', false, bool_yn : true, section: 'Configuration')


### PR DESCRIPTION
It is common to include in the summary whether a program or dependency was found. Simplify the code that does so, to avoid things such as

     prg.found() ? prg.full_path() : false