### PR TITLE
Add type annotations and typed_kwargs for external_project

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -29,7 +29,7 @@ from ..interpreterbase import FeatureDeprecated
 if T.TYPE_CHECKING:
     from ..compilers.compilers import Compiler
     from ..environment import Environment
-    from ..build import BuildTarget
+    from ..build import BuildTarget, CustomTarget
     from ..mesonlib import FileOrString
 
 
@@ -88,7 +88,7 @@ class Dependency(HoldableObject):
         # Raw -L and -l arguments without manual library searching
         # If None, self.link_args will be used
         self.raw_link_args: T.Optional[T.List[str]] = None
-        self.sources: T.List['FileOrString'] = []
+        self.sources: T.List[T.Union['FileOrString', 'CustomTarget']] = []
         self.include_type = self._process_include_type_kw(kwargs)
         self.ext_deps: T.List[Dependency] = []
 
@@ -142,7 +142,7 @@ class Dependency(HoldableObject):
     def found(self) -> bool:
         return self.is_found
 
-    def get_sources(self) -> T.List['FileOrString']:
+    def get_sources(self) -> T.List[T.Union['FileOrString', 'CustomTarget']]:
         """Source files that need to be added to the target.
         As an example, gtest-all.cc when using GTest."""
         return self.sources
@@ -218,7 +218,8 @@ class Dependency(HoldableObject):
 class InternalDependency(Dependency):
     def __init__(self, version: str, incdirs: T.List[str], compile_args: T.List[str],
                  link_args: T.List[str], libraries: T.List['BuildTarget'],
-                 whole_libraries: T.List['BuildTarget'], sources: T.List['FileOrString'],
+                 whole_libraries: T.List['BuildTarget'],
+                 sources: T.Sequence[T.Union['FileOrString', 'CustomTarget']],
                  ext_deps: T.List[Dependency], variables: T.Dict[str, T.Any]):
         super().__init__(DependencyTypeName('internal'), {})
         self.version = version
@@ -228,7 +229,7 @@ class InternalDependency(Dependency):
         self.link_args = link_args
         self.libraries = libraries
         self.whole_libraries = whole_libraries
-        self.sources = sources
+        self.sources = list(sources)
         self.ext_deps = ext_deps
         self.variables = variables
 

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -1093,7 +1093,7 @@ def join_args(args: T.Iterable[str]) -> str:
 
 
 def do_replacement(regex: T.Pattern[str], line: str, variable_format: str,
-                   confdata: 'ConfigurationData') -> T.Tuple[str, T.Set[str]]:
+                   confdata: T.Union[T.Dict[str, T.Tuple[str, T.Optional[str]]], 'ConfigurationData']) -> T.Tuple[str, T.Set[str]]:
     missing_variables = set()  # type: T.Set[str]
     if variable_format == 'cmake':
         start_tag = '${'
@@ -1116,7 +1116,7 @@ def do_replacement(regex: T.Pattern[str], line: str, variable_format: str,
             varname = match.group(1)
             var_str = ''
             if varname in confdata:
-                (var, desc) = confdata.get(varname)
+                var, _ = confdata.get(varname)
                 if isinstance(var, str):
                     var_str = var
                 elif isinstance(var, int):

--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -12,19 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os, subprocess, shlex
 from pathlib import Path
+import os
+import shlex
+import subprocess
 import typing as T
 
 from . import ExtensionModule, ModuleReturnValue, ModuleState, NewExtensionModule
 from .. import mlog, build
-from ..mesonlib import (EnvironmentException, MesonException, Popen_safe, MachineChoice,
-                       get_variable_regex, do_replacement, extract_as_list, join_args)
-from ..interpreterbase import InterpreterException, FeatureNew
-from ..interpreterbase import permittedKwargs, typed_pos_args
 from ..compilers.compilers import CFLAGS_MAPPING, CEXE_MAPPING
 from ..dependencies import InternalDependency, PkgConfigDependency
-from ..mesonlib import OptionKey
+from ..interpreterbase import InterpreterException, FeatureNew
+from ..interpreterbase import permittedKwargs, typed_pos_args
+from ..mesonlib import (EnvironmentException, MesonException, Popen_safe, MachineChoice,
+                       get_variable_regex, do_replacement, extract_as_list, join_args, OptionKey)
 
 class ExternalProject(NewExtensionModule):
     def __init__(self,

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -42,6 +42,7 @@ modules = [
     'mesonbuild/modules/i18n.py',
     'mesonbuild/modules/java.py',
     'mesonbuild/modules/qt.py',
+    'mesonbuild/modules/unstable_external_project.py',
     'mesonbuild/modules/unstable_rust.py',
     'mesonbuild/mparser.py',
     'mesonbuild/msetup.py',


### PR DESCRIPTION
~~This is based on the i18n series, so that should land first.~~ i18n changes are in.

This is more work toward being able to refactor the CustomTarget argument handling out of the build module and into the interpreter.