### PR TITLE
tests: make detecting broken compilers always run without tracebacks

### DIFF
--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1008,7 +1008,7 @@ def has_broken_rustc() -> bool:
 
 def has_broken_compiler_combination() -> bool:
     # Rust and vs2017 do not work together. But only with 32 bits.
-    if os.environ['VisualStudioVersion'] == '15.0' and os.environ['Platform'] == 'x86':
+    if os.environ.get('VisualStudioVersion') == '15.0' and os.environ.get('Platform') == 'x86':
         return True
     # Clang-cl also fails with Rust.
     if shutil.which('cl') is None and shutil.which('clang-cl'):


### PR DESCRIPTION
Fixes regression in commit 75688240cfca7eed08c2754daa784c9bd1a70a73. Even though this function is *currently* only invoked on Windows, these environment variables may not actually exist -- and apparently don't in at least the "UnusedMissingReturn / windows" test run, which... did not get triggered by that commit, since it only edited the testsuite runner, not any test cases. \o/