### PR TITLE
mtest fixes for 0.57

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -537,14 +537,19 @@ class ConsoleLogger(TestLogger):
         left = '[{}] {} '.format(count, self.SPINNER[self.spinner_index])
         self.spinner_index = (self.spinner_index + 1) % len(self.SPINNER)
 
-        right = '{spaces} {dur:{durlen}}/{timeout:{durlen}}s'.format(
+        right = '{spaces} {dur:{durlen}}'.format(
             spaces=' ' * TestResult.maxlen(),
             dur=int(time.time() - self.progress_test.starttime),
-            durlen=harness.duration_max_len,
-            timeout=int(self.progress_test.timeout or -1))
+            durlen=harness.duration_max_len)
+        if self.progress_test.timeout:
+            right += '/{timeout:{durlen}}'.format(
+                timeout=self.progress_test.timeout,
+                durlen=harness.duration_max_len)
+        right += 's'
         detail = self.progress_test.detail
         if detail:
             right += '   ' + detail
+
         line = harness.format(self.progress_test, colorize=True,
                               max_left_width=self.max_left_width,
                               left=left, right=right)

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1490,10 +1490,10 @@ class TestHarness:
             options.timeout_multiplier = current.timeout_multiplier
     #    if options.env is None:
     #        options.env = current.env # FIXME, should probably merge options here.
-        if options.wrapper is not None and current.exe_wrapper is not None:
-            sys.exit('Conflict: both test setup and command line specify an exe wrapper.')
         if options.wrapper is None:
             options.wrapper = current.exe_wrapper
+        elif current.exe_wrapper:
+            sys.exit('Conflict: both test setup and command line specify an exe wrapper.')
         return current.env.get_env(os.environ.copy())
 
     def get_test_runner(self, test: TestSerialisation) -> SingleTestRunner:

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -789,7 +789,9 @@ class JunitBuilder(TestLogger):
             )
 
             for subtest in test.results:
-                testcase = et.SubElement(suite, 'testcase', name=str(subtest))
+                # Both name and classname are required. Use the suite name as
+                # the class name, so that e.g. GitLab groups testcases correctly.
+                testcase = et.SubElement(suite, 'testcase', name=str(subtest), classname=suitename)
                 if subtest.result is TestResult.SKIP:
                     et.SubElement(testcase, 'skipped')
                 elif subtest.result is TestResult.ERROR:
@@ -823,7 +825,7 @@ class JunitBuilder(TestLogger):
                 suite.attrib['tests'] = str(int(suite.attrib['tests']) + 1)
 
             testcase = et.SubElement(suite, 'testcase', name=test.name,
-                                     time=str(test.duration))
+                                     classname=test.project, time=str(test.duration))
             if test.res is TestResult.SKIP:
                 et.SubElement(testcase, 'skipped')
                 suite.attrib['skipped'] = str(int(suite.attrib['skipped']) + 1)

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1164,11 +1164,11 @@ class TestSubprocess:
         # asyncio.ensure_future ensures that printing can
         # run in the background, even before it is awaited
         if self.stdo_task is None and self.stdout is not None:
-            decode_task = read_decode(self._process.stdout, console_mode)
-            self.stdo_task = asyncio.ensure_future(decode_task)
+            decode_coro = read_decode(self._process.stdout, console_mode)
+            self.stdo_task = asyncio.ensure_future(decode_coro)
         if self.stderr is not None and self.stderr != asyncio.subprocess.STDOUT:
-            decode_task = read_decode(self._process.stderr, console_mode)
-            self.stde_task = asyncio.ensure_future(decode_task)
+            decode_coro = read_decode(self._process.stderr, console_mode)
+            self.stde_task = asyncio.ensure_future(decode_coro)
 
         return self.stdo_task, self.stde_task
 
@@ -1383,7 +1383,8 @@ class SingleTestRunner:
 
         parse_task = None
         if self.runobj.needs_parsing:
-            parse_task = self.runobj.parse(harness, p.stdout_lines(self.console_mode))
+            parse_coro = self.runobj.parse(harness, p.stdout_lines(self.console_mode))
+            parse_task = asyncio.ensure_future(parse_coro)
 
         stdo_task, stde_task = p.communicate(self.console_mode)
         returncode, result, additional_error = await p.wait(self.runobj.timeout)

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -141,7 +141,8 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
                         '"subprojname:" to run all tests defined by "subprojname".')
 
 
-def print_safe(s: str, end: str = '\n') -> None:
+def print_safe(s: str) -> None:
+    end = '' if s[-1] == '\n' else '\n'
     try:
         print(s, end=end)
     except UnicodeEncodeError:
@@ -639,9 +640,8 @@ class ConsoleLogger(TestLogger):
         log = self.shorten_log(harness, result)
         if log:
             print(self.output_start)
-            print_safe(log, end='')
+            print_safe(log)
             print(self.output_end)
-        print(flush=True)
 
     def log_subtest(self, harness: 'TestHarness', test: 'TestRun', s: str, result: TestResult) -> None:
         if harness.options.verbose or (harness.options.print_errorlogs and result.is_bad()):
@@ -665,12 +665,13 @@ class ConsoleLogger(TestLogger):
                 if not result.needs_parsing:
                     print(self.output_end)
                 print(harness.format(result, mlog.colorize_console(), max_left_width=self.max_left_width))
-                print(flush=True)
             else:
                 print(harness.format(result, mlog.colorize_console(), max_left_width=self.max_left_width),
                       flush=True)
                 if harness.options.verbose or result.res.is_bad():
                     self.print_log(harness, result)
+            if harness.options.verbose or result.res.is_bad():
+                print(flush=True)
 
         self.request_update()
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2551,6 +2551,8 @@ class AllPlatformTests(BasePlatformTests):
         self._run(self.mtest_command + ['--setup=onlyenv3'])
         # Setup with only a timeout works
         self._run(self.mtest_command + ['--setup=timeout'])
+        # Setup that does not define a wrapper works with --wrapper
+        self._run(self.mtest_command + ['--setup=timeout', '--wrapper', shutil.which('valgrind')])
         # Setup that skips test works
         self._run(self.mtest_command + ['--setup=good'])
         with open(os.path.join(self.logdir, 'testlog-good.txt')) as f:


### PR DESCRIPTION
* another deadlock similar to #8212
* avoid printing progress report as `123/-1s` when timeout is disabled
* allow `--wrapper` in combination with `--setup`, if the setup does not define a wrapper.
* avoid that asyncio tasks linger on timeout
* make non-parallel tests emit their output on the fly, similar to ninja console jobs