### PR TITLE
Support Visual Studio 2022 backend

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -70,7 +70,7 @@ machine](#specifying-options-per-machine) section for details.
 | Option                               | Default value | Description                                                    | Is per machine | Is per subproject |
 | ------                               | ------------- | -----------                                                    | -------------- | ----------------- |
 | auto_features {enabled, disabled, auto} | auto       | Override value of all 'auto' features                          | no             | no                |
-| backend {ninja, vs,<br>vs2010, vs2012, vs2013, vs2015, vs2017, vs2019, xcode} | ninja | Backend to use                | no             | no                |
+| backend {ninja, vs,<br>vs2010, vs2012, vs2013, vs2015, vs2017, vs2019, vs2022, xcode} | ninja | Backend to use        | no             | no                |
 | buildtype {plain, debug,<br>debugoptimized, release, minsize, custom} | debug |  Build type to use                    | no             | no                |
 | debug                                | true          | Debug                                                          | no             | no                |
 | default_library {shared, static, both} | shared      | Default library type                                           | no             | yes               |

--- a/docs/markdown/Configuring-a-build-directory.md
+++ b/docs/markdown/Configuring-a-build-directory.md
@@ -21,20 +21,20 @@ a sample output for a simple project.
     Build dir  /home/jpakkane/clangdemo/2_address/buildmeson
 
     Core options:
-      Option          Current Value Possible Values                                          Description
-      ------          ------------- ---------------                                          -----------
-      auto_features   auto          [enabled, disabled, auto]                                Override value of all 'auto' features
-      backend         ninja         [ninja, vs, vs2010, vs2015, vs2017, vs2019, xcode]       Backend to use
-      buildtype       release       [plain, debug, debugoptimized, release, minsize, custom] Build type to use
-      debug           false         [true, false]                                            Debug
-      default_library shared        [shared, static, both]                                   Default library type
-      install_umask   0022          [preserve, 0000-0777]                                    Default umask to apply on permissions of installed files
-      layout          mirror        [mirror, flat]                                           Build directory layout
-      optimization    3             [0, g, 1, 2, 3, s]                                       Optimization level
-      strip           false         [true, false]                                            Strip targets on install
-      unity           off           [on, off, subprojects]                                   Unity build
-      warning_level   1             [0, 1, 2, 3]                                             Compiler warning level to use
-      werror          false         [true, false]                                            Treat warnings as errors
+      Option          Current Value Possible Values                                            Description
+      ------          ------------- ---------------                                            -----------
+      auto_features   auto          [enabled, disabled, auto]                                  Override value of all 'auto' features
+      backend         ninja         [ninja, vs, vs2010, vs2015, vs2017, vs2019, vs2022, xcode] Backend to use
+      buildtype       release       [plain, debug, debugoptimized, release, minsize, custom]   Build type to use
+      debug           false         [true, false]                                              Debug
+      default_library shared        [shared, static, both]                                     Default library type
+      install_umask   0022          [preserve, 0000-0777]                                      Default umask to apply on permissions of installed files
+      layout          mirror        [mirror, flat]                                             Build directory layout
+      optimization    3             [0, g, 1, 2, 3, s]                                         Optimization level
+      strip           false         [true, false]                                              Strip targets on install
+      unity           off           [on, off, subprojects]                                     Unity build
+      warning_level   1             [0, 1, 2, 3]                                               Compiler warning level to use
+      werror          false         [true, false]                                              Treat warnings as errors
 
     Backend options:
       Option            Current Value Possible Values Description

--- a/docs/markdown/snippets/vs_2022.md
+++ b/docs/markdown/snippets/vs_2022.md
@@ -1,0 +1,10 @@
+## Visual Studio 2022 backend
+
+As Visual Studio 2022 is released recently, it's time to support the
+new version in Meson. This mainly includes the new "v143" platform tools.
+
+The usage is similar to other backends. For example
+```meson
+meson setup builddir --backend=vs2022
+```
+will configure "builddir" for projects compatible with Visual Studio 2022.

--- a/docs/yaml/builtins/meson.yaml
+++ b/docs/yaml/builtins/meson.yaml
@@ -134,6 +134,7 @@ methods:
       - `vs2015`
       - `vs2017`
       - `vs2019`
+      - `vs2022`
       - `xcode`
 
   - name: build_root

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -259,6 +259,9 @@ def get_backend_from_name(backend: str, build: T.Optional[build.Build] = None, i
     elif backend == 'vs2019':
         from . import vs2019backend
         return vs2019backend.Vs2019Backend(build, interpreter)
+    elif backend == 'vs2022':
+        from . import vs2022backend
+        return vs2022backend.Vs2022Backend(build, interpreter)
     elif backend == 'xcode':
         from . import xcodebackend
         return xcodebackend.XCodeBackend(build, interpreter)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -56,6 +56,10 @@ def autodetect_vs_version(build: T.Optional[build.Build], interpreter: T.Optiona
        'Visual Studio\\2019' in vs_install_dir:
         from mesonbuild.backend.vs2019backend import Vs2019Backend
         return Vs2019Backend(build, interpreter)
+    if vs_version == '17.0' or 'Visual Studio 22' in vs_install_dir or \
+       'Visual Studio\\2022' in vs_install_dir:
+        from mesonbuild.backend.vs2022backend import Vs2022Backend
+        return Vs2022Backend(build, interpreter)
     if 'Visual Studio 10.0' in vs_install_dir:
         return Vs2010Backend(build, interpreter)
     raise MesonException('Could not detect Visual Studio using VisualStudioVersion: {!r} or VSINSTALLDIR: {!r}!\n'

--- a/mesonbuild/backend/vs2022backend.py
+++ b/mesonbuild/backend/vs2022backend.py
@@ -1,0 +1,57 @@
+# Copyright 2014-2021 The Meson development team
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import typing as T
+import xml.etree.ElementTree as ET
+
+from .vs2010backend import Vs2010Backend
+from ..interpreter import Interpreter
+from ..build import Build
+
+
+class Vs2022Backend(Vs2010Backend):
+    def __init__(self, build: T.Optional[Build], interpreter: T.Optional[Interpreter]):
+        super().__init__(build, interpreter)
+        self.name = 'vs2022'
+        if self.environment is not None:
+            comps = self.environment.coredata.compilers.host
+            if comps and all(c.id == 'clang-cl' for c in comps.values()):
+                self.platform_toolset = 'ClangCL'
+            elif comps and all(c.id == 'intel-cl' for c in comps.values()):
+                c = list(comps.values())[0]
+                if c.version.startswith('19'):
+                    self.platform_toolset = 'Intel C++ Compiler 19.0'
+                # We don't have support for versions older than 2022 right now.
+            if not self.platform_toolset:
+                self.platform_toolset = 'v143'
+            self.vs_version = '2022'
+        # WindowsSDKVersion should be set by command prompt.
+        sdk_version = os.environ.get('WindowsSDKVersion', None)
+        if sdk_version:
+            self.windows_target_platform_version = sdk_version.rstrip('\\')
+
+    def generate_debug_information(self, link):
+        # valid values for vs2022 is 'false', 'true', 'DebugFastLink', 'DebugFull'
+        ET.SubElement(link, 'GenerateDebugInformation').text = 'DebugFull'
+
+    def generate_lang_standard_info(self, file_args, clconf):
+        if 'cpp' in file_args:
+            optargs = [x for x in file_args['cpp'] if x.startswith('/std:c++')]
+            if optargs:
+                ET.SubElement(clconf, 'LanguageStandard').text = optargs[0].replace("/std:c++", "stdcpp")
+        if 'c' in file_args:
+            optargs = [x for x in file_args['c'] if x.startswith('/std:c')]
+            if optargs:
+                ET.SubElement(clconf, 'LanguageStandard_C').text = optargs[0].replace("/std:c", "stdc")

--- a/mesonbuild/cmake/common.py
+++ b/mesonbuild/cmake/common.py
@@ -44,6 +44,7 @@ backend_generator_map = {
     'vs2015': 'Visual Studio 14 2015',
     'vs2017': 'Visual Studio 15 2017',
     'vs2019': 'Visual Studio 16 2019',
+    'vs2022': 'Visual Studio 17 2022',
 }
 
 blacklist_cmake_defs = [

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -46,7 +46,7 @@ if T.TYPE_CHECKING:
 # Check major_versions_differ() if changing versioning scheme.
 version = '0.60.99'
 
-backendlist = ['ninja', 'vs', 'vs2010', 'vs2012', 'vs2013', 'vs2015', 'vs2017', 'vs2019', 'xcode']
+backendlist = ['ninja', 'vs', 'vs2010', 'vs2012', 'vs2013', 'vs2015', 'vs2017', 'vs2019', 'vs2022', 'xcode']
 
 default_yielding = False
 


### PR DESCRIPTION
Visual Studio 2022 just released yesterday. I saw no issue and PR about supporting this backend so here is my attempt.

The motivation to add this is that if the user just have VS 2022 installed, it only includes platform toolset v143, while vs2019 backend uses v142. Meaning without manually retarget the generated project files to v143, `meson compile` will fail to build.

This is my first time to do anything about Meson source code, so I may very likely miss some spots to change. Please let me know or edit when you merge.

I basically just copied whatever in vs2019 and change version numbers. I did test this change locally.