### PR TITLE
Add relative path support for native/crossfiles

### DIFF
--- a/docs/markdown/Machine-files.md
+++ b/docs/markdown/Machine-files.md
@@ -181,7 +181,7 @@ Or must be defined with their absolute path.
 c = '/opt/toolchain/bin/gcc'
 ```
 
-*New in 0.60.0* A further option is to define the binaries relative
+*New in 0.61.0* A further option is to define the binaries relative
 to the machine file. If the following machine file is located 
 under `/my_project/toolchain` the entry for `c` will be extended 
 to `/my_project/toolchain/bin/gcc`.

--- a/docs/markdown/Machine-files.md
+++ b/docs/markdown/Machine-files.md
@@ -168,6 +168,28 @@ strip = '/usr/i586-mingw32msvc/bin/strip'
 pkgconfig = '/usr/bin/i586-mingw32msvc-pkg-config'
 ```
 
+The binaries defined in the machine file must either be accessible 
+through the PATH variable.
+
+```ini
+c = 'gcc'
+```
+
+Or must be defined with their absolute path.
+
+```ini
+c = '/opt/toolchain/bin/gcc'
+```
+
+*New in 0.60.0* A further option is to define the binaries relative
+to the machine file. If the following machine file is located 
+under `/my_project/toolchain` the entry for `c` will be extended 
+to `/my_project/toolchain/bin/gcc`.
+
+```ini
+c = 'bin/gcc'
+```
+
 An incomplete list of internally used programs that can be overridden
 here is:
 

--- a/docs/markdown/snippets/relative_path_within_native_and_crossfiles.md
+++ b/docs/markdown/snippets/relative_path_within_native_and_crossfiles.md
@@ -1,0 +1,5 @@
+## Relative paths are supported within native and cross files
+
+Support for relative paths within native and cross files has been added. 
+This reduces the initial effort when projects include the toolchain 
+within the repository.

--- a/docs/markdown/snippets/relative_path_within_native_and_crossfiles.md
+++ b/docs/markdown/snippets/relative_path_within_native_and_crossfiles.md
@@ -1,5 +1,11 @@
 ## Relative paths are supported within native and cross files
 
-Support for relative paths within native and cross files has been added. 
-This reduces the initial effort when projects include the toolchain 
-within the repository.
+The binaries specified in the machine file can now be defined
+by using their relative path in relation to the machine file
+If the following machine file is located under 
+`/my_project/toolchain` the entry for `c` will be extended 
+to `/my_project/toolchain/bin/gcc`.
+
+```ini
+c = 'bin/gcc'
+```

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -968,7 +968,7 @@ class MachineFileParser():
                         f'Invalid type {res!r} for entry {entry!r} in machine file')
                 res = listify(res)
                 if self._is_binary_with_relative_path(res):
-                    res[0] = os.path.join(os.path.dirname(fname), res[0])            
+                    res[0] = os.path.normpath(os.path.join(os.path.dirname(fname), res[0]))
             
             section[entry] = res
             self.scope[entry] = res

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -961,11 +961,15 @@ class MachineFileParser():
                 raise EnvironmentException(f'Malformed value in machine file variable {entry!r}.')
             except KeyError as e:
                 raise EnvironmentException(f'Undefined constant {e.args[0]!r} in machine file variable {entry!r}.')
-                        
+
             if s == 'binaries':
-                if not isinstance(res, (list, str)):
-                    raise MesonException(
-                        f'Invalid type {res!r} for entry {entry!r} in machine file')
+                if isinstance(res, list):
+                    for element in res:
+                        if not isinstance(element, str):
+                            raise EnvironmentException(f'Invalid type {res!r} for entry {entry!r} in machine file')        
+                elif not isinstance(res, str):
+                    raise EnvironmentException(f'Invalid type {res!r} for entry {entry!r} in machine file')
+                
                 res = listify(res)
                 if self._is_binary_with_relative_path(res):
                     res[0] = os.path.normpath(os.path.join(os.path.dirname(fname), res[0]))

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass
 import subprocess
 import typing as T
 from enum import Enum
-import os
 
 from . import mesonlib
 from .mesonlib import EnvironmentException, HoldableObject

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 import subprocess
 import typing as T
 from enum import Enum
+import os
 
 from . import mesonlib
 from .mesonlib import EnvironmentException, HoldableObject

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -389,7 +389,7 @@ class BinaryTable:
                 command = self._rel2abs_path(command)
                 self.binaries[name] = mesonlib.listify(command)
 
-    def _rel2abs_path(self, command):
+    def _rel2abs_path(self, command: T.Union[str, T.List[str]]) -> T.Union[str, T.List[str]]:
         if command:
             if isinstance(command, list):
                 binary = command[0]

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -385,7 +385,24 @@ class BinaryTable:
                 if not isinstance(command, (list, str)):
                     raise mesonlib.MesonException(
                         f'Invalid type {command!r} for entry {name!r} in cross file')
+                command = self._rel2abs_path(command)
                 self.binaries[name] = mesonlib.listify(command)
+
+    def _rel2abs_path(self, command):
+        if command:
+            if isinstance(command, list):
+                binary = command[0]
+            else:
+                binary = command
+
+            if os.path.dirname(binary):
+                binary = os.path.abspath(binary)
+                if isinstance(command, list):
+                    command[0] = binary
+                else:
+                    command = binary
+
+        return command
 
     @staticmethod
     def detect_ccache() -> T.List[str]:

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -386,23 +386,13 @@ class BinaryTable:
                 if not isinstance(command, (list, str)):
                     raise mesonlib.MesonException(
                         f'Invalid type {command!r} for entry {name!r} in cross file')
-                command = self._rel2abs_path(command)
-                self.binaries[name] = mesonlib.listify(command)
+                self.binaries[name] = self._rel2abs_path(mesonlib.listify(command))
 
-    def _rel2abs_path(self, command: T.Union[str, T.List[str]]) -> T.Union[str, T.List[str]]:
+    def _rel2abs_path(self, command: T.List[str]) -> T.List[str]:
         if command:
-            if isinstance(command, list):
-                binary = command[0]
-            else:
-                binary = command
-
+            binary = command[0]
             if os.path.dirname(binary):
-                binary = os.path.abspath(binary)
-                if isinstance(command, list):
-                    command[0] = binary
-                else:
-                    command = binary
-
+                command[0] = os.path.abspath(binary)        
         return command
 
     @staticmethod

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -378,22 +378,12 @@ class BinaryTable:
 
     def __init__(
             self,
-            binaries: T.Optional[T.Dict[str, T.Union[str, T.List[str]]]] = None,
+            binaries: T.Optional[T.Dict[str, T.List[str]]] = None,
     ):
         self.binaries: T.Dict[str, T.List[str]] = {}
         if binaries:
             for name, command in binaries.items():
-                if not isinstance(command, (list, str)):
-                    raise mesonlib.MesonException(
-                        f'Invalid type {command!r} for entry {name!r} in cross file')
-                self.binaries[name] = self._rel2abs_path(mesonlib.listify(command))
-
-    def _rel2abs_path(self, command: T.List[str]) -> T.List[str]:
-        if command:
-            binary = command[0]
-            if os.path.dirname(binary):
-                command[0] = os.path.abspath(binary)        
-        return command
+                self.binaries[name] = command
 
     @staticmethod
     def detect_ccache() -> T.List[str]:

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4616,3 +4616,28 @@ class AllPlatformTests(BasePlatformTests):
                 self.assertEqual(bt.binaries['c'], ['X:\\opt\\toolchain\\bin\\gcc'])
             else:
                 self.assertEqual(bt.binaries['c'], ['/opt/toolchain/bin/gcc'])
+
+    def test_invalid_types_for_machinefile_binary(self):
+        # direct assignment of a boolean to binary entry should raise an exception
+        with self.assertRaises(EnvironmentException) as cm:
+            with temp_filename() as crossfile:
+                with open(crossfile, 'w', encoding='utf-8') as f:
+                    f.write(textwrap.dedent(
+                        '''
+                        [binaries]
+                        c = false
+                        '''))
+                _ = mesonbuild.coredata.parse_machine_files([crossfile])
+        self.assertEqual(str(cm.exception), 'Invalid type False for entry \'c\' in machine file')
+        
+        # boolean within a list assigned to a binary entry should raise an exception
+        with self.assertRaises(EnvironmentException) as cm:
+            with temp_filename() as crossfile:
+                with open(crossfile, 'w', encoding='utf-8') as f:
+                    f.write(textwrap.dedent(
+                        '''
+                        [binaries]
+                        c = [false]
+                        '''))
+                _ = mesonbuild.coredata.parse_machine_files([crossfile])
+        self.assertEqual(str(cm.exception), 'Invalid type [False] for entry \'c\' in machine file')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4579,7 +4579,7 @@ class AllPlatformTests(BasePlatformTests):
 
             config = mesonbuild.coredata.parse_machine_files(crossfile)
             bt = mesonbuild.envconfig.BinaryTable(config.get('binaries', {}))
-            self.assertEqual(bt.binaries['c'], [os.path.abspath('toolchain/gcc')])
+            self.assertEqual(bt.binaries['c'], [os.path.normpath(os.path.join(self.src_root, 'toolchain/gcc'))])
 
         # A binary entry without a path shouldn't be altered.
         with temp_filename() as crossfile:
@@ -4597,12 +4597,23 @@ class AllPlatformTests(BasePlatformTests):
         # A binary entry with an absolute path shouldn't be altered.
         with temp_filename() as crossfile:
             with open(crossfile, 'w', encoding='utf-8') as f:
-                f.write(textwrap.dedent(
-                    '''
-                    [binaries]
-                    c = '/opt/toolchain/bin/gcc'
-                    '''))
+                if is_windows():
+                    f.write(textwrap.dedent(
+                        '''
+                        [binaries]
+                        c = 'X:\\opt\\toolchain\\bin\\gcc'
+                        '''))
+                else:
+                    f.write(textwrap.dedent(
+                        '''
+                        [binaries]
+                        c = '/opt/toolchain/bin/gcc'
+                        '''))
 
             config = mesonbuild.coredata.parse_machine_files(crossfile)
             bt = mesonbuild.envconfig.BinaryTable(config.get('binaries', {}))
-            self.assertEqual(bt.binaries['c'], ['/opt/toolchain/bin/gcc'])
+            if is_windows():
+                self.assertEqual(bt.binaries['c'], ['X:\\opt\\toolchain\\bin\\gcc'])
+            else:
+                self.assertEqual(bt.binaries['c'], ['/opt/toolchain/bin/gcc'])
+

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3796,7 +3796,7 @@ class AllPlatformTests(BasePlatformTests):
                     '''))
 
             values = mesonbuild.coredata.parse_machine_files([crossfile1, crossfile2])
-            self.assertEqual(values['binaries']['c'], '/toolchain/gcc')
+            self.assertEqual(values['binaries']['c'], ['/toolchain/gcc'])
             self.assertEqual(values['properties']['c_args'],
                              ['--sysroot=/toolchain/sysroot', '-DSOMETHING'])
             self.assertEqual(values['properties']['cpp_args'],
@@ -4577,9 +4577,9 @@ class AllPlatformTests(BasePlatformTests):
                     c = 'toolchain/gcc'
                     '''))
 
-            config = mesonbuild.coredata.parse_machine_files(crossfile)
+            config = mesonbuild.coredata.parse_machine_files([crossfile])
             bt = mesonbuild.envconfig.BinaryTable(config.get('binaries', {}))
-            self.assertEqual(bt.binaries['c'], [os.path.normpath(os.path.join(self.src_root, 'toolchain/gcc'))])
+            self.assertEqual(bt.binaries['c'], [os.path.normpath(os.path.join(os.path.dirname(crossfile), 'toolchain/gcc'))])
 
         # A binary entry without a path shouldn't be altered.
         with temp_filename() as crossfile:
@@ -4590,7 +4590,7 @@ class AllPlatformTests(BasePlatformTests):
                     c = 'gcc'
                     '''))
 
-            config = mesonbuild.coredata.parse_machine_files(crossfile)
+            config = mesonbuild.coredata.parse_machine_files([crossfile])
             bt = mesonbuild.envconfig.BinaryTable(config.get('binaries', {}))
             self.assertEqual(bt.binaries['c'], ['gcc'])
 
@@ -4610,10 +4610,9 @@ class AllPlatformTests(BasePlatformTests):
                         c = '/opt/toolchain/bin/gcc'
                         '''))
 
-            config = mesonbuild.coredata.parse_machine_files(crossfile)
+            config = mesonbuild.coredata.parse_machine_files([crossfile])
             bt = mesonbuild.envconfig.BinaryTable(config.get('binaries', {}))
             if is_windows():
                 self.assertEqual(bt.binaries['c'], ['X:\\opt\\toolchain\\bin\\gcc'])
             else:
                 self.assertEqual(bt.binaries['c'], ['/opt/toolchain/bin/gcc'])
-

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4628,7 +4628,7 @@ class AllPlatformTests(BasePlatformTests):
                         c = false
                         '''))
                 _ = mesonbuild.coredata.parse_machine_files([crossfile])
-        self.assertEqual(str(cm.exception), 'Invalid type False for entry \'c\' in machine file')
+            self.assertEqual(str(cm.exception), 'Invalid type False for entry \'c\' in machine file')
         
         # boolean within a list assigned to a binary entry should raise an exception
         with self.assertRaises(EnvironmentException) as cm:
@@ -4640,4 +4640,16 @@ class AllPlatformTests(BasePlatformTests):
                         c = [false]
                         '''))
                 _ = mesonbuild.coredata.parse_machine_files([crossfile])
-        self.assertEqual(str(cm.exception), 'Invalid type [False] for entry \'c\' in machine file')
+            self.assertEqual(str(cm.exception), 'Invalid type [False] for entry \'c\' in machine file')
+
+    def test_relative_to_absolute_path_conversion_at_different_directories(self):
+        with tempfile.TemporaryDirectory() as tmpdir1, tempfile.TemporaryDirectory() as tmpdir2:
+            with tempfile.NamedTemporaryFile('w+t', encoding='utf-8', dir=tmpdir1) as crossfile1, tempfile.NamedTemporaryFile('w+t', encoding='utf-8', dir=tmpdir2) as crossfile2:
+                crossfile1.writelines("[binaries]\nfoo = 'bin/foo'\n")
+                crossfile1.flush()
+                crossfile2.writelines("[binaries]\nbar = 'bin/bar'\n")
+                crossfile2.flush()
+                config = mesonbuild.coredata.parse_machine_files([crossfile1.name, crossfile2.name])
+                bt = mesonbuild.envconfig.BinaryTable(config.get('binaries', {}))
+                self.assertEqual(bt.binaries['foo'], [os.path.normpath(os.path.join(os.path.dirname(crossfile1.name), 'bin/foo'))])
+                self.assertEqual(bt.binaries['bar'], [os.path.normpath(os.path.join(os.path.dirname(crossfile2.name), 'bin/bar'))])

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -4567,8 +4567,6 @@ class AllPlatformTests(BasePlatformTests):
         self.assertEqual(sorted(expected_meson_modules), sorted(meson_modules))
     
     def test_relative_to_absolute_path_conversion(self):
-        from mesonbuild.envconfig import BinaryTable
-
         # A binary entry with a relative path should be converted to
         # an entry with absolute path.
         with temp_filename() as crossfile:
@@ -4580,7 +4578,7 @@ class AllPlatformTests(BasePlatformTests):
                     '''))
 
             config = mesonbuild.coredata.parse_machine_files(crossfile)
-            bt = BinaryTable(config.get('binaries', {}))
+            bt = mesonbuild.envconfig.BinaryTable(config.get('binaries', {}))
             self.assertEqual(bt.binaries['c'], [os.path.abspath('toolchain/gcc')])
 
         # A binary entry without a path shouldn't be altered.
@@ -4593,7 +4591,7 @@ class AllPlatformTests(BasePlatformTests):
                     '''))
 
             config = mesonbuild.coredata.parse_machine_files(crossfile)
-            bt = BinaryTable(config.get('binaries', {}))
+            bt = mesonbuild.envconfig.BinaryTable(config.get('binaries', {}))
             self.assertEqual(bt.binaries['c'], ['gcc'])
 
         # A binary entry with an absolute path shouldn't be altered.
@@ -4606,5 +4604,5 @@ class AllPlatformTests(BasePlatformTests):
                     '''))
 
             config = mesonbuild.coredata.parse_machine_files(crossfile)
-            bt = BinaryTable(config.get('binaries', {}))
+            bt = mesonbuild.envconfig.BinaryTable(config.get('binaries', {}))
             self.assertEqual(bt.binaries['c'], ['/opt/toolchain/bin/gcc'])


### PR DESCRIPTION
As indicated in #3439 some project setups have the toolchain included within the repository. To reduce the initial starting effort when a developer clones/checkouts the repository this PR adds support for binaries with a relative path within native/crossfile.

Fixes #3439 