### PR TITLE
Add test for py.get_install_dir that fails with default prefix

### DIFF
--- a/test cases/python/1 basic/meson.build
+++ b/test cases/python/1 basic/meson.build
@@ -20,6 +20,12 @@ if not py_platlib.endswith('site-packages')
   error('Python3 platlib path seems invalid? ' + py_platlib)
 endif
 
+py_installdir = py.get_install_dir()
+if not py_installdir.startswith(py_purelib)
+  error('Python3 install dir seems invalid? ' + py_installdir)
+endif
+
+
 main = files('prog.py')
 
 test('toplevel', py, args : main)


### PR DESCRIPTION
Shows the issues described in gh-6469:

    message(python_inst.path())
    message(python_inst.get_install_dir())

gives:

    Message: /home/username/anaconda3/envs/meson-dev/bin/python
    Message: /usr/lib/python3.9/site-packages/

The root cause seems to be that the `prefix` variable retrieved at https://github.com/mesonbuild/meson/blob/1ca8fa31ea22df14bf78c90af5ca0b881165ac41/mesonbuild/modules/python.py#L290 gives `/usr`, which is clearly wrong. I'm just not sure what the best way to fix it is.

Submitting as a PR to see if any tests fail (it does fail for me locally).

Any hints on how to debug inside `python.py` would be much appreciated. Trying to set a breakpoint or embed IPython and then running the tests just gives `Reason: Generating the build system failed.` and doesn't actually get me into a debugger.