### PR TITLE
Fix for Issue 8910 (Meson filters CMake asm files)

### DIFF
--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -24,7 +24,7 @@ from .traceparser import CMakeTraceParser, CMakeGeneratorTarget
 from .. import mlog, mesonlib
 from ..mesonlib import MachineChoice, OrderedSet, version_compare, path_is_in_root, relative_to_if_possible, OptionKey
 from ..mesondata import mesondata
-from ..compilers.compilers import lang_suffixes, header_suffixes, obj_suffixes, lib_suffixes, is_header
+from ..compilers.compilers import assembler_suffixes, lang_suffixes, header_suffixes, obj_suffixes, lib_suffixes, is_header
 from ..programs import ExternalProgram
 from enum import Enum
 from functools import lru_cache
@@ -435,7 +435,7 @@ class ConverterTarget:
         self.link_libraries = temp
 
         # Filter out files that are not supported by the language
-        supported = list(header_suffixes) + list(obj_suffixes)
+        supported = list(assembler_suffixes) + list(header_suffixes) + list(obj_suffixes)
         for i in self.languages:
             supported += list(lang_suffixes[i])
         supported = [f'.{x}' for x in supported]

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -74,8 +74,7 @@ c_suffixes = lang_suffixes['c'] + ('h',)  # type: T.Tuple[str, ...]
 # C ABI; these can generally be used interchangeably
 clib_langs = ('objcpp', 'cpp', 'objc', 'c', 'fortran',)  # type: T.Tuple[str, ...]
 # List of assembler suffixes that can be linked with C code directly by the linker
-assembler_suffixes = tuple() # type: T.Tuple[str, ...]
-assembler_suffixes += ('s', 'S')
+assembler_suffixes: T.Tuple[str, ...] = ('s', 'S')
 # List of languages that can be linked with C code directly by the linker
 # used in build.py:process_compilers() and build.py:get_dynamic_linker()
 clink_langs = ('d', 'cuda') + clib_langs  # type: T.Tuple[str, ...]

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -73,6 +73,9 @@ c_suffixes = lang_suffixes['c'] + ('h',)  # type: T.Tuple[str, ...]
 # List of languages that by default consume and output libraries following the
 # C ABI; these can generally be used interchangeably
 clib_langs = ('objcpp', 'cpp', 'objc', 'c', 'fortran',)  # type: T.Tuple[str, ...]
+# List of assembler suffixes that can be linked with C code directly by the linker
+assembler_suffixes = tuple() # type: T.Tuple[str, ...]
+assembler_suffixes += ('s', 'S')
 # List of languages that can be linked with C code directly by the linker
 # used in build.py:process_compilers() and build.py:get_dynamic_linker()
 clink_langs = ('d', 'cuda') + clib_langs  # type: T.Tuple[str, ...]

--- a/test cases/cmake/25 assembler/main.c
+++ b/test cases/cmake/25 assembler/main.c
@@ -1,9 +1,9 @@
 #include <stdint.h>
 #include <stdio.h>
 
-int32_t cmTestFunc();
+int32_t cmTestFunc(void);
 
-int main(int argc, char* argv[])
+int main(void)
 {
     if (cmTestFunc() > 4200)
     {

--- a/test cases/cmake/25 assembler/main.c
+++ b/test cases/cmake/25 assembler/main.c
@@ -1,0 +1,18 @@
+#include <stdint.h>
+#include <stdio.h>
+
+int32_t cmTestFunc();
+
+int main(int argc, char* argv[])
+{
+    if (cmTestFunc() > 4200)
+    {
+        printf("Test success.\n");
+        return 0;
+    }
+    else
+    {
+        printf("Test failure.\n");
+        return 1;
+    }
+}

--- a/test cases/cmake/25 assembler/meson.build
+++ b/test cases/cmake/25 assembler/meson.build
@@ -1,4 +1,4 @@
-project('assembler test', ['c'])
+project('assembler test', ['c', 'cpp'])
 
 cm = import('cmake')
 

--- a/test cases/cmake/25 assembler/meson.build
+++ b/test cases/cmake/25 assembler/meson.build
@@ -1,0 +1,9 @@
+project('assembler test', ['c'])
+
+cm = import('cmake')
+
+sub_pro = cm.subproject('cmTest')
+sub_dep = sub_pro.dependency('cmTest')
+
+exe1 = executable('exe1', ['main.c'], dependencies: [sub_dep])
+test('test1', exe1)

--- a/test cases/cmake/25 assembler/subprojects/cmTest/CMakeLists.txt
+++ b/test cases/cmake/25 assembler/subprojects/cmTest/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(cmTest)
+
+#Detect processor
+if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "amd64")
+    SET(TEST_PROCESSOR "x86_64")
+elseif ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "x86_64")
+    SET(TEST_PROCESSOR "x86_64")
+elseif ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "i386")
+    SET(TEST_PROCESSOR "x86")
+elseif ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "i686")
+    SET(TEST_PROCESSOR "x86")
+elseif ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "arm")
+    SET(TEST_PROCESSOR "arm")
+elseif ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "aarch64")
+    SET(TEST_PROCESSOR "arm")
+else ()
+    message(FATAL_ERROR, 'MESON_SKIP_TEST: Unsupported Assembler Platform')
+endif ()
+
+#Detect ABI
+if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+    SET(TEST_ABI "sysv")
+elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
+    SET(TEST_ABI "sysv")
+elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "NetBSD")
+    SET(TEST_ABI "sysv")
+elseif ("${CMAKE_SYSTEM_NAME}" MATCHES "OpenBSD")
+    SET(TEST_ABI "sysv")
+else ()
+    message(FATAL_ERROR, 'MESON_SKIP_TEST: Unsupported Assembler Platform')
+endif ()
+
+SET(TEST_PLATFORM "${TEST_PROCESSOR}-${TEST_ABI}")
+
+if (    ("${TEST_PLATFORM}" MATCHES "x86_64-sysv")
+     OR ("${TEST_PLATFORM}" MATCHES "x86-sysv")
+     OR ("${TEST_PLATFORM}" MATCHES "arm-sysv"))
+    SET(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+    enable_language(ASM)
+    SET(TEST_SOURCE "cmTestAsm.s")
+endif ()
+
+add_library(cmTest STATIC cmTest.c ${TEST_SOURCE})

--- a/test cases/cmake/25 assembler/subprojects/cmTest/cmTest.c
+++ b/test cases/cmake/25 assembler/subprojects/cmTest/cmTest.c
@@ -1,0 +1,8 @@
+#include <stdint.h>
+
+extern const int32_t cmTestArea;
+
+int32_t cmTestFunc()
+{
+    return cmTestArea;
+}

--- a/test cases/cmake/25 assembler/subprojects/cmTest/cmTest.c
+++ b/test cases/cmake/25 assembler/subprojects/cmTest/cmTest.c
@@ -2,7 +2,7 @@
 
 extern const int32_t cmTestArea;
 
-int32_t cmTestFunc()
+int32_t cmTestFunc(void)
 {
     return cmTestArea;
 }

--- a/test cases/cmake/25 assembler/subprojects/cmTest/cmTestAsm.s
+++ b/test cases/cmake/25 assembler/subprojects/cmTest/cmTestAsm.s
@@ -1,0 +1,4 @@
+.text
+.globl cmTestArea
+cmTestArea:
+    .long 4242


### PR DESCRIPTION
This patch adds a variable, assembler_suffixes, which is added to the list of supported suffixes in the CMake interpreter.