### PR TITLE
Revert meson.build_root() and meson.source_root() deprecation

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1986,17 +1986,17 @@ the following methods.
   or `xcode`.
 
 - `build_root()`: returns a string with the absolute path to the build
-  root directory. *(deprecated since 0.56.0)*: this function will return the
-  build root of the parent project if called from a subproject, which is usually
-  not what you want. Try using `current_build_dir()` or `project_build_root()`.
+  root directory. This function will return the build root of the parent
+  project if called from a subproject, which is usually not what you want. Try
+  using `current_build_dir()` or `project_build_root()`.
 
 - `source_root()`: returns a string with the absolute path to the
   source root directory. Note: you should use the `files()` function
   to refer to files in the root source directory instead of
   constructing paths manually with `meson.source_root()`.
-  *(deprecated since 0.56.0)*: This function will return the source root of the
-  parent project if called from a subproject, which is usually not what you want.
-  Try using `current_source_dir()` or `project_source_root()`.
+  This function will return the source root of the parent project if called
+  from a subproject, which is usually not what you want. Try using
+  `current_source_dir()` or `project_source_root()`.
 
 - `project_build_root()` *(since 0.56.0)*: returns a string with the absolute path
   to the build root directory of the current (sub)project.

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -173,13 +173,11 @@ class MesonMain(InterpreterObject):
 
     @noPosargs
     @permittedKwargs({})
-    @FeatureDeprecated('meson.source_root', '0.56.0', 'use meson.current_source_dir instead.')
     def source_root_method(self, args, kwargs):
         return self.interpreter.environment.source_dir
 
     @noPosargs
     @permittedKwargs({})
-    @FeatureDeprecated('meson.build_root', '0.56.0', 'use meson.current_build_dir instead.')
     def build_root_method(self, args, kwargs):
         return self.interpreter.environment.build_dir
 


### PR DESCRIPTION
There are valid use-cases for these functions.

References: https://github.com/mesonbuild/meson/pull/7772