### PR TITLE
Use `typed_kwargs` and `typed_pos_args` for CustomTarget

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2226,6 +2226,11 @@ class BothLibraries(SecondLevelHolder):
         raise MesonBugException(f'self._preferred_library == "{self._preferred_library}" is neither "shared" nor "static".')
 
 class CommandBase:
+
+    depend_files: T.List[File]
+    dependencies: T.List[T.Union[BuildTarget, 'CustomTarget']]
+    subproject: str
+
     def flatten_command(self, cmd):
         cmd = listify(cmd)
         final_cmd = []

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -513,22 +513,22 @@ class Target(HoldableObject):
             raise RuntimeError(f'Target type is not set for target class "{type(self).__name__}". This is a bug')
 
     def __lt__(self, other: object) -> bool:
-        if not hasattr(other, 'get_id') and not callable(other.get_id):
+        if not isinstance(other, Target):
             return NotImplemented
         return self.get_id() < other.get_id()
 
     def __le__(self, other: object) -> bool:
-        if not hasattr(other, 'get_id') and not callable(other.get_id):
+        if not isinstance(other, Target):
             return NotImplemented
         return self.get_id() <= other.get_id()
 
     def __gt__(self, other: object) -> bool:
-        if not hasattr(other, 'get_id') and not callable(other.get_id):
+        if not isinstance(other, Target):
             return NotImplemented
         return self.get_id() > other.get_id()
 
     def __ge__(self, other: object) -> bool:
-        if not hasattr(other, 'get_id') and not callable(other.get_id):
+        if not isinstance(other, Target):
             return NotImplemented
         return self.get_id() >= other.get_id()
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2231,9 +2231,10 @@ class CommandBase:
     dependencies: T.List[T.Union[BuildTarget, 'CustomTarget']]
     subproject: str
 
-    def flatten_command(self, cmd):
+    def flatten_command(self, cmd: T.Sequence[T.Union[str, File, programs.ExternalProgram, 'BuildTarget', 'CustomTarget', 'CustomTargetIndex']]) -> \
+            T.List[T.Union[str, File, BuildTarget, 'CustomTarget']]:
         cmd = listify(cmd)
-        final_cmd = []
+        final_cmd: T.List[T.Union[str, File, BuildTarget, 'CustomTarget']] = []
         for c in cmd:
             if isinstance(c, str):
                 final_cmd.append(c)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -611,8 +611,15 @@ class Target(HoldableObject):
 
     @staticmethod
     def parse_overrides(kwargs: T.Dict[str, T.Any]) -> T.Dict[OptionKey, str]:
+        opts =  kwargs.get('override_options', [])
+
+        # In this case we hav ean already parsed and ready to go dictionary
+        # provided by typed_kwargs
+        if isinstance(opts, dict):
+            return T.cast(T.Dict[OptionKey, str], opts)
+
         result: T.Dict[OptionKey, str] = {}
-        overrides = stringlistify(kwargs.get('override_options', []))
+        overrides = stringlistify(opts)
         for o in overrides:
             if '=' not in o:
                 raise InvalidArguments('Overrides must be of form "key=value"')

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2583,7 +2583,8 @@ class RunTarget(Target, CommandBase):
         return "@run"
 
 class AliasTarget(RunTarget):
-    def __init__(self, name, dependencies, subdir, subproject):
+    def __init__(self, name: str, dependencies: T.Sequence[T.Union[BuildTarget, 'CustomTarget']],
+                 subdir: str, subproject: str):
         super().__init__(name, [], dependencies, subdir, subproject)
 
     def __repr__(self):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2536,8 +2536,13 @@ class CustomTarget(Target, CommandBase):
         return len(self.outputs)
 
 class RunTarget(Target, CommandBase):
-    def __init__(self, name: str, command, dependencies,
-                 subdir: str, subproject: str, env: T.Optional['EnvironmentVariables'] = None):
+
+    def __init__(self, name: str,
+                 command: T.Sequence[T.Union[str, File, BuildTarget, 'CustomTarget', 'CustomTargetIndex', programs.ExternalProgram]],
+                 dependencies: T.Sequence[T.Union[BuildTarget, 'CustomTarget']],
+                 subdir: str,
+                 subproject: str,
+                 env: T.Optional['EnvironmentVariables'] = None):
         self.typename = 'run'
         # These don't produce output artifacts
         super().__init__(name, subdir, subproject, False, MachineChoice.BUILD)
@@ -2554,13 +2559,13 @@ class RunTarget(Target, CommandBase):
     def process_kwargs(self, kwargs):
         return self.process_kwargs_base(kwargs)
 
-    def get_dependencies(self):
+    def get_dependencies(self) -> T.List[T.Union[BuildTarget, 'CustomTarget']]:
         return self.dependencies
 
-    def get_generated_sources(self):
+    def get_generated_sources(self) -> T.List['GeneratedTypes']:
         return []
 
-    def get_sources(self):
+    def get_sources(self) -> T.List[File]:
         return []
 
     def should_install(self) -> bool:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2388,7 +2388,7 @@ class CustomTarget(Target, CommandBase):
             raise InvalidArguments("Can't both capture output and output to console")
         if 'command' not in kwargs:
             raise InvalidArguments('Missing keyword argument "command".')
-        if 'depfile' in kwargs:
+        if kwargs.get('depfile') is not None:
             depfile = kwargs['depfile']
             if not isinstance(depfile, str):
                 raise InvalidArguments('Depfile must be a string.')
@@ -2410,32 +2410,32 @@ class CustomTarget(Target, CommandBase):
                     raise InvalidArguments('"install_dir" must be specified '
                                            'when installing a target')
 
-                if isinstance(kwargs['install_dir'], list):
-                    FeatureNew.single_use('multiple install_dir for custom_target', '0.40.0', self.subproject)
-                # If an item in this list is False, the output corresponding to
-                # the list index of that item will not be installed
-                self.install_dir = typeslistify(kwargs['install_dir'], (str, bool))
-                self.install_mode = kwargs.get('install_mode', None)
-                # If only one tag is provided, assume all outputs have the same tag.
-                # Otherwise, we must have as much tags as outputs.
-                self.install_tag = typeslistify(kwargs.get('install_tag', [None]), (str, bool))
-                if len(self.install_tag) == 1:
-                    self.install_tag = self.install_tag * len(self.outputs)
-                elif len(self.install_tag) != len(self.outputs):
-                    m = f'Target {self.name!r} has {len(self.outputs)} outputs but {len(self.install_tag)} "install_tag"s were found.'
-                    raise InvalidArguments(m)
+            if isinstance(kwargs['install_dir'], list):
+                FeatureNew.single_use('multiple install_dir for custom_target', '0.40.0', self.subproject)
+            # If an item in this list is False, the output corresponding to
+            # the list index of that item will not be installed
+            self.install_dir = typeslistify(kwargs['install_dir'], (str, bool))
+            self.install_mode = kwargs.get('install_mode', None)
+            # If only one tag is provided, assume all outputs have the same tag.
+            # Otherwise, we must have as much tags as outputs.
+            self.install_tag = typeslistify(kwargs.get('install_tag', [None]), (str, bool))
+            if len(self.install_tag) == 1:
+                self.install_tag = self.install_tag * len(self.outputs)
+            elif len(self.install_tag) != len(self.outputs):
+                m = f'Target {self.name!r} has {len(self.outputs)} outputs but {len(self.install_tag)} "install_tag"s were found.'
+                raise InvalidArguments(m)
         else:
             self.install = False
             self.install_dir = [None]
             self.install_mode = None
             self.install_tag = []
-        if 'build_always' in kwargs and 'build_always_stale' in kwargs:
+        if kwargs.get('build_always') is not None and kwargs.get('build_always_stale') is not None:
             raise InvalidArguments('build_always and build_always_stale are mutually exclusive. Combine build_by_default and build_always_stale.')
-        elif 'build_always' in kwargs:
-            if 'build_by_default' not in kwargs:
+        elif kwargs.get('build_always') is not None:
+            if kwargs.get('build_by_default') is not None:
                 self.build_by_default = kwargs['build_always']
             self.build_always_stale = kwargs['build_always']
-        elif 'build_always_stale' in kwargs:
+        elif kwargs.get('build_always_stale') is not None:
             self.build_always_stale = kwargs['build_always_stale']
         if not isinstance(self.build_always_stale, bool):
             raise InvalidArguments('Argument build_always_stale must be a boolean.')

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2541,7 +2541,7 @@ class RunTarget(Target, CommandBase):
         self.absolute_paths = False
         self.env = env
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         repr_str = "<{0} {1}: {2}>"
         return repr_str.format(self.__class__.__name__, self.get_id(), self.command[0])
 
@@ -2571,7 +2571,7 @@ class RunTarget(Target, CommandBase):
         else:
             raise RuntimeError('RunTarget: self.name is neither a list nor a string. This is a bug')
 
-    def type_suffix(self):
+    def type_suffix(self) -> str:
         return "@run"
 
 class AliasTarget(RunTarget):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2556,9 +2556,6 @@ class RunTarget(Target, CommandBase):
         repr_str = "<{0} {1}: {2}>"
         return repr_str.format(self.__class__.__name__, self.get_id(), self.command[0])
 
-    def process_kwargs(self, kwargs):
-        return self.process_kwargs_base(kwargs)
-
     def get_dependencies(self) -> T.List[T.Union[BuildTarget, 'CustomTarget']]:
         return self.dependencies
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1711,8 +1711,6 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         self.add_target(name, tg)
         return tg
 
-    @permittedKwargs({'arguments', 'output', 'depends', 'depfile', 'capture',
-                      'preserve_path_from'})
     @typed_pos_args('generator', (build.Executable, ExternalProgram))
     @typed_kwargs(
         'generator',

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -50,6 +50,7 @@ from .interpreterobjects import (
     NullSubprojectInterpreter,
 )
 from .type_checking import (
+    DEPFILE_KW,
     ENV_KW,
     INSTALL_MODE_KW,
     LANGUAGE_KW,
@@ -1717,7 +1718,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         'generator',
         KwargInfo('arguments', ContainerTypeInfo(list, str, allow_empty=False), required=True, listify=True),
         KwargInfo('output', ContainerTypeInfo(list, str, allow_empty=False), required=True, listify=True),
-        KwargInfo('depfile', (str, NoneType), validator=lambda x: 'Depfile must be a plain filename with a subdirectory' if has_path_sep(x) else None),
+        DEPFILE_KW,
         KwargInfo('capture', bool, default=False, since='0.43.0'),
         KwargInfo('depends', ContainerTypeInfo(list, (build.BuildTarget, build.CustomTarget)), default=[], listify=True),
     )

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -50,6 +50,7 @@ from .interpreterobjects import (
     NullSubprojectInterpreter,
 )
 from .type_checking import (
+    COMMAND_KW,
     DEPENDS_KW,
     DEPFILE_KW,
     ENV_KW,
@@ -1669,14 +1670,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
     @typed_pos_args('run_target', str)
     @typed_kwargs(
         'run_target',
-        KwargInfo(
-            'command',
-            # TODO: should accept CustomTargetIndex as well?
-            ContainerTypeInfo(list, (str, build.BuildTarget, build.CustomTarget, ExternalProgram, mesonlib.File), allow_empty=False),
-            required=True,
-            listify=True,
-            default=[],
-        ),
+        COMMAND_KW,
         DEPENDS_KW,
         ENV_KW.evolve(since='0.57.0'),
     )

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -50,6 +50,7 @@ from .interpreterobjects import (
     NullSubprojectInterpreter,
 )
 from .type_checking import (
+    DEPENDS_KW,
     DEPFILE_KW,
     ENV_KW,
     INSTALL_MODE_KW,
@@ -1676,12 +1677,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
             listify=True,
             default=[],
         ),
-        KwargInfo(
-            'depends',
-            ContainerTypeInfo(list, (build.BuildTarget, build.CustomTarget)),
-            listify=True,
-            default=[],
-        ),
+        DEPENDS_KW,
         ENV_KW.evolve(since='0.57.0'),
     )
     def func_run_target(self, node: mparser.FunctionNode, args: T.Tuple[str],

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1664,35 +1664,36 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         self.add_target(tg.name, tg)
         return tg
 
-    @FeatureNewKwargs('run_target', '0.57.0', ['env'])
-    @permittedKwargs({'command', 'depends', 'env'})
     @typed_pos_args('run_target', str)
-    def func_run_target(self, node: mparser.FunctionNode, args: T.Tuple[str], kwargs: 'TYPE_kwargs') -> build.RunTarget:
-        if 'command' not in kwargs:
-            raise InterpreterException('Missing "command" keyword argument')
-        all_args = extract_as_list(kwargs, 'command')
-        deps = extract_as_list(kwargs, 'depends')
+    @typed_kwargs(
+        'run_target',
+        KwargInfo(
+            'command',
+            # TODO: should accept CustomTargetIndex as well?
+            ContainerTypeInfo(list, (str, build.BuildTarget, build.CustomTarget, ExternalProgram, mesonlib.File), allow_empty=False),
+            required=True,
+            listify=True,
+            default=[],
+        ),
+        KwargInfo(
+            'depends',
+            ContainerTypeInfo(list, (build.BuildTarget, build.CustomTarget)),
+            listify=True,
+            default=[],
+        ),
+        ENV_KW.evolve(since='0.57.0'),
+    )
+    def func_run_target(self, node: mparser.FunctionNode, args: T.Tuple[str],
+                        kwargs: 'kwargs.RunTarget') -> build.RunTarget:
+        all_args = kwargs['command'].copy()
 
-        cleaned_args = []
         for i in listify(all_args):
-            if not isinstance(i, (str, build.BuildTarget, build.CustomTarget, ExternalProgram, mesonlib.File)):
-                mlog.debug('Wrong type:', str(i))
-                raise InterpreterException('Invalid argument to run_target.')
             if isinstance(i, ExternalProgram) and not i.found():
                 raise InterpreterException(f'Tried to use non-existing executable {i.name!r}')
-            cleaned_args.append(i)
-        if isinstance(cleaned_args[0], str):
-            cleaned_args[0] = self.func_find_program(node, cleaned_args[0], {})
+        if isinstance(all_args[0], str):
+            all_args[0] = self.func_find_program(node, all_args[0], {})
         name = args[0]
-        if not isinstance(name, str):
-            raise InterpreterException('First argument must be a string.')
-        cleaned_deps = []
-        for d in deps:
-            if not isinstance(d, (build.BuildTarget, build.CustomTarget)):
-                raise InterpreterException('Depends items must be build targets.')
-            cleaned_deps.append(d)
-        env = self.unpack_env_kwarg(kwargs)
-        tg = build.RunTarget(name, cleaned_args, cleaned_deps, self.subdir, self.subproject, env)
+        tg = build.RunTarget(name, all_args, kwargs['depends'], self.subdir, self.subproject, kwargs['env'])
         self.add_target(name, tg)
         full_name = (self.subproject, name)
         assert full_name not in self.build.run_target_names

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1898,6 +1898,8 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
     def _get_kwarg_install_mode(self, kwargs: T.Dict[str, T.Any]) -> T.Optional[FileMode]:
         if kwargs.get('install_mode', None) is None:
             return None
+        if isinstance(kwargs['install_mode'], FileMode):
+            return kwargs['install_mode']
         install_mode: T.List[str] = []
         mode = mesonlib.typeslistify(kwargs.get('install_mode', []), (str, int))
         for m in mode:

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -88,7 +88,7 @@ class FuncGenerator(TypedDict):
 
     arguments: T.List[str]
     output: T.List[str]
-    depfile: bool
+    depfile: T.Optional[str]
     capture:  bool
     depends: T.List[T.Union[build.BuildTarget, build.CustomTarget]]
 

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -11,6 +11,7 @@ from typing_extensions import TypedDict, Literal
 from .. import build
 from .. import coredata
 from ..mesonlib import MachineChoice, File, FileMode, FileOrString
+from ..programs import ExternalProgram
 
 
 class FuncAddProjectArgs(TypedDict):
@@ -155,3 +156,9 @@ class FuncIncludeDirectories(TypedDict):
 class FuncAddLanguages(ExtractRequired):
 
     native: T.Optional[bool]
+
+class RunTarget(TypedDict):
+
+    command: T.List[T.Union[str, build.BuildTarget, build.CustomTarget, ExternalProgram, File]]
+    depends: T.List[T.Union[build.BuildTarget, build.CustomTarget]]
+    env: build.EnvironmentVariables

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -10,7 +10,7 @@ from typing_extensions import TypedDict, Literal
 
 from .. import build
 from .. import coredata
-from ..mesonlib import MachineChoice, File, FileMode, FileOrString
+from ..mesonlib import MachineChoice, File, FileMode, FileOrString, OptionKey
 from ..programs import ExternalProgram
 
 
@@ -162,3 +162,27 @@ class RunTarget(TypedDict):
     command: T.List[T.Union[str, build.BuildTarget, build.CustomTarget, ExternalProgram, File]]
     depends: T.List[T.Union[build.BuildTarget, build.CustomTarget]]
     env: build.EnvironmentVariables
+
+
+class CustomTarget(TypedDict):
+
+    build_always: bool
+    build_always_stale: bool
+    build_by_default: bool
+    capture: bool
+    command: T.List[T.Union[str, build.BuildTarget, build.CustomTarget,
+                            build.CustomTargetIndex, ExternalProgram, File]]
+    consonle: bool
+    depend_files: T.List[FileOrString]
+    depends: T.List[T.Union[build.BuildTarget, build.CustomTarget]]
+    depfile: T.Optional[str]
+    env: build.EnvironmentVariables
+    feed: bool
+    input: T.List[T.Union[str, build.BuildTarget, build.CustomTarget, build.CustomTargetIndex,
+                          build.ExtractedObjects, build.GeneratedList, ExternalProgram, File]]
+    install: bool
+    install_dir: T.List[T.Union[str, bool]]
+    install_mode: FileMode
+    install_tag: T.List[T.Union[str, bool]]
+    output: T.List[str]
+    override_options: T.Dict[OptionKey, str]

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -11,6 +11,7 @@ from ..coredata import UserFeatureOption
 from ..interpreterbase import TYPE_var
 from ..interpreterbase.decorators import KwargInfo, ContainerTypeInfo
 from ..mesonlib import File, FileMode, MachineChoice, listify, has_path_sep
+from ..programs import ExternalProgram
 
 # Helper definition for type checks that are `Optional[T]`
 NoneType: T.Type[None] = type(None)
@@ -194,6 +195,15 @@ DEPENDS_KW: KwargInfo[T.List[T.Union[BuildTarget, CustomTarget]]] = KwargInfo(
 DEPEND_FILES_KW: KwargInfo[T.List[T.Union[str, File]]] = KwargInfo(
     'depend_files',
     ContainerTypeInfo(list, (File, str)),
+    listify=True,
+    default=[],
+)
+
+COMMAND_KW: KwargInfo[T.List[T.Union[BuildTarget, CustomTarget, ExternalProgram, File]]] = KwargInfo(
+    'command',
+    # TODO: should accept CustomTargetIndex as well?
+    ContainerTypeInfo(list, (str, BuildTarget, CustomTarget, ExternalProgram, File), allow_empty=False),
+    required=True,
     listify=True,
     default=[],
 )

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -6,7 +6,7 @@
 import typing as T
 
 from .. import compilers
-from ..build import EnvironmentVariables
+from ..build import EnvironmentVariables, CustomTarget, BuildTarget
 from ..coredata import UserFeatureOption
 from ..interpreterbase import TYPE_var
 from ..interpreterbase.decorators import KwargInfo, ContainerTypeInfo
@@ -182,4 +182,11 @@ DEPFILE_KW: KwargInfo[T.Optional[str]] = KwargInfo(
     'depfile',
     (str, type(None)),
     validator=lambda x: 'Depfile must be a plain filename with a subdirectory' if has_path_sep(x) else None
+)
+
+DEPENDS_KW: KwargInfo[T.List[T.Union[BuildTarget, CustomTarget]]] = KwargInfo(
+    'depends',
+    ContainerTypeInfo(list, (BuildTarget, CustomTarget)),
+    listify=True,
+    default=[],
 )

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -10,7 +10,7 @@ from ..build import EnvironmentVariables
 from ..coredata import UserFeatureOption
 from ..interpreterbase import TYPE_var
 from ..interpreterbase.decorators import KwargInfo, ContainerTypeInfo
-from ..mesonlib import FileMode, MachineChoice, listify
+from ..mesonlib import FileMode, MachineChoice, listify, has_path_sep
 
 # Helper definition for type checks that are `Optional[T]`
 NoneType: T.Type[None] = type(None)
@@ -176,4 +176,10 @@ ENV_KW: KwargInfo[T.Union[EnvironmentVariables, T.List, T.Dict, str, None]] = Kw
     (EnvironmentVariables, list, dict, str, NoneType),
     validator=_env_validator,
     convertor=_env_convertor,
+)
+
+DEPFILE_KW = KwargInfo(
+    'depfile',
+    str,
+    validator=lambda x: 'Depfile must be a plain filename with a subdirectory' if has_path_sep(x) else None
 )

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -10,7 +10,7 @@ from ..build import EnvironmentVariables, CustomTarget, BuildTarget
 from ..coredata import UserFeatureOption
 from ..interpreterbase import TYPE_var
 from ..interpreterbase.decorators import KwargInfo, ContainerTypeInfo
-from ..mesonlib import FileMode, MachineChoice, listify, has_path_sep
+from ..mesonlib import File, FileMode, MachineChoice, listify, has_path_sep
 
 # Helper definition for type checks that are `Optional[T]`
 NoneType: T.Type[None] = type(None)
@@ -187,6 +187,13 @@ DEPFILE_KW: KwargInfo[T.Optional[str]] = KwargInfo(
 DEPENDS_KW: KwargInfo[T.List[T.Union[BuildTarget, CustomTarget]]] = KwargInfo(
     'depends',
     ContainerTypeInfo(list, (BuildTarget, CustomTarget)),
+    listify=True,
+    default=[],
+)
+
+DEPEND_FILES_KW: KwargInfo[T.List[T.Union[str, File]]] = KwargInfo(
+    'depend_files',
+    ContainerTypeInfo(list, (File, str)),
     listify=True,
     default=[],
 )

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -6,11 +6,11 @@
 import typing as T
 
 from .. import compilers
-from ..build import EnvironmentVariables, CustomTarget, BuildTarget
+from ..build import EnvironmentVariables, CustomTarget, BuildTarget, CustomTargetIndex
 from ..coredata import UserFeatureOption
 from ..interpreterbase import TYPE_var
 from ..interpreterbase.decorators import KwargInfo, ContainerTypeInfo
-from ..mesonlib import File, FileMode, MachineChoice, listify, has_path_sep
+from ..mesonlib import File, FileMode, MachineChoice, listify, has_path_sep, OptionKey
 from ..programs import ExternalProgram
 
 # Helper definition for type checks that are `Optional[T]`
@@ -158,13 +158,21 @@ def _env_validator(value: T.Union[EnvironmentVariables, T.List['TYPE_var'], T.Di
     return None
 
 
-def _env_convertor(value: T.Union[EnvironmentVariables, T.List[str], T.Dict[str, str], str, None]) -> EnvironmentVariables:
-    def splitter(input: str) -> T.Tuple[str, str]:
-        a, b = input.split('=', 1)
-        return (a.strip(), b.strip())
 
-    if isinstance(value, (str, list)):
-        return EnvironmentVariables(dict(splitter(v) for v in listify(value)))
+def split_equal_string(input: str) -> T.Tuple[str, str]:
+    """Split a string in the form `x=y`
+
+    This assumes that the string has already been validated to split properly.
+    """
+    a, b = input.split('=', 1)
+    return (a, b)
+
+
+def _env_convertor(value: T.Union[EnvironmentVariables, T.List[str], T.List[T.List[str]], T.Dict[str, str], str, None]) -> EnvironmentVariables:
+    if isinstance(value, str):
+        return EnvironmentVariables(dict([split_equal_string(value)]))
+    elif isinstance(value, list):
+        return EnvironmentVariables(dict(split_equal_string(v) for v in listify(value)))
     elif isinstance(value, dict):
         return EnvironmentVariables(value)
     elif value is None:
@@ -199,11 +207,29 @@ DEPEND_FILES_KW: KwargInfo[T.List[T.Union[str, File]]] = KwargInfo(
     default=[],
 )
 
-COMMAND_KW: KwargInfo[T.List[T.Union[BuildTarget, CustomTarget, ExternalProgram, File]]] = KwargInfo(
+COMMAND_KW: KwargInfo[T.List[T.Union[str, BuildTarget, CustomTarget, CustomTargetIndex, ExternalProgram, File]]] = KwargInfo(
     'command',
     # TODO: should accept CustomTargetIndex as well?
-    ContainerTypeInfo(list, (str, BuildTarget, CustomTarget, ExternalProgram, File), allow_empty=False),
+    ContainerTypeInfo(list, (str, BuildTarget, CustomTarget, CustomTargetIndex, ExternalProgram, File), allow_empty=False),
     required=True,
     listify=True,
     default=[],
+)
+
+def _override_options_convertor(raw: T.List[str]) -> T.Dict[OptionKey, str]:
+    output: T.Dict[OptionKey, str] = {}
+    for each in raw:
+        k, v = split_equal_string(each)
+        output[OptionKey.from_string(k)] = v
+    return output
+
+
+OVERRIDE_OPTIONS_KW: KwargInfo[T.List[str]] = KwargInfo(
+    'override_options',
+    ContainerTypeInfo(list, str),
+    listify=True,
+    default=[],
+    # Reusing the env validator is a littl overkill, but nicer than duplicating the code
+    validator=_env_validator,
+    convertor=_override_options_convertor,
 )

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -178,8 +178,8 @@ ENV_KW: KwargInfo[T.Union[EnvironmentVariables, T.List, T.Dict, str, None]] = Kw
     convertor=_env_convertor,
 )
 
-DEPFILE_KW = KwargInfo(
+DEPFILE_KW: KwargInfo[T.Optional[str]] = KwargInfo(
     'depfile',
-    str,
+    (str, type(None)),
     validator=lambda x: 'Depfile must be a plain filename with a subdirectory' if has_path_sep(x) else None
 )

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -373,7 +373,7 @@ class KwargInfo(T.Generic[_T]):
                  since_values: T.Optional[T.Dict[str, str]] = None,
                  deprecated: T.Optional[str] = None,
                  deprecated_values: T.Optional[T.Dict[str, str]] = None,
-                 validator: T.Optional[T.Callable[[_T], T.Optional[str]]] = None,
+                 validator: T.Optional[T.Callable[[T.Any], T.Optional[str]]] = None,
                  convertor: T.Optional[T.Callable[[_T], object]] = None,
                  not_set_warning: T.Optional[str] = None):
         self.name = name

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -381,7 +381,8 @@ class PkgConfigModule(ExtensionModule):
                         if uninstalled:
                             install_dir = os.path.dirname(state.backend.get_target_filename_abs(l))
                         else:
-                            install_dir = l.get_custom_install_dir()[0]
+                            _i = l.get_custom_install_dir()
+                            install_dir = _i[0] if _i else None
                         if install_dir is False:
                             continue
                         is_custom_target = isinstance(l, (build.CustomTarget, build.CustomTargetIndex))
@@ -471,9 +472,9 @@ class PkgConfigModule(ExtensionModule):
                 raise mesonlib.MesonException('Pkgconfig_gen first positional argument must be a library object')
             default_name = mainlib.name
             default_description = state.project_name + ': ' + mainlib.name
-            install_dir = mainlib.get_custom_install_dir()[0]
-            if isinstance(install_dir, str):
-                default_install_dir = os.path.join(install_dir, 'pkgconfig')
+            install_dir = mainlib.get_custom_install_dir()
+            if install_dir and isinstance(install_dir[0], str):
+                default_install_dir = os.path.join(install_dir[0], 'pkgconfig')
         elif len(args) > 1:
             raise mesonlib.MesonException('Too many positional arguments passed to Pkgconfig_gen.')
 

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -556,14 +556,14 @@ class QtBaseModule(ExtensionModule):
             else:
                 outdir = state.subdir
             cmd = [self.tools['lrelease'], '@INPUT@', '-qm', '@OUTPUT@']
-            lrelease_kwargs = {'output': '@BASENAME@.qm',
-                               'input': ts,
-                               'install': kwargs['install'],
-                               'install_tag': 'i18n',
-                               'build_by_default': kwargs['build_by_default'],
-                               'command': cmd}
-            if install_dir is not None:
-                lrelease_kwargs['install_dir'] = install_dir
+            lrelease_kwargs: T.Dict[str, T.Any] = {
+                'output': '@BASENAME@.qm',
+                'input': ts,
+                'install': kwargs['install'],
+                'install_dir': install_dir or [],
+                'install_tag': 'i18n',
+                'build_by_default': kwargs['build_by_default'],
+                'command': cmd}
             lrelease_target = build.CustomTarget(f'qt{self.qt_version}-compile-{ts}', outdir, state.subproject, lrelease_kwargs)
             translations.append(lrelease_target)
         if qresource:

--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -71,7 +71,7 @@ class ExternalProject(NewExtensionModule):
 
         self.targets = self._create_targets()
 
-    def _configure(self, state: ModuleState):
+    def _configure(self, state: ModuleState) -> None:
         if self.configure_command == 'waf':
             FeatureNew('Waf external project', '0.60.0').use(self.subproject)
             waf = state.find_program('waf')


### PR DESCRIPTION
This is a rather lengthy series on it's own, but it's built on top of #9090. I tried to rebase it directly on master, and gave up.

This was originally suppsoed to be part of a larger series to fix the layering violations between the build and interpreter layers, but that turns out to be a *lot* of work, for a lot of reasons. To simplify things, and because this fixes an actual bug, I split some of the work off into it's own series.

Fixes #9096 