### PR TITLE
pkgconfig: Do not escape custom variables

### DIFF
--- a/docs/markdown/Pkgconfig-module.md
+++ b/docs/markdown/Pkgconfig-module.md
@@ -55,12 +55,20 @@ keyword arguments.
   `includedir` are reserved and may not be used. *Since 0.56.0* it can also be a
   dictionary but ordering of Meson dictionaries are not guaranteed, which could
   cause issues when some variables reference other variables.
+  Spaces in values are escaped with `\`, this is required in the case the value is
+  a path that and is used in `cflags` or `libs` arguments. *Since 0.59.0* if
+  escaping is not desired (e.g. space separate list of values) `unescaped_variables`
+  keyword argument should be used instead.
+- `uninstalled_variables` used instead of the `variables` keyword argument, when
+  generating the uninstalled pkg-config file. Since *0.54.0*
+  Spaces in values are escaped with `\`, this is required in the case the value is
+  a path that and is used in `cflags` or `libs` arguments. *Since 0.59.0* if
+  escaping is not desired (e.g. space separate list of values)
+  `unescaped_uninstalled_variables` keyword argument should be used instead.
 - `version` a string describing the version of this library, used to set the
   `Version:` field. (*since 0.46.0*) Defaults to the project version if unspecified.
 - `d_module_versions` a list of module version flags used when compiling
    D sources referred to by this pkg-config file
-- `uninstalled_variables` used instead of the `variables` keyword argument, when
-  generating the uninstalled pkg-config file. Since *0.54.0*
 - `dataonly` field. (*since 0.54.0*) this is used for architecture-independent
    pkg-config files in projects which also have architecture-dependent outputs.
 - `conflicts` (*since 0.36.0, incorrectly issued a warning prior to 0.54.0*) list of strings to be put in the `Conflicts` field.

--- a/docs/markdown/snippets/pkgconfig_var_escaping.md
+++ b/docs/markdown/snippets/pkgconfig_var_escaping.md
@@ -1,0 +1,23 @@
+## Unescaped variables in pkgconfig files
+
+Spaces in variable values are escaped with `\`, this is required in the case the
+value is a path that and is used in `cflags` or `libs` arguments. This was an
+undocumented behaviour that caused issues in the case the variable is a space
+separated list of items.
+
+For backward compatibility reasons this behaviour could not be changed, new
+keyword arguments have thus been added: `unescaped_variables` and
+`unescaped_uninstalled_variables`.
+
+```meson
+pkg = import('pkgconfig')
+...
+pkg.generate(lib,
+  variables: {
+    'mypath': '/path/with spaces/are/escaped',
+  },
+  unescaped_variables: {
+    'mylist': 'Hello World Is Not Escaped',
+  },
+)
+```

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -6545,6 +6545,8 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertEqual(libhello_nolib.get_compile_args(), [])
         self.assertEqual(libhello_nolib.get_pkgconfig_variable('foo', {}), 'bar')
         self.assertEqual(libhello_nolib.get_pkgconfig_variable('prefix', {}), self.prefix)
+        self.assertEqual(libhello_nolib.get_pkgconfig_variable('escaped_var', {}), 'hello\ world')
+        self.assertEqual(libhello_nolib.get_pkgconfig_variable('unescaped_var', {}), 'hello world')
 
         cc = env.detect_c_compiler(MachineChoice.HOST)
         if cc.get_id() in {'gcc', 'clang'}:

--- a/test cases/common/44 pkgconfig-gen/meson.build
+++ b/test cases/common/44 pkgconfig-gen/meson.build
@@ -70,7 +70,11 @@ pkgg.generate(
     # prefix is not set by default for dataonly pc files, but it is allowed to
     # define it manually.
     'prefix': get_option('prefix'),
+    'escaped_var': 'hello world',
   },
+  unescaped_variables: {
+    'unescaped_var': 'hello world',
+  }
 )
 
 # Regression test for 2 cases:


### PR DESCRIPTION
We need to escape space in variables that gets into cflags or libs
because otherwise we cannot split compiler args when paths contains
spaces. But custom variables are unlikely to be path that gets used in
cflags/libs, and escaping them cause regression in GStreamer that use
space as separator in a list variable.