### PR TITLE
Add type checking and annotations for run_target

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2179,9 +2179,14 @@ class BothLibraries(SecondLevelHolder):
         raise MesonBugException(f'self._preferred_library == "{self._preferred_library}" is neither "shared" nor "static".')
 
 class CommandBase:
-    def flatten_command(self, cmd):
+
+    depend_files: T.List[File]
+    dependencies: T.List[T.Union[BuildTarget, 'CustomTarget']]
+    subproject: str
+
+    def flatten_command(self, cmd: T.Sequence[T.Union[str, File, programs.ExternalProgram, BuildTarget, 'CustomTarget', 'CustomTargetIndex']]) -> T.List[str]:
         cmd = listify(cmd)
-        final_cmd = []
+        final_cmd: T.List[str] = []
         for c in cmd:
             if isinstance(c, str):
                 final_cmd.append(c)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2474,7 +2474,12 @@ class CustomTarget(Target, CommandBase):
 class RunTarget(Target, CommandBase):
     typename = 'run'
 
-    def __init__(self, name, command, dependencies, subdir, subproject, env=None):
+    def __init__(self, name: str,
+                 command: T.Sequence[T.Union[str, File, programs.ExternalProgram, BuildTarget, 'CustomTarget', 'CustomTargetIndex']],
+                 dependencies: T.List[T.Union['BuildTarget', 'CustomTarget']],
+                 subdir: str,
+                 subproject: str,
+                 env: T.Optional['EnvironmentVariables'] = None):
         # These don't produce output artifacts
         super().__init__(name, subdir, subproject, False, MachineChoice.BUILD)
         self.dependencies = dependencies
@@ -2486,20 +2491,20 @@ class RunTarget(Target, CommandBase):
     def get_custom_install_dir(self) -> T.List:
         raise NotImplementedError('This should never be reached')
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         repr_str = "<{0} {1}: {2}>"
         return repr_str.format(self.__class__.__name__, self.get_id(), self.command[0])
 
-    def process_kwargs(self, kwargs):
-        return self.process_kwargs_base(kwargs)
+    def process_kwargs(self, kwargs: T.Dict[str, T.Any]) -> None:
+        self.process_kwargs_base(kwargs)
 
-    def get_dependencies(self):
+    def get_dependencies(self) -> T.List[T.Union[BuildTarget, 'CustomTarget']]:
         return self.dependencies
 
-    def get_generated_sources(self):
+    def get_generated_sources(self) -> T.List[T.Union['CustomTarget', 'CustomTargetIndex', 'GeneratedList']]:
         return []
 
-    def get_sources(self):
+    def get_sources(self) -> T.List[File]:
         return []
 
     def should_install(self) -> bool:
@@ -2512,11 +2517,12 @@ class RunTarget(Target, CommandBase):
         if isinstance(self.name, str):
             return [self.name]
         elif isinstance(self.name, list):
+            # XXX: can this actually be reached? Target names should be just strings, right?
             return self.name
         else:
             raise RuntimeError('RunTarget: self.name is neither a list nor a string. This is a bug')
 
-    def type_suffix(self):
+    def type_suffix(self) -> str:
         return "@run"
 
 class AliasTarget(RunTarget):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2209,8 +2209,6 @@ class CommandBase:
                 FeatureNew.single_use('CustomTargetIndex for command argument', '0.60', self.subproject)
                 self.dependencies.append(c.target)
                 final_cmd += self.flatten_command(File.from_built_file(c.get_subdir(), c.get_filename()))
-            elif isinstance(c, list):
-                final_cmd += self.flatten_command(c)
             else:
                 raise InvalidArguments(f'Argument {c!r} in "command" is invalid')
         return final_cmd

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -496,22 +496,22 @@ class Target(HoldableObject, metaclass=abc.ABCMeta):
         pass
 
     def __lt__(self, other: object) -> bool:
-        if not hasattr(other, 'get_id') and not callable(other.get_id):
+        if not isinstance(other, (Target, CustomTargetIndex)):
             return NotImplemented
         return self.get_id() < other.get_id()
 
     def __le__(self, other: object) -> bool:
-        if not hasattr(other, 'get_id') and not callable(other.get_id):
+        if not isinstance(other, (Target, CustomTargetIndex)):
             return NotImplemented
         return self.get_id() <= other.get_id()
 
     def __gt__(self, other: object) -> bool:
-        if not hasattr(other, 'get_id') and not callable(other.get_id):
+        if not isinstance(other, (Target, CustomTargetIndex)):
             return NotImplemented
         return self.get_id() > other.get_id()
 
     def __ge__(self, other: object) -> bool:
-        if not hasattr(other, 'get_id') and not callable(other.get_id):
+        if not isinstance(other, (Target, CustomTargetIndex)):
             return NotImplemented
         return self.get_id() >= other.get_id()
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1644,10 +1644,10 @@ class GeneratedList(HoldableObject):
 
 class Executable(BuildTarget):
     known_kwargs = known_exe_kwargs
+    typename = 'executable'
 
     def __init__(self, name: str, subdir: str, subproject: str, for_machine: MachineChoice,
                  sources: T.List[File], objects, environment: environment.Environment, kwargs):
-        self.typename = 'executable'
         key = OptionKey('b_pie')
         if 'pie' not in kwargs and key in environment.coredata.options:
             kwargs['pie'] = environment.coredata.options[key].value
@@ -1763,9 +1763,9 @@ class Executable(BuildTarget):
 
 class StaticLibrary(BuildTarget):
     known_kwargs = known_stlib_kwargs
+    typename = 'static library'
 
     def __init__(self, name, subdir, subproject, for_machine: MachineChoice, sources, objects, environment, kwargs):
-        self.typename = 'static library'
         super().__init__(name, subdir, subproject, for_machine, sources, objects, environment, kwargs)
         if 'cs' in self.compilers:
             raise InvalidArguments('Static libraries not supported for C#.')
@@ -1824,9 +1824,9 @@ class StaticLibrary(BuildTarget):
 
 class SharedLibrary(BuildTarget):
     known_kwargs = known_shlib_kwargs
+    typename = 'shared library'
 
     def __init__(self, name, subdir, subproject, for_machine: MachineChoice, sources, objects, environment, kwargs):
-        self.typename = 'shared library'
         self.soversion = None
         self.ltversion = None
         # Max length 2, first element is compatibility_version, second is current_version
@@ -2149,6 +2149,7 @@ class SharedLibrary(BuildTarget):
 # into something else.
 class SharedModule(SharedLibrary):
     known_kwargs = known_shmod_kwargs
+    typename = 'shared module'
 
     def __init__(self, name, subdir, subproject, for_machine: MachineChoice, sources, objects, environment, kwargs):
         if 'version' in kwargs:
@@ -2156,7 +2157,6 @@ class SharedModule(SharedLibrary):
         if 'soversion' in kwargs:
             raise MesonException('Shared modules must not specify the soversion kwarg.')
         super().__init__(name, subdir, subproject, for_machine, sources, objects, environment, kwargs)
-        self.typename = 'shared module'
 
     def get_default_install_dir(self, environment):
         return environment.get_shared_module_dir()
@@ -2230,10 +2230,10 @@ class CustomTarget(Target, CommandBase):
         'console',
         'env',
     }
+    typename = 'custom'
 
     def __init__(self, name: str, subdir: str, subproject: str, kwargs: T.Dict[str, T.Any],
                  absolute_paths: bool = False, backend: T.Optional['Backend'] = None):
-        self.typename = 'custom'
         # TODO expose keyword arg to make MachineChoice.HOST configurable
         super().__init__(name, subdir, subproject, False, MachineChoice.HOST)
         self.dependencies: T.List[T.Union[CustomTarget, BuildTarget]] = []
@@ -2469,8 +2469,9 @@ class CustomTarget(Target, CommandBase):
             yield CustomTargetIndex(self, i)
 
 class RunTarget(Target, CommandBase):
+    typename = 'run'
+
     def __init__(self, name, command, dependencies, subdir, subproject, env=None):
-        self.typename = 'run'
         # These don't produce output artifacts
         super().__init__(name, subdir, subproject, False, MachineChoice.BUILD)
         self.dependencies = dependencies
@@ -2525,9 +2526,9 @@ class AliasTarget(RunTarget):
 
 class Jar(BuildTarget):
     known_kwargs = known_jar_kwargs
+    typename = 'jar'
 
     def __init__(self, name, subdir, subproject, for_machine: MachineChoice, sources, objects, environment, kwargs):
-        self.typename = 'jar'
         super().__init__(name, subdir, subproject, for_machine, sources, objects, environment, kwargs)
         for s in self.sources:
             if not s.endswith('.java'):
@@ -2569,9 +2570,9 @@ class CustomTargetIndex(HoldableObject):
     on the CustomTarget it's derived from, but only adding one source file to
     the sources.
     """
+    typename = 'custom'
 
     def __init__(self, target: CustomTarget, output: int):
-        self.typename = 'custom'
         self.target = target
         self.output = output
         self.for_machine = target.for_machine

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1720,19 +1720,18 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
                   kwargs: 'kwargs.FuncTest') -> None:
         self.add_test(node, args, kwargs, True)
 
-    def unpack_env_kwarg(self, kwargs: T.Union[EnvironmentVariablesObject, T.Dict[str, str], T.List[str]]) -> build.EnvironmentVariables:
+    def unpack_env_kwarg(self, kwargs: T.Dict[str, T.Union[EnvironmentVariablesObject, T.Dict[str, str], T.List[str], str, None]]) -> build.EnvironmentVariables:
         envlist = kwargs.get('env', EnvironmentVariablesObject())
-        if isinstance(envlist, EnvironmentVariablesObject):
-            env = envlist.vars
-        elif isinstance(envlist, dict):
+        if isinstance(envlist, dict):
             FeatureNew.single_use('environment dictionary', '0.52.0', self.subproject)
-            env = EnvironmentVariablesObject(envlist)
-            env = env.vars
-        else:
-            # Convert from array to environment object
-            env = EnvironmentVariablesObject(envlist)
-            env = env.vars
-        return env
+            envlist = EnvironmentVariablesObject(envlist)
+        elif isinstance(envlist, list):
+            envlist = EnvironmentVariablesObject(envlist)
+        elif isinstance(envlist, str):
+            envlist = EnvironmentVariablesObject([envlist])
+        elif envlist is None:
+            envlist = EnvironmentVariablesObject()
+        return envlist.vars
 
     def make_test(self, node: mparser.BaseNode,
                   args: T.Tuple[str, T.Union[build.Executable, build.Jar, ExternalProgram, mesonlib.File]],

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -11,6 +11,7 @@ from typing_extensions import TypedDict, Literal
 from .. import build
 from .. import coredata
 from ..mesonlib import MachineChoice, File, FileMode, FileOrString
+from ..programs import ExternalProgram
 from .interpreterobjects import EnvironmentVariablesObject
 
 
@@ -142,3 +143,10 @@ class FuncImportModule(ExtractRequired):
 class FuncIncludeDirectories(TypedDict):
 
     is_system: bool
+
+
+class RunTarget(TypedDict):
+
+    command: T.List[T.Union[str, File, build.BuildTarget, build.CustomTarget, build.CustomTargetIndex, ExternalProgram]]
+    depends: T.List[T.Union[build.BuildTarget, build.CustomTarget]]
+    env: T.Union[T.List[str], T.Dict[str, str], build.EnvironmentVariables, str]


### PR DESCRIPTION
This includes some basic cleanups, and a conversion of `func_run_target` to use `typoed_kwargs`, and the `build.RunTarget` to stop processing keyword arguments itself. This is my first step in untagling the build and interpreter target creation from each other.