### PR TITLE
make sure the devenv powershell script is actually distributed

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,9 @@ typing =
   mypy
   typing_extensions; python_version <"3.8"
 
+[options.package_data]
+mesonbuild.scripts = cmd_or_ps.ps1
+
 [options.packages.find]
 include = mesonbuild, mesonbuild.*
 exclude = *.data


### PR DESCRIPTION
It's not a python file, so it will never end up in the installed package unless we mark it as package_data. This causes problems for people using non-git checkouts.

Fixes #9435
Closes #9443