### PR TITLE
Fix crash when getting cuda options

### DIFF
--- a/test cases/cuda/16 multistd/lib.cu
+++ b/test cases/cuda/16 multistd/lib.cu
@@ -1,0 +1,3 @@
+int do_cuda_stuff() {
+  return 0;
+}

--- a/test cases/cuda/16 multistd/main.cu
+++ b/test cases/cuda/16 multistd/main.cu
@@ -7,6 +7,7 @@ auto cuda_devices(void) {
     return result;
 }
 
+int do_cuda_stuff();
 
 int main(void) {
     int n = cuda_devices();
@@ -16,5 +17,5 @@ int main(void) {
     }
 
     std::cout << "Found " << n << "Cuda devices.\n";
-    return 0;
+    return do_cuda_stuff();
 }

--- a/test cases/cuda/16 multistd/meson.build
+++ b/test cases/cuda/16 multistd/meson.build
@@ -2,6 +2,12 @@ project('C++-CUDA multi-std', 'cpp', 'cuda',
         version : '1.0.0',
         default_options : ['cpp_std=c++17', 'cuda_std=c++14'])
 
-exe = executable('prog', 'main.cu')
+# Regression test: Passing override_options used to cause a crash.
+# See https://github.com/mesonbuild/meson/issues/9448.
+libcpp11 = static_library('testcpp11', 'lib.cu',
+  override_options: ['cpp_std=c++11']
+)
+
+exe = executable('prog', 'main.cu', link_with: libcpp11)
 # The runtimes leak memory, so ignore it.
 test('cudatest', exe, env: ['ASAN_OPTIONS=detect_leaks=0'])


### PR DESCRIPTION
We could have an OptionOverrideProxy of an OptionOverrideProxy,
recursively. This fix is a minimal subset of the refactoring I did in
https://github.com/mesonbuild/meson/pull/9394. Instead of faking
UserOption we can just do a shallow copy of one and set a new value on
it.