### PR TITLE
modules/gnome: Add back deprecation message

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1045,6 +1045,8 @@ class GnomeModule(ExtensionModule):
     def yelp(self, state: 'ModuleState', args: T.Tuple[str, T.List[str]], kwargs: 'Yelp') -> ModuleReturnValue:
         project_id = args[0]
         sources = kwargs['sources']
+        if args[1]:
+            FeatureDeprecated.single_use('gnome.yelp more than one positional argument', '0.60.0', 'use the "sources" keyword argument instead.')
         if not sources:
             sources = args[1]
             if not sources:

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1051,9 +1051,8 @@ class GnomeModule(ExtensionModule):
             sources = args[1]
             if not sources:
                 raise MesonException('Yelp requires a list of sources')
-        else:
-            if len(args) > 1:
-                mlog.warning('"gnome.yelp" ignores positional sources arguments when the "sources" keyword argument is set')
+        elif args[1]:
+            mlog.warning('"gnome.yelp" ignores positional sources arguments when the "sources" keyword argument is set')
         source_str = '@@'.join(sources)
 
         langs = kwargs['languages']


### PR DESCRIPTION
This looks like it was probably removed in a bad rebase