### PR TITLE
Add Zig language support

### DIFF
--- a/ci/ciimage/arch/install.sh
+++ b/ci/ciimage/arch/install.sh
@@ -12,7 +12,7 @@ pkgs=(
   itstool gtk3 java-environment=8 gtk-doc llvm clang sdl2 graphviz
   doxygen vulkan-validation-layers openssh mercurial gtk-sharp-2 qt5-tools
   libwmf valgrind cmake netcdf-fortran openmpi nasm gnustep-base gettext
-  python-lxml hotdoc rust-bindgen qt6-base qt6-tools
+  python-lxml hotdoc rust-bindgen qt6-base qt6-tools zig curl
   # cuda
 )
 

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -34,6 +34,7 @@ These are return values of the `get_id` (Compiler family) and
 | sun       | Sun Fortran compiler             |                 |
 | valac     | Vala compiler                    |                 |
 | xc16      | Microchip XC16 C compiler        |                 |
+| zig       | Zig compiler                     |                 |
 
 ## Linker ids
 
@@ -159,6 +160,7 @@ These are the parameter names for passing language specific arguments to your bu
 | Objective C++ | objcpp_args   | objcpp_link_args  |
 | Rust          | rust_args     | rust_link_args    |
 | Vala          | vala_args     | vala_link_args    |
+| Zig           | zig_args      |                   |
 
 All these `<lang>_*` options are specified per machine. See in
 [specifying options per

--- a/docs/markdown/snippets/zig_language_support.md
+++ b/docs/markdown/snippets/zig_language_support.md
@@ -1,0 +1,5 @@
+## Basic support for the Zig language
+
+Meson now supports the compilation of basic Zig
+programs. Support for more advanced scenarios
+is not implemented yet.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1706,12 +1706,12 @@ int dummy;
         # Zig uses different subcommands for executables and libraries,
         # shared libraries are selected via the -dynamic flag
         if isinstance(target, build.Executable):
-            args.append('build-exe')
+            args += ['build-exe']
             args += zig.get_win_subsystem_args(target.win_subsystem)
             if has_shared_deps:
                 args += zig.get_pic_args()
         elif isinstance(target, build.StaticLibrary):
-            args.append('build-lib')
+            args += ['build-lib']
         elif isinstance(target, build.SharedLibrary):
             args += ['build-lib']
             args += zig.get_std_shared_lib_link_args()
@@ -1759,7 +1759,6 @@ int dummy;
                 args += [f'-l{ldir.join([d.get_filename()])}']
                 if d.should_install():
                     idir, _ = d.get_install_dir(self.environment)
-                    raise MesonException(f'{idir}')
                     args += ['-rpath', idir[0]]
                 else:
                     args += ['-rpath', ldir]

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -23,6 +23,7 @@ import itertools
 from pathlib import PurePath, Path
 from functools import lru_cache
 
+from .. import dependencies
 from . import backends
 from .. import modules
 from .. import environment, mesonlib
@@ -720,6 +721,9 @@ int dummy;
             return
         if 'swift' in target.compilers:
             self.generate_swift_target(target)
+            return
+        if 'zig' in target.compilers:
+            self.generate_zig_target(target)
             return
 
         # Now we handle the following languages:
@@ -1674,6 +1678,110 @@ int dummy;
             self.generate_shsym(target)
         self.create_target_source_introspection(target, rustc, args, [main_rust_file], [])
 
+    def generate_zig_target(self, target: build.BuildTarget):
+        zig = target.compilers['zig']
+        args = zig.compiler_args()
+
+        target_name = os.path.join(target.subdir, target.get_filename())
+        base_proxy = self.get_base_options_for_target(target)
+
+        # Adapted from the rust target generation logic, Zig behaves similarly
+        # in that it can work off of a single, so called "root source file" that
+        # imports other project source files
+        root_src_file = None
+        for i in target.get_sources():
+            if not zig.can_compile(i):
+                raise InvalidArguments(f'Zig target {target.get_basename()} contains a non-zig source file.')
+            if root_src_file is None:
+                root_src_file = i.rel_to_builddir(self.build_to_src)
+
+        if root_src_file is None:
+            raise MesonException('A Zig target has no Zig sources. This is weird. Also a bug. Please report')
+
+        has_shared_deps = False
+        for dep in target.get_dependencies():
+            if isinstance(dep, build.SharedLibrary):
+                has_shared_deps = True
+
+        # Zig uses different subcommands for executables and libraries,
+        # shared libraries are selected via the -dynamic flag
+        if isinstance(target, build.Executable):
+            args.append('build-exe')
+            args += zig.get_win_subsystem_args(target.win_subsystem)
+            if has_shared_deps:
+                args += zig.get_pic_args()
+        elif isinstance(target, build.StaticLibrary):
+            args.append('build-lib')
+        elif isinstance(target, build.SharedLibrary):
+            args += ['build-lib']
+            args += zig.get_std_shared_lib_link_args()
+            args += zig.get_pic_args()
+            args += ['--version', target.ltversion]
+        else:
+            raise InvalidArguments('Unknown target type for zig.')
+
+        # Add built-in options
+        args += compilers.get_base_compile_args(base_proxy, zig)
+
+        # Add otherwise needed flags
+        args += ['--enable-cache', '--cache-dir', self.environment.get_build_dir().join(['zig-cache'])]
+        args += zig.get_optimization_args(self.get_option_for_target(OptionKey('optimization'), target))
+        args += zig.get_output_args(target_name)
+
+        args += target.get_extra_args('zig')
+        args += self.build.get_global_args(zig, target.for_machine)
+        args += self.build.get_project_args(zig, target.subproject, target.for_machine)
+        args += self.environment.coredata.get_external_args(target.for_machine, zig.language)
+
+        # Handle target include directories, adapted from the Swift generation logic
+        for i in reversed(target.get_include_dirs()):
+            basedir = i.get_curdir()
+            for d in i.get_incdirs():
+                if d not in ('', '.'):
+                    expdir = os.path.join(basedir, d)
+                else:
+                    expdir = basedir
+                srctreedir = os.path.normpath(os.path.join(self.environment.get_build_dir(), self.build_to_src, expdir))
+                args += [f'-I{srctreedir}']
+
+        compiler_name = self.get_compiler_rule_name('zig', target.for_machine)
+        element = NinjaBuildElement(self.all_outputs, target_name, compiler_name, root_src_file)
+
+        # Provide the libaries the target links against
+        for d in target.link_targets:
+            reldir = self.get_target_dir(d)
+            if reldir == '':
+                reldir = '.'
+            ldir = os.path.normpath(os.path.join(self.environment.get_build_dir(), reldir))
+            args += [f'-L{ldir}']
+            # Also add shared libraries to rpath
+            if isinstance(d, build.SharedLibrary):
+                args += [f'-l{ldir.join([d.get_filename()])}']
+                if d.should_install():
+                    idir, _ = d.get_install_dir(self.environment)
+                    raise MesonException(f'{idir}')
+                    args += ['-rpath', idir[0]]
+                else:
+                    args += ['-rpath', ldir]
+            else:
+                args += [f'-l{ldir.join([d.name])}']
+            element.add_dep(d.get_filename())
+
+        # Handle external dependencies
+        for d in target.get_external_deps():
+            if isinstance(d, dependencies.platform.AppleFrameworks):
+                args += ['-framework', d.get_name()]
+            else:
+                args += d.get_compile_args()
+                args += d.get_link_args()
+
+        element.add_item('ARGS', args)
+        self.add_build(element)
+
+        # Generate symbol files for runtime linking
+        if isinstance(target, build.SharedLibrary):
+            self.generate_shsym(target)
+
     @staticmethod
     def get_rule_suffix(for_machine: MachineChoice) -> str:
         return PerMachine('_FOR_BUILD', '')[for_machine]
@@ -1873,10 +1981,7 @@ int dummy;
         for for_machine in MachineChoice:
             complist = self.environment.coredata.compilers[for_machine]
             for langname, compiler in complist.items():
-                if langname == 'java' \
-                        or langname == 'vala' \
-                        or langname == 'rust' \
-                        or langname == 'cs':
+                if langname in {'java', 'vala', 'rust', 'zig', 'cs'}:
                     continue
                 rule = '{}_LINKER{}'.format(langname, self.get_rule_suffix(for_machine))
                 command = compiler.get_linker_exelist()
@@ -1934,6 +2039,12 @@ int dummy;
         self.add_rule(NinjaRule(rule, command, [], description, deps=depstyle,
                                 depfile=depfile))
 
+    def generate_zig_compile_rules(self, compiler):
+        rule = self.compiler_to_rule_name(compiler)
+        command = compiler.get_exelist() + ['$ARGS', '$in']
+        description = 'Compiling Zig source $in'
+        self.add_rule(NinjaRule(rule, command, [], description))
+
     def generate_swift_compile_rules(self, compiler):
         rule = self.compiler_to_rule_name(compiler)
         full_exe = self.environment.get_build_command() + [
@@ -1990,6 +2101,9 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             return
         if langname == 'rust':
             self.generate_rust_compile_rules(compiler)
+            return
+        if langname == 'zig':
+            self.generate_zig_compile_rules(compiler)
             return
         if langname == 'swift':
             if self.environment.machines.matches_build_machine(compiler.for_machine):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -62,6 +62,7 @@ lang_arg_kwargs = {
     'rust_args',
     'vala_args',
     'cs_args',
+    'zig_args',
 }
 
 vala_kwargs = {'vala_header', 'vala_gir', 'vala_vapi'}
@@ -103,7 +104,7 @@ known_build_target_kwargs = (
     rust_kwargs |
     cs_kwargs)
 
-known_exe_kwargs = known_build_target_kwargs | {'implib', 'export_dynamic', 'pie'}
+known_exe_kwargs = known_build_target_kwargs | {'implib', 'export_dynamic', 'pie', 'link_script'}
 known_shlib_kwargs = known_build_target_kwargs | {'version', 'soversion', 'vs_module_defs', 'darwin_versions'}
 known_shmod_kwargs = known_build_target_kwargs | {'vs_module_defs'}
 known_stlib_kwargs = known_build_target_kwargs | {'pic', 'prelink'}
@@ -950,14 +951,23 @@ just like those detected with the dependency() function.''')
         for linktarget in lwhole:
             self.link_whole(linktarget)
 
-        c_pchlist, cpp_pchlist, clist, cpplist, cudalist, cslist, valalist,  objclist, objcpplist, fortranlist, rustlist \
-            = [extract_as_list(kwargs, c) for c in ['c_pch', 'cpp_pch', 'c_args', 'cpp_args', 'cuda_args', 'cs_args', 'vala_args', 'objc_args', 'objcpp_args', 'fortran_args', 'rust_args']]
+        c_pchlist, cpp_pchlist, clist, cpplist, cudalist, cslist, valalist, objclist, objcpplist, fortranlist, rustlist, ziglist \
+            = [extract_as_list(kwargs, c) for c in ['c_pch', 'cpp_pch', 'c_args', 'cpp_args', 'cuda_args', 'cs_args', 'vala_args', 'objc_args', 'objcpp_args', 'fortran_args', 'rust_args', 'zig_args']]
 
         self.add_pch('c', c_pchlist)
         self.add_pch('cpp', cpp_pchlist)
-        compiler_args = {'c': clist, 'cpp': cpplist, 'cuda': cudalist, 'cs': cslist, 'vala': valalist, 'objc': objclist, 'objcpp': objcpplist,
-                         'fortran': fortranlist, 'rust': rustlist
-                         }
+        compiler_args = {
+            'c': clist,
+            'cpp': cpplist,
+            'cuda': cudalist,
+            'cs': cslist,
+            'vala': valalist,
+            'objc': objclist,
+            'objcpp': objcpplist,
+            'fortran': fortranlist,
+            'rust': rustlist,
+            'zig': ziglist
+        }
         for key, value in compiler_args.items():
             self.add_compiler_args(key, value)
 
@@ -1734,6 +1744,9 @@ class Executable(BuildTarget):
 
         # Only linkwithable if using export_dynamic
         self.is_linkwithable = self.export_dynamic
+
+        if 'link_script' in self.kwargs:
+            raise MesonException('boom')
 
     def get_default_install_dir(self, environment: environment.Environment) -> str:
         return environment.get_bindir()

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -106,6 +106,7 @@ __all__ = [
     'VisualStudioLikeCompiler',
     'VisualStudioCCompiler',
     'VisualStudioCPPCompiler',
+    'ZigCompiler'
 ]
 
 # Bring symbols from each module into compilers sub-package namespace
@@ -207,6 +208,7 @@ from .objcpp import (
 from .rust import RustCompiler
 from .swift import SwiftCompiler
 from .vala import ValaCompiler
+from .zig import ZigCompiler
 from .mixins.visualstudio import VisualStudioLikeCompiler
 from .mixins.gnu import GnuCompiler, GnuLikeCompiler
 from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -64,6 +64,7 @@ lang_suffixes = {
     'cs': ('cs',),
     'swift': ('swift',),
     'java': ('java',),
+    'zig': ('zig',),
 }  # type: T.Dict[str, T.Tuple[str, ...]]
 all_languages = lang_suffixes.keys()
 cpp_suffixes = lang_suffixes['cpp'] + ('h',)  # type: T.Tuple[str, ...]

--- a/mesonbuild/compilers/zig.py
+++ b/mesonbuild/compilers/zig.py
@@ -25,7 +25,7 @@ from ..mesonlib import MachineChoice, EnvironmentException, MesonException
 if T.TYPE_CHECKING:
     from ..envconfig import MachineInfo
     from ..environment import Environment
-    from ..dependencies import ExternalProgram
+    from ..programs import ExternalProgram
 
 
 zig_optimization_args = {

--- a/mesonbuild/compilers/zig.py
+++ b/mesonbuild/compilers/zig.py
@@ -1,0 +1,115 @@
+# Copyright 2012-2021 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os.path
+import subprocess
+import textwrap
+import typing as T
+
+from .compilers import Compiler
+from .mixins.islinker import BasicLinkerIsCompilerMixin
+
+from ..mesonlib import MachineChoice, EnvironmentException, MesonException
+
+if T.TYPE_CHECKING:
+    from ..envconfig import MachineInfo
+    from ..environment import Environment
+    from ..dependencies import ExternalProgram
+
+
+zig_optimization_args = {
+    '0': [],
+    'g': ['-O', 'Debug'],
+    '1': ['-O', 'ReleaseSafe'],
+    '2': ['-O', 'ReleaseSafe'],
+    '3': ['-O', 'ReleaseFast'],
+    's': ['-O', 'ReleaseSmall'],
+}  # type: T.Dict[str, T.List[str]]
+
+
+class ZigCompiler(BasicLinkerIsCompilerMixin, Compiler):
+    language = 'zig'
+
+    def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, info: 'MachineInfo',
+                 exe_wrapper: T.Optional['ExternalProgram'] = None, is_cross: bool = False):
+        super().__init__(exelist, version, for_machine, info, is_cross=is_cross)
+        self.id = 'zig'
+        self.exe_wrapper = exe_wrapper
+
+    def get_optimization_args(self, optimization_level: str) -> T.List[str]:
+        return zig_optimization_args[optimization_level]
+
+    def get_output_args(self, outputname: str) -> T.List[str]:
+        return [f'-femit-bin={outputname}']
+
+    def get_pic_args(self) -> T.List[str]:
+        return ['-fPIC']
+
+    def get_win_subsystem_args(self, value: str) -> T.List[str]:
+        return ['--subsystem', value]
+
+    def get_colorout_args(self, colortype: str) -> T.List[str]:
+        if colortype == 'auto':
+            return ['--color', 'auto']
+        elif colortype == 'always':
+            return ['--color', 'on']
+        elif colortype == 'never':
+            return ['--color', 'off']
+        else:
+            raise MesonException(f'Invalid color type for zig {colortype}')
+
+    def get_std_shared_lib_link_args(self) -> T.List[str]:
+        return ['-dynamic']
+
+    def needs_static_linker(self) -> bool:
+        return False
+
+    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
+        source_name = os.path.join(work_dir, 'sanity.zig')
+        output_name = os.path.join(work_dir, 'zigtest')
+
+        with open(source_name, 'w') as ofile:
+            ofile.write(textwrap.dedent(
+                '''pub fn main() !void {
+                }
+                '''))
+
+        # Compile the source file to an executable
+        pc = subprocess.Popen(self.exelist + ['build-exe', source_name] + self.get_output_args(output_name),
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE,
+                              cwd=work_dir)
+        _stdo, _stde = pc.communicate()
+        assert isinstance(_stdo, bytes)
+        assert isinstance(_stde, bytes)
+        stdo = _stdo.decode('utf-8', errors='replace')
+        stde = _stde.decode('utf-8', errors='replace')
+
+        # Check if the build was successful
+        if pc.returncode != 0:
+            raise EnvironmentException(f'Zig compiler {self.name_string()} can not compile programs.\n{stdo}\n{stde}')
+
+        if self.is_cross:
+            if self.exe_wrapper is None:
+                # Can't check if the binaries run so we have to assume they do
+                return
+            cmdlist = self.exe_wrapper.get_command() + [output_name]
+        else:
+            cmdlist = [output_name]
+
+        # Check if the built executable is runnable
+        pe = subprocess.Popen(cmdlist, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        pe.wait()
+        if pe.returncode != 0:
+            raise EnvironmentException(f'Executables created by Zig compiler {self.name_string()} are not runnable.')

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -732,6 +732,7 @@ class Environment:
         self.default_rust = ['rustc']
         self.default_swift = ['swiftc']
         self.default_vala = ['valac']
+        self.default_zig = ['zig']
         self.default_static_linker = ['ar', 'gar']
         self.default_strip = ['strip']
         self.vs_static_linker = ['lib']
@@ -1997,6 +1998,24 @@ class Environment:
 
         raise EnvironmentException('Unknown compiler "' + ' '.join(exelist) + '"')
 
+    def detect_zig_compiler(self, for_machine: MachineChoice) -> compilers.ZigCompiler:
+        exelist = self.lookup_binary_entry(for_machine, 'zig')
+        is_cross = self.is_cross_build(for_machine)
+        info = self.machines[for_machine]
+        if exelist is None:
+            exelist = [self.default_zig[0]]
+
+        try:
+            _, ver, _ = Popen_safe(exelist + ['version'])
+        except OSError:
+            raise EnvironmentException('Could not execute Zig compiler "{}"'.format(' '.join(exelist)))
+
+        version = search_version(ver)
+        comp = compilers.ZigCompiler(exelist, version, for_machine, info, self.exe_wrapper, is_cross)
+        self.coredata.add_lang_args(comp.language, compilers.ZigCompiler, for_machine, self)
+
+        return comp
+
     def compiler_from_language(self, lang: str, for_machine: MachineChoice):
         if lang == 'c':
             comp = self.detect_c_compiler(for_machine)
@@ -2022,6 +2041,8 @@ class Environment:
             comp = self.detect_fortran_compiler(for_machine)
         elif lang == 'swift':
             comp = self.detect_swift_compiler(for_machine)
+        elif lang == 'zig':
+            comp = self.detect_zig_compiler(for_machine)
         else:
             comp = None
         return comp

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1777,7 +1777,6 @@ external dependencies (including libraries) must go to "dependencies".''')
     @FeatureNewKwargs('executable', '0.42.0', ['implib'])
     @FeatureNewKwargs('executable', '0.56.0', ['win_subsystem'])
     @FeatureDeprecatedKwargs('executable', '0.56.0', ['gui_app'], extra_message="Use 'win_subsystem' instead.")
-    @FeatureNewKwargs('executable', '0.58.0', ['link_script'])
     @permittedKwargs(permitted_kwargs['executable'])
     def func_executable(self, node, args, kwargs):
         return self.build_target(node, args, kwargs, ExecutableHolder)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1777,6 +1777,7 @@ external dependencies (including libraries) must go to "dependencies".''')
     @FeatureNewKwargs('executable', '0.42.0', ['implib'])
     @FeatureNewKwargs('executable', '0.56.0', ['win_subsystem'])
     @FeatureDeprecatedKwargs('executable', '0.56.0', ['gui_app'], extra_message="Use 'win_subsystem' instead.")
+    @FeatureNewKwargs('executable', '0.58.0', ['link_script'])
     @permittedKwargs(permitted_kwargs['executable'])
     def func_executable(self, node, args, kwargs):
         return self.build_target(node, args, kwargs, ExecutableHolder)

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -510,6 +510,10 @@ class DynamicLinker(metaclass=abc.ABCMeta):
         # only when targeting Windows
         return []
 
+    def get_link_script_args(self, value: str) -> T.List[str]:
+        """Arguments to pass a linker script to the linker."""
+        return []
+
     def bitcode_args(self) -> T.List[str]:
         raise mesonlib.MesonException('This linker does not support bitcode bundles')
 
@@ -703,6 +707,9 @@ class GnuLikeDynamicLinkerMixin:
             args[-1] = args[-1] + ':' + value.split(',')[1]
 
         return self._apply_prefix(args)
+
+    def get_link_script_args(self, value: str) -> T.List[str]:
+        return self._apply_prefix(f"-T,{value}")
 
 
 class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):

--- a/mesonbuild/linkers.py
+++ b/mesonbuild/linkers.py
@@ -510,10 +510,6 @@ class DynamicLinker(metaclass=abc.ABCMeta):
         # only when targeting Windows
         return []
 
-    def get_link_script_args(self, value: str) -> T.List[str]:
-        """Arguments to pass a linker script to the linker."""
-        return []
-
     def bitcode_args(self) -> T.List[str]:
         raise mesonlib.MesonException('This linker does not support bitcode bundles')
 
@@ -707,9 +703,6 @@ class GnuLikeDynamicLinkerMixin:
             args[-1] = args[-1] + ':' + value.split(',')[1]
 
         return self._apply_prefix(args)
-
-    def get_link_script_args(self, value: str) -> T.List[str]:
-        return self._apply_prefix(f"-T,{value}")
 
 
 class AppleDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -55,7 +55,7 @@ from run_tests import guess_backend
 ALL_TESTS = ['cmake', 'common', 'native', 'warning-meson', 'failing-meson', 'failing-build', 'failing-test',
              'keyval', 'platform-osx', 'platform-windows', 'platform-linux',
              'java', 'C#', 'vala',  'rust', 'd', 'objective c', 'objective c++',
-             'fortran', 'swift', 'cuda', 'python3', 'python', 'fpga', 'frameworks', 'nasm', 'wasm'
+             'fortran', 'swift', 'cuda', 'python3', 'python', 'fpga', 'frameworks', 'nasm', 'wasm', 'zig'
              ]
 
 
@@ -1030,6 +1030,7 @@ def detect_tests_to_run(only: T.Dict[str, T.List[str]], use_tmp: bool) -> T.List
         TestCategory('frameworks', 'frameworks'),
         TestCategory('nasm', 'nasm'),
         TestCategory('wasm', 'wasm', shutil.which('emcc') is None or backend is not Backend.ninja),
+        TestCategory('zig', 'zig', shutil.which('zig') is None or backend is not Backend.ninja),
     ]
 
     categories = [t.category for t in all_tests]

--- a/test cases/zig/1 basic/meson.build
+++ b/test cases/zig/1 basic/meson.build
@@ -1,0 +1,5 @@
+project('zigtest-exe', 'zig')
+
+executable('zigtest', 'src/main.zig',
+    zig_args: ['--strip']
+)

--- a/test cases/zig/1 basic/src/main.zig
+++ b/test cases/zig/1 basic/src/main.zig
@@ -1,0 +1,5 @@
+const std = @import("std");
+
+pub fn main() !void {
+    std.debug.print("Hello from {s}!", .{"meson"});
+}

--- a/test cases/zig/2 sharedlib/meson.build
+++ b/test cases/zig/2 sharedlib/meson.build
@@ -1,0 +1,10 @@
+project('zigtest-shared-lib', 'zig')
+
+lib = shared_library('hello', 'src/hello.zig',
+    version: '1.0.0',
+    install: true
+)
+executable('zigtest-shared-lib', 'src/main.zig',
+    link_with: lib,
+    install: true
+)

--- a/test cases/zig/2 sharedlib/src/hello.zig
+++ b/test cases/zig/2 sharedlib/src/hello.zig
@@ -1,0 +1,3 @@
+export fn hello() *const [5:0]u8 {
+    return "meson";
+}

--- a/test cases/zig/2 sharedlib/src/main.zig
+++ b/test cases/zig/2 sharedlib/src/main.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+extern fn hello() *const [5:0]u8;
+
+pub fn main() !void {
+    std.debug.print("Hello from {s}!", .{hello()});
+}

--- a/test cases/zig/2 sharedlib/test.json
+++ b/test cases/zig/2 sharedlib/test.json
@@ -1,0 +1,6 @@
+{
+  "installed": [
+    {"type": "exe", "file": "usr/bin/zigtest-shared-lib"},
+    {"type": "shared_lib", "file": "usr/lib/hello", "version": "1.0.0"}
+  ]
+}

--- a/test cases/zig/3 staticlib/meson.build
+++ b/test cases/zig/3 staticlib/meson.build
@@ -1,0 +1,6 @@
+project('zigtest-static-lib', 'zig')
+
+lib = static_library('hello', 'src/hello.zig')
+executable('zigtest-static-lib', 'src/main.zig',
+    link_with: lib
+)

--- a/test cases/zig/3 staticlib/src/hello.zig
+++ b/test cases/zig/3 staticlib/src/hello.zig
@@ -1,0 +1,3 @@
+export fn hello() *const [5:0]u8 {
+    return "meson";
+}

--- a/test cases/zig/3 staticlib/src/main.zig
+++ b/test cases/zig/3 staticlib/src/main.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+extern fn hello() *const [5:0]u8;
+
+pub fn main() !void {
+    std.debug.print("Hello from {s}!", .{hello()});
+}

--- a/test cases/zig/4 polyglot/meson.build
+++ b/test cases/zig/4 polyglot/meson.build
@@ -1,0 +1,6 @@
+project('zigtest-polyglot', 'c', 'zig')
+
+lib = library('hello', 'src/hello.c')
+executable('zigtest-polyglot', 'src/main.zig',
+    link_with: lib
+)

--- a/test cases/zig/4 polyglot/src/hello.c
+++ b/test cases/zig/4 polyglot/src/hello.c
@@ -1,0 +1,4 @@
+const char *hello(void)
+{
+    return "meson";
+}

--- a/test cases/zig/4 polyglot/src/main.zig
+++ b/test cases/zig/4 polyglot/src/main.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+extern fn hello() *const [5:0]u8;
+
+pub fn main() !void {
+    std.debug.print("Hello from {s}!", .{hello()});
+}

--- a/test cases/zig/5 deps/meson.build
+++ b/test cases/zig/5 deps/meson.build
@@ -1,0 +1,6 @@
+project('zigtest-deps', 'zig')
+
+curl_dep = dependency('libcurl')
+executable('zigtest-deps', 'src/main.zig',
+    dependencies: curl_dep
+)

--- a/test cases/zig/5 deps/src/main.zig
+++ b/test cases/zig/5 deps/src/main.zig
@@ -1,0 +1,12 @@
+const std = @import("std");
+
+const cUrl = @cImport({
+    @cInclude("curl/curl.h");
+});
+
+pub fn main() !void {
+    const handle: ?*cUrl.CURL = cUrl.curl_easy_init();
+    std.debug.print("Hello curl {s} from {s}!", .{cUrl.curl_version(), "meson"});
+
+    cUrl.curl_easy_cleanup(handle);
+}

--- a/test cases/zig/6 incdirs/include/test.h
+++ b/test cases/zig/6 incdirs/include/test.h
@@ -1,0 +1,9 @@
+#ifndef _ZIGTEST_TEST_H
+#define _ZIGTEST_TEST_H
+
+inline const char *hello(void)
+{
+    return "meson";
+}
+
+#endif

--- a/test cases/zig/6 incdirs/meson.build
+++ b/test cases/zig/6 incdirs/meson.build
@@ -1,0 +1,5 @@
+project('zigtest-includedirs', 'zig')
+
+executable('zigtest-includedirs', 'src/main.zig',
+    include_directories: include_directories('include')
+)

--- a/test cases/zig/6 incdirs/src/main.zig
+++ b/test cases/zig/6 incdirs/src/main.zig
@@ -1,0 +1,9 @@
+const std = @import("std");
+
+const cHello = @cImport({
+    @cInclude("test.h");
+});
+
+pub fn main() !void {
+    std.debug.print("Hello from {s}!", .{cHello.hello()});
+}


### PR DESCRIPTION
*Sigh*, hopefully this time around.

I closed the previous iteration (#7984) due to personal time constraints at the time and want to commit
to making this the best I can now. This contains everything the previous iteration had, plus a few
fixes and adjustments to accomodate for changes in Meson.

This will be a draft for now as it's still somewhat of a WIP. I tested a few zig projects from GitHub
and they build nicely. Some things in particular I'd like feedback on:
* The rpath handling - it appears to be working however I'm not sure this is the correct approach.
  In particular the project test `2 sharedlib` is failing during installation, it seems to be a
  `install_name_tool` related failure that I don't really know how to fix (see the logs below)

```
[0/1] Installing files.
Installing libhello.1.dylib to /Users/e820/Developer/meson/i _i1gsgsz/usr/lib
Installing zigtest-shared-lib to /Users/e820/Developer/meson/i _i1gsgsz/usr/bin
FAILED: meson-install
/opt/homebrew/opt/python@3.9/bin/python3.9 /Users/e820/Developer/meson/meson.py install --no-rebuild
ninja: build stopped: subcommand failed.


ninja explain: output libhello.1.dylib doesn't exist
ninja explain: libhello.1.dylib is dirty
ninja explain: libhello.1.dylib is dirty
ninja explain: zigtest-shared-lib is dirty

...

Command '['install_name_tool', '/Users/e820/Developer/meson/i _i1gsgsz/usr/bin/zigtest-shared-lib', '-delete_rpath', '/usr/lib']' returned non-zero exit status 1.
```