### PR TITLE
syntax-highlighting: vim: set b:undo_indent

### DIFF
--- a/data/syntax-highlighting/vim/indent/meson.vim
+++ b/data/syntax-highlighting/vim/indent/meson.vim
@@ -20,6 +20,8 @@ setlocal autoindent	" indentexpr isn't much help otherwise
 setlocal indentexpr=GetMesonIndent(v:lnum)
 setlocal indentkeys+==elif,=else,=endforeach,=endif,0)
 
+let b:undo_indent = "setl ai< inde< indk< lisp<"
+
 " Only define the function once.
 if exists("*GetMesonIndent")
   finish


### PR DESCRIPTION
The b:undo_indent variable gets executed to undo the effects of the
options set earlier in the file.

Signed-off-by: Doug Kearns <dougkearns@gmail.com>
Signed-off-by: Liam Beguin <liambeguin@gmail.com>