### PR TITLE
dependencies: Add JDK system dependency for Solaris

### DIFF
--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -545,6 +545,8 @@ class JDKSystemDependency(SystemDependency):
             return 'win32'
         elif m.is_darwin():
             return 'darwin'
+        elif m.is_sunos():
+            return 'solaris'
 
         return None
 


### PR DESCRIPTION
Handle is_sunos() machines in __machine_info_to_platform_include_dir