### PR TITLE
Improve error messages for wrap-redirect file

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -253,15 +253,15 @@ class PackageDefinition:
             for i, p in enumerate(fname.parts):
                 if i % 2 == 0:
                     if p == '..':
-                        raise WrapException('wrap-redirect filename cannot contain ".."')
+                        raise WrapException(f"wrap-redirect filename {values['filename']!r} cannot contain '..'")
                 else:
                     if p != 'subprojects':
-                        raise WrapException('wrap-redirect filename must be in the form foo/subprojects/bar.wrap')
+                        raise WrapException(f"wrap-redirect filename {values['filename']!r} must be in the form foo/subprojects/bar.wrap")
             if fname.suffix != '.wrap':
-                raise WrapException('wrap-redirect filename must be a .wrap file')
+                raise WrapException(f"wrap-redirect filename {values['filename']!r} must be a .wrap file")
             fname = Path(subprojects_dir, fname)
             if not fname.is_file():
-                raise WrapException(f'wrap-redirect {fname} filename does not exist')
+                raise WrapException(f"wrap-redirect filename {values['filename']!r} does not exist")
             wrap = PackageDefinition.from_wrap_file(str(fname), subproject)
             wrap.original_filename = filename
             wrap.redirected = True

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4617,7 +4617,7 @@ class AllPlatformTests(BasePlatformTests):
                 [wrap-redirect]
                 filename = foo/subprojects/real.wrapper
                 '''))
-        with self.assertRaisesRegex(WrapException, 'wrap-redirect filename must be a .wrap file'):
+        with self.assertRaisesRegex(WrapException, "wrap-redirect filename 'foo/subprojects/real.wrapper' must be a .wrap file"):
             PackageDefinition.from_wrap_file(redirect_wrap)
 
         # Invalid redirect, filename cannot be in parent directory
@@ -4626,7 +4626,7 @@ class AllPlatformTests(BasePlatformTests):
                 [wrap-redirect]
                 filename = ../real.wrap
                 '''))
-        with self.assertRaisesRegex(WrapException, 'wrap-redirect filename cannot contain ".."'):
+        with self.assertRaisesRegex(WrapException, "wrap-redirect filename '../real.wrap' cannot contain '..'"):
             PackageDefinition.from_wrap_file(redirect_wrap)
 
         # Invalid redirect, filename must be in foo/subprojects/real.wrap
@@ -4635,7 +4635,7 @@ class AllPlatformTests(BasePlatformTests):
                 [wrap-redirect]
                 filename = foo/real.wrap
                 '''))
-        with self.assertRaisesRegex(WrapException, 'wrap-redirect filename must be in the form foo/subprojects/bar.wrap'):
+        with self.assertRaisesRegex(WrapException, "wrap-redirect filename 'foo/real.wrap' must be in the form foo/subprojects/bar.wrap"):
             PackageDefinition.from_wrap_file(redirect_wrap)
 
         # Correct redirect


### PR DESCRIPTION
While discussing error messages on IRC with xclaesse, we found 448b11cb7fb41199880cc60d9fce040ea0cf5a3b which improves one of the error messages, but leaves out the others. This commit updates them, too.