### PR TITLE
Vala: Add missing FeatureNew() when C is missing

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1192,6 +1192,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         langs = set(self.coredata.compilers[for_machine].keys())
         langs.update(args)
         if 'vala' in langs and 'c' not in langs:
+            FeatureNew('Adding Vala language without C', '0.59.0').use(self.subproject)
             args.append('c')
 
         success = True


### PR DESCRIPTION
It was previously an hard error, only permitted since 0.59.0.