### PR TITLE
Argument against source file list specified as wild cards does not stand

### DIFF
--- a/docs/markdown/FAQ.md
+++ b/docs/markdown/FAQ.md
@@ -61,23 +61,16 @@ Instead of specifying files explicitly, people seem to want to do this:
 executable('myprog', sources : '*.cpp') # This does NOT work!
 ```
 
-Meson does not support this syntax and the reason for this is simple.
-This can not be made both reliable and fast. By reliable we mean that
-if the user adds a new source file to the subdirectory, Meson should
-detect that and make it part of the build automatically.
+Meson does not support this syntax.
 
 One of the main requirements of Meson is that it must be fast. This
 means that a no-op build in a tree of 10 000 source files must take no
-more than a fraction of a second. This is only possible because Meson
-knows the exact list of files to check. If any target is specified as
-a wildcard glob, this is no longer possible. Meson would need to
+more than a fraction of a second. Meson would need to
 re-evaluate the glob every time and compare the list of files produced
-against the previous list. This means inspecting the entire source
-tree (because the glob pattern could be `src/\*/\*/\*/\*.cpp` or
-something like that). This is impossible to do efficiently.
+against the previous list.
 
 The main backend of Meson is Ninja, which does not support wildcard
-matches either, and for the same reasons.
+matches either.
 
 Because of this, all source files must be specified explicitly.
 


### PR DESCRIPTION
I'm sorry, but the argument that says that dynamically looking up for 10k files is not achievable in a fraction of a second doesn't stand for a second.
First, looking up for directory changes means you only need to stat the directories, i.e. you don't need to read the directories!
Second, since you are already stating the 10k files for changes anyway, it already proves that this amount of stats is not problematic.
I've done an implementation in a python-based build system circa 2009 and it took about 0.6s for 20k files.