### PR TITLE
test:fortran:21: fix Windows by using configure_file(copy:)

### DIFF
--- a/test cases/fortran/21 install static/meson.build
+++ b/test cases/fortran/21 install static/meson.build
@@ -9,7 +9,7 @@ static_dep = dependency('static_hello', fallback: ['static_hello', 'static_hello
 
 mainsrc = 'main_lib.f90'
 mainsrc = configure_file(
-    command: [find_program('cp'), '@INPUT@', '@OUTPUT@'],
+    copy: true,
     input: mainsrc,
     output: 'main_lib_output.F90'
 )

--- a/test cases/fortran/21 install static/subprojects/static_hello/meson.build
+++ b/test cases/fortran/21 install static/subprojects/static_hello/meson.build
@@ -2,7 +2,7 @@ project('static-hello', 'fortran')
 
 # staticlibsource = 'static_hello.f90'
 staticlibsource = configure_file(
-    command: [find_program('cp'), '@INPUT@', '@OUTPUT@'],
+    copy: true,
     input: 'static_hello.f90',
     output: 'static_hello_output.F90'
 )


### PR DESCRIPTION
I didn't see a benefit from explicitly calling platform dependent program vs. using built-in copy method of configure_file(). This makes the test work on Windows, where previously it failed.