### PR TITLE
Type annotations and fixes for backend/backends

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -500,7 +500,7 @@ class Backend:
                                        exe_wrapper, workdir,
                                        extra_paths, capture, feed, tag)
 
-    def as_meson_exe_cmdline(self, tname, exe, cmd_args, workdir=None,
+    def as_meson_exe_cmdline(self, exe, cmd_args, workdir=None,
                              extra_bdeps=None, capture=None, feed=None,
                              force_serialize=False,
                              env: T.Optional[build.EnvironmentVariables] = None,

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -149,9 +149,18 @@ class SubdirInstallData(InstallDataBase):
         self.exclude = exclude
 
 class ExecutableSerialisation:
-    def __init__(self, cmd_args, env: T.Optional[build.EnvironmentVariables] = None, exe_wrapper=None,
-                 workdir=None, extra_paths=None, capture=None, feed=None,
-                 tag: T.Optional[str] = None) -> None:
+
+    # XXX: should capture and feed default to False, instead of None?
+
+    def __init__(self, cmd_args: T.List[str],
+                 env: T.Optional[build.EnvironmentVariables] = None,
+                 exe_wrapper: T.Optional['programs.ExternalProgram'] = None,
+                 workdir: T.Optional[str] = None,
+                 extra_paths: T.Optional[T.List] = None,
+                 capture: T.Optional[bool] = None,
+                 feed: T.Optional[bool] = None,
+                 tag: T.Optional[str] = None,
+                 ) -> None:
         self.cmd_args = cmd_args
         self.env = env
         if exe_wrapper is not None:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -48,7 +48,7 @@ if T.TYPE_CHECKING:
 LANGS_CANT_UNITY = ('d', 'fortran', 'vala')
 
 class RegenInfo:
-    def __init__(self, source_dir, build_dir, depfiles):
+    def __init__(self, source_dir: str, build_dir: str, depfiles: T.List[str]):
         self.source_dir = source_dir
         self.build_dir = build_dir
         self.depfiles = depfiles

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -45,6 +45,16 @@ if T.TYPE_CHECKING:
     from ..mesonlib import FileMode, FileOrString
     from ..wrap import WrapMode
 
+    from typing_extensions import TypedDict
+
+    class TargetIntrospectionData(TypedDict):
+
+        language: str
+        compiler : T.List[str]
+        parameters: T.List[str]
+        sources: T.List[str]
+        generated_sources: T.List[str]
+
 
 # Languages that can mix with C or C++ but don't support unity builds yet
 # because the syntax we use for unity builds is specific to C/++/ObjC/++.
@@ -1666,7 +1676,7 @@ class Backend:
             i = SubdirInstallData(src_dir, dst_dir, sd.install_mode, sd.exclude, sd.subproject)
             d.install_subdirs.append(i)
 
-    def get_introspection_data(self, target_id: str, target: build.Target) -> T.List[T.Dict[str, T.Union[bool, str, T.List[T.Union[str, T.Dict[str, T.Union[str, T.List[str], bool]]]]]]]:
+    def get_introspection_data(self, target_id: str, target: build.Target) -> T.List['TargetIntrospectionData']:
         '''
         Returns a list of source dicts with the following format for a given target:
         [

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -88,7 +88,7 @@ class CleanTrees:
     Directories outputted by custom targets that have to be manually cleaned
     because on Linux `ninja clean` only deletes empty directories.
     '''
-    def __init__(self, build_dir, trees):
+    def __init__(self, build_dir: str, trees: T.List[str]):
         self.build_dir = build_dir
         self.trees = trees
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -113,10 +113,13 @@ class InstallData:
         self.version = version
 
 class TargetInstallData:
+
+    # TODO: install_mode should just always be a FileMode object
+
     def __init__(self, fname: str, outdir: str, aliases: T.Dict[str, str], strip: bool,
-                 install_name_mappings: T.Dict, rpath_dirs_to_remove: T.Set[bytes],
-                 install_rpath: str, install_mode: 'FileMode', subproject: str,
-                 optional: bool = False, tag: T.Optional[str] = None):
+                 install_name_mappings: T.Mapping[str, str], rpath_dirs_to_remove: T.Set[bytes],
+                 install_rpath: str, install_mode: T.Optional['FileMode'],
+                 subproject: str, optional: bool = False, tag: T.Optional[str] = None):
         self.fname = fname
         self.outdir = outdir
         self.aliases = aliases

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -160,6 +160,7 @@ class ExecutableSerialisation:
                  capture: T.Optional[bool] = None,
                  feed: T.Optional[bool] = None,
                  tag: T.Optional[str] = None,
+                 verbose: bool = False,
                  ) -> None:
         self.cmd_args = cmd_args
         self.env = env
@@ -172,7 +173,7 @@ class ExecutableSerialisation:
         self.feed = feed
         self.pickled = False
         self.skip_if_destdir = False
-        self.verbose = False
+        self.verbose = verbose
         self.subproject = ''
         self.tag = tag
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -143,7 +143,8 @@ class InstallDataBase:
 
 class SubdirInstallData(InstallDataBase):
     def __init__(self, path: str, install_path: str, install_mode: 'FileMode',
-                 exclude, subproject: str, tag: T.Optional[str] = None):
+                 exclude: T.Tuple[T.Set[str], T.Set[str]], subproject: str,
+                 tag: T.Optional[str] = None):
         super().__init__(path, install_path, install_mode, subproject, tag)
         self.exclude = exclude
 

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -789,15 +789,20 @@ class Backend:
         return pch_rel_to_build
 
     @staticmethod
-    def escape_extra_args(compiler, args):
+    def escape_extra_args(args: T.List[str]) -> T.List[str]:
         # all backslashes in defines are doubly-escaped
-        extra_args = []
+        extra_args: T.List[str] = []
         for arg in args:
-            if arg.startswith('-D') or arg.startswith('/D'):
+            if arg.startswith(('-D', '/D')):
                 arg = arg.replace('\\', '\\\\')
             extra_args.append(arg)
 
         return extra_args
+
+    def get_no_stdlib_args(self, target: 'build.BuildTarget', compiler: 'Compiler') -> T.List[str]:
+        if compiler.language in self.build.stdlibs[target.for_machine]:
+            return compiler.get_no_stdinc_args()
+        return []
 
     def generate_basic_compiler_args(self, target: build.BuildTarget, compiler: 'Compiler', no_warn_args: bool = False) -> 'CompilerArgs':
         # Create an empty commands list, and start adding arguments from

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -975,7 +975,7 @@ class NinjaBackend(backends.Backend):
             for output in d.get_outputs():
                 elem.add_dep(os.path.join(self.get_target_dir(d), output))
 
-        cmd, reason = self.as_meson_exe_cmdline(target.name, target.command[0], cmd[1:],
+        cmd, reason = self.as_meson_exe_cmdline(target.command[0], cmd[1:],
                                                 extra_bdeps=target.get_transitive_build_target_deps(),
                                                 capture=ofilenames[0] if target.capture else None,
                                                 feed=srcs[0] if target.feed else None,
@@ -1013,7 +1013,7 @@ class NinjaBackend(backends.Backend):
         else:
             target_env = self.get_run_target_env(target)
             _, _, cmd = self.eval_custom_target_command(target)
-            meson_exe_cmd, reason = self.as_meson_exe_cmdline(target_name, target.command[0], cmd[1:],
+            meson_exe_cmd, reason = self.as_meson_exe_cmdline(target.command[0], cmd[1:],
                                                               force_serialize=True, env=target_env,
                                                               verbose=True)
             cmd_type = f' (wrapped by meson {reason})'
@@ -2209,8 +2209,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 outfilelist = outfilelist[len(generator.outputs):]
             args = self.replace_paths(target, args, override_subdir=subdir)
             cmdlist = exe_arr + self.replace_extra_args(args, genlist)
-            cmdlist, reason = self.as_meson_exe_cmdline('generator ' + cmdlist[0],
-                                                        cmdlist[0], cmdlist[1:],
+            cmdlist, reason = self.as_meson_exe_cmdline(cmdlist[0], cmdlist[1:],
                                                         capture=outfiles[0] if generator.capture else None)
             abs_pdir = os.path.join(self.environment.get_build_dir(), self.get_target_dir(target))
             os.makedirs(abs_pdir, exist_ok=True)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3077,7 +3077,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             except OSError:
                 mlog.debug("Library versioning disabled because we do not have symlink creation privileges.")
 
-    def generate_custom_target_clean(self, trees):
+    def generate_custom_target_clean(self, trees: T.List[str]) -> str:
         e = NinjaBuildElement(self.all_outputs, 'meson-clean-ctlist', 'CUSTOM_COMMAND', 'PHONY')
         d = CleanTrees(self.environment.get_build_dir(), trees)
         d_file = os.path.join(self.environment.get_scratch_dir(), 'cleantrees.dat')

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2479,8 +2479,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 commands += compiler.get_include_args(d, i.is_system)
         # Add per-target compile args, f.ex, `c_args : ['-DFOO']`. We set these
         # near the end since these are supposed to override everything else.
-        commands += self.escape_extra_args(compiler,
-                                           target.get_extra_args(compiler.get_language()))
+        commands += self.escape_extra_args(target.get_extra_args(compiler.get_language()))
 
         # D specific additional flags
         if compiler.language == 'd':

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2304,11 +2304,6 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         mod_files = _scan_fortran_file_deps(src, srcdir, dirname, tdeps, compiler)
         return mod_files
 
-    def get_no_stdlib_args(self, target, compiler):
-        if compiler.language in self.build.stdlibs[target.for_machine]:
-            return compiler.get_no_stdinc_args()
-        return []
-
     def get_no_stdlib_link_args(self, target, linker):
         if hasattr(linker, 'language') and linker.language in self.build.stdlibs[target.for_machine]:
             return linker.get_no_stdlib_link_args()

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -31,7 +31,7 @@ from ..mesonlib import (
 )
 from ..environment import Environment, build_filename
 
-def autodetect_vs_version(build: T.Optional[build.Build], interpreter: T.Optional[Interpreter]):
+def autodetect_vs_version(build: T.Optional[build.Build], interpreter: T.Optional[Interpreter]) -> backends.Backend:
     vs_version = os.getenv('VisualStudioVersion', None)
     vs_install_dir = os.getenv('VSINSTALLDIR', None)
     if not vs_install_dir:

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -150,7 +150,6 @@ class Vs2010Backend(backends.Backend):
                     # there are many arguments.
                     tdir_abs = os.path.join(self.environment.get_build_dir(), self.get_target_dir(target))
                     cmd, _ = self.as_meson_exe_cmdline(
-                        'generator ' + cmd[0],
                         cmd[0],
                         cmd[1:],
                         workdir=tdir_abs,
@@ -560,7 +559,7 @@ class Vs2010Backend(backends.Backend):
             _, _, cmd_raw = self.eval_custom_target_command(target)
         depend_files = self.get_custom_target_depend_files(target)
         target_env = self.get_run_target_env(target)
-        wrapper_cmd, _ = self.as_meson_exe_cmdline(target.name, target.command[0], cmd_raw[1:],
+        wrapper_cmd, _ = self.as_meson_exe_cmdline(target.command[0], cmd_raw[1:],
                                                    force_serialize=True, env=target_env,
                                                    verbose=True)
         self.add_custom_build(root, 'run_target', ' '.join(self.quote_arguments(wrapper_cmd)),
@@ -581,7 +580,7 @@ class Vs2010Backend(backends.Backend):
         # there are many arguments.
         tdir_abs = os.path.join(self.environment.get_build_dir(), self.get_target_dir(target))
         extra_bdeps = target.get_transitive_build_target_deps()
-        wrapper_cmd, _ = self.as_meson_exe_cmdline(target.name, target.command[0], cmd[1:],
+        wrapper_cmd, _ = self.as_meson_exe_cmdline(target.command[0], cmd[1:],
                                                    # All targets run from the target dir
                                                    workdir=tdir_abs,
                                                    extra_bdeps=extra_bdeps,

--- a/mesonbuild/backend/xcodebackend.py
+++ b/mesonbuild/backend/xcodebackend.py
@@ -1169,8 +1169,7 @@ class XCodeBackend(backends.Backend):
             if not isinstance(t, build.CustomTarget):
                 continue
             (srcs, ofilenames, cmd) = self.eval_custom_target_command(t, absolute_outputs=True)
-            fixed_cmd, _ = self.as_meson_exe_cmdline(t.name,
-                                                     cmd[0],
+            fixed_cmd, _ = self.as_meson_exe_cmdline(cmd[0],
                                                      cmd[1:],
                                                      #workdir=None,
                                                      env=t.env)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2573,6 +2573,10 @@ class CustomTargetIndex(HoldableObject):
         self.output = output
         self.for_machine = target.for_machine
 
+    @property
+    def name(self) -> str:
+        return f'{self.target.name}[{self.output}]'
+
     def __repr__(self):
         return '<CustomTargetIndex: {!r}[{}]>'.format(
             self.target, self.target.get_outputs().index(self.output))

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1744,7 +1744,7 @@ class Executable(BuildTarget):
             return [self.vs_import_filename, self.gcc_import_filename]
         return []
 
-    def get_debug_filename(self):
+    def get_debug_filename(self) -> T.Optional[str]:
         """
         The name of debuginfo file that will be created by the compiler
 
@@ -2087,7 +2087,7 @@ class SharedLibrary(BuildTarget):
         """
         return self.import_filename
 
-    def get_debug_filename(self):
+    def get_debug_filename(self) -> T.Optional[str]:
         """
         The name of debuginfo file that will be created by the compiler
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -47,7 +47,7 @@ if T.TYPE_CHECKING:
     from .interpreter.interpreter import Test, SourceOutputs, Interpreter
     from .mesonlib import FileMode, FileOrString
     from .modules import ModuleState
-    from .backend.backends import Backend
+    from .backend.backends import Backend, ExecutableSerialisation
 
 pch_kwargs = {'c_pch', 'cpp_pch'}
 
@@ -228,7 +228,7 @@ class Build:
         self.subprojects = {}
         self.subproject_dir = ''
         self.install_scripts = []
-        self.postconf_scripts = []
+        self.postconf_scripts: T.List['ExecutableSerialisation'] = []
         self.dist_scripts = []
         self.install_dirs: T.List[InstallDir] = []
         self.dep_manifest_name = None

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2567,7 +2567,7 @@ class CustomTargetIndex(HoldableObject):
     the sources.
     """
 
-    def __init__(self, target: CustomTarget, output: int):
+    def __init__(self, target: CustomTarget, output: str):
         self.typename = 'custom'
         self.target = target
         self.output = output

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -291,16 +291,16 @@ class Build:
     def get_benchmarks(self) -> T.List['Test']:
         return self.benchmarks
 
-    def get_headers(self):
+    def get_headers(self) -> T.List['Headers']:
         return self.headers
 
-    def get_man(self):
+    def get_man(self) -> T.List['Man']:
         return self.man
 
-    def get_data(self):
+    def get_data(self) -> T.List['Data']:
         return self.data
 
-    def get_install_subdirs(self):
+    def get_install_subdirs(self) -> T.List['InstallDir']:
         return self.install_dirs
 
     def get_global_args(self, compiler: 'Compiler', for_machine: 'MachineChoice') -> T.List[str]:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2472,7 +2472,8 @@ class CustomTarget(Target, CommandBase):
             yield CustomTargetIndex(self, i)
 
 class RunTarget(Target, CommandBase):
-    def __init__(self, name, command, dependencies, subdir, subproject, env=None):
+    def __init__(self, name: str, command, dependencies,
+                 subdir: str, subproject: str, env: T.Optional['EnvironmentVariables'] = None):
         self.typename = 'run'
         # These don't produce output artifacts
         super().__init__(name, subdir, subproject, False, MachineChoice.BUILD)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1731,7 +1731,7 @@ class Executable(BuildTarget):
     def type_suffix(self):
         return "@exe"
 
-    def get_import_filename(self):
+    def get_import_filename(self) -> T.Optional[str]:
         """
         The name of the import library that will be outputted by the compiler
 
@@ -2079,7 +2079,7 @@ class SharedLibrary(BuildTarget):
             else:
                 raise InvalidArguments(f'Invalid rust_crate_type "{rust_crate_type}": must be a string.')
 
-    def get_import_filename(self):
+    def get_import_filename(self) -> T.Optional[str]:
         """
         The name of the import library that will be outputted by the compiler
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2587,7 +2587,7 @@ class CustomTargetIndex(HoldableObject):
     def get_subdir(self) -> str:
         return self.target.get_subdir()
 
-    def get_filename(self):
+    def get_filename(self) -> str:
         return self.output
 
     def get_id(self):
@@ -2602,10 +2602,9 @@ class CustomTargetIndex(HoldableObject):
     def get_link_dep_subdirs(self):
         return self.target.get_link_dep_subdirs()
 
-    def is_linkable_target(self):
+    def is_linkable_target(self) -> bool:
         suf = os.path.splitext(self.output)[-1]
-        if suf == '.a' or suf == '.dll' or suf == '.lib' or suf == '.so':
-            return True
+        return suf in {'.a', '.dll', '.lib', '.so'}
 
     def should_install(self) -> bool:
         return self.target.should_install()
@@ -2613,7 +2612,7 @@ class CustomTargetIndex(HoldableObject):
     def is_internal(self) -> bool:
         return self.target.is_internal()
 
-    def extract_all_objects_recurse(self):
+    def extract_all_objects_recurse(self) -> T.List[T.Union[str, 'ExtractedObjects']]:
         return self.target.extract_all_objects_recurse()
 
     def get_custom_install_dir(self):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -213,7 +213,7 @@ class Build:
         self.project_version = None
         self.environment = environment
         self.projects = {}
-        self.targets: T.MutableMapping[str, 'Target'] = OrderedDict()
+        self.targets: 'T.OrderedDict[str, T.Union[CustomTarget, BuildTarget]]' = OrderedDict()
         self.run_target_names: T.Set[T.Tuple[str, str]] = set()
         self.global_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachine({}, {})
         self.global_link_args: PerMachine[T.Dict[str, T.List[str]]] = PerMachine({}, {})
@@ -282,7 +282,7 @@ class Build:
     def get_subproject_dir(self):
         return self.subproject_dir
 
-    def get_targets(self) -> T.Dict[str, 'Target']:
+    def get_targets(self) -> 'T.OrderedDict[str, T.Union[CustomTarget, BuildTarget]]':
         return self.targets
 
     def get_tests(self) -> T.List['Test']:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2260,7 +2260,7 @@ class CustomTarget(Target, CommandBase):
                 deps.append(c)
         return deps
 
-    def get_transitive_build_target_deps(self):
+    def get_transitive_build_target_deps(self) -> T.Set[T.Union[BuildTarget, 'CustomTarget']]:
         '''
         Recursively fetch the build targets that this custom target depends on,
         whether through `command:`, `depends:`, or `sources:` The recursion is
@@ -2269,7 +2269,7 @@ class CustomTarget(Target, CommandBase):
         F.ex, if you have a python script that loads a C module that links to
         other DLLs in your project.
         '''
-        bdeps = set()
+        bdeps: T.Set[T.Union[BuildTarget, 'CustomTarget']] = set()
         deps = self.get_target_dependencies()
         for d in deps:
             if isinstance(d, BuildTarget):
@@ -2394,26 +2394,26 @@ class CustomTarget(Target, CommandBase):
     def get_custom_install_dir(self):
         return self.install_dir
 
-    def get_custom_install_mode(self):
+    def get_custom_install_mode(self) -> T.Optional['FileMode']:
         return self.install_mode
 
     def get_outputs(self) -> T.List[str]:
         return self.outputs
 
-    def get_filename(self):
+    def get_filename(self) -> str:
         return self.outputs[0]
 
-    def get_sources(self):
+    def get_sources(self) -> T.List[T.Union[str, File, 'CustomTarget', 'CustomTargetIndex', 'GeneratedList', 'ExtractedObjects']]:
         return self.sources
 
-    def get_generated_lists(self):
-        genlists = []
+    def get_generated_lists(self) -> T.List[GeneratedList]:
+        genlists: T.List[GeneratedList] = []
         for c in self.sources:
             if isinstance(c, GeneratedList):
                 genlists.append(c)
         return genlists
 
-    def get_generated_sources(self):
+    def get_generated_sources(self) -> T.List[GeneratedList]:
         return self.get_generated_lists()
 
     def get_dep_outname(self, infilenames):
@@ -2428,12 +2428,11 @@ class CustomTarget(Target, CommandBase):
                 raise InvalidArguments('Substitution in depfile for custom_target that does not have an input file.')
             return self.depfile
 
-    def is_linkable_target(self):
+    def is_linkable_target(self) -> bool:
         if len(self.outputs) != 1:
             return False
         suf = os.path.splitext(self.outputs[0])[-1]
-        if suf == '.a' or suf == '.dll' or suf == '.lib' or suf == '.so' or suf == '.dylib':
-            return True
+        return suf in {'.a', '.dll', '.lib', '.so', '.dylib'}
 
     def get_link_deps_mapping(self, prefix: str, environment: environment.Environment) -> T.Mapping[str, str]:
         return {}
@@ -2453,7 +2452,7 @@ class CustomTarget(Target, CommandBase):
                 return False
         return True
 
-    def extract_all_objects_recurse(self):
+    def extract_all_objects_recurse(self) -> T.List[T.Union[str, 'ExtractedObjects']]:
         return self.get_outputs()
 
     def type_suffix(self):

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1260,6 +1260,10 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         """Arguments required for a debug build."""
         return []
 
+    def get_no_warn_args(self) -> T.List[str]:
+        """Arguments to completely disable warnings."""
+        return []
+
 
 def get_global_options(lang: str,
                        comp: T.Type[Compiler],

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -22,7 +22,7 @@ from . import mesonlib
 from .mesonlib import (
     MesonException, EnvironmentException, MachineChoice, Popen_safe, PerMachine,
     PerMachineDefaultable, PerThreeMachineDefaultable, split_args, quote_arg, OptionKey,
-    search_version
+    search_version, MesonBugException
 )
 from . import mlog
 from .programs import (
@@ -750,8 +750,12 @@ class Environment:
     def get_coredata(self) -> coredata.CoreData:
         return self.coredata
 
-    def get_build_command(self, unbuffered=False):
-        cmd = mesonlib.get_meson_command().copy()
+    @staticmethod
+    def get_build_command(unbuffered: bool = False) -> T.List[str]:
+        cmd = mesonlib.get_meson_command()
+        if cmd is None:
+            raise MesonBugException('No command?')
+        cmd = cmd.copy()
         if unbuffered and 'python' in os.path.basename(cmd[0]):
             cmd.insert(1, '-u')
         return cmd

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -756,19 +756,19 @@ class Environment:
             cmd.insert(1, '-u')
         return cmd
 
-    def is_header(self, fname):
+    def is_header(self, fname: 'mesonlib.FileOrString') -> bool:
         return is_header(fname)
 
-    def is_source(self, fname):
+    def is_source(self, fname: 'mesonlib.FileOrString') -> bool:
         return is_source(fname)
 
-    def is_assembly(self, fname):
+    def is_assembly(self, fname: 'mesonlib.FileOrString') -> bool:
         return is_assembly(fname)
 
-    def is_llvm_ir(self, fname):
+    def is_llvm_ir(self, fname: 'mesonlib.FileOrString') -> bool:
         return is_llvm_ir(fname)
 
-    def is_object(self, fname):
+    def is_object(self, fname: 'mesonlib.FileOrString') -> bool:
         return is_object(fname)
 
     @lru_cache(maxsize=None)

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -668,9 +668,12 @@ class GeneratedObjectsHolder(ObjectHolder[build.ExtractedObjects]):
     pass
 
 class Test(MesonInterpreterObject):
-    def __init__(self, name: str, project: str, suite: T.List[str], exe: build.Executable,
+    def __init__(self, name: str, project: str, suite: T.List[str],
+                 exe: T.Union[ExternalProgram, build.Executable, build.CustomTarget],
                  depends: T.List[T.Union[build.CustomTarget, build.BuildTarget]],
-                 is_parallel: bool, cmd_args: T.List[str], env: build.EnvironmentVariables,
+                 is_parallel: bool,
+                 cmd_args: T.List[T.Union[str, mesonlib.File, build.Target]],
+                 env: build.EnvironmentVariables,
                  should_fail: bool, timeout: int, workdir: T.Optional[str], protocol: str,
                  priority: int):
         super().__init__()
@@ -688,7 +691,7 @@ class Test(MesonInterpreterObject):
         self.protocol = TestProtocol.from_str(protocol)
         self.priority = priority
 
-    def get_exe(self) -> build.Executable:
+    def get_exe(self) -> T.Union[ExternalProgram, build.Executable, build.CustomTarget]:
         return self.exe
 
     def get_name(self) -> str:

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -1260,6 +1260,8 @@ def dump_conf_header(ofilename: str, cdata: 'ConfigurationData', output_format: 
     elif output_format == 'nasm':
         prelude = CONF_NASM_PRELUDE
         prefix = '%'
+    else:
+        raise MesonBugException(f'Undefined output_format: "{output_format}"')
 
     ofilename_tmp = ofilename + '~'
     with open(ofilename_tmp, 'w', encoding='utf-8') as ofile:

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -35,8 +35,7 @@ if T.TYPE_CHECKING:
     from .._typing import ImmutableListProtocol
     from ..build import ConfigurationData
     from ..coredata import KeyedOptionDictType, UserOption
-    from ..compilers.compilers import CompilerType
-    from ..interpreterbase import ObjectHolder
+    from ..compilers.compilers import Compiler
 
 FileOrString = T.Union['File', str]
 
@@ -453,7 +452,7 @@ class File(HoldableObject):
         return os.path.join(self.subdir, self.fname)
 
 
-def get_compiler_for_source(compilers: T.Iterable['CompilerType'], src: str) -> 'CompilerType':
+def get_compiler_for_source(compilers: T.Iterable['Compiler'], src: 'FileOrString') -> 'Compiler':
     """Given a set of compilers and a source, find the compiler for that source type."""
     for comp in compilers:
         if comp.can_compile(src):
@@ -461,8 +460,8 @@ def get_compiler_for_source(compilers: T.Iterable['CompilerType'], src: str) -> 
     raise MesonException(f'No specified compiler can handle file {src!s}')
 
 
-def classify_unity_sources(compilers: T.Iterable['CompilerType'], sources: T.Iterable[str]) -> T.Dict['CompilerType', T.List[str]]:
-    compsrclist = {}  # type: T.Dict[CompilerType, T.List[str]]
+def classify_unity_sources(compilers: T.Iterable['Compiler'], sources: T.Sequence['FileOrString']) -> T.Dict['Compiler', T.List['FileOrString']]:
+    compsrclist: T.Dict['Compiler', T.List['FileOrString']] = {}
     for src in sources:
         comp = get_compiler_for_source(compilers, src)
         if comp not in compsrclist:

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -22,6 +22,7 @@ modules = [
 
     # specific files
     'mesonbuild/arglist.py',
+    'mesonbuild/backend/backends.py',
     # 'mesonbuild/coredata.py',
     'mesonbuild/envconfig.py',
     'mesonbuild/interpreter/compiler.py',


### PR DESCRIPTION
My goal was to add type annotations to backend/backends.py, as it seemed like a good starting point for looking into the backend. This ended up requiring a lot of fixes for the build module as well, and revealed several issues in already typed modules, like mesonlib. I've split each change into a single patch, as this is good practice, and makes bisecting easier for regressions.