### PR TITLE
interpreter: Add IntegerHolder

### DIFF
--- a/docs/markdown/snippets/comp_error.md
+++ b/docs/markdown/snippets/comp_error.md
@@ -1,0 +1,5 @@
+## Comparing two objects with different types is now an error
+
+Using the `==` and `!=` operators to compare objects of different (for instance
+`[1] == 1`) types was deprecated and undefined behavior since 0.45.0 and is
+now a hard error.

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -368,7 +368,8 @@ class AstInterpreter(InterpreterBase):
                 elif isinstance(src, bool):
                     result = self.bool_method_call(src, node.name, margs, mkwargs)
                 elif isinstance(src, int):
-                    result = self.int_method_call(src, node.name, margs, mkwargs)
+                    from ..interpreter import Interpreter, IntegerHolder
+                    result = IntegerHolder(src, T.cast(Interpreter, self)).method_call(node.name, margs, mkwargs)
                 elif isinstance(src, list):
                     result = self.array_method_call(src, node.name, margs, mkwargs)
                 elif isinstance(src, dict):

--- a/mesonbuild/interpreter/__init__.py
+++ b/mesonbuild/interpreter/__init__.py
@@ -16,6 +16,28 @@
 
 """Meson interpreter."""
 
+__all__ = [
+    'Interpreter',
+    'permitted_dependency_kwargs',
+
+    'CompilerHolder',
+
+    'ExecutableHolder',
+    'BuildTargetHolder',
+    'CustomTargetHolder',
+    'CustomTargetIndexHolder',
+    'MachineHolder',
+    'Test',
+    'ConfigurationDataObject',
+    'SubprojectHolder',
+    'DependencyHolder',
+    'GeneratedListHolder',
+    'ExternalProgramHolder',
+    'extract_required_kwarg',
+
+    'IntegerHolder',
+]
+
 from .interpreter import Interpreter, permitted_dependency_kwargs
 from .compiler import CompilerHolder
 from .interpreterobjects import (ExecutableHolder, BuildTargetHolder, CustomTargetHolder,
@@ -23,3 +45,7 @@ from .interpreterobjects import (ExecutableHolder, BuildTargetHolder, CustomTarg
                                  ConfigurationDataObject, SubprojectHolder, DependencyHolder,
                                  GeneratedListHolder, ExternalProgramHolder,
                                  extract_required_kwarg)
+
+from .primitives import (
+    IntegerHolder,
+)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -58,6 +58,7 @@ from .type_checking import (
     NoneType,
     in_set_validator,
 )
+from . import primitives as P_OBJ
 
 from pathlib import Path
 import os
@@ -376,6 +377,10 @@ class Interpreter(InterpreterBase, HoldableObject):
             holderify all returned values from methods and functions.
         '''
         self.holder_map.update({
+            # Primitives
+            int: P_OBJ.IntegerHolder,
+
+            # Meson types
             mesonlib.File: OBJ.FileHolder,
             build.SharedLibrary: OBJ.SharedLibraryHolder,
             build.StaticLibrary: OBJ.StaticLibraryHolder,

--- a/mesonbuild/interpreter/primitives/__init__.py
+++ b/mesonbuild/interpreter/primitives/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2021 The Meson development team
+# SPDX-license-identifier: Apache-2.0
+
+__all__ = [
+    'IntegerHolder',
+]
+
+from .integer import IntegerHolder

--- a/mesonbuild/interpreter/primitives/integer.py
+++ b/mesonbuild/interpreter/primitives/integer.py
@@ -1,0 +1,84 @@
+# Copyright 2021 The Meson development team
+# SPDX-license-identifier: Apache-2.0
+
+from ...interpreterbase import (
+    ObjectHolder,
+    MesonOperator,
+    typed_operator,
+    noKwargs,
+    noPosargs,
+
+    TYPE_var,
+    TYPE_kwargs,
+
+    InvalidArguments
+)
+
+import typing as T
+
+if T.TYPE_CHECKING:
+    # Object holders need the actual interpreter
+    from ...interpreter import Interpreter
+
+class IntegerHolder(ObjectHolder[int]):
+    def __init__(self, obj: int, interpreter: 'Interpreter') -> None:
+        super().__init__(obj, interpreter)
+        self.methods.update({
+            'is_even': self.is_even_method,
+            'is_odd': self.is_odd_method,
+            'to_string': self.to_string_method,
+        })
+
+
+        self.trivial_operators.update({
+            # Arithmetic
+            MesonOperator.UMINUS: (None, lambda x: -self.held_object),
+            MesonOperator.PLUS: (int, lambda x: self.held_object + x),
+            MesonOperator.MINUS: (int, lambda x: self.held_object - x),
+            MesonOperator.TIMES: (int, lambda x: self.held_object * x),
+
+            # Comparison
+            MesonOperator.EQUALS: (int, lambda x: self.held_object == x),
+            MesonOperator.NOT_EQUALS: (int, lambda x: self.held_object != x),
+            MesonOperator.GREATER: (int, lambda x: self.held_object > x),
+            MesonOperator.LESS: (int, lambda x: self.held_object < x),
+            MesonOperator.GREATER_EQUALS: (int, lambda x: self.held_object >= x),
+            MesonOperator.LESS_EQUALS: (int, lambda x: self.held_object <= x),
+        })
+
+        # Use actual methods for functions that require additional checks
+        self.operators.update({
+            MesonOperator.DIV: self.op_div,
+            MesonOperator.MOD: self.op_mod,
+        })
+
+    def display_name(self) -> str:
+        return 'int'
+
+    @noKwargs
+    @noPosargs
+    def is_even_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> bool:
+        return self.held_object % 2 == 0
+
+    @noKwargs
+    @noPosargs
+    def is_odd_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> bool:
+        return self.held_object % 2 != 0
+
+    @noKwargs
+    @noPosargs
+    def to_string_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
+        return str(self.held_object)
+
+    @typed_operator(MesonOperator.DIV, int)
+    def op_div(self, other: int) -> int:
+        if other == 0:
+            raise InvalidArguments('Tried to divide by 0')
+        return self.held_object // other
+
+    @typed_operator(MesonOperator.MOD, int)
+    def op_mod(self, other: int) -> int:
+        if other == 0:
+            raise InvalidArguments('Tried to divide by 0')
+        return self.held_object % other
+

--- a/mesonbuild/interpreterbase/__init__.py
+++ b/mesonbuild/interpreterbase/__init__.py
@@ -20,6 +20,8 @@ __all__ = [
     'MesonVersionString',
     'MutableInterpreterObject',
 
+    'MesonOperator',
+
     'Disabler',
     'is_disabled',
 
@@ -43,6 +45,8 @@ __all__ = [
     'permissive_unholder_return',
     'disablerIfNotFound',
     'permittedKwargs',
+    'typed_operator',
+    'unary_operator',
     'typed_pos_args',
     'ContainerTypeInfo',
     'KwargInfo',

--- a/mesonbuild/interpreterbase/__init__.py
+++ b/mesonbuild/interpreterbase/__init__.py
@@ -69,6 +69,9 @@ __all__ = [
     'TYPE_kwargs',
     'TYPE_nkwargs',
     'TYPE_key_resolver',
+    'TYPE_HoldableTypes',
+
+    'HoldableTypes',
 ]
 
 from .baseobjects import (
@@ -88,6 +91,9 @@ from .baseobjects import (
     TYPE_kwargs,
     TYPE_nkwargs,
     TYPE_key_resolver,
+    TYPE_HoldableTypes,
+
+    HoldableTypes,
 )
 
 from .decorators import (
@@ -102,6 +108,8 @@ from .decorators import (
     typed_pos_args,
     ContainerTypeInfo,
     KwargInfo,
+    typed_operator,
+    unary_operator,
     typed_kwargs,
     FeatureCheckBase,
     FeatureNew,
@@ -122,3 +130,4 @@ from .exceptions import (
 from .disabler import Disabler, is_disabled
 from .helpers import check_stringlist, default_resolve_key, flatten, resolve_second_level_holders
 from .interpreterbase import MesonVersionString, InterpreterBase
+from .operator import MesonOperator

--- a/mesonbuild/interpreterbase/_unholder.py
+++ b/mesonbuild/interpreterbase/_unholder.py
@@ -12,21 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .baseobjects import InterpreterObject, MesonInterpreterObject, ObjectHolder, TYPE_var
+from .baseobjects import InterpreterObject, MesonInterpreterObject, ObjectHolder, TYPE_var, HoldableTypes
 from .exceptions import InvalidArguments
 from ..mesonlib import HoldableObject, MesonBugException
 
 import typing as T
 
 def _unholder(obj: T.Union[TYPE_var, InterpreterObject], *, permissive: bool = False) -> TYPE_var:
-    if isinstance(obj, (int, bool, str)):
+    if isinstance(obj, (bool, str)):
         return obj
     elif isinstance(obj, list):
         return [_unholder(x, permissive=permissive) for x in obj]
     elif isinstance(obj, dict):
         return {k: _unholder(v, permissive=permissive) for k, v in obj.items()}
     elif isinstance(obj, ObjectHolder):
-        assert isinstance(obj.held_object, HoldableObject)
+        assert isinstance(obj.held_object, HoldableTypes)
         return obj.held_object
     elif isinstance(obj, MesonInterpreterObject):
         return obj

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -111,6 +111,9 @@ class InterpreterObject:
         ))
 
     def op_equals(self, other: TYPE_var) -> bool:
+        # We use `type(...) == type(...)` here to enforce an *exact* match for comparison. We
+        # don't want comparisons to be possible where `isinstance(derived_obj, type(base_obj))`
+        # would pass because this comparison must never be true: `derived_obj == base_obj`
         if type(self) != type(other):
             self._throw_comp_exception(other, '==')
         return self == other
@@ -148,6 +151,7 @@ class ObjectHolder(InterpreterObject, T.Generic[InterpreterObjectTypeVar]):
 
     # Override default comparison operators for the held object
     def op_equals(self, other: TYPE_var) -> bool:
+        # See the comment from InterpreterObject why we are using `type()` here.
         if type(self.held_object) != type(other):
             self._throw_comp_exception(other, '==')
         return self.held_object == other

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -139,7 +139,7 @@ def typed_operator(operator: MesonOperator,
     return inner
 
 def unary_operator(operator: MesonOperator) -> T.Callable[['_TV_FN_Operator'], '_TV_FN_Operator']:
-    """Decorator that does type checking for operator calls.
+    """Decorator that does type checking for unary operator calls.
 
     This decorator is for unary operators that do not take any other objects.
     It should be impossible for a user to accidentally break this. Triggering

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -47,6 +47,7 @@ from ._unholder import _unholder
 
 import os, copy, re, pathlib
 import typing as T
+import textwrap
 
 if T.TYPE_CHECKING:
     from ..interpreter import Interpreter
@@ -306,11 +307,14 @@ class InterpreterBase:
         valid = self.validate_comparison_types(val1, val2)
         # Ordering comparisons of different types isn't allowed since PR #1810
         # (0.41.0).  Since PR #2884 we also warn about equality comparisons of
-        # different types, which will one day become an error.
+        # different types, which is now an error.
         if not valid and (node.ctype == '==' or node.ctype == '!='):
-            mlog.warning('''Trying to compare values of different types ({}, {}) using {}.
-The result of this is undefined and will become a hard error in a future Meson release.'''
-                         .format(type(val1).__name__, type(val2).__name__, node.ctype), location=node)
+            raise InvalidArguments(textwrap.dedent(
+                f'''
+                    Trying to compare values of different types ({type(val1).__name__}, {type(val2).__name__}) using {node.ctype}.
+                    This was deprecated and undefined behavior previously and is as of 0.60.0 a hard error.
+                '''
+            ))
         if node.ctype == '==':
             return val1 == val2
         elif node.ctype == '!=':

--- a/mesonbuild/interpreterbase/operator.py
+++ b/mesonbuild/interpreterbase/operator.py
@@ -1,0 +1,34 @@
+# SPDX-license-identifier: Apache-2.0
+
+from enum import Enum
+
+class MesonOperator(Enum):
+    # Arithmetic
+    PLUS = '+'
+    MINUS = '-'
+    TIMES = '*'
+    DIV = '/'
+    MOD = '%'
+
+    UMINUS = 'uminus'
+
+    # Logic
+    NOT = 'not'
+    AND = 'and'
+    OR = 'or'
+
+    # Should return the boolsche interpretation of the value (`'' == false` for instance)
+    BOOL = 'bool()'
+
+    # Comparision
+    EQUALS = '=='
+    NOT_EQUALS = '!='
+    GREATER = '>'
+    LESS = '<'
+    GREATER_EQUALS = '>='
+    LESS_EQUALS = '<='
+
+    # Container
+    IN = 'in'
+    NOT_IN = 'not in'
+    INDEX = '[]'

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -15,6 +15,7 @@ modules = [
     'mesonbuild/cmake',
     'mesonbuild/compilers',
     'mesonbuild/dependencies',
+    'mesonbuild/interpreter/primitives',
     'mesonbuild/interpreterbase',
     'mesonbuild/linkers',
     'mesonbuild/scripts',

--- a/test cases/common/16 comparison/meson.build
+++ b/test cases/common/16 comparison/meson.build
@@ -127,17 +127,6 @@ test('equaltrue', exe14)
 test('nequaltrue', exe15)
 test('nequalfalse', exe16)
 
-# Equality comparisons of different elementary types
-# (these all cause warnings currently, will become an error in future)
-
-assert([] != 'st', 'not equal')
-assert([] != 1, 'not equal')
-assert(2 != 'st', 'not equal')
-
-assert(not ([] == 'st'), 'not equal')
-assert(not ([] == 1), 'not equal')
-assert(not (2 == 'st'), 'not equal')
-
 # "in" and "not in" operators
 
 assert(1 in [1, 2], '''1 should be in [1, 2]''')

--- a/test cases/failing/50 executable comparison/test.json
+++ b/test cases/failing/50 executable comparison/test.json
@@ -1,7 +1,8 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/50 executable comparison/meson.build:6:0: ERROR: exe1 can only be compared for equality."
+      "match": "re",
+      "line": "test cases/failing/50 executable comparison/meson.build:6:0: ERROR: Object <ExecutableHolder prog1@exe: prog1(.exe)?> of type Executable does not support the `<` operator."
     }
   ]
 }


### PR DESCRIPTION
The goal of this PR is to introduce a foundation for holderifying all the primitive types that currently need special logic in `InterpreterBase`. The end goal is to just have `InterpreterBase` deal with method and operator calls to `InterpreterObjects`.

I have only added an `IntegerHolder` to keep (for once) the diff on the small side. The downside here is that some extra logic in `InterpreterBase` is required to support a mix of primitive holders and old-style primitive handling while the conversion process is in progress.

Finally, the long deprecated/undefined behavior comparisons with `==` and `!=` for objects with different types has been turned into a hard error.