### PR TITLE
Fix executable as script on Windows

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2609,14 +2609,6 @@ class Data:
         else:
             self.rename = rename
 
-class RunScript(dict):
-    def __init__(self, script, args):
-        super().__init__()
-        assert(isinstance(script, list))
-        assert(isinstance(args, list))
-        self['exe'] = script
-        self['args'] = args
-
 class TestSetup:
     def __init__(self, exe_wrapper: T.Optional[T.List[str]], gdb: bool,
                  timeout_multiplier: int, env: EnvironmentVariables):

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -26,6 +26,7 @@ from mesonbuild.environment import detect_ninja
 from mesonbuild.mesonlib import windows_proof_rmtree, MesonException, quiet_git
 from mesonbuild.wrap import wrap
 from mesonbuild import mlog, build
+from .scripts.meson_exe import run_exe
 
 archive_choices = ['gztar', 'xztar', 'zip']
 archive_extension = {'gztar': '.tar.gz',
@@ -79,17 +80,15 @@ def process_submodules(dirname):
 
 def run_dist_scripts(src_root, bld_root, dist_root, dist_scripts):
     assert(os.path.isabs(dist_root))
-    env = os.environ.copy()
+    env = {}
     env['MESON_DIST_ROOT'] = dist_root
     env['MESON_SOURCE_ROOT'] = src_root
     env['MESON_BUILD_ROOT'] = bld_root
     for d in dist_scripts:
-        script = d['exe']
-        args = d['args']
-        name = ' '.join(script + args)
+        name = ' '.join(d.cmd_args)
         print('Running custom dist script {!r}'.format(name))
         try:
-            rc = subprocess.call(script + args, env=env)
+            rc = run_exe(d, env)
             if rc != 0:
                 sys.exit('Dist script errored out')
         except OSError:

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -30,6 +30,7 @@ from .coredata import major_versions_differ, MesonVersionMismatchException
 from .coredata import version as coredata_version
 from .mesonlib import is_windows, Popen_safe
 from .scripts import depfixer, destdir_join
+from .scripts.meson_exe import run_exe
 try:
     from __main__ import __file__ as main_file
 except ImportError:
@@ -485,17 +486,12 @@ class Installer:
         if self.options.quiet:
             env['MESON_INSTALL_QUIET'] = '1'
 
-        child_env = os.environ.copy()
-        child_env.update(env)
-
         for i in d.install_scripts:
             self.did_install_something = True  # Custom script must report itself if it does nothing.
-            script = i['exe']
-            args = i['args']
-            name = ' '.join(script + args)
+            name = ' '.join(i.cmd_args)
             self.log('Running custom install script {!r}'.format(name))
             try:
-                rc = subprocess.call(script + args, env=child_env)
+                rc = run_exe(i, env)
             except OSError:
                 print('FAILED: install script \'{}\' could not be run, stopped'.format(name))
                 # POSIX shells return 127 when a command could not be found

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -899,7 +899,7 @@ class GnomeModule(ExtensionModule):
             args.append('--media=' + '@@'.join(media))
         if langs:
             args.append('--langs=' + '@@'.join(langs))
-        inscript = build.RunScript(script, args)
+        inscript = state.backend.get_executable_serialisation(script + args)
 
         potargs = state.environment.get_build_command() + [
             '--internal', 'yelphelper', 'pot',
@@ -1051,7 +1051,7 @@ class GnomeModule(ExtensionModule):
             self.interpreter.add_test(state.current_node, check_args, check_kwargs, True)
         res = [custom_target, alias_target]
         if kwargs.get('install', True):
-            res.append(build.RunScript(command, args))
+            res.append(state.backend.get_executable_serialisation(command + args))
         return ModuleReturnValue(custom_target, res)
 
     def _get_build_args(self, kwargs, state, depends):

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -350,7 +350,7 @@ class HotdocTargetBuilder:
 
         install_script = None
         if install is True:
-            install_script = HotdocRunScript(self.build_command, [
+            install_script = self.state.backend.get_executable_serialisation(self.build_command + [
                 "--internal", "hotdoc",
                 "--install", os.path.join(fullname, 'html'),
                 '--name', self.name,
@@ -389,11 +389,6 @@ class HotdocTarget(build.CustomTarget):
         res['subprojects'] = []
 
         return res
-
-
-class HotdocRunScript(build.RunScript):
-    def __init__(self, script, args):
-        super().__init__(script, args)
 
 
 class HotDocModule(ExtensionModule):

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -180,7 +180,7 @@ class I18nModule(ExtensionModule):
                     pkg_arg]
             if lang_arg:
                 args.append(lang_arg)
-            iscript = build.RunScript(script, args)
+            iscript = state.backend.get_executable_serialisation(script + args)
             targets.append(iscript)
 
         return ModuleReturnValue(None, targets)

--- a/test cases/common/54 install script/meson.build
+++ b/test cases/common/54 install script/meson.build
@@ -1,6 +1,5 @@
 project('custom install script', 'c')
 
-executable('prog', 'prog.c', install : true)
 meson.add_install_script('myinstall.py', 'diiba/daaba', 'file.dat')
 meson.add_install_script('myinstall.py', 'this/should', 'also-work.dat')
 
@@ -33,3 +32,14 @@ installer = configure_file(
 )
 
 meson.add_install_script(installer, 'otherdir', afile, '--mode=copy')
+
+# This executable links on a library built in src/ directory. On Windows this
+# means meson must add src/ into $PATH to find the DLL when running it as
+# install script.
+myexe = executable('prog', 'prog.c',
+  link_with: mylib,
+  install : true,
+)
+if meson.can_run_host_binaries()
+  meson.add_install_script(myexe)
+endif

--- a/test cases/common/54 install script/prog.c
+++ b/test cases/common/54 install script/prog.c
@@ -1,6 +1,14 @@
 #include<stdio.h>
 
+#ifdef _WIN32
+  #define DO_IMPORT __declspec(dllimport)
+#else
+  #define DO_IMPORT
+#endif
+
+DO_IMPORT int foo(void);
+
 int main(void) {
     printf("This is text.\n");
-    return 0;
+    return foo();
 }

--- a/test cases/common/54 install script/src/foo.c
+++ b/test cases/common/54 install script/src/foo.c
@@ -1,0 +1,10 @@
+#ifdef _WIN32
+  #define DO_EXPORT __declspec(dllexport)
+#else
+  #define DO_EXPORT
+#endif
+
+DO_EXPORT int foo(void)
+{
+  return 0;
+}

--- a/test cases/common/54 install script/src/meson.build
+++ b/test cases/common/54 install script/src/meson.build
@@ -1,3 +1,5 @@
 meson.add_install_script('myinstall.py', 'this/does', 'something-different.dat')
 
 afile = files('a file.txt')
+
+mylib = shared_library('mylib', 'foo.c')


### PR DESCRIPTION
On Windows this would fail because of missing DLL:
```
mylib = library(...)
exe = executable(..., link_with: mylib)
meson.add_install_script(exe)
```

The reason is on Windows we cannot rely on rpath to find libraries from
build directory, they are searched in $PATH. We already have all that
mechanism in place for custom_target() using ExecutableSerialisation
class, so reuse it for install/dist/postconf scripts too.

This has bonus side effect to also use exe_wrapper for those scripts.

Fixes: #8187