### PR TITLE
Add support for basic format strings

### DIFF
--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -170,6 +170,8 @@ functionality described below.
 
 ### String formatting
 
+#### .format()
+
 Strings can be built using the string formatting functionality.
 
 ```meson
@@ -181,6 +183,7 @@ res = template.format('text', 1, true)
 As can be seen, the formatting works by replacing placeholders of type
 `@number@` with the corresponding argument.
 
+#### Format strings
 *(Added 0.58)*
 
 Format strings can be used as a non-positional alternative to the

--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -198,7 +198,15 @@ s = f'int: @n@, string: @m@'
 ```
 
 Currently only identity-expressions are supported inside of format
-strings.
+strings, meaning you cannot use arbitrary Meson expressions inside of them.
+
+```meson
+n = 10
+m = 5
+
+# The following is not a valid format string
+s = f'result: @n + m@'
+```
 
 ### String methods
 

--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -181,6 +181,22 @@ res = template.format('text', 1, true)
 As can be seen, the formatting works by replacing placeholders of type
 `@number@` with the corresponding argument.
 
+*(Added 0.58)*
+
+Format strings can be used as a non-positional alternative to the
+string formatting functionality described above.
+
+```meson
+n = 10
+m = 'hi'
+
+s = f'int: @n@, string: @m@'
+# s now has the value 'int: 10, string: hi'
+```
+
+Currently only identity-expressions are supported inside of format
+strings.
+
 ### String methods
 
 Strings also support a number of other methods that return transformed

--- a/docs/markdown/snippets/fstrings.md
+++ b/docs/markdown/snippets/fstrings.md
@@ -1,0 +1,7 @@
+## Introducing format strings to the Meson language
+
+In addition to the conventional `'A string @0@ to be formatted @1@'.format(n, m)`
+method of formatting strings in the Meson DSL, there's now the additional
+`f'A string @n@ to be formatted @m@'` notation that provides a non-positional
+and clearer alternative. Meson's format strings are currently restricted to
+identity-expressions, meaning `f'format {'m' + 'e'}'` will not parse.

--- a/docs/markdown/snippets/fstrings.md
+++ b/docs/markdown/snippets/fstrings.md
@@ -1,7 +1,7 @@
 ## Introducing format strings to the Meson language
 
 In addition to the conventional `'A string @0@ to be formatted @1@'.format(n, m)`
-method of formatting strings in the Meson DSL, there's now the additional
+method of formatting strings in the Meson language, there's now the additional
 `f'A string @n@ to be formatted @m@'` notation that provides a non-positional
 and clearer alternative. Meson's format strings are currently restricted to
 identity-expressions, meaning `f'format @'m' + 'e'@'` will not parse.

--- a/docs/markdown/snippets/fstrings.md
+++ b/docs/markdown/snippets/fstrings.md
@@ -4,4 +4,4 @@ In addition to the conventional `'A string @0@ to be formatted @1@'.format(n, m)
 method of formatting strings in the Meson DSL, there's now the additional
 `f'A string @n@ to be formatted @m@'` notation that provides a non-positional
 and clearer alternative. Meson's format strings are currently restricted to
-identity-expressions, meaning `f'format {'m' + 'e'}'` will not parse.
+identity-expressions, meaning `f'format @'m' + 'e'@'` will not parse.

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -928,6 +928,7 @@ The result of this is undefined and will become a hard error in a future Meson r
         else:
             return self.evaluate_statement(node.falseblock)
 
+    @FeatureNew('format strings', '0.58.0')
     def evaluate_fstring(self, node: mparser.FormatStringNode) -> TYPE_var:
         assert(isinstance(node, mparser.FormatStringNode))
 

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -936,11 +936,11 @@ The result of this is undefined and will become a hard error in a future Meson r
             try:
                 val = self.variables[var]
                 if not isinstance(val, (str, int, float, bool)):
-                    raise mesonlib.MesonException(f'Identifier {var} does not name a formattable variable.')
+                    raise InvalidCode(f'Identifier {var} does not name a formattable variable.')
 
                 return str(val)
             except KeyError:
-                raise mesonlib.MesonException(f'Identifier "{var}" does not name a variable.')
+                raise InvalidCode(f'Identifier "{var}" does not name a variable.')
 
         return re.sub(r'@([_a-zA-Z][_0-9a-zA-Z]*)@', replace, node.value)
 

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -936,7 +936,7 @@ The result of this is undefined and will become a hard error in a future Meson r
             try:
                 val = self.variables[var]
                 if not isinstance(val, (str, int, float, bool)):
-                    raise InvalidCode(f'Identifier {var} does not name a formattable variable.')
+                    raise InvalidCode(f'Identifier "{var}" does not name a formattable variable.')
 
                 return str(val)
             except KeyError:

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -934,11 +934,15 @@ The result of this is undefined and will become a hard error in a future Meson r
         def replace(match: T.Match[str]) -> str:
             var = str(match.group(1))
             try:
-                return str(self.variables[var])
+                val = self.variables[var]
+                if not isinstance(val, (str, int, float, bool)):
+                    raise mesonlib.MesonException(f'Identifier {var} does not name a formattable variable.')
+
+                return str(val)
             except KeyError:
                 raise mesonlib.MesonException(f'Identifier "{var}" does not name a variable.')
 
-        return re.sub(r'{([_a-zA-Z][_0-9a-zA-Z]*)}', replace, node.value)
+        return re.sub(r'@([_a-zA-Z][_0-9a-zA-Z]*)@', replace, node.value)
 
     def evaluate_foreach(self, node: mparser.ForeachClauseNode) -> None:
         assert(isinstance(node, mparser.ForeachClauseNode))

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -937,7 +937,8 @@ The result of this is undefined and will become a hard error in a future Meson r
             try:
                 val = self.variables[var]
                 if not isinstance(val, (str, int, float, bool)):
-                    raise InvalidCode(f'Identifier "{var}" does not name a formattable variable.')
+                    raise InvalidCode(f'Identifier "{var}" does not name a formattable variable ' +
+                        '(has to be an integer, a string, a floating point number or a boolean).')
 
                 return str(val)
             except KeyError:

--- a/test cases/common/238 fstrings/meson.build
+++ b/test cases/common/238 fstrings/meson.build
@@ -2,8 +2,6 @@ project('meson-test', 'c')
 
 n = 10
 m = 'bar'
-s = f'test {n} string ({n}): {m}'
+s = f'test @n@ string (@@n@@): @m@'
 
-if s != 'test 10 string (10): bar'
-  error('Incorrect string formatting')
-endif
+assert(s == 'test 10 string (@10@): bar', 'Incorrect string formatting')

--- a/test cases/common/238 fstrings/meson.build
+++ b/test cases/common/238 fstrings/meson.build
@@ -1,0 +1,9 @@
+project('meson-test', 'c')
+
+n = 10
+m = 'bar'
+s = f'test {n} string ({n}): {m}'
+
+if s != 'test 10 string (10): bar'
+  error('Incorrect string formatting')
+endif

--- a/test cases/failing/113 invalid fstring/meson.build
+++ b/test cases/failing/113 invalid fstring/meson.build
@@ -1,0 +1,4 @@
+project('invalid-fstring', 'c')
+
+dict = {'key': true}
+s = f'invalid fstring: @dict@'

--- a/test cases/failing/113 invalid fstring/test.json
+++ b/test cases/failing/113 invalid fstring/test.json
@@ -2,6 +2,6 @@
     "stdout": [
         {
             "line": "test cases/failing/113 invalid fstring/meson.build:4:0: ERROR: Identifier \"dict\" does not name a formattable variable."
-	}
+        }
     ]
 }

--- a/test cases/failing/113 invalid fstring/test.json
+++ b/test cases/failing/113 invalid fstring/test.json
@@ -1,7 +1,7 @@
 {
     "stdout": [
         {
-            "line": "test cases/failing/113 invalid fstring/meson.build:4:0: ERROR: Identifier \"dict\" does not name a formattable variable."
+            "line": "test cases/failing/113 invalid fstring/meson.build:4:0: ERROR: Identifier \"dict\" does not name a formattable variable (has to be an integer, a string, a floating point number or a boolean)."
         }
     ]
 }

--- a/test cases/failing/113 invalid fstring/test.json
+++ b/test cases/failing/113 invalid fstring/test.json
@@ -1,0 +1,7 @@
+{
+    "stdout": [
+        {
+            "line": "test cases/failing/113 invalid fstring/meson.build:4:0: ERROR: Identifier \"dict\" does not name a formattable variable."
+	}
+    ]
+}

--- a/test cases/failing/114 invalid fstring/meson.build
+++ b/test cases/failing/114 invalid fstring/meson.build
@@ -1,0 +1,3 @@
+project('invalid-fstring', 'c')
+
+z = f'invalid fstring: @foo@'

--- a/test cases/failing/114 invalid fstring/test.json
+++ b/test cases/failing/114 invalid fstring/test.json
@@ -2,6 +2,6 @@
     "stdout": [
         {
             "line": "test cases/failing/114 invalid fstring/meson.build:3:0: ERROR: Identifier \"foo\" does not name a variable."
-	}
+        }
     ]
 }

--- a/test cases/failing/114 invalid fstring/test.json
+++ b/test cases/failing/114 invalid fstring/test.json
@@ -1,0 +1,7 @@
+{
+    "stdout": [
+        {
+            "line": "test cases/failing/114 invalid fstring/meson.build:3:0: ERROR: Identifier \"foo\" does not name a variable."
+	}
+    ]
+}


### PR DESCRIPTION
This is a little patch to add support for Python-esque format strings to the Meson language. This might be a controversial addition so I don't expect this to be merged as is, but I've purposefully limited this implementation to keep the lexer & parser simple.

The current version allows for the following (as indicated by the test case):
```meson
n = 10
s = 'a string'

message(f'n = {n}, string = {s}')
```

As I said the current version **is restricted** to identity-expressions inside of format strings (`{...}`) but if we decide that we want format strings and that they should support arbitrary expressions I'll lift that restriction.

I'm in favor of this addition as
- Format strings are intuitive, especially for people coming from Python and other languages offering them
- The current syntax is unnecessarily noisy and cumbersome to write