### PR TITLE
Handle aarch64_be as a cpu family

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -314,6 +314,9 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
         trial = 'x86'
     elif trial == 'arm64':
         trial = 'aarch64'
+    elif trial.startswith('aarch64'):
+        # This can be `aarch64_be`
+        trial = 'aarch64'
     elif trial.startswith('arm') or trial.startswith('earm'):
         trial = 'arm'
     elif trial.startswith(('powerpc64', 'ppc64')):
@@ -373,10 +376,13 @@ def detect_cpu(compilers: CompilersDict) -> str:
         # Same check as above for cpu_family
         if any_compiler_has_define(compilers, '__i386__'):
             trial = 'i686' # All 64 bit cpus have at least this level of x86 support.
-    elif trial == 'aarch64':
+    elif trial.startswith('aarch64'):
         # Same check as above for cpu_family
         if any_compiler_has_define(compilers, '__arm__'):
             trial = 'arm'
+        else:
+            # for aarch64_be
+            trial = 'aarch64'
     elif trial.startswith('earm'):
         trial = 'arm'
     elif trial == 'e2k':

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -387,6 +387,10 @@ def detect_cpu(compilers: CompilersDict) -> str:
             trial = 'mips'
         else:
             trial = 'mips64'
+    elif trial == 'ppc':
+        # AIX always returns powerpc, check here for 64-bit
+        if any_compiler_has_define(compilers, '__64BIT__'):
+            trial = 'ppc64'
 
     # Add more quirks here as bugs are reported. Keep in sync with
     # detect_cpu_family() above.

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -359,7 +359,7 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
 
     return trial
 
-def detect_cpu(compilers: CompilersDict):
+def detect_cpu(compilers: CompilersDict) -> str:
     if mesonlib.is_windows():
         trial = detect_windows_arch(compilers)
     elif mesonlib.is_freebsd() or mesonlib.is_netbsd() or mesonlib.is_openbsd() or mesonlib.is_aix():
@@ -392,15 +392,13 @@ def detect_cpu(compilers: CompilersDict):
     # detect_cpu_family() above.
     return trial
 
-def detect_system():
+def detect_system() -> str:
     if sys.platform == 'cygwin':
         return 'cygwin'
     return platform.system().lower()
 
-def detect_msys2_arch():
-    if 'MSYSTEM_CARCH' in os.environ:
-        return os.environ['MSYSTEM_CARCH']
-    return None
+def detect_msys2_arch() -> T.Optional[str]:
+    return os.environ.get('MSYSTEM_CARCH', None)
 
 def detect_machine_info(compilers: T.Optional[CompilersDict] = None) -> MachineInfo:
     """Detect the machine we're running on

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1465,6 +1465,8 @@ class InternalTests(unittest.TestCase):
             ('amd64', 'x86_64'),
             ('x64', 'x86_64'),
             ('i86pc', 'x86_64'),  # Solaris
+            ('aarch64', 'aarch64'),
+            ('aarch64_be', 'aarch64'),
         ]
 
         with mock.patch('mesonbuild.environment.any_compiler_has_define', mock.Mock(return_value=False)):
@@ -1500,6 +1502,8 @@ class InternalTests(unittest.TestCase):
             ('mips64', 'mips64'),
             ('mips', 'mips'),
             ('mipsel', 'mips'),
+            ('aarch64', 'aarch64'),
+            ('aarch64_be', 'aarch64'),
         ]
 
         with mock.patch('mesonbuild.environment.any_compiler_has_define', mock.Mock(return_value=False)):

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1509,7 +1509,7 @@ class InternalTests(unittest.TestCase):
                     self.assertEqual(actual, expected)
 
         with mock.patch('mesonbuild.environment.any_compiler_has_define', mock.Mock(return_value=True)):
-            for test, expected in [('x86_64', 'i686'), ('aarch64', 'arm')]:
+            for test, expected in [('x86_64', 'i686'), ('aarch64', 'arm'), ('ppc', 'ppc64')]:
                 with self.subTest(test, has_define=True), mock_trial(test):
                     actual = mesonbuild.environment.detect_cpu({})
                     self.assertEqual(actual, expected)

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1478,3 +1478,38 @@ class InternalTests(unittest.TestCase):
                 with self.subTest(test, has_define=True), mock_trial(test):
                     actual = mesonbuild.environment.detect_cpu_family({})
                     self.assertEqual(actual, expected)
+
+    def test_detect_cpu(self) -> None:
+
+        @contextlib.contextmanager
+        def mock_trial(value: str) -> T.Iterable[None]:
+            """Mock all of the ways we could get the trial at once."""
+            mocked = mock.Mock(return_value=value)
+
+            with mock.patch('mesonbuild.environment.detect_windows_arch', mocked), \
+                    mock.patch('mesonbuild.environment.platform.processor', mocked), \
+                    mock.patch('mesonbuild.environment.platform.machine', mocked):
+                yield
+
+        cases = [
+            ('amd64', 'x86_64'),
+            ('x64', 'x86_64'),
+            ('i86pc', 'x86_64'),
+            ('earm', 'arm'),
+            ('mips64el', 'mips64'),
+            ('mips64', 'mips64'),
+            ('mips', 'mips'),
+            ('mipsel', 'mips'),
+        ]
+
+        with mock.patch('mesonbuild.environment.any_compiler_has_define', mock.Mock(return_value=False)):
+            for test, expected in cases:
+                with self.subTest(test, has_define=False), mock_trial(test):
+                    actual = mesonbuild.environment.detect_cpu({})
+                    self.assertEqual(actual, expected)
+
+        with mock.patch('mesonbuild.environment.any_compiler_has_define', mock.Mock(return_value=True)):
+            for test, expected in [('x86_64', 'i686'), ('aarch64', 'arm')]:
+                with self.subTest(test, has_define=True), mock_trial(test):
+                    actual = mesonbuild.environment.detect_cpu({})
+                    self.assertEqual(actual, expected)

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import stat
 import subprocess
 import json
@@ -1422,3 +1423,58 @@ class InternalTests(unittest.TestCase):
         self.assertEqual(k.required, v.required)
         self.assertEqual(k.default, 'foo')
         self.assertEqual(v.default, 'bar')
+
+    def test_detect_cpu_family(self) -> None:
+        """Test the various cpu familes that we detect and normalize.
+
+        This is particularly useful as both documentation, and to keep testing
+        platforms that are less common.
+        """
+
+        @contextlib.contextmanager
+        def mock_trial(value: str) -> T.Iterable[None]:
+            """Mock all of the ways we could get the trial at once."""
+            mocked = mock.Mock(return_value=value)
+
+            with mock.patch('mesonbuild.environment.detect_windows_arch', mocked), \
+                    mock.patch('mesonbuild.environment.platform.processor', mocked), \
+                    mock.patch('mesonbuild.environment.platform.machine', mocked):
+                yield
+
+        cases = [
+            ('x86', 'x86'),
+            ('i386', 'x86'),
+            ('bepc', 'x86'),  # Haiku
+            ('earm', 'arm'),  # NetBSD
+            ('arm', 'arm'),
+            ('ppc64', 'ppc64'),
+            ('powerpc64', 'ppc64'),
+            ('powerpc', 'ppc'),
+            ('ppc', 'ppc'),
+            ('macppc', 'ppc'),
+            ('power macintosh', 'ppc'),
+            ('mips64el', 'mips64'),
+            ('mips64', 'mips64'),
+            ('mips', 'mips'),
+            ('mipsel', 'mips'),
+            ('ip30', 'mips64'),
+            ('ip35', 'mips64'),
+            ('parisc64', 'parisc'),
+            ('sun4u', 'sparc64'),
+            ('sun4v', 'sparc64'),
+            ('amd64', 'x86_64'),
+            ('x64', 'x86_64'),
+            ('i86pc', 'x86_64'),  # Solaris
+        ]
+
+        with mock.patch('mesonbuild.environment.any_compiler_has_define', mock.Mock(return_value=False)):
+            for test, expected in cases:
+                with self.subTest(test, has_define=False), mock_trial(test):
+                    actual = mesonbuild.environment.detect_cpu_family({})
+                    self.assertEqual(actual, expected)
+
+        with mock.patch('mesonbuild.environment.any_compiler_has_define', mock.Mock(return_value=True)):
+            for test, expected in [('x86_64', 'x86'), ('aarch64', 'arm'), ('ppc', 'ppc64')]:
+                with self.subTest(test, has_define=True), mock_trial(test):
+                    actual = mesonbuild.environment.detect_cpu_family({})
+                    self.assertEqual(actual, expected)


### PR DESCRIPTION
I've added aarch64_be, as well as some unit tests. I know this is a bit of a nitty unittest, and in some ways is a "test what I say" case, but these are getting big enough and complicated enough that I think it warrants tests, especially since many of these values can only be tested on specific operating systems with specific cpus, some of which are quite rare. I've also thrown in a few type annotations :)

Fixes #9191 