### PR TITLE
modules/gnome: check for dependencies before running yelphelper

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -303,8 +303,8 @@ VAPI or Vala binaries.
              languages: []string, symlink_media: bool = true): void
 ```
 
-Installs help documentation using Yelp. The first argument is the
-project id.
+Installs help documentation for Yelp using itstool and gettext. The first
+argument is the project id.
 
 Additionally, sources can be passed as additional positional arguments. This
 was, however, undocumented and never officially supported. Due to a longstanding

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -18,6 +18,7 @@ functionality such as gobject-introspection, gresources and gtk-doc'''
 import copy
 import functools
 import os
+import shutil
 import subprocess
 import textwrap
 import typing as T
@@ -1004,6 +1005,13 @@ class GnomeModule(ExtensionModule):
                              'Use a LINGUAS file in the source directory instead')
     @typed_pos_args('gnome.yelp', str, varargs=str)
     def yelp(self, state: 'ModuleState', args: T.Tuple[str, T.List[str]], kwargs) -> ModuleReturnValue:
+        if not shutil.which('itstool'):
+            raise MesonException('itstool not found, required for gnome.yelp target')
+        if not shutil.which('msgmerge'):
+            raise MesonException('gettext not found, required for gnome.yelp target')
+        if not shutil.which('msgfmt'):
+            raise MesonException('gettext not found, required for gnome.yelp target')
+
         project_id = args[0]
         if len(args) > 1:
             FeatureDeprecated.single_use('gnome.yelp more than one positional argument', '0.60.0', 'use the "sources" keyword argument instead.')


### PR DESCRIPTION
The original reason for this PR is that I was trying to minimize the set of build dependencies for a project in alpine linux and was surprised that the programs required for `gnome.yelp` were `itstool` and `gettext` instead of `yelp`. It took me a while reading the helper code and understanding how `yelp`, `itstool` and `gettext` interact to actually realize that `gnome.yelp` is building for `yelp`, but using the other tools to build the translations. Therefore, I thought that changing the wording and mentioning the tools used in the documentation could help others in the future. Additionally, as there exists an open ticket,  I added some checks to fail early if `gettext` or `itstool` are missing.

Closes #7653