### PR TITLE
Stop backend_startup_project from erasing the last project in sln.

### DIFF
--- a/docs/markdown/snippets/fix_backend_startup_project.md
+++ b/docs/markdown/snippets/fix_backend_startup_project.md
@@ -1,0 +1,4 @@
+## backend_startup_project
+
+`backend_startup_project` will no longer erase the last project in a VS
+solution if it is not the specified project.

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -467,7 +467,7 @@ class Vs2010Backend(backends.Backend):
 
         # Put the startup project first in the project list
         if startup_idx:
-            projlist = [projlist[startup_idx]] + projlist[0:startup_idx] + projlist[startup_idx + 1:-1]
+            projlist.insert(0, projlist.pop(startup_idx))
 
         return projlist
 


### PR DESCRIPTION
As mentioned here https://github.com/mesonbuild/meson/pull/9611#discussion_r754671772 
