### PR TITLE
Typing for the Windows module

### DIFF
--- a/docs/markdown/Windows-module.md
+++ b/docs/markdown/Windows-module.md
@@ -7,10 +7,22 @@ Windows.
 
 ### compile_resources
 
+```
+  windows.compile_resources(...(string | File | CustomTarget | CustomTargetIndex),
+                            args: []string,
+                            depend_files: [](string | File),
+                            depends: [](BuildTarget | CustomTarget)
+                            include_directories: [](IncludeDirectories | string)): []CustomTarget
+```
+
 Compiles Windows `rc` files specified in the positional arguments.
-Returns an opaque object that you put in the list of sources for the
-target you want to have the resources in. This method has the
-following keyword argument.
+Returns a list of `CustomTarget` objects that you put in the list of sources for
+the target you want to have the resources in.
+
+*Since 0.61.0* CustomTargetIndexs and CustomTargets with more than out output
+*may be used as positional arguments.
+
+This method has the following keyword arguments:
 
 - `args` lists extra arguments to pass to the resource compiler
 - `depend_files` lists resource files that the resource script depends on

--- a/docs/markdown/snippets/windows_custom_targets.md
+++ b/docs/markdown/snippets/windows_custom_targets.md
@@ -1,0 +1,22 @@
+## Windows.compile_resources CustomTarget
+
+Previously the Windows module only accepted CustomTargets with one output, it
+now accepts them with more than one output, and creates a windows resource
+target for each output. Additionally it now accepts indexes of CustomTargets
+
+```meson
+
+ct = custom_target(
+  'multiple',
+  output : ['resource', 'another resource'],
+  ...
+)
+
+ct2 = custom_target(
+  'slice',
+  output : ['resource', 'not a resource'],
+  ...
+)
+
+resources = windows.compile_resources(ct, ct2[0])
+```

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2684,7 +2684,7 @@ class CustomTargetIndex(HoldableObject):
     def get_filename(self) -> str:
         return self.output
 
-    def get_id(self):
+    def get_id(self) -> str:
         return self.target.get_id()
 
     def get_all_link_deps(self):

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -6,7 +6,7 @@
 import typing as T
 
 from .. import compilers
-from ..build import EnvironmentVariables, CustomTarget, BuildTarget, CustomTargetIndex, ExtractedObjects, GeneratedList
+from ..build import EnvironmentVariables, CustomTarget, BuildTarget, CustomTargetIndex, ExtractedObjects, GeneratedList, IncludeDirs
 from ..coredata import UserFeatureOption
 from ..interpreterbase import TYPE_var
 from ..interpreterbase.decorators import KwargInfo, ContainerTypeInfo
@@ -278,3 +278,10 @@ CT_INSTALL_DIR_KW: KwargInfo[T.List[T.Union[str, bool]]] = KwargInfo(
 )
 
 CT_BUILD_BY_DEFAULT: KwargInfo[T.Optional[bool]] = KwargInfo('build_by_default', (bool, type(None)), since='0.40.0')
+
+INCLUDE_DIRECTORIES: KwargInfo[T.List[T.Union[str, IncludeDirs]]] = KwargInfo(
+    'include_dirs',
+    ContainerTypeInfo(list, (str, IncludeDirs)),
+    listify=True,
+    default=[],
+)

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -23,7 +23,7 @@ from . import ModuleReturnValue
 from .. import mesonlib, build
 from .. import mlog
 from ..interpreter.type_checking import DEPEND_FILES_KW, DEPENDS_KW, INCLUDE_DIRECTORIES
-from ..interpreterbase.decorators import ContainerTypeInfo, KwargInfo, typed_kwargs, typed_pos_args
+from ..interpreterbase.decorators import ContainerTypeInfo, FeatureNew, KwargInfo, typed_kwargs, typed_pos_args
 from ..mesonlib import MachineChoice, MesonException
 from ..programs import ExternalProgram
 
@@ -98,7 +98,7 @@ class WindowsModule(ExtensionModule):
 
         return self._rescomp
 
-    @typed_pos_args('windows.compile_resources', varargs=(str, mesonlib.File, build.CustomTarget), min_varargs=1)
+    @typed_pos_args('windows.compile_resources', varargs=(str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex), min_varargs=1)
     @typed_kwargs(
         'winddows.compile_resoures',
         DEPEND_FILES_KW.evolve(since='0.47.0'),
@@ -107,7 +107,7 @@ class WindowsModule(ExtensionModule):
         KwargInfo('args', ContainerTypeInfo(list, str), default=[], listify=True),
     )
     def compile_resources(self, state: 'ModuleState',
-                          args: T.Tuple[T.List[T.Union[str, mesonlib.File, build.CustomTarget]]],
+                          args: T.Tuple[T.List[T.Union[str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex]]],
                           kwargs: 'CompileResources') -> ModuleReturnValue:
         extra_args = kwargs['args'].copy()
         wrc_depend_files = kwargs['depend_files']
@@ -151,6 +151,8 @@ class WindowsModule(ExtensionModule):
                 name_formatted = src.fname
                 name = src.relative_name()
             else:
+                if isinstance(src, build.CustomTargetIndex):
+                    FeatureNew.single_use('windows.compile_resource CustomTargetIndex in positional arguments', '0.61.0', state.subproject)
                 if len(src.get_outputs()) > 1:
                     raise MesonException('windows.compile_resources does not accept custom targets with more than 1 output.')
 

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -44,6 +44,7 @@ modules = [
     'mesonbuild/modules/qt.py',
     'mesonbuild/modules/unstable_external_project.py',
     'mesonbuild/modules/unstable_rust.py',
+    'mesonbuild/modules/windows.py',
     'mesonbuild/mparser.py',
     'mesonbuild/msetup.py',
     'mesonbuild/mtest.py',


### PR DESCRIPTION
Mostly this is the addition of type annotations and the `typed_*` decorators. It also adds support for CustomTargetIndexes, and relaxes the rule that only allows CustomTargets with 1 output, by generating a resource compile for all outputs of such CustomTargets. Since CustomTargetIndex is now accepted, anyone with a CustomTarget that generates both a resource file and a non-resource file can use that to avoid invalid targets.