### PR TITLE
tests: unskip a test on msys2 that now works

### DIFF
--- a/test cases/frameworks/15 llvm/test.json
+++ b/test cases/frameworks/15 llvm/test.json
@@ -3,7 +3,7 @@
     "options": {
       "method": [
         { "val": "config-tool", "skip_on_jobname": ["msys2-gcc"]},
-        { "val": "cmake", "skip_on_jobname": ["msys2"] }
+        { "val": "cmake" }
       ],
       "link-static": [
         { "val": true, "skip_on_jobname": ["opensuse"] },


### PR DESCRIPTION
See https://github.com/mesonbuild/meson/pull/9532#issuecomment-961522961
for context.

It's unclear why this was skipped exactly in the first place, but it started to
pass recently and MSYS2 fixed some cmake+llvm related things in
https://github.com/msys2/MINGW-packages/commit/345fe436e8dfdc3527791ca262fa2e77855edda1
at the same time, so this is likely the reason.