### PR TITLE
install_man: add support for building man pages via internal custom_target

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -231,6 +231,21 @@ permitted_dependency_kwargs = {
     'version',
 }
 
+CT_MAN_COMMON_KWARGS = [
+    CT_INPUT_KW,
+    DEPENDS_KW,
+    DEPEND_FILES_KW,
+    DEPFILE_KW,
+    ENV_KW.evolve(since='0.57.0'),
+    INSTALL_MODE_KW.evolve(since='0.47.0'),
+    OVERRIDE_OPTIONS_KW,
+    KwargInfo('build_always', (bool, type(None)), deprecated='0.47.0'),
+    KwargInfo('build_always_stale', (bool, type(None)), since='0.47.0'),
+    KwargInfo('feed', bool, default=False, since='0.59.0'),
+    KwargInfo('capture', bool, default=False),
+    KwargInfo('console', bool, default=False, since='0.48.0'),
+]
+
 class Interpreter(InterpreterBase, HoldableObject):
 
     def __init__(
@@ -1640,22 +1655,11 @@ external dependencies (including libraries) must go to "dependencies".''')
         'custom_target',
         COMMAND_KW,
         CT_BUILD_BY_DEFAULT,
-        CT_INPUT_KW,
         CT_INSTALL_DIR_KW,
         CT_INSTALL_TAG_KW,
         CT_OUTPUT_KW,
-        DEPENDS_KW,
-        DEPEND_FILES_KW,
-        DEPFILE_KW,
-        ENV_KW.evolve(since='0.57.0'),
         INSTALL_KW,
-        INSTALL_MODE_KW.evolve(since='0.47.0'),
-        OVERRIDE_OPTIONS_KW,
-        KwargInfo('build_always', (bool, type(None)), deprecated='0.47.0'),
-        KwargInfo('build_always_stale', (bool, type(None)), since='0.47.0'),
-        KwargInfo('feed', bool, default=False, since='0.59.0'),
-        KwargInfo('capture', bool, default=False),
-        KwargInfo('console', bool, default=False, since='0.48.0'),
+        *CT_MAN_COMMON_KWARGS
     )
     def func_custom_target(self, node: mparser.FunctionNode, args: T.Tuple[str],
                            kwargs: 'kwargs.CustomTarget') -> build.CustomTarget:
@@ -1872,14 +1876,38 @@ This will become a hard error in the future.''' % kwargs['input'], location=self
         'install_man',
         KwargInfo('install_dir', (str, NoneType)),
         KwargInfo('locale', (str, NoneType), since='0.58.0'),
-        INSTALL_MODE_KW.evolve(since='0.47.0')
+        COMMAND_KW.evolve(required=False, since='0.60.0'),
+        *CT_MAN_COMMON_KWARGS
     )
     def func_install_man(self, node: mparser.BaseNode,
                          args: T.Tuple[T.List['mesonlib.FileOrString']],
                          kwargs: 'kwargs.FuncInstallMan') -> build.Man:
-        # We just need to narrow this, because the input is limited to files and
-        # Strings as inputs, so only Files will be returned
-        sources = self.source_strings_to_files(args[0])
+        sources = args[0]
+        ct_man_common_kwarg_names = {i.name for i in CT_MAN_COMMON_KWARGS}
+
+        if kwargs['command']:
+            if len(sources) > 1:
+                raise InvalidArguments('Man files generated via a command cannot have multiple outputs')
+            output = sources[0]
+            self.environment
+            sources = [mesonlib.File.from_built_file(self.subdir, output)]
+
+            build_kwargs = {k: v for k, v in kwargs.items() if k in ct_man_common_kwarg_names and v is not None}
+            build_kwargs['command'] = kwargs['command']
+            build_kwargs['output'] = output
+            build_kwargs['build_by_default'] = True
+            self._func_custom_target_impl(node, [output], build_kwargs)
+        else:
+            # since typed kwargs always exist, and sometimes come with prefilled defaults,
+            # this cannot actually be validated. Apparently this is a good thing.
+            #used_ct_args = ct_man_common_kwarg_names.intersection(kwargs.keys())
+            #if used_ct_args:
+            #    raise InvalidArguments(f'cannot use kwargs {used_ct_args!r} without command')
+
+            # We just need to narrow this, because the input is limited to files and
+            # Strings as inputs, so only Files will be returned
+            sources = self.source_strings_to_files(args[0])
+
         for s in sources:
             try:
                 num = int(s.rsplit('.', 1)[-1])

--- a/test cases/common/10 man install/copyfile.py
+++ b/test cases/common/10 man install/copyfile.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import sys
+import shutil
+
+shutil.copyfile(sys.argv[1], sys.argv[2])

--- a/test cases/common/10 man install/meson.build
+++ b/test cases/common/10 man install/meson.build
@@ -12,3 +12,7 @@ b1 = configure_file(input : 'baz.1.in',
   configuration : cdata)
 
 install_man(b1)
+
+install_man('bar.3',
+  input: 'bar.2',
+  command: ['copyfile.py', '@INPUT@', '@OUTPUT@'])

--- a/test cases/common/10 man install/test.json
+++ b/test cases/common/10 man install/test.json
@@ -3,6 +3,7 @@
     { "type": "file", "file": "usr/share/man/man1/foo.1"       },
     { "type": "file", "file": "usr/share/man/fr/man1/foo.1"    },
     { "type": "file", "file": "usr/share/man/man2/bar.2"       },
+    { "type": "file", "file": "usr/share/man/man3/bar.3"       },
     { "type": "file", "file": "usr/share/man/man1/vanishing.1" },
     { "type": "file", "file": "usr/share/man/man2/vanishing.2" },
     { "type": "file", "file": "usr/share/man/man1/baz.1"       }


### PR DESCRIPTION
This is completely terrible, because really you should use a custom_target and then feed it to install_man. However, that has been decided to never happen. So, reluctantly, if install_man won't accept a custom_target, then let install_man copy the entire interface and internally make one.

This solves a massive usability problem where custom targets with install_dir are strictly inferior to install_man() which automatically handles sectioned or localized subdirectories of mandir, and results in nontrivial code to painfully work around this. One alternative approach was to hack in @MANDIR@ support to install_dir itself (which is itself an inconsistent interface), but after adding a locale kwarg to install_man it is no longer possible to infer all information from the filename alone, so that's a total wash.

Fixes: #1550