### PR TITLE
Ifort xilink subsystem

### DIFF
--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1244,6 +1244,12 @@ class XilinkDynamicLinker(VisualStudioLikeLinkerMixin, DynamicLinker):
                  direct: bool = True):
         super().__init__(['xilink.exe'], for_machine, '', always_args, version=version)
 
+    def get_gui_app_args(self, value: bool) -> T.List[str]:
+        return self.get_win_subsystem_args("windows" if value else "console")
+
+    def get_win_subsystem_args(self, value: str) -> T.List[str]:
+        return self._apply_prefix([f'/SUBSYSTEM:{value.upper()}'])
+
 
 class SolarisDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 


### PR DESCRIPTION
Somewhere between 0.56 and 0.57, linking using Intel [Visual] Fortran on Windows was broken, due to a failure to specify the target windows subsystem.  This patch restores specification of the /subsystem:xxx argument (where xxx is console, unless otherwise specified by the win_subsystem option.