### PR TITLE
test cases: enable cmake llvm on msys2

### DIFF
--- a/test cases/frameworks/15 llvm/test.json
+++ b/test cases/frameworks/15 llvm/test.json
@@ -2,8 +2,7 @@
   "matrix": {
     "options": {
       "method": [
-        { "val": "config-tool", "skip_on_jobname": ["msys2-gcc"]},
-        { "val": "cmake", "skip_on_jobname": ["msys2"] }
+        { "val": "config-tool", "skip_on_jobname": ["msys2-gcc"]}
       ],
       "link-static": [
         { "val": true, "skip_on_jobname": ["opensuse"] },


### PR DESCRIPTION
This seems to work now, though we don't expect it to. I don't know why
it works, I'm assuming a change to msys2 itself, and not something Meson
did.