### PR TITLE
windows_proof_rmtree: Also retry os.chmod() part

### DIFF
--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -1530,9 +1530,16 @@ def windows_proof_rmtree(f: str) -> None:
     # be scanning files you are trying to delete. The only
     # way to fix this is to try again and again.
     delays = [0.1, 0.1, 0.2, 0.2, 0.2, 0.5, 0.5, 1, 1, 1, 1, 2]
-    # Start by making the tree wriable.
-    _make_tree_writable(f)
+    writable = False
     for d in delays:
+        try:
+            # Start by making the tree writable.
+            if not writable:
+                _make_tree_writable(f)
+                writable = True
+        except PermissionError:
+            time.sleep(d)
+            continue
         try:
             shutil.rmtree(f)
             return


### PR DESCRIPTION
It looks like when Windows media scanner holds files we can't change
their permission neither.