### PR TITLE
MSVC: Support x86 compilation and xp compilation

### DIFF
--- a/mesonbuild/backend/vs2015backend.py
+++ b/mesonbuild/backend/vs2015backend.py
@@ -35,4 +35,4 @@ class Vs2015Backend(Vs2010Backend):
                     # We don't have support for versions older than 2019 right now.
                     raise MesonException('There is currently no support for ICL before 19, patches welcome.')
             if self.platform_toolset is None:
-                self.platform_toolset = 'v140'
+                self.platform_toolset = os.environ['VS_TOOLSET'] or 'v140'

--- a/mesonbuild/backend/vs2017backend.py
+++ b/mesonbuild/backend/vs2017backend.py
@@ -41,7 +41,7 @@ class Vs2017Backend(Vs2010Backend):
                         # We don't have support for versions older than 2019 right now.
                         raise MesonException('There is currently no support for ICL before 19, patches welcome.')
         if self.platform_toolset is None:
-            self.platform_toolset = 'v141'
+            self.platform_toolset = os.environ['VS_TOOLSET'] or 'v141'
         # WindowsSDKVersion should be set by command prompt.
         sdk_version = os.environ.get('WindowsSDKVersion', None)
         if sdk_version:

--- a/mesonbuild/backend/vs2019backend.py
+++ b/mesonbuild/backend/vs2019backend.py
@@ -35,7 +35,7 @@ class Vs2019Backend(Vs2010Backend):
                     self.platform_toolset = 'Intel C++ Compiler 19.0'
                 # We don't have support for versions older than 2019 right now.
             if not self.platform_toolset:
-                self.platform_toolset = 'v142'
+                self.platform_toolset = os.environ['VS_TOOLSET'] or 'v142'
             self.vs_version = '2019'
         # WindowsSDKVersion should be set by command prompt.
         sdk_version = os.environ.get('WindowsSDKVersion', None)

--- a/mesonbuild/mesonlib/vsenv.py
+++ b/mesonbuild/mesonlib/vsenv.py
@@ -12,7 +12,7 @@ from .universal import MesonException, is_windows
 
 bat_template = '''@ECHO OFF
 
-call "{}"
+call "{}" {}
 
 ECHO {}
 SET
@@ -70,13 +70,13 @@ def _setup_vsenv(force: bool) -> bool:
     if platform.machine() == 'ARM64':
         bat_path = bat_root / 'VC/Auxiliary/Build/vcvarsx86_arm64.bat'
     else:
-        bat_path = bat_root / 'VC/Auxiliary/Build/vcvars64.bat'
+        bat_path = bat_root / 'VC/Auxiliary/Build/vcvarsall.bat'
     if not bat_path.exists():
         raise MesonException(f'Could not find {bat_path}')
 
     mlog.log('Activating VS', bat_info[0]['catalog']['productDisplayVersion'])
     bat_separator = '---SPLIT---'
-    bat_contents = bat_template.format(bat_path, bat_separator)
+    bat_contents = bat_template.format(bat_path, os.environ['VS_ARCH'] or 'x64', bat_separator)
     bat_file = tempfile.NamedTemporaryFile('w', suffix='.bat', encoding='utf-8', delete=False)
     bat_file.write(bat_contents)
     bat_file.flush()


### PR DESCRIPTION
Two environment variables have been added so that the generated arch can be set, and the toolset can also be set.

If I need to generate x86 programs, I just need to simply set VS_ARCH to x86. Similarly, if I need to generate xp support, then I can set VS_TOOLSET to v141_xp.

Before that, it was very difficult to modify to x86 to compile or generate xp support, and it was necessary to modify the source code inside.

If you use conan, you can simply modify the code as follows
```
command = 'meson "%s" "%s" %s' % (source_dir, self.build_dir, arg_list)
with environment_append({"PKG_CONFIG_PATH": pc_paths,
    "VS_ARCH": self._settings.get_safe('arch'),
    "VS_TOOLSET": self._settings.get_safe('compiler.toolset')}):
    self._run(command)
```

