### PR TITLE
refactor: Refactor BothLibraries logic

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -29,7 +29,7 @@ from ..interpreterbase import FeatureDeprecated
 if T.TYPE_CHECKING:
     from ..compilers.compilers import Compiler
     from ..environment import Environment
-    from ..build import BuildTarget, BothLibraries
+    from ..build import BuildTarget
     from ..mesonlib import FileOrString
 
 
@@ -222,8 +222,8 @@ class Dependency(HoldableObject):
 
 class InternalDependency(Dependency):
     def __init__(self, version: str, incdirs: T.List[str], compile_args: T.List[str],
-                 link_args: T.List[str], libraries: T.List[T.Union['BuildTarget', 'BothLibraries']],
-                 whole_libraries: T.List[T.Union['BuildTarget', 'BothLibraries']], sources: T.List['FileOrString'],
+                 link_args: T.List[str], libraries: T.List['BuildTarget'],
+                 whole_libraries: T.List['BuildTarget'], sources: T.List['FileOrString'],
                  ext_deps: T.List[Dependency], variables: T.Dict[str, T.Any]):
         super().__init__(DependencyTypeName('internal'), {})
         self.version = version
@@ -236,11 +236,6 @@ class InternalDependency(Dependency):
         self.sources = sources
         self.ext_deps = ext_deps
         self.variables = variables
-
-        # Deal with BothLibraries
-        from ..build import BothLibraries
-        self.libraries = [x.get_preferred_library() if isinstance(x, BothLibraries) else x for x in self.libraries]
-        self.whole_libraries = [x.static if isinstance(x, BothLibraries) else x for x in self.whole_libraries]
 
     def __deepcopy__(self, memo: T.Dict[int, 'InternalDependency']) -> 'InternalDependency':
         result = self.__class__.__new__(self.__class__)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -26,7 +26,7 @@ from ..programs import ExternalProgram, NonExistingExternalProgram
 from ..dependencies import Dependency
 from ..depfile import DepFile
 from ..interpreterbase import ContainerTypeInfo, InterpreterBase, KwargInfo, typed_kwargs, typed_pos_args
-from ..interpreterbase import noPosargs, noKwargs, stringArgs, permittedKwargs, noArgsFlattening, unholder_return
+from ..interpreterbase import noPosargs, noKwargs, stringArgs, permittedKwargs, noArgsFlattening, noSecondLevelHolderResolving, unholder_return
 from ..interpreterbase import InterpreterException, InvalidArguments, InvalidCode, SubdirDoneRequest
 from ..interpreterbase import Disabler, disablerIfNotFound
 from ..interpreterbase import FeatureNew, FeatureDeprecated, FeatureNewKwargs, FeatureDeprecatedKwargs
@@ -2537,8 +2537,6 @@ Try setting b_lundef to false instead.'''.format(self.coredata.options[OptionKey
             sources = [sources]
         results: T.List['SourceOutputs'] = []
         for s in sources:
-            if isinstance(s, build.BothLibraries):
-                s = s.get_preferred_library()
             if isinstance(s, str):
                 self.validate_within_subproject(self.subdir, s)
                 results.append(mesonlib.File.from_source_file(self.environment.source_dir, self.subdir, s))
@@ -2713,6 +2711,7 @@ This will become a hard error in the future.''', location=self.current_node)
 
     @noKwargs
     @noArgsFlattening
+    @noSecondLevelHolderResolving
     def func_set_variable(self, node, args, kwargs):
         if len(args) != 2:
             raise InvalidCode('Set_variable takes two arguments.')

--- a/mesonbuild/interpreterbase/__init__.py
+++ b/mesonbuild/interpreterbase/__init__.py
@@ -33,12 +33,14 @@ __all__ = [
     'check_stringlist',
     'default_resolve_key',
     'flatten',
+    'resolve_second_level_holders',
 
     'noPosargs',
     'builtinMethodNoKwargs',
     'noKwargs',
     'stringArgs',
     'noArgsFlattening',
+    'noSecondLevelHolderResolving',
     'unholder_return',
     'disablerIfNotFound',
     'permittedKwargs',
@@ -91,6 +93,7 @@ from .decorators import (
     noKwargs,
     stringArgs,
     noArgsFlattening,
+    noSecondLevelHolderResolving,
     unholder_return,
     disablerIfNotFound,
     permittedKwargs,
@@ -115,5 +118,5 @@ from .exceptions import (
 )
 
 from .disabler import Disabler, is_disabled
-from .helpers import check_stringlist, default_resolve_key, flatten
+from .helpers import check_stringlist, default_resolve_key, flatten, resolve_second_level_holders
 from .interpreterbase import MesonVersionString, InterpreterBase

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -14,7 +14,7 @@
 
 from .. import mparser
 from .exceptions import InvalidCode
-from .helpers import flatten
+from .helpers import flatten, resolve_second_level_holders
 from ..mesonlib import HoldableObject
 
 import typing as T
@@ -57,6 +57,8 @@ class InterpreterObject:
             method = self.methods[method_name]
             if not getattr(method, 'no-args-flattening', False):
                 args = flatten(args)
+            if not getattr(method, 'no-second-level-holder-flattening', False):
+                args, kwargs = resolve_second_level_holders(args, kwargs)
             return method(args, kwargs)
         raise InvalidCode(f'Unknown method "{method_name}" in object {self} of type {type(self).__name__}.')
 

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -68,6 +68,10 @@ def noArgsFlattening(f: TV_func) -> TV_func:
     setattr(f, 'no-args-flattening', True)  # noqa: B010
     return f
 
+def noSecondLevelHolderResolving(f: TV_func) -> TV_func:
+    setattr(f, 'no-second-level-holder-flattening', True)  # noqa: B010
+    return f
+
 def unholder_return(f: TV_func) -> T.Callable[..., TYPE_var]:
     @wraps(f)
     def wrapped(*wrapped_args: T.Any, **wrapped_kwargs: T.Any) -> T.Any:

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -42,7 +42,7 @@ from .exceptions import (
 
 from .decorators import FeatureNew, builtinMethodNoKwargs
 from .disabler import Disabler, is_disabled
-from .helpers import check_stringlist, default_resolve_key, flatten
+from .helpers import check_stringlist, default_resolve_key, flatten, resolve_second_level_holders
 from ._unholder import _unholder
 
 import os, copy, re
@@ -546,6 +546,8 @@ The result of this is undefined and will become a hard error in a future Meson r
             func_args = posargs
             if not getattr(func, 'no-args-flattening', False):
                 func_args = flatten(posargs)
+            if not getattr(func, 'no-second-level-holder-flattening', False):
+                func_args, kwargs = resolve_second_level_holders(func_args, kwargs)
             res = func(node, func_args, kwargs)
             return self._holderify(res)
         else:

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -48,6 +48,7 @@ __all__ = [
     'python_command',
     'project_meson_versions',
     'HoldableObject',
+    'SecondLevelHolder',
     'File',
     'FileMode',
     'GitException',
@@ -272,6 +273,14 @@ an_unpicklable_object = threading.Lock()
 class HoldableObject(metaclass=abc.ABCMeta):
     ''' Dummy base class for all objects that can be
         held by an interpreter.baseobjects.ObjectHolder '''
+
+class SecondLevelHolder(HoldableObject, metaclass=abc.ABCMeta):
+    ''' A second level object holder. The primary purpose
+        of such objects is to hold multiple objects with one
+        default option. '''
+
+    @abc.abstractmethod
+    def get_default_object(self) -> HoldableObject: ...
 
 class FileMode:
     # The first triad is for owner permissions, the second for group permissions,

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -494,8 +494,6 @@ class GnomeModule(ExtensionModule):
             return cflags, internal_ldflags, external_ldflags, external_ldflags_nodedup, gi_includes
 
     def _unwrap_gir_target(self, girtarget, state):
-        if isinstance(girtarget, build.BothLibraries):
-            girtarget = girtarget.get_preferred_library()
         if not isinstance(girtarget, (build.Executable, build.SharedLibrary,
                                       build.StaticLibrary)):
             raise MesonException(f'Gir target must be an executable or library but is "{girtarget}" of type {type(girtarget).__name__}')

--- a/test cases/common/178 bothlibraries/meson.build
+++ b/test cases/common/178 bothlibraries/meson.build
@@ -34,8 +34,16 @@ exe_static2 = executable('prog-static2', 'main.c',
                          link_with : both_libs2.get_static_lib())
 exe_both2 = executable('prog-both2', 'main.c', link_with : both_libs2)
 
+# Test {set,get}_variable
+set_variable('both_libs2', both_libs)
+both_libs3 = get_variable('both_libs')
+
 # Ensure that calling the build target methods also works
 assert(both_libs.name() == 'mylib')
+assert(both_libs2.name() == 'mylib')
+assert(both_libs3.name() == 'mylib')
+assert(both_libs2.get_shared_lib().name() == 'mylib')
+assert(both_libs3.get_static_lib().name() == 'mylib')
 
 test('runtest-shared-2', exe_shared2)
 test('runtest-static-2', exe_static2)


### PR DESCRIPTION
This commit introduces a new type of `HoldableObject`: The
`SecondLevelHolder`. The primary purpose of this class is
to handle cases where two (or more) `HoldableObject`s are
stored at the same time (with one default object). The
best (and currently only) example here is the `BothLibraries`
class.