### PR TITLE
msubprojects: add new subcommand "packagefiles"

### DIFF
--- a/docs/markdown/snippets/subprojects_packagefiles.md
+++ b/docs/markdown/snippets/subprojects_packagefiles.md
@@ -1,0 +1,11 @@
+## New `subprojects packagefiles` subcommand
+
+It is now possible to re-apply `meson.build` overlays (`patch_filename` or
+`patch_directory` in the wrap ini file) after a subproject was downloaded and
+set up, via `meson subprojects packagefiles --apply <wrap-name>`.
+
+It is also possible for `patch_directory` overlays in a `[wrap-file]`, to copy
+the packagefiles out of the subproject and back into `packagefiles/<patch_directory>/`
+via `meson subprojects packagefiles --save <wrap-name>`. This is useful for
+testing an edit in the subproject and then saving it back to the overlay which
+is checked into git.

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -267,14 +267,9 @@ class Runner:
                 self.git_output(['fetch', '--refmap', heads_refmap, '--refmap', tags_refmap, 'origin', revision])
             except GitException as e:
                 self.log('  -> Could not fetch revision', mlog.bold(revision), 'in', mlog.bold(self.repo_dir))
-                if quiet_git(['rev-parse', revision + '^{commit}'], self.repo_dir)[0]:
-                    self.log(mlog.yellow('WARNING:'), 'Proceeding with locally available copy')
-                    # Trick git into setting FETCH_HEAD from the local revision.
-                    quiet_git(['fetch', '.', revision], self.repo_dir)
-                else:
-                    self.log(mlog.red(e.output))
-                    self.log(mlog.red(str(e)))
-                    return False
+                self.log(mlog.red(e.output))
+                self.log(mlog.red(str(e)))
+                return False
 
         if branch == '':
             # We are currently in detached mode


### PR DESCRIPTION
This will re-apply the meson.build patch overlay, ensuring it is up to date. Also take the opportunity offered by this infrastructure to repatch when performing `update --reset` since internally this will run `git stash` and thus cause the (possibly locally modified) meson.build files to disappear.

/cc @xclaesse 