### PR TITLE
install modes should not apply sticky bit to files

### DIFF
--- a/docs/markdown/snippets/deprecated_install_mode_sticky.md
+++ b/docs/markdown/snippets/deprecated_install_mode_sticky.md
@@ -1,0 +1,14 @@
+## various `install_*` functions no longer handle the sticky bit
+
+It is not possible to portably grant the sticky bit to a file, and where
+possible, it doesn't do anything. It is not expected that any users are using
+this functionality.
+
+Variously:
+- on Linux, it has no meaningful effect
+- on Solaris, attempting to set the permission bit is silently ignored by the OS
+- on FreeBSD, attempting to set the permission bit is an error
+
+Attempting to set this permission bit in the `install_mode:` kwarg to any
+function other than [[install_emptydir]] will now result in a warning, and the
+permission bit being ignored.

--- a/test cases/common/190 install_mode/test.json
+++ b/test cases/common/190 install_mode/test.json
@@ -11,5 +11,12 @@
     {"type": "file", "file": "usr/share/sub2/stub"},
     {"type": "file", "file": "usr/subdir/data.dat"}
   ],
-  "do_not_set_opts": ["libdir"]
+  "do_not_set_opts": ["libdir"],
+  "stdout": [
+    {
+      "line": ".* DEPRECATION: install_mode with the sticky bit on a file",
+      "match": "re",
+      "count": 3
+    }
+  ]
 }

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -615,7 +615,7 @@ class LinuxlikeTests(BasePlatformTests):
 
         f = os.path.join(self.installdir, 'etc', 'etcfile.dat')
         found_mode = stat.filemode(os.stat(f).st_mode)
-        want_mode = 'rw------T'
+        want_mode = 'rw-------'
         self.assertEqual(want_mode, found_mode[1:])
 
         f = os.path.join(self.installdir, 'usr', 'bin', 'runscript.sh')
@@ -650,7 +650,7 @@ class LinuxlikeTests(BasePlatformTests):
         f = os.path.join(self.installdir, 'usr', 'share', 'sub1', 'second.dat')
         statf = os.stat(f)
         found_mode = stat.filemode(statf.st_mode)
-        want_mode = 'rwxr-x--t'
+        want_mode = 'rwxr-x--x'
         self.assertEqual(want_mode, found_mode[1:])
         if os.getuid() == 0:
             # The chown failed nonfatally if we're not root
@@ -673,15 +673,15 @@ class LinuxlikeTests(BasePlatformTests):
                 ('bin/trivialprog', '-rwxr-sr-x'),
                 ('include', 'drwxr-x---'),
                 ('include/config.h', '-rw-rwSr--'),
-                ('include/rootdir.h', '-r--r--r-T'),
+                ('include/rootdir.h', '-r--r--r--'),
                 ('lib', 'drwxr-x---'),
                 ('lib/libstat.a', '-rw---Sr--'),
                 ('share', 'drwxr-x---'),
                 ('share/man', 'drwxr-x---'),
                 ('share/man/man1', 'drwxr-x---'),
-                ('share/man/man1/foo.1', '-r--r--r-T'),
+                ('share/man/man1/foo.1', '-r--r--r--'),
                 ('share/sub1', 'drwxr-x---'),
-                ('share/sub1/second.dat', '-rwxr-x--t'),
+                ('share/sub1/second.dat', '-rwxr-x--x'),
                 ('subdir', 'drwxr-x---'),
                 ('subdir/data.dat', '-rw-rwSr--'),
         ]:


### PR DESCRIPTION
This is generally a bad idea, e.g. it causes OSError on freebsd.

It also gets ignored by solaris and thus causes unittest failures.

The proper solution is to simply reject any attempt to set this, and log a warning.

The install_emptydir function does apply the mode as well, and since it is a directory it actually does something. This is the only place where we don't reset the mode.

Although install_subdir also installs directories, and in theory it could set the mode as well, that would be a new feature. Also it doesn't provide much granularity and has mixed semantics with files. Better to let people use install_emptydir + install_subdir.

Fixes #5902