### PR TITLE
Allow C# projects to contain multiple file types

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -818,8 +818,9 @@ class BuildTarget(Target):
                     m = '{0} targets can only contain {0} files:\n'.format(lang.capitalize())
                     m += '\n'.join([repr(c) for c in check_sources])
                     raise InvalidArguments(m)
-                # CSharp and Java targets can't contain any other file types
-                assert(len(self.compilers) == 1)
+                # Java targets can't contain any other file types
+                if lang == 'java':
+                    assert(len(self.compilers) == 1)
                 return
 
     def process_link_depends(self, sources, environment):


### PR DESCRIPTION
This allows for linking a C# executable against a C++ .NET assembly that was generated in the same project.