### PR TITLE
mconf: add --fatal-meson-warnings (just as msetup)

### DIFF
--- a/docs/markdown/snippets/fatal-meson-warnings.md
+++ b/docs/markdown/snippets/fatal-meson-warnings.md
@@ -1,0 +1,8 @@
+## `--fatal-meson-warnings` added to 'configure' task
+
+There was previously no way to enable fatal Meson warnings for the
+'configure' task. Hence it was easy to miss that an unknown option,
+e.g. caused by a typo, was encountered, since only a warning was
+emitted while Meson would exit without an error code. If
+`--fatal-meson-warnings` is now given, the 'configure' task will exit
+with an error code if an unknown Meson option was encountered.

--- a/mesonbuild/mconf.py
+++ b/mesonbuild/mconf.py
@@ -36,6 +36,9 @@ def add_arguments(parser: 'argparse.ArgumentParser') -> None:
     parser.add_argument('builddir', nargs='?', default='.')
     parser.add_argument('--clearcache', action='store_true', default=False,
                         help='Clear cached state (e.g. found dependencies)')
+    parser.add_argument('--fatal-meson-warnings', action='store_true', dest='fatal_warnings',
+                        help='Make all Meson warnings fatal')
+
 
 def make_lower_case(val: T.Any) -> T.Union[str, T.List[T.Any]]:  # T.Any because of recursion...
     if isinstance(val, bool):

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -223,6 +223,9 @@ class CommandLineParser:
         args = mesonlib.expand_arguments(args)
         options = parser.parse_args(args)
 
+        if hasattr(options, 'fatal_warnings'):
+            mlog.log_fatal_warnings = options.fatal_warnings
+
         try:
             return options.run_func(options)
         except MesonException as e:

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -97,11 +97,10 @@ def set_verbose() -> None:
     global log_errors_only
     log_errors_only = False
 
-def initialize(logdir: str, fatal_warnings: bool = False) -> None:
+def initialize(logdir: str) -> None:
     global log_dir, log_file, log_fatal_warnings
     log_dir = logdir
     log_file = open(os.path.join(logdir, log_fname), 'w', encoding='utf-8')
-    log_fatal_warnings = fatal_warnings
 
 def set_timestamp_start(start: float) -> None:
     global log_timestamp_start

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -175,7 +175,7 @@ class MesonApp:
 
     def generate(self) -> None:
         env = environment.Environment(self.source_dir, self.build_dir, self.options)
-        mlog.initialize(env.get_log_dir(), self.options.fatal_warnings)
+        mlog.initialize(env.get_log_dir())
         if self.options.profile:
             mlog.set_timestamp_start(time.monotonic())
         if env.coredata.options[mesonlib.OptionKey('backend')].value == 'xcode':


### PR DESCRIPTION
It is a common error, at least in my experience, that people invoke
"meson configure -D nonexistent=true" and miss the big yellow
uppercase WARNING about "nonexistent" being an unknown option. They
they happily continue building the project in the belief that
"nonexistent" is set to true, when it is, in fact not.

I am not sure why meason decided that this should only be a
WARNING. But users should at least be able to opt-in for a fail-safe
behavior. This is now possible via the --fatal-meson-warnings
switch for the 'configure' subcommand.

Partially fixes #7288.