### PR TITLE
Fix System dependencies setting type_name instead of name

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -60,6 +60,9 @@ class DependencyMethods(Enum):
     DUB = 'dub'
 
 
+DependencyTypeName = T.NewType('DependencyTypeName', str)
+
+
 class Dependency:
 
     @classmethod
@@ -72,7 +75,7 @@ class Dependency:
             raise DependencyException("include_type may only be one of ['preserve', 'system', 'non-system']")
         return kwargs['include_type']
 
-    def __init__(self, type_name: str, kwargs: T.Dict[str, T.Any]) -> None:
+    def __init__(self, type_name: DependencyTypeName, kwargs: T.Dict[str, T.Any]) -> None:
         self.name = "null"
         self.version:  T.Optional[str] = None
         self.language: T.Optional[str] = None # None means C-like
@@ -220,7 +223,7 @@ class InternalDependency(Dependency):
                  link_args: T.List[str], libraries: T.List['BuildTarget'],
                  whole_libraries: T.List['BuildTarget'], sources: T.List['FileOrString'],
                  ext_deps: T.List[Dependency], variables: T.Dict[str, T.Any]):
-        super().__init__('internal', {})
+        super().__init__(DependencyTypeName('internal'), {})
         self.version = version
         self.is_found = True
         self.include_directories = incdirs
@@ -307,7 +310,7 @@ class HasNativeKwarg:
         return MachineChoice.BUILD if kwargs.get('native', False) else MachineChoice.HOST
 
 class ExternalDependency(Dependency, HasNativeKwarg):
-    def __init__(self, type_name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any], language: T.Optional[str] = None):
+    def __init__(self, type_name: DependencyTypeName, environment: 'Environment', kwargs: T.Dict[str, T.Any], language: T.Optional[str] = None):
         Dependency.__init__(self, type_name, kwargs)
         self.env = environment
         self.name = type_name # default
@@ -392,7 +395,7 @@ class ExternalDependency(Dependency, HasNativeKwarg):
 
 class NotFoundDependency(Dependency):
     def __init__(self, environment: 'Environment') -> None:
-        super().__init__('not-found', {})
+        super().__init__(DependencyTypeName('not-found'), {})
         self.env = environment
         self.name = 'not-found'
         self.is_found = False
@@ -406,7 +409,7 @@ class NotFoundDependency(Dependency):
 class ExternalLibrary(ExternalDependency):
     def __init__(self, name: str, link_args: T.List[str], environment: 'Environment',
                  language: str, silent: bool = False) -> None:
-        super().__init__('library', environment, {}, language=language)
+        super().__init__(DependencyTypeName('library'), environment, {}, language=language)
         self.name = name
         self.language = language
         self.is_found = False

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -21,9 +21,10 @@ from .. import mlog
 from .. import mesonlib
 from ..environment import Environment
 
-from .base import DependencyException, ExternalDependency
+from .base import DependencyException
 from .pkgconfig import PkgConfigDependency
 from .misc import threads_factory
+from .system import SystemDependency
 
 if T.TYPE_CHECKING:
     from ..environment import Properties
@@ -340,7 +341,7 @@ class BoostLibraryFile():
     def get_link_args(self) -> T.List[str]:
         return [self.path.as_posix()]
 
-class BoostDependency(ExternalDependency):
+class BoostDependency(SystemDependency):
     def __init__(self, environment: Environment, kwargs: T.Dict[str, T.Any]) -> None:
         super().__init__('boost', environment, kwargs, language='cpp')
         buildtype = environment.coredata.get_option(mesonlib.OptionKey('buildtype'))

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import ExternalDependency, DependencyException, DependencyMethods
+from .base import ExternalDependency, DependencyException, DependencyMethods, DependencyTypeName
 from ..mesonlib import is_windows, MesonException, OptionKey, PerMachine, stringlistify, extract_as_list
 from ..mesondata import mesondata
 from ..cmake import CMakeExecutor, CMakeTraceParser, CMakeException, CMakeToolchain, CMakeExecScope, check_cmake_args
@@ -98,7 +98,7 @@ class CMakeDependency(ExternalDependency):
         # Ensure that the list is unique
         self.language_list = list(set(self.language_list))
 
-        super().__init__('cmake', environment, kwargs, language=language)
+        super().__init__(DependencyTypeName('cmake'), environment, kwargs, language=language)
         self.name = name
         self.is_libtool = False
         # Store a copy of the CMake path on the object itself so it is

--- a/mesonbuild/dependencies/coarrays.py
+++ b/mesonbuild/dependencies/coarrays.py
@@ -15,10 +15,11 @@
 import functools
 import typing as T
 
-from .base import DependencyMethods, ExternalDependency, detect_compiler
+from .base import DependencyMethods, detect_compiler
 from .cmake import CMakeDependency
 from .pkgconfig import PkgConfigDependency
 from .factory import factory_methods
+from .system import SystemDependency
 
 if T.TYPE_CHECKING:
     from . factory import DependencyGenerator
@@ -52,7 +53,7 @@ def coarray_factory(env: 'Environment',
     return candidates
 
 
-class CoarrayDependency(ExternalDependency):
+class CoarrayDependency(SystemDependency):
     """
     Coarrays are a Fortran 2008 feature.
 

--- a/mesonbuild/dependencies/configtool.py
+++ b/mesonbuild/dependencies/configtool.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import ExternalDependency, DependencyException, DependencyMethods
+from .base import ExternalDependency, DependencyException, DependencyMethods, DependencyTypeName
 from ..mesonlib import listify, Popen_safe, split_args, version_compare, version_compare_many
 from ..programs import find_external_program
 from .. import mlog
@@ -41,7 +41,7 @@ class ConfigToolDependency(ExternalDependency):
     __strip_version = re.compile(r'^[0-9][0-9.]+')
 
     def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any], language: T.Optional[str] = None):
-        super().__init__('config-tool', environment, kwargs, language=language)
+        super().__init__(DependencyTypeName('config-tool'), environment, kwargs, language=language)
         self.name = name
         # You may want to overwrite the class version in some cases
         self.tools = listify(kwargs.get('tools', self.tools))

--- a/mesonbuild/dependencies/cuda.py
+++ b/mesonbuild/dependencies/cuda.py
@@ -18,11 +18,12 @@ import os
 import typing as T
 from pathlib import Path
 
-from .. import mlog
 from .. import mesonlib
+from .. import mlog
 from ..environment import detect_cpu_family
+from .base import DependencyException
+from .system import SystemDependency
 
-from .base import (DependencyException, ExternalDependency)
 
 if T.TYPE_CHECKING:
     from ..environment import Environment
@@ -30,7 +31,7 @@ if T.TYPE_CHECKING:
 
 TV_ResultTuple = T.Tuple[T.Optional[str], T.Optional[str], bool]
 
-class CudaDependency(ExternalDependency):
+class CudaDependency(SystemDependency):
 
     supported_languages = ['cuda', 'cpp', 'c'] # see also _default_language
 

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -23,15 +23,16 @@ import shutil
 import typing as T
 
 from .. import mesonlib, mlog
-from ..mesonlib import version_compare, stringlistify, extract_as_list, MachineChoice
+from ..compilers import AppleClangCCompiler, AppleClangCPPCompiler
 from ..environment import get_llvm_tool_names
-from .base import DependencyException, DependencyMethods, ExternalDependency, strip_system_libdirs
+from ..mesonlib import version_compare, stringlistify, extract_as_list, MachineChoice
+from .base import DependencyException, DependencyMethods, strip_system_libdirs
 from .cmake import CMakeDependency
 from .configtool import ConfigToolDependency
-from .pkgconfig import PkgConfigDependency
 from .factory import DependencyFactory
 from .misc import threads_factory
-from ..compilers import AppleClangCCompiler, AppleClangCPPCompiler
+from .pkgconfig import PkgConfigDependency
+from .system import SystemDependency
 
 if T.TYPE_CHECKING:
     from ..envconfig import MachineInfo
@@ -50,7 +51,7 @@ def get_shared_library_suffix(environment: 'Environment', for_machine: MachineCh
     return '.so'
 
 
-class GTestDependencySystem(ExternalDependency):
+class GTestDependencySystem(SystemDependency):
     def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
         super().__init__(name, environment, kwargs, language='cpp')
         self.main = kwargs.get('main', False)
@@ -120,7 +121,7 @@ class GTestDependencyPC(PkgConfigDependency):
         super().__init__(name, environment, kwargs)
 
 
-class GMockDependencySystem(ExternalDependency):
+class GMockDependencySystem(SystemDependency):
     def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
         super().__init__(name, environment, kwargs, language='cpp')
         self.main = kwargs.get('main', False)
@@ -464,7 +465,7 @@ class ValgrindDependency(PkgConfigDependency):
         return []
 
 
-class ZlibSystemDependency(ExternalDependency):
+class ZlibSystemDependency(SystemDependency):
 
     def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, environment, kwargs)
@@ -513,7 +514,7 @@ class ZlibSystemDependency(ExternalDependency):
         return [DependencyMethods.SYSTEM]
 
 
-class JDKSystemDependency(ExternalDependency):
+class JDKSystemDependency(SystemDependency):
     def __init__(self, environment: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__('jdk', environment, kwargs)
 

--- a/mesonbuild/dependencies/dub.py
+++ b/mesonbuild/dependencies/dub.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import ExternalDependency, DependencyException, DependencyMethods
+from .base import ExternalDependency, DependencyException, DependencyMethods, DependencyTypeName
 from .pkgconfig import PkgConfigDependency
 from ..mesonlib import Popen_safe
 from ..programs import ExternalProgram
@@ -32,7 +32,7 @@ class DubDependency(ExternalDependency):
     class_dubbin = None
 
     def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any]):
-        super().__init__('dub', environment, kwargs, language='d')
+        super().__init__(DependencyTypeName('dub'), environment, kwargs, language='d')
         self.name = name
         self.module_path: T.Optional[str] = None
 

--- a/mesonbuild/dependencies/factory.py
+++ b/mesonbuild/dependencies/factory.py
@@ -1,4 +1,5 @@
 # Copyright 2013-2021 The Meson development team
+# Copyright © 2021 Intel Corporation
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import Dependency, ExternalDependency
+import functools
+import typing as T
+
+from ..mesonlib import MachineChoice
 from .base import DependencyException, DependencyMethods
+from .base import ExternalDependency
 from .base import process_method_kw
 from .cmake import CMakeDependency
 from .framework import ExtraFrameworkDependency
 from .pkgconfig import PkgConfigDependency
-from ..mesonlib import MachineChoice
-import functools
-import typing as T
+from .system import SystemDependency
 
 if T.TYPE_CHECKING:
     from ..environment import Environment
@@ -78,7 +81,7 @@ class DependencyFactory:
                  configtool_class: 'T.Optional[T.Type[ConfigToolDependency]]' = None,
                  framework_name: T.Optional[str] = None,
                  framework_class: 'T.Type[ExtraFrameworkDependency]' = ExtraFrameworkDependency,
-                 system_class: 'T.Type[ExternalDependency]' = ExternalDependency):
+                 system_class: 'T.Type[SystemDependency]' = SystemDependency):
 
         if DependencyMethods.CONFIG_TOOL in methods and not configtool_class:
             raise DependencyException('A configtool must have a custom class')

--- a/mesonbuild/dependencies/framework.py
+++ b/mesonbuild/dependencies/framework.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import ExternalDependency, DependencyException, DependencyMethods
+from .base import DependencyTypeName, ExternalDependency, DependencyException, DependencyMethods
 from ..mesonlib import MesonException, Version, stringlistify
 from .. import mlog
 from pathlib import Path
@@ -26,7 +26,7 @@ class ExtraFrameworkDependency(ExternalDependency):
 
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any], language: T.Optional[str] = None) -> None:
         paths = stringlistify(kwargs.get('paths', []))
-        super().__init__('extraframeworks', env, kwargs, language=language)
+        super().__init__(DependencyTypeName('extraframeworks'), env, kwargs, language=language)
         self.name = name
         # Full path to framework directory
         self.framework_path: T.Optional[str] = None

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -20,15 +20,15 @@ import re
 import sysconfig
 import typing as T
 
-from .. import mlog
 from .. import mesonlib
+from .. import mlog
 from ..environment import detect_cpu_family
-
-from .base import DependencyException, DependencyMethods, ExternalDependency
+from .base import DependencyException, DependencyMethods
 from .cmake import CMakeDependency
 from .configtool import ConfigToolDependency
-from .pkgconfig import PkgConfigDependency
 from .factory import DependencyFactory, factory_methods
+from .pkgconfig import PkgConfigDependency
+from .system import SystemDependency
 
 if T.TYPE_CHECKING:
     from ..environment import Environment, MachineChoice
@@ -60,7 +60,7 @@ def netcdf_factory(env: 'Environment',
     return candidates
 
 
-class OpenMPDependency(ExternalDependency):
+class OpenMPDependency(SystemDependency):
     # Map date of specification release (which is the macro value) to a version.
     VERSIONS = {
         '201811': '5.0',
@@ -112,7 +112,7 @@ class OpenMPDependency(ExternalDependency):
                 mlog.log(mlog.yellow('WARNING:'), 'OpenMP found but omp.h missing.')
 
 
-class ThreadDependency(ExternalDependency):
+class ThreadDependency(SystemDependency):
     def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
         super().__init__(name, environment, kwargs)
         self.is_found = True
@@ -130,7 +130,7 @@ class ThreadDependency(ExternalDependency):
         return [DependencyMethods.AUTO, DependencyMethods.CMAKE]
 
 
-class BlocksDependency(ExternalDependency):
+class BlocksDependency(SystemDependency):
     def __init__(self, environment: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
         super().__init__('blocks', environment, kwargs)
         self.name = 'blocks'
@@ -163,7 +163,7 @@ class BlocksDependency(ExternalDependency):
             self.is_found = True
 
 
-class Python3DependencySystem(ExternalDependency):
+class Python3DependencySystem(SystemDependency):
     def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
         super().__init__(name, environment, kwargs)
 
@@ -379,7 +379,7 @@ class GpgmeDependencyConfigTool(ConfigToolDependency):
         return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL]
 
 
-class ShadercDependency(ExternalDependency):
+class ShadercDependency(SystemDependency):
 
     def __init__(self, environment: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__('shaderc', environment, kwargs)
@@ -428,7 +428,7 @@ class CursesConfigToolDependency(ConfigToolDependency):
         self.link_args = self.get_config_value(['--libs'], 'link_args')
 
 
-class CursesSystemDependency(ExternalDependency):
+class CursesSystemDependency(SystemDependency):
 
     """Curses dependency the hard way.
 

--- a/mesonbuild/dependencies/mpi.py
+++ b/mesonbuild/dependencies/mpi.py
@@ -17,11 +17,12 @@ import typing as T
 import os
 import re
 
-from .base import DependencyMethods, detect_compiler, ExternalDependency
-from .configtool import ConfigToolDependency
-from .pkgconfig import PkgConfigDependency
-from .factory import factory_methods
 from ..environment import detect_cpu_family
+from .base import DependencyMethods, detect_compiler
+from .configtool import ConfigToolDependency
+from .factory import factory_methods
+from .pkgconfig import PkgConfigDependency
+from .system import SystemDependency
 
 if T.TYPE_CHECKING:
     from .factory import DependencyGenerator
@@ -200,7 +201,7 @@ class OpenMPIConfigToolDependency(_MPIConfigToolDependency):
         return out
 
 
-class MSMPIDependency(ExternalDependency):
+class MSMPIDependency(SystemDependency):
 
     """The Microsoft MPI."""
 

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import ExternalDependency, DependencyException, DependencyMethods, sort_libpaths
+from .base import ExternalDependency, DependencyException, DependencyMethods, sort_libpaths, DependencyTypeName
 from ..mesonlib import LibType, MachineChoice, OptionKey, OrderedSet, PerMachine, Popen_safe
 from ..programs import find_external_program, ExternalProgram
 from .. import mlog
@@ -36,7 +36,7 @@ class PkgConfigDependency(ExternalDependency):
     ] = {}
 
     def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any], language: T.Optional[str] = None) -> None:
-        super().__init__('pkgconfig', environment, kwargs, language=language)
+        super().__init__(DependencyTypeName('pkgconfig'), environment, kwargs, language=language)
         self.name = name
         self.is_libtool = False
         # Store a copy of the pkg-config path on the object itself so it is

--- a/mesonbuild/dependencies/platform.py
+++ b/mesonbuild/dependencies/platform.py
@@ -15,7 +15,7 @@
 # This file contains the detection logic for external dependencies that are
 # platform-specific (generally speaking).
 
-from .base import ExternalDependency, DependencyException
+from .base import DependencyTypeName, ExternalDependency, DependencyException
 from ..mesonlib import MesonException
 import typing as T
 
@@ -24,7 +24,7 @@ if T.TYPE_CHECKING:
 
 class AppleFrameworks(ExternalDependency):
     def __init__(self, env: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
-        super().__init__('appleframeworks', env, kwargs)
+        super().__init__(DependencyTypeName('appleframeworks'), env, kwargs)
         modules = kwargs.get('modules', [])
         if isinstance(modules, str):
             modules = [modules]

--- a/mesonbuild/dependencies/system.py
+++ b/mesonbuild/dependencies/system.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2021 Intel Corporation
+
+from .base import ExternalDependency, DependencyMethods
+import typing as T
+
+if T.TYPE_CHECKING:
+    from ..environment import Environment
+
+__all__ = [
+    'SystemDependency',
+]
+
+
+class SystemDependency(ExternalDependency):
+
+    """Dependency base for System type dependencies."""
+
+    def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any],
+                 language: T.Optional[str] = None) -> None:
+        super().__init__('system', env, kwargs, language=language)
+        self.name = name
+
+    @staticmethod
+    def get_methods() -> T.List[DependencyMethods]:
+        return [DependencyMethods.SYSTEM]
+
+    def log_tried(self) -> str:
+        return 'system'

--- a/mesonbuild/dependencies/system.py
+++ b/mesonbuild/dependencies/system.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright © 2021 Intel Corporation
 
-from .base import ExternalDependency, DependencyMethods
+from .base import DependencyTypeName, ExternalDependency, DependencyMethods
 import typing as T
 
 if T.TYPE_CHECKING:
@@ -18,7 +18,7 @@ class SystemDependency(ExternalDependency):
 
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any],
                  language: T.Optional[str] = None) -> None:
-        super().__init__('system', env, kwargs, language=language)
+        super().__init__(DependencyTypeName('system'), env, kwargs, language=language)
         self.name = name
 
     @staticmethod

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -25,7 +25,7 @@ from ..mesonlib import (
 )
 from ..environment import detect_cpu_family
 
-from .base import DependencyException, DependencyMethods
+from .base import DependencyException, DependencyMethods, DependencyTypeName
 from .configtool import ConfigToolDependency
 from .factory import DependencyFactory
 from .system import SystemDependency
@@ -233,7 +233,8 @@ class VulkanDependencySystem(SystemDependency):
             if not os.path.isfile(header):
                 raise DependencyException('VULKAN_SDK point to invalid directory (no include)')
 
-            self.type_name = 'vulkan_sdk'
+            # XXX: this is very odd, and may deserve being removed
+            self.type_name = DependencyTypeName('vulkan_sdk')
             self.is_found = True
             self.compile_args.append('-I' + inc_path)
             self.link_args.append('-L' + lib_path)
@@ -246,7 +247,6 @@ class VulkanDependencySystem(SystemDependency):
             # simply try to guess it, usually works on linux
             libs = self.clib_compiler.find_library('vulkan', environment, [])
             if libs is not None and self.clib_compiler.has_header('vulkan/vulkan.h', '', environment, disable_cache=True)[0]:
-                self.type_name = 'system'
                 self.is_found = True
                 for lib in libs:
                     self.link_args.append(lib)

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -26,15 +26,15 @@ from ..mesonlib import (
 from ..environment import detect_cpu_family
 
 from .base import DependencyException, DependencyMethods
-from .base import ExternalDependency
 from .configtool import ConfigToolDependency
 from .factory import DependencyFactory
+from .system import SystemDependency
 
 if T.TYPE_CHECKING:
     from ..environment import Environment
 
 
-class GLDependencySystem(ExternalDependency):
+class GLDependencySystem(SystemDependency):
     def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
         super().__init__(name, environment, kwargs)
 
@@ -196,7 +196,7 @@ class WxDependency(ConfigToolDependency):
         return candidates
 
 
-class VulkanDependencySystem(ExternalDependency):
+class VulkanDependencySystem(SystemDependency):
 
     def __init__(self, name: str, environment: 'Environment', kwargs: T.Dict[str, T.Any], language: T.Optional[str] = None) -> None:
         super().__init__(name, environment, kwargs, language=language)

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -30,17 +30,15 @@ from ..interpreter import ExternalProgramHolder, extract_required_kwarg, permitt
 from ..build import known_shmod_kwargs
 from .. import mlog
 from ..environment import detect_cpu_family
-from ..dependencies import (
-    DependencyMethods, ExternalDependency,
-    PkgConfigDependency, NotFoundDependency
-)
+from ..dependencies import DependencyMethods, PkgConfigDependency, NotFoundDependency
+from ..dependencies.system import SystemDependency
 from ..programs import ExternalProgram, NonExistingExternalProgram
 
 mod_kwargs = {'subdir'}
 mod_kwargs.update(known_shmod_kwargs)
 mod_kwargs -= {'name_prefix', 'name_suffix'}
 
-class PythonDependency(ExternalDependency):
+class PythonDependency(SystemDependency):
 
     def __init__(self, python_holder, environment, kwargs):
         super().__init__('python', environment, kwargs)

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -58,8 +58,8 @@ def check_mypy() -> None:
         print('Failed import mypy')
         sys.exit(1)
     from mypy.version import __version__ as mypy_version
-    if not version_compare(mypy_version, '>=0.902'):
-        print('mypy >=0.902 is required, older versions report spurious errors')
+    if not version_compare(mypy_version, '>=0.812'):
+        print('mypy >=0.812 is required, older versions report spurious errors')
         sys.exit(1)
 
 def main() -> int:

--- a/test cases/failing/68 wrong boost module/test.json
+++ b/test cases/failing/68 wrong boost module/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/68 wrong boost module/meson.build:9:0: ERROR: Dependency \"boost\" not found"
+      "line": "test cases/failing/68 wrong boost module/meson.build:9:0: ERROR: Dependency \"boost\" not found, tried system"
     }
   ]
 }


### PR DESCRIPTION
This makes two changes. First it introduces a new SystemDependency intermediate class, this works much like PkgConfigDependency or ConfigToolDependency, but for system dependencies, this resolves the actual issue. Then I've added a `typeing.NewType`, which allows mypy to find cases where we're accidently writing the dependeny name to the type_name. It found a few cases of that.

Fixes #8877