### PR TITLE
modules: Add API to add test

### DIFF
--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -18,7 +18,7 @@
 import os
 import typing as T
 
-from .. import build
+from .. import build, mesonlib
 from ..mesonlib import relpath, HoldableObject
 from ..interpreterbase.decorators import noKwargs, noPosargs
 
@@ -91,6 +91,17 @@ class ModuleState:
                      version_func: T.Optional[T.Callable[['ExternalProgram'], str]] = None,
                      wanted: T.Optional[str] = None) -> 'ExternalProgram':
         return self._interpreter.find_program_impl(prog, required=required, version_func=version_func, wanted=wanted)
+
+    def test(self, args: T.Tuple[str, T.Union[build.Executable, build.Jar, 'ExternalProgram', mesonlib.File]],
+             workdir: T.Optional[str] = None,
+             env: T.Union[T.List[str], T.Dict[str, str], str] = None,
+             depends: T.List[T.Union[build.CustomTarget, build.BuildTarget]] = None) -> None:
+        kwargs = {'workdir': workdir,
+                  'env': env,
+                  'depends': depends,
+                  }
+        # TODO: Use interpreter internal API, but we need to go through @typed_kwargs
+        self._interpreter.func_test(self.node, args, kwargs)
 
 
 class ModuleObject(HoldableObject):

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1136,10 +1136,8 @@ class GnomeModule(ExtensionModule):
             check_env = ['DOC_MODULE=' + modulename,
                          'DOC_MAIN_SGML_FILE=' + main_file]
             check_args = [targetname + '-check', check_cmd]
-            check_kwargs = {'env': check_env,
-                            'workdir': os.path.join(state.environment.get_build_dir(), state.subdir),
-                            'depends': custom_target}
-            self.interpreter.add_test(state.current_node, check_args, check_kwargs, True)
+            check_workdir = os.path.join(state.environment.get_build_dir(), state.subdir)
+            state.test(check_args, env=check_env, workdir=check_workdir, depends=custom_target)
         res = [custom_target, alias_target]
         if kwargs.get('install', True):
             res.append(state.backend.get_executable_serialisation(command + args))


### PR DESCRIPTION
This fix kwargs not going through typed_kwargs() decorator that sets
defaults.

Fixes: #9009