### PR TITLE
interpreter: extract_objects provides a valid source

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -90,11 +90,12 @@ if T.TYPE_CHECKING:
 
     # Input source types passed to Targets
     SourceInputs = T.Union[mesonlib.File, build.GeneratedList, build.BuildTarget, build.BothLibraries,
-                           build.CustomTargetIndex, build.CustomTarget, build.GeneratedList, str]
-    # Input source types passed to the build.Target5 classes
+                           build.CustomTargetIndex, build.CustomTarget, build.GeneratedList,
+                           build.ExtractedObjects, str]
+    # Input source types passed to the build.Target classes
     SourceOutputs = T.Union[mesonlib.File, build.GeneratedList,
                             build.BuildTarget, build.CustomTargetIndex, build.CustomTarget,
-                            build.GeneratedList]
+                            build.ExtractedObjects, build.GeneratedList]
 
 
 def stringifyUserArguments(args, quote=False):
@@ -2566,7 +2567,7 @@ Try setting b_lundef to false instead.'''.format(self.coredata.options[OptionKey
                 results.append(s)
             elif isinstance(s, (build.GeneratedList, build.BuildTarget,
                                 build.CustomTargetIndex, build.CustomTarget,
-                                build.GeneratedList)):
+                                build.ExtractedObjects)):
                 results.append(s)
             else:
                 raise InterpreterException(f'Source item is {s!r} instead of '

--- a/test cases/failing/115 nonsensical bindgen/meson.build
+++ b/test cases/failing/115 nonsensical bindgen/meson.build
@@ -1,0 +1,20 @@
+# SPDX-license-identifer: Apache-2.0
+# Copyright © 2021 Intel Corporation
+
+project('rustmod bindgen', 'c')
+
+if not add_languages('rust', required: false)
+  error('MESON_SKIP_TEST test requires rust compiler')
+endif
+
+prog_bindgen = find_program('bindgen', required : false)
+if not prog_bindgen.found()
+  error('MESON_SKIP_TEST bindgen not found')
+endif
+
+c_lib = static_library('clib', 'src/source.c')
+
+import('unstable-rust').bindgen(
+  input : c_lib,
+  output : 'header.rs',
+)

--- a/test cases/failing/115 nonsensical bindgen/src/header.h
+++ b/test cases/failing/115 nonsensical bindgen/src/header.h
@@ -1,0 +1,8 @@
+// SPDX-license-identifer: Apache-2.0
+// Copyright © 2021 Intel Corporation
+
+#pragma once
+
+#include <stdint.h>
+
+int32_t add(const int32_t, const int32_t);

--- a/test cases/failing/115 nonsensical bindgen/src/source.c
+++ b/test cases/failing/115 nonsensical bindgen/src/source.c
@@ -1,0 +1,8 @@
+// SPDX-license-identifer: Apache-2.0
+// Copyright © 2021 Intel Corporation
+
+#include "header.h"
+
+int32_t add(const int32_t first, const int32_t second) {
+    return first + second;
+}

--- a/test cases/failing/115 nonsensical bindgen/test.json
+++ b/test cases/failing/115 nonsensical bindgen/test.json
@@ -1,0 +1,8 @@
+{
+    "stdout": [
+        {
+            "line": "test cases/failing/115 nonsensical bindgen/meson.build:17:24: ERROR: bindgen source file must be a C header, not an object or build target"
+        }
+    ]
+}
+

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3536,6 +3536,12 @@ class AllPlatformTests(BasePlatformTests):
             self.build()
             self.run_tests()
 
+    def test_extract_objects_custom_target_no_warning(self):
+        testdir = os.path.join(self.common_test_dir, '22 object extraction')
+
+        out = self.init(testdir)
+        self.assertNotRegex(out, "WARNING:.*can't be converted to File object")
+
     def test_multi_output_custom_target_no_warning(self):
         testdir = os.path.join(self.common_test_dir, '228 custom_target source')
 


### PR DESCRIPTION
This ensures that there is no warnings when running meson on `test cases/common/22 object extraction`.