### PR TITLE
typing: Fully annotate dependencies.{detect,factory} + some other fixes

### DIFF
--- a/mesonbuild/dependencies/coarrays.py
+++ b/mesonbuild/dependencies/coarrays.py
@@ -22,14 +22,15 @@ from .factory import factory_methods
 
 if T.TYPE_CHECKING:
     from . base import Dependency
+    from . factory import TV_DepGenerators
     from ..environment import Environment, MachineChoice
 
 
 @factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.CMAKE, DependencyMethods.SYSTEM})
 def coarray_factory(env: 'Environment', for_machine: 'MachineChoice',
-                    kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> T.List[T.Callable[[], 'Dependency']]:
+                    kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> 'TV_DepGenerators':
     fcid = detect_compiler('coarray', env, for_machine, 'fortran').get_id()
-    candidates: T.List[T.Callable[[], 'Dependency']] = []
+    candidates: 'TV_DepGenerators' = []
 
     if fcid == 'gcc':
         # OpenCoarrays is the most commonly used method for Fortran Coarray with GCC

--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -30,6 +30,7 @@ import typing as T
 
 if T.TYPE_CHECKING:
     from .base import Dependency
+    from .factory import TV_DepGenerators
     from ..environment import Environment
     from ..mesonlib import MachineChoice
 
@@ -143,7 +144,7 @@ class HDF5ConfigToolDependency(ConfigToolDependency):
             nkwargs = kwargs.copy()
             nkwargs['language'] = 'c'
             # I'm being too clever for mypy and pylint
-            self.is_found = self._add_sub_dependency(hdf5_factory(environment, for_machine, nkwargs))  # type: ignore  # pylint: disable=no-value-for-parameter
+            self.is_found = self._add_sub_dependency(hdf5_factory(environment, for_machine, nkwargs))  # pylint: disable=no-value-for-parameter
 
     def _sanitize_version(self, ver: str) -> str:
         v = re.search(r'\s*HDF5 Version: (\d+\.\d+\.\d+)', ver)
@@ -152,9 +153,9 @@ class HDF5ConfigToolDependency(ConfigToolDependency):
 
 @factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL})
 def hdf5_factory(env: 'Environment', for_machine: 'MachineChoice',
-                 kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> T.List[T.Callable[[], 'Dependency']]:
+                 kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> 'TV_DepGenerators':
     language = kwargs.get('language')
-    candidates = []  # type: T.List[T.Callable[[], Dependency]]
+    candidates: 'TV_DepGenerators' = []
 
     if DependencyMethods.PKGCONFIG in methods:
         # Use an ordered set so that these remain the first tried pkg-config files

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -32,12 +32,13 @@ from .factory import DependencyFactory, factory_methods
 
 if T.TYPE_CHECKING:
     from ..environment import Environment, MachineChoice
+    from .factory import TV_DepGenerators
     from .base import DependencyType, Dependency  # noqa: F401
 
 
 @factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.CMAKE})
 def netcdf_factory(env: 'Environment', for_machine: 'MachineChoice',
-                   kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> T.List['DependencyType']:
+                   kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> 'TV_DepGenerators':
     language = kwargs.get('language', 'c')
     if language not in ('c', 'cpp', 'fortran'):
         raise DependencyException(f'Language {language} is not supported with NetCDF.')
@@ -487,8 +488,8 @@ class CursesSystemDependency(ExternalDependency):
 
 @factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.SYSTEM})
 def curses_factory(env: 'Environment', for_machine: 'MachineChoice',
-                   kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> T.List[T.Callable[[], 'Dependency']]:
-    candidates = []  # type: T.List[T.Callable[[], Dependency]]
+                   kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> 'TV_DepGenerators':
+    candidates: 'TV_DepGenerators' = []
 
     if DependencyMethods.PKGCONFIG in methods:
         pkgconfig_files = ['pdcurses', 'ncursesw', 'ncurses', 'curses']
@@ -510,7 +511,7 @@ def curses_factory(env: 'Environment', for_machine: 'MachineChoice',
 
 @factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM})
 def shaderc_factory(env: 'Environment', for_machine: 'MachineChoice',
-                    kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> T.List['DependencyType']:
+                    kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> 'TV_DepGenerators':
     """Custom DependencyFactory for ShaderC.
 
     ShaderC's odd you get three different libraries from the same build

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -25,6 +25,7 @@ from ..environment import detect_cpu_family
 
 if T.TYPE_CHECKING:
     from .base import Dependency
+    from .factory import TV_DepGenerators
     from ..compilers import Compiler
     from ..compilers.compiler import CompilerType
     from ..environment import Environment, MachineChoice
@@ -32,13 +33,13 @@ if T.TYPE_CHECKING:
 
 @factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.SYSTEM})
 def mpi_factory(env: 'Environment', for_machine: 'MachineChoice',
-                kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> T.List[T.Callable[[], 'Dependency']]:
+                kwargs: T.Dict[str, T.Any], methods: T.List[DependencyMethods]) -> 'TV_DepGenerators':
     language = kwargs.get('language', 'c')
     if language not in {'c', 'cpp', 'fortran'}:
         # OpenMPI doesn't work without any other languages
         return []
 
-    candidates = []  # type: T.List[T.Callable[[], Dependency]]
+    candidates: 'TV_DepGenerators' = []
     compiler = detect_compiler('mpi', env, for_machine, language)  # type: T.Optional['CompilerType']
     if compiler is None:
         return []

--- a/mesonbuild/dependencies/scalapack.py
+++ b/mesonbuild/dependencies/scalapack.py
@@ -25,13 +25,13 @@ from .factory import factory_methods
 
 if T.TYPE_CHECKING:
     from ..environment import Environment, MachineChoice
-    from .base import DependencyType
+    from .factory import TV_DepGenerators
 
 
 @factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.CMAKE})
 def scalapack_factory(env: 'Environment', for_machine: 'MachineChoice',
                       kwargs: T.Dict[str, T.Any],
-                      methods: T.List[DependencyMethods]) -> T.List['DependencyType']:
+                      methods: T.List[DependencyMethods]) -> 'TV_DepGenerators':
     candidates = []
 
     if DependencyMethods.PKGCONFIG in methods:

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -18,10 +18,13 @@ modules = [
     # specific files
     'mesonbuild/arglist.py',
     # 'mesonbuild/coredata.py',
+    'mesonbuild/dependencies/__init__.py',
+    'mesonbuild/dependencies/factory.py',
     'mesonbuild/dependencies/base.py',
     'mesonbuild/dependencies/coarrays.py',
     'mesonbuild/dependencies/configtool.py',
     'mesonbuild/dependencies/cuda.py',
+    'mesonbuild/dependencies/detect.py',
     'mesonbuild/dependencies/boost.py',
     'mesonbuild/dependencies/hdf5.py',
     'mesonbuild/dependencies/mpi.py',


### PR DESCRIPTION
This was more complicated than expected...

I replaced some `functools.partial` calls with lambdas because of typing issues: https://github.com/python/mypy/issues/1484