### PR TITLE
Don't use `os.path.relpath` in dist command

### DIFF
--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -313,5 +313,5 @@ def run(options):
     if rc == 0:
         for name in names:
             create_hash(name)
-            print('Created', os.path.relpath(name))
+            print('Created', name)
     return rc


### PR DESCRIPTION
This is problematic when we meson is installed in the different 
root(say C:) while building from another root(say D:).
This is how it is done in mesonpep517 and causes problems
because of that.
What I tried was clone https://gitlab.com/thiblahute/mesonpep517 then, run `python -m build -sn`
and this happened (I have removed all extra things to just show the error from meson)
```cmd
H:\mesonstuff\new\mesonpep517>python -m build -sn
Cloning into 'C:\Users\User\AppData\Local\Temp\tmp0isx1sp0\meson-dist\mesonp
ep517-0.2'...
done.
Traceback (most recent call last):
  File "C:\Users\User\AppData\Roaming\Python\Python37\site-packages\meson
build\mesonmain.py", line 134, in run
    return options.run_func(options)
  File "C:\Users\User\AppData\Roaming\Python\Python37\site-packages\meson
build\mdist.py", line 316, in run
    print('Created', os.path.relpath(name))
  File "c:\program files\python37\lib\ntpath.py", line 562, in relpath
    path_drive, start_drive))
ValueError: path is on mount 'C:', start on mount 'H:'
```
Rather than trying to print the relative path, it would simply be good to print the absolute path rather than erroring out. 

I have tested this and it seems to work.