### PR TITLE
fix missing D versions with generated source

### DIFF
--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -153,6 +153,9 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
     def get_feature_args(self, kwargs: T.Dict[str, T.Any], build_to_src: str) -> T.List[str]:
         # TODO: using a TypeDict here would improve this
         res = []
+        # get_feature_args can be called multiple times for the same target when there is generated source
+        # so we have to copy the kwargs (target.d_features) dict before popping from it
+        kwargs = kwargs.copy()
         if 'unittest' in kwargs:
             unittest = kwargs.pop('unittest')
             unittest_arg = d_feature_args[self.id]['unittest']
@@ -525,6 +528,9 @@ class DCompiler(Compiler):
     def get_feature_args(self, kwargs: T.Dict[str, T.Any], build_to_src: str) -> T.List[str]:
         # TODO: using a TypeDict here would improve this
         res = []
+        # get_feature_args can be called multiple times for the same target when there is generated source
+        # so we have to copy the kwargs (target.d_features) dict before popping from it
+        kwargs = kwargs.copy()
         if 'unittest' in kwargs:
             unittest = kwargs.pop('unittest')
             unittest_arg = d_feature_args[self.id]['unittest']


### PR DESCRIPTION
I've notice that when I add a generated source (with `custom_target`) to a target (e.g; an `executable` or `library`), the D versions specified with `d_module_versions` are not passed anymore to the compiler.
Inspecting the Ninja rules, I see that the D versions are passed to the compiler only for the generated source (which is first in the rules file), but not for the other sources.
I've tracked this down in the Meson code to the `get_feature_args` implementation that pops from `target.d_features`.

Tested to work in my own project.

Fixes: #7140