### PR TITLE
allow build.b_* options

### DIFF
--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -1910,7 +1910,6 @@ def _classify_argument(key: 'OptionKey') -> OptionType:
     """Classify arguments into groups so we know which dict to assign them to."""
 
     if key.name.startswith('b_'):
-        assert key.machine is MachineChoice.HOST, str(key)
         return OptionType.BASE
     elif key.lang is not None:
         return OptionType.COMPILER
@@ -2029,7 +2028,7 @@ class OptionKey:
             subproject, raw2 = '', raw
 
         if raw2.startswith('build.'):
-            raw3 = raw2.lstrip('build.')
+            raw3 = raw2.split('.', 1)[1]
             for_machine = MachineChoice.BUILD
         else:
             raw3 = raw2

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5491,6 +5491,11 @@ class AllPlatformTests(BasePlatformTests):
         self.init(srcdir, override_envvars=envs)
         self.build()
 
+    def test_build_b_options(self) -> None:
+        # Currently (0.57) these do nothing, but they've always been allowed
+        srcdir = os.path.join(self.common_test_dir, '2 cpp')
+        self.init(srcdir, extra_args=['-Dbuild.b_lto=true'])
+
 
 class FailureTests(BasePlatformTests):
     '''


### PR DESCRIPTION
These continue to be ignored as they always have, but no longer raise an
error.

Fixes: #8351
Fixes: #8354