### PR TITLE
replace `an_unpicklable_object` with proper python dunder methods

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -21,7 +21,7 @@ from .. import optinterpreter
 from .. import compilers
 from ..wrap import wrap, WrapMode
 from .. import mesonlib
-from ..mesonlib import HoldableObject, FileMode, MachineChoice, OptionKey, listify, extract_as_list, has_path_sep
+from ..mesonlib import MesonBugException, HoldableObject, FileMode, MachineChoice, OptionKey, listify, extract_as_list, has_path_sep
 from ..programs import ExternalProgram, NonExistingExternalProgram
 from ..dependencies import Dependency
 from ..depfile import DepFile
@@ -230,7 +230,6 @@ class Interpreter(InterpreterBase, HoldableObject):
                 is_translated: bool = False,
             ) -> None:
         super().__init__(_build.environment.get_source_dir(), subdir, subproject)
-        self.an_unpicklable_object = mesonlib.an_unpicklable_object
         self.build = _build
         self.environment = self.build.environment
         self.coredata = self.environment.get_coredata()
@@ -277,6 +276,9 @@ class Interpreter(InterpreterBase, HoldableObject):
         if not mock:
             self.parse_project()
         self._redetect_machines()
+
+    def __getnewargs_ex__(self) -> T.Tuple[T.Tuple[object], T.Dict[str, object]]:
+        raise MesonBugException('This class is unpicklable')
 
     def _redetect_machines(self):
         # Re-initialize machine descriptions. We can do a better job now because we

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -44,7 +44,6 @@ _U = T.TypeVar('_U')
 
 __all__ = [
     'GIT',
-    'an_unpicklable_object',
     'python_command',
     'project_meson_versions',
     'HoldableObject',
@@ -264,12 +263,6 @@ def check_direntry_issues(direntry_array: T.Union[T.List[T.Union[str, bytes]], s
                 locale but you are trying to access a file system entry called {de!r} which is
                 not pure ASCII. This may cause problems.
                 '''), file=sys.stderr)
-
-
-# Put this in objects that should not get dumped to pickle files
-# by accident.
-import threading
-an_unpicklable_object = threading.Lock()
 
 class HoldableObject(metaclass=abc.ABCMeta):
     ''' Dummy base class for all objects that can be

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
-import stat
-import subprocess
-import json
-import tempfile
-import os
-import io
-import operator
-from unittest import mock
 from configparser import ConfigParser
 from pathlib import Path
+from unittest import mock
+import contextlib
+import io
+import json
+import operator
+import os
+import pickle
+import stat
+import subprocess
+import tempfile
 import typing as T
 import unittest
 
@@ -1517,3 +1518,12 @@ class InternalTests(unittest.TestCase):
                 with self.subTest(test, has_define=True), mock_trial(test):
                     actual = mesonbuild.environment.detect_cpu({})
                     self.assertEqual(actual, expected)
+
+    def test_interpreter_unpicklable(self) -> None:
+        build = mock.Mock()
+        build.environment = mock.Mock()
+        build.environment.get_source_dir = mock.Mock(return_value='')
+        with mock.patch('mesonbuild.interpreter.Interpreter._redetect_machines', mock.Mock()), \
+                self.assertRaises(Exception):
+            i = mesonbuild.interpreter.Interpreter(build, mock=True)
+            pickle.dumps(i)

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1524,6 +1524,6 @@ class InternalTests(unittest.TestCase):
         build.environment = mock.Mock()
         build.environment.get_source_dir = mock.Mock(return_value='')
         with mock.patch('mesonbuild.interpreter.Interpreter._redetect_machines', mock.Mock()), \
-                self.assertRaises(Exception):
+                self.assertRaises(mesonbuild.mesonlib.MesonBugException):
             i = mesonbuild.interpreter.Interpreter(build, mock=True)
             pickle.dumps(i)


### PR DESCRIPTION
Instead of using an object that happens to be unpicklable to ensure the Interpreter isn't pickled, we can just make it an error to call the dunder methods used for pickling. I've also added a test for this, to ensure it remains working in the future.