### PR TITLE
add cpu family csky

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -86,6 +86,7 @@ set in the cross file.
 | arm                 | 32 bit ARM processor     |
 | avr                 | Atmel AVR processor      |
 | c2000               | 32 bit C2000 processor   |
+| csky                | 32 bit CSky processor    |
 | dspic               | 16 bit Microchip dsPIC   |
 | e2k                 | MCST Elbrus processor    |
 | ia64                | Itanium processor        |

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -42,6 +42,7 @@ known_cpu_families = (
     'arm',
     'avr',
     'c2000',
+    'csky',
     'dspic',
     'e2k',
     'ia64',


### PR DESCRIPTION
This is to support the relatively new CPU architecture CSky. See https://c-sky.github.io/