### PR TITLE
use typed_* args for the `run_command` function

### DIFF
--- a/docs/yaml/functions/run_command.yaml
+++ b/docs/yaml/functions/run_command.yaml
@@ -30,6 +30,15 @@ kwargs:
       and the configuration will fail if it is non-zero. Note that
       the default value will be `true` in future releases.
 
+  capture:
+    type: bool
+    since: 0.47.0
+    default: true
+    description: |
+      If `true`, any output generated on stdout will be captured and returned by
+      the `.stdout()` method. If it is false, then `.stdout()` will return an
+      empty string.
+
   env:
     type: env | list[str] | dict[str]
     since: 0.50.0

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -232,3 +232,10 @@ class FindProgram(ExtractRequired, ExtractSearchDirs):
 
     native: MachineChoice
     version: T.List[str]
+
+
+class RunCommand(TypedDict):
+
+    check: bool
+    capture: T.Optional[bool]
+    env: build.EnvironmentVariables

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -103,8 +103,7 @@ class ExternalProgram(mesonlib.HoldableObject):
     def get_version(self, interpreter: 'Interpreter') -> str:
         if not self.cached_version:
             raw_cmd = self.get_command() + ['--version']
-            cmd: T.List[T.Union[str, ExternalProgram]] = [self, '--version']
-            res = interpreter.run_command_impl(interpreter.current_node, cmd, {}, True)
+            res = interpreter.run_command_impl(interpreter.current_node, (self, ['--version']), {}, True)
             if res.returncode != 0:
                 raise mesonlib.MesonException(f'Running {raw_cmd!r} failed')
             output = res.stdout.strip()

--- a/mesonbuild/programs.py
+++ b/mesonbuild/programs.py
@@ -102,10 +102,11 @@ class ExternalProgram(mesonlib.HoldableObject):
 
     def get_version(self, interpreter: 'Interpreter') -> str:
         if not self.cached_version:
+            from . import build
             raw_cmd = self.get_command() + ['--version']
-            res = interpreter.run_command_impl(interpreter.current_node, (self, ['--version']), {}, True)
-            if res.returncode != 0:
-                raise mesonlib.MesonException(f'Running {raw_cmd!r} failed')
+            res = interpreter.run_command_impl(interpreter.current_node, (self, ['--version']),
+                                               {'capture': True, 'check': True, 'env': build.EnvironmentVariables()},
+                                               True)
             output = res.stdout.strip()
             if not output:
                 output = res.stderr.strip()


### PR DESCRIPTION
There is one strange thing about this function, we allow `build.Executable` to be passed through the type guards, even though it's actually an error to use it. We do this so that we can generate a better error message.

This also adds support for passing `Compiler` objects to any of the positional arguments of `run_command`, not just the first one.