### PR TITLE
Add deprecation messages to KwargInfo deprecation and since

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Run pip
         run: |
           export PATH=/usr/bin:/usr/local/bin:$(cygpath ${SYSTEMROOT})/system32
-          python3 -m pip --disable-pip-version-check install gcovr jsonschema pefile pytest pytest-xdist coverage codecov
+          python3 -m pip --disable-pip-version-check install gcovr jsonschema pefile pytest pytest-subtests pytest-xdist coverage codecov
         shell: C:\cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
 
       - name: Run tests

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: '3.x'
     - run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest pytest-xdist jsonschema coverage codecov
+        python -m pip install pytest pytest-xdist pytest-subtests jsonschema coverage codecov
     - run: brew install pkg-config ninja llvm qt@5
     - env:
         CPPFLAGS: "-I/usr/local/include"

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python3 -m pip --disable-pip-version-check install gcovr jsonschema pefile pytest pytest-xdist coverage codecov
+          python3 -m pip --disable-pip-version-check install gcovr jsonschema pefile pytest pytest-subtests pytest-xdist coverage codecov
 
       - name: Run Tests
         run: |

--- a/ci/ciimage/common.sh
+++ b/ci/ciimage/common.sh
@@ -13,6 +13,7 @@ set -x
 base_python_pkgs=(
   pytest
   pytest-xdist
+  pytest-subtests
   coverage
   codecov
   jsonschema

--- a/ci/ciimage/ubuntu-rolling/install.sh
+++ b/ci/ciimage/ubuntu-rolling/install.sh
@@ -12,7 +12,6 @@ pkgs=(
   python3-pip libxml2-dev libxslt1-dev libyaml-dev libjson-glib-dev
   wget unzip
   qt5-qmake qtbase5-dev qtchooser qtbase5-dev-tools clang
-  pkg-config-arm-linux-gnueabihf
   libomp-dev
   llvm lcov
   dub ldc

--- a/ci/run.ps1
+++ b/ci/run.ps1
@@ -81,7 +81,7 @@ python --version
 
 # Needed for running unit tests in parallel.
 echo ""
-python -m pip --disable-pip-version-check install --upgrade pefile pytest-xdist jsonschema coverage
+python -m pip --disable-pip-version-check install --upgrade pefile pytest-xdist pytest-subtests jsonschema coverage
 
 echo ""
 echo "=== Start running tests ==="

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -362,7 +362,10 @@ class KwargInfo(T.Generic[_T]):
         this may be safely set to a mutable type, as long as that type does not
         itself contain mutable types, typed_kwargs will copy the default
     :param since: Meson version in which this argument has been added. defaults to None
+    :param since_message: An extra message to pass to FeatureNew when since is triggered
     :param deprecated: Meson version in which this argument has been deprecated. defaults to None
+    :param deprecated_message: An extra message to pass to FeatureDeprecated
+        when since is triggered
     :param validator: A callable that does additional validation. This is mainly
         intended for cases where a string is expected, but only a few specific
         values are accepted. Must return None if the input is valid, or a
@@ -384,8 +387,10 @@ class KwargInfo(T.Generic[_T]):
                  *, required: bool = False, listify: bool = False,
                  default: T.Optional[_T] = None,
                  since: T.Optional[str] = None,
-                 since_values: T.Optional[T.Dict[str, str]] = None,
+                 since_message: T.Optional[str] = None,
+                 since_values: T.Optional[T.Dict[_T, str]] = None,
                  deprecated: T.Optional[str] = None,
+                 deprecated_message: T.Optional[str] = None,
                  deprecated_values: T.Optional[T.Dict[_T, str]] = None,
                  validator: T.Optional[T.Callable[[T.Any], T.Optional[str]]] = None,
                  convertor: T.Optional[T.Callable[[_T], object]] = None,
@@ -395,9 +400,11 @@ class KwargInfo(T.Generic[_T]):
         self.required = required
         self.listify = listify
         self.default = default
-        self.since_values = since_values
         self.since = since
+        self.since_message = since_message
+        self.since_values = since_values
         self.deprecated = deprecated
+        self.deprecated_message = deprecated_message
         self.deprecated_values = deprecated_values
         self.validator = validator
         self.convertor = convertor
@@ -409,9 +416,11 @@ class KwargInfo(T.Generic[_T]):
                listify: T.Union[bool, _NULL_T] = _NULL,
                default: T.Union[_T, None, _NULL_T] = _NULL,
                since: T.Union[str, None, _NULL_T] = _NULL,
-               since_values: T.Union[T.Dict[str, str], None, _NULL_T] = _NULL,
+               since_message: T.Union[str, None, _NULL_T] = _NULL,
+               since_values: T.Union[T.Dict[_T, str], None, _NULL_T] = _NULL,
                deprecated: T.Union[str, None, _NULL_T] = _NULL,
-               deprecated_values: T.Union[T.Dict[str, str], None, _NULL_T] = _NULL,
+               deprecated_message: T.Union[str, None, _NULL_T] = _NULL,
+               deprecated_values: T.Union[T.Dict[_T, str], None, _NULL_T] = _NULL,
                validator: T.Union[T.Callable[[_T], T.Optional[str]], None, _NULL_T] = _NULL,
                convertor: T.Union[T.Callable[[_T], TYPE_var], None, _NULL_T] = _NULL) -> 'KwargInfo':
         """Create a shallow copy of this KwargInfo, with modifications.
@@ -432,8 +441,10 @@ class KwargInfo(T.Generic[_T]):
             required=required if not isinstance(required, _NULL_T) else self.required,
             default=default if not isinstance(default, _NULL_T) else self.default,
             since=since if not isinstance(since, _NULL_T) else self.since,
+            since_message=since_message if not isinstance(since_message, _NULL_T) else self.since_message,
             since_values=since_values if not isinstance(since_values, _NULL_T) else self.since_values,
             deprecated=deprecated if not isinstance(deprecated, _NULL_T) else self.deprecated,
+            deprecated_message=deprecated_message if not isinstance(deprecated_message, _NULL_T) else self.deprecated_message,
             deprecated_values=deprecated_values if not isinstance(deprecated_values, _NULL_T) else self.deprecated_values,
             validator=validator if not isinstance(validator, _NULL_T) else self.validator,
             convertor=convertor if not isinstance(convertor, _NULL_T) else self.convertor,
@@ -508,10 +519,10 @@ def typed_kwargs(name: str, *types: KwargInfo) -> T.Callable[..., T.Any]:
                 if value is not None:
                     if info.since:
                         feature_name = info.name + ' arg in ' + name
-                        FeatureNew.single_use(feature_name, info.since, subproject, location=node)
+                        FeatureNew.single_use(feature_name, info.since, subproject, info.since_message, location=node)
                     if info.deprecated:
                         feature_name = info.name + ' arg in ' + name
-                        FeatureDeprecated.single_use(feature_name, info.deprecated, subproject, location=node)
+                        FeatureDeprecated.single_use(feature_name, info.deprecated, subproject, info.deprecated_message, location=node)
                     if info.listify:
                         kwargs[info.name] = value = mesonlib.listify(value)
                     if not check_value_type(types_tuple, value):

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -372,7 +372,8 @@ class KwargInfo(T.Generic[_T]):
         string, but the implementation using an Enum. This should not do
         validation, just conversion.
     :param deprecated_values: a dictionary mapping a value to the version of
-        meson it was deprecated in.
+        meson it was deprecated in. The Value may be any valid value for this
+        argument.
     :param since_values: a dictionary mapping a value to the version of meson it was
         added in.
     :param not_set_warning: A warning message that is logged if the kwarg is not
@@ -385,7 +386,7 @@ class KwargInfo(T.Generic[_T]):
                  since: T.Optional[str] = None,
                  since_values: T.Optional[T.Dict[str, str]] = None,
                  deprecated: T.Optional[str] = None,
-                 deprecated_values: T.Optional[T.Dict[str, str]] = None,
+                 deprecated_values: T.Optional[T.Dict[_T, str]] = None,
                  validator: T.Optional[T.Callable[[T.Any], T.Optional[str]]] = None,
                  convertor: T.Optional[T.Callable[[_T], object]] = None,
                  not_set_warning: T.Optional[str] = None):

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1378,6 +1378,7 @@ class InternalTests(unittest.TestCase):
             'testfunc',
             KwargInfo('input', ContainerTypeInfo(list, str), listify=True, default=[], deprecated_values={'foo': '0.9'}, since_values={'bar': '1.1'}),
             KwargInfo('output', ContainerTypeInfo(dict, str), default={}, deprecated_values={'foo': '0.9'}, since_values={'bar': '1.1'}),
+            KwargInfo('install_dir', (bool, str, NoneType), deprecated_values={False: '0.9'}),
             KwargInfo(
                 'mode',
                 (str, type(None)),
@@ -1401,6 +1402,10 @@ class InternalTests(unittest.TestCase):
         with mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'output': {'foo': 'a'}})
             self.assertRegex(out.getvalue(), r"""WARNING:.Project targeting '1.0'.*deprecated since '0.9': "testfunc" keyword argument "output" value "foo".*""")
+
+        with mock.patch('sys.stdout', io.StringIO()) as out:
+            _(None, mock.Mock(subproject=''), [], {'install_dir': False})
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targeting '1.0'.*deprecated since '0.9': "testfunc" keyword argument "install_dir" value "False".*""")
 
         with mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'output': {'bar': 'b'}})

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1374,7 +1374,7 @@ class InternalTests(unittest.TestCase):
 
         _(None, mock.Mock(), tuple(), dict(native=True))
 
-    @mock.patch.dict(mesonbuild.mesonlib.project_meson_versions, {})
+    @mock.patch('mesonbuild.mesonlib.project_meson_versions', {'': '1.0'})
     def test_typed_kwarg_since_values(self) -> None:
         @typed_kwargs(
             'testfunc',
@@ -1391,33 +1391,31 @@ class InternalTests(unittest.TestCase):
         def _(obj, node, args: T.Tuple, kwargs: T.Dict[str, str]) -> None:
             pass
 
-        mesonbuild.mesonlib.project_meson_versions[''] = '1.0'
-
-        with mock.patch('sys.stdout', io.StringIO()) as out:
+        with self.subTest('deprecated array string value'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'input': ['foo']})
             self.assertRegex(out.getvalue(), r"""WARNING:.Project targeting '1.0'.*deprecated since '0.9': "testfunc" keyword argument "input" value "foo".*""")
 
-        with mock.patch('sys.stdout', io.StringIO()) as out:
+        with self.subTest('new array string value'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'input': ['bar']})
             self.assertRegex(out.getvalue(), r"""WARNING:.Project targeting '1.0'.*introduced in '1.1': "testfunc" keyword argument "input" value "bar".*""")
 
-        with mock.patch('sys.stdout', io.StringIO()) as out:
+        with self.subTest('deprecated dict string value'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'output': {'foo': 'a'}})
             self.assertRegex(out.getvalue(), r"""WARNING:.Project targeting '1.0'.*deprecated since '0.9': "testfunc" keyword argument "output" value "foo".*""")
 
-        with mock.patch('sys.stdout', io.StringIO()) as out:
-            _(None, mock.Mock(subproject=''), [], {'install_dir': False})
-            self.assertRegex(out.getvalue(), r"""WARNING:.Project targeting '1.0'.*deprecated since '0.9': "testfunc" keyword argument "install_dir" value "False".*""")
-
-        with mock.patch('sys.stdout', io.StringIO()) as out:
+        with self.subTest('new dict string value'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'output': {'bar': 'b'}})
             self.assertRegex(out.getvalue(), r"""WARNING:.Project targeting '1.0'.*introduced in '1.1': "testfunc" keyword argument "output" value "bar".*""")
 
-        with mock.patch('sys.stdout', io.StringIO()) as out:
+        with self.subTest('non string union'), mock.patch('sys.stdout', io.StringIO()) as out:
+            _(None, mock.Mock(subproject=''), [], {'install_dir': False})
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targeting '1.0'.*deprecated since '0.9': "testfunc" keyword argument "install_dir" value "False".*""")
+
+        with self.subTest('deprecated string union'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'mode': 'deprecated'})
             self.assertRegex(out.getvalue(), r"""WARNING:.Project targeting '1.0'.*deprecated since '1.0': "testfunc" keyword argument "mode" value "deprecated".*""")
 
-        with mock.patch('sys.stdout', io.StringIO()) as out:
+        with self.subTest('new string union'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'mode': 'since'})
             self.assertRegex(out.getvalue(), r"""WARNING:.Project targeting '1.0'.*introduced in '1.1': "testfunc" keyword argument "mode" value "since".*""")
 

--- a/unittests/internaltests.py
+++ b/unittests/internaltests.py
@@ -1379,7 +1379,7 @@ class InternalTests(unittest.TestCase):
         @typed_kwargs(
             'testfunc',
             KwargInfo('input', ContainerTypeInfo(list, str), listify=True, default=[], deprecated_values={'foo': '0.9'}, since_values={'bar': '1.1'}),
-            KwargInfo('output', ContainerTypeInfo(dict, str), default={}, deprecated_values={'foo': '0.9'}, since_values={'bar': '1.1'}),
+            KwargInfo('output', ContainerTypeInfo(dict, str), default={}, deprecated_values={'foo': '0.9', 'foo2': ('0.9', 'dont use it')}, since_values={'bar': '1.1', 'bar2': ('1.1', 'use this')}),
             KwargInfo('install_dir', (bool, str, NoneType), deprecated_values={False: '0.9'}),
             KwargInfo(
                 'mode',
@@ -1403,9 +1403,17 @@ class InternalTests(unittest.TestCase):
             _(None, mock.Mock(subproject=''), [], {'output': {'foo': 'a'}})
             self.assertRegex(out.getvalue(), r"""WARNING:.Project targeting '1.0'.*deprecated since '0.9': "testfunc" keyword argument "output" value "foo".*""")
 
+        with self.subTest('deprecated dict string value with msg'), mock.patch('sys.stdout', io.StringIO()) as out:
+            _(None, mock.Mock(subproject=''), [], {'output': {'foo2': 'a'}})
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targeting '1.0'.*deprecated since '0.9': "testfunc" keyword argument "output" value "foo2". dont use it.*""")
+
         with self.subTest('new dict string value'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'output': {'bar': 'b'}})
             self.assertRegex(out.getvalue(), r"""WARNING:.Project targeting '1.0'.*introduced in '1.1': "testfunc" keyword argument "output" value "bar".*""")
+
+        with self.subTest('new dict string value with msg'), mock.patch('sys.stdout', io.StringIO()) as out:
+            _(None, mock.Mock(subproject=''), [], {'output': {'bar2': 'a'}})
+            self.assertRegex(out.getvalue(), r"""WARNING:.Project targeting '1.0'.*introduced in '1.1': "testfunc" keyword argument "output" value "bar2". use this.*""")
 
         with self.subTest('non string union'), mock.patch('sys.stdout', io.StringIO()) as out:
             _(None, mock.Mock(subproject=''), [], {'install_dir': False})


### PR DESCRIPTION
TypedKwarg currently doesn't allow an extra message to be passed when it uses FeatureDeprecated or FeatureNew, which is not commonly needed, but is needed sometimes. This series adds support for that.