### PR TITLE
Add trailing -- parameter to `git checkout` calls.

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -415,7 +415,7 @@ class Resolver:
             verbose_git(['remote', 'add', 'origin', self.wrap.get('url')], self.dirname, check=True)
             revno = self.wrap.get('revision')
             verbose_git(['fetch', *depth_option, 'origin', revno], self.dirname, check=True)
-            verbose_git(['checkout', revno], self.dirname, check=True)
+            verbose_git(['checkout', revno, '--'], self.dirname, check=True)
             if self.wrap.values.get('clone-recursive', '').lower() == 'true':
                 verbose_git(['submodule', 'update', '--init', '--checkout',
                              '--recursive', *depth_option], self.dirname, check=True)
@@ -426,9 +426,9 @@ class Resolver:
             if not is_shallow:
                 verbose_git(['clone', self.wrap.get('url'), self.directory], self.subdir_root, check=True)
                 if revno.lower() != 'head':
-                    if not verbose_git(['checkout', revno], self.dirname):
+                    if not verbose_git(['checkout', revno, '--'], self.dirname):
                         verbose_git(['fetch', self.wrap.get('url'), revno], self.dirname, check=True)
-                        verbose_git(['checkout', revno], self.dirname, check=True)
+                        verbose_git(['checkout', revno, '--'], self.dirname, check=True)
             else:
                 verbose_git(['clone', *depth_option, '--branch', revno, self.wrap.get('url'),
                              self.directory], self.subdir_root, check=True)


### PR DESCRIPTION
When using `wrap-git` with a `revision=` pointing at a branch, and the branch name happens to match the name of a file or folder in the default branch, `meson subprojects download` fails.

I've created a [simple git repository](https://github.com/drmoose/meson-git-checkout-bug) that just contains a folder called `foo` _and_ a branch called `foo`.

To reproduce the bug:

```bash
cd "$(mktemp -d)"
touch meson.build
mkdir subprojects
cat > subprojects/meson-git-checkout-bug.wrap <<EOF
[wrap-git]
directory=meson-git-checkout-bug
url=git@github.com:drmoose/meson-git-checkout-bug
revision=foo
EOF
meson subprojects download
```

The error message from the `meson subprojects download` command is

```
Download meson-git-checkout-bug...
Cloning into 'meson-git-checkout-bug'...
remote: Enumerating objects: 14, done.
remote: Counting objects: 100% (14/14), done.
remote: Compressing objects: 100% (9/9), done.
remote: Total 14 (delta 1), reused 0 (delta 0), pack-reused 0
Receiving objects: 100% (14/14), done.
Resolving deltas: 100% (1/1), done.
fatal: 'foo' could be both a local file and a tracking branch.
Please use -- (and optionally --no-guess) to disambiguate
From github.com:drmoose/meson-git-checkout-bug
 * branch            foo        -> FETCH_HEAD
fatal: 'foo' could be both a local file and a tracking branch.
Please use -- (and optionally --no-guess) to disambiguate
  -> Git command failed: ['/usr/bin/git', 'checkout', 'foo']
WARNING: Please check logs above as command failed in some subprojects which could have been left in conflict state: meson-git-checkout-bug
```

This PR fixes this issue by appending a `--` after each `git checkout (branch)` call done by `wrap.py`.

