### PR TITLE
Allow custom targets in extract_objects and test

### DIFF
--- a/docs/markdown/snippets/extract-more-objects.md
+++ b/docs/markdown/snippets/extract-more-objects.md
@@ -1,0 +1,4 @@
+## ``extract_objects()`` supports generated sources
+
+Custom targets or generated files (returned by ``generator.process()``)
+can now be passed to ``extract_objects()``.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1132,13 +1132,8 @@ class Backend:
                     cmd_args.append(a)
                 elif isinstance(a, str):
                     cmd_args.append(a)
-                elif isinstance(a, build.Executable):
-                    p = self.construct_target_rel_path(a, t.workdir)
-                    if p == a.get_filename():
-                        p = './' + p
-                    cmd_args.append(p)
                 elif isinstance(a, build.Target):
-                    cmd_args.append(self.construct_target_rel_path(a, t.workdir))
+                    cmd_args.extend(self.construct_target_rel_paths(a, t.workdir))
                 else:
                     raise MesonException('Bad object in test command.')
             ts = TestSerialisation(t.get_name(), t.project_name, t.suite, cmd, is_cross,
@@ -1155,12 +1150,24 @@ class Backend:
     def write_test_serialisation(self, tests: T.List['Test'], datafile: T.BinaryIO) -> None:
         pickle.dump(self.create_test_serialisation(tests), datafile)
 
-    def construct_target_rel_path(self, a: build.Target, workdir: T.Optional[str]) -> str:
-        if workdir is None:
-            return self.get_target_filename(a)
-        assert os.path.isabs(workdir)
-        abs_path = self.get_target_filename_abs(a)
-        return os.path.relpath(abs_path, workdir)
+    def construct_target_rel_paths(self, t: build.Target, workdir: T.Optional[str]) -> T.List[str]:
+        target_dir = self.get_target_dir(t)
+        # ensure that test executables can be run when passed as arguments
+        if isinstance(t, build.Executable) and workdir is None:
+            target_dir = target_dir or '.'
+
+        if isinstance(t, build.BuildTarget):
+            outputs = [t.get_filename()]
+        else:
+            assert isinstance(t, build.CustomTarget)
+            outputs = t.get_outputs()
+
+        outputs = [os.path.join(target_dir, x) for x in outputs]
+        if workdir is not None:
+            assert os.path.isabs(workdir)
+            outputs = [os.path.join(self.environment.get_build_dir(), x) for x in outputs]
+            outputs = [os.path.relpath(x, workdir) for x in outputs]
+        return outputs
 
     def generate_depmf_install(self, d: InstallData) -> None:
         if self.build.dep_manifest_name is None:

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1124,6 +1124,8 @@ class Backend:
             for a in t.cmd_args:
                 if isinstance(a, build.Target):
                     depends.add(a)
+                elif isinstance(a, build.CustomTargetIndex):
+                    depends.add(a.target)
                 if isinstance(a, build.BuildTarget):
                     extra_paths += self.determine_windows_extra_paths(a, [])
 
@@ -1132,7 +1134,7 @@ class Backend:
                     cmd_args.append(a)
                 elif isinstance(a, str):
                     cmd_args.append(a)
-                elif isinstance(a, build.Target):
+                elif isinstance(a, (build.Target, build.CustomTargetIndex)):
                     cmd_args.extend(self.construct_target_rel_paths(a, t.workdir))
                 else:
                     raise MesonException('Bad object in test command.')
@@ -1150,7 +1152,7 @@ class Backend:
     def write_test_serialisation(self, tests: T.List['Test'], datafile: T.BinaryIO) -> None:
         pickle.dump(self.create_test_serialisation(tests), datafile)
 
-    def construct_target_rel_paths(self, t: build.Target, workdir: T.Optional[str]) -> T.List[str]:
+    def construct_target_rel_paths(self, t: T.Union[build.Target, build.CustomTargetIndex], workdir: T.Optional[str]) -> T.List[str]:
         target_dir = self.get_target_dir(t)
         # ensure that test executables can be run when passed as arguments
         if isinstance(t, build.Executable) and workdir is None:
@@ -1159,7 +1161,7 @@ class Backend:
         if isinstance(t, build.BuildTarget):
             outputs = [t.get_filename()]
         else:
-            assert isinstance(t, build.CustomTarget)
+            assert isinstance(t, (build.CustomTarget, build.CustomTargetIndex))
             outputs = t.get_outputs()
 
         outputs = [os.path.join(target_dir, x) for x in outputs]

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -199,7 +199,7 @@ known_build_target_kwargs = (
 )
 
 TEST_KWARGS: T.List[KwargInfo] = [
-    KwargInfo('args', ContainerTypeInfo(list, (str, mesonlib.File, build.BuildTarget, build.CustomTarget)),
+    KwargInfo('args', ContainerTypeInfo(list, (str, mesonlib.File, build.BuildTarget, build.CustomTarget, build.CustomTargetIndex)),
               listify=True, default=[]),
     KwargInfo('should_fail', bool, default=False),
     KwargInfo('timeout', int, default=30),

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -825,8 +825,8 @@ class BuildTargetHolder(ObjectHolder[_BuildTarget]):
         return self.interpreter.backend.get_target_dir(self._target_object)
 
     @noKwargs
-    @typed_pos_args('extract_objects', varargs=(mesonlib.File, str))
-    def extract_objects_method(self, args: T.Tuple[T.List[mesonlib.FileOrString]], kwargs: TYPE_nkwargs) -> build.ExtractedObjects:
+    @typed_pos_args('extract_objects', varargs=(mesonlib.File, str, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList))
+    def extract_objects_method(self, args: T.Tuple[T.List[T.Union[mesonlib.FileOrString, 'build.GeneratedTypes']]], kwargs: TYPE_nkwargs) -> build.ExtractedObjects:
         return self._target_object.extract_objects(args[0])
 
     @noPosargs

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -968,7 +968,7 @@ class GeneratorHolder(ObjectHolder[build.Generator]):
         KwargInfo('extra_args', ContainerTypeInfo(list, str), listify=True, default=[]),
     )
     def process_method(self,
-                       args: T.Tuple[T.List[T.Union[str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList]]],
+                       args: T.Tuple[T.List[T.Union[str, mesonlib.File, 'build.GeneratedTypes']]],
                        kwargs: 'kwargs.GeneratorProcess') -> build.GeneratedList:
         preserve_path_from = kwargs['preserve_path_from']
         if preserve_path_from is not None:

--- a/test cases/common/22 object extraction/create-source.py
+++ b/test cases/common/22 object extraction/create-source.py
@@ -1,0 +1,3 @@
+#! /usr/bin/env python3
+import sys
+print(f'#include "{sys.argv[1]}"')

--- a/test cases/common/22 object extraction/meson.build
+++ b/test cases/common/22 object extraction/meson.build
@@ -20,6 +20,18 @@ else
   e5 = executable('main5', 'main.c', objects : obj5)
   e6 = executable('main6', 'main.c', objects : obj6)
 
+  ct_src = custom_target('lib3.c', output: 'lib3.c', capture: true,
+                         command: [find_program('create-source.py'), 'lib.c'])
+  lib3 = library('somelib3', ct_src)
+  e7 = executable('main7', 'main.c', objects: lib3.extract_objects(ct_src[0]))
+  e8 = executable('main8', 'main.c', objects: lib3.extract_objects(ct_src))
+
+  gen = generator(find_program('create-source.py'), arguments: ['@INPUT@'],
+                  output: '@BASENAME@4.c', capture: true)
+  gen_src = gen.process('lib.c')
+  lib4 = library('somelib4', gen_src)
+  e9 = executable('main9', 'main.c', objects: lib4.extract_objects(gen_src))
+
   custom_target('custom_target with object inputs', output: 'objs',
                 input: [obj1, obj2, obj3, obj5, obj6],
                 build_by_default: true,
@@ -32,4 +44,7 @@ else
   test('extraction test 4', e4)
   test('extraction test 5', e5)
   test('extraction test 6', e6)
+  test('extraction test 7', e7)
+  test('extraction test 8', e8)
+  test('extraction test 9', e9)
 endif

--- a/test cases/common/245 custom target index source/main.c
+++ b/test cases/common/245 custom target index source/main.c
@@ -1,6 +1,8 @@
+#include <assert.h>
 #include "gen.h"
 
-int main(void)
+int main(int argc)
 {
+  assert(argc == 3);
   return genfunc();
 }

--- a/test cases/common/245 custom target index source/meson.build
+++ b/test cases/common/245 custom target index source/meson.build
@@ -46,5 +46,6 @@ exe_together = executable('exe_together',
   install: false,
 )
 
-test('exe_separate', exe_separate)
-test('exe_together', exe_together)
+# also cover passing custom target to tests as arguments
+test('exe_separate', exe_separate, args: ['unused1', 'unused2'])
+test('exe_together', exe_together, args: gen)

--- a/test cases/common/245 custom target index source/meson.build
+++ b/test cases/common/245 custom target index source/meson.build
@@ -47,5 +47,5 @@ exe_together = executable('exe_together',
 )
 
 # also cover passing custom target to tests as arguments
-test('exe_separate', exe_separate, args: ['unused1', 'unused2'])
+test('exe_separate', exe_separate, args: [gen_c, gen_h])
 test('exe_together', exe_together, args: gen)

--- a/test cases/failing/116 run_target in test/test.json
+++ b/test cases/failing/116 run_target in test/test.json
@@ -1,7 +1,7 @@
 {
     "stdout": [
         {
-            "line": "test cases/failing/116 run_target in test/meson.build:4:0: ERROR: test keyword argument 'args' was of type array[RunTarget] but should have been array[str | File | BuildTarget | CustomTarget]"
+            "line": "test cases/failing/116 run_target in test/meson.build:4:0: ERROR: test keyword argument 'args' was of type array[RunTarget] but should have been array[str | File | BuildTarget | CustomTarget | CustomTargetIndex]"
         }
     ]
 }


### PR DESCRIPTION
This fixes two pending issues related to custom targets, allowing them to be used in extract_objects and in test. 

Fixes #7585
Fixes #8333 