### PR TITLE
docs: change duplicate "**.h" path to "**.c" [skip ci]

### DIFF
--- a/docs/markdown/Continuous-Integration.md
+++ b/docs/markdown/Continuous-Integration.md
@@ -217,7 +217,7 @@ on:
       - "**.h"
   pull_request:
     paths:
-      - "**.h"
+      - "**.c"
       - "**.h"
 
 jobs:


### PR DESCRIPTION
Hi, spotted this one while learning Meson.