### PR TITLE
run_target depends

### DIFF
--- a/docs/markdown/snippets/run_target-depends.md
+++ b/docs/markdown/snippets/run_target-depends.md
@@ -1,0 +1,20 @@
+## `run_target` can now be used as a dependency
+
+A `run_target()` can now be saved in a variable and reused as a dependency in
+an `alias_target()`. This can be used to create custom alias rules that ensure
+multiple other targets are run, even if those targets don't produce output
+files.
+
+For example:
+
+```
+i18n = import('i18n')
+
+all_pot_targets = []
+
+foo_i18n = i18n.gettext('foo')
+
+all_pot_targets += foo_i18n[1]
+
+alias_target('all-pot', all_pot_targets)
+```

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -358,7 +358,10 @@ class Backend:
 
     @lru_cache(maxsize=None)
     def get_target_dir(self, target: T.Union[build.Target, build.CustomTargetIndex]) -> str:
-        if self.environment.coredata.get_option(OptionKey('layout')) == 'mirror':
+        if isinstance(target, build.RunTarget):
+            # this produces no output, only a dummy top-level name
+            dirname = ''
+        elif self.environment.coredata.get_option(OptionKey('layout')) == 'mirror':
             dirname = target.get_subdir()
         else:
             dirname = 'meson-out'

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2528,6 +2528,10 @@ class AliasTarget(RunTarget):
     def __init__(self, name, dependencies, subdir, subproject):
         super().__init__(name, [], dependencies, subdir, subproject)
 
+    def __repr__(self):
+        repr_str = "<{0} {1}>"
+        return repr_str.format(self.__class__.__name__, self.get_id())
+
 class Jar(BuildTarget):
     known_kwargs = known_jar_kwargs
 

--- a/test cases/unit/65 alias target/meson.build
+++ b/test cases/unit/65 alias target/meson.build
@@ -13,3 +13,5 @@ custom_target = custom_target('custom-target',
 )
 
 alias_target('build-all', [exe_target, custom_target])
+
+subdir('subdir')

--- a/test cases/unit/65 alias target/subdir/meson.build
+++ b/test cases/unit/65 alias target/subdir/meson.build
@@ -1,0 +1,6 @@
+r = run_target('run-target',
+  command: [python3, '-c', 'print("a run target was here")']
+)
+
+alias_target('aliased-run', r)
+

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3076,6 +3076,8 @@ class AllPlatformTests(BasePlatformTests):
         self.run_target('build-all')
         self.assertPathExists(os.path.join(self.builddir, 'prog' + exe_suffix))
         self.assertPathExists(os.path.join(self.builddir, 'hello.txt'))
+        out = self.run_target('aliased-run')
+        self.assertIn('a run target was here', out)
 
     def test_configure(self):
         testdir = os.path.join(self.common_test_dir, '2 cpp')


### PR DESCRIPTION
run_target: do not yield broken names with subdirs

A run_target object created in a subdir/meson.build always has a ninja rule name of "name", not "subdir/name".

Fixes #9175
