### PR TITLE
Allow path separators in output kwargs

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1536,8 +1536,11 @@ class Generator:
             depfile = kwargs['depfile']
             if not isinstance(depfile, str):
                 raise InvalidArguments('Depfile must be a string.')
-            if os.path.basename(depfile) != depfile:
-                raise InvalidArguments('Depfile must be a plain filename without a subdirectory.')
+            deppath = pathlib.PurePath(depfile)
+            if deppath.is_absolute():
+                raise InvalidArguments('Depfile must not be an absolute path')
+            if '..' in deppath.parts:
+                raise InvalidArguments('Depfile must not contain ".."')
             self.depfile = depfile
         if 'capture' in kwargs:
             capture = kwargs['capture']
@@ -2286,8 +2289,11 @@ class CustomTarget(Target, CommandBase):
                 raise InvalidArguments('Output must not be empty.')
             if i.strip() == '':
                 raise InvalidArguments('Output must not consist only of whitespace.')
-            if has_path_sep(i):
-                raise InvalidArguments(f'Output {i!r} must not contain a path segment.')
+            ipath = pathlib.PurePath(i)
+            if ipath.is_absolute():
+                raise InvalidArguments('Output must not be an absolute path')
+            if '..' in ipath.parts:
+                raise InvalidArguments('Output path must not contain ".."')
             if '@INPUT@' in i or '@INPUT0@' in i:
                 m = 'Output cannot contain @INPUT@ or @INPUT0@, did you ' \
                     'mean @PLAINNAME@ or @BASENAME@?'


### PR DESCRIPTION
Path separators in output kwargs is very important for allowing Meson to wrap other tooling/compilers. Take for instance Meson wrapping Maven. This may sound kind of crazy, but imagine a C library and you are writing JNI bindings for it. There are essentially 2 build artifacts that you need to generate: a JNI library written in C and a JAR written in Java. In my case, errors in the C library exist as what are essentially errno values. I decided to pull in a dependency from Maven Central which provides errno values in Java-land. Manual management of the class path can be quite difficult and tedious among other things when reaching for `javac` directly. I decided to use Maven to compile the Java sources and create a JAR. What I essentially want is a one step process to build both my JNI library and the JAR (`ninja -C build`). Maven produces many artifacts in many different folders. Just off the top of my head, if you didn't care about any of the other build artifacts, Maven produces the JAR in the root of its build directory, and *.class files in the a subdir called `classes`. In order to properly model Maven in Meson, I need access to path separators in output kwargs. I have tested this patch locally on my system, and it works great.

Not entirely sure what the best way to add a test is.

Ninja: 1.10
Meson: master

Fixes #2320 