### PR TITLE
fix: Ensure that build targets have all methods from ExternalProgram

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2561,12 +2561,23 @@ module](#shared_module).
   this and will also allow Meson to setup inter-target dependencies
   correctly. Please file a bug if that doesn't work for you.
 
+- `path()` *(since 0.59.0)* **(deprecated)**: does the exact same
+  as `full_path()`. **NOTE:** This function is solely kept for compatebility
+  with [`external program`](#external-program-object) objects. It will be
+  removed once the, also deprecated, corresponding `path()` function in the
+  `external program` object is removed.
+
 - `private_dir_include()`: returns a opaque value that works like
   `include_directories` but points to the private directory of this
   target, usually only needed if an another target needs to access
   some generated internal headers of this target
 
 - `name()` *(since 0.54.0)*: returns the target name.
+
+- `found()` *(since 0.59.0)*: Always returns `true`. This function is meant
+  to make executables objects feature compatible with
+  [`external program`](#external-program-object) objects. This simplifies
+  use-cases where an executable is used instead of an external program.
 
 
 ### `configuration` data object

--- a/docs/markdown/snippets/build-target-found.md
+++ b/docs/markdown/snippets/build-target-found.md
@@ -1,0 +1,16 @@
+## New `build target` methods
+
+The [`build target` object](Reference-manual.md#build-target-object) now supports
+the following two functions, to ensure feature compatebility with
+[`external program` objects](Reference-manual.html#external-program-object):
+
+- `found()`: Always returns `true`. This function is meant
+  to make executables objects feature compatible with
+  `external program` objects. This simplifies
+  use-cases where an executable is used instead of an external program.
+
+- `path()`: **(deprecated)** does the exact same as `full_path()`.
+  **NOTE:** This function is solely kept for compatebility
+  with `external program` objects. It will be
+  removed once the, also deprecated, corresponding `path()` function in the
+  `external program` object is removed.

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -58,7 +58,7 @@ class InterpreterObject:
             if not getattr(method, 'no-args-flattening', False):
                 args = flatten(args)
             return method(args, kwargs)
-        raise InvalidCode('Unknown method "%s" in object.' % method_name)
+        raise InvalidCode(f'Unknown method "{method_name}" in object {self} of type {type(self).__name__}.')
 
 class MesonInterpreterObject(InterpreterObject):
     ''' All non-elementary objects and non-object-holders should be derived from this '''

--- a/test cases/common/182 find override/meson.build
+++ b/test cases/common/182 find override/meson.build
@@ -1,8 +1,10 @@
 project('find program override', 'c')
 
 gencodegen = find_program('gencodegen', required : false)
+six_prog = find_program('six_meson_exe', required : false)
 
 assert(not gencodegen.found(), 'gencodegen is an internal program, should not be found')
+assert(not six_prog.found(), 'six_meson_exe is an internal program, should not be found')
 
 # Test the check-if-found-else-override workflow
 if not gencodegen.found()
@@ -13,3 +15,11 @@ subdir('otherdir')
 
 tool = find_program('sometool')
 assert(tool.found())
+assert(tool.full_path() != '')
+assert(tool.full_path() == tool.path())
+
+# six_meson_exe is an overritten project executable
+six_prog = find_program('six_meson_exe')
+assert(six_prog.found())
+assert(six_prog.full_path() != '')
+assert(six_prog.full_path() == six_prog.path())

--- a/test cases/common/182 find override/otherdir/meson.build
+++ b/test cases/common/182 find override/otherdir/meson.build
@@ -10,6 +10,10 @@ e = executable('six', 'main.c', src)
 
 test('six', e)
 
+# Override stuff with an executables
+meson.override_find_program('six_meson_exe', e)
+
+
 # The same again, but this time with a program that was generated
 # with configure_file.
 


### PR DESCRIPTION
As a side-effect from #8885 `find_program()` returns now `Executable`
objects when `meson.override_find_program` is called with an
executable target. To resolve this conflict the missing methods
from `ExternalProgram` are added to `BuildTarget`.