### PR TITLE
Make the flex test case work

### DIFF
--- a/test cases/frameworks/8 flex/lexer.l
+++ b/test cases/frameworks/8 flex/lexer.l
@@ -6,6 +6,8 @@ extern int yylex(void);
 extern int yyerror(); 
 %}
 
-%% 
+%option noyywrap nounput noinput
+
+%%
 ("true"|"false")    {return BOOLEAN;}
 . { yyerror(); }

--- a/test cases/frameworks/8 flex/prog.c
+++ b/test cases/frameworks/8 flex/prog.c
@@ -9,7 +9,6 @@
 extern int yyparse();
 
 int main(int argc, char **argv) {
-    /*
     int input;
     if(argc != 2) {
         printf("%s <input file>");
@@ -19,15 +18,6 @@ int main(int argc, char **argv) {
     dup2(input, STDIN_FILENO);
     close(input);
     return yyparse();
-    */
-    /* We really should test that the
-     * generated parser works with input
-     * but it froze and I don't want to waste
-     * time debugging that. For this test what
-     * we care about is that it compiles and links.
-     */
-    void* __attribute__((unused)) dummy = (void*)yyparse;
-    return 0;
 }
 
 int yywrap(void) {


### PR DESCRIPTION
This adds the noyywrap option so flex doesn't wait for more input once
we reached EOF. This also adds the nounput and noinput options to fix
compilation warnings.

We can now run the test as expected.