### PR TITLE
interpreter: Introduce StringHolder

### DIFF
--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -2268,6 +2268,7 @@ are immutable, all operations return their results as a new string.
 
 - `join(list_of_strings)`: the opposite of split, for example
   `'.'.join(['a', 'b', 'c']` yields `'a.b.c'`.
+  *(Since 0.60.0)* more than one argument is supported and lists will be flattened.
 
 - `replace('old_substr', 'new_str')` *(since 0.58.0)*: replaces instances of
   `old_substr` in the string with `new_str` and returns a new string

--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -178,6 +178,18 @@ These are raw strings that do not support the escape sequences listed
 above.  These strings can also be combined with the string formatting
 functionality described below.
 
+### String index
+
+Stings support the indexing (`[<num>]`) operator. This operator allows (read
+only) acessing a specific character. The returned value is guaranteed to be
+a string of length 1.
+
+```meson
+foo = 'abcd'
+message(foo[1])  # Will print 'b'
+foo[2] = 'C'     # ERROR: Meson objects are immutable!
+```
+
 ### String formatting
 
 #### .format()

--- a/docs/markdown/snippets/str_join.md
+++ b/docs/markdown/snippets/str_join.md
@@ -1,0 +1,5 @@
+## Relax restrictions of `str.join()`
+
+Since 0.60.0, the [[str.join]] method can take an arbitrary number of arguments
+instead of just one list. Additionally, all lists past to [[str.join]] will now
+be flattened.

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -364,7 +364,8 @@ class AstInterpreter(InterpreterBase):
             mkwargs = {} # type: T.Dict[str, TYPE_nvar]
             try:
                 if isinstance(src, str):
-                    result = self.string_method_call(src, node.name, margs, mkwargs)
+                    from ..interpreter import Interpreter, StringHolder
+                    result = StringHolder(src, T.cast(Interpreter, self)).method_call(node.name, margs, mkwargs)
                 elif isinstance(src, bool):
                     from ..interpreter import Interpreter, BooleanHolder
                     result = BooleanHolder(src, T.cast(Interpreter, self)).method_call(node.name, margs, mkwargs)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2524,6 +2524,9 @@ class CustomTarget(Target, CommandBase):
         for i in self.outputs:
             yield CustomTargetIndex(self, i)
 
+    def __len__(self) -> int:
+        return len(self.outputs)
+
 class RunTarget(Target, CommandBase):
     def __init__(self, name: str, command, dependencies,
                  subdir: str, subproject: str, env: T.Optional['EnvironmentVariables'] = None):

--- a/mesonbuild/interpreter/__init__.py
+++ b/mesonbuild/interpreter/__init__.py
@@ -37,6 +37,7 @@ __all__ = [
 
     'BooleanHolder',
     'IntegerHolder',
+    'StringHolder',
 ]
 
 from .interpreter import Interpreter, permitted_dependency_kwargs
@@ -50,4 +51,5 @@ from .interpreterobjects import (ExecutableHolder, BuildTargetHolder, CustomTarg
 from .primitives import (
     BooleanHolder,
     IntegerHolder,
+    StringHolder,
 )

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -376,6 +376,8 @@ class Interpreter(InterpreterBase, HoldableObject):
             # Primitives
             int: P_OBJ.IntegerHolder,
             bool: P_OBJ.BooleanHolder,
+            str: P_OBJ.StringHolder,
+            P_OBJ.MesonVersionString: P_OBJ.MesonVersionStringHolder,
 
             # Meson types
             mesonlib.File: OBJ.FileHolder,
@@ -2399,7 +2401,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
     @typed_pos_args('join_paths', varargs=str, min_varargs=1)
     @noKwargs
     def func_join_paths(self, node: mparser.BaseNode, args: T.Tuple[T.List[str]], kwargs: 'TYPE_kwargs') -> str:
-        return self.join_path_strings(args[0])
+        return os.path.join(*args[0]).replace('\\', '/')
 
     def run(self) -> None:
         super().run()

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -14,8 +14,9 @@ from ..mesonlib import MachineChoice, OptionKey
 from ..programs import OverrideProgram, ExternalProgram
 from ..interpreter.type_checking import ENV_KW
 from ..interpreterbase import (MesonInterpreterObject, FeatureNew, FeatureDeprecated,
-                               typed_pos_args, noArgsFlattening, noPosargs, noKwargs,
-                               typed_kwargs, KwargInfo, MesonVersionString, InterpreterException)
+                               typed_pos_args,  noArgsFlattening, noPosargs, noKwargs,
+                               typed_kwargs, KwargInfo, InterpreterException)
+from .primitives import MesonVersionString
 from .type_checking import NATIVE_KW, NoneType
 
 if T.TYPE_CHECKING:

--- a/mesonbuild/interpreter/primitives/__init__.py
+++ b/mesonbuild/interpreter/primitives/__init__.py
@@ -4,7 +4,11 @@
 __all__ = [
     'BooleanHolder',
     'IntegerHolder',
+    'StringHolder',
+    'MesonVersionString',
+    'MesonVersionStringHolder',
 ]
 
 from .boolean import BooleanHolder
 from .integer import IntegerHolder
+from .string import StringHolder, MesonVersionString, MesonVersionStringHolder

--- a/mesonbuild/interpreter/primitives/string.py
+++ b/mesonbuild/interpreter/primitives/string.py
@@ -21,6 +21,11 @@ from ...interpreterbase import (
 
     InvalidArguments,
 )
+from ...mparser import (
+    MethodNode,
+    StringNode,
+    ArrayNode,
+)
 
 
 if T.TYPE_CHECKING:
@@ -105,6 +110,13 @@ class StringHolder(ObjectHolder[str]):
     @noKwargs
     @typed_pos_args('str.join', varargs=str)
     def join_method(self, args: T.Tuple[T.List[str]], kwargs: TYPE_kwargs) -> str:
+        # Implement some basic FeatureNew check on the AST level
+        assert isinstance(self.current_node, MethodNode)
+        n_args = self.current_node.args.arguments
+        if len(n_args) != 1 or not isinstance(n_args[0], ArrayNode) or not all(isinstance(x, StringNode) for x in n_args[0].args.arguments):
+            FeatureNew.single_use('str.join (varargs)', '0.60.0', self.subproject, 'List-flattening and variadic arguments')
+
+        # Actual implementation
         return self.held_object.join(args[0])
 
     @noKwargs

--- a/mesonbuild/interpreter/primitives/string.py
+++ b/mesonbuild/interpreter/primitives/string.py
@@ -64,6 +64,7 @@ class StringHolder(ObjectHolder[str]):
         # Use actual methods for functions that require additional checks
         self.operators.update({
             MesonOperator.DIV: self.op_div,
+            MesonOperator.INDEX: self.op_index,
         })
 
     def display_name(self) -> str:
@@ -161,6 +162,13 @@ class StringHolder(ObjectHolder[str]):
     @typed_operator(MesonOperator.DIV, str)
     def op_div(self, other: str) -> str:
         return (PurePath(self.held_object) / other).as_posix()
+
+    @typed_operator(MesonOperator.INDEX, int)
+    def op_index(self, other: int) -> str:
+        try:
+            return self.held_object[other]
+        except IndexError:
+            raise InvalidArguments(f'Index {other} out of bounds of string of size {len(self.held_object)}.')
 
 
 class MesonVersionString(str):

--- a/mesonbuild/interpreter/primitives/string.py
+++ b/mesonbuild/interpreter/primitives/string.py
@@ -1,0 +1,174 @@
+# Copyright 2021 The Meson development team
+# SPDX-license-identifier: Apache-2.0
+
+import re
+from pathlib import PurePath
+
+import typing as T
+
+from ...mesonlib import version_compare
+from ...interpreterbase import (
+    ObjectHolder,
+    MesonOperator,
+    FeatureNew,
+    typed_operator,
+    noKwargs,
+    noPosargs,
+    typed_pos_args,
+
+    TYPE_var,
+    TYPE_kwargs,
+
+    InvalidArguments,
+)
+
+
+if T.TYPE_CHECKING:
+    # Object holders need the actual interpreter
+    from ...interpreter import Interpreter
+
+class StringHolder(ObjectHolder[str]):
+    def __init__(self, obj: str, interpreter: 'Interpreter') -> None:
+        super().__init__(obj, interpreter)
+        self.methods.update({
+            'contains': self.contains_method,
+            'startswith': self.startswith_method,
+            'endswith': self.endswith_method,
+            'format': self.format_method,
+            'join': self.join_method,
+            'replace': self.replace_method,
+            'split': self.split_method,
+            'strip': self.strip_method,
+            'substring': self.substring_method,
+            'to_int': self.to_int_method,
+            'to_lower': self.to_lower_method,
+            'to_upper': self.to_upper_method,
+            'underscorify': self.underscorify_method,
+            'version_compare': self.version_compare_method,
+        })
+
+
+        self.trivial_operators.update({
+            # Arithmetic
+            MesonOperator.PLUS: (str, lambda x: self.held_object + x),
+
+            # Comparison
+            MesonOperator.EQUALS: (str, lambda x: self.held_object == x),
+            MesonOperator.NOT_EQUALS: (str, lambda x: self.held_object != x),
+            MesonOperator.GREATER: (str, lambda x: self.held_object > x),
+            MesonOperator.LESS: (str, lambda x: self.held_object < x),
+            MesonOperator.GREATER_EQUALS: (str, lambda x: self.held_object >= x),
+            MesonOperator.LESS_EQUALS: (str, lambda x: self.held_object <= x),
+        })
+
+        # Use actual methods for functions that require additional checks
+        self.operators.update({
+            MesonOperator.DIV: self.op_div,
+        })
+
+    def display_name(self) -> str:
+        return 'str'
+
+    @noKwargs
+    @typed_pos_args('str.contains', str)
+    def contains_method(self, args: T.Tuple[str], kwargs: TYPE_kwargs) -> bool:
+        return self.held_object.find(args[0]) >= 0
+
+    @noKwargs
+    @typed_pos_args('str.startswith', str)
+    def startswith_method(self, args: T.Tuple[str], kwargs: TYPE_kwargs) -> bool:
+        return self.held_object.startswith(args[0])
+
+    @noKwargs
+    @typed_pos_args('str.endswith', str)
+    def endswith_method(self, args: T.Tuple[str], kwargs: TYPE_kwargs) -> bool:
+        return self.held_object.endswith(args[0])
+
+    @noKwargs
+    @typed_pos_args('str.format', varargs=object)
+    def format_method(self, args: T.Tuple[T.List[object]], kwargs: TYPE_kwargs) -> str:
+        arg_strings: T.List[str] = []
+        for arg in args[0]:
+            if isinstance(arg, bool): # Python boolean is upper case.
+                arg = str(arg).lower()
+            arg_strings.append(str(arg))
+
+        def arg_replace(match: T.Match[str]) -> str:
+            idx = int(match.group(1))
+            if idx >= len(arg_strings):
+                raise InvalidArguments(f'Format placeholder @{idx}@ out of range.')
+            return arg_strings[idx]
+
+        return re.sub(r'@(\d+)@', arg_replace, self.held_object)
+
+    @noKwargs
+    @typed_pos_args('str.join', varargs=str)
+    def join_method(self, args: T.Tuple[T.List[str]], kwargs: TYPE_kwargs) -> str:
+        return self.held_object.join(args[0])
+
+    @noKwargs
+    @typed_pos_args('str.replace', str, str)
+    def replace_method(self, args: T.Tuple[str, str], kwargs: TYPE_kwargs) -> str:
+        return self.held_object.replace(args[0], args[1])
+
+    @noKwargs
+    @typed_pos_args('str.split', optargs=[str])
+    def split_method(self, args: T.Tuple[T.Optional[str]], kwargs: TYPE_kwargs) -> T.List[str]:
+        return self.held_object.split(args[0])
+
+    @noKwargs
+    @typed_pos_args('str.strip', optargs=[str])
+    def strip_method(self, args: T.Tuple[T.Optional[str]], kwargs: TYPE_kwargs) -> str:
+        return self.held_object.strip(args[0])
+
+    @noKwargs
+    @typed_pos_args('str.substring', optargs=[int, int])
+    def substring_method(self, args: T.Tuple[T.Optional[int], T.Optional[int]], kwargs: TYPE_kwargs) -> str:
+        start = args[0] if args[0] is not None else 0
+        end   = args[1] if args[1] is not None else len(self.held_object)
+        return self.held_object[start:end]
+
+    @noKwargs
+    @noPosargs
+    def to_int_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> int:
+        try:
+            return int(self.held_object)
+        except ValueError:
+            raise InvalidArguments(f'String {self.held_object!r} cannot be converted to int')
+
+    @noKwargs
+    @noPosargs
+    def to_lower_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
+        return self.held_object.lower()
+
+    @noKwargs
+    @noPosargs
+    def to_upper_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
+        return self.held_object.upper()
+
+    @noKwargs
+    @noPosargs
+    def underscorify_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
+        return re.sub(r'[^a-zA-Z0-9]', '_', self.held_object)
+
+    @noKwargs
+    @typed_pos_args('str.version_compare', str)
+    def version_compare_method(self, args: T.Tuple[str], kwargs: TYPE_kwargs) -> bool:
+        return version_compare(self.held_object, args[0])
+
+
+    @FeatureNew('/ with string arguments', '0.49.0')
+    @typed_operator(MesonOperator.DIV, str)
+    def op_div(self, other: str) -> str:
+        return (PurePath(self.held_object) / other).as_posix()
+
+
+class MesonVersionString(str):
+    pass
+
+class MesonVersionStringHolder(StringHolder):
+    @noKwargs
+    @typed_pos_args('str.version_compare', str)
+    def version_compare_method(self, args: T.Tuple[str], kwargs: TYPE_kwargs) -> bool:
+        self.interpreter.tmp_meson_version = args[0]
+        return version_compare(self.held_object, args[0])

--- a/mesonbuild/interpreterbase/__init__.py
+++ b/mesonbuild/interpreterbase/__init__.py
@@ -17,7 +17,6 @@ __all__ = [
     'MesonInterpreterObject',
     'ObjectHolder',
     'RangeHolder',
-    'MesonVersionString',
     'MutableInterpreterObject',
 
     'MesonOperator',
@@ -129,5 +128,5 @@ from .exceptions import (
 
 from .disabler import Disabler, is_disabled
 from .helpers import check_stringlist, default_resolve_key, flatten, resolve_second_level_holders
-from .interpreterbase import MesonVersionString, InterpreterBase
+from .interpreterbase import InterpreterBase
 from .operator import MesonOperator

--- a/mesonbuild/interpreterbase/__init__.py
+++ b/mesonbuild/interpreterbase/__init__.py
@@ -31,7 +31,6 @@ __all__ = [
     'ContinueRequest',
     'BreakRequest',
 
-    'check_stringlist',
     'default_resolve_key',
     'flatten',
     'resolve_second_level_holders',
@@ -127,6 +126,6 @@ from .exceptions import (
 )
 
 from .disabler import Disabler, is_disabled
-from .helpers import check_stringlist, default_resolve_key, flatten, resolve_second_level_holders
+from .helpers import default_resolve_key, flatten, resolve_second_level_holders
 from .interpreterbase import InterpreterBase
 from .operator import MesonOperator

--- a/mesonbuild/interpreterbase/_unholder.py
+++ b/mesonbuild/interpreterbase/_unholder.py
@@ -19,9 +19,7 @@ from ..mesonlib import HoldableObject, MesonBugException
 import typing as T
 
 def _unholder(obj: T.Union[TYPE_var, InterpreterObject]) -> TYPE_var:
-    if isinstance(obj, str):
-        return obj
-    elif isinstance(obj, list):
+    if isinstance(obj, list):
         return [_unholder(x) for x in obj]
     elif isinstance(obj, dict):
         return {k: _unholder(v) for k, v in obj.items()}

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -168,12 +168,18 @@ class RangeHolder(MesonInterpreterObject):
     def __init__(self, start: int, stop: int, step: int, *, subproject: str) -> None:
         super().__init__(subproject=subproject)
         self.range = range(start, stop, step)
+        self.operators.update({
+            MesonOperator.INDEX: self.op_index,
+        })
+
+    def op_index(self, other: int) -> int:
+        try:
+            return self.range[other]
+        except:
+            raise InvalidArguments(f'Index {other} out of bounds of range.')
 
     def __iter__(self) -> T.Iterator[int]:
         return iter(self.range)
-
-    def __getitem__(self, key: int) -> int:
-        return self.range[key]
 
     def __len__(self) -> int:
         return len(self.range)

--- a/mesonbuild/interpreterbase/baseobjects.py
+++ b/mesonbuild/interpreterbase/baseobjects.py
@@ -129,8 +129,8 @@ class MesonInterpreterObject(InterpreterObject):
 class MutableInterpreterObject:
     ''' Dummy class to mark the object type as mutable '''
 
-HoldableTypes = (HoldableObject, int, bool)
-TYPE_HoldableTypes = T.Union[HoldableObject, int, bool]
+HoldableTypes = (HoldableObject, int, bool, str)
+TYPE_HoldableTypes = T.Union[HoldableObject, int, bool, str]
 InterpreterObjectTypeVar = T.TypeVar('InterpreterObjectTypeVar', bound=TYPE_HoldableTypes)
 
 class ObjectHolder(InterpreterObject, T.Generic[InterpreterObjectTypeVar]):

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -16,7 +16,6 @@ from .. import mesonlib, mlog
 from .baseobjects import TV_func, TYPE_var, TYPE_kwargs
 from .disabler import Disabler
 from .exceptions import InterpreterException, InvalidArguments
-from .helpers import check_stringlist
 from .operator import MesonOperator
 from ._unholder import _unholder
 
@@ -64,8 +63,12 @@ def stringArgs(f: TV_func) -> TV_func:
     @wraps(f)
     def wrapped(*wrapped_args: T.Any, **wrapped_kwargs: T.Any) -> T.Any:
         args = get_callee_args(wrapped_args)[1]
-        assert isinstance(args, list)
-        check_stringlist(args)
+        if not isinstance(args, list):
+            mlog.debug('Not a list:', str(args))
+            raise InvalidArguments('Argument not a list.')
+        if not all(isinstance(s, str) for s in args):
+            mlog.debug('Element not a string:', str(args))
+            raise InvalidArguments('Arguments must be strings.')
         return f(*wrapped_args, **wrapped_kwargs)
     return T.cast(TV_func, wrapped)
 

--- a/mesonbuild/interpreterbase/helpers.py
+++ b/mesonbuild/interpreterbase/helpers.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .. import mesonlib, mparser, mlog
-from .exceptions import InvalidArguments, InterpreterException
+from .. import mesonlib, mparser
+from .exceptions import InterpreterException
 
 import collections.abc
 import typing as T
@@ -48,14 +48,6 @@ def resolve_second_level_holders(args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs'
             return arg.get_default_object()
         return arg
     return [resolver(x) for x in args], {k: resolver(v) for k, v in kwargs.items()}
-
-def check_stringlist(a: T.Any, msg: str = 'Arguments must be strings.') -> None:
-    if not isinstance(a, list):
-        mlog.debug('Not a list:', str(a))
-        raise InvalidArguments('Argument not a list.')
-    if not all(isinstance(s, str) for s in a):
-        mlog.debug('Element not a string:', str(a))
-        raise InvalidArguments(msg)
 
 def default_resolve_key(key: mparser.BaseNode) -> str:
     if not isinstance(key, mparser.IdNode):

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -44,7 +44,7 @@ from .exceptions import (
 
 from .decorators import FeatureNew, noKwargs
 from .disabler import Disabler, is_disabled
-from .helpers import check_stringlist, default_resolve_key, flatten, resolve_second_level_holders
+from .helpers import default_resolve_key, flatten, resolve_second_level_holders
 from .operator import MesonOperator
 from ._unholder import _unholder
 
@@ -579,11 +579,13 @@ class InterpreterBase:
         iobject = self.evaluate_statement(node.iobject)
         if isinstance(iobject, Disabler):
             return iobject
+        index = _unholder(self.evaluate_statement(node.index))
+
+        if isinstance(iobject, InterpreterObject):
+            return self._holderify(iobject.operator_call(MesonOperator.INDEX, index))
         if not hasattr(iobject, '__getitem__'):
             raise InterpreterException(
                 'Tried to index an object that doesn\'t support indexing.')
-        index = _unholder(self.evaluate_statement(node.index))
-
         if isinstance(iobject, dict):
             if not isinstance(index, str):
                 raise InterpreterException('Key is not a string')
@@ -887,7 +889,7 @@ To specify a keyword argument, use : instead of =.''')
         raise InvalidCode('Unknown variable "%s".' % varname)
 
     def is_assignable(self, value: T.Any) -> bool:
-        return isinstance(value, (InterpreterObject, str, int, list, dict))
+        return isinstance(value, (InterpreterObject, list, dict))
 
     def validate_extraction(self, buildtarget: mesonlib.HoldableObject) -> None:
         raise InterpreterException('validate_extraction is not implemented in this context (please file a bug)')

--- a/test cases/common/35 string operations/meson.build
+++ b/test cases/common/35 string operations/meson.build
@@ -61,6 +61,7 @@ assert('@0@'.format(true) == 'true', 'bool string formatting failed')
 assert(' '.join(['a', 'b', 'c']) == 'a b c', 'join() array broken')
 assert(''.join(['a', 'b', 'c']) == 'abc', 'empty join() broken')
 assert(' '.join(['a']) == 'a', 'single join broken')
+assert(' '.join(['a'], ['b', ['c']], 'd') == 'a b c d', 'varargs join broken')
 
 version_number = '1.2.8'
 

--- a/test cases/common/35 string operations/meson.build
+++ b/test cases/common/35 string operations/meson.build
@@ -1,4 +1,4 @@
-project('string formatting', 'c')
+project('string formatting', 'c', meson_version: '>=0.59.0')
 
 templ = '@0@bar@1@'
 

--- a/test cases/common/35 string operations/meson.build
+++ b/test cases/common/35 string operations/meson.build
@@ -19,6 +19,9 @@ long = 'abcde'
 prefix = 'abc'
 suffix = 'cde'
 
+assert(long[0] == 'a')
+assert(long[2] == 'c')
+
 assert(long.replace('b', 'd') == 'adcde')
 assert(long.replace('z', 'x') == long)
 assert(long.replace(prefix, suffix) == 'cdede')

--- a/test cases/common/35 string operations/test.json
+++ b/test cases/common/35 string operations/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "WARNING: Project targeting '>=0.59.0' but tried to use feature introduced in '0.60.0': str.join (varargs). List-flattening and variadic arguments"
+    }
+  ]
+}

--- a/test cases/failing/11 object arithmetic/test.json
+++ b/test cases/failing/11 object arithmetic/test.json
@@ -2,7 +2,7 @@
   "stdout": [
     {
       "match": "re",
-      "line": "test cases/failing/11 object arithmetic/meson\\.build:3:0: ERROR: Invalid use of addition: .*"
+      "line": "test cases/failing/11 object arithmetic/meson\\.build:3:0: ERROR: The `\\+` of str does not accept objects of type MesonMain .*"
     }
   ]
 }

--- a/test cases/failing/12 string arithmetic/test.json
+++ b/test cases/failing/12 string arithmetic/test.json
@@ -1,8 +1,7 @@
 {
   "stdout": [
     {
-      "match": "re",
-      "line": "test cases/failing/12 string arithmetic/meson\\.build:3:0: ERROR: Invalid use of addition: .*"
+      "line": "test cases/failing/12 string arithmetic/meson.build:3:0: ERROR: The `+` of str does not accept objects of type int (3)"
     }
   ]
 }


### PR DESCRIPTION
Another commit in my quest to rid InterpreterBase from all higher
level object processing logic.

Additionally, there is a a logic change here, since `str.join` now
uses varargs and can now accept more than one argument (and supports
list flattening).