### PR TITLE
destdir: Allow relative to build directory

### DIFF
--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -190,6 +190,9 @@ Install project to `$DESTDIR/prefix`:
 DESTDIR=/path/to/staging/area meson install -C builddir
 ```
 
+Since *0.60.0* `DESTDIR` and `--destdir` can be a path relative to build
+directory. An absolute path will be set into environment when executing scripts.
+
 ### rewrite
 
 *(since 0.50.0)*

--- a/docs/markdown/Installing.md
+++ b/docs/markdown/Installing.md
@@ -113,6 +113,12 @@ is used just like with other build systems:
 $ DESTDIR=/path/to/staging/area meson install
 ```
 
+Since *0.57.0* `--destdir` argument can be used instead of environment. In that
+case Meson will set `DESTDIR` into environment when runing install scripts.
+
+Since *0.60.0* `DESTDIR` and `--destdir` can be a path relative to build
+directory. An absolute path will be set into environment when executing scripts.
+
 ## Custom install behaviour
 
 Installation behaviour can be further customized using additional

--- a/docs/markdown/snippets/relative_destdir.md
+++ b/docs/markdown/snippets/relative_destdir.md
@@ -1,0 +1,6 @@
+## Install DESTDIR relative to build directory
+
+When `DESTDIR` environment or `meson install --destdir` option is a relative path,
+it is now assumed to be relative to the build directory. An absolute path will be
+set into environment when executing scripts. It was undefined behavior in prior
+Meson versions but was working as relative to build directory most of the time.

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -494,11 +494,16 @@ class Installer:
         with open(datafilename, 'rb') as ifile:
             d = self.check_installdata(pickle.load(ifile))
 
-        # Override in the env because some scripts could be relying on it.
-        if self.options.destdir is not None:
-            os.environ['DESTDIR'] = self.options.destdir
-
-        destdir = os.environ.get('DESTDIR', '')
+        destdir = self.options.destdir
+        if destdir is None:
+            destdir = os.environ.get('DESTDIR')
+        if destdir and not os.path.isabs(destdir):
+            destdir = os.path.join(d.build_dir, destdir)
+        # Override in the env because some scripts could use it and require an
+        # absolute path.
+        if destdir is not None:
+            os.environ['DESTDIR'] = destdir
+        destdir = destdir or ''
         fullprefix = destdir_join(destdir, d.prefix)
 
         if d.install_umask != 'preserve':

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -512,6 +512,12 @@ class AllPlatformTests(BasePlatformTests):
         self.assertEqual(logged, read_logs())
         self.assertFalse(os.path.exists(self.installdir))
 
+        # If destdir is relative to build directory it should install
+        # exactly the same files.
+        rel_installpath = os.path.relpath(self.installdir, self.builddir)
+        self._run(self.meson_command + ['install', '--dry-run', '--destdir', rel_installpath, '-C', self.builddir])
+        self.assertEqual(logged, read_logs())
+
     def test_uninstall(self):
         exename = os.path.join(self.installdir, 'usr/bin/prog' + exe_suffix)
         dirname = os.path.join(self.installdir, 'usr/share/dir')


### PR DESCRIPTION
Meson already works like that, except in do_copydir() that requires
absolute destdir. Better explicitly support that instead of leaving it
undefined and unconsistent.