### PR TITLE
Make installing generated man files easier

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -302,6 +302,8 @@ false otherwise.
 - `install_dir`: the subdirectory to install the generated file to
   (e.g. `share/myproject`), if omitted or given the value of empty
   string, the file is not installed.
+  *(since 0.58.0)* the special `'@MANDIR@'` value can be used for generated
+  man pages. [See here for examples](howtox.md#Install-my-generated-man-pages).
 - `install_mode` *(since 0.47.0)*: specify the file mode in symbolic format
   and optionally the owner/uid and group/gid for the installed files.
 - `output`: the output file name. *(since 0.41.0)* may contain
@@ -1132,8 +1134,8 @@ man directory during the install step. This directory can be
 overridden by specifying it with the `install_dir` keyword argument.
 
 *Note* `install_man` only accepts static files. See
-[`custom_target`](#custom_target) `install_dir` for how to install manpages
-generated that way.
+[`custom_target`](#custom_target) `install_dir` or
+[`configure_file`](#configure_file) for more information.
 
 Accepts the following keywords:
 

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -375,7 +375,10 @@ following.
   in any one of these files triggers a recompilation
 - `input`: list of source files. *(since 0.41.0)* the list is flattened.
 - `install`: when true, this target is installed during the install step
-- `install_dir`: directory to install to
+- `install_dir`: A directory or list of directories to install to.
+  *(since 0.40.0)* A list may be provided. It must be the same length as the
+  list of outputs. Each directory corresponds by index to the outputs of the
+  target. to skip installing one output set the index to `false`.
 - `install_mode` *(since 0.47.0)*: the file mode and optionally the
   owner/uid and group/gid
 - `output`: list of output files

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -379,6 +379,10 @@ following.
   *(since 0.40.0)* A list may be provided. It must be the same length as the
   list of outputs. Each directory corresponds by index to the outputs of the
   target. to skip installing one output set the index to `false`.
+  *(since 0.57.0)* accepts the special value of `'@MANDIR@`. In this case
+  meson wil automatically calculate the directory output for each output as
+  if it were a man file based on it's file extension.
+  [Further reading and examples.](howtox.md#Install-my-generated-man-files)
 - `install_mode` *(since 0.47.0)*: the file mode and optionally the
   owner/uid and group/gid
 - `output`: list of output files
@@ -1126,6 +1130,10 @@ Accepts the following keywords:
 Installs the specified man files from the source tree into system's
 man directory during the install step. This directory can be
 overridden by specifying it with the `install_dir` keyword argument.
+
+*Note* `install_man` only accepts static files. See
+[`custom_target`](#custom_target) `install_dir` for how to install manpages
+generated that way.
 
 Accepts the following keywords:
 

--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -309,3 +309,51 @@ executable(
   deps : [my_dep]
 )
 ```
+
+## Install my generated man files?
+
+You *cannot* do this by passing the output of `custom_target`
+to `install_man`. This would violate Meson's design goal of
+defining all attributes of a target when it is created.
+
+Since 0.57.0 you can use the special value `'@MANDIR@'` in the `install_dir`
+keyword argument to have meson automatically calculate this for you. For
+example:
+```meson
+custom_target(
+  'my man page',
+  input : 'my_man_page.1.in',
+  output : 'my_man_page.1',
+  comand : ...
+  install : true,
+  install_dir : '@MANDIR@',
+)
+```
+Meson will automatically calculate the install dir as `get_option('mandir') / 'man1'`,
+(`/usr/share/man/man1/my_man_page.1` by default.)
+
+This works for generating multiple man pages at once:
+```meson
+custom_target(
+  'my man page',
+  input : ['my_man_page.1.in', 'my_man_page.2.in,
+  output : ['my_man_page.1', my_man_page.2],
+  comand : ...
+  install : true,
+  install_dir : '@MANDIR@',
+)
+```
+
+And if your custom target outputs multiple things, only some of which are man pages:
+```meson
+docdir = get_option('datadir') / 'docs'
+
+custom_target(
+  'docs',
+  input : 'docs.in',
+  output : ['docs.1', 'docs.pdf', 'docs.html'],
+  comand : ...
+  install : true,
+  install_dir : ['@MANDIR@', docdir / 'pdf', docdir / 'html'],
+)
+```

--- a/docs/markdown/howtox.md
+++ b/docs/markdown/howtox.md
@@ -312,11 +312,11 @@ executable(
 
 ## Install my generated man files?
 
-You *cannot* do this by passing the output of `custom_target`
-to `install_man`. This would violate Meson's design goal of
+You *cannot* do this by passing the output of `custom_target` or
+`configure_file` to `install_man`. This would violate Meson's design goal of
 defining all attributes of a target when it is created.
 
-Since 0.57.0 you can use the special value `'@MANDIR@'` in the `install_dir`
+Since 0.58.0 you can use the special value `'@MANDIR@'` in the `install_dir`
 keyword argument to have meson automatically calculate this for you. For
 example:
 ```meson
@@ -355,5 +355,16 @@ custom_target(
   comand : ...
   install : true,
   install_dir : ['@MANDIR@', docdir / 'pdf', docdir / 'html'],
+)
+```
+
+for `configure_file`:
+```meson
+configure_file(
+  ...,
+  input : 'man.1.in',
+  output : 'man.1',
+  install : true,
+  install_dir : '@MANDIR@',
 )
 ```

--- a/docs/markdown/snippets/configure_file_mandir.md
+++ b/docs/markdown/snippets/configure_file_mandir.md
@@ -1,0 +1,13 @@
+## `configure_file` accepts `'@MANDIR@'` for its `install_dir` keyword
+
+Like `custom_target`, `configure_file` also accepts the `'@MANDIR@'` special
+value to automatically calculate the install directory for generated man files.
+
+```meson
+configure_file(
+    ...,
+    output : 'manpage.1',
+    install : true,
+    install_dir : '@MANDIR@',
+)
+```

--- a/docs/markdown/snippets/custom_target_mandir.md
+++ b/docs/markdown/snippets/custom_target_mandir.md
@@ -1,0 +1,19 @@
+## `custom_target` accepts `'@MANDIR@'` for install_dirs
+
+Until now there has been no nice way to handle generating man pages. Static
+ones can be installed with `install_man`, which automatically detects the
+extension of man pages and installs them to the right place. `custom_target`
+lacked this, and the paths had to be manually calculated.
+
+Now `'@MANDIR@'` can be used with `install_dir` to achieve the same effect:
+
+```meson
+custom_target(
+    'man page',
+    input : 'man.1.in',
+    output : 'man.1',
+    command : ...,
+    install : true,
+    install_dir : '@MANDIR@',
+)
+```

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1278,11 +1278,6 @@ class Backend:
             outdirs, custom_install_dir = t.get_install_dir(self.environment)
             # Sanity-check the outputs and install_dirs
             num_outdirs, num_out = len(outdirs), len(t.get_outputs())
-            if num_outdirs != 1 and num_outdirs != num_out:
-                m = 'Target {!r} has {} outputs: {!r}, but only {} "install_dir"s were found.\n' \
-                    "Pass 'false' for outputs that should not be installed and 'true' for\n" \
-                    'using the default installation directory for an output.'
-                raise MesonException(m.format(t.name, num_out, t.get_outputs(), num_outdirs))
             install_mode = t.get_custom_install_mode()
             # Install the target output(s)
             if isinstance(t, build.BuildTarget):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2333,6 +2333,9 @@ class CustomTarget(Target, CommandBase):
                 if '@MANDIR@' in install_dir:
                     FeatureNew.single_use('custom_target @MANDIR@ in install_dir', '0.57.0', self.subproject)
 
+                    # Yes this is gross, but all of this logic really belongs in the interpreter.
+                    from .interpreter import validate_manpage_name
+
                     # In this case we have a single '@MANDIR@' for install, but
                     # multiple outputs. We'll assume in that case all of the
                     # outputs are manual files, replace install_dir with a list
@@ -2344,11 +2347,7 @@ class CustomTarget(Target, CommandBase):
                     for i, v in enumerate(install_dir):
                         if v != '@MANDIR@':
                             continue
-                        ext = os.path.splitext(self.outputs[i])[1].lstrip('.')
-                        try:
-                            valid = 0 < int(ext) < 10
-                        except ValueError:
-                            valid = False
+                        valid, ext = validate_manpage_name(self.outputs[i])
                         if not valid:
                             raise InvalidArguments(f'custom_target @MANDIR@ requires a valid man section extension for output')
                         install_dir[i] = os.path.join(self.env.get_mandir(), f'man{ext}')

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2319,7 +2319,17 @@ class CustomTarget(Target, CommandBase):
                     FeatureNew.single_use('multiple install_dir for custom_target', '0.40.0', self.subproject)
                 # If an item in this list is False, the output corresponding to
                 # the list index of that item will not be installed
-                self.install_dir = typeslistify(kwargs['install_dir'], (str, bool))
+                install_dir = typeslistify(kwargs['install_dir'], (str, bool))
+                if True in install_dir:
+                    raise InvalidArguments('Only strings and `false` are valid for custom_target install_dir arguments.')
+                if len(install_dir) > 1 and len(install_dir) != len(self.outputs):
+                    raise InvalidArguments(
+                        'When more than one install dir is provided, the '
+                        'number of install dirs must match the number of '
+                        f'outputs. Has {len(self.outputs)} outputs: {self.outputs!r} '
+                        f'but {len(install_dir)} install dirs: {install_dir!r}')
+
+                self.install_dir = install_dir
                 self.install_mode = kwargs.get('install_mode', None)
         else:
             self.install = False

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2201,10 +2201,10 @@ class CustomTarget(Target, CommandBase):
         'console',
         'env',
     })
+    typename = 'custom'
 
     def __init__(self, name: str, subdir: str, subproject: str, kwargs: T.Dict[str, T.Any],
                  absolute_paths: bool = False, backend: T.Optional[str] = None):
-        self.typename = 'custom'
         # TODO expose keyword arg to make MachineChoice.HOST configurable
         super().__init__(name, subdir, subproject, False, MachineChoice.HOST)
         self.dependencies = []

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2181,8 +2181,9 @@ class CommandBase:
                 raise InvalidArguments('Argument {!r} in "command" is invalid'.format(c))
         return final_cmd
 
+
 class CustomTarget(Target, CommandBase):
-    known_kwargs = set([
+    KNOWN_KWARGS = frozenset({
         'input',
         'output',
         'command',
@@ -2199,7 +2200,7 @@ class CustomTarget(Target, CommandBase):
         'override_options',
         'console',
         'env',
-    ])
+    })
 
     def __init__(self, name: str, subdir: str, subproject: str, kwargs: T.Dict[str, T.Any],
                  absolute_paths: bool = False, backend: T.Optional[str] = None):
@@ -2213,12 +2214,10 @@ class CustomTarget(Target, CommandBase):
         self.process_kwargs(kwargs, backend)
         # Whether to use absolute paths for all files on the commandline
         self.absolute_paths = absolute_paths
-        unknowns = []
-        for k in kwargs:
-            if k not in CustomTarget.known_kwargs:
-                unknowns.append(k)
+
+        unknowns = set(kwargs).difference(self.KNOWN_KWARGS)
         if unknowns:
-            mlog.warning('Unknown keyword arguments in target {}: {}'.format(self.name, ', '.join(unknowns)))
+            mlog.warning('Unknown keyword arguments in target {}: {}'.format(self.name, ', '.join(sorted(unknowns))))
 
     def get_default_install_dir(self, environment):
         return None

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2205,13 +2205,15 @@ class CustomTarget(Target, CommandBase):
     typename = 'custom'
 
     def __init__(self, name: str, subdir: str, subproject: str, kwargs: T.Dict[str, T.Any],
-                 absolute_paths: bool = False, backend: T.Optional['Backend'] = None):
+                 env: environment.Environment, absolute_paths: bool = False,
+                 backend: T.Optional['Backend'] = None):
         # TODO expose keyword arg to make MachineChoice.HOST configurable
         super().__init__(name, subdir, subproject, False, MachineChoice.HOST)
         self.dependencies = []
         self.extra_depends = []
         self.depend_files = [] # Files that this target depends on but are not on the command line.
         self.depfile = None
+        self.env = env
         self.process_kwargs(kwargs, backend)
         # Whether to use absolute paths for all files on the commandline
         self.absolute_paths = absolute_paths

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -4428,7 +4428,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
     def func_configure_file(self, node, args, kwargs):
         if 'output' not in kwargs:
             raise InterpreterException('Required keyword argument "output" not defined.')
-        actions = set(['configuration', 'command', 'copy']).intersection(kwargs.keys())
+        actions = {'configuration', 'command', 'copy'}.intersection(kwargs.keys())
         if len(actions) == 0:
             raise InterpreterException('Must specify an action with one of these '
                                        'keyword arguments: \'configuration\', '
@@ -4454,7 +4454,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         else:
             fmt = 'meson'
 
-        if fmt not in ('meson', 'cmake', 'cmake@'):
+        if fmt not in {'meson', 'cmake', 'cmake@'}:
             raise InterpreterException('"format" possible values are "meson", "cmake" or "cmake@".')
 
         if 'output_format' in kwargs:

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -4054,7 +4054,7 @@ external dependencies (including libraries) must go to "dependencies".''')
                 mlog.warning('''Custom target input \'%s\' can\'t be converted to File object(s).
 This will become a hard error in the future.''' % kwargs['input'], location=self.current_node)
         kwargs['env'] = self.unpack_env_kwarg(kwargs)
-        tg = CustomTargetHolder(build.CustomTarget(name, self.subdir, self.subproject, kwargs, backend=self.backend), self)
+        tg = CustomTargetHolder(build.CustomTarget(name, self.subdir, self.subproject, kwargs, self.environment, backend=self.backend), self)
         self.add_target(name, tg.held_object)
         return tg
 

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1773,7 +1773,7 @@ class ModuleState(T.NamedTuple):
     environment: 'Environment'
     project_name: str
     project_version: str
-    backend: str
+    backend: Backend
     targets: T.Dict[str, build.Target]
     data: T.List[build.Data]
     headers: T.List[build.Headers]

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -4594,6 +4594,12 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
                                  'This will be a hard error in the next release.')
             else:
                 raise InterpreterException('"install_dir" must be a string')
+        if idir == '@MANDIR@':
+            FeatureNew.single_use('configure_file @MANDIR@ in install_dir', '0.58.0', self.subproject)
+            valid, ext = validate_manpage_name(ofile_fname)
+            if not valid:
+                raise InvalidArguments(f'configure_file @MANDIR@ requires a valid man section extension for output')
+            idir = os.path.join(self.environment.get_mandir(), f'man{ext}')
         install = kwargs.get('install', idir != '')
         if not isinstance(install, bool):
             raise InterpreterException('"install" must be a boolean')

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -2094,3 +2094,4 @@ class OptionKey:
     def is_base(self) -> bool:
         """Convenience method to check if this is a base option."""
         return self.type is OptionType.BASE
+

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -79,21 +79,16 @@ class ModuleReturnValue:
         self.new_objects = new_objects
 
 class GResourceTarget(build.CustomTarget):
-    def __init__(self, name, subdir, subproject, kwargs):
-        super().__init__(name, subdir, subproject, kwargs)
+    pass
 
 class GResourceHeaderTarget(build.CustomTarget):
-    def __init__(self, name, subdir, subproject, kwargs):
-        super().__init__(name, subdir, subproject, kwargs)
+    pass
 
 class GirTarget(build.CustomTarget):
-    def __init__(self, name, subdir, subproject, kwargs):
-        super().__init__(name, subdir, subproject, kwargs)
+    pass
 
 class TypelibTarget(build.CustomTarget):
-    def __init__(self, name, subdir, subproject, kwargs):
-        super().__init__(name, subdir, subproject, kwargs)
+    pass
 
 class VapiTarget(build.CustomTarget):
-    def __init__(self, name, subdir, subproject, kwargs):
-        super().__init__(name, subdir, subproject, kwargs)
+    pass

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -71,7 +71,7 @@ class I18nModule(ExtensionModule):
 
     @FeatureNew('i18n.merge_file', '0.37.0')
     @FeatureNewKwargs('i18n.merge_file', '0.51.0', ['args'])
-    @permittedKwargs(build.CustomTarget.known_kwargs | {'data_dirs', 'po_dir', 'type', 'args'})
+    @permittedKwargs(build.CustomTarget.KNOWN_KWARGS | {'data_dirs', 'po_dir', 'type', 'args'})
     def merge_file(self, state, args, kwargs):
         if not shutil.which('xgettext'):
             return self.nogettext_warning()

--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -204,7 +204,8 @@ class ExternalProject(InterpreterObject):
         self.target = build.CustomTarget(self.name,
                                          self.subdir.as_posix(),
                                          self.subproject,
-                                         target_kwargs)
+                                         target_kwargs,
+                                         self.env)
 
         idir = build.InstallDir(self.subdir.as_posix(),
                                 Path('dist', self.rel_prefix).as_posix(),

--- a/mesonbuild/modules/unstable_rust.py
+++ b/mesonbuild/modules/unstable_rust.py
@@ -197,6 +197,7 @@ class RustModule(ExtensionModule):
                 'depend_files': depend_files,
             },
             backend=state.backend,
+            env=state.environment,
         )
 
         return ModuleReturnValue([target], [CustomTargetHolder(target, self.interpreter)])

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -15,6 +15,7 @@
 import enum
 import os
 import re
+import typing as T
 
 from .. import mlog
 from .. import mesonlib, build
@@ -25,6 +26,9 @@ from . import ExtensionModule
 from ..interpreter import CustomTargetHolder
 from ..interpreterbase import permittedKwargs, FeatureNewKwargs, flatten
 from ..dependencies import ExternalProgram
+
+if T.TYPE_CHECKING:
+    from ..interpreter import ModuleState
 
 class ResourceCompilerType(enum.Enum):
     windres = 1
@@ -77,7 +81,7 @@ class WindowsModule(ExtensionModule):
 
     @FeatureNewKwargs('windows.compile_resources', '0.47.0', ['depend_files', 'depends'])
     @permittedKwargs({'args', 'include_directories', 'depend_files', 'depends'})
-    def compile_resources(self, state, args, kwargs):
+    def compile_resources(self, state: 'ModuleState', args, kwargs):
         extra_args = mesonlib.stringlistify(flatten(kwargs.get('args', [])))
         wrc_depend_files = extract_as_list(kwargs, 'depend_files', pop = True)
         wrc_depends = extract_as_list(kwargs, 'depends', pop = True)
@@ -152,7 +156,7 @@ class WindowsModule(ExtensionModule):
                 res_kwargs['depfile'] = res_kwargs['output'] + '.d'
                 res_kwargs['command'] += ['--preprocessor-arg=-MD', '--preprocessor-arg=-MQ@OUTPUT@', '--preprocessor-arg=-MF@DEPFILE@']
 
-            res_targets.append(build.CustomTarget(name_formatted, state.subdir, state.subproject, res_kwargs))
+            res_targets.append(build.CustomTarget(name_formatted, state.subdir, state.subproject, res_kwargs, state.environment))
 
         add_target(args)
 

--- a/test cases/common/235 custom_target mandir/copy.py
+++ b/test cases/common/235 custom_target mandir/copy.py
@@ -1,0 +1,27 @@
+# SPDX-license-identifier: Apache-2.0
+# Copyright © 2021 Intel Corporation
+
+import argparse
+import shutil
+
+
+def iter_two(seq):
+    itr = iter(seq)
+    while True:
+        try:
+            yield next(itr), next(itr)
+        except StopIteration:
+            break
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('values', nargs="*")
+    args = parser.parse_args()
+
+    for i, o in iter_two(args.values):
+        shutil.copyfile(i, o)
+
+
+if __name__ == "__main__":
+    main()

--- a/test cases/common/235 custom_target mandir/meson.build
+++ b/test cases/common/235 custom_target mandir/meson.build
@@ -33,3 +33,11 @@ custom_target(
   install : true,
   install_dir : '@MANDIR@',
 )
+
+configure_file(
+  input : 'page.1.in',
+  output : 'page.8',
+  copy : true,
+  install : true,
+  install_dir : '@MANDIR@',
+)

--- a/test cases/common/235 custom_target mandir/meson.build
+++ b/test cases/common/235 custom_target mandir/meson.build
@@ -1,0 +1,35 @@
+# SPDX-license-identifier: Apache-2.0
+# Copyright © 2021 Intel Corporation
+
+project('custom_target mandir')
+
+prog_py = import('python').find_installation()
+
+custom_target(
+  'man page',
+  input : ['copy.py', 'page.1.in'],
+  output : 'page.1',
+  command : [prog_py, '@INPUT@', '@OUTPUT@'],
+  install : true,
+  install_dir : '@MANDIR@',
+)
+
+# Multiple outputs
+custom_target(
+  'multiple man page',
+  input : ['copy.py', 'page.1.in'],
+  output : ['page.4', 'page.5'],
+  command : [prog_py, '@INPUT0@', '@INPUT1@', '@OUTPUT0@', '@INPUT1@', '@OUTPUT1@'],
+  install : true,
+  install_dir : ['@MANDIR@', '@MANDIR@'],
+)
+
+# Multiple outputs, single install_dir directive
+custom_target(
+  'multiple man page one output',
+  input : ['copy.py', 'page.1.in'],
+  output : ['page.2', 'page.3'],
+  command : [prog_py, '@INPUT0@', '@INPUT1@', '@OUTPUT0@', '@INPUT1@', '@OUTPUT1@'],
+  install : true,
+  install_dir : '@MANDIR@',
+)

--- a/test cases/common/235 custom_target mandir/page.1.in
+++ b/test cases/common/235 custom_target mandir/page.1.in
@@ -1,0 +1,1 @@
+A fake manpage

--- a/test cases/common/235 custom_target mandir/test.json
+++ b/test cases/common/235 custom_target mandir/test.json
@@ -4,6 +4,7 @@
     { "type": "file", "file": "usr/share/man/man4/page.4" },
     { "type": "file", "file": "usr/share/man/man5/page.5" },
     { "type": "file", "file": "usr/share/man/man2/page.2" },
-    { "type": "file", "file": "usr/share/man/man3/page.3" }
+    { "type": "file", "file": "usr/share/man/man3/page.3" },
+    { "type": "file", "file": "usr/share/man/man8/page.8" }
   ]
 }

--- a/test cases/common/235 custom_target mandir/test.json
+++ b/test cases/common/235 custom_target mandir/test.json
@@ -1,0 +1,9 @@
+{
+  "installed": [
+    { "type": "file", "file": "usr/share/man/man1/page.1" },
+    { "type": "file", "file": "usr/share/man/man4/page.4" },
+    { "type": "file", "file": "usr/share/man/man5/page.5" },
+    { "type": "file", "file": "usr/share/man/man2/page.2" },
+    { "type": "file", "file": "usr/share/man/man3/page.3" }
+  ]
+}

--- a/test cases/failing/42 custom target outputs not matching install_dirs/test.json
+++ b/test cases/failing/42 custom target outputs not matching install_dirs/test.json
@@ -27,7 +27,8 @@
   ],
   "stdout": [
     {
-      "line": "ERROR: Target 'too-few-install-dirs' has 3 outputs: ['toofew.h', 'toofew.c', 'toofew.sh'], but only 2 \"install_dir\"s were found."
+      "match": "re",
+      "line": "test cases/failing/42 custom target outputs not matching install_dirs/meson.build:9:0: ERROR: When more than one install dir is provided, the number of install dirs must match the number of outputs. Has 3 outputs: \\['toofew.h', 'toofew.c', 'toofew.sh'\\] but 2 install dirs: \\['([a-z]:)?/usr/include', False\\]"
     }
   ]
 }


### PR DESCRIPTION
Something that's long been a wart in meson is using man pages. If you man pages are static files you can pass them to `install_man`, which handles figuring out where to install the man pages to. For generated man pages (using either `configure_file` or `custom_target`) you must manually build the install directory. This is neither dry nor pleasant. We've discussed allowing passing these targets to `install_man`, but that creates an odd system where you either set `install : true; install_dir : ...` OR pass it to `install_man`, and violates the design goal of meson that all information about a target should be provided at target creation time.

This then, keeps all of those constraints by introducing an `'@MANDIR@'` special value that can be passed to `custom_target` and `configure_file`'s `install_dir` keyword arguments. Meson will then use the same logic it uses in `install_man` to calculate the correct install location for the target automatically.

For example:
```meson
custom_target(
  output : 'page.1',
  install : true,
  install_dir : '@MANDIR@',
)
```

Along the way I had to do a bit of refactoring, so there're some cleanups and type annotations and such in here as well. The only one of these that is significant is `Better documentation and argument checking for multiple install_dirs`, which adds and moves so argument validation logic around.

Fixes: #1550
Fixes: #2025