### PR TITLE
Improve speed of meson wrapped command execution (for capture etc).

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -34,6 +34,7 @@ from ..mesonlib import (
     File, MachineChoice, MesonException, OptionType, OrderedSet, OptionOverrideProxy,
     classify_unity_sources, OptionKey, join_args
 )
+from ..serialisation import (ExecutableSerialisation, TestSerialisation)
 
 if T.TYPE_CHECKING:
     from .._typing import ImmutableListProtocol
@@ -173,65 +174,6 @@ class SubdirInstallData(InstallDataBase):
                  subproject: str, tag: T.Optional[str] = None, data_type: T.Optional[str] = None):
         super().__init__(path, install_path, install_path_name, install_mode, subproject, tag, data_type)
         self.exclude = exclude
-
-class ExecutableSerialisation:
-
-    # XXX: should capture and feed default to False, instead of None?
-
-    def __init__(self, cmd_args: T.List[str],
-                 env: T.Optional[build.EnvironmentVariables] = None,
-                 exe_wrapper: T.Optional['programs.ExternalProgram'] = None,
-                 workdir: T.Optional[str] = None,
-                 extra_paths: T.Optional[T.List] = None,
-                 capture: T.Optional[bool] = None,
-                 feed: T.Optional[bool] = None,
-                 tag: T.Optional[str] = None,
-                 verbose: bool = False,
-                 ) -> None:
-        self.cmd_args = cmd_args
-        self.env = env
-        if exe_wrapper is not None:
-            assert isinstance(exe_wrapper, programs.ExternalProgram)
-        self.exe_runner = exe_wrapper
-        self.workdir = workdir
-        self.extra_paths = extra_paths
-        self.capture = capture
-        self.feed = feed
-        self.pickled = False
-        self.skip_if_destdir = False
-        self.verbose = verbose
-        self.subproject = ''
-        self.tag = tag
-
-class TestSerialisation:
-    def __init__(self, name: str, project: str, suite: T.List[str], fname: T.List[str],
-                 is_cross_built: bool, exe_wrapper: T.Optional[programs.ExternalProgram],
-                 needs_exe_wrapper: bool, is_parallel: bool, cmd_args: T.List[str],
-                 env: build.EnvironmentVariables, should_fail: bool,
-                 timeout: T.Optional[int], workdir: T.Optional[str],
-                 extra_paths: T.List[str], protocol: TestProtocol, priority: int,
-                 cmd_is_built: bool, depends: T.List[str], version: str):
-        self.name = name
-        self.project_name = project
-        self.suite = suite
-        self.fname = fname
-        self.is_cross_built = is_cross_built
-        if exe_wrapper is not None:
-            assert isinstance(exe_wrapper, programs.ExternalProgram)
-        self.exe_runner = exe_wrapper
-        self.is_parallel = is_parallel
-        self.cmd_args = cmd_args
-        self.env = env
-        self.should_fail = should_fail
-        self.timeout = timeout
-        self.workdir = workdir
-        self.extra_paths = extra_paths
-        self.protocol = protocol
-        self.priority = priority
-        self.needs_exe_wrapper = needs_exe_wrapper
-        self.cmd_is_built = cmd_is_built
-        self.depends = depends
-        self.version = version
 
 
 def get_backend_from_name(backend: str, build: T.Optional[build.Build] = None, interpreter: T.Optional['Interpreter'] = None) -> T.Optional['Backend']:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -44,11 +44,12 @@ from .interpreterbase import FeatureNew
 
 if T.TYPE_CHECKING:
     from ._typing import ImmutableListProtocol, ImmutableSetProtocol
-    from .backend.backends import Backend, ExecutableSerialisation
+    from .backend.backends import Backend
     from .interpreter.interpreter import Test, SourceOutputs, Interpreter
     from .mesonlib import FileMode, FileOrString
     from .modules import ModuleState
     from .mparser import BaseNode
+    from .serialisation import ExecutableSerialisation
 
     GeneratedTypes = T.Union['CustomTarget', 'CustomTargetIndex', 'GeneratedList']
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -35,7 +35,8 @@ from ..interpreterbase import ObjectHolder
 from ..interpreterbase.baseobjects import TYPE_nkwargs, TYPE_nvar, TYPE_var, TYPE_kwargs
 from ..modules import ExtensionModule, ModuleObject, MutableModuleObject, NewExtensionModule, NotFoundExtensionModule
 from ..cmake import CMakeInterpreter
-from ..backend.backends import Backend, ExecutableSerialisation
+from ..backend.backends import Backend
+from ..serialisation import ExecutableSerialisation
 
 from . import interpreterobjects as OBJ
 from . import compiler as compilerOBJ

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -20,7 +20,7 @@ from .primitives import MesonVersionString
 from .type_checking import NATIVE_KW, NoneType
 
 if T.TYPE_CHECKING:
-    from ..backend.backends import ExecutableSerialisation
+    from ..serialisation import ExecutableSerialisation
     from ..compilers import Compiler
     from ..interpreterbase import TYPE_kwargs, TYPE_var
     from .interpreter import Interpreter

--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -26,16 +26,18 @@ import shutil
 
 from . import mesonlib
 from . import mlog
-from . import mconf, mdist, minit, minstall, mintro, msetup, mtest, rewriter, msubprojects, munstable_coredata, mcompile, mdevenv
 from .mesonlib import MesonException
-from .environment import detect_msys2_arch
-from .wrap import wraptool
 
 
 # Note: when adding arguments, please also add them to the completion
 # scripts in $MESONSRC/data/shell-completions/
 class CommandLineParser:
     def __init__(self):
+        # Delay imports so that internal commands do not have to import all of these
+        from . import (mconf, mdist, minit, minstall, mintro, msetup, mtest,
+                       rewriter, msubprojects, munstable_coredata, mcompile, mdevenv)
+        from .wrap import wraptool
+
         self.term_width = shutil.get_terminal_size().columns
         self.formatter = lambda prog: argparse.HelpFormatter(prog, max_help_position=int(self.term_width / 2), width=self.term_width)
 
@@ -200,6 +202,7 @@ def run(original_args, mainfile):
 
     # https://github.com/mesonbuild/meson/issues/3653
     if sys.platform.lower() == 'msys':
+        from .environment import detect_msys2_arch
         mlog.error('This python3 seems to be msys/python on MSYS2 Windows, which is known to have path semantics incompatible with Meson')
         msys2_arch = detect_msys2_arch()
         if msys2_arch:

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -25,12 +25,14 @@ import sys
 import typing as T
 
 from . import environment
-from .backend.backends import InstallData, InstallDataBase, InstallEmptyDir, TargetInstallData, ExecutableSerialisation
+from .backend.backends import InstallData, InstallDataBase, InstallEmptyDir, TargetInstallData
 from .coredata import major_versions_differ, MesonVersionMismatchException
 from .coredata import version as coredata_version
 from .mesonlib import Popen_safe, RealPathAction, is_windows
 from .scripts import depfixer, destdir_join
 from .scripts.meson_exe import run_exe
+from .serialisation import ExecutableSerialisation
+
 try:
     from __main__ import __file__ as main_file
 except ImportError:

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -29,6 +29,7 @@ from .backend import backends
 from .mparser import BaseNode, FunctionNode, ArrayNode, ArgumentNode, StringNode
 from .interpreter import Interpreter
 from pathlib import Path, PurePath
+from .serialisation import TestSerialisation
 import typing as T
 import os
 import argparse
@@ -345,7 +346,7 @@ def list_deps(coredata: cdata.CoreData) -> T.List[T.Dict[str, T.Union[str, T.Lis
                         'link_args': d.get_link_args()}]
     return result
 
-def get_test_list(testdata: T.List[backends.TestSerialisation]) -> T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]]:
+def get_test_list(testdata: T.List[TestSerialisation]) -> T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]]:
     result = []  # type: T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]]
     for t in testdata:
         to = {}  # type: T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]
@@ -369,10 +370,10 @@ def get_test_list(testdata: T.List[backends.TestSerialisation]) -> T.List[T.Dict
         result.append(to)
     return result
 
-def list_tests(testdata: T.List[backends.TestSerialisation]) -> T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]]:
+def list_tests(testdata: T.List[TestSerialisation]) -> T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]]:
     return get_test_list(testdata)
 
-def list_benchmarks(benchdata: T.List[backends.TestSerialisation]) -> T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]]:
+def list_benchmarks(benchdata: T.List[TestSerialisation]) -> T.List[T.Dict[str, T.Union[str, int, T.List[str], T.Dict[str, str]]]]:
     return get_test_list(benchdata)
 
 def list_projinfo(builddata: build.Build) -> T.Dict[str, T.Union[str, T.List[T.Dict[str, str]]]]:

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -47,7 +47,8 @@ from .mesonlib import (MesonException, OrderedSet, RealPathAction,
                        get_wine_shortpath, join_args, split_args)
 from .mintro import get_infodir, load_info_file
 from .programs import ExternalProgram
-from .backend.backends import TestProtocol, TestSerialisation
+from .backend.backends import TestProtocol
+from .serialisation import TestSerialisation
 
 # GNU autotools interprets a return code of 77 from tests it executes to
 # mean that the test should be skipped.

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -21,7 +21,7 @@ import typing as T
 import locale
 
 from .. import mesonlib
-from ..backend.backends import ExecutableSerialisation
+from ..serialisation import ExecutableSerialisation
 
 options = None
 

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -20,7 +20,6 @@ import subprocess
 import typing as T
 import locale
 
-from .. import mesonlib
 from ..serialisation import ExecutableSerialisation
 
 options = None
@@ -46,6 +45,8 @@ def run_exe(exe: ExecutableSerialisation, extra_env: T.Optional[T.Dict[str, str]
     if exe.env:
         child_env = exe.env.get_env(child_env)
     if exe.extra_paths:
+        from .. import mesonlib
+
         child_env['PATH'] = (os.pathsep.join(exe.extra_paths + ['']) +
                              child_env['PATH'])
         if exe.exe_runner and mesonlib.substring_is_in_list('wine', exe.exe_runner.get_command()):

--- a/mesonbuild/serialisation.py
+++ b/mesonbuild/serialisation.py
@@ -1,0 +1,79 @@
+# Copyright 2013-2021 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import typing as T
+from . import programs
+
+if T.TYPE_CHECKING:
+    from . import build
+    from .backend.backends import TestProtocol
+
+class ExecutableSerialisation:
+
+    # XXX: should capture and feed default to False, instead of None?
+
+    def __init__(self, cmd_args: T.List[str],
+                 env: T.Optional['build.EnvironmentVariables'] = None,
+                 exe_wrapper: T.Optional[programs.ExternalProgram] = None,
+                 workdir: T.Optional[str] = None,
+                 extra_paths: T.Optional[T.List] = None,
+                 capture: T.Optional[bool] = None,
+                 feed: T.Optional[bool] = None,
+                 tag: T.Optional[str] = None,
+                 verbose: bool = False,
+                 ) -> None:
+        self.cmd_args = cmd_args
+        self.env = env
+        if exe_wrapper is not None:
+            assert isinstance(exe_wrapper, programs.ExternalProgram)
+        self.exe_runner = exe_wrapper
+        self.workdir = workdir
+        self.extra_paths = extra_paths
+        self.capture = capture
+        self.feed = feed
+        self.pickled = False
+        self.skip_if_destdir = False
+        self.verbose = verbose
+        self.subproject = ''
+        self.tag = tag
+
+class TestSerialisation:
+    def __init__(self, name: str, project: str, suite: T.List[str], fname: T.List[str],
+                 is_cross_built: bool, exe_wrapper: T.Optional[programs.ExternalProgram],
+                 needs_exe_wrapper: bool, is_parallel: bool, cmd_args: T.List[str],
+                 env: 'build.EnvironmentVariables', should_fail: bool,
+                 timeout: T.Optional[int], workdir: T.Optional[str],
+                 extra_paths: T.List[str], protocol: 'TestProtocol', priority: int,
+                 cmd_is_built: bool, depends: T.List[str], version: str):
+        self.name = name
+        self.project_name = project
+        self.suite = suite
+        self.fname = fname
+        self.is_cross_built = is_cross_built
+        if exe_wrapper is not None:
+            assert isinstance(exe_wrapper, programs.ExternalProgram)
+        self.exe_runner = exe_wrapper
+        self.is_parallel = is_parallel
+        self.cmd_args = cmd_args
+        self.env = env
+        self.should_fail = should_fail
+        self.timeout = timeout
+        self.workdir = workdir
+        self.extra_paths = extra_paths
+        self.protocol = protocol
+        self.priority = priority
+        self.needs_exe_wrapper = needs_exe_wrapper
+        self.cmd_is_built = cmd_is_built
+        self.depends = depends
+        self.version = version

--- a/mesonbuild/serialisation.py
+++ b/mesonbuild/serialisation.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import typing as T
-from . import programs
 
 if T.TYPE_CHECKING:
     from . import build
+    from . import programs
     from .backend.backends import TestProtocol
 
 class ExecutableSerialisation:
@@ -25,7 +25,7 @@ class ExecutableSerialisation:
 
     def __init__(self, cmd_args: T.List[str],
                  env: T.Optional['build.EnvironmentVariables'] = None,
-                 exe_wrapper: T.Optional[programs.ExternalProgram] = None,
+                 exe_wrapper: T.Optional['programs.ExternalProgram'] = None,
                  workdir: T.Optional[str] = None,
                  extra_paths: T.Optional[T.List] = None,
                  capture: T.Optional[bool] = None,
@@ -36,6 +36,9 @@ class ExecutableSerialisation:
         self.cmd_args = cmd_args
         self.env = env
         if exe_wrapper is not None:
+            # XXX: import is a bit slow - but perhaps mypy type checking obsoleted this
+            # anyway?
+            from . import programs
             assert isinstance(exe_wrapper, programs.ExternalProgram)
         self.exe_runner = exe_wrapper
         self.workdir = workdir
@@ -50,7 +53,7 @@ class ExecutableSerialisation:
 
 class TestSerialisation:
     def __init__(self, name: str, project: str, suite: T.List[str], fname: T.List[str],
-                 is_cross_built: bool, exe_wrapper: T.Optional[programs.ExternalProgram],
+                 is_cross_built: bool, exe_wrapper: T.Optional['programs.ExternalProgram'],
                  needs_exe_wrapper: bool, is_parallel: bool, cmd_args: T.List[str],
                  env: 'build.EnvironmentVariables', should_fail: bool,
                  timeout: T.Optional[int], workdir: T.Optional[str],
@@ -62,6 +65,8 @@ class TestSerialisation:
         self.fname = fname
         self.is_cross_built = is_cross_built
         if exe_wrapper is not None:
+            # See ExecutableSerialisation case above
+            from . import programs
             assert isinstance(exe_wrapper, programs.ExternalProgram)
         self.exe_runner = exe_wrapper
         self.is_parallel = is_parallel

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -49,6 +49,7 @@ modules = [
     'mesonbuild/mtest.py',
     'mesonbuild/optinterpreter.py',
     'mesonbuild/programs.py',
+    'mesonbuild/serialisation.py',
 
     'run_custom_lint.py',
     'run_mypy.py',


### PR DESCRIPTION
This improves meson wrapped command execution ~215ms to ~66ms on average on my machine. There's more changes to come, but I thought this is a good enough piece to get some feedback.

Any thoughts on mesonbuild/serialization.py as the location for {Executable,Test}Serialisation?

I'm not sure that the deferred import in mesonmain.py is the best approach. Might be better to just not build a global argparse with all the sub-parsers at all, and just import the relevant subcommand when the relevant top-level command is specified?