### PR TITLE
Clean up gnome mkenums, and use typed_kwargs

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -754,7 +754,7 @@ class GnomeModule(ExtensionModule):
 
         return ret
 
-    def _scan_gir_targets(self, state: 'ModuleState', girtargets: T.List[build.BuildTarget]) -> T.List[T.Union[str, build.Executable]]:
+    def _scan_gir_targets(self, state: 'ModuleState', girtargets: T.Sequence[build.BuildTarget]) -> T.List[T.Union[str, build.Executable]]:
         ret: T.List[T.Union[str, build.Executable]] = []
 
         for girtarget in girtargets:
@@ -806,7 +806,7 @@ class GnomeModule(ExtensionModule):
             ret += girtarget.get_external_deps()
         return ret
 
-    def _get_gir_targets_inc_dirs(self, girtargets: T.List[build.BuildTarget]) -> T.List[build.IncludeDirs]:
+    def _get_gir_targets_inc_dirs(self, girtargets: T.Sequence[build.BuildTarget]) -> T.List[build.IncludeDirs]:
         ret: T.List[build.IncludeDirs] = []
         for girtarget in girtargets:
             ret += girtarget.get_include_dirs()
@@ -841,7 +841,7 @@ class GnomeModule(ExtensionModule):
         return cflags, internal_ldflags, external_ldflags
 
     def _make_gir_filelist(self, state: 'ModuleState', srcdir: str, ns: str,
-                           nsversion: str, girtargets: T.List[build.BuildTarget],
+                           nsversion: str, girtargets: T.Sequence[build.BuildTarget],
                            libsources: T.Sequence[T.Union[
                                str, mesonlib.File, build.GeneratedList,
                                build.CustomTarget, build.CustomTargetIndex]]

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1493,7 +1493,7 @@ class GnomeModule(ExtensionModule):
 
         cmd = []
         known_kwargs = ['comments', 'eprod', 'fhead', 'fprod', 'ftail',
-                        'identifier_prefix', 'symbol_prefix', 'template',
+                        'identifier_prefix', 'symbol_prefix',
                         'vhead', 'vprod', 'vtail']
         known_custom_target_kwargs = ['install_dir', 'build_always',
                                       'depends', 'depend_files']
@@ -1506,18 +1506,10 @@ class GnomeModule(ExtensionModule):
                 c_template = value
                 if isinstance(c_template, mesonlib.File):
                     c_template = c_template.absolute_path(state.environment.source_dir, state.environment.build_dir)
-                if 'template' in kwargs:
-                    raise MesonException('Mkenums does not accept both '
-                                         'c_template and template keyword '
-                                         'arguments at the same time.')
             elif arg == 'h_template':
                 h_template = value
                 if isinstance(h_template, mesonlib.File):
                     h_template = h_template.absolute_path(state.environment.source_dir, state.environment.build_dir)
-                if 'template' in kwargs:
-                    raise MesonException('Mkenums does not accept both '
-                                         'h_template and template keyword '
-                                         'arguments at the same time.')
             elif arg == 'install_header':
                 install_header = value
             elif arg in known_kwargs:


### PR DESCRIPTION
this makes two sets of distinct changes
1. it cleans up mkenums and mkenums_simple so that they don't call into each other
2. it uses typed_kwargs for both of them

This is currently based on #9594, and that should be reviewed and merged first.

This does not fix all the type issues in the gnome module, I'll follow this up with another series to address that separately, but this does get us complete typed_pos_args and typed_kwargs coverage