### PR TITLE
Use sanity_check_impl for objc/objpp

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -313,7 +313,7 @@ class CLikeCompiler(Compiler):
         # Compile sanity check
         # NOTE: extra_flags must be added at the end. On MSVC, it might contain a '/link' argument
         # after which all further arguments will be passed directly to the linker
-        cmdlist = self.exelist + [source_name] + self.get_output_args(binary_name) + extra_flags
+        cmdlist = self.exelist + [sname] + self.get_output_args(binname) + extra_flags
         pc, stdo, stde = mesonlib.Popen_safe(cmdlist, cwd=work_dir)
         mlog.debug('Sanity check compiler command line:', ' '.join(cmdlist))
         mlog.debug('Sanity check compile stdout:')

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os.path, subprocess
 import typing as T
 
-from ..mesonlib import EnvironmentException, MachineChoice
+from ..mesonlib import MachineChoice
 
 from .compilers import Compiler
 from .mixins.clike import CLikeCompiler

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -48,29 +48,8 @@ class ObjCCompiler(CLikeCompiler, Compiler):
         return 'Objective-C'
 
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        # TODO try to use sanity_check_impl instead of duplicated code
-        source_name = os.path.join(work_dir, 'sanitycheckobjc.m')
-        binary_name = os.path.join(work_dir, 'sanitycheckobjc')
-        extra_flags: T.List[str] = []
-        extra_flags += environment.coredata.get_external_args(self.for_machine, self.language)
-        if self.is_cross:
-            extra_flags += self.get_compile_only_args()
-        else:
-            extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)
-        with open(source_name, 'w') as ofile:
-            ofile.write('#import<stddef.h>\n'
-                        'int main(void) { return 0; }\n')
-        pc = subprocess.Popen(self.exelist + extra_flags + [source_name, '-o', binary_name])
-        pc.wait()
-        if pc.returncode != 0:
-            raise EnvironmentException('ObjC compiler %s can not compile programs.' % self.name_string())
-        if self.is_cross:
-            # Can't check if the binaries run so we have to assume they do
-            return
-        pe = subprocess.Popen(binary_name)
-        pe.wait()
-        if pe.returncode != 0:
-            raise EnvironmentException('Executables created by ObjC compiler %s are not runnable.' % self.name_string())
+        code = '#import<stddef.h>\nint main(void) { return 0; }\n'
+        return self._sanity_check_impl(work_dir, environment, 'sanitycheckobjc.m', code)
 
 
 class GnuObjCCompiler(GnuCompiler, ObjCCompiler):

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -47,30 +47,8 @@ class ObjCPPCompiler(CLikeCompiler, Compiler):
         return 'Objective-C++'
 
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
-        # TODO try to use sanity_check_impl instead of duplicated code
-        source_name = os.path.join(work_dir, 'sanitycheckobjcpp.mm')
-        binary_name = os.path.join(work_dir, 'sanitycheckobjcpp')
-        extra_flags: T.List[str] = []
-        extra_flags += environment.coredata.get_external_args(self.for_machine, self.language)
-        if self.is_cross:
-            extra_flags += self.get_compile_only_args()
-        else:
-            extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)
-        with open(source_name, 'w') as ofile:
-            ofile.write('#import<stdio.h>\n'
-                        'class MyClass;'
-                        'int main(void) { return 0; }\n')
-        pc = subprocess.Popen(self.exelist + extra_flags + [source_name, '-o', binary_name])
-        pc.wait()
-        if pc.returncode != 0:
-            raise EnvironmentException('ObjC++ compiler %s can not compile programs.' % self.name_string())
-        if self.is_cross:
-            # Can't check if the binaries run so we have to assume they do
-            return
-        pe = subprocess.Popen(binary_name)
-        pe.wait()
-        if pe.returncode != 0:
-            raise EnvironmentException('Executables created by ObjC++ compiler %s are not runnable.' % self.name_string())
+        code = '#import<stdio.h>\nclass MyClass;int main(void) { return 0; }\n'
+        return self._sanity_check_impl(work_dir, environment, 'sanitycheckobjcpp.mm', code)
 
 
 class GnuObjCPPCompiler(GnuCompiler, ObjCPPCompiler):

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os.path, subprocess
 import typing as T
 
-from ..mesonlib import EnvironmentException, MachineChoice
+from ..mesonlib import MachineChoice
 
 from .mixins.clike import CLikeCompiler
 from .compilers import Compiler

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -999,7 +999,7 @@ def detect_tests_to_run(only: T.Dict[str, T.List[str]], use_tmp: bool) -> T.List
             self.category = category                  # category name
             self.subdir = subdir                      # subdirectory
             self.skip = skip                          # skip condition
-            self.stdout_mandatory = stdout_mandatory  # expected stdout is mandatory for tests in this categroy
+            self.stdout_mandatory = stdout_mandatory  # expected stdout is mandatory for tests in this category
 
     all_tests = [
         TestCategory('cmake', 'cmake', not shutil.which('cmake') or (os.environ.get('compiler') == 'msvc2015' and under_ci)),
@@ -1036,6 +1036,8 @@ def detect_tests_to_run(only: T.Dict[str, T.List[str]], use_tmp: bool) -> T.List
     assert categories == ALL_TESTS, 'argparse("--only", choices=ALL_TESTS) need to be updated to match all_tests categories'
 
     if only:
+        for key in only.keys():
+            assert key in categories, 'key `{}` is not a recognized category'.format(key)
         all_tests = [t for t in all_tests if t.category in only.keys()]
 
     gathered_tests = [(t.category, gather_tests(Path('test cases', t.subdir), t.stdout_mandatory, only[t.category]), t.skip) for t in all_tests]


### PR DESCRIPTION
This gets rid of compile warnings when running the test suite (see gh-7344), and simplifies the code. Note that `work_dir` in `sanity_check_impl` was incorrect, it was used both to prepend to file names _and_ as `cwd=work_dir` argument to `Popen`. This is fixed here.

Closes gh-7344


Also adds validation for `--only`. This now gives a clear error rather than silently passes for unrecognized categories, like:
```
python run_project_tests.py --only objc  # should be 'objective c'
```
That's just a tiny 2-line usability improvement.