### PR TITLE
Make warning color readable on a white background

### DIFF
--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -166,7 +166,7 @@ def green(text: str) -> AnsiDecorator:
     return AnsiDecorator(text, "\033[1;32m")
 
 def yellow(text: str) -> AnsiDecorator:
-    return AnsiDecorator(text, "\033[1;33m")
+    return AnsiDecorator(text, "\033[33m")
 
 def blue(text: str) -> AnsiDecorator:
     return AnsiDecorator(text, "\033[1;34m")


### PR DESCRIPTION
Use standard yellow instead of bright yellow. Standard yellow is readable on black, white, light yellow and solarized light backgrounds.

Fixes: #2370