### PR TITLE
Visual Studio Address Sanitizer updates

### DIFF
--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -125,7 +125,7 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
             self.machine = 'arm'
         else:
             self.machine = target
-        if mesonlib.version_compare(self.version, '>=19.29.29917'):
+        if mesonlib.version_compare(self.version, '>=19.28.29910'): # VS 16.9.0 includes cl 19.28.29910
             self.base_options.add(mesonlib.OptionKey('b_sanitize'))
         assert self.linker is not None
         self.linker.machine = self.machine


### PR DESCRIPTION
Two commits in this merge request. I'd like feedback on both:

1. Reduce minimum compiler version to 16.9. The version check for 19.29.29917 added in d76345b4beec48484e31110b225c3256d8ba264b refers to an unreleased version (16.10 beta, perhaps?). Was that intentional (ie. is there some fix in the beta that I'm not aware of)? Seems to work in the current "released" version 16.9.4 / 19.28.29914
2. Covert /fstanitize=address to project setting. When I tested this, /fsanitize=address is still being added to "AdditionalOptions". It seems to work as-is, but it would be cleaner if I could remove it from "AdditionalOptions". I'm not quite sure how or where it is being added; pointers would be appreciated.