### PR TITLE
interpreter: correctly track whether a subproject is initialized

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -3171,7 +3171,11 @@ external dependencies (including libraries) must go to "dependencies".''')
         # have any effect.
         self.project_default_options = mesonlib.stringlistify(kwargs.get('default_options', []))
         self.project_default_options = coredata.create_options_dict(self.project_default_options, self.subproject)
-        if self.environment.first_invocation:
+
+        # If this is the first invocation we alway sneed to initialize
+        # builtins, if this is a subproject that is new in a re-invocation we
+        # need to initialize builtins for that
+        if self.environment.first_invocation or (self.subproject != '' and self.subproject not in self.subprojects):
             default_options = self.project_default_options.copy()
             default_options.update(self.default_project_options)
             self.coredata.init_builtins(self.subproject)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5543,6 +5543,13 @@ class AllPlatformTests(BasePlatformTests):
         check_installed_files(['--skip-subprojects', 'bar'], main_expected)
         check_installed_files(['--skip-subprojects', 'another'], all_expected)
 
+    def test_adding_subproject_to_configure_project(self) -> None:
+        srcdir = os.path.join(self.unit_test_dir, '92 new subproject in configured project')
+        self.init(srcdir)
+        self.build()
+        self.setconf('-Duse-sub=true')
+        self.build()
+
 
 class FailureTests(BasePlatformTests):
     '''

--- a/test cases/unit/92 new subproject in configured project/meson.build
+++ b/test cases/unit/92 new subproject in configured project/meson.build
@@ -1,0 +1,7 @@
+# SPDX-license-identifier: Apache-2.0
+# Copyright © 2021 Intel Corporation
+project('existing project with new subproject', 'c')
+
+if get_option('use-sub')
+  dep = subproject('sub')
+endif

--- a/test cases/unit/92 new subproject in configured project/meson_options.txt
+++ b/test cases/unit/92 new subproject in configured project/meson_options.txt
@@ -1,0 +1,3 @@
+# SPDX-license-identifier: Apache-2.0
+# Copyright © 2021 Intel Corporation
+option('use-sub', type : 'boolean', value : false)

--- a/test cases/unit/92 new subproject in configured project/subprojects/sub/foo.c
+++ b/test cases/unit/92 new subproject in configured project/subprojects/sub/foo.c
@@ -1,0 +1,6 @@
+/* SPDX-license-identifier: Apache-2.0 */
+/* Copyright © 2021 Intel Corporation */
+
+int func(void) {
+    return 1;
+}

--- a/test cases/unit/92 new subproject in configured project/subprojects/sub/meson.build
+++ b/test cases/unit/92 new subproject in configured project/subprojects/sub/meson.build
@@ -1,0 +1,7 @@
+# SPDX-license-identifier: Apache-2.0
+# Copyright © 2021 Intel Corporation
+project('new subproject', 'c')
+
+l = library('foo', 'foo.c')
+
+dep = declare_dependency(link_with : l)


### PR DESCRIPTION
The way the tracking is currently done it works if no new subprojects
are added to a configured build directory. For cases where we want to
add a new subproject, it fails because we don't initialize builtins for
that subproject. This corrects that by checking to see if the subproject
already exists, and if it doesn't initializes the bultins for it.

Fixes: #8421