### PR TITLE
Allow for case-insensitive file-system for Python

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -406,6 +406,13 @@ class PythonExternalProgram(ExternalProgram):
         user_dir = str(Path.home())
         sys_paths = self.info['sys_paths']
         rel_path = self.info['install_paths'][key][1:]
+        # The paths may not be sensitive to case (e.g. Windows NTFS).
+        # Realpath appears to canonicalize.
+        abs_path = self.info['install_paths'][key][1:]
+        if os.path.realpath(abs_path) == os.path.realpath(abs_path.swapcase()):
+            rel_path = rel_path.lower()
+            sys_paths = [p.lower() for p in sys_paths]
+            user_dir = user_dir.lower()
         if not any(p.endswith(rel_path) for p in sys_paths if not p.startswith(user_dir)):
             mlog.warning('Broken python installation detected. Python files',
                          'installed by Meson might not be found by python interpreter.\n',


### PR DESCRIPTION
On Windows, in particular, the file-system is case-insensitive, and the
paths that come back from `sysconfig.get_paths()` and `sys.path` do
appear to differ in their case choices.

The `_get_path` code here checks (I think) that the Python `sys.path`
does include Python's own `site-packages`.  Because of case difference,
a simple check for the same suffix may fail, even though the strings do
represent the same file.

Here I've just done a hackish clause to fix the immediate problem, but
it seems to me the better way would be to directly check for the
corresponding entry in the `info['paths']` variable, rather than the
mysteriously relative paths that come back from
`sysconfig.get_paths(vars=some_dict)`.  But I couldn't see immediately
whether there was some reason for relying on this relative path.