### PR TITLE
dependencies/zlib: Allow for generic OS checks

### DIFF
--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -473,7 +473,7 @@ class ZlibSystemDependency(SystemDependency):
 
             self.is_found = True
             self.link_args = ['-lz']
-        elif m.is_windows():
+        else:
             # Without a clib_compiler we can't find zlib, so just give up.
             if self.clib_compiler is None:
                 self.is_found = False
@@ -492,9 +492,6 @@ class ZlibSystemDependency(SystemDependency):
                     break
             else:
                 return
-        else:
-            mlog.debug(f'Unsupported OS {m.system}')
-            return
 
         v, _ = self.clib_compiler.get_define('ZLIB_VERSION', '#include <zlib.h>', self.env, [], [self])
         self.version = v.strip('"')


### PR DESCRIPTION
Contrary to most system method checks, zlib currently functions as a
whitelist of OSes. This isn't really needed however. The first special
case for OSes that provide zlib as part of the base OS is worth keeping.
However, the elif for windows is more than generic enough to allow any
other potential OSes to try. Just make it a simplie if/else instead.