### PR TITLE
compilers: Only insert -flto-jobs in clang's link arguments

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -375,7 +375,9 @@ def get_base_link_args(options: 'KeyedOptionDictType', linker: 'Compiler',
     args = []  # type: T.List[str]
     try:
         if options[OptionKey('b_lto')].value:
-            args.extend(linker.get_lto_link_args())
+            args.extend(linker.get_lto_link_args(
+                threads=get_option_value(options, OptionKey('b_lto_threads'), 0),
+                mode=get_option_value(options, OptionKey('b_lto_mode'), 'default')))
     except KeyError:
         pass
     try:
@@ -950,7 +952,7 @@ class Compiler(metaclass=abc.ABCMeta):
     def get_lto_compile_args(self, *, threads: int = 0, mode: str = 'default') -> T.List[str]:
         return []
 
-    def get_lto_link_args(self) -> T.List[str]:
+    def get_lto_link_args(self, *, threads: int = 0, mode: str = 'default') -> T.List[str]:
         return self.linker.get_lto_args()
 
     def sanitizer_compile_args(self, value: str) -> T.List[str]:

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -148,6 +148,10 @@ class ClangCompiler(GnuLikeCompiler):
         else:
             assert mode == 'default', 'someone forgot to wire something up'
             args.extend(super().get_lto_compile_args(threads=threads))
+        return args
+
+    def get_lto_link_args(self, *, threads: int = 0, mode: str = 'default') -> T.List[str]:
+        args = self.get_lto_compile_args(threads=threads, mode=mode)
         # In clang -flto=0 means auto
         if threads >= 0:
             args.append(f'-flto-jobs={threads}')

--- a/mesonbuild/compilers/mixins/islinker.py
+++ b/mesonbuild/compilers/mixins/islinker.py
@@ -48,7 +48,7 @@ class BasicLinkerIsCompilerMixin(Compiler):
     def sanitizer_link_args(self, value: str) -> T.List[str]:
         return []
 
-    def get_lto_link_args(self) -> T.List[str]:
+    def get_lto_link_args(self, *, threads: int = 0, mode: str = 'default') -> T.List[str]:
         return []
 
     def can_linker_accept_rsp(self) -> bool:


### PR DESCRIPTION
Clang has a hand `-Wunused-command-line-argument` switch, which when
turned to an error, gets very grump about `-flto-jobs=0` being set in
the compiler arguments (although `-flto=` belongs there). We'll refactor
a bit to put that only in the link arguments.

GCC doesn't have this probably because, a) it doesn't have an equivalent
warning, and b) it uses `-flto=<$numthreads.

Fixes: #8347