### PR TITLE
Update Syntax.md

### DIFF
--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -36,8 +36,10 @@ var2 = 102
 ```
 
 One important difference in how variables work in Meson is that all
-objects are stored by value. This is different from, for example, how
-Python works.
+objects are immutable. When you see an operation which appears like
+a mutation, actually a new object is created and assigned to the
+name. This is different from, for example, how Python works for
+objects, but similar to e.g. Python strings.
 
 ```meson
 var1 = [1, 2, 3]

--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -36,8 +36,8 @@ var2 = 102
 ```
 
 One important difference in how variables work in Meson is that all
-objects are immutable. This is different from, for example, how Python
-works.
+objects are stored by value. This is different from, for example, how
+Python works.
 
 ```meson
 var1 = [1, 2, 3]


### PR DESCRIPTION
"Stored by value" is more correct way to explain that example.

Mutable vs immutable means that you cannot mutate the value (e.g. list vs tuple in Python), and the example shows that `var2` is actually mutable.

Copying/storing a reference vs value is what what matters in the assignment, in Python `a=b` means `a` and `b` are references to the same list, while in meson `a=b` copies the value of `b` into `a`.