### PR TITLE
minit: do not misdetect files suffixed as "" or named "." or "c" or "s" as c#

### DIFF
--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -105,7 +105,7 @@ def autodetect_options(options: 'argparse.Namespace', sample: bool = False) -> N
             if f.suffix in ('.cc', '.cpp'):
                 options.language = 'cpp'
                 break
-            if f.suffix in '.cs':
+            if f.suffix == '.cs':
                 options.language = 'cs'
                 break
             if f.suffix == '.cu':


### PR DESCRIPTION
You cannot `str() in str()` and expect it to act like `str() in list()`.

Fixes regression in commit bbc2745dccc40761989a3e1efbe5a69eea0bc77e
Unbreaks #6573
Fixes #8872