### PR TITLE
Re-enable various tests on Cygwin

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,8 +116,8 @@ jobs:
       displayName: Install Dependencies
     - script: |
         set PATH=%CYGWIN_ROOT%\bin;%SYSTEMROOT%\system32
-        env.exe -- python3 -m pip --disable-pip-version-check install gcovr pefile jsonschema
-      displayName: "pip install gcovr pefile jsonschema (pytest-xdist broken, skipped: CHECK ME AGAIN)"
+        env.exe -- python3 -m pip --disable-pip-version-check install gcovr pefile pytest-xdist jsonschema
+      displayName: pip install gcovr pefile pytest-xdist jsonschema
     - script: |
         set BOOST_ROOT=
         set PATH=%CYGWIN_ROOT%\bin;%SYSTEMROOT%\system32

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -3075,8 +3075,6 @@ class AllPlatformTests(BasePlatformTests):
 
     @skip_if_not_base_option('b_lto_threads')
     def test_lto_threads(self):
-        if is_cygwin():
-            raise unittest.SkipTest('LTO is broken on Cygwin.')
         testdir = os.path.join(self.common_test_dir, '6 linkshared')
 
         env = get_fake_env(testdir, self.builddir, self.prefix)

--- a/test cases/common/127 generated assembly/meson.build
+++ b/test cases/common/127 generated assembly/meson.build
@@ -2,10 +2,6 @@ project('generated assembly', 'c')
 
 cc = meson.get_compiler('c')
 
-if build_machine.system() == 'cygwin'
-  error('MESON_SKIP_TEST: Cygwin is broken and nobody knows how to fix it. Patches welcome.')
-endif
-
 if ['msvc', 'intel-cl'].contains(cc.get_id())
   error('MESON_SKIP_TEST: assembly files cannot be compiled directly by the compiler')
 endif

--- a/test cases/common/6 linkshared/cpplib.cpp
+++ b/test cases/common/6 linkshared/cpplib.cpp
@@ -1,8 +1,5 @@
-#if defined _WIN32
-    #define DLL_PUBLIC __declspec(dllexport)
-#else
-    #define DLL_PUBLIC __attribute__ ((visibility ("default")))
-#endif
+#define BUILDING_DLL
+#include "cpplib.h"
 
 int DLL_PUBLIC cppfunc(void) {
     return 42;

--- a/test cases/common/6 linkshared/cpplib.h
+++ b/test cases/common/6 linkshared/cpplib.h
@@ -1,0 +1,12 @@
+/* See http://gcc.gnu.org/wiki/Visibility#How_to_use_the_new_C.2B-.2B-_visibility_support */
+#if defined(_WIN32) || defined(__CYGWIN__)
+  #ifdef BUILDING_DLL
+    #define DLL_PUBLIC __declspec(dllexport)
+  #else
+    #define DLL_PUBLIC __declspec(dllimport)
+  #endif
+#else
+    #define DLL_PUBLIC __attribute__ ((visibility ("default")))
+#endif
+
+int DLL_PUBLIC cppfunc(void);

--- a/test cases/common/6 linkshared/cppmain.cpp
+++ b/test cases/common/6 linkshared/cppmain.cpp
@@ -1,4 +1,4 @@
-int cppfunc(void);
+#include "cpplib.h"
 
 int main(void) {
     return cppfunc() != 42;

--- a/test cases/frameworks/11 gir subproject/meson.build
+++ b/test cases/frameworks/11 gir subproject/meson.build
@@ -5,10 +5,6 @@ if not gir.found()
   error('MESON_SKIP_TEST g-ir-scanner not found.')
 endif
 
-if build_machine.system() == 'cygwin'
-  error('MESON_SKIP_TEST GIR seems to be broken in Cygwin and no-one knows how to fix it. Thus we have to disable this.')
-endif
-
 python3 = import('python3')
 py3 = python3.find_python()
 if run_command(py3, '-c', 'import gi;').returncode() != 0

--- a/test cases/frameworks/12 multiple gir/meson.build
+++ b/test cases/frameworks/12 multiple gir/meson.build
@@ -5,10 +5,6 @@ if not gir.found()
   error('MESON_SKIP_TEST g-ir-scanner not found.')
 endif
 
-if build_machine.system() == 'cygwin'
-  error('MESON_SKIP_TEST GIR seems to be broken in Cygwin and no-one knows how to fix it. Thus we have to disable this.')
-endif
-
 gnome = import('gnome')
 gobj = dependency('gobject-2.0')
 

--- a/test cases/frameworks/22 gir link order/meson.build
+++ b/test cases/frameworks/22 gir link order/meson.build
@@ -4,10 +4,6 @@ if not dependency('glib-2.0', required : false).found() or not find_program('g-i
   error('MESON_SKIP_TEST glib not found.')
 endif
 
-if build_machine.system() == 'cygwin'
-  error('MESON_SKIP_TEST GIR seems to be broken in Cygwin and no-one knows how to fix it. Thus we have to disable this.')
-endif
-
 gnome = import('gnome')
 glib = dependency('glib-2.0')
 gobject = dependency('gobject-2.0')

--- a/test cases/frameworks/28 gir link order 2/meson.build
+++ b/test cases/frameworks/28 gir link order 2/meson.build
@@ -4,10 +4,6 @@ if not dependency('gobject-2.0', required : false).found() or not find_program('
   error('MESON_SKIP_TEST gobject not found.')
 endif
 
-if build_machine.system() == 'cygwin'
-  error('MESON_SKIP_TEST GIR seems to be broken in Cygwin and no-one knows how to fix it. Thus we have to disable this.')
-endif
-
 gnome = import('gnome')
 gobject = dependency('gobject-2.0')
 

--- a/test cases/vala/11 generated vapi/meson.build
+++ b/test cases/vala/11 generated vapi/meson.build
@@ -1,9 +1,5 @@
 project('vapi-test', ['c', 'vala'])
 
-if build_machine.system() == 'cygwin'
-  error('MESON_SKIP_TEST GIR seems to be broken in Cygwin and no-one knows how to fix it. Thus we have to disable this.')
-endif
-
 gnome = import('gnome')
 subdir('libfoo')
 subdir('libbar')


### PR DESCRIPTION
`f76c6b8d0 Fix LTO test on Cygwin`

Disabled in #8381
I'm not sure how/if this ever worked.

`91aeae558 Revert "ci: Disable pytest-xdist on cygwin"`

DIsabled in #7597
python-psutil doesn't seem to be in the dependencies for pytest-xdist anymore.

`2d215d93b Revert "Disable failing Cygwin GIR test."`

Disabled in #8381
This was a problem with the Cygwin `gobject-introspection` package which has been fixed.

`1694e4cec Revert "Disable broken asm test on Cygwin as nobody knows how to fix it."`

Disabled in #8505.
