### PR TITLE
setuptools: move stuff to declarative cfg if possible

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,6 @@
 [metadata]
+name = meson
+version = attr: mesonbuild.coredata.version
 description = A high performance build system
 author = Jussi Pakkanen
 author_email = jpakkane@gmail.com
@@ -29,16 +31,24 @@ classifiers =
 long_description = Meson is a cross-platform build system designed to be both as fast and as user friendly as possible. It supports many languages and compilers, including GCC, Clang, PGI, Intel, and Visual Studio. Its build definitions are written in a simple non-Turing complete DSL.
 
 [options]
+packages = find:
 python_requires = >= 3.6
 setup_requires =
   setuptools
+
+[options.entry_points]
+console_scripts =
+  meson = mesonbuild.mesonmain:main
 
 [options.extras_require]
 progress =
   tqdm
 
+[options.packages.find]
+include = mesonbuild, mesonbuild.*
+exclude = *.data
+
 [tool:pytest]
 python_classes =
 python_files =
     run_unittests.py
-

--- a/setup.py
+++ b/setup.py
@@ -20,23 +20,12 @@ if sys.version_info < (3, 6):
     raise SystemExit('ERROR: Tried to install Meson with an unsupported Python version: \n{}'
                      '\nMeson requires Python 3.6.0 or greater'.format(sys.version))
 
-from mesonbuild.coredata import version
-from setuptools import setup, find_packages
+from setuptools import setup
 
-# On windows, will create Scripts/meson.exe and Scripts/meson-script.py
-# Other platforms will create bin/meson
-entries = {'console_scripts': ['meson=mesonbuild.mesonmain:main']}
 data_files = []
 if sys.platform != 'win32':
     # Only useful on UNIX-like systems
     data_files = [('share/man/man1', ['man/meson.1']),
                   ('share/polkit-1/actions', ['data/com.mesonbuild.install.policy'])]
 
-setup(name='meson',
-      version=version,
-      packages=find_packages(
-          include=['mesonbuild', 'mesonbuild.*'],
-          exclude=['*.data']
-      ),
-      entry_points=entries,
-      data_files=data_files,)
+setup(data_files=data_files,)


### PR DESCRIPTION
We're down to just declaring the data files in python now.