### PR TITLE
mtest: Allow gtest protocol test to fail more gracefully

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -990,7 +990,14 @@ class TestRunGTest(TestRunExitCode):
         if self.test.workdir:
             filename = os.path.join(self.test.workdir, filename)
 
-        self.junit = et.parse(filename)
+        try:
+            self.junit = et.parse(filename)
+        except FileNotFoundError:
+            # This can happen if the test fails to run or complete for some
+            # reason, like the rpath for libgtest isn't properly set. ExitCode
+            # will handle the failure, don't generate a stacktrace.
+            pass
+
         super().complete(returncode, res, stdo, stde)
 
 TestRun.PROTOCOL_TO_CLASS[TestProtocol.GTEST] = TestRunGTest


### PR DESCRIPTION
Currently, if the test fails to produce XML (or valid XML) then the test
fails with a backtrace. It's actually pretty easy to get into this
situation, a total failure of the test will result in no XML being
written (this can happen, for example, if rpaths to gtest are not
correctly set up). If we can't read the test, go ahead and complete
using `TestRunExitCode.complete()`, which will fail for the bad exit
code.