### PR TITLE
Annotate framework tests with where they are expected to skip in CI

### DIFF
--- a/.github/workflows/os_comp.yml
+++ b/.github/workflows/os_comp.yml
@@ -1,4 +1,4 @@
-name: OS Comp Tests
+name: linux
 
 on:
   push:
@@ -34,6 +34,9 @@ jobs:
           - { name: OpenSUSE,         id: opensuse }
           - { name: Ubuntu Bionic,    id: bionic   }
     container: mesonbuild/${{ matrix.cfg.id }}:latest
+    env:
+      MESON_CI_JOBNAME: linux-${{ matrix.cfg.id }}-gcc
+
     steps:
     - uses: actions/checkout@v2
     - name: Run tests
@@ -76,6 +79,9 @@ jobs:
             MESON_ARGS: '--unity=on'
             CC: 'gcc'
             CXX: 'g++'
+
+    env:
+      MESON_CI_JOBNAME: linux-${{ github.job }}-${{ matrix.cfg.CC }}
 
     container:
       image: mesonbuild/ubuntu-rolling

--- a/ci/ciimage/bionic/image.json
+++ b/ci/ciimage/bionic/image.json
@@ -2,7 +2,6 @@
   "base_image": "ubuntu:bionic",
   "env": {
     "CI": "1",
-    "SKIP_SCIENTIFIC": "1",
     "DC": "gdc"
   }
 }

--- a/ci/ciimage/fedora/image.json
+++ b/ci/ciimage/fedora/image.json
@@ -2,7 +2,6 @@
   "base_image": "fedora:latest",
   "env": {
     "CI":                "1",
-    "SKIP_SCIENTIFIC":   "1",
     "SKIP_STATIC_BOOST": "1"
   }
 }

--- a/ci/ciimage/opensuse/image.json
+++ b/ci/ciimage/opensuse/image.json
@@ -2,7 +2,6 @@
   "base_image": "opensuse/tumbleweed:latest",
   "env": {
     "CI":                  "1",
-    "SKIP_SCIENTIFIC":     "1",
     "SKIP_STATIC_BOOST":   "1",
     "SINGLE_DUB_COMPILER": "1"
   }

--- a/data/test.schema.json
+++ b/data/test.schema.json
@@ -147,6 +147,12 @@
       "items": {
         "type": "string"
       }
+    },
+    "skip_on_os": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/data/test.schema.json
+++ b/data/test.schema.json
@@ -79,6 +79,18 @@
                   "items": {
                     "type": "string"
                   }
+                },
+                "skip_on_jobname": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "skip_on_os": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               },
               "required": [
@@ -140,6 +152,12 @@
         "required": [
           "line"
         ]
+      }
+    },
+    "skip_on_env": {
+      "type": "array",
+      "items": {
+        "type": "string"
       }
     },
     "skip_on_jobname": {

--- a/data/test.schema.json
+++ b/data/test.schema.json
@@ -141,6 +141,12 @@
           "line"
         ]
       }
+    },
+    "skip_on_jobname": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/docs/markdown/Contributing.md
+++ b/docs/markdown/Contributing.md
@@ -380,6 +380,16 @@ matched:
 | `literal` | Literal match (default) |
 | `re`      | regex match             |
 
+#### skip_on_jobname
+
+The `skip_on_jobname` key contains a list of strings. If the `MESON_CI_JOBNAME`
+environment variable is set, and any of them are a sub-string of it, the test is
+expected to be skipped (that is, it is expected that the test will output
+`MESON_SKIP_TEST`, because the CI environment is not one in which it can run,
+for whatever reason).
+
+The test is failed if it skips or runs unexpectedly.
+
 ### Skipping integration tests
 
 Meson uses several continuous integration testing systems that have

--- a/docs/markdown/Contributing.md
+++ b/docs/markdown/Contributing.md
@@ -390,6 +390,14 @@ for whatever reason).
 
 The test is failed if it skips or runs unexpectedly.
 
+#### skip_on_os
+
+The `skip_on_os` key can be used to specify a list of OS names (or their
+negations, prefixed with a `!`).  If at least one item in the `skip_on_os` list
+is matched, the test is expected to be skipped.
+
+The test is failed if it skips or runs unexpectedly.
+
 ### Skipping integration tests
 
 Meson uses several continuous integration testing systems that have

--- a/docs/markdown/Contributing.md
+++ b/docs/markdown/Contributing.md
@@ -305,17 +305,15 @@ project tests with different Meson options.
 
 In the `options` dict, all possible options and their values are
 specified. Each key in the `options` dict is a Meson option. It stores
-a list of all potential values in a dict format, which allows to skip
-specific values based on the current environment.
+a list of all potential values in a dict format.
 
 Each value must contain the `val` key for the value of the option.
 `null` can be used for adding matrix entries without the current
 option.
 
-Additionally, the `skip_on_env` key can be used to specify a list of
-environment variables. If at least one environment variable in
-`skip_on_env` is present, all matrix entries containing this value are
-skipped.
+The `skip_on_env`, `skip_on_jobname` and `skip_on_os` keys (as described below)
+may be used in the value to skip that matrix entry, based on the current
+environment.
 
 Similarly, the `compilers` key can be used to define a mapping of
 compilers to languages that are required for this value.
@@ -379,6 +377,12 @@ matched:
 | --------  | ----------------------- |
 | `literal` | Literal match (default) |
 | `re`      | regex match             |
+
+#### skip_on_env
+
+The `skip_on_env` key can be used to specify a list of environment variables. If
+at least one environment variable in the `skip_on_env` list is present, the test
+is skipped.
 
 #### skip_on_jobname
 

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -779,6 +779,17 @@ def load_test_json(t: TestDef, stdout_mandatory: bool) -> T.List[TestDef]:
     else:
         skip_expected = False
 
+    # Test is expected to skip if os matches
+    if 'skip_on_os' in test_def:
+        mesonenv = environment.Environment(None, None, get_fake_options('/'))
+        for skip_os in test_def['skip_on_os']:
+            if skip_os.startswith('!'):
+                if mesonenv.machines.host.system != skip_os[1:]:
+                    skip_expected = True
+            else:
+                if mesonenv.machines.host.system == skip_os:
+                    skip_expected = True
+
     # Skip the matrix code and just update the existing test
     if 'matrix' not in test_def:
         t.env.update(env)

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1386,33 +1386,32 @@ def check_meson_commands_work(use_tmpdir: bool, extra_args: T.List[str]) -> None
 def detect_system_compiler(options: 'CompilerArgumentType') -> None:
     global host_c_compiler, compiler_id_map
 
-    with TemporaryDirectoryWinProof(prefix='b ', dir=None if options.use_tmpdir else '.') as build_dir:
-        fake_opts = get_fake_options('/')
-        if options.cross_file:
-            fake_opts.cross_file = [options.cross_file]
-        if options.native_file:
-            fake_opts.native_file = [options.native_file]
+    fake_opts = get_fake_options('/')
+    if options.cross_file:
+        fake_opts.cross_file = [options.cross_file]
+    if options.native_file:
+        fake_opts.native_file = [options.native_file]
 
-        env = environment.Environment(None, build_dir, fake_opts)
+    env = environment.Environment(None, None, fake_opts)
 
-        print_compilers(env, MachineChoice.HOST)
-        if options.cross_file:
-            print_compilers(env, MachineChoice.BUILD)
+    print_compilers(env, MachineChoice.HOST)
+    if options.cross_file:
+        print_compilers(env, MachineChoice.BUILD)
 
-        for lang in sorted(compilers.all_languages):
-            try:
-                comp = compiler_from_language(env, lang, MachineChoice.HOST)
-                # note compiler id for later use with test.json matrix
-                compiler_id_map[lang] = comp.get_id()
-            except mesonlib.MesonException:
-                comp = None
+    for lang in sorted(compilers.all_languages):
+        try:
+            comp = compiler_from_language(env, lang, MachineChoice.HOST)
+            # note compiler id for later use with test.json matrix
+            compiler_id_map[lang] = comp.get_id()
+        except mesonlib.MesonException:
+            comp = None
 
-            # note C compiler for later use by platform_fix_name()
-            if lang == 'c':
-                if comp:
-                    host_c_compiler = comp.get_id()
-                else:
-                    raise RuntimeError("Could not find C compiler.")
+        # note C compiler for later use by platform_fix_name()
+        if lang == 'c':
+            if comp:
+                host_c_compiler = comp.get_id()
+            else:
+                raise RuntimeError("Could not find C compiler.")
 
 
 def print_compilers(env: 'Environment', machine: MachineChoice) -> None:

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -930,10 +930,6 @@ def skippable(suite: str, test: str) -> bool:
     if not suite.endswith('frameworks'):
         return True
 
-    # this test assumptions aren't valid for Windows paths
-    if test.endswith('38 libdir must be inside prefix'):
-        return True
-
     # gtk-doc test may be skipped, pending upstream fixes for spaces in
     # filenames landing in the distro used for CI
     if test.endswith('10 gtk-doc'):
@@ -941,10 +937,6 @@ def skippable(suite: str, test: str) -> bool:
 
     # NetCDF is not in the CI Docker image
     if test.endswith('netcdf'):
-        return True
-
-    # MSVC doesn't link with GFortran
-    if test.endswith('14 fortran links c'):
         return True
 
     # Blocks are not supported on all compilers
@@ -983,10 +975,6 @@ def skippable(suite: str, test: str) -> bool:
     # On macOS we should have all of the requirements at all times.
     if test.endswith('4 qt'):
         return not mesonlib.is_osx()
-
-    # Bindgen isn't available in all distros
-    if test.endswith('12 bindgen'):
-        return False
 
     # No frameworks test should be skipped on linux CI, as we expect all
     # prerequisites to be installed

--- a/run_single_test.py
+++ b/run_single_test.py
@@ -13,7 +13,7 @@ import pathlib
 import typing as T
 
 from mesonbuild import mlog
-from run_project_tests import TestDef, load_test_json, run_test, BuildStep, skippable
+from run_project_tests import TestDef, load_test_json, run_test, BuildStep
 from run_project_tests import setup_commands, detect_system_compiler, print_tool_versions
 
 if T.TYPE_CHECKING:
@@ -50,7 +50,7 @@ def main() -> None:
     results = [run_test(t, t.args, '', True) for t in tests]
     failed = False
     for test, result in zip(tests, results):
-        if (result is None) or (('MESON_SKIP_TEST' in result.stdo) and (skippable(str(args.case.parent), test.path.as_posix()))):
+        if (result is None) or ('MESON_SKIP_TEST' in result.stdo):
             msg = mlog.yellow('SKIP:')
         elif result.msg:
             msg = mlog.red('FAIL:')

--- a/test cases/frameworks/15 llvm/meson.build
+++ b/test cases/frameworks/15 llvm/meson.build
@@ -34,8 +34,12 @@ llvm_dep = dependency(
   static : static,
   method : method,
 )
-if llvm_dep.found()
-  executable(
+
+if not llvm_dep.found()
+  error('MESON_SKIP_TEST required llvm modules not found.')
+endif
+
+executable(
     'sum',
     'sum.c',
     dependencies : [
@@ -45,4 +49,3 @@ if llvm_dep.found()
       meson.get_compiler('c').find_library('dl', required : false),
     ]
   )
-endif

--- a/test cases/frameworks/15 llvm/test.json
+++ b/test cases/frameworks/15 llvm/test.json
@@ -6,7 +6,7 @@
         { "val": "cmake" }
       ],
       "link-static": [
-        { "val": true },
+        { "val": true, "skip_on_jobname": ["opensuse"] },
         { "val": false }
       ]
     },

--- a/test cases/frameworks/16 sdl2/test.json
+++ b/test cases/frameworks/16 sdl2/test.json
@@ -6,7 +6,7 @@
         { "val": "pkg-config" },
         { "val": "config-tool" },
         { "val": "sdlconfig" },
-        { "val": "extraframework" }
+        { "val": "extraframework", "skip_on_os": ["!macos"] }
       ]
     }
   }

--- a/test cases/frameworks/17 mpi/test.json
+++ b/test cases/frameworks/17 mpi/test.json
@@ -4,12 +4,14 @@
       "method": [
         { "val": "auto" },
         { "val": "pkg-config" },
-        { "val": "config-tool" },
+        { "val": "config-tool",
+          "skip_on_jobname": ["fedora"] },
         {
           "val": "system",
           "compilers": { "c" :"msvc", "cpp": "msvc" }
         }
       ]
     }
-  }
+  },
+  "skip_on_jobname": ["opensuse"]
 }

--- a/test cases/frameworks/25 hdf5/test.json
+++ b/test cases/frameworks/25 hdf5/test.json
@@ -6,5 +6,6 @@
         { "val": "config-tool" }
       ]
     }
-  }
+  },
+  "skip_on_jobname": ["fedora", "opensuse"]
 }

--- a/test cases/frameworks/26 netcdf/test.json
+++ b/test cases/frameworks/26 netcdf/test.json
@@ -1,0 +1,3 @@
+{
+  "skip_on_jobname": ["bionic", "fedora", "opensuse", "ubuntu"]
+}

--- a/test cases/frameworks/29 blocks/test.json
+++ b/test cases/frameworks/29 blocks/test.json
@@ -1,0 +1,3 @@
+{
+  "skip_on_jobname": ["gcc"]
+}

--- a/test cases/frameworks/30 scalapack/test.json
+++ b/test cases/frameworks/30 scalapack/test.json
@@ -1,0 +1,3 @@
+{
+  "skip_on_jobname": ["bionic", "fedora", "opensuse"]
+}

--- a/test cases/frameworks/34 gir static lib/test.json
+++ b/test cases/frameworks/34 gir static lib/test.json
@@ -4,5 +4,6 @@
     {"type": "expr", "file": "usr/lib/?libgirlib.so"},
     {"type": "file", "platform": "cygwin", "file": "usr/lib/libgirlib.dll.a"},
     {"type": "file", "file": "usr/share/gir-1.0/Meson-1.0.gir"}
-  ]
+  ],
+  "skip_on_jobname": ["bionic"]
 }

--- a/test cases/frameworks/4 qt/test.json
+++ b/test cases/frameworks/4 qt/test.json
@@ -2,8 +2,8 @@
   "matrix": {
     "options": {
       "method": [
-        { "val": "config-tool" },
-        { "val": "qmake" },
+        { "val": "config-tool", "skip_on_jobname": ["fedora", "opensuse"] },
+        { "val": "qmake", "skip_on_jobname": ["fedora", "opensuse"] },
         { "val": "pkg-config" }
       ]
     }


### PR DESCRIPTION
Replace the hard-coded list of 'may be skipped' framework tests in `skippable()` with annotations in `test.json` which record 'will be skipped in these specific CI jobs'.

The motivation here is that, at the moment, if something is dropped from any VM image our CI runs on, if it's permitted by `skippable()`, we'll just silently stop testing it.  This is particularly relevant where we don't control the VM image (e.g. on Windows), and has actually happened with boost on Windows (see the comments for commit 5c0cb0547bd52230faff322a33bfeac0eaaeea0d).