### PR TITLE
hdf5 dependency: check for alternative config-tool names

### DIFF
--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -96,13 +96,13 @@ class HDF5ConfigToolDependency(ConfigToolDependency):
 
         if language == 'c':
             cenv = 'CC'
-            tools = ['h5cc']
+            tools = ['h5cc', 'h5pcc']
         elif language == 'cpp':
             cenv = 'CXX'
-            tools = ['h5c++']
+            tools = ['h5c++', 'h5pc++']
         elif language == 'fortran':
             cenv = 'FC'
-            tools = ['h5fc']
+            tools = ['h5fc', 'h5pfc']
         else:
             raise DependencyException('How did you get here?')
 


### PR DESCRIPTION
Depending on whether hdf5 is compiled with parallel support, the same config-tool program may be installed with a mysterious "p" in the name. In this case, dependency lookup will totally fail, unless of course you use the superior pkg-config interface in which case you get a predictable name.

Work around this insanity by checking for both types of config-tool name.

Fixes #9555