### PR TITLE
Refactor subdir visitation to track files instead of dirs.

### DIFF
--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -70,10 +70,10 @@ class AstInterpreter(interpreterbase.InterpreterBase):
     def __init__(self, source_root: str, subdir: str, subproject: str, visitors: T.Optional[T.List[AstVisitor]] = None):
         super().__init__(source_root, subdir, subproject)
         self.visitors = visitors if visitors is not None else []
-        self.visited_subdirs = {}     # type: T.Dict[str, bool]
-        self.assignments = {}         # type: T.Dict[str, BaseNode]
-        self.assign_vals = {}         # type: T.Dict[str, T.Any]
-        self.reverse_assignment = {}  # type: T.Dict[str, BaseNode]
+        self.processed_buildfiles = set() # type: T.Set[str]
+        self.assignments = {}             # type: T.Dict[str, BaseNode]
+        self.assign_vals = {}             # type: T.Dict[str, T.Any]
+        self.reverse_assignment = {}      # type: T.Dict[str, BaseNode]
         self.funcs.update({'project': self.func_do_nothing,
                            'test': self.func_do_nothing,
                            'benchmark': self.func_do_nothing,
@@ -150,10 +150,11 @@ class AstInterpreter(interpreterbase.InterpreterBase):
         buildfilename = os.path.join(subdir, environment.build_filename)
         absname = os.path.join(self.source_root, buildfilename)
         symlinkless_dir = os.path.realpath(absdir)
-        if symlinkless_dir in self.visited_subdirs:
+        build_file = os.path.join(symlinkless_dir, 'meson.build')
+        if build_file in self.processed_buildfiles:
             sys.stderr.write('Trying to enter {} which has already been visited --> Skipping\n'.format(args[0]))
             return
-        self.visited_subdirs[symlinkless_dir] = True
+        self.processed_buildfiles.add(build_file)
 
         if not os.path.isfile(absname):
             sys.stderr.write(f'Unable to find build file {buildfilename} --> Skipping\n')

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2380,7 +2380,7 @@ class Interpreter(InterpreterBase):
             self.sanity_check_ast()
         self.builtin.update({'meson': MesonMain(build, self)})
         self.generators = []
-        self.visited_subdirs = {}
+        self.processed_buildfiles = set() # type: T.Set[str]
         self.project_args_frozen = False
         self.global_args_frozen = False  # implies self.project_args_frozen
         self.subprojects = {}
@@ -4212,10 +4212,11 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
             raise InvalidArguments('Subdir argument must be a relative path.')
         absdir = os.path.join(self.environment.get_source_dir(), subdir)
         symlinkless_dir = os.path.realpath(absdir)
-        if symlinkless_dir in self.visited_subdirs:
+        build_file = os.path.join(symlinkless_dir, 'meson.build')
+        if build_file in self.processed_buildfiles:
             raise InvalidArguments('Tried to enter directory "%s", which has already been visited.'
                                    % subdir)
-        self.visited_subdirs[symlinkless_dir] = True
+        self.processed_buildfiles.add(build_file)
         self.subdir = subdir
         os.makedirs(os.path.join(self.environment.build_dir, subdir), exist_ok=True)
         buildfilename = os.path.join(self.subdir, environment.build_filename)

--- a/test cases/failing/112 enter subdir twice/meson.build
+++ b/test cases/failing/112 enter subdir twice/meson.build
@@ -1,0 +1,3 @@
+project('subdir2', 'c')
+subdir('sub')
+subdir('sub')

--- a/test cases/failing/112 enter subdir twice/sub/meson.build
+++ b/test cases/failing/112 enter subdir twice/sub/meson.build
@@ -1,0 +1,1 @@
+message('Now in subdir')

--- a/test cases/failing/112 enter subdir twice/test.json
+++ b/test cases/failing/112 enter subdir twice/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/112 enter subdir twice/meson.build:3:0: ERROR: Tried to enter directory \"sub\", which has already been visited."
+    }
+  ]
+}


### PR DESCRIPTION
For #5209, it's better to have only one place where processed buildfiles are stored.

Added an explicit test for this, since one did not seem to already exist.