### PR TITLE
Make the generated reproducible .cmake files reproducible.

### DIFF
--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -299,7 +299,7 @@ class CmakeModule(ExtensionModule):
 
     def create_package_file(self, infile, outfile, PACKAGE_RELATIVE_PATH, extra, confdata):
         package_init = PACKAGE_INIT_BASE.replace('@PACKAGE_RELATIVE_PATH@', PACKAGE_RELATIVE_PATH)
-        package_init = package_init.replace('@inputFileName@', infile)
+        package_init = package_init.replace('@inputFileName@', os.path.basename(infile))
         package_init += extra
         package_init += PACKAGE_INIT_SET_AND_CHECK
 


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/), I noticed that meson did not generate reproducible `.cmake` files: they include the full path name. This commit not only makes the build reproducible, but it also matches CMake's own behaviour. Specifically, CMakePackageConfigHelpers.cmake does the equivalent transformation using `get_filename_component(inputFileName "${_inputFile}" NAME)`.

I originally filed this in Debian as [bug #1000327](https://bugs.debian.org/1000327).