### PR TITLE
Allow printing UserOptions in the summary

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1356,6 +1356,7 @@ dictionaries does not guarantee ordering. `key` must be string,
 
 - an integer, boolean or string
 - *since 0.57.0* an external program or a dependency
+- *since 0.58.0* a feature option
 - a list of those.
 
 `summary()` can be called multiple times as long as the same

--- a/docs/markdown/snippets/summary-accepts-features.md
+++ b/docs/markdown/snippets/summary-accepts-features.md
@@ -1,0 +1,3 @@
+## `summary()` accepts features
+
+Build feature options can be passed to `summary()` as the value to be printed.

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -1877,6 +1877,9 @@ class Summary:
                 elif isinstance(i, (ExternalProgram, Dependency)):
                     FeatureNew.single_use('dependency or external program in summary', '0.57.0', subproject)
                     formatted_values.append(i.summary_value())
+                elif isinstance(i, coredata.UserOption):
+                    FeatureNew.single_use('feature option in summary', '0.58.0', subproject)
+                    formatted_values.append(i.printable_value())
                 else:
                     m = 'Summary value in section {!r}, key {!r}, must be string, integer, boolean, dependency or external program'
                     raise InterpreterException(m.format(section, k))

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4996,6 +4996,7 @@ class AllPlatformTests(BasePlatformTests):
                                  1
                                  True
                 empty list     :
+                enabled_opt    : enabled
                 A number       : 1
                 yes            : YES
                 no             : NO

--- a/test cases/unit/73 summary/meson.build
+++ b/test cases/unit/73 summary/meson.build
@@ -8,6 +8,7 @@ summary({'Some boolean': false,
          'Some string': 'Hello World',
          'A list': ['string', 1, true],
          'empty list': [],
+         'enabled_opt': get_option('enabled_opt'),
         }, section: 'Configuration')
 summary({'missing prog': find_program('xyzzy', required: false),
          'existing prog': import('python').find_installation(),

--- a/test cases/unit/73 summary/meson_options.txt
+++ b/test cases/unit/73 summary/meson_options.txt
@@ -1,0 +1,1 @@
+option('enabled_opt', type: 'feature', value: 'enabled')


### PR DESCRIPTION
Currently, if a user wants to print the status of a build option in the `summary()`, they would have do do something like:

```meson
summary({
	'feature': get_option('feature').enabled()
})
```

which prints the feature status as a boolean to string:

```
feature: True
```

This patch allows any `UserOption` to be printed in the summary, so:

```meson
summary({
	'feature': get_option('feature')
})
```

gives:

```
feature: enabled
```

Another enhancement would be to check for an instance of `UserFeatureOption` and highlight enabled/disabled as green/red like for normal bools.