### PR TITLE
Clang: Apply `-O0`

### DIFF
--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -35,7 +35,7 @@ clang_color_args = {
 }  # type: T.Dict[str, T.List[str]]
 
 clang_optimization_args = {
-    '0': [],
+    '0': ['-O0'],
     'g': ['-Og'],
     '1': ['-O1'],
     '2': ['-O2'],


### PR DESCRIPTION
Fix #8986

**Motivation for this change**

Calling `clang` without any `-O` option is **NOT** equivalent to calling it with `-O0`.
One important difference is that when debugging, without `-O0` (and even with `-Og`), certain parameter values are marked as `<optimized out>` in GDB;
On the contrary, using `-O0` allows to get the value of any variable.