### PR TITLE
markdown/Dependencies:replace tabs with spaces

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -673,20 +673,20 @@ To define some of the the preprocessor symbols mentioned in the
 ```meson
 conf = configuration_data()
 check_headers = [
-	['ncursesw/menu.h', 'HAVE_NCURSESW_MENU_H'],
-	['ncurses/menu.h', 'HAVE_NCURSES_MENU_H'],
-	['menu.h', 'HAVE_MENU_H'],
-	['ncursesw/curses.h', 'HAVE_NCURSESW_CURSES_H'],
-	['ncursesw.h', 'HAVE_NCURSESW_H'],
-	['ncurses/curses.h', 'HAVE_NCURSES_CURSES_H'],
-	['ncurses.h', 'HAVE_NCURSES_H'],
-	['curses.h', 'HAVE_CURSES_H'],
+  ['ncursesw/menu.h', 'HAVE_NCURSESW_MENU_H'],
+  ['ncurses/menu.h', 'HAVE_NCURSES_MENU_H'],
+  ['menu.h', 'HAVE_MENU_H'],
+  ['ncursesw/curses.h', 'HAVE_NCURSESW_CURSES_H'],
+  ['ncursesw.h', 'HAVE_NCURSESW_H'],
+  ['ncurses/curses.h', 'HAVE_NCURSES_CURSES_H'],
+  ['ncurses.h', 'HAVE_NCURSES_H'],
+  ['curses.h', 'HAVE_CURSES_H'],
 ]
 
 foreach h : check_headers
-	if compiler.has_header(h.get(0))
-		conf.set(h.get(1), 1)
-	endif
+  if compiler.has_header(h.get(0))
+    conf.set(h.get(1), 1)
+  endif
 endforeach
 ```
 


### PR DESCRIPTION
Remove tabs I introduced by https://github.com/mesonbuild/meson/pull/8866

Thanks for pointing those out @jon-turney 