### PR TITLE
msubprojects: wrap-file should be re-extracted with --reset

### DIFF
--- a/docs/markdown/Subprojects.md
+++ b/docs/markdown/Subprojects.md
@@ -310,7 +310,8 @@ To pull latest version of all your subprojects at once, just run the command:
 - If the wrap file comes from wrapdb, the latest version of the wrap file will
   be pulled and used next time meson reconfigure the project. This can be
   triggered using `meson --reconfigure`. Previous source tree is not deleted, to
-  prevent from any loss of local changes.
+  prevent from any loss of local changes. *Since 0.58.0* If `--reset` is
+  specified, the source tree is deleted and new source is extracted.
 - If subproject is currently in detached mode, a checkout of the revision from
   wrap file is performed. *Since 0.56.0* a rebase is also performed in case the
   revision already existed locally but was outdated. If `--reset` is specified,

--- a/docs/markdown/snippets/subprojects_update.md
+++ b/docs/markdown/snippets/subprojects_update.md
@@ -1,0 +1,8 @@
+## `meson subprojects update --reset` now re-extract tarballs
+
+When using `--reset` option, the source tree of `[wrap-file]` subprojects is now
+deleted and re-extracted from cached tarballs, or re-downloaded. This is because
+Meson has no way to know if the source tree or the wrap file has been modified,
+and `--reset` should guarantee that latest code is being used on next reconfigure.
+
+Use `--reset` with caution if you do local changes on non-git subprojects.


### PR DESCRIPTION
When using --reset we should guarantee that next reconfigure will pick
the latest code. For wrap-file we have no way to know if the revision
changed, so we have to delete the source tree and extract again.

It is unlikely that user has local changes in non-git subprojects, and
--reset is known to be dangerous.