### PR TITLE
Add a positional argumetn checking deocrator for the interpreter

### DIFF
--- a/docs/markdown/Windows-module.md
+++ b/docs/markdown/Windows-module.md
@@ -7,6 +7,12 @@ Windows.
 
 ### compile_resources
 
+Arguments may be of types (or lists thereof):
+ - `file`
+ - `str`
+ - `custom_target`
+ - `custom_target indicies` *(new in 0.58.0)*
+
 Compiles Windows `rc` files specified in the positional arguments.
 Returns an opaque object that you put in the list of sources for the
 target you want to have the resources in. This method has the

--- a/docs/markdown/snippets/windows_module_compiler_resources_custom_target_indicies.md
+++ b/docs/markdown/snippets/windows_module_compiler_resources_custom_target_indicies.md
@@ -1,0 +1,9 @@
+## `windows.compiler_resources` now accepts indices of `custom_targets`
+
+You may now write:
+```meson
+ct = custom_target(...)
+
+win = import('windows')
+win.compile_resources(ct[0])
+```

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1483,12 +1483,7 @@ You probably should put it in link_with instead.''')
                 return
 
 class Generator:
-    def __init__(self, args, kwargs):
-        if len(args) != 1:
-            raise InvalidArguments('Generator requires exactly one positional argument: the executable')
-        exe = unholder(args[0])
-        if not isinstance(exe, (Executable, programs.ExternalProgram)):
-            raise InvalidArguments('First generator argument must be an executable.')
+    def __init__(self, exe: T.Union['Executable', dependencies.ExternalProgram], kwargs):
         self.exe = exe
         self.depfile = None
         self.capture = False
@@ -1570,8 +1565,7 @@ class Generator:
         relpath = pathlib.PurePath(trial).relative_to(parent)
         return relpath.parts[0] != '..' # For subdirs we can only go "down".
 
-    def process_files(self, name, files, state, preserve_path_from=None, extra_args=None):
-        new = False
+    def process_files(self, name, files: T.Iterable['FileOrString'], state, preserve_path_from=None, extra_args=None):
         output = GeneratedList(self, state.subdir, preserve_path_from, extra_args=extra_args if extra_args is not None else [])
         for e in unholder(files):
             fs = [e]

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3119,15 +3119,15 @@ external dependencies (including libraries) must go to "dependencies".''')
 
     @FeatureNewKwargs('add_languages', '0.54.0', ['native'])
     @permittedKwargs(permitted_kwargs['add_languages'])
-    @stringArgs
-    def func_add_languages(self, node, args, kwargs):
+    @typed_pos_args('add_languages', varargs=str)
+    def func_add_languages(self, node, args: T.Tuple[T.List[str]], kwargs):
         disabled, required, feature = extract_required_kwarg(kwargs, self.subproject)
         if disabled:
-            for lang in sorted(args, key=compilers.sort_clink):
+            for lang in sorted(args[0], key=compilers.sort_clink):
                 mlog.log('Compiler for language', mlog.bold(lang), 'skipped: feature', mlog.bold(feature), 'disabled')
             return False
         if 'native' in kwargs:
-            return self.add_languages(args, required, self.machine_from_native_kwarg(kwargs))
+            return self.add_languages(args[0], required, self.machine_from_native_kwarg(kwargs))
         else:
             # absent 'native' means 'both' for backwards compatibility
             tv = FeatureNew.get_target_version(self.subproject)
@@ -3135,8 +3135,8 @@ external dependencies (including libraries) must go to "dependencies".''')
                 mlog.warning('add_languages is missing native:, assuming languages are wanted for both host and build.',
                              location=self.current_node)
 
-            success = self.add_languages(args, False, MachineChoice.BUILD)
-            success &= self.add_languages(args, required, MachineChoice.HOST)
+            success = self.add_languages(args[0], False, MachineChoice.BUILD)
+            success &= self.add_languages(args[0], required, MachineChoice.HOST)
             return success
 
     @noArgsFlattening
@@ -4563,28 +4563,28 @@ This warning will become a hard error in a future Meson release.
                                                              exclude_suites)
 
     @permittedKwargs(permitted_kwargs['add_global_arguments'])
-    @stringArgs
-    def func_add_global_arguments(self, node, args, kwargs):
+    @typed_pos_args('add_global_arguments', varargs=str)
+    def func_add_global_arguments(self, node, args: T.Tuple[T.List[str]], kwargs):
         for_machine = self.machine_from_native_kwarg(kwargs)
-        self.add_global_arguments(node, self.build.global_args[for_machine], args, kwargs)
+        self.add_global_arguments(node, self.build.global_args[for_machine], args[0], kwargs)
 
     @permittedKwargs(permitted_kwargs['add_global_link_arguments'])
-    @stringArgs
-    def func_add_global_link_arguments(self, node, args, kwargs):
+    @typed_pos_args('add_global_link_arguments', varargs=str)
+    def func_add_global_link_arguments(self, node, args: T.Tuple[T.List[str]], kwargs):
         for_machine = self.machine_from_native_kwarg(kwargs)
-        self.add_global_arguments(node, self.build.global_link_args[for_machine], args, kwargs)
+        self.add_global_arguments(node, self.build.global_link_args[for_machine], args[0], kwargs)
 
     @permittedKwargs(permitted_kwargs['add_project_arguments'])
-    @stringArgs
-    def func_add_project_arguments(self, node, args, kwargs):
+    @typed_pos_args('add_project_arguments', varargs=str)
+    def func_add_project_arguments(self, node, args: T.Tuple[T.List[str]], kwargs):
         for_machine = self.machine_from_native_kwarg(kwargs)
-        self.add_project_arguments(node, self.build.projects_args[for_machine], args, kwargs)
+        self.add_project_arguments(node, self.build.projects_args[for_machine], args[0], kwargs)
 
     @permittedKwargs(permitted_kwargs['add_project_link_arguments'])
-    @stringArgs
-    def func_add_project_link_arguments(self, node, args, kwargs):
+    @typed_pos_args('add_project_link_arguments', varargs=str)
+    def func_add_project_link_arguments(self, node, args: T.Tuple[T.List[str]], kwargs):
         for_machine = self.machine_from_native_kwarg(kwargs)
-        self.add_project_arguments(node, self.build.projects_link_args[for_machine], args, kwargs)
+        self.add_project_arguments(node, self.build.projects_link_args[for_machine], args[0], kwargs)
 
     def warn_about_builtin_args(self, args):
         # -Wpedantic is deliberately not included, since some people want to use it but not use -Wextra
@@ -4613,7 +4613,7 @@ This warning will become a hard error in a future Meson release.
                 mlog.warning(f'Consider using the built-in option for language standard version instead of using "{arg}".',
                              location=self.current_node)
 
-    def add_global_arguments(self, node, argsdict, args, kwargs):
+    def add_global_arguments(self, node: mparser.BaseNode, argsdict, args: T.List[str], kwargs) -> None:
         if self.is_subproject():
             msg = 'Function \'{}\' cannot be used in subprojects because ' \
                   'there is no way to make that reliable.\nPlease only call ' \
@@ -4631,7 +4631,7 @@ This warning will become a hard error in a future Meson release.
         self.add_arguments(node, argsdict[self.subproject],
                            self.project_args_frozen, args, kwargs)
 
-    def add_arguments(self, node, argsdict, args_frozen, args, kwargs):
+    def add_arguments(self, node: mparser.BaseNode, argsdict, args_frozen: bool, args: T.List[str], kwargs):
         if args_frozen:
             msg = 'Tried to use \'{}\' after a build target has been declared.\n' \
                   'This is not permitted. Please declare all ' \
@@ -4922,7 +4922,6 @@ This will become a hard error in the future.''', location=self.current_node)
             return fallback
         raise InterpreterException('Tried to get unknown variable "%s".' % varname)
 
-    @stringArgs
     @noKwargs
     @typed_pos_args('is_variable', object)
     def func_is_variable(self, node, args: T.Tuple[object], kwargs):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -4723,9 +4723,11 @@ Try setting b_lundef to false instead.'''.format(self.coredata.options[OptionKey
         if project_root / self.subproject_dir in norm.parents:
             raise InterpreterException(f'Sandbox violation: Tried to grab {inputtype} {norm.name} from a nested subproject.')
 
-    def source_strings_to_files(self, sources: T.Sequence[str]) -> T.List[mesonlib.File]:
+    def source_strings_to_files(self, sources: T.Sequence[T.Union[mesonlib.File, GeneratedListHolder, TargetHolder, CustomTargetIndexHolder, GeneratedObjectsHolder, str]]) -> \
+            T.List[T.Union[mesonlib.File, GeneratedListHolder, TargetHolder, CustomTargetIndexHolder, GeneratedObjectsHolder]]:
+        # TODO: should we be unohldering here?
         mesonlib.check_direntry_issues(sources)
-        results: T.List[mesonlib.File] = []
+        results: T.List[T.Union[mesonlib.File, GeneratedListHolder, TargetHolder, CustomTargetIndexHolder, GeneratedObjectsHolder]] = []
         for s in sources:
             if isinstance(s, (mesonlib.File, GeneratedListHolder,
                               TargetHolder, CustomTargetIndexHolder,

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -246,7 +246,7 @@ class permittedKwargs:
 
 def typed_pos_args(name: str, *types: T.Union[T.Type, T.Tuple[T.Type, ...]],
                    varargs: T.Optional[T.Union[T.Type, T.Tuple[T.Type]]] = None,
-                   optargs: T.Optional[T.List[T.Union[T.Type, T.Tuple[T.Type]]]] = None,
+                   optargs: T.Optional[T.Sequence[T.Union[T.Type, T.Tuple[T.Type]]]] = None,
                    min_varargs: int = 0, max_varargs: int = 0) -> T.Callable[..., T.Any]:
     """Decorator that types type checking of positional arguments.
 

--- a/mesonbuild/modules/dlang.py
+++ b/mesonbuild/modules/dlang.py
@@ -17,18 +17,18 @@
 
 import json
 import os
+import typing as T
 
 from . import ExtensionModule
-
 from .. import mlog
-
 from ..mesonlib import (
     Popen_safe, MesonException
 )
-
 from ..dependencies.base import DubDependency
 from ..programs import ExternalProgram
 from ..interpreter import DependencyHolder
+from ..interpreterbase import typed_pos_args
+
 
 class DlangModule(ExtensionModule):
     class_dubbin = None
@@ -46,7 +46,7 @@ class DlangModule(ExtensionModule):
             self.dubbin = DlangModule.class_dubbin
 
         if DlangModule.class_dubbin is None:
-            self.dubbin = self.check_dub()
+            self.dubbin = self._check_dub()
             DlangModule.class_dubbin = self.dubbin
         else:
             self.dubbin = DlangModule.class_dubbin
@@ -55,12 +55,10 @@ class DlangModule(ExtensionModule):
             if not self.dubbin:
                 raise MesonException('DUB not found.')
 
-    def generate_dub_file(self, interpreter, state, args, kwargs):
+    @typed_pos_args('dlangmod.generate_dub_file', str, str)
+    def generate_dub_file(self, interpreter, state, args: T.Tuple[str, str], kwargs):
         if not DlangModule.init_dub:
             self._init_dub()
-
-        if len(args) < 2:
-            raise MesonException('Missing arguments')
 
         config = {
             'name': args[0]
@@ -113,7 +111,7 @@ class DlangModule(ExtensionModule):
         p, out = Popen_safe(self.dubbin.get_command() + args, env=env)[0:2]
         return p.returncode, out.strip()
 
-    def check_dub(self):
+    def _check_dub(self):
         dubbin = ExternalProgram('dub', silent=True)
         if dubbin.found():
             try:

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -16,6 +16,7 @@
 
 import os
 from collections import OrderedDict
+import typing as T
 
 from mesonbuild import mesonlib
 from mesonbuild import mlog, build
@@ -24,7 +25,7 @@ from . import ModuleReturnValue
 from . import ExtensionModule
 from . import get_include_args
 from ..dependencies import Dependency, InternalDependency
-from ..interpreterbase import FeatureNew, InvalidArguments, noPosargs, noKwargs
+from ..interpreterbase import FeatureNew, InvalidArguments, noPosargs, noKwargs, typed_pos_args
 from ..interpreter import CustomTargetHolder
 from ..programs import ExternalProgram
 
@@ -408,15 +409,13 @@ class HotDocModule(ExtensionModule):
                 MIN_HOTDOC_VERSION, e))
 
     @noKwargs
-    def has_extensions(self, state, args, kwargs):
-        res = self.hotdoc.run_hotdoc(['--has-extension=%s' % extension for extension in args]) == 0
+    @typed_pos_args('hotdoc.has_extensions', varargs=str, min_varargs=1)
+    def has_extensions(self, state, args: T.Tuple[T.List[str]], kwargs):
+        res = self.hotdoc.run_hotdoc(['--has-extension=%s' % extension for extension in args[0]]) == 0
         return ModuleReturnValue(res, [res])
 
-    def generate_doc(self, state, args, kwargs):
-        if len(args) != 1:
-            raise MesonException('One positional argument is'
-                                 ' required for the project name.')
-
+    @typed_pos_args('hotdoc.generate_doc', str)
+    def generate_doc(self, state, args: T.Tuple[str], kwargs):
         project_name = args[0]
         builder = HotdocTargetBuilder(project_name, state, self.hotdoc, self.interpreter, kwargs)
         target, install_script = builder.make_targets()

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 import shutil
+import typing as T
 
 from os import path
 from .. import coredata, mesonlib, build, mlog
 from ..mesonlib import MesonException
 from . import ModuleReturnValue
 from . import ExtensionModule
-from ..interpreterbase import permittedKwargs, FeatureNew, FeatureNewKwargs
+from ..interpreterbase import noPosargs, permittedKwargs, FeatureNew, FeatureNewKwargs, typed_pos_args
 
 PRESET_ARGS = {
     'glib': [
@@ -72,6 +73,7 @@ class I18nModule(ExtensionModule):
     @FeatureNew('i18n.merge_file', '0.37.0')
     @FeatureNewKwargs('i18n.merge_file', '0.51.0', ['args'])
     @permittedKwargs(build.CustomTarget.known_kwargs | {'data_dirs', 'po_dir', 'type', 'args'})
+    @noPosargs
     def merge_file(self, state, args, kwargs):
         if not shutil.which('xgettext'):
             return self.nogettext_warning()
@@ -124,9 +126,8 @@ class I18nModule(ExtensionModule):
     @FeatureNewKwargs('i18n.gettext', '0.37.0', ['preset'])
     @FeatureNewKwargs('i18n.gettext', '0.50.0', ['install_dir'])
     @permittedKwargs({'po_dir', 'data_dirs', 'type', 'languages', 'args', 'preset', 'install', 'install_dir'})
-    def gettext(self, state, args, kwargs):
-        if len(args) != 1:
-            raise coredata.MesonException('Gettext requires one positional argument (package name).')
+    @typed_pos_args('i18n.gettext', str)
+    def gettext(self, state, args: T.Tuple[str], kwargs):
         if not shutil.which('xgettext'):
             return self.nogettext_warning()
         packagename = args[0]

--- a/mesonbuild/modules/keyval.py
+++ b/mesonbuild/modules/keyval.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import ExtensionModule
-
-from .. import mesonlib
-from ..mesonlib import typeslistify
-from ..interpreterbase import FeatureNew, noKwargs
-from ..interpreter import InvalidCode
-
 import os
+import typing as T
+
+from . import ExtensionModule
+from .. import mesonlib
+from ..interpreterbase import FeatureNew, noKwargs, typed_pos_args
 
 class KeyvalModule(ExtensionModule):
 
@@ -48,12 +46,9 @@ class KeyvalModule(ExtensionModule):
         return result
 
     @noKwargs
-    def load(self, interpreter, state, args, kwargs):
-        sources = typeslistify(args, (str, mesonlib.File))
-        if len(sources) != 1:
-            raise InvalidCode('load takes only one file input.')
-
-        s = sources[0]
+    @typed_pos_args('keyval.load', (str, mesonlib.File))
+    def load(self, interpreter, state, args: T.Tuple['mesonlib.FileOrString'], kwargs):
+        s = args[0]
         is_built = False
         if isinstance(s, mesonlib.File):
             is_built = is_built or s.is_built

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 import sysconfig
-from .. import mesonlib
+import typing as T
 
+from .. import mesonlib
 from . import ExtensionModule
 from mesonbuild.modules import ModuleReturnValue
-from ..interpreterbase import noKwargs, permittedKwargs, FeatureDeprecated
+from ..interpreterbase import noKwargs, noPosargs, permittedKwargs, FeatureDeprecated, typed_pos_args
 from ..build import known_shmod_kwargs
 from ..programs import ExternalProgram
 
@@ -48,6 +49,7 @@ class Python3Module(ExtensionModule):
         return interpreter.func_shared_module(None, args, kwargs)
 
     @noKwargs
+    @noPosargs
     def find_python(self, state, args, kwargs):
         command = state.environment.lookup_binary_entry(mesonlib.MachineChoice.HOST, 'python3')
         if command is not None:
@@ -57,13 +59,13 @@ class Python3Module(ExtensionModule):
         return ModuleReturnValue(py3, [py3])
 
     @noKwargs
+    @noPosargs
     def language_version(self, state, args, kwargs):
         return ModuleReturnValue(sysconfig.get_python_version(), [])
 
     @noKwargs
-    def sysconfig_path(self, state, args, kwargs):
-        if len(args) != 1:
-            raise mesonlib.MesonException('sysconfig_path() requires passing the name of path to get.')
+    @typed_pos_args('python3.sysconfig_path', str)
+    def sysconfig_path(self, state, args: T.Tuple[str], kwargs):
         path_name = args[0]
         valid_names = sysconfig.get_path_names()
         if path_name not in valid_names:

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -236,7 +236,7 @@ class QtBaseModule(ExtensionModule):
             arguments = uic_extra_arguments + ['-o', '@OUTPUT@', '@INPUT@']
             ui_kwargs = {'output': 'ui_@BASENAME@.h',
                          'arguments': arguments}
-            ui_gen = build.Generator([self.uic], ui_kwargs)
+            ui_gen = build.Generator(self.uic, ui_kwargs)
             ui_output = ui_gen.process_files(f'Qt{self.qt_version} ui', ui_files, state)
             sources.append(ui_output)
         inc = get_include_args(include_dirs=include_directories)
@@ -255,14 +255,13 @@ class QtBaseModule(ExtensionModule):
             arguments = moc_extra_arguments + inc + compile_args + ['@INPUT@', '-o', '@OUTPUT@']
             moc_kwargs = {'output': 'moc_@BASENAME@.cpp',
                           'arguments': arguments}
-            moc_gen = build.Generator([self.moc], moc_kwargs)
+            moc_gen = build.Generator(self.moc, moc_kwargs)
             moc_output = moc_gen.process_files(f'Qt{self.qt_version} moc header', moc_headers, state)
             sources.append(moc_output)
         if moc_sources:
             arguments = moc_extra_arguments + inc + compile_args + ['@INPUT@', '-o', '@OUTPUT@']
             moc_kwargs = {'output': '@BASENAME@.moc',
                           'arguments': arguments}
-            moc_gen = build.Generator([self.moc], moc_kwargs)
             moc_output = moc_gen.process_files(f'Qt{self.qt_version} moc source', moc_sources, state)
             sources.append(moc_output)
         return ModuleReturnValue(sources, sources)

--- a/mesonbuild/modules/rpm.py
+++ b/mesonbuild/modules/rpm.py
@@ -22,13 +22,14 @@ from .. import mlog
 from . import GirTarget, TypelibTarget
 from . import ModuleReturnValue
 from . import ExtensionModule
-from ..interpreterbase import noKwargs
+from ..interpreterbase import noKwargs, noPosargs
 
 import os
 
 class RPMModule(ExtensionModule):
 
     @noKwargs
+    @noPosargs
     def generate_spec_template(self, coredata, args, kwargs):
         self.coredata = coredata
         required_compilers = self.__get_required_compilers()

--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -21,7 +21,7 @@ from .. import mlog, build
 from ..mesonlib import (MesonException, Popen_safe, MachineChoice,
                        get_variable_regex, do_replacement, extract_as_list)
 from ..interpreterbase import InterpreterObject, InterpreterException, FeatureNew
-from ..interpreterbase import stringArgs, permittedKwargs, typed_pos_args
+from ..interpreterbase import permittedKwargs, typed_pos_args
 from ..interpreter import Interpreter, DependencyHolder
 from ..compilers.compilers import CFLAGS_MAPPING, CEXE_MAPPING
 from ..dependencies.base import InternalDependency, PkgConfigDependency
@@ -37,7 +37,7 @@ class ExternalProject(InterpreterObject):
                  environment: Environment,
                  build_machine: str,
                  host_machine: str,
-                 configure_command: T.List[str],
+                 configure_command: str,
                  configure_options: T.List[str],
                  cross_configure_options: T.List[str],
                  env: build.EnvironmentVariables,
@@ -219,12 +219,9 @@ class ExternalProject(InterpreterObject):
 
         return [self.target, idir]
 
-    @stringArgs
     @permittedKwargs({'subdir'})
-    def dependency_method(self, args, kwargs):
-        if len(args) != 1:
-            m = 'ExternalProject.dependency takes exactly 1 positional arguments'
-            raise InterpreterException(m)
+    @typed_pos_args('external_project.dependency', str)
+    def dependency_method(self, args: T.Tuple[str], kwargs):
         libname = args[0]
 
         subdir = kwargs.get('subdir', '')
@@ -258,9 +255,8 @@ class ExternalProjectModule(ExtensionModule):
         self.methods.update({'add_project': self.add_project,
                              })
 
-    @stringArgs
     @permittedKwargs({'configure_options', 'cross_configure_options', 'verbose', 'env'})
-    @typed_pos_args('add_project', str)
+    @typed_pos_args('external_project_mod.add_project', str)
     def add_project(self, state: ModuleState, args: T.Tuple[str], kwargs: T.Dict[str, T.Any]):
         configure_command = args[0]
         configure_options = extract_as_list(kwargs, 'configure_options')

--- a/mesonbuild/modules/unstable_icestorm.py
+++ b/mesonbuild/modules/unstable_icestorm.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .. import mesonlib
-from ..interpreterbase import flatten
-from ..interpreterbase import FeatureNew
+import typing as T
 
 from . import ExtensionModule
+from .. import mesonlib
+from ..interpreter import CustomTargetHolder, CustomTargetIndexHolder, GeneratedListHolder
+from ..interpreterbase import FeatureNew
+from ..interpreterbase import flatten, typed_pos_args
 
 class IceStormModule(ExtensionModule):
 
@@ -33,18 +35,13 @@ class IceStormModule(ExtensionModule):
         self.iceprog_bin = interpreter.find_program_impl(['iceprog'])
         self.icetime_bin = interpreter.find_program_impl(['icetime'])
 
-    def project(self, interpreter, state, args, kwargs):
+    @typed_pos_args('icestorm.project', str, varargs=(str, mesonlib.File, CustomTargetHolder, CustomTargetIndexHolder, GeneratedListHolder), min_varargs=1)
+    def project(self, interpreter, state, args: T.Tuple[str, T.List[T.Union[str, mesonlib.File, CustomTargetHolder, CustomTargetIndexHolder, GeneratedListHolder]]], kwargs):
         if not self.yosys_bin:
             self.detect_binaries(interpreter)
-        if not args:
-            raise mesonlib.MesonException('Project requires at least one argument, which is the project name.')
         proj_name = args[0]
-        arg_sources = args[1:]
-        if not isinstance(proj_name, str):
-            raise mesonlib.MesonException('Argument must be a string.')
+        arg_sources = args[1]
         kwarg_sources = kwargs.get('sources', [])
-        if not isinstance(kwarg_sources, list):
-            kwarg_sources = [kwarg_sources]
         all_sources = interpreter.source_strings_to_files(flatten(arg_sources + kwarg_sources))
         if 'constraint_file' not in kwargs:
             raise mesonlib.MesonException('Constraint file not specified.')

--- a/mesonbuild/modules/unstable_simd.py
+++ b/mesonbuild/modules/unstable_simd.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .. import mesonlib, compilers, mlog
+import typing as T
 
 from . import ExtensionModule
-
-from ..interpreterbase import FeatureNew
+from .. import mesonlib, compilers, mlog
+from ..interpreterbase import FeatureNew, typed_pos_args
 
 class SimdModule(ExtensionModule):
 
@@ -37,13 +37,10 @@ class SimdModule(ExtensionModule):
                       'neon',
                       )
 
-    def check(self, interpreter, state, args, kwargs):
+    @typed_pos_args('simdmod.check', str)
+    def check(self, interpreter, state, args: T.Tuple[str], kwargs):
         result = []
-        if len(args) != 1:
-            raise mesonlib.MesonException('Check requires one argument, a name prefix for checks.')
         prefix = args[0]
-        if not isinstance(prefix, str):
-            raise mesonlib.MesonException('Argument must be a string.')
         if 'compiler' not in kwargs:
             raise mesonlib.MesonException('Must specify compiler keyword')
         if 'sources' in kwargs:

--- a/test cases/failing/95 custom target install data/test.json
+++ b/test cases/failing/95 custom target install data/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/95 custom target install data/meson.build:11:0: ERROR: Argument must be string or file."
+      "line": "meson.build:11:0: ERROR: install_data argument 1 was of type CustomTargetHolder but should have been one of str, File"
     }
   ]
 }


### PR DESCRIPTION
edit: We're looking to land this incrementally, starting with: #8304 

This should not be merged until after 0.57.0 is released.

Currently, we have a rather haphazard level of typing checking for arguments in the interpreter. Some functions and methods open code type checking and argument number checking, but not all of them do. Even when functions do said checking it's a ton of repetitive boilerplate that everyone has to implement. I propose instead using a function decorator for this. It works like this:
```python
@typed_pos_args('func_name', str, int, (CustomTargetHolder, CustomTargetIndexHolder)
def func(..., args : T.Tuple[str, int, T.Union[CustomTargetHolder, CustomTargetIndexHolder]], kwargs):
```
The function will detect two things, first that the number of arguments is correct (3), then it will detect that they have the correct type, and finally create a tuple of the arguments (rather than a list, because in tuples the index is relevant for the types). We can annotate the function appropriately, and both mypy is happy, and we get cheap, easy, painless type checking *before* the function actually starts looking at the positional arguments.

But what about optional arguments? We can handle that too!
```python
@typed_pos_ags('name', str, optargs=[str, (int, float)])
def func(..., args: T.Tuple[str, T.Optional[str], T.Optional[int, float], kwargs):
```
In this case we get the same level of type checking awesomeness, but optional values are optional, and we get a `None` for them. This has nice properties as we can do things like
```python
def func(...):
    name, pos, value = args
    if pos is not None:
        ...
```
And not have to resort to length checks. The decorator will also enforce that the positional arguments are given, and that no more than the maximum number of optional arguments are given.

But what about variadic functions? Got that covered too!
```python
@typed_pos_args('name', str, varargs=str)
def func(..., args: T.Tuple[str, T.List[str]], kwargs):
    ...
```
Notice that the decorator puts the variadic args in a list at the end? We can use this to separate mandatory arguments from variadiac ones. We can also set a minimum and maximum number of variadic arguments, and have functions with only variadic arguments.

Also, this code comes with unit tests, unlike the open coded versions.

Now, let's be clear, I've done my best to make sure that all the correct types are allowed. But I've certainly made mistakes, there are going to be some cases where what I've written breaks something. Therefore, I'd like to merge this as early in the 0.58 cycle as possible to get the most testing possible. And this is tightening the allowed types on many functions in meson that previously would take whatever was thrown at them.

I've tried to get as much of the code as possible converted over to this, but there is one case that this cannot handle, and that's the case of functions that are overloaded. There were only a couple of those that I could find, so I didn't feel like trying to add a bunch of infrastructure that would be more code than it removed. I've also not gone into the qt modules, both because that's where the overloaded functions are, and also because understanding that module is hard, and the documentation is lacking.