### PR TITLE
Set RPATH for all non-system libs with absolute paths

### DIFF
--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -1756,6 +1756,10 @@ class OrderedSet(T.MutableSet[_T]):
     def difference(self, set_: T.Union[T.Set[_T], 'OrderedSet[_T]']) -> 'OrderedSet[_T]':
         return type(self)(e for e in self if e not in set_)
 
+    def difference_update(self, iterable: T.Iterable[_T]) -> None:
+        for item in iterable:
+            self.discard(item)
+
 def relpath(path: str, start: str) -> str:
     # On Windows a relative path can't be evaluated for paths on two different
     # drives (i.e. c:\foo and f:\bar).  The only thing left to do is to use the

--- a/test cases/common/44 pkgconfig-gen/answer.c
+++ b/test cases/common/44 pkgconfig-gen/answer.c
@@ -1,0 +1,3 @@
+int answer_to_life_the_universe_and_everything(void) {
+    return 42;
+}

--- a/test cases/common/44 pkgconfig-gen/foo.c
+++ b/test cases/common/44 pkgconfig-gen/foo.c
@@ -1,0 +1,7 @@
+#include"simple.h"
+
+int answer_to_life_the_universe_and_everything (void);
+
+int simple_function(void) {
+    return answer_to_life_the_universe_and_everything();
+}

--- a/test cases/common/44 pkgconfig-gen/meson.build
+++ b/test cases/common/44 pkgconfig-gen/meson.build
@@ -47,6 +47,7 @@ answerlib = shared_library('answer', 'answer.c')
 pkgg.generate(answerlib,
   name : 'libanswer',
   description : 'An answer library.',
+  extra_cflags : ['-DLIBFOO'],
 )
 
 # Test that name_prefix='' and name='libfoo' results in '-lfoo'

--- a/test cases/common/44 pkgconfig-gen/meson.build
+++ b/test cases/common/44 pkgconfig-gen/meson.build
@@ -42,13 +42,21 @@ test('pkgconfig-validation', pkgconfig,
   args: ['--validate', 'simple'],
   env: [ 'PKG_CONFIG_PATH=' + meson.current_build_dir() + '/meson-private' ])
 
+answerlib = shared_library('answer', 'answer.c')
+
+pkgg.generate(answerlib,
+  name : 'libanswer',
+  description : 'An answer library.',
+)
+
 # Test that name_prefix='' and name='libfoo' results in '-lfoo'
-lib2 = shared_library('libfoo', 'simple.c',
+lib2 = shared_library('libfoo', 'foo.c',
+  link_with: answerlib,
   name_prefix : '',
   version : libver)
 
-pkgg.generate(
-  libraries : lib2,
+pkgg.generate(lib2,
+  libraries : [lib2, answerlib],
   name : 'libfoo',
   version : libver,
   description : 'A foo library.',

--- a/test cases/common/44 pkgconfig-gen/test.json
+++ b/test cases/common/44 pkgconfig-gen/test.json
@@ -3,6 +3,7 @@
     {"type": "file", "file": "usr/include/simple.h"},
     {"type": "file", "file": "usr/lib/libstat2.a"},
     {"type": "file", "file": "usr/lib/pkgconfig/simple.pc"},
+    {"type": "file", "file": "usr/lib/pkgconfig/libanswer.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/libfoo.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/libhello.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/libhello_nolib.pc"},

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1595,7 +1595,7 @@ class AllPlatformTests(BasePlatformTests):
         foo_dep = PkgConfigDependency('libfoo', env, kwargs)
         # Ensure link_args are properly quoted
         libdir = PurePath(prefix) / PurePath(libdir)
-        link_args = ['-L' + libdir.as_posix(), '-lfoo']
+        link_args = ['-L' + libdir.as_posix(), '-lfoo', '-lanswer']
         self.assertEqual(foo_dep.get_link_args(), link_args)
         # Ensure include args are properly quoted
         incdir = PurePath(prefix) / PurePath('include')

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -1592,10 +1592,10 @@ class AllPlatformTests(BasePlatformTests):
         os.environ['PKG_CONFIG_LIBDIR'] = self.privatedir
         env = get_fake_env(testdir, self.builddir, self.prefix)
         kwargs = {'required': True, 'silent': True}
-        foo_dep = PkgConfigDependency('libfoo', env, kwargs)
+        foo_dep = PkgConfigDependency('libanswer', env, kwargs)
         # Ensure link_args are properly quoted
         libdir = PurePath(prefix) / PurePath(libdir)
-        link_args = ['-L' + libdir.as_posix(), '-lfoo', '-lanswer']
+        link_args = ['-L' + libdir.as_posix(), '-lanswer']
         self.assertEqual(foo_dep.get_link_args(), link_args)
         # Ensure include args are properly quoted
         incdir = PurePath(prefix) / PurePath('include')


### PR DESCRIPTION
If a pkg-config dependency has multiple libraries in it, which is the most common case when it has a `Requires:` directive, or when it has multiple `-l` args in `Libs:` (rare), then we don't add `-Wl,-rpath` directives to it when linking.

The existing test wasn't catching it because it was linking to a pkgconfig file with a single library in it. Update the test to demonstrate this.

This function was originally added for shared libraries in the source directory, which explains the name: https://github.com/mesonbuild/meson/pull/2397

However, now it is also used for linking to *all* non-system shared libraries that we link to with absolute paths: https://github.com/mesonbuild/meson/pull/3092

But that PR is incomplete / wrong, because it only adds RPATHs for dependencies that specify a single library, which is simply inconsistent. Things will work for some dependencies and not work for others, with no logical reason for it.

We should add RPATHs for *all* libraries. There are no special length limits for RPATHs that I can find.

For ELF, `DT_RPATH` or `DT_RUNPATH` are used, which have are just stored in a string table `DT_STRTAB`. The maximum length is only a problem when editing pre-existing tags.

For Mach-O, each RPATH is stored in a separate `LC_RPATH` entry so there are no length issues there either.

Fixes https://github.com/mesonbuild/meson/issues/9543

Fixes https://github.com/mesonbuild/meson/issues/4372