### PR TITLE
Fix unsupported linker error message

### DIFF
--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -316,7 +316,7 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
     def use_linker_args(cls, linker: str) -> T.List[str]:
         if linker not in {'gold', 'bfd', 'lld'}:
             raise mesonlib.MesonException(
-                'Unsupported linker, only bfd, gold, and lld are supported, not {linker}.')
+                f'Unsupported linker, only bfd, gold, and lld are supported, not {linker}.')
         return [f'-fuse-ld={linker}']
 
     def get_coverage_args(self) -> T.List[str]:


### PR DESCRIPTION
An `f` was dropped in bd6f46e723813dfadaba1f7c87d3b0b751d05219