### PR TITLE
msetup: do not print bogus "Option ... is:" messages

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2429,7 +2429,12 @@ class Interpreter(InterpreterBase):
     def get_non_matching_default_options(self) -> T.Iterator[T.Tuple[str, str, coredata.UserOption]]:
         for def_opt_name, def_opt_value in self.project_default_options.items():
             cur_opt_value = self.coredata.options.get(def_opt_name)
-            if cur_opt_value is not None and def_opt_value != cur_opt_value.value:
+            try:
+                if cur_opt_value is not None and cur_opt_value.validate_value(def_opt_value) != cur_opt_value.value:
+                    yield (str(def_opt_name), def_opt_value, cur_opt_value)
+            except mesonlib.MesonException:
+                # Since the default value does not validate, it cannot be in use
+                # Report the user-specified value as non-matching
                 yield (str(def_opt_name), def_opt_value, cur_opt_value)
 
     def build_func_dict(self):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4002,7 +4002,8 @@ class AllPlatformTests(BasePlatformTests):
 
         # Verify default values when passing no args that affect the
         # configuration, and as a bonus, test that --profile-self works.
-        self.init(testdir, extra_args=['--profile-self', '--fatal-meson-warnings'])
+        out = self.init(testdir, extra_args=['--profile-self', '--fatal-meson-warnings'])
+        self.assertNotIn('[default: true]', out)
         obj = mesonbuild.coredata.load(self.builddir)
         self.assertEqual(obj.options[OptionKey('default_library')].value, 'static')
         self.assertEqual(obj.options[OptionKey('warning_level')].value, '1')


### PR DESCRIPTION
`get_non_matching_default_options` is checking a string from `project_default_options` against a validated value from `coredata.options`.

Passing the string to validate_value ensures that the comparison is sound; otherwise, `'false'` might be compared against `False`
and a bogus difference is printed.

Would be nice to have in 0.57.2 (QEMU is seeing this now that we can set `b_staticpic` to false in the default options).