### PR TITLE
test cases/common/103 has header symbol: set c++ standard

### DIFF
--- a/test cases/common/103 has header symbol/meson.build
+++ b/test cases/common/103 has header symbol/meson.build
@@ -1,4 +1,8 @@
-project('has header symbol', 'c', 'cpp')
+project(
+  'has header symbol',
+  'c', 'cpp',
+  default_options : ['cpp_std=c++11'],
+)
 
 cc = meson.get_compiler('c')
 cpp = meson.get_compiler('cpp')


### PR DESCRIPTION
On mac this appears to default to c++98, which in turn falls over with
boost that requires at least c++11