### PR TITLE
Support multiple args in error()

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -580,6 +580,9 @@ Returns a [disabler object](#disabler-object).
 
 Print the argument string and halts the build process.
 
+*(since 0.58.0)* Can take more than one argument that will be separated by
+space.
+
 ### environment()
 
 ``` meson

--- a/docs/markdown/snippets/error_msg.md
+++ b/docs/markdown/snippets/error_msg.md
@@ -1,0 +1,4 @@
+## `error()` with multiple arguments
+
+Just like `warning()` and `message()`, `error()` can now take more than one
+argument that will be separated by space.

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5864,6 +5864,11 @@ class FailureTests(BasePlatformTests):
                                "meson.override_dependency('zlib', declare_dependency())",
                                """Tried to override dependency 'zlib' which has already been resolved or overridden""")
 
+    def test_error_func(self):
+        self.assertMesonRaises("error('a', 'b', ['c', ['d', {'e': 'f'}]], 'g')",
+                               "Problem encountered: a b \['c', \['d', {'e' : 'f'}\]\] g")
+
+
 @unittest.skipUnless(is_windows() or is_cygwin(), "requires Windows (or Windows via Cygwin)")
 class WindowsTests(BasePlatformTests):
     '''


### PR DESCRIPTION
Seems it got forgotten when that was added to warnings() and message().

Fixes: #8414.