### PR TITLE
cmd_line_file.txt: Use cross/native file path resolved by coredata

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -905,9 +905,9 @@ def write_cmd_line_file(build_dir: str, options: argparse.Namespace) -> None:
 
     properties = OrderedDict()
     if options.cross_file:
-        properties['cross_file'] = [os.path.abspath(f) for f in options.cross_file]
+        properties['cross_file'] = options.cross_file
     if options.native_file:
-        properties['native_file'] = [os.path.abspath(f) for f in options.native_file]
+        properties['native_file'] = options.native_file
 
     config['options'] = {str(k): str(v) for k, v in options.cmd_line_options.items()}
     config['properties'] = properties

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -246,6 +246,10 @@ class MesonApp:
             b.devenv.append(intr.backend.get_devenv())
             build.save(b, dumpfile)
             if env.first_invocation:
+                # Use path resolved by coredata because they could have been
+                # read from a pipe and wrote into a private file.
+                self.options.cross_file = env.coredata.cross_files
+                self.options.native_file = env.coredata.config_files
                 coredata.write_cmd_line_file(self.build_dir, self.options)
             else:
                 coredata.update_cmd_line_file(self.build_dir, self.options)


### PR DESCRIPTION
This fix issue when using --wipe and the machine file was passed as a
pipe and written locally, or when the file was resolved in XDG_DATA_HOME
or XDG_DATA_DIRS.

Fixes: #8560