### PR TITLE
Disable asan memory leak checks on a Cuda test.

### DIFF
--- a/test cases/cuda/16 multistd/meson.build
+++ b/test cases/cuda/16 multistd/meson.build
@@ -1,4 +1,7 @@
-project('C++-CUDA multi-std', 'cpp', 'cuda', version : '1.0.0', default_options : ['cpp_std=c++17', 'cuda_std=c++14'])
+project('C++-CUDA multi-std', 'cpp', 'cuda',
+        version : '1.0.0',
+        default_options : ['cpp_std=c++17', 'cuda_std=c++14'])
 
 exe = executable('prog', 'main.cu')
-test('cudatest', exe)
+# The runtimes leak memory, so ignore it.
+test('cudatest', exe, env: ['ASAN_OPTIONS=detect_leaks=0'])


### PR DESCRIPTION
Should fix Arch Cuda CI failure.