### PR TITLE
Support ancient (<3.4.0) gcc versions

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -245,6 +245,7 @@ class GnuCCompiler(GnuCompiler, CCompiler):
 
     _C18_VERSION = '>=8.0.0'
     _C2X_VERSION = '>=9.0.0'
+    _INVALID_PCH_VERSION = ">=3.4.0"
 
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
@@ -253,7 +254,9 @@ class GnuCCompiler(GnuCompiler, CCompiler):
                  full_version: T.Optional[str] = None):
         CCompiler.__init__(self, exelist, version, for_machine, is_cross, info, exe_wrapper, linker=linker, full_version=full_version)
         GnuCompiler.__init__(self, defines)
-        default_warn_args = ['-Wall', '-Winvalid-pch']
+        default_warn_args = ['-Wall']
+        if version_compare(self.version, self._INVALID_PCH_VERSION):
+            default_warn_args += ['-Winvalid-pch']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
                           '2': default_warn_args + ['-Wextra'],


### PR DESCRIPTION
I'd usually keep such esoteric support in a personal fork, but the change is so simple it might be worth merging.

GCC didn't support the `-Winvalid-pch` flag til 3.4.0 (released in 2004, might I add). Amazingly, removing it is all that's required to get code from back then compiling using meson.

Flags like --std=c11 aren't going to fail gracefully, but it should be fairly obvious if you're using a compiler that old that c89/c99 is all you get.