### PR TITLE
Add general override functionality. Closes #3001. [WIP]

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -858,6 +858,10 @@ external dependencies (including libraries) must go to "dependencies".''')
     def get_option_internal(self, optname: str):
         key = OptionKey.from_string(optname).evolve(subproject=self.subproject)
 
+        maybe_v = self.coredata.overrides.value_if_overridden(optname, self.subproject)
+        if maybe_v is not None:
+            return maybe_v
+
         if not key.is_project():
             for opts in [self.coredata.options, compilers.base_options]:
                 v = opts.get(key)

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5702,6 +5702,11 @@ class AllPlatformTests(BasePlatformTests):
                 link_args = env.coredata.get_external_link_args(cc.for_machine, cc.language)
                 self.assertEqual(sorted(link_args), sorted(['-flto']))
 
+    def test_overrides(self):
+        testdir = os.path.join(self.unit_test_dir, '96 overriding')
+        native_file = os.path.join(testdir, 'native_overrides.txt')
+        self.init(testdir, extra_args=['--native-file', native_file])
+
 class FailureTests(BasePlatformTests):
     '''
     Tests that test failure conditions. Build files here should be dynamically

--- a/test cases/unit/96 overriding/meson.build
+++ b/test cases/unit/96 overriding/meson.build
@@ -1,0 +1,4 @@
+project('mainprog', 'c')
+
+assert(get_option('buildtype') == 'debug')
+subproject('somesub')

--- a/test cases/unit/96 overriding/native_overrides.txt
+++ b/test cases/unit/96 overriding/native_overrides.txt
@@ -1,0 +1,2 @@
+[override_subprojects]
+buildtype = 'debugoptimized'

--- a/test cases/unit/96 overriding/subprojects/somesub/meson.build
+++ b/test cases/unit/96 overriding/subprojects/somesub/meson.build
@@ -1,0 +1,3 @@
+project('somesub', 'c')
+
+assert(get_option('buildtype') == 'debugoptimized')


### PR DESCRIPTION
This is the very beginning of #3001. Currently only allows overriding an option value for all subprojects (not wired to the backend so does not actually work yet). Should permit at least:

- overriding an option value (`c_std`) per-subproject
- overriding options per target (i.e. optimization value for one target)
- whether a target gets built as a shared or static lib

I currently put the definitions inside the native file. This is probably bad. Maybe we should create its own file type and argument for this? Definitely editing the override file should cause a reconfiguration and rebuild as needed.

Ideas and design requirements welcome.