### PR TITLE
docs: Clarify compiler.cmd_array()

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2236,8 +2236,7 @@ the following methods:
   the positional argument, you can specify external dependencies to
   use with `dependencies` keyword argument.
 
-- `cmd_array()`: returns an array containing the command arguments for
-  the current compiler.
+- `cmd_array()`: returns an array containing the command(s) for the compiler.
 
 - `compiles(code)`: returns true if the code fragment given in the
   positional argument compiles, you can specify external dependencies


### PR DESCRIPTION
Make it easier to understand that this array contains the compiler
command, not arguments to it, and may only have one element.

---

I read past this several times not realising it was `cmd_array()` that would give me the command name.
Please check the new wording is correct for more complex cases - I've only used it for C and Vala.
