### PR TITLE
d_import_dirs add search path in the build directory

### DIFF
--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -220,13 +220,15 @@ class DmdLikeCompilerMixin(CompilerMixinBase):
             for idir_obj in import_dirs:
                 basedir = idir_obj.get_curdir()
                 for idir in idir_obj.get_incdirs():
+                    bldtreedir = os.path.join(basedir, idir)
                     # Avoid superfluous '/.' at the end of paths when d is '.'
                     if idir not in ('', '.'):
-                        expdir = os.path.join(basedir, idir)
+                        expdir = bldtreedir
                     else:
                         expdir = basedir
                     srctreedir = os.path.join(build_to_src, expdir)
                     res.append('{0}{1}'.format(import_dir_arg, srctreedir))
+                    res.append('{0}{1}'.format(import_dir_arg, bldtreedir))
 
         if kwargs:
             raise EnvironmentException('Unknown D compiler feature(s) selected: %s' % ', '.join(kwargs.keys()))
@@ -592,13 +594,15 @@ class DCompiler(Compiler):
             for idir_obj in import_dirs:
                 basedir = idir_obj.get_curdir()
                 for idir in idir_obj.get_incdirs():
+                    bldtreedir = os.path.join(basedir, idir)
                     # Avoid superfluous '/.' at the end of paths when d is '.'
                     if idir not in ('', '.'):
-                        expdir = os.path.join(basedir, idir)
+                        expdir = bldtreedir
                     else:
                         expdir = basedir
                     srctreedir = os.path.join(build_to_src, expdir)
                     res.append('{0}{1}'.format(import_dir_arg, srctreedir))
+                    res.append('{0}{1}'.format(import_dir_arg, bldtreedir))
 
         if kwargs:
             raise EnvironmentException('Unknown D compiler feature(s) selected: %s' % ', '.join(kwargs.keys()))


### PR DESCRIPTION
I'd like to have the possibility to import files from the build directory (resource files generated with `custom_target`).
The following works:
```meson
executable('my_exe', my_src,
    include_directories: include_directories('source'),
    d_import_dirs: [
        include_directories('views'),
        meson.current_build_dir() / 'views',
    ],
)
```
but is an anti-pattern, and rightfully warned:
```
WARNING: Building a path to the source dir is not supported. Use a relative path instead.
This will become a hard error in the future.
```
Instead I am proposing that `include_directories` have the same behavior in the context of `d_import_dirs` than in the context of adding header (or modules for D) search path: 
 - add the path to the source directory (as currently done)
 - add the path to the corresponding build directory 

This is already the documented behavior of `include_directories`, so this PR is more a fix than a new feature IMO.