### PR TITLE
Use appropriate compiler for the source file for "links" tests with file argument

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2513,7 +2513,10 @@ the following methods:
   positional argument compiles and links, you can specify external
   dependencies to use with `dependencies` keyword argument, `code` can
   be either a string containing source code or a `file` object
-  pointing to the source code.
+  pointing to the source code.  *Since 0.60.0*, if the `file` object's
+  suffix does not match the compiler object's language, the compiler
+  corresponding to the suffix is used to compile the source, while the
+  target of the `links` method is used to link the resulting object file.
 
 - `run(code)`: attempts to compile and execute the given code fragment,
   returns a run result object, you can specify external dependencies

--- a/docs/markdown/snippets/mixed_language_linker_tests.md
+++ b/docs/markdown/snippets/mixed_language_linker_tests.md
@@ -1,0 +1,21 @@
+== Link tests can use sources for a different compiler ==
+
+Usually, the `links` method of the compiler object uses a single program
+invocation to do both compilation and linking.  Starting with this version,
+whenever the argument to `links` is a file, Meson will check if the file
+suffix matches the compiler object's language.  If they do not match,
+as in the following case:
+
+```
+cxx = meson.get_compiler('cpp')
+cxx.links(files('test.c'))
+```
+
+then Meson will separate compilation and linking.  In the above example
+`test.c` will be compiled with a C compiler and the resulting object file
+will be linked with a C++ compiler.  This makes it possible to detect
+misconfigurations of the compilation environment, for example when the
+C++ runtime is not compatible with the one expected by the C compiler.
+
+For this reason, passing file arguments with an unrecognized suffix to
+`links` will cause a warning.

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     'is_known_suffix',
     'lang_suffixes',
     'sort_clink',
+    'SUFFIX_TO_LANG',
 
     'compiler_from_language',
     'detect_compiler_for',
@@ -148,6 +149,7 @@ from .compilers import (
     lang_suffixes,
     LANGUAGES_USING_LDFLAGS,
     sort_clink,
+    SUFFIX_TO_LANG,
 )
 from .detect import (
     compiler_from_language,

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -32,13 +32,13 @@ from ..arglist import CompilerArgs
 
 if T.TYPE_CHECKING:
     from ..build import BuildTarget
-    from ..coredata import OptionDictType, KeyedOptionDictType
+    from ..coredata import KeyedOptionDictType
     from ..envconfig import MachineInfo
     from ..environment import Environment
     from ..linkers import DynamicLinker, RSPFileSyntax
     from ..dependencies import Dependency
 
-    CompilerType = T.TypeVar('CompilerType', bound=Compiler)
+    CompilerType = T.TypeVar('CompilerType', bound='Compiler')
     _T = T.TypeVar('_T')
 
 """This file contains the data files of all compilers Meson knows
@@ -276,7 +276,7 @@ base_options: 'KeyedOptionDictType' = {
     OptionKey('b_pch'): coredata.UserBooleanOption('Use precompiled headers', True),
     OptionKey('b_lto'): coredata.UserBooleanOption('Use link time optimization', False),
     OptionKey('b_lto'): coredata.UserBooleanOption('Use link time optimization', False),
-    OptionKey('b_lto_threads'): coredata.UserIntegerOption('Use multiple threads for Link Time Optimization', (None, None,0)),
+    OptionKey('b_lto_threads'): coredata.UserIntegerOption('Use multiple threads for Link Time Optimization', (None, None, 0)),
     OptionKey('b_lto_mode'): coredata.UserComboOption('Select between different LTO modes.',
                                                       ['default', 'thin'],
                                                       'default'),
@@ -680,8 +680,8 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         raise EnvironmentException('Language %s does not support sizeof checks.' % self.get_display_language())
 
     def alignment(self, typename: str, prefix: str, env: 'Environment', *,
-                 extra_args: T.Optional[T.List[str]] = None,
-                 dependencies: T.Optional[T.List['Dependency']] = None) -> int:
+                  extra_args: T.Optional[T.List[str]] = None,
+                  dependencies: T.Optional[T.List['Dependency']] = None) -> int:
         raise EnvironmentException('Language %s does not support alignment checks.' % self.get_display_language())
 
     def has_function(self, funcname: str, prefix: str, env: 'Environment', *,
@@ -767,7 +767,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
             no_ccache = False
             if isinstance(code, str):
                 srcname = os.path.join(tmpdirname,
-                                    'testfile.' + self.default_suffix)
+                                       'testfile.' + self.default_suffix)
                 with open(srcname, 'w', encoding='utf-8') as ofile:
                     ofile.write(code)
                 # ccache would result in a cache miss
@@ -1231,7 +1231,6 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
                  disable_cache: bool = False) -> T.Tuple[bool, bool]:
         with self._build_wrapper(code, env, extra_args, dependencies, mode, disable_cache=disable_cache) as p:
             return p.returncode == 0, p.cached
-
 
     def links(self, code: 'mesonlib.FileOrString', env: 'Environment', *,
               extra_args: T.Union[None, T.List[str], CompilerArgs, T.Callable[[CompileCheckMode], T.List[str]]] = None,

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -791,7 +791,8 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
             # extra_args must be last because it could contain '/link' to
             # pass args to VisualStudio's linker. In that case everything
             # in the command line after '/link' is given to the linker.
-            commands += extra_args
+            if extra_args:
+                commands += extra_args
             # Generate full command-line with the exelist
             command_list = self.get_exelist() + commands.to_native()
             mlog.debug('Running compile:')

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -84,6 +84,8 @@ for _l in clink_langs + ('vala',):
     clink_suffixes += lang_suffixes[_l]
 clink_suffixes += ('h', 'll', 's')
 all_suffixes = set(itertools.chain(*lang_suffixes.values(), clink_suffixes))  # type: T.Set[str]
+SUFFIX_TO_LANG = dict(itertools.chain(*(
+    [(suffix, lang) for suffix in v] for lang, v in lang_suffixes.items()))) # type: T.Dict[str, str]
 
 # Languages that should use LDFLAGS arguments when linking.
 LANGUAGES_USING_LDFLAGS = {'objcpp', 'cpp', 'objc', 'c', 'fortran', 'd', 'cuda'}  # type: T.Set[str]

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -421,6 +421,10 @@ class File(HoldableObject):
             absdir = builddir
         return os.path.join(absdir, self.relative_name())
 
+    @property
+    def suffix(self) -> str:
+        return os.path.splitext(self.fname)[1][1:].lower()
+
     def endswith(self, ending: str) -> bool:
         return self.fname.endswith(ending)
 

--- a/test cases/unit/97 compiler.links file arg/meson.build
+++ b/test cases/unit/97 compiler.links file arg/meson.build
@@ -1,0 +1,11 @@
+project('test', ['c', 'cpp'])
+
+cc = meson.get_compiler('c')
+cxx = meson.get_compiler('cpp')
+
+# used by run_unittests.py to grab the path to the C and C++ compilers
+assert(cc.compiles(files('test.c')))
+assert(cxx.compiles(files('test.c')))
+
+assert(cc.links(files('test.c')))
+assert(cxx.links(files('test.c')))

--- a/test cases/unit/97 compiler.links file arg/test.c
+++ b/test cases/unit/97 compiler.links file arg/test.c
@@ -1,0 +1,1 @@
+int main(void) { return 0; }

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1924,6 +1924,20 @@ class AllPlatformTests(BasePlatformTests):
                'recommended as it is not supported on some platforms')
         self.assertIn(msg, out)
 
+    def test_mixed_language_linker_check(self):
+        testdir = os.path.join(self.unit_test_dir, '97 compiler.links file arg')
+        self.init(testdir)
+        cmds = self.get_meson_log_compiler_checks()
+        self.assertEqual(len(cmds), 5)
+        # Path to the compilers, gleaned from cc.compiles tests
+        cc = cmds[0][0]
+        cxx = cmds[1][0]
+        # cc.links
+        self.assertEqual(cmds[2][0], cc)
+        # cxx.links with C source
+        self.assertEqual(cmds[3][0], cc)
+        self.assertEqual(cmds[4][0], cxx)
+
     def test_ndebug_if_release_disabled(self):
         testdir = os.path.join(self.unit_test_dir, '28 ndebug if-release')
         self.init(testdir, extra_args=['--buildtype=release', '-Db_ndebug=if-release'])


### PR DESCRIPTION
These patches makes it possible to test that the C++ driver (e.g. g++) can be used to link C objects, for example to check that the C compiler's `libsanitizer` is compatible with the one included by the C++ driver.

For example `meson.get_compiler('cpp').links(files('main.c'))` results in the following log:

```
Command line:  cc /home/pbonzini/ff/main.c -o /home/pbonzini/ff/build/meson-private/tmpa0bmxj_m/output.obj -pipe -D_FILE_OFFSET_BITS=64 -O0
Command line:  c++ /home/pbonzini/ff/build/meson-private/tmpa0bmxj_m/output.obj -o /home/pbonzini/ff/build/meson-private/tmpa0bmxj_m/output.exe -O0
```
Fixes: #7703
