### PR TITLE
modules/gnome: fix missing install_dir, again, harder

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1458,7 +1458,7 @@ class GnomeModule(ExtensionModule):
             c_kwargs = custom_kwargs.copy()
             # Never install the C file. Complain on bug tracker if you need it.
             c_kwargs['install'] = False
-            c_kwargs['install_dir'] = False
+            c_kwargs['install_dir'] = []
             if h_template is not None:
                 if 'depends' in custom_kwargs:
                     c_kwargs['depends'] += [h_target]


### PR DESCRIPTION
It turns out this could be missing in GResource*Target as well, due
mostly to the same problem, side effects of mutating a shared
dictionary; though it could also happen with a specific set of keywords
given and others omitted.

Fixes #9350, again