### PR TITLE
Add Visual Studio 2012/2013 backends

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -69,7 +69,7 @@ machine](#specifying-options-per-machine) section for details.
 | Option                               | Default value | Description                                                    | Is per machine | Is per subproject |
 | ------                               | ------------- | -----------                                                    | -------------- | ----------------- |
 | auto_features {enabled, disabled, auto} | auto       | Override value of all 'auto' features                          | no             | no                |
-| backend {ninja, vs,<br>vs2010, vs2015, vs2017, vs2019, xcode} | ninja | Backend to use                                | no             | no                |
+| backend {ninja, vs,<br>vs2010, vs2012, vs2013, vs2015, vs2017, vs2019, xcode} | ninja | Backend to use                | no             | no                |
 | buildtype {plain, debug,<br>debugoptimized, release, minsize, custom} | debug |  Build type to use                    | no             | no                |
 | debug                                | true          | Debug                                                          | no             | no                |
 | default_library {shared, static, both} | shared      | Default library type                                           | no             | yes               |

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1982,8 +1982,8 @@ the following methods.
   *used as the `script_name` parameter.
 
 - `backend()` *(since 0.37.0)*: returns a string representing the
-  current backend: `ninja`, `vs2010`, `vs2015`, `vs2017`, `vs2019`,
-  or `xcode`.
+  current backend: `ninja`, `vs2010`, `vs2012`, `vs2013`, `vs2015`,
+  `vs2017`, `vs2019`, or `xcode`.
 
 - `build_root()`: returns a string with the absolute path to the build
   root directory. *(deprecated since 0.56.0)*: this function will return the

--- a/docs/markdown/snippets/newvsbackends.md
+++ b/docs/markdown/snippets/newvsbackends.md
@@ -1,0 +1,15 @@
+## New `vs2012` and `vs2013` backend options
+
+Adds the ability to generate Visual Studio 2012 and 2013 projects.  This is an
+extension to the existing Visual Studio 2010 projects so that it is no longer
+required to manually upgrade the generated Visual Studio 2010 projects.
+
+Generating Visual Studio 2010 projects has also been fixed since its developer
+command prompt does not provide a `%VisualStudioVersion%` envvar.
+
+## Developer environment
+
+Expand the support for the `link_whole:` project option for pre-Visual Studio 2015
+Update 2, where previously Visual Studio 2015 Update 2 or later was required for
+this, for the Ninja backend as well as the vs2010 (as well as the newly-added
+vs2012 and vs2013 backends).

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -199,6 +199,9 @@ def get_backend_from_name(backend: str, build: T.Optional[build.Build] = None, i
     elif backend == 'vs2010':
         from . import vs2010backend
         return vs2010backend.Vs2010Backend(build, interpreter)
+    elif backend == 'vs2012':
+        from . import vs2012backend
+        return vs2012backend.Vs2012Backend(build, interpreter)
     elif backend == 'vs2013':
         from . import vs2013backend
         return vs2013backend.Vs2013Backend(build, interpreter)

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -199,6 +199,9 @@ def get_backend_from_name(backend: str, build: T.Optional[build.Build] = None, i
     elif backend == 'vs2010':
         from . import vs2010backend
         return vs2010backend.Vs2010Backend(build, interpreter)
+    elif backend == 'vs2013':
+        from . import vs2013backend
+        return vs2013backend.Vs2013Backend(build, interpreter)
     elif backend == 'vs2015':
         from . import vs2015backend
         return vs2015backend.Vs2015Backend(build, interpreter)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -216,7 +216,7 @@ class Vs2010Backend(backends.Backend):
         if 'VCINSTALLDIR' in os.environ:
             vs_version = os.environ['VisualStudioVersion'] \
                 if 'VisualStudioVersion' in os.environ else None
-            relative_path = 'Auxiliary\\Build\\' if vs_version >= '15.0' else ''
+            relative_path = 'Auxiliary\\Build\\' if vs_version is not None and vs_version >= '15.0' else ''
             script_path = os.environ['VCINSTALLDIR'] + relative_path + 'vcvarsall.bat'
             if os.path.exists(script_path):
                 if has_arch_values:

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -37,8 +37,11 @@ def autodetect_vs_version(build: T.Optional[build.Build], interpreter: T.Optiona
     if not vs_install_dir:
         raise MesonException('Could not detect Visual Studio: Environment variable VSINSTALLDIR is not set!\n'
                              'Are you running meson from the Visual Studio Developer Command Prompt?')
-    # VisualStudioVersion is set since Visual Studio 12.0, but sometimes
+    # VisualStudioVersion is set since Visual Studio 11.0, but sometimes
     # vcvarsall.bat doesn't set it, so also use VSINSTALLDIR
+    if vs_version == '11.0' or 'Visual Studio 11' in vs_install_dir:
+        from mesonbuild.backend.vs2012backend import Vs2012Backend
+        return Vs2012Backend(build, interpreter)
     if vs_version == '12.0' or 'Visual Studio 12' in vs_install_dir:
         from mesonbuild.backend.vs2013backend import Vs2013Backend
         return Vs2013Backend(build, interpreter)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -39,6 +39,9 @@ def autodetect_vs_version(build: T.Optional[build.Build], interpreter: T.Optiona
                              'Are you running meson from the Visual Studio Developer Command Prompt?')
     # VisualStudioVersion is set since Visual Studio 12.0, but sometimes
     # vcvarsall.bat doesn't set it, so also use VSINSTALLDIR
+    if vs_version == '12.0' or 'Visual Studio 12' in vs_install_dir:
+        from mesonbuild.backend.vs2013backend import Vs2013Backend
+        return Vs2013Backend(build, interpreter)
     if vs_version == '14.0' or 'Visual Studio 14' in vs_install_dir:
         from mesonbuild.backend.vs2015backend import Vs2015Backend
         return Vs2015Backend(build, interpreter)

--- a/mesonbuild/backend/vs2012backend.py
+++ b/mesonbuild/backend/vs2012backend.py
@@ -1,0 +1,38 @@
+# Copyright 2014-2016 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .vs2010backend import Vs2010Backend
+from ..mesonlib import MesonException
+from ..interpreter import Interpreter
+from ..build import Build
+import typing as T
+
+
+class Vs2012Backend(Vs2010Backend):
+    def __init__(self, build: T.Optional[Build], interpreter: T.Optional[Interpreter]):
+        super().__init__(build, interpreter)
+        self.name = 'vs2012'
+        self.vs_version = '2012'
+        if self.environment is not None:
+            # TODO: we assume host == build
+            comps = self.environment.coredata.compilers.host
+            if comps and all(c.id == 'intel-cl' for c in comps.values()):
+                c = list(comps.values())[0]
+                if c.version.startswith('19'):
+                    self.platform_toolset = 'Intel C++ Compiler 19.0'
+                else:
+                    # We don't have support for versions older than 2019 right now.
+                    raise MesonException('There is currently no support for ICL before 19, patches welcome.')
+            if self.platform_toolset is None:
+                self.platform_toolset = 'v110'

--- a/mesonbuild/backend/vs2013backend.py
+++ b/mesonbuild/backend/vs2013backend.py
@@ -1,0 +1,38 @@
+# Copyright 2014-2016 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .vs2010backend import Vs2010Backend
+from ..mesonlib import MesonException
+from ..interpreter import Interpreter
+from ..build import Build
+import typing as T
+
+
+class Vs2013Backend(Vs2010Backend):
+    def __init__(self, build: T.Optional[Build], interpreter: T.Optional[Interpreter]):
+        super().__init__(build, interpreter)
+        self.name = 'vs2013'
+        self.vs_version = '2013'
+        if self.environment is not None:
+            # TODO: we assume host == build
+            comps = self.environment.coredata.compilers.host
+            if comps and all(c.id == 'intel-cl' for c in comps.values()):
+                c = list(comps.values())[0]
+                if c.version.startswith('19'):
+                    self.platform_toolset = 'Intel C++ Compiler 19.0'
+                else:
+                    # We don't have support for versions older than 2019 right now.
+                    raise MesonException('There is currently no support for ICL before 19, patches welcome.')
+            if self.platform_toolset is None:
+                self.platform_toolset = 'v120'

--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -39,6 +39,7 @@ backend_generator_map = {
     'ninja': 'Ninja',
     'xcode': 'Xcode',
     'vs2010': 'Visual Studio 10 2010',
+    'vs2012': 'Visual Studio 11 2012',
     'vs2013': 'Visual Studio 12 2013',
     'vs2015': 'Visual Studio 14 2015',
     'vs2017': 'Visual Studio 15 2017',

--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -39,7 +39,8 @@ backend_generator_map = {
     'ninja': 'Ninja',
     'xcode': 'Xcode',
     'vs2010': 'Visual Studio 10 2010',
-    'vs2015': 'Visual Studio 15 2017',
+    'vs2013': 'Visual Studio 12 2013',
+    'vs2015': 'Visual Studio 14 2015',
     'vs2017': 'Visual Studio 15 2017',
     'vs2019': 'Visual Studio 16 2019',
 }

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -43,7 +43,7 @@ if T.TYPE_CHECKING:
     CompilerCheckCacheKey = T.Tuple[T.Tuple[str, ...], str, str, T.Tuple[str, ...], str]
 
 version = '0.58.999'
-backendlist = ['ninja', 'vs', 'vs2010', 'vs2013', 'vs2015', 'vs2017', 'vs2019', 'xcode']
+backendlist = ['ninja', 'vs', 'vs2010', 'vs2012', 'vs2013', 'vs2015', 'vs2017', 'vs2019', 'xcode']
 
 default_yielding = False
 

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -43,7 +43,7 @@ if T.TYPE_CHECKING:
     CompilerCheckCacheKey = T.Tuple[T.Tuple[str, ...], str, str, T.Tuple[str, ...], str]
 
 version = '0.58.999'
-backendlist = ['ninja', 'vs', 'vs2010', 'vs2015', 'vs2017', 'vs2019', 'xcode']
+backendlist = ['ninja', 'vs', 'vs2010', 'vs2013', 'vs2015', 'vs2017', 'vs2019', 'xcode']
 
 default_yielding = False
 

--- a/test cases/common/137 whole archive/meson.build
+++ b/test cases/common/137 whole archive/meson.build
@@ -1,14 +1,13 @@
 project('whole archive', 'c')
 
-if meson.backend() == 'xcode'
-    error('MESON_SKIP_TEST: whole-archive not supported in Xcode. Patches welcome.')
+if meson.backend() == 'xcode' or \
+   meson.backend() == 'vs2010' or \
+   meson.backend() == 'vs2012' or \
+   meson.backend() == 'vs2013'
+    error('MESON_SKIP_TEST: whole-archive not supported in Xcode nor pre-VS2015 IDE. Patches welcome.')
 endif
 
 add_project_arguments('-I' + meson.source_root(), language : 'c')
-
-if meson.backend() == 'vs2010'
-  error('MESON_SKIP_TEST whole-archive not supported in VS2010. Patches welcome.')
-endif
 
 # Test 1: link_whole keeps all symbols
 # Make static func1


### PR DESCRIPTION
Hi,

This PR attempts to add Visual Studio 2012/2013 backends, along with implementing `link_whole:` on pre-Visual Studio 2015 Update 2.

The 2012/2013 backend is a quick port from the 2015 one, and the implementation of `link_whole:` is a port from the one that is being done in PR 8802, but adapted for the Visual Studio backends.

Also fix the Visual Studio 2015 version string in `mesonbuild/cmake/interpretor.py`.

With blessings, thank you!