### PR TITLE
interpreter: Add dependency_fallbacks()

### DIFF
--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -61,6 +61,14 @@ find_library_permitted_kwargs = {
 
 find_library_permitted_kwargs |= {'header_' + k for k in header_permitted_kwargs}
 
+has_function_permitted_kwargs = {
+    'prefix',
+    'no_builtin_args',
+    'include_directories',
+    'args',
+    'dependencies',
+}
+
 class CompilerHolder(InterpreterObject):
     def __init__(self, compiler: 'Compiler', env: 'Environment', subproject: str):
         InterpreterObject.__init__(self)
@@ -313,13 +321,7 @@ class CompilerHolder(InterpreterObject):
                  'has members', members, msg, hadtxt, cached)
         return had
 
-    @permittedKwargs({
-        'prefix',
-        'no_builtin_args',
-        'include_directories',
-        'args',
-        'dependencies',
-    })
+    @permittedKwargs(has_function_permitted_kwargs)
     def has_function_method(self, args, kwargs):
         if len(args) != 1:
             raise InterpreterException('Has_function takes exactly one argument.')

--- a/test cases/common/242 dependency fallbacks/meson.build
+++ b/test cases/common/242 dependency fallbacks/meson.build
@@ -1,0 +1,53 @@
+project('dependency fallbacks', 'c')
+
+cc = meson.get_compiler('c')
+
+# Use different dependency name for each case to bypass caching
+
+df = dependency_fallbacks('test1')
+d = dependency(df, required: false)
+assert(not d.found())
+
+df = dependency_fallbacks('test2', 'zlib')
+d = dependency(df)
+assert(d.found())
+
+df = dependency_fallbacks('test3')
+df.has_function(cc, 'donotexist')
+d = dependency(df, required: false)
+assert(not d.found())
+
+df = dependency_fallbacks('test4')
+df.has_function(cc, 'malloc')
+d = dependency(df)
+assert(d.found())
+
+df = dependency_fallbacks('test5')
+df.find_library(cc, 'z', has_headers: 'notfound.h')
+d = dependency(df, required : false)
+assert(not d.found())
+
+df = dependency_fallbacks('test6')
+df.find_library(cc, 'z', has_headers: 'zlib.h')
+d = dependency(df)
+assert(d.found())
+
+# foo-1.0 is provided by a wrap
+df = dependency_fallbacks('foo-1.0', wraps: false)
+d = dependency(df, required: false)
+assert(not d.found())
+
+# With wraps it works
+df = dependency_fallbacks('foo-1.0')
+d = dependency(df)
+assert(d.found())
+
+# Now that it is cached, it works even without wraps
+df = dependency_fallbacks('foo-1.0', wraps: false)
+d = dependency(df)
+assert(d.found())
+
+# Subproject foo does not override bar-1.0 but its wrap has the variable name
+df = dependency_fallbacks('bar-1.0')
+d = dependency(df)
+assert(d.found())

--- a/test cases/common/242 dependency fallbacks/subprojects/foo.wrap
+++ b/test cases/common/242 dependency fallbacks/subprojects/foo.wrap
@@ -1,0 +1,5 @@
+[wrap-file]
+
+[provide]
+dependency_names = foo-1.0
+bar-1.0 = bar_dep

--- a/test cases/common/242 dependency fallbacks/subprojects/foo/meson.build
+++ b/test cases/common/242 dependency fallbacks/subprojects/foo/meson.build
@@ -1,0 +1,4 @@
+project('foo')
+
+meson.override_dependency('foo-1.0', declare_dependency())
+bar_dep = declare_dependency()


### PR DESCRIPTION
The main goal of the new dependency_fallbacks() function call is to be
able to express the common pattern: Check pkg-config first with
multiple names, then try with find_library with multiple names, and
finally fallback to a subproject. An extra niche use-case is to try with
has_function() too in the case the needed API is part of libc builtin in
the compiler (e.g. iconv in glib).