### PR TITLE
Fix CPU detection on iOS

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -353,6 +353,16 @@ def detect_cpu_family(compilers: CompilersDict) -> str:
         # AIX always returns powerpc, check here for 64-bit
         if any_compiler_has_define(compilers, '__64BIT__'):
             trial = 'ppc64'
+    # While trying to read machine infomations on iOS/watchOS/tvOS, it returns
+    # the machine model name rather than architecture, e.g. `uname -m` would get
+    # 'iPhone13,1' but not 'arm64' on iPhone 12 mini. Same thing happens on other
+    # Apple mobile devices, but `uname -p` is having correct values, so use
+    # platform.processor instead of the default platform.machine
+    elif any(appleDevices in trial for appleDevice in ['iphone', 'ipad', 'ipod', 'watch', 'appletv', 'audioaccessory']):
+        if 'arm64' in platform.processor().lower():
+            trial = 'aarch64'
+        elif 'armv7' in platform.processor().lower():
+            trial = 'arm'
 
     if trial not in known_cpu_families:
         mlog.warning(f'Unknown CPU family {trial!r}, please report this at '
@@ -396,6 +406,9 @@ def detect_cpu(compilers: CompilersDict) -> str:
         # AIX always returns powerpc, check here for 64-bit
         if any_compiler_has_define(compilers, '__64BIT__'):
             trial = 'ppc64'
+    # Same iOS detection as above, but use processor type directly
+    elif any(appleDevices in trial for appleDevice in ['iphone', 'ipad', 'ipod', 'watch', 'appletv', 'audioaccessory']):
+        trial = platform.processor().lower()
 
     # Add more quirks here as bugs are reported. Keep in sync with
     # detect_cpu_family() above.


### PR DESCRIPTION
I'm using a jailbroken iOS device to run mesonbuild, but it seems having issues while detecting CPU
```
The Meson build system
Version: 0.59.1
Source dir: /private/var/mobile/proj/gobject-introspection-1.70.0
Build dir: /private/var/mobile/proj/gobject-introspection-1.70.0/build
Build type: native build
Project name: gobject-introspection
Project version: 1.70.0
C compiler for the host machine: ccache cc (clang 10.0.0 "clang version 10.0.0 (git@bingner.com:elucubratus.git 38d9371d79ade653c47347ca418b91e61808011c)")
C linker for the host machine: cc ld64 609
WARNING: Unknown CPU family 'iphone13,1', please report this at https://github.com/mesonbuild/meson/issues/new with the output of `uname -a` and `cat /proc/cpuinfo`
WARNING: Unknown CPU family 'iphone13,1', please report this at https://github.com/mesonbuild/meson/issues/new with the output of `uname -a` and `cat /proc/cpuinfo`
WARNING: Unknown CPU family 'iphone13,1', please report this at https://github.com/mesonbuild/meson/issues/new with the output of `uname -a` and `cat /proc/cpuinfo`
Host machine cpu family: iphone13,1
Host machine cpu: iphone13,1
```
Then I figured out it was not caused by Python; after executing `uname -m`, I still got an unexpected result. After that I found processor output was correct
```
iPhone:~/proj/gobject-introspection-1.70.0/build mobile$ uname -m
iPhone13,1
iPhone:~/proj/gobject-introspection-1.70.0/build mobile$ uname -p
arm64
iPhone:~/proj/gobject-introspection-1.70.0/build mobile$ uname -a
Darwin iPhone 20.1.0 Darwin Kernel Version 20.1.0: Fri Oct 30 00:34:17 PDT 2020; root:xnu-7195.42.3~1/RELEASE_ARM64_T8101 iPhone13,1 arm64 D52gAP Darwin
```
Before Python do something regarding to this bug, I have made some simple fixes here, after this modification, it then works fine.
```
Phone:~/proj/gobject-introspection-1.70.0/build mobile$ GI_SCANNER_DISABLE_CACHE=true meson -Dpython=/usr/bin/python3.9 -Dextra_library_paths=/usr/lib .. 
The Meson build system
Version: 0.59.1
Source dir: /private/var/mobile/proj/gobject-introspection-1.70.0
Build dir: /private/var/mobile/proj/gobject-introspection-1.70.0/build
Build type: native build
Project name: gobject-introspection
Project version: 1.70.0
C compiler for the host machine: ccache cc (clang 10.0.0 "clang version 10.0.0 (git@bingner.com:elucubratus.git 38d9371d79ade653c47347ca418b91e61808011c)")
C linker for the host machine: cc ld64 609
Host machine cpu family: aarch64
Host machine cpu: arm64
Program python3 found: YES (/usr/bin/python3.9)
Compiler for C supports arguments -Warray-bounds: YES 
Compiler for C supports arguments -Wcast-align: YES 
Compiler for C supports arguments -Wdeclaration-after-statement: YES 
Compiler for C supports arguments -Wduplicated-branches: NO 
Compiler for C supports arguments -Wformat=2: YES 
Compiler for C supports arguments -Wformat-nonliteral: YES 
Compiler for C supports arguments -Wformat-security: YES 
Compiler for C supports arguments -Wimplicit-function-declaration: YES 
Compiler for C supports arguments -Winit-self: YES 
Compiler for C supports arguments -Wjump-misses-init: NO 
Compiler for C supports arguments -Wlogical-op: NO 
Compiler for C supports arguments -Wmissing-declarations: YES 
Compiler for C supports arguments -Wmissing-format-attribute: YES 
Compiler for C supports arguments -Wmissing-include-dirs: YES 
Compiler for C supports arguments -Wmissing-noreturn: YES 
Compiler for C supports arguments -Wmissing-prototypes: YES 
Compiler for C supports arguments -Wnested-externs: YES 
Compiler for C supports arguments -Wnull-dereference: YES 
Compiler for C supports arguments -Wold-style-definition: YES 
Compiler for C supports arguments -Wpacked: YES 
Compiler for C supports arguments -Wpointer-arith: YES 
Compiler for C supports arguments -Wrestrict: NO 
Compiler for C supports arguments -Wreturn-type: YES 
Compiler for C supports arguments -Wshadow: YES 
Compiler for C supports arguments -Wsign-compare: YES 
Compiler for C supports arguments -Wstrict-aliasing: YES 
Compiler for C supports arguments -Wstrict-prototypes: YES 
Compiler for C supports arguments -Wundef: YES 
Compiler for C supports arguments -Wunused-but-set-variable: NO 
Compiler for C supports arguments -Wwrite-strings: YES 
Compiler for C supports arguments -fno-strict-aliasing: YES 
Checking for size of "char" : 1
Checking for size of "short" : 2
Checking for size of "int" : 4
Checking for size of "long" : 8
Configuring config.h using configuration
Found pkg-config: /usr/bin/pkg-config (0.29.2)
Run-time dependency glib-2.0 found: YES 2.68.2
Run-time dependency gobject-2.0 found: YES 2.68.2
Run-time dependency gio-2.0 found: YES 2.68.2
Run-time dependency gmodule-2.0 found: YES 2.68.2
Run-time dependency gio-unix-2.0 found: YES 2.68.2
Run-time dependency libffi found: YES 3.4.2
Dependency python found: YES (pkgconfig)
Check usable header "Python.h" with dependency python: YES 
Run-time dependency cairo found: YES 1.16.0
Run-time dependency cairo-gobject found: YES 1.16.0
../meson.build:212: WARNING: Not building with doctool support, not all tests will be run
Library m found: YES
Compiler for C supports arguments -Wno-implicit-fallthrough: YES 
Compiler for C supports arguments -Wno-old-style-definition: YES 
Compiler for C supports arguments -Wno-suggest-attribute=noreturn: NO 
Compiler for C supports arguments -Wno-type-limits: YES 
Compiler for C supports arguments -Wno-undef: YES 
Compiler for C supports arguments -Wno-unused-parameter: YES 
Compiler for C supports arguments -Wno-cast-align: YES 
Compiler for C supports arguments -Wno-unused-function: YES 
Compiler for C supports arguments -Wno-return-type: YES 
Compiler for C supports arguments -Wno-old-style-definition: YES (cached)
Compiler for C supports arguments -Wno-type-limits: YES (cached)
Compiler for C supports arguments -Wno-old-style-definition: YES (cached)
Compiler for C supports arguments -Wno-cast-align: YES (cached)
Compiler for C supports arguments -Wno-unused-parameter: YES (cached)
Compiler for C supports arguments -Wno-duplicated-branches: NO 
Compiler for C supports arguments -Wno-cast-align: YES (cached)
Configuring giversion.h using configuration
Compiler for C supports arguments -Wno-unused-parameter: YES (cached)
Compiler for C supports arguments -Wno-duplicated-branches: NO (cached)
Compiler for C supports arguments -Wno-type-limits: YES (cached)
Compiler for C supports arguments -Wno-cast-align: YES (cached)
Compiler for C supports arguments -Wno-missing-field-initializers: YES 
Configuring g-ir-scanner using configuration
Program g-ir-scanner found: YES (/private/var/mobile/proj/gobject-introspection-1.70.0/build/tools/g-ir-scanner)
Configuring g-ir-annotation-tool using configuration
Program g-ir-annotation-tool found: YES (/private/var/mobile/proj/gobject-introspection-1.70.0/build/tools/g-ir-annotation-tool)
Compiler for C supports arguments -Wno-missing-field-initializers: YES (cached)
Configuring _version.py using configuration
Configuring __init__.py using configuration
Configuring annotationmain.py using configuration
Configuring annotationparser.py using configuration
Configuring ast.py using configuration
Configuring cachestore.py using configuration
Configuring ccompiler.py using configuration
Configuring codegen.py using configuration
Configuring docmain.py using configuration
Configuring docwriter.py using configuration
Configuring dumper.py using configuration
Configuring introspectablepass.py using configuration
Configuring girparser.py using configuration
Configuring girwriter.py using configuration
Configuring gdumpparser.py using configuration
Configuring maintransformer.py using configuration
Configuring mdextensions.py using configuration
Configuring message.py using configuration
Configuring msvccompiler.py using configuration
Configuring pkgconfig.py using configuration
Configuring shlibs.py using configuration
Configuring scannermain.py using configuration
Configuring sectionparser.py using configuration
Configuring sourcescanner.py using configuration
Configuring testcodegen.py using configuration
Configuring transformer.py using configuration
Configuring utils.py using configuration
Configuring xmlwriter.py using configuration
../giscanner/meson.build:66: WARNING: Custom target input 'doctemplates' can't be converted to File object(s).
This will become a hard error in the future.
Program flex found: YES (/usr/bin/flex)
Program bison found: YES (/usr/bin/bison)
Has header "unistd.h" : YES 
Compiler for C supports arguments -Wno-missing-field-initializers: YES (cached)
Compiler for C supports arguments -Wno-unused-parameter: YES (cached)
Dependency python found: YES (pkgconfig)
Configuring cairo-1.0.gir using configuration
Program g-ir-scanner found: YES (overridden)
Program g-ir-scanner found: YES (overridden)
Program g-ir-compiler found: YES (overridden)
Compiler for C supports arguments -Wno-unused-parameter: YES (cached)
Compiler for C supports arguments -Wno-unused-parameter: YES (cached)
Compiler for C supports arguments -Wno-unused-parameter: YES (cached)
Compiler for C supports arguments -Wno-unused-parameter: YES (cached)
Compiler for C supports arguments -Wno-old-style-definition: YES (cached)
Compiler for C supports arguments -Wno-missing-field-initializers: YES (cached)
Compiler for C supports arguments -Wno-unused-parameter: YES (cached)
Build targets in project: 83

Found ninja-1.10.0 at /usr/bin/ninja
```