### PR TITLE
tests: remove extraframework test for python

### DIFF
--- a/test cases/osx/5 extra frameworks/meson.build
+++ b/test cases/osx/5 extra frameworks/meson.build
@@ -6,8 +6,5 @@ assert(dep_libs.type_name() == 'extraframeworks', 'type_name is ' + dep_libs.typ
 dep_main = dependency('Foundation')
 assert(dep_main.type_name() == 'extraframeworks', 'type_name is ' + dep_main.type_name())
 
-dep_py = dependency('python', method : 'extraframework')
-assert(dep_main.type_name() == 'extraframeworks', 'type_name is ' + dep_main.type_name())
-
 stlib = static_library('stat', 'stat.c', install : true, dependencies: dep_libs)
 exe = executable('prog', 'prog.c', install : true, dependencies: dep_main)

--- a/unittests/failuretests.py
+++ b/unittests/failuretests.py
@@ -169,12 +169,12 @@ class FailureTests(BasePlatformTests):
                                "requires at least one module")
 
     def test_extraframework_dependency_method(self):
-        code = "dependency('python', method : 'extraframework')"
+        code = "dependency('metal', method : 'extraframework')"
         if not is_osx():
             self.assertMesonRaises(code, self.dnf)
         else:
-            # Python2 framework is always available on macOS
-            self.assertMesonOutputs(code, '[Dd]ependency.*python.*found.*YES')
+            # metal framework is always available on macOS
+            self.assertMesonOutputs(code, '[Dd]ependency.*metal.*found.*YES')
 
     def test_sdl2_notfound_dependency(self):
         # Want to test failure, so skip if available


### PR DESCRIPTION
This tries to link the system provided python, which is deprecated and
will result in an ambiguous error like "your binary is not an allowed
client of .../Library/Frameworks/python.framework/python.tbd for
architecture x86_64". Just remove it, we already have coverage of
extraframeworks anyway.