### PR TITLE
Check correct directory for wrap install

### DIFF
--- a/mesonbuild/wrap/wraptool.py
+++ b/mesonbuild/wrap/wraptool.py
@@ -91,12 +91,12 @@ def install(options: 'argparse.Namespace') -> None:
     name = options.name
     if not os.path.isdir('subprojects'):
         raise SystemExit('Subprojects dir not found. Run this script in your source root directory.')
-    if os.path.isdir(os.path.join('subprojects', name)):
+    (version, revision) = get_latest_version(name)
+    if os.path.isdir(os.path.join('subprojects', f'{name}-{version}')):
         raise SystemExit('Subproject directory for this project already exists.')
     wrapfile = os.path.join('subprojects', name + '.wrap')
     if os.path.exists(wrapfile):
         raise SystemExit('Wrap file already exists.')
-    (version, revision) = get_latest_version(name)
     url = urlopen(f'https://wrapdb.mesonbuild.com/v2/{name}_{version}-{revision}/{name}.wrap')
     with open(wrapfile, 'wb') as f:
         f.write(url.read())


### PR DESCRIPTION
wrap install checks if its subproject directory already exists
and fails in this case.
Current wrapdb wraps specify this directory as {name}-{version},
while subprojects/{name} directory was checked

Signed-off-by: Piotr Rak <piotr.rak@gmail.com>