### PR TITLE
qt: Allow CustomTargets for qt.preprocess source arguments

### DIFF
--- a/docs/markdown/_include_qt_base.md
+++ b/docs/markdown/_include_qt_base.md
@@ -62,10 +62,10 @@ sources += qt.preprocess(qresources : ['resources'])
 ```
 
 This method takes the following keyword arguments:
- - `qresources` (string | File | CustomTarget | BuildTarget)[]: Passed to the RCC compiler
- - `ui_files`: (string | File | CustomTarget | BuilduTarget)[]: Passed the `uic` compiler
- - `moc_sources`: (string | File | CustomTarget | BuildTarget)[]: Passed the `moc` compiler the
- - `moc_headers`: (string | File | CustomTarget | BuildTarget)[]: Passied the `moc` compiler. These will be converted into .cpp files
+ - `qresources` (string | File)[]: Passed to the RCC compiler
+ - `ui_files`: (string | File | CustomTarget)[]: Passed the `uic` compiler
+ - `moc_sources`: (string | File | CustomTarget)[]: Passed the `moc` compiler. These are converted into .moc files meant to be `#include`ed
+ - `moc_headers`: (string | File | CustomTarget)[]: Passied the `moc` compiler. These will be converted into .cpp files
  - `include_directories` (IncludeDirectories | string)[], the directories to add to header search path for `moc`
  - `moc_extra_arguments` string[]: any additional arguments to `moc`. Since v0.44.0.
  - `uic_extra_arguments` string[]: any additional arguments to `uic`. Since v0.49.0.

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -52,7 +52,7 @@ if T.TYPE_CHECKING:
 
         """Keyword arguments for the Ui Compiler method."""
 
-        sources: T.List[FileOrString]
+        sources: T.Sequence[T.Union[FileOrString, build.CustomTarget]]
         extra_args: T.List[str]
         method: str
 
@@ -60,8 +60,8 @@ if T.TYPE_CHECKING:
 
         """Keyword arguments for the Moc Compiler method."""
 
-        sources: T.List[FileOrString]
-        headers: T.List[FileOrString]
+        sources: T.List[T.Union[FileOrString, build.CustomTarget]]
+        headers: T.List[T.Union[FileOrString, build.CustomTarget]]
         extra_args: T.List[str]
         method: str
         include_directories: T.List[T.Union[str, build.IncludeDirs]]
@@ -70,10 +70,10 @@ if T.TYPE_CHECKING:
     class PreprocessKwArgs(TypedDict):
 
         sources: T.List[FileOrString]
-        moc_sources: T.List[FileOrString]
-        moc_headers: T.List[FileOrString]
+        moc_sources: T.List[T.Union[FileOrString, build.CustomTarget]]
+        moc_headers: T.List[T.Union[FileOrString, build.CustomTarget]]
         qresources: T.List[FileOrString]
-        ui_files: T.List[FileOrString]
+        ui_files: T.List[T.Union[FileOrString, build.CustomTarget]]
         moc_extra_arguments: T.List[str]
         rcc_extra_arguments: T.List[str]
         uic_extra_arguments: T.List[str]
@@ -366,8 +366,8 @@ class QtBaseModule(ExtensionModule):
     @noPosargs
     @typed_kwargs(
         'qt.compile_moc',
-        KwargInfo('sources', ContainerTypeInfo(list, (File, str)), listify=True, default=[]),
-        KwargInfo('headers', ContainerTypeInfo(list, (File, str)), listify=True, default=[]),
+        KwargInfo('sources', ContainerTypeInfo(list, (File, str, build.CustomTarget)), listify=True, default=[]),
+        KwargInfo('headers', ContainerTypeInfo(list, (File, str, build.CustomTarget)), listify=True, default=[]),
         KwargInfo('extra_args', ContainerTypeInfo(list, str), listify=True, default=[]),
         KwargInfo('method', str, default='auto'),
         KwargInfo('include_directories', ContainerTypeInfo(list, (build.IncludeDirs, str)), listify=True, default=[]),
@@ -414,9 +414,9 @@ class QtBaseModule(ExtensionModule):
         'qt.preprocess',
         KwargInfo('sources', ContainerTypeInfo(list, (File, str)), listify=True, default=[], deprecated='0.59.0'),
         KwargInfo('qresources', ContainerTypeInfo(list, (File, str)), listify=True, default=[]),
-        KwargInfo('ui_files', ContainerTypeInfo(list, (File, str)), listify=True, default=[]),
-        KwargInfo('moc_sources', ContainerTypeInfo(list, (File, str)), listify=True, default=[]),
-        KwargInfo('moc_headers', ContainerTypeInfo(list, (File, str)), listify=True, default=[]),
+        KwargInfo('ui_files', ContainerTypeInfo(list, (File, str, build.CustomTarget)), listify=True, default=[]),
+        KwargInfo('moc_sources', ContainerTypeInfo(list, (File, str, build.CustomTarget)), listify=True, default=[]),
+        KwargInfo('moc_headers', ContainerTypeInfo(list, (File, str, build.CustomTarget)), listify=True, default=[]),
         KwargInfo('moc_extra_arguments', ContainerTypeInfo(list, str), listify=True, default=[], since='0.44.0'),
         KwargInfo('rcc_extra_arguments', ContainerTypeInfo(list, str), listify=True, default=[], since='0.49.0'),
         KwargInfo('uic_extra_arguments', ContainerTypeInfo(list, str), listify=True, default=[], since='0.49.0'),


### PR DESCRIPTION
This works for `moc_*` and `ui_files`, but it never could have worked
for `qresources` due to the implementation assuming a `str` or `File`.
To restore previous compatibility I've added `CustomTarget` where it
would have worked, but not where it would have failed, the former would
raised an exception along the lines anyway.

Fixes #9007