### PR TITLE
backends/vs: Do not emit dummy command for alias_command().

### DIFF
--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3066,9 +3066,6 @@ class AllPlatformTests(BasePlatformTests):
         self.init(testdir, extra_args=['-Dcmake_prefix_path=' + os.path.join(testdir, 'prefix')])
 
     def test_alias_target(self):
-        if self.backend is Backend.vs:
-            # FIXME: This unit test is broken with vs backend, needs investigation
-            raise SkipTest(f'Skipping alias_target test with {self.backend.name} backend')
         testdir = os.path.join(self.unit_test_dir, '65 alias target')
         self.init(testdir)
         self.build()


### PR DESCRIPTION
Alias commands did not work with the vs backend, due to trying to access
target.command[0] with an empty command. Fix this by just not emitting a
CustomBuild node for alias targets - the project references are enough to
trigger the necessary actions.

Fixes: #9247