### PR TITLE
OpenMP: do a compile test before declaring the dependency found

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -91,7 +91,13 @@ class OpenMPDependency(ExternalDependency):
             openmp_date = None
 
         if openmp_date:
-            self.version = self.VERSIONS[openmp_date]
+            try:
+                self.version = self.VERSIONS[openmp_date]
+            except KeyError:
+                mlog.debug(f'Could not find an OpenMP version matching {openmp_date}')
+                if openmp_date == '_OPENMP':
+                    mlog.debug('This can be caused by flags such as gcc\'s `-fdirectives-only`, which affect preprocessor behavior.')
+                return
             # Flang has omp_lib.h
             header_names = ('omp.h', 'omp_lib.h')
             for name in header_names:


### PR DESCRIPTION
Our dependency is pretty fragile, it assumes that if it can find a header and there are arguments in the compiler everything is good to go. That may or may not be the case. For GCC and Clang, `-fopenmp` actually instructs them to add linking arguments, such as `-lgomp` or `-lomp`, if those aren't available then the dependency will still return found, but fail to work. Let's just do a simple compile to make sure that the dependency actually works.