### PR TITLE
More typed_kwargs for the gnome module

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -120,18 +120,22 @@ typelib_target]`
 Generates a marshal file using the `glib-genmarshal` tool. The first
 argument is the basename of the output files.
 
-* `extra_args`: (*Added 0.42.0*) additional command line arguments to
-  pass
+* `depends` [](BuildTarget | CustomTarget | CustomTargetIndex):
+  passed directly to CustomTarget (*since 0.61.0*)
+* `depend_files` [](str | File): Passed directly to CustomTarget (*since 0.61.0*)
+* `extra_args`: (*Added 0.42.0*) additional command line arguments to pass
+* `install_dir`: directory to install header to
 * `install_header`: if true, install the generated header
 * `install_dir`: directory to install header to
-* `nostdinc`: if true, don't include the standard marshallers from
-  glib
-* `internal`: if true, mark generated sources as internal to
-  `glib-genmarshal` (*Requires GLib 2.54*)
+* `install_header`: if true, install the generated header
+* `internal`: if true, mark generated sources as internal to `glib-genmarshal`
+  (*Requires GLib 2.54*)
+* `nostdinc`: if true, don't include the standard marshallers from glib
 * `prefix`: the prefix to use for symbols
 * `skip_source`: if true, skip source location comments
-* `stdinc`: if true, include the standard marshallers from glib
+* `sources` []str *required*: List of string sources to consume
 * `sources`: the list of sources to use as inputs
+* `stdinc`: if true, include the standard marshallers from glib
 * `valist_marshallers`: if true, generate va_list marshallers
 
 *Added 0.35.0*
@@ -158,6 +162,7 @@ template with only minor tweaks, in which case the
 Note that if you `#include` the generated header in any of the sources
 for a build target, you must add the generated header to the build
 target's list of sources to codify the dependency. This is true for
+
 all generated sources, not just `mkenums`.
 
 * `c_template`: template to use for generating the source

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -51,7 +51,7 @@ from .interpreterobjects import (
     NullSubprojectInterpreter,
 )
 from .type_checking import (
-    COMMAND_KW,
+    COMMAND_KW, CT_BUILD_ALWAYS, CT_BUILD_ALWAYS_STALE,
     CT_BUILD_BY_DEFAULT,
     CT_INPUT_KW,
     CT_INSTALL_DIR_KW,
@@ -1706,6 +1706,8 @@ external dependencies (including libraries) must go to "dependencies".''')
     @typed_kwargs(
         'custom_target',
         COMMAND_KW,
+        CT_BUILD_ALWAYS.evolve(deprecated='0.47.0'),
+        CT_BUILD_ALWAYS_STALE.evolve(since='0.47.0'),
         CT_BUILD_BY_DEFAULT,
         CT_INPUT_KW,
         CT_INSTALL_DIR_KW,
@@ -1718,8 +1720,6 @@ external dependencies (including libraries) must go to "dependencies".''')
         INSTALL_KW,
         INSTALL_MODE_KW.evolve(since='0.47.0'),
         OVERRIDE_OPTIONS_KW,
-        KwargInfo('build_always', (bool, type(None)), deprecated='0.47.0'),
-        KwargInfo('build_always_stale', (bool, type(None)), since='0.47.0'),
         KwargInfo('feed', bool, default=False, since='0.59.0'),
         KwargInfo('capture', bool, default=False),
         KwargInfo('console', bool, default=False, since='0.48.0'),

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -209,11 +209,10 @@ TEST_KWARGS: T.List[KwargInfo] = [
               default='exitcode',
               validator=in_set_validator({'exitcode', 'tap', 'gtest', 'rust'}),
               since_values={'gtest': '0.55.0', 'rust': '0.57.0'}),
-    KwargInfo('depends', ContainerTypeInfo(list, (build.CustomTarget, build.BuildTarget)),
-              listify=True, default=[], since='0.46.0'),
     KwargInfo('priority', int, default=0, since='0.52.0'),
     # TODO: env needs reworks of the way the environment variable holder itself works probably
     ENV_KW,
+    DEPENDS_KW.evolve(since='0.46.0'),
     KwargInfo('suite', ContainerTypeInfo(list, str), listify=True, default=['']),  # yes, a list of empty string
 ]
 
@@ -1822,8 +1821,8 @@ This will become a hard error in the future.''', location=node)
         KwargInfo('arguments', ContainerTypeInfo(list, str, allow_empty=False), required=True, listify=True),
         KwargInfo('output', ContainerTypeInfo(list, str, allow_empty=False), required=True, listify=True),
         DEPFILE_KW,
+        DEPENDS_KW,
         KwargInfo('capture', bool, default=False, since='0.43.0'),
-        KwargInfo('depends', ContainerTypeInfo(list, (build.BuildTarget, build.CustomTarget)), default=[], listify=True),
     )
     def func_generator(self, node: mparser.FunctionNode,
                        args: T.Tuple[T.Union[build.Executable, ExternalProgram]],

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -281,6 +281,11 @@ CT_INSTALL_DIR_KW: KwargInfo[T.List[T.Union[str, bool]]] = KwargInfo(
 
 CT_BUILD_BY_DEFAULT: KwargInfo[T.Optional[bool]] = KwargInfo('build_by_default', (bool, type(None)), since='0.40.0')
 
+CT_BUILD_ALWAYS: KwargInfo[T.Optional[bool]] = KwargInfo('build_always', (bool, NoneType))
+
+CT_BUILD_ALWAYS_STALE: KwargInfo[T.Optional[bool]] = KwargInfo(
+    'build_always_stale', (bool, NoneType))
+
 INCLUDE_DIRECTORIES: KwargInfo[T.List[T.Union[str, IncludeDirs]]] = KwargInfo(
     'include_dirs',
     ContainerTypeInfo(list, (str, IncludeDirs)),

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -193,6 +193,7 @@ DEPFILE_KW: KwargInfo[T.Optional[str]] = KwargInfo(
     validator=lambda x: 'Depfile must be a plain filename with a subdirectory' if has_path_sep(x) else None
 )
 
+# TODO: CustomTargetIndex should be supported here as well
 DEPENDS_KW: KwargInfo[T.List[T.Union[BuildTarget, CustomTarget]]] = KwargInfo(
     'depends',
     ContainerTypeInfo(list, (BuildTarget, CustomTarget)),

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1086,12 +1086,15 @@ class GnomeModule(ExtensionModule):
         self._devenv_prepend('GSETTINGS_SCHEMA_DIR', os.path.join(state.environment.get_build_dir(), state.subdir))
         return ModuleReturnValue(target_g, [target_g])
 
-    @FeatureDeprecatedKwargs('gnome.yelp', '0.43.0', ['languages'],
-                             'Use a LINGUAS file in the source directory instead')
     @typed_pos_args('gnome.yelp', str, varargs=str)
     @typed_kwargs(
         'gnome.yelp',
-        KwargInfo('languages', ContainerTypeInfo(list, str), listify=True, default=[]),
+        KwargInfo(
+            'languages', ContainerTypeInfo(list, str),
+            listify=True, default=[],
+            deprecated='0.43.0',
+            deprecated_message='Use a LINGUAS file in the source directory instead',
+        ),
         KwargInfo('media', ContainerTypeInfo(list, str), listify=True, default=[]),
         KwargInfo('sources', ContainerTypeInfo(list, str), listify=True, default=[]),
         KwargInfo('symlink_media', bool, default=True),

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1692,7 +1692,7 @@ class GnomeModule(ExtensionModule):
 
     @permittedKwargs({'sources', 'prefix', 'install_header', 'install_dir', 'stdinc',
                       'nostdinc', 'internal', 'skip_source', 'valist_marshallers',
-                      'extra_args'})
+                      'extra_args', 'depends', 'depend_files'})
     @typed_pos_args('gnome.genmarshal', str)
     def genmarshal(self, state: 'ModuleState', args: T.Tuple[str], kwargs) -> ModuleReturnValue:
         output = args[0]


### PR DESCRIPTION
This is a smaller follow up to the last set of cleanups to the gnome module with conversions to `typed_kwargs`. There are only two functions covered here, genmarshal and generate_vapi. Again, this allows a number of nice cleanups. In addition I noticed that genmarshal still exposes `build_always` without deprecation. I've made that deprecated, and added the `build_always_stale` and `build_by_default` keyword arguments matching the behavior of `custom_target`.