### PR TITLE
Vim: use the Boolean highlight group for boolean literals

### DIFF
--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -58,7 +58,7 @@ syn match   mesonEscape	"\\$"
 syn match   mesonNumber	"\<\d\+\>"
 
 " booleans
-syn keyword mesonConstant	false true
+syn keyword mesonBoolean	false true
 
 " Built-in functions
 syn keyword mesonBuiltin
@@ -142,7 +142,7 @@ hi def link mesonString	String
 hi def link mesonEscape	Special
 hi def link mesonNumber	Number
 hi def link mesonBuiltin	Function
-hi def link mesonConstant	Number
+hi def link mesonBoolean	Boolean
 if exists("meson_space_error_higlight")
   hi def link mesonSpaceError	Error
 endif


### PR DESCRIPTION
It seems like a good idea.  Some color schemes are granular enough to match this group differently.
