### PR TITLE
add ft32 cpu family

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -90,6 +90,7 @@ set in the cross file.
 | csky                | 32 bit CSky processor    |
 | dspic               | 16 bit Microchip dsPIC   |
 | e2k                 | MCST Elbrus processor    |
+| ft32                | 32 bit Bridgetek MCU     |
 | ia64                | Itanium processor        |
 | loongarch64         | 64 bit Loongson processor|
 | m68k                | Motorola 68000 processor |

--- a/mesonbuild/envconfig.py
+++ b/mesonbuild/envconfig.py
@@ -45,6 +45,7 @@ known_cpu_families = (
     'csky',
     'dspic',
     'e2k',
+    'ft32',
     'ia64',
     'loongarch64',
     'm68k',


### PR DESCRIPTION
Is there anything one needs to to 'support' a new family? this is only use for quirks correct?

closes #9670