### PR TITLE
Use relative paths to headers in mkenums_simple.

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1452,12 +1452,7 @@ class GnomeModule(ExtensionModule):
         c_file_kwargs = copy.deepcopy(mkenums_kwargs)
         if 'sources' not in kwargs:
             raise MesonException('Missing keyword argument "sources".')
-        sources = kwargs['sources']
-        if isinstance(sources, str):
-            sources = [sources]
-        elif not isinstance(sources, list):
-            raise MesonException(
-                'Sources keyword argument must be a string or array.')
+        sources = self.interpreter.source_strings_to_files(kwargs['sources'])
 
         # The `install_header` argument will be used by mkenums() when
         # not using template files, so we need to forcibly unset it
@@ -1477,7 +1472,8 @@ class GnomeModule(ExtensionModule):
             fhead += '%s\n' % body_prefix
         fhead += '#include "%s"\n' % hdr_filename
         for hdr in sources:
-            fhead += '#include "%s"\n' % os.path.basename(str(hdr))
+            relpath = hdr.rel_to_builddir(os.path.join(os.path.relpath('.', state.subdir), state.build_to_src))
+            fhead += '#include "%s"\n' % (relpath, )
         fhead += '''
 #define C_ENUM(v) ((gint) v)
 #define C_FLAGS(v) ((guint) v)

--- a/test cases/frameworks/7 gnome/mkenums/meson.build
+++ b/test cases/frameworks/7 gnome/mkenums/meson.build
@@ -138,12 +138,9 @@ enumexe5 = executable('enumprog5', main, enums5, dependencies : gobj)
 
 # Generate template then use as input to mkenums
 
-# Simple trick to copy the file without substitutions, can be
-# removed when https://github.com/mesonbuild/meson/pull/3383 is fixed
 gen_h_template = configure_file(input: 'enums.h.in',
   output: 'enums6.h.in',
-  configuration: configuration_data(),
-  format: 'cmake')
+  copy: true)
 
 enums_h6 = gnome.mkenums('enums6',
   sources : 'meson-sample.h',


### PR DESCRIPTION
This fixes `#include` when the source headers are in a different directory to the final target, while not having `include_directories` for the other directory (which otherwise works by having a subdirectory in `#include` lines). It also fixes the case of `implicit_include_directories: false`.