### PR TITLE
Fix cygwin test failure due to shortpath usage

### DIFF
--- a/test cases/common/51 run target/check-env.py
+++ b/test cases/common/51 run target/check-env.py
@@ -15,9 +15,14 @@ assert 'MY_ENV' in os.environ
 env_source_root = Path(os.environ['MESON_SOURCE_ROOT']).resolve()
 env_build_root = Path(os.environ['MESON_BUILD_ROOT']).resolve()
 env_current_source_dir = Path(env_source_root, os.environ['MESON_SUBDIR']).resolve()
+
+print(sys.argv)
 argv_paths = [Path(i).resolve() for i in sys.argv[1:]]
 source_root, build_root, current_source_dir = argv_paths
 
+print(f'{source_root} == {env_source_root}')
 assert source_root == env_source_root
+print(f'{build_root} == {env_build_root}')
 assert build_root == env_build_root
+print(f'{current_source_dir} == {env_current_source_dir}')
 assert current_source_dir == env_current_source_dir

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -100,14 +100,21 @@ class BasePlatformTests(TestCase):
         self.builddirs.append(self.builddir)
 
     def new_builddir(self):
-        if not is_cygwin():
-            # Keep builddirs inside the source tree so that virus scanners
-            # don't complain
-            newdir = tempfile.mkdtemp(dir=os.getcwd())
-        else:
-            # But not on Cygwin because that breaks the umask tests. See:
-            # https://github.com/mesonbuild/meson/pull/5546#issuecomment-509666523
-            newdir = tempfile.mkdtemp()
+        # Keep builddirs inside the source tree so that virus scanners
+        # don't complain
+        newdir = tempfile.mkdtemp(dir=os.getcwd())
+        # In case the directory is inside a symlinked directory, find the real
+        # path otherwise we might not find the srcdir from inside the builddir.
+        newdir = os.path.realpath(newdir)
+        self.change_builddir(newdir)
+
+    def new_builddir_in_tempdir(self):
+        # Can't keep the builddir inside the source tree for the umask tests:
+        # https://github.com/mesonbuild/meson/pull/5546#issuecomment-509666523
+        # And we can't do this for all tests because it causes the path to be
+        # a short-path which breaks other tests:
+        # https://github.com/mesonbuild/meson/pull/9497
+        newdir = tempfile.mkdtemp()
         # In case the directory is inside a symlinked directory, find the real
         # path otherwise we might not find the srcdir from inside the builddir.
         newdir = os.path.realpath(newdir)

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -574,6 +574,8 @@ class LinuxlikeTests(BasePlatformTests):
         Test that files installed by these tests have the correct permissions.
         Can't be an ordinary test because our installed_files.txt is very basic.
         '''
+        if is_cygwin():
+            self.new_builddir_in_tempdir()
         # Test file modes
         testdir = os.path.join(self.common_test_dir, '12 data')
         self.init(testdir)
@@ -626,6 +628,8 @@ class LinuxlikeTests(BasePlatformTests):
         '''
         Test that files are installed with correct permissions using install_mode.
         '''
+        if is_cygwin():
+            self.new_builddir_in_tempdir()
         testdir = os.path.join(self.common_test_dir, '190 install_mode')
         self.init(testdir)
         self.build()
@@ -664,6 +668,8 @@ class LinuxlikeTests(BasePlatformTests):
         install umask of 022, regardless of the umask at time the worktree
         was checked out or the build was executed.
         '''
+        if is_cygwin():
+            self.new_builddir_in_tempdir()
         # Copy source tree to a temporary directory and change permissions
         # there to simulate a checkout with umask 002.
         orig_testdir = os.path.join(self.unit_test_dir, '26 install umask')


### PR DESCRIPTION
For some reason two tests are failing on Cygwin because the argument
is passed as a long-path and the Path is ending up as a short-path:

AllPlatformTests.test_run_target_files_path

```
  Traceback (most recent call last):
    File "/cygdrive/d/a/meson/meson/test cases/common/51 run target/check-env.py", line 22, in <module>
      assert build_root == env_build_root
  AssertionError
```

SubprojectsCommandTests.test_purge

```
  >       self.assertEqual(deleting(out), sorted([
              str(self.subprojects_dir / 'redirect.wrap'),
              str(self.subprojects_dir / 'sub_file'),
              str(self.subprojects_dir / 'sub_git'),
          ]))
  E       AssertionError: Lists differ: ['/cygdrive/c/Users/runneradmin/AppData/Local/Temp/tmpeaa2a49[205 chars]git'] != ['/cygdrive/c/Users/RUNNER~1/AppData/Local/Temp/tmpeaa2a49z/s[196 chars]git']

  [...]

  ['/cygdrive/c/Users/runneradmin/AppData/Local/Temp/tmpeaa2a49z/src/subprojects/redirect.wrap',
                      ^^^^^^^^^^^
  ['/cygdrive/c/Users/RUNNER~1/AppData/Local/Temp/tmpeaa2a49z/src/subprojects/redirect.wrap',
                      ^^^^^^^^
```