### PR TITLE
Type checking and annotations for the `add_*_arguments functions and helpers

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -213,9 +213,9 @@ class Build:
             environment.is_cross_build(), {}, {})
         self.global_link_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachineDefaultable.default(
             environment.is_cross_build(), {}, {})
-        self.projects_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachineDefaultable.default(
+        self.projects_args: PerMachine[T.Dict[str, T.Dict[str, T.List[str]]]] = PerMachineDefaultable.default(
             environment.is_cross_build(), {}, {})
-        self.projects_link_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachineDefaultable.default(
+        self.projects_link_args: PerMachine[T.Dict[str, T.Dict[str, T.List[str]]]] = PerMachineDefaultable.default(
             environment.is_cross_build(), {}, {})
         self.tests: T.List['Test'] = []
         self.benchmarks: T.List['Test'] = []

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2556,24 +2556,24 @@ This warning will become a hard error in a future Meson release.
     @typed_pos_args('add_global_arguments', varargs=str)
     @typed_kwargs('add_global_arguments', _NATIVE_KW, _LANGUAGE_KW)
     def func_add_global_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs: 'kwargs.FuncAddProjectArgs') -> None:
-        self.add_global_arguments(node, self.build.global_args[kwargs['native']], args[0], kwargs)
+        self._add_global_arguments(node, self.build.global_args[kwargs['native']], args[0], kwargs)
 
     @typed_pos_args('add_global_link_arguments', varargs=str)
     @typed_kwargs('add_global_arguments', _NATIVE_KW, _LANGUAGE_KW)
     def func_add_global_link_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs: 'kwargs.FuncAddProjectArgs') -> None:
-        self.add_global_arguments(node, self.build.global_link_args[kwargs['native']], args[0], kwargs)
+        self._add_global_arguments(node, self.build.global_link_args[kwargs['native']], args[0], kwargs)
 
     @typed_pos_args('add_project_arguments', varargs=str)
     @typed_kwargs('add_global_arguments', _NATIVE_KW, _LANGUAGE_KW)
     def func_add_project_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs: 'kwargs.FuncAddProjectArgs') -> None:
-        self.add_project_arguments(node, self.build.projects_args[kwargs['native']], args[0], kwargs)
+        self._add_project_arguments(node, self.build.projects_args[kwargs['native']], args[0], kwargs)
 
     @typed_pos_args('add_project_link_arguments', varargs=str)
     @typed_kwargs('add_global_arguments', _NATIVE_KW, _LANGUAGE_KW)
     def func_add_project_link_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs: 'kwargs.FuncAddProjectArgs') -> None:
-        self.add_project_arguments(node, self.build.projects_link_args[kwargs['native']], args[0], kwargs)
+        self._add_project_arguments(node, self.build.projects_link_args[kwargs['native']], args[0], kwargs)
 
-    def warn_about_builtin_args(self, args: T.List[str]) -> None:
+    def _warn_about_builtin_args(self, args: T.List[str]) -> None:
         # -Wpedantic is deliberately not included, since some people want to use it but not use -Wextra
         # see e.g.
         # https://github.com/mesonbuild/meson/issues/3275#issuecomment-641354956
@@ -2600,8 +2600,8 @@ This warning will become a hard error in a future Meson release.
                 mlog.warning(f'Consider using the built-in option for language standard version instead of using "{arg}".',
                              location=self.current_node)
 
-    def add_global_arguments(self, node: mparser.FunctionNode, argsdict: T.Dict[str, T.List[str]],
-                             args: T.List[str], kwargs: 'kwargs.FuncAddProjectArgs') -> None:
+    def _add_global_arguments(self, node: mparser.FunctionNode, argsdict: T.Dict[str, T.List[str]],
+                              args: T.List[str], kwargs: 'kwargs.FuncAddProjectArgs') -> None:
         if self.is_subproject():
             msg = 'Function \'{}\' cannot be used in subprojects because ' \
                   'there is no way to make that reliable.\nPlease only call ' \
@@ -2611,24 +2611,24 @@ This warning will become a hard error in a future Meson release.
                   'in each target.'.format(node.func_name)
             raise InvalidCode(msg)
         frozen = self.project_args_frozen or self.global_args_frozen
-        self.add_arguments(node, argsdict, frozen, args, kwargs)
+        self._add_arguments(node, argsdict, frozen, args, kwargs)
 
-    def add_project_arguments(self, node: mparser.FunctionNode, argsdict: T.Dict[str, T.Dict[str, T.List[str]]],
-                              args: T.List[str], kwargs: 'kwargs.FuncAddProjectArgs') -> None:
+    def _add_project_arguments(self, node: mparser.FunctionNode, argsdict: T.Dict[str, T.Dict[str, T.List[str]]],
+                               args: T.List[str], kwargs: 'kwargs.FuncAddProjectArgs') -> None:
         if self.subproject not in argsdict:
             argsdict[self.subproject] = {}
-        self.add_arguments(node, argsdict[self.subproject],
-                           self.project_args_frozen, args, kwargs)
+        self._add_arguments(node, argsdict[self.subproject],
+                            self.project_args_frozen, args, kwargs)
 
-    def add_arguments(self, node: mparser.FunctionNode, argsdict: T.Dict[str, T.List[str]],
-                      args_frozen: bool, args: T.List[str], kwargs: 'kwargs.FuncAddProjectArgs') -> None:
+    def _add_arguments(self, node: mparser.FunctionNode, argsdict: T.Dict[str, T.List[str]],
+                       args_frozen: bool, args: T.List[str], kwargs: 'kwargs.FuncAddProjectArgs') -> None:
         if args_frozen:
             msg = 'Tried to use \'{}\' after a build target has been declared.\n' \
                   'This is not permitted. Please declare all ' \
                   'arguments before your targets.'.format(node.func_name)
             raise InvalidCode(msg)
 
-        self.warn_about_builtin_args(args)
+        self._warn_about_builtin_args(args)
 
         for lang in kwargs['language']:
             argsdict[lang] = argsdict.get(lang, []) + args

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2531,28 +2531,28 @@ This warning will become a hard error in a future Meson release.
                                                              exclude_suites)
 
     @permittedKwargs({'language', 'native'})
-    @stringArgs
-    def func_add_global_arguments(self, node, args, kwargs):
+    @typed_pos_args('add_global_arguments', varargs=str)
+    def func_add_global_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs):
         for_machine = self.machine_from_native_kwarg(kwargs)
-        self.add_global_arguments(node, self.build.global_args[for_machine], args, kwargs)
+        self.add_global_arguments(node, self.build.global_args[for_machine], args[0], kwargs)
 
     @permittedKwargs({'language', 'native'})
-    @stringArgs
-    def func_add_global_link_arguments(self, node, args, kwargs):
+    @typed_pos_args('add_global_link_arguments', varargs=str)
+    def func_add_global_link_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs):
         for_machine = self.machine_from_native_kwarg(kwargs)
-        self.add_global_arguments(node, self.build.global_link_args[for_machine], args, kwargs)
+        self.add_global_arguments(node, self.build.global_link_args[for_machine], args[0], kwargs)
 
     @permittedKwargs({'language', 'native'})
-    @stringArgs
-    def func_add_project_arguments(self, node, args, kwargs):
+    @typed_pos_args('add_project_arguments', varargs=str)
+    def func_add_project_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs):
         for_machine = self.machine_from_native_kwarg(kwargs)
-        self.add_project_arguments(node, self.build.projects_args[for_machine], args, kwargs)
+        self.add_project_arguments(node, self.build.projects_args[for_machine], args[0], kwargs)
 
     @permittedKwargs({'language', 'native'})
-    @stringArgs
-    def func_add_project_link_arguments(self, node, args, kwargs):
+    @typed_pos_args('add_project_link_arguments', varargs=str)
+    def func_add_project_link_arguments(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs):
         for_machine = self.machine_from_native_kwarg(kwargs)
-        self.add_project_arguments(node, self.build.projects_link_args[for_machine], args, kwargs)
+        self.add_project_arguments(node, self.build.projects_link_args[for_machine], args[0], kwargs)
 
     def warn_about_builtin_args(self, args):
         # -Wpedantic is deliberately not included, since some people want to use it but not use -Wextra

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2021 The Meson Developers
+# Copyright © 2021 Intel Corporation
+
+"""Keyword Argument type annotations."""
+
+import typing as T
+
+from typing_extensions import TypedDict
+
+from ..mesonlib import MachineChoice
+
+
+class FuncAddProjectArgs(TypedDict):
+
+    """Keyword Arguments for the add_*_arguments family of arguments.
+
+    including `add_global_arguments`, `add_project_arguments`, and their
+    link variants
+
+    Because of the use of a convertor function, we get the native keyword as
+    a MachineChoice instance already.
+    """
+
+    native: MachineChoice
+    language: T.List[str]

--- a/mesonbuild/interpreterbase.py
+++ b/mesonbuild/interpreterbase.py
@@ -427,7 +427,8 @@ class KwargInfo(T.Generic[_T]):
     """
 
     def __init__(self, name: str, types: T.Union[T.Type[_T], T.Tuple[T.Type[_T], ...], ContainerTypeInfo],
-                 required: bool = False, listify: bool = False, default: T.Optional[_T] = None,
+                 *, required: bool = False, listify: bool = False,
+                 default: T.Optional[_T] = None,
                  since: T.Optional[str] = None, deprecated: T.Optional[str] = None):
         self.name = name
         self.types = types

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1608,28 +1608,26 @@ class InternalTests(unittest.TestCase):
             self.assertIsInstance(kwargs['input'], str)
             self.assertEqual(kwargs['input'], 'foo')
 
-        # With Meson 0.1 it should trigger the "introduced" warning but not the "deprecated" warning
-        mesonbuild.mesonlib.project_meson_versions[''] = '0.1'
-        sys.stdout = io.StringIO()
-        _(None, mock.Mock(subproject=''), [], {'input': 'foo'})
-        self.assertRegex(sys.stdout.getvalue(), r'WARNING:.*introduced.*input arg in testfunc')
-        self.assertNotRegex(sys.stdout.getvalue(), r'WARNING:.*deprecated.*input arg in testfunc')
+        with mock.patch('sys.stdout', io.StringIO()) as out:
+            # With Meson 0.1 it should trigger the "introduced" warning but not the "deprecated" warning
+            mesonbuild.mesonlib.project_meson_versions[''] = '0.1'
+            _(None, mock.Mock(subproject=''), [], {'input': 'foo'})
+            self.assertRegex(out.getvalue(), r'WARNING:.*introduced.*input arg in testfunc')
+            self.assertNotRegex(out.getvalue(), r'WARNING:.*deprecated.*input arg in testfunc')
 
-        # With Meson 1.5 it shouldn't trigger any warning
-        mesonbuild.mesonlib.project_meson_versions[''] = '1.5'
-        sys.stdout = io.StringIO()
-        _(None, mock.Mock(subproject=''), [], {'input': 'foo'})
-        self.assertNotRegex(sys.stdout.getvalue(), r'WARNING:.*')
-        self.assertNotRegex(sys.stdout.getvalue(), r'WARNING:.*')
+        with mock.patch('sys.stdout', io.StringIO()) as out:
+            # With Meson 1.5 it shouldn't trigger any warning
+            mesonbuild.mesonlib.project_meson_versions[''] = '1.5'
+            _(None, mock.Mock(subproject=''), [], {'input': 'foo'})
+            self.assertNotRegex(out.getvalue(), r'WARNING:.*')
+            self.assertNotRegex(out.getvalue(), r'WARNING:.*')
 
-        # With Meson 2.0 it should trigger the "deprecated" warning but not the "introduced" warning
-        mesonbuild.mesonlib.project_meson_versions[''] = '2.0'
-        sys.stdout = io.StringIO()
-        _(None, mock.Mock(subproject=''), [], {'input': 'foo'})
-        self.assertRegex(sys.stdout.getvalue(), r'WARNING:.*deprecated.*input arg in testfunc')
-        self.assertNotRegex(sys.stdout.getvalue(), r'WARNING:.*introduced.*input arg in testfunc')
-
-        sys.stdout = sys.__stdout__
+        with mock.patch('sys.stdout', io.StringIO()) as out:
+            # With Meson 2.0 it should trigger the "deprecated" warning but not the "introduced" warning
+            mesonbuild.mesonlib.project_meson_versions[''] = '2.0'
+            _(None, mock.Mock(subproject=''), [], {'input': 'foo'})
+            self.assertRegex(out.getvalue(), r'WARNING:.*deprecated.*input arg in testfunc')
+            self.assertNotRegex(out.getvalue(), r'WARNING:.*introduced.*input arg in testfunc')
 
 
 @unittest.skipIf(is_tarball(), 'Skipping because this is a tarball release')

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -1644,6 +1644,16 @@ class InternalTests(unittest.TestCase):
             _(None, mock.Mock(), tuple(), dict(input='bar'))
         self.assertEqual(str(cm.exception), "testfunc keyword argument \"input\" invalid!")
 
+    def test_typed_kwarg_convertor(self) -> None:
+        @typed_kwargs(
+            'testfunc',
+            KwargInfo('native', bool, convertor=lambda n: MachineChoice.BUILD if n else MachineChoice.HOST)
+        )
+        def _(obj, node, args: T.Tuple, kwargs: T.Dict[str, MachineChoice]) -> None:
+            assert isinstance(kwargs['native'], MachineChoice)
+
+        _(None, mock.Mock(), tuple(), dict(native=True))
+
 
 @unittest.skipIf(is_tarball(), 'Skipping because this is a tarball release')
 class DataTests(unittest.TestCase):


### PR DESCRIPTION
This adds two additional keywords to the `KwargInfo` used by `typed_kwargs` (which are the last two I'd planned to add): "validator" and "converter" the first is used to set additional validation constraints (say a function accepts a string that is really an enum and only accepts 3 values). The converter can then be used to convert the Meson DSL value into whatever our implementation actually wants (like an Enum type instead of a string, or bool).

I'm trying to just pick small pieces to add type checking to so that they're easier to review than doing everything all at once.