### PR TITLE
Fix using CustomTargetIndex as a cython source

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1608,7 +1608,7 @@ class NinjaBackend(backends.Backend):
                     # TODO: introspection?
                     cython_sources.append(output)
                 else:
-                    generated_sources[ssrc] = mesonlib.File.from_built_file(gen.subdir, ssrc)
+                    generated_sources[ssrc] = mesonlib.File.from_built_file(gen.get_subdir(), ssrc)
 
         return static_sources, generated_sources, cython_sources
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2566,7 +2566,7 @@ class CustomTargetIndex(HoldableObject):
     def get_outputs(self) -> T.List[str]:
         return [self.output]
 
-    def get_subdir(self):
+    def get_subdir(self) -> str:
         return self.target.get_subdir()
 
     def get_filename(self):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1628,6 +1628,10 @@ class GeneratedList(HoldableObject):
     def get_extra_args(self) -> T.List[str]:
         return self.extra_args
 
+    def get_subdir(self) -> str:
+        return self.subdir
+
+
 class Executable(BuildTarget):
     known_kwargs = known_exe_kwargs
 

--- a/test cases/cython/2 generated sources/meson.build
+++ b/test cases/cython/2 generated sources/meson.build
@@ -26,6 +26,16 @@ test(
   env : ['PYTHONPATH=' + meson.current_build_dir()]
 )
 
+# Test a CustomTargetIndex
+cti = custom_target(
+  'cti',
+  input : 'gen.py',
+  output : 'cti.pyx',
+  command : [py3, '@INPUT@', '@OUTPUT@'],
+)
+
+cti_ext = py3.extension_module('cti', cti[0], dependencies : py3_dep)
+
 cf = configure_file(
   input : 'configure.pyx.in',
   output : 'cf.pyx',


### PR DESCRIPTION
We should have been using `.get_subdir()`, not `.subdir` as `CustomTargetIndex` classes don't have a `.subdir` attribute, just the `.get_subdir()` method.