### PR TITLE
Use typed_pos args in gnome module (and other typing cleanups)

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1003,7 +1003,7 @@ class BuildTarget(Target):
         return ExtractedObjects(self, self.sources, self.generated, self.objects,
                                 recursive)
 
-    def get_all_link_deps(self):
+    def get_all_link_deps(self) -> 'ImmutableListProtocol[Target]':
         return self.get_transitive_link_deps()
 
     @lru_cache(maxsize=None)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -685,7 +685,7 @@ class BuildTarget(Target):
         self.compilers = OrderedDict() # type: OrderedDict[str, Compiler]
         self.objects: T.List[T.Union[str, 'File', 'ExtractedObjects']] = []
         self.external_deps: T.List[dependencies.Dependency] = []
-        self.include_dirs = []
+        self.include_dirs: T.List['IncludeDirs'] = []
         self.link_language = kwargs.get('link_language')
         self.link_targets: T.List[BuildTarget] = []
         self.link_whole_targets = []
@@ -1276,7 +1276,7 @@ class BuildTarget(Target):
     def get_pch(self, language: str) -> T.List[str]:
         return self.pch.get(language, [])
 
-    def get_include_dirs(self):
+    def get_include_dirs(self) -> T.List['IncludeDirs']:
         return self.include_dirs
 
     def add_deps(self, deps):
@@ -1423,8 +1423,8 @@ You probably should put it in link_with instead.''')
                 raise MesonException(f'File {f} does not exist.')
         self.pch[language] = pchlist
 
-    def add_include_dirs(self, args, set_is_system: T.Optional[str] = None):
-        ids = []
+    def add_include_dirs(self, args: T.Sequence['IncludeDirs'], set_is_system: T.Optional[str] = None) -> None:
+        ids: T.List['IncludeDirs'] = []
         for a in args:
             if not isinstance(a, IncludeDirs):
                 raise InvalidArguments('Include directory to be added is not an include directory object.')

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2347,7 +2347,7 @@ class CustomTarget(Target, CommandBase):
         # TODO expose keyword arg to make MachineChoice.HOST configurable
         super().__init__(name, subdir, subproject, False, MachineChoice.HOST)
         self.dependencies: T.List[T.Union[CustomTarget, BuildTarget]] = []
-        self.extra_depends = []
+        self.extra_depends: T.List[T.Union[CustomTarget, BuildTarget]] = []
         self.depend_files = [] # Files that this target depends on but are not on the command line.
         self.depfile = None
         self.process_kwargs(kwargs, backend)
@@ -2367,7 +2367,7 @@ class CustomTarget(Target, CommandBase):
         repr_str = "<{0} {1}: {2}>"
         return repr_str.format(self.__class__.__name__, self.get_id(), self.command)
 
-    def get_target_dependencies(self):
+    def get_target_dependencies(self) -> T.List[T.Union['BuildTarget', 'CustomTarget']]:
         deps = self.dependencies[:]
         deps += self.extra_depends
         for c in self.sources:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1857,6 +1857,13 @@ class Executable(BuildTarget):
     def is_linkable_target(self):
         return self.is_linkwithable
 
+    def get_command(self) -> 'ImmutableListProtocol[str]':
+        """Provides compatibility with ExternalProgram.
+
+        Since you can override ExternalProgram instances with Executables.
+        """
+        return self.outputs
+
 class StaticLibrary(BuildTarget):
     known_kwargs = known_stlib_kwargs
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -385,11 +385,19 @@ class IncludeDirs(HoldableObject):
     def get_extra_build_dirs(self) -> T.List[str]:
         return self.extra_build_dirs
 
-    def to_string_list(self, sourcedir: str) -> T.List[str]:
-        """Convert IncludeDirs object to a list of strings."""
+    def to_string_list(self, sourcedir: str, builddir: T.Optional[str] = None) -> T.List[str]:
+        """Convert IncludeDirs object to a list of strings.
+
+        :param sourcedir: The absolute source directory
+        :param builddir: The absolute build directory, option, buid dir will not
+            be added if this is unset
+        :returns: A list of strings (without compiler argument)
+        """
         strlist: T.List[str] = []
         for idir in self.incdirs:
             strlist.append(os.path.join(sourcedir, self.curdir, idir))
+            if builddir:
+                strlist.append(os.path.join(builddir, self.curdir, idir))
         return strlist
 
 class ExtractedObjects(HoldableObject):

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -118,6 +118,7 @@ ENV_VAR_PROG_MAP: T.Mapping[str, str] = {
     'qmake': 'QMAKE',
     'pkgconfig': 'PKG_CONFIG',
     'make': 'MAKE',
+    'vapigen': 'VAPIGEN',
 }
 
 # Deprecated environment variables mapped from the new variable to the old one

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1368,7 +1368,8 @@ external dependencies (including libraries) must go to "dependencies".''')
                 extra_info.append(f"({' '.join(extprog.get_command())})")
                 return extprog
 
-    def program_from_overrides(self, command_names, extra_info):
+    def program_from_overrides(self, command_names: T.List[str], extra_info: T.List['mlog.TV_Loggable']) -> \
+            T.Optional[T.Union[ExternalProgram, 'OverrideProgram', 'build.Executable']]:
         for name in command_names:
             if not isinstance(name, str):
                 continue

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -455,7 +455,7 @@ class Interpreter(InterpreterBase, HoldableObject):
             held_type: holder_type
         })
 
-    def process_new_values(self, invalues: T.List[TYPE_var]) -> None:
+    def process_new_values(self, invalues: T.List[T.Union[TYPE_var, ExecutableSerialisation]]) -> None:
         invalues = listify(invalues)
         for v in invalues:
             if isinstance(v, ObjectHolder):

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -72,18 +72,9 @@ class ModuleState:
         for dirs in include_dirs:
             if isinstance(dirs, str):
                 dirs_str += [f'{prefix}{dirs}']
-                continue
-
-            # Should be build.IncludeDirs object.
-            basedir = dirs.get_curdir()
-            for d in dirs.get_incdirs():
-                expdir = os.path.join(basedir, d)
-                srctreedir = os.path.join(srcdir, expdir)
-                buildtreedir = os.path.join(builddir, expdir)
-                dirs_str += [f'{prefix}{buildtreedir}',
-                             f'{prefix}{srctreedir}']
-            for d in dirs.get_extra_build_dirs():
-                dirs_str += [f'{prefix}{d}']
+            else:
+                dirs_str.extend([f'{prefix}{i}' for i in dirs.to_string_list(srcdir, builddir)])
+                dirs_str.extend([f'{prefix}{i}' for i in dirs.get_extra_build_dirs()])
 
         return dirs_str
 

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -192,10 +192,11 @@ def is_module_library(fname):
 
 
 class ModuleReturnValue:
-    def __init__(self, return_value: T.Optional['TYPE_var'], new_objects: T.Sequence['TYPE_var']) -> None:
+    def __init__(self, return_value: T.Optional['TYPE_var'],
+                 new_objects: T.Sequence[T.Union['TYPE_var', 'build.ExecutableSerialisation']]) -> None:
         self.return_value = return_value
         assert isinstance(new_objects, list)
-        self.new_objects = new_objects
+        self.new_objects: T.List[T.Union['TYPE_var', 'build.ExecutableSerialisation']] = new_objects
 
 class GResourceTarget(build.CustomTarget):
     pass

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -198,21 +198,16 @@ class ModuleReturnValue:
         self.new_objects = new_objects
 
 class GResourceTarget(build.CustomTarget):
-    def __init__(self, name, subdir, subproject, kwargs):
-        super().__init__(name, subdir, subproject, kwargs)
+    pass
 
 class GResourceHeaderTarget(build.CustomTarget):
-    def __init__(self, name, subdir, subproject, kwargs):
-        super().__init__(name, subdir, subproject, kwargs)
+    pass
 
 class GirTarget(build.CustomTarget):
-    def __init__(self, name, subdir, subproject, kwargs):
-        super().__init__(name, subdir, subproject, kwargs)
+    pass
 
 class TypelibTarget(build.CustomTarget):
-    def __init__(self, name, subdir, subproject, kwargs):
-        super().__init__(name, subdir, subproject, kwargs)
+    pass
 
 class VapiTarget(build.CustomTarget):
-    def __init__(self, name, subdir, subproject, kwargs):
-        super().__init__(name, subdir, subproject, kwargs)
+    pass

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1075,12 +1075,9 @@ class GnomeModule(ExtensionModule):
                       'mkdb_args', 'ignore_headers', 'include_directories',
                       'namespace', 'mode', 'expand_content_files', 'module_version',
                       'c_args', 'check'})
-    def gtkdoc(self, state, args, kwargs):
-        if len(args) != 1:
-            raise MesonException('Gtkdoc must have one positional argument.')
+    @typed_pos_args('gnome.gtkdok', str)
+    def gtkdoc(self, state: 'ModuleState', args: T.Tuple[str], kwargs):
         modulename = args[0]
-        if not isinstance(modulename, str):
-            raise MesonException('Gtkdoc arg must be string.')
         if 'src_dir' not in kwargs:
             raise MesonException('Keyword argument src_dir missing.')
         main_file = kwargs.get('main_sgml', '')

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -269,10 +269,10 @@ class GnomeModule(ExtensionModule):
             output = f'{target_name}.gresource'
             name = f'{target_name}_gresource'
         else:
-            if 'c' in state.environment.coredata.compilers.host.keys():
+            if 'c' in state.environment.coredata.compilers.host:
                 output = f'{target_name}.c'
                 name = f'{target_name}_c'
-            elif 'cpp' in state.environment.coredata.compilers.host.keys():
+            elif 'cpp' in state.environment.coredata.compilers.host:
                 output = f'{target_name}.cpp'
                 name = f'{target_name}_cpp'
             else:

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1399,9 +1399,8 @@ class GnomeModule(ExtensionModule):
     @permittedKwargs({'sources', 'c_template', 'h_template', 'install_header', 'install_dir',
                       'comments', 'identifier_prefix', 'symbol_prefix', 'eprod', 'vprod',
                       'fhead', 'fprod', 'ftail', 'vhead', 'vtail', 'depends'})
-    def mkenums(self, state, args, kwargs):
-        if len(args) != 1:
-            raise MesonException('Mkenums requires one positional argument.')
+    @typed_pos_args('gnome.mkenums', str)
+    def mkenums(self, state: 'ModuleState', args: T.Tuple[str], kwargs) -> ModuleReturnValue:
         basename = args[0]
 
         if 'sources' not in kwargs:

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -207,7 +207,7 @@ class GnomeModule(ExtensionModule):
         # Validate dependencies
         subdirs = []
         depends = []
-        for (ii, dep) in enumerate(dependencies):
+        for dep in dependencies:
             if isinstance(dep, mesonlib.File):
                 subdirs.append(dep.subdir)
             elif isinstance(dep, (build.CustomTarget, build.CustomTargetIndex)):

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -19,6 +19,7 @@ import copy
 import functools
 import os
 import subprocess
+import textwrap
 import typing as T
 
 from . import ExtensionModule
@@ -1558,33 +1559,37 @@ class GnomeModule(ExtensionModule):
         fhead += '#include "%s"\n' % hdr_filename
         for hdr in sources:
             fhead += '#include "{}"\n'.format(os.path.basename(str(hdr)))
-        fhead += '''
-#define C_ENUM(v) ((gint) v)
-#define C_FLAGS(v) ((guint) v)
-'''
+        fhead += textwrap.dedent(
+            '''
+            #define C_ENUM(v) ((gint) v)
+            #define C_FLAGS(v) ((guint) v)
+            ''')
         c_file_kwargs['fhead'] = fhead
 
-        c_file_kwargs['fprod'] = '''
-/* enumerations from "@basename@" */
-'''
+        c_file_kwargs['fprod'] = textwrap.dedent(
+            '''
+            /* enumerations from "@basename@" */
+            ''')
 
-        c_file_kwargs['vhead'] = f'''
-GType
-{func_prefix}@enum_name@_get_type (void)
-{{
-  static gsize gtype_id = 0;
-  static const G@Type@Value values[] = {{'''
+        c_file_kwargs['vhead'] = textwrap.dedent(
+            f'''
+            GType
+            {func_prefix}@enum_name@_get_type (void)
+            {{
+            static gsize gtype_id = 0;
+            static const G@Type@Value values[] = {{''')
 
         c_file_kwargs['vprod'] = '    { C_@TYPE@(@VALUENAME@), "@VALUENAME@", "@valuenick@" },'
 
-        c_file_kwargs['vtail'] = '''    { 0, NULL, NULL }
-  };
-  if (g_once_init_enter (&gtype_id)) {
-    GType new_type = g_@type@_register_static (g_intern_static_string ("@EnumName@"), values);
-    g_once_init_leave (&gtype_id, new_type);
-  }
-  return (GType) gtype_id;
-}'''
+        c_file_kwargs['vtail'] = textwrap.dedent(
+            '''    { 0, NULL, NULL }
+            };
+            if (g_once_init_enter (&gtype_id)) {
+                GType new_type = g_@type@_register_static (g_intern_static_string ("@EnumName@"), values);
+                g_once_init_leave (&gtype_id, new_type);
+            }
+            return (GType) gtype_id;
+            }''')
 
         rv = self.mkenums(state, [body_filename], c_file_kwargs)
         c_file = rv.return_value
@@ -1592,25 +1597,29 @@ GType
         # .h file generation
         h_file_kwargs = copy.deepcopy(mkenums_kwargs)
 
-        h_file_kwargs['fhead'] = f'''#pragma once
+        h_file_kwargs['fhead'] = textwrap.dedent(
+            f'''#pragma once
 
-#include <glib-object.h>
-{header_prefix}
+            #include <glib-object.h>
+            {header_prefix}
 
-G_BEGIN_DECLS
-'''
+            G_BEGIN_DECLS
+            ''')
 
-        h_file_kwargs['fprod'] = '''
-/* enumerations from "@basename@" */
-'''
+        h_file_kwargs['fprod'] = textwrap.dedent(
+            '''
+            /* enumerations from "@basename@" */
+            ''')
 
-        h_file_kwargs['vhead'] = f'''
-{decl_decorator}
-GType {func_prefix}@enum_name@_get_type (void);
-#define @ENUMPREFIX@_TYPE_@ENUMSHORT@ ({func_prefix}@enum_name@_get_type())'''
+        h_file_kwargs['vhead'] = textwrap.dedent(
+            f'''
+            {decl_decorator}
+            GType {func_prefix}@enum_name@_get_type (void);
+            #define @ENUMPREFIX@_TYPE_@ENUMSHORT@ ({func_prefix}@enum_name@_get_type())''')
 
-        h_file_kwargs['ftail'] = '''
-G_END_DECLS'''
+        h_file_kwargs['ftail'] = textwrap.dedent(
+            '''
+            G_END_DECLS''')
 
         rv = self.mkenums(state, [hdr_filename], h_file_kwargs)
         h_file = rv.return_value

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1001,18 +1001,15 @@ class GnomeModule(ExtensionModule):
     @permittedKwargs({'sources', 'media', 'symlink_media', 'languages'})
     @FeatureDeprecatedKwargs('gnome.yelp', '0.43.0', ['languages'],
                              'Use a LINGUAS file in the source directory instead')
-    def yelp(self, state, args, kwargs):
-        if len(args) < 1:
-            raise MesonException('Yelp requires a project id')
-
+    @typed_pos_args('gnome.yelp', str, varargs=str)
+    def yelp(self, state: 'ModuleState', args: T.Tuple[str, T.List[str]], kwargs) -> ModuleReturnValue:
         project_id = args[0]
         if len(args) > 1:
             FeatureDeprecated.single_use('gnome.yelp more than one positional argument', '0.60.0', 'use the "sources" keyword argument instead.')
 
         sources = mesonlib.stringlistify(kwargs.pop('sources', []))
         if not sources:
-            if len(args) > 1:
-                sources = mesonlib.stringlistify(args[1:])
+            sources = args[1]
             if not sources:
                 raise MesonException('Yelp requires a list of sources')
         else:

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -45,7 +45,7 @@ if T.TYPE_CHECKING:
     from . import ModuleState
     from ..compilers import Compiler
     from ..interpreter import Interpreter
-    from ..interpreterbase import TYPE_var
+    from ..interpreterbase import TYPE_var, TYPE_kwargs
     from ..mesonlib import FileOrString
 
     class PostInstall(TypedDict):
@@ -1075,7 +1075,7 @@ class GnomeModule(ExtensionModule):
                       'mkdb_args', 'ignore_headers', 'include_directories',
                       'namespace', 'mode', 'expand_content_files', 'module_version',
                       'c_args', 'check'})
-    @typed_pos_args('gnome.gtkdok', str)
+    @typed_pos_args('gnome.gtkdoc', str)
     def gtkdoc(self, state: 'ModuleState', args: T.Tuple[str], kwargs):
         modulename = args[0]
         if 'src_dir' not in kwargs:
@@ -1228,13 +1228,9 @@ class GnomeModule(ExtensionModule):
         return args
 
     @noKwargs
-    def gtkdoc_html_dir(self, state, args, kwargs):
-        if len(args) != 1:
-            raise MesonException('Must have exactly one argument.')
-        modulename = args[0]
-        if not isinstance(modulename, str):
-            raise MesonException('Argument must be a string')
-        return os.path.join('share/gtk-doc/html', modulename)
+    @typed_pos_args('gnome.gtkdoc_html_dir', str)
+    def gtkdoc_html_dir(self, state: 'ModuleState', args: T.Tuple[str], kwargs: 'TYPE_kwargs') -> str:
+        return os.path.join('share/gtk-doc/html', args[0])
 
     @staticmethod
     def _unpack_args(arg, kwarg_name: str, kwargs: T.Dict[str, T.Any], expend_file_state: T.Optional['ModuleState'] = None) -> T.List[str]:

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -980,9 +980,8 @@ class GnomeModule(ExtensionModule):
 
     @FeatureNewKwargs('build target', '0.40.0', ['build_by_default'])
     @permittedKwargs({'build_by_default', 'depend_files'})
-    def compile_schemas(self, state, args, kwargs):
-        if args:
-            raise MesonException('Compile_schemas does not take positional arguments.')
+    @noPosargs
+    def compile_schemas(self, state: 'ModuleState', args: T.List['TYPE_var'], kwargs) -> ModuleReturnValue:
         srcdir = os.path.join(state.build_to_src, state.subdir)
         outdir = state.subdir
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1508,9 +1508,10 @@ class GnomeModule(ExtensionModule):
             return ModuleReturnValue(targets, targets)
 
     @FeatureNew('gnome.mkenums_simple', '0.42.0')
-    def mkenums_simple(self, state, args, kwargs):
-        hdr_filename = args[0] + '.h'
-        body_filename = args[0] + '.c'
+    @typed_pos_args('gnome.mkenums_simple', str)
+    def mkenums_simple(self, state: 'ModuleState', args: T.Tuple[str], kwargs) -> ModuleReturnValue:
+        hdr_filename = f'{args[0]}.h'
+        body_filename = f'{args[0]}.c'
 
         # not really needed, just for sanity checking
         forbidden_kwargs = ['c_template', 'h_template', 'eprod', 'fhead',

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1780,14 +1780,9 @@ G_END_DECLS'''
 
     @permittedKwargs({'sources', 'packages', 'metadata_dirs', 'gir_dirs',
                       'vapi_dirs', 'install', 'install_dir'})
-    def generate_vapi(self, state: 'ModuleState', args, kwargs) -> ModuleReturnValue:
-        if len(args) != 1:
-            raise MesonException('The library name is required')
-
-        if not isinstance(args[0], str):
-            raise MesonException('The first argument must be the name of the library')
+    @typed_pos_args('gnome.generate_vapi', str)
+    def generate_vapi(self, state: 'ModuleState', args: T.Tuple[str], kwargs) -> ModuleReturnValue:
         created_values = []
-
         library = args[0]
         build_dir = os.path.join(state.environment.get_build_dir(), state.subdir)
         source_dir = os.path.join(state.environment.get_source_dir(), state.subdir)

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -873,13 +873,13 @@ class GnomeModule(ExtensionModule):
                       'export_packages', 'includes', 'dependencies', 'link_with', 'include_directories',
                       'install', 'install_dir_gir', 'install_dir_typelib', 'extra_args',
                       'packages', 'header', 'build_by_default', 'fatal_warnings'})
-    def generate_gir(self, state, args, kwargs: T.Dict[str, T.Any]):
-        if not args:
-            raise MesonException('generate_gir takes at least one argument')
+    @typed_pos_args('gnome.generate_gir', varargs=(build.Executable, build.SharedLibrary, build.StaticLibrary), min_varargs=1)
+    def generate_gir(self, state: 'ModuleState', args: T.Tuple[T.List[T.Union[build.Executable, build.SharedLibrary, build.StaticLibrary]]],
+                     kwargs: T.Dict[str, T.Any]) -> ModuleReturnValue:
         if kwargs.get('install_dir'):
             raise MesonException('install_dir is not supported with generate_gir(), see "install_dir_gir" and "install_dir_typelib"')
 
-        girtargets = [self._unwrap_gir_target(arg, state) for arg in args]
+        girtargets = [self._unwrap_gir_target(arg, state) for arg in args[0]]
 
         if len(girtargets) > 1 and any([isinstance(el, build.Executable) for el in girtargets]):
             raise MesonException('generate_gir only accepts a single argument when one of the arguments is an executable')

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -15,28 +15,28 @@
 '''This module provides helper functions for Gnome/GLib related
 functionality such as gobject-introspection, gresources and gtk-doc'''
 
-import os
 import copy
-import subprocess
 import functools
+import os
+import subprocess
 import typing as T
 
-from .. import build
-from .. import mlog
-from .. import mesonlib
-from .. import interpreter
-from . import GResourceTarget, GResourceHeaderTarget, GirTarget, TypelibTarget, VapiTarget
 from . import ExtensionModule
+from . import GResourceTarget, GResourceHeaderTarget, GirTarget, TypelibTarget, VapiTarget
 from . import ModuleReturnValue
+from .. import build
+from .. import interpreter
+from .. import mesonlib
+from .. import mlog
+from ..build import CustomTarget, CustomTargetIndex, GeneratedList
+from ..dependencies import Dependency, PkgConfigDependency, InternalDependency
+from ..interpreterbase import noPosargs, noKwargs, permittedKwargs, FeatureNew, FeatureNewKwargs, FeatureDeprecatedKwargs, FeatureDeprecated
+from ..interpreterbase import typed_kwargs, KwargInfo, ContainerTypeInfo
 from ..mesonlib import (
     MachineChoice, MesonException, OrderedSet, Popen_safe, extract_as_list,
     join_args, HoldableObject
 )
-from ..dependencies import Dependency, PkgConfigDependency, InternalDependency
-from ..interpreterbase import noPosargs, noKwargs, permittedKwargs, FeatureNew, FeatureNewKwargs, FeatureDeprecatedKwargs, FeatureDeprecated
-from ..interpreterbase import typed_kwargs, KwargInfo, ContainerTypeInfo
 from ..programs import ExternalProgram, OverrideProgram
-from ..build import CustomTarget, CustomTargetIndex, GeneratedList
 
 if T.TYPE_CHECKING:
     from ..compilers import Compiler

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1636,10 +1636,8 @@ G_END_DECLS'''
     @permittedKwargs({'sources', 'prefix', 'install_header', 'install_dir', 'stdinc',
                       'nostdinc', 'internal', 'skip_source', 'valist_marshallers',
                       'extra_args'})
-    def genmarshal(self, state, args, kwargs):
-        if len(args) != 1:
-            raise MesonException(
-                'Genmarshal requires one positional argument.')
+    @typed_pos_args('gnome.genmarshal', str)
+    def genmarshal(self, state: 'ModuleState', args: T.Tuple[str], kwargs) -> ModuleReturnValue:
         output = args[0]
 
         if 'sources' not in kwargs:

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1273,11 +1273,10 @@ class GnomeModule(ExtensionModule):
     @FeatureNewKwargs('build target', '0.47.0', ['extra_args', 'autocleanup'])
     @permittedKwargs({'interface_prefix', 'namespace', 'extra_args', 'autocleanup', 'object_manager', 'build_by_default',
                       'annotations', 'docbook', 'install_header', 'install_dir', 'sources'})
-    def gdbus_codegen(self, state, args, kwargs):
-        if len(args) not in (1, 2):
-            raise MesonException('gdbus_codegen takes at most two arguments, name and xml file.')
+    @typed_pos_args('gnome.gdbus_codegen', str, optargs=[str])
+    def gdbus_codegen(self, state: 'ModuleState', args: T.Tuple[str, T.Optional[str]], kwargs) -> ModuleReturnValue:
         namebase = args[0]
-        xml_files = args[1:]
+        xml_files: T.List[str] = [args[1]] if args[1] else []
         cmd = [state.find_program('gdbus-codegen')]
         extra_args = mesonlib.stringlistify(kwargs.pop('extra_args', []))
         cmd += extra_args

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1788,10 +1788,7 @@ G_END_DECLS'''
         source_dir = os.path.join(state.environment.get_source_dir(), state.subdir)
         pkg_cmd, vapi_depends, vapi_packages, vapi_includes = self._extract_vapi_packages(state, kwargs)
         cmd: T.List[T.Union[str, 'ExternalProgram']]
-        if 'VAPIGEN' in os.environ:
-            cmd = [state.find_program(os.environ['VAPIGEN'])]
-        else:
-            cmd = [state.find_program('vapigen')]
+        cmd = [state.find_program('vapigen')]
         cmd += ['--quiet', '--library=' + library, '--directory=' + build_dir]
         cmd += self._vapi_args_to_command('--vapidir=', 'vapi_dirs', kwargs)
         cmd += self._vapi_args_to_command('--metadatadir=', 'metadata_dirs', kwargs)


### PR DESCRIPTION
This series is the starting work of a larger gnome module modernization/cleanup I've been working on. The series is quite large, and the keyword argument conversion is much more involved, and likely to require a deeper review. I've shaved off what are (hopefully) smaller, easier to verify changes.

The first part of this series is groundwork, adding or fixing type annotations, using helpers instead of open coding, fixing polymorphism in union types, and that sort of thing.

Then i've added most of the "easy" type annotations to the gnome module, namely those that don't involve using typed_pos_args or typed_kwargs.

Finally, the last par of the series makes use of `typed_pos_args` or `noPosargs`, as appropriate. I'll follow this up with work on using typed_kwargs, some of which is done, some of which is in progress, but I felt this was already big enough of a series without that.