### PR TITLE
Don't access other enum members from self

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -69,11 +69,12 @@ class TestProtocol(enum.Enum):
         raise MesonException('unknown test format {}'.format(string))
 
     def __str__(self) -> str:
-        if self is self.EXITCODE:
+        cls = type(self)
+        if self is cls.EXITCODE:
             return 'exitcode'
-        elif self is self.GTEST:
+        elif self is cls.GTEST:
             return 'gtest'
-        elif self is self.RUST:
+        elif self is cls.RUST:
             return 'rust'
         return 'tap'
 


### PR DESCRIPTION
This is deprecated in Python 3.10.
Instead, acces them from the class.

Fixes https://github.com/mesonbuild/meson/issues/8318