### PR TITLE
meson: add .has_external_property() method

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1991,6 +1991,13 @@ the following methods.
   If `native: false` or not specified, variable is retrieved from the
   cross-file if cross-compiling, and from the native-file when not cross-compiling.
 
+- `has_external_property(propname, native: true/false)`
+  *(since 0.58.0)*: checks whether the given property exist in a native or
+  cross file. The optional `native: true` forces checking for the variable
+  in the native file, even when cross-compiling.
+  If `native: false` or not specified, the variable is checked for in the
+  cross-file if cross-compiling, and in the native-file when not cross-compiling.
+
 - `can_run_host_binaries()` *(since 0.55.0)*: returns true if the build machine can run
   binaries compiled for the host. This returns true unless you are
   cross compiling, need a helper to run host binaries, and don't have one.

--- a/docs/markdown/snippets/has_external_property.md
+++ b/docs/markdown/snippets/has_external_property.md
@@ -1,0 +1,7 @@
+## Check if native or cross-file properties exist
+
+It is now possible to check whether a native property or a cross-file property
+exists with `meson.has_external_property('foo')`. This is useful if the
+property in question is a boolean and one wants to distinguish between
+"set" and "not provided" which can't be done the usual way by passing a
+fallback parameter to `meson.get_external_property()` in this particular case.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -32,6 +32,7 @@ from .interpreterbase import InterpreterObject, MutableInterpreterObject, Disabl
 from .interpreterbase import FeatureNew, FeatureDeprecated, FeatureNewKwargs, FeatureDeprecatedKwargs
 from .interpreterbase import ObjectHolder, MesonVersionString
 from .interpreterbase import TYPE_var, TYPE_nkwargs
+from .interpreterbase import typed_pos_args
 from .modules import ModuleReturnValue, ExtensionModule
 from .cmake import CMakeInterpreter
 from .backend.backends import TestProtocol, Backend, ExecutableSerialisation
@@ -1947,6 +1948,7 @@ class MesonMain(InterpreterObject):
                              'project_name': self.project_name_method,
                              'get_cross_property': self.get_cross_property_method,
                              'get_external_property': self.get_external_property_method,
+                             'has_external_property': self.has_external_property_method,
                              'backend': self.backend_method,
                              })
 
@@ -2284,6 +2286,14 @@ class MesonMain(InterpreterObject):
                 return self.get_cross_property_method(args, kwargs)
             else:
                 return _get_native()
+
+    @permittedKwargs({'native'})
+    @FeatureNew('meson.has_external_property', '0.58.0')
+    @typed_pos_args('meson.has_external_property', str)
+    def has_external_property_method(self, args: T.Tuple[str], kwargs: T.Dict[str, T.Any]) -> str:
+        prop_name = args[0]
+        for_machine = self.interpreter.machine_from_native_kwarg(kwargs)
+        return prop_name in self.interpreter.environment.properties[for_machine]
 
 known_library_kwargs = (
     build.known_shlib_kwargs |

--- a/test cases/common/223 native prop/crossfile.ini
+++ b/test cases/common/223 native prop/crossfile.ini
@@ -1,3 +1,4 @@
 [properties]
 astring = 'cross'
 anarray = ['one', 'two']
+red = true

--- a/test cases/common/223 native prop/meson.build
+++ b/test cases/common/223 native prop/meson.build
@@ -23,3 +23,27 @@ assert(x=='fallback', 'fallback native:false did not work')
 
 x = meson.get_external_property('anarray')
 assert(x==['one', 'two'], 'array did not work')
+
+assert(meson.has_external_property('anarray'), 'expected property "anarray" to exist')
+assert(meson.has_external_property('astring'), 'expected property "astring" to exist')
+assert(not meson.has_external_property('abool'), 'did not expect property "abool" to exist')
+
+# These exist in both
+assert(meson.has_external_property('anarray', native: false), 'FIXME')
+assert(meson.has_external_property('anarray', native: true), 'FIXME')
+assert(meson.has_external_property('astring', native: false), 'FIXME')
+assert(meson.has_external_property('astring', native: true), 'FIXME')
+
+if meson.is_cross_build()
+  # This property only exists in the cross file
+  assert(meson.has_external_property('red'), 'expected property "red" to exist in cross file')
+  assert(meson.has_external_property('red', native: false), 'expected property "red" to exist in cross file')
+  assert(not meson.has_external_property('red', native: true), 'did not expect property "red" to exist in native file')
+
+  assert(not meson.has_external_property('abool', native: false), 'FIXME')
+  assert(not meson.has_external_property('abool', native: false), 'FIXME')
+else
+  assert(not meson.has_external_property('red'), 'did not expect property "red" to exist in native file')
+  assert(not meson.has_external_property('red', native: false), 'did not expect property "red" to exist in cross file because we are not doing a cross build')
+  assert(not meson.has_external_property('red', native: true), 'did not expect property "red" to exist in native file')
+endif


### PR DESCRIPTION
Useful in case of boolean values to distinguish between a boolean
value having been set in the native/cross file and not having been
provided, which can't be achieved by passing a fallback parameter
to .get_external_property().