### PR TITLE
Remove premature return in BuildTarget.check_module_linking()

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1588,7 +1588,7 @@ You probably should put it in link_with instead.''')
         Warn if shared modules are linked with target: (link_with) #2865
         '''
         for link_target in self.link_targets:
-            if isinstance(link_target, SharedModule):
+            if isinstance(link_target, SharedModule) and not link_target.backwards_compat_want_soname:
                 if self.environment.machines[self.for_machine].is_darwin():
                     raise MesonException(
                         f'target {self.name} links against shared module {link_target.name}. This is not permitted on OSX')
@@ -1601,7 +1601,6 @@ You probably should put it in link_with instead.''')
                             '\n             '
                             'use shared_libary() with `override_options: [\'b_lundef=false\']` instead.')
                     link_target.backwards_compat_want_soname = True
-                return
 
 class Generator(HoldableObject):
     def __init__(self, exe: T.Union['Executable', programs.ExternalProgram],


### PR DESCRIPTION
We want to loop over all link_targets to update
backwards_compat_want_soname if necessary.

Fixes: ec9bdc6edb17d1d9da5df2d6525025242c119f3a