### PR TITLE
Deprecate wrap-redirect and stop creating them

### DIFF
--- a/docs/markdown/snippets/redirect_wrap.md
+++ b/docs/markdown/snippets/redirect_wrap.md
@@ -1,0 +1,7 @@
+## Redirect wraps are deprecated
+
+When Meson promote a `.wrap` file from another subproject, it used to create
+a new `.wrap` file in the main project with `[wrap-redirect]` section.
+
+Those files created lots of confusion so Meson will not create them any more.
+Existing files will keep working but will produce a deprecation warning.

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -28,13 +28,12 @@ import sys
 import configparser
 import time
 import typing as T
-import textwrap
 
 from pathlib import Path
 from . import WrapMode
 from .. import coredata
 from ..mesonlib import quiet_git, GIT, ProgressBar, MesonException, windows_proof_rmtree
-from ..interpreterbase import FeatureNew
+from ..interpreterbase import FeatureNew, FeatureDeprecated
 from ..interpreterbase import SubProject
 from .. import mesonlib
 
@@ -126,6 +125,8 @@ class PackageDefinition:
             raise WrapException(f'Failed to parse {self.basename}: {e!s}')
         self.parse_wrap_section(config)
         if self.type == 'redirect':
+            m = 'wrap-redirect files are not created by Meson any more and should be deleted'
+            FeatureDeprecated(m, '0.62.0').use(self.subproject)
             # [wrap-redirect] have a `filename` value pointing to the real wrap
             # file we should parse instead. It must be relative to the current
             # wrap file location and must be in the form foo/subprojects/bar.wrap.
@@ -303,13 +304,6 @@ class Resolver:
             if self.wrap.filename != main_fname:
                 rel = os.path.relpath(self.wrap.filename, self.source_dir)
                 mlog.log('Using', mlog.bold(rel))
-                # Write a dummy wrap file in main project that redirect to the
-                # wrap we picked.
-                with open(main_fname, 'w', encoding='utf-8') as f:
-                    f.write(textwrap.dedent('''\
-                        [wrap-redirect]
-                        filename = {}
-                        '''.format(os.path.relpath(self.wrap.filename, self.subdir_root))))
         else:
             # No wrap file, it's a dummy package definition for an existing
             # directory. Use the source code in place.


### PR DESCRIPTION
It has been a source of confusion to many users and are hard to keep in
gitignore (https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/1140).
In general we should avoid creating unexpected files in user's source
tree.

Originally they served 2 purposes:
- Inform user where a wrap that has been auto promoted comes from. This
  information is already in the log, and feedback shows that it created
  more confusion than actual useful information.
- Ensure that subsequent builds will use the same wrap in case the order
  in which subprojects are configured changes. This is potentially wrong
  in the case the user pruposedly change the order in which their
  subprojects are configured. First one wins is an established policy,
  people could be counting on it.