### PR TITLE
Add NASM compiler

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -36,6 +36,8 @@ These are return values of the `get_id` (Compiler family) and
 | valac     | Vala compiler                    |                 |
 | xc16      | Microchip XC16 C compiler        |                 |
 | cython    | The Cython compiler              |                 |
+| nasm      | The NASM compiler (Since 0.64.0) |                 |
+| yasm      | The YASM compiler (Since 0.64.0) |                 |
 
 ## Linker ids
 
@@ -167,6 +169,7 @@ These are the parameter names for passing language specific arguments to your bu
 | Rust          | rust_args     | rust_link_args    |
 | Vala          | vala_args     | vala_link_args    |
 | Cython        | cython_args   | cython_link_args  |
+| NASM          | nasm_args     |                   |
 
 All these `<lang>_*` options are specified per machine. See in
 [specifying options per
@@ -315,6 +318,7 @@ machine](#Environment-variables-per-machine) section for details.
 | Rust          | RUSTC    | RUSTC_LD  | Before 0.54 RUST_LD*                        |
 | Vala          | VALAC    |           | Use CC_LD. Vala transpiles to C             |
 | C#            | CSC      | CSC       | The linker is the compiler                  |
+| nasm          | NASM     |           | Uses the C linker                           |
 
 *The old environment variales are still supported, but are deprecated
 and will be removed in a future version of Meson.*

--- a/docs/markdown/snippets/asm.md
+++ b/docs/markdown/snippets/asm.md
@@ -1,0 +1,18 @@
+## New language `nasm`
+
+When the `nasm` language is added to the project, `.asm` files are
+automatically compiled with NASM. This is only supported for x86 and x86_64 CPU
+family.
+
+Support for other compilers compatible with NASM language, such as YASM, could
+be added in the future.
+
+Note that GNU Assembly files usually have `.s` extension and were already built
+using C compiler such as GCC or CLANG.
+
+```meson
+project('test', 'nasm')
+
+exe = executable('hello', 'hello.asm')
+test('hello', exe)
+```

--- a/docs/markdown/snippets/asm.md
+++ b/docs/markdown/snippets/asm.md
@@ -2,10 +2,7 @@
 
 When the `nasm` language is added to the project, `.asm` files are
 automatically compiled with NASM. This is only supported for x86 and x86_64 CPU
-family.
-
-Support for other compilers compatible with NASM language, such as YASM, could
-be added in the future.
+family. `yasm` is used as fallback if `nasm` command is not found.
 
 Note that GNU Assembly files usually have `.s` extension and were already built
 using C compiler such as GCC or CLANG.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1568,6 +1568,15 @@ You probably should put it in link_with instead.''')
                 # Pretty hard to fix because the return value is passed everywhere
                 return linker, stdlib_args
 
+        # None of our compilers can do clink, this happens for example if the
+        # target only has ASM sources. Pick the first capable compiler.
+        for l in clink_langs:
+            try:
+                comp = self.all_compilers[l]
+                return comp, comp.language_stdlib_only_link_flags(self.environment)
+            except KeyError:
+                pass
+
         raise AssertionError(f'Could not get a dynamic linker for build target {self.name!r}')
 
     def uses_rust(self) -> bool:

--- a/mesonbuild/compilers/asm.py
+++ b/mesonbuild/compilers/asm.py
@@ -1,0 +1,77 @@
+import os
+import typing as T
+
+from ..mesonlib import EnvironmentException
+from .compilers import Compiler
+
+if T.TYPE_CHECKING:
+    from ..environment import Environment
+
+
+class NasmCompiler(Compiler):
+    language = 'nasm'
+    id = 'nasm'
+
+    def needs_static_linker(self) -> bool:
+        return True
+
+    def get_always_args(self) -> T.List[str]:
+        cpu = '64' if self.info.is_64_bit else '32'
+        if self.info.is_windows() or self.info.is_cygwin():
+            plat = 'win'
+            define = f'WIN{cpu}'
+        elif self.info.is_darwin():
+            plat = 'macho'
+            define = 'MACHO'
+        else:
+            plat = 'elf'
+            define = 'ELF'
+        args = ['-f', f'{plat}{cpu}', f'-D{define}']
+        if self.info.is_64_bit:
+            args.append('-D__x86_64__')
+        return args
+
+    def get_werror_args(self) -> T.List[str]:
+        return ['-Werror']
+
+    def get_output_args(self, outputname: str) -> T.List[str]:
+        return ['-o', outputname]
+
+    def get_optimization_args(self, optimization_level: str) -> T.List[str]:
+        return [f'-O{optimization_level}']
+
+    def get_debug_args(self, is_debug: bool) -> T.List[str]:
+        if is_debug:
+            if self.info.is_windows():
+                return []
+            return ['-g', '-F', 'dwarf']
+        return []
+
+    def get_depfile_suffix(self) -> str:
+        return 'd'
+
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+        return ['-MD', '-MQ', outtarget, '-MF', outfile]
+
+    def sanity_check(self, work_dir: str, environment: 'Environment') -> None:
+        if self.info.cpu_family not in {'x86', 'x86_64'}:
+            raise EnvironmentException(f'ASM compiler {self.id!r} does not support {self.info.cpu_family} CPU family')
+
+    def get_buildtype_args(self, buildtype: str) -> T.List[str]:
+        # FIXME: Not implemented
+        return []
+
+    def get_pic_args(self) -> T.List[str]:
+        return []
+
+    def get_include_args(self, path: str, is_system: bool) -> T.List[str]:
+        if not path:
+            path = '.'
+        return ['-I' + path]
+
+    def compute_parameters_with_absolute_paths(self, parameter_list: T.List[str],
+                                               build_dir: str) -> T.List[str]:
+        for idx, i in enumerate(parameter_list):
+            if i[:2] == '-I':
+                parameter_list[idx] = i[:2] + os.path.normpath(os.path.join(build_dir, i[2:]))
+        return parameter_list

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -70,12 +70,13 @@ lang_suffixes = {
     'swift': ('swift',),
     'java': ('java',),
     'cython': ('pyx', ),
+    'nasm': ('asm',),
 }
 all_languages = lang_suffixes.keys()
 c_cpp_suffixes = {'h'}
 cpp_suffixes = set(lang_suffixes['cpp']) | c_cpp_suffixes
 c_suffixes = set(lang_suffixes['c']) | c_cpp_suffixes
-assembler_suffixes = {'s', 'S'}
+assembler_suffixes = {'s', 'S', 'asm'}
 llvm_ir_suffixes = {'ll'}
 all_suffixes = set(itertools.chain(*lang_suffixes.values(), assembler_suffixes, llvm_ir_suffixes, c_cpp_suffixes))
 source_suffixes = all_suffixes - header_suffixes

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -88,7 +88,7 @@ defaults['clang_cl_static_linker'] = ['llvm-lib']
 defaults['cuda_static_linker'] = ['nvlink']
 defaults['gcc_static_linker'] = ['gcc-ar']
 defaults['clang_static_linker'] = ['llvm-ar']
-defaults['nasm'] = ['nasm']
+defaults['nasm'] = ['nasm', 'yasm']
 
 
 def compiler_from_language(env: 'Environment', lang: str, for_machine: MachineChoice) -> T.Optional[Compiler]:
@@ -1137,7 +1137,7 @@ def detect_swift_compiler(env: 'Environment', for_machine: MachineChoice) -> Com
     raise EnvironmentException('Unknown compiler: ' + join_args(exelist))
 
 def detect_nasm_compiler(env: 'Environment', for_machine: MachineChoice) -> Compiler:
-    from .asm import NasmCompiler
+    from .asm import NasmCompiler, YasmCompiler
     compilers, _, _ = _get_compilers(env, 'nasm', for_machine)
     is_cross = env.is_cross_build(for_machine)
 
@@ -1160,6 +1160,10 @@ def detect_nasm_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
         version = search_version(output)
         if 'NASM' in output:
             comp_class = NasmCompiler
+            env.coredata.add_lang_args(comp_class.language, comp_class, for_machine, env)
+            return comp_class(comp, version, for_machine, info, cc.linker, is_cross=is_cross)
+        elif 'yasm' in output:
+            comp_class = YasmCompiler
             env.coredata.add_lang_args(comp_class.language, comp_class, for_machine, env)
             return comp_class(comp, version, for_machine, info, cc.linker, is_cross=is_cross)
     _handle_exceptions(popen_exceptions, compilers)

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1151,6 +1151,10 @@ def detect_nasm_compiler(env: 'Environment', for_machine: MachineChoice) -> Comp
 
     popen_exceptions: T.Dict[str, Exception] = {}
     for comp in compilers:
+        if comp == ['nasm'] and is_windows() and not shutil.which(comp[0]):
+            # nasm is not in PATH on Windows by default
+            default_path = os.path.join(os.environ['ProgramFiles'], 'NASM')
+            comp[0] = shutil.which(comp[0], path=default_path) or comp[0]
         try:
             output = Popen_safe(comp + ['--version'])[1]
         except OSError as e:

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -101,6 +101,7 @@ ENV_VAR_COMPILER_MAP: T.Mapping[str, str] = {
     'objcpp': 'OBJCXX',
     'rust': 'RUSTC',
     'vala': 'VALAC',
+    'nasm': 'NASM',
 
     # Linkers
     'c_ld': 'CC_LD',

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1422,6 +1422,8 @@ class Interpreter(InterpreterBase, HoldableObject):
         if 'vala' in langs and 'c' not in langs:
             FeatureNew.single_use('Adding Vala language without C', '0.59.0', self.subproject, location=self.current_node)
             args.append('c')
+        if 'nasm' in langs:
+            FeatureNew.single_use('Adding NASM language', '0.64.0', self.subproject, location=self.current_node)
 
         success = True
         for lang in sorted(args, key=compilers.sort_clink):

--- a/mesonbuild/scripts/yasm.py
+++ b/mesonbuild/scripts/yasm.py
@@ -1,0 +1,22 @@
+import argparse
+import subprocess
+import typing as T
+
+def run(args: T.List[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--depfile')
+    options, yasm_cmd = parser.parse_known_args(args)
+
+    # Compile
+    returncode = subprocess.call(yasm_cmd)
+    if returncode != 0:
+        return returncode
+
+    # Capture and write depfile
+    ret = subprocess.run(yasm_cmd + ['-M'], capture_output=True)
+    if ret.returncode != 0:
+        return ret.returncode
+    with open(options.depfile, 'wb') as f:
+        f.write(ret.stdout)
+
+    return 0

--- a/test cases/nasm/2 asm language/hello.asm
+++ b/test cases/nasm/2 asm language/hello.asm
@@ -1,0 +1,21 @@
+%include "config.asm"
+
+global main
+extern puts
+
+section .data
+  hi db 'Hello, World', 0
+
+%ifdef FOO
+%define RETVAL HELLO
+%endif
+
+section .text
+main:
+  push rbp
+  lea rdi, [rel hi]
+  call puts wrt ..plt
+  pop rbp
+  mov ebx,RETVAL
+  mov eax,1
+  int 0x80

--- a/test cases/nasm/2 asm language/meson.build
+++ b/test cases/nasm/2 asm language/meson.build
@@ -1,7 +1,8 @@
 project('test', 'c')
 
 nasm = find_program('nasm', required: false)
-if not nasm.found()
+yasm = find_program('yasm', required: false)
+if not nasm.found() and not yasm.found()
   assert(not add_languages('nasm', required: false))
   error('MESON_SKIP_TEST: nasm not available')
 endif

--- a/test cases/nasm/2 asm language/meson.build
+++ b/test cases/nasm/2 asm language/meson.build
@@ -1,0 +1,25 @@
+project('test', 'c')
+
+nasm = find_program('nasm', required: false)
+if not nasm.found()
+  assert(not add_languages('nasm', required: false))
+  error('MESON_SKIP_TEST: nasm not available')
+endif
+
+if not host_machine.cpu_family().startswith('x86')
+  assert(not add_languages('nasm', required: false))
+  error('MESON_SKIP_TEST: nasm only supported for x86 and x86_64')
+endif
+
+add_languages('nasm')
+
+config_file = configure_file(
+  output: 'config.asm',
+  configuration: {'HELLO': 0},
+  output_format: 'nasm',
+)
+
+exe = executable('hello', 'hello.asm',
+  nasm_args: '-DFOO',
+)
+test('hello', exe)

--- a/test cases/nasm/2 asm language/meson.build
+++ b/test cases/nasm/2 asm language/meson.build
@@ -1,18 +1,15 @@
 project('test', 'c')
 
-nasm = find_program('nasm', required: false)
-yasm = find_program('yasm', required: false)
-if not nasm.found() and not yasm.found()
-  assert(not add_languages('nasm', required: false))
-  error('MESON_SKIP_TEST: nasm not available')
-endif
-
 if not host_machine.cpu_family().startswith('x86')
   assert(not add_languages('nasm', required: false))
   error('MESON_SKIP_TEST: nasm only supported for x86 and x86_64')
 endif
 
-add_languages('nasm')
+if not add_languages('nasm', required: false)
+  nasm = find_program('nasm', 'yasm', required: false)
+  assert(not nasm.found())
+  error('MESON_SKIP_TEST: nasm not found')
+endif
 
 config_file = configure_file(
   output: 'config.asm',


### PR DESCRIPTION
Currently Meson can only compile `.s` assembly files when the C compiler supports it. To compile `.asm` files with NASM we need a generator, see for example: https://code.videolan.org/videolan/dav1d/-/blob/master/meson.build#L442.

This adds a new language `asm` to build `.asm` files using NASM.

Note for example that OpenSSL generates .s files on Linux that build with gcc, but .asm files on Windows that build with nasm, so this is going to be useful there too.