### PR TITLE
Make EnvironmentVariablesObject a  holder

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -426,10 +426,14 @@ class ExtractedObjects(HoldableObject):
         ]
 
 class EnvironmentVariables(HoldableObject):
-    def __init__(self) -> None:
+    def __init__(self, values: T.Optional[T.Dict[str, str]] = None) -> None:
         self.envvars: T.List[T.Tuple[T.Callable[[T.Dict[str, str], str, T.List[str], str], str], str, T.List[str], str]] = []
         # The set of all env vars we have operations for. Only used for self.has_name()
         self.varnames: T.Set[str] = set()
+
+        if values:
+            for name, value in values.items():
+                self.set(name, [value])
 
     def __repr__(self) -> str:
         repr_str = "<{0}: {1}>"

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -427,11 +427,11 @@ class ExtractedObjects(HoldableObject):
 
 class EnvironmentVariables(HoldableObject):
     def __init__(self) -> None:
-        self.envvars = []
+        self.envvars: T.List[T.Tuple[T.Callable[[T.Dict[str, str], str, T.List[str], str], str], str, T.List[str], str]] = []
         # The set of all env vars we have operations for. Only used for self.has_name()
-        self.varnames = set()
+        self.varnames: T.Set[str] = set()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         repr_str = "<{0}: {1}>"
         return repr_str.format(self.__class__.__name__, self.envvars)
 
@@ -450,14 +450,17 @@ class EnvironmentVariables(HoldableObject):
         self.varnames.add(name)
         self.envvars.append((self._prepend, name, values, separator))
 
-    def _set(self, env: T.Dict[str, str], name: str, values: T.List[str], separator: str) -> str:
+    @staticmethod
+    def _set(env: T.Dict[str, str], name: str, values: T.List[str], separator: str) -> str:
         return separator.join(values)
 
-    def _append(self, env: T.Dict[str, str], name: str, values: T.List[str], separator: str) -> str:
+    @staticmethod
+    def _append(env: T.Dict[str, str], name: str, values: T.List[str], separator: str) -> str:
         curr = env.get(name)
         return separator.join(values if curr is None else [curr] + values)
 
-    def _prepend(self, env: T.Dict[str, str], name: str, values: T.List[str], separator: str) -> str:
+    @staticmethod
+    def _prepend(env: T.Dict[str, str], name: str, values: T.List[str], separator: str) -> str:
         curr = env.get(name)
         return separator.join(values if curr is None else values + [curr])
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -51,6 +51,7 @@ from .interpreterobjects import (
     NullSubprojectInterpreter,
 )
 from .type_checking import (
+    ENV_KW,
     INSTALL_MODE_KW,
     LANGUAGE_KW,
     NATIVE_KW,
@@ -189,7 +190,7 @@ TEST_KWARGS: T.List[KwargInfo] = [
               listify=True, default=[], since='0.46.0'),
     KwargInfo('priority', int, default=0, since='0.52.0'),
     # TODO: env needs reworks of the way the environment variable holder itself works probably
-    KwargInfo('env', (EnvironmentVariablesObject, list, dict, str, NoneType)),
+    ENV_KW,
     KwargInfo('suite', ContainerTypeInfo(list, str), listify=True, default=['']),  # yes, a list of empty string
 ]
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -395,7 +395,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             build.Data: OBJ.DataHolder,
             build.InstallDir: OBJ.InstallDirHolder,
             build.IncludeDirs: OBJ.IncludeDirsHolder,
-            build.EnvironmentVariables: OBJ.EnvironmentVariablesObject,
+            build.EnvironmentVariables: OBJ.EnvironmentVariablesHolder,
             compilers.RunResult: compilerOBJ.TryRunResultHolder,
             dependencies.ExternalLibrary: OBJ.ExternalLibraryHolder,
             coredata.UserFeatureOption: OBJ.FeatureOptionHolder,

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -241,7 +241,9 @@ class EnvironmentVariablesObject(MutableInterpreterObject, MesonInterpreterObjec
                              'append': self.append_method,
                              'prepend': self.prepend_method,
                              })
-        if isinstance(initial_values, dict):
+        if isinstance(initial_values, build.EnvironmentVariables):
+            self.vars = initial_values
+        elif isinstance(initial_values, dict):
             for k, v in initial_values.items():
                 self.set_method([k, v], {})
         elif initial_values is not None:

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -238,7 +238,7 @@ class RunProcess(MesonInterpreterObject):
 _ENV_SEPARATOR_KW = KwargInfo('separator', str, default=os.pathsep)
 
 
-class EnvironmentVariablesObject(ObjectHolder[build.EnvironmentVariables], MutableInterpreterObject):
+class EnvironmentVariablesHolder(ObjectHolder[build.EnvironmentVariables], MutableInterpreterObject):
 
     def __init__(self, obj: build.EnvironmentVariables, interpreter: 'Interpreter'):
         super().__init__(obj, interpreter)
@@ -251,9 +251,9 @@ class EnvironmentVariablesObject(ObjectHolder[build.EnvironmentVariables], Mutab
         repr_str = "<{0}: {1}>"
         return repr_str.format(self.__class__.__name__, self.held_object.envvars)
 
-    def __deepcopy__(self, memo: T.Dict[str, object]) -> 'EnvironmentVariablesObject':
+    def __deepcopy__(self, memo: T.Dict[str, object]) -> 'EnvironmentVariablesHolder':
         # Avoid trying to copy the intepreter
-        return EnvironmentVariablesObject(copy.deepcopy(self.held_object), self.interpreter)
+        return EnvironmentVariablesHolder(copy.deepcopy(self.held_object), self.interpreter)
 
     def warn_if_has_name(self, name: str) -> None:
         # Multiple append/prepend operations was not supported until 0.58.0.

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -39,7 +39,7 @@ class BaseTest(TypedDict):
     workdir: T.Optional[str]
     depends: T.List[T.Union[build.CustomTarget, build.BuildTarget]]
     priority: int
-    env: T.Union[EnvironmentVariablesObject, T.List[str], T.Dict[str, str], str]
+    env: EnvironmentVariablesObject
     suite: T.List[str]
 
 

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -11,7 +11,6 @@ from typing_extensions import TypedDict, Literal
 from .. import build
 from .. import coredata
 from ..mesonlib import MachineChoice, File, FileMode, FileOrString
-from .interpreterobjects import EnvironmentVariablesObject
 
 
 class FuncAddProjectArgs(TypedDict):
@@ -39,7 +38,7 @@ class BaseTest(TypedDict):
     workdir: T.Optional[str]
     depends: T.List[T.Union[build.CustomTarget, build.BuildTarget]]
     priority: int
-    env: EnvironmentVariablesObject
+    env: build.EnvironmentVariables
     suite: T.List[str]
 
 

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -7,13 +7,13 @@ from .. import mlog
 
 from ..mesonlib import MachineChoice, OptionKey
 from ..programs import OverrideProgram, ExternalProgram
+from ..interpreter.type_checking import ENV_KW
 from ..interpreterbase import (MesonInterpreterObject, FeatureNew, FeatureDeprecated,
                                typed_pos_args, permittedKwargs, noArgsFlattening, noPosargs, noKwargs,
                                typed_kwargs, KwargInfo, MesonVersionString, InterpreterException)
 
 from .interpreterobjects import (ExecutableHolder, ExternalProgramHolder,
-                                 CustomTargetHolder, CustomTargetIndexHolder,
-                                 EnvironmentVariablesObject)
+                                 CustomTargetHolder, CustomTargetIndexHolder)
 from .type_checking import NATIVE_KW, NoneType
 
 import typing as T
@@ -415,9 +415,10 @@ class MesonMain(MesonInterpreterObject):
 
     @FeatureNew('add_devenv', '0.58.0')
     @noKwargs
-    @typed_pos_args('add_devenv', (str, list, dict, EnvironmentVariablesObject))
-    def add_devenv_method(self, args: T.Union[str, list, dict, EnvironmentVariablesObject], kwargs: T.Dict[str, T.Any]) -> None:
+    @typed_pos_args('add_devenv', (str, list, dict, build.EnvironmentVariables))
+    def add_devenv_method(self, args: T.Tuple[T.Union[str, list, dict, build.EnvironmentVariables]], kwargs: T.Dict[str, T.Any]) -> None:
         env = args[0]
-        if isinstance(env, (str, list, dict)):
-            env = EnvironmentVariablesObject(env)
-        self.build.devenv.append(env.vars)
+        msg = ENV_KW.validator(env)
+        if msg:
+            raise build.InvalidArguments(f'"add_devenv": {msg}')
+        self.build.devenv.append(ENV_KW.convertor(env))

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -6,6 +6,7 @@
 import typing as T
 
 from .. import compilers
+from ..build import EnvironmentVariables
 from ..coredata import UserFeatureOption
 from ..interpreterbase.decorators import KwargInfo, ContainerTypeInfo
 from ..mesonlib import FileMode, MachineChoice
@@ -125,4 +126,9 @@ REQUIRED_KW: KwargInfo[T.Union[bool, UserFeatureOption]] = KwargInfo(
     (bool, UserFeatureOption),
     default=True,
     # TODO: extract_required_kwarg could be converted to a convertor
+)
+
+ENV_KW: KwargInfo[T.Union[EnvironmentVariables, T.List, T.Dict, str, NoneType]] = KwargInfo(
+    'env',
+    (EnvironmentVariables, list, dict, str),
 )

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -134,8 +134,6 @@ def _env_validator(value: T.Union[EnvironmentVariables, T.List['TYPE_var'], T.Di
         split = v.split('=', 1)
         if len(split) == 1:
             return f'"{v}" is not two string values separated by an "="'
-        # We have to cast here, assert isn't good enough to narrow from
-        # Tuple[str, ...] -> Tuple[str, str]
         return None
 
     if isinstance(value, str):
@@ -159,8 +157,23 @@ def _env_validator(value: T.Union[EnvironmentVariables, T.List['TYPE_var'], T.Di
     return None
 
 
+def _env_convertor(value: T.Union[EnvironmentVariables, T.List[str], T.Dict[str, str], str, None]) -> EnvironmentVariables:
+    def splitter(input: str) -> T.Tuple[str, str]:
+        a, b = input.split('=', 1)
+        return (a.strip(), b.strip())
+
+    if isinstance(value, (str, list)):
+        return EnvironmentVariables(dict(splitter(v) for v in listify(value)))
+    elif isinstance(value, dict):
+        return EnvironmentVariables(value)
+    elif value is None:
+        return EnvironmentVariables()
+    return value
+
+
 ENV_KW: KwargInfo[T.Union[EnvironmentVariables, T.List, T.Dict, str, None]] = KwargInfo(
     'env',
-    (EnvironmentVariables, list, dict, str),
+    (EnvironmentVariables, list, dict, str, NoneType),
     validator=_env_validator,
+    convertor=_env_convertor,
 )


### PR DESCRIPTION
EnvironmentVariablesObject is a somewhat odd class, it's effectively a holder for `build.EnvironmentVariables`, but it it's not. This series converts it into one, and adds some additional type checking and validation.

My motivaiton here is that doing this simplifies add the type checking decorators to the various target interfaces, as we know we'll have an EnviornmentVariables object. This also is nice, in that it means that all cases where an and EnvironmentVariables is expected can get one, instead of each caller having to go through the dance of "is this a list? a dict? a str? an EnviornmentVariablesObject?" Instead that's all done in the inerpreter, and the lower layers always get a ciearn, EnvironmentVaraibles object.