### PR TITLE
compilers/rust: add support for the 2021 edition

### DIFF
--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -148,7 +148,7 @@ class RustCompiler(Compiler):
         return {
             key: coredata.UserComboOption(
                 'Rust Eddition to use',
-                ['none', '2015', '2018'],
+                ['none', '2015', '2018', '2021'],
                 'none',
             ),
         }


### PR DESCRIPTION
The Rust 2021 edition is live, we should support it.