### PR TITLE
python module: produce the correct install path on every OS

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -279,7 +279,7 @@ import sysconfig
 import json
 import sys
 
-install_paths = sysconfig.get_paths(scheme='posix_prefix', vars={'base': '', 'platbase': '', 'installed_base': ''})
+install_paths = sysconfig.get_paths(vars={'base': '', 'platbase': '', 'installed_base': ''})
 
 def links_against_libpython():
     from distutils.core import Distribution, Extension


### PR DESCRIPTION
The sysconfig paths are, by default, correct for every OS -- they are supposed to follow the scheme that python knows about per default.

For some reason, this overrode the scheme to posix_prefix, which is the default for posix OSes like linux and macOS, but wrong on Windows. Simply deleting this entirely makes everything that used to work, still work, and a couple new things start working.

@MathieuDuponchelle I'm seeking insight into why this originally got implemented the way it did. Do you happen to remember?