### PR TITLE
Automatically use WrapDB fallback

### DIFF
--- a/docs/markdown/Using-wraptool.md
+++ b/docs/markdown/Using-wraptool.md
@@ -82,3 +82,17 @@ straightforward:
 Wraptool can do other things besides these. Documentation for these
 can be found in the command line help, which can be accessed by
 `meson wrap --help`.
+
+## Automatic dependency fallback
+
+Since *0.64.0* Meson can use WrapDB to automatically find missing dependencies.
+
+The user simply needs to download latest database, the following command stores
+it in `subprojects/wrapdb.json`:
+    $ meson wrap update-db
+
+Once the database is available locally, any dependency not found on the system
+but available in WrapDB will automatically be downloaded.
+
+Automatic fetch of WrapDB subprojects can be disabled by removing the file
+`subprojects/wrapdb.json`, or by using `--wrap-mode=nodownload`.

--- a/docs/markdown/snippets/wrapdb.md
+++ b/docs/markdown/snippets/wrapdb.md
@@ -1,0 +1,6 @@
+## Automatic fallback using WrapDB
+
+A new command has been added: `meson wrap update-db`. It downloads the list of
+wraps available in [WrapDB](wrapdb.mesonbuild.com) and stores it locally in
+`subprojects/wrapdb.json`. When that file exists and a dependency is not found
+on the system but is available in WrapDB, Meson will automatically download it.

--- a/docs/yaml/functions/dependency.yaml
+++ b/docs/yaml/functions/dependency.yaml
@@ -15,6 +15,11 @@ description: |
   of those name will return the same value. This is useful in case a dependency
   could have different names, such as `png` and `libpng`.
 
+  * Since *0.64.0* a dependency fallback can be provided by WrapDB. Simply download
+  the database locally using `meson wrap update-db` command and Meson will
+  automatically fallback to subprojects provided by WrapDB if the dependency is
+  not found on the system and the project does not ship their own `.wrap` file.
+
   Dependencies can also be resolved in two other ways:
 
   * if the same name was used in a `meson.override_dependency` prior to

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -66,14 +66,6 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
         self._subproject_impl(subp_name, varname)
 
     def _subproject_impl(self, subp_name: str, varname: str) -> None:
-        if not varname:
-            # If no variable name is specified, check if the wrap file has one.
-            # If the wrap file has a variable name, better use it because the
-            # subproject most probably is not using meson.override_dependency().
-            for name in self.names:
-                varname = self.wrap_resolver.get_varname(subp_name, name)
-                if varname:
-                    break
         assert self.subproject_name is None
         self.subproject_name = subp_name
         self.subproject_varname = varname
@@ -174,6 +166,14 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
 
         # Legacy: Use the variable name if provided instead of relying on the
         # subproject to override one of our dependency names
+        if not varname:
+            # If no variable name is specified, check if the wrap file has one.
+            # If the wrap file has a variable name, better use it because the
+            # subproject most probably is not using meson.override_dependency().
+            for name in self.names:
+                varname = self.wrap_resolver.get_varname(subp_name, name)
+                if varname:
+                    break
         if not varname:
             mlog.warning(f'Subproject {subp_name!r} did not override {self._display_name!r} dependency and no variable name specified')
             mlog.log('Dependency', mlog.bold(self._display_name), 'from subproject',


### PR DESCRIPTION
New command `meson wrap update-db` downloads the DB into `subprojects/wrapdb.json`. If that file exists, dependency() will automatically download missing wrap files from WrapDB.