### PR TITLE
interpreter: fix IndexError when specifying dependency 'include_type'

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1481,7 +1481,7 @@ external dependencies (including libraries) must go to "dependencies".''')
                 raise InvalidArguments('The `include_type` kwarg must be a string')
             actual = d.get_include_type()
             if wanted != actual:
-                mlog.debug(f'Current include type of {names[0]} is {actual}. Converting to requested {wanted}')
+                mlog.debug(f'Current include type of {args[0]} is {actual}. Converting to requested {wanted}')
                 d = d.generate_system_dependency(wanted)
         return d
 

--- a/test cases/common/219 include_type dependency/meson.build
+++ b/test cases/common/219 include_type dependency/meson.build
@@ -36,6 +36,9 @@ assert(sp_dep.include_type() == 'preserve', 'as_system must not mutate the origi
 fallback = dependency('sdffgagf_does_not_exist', include_type: 'system', fallback: ['subDep', 'subDep_dep'])
 assert(fallback.include_type() == 'system', 'include_type works with dependency fallback')
 
+fallback_empty = dependency('', include_type: 'system', fallback: ['subDep', 'subDep_dep'])
+assert(fallback_empty.include_type() == 'system', 'include_type works with empty name dependency fallback')
+
 # Check that PCH works with `include_type : 'system'` See https://github.com/mesonbuild/meson/issues/7167
 main_exe = executable('main_exe', 'main.cpp', cpp_pch: 'pch/test.hpp', dependencies: boost_dep)
 test('main_test', main_exe)


### PR DESCRIPTION
Exception is thrown when dependency name is empty and when its `include_type` differs from the default one.

Regression from b6d754a40c.