### PR TITLE
backend/vs: Parallelize compilation inside one project

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -549,6 +549,7 @@ class Vs2010Backend(backends.Backend):
         pname.text = target_name
         if self.windows_target_platform_version:
             ET.SubElement(globalgroup, 'WindowsTargetPlatformVersion').text = self.windows_target_platform_version
+        ET.SubElement(globalgroup, 'UseMultiToolTask').text = 'true'
 
         ET.SubElement(root, 'Import', Project=r'$(VCTargetsPath)\Microsoft.Cpp.Default.props')
 


### PR DESCRIPTION
As a prerequisite I had to fix a bug ("Name pch pdb files to avoid naming & lock conflicts.") and decided to deduplicate some code , an arguable bug ("Move Microsoft.Cpp.props to before ItemDefinitionGroup.") and decided to do some cleanup ("Deduplicate basic project template.")

If preferrable I can split this up into separate PRs as well.

The biggest change is the cleanup - note the output changed for some target types. I think I called them out with XXXs in the code for now.

Fixes: #6882
Fixes:  #8442