### PR TITLE
make the display name of a gettext translation build, look prettier

### DIFF
--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -184,7 +184,7 @@ class I18nModule(ExtensionModule):
                           'install_dir': path.join(install_dir, l, 'LC_MESSAGES'),
                           'install_tag': 'i18n',
                           }
-            gmotarget = build.CustomTarget(l+'.mo', path.join(state.subdir, l, 'LC_MESSAGES'), state.subproject, gmo_kwargs)
+            gmotarget = build.CustomTarget(f'{packagename}-{l}.mo', path.join(state.subdir, l, 'LC_MESSAGES'), state.subproject, gmo_kwargs)
             targets.append(gmotarget)
             gmotargets.append(gmotarget)
 


### PR DESCRIPTION
And more accurate too, TBH. Currently it says it is building "lang.mo", even though it is actually building "domain.mo" inside lang/LC_MESSAGES/.

Since meson loudly complains if I try to name the display name "lang/domain.mo", name it with a dash instead of a slash. The actual name isn't a priority here IMO, and this is nicely readable.