### PR TITLE
dep.name(): return dependency name even if dependency is not found

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -394,10 +394,10 @@ class ExternalDependency(Dependency, HasNativeKwarg):
 
 
 class NotFoundDependency(Dependency):
-    def __init__(self, environment: 'Environment') -> None:
+    def __init__(self, name: str, environment: 'Environment') -> None:
         super().__init__(DependencyTypeName('not-found'), {})
         self.env = environment
-        self.name = 'not-found'
+        self.name = name
         self.is_found = False
 
     def get_partial_dependency(self, *, compile_args: bool = False,

--- a/mesonbuild/dependencies/detect.py
+++ b/mesonbuild/dependencies/detect.py
@@ -162,7 +162,7 @@ def find_external_dependency(name: str, env: 'Environment', kwargs: T.Dict[str, 
         raise DependencyException('Dependency "%s" not found' % (name) +
                                   (', tried %s' % (tried) if tried else ''))
 
-    return NotFoundDependency(env)
+    return NotFoundDependency(name, env)
 
 
 def _build_external_dependency_list(name: str, env: 'Environment', for_machine: MachineChoice,

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -270,7 +270,7 @@ class DependencyFallbacksHolder(MesonInterpreterObject):
             FeatureNew.single_use('OpenMP Dependency', '0.46.0', self.subproject)
 
     def _notfound_dependency(self) -> NotFoundDependency:
-        return NotFoundDependency(self.environment)
+        return NotFoundDependency(self.names[0] if self.names else '', self.environment)
 
     @staticmethod
     def _check_version(wanted: T.Optional[str], found: str) -> bool:

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -494,10 +494,9 @@ class PythonInstallation(ExternalProgramHolder):
     @noPosargs
     def dependency_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> 'Dependency':
         disabled, required, feature = extract_required_kwarg(kwargs, self.subproject)
-
         # it's theoretically (though not practically) possible for the else clse
         # to not bind dep, let's ensure it is.
-        dep: 'Dependency' = NotFoundDependency(self.interpreter.environment)
+        dep: 'Dependency' = NotFoundDependency('python', self.interpreter.environment)
         if disabled:
             mlog.log('Dependency', mlog.bold('python'), 'skipped: feature', mlog.bold(feature), 'disabled')
         else:


### PR DESCRIPTION
The dep.name() function schould always return the name of the
dependency as documented. No matter if it was found or not.
https://mesonbuild.com/Reference-manual_returned_dep.html#depfound

Currently it returns 'not-found'

https://github.com/mesonbuild/meson/issues/8114