### PR TITLE
during executable lookup, do not search PATH if a directory component is given

### DIFF
--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -295,6 +295,9 @@ class ExternalProgram(mesonlib.HoldableObject):
         commands = self._search_dir(name, search_dir)
         if commands:
             return commands
+        # If there is a directory component, do not look in PATH
+        if os.path.dirname(name) and not os.path.isabs(name):
+            return [None]
         # Do a standard search in PATH
         path = os.environ.get('PATH', None)
         if mesonlib.is_windows() and path:


### PR DESCRIPTION
This will always be wrong, because when a directory component is provided we need to match an exact filename on a manual search path, for example find_program with dirs: or the current meson.build subdir.

If we ever get this far, shutil.which will do the same "is there a dirname, if so just check whether the filename exists relative to
cwd"... except that the documented meson lookup path is that we check relative to meson.build subdir, not relative to the cwd, and the cwd could be anything, but is probably the root sourcedir.

Since internally, meson does not actually os.chdir into the sourcedir, it could be absolutely anything at all, though.

...

The actual returned name for shutil.which(name) given a literal pathname with a directory component is "return name" without adding the absolute path, which means that this is double-broken. Not only does it find things we didn't expect, the resulting ExternalProgram object doesn't have the correct path to the program, so it will report "found" and then fail to actually run when the current directory is changed, for example by ninja -C.

Fixes #9262