### PR TITLE
Update SimpleStart.md

### DIFF
--- a/docs/markdown/SimpleStart.md
+++ b/docs/markdown/SimpleStart.md
@@ -160,5 +160,5 @@ is put in the `build` subdirectory and can be run directly from there.
 ![All finished and ready to go](images/linux_alldone.png)
 
 The project is now ready for development. You can edit the code with
-any editor and it is rebuilt by going in the `build` subdirectory and
-executing the `meson compile` command.
+any editor and it is rebuilt by executing the `ninja` command in the
+`build` directory.


### PR DESCRIPTION
Running `meson compile` command in `build` directory resulted in error "ERROR: Neither directory contains a build file meson.build.". Running `ninja` command in the `build` directory worked fine.

How to recreate: 
Follow the steps for Ubuntu https://mesonbuild.com/SimpleStart.html

System: Ubuntu 20.xx
Meson 0.53.2