### PR TITLE
rust: dependencies need to cause a rebuild/relink not just reorder

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1651,7 +1651,10 @@ class NinjaBackend(backends.Backend):
         args += compilers.get_base_compile_args(base_proxy, rustc)
         self.generate_generator_list_rules(target)
 
-        orderdeps = [os.path.join(t.subdir, t.get_filename()) for t in target.link_targets]
+        # dependencies need to cause a relink, they're not just for odering
+        deps = [os.path.join(t.subdir, t.get_filename()) for t in target.link_targets]
+
+        orderdeps: T.List[str] = []
 
         main_rust_file = None
         for i in target.get_sources():
@@ -1772,6 +1775,8 @@ class NinjaBackend(backends.Backend):
         element = NinjaBuildElement(self.all_outputs, target_name, compiler_name, main_rust_file)
         if orderdeps:
             element.add_orderdep(orderdeps)
+        if deps:
+            element.add_dep(deps)
         element.add_item('ARGS', args)
         element.add_item('targetdep', depfile)
         element.add_item('cratetype', cratetype)

--- a/test cases/unit/100 rlib linkage/lib2.rs
+++ b/test cases/unit/100 rlib linkage/lib2.rs
@@ -1,0 +1,5 @@
+use lib;
+
+pub fn fun() {
+    lib::fun();
+}

--- a/test cases/unit/100 rlib linkage/main.rs
+++ b/test cases/unit/100 rlib linkage/main.rs
@@ -1,0 +1,5 @@
+use lib2::fun;
+
+fn main() {
+    fun();
+}

--- a/test cases/unit/100 rlib linkage/meson.build
+++ b/test cases/unit/100 rlib linkage/meson.build
@@ -1,0 +1,22 @@
+project('rlib linkage', 'rust', default_options : ['rust_std=2018'])
+
+lib = static_library(
+  'lib',
+  'lib.rs',
+  rust_crate_type : 'rlib',
+)
+
+lib2 = static_library(
+  'lib2',
+  'lib2.rs',
+  rust_crate_type : 'rlib',
+  link_with : lib,
+)
+
+exe = executable(
+  'exe',
+  'main.rs',
+  link_with : lib2,
+)
+
+test('main', exe)


### PR DESCRIPTION
Otherwise changes to a dependency don't propagate