### PR TITLE
Revert "Disable vs2017 + 32bit Rust combo as it is broken."

### DIFF
--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1007,10 +1007,7 @@ def has_broken_rustc() -> bool:
     return pc.returncode != 0
 
 def has_broken_compiler_combination() -> bool:
-    # Rust and vs2017 do not work together. But only with 32 bits.
-    if os.environ.get('VisualStudioVersion') == '15.0' and os.environ.get('Platform') == 'x86':
-        return True
-    # Clang-cl also fails with Rust.
+    # Clang-cl fails with Rust on the CI
     if shutil.which('cl') is None and shutil.which('clang-cl'):
         return True
     return False


### PR DESCRIPTION
This reverts commit 75688240cfca7eed08c2754daa784c9bd1a70a73

Should've been fixed by c95bffb295dd8ae12dd37c9a6c33372a20cf9a68. Let's see if it was.