### PR TITLE
Fix fortran

### DIFF
--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -72,7 +72,7 @@ class FortranCompiler(CLikeCompiler, Compiler):
         if binary_name.is_file():
             binary_name.unlink()
 
-        source_name.write_text('print *, "Fortran compilation is working."; end', encoding='utf-8')
+        source_name.write_text('program main; print *, "Fortran compilation is working."; end program', encoding='utf-8')
 
         extra_flags: T.List[str] = []
         extra_flags += environment.coredata.get_external_args(self.for_machine, self.language)

--- a/test cases/fortran/1 basic/simple.f90
+++ b/test cases/fortran/1 basic/simple.f90
@@ -1,2 +1,3 @@
+program main
 print *, "Fortran compilation is working."
 end program

--- a/test cases/fortran/10 find library/main.f90
+++ b/test cases/fortran/10 find library/main.f90
@@ -1,4 +1,4 @@
-
+program main
 use iso_fortran_env, only: stderr=>error_unit
 use iso_c_binding, only: c_int, c_char, c_null_char, c_ptr
 use gzip, only: gzopen, gzwrite, gzclose

--- a/test cases/fortran/12 submodule/parent.f90
+++ b/test cases/fortran/12 submodule/parent.f90
@@ -13,6 +13,7 @@ end interface
 
 end module parent
 
+program main
 
 use parent
 

--- a/test cases/fortran/13 coarray/main.f90
+++ b/test cases/fortran/13 coarray/main.f90
@@ -1,3 +1,4 @@
+program main
 implicit none
 
 if (this_image() == 1)  print *, 'number of Fortran coarray images:', num_images()

--- a/test cases/fortran/14 fortran links c/f_call_c.f90
+++ b/test cases/fortran/14 fortran links c/f_call_c.f90
@@ -1,3 +1,4 @@
+program main
 implicit none
 
 interface

--- a/test cases/fortran/16 openmp/main.f90
+++ b/test cases/fortran/16 openmp/main.f90
@@ -1,3 +1,4 @@
+program main
 use, intrinsic :: iso_fortran_env, only: stderr=>error_unit
 use omp_lib, only: omp_get_max_threads
 implicit none

--- a/test cases/fortran/18 first_arg/main.f90
+++ b/test cases/fortran/18 first_arg/main.f90
@@ -1,2 +1,3 @@
+program main
 i = 3
 end program

--- a/test cases/fortran/19 fortran_std/legacy.f
+++ b/test cases/fortran/19 fortran_std/legacy.f
@@ -1,3 +1,4 @@
+      program main
     ! non-integer loop indices are deleted in Fortran 95 standard
       real a
 

--- a/test cases/fortran/19 fortran_std/std2003.f90
+++ b/test cases/fortran/19 fortran_std/std2003.f90
@@ -1,3 +1,4 @@
+program main
 use, intrinsic :: iso_fortran_env, only : error_unit
 implicit none
 

--- a/test cases/fortran/19 fortran_std/std2008.f90
+++ b/test cases/fortran/19 fortran_std/std2008.f90
@@ -1,3 +1,4 @@
+program main
 use, intrinsic :: iso_fortran_env, only : error_unit, sp=>real32, dp=>real64
 implicit none
 

--- a/test cases/fortran/19 fortran_std/std2018.f90
+++ b/test cases/fortran/19 fortran_std/std2018.f90
@@ -1,3 +1,4 @@
+program main
 use, intrinsic :: iso_fortran_env, only : error_unit, sp=>real32, dp=>real64
 implicit none
 

--- a/test cases/fortran/19 fortran_std/std95.f90
+++ b/test cases/fortran/19 fortran_std/std95.f90
@@ -1,3 +1,4 @@
+program main
 implicit none
 
 integer :: i, j

--- a/test cases/fortran/2 modules/prog.f90
+++ b/test cases/fortran/2 modules/prog.f90
@@ -1,3 +1,4 @@
+program main
 use circle, only: pi
 use line, only: length
 implicit none

--- a/test cases/fortran/20 buildtype/main.f90
+++ b/test cases/fortran/20 buildtype/main.f90
@@ -1,1 +1,2 @@
+program main
 end program

--- a/test cases/fortran/21 install static/main.f90
+++ b/test cases/fortran/21 install static/main.f90
@@ -1,3 +1,4 @@
+program main
 use main_lib
 implicit none
 call main_hello()

--- a/test cases/fortran/5 static/main.f90
+++ b/test cases/fortran/5 static/main.f90
@@ -1,4 +1,4 @@
-
+program main
 use static_hello
 implicit none
 

--- a/test cases/fortran/6 dynamic/main.f90
+++ b/test cases/fortran/6 dynamic/main.f90
@@ -1,3 +1,4 @@
+program main
 use dynamic, only: hello
 implicit none
 

--- a/test cases/fortran/8 module names/test.f90
+++ b/test cases/fortran/8 module names/test.f90
@@ -1,3 +1,4 @@
+program main
 use mymod1
 use MyMod2  ! test inline comment
 


### PR DESCRIPTION
This PR ensures that the test programs can be compiled with standards conforming compilers like conda's `gfortran` and others.

- Fixes compiler check
- Updates tests
- ~Changes `.gitignore` to ignore generated `fortran`~