### PR TITLE
Improve Error message of invalid user build option

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -103,6 +103,7 @@ class CCompiler(CLikeCompiler, Compiler):
                 'C language standard to use',
                 ['none'],
                 'none',
+                'std',
             )
         })
         return opts
@@ -161,6 +162,7 @@ class ClangCCompiler(_ClangCStds, ClangCompiler, CCompiler):
                 OptionKey('winlibs', machine=self.for_machine, lang=self.language): coredata.UserArrayOption(
                     'Standard Win libraries to link against',
                     gnu_winlibs,
+                    'winlibs',
                 ),
             })
         return opts
@@ -276,6 +278,7 @@ class GnuCCompiler(GnuCompiler, CCompiler):
                 key.evolve('winlibs'): coredata.UserArrayOption(
                     'Standard Win libraries to link against',
                     gnu_winlibs,
+                    'winlibs',
                 ),
             })
         return opts
@@ -402,6 +405,7 @@ class VisualStudioLikeCCompilerMixin(CompilerMixinBase):
             OptionKey('winlibs', machine=self.for_machine, lang=self.language): coredata.UserArrayOption(
                 'Windows libs to link against.',
                 msvc_winlibs,
+                'winlibs',
             ),
         })
         return opts

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -275,32 +275,32 @@ clike_debug_args = {False: [],
                     True: ['-g']}  # type: T.Dict[bool, T.List[str]]
 
 base_options: 'KeyedOptionDictType' = {
-    OptionKey('b_pch'): coredata.UserBooleanOption('Use precompiled headers', True),
-    OptionKey('b_lto'): coredata.UserBooleanOption('Use link time optimization', False),
-    OptionKey('b_lto'): coredata.UserBooleanOption('Use link time optimization', False),
-    OptionKey('b_lto_threads'): coredata.UserIntegerOption('Use multiple threads for Link Time Optimization', (None, None, 0)),
+    OptionKey('b_pch'): coredata.UserBooleanOption('Use precompiled headers', True, 'b_pch'),
+    OptionKey('b_lto'): coredata.UserBooleanOption('Use link time optimization', False, 'b_lto'),
+    OptionKey('b_lto'): coredata.UserBooleanOption('Use link time optimization', False, 'b_lto'),
+    OptionKey('b_lto_threads'): coredata.UserIntegerOption('Use multiple threads for Link Time Optimization', (None, None, 0), 'b_lto_threads'),
     OptionKey('b_lto_mode'): coredata.UserComboOption('Select between different LTO modes.',
                                                       ['default', 'thin'],
-                                                      'default'),
+                                                      'default', 'b_lto_mode'),
     OptionKey('b_sanitize'): coredata.UserComboOption('Code sanitizer to use',
                                                       ['none', 'address', 'thread', 'undefined', 'memory', 'address,undefined'],
-                                                      'none'),
-    OptionKey('b_lundef'): coredata.UserBooleanOption('Use -Wl,--no-undefined when linking', True),
-    OptionKey('b_asneeded'): coredata.UserBooleanOption('Use -Wl,--as-needed when linking', True),
+                                                      'none', 'b_sanitize'),
+    OptionKey('b_lundef'): coredata.UserBooleanOption('Use -Wl,--no-undefined when linking', True, 'b_lundef'),
+    OptionKey('b_asneeded'): coredata.UserBooleanOption('Use -Wl,--as-needed when linking', True, 'b_asneeded'),
     OptionKey('b_pgo'): coredata.UserComboOption('Use profile guided optimization',
                                                  ['off', 'generate', 'use'],
-                                                 'off'),
-    OptionKey('b_coverage'): coredata.UserBooleanOption('Enable coverage tracking.', False),
+                                                 'off', 'b_pgo'),
+    OptionKey('b_coverage'): coredata.UserBooleanOption('Enable coverage tracking.', False, 'b_coverage'),
     OptionKey('b_colorout'): coredata.UserComboOption('Use colored output',
                                                       ['auto', 'always', 'never'],
-                                                      'always'),
-    OptionKey('b_ndebug'): coredata.UserComboOption('Disable asserts', ['true', 'false', 'if-release'], 'false'),
-    OptionKey('b_staticpic'): coredata.UserBooleanOption('Build static libraries as position independent', True),
-    OptionKey('b_pie'): coredata.UserBooleanOption('Build executables as position independent', False),
-    OptionKey('b_bitcode'): coredata.UserBooleanOption('Generate and embed bitcode (only macOS/iOS/tvOS)', False),
+                                                      'always', 'b_colorout'),
+    OptionKey('b_ndebug'): coredata.UserComboOption('Disable asserts', ['true', 'false', 'if-release'], 'false', 'b_ndebug'),
+    OptionKey('b_staticpic'): coredata.UserBooleanOption('Build static libraries as position independent', True, 'b_staticpic'),
+    OptionKey('b_pie'): coredata.UserBooleanOption('Build executables as position independent', False, 'b_pie'),
+    OptionKey('b_bitcode'): coredata.UserBooleanOption('Generate and embed bitcode (only macOS/iOS/tvOS)', False, 'b_bitcode'),
     OptionKey('b_vscrt'): coredata.UserComboOption('VS run-time library type to use.',
                                                    ['none', 'md', 'mdd', 'mt', 'mtd', 'from_buildtype', 'static_from_buildtype'],
-                                                   'from_buildtype'),
+                                                   'from_buildtype', 'b_vscrt'),
 }
 
 def option_enabled(boptions: T.Set[OptionKey], options: 'KeyedOptionDictType',
@@ -1295,11 +1295,11 @@ def get_global_options(lang: str,
 
     cargs = coredata.UserArrayOption(
         description + ' compiler',
-        comp_options, split_args=True, user_input=True, allow_dups=True)
+        comp_options, split_args=True, user_input=True, allow_dups=True, opt_name='args')
 
     largs = coredata.UserArrayOption(
         description + ' linker',
-        link_options, split_args=True, user_input=True, allow_dups=True)
+        link_options, split_args=True, user_input=True, allow_dups=True, opt_name='link_args')
 
     if comp.INVOKES_LINKER and comp_key == envkey:
         # If the compiler acts as a linker driver, and we're using the

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -176,6 +176,7 @@ class CPPCompiler(CLikeCompiler, Compiler):
                 'C++ language standard to use',
                 ['none'],
                 'none',
+                'std',
             ),
         })
         return opts
@@ -204,8 +205,9 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
                 'C++ exception handling type.',
                 ['none', 'default', 'a', 's', 'sc'],
                 'default',
+                'eh',
             ),
-            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True),
+            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True, 'rtti'),
         })
         opts[key.evolve('std')].choices = [
             'none', 'c++98', 'c++03', 'c++11', 'c++14', 'c++17', 'c++1z',
@@ -217,6 +219,7 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
                 key.evolve('winlibs'): coredata.UserArrayOption(
                     'Standard Win libraries to link against',
                     gnu_winlibs,
+                    'winlibs',
                 ),
             })
         return opts
@@ -317,6 +320,7 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
                 'C++ exception handling type.',
                 ['none', 'default', 'a', 's', 'sc'],
                 'default',
+                'eh',
             ),
         })
         opts[key].choices = [
@@ -363,11 +367,13 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
                 'C++ exception handling type.',
                 ['none', 'default', 'a', 's', 'sc'],
                 'default',
+                'eh',
             ),
-            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True),
+            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True, 'rtti'),
             key.evolve('debugstl'): coredata.UserBooleanOption(
                 'STL debug mode',
                 False,
+                'debugstl',
             )
         })
         opts[key].choices = [
@@ -380,6 +386,7 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
                 key.evolve('winlibs'): coredata.UserArrayOption(
                     'Standard Win libraries to link against',
                     gnu_winlibs,
+                    'winlibs'
                 ),
             })
         return opts
@@ -484,10 +491,12 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
                 'C++ exception handling type.',
                 ['none', 'default', 'a', 's', 'sc'],
                 'default',
+                'eh',
             ),
             key.evolve('debugstl'): coredata.UserBooleanOption(
                 'STL debug mode',
                 False,
+                'debugstl',
             ),
         })
         opts[key].choices = cpp_stds
@@ -560,9 +569,10 @@ class IntelCPPCompiler(IntelGnuLikeCompiler, CPPCompiler):
                 'C++ exception handling type.',
                 ['none', 'default', 'a', 's', 'sc'],
                 'default',
+                'eh',
             ),
-            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True),
-            key.evolve('debugstl'): coredata.UserBooleanOption('STL debug mode', False),
+            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True, 'rtti'),
+            key.evolve('debugstl'): coredata.UserBooleanOption('STL debug mode', False, 'debugstl'),
         })
         opts[key].choices = ['none'] + c_stds + g_stds
         return opts
@@ -617,11 +627,13 @@ class VisualStudioLikeCPPCompilerMixin(CompilerMixinBase):
                 'C++ exception handling type.',
                 ['none', 'default', 'a', 's', 'sc'],
                 'default',
+                'eh',
             ),
-            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True),
+            key.evolve('rtti'): coredata.UserBooleanOption('Enable RTTI', True, 'rtti'),
             key.evolve('winlibs'): coredata.UserArrayOption(
                 'Windows libs to link against.',
                 msvc_winlibs,
+                'winlibs',
             ),
         })
         opts[key.evolve('std')].choices = cpp_stds

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -614,9 +614,9 @@ class CudaCompiler(Compiler):
         ccbindir_key = OptionKey('ccbindir', machine=self.for_machine, lang=self.language)
         opts.update({
             std_key:      coredata.UserComboOption('C++ language standard to use with CUDA',
-                                                   ['none', 'c++03', 'c++11', 'c++14', 'c++17'], 'none'),
+                                                   ['none', 'c++03', 'c++11', 'c++14', 'c++17'], 'none', 'std'),
             ccbindir_key: coredata.UserStringOption('CUDA non-default toolchain directory to use (-ccbin)',
-                                                    ''),
+                                                    '', 'ccbindir'),
         })
         return opts
 

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -68,6 +68,7 @@ class CythonCompiler(Compiler):
                 'Python version to target',
                 ['2', '3'],
                 '3',
+                'version',
             ),
             OptionKey('language', machine=self.for_machine, lang=self.language): coredata.UserComboOption(
                 'Output C or C++ files',

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -161,6 +161,7 @@ class FortranCompiler(CLikeCompiler, Compiler):
                 'Fortran language standard to use',
                 ['none'],
                 'none',
+                'std',
             ),
         })
         return opts

--- a/mesonbuild/compilers/mixins/emscripten.py
+++ b/mesonbuild/compilers/mixins/emscripten.py
@@ -75,6 +75,7 @@ class EmscriptenMixin(Compiler):
             key: coredata.UserIntegerOption(
                 'Number of threads to use in web assembly, set to 0 to disable',
                 (0, None, 4),  # Default was picked at random
+                'thread_count',
             ),
         })
 

--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -92,6 +92,7 @@ class ClangObjCCompiler(ClangCompiler, ObjCCompiler):
                 'C language standard to use',
                 ['none', 'c89', 'c99', 'c11', 'c17', 'gnu89', 'gnu99', 'gnu11', 'gnu17'],
                 'none',
+                'std',
             )
         })
         return opts

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -92,6 +92,7 @@ class ClangObjCPPCompiler(ClangCompiler, ObjCPPCompiler):
                 'C++ language standard to use',
                 ['none', 'c++98', 'c++11', 'c++14', 'c++17', 'gnu++98', 'gnu++11', 'gnu++14', 'gnu++17'],
                 'none',
+                'std',
             )
         })
         return opts

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -150,6 +150,7 @@ class RustCompiler(Compiler):
                 'Rust Eddition to use',
                 ['none', '2015', '2018'],
                 'none',
+                'std',
             ),
         }
 

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -35,7 +35,7 @@ if T.TYPE_CHECKING:
     import argparse
 
 def array_arg(value: str) -> T.List[str]:
-    return UserArrayOption(None, value, allow_dups=True, user_input=True).value
+    return UserArrayOption(None, value, allow_dups=True, user_input=True, opt_name='').value
 
 def validate_builddir(builddir: Path) -> None:
     if not (builddir / 'meson-private' / 'coredata.dat' ).is_file():

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -182,42 +182,43 @@ class OptionInterpreter:
         self.options[key] = opt
 
     @permittedKwargs({'value', 'yield'})
-    def string_parser(self, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
+    def string_parser(self, opt_name: str, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
         value = kwargs.get('value', '')
-        return coredata.UserStringOption(description, value, kwargs['yield'])
+        return coredata.UserStringOption(description, value, opt_name, kwargs['yield'])
 
     @permittedKwargs({'value', 'yield'})
-    def boolean_parser(self, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
+    def boolean_parser(self, opt_name: str, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
         value = kwargs.get('value', True)
-        return coredata.UserBooleanOption(description, value, kwargs['yield'])
+        return coredata.UserBooleanOption(description, value, opt_name, kwargs['yield'])
 
     @permittedKwargs({'value', 'yield', 'choices'})
-    def combo_parser(self, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
+    def combo_parser(self, opt_name: str, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
         choices = kwargs.get('choices')
         if not choices:
-            raise OptionException(f'Choice list for combo choice option with description "{description}" misses "choices" keyword.')
+            raise OptionException(f'Choice list for combo option "{opt_name}" misses "choices" keyword.')
         value = kwargs.get('value', choices[0])
-        return coredata.UserComboOption(description, choices, value, kwargs['yield'])
+        return coredata.UserComboOption(description, choices, value, opt_name, kwargs['yield'])
 
     @permittedKwargs({'value', 'min', 'max', 'yield'})
-    def integer_parser(self, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
+    def integer_parser(self, opt_name: str, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
         value = kwargs.get('value')
         if value is None:
-            raise OptionException(f'Integer option must with description "{description}" must contain a "value" argument.')
+            raise OptionException(f'Integer option "{opt_name}" must contain a "value" argument.')
         inttuple = (kwargs.get('min'), kwargs.get('max'), value)
-        return coredata.UserIntegerOption(description, inttuple, kwargs['yield'])
+        return coredata.UserIntegerOption(description, inttuple, opt_name, kwargs['yield'])
 
     @permittedKwargs({'value', 'yield', 'choices'})
-    def string_array_parser(self, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
+    def string_array_parser(self, opt_name: str, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
         choices = kwargs.get('choices', [])
         value = kwargs.get('value', choices)
         if not isinstance(value, list):
-            raise OptionException(f'Choice options "{choices}" for array option with description "{description}" must be passed as an array.')
+            raise OptionException(f'Choice options "{choices}" for array option "{opt_name}" must be passed as an array.')
         return coredata.UserArrayOption(description, value,
                                         choices=choices,
+                                        opt_name=opt_name,
                                         yielding=kwargs['yield'])
 
     @permittedKwargs({'value', 'yield'})
-    def feature_parser(self, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
+    def feature_parser(self, opt_name: str, description: str, kwargs: 'ParserArgs') -> coredata.UserOption:
         value = kwargs.get('value', 'auto')
-        return coredata.UserFeatureOption(description, value, kwargs['yield'])
+        return coredata.UserFeatureOption(description, value, opt_name, kwargs['yield'])


### PR DESCRIPTION
The topic of better error messages for user build options was brought up in issue #6797. The commit 17c8193 partially covered the issue by adding details to the error message for one specific user build option that was mentioned in the issue.
This pull request however applies the same treatment to all types of user build options with the aim to enhance the general usefulness of these error messages. This closes the issue #6797.
The error messages now print out the description of each option in addition to the value to let the user easily know which option has an invalid value.
Additionally due to the changes in the error messages, the test cases previously added by commit 17c8193 have been adjusted accordingly.
