### PR TITLE
Fix linking Rust with C dependencies

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1630,10 +1630,7 @@ int dummy;
             if d == '':
                 d = '.'
             args += ['-L', d]
-        has_shared_deps = False
-        for dep in target.get_dependencies():
-            if isinstance(dep, build.SharedLibrary):
-                has_shared_deps = True
+        has_shared_deps = any(isinstance(dep, build.SharedLibrary) for dep in target.get_dependencies())
         if isinstance(target, build.SharedLibrary) or has_shared_deps:
             # add prefer-dynamic if any of the Rust libraries we link
             # against are dynamic, otherwise we'll end up with

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1598,6 +1598,7 @@ int dummy;
         args += rustc.get_output_args(os.path.join(target.subdir, target.get_filename()))
         args += self.environment.coredata.get_external_args(target.for_machine, rustc.language)
         linkdirs = mesonlib.OrderedSet()
+        external_deps = target.external_deps.copy()
         for d in target.link_targets:
             linkdirs.add(d.subdir)
             if d.uses_rust():
@@ -1609,6 +1610,22 @@ int dummy;
                 # Rust uses -l for non rust dependencies, but we still need to add (shared|static)=foo
                 _type = 'static' if d.typename == 'static library' else 'shared'
                 args += ['-l', f'{_type}={d.name}']
+                if d.typename == 'static library':
+                    external_deps.extend(d.external_deps)
+        for e in external_deps:
+            for a in e.get_link_args():
+                if a.endswith(('.dll', '.so', '.dylib')):
+                    dir_, lib = os.path.split(a)
+                    linkdirs.add(dir_)
+                    lib, ext = os.path.splitext(lib)
+                    if lib.startswith('lib'):
+                        lib = lib[3:]
+                    args.extend(['-l', f'dylib={lib}'])
+                elif a.startswith('-L'):
+                    args.append(a)
+                elif a.startswith('-l'):
+                    # This should always be a static lib, I think
+                    args.extend(['-l', f'static={a[2:]}'])
         for d in linkdirs:
             if d == '':
                 d = '.'

--- a/test cases/rust/13 external c dependencies/c_accessing_zlib.c
+++ b/test cases/rust/13 external c dependencies/c_accessing_zlib.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <string.h>
+#include <zlib.h>
+
+void c_accessing_zlib(void) {
+    struct z_stream_s zstream;
+    printf("Hello from C!\n");
+    memset(&zstream, 0, sizeof(zstream));
+    inflateInit(&zstream);
+}

--- a/test cases/rust/13 external c dependencies/meson.build
+++ b/test cases/rust/13 external c dependencies/meson.build
@@ -1,0 +1,23 @@
+project('rust linking to c using dependency', 'c', 'rust')
+
+if host_machine.system() == 'darwin'
+  error('MESON_SKIP_TEST: doesnt work right on macos, please fix!')
+endif
+
+dep_zlib = dependency('zlib', static : get_option('static'), method : get_option('method'), required : false)
+if not dep_zlib.found()
+  error('MESON_SKIP_TEST: Could not find a @0@ zlib'.format(get_option('static') ? 'static' : 'shared'))
+endif
+
+l = static_library(
+  'c_accessing_zlib',
+  'c_accessing_zlib.c',
+  dependencies: [dep_zlib],
+)
+
+e = executable(
+  'prog', 'prog.rs',
+  link_with : l,
+)
+
+test('cdepstest', e)

--- a/test cases/rust/13 external c dependencies/meson_options.txt
+++ b/test cases/rust/13 external c dependencies/meson_options.txt
@@ -1,0 +1,2 @@
+option('static', type : 'boolean')
+option('method', type : 'string')

--- a/test cases/rust/13 external c dependencies/prog.rs
+++ b/test cases/rust/13 external c dependencies/prog.rs
@@ -1,0 +1,9 @@
+extern "C" {
+    fn c_accessing_zlib();
+}
+
+fn main() {
+    unsafe {
+        c_accessing_zlib();
+    }
+}

--- a/test cases/rust/13 external c dependencies/test.json
+++ b/test cases/rust/13 external c dependencies/test.json
@@ -1,0 +1,15 @@
+{
+  "matrix": {
+    "options": {
+      "static": [
+        { "val": true },
+        { "val": false }
+      ],
+      "method": [
+        { "val": "pkg-config" },
+        { "val": "cmake" },
+        { "val": "system" }
+      ]
+    }
+  }
+}

--- a/test cases/rust/13 external c dependencies/test.json
+++ b/test cases/rust/13 external c dependencies/test.json
@@ -10,6 +10,9 @@
         { "val": "cmake" },
         { "val": "system" }
       ]
-    }
+    },
+    "exclude": [
+      { "static": true, "method": "pkg-config" }
+    ]
   }
 }


### PR DESCRIPTION
Currently, Meson doesn't correctly handle linking Rust with C-linkage external dependencies at all. This is obviously a big problem. This patch addresses that by adding support. Zlib is an excelent choice as it's often available as both static and shared, and it can be found in a bunch of ways (cmake, pkg-config, and system).