### PR TITLE
Fix some gnome module bugs spotted by mypy

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -222,9 +222,9 @@ class GnomeModule(ExtensionModule):
                     ifile = os.path.join(ifile.subdir, ifile.fname)
             elif isinstance(ifile, str):
                 ifile = os.path.join(state.subdir, ifile)
-            elif isinstance(ifile, (interpreter.CustomTargetHolder,
-                                    interpreter.CustomTargetIndexHolder,
-                                    interpreter.GeneratedObjectsHolder)):
+            elif isinstance(ifile, (build.CustomTarget,
+                                    build.CustomTargetIndex,
+                                    build.GeneratedList)):
                 m = 'Resource xml files generated at build-time cannot be used ' \
                     'with gnome.compile_resources() because we need to scan ' \
                     'the xml for dependencies. Use configure_file() instead ' \

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -286,7 +286,7 @@ class GnomeModule(ExtensionModule):
             kwargs['depend_files'] = depend_files
             kwargs['command'] = cmd
         else:
-            depfile = kwargs['output'] + '.d'
+            depfile = f'{output}.d'
             kwargs['depfile'] = depfile
             kwargs['command'] = copy.copy(cmd) + ['--dependency-file', '@DEPFILE@']
         target_c = GResourceTarget(name, state.subdir, state.subproject, kwargs)


### PR DESCRIPTION
I have a larger branch fully type annotating and using the various `typed_*' decorators, but that's probably not going to be ready before 0.60 is released, and these are real bugs that should be fixed asap.