### PR TITLE
mtest: create separate runners for multiple repeats

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2524,6 +2524,12 @@ class AllPlatformTests(BasePlatformTests):
         self.assertNotRegex(out, r'WARNING: Overriding.*TEST_VAR_SET')
         self.run_tests()
 
+    def test_testrepeat(self):
+        testdir = os.path.join(self.common_test_dir, '207 tap tests')
+        self.init(testdir)
+        self.build()
+        self._run(self.mtest_command + ['--repeat=2'])
+
     def test_testsetups(self):
         if not shutil.which('valgrind'):
             raise unittest.SkipTest('Valgrind not installed.')


### PR DESCRIPTION
Reusing the runners for multiple repeats of the test run gets in the way of the progress report, which stores runners in an OrderedSet. Instead, create a separate SingleTestRunner object for each repeat.

While at it, fix the "duplicate suite" assertion as it can fire with TAP tests and --repeat=N.

Fixes: #8405