### PR TITLE
pkg-config: dump all PKG_CONFIG environment variables to simplify debugging

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -676,14 +676,16 @@ class PkgConfigDependency(ExternalDependency):
         if sysroot:
             env['PKG_CONFIG_SYSROOT_DIR'] = sysroot
         new_pkg_config_path = ':'.join([p for p in extra_paths])
-        mlog.debug('PKG_CONFIG_PATH: ' + new_pkg_config_path)
         env['PKG_CONFIG_PATH'] = new_pkg_config_path
 
         pkg_config_libdir_prop = environment.properties[for_machine].get_pkg_config_libdir()
         if pkg_config_libdir_prop:
             new_pkg_config_libdir = ':'.join([p for p in pkg_config_libdir_prop])
             env['PKG_CONFIG_LIBDIR'] = new_pkg_config_libdir
-            mlog.debug('PKG_CONFIG_LIBDIR: ' + new_pkg_config_libdir)
+        # Dump all PKG_CONFIG environment variables
+        for key, value in env.items():
+            if key.startswith('PKG_'):
+                mlog.debug(f'env[{key}]: {value}')
 
     def _call_pkgbin(self, args, env=None):
         # Always copy the environment since we're going to modify it


### PR DESCRIPTION
The output of pkg-config is affected by environment variables.
Currently, the meson log output doesn't provide sufficient information to debug pkg-config issues.
With this change, all the pkg-config environment variables are outputted, including the system env variables, to simplify debugging.