### PR TITLE
iconv dependency: include header when checking for libc builtin

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -452,7 +452,7 @@ class IconvBuiltinDependency(BuiltinDependency):
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
 
-        if self.clib_compiler.has_function('iconv_open', '', env)[0]:
+        if self.clib_compiler.has_function('iconv_open', '#include <iconv.h>', env)[0]:
             self.is_found = True
 
 


### PR DESCRIPTION
This header is required anyway. And the compile test for linking to libc with the iconv_open symbol, can succeed when we try to use the literal symbol name without includes, but fail later during project build, because actually including iconv.h might redefine the function to match a forked symbol. This happens when GNU iconv is installed as a standalone library on systems that have a less fully-featured iconv implementation.

So, by including the header in has_function, we ensure that we test against the default resolved header. In the event that the symbol which is #define'd by the header is 'libiconv_open', linking will fail against libc even when a builtin iconv does exist, and we will fall back to the iconv dependency that provides -liconv (and which is needed to properly use the default header).

Fixes compiling against the iconv dependency on e.g. FreeBSD when the libiconv port is installed.