### PR TITLE
Add missing rpath when using link_whole

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -917,7 +917,7 @@ class BuildTarget(Target):
     @lru_cache(maxsize=None)
     def get_link_dep_subdirs(self):
         result = OrderedSet()
-        for i in self.link_targets:
+        for i in itertools.chain(self.link_targets, self.link_whole_targets):
             if not isinstance(i, StaticLibrary):
                 result.add(i.get_subdir())
             result.update(i.get_link_dep_subdirs())


### PR DESCRIPTION
A static library we link_whole could itself depend on shared libraries
that needs to be added to our rpath.