### PR TITLE
docs: add note about built-in options support

### DIFF
--- a/docs/markdown/Machine-files.md
+++ b/docs/markdown/Machine-files.md
@@ -297,6 +297,8 @@ build-tests = false
 
 ### Meson built-in options
 
+*Before 0.56.0, `<lang>_args` and `<lang>_link_args` must be put in the `properties` section instead, else they will be ignored.*
+
 Meson built-in options can be set the same way:
 
 ```ini


### PR DESCRIPTION
Older meson versions would not honor the `<lang>_args` and `<lang>_link_args` in the built-in
options section, add a note about this to the relevant section as it can cause quite some surprises
when using a crossfile with an older meson version.