### PR TITLE
Fix lang args spliiting

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1227,22 +1227,18 @@ def get_global_options(lang: str,
     argkey = OptionKey('args', lang=lang, machine=for_machine)
     largkey = argkey.evolve('link_args')
 
-    # We shouldn't need listify here, but until we have a separate
-    # linker-driver representation and can have that do the combine we have to
-    # do it this way.
-    compile_args = mesonlib.listify(env.options.get(argkey, []))
-    link_args = mesonlib.listify(env.options.get(largkey, []))
+    cargs = coredata.UserArrayOption(
+        description + ' compiler',
+        env.options.get(argkey, []), split_args=True, user_input=True, allow_dups=True)
+    largs = coredata.UserArrayOption(
+        description + ' linker',
+        env.options.get(largkey, []), split_args=True, user_input=True, allow_dups=True)
 
+    # This needs to be done here, so that if we have string values in the env
+    # options that we can safely combine them *after* they've been split
     if comp.INVOKES_LINKER:
-        link_args = compile_args + link_args
+        largs.set_value(largs.value + cargs.value)
 
-    opts: 'KeyedOptionDictType' = {
-        argkey: coredata.UserArrayOption(
-            description + ' compiler',
-            compile_args, split_args=True, user_input=True, allow_dups=True),
-        largkey: coredata.UserArrayOption(
-            description + ' linker',
-            link_args, split_args=True, user_input=True, allow_dups=True),
-    }
+    opts: 'KeyedOptionDictType' = {argkey: cargs, largkey: largs}
 
     return opts

--- a/test cases/common/237 proper args splitting/main.c
+++ b/test cases/common/237 proper args splitting/main.c
@@ -1,0 +1,11 @@
+#ifndef FOO
+# error "FOO is not defined"
+#endif
+
+#ifndef BAR
+# error "BAR is not defined"
+#endif
+
+int main(void) {
+    return 0;
+}

--- a/test cases/common/237 proper args splitting/meson.build
+++ b/test cases/common/237 proper args splitting/meson.build
@@ -1,0 +1,9 @@
+project('proper args splitting', 'c')
+
+test(
+  'main',
+  executable(
+    'main',
+    'main.c',
+  )
+)

--- a/test cases/common/237 proper args splitting/test.json
+++ b/test cases/common/237 proper args splitting/test.json
@@ -1,0 +1,9 @@
+{
+  "matrix": {
+    "options": {
+      "c_args": [
+        { "val": "-DFOO -DBAR" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The problem, it turns out, is actually rather simple, in order to allow combining link and compile args we were calling listify on them. When we do this, they go into the convertor for the argument type as a list, it sees them as a list and retursn them as-is. This results in not splitting the arguments at all, and we get errors where `"-DFOO -DBAR"` doesn't get split into `['-DFOO', '-DBAR']`. This changes that by doing the combination of compiler and linker arguments (when required) to the values parsed by the `UserOption` class.

Fixes: #8348