### PR TITLE
minstall: Correctly set uid/gid of installed files

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1065,7 +1065,7 @@ arguments. The following keyword arguments are supported:
 
   `install_mode: 'rw-r--r--'` for just the file mode
 
-  `install_mode: ['rw-r--r--', 'nobody', 'nobody']` for the file mode and the user/group
+  `install_mode: ['rw-r--r--', 'nobody', 'nogroup']` for the file mode and the user/group
 
   `install_mode: ['rw-r-----', 0, 0]` for the file mode and uid/gid
 

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -148,7 +148,7 @@ def set_chown(path: str, user: T.Optional[str] = None, group: T.Optional[str] = 
         Use a real function rather than a lambda to help mypy out. Also real
         functions are faster.
         """
-        real_os_chown(path, gid, uid, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
+        real_os_chown(path, uid, gid, dir_fd=dir_fd, follow_symlinks=follow_symlinks)
 
     try:
         os.chown = chown


### PR DESCRIPTION
In commit caab4d3d, the uid and gid arguments passed to os.chown() by
set_chown() were accidentally swapped, causing files to end up with
incorrect owner/group if the owner and group are not the same.

Also update the documentation to better indicate which argument to
install_mode is which.

Signed-off-by: Peter Kjellerstedt <peter.kjellerstedt@axis.com>