### PR TITLE
Small fix to dependency() kwargs

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -2061,6 +2061,9 @@ class DependencyFactory:
 
 def get_dep_identifier(name, kwargs) -> T.Tuple:
     identifier = (name, )
+    from ..interpreter import permitted_dependency_kwargs
+    assert len(permitted_dependency_kwargs) == 19, \
+           'Extra kwargs have been added to dependency(), please review if it makes sense to handle it here'
     for key, value in kwargs.items():
         # 'version' is irrelevant for caching; the caller must check version matches
         # 'native' is handled above with `for_machine`
@@ -2069,7 +2072,10 @@ def get_dep_identifier(name, kwargs) -> T.Tuple:
         #     once a dependency has been found through a fallback, it should
         #     be used for the rest of the Meson run.
         # 'default_options' is only used in fallback case
-        if key in ('version', 'native', 'required', 'fallback', 'allow_fallback', 'default_options'):
+        # 'not_found_message' has no impact on the dependency lookup
+        # 'include_type' is handled after the dependency lookup
+        if key in ('version', 'native', 'required', 'fallback', 'allow_fallback', 'default_options',
+                   'not_found_message', 'include_type'):
             continue
         # All keyword arguments are strings, ints, or lists (or lists of lists)
         if isinstance(value, list):

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -176,7 +176,6 @@ permitted_dependency_kwargs = {
     'cmake_package_version',
     'components',
     'default_options',
-    'embed',
     'fallback',
     'include_type',
     'language',

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1538,6 +1538,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         elif name == 'openmp':
             FeatureNew.single_use('OpenMP Dependency', '0.46.0', self.subproject)
 
+    # When adding kwargs, please check if they make sense in dependencies.get_dep_identifier()
     @FeatureNewKwargs('dependency', '0.57.0', ['cmake_package_version'])
     @FeatureNewKwargs('dependency', '0.54.0', ['components'])
     @FeatureNewKwargs('dependency', '0.52.0', ['include_type'])

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -347,7 +347,7 @@ class PythonInstallation(ExternalProgramHolder):
 
         return self.interpreter.func_shared_module(None, args, kwargs)
 
-    @permittedKwargs(permitted_dependency_kwargs)
+    @permittedKwargs(permitted_dependency_kwargs | {'embed'})
     @FeatureNewKwargs('python_installation.dependency', '0.53.0', ['embed'])
     def dependency_method(self, args, kwargs):
         if args:


### PR DESCRIPTION
commit b44b9437f21398fe6af0767860a75a1e12716a3d
Date:   Thu May 6 09:38:35 2021 -0400

    interpreter: Skip not_found_message and include_type in cache id

commit 3d2cbc5c031d0577723c5f783bb704d8cdbe6392
Date:   Thu May 6 09:31:19 2021 -0400

    interpreter: 'embed' kwarg is only valid in python module
