### PR TITLE
Restore the possibility of forcing "fat" static library links on a per-target basis

### DIFF
--- a/docs/yaml/functions/static_library.yaml
+++ b/docs/yaml/functions/static_library.yaml
@@ -23,3 +23,15 @@ kwargs:
       If `true` the object files in the target will be prelinked,
       meaning that it will contain only one prelinked
       object file rather than the individual object files.
+
+  thin:
+    type: bool
+    since: 0.61.0
+    description: |
+      If `true` (the default) and the static linker supports it,
+      attempt to use thin archives, which only contain references to
+      the linked object files rather than a copy of them. Doing so
+      speeds up the build and reduces disk space usage. This option
+      is ignored for static libraries to be installed; it is also
+      ignored on OS X because its toolchain does not support thin
+      archives.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2789,7 +2789,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             if target.import_filename:
                 commands += linker.gen_import_library_args(self.get_import_filename(target))
         elif isinstance(target, build.StaticLibrary):
-            commands += linker.get_std_link_args(not target.should_install())
+            commands += linker.get_std_link_args(target.thin and not target.should_install())
         else:
             raise RuntimeError('Unknown build target type.')
         return commands

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -116,7 +116,7 @@ known_build_target_kwargs = (
 known_exe_kwargs = known_build_target_kwargs | {'implib', 'export_dynamic', 'pie'}
 known_shlib_kwargs = known_build_target_kwargs | {'version', 'soversion', 'vs_module_defs', 'darwin_versions'}
 known_shmod_kwargs = known_build_target_kwargs | {'vs_module_defs'}
-known_stlib_kwargs = known_build_target_kwargs | {'pic', 'prelink'}
+known_stlib_kwargs = known_build_target_kwargs | {'pic', 'prelink', 'thin'}
 known_jar_kwargs = known_exe_kwargs | {'main_class'}
 
 @lru_cache(maxsize=None)
@@ -1880,6 +1880,9 @@ class StaticLibrary(BuildTarget):
         self.prelink = kwargs.get('prelink', False)
         if not isinstance(self.prelink, bool):
             raise InvalidArguments('Prelink keyword argument must be a boolean.')
+        self.thin = kwargs.get('thin', True)
+        if not isinstance(self.thin, bool):
+            raise InvalidArguments('Thin keyword argument must be a boolean.')
 
     def get_link_deps_mapping(self, prefix: str, environment: environment.Environment) -> T.Mapping[str, str]:
         return {}

--- a/test cases/unit/101 thinlinking/archeck.py
+++ b/test cases/unit/101 thinlinking/archeck.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import sys
+
+assert len(sys.argv) == 3
+assert sys.argv[1] in {'thin', 'fat'}
+
+FAT_MAGIC  = b'!<arch>\n'
+THIN_MAGIC = b'!<thin>\n'
+magic = open(sys.argv[2], 'rb').read(8)
+
+
+# Check if signature of archive is as expected
+if sys.argv[1] == 'thin':
+    if   magic.startswith(THIN_MAGIC): sys.exit(0)
+    elif magic.startswith(FAT_MAGIC):  sys.exit(1)
+else:
+    if   magic.startswith(THIN_MAGIC): sys.exit(1)
+    elif magic.startswith(FAT_MAGIC):  sys.exit(0)
+
+
+# Inconclusive test, probably an unknown or foreign static archive format.
+# Allow check to pass
+sys.exit(0)

--- a/test cases/unit/101 thinlinking/file1.c
+++ b/test cases/unit/101 thinlinking/file1.c
@@ -1,0 +1,14 @@
+#include<public_header.h>
+#include<private_header.h>
+
+int public_func() {
+    return round1_a();
+}
+
+int round1_a() {
+    return round1_b();
+}
+
+int round2_a() {
+    return round2_b();
+}

--- a/test cases/unit/101 thinlinking/file2.c
+++ b/test cases/unit/101 thinlinking/file2.c
@@ -1,0 +1,9 @@
+#include<private_header.h>
+
+int round1_b() {
+    return round1_c();
+}
+
+int round2_b() {
+    return round2_c();
+}

--- a/test cases/unit/101 thinlinking/file3.c
+++ b/test cases/unit/101 thinlinking/file3.c
@@ -1,0 +1,9 @@
+#include<private_header.h>
+
+int round1_c() {
+    return round1_d();
+}
+
+int round2_c() {
+    return round2_d();
+}

--- a/test cases/unit/101 thinlinking/file4.c
+++ b/test cases/unit/101 thinlinking/file4.c
@@ -1,0 +1,9 @@
+#include<private_header.h>
+
+int round1_d() {
+    return round2_a();
+}
+
+int round2_d() {
+    return 42;
+}

--- a/test cases/unit/101 thinlinking/main.c
+++ b/test cases/unit/101 thinlinking/main.c
@@ -1,0 +1,10 @@
+#include<public_header.h>
+#include<stdio.h>
+
+int main(int argc, char **argv) {
+    if(public_func() != 42) {
+        printf("Something failed.\n");
+        return 1;
+    }
+    return 0;
+}

--- a/test cases/unit/101 thinlinking/meson.build
+++ b/test cases/unit/101 thinlinking/meson.build
@@ -1,0 +1,22 @@
+project('thinlinking', 'c')
+
+hostsystem = host_machine.system()
+archeck    = find_program(files('archeck.py'))
+libthin    = static_library('thinlinked',    'file1.c', thin: true)
+libfat     = static_library('fatlinked',     'file2.c', thin: false)
+libthinpre = static_library('thinprelinked', 'file3.c', thin: true,  prelink: true)
+libfatpre  = static_library('fatprelinked',  'file4.c', thin: false, prelink: true)
+libmainpic = static_library('defpiclinked',  'main.c', pic: true)
+
+exe = executable('testprog', [], link_with:
+    [libthinpre, libthin, libfatpre,  libfat, libmainpic])
+
+test('thinlinked', exe)
+
+# On OS X and other systems, toolchains may not support thin-linking.
+if hostsystem.contains('bsd') or hostsystem in ['dragonfly', 'linux']
+  test('thin 1', archeck, args: ['thin', libthin])
+  test('thin 2', archeck, args: ['thin', libthinpre])
+endif
+test('fat  1', archeck, args: ['fat',  libfat])
+test('fat  2', archeck, args: ['fat',  libfatpre])

--- a/test cases/unit/101 thinlinking/private_header.h
+++ b/test cases/unit/101 thinlinking/private_header.h
@@ -1,0 +1,11 @@
+#pragma once
+
+int round1_a();
+int round1_b();
+int round1_c();
+int round1_d();
+
+int round2_a();
+int round2_b();
+int round2_c();
+int round2_d();

--- a/test cases/unit/101 thinlinking/public_header.h
+++ b/test cases/unit/101 thinlinking/public_header.h
@@ -1,0 +1,3 @@
+#pragma once
+
+int public_func();


### PR DESCRIPTION
With 0.60.0, non-installed `static_library()` targets are built by default as thin archives where supported, such as with `ar csrT`.  This broke a flow where I was statically linking code into an archive, then passing the archive to a `custom_target()` that was expecting a "fat" archive and wasn't handling "thin" archives _(specifically, it's `nvcc` being driven with custom flags)_.

Thin archives are handy, but "fattening" an archive where needed is quite involved and annoying.

Add a `thin:` kwarg to `static_library()` and default it to `true`, continuing the new behaviour of using thin archives in 0.60.0+. Passing the non-default `thin: false` restores the known-good behaviour of Meson prior to 0.60.0.