### PR TITLE
Make workflow steps requiring secrets conditional

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -21,6 +21,8 @@ on:
 
 jobs:
   build:
+    env:
+      HAS_DOCKER_CREDENTIALS: ${{ secrets.DOCKER_PASSWORD != '' }}
     name: ${{ matrix.cfg.name }}
     runs-on: ubuntu-latest
     strategy:
@@ -38,7 +40,7 @@ jobs:
 
       # Login to dockerhub
       - name: Docker login
-        if:   github.event_name == 'push' || github.event_name == 'schedule'
+        if:   (github.event_name == 'push' || github.event_name == 'schedule') && env.HAS_DOCKER_CREDENTIALS == 'true'
         uses: azure/docker-login@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -52,5 +54,5 @@ jobs:
 
       # Publish
       - name: Push the ${{ matrix.cfg.id }} image
-        if:   github.event_name == 'push' || github.event_name == 'schedule'
         run:  docker push mesonbuild/${{ matrix.cfg.id }}
+        if:   (github.event_name == 'push' || github.event_name == 'schedule') && env.HAS_DOCKER_CREDENTIALS == 'true'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   update_website:
+    env:
+      HAS_SSH_KEY: ${{ secrets.WEBSITE_PRIV_KEY != '' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -23,13 +25,18 @@ jobs:
         run: |
           ssh-agent -a $SSH_AUTH_SOCK > /dev/null
           ssh-add - <<< "${{ secrets.WEBSITE_PRIV_KEY }}"
-      - name: Update website
-        env:
-          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        if: env.HAS_SSH_KEY == 'true'
+      - name: Build website
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"
           cd docs
           meson setup _build
           ninja -C _build
+      - name: Update website
+        env:
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+        run: |
+          cd docs
           ninja -C _build upload
+        if: env.HAS_SSH_KEY == 'true'


### PR DESCRIPTION
Make workflow steps requiring secrets conditional on the presence of those secrets.

This stops the 'build images' workflow from running and failing on it's weekly schedule in a forked repository, which results in a mail, unless you manually disable that workflow.

(The test has to be written rather indirectly as secrets aren't available to `if`, see actions/runner#520)
