### PR TITLE
fix depscan json depends

### DIFF
--- a/test cases/fortran/7 generated/meson.build
+++ b/test cases/fortran/7 generated/meson.build
@@ -9,10 +9,8 @@ conf_data.set('ONE', 1)
 conf_data.set('TWO', 2)
 conf_data.set('THREE', 3)
 
-configure_file(input : 'mod3.fpp', output : 'mod3.f90', configuration : conf_data)
-# Manually build absolute path to source file to test
-# https://github.com/mesonbuild/meson/issues/7265
-three = library('mod3', meson.current_build_dir() / 'mod3.f90')
+mod3_f = configure_file(input : 'mod3.fpp', output : 'mod3.f90', configuration : conf_data)
+three = library('mod3', mod3_f)
 
 templates_basenames = ['mod2', 'mod1']
 generated_sources = []

--- a/test cases/fortran/7 generated/meson.build
+++ b/test cases/fortran/7 generated/meson.build
@@ -7,9 +7,21 @@ project('generated', 'fortran',
 conf_data = configuration_data()
 conf_data.set('ONE', 1)
 conf_data.set('TWO', 2)
-conf_data.set('THREE', 3)
 
-mod3_f = configure_file(input : 'mod3.fpp', output : 'mod3.f90', configuration : conf_data)
+mod3_f = custom_target(
+  'mod3.f',
+  input : 'mod3.f90',
+  output : 'mod3.f90',
+  # We need a platform agnostic way to do a copy a file, using a custom_target
+  # and we need to use the @OUTDIR@, not @OUTPUT@ in order to exercise
+  # https://github.com/mesonbuild/meson/issues/9258
+  command : [
+    find_program('python', 'python3'), '-c',
+    'import sys, shutil; shutil.copy(sys.argv[1], sys.argv[2])',
+    '@INPUT@', '@OUTDIR@',
+  ],
+)
+
 three = library('mod3', mod3_f)
 
 templates_basenames = ['mod2', 'mod1']

--- a/test cases/fortran/7 generated/mod3.f90
+++ b/test cases/fortran/7 generated/mod3.f90
@@ -1,6 +1,6 @@
 module mod3
 implicit none
 
-integer, parameter :: modval3 = @THREE@
+integer, parameter :: modval3 = 3
 
 end module mod3


### PR DESCRIPTION
After we changed to the depscan tool consuming a json file, we lost the correct ordering dependencies, so we need to add those back.

Fixes: #9258