### PR TITLE
setuptools: don't hardcode list of modules to install, use find_packages

### DIFF
--- a/run_meson_command_tests.py
+++ b/run_meson_command_tests.py
@@ -136,21 +136,6 @@ class CommandTests(unittest.TestCase):
         # Check that all the files were installed correctly
         self.assertTrue(bindir.is_dir())
         self.assertTrue(pylibdir.is_dir())
-        from setup import packages
-        # Extract list of expected python module files
-        expect = set()
-        for pkg in packages:
-            expect.update([p.as_posix() for p in Path(pkg.replace('.', '/')).glob('*.py')])
-        # Check what was installed, only count files that are inside 'mesonbuild'
-        have = set()
-        for p in Path(pylibdir).glob('**/*.py'):
-            s = p.as_posix()
-            if 'mesonbuild' not in s:
-                continue
-            if '/data/' in s:
-                continue
-            have.add(s[s.rfind('mesonbuild'):])
-        self.assertEqual(have, expect)
         # Run `meson`
         os.chdir('/')
         resolved_meson_command = [str(bindir / 'meson')]

--- a/setup.py
+++ b/setup.py
@@ -32,12 +32,11 @@ if sys.platform != 'win32':
     data_files = [('share/man/man1', ['man/meson.1']),
                   ('share/polkit-1/actions', ['data/com.mesonbuild.install.policy'])]
 
-if __name__ == '__main__':
-    setup(name='meson',
-          version=version,
-          packages=find_packages(
-              include=['mesonbuild', 'mesonbuild.*'],
-              exclude=['*.data']
-          ),
-          entry_points=entries,
-          data_files=data_files,)
+setup(name='meson',
+      version=version,
+      packages=find_packages(
+          include=['mesonbuild', 'mesonbuild.*'],
+          exclude=['*.data']
+      ),
+      entry_points=entries,
+      data_files=data_files,)

--- a/setup.py
+++ b/setup.py
@@ -21,23 +21,11 @@ if sys.version_info < (3, 6):
                      '\nMeson requires Python 3.6.0 or greater'.format(sys.version))
 
 from mesonbuild.coredata import version
-from setuptools import setup
+from setuptools import setup, find_packages
 
 # On windows, will create Scripts/meson.exe and Scripts/meson-script.py
 # Other platforms will create bin/meson
 entries = {'console_scripts': ['meson=mesonbuild.mesonmain:main']}
-packages = ['mesonbuild',
-            'mesonbuild.ast',
-            'mesonbuild.backend',
-            'mesonbuild.cmake',
-            'mesonbuild.compilers',
-            'mesonbuild.compilers.mixins',
-            'mesonbuild.dependencies',
-            'mesonbuild.mesonlib',
-            'mesonbuild.modules',
-            'mesonbuild.scripts',
-            'mesonbuild.templates',
-            'mesonbuild.wrap']
 data_files = []
 if sys.platform != 'win32':
     # Only useful on UNIX-like systems
@@ -47,6 +35,9 @@ if sys.platform != 'win32':
 if __name__ == '__main__':
     setup(name='meson',
           version=version,
-          packages=packages,
+          packages=find_packages(
+              include=['mesonbuild', 'mesonbuild.*'],
+              exclude=['*.data']
+          ),
           entry_points=entries,
           data_files=data_files,)


### PR DESCRIPTION
And don't run a pointless test to verify that the hardcoded list has been manually maintained correctly. The same test rules used there can translate directly to find_packages pattern rules.

...

Why do we need this either? find_packages() on its own behaves completely correctly, passing options to it is more explicit but does not actually change anything.