### PR TITLE
Submit/rust fix shared internal linking

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1610,7 +1610,7 @@ int dummy;
                 args += ['--extern', '{}={}'.format(d.name, os.path.join(d.subdir, d.filename))]
             else:
                 # Rust uses -l for non rust dependencies, but we still need to add (shared|static)=foo
-                _type = 'static' if d.typename == 'static library' else 'shared'
+                _type = 'static' if d.typename == 'static library' else 'dylib'
                 args += ['-l', f'{_type}={d.name}']
                 if d.typename == 'static library':
                     external_deps.extend(d.external_deps)

--- a/test cases/rust/16 internal c dependencies/lib.c
+++ b/test cases/rust/16 internal c dependencies/lib.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include "lib.h"
+
+void c_func(void) {
+    printf("This is a " MODE " C library\n");
+}

--- a/test cases/rust/16 internal c dependencies/lib.h
+++ b/test cases/rust/16 internal c dependencies/lib.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#if defined _WIN32 || defined __CYGWIN__
+  #if defined BUILDING_ADDER
+    #define DLL_PUBLIC __declspec(dllexport)
+  #else
+    #define DLL_PUBLIC __declspec(dllimport)
+  #endif
+#else
+  #if defined __GNUC__
+    #if defined BUILDING_ADDER
+      #define DLL_PUBLIC __attribute__ ((visibility("default")))
+    #else
+      #define DLL_PUBLIC
+    #endif
+  #else
+    #pragma message("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+DLL_PUBLIC void c_func(void);

--- a/test cases/rust/16 internal c dependencies/main.rs
+++ b/test cases/rust/16 internal c dependencies/main.rs
@@ -1,0 +1,9 @@
+extern "C" {
+    fn c_func();
+}
+
+fn main() {
+    unsafe {
+        c_func();
+    }
+}

--- a/test cases/rust/16 internal c dependencies/meson.build
+++ b/test cases/rust/16 internal c dependencies/meson.build
@@ -1,0 +1,14 @@
+project('internal dependencies', 'c', 'rust')
+
+test_prog = find_program('test.py')
+
+static = static_library('static', 'lib.c', c_args : '-DMODE="static"')
+exe = executable('static', 'main.rs', link_with : static)
+test('static linkage', test_prog, args : [exe, 'This is a static C library'])
+
+# Shared linkage with rust doesn't work on macOS with meson, yet
+if host_machine.system() != 'darwin'
+  shared = shared_library('shared', 'lib.c', c_args : '-DMODE="shared"')
+  exe = executable('shared', 'main.rs', link_with : shared)
+  test('shared linkage', test_prog, args : [exe, 'This is a shared C library'])
+endif

--- a/test cases/rust/16 internal c dependencies/test.py
+++ b/test cases/rust/16 internal c dependencies/test.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import argparse
+import subprocess
+import sys
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('command')
+    parser.add_argument('expected')
+    args = parser.parse_args()
+
+    out = subprocess.run(args.command, stdout=subprocess.PIPE)
+    actual = out.stdout.decode().strip()
+
+    if args.expected != actual:
+        print('expected:', args.expected, file=sys.stderr)
+        print('actual:  ', actual, file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Found through inspection, even in 0.57 we don't correctly generate linking arguments for shared c linkage libraries that Meson itself builds. This is a bug in 0.57 and should be applied to 0.57.2