### PR TITLE
modules/gnome: Correctly handle generated sources for generate_gir

### DIFF
--- a/test cases/frameworks/7 gnome/gir/copy.py
+++ b/test cases/frameworks/7 gnome/gir/copy.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2021 Intel Corproation
+
+import argparse
+import shutil
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('src')
+    parser.add_argument('dest')
+    args = parser.parse_args()
+
+    shutil.copy(args.src, args.dest)
+
+
+if __name__ == "__main__":
+    main()

--- a/test cases/frameworks/7 gnome/gir/meson.build
+++ b/test cases/frameworks/7 gnome/gir/meson.build
@@ -3,6 +3,14 @@ subdir('dep1')
 libsources = ['meson-sample.c', 'meson-sample.h']
 lib2sources = ['meson-sample2.c', 'meson-sample2.h']
 
+gen_source = custom_target(
+  'meson_smaple3.h',
+  input : 'meson-sample.h',
+  output : 'meson-sample3.h',
+  command : [find_program('copy.py'), '@INPUT@', '@OUTPUT@'],
+  build_by_default : false,  # this will force a race condition if one exists
+)
+
 girlib = shared_library(
   'gir_lib',
   sources : libsources,
@@ -28,7 +36,7 @@ fake_dep = dependency('no-way-this-exists', required: false)
 
 gnome.generate_gir(
   girlib, girlib2,
-  sources : libsources + lib2sources,
+  sources : [libsources, lib2sources, gen_source],
   nsversion : '1.0',
   namespace : 'Meson',
   symbol_prefix : 'meson',


### PR DESCRIPTION
We need to pass any generated sources down the CustomTarget
inititalizers so that they will generate a dependency correctly,
otherwise we get race conditions.