### PR TITLE
cmake: Add support for the Linux CMake registry (fixes #9418)

### DIFF
--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -346,6 +346,12 @@ class CMakeDependency(ExternalDependency):
         if env_path and find_module(env_path):
             return True
 
+        # Check the Linux CMake registry
+        linux_reg = Path.home() / '.cmake' / 'packages'
+        for p in [linux_reg / name, linux_reg / lname]:
+            if p.exists():
+                return True
+
         return False
 
     def _detect_dep(self, name: str, package_version: str, modules: T.List[T.Tuple[str, bool]], components: T.List[T.Tuple[str, bool]], args: T.List[str]) -> None:


### PR DESCRIPTION
I am only adding the [Linux CMake registry](https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#user-package-registry) support now since I am currently on Linux and can't test [winreg](https://docs.python.org/3/library/winreg.html).

I am adding this to 0.60.0, since this is a fairly trivial change that only affects the *preliminary* CMake dependency lookup. This change also only loosens the restrictions from the preliminary CMake check, so all dependencies that are currently passing will also pass after this PR is merged. The `_preliminary_find_check` function is solely used to avoid running CMake when there is (theoretically) no hope for CMake to find a dependency.