### PR TITLE
Per-machine caches that are user accessible should use PerMachineDefaultable

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -206,10 +206,21 @@ class Build:
         self.projects = {}
         self.targets: T.MutableMapping[str, 'Target'] = OrderedDict()
         self.run_target_names: T.Set[T.Tuple[str, str]] = set()
-        self.global_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachine({}, {})
-        self.projects_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachine({}, {})
-        self.global_link_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachine({}, {})
-        self.projects_link_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachine({}, {})
+
+        global_args: PerMachineDefaultable[T.Dict[str, T.List[str]]] = PerMachineDefaultable({})
+        global_link_args: PerMachineDefaultable[T.Dict[str, T.List[str]]] = PerMachineDefaultable({})
+        project_args: PerMachineDefaultable[T.Dict[str, T.List[str]]] = PerMachineDefaultable({})
+        project_link_args: PerMachineDefaultable[T.Dict[str, T.List[str]]] = PerMachineDefaultable({})
+        if environment.is_cross_build():
+            global_args.host = {}
+            global_link_args.host = {}
+            project_args.host = {}
+            project_link_args.host = {}
+        self.global_args = global_args.default_missing()
+        self.projects_args = project_args.default_missing()
+        self.global_link_args = global_link_args.default_missing()
+        self.projects_link_args = project_link_args.default_missing()
+
         self.tests: T.List['Test'] = []
         self.benchmarks: T.List['Test'] = []
         self.headers: T.List[Headers] = []

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -206,21 +206,14 @@ class Build:
         self.projects = {}
         self.targets: T.MutableMapping[str, 'Target'] = OrderedDict()
         self.run_target_names: T.Set[T.Tuple[str, str]] = set()
-
-        global_args: PerMachineDefaultable[T.Dict[str, T.List[str]]] = PerMachineDefaultable({})
-        global_link_args: PerMachineDefaultable[T.Dict[str, T.List[str]]] = PerMachineDefaultable({})
-        project_args: PerMachineDefaultable[T.Dict[str, T.List[str]]] = PerMachineDefaultable({})
-        project_link_args: PerMachineDefaultable[T.Dict[str, T.List[str]]] = PerMachineDefaultable({})
-        if environment.is_cross_build():
-            global_args.host = {}
-            global_link_args.host = {}
-            project_args.host = {}
-            project_link_args.host = {}
-        self.global_args = global_args.default_missing()
-        self.projects_args = project_args.default_missing()
-        self.global_link_args = global_link_args.default_missing()
-        self.projects_link_args = project_link_args.default_missing()
-
+        self.global_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachineDefaultable.default(
+            environment.is_cross_build(), {}, {})
+        self.global_link_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachineDefaultable.default(
+            environment.is_cross_build(), {}, {})
+        self.projects_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachineDefaultable.default(
+            environment.is_cross_build(), {}, {})
+        self.projects_link_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachineDefaultable.default(
+            environment.is_cross_build(), {}, {})
         self.tests: T.List['Test'] = []
         self.benchmarks: T.List['Test'] = []
         self.headers: T.List[Headers] = []
@@ -243,10 +236,8 @@ class Build:
 
         # If we are doing a cross build we need two caches, if we're doing a
         # build == host compilation the both caches should point to the same place.
-        dependency_overrides: PerMachineDefaultable[T.Dict[T.Tuple, DependencyOverride]] = PerMachineDefaultable({})
-        if environment.is_cross_build():
-            dependency_overrides.host = {}
-        self.dependency_overrides = dependency_overrides.default_missing()
+        self.dependency_overrides: PerMachine[T.Dict[T.Tuple, DependencyOverride]] = PerMachineDefaultable.default(
+            environment.is_cross_build(), {}, {})
         self.devenv: T.List[EnvironmentVariables] = []
 
     def get_build_targets(self):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -42,7 +42,7 @@ from .interpreterbase import FeatureNew
 if T.TYPE_CHECKING:
     from .interpreter import Test
     from .mesonlib import FileMode, FileOrString
-    from .mesonlib.backend import Backend
+    from .backend.backends import Backend
 
 pch_kwargs = {'c_pch', 'cpp_pch'}
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -407,11 +407,10 @@ class CoreData:
         self.initialized_subprojects: T.Set[str] = set()
 
         # For host == build configuraitons these caches should be the same.
-        deps: PerMachineDefaultable[DependencyCache] = PerMachineDefaultable(
-            DependencyCache(self.options, MachineChoice.BUILD))
-        if self.is_cross_build():
-            deps.host = DependencyCache(self.options, MachineChoice.HOST)
-        self.deps = deps.default_missing()
+        self.deps: PerMachine[DependencyCache] = PerMachineDefaultable.default(
+            self.is_cross_build(),
+            DependencyCache(self.options, MachineChoice.BUILD),
+            DependencyCache(self.options, MachineChoice.HOST))
 
         self.compiler_check_cache = OrderedDict()  # type: T.Dict[CompilerCheckCacheKey, compiler.CompileResult]
 

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -475,13 +475,18 @@ class ZlibSystemDependency(ExternalDependency):
         # from something to macOS?
         if ((m.is_darwin() and isinstance(self.clib_compiler, (AppleClangCCompiler, AppleClangCPPCompiler))) or
                 m.is_freebsd() or m.is_dragonflybsd()):
-            self.is_found = True
-            self.link_args = ['-lz']
-
             # No need to set includes,
             # on macos xcode/clang will do that for us.
             # on freebsd zlib.h is in /usr/include
+
+            self.is_found = True
+            self.link_args = ['-lz']
         elif m.is_windows():
+            # Without a clib_compiler we can't find zlib, s just give up.
+            if self.clib_compiler is None:
+                self.is_found = False
+                return
+
             if self.clib_compiler.get_argument_syntax() == 'msvc':
                 libs = ['zlib1' 'zlib']
             else:

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -545,6 +545,21 @@ class PerMachineDefaultable(PerMachine[T.Optional[_T]]):
     def __repr__(self) -> str:
         return f'PerMachineDefaultable({self.build!r}, {self.host!r})'
 
+    @classmethod
+    def default(cls, is_cross: bool, build: _T, host: _T) -> PerMachine[_T]:
+        """Easy way to get a defaulted value
+
+        This allows simplifying the case where you can control whether host and
+        build are separate or not with a boolean. If the is_cross value is set
+        to true then the optional host value will be used, otherwise the host
+        will be set to the build value.
+        """
+        m = cls(build)
+        if is_cross:
+            m.host = host
+        return m.default_missing()
+
+
 
 class PerThreeMachineDefaultable(PerMachineDefaultable, PerThreeMachine[T.Optional[_T]]):
     """Extends `PerThreeMachine` with the ability to default from `None`s.

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -531,7 +531,7 @@ class PerMachineDefaultable(PerMachine[T.Optional[_T]]):
     def __init__(self) -> None:
         super().__init__(None, None)
 
-    def default_missing(self) -> "PerMachine[T.Optional[_T]]":
+    def default_missing(self) -> "PerMachine[_T]":
         """Default host to build
 
         This allows just specifying nothing in the native case, and just host in the

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -528,8 +528,8 @@ class PerThreeMachine(PerMachine[_T]):
 class PerMachineDefaultable(PerMachine[T.Optional[_T]]):
     """Extends `PerMachine` with the ability to default from `None`s.
     """
-    def __init__(self) -> None:
-        super().__init__(None, None)
+    def __init__(self, build: T.Optional[_T] = None, host: T.Optional[_T] = None) -> None:
+        super().__init__(build, host)
 
     def default_missing(self) -> "PerMachine[_T]":
         """Default host to build

--- a/test cases/common/241 dependency native host == build/meson.build
+++ b/test cases/common/241 dependency native host == build/meson.build
@@ -1,0 +1,18 @@
+project('foo', 'c')
+
+if meson.is_cross_build()
+  error('MESON_SKIP_TEST Test does not make sense for cross builds')
+endif
+
+dep_zlib = dependency('zlib', required : false)
+if not dep_zlib.found()
+  error('MESON_SKIP_TEST Test requires zlib')
+endif
+dependency('zlib', native : true, required : false)
+dependency('zlib', native : false)
+
+# `native: true` should not make a difference when doing a native build.
+meson.override_dependency('expat', declare_dependency())
+dependency('expat')
+dependency('expat', native : true)
+dependency('expat', native : false)

--- a/test cases/common/241 dependency native host == build/test.json
+++ b/test cases/common/241 dependency native host == build/test.json
@@ -1,0 +1,14 @@
+{
+  "stdout": [
+    {
+      "line": "Dependency zlib found: YES .* \\(cached\\)",
+      "match": "re",
+      "count": 2
+    },
+    {
+      "line": "Dependency expat found: YES .* \\(overridden\\)",
+      "match": "re",
+      "count": 3
+    }
+  ]
+}


### PR DESCRIPTION
For structures that are not exposed to the user it is fine to have completely separate build and host structures, but for anything exposed to the user we need to use PerMachineDefaultable. This is because PerMachine is a host/build separated structure, but meson as a language doesn't expose this, it exposes a native/not native interface.

The implication of this is if a user says `native : true`, that has a different meaning in a cross compile than in a !cross compile, whereas build and host do not. So `depencency('zlib', native : true)` in a cross compile (host != build) means find zlib for the build machine, but in a native build (host == build) then it means get zlib for the host machine. To deal with this, data structures exposed to the user use a Defaultable, which in host == build configurations makes the host and build attributes references to the same object, but in a host != build configuration they are references to separate objects.