### PR TITLE
intl dep: forward static to iconv if needed

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -487,7 +487,7 @@ class IntlSystemDependency(SystemDependency):
             self.is_found = True
 
             if self.static:
-                if not self._add_sub_dependency(iconv_factory(env, self.for_machine, {})):
+                if not self._add_sub_dependency(iconv_factory(env, self.for_machine, {'static': True})):
                     self.is_found = False
                     return
 


### PR DESCRIPTION
In 1fb6c939473ca7cdab2 the intl dep gained support for static linking
which also forwarded this property to the iconv sub dependency.

The refactoring in 214d03568f75 lost this change, which results in
iconv getting linked dynamically again.

Forward static again to fix this.