### PR TITLE
Duplicate pkg config path

### DIFF
--- a/docs/markdown/snippets/javac-detection.md
+++ b/docs/markdown/snippets/javac-detection.md
@@ -1,0 +1,5 @@
+## Java Compiler Detection
+
+The way that Meson detects `javac` has changed a little bit. Meson will now
+read the `JAVA_HOME` environment variable when looking for `javac` and will
+then fallback to looking for `javac` on the `PATH` if `JAVA_HOME` was unset.

--- a/docs/markdown/snippets/jdk-system-dependency.md
+++ b/docs/markdown/snippets/jdk-system-dependency.md
@@ -1,0 +1,14 @@
+## JDK System Dependency
+
+When building projects such as those interacting with the JNI, you need access
+to a few header files located in `JAVA_HOME`. This system dependency will add
+the correct include paths to your target assuming the dependency has been setup
+properly with `JAVA_HOME` pointing to a valid JDK installation.
+
+```meson
+jdk = dependency('jdk', version : '>=1.8', required : true)
+```
+
+Currently this system dependency only works on linux, win32, and darwin. This
+can easily be extended given the correct information about your compiler and
+platform.

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -20,7 +20,7 @@ from .base import (  # noqa: F401
     ExternalDependency, NotFoundDependency, ExternalLibrary, ExtraFrameworkDependency, InternalDependency,
     PkgConfigDependency, CMakeDependency, find_external_dependency, get_dep_identifier, packages, _packages_accept_language,
     DependencyFactory)
-from .dev import ValgrindDependency, gmock_factory, gtest_factory, llvm_factory, zlib_factory
+from .dev import JDKSystemDependency, ValgrindDependency, gmock_factory, gtest_factory, llvm_factory, zlib_factory
 from .coarrays import coarray_factory
 from .mpi import mpi_factory
 from .scalapack import scalapack_factory
@@ -45,6 +45,7 @@ packages.update({
     'llvm': llvm_factory,
     'valgrind': ValgrindDependency,
     'zlib': zlib_factory,
+    'jdk': JDKSystemDependency,
 
     'boost': BoostDependency,
     'cuda': CudaDependency,

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -658,7 +658,7 @@ class PkgConfigDependency(ExternalDependency):
     def setup_env(env: T.MutableMapping[str, str], environment: 'Environment', for_machine: MachineChoice,
                   extra_path: T.Optional[str] = None) -> None:
         extra_paths: T.List[str] = environment.coredata.options[OptionKey('pkg_config_path', machine=for_machine)].value
-        if extra_path:
+        if extra_path and extra_path no in extra_paths:
             extra_paths.append(extra_path)
         sysroot = environment.properties[for_machine].get_sys_root()
         if sysroot:

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -208,6 +208,14 @@ class Properties:
         assert isinstance(res, bool)
         return res
 
+    def get_java_home(self) -> T.Optional[str]:
+        if 'java_home' not in self.properties:
+            return None
+
+        raw = self.properties['java_home']
+        assert isinstance(raw, str)
+        return raw
+
     def __eq__(self, other: object) -> bool:
         if isinstance(other, type(self)):
             return self.properties == other.properties

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -18,6 +18,7 @@ import tempfile
 import shlex
 import typing as T
 import collections
+import pathlib
 
 from . import coredata
 from .linkers import ArLinker, ArmarLinker, VisualStudioLinker, DLinker, CcrxLinker, Xc16Linker, CompCertLinker, C2000Linker, IntelVisualStudioLinker, AIXArLinker
@@ -844,12 +845,13 @@ class Environment:
                 self.binaries[for_machine].binaries.setdefault(name, mesonlib.split_args(p_env))
 
     def _set_default_properties_from_env(self) -> None:
-        """Properties which can alkso be set from the environment."""
+        """Properties which can also be set from the environment."""
         # name, evar, split
         opts: T.List[T.Tuple[str, T.List[str], bool]] = [
             ('boost_includedir', ['BOOST_INCLUDEDIR'], False),
             ('boost_librarydir', ['BOOST_LIBRARYDIR'], False),
             ('boost_root', ['BOOST_ROOT', 'BOOSTROOT'], True),
+            ('java_home', ['JAVA_HOME'], False),
         ]
 
         for (name, evars, split), for_machine in itertools.product(opts, MachineChoice):
@@ -1677,7 +1679,11 @@ class Environment:
         self._handle_exceptions(popen_exceptions, compilers)
 
     def detect_java_compiler(self, for_machine):
-        exelist = self.lookup_binary_entry(for_machine, 'java')
+        java_home = self.properties[for_machine].get_java_home()
+        if java_home is not None:
+            exelist = [str(pathlib.Path(java_home) / 'bin' / 'javac')]
+        else:
+            exelist = self.lookup_binary_entry(for_machine, 'javac')
         info = self.machines[for_machine]
         if exelist is None:
             # TODO support fallback

--- a/test cases/java/9 jdk/lib/meson.build
+++ b/test cases/java/9 jdk/lib/meson.build
@@ -1,0 +1,7 @@
+sources = files(
+  'native.c',
+)
+
+library('jdkjava', sources,
+  dependencies : [jdk],
+)

--- a/test cases/java/9 jdk/lib/native.c
+++ b/test cases/java/9 jdk/lib/native.c
@@ -1,0 +1,12 @@
+#include <jni.h>
+
+JNIEXPORT jint JNICALL
+JNI_OnLoad(JavaVM *vm, void *reserved)
+{
+    return 0;
+}
+
+JNIEXPORT void JNICALL
+JNI_OnUnload(JavaVM *vm, void *reserved)
+{
+}

--- a/test cases/java/9 jdk/meson.build
+++ b/test cases/java/9 jdk/meson.build
@@ -1,0 +1,5 @@
+project('jdkjava', 'c')
+
+jdk = dependency('jdk', version : '>=1.8', required : true)
+
+subdir('lib')


### PR DESCRIPTION
Previously builds would *potentially* get spammed with messaging at
configure time that duplicate entries in an array would be an error in
the future, and the cause was because the same entries were getting
added over and over to pkg_config_path.