### PR TITLE
[CUDA] Bugfix: Forward sanitizer_*_args() methods to host compiler.

### DIFF
--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -625,6 +625,12 @@ class CudaCompiler(Compiler):
         # return self._to_host_flags(self.host_compiler.get_optimization_args(optimization_level))
         return cuda_optimization_args[optimization_level]
 
+    def sanitizer_compile_args(self, value: str) -> T.List[str]:
+        return self._to_host_flags(self.host_compiler.sanitizer_compile_args(value))
+
+    def sanitizer_link_args(self, value: str) -> T.List[str]:
+        return self._to_host_flags(self.host_compiler.sanitizer_link_args(value))
+
     def get_debug_args(self, is_debug: bool) -> T.List[str]:
         return cuda_debug_args[is_debug]
 

--- a/test cases/cuda/15 sanitizer/meson.build
+++ b/test cases/cuda/15 sanitizer/meson.build
@@ -1,0 +1,4 @@
+project('simple', 'cuda', version : '1.0.0',
+        default_options: ['b_sanitize=address,undefined'])
+
+libtests = shared_library('tests', 'prog.cu')

--- a/test cases/cuda/15 sanitizer/prog.cu
+++ b/test cases/cuda/15 sanitizer/prog.cu
@@ -1,0 +1,30 @@
+#include <iostream>
+
+int run_tests(void) {
+    int cuda_devices = 0;
+    std::cout << "CUDA version: " << CUDART_VERSION << "\n";
+    cudaGetDeviceCount(&cuda_devices);
+    if(cuda_devices == 0) {
+        std::cout << "No Cuda hardware found. Exiting.\n";
+        return 0;
+    }
+    std::cout << "This computer has " << cuda_devices << " Cuda device(s).\n";
+    cudaDeviceProp props;
+    cudaGetDeviceProperties(&props, 0);
+    std::cout << "Properties of device 0.\n\n";
+
+    std::cout << "  Name:            " << props.name << "\n";
+    std::cout << "  Global memory:   " << props.totalGlobalMem << "\n";
+    std::cout << "  Shared memory:   " << props.sharedMemPerBlock << "\n";
+    std::cout << "  Constant memory: " << props.totalConstMem << "\n";
+    std::cout << "  Block registers: " << props.regsPerBlock << "\n";
+
+    std::cout << "  Warp size:         " << props.warpSize << "\n";
+    std::cout << "  Threads per block: " << props.maxThreadsPerBlock << "\n";
+    std::cout << "  Max block dimensions: [ " << props.maxThreadsDim[0] << ", " << props.maxThreadsDim[1]  << ", " << props.maxThreadsDim[2] << " ]" << "\n";
+    std::cout << "  Max grid dimensions:  [ " << props.maxGridSize[0] << ", " << props.maxGridSize[1]  << ", " << props.maxGridSize[2] << " ]" << "\n";
+    std::cout << "\n";
+
+    return 0;
+}
+


### PR DESCRIPTION
Enables `-Db_sanitize=undefined` and company.

Also serves as a testcase for NVCC comma-shielding: Because the test-case declares `b_sanitize=address,undefined`, the host GCC compiler needs `-fsanitize=address,undefined`, but this stands a danger of being split by NVCC when wrapped with `-Xcompiler=args,args`. Special, already-existing comma-shielding codepaths activate to prevent this splitting.

Closes #8394.
