### PR TITLE
Make installing non-existing subdirs a supported feature

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1140,6 +1140,10 @@ Installs the entire given subdirectory and its contents from the
 source tree to the location specified by the keyword argument
 `install_dir`.
 
+If the subdirectory does not exist in the source tree, an empty directory is
+created in the specified location. *(since 0.45.0)* A newly created
+subdirectory may only be created in the keyword argument `install_dir`.
+
 The following keyword arguments are supported:
 
 - `exclude_files`: a list of file names that should not be installed.
@@ -1187,6 +1191,12 @@ share/
 ```text
 share/
   file1
+```
+
+`install_subdir('new_directory', install_dir : 'share')` creates
+```text
+share/
+  new_directory/
 ```
 
 ### is_disabler()

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2224,6 +2224,7 @@ class AllPlatformTests(BasePlatformTests):
             'sub/sub1': 'share/sub1',
             'sub_elided': 'share',
             'nested_elided/sub': 'share',
+            'new_directory': 'share/new_directory',
         }
 
         self.assertEqual(len(intro), len(expected))

--- a/test cases/common/60 install subdir/meson.build
+++ b/test cases/common/60 install subdir/meson.build
@@ -16,3 +16,6 @@ install_subdir('sub/sub1', install_dir : 'share')
 # strip_directory
 install_subdir('sub_elided', install_dir : 'share', strip_directory : true)
 install_subdir('nested_elided/sub', install_dir : 'share', strip_directory : true)
+
+# Create new empty directory that doesn't exist in the source tree
+install_subdir('new_directory', install_dir : 'share')

--- a/test cases/common/60 install subdir/test.json
+++ b/test cases/common/60 install subdir/test.json
@@ -11,6 +11,7 @@
     {"type": "file", "file": "usr/share/sub1/third.dat"},
     {"type": "file", "file": "usr/share/sub1/sub2/data2.dat"},
     {"type": "file", "file": "usr/share/sub2/one.dat"},
-    {"type": "file", "file": "usr/share/sub2/dircheck/excluded-three.dat"}
+    {"type": "file", "file": "usr/share/sub2/dircheck/excluded-three.dat"},
+    {"type": "dir", "file": "usr/share/new_directory"}
   ]
 }


### PR DESCRIPTION
`install_subdir()` with a non-existing subdir creates the directory in the
target directory. This seems like an implementation detail but is quite useful
to create new directories for e.g. configuration or plugins in the installed
locations.

Let's add a test for it and document it to make this behavior official.

Limitation: it can only create at the install_dir location, trying to create
nested subdirectories does not work and indeed creates the wrong directory
structure. That is a bug that should be fixed separately:

        install_subdir('blah',
                        install_dir: get_option('prefix'))
        install_subdir('sub/foobar',
                        install_dir: get_option('prefix'))
        install_subdir('foo/baz',
                        install_dir: get_option('prefix'))

        $ tree ../_inst
        ../_inst
        ├── baz
        ├── blah
        └── foobar

Fixes #2904