### PR TITLE
vala: Test that adding C manually isn't required

### DIFF
--- a/test cases/vala/2 multiple files/meson.build
+++ b/test cases/vala/2 multiple files/meson.build
@@ -1,4 +1,5 @@
-project('multiple files', 'c')
+# adding 'c' shouldn't be required
+project('multiple files')
 add_languages('vala')
 
 glib = dependency('glib-2.0')


### PR DESCRIPTION
I deleted the test that enforced that this failed, but having a test that enforces it passes would be good too.