### PR TITLE
A few of the basic cleanups and enhancements from the Qt series

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2242,7 +2242,7 @@ class CustomTarget(Target, CommandBase):
         self.typename = 'custom'
         # TODO expose keyword arg to make MachineChoice.HOST configurable
         super().__init__(name, subdir, subproject, False, MachineChoice.HOST)
-        self.dependencies = []
+        self.dependencies: T.List[T.Union[CustomTarget, BuildTarget]] = []
         self.extra_depends = []
         self.depend_files = [] # Files that this target depends on but are not on the command line.
         self.depfile = None

--- a/mesonbuild/dependencies/detect.py
+++ b/mesonbuild/dependencies/detect.py
@@ -25,6 +25,7 @@ import typing as T
 
 if T.TYPE_CHECKING:
     from ..environment import Environment
+    from .base import ExternalDependency
     from .factory import DependencyType
 
 # These must be defined in this file to avoid cyclical references.
@@ -69,7 +70,7 @@ display_name_map = {
     'wxwidgets': 'WxWidgets',
 }
 
-def find_external_dependency(name, env, kwargs):
+def find_external_dependency(name: str, env: 'Environment', kwargs: T.Dict[str, object]) -> 'ExternalDependency':
     assert(name)
     required = kwargs.get('required', True)
     if not isinstance(required, bool):
@@ -92,8 +93,8 @@ def find_external_dependency(name, env, kwargs):
     # build a list of dependency methods to try
     candidates = _build_external_dependency_list(name, env, for_machine, kwargs)
 
-    pkg_exc = []
-    pkgdep = []
+    pkg_exc: T.List[DependencyException] = []
+    pkgdep: T.List['ExternalDependency'] = []
     details = ''
 
     for c in candidates:
@@ -154,7 +155,7 @@ def find_external_dependency(name, env, kwargs):
 
 
 def _build_external_dependency_list(name: str, env: 'Environment', for_machine: MachineChoice,
-                                    kwargs: T.Dict[str, T.Any]) -> T.List['DependencyType']:
+                                    kwargs: T.Dict[str, T.Any]) -> T.List[T.Callable[[], 'ExternalDependency']]:
     # First check if the method is valid
     if 'method' in kwargs and kwargs['method'] not in [e.value for e in DependencyMethods]:
         raise DependencyException('method {!r} is invalid'.format(kwargs['method']))

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -947,7 +947,7 @@ class CustomTargetIndexHolder(TargetHolder[build.CustomTargetIndex]):
     def full_path_method(self, args, kwargs):
         return self.interpreter.backend.get_target_filename_abs(self.held_object)
 
-class CustomTargetHolder(TargetHolder):
+class CustomTargetHolder(TargetHolder[build.CustomTarget]):
     def __init__(self, target: 'build.CustomTarget', interp: 'Interpreter'):
         super().__init__(target, interp)
         self.methods.update({'full_path': self.full_path_method,

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -238,8 +238,8 @@ class permittedKwargs:
 
 
 def typed_pos_args(name: str, *types: T.Union[T.Type, T.Tuple[T.Type, ...]],
-                   varargs: T.Optional[T.Union[T.Type, T.Tuple[T.Type]]] = None,
-                   optargs: T.Optional[T.List[T.Union[T.Type, T.Tuple[T.Type]]]] = None,
+                   varargs: T.Optional[T.Union[T.Type, T.Tuple[T.Type, ...]]] = None,
+                   optargs: T.Optional[T.List[T.Union[T.Type, T.Tuple[T.Type, ...]]]] = None,
                    min_varargs: int = 0, max_varargs: int = 0) -> T.Callable[..., T.Any]:
     """Decorator that types type checking of positional arguments.
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1574,6 +1574,17 @@ class InternalTests(unittest.TestCase):
 
         _(None, mock.Mock(), [], {'input': 'str'})
 
+    def test_typed_kwarg_container_default_copy(self) -> None:
+        default: T.List[str] = []
+        @typed_kwargs(
+            'testfunc',
+            KwargInfo('input', ContainerTypeInfo(list, str), listify=True, default=default),
+        )
+        def _(obj, node, args: T.Tuple, kwargs: T.Dict[str, T.List[str]]) -> None:
+            self.assertIsNot(kwargs['input'], default)
+
+        _(None, mock.Mock(), [], {})
+
     def test_typed_kwarg_container_pairs(self) -> None:
         @typed_kwargs(
             'testfunc',


### PR DESCRIPTION
This is a few of the simpler side cleanup sort of patches from #8822, most of these are type annotations, but there is also a change to the `typed_kwargs` decorator to allow safely passing mutable containers as default values in the Kwargs, which is useful for cases were you want the default to be an empty list.