### PR TITLE
fix custom_target with install: true and no install_dir, crashing

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2457,7 +2457,7 @@ class CustomTarget(Target, CommandBase):
             if not isinstance(self.install, bool):
                 raise InvalidArguments('"install" must be boolean.')
             if self.install:
-                if 'install_dir' not in kwargs:
+                if not kwargs.get('install_dir', False):
                     raise InvalidArguments('"install_dir" must be specified '
                                            'when installing a target')
 


### PR DESCRIPTION
It's supposed to emit an error message, but instead it did a traceback. It used to be, if no install_dir was specified then it was simply not in kwargs, but due to typed_kwargs it will now be there, but not have viable contents, so the dict membership check got skipped.

Fixes #9522