### PR TITLE
external_project: Fix default cross compile parameters

### DIFF
--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -261,7 +261,7 @@ class ExternalProjectModule(ExtensionModule):
             raise InterpreterException('add_project takes exactly one positional argument')
         configure_command = args[0]
         configure_options = kwargs.get('configure_options', [])
-        cross_configure_options = kwargs.get('cross_configure_options', ['--host={host}'])
+        cross_configure_options = kwargs.get('cross_configure_options', ['--host=@HOST@'])
         verbose = kwargs.get('verbose', False)
         env = self.interpreter.unpack_env_kwarg(kwargs)
         project = ExternalProject(self.interpreter,


### PR DESCRIPTION
The variable `{host}` cannot be successfully expanded.
Using the `@HOST@` parameter, as suggested by the documentation, works.