### PR TITLE
WIP: interpreter: don't flip user-specified 'auto' with 'auto_features'

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -72,6 +72,7 @@ class UserOption(T.Generic[_T], HoldableObject):
         if not isinstance(yielding, bool):
             raise MesonException('Value of "yielding" must be a boolean.')
         self.yielding = yielding
+        self.user_input = False
 
     def printable_value(self) -> T.Union[str, int, bool, T.List[T.Union[str, int, bool]]]:
         assert isinstance(self.value, (str, int, bool, list))
@@ -83,8 +84,12 @@ class UserOption(T.Generic[_T], HoldableObject):
     def validate_value(self, value: T.Any) -> _T:
         raise RuntimeError('Derived option class did not override validate_value.')
 
-    def set_value(self, newvalue: T.Any) -> None:
+    def set_value(self, newvalue: T.Any, user_input: T.Optional[bool] = False) -> None:
         self.value = self.validate_value(newvalue)
+        self.user_input = user_input
+
+    def is_user_input(self) -> bool:
+        return self.user_input
 
 class UserStringOption(UserOption[str]):
     def __init__(self, description: str, value: T.Any, yielding: T.Optional[bool] = None):
@@ -629,7 +634,7 @@ class CoreData:
                 value = self.sanitize_dir_option_value(prefix, key, value)
 
         try:
-            self.options[key].set_value(value)
+            self.options[key].set_value(value, True)
         except KeyError:
             raise MesonException(f'Tried to set unknown builtin option {str(key)}')
 

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -83,7 +83,7 @@ def extract_search_dirs(kwargs: 'kwargs.ExtractSearchDirs') -> T.List[str]:
 class FeatureOptionHolder(ObjectHolder[coredata.UserFeatureOption]):
     def __init__(self, option: coredata.UserFeatureOption, interpreter: 'Interpreter'):
         super().__init__(option, interpreter)
-        if option and option.is_auto():
+        if option and option.is_auto() and not option.is_user_input():
             # TODO: we need to case here because options is not a TypedDict
             self.held_object = T.cast(coredata.UserFeatureOption, self.env.coredata.options[OptionKey('auto_features')])
             self.held_object.name = option.name


### PR DESCRIPTION
Would like some feedback on this one.

The problem it is solving is that for GStreamer, you might want to be very picky about what gets built, and in that case
setting 'auto_features' to disabled is the perfect solution.

However, you might want to build some platform dependant plugins, like v4l2 or applemedia,  and the best way to build these it to use the 'auto' feature, where they will be built dependent on their dependencies existing on your system.

So this patch proposes to keep track of all "user defined" options, and then *not* flip the 'auto' ones that are specifically set to 'auto' by the user.