### PR TITLE
mcompile: make sure arguments are passed in the correct order

### DIFF
--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -144,13 +144,6 @@ def get_parsed_args_ninja(options: 'argparse.Namespace', builddir: Path) -> T.Tu
 
     cmd = runner + ['-C', builddir.as_posix()]
 
-    if options.targets:
-        intro_data = parse_introspect_data(builddir)
-        for t in options.targets:
-            cmd.extend(generate_target_names_ninja(ParsedTargetName(t), builddir, intro_data))
-    if options.clean:
-        cmd.append('clean')
-
     # If the value is set to < 1 then don't set anything, which let's
     # ninja/samu decide what to do.
     if options.jobs > 0:
@@ -162,6 +155,14 @@ def get_parsed_args_ninja(options: 'argparse.Namespace', builddir: Path) -> T.Tu
         cmd.append('-v')
 
     cmd += options.ninja_args
+
+    # operands must be processed after options/option-arguments
+    if options.targets:
+        intro_data = parse_introspect_data(builddir)
+        for t in options.targets:
+            cmd.extend(generate_target_names_ninja(ParsedTargetName(t), builddir, intro_data))
+    if options.clean:
+        cmd.append('clean')
 
     return cmd, None
 

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -142,7 +142,9 @@ def get_parsed_args_ninja(options: 'argparse.Namespace', builddir: Path) -> T.Tu
     if runner is None:
         raise MesonException('Cannot find ninja.')
 
-    cmd = runner + ['-C', builddir.as_posix()]
+    cmd = runner
+    if not builddir.samefile('.'):
+        cmd.extend(['-C', builddir.as_posix()])
 
     # If the value is set to < 1 then don't set anything, which let's
     # ninja/samu decide what to do.


### PR DESCRIPTION
meson compile itself doesn't permit GNU-style argument permutation, i.e. TARGET to precede options, so why should we expect ninja to?

And indeed, ninja doesn't document support for this -- but it does accept it anyway, which is confusing and results in people thinking it's "supposed to" work.
    
However, if `NINJA=samu` then this is in fact enforced. samu does not permit GNU-style argument permutation. As a result, the arguments passed to mcompile are actively re-ordered before being passed to the subprocess, and samu dies with a fatal error.
    
Fix ordering in mcompile.py and add a comment to warn future readers that the order does, in fact, matter.