### PR TITLE
CODEOWNERS: add myself as "meson test" owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,3 +7,4 @@
 /mesonbuild/cmake/ @mensinda
 /mesonbuild/compilers/ @dcbaker
 /mesonbuild/linkers.py @dcbaker
+/mesonbuild/mtest.py @bonzini


### PR DESCRIPTION
"git shortlog" lists myself as the main contributor to `meson test`. Add myself to CODEOWNERS so that I automatically get subscribed to pull requests and can help with review.