### PR TITLE
properly error out when project version is an array other than files()

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -104,8 +104,8 @@ def _project_version_validator(value: T.Union[T.List, str, mesonlib.File, None])
     if isinstance(value, list):
         if len(value) != 1:
             return 'when passed as array must have a length of 1'
-        elif not isinstance(value[0], (str, mesonlib.File)):
-            return 'when passed as array must contain a string or File'
+        elif not isinstance(value[0], mesonlib.File):
+            return 'when passed as array must contain a File'
     return None
 
 


### PR DESCRIPTION
Due to the support for specifying version as files('VERSION'), we need to internally accept an array, since that is what files() returns. Before that, we didn't accept arrays, and after that, we don't intend to accept generic arrays, only arrays as a side effect of files(). So tighten the typechecking to ensure that that is what we actually get.

See https://github.com/mesonbuild/meson/pull/9531#discussion_r757838111