### PR TITLE
Structured Sources

### DIFF
--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -116,6 +116,7 @@ syn keyword mesonBuiltin
   \ shared_library
   \ shared_module
   \ static_library
+  \ structured_sources
   \ subdir
   \ subdir_done
   \ subproject

--- a/docs/markdown/Rust.md
+++ b/docs/markdown/Rust.md
@@ -1,0 +1,56 @@
+---
+title: Rust
+short-description: Working with Rust in Meson
+---
+
+# Using Rust with Meson
+
+## Mixing Rust and non-Rust sources
+
+Meson currently does not support creating a single target with Rust and non Rust
+sources mixed together, therefore one must compile multiple libraries and link
+them.
+
+```meson
+rust_lib = static_library(
+    'rust_lib',
+    sources : 'lib.rs',
+    ...
+)
+
+c_lib = static_library(
+    'c_lib',
+    sources : 'lib.c',
+    link_with : rust_lib,
+)
+```
+This is an implementation detail of Meson, and is subject to change in the future.
+
+## Mixing Generated and Static sources
+
+*Note* This feature was added in 0.62
+
+You can use a [[structured_source]] for this. Structured sources are a dictionary
+mapping a string of the directory, to a source or list of sources.
+When using a structured source all inputs *must* be listed, as Meson may copy
+the sources from the source tree to the build tree.
+
+Structured inputs are generally not needed when not using generated sources.
+
+As an implementation detail, Meson will attempt to determine if it needs to copy
+files at configure time and will skip copying if it can. Copying is done at
+build time (when necessary), to avoid reconfiguring when sources change.
+
+```meson
+executable(
+    'rust_exe',
+    structured_sources(
+        'main.rs',
+        {
+            'foo' : ['bar.rs', 'foo/lib.rs', generated_rs],
+            'foo/bar' : [...],
+            'other' : [...],
+        }
+    )
+)
+```

--- a/docs/markdown/snippets/structured_sources.md
+++ b/docs/markdown/snippets/structured_sources.md
@@ -1,0 +1,26 @@
+## structured_sources()
+
+A new function, `structured_sources()` has been added. This function allows
+languages like Rust which depend on the filesystem layout at compile time to mix
+generated and static sources.
+
+```meson
+executable(
+  'main',
+  structured_sources(
+    'main.rs,
+    {'mod' : generated_mod_rs},
+  )
+)
+```
+
+Meson will then at build time copy the files into the build directory (if
+necessary), so that the desired file structure is laid out, and compile that. In
+this case:
+
+```
+root/
+  main.rs
+  mod/
+    mod.rs
+```

--- a/docs/sitemap.txt
+++ b/docs/sitemap.txt
@@ -63,6 +63,7 @@ index.md
 		Vala.md
 		D.md
 		Cython.md
+		Rust.md
 		IDE-integration.md
 		Custom-build-targets.md
 		Build-system-converters.md

--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -49,7 +49,7 @@ kwargs:
       eg: `cpp_args` for C++
 
   sources:
-    type: str | file | custom_tgt | custom_idx | generated_list
+    type: str | file | custom_tgt | custom_idx | generated_list | structured_src
     description: Additional source files. Same as the source varargs.
 
   build_by_default:

--- a/docs/yaml/functions/structured_sources.yaml
+++ b/docs/yaml/functions/structured_sources.yaml
@@ -1,0 +1,21 @@
+name: structured_sources
+returns: structured_src
+since: 0.62.0
+description: |
+  Create a StructuredSource object, which is opaque and may be passed as a source
+  to any build_target (including static_library, shared_library, executable,
+  etc.). This is useful for languages like Rust, which use the filesystem layout
+  to determine import names. This is only allowed in Rust targets, and cannot be
+  mixed with non structured inputs.
+
+posargs:
+  root:
+    type: list[str | file | custom_tgt | custom_idx | generated_list]
+    description: Sources to put at the root of the generated structure
+
+optargs:
+  additional:
+    type: dict[str | file | custom_tgt | custom_idx | generated_list]
+    description: |
+      Additional sources, where the key is the directory under the root to place
+      the values

--- a/docs/yaml/objects/structured_src.yaml
+++ b/docs/yaml/objects/structured_src.yaml
@@ -1,0 +1,3 @@
+name: structured_src
+long_name: Structured Source
+description: Opaque object returned by [[structured_sources]].

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -154,6 +154,7 @@ class AstInterpreter(InterpreterBase):
                            'alias_target': self.func_do_nothing,
                            'summary': self.func_do_nothing,
                            'range': self.func_do_nothing,
+                           'structured_sources': self.func_do_nothing,
                            })
 
     def _unholder_args(self, args: _T, kwargs: _V) -> T.Tuple[_T, _V]:

--- a/mesonbuild/ast/introspection.py
+++ b/mesonbuild/ast/introspection.py
@@ -249,7 +249,7 @@ class IntrospectionInterpreter(AstInterpreter):
         objects = []        # type: T.List[T.Any]
         empty_sources = []  # type: T.List[T.Any]
         # Passing the unresolved sources list causes errors
-        target = targetclass(name, self.subdir, self.subproject, for_machine, empty_sources, objects, self.environment, kwargs_reduced)
+        target = targetclass(name, self.subdir, self.subproject, for_machine, empty_sources, [], objects, self.environment, kwargs_reduced)
 
         new_target = {
             'name': target.get_basename(),

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -54,6 +54,7 @@ if T.TYPE_CHECKING:
     from .._typing import ImmutableListProtocol
     from ..linkers import DynamicLinker, StaticLinker
     from ..compilers.cs import CsCompiler
+    from ..interpreter.interpreter import SourceOutputs
 
 
 FORTRAN_INCLUDE_PAT = r"^\s*#?include\s*['\"](\w+\.\w+)['\"]"
@@ -1662,6 +1663,29 @@ class NinjaBackend(backends.Backend):
         elem.add_orderdep(instr)
         self.add_build(elem)
 
+    def __generate_compile_structure(self, target: build.BuildTarget) -> T.Tuple[T.List[str], T.Optional[str]]:
+        first_file: T.Optional[str] = None
+        orderdeps: T.List[str] = []
+        root = Path(self.get_target_private_dir(target)) / 'structured'
+        for path, files in target.structured_sources.sources.items():
+            for file in files:
+                if isinstance(file, (str, File)):
+                    if isinstance(file, str):
+                        file = File.from_absolute_file(file)
+                    out = root / path / Path(file.fname).name
+                    orderdeps.append(str(out))
+                    self._generate_copy_target(file, out)
+                    if first_file is None:
+                        first_file = str(out)
+                else:
+                    for f in file.get_outputs():
+                        out = root / path / f
+                        orderdeps.append(str(out))
+                        self._generate_copy_target(str(Path(file.subdir) / f), out)
+                        if first_file is None:
+                            first_file = str(out)
+        return orderdeps, first_file
+
     def generate_rust_target(self, target: build.BuildTarget) -> None:
         rustc = target.compilers['rust']
         # Rust compiler takes only the main file as input and
@@ -1682,6 +1706,25 @@ class NinjaBackend(backends.Backend):
         orderdeps: T.List[str] = []
 
         main_rust_file = None
+        if target.structured_sources:
+            if target.structured_sources.needs_copy(target):
+                _ods, main_rust_file = self.__generate_compile_structure(target)
+                orderdeps.extend(_ods)
+            else:
+                g = target.structured_sources.first_file()
+                if isinstance(g, str):
+                    g = File.from_source_file(self.environment.source_dir, target.subdir, g)
+
+                if isinstance(g, File):
+                    main_rust_file = g.rel_to_builddir(self.build_to_src)
+                elif isinstance(g, GeneratedList):
+                    main_rust_file = os.path.join(self.get_target_private_dir(target), i)
+                else:
+                    main_rust_file = os.path.join(g.get_subdir(), i)
+                orderdeps.extend([os.path.join(self.build_to_src, target.subdir, s)
+                                  for s in  target.structured_sources.as_list()])
+
+
         for i in target.get_sources():
             if not rustc.can_compile(i):
                 raise InvalidArguments(f'Rust target {target.get_basename()} contains a non-rust source file.')

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -455,7 +455,7 @@ class ExtractedObjects(HoldableObject):
 EnvInitValueType = T.Dict[str, T.Union[str, T.List[str]]]
 
 class EnvironmentVariables(HoldableObject):
-    def __init__(self, values: T.Optional[EnvValueType] = None,
+    def __init__(self, values: T.Optional[EnvInitValueType] = None,
                  init_method: Literal['set', 'prepend', 'append'] = 'set', separator: str = os.pathsep) -> None:
         self.envvars: T.List[T.Tuple[T.Callable[[T.Dict[str, str], str, T.List[str], str], str], str, T.List[str], str]] = []
         # The set of all env vars we have operations for. Only used for self.has_name()

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -426,7 +426,7 @@ class ExtractedObjects(HoldableObject):
         # Filter out headers and all non-source files
         return [s for s in sources if environment.is_source(s) and not environment.is_header(s)]
 
-    def classify_all_sources(self, sources: T.List[str], generated_sources: T.Sequence['GeneratedTypes']) -> T.Dict['Compiler', T.List['FileOrString']]:
+    def classify_all_sources(self, sources: T.List[FileOrString], generated_sources: T.Sequence['GeneratedTypes']) -> T.Dict['Compiler', T.List['FileOrString']]:
         sources_ = self.get_sources(sources, generated_sources)
         return classify_unity_sources(self.target.compilers.values(), sources_)
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -452,7 +452,62 @@ class ExtractedObjects(HoldableObject):
             for source in self.get_sources(self.srclist, self.genlist)
         ]
 
+
+@dataclass(eq=False, order=False)
+class StructuredSources(HoldableObject):
+
+    """A container for sources in languages that use filesystem hierarchy.
+
+    Languages like Rust and Cython rely on the layout of files in the filesystem
+    as part of the compiler implementation. This structure allows us to
+    represent the required filesystem layout.
+    """
+
+    sources: T.DefaultDict[str, T.List[T.Union[str, File, CustomTarget, CustomTargetIndex, GeneratedList]]] = field(
+        default_factory=lambda: defaultdict(list))
+
+    def __add__(self, other: StructuredSources) -> StructuredSources:
+        sources = self.sources.copy()
+        for k, v in other.sources.items():
+            sources[k].extend(v)
+        return StructuredSources(sources)
+
+    def __bool__(self) -> bool:
+        return bool(self.sources)
+
+    def first_file(self) -> T.Union[str, File, CustomTarget, CustomTargetIndex, GeneratedList]:
+        """Get the first source in the root
+
+        :return: The first source in the root
+        """
+        return self.sources[''][0]
+
+    def as_list(self) -> T.List[T.Union[str, File, CustomTarget, CustomTargetIndex, GeneratedList]]:
+        return list(itertools.chain.from_iterable(self.sources.values()))
+
+    def needs_copy(self, target: BuildTarget) -> bool:
+        """Do we need to create a structure in the build directory.
+
+        This allows us to avoid making copies if the structures exists in the
+        source dir. Which could happen in situations where a generated source
+        only exists in some configurations
+        """
+        p = pathlib.Path(target.subdir)
+        for files in self.sources.values():
+            for f in files:
+                if isinstance(f, str):
+                    if not (target.environment.source_dir / p / f).exists():
+                        return True
+                elif isinstance(f, File):
+                    if f.is_built:
+                        return True
+                else:
+                    return True
+        return False
+
+
 EnvInitValueType = T.Dict[str, T.Union[str, T.List[str]]]
+
 
 class EnvironmentVariables(HoldableObject):
     def __init__(self, values: T.Optional[EnvInitValueType] = None,

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -14,6 +14,8 @@
 
 # This file contains the detection logic for external dependencies.
 # Custom logic for several other packages are in separate files.
+
+from __future__ import annotations
 import copy
 import os
 import collections
@@ -29,6 +31,7 @@ from ..mesonlib import version_compare_many
 
 if T.TYPE_CHECKING:
     from .._typing import ImmutableListProtocol
+    from ..build import StructuredSources
     from ..compilers.compilers import Compiler
     from ..environment import Environment
     from ..interpreterbase import FeatureCheckBase
@@ -91,7 +94,7 @@ class Dependency(HoldableObject):
         # Raw -L and -l arguments without manual library searching
         # If None, self.link_args will be used
         self.raw_link_args: T.Optional[T.List[str]] = None
-        self.sources: T.List[T.Union['FileOrString', 'CustomTarget']] = []
+        self.sources: T.List[T.Union['FileOrString', 'CustomTarget', 'StructuredSources']] = []
         self.include_type = self._process_include_type_kw(kwargs)
         self.ext_deps: T.List[Dependency] = []
         self.d_features: T.DefaultDict[str, T.List[T.Any]] = collections.defaultdict(list)
@@ -148,7 +151,7 @@ class Dependency(HoldableObject):
     def found(self) -> bool:
         return self.is_found
 
-    def get_sources(self) -> T.List[T.Union['FileOrString', 'CustomTarget']]:
+    def get_sources(self) -> T.List[T.Union['FileOrString', 'CustomTarget', 'StructuredSources']]:
         """Source files that need to be added to the target.
         As an example, gtest-all.cc when using GTest."""
         return self.sources
@@ -228,7 +231,7 @@ class InternalDependency(Dependency):
                  link_args: T.List[str],
                  libraries: T.List[T.Union['BuildTarget', 'CustomTarget']],
                  whole_libraries: T.List[T.Union['BuildTarget', 'CustomTarget']],
-                 sources: T.Sequence[T.Union['FileOrString', 'CustomTarget']],
+                 sources: T.Sequence[T.Union['FileOrString', 'CustomTarget', StructuredSources]],
                  ext_deps: T.List[Dependency], variables: T.Dict[str, T.Any],
                  d_module_versions: T.List[str], d_import_dirs: T.List['IncludeDirs']):
         super().__init__(DependencyTypeName('internal'), {})

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -438,6 +438,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             build.InstallDir: OBJ.InstallDirHolder,
             build.IncludeDirs: OBJ.IncludeDirsHolder,
             build.EnvironmentVariables: OBJ.EnvironmentVariablesHolder,
+            build.StructuredSources: OBJ.StructuredSourcesHolder,
             compilers.RunResult: compilerOBJ.TryRunResultHolder,
             dependencies.ExternalLibrary: OBJ.ExternalLibraryHolder,
             coredata.UserFeatureOption: OBJ.FeatureOptionHolder,

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2753,7 +2753,7 @@ Try setting b_lundef to false instead.'''.format(self.coredata.options[OptionKey
                 results.append(s)
             elif isinstance(s, (build.GeneratedList, build.BuildTarget,
                                 build.CustomTargetIndex, build.CustomTarget,
-                                build.ExtractedObjects)):
+                                build.ExtractedObjects, build.StructuredSources)):
                 results.append(s)
             else:
                 raise InterpreterException(f'Source item is {s!r} instead of '

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -978,3 +978,9 @@ class GeneratorHolder(ObjectHolder[build.Generator]):
                                             preserve_path_from, extra_args=kwargs['extra_args'])
 
         return gl
+
+
+class StructuredSourcesHolder(ObjectHolder[build.StructuredSources]):
+
+    def __init__(self, sources: build.StructuredSources, interp: 'Interpreter'):
+        super().__init__(sources, interp)

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -41,6 +41,7 @@ if T.TYPE_CHECKING:
     from ..build import ConfigurationData
     from ..coredata import KeyedOptionDictType, UserOption
     from ..compilers.compilers import Compiler
+    from ..mparser import BaseNode
 
 FileOrString = T.Union['File', str]
 
@@ -170,6 +171,15 @@ class MesonException(Exception):
         self.file = file
         self.lineno = lineno
         self.colno = colno
+
+    @classmethod
+    def from_node(cls, *args: object, node: BaseNode) -> MesonException:
+        """Create a MesonException with location data from a BaseNode
+
+        :param node: A BaseNode to set location data from
+        :return: A Meson Exception instance
+        """
+        return cls(*args, file=node.filename, lineno=node.lineno, colno=node.colno)
 
 
 class MesonBugException(MesonException):

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -607,10 +607,10 @@ class GnomeModule(ExtensionModule):
 
     def _get_link_args(self, state: 'ModuleState',
                        lib: T.Union[build.SharedLibrary, build.StaticLibrary],
-                       depends: T.Sequence[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString']],
+                       depends: T.Sequence[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString', build.StructuredSources]],
                        include_rpath: bool = False,
                        use_gir_args: bool = False
-                       ) -> T.Tuple[T.List[str], T.List[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString']]]:
+                       ) -> T.Tuple[T.List[str], T.List[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString', build.StructuredSources]]]:
         link_command: T.List[str] = []
         new_depends = list(depends)
         # Construct link args
@@ -638,12 +638,12 @@ class GnomeModule(ExtensionModule):
     def _get_dependencies_flags(
             self, deps: T.Sequence[T.Union['Dependency', build.BuildTarget, build.CustomTarget, build.CustomTargetIndex]],
             state: 'ModuleState',
-            depends: T.Sequence[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString']],
+            depends: T.Sequence[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString', build.StructuredSources]],
             include_rpath: bool = False,
             use_gir_args: bool = False,
             separate_nodedup: bool = False
             ) -> T.Tuple[OrderedSet[str], OrderedSet[str], OrderedSet[str], T.Optional[T.List[str]], OrderedSet[str],
-                         T.List[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString']]]:
+                         T.List[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString', build.StructuredSources]]]:
         cflags: OrderedSet[str] = OrderedSet()
         internal_ldflags: OrderedSet[str] = OrderedSet()
         external_ldflags: OrderedSet[str] = OrderedSet()
@@ -931,7 +931,7 @@ class GnomeModule(ExtensionModule):
             girfile: str,
             scan_command: T.Sequence[T.Union['FileOrString', Executable, ExternalProgram, OverrideProgram]],
             generated_files: T.Sequence[T.Union[str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList]],
-            depends: T.Sequence[T.Union['FileOrString', build.BuildTarget, 'build.GeneratedTypes']],
+            depends: T.Sequence[T.Union['FileOrString', build.BuildTarget, 'build.GeneratedTypes', build.StructuredSources]],
             kwargs: T.Dict[str, T.Any]) -> GirTarget:
         install = kwargs['install_gir']
         if install is None:
@@ -989,8 +989,8 @@ class GnomeModule(ExtensionModule):
     def _gather_typelib_includes_and_update_depends(
             state: 'ModuleState',
             deps: T.Sequence[T.Union[Dependency, build.BuildTarget, build.CustomTarget, build.CustomTargetIndex]],
-            depends: T.Sequence[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString']]
-            ) -> T.Tuple[T.List[str], T.List[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString']]]:
+            depends: T.Sequence[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString', build.StructuredSources]]
+            ) -> T.Tuple[T.List[str], T.List[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString', build.StructuredSources]]]:
         # Need to recursively add deps on GirTarget sources from our
         # dependencies and also find the include directories needed for the
         # typelib generation custom target below.
@@ -1092,7 +1092,7 @@ class GnomeModule(ExtensionModule):
         srcdir = os.path.join(state.environment.get_source_dir(), state.subdir)
         builddir = os.path.join(state.environment.get_build_dir(), state.subdir)
 
-        depends: T.List[T.Union['FileOrString', 'build.GeneratedTypes', build.BuildTarget]] = []
+        depends: T.List[T.Union['FileOrString', 'build.GeneratedTypes', build.BuildTarget, build.StructuredSources]] = []
         depends.extend(gir_dep.sources)
         depends.extend(girtargets)
 

--- a/mesonbuild/modules/unstable_rust.py
+++ b/mesonbuild/modules/unstable_rust.py
@@ -17,7 +17,7 @@ import typing as T
 
 from . import ExtensionModule, ModuleReturnValue
 from .. import mlog
-from ..build import BothLibraries, BuildTarget, CustomTargetIndex, Executable, ExtractedObjects, GeneratedList, IncludeDirs, CustomTarget
+from ..build import BothLibraries, BuildTarget, CustomTargetIndex, Executable, ExtractedObjects, GeneratedList, IncludeDirs, CustomTarget, StructuredSources
 from ..dependencies import Dependency, ExternalLibrary
 from ..interpreter.interpreter import TEST_KWARGS
 from ..interpreterbase import ContainerTypeInfo, InterpreterException, KwargInfo, FeatureNew, typed_kwargs, typed_pos_args, noPosargs
@@ -149,10 +149,9 @@ class RustModule(ExtensionModule):
         new_target_kwargs['dependencies'] = new_target_kwargs.get('dependencies', []) + dependencies
 
         new_target = Executable(
-            name, base_target.subdir, state.subproject,
-            base_target.for_machine, base_target.sources,
-            base_target.objects, base_target.environment,
-            new_target_kwargs
+            name, base_target.subdir, state.subproject, base_target.for_machine,
+            base_target.sources, base_target.structured_sources,
+            base_target.objects, base_target.environment, new_target_kwargs
         )
 
         test = self.interpreter.make_test(
@@ -203,7 +202,7 @@ class RustModule(ExtensionModule):
         name: str
         if isinstance(header, File):
             name = header.fname
-        elif isinstance(header, (BuildTarget, BothLibraries, ExtractedObjects)):
+        elif isinstance(header, (BuildTarget, BothLibraries, ExtractedObjects, StructuredSources)):
             raise InterpreterException('bindgen source file must be a C header, not an object or build target')
         else:
             name = header.get_outputs()[0]

--- a/mesonbuild/scripts/copy.py
+++ b/mesonbuild/scripts/copy.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifer: Apache-2.0
+# Copyright © 2021 Intel Corporation
+
+"""Helper script to copy files at build time.
+
+This is easier than trying to detect whether to use copy, cp, or something else.
+"""
+
+import shutil
+import typing as T
+
+
+def run(args: T.List[str]) -> int:
+    try:
+        shutil.copy2(args[0], args[1])
+    except Exception:
+        return 1
+    return 0

--- a/test cases/failing/121 structured source empty string/meson.build
+++ b/test cases/failing/121 structured source empty string/meson.build
@@ -1,0 +1,13 @@
+project('structured_source with empty string key')
+
+if not add_languages(['rust'], required : false, native : false)
+  error('MESON_SKIP_TEST: Rust is required but not found.')
+endif
+
+executable(
+  'main',
+  structured_sources(
+    'main.rs',
+    {'' : 'main.rs'},
+  )
+)

--- a/test cases/failing/121 structured source empty string/test.json
+++ b/test cases/failing/121 structured source empty string/test.json
@@ -1,0 +1,7 @@
+{
+    "stdout": [
+        {
+            "line": "test cases/failing/121 structured source empty string/meson.build:7:0: ERROR: structured_sources: keys to dictionary argument may not be an empty string."
+        }
+    ]
+}

--- a/test cases/failing/122 structured_sources conflicts/meson.build
+++ b/test cases/failing/122 structured_sources conflicts/meson.build
@@ -1,0 +1,17 @@
+project('structured_source with empty string key')
+
+if not add_languages(['rust'], required : false, native : false)
+  error('MESON_SKIP_TEST: Rust is required but not found.')
+endif
+
+executable(
+  'main',
+  [
+    structured_sources(
+      'main.rs',
+    ),
+    structured_sources(
+      'main.rs',
+    ),
+  ],
+)

--- a/test cases/failing/122 structured_sources conflicts/test.json
+++ b/test cases/failing/122 structured_sources conflicts/test.json
@@ -1,0 +1,7 @@
+{
+    "stdout": [
+        {
+            "line": "test cases/failing/122 structured_sources conflicts/meson.build:7:0: ERROR: Conflicting sources in structured sources: main.rs"
+        }
+    ]
+}

--- a/test cases/rust/18 structured sources/gen.py
+++ b/test cases/rust/18 structured sources/gen.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import argparse
+import textwrap
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('output')
+    args = parser.parse_args()
+
+    with open(args.output, 'w') as f:
+        f.write(textwrap.dedent('''\
+            pub fn bar() -> () {
+                println!("Hello, World!");
+            }'''))
+
+
+if __name__ == "__main__":
+    main()

--- a/test cases/rust/18 structured sources/meson.build
+++ b/test cases/rust/18 structured sources/meson.build
@@ -1,0 +1,39 @@
+project('structured input', 'rust')
+
+foo_mod_rs = configure_file(
+  input : 'src/foo.rs.in',
+  output : 'mod.rs',
+  configuration : {'message' : 'Hello, World!'},
+)
+
+conf_file = executable(
+  'main_conf_file',
+  structured_sources(
+    'src/main.rs',
+    {'foo' : [foo_mod_rs]},
+  ),
+)
+
+ct = custom_target(
+  'foo.rs',
+  output : 'foo.rs',
+  command : ['gen.py', '@OUTPUT@'],
+)
+
+target = executable(
+  'main_custom_target',
+  structured_sources(
+    ['src/main.rs', ct],
+  ),
+)
+
+# Should not be coppied
+executable(
+  'no_copy_target',
+  structured_sources(
+    ['src2/main-unique.rs'],
+    {'foo': 'src2/foo/mod.rs'},
+  ),
+)
+
+test('no-copy', find_program('no_copy_test.py'), args : meson.current_build_dir())

--- a/test cases/rust/18 structured sources/no_copy_test.py
+++ b/test cases/rust/18 structured sources/no_copy_test.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('builddir')
+    args = parser.parse_args()
+
+    for _, _, files in os.walk(args.builddir):
+        if 'main-unique.rs' in files:
+            exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test cases/rust/18 structured sources/src/foo.rs.in
+++ b/test cases/rust/18 structured sources/src/foo.rs.in
@@ -1,0 +1,4 @@
+
+pub fn bar() -> () {
+    println!("@message@");
+}

--- a/test cases/rust/18 structured sources/src/main.rs
+++ b/test cases/rust/18 structured sources/src/main.rs
@@ -1,0 +1,5 @@
+mod foo;
+
+fn main() {
+    foo::bar();
+}

--- a/test cases/rust/18 structured sources/src2/foo/mod.rs
+++ b/test cases/rust/18 structured sources/src2/foo/mod.rs
@@ -1,0 +1,4 @@
+
+pub fn bar() -> () {
+    println!("Hello, World!");
+}

--- a/test cases/rust/18 structured sources/src2/main-unique.rs
+++ b/test cases/rust/18 structured sources/src2/main-unique.rs
@@ -1,0 +1,5 @@
+mod foo;
+
+fn main() {
+    foo::bar();
+}

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3988,6 +3988,7 @@ class AllPlatformTests(BasePlatformTests):
         def output_name(name, type_):
             return type_(name=name, subdir=None, subproject=None,
                          for_machine=MachineChoice.HOST, sources=[],
+                         structured_sources=None,
                          objects=[], environment=env, kwargs={}).filename
 
         shared_lib_name = lambda name: output_name(name, SharedLibrary)


### PR DESCRIPTION
This is a reworked version of https://github.com/mesonbuild/meson/pull/8775, with the main complaints resolved.

The purpose of this series is to provide a mechanism for languages in which filesystem layout is relevant to ensure that generated sources end up in the right place. To do this, one describes the layout they want to a `structrued_sources` object, which the backend converts (if necessary) into a series of copy commands, to build the correct directory structure in the build directory. This structure is placed in the private directory of the target, to eliminate collisions. Then the actual compile is done on the copied sources rather than on the original sources. This is done at build time to avoid reconfiguration when any of the structured sources are changed.