### PR TITLE
interpreter: Improve incorrect source root error

### DIFF
--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -45,7 +45,7 @@ from .disabler import Disabler, is_disabled
 from .helpers import check_stringlist, default_resolve_key, flatten, resolve_second_level_holders
 from ._unholder import _unholder
 
-import os, copy, re, pathlib
+import os, copy, re
 import typing as T
 
 if T.TYPE_CHECKING:
@@ -123,19 +123,7 @@ class InterpreterBase:
             raise InvalidCode('No statements in code.')
         first = self.ast.lines[0]
         if not isinstance(first, mparser.FunctionNode) or first.func_name != 'project':
-            p = pathlib.Path(self.source_root).resolve()
-            found = p
-            for parent in p.parents:
-                if (parent / 'meson.build').is_file():
-                    found = parent
-                else:
-                    break
-
-            error = 'first statement must be a call to project()'
-            if found != p:
-                raise InvalidCode(f'Not the project root: {error}\n\nDid you mean to run meson from the directory: "{found}"?')
-            else:
-                raise InvalidCode(f'Invalid source tree: {error}')
+            raise InvalidCode('First statement must be a call to project')
 
     def run(self) -> None:
         # Evaluate everything after the first line, which is project() because

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -123,7 +123,10 @@ class InterpreterBase:
             raise InvalidCode('No statements in code.')
         first = self.ast.lines[0]
         if not isinstance(first, mparser.FunctionNode) or first.func_name != 'project':
-            raise InvalidCode('First statement must be a call to project')
+            raise InvalidCode('Could not find a meson.build with project() ' \
+                    'as the first statement.\nDid you point Meson to the source ' \
+                    'directory with the top-most meson.build file?\nCurrently '\
+                    f'using: {self.source_root}')
 
     def run(self) -> None:
         # Evaluate everything after the first line, which is project() because

--- a/test cases/failing/1 project not first/test.json
+++ b/test cases/failing/1 project not first/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "ERROR: Invalid source tree: first statement must be a call to project()"
+      "line": "ERROR: First statement must be a call to project"
     }
   ]
 }


### PR DESCRIPTION
Keep it simple instead of using a complicated git walk or recursive
parent listdir, which would likely be wrong. For instance:

1. We would have to parse the topmost meson.build file to
   check if it does indeed contain a project()
2. It is not required that each subdir with a meson.build file has
   a meson.build file in its parent, since you can call
   subdir('foo/bar')
3. Anytime we do recursive searches, we can fall prey to loops due to
   symlinks or mounts.

Fixes https://github.com/mesonbuild/meson/issues/3426