### PR TITLE
Add support for gcovr --sonarqube report

### DIFF
--- a/docs/markdown/Feature-autodetection.md
+++ b/docs/markdown/Feature-autodetection.md
@@ -26,6 +26,8 @@ Coverage
 When doing a code coverage build, Meson will check for existence of
 the binaries `gcovr`, `lcov` and `genhtml`. If version 3.3 or higher
 of the first is found, targets called *coverage-text*, *coverage-xml*
+and *coverage-html* are generated. If version 4.2 or higher of the
+first is found, targets *coverage-text*, *coverage-xml*, *coverage-sonarqube*
 and *coverage-html* are generated. Alternatively, if the latter two
 are found, only the target *coverage-html* is generated. Coverage
 reports can then be produced simply by calling e.g. `meson compile

--- a/docs/markdown/Unit-tests.md
+++ b/docs/markdown/Unit-tests.md
@@ -47,6 +47,7 @@ functions that get called). Meson will autodetect what coverage
 generator tools you have installed and will generate the corresponding
 targets. These targets are `coverage-xml` and `coverage-text` which
 are both provided by [Gcovr](http://gcovr.com) (version 3.3 or higher)
+`coverage-sonarqube` which is provided by [Gcovr](http://gcovr.com) (version 4.2 or higher)
 and `coverage-html`, which requires
 [Lcov](https://ltp.sourceforge.io/coverage/lcov.php) and
 [GenHTML](https://linux.die.net/man/1/genhtml) or

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1064,6 +1064,13 @@ class NinjaBackend(backends.Backend):
         # Alias that runs the target defined above
         self.create_target_alias('meson-coverage-xml')
 
+        e = NinjaBuildElement(self.all_outputs, 'meson-coverage-sonarqube', 'CUSTOM_COMMAND', 'PHONY')
+        self.generate_coverage_command(e, ['--sonarqube'])
+        e.add_item('description', 'Generates Sonarqube XML coverage report')
+        self.add_build(e)
+        # Alias that runs the target defined above
+        self.create_target_alias('meson-coverage-sonarqube')
+
         e = NinjaBuildElement(self.all_outputs, 'meson-coverage-text', 'CUSTOM_COMMAND', 'PHONY')
         self.generate_coverage_command(e, ['--text'])
         e.add_item('description', 'Generates text coverage report')

--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -46,6 +46,18 @@ def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build
             print('gcovr >= 3.3 needed to generate Xml coverage report')
             exitcode = 1
 
+    if not outputs or 'sonarqube' in outputs:
+        if gcovr_exe:
+            subprocess.check_call(gcovr_base_cmd +
+                                  ['--sonarqube',
+                                   '-o', os.path.join(log_dir, 'sonarqube.xml'),
+                                   '-e', subproject_root
+                                   ] + gcov_exe_args)
+            outfiles.append(('Sonarqube', pathlib.Path(log_dir, 'sonarqube.xml')))
+        elif outputs:
+            print('gcovr >= 4.2 needed to generate Xml coverage report')
+            exitcode = 1
+
     if not outputs or 'text' in outputs:
         if gcovr_exe:
             subprocess.check_call(gcovr_base_cmd +
@@ -156,6 +168,8 @@ def run(args: T.List[str]) -> int:
                         const='text', help='generate Text report')
     parser.add_argument('--xml', dest='outputs', action='append_const',
                         const='xml', help='generate Xml report')
+    parser.add_argument('--sonarqube', dest='outputs', action='append_const',
+                        const='sonarqube', help='generate Sonarqube Xml report')
     parser.add_argument('--html', dest='outputs', action='append_const',
                         const='html', help='generate Html report')
     parser.add_argument('--use_llvm_cov', action='store_true',

--- a/test cases/common/150 reserved targets/coverage-sonarqube/meson.build
+++ b/test cases/common/150 reserved targets/coverage-sonarqube/meson.build
@@ -1,0 +1,1 @@
+executable('test-coverage-sonarqube', '../test.c')


### PR DESCRIPTION
Sonarcloud.io only can read the sonarqube based report that gcovr can
produce.  This change enables support for this output in meson and
ninja.

Signed-off-by: Weston Schmidt <Weston_Schmidt@alumni.purdue.edu>