### PR TITLE
dependency: fallback and allow_fallback are mutually exclusive

### DIFF
--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -46,6 +46,8 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
                 mlog.warning('The "default_options" keyword argument does nothing without a fallback subproject.',
                              location=self.interpreter.current_node)
             return
+        if self.allow_fallback is not None:
+            raise InvalidArguments('"fallback" and "allow_fallback" arguments are mutually exclusive')
         fbinfo = stringlistify(fbinfo)
         if len(fbinfo) == 0:
             # dependency('foo', fallback: []) is the same as dependency('foo', allow_fallback: false)

--- a/test cases/failing/114 allow_fallback with fallback/meson.build
+++ b/test cases/failing/114 allow_fallback with fallback/meson.build
@@ -1,0 +1,3 @@
+project('fallback and allow_fallback')
+
+dependency('foo', fallback: 'foo', allow_fallback: false)

--- a/test cases/failing/114 allow_fallback with fallback/test.json
+++ b/test cases/failing/114 allow_fallback with fallback/test.json
@@ -1,0 +1,8 @@
+{
+    "stdout": [
+        {
+            "line": "test cases/failing/114 allow_fallback with fallback/meson.build:3:0: ERROR: \"fallback\" and \"allow_fallback\" arguments are mutually exclusive"
+        }
+    ]
+}
+


### PR DESCRIPTION
That used to abort in previous Meson versions but 0.59 stopped
forbidding that by mistake.