### PR TITLE
objc/objcpp compiler: accept all gnu stds corresponding to c/c++ stds

### DIFF
--- a/mesonbuild/compilers/objc.py
+++ b/mesonbuild/compilers/objc.py
@@ -90,7 +90,7 @@ class ClangObjCCompiler(ClangCompiler, ObjCCompiler):
         opts.update({
             OptionKey('std', machine=self.for_machine, lang='c'): coredata.UserComboOption(
                 'C language standard to use',
-                ['none', 'c89', 'c99', 'c11', 'c17', 'gnu99', 'gnu11'],
+                ['none', 'c89', 'c99', 'c11', 'c17', 'gnu89', 'gnu99', 'gnu11', 'gnu17'],
                 'none',
             )
         })

--- a/mesonbuild/compilers/objcpp.py
+++ b/mesonbuild/compilers/objcpp.py
@@ -91,7 +91,7 @@ class ClangObjCPPCompiler(ClangCompiler, ObjCPPCompiler):
         opts.update({
             OptionKey('std', machine=self.for_machine, lang='cpp'): coredata.UserComboOption(
                 'C++ language standard to use',
-                ['none', 'c++98', 'c++11', 'c++14', 'c++17'],
+                ['none', 'c++98', 'c++11', 'c++14', 'c++17', 'gnu++98', 'gnu++11', 'gnu++14', 'gnu++17'],
                 'none',
             )
         })


### PR DESCRIPTION
The clang compiler now reimplements and re-checks the c_std and cpp_std options in order to use them for objc as well, but it didn't consistently support the same options. First it completely excluded all the gnu ones, and then it added a handful of them but not for C++.

Be fully consistent -- or at least as consistent as we can be, given a minimally working fix. (The C/C++ compiler mixin actually gates different stds depending on detected clang version, we do not do that here.)

Fixes regression in c54dd63547b030e3d9feee694ec6f49c434f0df8
Fixes incomplete fix from #8766 (which didn't fix objcpp at all)

Fixes #9237