### PR TITLE
modules/i18n: fix gettext use of --datadirs param

### DIFF
--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -245,7 +245,7 @@ class I18nModule(ExtensionModule):
 
         potargs = state.environment.get_build_command() + ['--internal', 'gettext', 'pot', pkg_arg]
         if datadirs:
-            potargs.append(_datadirs)
+            potargs.append(datadirs)
         if extra_arg:
             potargs.append(extra_arg)
         pottarget = build.RunTarget(packagename + '-pot', potargs, [], state.subdir, state.subproject)


### PR DESCRIPTION
The previous commit bd2fcb268b9ff48797bebb6a2ef94d2741234191
accidentally used the wrong var so the param name was missing,
leading to an error of "unrecognized arguments" for the
datadirs parameter value.