### PR TITLE
Add typed_kwargs to some of the gnome module functions

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -21,6 +21,19 @@ with anything else.
 
 ### gnome.compile_resources()
 
+```
+    gnome.compile_resources(id: string, input_file: string | File,
+                            build_by_default: bool = false,
+                            c_name: string | None = None,
+                            dependencies: [](File, CustomTarget, CustomTargetIndex) = [],
+                            export: bool = false,
+                            extra_args: []string = [],
+                            gresource_bundle: bool = false,
+                            install_dir: string | None = None,
+                            source_dir: [string] = [],
+                            ): (CustomTarget, CustomTarget) | CustomTarget
+```
+
 This function compiles resources specified in an XML file into code
 that can be embedded inside the main binary. Similar a build target it
 takes two positional arguments. The first one is the name of the

--- a/test cases/vala/11 generated vapi/libbar/meson.build
+++ b/test cases/vala/11 generated vapi/libbar/meson.build
@@ -19,7 +19,6 @@ libbar_gir = gnome.generate_gir(libbar,
   sources: libbar_sources,
   namespace: 'Bar',
   nsversion: libbar_api_ver,
-  packages: 'gobject-2.0',
   symbol_prefix: 'bar',
   extra_args: [
     '--c-include=bar.h',

--- a/test cases/vala/11 generated vapi/libfoo/meson.build
+++ b/test cases/vala/11 generated vapi/libfoo/meson.build
@@ -18,7 +18,6 @@ libfoo_gir = gnome.generate_gir(libfoo,
   sources: libfoo_sources,
   namespace: 'Foo',
   nsversion: libfoo_api_ver,
-  packages: 'gobject-2.0',
   symbol_prefix: 'foo',
   extra_args: [
     '--c-include=foo.h',


### PR DESCRIPTION
This is not complete for the module, but it is a start. I've broken this up as these are fairly complex changes:
- A fair number of helper functions are ripped out as they are not helpful once we konw that the key in the dictionary exists
- avoiding kwargs mutation
- moving invalid argument handling to the typed_kwarg helper

Since this is already around 750 LOC change,  I thought it would be easier to review in smaller pieces like this.