### PR TITLE
store the list of initializes subprojects in the coredata structure

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -401,6 +401,11 @@ class CoreData:
         self.cross_files = self.__load_config_files(options, scratch_dir, 'cross')
         self.compilers = PerMachine(OrderedDict(), OrderedDict())  # type: PerMachine[T.Dict[str, Compiler]]
 
+        # Set of subprojects that have already been initialized once, this is
+        # required to be stored and reloaded with the coredata, as we don't
+        # want to overwrite options for such subprojects.
+        self.initialized_subprojects: T.Set[str] = set()
+
         build_cache = DependencyCache(self.options, MachineChoice.BUILD)
         host_cache = DependencyCache(self.options, MachineChoice.HOST)
         self.deps = PerMachine(build_cache, host_cache)  # type: PerMachine[DependencyCache]

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -692,6 +692,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         sub = SubprojectHolder(None, os.path.join(self.subproject_dir, subp_name),
                                disabled_feature=disabled_feature, exception=exception)
         self.subprojects[subp_name] = sub
+        self.coredata.initialized_subprojects.add(subp_name)
         return sub
 
     def get_subproject(self, subp_name):
@@ -807,6 +808,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         self.build_def_files = list(set(self.build_def_files + subi.build_def_files))
         self.build.merge(subi.build)
         self.build.subprojects[subp_name] = subi.project_version
+        self.coredata.initialized_subprojects.add(subp_name)
         self.summary.update(subi.summary)
         return self.subprojects[subp_name]
 
@@ -975,7 +977,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         # If this is the first invocation we alway sneed to initialize
         # builtins, if this is a subproject that is new in a re-invocation we
         # need to initialize builtins for that
-        if self.environment.first_invocation or (self.subproject != '' and self.subproject not in self.subprojects):
+        if self.environment.first_invocation or (self.subproject != '' and self.subproject not in self.coredata.initialized_subprojects):
             default_options = self.project_default_options.copy()
             default_options.update(self.default_project_options)
             self.coredata.init_builtins(self.subproject)
@@ -2452,7 +2454,7 @@ subproject. This is a problem as it hardcodes the relative paths of these two pr
 This makes it impossible to compile the project in any other directory layout and also
 prevents the subproject from changing its own directory layout.
 
-Instead of poking directly at the internals the subproject should be executed and 
+Instead of poking directly at the internals the subproject should be executed and
 it should set a variable that the caller can then use. Something like:
 
 # In subproject
@@ -2462,7 +2464,7 @@ some_dep = declare_depencency(include_directories: include_directories('include'
 some_dep = depencency('some')
 executable(..., dependencies: [some_dep])
 
-This warning will become a hard error in a future Meson release. 
+This warning will become a hard error in a future Meson release.
 ''')
             absdir_src = os.path.join(absbase_src, a)
             absdir_build = os.path.join(absbase_build, a)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -4313,7 +4313,7 @@ class AllPlatformTests(BasePlatformTests):
 
     def test_reconfigure(self):
         testdir = os.path.join(self.unit_test_dir, '48 reconfigure')
-        self.init(testdir, extra_args=['-Dopt1=val1'])
+        self.init(testdir, extra_args=['-Dopt1=val1', '-Dsub1:werror=true'])
         self.setconf('-Dopt2=val2')
 
         self.__reconfigure()
@@ -4324,6 +4324,7 @@ class AllPlatformTests(BasePlatformTests):
         self.assertRegex(out, 'opt2 val2')
         self.assertRegex(out, 'opt3 val3')
         self.assertRegex(out, 'opt4 default4')
+        self.assertRegex(out, 'sub1:werror True')
         self.build()
         self.run_tests()
 
@@ -4337,6 +4338,7 @@ class AllPlatformTests(BasePlatformTests):
         self.assertRegex(out, 'opt2 val2')
         self.assertRegex(out, 'opt3 val3')
         self.assertRegex(out, 'opt4 val4')
+        self.assertRegex(out, 'sub1:werror True')
         self.assertTrue(Path(self.builddir, '.gitignore').exists())
         self.build()
         self.run_tests()

--- a/test cases/unit/48 reconfigure/meson.build
+++ b/test cases/unit/48 reconfigure/meson.build
@@ -7,3 +7,5 @@ message('opt4 ' + get_option('opt4'))
 
 exe = executable('test1', 'main.c')
 test('test1', exe)
+
+sub1 = subproject('sub1')

--- a/test cases/unit/48 reconfigure/subprojects/sub1/meson.build
+++ b/test cases/unit/48 reconfigure/subprojects/sub1/meson.build
@@ -1,0 +1,3 @@
+project('sub1')
+
+message('sub1:werror', get_option('werror'))


### PR DESCRIPTION
We need to konw on rconfigure which options have already bee set not
just for the super project, but also for the subproject. However, using
first_invocation is not sufficient, as a reconfigure could add a new
subpproject that wasn't present before, and we need to initialize that
project's builtins.