### PR TITLE
dependencies/zlib: Add system zlib method for android

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -711,7 +711,7 @@ $ wx-config --libs std stc
 ## Zlib
 
 Zlib ships with pkg-config and cmake support, but on some operating
-systems (windows, macOs, FreeBSD, dragonflybsd), it is provided as
+systems (windows, macOs, FreeBSD, dragonflybsd, android), it is provided as
 part of the base operating system without pkg-config support. The new
 System finder can be used on these OSes to link with the bundled
 version.

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -466,7 +466,7 @@ class ZlibSystemDependency(SystemDependency):
         # I'm not sure this is entirely correct. What if we're cross compiling
         # from something to macOS?
         if ((m.is_darwin() and isinstance(self.clib_compiler, (AppleClangCCompiler, AppleClangCPPCompiler))) or
-                m.is_freebsd() or m.is_dragonflybsd()):
+                m.is_freebsd() or m.is_dragonflybsd() or m.is_android()):
             # No need to set includes,
             # on macos xcode/clang will do that for us.
             # on freebsd zlib.h is in /usr/include
@@ -474,7 +474,7 @@ class ZlibSystemDependency(SystemDependency):
             self.is_found = True
             self.link_args = ['-lz']
         elif m.is_windows():
-            # Without a clib_compiler we can't find zlib, s just give up.
+            # Without a clib_compiler we can't find zlib, so just give up.
             if self.clib_compiler is None:
                 self.is_found = False
                 return

--- a/test cases/common/221 zlib/meson.build
+++ b/test cases/common/221 zlib/meson.build
@@ -1,7 +1,7 @@
 project('zlib system dependency', 'c')
 
-if not ['darwin', 'freebsd', 'dragonfly', 'windows'].contains(host_machine.system())
-  error('MESON_SKIP_TEST only applicable on macOS, FreeBSD, DragonflyBSD, and Windows.')
+if not ['darwin', 'freebsd', 'dragonfly', 'windows', 'android'].contains(host_machine.system())
+  error('MESON_SKIP_TEST only applicable on macOS, FreeBSD, DragonflyBSD, Windows, and Android.')
 endif
 
 cc = meson.get_compiler('c')


### PR DESCRIPTION
I noticed that the zlib system method currently doesn't work on android and it seems it wasn't included with #6421. The same method that the BSDs use should also work for android, and with some very light testing on my end with cross-compiling to android it behaves as expected.