### PR TITLE
Add basic support for Tiny C Compiler

### DIFF
--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -127,6 +127,7 @@ __all__ = [
     'VisualStudioCCompiler',
     'VisualStudioCPPCompiler',
     'CythonCompiler',
+    'TinyCCompiler',
 ]
 
 # Bring symbols from each module into compilers sub-package namespace
@@ -189,6 +190,7 @@ from .c import (
     CompCertCCompiler,
     C2000CCompiler,
     VisualStudioCCompiler,
+    TinyCCompiler,
 )
 from .cpp import (
     CPPCompiler,

--- a/mesonbuild/linkers/__init__.py
+++ b/mesonbuild/linkers/__init__.py
@@ -33,6 +33,7 @@ from .linkers import (
     C2000Linker,
     AIXArLinker,
     PGIStaticLinker,
+    TinyCArLinker,
     NvidiaHPC_StaticLinker,
 
     DynamicLinker,
@@ -63,6 +64,7 @@ from .linkers import (
     AIXDynamicLinker,
     OptlinkDynamicLinker,
     CudaLinker,
+    TinyCDynamicLinker,
 
     prepare_rpaths,
     order_rpaths,
@@ -90,6 +92,7 @@ __all__ = [
     'CompCertLinker',
     'C2000Linker',
     'AIXArLinker',
+    'TinyCArLinker',
     'PGIStaticLinker',
     'NvidiaHPC_StaticLinker',
 

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -308,6 +308,10 @@ class AIXArLinker(ArLikeLinker):
     id = 'aixar'
     std_args = ['-csr', '-Xany']
 
+class TinyCArLinker(ArLikeLinker):
+    id = 'ar'
+    # TinyC does not support thin archives
+    std_args = ['csr']
 
 def prepare_rpaths(raw_rpaths: str, build_dir: str, from_dir: str) -> T.List[str]:
     # The rpaths we write must be relative if they point to the build dir,
@@ -1465,3 +1469,78 @@ class CudaLinker(PosixDynamicLinkerMixin, DynamicLinker):
     def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
                         suffix: str, soversion: str, darwin_versions: T.Tuple[str, str]) -> T.List[str]:
         return []
+
+class TinyCDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
+    """Linker for TCC compiler."""
+    id = 'tcc'
+
+    def get_allow_undefined_args(self) -> T.List[str]:
+        return []
+
+    def get_pic_args(self) -> T.List[str]:
+        raise mesonlib.MesonException('This linker does not support PIC')
+
+    def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:
+        if not args:
+            return args
+        return self._apply_prefix('--whole-archive') + args + self._apply_prefix('--no-whole-archive')
+
+    def get_coverage_args(self) -> T.List[str]:
+        return []
+
+    def export_dynamic_args(self, env: 'Environment') -> T.List[str]:
+        m = env.machines[self.for_machine]
+        if m.is_windows() or m.is_cygwin():
+            return self._apply_prefix('--export-all-symbols')
+        return self._apply_prefix('-export-dynamic')
+
+    def build_rpath_args(self, env: 'Environment', build_dir: str, from_dir: str,
+                         rpath_paths: str, build_rpath: str,
+                         install_rpath: str) -> T.Tuple[T.List[str], T.Set[bytes]]:
+        m = env.machines[self.for_machine]
+        if m.is_windows() or m.is_cygwin():
+            return ([], set())
+        if not rpath_paths and not install_rpath and not build_rpath:
+            return ([], set())
+        args = []
+        origin_placeholder = '$ORIGIN'
+        processed_rpaths = prepare_rpaths(rpath_paths, build_dir, from_dir)
+        all_paths = mesonlib.OrderedSet([os.path.join(origin_placeholder, p) for p in processed_rpaths])
+        rpath_dirs_to_remove = set()
+        for p in all_paths:
+            rpath_dirs_to_remove.add(p.encode('utf8'))
+        # Build_rpath is used as-is (it is usually absolute).
+        if build_rpath != '':
+            all_paths.add(build_rpath)
+            for p in build_rpath.split(':'):
+                rpath_dirs_to_remove.add(p.encode('utf8'))
+
+        # In order to avoid relinking for RPATH removal, the binary needs to contain just
+        # enough space in the ELF header to hold the final installation RPATH.
+        paths = ':'.join(all_paths)
+        if len(paths) < len(install_rpath):
+            padding = 'X' * (len(install_rpath) - len(paths))
+            if not paths:
+                paths = padding
+            else:
+                paths = paths + ':' + padding
+        args.extend(self._apply_prefix('-rpath,' + paths))
+
+        for p in rpath_paths:
+            args.extend(['-L' + os.path.join(build_dir, p)])
+
+        return (args, rpath_dirs_to_remove)
+
+    def get_soname_args(self, env: 'Environment', prefix: str, shlib_name: str,
+                        suffix: str, soversion: str, darwin_versions: T.Tuple[str, str]) -> T.List[str]:
+        m = env.machines[self.for_machine]
+        if m.is_windows() or m.is_cygwin():
+            # For PE/COFF the soname argument has no effect
+            return []
+        sostr = '' if soversion is None else '.' + soversion
+        return self._apply_prefix(f'-soname,{prefix}{shlib_name}.{suffix}{sostr}')
+
+    def thread_flags(self, env: 'Environment') -> T.List[str]:
+        if env.machines[self.for_machine].is_haiku():
+            return []
+        return ['-pthread']

--- a/test cases/common/36 has function/meson.build
+++ b/test cases/common/36 has function/meson.build
@@ -87,7 +87,7 @@ foreach cc : compilers
     assert(cc.has_function('alloca', prefix : '#include <alloca.h>',
            args : unit_test_args),
            'built-in alloca must be found with #include')
-    if not cc.compiles(defines_has_builtin, args : unit_test_args)
+    if not cc.compiles(defines_has_builtin, args : unit_test_args) and cc.get_id() != 'tcc'
       assert(not cc.has_function('alloca',
              prefix : '#include <alloca.h>\n#undef alloca',
              args : unit_test_args),

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -818,7 +818,9 @@ class AllPlatformTests(BasePlatformTests):
         intel = IntelGnuLikeCompiler
         msvc = (VisualStudioCCompiler, VisualStudioCPPCompiler)
         clangcl = (ClangClCCompiler, ClangClCPPCompiler)
+        tcc = mesonbuild.compilers.TinyCCompiler
         ar = mesonbuild.linkers.ArLinker
+        tccar = mesonbuild.linkers.TinyCArLinker
         lib = mesonbuild.linkers.VisualStudioLinker
         langs = [('c', 'CC'), ('cpp', 'CXX')]
         if not is_windows() and platform.machine().lower() != 'e2k':
@@ -845,6 +847,9 @@ class AllPlatformTests(BasePlatformTests):
                 elif 'clang' in ebase:
                     self.assertIsInstance(ecc, clang)
                     self.assertIsInstance(elinker, ar)
+                elif ebase == 'tcc':
+                    self.assertIsInstance(ecc, tcc)
+                    self.assertIsInstance(elinker, tccar)
                 elif ebase.startswith('ic'):
                     self.assertIsInstance(ecc, intel)
                     self.assertIsInstance(elinker, ar)
@@ -1003,6 +1008,11 @@ class AllPlatformTests(BasePlatformTests):
         not LDFLAGS.
         '''
         testdir = os.path.join(self.common_test_dir, '132 get define')
+        env = get_fake_env(testdir, self.builddir, self.prefix)
+        cc = detect_c_compiler(env, MachineChoice.HOST)
+        if cc.get_id() == 'tcc':
+            raise SkipTest('Test only applies to non-TCC compilers')
+
         define = 'MESON_TEST_DEFINE_VALUE'
         # NOTE: this list can't have \n, ' or "
         # \n is never substituted by the GNU pre-processor via a -D define
@@ -2379,6 +2389,7 @@ class AllPlatformTests(BasePlatformTests):
         with open(filename, 'wb') as f:
             pickle.dump(obj, f)
 
+    @skip_if_not_base_option('b_coverage')
     def test_reconfigure(self):
         testdir = os.path.join(self.unit_test_dir, '48 reconfigure')
         self.init(testdir, extra_args=['-Dopt1=val1', '-Dsub1:werror=true'])
@@ -3385,6 +3396,8 @@ class AllPlatformTests(BasePlatformTests):
                 raise SkipTest('llvm-cov not found')
         if cc.get_id() == 'msvc':
             raise SkipTest('Test only applies to non-MSVC compilers')
+        if cc.get_id() == 'tcc':
+            raise SkipTest('Test only applies to non-TinyC compilers')
         self.init(testdir, extra_args=['-Db_coverage=true'])
         self.build()
         self.run_tests()
@@ -3405,6 +3418,8 @@ class AllPlatformTests(BasePlatformTests):
                 raise SkipTest('llvm-cov not found')
         if cc.get_id() == 'msvc':
             raise SkipTest('Test only applies to non-MSVC compilers')
+        if cc.get_id() == 'tcc':
+            raise SkipTest('Test only applies to non-TinyC compilers')
         self.init(testdir, extra_args=['-Db_coverage=true'])
         self.build()
         self.run_tests()
@@ -3425,6 +3440,8 @@ class AllPlatformTests(BasePlatformTests):
                 raise SkipTest('llvm-cov not found')
         if cc.get_id() == 'msvc':
             raise SkipTest('Test only applies to non-MSVC compilers')
+        if cc.get_id() == 'tcc':
+            raise SkipTest('Test only applies to non-TinyC compilers')
         self.init(testdir, extra_args=['-Db_coverage=true'])
         self.build()
         self.run_tests()
@@ -3445,6 +3462,8 @@ class AllPlatformTests(BasePlatformTests):
                 raise SkipTest('llvm-cov not found')
         if cc.get_id() == 'msvc':
             raise SkipTest('Test only applies to non-MSVC compilers')
+        if cc.get_id() == 'tcc':
+            raise SkipTest('Test only applies to non-TinyC compilers')
         self.init(testdir, extra_args=['-Db_coverage=true'])
         self.build()
         self.run_tests()
@@ -3465,6 +3484,8 @@ class AllPlatformTests(BasePlatformTests):
                 raise SkipTest('llvm-cov not found')
         if cc.get_id() == 'msvc':
             raise SkipTest('Test only applies to non-MSVC compilers')
+        if cc.get_id() == 'tcc':
+            raise SkipTest('Test only applies to non-TinyC compilers')
         self.init(testdir, extra_args=['-Db_coverage=true'])
         self.build()
         self.run_tests()
@@ -3485,6 +3506,8 @@ class AllPlatformTests(BasePlatformTests):
                 raise SkipTest('llvm-cov not found')
         if cc.get_id() == 'msvc':
             raise SkipTest('Test only applies to non-MSVC compilers')
+        if cc.get_id() == 'tcc':
+            raise SkipTest('Test only applies to non-TinyC compilers')
         self.init(testdir, extra_args=['-Db_coverage=true'])
         self.build()
         self.run_tests()
@@ -3551,6 +3574,8 @@ class AllPlatformTests(BasePlatformTests):
     @skipUnless(is_linux() and (re.search('^i.86$|^x86$|^x64$|^x86_64$|^amd64$', platform.processor()) is not None),
         'Requires ASM compiler for x86 or x86_64 platform currently only available on Linux CI runners')
     def test_nostdlib(self):
+        if 'tcc' in os.environ.get('CC', 'dummy'):
+            raise SkipTest('TinyCC does not correctly support extended asm.')
         testdir = os.path.join(self.unit_test_dir, '78 nostdlib')
         machinefile = os.path.join(self.builddir, 'machine.txt')
         with open(machinefile, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
This PR tries to add basic support tor tcc, Tiny C Compiler https://bellard.org/tcc/ .
I was able to use this to compile [Rizin](https://rizin.re) with tcc, however it probably still needs some adjustments because some unit tests still fail.

These are the failing tests: https://gist.github.com/ret2libc/1f386c7230e17a2c31be9ebf2c359523

Any hint on how to improve this support is welcome.

Do you suggest me to add `tcc` to the `mesonbuild/eoan` container and improve `os_comp.yaml` to test it?