### PR TITLE
ninjabackend.py: Implement `link_whole:` for pre-VS2015

### DIFF
--- a/test cases/common/137 whole archive/meson.build
+++ b/test cases/common/137 whole archive/meson.build
@@ -6,14 +6,6 @@ endif
 
 add_project_arguments('-I' + meson.source_root(), language : 'c')
 
-cc = meson.get_compiler('c')
-
-if cc.get_id() == 'msvc'
-  if cc.version().version_compare('<19')
-    error('MESON_SKIP_TEST link_whole only works on VS2015 or newer.')
-  endif
-endif
-
 # Test 1: link_whole keeps all symbols
 # Make static func1
 subdir('st_func1')

--- a/test cases/common/137 whole archive/meson.build
+++ b/test cases/common/137 whole archive/meson.build
@@ -6,6 +6,10 @@ endif
 
 add_project_arguments('-I' + meson.source_root(), language : 'c')
 
+if meson.backend() == 'vs2010'
+  error('MESON_SKIP_TEST whole-archive not supported in VS2010. Patches welcome.')
+endif
+
 # Test 1: link_whole keeps all symbols
 # Make static func1
 subdir('st_func1')

--- a/test cases/common/170 generator link whole/meson.build
+++ b/test cases/common/170 generator link whole/meson.build
@@ -4,13 +4,6 @@ if meson.backend() == 'xcode'
     error('MESON_SKIP_TEST: whole-archive not supported in Xcode. Patches welcome.')
 endif
 
-cc = meson.get_compiler('c')
-if cc.get_id() == 'msvc'
-  if cc.version().version_compare('<19')
-    error('MESON_SKIP_TEST link_whole only works on VS2015 or newer.')
-  endif
-endif
-
 # This just generates foo.h and foo.c with int foo() defined.
 gen_py = find_program('generator.py')
 gen = generator(gen_py,


### PR DESCRIPTION
...Update 2, to be exact, since the Visual Studio linker only gained the
`/WHOLEARCHIVE:` feature since Visual Studio 2015 Update 2.

This checks whether we have the corresponding `cl.exe` which is
versioned at or after Visual Studio 2015 Update 2 before we try to apply
the `/WHOLEARCHIVE:xxx` linker flag.  If we aren't, use built-in methods
in Meson to grab the object files of the dependent static lib's, along
with the objects that were `link_whole:`'ed into them, and feed this
list into the linker instead.

This would make `link_whole:` work on Visual Studio 2015 Update 1 and
earlier, including previous Visual Studio versions.

With blessings, thank you!