### PR TITLE
Module:Python:: Added a bit documentation for quirky behaviour when chained with mesonpep517

### DIFF
--- a/docs/markdown/Python-module.md
+++ b/docs/markdown/Python-module.md
@@ -140,6 +140,10 @@ All positional and keyword arguments are the same as for
 - `install_tag` *(since 0.60.0)*: A string used by `meson install --tags` command
   to install only a subset of the files. By default it has the tag `python-runtime`.
 
+If one uses `mesonpep517` to build packages with C extensions
+(`extension_module(..., install:true)`) `pure:false` must be specified for
+wheels to contain both binaries and sources.
+
 #### `get_install_dir()`
 
 ``` meson


### PR DESCRIPTION
I found this quirk which I thought was a bug(#9275). It should probably be fixed in `mesonpep517` (although I am not sure if it can be fixed there). For now it seems like it should be noted in the docs.