### PR TITLE
Allow overriding MSVC debug info format with global or project arguments

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -976,10 +976,9 @@ class Backend:
         # Add compile args added using add_global_arguments()
         # These override per-project arguments
         commands += self.build.get_global_args(compiler, target.for_machine)
-        # Using both /ZI and /Zi at the same times produces a compiler warning.
-        # We do not add /ZI by default. If it is being used it is because the user has explicitly enabled it.
-        # /ZI needs to be removed in that case to avoid cl's warning to that effect (D9025 : overriding '/ZI' with '/Zi')
-        if ('/ZI' in commands) and ('/Zi' in commands):
+        # Using /ZI, /Z7 and /Zi at the same time produces a compiler warning.
+        # Remove /Zi if the user has explicitly enabled /Z7 or /ZI to avoid cl's warning to that effect (D9025 : overriding '/ZI' with '/Zi')
+        if any(x in commands for x in ['/ZI', '/Z7']) and ('/Zi' in commands):
             commands.remove('/Zi')
         # Compile args added from the env: CFLAGS/CXXFLAGS, etc, or the cross
         # file. We want these to override all the defaults, but not the

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -901,7 +901,6 @@ class Vs2010Backend(backends.Backend):
         # Incremental linking increases code size
         if '/INCREMENTAL:NO' in buildtype_link_args:
             ET.SubElement(type_config, 'LinkIncremental').text = 'false'
-
         # Build information
         compiles = ET.SubElement(root, 'ItemDefinitionGroup')
         clconf = ET.SubElement(compiles, 'ClCompile')
@@ -937,13 +936,15 @@ class Vs2010Backend(backends.Backend):
         # Sanitizers
         if '/fsanitize=address' in build_args:
             ET.SubElement(type_config, 'EnableASAN').text = 'true'
-        # Debug format
-        if '/ZI' in build_args:
+        # Debug format. Allow debug information format to be overridden by user using project or global args.
+        project_args = self.build.get_project_args(compiler, target.subproject, target.for_machine)
+        global_args = self.build.get_global_args(compiler, target.for_machine)
+        if '/ZI' in build_args + project_args + global_args:
             ET.SubElement(clconf, 'DebugInformationFormat').text = 'EditAndContinue'
-        elif '/Zi' in build_args:
-            ET.SubElement(clconf, 'DebugInformationFormat').text = 'ProgramDatabase'
-        elif '/Z7' in build_args:
+        elif '/Z7' in build_args + project_args + global_args:
             ET.SubElement(clconf, 'DebugInformationFormat').text = 'OldStyle'
+        elif '/Zi' in build_args + project_args + global_args:
+            ET.SubElement(clconf, 'DebugInformationFormat').text = 'ProgramDatabase'
         else:
             ET.SubElement(clconf, 'DebugInformationFormat').text = 'None'
         # Runtime checks

--- a/test cases/unit/102 debug info/main.c
+++ b/test cases/unit/102 debug info/main.c
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/test cases/unit/102 debug info/main.cpp
+++ b/test cases/unit/102 debug info/main.cpp
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/test cases/unit/102 debug info/meson.build
+++ b/test cases/unit/102 debug info/meson.build
@@ -1,0 +1,10 @@
+project('msvc_debuginfo', ['c', 'cpp'])
+
+add_project_arguments('/Z7', language : 'cpp')
+add_project_arguments('/ZI', language : 'c')
+
+exe_c = executable('exe_c', 'main.c')
+exe_cpp = executable('exe_cpp', 'main.cpp')
+
+test('debuginfo_c', exe_c)
+test('debuginfo_cpp', exe_cpp)

--- a/unittests/windowstests.py
+++ b/unittests/windowstests.py
@@ -373,3 +373,13 @@ class WindowsTests(BasePlatformTests):
             raise SkipTest('Not using MSVC')
         self.init(testdir, extra_args=['-Dtest-failure=true'])
         self.assertRaises(subprocess.CalledProcessError, self.build)
+
+    def test_debug_info_format(self):
+        testdir = os.path.join(self.unit_test_dir, '102 debug info')
+        env = get_fake_env(testdir, self.builddir, self.prefix)
+        cc = detect_c_compiler(env, MachineChoice.HOST)
+        if cc.get_argument_syntax() != 'msvc':
+            raise SkipTest('Not using MSVC')
+        self.init(testdir)
+        out = self.build()
+        self.assertNotRegex(out, r'warning D9025') #: overriding \'/Zi\' with \'/Z7\'')


### PR DESCRIPTION
Before setting /ZI or /Z7 caused warning D9025 to be emitted for every file. Using /Z7 is required to be able to use sccache or buildcache with MSVC.