### PR TITLE
Add missing but expected as exception clause

### DIFF
--- a/mesonbuild/mesonlib/vsenv.py
+++ b/mesonbuild/mesonlib/vsenv.py
@@ -94,7 +94,7 @@ def _setup_vsenv(force: bool) -> bool:
 def setup_vsenv(force: bool = False):
     try:
         _setup_vsenv(force)
-    except MesonException:
+    except MesonException as e:
         if force:
             raise
         mlog.warning('Failed to activate VS environment:', str(e))


### PR DESCRIPTION
The `except` line was missing its `as e` clause.

As a result, when erroring out, after not finding a compiler, Meson
gives an error ending:

```
File "C:\Users\Matthew\AppData\Roaming\Python\Python39\site-packages\mesonbuild\mesonlib\vsenv.py",
  line 100, in setup_vsenv
      mlog.warning('Failed to activate VS environment:', str(e))
```