### PR TITLE
modules/qt: compeil_resources allow name to be unset

### DIFF
--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -277,7 +277,7 @@ class QtBaseModule(ExtensionModule):
     @noPosargs
     @typed_kwargs(
         'qt.compile_resources',
-        KwargInfo('name', str),
+        KwargInfo('name', (str, NoneType)),
         KwargInfo(
             'sources',
             ContainerTypeInfo(list, (File, str, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList), allow_empty=False),


### PR DESCRIPTION
Originally name should have been set to required=True, but since then
the requirement to name CustomTargets (which compile_resources is a
wrapper around) has been dropped. As such we just need to allow the
default value of None through.

Fixes: #9698