### PR TITLE
Support import() of out-of-tree modules

### DIFF
--- a/docs/markdown/Modules.md
+++ b/docs/markdown/Modules.md
@@ -23,3 +23,12 @@ Meson has a selection of modules to make common requirements easy to
 use. Modules can be thought of like the standard library of a
 programming language. Currently Meson provides the modules listed on
 subpages.
+
+In addition to modules that come with Meson, it is possible to write
+your own. These can then be imported using the `dirs` kwarg:
+
+```meson
+mymod = import('somemodule', dirs : meson.project_source_root() / 'modules')
+```
+
+This will import the file `modules/somemodule.py` as a Meson module.

--- a/docs/markdown/Reference-manual.md
+++ b/docs/markdown/Reference-manual.md
@@ -1001,8 +1001,17 @@ a non-existing variable will cause a fatal error.
 ### import()
 
 ```
-  module_object import(string, required : bool | feature, disabler : bool)
+  module_object import(string, ...)
 ```
+
+Keyword arguments are the following:
+
+- `required` *(since 0.59.0)*: By default, `required` is `true` and
+  Meson will abort if the module could not be found.
+- `disabler` *(since 0.59.0)*: if `true` and the module couldn't be found,
+  returns a [disabler object](#disabler-object) instead of a not-found module.
+- `dirs` *(since 0.60.0)*: extra list of absolute paths where to look for program
+  names.
 
 Imports the given extension module. Returns an object that can be used to call
 the methods of the module. Here's an example for a hypothetical `testmod`
@@ -1012,8 +1021,6 @@ module.
     tmod = import('testmod')
     tmod.do_something()
 ```
-
-*Since 0.59.0* the required and disabler keyword arguments
 
 ### include_directories()
 

--- a/test cases/common/245 external module/meson.build
+++ b/test cases/common/245 external module/meson.build
@@ -1,0 +1,5 @@
+project('imports')
+
+extmod = import('external_module', dirs : [meson.project_source_root() / 'modules'])
+
+assert(extmod.return_true(), 'external module did not function correctly.')

--- a/test cases/common/245 external module/modules/external_module.py
+++ b/test cases/common/245 external module/modules/external_module.py
@@ -1,0 +1,14 @@
+from mesonbuild.modules import ExtensionModule, ModuleReturnValue
+
+class ExternalModule(ExtensionModule):
+    def __init__(self, interpreter):
+        super().__init__(interpreter)
+        self.methods.update({
+            'return_true': self.return_true,
+        })
+
+    def return_true(self, state, args, kwargs):
+        return ModuleReturnValue(True, [])
+
+def initialize(*args, **kwargs) -> ExternalModule:
+    return ExternalModule(*args, **kwargs)

--- a/test cases/failing/115 module missing/meson.build
+++ b/test cases/failing/115 module missing/meson.build
@@ -1,0 +1,3 @@
+project('imports')
+
+import('no_such_module')

--- a/test cases/failing/115 module missing/test.json
+++ b/test cases/failing/115 module missing/test.json
@@ -1,0 +1,7 @@
+{
+    "stdout": [
+        {
+            "line": "test cases/failing/115 module missing/meson.build:3:0: ERROR: Module \"no_such_module\" does not exist"
+        }
+    ]
+}


### PR DESCRIPTION
This pull-request adds a 'dirs' kwarg to import(), and updates tests / documentation to include this parameter.

`import('foo', dirs: '/bar')` will search for /bar/foo.py, and attempt to load it as an external module, failing if it's not found.

---

I have a couple modules that I'm not able to merge upstream. With this change, I'm able to manage these as part of the projects they're related to, rather than by shipping my own package of Meson with them included.