### PR TITLE
fix BSD ldconfig handling

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -107,7 +107,7 @@ class CleanTrees:
         self.trees = trees
 
 class InstallData:
-    def __init__(self, source_dir: str, build_dir: str, prefix: str,
+    def __init__(self, source_dir: str, build_dir: str, prefix: str, libdir: str,
                  strip_bin: T.List[str], install_umask: T.Union[str, int],
                  mesonintrospect: T.List[str], version: str):
         # TODO: in python 3.8 or with typing_Extensions install_umask could be:
@@ -115,6 +115,7 @@ class InstallData:
         self.source_dir = source_dir
         self.build_dir = build_dir
         self.prefix = prefix
+        self.libdir = libdir
         self.strip_bin = strip_bin
         self.install_umask = install_umask
         self.targets: T.List[TargetInstallData] = []
@@ -1485,6 +1486,7 @@ class Backend:
         d = InstallData(self.environment.get_source_dir(),
                         self.environment.get_build_dir(),
                         self.environment.get_prefix(),
+                        self.environment.get_libdir(),
                         strip_bin,
                         umask,
                         self.environment.get_build_command() + ['introspect'],

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -252,7 +252,8 @@ def apply_ldconfig(dm: DirMaker, libdir: str) -> None:
         # If we don't have ldconfig, failure is ignored quietly.
         return
 
-    if 'bsd' in platform.system().lower():
+    platlower = platform.system().lower()
+    if platlower == 'dragonfly' or 'bsd' in platlower:
         if libdir in dm.all_dirs:
             proc, out, err = Popen_safe(['ldconfig', '-m', libdir])
             if proc.returncode != 0:


### PR DESCRIPTION
This fix comes in two parts:
- prevent ldconfig from running in a broken fashion
- add a new feature to use ldconfig -m and add the configured libdir

Fixes #9592


/cc @jbeich, thoughts?

At least the first commit should probably go into 0.60.2