### PR TITLE
docs: Fix sentence in Machine-files.md

### DIFF
--- a/docs/markdown/Machine-files.md
+++ b/docs/markdown/Machine-files.md
@@ -34,7 +34,7 @@ A boolean must be either `true` or `false`, and unquoted.
 option = false
 ```
 
-An integer must be either an unquoted numeric constant;
+An integer must be an unquoted numeric constant.
 ```ini
 option = 42
 ```


### PR DESCRIPTION
Fixes: 1ca17dc853ec ("docs/machine-files: Add a section on data types")