### PR TITLE
Add path filter to azure pipelines trigger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,28 @@ trigger:
     - 'master'
     # Release branches
     - '0.*'
+  paths:
+    include:
+      - 'mesonbuild'
+      - 'test cases'
+      - 'azure-pipelines.yml'
+      - 'ci/azure-steps.yml'
+      - 'run_project_tests.py'
+      - 'run_tests.py'
+      - 'run_unittests.py'
+pr:
+  branches:
+    include:
+    - '*'
+  paths:
+    include:
+      - 'mesonbuild'
+      - 'test cases'
+      - 'azure-pipelines.yml'
+      - 'ci/azure-steps.yml'
+      - 'run_project_tests.py'
+      - 'run_tests.py'
+      - 'run_unittests.py'
 
 variables:
   CI: 1


### PR DESCRIPTION
This restricts the pipeline from running on 'non-code' pushes and PRs in the same way that GitHub workflows which run project tests are (although the syntax is different, and must be made more explicit as wildcards aren't supported).