### PR TITLE
Vim: add some 'standard' features to the ftplugin

### DIFF
--- a/data/syntax-highlighting/vim/ftplugin/meson.vim
+++ b/data/syntax-highlighting/vim/ftplugin/meson.vim
@@ -12,9 +12,28 @@ set cpo&vim
 
 setlocal commentstring=#\ %s
 setlocal comments=:#
+setlocal formatoptions+=croql formatoptions-=t
 
-setlocal shiftwidth=2
-setlocal softtabstop=2
+let b:undo_ftplugin = "setl com< cms< fo<"
+
+if get(g:, "meson_recommended_style", 1)
+  setlocal expandtab
+  setlocal shiftwidth=2
+  setlocal softtabstop=2
+  let b:undo_ftplugin .= " | setl et< sts< sw<"
+endif
+
+if exists("loaded_matchit") && !exists("b:match_words")
+  let b:match_words = '\<if\>:\<elif\>:\<else\>:\<endif\>,' .
+	\             '\<foreach\>:\<break\>:\<continue\>:\<endforeach\>'
+  let b:undo_ftplugin .= "| unlet! b:match_words"
+endif
+
+if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
+  let b:browsefilter = "Meson Build Files (meson.build)\tmeson.build\n" .
+	\	       "All Files (*.*)\t*.*\n"
+  let b:undo_ftplugin .= "| unlet! b:browsefilter"
+endif
 
 let &cpo = s:keepcpo
 unlet s:keepcpo


### PR DESCRIPTION
Add 'formatoptions' to improve comment formatting.

Set b:match_words.  See :help matchit

Set b:browsefilter. See :help browsefilter

Add 'expandtab' from the style guide and a meson_recommended_style
config variable to allow users to disable style-related settings.  This
is a defacto standard feature for ftplugins.
