### PR TITLE
don't spew pathlib internal state if $HOME is not readable

### DIFF
--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -349,8 +349,11 @@ class CMakeDependency(ExternalDependency):
         # Check the Linux CMake registry
         linux_reg = Path.home() / '.cmake' / 'packages'
         for p in [linux_reg / name, linux_reg / lname]:
-            if p.exists():
-                return True
+            try:
+                if p.exists():
+                    return True
+            except PermissionError:
+                continue
 
         return False
 


### PR DESCRIPTION
For some reason, pathlib raises tracebacks when exists() fails due to permission errors. This is obviously wrong, and worse, unfriendly; use the sane os.path.exists() behavior and return "doesn't exist".