### PR TITLE
summary: fix dependencies

### DIFF
--- a/mesonbuild/_typing.py
+++ b/mesonbuild/_typing.py
@@ -36,6 +36,9 @@ T = typing.TypeVar('T')
 class StringProtocol(Protocol):
     def __str__(self) -> str: ...
 
+class SizedStringProtocol(Protocol, StringProtocol, typing.Sized):
+    pass
+
 class ImmutableListProtocol(Protocol[T]):
 
     """A protocol used in cases where a list is returned, but should not be

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -103,7 +103,7 @@ class Dependency(HoldableObject):
             return mlog.red('NO')
         if not self.version:
             return mlog.green('YES')
-        return mlog.AnsiText([mlog.green('YES'), ' ', mlog.cyan(self.version)])
+        return mlog.AnsiText(mlog.green('YES'), ' ', mlog.cyan(self.version))
 
     def get_compile_args(self) -> T.List[str]:
         if self.include_type == 'system':

--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -22,7 +22,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 if T.TYPE_CHECKING:
-    from ._typing import StringProtocol
+    from ._typing import StringProtocol, SizedStringProtocol
 
 """This is (mostly) a standalone module used to write logging
 information about Meson runs. Some output goes to screen,
@@ -143,7 +143,7 @@ TV_Loggable = T.Union[str, AnsiDecorator, 'StringProtocol']
 TV_LoggableList = T.List[TV_Loggable]
 
 class AnsiText:
-    def __init__(self, *args: TV_LoggableList):
+    def __init__(self, *args: 'SizedStringProtocol'):
         self.args = args
 
     def __len__(self) -> int:

--- a/test cases/unit/72 summary/meson.build
+++ b/test cases/unit/72 summary/meson.build
@@ -13,6 +13,7 @@ summary({'Some boolean': false,
 summary({'missing prog': find_program('xyzzy', required: false),
          'existing prog': import('python').find_installation(),
          'missing dep': dependency('', required: false),
+         'external dep': dependency('zlib', required: false),
          'internal dep': declare_dependency(),
         }, section: 'Stuff')
 summary('A number', 1, section: 'Configuration')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3119,6 +3119,7 @@ class AllPlatformTests(BasePlatformTests):
                 missing prog   : NO
                 existing prog  : ''' + sys.executable + '''
                 missing dep    : NO
+                external dep   : YES 1.2.3
                 internal dep   : YES
 
               Plugins
@@ -3142,9 +3143,13 @@ class AllPlatformTests(BasePlatformTests):
         if sys.version_info < (3, 7, 0):
             # Dictionary order is not stable in Python <3.7, so sort the lines
             # while comparing
-            self.assertEqual(sorted(expected_lines), sorted(out_lines))
-        else:
-            self.assertEqual(expected_lines, out_lines)
+            expected_lines = sorted(expected_lines)
+            out_lines = sorted(out_lines)
+        for e, o in zip(expected_lines, out_lines):
+            if e.startswith('    external dep'):
+                self.assertRegex(o, r'^    external dep   : (YES [0-9.]*|NO)$')
+            else:
+                self.assertEqual(o, e)
 
     def test_meson_compile(self):
         """Test the meson compile command."""


### PR DESCRIPTION
Dependencies are currently printed as

   [<mesonbuild.mlog.AnsiDecorator object at 0x7faa85aeac70>, ' ', <mesonbuild.mlog.AnsiDecorator object at 0x7faa85aeab50>]

This was introduced in commit adb1b2f3f6ad54b346348ec6e5b8d96f2f7ba0a6, due to
an incorrect type annotation on the AnsiText constructor.  Fix both the
annotation and the usage.

This is a regression in 0.59.