### PR TITLE
pkgconfig: Allow setting prefix in dataonly pc file

### DIFF
--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -469,10 +469,12 @@ class PkgConfigModule(ExtensionModule):
             raise mesonlib.MesonException('Too many positional arguments passed to Pkgconfig_gen.')
 
         dataonly = kwargs.get('dataonly', False)
+        if not isinstance(dataonly, bool):
+            raise mesonlib.MesonException('dataonly must be boolean.')
         if dataonly:
             default_subdirs = []
             blocked_vars = ['libraries', 'libraries_private', 'require_private', 'extra_cflags', 'subdirs']
-            if len(set(kwargs) & set(blocked_vars)) > 0:
+            if any(k in kwargs for k in blocked_vars):
                 raise mesonlib.MesonException(f'Cannot combine dataonly with any of {blocked_vars}')
 
         subdirs = mesonlib.stringlistify(kwargs.get('subdirs', default_subdirs))
@@ -519,7 +521,7 @@ class PkgConfigModule(ExtensionModule):
             reserved = ['prefix', 'libdir', 'includedir']
             variables = []
             for name, value in vardict.items():
-                if name in reserved:
+                if not dataonly and name in reserved:
                     raise mesonlib.MesonException(f'Variable "{name}" is reserved')
                 variables.append((name, value))
             return variables

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6444,6 +6444,7 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertEqual(libhello_nolib.get_link_args(), [])
         self.assertEqual(libhello_nolib.get_compile_args(), [])
         self.assertEqual(libhello_nolib.get_pkgconfig_variable('foo', {}), 'bar')
+        self.assertEqual(libhello_nolib.get_pkgconfig_variable('prefix', {}), self.prefix)
 
     def test_pkgconfig_gen_deps(self):
         '''

--- a/test cases/common/45 pkgconfig-gen/meson.build
+++ b/test cases/common/45 pkgconfig-gen/meson.build
@@ -65,7 +65,12 @@ pkgg.generate(
   description : 'A minimalistic pkgconfig file.',
   version : libver,
   dataonly: true,
-  variables : {'foo': 'bar'},
+  variables : {
+    'foo': 'bar',
+    # prefix is not set by default for dataonly pc files, but it is allowed to
+    # define it manually.
+    'prefix': get_option('prefix'),
+  },
 )
 
 # Regression test for 2 cases:


### PR DESCRIPTION
Some variables are reserved because meson set them automatically. But we
are not setting them for dataonly pc files, so there is no reason to
reserve them.

Fixes: #8583.