### PR TITLE
interpreter: flatten environment() initial values

### DIFF
--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -165,7 +165,9 @@ class EnvironmentVariablesHolder(MutableInterpreterObject, ObjectHolder[build.En
             for k, v in initial_values.items():
                 self.set_method([k, v], {})
         elif initial_values is not None:
-            for e in mesonlib.stringlistify(initial_values):
+            for e in mesonlib.listify(initial_values):
+                if not isinstance(e, str):
+                    raise InterpreterException('Env var definition must be a list of strings.')
                 if '=' not in e:
                     raise InterpreterException('Env var definition must be of type key=val.')
                 (k, val) = e.split('=', 1)

--- a/test cases/common/41 test args/meson.build
+++ b/test cases/common/41 test args/meson.build
@@ -23,7 +23,7 @@ test('environment variables 2', e3, env : env2)
 env_array = ['MESONTESTING=picklerror']
 testfile = files('testfile.txt')
 testerpy = find_program('tester.py')
-test('file arg', testerpy, args : testfile, env : env_array)
+test('file arg', testerpy, args : testfile, env : [env_array, 'TEST_LIST_FLATTENING=1'])
 
 copy = find_program('copyfile.py')
 tester = executable('tester', 'tester.c')

--- a/test cases/common/41 test args/tester.py
+++ b/test cases/common/41 test args/tester.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 
 import sys
+import os
+
+assert os.environ['MESONTESTING'] == 'picklerror'
+assert os.environ['TEST_LIST_FLATTENING'] == '1'
 
 with open(sys.argv[1]) as f:
     if f.read() != 'contents\n':


### PR DESCRIPTION
Turns out listify() flattens by default, but stringlistify() cannot
flatten... How do I realize this only now?

Fixes: #8727