### PR TITLE
externalproject: misc stuff

### DIFF
--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -92,7 +92,7 @@ class ExternalProject(InterpreterObject):
 
         d = [('PREFIX', '--prefix=@PREFIX@', self.prefix.as_posix()),
              ('LIBDIR', '--libdir=@PREFIX@/@LIBDIR@', self.libdir.as_posix()),
-             ('INCLUDEDIR', '--includedir=@PREFIX@/@INCLUDEDIR@', self.includedir.as_posix()),
+             ('INCLUDEDIR', None, self.includedir.as_posix()),
              ]
         self._validate_configure_options(d)
 
@@ -140,6 +140,8 @@ class ExternalProject(InterpreterObject):
         # Ensure the user at least try to pass basic info to the build system,
         # like the prefix, libdir, etc.
         for key, default, val in variables:
+            if default is None:
+                continue
             key_format = f'@{key}@'
             for option in self.configure_options:
                 if key_format in option:

--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -59,13 +59,13 @@ class ExternalProject(InterpreterObject):
         self.verbose = verbose
         self.user_env = env
 
-        self.name = self.subdir.name
         self.src_dir = Path(self.env.get_source_dir(), self.subdir)
         self.build_dir = Path(self.env.get_build_dir(), self.subdir, 'build')
         self.install_dir = Path(self.env.get_build_dir(), self.subdir, 'dist')
         self.prefix = Path(self.env.coredata.get_option(OptionKey('prefix')))
         self.libdir = Path(self.env.coredata.get_option(OptionKey('libdir')))
         self.includedir = Path(self.env.coredata.get_option(OptionKey('includedir')))
+        self.name = self.src_dir.name
 
         # On Windows if the prefix is "c:/foo" and DESTDIR is "c:/bar", `make`
         # will install files into "c:/bar/c:/foo" which is an invalid path.


### PR DESCRIPTION
commit 85011f01be75546718fbf8f11d755e449edf2ecf

    externalproject: Flatten configure_options kwarg

commit 65b323e4c053fbc258f127ee900ba8df47807914

    externalproject: Do not add --includedir by default
    
    Some projects (e.g. OpenSSL) does not support setting include directory
    at all.

commit 1174973bd2db35fd13931a802b4ba23fe57bf027

    externalproject: Fix error when used from main project

