### PR TITLE
Add type checking for the Compiler and RunResult objects

### DIFF
--- a/docs/markdown/snippets/remove_unittest_args_method.md
+++ b/docs/markdown/snippets/remove_unittest_args_method.md
@@ -1,0 +1,4 @@
+## Compiler.unittest_args has been removed
+
+It's never been documented, and it's been marked deprecated for a long time, so
+let's remove it.

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -45,6 +45,7 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..linkers import DynamicLinker
     from ..programs import ExternalProgram
+    from .compilers import CompileCheckMode
 
     CompilerMixinBase = Compiler
 else:
@@ -81,7 +82,7 @@ class CCompiler(CLikeCompiler, Compiler):
 
     def has_header_symbol(self, hname: str, symbol: str, prefix: str,
                           env: 'Environment', *,
-                          extra_args: T.Optional[T.List[str]] = None,
+                          extra_args: T.Union[None, T.List[str], T.Callable[['CompileCheckMode'], T.List[str]]] = None,
                           dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
         fargs = {'prefix': prefix, 'header': hname, 'symbol': symbol}
         t = '''{prefix}

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -550,13 +550,15 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         return self.default_suffix
 
     def get_define(self, dname: str, prefix: str, env: 'Environment',
-                   extra_args: T.List[str], dependencies: T.List['Dependency'],
+                   extra_args: T.Union[T.List[str], T.Callable[[CompileCheckMode], T.List[str]]],
+                   dependencies: T.List['Dependency'],
                    disable_cache: bool = False) -> T.Tuple[str, bool]:
         raise EnvironmentException('%s does not support get_define ' % self.get_id())
 
     def compute_int(self, expression: str, low: T.Optional[int], high: T.Optional[int],
                     guess: T.Optional[int], prefix: str, env: 'Environment', *,
-                    extra_args: T.Optional[T.List[str]], dependencies: T.Optional[T.List['Dependency']]) -> int:
+                    extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]],
+                    dependencies: T.Optional[T.List['Dependency']]) -> int:
         raise EnvironmentException('%s does not support compute_int ' % self.get_id())
 
     def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str],
@@ -565,12 +567,12 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
 
     def has_members(self, typename: str, membernames: T.List[str],
                     prefix: str, env: 'Environment', *,
-                    extra_args: T.Optional[T.List[str]] = None,
+                    extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
                     dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
         raise EnvironmentException('%s does not support has_member(s) ' % self.get_id())
 
     def has_type(self, typename: str, prefix: str, env: 'Environment',
-                 extra_args: T.List[str], *,
+                 extra_args: T.Union[T.List[str], T.Callable[[CompileCheckMode], T.List[str]]], *,
                  dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
         raise EnvironmentException('%s does not support has_type ' % self.get_id())
 
@@ -631,7 +633,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         return self.linker.get_option_args(options)
 
     def check_header(self, hname: str, prefix: str, env: 'Environment', *,
-                     extra_args: T.Optional[T.List[str]] = None,
+                     extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
                      dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
         """Check that header is usable.
 
@@ -642,7 +644,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         raise EnvironmentException('Language %s does not support header checks.' % self.get_display_language())
 
     def has_header(self, hname: str, prefix: str, env: 'Environment', *,
-                   extra_args: T.Optional[T.List[str]] = None,
+                   extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
                    dependencies: T.Optional[T.List['Dependency']] = None,
                    disable_cache: bool = False) -> T.Tuple[bool, bool]:
         """Check that header is exists.
@@ -663,17 +665,17 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
 
     def has_header_symbol(self, hname: str, symbol: str, prefix: str,
                           env: 'Environment', *,
-                          extra_args: T.Optional[T.List[str]] = None,
+                          extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
                           dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
         raise EnvironmentException('Language %s does not support header symbol checks.' % self.get_display_language())
 
     def run(self, code: 'mesonlib.FileOrString', env: 'Environment', *,
-            extra_args: T.Optional[T.List[str]] = None,
+            extra_args: T.Union[T.List[str], T.Callable[[CompileCheckMode], T.List[str]], None] = None,
             dependencies: T.Optional[T.List['Dependency']] = None) -> RunResult:
         raise EnvironmentException('Language %s does not support run checks.' % self.get_display_language())
 
     def sizeof(self, typename: str, prefix: str, env: 'Environment', *,
-               extra_args: T.Optional[T.List[str]] = None,
+               extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
                dependencies: T.Optional[T.List['Dependency']] = None) -> int:
         raise EnvironmentException('Language %s does not support sizeof checks.' % self.get_display_language())
 
@@ -1163,7 +1165,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         return []
 
     def build_wrapper_args(self, env: 'Environment',
-                           extra_args: T.Union[None, CompilerArgs, T.List[str]],
+                           extra_args: T.Union[None, CompilerArgs, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]],
                            dependencies: T.Optional[T.List['Dependency']],
                            mode: CompileCheckMode = CompileCheckMode.COMPILE) -> CompilerArgs:
         """Arguments to pass the build_wrapper helper.
@@ -1201,7 +1203,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
 
     @contextlib.contextmanager
     def _build_wrapper(self, code: 'mesonlib.FileOrString', env: 'Environment',
-                       extra_args: T.Union[None, CompilerArgs, T.List[str]] = None,
+                       extra_args: T.Union[None, CompilerArgs, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
                        dependencies: T.Optional[T.List['Dependency']] = None,
                        mode: str = 'compile', want_output: bool = False,
                        disable_cache: bool = False,
@@ -1220,7 +1222,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
                 yield r
 
     def compiles(self, code: 'mesonlib.FileOrString', env: 'Environment', *,
-                 extra_args: T.Union[None, T.List[str], CompilerArgs] = None,
+                extra_args: T.Union[None, T.List[str], CompilerArgs, T.Callable[[CompileCheckMode], T.List[str]]] = None,
                  dependencies: T.Optional[T.List['Dependency']] = None,
                  mode: str = 'compile',
                  disable_cache: bool = False) -> T.Tuple[bool, bool]:
@@ -1229,7 +1231,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
 
 
     def links(self, code: 'mesonlib.FileOrString', env: 'Environment', *,
-              extra_args: T.Union[None, T.List[str], CompilerArgs] = None,
+              extra_args: T.Union[None, T.List[str], CompilerArgs, T.Callable[[CompileCheckMode], T.List[str]]] = None,
               dependencies: T.Optional[T.List['Dependency']] = None,
               mode: str = 'compile',
               disable_cache: bool = False) -> T.Tuple[bool, bool]:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -773,7 +773,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
                 # ccache would result in a cache miss
                 no_ccache = True
                 contents = code
-            elif isinstance(code, mesonlib.File):
+            else:
                 srcname = code.fname
                 with open(code.fname, encoding='utf-8') as f:
                     contents = f.read()
@@ -781,11 +781,13 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
             # Construct the compiler command-line
             commands = self.compiler_args()
             commands.append(srcname)
+
             # Preprocess mode outputs to stdout, so no output args
+            output = self._get_compile_output(tmpdirname, mode)
             if mode != 'preprocess':
-                output = self._get_compile_output(tmpdirname, mode)
                 commands += self.get_output_args(output)
             commands.extend(self.get_compiler_args_for_mode(CompileCheckMode(mode)))
+
             # extra_args must be last because it could contain '/link' to
             # pass args to VisualStudio's linker. In that case everything
             # in the command line after '/link' is given to the linker.

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -667,7 +667,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
                           dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
         raise EnvironmentException('Language %s does not support header symbol checks.' % self.get_display_language())
 
-    def run(self, code: str, env: 'Environment', *,
+    def run(self, code: 'mesonlib.FileOrString', env: 'Environment', *,
             extra_args: T.Optional[T.List[str]] = None,
             dependencies: T.Optional[T.List['Dependency']] = None) -> RunResult:
         raise EnvironmentException('Language %s does not support run checks.' % self.get_display_language())
@@ -808,7 +808,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
             yield result
 
     @contextlib.contextmanager
-    def cached_compile(self, code: str, cdata: coredata.CoreData, *,
+    def cached_compile(self, code: 'mesonlib.FileOrString', cdata: coredata.CoreData, *,
                        extra_args: T.Union[None, T.List[str], CompilerArgs] = None,
                        mode: str = 'link',
                        temp_dir: T.Optional[str] = None) -> T.Iterator[T.Optional[CompileResult]]:
@@ -1200,7 +1200,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         return args
 
     @contextlib.contextmanager
-    def _build_wrapper(self, code: str, env: 'Environment',
+    def _build_wrapper(self, code: 'mesonlib.FileOrString', env: 'Environment',
                        extra_args: T.Union[None, CompilerArgs, T.List[str]] = None,
                        dependencies: T.Optional[T.List['Dependency']] = None,
                        mode: str = 'compile', want_output: bool = False,
@@ -1219,7 +1219,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
             with self.cached_compile(code, env.coredata, extra_args=args, mode=mode, temp_dir=env.scratch_dir) as r:
                 yield r
 
-    def compiles(self, code: str, env: 'Environment', *,
+    def compiles(self, code: 'mesonlib.FileOrString', env: 'Environment', *,
                  extra_args: T.Union[None, T.List[str], CompilerArgs] = None,
                  dependencies: T.Optional[T.List['Dependency']] = None,
                  mode: str = 'compile',
@@ -1228,7 +1228,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
             return p.returncode == 0, p.cached
 
 
-    def links(self, code: str, env: 'Environment', *,
+    def links(self, code: 'mesonlib.FileOrString', env: 'Environment', *,
               extra_args: T.Union[None, T.List[str], CompilerArgs] = None,
               dependencies: T.Optional[T.List['Dependency']] = None,
               mode: str = 'compile',

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -99,7 +99,7 @@ class CPPCompiler(CLikeCompiler, Compiler):
 
     def has_header_symbol(self, hname: str, symbol: str, prefix: str,
                           env: 'Environment', *,
-                          extra_args: T.Optional[T.List[str]] = None,
+                          extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
                           dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
         # Check if it's a C-like symbol
         found, cached = super().has_header_symbol(hname, symbol, prefix, env,

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -24,7 +24,7 @@ from ..mesonlib import (
     is_windows, LibType, OptionKey,
 )
 from .compilers import (Compiler, cuda_buildtype_args, cuda_optimization_args,
-                        cuda_debug_args)
+                        cuda_debug_args, CompileCheckMode)
 
 if T.TYPE_CHECKING:
     from ..build import BuildTarget
@@ -584,7 +584,7 @@ class CudaCompiler(Compiler):
 
     def has_header_symbol(self, hname: str, symbol: str, prefix: str,
                           env: 'Environment', *,
-                          extra_args: T.Optional[T.List[str]] = None,
+                          extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
                           dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
         if extra_args is None:
             extra_args = []

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -42,6 +42,7 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..linkers import DynamicLinker
     from ..programs import ExternalProgram
+    from .compilers import CompileCheckMode
 
 
 class FortranCompiler(CLikeCompiler, Compiler):
@@ -214,7 +215,7 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
         return ['-lgfortran', '-lm']
 
     def has_header(self, hname: str, prefix: str, env: 'Environment', *,
-                   extra_args: T.Optional[T.List[str]] = None,
+                   extra_args: T.Union[None, T.List[str], T.Callable[['CompileCheckMode'], T.List[str]]] = None,
                    dependencies: T.Optional[T.List['Dependency']] = None,
                    disable_cache: bool = False) -> T.Tuple[bool, bool]:
         '''

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -343,7 +343,7 @@ class CLikeCompiler(Compiler):
         return self._sanity_check_impl(work_dir, environment, 'sanitycheckc.c', code)
 
     def check_header(self, hname: str, prefix: str, env: 'Environment', *,
-                     extra_args: T.Optional[T.List[str]] = None,
+                     extra_args: T.Union[None, T.List[str], T.Callable[['CompileCheckMode'], T.List[str]]] = None,
                      dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
         code = f'''{prefix}
         #include <{hname}>'''
@@ -351,7 +351,7 @@ class CLikeCompiler(Compiler):
                              dependencies=dependencies)
 
     def has_header(self, hname: str, prefix: str, env: 'Environment', *,
-                   extra_args: T.Optional[T.List[str]] = None,
+                   extra_args: T.Union[None, T.List[str], T.Callable[['CompileCheckMode'], T.List[str]]] = None,
                    dependencies: T.Optional[T.List['Dependency']] = None,
                    disable_cache: bool = False) -> T.Tuple[bool, bool]:
         code = f'''{prefix}
@@ -367,7 +367,7 @@ class CLikeCompiler(Compiler):
 
     def has_header_symbol(self, hname: str, symbol: str, prefix: str,
                           env: 'Environment', *,
-                          extra_args: T.Optional[T.List[str]] = None,
+                          extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
                           dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
         t = f'''{prefix}
         #include <{hname}>
@@ -422,7 +422,7 @@ class CLikeCompiler(Compiler):
         return cargs, largs
 
     def build_wrapper_args(self, env: 'Environment',
-                           extra_args: T.Union[None, arglist.CompilerArgs, T.List[str]],
+                           extra_args: T.Union[None, arglist.CompilerArgs, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]],
                            dependencies: T.Optional[T.List['Dependency']],
                            mode: CompileCheckMode = CompileCheckMode.COMPILE) -> arglist.CompilerArgs:
         # TODO: the caller should handle the listfing of these arguments
@@ -463,7 +463,7 @@ class CLikeCompiler(Compiler):
         return args
 
     def run(self, code: 'mesonlib.FileOrString', env: 'Environment', *,
-            extra_args: T.Optional[T.List[str]] = None,
+            extra_args: T.Union[T.List[str], T.Callable[[CompileCheckMode], T.List[str]], None] = None,
             dependencies: T.Optional[T.List['Dependency']] = None) -> compilers.RunResult:
         need_exe_wrapper = env.need_exe_wrapper(self.for_machine)
         if need_exe_wrapper and self.exe_wrapper is None:
@@ -489,7 +489,7 @@ class CLikeCompiler(Compiler):
         return compilers.RunResult(True, pe.returncode, so, se)
 
     def _compile_int(self, expression: str, prefix: str, env: 'Environment',
-                     extra_args: T.Optional[T.List[str]],
+                     extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]],
                      dependencies: T.Optional[T.List['Dependency']]) -> bool:
         t = f'''#include <stdio.h>
         {prefix}
@@ -499,7 +499,7 @@ class CLikeCompiler(Compiler):
 
     def cross_compute_int(self, expression: str, low: T.Optional[int], high: T.Optional[int],
                           guess: T.Optional[int], prefix: str, env: 'Environment',
-                          extra_args: T.Optional[T.List[str]] = None,
+                          extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
                           dependencies: T.Optional[T.List['Dependency']] = None) -> int:
         # Try user's guess first
         if isinstance(guess, int):
@@ -550,7 +550,7 @@ class CLikeCompiler(Compiler):
 
     def compute_int(self, expression: str, low: T.Optional[int], high: T.Optional[int],
                     guess: T.Optional[int], prefix: str, env: 'Environment', *,
-                    extra_args: T.Optional[T.List[str]] = None,
+                    extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]],
                     dependencies: T.Optional[T.List['Dependency']] = None) -> int:
         if extra_args is None:
             extra_args = []
@@ -571,7 +571,7 @@ class CLikeCompiler(Compiler):
         return int(res.stdout)
 
     def cross_sizeof(self, typename: str, prefix: str, env: 'Environment', *,
-                     extra_args: T.Optional[T.List[str]] = None,
+                     extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
                      dependencies: T.Optional[T.List['Dependency']] = None) -> int:
         if extra_args is None:
             extra_args = []
@@ -587,7 +587,7 @@ class CLikeCompiler(Compiler):
         return self.cross_compute_int(f'sizeof({typename})', None, None, None, prefix, env, extra_args, dependencies)
 
     def sizeof(self, typename: str, prefix: str, env: 'Environment', *,
-               extra_args: T.Optional[T.List[str]] = None,
+               extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
                dependencies: T.Optional[T.List['Dependency']] = None) -> int:
         if extra_args is None:
             extra_args = []
@@ -661,7 +661,7 @@ class CLikeCompiler(Compiler):
         return align
 
     def get_define(self, dname: str, prefix: str, env: 'Environment',
-                   extra_args: T.Optional[T.List[str]],
+                   extra_args: T.Union[T.List[str], T.Callable[[CompileCheckMode], T.List[str]]],
                    dependencies: T.Optional[T.List['Dependency']],
                    disable_cache: bool = False) -> T.Tuple[str, bool]:
         delim = '"MESON_GET_DEFINE_DELIMITER"'
@@ -874,7 +874,7 @@ class CLikeCompiler(Compiler):
 
     def has_members(self, typename: str, membernames: T.List[str],
                     prefix: str, env: 'Environment', *,
-                    extra_args: T.Optional[T.List[str]] = None,
+                    extra_args: T.Union[None, T.List[str], T.Callable[[CompileCheckMode], T.List[str]]] = None,
                     dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
         if extra_args is None:
             extra_args = []
@@ -890,7 +890,8 @@ class CLikeCompiler(Compiler):
         return self.compiles(t, env, extra_args=extra_args,
                              dependencies=dependencies)
 
-    def has_type(self, typename: str, prefix: str, env: 'Environment', extra_args: T.List[str],
+    def has_type(self, typename: str, prefix: str, env: 'Environment',
+                 extra_args: T.Union[T.List[str], T.Callable[[CompileCheckMode], T.List[str]]], *,
                  dependencies: T.Optional[T.List['Dependency']] = None) -> T.Tuple[bool, bool]:
         t = f'''{prefix}
         void bar(void) {{

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -462,7 +462,7 @@ class CLikeCompiler(Compiler):
         args = cargs + extra_args + largs
         return args
 
-    def run(self, code: str, env: 'Environment', *,
+    def run(self, code: 'mesonlib.FileOrString', env: 'Environment', *,
             extra_args: T.Optional[T.List[str]] = None,
             dependencies: T.Optional[T.List['Dependency']] = None) -> compilers.RunResult:
         need_exe_wrapper = env.need_exe_wrapper(self.for_machine)

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -34,14 +34,14 @@ import typing as T
 
 if T.TYPE_CHECKING:
     from . import dependencies
-    from .compilers.compilers import Compiler, CompileResult  # noqa: F401
+    from .compilers.compilers import Compiler
     from .environment import Environment
-    from .mesonlib import OptionOverrideProxy
+    from .mesonlib import OptionOverrideProxy, FileOrString
     from .cmake.traceparser import CMakeCacheEntry
 
     OptionDictType = T.Union[T.Dict[str, 'UserOption[T.Any]'], OptionOverrideProxy]
     KeyedOptionDictType = T.Union[T.Dict['OptionKey', 'UserOption[T.Any]'], OptionOverrideProxy]
-    CompilerCheckCacheKey = T.Tuple[T.Tuple[str, ...], str, str, T.Tuple[str, ...], str]
+    CompilerCheckCacheKey = T.Tuple[T.Tuple[str, ...], str, 'FileOrString', T.Tuple[str, ...], str]
 
 version = '0.59.99'
 backendlist = ['ninja', 'vs', 'vs2010', 'vs2012', 'vs2013', 'vs2015', 'vs2017', 'vs2019', 'xcode']

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -1,22 +1,90 @@
+# SPDX-Licnese-Identifier: Apache-2.0
+# Copyright 2012-2021 The Meson development team
+# Copyright © 2021 Intel Corpration
+
+import enum
 import functools
+import typing as T
 
-from ..interpreterbase.decorators import typed_kwargs, KwargInfo
-
-from .interpreterobjects import (extract_required_kwarg, extract_search_dirs)
-
+from .. import build
+from .. import coredata
+from .. import dependencies
 from .. import mesonlib
 from .. import mlog
-from .. import dependencies
-from ..interpreterbase import (ObjectHolder, noPosargs, noKwargs, permittedKwargs,
-                               FeatureNew, FeatureNewKwargs, disablerIfNotFound,
-                               check_stringlist, InterpreterException, InvalidArguments)
-
-import typing as T
-import os
+from ..compilers.compilers import CompileCheckMode
+from ..interpreterbase import (ObjectHolder, noPosargs, noKwargs,
+                               FeatureNew, disablerIfNotFound,
+                               InterpreterException)
+from ..interpreterbase.decorators import ContainerTypeInfo, typed_kwargs, KwargInfo, typed_pos_args
+from .interpreterobjects import (extract_required_kwarg, extract_search_dirs)
+from .type_checking import REQUIRED_KW
 
 if T.TYPE_CHECKING:
     from ..interpreter import Interpreter
     from ..compilers import Compiler, RunResult
+    from ..interpreterbase import TYPE_var, TYPE_kwargs
+    from .kwargs import ExtractRequired, ExtractSearchDirs
+
+    from typing_extensions import TypedDict, Literal
+
+    class GetSupportedArgumentKw(TypedDict):
+
+        checked: Literal['warn', 'require', 'off']
+
+    class AlignmentKw(TypedDict):
+
+        prefix: str
+        args: T.List[str]
+        dependencies: T.List[dependencies.Dependency]
+
+    class CompileKW(TypedDict):
+
+        name: str
+        no_builtin_args: bool
+        include_directories: T.List[build.IncludeDirs]
+        args: T.List[str]
+        dependencies: T.List[dependencies.Dependency]
+
+    class CommonKW(TypedDict):
+
+        prefix: str
+        no_builtin_args: bool
+        include_directories: T.List[build.IncludeDirs]
+        args: T.List[str]
+        dependencies: T.List[dependencies.Dependency]
+
+    class CompupteIntKW(CommonKW):
+
+        guess: T.Optional[int]
+        high: T.Optional[int]
+        low: T.Optional[int]
+
+    class HeaderKW(CommonKW, ExtractRequired):
+        pass
+
+    class FindLibraryKW(ExtractRequired, ExtractSearchDirs):
+
+        disabler: bool
+        has_headers: T.List[str]
+        static: bool
+
+        # This list must be all of the `HeaderKW` values with `header_`
+        # prepended to the key
+        header_args: T.List[str]
+        header_dependencies: T.List[dependencies.Dependency]
+        header_include_directories: T.List[build.IncludeDirs]
+        header_no_builtin_args: bool
+        header_prefix: str
+        header_required: T.Union[bool, coredata.UserFeatureOption]
+
+
+class _TestMode(enum.Enum):
+
+    """Whether we're doing a compiler or linker check."""
+
+    COMPILER = 0
+    LINKER = 1
+
 
 class TryRunResultHolder(ObjectHolder['RunResult']):
     def __init__(self, res: 'RunResult', interpreter: 'Interpreter'):
@@ -47,23 +115,37 @@ class TryRunResultHolder(ObjectHolder['RunResult']):
     def stderr_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> str:
         return self.held_object.stderr
 
-header_permitted_kwargs = {
-    'required',
-    'prefix',
-    'no_builtin_args',
-    'include_directories',
+
+_ARGS_KW: KwargInfo[T.List[str]] = KwargInfo(
     'args',
+    ContainerTypeInfo(list, str),
+    listify=True,
+    default=[],
+)
+_DEPENDENCIES_KW: KwargInfo[T.List['dependencies.Dependency']] = KwargInfo(
     'dependencies',
-}
+    ContainerTypeInfo(list, dependencies.Dependency),
+    listify=True,
+    default=[],
+)
+_INCLUDE_DIRS_KW: KwargInfo[T.List[build.IncludeDirs]] = KwargInfo(
+    'include_directories',
+    ContainerTypeInfo(list, build.IncludeDirs),
+    default=[],
+    listify=True,
+)
+_PREFIX_KW = KwargInfo('prefix', str, default='')
+_NO_BUILTIN_ARGS_KW = KwargInfo('no_builtin_args', bool, default=False)
+_NAME_KW = KwargInfo('name', str, default='')
 
-find_library_permitted_kwargs = {
-    'has_headers',
-    'required',
-    'dirs',
-    'static',
-}
+# Many of the compiler methods take this kwarg signature exactly, this allows
+# simplifying the `typed_kwargs` calls
+_COMMON_KWS: T.List[KwargInfo] = [_ARGS_KW, _DEPENDENCIES_KW, _INCLUDE_DIRS_KW, _PREFIX_KW, _NO_BUILTIN_ARGS_KW]
 
-find_library_permitted_kwargs |= {'header_' + k for k in header_permitted_kwargs}
+# Common methods of compiles, links, runs, and similar
+_COMPILES_KWS: T.List[KwargInfo] = [_NAME_KW, _ARGS_KW, _DEPENDENCIES_KW, _INCLUDE_DIRS_KW, _NO_BUILTIN_ARGS_KW]
+
+_HEADER_KWS: T.List[KwargInfo] = [REQUIRED_KW.evolve(since='0.50.0', default=False), *_COMMON_KWS]
 
 class CompilerHolder(ObjectHolder['Compiler']):
     def __init__(self, compiler: 'Compiler', interpreter: 'Interpreter'):
@@ -106,7 +188,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
     def compiler(self) -> 'Compiler':
         return self.held_object
 
-    def _dep_msg(self, deps, endl):
+    @staticmethod
+    def _dep_msg(deps: T.List['dependencies.Dependency'], endl: str) -> str:
         msg_single = 'with dependency {}'
         msg_many = 'with dependencies {}'
         if not deps:
@@ -129,37 +212,32 @@ class CompilerHolder(ObjectHolder['Compiler']):
 
     @noPosargs
     @noKwargs
-    def version_method(self, args, kwargs):
+    def version_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> str:
         return self.compiler.version
 
     @noPosargs
     @noKwargs
-    def cmd_array_method(self, args, kwargs):
+    def cmd_array_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> T.List[str]:
         return self.compiler.exelist
 
-    def determine_args(self, kwargs, mode='link'):
-        nobuiltins = kwargs.get('no_builtin_args', False)
-        if not isinstance(nobuiltins, bool):
-            raise InterpreterException('Type of no_builtin_args not a boolean.')
-        args = []
-        incdirs = mesonlib.extract_as_list(kwargs, 'include_directories')
+    def determine_args(self, nobuiltins: bool,
+                       incdirs: T.List[build.IncludeDirs],
+                       extra_args: T.List[str],
+                       mode: CompileCheckMode = CompileCheckMode.LINK) -> T.List[str]:
+        args: T.List[str] = []
         for i in incdirs:
-            from ..build import IncludeDirs
-            if not isinstance(i, IncludeDirs):
-                raise InterpreterException('Include directories argument must be an include_directories object.')
             for idir in i.to_string_list(self.environment.get_source_dir()):
-                args += self.compiler.get_include_args(idir, False)
+                args.extend(self.compiler.get_include_args(idir, False))
         if not nobuiltins:
             opts = self.environment.coredata.options
             args += self.compiler.get_option_compile_args(opts)
-            if mode == 'link':
-                args += self.compiler.get_option_link_args(opts)
-        args += mesonlib.stringlistify(kwargs.get('args', []))
+            if mode is CompileCheckMode.LINK:
+                args.extend(self.compiler.get_option_link_args(opts))
+        args.extend(extra_args)
         return args
 
-    def determine_dependencies(self, kwargs, endl=':'):
-        deps = kwargs.get('dependencies', None)
-        if deps is not None:
+    def determine_dependencies(self, deps: T.List['dependencies.Dependency'], endl: str = ':') -> T.Tuple[T.List['dependencies.Dependency'], str]:
+        if deps:
             final_deps = []
             while deps:
                 next_deps = []
@@ -170,53 +248,40 @@ class CompilerHolder(ObjectHolder['Compiler']):
                     next_deps.extend(d.ext_deps)
                 deps = next_deps
             deps = final_deps
+        else:
+            # Ensure that we alway return a new instance
+            deps = deps.copy()
         return deps, self._dep_msg(deps, endl)
 
-    @permittedKwargs({
-        'prefix',
-        'args',
-        'dependencies',
-    })
-    def alignment_method(self, args, kwargs):
-        if len(args) != 1:
-            raise InterpreterException('Alignment method takes exactly one positional argument.')
-        check_stringlist(args)
+    @typed_pos_args('compiler.alignment', str)
+    @typed_kwargs(
+        'compiler.alignment',
+        _PREFIX_KW,
+        _ARGS_KW,
+        _DEPENDENCIES_KW,
+    )
+    def alignment_method(self, args: T.Tuple[str], kwargs: 'AlignmentKw') -> int:
         typename = args[0]
-        prefix = kwargs.get('prefix', '')
-        if not isinstance(prefix, str):
-            raise InterpreterException('Prefix argument of alignment must be a string.')
-        extra_args = mesonlib.stringlistify(kwargs.get('args', []))
-        deps, msg = self.determine_dependencies(kwargs)
-        result = self.compiler.alignment(typename, prefix, self.environment,
-                                         extra_args=extra_args,
+        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        result = self.compiler.alignment(typename, kwargs['prefix'], self.environment,
+                                         extra_args=kwargs['args'],
                                          dependencies=deps)
         mlog.log('Checking for alignment of', mlog.bold(typename, True), msg, result)
         return result
 
-    @permittedKwargs({
-        'name',
-        'no_builtin_args',
-        'include_directories',
-        'args',
-        'dependencies',
-    })
-    def run_method(self, args, kwargs):
-        if len(args) != 1:
-            raise InterpreterException('Run method takes exactly one positional argument.')
+    @typed_pos_args('compiler.run', (str, mesonlib.File))
+    @typed_kwargs('compiler.run', *_COMPILES_KWS)
+    def run_method(self, args: T.Tuple['mesonlib.FileOrString'], kwargs: 'CompileKW') -> 'RunResult':
         code = args[0]
         if isinstance(code, mesonlib.File):
             code = mesonlib.File.from_absolute_file(
                 code.rel_to_builddir(self.environment.source_dir))
-        elif not isinstance(code, str):
-            raise InvalidArguments('Argument must be string or file.')
-        testname = kwargs.get('name', '')
-        if not isinstance(testname, str):
-            raise InterpreterException('Testname argument must be a string.')
-        extra_args = functools.partial(self.determine_args, kwargs)
-        deps, msg = self.determine_dependencies(kwargs, endl=None)
+        testname = kwargs['name']
+        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self.determine_dependencies(kwargs['dependencies'], endl=None)
         result = self.compiler.run(code, self.environment, extra_args=extra_args,
                                    dependencies=deps)
-        if len(testname) > 0:
+        if testname:
             if not result.compiled:
                 h = mlog.red('DID NOT COMPILE')
             elif result.returncode == 0:
@@ -246,346 +311,226 @@ class CompilerHolder(ObjectHolder['Compiler']):
         '''
         return self.compiler.symbols_have_underscore_prefix(self.environment)
 
-    @permittedKwargs({
-        'prefix',
-        'no_builtin_args',
-        'include_directories',
-        'args',
-        'dependencies',
-    })
-    def has_member_method(self, args, kwargs):
-        if len(args) != 2:
-            raise InterpreterException('Has_member takes exactly two arguments.')
-        check_stringlist(args)
+    @typed_pos_args('compiler.has_member', str, str)
+    @typed_kwargs('compiler.has_member', *_COMMON_KWS)
+    def has_member_method(self, args: T.Tuple[str, str], kwargs: 'CommonKW') -> bool:
         typename, membername = args
-        prefix = kwargs.get('prefix', '')
-        if not isinstance(prefix, str):
-            raise InterpreterException('Prefix argument of has_member must be a string.')
-        extra_args = functools.partial(self.determine_args, kwargs)
-        deps, msg = self.determine_dependencies(kwargs)
-        had, cached = self.compiler.has_members(typename, [membername], prefix,
+        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        had, cached = self.compiler.has_members(typename, [membername], kwargs['prefix'],
                                                 self.environment,
                                                 extra_args=extra_args,
                                                 dependencies=deps)
-        cached = mlog.blue('(cached)') if cached else ''
+        cached_msg = mlog.blue('(cached)') if cached else ''
         if had:
             hadtxt = mlog.green('YES')
         else:
             hadtxt = mlog.red('NO')
         mlog.log('Checking whether type', mlog.bold(typename, True),
-                 'has member', mlog.bold(membername, True), msg, hadtxt, cached)
+                 'has member', mlog.bold(membername, True), msg, hadtxt, cached_msg)
         return had
 
-    @permittedKwargs({
-        'prefix',
-        'no_builtin_args',
-        'include_directories',
-        'args',
-        'dependencies',
-    })
-    def has_members_method(self, args, kwargs):
-        if len(args) < 2:
-            raise InterpreterException('Has_members needs at least two arguments.')
-        check_stringlist(args)
-        typename, *membernames = args
-        prefix = kwargs.get('prefix', '')
-        if not isinstance(prefix, str):
-            raise InterpreterException('Prefix argument of has_members must be a string.')
-        extra_args = functools.partial(self.determine_args, kwargs)
-        deps, msg = self.determine_dependencies(kwargs)
-        had, cached = self.compiler.has_members(typename, membernames, prefix,
+    @typed_pos_args('compiler.has_members', str, varargs=str, min_varargs=1)
+    @typed_kwargs('compiler.has_members', *_COMMON_KWS)
+    def has_members_method(self, args: T.Tuple[str, T.List[str]], kwargs: 'CommonKW') -> bool:
+        typename, membernames = args
+        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        had, cached = self.compiler.has_members(typename, membernames, kwargs['prefix'],
                                                 self.environment,
                                                 extra_args=extra_args,
                                                 dependencies=deps)
-        cached = mlog.blue('(cached)') if cached else ''
+        cached_msg = mlog.blue('(cached)') if cached else ''
         if had:
             hadtxt = mlog.green('YES')
         else:
             hadtxt = mlog.red('NO')
         members = mlog.bold(', '.join([f'"{m}"' for m in membernames]))
         mlog.log('Checking whether type', mlog.bold(typename, True),
-                 'has members', members, msg, hadtxt, cached)
+                 'has members', members, msg, hadtxt, cached_msg)
         return had
 
-    @permittedKwargs({
-        'prefix',
-        'no_builtin_args',
-        'include_directories',
-        'args',
-        'dependencies',
-    })
-    def has_function_method(self, args, kwargs):
-        if len(args) != 1:
-            raise InterpreterException('Has_function takes exactly one argument.')
-        check_stringlist(args)
+    @typed_pos_args('compiler.has_function', str)
+    @typed_kwargs('compiler.has_type', *_COMMON_KWS)
+    def has_function_method(self, args: T.Tuple[str], kwargs: 'CommonKW') -> bool:
         funcname = args[0]
-        prefix = kwargs.get('prefix', '')
-        if not isinstance(prefix, str):
-            raise InterpreterException('Prefix argument of has_function must be a string.')
-        extra_args = self.determine_args(kwargs)
-        deps, msg = self.determine_dependencies(kwargs)
-        had, cached = self.compiler.has_function(funcname, prefix, self.environment,
+        extra_args = self.determine_args(kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        had, cached = self.compiler.has_function(funcname, kwargs['prefix'], self.environment,
                                                  extra_args=extra_args,
                                                  dependencies=deps)
-        cached = mlog.blue('(cached)') if cached else ''
+        cached_msg = mlog.blue('(cached)') if cached else ''
         if had:
             hadtxt = mlog.green('YES')
         else:
             hadtxt = mlog.red('NO')
-        mlog.log('Checking for function', mlog.bold(funcname, True), msg, hadtxt, cached)
+        mlog.log('Checking for function', mlog.bold(funcname, True), msg, hadtxt, cached_msg)
         return had
 
-    @permittedKwargs({
-        'prefix',
-        'no_builtin_args',
-        'include_directories',
-        'args',
-        'dependencies',
-    })
-    def has_type_method(self, args, kwargs):
-        if len(args) != 1:
-            raise InterpreterException('Has_type takes exactly one argument.')
-        check_stringlist(args)
+    @typed_pos_args('compiler.has_type', str)
+    @typed_kwargs('compiler.has_type', *_COMMON_KWS)
+    def has_type_method(self, args: T.Tuple[str], kwargs: 'CommonKW') -> bool:
         typename = args[0]
-        prefix = kwargs.get('prefix', '')
-        if not isinstance(prefix, str):
-            raise InterpreterException('Prefix argument of has_type must be a string.')
-        extra_args = functools.partial(self.determine_args, kwargs)
-        deps, msg = self.determine_dependencies(kwargs)
-        had, cached = self.compiler.has_type(typename, prefix, self.environment,
+        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        had, cached = self.compiler.has_type(typename, kwargs['prefix'], self.environment,
                                              extra_args=extra_args, dependencies=deps)
-        cached = mlog.blue('(cached)') if cached else ''
+        cached_msg = mlog.blue('(cached)') if cached else ''
         if had:
             hadtxt = mlog.green('YES')
         else:
             hadtxt = mlog.red('NO')
-        mlog.log('Checking for type', mlog.bold(typename, True), msg, hadtxt, cached)
+        mlog.log('Checking for type', mlog.bold(typename, True), msg, hadtxt, cached_msg)
         return had
 
     @FeatureNew('compiler.compute_int', '0.40.0')
-    @permittedKwargs({
-        'prefix',
-        'low',
-        'high',
-        'guess',
-        'no_builtin_args',
-        'include_directories',
-        'args',
-        'dependencies',
-    })
-    def compute_int_method(self, args, kwargs):
-        if len(args) != 1:
-            raise InterpreterException('Compute_int takes exactly one argument.')
-        check_stringlist(args)
+    @typed_pos_args('compiler.compute_int', str)
+    @typed_kwargs(
+        'compiler.compute_int',
+        KwargInfo('low', (int, None)),
+        KwargInfo('high', (int, None)),
+        KwargInfo('guess', (int, None)),
+        *_COMMON_KWS,
+    )
+    def compute_int_method(self, args: T.Tuple[str], kwargs: 'CompupteIntKW') -> int:
         expression = args[0]
-        prefix = kwargs.get('prefix', '')
-        low = kwargs.get('low', None)
-        high = kwargs.get('high', None)
-        guess = kwargs.get('guess', None)
-        if not isinstance(prefix, str):
-            raise InterpreterException('Prefix argument of compute_int must be a string.')
-        if low is not None and not isinstance(low, int):
-            raise InterpreterException('Low argument of compute_int must be an int.')
-        if high is not None and not isinstance(high, int):
-            raise InterpreterException('High argument of compute_int must be an int.')
-        if guess is not None and not isinstance(guess, int):
-            raise InterpreterException('Guess argument of compute_int must be an int.')
-        extra_args = functools.partial(self.determine_args, kwargs)
-        deps, msg = self.determine_dependencies(kwargs)
-        res = self.compiler.compute_int(expression, low, high, guess, prefix,
+        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        res = self.compiler.compute_int(expression, kwargs['low'], kwargs['high'],
+                                        kwargs['guess'], kwargs['prefix'],
                                         self.environment, extra_args=extra_args,
                                         dependencies=deps)
         mlog.log('Computing int of', mlog.bold(expression, True), msg, res)
         return res
 
-    @permittedKwargs({
-        'prefix',
-        'no_builtin_args',
-        'include_directories',
-        'args',
-        'dependencies',
-    })
-    def sizeof_method(self, args, kwargs):
-        if len(args) != 1:
-            raise InterpreterException('Sizeof takes exactly one argument.')
-        check_stringlist(args)
+    @typed_pos_args('compiler.sizeof', str)
+    @typed_kwargs('compiler.sizeof', *_COMMON_KWS)
+    def sizeof_method(self, args: T.Tuple[str], kwargs: 'CommonKW') -> int:
         element = args[0]
-        prefix = kwargs.get('prefix', '')
-        if not isinstance(prefix, str):
-            raise InterpreterException('Prefix argument of sizeof must be a string.')
-        extra_args = functools.partial(self.determine_args, kwargs)
-        deps, msg = self.determine_dependencies(kwargs)
-        esize = self.compiler.sizeof(element, prefix, self.environment,
+        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        esize = self.compiler.sizeof(element, kwargs['prefix'], self.environment,
                                      extra_args=extra_args, dependencies=deps)
         mlog.log('Checking for size of', mlog.bold(element, True), msg, esize)
         return esize
 
     @FeatureNew('compiler.get_define', '0.40.0')
-    @permittedKwargs({
-        'prefix',
-        'no_builtin_args',
-        'include_directories',
-        'args',
-        'dependencies',
-    })
-    def get_define_method(self, args, kwargs):
-        if len(args) != 1:
-            raise InterpreterException('get_define() takes exactly one argument.')
-        check_stringlist(args)
+    @typed_pos_args('compiler.get_define', str)
+    @typed_kwargs('compiler.get_define', *_COMMON_KWS)
+    def get_define_method(self, args: T.Tuple[str], kwargs: 'CommonKW') -> str:
         element = args[0]
-        prefix = kwargs.get('prefix', '')
-        if not isinstance(prefix, str):
-            raise InterpreterException('Prefix argument of get_define() must be a string.')
-        extra_args = functools.partial(self.determine_args, kwargs)
-        deps, msg = self.determine_dependencies(kwargs)
-        value, cached = self.compiler.get_define(element, prefix, self.environment,
+        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        value, cached = self.compiler.get_define(element, kwargs['prefix'], self.environment,
                                                  extra_args=extra_args,
                                                  dependencies=deps)
-        cached = mlog.blue('(cached)') if cached else ''
-        mlog.log('Fetching value of define', mlog.bold(element, True), msg, value, cached)
+        cached_msg = mlog.blue('(cached)') if cached else ''
+        mlog.log('Fetching value of define', mlog.bold(element, True), msg, value, cached_msg)
         return value
 
-    @permittedKwargs({
-        'name',
-        'no_builtin_args',
-        'include_directories',
-        'args',
-        'dependencies',
-    })
-    def compiles_method(self, args, kwargs):
-        if len(args) != 1:
-            raise InterpreterException('compiles method takes exactly one argument.')
+    @typed_pos_args('compiler.compiles', (str, mesonlib.File))
+    @typed_kwargs('compiler.compiles', *_COMPILES_KWS)
+    def compiles_method(self, args: T.Tuple['mesonlib.FileOrString'], kwargs: 'CompileKW') -> bool:
         code = args[0]
         if isinstance(code, mesonlib.File):
             code = mesonlib.File.from_absolute_file(
                 code.rel_to_builddir(self.environment.source_dir))
-        elif not isinstance(code, str):
-            raise InvalidArguments('Argument must be string or file.')
-        testname = kwargs.get('name', '')
-        if not isinstance(testname, str):
-            raise InterpreterException('Testname argument must be a string.')
-        extra_args = functools.partial(self.determine_args, kwargs)
-        deps, msg = self.determine_dependencies(kwargs, endl=None)
+        testname = kwargs['name']
+        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self.determine_dependencies(kwargs['dependencies'])
         result, cached = self.compiler.compiles(code, self.environment,
                                                 extra_args=extra_args,
                                                 dependencies=deps)
-        if len(testname) > 0:
+        if testname:
             if result:
                 h = mlog.green('YES')
             else:
                 h = mlog.red('NO')
-            cached = mlog.blue('(cached)') if cached else ''
-            mlog.log('Checking if', mlog.bold(testname, True), msg, 'compiles:', h, cached)
+            cached_msg = mlog.blue('(cached)') if cached else ''
+            mlog.log('Checking if', mlog.bold(testname, True), msg, 'compiles:', h, cached_msg)
         return result
 
-    @permittedKwargs({
-        'name',
-        'no_builtin_args',
-        'include_directories',
-        'args',
-        'dependencies',
-    })
-    def links_method(self, args, kwargs):
-        if len(args) != 1:
-            raise InterpreterException('links method takes exactly one argument.')
+    @typed_pos_args('compiler.links', (str, mesonlib.File))
+    @typed_kwargs('compiler.links', *_COMPILES_KWS)
+    def links_method(self, args: T.Tuple['mesonlib.FileOrString'], kwargs: 'CompileKW') -> bool:
         code = args[0]
         if isinstance(code, mesonlib.File):
             code = mesonlib.File.from_absolute_file(
                 code.rel_to_builddir(self.environment.source_dir))
-        elif not isinstance(code, str):
-            raise InvalidArguments('Argument must be string or file.')
-        testname = kwargs.get('name', '')
-        if not isinstance(testname, str):
-            raise InterpreterException('Testname argument must be a string.')
-        extra_args = functools.partial(self.determine_args, kwargs)
-        deps, msg = self.determine_dependencies(kwargs, endl=None)
+        testname = kwargs['name']
+        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self.determine_dependencies(kwargs['dependencies'])
         result, cached = self.compiler.links(code, self.environment,
                                              extra_args=extra_args,
                                              dependencies=deps)
-        cached = mlog.blue('(cached)') if cached else ''
-        if len(testname) > 0:
+        cached_msg = mlog.blue('(cached)') if cached else ''
+        if testname:
             if result:
                 h = mlog.green('YES')
             else:
                 h = mlog.red('NO')
-            mlog.log('Checking if', mlog.bold(testname, True), msg, 'links:', h, cached)
+            mlog.log('Checking if', mlog.bold(testname, True), msg, 'links:', h, cached_msg)
         return result
 
     @FeatureNew('compiler.check_header', '0.47.0')
-    @FeatureNewKwargs('compiler.check_header', '0.50.0', ['required'])
-    @permittedKwargs(header_permitted_kwargs)
-    def check_header_method(self, args, kwargs):
-        if len(args) != 1:
-            raise InterpreterException('check_header method takes exactly one argument.')
-        check_stringlist(args)
+    @typed_pos_args('compiler.check_header', str)
+    @typed_kwargs('compiler.check_header', *_HEADER_KWS)
+    def check_header_method(self, args: T.Tuple[str], kwargs: 'HeaderKW') -> bool:
         hname = args[0]
-        prefix = kwargs.get('prefix', '')
-        if not isinstance(prefix, str):
-            raise InterpreterException('Prefix argument of has_header must be a string.')
         disabled, required, feature = extract_required_kwarg(kwargs, self.subproject, default=False)
         if disabled:
             mlog.log('Check usable header', mlog.bold(hname, True), 'skipped: feature', mlog.bold(feature), 'disabled')
             return False
-        extra_args = functools.partial(self.determine_args, kwargs)
-        deps, msg = self.determine_dependencies(kwargs)
-        haz, cached = self.compiler.check_header(hname, prefix, self.environment,
+        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        haz, cached = self.compiler.check_header(hname, kwargs['prefix'], self.environment,
                                                  extra_args=extra_args,
                                                  dependencies=deps)
-        cached = mlog.blue('(cached)') if cached else ''
+        cached_msg = mlog.blue('(cached)') if cached else ''
         if required and not haz:
             raise InterpreterException(f'{self.compiler.get_display_language()} header {hname!r} not usable')
         elif haz:
             h = mlog.green('YES')
         else:
             h = mlog.red('NO')
-        mlog.log('Check usable header', mlog.bold(hname, True), msg, h, cached)
+        mlog.log('Check usable header', mlog.bold(hname, True), msg, h, cached_msg)
         return haz
 
-    @FeatureNewKwargs('compiler.has_header', '0.50.0', ['required'])
-    @permittedKwargs(header_permitted_kwargs)
-    def has_header_method(self, args, kwargs):
-        if len(args) != 1:
-            raise InterpreterException('has_header method takes exactly one argument.')
-        check_stringlist(args)
-        hname = args[0]
-        prefix = kwargs.get('prefix', '')
-        if not isinstance(prefix, str):
-            raise InterpreterException('Prefix argument of has_header must be a string.')
+    def _has_header_impl(self, hname: str, kwargs: 'HeaderKW') -> bool:
         disabled, required, feature = extract_required_kwarg(kwargs, self.subproject, default=False)
         if disabled:
             mlog.log('Has header', mlog.bold(hname, True), 'skipped: feature', mlog.bold(feature), 'disabled')
             return False
-        extra_args = functools.partial(self.determine_args, kwargs)
-        deps, msg = self.determine_dependencies(kwargs)
-        haz, cached = self.compiler.has_header(hname, prefix, self.environment,
+        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        haz, cached = self.compiler.has_header(hname, kwargs['prefix'], self.environment,
                                                extra_args=extra_args, dependencies=deps)
-        cached = mlog.blue('(cached)') if cached else ''
+        cached_msg = mlog.blue('(cached)') if cached else ''
         if required and not haz:
             raise InterpreterException(f'{self.compiler.get_display_language()} header {hname!r} not found')
         elif haz:
             h = mlog.green('YES')
         else:
             h = mlog.red('NO')
-        mlog.log('Has header', mlog.bold(hname, True), msg, h, cached)
+        mlog.log('Has header', mlog.bold(hname, True), msg, h, cached_msg)
         return haz
 
-    @FeatureNewKwargs('compiler.has_header_symbol', '0.50.0', ['required'])
-    @permittedKwargs(header_permitted_kwargs)
-    def has_header_symbol_method(self, args, kwargs):
-        if len(args) != 2:
-            raise InterpreterException('has_header_symbol method takes exactly two arguments.')
-        check_stringlist(args)
+    @typed_pos_args('compiler.has_header', str)
+    @typed_kwargs('compiler.has_header', *_HEADER_KWS)
+    def has_header_method(self, args: T.Tuple[str], kwargs: 'HeaderKW') -> bool:
+        return self._has_header_impl(args[0], kwargs)
+
+    @typed_pos_args('compiler.has_header_symbol', str, str)
+    @typed_kwargs('compiler.has_header_symbol', *_HEADER_KWS)
+    def has_header_symbol_method(self, args: T.Tuple[str, str], kwargs: 'HeaderKW') -> bool:
         hname, symbol = args
-        prefix = kwargs.get('prefix', '')
-        if not isinstance(prefix, str):
-            raise InterpreterException('Prefix argument of has_header_symbol must be a string.')
         disabled, required, feature = extract_required_kwarg(kwargs, self.subproject, default=False)
         if disabled:
             mlog.log(f'Header <{hname}> has symbol', mlog.bold(symbol, True), 'skipped: feature', mlog.bold(feature), 'disabled')
             return False
-        extra_args = functools.partial(self.determine_args, kwargs)
-        deps, msg = self.determine_dependencies(kwargs)
-        haz, cached = self.compiler.has_header_symbol(hname, symbol, prefix, self.environment,
+        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        haz, cached = self.compiler.has_header_symbol(hname, symbol, kwargs['prefix'], self.environment,
                                                       extra_args=extra_args,
                                                       dependencies=deps)
         if required and not haz:
@@ -594,97 +539,113 @@ class CompilerHolder(ObjectHolder['Compiler']):
             h = mlog.green('YES')
         else:
             h = mlog.red('NO')
-        cached = mlog.blue('(cached)') if cached else ''
-        mlog.log(f'Header <{hname}> has symbol', mlog.bold(symbol, True), msg, h, cached)
+        cached_msg = mlog.blue('(cached)') if cached else ''
+        mlog.log(f'Header <{hname}> has symbol', mlog.bold(symbol, True), msg, h, cached_msg)
         return haz
 
-    def notfound_library(self, libname):
+    def notfound_library(self, libname: str) -> 'dependencies.ExternalLibrary':
         lib = dependencies.ExternalLibrary(libname, None,
                                            self.environment,
                                            self.compiler.language,
                                            silent=True)
         return lib
 
-    @FeatureNewKwargs('compiler.find_library', '0.51.0', ['static'])
-    @FeatureNewKwargs('compiler.find_library', '0.50.0', ['has_headers'])
-    @FeatureNewKwargs('compiler.find_library', '0.49.0', ['disabler'])
     @disablerIfNotFound
-    @permittedKwargs(find_library_permitted_kwargs)
-    def find_library_method(self, args, kwargs):
+    @typed_pos_args('compiler.find_library', str)
+    @typed_kwargs(
+        'compiler.find_library',
+        KwargInfo('required', (bool, coredata.UserFeatureOption), default=True),
+        KwargInfo('has_headers', ContainerTypeInfo(list, str), listify=True, default=[], since='0.50.0'),
+        KwargInfo('static', (bool, None), since='0.51.0'),
+        KwargInfo('disabler', bool, default=False, since='0.49.0'),
+        KwargInfo('dirs', ContainerTypeInfo(list, str), listify=True, default=[]),
+        *[k.evolve(name=f'header_{k.name}') for k in _HEADER_KWS]
+    )
+    def find_library_method(self, args: T.Tuple[str], kwargs: 'FindLibraryKW') -> 'dependencies.ExternalLibrary':
         # TODO add dependencies support?
-        if len(args) != 1:
-            raise InterpreterException('find_library method takes one argument.')
         libname = args[0]
-        if not isinstance(libname, str):
-            raise InterpreterException('Library name not a string.')
 
         disabled, required, feature = extract_required_kwarg(kwargs, self.subproject)
         if disabled:
             mlog.log('Library', mlog.bold(libname), 'skipped: feature', mlog.bold(feature), 'disabled')
             return self.notfound_library(libname)
 
-        has_header_kwargs = {k[7:]: v for k, v in kwargs.items() if k.startswith('header_')}
-        has_header_kwargs['required'] = required
-        headers = mesonlib.stringlistify(kwargs.get('has_headers', []))
-        for h in headers:
-            if not self.has_header_method([h], has_header_kwargs):
+        # This could be done with a comprehension, but that confuses the type
+        # checker, and having it check this seems valuable
+        has_header_kwargs: 'HeaderKW' = {
+            'required': required,
+            'args': kwargs['header_args'],
+            'dependencies': kwargs['header_dependencies'],
+            'include_directories': kwargs['header_include_directories'],
+            'prefix': kwargs['header_prefix'],
+            'no_builtin_args': kwargs['header_no_builtin_args'],
+        }
+        for h in kwargs['has_headers']:
+            if not self._has_header_impl(h, has_header_kwargs):
                 return self.notfound_library(libname)
 
         search_dirs = extract_search_dirs(kwargs)
 
-        libtype = mesonlib.LibType.PREFER_SHARED
-        if 'static' in kwargs:
-            if not isinstance(kwargs['static'], bool):
-                raise InterpreterException('static must be a boolean')
-            libtype = mesonlib.LibType.STATIC if kwargs['static'] else mesonlib.LibType.SHARED
+        if kwargs['static'] is True:
+            libtype = mesonlib.LibType.STATIC
+        elif kwargs['static'] is False:
+            libtype = mesonlib.LibType.SHARED
+        else:
+            libtype = mesonlib.LibType.PREFER_SHARED
         linkargs = self.compiler.find_library(libname, self.environment, search_dirs, libtype)
         if required and not linkargs:
             if libtype == mesonlib.LibType.PREFER_SHARED:
-                libtype = 'shared or static'
+                libtype_s = 'shared or static'
             else:
-                libtype = libtype.name.lower()
+                libtype_s = libtype.name.lower()
             raise InterpreterException('{} {} library {!r} not found'
                                        .format(self.compiler.get_display_language(),
-                                               libtype, libname))
+                                               libtype_s, libname))
         lib = dependencies.ExternalLibrary(libname, linkargs, self.environment,
                                            self.compiler.language)
         return lib
 
-    @noKwargs
-    def has_argument_method(self, args: T.Sequence[str], kwargs) -> bool:
-        args = mesonlib.stringlistify(args)
-        if len(args) != 1:
-            raise InterpreterException('has_argument takes exactly one argument.')
-        return self.has_multi_arguments_method(args, kwargs)
-
-    @noKwargs
-    def has_multi_arguments_method(self, args: T.Sequence[str], kwargs: dict):
-        args = mesonlib.stringlistify(args)
-        result, cached = self.compiler.has_multi_arguments(args, self.environment)
-        if result:
-            h = mlog.green('YES')
-        else:
-            h = mlog.red('NO')
-        cached = mlog.blue('(cached)') if cached else ''
+    def _has_argument_impl(self, arguments: T.Union[str, T.List[str]],
+                           mode: _TestMode = _TestMode.COMPILER) -> bool:
+        """Shared implementaiton for methods checking compiler and linker arguments."""
+        # This simplifies the callers
+        if isinstance(arguments, str):
+            arguments = [arguments]
+        test = self.compiler.has_multi_link_arguments if mode is _TestMode.LINKER else self.compiler.has_multi_arguments
+        result, cached = test(arguments, self.environment)
+        cached_msg = mlog.blue('(cached)') if cached else ''
         mlog.log(
-            'Compiler for {} supports arguments {}:'.format(
-                self.compiler.get_display_language(), ' '.join(args)),
-            h, cached)
+            'Compiler for',
+            self.compiler.get_display_language(),
+            'supports{}'.format(' link' if mode is _TestMode.LINKER else ''),
+            'arguments {}:'.format(' '.join(arguments)),
+            mlog.green('YES') if result else mlog.red('NO'),
+            cached_msg)
         return result
 
+    @noKwargs
+    @typed_pos_args('compiler.has_argument', str)
+    def has_argument_method(self, args: T.Tuple[str], kwargs: 'TYPE_kwargs') -> bool:
+        return self._has_argument_impl([args[0]])
+
+    @noKwargs
+    @typed_pos_args('compiler.has_multi_arguments', varargs=str)
+    def has_multi_arguments_method(self, args: T.Tuple[T.List[str]], kwargs: 'TYPE_kwargs') -> bool:
+        return self._has_argument_impl(args[0])
+
     @FeatureNew('compiler.get_supported_arguments', '0.43.0')
+    @typed_pos_args('compiler.get_supported_arguments', varargs=str)
     @typed_kwargs(
         'compiler.get_supported_arguments',
         KwargInfo('checked', str, default='off', since='0.59.0',
                   validator=lambda s: 'must be one of "warn", "require" or "off"' if s not in ['warn', 'require', 'off'] else None)
     )
-    def get_supported_arguments_method(self, args: T.Sequence[str], kwargs: T.Dict[str, T.Any]):
-        args = mesonlib.stringlistify(args)
-        supported_args = []
-        checked = kwargs.pop('checked')
+    def get_supported_arguments_method(self, args: T.Tuple[T.List[str]], kwargs: 'GetSupportedArgumentKw') -> T.List[str]:
+        supported_args: T.List[str] = []
+        checked = kwargs['checked']
 
-        for arg in args:
-            if not self.has_argument_method(arg, kwargs):
+        for arg in args[0]:
+            if not self._has_argument_impl([arg]):
                 msg = f'Compiler for {self.compiler.get_display_language()} does not support "{arg}"'
                 if checked == 'warn':
                     mlog.warning(msg)
@@ -695,9 +656,10 @@ class CompilerHolder(ObjectHolder['Compiler']):
         return supported_args
 
     @noKwargs
-    def first_supported_argument_method(self, args: T.Sequence[str], kwargs: dict) -> T.List[str]:
-        for arg in mesonlib.stringlistify(args):
-            if self.has_argument_method(arg, kwargs):
+    @typed_pos_args('compiler.first_supported_argument', varargs=str)
+    def first_supported_argument_method(self, args: T.Tuple[T.List[str]], kwargs: 'TYPE_kwargs') -> T.List[str]:
+        for arg in args[0]:
+            if self._has_argument_impl([arg]):
                 mlog.log('First supported argument:', mlog.bold(arg))
                 return [arg]
         mlog.log('First supported argument:', mlog.red('None'))
@@ -705,68 +667,59 @@ class CompilerHolder(ObjectHolder['Compiler']):
 
     @FeatureNew('compiler.has_link_argument', '0.46.0')
     @noKwargs
-    def has_link_argument_method(self, args, kwargs):
-        args = mesonlib.stringlistify(args)
-        if len(args) != 1:
-            raise InterpreterException('has_link_argument takes exactly one argument.')
-        return self.has_multi_link_arguments_method(args, kwargs)
+    @typed_pos_args('compiler.has_link_argument', str)
+    def has_link_argument_method(self, args: T.Tuple[str], kwargs: 'TYPE_kwargs') -> bool:
+        return self._has_argument_impl([args[0]], mode=_TestMode.LINKER)
 
     @FeatureNew('compiler.has_multi_link_argument', '0.46.0')
     @noKwargs
-    def has_multi_link_arguments_method(self, args, kwargs):
-        args = mesonlib.stringlistify(args)
-        result, cached = self.compiler.has_multi_link_arguments(args, self.environment)
-        cached = mlog.blue('(cached)') if cached else ''
-        if result:
-            h = mlog.green('YES')
-        else:
-            h = mlog.red('NO')
-        mlog.log(
-            'Compiler for {} supports link arguments {}:'.format(
-                self.compiler.get_display_language(), ' '.join(args)),
-            h, cached)
-        return result
+    @typed_pos_args('compiler.has_multi_link_argument', varargs=str)
+    def has_multi_link_arguments_method(self, args: T.Tuple[T.List[str]], kwargs: 'TYPE_kwargs') -> bool:
+        return self._has_argument_impl(args[0], mode=_TestMode.LINKER)
 
-    @FeatureNew('compiler.get_supported_link_arguments_method', '0.46.0')
+    @FeatureNew('compiler.get_supported_link_arguments', '0.46.0')
     @noKwargs
-    def get_supported_link_arguments_method(self, args, kwargs):
-        args = mesonlib.stringlistify(args)
-        supported_args = []
-        for arg in args:
-            if self.has_link_argument_method(arg, kwargs):
+    @typed_pos_args('compiler.get_supported_link_arguments', varargs=str)
+    def get_supported_link_arguments_method(self, args: T.Tuple[T.List[str]], kwargs: 'TYPE_kwargs') -> T.List[str]:
+        supported_args: T.List[str] = []
+        for arg in args[0]:
+            if self._has_argument_impl([arg], mode=_TestMode.LINKER):
                 supported_args.append(arg)
         return supported_args
 
     @FeatureNew('compiler.first_supported_link_argument_method', '0.46.0')
     @noKwargs
-    def first_supported_link_argument_method(self, args, kwargs):
-        for i in mesonlib.stringlistify(args):
-            if self.has_link_argument_method(i, kwargs):
-                mlog.log('First supported link argument:', mlog.bold(i))
-                return [i]
+    @typed_pos_args('compiler.first_supported_link_argument', varargs=str)
+    def first_supported_link_argument_method(self, args: T.Tuple[T.List[str]], kwargs: 'TYPE_kwargs') -> T.List[str]:
+        for arg in args[0]:
+            if self._has_argument_impl([arg], mode=_TestMode.LINKER):
+                mlog.log('First supported link argument:', mlog.bold(arg))
+                return [arg]
         mlog.log('First supported link argument:', mlog.red('None'))
         return []
 
+    def _has_function_attribute_impl(self, attr: str) -> bool:
+        """Common helper for function attribute testing."""
+        result, cached = self.compiler.has_func_attribute(attr, self.environment)
+        cached_msg = mlog.blue('(cached)') if cached else ''
+        h = mlog.green('YES') if result else mlog.red('NO')
+        mlog.log('Compiler for {} supports function attribute {}:'.format(self.compiler.get_display_language(), attr), h, cached_msg)
+        return result
+
     @FeatureNew('compiler.has_function_attribute', '0.48.0')
     @noKwargs
-    def has_func_attribute_method(self, args, kwargs):
-        args = mesonlib.stringlistify(args)
-        if len(args) != 1:
-            raise InterpreterException('has_func_attribute takes exactly one argument.')
-        result, cached = self.compiler.has_func_attribute(args[0], self.environment)
-        cached = mlog.blue('(cached)') if cached else ''
-        h = mlog.green('YES') if result else mlog.red('NO')
-        mlog.log('Compiler for {} supports function attribute {}:'.format(self.compiler.get_display_language(), args[0]), h, cached)
-        return result
+    @typed_pos_args('compiler.has_function_attribute', str)
+    def has_func_attribute_method(self, args: T.Tuple[str], kwargs: 'TYPE_kwargs') -> bool:
+        return self._has_function_attribute_impl(args[0])
 
     @FeatureNew('compiler.get_supported_function_attributes', '0.48.0')
     @noKwargs
-    def get_supported_function_attributes_method(self, args, kwargs):
-        args = mesonlib.stringlistify(args)
-        return [a for a in args if self.has_func_attribute_method(a, kwargs)]
+    @typed_pos_args('compiler.get_supported_function_attributes', varargs=str)
+    def get_supported_function_attributes_method(self, args: T.Tuple[T.List[str]], kwargs: 'TYPE_kwargs') -> T.List[str]:
+        return [a for a in args[0] if self._has_function_attribute_impl(a)]
 
     @FeatureNew('compiler.get_argument_syntax_method', '0.49.0')
     @noPosargs
     @noKwargs
-    def get_argument_syntax_method(self, args, kwargs):
+    def get_argument_syntax_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> str:
         return self.compiler.get_argument_syntax()

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -220,7 +220,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
     def cmd_array_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> T.List[str]:
         return self.compiler.exelist
 
-    def determine_args(self, nobuiltins: bool,
+    def _determine_args(self, nobuiltins: bool,
                        incdirs: T.List[build.IncludeDirs],
                        extra_args: T.List[str],
                        mode: CompileCheckMode = CompileCheckMode.LINK) -> T.List[str]:
@@ -236,7 +236,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
         args.extend(extra_args)
         return args
 
-    def determine_dependencies(self, deps: T.List['dependencies.Dependency'], endl: str = ':') -> T.Tuple[T.List['dependencies.Dependency'], str]:
+    def _determine_dependencies(self, deps: T.List['dependencies.Dependency'], endl: str = ':') -> T.Tuple[T.List['dependencies.Dependency'], str]:
         if deps:
             final_deps = []
             while deps:
@@ -262,7 +262,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
     )
     def alignment_method(self, args: T.Tuple[str], kwargs: 'AlignmentKw') -> int:
         typename = args[0]
-        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'])
         result = self.compiler.alignment(typename, kwargs['prefix'], self.environment,
                                          extra_args=kwargs['args'],
                                          dependencies=deps)
@@ -277,8 +277,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
             code = mesonlib.File.from_absolute_file(
                 code.rel_to_builddir(self.environment.source_dir))
         testname = kwargs['name']
-        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self.determine_dependencies(kwargs['dependencies'], endl=None)
+        extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'], endl=None)
         result = self.compiler.run(code, self.environment, extra_args=extra_args,
                                    dependencies=deps)
         if testname:
@@ -315,8 +315,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
     @typed_kwargs('compiler.has_member', *_COMMON_KWS)
     def has_member_method(self, args: T.Tuple[str, str], kwargs: 'CommonKW') -> bool:
         typename, membername = args
-        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'])
         had, cached = self.compiler.has_members(typename, [membername], kwargs['prefix'],
                                                 self.environment,
                                                 extra_args=extra_args,
@@ -334,8 +334,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
     @typed_kwargs('compiler.has_members', *_COMMON_KWS)
     def has_members_method(self, args: T.Tuple[str, T.List[str]], kwargs: 'CommonKW') -> bool:
         typename, membernames = args
-        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'])
         had, cached = self.compiler.has_members(typename, membernames, kwargs['prefix'],
                                                 self.environment,
                                                 extra_args=extra_args,
@@ -354,8 +354,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
     @typed_kwargs('compiler.has_type', *_COMMON_KWS)
     def has_function_method(self, args: T.Tuple[str], kwargs: 'CommonKW') -> bool:
         funcname = args[0]
-        extra_args = self.determine_args(kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        extra_args = self._determine_args(kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'])
         had, cached = self.compiler.has_function(funcname, kwargs['prefix'], self.environment,
                                                  extra_args=extra_args,
                                                  dependencies=deps)
@@ -371,8 +371,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
     @typed_kwargs('compiler.has_type', *_COMMON_KWS)
     def has_type_method(self, args: T.Tuple[str], kwargs: 'CommonKW') -> bool:
         typename = args[0]
-        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'])
         had, cached = self.compiler.has_type(typename, kwargs['prefix'], self.environment,
                                              extra_args=extra_args, dependencies=deps)
         cached_msg = mlog.blue('(cached)') if cached else ''
@@ -394,8 +394,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
     )
     def compute_int_method(self, args: T.Tuple[str], kwargs: 'CompupteIntKW') -> int:
         expression = args[0]
-        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'])
         res = self.compiler.compute_int(expression, kwargs['low'], kwargs['high'],
                                         kwargs['guess'], kwargs['prefix'],
                                         self.environment, extra_args=extra_args,
@@ -407,8 +407,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
     @typed_kwargs('compiler.sizeof', *_COMMON_KWS)
     def sizeof_method(self, args: T.Tuple[str], kwargs: 'CommonKW') -> int:
         element = args[0]
-        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'])
         esize = self.compiler.sizeof(element, kwargs['prefix'], self.environment,
                                      extra_args=extra_args, dependencies=deps)
         mlog.log('Checking for size of', mlog.bold(element, True), msg, esize)
@@ -419,8 +419,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
     @typed_kwargs('compiler.get_define', *_COMMON_KWS)
     def get_define_method(self, args: T.Tuple[str], kwargs: 'CommonKW') -> str:
         element = args[0]
-        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'])
         value, cached = self.compiler.get_define(element, kwargs['prefix'], self.environment,
                                                  extra_args=extra_args,
                                                  dependencies=deps)
@@ -436,8 +436,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
             code = mesonlib.File.from_absolute_file(
                 code.rel_to_builddir(self.environment.source_dir))
         testname = kwargs['name']
-        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'])
         result, cached = self.compiler.compiles(code, self.environment,
                                                 extra_args=extra_args,
                                                 dependencies=deps)
@@ -458,8 +458,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
             code = mesonlib.File.from_absolute_file(
                 code.rel_to_builddir(self.environment.source_dir))
         testname = kwargs['name']
-        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'])
         result, cached = self.compiler.links(code, self.environment,
                                              extra_args=extra_args,
                                              dependencies=deps)
@@ -481,8 +481,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
         if disabled:
             mlog.log('Check usable header', mlog.bold(hname, True), 'skipped: feature', mlog.bold(feature), 'disabled')
             return False
-        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'])
         haz, cached = self.compiler.check_header(hname, kwargs['prefix'], self.environment,
                                                  extra_args=extra_args,
                                                  dependencies=deps)
@@ -501,8 +501,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
         if disabled:
             mlog.log('Has header', mlog.bold(hname, True), 'skipped: feature', mlog.bold(feature), 'disabled')
             return False
-        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'])
         haz, cached = self.compiler.has_header(hname, kwargs['prefix'], self.environment,
                                                extra_args=extra_args, dependencies=deps)
         cached_msg = mlog.blue('(cached)') if cached else ''
@@ -528,8 +528,8 @@ class CompilerHolder(ObjectHolder['Compiler']):
         if disabled:
             mlog.log(f'Header <{hname}> has symbol', mlog.bold(symbol, True), 'skipped: feature', mlog.bold(feature), 'disabled')
             return False
-        extra_args = functools.partial(self.determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self.determine_dependencies(kwargs['dependencies'])
+        extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'])
         haz, cached = self.compiler.has_header_symbol(hname, symbol, kwargs['prefix'], self.environment,
                                                       extra_args=extra_args,
                                                       dependencies=deps)

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -29,22 +29,22 @@ class TryRunResultHolder(ObjectHolder['RunResult']):
 
     @noPosargs
     @noKwargs
-    def returncode_method(self, args, kwargs):
+    def returncode_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> int:
         return self.held_object.returncode
 
     @noPosargs
     @noKwargs
-    def compiled_method(self, args, kwargs):
+    def compiled_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> bool:
         return self.held_object.compiled
 
     @noPosargs
     @noKwargs
-    def stdout_method(self, args, kwargs):
+    def stdout_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> str:
         return self.held_object.stdout
 
     @noPosargs
     @noKwargs
-    def stderr_method(self, args, kwargs):
+    def stderr_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> str:
         return self.held_object.stderr
 
 header_permitted_kwargs = {

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -28,22 +28,22 @@ class TryRunResultHolder(ObjectHolder['RunResult']):
                              })
 
     @noPosargs
-    @permittedKwargs({})
+    @noKwargs
     def returncode_method(self, args, kwargs):
         return self.held_object.returncode
 
     @noPosargs
-    @permittedKwargs({})
+    @noKwargs
     def compiled_method(self, args, kwargs):
         return self.held_object.compiled
 
     @noPosargs
-    @permittedKwargs({})
+    @noKwargs
     def stdout_method(self, args, kwargs):
         return self.held_object.stdout
 
     @noPosargs
-    @permittedKwargs({})
+    @noKwargs
     def stderr_method(self, args, kwargs):
         return self.held_object.stderr
 
@@ -129,12 +129,12 @@ class CompilerHolder(ObjectHolder['Compiler']):
         return tpl.format(', '.join(names)) + endl
 
     @noPosargs
-    @permittedKwargs({})
+    @noKwargs
     def version_method(self, args, kwargs):
         return self.compiler.version
 
     @noPosargs
-    @permittedKwargs({})
+    @noKwargs
     def cmd_array_method(self, args, kwargs):
         return self.compiler.exelist
 
@@ -228,18 +228,18 @@ class CompilerHolder(ObjectHolder['Compiler']):
         return result
 
     @noPosargs
-    @permittedKwargs({})
+    @noKwargs
     def get_id_method(self, args, kwargs):
         return self.compiler.get_id()
 
     @noPosargs
-    @permittedKwargs({})
+    @noKwargs
     @FeatureNew('compiler.get_linker_id', '0.53.0')
     def get_linker_id_method(self, args, kwargs):
         return self.compiler.get_linker_id()
 
     @noPosargs
-    @permittedKwargs({})
+    @noKwargs
     def symbols_have_underscore_prefix_method(self, args, kwargs):
         '''
         Check if the compiler prefixes _ (underscore) to global C symbols
@@ -248,7 +248,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
         return self.compiler.symbols_have_underscore_prefix(self.environment)
 
     @noPosargs
-    @permittedKwargs({})
+    @noKwargs
     def unittest_args_method(self, args, kwargs):
         '''
         This function is deprecated and should not be used.
@@ -663,14 +663,14 @@ class CompilerHolder(ObjectHolder['Compiler']):
                                            self.compiler.language)
         return lib
 
-    @permittedKwargs({})
+    @noKwargs
     def has_argument_method(self, args: T.Sequence[str], kwargs) -> bool:
         args = mesonlib.stringlistify(args)
         if len(args) != 1:
             raise InterpreterException('has_argument takes exactly one argument.')
         return self.has_multi_arguments_method(args, kwargs)
 
-    @permittedKwargs({})
+    @noKwargs
     def has_multi_arguments_method(self, args: T.Sequence[str], kwargs: dict):
         args = mesonlib.stringlistify(args)
         result, cached = self.compiler.has_multi_arguments(args, self.environment)
@@ -707,7 +707,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
                 supported_args.append(arg)
         return supported_args
 
-    @permittedKwargs({})
+    @noKwargs
     def first_supported_argument_method(self, args: T.Sequence[str], kwargs: dict) -> T.List[str]:
         for arg in mesonlib.stringlistify(args):
             if self.has_argument_method(arg, kwargs):
@@ -717,7 +717,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
         return []
 
     @FeatureNew('compiler.has_link_argument', '0.46.0')
-    @permittedKwargs({})
+    @noKwargs
     def has_link_argument_method(self, args, kwargs):
         args = mesonlib.stringlistify(args)
         if len(args) != 1:
@@ -725,7 +725,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
         return self.has_multi_link_arguments_method(args, kwargs)
 
     @FeatureNew('compiler.has_multi_link_argument', '0.46.0')
-    @permittedKwargs({})
+    @noKwargs
     def has_multi_link_arguments_method(self, args, kwargs):
         args = mesonlib.stringlistify(args)
         result, cached = self.compiler.has_multi_link_arguments(args, self.environment)
@@ -741,7 +741,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
         return result
 
     @FeatureNew('compiler.get_supported_link_arguments_method', '0.46.0')
-    @permittedKwargs({})
+    @noKwargs
     def get_supported_link_arguments_method(self, args, kwargs):
         args = mesonlib.stringlistify(args)
         supported_args = []
@@ -751,7 +751,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
         return supported_args
 
     @FeatureNew('compiler.first_supported_link_argument_method', '0.46.0')
-    @permittedKwargs({})
+    @noKwargs
     def first_supported_link_argument_method(self, args, kwargs):
         for i in mesonlib.stringlistify(args):
             if self.has_link_argument_method(i, kwargs):
@@ -761,7 +761,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
         return []
 
     @FeatureNew('compiler.has_function_attribute', '0.48.0')
-    @permittedKwargs({})
+    @noKwargs
     def has_func_attribute_method(self, args, kwargs):
         args = mesonlib.stringlistify(args)
         if len(args) != 1:
@@ -773,7 +773,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
         return result
 
     @FeatureNew('compiler.get_supported_function_attributes', '0.48.0')
-    @permittedKwargs({})
+    @noKwargs
     def get_supported_function_attributes_method(self, args, kwargs):
         args = mesonlib.stringlistify(args)
         return [a for a in args if self.has_func_attribute_method(a, kwargs)]

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -98,7 +98,6 @@ class CompilerHolder(ObjectHolder['Compiler']):
                              'has_multi_link_arguments': self.has_multi_link_arguments_method,
                              'get_supported_link_arguments': self.get_supported_link_arguments_method,
                              'first_supported_link_argument': self.first_supported_link_argument_method,
-                             'unittest_args': self.unittest_args_method,
                              'symbols_have_underscore_prefix': self.symbols_have_underscore_prefix_method,
                              'get_argument_syntax': self.get_argument_syntax_method,
                              })
@@ -229,35 +228,23 @@ class CompilerHolder(ObjectHolder['Compiler']):
 
     @noPosargs
     @noKwargs
-    def get_id_method(self, args, kwargs):
+    def get_id_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> str:
         return self.compiler.get_id()
 
     @noPosargs
     @noKwargs
     @FeatureNew('compiler.get_linker_id', '0.53.0')
-    def get_linker_id_method(self, args, kwargs):
+    def get_linker_id_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> str:
         return self.compiler.get_linker_id()
 
     @noPosargs
     @noKwargs
-    def symbols_have_underscore_prefix_method(self, args, kwargs):
+    def symbols_have_underscore_prefix_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> bool:
         '''
         Check if the compiler prefixes _ (underscore) to global C symbols
         See: https://en.wikipedia.org/wiki/Name_mangling#C
         '''
         return self.compiler.symbols_have_underscore_prefix(self.environment)
-
-    @noPosargs
-    @noKwargs
-    def unittest_args_method(self, args, kwargs):
-        '''
-        This function is deprecated and should not be used.
-        It can be removed in a future version of Meson.
-        '''
-        if not hasattr(self.compiler, 'get_feature_args'):
-            raise InterpreterException(f'This {self.compiler.get_display_language()} compiler has no feature arguments.')
-        build_to_src = os.path.relpath(self.environment.get_source_dir(), self.environment.get_build_dir())
-        return self.compiler.get_feature_args({'unittest': 'true'}, build_to_src)
 
     @permittedKwargs({
         'prefix',

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -62,7 +62,7 @@ def extract_required_kwarg(kwargs: 'kwargs.ExtractRequired',
 
     return disabled, required, feature
 
-def extract_search_dirs(kwargs: T.Dict[str, T.Any]) -> T.List[str]:
+def extract_search_dirs(kwargs: 'kwargs.ExtractSearchDirs') -> T.List[str]:
     search_dirs_str = mesonlib.stringlistify(kwargs.get('dirs', []))
     search_dirs = [Path(d).expanduser() for d in search_dirs_str]
     for d in search_dirs:

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -72,6 +72,16 @@ class ExtractRequired(TypedDict):
     required: T.Union[bool, coredata.UserFeatureOption]
 
 
+class ExtractSearchDirs(TypedDict):
+
+    """Keyword arguments consumed by the `extract_search_dirs` function.
+
+    See the not in `ExtractRequired`
+    """
+
+    dirs: T.List[str]
+
+
 class FuncGenerator(TypedDict):
 
     """Keyword rguments for the generator function."""

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -73,7 +73,11 @@ InterpreterObjectTypeVar = T.TypeVar('InterpreterObjectTypeVar', bound=HoldableO
 class ObjectHolder(InterpreterObject, T.Generic[InterpreterObjectTypeVar]):
     def __init__(self, obj: InterpreterObjectTypeVar, interpreter: 'Interpreter') -> None:
         super().__init__(subproject=interpreter.subproject)
-        assert isinstance(obj, HoldableObject), f'This is a bug: Trying to hold object of type `{type(obj).__name__}` that is not an `HoldableObject`'
+        # This causes some type checkers to assume that obj is a base
+        # HoldableObject, not the specialized type, so only do this assert in
+        # non-type checking situations
+        if not T.TYPE_CHECKING:
+            assert isinstance(obj, HoldableObject), f'This is a bug: Trying to hold object of type `{type(obj).__name__}` that is not an `HoldableObject`'
         self.held_object = obj
         self.interpreter = interpreter
         self.env = self.interpreter.environment

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -339,6 +339,7 @@ class KwargInfo(T.Generic[_T]):
         self.not_set_warning = not_set_warning
 
     def evolve(self, *,
+               name: T.Union[str, _NULL_T] = _NULL,
                required: T.Union[bool, _NULL_T] = _NULL,
                listify: T.Union[bool, _NULL_T] = _NULL,
                default: T.Union[_T, None, _NULL_T] = _NULL,
@@ -360,7 +361,7 @@ class KwargInfo(T.Generic[_T]):
         being replaced by either the copy in self, or the provided new version.
         """
         return type(self)(
-            self.name,
+            name if not isinstance(name, _NULL_T) else self.name,
             self.types,
             listify=listify if not isinstance(listify, _NULL_T) else self.listify,
             required=required if not isinstance(required, _NULL_T) else self.required,

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -24,6 +24,7 @@ modules = [
     'mesonbuild/arglist.py',
     # 'mesonbuild/coredata.py',
     'mesonbuild/envconfig.py',
+    'mesonbuild/interpreter/compiler.py',
     'mesonbuild/interpreter/interpreterobjects.py',
     'mesonbuild/interpreter/type_checking.py',
     'mesonbuild/mcompile.py',

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1826,13 +1826,8 @@ class AllPlatformTests(BasePlatformTests):
 
     def test_permitted_method_kwargs(self):
         tdir = os.path.join(self.unit_test_dir, '25 non-permitted kwargs')
-        out = self.init(tdir)
-        for expected in [
-            r'WARNING: Passed invalid keyword argument "prefixxx".',
-            r'WARNING: Passed invalid keyword argument "argsxx".',
-            r'WARNING: Passed invalid keyword argument "invalidxx".',
-        ]:
-            self.assertRegex(out, re.escape(expected))
+        out = self.init(tdir, allow_fail=True)
+        self.assertIn('Function does not take keyword arguments.', out)
 
     def test_templates(self):
         ninja = mesonbuild.environment.detect_ninja()

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -186,8 +186,10 @@ class BasePlatformTests(TestCase):
                     print('Stderr:\n')
                     print(err)
                     raise RuntimeError('Configure failed')
-            except Exception:
-                self._print_meson_log()
+            except Exception as e:
+                # Don't double print
+                if str(e) != 'Configure failed':
+                    self._print_meson_log()
                 raise
             finally:
                 # Close log file to satisfy Windows file locking


### PR DESCRIPTION
This uses a full set of `typed_pos_args` and `typed_kwargs` to the `interpreter/compiler` module. In doing this I discovered several deficiencies in the `compiler` annotations, as well as one case of undesirable behavior for the type checkers.

I did remove the `unittest_args` method, which has been marked in the docstring as deprecated for some time, as well as not being documented. I feel like given those two features, it's fine to remove it.