### PR TITLE
Add entries for new CUDA Toolkit versions

### DIFF
--- a/mesonbuild/modules/unstable_cuda.py
+++ b/mesonbuild/modules/unstable_cuda.py
@@ -53,6 +53,8 @@ class CudaModule(NewExtensionModule):
 
         cuda_version = args[0]
         driver_version_table = [
+            {'cuda_version': '>=11.5.0',   'windows': '496.04', 'linux': '495.29.05'},
+            {'cuda_version': '>=11.4.1',   'windows': '471.41', 'linux': '470.57.02'},
             {'cuda_version': '>=11.4.0',   'windows': '471.11', 'linux': '470.42.01'},
             {'cuda_version': '>=11.3.0',   'windows': '465.89', 'linux': '465.19.01'},
             {'cuda_version': '>=11.2.2',   'windows': '461.33', 'linux': '460.32.03'},


### PR DESCRIPTION
CUDA Toolkit 11.5 GA just came out, and per Table 3 of this [Release Notes](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#cuda-major-component-versions), corresponds to drivers 495.29.05 (linux) and 496.04 (windows). Add its entry to `import('cuda').min_driver_version()`.

Also add an entry for 11.4.1 since it (and 11.4.2) both require the same slightly newer driver than 11.4 GA.

With your permission @jpakkane @nirbheek would love if it could be squeezed in for 0.60.0 final and 0.59.3 as it is a very low-risk addition, but won't begrudge you for delaying it to 0.60.1 or 0.61.0.