### PR TITLE
gnome module: document and fix install_dir x3, by allowing false *_gir and *_typelib

### DIFF
--- a/docs/markdown/Gnome-module.md
+++ b/docs/markdown/Gnome-module.md
@@ -104,9 +104,9 @@ There are several keyword arguments. Many of these map directly to the
 * `include_directories`: extra include paths to look for gir files
 * `install`: if true, install the generated files
 * `install_dir_gir`: (*Added 0.35.0*) which directory to install the
-  gir file into
+  gir file into; can be false to disable installation
 * `install_dir_typelib`: (*Added 0.35.0*) which directory to install
-  the typelib file into
+  the typelib file into; can be false to disable installation
 * `link_with`: list of libraries to link with
 * `symbol_prefix`: the symbol prefix for the gir object, e.g. `gtk`,
   (*Since 0.43.0*) an ordered list of multiple prefixes is allowed

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -801,13 +801,21 @@ class GnomeModule(ExtensionModule):
     def _make_gir_target(self, state: 'ModuleState', girfile: str, scan_command: T.List[str],
                          generated_files: T.Sequence[T.Union[str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList]],
                          depends: T.List[build.Target], kwargs: T.Dict[str, T.Any]) -> GirTarget:
+        install = kwargs['install']
+
+        install_dir = kwargs['install_dir_gir']
+        if install_dir is None:
+            install_dir = os.path.join(state.environment.get_datadir(), 'gir-1.0')
+        elif install_dir is False:
+            install = False
+
         scankwargs = {
             'input': generated_files,
             'output': girfile,
             'command': scan_command,
             'depends': depends,
-            'install': kwargs['install'],
-            'install_dir': kwargs['install_dir_gir'] or os.path.join(state.environment.get_datadir(), 'gir-1.0'),
+            'install': install,
+            'install_dir': install_dir,
             'install_tag': 'devel',
             'build_by_default': kwargs['build_by_default'],
         }
@@ -817,12 +825,20 @@ class GnomeModule(ExtensionModule):
     def _make_typelib_target(self, state: 'ModuleState', typelib_output: str, typelib_cmd: T.List[str],
                              generated_files: T.Sequence[T.Union[str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList]],
                              kwargs: T.Dict[str, T.Any]) -> TypelibTarget:
+        install = kwargs['install']
+
+        install_dir = kwargs['install_dir_typelib']
+        if install_dir is None:
+            install_dir = os.path.join(state.environment.get_libdir(), 'girepository-1.0')
+        elif install_dir is False:
+            install = False
+
         typelib_kwargs = {
             'input': generated_files,
             'output': [typelib_output],
             'command': typelib_cmd,
-            'install': kwargs['install'],
-            'install_dir': kwargs['install_dir_typelib'] or os.path.join(state.environment.get_libdir(), 'girepository-1.0'),
+            'install': install,
+            'install_dir': install_dir,
             'install_tag': 'typelib',
             'build_by_default': kwargs['build_by_default'],
         }
@@ -900,8 +916,10 @@ class GnomeModule(ExtensionModule):
         KwargInfo('identifier_prefix', ContainerTypeInfo(list, str), default=[], listify=True),
         KwargInfo('include_directories', ContainerTypeInfo(list, (str, build.IncludeDirs)), default=[], listify=True),
         KwargInfo('includes', ContainerTypeInfo(list, (str, GirTarget)), default=[], listify=True),
-        KwargInfo('install_dir_gir', (str, NoneType)),
-        KwargInfo('install_dir_typelib', (str, NoneType)),
+        KwargInfo('install_dir_gir', (str, bool, NoneType),
+            validator=lambda x: 'as boolean can only be false' if x is True else None),
+        KwargInfo('install_dir_typelib', (str, bool, NoneType),
+            validator=lambda x: 'as boolean can only be false' if x is True else None),
         KwargInfo('link_with', ContainerTypeInfo(list, (build.SharedLibrary, build.StaticLibrary)), default=[], listify=True),
         KwargInfo('namespace', str, required=True),
         KwargInfo('nsversion', str, required=True),

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -801,7 +801,9 @@ class GnomeModule(ExtensionModule):
     def _make_gir_target(self, state: 'ModuleState', girfile: str, scan_command: T.List[str],
                          generated_files: T.Sequence[T.Union[str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList]],
                          depends: T.List[build.Target], kwargs: T.Dict[str, T.Any]) -> GirTarget:
-        install = kwargs['install']
+        install = kwargs['install_gir']
+        if install is None:
+            install = kwargs['install']
 
         install_dir = kwargs['install_dir_gir']
         if install_dir is None:
@@ -825,7 +827,9 @@ class GnomeModule(ExtensionModule):
     def _make_typelib_target(self, state: 'ModuleState', typelib_output: str, typelib_cmd: T.List[str],
                              generated_files: T.Sequence[T.Union[str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList]],
                              kwargs: T.Dict[str, T.Any]) -> TypelibTarget:
-        install = kwargs['install']
+        install = kwargs['install_typelib']
+        if install is None:
+            install = kwargs['install']
 
         install_dir = kwargs['install_dir_typelib']
         if install_dir is None:
@@ -916,9 +920,13 @@ class GnomeModule(ExtensionModule):
         KwargInfo('identifier_prefix', ContainerTypeInfo(list, str), default=[], listify=True),
         KwargInfo('include_directories', ContainerTypeInfo(list, (str, build.IncludeDirs)), default=[], listify=True),
         KwargInfo('includes', ContainerTypeInfo(list, (str, GirTarget)), default=[], listify=True),
+        KwargInfo('install_gir', (bool, NoneType), since='0.61.0'),
         KwargInfo('install_dir_gir', (str, bool, NoneType),
+            deprecated_values={False: ('0.61.0', 'Use install_gir to disable installation')},
             validator=lambda x: 'as boolean can only be false' if x is True else None),
+        KwargInfo('install_typelib', (bool, NoneType), since='0.61.0'),
         KwargInfo('install_dir_typelib', (str, bool, NoneType),
+            deprecated_values={False: ('0.61.0', 'Use install_typelib to disable installation')},
             validator=lambda x: 'as boolean can only be false' if x is True else None),
         KwargInfo('link_with', ContainerTypeInfo(list, (build.SharedLibrary, build.StaticLibrary)), default=[], listify=True),
         KwargInfo('namespace', str, required=True),

--- a/test cases/frameworks/12 multiple gir/gir/meson.build
+++ b/test cases/frameworks/12 multiple gir/gir/meson.build
@@ -22,7 +22,8 @@ gnome.generate_gir(
   symbol_prefix : 'meson_sub_',
   identifier_prefix : 'MesonSub',
   includes : ['GObject-2.0', meson_gir],
-  install : true
+  install : true,
+  install_dir_gir: false,
 )
 
 message('TEST: ' + girsubproject.outdir())

--- a/test cases/frameworks/12 multiple gir/meson.build
+++ b/test cases/frameworks/12 multiple gir/meson.build
@@ -1,4 +1,4 @@
-project('multiple-gobject-introspection', 'c')
+project('multiple-gobject-introspection', 'c', meson_version: '>=0.50.0')
 
 gir = find_program('g-ir-scanner', required: false)
 if not gir.found()

--- a/test cases/frameworks/12 multiple gir/mesongir/meson.build
+++ b/test cases/frameworks/12 multiple gir/mesongir/meson.build
@@ -24,7 +24,8 @@ girtarget = gnome.generate_gir(
   identifier_prefix : 'Meson',
   includes : ['GObject-2.0'],
   export_packages : 'meson',
-  install : true
+  install : true,
+  install_gir: false,
 )
 meson_gir = girtarget[0]
 meson_typelib = girtarget[1]

--- a/test cases/frameworks/12 multiple gir/test.json
+++ b/test cases/frameworks/12 multiple gir/test.json
@@ -6,8 +6,7 @@
     {"type": "file", "platform": "cygwin", "file": "usr/lib/libgirlib.dll.a"},
     {"type": "expr", "file": "usr/lib/?libgirsubproject.so"},
     {"type": "file", "platform": "cygwin", "file": "usr/lib/libgirsubproject.dll.a"},
-    {"type": "file", "file": "usr/share/gir-1.0/Meson-1.0.gir"},
-    {"type": "file", "file": "usr/share/gir-1.0/MesonSub-1.0.gir"}
+    {"type": "file", "file": "usr/share/gir-1.0/Meson-1.0.gir"}
   ],
   "skip_on_jobname": ["azure", "macos", "msys2"]
 }

--- a/test cases/frameworks/12 multiple gir/test.json
+++ b/test cases/frameworks/12 multiple gir/test.json
@@ -5,8 +5,13 @@
     {"type": "expr", "file": "usr/lib/?libgirlib.so"},
     {"type": "file", "platform": "cygwin", "file": "usr/lib/libgirlib.dll.a"},
     {"type": "expr", "file": "usr/lib/?libgirsubproject.so"},
-    {"type": "file", "platform": "cygwin", "file": "usr/lib/libgirsubproject.dll.a"},
-    {"type": "file", "file": "usr/share/gir-1.0/Meson-1.0.gir"}
+    {"type": "file", "platform": "cygwin", "file": "usr/lib/libgirsubproject.dll.a"}
   ],
-  "skip_on_jobname": ["azure", "macos", "msys2"]
+  "skip_on_jobname": ["azure", "macos", "msys2"],
+  "stdout": [
+    {
+      "comment": "This will either match in the future-deprecated notice summary, or match the warning summary",
+      "line": " * 0.61.0: {'\"gnome.generate_gir\" keyword argument \"install_dir_gir\" value \"False\"'}"
+    }
+  ]
 }


### PR DESCRIPTION
generate_gir forces building both the typelib and gir, and some people only want one or the other (probably only the typelib?) which means flagging the other as install_dir: false in the same way custom_target supports.

As this always worked, albeit undocumented, make sure it keeps working. It's pretty reasonable to allow, anyway.

Fixes https://github.com/mesonbuild/meson/pull/9484#issuecomment-980131791