### PR TITLE
Fully type check the gnome module

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1058,7 +1058,7 @@ class Backend:
         tests.
         """
         result: T.Set[str] = set()
-        prospectives: T.Set[build.Target] = set()
+        prospectives: T.Set[T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex]] = set()
         if isinstance(target, build.BuildTarget):
             prospectives.update(target.get_transitive_link_deps())
             # External deps

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1001,11 +1001,11 @@ class BuildTarget(Target):
         return ExtractedObjects(self, self.sources, self.generated, self.objects,
                                 recursive)
 
-    def get_all_link_deps(self) -> 'ImmutableListProtocol[Target]':
+    def get_all_link_deps(self) -> 'ImmutableListProtocol[T.Union[BuildTarget, CustomTarget, CustomTargetIndex]]':
         return self.get_transitive_link_deps()
 
     @lru_cache(maxsize=None)
-    def get_transitive_link_deps(self) -> 'ImmutableListProtocol[Target]':
+    def get_transitive_link_deps(self) -> 'ImmutableListProtocol[T.Union[BuildTarget, CustomTarget, CustomTargetIndex]]':
         result: T.List[Target] = []
         for i in self.link_targets:
             result += i.get_all_link_deps()

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2610,7 +2610,7 @@ class RunTarget(Target, CommandBase):
 
     def __init__(self, name: str,
                  command: T.Sequence[T.Union[str, File, BuildTarget, 'CustomTarget', 'CustomTargetIndex', programs.ExternalProgram]],
-                 dependencies: T.Sequence[T.Union[BuildTarget, 'CustomTarget']],
+                 dependencies: T.Sequence[Target],
                  subdir: str,
                  subproject: str,
                  env: T.Optional['EnvironmentVariables'] = None):
@@ -2654,7 +2654,7 @@ class RunTarget(Target, CommandBase):
         return "@run"
 
 class AliasTarget(RunTarget):
-    def __init__(self, name: str, dependencies: T.Sequence[T.Union[BuildTarget, 'CustomTarget']],
+    def __init__(self, name: str, dependencies: T.Sequence['Target'],
                  subdir: str, subproject: str):
         super().__init__(name, [], dependencies, subdir, subproject)
 

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -29,7 +29,7 @@ from ..interpreterbase import FeatureDeprecated
 if T.TYPE_CHECKING:
     from ..compilers.compilers import Compiler
     from ..environment import Environment
-    from ..build import BuildTarget, CustomTarget
+    from ..build import BuildTarget, CustomTarget, IncludeDirs
     from ..mesonlib import FileOrString
 
 
@@ -216,9 +216,10 @@ class Dependency(HoldableObject):
         return new_dep
 
 class InternalDependency(Dependency):
-    def __init__(self, version: str, incdirs: T.List[str], compile_args: T.List[str],
-                 link_args: T.List[str], libraries: T.List['BuildTarget'],
-                 whole_libraries: T.List['BuildTarget'],
+    def __init__(self, version: str, incdirs: T.List['IncludeDirs'], compile_args: T.List[str],
+                 link_args: T.List[str],
+                 libraries: T.List[T.Union['BuildTarget', 'CustomTarget']],
+                 whole_libraries: T.List[T.Union['BuildTarget', 'CustomTarget']],
                  sources: T.Sequence[T.Union['FileOrString', 'CustomTarget']],
                  ext_deps: T.List[Dependency], variables: T.Dict[str, T.Any]):
         super().__init__(DependencyTypeName('internal'), {})

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -16,6 +16,7 @@
 functionality such as gobject-introspection, gresources and gtk-doc'''
 
 import copy
+import itertools
 import functools
 import os
 import subprocess
@@ -1106,7 +1107,7 @@ class GnomeModule(ExtensionModule):
         scan_command += scan_cflags
         scan_command += ['--cflags-end']
         scan_command += state.get_include_args(inc_dirs)
-        scan_command += state.get_include_args(list(gi_includes) + gir_inc_dirs + inc_dirs, prefix='--add-include-path=')
+        scan_command += state.get_include_args(itertools.chain(gi_includes, gir_inc_dirs, inc_dirs), prefix='--add-include-path=')
         scan_command += list(scan_internal_ldflags)
         scan_command += self._scan_gir_targets(state, girtargets)
         scan_command += self._scan_langs(state, [lc[0] for lc in langs_compilers])

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1958,7 +1958,7 @@ class GnomeModule(ExtensionModule):
         KwargInfo('packages', ContainerTypeInfo(list, (str, InternalDependency)), listify=True, default=[]),
     )
     def generate_vapi(self, state: 'ModuleState', args: T.Tuple[str], kwargs: 'GenerateVapi') -> ModuleReturnValue:
-        created_values: T.List[Dependency] = []
+        created_values: T.List[T.Union[Dependency, build.Data]] = []
         library = args[0]
         build_dir = os.path.join(state.environment.get_build_dir(), state.subdir)
         source_dir = os.path.join(state.environment.get_source_dir(), state.subdir)

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1795,7 +1795,8 @@ class GnomeModule(ExtensionModule):
             *,
             install: bool = False,
             install_dir: T.Optional[T.Sequence[T.Union[str, bool]]] = None,
-            depends: T.Optional[T.List[CustomTarget]] = None) -> build.CustomTarget:
+            depends: T.Optional[T.Sequence[T.Union[CustomTarget, CustomTargetIndex, BuildTarget]]] = None
+            ) -> build.CustomTarget:
         real_cmd: T.List[T.Union[str, ExternalProgram]] = [state.find_program(['glib-mkenums', 'mkenums'])]
         real_cmd.extend(cmd)
         custom_kwargs = {
@@ -1805,7 +1806,7 @@ class GnomeModule(ExtensionModule):
             'command': real_cmd,
             'install': install,
             'install_dir': install_dir or state.environment.coredata.get_option(mesonlib.OptionKey('includedir')),
-            'depends': depends or [],
+            'depends': list(depends or []),
         }
         return build.CustomTarget(output, state.subdir, state.subproject, custom_kwargs,
                                   # https://github.com/mesonbuild/meson/issues/973

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -521,8 +521,9 @@ class GnomeModule(ExtensionModule):
         rv = [target_c, target_h]
         return ModuleReturnValue(rv, rv)
 
+    @staticmethod
     def _get_gresource_dependencies(
-            self, state: 'ModuleState', input_file: str, source_dirs: T.List[str],
+            state: 'ModuleState', input_file: str, source_dirs: T.List[str],
             dependencies: T.Sequence[T.Union[mesonlib.File, build.CustomTarget, build.CustomTargetIndex]]
             ) -> T.Tuple[T.List[mesonlib.FileOrString], T.List[T.Union[build.CustomTarget, build.CustomTargetIndex]], T.List[str]]:
 
@@ -763,7 +764,8 @@ class GnomeModule(ExtensionModule):
         return p.returncode == 0 and option in o
 
     # May mutate depends and gir_inc_dirs
-    def _scan_include(self, state: 'ModuleState', includes: T.List[T.Union[str, GirTarget]]
+    @staticmethod
+    def _scan_include(state: 'ModuleState', includes: T.List[T.Union[str, GirTarget]]
                       ) -> T.Tuple[T.List[str], T.List[str], T.List[GirTarget]]:
         ret: T.List[str] = []
         gir_inc_dirs: T.List[str] = []
@@ -779,7 +781,8 @@ class GnomeModule(ExtensionModule):
 
         return ret, gir_inc_dirs, depends
 
-    def _scan_langs(self, state: 'ModuleState', langs: T.Iterable[str]) -> T.List[str]:
+    @staticmethod
+    def _scan_langs(state: 'ModuleState', langs: T.Iterable[str]) -> T.List[str]:
         ret: T.List[str] = []
 
         for lang in langs:
@@ -790,7 +793,8 @@ class GnomeModule(ExtensionModule):
 
         return ret
 
-    def _scan_gir_targets(self, state: 'ModuleState', girtargets: T.Sequence[build.BuildTarget]) -> T.List[T.Union[str, build.Executable]]:
+    @staticmethod
+    def _scan_gir_targets(state: 'ModuleState', girtargets: T.Sequence[build.BuildTarget]) -> T.List[T.Union[str, build.Executable]]:
         ret: T.List[T.Union[str, build.Executable]] = []
 
         for girtarget in girtargets:
@@ -823,7 +827,8 @@ class GnomeModule(ExtensionModule):
 
         return ret
 
-    def _get_girtargets_langs_compilers(self, girtargets: T.Sequence[build.BuildTarget]) -> T.List[T.Tuple[str, 'Compiler']]:
+    @staticmethod
+    def _get_girtargets_langs_compilers(girtargets: T.Sequence[build.BuildTarget]) -> T.List[T.Tuple[str, 'Compiler']]:
         ret: T.List[T.Tuple[str, 'Compiler']] = []
         for girtarget in girtargets:
             for lang, compiler in girtarget.compilers.items():
@@ -834,7 +839,8 @@ class GnomeModule(ExtensionModule):
 
         return ret
 
-    def _get_gir_targets_deps(self, girtargets: T.Sequence[build.BuildTarget]
+    @staticmethod
+    def _get_gir_targets_deps(girtargets: T.Sequence[build.BuildTarget]
                               ) -> T.List[T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex, Dependency]]:
         ret: T.List[T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex, Dependency]] = []
         for girtarget in girtargets:
@@ -842,13 +848,15 @@ class GnomeModule(ExtensionModule):
             ret += girtarget.get_external_deps()
         return ret
 
-    def _get_gir_targets_inc_dirs(self, girtargets: T.Sequence[build.BuildTarget]) -> T.List[build.IncludeDirs]:
+    @staticmethod
+    def _get_gir_targets_inc_dirs(girtargets: T.Sequence[build.BuildTarget]) -> T.List[build.IncludeDirs]:
         ret: T.List[build.IncludeDirs] = []
         for girtarget in girtargets:
             ret += girtarget.get_include_dirs()
         return ret
 
-    def _get_langs_compilers_flags(self, state: 'ModuleState', langs_compilers: T.List[T.Tuple[str, 'Compiler']]
+    @staticmethod
+    def _get_langs_compilers_flags(state: 'ModuleState', langs_compilers: T.List[T.Tuple[str, 'Compiler']]
                                    ) -> T.Tuple[T.List[str], T.List[str], T.List[str]]:
         cflags: T.List[str] = []
         internal_ldflags: T.List[str] = []
@@ -876,7 +884,8 @@ class GnomeModule(ExtensionModule):
 
         return cflags, internal_ldflags, external_ldflags
 
-    def _make_gir_filelist(self, state: 'ModuleState', srcdir: str, ns: str,
+    @staticmethod
+    def _make_gir_filelist(state: 'ModuleState', srcdir: str, ns: str,
                            nsversion: str, girtargets: T.Sequence[build.BuildTarget],
                            libsources: T.Sequence[T.Union[
                                str, mesonlib.File, build.GeneratedList,
@@ -904,8 +913,8 @@ class GnomeModule(ExtensionModule):
 
         return gir_filelist_filename
 
+    @staticmethod
     def _make_gir_target(
-            self,
             state: 'ModuleState',
             girfile: str,
             scan_command: T.Sequence[T.Union['FileOrString', Executable, ExternalProgram, OverrideProgram]],
@@ -935,7 +944,8 @@ class GnomeModule(ExtensionModule):
 
         return GirTarget(girfile, state.subdir, state.subproject, scankwargs)
 
-    def _make_typelib_target(self, state: 'ModuleState', typelib_output: str,
+    @staticmethod
+    def _make_typelib_target(state: 'ModuleState', typelib_output: str,
                              typelib_cmd: T.Sequence[T.Union[str, build.Executable, ExternalProgram, build.CustomTarget]],
                              generated_files: T.Sequence[T.Union[str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList]],
                              kwargs: T.Dict[str, T.Any]) -> TypelibTarget:
@@ -961,8 +971,9 @@ class GnomeModule(ExtensionModule):
 
         return TypelibTarget(typelib_output, state.subdir, state.subproject, typelib_kwargs)
 
+    @staticmethod
     def _gather_typelib_includes_and_update_depends(
-            self, state: 'ModuleState',
+            state: 'ModuleState',
             deps: T.Sequence[T.Union[Dependency, build.BuildTarget, build.CustomTarget, build.CustomTargetIndex]],
             depends: T.Sequence[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString']]
             ) -> T.Tuple[T.List[str], T.List[T.Union[build.BuildTarget, 'build.GeneratedTypes', 'FileOrString']]]:
@@ -1001,7 +1012,8 @@ class GnomeModule(ExtensionModule):
                     typelib_includes.append(girdir)
         return typelib_includes, new_depends
 
-    def _get_external_args_for_langs(self, state: 'ModuleState', langs: T.Sequence[str]) -> T.List[str]:
+    @staticmethod
+    def _get_external_args_for_langs(state: 'ModuleState', langs: T.Sequence[str]) -> T.List[str]:
         ret: T.List[str] = []
         for lang in langs:
             ret += mesonlib.listify(state.environment.coredata.get_external_args(MachineChoice.HOST, lang))

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -935,7 +935,8 @@ class GnomeModule(ExtensionModule):
 
         return GirTarget(girfile, state.subdir, state.subproject, scankwargs)
 
-    def _make_typelib_target(self, state: 'ModuleState', typelib_output: str, typelib_cmd: T.List[str],
+    def _make_typelib_target(self, state: 'ModuleState', typelib_output: str,
+                             typelib_cmd: T.Sequence[T.Union[str, build.Executable, ExternalProgram, build.CustomTarget]],
                              generated_files: T.Sequence[T.Union[str, mesonlib.File, build.CustomTarget, build.CustomTargetIndex, build.GeneratedList]],
                              kwargs: T.Dict[str, T.Any]) -> TypelibTarget:
         install = kwargs['install_typelib']
@@ -951,7 +952,7 @@ class GnomeModule(ExtensionModule):
         typelib_kwargs = {
             'input': generated_files,
             'output': [typelib_output],
-            'command': typelib_cmd,
+            'command': list(typelib_cmd),
             'install': install,
             'install_dir': install_dir,
             'install_tag': 'typelib',
@@ -1150,7 +1151,7 @@ class GnomeModule(ExtensionModule):
         for incdir in typelib_includes:
             typelib_cmd += ["--includedir=" + incdir]
 
-        typelib_target = self._make_typelib_target(state, typelib_output, typelib_cmd, generated_files, kwargs)
+        typelib_target = self._make_typelib_target(state, typelib_output, typelib_cmd, generated_files, T.cast(T.Dict[str, T.Any], kwargs))
 
         self._devenv_prepend('GI_TYPELIB_PATH', os.path.join(state.environment.get_build_dir(), state.subdir))
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1213,7 +1213,7 @@ class GnomeModule(ExtensionModule):
 
         media = kwargs['media']
         symlinks = kwargs['symlink_media']
-        targets: T.List[T.Union['Target', build.Data, build.SymlinkData]] = []
+        targets: T.List[T.Union['build.Target', build.Data, build.SymlinkData]] = []
         potargets: T.List[build.RunTarget] = []
 
         itstool = state.find_program('itstool')

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -310,7 +310,10 @@ class GnomeModule(ExtensionModule):
     def _get_dep(self, state: 'ModuleState', depname: str, native: bool = False,
                  required: bool = True) -> Dependency:
         kwargs = {'native': native, 'required': required}
-        return self.interpreter.func_dependency(state.current_node, [depname], kwargs)
+        # FIXME: Even if we fix the function, mypy still can't figure out what's
+        # going on here. And we really dont want to call interpreter
+        # implementations of meson functions anyway.
+        return self.interpreter.func_dependency(state.current_node, [depname], kwargs)  # type: ignore
 
     def _get_native_binary(self, state: 'ModuleState', name: str, depname: str,
                            varname: str, required: bool = True) -> T.Union[ExternalProgram, OverrideProgram, 'build.Executable']:
@@ -1048,7 +1051,7 @@ class GnomeModule(ExtensionModule):
         srcdir = os.path.join(state.environment.get_source_dir(), state.subdir)
         builddir = os.path.join(state.environment.get_build_dir(), state.subdir)
 
-        depends: T.List[T.Union['FileOrString', build.GeneratedTypes, build.Executable, build.SharedLibrary, build.StaticLibrary]] = []
+        depends: T.List[T.Union['FileOrString', 'build.GeneratedTypes', build.BuildTarget]] = []
         depends.extend(gir_dep.sources)
         depends.extend(girtargets)
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1437,7 +1437,8 @@ class GnomeModule(ExtensionModule):
 
     def _get_build_args(self, c_args: T.List[str], inc_dirs: T.List[T.Union[str, build.IncludeDirs]],
                         deps: T.List[T.Union[Dependency, build.SharedLibrary, build.StaticLibrary]],
-                        state: 'ModuleState', depends: T.List[build.BuildTarget]) -> T.List[str]:
+                        state: 'ModuleState',
+                        depends: T.Sequence[T.Union[build.BuildTarget, 'build.GeneratedTypes']]) -> T.List[str]:
         args: T.List[str] = []
         cflags = c_args.copy()
         deps_cflags, internal_ldflags, external_ldflags, *_ = \

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -255,12 +255,14 @@ native_glib_version = None
 class GnomeModule(ExtensionModule):
     def __init__(self, interpreter: 'Interpreter') -> None:
         super().__init__(interpreter)
-        self.gir_dep = None
+        self.gir_dep: T.Optional[Dependency] = None
+        self.giscanner: T.Optional[T.Union[ExternalProgram, build.Executable, OverrideProgram]] = None
+        self.gicompiler: T.Optional[T.Union[ExternalProgram, build.Executable, OverrideProgram]] = None
         self.install_glib_compile_schemas = False
-        self.install_gio_querymodules = []
+        self.install_gio_querymodules: T.List[str] = []
         self.install_gtk_update_icon_cache = False
         self.install_update_desktop_database = False
-        self.devenv = None
+        self.devenv: T.Optional[build.EnvironmentVariables] = None
         self.methods.update({
             'post_install': self.post_install,
             'compile_resources': self.compile_resources,

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -41,6 +41,7 @@ modules = [
     'mesonbuild/mlog.py',
     'mesonbuild/msubprojects.py',
     'mesonbuild/modules/fs.py',
+    'mesonbuild/modules/gnome.py',
     'mesonbuild/modules/i18n.py',
     'mesonbuild/modules/java.py',
     'mesonbuild/modules/keyval.py',


### PR DESCRIPTION
Finally, with these changes (and the ones in #9700), the gnome module has become type safe, and with it all callers of CustomTarget, so I can finally get to the work I actually wanted to, fixing the layering violation between the build and interpreter modules!