### PR TITLE
Add compiler arguments to linker arguments when the compiler acts as a linker driver

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -540,14 +540,11 @@ class Backend:
                 return True
         return False
 
-    def get_external_rpath_dirs(self, target):
+    def get_external_rpath_dirs(self, target: build.BuildTarget):
         dirs = set()
         args = []
-        for lang in LANGUAGES_USING_LDFLAGS:
-            try:
-                args.extend(self.environment.coredata.get_external_link_args(target.for_machine, lang))
-            except Exception:
-                pass
+        for comp in (comp for lang, comp in target.compilers.items() if lang in LANGUAGES_USING_LDFLAGS):
+            args.extend(comp.get_external_link_args(self.environment.coredata))
         # Match rpath formats:
         # -Wl,-rpath=
         # -Wl,-rpath,
@@ -788,7 +785,7 @@ class Backend:
         # Compile args added from the env: CFLAGS/CXXFLAGS, etc, or the cross
         # file. We want these to override all the defaults, but not the
         # per-target compile args.
-        commands += self.environment.coredata.get_external_args(target.for_machine, compiler.get_language())
+        commands += compiler.get_external_compile_args(self.environment.coredata)
         # Always set -fPIC for shared libraries
         if isinstance(target, build.SharedLibrary):
             commands += compiler.get_pic_args()

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1598,7 +1598,7 @@ int dummy;
         args += ['--emit', f'dep-info={depfile}', '--emit', 'link']
         args += target.get_extra_args('rust')
         args += rustc.get_output_args(os.path.join(target.subdir, target.get_filename()))
-        args += self.environment.coredata.get_external_args(target.for_machine, rustc.language)
+        args += rustc.get_external_compile_args(self.environment.coredata)
         linkdirs = mesonlib.OrderedSet()
         external_deps = target.external_deps.copy()
         for d in target.link_targets:
@@ -2870,7 +2870,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             commands += self.build.get_global_link_args(linker, target.for_machine)
             # Link args added from the env: LDFLAGS. We want these to override
             # all the defaults but not the per-target link args.
-            commands += self.environment.coredata.get_external_link_args(target.for_machine, linker.get_language())
+            commands += linker.get_external_link_args(self.environment.coredata)
 
         # Now we will add libraries and library paths from various sources
 

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1120,7 +1120,7 @@ class Vs2010Backend(backends.Backend):
             # Link args added from the env: LDFLAGS, or the cross file. We want
             # these to override all the defaults but not the per-target link
             # args.
-            extra_link_args += self.environment.coredata.get_external_link_args(target.for_machine, compiler.get_language())
+            extra_link_args += compiler.get_external_link_args(self.environment.coredata)
             # Only non-static built targets need link args and link dependencies
             extra_link_args += target.link_args
             # External deps must be last because target link libraries may depend on them.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1235,10 +1235,16 @@ class Compiler(metaclass=abc.ABCMeta):
     def get_external_link_args(self, cdata: coredata.CoreData) -> T.List[str]:
         """Linker arguments for this compiler, as set by "$LDFLAGS" and
         "-D${LANG}_link_args".
+
+        If this is a compiler being called as a linker driver we also need to
+        add the compiler arguments here.
         """
         # The cast is required because mypy can't figure out what the type the
         # option is
-        return T.cast(T.List[str], cdata.options[OptionKey('link_args', machine=self.for_machine, lang=self.language)].value)
+        v = T.cast(T.List[str], cdata.options[OptionKey('link_args', machine=self.for_machine, lang=self.language)].value)
+        if self.INVOKES_LINKER:
+            return self.get_external_compile_args(cdata) + v
+        return v
 
 
 def get_global_options(lang: str, for_machine: MachineChoice, env: 'Environment') -> 'KeyedOptionDictType':

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1226,10 +1226,7 @@ class Compiler(metaclass=abc.ABCMeta):
         return self.linker.rsp_file_syntax()
 
 
-def get_global_options(lang: str,
-                       comp: T.Type[Compiler],
-                       for_machine: MachineChoice,
-                       env: 'Environment') -> 'KeyedOptionDictType':
+def get_global_options(lang: str, for_machine: MachineChoice, env: 'Environment') -> 'KeyedOptionDictType':
     """Retrieve options that apply to all compilers for a given language."""
     description = f'Extra arguments passed to the {lang}'
     argkey = OptionKey('args', lang=lang, machine=for_machine)
@@ -1241,11 +1238,6 @@ def get_global_options(lang: str,
     largs = coredata.UserArrayOption(
         description + ' linker',
         env.options.get(largkey, []), split_args=True, user_input=True, allow_dups=True)
-
-    # This needs to be done here, so that if we have string values in the env
-    # options that we can safely combine them *after* they've been split
-    if comp.INVOKES_LINKER:
-        largs.set_value(largs.value + cargs.value)
 
     opts: 'KeyedOptionDictType' = {argkey: cargs, largkey: largs}
 

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -74,8 +74,8 @@ class FortranCompiler(CLikeCompiler, Compiler):
         source_name.write_text('print *, "Fortran compilation is working."; end')
 
         extra_flags: T.List[str] = []
-        extra_flags += environment.coredata.get_external_args(self.for_machine, self.language)
-        extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)
+        extra_flags += self.get_external_compile_args(environment.coredata)
+        extra_flags += self.get_external_link_args(environment.coredata)
         extra_flags += self.get_always_args()
         # %% build the test executable "sanitycheckf"
         # cwd=work_dir is necessary on Windows especially for Intel compilers to avoid error: cannot write on sanitycheckf.obj

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -402,7 +402,7 @@ class CLikeCompiler(Compiler):
                 pass
 
         # Add CFLAGS/CXXFLAGS/OBJCFLAGS/OBJCXXFLAGS and CPPFLAGS from the env
-        sys_args = env.coredata.get_external_args(self.for_machine, self.language)
+        sys_args = self.get_external_compile_args(env.coredata)
         if isinstance(sys_args, str):
             sys_args = [sys_args]
         # Apparently it is a thing to inject linker flags both
@@ -418,7 +418,7 @@ class CLikeCompiler(Compiler):
                 largs += self.use_linker_args(ld_value[0])
 
             # Add LDFLAGS from the env
-            sys_ld_args = env.coredata.get_external_link_args(self.for_machine, self.language)
+            sys_ld_args = self.get_external_link_args(env.coredata)
             # CFLAGS and CXXFLAGS go to both linking and compiling, but we want them
             # to only appear on the command line once. Remove dupes.
             largs += [x for x in sys_ld_args if x not in sys_args]
@@ -1152,7 +1152,7 @@ class CLikeCompiler(Compiler):
         commands = self.get_exelist() + ['-v', '-E', '-']
         commands += self.get_always_args()
         # Add CFLAGS/CXXFLAGS/OBJCFLAGS/OBJCXXFLAGS from the env
-        commands += env.coredata.get_external_args(self.for_machine, self.language)
+        commands += self.get_external_compile_args(env.coredata)
         mlog.debug('Finding framework path by running: ', ' '.join(commands), '\n')
         os_env = os.environ.copy()
         os_env['LC_ALL'] = 'C'

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -52,11 +52,11 @@ class ObjCCompiler(CLikeCompiler, Compiler):
         source_name = os.path.join(work_dir, 'sanitycheckobjc.m')
         binary_name = os.path.join(work_dir, 'sanitycheckobjc')
         extra_flags: T.List[str] = []
-        extra_flags += environment.coredata.get_external_args(self.for_machine, self.language)
+        extra_flags += self.get_external_compile_args(environment.coredata)
         if self.is_cross:
             extra_flags += self.get_compile_only_args()
         else:
-            extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)
+            extra_flags += self.get_external_link_args(environment.coredata)
         with open(source_name, 'w') as ofile:
             ofile.write('#import<stddef.h>\n'
                         'int main(void) { return 0; }\n')

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -51,11 +51,11 @@ class ObjCPPCompiler(CLikeCompiler, Compiler):
         source_name = os.path.join(work_dir, 'sanitycheckobjcpp.mm')
         binary_name = os.path.join(work_dir, 'sanitycheckobjcpp')
         extra_flags: T.List[str] = []
-        extra_flags += environment.coredata.get_external_args(self.for_machine, self.language)
+        extra_flags += self.get_external_compile_args(environment.coredata)
         if self.is_cross:
             extra_flags += self.get_compile_only_args()
         else:
-            extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)
+            extra_flags += self.get_external_link_args(environment.coredata)
         with open(source_name, 'w') as ofile:
             ofile.write('#import<stdio.h>\n'
                         'class MyClass;'

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -102,11 +102,11 @@ class SwiftCompiler(Compiler):
         source_name = os.path.join(work_dir, src)
         output_name = os.path.join(work_dir, 'swifttest')
         extra_flags: T.List[str] = []
-        extra_flags += environment.coredata.get_external_args(self.for_machine, self.language)
+        extra_flags += self.get_external_compile_args(environment.coredata)
         if self.is_cross:
             extra_flags += self.get_compile_only_args()
         else:
-            extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)
+            extra_flags += self.get_external_link_args(environment.coredata)
         with open(source_name, 'w') as ofile:
             ofile.write('''print("Swift compilation is working.")
 ''')

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -93,11 +93,11 @@ class ValaCompiler(Compiler):
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
         code = 'class MesonSanityCheck : Object { }'
         extra_flags: T.List[str] = []
-        extra_flags += environment.coredata.get_external_args(self.for_machine, self.language)
+        extra_flags += self.get_external_compile_args(environment.coredata)
         if self.is_cross:
             extra_flags += self.get_compile_only_args()
         else:
-            extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)
+            extra_flags += self.get_external_link_args(environment.coredata)
         with self.cached_compile(code, environment.coredata, extra_args=extra_flags, mode='compile') as p:
             if p.returncode != 0:
                 msg = f'Vala compiler {self.name_string()!r} can not compile programs'
@@ -117,7 +117,7 @@ class ValaCompiler(Compiler):
         if not extra_dirs:
             code = 'class MesonFindLibrary : Object { }'
             args: T.List[str] = []
-            args += env.coredata.get_external_args(self.for_machine, self.language)
+            args += self.get_external_compile_args(env.coredata)
             vapi_args = ['--pkg', libname]
             args += vapi_args
             with self.cached_compile(code, env.coredata, extra_args=args, mode='compile') as p:

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -658,12 +658,6 @@ class CoreData:
             raise type(e)(('Validation failed for option %s: ' % option_name) + str(e)) \
                 .with_traceback(sys.exc_info()[2])
 
-    def get_external_args(self, for_machine: MachineChoice, lang: str) -> T.Union[str, T.List[str]]:
-        return self.options[OptionKey('args', machine=for_machine, lang=lang)].value
-
-    def get_external_link_args(self, for_machine: MachineChoice, lang: str) -> T.Union[str, T.List[str]]:
-        return self.options[OptionKey('link_args', machine=for_machine, lang=lang)].value
-
     def update_project_options(self, options: 'KeyedOptionDictType') -> None:
         for key, value in options.items():
             if not key.is_project():

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -776,7 +776,7 @@ class CoreData:
                       for_machine: MachineChoice, env: 'Environment') -> None:
         """Add global language arguments that are needed before compiler/linker detection."""
         from .compilers import compilers
-        options = compilers.get_global_options(lang, comp, for_machine, env)
+        options = compilers.get_global_options(lang, for_machine, env)
         self.add_compiler_options(options, lang, for_machine, env)
 
     def process_new_compiler(self, lang: str, comp: 'Compiler', env: 'Environment') -> None:

--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -112,12 +112,12 @@ class ExternalProject(InterpreterObject):
         for lang, compiler in self.env.coredata.compilers[MachineChoice.HOST].items():
             if any(lang not in i for i in (CEXE_MAPPING, CFLAGS_MAPPING)):
                 continue
-            cargs = self.env.coredata.get_external_args(MachineChoice.HOST, lang)
+            cargs = compiler.get_external_compile_args(self.env.coredata)
             self.run_env[CEXE_MAPPING[lang]] = self._quote_and_join(compiler.get_exelist())
             self.run_env[CFLAGS_MAPPING[lang]] = self._quote_and_join(cargs)
             if not link_exelist:
                 link_exelist = compiler.get_linker_exelist()
-                link_args = self.env.coredata.get_external_link_args(MachineChoice.HOST, lang)
+                link_args = compiler.get_external_link_args(self.env.coredata)
         if link_exelist:
             # FIXME: Do not pass linker because Meson uses CC as linker wrapper,
             # but autotools often expects the real linker (e.h. GNU ld).

--- a/run_tests.py
+++ b/run_tests.py
@@ -118,6 +118,9 @@ class FakeCompilerOptions:
     def __init__(self):
         self.value = []
 
+    def set_value(self, v):
+        self.value = v
+
 # TODO: use a typing.Protocol here
 def get_fake_options(prefix: str = '') -> argparse.Namespace:
     opts = argparse.Namespace()


### PR DESCRIPTION
The original approach we used was completely and totally wrong, didn't work, shouldn't have worked, and was just bad. I've deleted that, done a bit of refactoring, and put the logic in the Compiler class, which makes more sense. 

Fixes: #8345