### PR TITLE
compilers: clang-cl: Also accept .s files

### DIFF
--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -412,6 +412,9 @@ class ClangClCompiler(VisualStudioLikeCompiler):
         super().__init__(target)
         self.id = 'clang-cl'
 
+        # Assembly
+        self.can_compile_suffixes.add('s')
+
     def has_arguments(self, args: T.List[str], env: 'Environment', code: str, mode: str) -> T.Tuple[bool, bool]:
         if mode != 'link':
             args = args + ['-Werror=unknown-argument']

--- a/test cases/common/128 generated assembly/meson.build
+++ b/test cases/common/128 generated assembly/meson.build
@@ -6,8 +6,23 @@ if build_machine.system() == 'cygwin'
   error('MESON_SKIP_TEST: Cygwin is broken and nobody knows how to fix it. Patches welcome.')
 endif
 
-if ['msvc', 'clang-cl', 'intel-cl'].contains(cc.get_id())
+if ['msvc', 'intel-cl'].contains(cc.get_id())
   error('MESON_SKIP_TEST: assembly files cannot be compiled directly by the compiler')
+endif
+
+crt_workaround = []
+if cc.get_linker_id() == 'lld-link'
+  # It seems that when building without a .c file, lld-link.exe
+  # misses the fact that it needs to include the c runtime to
+  # make a working .dll. So here we add an empty .c file to easily
+  # pull in crt.
+  crt_workaround += 'empty.c'
+  if host_machine.cpu_family() == 'x86'
+    # x86 assembly needs manual annotation to be compatible with
+    # Safe Exception Handlers (?) This assembly doesn't have such
+    # annotation, so just disable the feature.
+    add_project_link_arguments('/SAFESEH:NO', language : 'c')
+  endif
 endif
 
 cpu = host_machine.cpu_family()
@@ -15,6 +30,11 @@ supported_cpus = ['arm', 'x86', 'x86_64']
 
 if not supported_cpus.contains(cpu)
   error('MESON_SKIP_TEST: unsupported cpu family: ' + cpu)
+endif
+
+if cc.get_id() == 'clang-cl' and cc.version().version_compare('< 12.0.0') and cpu == 'arm'
+  # https://reviews.llvm.org/D89622
+  error('MESON_SKIP_TEST: arm debug symbols not supported in clang-cl < 12.0.0')
 endif
 
 if cc.symbols_have_underscore_prefix()
@@ -29,7 +49,8 @@ copygen = generator(copy,
   arguments : ['@INPUT@', '@OUTPUT@'],
   output : '@BASENAME@')
 
-l = shared_library('square-gen', copygen.process(input))
+l = shared_library('square-gen', crt_workaround + [copygen.process(input)],
+  vs_module_defs: 'square.def')
 
 test('square-gen-test', executable('square-gen-test', 'main.c', link_with : l))
 
@@ -38,6 +59,7 @@ copyct = custom_target('square',
   output : output,
   command : [copy, '@INPUT@', '@OUTPUT@'])
 
-l = shared_library('square-ct', copyct)
+l = shared_library('square-ct', crt_workaround + [copyct],
+  vs_module_defs: 'square.def')
 
 test('square-ct-test', executable('square-ct-test', 'main.c', link_with : l))

--- a/test cases/common/128 generated assembly/square-x86.S.in
+++ b/test cases/common/128 generated assembly/square-x86.S.in
@@ -1,6 +1,6 @@
 #include "symbol-underscore.h"
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 
 .386
 .MODEL FLAT, C

--- a/test cases/common/128 generated assembly/square-x86_64.S.in
+++ b/test cases/common/128 generated assembly/square-x86_64.S.in
@@ -1,6 +1,6 @@
 #include "symbol-underscore.h"
 
-#ifdef _MSC_VER /* MSVC on Windows */
+#if defined(_MSC_VER) && !defined(__clang__) /* MSVC on Windows */
 
 PUBLIC SYMBOL_NAME(square_unsigned)
 _TEXT   SEGMENT

--- a/test cases/common/128 generated assembly/square.def
+++ b/test cases/common/128 generated assembly/square.def
@@ -1,0 +1,2 @@
+EXPORTS
+	square_unsigned


### PR DESCRIPTION
clang-cl has support for gas-compatible assembly files.