### PR TITLE
Use `installed_base` instead of `base` in sysconfig and don't Define scheme when calling `sysconfig.get_paths`

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -184,7 +184,10 @@ class PythonDependency(ExternalDependency):
                     libpath = f'python{vernum}.dll'
                 else:
                     libpath = Path('libs') / f'python{vernum}.lib'
-            lib = Path(self.variables.get('base')) / libpath
+            if self.variables.get('installed_base') is None:
+                lib = Path(self.variables.get('base')) / libpath
+            else:
+                lib = Path(self.variables.get('installed_base')) / libpath
         elif self.platform == 'mingw':
             if self.static:
                 libname = self.variables.get('LIBRARY')

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -265,7 +265,7 @@ INTROSPECT_COMMAND = '''import sysconfig
 import json
 import sys
 
-install_paths = sysconfig.get_paths(scheme='posix_prefix', vars={'base': '', 'platbase': '', 'installed_base': ''})
+install_paths = sysconfig.get_paths(vars={'base': '', 'platbase': '', 'installed_base': ''})
 
 def links_against_libpython():
     from distutils.core import Distribution, Extension


### PR DESCRIPTION
-  sysconfig: use `installed_base` instead of `base` on windows MSVC python.

    This will help in finding `python<version>.lib` correctly even when we
    are in an virtual environment(venv). So, that people can install from
    source for projects using mesonpep517 on a virtual environment directly,
    with pip.

-  Don't define the scheme when calling `sysconfig.get_paths`
    When using sysconfig to find python on Windows, I find that
    the install location is wrong, as in it installs like posix
    system, which MSVC python can't understand.
    
    The sitepackages folder on win32 for MSVC python
    should be `${PREFIX}\\Lib\\site-packages` but meson currently
    installs it in `${PREFIX}\\lib\\python<version>\\site-packages`
    which is doesn't works even the prefix is set to python install
    location or an venv.
    
    I have also, tested this on Msys2-mingw python, where it returns
    the correct directories.
    
    Fixes #3995

About: https://github.com/mesonbuild/meson/commit/a056dd831e724a16946e4f1781a3a63c5791160c: I don't think this could break `mesonpep517` from the code [here](https://gitlab.com/thiblahute/mesonpep517/-/blob/master/mesonpep517/buildapi.py#L358), also, this would help anyone to add prefix as the python prefix and install directly there using meson itself on Windows, previously I had to manually move folders.

About https://github.com/mesonbuild/meson/commit/703e45f37b9e606e642223b10960ad0c9317f449: this will allow windows users, for projects using `mesonpep517`, to directly install from source on a virtual environment using `pip` or something. This is something I tried with the current version, but meson was unable to find python.
