### PR TITLE
Support for appleframeworks with GCC and Intel

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -1177,9 +1177,7 @@ class CLikeCompiler(Compiler):
         Finds the framework with the specified name, and returns link args for
         the same or returns None when the framework is not found.
         '''
-        # TODO: maybe this belongs in clang? also, should probably check for macOS?
-        if self.id != 'clang':
-            raise mesonlib.MesonException('Cannot find frameworks with non-clang compiler')
+        # TODO: should probably check for macOS?
         return self._find_framework_impl(name, env, extra_dirs, allow_system)
 
     def get_crt_compile_args(self, crt_val: str, buildtype: str) -> T.List[str]:


### PR DESCRIPTION
Modern GCC and ICC support the `-framework` flag. Without this change, configuration results in:

```
ERROR: Dependency "appleframeworks" not found, tried framework
```

Fixes #8792
Fixes #8733