### PR TITLE
cuda module: fully buy into new modules API

### DIFF
--- a/mesonbuild/modules/unstable_cuda.py
+++ b/mesonbuild/modules/unstable_cuda.py
@@ -19,18 +19,18 @@ from ..mesonlib import version_compare
 from ..interpreter import CompilerHolder
 from ..compilers import CudaCompiler
 
-from . import ExtensionModule
+from . import ModuleObject
 
 from ..interpreterbase import (
     flatten, permittedKwargs, noKwargs,
     InvalidArguments, FeatureNew
 )
 
-class CudaModule(ExtensionModule):
+class CudaModule(ModuleObject):
 
     @FeatureNew('CUDA module', '0.50.0')
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__()
         self.methods.update({
             "min_driver_version": self.min_driver_version,
             "nvcc_arch_flags":    self.nvcc_arch_flags,


### PR DESCRIPTION
In commit 3340284805b96a4b9b62405f626020276341944c the new ModuleObject API got further updated to hide self.interpreter; at the time, the CUDA module got transferred over to the wrapper which does provide it.

But it works fine without self.interpreter, so let's just use the best base class.