### PR TITLE
doc: fix array syntax

### DIFF
--- a/docs/markdown/Rust-module.md
+++ b/docs/markdown/Rust-module.md
@@ -62,7 +62,7 @@ inc = include_directories('..'¸ '../../foo')
 generated = rust.bindgen(
     'myheader.h',
     'generated.rs',
-    include_directories : [inc, include_directories('foo'),
+    include_directories : [inc, include_directories('foo')],
     args : ['--no-rustfmt-bindings'],
     c_args : ['-DFOO=1'],
 )


### PR DESCRIPTION
Add a missing square bracket to create a valid array.

Edit: I've just noticed the need for the `[skip ci]` tag in the commit message. 