### PR TITLE
compilers/gnu: set level 0 optimization to '-O0'

### DIFF
--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -55,7 +55,7 @@ gnulike_buildtype_args = {
 }  # type: T.Dict[str, T.List[str]]
 
 gnu_optimization_args = {
-    '0': [],
+    '0': ['-O0'],
     'g': ['-Og'],
     '1': ['-O1'],
     '2': ['-O2'],


### PR DESCRIPTION
GCC with optimization set to 0 does not actually result in no
optimizations, which can be annoying when trying to use a debugger like
gdb, and finding that your variable has been optimized out. We already
do this with clang, so gcc is a bit of an outlier here.