### PR TITLE
qt module: fix stupid copy-paste error

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1159,7 +1159,7 @@ external dependencies (including libraries) must go to "dependencies".''')
             tv = FeatureNew.get_target_version(self.subproject)
             if FeatureNew.check_version(tv, '0.54.0'):
                 mlog.warning('add_languages is missing native:, assuming languages are wanted for both host and build.',
-                             location=self.current_node)
+                             location=node)
 
             success = self.add_languages(langs, False, MachineChoice.BUILD)
             success &= self.add_languages(langs, required, MachineChoice.HOST)
@@ -1731,7 +1731,7 @@ external dependencies (including libraries) must go to "dependencies".''')
                 kwargs['input'] = self.source_strings_to_files(extract_as_list(kwargs, 'input'))
             except mesonlib.MesonException:
                 mlog.warning(f'''Custom target input '{kwargs['input']}' can't be converted to File object(s).
-This will become a hard error in the future.''', location=self.current_node)
+This will become a hard error in the future.''', location=node)
         kwargs['env'] = self.unpack_env_kwarg(kwargs)
         if 'command' in kwargs and isinstance(kwargs['command'], list) and kwargs['command']:
             if isinstance(kwargs['command'][0], str):

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -170,7 +170,7 @@ class QtBaseModule(ExtensionModule):
         if qt.found():
             # Get all tools and then make sure that they are the right version
             self.compilers_detect(state, qt)
-            if version_compare(qt.version, '>=5.14.0'):
+            if version_compare(qt.version, '>=5.15.0'):
                 self._moc_supports_depfiles = True
             else:
                 mlog.warning('moc dependencies will not work properly until you move to Qt >= 5.15', fatal=False)


### PR DESCRIPTION
As evidenced by the warning message immediately below this, I meant to write "5.15" here. As is, this will enable depfile support on too-old versions of moc.

@textshell
cf. https://github.com/mesonbuild/meson/pull/7451#issuecomment-975694152