### PR TITLE
Fix KeyError: 'install_dir' in build.py

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2437,6 +2437,10 @@ class CustomTarget(Target, CommandBase):
                 raise InvalidArguments('@OUTPUT@ is not allowed when capturing output.')
             if self.feed and isinstance(c, str) and '@INPUT@' in c:
                 raise InvalidArguments('@INPUT@ is not allowed when feeding input.')
+        self.install = False
+        self.install_dir = []
+        self.install_mode = None
+        self.install_tag = []
         if 'install' in kwargs:
             self.install = kwargs['install']
             if not isinstance(self.install, bool):
@@ -2446,29 +2450,24 @@ class CustomTarget(Target, CommandBase):
                     raise InvalidArguments('"install_dir" must be specified '
                                            'when installing a target')
 
-            if isinstance(kwargs['install_dir'], list):
-                FeatureNew.single_use('multiple install_dir for custom_target', '0.40.0', self.subproject)
-            # If an item in this list is False, the output corresponding to
-            # the list index of that item will not be installed
-            self.install_dir = typeslistify(kwargs['install_dir'], (str, bool))
-            self.install_mode = kwargs.get('install_mode', None)
-            # If only one tag is provided, assume all outputs have the same tag.
-            # Otherwise, we must have as much tags as outputs.
-            install_tag: T.List[T.Union[str, bool, None]] = typeslistify(kwargs.get('install_tag', []), (str, bool, type(None)))
-            if not install_tag:
-                self.install_tag = [None] * len(self.outputs)
-            elif len(install_tag) == 1:
-                self.install_tag = install_tag * len(self.outputs)
-            elif install_tag and len(install_tag) != len(self.outputs):
-                m = f'Target {self.name!r} has {len(self.outputs)} outputs but {len(install_tag)} "install_tag"s were found.'
-                raise InvalidArguments(m)
-            else:
-                self.install_tag = install_tag
-        else:
-            self.install = False
-            self.install_dir = []
-            self.install_mode = None
-            self.install_tag = []
+                if isinstance(kwargs['install_dir'], list):
+                    FeatureNew.single_use('multiple install_dir for custom_target', '0.40.0', self.subproject)
+                # If an item in this list is False, the output corresponding to
+                # the list index of that item will not be installed
+                self.install_dir = typeslistify(kwargs['install_dir'], (str, bool))
+                self.install_mode = kwargs.get('install_mode', None)
+                # If only one tag is provided, assume all outputs have the same tag.
+                # Otherwise, we must have as much tags as outputs.
+                install_tag: T.List[T.Union[str, bool, None]] = typeslistify(kwargs.get('install_tag', []), (str, bool, type(None)))
+                if not install_tag:
+                    self.install_tag = [None] * len(self.outputs)
+                elif len(install_tag) == 1:
+                    self.install_tag = install_tag * len(self.outputs)
+                elif install_tag and len(install_tag) != len(self.outputs):
+                    m = f'Target {self.name!r} has {len(self.outputs)} outputs but {len(install_tag)} "install_tag"s were found.'
+                    raise InvalidArguments(m)
+                else:
+                    self.install_tag = install_tag
         if kwargs.get('build_always') is not None and kwargs.get('build_always_stale') is not None:
             raise InvalidArguments('build_always and build_always_stale are mutually exclusive. Combine build_by_default and build_always_stale.')
         elif kwargs.get('build_always') is not None:


### PR DESCRIPTION
There is a scenario where when install=False was passed and install_dir
not defined, the code in build.py would fail.
I reorganised the logic so that this does not happen anymore

Seen while building gtkmm3 on macOS Monterey

2021-10-27T09:41:13.8833710Z [34m==>[0m [1mmeson --prefix=/opt/homebrew/Cellar/gtkmm3/3.24.5 --libdir=/opt/homebrew/Cellar/gtkmm3/3.24.5/lib --buildtype=release --wrap-mode=nofallback ..[0m
2021-10-27T09:41:13.8835310Z Traceback (most recent call last):
2021-10-27T09:41:13.8837030Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/mesonmain.py", line 138, in run
2021-10-27T09:41:13.8838360Z     return options.run_func(options)
2021-10-27T09:41:13.8840090Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/msetup.py", line 294, in run
2021-10-27T09:41:13.8841260Z     app.generate()
2021-10-27T09:41:13.8842890Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/msetup.py", line 185, in generate
2021-10-27T09:41:13.8844130Z     self._generate(env)
2021-10-27T09:41:13.8845750Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/msetup.py", line 229, in _generate
2021-10-27T09:41:13.8846930Z     intr.run()
2021-10-27T09:41:13.8848640Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreter/interpreter.py", line 2484, in run
2021-10-27T09:41:13.8849970Z     super().run()
2021-10-27T09:41:13.8851920Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 150, in run
2021-10-27T09:41:13.8853620Z     self.evaluate_codeblock(self.ast, start=1)
2021-10-27T09:41:13.8855840Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 175, in evaluate_codeblock
2021-10-27T09:41:13.8857470Z     raise e
2021-10-27T09:41:13.8859420Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 168, in evaluate_codeblock
2021-10-27T09:41:13.8861160Z     self.evaluate_statement(cur)
2021-10-27T09:41:13.8863390Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 181, in evaluate_statement
2021-10-27T09:41:13.8865390Z     return self.function_call(cur)
2021-10-27T09:41:13.8867480Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 456, in function_call
2021-10-27T09:41:13.8869130Z     res = func(node, func_args, kwargs)
2021-10-27T09:41:13.8871040Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/decorators.py", line 713, in wrapped
2021-10-27T09:41:13.8872660Z     return f(*wrapped_args, **wrapped_kwargs)
2021-10-27T09:41:13.8874670Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/decorators.py", line 115, in wrapped
2021-10-27T09:41:13.8876330Z     return f(*wrapped_args, **wrapped_kwargs)
2021-10-27T09:41:13.8878320Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/decorators.py", line 276, in wrapper
2021-10-27T09:41:13.8879840Z     return f(*nargs, **wrapped_kwargs)
2021-10-27T09:41:13.8881800Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreter/interpreter.py", line 1969, in func_subdir
2021-10-27T09:41:13.8883340Z     self.evaluate_codeblock(codeblock)
2021-10-27T09:41:13.8885340Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 175, in evaluate_codeblock
2021-10-27T09:41:13.8886880Z     raise e
2021-10-27T09:41:13.8889000Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 168, in evaluate_codeblock
2021-10-27T09:41:13.8890940Z     self.evaluate_statement(cur)
2021-10-27T09:41:13.8892980Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 191, in evaluate_statement
2021-10-27T09:41:13.8894470Z     return self.evaluate_if(cur)
2021-10-27T09:41:13.8896230Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 274, in evaluate_if
2021-10-27T09:41:13.8897680Z     self.evaluate_codeblock(i.block)
2021-10-27T09:41:13.8899570Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 175, in evaluate_codeblock
2021-10-27T09:41:13.8900940Z     raise e
2021-10-27T09:41:13.8902680Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 168, in evaluate_codeblock
2021-10-27T09:41:13.8904180Z     self.evaluate_statement(cur)
2021-10-27T09:41:13.8906030Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 183, in evaluate_statement
2021-10-27T09:41:13.8907480Z     self.assignment(cur)
2021-10-27T09:41:13.8909240Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 568, in assignment
2021-10-27T09:41:13.8910790Z     value = self.evaluate_statement(node.value)
2021-10-27T09:41:13.8912710Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 185, in evaluate_statement
2021-10-27T09:41:13.8914180Z     return self.method_call(cur)
2021-10-27T09:41:13.8915920Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 484, in method_call
2021-10-27T09:41:13.8917430Z     res = obj.method_call(method_name, args, kwargs)
2021-10-27T09:41:13.8919240Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreter/interpreterobjects.py", line 754, in method_call
2021-10-27T09:41:13.8920720Z     ret = method(state, args, kwargs)
2021-10-27T09:41:13.8922380Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/decorators.py", line 713, in wrapped
2021-10-27T09:41:13.8923730Z     return f(*wrapped_args, **wrapped_kwargs)
2021-10-27T09:41:13.8925480Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/interpreterbase/decorators.py", line 115, in wrapped
2021-10-27T09:41:13.8926850Z     return f(*wrapped_args, **wrapped_kwargs)
2021-10-27T09:41:13.8928490Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/modules/gnome.py", line 292, in compile_resources
2021-10-27T09:41:13.8930020Z     target_c = GResourceTarget(name, state.subdir, state.subproject, kwargs)
2021-10-27T09:41:13.8932440Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/modules/__init__.py", line 202, in __init__
2021-10-27T09:41:13.8933700Z     super().__init__(name, subdir, subproject, kwargs)
2021-10-27T09:41:13.8935250Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/build.py", line 2330, in __init__
2021-10-27T09:41:13.8936440Z     self.process_kwargs(kwargs, backend)
2021-10-27T09:41:13.8938010Z   File "/opt/homebrew/lib/python3.10/site-packages/mesonbuild/build.py", line 2441, in process_kwargs
2021-10-27T09:41:13.8939540Z     if isinstance(kwargs['install_dir'], list):
2021-10-27T09:41:13.8940650Z KeyError: 'install_dir'
2021-10-27T09:41:13.8941270Z The Meson build system
2021-10-27T09:41:13.8941720Z
2021-10-27T09:41:13.8942220Z Version: 0.60.0