### PR TITLE
Make `meson.override_find_program` more cross compile friendly

### DIFF
--- a/docs/markdown/snippets/override_find_program-native.md
+++ b/docs/markdown/snippets/override_find_program-native.md
@@ -1,0 +1,12 @@
+## Meson.override_find_program now tracks host and build overrides correctly
+
+Previously Meson tracked the overrides in a single flat list, this means that
+if you write
+```meson
+exe_for_host = executable(..., native : false)
+exe_for_build = executable(..., native : true)
+meson.override_find_program('exe', exe_for_host)
+meson.override_find_program('exe', exe_for_build)
+```
+Meson would raise an error because `'exe'` had already been overwritten. This
+has been fixed.

--- a/docs/markdown/snippets/override_find_program-native.md
+++ b/docs/markdown/snippets/override_find_program-native.md
@@ -10,3 +10,8 @@ meson.override_find_program('exe', exe_for_build)
 ```
 Meson would raise an error because `'exe'` had already been overwritten. This
 has been fixed.
+
+Additionally, a `native` keyword argument has been added. For built
+dependencies, or those found with `find_program`, it's generally unnecessary
+to use this argument, as Meson already know what those binaries are for. But
+for scripts it is necessary.

--- a/docs/yaml/builtins/meson.yaml
+++ b/docs/yaml/builtins/meson.yaml
@@ -128,7 +128,7 @@ methods:
           to install only a subset of the files.
           By default the script has no install tag which means it is not being run when
           `meson install --tags` argument is specified.
-      
+
       dry_run:
         type: bool
         since: 1.1.0
@@ -371,6 +371,10 @@ methods:
       *(since 0.55.0)* If a version
       check is passed to [[find_program]] for a program that has been overridden with
       an executable, the current project version is used.
+
+      *(since 1.2.0)* the machine that the override is for is correctly tracked,
+      Which allows host and build binaries to be overridden separately in a
+      cross build
 
     posargs:
       progname:

--- a/docs/yaml/builtins/meson.yaml
+++ b/docs/yaml/builtins/meson.yaml
@@ -385,6 +385,16 @@ methods:
         type: exe | file | external_program
         description: The program to set as the override for `progname`.
 
+    kwargs:
+      native:
+        type: bool
+        since: 1.2.0
+        default: false
+        description: |
+          If set to `true`, the dependency is always overwritten for the build machine.
+          Otherwise, the dependency is overwritten for the host machine, which
+          differs from the build machine when cross-compiling.
+
   - name: override_dependency
     returns: void
     since: 0.54.0

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -268,18 +268,18 @@ class Build:
         self.test_setup_default_name = None
 
         # All overwritten programs, per-machine
-        find_overrides: PerMachineDefaultable[T.Dict[str, T.Union[ExternalProgram, Executable, programs.OverrideProgram, File]]] = PerMachineDefaultable()
-        find_overrides.build = {}
+        program_overrides: PerMachineDefaultable[T.Dict[str, T.Union[ExternalProgram, Executable, programs.OverrideProgram, File]]] = PerMachineDefaultable()
+        program_overrides.build = {}
 
         # All programs that have been searched for, per machine
         searched_programs: PerMachineDefaultable[T.Set[str]] = PerMachineDefaultable()
         searched_programs.build = set()
 
         if environment.is_cross_build():
-            find_overrides.host = {}
+            program_overrides.host = {}
             searched_programs.host = set()
 
-        self.find_overrides = find_overrides.default_missing()
+        self.program_overrides = program_overrides.default_missing()
         self.searched_programs = searched_programs.default_missing()
 
         # If we are doing a cross build we need two caches, if we're doing a

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -266,15 +266,20 @@ class Build:
         self.stdlibs = PerMachine({}, {})
         self.test_setups: T.Dict[str, TestSetup] = {}
         self.test_setup_default_name = None
-        self.find_overrides: T.Dict[str, T.Union['Executable', programs.ExternalProgram, programs.OverrideProgram]] = {}
+
+        # All overwritten programs, per-machine
+        find_overrides: PerMachineDefaultable[T.Dict[str, T.Union[ExternalProgram, Executable, programs.OverrideProgram, File]]] = PerMachineDefaultable()
+        find_overrides.build = {}
 
         # All programs that have been searched for, per machine
         searched_programs: PerMachineDefaultable[T.Set[str]] = PerMachineDefaultable()
         searched_programs.build = set()
 
         if environment.is_cross_build():
+            find_overrides.host = {}
             searched_programs.host = set()
 
+        self.find_overrides = find_overrides.default_missing()
         self.searched_programs = searched_programs.default_missing()
 
         # If we are doing a cross build we need two caches, if we're doing a

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -56,6 +56,7 @@ if T.TYPE_CHECKING:
     from .mesonlib import FileMode, FileOrString
     from .modules import ModuleState
     from .mparser import BaseNode
+    from .programs import ExternalProgram
     from .wrap import WrapMode
 
     GeneratedTypes = T.Union['CustomTarget', 'CustomTargetIndex', 'GeneratedList']
@@ -266,7 +267,15 @@ class Build:
         self.test_setups: T.Dict[str, TestSetup] = {}
         self.test_setup_default_name = None
         self.find_overrides: T.Dict[str, T.Union['Executable', programs.ExternalProgram, programs.OverrideProgram]] = {}
-        self.searched_programs: T.Set[str] = set() # The list of all programs that have been searched for.
+
+        # All programs that have been searched for, per machine
+        searched_programs: PerMachineDefaultable[T.Set[str]] = PerMachineDefaultable()
+        searched_programs.build = set()
+
+        if environment.is_cross_build():
+            searched_programs.host = set()
+
+        self.searched_programs = searched_programs.default_missing()
 
         # If we are doing a cross build we need two caches, if we're doing a
         # build == host compilation the both caches should point to the same place.

--- a/mesonbuild/cmake/executor.py
+++ b/mesonbuild/cmake/executor.py
@@ -97,7 +97,7 @@ class CMakeExecutor:
                     mlog.log('Found CMake:', mlog.red('NO'))
                 # Set to False instead of None to signify that we've already
                 # searched for it and not found it
-                CMakeExecutor.class_cmakebin[self.for_machine] = NonExistingExternalProgram()
+                CMakeExecutor.class_cmakebin[self.for_machine] = NonExistingExternalProgram(for_machine=self.for_machine)
                 CMakeExecutor.class_cmakevers[self.for_machine] = None
                 return None, None
 

--- a/mesonbuild/dependencies/python.py
+++ b/mesonbuild/dependencies/python.py
@@ -79,6 +79,7 @@ class BasicPythonExternalProgram(ExternalProgram):
             self.command = ext_prog.command
             self.path = ext_prog.path
             self.cached_version = None
+            self.for_machine = ext_prog.for_machine
 
         # We want strong key values, so we always populate this with bogus data.
         # Otherwise to make the type checkers happy we'd have to do .get() for

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1618,14 +1618,14 @@ class Interpreter(InterpreterBase, HoldableObject):
                           ) -> T.Union['ExternalProgram', 'build.Executable', 'OverrideProgram']:
         args = mesonlib.listify(args)
 
-        extra_info: T.List[mlog.TV_Loggable] = []
+        extra_info: T.List[mlog.TV_Loggable] = [mlog.cyan(f'(for {for_machine.get_lower_case_name()})')]
         progobj = self.program_lookup(args, for_machine, required, search_dirs, extra_info)
         if progobj is None:
             progobj = self.notfound_program(args)
 
-        if isinstance(progobj, ExternalProgram) and not progobj.found():
+        if not progobj.found():
             if not silent:
-                mlog.log('Program', mlog.bold(progobj.get_name()), 'found:', mlog.red('NO'))
+                mlog.log('Program', mlog.bold(progobj.get_name()), 'found:', mlog.red('NO'), *extra_info)
             if required:
                 m = 'Program {!r} not found or not executable'
                 raise InterpreterException(m.format(progobj.get_name()))

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -799,7 +799,7 @@ class Interpreter(InterpreterBase, HoldableObject):
                           'configuration')
         expanded_args: T.List[str] = []
         if isinstance(cmd, build.Executable):
-            for name, exe in self.build.find_overrides.items():
+            for name, exe in self.build.build_overrides.items():
                 if cmd == exe:
                     progname = name
                     break
@@ -1601,7 +1601,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         if name in self.build.searched_programs[for_machine]:
             raise InterpreterException(f'Tried to override finding of executable "{name}" for the '
                                        f'{for_machine.get_lower_case_name()} machine which has already been found.')
-        if name in self.build.find_overrides[for_machine]:
+        if name in self.build.program_overrides[for_machine]:
             raise InterpreterException(f'Tried to override executable "{name}" for the {for_machine.get_lower_case_name()} machine '
                                        'which has already been overridden.')
         self.build.program_overrides[for_machine][name] = exe

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1589,14 +1589,15 @@ class Interpreter(InterpreterBase, HoldableObject):
                 return exe
         return None
 
-    def store_name_lookups(self, command_names: T.List[mesonlib.FileOrString]) -> None:
+    def store_name_lookups(self, command_names: T.List[mesonlib.FileOrString], for_machine: MachineChoice) -> None:
         for name in command_names:
             if isinstance(name, str):
-                self.build.searched_programs.add(name)
+                self.build.searched_programs[for_machine].add(name)
 
     def add_find_program_override(self, name: str, exe: T.Union[build.Executable, ExternalProgram, 'OverrideProgram']) -> None:
-        if name in self.build.searched_programs:
-            raise InterpreterException(f'Tried to override finding of executable "{name}" which has already been found.')
+        if name in self.build.searched_programs.host:
+            raise InterpreterException('Tried to override finding of executable "%s" which has already been found.'
+                                       % name)
         if name in self.build.find_overrides:
             raise InterpreterException(f'Tried to override executable "{name}" which has already been overridden.')
         self.build.find_overrides[name] = exe
@@ -1654,7 +1655,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             extra_info.insert(0, mlog.normal_cyan(version))
 
         # Only store successful lookups
-        self.store_name_lookups(args)
+        self.store_name_lookups(args, for_machine)
         if not silent:
             mlog.log('Program', mlog.bold(progobj.name), 'found:', mlog.green('YES'), *extra_info)
         if isinstance(progobj, build.Executable):

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1583,8 +1583,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         for name in command_names:
             if not isinstance(name, str):
                 continue
-            if name in self.build.find_overrides:
-                exe = self.build.find_overrides[name]
+            if name in self.build.find_overrides.host:
+                exe = self.build.find_overrides.host[name]
                 extra_info.append(mlog.blue('(overridden)'))
                 return exe
         return None
@@ -1598,9 +1598,9 @@ class Interpreter(InterpreterBase, HoldableObject):
         if name in self.build.searched_programs.host:
             raise InterpreterException('Tried to override finding of executable "%s" which has already been found.'
                                        % name)
-        if name in self.build.find_overrides:
+        if name in self.build.find_overrides.host:
             raise InterpreterException(f'Tried to override executable "{name}" which has already been overridden.')
-        self.build.find_overrides[name] = exe
+        self.build.find_overrides.host[name] = exe
 
     def notfound_program(self, args: T.List[mesonlib.FileOrString]) -> ExternalProgram:
         return NonExistingExternalProgram(' '.join(

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1585,8 +1585,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         for name in command_names:
             if not isinstance(name, str):
                 continue
-            if name in self.build.find_overrides[for_machine]:
-                exe = self.build.find_overrides[for_machine][name]
+            if name in self.build.program_overrides[for_machine]:
+                exe = self.build.program_overrides[for_machine][name]
                 extra_info.append(mlog.blue('(overridden)'))
                 return exe
         return None
@@ -1604,7 +1604,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         if name in self.build.find_overrides[for_machine]:
             raise InterpreterException(f'Tried to override executable "{name}" for the {for_machine.get_lower_case_name()} machine '
                                        'which has already been overridden.')
-        self.build.find_overrides[for_machine][name] = exe
+        self.build.program_overrides[for_machine][name] = exe
 
     def notfound_program(self, args: T.List[mesonlib.FileOrString]) -> ExternalProgram:
         return NonExistingExternalProgram(' '.join(

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1596,14 +1596,15 @@ class Interpreter(InterpreterBase, HoldableObject):
             if isinstance(name, str):
                 self.build.searched_programs[for_machine].add(name)
 
-    def add_find_program_override(self, name: str, exe: T.Union[build.Executable, ExternalProgram, 'OverrideProgram']) -> None:
-        if name in self.build.searched_programs[exe.for_machine]:
+    def add_find_program_override(self, name: str, exe: T.Union[build.Executable, ExternalProgram, 'OverrideProgram'],
+                                  for_machine: MachineChoice) -> None:
+        if name in self.build.searched_programs[for_machine]:
             raise InterpreterException(f'Tried to override finding of executable "{name}" for the '
-                                       f'{exe.for_machine.get_lower_case_name()} machine which has already been found.')
-        if name in self.build.find_overrides[exe.for_machine]:
-            raise InterpreterException(f'Tried to override executable "{name}" for the {exe.for_machine.get_lower_case_name()} machine '
+                                       f'{for_machine.get_lower_case_name()} machine which has already been found.')
+        if name in self.build.find_overrides[for_machine]:
+            raise InterpreterException(f'Tried to override executable "{name}" for the {for_machine.get_lower_case_name()} machine '
                                        'which has already been overridden.')
-        self.build.find_overrides[exe.for_machine][name] = exe
+        self.build.find_overrides[for_machine][name] = exe
 
     def notfound_program(self, args: T.List[mesonlib.FileOrString]) -> ExternalProgram:
         return NonExistingExternalProgram(' '.join(

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -99,7 +99,7 @@ class ModuleState:
     def find_tool(self, name: str, depname: str, varname: str, required: bool = True,
                   wanted: T.Optional[str] = None) -> T.Union['Executable', ExternalProgram, 'OverrideProgram']:
         # Look in overrides in case it's built as subproject
-        progobj = self._interpreter.program_from_overrides([name], [])
+        progobj = self._interpreter.program_from_overrides([name], [], MachineChoice.HOST)
         if progobj is not None:
             return progobj
 

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -106,7 +106,7 @@ class ModuleState:
         # Look in machine file
         prog_list = self.environment.lookup_binary_entry(MachineChoice.HOST, name)
         if prog_list is not None:
-            return ExternalProgram.from_entry(name, prog_list)
+            return ExternalProgram.from_entry(name, prog_list, MachineChoice.HOST)
 
         # Check if pkgconfig has a variable
         dep = self.dependency(depname, native=True, required=False, wanted=wanted)

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -376,7 +376,7 @@ class PythonModule(ExtensionModule):
         if not name_or_path:
             python = PythonExternalProgram('python3', mesonlib.python_command)
         else:
-            tmp_python = ExternalProgram.from_entry(display_name, name_or_path)
+            tmp_python = ExternalProgram.from_entry(display_name, name_or_path, MachineChoice.BUILD)
             python = PythonExternalProgram(display_name, ext_prog=tmp_python)
 
             if not python.found() and mesonlib.is_windows():
@@ -390,7 +390,7 @@ class PythonModule(ExtensionModule):
             # named python is available and has a compatible version, let's use
             # it
             if not python.found() and name_or_path in {'python2', 'python3'}:
-                tmp_python = ExternalProgram.from_entry(display_name, 'python')
+                tmp_python = ExternalProgram.from_entry(display_name, 'python', MachineChoice.BUILD)
                 python = PythonExternalProgram(name_or_path, ext_prog=tmp_python)
 
         if python.found():

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+from mesonbuild.mesonlib.universal import MachineChoice
 import sysconfig
 from .. import mesonlib
 
@@ -57,9 +58,9 @@ class Python3Module(ExtensionModule):
     @noPosargs
     @noKwargs
     def find_python(self, state, args, kwargs):
-        command = state.environment.lookup_binary_entry(mesonlib.MachineChoice.HOST, 'python3')
+        command = state.environment.lookup_binary_entry(mesonlib.MachineChoice.BUILD, 'python3')
         if command is not None:
-            py3 = ExternalProgram.from_entry('python3', command)
+            py3 = ExternalProgram.from_entry('python3', command, MachineChoice.BUILD)
         else:
             py3 = ExternalProgram('python3', mesonlib.python_command, silent=True)
         return py3

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 from __future__ import annotations
 
-from mesonbuild.mesonlib.universal import MachineChoice
 import sysconfig
 from .. import mesonlib
 
@@ -21,6 +20,7 @@ from . import ExtensionModule, ModuleInfo
 from ..interpreterbase import typed_pos_args, noPosargs, noKwargs, permittedKwargs
 from ..build import known_shmod_kwargs
 from ..programs import ExternalProgram
+from ..mesonlib import MachineChoice
 
 
 class Python3Module(ExtensionModule):

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -38,11 +38,12 @@ class ExternalProgram(mesonlib.HoldableObject):
     """A program that is found on the system."""
 
     windows_exts = ('exe', 'msc', 'com', 'bat', 'cmd')
-    for_machine = MachineChoice.BUILD
 
     def __init__(self, name: str, command: T.Optional[T.List[str]] = None,
                  silent: bool = False, search_dir: T.Optional[str] = None,
-                 extra_search_dirs: T.Optional[T.List[str]] = None):
+                 extra_search_dirs: T.Optional[T.List[str]] = None,
+                 for_machine: MachineChoice = MachineChoice.BUILD):
+        self.for_machine = for_machine
         self.name = name
         self.path: T.Optional[str] = None
         self.cached_version: T.Optional[str] = None
@@ -333,10 +334,11 @@ class ExternalProgram(mesonlib.HoldableObject):
 class NonExistingExternalProgram(ExternalProgram):  # lgtm [py/missing-call-to-init]
     "A program that will never exist"
 
-    def __init__(self, name: str = 'nonexistingprogram') -> None:
+    def __init__(self, name: str = 'nonexistingprogram', for_machine: MachineChoice = MachineChoice.BUILD) -> None:
         self.name = name
         self.command = [None]
         self.path = None
+        self.for_machine = for_machine
 
     def __repr__(self) -> str:
         r = '<{} {!r} -> {!r}>'

--- a/test cases/native/9 override with exe/meson.build
+++ b/test cases/native/9 override with exe/meson.build
@@ -5,6 +5,15 @@ prog = find_program('foobar', version : '>= 2.0', required : false, native : tru
 assert(not prog.found())
 
 prog = find_program('foobar', version : '>= 1.0', native : true)
+
+if meson.is_cross_build()
+  prog_for_host = find_program('foobar', version : '>= 1.0', native : false, required : false)
+  assert(not prog_for_host.found(), 'got build machine binary for host machine!')
+else
+  prog_for_host = find_program('foobar', version : '>= 1.0', native : false, required : false)
+  assert(prog_for_host.found(), 'host and build are the same, should have been found')
+endif
+
 custom1 = custom_target('custom1',
                         build_by_default : true,
                         input : [],

--- a/test cases/native/9 override with exe/meson.build
+++ b/test cases/native/9 override with exe/meson.build
@@ -1,10 +1,10 @@
 project('myexe', 'c', version: '0.1')
 sub = subproject('sub')
 
-prog = find_program('foobar', version : '>= 2.0', required : false)
+prog = find_program('foobar', version : '>= 2.0', required : false, native : true)
 assert(not prog.found())
 
-prog = find_program('foobar', version : '>= 1.0')
+prog = find_program('foobar', version : '>= 1.0', native : true)
 custom1 = custom_target('custom1',
                         build_by_default : true,
                         input : [],

--- a/test cases/native/9 override with exe/meson.build
+++ b/test cases/native/9 override with exe/meson.build
@@ -9,6 +9,9 @@ prog = find_program('foobar', version : '>= 1.0', native : true)
 if meson.is_cross_build()
   prog_for_host = find_program('foobar', version : '>= 1.0', native : false, required : false)
   assert(not prog_for_host.found(), 'got build machine binary for host machine!')
+
+  prog_forced = find_program('foobar2', native : false)
+  assert(prog_forced.found())
 else
   prog_for_host = find_program('foobar', version : '>= 1.0', native : false, required : false)
   assert(prog_for_host.found(), 'host and build are the same, should have been found')

--- a/test cases/native/9 override with exe/subprojects/sub/meson.build
+++ b/test cases/native/9 override with exe/subprojects/sub/meson.build
@@ -1,3 +1,6 @@
 project('sub', 'c', version : '1.0')
 foobar = executable('foobar', 'foobar.c',  native : true)
 meson.override_find_program('foobar', foobar)
+
+# Force this to be used for the host machine.
+meson.override_find_program('foobar2', foobar, native : false)


### PR DESCRIPTION
Currently, Meson doesn't track the difference between a `find_program` override for the build machine vs the host machine. So if you run some code like:
```meson
exe = executable(..., native : true)
meson.overide_find_program('exe', exe)
```
then run
```meson
exe = find_program('exe', native : false)
```
you'll get the exe your overwrote, even though that probably isn't what you meant. With this PR that is actually correctly tracked. The best part is that you don't need to pass a `native` argument to `override_find_program` in most cases, as Meson already knows what the built binaries are for. However, when using a script (like a python script) you do need to set the machine, otherwise it's assumed to be for the HOST machine. 