### PR TITLE
only pass clang LTO arguments when they are needed

### DIFF
--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -156,7 +156,9 @@ class ClangCompiler(GnuLikeCompiler):
 
     def get_lto_link_args(self, *, threads: int = 0, mode: str = 'default') -> T.List[str]:
         args = self.get_lto_compile_args(threads=threads, mode=mode)
-        # In clang -flto=0 means auto
-        if threads >= 0:
+        # In clang -flto-jobs=0 means auto, and is the default if unspecified, just like in meson
+        if threads > 0:
+            if not mesonlib.version_compare(self.version, '>=4.0.0'):
+                raise mesonlib.MesonException('clang support for LTO threads requires clang >=4.0')
             args.append(f'-flto-jobs={threads}')
         return args


### PR DESCRIPTION
If the LTO threads == 0 clang will default to the same argument we manually pass, which meant we dropped support for admittedly ancient versions of clang that didn't yet add that option.

Drop the extraneous argument, and add a specific error condition when too old versions of clang are detected.

Fixes #9569