### PR TITLE
Implemented some missing operation for the NAG Fortran Compiler.

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -34,6 +34,7 @@ from ..linkers import (
     C2000Linker,
     C2000DynamicLinker,
     DLinker,
+    NAGDynamicLinker,
     NvidiaHPC_DynamicLinker,
     PGIDynamicLinker,
     PGIStaticLinker,
@@ -774,9 +775,14 @@ def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> C
                     exe_wrap, full_version=full_version, linker=linker)
 
             if 'NAG Fortran' in err:
-                linker = guess_nix_linker(env,
-                    compiler, NAGFortranCompiler, for_machine)
-                return NAGFortranCompiler(
+                full_version = err.split('\n', 1)[0]
+                version = full_version.split()[-1]
+                cls = NAGFortranCompiler
+                env.coredata.add_lang_args(cls.language, cls, for_machine, env)
+                linker = NAGDynamicLinker(
+                    compiler, for_machine, cls.LINKER_PREFIX, [],
+                    version=version)
+                return cls(
                     compiler, version, for_machine, is_cross, info,
                     exe_wrap, full_version=full_version, linker=linker)
 

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -494,6 +494,7 @@ class NAGFortranCompiler(FortranCompiler):
                                  is_cross, info, exe_wrapper, linker=linker,
                                  full_version=full_version)
         self.id = 'nagfor'
+        # Warnings are on by default; -w disables (by category):
         self.warn_args = {
             '0': ['-w=all'],
             '1': [],

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -494,12 +494,28 @@ class NAGFortranCompiler(FortranCompiler):
                                  is_cross, info, exe_wrapper, linker=linker,
                                  full_version=full_version)
         self.id = 'nagfor'
+        self.warn_args = {
+            '0': ['-w=all'],
+            '1': [],
+            '2': [],
+            '3': [],
+        }
 
-    def get_warn_args(self, level: str) -> T.List[str]:
-        return []
+    def get_always_args(self) -> T.List[str]:
+        return self.get_nagfor_quiet(self.version)
 
     def get_module_outdir_args(self, path: str) -> T.List[str]:
         return ['-mdir', path]
+
+    @staticmethod
+    def get_nagfor_quiet(version: str) -> T.List[str]:
+        return ['-quiet'] if version_compare(version, '>=7100') else []
+
+    def get_pic_args(self) -> T.List[str]:
+        return ['-PIC']
+
+    def get_std_exe_link_args(self) -> T.List[str]:
+        return self.get_always_args()
 
     def openmp_flags(self) -> T.List[str]:
         return ['-openmp']

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -515,6 +515,9 @@ class NAGFortranCompiler(FortranCompiler):
     def get_pic_args(self) -> T.List[str]:
         return ['-PIC']
 
+    def get_preprocess_only_args(self) -> T.List[str]:
+        return ['-fpp']
+
     def get_std_exe_link_args(self) -> T.List[str]:
         return self.get_always_args()
 

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -78,6 +78,12 @@ class OpenMPDependency(SystemDependency):
         language = kwargs.get('language')
         super().__init__('openmp', environment, kwargs, language=language)
         self.is_found = False
+        if self.clib_compiler.get_id() == 'nagfor':
+            # No macro defined for OpenMP, but OpenMP 3.1 is supported.
+            self.version = '3.1'
+            self.is_found = True
+            self.compile_args = self.link_args = self.clib_compiler.openmp_flags()
+            return
         if self.clib_compiler.get_id() == 'pgi':
             # through at least PGI 19.4, there is no macro defined for OpenMP, but OpenMP 3.1 is supported.
             self.version = '3.1'

--- a/mesonbuild/linkers/__init__.py
+++ b/mesonbuild/linkers/__init__.py
@@ -53,6 +53,7 @@ from .linkers import (
     QualcommLLVMDynamicLinker,
     PGIDynamicLinker,
     NvidiaHPC_DynamicLinker,
+    NAGDynamicLinker,
 
     VisualStudioLikeLinkerMixin,
     MSVCDynamicLinker,
@@ -110,6 +111,7 @@ __all__ = [
     'QualcommLLVMDynamicLinker',
     'PGIDynamicLinker',
     'NvidiaHPC_DynamicLinker',
+    'NAGDynamicLinker',
 
     'VisualStudioLikeLinkerMixin',
     'MSVCDynamicLinker',

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1045,6 +1045,36 @@ class QualcommLLVMDynamicLinker(LLVMDynamicLinker):
     id = 'ld.qcld'
 
 
+class NAGDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
+
+    """NAG Fortran linker, ld via gcc indirection."""
+
+    id = 'nag'
+
+    def build_rpath_args(self, env: 'Environment', build_dir: str, from_dir: str,
+                         rpath_paths: str, build_rpath: str,
+                         install_rpath: str) -> T.Tuple[T.List[str], T.Set[bytes]]:
+        if not rpath_paths and not install_rpath and not build_rpath:
+            return ([], set())
+        args = []
+        origin_placeholder = '$ORIGIN'
+        processed_rpaths = prepare_rpaths(rpath_paths, build_dir, from_dir)
+        all_paths = mesonlib.OrderedSet([os.path.join(origin_placeholder, p) for p in processed_rpaths])
+        if build_rpath != '':
+            all_paths.add(build_rpath)
+        for rp in all_paths:
+            args.extend(self._apply_prefix('-Wl,-Wl,,-rpath,,' + rp))
+
+        return (args, set())
+
+    def get_allow_undefined_args(self) -> T.List[str]:
+        return []
+
+    def get_std_shared_lib_args(self) -> T.List[str]:
+        from ..compilers import NAGFortranCompiler
+        return NAGFortranCompiler.get_nagfor_quiet(self.version) + ['-Wl,-shared']
+
+
 class PGIDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
     """PGI linker."""

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -1047,7 +1047,14 @@ class QualcommLLVMDynamicLinker(LLVMDynamicLinker):
 
 class NAGDynamicLinker(PosixDynamicLinkerMixin, DynamicLinker):
 
-    """NAG Fortran linker, ld via gcc indirection."""
+    """NAG Fortran linker, ld via gcc indirection.
+
+    Using nagfor -Wl,foo passes option foo to a backend gcc invocation.
+    (This linking gathers the correct objects needed from the nagfor runtime
+    system.)
+    To pass gcc -Wl,foo options (i.e., to ld) one must apply indirection
+    again: nagfor -Wl,-Wl,,foo
+    """
 
     id = 'nag'
 

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -1050,6 +1050,7 @@ def detect_tests_to_run(only: T.Dict[str, T.List[str]], use_tmp: bool) -> T.List
     skip_fortran = not(shutil.which('gfortran') or
                        shutil.which('flang') or
                        shutil.which('pgfortran') or
+                       shutil.which('nagfor') or
                        shutil.which('ifort'))
 
     class TestCategory:

--- a/test cases/fortran/12 submodule/child.f90
+++ b/test cases/fortran/12 submodule/child.f90
@@ -1,4 +1,4 @@
-submodule (parent) parent
+submodule (parent) child
 
 contains
 
@@ -10,4 +10,4 @@ module procedure good
 print *, 'Good!'
 end procedure good
 
-end submodule parent
+end submodule child


### PR DESCRIPTION
Not sure whether you need a specific test case with this (since it's a proprietary compiler); here's a shell script I used for testing:

```sh
#!/bin/sh
set -eux

pdir=nagfor_proj
bdir=build

export FC=nagfor

mkdir -p "${pdir}"
cd "${pdir}"

main_file="prog.f90"
cat <<EOF > "${main_file}"
Program p
  Interface
    Function f(i)
      Integer, Intent (In) :: i
      Integer :: f
    End Function
  End Interface
  If (f(11)/=53) Stop 'FAIL'
  Print *, 'ok'
End Program
EOF

lib_file="f.f90"
cat <<EOF > "${lib_file}"
Function f(i)
  Integer, Intent (In) :: i
  Integer :: f
  f = i + 42
End Function
EOF

cat <<EOF > meson.build
project('nagfor test', 'fortran', meson_version: '>=0.59.99')
both_libs = both_libraries('mylib', '${lib_file}')
ste = executable('stprog', '${main_file}', link_with: both_libs.get_static_lib())
she = executable('shprog', '${main_file}', link_with: both_libs.get_shared_lib())
test('static_exe', ste)
test('shared_exe', she)
EOF

rm -rf "${bdir}"

meson setup "${bdir}"
meson compile -C "${bdir}"
meson test -C "${bdir}"
```