### PR TITLE
Improve WSL detection

### DIFF
--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -636,7 +636,7 @@ def is_windows() -> bool:
     return platname == 'windows'
 
 def is_wsl() -> bool:
-    return is_linux() and 'microsoft' in platform.version().lower()
+    return is_linux() and 'microsoft' in platform.release().lower()
 
 def is_cygwin() -> bool:
     return sys.platform == 'cygwin'


### PR DESCRIPTION
WSL 2 removes the "Microsoft" from `platform.version` but leaves it inside `platform.release`. This lets us detect both types of WSL without issue.

Followup from #9208