### PR TITLE
iconv dependency: try even harder to find working iconv

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -451,8 +451,9 @@ class CursesSystemDependency(SystemDependency):
 class IconvBuiltinDependency(BuiltinDependency):
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
+        code = '''#include <iconv.h>\n\nint main() {\n    iconv_open("","");\n}''' # [ignore encoding] this is C, not python, Mr. Lint
 
-        if self.clib_compiler.has_function('iconv_open', '#include <iconv.h>', env)[0]:
+        if self.clib_compiler.links(code, env)[0]:
             self.is_found = True
 
 


### PR DESCRIPTION
has_function(prefix: '...') is useless to check the difference between builtins and external library functions. It has code to detect
"builtins" that misfires and reports that iconv_open is defined as a builtin on mingw, but only if you include the header.

Instead compile an open-coded test file that this iconv dependency implementation fully controls, that doesn't get up to imaginative edge cases like trying to find `__builtin_iconv_open`.

Fixes commit db1fa702f3943c6e4fec142b2bf5468c89173993, which merely moved the brokenness over one step to the right (by breaking mingw instead of freebsd)

Fixes https://github.com/mesonbuild/meson/pull/9632#issuecomment-979581509