### PR TITLE
Some DESTDIR improvements

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1851,6 +1851,10 @@ the following methods.
   `MESON_BUILD_ROOT`, `MESON_INSTALL_PREFIX`,
   `MESON_INSTALL_DESTDIR_PREFIX`, and `MESONINTROSPECT` set.
   All positional arguments are passed as parameters.
+  *since 0.57.0* `skip_if_destdir` boolean keyword argument (defaults to `false`)
+  can be specified. If `true` the script will not be run if DESTDIR is set during
+  installation. This is useful in the case the script updates system wide
+  cache that is only needed when copying files into final destination.
 
   *(since 0.54.0)* If `meson install` is called with the `--quiet` option, the
   environment variable `MESON_INSTALL_QUIET` will be set.

--- a/docs/markdown/snippets/destdir.md
+++ b/docs/markdown/snippets/destdir.md
@@ -1,0 +1,11 @@
+## Specify DESTDIR on command line
+
+`meson install` command now has `--destdir` argument that overrides DESTDIR
+from environment.
+
+## Skip install scripts if DESTDIR is set
+
+`meson.add_install_script()` now has `skip_if_destdir` keyword argument. If set
+to `true` the script won't be run if DESTDIR is set during installation. This is
+useful in the case the script updates system wide cache that is only needed when
+copying files into final destination.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -137,6 +137,7 @@ class ExecutableSerialisation:
         self.extra_paths = extra_paths
         self.capture = capture
         self.pickled = False
+        self.skip_if_destdir = False
 
 class TestSerialisation:
     def __init__(self, name: str, project: str, suite: str, fname: T.List[str],

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2015,15 +2015,20 @@ class MesonMain(InterpreterObject):
                 '0.55.0', self.interpreter.subproject)
         return script_args
 
-    @permittedKwargs(set())
+    @FeatureNewKwargs('add_install_script', '0.57.0', ['skip_if_destdir'])
+    @permittedKwargs({'skip_if_destdir'})
     def add_install_script_method(self, args: 'T.Tuple[T.Union[str, mesonlib.File, ExecutableHolder], T.Union[str, mesonlib.File, CustomTargetHolder, CustomTargetIndexHolder, ConfigureFileHolder], ...]', kwargs):
         if len(args) < 1:
             raise InterpreterException('add_install_script takes one or more arguments')
         if isinstance(args[0], mesonlib.File):
             FeatureNew.single_use('Passing file object to script parameter of add_install_script',
                                   '0.57.0', self.interpreter.subproject)
+        skip_if_destdir = kwargs.get('skip_if_destdir', False)
+        if not isinstance(skip_if_destdir, bool):
+            raise InterpreterException('skip_if_destdir keyword argument must be boolean')
         script_args = self._process_script_args('add_install_script', args[1:], allow_built=True)
         script = self._find_source_script(args[0], script_args)
+        script.skip_if_destdir = skip_if_destdir
         self.build.install_scripts.append(script)
 
     @permittedKwargs(set())

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -53,6 +53,7 @@ if T.TYPE_CHECKING:
         profile: bool
         quiet: bool
         wd: str
+        destdir: str
 
 
 symlink_warning = '''Warning: trying to copy a symlink that points to a file. This will copy the file,
@@ -72,6 +73,8 @@ def add_arguments(parser: argparse.Namespace) -> None:
                         help='Only overwrite files that are older than the copied file.')
     parser.add_argument('--quiet', default=False, action='store_true',
                         help='Do not print every file that was installed.')
+    parser.add_argument('--destdir', default=None,
+                        help='Sets or overrides DESTDIR environment. (Since 0.57.0)')
 
 class DirMaker:
     def __init__(self, lf: T.TextIO):
@@ -405,6 +408,10 @@ class Installer:
     def do_install(self, datafilename: str) -> None:
         with open(datafilename, 'rb') as ifile:
             d = self.check_installdata(pickle.load(ifile))
+
+        # Override in the env because some scripts could be relying on it.
+        if self.options.destdir is not None:
+            os.environ['DESTDIR'] = self.options.destdir
 
         destdir = os.environ.get('DESTDIR', '')
         fullprefix = destdir_join(destdir, d.prefix)


### PR DESCRIPTION
commit 866c9937d76375b19e2faf24158202f4f32162e1
Author: Xavier Claessens <xavier.claessens@collabora.com>
Date:   Fri Jan 29 15:18:12 2021 -0500

    add_install_script: add skip_if_destdir kwarg
    
    It is common, at least in GNOME projects, to have scripts that must be
    run only in the final destination, to update system icon cache, etc.
    Skipping them from Meson ensures we can properly log that they have not
    been run instead of relying on such scripts to to it (they don't
    always).

commit e56507415b389a0fa698a7af2d4b87251331739b
Author: Xavier Claessens <xavier.claessens@collabora.com>
Date:   Fri Jan 29 15:14:02 2021 -0500

    minstall: Add --destdir command line option