### PR TITLE
docs: document bool to_int and to_string methods

### DIFF
--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -93,6 +93,14 @@ A boolean is either `true` or `false`.
 truth = true
 ```
 
+Booleans can be converted to a string or to a number:
+
+```meson
+bool_var = true
+string_var = bool_var.to_string()
+int_var = bool_var.to_int()
+```
+
 ## Strings
 
 Strings in Meson are declared with single quotes. To enter a literal


### PR DESCRIPTION
This documents the bool methods to_int and to_string implemented in
[1].

[1]: https://github.com/mesonbuild/meson/blob/a9e9b7c7501a3c8a5984a93879d1f309bf8c72aa/mesonbuild/interpreterbase.py#L1109