### PR TITLE
Make private include directories implicit

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -671,11 +671,11 @@ class Backend:
     def get_pch_include_args(self, compiler, target):
         args = []
         pchpath = self.get_target_private_dir(target)
-        includeargs = compiler.get_include_args(pchpath, False)
         p = target.get_pch(compiler.get_language())
         if p:
             args += compiler.get_pch_use_args(pchpath, p[0])
-        return includeargs + args
+            args += compiler.get_include_args(pchpath, False)
+        return args
 
     def create_msvc_pch_implementation(self, target, lang, pch_header):
         # We have to include the language in the file name, otherwise

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2454,11 +2454,12 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         # both Meson and Autotools in parallel as part of the transition.
         if target.implicit_include_directories:
             commands += self.get_source_dir_include_args(target, compiler)
-        if target.implicit_include_directories:
             commands += self.get_build_dir_include_args(target, compiler)
-        # Finally add the private dir for the target to the include path. This
-        # must override everything else and must be the final path added.
-        commands += compiler.get_include_args(self.get_target_private_dir(target), False)
+            # Finally add the private dir for the target to the include path.
+            # This must override everything else and must be the final path
+            # added.
+            commands += compiler.get_include_args(self.get_target_private_dir(target), False)
+
         return commands
 
     def generate_single_compile(self, target, src, is_generated=False, header_deps=None, order_deps=None):

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -983,12 +983,15 @@ class Vs2010Backend(backends.Backend):
                 file_args[l] += args
         # The highest priority includes. In order of directory search:
         # target private dir, target build dir, target source dir
-        for args in file_args.values():
-            t_inc_dirs = [self.relpath(self.get_target_private_dir(target),
-                                       self.get_target_dir(target))]
-            if target.implicit_include_directories:
-                t_inc_dirs += ['.', proj_to_src_dir]
-            args += ['-I' + arg for arg in t_inc_dirs]
+        if target.implicit_include_directories:
+            for args in file_args.values():
+                t_inc_dirs = [
+                    self.relpath(self.get_target_private_dir(target),
+                                 self.get_target_dir(target)),
+                    '.',
+                    proj_to_src_dir,
+                ]
+                args += ['-I' + arg for arg in t_inc_dirs]
 
         # Split preprocessor defines and include directories out of the list of
         # all extra arguments. The rest go into %(AdditionalOptions).

--- a/test cases/common/235 pch implicit include directories/main.cpp
+++ b/test cases/common/235 pch implicit include directories/main.cpp
@@ -1,0 +1,5 @@
+#include <vector>
+#include <string>
+#include <map>
+
+int main() {}

--- a/test cases/common/235 pch implicit include directories/meson.build
+++ b/test cases/common/235 pch implicit include directories/meson.build
@@ -1,0 +1,14 @@
+project('PCH implicit include directories', 'cpp')
+# This example should have 3 steps:
+# 1) PCH step
+# 2) Compile step (which will require -Iprog.p)
+# 3) Link step
+e_pch = executable('e_pch', sources : 'main.cpp' , cpp_pch : 'pch/myexe_pch.hpp',
+  implicit_include_directories : false)
+test('e_pch', e_pch)
+
+# This example should have 2 steps:
+# 1) Compile step (which will not require -Iprog.p)
+# 2) Link step
+e_no_pch = executable('e_no_pch', sources : 'main.cpp', implicit_include_directories : false)
+test('e_no_pch', e_no_pch)

--- a/test cases/common/235 pch implicit include directories/pch/myexe_pch.hpp
+++ b/test cases/common/235 pch implicit include directories/pch/myexe_pch.hpp
@@ -1,0 +1,3 @@
+#include <vector>
+#include <string>
+#include <map>


### PR DESCRIPTION
This addresses #8276.

Each target ends up with a private directory where object files and
other generated or otherwise intermediate files are placed. This commit
makes the private directory part of the set of implicit include
directories.

The default behavior of meson is unchanged. For targets declaring
implicit_include_directories: false, the private directory is no longer
present in the compile include directories path, which may cause
problems in cases where there are implicit dependencies upon headers
that end up in the private directory.