### PR TITLE
C2000 compiler also accepts *.cla files

### DIFF
--- a/docs/markdown/snippets/Cross_compilation_with_C2000_toolchain_supports_CLA_files.md
+++ b/docs/markdown/snippets/Cross_compilation_with_C2000_toolchain_supports_CLA_files.md
@@ -1,0 +1,3 @@
+## Added support for CLA sources when cross-compiling with the C2000 toolchain
+
+Support for CLA sources has been added for cross-compilation with the C2000 toolchain.

--- a/mesonbuild/compilers/mixins/c2000.py
+++ b/mesonbuild/compilers/mixins/c2000.py
@@ -59,8 +59,10 @@ class C2000Compiler(Compiler):
         if not self.is_cross:
             raise EnvironmentException('c2000 supports only cross-compilation.')
         self.id = 'c2000'
-        # Assembly
-        self.can_compile_suffixes.add('asm')
+
+        self.can_compile_suffixes.add('asm')    # Assembly
+        self.can_compile_suffixes.add('cla')    # Control Law Accelerator (CLA)
+
         default_warn_args = []  # type: T.List[str]
         self.warn_args = {'0': [],
                           '1': default_warn_args,


### PR DESCRIPTION
Some TI C2000 controllers own a [Control Law Accelerator](https://software-dl.ti.com/C2000/docs/cla_software_dev_guide/intro.html) (CLA, like some kind of limited co-processor). 
For code that should run on the CLA it is mandatory that the suffix is ".cla", so this PR just adds this suffix to the list of compilable source types.
