### PR TITLE
dependencies: add a system dependency for OpenSSL

### DIFF
--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -36,7 +36,7 @@ from .misc import (
     BlocksDependency, OpenMPDependency, cups_factory, curses_factory, gpgme_factory,
     libgcrypt_factory, libwmf_factory, netcdf_factory, pcap_factory, python3_factory,
     shaderc_factory, threads_factory, ThreadDependency, iconv_factory, intl_factory,
-    dl_factory
+    dl_factory, openssl_factory, libcrypto_factory, libssl_factory,
 )
 from .platform import AppleFrameworks
 from .qt import qt4_factory, qt5_factory, qt6_factory
@@ -256,6 +256,9 @@ packages.update({
     'iconv': iconv_factory,
     'intl': intl_factory,
     'dl': dl_factory,
+    'openssl': openssl_factory,
+    'libcrypto': libcrypto_factory,
+    'libssl': libssl_factory,
 
     # From platform:
     'appleframeworks': AppleFrameworks,

--- a/mesonbuild/dependencies/factory.py
+++ b/mesonbuild/dependencies/factory.py
@@ -49,6 +49,10 @@ if T.TYPE_CHECKING:
         T.List[DependencyGenerator]
     ]
 
+    # This should be str, Environment, T.Dict[str, T.Any], T.Optional[str]
+    # But if you try that, you get error: Cannot infer type of lambda
+    CmakeDependencyFunc = T.Callable[..., CMakeDependency]
+
 class DependencyFactory:
 
     """Factory to get dependencies from multiple sources.
@@ -77,7 +81,7 @@ class DependencyFactory:
                  pkgconfig_name: T.Optional[str] = None,
                  pkgconfig_class: 'T.Type[PkgConfigDependency]' = PkgConfigDependency,
                  cmake_name: T.Optional[str] = None,
-                 cmake_class: 'T.Type[CMakeDependency]' = CMakeDependency,
+                 cmake_class: 'T.Union[T.Type[CMakeDependency], CmakeDependencyFunc]' = CMakeDependency,
                  configtool_class: 'T.Optional[T.Type[ConfigToolDependency]]' = None,
                  framework_name: T.Optional[str] = None,
                  framework_class: 'T.Type[ExtraFrameworkDependency]' = ExtraFrameworkDependency,

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -511,6 +511,55 @@ class IntlSystemDependency(SystemDependency):
                     return
 
 
+class OpensslSystemDependency(SystemDependency):
+    def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
+        super().__init__(name, env, kwargs)
+
+        dependency_kwargs = {
+            'method': 'system',
+            'static': self.static,
+        }
+        if not self.clib_compiler.has_header('openssl/ssl.h', '', env)[0]:
+            return
+
+        # openssl >= 3 only
+        self.version = self.clib_compiler.get_define('OPENSSL_VERSION_STR', '#include <openssl/opensslv.h>', env, [], [self])[0]
+        # openssl < 3 only
+        if not self.version:
+            version_hex = self.clib_compiler.get_define('OPENSSL_VERSION_NUMBER', '#include <openssl/opensslv.h>', env, [], [self])[0]
+            if not version_hex:
+                return
+            version_hex = version_hex.rstrip('L')
+            version_ints = [((int(version_hex.rstrip('L'), 16) >> 4 + i) & 0xFF) for i in (24, 16, 8, 0)]
+            # since this is openssl, the format is 1.2.3a in four parts
+            self.version = '.'.join(str(i) for i in version_ints[:3]) + chr(ord('a') + version_ints[3] - 1)
+
+        if name == 'openssl':
+            if self._add_sub_dependency(libssl_factory(env, self.for_machine, dependency_kwargs)) and \
+                    self._add_sub_dependency(libcrypto_factory(env, self.for_machine, dependency_kwargs)):
+                self.is_found = True
+            return
+        else:
+            self.link_args = self.clib_compiler.find_library(name.lstrip('lib'), env, [], self.libtype)
+            if not self.link_args:
+                return
+
+        if not self.static:
+            self.is_found = True
+        else:
+            if name == 'libssl':
+                if self._add_sub_dependency(libcrypto_factory(env, self.for_machine, dependency_kwargs)):
+                    self.is_found = True
+            elif name == 'libcrypto':
+                use_threads = self.clib_compiler.has_header_symbol('openssl/opensslconf.h', 'OPENSSL_THREADS', '', env, dependencies=[self])[0]
+                if not use_threads or self._add_sub_dependency(threads_factory(env, self.for_machine, {})):
+                    self.is_found = True
+                # only relevant on platforms where it is distributed with the libc, in which case it always succeeds
+                sublib = self.clib_compiler.find_library('dl', env, [], self.libtype)
+                if sublib:
+                    self.link_args.extend(sublib)
+
+
 @factory_methods({DependencyMethods.PKGCONFIG, DependencyMethods.CONFIG_TOOL, DependencyMethods.SYSTEM})
 def curses_factory(env: 'Environment',
                    for_machine: 'MachineChoice',
@@ -640,4 +689,22 @@ intl_factory = DependencyFactory(
     [DependencyMethods.BUILTIN, DependencyMethods.SYSTEM],
     builtin_class=IntlBuiltinDependency,
     system_class=IntlSystemDependency,
+)
+
+openssl_factory = DependencyFactory(
+    'openssl',
+    [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM],
+    system_class=OpensslSystemDependency,
+)
+
+libcrypto_factory = DependencyFactory(
+    'libcrypto',
+    [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM],
+    system_class=OpensslSystemDependency,
+)
+
+libssl_factory = DependencyFactory(
+    'libssl',
+    [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM],
+    system_class=OpensslSystemDependency,
 )

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -693,18 +693,21 @@ intl_factory = DependencyFactory(
 
 openssl_factory = DependencyFactory(
     'openssl',
-    [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM],
+    [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM, DependencyMethods.CMAKE],
     system_class=OpensslSystemDependency,
+    cmake_class=lambda name, env, kwargs: CMakeDependency('OpenSSL', env, dict(kwargs, modules=['OpenSSL::Crypto', 'OpenSSL::SSL'])),
 )
 
 libcrypto_factory = DependencyFactory(
     'libcrypto',
-    [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM],
+    [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM, DependencyMethods.CMAKE],
     system_class=OpensslSystemDependency,
+    cmake_class=lambda name, env, kwargs: CMakeDependency('OpenSSL', env, dict(kwargs, modules=['OpenSSL::Crypto'])),
 )
 
 libssl_factory = DependencyFactory(
     'libssl',
-    [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM],
+    [DependencyMethods.PKGCONFIG, DependencyMethods.SYSTEM, DependencyMethods.CMAKE],
     system_class=OpensslSystemDependency,
+    cmake_class=lambda name, env, kwargs: CMakeDependency('OpenSSL', env, dict(kwargs, modules=['OpenSSL::SSL'])),
 )


### PR DESCRIPTION
On some platforms, this is provided by the base system, which nevertheless refrains from providing the .pc files that go along with it. As a result, it's impossible to sensibly find these dependencies.

I'm looking at you, FreeBSD...

Upstream tracking bug: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=257659

This is also a problem on macOS, but that's unfixable (and I believe they provide some truly ancient and out-of-support version anyway) and you probably want to use the homebrew OpenSSL. Still, meson can now detect these old versions and even set their version number.