### PR TITLE
ninjabackend/vs: handle builddir on different drive than cwd

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -515,7 +515,13 @@ class NinjaBackend(backends.Backend):
         ninja = environment.detect_ninja_command_and_version(log=True)
         if need_setup_vsenv:
             builddir = Path(self.environment.get_build_dir())
-            builddir = builddir.relative_to(Path.cwd())
+            try:
+                # For prettier printing, reduce to a relative path. If
+                # impossible (e.g., because builddir and cwd are on
+                # different Windows drives), skip and use the full path.
+                builddir = builddir.relative_to(Path.cwd())
+            except ValueError:
+                pass
             meson_command = mesonlib.join_args(mesonlib.get_meson_command())
             mlog.log()
             mlog.log('Visual Studio environment is needed to run Ninja. It is recommended to use Meson wrapper:')


### PR DESCRIPTION
When setup creates a Visual Studio environment, a message is logged
which contains a path to the build directory. Typically, this path is
converted to a relative path prior to printing. If the path cannot be
converted to a relative path (e.g., because buildpath is on a different
drive from the cwd), print out the full path instead of failing with an
unhandled exception.