### PR TITLE
python module: fix error message mentioning setuptools

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -674,7 +674,7 @@ class PythonModule(ExtensionModule):
                 return python
             else:
                 if required:
-                    raise mesonlib.MesonException(f'{python} is not a valid python or it is missing setuptools')
+                    raise mesonlib.MesonException(f'{python} is not a valid python or it is missing distutils')
                 return NonExistingExternalProgram()
 
         raise mesonlib.MesonBugException('Unreachable code was reached (PythonModule.find_installation).')


### PR DESCRIPTION
We use distutils, not setuptools, for probing information.