### PR TITLE
scripts/meson_exe: fix stdout and stderr decoding

### DIFF
--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -18,6 +18,7 @@ import argparse
 import pickle
 import subprocess
 import typing as T
+import locale
 
 from .. import mesonlib
 from ..backend.backends import ExecutableSerialisation
@@ -70,11 +71,12 @@ def run_exe(exe: ExecutableSerialisation, extra_env: T.Optional[dict] = None) ->
             print(f'while executing {cmd_args!r}')
         if exe.verbose:
             return p.returncode
+        encoding = locale.getpreferredencoding()
         if not exe.capture:
             print('--- stdout ---')
-            print(stdout.decode())
+            print(stdout.decode(encoding=encoding, errors='replace'))
         print('--- stderr ---')
-        print(stderr.decode())
+        print(stderr.decode(encoding=encoding, errors='replace'))
         return p.returncode
 
     if exe.capture:


### PR DESCRIPTION
1. use `locale.getpreferredencoding()` to get encoding name.

`bytes.decode()` assumes `encoding='utf-8'` by default. It is incorrect on my
Windows setup, and causes `UnicodeDecodeError`.

2. use `errors='replace'`.

`bytes.decode()` assumes `errors='strict'` by default. Meson shouldn't crash
if subprocess outputs some garbage that can't be decoded.

`surrogateescape` doesn't work as expected on Windows. On Linux, default
`errors` for `sys.stdout` is `strict`, so `surrogateescape` can't be used there
too (at least until `sys.stdout` is reconfigured).

Fixes https://github.com/mesonbuild/meson/issues/8480