### PR TITLE
Allow 'backend_startup_project' to refer to a variable.

### DIFF
--- a/docs/markdown/snippets/allow_variable_backend_startup_project.md
+++ b/docs/markdown/snippets/allow_variable_backend_startup_project.md
@@ -1,0 +1,13 @@
+## backend_startup_project can reference a target variable
+
+If the value of `backend_startup_project` is not the name of a target, it
+can be the name of a variable assigned to a target.
+
+This allows referencing a target that has an unknown name at the point
+default project options are specified:
+```
+project('startup_test', ['cpp'], default_options : ['backend_startup_project=b'])
+my_suffix = '_some_suffix_based_off_environment'
+a = executable('a' + my_suffix, 'main.cpp')
+b = executable('b' + my_suffix, 'main.cpp')
+```

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -447,11 +447,22 @@ class Vs2010Backend(backends.Backend):
 
     def generate_projects(self):
         startup_project = self.environment.coredata.options[OptionKey('backend_startup_project')].value
+        startup_target = None
+        try:
+            if startup_project:
+                startup_target = self.interpreter.get_variable(startup_project)
+        except MesonException:
+            pass
+
         projlist = []
         startup_idx = 0
         for (i, (name, target)) in enumerate(self.build.targets.items()):
-            if startup_project and startup_project == target.get_basename():
-                startup_idx = i
+            try:
+                if startup_project and ((startup_project == target.get_basename()) or (startup_target.op_equals(target))):
+                    startup_idx = i
+            except MesonException:
+                pass
+
             outdir = Path(
                 self.environment.get_build_dir(),
                 self.get_target_dir(target)


### PR DESCRIPTION
There's one last issue stopping `backend_startup_project` working for me: when a target's name is derived and not a trivial constant string, it can't be set in a project's default options.

I wondered if you'd consider allowing `backend_startup_project` to refer to a variable assigned to a target? E.g.

```
project('startup_test', ['cpp'], default_options : ['backend_startup_project=b'])
my_suffix = '_some_suffix_derived_from_environment'
a = executable('a' + my_suffix, 'main.cpp')
b = executable('b' + my_suffix, 'main.cpp')
```

Pretty simple mod attempted. I guess behaviour might change if there happened to be a variable with the same name as a later target's actual name, the earlier seen target would be selected as the default project. Pretty unlikely I'd have thought and not like it breaks anything "real"!

I haven't done a test as a) you might reject this out of hand and b) I can't see any existing ones for `backend_startup_project`. Plus c) it would have to parse a sln...

Thanks
