### PR TITLE
compilers: Add default search path stdlib_only_link_flags

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1425,7 +1425,7 @@ You probably should put it in link_with instead.''')
         # If the user set the link_language, just return that.
         if self.link_language:
             comp = all_compilers[self.link_language]
-            return comp, comp.language_stdlib_only_link_flags()
+            return comp, comp.language_stdlib_only_link_flags(self.environment)
 
         # Languages used by dependencies
         dep_langs = self.get_langs_used_by_deps()
@@ -1443,7 +1443,7 @@ You probably should put it in link_with instead.''')
                 added_languages: T.Set[str] = set()
                 for dl in itertools.chain(self.compilers, dep_langs):
                     if dl != linker.language:
-                        stdlib_args += all_compilers[dl].language_stdlib_only_link_flags()
+                        stdlib_args += all_compilers[dl].language_stdlib_only_link_flags(self.environment)
                         added_languages.add(dl)
                 # Type of var 'linker' is Compiler.
                 # Pretty hard to fix because the return value is passed everywhere

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -893,7 +893,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def openmp_link_flags(self) -> T.List[str]:
         return self.openmp_flags()
 
-    def language_stdlib_only_link_flags(self) -> T.List[str]:
+    def language_stdlib_only_link_flags(self, env: 'Environment') -> T.List[str]:
         return []
 
     def gnu_symbol_visibility_args(self, vistype: str) -> T.List[str]:

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -246,13 +246,31 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
             return libs
         return []
 
-    def language_stdlib_only_link_flags(self) -> T.List[str]:
-        return ['-lstdc++']
+    def language_stdlib_only_link_flags(self, env: 'Environment') -> T.List[str]:
+        # We need to apply the search prefix here, as these link arguments may
+        # be passed to a differen compiler with a different set of default
+        # search paths, such as when using Clang for C/C++ and gfortran for
+        # fortran,
+        search_dir = self._get_search_dirs(env)
+        search_dirs: T.List[str] = []
+        if search_dir is not None:
+            for d in search_dir.split()[-1][len('libraries: ='):].split(':'):
+                search_dirs.append(f'-L{d}')
+        return search_dirs + ['-lstdc++']
 
 
 class AppleClangCPPCompiler(ClangCPPCompiler):
-    def language_stdlib_only_link_flags(self) -> T.List[str]:
-        return ['-lc++']
+    def language_stdlib_only_link_flags(self, env: 'Environment') -> T.List[str]:
+        # We need to apply the search prefix here, as these link arguments may
+        # be passed to a differen compiler with a different set of default
+        # search paths, such as when using Clang for C/C++ and gfortran for
+        # fortran,
+        search_dir = self._get_search_dirs(env)
+        search_dirs: T.List[str] = []
+        if search_dir is not None:
+            for d in search_dir.split()[-1][len('libraries: ='):].split(':'):
+                search_dirs.append(f'-L{d}')
+        return search_dirs + ['-lc++']
 
 
 class EmscriptenCPPCompiler(EmscriptenMixin, ClangCPPCompiler):
@@ -396,7 +414,16 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
     def get_pch_use_args(self, pch_dir: str, header: str) -> T.List[str]:
         return ['-fpch-preprocess', '-include', os.path.basename(header)]
 
-    def language_stdlib_only_link_flags(self) -> T.List[str]:
+    def language_stdlib_only_link_flags(self, env: 'Environment') -> T.List[str]:
+        # We need to apply the search prefix here, as these link arguments may
+        # be passed to a differen compiler with a different set of default
+        # search paths, such as when using Clang for C/C++ and gfortran for
+        # fortran,
+        search_dir = self._get_search_dirs(env)
+        search_dirs: T.List[str] = []
+        if search_dir is not None:
+            for d in search_dir.split()[-1][len('libraries: ='):].split(':'):
+                search_dirs.append(f'-L{d}')
         return ['-lstdc++']
 
 

--- a/test cases/fortran/9 cpp/meson.build
+++ b/test cases/fortran/9 cpp/meson.build
@@ -3,10 +3,6 @@ project('C, C++ and Fortran', 'c', 'cpp', 'fortran')
 cpp = meson.get_compiler('cpp')
 fc = meson.get_compiler('fortran')
 
-if cpp.get_id() == 'clang'
-  error('MESON_SKIP_TEST Clang C++ does not find -lgfortran for some reason.')
-endif
-
 if build_machine.system() == 'windows' and cpp.get_id() != fc.get_id()
   error('MESON_SKIP_TEST mixing gfortran with non-GNU C++ does not work.')
 endif


### PR DESCRIPTION
This should be done in all cases of language_stdlib_only_link_flags, but
I don't have access to all of the compilers to test it.

This is required in cases where object files created by gfortran are
linked using another compiler with a different default search path, such
as gfortran and clang together. And also on nixos, where no compilers
implementation libs are in another compiler's path.