### PR TITLE
wrap: Fix concurrent os.mkdir()

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -556,8 +556,7 @@ class Resolver:
                 mlog.log('Using', mlog.bold(self.packagename), what, 'from cache.')
                 return cache_path
 
-            if not os.path.isdir(self.cachedir):
-                os.mkdir(self.cachedir)
+            os.makedirs(self.cachedir, exist_ok=True)
             self.download(what, cache_path)
             return cache_path
         else:


### PR DESCRIPTION
Since 0.59.0 Meson downloads multiple wraps in parallel, so the
packagecache directory could be created by one then the 2nd would hit
error when calling os.mkdir() because it already exists.