### PR TITLE
Allow cython to be transpiled to c++

### DIFF
--- a/docs/markdown/Cython.md
+++ b/docs/markdown/Cython.md
@@ -31,3 +31,32 @@ py.extension_module(
     dependencies : dep_py,
 )
 ```
+
+## C++ intermediate support
+
+*(New in 0.60.0)*
+
+An option has been added to control this, called `cython_language`. This can be
+either `'c'` or `'cpp'`.
+
+For those coming from setuptools/distutils, they will find two things. First,
+meson ignores `# distutils: language = c++` inline directives. Second that Meson
+allows options only on a per-target granularity. This means that if you need to mix
+cython files being transpiled to C and to C++ you need two targets:
+
+```meson
+project('my project', 'cython')
+
+cython_cpp_lib = static_library(
+    'helper_lib',
+    'foo_cpp.pyx',  # will be transpiled to C++
+    override_options : ['cython_language=cpp'],
+)
+
+py.extension_module(
+    'foo',
+    'foo.pyx',  # will be transpiled to C
+    link_with : [cython_cpp_lib],
+    dependencies : dep_py,
+)
+```

--- a/docs/markdown/snippets/cython-c++-intermediate.md
+++ b/docs/markdown/snippets/cython-c++-intermediate.md
@@ -1,0 +1,22 @@
+## Cython can now transpile to C++ as an intermediate language
+
+Built-in cython support currently only allows C as an intermediate language, now
+C++ is also allowed. This can be set via the `cython_language` option, either on
+the command line, or in the meson.build files.
+
+```meson
+project(
+  'myproject',
+  'cython',
+  default_options : ['cython_language=cpp'],
+)
+```
+
+or on a per target basis with:
+```meson
+python.extension_module(
+  'mod',
+  'mod.pyx',
+  override_options : ['cython_language=cpp'],
+)
+```

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1598,9 +1598,11 @@ class NinjaBackend(backends.Backend):
         args += self.build.get_global_args(cython, target.for_machine)
         args += self.build.get_project_args(cython, target.subproject, target.for_machine)
 
+        ext = opt_proxy[OptionKey('language', machine=target.for_machine, lang='cython')].value
+
         for src in target.get_sources():
             if src.endswith('.pyx'):
-                output = os.path.join(self.get_target_private_dir(target), f'{src}.c')
+                output = os.path.join(self.get_target_private_dir(target), f'{src}.{ext}')
                 args = args.copy()
                 args += cython.get_output_args(output)
                 element = NinjaBuildElement(
@@ -1622,7 +1624,7 @@ class NinjaBackend(backends.Backend):
                     ssrc = os.path.join(gen.get_subdir(), ssrc)
                 if ssrc.endswith('.pyx'):
                     args = args.copy()
-                    output = os.path.join(self.get_target_private_dir(target), f'{ssrc}.c')
+                    output = os.path.join(self.get_target_private_dir(target), f'{ssrc}.{ext}')
                     args += cython.get_output_args(output)
                     element = NinjaBuildElement(
                         self.all_outputs, [output],

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -68,6 +68,11 @@ class CythonCompiler(Compiler):
                 'Python version to target',
                 ['2', '3'],
                 '3',
+            ),
+            OptionKey('language', machine=self.for_machine, lang=self.language): coredata.UserComboOption(
+                'Output C or C++ files',
+                ['c', 'cpp'],
+                'c',
             )
         })
         return opts
@@ -76,4 +81,7 @@ class CythonCompiler(Compiler):
         args: T.List[str] = []
         key = options[OptionKey('version', machine=self.for_machine, lang=self.language)]
         args.append(f'-{key.value}')
+        lang = options[OptionKey('language', machine=self.for_machine, lang=self.language)]
+        if lang.value == 'cpp':
+            args.append('--cplus')
         return args

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1241,9 +1241,14 @@ external dependencies (including libraries) must go to "dependencies".''')
         args = [a.lower() for a in args]
         langs = set(self.coredata.compilers[for_machine].keys())
         langs.update(args)
-        if ('vala' in langs or 'cython' in langs) and 'c' not in langs:
-            if 'vala' in langs:
-                FeatureNew.single_use('Adding Vala language without C', '0.59.0', self.subproject)
+        # We'd really like to add cython's default language here, but it can't
+        # actually be done because the cython compiler hasn't been initialized,
+        # so we can't actually get the option yet. Because we can't know what
+        # compiler to add by default, and we don't want to add unnecessary
+        # compilers we don't add anything for cython here, and instead do it
+        # When the first cython target using a particular language is used.
+        if 'vala' in langs and 'c' not in langs:
+            FeatureNew.single_use('Adding Vala language without C', '0.59.0', self.subproject)
             args.append('c')
 
         success = True

--- a/test cases/cython/1 basic/libdir/storer.h
+++ b/test cases/cython/1 basic/libdir/storer.h
@@ -1,8 +1,16 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct _Storer Storer;
 
 Storer* storer_new();
 void storer_destroy(Storer *s);
 int storer_get_value(Storer *s);
 void storer_set_value(Storer *s, int v);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test cases/cython/1 basic/test.json
+++ b/test cases/cython/1 basic/test.json
@@ -1,0 +1,10 @@
+{
+  "matrix": {
+    "options": {
+      "cython_language": [
+         { "val": "c" },
+         { "val": "cpp" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This patch adds a new meson built-in option for cython, allowing it to
target C++ instead of C as the intermediate language. This can, of
course, be done on a per-target basis using the `override_options`
keyword argument, or for the entire project.

WIP: there are still some corners here in regards to the automatic
addition of C and C++ compilers when using cython that need to be
resolved.

Fixes #9015