### PR TITLE
Allow as_link_whole() on external dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 *.icns binary
 data/shell-completions/bash/meson linguist-language=Shell
 data/shell-completions/zsh/_meson linguist-language=Shell
+*.a binary

--- a/docs/markdown/snippets/link_whole_external_dep.md
+++ b/docs/markdown/snippets/link_whole_external_dep.md
@@ -1,0 +1,5 @@
+## Allow as_link_whole() on external dependencies
+
+It returns a copy of the dependency object with `*.a` arguments replaced with
+the list of `.o` files they contain. This allows to merge together two static
+libraries.

--- a/docs/yaml/objects/dep.yaml
+++ b/docs/yaml/objects/dep.yaml
@@ -101,12 +101,15 @@ methods:
     returns: dep
     since: 0.56.0
     description: |
-      Only dependencies created with [[declare_dependency]],
-      returns a copy of the dependency object with all
+      - For dependencies created with [[declare_dependency]]:
+      Returns a copy of the dependency object with all
       link_with arguments changed to link_whole. This is useful for example for
       fallback dependency from a subproject built with `default_library=static`.
       Note that all `link_with` objects must be static libraries otherwise an error
       will be raised when trying to `link_whole` a shared library.
+      - *(Since 1.11.0)* For external dependencies, returns a copy of the dependency
+      object with `*.a` arguments replaced with the list of `.o` files they contain.
+      This allows to merge together two static libraries.
 
   - name: partial_dependency
     returns: dep

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1506,9 +1506,9 @@ class BuildTarget(Target):
             if isinstance(dep, dependencies.InternalDependency):
                 # Those parts that are internal.
                 self.process_sourcelist(dep.sources)
+                self.process_objectlist(dep.objects)
                 self.extra_files.extend(f for f in dep.extra_files if f not in self.extra_files)
                 self.add_include_dirs(dep.include_directories, dep.get_include_type())
-                self.objects.extend(dep.objects)
                 self.link_targets.extend(dep.libraries)
                 self.link_whole_targets.extend(dep.whole_libraries)
                 if dep.get_compile_args() or dep.get_link_args():
@@ -1526,6 +1526,7 @@ class BuildTarget(Target):
                 if dep not in self.external_deps:
                     self.external_deps.append(dep)
                     self.process_sourcelist(dep.get_sources())
+                    self.process_objectlist(dep.objects)
                 self.add_deps(dep.ext_deps)
 
             dep_d_features = dep.d_features

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -14,6 +14,7 @@ import itertools
 import typing as T
 import uuid
 from enum import Enum
+from dataclasses import dataclass
 
 from .. import mlog, mesonlib
 from ..compilers import clib_langs
@@ -129,6 +130,12 @@ class DependencyMethods(Enum):
 
 
 DependencyTypeName = T.NewType('DependencyTypeName', str)
+
+
+@dataclass
+class ExtractArchives:
+    archive_filename: str
+    objects: T.List[str]
 
 
 class Dependency(HoldableObject):
@@ -303,6 +310,26 @@ class Dependency(HoldableObject):
         """Used as base case for internal_dependency"""
         return self
 
+    def generate_link_whole_dependency(self) -> T.Tuple[Dependency, T.List[ExtractArchives]]:
+        ''' Return a copy of this dependency suited for link-whole
+        Removes all external static libraries (*.a, *.lib) this dependency links
+        with, and return them as a list of ExtractArchives.
+        '''
+        from ..utils import ar
+
+        new_dep = copy.copy(self)
+        new_dep.link_args = []
+        archives: T.List[ExtractArchives] = []
+        for arg in self.link_args:
+            if arg.endswith('.a'):
+                objects = ar.extract(arg, dry_run=True)
+                if objects:
+                    t = ExtractArchives(arg, objects)
+                    archives.append(t)
+                    continue
+            new_dep.link_args.append(arg)
+        return new_dep, archives
+
 class InternalDependency(Dependency):
 
     type_name = DependencyTypeName('internal')
@@ -389,22 +416,21 @@ class InternalDependency(Dependency):
             return val
         raise DependencyException(f'Could not get an internal variable and no default provided for {self!r}')
 
-    def generate_link_whole_dependency(self) -> Dependency:
+    def generate_link_whole_dependency(self) -> T.Tuple[Dependency, T.List[ExtractArchives]]:
         from ..build import SharedLibrary, CustomTarget, CustomTargetIndex
-        new_dep = copy.deepcopy(self)
-        for x in new_dep.libraries:
+        new_dep, archives = super().generate_link_whole_dependency()
+        assert isinstance(new_dep, InternalDependency) # For mypy
+        new_dep.libraries = []
+        new_dep.whole_libraries = self.whole_libraries.copy()
+        for x in self.libraries:
             if isinstance(x, SharedLibrary):
                 raise MesonException('Cannot convert a dependency to link_whole when it contains a '
                                      'SharedLibrary')
             elif isinstance(x, (CustomTarget, CustomTargetIndex)) and x.links_dynamically():
                 raise MesonException('Cannot convert a dependency to link_whole when it contains a '
                                      'CustomTarget or CustomTargetIndex which is a shared library')
-
-        # Mypy doesn't understand that the above is a TypeGuard
-        new_dep.whole_libraries += T.cast('T.List[T.Union[StaticLibrary, CustomTarget, CustomTargetIndex]]',
-                                          new_dep.libraries)
-        new_dep.libraries = []
-        return new_dep
+            new_dep.whole_libraries.append(x)
+        return new_dep, archives
 
     def get_as_static(self, recursive: bool) -> InternalDependency:
         new_dep = copy.copy(self)

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -29,7 +29,8 @@ if T.TYPE_CHECKING:
     from ..interpreterbase import FeatureCheckBase
     from ..build import (
         CustomTarget, IncludeDirs, CustomTargetIndex, LibTypes,
-        StaticLibrary, StructuredSources, ExtractedObjects, GeneratedTypes
+        StaticLibrary, StructuredSources, ExtractedObjects, GeneratedTypes,
+        GeneratedList
     )
     from ..interpreter.type_checking import PkgConfigDefineType
 
@@ -155,6 +156,7 @@ class Dependency(HoldableObject):
         self.featurechecks: T.List['FeatureCheckBase'] = []
         self.feature_since: T.Optional[T.Tuple[str, str]] = None
         self.meson_variables: T.List[str] = []
+        self.objects: T.List[T.Union[str, mesonlib.File, ExtractedObjects, CustomTarget, CustomTargetIndex, GeneratedList]] = []
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Dependency):
@@ -327,7 +329,7 @@ class InternalDependency(Dependency):
         self.extra_files = list(extra_files)
         self.ext_deps = ext_deps
         self.variables = variables
-        self.objects = objects
+        self.objects.extend(objects)
         if d_module_versions:
             self.d_features['versions'] = d_module_versions
         if d_import_dirs:

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -603,8 +603,25 @@ class DependencyHolder(ObjectHolder[Dependency]):
     @InterpreterObject.method('as_link_whole')
     def as_link_whole_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> Dependency:
         if not isinstance(self.held_object, InternalDependency):
-            raise InterpreterException('as_link_whole method is only supported on declare_dependency() objects')
-        new_dep = self.held_object.generate_link_whole_dependency()
+            FeatureNew('as_link_whole on external dependency', '1.11.0').use(self.subproject)
+        new_dep, archives = self.held_object.generate_link_whole_dependency()
+        new_dep.objects = new_dep.objects.copy()
+        for a in archives:
+            basename = os.path.basename(a.archive_filename)
+            outdir = os.path.join(self.interpreter.environment.get_scratch_dir(), f'{basename}.p')
+            cmd = self.interpreter.environment.get_build_command() + [
+                '--internal', 'ar', '--outdir', outdir, a.archive_filename,
+            ]
+            outputs = [os.path.join(outdir, i) for i in a.objects]
+            t = build.CustomTarget(f'{basename} objects',
+                                   self.interpreter.subdir,
+                                   self.interpreter.subproject,
+                                   self.interpreter.environment,
+                                   cmd,
+                                   [a.archive_filename],
+                                   outputs)
+            self.interpreter.add_target(t.name, t)
+            new_dep.objects.append(t)
         return new_dep
 
     @FeatureNew('dependency.as_static', '1.6.0')

--- a/mesonbuild/scripts/ar.py
+++ b/mesonbuild/scripts/ar.py
@@ -1,0 +1,20 @@
+import argparse
+import typing as T
+
+from ..utils import ar
+
+def run(args: T.List[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Only print file names')
+    parser.add_argument('--outdir', default='.',
+                        help='Directory where to extract archive')
+    parser.add_argument('filename',
+                        help='Path to static library')
+    options = parser.parse_args(args)
+
+    files = ar.extract(options.filename, options.outdir, options.dry_run)
+    if options.dry_run:
+        print('\n'.join(files))
+
+    return 0

--- a/mesonbuild/utils/ar.py
+++ b/mesonbuild/utils/ar.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+import typing as T
+
+from .core import MesonException
+
+if T.TYPE_CHECKING:
+    from io import BufferedReader
+
+MAGIC = b'!<arch>\n'
+HEADER_SIZE = 60
+
+def _read_header(f: 'BufferedReader') -> T.Tuple[bytes, int]:
+    header = f.read(HEADER_SIZE)
+    if len(header) < HEADER_SIZE:
+        return None, None
+    file_id = header[0:16].rstrip()
+    file_size = int(header[48:58])
+    return file_id, file_size
+
+def _read_data(f: 'BufferedReader', file_size: int) -> bytes:
+    file_data = f.read(file_size)
+    if file_size % 2 == 1:
+        f.read(1)
+    return file_data
+
+def _skip_data(f: 'BufferedReader', file_size: int) -> None:
+    if file_size % 2 == 1:
+        file_size += 1
+    f.seek(file_size, 1)
+
+def extract(archive_filename: str, outdir: str = '.', dry_run: bool = False) -> T.List[str]:
+    with open(archive_filename, 'rb') as f:
+        if f.read(len(MAGIC)) != MAGIC:
+            raise MesonException(f'{archive_filename} does not seems to be a static library')
+        outpath = Path(outdir)
+        if not dry_run:
+            outpath.mkdir(exist_ok=True)
+        files = []
+        file_id_table = {}
+        unique_id = 0
+        while True:
+            file_id, file_size = _read_header(f)
+            if file_id is None:
+                break
+            elif file_id == b'/':
+                # Skip symbols table.
+                _skip_data(f, file_size)
+                continue
+            elif file_id == b'//':
+                # GNU variant: extended filenames table.
+                file_data = _read_data(f, file_size)
+                start = 0
+                for i, c in enumerate(file_data):
+                    if c == ord('\n'):
+                        file_id_table[start] = file_data[start:i]
+                        start = i + 1
+                continue
+            elif file_id.startswith(b'/'):
+                # GNU variant: file_id is an index into the table.
+                idx = int(file_id[1:])
+                file_id = file_id_table[idx]
+            elif file_id.startswith(b'#1/'):
+                # BSD variant: extended filename is prepended to the file data.
+                id_len = int(file_id[3:])
+                file_id = f.read(id_len).rstrip(b'\x00')
+                file_size -= id_len
+
+            if file_id[-1] == ord('/'):
+                file_id = file_id[:-1]
+
+            if file_id.startswith(b'__.SYMDEF'):
+                # BSD variant: Skip symbols table.
+                _skip_data(f, file_size)
+                continue
+
+            fname = f'{unique_id}-{file_id.decode()}'
+            unique_id += 1
+            files.append(fname)
+
+            if dry_run:
+                _skip_data(f, file_size)
+            else:
+                file_data = _read_data(f, file_size)
+                output = outpath / fname
+                with output.open('wb') as ofile:
+                    ofile.write(file_data)
+
+        return files

--- a/test cases/unit/111 extract static library/meson.build
+++ b/test cases/unit/111 extract static library/meson.build
@@ -1,0 +1,15 @@
+project('extract archives', 'c')
+
+glib_dep = dependency('glib-2.0',
+  static: true,
+  required: false,
+)
+
+if not glib_dep.found()
+  error('MESON_SKIP_TEST glib static library is needed')
+endif
+
+both_libraries('glib-wrapper',
+  dependencies: glib_dep.as_link_whole(),
+  install: true,
+)

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -5597,3 +5597,27 @@ class AllPlatformTests(BasePlatformTests):
         output = entry['output']
 
         self.build(output, extra_args=['-j1'])
+
+    def test_extract_static_library(self) -> None:
+        testdir = os.path.join(self.unit_test_dir, '111 extract static library')
+        o = self.init(testdir)
+        if "Static library 'glib-2.0' not found" in o:
+            self.skipTest('Static glib-2.0 not found')
+
+        # Libraries should not be extracted at configure time
+        privatepath = Path(self.privatedir)
+        self.assertFalse(set(privatepath.glob('*.a.p')))
+
+        # Depending on which CI machine this is running, there could be different
+        # set of static libraries, glib and its dependencies.
+        self.build()
+        objects = set(privatepath.glob('*.a.p/*.o'))
+        self.assertTrue(objects)
+
+        # Check that the shared library exposes symbols from glib even if we don't use them.
+        o = self._run(['objdump', '-TC', os.path.join(self.builddir, 'libglib-wrapper.so')])
+        self.assertIn('g_hash_table_new', o)
+
+        # Check that the static library contains all objects we extracted
+        o = self._run(['ar', 't', os.path.join(self.builddir, 'libglib-wrapper.a')])
+        self.assertEqual(set(o.split()), {o.name for o in objects})


### PR DESCRIPTION
When a static library link whole on an external static library we need
to extract the archive and use object files it contains instead.

Fixes: #5797 