### PR TITLE
intel-cl fortran: recognize oneAPI LLVM and Classic compilers

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -1587,7 +1587,8 @@ class Environment:
                         compiler, version, for_machine, is_cross, info,
                         exe_wrap, full_version=full_version, linker=linker)
 
-                if 'Intel(R) Visual Fortran' in err:
+                if any(s in err for s in ['Intel(R) Visual Fortran', 'Intel(R) Fortran Compiler',
+                                          'Intel(R) Fortran Intel(R) 64 Compiler Classic']):
                     version = search_version(err)
                     target = 'x86' if 'IA-32' in err else 'x86_64'
                     cls = IntelClFortranCompiler


### PR DESCRIPTION
Intel oneAPI was officially released January 2021. The Linux / Mac just works with Meson so far as I see in casual tests.
For Windows oneAPI is broken because [xilink is deprecated and removed](https://software.intel.com/content/www/us/en/develop/articles/porting-guide-for-icc-users-to-dpcpp-or-icx.html?wapkw=xilink).
Meson still works on Windows and Mac because simply "ifort" is invoked for linking. That also works for Windows when done by hand. 

```sh
ifort simple.exe.p\simple.f90.obj
```
works for Windows Intel-Cl like on Linux.

@dcbaker do you have thoughts about this?

I think we might detect oneAPI for Windows, and treat it separately from the pre-oneAPI Intel compiler, which is soon to be deprecated and replaced by oneAPI. Instead of the Xilink functions we can make oneAPI on Windows link very similar to Linux/Mac I think.