### PR TITLE
build: learn to take CustomTargetIndex as custom_target command argument

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2186,6 +2186,10 @@ class CommandBase:
             elif isinstance(c, (BuildTarget, CustomTarget)):
                 self.dependencies.append(c)
                 final_cmd.append(c)
+            elif isinstance(c, CustomTargetIndex):
+                FeatureNew.single_use('CustomTargetIndex for command argument', '0.60', self.subproject)
+                self.dependencies.append(c.target)
+                final_cmd += self.flatten_command(File.from_built_file(c.get_subdir(), c.get_filename()))
             elif isinstance(c, list):
                 final_cmd += self.flatten_command(c)
             else:

--- a/test cases/common/49 custom target/meson.build
+++ b/test cases/common/49 custom target/meson.build
@@ -46,6 +46,12 @@ endif
 
 assert(mytarget_disabled, 'Disabled custom target should not be found.')
 
+mytarget_ci = custom_target('bindat_ci',
+output : 'data_ci.dat',
+input : 'data_source.txt',
+command : [python, comp, '--input=@INPUT@', '--output=@OUTPUT@', mytarget.to_list()],
+)
+
 mytarget_disabler = custom_target('bindat',
 output : 'data.dat',
 input : disabler(),


### PR DESCRIPTION
Fix ERROR: Argument <CustomTargetIndex:...>[0]> in "command" is invalid.
