### PR TITLE
Qt: Fix some issues with the type safety reworks

### DIFF
--- a/docs/markdown/_include_qt_base.md
+++ b/docs/markdown/_include_qt_base.md
@@ -41,7 +41,7 @@ It takes no positional arguments, and the following keyword arguments:
   - `extra_args` string[]: Extra arguments to pass directly to `qt-moc`
   - `method` string: The method to use to detect qt, see `dependency()` for more
     information.
-  - `include_directories` IncludeDirectory[]: A list of `include_directory()`
+  - `include_directories` (string | IncludeDirectory)[]: A list of `include_directory()`
     objects used when transpiling the .moc files
 
 ## preprocess
@@ -62,16 +62,16 @@ sources += qt.preprocess(qresources : ['resources'])
 ```
 
 This method takes the following keyword arguments:
- - `qresources`: a list of strings, Files, Custom Targets, or Build Targets to pass the `rcc` compiler
- - `ui_files`: a list of strings, Files, Custom Targets, or Build Targets to pass the `uic` compiler
- - `moc_sources`: a list of strings, Files, Custom Targets, or Build Targets to pass the `moc` compiler the
- - `moc_headers`: a list of strings, Files, Custom Targets, or Build Targets to pass the `moc` compiler. These will be converted into .cpp files
- - `include_directories`, the directories to add to header search path for `moc` (optional)
- - `moc_extra_arguments`, any additional arguments to `moc` (optional). Available since v0.44.0.
- - `uic_extra_arguments`, any additional arguments to `uic` (optional). Available since v0.49.0.
- - `rcc_extra_arguments`, any additional arguments to `rcc` (optional). Available since v0.49.0.
- - `dependencies`, dependency objects needed by moc. Available since v0.48.0.
- - `sources`, a list of extra sources, which are added to the output unchaged. Deprecated in 0.59.0
+ - `qresources` (string | File | CustomTarget | BuildTarget)[]: Passed to the RCC compiler
+ - `ui_files`: (string | File | CustomTarget | BuilduTarget)[]: Passed the `uic` compiler
+ - `moc_sources`: (string | File | CustomTarget | BuildTarget)[]: Passed the `moc` compiler the
+ - `moc_headers`: (string | File | CustomTarget | BuildTarget)[]: Passied the `moc` compiler. These will be converted into .cpp files
+ - `include_directories` (IncludeDirectories | string)[], the directories to add to header search path for `moc`
+ - `moc_extra_arguments` string[]: any additional arguments to `moc`. Since v0.44.0.
+ - `uic_extra_arguments` string[]: any additional arguments to `uic`. Since v0.49.0.
+ - `rcc_extra_arguments` string[]: any additional arguments to `rcc`. Since v0.49.0.
+ - `dependencies` Dependency[]: dependency objects needed by moc. Available since v0.48.0.
+ - `sources`: a list of extra sources, which are added to the output unchaged. Deprecated in 0.59.0.
 
 It returns an array of targets and sources to pass to a compilation target.
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -327,28 +327,30 @@ class Build:
         return link_args.get(compiler.get_language(), [])
 
 class IncludeDirs:
-    def __init__(self, curdir, dirs, is_system, extra_build_dirs=None):
+
+    """Internal representation of an include_directories call."""
+
+    def __init__(self, curdir: str, dirs: T.List[str], is_system: bool,
+                 extra_build_dirs: T.Optional[T.List[str]] = None):
         self.curdir = curdir
         self.incdirs = dirs
         self.is_system = is_system
+
         # Interpreter has validated that all given directories
         # actually exist.
-        if extra_build_dirs is None:
-            self.extra_build_dirs = []
-        else:
-            self.extra_build_dirs = extra_build_dirs
+        self.extra_build_dirs: T.List[str] = extra_build_dirs or []
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         r = '<{} {}/{}>'
         return r.format(self.__class__.__name__, self.curdir, self.incdirs)
 
-    def get_curdir(self):
+    def get_curdir(self) -> str:
         return self.curdir
 
-    def get_incdirs(self):
+    def get_incdirs(self) -> T.List[str]:
         return self.incdirs
 
-    def get_extra_build_dirs(self):
+    def get_extra_build_dirs(self) -> T.List[str]:
         return self.extra_build_dirs
 
     def to_string_list(self, sourcedir: str) -> T.List[str]:

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -428,11 +428,11 @@ class QtBaseModule(ExtensionModule):
                 if not isinstance(args[0], str):
                     raise build.InvalidArguments('First argument to qt.preprocess must be a string')
                 rcc_kwargs['name'] = args[0]
-            sources.extend(self.compile_resources(state, tuple(), rcc_kwargs).return_value)
+            sources.append(self.compile_resources(state, tuple(), rcc_kwargs).return_value)
 
         if kwargs['ui_files']:
             ui_kwargs: 'UICompilerKwArgs' = {'sources': kwargs['ui_files'], 'extra_args': kwargs['uic_extra_arguments'], 'method': method}
-            sources.extend(self.compile_ui(state, tuple(), ui_kwargs).return_value)
+            sources.append(self.compile_ui(state, tuple(), ui_kwargs).return_value)
 
         if kwargs['moc_headers'] or kwargs['moc_sources']:
             moc_kwargs: 'MocCompilerKwArgs' = {
@@ -443,7 +443,7 @@ class QtBaseModule(ExtensionModule):
                 'dependencies': kwargs['dependencies'],
                 'method': method,
             }
-            sources.extend(self.compile_moc(state, tuple(), moc_kwargs).return_value)
+            sources.append(self.compile_moc(state, tuple(), moc_kwargs).return_value)
 
         return ModuleReturnValue(sources, [sources])
 

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -65,7 +65,7 @@ if T.TYPE_CHECKING:
         headers: T.List[mesonlib.FileOrString]
         extra_args: T.List[str]
         method: str
-        include_directories: T.List[IncludeDirsHolder]
+        include_directories: T.List[T.Union[str, IncludeDirsHolder]]
         dependencies: T.List[T.Union[DependencyHolder, ExternalLibraryHolder]]
 
     class PreprocessKwArgs(TypedDict):
@@ -78,7 +78,7 @@ if T.TYPE_CHECKING:
         moc_extra_arguments: T.List[str]
         rcc_extra_arguments: T.List[str]
         uic_extra_arguments: T.List[str]
-        include_directories: T.List[IncludeDirsHolder]
+        include_directories: T.List[T.Union[str, IncludeDirsHolder]]
         dependencies: T.List[T.Union[DependencyHolder, ExternalLibraryHolder]]
         method: str
 
@@ -362,7 +362,7 @@ class QtBaseModule(ExtensionModule):
         KwargInfo('headers', ContainerTypeInfo(list, (File, str)), listify=True, default=[]),
         KwargInfo('extra_args', ContainerTypeInfo(list, str), listify=True, default=[]),
         KwargInfo('method', str, default='auto'),
-        KwargInfo('include_directories', ContainerTypeInfo(list, IncludeDirsHolder), listify=True, default=[]),
+        KwargInfo('include_directories', ContainerTypeInfo(list, (IncludeDirsHolder, str)), listify=True, default=[]),
         KwargInfo('dependencies', ContainerTypeInfo(list, (DependencyHolder, ExternalLibraryHolder)), listify=True, default=[]),
     )
     def compile_moc(self, state: 'ModuleState', args: T.Tuple, kwargs: 'MocCompilerKwArgs') -> ModuleReturnValue:
@@ -408,7 +408,7 @@ class QtBaseModule(ExtensionModule):
         KwargInfo('rcc_extra_arguments', ContainerTypeInfo(list, str), listify=True, default=[], since='0.49.0'),
         KwargInfo('uic_extra_arguments', ContainerTypeInfo(list, str), listify=True, default=[], since='0.49.0'),
         KwargInfo('method', str, default='auto'),
-        KwargInfo('include_directories', ContainerTypeInfo(list, IncludeDirsHolder), listify=True, default=[]),
+        KwargInfo('include_directories', ContainerTypeInfo(list, (IncludeDirsHolder, str)), listify=True, default=[]),
         KwargInfo('dependencies', ContainerTypeInfo(list, (DependencyHolder, ExternalLibraryHolder)), listify=True, default=[]),
     )
     def preprocess(self, state: 'ModuleState', args: T.List[T.Union[str, File]], kwargs: 'PreprocessKwArgs') -> ModuleReturnValue:

--- a/test cases/failing/45 abspath to srcdir/test.json
+++ b/test cases/failing/45 abspath to srcdir/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/45 abspath to srcdir/meson.build:3:0: ERROR: Tried to form an absolute path to a source dir. You should not do that but use relative paths instead."
+      "line": "test cases/failing/45 abspath to srcdir/meson.build:3:0: ERROR: Tried to form an absolute path to a source dir."
     }
   ]
 }

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -57,6 +57,10 @@ foreach qt : ['qt4', 'qt5', 'qt6']
     # XML files that need to be compiled with the uic tol.
     prep += qtmodule.compile_ui(sources : 'mainWindow.ui', method: get_option('method'))
 
+    qtmodule.preprocess(
+      ui_files : 'mainWindow.ui',
+      method: get_option('method'))
+
     # Resource file(s) for rcc compiler
     extra_cpp_args = []
     if meson.is_unity()
@@ -100,6 +104,12 @@ foreach qt : ['qt4', 'qt5', 'qt6']
     # The build system needs to include the cpp files from
     # headers but the user must manually include moc
     # files from sources.
+    qtmodule.preprocess(
+      moc_extra_arguments : ['-DMOC_EXTRA_FLAG'], # This is just a random macro to test `extra_arguments`
+      moc_sources : 'manualinclude.cpp',
+      moc_headers : 'manualinclude.h',
+      method : get_option('method'))
+
     manpreprocessed = qtmodule.compile_moc(
       extra_args : ['-DMOC_EXTRA_FLAG'], # This is just a random macro to test `extra_arguments`
       sources : 'manualinclude.cpp',


### PR DESCRIPTION
This fixes two issues:
1. using extend where we should be using append
2. preprocess previously accepted strings for include directories, make that work again.