### PR TITLE
Support llvm-rc with WINDRES

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -40,6 +40,13 @@ jobs:
             MSYS2_CURSES:
             COMPILER: clang
             TOOLCHAIN: clang
+          - NAME: clangx64ninjallvm
+            MSYSTEM: MINGW64
+            MSYS2_ARCH: x86_64
+            MSYS2_CURSES:
+            COMPILER: clang
+            TOOLCHAIN: clang
+            WINDRES: llvm
 
     defaults:
       run:
@@ -83,6 +90,9 @@ jobs:
             export CXX=clang++
             export OBJC=clang
             export OBJCXX=clang++
+          fi
+          if [[ '${{ matrix.WINDRES }}' == 'llvm' ]]; then
+            export WINDRES=llvm-rc
           fi
 
           if [[ "${{ matrix.MSYS2_CURSES }}" != "" ]]; then

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -63,6 +63,7 @@ class WindowsModule(ExtensionModule):
         for (arg, match, rc_type) in [
                 ('/?', '^.*Microsoft.*Resource Compiler.*$', ResourceCompilerType.rc),
                 ('--version', '^.*GNU windres.*$', ResourceCompilerType.windres),
+                ('/?', '^.*Resource Converter*$', ResourceCompilerType.rc), # llvm-rc
         ]:
             p, o, e = mesonlib.Popen_safe(rescomp.get_command() + [arg])
             m = re.search(match, o, re.MULTILINE)


### PR DESCRIPTION
I'm a beginner user of this tool. I will add more updates following the guideline.

### Environment

* Windows 10 Pro 10.0.18363 x64
* Meson master branch, commit 2a8d6690f73ec6415c2ee592e856b3b6de7cfb02
* LLVM 11.0.1 ([Installed via Chocolatey `llvm`](https://chocolatey.org/packages/llvm))
* Anaconda3 v2020.11 ([Installed via Chocolatey `anaconda3`](https://chocolatey.org/packages/anaconda3))
   * Python 3.9 
   * PIP 20.3.3

Installed Meson from the source.

```
python ./setup.py install 
```

### Description

I was trying to build [gstreamer 1.18.3](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/tags/1.18.3) using Meson. While following [the document, "Building from source using meson"](https://gstreamer.freedesktop.org/documentation/installing/building-from-source-using-meson.html),
It selected `clang-cl` and reported an error message.

```
ERROR: Could not find Windows resource compiler
...
```

I tried to override [`WINDRES`](https://github.com/mesonbuild/meson/blob/master/docs/markdown/Windows-module.md#compile_resources) but it failed with an exception, `Could not determine type of Windows resource compiler`.

```console
PS C:\Users\user\gst-build> $env:WINDRES="llvm-rc"
PS C:\Users\user\gst-build> meson build
.... failed ...
```

I searched for the message and found that `llvm-rc`'s output was not expected.

https://github.com/mesonbuild/meson/blob/5f73f3b715f39217e7d063b6b112c5c80010379c/mesonbuild/modules/windows.py#L62-L75

The output of the `llvm-rc` is like the following.

```console
PS C:\Users\user\develop> llvm-rc /?
OVERVIEW: Resource Converter

USAGE: rc [options] file...

OPTIONS:
  /?          Display this help and exit.
  /C <value>  Set the codepage used for input strings.
  /dry-run    Don't compile the input; only try to parse it.
  /D <value>  Define a symbol for the C preprocessor.
  /FO <value> Change the output file location.
  /H          Display this help and exit.
  /I <value>  Add an include path.
  /LN <value> Set the default language name.
  /L <value>  Set the default language identifier.
  /N          Null-terminate all strings in the string table.
  /U <value>  Undefine a symbol for the C preprocessor.
  /V          Be verbose.
  /X          Ignore 'include' variable.
  /Y          Suppress warnings on duplicate resource IDs.
```

### Changes

* Add a regex to match `llvm-rc`'s output

After the change, `meson build` ended successfully. (The actual build with ninja failed but it's out of concern.)

I'm not sure its type can be `ResourceCompilerType.rc`.

### Related Issues?

Seems like #4105 is related, but not sure.
