### PR TITLE
linkers: detect LLD when built with PACKAGE_VENDOR

### DIFF
--- a/mesonbuild/linkers/detect.py
+++ b/mesonbuild/linkers/detect.py
@@ -79,7 +79,7 @@ def guess_win_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
         check_args.extend(extra_args)
 
     p, o, _ = Popen_safe(compiler + check_args)
-    if o.startswith('LLD'):
+    if 'LLD' in o.split('\n')[0]:
         if '(compatible with GNU linkers)' in o:
             return LLVMDynamicLinker(
                 compiler, for_machine, comp_class.LINKER_PREFIX,
@@ -94,7 +94,7 @@ def guess_win_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
         # We've already hanedled the non-direct case above
 
     p, o, e = Popen_safe(compiler + check_args)
-    if o.startswith('LLD'):
+    if 'LLD' in o.split('\n')[0]:
         return ClangClDynamicLinker(
             for_machine, [],
             prefix=comp_class.LINKER_PREFIX if use_linker_prefix else [],
@@ -151,7 +151,7 @@ def guess_nix_linker(env: 'Environment', compiler: T.List[str], comp_class: T.Ty
     _, o, e = Popen_safe(compiler + check_args)
     v = search_version(o + e)
     linker: DynamicLinker
-    if o.startswith('LLD'):
+    if 'LLD' in o.split('\n')[0]:
         linker = LLVMDynamicLinker(
             compiler, for_machine, comp_class.LINKER_PREFIX, override, version=v)
     elif 'Snapdragon' in e and 'LLVM' in e:


### PR DESCRIPTION
This should make CI green again. Homebrew's "lld -v" output now starts with "Homebrew LLD", and Meson no longer detects it,