### PR TITLE
Die, layout=flat, die

### DIFF
--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -177,8 +177,6 @@ class MesonApp:
         mlog.initialize(env.get_log_dir(), self.options.fatal_warnings)
         if self.options.profile:
             mlog.set_timestamp_start(time.monotonic())
-        if env.coredata.options[mesonlib.OptionKey('backend')].value == 'xcode':
-            mlog.warning('xcode backend is currently unmaintained, patches welcome')
         with mesonlib.BuildDirLock(self.build_dir):
             self._generate(env)
 
@@ -264,6 +262,11 @@ class MesonApp:
 
             # Post-conf scripts must be run after writing coredata or else introspection fails.
             intr.backend.run_postconf_scripts()
+
+            # collect warnings about unsupported build configurations; must be done after full arg processing
+            # by Interpreter() init, but this is most visible at the end
+            if env.coredata.options[mesonlib.OptionKey('backend')].value == 'xcode':
+                mlog.warning('xcode backend is currently unmaintained, patches welcome')
         except Exception as e:
             mintro.write_meson_info_file(b, [e])
             if 'cdf' in locals():

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -267,6 +267,13 @@ class MesonApp:
             # by Interpreter() init, but this is most visible at the end
             if env.coredata.options[mesonlib.OptionKey('backend')].value == 'xcode':
                 mlog.warning('xcode backend is currently unmaintained, patches welcome')
+            if env.coredata.options[mesonlib.OptionKey('layout')].value == 'flat':
+                mlog.warning('-Dlayout=flat is unsupported and probably broken. It was a failed experiment at '
+                             'making Windows build artifacts runnable while uninstalled, due to PATH considerations, '
+                             'but was untested by CI and anyways breaks reasonable use of conflicting targets in different subdirs. '
+                             'Please consider using `meson devenv` instead. See https://github.com/mesonbuild/meson/pull/9243 '
+                             'for details.')
+
         except Exception as e:
             mintro.write_meson_info_file(b, [e])
             if 'cdf' in locals():


### PR DESCRIPTION
The option for layout=flat is horribly broken beyond repair in various circumstances which no one really keeps track of, no one seems to actually use it in practice for any good reason, CI doesn't test it, no one is committed to maintaining it, etc. etc. etc.

How is it broken? Well:
- projects doing trivially reasonable things, such as generating "foo/util.py" and "bar/util.py", create clashing output names. This will never, ever, ever, ever work with layout=flat. This is by design, because they are fundamentally incompatible goals.
- Generally, meson assumes all over the place that files go in their subdir output directories, and since it is never tested in CI, these assumptions go unnoticed...
- Sometimes meson itself generates files in subdir-based layouts, for example my recent changes to the i18n module produce dozens of files all named "project.mo" but in directories distinguished by unique locales. This is because locale files are all named the same thing, and gettext chooses the right file by searching a locale directory... there is nothing we can do here! There are probably also other generated cases, but who even cares to try to figure out what they are???

I propose that layout=flat is a failed experiment. It only ever existed in the first place, because... Windows. Windows is technically  broken. It relies on PATH to find dlls which executables depend on, so programs don't run while uninstalled if subdirs are in play. Enter `layout=flat` just stick everything all in one directory, surely nothing can possibly go wrong... except it does.

There is a much better way to handle this, and recent versions of meson include it: `meson devenv` will let you enter an environment where your PATH is set up properly and you can run uninstalled programs. Let's deprecate and remove layout=flat in favor of `devenv`. Everyone will thank us.

Closes #996
Closes #1521
Closes #1908
Closes #7133
Closes #7135
Closes #7480
Closes #8378

(and probably more, who knows)