### PR TITLE
Clang should error for all implicit function checks

### DIFF
--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1154,11 +1154,12 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
         """Arguments to pass the compiler and/or linker for checks.
 
-        The default implementation turns off optimizations. mode should be
-        one of:
+        The default implementation turns off optimizations.
 
         Examples of things that go here:
           - extra arguments for error checking
+          - Arguments required to make the compiler exit with a non-zero status
+            when something is wrong.
         """
         return self.get_no_optimization_args()
 

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -81,7 +81,11 @@ class ClangCompiler(GnuLikeCompiler):
         return ['-include-pch', os.path.join(pch_dir, self.get_pch_name(header))]
 
     def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
-        myargs = []  # type: T.List[str]
+        # Clang is different than GCC, it will return True when a symbol isn't
+        # defined in a header. Specifically this seems ot have something to do
+        # with functions that may be in a header on some systems, but not all of
+        # them. `strlcat` specifically with can trigger this.
+        myargs: T.List[str] = ['-Werror=implicit-function-declaration']
         if mode is CompileCheckMode.COMPILE:
             myargs.extend(['-Werror=unknown-warning-option', '-Werror=unused-command-line-argument'])
             if mesonlib.version_compare(self.version, '>=3.6.0'):


### PR DESCRIPTION
Clang has a peculiar behavior, that it seems to allow functions that exist in c headers on some OSes/libc implementations even if the current one doesn't provide that function. For example, `strlcat` is available on the BSDs and Solaris, but not in glibc. Despite this running `cc.has_header_symbol('string.h', 'strlcat')` on glibc with clang will result in a warning, but a successful return code; while GCC will error. This does not work for never defined symbols, such as a `foobar`. To ensure that clang correctly errors in these cases Meson should add the `-Werror=implicit-function-declarations` to clang's check arguments.

Fixes #9140 