### PR TITLE
Add representation of the C (or other language) preprocessor

### DIFF
--- a/docs/markdown/snippets/pre_processor.md
+++ b/docs/markdown/snippets/pre_processor.md
@@ -1,0 +1,3 @@
+## A pre-processor object
+
+A new pre-processor object has been added.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1031,7 +1031,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         return []
 
     def get_preprocess_only_args(self) -> T.List[str]:
-        raise EnvironmentException('This compiler does not have a preprocessor')
+        raise EnvironmentException(f'The {self.id} compiler for {self.language} does not have a preprocessor')
 
     def get_default_include_dirs(self) -> T.List[str]:
         # TODO: This is a candidate for returning an immutable list

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -423,6 +423,12 @@ class File(HoldableObject):
 
     @lru_cache(maxsize=None)
     def rel_to_builddir(self, build_to_src: str) -> str:
+        """String path relative to the build directory.
+
+        :param build_to_src:
+            The relative path of the build directory to the source directory
+        :return: the file path relative to the build directory
+        """
         if self.is_built:
             return self.relative_name()
         else:


### PR DESCRIPTION
There are cases where users want/need to use the C Pre Processor directly. They might attempt this with code like:
```meson
cpp = find_program('cpp')
custom_target(..., command : [cpp, ...])
```
Of course, that runs into problems when they use a machine file, because meson uses `cpp` to mean `C++`, and they get their compiler instead of `cpp`. Of course, there's another problem, `cpp` isn't portable.

This MR attempts make that better by adding an object representation it can be gotten like this:
```meson
cc = meson.get_compiler('c')  # or cpp, objc, objc++, or any other compiler with a pre-processor
pp = cc.get_preprocessor()
if pp.has_argument('-foo')
   ...
endif
```

It provides a number of methods like the compiler object:
- cmd_array
- has_argument
- has_multi_argument
- get_supported_arguments
- first_supported_argument

But is also an `ExternalProgram`, like those returned by `find_program()` and can be used like one:
```meson
custom_target(..., command : [pp, ...])
```

This has the advantage of being portable, and has the ability to be tested like a compiler would be.

This is obviously still a WIP, it needs tests, docs, and such. I'm just trying to gauge if this is a useful solution or not.

Related: #8434 