### PR TITLE
Revert "mtest: fix test output issues (in console)"

### DIFF
--- a/mesonbuild/mlog.py
+++ b/mesonbuild/mlog.py
@@ -158,9 +158,6 @@ class AnsiText:
 def bold(text: str, quoted: bool = False) -> AnsiDecorator:
     return AnsiDecorator(text, "\033[1m", quoted=quoted)
 
-def italic(text: str, quoted: bool = False) -> AnsiDecorator:
-    return AnsiDecorator(text, "\033[3m", quoted=quoted)
-
 def plain(text: str) -> AnsiDecorator:
     return AnsiDecorator(text, "")
 


### PR DESCRIPTION
This reverts commit 5fcb0e6525e2044e0f82bda488a51350e0f7f29f.
The commit is a massive change that should have been split in
separate pieces, and it also removes a few features:

* in verbose mode, subtests are not printed as they happen

* in non-verbose mode the progress report does not include the number of subtests that have been run

* in non-parallel mode, output is batched rather than printed as it happens

Furthermore, none of these changes are not documented in the release
notes.  Revert so that each proposal can be tested, evaluated and
documented individually.