### PR TITLE
Add a method to the Compiler and Linker objects for rsp syntax

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -34,7 +34,7 @@ if T.TYPE_CHECKING:
     from ..coredata import OptionDictType, KeyedOptionDictType
     from ..envconfig import MachineInfo
     from ..environment import Environment
-    from ..linkers import DynamicLinker  # noqa: F401
+    from ..linkers import DynamicLinker, RSPFileSyntax
     from ..dependencies import Dependency
 
     CompilerType = T.TypeVar('CompilerType', bound=Compiler)
@@ -1216,6 +1216,14 @@ class Compiler(metaclass=abc.ABCMeta):
 
     def get_prelink_args(self, prelink_name: str, obj_list: T.List[str]) -> T.List[str]:
         raise EnvironmentException(f'{self.id} does not know how to do prelinking.')
+
+    def rsp_file_syntax(self) -> 'RSPFileSyntax':
+        """The format of the RSP file that this compiler supports.
+
+        If `self.can_linker_accept_rsp()` returns True, then this needs to
+        be implemented
+        """
+        return self.linker.rsp_file_syntax()
 
 
 def get_global_options(lang: str,

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -17,6 +17,7 @@ import textwrap
 import typing as T
 
 from ..mesonlib import EnvironmentException
+from ..linkers import RSPFileSyntax
 
 from .compilers import Compiler, MachineChoice, mono_buildtype_args
 from .mixins.islinker import BasicLinkerIsCompilerMixin
@@ -125,6 +126,9 @@ class MonoCompiler(CsCompiler):
         super().__init__(exelist, version, for_machine, info, 'mono',
                          runner='mono')
 
+    def rsp_file_syntax(self) -> 'RSPFileSyntax':
+        return RSPFileSyntax.GCC
+
 
 class VisualStudioCsCompiler(CsCompiler):
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
@@ -141,3 +145,6 @@ class VisualStudioCsCompiler(CsCompiler):
                 tmp.append(flag)
             res = tmp
         return res
+
+    def rsp_file_syntax(self) -> 'RSPFileSyntax':
+        return RSPFileSyntax.MSVC

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -18,7 +18,7 @@ import subprocess
 import typing as T
 
 from ..mesonlib import (
-    EnvironmentException, MachineChoice, version_compare, OptionKey,
+    EnvironmentException, MachineChoice, version_compare, OptionKey, is_windows
 )
 
 from ..arglist import CompilerArgs
@@ -36,7 +36,7 @@ if T.TYPE_CHECKING:
     from ..dependencies import Dependency, ExternalProgram
     from ..envconfig import MachineInfo
     from ..environment import Environment
-    from ..linkers import DynamicLinker
+    from ..linkers import DynamicLinker, RSPFileSyntax
 else:
     CompilerMixinBase = object
 
@@ -780,6 +780,12 @@ class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
     def get_disable_assert_args(self) -> T.List[str]:
         return ['--release']
 
+    def rsp_file_syntax(self) -> 'RSPFileSyntax':
+        # We use `mesonlib.is_windows` here because we want to konw what the
+        # build machine is, not the host machine. This really means whe whould
+        # have the Environment not the MachineInfo in the compiler.
+        return RSPFileSyntax.MSVC if is_windows() else RSPFileSyntax.GCC
+
 
 class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
 
@@ -860,3 +866,6 @@ class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
 
     def get_disable_assert_args(self) -> T.List[str]:
         return ['-release']
+
+    def rsp_file_syntax(self) -> 'RSPFileSyntax':
+        return RSPFileSyntax.MSVC

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -22,6 +22,7 @@ from ..mesonlib import (
 )
 
 from ..arglist import CompilerArgs
+from ..linkers import RSPFileSyntax
 from .compilers import (
     d_dmd_buildtype_args,
     d_gdc_buildtype_args,
@@ -36,7 +37,7 @@ if T.TYPE_CHECKING:
     from ..dependencies import Dependency, ExternalProgram
     from ..envconfig import MachineInfo
     from ..environment import Environment
-    from ..linkers import DynamicLinker, RSPFileSyntax
+    from ..linkers import DynamicLinker
 else:
     CompilerMixinBase = object
 
@@ -780,7 +781,7 @@ class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
     def get_disable_assert_args(self) -> T.List[str]:
         return ['--release']
 
-    def rsp_file_syntax(self) -> 'RSPFileSyntax':
+    def rsp_file_syntax(self) -> RSPFileSyntax:
         # We use `mesonlib.is_windows` here because we want to konw what the
         # build machine is, not the host machine. This really means whe whould
         # have the Environment not the MachineInfo in the compiler.
@@ -867,5 +868,5 @@ class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
     def get_disable_assert_args(self) -> T.List[str]:
         return ['-release']
 
-    def rsp_file_syntax(self) -> 'RSPFileSyntax':
+    def rsp_file_syntax(self) -> RSPFileSyntax:
         return RSPFileSyntax.MSVC

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -2061,7 +2061,7 @@ class Environment:
             if 'DMD32 D Compiler' in out or 'DMD64 D Compiler' in out:
                 return DLinker(linker, compiler.arch)
             if 'LDC - the LLVM D compiler' in out:
-                return DLinker(linker, compiler.arch)
+                return DLinker(linker, compiler.arch, rsp_syntax=compiler.rsp_file_syntax())
             if 'GDC' in out and ' based on D ' in out:
                 return DLinker(linker, compiler.arch)
             if err.startswith('Renesas') and ('rlink' in linker or 'rlink.exe' in linker):


### PR DESCRIPTION
Since this really is something about the compilers and linkers themselves, the information should be encoded there.

Fixes  #8502