### PR TITLE
Automatically added the build dir to include directories in the compiler.check_header routine in case include_directories are passed.

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -347,6 +347,18 @@ class CLikeCompiler(Compiler):
                      dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
         code = f'''{prefix}
         #include <{hname}>'''
+
+        # Change extra_args to list of strings
+        if callable(extra_args):
+            extra_args = extra_args("compile")
+
+        if extra_args is not None:
+            builddir = Path(env.build_dir)
+
+            # Append builddir to include directories in case config_header is used before check header
+            if any(arg.startswith("-I") and not builddir.samefile(arg[2:]) for arg in extra_args):
+                extra_args.append(f"-I{builddir.as_posix()}")
+
         return self.compiles(code, env, extra_args=extra_args,
                              dependencies=dependencies)
 


### PR DESCRIPTION
This prevents generated config header files from not being recognized when checking for them, because they only occur in the build dir and not in the source tree.
Link to issue: [https://github.com/mesonbuild/meson/issues/8772](url)