### PR TITLE
gnome: don't let fortify defines into the g-ir-scanner after stripping -O

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -817,7 +817,9 @@ class GnomeModule(ExtensionModule):
     def _get_scanner_cflags(cflags):
         'g-ir-scanner only accepts -I/-D/-U; must ignore all other flags'
         for f in cflags:
-            if f.startswith(('-D', '-U', '-I')):
+            # _FORTIFY_SOURCE depends on / works together with -O, on the other hand this
+            # just invokes the preprocessor anyway
+            if f.startswith(('-D', '-U', '-I')) and not f.startswith('-D_FORTIFY_SOURCE'):
                 yield f
 
     @staticmethod


### PR DESCRIPTION
The tool needs to run the preprocessor (but does not actually produce compiled outputs), and meanwhile ignores lots of flags it doesn't think it needs. In the case of -D_FORTIFY_SOURCE=...  this is only valid if -O is there too, but otherwise spits out confusing warnings.

The warnings are spurious and can be safely ignored, but in this case let's go the extra mile and fix g-ir-scanner's upstream bug by removing the fortify flag first.

Fixes #9161