### PR TITLE
More use of typed_* in the interpreter module

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2796,7 +2796,7 @@ class Data(HoldableObject):
         self.data_type = data_type
 
 class TestSetup:
-    def __init__(self, exe_wrapper: T.Optional[T.List[str]], gdb: bool,
+    def __init__(self, exe_wrapper: T.List[str], gdb: bool,
                  timeout_multiplier: int, env: EnvironmentVariables,
                  exclude_suites: T.List[str]):
         self.exe_wrapper = exe_wrapper

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1751,7 +1751,7 @@ This will become a hard error in the future.''', location=self.current_node)
         kwargs['env'] = self.unpack_env_kwarg(kwargs)
         if 'command' in kwargs and isinstance(kwargs['command'], list) and kwargs['command']:
             if isinstance(kwargs['command'][0], str):
-                kwargs['command'][0] = self.func_find_program(node, kwargs['command'][0], {})
+                kwargs['command'][0] = self.find_program_impl([kwargs['command'][0]])
         tg = build.CustomTarget(name, self.subdir, self.subproject, kwargs, backend=self.backend)
         self.add_target(tg.name, tg)
         return tg
@@ -1771,7 +1771,7 @@ This will become a hard error in the future.''', location=self.current_node)
             if isinstance(i, ExternalProgram) and not i.found():
                 raise InterpreterException(f'Tried to use non-existing executable {i.name!r}')
         if isinstance(all_args[0], str):
-            all_args[0] = self.func_find_program(node, all_args[0], {})
+            all_args[0] = self.find_program_impl([all_args[0]])
         name = args[0]
         tg = build.RunTarget(name, all_args, kwargs['depends'], self.subdir, self.subproject, kwargs['env'])
         self.add_target(name, tg)
@@ -1849,7 +1849,7 @@ This will become a hard error in the future.''', location=self.current_node)
             name = name.replace(':', '_')
         exe = args[1]
         if isinstance(exe, mesonlib.File):
-            exe = self.func_find_program(node, args[1], {})
+            exe = self.find_program_impl([exe])
 
         env = self.unpack_env_kwarg(kwargs)
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1408,9 +1408,13 @@ external dependencies (including libraries) must go to "dependencies".''')
 
     # TODO update modules to always pass `for_machine`. It is bad-form to assume
     # the host machine.
-    def find_program_impl(self, args, for_machine: MachineChoice = MachineChoice.HOST,
-                          required=True, silent=True, wanted='', search_dirs=None,
-                          version_func=None):
+    def find_program_impl(self, args: T.List[mesonlib.FileOrString],
+                          for_machine: MachineChoice = MachineChoice.HOST,
+                          required: bool = True, silent: bool = True,
+                          wanted: T.Union[str, T.List[str]] = '',
+                          search_dirs: T.Optional[T.List[str]] = None,
+                          version_func: T.Optional[T.Callable[[T.Union['ExternalProgram', 'build.Executable', 'OverrideProgram']], str]] = None
+                          ) -> T.Union['ExternalProgram', 'build.Executable', 'OverrideProgram']:
         args = mesonlib.listify(args)
 
         extra_info = []
@@ -1434,7 +1438,7 @@ external dependencies (including libraries) must go to "dependencies".''')
                     interp = self.subprojects[progobj.subproject].held_object
                     assert isinstance(interp, Interpreter)
                 version = interp.project_version
-            elif isinstance(progobj, ExternalProgram):
+            else:
                 version = progobj.get_version(self)
             is_found, not_found, found = mesonlib.version_compare_many(version, wanted)
             if not is_found:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -60,6 +60,7 @@ from .type_checking import (
     DEPENDS_KW,
     DEPEND_FILES_KW,
     DEPFILE_KW,
+    DISABLER_KW,
     ENV_KW,
     INSTALL_KW,
     INSTALL_MODE_KW,
@@ -570,7 +571,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_kwargs(
         'import',
         REQUIRED_KW.evolve(since='0.59.0'),
-        KwargInfo('disabler', bool, default=False, since='0.59.0'),
+        DISABLER_KW.evolve(since='0.59.0'),
     )
     @disablerIfNotFound
     def func_import(self, node: mparser.BaseNode, args: T.Tuple[str],

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1493,19 +1493,17 @@ external dependencies (including libraries) must go to "dependencies".''')
     @FeatureNewKwargs('find_program', '0.49.0', ['disabler'])
     @disablerIfNotFound
     @permittedKwargs({'required', 'native', 'version', 'dirs'})
-    def func_find_program(self, node, args, kwargs) -> T.Union['build.Executable', ExternalProgram, 'OverrideProgram']:
-        if not args:
-            raise InterpreterException('No program name specified.')
-
+    @typed_pos_args('find_program', varargs=(str, mesonlib.File), min_varargs=1)
+    def func_find_program(self, node: mparser.BaseNode, args: T.Tuple[T.List[mesonlib.FileOrString]], kwargs) -> T.Union['build.Executable', ExternalProgram, 'OverrideProgram']:
         disabled, required, feature = extract_required_kwarg(kwargs, self.subproject)
         if disabled:
-            mlog.log('Program', mlog.bold(' '.join(args)), 'skipped: feature', mlog.bold(feature), 'disabled')
-            return self.notfound_program(args)
+            mlog.log('Program', mlog.bold(' '.join(args[0])), 'skipped: feature', mlog.bold(feature), 'disabled')
+            return self.notfound_program(args[0])
 
         search_dirs = extract_search_dirs(kwargs)
         wanted = mesonlib.stringlistify(kwargs.get('version', []))
         for_machine = self.machine_from_native_kwarg(kwargs)
-        return self.find_program_impl(args, for_machine, required=required,
+        return self.find_program_impl(args[0], for_machine, required=required,
                                       silent=False, wanted=wanted,
                                       search_dirs=search_dirs)
 
@@ -2385,7 +2383,7 @@ This will become a hard error in the future.''', location=self.current_node)
         if re.fullmatch('([_a-zA-Z][_0-9a-zA-Z]*:)?[_a-zA-Z][_0-9a-zA-Z]*', setup_name) is None:
             raise InterpreterException('Setup name may only contain alphanumeric characters.')
         if ":" not in setup_name:
-            setup_name = f'{(self.subproject if self.subproject else self.build.project_name)}: {setup_name}'
+            setup_name = f'{(self.subproject if self.subproject else self.build.project_name)}:{setup_name}'
 
         exe_wrapper: T.List[str] = []
         for i in kwargs['exe_wrapper']:

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -195,3 +195,12 @@ class AddTestSetup(TypedDict):
     is_default: bool
     exclude_suites: T.List[str]
     env: build.EnvironmentVariables
+
+
+class Project(TypedDict):
+
+    version: T.Optional[FileOrString]
+    meson_version: T.Optional[str]
+    default_options: T.List[str]
+    license: T.List[str]
+    subproject_dir: str

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -226,3 +226,9 @@ class Summary(TypedDict):
     section: str
     bool_yn: bool
     list_sep: T.Optional[str]
+
+
+class FindProgram(ExtractRequired, ExtractSearchDirs):
+
+    native: MachineChoice
+    version: T.List[str]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -219,3 +219,10 @@ class _FoundProto(Protocol):
 class Subdir(TypedDict):
 
     if_found: T.List[_FoundProto]
+
+
+class Summary(TypedDict):
+
+    section: str
+    bool_yn: bool
+    list_sep: T.Optional[str]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -6,7 +6,7 @@
 
 import typing as T
 
-from typing_extensions import TypedDict, Literal
+from typing_extensions import TypedDict, Literal, Protocol
 
 from .. import build
 from .. import coredata
@@ -204,3 +204,18 @@ class Project(TypedDict):
     default_options: T.List[str]
     license: T.List[str]
     subproject_dir: str
+
+
+class _FoundProto(Protocol):
+
+    """Protocol for subdir arguments.
+
+    This allows us to define any objec that has a found(self) -> bool method
+    """
+
+    def found(self) -> bool: ...
+
+
+class Subdir(TypedDict):
+
+    if_found: T.List[_FoundProto]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -186,3 +186,12 @@ class CustomTarget(TypedDict):
     install_tag: T.List[T.Union[str, bool]]
     output: T.List[str]
     override_options: T.Dict[OptionKey, str]
+
+class AddTestSetup(TypedDict):
+
+    exe_wrapper: T.List[T.Union[str, ExternalProgram]]
+    gdb: bool
+    timeout_multiplier: int
+    is_default: bool
+    exclude_suites: T.List[str]
+    env: build.EnvironmentVariables

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -86,7 +86,7 @@ class MesonMain(MesonInterpreterObject):
             largs.append(prog)
             largs.extend(args)
             return self.interpreter.backend.get_executable_serialisation(largs)
-        found = self.interpreter.func_find_program({}, prog, {})
+        found = self.interpreter.find_program_impl([prog])
         largs.append(found)
         largs.extend(args)
         es = self.interpreter.backend.get_executable_serialisation(largs)

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -285,3 +285,12 @@ INCLUDE_DIRECTORIES: KwargInfo[T.List[T.Union[str, IncludeDirs]]] = KwargInfo(
     listify=True,
     default=[],
 )
+
+# for cases like default_options and override_options
+DEFAULT_OPTIONS: KwargInfo[T.List[str]] = KwargInfo(
+    'default_options',
+    ContainerTypeInfo(list, (str, IncludeDirs)),
+    listify=True,
+    default=[],
+    validator=_env_validator,
+)

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -129,6 +129,8 @@ REQUIRED_KW: KwargInfo[T.Union[bool, UserFeatureOption]] = KwargInfo(
     # TODO: extract_required_kwarg could be converted to a convertor
 )
 
+DISABLER_KW: KwargInfo[bool] = KwargInfo('disabler', bool, default=False)
+
 def _env_validator(value: T.Union[EnvironmentVariables, T.List['TYPE_var'], T.Dict[str, 'TYPE_var'], str, None]) -> T.Optional[str]:
     def _splitter(v: str) -> T.Optional[str]:
         split = v.split('=', 1)


### PR DESCRIPTION
This covers many of the non target uses remaining, `add_test_setup`, `project`, `summary`, and `find_program`. Some of these already used `typed_pos_args`, but not `typed_kwargs`