### PR TITLE
CMake: Implement support for keywords in *_LIBRARIES variables.

### DIFF
--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -15,7 +15,7 @@
 from .base import ExternalDependency, DependencyException, DependencyTypeName
 from ..mesonlib import is_windows, MesonException, OptionKey, PerMachine, stringlistify, extract_as_list
 from ..mesondata import mesondata
-from ..cmake import CMakeExecutor, CMakeTraceParser, CMakeException, CMakeToolchain, CMakeExecScope, check_cmake_args
+from ..cmake import CMakeExecutor, CMakeTraceParser, CMakeException, CMakeToolchain, CMakeExecScope, check_cmake_args, CMakeTarget
 from .. import mlog
 from pathlib import Path
 import functools
@@ -446,6 +446,37 @@ class CMakeDependency(ExternalDependency):
 
         # Failed to guess a target --> try the old-style method
         if len(modules) == 0:
+            # Warn when there might be matching imported targets but no automatic match was used
+            partial_modules: T.List[CMakeTarget] = []
+            for k, v in self.traceparser.targets.items():
+                tg = k.lower()
+                lname = name.lower()
+                if tg.startswith(f'{lname}::'):
+                    partial_modules += [v]
+            if partial_modules:
+                mlog.warning(textwrap.dedent(f'''\
+                    Could not find and exact match for the CMake dependency {name}.
+
+                    However, Meson found the following partial matches:
+
+                        {[x.name for x in partial_modules]}
+
+                    Using imported is recommended, since this approach is less error prone
+                    and better supported by Meson. Consider explicitly specifying one of
+                    these in the dependency call with:
+
+                        dependency('{name}', modules: ['{name}::<name>', ...])
+
+                    Meson will now continue to use the old-style {name}_LIBRARIES CMake
+                    variables to extract the dependency information since no explicit
+                    target is currently specified.
+
+                '''))
+                mlog.debug('More info for the partial match targets:')
+                for tgt in partial_modules:
+                    mlog.debug(tgt)
+
+
             incDirs = [x for x in self.traceparser.get_cmake_var('PACKAGE_INCLUDE_DIRS') if x]
             defs = [x for x in self.traceparser.get_cmake_var('PACKAGE_DEFINITIONS') if x]
             libs = [x for x in self.traceparser.get_cmake_var('PACKAGE_LIBRARIES') if x]

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -433,6 +433,18 @@ class CMakeDependency(ExternalDependency):
         modules = self._map_module_list(modules, components)
         autodetected_module_list = False
 
+        # Check if we need a DEBUG or RELEASE CMake dependencies
+        is_debug = False
+        if OptionKey('b_vscrt') in self.env.coredata.options:
+            is_debug = self.env.coredata.get_option(OptionKey('buildtype')) == 'debug'
+            if self.env.coredata.options[OptionKey('b_vscrt')].value in {'mdd', 'mtd'}:
+                is_debug = True
+        else:
+            # Don't directly assign to is_debug to make mypy happy
+            debug_opt = self.env.coredata.get_option(OptionKey('debug'))
+            assert isinstance(debug_opt, bool)
+            is_debug = debug_opt
+
         # Try guessing a CMake target if none is provided
         if len(modules) == 0:
             for i in self.traceparser.targets:
@@ -479,7 +491,26 @@ class CMakeDependency(ExternalDependency):
 
             incDirs = [x for x in self.traceparser.get_cmake_var('PACKAGE_INCLUDE_DIRS') if x]
             defs = [x for x in self.traceparser.get_cmake_var('PACKAGE_DEFINITIONS') if x]
-            libs = [x for x in self.traceparser.get_cmake_var('PACKAGE_LIBRARIES') if x]
+            libs_raw = [x for x in self.traceparser.get_cmake_var('PACKAGE_LIBRARIES') if x]
+
+            # CMake has a "fun" API, where certain keywords describing
+            # configurations can be in the *_LIBRARIES vraiables. See:
+            # - https://github.com/mesonbuild/meson/issues/9197
+            # - https://gitlab.freedesktop.org/libnice/libnice/-/issues/140
+            # - https://cmake.org/cmake/help/latest/command/target_link_libraries.html#overview  (the last point in the section)
+            libs: T.List[str] = []
+            cfg_matches = True
+            cm_tag_map = {'debug': is_debug, 'optimized': not is_debug, 'general': True}
+            for i in libs_raw:
+                if i.lower() in cm_tag_map:
+                    cfg_matches = cm_tag_map[i.lower()]
+                    continue
+                if cfg_matches:
+                    libs += [i]
+                # According to the CMake docs, a keyword only works for the
+                # directly the following item and all items without a keyword
+                # are implizitly `general`
+                cfg_matches = True
 
             # Try to use old style variables if no module is specified
             if len(libs) > 0:
@@ -545,15 +576,6 @@ class CMakeDependency(ExternalDependency):
                     cfgs = [x for x in tgt.properties['IMPORTED_CONFIGURATIONS'] if x]
                     cfg = cfgs[0]
 
-                if OptionKey('b_vscrt') in self.env.coredata.options:
-                    is_debug = self.env.coredata.get_option(OptionKey('buildtype')) == 'debug'
-                    if self.env.coredata.options[OptionKey('b_vscrt')].value in {'mdd', 'mtd'}:
-                        is_debug = True
-                else:
-                    # Don't directly assign to is_debug to make mypy happy
-                    debug_opt = self.env.coredata.get_option(OptionKey('debug'))
-                    assert isinstance(debug_opt, bool)
-                    is_debug = debug_opt
                 if is_debug:
                     if 'DEBUG' in cfgs:
                         cfg = 'DEBUG'

--- a/test cases/linuxlike/13 cmake dependency/cmake_fake1/cmMesonTestF1Config.cmake
+++ b/test cases/linuxlike/13 cmake dependency/cmake_fake1/cmMesonTestF1Config.cmake
@@ -4,6 +4,8 @@ if(ZLIB_FOUND OR ZLIB_Found)
   set(cmMesonTestF1_FOUND        ON)
   set(cmMesonTestF1_LIBRARIES    ${ZLIB_LIBRARY})
   set(cmMesonTestF1_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR})
+
+  add_library(CMMesonTESTf1::evil_non_standard_trget UNKNOWN IMPORTED)
 else()
   set(cmMesonTestF1_FOUND       OFF)
 endif()

--- a/test cases/linuxlike/13 cmake dependency/cmake_fake1/cmMesonTestF1Config.cmake
+++ b/test cases/linuxlike/13 cmake dependency/cmake_fake1/cmMesonTestF1Config.cmake
@@ -2,7 +2,7 @@ find_package(ZLIB)
 
 if(ZLIB_FOUND OR ZLIB_Found)
   set(cmMesonTestF1_FOUND        ON)
-  set(cmMesonTestF1_LIBRARIES    ${ZLIB_LIBRARY})
+  set(cmMesonTestF1_LIBRARIES    general ${ZLIB_LIBRARY})
   set(cmMesonTestF1_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR})
 
   add_library(CMMesonTESTf1::evil_non_standard_trget UNKNOWN IMPORTED)

--- a/test cases/linuxlike/13 cmake dependency/meson.build
+++ b/test cases/linuxlike/13 cmake dependency/meson.build
@@ -48,6 +48,10 @@ depPrefEnv1 = dependency('cmMesonTestF1', required : true, method : 'cmake')
 depPrefEnv2 = dependency('cmMesonTestF2', required : true, method : 'cmake')
 depPrefEnv3 = dependency('cmMesonTestF3', required : true, method : 'cmake')
 
+# Try to actually link with depPrefEnv1, since we are doing "fun" stuff there
+exe3 = executable('zlibprog3', 'prog.c', dependencies : depPrefEnv1)
+test('zlibtest3', exe3)
+
 # Try to find a dependency with a custom CMake module
 
 depm1 = dependency('SomethingLikeZLIB', required : true, components : 'required_comp',   method : 'cmake', cmake_module_path : 'cmake')

--- a/test cases/linuxlike/13 cmake dependency/test.json
+++ b/test cases/linuxlike/13 cmake dependency/test.json
@@ -2,5 +2,13 @@
   "env": {
     "CMAKE_PREFIX_PATH": "@ROOT@/cmake_fake1;@ROOT@/cmake_fake2:@ROOT@/cmake_pref_env",
     "PATH": "@ROOT@/cmake_fake3/bin:@PATH@"
-  }
+  },
+  "stdout": [
+    {
+      "line": "WARNING: Could not find and exact match for the CMake dependency cmMesonTestF1."
+    },
+    {
+      "line": "    ['CMMesonTESTf1::evil_non_standard_trget']"
+    }
+  ]
 }


### PR DESCRIPTION
CMakes `target_link_libraries()` supports certain keywords to only enable specific libraries for specific CMake configurations. We now try our best to replicate this for Meson dependencies.

Additionally, a warning is printed if the old fallback variables are used instead of an imported target.

This is not a regression but a bug fix. However, it should still be good for 0.59.2. Feel free to remove the milestone if there are any concerns.

Fixes:
- https://github.com/mesonbuild/meson/issues/9197
- https://gitlab.freedesktop.org/libnice/libnice/-/issues/140