### PR TITLE
use even more informative error message for invoking meson in a subdir

### DIFF
--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -127,7 +127,10 @@ class InterpreterBase:
             found = p
             for parent in p.parents:
                 if (parent / 'meson.build').is_file():
-                    found = parent
+                    with open(parent / 'meson.build', encoding='utf-8') as f:
+                        if f.readline().startswith('project('):
+                            found = parent
+                            break
                 else:
                     break
 


### PR DESCRIPTION
Follow-up on commit 5a7b8d86d0c455680096d47cb87f0de08c0954ac

Sometimes, we find a parent meson.build which is also malformed, and we shouldn't suggest that maybe the user meant to use that, if it isn't a valid project() either. Do a rough and dirty check to see if the very first line is a project() declaration, and if not, don't try to be clever and suggest using it.

The "invalid source tree" error suffices here, since we're not absolutely sure meson can be successfully run in that parent directory and actually advising people about the wrong location is a lot more confusing than just saying "please figure this out yourself, here is what to look for".

Granted, we miss cases where project() comes after blank lines and/or comments, but doing a full AST parse here is excessively overkill and probably too painful to do, and we don't need to be *that* clever. So let's be content with merely going above and beyond the call of duty.

/cc @nirbheek 