### PR TITLE
Recursively look for rpath dependencies

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -768,7 +768,7 @@ class Backend:
     def determine_rpath_dirs(self, target: build.BuildTarget) -> T.Tuple[str, ...]:
         result: OrderedSet[str]
         if self.environment.coredata.get_option(OptionKey('layout')) == 'mirror':
-            # NEed a copy here
+            # Need a copy here
             result = OrderedSet(target.get_link_dep_subdirs())
         else:
             result = OrderedSet()

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -395,15 +395,15 @@ class Backend:
             return os.path.join(self.build_to_src, target_dir)
         return self.build_to_src
 
-    def get_target_private_dir(self, target: build.Target) -> str:
+    def get_target_private_dir(self, target: T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex]) -> str:
         return os.path.join(self.get_target_filename(target, warn_multi_output=False) + '.p')
 
-    def get_target_private_dir_abs(self, target: build.Target) -> str:
+    def get_target_private_dir_abs(self, target: T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex]) -> str:
         return os.path.join(self.environment.get_build_dir(), self.get_target_private_dir(target))
 
     @lru_cache(maxsize=None)
     def get_target_generated_dir(
-            self, target: build.Target,
+            self, target: T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex],
             gensrc: T.Union[build.CustomTarget, build.CustomTargetIndex, build.GeneratedList],
             src: str) -> str:
         """
@@ -418,7 +418,8 @@ class Backend:
         # target that the GeneratedList is used in
         return os.path.join(self.get_target_private_dir(target), src)
 
-    def get_unity_source_file(self, target: build.Target, suffix: str, number: int) -> mesonlib.File:
+    def get_unity_source_file(self, target: T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex],
+                              suffix: str, number: int) -> mesonlib.File:
         # There is a potential conflict here, but it is unlikely that
         # anyone both enables unity builds and has a file called foo-unity.cpp.
         osrc = f'{target.name}-unity{number}.{suffix}'
@@ -765,7 +766,9 @@ class Backend:
                 paths.append(libdir)
         return paths
 
-    def determine_rpath_dirs(self, target: build.BuildTarget) -> T.Tuple[str, ...]:
+    # This may take other types
+    def determine_rpath_dirs(self, target: T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex]
+                             ) -> T.Tuple[str, ...]:
         result: OrderedSet[str]
         if self.environment.coredata.get_option(OptionKey('layout')) == 'mirror':
             # Need a copy here
@@ -773,8 +776,9 @@ class Backend:
         else:
             result = OrderedSet()
             result.add('meson-out')
-        result.update(self.rpaths_for_bundled_shared_libraries(target))
-        target.rpath_dirs_to_remove.update([d.encode('utf-8') for d in result])
+        if isinstance(target, build.BuildTarget):
+            result.update(self.rpaths_for_bundled_shared_libraries(target))
+            target.rpath_dirs_to_remove.update([d.encode('utf-8') for d in result])
         return tuple(result)
 
     @staticmethod

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -764,6 +764,9 @@ class Backend:
                 paths.append(os.path.join(self.build_to_src, rel_to_src))
             else:
                 paths.append(libdir)
+        for i in chain(target.link_targets, target.link_whole_targets):
+            if isinstance(i, build.BuildTarget):
+                paths.extend(self.rpaths_for_bundled_shared_libraries(i, exclude_system))
         return paths
 
     # This may take other types

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -695,7 +695,7 @@ class BuildTarget(Target):
         self.external_deps: T.List[dependencies.Dependency] = []
         self.include_dirs: T.List['IncludeDirs'] = []
         self.link_language = kwargs.get('link_language')
-        self.link_targets: T.List[BuildTarget] = []
+        self.link_targets: T.List[T.Union['BuildTarget', 'CustomTarget', 'CustomTargetIndex']] = []
         self.link_whole_targets = []
         self.link_depends = []
         self.added_deps = set()

--- a/test cases/unit/17 prebuilt shared/meson.build
+++ b/test cases/unit/17 prebuilt shared/meson.build
@@ -1,7 +1,12 @@
 project('prebuilt shared library', 'c')
 
+search_dir = get_option('search_dir')
+if search_dir == 'auto'
+  search_dir = meson.current_source_dir()
+endif
+
 cc = meson.get_compiler('c')
-shlib = cc.find_library('alexandria', dirs : meson.current_source_dir())
+shlib = cc.find_library('alexandria', dirs : search_dir)
 
 exe = executable('patron', 'patron.c', dependencies : shlib)
 test('visitation', exe)
@@ -11,3 +16,23 @@ d = declare_dependency(dependencies : shlib)
 exe2 = executable('another_visitor', 'another_visitor.c',
   dependencies : d)
 test('another', exe2)
+
+stlib = static_library(
+  'rejected',
+  'rejected.c',
+  dependencies : shlib,
+)
+
+rejected = executable(
+  'rejected',
+  'rejected_main.c',
+  link_with : stlib,
+)
+test('rejected', rejected)
+
+rejected_whole = executable(
+  'rejected_whole',
+  'rejected_main.c',
+  link_whole : stlib,
+)
+test('rejected (whole archive)', rejected_whole)

--- a/test cases/unit/17 prebuilt shared/meson_options.txt
+++ b/test cases/unit/17 prebuilt shared/meson_options.txt
@@ -1,0 +1,1 @@
+option('search_dir', type : 'string', value : 'auto')

--- a/test cases/unit/17 prebuilt shared/rejected.c
+++ b/test cases/unit/17 prebuilt shared/rejected.c
@@ -1,0 +1,8 @@
+#include "rejected.h"
+
+void say(void) {
+    printf("You are standing outside the Great Library of Alexandria.\n");
+    printf("You decide to go inside.\n\n");
+    alexandria_visit();
+    printf("The librarian tells you it's time to leave\n");
+}

--- a/test cases/unit/17 prebuilt shared/rejected.h
+++ b/test cases/unit/17 prebuilt shared/rejected.h
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include <alexandria.h>
+
+#pragma once
+
+void say(void);

--- a/test cases/unit/17 prebuilt shared/rejected_main.c
+++ b/test cases/unit/17 prebuilt shared/rejected_main.c
@@ -1,0 +1,6 @@
+#include "rejected.h"
+
+int main(void) {
+    say();
+    return 0;
+}

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1499,19 +1499,22 @@ class AllPlatformTests(BasePlatformTests):
         else:
             shlibfile = os.path.join(tdir, 'libalexandria.' + shared_suffix)
         self.build_shared_lib(cc, source, objectfile, shlibfile, impfile)
-        # Run the test
-        try:
-            self.init(tdir)
-            self.build()
-            self.run_tests()
-        finally:
-            os.unlink(shlibfile)
-            if is_windows():
-                # Clean up all the garbage MSVC writes in the
-                # source tree.
+
+        if is_windows():
+            def cleanup() -> None:
+                """Clean up all the garbage MSVC writes in the source tree."""
+
                 for fname in glob(os.path.join(tdir, 'alexandria.*')):
-                    if os.path.splitext(fname)[1] not in ['.c', '.h']:
+                    if os.path.splitext(fname)[1] not in {'.c', '.h'}:
                         os.unlink(fname)
+            self.addCleanup(cleanup)
+        else:
+            self.addCleanup(os.unlink, shlibfile)
+
+        # Run the test
+        self.init(tdir)
+        self.build()
+        self.run_tests()
 
     @skipIfNoPkgconfig
     def test_pkgconfig_static(self):


### PR DESCRIPTION
In 0.60 a bug was fixed where a cached variable was being mutated. Unfortunately, we were relying on that mutation to get the behavior of recursively looking up the dependency web of a target. This series does a bit of cleanup, then fixes the bug by explicitly doing the up chain lookup.

Fixes #9542