### PR TITLE
[TAP] Fix TAP parser when test exits with status

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1004,6 +1004,7 @@ class TestRunTAP(TestRun):
                  stdo: str, stde: str) -> None:
         if returncode != 0 and not res.was_killed():
             res = TestResult.ERROR
+            stde = stde or ''
             stde += '\n(test program exited with status code {})'.format(returncode,)
 
         super().complete(returncode, res, stdo, stde)

--- a/test cases/failing test/5 tap tests/meson.build
+++ b/test cases/failing test/5 tap tests/meson.build
@@ -1,7 +1,9 @@
 project('test features', 'c')
 
 tester = executable('tester', 'tester.c')
-test('nonzero return code', tester, args : [], protocol: 'tap')
+test_with_status = executable('test-with-status', 'tester_with_status.c')
+test('nonzero return code no tests', tester, args : [], protocol: 'tap')
+test('nonzero return code with tests', test_with_status, protocol: 'tap')
 test('missing test', tester, args : ['1..1'], protocol: 'tap')
 test('incorrect skip', tester, args : ['1..1 # skip\nok 1'], protocol: 'tap')
 test('partially skipped', tester, args : ['not ok 1\nok 2 # skip'], protocol: 'tap')

--- a/test cases/failing test/5 tap tests/tester_with_status.c
+++ b/test cases/failing test/5 tap tests/tester_with_status.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+    puts("1..1");
+    puts("not ok 1 - some test");
+    return 2;
+}


### PR DESCRIPTION
Some time between 0.56 and 0.57 the TAP parser broke when a test exits
with a nonzero status.
The TAP protocol does not specify this behaviour - giving latitude to
implementers, and meson's previous behaviour was to report the exit
status gracefully.

This patch restores the old behaviour and adds a regression test