### PR TITLE
rust: correctly handle -l link args

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1624,8 +1624,8 @@ int dummy;
                 elif a.startswith('-L'):
                     args.append(a)
                 elif a.startswith('-l'):
-                    # This should always be a static lib, I think
-                    args.extend(['-l', f'static={a[2:]}'])
+                    _type = 'static' if e.static else 'dylib'
+                    args.extend(['-l', f'{_type}={a[2:]}'])
         for d in linkdirs:
             if d == '':
                 d = '.'

--- a/test cases/rust/14 external libm/meson.build
+++ b/test cases/rust/14 external libm/meson.build
@@ -1,0 +1,24 @@
+project('rust linking to libm', 'c', 'rust')
+
+if host_machine.system() == 'darwin'
+  error('MESON_SKIP_TEST: doesnt work right on macos, please fix!')
+endif
+
+cc = meson.get_compiler('c')
+dep_m = cc.find_library('m', required : false, static : get_option('static'))
+if not dep_m.found()
+  error('MESON_SKIP_TEST: Could not find a @0@ libm'.format(get_option('static') ? 'static' : 'shared'))
+endif
+
+librs_math = static_library(
+  'rs_math',
+  'rs_math.rs',
+  dependencies : [dep_m],
+)
+
+e = executable(
+  'prog', 'prog.rs',
+  link_with : [librs_math],
+)
+
+test('cdepstest', e)

--- a/test cases/rust/14 external libm/meson_options.txt
+++ b/test cases/rust/14 external libm/meson_options.txt
@@ -1,0 +1,2 @@
+option('static', type : 'boolean')
+option('method', type : 'string')

--- a/test cases/rust/14 external libm/prog.rs
+++ b/test cases/rust/14 external libm/prog.rs
@@ -1,0 +1,5 @@
+extern crate rs_math;
+
+fn main() {
+    assert_eq!(rs_math::rs_log2(8.0), 3.0);
+}

--- a/test cases/rust/14 external libm/rs_math.rs
+++ b/test cases/rust/14 external libm/rs_math.rs
@@ -1,0 +1,12 @@
+#![crate_name = "rs_math"]
+
+use std::os::raw::c_double;
+
+extern "C" {
+    fn log2(n: c_double) -> c_double;
+}
+
+#[no_mangle]
+pub extern fn rs_log2(n: c_double) -> c_double {
+    unsafe { log2(n) }
+}

--- a/test cases/rust/14 external libm/test.json
+++ b/test cases/rust/14 external libm/test.json
@@ -1,0 +1,10 @@
+{
+  "matrix": {
+    "options": {
+      "static": [
+        { "val": true },
+        { "val": false }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Previously it was assumed (because of the way meson handles pkg-config
dependencies) that `-l` option would be static. This is not true, `-l`
could be a shared lib as well. So, let's respect that.

Co-Authored-by: Dylan Baker <dylan@pnwbakers.com>