### PR TITLE
windows: Support wrc resource compiler

### DIFF
--- a/docs/markdown/snippets/wrc.md
+++ b/docs/markdown/snippets/wrc.md
@@ -1,0 +1,7 @@
+## Support for the Wine Resource Compiler
+
+Users can now choose `wrc` as the `windres` binary in their cross files and
+`windows.compile_resources` will handle it correctly. Together with `winegcc`
+patches in Wine 6.12 this enables basic support for compiling projects as a
+winelib by specifying `winegcc`/`wineg++` as the compiler and `wrc` as the
+resource compiler in a cross file.


### PR DESCRIPTION
It has a similar interface to windres, but it produces ELF instead of
COFF binaries. It uses its own preprocessor which doesn't support
creating depfiles, but we can convince it to use the system preprocessor
instead and pass those arguments using the --preprocessor option.

Together with some hacks to override the shared library/executable
suffix and some wine patches [1] this is enough to compile dxvk when
ripping out the hand-rolled rc support.

[1] https://www.winehq.org/pipermail/wine-devel/2021-July/190100.html
https://www.winehq.org/pipermail/wine-devel/2021-July/190098.html
https://www.winehq.org/pipermail/wine-devel/2021-July/190099.html
https://www.winehq.org/pipermail/wine-devel/2021-July/190101.html