### PR TITLE
Lookup readelf in Environment and use it in Ninja backend

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -50,6 +50,7 @@ from .backends import CleanTrees
 from ..build import GeneratedList, InvalidArguments, ExtractedObjects
 from ..interpreter import Interpreter
 from ..mesonmain import need_setup_vsenv
+from ..programs import ExternalProgram
 
 if T.TYPE_CHECKING:
     from .._typing import ImmutableListProtocol
@@ -1993,6 +1994,9 @@ class NinjaBackend(backends.Backend):
              '$in',
              '$IMPLIB',
              '$out']
+        readelf_cmd = ExternalProgram.from_bin_list(self.environment, MachineChoice.BUILD, 'readelf')
+        if readelf_cmd.found():
+            args.append('--readelf="{}"'.format(readelf_cmd.get_path()))
         symrule = 'SHSYM'
         symcmd = args + ['$CROSS']
         syndesc = 'Generating symbol file $out'


### PR DESCRIPTION
### Description

By configuring a development environment which has `readelf` with a different name (`x86_64-conda-linux-gnu-readelf`), I am experiencing the following warning:

```
WARNING: ['readelf'] not found. Relinking will always happen on source changes.
```

But when I informed Meson of the different name via a native file (which I also use to specify the C++ compiler), that had no effect. I talked about this in the Matrix chat and received a suggestion to simply add a CLI argument to `symbolextractor.py` to override the `readelf` command. So here it is.

### Changes

1. added a `--readelf` argument to the CLI of `symbolextractor.py`
    - if that's specified, it fills in a global dictionary, `TOOL_CMD`, which is used in `get_tool`
1. modified `get_tool` to always prefer tool commands already in the global dict `TOOL_CMD`
    - that acts both as an override and as a cache for previously looked-up tools. I did this because it felt like a missed opportunity if I didn't, since it was a really small step from what I had done
    - if the tool is not found in `TOOL_CMD`, look for it in `os.environ` as before
    - always save the result in `TOOL_CMD` to avoid future environment lookups and calls to `shlex.split`
1. in the Ninja backend, lookup `readelf` in `Environment` to pass it to `symbolextractor.py`

### Notes

- PR in draft to allow for early feedback

- I was told to not generalize my solution, so I only added the option for `readelf`. However, it's _kinda generic_ in code because of the `TOOL_CMD` dictionary. I did that because it felt very weird to check _specifically_ for `readelf` in `get_tool`
    - **EDIT:** so now that `readelf` is found, `nm` is not :grimacing: I believe that's because `gnu_syms` uses that too, and only when `readelf` is found (otherwise it falls back early to `dummy_syms`)

- Obviously, feel free to tell me to implement this in another way, or remove this caching thing XD

- I'm not sure how I should test what I've done :sweat_smile: where should I add tests for the changes this PR introduces?