### PR TITLE
cmake module: if cmake cannot be found, do not traceback

### DIFF
--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -238,6 +238,9 @@ class CmakeModule(ExtensionModule):
             return True
 
         cmakebin = ExternalProgram('cmake', silent=False)
+        if not cmakebin.found():
+            return False
+
         p, stdout, stderr = mesonlib.Popen_safe(cmakebin.get_command() + ['--system-information', '-G', 'Ninja'])[0:3]
         if p.returncode != 0:
             mlog.log(f'error retrieving cmake information: returnCode={p.returncode} stdout={stdout} stderr={stderr}')


### PR DESCRIPTION
We ended up passing a NoneType as the program binary, which is a very awkward way to communicate an error when failing to write a basic package version file.