### PR TITLE
fix coding errors in unstable-coredata subcommand

### DIFF
--- a/mesonbuild/munstable_coredata.py
+++ b/mesonbuild/munstable_coredata.py
@@ -95,7 +95,7 @@ def run(options):
                 dump_compilers(v[for_machine])
         elif k == 'deps':
             def print_dep(dep_key, dep):
-                print('  ' + dep_key[0] + ": ")
+                print('  ' + dep_key[0][1] + ": ")
                 print('      compile args: ' + repr(dep.get_compile_args()))
                 print('      link args: ' + repr(dep.get_link_args()))
                 if dep.get_sources():
@@ -105,7 +105,7 @@ def run(options):
             for for_machine in iter(MachineChoice):
                 items_list = list(sorted(v[for_machine].items()))
                 if items_list:
-                    print('Cached dependencies for {} machine' % for_machine.get_lower_case_name())
+                    print(f'Cached dependencies for {for_machine.get_lower_case_name()} machine')
                     for dep_key, deps in items_list:
                         for dep in deps:
                             print_dep(dep_key, dep)


### PR DESCRIPTION
One percent-formatted string had a .format() method style placeholder and thus never output anything other than
```
TypeError: not all arguments converted during string formatting
```
The other error may be due to changing format elsewhere, because it attempted to treat an entire tuple as though it only contained one element. Based on context, it's clear this is supposed to be the actual dependency name, but the internal representation may have changed over time.

These fixes allow the command to run to completion successfully; of course it is still unstable and possibly not actually maintained, since it's been broken for 2 years and no one actually noticed.