### PR TITLE
[RFC] add prefer_static built-in option

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -79,6 +79,7 @@ machine](#specifying-options-per-machine) section for details.
 | layout {mirror,flat}                 | mirror        | Build directory layout                                         | no             | no                |
 | optimization {0, g, 1, 2, 3, s}      | 0             | Optimization level                                             | no             | no                |
 | pkg_config_path {OS separated path}  | ''            | Additional paths for pkg-config to search before builtin paths | yes            | no                |
+| prefer_static                        | false         | Whether to try static linking before shared linking            | no             | no                |
 | cmake_prefix_path                    | []            | Additional prefixes for cmake to search before builtin paths   | yes            | no                |
 | stdsplit                             | true          | Split stdout and stderr in test logs                           | no             | no                |
 | strip                                | false         | Strip targets on install                                       | no             | no                |

--- a/docs/markdown/Configuring-a-build-directory.md
+++ b/docs/markdown/Configuring-a-build-directory.md
@@ -31,6 +31,7 @@ a sample output for a simple project.
       install_umask   0022          [preserve, 0000-0777]                                      Default umask to apply on permissions of installed files
       layout          mirror        [mirror, flat]                                             Build directory layout
       optimization    3             [0, g, 1, 2, 3, s]                                         Optimization level
+      prefer_static   false         [true, false]                                              Whether to try static linking before shared linking
       strip           false         [true, false]                                              Strip targets on install
       unity           off           [on, off, subprojects]                                     Unity build
       warning_level   1             [0, 1, 2, 3]                                               Compiler warning level to use

--- a/docs/markdown/snippets/prefer_static.md
+++ b/docs/markdown/snippets/prefer_static.md
@@ -1,0 +1,9 @@
+## New prefer_static built-in option
+
+Users can now set a boolean, `prefer_static`, that controls whether or not
+static linking should be tried before shared linking. This option acts as
+strictly a preference. If the preferred linking method is not successful,
+then Meson will fallback and try the other linking method. Specifically
+setting the `static` kwarg in the meson.build will take precedence over
+the value of `prefer_static` for that specific `dependency` or
+`find_library` call.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1210,6 +1210,7 @@ BUILTIN_CORE_OPTIONS: 'KeyedOptionDictType' = OrderedDict([
     (OptionKey('install_umask'),   BuiltinOption(UserUmaskOption, 'Default umask to apply on permissions of installed files', '022')),
     (OptionKey('layout'),          BuiltinOption(UserComboOption, 'Build directory layout', 'mirror', choices=['mirror', 'flat'])),
     (OptionKey('optimization'),    BuiltinOption(UserComboOption, 'Optimization level', '0', choices=['0', 'g', '1', '2', '3', 's'])),
+    (OptionKey('prefer_static'),   BuiltinOption(UserBooleanOption, 'Whether to try static linking before shared linking', False)),
     (OptionKey('stdsplit'),        BuiltinOption(UserBooleanOption, 'Split stdout and stderr in test logs', True)),
     (OptionKey('strip'),           BuiltinOption(UserBooleanOption, 'Strip targets on install', False)),
     (OptionKey('unity'),           BuiltinOption(UserComboOption, 'Unity build', 'off', choices=['on', 'off', 'subprojects'])),

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -140,8 +140,8 @@ There are a couple of things about this that still aren't ideal. For one, we
 don't want to be reading random environment variables at this point. Those
 should actually be added to `envconfig.Properties` and read in
 `environment.Environment._set_default_properties_from_env` (see how
-`BOOST_ROOT` is handled). We can also handle the `static` keyword. So
-now that becomes:
+`BOOST_ROOT` is handled). We can also handle the `static` keyword and the
+`prefer_static` built-in option. So now that becomes:
 
 ```python
 class FooSystemDependency(ExternalDependency):
@@ -154,7 +154,9 @@ class FooSystemDependency(ExternalDependency):
             self.is_found = False
             return
 
-        static = Mesonlib.LibType.STATIC if kwargs.get('static', False) else Mesonlib.LibType.SHARED
+        get_option = environment.coredata.get_option
+        static_opt = kwargs.get('static', get_option(Mesonlib.OptionKey('prefer_static'))
+        static = Mesonlib.LibType.STATIC if static_opt else Mesonlib.LibType.SHARED
         lib = self.clib_compiler.find_library(
             'foo', environment, [os.path.join(root, 'lib')], libtype=static)
         if lib is None:

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -22,7 +22,7 @@ from enum import Enum
 
 from .. import mlog
 from ..compilers import clib_langs
-from ..mesonlib import LibType, MachineChoice, MesonException, HoldableObject
+from ..mesonlib import LibType, MachineChoice, MesonException, HoldableObject, OptionKey
 from ..mesonlib import version_compare_many
 from ..interpreterbase import FeatureDeprecated
 
@@ -325,7 +325,7 @@ class ExternalDependency(Dependency, HasNativeKwarg):
             self.version_reqs = [self.version_reqs]
         self.required = kwargs.get('required', True)
         self.silent = kwargs.get('silent', False)
-        self.static = kwargs.get('static', False)
+        self.static = kwargs.get('static', self.env.coredata.get_option(OptionKey('prefer_static')))
         self.libtype = LibType.STATIC if self.static else LibType.PREFER_SHARED
         if not isinstance(self.static, bool):
             raise DependencyException('Static keyword must be boolean')

--- a/mesonbuild/dependencies/hdf5.py
+++ b/mesonbuild/dependencies/hdf5.py
@@ -51,7 +51,7 @@ class HDF5PkgConfigDependency(PkgConfigDependency):
         newinc = []  # type: T.List[str]
         for arg in self.compile_args:
             if arg.startswith('-I'):
-                stem = 'static' if kwargs.get('static', False) else 'shared'
+                stem = 'static' if self.static else 'shared'
                 if (Path(arg[2:]) / stem).is_dir():
                     newinc.append('-I' + str(Path(arg[2:]) / stem))
         self.compile_args += newinc
@@ -129,7 +129,7 @@ class HDF5ConfigToolDependency(ConfigToolDependency):
         # We first need to call the tool with -c to get the compile arguments
         # and then without -c to get the link arguments.
         args = self.get_config_value(['-show', '-c'], 'args')[1:]
-        args += self.get_config_value(['-show', '-noshlib' if kwargs.get('static', False) else '-shlib'], 'args')[1:]
+        args += self.get_config_value(['-show', '-noshlib' if self.static else '-shlib'], 'args')[1:]
         for arg in args:
             if arg.startswith(('-I', '-f', '-D')) or arg == '-pthread':
                 self.compile_args.append(arg)

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -537,7 +537,7 @@ def shaderc_factory(env: 'Environment',
         shared_libs = ['shaderc']
         static_libs = ['shaderc_combined', 'shaderc_static']
 
-        if kwargs.get('static', False):
+        if kwargs.get('static', env.coredata.get_option(mesonlib.OptionKey('prefer_static'))):
             c = [functools.partial(PkgConfigDependency, name, env, kwargs)
                  for name in static_libs + shared_libs]
         else:

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -175,7 +175,6 @@ class Python3DependencySystem(SystemDependency):
             return
 
         self.name = 'python3'
-        self.static = kwargs.get('static', False)
         # We can only be sure that it is Python 3 at this point
         self.version = '3'
         self._find_libpy3_windows(environment)

--- a/mesonbuild/dependencies/scalapack.py
+++ b/mesonbuild/dependencies/scalapack.py
@@ -17,6 +17,7 @@ import functools
 import os
 import typing as T
 
+from ..mesonlib import OptionKey
 from .base import DependencyMethods
 from .base import DependencyException
 from .cmake import CMakeDependency
@@ -35,7 +36,8 @@ def scalapack_factory(env: 'Environment', for_machine: 'MachineChoice',
     candidates: T.List['DependencyGenerator'] = []
 
     if DependencyMethods.PKGCONFIG in methods:
-        mkl = 'mkl-static-lp64-iomp' if kwargs.get('static', False) else 'mkl-dynamic-lp64-iomp'
+        static_opt = kwargs.get('static', env.coredata.get_option(OptionKey('prefer_static')))
+        mkl = 'mkl-static-lp64-iomp' if static_opt else 'mkl-dynamic-lp64-iomp'
         candidates.append(functools.partial(
             MKLPkgConfigDependency, mkl, env, kwargs))
 

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -17,6 +17,7 @@ from ..interpreterbase import (ObjectHolder, noPosargs, noKwargs,
                                FeatureNew, disablerIfNotFound,
                                InterpreterException)
 from ..interpreterbase.decorators import ContainerTypeInfo, typed_kwargs, KwargInfo, typed_pos_args
+from ..mesonlib import OptionKey
 from .interpreterobjects import (extract_required_kwarg, extract_search_dirs)
 from .type_checking import REQUIRED_KW, in_set_validator, NoneType
 
@@ -604,10 +605,13 @@ class CompilerHolder(ObjectHolder['Compiler']):
 
         search_dirs = extract_search_dirs(kwargs)
 
+        prefer_static = self.environment.coredata.get_option(OptionKey('prefer_static'))
         if kwargs['static'] is True:
             libtype = mesonlib.LibType.STATIC
         elif kwargs['static'] is False:
             libtype = mesonlib.LibType.SHARED
+        elif prefer_static:
+            libtype = mesonlib.LibType.PREFER_STATIC
         else:
             libtype = mesonlib.LibType.PREFER_SHARED
         linkargs = self.compiler.find_library(libname, self.environment, search_dirs, libtype)

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -2001,6 +2001,7 @@ _BUILTIN_NAMES = {
     'install_umask',
     'layout',
     'optimization',
+    'prefer_static',
     'stdsplit',
     'strip',
     'unity',


### PR DESCRIPTION
By default, meson will try to look for shared libraries first before
static ones. In the meson.build itself, one can use the static keyword
to control if a static library will be tried first but there's no simple
way for an end user performing a build to switch back and forth at will.
Let's cover this usecase by adding an option that allows a user to
specify if they want dependency lookups to try static or shared
libraries first. The writer of the meson.build can manually specify the
static keyword where appropriate which will override the value of this
option.

I suppose this needs test cases to go with it? I was a bit lost on where exactly tests should be made/created so that was left out for now (guidance would be appreciated).

Fixes #2816
Fixes #4276
Fixes #6109
Fixes #6629
Fixes #7621