### PR TITLE
coredata: be more robust on unpickling errors

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -943,7 +943,7 @@ def load(build_dir: str) -> CoreData:
             obj = pickle.load(f)
     except (pickle.UnpicklingError, EOFError):
         raise MesonException(load_fail_msg)
-    except AttributeError:
+    except (ModuleNotFoundError, AttributeError):
         raise MesonException(
             "Coredata file {!r} references functions or classes that don't "
             "exist. This probably means that it was generated with an old "


### PR DESCRIPTION
When reverting from 0.57 to 0.56, one can see an error like this:

```
  File /Users/pm215/src/qemu-for-merges/meson/mesonbuild/coredata.py,
line 1016, in load
    obj = pickle.load(f)
ModuleNotFoundError: No module named 'mesonbuild.mesonlib.universal';
'mesonbuild.mesonlib' is not a package
FAILED: build.ninja
```

The reason is that the old version fails to resolve mesonbuild.mesonlib, which is a similar situation to the existing AttributeError check.  Raise a MesonException for ModuleNotFoundError as well, so that reconfiguration proceeds using cmd_line.txt.