### PR TITLE
compilers/cpp: Set the MSVC macro to make the __cplusplus define

### DIFF
--- a/docs/markdown/snippets/msvc_cplusplus_define.md
+++ b/docs/markdown/snippets/msvc_cplusplus_define.md
@@ -1,0 +1,7 @@
+## MSVC now sets the __cplusplus #define accurately
+
+For reasons, MSVC will always return `199711L` for `__cplusplus`, even when a
+newer c++ standard is explicitly requested, unless you pass a specific option to
+the compiler for MSVC 2017 15.7 and newer. Older versions are unaffected by
+this. Meson now always sets the option if it is available, as it is unlikley
+that users want the default behavior.

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -692,6 +692,17 @@ class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixi
             del args[i]
         return args
 
+    def get_always_args(self) -> T.List[str]:
+        args = super().get_always_args()
+
+        # update the __cplusplus #define to match the version given on the
+        # command line with /std:NNN, but only for versions above 15.7 (2017)
+        # https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-160
+        if version_compare(self.version, '>= 15.7'):
+            args.append('/Zc:__cplusplus')
+
+        return args
+
 class ClangClCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixin, ClangClCompiler, CPPCompiler):
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
                  is_cross: bool, info: 'MachineInfo', target: str,

--- a/test cases/windows/18 msvc cplusplus define/main.cpp
+++ b/test cases/windows/18 msvc cplusplus define/main.cpp
@@ -1,0 +1,7 @@
+int main() {
+#if __cplusplus == 199711L
+    return 1;
+#else
+    return 0;
+#endif
+}

--- a/test cases/windows/18 msvc cplusplus define/meson.build
+++ b/test cases/windows/18 msvc cplusplus define/meson.build
@@ -1,0 +1,14 @@
+project('msvc __cplusplus', 'cpp', default_options : ['cpp_std=c++14'])
+
+cpp = meson.get_compiler('cpp')
+
+if cpp.get_id() != 'msvc'
+  error('MESON_SKIP_TEST: test is only relavent for msvc')
+elif meson.project_version().version_compare('< 15.7')
+  error('MESON_SKIP_TEST: test is only relavent for msvc versions >= 15.7')
+endif
+
+test(
+  'main',
+  executable('main', 'main.cpp'),
+)

--- a/test cases/windows/3 cpp/meson.build
+++ b/test cases/windows/3 cpp/meson.build
@@ -1,4 +1,4 @@
-project('wincpp', 'cpp')
+project('wincpp', 'cpp', default_options : ['cpp_std=c++14'])
 
 exe = executable('prog', 'prog.cpp')
 test('wincpp', exe)

--- a/unittests/windowstests.py
+++ b/unittests/windowstests.py
@@ -359,4 +359,3 @@ class WindowsTests(BasePlatformTests):
             raise SkipTest('C++ modules are only supported with VS 2019 Preview or newer.')
         self.init(os.path.join(self.unit_test_dir, '86 cpp modules'))
         self.build()
-


### PR DESCRIPTION
accurate

Otherwise it always returns the value for c++98.

TODO: needs test
TODO: needs docs