### PR TITLE
Add ARM64EC as a new conceptual cpu type of arm64

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -176,7 +176,11 @@ class Vs2010Backend(backends.Backend):
             # x86
             self.platform = 'Win32'
         elif target_machine == 'aarch64' or target_machine == 'arm64':
-            self.platform = 'arm64'
+            target_cpu = self.interpreter.builtin['target_machine'].cpu_method(None, None)
+            if target_cpu == 'arm64ec':
+                self.platform = 'arm64ec'
+            else:
+                self.platform = 'arm64'
         elif 'arm' in target_machine.lower():
             self.platform = 'ARM'
         else:
@@ -1218,6 +1222,8 @@ class Vs2010Backend(backends.Backend):
             targetmachine.text = 'MachineARM'
         elif targetplatform == 'arm64':
             targetmachine.text = 'MachineARM64'
+        elif targetplatform == 'arm64ec':
+            targetmachine.text = 'MachineARM64EC'
         else:
             raise MesonException('Unsupported Visual Studio target machine: ' + targetplatform)
         # /nologo


### PR DESCRIPTION
ARM64EC is a new ARM64 ABI made by Microsoft. The ARM64EC binaries can be loaded in x64 processes on the latest Windows Insider Preview on ARM64, and they don't need to be emulated for the sake of performance.

To support the ARM64EC build target, a new conceptual arm64 cpu type 'arm64ec' is added. The cpu can be specified in cross files like below to generate msbuild solution/vcxproj files with platform set to ARM64EC.

```
[target_machine]
system = 'windows'
cpu_family = 'aarch64'
cpu = 'arm64ec'
endian = 'little'
```