### PR TITLE
minstall: always track meson-created directories

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -292,10 +292,6 @@ class Installer:
         # ['sub1', ...] means skip only those.
         self.skip_subprojects = [i.strip() for i in options.skip_subprojects.split(',')]
 
-    def mkdir(self, *args: T.Any, **kwargs: T.Any) -> None:
-        if not self.dry_run:
-            os.mkdir(*args, **kwargs)
-
     def remove(self, *args: T.Any, **kwargs: T.Any) -> None:
         if not self.dry_run:
             os.remove(*args, **kwargs)
@@ -479,7 +475,7 @@ class Installer:
                     sys.exit(1)
                 parent_dir = os.path.dirname(abs_dst)
                 if not os.path.isdir(parent_dir):
-                    self.mkdir(parent_dir)
+                    dm.makedirs(parent_dir)
                     self.copystat(os.path.dirname(abs_src), parent_dir)
                 # FIXME: what about symlinks?
                 self.do_copyfile(abs_src, abs_dst)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -2496,6 +2496,7 @@ class AllPlatformTests(BasePlatformTests):
 
     def test_uninstall(self):
         exename = os.path.join(self.installdir, 'usr/bin/prog' + exe_suffix)
+        dirname = os.path.join(self.installdir, 'usr/share/dir')
         testdir = os.path.join(self.common_test_dir, '8 install')
         self.init(testdir)
         self.assertPathDoesNotExist(exename)
@@ -2503,6 +2504,7 @@ class AllPlatformTests(BasePlatformTests):
         self.assertPathExists(exename)
         self.uninstall()
         self.assertPathDoesNotExist(exename)
+        self.assertPathDoesNotExist(dirname)
 
     def test_forcefallback(self):
         testdir = os.path.join(self.unit_test_dir, '31 forcefallback')

--- a/test cases/common/8 install/gendir.py
+++ b/test cases/common/8 install/gendir.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+import sys, os
+
+dirname = sys.argv[1]
+fname = os.path.join(dirname, 'file.txt')
+os.makedirs(dirname, exist_ok=True)
+open(fname, 'w').close()

--- a/test cases/common/8 install/meson.build
+++ b/test cases/common/8 install/meson.build
@@ -2,3 +2,9 @@ project('install test', 'c', default_options : ['libdir=libtest'])
 
 stlib = static_library('stat', 'stat.c', install : true)
 exe = executable('prog', 'prog.c', install : true)
+
+dirtarget = custom_target('dirtarget',
+  output: ['dir'],
+  install: true,
+  command: [find_program('gendir.py'), '@OUTPUT@'],
+  install_dir: get_option('datadir'))

--- a/test cases/common/8 install/test.json
+++ b/test cases/common/8 install/test.json
@@ -1,8 +1,9 @@
 {
   "installed": [
-    { "type": "exe",  "file": "usr/bin/prog"          },
-    { "type": "pdb",  "file": "usr/bin/prog"          },
-    { "type": "file", "file": "usr/libtest/libstat.a" }
+    { "type": "exe",  "file": "usr/bin/prog"           },
+    { "type": "pdb",  "file": "usr/bin/prog"           },
+    { "type": "file", "file": "usr/share/dir/file.txt" },
+    { "type": "file", "file": "usr/libtest/libstat.a"  }
   ],
   "do_not_set_opts": ["libdir"]
 }


### PR DESCRIPTION
If a custom_target output is a directory, we install it as a directory, not as a file. And, we try to track subdirectories which are created so uninstalling works. But one directory creation did not go through DirMaker, in the case where the output directory does not have any further subdirectories.

Consolidate on makedirs, since I don't see much point in using os.mkdir right here.

Discovered while investigating https://github.com/DISTRHO/DISTRHO-Ports/issues/83