### PR TITLE
Fix python exception thrown for invalid resource path

### DIFF
--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -136,7 +136,7 @@ class QtBaseModule(ExtensionModule):
 
             return rcc_dirname, result
         except Exception:
-            return []
+            raise MesonException(f'Unable to parse resource file {abspath}')
 
     def parse_qrc_deps(self, state, rcc_file):
         rcc_dirname, nodes = self.qrc_nodes(state, rcc_file)


### PR DESCRIPTION
This codepath is reached if a bad path is specified for a qt resource file. The empty list return value is used in two places, both of which unpack to a tuple, which fails, resulting in a python exception and a backtrace written to the console. This change makes the error message look more like meson's other error messages.