### PR TITLE
interpreter: fix `feature.require` handling of error message

### DIFF
--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -139,7 +139,8 @@ class FeatureOptionHolder(ObjectHolder[coredata.UserFeatureOption]):
         assert isinstance(error_message, str)
         if self.value == 'enabled':
             prefix = f'Feature {self.held_object.name} cannot be enabled'
-            prefix = prefix + ': ' if error_message else ''
+            if error_message:
+                prefix += ': '
             raise InterpreterException(prefix + error_message)
         return self.as_disabled()
 

--- a/test cases/failing/106 feature require.bis/meson.build
+++ b/test cases/failing/106 feature require.bis/meson.build
@@ -1,0 +1,2 @@
+project('no fallback', 'c')
+foo = get_option('reqfeature').require(false)

--- a/test cases/failing/106 feature require.bis/meson_options.txt
+++ b/test cases/failing/106 feature require.bis/meson_options.txt
@@ -1,0 +1,1 @@
+option('reqfeature', type : 'feature', value : 'enabled', description : 'A required feature')

--- a/test cases/failing/106 feature require.bis/test.json
+++ b/test cases/failing/106 feature require.bis/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+      "match": "re",
+      "line": ".*/meson\\.build:2:0: ERROR: Feature reqfeature cannot be enabled"
+    }
+  ]
+}


### PR DESCRIPTION
Don't show a blank error when no `error_message` was passed as argument.