### PR TITLE
install: Don't run ldconfig on cross builds

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -109,7 +109,8 @@ class CleanTrees:
 class InstallData:
     def __init__(self, source_dir: str, build_dir: str, prefix: str, libdir: str,
                  strip_bin: T.List[str], install_umask: T.Union[str, int],
-                 mesonintrospect: T.List[str], version: str):
+                 mesonintrospect: T.List[str], version: str,
+                 is_cross_build: bool):
         # TODO: in python 3.8 or with typing_Extensions install_umask could be:
         # `T.Union[T.Literal['preserve'], int]`, which would be more accurate.
         self.source_dir = source_dir
@@ -128,6 +129,7 @@ class InstallData:
         self.install_subdirs: T.List[SubdirInstallData] = []
         self.mesonintrospect = mesonintrospect
         self.version = version
+        self.is_cross_build = is_cross_build
 
 class TargetInstallData:
 
@@ -1510,7 +1512,8 @@ class Backend:
                         strip_bin,
                         umask,
                         self.environment.get_build_command() + ['introspect'],
-                        self.environment.coredata.version)
+                        self.environment.coredata.version,
+                        self.environment.is_cross_build())
         self.generate_depmf_install(d)
         self.generate_target_install(d)
         self.generate_header_install(d)

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -383,9 +383,10 @@ class Installer:
         if not self.dry_run and not destdir:
             restore_selinux_contexts()
 
-    def apply_ldconfig(self, dm: DirMaker, destdir: str, libdir: str) -> None:
-        if not self.dry_run and not destdir:
-            apply_ldconfig(dm, libdir)
+    def apply_ldconfig(self, dm: DirMaker, destdir: str, is_cross_build: bool, libdir: str) -> None:
+        if any([self.dry_run, destdir, is_cross_build]):
+            return
+        apply_ldconfig(dm, libdir)
 
     def Popen_safe(self, *args: T.Any, **kwargs: T.Any) -> T.Tuple[int, str, str]:
         if not self.dry_run:
@@ -589,7 +590,7 @@ class Installer:
                 self.install_data(d, dm, destdir, fullprefix)
                 self.install_symlinks(d, dm, destdir, fullprefix)
                 self.restore_selinux_contexts(destdir)
-                self.apply_ldconfig(dm, destdir, libdir)
+                self.apply_ldconfig(dm, destdir, d.is_cross_build, libdir)
                 self.run_install_script(d, destdir, fullprefix)
                 if not self.did_install_something:
                     self.log('Nothing to install.')


### PR DESCRIPTION
Even if we install without a DESTDIR set, we should never update
ldconfig when cross compiling.

Fixes #9707