### PR TITLE
tests/rust: add libm to fix build with rust 1.55

### DIFF
--- a/test cases/rust/5 polyglot static/meson.build
+++ b/test cases/rust/5 polyglot static/meson.build
@@ -2,6 +2,7 @@ project('static rust and c polyglot executable', 'c', 'rust')
 
 deps = [
   meson.get_compiler('c').find_library('dl', required: false),
+  meson.get_compiler('c').find_library('m', required: false),
   dependency('threads'),
 ]
 


### PR DESCRIPTION
Fixes #9309
