### PR TITLE
vsenv: Recommend using "meson compile" wrapper

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -46,6 +46,7 @@ from ..mesonlib import get_compiler_for_source, has_path_sep, OptionKey
 from .backends import CleanTrees
 from ..build import GeneratedList, InvalidArguments, ExtractedObjects
 from ..interpreter import Interpreter
+from ..mesonmain import need_setup_vsenv
 
 if T.TYPE_CHECKING:
     from ..linkers import StaticLinker
@@ -508,6 +509,13 @@ int dummy;
 
     def generate(self):
         ninja = environment.detect_ninja_command_and_version(log=True)
+        if need_setup_vsenv:
+            builddir = Path(self.environment.get_build_dir())
+            builddir = builddir.relative_to(Path.cwd())
+            meson_command = mesonlib.join_args(mesonlib.get_meson_command())
+            mlog.log()
+            mlog.log('Visual Studio environment is needed to run Ninja. It is recommended to use Meson wrapper:')
+            mlog.log(f'{meson_command} compile -C {builddir}')
         if ninja is None:
             raise MesonException('Could not detect Ninja v1.8.2 or newer')
         (self.ninja_command, self.ninja_version) = ninja

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -27,6 +27,8 @@ from .mesonlib import MesonException
 from .environment import detect_msys2_arch
 from .wrap import wraptool
 
+need_setup_vsenv = False
+
 bat_template = '''@ECHO OFF
 
 call "{}"
@@ -102,7 +104,8 @@ def setup_vsenv():
             continue
         k, v = bat_line.split('=', 1)
         os.environ[k] = v
-
+    global need_setup_vsenv
+    need_setup_vsenv = True
 
 
 # Note: when adding arguments, please also add them to the completion


### PR DESCRIPTION
When meson has setup the VS environment, running ninja to build won't
work, user should use meson wrapper to compile.