### PR TITLE
qt module: correctly register a found tool and stop looking for it

### DIFF
--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -539,7 +539,7 @@ class QtBaseModule(ExtensionModule):
                     ts_files.append(c.rstrip('.qm') + '.ts')
                 else:
                     raise MesonException(f'qt.compile_translations: qresource can only contain qm files, found {c}')
-            results = self.preprocess(state, [], {'qresources': qresource, 'rcc_extra_arguments': kwargs['rcc_extra_arguments']})
+            results = self.preprocess(state, [], {'qresources': qresource_file, 'rcc_extra_arguments': kwargs['rcc_extra_arguments']})
         self._detect_tools(state, kwargs['method'])
         translations: T.List[build.CustomTarget] = []
         for ts in ts_files:

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -122,8 +122,6 @@ class QtBaseModule(ExtensionModule):
         # It is important that this list does not change order as the order of
         # the returned ExternalPrograms will change as well
         bins = ['moc', 'uic', 'rcc', 'lrelease']
-        found = {b: NonExistingExternalProgram(name=f'{b}-qt{qt_dep.qtver}')
-                 for b in bins}
         wanted = f'== {qt_dep.version}'
 
         def gen_bins() -> T.Generator[T.Tuple[str, str], None, None]:
@@ -136,7 +134,7 @@ class QtBaseModule(ExtensionModule):
                 yield b, b
 
         for b, name in gen_bins():
-            if found[name].found():
+            if getattr(self, name).found():
                 continue
 
             if name == 'lrelease':

--- a/test cases/frameworks/4 qt/main.cpp
+++ b/test cases/frameworks/4 qt/main.cpp
@@ -1,4 +1,6 @@
 #include <QApplication>
+#include <QTranslator>
+#include <QDebug>
 #include "mainWindow.h"
 
 #if QT_VERSION > 0x050000
@@ -16,6 +18,13 @@ int main(int argc, char **argv) {
   Q_INIT_RESOURCE(stuff2);
   #endif
   QApplication app(argc, argv);
+
+  auto *translator = new QTranslator;
+  if (translator->load(QLocale(), QT "embedded", "_", ":/lang"))
+      qApp->installTranslator(translator);
+
+  qDebug() << QObject::tr("Translate me!");
+
   MainWindow *win = new MainWindow();
   QImage qi(":/thing.png");
   if(qi.width() != 640) {

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -81,10 +81,16 @@ foreach qt : ['qt4', 'qt5', 'qt6']
     # qt4-rcc and qt5-rcc take different arguments, for example qt4: ['-compress', '3']; qt5: '--compress=3'
     qtmodule.preprocess(qt + 'testrccarg', qresources : files(['stuff.qrc', 'stuff2.qrc']), rcc_extra_arguments : '--compress=3', method : get_option('method'))
 
+    translations_cpp = qtmodule.compile_translations(qresource: qt+'_lang.qrc')
+    # unity builds suck and definitely cannot handle two qrc embeds in one compilation unit
+    unityproof_translations = static_library('unityproof_translations', translations_cpp)
+
+    extra_cpp_args += '-DQT="@0@"'.format(qt)
     qexe = executable(qt + 'app',
       sources : ['main.cpp', 'mainWindow.cpp', # Sources that don't need preprocessing.
       prep, prep_rcc],
       dependencies : qtdep,
+      link_with: unityproof_translations,
       cpp_args: extra_cpp_args,
       gui_app : true)
 

--- a/test cases/frameworks/4 qt/qt4_lang.qrc
+++ b/test cases/frameworks/4 qt/qt4_lang.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/lang">
+        <file>qt4embedded_fr.qm</file>
+    </qresource>
+</RCC>
+

--- a/test cases/frameworks/4 qt/qt4embedded_fr.ts
+++ b/test cases/frameworks/4 qt/qt4embedded_fr.ts
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.0" language="fr_FR">
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="q5core.cpp" line="23"/>
+        <source>Translate me!</source>
+        <translation>Traduisez moi!</translation>
+    </message>
+</context>
+</TS>

--- a/test cases/frameworks/4 qt/qt5_lang.qrc
+++ b/test cases/frameworks/4 qt/qt5_lang.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/lang">
+        <file>qt5embedded_fr.qm</file>
+    </qresource>
+</RCC>
+

--- a/test cases/frameworks/4 qt/qt5embedded_fr.ts
+++ b/test cases/frameworks/4 qt/qt5embedded_fr.ts
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr_FR">
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="q5core.cpp" line="23"/>
+        <source>Translate me!</source>
+        <translation>Traduisez moi!</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Regression in commit d7ac2f10655433989e5e17867b6c8ef428fd39e8 since self.{tool_name} is not how it used to be tracked, and the "found" dictionary is a legacy of the old location.