### PR TITLE
mtest: limit "magic" CTRL+C behavior to process group leaders

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1893,7 +1893,10 @@ class TestHarness:
             l.start(self)
 
         if sys.platform != 'win32':
-            asyncio.get_event_loop().add_signal_handler(signal.SIGINT, sigint_handler)
+            if os.getpgid(0) == os.getpid():
+                asyncio.get_event_loop().add_signal_handler(signal.SIGINT, sigint_handler)
+            else:
+                asyncio.get_event_loop().add_signal_handler(signal.SIGINT, sigterm_handler)
             asyncio.get_event_loop().add_signal_handler(signal.SIGTERM, sigterm_handler)
         try:
             for runner in runners:


### PR DESCRIPTION
If meson is not a process group leader, a SIGINT will be delivered also to its parent process (and possibly other processes).  The parent process then will probably exit and mtest will continue running in the background, without any way to interrupt the run completely.

To fix this, treat SIGINT and SIGTERM the same way unless mtest is a process group leader.

This can be reproduced when a parallel make invokes "meson test".