### PR TITLE
XCode backend: resolve crash when using custom targets

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -223,6 +223,13 @@ class Build:
         self.searched_programs = set() # The list of all programs that have been searched for.
         self.dependency_overrides = PerMachine({}, {})
 
+    def get_build_targets(self):
+        build_targets = OrderedDict()
+        for name, t in self.targets.items():
+            if isinstance(t, BuildTarget):
+                build_targets[name] = t
+        return build_targets
+
     def copy(self):
         other = Build(self.environment)
         for k, v in self.__dict__.items():


### PR DESCRIPTION
XCode backend current crashes when using custom targets
This is a step forward in fixing the issue.  
Custom targets is not yet supported, 
but at least the xcode backend doesn't crash, and the project file is generated