### PR TITLE
C2000: Added depfile generation for incremental builds

### DIFF
--- a/mesonbuild/compilers/mixins/c2000.py
+++ b/mesonbuild/compilers/mixins/c2000.py
@@ -124,3 +124,6 @@ class C2000Compiler(Compiler):
                 parameter_list[idx] = i[:9] + os.path.normpath(os.path.join(build_dir, i[9:]))
 
         return parameter_list
+    
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+        return ['--preproc_with_compile', f'--preproc_dependency={outfile}']


### PR DESCRIPTION
While working with meson and the `C2000` toolchain, I noticed that changes in the header file did not result in a recompilation of the corresponding source files. Since the function `get_dependency_gen_args()` was not implemented, this is not a big surprise.