### PR TITLE
tests/rust: Add rust case linking to zlib dependency

### DIFF
--- a/test cases/rust/13 c deps/c_accessing_zlib.c
+++ b/test cases/rust/13 c deps/c_accessing_zlib.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <string.h>
+#include <zlib.h>
+
+void c_accessing_zlib(void) {
+    struct z_stream_s zstream;
+    printf("Hello from C!\n");
+    memset(&zstream, 0, sizeof(zstream));
+    inflateInit(&zstream);
+}

--- a/test cases/rust/13 c deps/meson.build
+++ b/test cases/rust/13 c deps/meson.build
@@ -1,0 +1,23 @@
+project('rust linking to c using dependency', 'c', 'rust')
+
+if host_machine.system() == 'darwin'
+  error('MESON_SKIP_TEST: doesnt work right on macos, please fix!')
+endif
+
+dep_zlib = dependency('zlib')
+
+l = static_library(
+        'c_accessing_zlib',
+        'c_accessing_zlib.c',
+        dependencies: [dep_zlib],
+    )
+
+e = executable(
+        'prog', 'prog.rs',
+        link_with : l,
+
+        # This rust_args allows the link to succeed
+        # rust_args: ['-l', 'static=z'],
+    )
+
+test('cdepstest', e)

--- a/test cases/rust/13 c deps/prog.rs
+++ b/test cases/rust/13 c deps/prog.rs
@@ -1,0 +1,9 @@
+extern "C" {
+    fn c_accessing_zlib();
+}
+
+fn main() {
+    unsafe {
+        c_accessing_zlib();
+    }
+}


### PR DESCRIPTION
@dcbaker: I think this is a fairly minimal test case of the issue I mentioned on irc. I hope the test case is valid!

Note that I have a commented rust_args line in the meson.build file which probably doesn't belong in the final test case, but rather just shows one work-around I found.