### PR TITLE
Allow Visual Studio Version Selector to open the correct VS version

### DIFF
--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -98,6 +98,8 @@ class Vs2010Backend(backends.Backend):
         super().__init__(build, interpreter)
         self.name = 'vs2010'
         self.project_file_version = '10.0.30319.1'
+        self.sln_file_version = '11.00'
+        self.sln_version_comment = '2010'
         self.platform_toolset = None
         self.vs_version = '2010'
         self.windows_target_platform_version = None
@@ -348,10 +350,11 @@ class Vs2010Backend(backends.Backend):
     def generate_solution(self, sln_filename, projlist):
         default_projlist = self.get_build_by_default_targets()
         sln_filename_tmp = sln_filename + '~'
-        with open(sln_filename_tmp, 'w', encoding='utf-8') as ofile:
-            ofile.write('Microsoft Visual Studio Solution File, Format '
-                        'Version 11.00\n')
-            ofile.write('# Visual Studio ' + self.vs_version + '\n')
+        # Note using the utf-8 BOM requires the blank line, otherwise Visual Studio Version Selector fails.
+        # Without the BOM, VSVS fails if there is a blank line.
+        with open(sln_filename_tmp, 'w', encoding='utf-8-sig') as ofile:
+            ofile.write('\nMicrosoft Visual Studio Solution File, Format Version %s\n' % self.sln_file_version)
+            ofile.write('# Visual Studio %s\n' % self.sln_version_comment)
             prj_templ = 'Project("{%s}") = "%s", "%s", "{%s}"\n'
             for prj in projlist:
                 coredata = self.environment.coredata

--- a/mesonbuild/backend/vs2012backend.py
+++ b/mesonbuild/backend/vs2012backend.py
@@ -24,6 +24,8 @@ class Vs2012Backend(Vs2010Backend):
         super().__init__(build, interpreter)
         self.name = 'vs2012'
         self.vs_version = '2012'
+        self.sln_file_version = '12.00'
+        self.sln_version_comment = '2012'
         if self.environment is not None:
             # TODO: we assume host == build
             comps = self.environment.coredata.compilers.host

--- a/mesonbuild/backend/vs2013backend.py
+++ b/mesonbuild/backend/vs2013backend.py
@@ -24,6 +24,8 @@ class Vs2013Backend(Vs2010Backend):
         super().__init__(build, interpreter)
         self.name = 'vs2013'
         self.vs_version = '2013'
+        self.sln_file_version = '12.00'
+        self.sln_version_comment = '2013'
         if self.environment is not None:
             # TODO: we assume host == build
             comps = self.environment.coredata.compilers.host

--- a/mesonbuild/backend/vs2015backend.py
+++ b/mesonbuild/backend/vs2015backend.py
@@ -24,6 +24,8 @@ class Vs2015Backend(Vs2010Backend):
         super().__init__(build, interpreter)
         self.name = 'vs2015'
         self.vs_version = '2015'
+        self.sln_file_version = '12.00'
+        self.sln_version_comment = '14'
         if self.environment is not None:
             # TODO: we assume host == build
             comps = self.environment.coredata.compilers.host

--- a/mesonbuild/backend/vs2017backend.py
+++ b/mesonbuild/backend/vs2017backend.py
@@ -27,6 +27,8 @@ class Vs2017Backend(Vs2010Backend):
         super().__init__(build, interpreter)
         self.name = 'vs2017'
         self.vs_version = '2017'
+        self.sln_file_version = '12.00'
+        self.sln_version_comment = '15'
         # We assume that host == build
         if self.environment is not None:
             comps = self.environment.coredata.compilers.host

--- a/mesonbuild/backend/vs2019backend.py
+++ b/mesonbuild/backend/vs2019backend.py
@@ -25,6 +25,8 @@ class Vs2019Backend(Vs2010Backend):
     def __init__(self, build: T.Optional[Build], interpreter: T.Optional[Interpreter]):
         super().__init__(build, interpreter)
         self.name = 'vs2019'
+        self.sln_file_version = '12.00'
+        self.sln_version_comment = 'Version 16'
         if self.environment is not None:
             comps = self.environment.coredata.compilers.host
             if comps and all(c.id == 'clang-cl' for c in comps.values()):

--- a/mesonbuild/backend/vs2022backend.py
+++ b/mesonbuild/backend/vs2022backend.py
@@ -25,6 +25,8 @@ class Vs2022Backend(Vs2010Backend):
     def __init__(self, build: T.Optional[Build], interpreter: T.Optional[Interpreter]):
         super().__init__(build, interpreter)
         self.name = 'vs2022'
+        self.sln_file_version = '12.00'
+        self.sln_version_comment = 'Version 17'
         if self.environment is not None:
             comps = self.environment.coredata.compilers.host
             if comps and all(c.id == 'clang-cl' for c in comps.values()):


### PR DESCRIPTION
Visual Studio Version Selector is super fussy about the comment line in a solution. If wrong, you just get an arbitrary (or newest, or most recently installed, or whatever it might be...) VS launched when opening a solution.

- 2010 `# Visual Studio 2010`
- 2012 `# Visual Studio 2012`
- 2013 `# Visual Studio 2013`
- 2015 `# Visual Studio 14`
- 2017 `# Visual Studio 15`
- 2019 `# Visual Studio Version 16`
- 2022 `# Visual Studio Version 17`

(I'm actually not sure how far back VSVS would go, but these are the VS-created solution comments from each version.)

Couple of points:

1. I've also adjusted the `Format Version N` in the sln file as appropriate. This doesn't seem to be required for VSVS, but surely better to be closer to the "native" files.
2. Similarly, VS created solutions have the UTF-8 BOM and a blank line at the start, so this does similar. Note that if you don't want to do this, then VSVS will work but only if the blank line is removed! Good times.

Cheers