### PR TITLE
coverage generator: obey the documentation and only generate supported outputs

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -84,7 +84,7 @@ def _get_env_var(for_machine: MachineChoice, is_cross: bool, var_name: str) -> T
     return value
 
 
-def detect_gcovr(min_version='3.3', new_rootdir_version='4.2', log=False):
+def detect_gcovr(min_version='3.3', log=False):
     gcovr_exe = 'gcovr'
     try:
         p, found = Popen_safe([gcovr_exe, '--version'])[0:2]
@@ -95,7 +95,7 @@ def detect_gcovr(min_version='3.3', new_rootdir_version='4.2', log=False):
     if p.returncode == 0 and mesonlib.version_compare(found, '>=' + min_version):
         if log:
             mlog.log('Found gcovr-{} at {}'.format(found, quote_arg(shutil.which(gcovr_exe))))
-        return gcovr_exe, mesonlib.version_compare(found, '>=' + new_rootdir_version)
+        return gcovr_exe, found
     return None, None
 
 def detect_llvm_cov():
@@ -106,7 +106,7 @@ def detect_llvm_cov():
     return None
 
 def find_coverage_tools() -> T.Tuple[T.Optional[str], T.Optional[str], T.Optional[str], T.Optional[str], T.Optional[str]]:
-    gcovr_exe, gcovr_new_rootdir = detect_gcovr()
+    gcovr_exe, gcovr_version = detect_gcovr()
 
     llvm_cov_exe = detect_llvm_cov()
 
@@ -118,7 +118,7 @@ def find_coverage_tools() -> T.Tuple[T.Optional[str], T.Optional[str], T.Optiona
     if not mesonlib.exe_exists([genhtml_exe, '--version']):
         genhtml_exe = None
 
-    return gcovr_exe, gcovr_new_rootdir, lcov_exe, genhtml_exe, llvm_cov_exe
+    return gcovr_exe, gcovr_version, lcov_exe, genhtml_exe, llvm_cov_exe
 
 def detect_ninja(version: str = '1.8.2', log: bool = False) -> T.List[str]:
     r = detect_ninja_command_and_version(version, log)

--- a/mesonbuild/scripts/coverage.py
+++ b/mesonbuild/scripts/coverage.py
@@ -21,10 +21,10 @@ def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build
     outfiles = []
     exitcode = 0
 
-    (gcovr_exe, gcovr_new_rootdir, lcov_exe, genhtml_exe, llvm_cov_exe) = environment.find_coverage_tools()
+    (gcovr_exe, gcovr_version, lcov_exe, genhtml_exe, llvm_cov_exe) = environment.find_coverage_tools()
 
     # gcovr >= 4.2 requires a different syntax for out of source builds
-    if gcovr_new_rootdir:
+    if gcovr_exe and mesonlib.version_compare(gcovr_version, '>=4.2'):
         gcovr_base_cmd = [gcovr_exe, '-r', source_root, build_root]
     else:
         gcovr_base_cmd = [gcovr_exe, '-r', build_root]
@@ -35,7 +35,7 @@ def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build
         gcov_exe_args = []
 
     if not outputs or 'xml' in outputs:
-        if gcovr_exe:
+        if gcovr_exe and mesonlib.version_compare(gcovr_version, '>=3.3'):
             subprocess.check_call(gcovr_base_cmd +
                                   ['-x',
                                    '-e', re.escape(subproject_root),
@@ -47,7 +47,7 @@ def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build
             exitcode = 1
 
     if not outputs or 'sonarqube' in outputs:
-        if gcovr_exe:
+        if gcovr_exe and mesonlib.version_compare(gcovr_version, '>=4.2'):
             subprocess.check_call(gcovr_base_cmd +
                                   ['--sonarqube',
                                    '-o', os.path.join(log_dir, 'sonarqube.xml'),
@@ -59,7 +59,7 @@ def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build
             exitcode = 1
 
     if not outputs or 'text' in outputs:
-        if gcovr_exe:
+        if gcovr_exe and mesonlib.version_compare(gcovr_version, '>=3.3'):
             subprocess.check_call(gcovr_base_cmd +
                                   ['-e', re.escape(subproject_root),
                                    '-o', os.path.join(log_dir, 'coverage.txt')
@@ -132,7 +132,7 @@ def coverage(outputs: T.List[str], source_root: str, subproject_root: str, build
                                    '--branch-coverage',
                                    covinfo])
             outfiles.append(('Html', pathlib.Path(htmloutdir, 'index.html')))
-        elif gcovr_exe:
+        elif gcovr_exe and mesonlib.version_compare(gcovr_version, '>=3.3'):
             htmloutdir = os.path.join(log_dir, 'coveragereport')
             if not os.path.isdir(htmloutdir):
                 os.mkdir(htmloutdir)


### PR DESCRIPTION
We say:

> If version 4.2 or higher of the first is found, targets coverage-text, coverage-xml, coverage-sonarqube and coverage-html are generated.

But this is totally untrue. Make it true, by actually checking (and not generating broken coverage commands when older versions of gcovr are found).

Fixes #9505