### PR TITLE
bugfix concerning octal umasks

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -146,7 +146,7 @@ class UserIntegerOption(UserOption[int]):
 
 class OctalInt(int):
     # NinjaBackend.get_user_option_args uses str() to converts it to a command line option
-    # UserUmaskOption uses int(str, 8) to convert it to an integer
+    # UserUmaskOption.to_int() uses int(str, 8) to convert it to an integer
     # So we need to use oct instead of dec here if we do not want values to be misinterpreted.
     def __str__(self):
         return oct(int(self))

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -146,7 +146,7 @@ class UserIntegerOption(UserOption[int]):
 
 class OctalInt(int):
     # NinjaBackend.get_user_option_args uses str() to converts it to a command line option
-    # UserUmaskOption.to_int() uses int(str, 8) to convert it to an integer
+    # UserUmaskOption.toint() uses int(str, 8) to convert it to an integer
     # So we need to use oct instead of dec here if we do not want values to be misinterpreted.
     def __str__(self):
         return oct(int(self))


### PR DESCRIPTION
There is a bug concerning the `install_umask` option.
The default value is 0o22 = 18

Without this patch:

This value gets converted to an integer by `validate_value`, then NinjaBackend.get_user_option_args uses str() to converts it to ` -Dinstall_umask=18` and it gets written into build.ninja like that.

```
build meson-scan-build: CUSTOM_COMMAND PHONY
 COMMAND = ... -Dinstall_umask=18 ...
```

If you run `ninja scan-build`, then `UserUmaskOption.toint()` tries to convert that to an integer using `int(str, 8)`. This fails:

```
Invalid mode: invalid literal for int() with base 8: '18'
```

This patch fixes this.

Note that this might also be a security vulnerability, because the umask used might not be the umask you wanted. If an attacker can write to the installation, it's probably a vulnerability.
