### PR TITLE
make python extension_module install to the documented location

### DIFF
--- a/data/test.schema.json
+++ b/data/test.schema.json
@@ -21,11 +21,14 @@
             "type": "string",
             "enum": [
               "file",
+              "python_file",
               "dir",
               "exe",
               "shared_lib",
+              "python_lib",
               "pdb",
               "implib",
+              "py_implib",
               "implibempty",
               "expr"
             ]

--- a/docs/markdown/Contributing.md
+++ b/docs/markdown/Contributing.md
@@ -264,15 +264,18 @@ current platform. The following values are currently supported:
 | type          | Description                                                                                             |
 | ------------- | ------------------------------------------------------------------------------------------------------- |
 | `file`        | No postprocessing, just use the provided path                                                           |
+| `python_file` | Use the provided path while replacing the python directory.                                             |
 | `dir`         | To include all files inside the directory (for generated docs, etc). The path must be a valid directory |
 | `exe`         | For executables. On Windows the `.exe` suffix is added to the path in `file`                            |
 | `shared_lib`  | For shared libraries, always written as `name`. The appropriate suffix and prefix are added by platform |
+| `python_lib`  | For python libraries, while replacing the python directory. The appropriate suffix is added by platform |
 | `pdb`         | For Windows PDB files. PDB entries are ignored on non Windows platforms                                 |
 | `implib`      | For Windows import libraries. These entries are ignored on non Windows platforms                        |
+| `py_implib`   | For Windows import libraries. These entries are ignored on non Windows platforms                        |
 | `implibempty` | Like `implib`, but no symbols are exported in the library                                               |
 | `expr`        | `file` is an expression. This type should be avoided and removed if possible                            |
 
-Except for the `file` and `expr` types, all paths should be provided *without* a suffix.
+Except for the `file`, `python_file` and `expr` types, all paths should be provided *without* a suffix.
 
 | Argument   | Applies to                 | Description                                                                   |
 | -----------|----------------------------|-------------------------------------------------------------------------------|
@@ -283,6 +286,11 @@ The `shared_lib` and `pdb` types takes an optional additional
 parameter, `version`, this is us a string in `X.Y.Z` format that will
 be applied to the library. Each version to be tested must have a
 single version. The harness will apply this correctly per platform:
+
+The `python_file`, `python_lib`, and `py_implib` types have basic support for configuring the string with the `@<VAR>@` syntax:
+
+- `@PYTHON_PLATLIB@`: python `get_install_dir` directory relative to prefix
+- `@PYTHON_PURELIB@`: python `get_install_dir(pure: true)` directory relative to prefix
 
 `pdb` takes an optional `language` argument. This determines which
 compiler/linker should generate the pdb file. Because it's possible to

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -402,9 +402,9 @@ class PythonInstallation(ExternalProgramHolder):
         suffix = self.variables.get('EXT_SUFFIX') or self.variables.get('SO') or self.variables.get('.so')
 
         # msys2's python3 has "-cpython-36m.dll", we have to be clever
-        split = suffix.rsplit('.', 1)
-        suffix = split.pop(-1)
-        args[0] += ''.join(s for s in split)
+        # FIXME: explain what the specific cleverness is here
+        split, suffix = suffix.rsplit('.', 1)
+        args[0] += split
 
         kwargs['name_prefix'] = ''
         kwargs['name_suffix'] = suffix

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -409,10 +409,10 @@ class PythonInstallation(ExternalProgramHolder):
 
     @permittedKwargs(mod_kwargs)
     def extension_module_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> 'SharedModule':
-        if 'subdir' in kwargs and 'install_dir' in kwargs:
-            raise InvalidArguments('"subdir" and "install_dir" are mutually exclusive')
-
-        if 'subdir' in kwargs:
+        if 'install_dir' in kwargs:
+            if 'subdir' in kwargs:
+                raise InvalidArguments('"subdir" and "install_dir" are mutually exclusive')
+        else:
             subdir = kwargs.pop('subdir', '')
             if not isinstance(subdir, str):
                 raise InvalidArguments('"subdir" argument must be a string.')

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -316,7 +316,7 @@ class PythonExternalProgram(ExternalProgram):
         if ext_prog is None:
             super().__init__(name, command=command, silent=True)
         else:
-            self.name = ext_prog.name
+            self.name = name
             self.command = ext_prog.command
             self.path = ext_prog.path
 
@@ -567,6 +567,7 @@ class PythonModule(ExtensionModule):
         # $PATH, or that uses a wrapper of some kind.
         np: T.List[str] = state.environment.lookup_binary_entry(MachineChoice.HOST, 'python') or []
         fallback = args[0]
+        display_name = fallback or 'python'
         if not np and fallback is not None:
             np = [fallback]
         name_or_path = np[0] if np else None
@@ -578,8 +579,8 @@ class PythonModule(ExtensionModule):
         if not name_or_path:
             python = PythonExternalProgram('python3', mesonlib.python_command)
         else:
-            tmp_python = ExternalProgram.from_entry('python3', name_or_path)
-            python = PythonExternalProgram('python3', ext_prog=tmp_python)
+            tmp_python = ExternalProgram.from_entry(display_name, name_or_path)
+            python = PythonExternalProgram(display_name, ext_prog=tmp_python)
 
             if not python.found() and mesonlib.is_windows():
                 pythonpath = self._get_win_pythonpath(name_or_path)

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -52,6 +52,7 @@ from mesonbuild.mesonlib import MachineChoice, Popen_safe, TemporaryDirectoryWin
 from mesonbuild.mlog import blue, bold, cyan, green, red, yellow, normal_green
 from mesonbuild.coredata import backendlist, version as meson_version
 from mesonbuild.mesonmain import setup_vsenv
+from mesonbuild.modules.python import PythonExternalProgram
 from run_tests import get_fake_options, run_configure, get_meson_script
 from run_tests import get_backend_commands, get_backend_args_for_dir, Backend
 from run_tests import ensure_backend_detects_changes
@@ -62,6 +63,7 @@ if T.TYPE_CHECKING:
     from mesonbuild.environment import Environment
     from mesonbuild._typing import Protocol
     from concurrent.futures import Future
+    from mesonbuild.modules.python import PythonIntrospectionDict
 
     class CompilerArgumentType(Protocol):
         cross_file: str
@@ -122,6 +124,9 @@ class TestResult(BaseException):
     def fail(self, msg: str) -> None:
         self.msg = msg
 
+python = PythonExternalProgram(sys.executable)
+python.sanity()
+
 class InstalledFile:
     def __init__(self, raw: T.Dict[str, str]):
         self.path = raw['file']
@@ -143,6 +148,9 @@ class InstalledFile:
                 (env.machines.host.is_windows() and compiler in {'pgi', 'dmd', 'ldc'})):
             canonical_compiler = 'msvc'
 
+        python_paths = python.info['install_paths']
+        python_suffix = python.info['suffix']
+
         has_pdb = False
         if self.language in {'c', 'cpp'}:
             has_pdb = canonical_compiler == 'msvc'
@@ -161,6 +169,15 @@ class InstalledFile:
             return None
 
         # Handle the different types
+        if self.typ in {'py_implib', 'python_lib', 'python_file'}:
+            val = p.as_posix()
+            val = val.replace('@PYTHON_PLATLIB@', python_paths['platlib'])
+            val = val.replace('@PYTHON_PURELIB@', python_paths['purelib'])
+            p = Path(val)
+            if self.typ == 'python_file':
+                return p
+            if self.typ == 'python_lib':
+                return p.with_suffix(python_suffix)
         if self.typ in ['file', 'dir']:
             return p
         elif self.typ == 'shared_lib':
@@ -195,13 +212,15 @@ class InstalledFile:
             if self.version:
                 p = p.with_name('{}-{}'.format(p.name, self.version[0]))
             return p.with_suffix('.pdb') if has_pdb else None
-        elif self.typ == 'implib' or self.typ == 'implibempty':
+        elif self.typ in {'implib', 'implibempty', 'py_implib'}:
             if env.machines.host.is_windows() and canonical_compiler == 'msvc':
                 # only MSVC doesn't generate empty implibs
                 if self.typ == 'implibempty' and compiler == 'msvc':
                     return None
                 return p.parent / (re.sub(r'^lib', '', p.name) + '.lib')
             elif env.machines.host.is_windows() or env.machines.host.is_cygwin():
+                if self.typ == 'py_implib':
+                    p = p.with_suffix(python_suffix)
                 return p.with_suffix('.dll.a')
             else:
                 return None

--- a/test cases/python/2 extmodule/blaster.py.in
+++ b/test cases/python/2 extmodule/blaster.py.in
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import tachyon
+import @tachyon_module@ as tachyon
 
 result = tachyon.phaserize('shoot')
 

--- a/test cases/python/2 extmodule/ext/meson.build
+++ b/test cases/python/2 extmodule/ext/meson.build
@@ -1,6 +1,10 @@
 pylib = py.extension_module('tachyon',
   'tachyon_module.c',
   dependencies : py_dep,
+  c_args: '-DMESON_MODULENAME="tachyon"',
+  install: true,
 )
 
+subdir('nested')
+subdir('wrongdir')
 pypathdir = meson.current_build_dir()

--- a/test cases/python/2 extmodule/ext/nested/meson.build
+++ b/test cases/python/2 extmodule/ext/nested/meson.build
@@ -1,0 +1,16 @@
+py.extension_module('tachyon',
+  '../tachyon_module.c',
+  dependencies : py_dep,
+  c_args: '-DMESON_MODULENAME="nested.tachyon"',
+  install: true,
+  subdir: 'nested'
+)
+py.install_sources(
+  configure_file(
+    input: '../../blaster.py.in',
+    output: 'blaster.py',
+    configuration: {'tachyon_module': 'nested.tachyon'}
+  ),
+  pure: false,
+  subdir: 'nested',
+)

--- a/test cases/python/2 extmodule/ext/tachyon_module.c
+++ b/test cases/python/2 extmodule/ext/tachyon_module.c
@@ -38,7 +38,7 @@ static PyMethodDef TachyonMethods[] = {
 
 static struct PyModuleDef tachyonmodule = {
    PyModuleDef_HEAD_INIT,
-   "tachyon",
+   MESON_MODULENAME,
    NULL,
    -1,
    TachyonMethods

--- a/test cases/python/2 extmodule/ext/wrongdir/meson.build
+++ b/test cases/python/2 extmodule/ext/wrongdir/meson.build
@@ -1,0 +1,7 @@
+py.extension_module('tachyon',
+  '../tachyon_module.c',
+  dependencies : py_dep,
+  c_args: '-DMESON_MODULENAME="tachyon"',
+  install: true,
+  install_dir: get_option('libdir')
+)

--- a/test cases/python/2 extmodule/meson.build
+++ b/test cases/python/2 extmodule/meson.build
@@ -18,11 +18,19 @@ endif
 
 subdir('ext')
 
+blaster = configure_file(
+  input: 'blaster.py.in',
+  output: 'blaster.py',
+  configuration: {'tachyon_module': 'tachyon'}
+)
+
 test('extmod',
   py,
-  args : files('blaster.py'),
+  args : blaster,
   env : ['PYTHONPATH=' + pypathdir])
 
+py.install_sources(blaster, pure: false)
+py.install_sources(blaster, subdir: 'pure')
 
 py3_pkg_dep = dependency('python3', method: 'pkg-config', required : false)
 if py3_pkg_dep.found()

--- a/test cases/python/2 extmodule/test.json
+++ b/test cases/python/2 extmodule/test.json
@@ -1,0 +1,13 @@
+{
+  "installed": [
+    { "type": "python_file", "file": "usr/@PYTHON_PLATLIB@/blaster.py" },
+    { "type": "python_lib",  "file": "usr/@PYTHON_PLATLIB@/tachyon" },
+    { "type": "py_implib",   "file": "usr/@PYTHON_PLATLIB@/tachyon" },
+    { "type": "python_file", "file": "usr/@PYTHON_PURELIB@/pure/blaster.py" },
+    { "type": "python_file", "file": "usr/@PYTHON_PLATLIB@/nested/blaster.py" },
+    { "type": "python_lib",  "file": "usr/@PYTHON_PLATLIB@/nested/tachyon" },
+    { "type": "py_implib",   "file": "usr/@PYTHON_PLATLIB@/nested/tachyon" },
+    { "type": "python_lib",  "file": "usr/lib/tachyon" },
+    { "type": "py_implib",   "file": "usr/lib/tachyon" }
+  ]
+}


### PR DESCRIPTION
Currently it installs to libdir instead.

While I am at it, I had to extend the testsuite to support configuring via test.json, if a file is a python file and needs to be configured with python-specific path expansions.

Fixes #6331