### PR TITLE
Fix when gtest dep is found but does not pass version check

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -363,6 +363,7 @@ class ExternalDependency(Dependency, HasNativeKwarg):
         if self.version_reqs:
             # an unknown version can never satisfy any requirement
             if not self.version:
+                self.is_found = False
                 found_msg: mlog.TV_LoggableList = []
                 found_msg += ['Dependency', mlog.bold(self.name), 'found:']
                 found_msg += [mlog.red('NO'), 'unknown version, but need:', self.version_reqs]


### PR DESCRIPTION
GTestDependencySystem (and other similar dep classes) sets
self.is_found=True, but the version check could still fail. In the case
the dependency is not required `ExternalDependency._check_version()`
won't raise an exception and thus the dependency is accepted.

_check_version() sets self.is_found() in the case self.version is not
empty, we should do it too when self.version is empty.

Fixes: #9036.