### PR TITLE
Fix using a cross and native file at the same time

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -759,7 +759,11 @@ class CoreData:
             if k.subproject and k.subproject != subproject:
                 continue
             # If the option is a builtin and is yielding then it's not allowed per subproject.
-            if subproject and k.is_builtin() and self.options[k.as_root()].yielding:
+            #
+            # Always test this using the HOST machine, as many builtin options
+            # are not valid for the BUILD machine, but the yielding value does
+            # not differ between them even when they are valid for both.
+            if subproject and k.is_builtin() and self.options[k.evolve(subproject='', machine=MachineChoice.HOST)].yielding:
                 continue
             # Skip base, compiler, and backend options, they are handled when
             # adding languages and setting backend.

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -662,7 +662,7 @@ class Environment:
                     self.options[key.as_build()] = value
             self._load_machine_file_options(config, properties.host, MachineChoice.HOST)
         else:
-            # IF we aren't cross compiling, but we hav ea native file, the
+            # If we aren't cross compiling, but we have a native file, the
             # native file is for the host. This is due to an mismatch between
             # meson internals which talk about build an host, and external
             # interfaces which talk about native and cross.

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -749,12 +749,20 @@ class Environment:
 
     def _load_machine_file_options(self, config: 'ConfigParser', properties: Properties, machine: MachineChoice) -> None:
         """Read the contents of a Machine file and put it in the options store."""
+
+        # Look for any options in the deprecated paths section, warn about
+        # those, then assign them. They will be overwritten by the ones in the
+        # "built-in options" section if they're in both sections.
         paths = config.get('paths')
         if paths:
             mlog.deprecation('The [paths] section is deprecated, use the [built-in options] section instead.')
             for k, v in paths.items():
                 self.options[OptionKey.from_string(k).evolve(machine=machine)] = v
-        deprecated_properties = set()
+
+        # Next look for compiler options in the "properties" section, this is
+        # also deprecated, and these will also be overwritten by the "built-in
+        # options" section. We need to remove these from this section, as well.
+        deprecated_properties: T.Set[str] = set()
         for lang in compilers.all_languages:
             deprecated_properties.add(lang + '_args')
             deprecated_properties.add(lang + '_link_args')
@@ -763,6 +771,7 @@ class Environment:
                 mlog.deprecation(f'{k} in the [properties] section of the machine file is deprecated, use the [built-in options] section.')
                 self.options[OptionKey.from_string(k).evolve(machine=machine)] = v
                 del properties.properties[k]
+
         for section, values in config.items():
             if ':' in section:
                 subproject, section = section.split(':')
@@ -779,7 +788,7 @@ class Environment:
                     self.options[key.evolve(subproject=subproject, machine=machine)] = v
             elif section == 'project options':
                 for k, v in values.items():
-                    # Project options are always for the machine machine
+                    # Project options are always for the host machine
                     key = OptionKey.from_string(k)
                     if key.subproject:
                         raise MesonException('Do not set subproject options in [built-in options] section, use [subproject:built-in options] instead.')

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -642,7 +642,9 @@ class Environment:
             binaries.build = BinaryTable(config.get('binaries', {}))
             properties.build = Properties(config.get('properties', {}))
             cmakevars.build = CMakeVariables(config.get('cmake', {}))
-            self._load_machine_file_options(config, properties.build, MachineChoice.BUILD)
+            self._load_machine_file_options(
+                config, properties.build,
+                MachineChoice.BUILD if self.coredata.cross_files else MachineChoice.HOST)
 
         ## Read in cross file(s) to override host machine configuration
 
@@ -661,12 +663,6 @@ class Environment:
                 if self.coredata.is_per_machine_option(key):
                     self.options[key.as_build()] = value
             self._load_machine_file_options(config, properties.host, MachineChoice.HOST)
-        else:
-            # If we aren't cross compiling, but we have a native file, the
-            # native file is for the host. This is due to an mismatch between
-            # meson internals which talk about build an host, and external
-            # interfaces which talk about native and cross.
-            self.options = {k.as_host(): v for k, v in self.options.items()}
 
 
         ## "freeze" now initialized configuration, and "save" to the class.

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -786,7 +786,9 @@ class Environment:
                     if key.subproject:
                         raise MesonException('Do not set subproject options in [built-in options] section, use [subproject:built-in options] instead.')
                     self.options[key.evolve(subproject=subproject, machine=machine)] = v
-            elif section == 'project options':
+            elif section == 'project options' and machine is MachineChoice.HOST:
+                # Project options are only for the host machine, we don't want
+                # to read these from the native file
                 for k, v in values.items():
                     # Project options are always for the host machine
                     key = OptionKey.from_string(k)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -9202,7 +9202,7 @@ class CrossFileTests(BasePlatformTests):
             for section, entries in values.items():
                 f.write(f'[{section}]\n')
                 for k, v in entries.items():
-                    f.write(f"{k}='{v}'\n")
+                    f.write(f"{k}={v!r}\n")
         return filename
 
     def test_cross_file_dirs(self):
@@ -9367,6 +9367,22 @@ class CrossFileTests(BasePlatformTests):
             if found == 2:
                 break
         self.assertEqual(found, 2, 'Did not find all sections.')
+
+    def test_project_options_native_only(self) -> None:
+        # Do not load project options from a native file when doing a cross
+        # build
+        testcase = os.path.join(self.unit_test_dir, '19 array option')
+        config = self.helper_create_cross_file({'project options': {'list': ['bar', 'foo']}})
+        cross = self.helper_create_cross_file({'binaries': {}})
+
+        self.init(testcase, extra_args=['--native-file', config, '--cross-file', cross])
+        configuration = self.introspect('--buildoptions')
+        for each in configuration:
+            if each['name'] == 'list':
+                self.assertEqual(each['value'], ['foo', 'bar'])
+                break
+        else:
+            self.fail('Did not find expected option.')
 
 
 class TAPParserTests(unittest.TestCase):


### PR DESCRIPTION
Currently, there are two bugs (one reported and one I found by inspection):

1) If a native file contains a `[project options]` section, and is used in a cross compile, then it's options will be loaded. This is a bug, only the cross file's `[project options]` should be used
2) If a native file is used in a cross compile, if it defines builtin options that are not allowed for the build machine, then those options will cause an uncaught exception in subprojects.

@nirbheek, I think these are probably worth fixing for 0.57.2 as they're regressions in the 0.57 branch, but I also don't want to hold up the release forever.