### PR TITLE
Fix _FOR_BUILD env variables

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -798,11 +798,7 @@ class Environment:
 
         env_opts: T.DefaultDict[OptionKey, T.List[str]] = collections.defaultdict(list)
 
-        if self.is_cross_build():
-            for_machine = MachineChoice.BUILD
-        else:
-            for_machine = MachineChoice.HOST
-        for evar, keyname in opts:
+        for (evar, keyname), for_machine in itertools.product(opts, MachineChoice):
             p_env = _get_env_var(for_machine, self.is_cross_build(), evar)
             if p_env is not None:
                 # these may contain duplicates, which must be removed, else
@@ -832,7 +828,7 @@ class Environment:
                             key = key.evolve(lang=lang)
                             env_opts[key].extend(p_list)
                     elif keyname == 'cppflags':
-                        key = OptionKey('args', machine=for_machine, lang='c')
+                        key = OptionKey('env_args', machine=for_machine, lang='c')
                         for lang in compilers.compilers.LANGUAGES_USING_CPPFLAGS:
                             key = key.evolve(lang=lang)
                             env_opts[key].extend(p_list)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -9348,6 +9348,26 @@ class CrossFileTests(BasePlatformTests):
                 break
         self.assertEqual(found, expected, 'Did not find all sections.')
 
+    def test_for_build_env_vars(self) -> None:
+        testcase = os.path.join(self.common_test_dir, '2 cpp')
+        config = self.helper_create_cross_file({'built-in options': {}})
+        cross = self.helper_create_cross_file({'built-in options': {}})
+
+        self.init(testcase, extra_args=['--native-file', config, '--cross-file', cross],
+                  override_envvars={'PKG_CONFIG_PATH': '/bar', 'PKG_CONFIG_PATH_FOR_BUILD': '/dir'})
+        configuration = self.introspect('--buildoptions')
+        found = 0
+        for each in configuration:
+            if each['name'] == 'pkg_config_path':
+                self.assertEqual(each['value'], ['/bar'])
+                found += 1
+            elif each['name'] == 'build.pkg_config_path':
+                self.assertEqual(each['value'], ['/dir'])
+                found += 1
+            if found == 2:
+                break
+        self.assertEqual(found, 2, 'Did not find all sections.')
+
 
 class TAPParserTests(unittest.TestCase):
     def assert_test(self, events, **kwargs):

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -9325,13 +9325,15 @@ class CrossFileTests(BasePlatformTests):
 
     def test_builtin_options_conf_overrides_env(self):
         testcase = os.path.join(self.common_test_dir, '2 cpp')
-        config = self.helper_create_cross_file({'built-in options': {'pkg_config_path': '/native'}})
-        cross = self.helper_create_cross_file({'built-in options': {'pkg_config_path': '/cross'}})
+        config = self.helper_create_cross_file({'built-in options': {'pkg_config_path': '/native', 'cpp_args': '-DFILE'}})
+        cross = self.helper_create_cross_file({'built-in options': {'pkg_config_path': '/cross', 'cpp_args': '-DFILE'}})
 
         self.init(testcase, extra_args=['--native-file', config, '--cross-file', cross],
-                  override_envvars={'PKG_CONFIG_PATH': '/bar', 'PKG_CONFIG_PATH_FOR_BUILD': '/dir'})
+                  override_envvars={'PKG_CONFIG_PATH': '/bar', 'PKG_CONFIG_PATH_FOR_BUILD': '/dir',
+                                    'CXXFLAGS': '-DENV', 'CXXFLAGS_FOR_BUILD': '-DENV'})
         configuration = self.introspect('--buildoptions')
         found = 0
+        expected = 4
         for each in configuration:
             if each['name'] == 'pkg_config_path':
                 self.assertEqual(each['value'], ['/cross'])
@@ -9339,9 +9341,12 @@ class CrossFileTests(BasePlatformTests):
             elif each['name'] == 'build.pkg_config_path':
                 self.assertEqual(each['value'], ['/native'])
                 found += 1
-            if found == 2:
+            elif each['name'].endswith('cpp_args'):
+                self.assertEqual(each['value'], ['-DFILE'])
+                found += 1
+            if found == expected:
                 break
-        self.assertEqual(found, 2, 'Did not find all sections.')
+        self.assertEqual(found, expected, 'Did not find all sections.')
 
 
 class TAPParserTests(unittest.TestCase):


### PR DESCRIPTION
How this was all working before is a mystery to me. we had
1) a test that was wrong
2) no test for the right behavior
3) then broke the right behavior to fix the test that was implementing the wrong behavior.

For reference, the correct behavior is documented here: https://mesonbuild.com/Reference-tables.html#environment-variables-per-machine