### PR TITLE
Revert "Disable Rust + clangcl." and fix the actual bugs it was demonstrating

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1694,9 +1694,9 @@ class NinjaBackend(backends.Backend):
                 args += ['--extern', '{}={}'.format(d.name, os.path.join(d.subdir, d.filename))]
             elif d.typename == 'static library':
                 # Rustc doesn't follow Meson's convention that static libraries
-                # are called .a, and implementation libraries are .lib, so we
-                # have to manually handle that.
-                if rustc.linker.id == 'link':
+                # are called .a, and import libraries are .lib, so we have to
+                # manually handle that.
+                if rustc.linker.id in {'link', 'lld-link'}:
                     args += ['-C', f'link-arg={self.get_target_filename_for_linking(d)}']
                 else:
                     args += ['-l', f'static={d.name}']

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1006,12 +1006,6 @@ def has_broken_rustc() -> bool:
     mesonlib.windows_proof_rmtree(dirname.as_posix())
     return pc.returncode != 0
 
-def has_broken_compiler_combination() -> bool:
-    # Clang-cl fails with Rust on the CI
-    if shutil.which('cl') is None and shutil.which('clang-cl'):
-        return True
-    return False
-
 def should_skip_rust(backend: Backend) -> bool:
     if not shutil.which('rustc'):
         return True
@@ -1019,8 +1013,6 @@ def should_skip_rust(backend: Backend) -> bool:
         return True
     if mesonlib.is_windows():
         if has_broken_rustc():
-            return True
-        if has_broken_compiler_combination():
             return True
     return False
 

--- a/test cases/rust/5 polyglot static/meson.build
+++ b/test cases/rust/5 polyglot static/meson.build
@@ -5,7 +5,7 @@ deps = [
   dependency('threads'),
 ]
 
-extra_winlibs = meson.get_compiler('c').get_id() == 'msvc' ? ['userenv.lib', 'ws2_32.lib'] : []
+extra_winlibs = meson.get_compiler('c').get_id() in ['msvc', 'clang-cl'] ? ['userenv.lib', 'ws2_32.lib'] : []
 
 l = static_library('stuff', 'stuff.rs', rust_crate_type : 'staticlib', install : true)
 e = executable('prog', 'prog.c',


### PR DESCRIPTION
* test cases/rust: clang-cl also needs extra_winlibs
* rust targets: lld-link is the same as link for static libs