### PR TITLE
fix bat_info UTF-8 string error

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -82,6 +82,7 @@ def setup_vsenv() -> None:
             '-requiresAny',
             '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
             '-products', '*',
+            '-utf8',
             '-format',
             'json'
         ]


### PR DESCRIPTION
" bat_info = json.loads(bat_json) " may produce error
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc3 ...
Because the vswhere.exe's output is not utf-8 by default
Use UTF-8 encoding for vswhere.exe can fixing it .