### PR TITLE
mconf: add --error-on-unkown-options/-e

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -709,7 +709,7 @@ class CoreData:
                 except KeyError:
                     continue
 
-    def set_options(self, options: T.Dict[OptionKey, T.Any], subproject: str = '', warn_unknown: bool = True) -> None:
+    def set_options(self, options: T.Dict[OptionKey, T.Any], subproject: str = '', warn_unknown: bool = True, error_unknown: bool = False) -> None:
         if not self.is_cross_build():
             options = {k: v for k, v in options.items() if k.machine is not MachineChoice.BUILD}
         # Set prefix first because it's needed to sanitize other options
@@ -729,10 +729,13 @@ class CoreData:
                 unknown_options.append(k)
             else:
                 self.set_option(k, v)
-        if unknown_options and warn_unknown:
+        if unknown_options and (warn_unknown or error_unknown):
             unknown_options_str = ', '.join(sorted(str(s) for s in unknown_options))
             sub = f'In subproject {subproject}: ' if subproject else ''
-            mlog.warning(f'{sub}Unknown options: "{unknown_options_str}"')
+            message = f'{sub}Unknown options: "{unknown_options_str}"'
+            if error_unknown:
+                raise MesonException(message)
+            mlog.warning(message)
             mlog.log('The value of new options can be set with:')
             mlog.log(mlog.bold('meson setup <builddir> --reconfigure -Dnew_option=new_value ...'))
         if not self.is_cross_build():

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -28,6 +28,9 @@ def add_arguments(parser: 'argparse.ArgumentParser') -> None:
     parser.add_argument('builddir', nargs='?', default='.')
     parser.add_argument('--clearcache', action='store_true', default=False,
                         help='Clear cached state (e.g. found dependencies)')
+    parser.add_argument('-e', '--error-on-unknown-options', action='store_true',
+                        dest='error_unknown',
+                        help='Fail with an error if an unknown option is provided')
 
 def make_lower_case(val: T.Any) -> T.Union[str, T.List[T.Any]]:  # T.Any because of recursion...
     if isinstance(val, bool):
@@ -79,8 +82,8 @@ class Conf:
         self.coredata.deps.host.clear()
         self.coredata.deps.build.clear()
 
-    def set_options(self, options):
-        self.coredata.set_options(options)
+    def set_options(self, options, error_unknown: bool = False):
+        self.coredata.set_options(options, error_unknown=error_unknown)
 
     def save(self):
         # Do nothing when using introspection
@@ -266,7 +269,7 @@ def run(options):
 
         save = False
         if options.cmd_line_options:
-            c.set_options(options.cmd_line_options)
+            c.set_options(options.cmd_line_options, options.error_unknown)
             coredata.update_cmd_line_file(builddir, options)
             save = True
         elif options.clearcache:


### PR DESCRIPTION
It is a common error, at least in my experience, that people invoke
"meson configure -D nonexistent=true" and miss the big yellow
uppercase WARNING about "nonexistent" being an unknown option. They
they happily continue building the project in the belief that
"nonexistent" is set to true, when it is, in fact not.

I am not sure why meason decided that this should only be a
WARNING. But users should at least be able to opt-in for a fail-safe
behavior. This is now possible via the --error-on-unknown-options
switch.