### PR TITLE
do not require git installed in order to use wraps

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -353,8 +353,10 @@ class Resolver:
             raise WrapException(m)
 
     def resolve_git_submodule(self) -> bool:
+        # Is git installed? If not, we're probably not in a git repository and
+        # definitely cannot try to conveniently set up a submodule.
         if not GIT:
-            raise WrapException('Git program not found.')
+            return False
         # Are we in a git repository?
         ret, out = quiet_git(['rev-parse'], self.subdir_root)
         if not ret:


### PR DESCRIPTION
It doesn't make sense to check for the presence of git every time we use it, but short-circuit any attempt to use a wrap right from the get-go because we are trying to be fancy with submodules.

If git is not installed, simply do not try to figure out whether the wrap is a submodule that can potentially be checked out/updated for the user. Just take it on faith that it isn't one.

Fixes #2623