### PR TITLE
minstall: do not run ldconfig on the *BSDs

### DIFF
--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -18,6 +18,7 @@ import argparse
 import errno
 import os
 import pickle
+import platform
 import shlex
 import shutil
 import subprocess
@@ -249,6 +250,9 @@ def apply_ldconfig(dm: DirMaker) -> None:
     '''
     if not shutil.which('ldconfig'):
         # If we don't have ldconfig, failure is ignored quietly.
+        return
+
+    if 'bsd' in platform.system().lower():
         return
 
     # Try to update ld cache, it could fail if we don't have permission.


### PR DESCRIPTION
They don't utilize a soname cache, so running ldconfig without arguments
is basically pointless -- and at least some of them are buggy: running
ldconfig with the verbose flag switches on "delete all directories from
the hints file, and recreate it using 0 command-line positional
arguments", which would soft-brick the system.

Fixes #9592