### PR TITLE
interpreter: Fix a typo

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2316,7 +2316,7 @@ This will become a hard error in the future.''', location=self.current_node)
                     mlog.warning('include_directories sandbox violation!')
                     print(textwrap.dedent(f'''\
                         The project is trying to access the directory {a} which belongs to a different
-                        subproject. This is a problem as it hardcodes the relative paths of these two projeccts.
+                        subproject. This is a problem as it hardcodes the relative paths of these two projects.
                         This makes it impossible to compile the project in any other directory layout and also
                         prevents the subproject from changing its own directory layout.
 


### PR DESCRIPTION
This is a trivial typo.  Fix projeccts to projects.

Signed-off-by: Yasushi SHOJI <yashi@spacecubics.com>