### PR TITLE
xcode-backend: fix include paths

### DIFF
--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -735,6 +735,7 @@ class XCodeBackend(backends.Backend):
                     product_name = target.get_basename()
                 ldargs += target.link_args
                 cargs = []
+                cargs.append('-I.')
                 for dep in target.get_external_deps():
                     cargs += dep.get_compile_args()
                     ldargs += dep.get_link_args()
@@ -753,7 +754,7 @@ class XCodeBackend(backends.Backend):
                     args = pargs + gargs + targs
                     if args:
                         langargs[langnamemap[lang]] = args
-                langargs['C'] += cargs
+                        langargs[langnamemap[lang]] += cargs
                 symroot = os.path.join(self.environment.get_build_dir(), target.subdir)
                 self.write_line('%s /* %s */ = {' % (valid, buildtype))
                 self.indent_level += 1


### PR DESCRIPTION
Add include paths from dependencies for all languages (c, c++, objc, objc++)

This is a continuation of https://github.com/mesonbuild/meson/pull/8257