### PR TITLE
modules: python: better handling of the Python paths for Debian

### DIFF
--- a/test cases/python/1 basic/meson.build
+++ b/test cases/python/1 basic/meson.build
@@ -9,14 +9,14 @@ if py_version.version_compare('< 3.2')
 endif
 
 py_purelib = py.get_path('purelib')
-if not py_purelib.endswith('site-packages')
+if not (py_purelib.endswith('site-packages') or py_purelib.endswith('dist-packages'))
   error('Python3 purelib path seems invalid? ' + py_purelib)
 endif
 message('Python purelib path:', py_purelib)
 
 # could be 'lib64' or 'Lib' on some systems
 py_platlib = py.get_path('platlib')
-if not py_platlib.endswith('site-packages')
+if not (py_platlib.endswith('site-packages') or py_platlib.endswith('dist-packages'))
   error('Python3 platlib path seems invalid? ' + py_platlib)
 endif
 

--- a/test cases/python3/1 basic/meson.build
+++ b/test cases/python3/1 basic/meson.build
@@ -9,13 +9,13 @@ if py3_version.version_compare('< 3.2')
 endif
 
 py3_purelib = py3_mod.sysconfig_path('purelib')
-if not py3_purelib.to_lower().startswith('lib') or not py3_purelib.endswith('site-packages')
+if not py3_purelib.to_lower().startswith('lib') or not (py3_purelib.endswith('site-packages') or py3_purelib.endswith('dist-packages'))
   error('Python3 purelib path seems invalid?')
 endif
 
 # could be 'lib64' or 'Lib' on some systems
 py3_platlib = py3_mod.sysconfig_path('platlib')
-if not py3_platlib.to_lower().startswith('lib') or not py3_platlib.endswith('site-packages')
+if not py3_platlib.to_lower().startswith('lib') or not (py3_platlib.endswith('site-packages') or py3_platlib.endswith('dist-packages'))
   error('Python3 platlib path seems invalid?')
 endif
 


### PR DESCRIPTION
Hardcoding the name is fragile, and enabling it based on the existence of
/etc/debian_version (as the is_debianlike helper does) will result in
incorrect paths if the Python binary is not provided by Debian.

Using the deb_system distutils scheme instead makes sure we use the
install path from the current interpreter, which Debian could change
between releases, and gives us the correct value on Python installations
that are not provided by Debian (eg. deadsnakes, Github Action Python,
etc.)

Do notice, though, that there is still no guarantee that these are the
correct paths, as they assume all schemes paths have the install prefix
as a base, see #9284.

Signed-off-by: Filipe Laíns <lains@riseup.net>