### PR TITLE
intro-install_plan: fix destinations for build_targets with custom install_dir

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -624,13 +624,14 @@ class Target(HoldableObject):
 
     def get_install_dir(self) -> T.Tuple[T.List[T.Union[str, Literal[False]]], str, Literal[False]]:
         # Find the installation directory.
-        default_install_dir, install_dir_name = self.get_default_install_dir()
+        default_install_dir, default_install_dir_name = self.get_default_install_dir()
         outdirs = self.get_custom_install_dir()
         if outdirs and outdirs[0] != default_install_dir and outdirs[0] is not True:
             # Either the value is set to a non-default value, or is set to
             # False (which means we want this specific output out of many
             # outputs to not be installed).
             custom_install_dir = True
+            default_install_dir_name = None
         else:
             custom_install_dir = False
             # if outdirs is empty we need to set to something, otherwise we set
@@ -640,7 +641,7 @@ class Target(HoldableObject):
             else:
                 outdirs = [default_install_dir]
 
-        return outdirs, install_dir_name, custom_install_dir
+        return outdirs, default_install_dir_name, custom_install_dir
 
     def get_basename(self) -> str:
         return self.name

--- a/test cases/unit/98 install all targets/meson.build
+++ b/test cases/unit/98 install all targets/meson.build
@@ -36,6 +36,10 @@ static_library('static', 'lib.c',
 executable('app', 'main.c',
   install: true,
 )
+executable('app-otherdir', 'main.c',
+  install: true,
+  install_dir: 'otherbin',
+)
 shared_library('shared', 'lib.c',
   install: true,
 )

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3961,6 +3961,8 @@ class AllPlatformTests(BasePlatformTests):
                 Path(installpath, 'usr/lib/bothcustom.lib'),
                 Path(installpath, 'usr/lib/shared.lib'),
                 Path(installpath, 'usr/lib/versioned_shared.lib'),
+                Path(installpath, 'usr/otherbin'),
+                Path(installpath, 'usr/otherbin/app-otherdir.pdb'),
             }
         elif is_windows() or is_cygwin():
             expected_devel |= {
@@ -3978,6 +3980,8 @@ class AllPlatformTests(BasePlatformTests):
         expected_runtime = expected_common | {
             Path(installpath, 'usr/bin'),
             Path(installpath, 'usr/bin/' + exe_name('app')),
+            Path(installpath, 'usr/otherbin'),
+            Path(installpath, 'usr/otherbin/' + exe_name('app-otherdir')),
             Path(installpath, 'usr/bin/' + exe_name('app2')),
             Path(installpath, 'usr/' + shared_lib_name('shared')),
             Path(installpath, 'usr/' + shared_lib_name('both')),
@@ -4084,6 +4088,10 @@ class AllPlatformTests(BasePlatformTests):
                 },
                 f'{self.builddir}/' + exe_name('app'): {
                     'destination': '{bindir}/' + exe_name('app'),
+                    'tag': 'runtime',
+                },
+                f'{self.builddir}/' + exe_name('app-otherdir'): {
+                    'destination': '{prefix}/otherbin/' + exe_name('app-otherdir'),
                     'tag': 'runtime',
                 },
                 f'{self.builddir}/subdir/' + exe_name('app2'): {


### PR DESCRIPTION
There are a couple issues that combine to make the current handling a bit confusing.

- we call it "install_dir_name" but it is only ever the class default
- CustomTarget always has it set to None, and then we check if it is None then create a different variable with a safe fallback. The if is useless -- it cannot fail, but if it did we'd get an undefined variable error when we tried to use `dir_name`

Remove the special handling for CustomTarget. Instead, just always accept None as a possible value of outdir_name when constructing install data, and, if it is None, fall back to {prefix}/outdir regardless of what type it used to be.

This resolves some of the confusion inherent in #9474 but unfortunately does not *actually* fix it. Python shared extension_modules are no longer generated with a destination plan of `{moduledir_shared}/modname.cpython-39-x86_64-linux-gnu.so`.

Instead, they are generated with a destination plan of `/usr/lib/python3.9/site-packages/packagename/modname.cpython-39-x86_64-linux-gnu.so` which is... unfortunate.

Still, it is a start at the correct solution. I think the remaining factor here will be either:
- subclassing SharedModule to PythonSharedModule and teaching it a better constructor
- teaching Target to accept an arbitrary override, like build.Data does, which contains a better value
- teaching the `install_dir` kwarg in any function in meson.build, to accept replacements such as `install_dir: '@PYTHON.PLATLIBDIR@/package/subpackage'` or `install_dir: '@LIBDIR@/subdir` (and redesigning install_dir_name to use this)

The last option there would be a bit invasive, but has the advantage of:
- allowing people to get some benefit from install_plan even with generic custom install directories
- let people avoid using `join_paths(get_option('libdir'), 'subdir')` and similar, to construct custom install dirs that simply act as a subdirectory of a built-in directory

I'm not 100% positive on the best way forward, but this clearly does need a fix badly.

/cc @FFY00