### PR TITLE
Fix incomplete guidance on solving sandbox violations

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2215,6 +2215,10 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
                         # In subproject
                         some_dep = declare_dependency(include_directories: include_directories('include'))
 
+                        # In subproject wrap file
+                        [provide]
+                        some = some_dep
+
                         # In parent project
                         some_dep = dependency('some')
                         executable(..., dependencies: [some_dep])


### PR DESCRIPTION
We recommend people use declare_dependency and access it via dependency() in a parent project. But this requires a wrap file (or to use override_dependency and an explicit subproject call).

Let's actually mention that.

Fixes #9146