### PR TITLE
msubprojects: catch exceptions and continue with others

### DIFF
--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -70,7 +70,11 @@ class Runner:
 
     def run(self):
         self.logger.start(self.wrap.name)
-        result = self.run_method()
+        try:
+            result = self.run_method()
+        except MesonException as e:
+            self.log(mlog.red('Error:'), str(e))
+            result = False
         self.logger.done(self.wrap.name, self.log_queue)
         return result
 


### PR DESCRIPTION
If the command fails for one subproject we should still continue with
others. Failed subprojects are reported at the end.

This issue became more problematic when doing parallel tasks because the
reason the command fails was completely hidden by other parallel tasks.