### PR TITLE
fix regression that broke string.format with list objects

### DIFF
--- a/mesonbuild/interpreter/primitives/string.py
+++ b/mesonbuild/interpreter/primitives/string.py
@@ -13,6 +13,7 @@ from ...interpreterbase import (
     MesonOperator,
     FeatureNew,
     typed_operator,
+    noArgsFlattening,
     noKwargs,
     noPosargs,
     typed_pos_args,
@@ -85,6 +86,7 @@ class StringHolder(ObjectHolder[str]):
     def endswith_method(self, args: T.Tuple[str], kwargs: TYPE_kwargs) -> bool:
         return self.held_object.endswith(args[0])
 
+    @noArgsFlattening
     @noKwargs
     @typed_pos_args('str.format', varargs=object)
     def format_method(self, args: T.Tuple[T.List[object]], kwargs: TYPE_kwargs) -> str:

--- a/test cases/common/35 string operations/meson.build
+++ b/test cases/common/35 string operations/meson.build
@@ -60,6 +60,7 @@ assert(false.to_string() == 'false', 'bool string conversion failed')
 assert(true.to_string('yes', 'no') == 'yes', 'bool string conversion with args failed')
 assert(false.to_string('yes', 'no') == 'no', 'bool string conversion with args failed')
 assert('@0@'.format(true) == 'true', 'bool string formatting failed')
+assert('@0@'.format(['one', 'two']) == '[\'one\', \'two\']', 'list string formatting failed')
 
 assert(' '.join(['a', 'b', 'c']) == 'a b c', 'join() array broken')
 assert(''.join(['a', 'b', 'c']) == 'abc', 'empty join() broken')


### PR DESCRIPTION
String formatting should validly assume that printing a list means printing the list itself. Instead, something like this broke:

```
'one is: @0@ and two is: @1@'.format(['foo',  'bar'], ['baz'])
```

which would evaluate as:

```
'one is: foo and two is: bar'
```

or:

```
'the value of array option foobar is: @0@'.format(get_option('foobar'))
```

which should evaluate with '-Dfoobar=[]' as

```
'the value of array option foobar is: []'
```

But instead produced:

```
meson.build:7:0: ERROR: Format placeholder @0@ out of range.
```

Fixes #9530