### PR TITLE
Documentation: Add Mac installation instructions for Homebrew

### DIFF
--- a/docs/markdown/SimpleStart.md
+++ b/docs/markdown/SimpleStart.md
@@ -91,6 +91,10 @@ versions.
 
 ### macOS
 
+#### With Homebrew
+`brew install meson ninja`
+
+#### Without Homebrew
 Start by downloading the installation package from [the Releases
 page](https://github.com/mesonbuild/meson/releases).
 


### PR DESCRIPTION
Adds simple instructions to install `ninja` and `meson` with `brew`.