### PR TITLE
build: fix object path for vs backend

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -412,7 +412,14 @@ class Backend:
                                  self.build_to_src, target.get_subdir(), obj)
                 obj_list.append(o)
             elif isinstance(obj, mesonlib.File):
-                obj_list.append(obj.rel_to_builddir(self.build_to_src))
+                if obj.is_built:
+                    o = os.path.join(proj_dir_to_build_root,
+                                     obj.rel_to_builddir(self.build_to_src))
+                    obj_list.append(o)
+                else:
+                    o = os.path.join(proj_dir_to_build_root,
+                                     self.build_to_src)
+                    obj_list.append(obj.rel_to_builddir(o))
             elif isinstance(obj, build.ExtractedObjects):
                 if obj.recursive:
                     obj_list += self._flatten_object_list(obj.target, obj.objlist, proj_dir_to_build_root)

--- a/test cases/common/121 object only target/meson.build
+++ b/test cases/common/121 object only target/meson.build
@@ -43,7 +43,9 @@ generated2 = gen2.process(['source3.c'])
 
 stc = static_library('stc', generated2)
 
-e = executable('prog', 'prog.c', link_with : [obj, shr, stc],
+subdir('objdir')
+
+e = executable('prog', 'prog.c', link_with : [obj, shr, stc, subdirfilebuilt_obj, subdirfile_obj, subdirstr_obj],
   install : true)
 
 test('objgen', e)

--- a/test cases/common/121 object only target/objdir/meson.build
+++ b/test cases/common/121 object only target/objdir/meson.build
@@ -1,0 +1,27 @@
+
+#mesonlib.File built
+source4 = configure_file(input : 'source4.c',
+  output : 'source4' + ext,
+  command : [comp, cc, files('source4.c'),
+             join_paths(meson.current_build_dir(), 'source4' + ext)])
+
+subdirfilebuilt_obj = static_library('subdirfilebuilt_obj', objects : source4)
+
+
+#mesonlib.File not built
+configure_file(input : 'source5.c',
+  output : 'source5' + ext,
+  command : [comp, cc, files('source5.c'),
+             join_paths(meson.current_build_dir(), 'source5' + ext)])
+
+subdirfile_obj = static_library('subdirfile_obj', objects : files(meson.current_build_dir()/'source5' + ext))
+
+
+#str
+configure_file(input : 'source6.c',
+  output : 'source6' + ext,
+  command : [comp, cc, files('source6.c'),
+             join_paths(meson.current_build_dir(), 'source6' + ext)])
+
+
+subdirstr_obj = static_library('subdirstr_obj', objects : meson.current_build_dir()/'source6' + ext)

--- a/test cases/common/121 object only target/objdir/source4.c
+++ b/test cases/common/121 object only target/objdir/source4.c
@@ -1,0 +1,3 @@
+int func4_in_obj(void) {
+    return 0;
+}

--- a/test cases/common/121 object only target/objdir/source5.c
+++ b/test cases/common/121 object only target/objdir/source5.c
@@ -1,0 +1,3 @@
+int func5_in_obj(void) {
+    return 0;
+}

--- a/test cases/common/121 object only target/objdir/source6.c
+++ b/test cases/common/121 object only target/objdir/source6.c
@@ -1,0 +1,3 @@
+int func6_in_obj(void) {
+    return 0;
+}

--- a/test cases/common/121 object only target/prog.c
+++ b/test cases/common/121 object only target/prog.c
@@ -1,7 +1,11 @@
 int func1_in_obj(void);
 int func2_in_obj(void);
 int func3_in_obj(void);
+int func4_in_obj(void);
+int func5_in_obj(void);
+int func6_in_obj(void);
 
 int main(void) {
-    return func1_in_obj() + func2_in_obj() + func3_in_obj();
+    return func1_in_obj() + func2_in_obj() + func3_in_obj()
+         + func4_in_obj() + func5_in_obj() + func6_in_obj();
 }


### PR DESCRIPTION
Using objects in library with the vs backend will generate a project with the wrong path to the object.
This merge request adds more tests to this specific test case and fixes the issue with vs backend.
Warning: the test case will leave object files in the source directory.