### PR TITLE
Add minimum NVIDIA driver version entry in table for newly-released CUDA Toolkit 11.4.0.

### DIFF
--- a/mesonbuild/modules/unstable_cuda.py
+++ b/mesonbuild/modules/unstable_cuda.py
@@ -50,6 +50,7 @@ class CudaModule(ModuleObject):
 
         cuda_version = args[0]
         driver_version_table = [
+            {'cuda_version': '>=11.4.0',   'windows': '471.11', 'linux': '470.42.01'},
             {'cuda_version': '>=11.3.0',   'windows': '465.89', 'linux': '465.19.01'},
             {'cuda_version': '>=11.2.2',   'windows': '461.33', 'linux': '460.32.03'},
             {'cuda_version': '>=11.2.1',   'windows': '461.09', 'linux': '460.32.03'},


### PR DESCRIPTION
Continuing to use Table 3 in the [Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html) as the reference.