### PR TITLE
Tests: add (broken) override_options test case

### DIFF
--- a/run_unittests.py
+++ b/run_unittests.py
@@ -7915,6 +7915,18 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertEqual(len(obj_files), 1)
         self.assertTrue(obj_files[0].endswith('-prelink.o'))
 
+    @skipIfNoPkgconfig
+    def test_override_options_cpp_std(self):
+        '''
+        Tests that a cpp_std passed through override_options takes
+        precedence over a different -std retrieved from a pkg-config
+        dependency
+        '''
+        testdir = os.path.join(self.unit_test_dir, '94 override_options cpp_std')
+        self.init(testdir, override_envvars={'PKG_CONFIG_PATH': testdir})
+        self.build()
+
+
 class BaseLinuxCrossTests(BasePlatformTests):
     # Don't pass --libdir when cross-compiling. We have tests that
     # check whether meson auto-detects it correctly.

--- a/test cases/unit/94 override_options cpp_std/meson.build
+++ b/test cases/unit/94 override_options cpp_std/meson.build
@@ -1,0 +1,5 @@
+project('override_options_std_cpp', 'cpp')
+
+dep = dependency('std_cpp_11')
+
+executable('prog', 'prog.cpp', dependencies : [dep], override_options : ['cpp_std=c++17'])

--- a/test cases/unit/94 override_options cpp_std/prog.cpp
+++ b/test cases/unit/94 override_options cpp_std/prog.cpp
@@ -1,0 +1,14 @@
+#include <cstdio>
+#include <string>
+#include <variant>
+
+struct Error {
+    std::string name;
+};
+
+using Result = std::variant<bool, const Error>;
+
+int main (int ac, char **av)
+{
+  return 0;
+}

--- a/test cases/unit/94 override_options cpp_std/std_cpp_11.pc
+++ b/test cases/unit/94 override_options cpp_std/std_cpp_11.pc
@@ -1,0 +1,7 @@
+prefix=/foo
+libdir=${prefix}/dummy
+
+Name: std_cpp_1
+Description: Nonexisting lib but specifies a C++ standard
+Version: 1.0.0
+Cflags: -std=c++11


### PR DESCRIPTION
This reproduces a case I encountered in a project, where a pkg-config
dependency (aws-cpp-sdk-s3) has -std=c++11 in its cflags, but the
project uses c++17 features and passes -std=c++17 through
override_options.

The final compile command has c++17 before c++11, causing compilation
to fail.