### PR TITLE
Fix issue with generated Cython code in a subdir

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1583,6 +1583,8 @@ int dummy;
             for ssrc in gen.get_outputs():
                 if isinstance(gen, GeneratedList):
                     ssrc = os.path.join(self.get_target_private_dir(target) , ssrc)
+                else:
+                    ssrc = os.path.join(gen.get_subdir(), ssrc)
                 if ssrc.endswith('.pyx'):
                     args = args.copy()
                     output = os.path.join(self.get_target_private_dir(target), f'{ssrc}.c')

--- a/test cases/cython/2 generated sources/libdir/gen.py
+++ b/test cases/cython/2 generated sources/libdir/gen.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import textwrap
+
+parser = argparse.ArgumentParser()
+parser.add_argument('output')
+args = parser.parse_args()
+
+with open(args.output, 'w') as f:
+    f.write(textwrap.dedent('''\
+        cpdef func():
+            return "Hello, World!"
+        '''))

--- a/test cases/cython/2 generated sources/libdir/meson.build
+++ b/test cases/cython/2 generated sources/libdir/meson.build
@@ -1,0 +1,10 @@
+ct2 = custom_target(
+  'ct2',
+  input : 'gen.py',
+  output : 'ct2.pyx',
+  command : [py3, '@INPUT@', '@OUTPUT@'],
+)
+
+ct2_ext = py3.extension_module('ct2', ct2, dependencies : py3_dep)
+
+pydir = meson.current_build_dir()

--- a/test cases/cython/2 generated sources/meson.build
+++ b/test cases/cython/2 generated sources/meson.build
@@ -59,3 +59,12 @@ test(
   args : [files('test.py'), 'g'],
   env : ['PYTHONPATH=' + meson.current_build_dir()]
 )
+
+subdir('libdir')
+
+test(
+  'custom target in subdir',
+  py3,
+  args : [files('test.py'), 'ct2'],
+  env : ['PYTHONPATH=' + pydir]
+)


### PR DESCRIPTION
This is a follow-up to gh-8706 (Cc @dcbaker), which contained the initial fix to `ninjabackend.py` but somehow lost it. This re-applies the fix and adds a test for it.

Without the fix, the error is:
```
  ninja: error: 'ct2.pyx', needed by 'libdir/ct2.cpython-39-x86_64-linux-gnu.so.p/ct2.pyx.c',
  missing and no known rule to make it
```