### PR TITLE
introduce add_test_setup(exclude suites: ...) keyword argument

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -125,6 +125,9 @@ the following:
 - `is_default` *(since 0.49.0)*: a bool to set whether this is the default test setup.
   If `true`, the setup will be used whenever `meson test` is run
   without the `--setup` option.
+- `exclude_suites` *(since 0.57.0)*: a list of test suites that should be
+  excluded when using this setup.  Suites specified in the `--suite` option
+  to `meson test` will always run, overriding `add_test_setup` if necessary.
 
 To use the test setup, run `meson test --setup=*name*` inside the
 build dir.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -39,7 +39,6 @@ from .linkers import StaticLinker
 from .interpreterbase import FeatureNew
 
 if T.TYPE_CHECKING:
-    from .coredata import KeyedOptionDictType, OptionDictType
     from .interpreter import Test
     from .mesonlib import FileMode, FileOrString
 
@@ -2325,7 +2324,7 @@ class CustomTarget(Target):
         for ed in unholder(extra_deps):
             if not isinstance(ed, (CustomTarget, BuildTarget)):
                 raise InvalidArguments('Can only depend on toplevel targets: custom_target or build_target (executable or a library) got: {}({})'
-                                      .format(type(ed), ed))
+                                       .format(type(ed), ed))
             self.extra_depends.append(ed)
         for i in depend_files:
             if isinstance(i, (File, str)):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2617,11 +2617,13 @@ class Data:
 
 class TestSetup:
     def __init__(self, exe_wrapper: T.Optional[T.List[str]], gdb: bool,
-                 timeout_multiplier: int, env: EnvironmentVariables):
+                 timeout_multiplier: int, env: EnvironmentVariables,
+                 exclude_suites: T.List[str]):
         self.exe_wrapper = exe_wrapper
         self.gdb = gdb
         self.timeout_multiplier = timeout_multiplier
         self.env = env
+        self.exclude_suites = exclude_suites
 
 def get_sources_string_names(sources, backend):
     '''

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2300,7 +2300,8 @@ permitted_kwargs = {'add_global_arguments': {'language', 'native'},
                     'add_languages': {'required', 'native'},
                     'add_project_link_arguments': {'language', 'native'},
                     'add_project_arguments': {'language', 'native'},
-                    'add_test_setup': {'exe_wrapper', 'gdb', 'timeout_multiplier', 'env', 'is_default'},
+                    'add_test_setup': {'exe_wrapper', 'gdb', 'timeout_multiplier', 'env', 'is_default',
+                                       'exclude_suites'},
                     'benchmark': _base_test_args,
                     'build_target': known_build_target_kwargs,
                     'configure_file': {'input',
@@ -4687,8 +4688,10 @@ different subdirectory.
                 raise InterpreterException('\'%s\' is already set as default. '
                                            'is_default can be set to true only once' % self.build.test_setup_default_name)
             self.build.test_setup_default_name = setup_name
+        exclude_suites = mesonlib.stringlistify(kwargs.get('exclude_suites', []))
         env = self.unpack_env_kwarg(kwargs)
-        self.build.test_setups[setup_name] = build.TestSetup(exe_wrapper, gdb, timeout_multiplier, env)
+        self.build.test_setups[setup_name] = build.TestSetup(exe_wrapper, gdb, timeout_multiplier, env,
+                                                             exclude_suites)
 
     @permittedKwargs(permitted_kwargs['add_global_arguments'])
     @stringArgs

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1564,14 +1564,14 @@ class TestHarness:
     def total_failure_count(self) -> int:
         return self.fail_count + self.unexpectedpass_count + self.timeout_count
 
-    def doit(self, options: argparse.Namespace) -> int:
+    def doit(self) -> int:
         if self.is_run:
             raise RuntimeError('Test harness object can only be used once.')
         self.is_run = True
         tests = self.get_tests()
         if not tests:
             return 0
-        if not options.no_rebuild and not rebuild_deps(options.wd, tests):
+        if not self.options.no_rebuild and not rebuild_deps(self.options.wd, tests):
             # We return 125 here in case the build failed.
             # The reason is that exit code 125 tells `git bisect run` that the current
             # commit should be skipped.  Thus users can directly use `meson test` to
@@ -1913,7 +1913,7 @@ def run(options: argparse.Namespace) -> int:
         try:
             if options.list:
                 return list_tests(th)
-            return th.doit(options)
+            return th.doit()
         except TestException as e:
             print('Meson test encountered an error:\n')
             if os.environ.get('MESON_FORCE_BACKTRACE'):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2351,6 +2351,16 @@ class AllPlatformTests(BasePlatformTests):
         self._run(self.mtest_command + ['--setup=onlyenv3'])
         # Setup with only a timeout works
         self._run(self.mtest_command + ['--setup=timeout'])
+        # Setup that skips test works
+        self._run(self.mtest_command + ['--setup=good'])
+        with open(os.path.join(self.logdir, 'testlog-good.txt')) as f:
+            exclude_suites_log = f.read()
+        self.assertFalse('buggy' in exclude_suites_log)
+        # --suite overrides add_test_setup(xclude_suites)
+        self._run(self.mtest_command + ['--setup=good', '--suite', 'buggy'])
+        with open(os.path.join(self.logdir, 'testlog-good.txt')) as f:
+            include_suites_log = f.read()
+        self.assertTrue('buggy' in include_suites_log)
 
     def test_testsetup_selection(self):
         testdir = os.path.join(self.unit_test_dir, '14 testsetup selection')

--- a/test cases/unit/2 testsetups/meson.build
+++ b/test cases/unit/2 testsetups/meson.build
@@ -12,7 +12,7 @@ add_test_setup('valgrind',
   env : env)
 
 buggy = executable('buggy', 'buggy.c', 'impl.c')
-test('Test buggy', buggy)
+test('Test buggy', buggy, suite: ['buggy'])
 
 envcheck = find_program('envcheck.py')
 test('test-env', envcheck)
@@ -23,3 +23,4 @@ add_test_setup('onlyenv2', env : 'TEST_ENV=1')
 add_test_setup('onlyenv3', env : ['TEST_ENV=1'])
 add_test_setup('wrapper', exe_wrapper : [vg, '--error-exitcode=1'])
 add_test_setup('timeout', timeout_multiplier : 20)
+add_test_setup('good', exclude_suites : 'buggy')


### PR DESCRIPTION
This new keyword argument makes it possible to run specific test setups only on a subset of the tests.  For example, to mark some tests as slow and avoid running them by default:
    
    add_test_setup('quick', exclude_suites: ['slow'], is_default: true)

It will then be possible to run the slow tests with `meson test --suite slow` (or one could add `add_test_setup('slow')` for symmetry, if so inclined).
