### PR TITLE
cmake: handle arguments in the [binaries] section of the machine file

### DIFF
--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1697,3 +1697,35 @@ class LinuxlikeTests(BasePlatformTests):
         obj_files = p.stdout.strip().split('\n')
         self.assertEqual(len(obj_files), 1)
         self.assertTrue(obj_files[0].endswith('-prelink.o'))
+
+    def do_one_test_with_nativefile(self, testdir, args):
+        testdir = os.path.join(self.common_test_dir, testdir)
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / 'nativefile'
+            with p.open('wt', encoding='utf-8') as f:
+                f.write(f'''[binaries]
+                    c = {args}
+                    ''')
+            self.init(testdir, extra_args=['--native-file=' + str(p)])
+            self.build()
+
+    def test_cmake_multilib(self):
+        '''
+        Test that the cmake module handles multilib paths correctly.
+        '''
+        # Verify that "gcc -m32" works
+        try:
+            self.do_one_test_with_nativefile('1 trivial', "['gcc', '-m32']")
+        except subprocess.CalledProcessError as e:
+            raise SkipTest('Not GCC, or GCC does not have the -m32 option')
+        self.wipe()
+
+        # Verify that cmake works
+        try:
+            self.do_one_test_with_nativefile('../cmake/1 basic', "['gcc']")
+        except subprocess.CalledProcessError as e:
+            raise SkipTest('Could not build basic cmake project')
+        self.wipe()
+
+        # If so, we can test that cmake works with "gcc -m32"
+        self.do_one_test_with_nativefile('../cmake/1 basic', "['gcc', '-m32']")


### PR DESCRIPTION
Sometimes, the machine file can include compiler command line options, in order to pick the correct multilib.  For example, Meson uses `$cc --print-search-dirs` to find the library search path, where `$cc` is the cc from the machine file.  Because the
outputs of `gcc -m32 --print-search-dirs` and `gcc --print-search-dirs` are different, this only works if you have

    [binaries]
    cc = ['gcc', '-m32']

in the machine file.  Right now, however, the cmake module assumes that the compiler listed in the machine file is either a compiler, or a "launcher" followed by the compiler.  Check if the second argument starts with a slash (for Microsoft-like compilers) or a dash (for everyone else), and if so presume that `CMAKE_*_COMPILER_LAUNCHER` need not be defined.