### PR TITLE
C2000: linker uses now binary setting from cross-file

### DIFF
--- a/.github/workflows/lint_mypy.yml
+++ b/.github/workflows/lint_mypy.yml
@@ -23,6 +23,15 @@ jobs:
     - run: python -m pip install pylint==2.4.4
     - run: pylint mesonbuild
 
+  custom_lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - run: python ./run_custom_lint.py
+
   mypy:
     runs-on: ubuntu-latest
     steps:

--- a/ci/ciimage/build.py
+++ b/ci/ciimage/build.py
@@ -18,7 +18,7 @@ install_script = 'install.sh'
 class ImageDef:
     def __init__(self, image_dir: Path) -> None:
         path = image_dir / image_def_file
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding='utf-8'))
 
         assert isinstance(data, dict)
         assert all([x in data for x in ['base_image', 'env']])
@@ -74,7 +74,7 @@ class Builder(BuilderBase):
         # Also add /ci to PATH
         out_data += 'export PATH="/ci:$PATH"\n'
 
-        out_file.write_text(out_data)
+        out_file.write_text(out_data, encoding='utf-8')
 
         # make it executable
         mode = out_file.stat().st_mode
@@ -91,7 +91,7 @@ class Builder(BuilderBase):
             RUN /ci/install.sh
         ''')
 
-        out_file.write_text(out_data)
+        out_file.write_text(out_data, encoding='utf-8')
 
     def do_build(self) -> None:
         # copy files
@@ -131,7 +131,7 @@ class ImageTester(BuilderBase):
             ADD meson /meson
         ''')
 
-        out_file.write_text(out_data)
+        out_file.write_text(out_data, encoding='utf-8')
 
     def copy_meson(self) -> None:
         shutil.copytree(

--- a/data/test.schema.json
+++ b/data/test.schema.json
@@ -12,6 +12,7 @@
       "type": "array",
       "items": {
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "file": {
             "type": "string"
@@ -53,15 +54,19 @@
     },
     "matrix": {
       "type": "object",
-      "additionalProperties": {
-        "properties": {
-          "options": {
+      "properties": {
+        "options": {
+          "additionalProperties": {
             "type": "array",
             "items": {
               "type": "object",
+              "additionalProperties": false,
               "properties": {
                 "val": {
-                  "type": "string"
+                  "type": ["string", "boolean", "null", "array"],
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "compilers": {
                   "type": "object",
@@ -86,7 +91,10 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "type": "string"
+                "type": ["string", "boolean", "array"],
+                "items": {
+                  "type": "string"
+                }
               }
             }
           }
@@ -110,6 +118,7 @@
       "type": "array",
       "items": {
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "line": {
             "type": "string"
@@ -120,6 +129,12 @@
               "literal",
               "re"
             ]
+          },
+          "count": {
+            "type": "integer"
+          },
+          "comment": {
+            "type": "string"
           }
         },
         "required": [

--- a/docs/genrelnotes.py
+++ b/docs/genrelnotes.py
@@ -36,10 +36,10 @@ def add_to_sitemap(from_version, to_version):
        Adds release note entry to sitemap.txt.
     '''
     sitemapfile = '../sitemap.txt'
-    s_f = open(sitemapfile)
+    s_f = open(sitemapfile, encoding='utf-8')
     lines = s_f.readlines()
     s_f.close()
-    with open(sitemapfile, 'w') as s_f:
+    with open(sitemapfile, 'w', encoding='utf-8') as s_f:
         for line in lines:
             if 'Release-notes' in line and from_version in line:
                 new_line = line.replace(from_version, to_version)
@@ -51,10 +51,10 @@ def generate(from_version, to_version):
        Generate notes for Meson build next release.
     '''
     ofilename = f'Release-notes-for-{to_version}.md'
-    with open(ofilename, 'w') as ofile:
+    with open(ofilename, 'w', encoding='utf-8') as ofile:
         ofile.write(RELNOTE_TEMPLATE.format(to_version, to_version))
         for snippetfile in glob('snippets/*.md'):
-            snippet = open(snippetfile).read()
+            snippet = open(snippetfile, encoding='utf-8').read()
             ofile.write(snippet)
             if not snippet.endswith('\n'):
                 ofile.write('\n')

--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -228,7 +228,9 @@ meson setup builddir
 
 {{ subprojects_usage.inc }}
 
-Manages subprojects of the Meson project.
+Manages subprojects of the Meson project. *Since 0.59.0* commands are run on
+multiple subprojects in parallel by default, use `--num-processes=1` if it is
+not desired.
 
 {{ subprojects_arguments.inc }}
 

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -383,6 +383,10 @@ following.
   `{'NAME1': 'value1', 'NAME2': 'value2'}` or `['NAME1=value1', 'NAME2=value2']`,
   or an [`environment()` object](#environment-object) which allows more
   sophisticated environment juggling.
+- `feed` *(since 0.59.0)*: there are some compilers that can't be told to read
+  their input from a file and instead read it from standard input. When this
+  argument is set to true, Meson feeds the input file to `stdin`. Note that
+  your argument list may not contain `@INPUT@` when feed mode is active.
 
 The list of strings passed to the `command` keyword argument accept
 the following special string substitutions:

--- a/docs/markdown/Users.md
+++ b/docs/markdown/Users.md
@@ -121,6 +121,7 @@ format files
  - [Polari](https://gitlab.gnome.org/GNOME/polari), an IRC client
  - [qboot](https://github.com/bonzini/qboot), a minimal x86 firmware for booting Linux kernels
  - [radare2](https://github.com/radare/radare2), unix-like reverse engineering framework and commandline tools (not the default)
+ - [rmw](https://remove-to-waste.info), safe-remove utility for the command line
  - [Rizin](https://rizin.re), Free and Open Source Reverse Engineering Framework
  - [QEMU](https://qemu.org), a processor emulator and virtualizer
  - [RxDock](https://gitlab.com/rxdock/rxdock), a protein-ligand docking software designed for high throughput virtual screening (fork of rDock)

--- a/docs/markdown/snippets/custom-target-feed.md
+++ b/docs/markdown/snippets/custom-target-feed.md
@@ -1,0 +1,4 @@
+## The custom_target() function now accepts a feed argument
+
+It is now possible to provide a `feed: true` argument to `custom_target()` to
+pipe the target's input file to the program's standard input.

--- a/docs/markdown/snippets/subprojects_command_parallel.md
+++ b/docs/markdown/snippets/subprojects_command_parallel.md
@@ -1,0 +1,7 @@
+## Parallelized `meson subprojects` commands
+
+All `meson subprojects` commands are now run on each subproject in parallel by
+default. The number of processes can be controlled with `--num-processes`
+argument.
+
+This speeds up considerably IO-bound operations such as downloads and git fetch.

--- a/mesonbuild/_pathlib.py
+++ b/mesonbuild/_pathlib.py
@@ -1,0 +1,73 @@
+# Copyright 2021 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+    This module soly exists to work around a pathlib.resolve bug on
+    certain Windows systems:
+
+    https://github.com/mesonbuild/meson/issues/7295
+    https://bugs.python.org/issue31842
+
+    It should **never** be used directly. Instead, it is automatically
+    used when `import pathlib` is used. This is achieved by messing with
+    `sys.modules['pathlib']` in mesonmain.
+
+    Additionally, the sole purpose of this module is to work around a
+    python bug. This only bugfixes to pathlib functions and classes are
+    allowed here. Finally, this file should be removed once all upstream
+    python bugs are fixed and it is OK to tell our users to "just upgrade
+    python".
+'''
+
+import pathlib
+import os
+import platform
+
+__all__ = [
+    'PurePath',
+    'PurePosixPath',
+    'PureWindowsPath',
+    'Path',
+]
+
+PurePath = pathlib.PurePath
+PurePosixPath = pathlib.PurePosixPath
+PureWindowsPath = pathlib.PureWindowsPath
+
+# Only patch on platforms where the bug occurs
+if platform.system().lower() in {'windows'}:
+    # Can not directly inherit from pathlib.Path because the __new__
+    # operator of pathlib.Path() returns a {Posix,Windows}Path object.
+    class Path(type(pathlib.Path())):
+        def resolve(self, strict: bool = False) -> 'Path':
+            '''
+                Work around a resolve bug on certain Windows systems:
+
+                https://github.com/mesonbuild/meson/issues/7295
+                https://bugs.python.org/issue31842
+            '''
+
+            try:
+                return super().resolve(strict=strict)
+            except OSError:
+                return Path(os.path.normpath(self))
+else:
+    Path = pathlib.Path
+    PosixPath = pathlib.PosixPath
+    WindowsPath = pathlib.WindowsPath
+
+    __all__ += [
+        'PosixPath',
+        'WindowsPath',
+    ]

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -179,7 +179,7 @@ class AstInterpreter(InterpreterBase):
         if not os.path.isfile(absname):
             sys.stderr.write(f'Unable to find build file {buildfilename} --> Skipping\n')
             return
-        with open(absname, encoding='utf8') as f:
+        with open(absname, encoding='utf-8') as f:
             code = f.read()
         assert(isinstance(code, str))
         try:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -374,7 +374,7 @@ class Backend:
             if not os.path.exists(outfileabs_tmp_dir):
                 os.makedirs(outfileabs_tmp_dir)
             result.append(unity_src)
-            return open(outfileabs_tmp, 'w')
+            return open(outfileabs_tmp, 'w', encoding='utf-8')
 
         # For each language, generate unity source files and return the list
         for comp, srcs in compsrcs.items():
@@ -765,7 +765,7 @@ class Backend:
 
         content = f'#include "{os.path.basename(pch_header)}"'
         pch_file_tmp = pch_file + '.tmp'
-        with open(pch_file_tmp, 'w') as f:
+        with open(pch_file_tmp, 'w', encoding='utf-8') as f:
             f.write(content)
         mesonlib.replace_if_different(pch_file, pch_file_tmp)
         return pch_rel_to_build
@@ -1019,7 +1019,7 @@ class Backend:
         ifilename = os.path.join(self.environment.get_build_dir(), 'depmf.json')
         ofilename = os.path.join(self.environment.get_prefix(), self.build.dep_manifest_name)
         mfobj = {'type': 'dependency manifest', 'version': '1.0', 'projects': self.build.dep_manifest}
-        with open(ifilename, 'w') as f:
+        with open(ifilename, 'w', encoding='utf-8') as f:
             f.write(json.dumps(mfobj))
         # Copy file from, to, and with mode unchanged
         d.data.append(InstallDataBase(ifilename, ofilename, None, ''))

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -20,6 +20,7 @@ import subprocess
 from collections import OrderedDict
 from enum import Enum, unique
 import itertools
+from textwrap import dedent
 from pathlib import PurePath, Path
 from functools import lru_cache
 
@@ -462,10 +463,11 @@ class NinjaBackend(backends.Backend):
             return open(tempfilename, 'a', encoding='utf-8')
         filename = os.path.join(self.environment.get_scratch_dir(),
                                 'incdetect.c')
-        with open(filename, 'w') as f:
-            f.write('''#include<stdio.h>
-int dummy;
-''')
+        with open(filename, 'w', encoding='utf-8') as f:
+            f.write(dedent('''\
+                #include<stdio.h>
+                int dummy;
+            '''))
 
         # The output of cl dependency information is language
         # and locale dependent. Any attempt at converting it to
@@ -1215,7 +1217,7 @@ int dummy;
         manifest_path = os.path.join(self.get_target_private_dir(target), 'META-INF', 'MANIFEST.MF')
         manifest_fullpath = os.path.join(self.environment.get_build_dir(), manifest_path)
         os.makedirs(os.path.dirname(manifest_fullpath), exist_ok=True)
-        with open(manifest_fullpath, 'w') as manifest:
+        with open(manifest_fullpath, 'w', encoding='utf-8') as manifest:
             if any(target.link_targets):
                 manifest.write('Class-Path: ')
                 cp_paths = [os.path.join(self.get_target_dir(l), l.get_filename()) for l in target.link_targets]

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -975,6 +975,7 @@ class NinjaBackend(backends.Backend):
         cmd, reason = self.as_meson_exe_cmdline(target.name, target.command[0], cmd[1:],
                                                 extra_bdeps=target.get_transitive_build_target_deps(),
                                                 capture=ofilenames[0] if target.capture else None,
+                                                feed=srcs[0] if target.feed else None,
                                                 env=target.env)
         if reason:
             cmd_type = f' (wrapped by meson {reason})'

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -563,6 +563,7 @@ class Vs2010Backend(backends.Backend):
                                                    workdir=tdir_abs,
                                                    extra_bdeps=extra_bdeps,
                                                    capture=ofilenames[0] if target.capture else None,
+                                                   feed=srcs[0] if target.feed else None,
                                                    force_serialize=True,
                                                    env=target.env)
         if target.build_always_stale:

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -206,7 +206,7 @@ class Vs2010Backend(backends.Backend):
 
     @staticmethod
     def touch_regen_timestamp(build_dir: str) -> None:
-        with open(Vs2010Backend.get_regen_stampfile(build_dir), 'w'):
+        with open(Vs2010Backend.get_regen_stampfile(build_dir), 'w', encoding='utf-8'):
             pass
 
     def get_vcvars_command(self):

--- a/mesonbuild/cmake/fileapi.py
+++ b/mesonbuild/cmake/fileapi.py
@@ -51,7 +51,7 @@ class CMakeFileAPI:
         }
 
         query_file = self.request_dir / 'query.json'
-        query_file.write_text(json.dumps(query, indent=2))
+        query_file.write_text(json.dumps(query, indent=2), encoding='utf-8')
 
     def load_reply(self) -> None:
         if not self.reply_dir.is_dir():
@@ -75,7 +75,7 @@ class CMakeFileAPI:
         # Debug output
         debug_json = self.build_dir / '..' / 'fileAPI.json'
         debug_json = debug_json.resolve()
-        debug_json.write_text(json.dumps(index, indent=2))
+        debug_json.write_text(json.dumps(index, indent=2), encoding='utf-8')
         mlog.cmd_ci_include(debug_json.as_posix())
 
         # parse the JSON
@@ -313,7 +313,7 @@ class CMakeFileAPI:
         if not real_path.exists():
             raise CMakeException(f'File "{real_path}" does not exist')
 
-        data = json.loads(real_path.read_text())
+        data = json.loads(real_path.read_text(encoding='utf-8'))
         assert isinstance(data, dict)
         for i in data.keys():
             assert isinstance(i, str)

--- a/mesonbuild/cmake/toolchain.py
+++ b/mesonbuild/cmake/toolchain.py
@@ -66,8 +66,8 @@ class CMakeToolchain:
     def write(self) -> Path:
         if not self.toolchain_file.parent.exists():
             self.toolchain_file.parent.mkdir(parents=True)
-        self.toolchain_file.write_text(self.generate())
-        self.cmcache_file.write_text(self.generate_cache())
+        self.toolchain_file.write_text(self.generate(), encoding='utf-8')
+        self.cmcache_file.write_text(self.generate_cache(), encoding='utf-8')
         mlog.cmd_ci_include(self.toolchain_file.as_posix())
         return self.toolchain_file
 
@@ -215,11 +215,11 @@ class CMakeToolchain:
         build_dir = Path(self.env.scratch_dir) / '__CMake_compiler_info__'
         build_dir.mkdir(parents=True, exist_ok=True)
         cmake_file = build_dir / 'CMakeLists.txt'
-        cmake_file.write_text(cmake_content)
+        cmake_file.write_text(cmake_content, encoding='utf-8')
 
         # Generate the temporary toolchain file
         temp_toolchain_file = build_dir / 'CMakeMesonTempToolchainFile.cmake'
-        temp_toolchain_file.write_text(CMakeToolchain._print_vars(self.variables))
+        temp_toolchain_file.write_text(CMakeToolchain._print_vars(self.variables), encoding='utf-8')
 
         # Configure
         trace = CMakeTraceParser(self.cmakebin.version(), build_dir)

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -158,7 +158,7 @@ class CMakeTraceParser:
         if not self.requires_stderr():
             if not self.trace_file_path.exists and not self.trace_file_path.is_file():
                 raise CMakeException('CMake: Trace file "{}" not found'.format(str(self.trace_file_path)))
-            trace = self.trace_file_path.read_text(errors='ignore')
+            trace = self.trace_file_path.read_text(errors='ignore', encoding='utf-8')
         if not trace:
             raise CMakeException('CMake: The CMake trace was not provided or is empty')
 

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -765,14 +765,14 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
             if isinstance(code, str):
                 srcname = os.path.join(tmpdirname,
                                     'testfile.' + self.default_suffix)
-                with open(srcname, 'w') as ofile:
+                with open(srcname, 'w', encoding='utf-8') as ofile:
                     ofile.write(code)
                 # ccache would result in a cache miss
                 no_ccache = True
                 contents = code
             elif isinstance(code, mesonlib.File):
                 srcname = code.fname
-                with open(code.fname) as f:
+                with open(code.fname, encoding='utf-8') as f:
                     contents = f.read()
 
             # Construct the compiler command-line

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -87,7 +87,7 @@ class CsCompiler(BasicLinkerIsCompilerMixin, Compiler):
         src = 'sanity.cs'
         obj = 'sanity.exe'
         source_name = os.path.join(work_dir, src)
-        with open(source_name, 'w') as ofile:
+        with open(source_name, 'w', encoding='utf-8') as ofile:
             ofile.write(textwrap.dedent('''
                 public class Sanity {
                     static public void Main () {

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -504,7 +504,7 @@ class CudaCompiler(Compiler):
         binname += '_cross' if self.is_cross else ''
         source_name = os.path.join(work_dir, sname)
         binary_name = os.path.join(work_dir, binname + '.exe')
-        with open(source_name, 'w') as ofile:
+        with open(source_name, 'w', encoding='utf-8') as ofile:
             ofile.write(code)
 
         # The Sanity Test for CUDA language will serve as both a sanity test

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -535,7 +535,7 @@ class DCompiler(Compiler):
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
         source_name = os.path.join(work_dir, 'sanity.d')
         output_name = os.path.join(work_dir, 'dtest')
-        with open(source_name, 'w') as ofile:
+        with open(source_name, 'w', encoding='utf-8') as ofile:
             ofile.write('''void main() { }''')
         pc = subprocess.Popen(self.exelist + self.get_output_args(output_name) + self._get_target_arch_args() + [source_name], cwd=work_dir)
         pc.wait()

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -71,7 +71,7 @@ class FortranCompiler(CLikeCompiler, Compiler):
         if binary_name.is_file():
             binary_name.unlink()
 
-        source_name.write_text('print *, "Fortran compilation is working."; end')
+        source_name.write_text('print *, "Fortran compilation is working."; end', encoding='utf-8')
 
         extra_flags: T.List[str] = []
         extra_flags += environment.coredata.get_external_args(self.for_machine, self.language)

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -70,7 +70,7 @@ class JavaCompiler(BasicLinkerIsCompilerMixin, Compiler):
         src = 'SanityCheck.java'
         obj = 'SanityCheck'
         source_name = os.path.join(work_dir, src)
-        with open(source_name, 'w') as ofile:
+        with open(source_name, 'w', encoding='utf-8') as ofile:
             ofile.write(textwrap.dedent(
                 '''class SanityCheck {
                   public static void main(String[] args) {

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -306,7 +306,7 @@ class CLikeCompiler(Compiler):
         binname += '.exe'
         # Write binary check source
         binary_name = os.path.join(work_dir, binname)
-        with open(source_name, 'w') as ofile:
+        with open(source_name, 'w', encoding='utf-8') as ofile:
             ofile.write(code)
         # Compile sanity check
         # NOTE: extra_flags must be added at the end. On MSVC, it might contain a '/link' argument

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -65,7 +65,7 @@ class RustCompiler(Compiler):
     def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
         source_name = os.path.join(work_dir, 'sanity.rs')
         output_name = os.path.join(work_dir, 'rusttest')
-        with open(source_name, 'w') as ofile:
+        with open(source_name, 'w', encoding='utf-8') as ofile:
             ofile.write(textwrap.dedent(
                 '''fn main() {
                 }

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -107,7 +107,7 @@ class SwiftCompiler(Compiler):
             extra_flags += self.get_compile_only_args()
         else:
             extra_flags += environment.coredata.get_external_link_args(self.for_machine, self.language)
-        with open(source_name, 'w') as ofile:
+        with open(source_name, 'w', encoding='utf-8') as ofile:
             ofile.write('''print("Swift compilation is working.")
 ''')
         pc = subprocess.Popen(self.exelist + extra_flags + ['-emit-executable', '-o', output_name, src], cwd=work_dir)

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -481,8 +481,8 @@ class CoreData:
                     # the contents of that file into the meson private (scratch)
                     # directory so that it can be re-read when wiping/reconfiguring
                     copy = os.path.join(scratch_dir, f'{uuid.uuid4()}.{ftype}.ini')
-                    with open(f) as rf:
-                        with open(copy, 'w') as wf:
+                    with open(f, encoding='utf-8') as rf:
+                        with open(copy, 'w', encoding='utf-8') as wf:
                             wf.write(rf.read())
                     real.append(copy)
 
@@ -973,7 +973,7 @@ def write_cmd_line_file(build_dir: str, options: argparse.Namespace) -> None:
 
     config['options'] = {str(k): str(v) for k, v in options.cmd_line_options.items()}
     config['properties'] = properties
-    with open(filename, 'w') as f:
+    with open(filename, 'w', encoding='utf-8') as f:
         config.write(f)
 
 def update_cmd_line_file(build_dir: str, options: argparse.Namespace):
@@ -981,7 +981,7 @@ def update_cmd_line_file(build_dir: str, options: argparse.Namespace):
     config = CmdLineFileParser()
     config.read(filename)
     config['options'].update({str(k): str(v) for k, v in options.cmd_line_options.items()})
-    with open(filename, 'w') as f:
+    with open(filename, 'w', encoding='utf-8') as f:
         config.write(f)
 
 def get_cmd_line_options(build_dir: str, options: argparse.Namespace) -> str:

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -717,7 +717,7 @@ class BoostDependency(SystemDependency):
         # also work, however, this is slower (since it the compiler has to be
         # invoked) and overkill since the layout of the header is always the same.
         assert hfile.exists()
-        raw = hfile.read_text()
+        raw = hfile.read_text(encoding='utf-8')
         m = re.search(r'#define\s+BOOST_VERSION\s+([0-9]+)', raw)
         if not m:
             mlog.debug(f'Failed to extract version information from {hfile}')

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -620,7 +620,7 @@ class CMakeDependency(ExternalDependency):
         """).format(' '.join(cmake_language)) + cmake_txt
 
         cm_file = build_dir / 'CMakeLists.txt'
-        cm_file.write_text(cmake_txt)
+        cm_file.write_text(cmake_txt, encoding='utf-8')
         mlog.cmd_ci_include(cm_file.absolute().as_posix())
 
         return build_dir

--- a/mesonbuild/dependencies/cuda.py
+++ b/mesonbuild/dependencies/cuda.py
@@ -184,7 +184,7 @@ class CudaDependency(SystemDependency):
     def _read_cuda_runtime_api_version(self, path_str: str) -> T.Optional[str]:
         path = Path(path_str)
         for i in path.rglob('cuda_runtime_api.h'):
-            raw = i.read_text()
+            raw = i.read_text(encoding='utf-8')
             m = self.cudart_version_regex.search(raw)
             if not m:
                 continue
@@ -202,7 +202,7 @@ class CudaDependency(SystemDependency):
         # Read 'version.txt' at the root of the CUDA Toolkit directory to determine the tookit version
         version_file_path = os.path.join(path, 'version.txt')
         try:
-            with open(version_file_path) as version_file:
+            with open(version_file_path, encoding='utf-8') as version_file:
                 version_str = version_file.readline() # e.g. 'CUDA Version 10.1.168'
                 m = self.toolkit_version_regex.match(version_str)
                 if m:

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -423,7 +423,7 @@ class PkgConfigDependency(ExternalDependency):
         return out.strip()
 
     def extract_field(self, la_file: str, fieldname: str) -> T.Optional[str]:
-        with open(la_file) as f:
+        with open(la_file, encoding='utf-8') as f:
             for line in f:
                 arr = line.strip().split('=')
                 if arr[0] == fieldname:

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -778,6 +778,707 @@ class Environment:
     def lookup_binary_entry(self, for_machine: MachineChoice, name: str) -> T.Optional[T.List[str]]:
         return self.binaries[for_machine].lookup_entry(name)
 
+    @staticmethod
+    def get_gnu_compiler_defines(compiler):
+        """
+        Detect GNU compiler platform type (Apple, MinGW, Unix)
+        """
+        # Arguments to output compiler pre-processor defines to stdout
+        # gcc, g++, and gfortran all support these arguments
+        args = compiler + ['-E', '-dM', '-']
+        p, output, error = Popen_safe(args, write='', stdin=subprocess.PIPE)
+        if p.returncode != 0:
+            raise EnvironmentException('Unable to detect GNU compiler type:\n' + output + error)
+        # Parse several lines of the type:
+        # `#define ___SOME_DEF some_value`
+        # and extract `___SOME_DEF`
+        defines = {}
+        for line in output.split('\n'):
+            if not line:
+                continue
+            d, *rest = line.split(' ', 2)
+            if d != '#define':
+                continue
+            if len(rest) == 1:
+                defines[rest] = True
+            if len(rest) == 2:
+                defines[rest[0]] = rest[1]
+        return defines
+
+    @staticmethod
+    def get_gnu_version_from_defines(defines):
+        dot = '.'
+        major = defines.get('__GNUC__', '0')
+        minor = defines.get('__GNUC_MINOR__', '0')
+        patch = defines.get('__GNUC_PATCHLEVEL__', '0')
+        return dot.join((major, minor, patch))
+
+    @staticmethod
+    def get_lcc_version_from_defines(defines):
+        dot = '.'
+        generation_and_major = defines.get('__LCC__', '100')
+        generation = generation_and_major[:1]
+        major = generation_and_major[1:]
+        minor = defines.get('__LCC_MINOR__', '0')
+        return dot.join((generation, major, minor))
+
+    @staticmethod
+    def get_clang_compiler_defines(compiler):
+        """
+        Get the list of Clang pre-processor defines
+        """
+        args = compiler + ['-E', '-dM', '-']
+        p, output, error = Popen_safe(args, write='', stdin=subprocess.PIPE)
+        if p.returncode != 0:
+            raise EnvironmentException('Unable to get clang pre-processor defines:\n' + output + error)
+        defines = {}
+        for line in output.split('\n'):
+            if not line:
+                continue
+            d, *rest = line.split(' ', 2)
+            if d != '#define':
+                continue
+            if len(rest) == 1:
+                defines[rest] = True
+            if len(rest) == 2:
+                defines[rest[0]] = rest[1]
+        return defines
+
+    def _get_compilers(self, lang: str, for_machine: MachineChoice) -> T.Tuple[T.List[T.List[str]], T.List[str], T.Optional['ExternalProgram']]:
+        '''
+        The list of compilers is detected in the exact same way for
+        C, C++, ObjC, ObjC++, Fortran, CS so consolidate it here.
+        '''
+        value = self.lookup_binary_entry(for_machine, lang)
+        if value is not None:
+            compilers, ccache = BinaryTable.parse_entry(value)
+            # Return value has to be a list of compiler 'choices'
+            compilers = [compilers]
+        else:
+            if not self.machines.matches_build_machine(for_machine):
+                raise EnvironmentException(f'{lang!r} compiler binary not defined in cross or native file')
+            compilers = getattr(self, 'default_' + lang)
+            ccache = BinaryTable.detect_ccache()
+
+        if self.machines.matches_build_machine(for_machine):
+            exe_wrap = None
+        else:
+            exe_wrap = self.get_exe_wrapper()
+
+        return compilers, ccache, exe_wrap
+
+    def _handle_exceptions(self, exceptions, binaries, bintype='compiler'):
+        errmsg = f'Unknown {bintype}(s): {binaries}'
+        if exceptions:
+            errmsg += '\nThe following exception(s) were encountered:'
+            for (c, e) in exceptions.items():
+                errmsg += f'\nRunning "{c}" gave "{e}"'
+        raise EnvironmentException(errmsg)
+
+    @staticmethod
+    def __failed_to_detect_linker(compiler: T.List[str], args: T.List[str], stdout: str, stderr: str) -> 'T.NoReturn':
+        msg = 'Unable to detect linker for compiler "{} {}"\nstdout: {}\nstderr: {}'.format(
+            ' '.join(compiler), ' '.join(args), stdout, stderr)
+        raise EnvironmentException(msg)
+
+    def _guess_win_linker(self, compiler: T.List[str], comp_class: Compiler,
+                          for_machine: MachineChoice, *,
+                          use_linker_prefix: bool = True, invoked_directly: bool = True,
+                          extra_args: T.Optional[T.List[str]] = None) -> 'DynamicLinker':
+        self.coredata.add_lang_args(comp_class.language, comp_class, for_machine, self)
+
+        # Explicitly pass logo here so that we can get the version of link.exe
+        if not use_linker_prefix or comp_class.LINKER_PREFIX is None:
+            check_args = ['/logo', '--version']
+        elif isinstance(comp_class.LINKER_PREFIX, str):
+            check_args = [comp_class.LINKER_PREFIX + '/logo', comp_class.LINKER_PREFIX + '--version']
+        elif isinstance(comp_class.LINKER_PREFIX, list):
+            check_args = comp_class.LINKER_PREFIX + ['/logo'] + comp_class.LINKER_PREFIX + ['--version']
+
+        check_args += self.coredata.options[OptionKey('args', lang=comp_class.language, machine=for_machine)].value
+
+        override = []  # type: T.List[str]
+        value = self.lookup_binary_entry(for_machine, comp_class.language + '_ld')
+        if value is not None:
+            override = comp_class.use_linker_args(value[0])
+            check_args += override
+
+        if extra_args is not None:
+            check_args.extend(extra_args)
+
+        p, o, _ = Popen_safe(compiler + check_args)
+        if o.startswith('LLD'):
+            if '(compatible with GNU linkers)' in o:
+                return LLVMDynamicLinker(
+                    compiler, for_machine, comp_class.LINKER_PREFIX,
+                    override, version=search_version(o))
+            elif not invoked_directly:
+                return ClangClDynamicLinker(
+                    for_machine, override, exelist=compiler, prefix=comp_class.LINKER_PREFIX,
+                    version=search_version(o), direct=False, machine=None)
+
+        if value is not None and invoked_directly:
+            compiler = value
+            # We've already hanedled the non-direct case above
+
+        p, o, e = Popen_safe(compiler + check_args)
+        if o.startswith('LLD'):
+            return ClangClDynamicLinker(
+                for_machine, [],
+                prefix=comp_class.LINKER_PREFIX if use_linker_prefix else [],
+                exelist=compiler, version=search_version(o), direct=invoked_directly)
+        elif 'OPTLINK' in o:
+            # Opltink's stdout *may* beging with a \r character.
+            return OptlinkDynamicLinker(compiler, for_machine, version=search_version(o))
+        elif o.startswith('Microsoft') or e.startswith('Microsoft'):
+            out = o or e
+            match = re.search(r'.*(X86|X64|ARM|ARM64).*', out)
+            if match:
+                target = str(match.group(1))
+            else:
+                target = 'x86'
+
+            return MSVCDynamicLinker(
+                for_machine, [], machine=target, exelist=compiler,
+                prefix=comp_class.LINKER_PREFIX if use_linker_prefix else [],
+                version=search_version(out), direct=invoked_directly)
+        elif 'GNU coreutils' in o:
+            raise EnvironmentException(
+                "Found GNU link.exe instead of MSVC link.exe. This link.exe "
+                "is not a linker. You may need to reorder entries to your "
+                "%PATH% variable to resolve this.")
+        self.__failed_to_detect_linker(compiler, check_args, o, e)
+
+    def _guess_nix_linker(self, compiler: T.List[str], comp_class: T.Type[Compiler],
+                          for_machine: MachineChoice, *,
+                          extra_args: T.Optional[T.List[str]] = None) -> 'DynamicLinker':
+        """Helper for guessing what linker to use on Unix-Like OSes.
+
+        :compiler: Invocation to use to get linker
+        :comp_class: The Compiler Type (uninstantiated)
+        :for_machine: which machine this linker targets
+        :extra_args: Any additional arguments required (such as a source file)
+        """
+        self.coredata.add_lang_args(comp_class.language, comp_class, for_machine, self)
+        extra_args = extra_args or []
+        extra_args += self.coredata.options[OptionKey('args', lang=comp_class.language, machine=for_machine)].value
+
+        if isinstance(comp_class.LINKER_PREFIX, str):
+            check_args = [comp_class.LINKER_PREFIX + '--version'] + extra_args
+        else:
+            check_args = comp_class.LINKER_PREFIX + ['--version'] + extra_args
+
+        override = []  # type: T.List[str]
+        value = self.lookup_binary_entry(for_machine, comp_class.language + '_ld')
+        if value is not None:
+            override = comp_class.use_linker_args(value[0])
+            check_args += override
+
+        _, o, e = Popen_safe(compiler + check_args)
+        v = search_version(o + e)
+        if o.startswith('LLD'):
+            linker = LLVMDynamicLinker(
+                compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)  # type: DynamicLinker
+        elif 'Snapdragon' in e and 'LLVM' in e:
+            linker = QualcommLLVMDynamicLinker(
+                compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)  # type: DynamicLinker
+        elif e.startswith('lld-link: '):
+            # The LLD MinGW frontend didn't respond to --version before version 9.0.0,
+            # and produced an error message about failing to link (when no object
+            # files were specified), instead of printing the version number.
+            # Let's try to extract the linker invocation command to grab the version.
+
+            _, o, e = Popen_safe(compiler + check_args + ['-v'])
+
+            try:
+                linker_cmd = re.match(r'.*\n(.*?)\nlld-link: ', e, re.DOTALL).group(1)
+                linker_cmd = shlex.split(linker_cmd)[0]
+            except (AttributeError, IndexError, ValueError):
+                pass
+            else:
+                _, o, e = Popen_safe([linker_cmd, '--version'])
+                v = search_version(o)
+
+            linker = LLVMDynamicLinker(compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)
+        # first is for apple clang, second is for real gcc, the third is icc
+        elif e.endswith('(use -v to see invocation)\n') or 'macosx_version' in e or 'ld: unknown option:' in e:
+            if isinstance(comp_class.LINKER_PREFIX, str):
+                _, _, e = Popen_safe(compiler + [comp_class.LINKER_PREFIX + '-v'] + extra_args)
+            else:
+                _, _, e = Popen_safe(compiler + comp_class.LINKER_PREFIX + ['-v'] + extra_args)
+            for line in e.split('\n'):
+                if 'PROJECT:ld' in line:
+                    v = line.split('-')[1]
+                    break
+            else:
+                v = 'unknown version'
+            linker = AppleDynamicLinker(compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)
+        elif 'GNU' in o or 'GNU' in e:
+            if 'gold' in o or 'gold' in e:
+                cls = GnuGoldDynamicLinker
+            else:
+                cls = GnuBFDDynamicLinker
+            linker = cls(compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)
+        elif 'Solaris' in e or 'Solaris' in o:
+            for line in (o+e).split('\n'):
+                if 'ld: Software Generation Utilities' in line:
+                    v = line.split(':')[2].lstrip()
+                    break
+            else:
+                v = 'unknown version'
+            linker = SolarisDynamicLinker(
+                compiler, for_machine, comp_class.LINKER_PREFIX, override,
+                version=v)
+        elif 'ld: 0706-012 The -- flag is not recognized' in e:
+            if isinstance(comp_class.LINKER_PREFIX, str):
+                _, _, e = Popen_safe(compiler + [comp_class.LINKER_PREFIX + '-V'] + extra_args)
+            else:
+                _, _, e = Popen_safe(compiler + comp_class.LINKER_PREFIX + ['-V'] + extra_args)
+            linker = AIXDynamicLinker(
+                compiler, for_machine, comp_class.LINKER_PREFIX, override,
+                version=search_version(e))
+        else:
+            self.__failed_to_detect_linker(compiler, check_args, o, e)
+        return linker
+
+    def _detect_c_or_cpp_compiler(self, lang: str, for_machine: MachineChoice, *, override_compiler: T.Optional[T.List[str]] = None) -> Compiler:
+        """Shared implementation for finding the C or C++ compiler to use.
+
+        the override_compiler option is provided to allow compilers which use
+        the compiler (GCC or Clang usually) as their shared linker, to find
+        the linker they need.
+        """
+        popen_exceptions = {}
+        compilers, ccache, exe_wrap = self._get_compilers(lang, for_machine)
+        if override_compiler is not None:
+            compilers = [override_compiler]
+        is_cross = self.is_cross_build(for_machine)
+        info = self.machines[for_machine]
+
+        for compiler in compilers:
+            if isinstance(compiler, str):
+                compiler = [compiler]
+            compiler_name = os.path.basename(compiler[0])
+
+            if not {'cl', 'cl.exe', 'clang-cl', 'clang-cl.exe'}.isdisjoint(compiler):
+                # Watcom C provides it's own cl.exe clone that mimics an older
+                # version of Microsoft's compiler. Since Watcom's cl.exe is
+                # just a wrapper, we skip using it if we detect its presence
+                # so as not to confuse Meson when configuring for MSVC.
+                #
+                # Additionally the help text of Watcom's cl.exe is paged, and
+                # the binary will not exit without human intervention. In
+                # practice, Meson will block waiting for Watcom's cl.exe to
+                # exit, which requires user input and thus will never exit.
+                if 'WATCOM' in os.environ:
+                    def sanitize(p):
+                        return os.path.normcase(os.path.abspath(p))
+
+                    watcom_cls = [sanitize(os.path.join(os.environ['WATCOM'], 'BINNT', 'cl')),
+                                  sanitize(os.path.join(os.environ['WATCOM'], 'BINNT', 'cl.exe'))]
+                    found_cl = sanitize(shutil.which('cl'))
+                    if found_cl in watcom_cls:
+                        continue
+                arg = '/?'
+            elif 'armcc' in compiler_name:
+                arg = '--vsn'
+            elif 'ccrx' in compiler_name:
+                arg = '-v'
+            elif 'xc16' in compiler_name:
+                arg = '--version'
+            elif 'ccomp' in compiler_name:
+                arg = '-version'
+            elif 'cl2000' in compiler_name:
+                arg = '-version'
+            elif compiler_name in {'icl', 'icl.exe'}:
+                # if you pass anything to icl you get stuck in a pager
+                arg = ''
+            else:
+                arg = '--version'
+
+            try:
+                p, out, err = Popen_safe(compiler + [arg])
+            except OSError as e:
+                popen_exceptions[' '.join(compiler + [arg])] = e
+                continue
+
+            if 'ccrx' in compiler_name:
+                out = err
+
+            full_version = out.split('\n', 1)[0]
+            version = search_version(out)
+
+            guess_gcc_or_lcc = False
+            if 'Free Software Foundation' in out or 'xt-' in out:
+                guess_gcc_or_lcc = 'gcc'
+            if 'e2k' in out and 'lcc' in out:
+                guess_gcc_or_lcc = 'lcc'
+            if 'Microchip Technology' in out:
+                # this output has "Free Software Foundation" in its version
+                guess_gcc_or_lcc = False
+
+            if guess_gcc_or_lcc:
+                defines = self.get_gnu_compiler_defines(compiler)
+                if not defines:
+                    popen_exceptions[' '.join(compiler)] = 'no pre-processor defines'
+                    continue
+
+                if guess_gcc_or_lcc == 'lcc':
+                    version = self.get_lcc_version_from_defines(defines)
+                    cls = ElbrusCCompiler if lang == 'c' else ElbrusCPPCompiler
+                else:
+                    version = self.get_gnu_version_from_defines(defines)
+                    cls = GnuCCompiler if lang == 'c' else GnuCPPCompiler
+
+                linker = self._guess_nix_linker(compiler, cls, for_machine)
+
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross,
+                    info, exe_wrap, defines=defines, full_version=full_version,
+                    linker=linker)
+
+            if 'Emscripten' in out:
+                cls = EmscriptenCCompiler if lang == 'c' else EmscriptenCPPCompiler
+                self.coredata.add_lang_args(cls.language, cls, for_machine, self)
+
+                # emcc requires a file input in order to pass arguments to the
+                # linker. It'll exit with an error code, but still print the
+                # linker version. Old emcc versions ignore -Wl,--version completely,
+                # however. We'll report "unknown version" in that case.
+                with tempfile.NamedTemporaryFile(suffix='.c') as f:
+                    cmd = compiler + [cls.LINKER_PREFIX + "--version", f.name]
+                    _, o, _ = Popen_safe(cmd)
+
+                linker = WASMDynamicLinker(
+                    compiler, for_machine, cls.LINKER_PREFIX,
+                    [], version=search_version(o))
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross, info,
+                    exe_wrap, linker=linker, full_version=full_version)
+
+            if 'armclang' in out:
+                # The compiler version is not present in the first line of output,
+                # instead it is present in second line, startswith 'Component:'.
+                # So, searching for the 'Component' in out although we know it is
+                # present in second line, as we are not sure about the
+                # output format in future versions
+                arm_ver_str = re.search('.*Component.*', out)
+                if arm_ver_str is None:
+                    popen_exceptions[' '.join(compiler)] = 'version string not found'
+                    continue
+                arm_ver_str = arm_ver_str.group(0)
+                # Override previous values
+                version = search_version(arm_ver_str)
+                full_version = arm_ver_str
+                cls = ArmclangCCompiler if lang == 'c' else ArmclangCPPCompiler
+                linker = ArmClangDynamicLinker(for_machine, version=version)
+                self.coredata.add_lang_args(cls.language, cls, for_machine, self)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross, info,
+                    exe_wrap, full_version=full_version, linker=linker)
+            if 'CL.EXE COMPATIBILITY' in out:
+                # if this is clang-cl masquerading as cl, detect it as cl, not
+                # clang
+                arg = '--version'
+                try:
+                    p, out, err = Popen_safe(compiler + [arg])
+                except OSError as e:
+                    popen_exceptions[' '.join(compiler + [arg])] = e
+                version = search_version(out)
+                match = re.search('^Target: (.*?)-', out, re.MULTILINE)
+                if match:
+                    target = match.group(1)
+                else:
+                    target = 'unknown target'
+                cls = ClangClCCompiler if lang == 'c' else ClangClCPPCompiler
+                linker = self._guess_win_linker(['lld-link'], cls, for_machine)
+                return cls(
+                    compiler, version, for_machine, is_cross, info, target,
+                    exe_wrap, linker=linker)
+            if 'clang' in out or 'Clang' in out:
+                linker = None
+
+                defines = self.get_clang_compiler_defines(compiler)
+
+                # Even if the for_machine is darwin, we could be using vanilla
+                # clang.
+                if 'Apple' in out:
+                    cls = AppleClangCCompiler if lang == 'c' else AppleClangCPPCompiler
+                else:
+                    cls = ClangCCompiler if lang == 'c' else ClangCPPCompiler
+
+                if 'windows' in out or self.machines[for_machine].is_windows():
+                    # If we're in a MINGW context this actually will use a gnu
+                    # style ld, but for clang on "real" windows we'll use
+                    # either link.exe or lld-link.exe
+                    try:
+                        linker = self._guess_win_linker(compiler, cls, for_machine, invoked_directly=False)
+                    except MesonException:
+                        pass
+                if linker is None:
+                    linker = self._guess_nix_linker(compiler, cls, for_machine)
+
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross, info,
+                    exe_wrap, defines=defines, full_version=full_version, linker=linker)
+
+            if 'Intel(R) C++ Intel(R)' in err:
+                version = search_version(err)
+                target = 'x86' if 'IA-32' in err else 'x86_64'
+                cls = IntelClCCompiler if lang == 'c' else IntelClCPPCompiler
+                self.coredata.add_lang_args(cls.language, cls, for_machine, self)
+                linker = XilinkDynamicLinker(for_machine, [], version=version)
+                return cls(
+                    compiler, version, for_machine, is_cross, info, target,
+                    exe_wrap, linker=linker)
+            if 'Microsoft' in out or 'Microsoft' in err:
+                # Latest versions of Visual Studio print version
+                # number to stderr but earlier ones print version
+                # on stdout.  Why? Lord only knows.
+                # Check both outputs to figure out version.
+                for lookat in [err, out]:
+                    version = search_version(lookat)
+                    if version != 'unknown version':
+                        break
+                else:
+                    m = 'Failed to detect MSVC compiler version: stderr was\n{!r}'
+                    raise EnvironmentException(m.format(err))
+                cl_signature = lookat.split('\n')[0]
+                match = re.search(r'.*(x86|x64|ARM|ARM64)([^_A-Za-z0-9]|$)', cl_signature)
+                if match:
+                    target = match.group(1)
+                else:
+                    m = 'Failed to detect MSVC compiler target architecture: \'cl /?\' output is\n{}'
+                    raise EnvironmentException(m.format(cl_signature))
+                cls = VisualStudioCCompiler if lang == 'c' else VisualStudioCPPCompiler
+                linker = self._guess_win_linker(['link'], cls, for_machine)
+                return cls(
+                    compiler, version, for_machine, is_cross, info, target,
+                    exe_wrap, full_version=cl_signature, linker=linker)
+            if 'PGI Compilers' in out:
+                cls = PGICCompiler if lang == 'c' else PGICPPCompiler
+                self.coredata.add_lang_args(cls.language, cls, for_machine, self)
+                linker = PGIDynamicLinker(compiler, for_machine, cls.LINKER_PREFIX, [], version=version)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross,
+                    info, exe_wrap, linker=linker)
+            if 'NVIDIA Compilers and Tools' in out:
+                cls = NvidiaHPC_CCompiler if lang == 'c' else NvidiaHPC_CPPCompiler
+                self.coredata.add_lang_args(cls.language, cls, for_machine, self)
+                linker = NvidiaHPC_DynamicLinker(compiler, for_machine, cls.LINKER_PREFIX, [], version=version)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross,
+                    info, exe_wrap, linker=linker)
+            if '(ICC)' in out:
+                cls = IntelCCompiler if lang == 'c' else IntelCPPCompiler
+                l = self._guess_nix_linker(compiler, cls, for_machine)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross, info,
+                    exe_wrap, full_version=full_version, linker=l)
+            if 'ARM' in out:
+                cls = ArmCCompiler if lang == 'c' else ArmCPPCompiler
+                self.coredata.add_lang_args(cls.language, cls, for_machine, self)
+                linker = ArmDynamicLinker(for_machine, version=version)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross,
+                    info, exe_wrap, full_version=full_version, linker=linker)
+            if 'RX Family' in out:
+                cls = CcrxCCompiler if lang == 'c' else CcrxCPPCompiler
+                self.coredata.add_lang_args(cls.language, cls, for_machine, self)
+                linker = CcrxDynamicLinker(for_machine, version=version)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross, info,
+                    exe_wrap, full_version=full_version, linker=linker)
+
+            if 'Microchip Technology' in out:
+                cls = Xc16CCompiler if lang == 'c' else Xc16CCompiler
+                self.coredata.add_lang_args(cls.language, cls, for_machine, self)
+                linker = Xc16DynamicLinker(for_machine, version=version)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross, info,
+                    exe_wrap, full_version=full_version, linker=linker)
+
+            if 'CompCert' in out:
+                cls = CompCertCCompiler
+                self.coredata.add_lang_args(cls.language, cls, for_machine, self)
+                linker = CompCertDynamicLinker(for_machine, version=version)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross, info,
+                    exe_wrap, full_version=full_version, linker=linker)
+
+            if 'TMS320C2000 C/C++' in out:
+                cls = C2000CCompiler if lang == 'c' else C2000CPPCompiler
+                self.coredata.add_lang_args(cls.language, cls, for_machine, self)
+                linker = C2000DynamicLinker(compiler, for_machine, version=version)
+                return cls(
+                    ccache + compiler, version, for_machine, is_cross, info,
+                    exe_wrap, full_version=full_version, linker=linker)
+
+
+        self._handle_exceptions(popen_exceptions, compilers)
+
+    def detect_c_compiler(self, for_machine):
+        return self._detect_c_or_cpp_compiler('c', for_machine)
+
+    def detect_cpp_compiler(self, for_machine):
+        return self._detect_c_or_cpp_compiler('cpp', for_machine)
+
+    def detect_cuda_compiler(self, for_machine):
+        popen_exceptions = {}
+        is_cross = self.is_cross_build(for_machine)
+        compilers, ccache, exe_wrap = self._get_compilers('cuda', for_machine)
+        info = self.machines[for_machine]
+        for compiler in compilers:
+            if isinstance(compiler, str):
+                compiler = [compiler]
+            arg = '--version'
+            try:
+                p, out, err = Popen_safe(compiler + [arg])
+            except OSError as e:
+                popen_exceptions[' '.join(compiler + [arg])] = e
+                continue
+            # Example nvcc printout:
+            #
+            #     nvcc: NVIDIA (R) Cuda compiler driver
+            #     Copyright (c) 2005-2018 NVIDIA Corporation
+            #     Built on Sat_Aug_25_21:08:01_CDT_2018
+            #     Cuda compilation tools, release 10.0, V10.0.130
+            #
+            # search_version() first finds the "10.0" after "release",
+            # rather than the more precise "10.0.130" after "V".
+            # The patch version number is occasionally important; For
+            # instance, on Linux,
+            #    - CUDA Toolkit 8.0.44 requires NVIDIA Driver 367.48
+            #    - CUDA Toolkit 8.0.61 requires NVIDIA Driver 375.26
+            # Luckily, the "V" also makes it very simple to extract
+            # the full version:
+            version = out.strip().split('V')[-1]
+            cpp_compiler = self.detect_cpp_compiler(for_machine)
+            cls = CudaCompiler
+            self.coredata.add_lang_args(cls.language, cls, for_machine, self)
+            linker = CudaLinker(compiler, for_machine, CudaCompiler.LINKER_PREFIX, [], version=CudaLinker.parse_version())
+            return cls(ccache + compiler, version, for_machine, is_cross, exe_wrap, host_compiler=cpp_compiler, info=info, linker=linker)
+        raise EnvironmentException('Could not find suitable CUDA compiler: "' + ' '.join(compilers) + '"')
+
+    def detect_fortran_compiler(self, for_machine: MachineChoice):
+        popen_exceptions = {}
+        compilers, ccache, exe_wrap = self._get_compilers('fortran', for_machine)
+        is_cross = self.is_cross_build(for_machine)
+        info = self.machines[for_machine]
+        for compiler in compilers:
+            if isinstance(compiler, str):
+                compiler = [compiler]
+            for arg in ['--version', '-V']:
+                try:
+                    p, out, err = Popen_safe(compiler + [arg])
+                except OSError as e:
+                    popen_exceptions[' '.join(compiler + [arg])] = e
+                    continue
+
+                version = search_version(out)
+                full_version = out.split('\n', 1)[0]
+
+                guess_gcc_or_lcc = False
+                if 'GNU Fortran' in out:
+                    guess_gcc_or_lcc = 'gcc'
+                if 'e2k' in out and 'lcc' in out:
+                    guess_gcc_or_lcc = 'lcc'
+
+                if guess_gcc_or_lcc:
+                    defines = self.get_gnu_compiler_defines(compiler)
+                    if not defines:
+                        popen_exceptions[' '.join(compiler)] = 'no pre-processor defines'
+                        continue
+                    if guess_gcc_or_lcc == 'lcc':
+                        version = self.get_lcc_version_from_defines(defines)
+                        cls = ElbrusFortranCompiler
+                    else:
+                        version = self.get_gnu_version_from_defines(defines)
+                        cls = GnuFortranCompiler
+                    linker = self._guess_nix_linker(
+                        compiler, cls, for_machine)
+                    return cls(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, defines, full_version=full_version,
+                        linker=linker)
+
+                if 'G95' in out:
+                    linker = self._guess_nix_linker(
+                        compiler, cls, for_machine)
+                    return G95FortranCompiler(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, full_version=full_version, linker=linker)
+
+                if 'Sun Fortran' in err:
+                    version = search_version(err)
+                    linker = self._guess_nix_linker(
+                        compiler, cls, for_machine)
+                    return SunFortranCompiler(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, full_version=full_version, linker=linker)
+
+                if 'Intel(R) Visual Fortran' in err:
+                    version = search_version(err)
+                    target = 'x86' if 'IA-32' in err else 'x86_64'
+                    cls = IntelClFortranCompiler
+                    self.coredata.add_lang_args(cls.language, cls, for_machine, self)
+                    linker = XilinkDynamicLinker(for_machine, [], version=version)
+                    return cls(
+                        compiler, version, for_machine, is_cross, info,
+                        target, exe_wrap, linker=linker)
+
+                if 'ifort (IFORT)' in out:
+                    linker = self._guess_nix_linker(compiler, IntelFortranCompiler, for_machine)
+                    return IntelFortranCompiler(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, full_version=full_version, linker=linker)
+
+                if 'PathScale EKOPath(tm)' in err:
+                    return PathScaleFortranCompiler(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, full_version=full_version)
+
+                if 'PGI Compilers' in out:
+                    cls = PGIFortranCompiler
+                    self.coredata.add_lang_args(cls.language, cls, for_machine, self)
+                    linker = PGIDynamicLinker(compiler, for_machine,
+                                              cls.LINKER_PREFIX, [], version=version)
+                    return cls(
+                        compiler, version, for_machine, is_cross, info, exe_wrap,
+                        full_version=full_version, linker=linker)
+
+                if 'NVIDIA Compilers and Tools' in out:
+                    cls = NvidiaHPC_FortranCompiler
+                    self.coredata.add_lang_args(cls.language, cls, for_machine, self)
+                    linker = PGIDynamicLinker(compiler, for_machine,
+                                              cls.LINKER_PREFIX, [], version=version)
+                    return cls(
+                        compiler, version, for_machine, is_cross, info, exe_wrap,
+                        full_version=full_version, linker=linker)
+
+                if 'flang' in out or 'clang' in out:
+                    linker = self._guess_nix_linker(
+                        compiler, FlangFortranCompiler, for_machine)
+                    return FlangFortranCompiler(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, full_version=full_version, linker=linker)
+
+                if 'Open64 Compiler Suite' in err:
+                    linker = self._guess_nix_linker(
+                        compiler, Open64FortranCompiler, for_machine)
+                    return Open64FortranCompiler(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, full_version=full_version, linker=linker)
+
+                if 'NAG Fortran' in err:
+                    linker = self._guess_nix_linker(
+                        compiler, NAGFortranCompiler, for_machine)
+                    return NAGFortranCompiler(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, full_version=full_version, linker=linker)
+
+        self._handle_exceptions(popen_exceptions, compilers)
+
     def get_scratch_dir(self) -> str:
         return self.scratch_dir
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -973,7 +973,7 @@ external dependencies (including libraries) must go to "dependencies".''')
                 ast.accept(printer)
                 printer.post_process()
                 meson_filename = os.path.join(self.build.environment.get_build_dir(), subdir, 'meson.build')
-                with open(meson_filename, "w") as f:
+                with open(meson_filename, "w", encoding='utf-8') as f:
                     f.write(printer.result)
 
                 mlog.log('Build file:', meson_filename)
@@ -1964,7 +1964,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         if not os.path.isfile(absname):
             self.subdir = prev_subdir
             raise InterpreterException(f"Non-existent build file '{buildfilename!s}'")
-        with open(absname, encoding='utf8') as f:
+        with open(absname, encoding='utf-8') as f:
             code = f.read()
         assert(isinstance(code, str))
         try:
@@ -2198,7 +2198,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
                 mesonlib.replace_if_different(ofile_abs, dst_tmp)
             if depfile:
                 mlog.log('Reading depfile:', mlog.bold(depfile))
-                with open(depfile) as f:
+                with open(depfile, encoding='utf-8') as f:
                     df = DepFile(f.readlines())
                     deps = df.get_all_dependencies(ofile_fname)
                     for dep in deps:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1694,9 +1694,11 @@ external dependencies (including libraries) must go to "dependencies".''')
     @FeatureNewKwargs('custom_target', '0.48.0', ['console'])
     @FeatureNewKwargs('custom_target', '0.47.0', ['install_mode', 'build_always_stale'])
     @FeatureNewKwargs('custom_target', '0.40.0', ['build_by_default'])
+    @FeatureNewKwargs('custom_target', '0.59.0', ['feed'])
     @permittedKwargs({'input', 'output', 'command', 'install', 'install_dir', 'install_mode',
                       'build_always', 'capture', 'depends', 'depend_files', 'depfile',
-                      'build_by_default', 'build_always_stale', 'console', 'env'})
+                      'build_by_default', 'build_always_stale', 'console', 'env',
+                      'feed'})
     def func_custom_target(self, node, args, kwargs):
         if len(args) != 1:
             raise InterpreterException('custom_target: Only one positional argument is allowed, and it must be a string name')

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -95,7 +95,7 @@ class InterpreterBase:
         mesonfile = os.path.join(self.source_root, self.subdir, environment.build_filename)
         if not os.path.isfile(mesonfile):
             raise InvalidArguments('Missing Meson file in %s' % mesonfile)
-        with open(mesonfile, encoding='utf8') as mf:
+        with open(mesonfile, encoding='utf-8') as mf:
             code = mf.read()
         if code.isspace():
             raise InvalidCode('Builder file is empty.')

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -982,9 +982,9 @@ class C2000DynamicLinker(DynamicLinker):
 
     id = 'cl2000'
 
-    def __init__(self, for_machine: mesonlib.MachineChoice,
+    def __init__(self, exelist: T.List[str], for_machine: mesonlib.MachineChoice,
                  *, version: str = 'unknown version'):
-        super().__init__(['cl2000.exe'], for_machine, '', [],
+        super().__init__(exelist or ['cl2000.exe'], for_machine, '', [],
                          version=version)
 
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:

--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -58,7 +58,7 @@ def parse_introspect_data(builddir: Path) -> T.Dict[str, T.List[dict]]:
     path_to_intro = builddir / 'meson-info' / 'intro-targets.json'
     if not path_to_intro.exists():
         raise MesonException(f'`{path_to_intro.name}` is missing! Directory is not configured yet?')
-    with path_to_intro.open() as f:
+    with path_to_intro.open(encoding='utf-8') as f:
         schema = json.load(f)
 
     parsed_data = defaultdict(list) # type: T.Dict[str, T.List[dict]]

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -49,7 +49,7 @@ def create_hash(fname):
     hashname = fname + '.sha256sum'
     m = hashlib.sha256()
     m.update(open(fname, 'rb').read())
-    with open(hashname, 'w') as f:
+    with open(hashname, 'w', encoding='utf-8') as f:
         # A space and an asterisk because that is the format defined by GNU coreutils
         # and accepted by busybox and the Perl shasum tool.
         f.write('{} *{}\n'.format(m.hexdigest(), os.path.basename(fname)))
@@ -67,7 +67,7 @@ def process_submodules(dirname):
     if not os.path.exists(module_file):
         return
     subprocess.check_call(['git', 'submodule', 'update', '--init', '--recursive'], cwd=dirname)
-    for line in open(module_file):
+    for line in open(module_file, encoding='utf-8'):
         line = line.strip()
         if '=' not in line:
             continue
@@ -242,7 +242,7 @@ def check_dist(packagename, meson_command, extra_meson_args, bld_root, privdir):
     unpacked_files = glob(os.path.join(unpackdir, '*'))
     assert(len(unpacked_files) == 1)
     unpacked_src_dir = unpacked_files[0]
-    with open(os.path.join(bld_root, 'meson-info', 'intro-buildoptions.json')) as boptions:
+    with open(os.path.join(bld_root, 'meson-info', 'intro-buildoptions.json'), encoding='utf-8') as boptions:
         meson_command += ['-D{name}={value}'.format(**o) for o in json.load(boptions)
                           if o['name'] not in ['backend', 'install_umask', 'buildtype']]
     meson_command += extra_meson_args

--- a/mesonbuild/mesondata.py
+++ b/mesonbuild/mesondata.py
@@ -361,7 +361,7 @@ class DataFile:
 
     def write_once(self, path: Path) -> None:
         if not path.exists():
-            path.write_text(self.data)
+            path.write_text(self.data, encoding='utf-8')
 
     def write_to_private(self, env: 'Environment') -> Path:
         out_file = Path(env.scratch_dir) / 'data' / self.path.name

--- a/mesonbuild/mesonlib/posix.py
+++ b/mesonbuild/mesonlib/posix.py
@@ -27,7 +27,7 @@ __all__ = ['BuildDirLock']
 class BuildDirLock(BuildDirLockBase):
 
     def __enter__(self) -> None:
-        self.lockfile = open(self.lockfilename, 'w')
+        self.lockfile = open(self.lockfilename, 'w', encoding='utf-8')
         try:
             fcntl.flock(self.lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
         except (BlockingIOError, PermissionError):

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -1359,7 +1359,7 @@ def expand_arguments(args: T.Iterable[str]) -> T.Optional[T.List[str]]:
 
         args_file = arg[1:]
         try:
-            with open(args_file) as f:
+            with open(args_file, encoding='utf-8') as f:
                 extended_args = f.read().split()
             expended_args += extended_args
         except Exception as e:
@@ -1854,11 +1854,11 @@ def get_wine_shortpath(winecmd: T.List[str], wine_paths: T.Sequence[str]) -> str
     wine_paths = list(OrderedSet(wine_paths))
 
     getShortPathScript = '%s.bat' % str(uuid.uuid4()).lower()[:5]
-    with open(getShortPathScript, mode='w') as f:
+    with open(getShortPathScript, mode='w', encoding='utf-8') as f:
         f.write("@ECHO OFF\nfor %%x in (%*) do (\n echo|set /p=;%~sx\n)\n")
         f.flush()
     try:
-        with open(os.devnull, 'w') as stderr:
+        with open(os.devnull, 'w', encoding='utf-8') as stderr:
             wine_path = subprocess.check_output(
                 winecmd +
                 ['cmd', '/C', getShortPathScript] + wine_paths,

--- a/mesonbuild/mesonlib/win32.py
+++ b/mesonbuild/mesonlib/win32.py
@@ -27,7 +27,7 @@ __all__ = ['BuildDirLock']
 class BuildDirLock(BuildDirLockBase):
 
     def __enter__(self) -> None:
-        self.lockfile = open(self.lockfilename, 'w')
+        self.lockfile = open(self.lockfilename, 'w', encoding='utf-8')
         try:
             msvcrt.locking(self.lockfile.fileno(), msvcrt.LK_NBLCK, 1)
         except (BlockingIOError, PermissionError):

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Work around some pathlib bugs...
+from . import _pathlib
 import sys
+sys.modules['pathlib'] = _pathlib
+
 import os.path
 import importlib
 import traceback
@@ -96,7 +100,7 @@ def setup_vsenv() -> None:
 
     bat_separator = '---SPLIT---'
     bat_contents = bat_template.format(bat_path, bat_separator)
-    bat_file.write_text(bat_contents)
+    bat_file.write_text(bat_contents, encoding='utf-8')
     try:
         bat_output = subprocess.check_output(str(bat_file), universal_newlines=True)
     finally:

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -708,7 +708,7 @@ def run(opts: 'ArgumentType') -> int:
         if not rebuild_all(opts.wd):
             sys.exit(-1)
     os.chdir(opts.wd)
-    with open(os.path.join(log_dir, 'install-log.txt'), 'w') as lf:
+    with open(os.path.join(log_dir, 'install-log.txt'), 'w', encoding='utf-8') as lf:
         installer = Installer(opts, lf)
         append_to_log(lf, '# List of files installed by Meson')
         append_to_log(lf, '# Does not contain files installed by custom scripts.')

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -394,7 +394,7 @@ def get_info_file(infodir: str, kind: T.Optional[str] = None) -> str:
                         'meson-info.json' if not kind else f'intro-{kind}.json')
 
 def load_info_file(infodir: str, kind: T.Optional[str] = None) -> T.Any:
-    with open(get_info_file(infodir, kind)) as fp:
+    with open(get_info_file(infodir, kind), encoding='utf-8') as fp:
         return json.load(fp)
 
 def run(options: argparse.Namespace) -> int:
@@ -464,7 +464,7 @@ def write_intro_info(intro_info: T.Sequence[T.Tuple[str, T.Union[dict, T.List[T.
     for i in intro_info:
         out_file = os.path.join(info_dir, 'intro-{}.json'.format(i[0]))
         tmp_file = os.path.join(info_dir, 'tmp_dump.json')
-        with open(tmp_file, 'w') as fp:
+        with open(tmp_file, 'w', encoding='utf-8') as fp:
             json.dump(i[1], fp)
             fp.flush() # Not sure if this is needed
         os.replace(tmp_file, out_file)
@@ -535,7 +535,7 @@ def write_meson_info_file(builddata: build.Build, errors: list, build_files_upda
 
     # Write the data to disc
     tmp_file = os.path.join(info_dir, 'tmp_dump.json')
-    with open(tmp_file, 'w') as fp:
+    with open(tmp_file, 'w', encoding='utf-8') as fp:
         json.dump(info_data, fp)
         fp.flush()
     os.replace(tmp_file, info_file)

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -100,7 +100,7 @@ def set_verbose() -> None:
 def initialize(logdir: str, fatal_warnings: bool = False) -> None:
     global log_dir, log_file, log_fatal_warnings
     log_dir = logdir
-    log_file = open(os.path.join(logdir, log_fname), 'w', encoding='utf8')
+    log_file = open(os.path.join(logdir, log_fname), 'w', encoding='utf-8')
     log_fatal_warnings = fatal_warnings
 
 def set_timestamp_start(start: float) -> None:

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -298,7 +298,7 @@ class CmakeModule(ExtensionModule):
         package_init += PACKAGE_INIT_SET_AND_CHECK
 
         try:
-            with open(infile) as fin:
+            with open(infile, encoding='utf-8') as fin:
                 data = fin.readlines()
         except Exception as e:
             raise mesonlib.MesonException('Could not read input file {}: {}'.format(infile, str(e)))

--- a/mesonbuild/modules/dlang.py
+++ b/mesonbuild/modules/dlang.py
@@ -70,7 +70,7 @@ class DlangModule(ExtensionModule):
 
         config_path = os.path.join(args[1], 'dub.json')
         if os.path.exists(config_path):
-            with open(config_path, encoding='utf8') as ofile:
+            with open(config_path, encoding='utf-8') as ofile:
                 try:
                     config = json.load(ofile)
                 except ValueError:
@@ -108,7 +108,7 @@ class DlangModule(ExtensionModule):
             else:
                 config[key] = value
 
-        with open(config_path, 'w', encoding='utf8') as ofile:
+        with open(config_path, 'w', encoding='utf-8') as ofile:
             ofile.write(json.dumps(config, indent=4, ensure_ascii=False))
 
     def _call_dubbin(self, args, env=None):

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1713,7 +1713,7 @@ G_END_DECLS'''
     def _generate_deps(self, state, library, packages, install_dir):
         outdir = state.environment.scratch_dir
         fname = os.path.join(outdir, library + '.deps')
-        with open(fname, 'w') as ofile:
+        with open(fname, 'w', encoding='utf-8') as ofile:
             for package in packages:
                 ofile.write(package + '\n')
         return build.Data([mesonlib.File(True, outdir, fname)], install_dir, None, state.subproject)

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -310,7 +310,7 @@ class HotdocTargetBuilder:
         hotdoc_config_name = fullname + '.json'
         hotdoc_config_path = os.path.join(
             self.builddir, self.subdir, hotdoc_config_name)
-        with open(hotdoc_config_path, 'w') as f:
+        with open(hotdoc_config_path, 'w', encoding='utf-8') as f:
             f.write('{}')
 
         self.cmd += ['--conf-file', hotdoc_config_path]

--- a/mesonbuild/modules/keyval.py
+++ b/mesonbuild/modules/keyval.py
@@ -32,7 +32,7 @@ class KeyvalModule(ExtensionModule):
     def _load_file(self, path_to_config):
         result = dict()
         try:
-            with open(path_to_config) as f:
+            with open(path_to_config, encoding='utf-8') as f:
                 for line in f:
                     if '#' in line:
                         comment_idx = line.index('#')

--- a/mesonbuild/modules/rpm.py
+++ b/mesonbuild/modules/rpm.py
@@ -77,7 +77,7 @@ class RPMModule(ExtensionModule):
 
         filename = os.path.join(state.environment.get_build_dir(),
                                 '%s.spec' % proj)
-        with open(filename, 'w+') as fn:
+        with open(filename, 'w+', encoding='utf-8') as fn:
             fn.write('Name: %s\n' % proj)
             fn.write('Version: # FIXME\n')
             fn.write('Release: 1%{?dist}\n')

--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -162,7 +162,7 @@ class ExternalProject(ModuleObject):
         log_filename = Path(mlog.log_dir, f'{self.name}-{step}.log')
         output = None
         if not self.verbose:
-            output = open(log_filename, 'w')
+            output = open(log_filename, 'w', encoding='utf-8')
             output.write(m + '\n')
             output.flush()
         else:

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -148,9 +148,9 @@ class MesonApp:
     def add_vcs_ignore_files(self, build_dir: str) -> None:
         if os.listdir(build_dir):
             return
-        with open(os.path.join(build_dir, '.gitignore'), 'w') as ofile:
+        with open(os.path.join(build_dir, '.gitignore'), 'w', encoding='utf-8') as ofile:
             ofile.write(git_ignore_file)
-        with open(os.path.join(build_dir, '.hgignore'), 'w') as ofile:
+        with open(os.path.join(build_dir, '.hgignore'), 'w', encoding='utf-8') as ofile:
             ofile.write(hg_ignore_file)
 
     def validate_dirs(self, dir1: str, dir2: str, reconfigure: bool, wipe: bool) -> T.Tuple[str, str]:

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -1,380 +1,460 @@
 import os, subprocess
 import argparse
+import asyncio
+import threading
+import copy
+import shutil
+from concurrent.futures.thread import ThreadPoolExecutor
 from pathlib import Path
+import typing as T
 
 from . import mlog
-from .mesonlib import quiet_git, verbose_git, GitException, Popen_safe, MesonException, windows_proof_rmtree
+from .mesonlib import quiet_git, GitException, Popen_safe, MesonException, windows_proof_rmtree
 from .wrap.wrap import PackageDefinition, Resolver, WrapException, ALL_TYPES
 from .wrap import wraptool
 
 ALL_TYPES_STRING = ', '.join(ALL_TYPES)
 
-def update_wrapdb_file(wrap):
-    try:
-        patch_url = wrap.get('patch_url')
-        branch, revision = wraptool.parse_patch_url(patch_url)
-    except WrapException:
-        return
-    new_branch, new_revision = wraptool.get_latest_version(wrap.name)
-    if new_branch != branch or new_revision != revision:
-        wraptool.update_wrap_file(wrap.filename, wrap.name, new_branch, new_revision)
-        mlog.log('  -> New wrap file downloaded.')
+class Logger:
+    def __init__(self, total_tasks: int) -> None:
+        self.lock = threading.Lock()
+        self.total_tasks = total_tasks
+        self.completed_tasks = 0
+        self.running_tasks = set()
+        self.should_erase_line = ''
 
-def update_file(r, wrap, repo_dir, options):
-    update_wrapdb_file(wrap)
-    if not os.path.isdir(repo_dir):
-        # The subproject is not needed, or it is a tarball extracted in
-        # 'libfoo-1.0' directory and the version has been bumped and the new
-        # directory is 'libfoo-2.0'. In that case forcing a meson
-        # reconfigure will download and use the new tarball.
-        mlog.log('  -> Not used.')
-        return True
-    elif options.reset:
-        # Delete existing directory and redownload. It is possible that nothing
-        # changed but we have no way to know. Hopefully tarballs are still
-        # cached.
-        windows_proof_rmtree(repo_dir)
+    def flush(self) -> None:
+        if self.should_erase_line:
+            print(self.should_erase_line, end='\r')
+            self.should_erase_line = ''
+
+    def print_progress(self) -> None:
+        line = f'Progress: {self.completed_tasks} / {self.total_tasks}'
+        max_len = shutil.get_terminal_size().columns - len(line)
+        running = ', '.join(self.running_tasks)
+        if len(running) + 3 > max_len:
+            running = running[:max_len - 6] + '...'
+        line = line + f' ({running})'
+        print(self.should_erase_line, line, sep='', end='\r')
+        self.should_erase_line = '\x1b[K'
+
+    def start(self, wrap_name: str) -> None:
+        with self.lock:
+            self.running_tasks.add(wrap_name)
+            self.print_progress()
+
+    def done(self, wrap_name: str, log_queue: T.List[T.Tuple[mlog.TV_LoggableList, T.Any]]) -> None:
+        with self.lock:
+            self.flush()
+            for args, kwargs in log_queue:
+                mlog.log(*args, **kwargs)
+            self.running_tasks.remove(wrap_name)
+            self.completed_tasks += 1
+            self.print_progress()
+
+
+class Runner:
+    def __init__(self, logger: Logger, r: Resolver, wrap: PackageDefinition, repo_dir: str, options: argparse.Namespace) -> None:
+        # FIXME: Do a copy because Resolver.resolve() is stateful method that
+        # cannot be called from multiple threads.
+        self.wrap_resolver = copy.copy(r)
+        self.wrap = wrap
+        self.repo_dir = repo_dir
+        self.options = options
+        self.run_method = options.subprojects_func.__get__(self)
+        self.log_queue = []
+        self.logger = logger
+
+    def log(self, *args, **kwargs):
+        self.log_queue.append((args, kwargs))
+
+    def run(self):
+        self.logger.start(self.wrap.name)
+        result = self.run_method()
+        self.logger.done(self.wrap.name, self.log_queue)
+        return result
+
+    def update_wrapdb_file(self):
         try:
-            r.resolve(wrap.name, 'meson')
-            mlog.log('  -> New version extracted')
+            patch_url = self.wrap.get('patch_url')
+            branch, revision = wraptool.parse_patch_url(patch_url)
+        except WrapException:
+            return
+        new_branch, new_revision = wraptool.get_latest_version(self.wrap.name)
+        if new_branch != branch or new_revision != revision:
+            wraptool.update_wrap_file(self.wrap.filename, self.wrap.name, new_branch, new_revision)
+            self.log('  -> New wrap file downloaded.')
+
+    def update_file(self):
+        self.update_wrapdb_file()
+        if not os.path.isdir(self.repo_dir):
+            # The subproject is not needed, or it is a tarball extracted in
+            # 'libfoo-1.0' directory and the version has been bumped and the new
+            # directory is 'libfoo-2.0'. In that case forcing a meson
+            # reconfigure will download and use the new tarball.
+            self.log('  -> Not used.')
             return True
-        except WrapException as e:
-            mlog.log('  ->', mlog.red(str(e)))
-            return False
-    else:
-        # The subproject has not changed, or the new source and/or patch
-        # tarballs should be extracted in the same directory than previous
-        # version.
-        mlog.log('  -> Subproject has not changed, or the new source/patch needs to be extracted on the same location.')
-        mlog.log('     Pass --reset option to delete directory and redownload.')
-        return False
-
-def git_output(cmd, workingdir):
-    return quiet_git(cmd, workingdir, check=True)[1]
-
-def git_stash(workingdir):
-    # That git command return 1 (failure) when there is something to stash.
-    # We don't want to stash when there is nothing to stash because that would
-    # print spurious "No local changes to save".
-    if not quiet_git(['diff', '--quiet', 'HEAD'], workingdir)[0]:
-        # Don't pipe stdout here because we want the user to see their changes have
-        # been saved.
-        verbose_git(['stash'], workingdir, check=True)
-
-def git_show(repo_dir):
-    commit_message = git_output(['show', '--quiet', '--pretty=format:%h%n%d%n%s%n[%an]'], repo_dir)
-    parts = [s.strip() for s in commit_message.split('\n')]
-    mlog.log('  ->', mlog.yellow(parts[0]), mlog.red(parts[1]), parts[2], mlog.blue(parts[3]))
-
-def git_rebase(repo_dir, revision):
-    try:
-        git_output(['-c', 'rebase.autoStash=true', 'rebase', 'FETCH_HEAD'], repo_dir)
-    except GitException as e:
-        mlog.log('  -> Could not rebase', mlog.bold(repo_dir), 'onto', mlog.bold(revision))
-        mlog.log(mlog.red(e.output))
-        mlog.log(mlog.red(str(e)))
-        return False
-    return True
-
-def git_reset(repo_dir, revision):
-    try:
-        # Stash local changes, commits can always be found back in reflog, to
-        # avoid any data lost by mistake.
-        git_stash(repo_dir)
-        git_output(['reset', '--hard', 'FETCH_HEAD'], repo_dir)
-    except GitException as e:
-        mlog.log('  -> Could not reset', mlog.bold(repo_dir), 'to', mlog.bold(revision))
-        mlog.log(mlog.red(e.output))
-        mlog.log(mlog.red(str(e)))
-        return False
-    return True
-
-def git_checkout(repo_dir, revision, create=False):
-    cmd = ['checkout', '--ignore-other-worktrees', revision, '--']
-    if create:
-        cmd.insert('-b', 1)
-    try:
-        # Stash local changes, commits can always be found back in reflog, to
-        # avoid any data lost by mistake.
-        git_stash(repo_dir)
-        git_output(cmd, repo_dir)
-    except GitException as e:
-        mlog.log('  -> Could not checkout', mlog.bold(revision), 'in', mlog.bold(repo_dir))
-        mlog.log(mlog.red(e.output))
-        mlog.log(mlog.red(str(e)))
-        return False
-    return True
-
-def git_checkout_and_reset(repo_dir, revision):
-    # revision could be a branch that already exists but is outdated, so we still
-    # have to reset after the checkout.
-    success = git_checkout(repo_dir, revision)
-    if success:
-        success = git_reset(repo_dir, revision)
-    return success
-
-def git_checkout_and_rebase(repo_dir, revision):
-    # revision could be a branch that already exists but is outdated, so we still
-    # have to rebase after the checkout.
-    success = git_checkout(repo_dir, revision)
-    if success:
-        success = git_rebase(repo_dir, revision)
-    return success
-
-def update_git(r, wrap, repo_dir, options):
-    if not os.path.isdir(repo_dir):
-        mlog.log('  -> Not used.')
-        return True
-    if not os.path.exists(os.path.join(repo_dir, '.git')):
-        if options.reset:
-            # Delete existing directory and redownload
-            windows_proof_rmtree(repo_dir)
+        elif self.options.reset:
+            # Delete existing directory and redownload. It is possible that nothing
+            # changed but we have no way to know. Hopefully tarballs are still
+            # cached.
+            windows_proof_rmtree(self.repo_dir)
             try:
-                r.resolve(wrap.name, 'meson')
-                update_git_done(repo_dir)
+                self.wrap_resolver.resolve(self.wrap.name, 'meson')
+                self.log('  -> New version extracted')
                 return True
             except WrapException as e:
-                mlog.log('  ->', mlog.red(str(e)))
+                self.log('  ->', mlog.red(str(e)))
                 return False
         else:
-            mlog.log('  -> Not a git repository.')
-            mlog.log('Pass --reset option to delete directory and redownload.')
+            # The subproject has not changed, or the new source and/or patch
+            # tarballs should be extracted in the same directory than previous
+            # version.
+            self.log('  -> Subproject has not changed, or the new source/patch needs to be extracted on the same location.')
+            self.log('     Pass --reset option to delete directory and redownload.')
             return False
-    revision = wrap.values.get('revision')
-    url = wrap.values.get('url')
-    push_url = wrap.values.get('push-url')
-    if not revision or not url:
-        # It could be a detached git submodule for example.
-        mlog.log('  -> No revision or URL specified.')
-        return True
-    try:
-        origin_url = git_output(['remote', 'get-url', 'origin'], repo_dir).strip()
-    except GitException as e:
-        mlog.log('  -> Failed to determine current origin URL in', mlog.bold(repo_dir))
-        mlog.log(mlog.red(e.output))
-        mlog.log(mlog.red(str(e)))
-        return False
-    if options.reset:
+
+    def git_output(self, cmd):
+        return quiet_git(cmd, self.repo_dir, check=True)[1]
+
+    def git_verbose(self, cmd):
+        self.log(self.git_output(cmd))
+
+    def git_stash(self):
+        # That git command return 1 (failure) when there is something to stash.
+        # We don't want to stash when there is nothing to stash because that would
+        # print spurious "No local changes to save".
+        if not quiet_git(['diff', '--quiet', 'HEAD'], self.repo_dir)[0]:
+            # Don't pipe stdout here because we want the user to see their changes have
+            # been saved.
+            self.git_verbose(['stash'])
+
+    def git_show(self):
+        commit_message = self.git_output(['show', '--quiet', '--pretty=format:%h%n%d%n%s%n[%an]'])
+        parts = [s.strip() for s in commit_message.split('\n')]
+        self.log('  ->', mlog.yellow(parts[0]), mlog.red(parts[1]), parts[2], mlog.blue(parts[3]))
+
+    def git_rebase(self, revision):
         try:
-            git_output(['remote', 'set-url', 'origin', url], repo_dir)
-            if push_url:
-                git_output(['remote', 'set-url', '--push', 'origin', push_url], repo_dir)
+            self.git_output(['-c', 'rebase.autoStash=true', 'rebase', 'FETCH_HEAD'])
         except GitException as e:
-            mlog.log('  -> Failed to reset origin URL in', mlog.bold(repo_dir))
-            mlog.log(mlog.red(e.output))
-            mlog.log(mlog.red(str(e)))
+            self.log('  -> Could not rebase', mlog.bold(self.repo_dir), 'onto', mlog.bold(revision))
+            self.log(mlog.red(e.output))
+            self.log(mlog.red(str(e)))
             return False
-    elif url != origin_url:
-        mlog.log(f'  -> URL changed from {origin_url!r} to {url!r}')
-        return False
-    try:
-        # Same as `git branch --show-current` but compatible with older git version
-        branch = git_output(['rev-parse', '--abbrev-ref', 'HEAD'], repo_dir).strip()
-        branch = branch if branch != 'HEAD' else ''
-    except GitException as e:
-        mlog.log('  -> Failed to determine current branch in', mlog.bold(repo_dir))
-        mlog.log(mlog.red(e.output))
-        mlog.log(mlog.red(str(e)))
-        return False
-    try:
-        # Fetch only the revision we need, this avoids fetching useless branches.
-        # revision can be either a branch, tag or commit id. In all cases we want
-        # FETCH_HEAD to be set to the desired commit and "git checkout <revision>"
-        # to to either switch to existing/new branch, or detach to tag/commit.
-        # It is more complicated than it first appear, see discussion there:
-        # https://github.com/mesonbuild/meson/pull/7723#discussion_r488816189.
-        heads_refmap = '+refs/heads/*:refs/remotes/origin/*'
-        tags_refmap = '+refs/tags/*:refs/tags/*'
-        git_output(['fetch', '--refmap', heads_refmap, '--refmap', tags_refmap, 'origin', revision], repo_dir)
-    except GitException as e:
-        mlog.log('  -> Could not fetch revision', mlog.bold(revision), 'in', mlog.bold(repo_dir))
-        mlog.log(mlog.red(e.output))
-        mlog.log(mlog.red(str(e)))
-        return False
-
-    if branch == '':
-        # We are currently in detached mode
-        if options.reset:
-            success = git_checkout_and_reset(repo_dir, revision)
-        else:
-            success = git_checkout_and_rebase(repo_dir, revision)
-    elif branch == revision:
-        # We are in the same branch. A reset could still be needed in the case
-        # a force push happened on remote repository.
-        if options.reset:
-            success = git_reset(repo_dir, revision)
-        else:
-            success = git_rebase(repo_dir, revision)
-    else:
-        # We are in another branch, either the user created their own branch and
-        # we should rebase it, or revision changed in the wrap file and we need
-        # to checkout the new branch.
-        if options.reset:
-            success = git_checkout_and_reset(repo_dir, revision)
-        else:
-            success = git_rebase(repo_dir, revision)
-    if success:
-        update_git_done(repo_dir)
-    return success
-
-def update_git_done(repo_dir):
-    git_output(['submodule', 'update', '--checkout', '--recursive'], repo_dir)
-    git_show(repo_dir)
-
-def update_hg(r, wrap, repo_dir, options):
-    if not os.path.isdir(repo_dir):
-        mlog.log('  -> Not used.')
-        return True
-    revno = wrap.get('revision')
-    if revno.lower() == 'tip':
-        # Failure to do pull is not a fatal error,
-        # because otherwise you can't develop without
-        # a working net connection.
-        subprocess.call(['hg', 'pull'], cwd=repo_dir)
-    else:
-        if subprocess.call(['hg', 'checkout', revno], cwd=repo_dir) != 0:
-            subprocess.check_call(['hg', 'pull'], cwd=repo_dir)
-            subprocess.check_call(['hg', 'checkout', revno], cwd=repo_dir)
-    return True
-
-def update_svn(r, wrap, repo_dir, options):
-    if not os.path.isdir(repo_dir):
-        mlog.log('  -> Not used.')
-        return True
-    revno = wrap.get('revision')
-    p, out, _ = Popen_safe(['svn', 'info', '--show-item', 'revision', repo_dir])
-    current_revno = out
-    if current_revno == revno:
-        return True
-    if revno.lower() == 'head':
-        # Failure to do pull is not a fatal error,
-        # because otherwise you can't develop without
-        # a working net connection.
-        subprocess.call(['svn', 'update'], cwd=repo_dir)
-    else:
-        subprocess.check_call(['svn', 'update', '-r', revno], cwd=repo_dir)
-    return True
-
-def update(r, wrap, repo_dir, options):
-    mlog.log(f'Updating {wrap.name}...')
-    if wrap.type == 'file':
-        return update_file(r, wrap, repo_dir, options)
-    elif wrap.type == 'git':
-        return update_git(r, wrap, repo_dir, options)
-    elif wrap.type == 'hg':
-        return update_hg(r, wrap, repo_dir, options)
-    elif wrap.type == 'svn':
-        return update_svn(r, wrap, repo_dir, options)
-    elif wrap.type is None:
-        mlog.log('  -> Cannot update subproject with no wrap file')
-    else:
-        mlog.log('  -> Cannot update', wrap.type, 'subproject')
-    return True
-
-def checkout(r, wrap, repo_dir, options):
-    if wrap.type != 'git' or not os.path.isdir(repo_dir):
-        return True
-    branch_name = options.branch_name if options.branch_name else wrap.get('revision')
-    if not branch_name:
-        # It could be a detached git submodule for example.
-        return True
-    mlog.log(f'Checkout {branch_name} in {wrap.name}...')
-    if git_checkout(repo_dir, branch_name, create=options.b):
-        git_show(repo_dir)
-        return True
-    return False
-
-def download(r, wrap, repo_dir, options):
-    mlog.log(f'Download {wrap.name}...')
-    if os.path.isdir(repo_dir):
-        mlog.log('  -> Already downloaded')
-        return True
-    try:
-        r.resolve(wrap.name, 'meson')
-        mlog.log('  -> done')
-    except WrapException as e:
-        mlog.log('  ->', mlog.red(str(e)))
-        return False
-    return True
-
-def foreach(r, wrap, repo_dir, options):
-    mlog.log(f'Executing command in {repo_dir}')
-    if not os.path.isdir(repo_dir):
-        mlog.log('  -> Not downloaded yet')
-        return True
-    cmd = [options.command] + options.args
-    p, out, _ = Popen_safe(cmd, stderr=subprocess.STDOUT, cwd=repo_dir)
-    if p.returncode != 0:
-        err_message = "Command '{}' returned non-zero exit status {}.".format(" ".join(cmd), p.returncode)
-        mlog.log('  -> ', mlog.red(err_message))
-        mlog.log(out, end='')
-        return False
-
-    mlog.log(out, end='')
-    return True
-
-def purge(r: Resolver, wrap: PackageDefinition, repo_dir: str, options: argparse.Namespace) -> bool:
-    # if subproject is not wrap-based, then don't remove it
-    if not wrap.type:
         return True
 
-    if wrap.type == 'redirect':
-        redirect_file = Path(wrap.filename).resolve()
-        if options.confirm:
-            redirect_file.unlink()
-        mlog.log(f'Deleting {redirect_file}')
-
-    if options.include_cache:
-        packagecache = Path(r.cachedir).resolve()
+    def git_reset(self, revision):
         try:
-            subproject_cache_file = packagecache / wrap.get("source_filename")
-            if subproject_cache_file.is_file():
-                if options.confirm:
-                    subproject_cache_file.unlink()
-                mlog.log(f'Deleting {subproject_cache_file}')
-        except WrapException:
-            pass
+            # Stash local changes, commits can always be found back in reflog, to
+            # avoid any data lost by mistake.
+            self.git_stash()
+            self.git_output(['reset', '--hard', 'FETCH_HEAD'])
+        except GitException as e:
+            self.log('  -> Could not reset', mlog.bold(repo_dir), 'to', mlog.bold(revision))
+            self.log(mlog.red(e.output))
+            self.log(mlog.red(str(e)))
+            return False
+        return True
 
+    def git_checkout(self, revision, create=False):
+        cmd = ['checkout', '--ignore-other-worktrees', revision, '--']
+        if create:
+            cmd.insert('-b', 1)
         try:
-            subproject_patch_file = packagecache / wrap.get("patch_filename")
-            if subproject_patch_file.is_file():
-                if options.confirm:
-                    subproject_patch_file.unlink()
-                mlog.log(f'Deleting {subproject_patch_file}')
-        except WrapException:
-            pass
-
-        # Don't log that we will remove an empty directory
-        if packagecache.exists() and not any(packagecache.iterdir()):
-            packagecache.rmdir()
-
-    subproject_source_dir = Path(repo_dir).resolve()
-
-    # Don't follow symlink. This is covered by the next if statement, but why
-    # not be doubly sure.
-    if subproject_source_dir.is_symlink():
-        if options.confirm:
-            subproject_source_dir.unlink()
-        mlog.log(f'Deleting {subproject_source_dir}')
-        return True
-    if not subproject_source_dir.is_dir():
+            # Stash local changes, commits can always be found back in reflog, to
+            # avoid any data lost by mistake.
+            self.git_stash()
+            self.git_output(cmd)
+        except GitException as e:
+            self.log('  -> Could not checkout', mlog.bold(revision), 'in', mlog.bold(self.repo_dir))
+            self.log(mlog.red(e.output))
+            self.log(mlog.red(str(e)))
+            return False
         return True
 
-    try:
-        if options.confirm:
-            windows_proof_rmtree(str(subproject_source_dir))
-        mlog.log(f'Deleting {subproject_source_dir}')
-    except OSError as e:
-        mlog.error(f'Unable to remove: {subproject_source_dir}: {e}')
+    def git_checkout_and_reset(self, revision):
+        # revision could be a branch that already exists but is outdated, so we still
+        # have to reset after the checkout.
+        success = self.git_checkout(revision)
+        if success:
+            success = self.git_reset(revision)
+        return success
+
+    def git_checkout_and_rebase(self, revision):
+        # revision could be a branch that already exists but is outdated, so we still
+        # have to rebase after the checkout.
+        success = self.git_checkout(revision)
+        if success:
+            success = self.git_rebase(revision)
+        return success
+
+    def update_git(self):
+        if not os.path.isdir(self.repo_dir):
+            self.log('  -> Not used.')
+            return True
+        if not os.path.exists(os.path.join(self.repo_dir, '.git')):
+            if self.options.reset:
+                # Delete existing directory and redownload
+                windows_proof_rmtree(self.repo_dir)
+                try:
+                    self.wrap_resolver.resolve(self.wrap.name, 'meson')
+                    self.update_git_done()
+                    return True
+                except WrapException as e:
+                    self.log('  ->', mlog.red(str(e)))
+                    return False
+            else:
+                self.log('  -> Not a git repository.')
+                self.log('Pass --reset option to delete directory and redownload.')
+                return False
+        revision = self.wrap.values.get('revision')
+        url = self.wrap.values.get('url')
+        push_url = self.wrap.values.get('push-url')
+        if not revision or not url:
+            # It could be a detached git submodule for example.
+            self.log('  -> No revision or URL specified.')
+            return True
+        try:
+            origin_url = self.git_output(['remote', 'get-url', 'origin']).strip()
+        except GitException as e:
+            self.log('  -> Failed to determine current origin URL in', mlog.bold(self.repo_dir))
+            self.log(mlog.red(e.output))
+            self.log(mlog.red(str(e)))
+            return False
+        if self.options.reset:
+            try:
+                self.git_output(['remote', 'set-url', 'origin', url])
+                if push_url:
+                    self.git_output(['remote', 'set-url', '--push', 'origin', push_url])
+            except GitException as e:
+                self.log('  -> Failed to reset origin URL in', mlog.bold(self.repo_dir))
+                self.log(mlog.red(e.output))
+                self.log(mlog.red(str(e)))
+                return False
+        elif url != origin_url:
+            self.log(f'  -> URL changed from {origin_url!r} to {url!r}')
+            return False
+        try:
+            # Same as `git branch --show-current` but compatible with older git version
+            branch = self.git_output(['rev-parse', '--abbrev-ref', 'HEAD']).strip()
+            branch = branch if branch != 'HEAD' else ''
+        except GitException as e:
+            self.log('  -> Failed to determine current branch in', mlog.bold(self.repo_dir))
+            self.log(mlog.red(e.output))
+            self.log(mlog.red(str(e)))
+            return False
+        try:
+            # Fetch only the revision we need, this avoids fetching useless branches.
+            # revision can be either a branch, tag or commit id. In all cases we want
+            # FETCH_HEAD to be set to the desired commit and "git checkout <revision>"
+            # to to either switch to existing/new branch, or detach to tag/commit.
+            # It is more complicated than it first appear, see discussion there:
+            # https://github.com/mesonbuild/meson/pull/7723#discussion_r488816189.
+            heads_refmap = '+refs/heads/*:refs/remotes/origin/*'
+            tags_refmap = '+refs/tags/*:refs/tags/*'
+            self.git_output(['fetch', '--refmap', heads_refmap, '--refmap', tags_refmap, 'origin', revision])
+        except GitException as e:
+            self.log('  -> Could not fetch revision', mlog.bold(revision), 'in', mlog.bold(self.repo_dir))
+            self.log(mlog.red(e.output))
+            self.log(mlog.red(str(e)))
+            return False
+
+        if branch == '':
+            # We are currently in detached mode
+            if self.options.reset:
+                success = self.git_checkout_and_reset(revision)
+            else:
+                success = self.git_checkout_and_rebase(revision)
+        elif branch == revision:
+            # We are in the same branch. A reset could still be needed in the case
+            # a force push happened on remote repository.
+            if self.options.reset:
+                success = self.git_reset(revision)
+            else:
+                success = self.git_rebase(revision)
+        else:
+            # We are in another branch, either the user created their own branch and
+            # we should rebase it, or revision changed in the wrap file and we need
+            # to checkout the new branch.
+            if self.options.reset:
+                success = self.git_checkout_and_reset(revision)
+            else:
+                success = self.git_rebase(revision)
+        if success:
+            self.update_git_done()
+        return success
+
+    def update_git_done(self):
+        self.git_output(['submodule', 'update', '--checkout', '--recursive'])
+        self.git_show()
+
+    def update_hg(self):
+        if not os.path.isdir(self.repo_dir):
+            self.log('  -> Not used.')
+            return True
+        revno = self.wrap.get('revision')
+        if revno.lower() == 'tip':
+            # Failure to do pull is not a fatal error,
+            # because otherwise you can't develop without
+            # a working net connection.
+            subprocess.call(['hg', 'pull'], cwd=self.repo_dir)
+        else:
+            if subprocess.call(['hg', 'checkout', revno], cwd=self.repo_dir) != 0:
+                subprocess.check_call(['hg', 'pull'], cwd=self.repo_dir)
+                subprocess.check_call(['hg', 'checkout', revno], cwd=self.repo_dir)
+        return True
+
+    def update_svn(self):
+        if not os.path.isdir(self.repo_dir):
+            self.log('  -> Not used.')
+            return True
+        revno = self.wrap.get('revision')
+        p, out, _ = Popen_safe(['svn', 'info', '--show-item', 'revision', self.repo_dir])
+        current_revno = out
+        if current_revno == revno:
+            return True
+        if revno.lower() == 'head':
+            # Failure to do pull is not a fatal error,
+            # because otherwise you can't develop without
+            # a working net connection.
+            subprocess.call(['svn', 'update'], cwd=self.repo_dir)
+        else:
+            subprocess.check_call(['svn', 'update', '-r', revno], cwd=self.repo_dir)
+        return True
+
+    def update(self):
+        self.log(f'Updating {self.wrap.name}...')
+        if self.wrap.type == 'file':
+            return self.update_file()
+        elif self.wrap.type == 'git':
+            return self.update_git()
+        elif self.wrap.type == 'hg':
+            return self.update_hg()
+        elif self.wrap.type == 'svn':
+            return self.update_svn()
+        elif self.wrap.type is None:
+            self.log('  -> Cannot update subproject with no wrap file')
+        else:
+            self.log('  -> Cannot update', self.wrap.type, 'subproject')
+        return True
+
+    def checkout(self):
+        if self.wrap.type != 'git' or not os.path.isdir(self.repo_dir):
+            return True
+        branch_name = self.options.branch_name if self.options.branch_name else self.wrap.get('revision')
+        if not branch_name:
+            # It could be a detached git submodule for example.
+            return True
+        self.log(f'Checkout {branch_name} in {self.wrap.name}...')
+        if self.git_checkout(branch_name, create=self.options.b):
+            self.git_show()
+            return True
         return False
 
-    return True
+    def download(self):
+        self.log(f'Download {self.wrap.name}...')
+        if os.path.isdir(self.repo_dir):
+            self.log('  -> Already downloaded')
+            return True
+        try:
+            self.wrap_resolver.resolve(self.wrap.name, 'meson')
+            self.log('  -> done')
+        except WrapException as e:
+            self.log('  ->', mlog.red(str(e)))
+            return False
+        return True
+
+    def foreach(self):
+        self.log(f'Executing command in {self.repo_dir}')
+        if not os.path.isdir(self.repo_dir):
+            self.log('  -> Not downloaded yet')
+            return True
+        cmd = [self.options.command] + self.options.args
+        p, out, _ = Popen_safe(cmd, stderr=subprocess.STDOUT, cwd=self.repo_dir)
+        if p.returncode != 0:
+            err_message = "Command '{}' returned non-zero exit status {}.".format(" ".join(cmd), p.returncode)
+            self.log('  -> ', mlog.red(err_message))
+            self.log(out, end='')
+            return False
+
+        self.log(out, end='')
+        return True
+
+    def purge(self) -> bool:
+        # if subproject is not wrap-based, then don't remove it
+        if not self.wrap.type:
+            return True
+
+        if self.wrap.type == 'redirect':
+            redirect_file = Path(self.wrap.filename).resolve()
+            if self.options.confirm:
+                redirect_file.unlink()
+            self.log(f'Deleting {redirect_file}')
+
+        if self.options.include_cache:
+            packagecache = Path(self.wrap_resolver.cachedir).resolve()
+            try:
+                subproject_cache_file = packagecache / self.wrap.get("source_filename")
+                if subproject_cache_file.is_file():
+                    if self.options.confirm:
+                        subproject_cache_file.unlink()
+                    self.log(f'Deleting {subproject_cache_file}')
+            except WrapException:
+                pass
+
+            try:
+                subproject_patch_file = packagecache / self.wrap.get("patch_filename")
+                if subproject_patch_file.is_file():
+                    if self.options.confirm:
+                        subproject_patch_file.unlink()
+                    self.log(f'Deleting {subproject_patch_file}')
+            except WrapException:
+                pass
+
+            # Don't log that we will remove an empty directory. Since purge is
+            # parallelized, another thread could have deleted it already.
+            try:
+                if not any(packagecache.iterdir()):
+                    packagecache.rmdir()
+            except FileNotFoundError:
+                pass
+
+        subproject_source_dir = Path(self.repo_dir).resolve()
+
+        # Don't follow symlink. This is covered by the next if statement, but why
+        # not be doubly sure.
+        if subproject_source_dir.is_symlink():
+            if self.options.confirm:
+                subproject_source_dir.unlink()
+            self.log(f'Deleting {subproject_source_dir}')
+            return True
+        if not subproject_source_dir.is_dir():
+            return True
+
+        try:
+            if self.options.confirm:
+                windows_proof_rmtree(str(subproject_source_dir))
+            self.log(f'Deleting {subproject_source_dir}')
+        except OSError as e:
+            mlog.error(f'Unable to remove: {subproject_source_dir}: {e}')
+            return False
+
+        return True
+
+    @staticmethod
+    def post_purge(options):
+        if not options.confirm:
+            mlog.log('')
+            mlog.log('Nothing has been deleted, run again with --confirm to apply.')
 
 def add_common_arguments(p):
     p.add_argument('--sourcedir', default='.',
                    help='Path to source directory')
     p.add_argument('--types', default='',
                    help=f'Comma-separated list of subproject types. Supported types are: {ALL_TYPES_STRING} (default: all)')
+    p.add_argument('--num-processes', default=None, type=int,
+                   help='How many parallel processes to use (Since 0.59.0).')
 
 def add_subprojects_argument(p):
     p.add_argument('subprojects', nargs='*',
@@ -392,7 +472,7 @@ def add_arguments(parser):
                    help='Checkout wrap\'s revision and hard reset to that commit. (git only)')
     add_common_arguments(p)
     add_subprojects_argument(p)
-    p.set_defaults(subprojects_func=update)
+    p.set_defaults(subprojects_func=Runner.update)
 
     p = subparsers.add_parser('checkout', help='Checkout a branch (git only)')
     p.add_argument('-b', default=False, action='store_true',
@@ -401,14 +481,14 @@ def add_arguments(parser):
                    help='Name of the branch to checkout or create (default: revision set in wrap file)')
     add_common_arguments(p)
     add_subprojects_argument(p)
-    p.set_defaults(subprojects_func=checkout)
+    p.set_defaults(subprojects_func=Runner.checkout)
 
     p = subparsers.add_parser('download', help='Ensure subprojects are fetched, even if not in use. ' +
                                                'Already downloaded subprojects are not modified. ' +
                                                'This can be used to pre-fetch all subprojects and avoid downloads during configure.')
     add_common_arguments(p)
     add_subprojects_argument(p)
-    p.set_defaults(subprojects_func=download)
+    p.set_defaults(subprojects_func=Runner.download)
 
     p = subparsers.add_parser('foreach', help='Execute a command in each subproject directory.')
     p.add_argument('command', metavar='command ...',
@@ -417,14 +497,15 @@ def add_arguments(parser):
                    help=argparse.SUPPRESS)
     add_common_arguments(p)
     p.set_defaults(subprojects=[])
-    p.set_defaults(subprojects_func=foreach)
+    p.set_defaults(subprojects_func=Runner.foreach)
 
     p = subparsers.add_parser('purge', help='Remove all wrap-based subproject artifacts')
     add_common_arguments(p)
     add_subprojects_argument(p)
     p.add_argument('--include-cache', action='store_true', default=False, help='Remove the package cache as well')
     p.add_argument('--confirm', action='store_true', default=False, help='Confirm the removal of subproject artifacts')
-    p.set_defaults(subprojects_func=purge)
+    p.set_defaults(subprojects_func=Runner.purge)
+    p.set_defaults(post_func=Runner.post_purge)
 
 def run(options):
     src_dir = os.path.relpath(os.path.realpath(options.sourcedir))
@@ -444,13 +525,25 @@ def run(options):
     for t in types:
         if t not in ALL_TYPES:
             raise MesonException(f'Unknown subproject type {t!r}, supported types are: {ALL_TYPES_STRING}')
-    failures = []
+    tasks = []
+    task_names = []
+    loop = asyncio.get_event_loop()
+    executor = ThreadPoolExecutor(options.num_processes)
+    if types:
+        wraps = [wrap for wrap in wraps if wrap.type in types]
+    logger = Logger(len(wraps))
     for wrap in wraps:
-        if types and wrap.type not in types:
-            continue
         dirname = Path(subprojects_dir, wrap.directory).as_posix()
-        if not options.subprojects_func(r, wrap, dirname, options):
-            failures.append(wrap.name)
+        runner = Runner(logger, r, wrap, dirname, options)
+        task = loop.run_in_executor(executor, runner.run)
+        tasks.append(task)
+        task_names.append(wrap.name)
+    results = loop.run_until_complete(asyncio.gather(*tasks))
+    logger.flush()
+    post_func = getattr(options, 'post_func', None)
+    if post_func:
+        post_func(options)
+    failures = [name for name, success in zip(task_names, results) if not success]
     if failures:
         m = 'Please check logs above as command failed in some subprojects which could have been left in conflict state: '
         m += ', '.join(failures)

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -467,7 +467,7 @@ class TestLogger:
 class TestFileLogger(TestLogger):
     def __init__(self, filename: str, errors: str = 'replace') -> None:
         self.filename = filename
-        self.file = open(filename, 'w', encoding='utf8', errors=errors)
+        self.file = open(filename, 'w', encoding='utf-8', errors=errors)
 
     def close(self) -> None:
         if self.file:

--- a/mesonbuild/optinterpreter.py
+++ b/mesonbuild/optinterpreter.py
@@ -142,7 +142,7 @@ class OptionInterpreter:
 
     def process(self, option_file: str) -> None:
         try:
-            with open(option_file, encoding='utf8') as f:
+            with open(option_file, encoding='utf-8') as f:
                 ast = mparser.Parser(f.read(), option_file).parse()
         except mesonlib.MesonException as me:
             me.file = option_file

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -176,7 +176,7 @@ class ExternalProgram(mesonlib.HoldableObject):
         or if we're on Windows (which does not understand shebangs).
         """
         try:
-            with open(script) as f:
+            with open(script, encoding='utf-8') as f:
                 first_line = f.readline().strip()
             if first_line.startswith('#!'):
                 # In a shebang, everything before the first space is assumed to

--- a/mesonbuild/rewriter.py
+++ b/mesonbuild/rewriter.py
@@ -818,9 +818,9 @@ class Rewriter:
             fdata = ''
             # Create an empty file if it does not exist
             if not os.path.exists(fpath):
-                with open(fpath, 'w'):
+                with open(fpath, 'w', encoding='utf-8'):
                     pass
-            with open(fpath) as fp:
+            with open(fpath, encoding='utf-8') as fp:
                 fdata = fp.read()
 
             # Generate line offsets numbers
@@ -871,7 +871,7 @@ class Rewriter:
         # Write the files back
         for key, val in files.items():
             mlog.log('Rewriting', mlog.yellow(key))
-            with open(val['path'], 'w') as fp:
+            with open(val['path'], 'w', encoding='utf-8') as fp:
                 fp.write(val['raw'])
 
 target_operation_map = {
@@ -923,7 +923,7 @@ def generate_def_opts(options) -> T.List[dict]:
 
 def generate_cmd(options) -> T.List[dict]:
     if os.path.exists(options.json):
-        with open(options.json) as fp:
+        with open(options.json, encoding='utf-8') as fp:
             return json.load(fp)
     else:
         return json.loads(options.json)

--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -68,11 +68,11 @@ def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build
                 # Create a shim to allow using llvm-cov as a gcov tool.
                 if mesonlib.is_windows():
                     llvm_cov_shim_path = os.path.join(log_dir, 'llvm-cov.bat')
-                    with open(llvm_cov_shim_path, 'w') as llvm_cov_bat:
+                    with open(llvm_cov_shim_path, 'w', encoding='utf-8') as llvm_cov_bat:
                         llvm_cov_bat.write(f'@"{llvm_cov_exe}" gcov %*')
                 else:
                     llvm_cov_shim_path = os.path.join(log_dir, 'llvm-cov.sh')
-                    with open(llvm_cov_shim_path, 'w') as llvm_cov_sh:
+                    with open(llvm_cov_shim_path, 'w', encoding='utf-8') as llvm_cov_sh:
                         llvm_cov_sh.write(f'#!/usr/bin/env sh\nexec "{llvm_cov_exe}" gcov $@')
                     os.chmod(llvm_cov_shim_path, os.stat(llvm_cov_shim_path).st_mode | stat.S_IEXEC)
                 gcov_tool_args = ['--gcov-tool', llvm_cov_shim_path]

--- a/mesonbuild/scripts/depfixer.py
+++ b/mesonbuild/scripts/depfixer.py
@@ -468,7 +468,7 @@ def fix_darwin(fname: str, new_rpath: str, final_path: str, install_name_mapping
 
 def fix_jar(fname: str) -> None:
     subprocess.check_call(['jar', 'xfv', fname, 'META-INF/MANIFEST.MF'])
-    with open('META-INF/MANIFEST.MF', 'r+') as f:
+    with open('META-INF/MANIFEST.MF', 'r+', encoding='utf-8') as f:
         lines = f.readlines()
         f.seek(0)
         for line in lines:

--- a/mesonbuild/scripts/depscan.py
+++ b/mesonbuild/scripts/depscan.py
@@ -57,7 +57,7 @@ class DependencyScanner:
     def scan_fortran_file(self, fname: str) -> None:
         fpath = pathlib.Path(fname)
         modules_in_this_file = set()
-        for line in fpath.read_text().split('\n'):
+        for line in fpath.read_text(encoding='utf-8').split('\n'):
             import_match = FORTRAN_USE_RE.match(line)
             export_match = FORTRAN_MODULE_RE.match(line)
             submodule_export_match = FORTRAN_SUBMOD_RE.match(line)
@@ -108,7 +108,7 @@ class DependencyScanner:
 
     def scan_cpp_file(self, fname: str) -> None:
         fpath = pathlib.Path(fname)
-        for line in fpath.read_text().split('\n'):
+        for line in fpath.read_text(encoding='utf-8').split('\n'):
             import_match = CPP_IMPORT_RE.match(line)
             export_match = CPP_EXPORT_RE.match(line)
             if import_match:
@@ -150,7 +150,7 @@ class DependencyScanner:
     def scan(self) -> int:
         for s in self.sources:
             self.scan_file(s)
-        with open(self.outfile, 'w') as ofile:
+        with open(self.outfile, 'w', encoding='utf-8') as ofile:
             ofile.write('ninja_dyndep_version = 1\n')
             for src in self.sources:
                 objfilename = self.objname_for(src)

--- a/mesonbuild/scripts/externalproject.py
+++ b/mesonbuild/scripts/externalproject.py
@@ -34,7 +34,7 @@ class ExternalProject:
         self.make = options.make
 
     def write_depfile(self) -> None:
-        with open(self.depfile, 'w') as f:
+        with open(self.depfile, 'w', encoding='utf-8') as f:
             f.write(f'{self.stampfile}: \\\n')
             for dirpath, dirnames, filenames in os.walk(self.src_dir):
                 dirnames[:] = [d for d in dirnames if not d.startswith('.')]
@@ -45,7 +45,7 @@ class ExternalProject:
                     f.write('  {} \\\n'.format(path.as_posix().replace(' ', '\\ ')))
 
     def write_stampfile(self) -> None:
-        with open(self.stampfile, 'w') as f:
+        with open(self.stampfile, 'w', encoding='utf-8') as f:
             pass
 
     def gnu_make(self) -> bool:
@@ -78,7 +78,7 @@ class ExternalProject:
         log_filename = Path(self.log_dir, f'{self.name}-{step}.log')
         output = None
         if not self.verbose:
-            output = open(log_filename, 'w')
+            output = open(log_filename, 'w', encoding='utf-8')
             output.write(m + '\n')
             output.flush()
         else:

--- a/mesonbuild/scripts/gettext.py
+++ b/mesonbuild/scripts/gettext.py
@@ -34,7 +34,7 @@ def read_linguas(src_sub: str) -> T.List[str]:
     linguas = os.path.join(src_sub, 'LINGUAS')
     try:
         langs = []
-        with open(linguas) as f:
+        with open(linguas, encoding='utf-8') as f:
             for line in f:
                 line = line.strip()
                 if line and not line.startswith('#'):

--- a/mesonbuild/scripts/symbolextractor.py
+++ b/mesonbuild/scripts/symbolextractor.py
@@ -38,18 +38,18 @@ RELINKING_WARNING = 'Relinking will always happen on source changes.'
 
 def dummy_syms(outfilename: str) -> None:
     """Just touch it so relinking happens always."""
-    with open(outfilename, 'w'):
+    with open(outfilename, 'w', encoding='utf-8'):
         pass
 
 def write_if_changed(text: str, outfilename: str) -> None:
     try:
-        with open(outfilename) as f:
+        with open(outfilename, encoding='utf-8') as f:
             oldtext = f.read()
         if text == oldtext:
             return
     except FileNotFoundError:
         pass
-    with open(outfilename, 'w') as f:
+    with open(outfilename, 'w', encoding='utf-8') as f:
         f.write(text)
 
 def print_tool_warning(tools: T.List[str], msg: str, stderr: T.Optional[str] = None) -> None:
@@ -61,7 +61,7 @@ def print_tool_warning(tools: T.List[str], msg: str, stderr: T.Optional[str] = N
         m += '\n' + stderr
     mlog.warning(m)
     # Write it out so we don't warn again
-    with open(TOOL_WARNING_FILE, 'w'):
+    with open(TOOL_WARNING_FILE, 'w', encoding='utf-8'):
         pass
 
 def get_tool(name: str) -> T.List[str]:
@@ -309,7 +309,7 @@ def gen_symbols(libfilename: str, impfilename: str, outfilename: str, cross_host
             mlog.warning('Symbol extracting has not been implemented for this '
                          'platform. ' + RELINKING_WARNING)
             # Write it out so we don't warn again
-            with open(TOOL_WARNING_FILE, 'w'):
+            with open(TOOL_WARNING_FILE, 'w', encoding='utf-8'):
                 pass
         dummy_syms(outfilename)
 

--- a/mesonbuild/scripts/uninstall.py
+++ b/mesonbuild/scripts/uninstall.py
@@ -20,7 +20,7 @@ logfile = 'meson-logs/install-log.txt'
 def do_uninstall(log: str) -> None:
     failures = 0
     successes = 0
-    for line in open(log):
+    for line in open(log, encoding='utf-8'):
         if line.startswith('#'):
             continue
         fname = line.strip()

--- a/mesonbuild/scripts/vcstagger.py
+++ b/mesonbuild/scripts/vcstagger.py
@@ -22,15 +22,15 @@ def config_vcs_tag(infile: str, outfile: str, fallback: str, source_dir: str, re
     except Exception:
         new_string = fallback
 
-    with open(infile, encoding='utf8') as f:
+    with open(infile, encoding='utf-8') as f:
         new_data = f.read().replace(replace_string, new_string)
     if os.path.exists(outfile):
-        with open(outfile, encoding='utf8') as f:
+        with open(outfile, encoding='utf-8') as f:
             needs_update = (f.read() != new_data)
     else:
         needs_update = True
     if needs_update:
-        with open(outfile, 'w', encoding='utf8') as f:
+        with open(outfile, 'w', encoding='utf-8') as f:
             f.write(new_data)
 
 

--- a/mesonbuild/templates/cpptemplates.py
+++ b/mesonbuild/templates/cpptemplates.py
@@ -149,11 +149,12 @@ class CppProject(SampleImpl):
     def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.cpp'
-        open(source_name, 'w').write(hello_cpp_template.format(project_name=self.name))
-        open('meson.build', 'w').write(hello_cpp_meson_template.format(project_name=self.name,
-                                                                       exe_name=lowercase_token,
-                                                                       source_name=source_name,
-                                                                       version=self.version))
+        open(source_name, 'w', encoding='utf-8').write(hello_cpp_template.format(project_name=self.name))
+        open('meson.build', 'w', encoding='utf-8').write(
+            hello_cpp_meson_template.format(project_name=self.name,
+                                            exe_name=lowercase_token,
+                                            source_name=source_name,
+                                            version=self.version))
 
     def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
@@ -178,7 +179,7 @@ class CppProject(SampleImpl):
                   'test_name': lowercase_token,
                   'version': self.version,
                   }
-        open(lib_hpp_name, 'w').write(lib_hpp_template.format(**kwargs))
-        open(lib_cpp_name, 'w').write(lib_cpp_template.format(**kwargs))
-        open(test_cpp_name, 'w').write(lib_cpp_test_template.format(**kwargs))
-        open('meson.build', 'w').write(lib_cpp_meson_template.format(**kwargs))
+        open(lib_hpp_name, 'w', encoding='utf-8').write(lib_hpp_template.format(**kwargs))
+        open(lib_cpp_name, 'w', encoding='utf-8').write(lib_cpp_template.format(**kwargs))
+        open(test_cpp_name, 'w', encoding='utf-8').write(lib_cpp_test_template.format(**kwargs))
+        open('meson.build', 'w', encoding='utf-8').write(lib_cpp_meson_template.format(**kwargs))

--- a/mesonbuild/templates/cstemplates.py
+++ b/mesonbuild/templates/cstemplates.py
@@ -100,12 +100,14 @@ class CSharpProject(SampleImpl):
         uppercase_token = lowercase_token.upper()
         class_name = uppercase_token[0] + lowercase_token[1:]
         source_name = uppercase_token[0] + lowercase_token[1:] + '.cs'
-        open(source_name, 'w').write(hello_cs_template.format(project_name=self.name,
-                                                              class_name=class_name))
-        open('meson.build', 'w').write(hello_cs_meson_template.format(project_name=self.name,
-                                                                      exe_name=self.name,
-                                                                      source_name=source_name,
-                                                                      version=self.version))
+        open(source_name, 'w', encoding='utf-8').write(
+            hello_cs_template.format(project_name=self.name,
+                                     class_name=class_name))
+        open('meson.build', 'w', encoding='utf-8').write(
+          hello_cs_meson_template.format(project_name=self.name,
+                                         exe_name=self.name,
+                                         source_name=source_name,
+                                         version=self.version))
 
     def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
@@ -127,6 +129,6 @@ class CSharpProject(SampleImpl):
                   'test_name': lowercase_token,
                   'version': self.version,
                   }
-        open(lib_cs_name, 'w').write(lib_cs_template.format(**kwargs))
-        open(test_cs_name, 'w').write(lib_cs_test_template.format(**kwargs))
-        open('meson.build', 'w').write(lib_cs_meson_template.format(**kwargs))
+        open(lib_cs_name, 'w', encoding='utf-8').write(lib_cs_template.format(**kwargs))
+        open(test_cs_name, 'w', encoding='utf-8').write(lib_cs_test_template.format(**kwargs))
+        open('meson.build', 'w', encoding='utf-8').write(lib_cs_meson_template.format(**kwargs))

--- a/mesonbuild/templates/ctemplates.py
+++ b/mesonbuild/templates/ctemplates.py
@@ -132,11 +132,12 @@ class CProject(SampleImpl):
     def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.c'
-        open(source_name, 'w').write(hello_c_template.format(project_name=self.name))
-        open('meson.build', 'w').write(hello_c_meson_template.format(project_name=self.name,
-                                                                     exe_name=lowercase_token,
-                                                                     source_name=source_name,
-                                                                     version=self.version))
+        open(source_name, 'w', encoding='utf-8').write(hello_c_template.format(project_name=self.name))
+        open('meson.build', 'w', encoding='utf-8').write(
+            hello_c_meson_template.format(project_name=self.name,
+                                          exe_name=lowercase_token,
+                                          source_name=source_name,
+                                          version=self.version))
 
     def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
@@ -159,7 +160,7 @@ class CProject(SampleImpl):
                   'test_name': lowercase_token,
                   'version': self.version,
                   }
-        open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
-        open(lib_c_name, 'w').write(lib_c_template.format(**kwargs))
-        open(test_c_name, 'w').write(lib_c_test_template.format(**kwargs))
-        open('meson.build', 'w').write(lib_c_meson_template.format(**kwargs))
+        open(lib_h_name, 'w', encoding='utf-8').write(lib_h_template.format(**kwargs))
+        open(lib_c_name, 'w', encoding='utf-8').write(lib_c_template.format(**kwargs))
+        open(test_c_name, 'w', encoding='utf-8').write(lib_c_test_template.format(**kwargs))
+        open('meson.build', 'w', encoding='utf-8').write(lib_c_meson_template.format(**kwargs))

--- a/mesonbuild/templates/cudatemplates.py
+++ b/mesonbuild/templates/cudatemplates.py
@@ -149,11 +149,12 @@ class CudaProject(SampleImpl):
     def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.cu'
-        open(source_name, 'w').write(hello_cuda_template.format(project_name=self.name))
-        open('meson.build', 'w').write(hello_cuda_meson_template.format(project_name=self.name,
-                                                                        exe_name=lowercase_token,
-                                                                        source_name=source_name,
-                                                                        version=self.version))
+        open(source_name, 'w', encoding='utf-8').write(hello_cuda_template.format(project_name=self.name))
+        open('meson.build', 'w', encoding='utf-8').write(
+            hello_cuda_meson_template.format(project_name=self.name,
+                                             exe_name=lowercase_token,
+                                             source_name=source_name,
+                                             version=self.version))
 
     def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
@@ -178,7 +179,7 @@ class CudaProject(SampleImpl):
                   'test_name': lowercase_token,
                   'version': self.version,
                   }
-        open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
-        open(lib_cuda_name, 'w').write(lib_cuda_template.format(**kwargs))
-        open(test_cuda_name, 'w').write(lib_cuda_test_template.format(**kwargs))
-        open('meson.build', 'w').write(lib_cuda_meson_template.format(**kwargs))
+        open(lib_h_name, 'w', encoding='utf-8').write(lib_h_template.format(**kwargs))
+        open(lib_cuda_name, 'w', encoding='utf-8').write(lib_cuda_template.format(**kwargs))
+        open(test_cuda_name, 'w', encoding='utf-8').write(lib_cuda_test_template.format(**kwargs))
+        open('meson.build', 'w', encoding='utf-8').write(lib_cuda_meson_template.format(**kwargs))

--- a/mesonbuild/templates/dlangtemplates.py
+++ b/mesonbuild/templates/dlangtemplates.py
@@ -110,11 +110,12 @@ class DlangProject(SampleImpl):
     def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.d'
-        open(source_name, 'w').write(hello_d_template.format(project_name=self.name))
-        open('meson.build', 'w').write(hello_d_meson_template.format(project_name=self.name,
-                                                                     exe_name=lowercase_token,
-                                                                     source_name=source_name,
-                                                                     version=self.version))
+        open(source_name, 'w', encoding='utf-8').write(hello_d_template.format(project_name=self.name))
+        open('meson.build', 'w', encoding='utf-8').write(
+            hello_d_meson_template.format(project_name=self.name,
+                                          exe_name=lowercase_token,
+                                          source_name=source_name,
+                                          version=self.version))
 
     def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
@@ -137,6 +138,6 @@ class DlangProject(SampleImpl):
                   'test_name': lowercase_token,
                   'version': self.version,
                   }
-        open(lib_d_name, 'w').write(lib_d_template.format(**kwargs))
-        open(test_d_name, 'w').write(lib_d_test_template.format(**kwargs))
-        open('meson.build', 'w').write(lib_d_meson_template.format(**kwargs))
+        open(lib_d_name, 'w', encoding='utf-8').write(lib_d_template.format(**kwargs))
+        open(test_d_name, 'w', encoding='utf-8').write(lib_d_test_template.format(**kwargs))
+        open('meson.build', 'w', encoding='utf-8').write(lib_d_meson_template.format(**kwargs))

--- a/mesonbuild/templates/fortrantemplates.py
+++ b/mesonbuild/templates/fortrantemplates.py
@@ -109,11 +109,12 @@ class FortranProject(SampleImpl):
     def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.f90'
-        open(source_name, 'w').write(hello_fortran_template.format(project_name=self.name))
-        open('meson.build', 'w').write(hello_fortran_meson_template.format(project_name=self.name,
-                                                                           exe_name=lowercase_token,
-                                                                           source_name=source_name,
-                                                                           version=self.version))
+        open(source_name, 'w', encoding='utf-8').write(hello_fortran_template.format(project_name=self.name))
+        open('meson.build', 'w', encoding='utf-8').write(
+            hello_fortran_meson_template.format(project_name=self.name,
+                                                exe_name=lowercase_token,
+                                                source_name=source_name,
+                                                version=self.version))
 
     def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
@@ -134,6 +135,6 @@ class FortranProject(SampleImpl):
                   'test_name': lowercase_token,
                   'version': self.version,
                   }
-        open(lib_fortran_name, 'w').write(lib_fortran_template.format(**kwargs))
-        open(test_fortran_name, 'w').write(lib_fortran_test_template.format(**kwargs))
-        open('meson.build', 'w').write(lib_fortran_meson_template.format(**kwargs))
+        open(lib_fortran_name, 'w', encoding='utf-8').write(lib_fortran_template.format(**kwargs))
+        open(test_fortran_name, 'w', encoding='utf-8').write(lib_fortran_test_template.format(**kwargs))
+        open('meson.build', 'w', encoding='utf-8').write(lib_fortran_meson_template.format(**kwargs))

--- a/mesonbuild/templates/javatemplates.py
+++ b/mesonbuild/templates/javatemplates.py
@@ -104,12 +104,14 @@ class JavaProject(SampleImpl):
         uppercase_token = lowercase_token.upper()
         class_name = uppercase_token[0] + lowercase_token[1:]
         source_name = uppercase_token[0] + lowercase_token[1:] + '.java'
-        open(source_name, 'w').write(hello_java_template.format(project_name=self.name,
-                                                                class_name=class_name))
-        open('meson.build', 'w').write(hello_java_meson_template.format(project_name=self.name,
-                                                                        exe_name=class_name,
-                                                                        source_name=source_name,
-                                                                        version=self.version))
+        open(source_name, 'w', encoding='utf-8').write(
+            hello_java_template.format(project_name=self.name,
+                                       class_name=class_name))
+        open('meson.build', 'w', encoding='utf-8').write(
+            hello_java_meson_template.format(project_name=self.name,
+                                             exe_name=class_name,
+                                             source_name=source_name,
+                                             version=self.version))
 
     def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
@@ -129,6 +131,6 @@ class JavaProject(SampleImpl):
                   'test_name': lowercase_token,
                   'version': self.version,
                   }
-        open(lib_java_name, 'w').write(lib_java_template.format(**kwargs))
-        open(test_java_name, 'w').write(lib_java_test_template.format(**kwargs))
-        open('meson.build', 'w').write(lib_java_meson_template.format(**kwargs))
+        open(lib_java_name, 'w', encoding='utf-8').write(lib_java_template.format(**kwargs))
+        open(test_java_name, 'w', encoding='utf-8').write(lib_java_test_template.format(**kwargs))
+        open('meson.build', 'w', encoding='utf-8').write(lib_java_meson_template.format(**kwargs))

--- a/mesonbuild/templates/mesontemplates.py
+++ b/mesonbuild/templates/mesontemplates.py
@@ -71,5 +71,5 @@ def create_meson_build(options: argparse.Namespace) -> None:
                                             sourcespec=sourcespec,
                                             depspec=depspec,
                                             default_options=formatted_default_options)
-    open('meson.build', 'w').write(content)
+    open('meson.build', 'w', encoding='utf-8').write(content)
     print('Generated meson.build file:\n\n' + content)

--- a/mesonbuild/templates/objcpptemplates.py
+++ b/mesonbuild/templates/objcpptemplates.py
@@ -132,11 +132,12 @@ class ObjCppProject(SampleImpl):
     def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.mm'
-        open(source_name, 'w').write(hello_objcpp_template.format(project_name=self.name))
-        open('meson.build', 'w').write(hello_objcpp_meson_template.format(project_name=self.name,
-                                                                          exe_name=lowercase_token,
-                                                                          source_name=source_name,
-                                                                          version=self.version))
+        open(source_name, 'w', encoding='utf-8').write(hello_objcpp_template.format(project_name=self.name))
+        open('meson.build', 'w', encoding='utf-8').write(
+            hello_objcpp_meson_template.format(project_name=self.name,
+                                               exe_name=lowercase_token,
+                                               source_name=source_name,
+                                               version=self.version))
 
     def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
@@ -159,8 +160,8 @@ class ObjCppProject(SampleImpl):
                   'test_name': lowercase_token,
                   'version': self.version,
                   }
-        open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
-        open(lib_objcpp_name, 'w').write(lib_objcpp_template.format(**kwargs))
-        open(test_objcpp_name, 'w').write(lib_objcpp_test_template.format(**kwargs))
-        open('meson.build', 'w').write(lib_objcpp_meson_template.format(**kwargs))
+        open(lib_h_name, 'w', encoding='utf-8').write(lib_h_template.format(**kwargs))
+        open(lib_objcpp_name, 'w', encoding='utf-8').write(lib_objcpp_template.format(**kwargs))
+        open(test_objcpp_name, 'w', encoding='utf-8').write(lib_objcpp_test_template.format(**kwargs))
+        open('meson.build', 'w', encoding='utf-8').write(lib_objcpp_meson_template.format(**kwargs))
 

--- a/mesonbuild/templates/objctemplates.py
+++ b/mesonbuild/templates/objctemplates.py
@@ -132,11 +132,12 @@ class ObjCProject(SampleImpl):
     def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.m'
-        open(source_name, 'w').write(hello_objc_template.format(project_name=self.name))
-        open('meson.build', 'w').write(hello_objc_meson_template.format(project_name=self.name,
-                                                                        exe_name=lowercase_token,
-                                                                        source_name=source_name,
-                                                                        version=self.version))
+        open(source_name, 'w', encoding='utf-8').write(hello_objc_template.format(project_name=self.name))
+        open('meson.build', 'w', encoding='utf-8').write(
+            hello_objc_meson_template.format(project_name=self.name,
+                                             exe_name=lowercase_token,
+                                             source_name=source_name,
+                                             version=self.version))
 
     def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
@@ -159,7 +160,7 @@ class ObjCProject(SampleImpl):
                   'test_name': lowercase_token,
                   'version': self.version,
                   }
-        open(lib_h_name, 'w').write(lib_h_template.format(**kwargs))
-        open(lib_objc_name, 'w').write(lib_objc_template.format(**kwargs))
-        open(test_objc_name, 'w').write(lib_objc_test_template.format(**kwargs))
-        open('meson.build', 'w').write(lib_objc_meson_template.format(**kwargs))
+        open(lib_h_name, 'w', encoding='utf-8').write(lib_h_template.format(**kwargs))
+        open(lib_objc_name, 'w', encoding='utf-8').write(lib_objc_template.format(**kwargs))
+        open(test_objc_name, 'w', encoding='utf-8').write(lib_objc_test_template.format(**kwargs))
+        open('meson.build', 'w', encoding='utf-8').write(lib_objc_meson_template.format(**kwargs))

--- a/mesonbuild/templates/rusttemplates.py
+++ b/mesonbuild/templates/rusttemplates.py
@@ -80,11 +80,12 @@ class RustProject(SampleImpl):
     def create_executable(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
         source_name = lowercase_token + '.rs'
-        open(source_name, 'w').write(hello_rust_template.format(project_name=self.name))
-        open('meson.build', 'w').write(hello_rust_meson_template.format(project_name=self.name,
-                                                                        exe_name=lowercase_token,
-                                                                        source_name=source_name,
-                                                                        version=self.version))
+        open(source_name, 'w', encoding='utf-8').write(hello_rust_template.format(project_name=self.name))
+        open('meson.build', 'w', encoding='utf-8').write(
+            hello_rust_meson_template.format(project_name=self.name,
+                                             exe_name=lowercase_token,
+                                             source_name=source_name,
+                                             version=self.version))
 
     def create_library(self) -> None:
         lowercase_token = re.sub(r'[^a-z0-9]', '_', self.name.lower())
@@ -107,6 +108,6 @@ class RustProject(SampleImpl):
                   'test_name': lowercase_token,
                   'version': self.version,
                   }
-        open(lib_rs_name, 'w').write(lib_rust_template.format(**kwargs))
-        open(test_rs_name, 'w').write(lib_rust_test_template.format(**kwargs))
-        open('meson.build', 'w').write(lib_rust_meson_template.format(**kwargs))
+        open(lib_rs_name, 'w', encoding='utf-8').write(lib_rust_template.format(**kwargs))
+        open(test_rs_name, 'w', encoding='utf-8').write(lib_rust_test_template.format(**kwargs))
+        open('meson.build', 'w', encoding='utf-8').write(lib_rust_meson_template.format(**kwargs))

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -291,7 +291,7 @@ class Resolver:
                 mlog.log('Using', mlog.bold(rel))
                 # Write a dummy wrap file in main project that redirect to the
                 # wrap we picked.
-                with open(main_fname, 'w') as f:
+                with open(main_fname, 'w', encoding='utf-8') as f:
                     f.write(textwrap.dedent('''\
                         [wrap-redirect]
                         filename = {}

--- a/run_cross_test.py
+++ b/run_cross_test.py
@@ -49,7 +49,7 @@ def main():
     options = parser.parse_args()
     cf_path = Path(options.cross_file)
     try:
-        data = json.loads(cf_path.read_text())
+        data = json.loads(cf_path.read_text(encoding='utf-8'))
         real_cf = cf_path.resolve().parent / data['file']
         assert real_cf.exists()
         env = os.environ.copy()

--- a/run_custom_lint.py
+++ b/run_custom_lint.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import typing as T
+
+root = Path(__file__).absolute().parent
+mesonbuild = root / 'mesonbuild'
+
+whitelist = ['mesonbuild/', 'run_', 'ci/', 'tools/', 'docs/']
+
+def check_missing_encoding(lines: T.List[str], path: str) -> int:
+    errors = 0
+    functions = ['read_text', 'write_text', 'open']
+    for num, line in enumerate(lines):
+        for func in functions:
+            l = line
+
+            # Skip ignored lines
+            if '[ignore encoding]' in l:
+                continue
+
+            # Do we have a match?
+            loc = l.find(func + '(')
+            if loc < 0:
+                continue
+            if loc > 0 and ord(l[loc-1].lower()) in [*range(ord('a'), ord('z')), *range(ord('0'), ord('9')), '_']:
+                continue
+            loc += len(func) + 1
+            # Some preprocessign to make parsing easier
+            l = l[loc:]
+            l = l.replace(' ', '')
+            l = l.replace('\t', '')
+            l = l.replace('\n', '')
+            l = l.replace('\'', '"')
+
+            # Parameter begin
+            args = ''
+            b_open = 1
+            while l:
+                c = l[0]
+                l = l[1:]
+                if c == ')':
+                    b_open -= 1
+                if b_open == 0:
+                    break
+                elif b_open == 1:
+                    args += c
+                if c == '(':
+                    b_open += 1
+
+            binary_modes = ['rb', 'br', 'r+b', 'wb', 'bw', 'ab', 'ba']
+            is_binary = any([f'"{x}"' in args for x in binary_modes])
+            if 'encoding=' not in args and not (func == 'open' and is_binary):
+                location = f'\x1b[33;1m[\x1b[0;1m{path}:{num+1}\x1b[33m]\x1b[0m'
+                #print(f'{location:<64}: \x1b[31;1mERROR:\x1b[0m Missing `encoding=` parameter in "{line.strip()}"')
+                print(f'{location:<72}: \x1b[31;1mERROR:\x1b[0m Missing `encoding=` parameter in `{func}` call')
+                errors += 1
+    return errors
+
+def main() -> int:
+    print('Scanning mesonbuild...')
+    errors = 0
+    for i in sorted(root.glob('**/*.py')):
+        raw = i.read_text(encoding='utf-8')
+        lines = raw.splitlines()
+        filename = i.relative_to(root).as_posix()
+
+        if not any([filename.startswith(x) for x in whitelist]):
+            continue
+
+        errors += check_missing_encoding(lines, filename)
+    print(f'Found {errors} errors while scanning mesonbuild')
+    return 0 if errors == 0 else 1
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/run_meson_command_tests.py
+++ b/run_meson_command_tests.py
@@ -165,7 +165,7 @@ class CommandTests(unittest.TestCase):
         builddir = str(self.tmpdir / 'build4')
         (bindir / 'meson').rename(bindir / 'meson.real')
         wrapper = (bindir / 'meson')
-        wrapper.open('w').write('#!/bin/sh\n\nmeson.real "$@"')
+        wrapper.write_text('#!/bin/sh\n\nmeson.real "$@"', encoding='utf-8')
         wrapper.chmod(0o755)
         meson_setup = [str(wrapper), 'setup']
         meson_command = meson_setup + self.meson_args

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -42,6 +42,7 @@ modules = [
     'mesonbuild/optinterpreter.py',
     'mesonbuild/programs.py',
 
+    'run_custom_lint.py',
     'run_mypy.py',
     'run_project_tests.py',
     'run_single_test.py',

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Work around some pathlib bugs...
+from mesonbuild import _pathlib
+import sys
+sys.modules['pathlib'] = _pathlib
+
 from concurrent.futures import ProcessPoolExecutor, CancelledError
 from enum import Enum
 from io import StringIO
@@ -29,7 +34,6 @@ import shlex
 import shutil
 import signal
 import subprocess
-import sys
 import tempfile
 import time
 import typing as T
@@ -518,7 +522,7 @@ def run_test_inprocess(testdir: str) -> T.Tuple[int, str, str, str]:
     try:
         returncode_test = mtest.run_with_args(['--no-rebuild'])
         if test_log_fname.exists():
-            test_log = test_log_fname.open(errors='ignore').read()
+            test_log = test_log_fname.open(encoding='utf-8', errors='ignore').read()
         else:
             test_log = ''
         returncode_benchmark = mtest.run_with_args(['--no-rebuild', '--benchmark', '--logbase', 'benchmarklog'])
@@ -732,7 +736,7 @@ def load_test_json(t: TestDef, stdout_mandatory: bool) -> T.List[TestDef]:
     test_def = {}
     test_def_file = t.path / 'test.json'
     if test_def_file.is_file():
-        test_def = json.loads(test_def_file.read_text())
+        test_def = json.loads(test_def_file.read_text(encoding='utf-8'))
 
     # Handle additional environment variables
     env = {}  # type: T.Dict[str, str]
@@ -1018,18 +1022,17 @@ def skip_csharp(backend: Backend) -> bool:
 # on all compilation attempts.
 
 def has_broken_rustc() -> bool:
-    dirname = 'brokenrusttest'
-    if os.path.exists(dirname):
-        mesonlib.windows_proof_rmtree(dirname)
-    os.mkdir(dirname)
-    open(dirname + '/sanity.rs', 'w').write('''fn main() {
-}
-''')
+    dirname = Path('brokenrusttest')
+    if dirname.exists():
+        mesonlib.windows_proof_rmtree(dirname.as_posix())
+    dirname.mkdir()
+    sanity_file = dirname / 'sanity.rs'
+    sanity_file.write_text('fn main() {\n}\n', encoding='utf-8')
     pc = subprocess.run(['rustc', '-o', 'sanity.exe', 'sanity.rs'],
-                        cwd=dirname,
+                        cwd=dirname.as_posix(),
                         stdout = subprocess.DEVNULL,
                         stderr = subprocess.DEVNULL)
-    mesonlib.windows_proof_rmtree(dirname)
+    mesonlib.windows_proof_rmtree(dirname.as_posix())
     return pc.returncode != 0
 
 def should_skip_rust(backend: Backend) -> bool:

--- a/run_tests.py
+++ b/run_tests.py
@@ -14,9 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Work around some pathlib bugs...
+from mesonbuild import _pathlib
+import sys
+sys.modules['pathlib'] = _pathlib
+
 import collections
 import os
-import sys
 import time
 import shutil
 import subprocess

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Work around some pathlib bugs...
+from mesonbuild import _pathlib
+import sys
+sys.modules['pathlib'] = _pathlib
+
 import time
 import stat
 import subprocess
@@ -22,7 +27,6 @@ import tempfile
 import textwrap
 import os
 import shutil
-import sys
 import unittest
 import platform
 import pickle
@@ -805,16 +809,9 @@ class InternalTests(unittest.TestCase):
         if platform != 'openbsd':
             return
         with tempfile.TemporaryDirectory() as tmpdir:
-            with open(os.path.join(tmpdir, 'libfoo.so.6.0'), 'w') as f:
-                f.write('')
-            with open(os.path.join(tmpdir, 'libfoo.so.5.0'), 'w') as f:
-                f.write('')
-            with open(os.path.join(tmpdir, 'libfoo.so.54.0'), 'w') as f:
-                f.write('')
-            with open(os.path.join(tmpdir, 'libfoo.so.66a.0b'), 'w') as f:
-                f.write('')
-            with open(os.path.join(tmpdir, 'libfoo.so.70.0.so.1'), 'w') as f:
-                f.write('')
+            for i in ['libfoo.so.6.0', 'libfoo.so.5.0', 'libfoo.so.54.0', 'libfoo.so.66a.0b', 'libfoo.so.70.0.so.1']:
+                libpath = Path(tmpdir) / i
+                libpath.write_text('', encoding='utf-8')
             found = cc._find_library_real('foo', env, [tmpdir], '', LibType.PREFER_SHARED)
             self.assertEqual(os.path.basename(found[0]), 'libfoo.so.54.0')
 
@@ -872,11 +869,11 @@ class InternalTests(unittest.TestCase):
         '''
         def create_static_lib(name):
             if not is_osx():
-                name.open('w').close()
+                name.open('w', encoding='utf-8').close()
                 return
             src = name.with_suffix('.c')
             out = name.with_suffix('.o')
-            with src.open('w') as f:
+            with src.open('w', encoding='utf-8') as f:
                 f.write('int meson_foobar (void) { return 0; }')
             subprocess.check_call(['clang', '-c', str(src), '-o', str(out)])
             subprocess.check_call(['ar', 'csr', str(name), str(out)])
@@ -1080,7 +1077,7 @@ class InternalTests(unittest.TestCase):
         else:
             self.assertIn('VCINSTALLDIR', os.environ)
             # See https://devblogs.microsoft.com/cppblog/finding-the-visual-c-compiler-tools-in-visual-studio-2017/
-            vctools_ver = (Path(os.environ['VCINSTALLDIR']) / 'Auxiliary' / 'Build' / 'Microsoft.VCToolsVersion.default.txt').read_text()
+            vctools_ver = (Path(os.environ['VCINSTALLDIR']) / 'Auxiliary' / 'Build' / 'Microsoft.VCToolsVersion.default.txt').read_text(encoding='utf-8')
         self.assertTrue(vctools_ver.startswith(toolset_ver),
                         msg=f'{vctools_ver!r} does not start with {toolset_ver!r}')
 
@@ -1288,16 +1285,14 @@ class InternalTests(unittest.TestCase):
                 raise
             raise unittest.SkipTest('Python jsonschema module not found.')
 
-        with Path('data/test.schema.json').open() as f:
-            schema = json.load(f)
+        schema = json.loads(Path('data/test.schema.json').read_text(encoding='utf-8'))
 
         errors = []  # type: T.Tuple[str, Exception]
         for p in Path('test cases').glob('**/test.json'):
-            with p.open() as f:
-                try:
-                    validate(json.load(f), schema=schema)
-                except ValidationError as e:
-                    errors.append((p.resolve(), e))
+            try:
+                validate(json.loads(p.read_text(encoding='utf-8')), schema=schema)
+            except ValidationError as e:
+                errors.append((p.resolve(), e))
 
         for f, e in errors:
             print(f'Failed to validate: "{f}"')
@@ -1727,7 +1722,7 @@ class DataTests(unittest.TestCase):
                 continue
             if f.suffix == '.md':
                 in_code_block = False
-                with f.open() as snippet:
+                with f.open(encoding='utf-8') as snippet:
                     for line in snippet:
                         if line.startswith('    '):
                             continue
@@ -1891,7 +1886,7 @@ class DataTests(unittest.TestCase):
         '''
         env = get_fake_env()
         interp = Interpreter(FakeBuild(env), mock=True)
-        with open('data/syntax-highlighting/vim/syntax/meson.vim') as f:
+        with open('data/syntax-highlighting/vim/syntax/meson.vim', encoding='utf-8') as f:
             res = re.search(r'syn keyword mesonBuiltin(\s+\\\s\w+)+', f.read(), re.MULTILINE)
             defined = set([a.strip() for a in res.group().split('\\')][1:])
             self.assertEqual(defined, set(chain(interp.funcs.keys(), interp.builtin.keys())))
@@ -2159,7 +2154,7 @@ class BasePlatformTests(unittest.TestCase):
         if self.backend is not Backend.ninja:
             raise unittest.SkipTest(f'Compiler db not available with {self.backend.name} backend')
         try:
-            with open(os.path.join(self.builddir, 'compile_commands.json')) as ifile:
+            with open(os.path.join(self.builddir, 'compile_commands.json'), encoding='utf-8') as ifile:
                 contents = json.load(ifile)
         except FileNotFoundError:
             raise unittest.SkipTest('Compiler db not found')
@@ -2178,7 +2173,7 @@ class BasePlatformTests(unittest.TestCase):
         return contents
 
     def get_meson_log(self):
-        with open(os.path.join(self.builddir, 'meson-logs', 'meson-log.txt')) as f:
+        with open(os.path.join(self.builddir, 'meson-logs', 'meson-log.txt'), encoding='utf-8') as f:
             return f.readlines()
 
     def get_meson_log_compiler_checks(self):
@@ -2722,7 +2717,7 @@ class AllPlatformTests(BasePlatformTests):
             expected[name] = 0
         def read_logs():
             # Find logged files and directories
-            with Path(self.builddir, 'meson-logs', 'install-log.txt').open() as f:
+            with Path(self.builddir, 'meson-logs', 'install-log.txt').open(encoding='utf-8') as f:
                 return list(map(lambda l: Path(l.strip()),
                                   filter(lambda l: not l.startswith('#'),
                                          f.readlines())))
@@ -3406,7 +3401,7 @@ class AllPlatformTests(BasePlatformTests):
 
         def hg_init(project_dir):
             subprocess.check_call(['hg', 'init'], cwd=project_dir)
-            with open(os.path.join(project_dir, '.hg', 'hgrc'), 'w') as f:
+            with open(os.path.join(project_dir, '.hg', 'hgrc'), 'w', encoding='utf-8') as f:
                 print('[ui]', file=f)
                 print('username=Author Person <teh_coderz@example.com>', file=f)
             subprocess.check_call(['hg', 'add', 'meson.build', 'distexe.c'], cwd=project_dir)
@@ -3447,7 +3442,7 @@ class AllPlatformTests(BasePlatformTests):
     def create_dummy_subproject(self, project_dir, name):
         path = os.path.join(project_dir, 'subprojects', name)
         os.makedirs(path)
-        with open(os.path.join(path, 'meson.build'), 'w') as ofile:
+        with open(os.path.join(path, 'meson.build'), 'w', encoding='utf-8') as ofile:
             ofile.write(f"project('{name}', version: '1.0')")
         return path
 
@@ -3455,7 +3450,7 @@ class AllPlatformTests(BasePlatformTests):
         # Create this on the fly because having rogue .git directories inside
         # the source tree leads to all kinds of trouble.
         with tempfile.TemporaryDirectory() as project_dir:
-            with open(os.path.join(project_dir, 'meson.build'), 'w') as ofile:
+            with open(os.path.join(project_dir, 'meson.build'), 'w', encoding='utf-8') as ofile:
                 ofile.write(textwrap.dedent('''\
                     project('disttest', 'c', version : '1.4.3')
                     e = executable('distexe', 'distexe.c')
@@ -3464,7 +3459,7 @@ class AllPlatformTests(BasePlatformTests):
                     subproject('tarballsub', required : false)
                     subproject('samerepo', required : false)
                     '''))
-            with open(os.path.join(project_dir, 'distexe.c'), 'w') as ofile:
+            with open(os.path.join(project_dir, 'distexe.c'), 'w', encoding='utf-8') as ofile:
                 ofile.write(textwrap.dedent('''\
                     #include<stdio.h>
 
@@ -3554,7 +3549,7 @@ class AllPlatformTests(BasePlatformTests):
                 xz_checksumfile = xz_distfile + '.sha256sum'
                 self.assertPathExists(xz_distfile)
                 self.assertPathExists(xz_checksumfile)
-                tar = tarfile.open(xz_distfile, "r:xz")
+                tar = tarfile.open(xz_distfile, "r:xz")  # [ignore encoding]
                 self.assertEqual(sorted(['samerepo-1.0',
                                          'samerepo-1.0/meson.build']),
                                  sorted([i.name for i in tar]))
@@ -4088,12 +4083,12 @@ class AllPlatformTests(BasePlatformTests):
             # test directory with existing code file
             if lang in {'c', 'cpp', 'd'}:
                 with tempfile.TemporaryDirectory() as tmpdir:
-                    with open(os.path.join(tmpdir, 'foo.' + lang), 'w') as f:
+                    with open(os.path.join(tmpdir, 'foo.' + lang), 'w', encoding='utf-8') as f:
                         f.write('int main(void) {}')
                     self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
             elif lang in {'java'}:
                 with tempfile.TemporaryDirectory() as tmpdir:
-                    with open(os.path.join(tmpdir, 'Foo.' + lang), 'w') as f:
+                    with open(os.path.join(tmpdir, 'Foo.' + lang), 'w', encoding='utf-8') as f:
                         f.write('public class Foo { public static void main() {} }')
                     self._run(self.meson_command + ['init', '-b'], workdir=tmpdir)
 
@@ -4485,7 +4480,7 @@ class AllPlatformTests(BasePlatformTests):
         with tempfile.TemporaryDirectory() as containing:
             with tempfile.TemporaryDirectory(dir=containing) as srcdir:
                 mfile = os.path.join(srcdir, 'meson.build')
-                of = open(mfile, 'w')
+                of = open(mfile, 'w', encoding='utf-8')
                 of.write("project('foobar', 'c')\n")
                 of.close()
                 pc = subprocess.run(self.setup_command,
@@ -4610,7 +4605,7 @@ class AllPlatformTests(BasePlatformTests):
 
         # Create a file in builddir and verify wipe command removes it
         filename = os.path.join(self.builddir, 'something')
-        open(filename, 'w').close()
+        open(filename, 'w', encoding='utf-8').close()
         self.assertTrue(os.path.exists(filename))
         out = self.init(testdir, extra_args=['--wipe', '-Dopt4=val4'])
         self.assertFalse(os.path.exists(filename))
@@ -4767,13 +4762,13 @@ class AllPlatformTests(BasePlatformTests):
             shutil.copyfile(badfile, testfile)
             shutil.copyfile(badheader, testheader)
             self.init(testdir)
-            self.assertNotEqual(Path(testfile).read_text(),
-                                Path(goodfile).read_text())
-            self.assertNotEqual(Path(testheader).read_text(),
-                                Path(goodheader).read_text())
+            self.assertNotEqual(Path(testfile).read_text(encoding='utf-8'),
+                                Path(goodfile).read_text(encoding='utf-8'))
+            self.assertNotEqual(Path(testheader).read_text(encoding='utf-8'),
+                                Path(goodheader).read_text(encoding='utf-8'))
             self.run_target('clang-format')
-            self.assertEqual(Path(testheader).read_text(),
-                             Path(goodheader).read_text())
+            self.assertEqual(Path(testheader).read_text(encoding='utf-8'),
+                             Path(goodheader).read_text(encoding='utf-8'))
         finally:
             if os.path.exists(testfile):
                 os.unlink(testfile)
@@ -4833,7 +4828,7 @@ class AllPlatformTests(BasePlatformTests):
         infodir = os.path.join(self.builddir, 'meson-info')
         self.assertPathExists(infodir)
 
-        with open(os.path.join(infodir, 'intro-targets.json')) as fp:
+        with open(os.path.join(infodir, 'intro-targets.json'), encoding='utf-8') as fp:
             targets = json.load(fp)
 
         for i in targets:
@@ -4942,7 +4937,7 @@ class AllPlatformTests(BasePlatformTests):
         for i in root_keylist:
             curr = os.path.join(infodir, 'intro-{}.json'.format(i[0]))
             self.assertPathExists(curr)
-            with open(curr) as fp:
+            with open(curr, encoding='utf-8') as fp:
                 res[i[0]] = json.load(fp)
 
         assertKeyTypes(root_keylist, res)
@@ -5064,7 +5059,7 @@ class AllPlatformTests(BasePlatformTests):
         for i in root_keylist:
             curr = os.path.join(infodir, f'intro-{i}.json')
             self.assertPathExists(curr)
-            with open(curr) as fp:
+            with open(curr, encoding='utf-8') as fp:
                 res_file[i] = json.load(fp)
 
         self.assertEqual(res_all, res_file)
@@ -5074,7 +5069,7 @@ class AllPlatformTests(BasePlatformTests):
         introfile = os.path.join(self.builddir, 'meson-info', 'meson-info.json')
         self.init(testdir)
         self.assertPathExists(introfile)
-        with open(introfile) as fp:
+        with open(introfile, encoding='utf-8') as fp:
             res1 = json.load(fp)
 
         for i in ['meson_version', 'directories', 'introspection', 'build_files_updated', 'error']:
@@ -5088,7 +5083,7 @@ class AllPlatformTests(BasePlatformTests):
         introfile = os.path.join(self.builddir, 'meson-info', 'intro-buildoptions.json')
         self.init(testdir)
         self.assertPathExists(introfile)
-        with open(introfile) as fp:
+        with open(introfile, encoding='utf-8') as fp:
             res1 = json.load(fp)
 
         for i in res1:
@@ -5106,7 +5101,7 @@ class AllPlatformTests(BasePlatformTests):
         self.setconf('-Dcpp_std=c++14')
         self.setconf('-Dbuildtype=release')
 
-        with open(introfile) as fp:
+        with open(introfile, encoding='utf-8') as fp:
             res2 = json.load(fp)
 
         self.assertListEqual(res1, res2)
@@ -5117,7 +5112,7 @@ class AllPlatformTests(BasePlatformTests):
         introfile = os.path.join(self.builddir, 'meson-info', 'intro-targets.json')
         self.init(testdir)
         self.assertPathExists(introfile)
-        with open(introfile) as fp:
+        with open(introfile, encoding='utf-8') as fp:
             res_wb = json.load(fp)
 
         res_nb = self.introspect_directory(testfile, ['--targets'] + self.meson_args)
@@ -5659,13 +5654,13 @@ class AllPlatformTests(BasePlatformTests):
 
     def test_cross_file_constants(self):
         with temp_filename() as crossfile1, temp_filename() as crossfile2:
-            with open(crossfile1, 'w') as f:
+            with open(crossfile1, 'w', encoding='utf-8') as f:
                 f.write(textwrap.dedent(
                     '''
                     [constants]
                     compiler = 'gcc'
                     '''))
-            with open(crossfile2, 'w') as f:
+            with open(crossfile2, 'w', encoding='utf-8') as f:
                 f.write(textwrap.dedent(
                     '''
                     [constants]
@@ -5695,7 +5690,7 @@ class AllPlatformTests(BasePlatformTests):
             upstream = os.path.join(srcdir, 'subprojects', 'wrap_git_upstream')
             upstream_uri = Path(upstream).as_uri()
             _git_init(upstream)
-            with open(os.path.join(srcdir, 'subprojects', 'wrap_git.wrap'), 'w') as f:
+            with open(os.path.join(srcdir, 'subprojects', 'wrap_git.wrap'), 'w', encoding='utf-8') as f:
                 f.write(textwrap.dedent('''
                   [wrap-git]
                   url = {}
@@ -5719,7 +5714,7 @@ class AllPlatformTests(BasePlatformTests):
     def test_nostdlib(self):
         testdir = os.path.join(self.unit_test_dir, '78 nostdlib')
         machinefile = os.path.join(self.builddir, 'machine.txt')
-        with open(machinefile, 'w') as f:
+        with open(machinefile, 'w', encoding='utf-8') as f:
             f.write(textwrap.dedent('''
                 [properties]
                 c_stdlib = 'mylibc'
@@ -5748,7 +5743,7 @@ class AllPlatformTests(BasePlatformTests):
         os.makedirs(os.path.dirname(real_wrap))
 
         # Invalid redirect, filename must have .wrap extension
-        with open(redirect_wrap, 'w') as f:
+        with open(redirect_wrap, 'w', encoding='utf-8') as f:
             f.write(textwrap.dedent('''
                 [wrap-redirect]
                 filename = foo/subprojects/real.wrapper
@@ -5757,7 +5752,7 @@ class AllPlatformTests(BasePlatformTests):
             PackageDefinition(redirect_wrap)
 
         # Invalid redirect, filename cannot be in parent directory
-        with open(redirect_wrap, 'w') as f:
+        with open(redirect_wrap, 'w', encoding='utf-8') as f:
             f.write(textwrap.dedent('''
                 [wrap-redirect]
                 filename = ../real.wrap
@@ -5766,7 +5761,7 @@ class AllPlatformTests(BasePlatformTests):
             PackageDefinition(redirect_wrap)
 
         # Invalid redirect, filename must be in foo/subprojects/real.wrap
-        with open(redirect_wrap, 'w') as f:
+        with open(redirect_wrap, 'w', encoding='utf-8') as f:
             f.write(textwrap.dedent('''
                 [wrap-redirect]
                 filename = foo/real.wrap
@@ -5775,12 +5770,12 @@ class AllPlatformTests(BasePlatformTests):
             wrap = PackageDefinition(redirect_wrap)
 
         # Correct redirect
-        with open(redirect_wrap, 'w') as f:
+        with open(redirect_wrap, 'w', encoding='utf-8') as f:
             f.write(textwrap.dedent('''
                 [wrap-redirect]
                 filename = foo/subprojects/real.wrap
                 '''))
-        with open(real_wrap, 'w') as f:
+        with open(real_wrap, 'w', encoding='utf-8') as f:
             f.write(textwrap.dedent('''
                 [wrap-git]
                 url = http://invalid
@@ -5797,7 +5792,7 @@ class AllPlatformTests(BasePlatformTests):
         cmakefile = Path(testdir) / 'subprojects' / 'sub2' / 'CMakeLists.txt'
         self.init(testdir)
         self.build()
-        with cmakefile.open('a') as f:
+        with cmakefile.open('a', encoding='utf-8') as f:
             os.utime(str(cmakefile))
         self.assertReconfiguredBuildIsNoop()
 
@@ -5987,7 +5982,7 @@ class FailureTests(BasePlatformTests):
         '''
         if langs is None:
             langs = []
-        with open(self.mbuild, 'w') as f:
+        with open(self.mbuild, 'w', encoding='utf-8') as f:
             f.write("project('failure test', 'c', 'cpp'")
             if meson_version:
                 f.write(f", meson_version: '{meson_version}'")
@@ -5996,7 +5991,7 @@ class FailureTests(BasePlatformTests):
                 f.write(f"add_languages('{lang}', required : false)\n")
             f.write(contents)
         if options is not None:
-            with open(self.moptions, 'w') as f:
+            with open(self.moptions, 'w', encoding='utf-8') as f:
                 f.write(options)
         o = {'MESON_FORCE_BACKTRACE': '1'}
         if override_envvars is None:
@@ -6013,7 +6008,7 @@ class FailureTests(BasePlatformTests):
     def obtainMesonOutput(self, contents, match, extra_args, langs, meson_version=None):
         if langs is None:
             langs = []
-        with open(self.mbuild, 'w') as f:
+        with open(self.mbuild, 'w', encoding='utf-8') as f:
             f.write("project('output test', 'c', 'cpp'")
             if meson_version:
                 f.write(f", meson_version: '{meson_version}'")
@@ -6834,7 +6829,7 @@ class LinuxlikeTests(BasePlatformTests):
         }
         if is_osx() or is_haiku():
             expected['Cflags'] = expected['Cflags'].replace('-pthread ', '')
-        with open(os.path.join(privatedir2, 'dependency-test.pc')) as f:
+        with open(os.path.join(privatedir2, 'dependency-test.pc'), encoding='utf-8') as f:
             matched_lines = 0
             for line in f:
                 parts = line.split(':', 1)
@@ -6865,16 +6860,16 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertEqual(out, ['-llibmain2', '-llibinternal'])
 
         # See common/44 pkgconfig-gen/meson.build for description of the case this test
-        with open(os.path.join(privatedir1, 'simple2.pc')) as f:
+        with open(os.path.join(privatedir1, 'simple2.pc'), encoding='utf-8') as f:
             content = f.read()
             self.assertIn('Libs: -L${libdir} -lsimple2 -lsimple1', content)
             self.assertIn('Libs.private: -lz', content)
 
-        with open(os.path.join(privatedir1, 'simple3.pc')) as f:
+        with open(os.path.join(privatedir1, 'simple3.pc'), encoding='utf-8') as f:
             content = f.read()
             self.assertEqual(1, content.count('-lsimple3'))
 
-        with open(os.path.join(privatedir1, 'simple5.pc')) as f:
+        with open(os.path.join(privatedir1, 'simple5.pc'), encoding='utf-8') as f:
             content = f.read()
             self.assertNotIn('-lstat2', content)
 
@@ -6897,7 +6892,7 @@ class LinuxlikeTests(BasePlatformTests):
     def test_pkg_unfound(self):
         testdir = os.path.join(self.unit_test_dir, '23 unfound pkgconfig')
         self.init(testdir)
-        with open(os.path.join(self.privatedir, 'somename.pc')) as f:
+        with open(os.path.join(self.privatedir, 'somename.pc'), encoding='utf-8') as f:
             pcfile = f.read()
         self.assertFalse('blub_blob_blib' in pcfile)
 
@@ -7417,7 +7412,7 @@ class LinuxlikeTests(BasePlatformTests):
                           ('-L/me/fourth', '-lfoo4'),
                           ('-lfoo3', '-lfoo4'),
                           ]
-        with open(os.path.join(self.builddir, 'build.ninja')) as ifile:
+        with open(os.path.join(self.builddir, 'build.ninja'), encoding='utf-8') as ifile:
             for line in ifile:
                 if expected_order[0][0] in line:
                     for first, second in expected_order:
@@ -7829,7 +7824,7 @@ class LinuxlikeTests(BasePlatformTests):
         '''
         testdir = os.path.join(self.unit_test_dir, '43 dep order')
         self.init(testdir)
-        with open(os.path.join(self.builddir, 'build.ninja')) as bfile:
+        with open(os.path.join(self.builddir, 'build.ninja'), encoding='utf-8') as bfile:
             for line in bfile:
                 if 'build myexe:' in line or 'build myexe.exe:' in line:
                     self.assertIn('liblib1.a liblib2.a', line)
@@ -7848,7 +7843,7 @@ class LinuxlikeTests(BasePlatformTests):
             rpathre = re.compile(r'-rpath,.*/subprojects/sub1.*-rpath,.*/subprojects/sub2')
         else:
             rpathre = re.compile(r'-rpath,\$\$ORIGIN/subprojects/sub1:\$\$ORIGIN/subprojects/sub2')
-        with open(os.path.join(self.builddir, 'build.ninja')) as bfile:
+        with open(os.path.join(self.builddir, 'build.ninja'), encoding='utf-8') as bfile:
             for line in bfile:
                 if '-rpath' in line:
                     self.assertRegex(line, rpathre)
@@ -7861,7 +7856,7 @@ class LinuxlikeTests(BasePlatformTests):
         '''
         testdir = os.path.join(self.src_root, 'test cases', 'native', '9 override with exe')
         self.init(testdir)
-        with open(os.path.join(self.builddir, 'build.ninja')) as bfile:
+        with open(os.path.join(self.builddir, 'build.ninja'), encoding='utf-8') as bfile:
             for line in bfile:
                 if 'main1.c:' in line or 'main2.c:' in line:
                     self.assertIn('| subprojects/sub/foobar', line)
@@ -8202,7 +8197,7 @@ class LinuxlikeTests(BasePlatformTests):
             patch_filename = foo-patch.tar.xz
             patch_hash = {}
             """.format(source_filename, source_hash, patch_filename, patch_hash))
-        with open(wrap_filename, 'w') as f:
+        with open(wrap_filename, 'w', encoding='utf-8') as f:
             f.write(wrap)
         self.init(testdir)
         self.build()
@@ -8230,7 +8225,7 @@ class LinuxlikeTests(BasePlatformTests):
         # the 2nd dependency() to lookup on system.
         self.new_builddir()
         with tempfile.TemporaryDirectory() as d:
-            with open(os.path.join(d, 'meson.build'), 'w') as f:
+            with open(os.path.join(d, 'meson.build'), 'w', encoding='utf-8') as f:
                 f.write(textwrap.dedent('''\
                     project('test')
                     dependency('notfound', fallback: 'broken', required: false)
@@ -8241,10 +8236,10 @@ class LinuxlikeTests(BasePlatformTests):
     def test_as_link_whole(self):
         testdir = os.path.join(self.unit_test_dir, '77 as link whole')
         self.init(testdir)
-        with open(os.path.join(self.privatedir, 'bar1.pc')) as f:
+        with open(os.path.join(self.privatedir, 'bar1.pc'), encoding='utf-8') as f:
             content = f.read()
             self.assertIn('-lfoo', content)
-        with open(os.path.join(self.privatedir, 'bar2.pc')) as f:
+        with open(os.path.join(self.privatedir, 'bar2.pc'), encoding='utf-8') as f:
             content = f.read()
             self.assertNotIn('-lfoo', content)
 
@@ -8844,7 +8839,7 @@ class NativeFileTests(BasePlatformTests):
         """
         filename = os.path.join(self.builddir, f'generated{self.current_config}.config')
         self.current_config += 1
-        with open(filename, 'wt') as f:
+        with open(filename, 'wt', encoding='utf-8') as f:
             for section, entries in values.items():
                 f.write(f'[{section}]\n')
                 for k, v in entries.items():
@@ -8866,7 +8861,7 @@ class NativeFileTests(BasePlatformTests):
         else:
             chbang = '#!/usr/bin/env python3'
 
-        with open(filename, 'wt') as f:
+        with open(filename, 'wt', encoding='utf-8') as f:
             f.write(textwrap.dedent('''\
                 {}
                 import argparse
@@ -8904,7 +8899,7 @@ class NativeFileTests(BasePlatformTests):
         # invoke python files itself, so instead we generate a .bat file, which
         # invokes our python wrapper
         batfile = os.path.join(self.builddir, f'binary_wrapper{self.current_wrapper}.bat')
-        with open(batfile, 'wt') as f:
+        with open(batfile, 'wt', encoding='utf-8') as f:
             f.write(fr'@{sys.executable} {filename} %*')
         return batfile
 
@@ -8938,7 +8933,7 @@ class NativeFileTests(BasePlatformTests):
             wrapper = self.helper_create_binary_wrapper('bash', d, version='12345')
 
             def filler():
-                with open(fifo, 'w') as f:
+                with open(fifo, 'w', encoding='utf-8') as f:
                     f.write('[binaries]\n')
                     f.write(f"bash = '{wrapper}'\n")
 
@@ -9423,7 +9418,7 @@ class CrossFileTests(BasePlatformTests):
         testdir = os.path.join(self.unit_test_dir, '71 cross test passed')
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / 'crossfile'
-            with p.open('wt') as f:
+            with p.open('wt', encoding='utf-8') as f:
                 f.write(self._cross_file_generator(needs_exe_wrapper=True))
             self.init(testdir, extra_args=['--cross-file=' + str(p)])
             out = self.run_target('test')
@@ -9433,7 +9428,7 @@ class CrossFileTests(BasePlatformTests):
         testdir = os.path.join(self.unit_test_dir, '71 cross test passed')
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / 'crossfile'
-            with p.open('wt') as f:
+            with p.open('wt', encoding='utf-8') as f:
                 f.write(self._cross_file_generator(needs_exe_wrapper=False))
             self.init(testdir, extra_args=['--cross-file=' + str(p)])
             out = self.run_target('test')
@@ -9443,11 +9438,11 @@ class CrossFileTests(BasePlatformTests):
         testdir = os.path.join(self.unit_test_dir, '71 cross test passed')
         with tempfile.TemporaryDirectory() as d:
             s = Path(d) / 'wrapper.py'
-            with s.open('wt') as f:
+            with s.open('wt', encoding='utf-8') as f:
                 f.write(self._stub_exe_wrapper())
             s.chmod(0o774)
             p = Path(d) / 'crossfile'
-            with p.open('wt') as f:
+            with p.open('wt', encoding='utf-8') as f:
                 f.write(self._cross_file_generator(
                     needs_exe_wrapper=True,
                     exe_wrapper=[str(s)]))
@@ -9460,7 +9455,7 @@ class CrossFileTests(BasePlatformTests):
         testdir = os.path.join(self.unit_test_dir, '71 cross test passed')
         with tempfile.TemporaryDirectory() as d:
             p = Path(d) / 'crossfile'
-            with p.open('wt') as f:
+            with p.open('wt', encoding='utf-8') as f:
                 f.write(self._cross_file_generator(needs_exe_wrapper=True))
 
             self.init(testdir, extra_args=['--cross-file=' + str(p)])
@@ -9518,7 +9513,7 @@ class CrossFileTests(BasePlatformTests):
         """
         filename = os.path.join(self.builddir, f'generated{self.current_config}.config')
         self.current_config += 1
-        with open(filename, 'wt') as f:
+        with open(filename, 'wt', encoding='utf-8') as f:
             for section, entries in values.items():
                 f.write(f'[{section}]\n')
                 for k, v in entries.items():
@@ -9992,7 +9987,7 @@ class SubprojectsCommandTests(BasePlatformTests):
 
     def _create_project(self, path, project_name='dummy'):
         os.makedirs(str(path), exist_ok=True)
-        with open(str(path / 'meson.build'), 'w') as f:
+        with open(str(path / 'meson.build'), 'w', encoding='utf-8') as f:
             f.write(f"project('{project_name}')")
 
     def _git(self, cmd, workdir):
@@ -10054,7 +10049,7 @@ class SubprojectsCommandTests(BasePlatformTests):
 
     def _wrap_create_git(self, name, revision='master'):
         path = self.root_dir / name
-        with open(str((self.subprojects_dir / name).with_suffix('.wrap')), 'w') as f:
+        with open(str((self.subprojects_dir / name).with_suffix('.wrap')), 'w', encoding='utf-8') as f:
             f.write(textwrap.dedent(
                 '''
                 [wrap-git]
@@ -10064,7 +10059,7 @@ class SubprojectsCommandTests(BasePlatformTests):
 
     def _wrap_create_file(self, name, tarball='dummy.tar.gz'):
         path = self.root_dir / tarball
-        with open(str((self.subprojects_dir / name).with_suffix('.wrap')), 'w') as f:
+        with open(str((self.subprojects_dir / name).with_suffix('.wrap')), 'w', encoding='utf-8') as f:
             f.write(textwrap.dedent(
                 f'''
                 [wrap-file]

--- a/test cases/common/243 custom target feed/data_source.txt
+++ b/test cases/common/243 custom target feed/data_source.txt
@@ -1,0 +1,1 @@
+This is a text only input file.

--- a/test cases/common/243 custom target feed/meson.build
+++ b/test cases/common/243 custom target feed/meson.build
@@ -1,0 +1,24 @@
+project('custom target feed', 'c')
+
+python3 = import('python3').find_python()
+
+# Note that this will not add a dependency to the compiler executable.
+# Code will not be rebuilt if it changes.
+comp = '@0@/@1@'.format(meson.current_source_dir(), 'my_compiler.py')
+
+mytarget = custom_target('bindat',
+  output : 'data.dat',
+  input : 'data_source.txt',
+  feed : true,
+  command : [python3, comp, '@OUTPUT@'],
+  install : true,
+  install_dir : 'subdir'
+)
+
+ct_output_exists = '''import os, sys
+if not os.path.exists(sys.argv[1]):
+  print("could not find {!r} in {!r}".format(sys.argv[1], os.getcwd()))
+  sys.exit(1)
+'''
+
+test('capture-wrote', python3, args : ['-c', ct_output_exists, mytarget])

--- a/test cases/common/243 custom target feed/my_compiler.py
+++ b/test cases/common/243 custom target feed/my_compiler.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+import sys
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print(sys.argv[0], 'output_file')
+        sys.exit(1)
+    ifile = sys.stdin.read()
+    if ifile != 'This is a text only input file.\n':
+        print('Malformed input')
+        sys.exit(1)
+    with open(sys.argv[1], 'w+') as f:
+        f.write('This is a binary output file.')

--- a/test cases/common/243 custom target feed/test.json
+++ b/test cases/common/243 custom target feed/test.json
@@ -1,0 +1,5 @@
+{
+  "installed": [
+    {"type": "file", "file": "usr/subdir/data.dat"}
+  ]
+}

--- a/test cases/frameworks/1 boost/test.json
+++ b/test cases/frameworks/1 boost/test.json
@@ -7,10 +7,10 @@
       ],
       "b_vscrt": [
         { "val": null },
-        { "val": "md",  "compilers": { "cpp": [ "msvc" ] } },
-        { "val": "mdd", "compilers": { "cpp": [ "msvc" ] } },
-        { "val": "mt",  "compilers": { "cpp": [ "msvc" ] } },
-        { "val": "mtd", "compilers": { "cpp": [ "msvc" ] } }
+        { "val": "md",  "compilers": { "cpp": "msvc" } },
+        { "val": "mdd", "compilers": { "cpp": "msvc" } },
+        { "val": "mt",  "compilers": { "cpp": "msvc" } },
+        { "val": "mtd", "compilers": { "cpp": "msvc" } }
       ]
     },
     "exclude": [

--- a/tools/ac_converter.py
+++ b/tools/ac_converter.py
@@ -371,7 +371,7 @@ if len(sys.argv) != 2:
     print(help_message.format(sys.argv[0]))
     sys.exit(0)
 
-with open(sys.argv[1]) as f:
+with open(sys.argv[1], encoding='utf-8') as f:
     for line in f:
         line = line.strip()
         arr = line.split()

--- a/tools/boost_names.py
+++ b/tools/boost_names.py
@@ -78,7 +78,7 @@ class BoostModule():
 
 
 def get_boost_version() -> T.Optional[str]:
-    raw = jamroot.read_text()
+    raw = jamroot.read_text(encoding='utf-8')
     m = re.search(r'BOOST_VERSION\s*:\s*([0-9\.]+)\s*;', raw)
     if m:
         return m.group(1)
@@ -91,7 +91,7 @@ def get_libraries(jamfile: Path) -> T.List[BoostLibrary]:
     #  - compiler flags
 
     libs: T.List[BoostLibrary] = []
-    raw = jamfile.read_text()
+    raw = jamfile.read_text(encoding='utf-8')
     raw = re.sub(r'#.*\n', '\n', raw)  # Remove comments
     raw = re.sub(r'\s+', ' ', raw)     # Force single space
     raw = re.sub(r'}', ';', raw)       # Cheat code blocks by converting } to ;
@@ -185,7 +185,7 @@ def process_lib_dir(ldir: Path) -> T.List[BoostModule]:
         libs = get_libraries(bjam_file)
 
     # Extract metadata
-    data = json.loads(meta_file.read_text())
+    data = json.loads(meta_file.read_text(encoding='utf-8'))
     if not isinstance(data, list):
         data = [data]
 

--- a/tools/cmake2meson.py
+++ b/tools/cmake2meson.py
@@ -280,13 +280,13 @@ class Converter:
             subdir = self.cmake_root
         cfile = Path(subdir).expanduser() / 'CMakeLists.txt'
         try:
-            with cfile.open() as f:
+            with cfile.open(encoding='utf-8') as f:
                 cmakecode = f.read()
         except FileNotFoundError:
             print('\nWarning: No CMakeLists.txt in', subdir, '\n', file=sys.stderr)
             return
         p = Parser(cmakecode)
-        with (subdir / 'meson.build').open('w') as outfile:
+        with (subdir / 'meson.build').open('w', encoding='utf-8') as outfile:
             for t in p.parse():
                 if t.name == 'add_subdirectory':
                     # print('\nRecursing to subdir',
@@ -300,7 +300,7 @@ class Converter:
 
     def write_options(self) -> None:
         filename = self.cmake_root / 'meson_options.txt'
-        with filename.open('w') as optfile:
+        with filename.open('w', encoding='utf-8') as optfile:
             for o in self.options:
                 (optname, description, default) = o
                 if default is None:

--- a/tools/dircondenser.py
+++ b/tools/dircondenser.py
@@ -54,11 +54,11 @@ def get_entries() -> T.List[T.Tuple[int, str]]:
     return entries
 
 def replace_source(sourcefile: str, replacements: T.List[T.Tuple[str, str]]) -> None:
-    with open(sourcefile) as f:
+    with open(sourcefile, encoding='utf-8') as f:
         contents = f.read()
     for old_name, new_name in replacements:
         contents = contents.replace(old_name, new_name)
-    with open(sourcefile, 'w') as f:
+    with open(sourcefile, 'w', encoding='utf-8') as f:
         f.write(contents)
 
 def condense(dirname: str) -> None:

--- a/tools/gen_data.py
+++ b/tools/gen_data.py
@@ -107,7 +107,7 @@ def main() -> int:
 
             def write_once(self, path: Path) -> None:
                 if not path.exists():
-                    path.write_text(self.data)
+                    path.write_text(self.data, encoding='utf-8')
 
             def write_to_private(self, env: 'Environment') -> Path:
                 out_file = Path(env.scratch_dir) / 'data' / self.path.name
@@ -133,7 +133,7 @@ def main() -> int:
     ''')
 
     print(f'Updating {out_file}')
-    out_file.write_text(data)
+    out_file.write_text(data, encoding='utf-8')
     return 0
 
 if __name__ == '__main__':

--- a/tools/regenerate_docs.py
+++ b/tools/regenerate_docs.py
@@ -114,13 +114,13 @@ def generate_hotdoc_includes(root_dir: Path, output_dir: Path) -> None:
 
     for cmd, parsed in cmd_data.items():
         for typ in parsed.keys():
-            with open(output_dir / (cmd+'_'+typ+'.inc'), 'w') as f:
+            with open(output_dir / (cmd+'_'+typ+'.inc'), 'w', encoding='utf-8') as f:
                 f.write(parsed[typ])
 
 def generate_wrapdb_table(output_dir: Path) -> None:
     url = urlopen('https://wrapdb.mesonbuild.com/v2/releases.json')
     releases = json.loads(url.read().decode())
-    with open(output_dir / 'wrapdb-table.md', 'w') as f:
+    with open(output_dir / 'wrapdb-table.md', 'w', encoding='utf-8') as f:
         f.write('| Project | Versions | Provided dependencies | Provided programs |\n')
         f.write('| ------- | -------- | --------------------- | ----------------- |\n')
         for name, info in releases.items():
@@ -147,7 +147,7 @@ def regenerate_docs(output_dir: PathLike,
     generate_wrapdb_table(output_dir)
 
     if dummy_output_file:
-        with open(output_dir/dummy_output_file, 'w') as f:
+        with open(output_dir/dummy_output_file, 'w', encoding='utf-8') as f:
             f.write('dummy file for custom_target output')
 
 if __name__ == '__main__':

--- a/tools/run_with_cov.py
+++ b/tools/run_with_cov.py
@@ -28,9 +28,9 @@ from mesonbuild import mesonlib
 def generate_coveragerc() -> Path:
     i_file = (root_path / 'data' / '.coveragerc.in')
     o_file = (root_path / '.coveragerc')
-    raw = i_file.read_text()
+    raw = i_file.read_text(encoding='utf-8')
     raw = raw.replace('@ROOT@', root_path.as_posix())
-    o_file.write_text(raw)
+    o_file.write_text(raw, encoding='utf-8')
     return o_file
 
 def main() -> int:


### PR DESCRIPTION
When using the C2000 toolchain under a non Windows-OS meson can't setup or compile the project since the linker binary is hardcoded within linkers.py. With this PR the setting from the cross-file will be used.

I'm not sure if
`super().__init__(exelist, for_machine, '', [],`
should be prefered instead of
`super().__init__(exelist or ['cl2000.exe'], for_machine, '', [],`

