### PR TITLE
dist: only exclude actual git files

### DIFF
--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -56,11 +56,13 @@ def create_hash(fname):
 
 
 def del_gitfiles(dirname):
+    gitfiles = ('.git', '.gitattributes', '.gitignore', '.gitmodules')
     for f in glob(os.path.join(dirname, '.git*')):
-        if os.path.isdir(f) and not os.path.islink(f):
-            windows_proof_rmtree(f)
-        else:
-            os.unlink(f)
+        if os.path.split(f)[1] in gitfiles:
+            if os.path.isdir(f) and not os.path.islink(f):
+                windows_proof_rmtree(f)
+            else:
+                os.unlink(f)
 
 def process_submodules(dirname):
     module_file = os.path.join(dirname, '.gitmodules')


### PR DESCRIPTION
`meson dist` currently excludes all files starting with `.git`. The actual special files used by Git are `.git/`, `.gitattributes`, `.gitignore` and `.gitmodules`; other files starting with `.git` are not part of revision control metadata. The current behavior can leave users surprised, mainly because it is undocumented (happened to me in #8541).

I've never touched Python, so my solution could be extremely inefficient, and maybe there is a method to avoid duplicating code as I did :)