### PR TITLE
Fix duplicate pkg_config_path entries

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -669,8 +669,8 @@ class PkgConfigDependency(ExternalDependency):
     @staticmethod
     def setup_env(env: T.MutableMapping[str, str], environment: 'Environment', for_machine: MachineChoice,
                   extra_path: T.Optional[str] = None) -> None:
-        extra_paths: T.List[str] = environment.coredata.options[OptionKey('pkg_config_path', machine=for_machine)].value
-        if extra_path:
+        extra_paths: T.List[str] = environment.coredata.options[OptionKey('pkg_config_path', machine=for_machine)].value[:]
+        if extra_path and extra_path not in extra_paths:
             extra_paths.append(extra_path)
         sysroot = environment.properties[for_machine].get_sys_root()
         if sysroot:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -7318,6 +7318,18 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertEqual(relative_path_dep.get_link_args(), link_args)
 
     @skipIfNoPkgconfig
+    def test_pkgconfig_duplicate_path_entries(self):
+        testdir = os.path.join(self.unit_test_dir, '111 pkgconfig duplicate path entries')
+        pkg_dir = os.path.join(testdir, 'pkgconfig')
+
+        env = get_fake_env(testdir, self.builddir, self.prefix)
+        env.coredata.set_options({OptionKey('pkg_config_path'): pkg_dir}, subproject='')
+
+        PkgConfigDependency.setup_env({}, env, MachineChoice.HOST, pkg_dir)
+        pkg_config_path = env.coredata.options[OptionKey('pkg_config_path')].value
+        self.assertTrue(len(pkg_config_path) == 1)
+
+    @skipIfNoPkgconfig
     def test_pkgconfig_internal_libraries(self):
         '''
         '''


### PR DESCRIPTION
Previously builds would *potentially* get sammed with messaging at
configure time that duplicate entries in an array would be an error in
the future, and the cause was because the same entries were getting
added over and over to pkg_config_path.p