### PR TITLE
stdout content is printed to console again if capture is not enabled

### DIFF
--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -87,6 +87,9 @@ def run_exe(exe: ExecutableSerialisation, extra_env: T.Optional[dict] = None) ->
         if not skip_write:
             with open(exe.capture, 'wb') as output:
                 output.write(stdout)
+    else:
+        if stdout:
+            print(stdout.decode())
 
     return 0
 


### PR DESCRIPTION
stdout content is printed to the console again if capturing to a file is not enabled