### PR TITLE
Better detection of Visual Studio compiler

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -54,6 +54,16 @@ def setup_vsenv():
         return
     if 'Visual Studio' in os.environ['PATH']:
         return
+    # VSINSTALL is set when running setvars from a Visual Studio installation
+    # Tested with Visual Studio 2012 and 2017
+    if os.environ.get('VSINSTALLDIR', bat_placeholder) != '%VSINSTALLDIR%':
+        return
+    # Check explicitly for cl when on Windows
+    # Windows XP, 2000 and 10 reports 'Windows_NT'. I assume that all other Windows versions in between do the same.
+    if (os.environ.get('OS', bat_placeholder) == 'Windows_NT'):
+        if shutil.which('cl.exe'):
+            return
+
     bat_locator_bin = r'c:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'
     if not os.path.exists(bat_locator_bin):
         return

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -56,7 +56,7 @@ def setup_vsenv():
         return
     # VSINSTALL is set when running setvars from a Visual Studio installation
     # Tested with Visual Studio 2012 and 2017
-    if os.environ.get('VSINSTALLDIR', bat_placeholder) != '%VSINSTALLDIR%':
+    if 'VSINSTALLDIR' in os.environ:
         return
     # Check explicitly for cl when on Windows
     # Windows XP, 2000 and 10 reports 'Windows_NT'. I assume that all other Windows versions in between do the same.

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -59,10 +59,8 @@ def setup_vsenv():
     if 'VSINSTALLDIR' in os.environ:
         return
     # Check explicitly for cl when on Windows
-    # Windows XP, 2000 and 10 reports 'Windows_NT'. I assume that all other Windows versions in between do the same.
-    if (os.environ.get('OS', bat_placeholder) == 'Windows_NT'):
-        if shutil.which('cl.exe'):
-            return
+    if shutil.which('cl.exe'):
+        return
 
     bat_locator_bin = r'c:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'
     if not os.path.exists(bat_locator_bin):


### PR DESCRIPTION
setup_vsenv() failed for me as:
1. I have VS 2021 and 2017 installed and both in non-standard locations (paths without spaces in them)
2. Meson defaulted to VS 2017 but I use VS 2012 and had called setvars in VS 2012 before calling Meson.

I implemented two additional checks:
- one for the VSINSTALLDIR environment variable
- one that checks for "cl.exe" in PATH when the environment variable OS is Windows_NT