### PR TITLE
Cleanup the dlang module and add annotations

### DIFF
--- a/mesonbuild/modules/dlang.py
+++ b/mesonbuild/modules/dlang.py
@@ -48,8 +48,7 @@ class DlangModule(ExtensionModule):
             self.dubbin = DlangModule.class_dubbin
 
         if not self.dubbin:
-            if not self.dubbin:
-                raise MesonException('DUB not found.')
+            raise MesonException('DUB not found.')
 
     def generate_dub_file(self, state, args, kwargs):
         if not DlangModule.init_dub:

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -38,6 +38,7 @@ modules = [
     'mesonbuild/minstall.py',
     'mesonbuild/mintro.py',
     'mesonbuild/mlog.py',
+    'mesonbuild/modules/dlang.py',
     'mesonbuild/modules/fs.py',
     'mesonbuild/modules/i18n.py',
     'mesonbuild/modules/java.py',


### PR DESCRIPTION
Initially I just wanted to quickly add annotations, but discovered that there was some serious duplication of code (plus some confusion on python class vs instance attributes). This starts by de-duplicating the code to find dub between the the `DubDependency` class and the `DlangModule` class. It does this using a constructor (yes, a constructor, not an initializer), which isn't a common pattern in python, but I think is pretty elegant in this situation. Then the standard type cleanups and the addition to the run mypy script.

This does not use `typed_kwargs` for the one method in the module, as the keyword arguments seem to be more freeform than structured inputs, that are just passed directly into a json file.