### PR TITLE
optinterpreter: Normalize options and check for dups

### DIFF
--- a/docs/markdown/Build-options.md
+++ b/docs/markdown/Build-options.md
@@ -27,6 +27,9 @@ option('long_desc', type : 'string', value : 'optval',
 
 For built-in options, see [Built-in options][builtin_opts].
 
+*Since 0.60.0* Option names are case unsensitive, dash `-` and underscore `_`
+can be interchanged.
+
 ## Build option types
 
 All types allow a `description` value to be set describing the option,

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -2033,6 +2033,8 @@ def _classify_argument(key: 'OptionKey') -> OptionType:
         assert key.machine is MachineChoice.HOST, str(key)
         return OptionType.PROJECT
 
+def _normalize_option_name(name: str) -> str:
+    return name.replace('-', '_').lower()
 
 @total_ordering
 class OptionKey:
@@ -2060,9 +2062,10 @@ class OptionKey:
                  module: T.Optional[str] = None,
                  _type: T.Optional[OptionType] = None):
         # the _type option to the constructor is kinda private. We want to be
-        # able tos ave the state and avoid the lookup function when
+        # able to save the state and avoid the lookup function when
         # pickling/unpickling, but we need to be able to calculate it when
         # constructing a new OptionKey
+        name = _normalize_option_name(name)
         object.__setattr__(self, 'name', name)
         object.__setattr__(self, 'subproject', subproject)
         object.__setattr__(self, 'machine', machine)
@@ -2175,7 +2178,7 @@ class OptionKey:
         # We have to be a little clever with lang here, because lang is valid
         # as None, for non-compiler options
         return OptionKey(
-            name if name is not None else self.name,
+            _normalize_option_name(name) if name is not None else self.name,
             subproject if subproject is not None else self.subproject,
             machine if machine is not None else self.machine,
             lang if lang != '' else self.lang,

--- a/test cases/failing/115 dup option/meson.build
+++ b/test cases/failing/115 dup option/meson.build
@@ -1,0 +1,1 @@
+project('dup object')

--- a/test cases/failing/115 dup option/meson_options.txt
+++ b/test cases/failing/115 dup option/meson_options.txt
@@ -1,0 +1,2 @@
+option('FOO-BAR', type: 'boolean')
+option('foo_bar', type: 'boolean')

--- a/test cases/failing/115 dup option/test.json
+++ b/test cases/failing/115 dup option/test.json
@@ -1,0 +1,7 @@
+{
+    "stdout": [
+        {
+            "line": "test cases/failing/115 dup option/meson_options.txt:2:0: ERROR: Option foo_bar already exists"
+        }
+    ]
+}

--- a/test cases/unit/99 normalize option name/meson.build
+++ b/test cases/unit/99 normalize option name/meson.build
@@ -1,0 +1,9 @@
+project('normalize option name',
+  default_options: ['default-library=static'])
+
+assert(get_option('default-library') == 'static')
+assert(get_option('default_library') == 'static')
+assert(get_option('warning-level') == '3')
+assert(get_option('warning_level') == '3')
+assert(get_option('foo-bar'))
+assert(get_option('foo_bar'))

--- a/test cases/unit/99 normalize option name/meson_options.txt
+++ b/test cases/unit/99 normalize option name/meson_options.txt
@@ -1,0 +1,1 @@
+option('foo-bar', type: 'boolean', value: false)

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4118,3 +4118,7 @@ class AllPlatformTests(BasePlatformTests):
         if self.backend is Backend.ninja:
             self.assertIn('Generating file.txt with a custom command', out)
             self.assertIn('Generating subdir/file.txt with a custom command', out)
+
+    def test_normalize_option_name(self) -> None:
+        testdir = os.path.join(self.unit_test_dir, '99 normalize option name')
+        self.init(testdir, extra_args=['-Dfoo_bar=true', '-Dwarning-level=3'])


### PR DESCRIPTION
Meson always favoured underscore instead of dash, but in practice it's
an unconsistent mess in most projects. Instead of having to remember
which option is named foo-bar or foo_bar, better treat them the same way
so -Dfoo-bar=val and -Dfoo_bar=val works the same.

While at it, also make option name case unsensitive.