### PR TITLE
There's a problem with compiler arguments subcommand parser

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1350,7 +1350,18 @@ You probably should put it in link_with instead.''')
         if language in self.extra_args:
             self.extra_args[language] += args
         else:
-            self.extra_args[language] = args
+            arglist: T.List[FileOrString] = None
+            string = ''.join(args)
+            argslist = string.split(' ')
+            for argsanitizer in argslist:
+                if not len(argsanitizer):
+                    argslist = None
+                    break
+            if argslist != None:
+                arglist = argslist
+                self.extra_args[language] = arglist
+            else:
+                self.extra_args[language] = args
 
     def get_aliases(self) -> T.Dict[str, str]:
         return {}


### PR DESCRIPTION
There's was a problem with the argument list passed for target object as LANGUAGE_args: ['ARGS'],
that all user arguments passed in the form of a single text (without backspaces)
like: "-Cprefer-dynamic=yes" works without problems, but "-C prefer-dynamic=yes"
does not works and lead in various errors!

The meson.build file:
![Screenshot from 2021-08-20 19-53-38](https://user-images.githubusercontent.com/83143947/130302618-dc66b410-2071-45f5-b5ce-0743f4865e96.png)

The problem:
![Screenshot from 2021-08-20 19-11-23](https://user-images.githubusercontent.com/83143947/130302617-0bf56532-c2bb-4c39-adb4-1c4aa673e247.png)
![Screenshot from 2021-08-20 20-37-18](https://user-images.githubusercontent.com/83143947/130302804-6d802408-cc12-43b1-a86c-963ee55a6554.png)

My fix:
![Screenshot from 2021-08-20 19-53-57](https://user-images.githubusercontent.com/83143947/130302619-f5a3bf24-d141-419a-868b-97325b5edc74.png)

