### PR TITLE
Changing xc16's linker from xc16-gcc.exe to xc16-gcc

### DIFF
--- a/mesonbuild/linkers/linkers.py
+++ b/mesonbuild/linkers/linkers.py
@@ -893,7 +893,7 @@ class Xc16DynamicLinker(DynamicLinker):
 
     def __init__(self, for_machine: mesonlib.MachineChoice,
                  *, version: str = 'unknown version'):
-        super().__init__(['xc16-gcc.exe'], for_machine, '', [],
+        super().__init__(['xc16-gcc'], for_machine, '', [],
                          version=version)
 
     def get_link_whole_for(self, args: T.List[str]) -> T.List[str]:
@@ -914,7 +914,7 @@ class Xc16DynamicLinker(DynamicLinker):
         return [f'-o{outputname}']
 
     def get_search_args(self, dirname: str) -> 'T.NoReturn':
-        raise OSError('xc16-gcc.exe does not have a search dir argument')
+        raise OSError('xc16-gcc does not have a search dir argument')
 
     def get_allow_undefined_args(self) -> T.List[str]:
         return []


### PR DESCRIPTION
Changing xc16's linker from 'xc16-gcc.exe' to 'xc16-gcc'. Windows will still find the correct linker and now linux will be able to use its xc16-gcc as the linker.