### PR TITLE
backends/vs: Set ObjectFileName for generated sources.

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1342,6 +1342,8 @@ class Vs2010Backend(backends.Backend):
                     self.add_additional_options(lang, inc_cl, file_args)
                     self.add_preprocessor_defines(lang, inc_cl, file_defines)
                     self.add_include_dirs(lang, inc_cl, file_inc_dirs)
+                    s = File.from_built_file(target.get_subdir(), s)
+                    ET.SubElement(inc_cl, 'ObjectFileName').text = "$(IntDir)" + self.object_filename_from_source(target, s)
             for lang in pch_sources:
                 impl = pch_sources[lang][1]
                 if impl and path_normalize_add(impl, previous_sources):
@@ -1356,6 +1358,7 @@ class Vs2010Backend(backends.Backend):
                     else:
                         inc_dirs = file_inc_dirs
                     self.add_include_dirs(lang, inc_cl, inc_dirs)
+                    #XXX: Do we need to set the object file name name here too?
 
         previous_objects = []
         if self.has_objects(objects, additional_objects, gen_objs):

--- a/test cases/windows/19 vs install static lib with generated obj deps/both_lib_source.c
+++ b/test cases/windows/19 vs install static lib with generated obj deps/both_lib_source.c
@@ -1,0 +1,7 @@
+extern int static_lib_function(void);
+extern __declspec(dllexport) int both_lib_function(void);
+
+int both_lib_function(void)
+{
+    return static_lib_function();
+}

--- a/test cases/windows/19 vs install static lib with generated obj deps/copyfile.py
+++ b/test cases/windows/19 vs install static lib with generated obj deps/copyfile.py
@@ -1,0 +1,4 @@
+from shutil import copyfile
+import sys
+
+copyfile(sys.argv[1], sys.argv[2])

--- a/test cases/windows/19 vs install static lib with generated obj deps/generated_source.c
+++ b/test cases/windows/19 vs install static lib with generated obj deps/generated_source.c
@@ -1,0 +1,4 @@
+int generated_function(void)
+{
+    return 42;
+}

--- a/test cases/windows/19 vs install static lib with generated obj deps/meson.build
+++ b/test cases/windows/19 vs install static lib with generated obj deps/meson.build
@@ -1,0 +1,20 @@
+project('test', 'c')
+
+generated_c = custom_target(
+  'generated.c',
+  input : files('generated_source.c', 'copyfile.py'),
+  output : 'generated.c',
+  command : ['python', '@INPUT1@', '@INPUT0@', '@OUTPUT@'],
+)
+
+static_lib = static_library(
+    'static_lib',
+    [files('static_lib_source.c'), generated_c],
+)
+
+both_lib = both_libraries(
+    'both_lib',
+    [files('both_lib_source.c')],
+    link_with : [static_lib],
+    install : true,
+)

--- a/test cases/windows/19 vs install static lib with generated obj deps/static_lib_source.c
+++ b/test cases/windows/19 vs install static lib with generated obj deps/static_lib_source.c
@@ -1,0 +1,6 @@
+extern int generated_function(void);
+
+int static_lib_function(void)
+{
+    return generated_function();
+}

--- a/test cases/windows/19 vs install static lib with generated obj deps/test.json
+++ b/test cases/windows/19 vs install static lib with generated obj deps/test.json
@@ -1,0 +1,13 @@
+{
+  "installed": [
+    {"type": "file", "file": "usr/lib/libboth_lib.a"},
+
+    {"type": "shared_lib", "platform": "msvc", "file": "usr/bin/both_lib"},
+    {"type": "implib", "platform": "msvc", "file": "usr/lib/both_lib"},
+    {"type": "pdb", "platform": "msvc", "file": "usr/bin/both_lib"},
+
+    {"type": "expr", "platform": "gcc", "file": "usr/lib/?libboth_lib.dll"},
+    {"type": "implib", "platform": "gcc", "file": "usr/lib/libboth_lib"},
+    {"type": "pdb", "platform": "gcc", "file": "usr/bin/libboth_lib"}
+  ]
+}


### PR DESCRIPTION
 
When a static library B to a static library A with generated sources, B
directly references the object file corresponding to the generated source in
A. For that reference in B object_filename_from_source() is used.  But A did
not specify the object file name, ending up with cl.exe's default.

This contains the test @jenatali wrote in #9259 / #9235
