### PR TITLE
ast: Add dummy "support" for fstrings in the ast package

### DIFF
--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -197,6 +197,10 @@ class AstInterpreter(InterpreterBase):
     def method_call(self, node: BaseNode) -> bool:
         return True
 
+    def evaluate_fstring(self, node: mparser.FormatStringNode) -> str:
+        assert(isinstance(node, mparser.FormatStringNode))
+        return node.value
+
     def evaluate_arithmeticstatement(self, cur: ArithmeticNode) -> int:
         self.evaluate_statement(cur.left)
         self.evaluate_statement(cur.right)

--- a/mesonbuild/ast/printer.py
+++ b/mesonbuild/ast/printer.py
@@ -70,6 +70,10 @@ class AstPrinter(AstVisitor):
         assert isinstance(node.value, str)
         self.append("'" + node.value + "'", node)
 
+    def visit_FormatStringNode(self, node: mparser.FormatStringNode) -> None:
+        assert isinstance(node.value, str)
+        self.append("f'" + node.value + "'", node)
+
     def visit_ContinueNode(self, node: mparser.ContinueNode) -> None:
         self.append('continue', node)
 
@@ -254,6 +258,9 @@ class AstJSONPrinter(AstVisitor):
         self.gen_ElementaryNode(node)
 
     def visit_StringNode(self, node: mparser.StringNode) -> None:
+        self.gen_ElementaryNode(node)
+
+    def visit_FormatStringNode(self, node: mparser.FormatStringNode) -> None:
         self.gen_ElementaryNode(node)
 
     def visit_ArrayNode(self, node: mparser.ArrayNode) -> None:

--- a/mesonbuild/ast/visitor.py
+++ b/mesonbuild/ast/visitor.py
@@ -36,6 +36,9 @@ class AstVisitor:
     def visit_StringNode(self, node: mparser.StringNode) -> None:
         self.visit_default_func(node)
 
+    def visit_FormatStringNode(self, node: mparser.FormatStringNode) -> None:
+        self.visit_default_func(node)
+
     def visit_ContinueNode(self, node: mparser.ContinueNode) -> None:
         self.visit_default_func(node)
 

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -5167,6 +5167,7 @@ class AllPlatformTests(BasePlatformTests):
             'IdNode': [('value', None, str)],
             'NumberNode': [('value', None, int)],
             'StringNode': [('value', None, str)],
+            'FormatStringNode': [('value', None, str)],
             'ContinueNode': [],
             'BreakNode': [],
             'ArgumentNode': [('positional', accept_node_list), ('kwargs', accept_kwargs)],

--- a/test cases/unit/57 introspection/meson.build
+++ b/test cases/unit/57 introspection/meson.build
@@ -27,6 +27,8 @@ var1 = '1'
 var2 = 2.to_string()
 var3 = 'test3'
 
+var4 = f'test @var1@ string' # TODO: Actually implement fstrings
+
 cus1 = custom_target('custom target test 1', output: 'file2', input: 'cp.py',
                      command: [find_program('cp.py'), '@INPUT@', '@OUTPUT@'])
 cus2 = custom_target('custom target test 2', output: 'file3', input: cus1,


### PR DESCRIPTION
Without this PR, introspection fails if any fstrings are present.