### PR TITLE
log a more informative error when wrap-git subprojects cannot be downloaded

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -402,7 +402,7 @@ class Resolver:
 
     def get_git(self) -> None:
         if not GIT:
-            raise WrapException('Git program not found.')
+            raise WrapException(f'Git program not found, cannot download {self.packagename}.wrap via git.')
         revno = self.wrap.get('revision')
         is_shallow = False
         depth_option = []    # type: T.List[str]


### PR DESCRIPTION
"ERROR: Git program not found" is both highly true, and somewhat inscrutable. Sure, looking at the line number you can basically figure out that subproject('something') must somehow need git to operate, but that may not be immediately obvious.

Make mention of the fact that it is needed to "download foo.wrap".

Fixes #7764