### PR TITLE
Cleanup the python module

### DIFF
--- a/docs/markdown/snippets/python_dependency_args_removed.md
+++ b/docs/markdown/snippets/python_dependency_args_removed.md
@@ -1,0 +1,3 @@
+## The Python Modules dependency method no longer accepts positional arguments
+
+Previously these were igrnoed with a warning, now they're a hard error.

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -89,7 +89,6 @@ class Dependency(HoldableObject):
         # If None, self.link_args will be used
         self.raw_link_args: T.Optional[T.List[str]] = None
         self.sources: T.List['FileOrString'] = []
-        self.methods = process_method_kw(self.get_methods(), kwargs)
         self.include_type = self._process_include_type_kw(kwargs)
         self.ext_deps: T.List[Dependency] = []
 
@@ -147,10 +146,6 @@ class Dependency(HoldableObject):
         """Source files that need to be added to the target.
         As an example, gtest-all.cc when using GTest."""
         return self.sources
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.AUTO]
 
     def get_name(self) -> str:
         return self.name
@@ -547,10 +542,6 @@ class SystemDependency(ExternalDependency):
         super().__init__(DependencyTypeName('system'), env, kwargs, language=language)
         self.name = name
 
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.SYSTEM]
-
     def log_tried(self) -> str:
         return 'system'
 
@@ -563,10 +554,6 @@ class BuiltinDependency(ExternalDependency):
                  language: T.Optional[str] = None) -> None:
         super().__init__(DependencyTypeName('builtin'), env, kwargs, language=language)
         self.name = name
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.BUILTIN]
 
     def log_tried(self) -> str:
         return 'builtin'

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import ExternalDependency, DependencyException, DependencyMethods, DependencyTypeName
+from .base import ExternalDependency, DependencyException, DependencyTypeName
 from ..mesonlib import is_windows, MesonException, OptionKey, PerMachine, stringlistify, extract_as_list
 from ..mesondata import mesondata
 from ..cmake import CMakeExecutor, CMakeTraceParser, CMakeException, CMakeToolchain, CMakeExecScope, check_cmake_args
@@ -631,10 +631,6 @@ class CMakeDependency(ExternalDependency):
                     env: T.Optional[T.Dict[str, str]] = None) -> T.Tuple[int, T.Optional[str], T.Optional[str]]:
         build_dir = self._setup_cmake_dir(cmake_file)
         return self.cmakebin.call(args, build_dir, env=env)
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.CMAKE]
 
     def log_tried(self) -> str:
         return self.type_name

--- a/mesonbuild/dependencies/coarrays.py
+++ b/mesonbuild/dependencies/coarrays.py
@@ -84,7 +84,3 @@ class CoarrayDependency(SystemDependency):
         elif cid == 'nagfor':
             # NAG doesn't require any special arguments for Coarray
             self.is_found = True
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.AUTO, DependencyMethods.CMAKE, DependencyMethods.PKGCONFIG]

--- a/mesonbuild/dependencies/configtool.py
+++ b/mesonbuild/dependencies/configtool.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import ExternalDependency, DependencyException, DependencyMethods, DependencyTypeName
+from .base import ExternalDependency, DependencyException, DependencyTypeName
 from ..mesonlib import listify, Popen_safe, split_args, version_compare, version_compare_many
 from ..programs import find_external_program
 from .. import mlog
@@ -137,10 +137,6 @@ class ConfigToolDependency(ExternalDependency):
                 raise DependencyException(f'Could not generate {stage} for {self.name}.\n{err}')
             return []
         return split_args(out)
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.AUTO, DependencyMethods.CONFIG_TOOL]
 
     def get_configtool_variable(self, variable_name: str) -> str:
         p, out, _ = Popen_safe(self.config + [f'--{variable_name}'])

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -106,10 +106,6 @@ class GTestDependencySystem(SystemDependency):
     def log_tried(self) -> str:
         return 'system'
 
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM]
-
 
 class GTestDependencyPC(PkgConfigDependency):
 
@@ -180,10 +176,6 @@ class GMockDependencySystem(SystemDependency):
 
     def log_tried(self) -> str:
         return 'system'
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM]
 
 
 class GMockDependencyPC(PkgConfigDependency):
@@ -508,11 +500,6 @@ class ZlibSystemDependency(SystemDependency):
         self.version = v.strip('"')
 
 
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.SYSTEM]
-
-
 class JDKSystemDependency(SystemDependency):
     def __init__(self, environment: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__('jdk', environment, kwargs)
@@ -543,10 +530,6 @@ class JDKSystemDependency(SystemDependency):
         self.compile_args.append(f'-I{java_home_include}')
         self.compile_args.append(f'-I{java_home_include / platform_include_dir}')
         self.is_found = True
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.SYSTEM]
 
     @staticmethod
     def __machine_info_to_platform_include_dir(m: 'MachineInfo') -> T.Optional[str]:

--- a/mesonbuild/dependencies/dub.py
+++ b/mesonbuild/dependencies/dub.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import ExternalDependency, DependencyException, DependencyMethods, DependencyTypeName
+from .base import ExternalDependency, DependencyException, DependencyTypeName
 from .pkgconfig import PkgConfigDependency
 from ..mesonlib import Popen_safe
 from ..programs import ExternalProgram
@@ -234,7 +234,3 @@ class DubDependency(ExternalDependency):
         else:
             mlog.log('Found DUB:', mlog.red('NO'))
         return dubbin
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.DUB]

--- a/mesonbuild/dependencies/framework.py
+++ b/mesonbuild/dependencies/framework.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import DependencyTypeName, ExternalDependency, DependencyException, DependencyMethods
+from .base import DependencyTypeName, ExternalDependency, DependencyException
 from ..mesonlib import MesonException, Version, stringlistify
 from .. import mlog
 from pathlib import Path
@@ -111,10 +111,6 @@ class ExtraFrameworkDependency(ExternalDependency):
             if trial.is_dir():
                 return trial.as_posix()
         return None
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.EXTRAFRAMEWORK]
 
     def log_info(self) -> str:
         return self.framework_path or ''

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -125,10 +125,6 @@ class ThreadDependency(SystemDependency):
             self.compile_args = self.clib_compiler.thread_flags(environment)
             self.link_args = self.clib_compiler.thread_link_flags(environment)
 
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.AUTO, DependencyMethods.CMAKE]
-
 
 class BlocksDependency(SystemDependency):
     def __init__(self, environment: 'Environment', kwargs: T.Dict[str, T.Any]) -> None:
@@ -262,15 +258,6 @@ class Python3DependencySystem(SystemDependency):
         self.version = sysconfig.get_config_var('py_version')
         self.is_found = True
 
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        if mesonlib.is_windows():
-            return [DependencyMethods.PKGCONFIG, DependencyMethods.SYSCONFIG]
-        elif mesonlib.is_osx():
-            return [DependencyMethods.PKGCONFIG, DependencyMethods.EXTRAFRAMEWORK]
-        else:
-            return [DependencyMethods.PKGCONFIG]
-
     def log_tried(self) -> str:
         return 'sysconfig'
 
@@ -286,10 +273,6 @@ class PcapDependencyConfigTool(ConfigToolDependency):
         self.compile_args = self.get_config_value(['--cflags'], 'compile_args')
         self.link_args = self.get_config_value(['--libs'], 'link_args')
         self.version = self.get_pcap_lib_version()
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL]
 
     def get_pcap_lib_version(self) -> T.Optional[str]:
         # Since we seem to need to run a program to discover the pcap version,
@@ -317,13 +300,6 @@ class CupsDependencyConfigTool(ConfigToolDependency):
         self.compile_args = self.get_config_value(['--cflags'], 'compile_args')
         self.link_args = self.get_config_value(['--ldflags', '--libs'], 'link_args')
 
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        if mesonlib.is_osx():
-            return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.EXTRAFRAMEWORK, DependencyMethods.CMAKE]
-        else:
-            return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.CMAKE]
-
 
 class LibWmfDependencyConfigTool(ConfigToolDependency):
 
@@ -336,10 +312,6 @@ class LibWmfDependencyConfigTool(ConfigToolDependency):
             return
         self.compile_args = self.get_config_value(['--cflags'], 'compile_args')
         self.link_args = self.get_config_value(['--libs'], 'link_args')
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL]
 
 
 class LibGCryptDependencyConfigTool(ConfigToolDependency):
@@ -355,10 +327,6 @@ class LibGCryptDependencyConfigTool(ConfigToolDependency):
         self.link_args = self.get_config_value(['--libs'], 'link_args')
         self.version = self.get_config_value(['--version'], 'version')[0]
 
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL]
-
 
 class GpgmeDependencyConfigTool(ConfigToolDependency):
 
@@ -372,10 +340,6 @@ class GpgmeDependencyConfigTool(ConfigToolDependency):
         self.compile_args = self.get_config_value(['--cflags'], 'compile_args')
         self.link_args = self.get_config_value(['--libs'], 'link_args')
         self.version = self.get_config_value(['--version'], 'version')[0]
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL]
 
 
 class ShadercDependency(SystemDependency):
@@ -405,10 +369,6 @@ class ShadercDependency(SystemDependency):
 
     def log_tried(self) -> str:
         return 'system'
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.SYSTEM, DependencyMethods.PKGCONFIG]
 
 
 class CursesConfigToolDependency(ConfigToolDependency):
@@ -480,10 +440,6 @@ class CursesSystemDependency(SystemDependency):
                             break
             if self.is_found:
                 break
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.SYSTEM]
 
 
 class IntlBuiltinDependency(BuiltinDependency):

--- a/mesonbuild/dependencies/pkgconfig.py
+++ b/mesonbuild/dependencies/pkgconfig.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .base import ExternalDependency, DependencyException, DependencyMethods, sort_libpaths, DependencyTypeName
+from .base import ExternalDependency, DependencyException, sort_libpaths, DependencyTypeName
 from ..mesonlib import LibType, MachineChoice, OptionKey, OrderedSet, PerMachine, Popen_safe
 from ..programs import find_external_program, ExternalProgram
 from .. import mlog
@@ -395,10 +395,6 @@ class PkgConfigDependency(ExternalDependency):
 
         mlog.debug(f'Got pkgconfig variable {variable_name} : {variable}')
         return variable
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.PKGCONFIG]
 
     def check_pkgconfig(self, pkgbin: ExternalProgram) -> T.Optional[str]:
         if not pkgbin.found():

--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -50,13 +50,6 @@ class GLDependencySystem(SystemDependency):
             # FIXME: Detect version using self.clib_compiler
             return
 
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        if mesonlib.is_osx() or mesonlib.is_windows():
-            return [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM]
-        else:
-            return [DependencyMethods.PKGCONFIG]
-
     def log_tried(self) -> str:
         return 'system'
 
@@ -148,13 +141,6 @@ class SDL2DependencyConfigTool(ConfigToolDependency):
             return
         self.compile_args = self.get_config_value(['--cflags'], 'compile_args')
         self.link_args = self.get_config_value(['--libs'], 'link_args')
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        if mesonlib.is_osx():
-            return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.EXTRAFRAMEWORK]
-        else:
-            return [DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL]
 
 
 class WxDependency(ConfigToolDependency):
@@ -250,10 +236,6 @@ class VulkanDependencySystem(SystemDependency):
                 for lib in libs:
                     self.link_args.append(lib)
                 return
-
-    @staticmethod
-    def get_methods() -> T.List[DependencyMethods]:
-        return [DependencyMethods.SYSTEM]
 
     def log_tried(self) -> str:
         return 'system'

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2032,9 +2032,12 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
                     '"rename" and "sources" argument lists must be the same length if "rename" is given. '
                     f'Rename has {len(rename)} elements and sources has {len(sources)}.')
 
-        data = build.Data(
-            sources, kwargs['install_dir'], kwargs['install_mode'],
-            self.subproject, rename)
+        return self.install_data_impl(sources, kwargs['install_dir'], kwargs['install_mode'], rename)
+
+    def install_data_impl(self, sources: T.List[mesonlib.File], install_dir: str,
+                          install_mode: FileMode, rename: T.Optional[str]) -> build.Data:
+        """Just the implementation with no validation."""
+        data = build.Data(sources, install_dir, install_mode, self.subproject, rename)
         self.build.data.append(data)
         return data
 

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -81,11 +81,6 @@ class DependenciesHelper:
             if hasattr(obj, 'generated_pc'):
                 self._check_generated_pc_deprecation(obj)
                 processed_reqs.append(obj.generated_pc)
-            elif hasattr(obj, 'pcdep'):
-                pcdeps = mesonlib.listify(obj.pcdep)
-                for d in pcdeps:
-                    processed_reqs.append(d.name)
-                    self.add_version_reqs(d.name, obj.version_reqs)
             elif isinstance(obj, dependencies.PkgConfigDependency):
                 if obj.found():
                     processed_reqs.append(obj.name)
@@ -114,12 +109,7 @@ class DependenciesHelper:
         processed_reqs = []
         processed_cflags = []
         for obj in libs:
-            if hasattr(obj, 'pcdep'):
-                pcdeps = mesonlib.listify(obj.pcdep)
-                for d in pcdeps:
-                    processed_reqs.append(d.name)
-                    self.add_version_reqs(d.name, obj.version_reqs)
-            elif hasattr(obj, 'generated_pc'):
+            if hasattr(obj, 'generated_pc'):
                 self._check_generated_pc_deprecation(obj)
                 processed_reqs.append(obj.generated_pc)
             elif isinstance(obj, dependencies.PkgConfigDependency):

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -123,7 +123,7 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
 
         self.compile_args += ['-I' + path for path in inc_paths if path]
 
-    def get_windows_python_arch(self) -> T.Optional[str]:
+    def _get_windows_python_arch(self) -> T.Optional[str]:
         if self.platform == 'mingw':
             pycc = self.variables.get('CC')
             if pycc.startswith('x86_64'):
@@ -141,7 +141,7 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
         mlog.log(f'Unknown Windows Python platform {self.platform!r}')
         return None
 
-    def get_windows_link_args(self) -> T.Optional[T.List[str]]:
+    def _get_windows_link_args(self) -> T.Optional[T.List[str]]:
         if self.platform.startswith('win'):
             vernum = self.variables.get('py_version_nodot')
             if self.static:
@@ -169,7 +169,7 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
         Find python3 libraries on Windows and also verify that the arch matches
         what we are building for.
         '''
-        pyarch = self.get_windows_python_arch()
+        pyarch = self._get_windows_python_arch()
         if pyarch is None:
             self.is_found = False
             return
@@ -191,7 +191,7 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
             self.is_found = False
             return
         # This can fail if the library is not found
-        largs = self.get_windows_link_args()
+        largs = self._get_windows_link_args()
         if largs is None:
             self.is_found = False
             return

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -12,30 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
 import os
 import json
 import shutil
 import typing as T
 
-from pathlib import Path
-from .. import mesonlib
-from ..mesonlib import MachineChoice, MesonException
 from . import ExtensionModule
+from .. import mesonlib
+from .. import mlog
+from ..build import known_shmod_kwargs
+from ..dependencies import DependencyMethods, PkgConfigDependency, NotFoundDependency, SystemDependency
+from ..environment import detect_cpu_family
+from ..interpreter import ExternalProgramHolder, extract_required_kwarg, permitted_dependency_kwargs
 from ..interpreterbase import (
     noPosargs, noKwargs, permittedKwargs,
     InvalidArguments,
     FeatureNew, FeatureNewKwargs, disablerIfNotFound
 )
-from ..interpreter import ExternalProgramHolder, extract_required_kwarg, permitted_dependency_kwargs
-from ..build import known_shmod_kwargs
-from .. import mlog
-from ..environment import detect_cpu_family
-from ..dependencies import DependencyMethods, PkgConfigDependency, NotFoundDependency, SystemDependency
+from ..mesonlib import MachineChoice, MesonException
 from ..programs import ExternalProgram, NonExistingExternalProgram
 
 mod_kwargs = {'subdir'}
 mod_kwargs.update(known_shmod_kwargs)
 mod_kwargs -= {'name_prefix', 'name_suffix'}
+
 
 class PythonDependency(SystemDependency):
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -774,24 +774,6 @@ class InternalTests(unittest.TestCase):
         kwargs = {'sources': [1, [2, [3]]]}
         self.assertEqual([1, 2, 3], extract(kwargs, 'sources'))
 
-    def test_pkgconfig_module(self):
-        dummystate = mock.Mock()
-        dummystate.subproject = 'dummy'
-        _mock = mock.Mock(spec=mesonbuild.dependencies.ExternalDependency)
-        _mock.pcdep = mock.Mock()
-        _mock.pcdep.name = "some_name"
-        _mock.version_reqs = []
-
-        # pkgconfig dependency as lib
-        deps = mesonbuild.modules.pkgconfig.DependenciesHelper(dummystate, "thislib")
-        deps.add_pub_libs([_mock])
-        self.assertEqual(deps.format_reqs(deps.pub_reqs), "some_name")
-
-        # pkgconfig dependency as requires
-        deps = mesonbuild.modules.pkgconfig.DependenciesHelper(dummystate, "thislib")
-        deps.add_pub_reqs([_mock])
-        self.assertEqual(deps.format_reqs(deps.pub_reqs), "some_name")
-
     def _test_all_naming(self, cc, env, patterns, platform):
         shr = patterns[platform]['shared']
         stc = patterns[platform]['static']


### PR DESCRIPTION
I wanted to get us down to one set of python dependency classes, but that's still not achieved here. What is achieved is a complete set of type annotations for the python module (there's still some places where things fail because we need more typing in the interpreter), the use of the `typed_*` decorators where applicable, and the conversion of the mega `PythonDependency` to a dependency factory. The use of a factory allows us to drop a bunch of legacy cruft that had been mostly purged, but was sitll around because of this one dependency.

@xclaesse I dropped the test that checked the pkg_config.pcdep test, but I'm not sure if you were specifically trying to test `.pcdep` or if that was just the method you used to test the module itself. If the latter I can rewrite the test instead.