### PR TITLE
dependencies/OpenMP: If the version returned is not supported fail gr…

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -91,7 +91,13 @@ class OpenMPDependency(ExternalDependency):
             openmp_date = None
 
         if openmp_date:
-            self.version = self.VERSIONS[openmp_date]
+            try:
+                self.version = self.VERSIONS[openmp_date]
+            except KeyError:
+                mlog.debug(f'Could not find an OpenMP version matching {openmp_date}')
+                if openmp_date == '_OPENMP':
+                    mlog.debug('This can be caused by flags such as gcc\'s `-fdirectives-only`, which affect preprocessor behavior.')
+                return
             # Flang has omp_lib.h
             header_names = ('omp.h', 'omp_lib.h')
             for name in header_names:


### PR DESCRIPTION
…acefully

Currently if the version returned is not a supported version, then you
get a lovely stack trace. This is not nice. This can be triggered easily
by adding gcc's `-fdirectives-only` flag, which stops the preprocessor
from doing certain macro expansions, including those used to detect
OpenMP.

Fixes #8652