### PR TITLE
fix message function accepting bools and casting to string

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -91,6 +91,8 @@ def stringifyUserArguments(args, quote=False):
         return '[%s]' % ', '.join([stringifyUserArguments(x, True) for x in args])
     elif isinstance(args, dict):
         return '{%s}' % ', '.join(['{} : {}'.format(stringifyUserArguments(k, True), stringifyUserArguments(v, True)) for k, v in args.items()])
+    elif isinstance(args, bool):
+        pass # bools are a type of int, make this fallthrough to the error case
     elif isinstance(args, int):
         return str(args)
     elif isinstance(args, str):

--- a/test cases/unit/48 reconfigure/subprojects/sub1/meson.build
+++ b/test cases/unit/48 reconfigure/subprojects/sub1/meson.build
@@ -1,3 +1,3 @@
 project('sub1')
 
-message('sub1:werror', get_option('werror'))
+message('sub1:werror @0@'.format(get_option('werror')))

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2378,7 +2378,7 @@ class AllPlatformTests(BasePlatformTests):
         self.assertRegex(out, 'opt2 val2')
         self.assertRegex(out, 'opt3 val3')
         self.assertRegex(out, 'opt4 default4')
-        self.assertRegex(out, 'sub1:werror True')
+        self.assertRegex(out, 'sub1:werror true')
         self.build()
         self.run_tests()
 
@@ -2392,7 +2392,7 @@ class AllPlatformTests(BasePlatformTests):
         self.assertRegex(out, 'opt2 val2')
         self.assertRegex(out, 'opt3 val3')
         self.assertRegex(out, 'opt4 val4')
-        self.assertRegex(out, 'sub1:werror True')
+        self.assertRegex(out, 'sub1:werror true')
         self.assertTrue(Path(self.builddir, '.gitignore').exists())
         self.build()
         self.run_tests()


### PR DESCRIPTION
This was allowed by accident despite what meson said would work, because in python a bool counts as a subclass of int.