### PR TITLE
Add feed arg to custom_target()

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -383,6 +383,10 @@ following.
   `{'NAME1': 'value1', 'NAME2': 'value2'}` or `['NAME1=value1', 'NAME2=value2']`,
   or an [`environment()` object](#environment-object) which allows more
   sophisticated environment juggling.
+- `feed` *(since 0.59.0)*: there are some compilers that can't be told to read
+  their input from a file and instead read it from standard input. When this
+  argument is set to true, Meson feeds the input file to `stdin`. Note that
+  your argument list may not contain `@INPUT@` when feed mode is active.
 
 The list of strings passed to the `command` keyword argument accept
 the following special string substitutions:

--- a/docs/markdown/snippets/custom-target-feed.md
+++ b/docs/markdown/snippets/custom-target-feed.md
@@ -1,0 +1,4 @@
+## The custom_target() function now accepts a feed argument
+
+It is now possible to provide a `feed: true` argument to `custom_target()` to
+pipe the target's input file to the program's standard input.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -973,6 +973,7 @@ int dummy;
         cmd, reason = self.as_meson_exe_cmdline(target.name, target.command[0], cmd[1:],
                                                 extra_bdeps=target.get_transitive_build_target_deps(),
                                                 capture=ofilenames[0] if target.capture else None,
+                                                feed=srcs[0] if target.feed else None,
                                                 env=target.env)
         if reason:
             cmd_type = f' (wrapped by meson {reason})'

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -563,6 +563,7 @@ class Vs2010Backend(backends.Backend):
                                                    workdir=tdir_abs,
                                                    extra_bdeps=extra_bdeps,
                                                    capture=ofilenames[0] if target.capture else None,
+                                                   feed=srcs[0] if target.feed else None,
                                                    force_serialize=True,
                                                    env=target.env)
         if target.build_always_stale:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1694,9 +1694,11 @@ external dependencies (including libraries) must go to "dependencies".''')
     @FeatureNewKwargs('custom_target', '0.48.0', ['console'])
     @FeatureNewKwargs('custom_target', '0.47.0', ['install_mode', 'build_always_stale'])
     @FeatureNewKwargs('custom_target', '0.40.0', ['build_by_default'])
+    @FeatureNewKwargs('custom_target', '0.59.0', ['feed'])
     @permittedKwargs({'input', 'output', 'command', 'install', 'install_dir', 'install_mode',
                       'build_always', 'capture', 'depends', 'depend_files', 'depfile',
-                      'build_by_default', 'build_always_stale', 'console', 'env'})
+                      'build_by_default', 'build_always_stale', 'console', 'env',
+                      'feed'})
     def func_custom_target(self, node, args, kwargs):
         if len(args) != 1:
             raise InterpreterException('custom_target: Only one positional argument is allowed, and it must be a string name')

--- a/test cases/common/243 custom target feed/data_source.txt
+++ b/test cases/common/243 custom target feed/data_source.txt
@@ -1,0 +1,1 @@
+This is a text only input file.

--- a/test cases/common/243 custom target feed/meson.build
+++ b/test cases/common/243 custom target feed/meson.build
@@ -1,0 +1,24 @@
+project('custom target feed', 'c')
+
+python3 = import('python3').find_python()
+
+# Note that this will not add a dependency to the compiler executable.
+# Code will not be rebuilt if it changes.
+comp = '@0@/@1@'.format(meson.current_source_dir(), 'my_compiler.py')
+
+mytarget = custom_target('bindat',
+  output : 'data.dat',
+  input : 'data_source.txt',
+  feed : true,
+  command : [python3, comp, '@OUTPUT@'],
+  install : true,
+  install_dir : 'subdir'
+)
+
+ct_output_exists = '''import os, sys
+if not os.path.exists(sys.argv[1]):
+  print("could not find {!r} in {!r}".format(sys.argv[1], os.getcwd()))
+  sys.exit(1)
+'''
+
+test('capture-wrote', python3, args : ['-c', ct_output_exists, mytarget])

--- a/test cases/common/243 custom target feed/my_compiler.py
+++ b/test cases/common/243 custom target feed/my_compiler.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import sys
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print(sys.argv[0], 'output_file')
+        sys.exit(1)
+    ifile = sys.stdin.read()
+    if ifile != 'This is a text only input file.\n':
+        print('Malformed input')
+        sys.exit(1)
+    with open(sys.argv[1], 'w+') as f:
+        f.write('This is a binary output file.')

--- a/test cases/common/243 custom target feed/test.json
+++ b/test cases/common/243 custom target feed/test.json
@@ -1,0 +1,5 @@
+{
+  "installed": [
+    {"type": "file", "file": "usr/subdir/data.dat"}
+  ]
+}


### PR DESCRIPTION
An example of a tool not accepting an input file param is [scdoc](https://git.sr.ht/~sircmpwn/scdoc/).