### PR TITLE
mconf: only print correct options in the correct sections

### DIFF
--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -216,8 +216,8 @@ class Conf:
         self.print_options('Core options', host_core_options[''])
         if show_build_options:
             self.print_options('', build_core_options[''])
-        self.print_options('Backend options', {str(k): v for k, v in self.coredata.options.items()})
-        self.print_options('Base options', {str(k): v for k, v in self.coredata.options.items()})
+        self.print_options('Backend options', {str(k): v for k, v in self.coredata.options.items() if k.is_backend()})
+        self.print_options('Base options', {str(k): v for k, v in self.coredata.options.items() if k.is_base()})
         self.print_options('Compiler options', host_compiler_options.get('', {}))
         if show_build_options:
             self.print_options('', build_compiler_options.get('', {}))


### PR DESCRIPTION
A predicate in two comprehensions was dropped, in what looks like a
rebase error on my part. With the predicate added things work correctly.

Fixes: #8344