### PR TITLE
Update of Elbrus support

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -333,14 +333,19 @@ class ElbrusCCompiler(ElbrusCompiler, CCompiler):
                            info, exe_wrapper, linker=linker, full_version=full_version)
         ElbrusCompiler.__init__(self)
 
-    # It does support some various ISO standards and c/gnu 90, 9x, 1x in addition to those which GNU CC supports.
     def get_options(self) -> 'KeyedOptionDictType':
         opts = CCompiler.get_options(self)
-        opts[OptionKey('std', machine=self.for_machine, lang=self.language)].choices = [
-            'none', 'c89', 'c90', 'c9x', 'c99', 'c1x', 'c11',
-            'gnu89', 'gnu90', 'gnu9x', 'gnu99', 'gnu1x', 'gnu11',
-            'iso9899:2011', 'iso9899:1990', 'iso9899:199409', 'iso9899:1999',
-        ]
+        stds = ['c89', 'c9x', 'c99', 'gnu89', 'gnu9x', 'gnu99']
+        stds += ['iso9899:1990', 'iso9899:199409', 'iso9899:1999']
+        if version_compare(self.version, '>=1.20.00'):
+            stds += ['c11', 'gnu11']
+        if version_compare(self.version, '>=1.21.00') and version_compare(self.version, '<1.22.00'):
+            stds += ['c90', 'c1x', 'gnu90', 'gnu1x', 'iso9899:2011']
+        if version_compare(self.version, '>=1.23.00'):
+            stds += ['c90', 'c1x', 'gnu90', 'gnu1x', 'iso9899:2011']
+        if version_compare(self.version, '>=1.26.00'):
+            stds += ['c17', 'c18', 'iso9899:2017', 'iso9899:2018', 'gnu17', 'gnu18']
+        opts[OptionKey('std', machine=self.for_machine, lang=self.language)].choices = ['none'] + stds
         return opts
 
     # Elbrus C compiler does not have lchmod, but there is only linker warning, not compiler error.
@@ -354,6 +359,7 @@ class ElbrusCCompiler(ElbrusCompiler, CCompiler):
             return super().has_function(funcname, prefix, env,
                                         extra_args=extra_args,
                                         dependencies=dependencies)
+
 
 class IntelCCompiler(IntelGnuLikeCompiler, CCompiler):
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -323,15 +323,14 @@ class NvidiaHPC_CCompiler(PGICompiler, CCompiler):
         self.id = 'nvidia_hpc'
 
 
-class ElbrusCCompiler(GnuCCompiler, ElbrusCompiler):
+class ElbrusCCompiler(ElbrusCompiler, CCompiler):
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,
                  defines: T.Optional[T.Dict[str, str]] = None,
                  full_version: T.Optional[str] = None):
-        GnuCCompiler.__init__(self, exelist, version, for_machine, is_cross,
-                              info, exe_wrapper, defines=defines,
-                              linker=linker, full_version=full_version)
+        CCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                           info, exe_wrapper, linker=linker, full_version=full_version)
         ElbrusCompiler.__init__(self)
 
     # It does support some various ISO standards and c/gnu 90, 9x, 1x in addition to those which GNU CC supports.
@@ -355,7 +354,6 @@ class ElbrusCCompiler(GnuCCompiler, ElbrusCompiler):
             return super().has_function(funcname, prefix, env,
                                         extra_args=extra_args,
                                         dependencies=dependencies)
-
 
 class IntelCCompiler(IntelGnuLikeCompiler, CCompiler):
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -449,15 +449,14 @@ class NvidiaHPC_CPPCompiler(PGICompiler, CPPCompiler):
         self.id = 'nvidia_hpc'
 
 
-class ElbrusCPPCompiler(GnuCPPCompiler, ElbrusCompiler):
+class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,
                  defines: T.Optional[T.Dict[str, str]] = None,
                  full_version: T.Optional[str] = None):
-        GnuCPPCompiler.__init__(self, exelist, version, for_machine, is_cross,
-                                info, exe_wrapper, linker=linker,
-                                full_version=full_version, defines=defines)
+        CPPCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                             info, exe_wrapper, linker=linker, full_version=full_version)
         ElbrusCompiler.__init__(self)
 
     def get_options(self) -> 'KeyedOptionDictType':

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -462,16 +462,21 @@ class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
     def get_options(self) -> 'KeyedOptionDictType':
         opts = CPPCompiler.get_options(self)
 
-        cpp_stds = [
-            'none', 'c++98', 'c++03', 'c++0x', 'c++11', 'c++14', 'c++1y',
-            'gnu++98', 'gnu++03', 'gnu++0x', 'gnu++11', 'gnu++14', 'gnu++1y',
-        ]
-
+        cpp_stds = ['none', 'c++98', 'gnu++98']
+        if version_compare(self.version, '>=1.20.00'):
+            cpp_stds += ['c++03', 'c++0x', 'c++11', 'gnu++03', 'gnu++0x', 'gnu++11']
+        if version_compare(self.version, '>=1.21.00') and version_compare(self.version, '<1.22.00'):
+            cpp_stds += ['c++14', 'gnu++14', 'c++1y', 'gnu++1y']
+        if version_compare(self.version, '>=1.22.00'):
+            cpp_stds += ['c++14', 'gnu++14']
+        if version_compare(self.version, '>=1.23.00'):
+            cpp_stds += ['c++1y', 'gnu++1y']
         if version_compare(self.version, '>=1.24.00'):
-            cpp_stds += [ 'c++1z', 'c++17', 'gnu++1z', 'gnu++17' ]
-
+            cpp_stds += ['c++1z', 'c++17', 'gnu++1z', 'gnu++17']
         if version_compare(self.version, '>=1.25.00'):
-            cpp_stds += [ 'c++2a', 'gnu++2a' ]
+            cpp_stds += ['c++2a', 'gnu++2a']
+        if version_compare(self.version, '>=1.26.00'):
+            cpp_stds += ['c++20', 'gnu++20']
 
         key = OptionKey('std', machine=self.for_machine, lang=self.language)
         opts.update({

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -168,9 +168,9 @@ if is_windows():
 else:
     if platform.machine().lower() == 'e2k':
         defaults['c'] = ['cc', 'gcc', 'lcc', 'clang']
-        defaults['cpp'] = ['c++', 'g++', 'l++', 'clang']
+        defaults['cpp'] = ['c++', 'g++', 'l++', 'clang++']
         defaults['objc'] = ['clang']
-        defaults['objcpp'] = ['clang']
+        defaults['objcpp'] = ['clang++']
     else:
         defaults['c'] = ['cc', 'gcc', 'clang', 'nvc', 'pgcc', 'icc']
         defaults['cpp'] = ['c++', 'g++', 'clang++', 'nvc++', 'pgc++', 'icpc']

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -167,12 +167,10 @@ if is_windows():
     defaults['cs'] = ['csc', 'mcs']
 else:
     if platform.machine().lower() == 'e2k':
-        # There are no objc or objc++ compilers for Elbrus,
-        # and there's no clang which can build binaries for host.
-        defaults['c'] = ['cc', 'gcc', 'lcc']
-        defaults['cpp'] = ['c++', 'g++', 'l++']
-        defaults['objc'] = []
-        defaults['objcpp'] = []
+        defaults['c'] = ['cc', 'gcc', 'lcc', 'clang']
+        defaults['cpp'] = ['c++', 'g++', 'l++', 'clang']
+        defaults['objc'] = ['clang']
+        defaults['objcpp'] = ['clang']
     else:
         defaults['c'] = ['cc', 'gcc', 'clang', 'nvc', 'pgcc', 'icc']
         defaults['cpp'] = ['c++', 'g++', 'clang++', 'nvc++', 'pgc++', 'icpc']

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -694,14 +694,17 @@ def detect_fortran_compiler(env: 'Environment', for_machine: MachineChoice) -> C
                 if guess_gcc_or_lcc == 'lcc':
                     version = _get_lcc_version_from_defines(defines)
                     cls = ElbrusFortranCompiler
+                    linker = guess_nix_linker(env, compiler, cls, for_machine)
+                    return cls(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, defines, full_version=full_version, linker=linker)
                 else:
                     version = _get_gnu_version_from_defines(defines)
                     cls = GnuFortranCompiler
-                linker = guess_nix_linker(env, compiler, cls, for_machine)
-                return cls(
-                    compiler, version, for_machine, is_cross, info,
-                    exe_wrap, defines, full_version=full_version,
-                    linker=linker)
+                    linker = guess_nix_linker(env, compiler, cls, for_machine)
+                    return cls(
+                        compiler, version, for_machine, is_cross, info,
+                        exe_wrap, defines, full_version=full_version, linker=linker)
 
             if 'G95' in out:
                 cls = G95FortranCompiler

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -237,15 +237,14 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
                              dependencies=dependencies, mode='preprocess', disable_cache=disable_cache)
 
 
-class ElbrusFortranCompiler(GnuFortranCompiler, ElbrusCompiler):
+class ElbrusFortranCompiler(ElbrusCompiler, FortranCompiler):
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  defines: T.Optional[T.Dict[str, str]] = None,
                  linker: T.Optional['DynamicLinker'] = None,
                  full_version: T.Optional[str] = None):
-        GnuFortranCompiler.__init__(self, exelist, version, for_machine, is_cross,
-                                    info, exe_wrapper, defines=defines,
-                                    linker=linker, full_version=full_version)
+        FortranCompiler.__init__(self, exelist, version, for_machine, is_cross,
+                                 info, exe_wrapper, linker=linker, full_version=full_version)
         ElbrusCompiler.__init__(self)
 
 class G95FortranCompiler(FortranCompiler):

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -247,6 +247,17 @@ class ElbrusFortranCompiler(ElbrusCompiler, FortranCompiler):
                                  info, exe_wrapper, linker=linker, full_version=full_version)
         ElbrusCompiler.__init__(self)
 
+    def get_options(self) -> 'KeyedOptionDictType':
+        opts = FortranCompiler.get_options(self)
+        fortran_stds = ['f95', 'f2003', 'f2008', 'gnu', 'legacy', 'f2008ts']
+        key = OptionKey('std', machine=self.for_machine, lang=self.language)
+        opts[key].choices = ['none'] + fortran_stds
+        return opts
+
+    def get_module_outdir_args(self, path: str) -> T.List[str]:
+        return ['-J' + path]
+
+
 class G95FortranCompiler(FortranCompiler):
 
     LINKER_PREFIX = '-Wl,'

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -79,6 +79,9 @@ class ElbrusCompiler(GnuLikeCompiler):
     def get_optimization_args(self, optimization_level: str) -> T.List[str]:
         return gnu_optimization_args[optimization_level]
 
+    def get_prelink_args(self, prelink_name: str, obj_list: T.List[str]) -> T.List[str]:
+        return ['-r', '-nodefaultlibs', '-nostartfiles', '-o', prelink_name] + obj_list
+
     def get_pch_suffix(self) -> str:
         # Actually it's not supported for now, but probably will be supported in future
         return 'pch'

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -86,5 +86,12 @@ class ElbrusCompiler(GnuLikeCompiler):
         # Actually it's not supported for now, but probably will be supported in future
         return 'pch'
 
+    def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
+        args = []
+        std = options[OptionKey('std', lang=self.language, machine=self.for_machine)]
+        if std.value != 'none':
+            args.append('-std=' + std.value)
+        return args
+
     def openmp_flags(self) -> T.List[str]:
         return ['-fopenmp']

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -35,6 +35,11 @@ class ElbrusCompiler(GnuLikeCompiler):
         super().__init__()
         self.id = 'lcc'
         self.base_options = {OptionKey(o) for o in ['b_pgo', 'b_coverage', 'b_ndebug', 'b_staticpic', 'b_lundef', 'b_asneeded']}
+        default_warn_args = ['-Wall']
+        self.warn_args = {'0': [],
+                          '1': default_warn_args,
+                          '2': default_warn_args + ['-Wextra'],
+                          '3': default_warn_args + ['-Wextra', '-Wpedantic']}
 
     # FIXME: use _build_wrapper to call this so that linker flags from the env
     # get applied

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -25,6 +25,7 @@ from ...mesonlib import Popen_safe, OptionKey
 
 if T.TYPE_CHECKING:
     from ...environment import Environment
+    from ...coredata import KeyedOptionDictType
 
 
 class ElbrusCompiler(GnuLikeCompiler):

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -83,7 +83,7 @@ foreach qt : ['qt4', 'qt5', 'qt6']
 
     translations_cpp = qtmodule.compile_translations(qresource: qt+'_lang.qrc')
     # unity builds suck and definitely cannot handle two qrc embeds in one compilation unit
-    unityproof_translations = static_library('unityproof_translations', translations_cpp)
+    unityproof_translations = static_library(qt+'unityproof_translations', translations_cpp)
 
     extra_cpp_args += '-DQT="@0@"'.format(qt)
     qexe = executable(qt + 'app',

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -157,7 +157,8 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertEqual(libhello_nolib.get_compile_args(), [])
         self.assertEqual(libhello_nolib.get_pkgconfig_variable('foo', {}), 'bar')
         self.assertEqual(libhello_nolib.get_pkgconfig_variable('prefix', {}), self.prefix)
-        self.assertEqual(libhello_nolib.get_pkgconfig_variable('escaped_var', {}), r'hello\ world')
+        if version_compare(libhello_nolib.check_pkgconfig(libhello_nolib.pkgbin),">=0.29.1"):
+            self.assertEqual(libhello_nolib.get_pkgconfig_variable('escaped_var', {}), r'hello\ world')
         self.assertEqual(libhello_nolib.get_pkgconfig_variable('unescaped_var', {}), 'hello world')
 
         cc = detect_c_compiler(env, MachineChoice.HOST)


### PR DESCRIPTION
Some new changes primarily to keep Elbrus platform support up to date.

Support is generally still was ok, but a few unit tests were failed, so I've fixed it:
* `-std` support clarified for various versions of Elbrus compiler
* Added required prelinking arguments for linking with `-r` parameter
* Don't fail unit tests if `pkg-config` is less than 0.29.1 (0.29 it is on reference Elbrus OS)
* Don't fail unit tests if there is more than one major versions of qt installed (reference Elbrus OS has qt4 and qt5)

Unit tests results:

| Host | Arch | OS | Python | gcc/lcc | clang | Result |
|-------|-------|-------|-------|-------|-------|-------|
| flandre | x86_64 | Ubuntu 20.04.2 | 3.8.10 | gcc 9.3.0 | 10.0.0 | 394 passed, 54 skipped in 39.51s |
| shizuha | i686 | Ubuntu 18.04.5 | 3.6.9 | gcc 7.5.0 | None | 1 failed, 367 passed, 80 skipped in 1754.42s |
| daiyousei | aarch64 | Ubuntu 21.04 | 3.9.5 | gcc 10.3.0 | 12.0.0 | 376 passed, 72 skipped in 559.70s |
| sakuya | e8c | OS Elbrus 6.0-rc3 | 3.7.4 | lcc 1.25.09 | 9.0.1 | 381 passed, 67 skipped in 317.96s |
| minoriko | e8c2 | OS Elbrus 6.0-rc3 | 3.7.4 | lcc 1.25.17 | 9.0.1 | 1 failed, 379 passed, 68 skipped in 281.29s |

Elbrus-8CV had `LinuxlikeTests::test_pkgconfig_csharp_library` test failed, but it is not related to meson, it's broken experimental `mcs` that can't build simple programs (that's the thing our devs are working on).
Also i686 somehow had `AllPlatformTests::test_options_with_choices_changing` failed with `AssertionError: 'a' != 'b'`, but the current master fails the same test too. Don't know what to do with that.