### PR TITLE
Qt module generated sources

### DIFF
--- a/docs/markdown/_include_qt_base.md
+++ b/docs/markdown/_include_qt_base.md
@@ -21,8 +21,9 @@ It takes no positional arguments, and the following keyword arguments:
 Compiles Qt's ui files (.ui) into header files.
 
 It takes no positional arguments, and the following keyword arguments:
-  - `sources` (File | string)[]: A list of sources to be transpiled. Required,
-    must have at least one source
+  - `sources` (File | string | custom_target | custom_target index | generator_output)[]:
+    A list of sources to be transpiled. Required, must have at least one source
+    *New in 0.60.0*: support for custom_target, custom_target_index, and generator_output.
   - `extra_args` string[]: Extra arguments to pass directly to `qt-uic`
   - `method` string: The method to use to detect qt, see `dependency()` for more
     information.

--- a/docs/markdown/_include_qt_base.md
+++ b/docs/markdown/_include_qt_base.md
@@ -8,8 +8,9 @@ It takes no positional arguments, and the following keyword arguments:
   - `name` (string | empty): if provided a single .cpp file will be generated,
     and the output of all qrc files will be combined in this file, otherwise
     each qrc file be written to it's own cpp file.
-  - `sources` (File | string)[]: A list of sources to be transpiled. Required,
-    must have at least one source
+  - `sources` (File | string | custom_target | custom_target index | generator_output)[]:
+    A list of sources to be transpiled. Required, must have at least one source
+    *New in 0.60.0*: support for custom_target, custom_target_index, and generator_output.
   - `extra_args` string[]: Extra arguments to pass directly to `qt-rcc`
   - `method` string: The method to use to detect qt, see `dependency()` for more
     information.

--- a/docs/markdown/_include_qt_base.md
+++ b/docs/markdown/_include_qt_base.md
@@ -35,9 +35,12 @@ Compiles Qt's moc files (.moc) into header and/or source files. At least one of
 the keyword arguments `headers` and `sources` must be provided.
 
 It takes no positional arguments, and the following keyword arguments:
-  - `sources` (File | string)[]: A list of sources to be transpiled into .moc
-    files for manual inclusion.
-  - `headers` (File | string)[]: A list of headers to be transpiled into .cpp files
+  - `sources` (File | string | custom_target | custom_target index | generator_output)[]:
+    A list of sources to be transpiled into .moc files for manual inclusion.
+    *New in 0.60.0*: support for custom_target, custom_target_index, and generator_output.
+  - `headers` (File | string | custom_target | custom_target index | generator_output)[]:
+     A list of headers to be transpiled into .cpp files
+    *New in 0.60.0*: support for custom_target, custom_target_index, and generator_output.
   - `extra_args` string[]: Extra arguments to pass directly to `qt-moc`
   - `method` string: The method to use to detect qt, see `dependency()` for more
     information.

--- a/docs/markdown/_include_qt_base.md
+++ b/docs/markdown/_include_qt_base.md
@@ -85,7 +85,9 @@ It returns an array of targets and sources to pass to a compilation target.
 This method generates the necessary targets to build translation files with
 lrelease, it takes no positional arguments, and the following keyword arguments:
 
- - `ts_files` (str | File)[], the list of input translation files produced by Qt's lupdate tool.
+ - `ts_files` (File | string | custom_target | custom_target index | generator_output)[]:
+    the list of input translation files produced by Qt's lupdate tool.
+    *New in 0.60.0*: support for custom_target, custom_target_index, and generator_output.
  - `install` bool: when true, this target is installed during the install step (optional).
  - `install_dir` string: directory to install to (optional).
  - `build_by_default` bool: when set to true, to have this target be built by

--- a/docs/markdown/snippets/qt_module_generated_inputs.md
+++ b/docs/markdown/snippets/qt_module_generated_inputs.md
@@ -1,0 +1,13 @@
+## The qt modules now accept generated outputs as inputs for qt.compile_*
+
+This means you can uset `custom_target`, custom_target indecies
+(`custom_target[0]`, for example), or the output of `generator.process` as
+inputs to the various `qt.compile_*` methods.
+
+```meson
+qt = import('qt5')
+
+ct = custom_target(...)
+
+out = qt.compile_ui(sources : ct)
+```

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2434,6 +2434,9 @@ Try setting b_lundef to false instead.'''.format(self.coredata.options[OptionKey
     @T.overload
     def source_strings_to_files(self, sources: T.List['mesonlib.FileOrString']) -> T.List['mesonlib.File']: ...
 
+    @T.overload
+    def source_strings_to_files(self, sources: T.List['SourceInputs']) -> T.List['SourceOutputs']: ...
+
     def source_strings_to_files(self, sources: T.List['SourceInputs']) -> T.List['SourceOutputs']:
         """Lower inputs to a list of Targets and Files, replacing any strings.
 


### PR DESCRIPTION
This has two things in it, a fix for #9007, in which CustomTargets were erroneously excluded as inputs to the various `qt.preprocess` arguments, and then a series of patches to make the various `compile_*` arguments accept all forms of generated inputs, not just `CustomTargets` (including CustomTargetIndex and GeneratedList inputs`.

@nirbheek: the first patch to this series should be pulled for 0.59.1, but the rest should not.

@ximion: can you see if the first patch fixes your issue?