### PR TITLE
Zipapp docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,7 @@ Meson can be run as a [Python zip
 app](https://docs.python.org/3/library/zipapp.html). To generate the
 executable run the following command:
 
-    python3 -m zipapp -p '/usr/bin/env python3' -m meson:main -o meson <source checkout>
-
-Note that the source checkout may not be `meson` because it would
-clash with the generated binary name.
-
-This will zip all files inside the source checkout into the script
-which includes hundreds of tests, so you might want to temporarily
-remove those before running it.
+    ./packaging/create_zipapp.py --outfile meson.pyz --interpreter '/usr/bin/env python3' <source checkout>
 
 #### Running
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ python3 -m pip install ninja
 More on Installing Meson build can be found at the
 [getting meson page](https://mesonbuild.com/Getting-meson.html).
 
+#### Creating a standalone script
+
+Meson can be run as a [Python zip
+app](https://docs.python.org/3/library/zipapp.html). To generate the
+executable run the following command:
+
+    python3 -m zipapp -p '/usr/bin/env python3' -m meson:main -o meson <source checkout>
+
+Note that the source checkout may not be `meson` because it would
+clash with the generated binary name.
+
+This will zip all files inside the source checkout into the script
+which includes hundreds of tests, so you might want to temporarily
+remove those before running it.
+
 #### Running
 
 Meson requires that you have a source directory and a build directory

--- a/docs/markdown/Getting-meson.md
+++ b/docs/markdown/Getting-meson.md
@@ -21,6 +21,17 @@ we strive to ensure that it will always be working and usable. All
 commits go through a pull-request process that runs CI and tests
 several platforms.
 
+### Packing Meson into a zipapp
+
+After downloading the release, you can create a standalone single-file
+executable for Meson by running the script:
+
+```
+./packaging/create_zipapp.py --outfile meson.pyz --interpreter '/usr/bin/env python3' <source checkout>
+```
+
+This uses python's native support for [zipapp].
+
 ## Installing Meson with pip
 
 Meson is available in the [Python Package Index] and can be installed
@@ -92,6 +103,7 @@ provide Python 3. Use either `mingw32/mingw-w64-i686-python3` or
 are building for.
 
   [GitHub release page]: https://github.com/mesonbuild/meson/releases
+  [zipapp]: https://docs.python.org/3/library/zipapp.html
   [Python Package Index]: https://pypi.python.org/pypi/meson/
   [Git]: https://github.com/mesonbuild/meson
   [Python's home page]: https://www.python.org/downloads/


### PR DESCRIPTION
Make this actually visible to users. We have previously documented this but only in README.md... it got removed "temporarily" because it was incompatible with multiple entry points, which we no longer use, but the docs never got restored at that time.

Motivation: this is helpful to e.g. packagers such as https://github.com/openwrt/openwrt/pull/4635 but people simply don't know it exists until I mention it directly.