### PR TITLE
Delete redirected wrap files in subprojects purge

### DIFF
--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -386,6 +386,12 @@ class Runner:
         if not self.wrap.type:
             return True
 
+        if self.wrap.redirected:
+            redirect_file = Path(self.wrap.original_filename).resolve()
+            if self.options.confirm:
+                redirect_file.unlink()
+            mlog.log(f'Deleting {redirect_file}')
+
         if self.wrap.type == 'redirect':
             redirect_file = Path(self.wrap.filename).resolve()
             if self.options.confirm:
@@ -416,7 +422,7 @@ class Runner:
             # parallelized, another thread could have deleted it already.
             try:
                 if not any(packagecache.iterdir()):
-                    packagecache.rmdir()
+                    windows_proof_rmtree(str(packagecache))
             except FileNotFoundError:
                 pass
 

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -101,6 +101,8 @@ class PackageDefinition:
         self.name = self.basename[:-5] if self.has_wrap else self.basename
         self.directory = self.name
         self.provided_deps[self.name] = None
+        self.original_filename = fname
+        self.redirected = False
         if self.has_wrap:
             self.parse_wrap()
         self.directory = self.values.get('directory', self.name)
@@ -109,6 +111,7 @@ class PackageDefinition:
         if self.type and self.type not in ALL_TYPES:
             raise WrapException(f'Unknown wrap type {self.type!r}')
         self.filesdir = os.path.join(os.path.dirname(self.filename), 'packagefiles')
+        # What the original file name was before redirection
 
     def parse_wrap(self) -> None:
         try:
@@ -137,6 +140,7 @@ class PackageDefinition:
                 raise WrapException(f'wrap-redirect {fname} filename does not exist')
             self.filename = str(fname)
             self.parse_wrap()
+            self.redirected = True
             return
         self.parse_provide_section(config)
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -10181,6 +10181,19 @@ class SubprojectsCommandTests(BasePlatformTests):
         self._git_create_local_repo('sub_git')
         self._wrap_create_git('sub_git')
 
+        sub_file_subprojects_dir = self.subprojects_dir / 'sub_file' / 'subprojects'
+        sub_file_subprojects_dir.mkdir(exist_ok=True, parents=True)
+        real_dir = Path('sub_file') / 'subprojects' / 'real'
+
+        self._wrap_create_file(real_dir, tarball='dummy2.tar.gz')
+
+        with open(str((self.subprojects_dir / 'redirect').with_suffix('.wrap')), 'w', encoding='utf-8') as f:
+            f.write(textwrap.dedent(
+                f'''
+                [wrap-redirect]
+                filename = {real_dir}.wrap
+                '''))
+
         def deleting(s: str) -> T.List[str]:
             ret = []
             prefix = 'Deleting '
@@ -10190,14 +10203,31 @@ class SubprojectsCommandTests(BasePlatformTests):
             return sorted(ret)
 
         out = self._subprojects_cmd(['purge'])
-        self.assertEqual(deleting(out), [str(self.subprojects_dir / 'sub_file'), str(self.subprojects_dir / 'sub_git')])
+        self.assertEqual(deleting(out), sorted([
+            str(self.subprojects_dir / 'redirect.wrap'),
+            str(self.subprojects_dir / 'sub_file'),
+            str(self.subprojects_dir / 'sub_git'),
+        ]))
         out = self._subprojects_cmd(['purge', '--include-cache'])
-        self.assertEqual(deleting(out), [str(self.subprojects_dir / 'packagecache' / 'dummy.tar.gz'), str(self.subprojects_dir / 'sub_file'), str(self.subprojects_dir / 'sub_git')])
+        self.assertEqual(deleting(out), sorted([
+            str(self.subprojects_dir / 'sub_git'),
+            str(self.subprojects_dir / 'redirect.wrap'),
+            str(self.subprojects_dir / 'packagecache' / 'dummy.tar.gz'),
+            str(self.subprojects_dir / 'packagecache' / 'dummy2.tar.gz'),
+            str(self.subprojects_dir / 'sub_file'),
+        ]))
         out = self._subprojects_cmd(['purge', '--include-cache', '--confirm'])
-        self.assertEqual(deleting(out), [str(self.subprojects_dir / 'packagecache' / 'dummy.tar.gz'), str(self.subprojects_dir / 'sub_file'), str(self.subprojects_dir / 'sub_git')])
+        self.assertEqual(deleting(out), sorted([
+            str(self.subprojects_dir / 'sub_git'),
+            str(self.subprojects_dir / 'redirect.wrap'),
+            str(self.subprojects_dir / 'packagecache' / 'dummy.tar.gz'),
+            str(self.subprojects_dir / 'packagecache' / 'dummy2.tar.gz'),
+            str(self.subprojects_dir / 'sub_file'),
+        ]))
         self.assertFalse(Path(self.subprojects_dir / 'packagecache' / 'dummy.tar.gz').exists())
         self.assertFalse(Path(self.subprojects_dir / 'sub_file').exists())
         self.assertFalse(Path(self.subprojects_dir / 'sub_git').exists())
+        self.assertFalse(Path(self.subprojects_dir / 'redirect.wrap').exists())
 
 def _clang_at_least(compiler: 'Compiler', minver: str, apple_minver: T.Optional[str]) -> bool:
     """


### PR DESCRIPTION
We need to store the original filename as well as whether the wrap was
redirected in order to properly purge the redirected wrap.

Follow on to https://github.com/mesonbuild/meson/pull/8524. Maybe it is worth backporting.