### PR TITLE
deprecated `meson.get_cross_property`

### DIFF
--- a/docs/markdown/Cross-compilation.md
+++ b/docs/markdown/Cross-compilation.md
@@ -315,7 +315,7 @@ somekey = 'somevalue'
 then you can access that using the `meson` object like this:
 
 ```meson
-myvar = meson.get_cross_property('somekey')
+myvar = meson.get_external_property('somekey')
 # myvar now has the value 'somevalue'
 ```
 

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1979,9 +1979,9 @@ the following methods.
   the "native" compiler if we're not.
 
 - `get_cross_property(propname, fallback_value)`:
-  *Consider `get_external_property()` instead*. Returns the given
-  property from a cross file, the optional fallback_value is returned
-  if not cross compiling or the given property is not found.
+  *Deprecated since 0.58.0, use `get_external_property()` instead*.
+  Returns the given property from a cross file, the optional fallback_value
+  is returned if not cross compiling or the given property is not found.
 
 - `get_external_property(propname, fallback_value, native: true/false)`
   *(since 0.54.0)*: returns the given property from a native or cross file.

--- a/docs/markdown/snippets/deprecated_get_cross_property.md
+++ b/docs/markdown/snippets/deprecated_get_cross_property.md
@@ -1,0 +1,5 @@
+## `meson.get_cross_property()` has been deprecated
+
+It's a pure subset of `meson.get_external_property`, and works strangely in
+host == build configurations, since it would be more accurately described as
+`get_host_property`.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2241,6 +2241,7 @@ class MesonMain(InterpreterObject):
 
     @noArgsFlattening
     @permittedKwargs({})
+    @FeatureDeprecated('meson.get_cross_property', '0.58.0', 'Use meson.get_external_property() instead')
     def get_cross_property_method(self, args, kwargs) -> str:
         if len(args) < 1 or len(args) > 2:
             raise InterpreterException('Must have one or two arguments.')


### PR DESCRIPTION
It's a pure subset of `get_external_property`, and has odd behavior in
host == build configurations. `get_external_property` is clear, and uses
the standard `native : bool` syntax to control host vs build properties