### PR TITLE
remove unused environment function

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -888,10 +888,6 @@ class Environment:
     def dump_coredata(self) -> str:
         return coredata.save(self.coredata, self.get_build_dir())
 
-    def get_script_dir(self) -> str:
-        import mesonbuild.scripts
-        return os.path.dirname(mesonbuild.scripts.__file__)
-
     def get_log_dir(self) -> str:
         return self.log_dir
 


### PR DESCRIPTION
The script dir is never really used since meson --internal handles this. The last remaining use of the raw script dir got removed in commit 522392e7553823e6b3ac38cadc4fbee72eae9540.