### PR TITLE
cmake: Deprecate CMake <3.14 and warn for <3.17

### DIFF
--- a/docs/markdown/snippets/cmake_deprecated.md
+++ b/docs/markdown/snippets/cmake_deprecated.md
@@ -1,0 +1,7 @@
+## Support for CMake <3.14 is now deprecated for CMake subprojects
+
+In CMake 3.14, the File API was introduced and the old CMake server API was
+deprecated (and removed in CMake 3.20). Thus support for this API will also
+be removed from Meson in future releases.
+
+This deprecation only affects CMake subprojects.

--- a/mesonbuild/cmake/interpreter.py
+++ b/mesonbuild/cmake/interpreter.py
@@ -32,6 +32,7 @@ from functools import lru_cache
 from pathlib import Path
 import typing as T
 import re
+import textwrap
 from os import environ
 
 from ..mparser import (
@@ -903,6 +904,19 @@ class CMakeInterpreter:
         if version_compare(cmake_exe.version(), '>=3.14'):
             self.cmake_api = CMakeAPI.FILE
             self.fileapi.setup_request()
+        else:
+            mlog.deprecation(f'Support for CMake <3.14 (Meson found {cmake_exe.version()}) is deprecated since Meson 0.61.0')
+
+        if version_compare(cmake_exe.version(), '<3.17.0'):
+            mlog.warning(textwrap.dedent(f'''\
+                The minimum recommended CMake version is 3.17.0.
+                |
+                |   However, Meson was only able to find CMake {cmake_exe.version()} at {cmake_exe.cmakebin.command}.
+                |
+                |   Support for all CMake versions below 3.17.0 will be deprecated and
+                |   removed once newer CMake versions are more widely adopted. If you encounter
+                |   any errors please try upgrading CMake to a newer version first.
+            '''))
 
         # Run CMake
         mlog.log()


### PR DESCRIPTION
See:

- #7832
- #9676

I did *not* deprecate CMake <3.14 support for CMake dependencies, since it makes no difference because the CMake server API is not used. The only meaningful minimum version bump for CMake deps would be to 3.17.0