### PR TITLE
coverage: disable the concept of "CI failures"

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
code coverage may be interesting to some people as an informational update, but it's really fragile and sometimes obscure, and overall we would really like to NOT have most PRs reporting a red X in the CI overview, when all project/unittests succeeded but codecov decides that by some inscrutbale metric, coverage by % has dropped.

Elegant refactorings are penalized, because removing lines of code or rewriting them to be more compact, means the overall percentage of covered code is "less", even though no uncovered code got added.

Even worse, the coverage reports often erroneously complain that a PR has "added lines #L<num> - L<num> were not covered by tests" even though github helpfully points out they are "Unchanged files with check annotations". Or more generally, codecov claims that coverage has dropped in code which the PR can't touch.

The whole thing is just too much of a source of trouble. So, configure codecov to consider all PRs as successful no matter what. It is still welcome to leave informational comments, though.