### PR TITLE
Quick update of table of CUDA Toolkit vs. NVIDIA driver versions

### DIFF
--- a/mesonbuild/modules/unstable_cuda.py
+++ b/mesonbuild/modules/unstable_cuda.py
@@ -43,6 +43,8 @@ class CudaModule(ExtensionModule):
 
         cuda_version = args[0]
         driver_version_table = [
+            {'cuda_version': '>=11.2.0',   'windows': '460.89', 'linux': '460.27.04'},
+            {'cuda_version': '>=11.1.1',   'windows': '456.81', 'linux': '455.32'},
             {'cuda_version': '>=11.1.0',   'windows': '456.38', 'linux': '455.23'},
             {'cuda_version': '>=11.0.3',   'windows': '451.82', 'linux': '450.51.06'},
             {'cuda_version': '>=11.0.2',   'windows': '451.48', 'linux': '450.51.05'},


### PR DESCRIPTION
CUDA Toolkits 11.1.1 and 11.2.0 have been released since the last time the module has been updated, but no new compute capabilities. So simply add the two entries as they appear in the official Release Notes, [Table 2](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html).