### PR TITLE
Add test to build a mixed C/Rust shared library.

### DIFF
--- a/test cases/rust/15 polyglot sharedlib/adder.c
+++ b/test cases/rust/15 polyglot sharedlib/adder.c
@@ -1,0 +1,18 @@
+#include<adder.h>
+#include<stdlib.h>
+
+struct _Adder {
+    int number;
+};
+
+adder* adder_create(int number) {
+    adder *a = malloc(sizeof(struct _Adder));
+    a->number = number;
+    return a;
+}
+
+// adder_add is implemented in the Rust file.
+
+void adder_destroy(adder *a) {
+    free(a);
+}

--- a/test cases/rust/15 polyglot sharedlib/adder.h
+++ b/test cases/rust/15 polyglot sharedlib/adder.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined _WIN32 || defined __CYGWIN__
+  #if defined BUILDING_ADDER
+    #define DLL_PUBLIC __declspec(dllexport)
+  #else
+    #define DLL_PUBLIC __declspec(dllimport)
+  #endif
+#else
+  #if defined __GNUC__
+    #if defined BUILDING_ADDER
+      #define DLL_PUBLIC __attribute__ ((visibility("default")))
+    #else
+      #define DLL_PUBLIC
+    #endif
+  #else
+    #pragma message ("Compiler does not support symbol visibility.")
+    #define DLL_PUBLIC
+  #endif
+#endif
+
+typedef struct _Adder adder;
+
+DLL_PUBLIC extern adder*  adder_create(int number);
+DLL_PUBLIC extern int  adder_add(adder *a, int number);
+DLL_PUBLIC extern void  adder_destroy(adder*);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test cases/rust/15 polyglot sharedlib/adder.rs
+++ b/test cases/rust/15 polyglot sharedlib/adder.rs
@@ -1,0 +1,9 @@
+#[repr(C)]
+pub struct Adder {
+  pub number: i32
+}
+
+#[no_mangle]
+pub extern fn adder_add(a: &Adder, number: i32) -> i32 {
+    return a.number + number;
+}

--- a/test cases/rust/15 polyglot sharedlib/addertest.c
+++ b/test cases/rust/15 polyglot sharedlib/addertest.c
@@ -1,0 +1,12 @@
+#include<stdlib.h>
+#include<adder.h>
+
+int main(int argc, char **argv) {
+    adder *a = adder_create(3);
+    int result = adder_add(a, 4);
+    if(result != 7) {
+        return 1;
+    }
+    adder_destroy(a);
+    return 0;
+}

--- a/test cases/rust/15 polyglot sharedlib/meson.build
+++ b/test cases/rust/15 polyglot sharedlib/meson.build
@@ -1,0 +1,20 @@
+project('adder', 'c', 'rust', version: '1.0.0')
+
+if build_machine.system() != 'linux'
+    error('MESON_SKIP_TEST, this test only works on Linux. Patches welcome.')
+endif
+
+thread_dep = dependency('threads')
+dl_dep = meson.get_compiler('c').find_library('dl', required: false)
+m_dep = meson.get_compiler('c').find_library('m', required: false)
+
+rl = static_library('radder', 'adder.rs', rust_crate_type: 'staticlib')
+
+l = shared_library('adder', 'adder.c',
+    c_args: '-DBUILDING_ADDER',
+    link_with: rl,
+    version: '1.0.0',
+    soversion: '1',
+    link_args: '-Wl,-u,adder_add', # Ensure that Rust code is not removed as unused.
+    dependencies: [thread_dep, dl_dep, m_dep])
+test('adder', executable('addertest', 'addertest.c', link_with: l))


### PR DESCRIPTION
This will probably fail on Windows and macOS. But those platforms probably don't care about this use case so disabling the test there is an option.