### PR TITLE
environment: Add LLVM suffixes for 11 and 12

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -246,7 +246,9 @@ def get_llvm_tool_names(tool: str) -> T.List[str]:
     # unless it becomes a stable release.
     suffixes = [
         '', # base (no suffix)
-        '-10',  '100',
+        '-12',  '12',
+        '-11',  '11',
+        '-10',  '10',
         '-9',   '90',
         '-8',   '80',
         '-7',   '70',
@@ -258,7 +260,7 @@ def get_llvm_tool_names(tool: str) -> T.List[str]:
         '-3.7', '37',
         '-3.6', '36',
         '-3.5', '35',
-        '-11',    # Debian development snapshot
+        '-13',    # Debian development snapshot
         '-devel', # FreeBSD development snapshot
     ]
     names = []


### PR DESCRIPTION
Both LLVM 11 and 12 are stable releases. Note that FreeBSD changes the
way to version LLVM executables in LLVM 10.