### PR TITLE
Revert "interpreter: Add FeatureNew check"

### DIFF
--- a/mesonbuild/interpreter/primitives/string.py
+++ b/mesonbuild/interpreter/primitives/string.py
@@ -21,11 +21,6 @@ from ...interpreterbase import (
 
     InvalidArguments,
 )
-from ...mparser import (
-    MethodNode,
-    StringNode,
-    ArrayNode,
-)
 
 
 if T.TYPE_CHECKING:
@@ -109,13 +104,6 @@ class StringHolder(ObjectHolder[str]):
     @noKwargs
     @typed_pos_args('str.join', varargs=str)
     def join_method(self, args: T.Tuple[T.List[str]], kwargs: TYPE_kwargs) -> str:
-        # Implement some basic FeatureNew check on the AST level
-        assert isinstance(self.current_node, MethodNode)
-        n_args = self.current_node.args.arguments
-        if len(n_args) != 1 or not isinstance(n_args[0], ArrayNode) or not all(isinstance(x, StringNode) for x in n_args[0].args.arguments):
-            FeatureNew.single_use('str.join (varargs)', '0.60.0', self.subproject, 'List-flattening and variadic arguments')
-
-        # Actual implementation
         return self.held_object.join(args[0])
 
     @noKwargs

--- a/test cases/common/35 string operations/meson.build
+++ b/test cases/common/35 string operations/meson.build
@@ -1,4 +1,4 @@
-project('string formatting', 'c', meson_version: '>=0.59.0')
+project('string formatting', 'c')
 
 templ = '@0@bar@1@'
 

--- a/test cases/common/35 string operations/test.json
+++ b/test cases/common/35 string operations/test.json
@@ -1,7 +1,0 @@
-{
-  "stdout": [
-    {
-      "line": "WARNING: Project targeting '>=0.59.0' but tried to use feature introduced in '0.60.0': str.join (varargs). List-flattening and variadic arguments"
-    }
-  ]
-}


### PR DESCRIPTION
This reverts commit c0efa7ab22f8900f6fa1dadf0d306ec375569c8d.

This was a nice idea, or a beautiful hack depending on your perspective. Unfortunately, it turns out to be a lot harder than we originally thought. By operating on bare nodes, we end up triggering a FeatureNew on anything that isn't a string literal, rather than anything that isn't a string.

Since no one else has come up with a better idea for implementing a FeatureNew, let's just revert it. Better to not have a warning, than have it trigger way too often.