### PR TITLE
Fix spurious sandbox violation warning

### DIFF
--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -4601,7 +4601,7 @@ different subdirectory.
 ''')
             else:
                 try:
-                    self.validate_within_subproject(a, '')
+                    self.validate_within_subproject(self.subdir, a)
                 except InterpreterException:
                     mlog.warning('include_directories sandbox violation!')
                     print(f'''The project is trying to access the directory {a} which belongs to a different
@@ -4830,6 +4830,8 @@ Try setting b_lundef to false instead.'''.format(self.coredata.options[OptionKey
             # /opt/vendorsdk/src/file_with_license_restrictions.c
             return
         project_root = Path(srcdir, self.root_subdir)
+        if norm == project_root:
+            return
         if project_root not in norm.parents:
             raise InterpreterException(f'Sandbox violation: Tried to grab {inputtype} {norm.name} outside current (sub)project.')
         if project_root / self.subproject_dir in norm.parents:

--- a/test cases/common/240 includedir violation/meson.build
+++ b/test cases/common/240 includedir violation/meson.build
@@ -1,5 +1,9 @@
 project('foo', 'c')
 
+# It is fine to include the root source dir
+include_directories('.')
+subproject('sub')
+
 # This is here rather than in failing because this needs a
 # transition period to avoid breaking existing projects.
 # Once this becomes an error, move this under failing tests.

--- a/test cases/common/240 includedir violation/subprojects/sub/meson.build
+++ b/test cases/common/240 includedir violation/subprojects/sub/meson.build
@@ -1,3 +1,3 @@
 project('subproj', 'c')
 
-# This is never actually executed, just here for completeness.
+include_directories('.')

--- a/test cases/common/240 includedir violation/test.json
+++ b/test cases/common/240 includedir violation/test.json
@@ -1,7 +1,9 @@
 {
   "stdout": [
     {
-      "line": "WARNING: include_directories sandbox violation!"
+      "line": ".*WARNING: include_directories sandbox violation!",
+      "match": "re",
+      "count": 1
     }
   ]
 }


### PR DESCRIPTION
commit 366fa781fd95db80908856f6b75c3214d67b29f5

    interpreter: Fix spurious warning in include_directories()
    
    When doing include_directories('.') at the root of the subproject we
    should not warn about sandboxing violation.

commit 00020a34de5ef6b0c4d32e60a0b65a75e800ff0c

    test.json: Add support for not matching stdout lines
    
    By default expected line must be matched in order. When an expected line
    is matched it does not matter if it's matched again later or not.
    
    When defining "count", it means that line must be matched exactly that
    many times before matching the next expected line. Once all occurences
    have been matched for an expected line, it not must appear any more in
    all next lines.

commit 29f700e6b3ff0bb6d8de2142437834c9de291b55

    run_project_tests.py: Allow "--only common/240" syntax
