### PR TITLE
Permit buildtargets in generator process

### DIFF
--- a/docs/markdown/snippets/permit_generator_any_target.md
+++ b/docs/markdown/snippets/permit_generator_any_target.md
@@ -1,0 +1,3 @@
+## Allow using generator with any Build Target.
+
+Calling `generator.process()` with a BuildTarget is now permitted.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -296,7 +296,7 @@ class Vs2010Backend(backends.Backend):
                 raise MesonException('Unknown target type for target %s' % target)
 
             for gendep in target.get_generated_sources():
-                if isinstance(gendep, build.CustomTarget):
+                if isinstance(gendep, (build.BuildTarget, build.CustomTarget)):
                     all_deps[gendep.get_id()] = gendep
                 elif isinstance(gendep, build.CustomTargetIndex):
                     all_deps[gendep.target.get_id()] = gendep.target

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1628,19 +1628,19 @@ class Generator(HoldableObject):
         relpath = pathlib.PurePath(trial).relative_to(parent)
         return relpath.parts[0] != '..' # For subdirs we can only go "down".
 
-    def process_files(self, files: T.Iterable[T.Union[str, File, 'CustomTarget', 'CustomTargetIndex', 'GeneratedList']],
+    def process_files(self, files: T.Iterable[T.Union[str, File, 'BuildTarget', 'CustomTarget', 'CustomTargetIndex', 'GeneratedList']],
                       state: T.Union['Interpreter', 'ModuleState'],
                       preserve_path_from: T.Optional[str] = None,
                       extra_args: T.Optional[T.List[str]] = None) -> 'GeneratedList':
         output = GeneratedList(self, state.subdir, preserve_path_from, extra_args=extra_args if extra_args is not None else [])
 
         for e in files:
-            if isinstance(e, CustomTarget):
+            if isinstance(e, (BuildTarget, CustomTarget)):
                 output.depends.add(e)
             if isinstance(e, CustomTargetIndex):
                 output.depends.add(e.target)
 
-            if isinstance(e, (CustomTarget, CustomTargetIndex, GeneratedList)):
+            if isinstance(e, (BuildTarget, CustomTarget, CustomTargetIndex, GeneratedList)):
                 self.depends.append(e) # BUG: this should go in the GeneratedList object, not this object.
                 fs = [File.from_built_file(state.subdir, f) for f in e.get_outputs()]
             elif isinstance(e, str):

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -960,14 +960,14 @@ class GeneratorHolder(ObjectHolder[build.Generator]):
         super().__init__(gen, interpreter)
         self.methods.update({'process': self.process_method})
 
-    @typed_pos_args('generator.process', min_varargs=1, varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList))
+    @typed_pos_args('generator.process', min_varargs=1, varargs=(str, mesonlib.File, build.BuildTarget, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList))
     @typed_kwargs(
         'generator.process',
         KwargInfo('preserve_path_from', (str, NoneType), since='0.45.0'),
         KwargInfo('extra_args', ContainerTypeInfo(list, str), listify=True, default=[]),
     )
     def process_method(self,
-                       args: T.Tuple[T.List[T.Union[str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList]]],
+                       args: T.Tuple[T.List[T.Union[str, mesonlib.File, build.BuildTarget, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList]]],
                        kwargs: 'kwargs.GeneratorProcess') -> build.GeneratedList:
         preserve_path_from = kwargs['preserve_path_from']
         if preserve_path_from is not None:
@@ -980,6 +980,11 @@ class GeneratorHolder(ObjectHolder[build.Generator]):
             FeatureNew.single_use(
                 'Calling generator.process with CustomTaget or Index of CustomTarget.',
                 '0.57.0', self.interpreter.subproject)
+
+        if any(isinstance(a, build.BuildTarget) for a in args[0]):
+            FeatureNew.single_use(
+                f'Calling generator.process with BuildTarget.',
+                '0.60.0', self.interpreter.subproject)
 
         gl = self.held_object.process_files(args[0], self.interpreter,
                                             preserve_path_from, extra_args=kwargs['extra_args'])

--- a/test cases/common/105 generatorcustom/embedded.c
+++ b/test cases/common/105 generatorcustom/embedded.c
@@ -1,0 +1,3 @@
+int main(void) {
+    return 0;
+}

--- a/test cases/common/105 generatorcustom/gen.py
+++ b/test cases/common/105 generatorcustom/gen.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 
+from pathlib import Path
 import sys
 
 ifile = sys.argv[1]
 ofile = sys.argv[2]
 
-with open(ifile) as f:
-    resname = f.readline().strip()
+
+resname = Path(ifile).stem
 
 templ = 'const char %s[] = "%s";\n'
 with open(ofile, 'w') as f:

--- a/test cases/common/105 generatorcustom/main.c
+++ b/test cases/common/105 generatorcustom/main.c
@@ -3,6 +3,6 @@
 #include "alltogether.h"
 
 int main(void) {
-    printf("%s - %s - %s - %s\n", res1, res2, res3, res4);
+    printf("%s - %s - %s - %s - %s\n", res1, res2, res3, res4, embedded);
     return 0;
 }

--- a/test cases/common/105 generatorcustom/meson.build
+++ b/test cases/common/105 generatorcustom/meson.build
@@ -16,7 +16,9 @@ res4 = custom_target('gen-res4',
     output : 'res4.txt',
     command : [gen_resx, '@OUTPUT@', '4'])
 
-hs = gen.process('res1.txt', 'res2.txt', res3, res4[0])
+embedded = executable('embedded', 'embedded.c')
+
+hs = gen.process('res1.txt', 'res2.txt', res3, res4[0], embedded)
 
 allinone = custom_target('alltogether',
     input : hs,


### PR DESCRIPTION
Hi!
This change permits a generator to consume outputs by any target instead of failing.
This is helpfull to create objcopy generators. I want to use objcopy and an python script to generate a header to embed an executable inside another executable for an dual core embedded target.