### PR TITLE
[WIP]: envconfig: Add support for secure operation system

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -160,6 +160,7 @@ These are provided by the `.system()` method call.
 | linux               | |
 | netbsd              | |
 | openbsd             | |
+| teeos               | Any secure Operating System, likes optee, trusty |
 | windows             | Any version of Windows |
 | sunos               | illumos and Solaris |
 

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -346,6 +346,12 @@ class MachineInfo(HoldableObject):
         """
         return self.system == 'openbsd'
 
+    def is_teeos(self) -> bool:
+        """
+        Machine is a secure Operating System (optee/trusty)
+        """
+        return self.system == 'teeos'
+
     def is_dragonflybsd(self) -> bool:
         """Machine is DragonflyBSD?"""
         return self.system == 'dragonfly'

--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -651,7 +651,8 @@ class GnuLikeDynamicLinkerMixin(DynamicLinkerBase):
         return self._apply_prefix('--out-implib=' + implibname)
 
     def thread_flags(self, env: 'Environment') -> T.List[str]:
-        if env.machines[self.for_machine].is_haiku():
+        m = env.machines[self.for_machine]
+        if m.is_haiku() or m.is_teeos():
             return []
         return ['-pthread']
 

--- a/mesonbuild/utils/universal.py
+++ b/mesonbuild/utils/universal.py
@@ -134,6 +134,7 @@ __all__ = [
     'is_osx',
     'is_qnx',
     'is_sunos',
+    'is_teeos',
     'is_windows',
     'is_wsl',
     'iter_regexin_iter',
@@ -648,6 +649,10 @@ def is_haiku() -> bool:
 
 def is_openbsd() -> bool:
     return platform.system().lower() == 'openbsd'
+
+
+def is_teeos() -> bool:
+    return platform.system().lower() == 'teeos'
 
 
 def is_windows() -> bool:

--- a/test cases/common/132 get define/meson.build
+++ b/test cases/common/132 get define/meson.build
@@ -19,6 +19,8 @@ system_define_map = {
   # being run on various versions of FreeBSD, just test that the define is
   # set.
   'freebsd'   : ['__FreeBSD__'],
+  # TEE likes OpenTEE didn't define any thing
+  'teeos'     : [],
 }
 
 foreach lang : ['c', 'cpp']


### PR DESCRIPTION
There are many secure operation systems likes optee from linaro, trusty from Google, and many SoC vendor has its own proprietary one.

They don't really share many APIs, we could build trusted application with meson as long as you prepare a proper
staging sysroot and correct cross properties.

We need a cross file for host to build the client agent part and another cross file for teeos to build TA. So currently I need to run meson twice. In some case, they would have to same the same top directory, without this patch I would not know I am building the CA or TA.