### PR TITLE
compilers: clang: Drop -Xclang before -fcolor-diagnostics flag

### DIFF
--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -29,9 +29,9 @@ if T.TYPE_CHECKING:
     from ...dependencies import Dependency  # noqa: F401
 
 clang_color_args = {
-    'auto': ['-Xclang', '-fcolor-diagnostics'],
-    'always': ['-Xclang', '-fcolor-diagnostics'],
-    'never': ['-Xclang', '-fno-color-diagnostics'],
+    'auto': ['-fcolor-diagnostics'],
+    'always': ['-fcolor-diagnostics'],
+    'never': ['-fno-color-diagnostics'],
 }  # type: T.Dict[str, T.List[str]]
 
 clang_optimization_args = {


### PR DESCRIPTION
Using `-Xclang -fcolor-diagnostics` provides no advantage to using just `-fcolor-diagnostics` option and sometimes causes problems:
* uncolored diagnostics on Arch Linux: https://bugs.archlinux.org/task/69662
* simple problem with removing flag `-fcolor-diagnostics`:  https://github.com/clangd/clangd/issues/279

This change fixes bug under Arch Linux (clang 11.0.1) where the following setup does not produce colored diagnostics:
* file `foo.c` with contents:
```c
int main() {
    return "" * "";
}
```
* file `meson.build` with contents:
```meson
project('foo', 'c')
executable('foo', 'foo.c')
```
Building it with `CC=clang meson setup build && meson compile -C build` does not produce colored diagnostics.