### PR TITLE
C2000: linker uses now binary setting defined within the cross-file

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -616,7 +616,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
         if 'TMS320C2000 C/C++' in out:
             cls = C2000CCompiler if lang == 'c' else C2000CPPCompiler
             env.coredata.add_lang_args(cls.language, cls, for_machine, env)
-            linker = C2000DynamicLinker(for_machine, version=version)
+            linker = C2000DynamicLinker(compiler, for_machine, version=version)
             return cls(
                 ccache + compiler, version, for_machine, is_cross, info,
                 exe_wrap, full_version=full_version, linker=linker)

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -982,9 +982,9 @@ class C2000DynamicLinker(DynamicLinker):
 
     id = 'cl2000'
 
-    def __init__(self, for_machine: mesonlib.MachineChoice,
+    def __init__(self, exelist: T.List[str], for_machine: mesonlib.MachineChoice,
                  *, version: str = 'unknown version'):
-        super().__init__(['cl2000.exe'], for_machine, '', [],
+        super().__init__(exelist or ['cl2000.exe'], for_machine, '', [],
                          version=version)
 
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:


### PR DESCRIPTION
[2nd try, since I had some difficulties with my 1st rebasing...] When using the C2000 toolchain under a non Windows-OS meson can't setup or compile the project since the linker binary is hard-coded within `linkers.py`. With this PR the setting from the cross-file will be used.

I'm not sure if
`super().__init__(exelist, for_machine, '', [],`
should be preferred instead of
`super().__init__(exelist or ['cl2000.exe'], for_machine, '', [],`

`exelist or ['cl2000'] `should work for windows and non-windows OS but since this is a cross-compile setup, the compiler must be set within the crossfile and `exelist` will always be **not** empty, so the hard coded `cl2000.exe` isn't needed at all(?).