### PR TITLE
Fix _calculate_toolset_version for VS2022.

### DIFF
--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -332,6 +332,8 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
             return '14.1' # (Visual Studio 2017)
         elif version < 1930:
             return '14.2' # (Visual Studio 2019)
+        elif version < 1940:
+            return '14.3' # (Visual Studio 2022)
         mlog.warning(f'Could not find toolset for version {self.version!r}')
         return None
 


### PR DESCRIPTION
Fixes InternalTests

```
Stdout:
WARNING: Could not find toolset for version '19.30.30705'
```
