### PR TITLE
Add full_path() method to files objects

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -860,6 +860,8 @@ Then you can use it in `bar2` like this:
 
 Meson will then do the right thing.
 
+The returned object is a array of [`file objects`](#File-object).
+
 ### generator()
 
 ``` meson
@@ -2713,6 +2715,15 @@ library. This object has the following methods:
   type name, and methods as the object that called it. This new
   object will only inherit other attributes from its parent as
   controlled by keyword arguments.
+
+### File object
+
+*(since 0.58.0)*
+
+This object is an entry in the file array returned by [`files()`](#files). This
+object contains the following methods:
+
+- `full_path()`: returns a string of the full path to the file
 
 ### Feature option object
 

--- a/docs/markdown/snippets/file_full_path.md
+++ b/docs/markdown/snippets/file_full_path.md
@@ -1,0 +1,11 @@
+## file.full_path()
+
+File objects now support a method called `full_path()`. It returns the full path
+of the file.
+
+```meson
+srcs = files('x.c', 'y.c')
+foreach s : srcs
+  message(s.full_path()) # prints the full path of each file
+endforeach
+```


### PR DESCRIPTION
I am missing some places where mesonlib.File is probably assumed. This is a work in progress, but it worked in my very minimal test case.

The holder pattern is quite nice. Wasn't super hard to contribute this at all.

Fixes #8433 