### PR TITLE
Environment: Fix passing envrionment both CPPFLAGS and CFLAGS

### DIFF
--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -2023,7 +2023,6 @@ class OptionKey:
         This takes strings like `mysubproject:build.myoption` and Creates an
         OptionKey out of them.
         """
-
         try:
             subproject, raw2 = raw.split(':')
         except ValueError:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5476,6 +5476,14 @@ class AllPlatformTests(BasePlatformTests):
         projinfo = self.introspect('--projectinfo')
         self.assertEqual(projinfo['version'], '1.0.0')
 
+    def test_cflags_cppflags(self):
+        envs = {'CPPFLAGS': '-DCPPFLAG',
+                'CFLAGS': '-DCFLAG',
+                'CXXFLAGS': '-DCXXFLAG'}
+        srcdir = os.path.join(self.unit_test_dir, '90 multiple envvars')
+        self.init(srcdir, override_envvars=envs)
+        self.build()
+
 
 class FailureTests(BasePlatformTests):
     '''

--- a/test cases/unit/90 multiple envvars/meson.build
+++ b/test cases/unit/90 multiple envvars/meson.build
@@ -1,0 +1,4 @@
+project('multienv', 'c', 'cpp')
+
+executable('cexe', 'prog.c')
+executable('cppexe', 'prog.cpp')

--- a/test cases/unit/90 multiple envvars/prog.c
+++ b/test cases/unit/90 multiple envvars/prog.c
@@ -1,0 +1,18 @@
+#include<stdio.h>
+
+#ifndef CPPFLAG
+#error CPPFLAG not set
+#endif
+
+#ifndef CFLAG
+#error CFLAGS not set
+#endif
+
+#ifdef CXXFLAG
+#error CXXFLAG is set
+#endif
+
+int main(int argc, char **argv) {
+    printf("%d %s\n", argc, argv[0]);
+    return 0;
+}

--- a/test cases/unit/90 multiple envvars/prog.cpp
+++ b/test cases/unit/90 multiple envvars/prog.cpp
@@ -1,0 +1,18 @@
+#include<cstdio>
+
+#ifndef CPPFLAG
+#error CPPFLAG not set
+#endif
+
+#ifdef CFLAG
+#error CFLAG is set
+#endif
+
+#ifndef CXXFLAG
+#error CXXFLAG not set
+#endif
+
+int main(int argc, char **argv) {
+    printf("%d %s\n", argc, argv[0]);
+    return 0;
+}


### PR DESCRIPTION
Or other language flags that use CPPFLAGS (like CXXFLAGS). The problem
here is actually rather simple, `dict.setdefault()` doesn't work like I
thought it did, I thought it created a weak entry, but it actually is
equivalent to:
```python
if k not in dict:
    dict[k] = v
```
Instead we'll use an intermediate dictionary (a default dictionary
actually, since that makes things a little cleaner) and then add the
keys from that dict to self.options as applicable.

Test case written by Jussi, Fix by Dylan

Co-authored-by: Jussi Pakkanen
Fixes: #8361
Fixes: #8345