### PR TITLE
Warn when grabbing internals of subprojects with include_directories.

### DIFF
--- a/test cases/common/240 includedir violation/meson.build
+++ b/test cases/common/240 includedir violation/meson.build
@@ -1,0 +1,7 @@
+project('foo', 'c')
+
+# This is here rather than in failing because this needs a
+# transition period to avoid breaking existing projects.
+# Once this becomes an error, move this under failing tests.
+
+inc = include_directories('subprojects/sub/include')

--- a/test cases/common/240 includedir violation/subprojects/sub/include/placeholder.h
+++ b/test cases/common/240 includedir violation/subprojects/sub/include/placeholder.h
@@ -1,0 +1,3 @@
+#pragma once
+
+// Git can not handle empty directories, so there must be something here.

--- a/test cases/common/240 includedir violation/subprojects/sub/meson.build
+++ b/test cases/common/240 includedir violation/subprojects/sub/meson.build
@@ -1,0 +1,3 @@
+project('subproj', 'c')
+
+# This is never actually executed, just here for completeness.

--- a/test cases/common/240 includedir violation/test.json
+++ b/test cases/common/240 includedir violation/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "WARNING: include_directories sandbox violation!"
+    }
+  ]
+}


### PR DESCRIPTION
And again we find that if something is possible, no matter how wrong, someone will do it.