### PR TITLE
Revert use of thin archives in 0.60 branch

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2789,7 +2789,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             if target.import_filename:
                 commands += linker.gen_import_library_args(self.get_import_filename(target))
         elif isinstance(target, build.StaticLibrary):
-            commands += linker.get_std_link_args(not target.should_install())
+            commands += linker.get_std_link_args(False)
         else:
             raise RuntimeError('Unknown build target type.')
         return commands


### PR DESCRIPTION
Some `custom_target()`s may want to receive "fat" archives, so making use of thin `static_library()` archives conditional only on it not being installed, and without the possibility of an override by the user, is undesirable. In #9453 I propose adding a `thin:` kwarg defaulting to `true`, but that's a new feature that can only land in 0.61.

Tag @xclaesse, @nirbheek.