### PR TITLE
Use `-Oz` when `optimization=s` in Clang

### DIFF
--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -40,7 +40,7 @@ clang_optimization_args = {
     '1': ['-O1'],
     '2': ['-O2'],
     '3': ['-O3'],
-    's': ['-Os'],
+    's': ['-Oz'],
 }  # type: T.Dict[str, T.List[str]]
 
 class ClangCompiler(GnuLikeCompiler):

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2322,7 +2322,7 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         # https://github.com/mesonbuild/meson/issues/3275#issuecomment-641354956
         # https://github.com/mesonbuild/meson/issues/3742
         warnargs = ('/W1', '/W2', '/W3', '/W4', '/Wall', '-Wall', '-Wextra')
-        optargs = ('-O0', '-O2', '-O3', '-Os', '/O1', '/O2', '/Os')
+        optargs = ('-O0', '-O2', '-O3', '-Os', '-Oz', '/O1', '/O2', '/Os')
         for arg in args:
             if arg in warnargs:
                 mlog.warning(f'Consider using the built-in warning_level option instead of using "{arg}".',


### PR DESCRIPTION
`-Oz` is the appropriate flag to use when you want to produce the smallest possible binary, and is one would expect when setting `optimization` to `s` or using the `minsize` build type.

More info [here](https://android.googlesource.com/platform/ndk/+/master/docs/ClangMigration.md#versus) 

Related to #7176