### PR TITLE
Full typing and typed_* for the interperterobjects module

### DIFF
--- a/docs/yaml/objects/cfg_data.yaml
+++ b/docs/yaml/objects/cfg_data.yaml
@@ -41,8 +41,17 @@ methods:
       type: str
       description: The name of the variable to set
     value:
-      type: bool
-      description: The value to set as either `1` or `0`
+      type: bool | int
+      description: |
+        The value to set as either `1` or `0`
+
+        Passing numbers was never intended to work, and since 0.62 it has been
+        deprecated. It will be removed in a future version of Meson. If you
+        need to pass numbers use the `.set` method.
+  warnings:
+  - numeric values < 0 have the surprising behavior of being converted to
+    [[true]], values > 1 have the more expected but unintentional behavior of
+    being interpretered as [[true]].
 
   kwargs_inherit: cfg_data.set
 

--- a/docs/yaml/objects/feature.yaml
+++ b/docs/yaml/objects/feature.yaml
@@ -54,7 +54,7 @@ methods:
     if get_option('directx').require(host_machine.system() == 'windows',
           error_message: 'DirectX only available on Windows').allowed() then
       src += ['directx.c']
-      config.set10('HAVE_DIRECTX', 1)
+      config.set10('HAVE_DIRECTX', true)
     endif
     ```
 

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2767,17 +2767,16 @@ class CustomTargetIndex(HoldableObject):
         return self.target.get_custom_install_dir()
 
 class ConfigurationData(HoldableObject):
-    def __init__(self) -> None:
+    def __init__(self, initial_values: T.Optional[T.Union[
+                T.Dict[str, T.Tuple[T.Union[str, int, bool], T.Optional[str]]],
+                T.Dict[str, T.Union[str, int, bool]]]
+            ] = None):
         super().__init__()
-        self.values: T.Dict[
-            str,
-            T.Tuple[
-                T.Union[str, int, bool],
-                T.Optional[str]
-            ]
-        ] = {}
+        self.values: T.Dict[str, T.Tuple[T.Union[str, int, bool], T.Optional[str]]] = \
+            {k: v if isinstance(v, tuple) else (v, None) for k, v in initial_values.items()} if initial_values else {}
+        self.used: bool = False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return repr(self.values)
 
     def __contains__(self, value: str) -> bool:

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -27,6 +27,7 @@ from ..mesonlib import version_compare_many
 from ..interpreterbase import FeatureDeprecated
 
 if T.TYPE_CHECKING:
+    from .._typing import ImmutableListProtocol
     from ..compilers.compilers import Compiler
     from ..environment import Environment
     from ..build import BuildTarget, CustomTarget
@@ -162,7 +163,9 @@ class Dependency(HoldableObject):
     def get_exe_args(self, compiler: 'Compiler') -> T.List[str]:
         return []
 
-    def get_pkgconfig_variable(self, variable_name: str, kwargs: T.Dict[str, T.Any]) -> str:
+    def get_pkgconfig_variable(self, variable_name: str,
+                               define_variable: 'ImmutableListProtocol[str]',
+                               default: T.Optional[str]) -> str:
         raise DependencyException(f'{self.name!r} is not a pkgconfig dependency')
 
     def get_configtool_variable(self, variable_name: str) -> str:
@@ -254,7 +257,9 @@ class InternalDependency(Dependency):
             return True
         return any(d.is_built() for d in self.ext_deps)
 
-    def get_pkgconfig_variable(self, variable_name: str, kwargs: T.Dict[str, T.Any]) -> str:
+    def get_pkgconfig_variable(self, variable_name: str,
+                               define_variable: 'ImmutableListProtocol[str]',
+                               default: T.Optional[str]) -> str:
         raise DependencyException('Method "get_pkgconfig_variable()" is '
                                   'invalid for an internal dependency')
 

--- a/mesonbuild/dependencies/boost.py
+++ b/mesonbuild/dependencies/boost.py
@@ -648,7 +648,7 @@ class BoostDependency(SystemDependency):
         try:
             boost_pc = PkgConfigDependency('boost', self.env, {'required': False})
             if boost_pc.found():
-                boost_root = boost_pc.get_pkgconfig_variable('prefix', {'default': None})
+                boost_root = boost_pc.get_pkgconfig_variable('prefix', [], None)
                 if boost_root:
                     roots += [Path(boost_root)]
         except DependencyException:

--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -181,7 +181,7 @@ class QtPkgConfigDependency(_QtBase, PkgConfigDependency, metaclass=abc.ABCMeta)
                 self.is_found = False
                 return
             if self.private_headers:
-                qt_inc_dir = mod.get_pkgconfig_variable('includedir', {})
+                qt_inc_dir = mod.get_pkgconfig_variable('includedir', [], None)
                 mod_private_dir = os.path.join(qt_inc_dir, 'Qt' + m)
                 if not os.path.isdir(mod_private_dir):
                     # At least some versions of homebrew don't seem to set this
@@ -203,7 +203,7 @@ class QtPkgConfigDependency(_QtBase, PkgConfigDependency, metaclass=abc.ABCMeta)
                 if arg == f'-l{debug_lib_name}' or arg.endswith(f'{debug_lib_name}.lib') or arg.endswith(f'{debug_lib_name}.a'):
                     is_debug = True
                     break
-            libdir = self.get_pkgconfig_variable('libdir', {})
+            libdir = self.get_pkgconfig_variable('libdir', [], None)
             if not self._link_with_qtmain(is_debug, libdir):
                 self.is_found = False
                 return
@@ -211,7 +211,7 @@ class QtPkgConfigDependency(_QtBase, PkgConfigDependency, metaclass=abc.ABCMeta)
         self.bindir = self.get_pkgconfig_host_bins(self)
         if not self.bindir:
             # If exec_prefix is not defined, the pkg-config file is broken
-            prefix = self.get_pkgconfig_variable('exec_prefix', {})
+            prefix = self.get_pkgconfig_variable('exec_prefix', [], None)
             if prefix:
                 self.bindir = os.path.join(prefix, 'bin')
 
@@ -387,7 +387,7 @@ class Qt4PkgConfigDependency(QtPkgConfigDependency):
         applications = ['moc', 'uic', 'rcc', 'lupdate', 'lrelease']
         for application in applications:
             try:
-                return os.path.dirname(core.get_pkgconfig_variable(f'{application}_location', {}))
+                return os.path.dirname(core.get_pkgconfig_variable(f'{application}_location', [], None))
             except mesonlib.MesonException:
                 pass
         return None
@@ -400,7 +400,7 @@ class Qt5PkgConfigDependency(QtPkgConfigDependency):
 
     @staticmethod
     def get_pkgconfig_host_bins(core: PkgConfigDependency) -> str:
-        return core.get_pkgconfig_variable('host_bins', {})
+        return core.get_pkgconfig_variable('host_bins', [], None)
 
     def get_private_includes(self, mod_inc_dir: str, module: str) -> T.List[str]:
         return _qt_get_private_includes(mod_inc_dir, module, self.version)
@@ -410,7 +410,7 @@ class Qt6PkgConfigDependency(QtPkgConfigDependency):
 
     @staticmethod
     def get_pkgconfig_host_bins(core: PkgConfigDependency) -> str:
-        return core.get_pkgconfig_variable('host_bins', {})
+        return core.get_pkgconfig_variable('host_bins', [], None)
 
     def get_private_includes(self, mod_inc_dir: str, module: str) -> T.List[str]:
         return _qt_get_private_includes(mod_inc_dir, module, self.version)

--- a/mesonbuild/interpreter/__init__.py
+++ b/mesonbuild/interpreter/__init__.py
@@ -28,7 +28,7 @@ __all__ = [
     'CustomTargetIndexHolder',
     'MachineHolder',
     'Test',
-    'ConfigurationDataObject',
+    'ConfigurationDataHolder',
     'SubprojectHolder',
     'DependencyHolder',
     'GeneratedListHolder',
@@ -46,7 +46,7 @@ from .interpreter import Interpreter, permitted_dependency_kwargs
 from .compiler import CompilerHolder
 from .interpreterobjects import (ExecutableHolder, BuildTargetHolder, CustomTargetHolder,
                                  CustomTargetIndexHolder, MachineHolder, Test,
-                                 ConfigurationDataObject, SubprojectHolder, DependencyHolder,
+                                 ConfigurationDataHolder, SubprojectHolder, DependencyHolder,
                                  GeneratedListHolder, ExternalProgramHolder,
                                  extract_required_kwarg)
 

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -477,14 +477,9 @@ class DependencyHolder(ObjectHolder[Dependency]):
     @FeatureDeprecated('dependency.get_configtool_variable', '0.56.0',
                        'use dependency.get_variable(configtool : ...) instead')
     @noKwargs
-    def configtool_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
-        args = listify(args)
-        if len(args) != 1:
-            raise InterpreterException('get_configtool_variable takes exactly one argument.')
-        varname = args[0]
-        if not isinstance(varname, str):
-            raise InterpreterException('Variable name must be a string.')
-        return self.held_object.get_configtool_variable(varname)
+    @typed_pos_args('dependency.get_config_tool_variable', str)
+    def configtool_method(self, args: T.Tuple[str], kwargs: TYPE_kwargs) -> str:
+        return self.held_object.get_configtool_variable(args[0])
 
     @FeatureNew('dependency.partial_dependency', '0.46.0')
     @noPosargs

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -361,6 +361,7 @@ class ConfigurationDataHolder(ObjectHolder[build.ConfigurationData], MutableInte
 
     @FeatureNew('configuration_data.keys()', '0.57.0')
     @noPosargs
+    @noKwargs
     def keys_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> T.List[str]:
         return sorted(self.keys())
 

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -464,7 +464,7 @@ class DependencyHolder(ObjectHolder[Dependency]):
     @permittedKwargs({'define_variable', 'default'})
     @typed_pos_args('dependency.get_pkgconfig_variable', str)
     def pkgconfig_method(self, args: T.Tuple[str], kwargs: TYPE_kwargs) -> str:
-        return self.held_object.get_pkgconfig_variable(args[0], kwargs)
+        return self.held_object.get_pkgconfig_variable(args[0], **kwargs)
 
     @FeatureNew('dependency.get_configtool_variable', '0.44.0')
     @FeatureDeprecated('dependency.get_configtool_variable', '0.56.0',

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -348,7 +348,9 @@ class ConfigurationDataObject(MutableInterpreterObject, MesonInterpreterObject):
         else:
             self.conf_data.values[name] = (0, desc)
 
-    def has_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> bool:
+    @typed_pos_args('configuration_data.has', (str, int, bool))
+    @noKwargs
+    def has_method(self, args: T.Tuple[T.Union[str, int, bool]], kwargs: TYPE_kwargs) -> bool:
         return args[0] in self.conf_data.values
 
     @FeatureNew('configuration_data.get()', '0.38.0')

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -328,7 +328,6 @@ class ConfigurationDataHolder(ObjectHolder[build.ConfigurationData], MutableInte
         return args[0] in self.held_object.values
 
     @FeatureNew('configuration_data.get()', '0.38.0')
-    @noArgsFlattening
     @typed_pos_args('configuration_data.get', str, optargs=[(str, int, bool)])
     @noKwargs
     def get_method(self, args: T.Tuple[str, T.Optional[T.Union[str, int, bool]]],

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -367,16 +367,14 @@ class ConfigurationDataObject(MutableInterpreterObject, MesonInterpreterObject):
         raise InterpreterException(f'Entry {name} not in configuration data.')
 
     @FeatureNew('configuration_data.get_unquoted()', '0.44.0')
-    def get_unquoted_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> T.Union[str, int, bool]:
-        if len(args) < 1 or len(args) > 2:
-            raise InterpreterException('Get method takes one or two arguments.')
-        if not isinstance(args[0], str):
-            raise InterpreterException('The variable name must be a string.')
+    @typed_pos_args('configuration_data.get_unquoted', str, optargs=[(str, int, bool)])
+    @noKwargs
+    def get_unquoted_method(self, args: T.Tuple[str, T.Optional[T.Union[str, int, bool]]],
+                            kwargs: TYPE_kwargs) -> T.Union[str, int, bool]:
         name = args[0]
         if name in self.conf_data:
             val = self.conf_data.get(name)[0]
-        elif len(args) > 1:
-            assert isinstance(args[1], (str, int, bool))
+        elif args[1] is not None:
             val = args[1]
         else:
             raise InterpreterException(f'Entry {name} not in configuration data.')

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -293,11 +293,9 @@ class ConfigurationDataObject(MutableInterpreterObject, MesonInterpreterObject):
                              'get_unquoted': self.get_unquoted_method,
                              'merge_from': self.merge_from_method,
                              })
-        if isinstance(initial_values, dict):
+        if initial_values:
             for k, v in initial_values.items():
-                self.set_method([k, v], {})
-        elif initial_values:
-            raise AssertionError('Unsupported ConfigurationDataObject initial_values')
+                self.conf_data.values[k] = (v, None)
 
     def is_used(self) -> bool:
         return self.used

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -355,21 +355,15 @@ class ConfigurationDataObject(MutableInterpreterObject, MesonInterpreterObject):
 
     @FeatureNew('configuration_data.get()', '0.38.0')
     @noArgsFlattening
-    def get_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> T.Union[str, int, bool]:
-        if len(args) < 1 or len(args) > 2:
-            raise InterpreterException('Get method takes one or two arguments.')
-        if not isinstance(args[0], str):
-            raise InterpreterException('The variable name must be a string.')
+    @typed_pos_args('configuration_data.get', str, optargs=[(str, int, bool)])
+    @noKwargs
+    def get_method(self, args: T.Tuple[str, T.Optional[T.Union[str, int, bool]]],
+                   kwargs: TYPE_kwargs) -> T.Union[str, int, bool]:
         name = args[0]
         if name in self.conf_data:
             return self.conf_data.get(name)[0]
-        if len(args) > 1:
-            # Assertion does not work because setting other values is still
-            # supported, but deprecated. Use T.cast in the meantime (even though
-            # this is a lie).
-            # TODO: Fix this once the deprecation is removed
-            # assert isinstance(args[1], (int, str, bool))
-            return T.cast(T.Union[str, int, bool], args[1])
+        elif args[1] is not None:
+            return args[1]
         raise InterpreterException(f'Entry {name} not in configuration data.')
 
     @FeatureNew('configuration_data.get_unquoted()', '0.44.0')

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -320,6 +320,14 @@ class ConfigurationDataHolder(ObjectHolder[build.ConfigurationData], MutableInte
     @typed_kwargs('configuration_data.set10', _CONF_DATA_SET_KWS)
     def set10_method(self, args: T.Tuple[str, T.Union[int, bool]], kwargs: 'kwargs.ConfigurationDataSet') -> None:
         self.__check_used()
+        if isinstance(args[1], int):
+            mlog.deprecation('configuration_data.set10 with number. the `set10` '
+                             'method should only be used with booleans',
+                             location=self.interpreter.current_node)
+            if args[1] < 0:
+                mlog.warning('Passing a number that is less than 0 may not have the intended result, '
+                             'as meson will treat all non-zero values as true.',
+                             location=self.interpreter.current_node)
         self.held_object.values[args[0]] = (int(args[1]), kwargs['description'])
 
     @typed_pos_args('configuration_data.has', (str, int, bool))

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -466,8 +466,8 @@ class DependencyHolder(ObjectHolder[Dependency]):
     def name_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
         return self.held_object.get_name()
 
-    @FeatureDeprecated('Dependency.get_pkgconfig_variable', '0.56.0',
-                       'use Dependency.get_variable(pkgconfig : ...) instead')
+    @FeatureDeprecated('dependency.get_pkgconfig_variable', '0.56.0',
+                       'use dependency.get_variable(pkgconfig : ...) instead')
     @permittedKwargs({'define_variable', 'default'})
     def pkgconfig_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
         args = listify(args)
@@ -478,9 +478,9 @@ class DependencyHolder(ObjectHolder[Dependency]):
             raise InterpreterException('Variable name must be a string.')
         return self.held_object.get_pkgconfig_variable(varname, kwargs)
 
-    @FeatureNew('dep.get_configtool_variable', '0.44.0')
-    @FeatureDeprecated('Dependency.get_configtool_variable', '0.56.0',
-                       'use Dependency.get_variable(configtool : ...) instead')
+    @FeatureNew('dependency.get_configtool_variable', '0.44.0')
+    @FeatureDeprecated('dependency.get_configtool_variable', '0.56.0',
+                       'use dependency.get_variable(configtool : ...) instead')
     @noKwargs
     def configtool_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
         args = listify(args)
@@ -491,32 +491,32 @@ class DependencyHolder(ObjectHolder[Dependency]):
             raise InterpreterException('Variable name must be a string.')
         return self.held_object.get_configtool_variable(varname)
 
-    @FeatureNew('dep.partial_dependency', '0.46.0')
+    @FeatureNew('dependency.partial_dependency', '0.46.0')
     @noPosargs
-    @typed_kwargs('dep.partial_dependency', *_PARTIAL_DEP_KWARGS)
+    @typed_kwargs('dependency.partial_dependency', *_PARTIAL_DEP_KWARGS)
     def partial_dependency_method(self, args: T.List[TYPE_nvar], kwargs: 'kwargs.DependencyMethodPartialDependency') -> Dependency:
         pdep = self.held_object.get_partial_dependency(**kwargs)
         return pdep
 
-    @FeatureNew('dep.get_variable', '0.51.0')
-    @typed_pos_args('dep.get_variable', optargs=[str])
+    @FeatureNew('dependency.get_variable', '0.51.0')
+    @typed_pos_args('dependency.get_variable', optargs=[str])
     @permittedKwargs({'cmake', 'pkgconfig', 'configtool', 'internal', 'default_value', 'pkgconfig_define'})
-    @FeatureNewKwargs('dep.get_variable', '0.54.0', ['internal'])
+    @FeatureNewKwargs('dependency.get_variable', '0.54.0', ['internal'])
     def variable_method(self, args: T.Tuple[T.Optional[str]], kwargs: T.Dict[str, T.Any]) -> T.Union[str, T.List[str]]:
         default_varname = args[0]
         if default_varname is not None:
-            FeatureNew('Positional argument to dep.get_variable()', '0.58.0', location=self.current_node).use(self.subproject)
+            FeatureNew('Positional argument to dependency.get_variable()', '0.58.0', location=self.current_node).use(self.subproject)
             for k in ['cmake', 'pkgconfig', 'configtool', 'internal']:
                 kwargs.setdefault(k, default_varname)
         return self.held_object.get_variable(**kwargs)
 
-    @FeatureNew('dep.include_type', '0.52.0')
+    @FeatureNew('dependency.include_type', '0.52.0')
     @noPosargs
     @noKwargs
     def include_type_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
         return self.held_object.get_include_type()
 
-    @FeatureNew('dep.as_system', '0.52.0')
+    @FeatureNew('dependency.as_system', '0.52.0')
     @noKwargs
     def as_system_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> Dependency:
         args = listify(args)
@@ -530,7 +530,7 @@ class DependencyHolder(ObjectHolder[Dependency]):
         new_dep = self.held_object.generate_system_dependency(new_is_system)
         return new_dep
 
-    @FeatureNew('dep.as_link_whole', '0.56.0')
+    @FeatureNew('dependency.as_link_whole', '0.56.0')
     @noKwargs
     @noPosargs
     def as_link_whole_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> Dependency:
@@ -592,9 +592,9 @@ class ExternalLibraryHolder(ObjectHolder[ExternalLibrary]):
     def found_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> bool:
         return self.held_object.found()
 
-    @FeatureNew('dep.partial_dependency', '0.46.0')
+    @FeatureNew('dependency.partial_dependency', '0.46.0')
     @noPosargs
-    @typed_kwargs('dep.partial_dependency', *_PARTIAL_DEP_KWARGS)
+    @typed_kwargs('dependency.partial_dependency', *_PARTIAL_DEP_KWARGS)
     def partial_dependency_method(self, args: T.List[TYPE_nvar], kwargs: 'kwargs.DependencyMethodPartialDependency') -> Dependency:
         pdep = self.held_object.get_partial_dependency(**kwargs)
         return pdep

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -393,15 +393,13 @@ class ConfigurationDataObject(MutableInterpreterObject, MesonInterpreterObject):
     def keys(self) -> T.List[str]:
         return list(self.conf_data.values.keys())
 
+    @typed_pos_args('configuration_data.merge_from', object)  # yay for recursive type validation!
+    @noKwargs
     def merge_from_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> None:
-        if len(args) != 1:
-            raise InterpreterException('Merge_from takes one positional argument.')
-        from_object_holder = args[0]
-        if not isinstance(from_object_holder, ConfigurationDataObject):
+        from_object = args[0]
+        if not isinstance(from_object, ConfigurationDataObject):
             raise InterpreterException('Merge_from argument must be a configuration data object.')
-        from_object = from_object_holder.conf_data
-        for k, v in from_object.values.items():
-            self.conf_data.values[k] = v
+        self.conf_data.values.update(from_object.conf_data.values)
 
 
 _PARTIAL_DEP_KWARGS = [

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -461,9 +461,19 @@ class DependencyHolder(ObjectHolder[Dependency]):
 
     @FeatureDeprecated('dependency.get_pkgconfig_variable', '0.56.0',
                        'use dependency.get_variable(pkgconfig : ...) instead')
-    @permittedKwargs({'define_variable', 'default'})
     @typed_pos_args('dependency.get_pkgconfig_variable', str)
-    def pkgconfig_method(self, args: T.Tuple[str], kwargs: TYPE_kwargs) -> str:
+    @typed_kwargs(
+        'dependency.get_pkgconfig_variable',
+        KwargInfo('default', (str, NoneType)),
+        KwargInfo(
+            'define_variable',
+            ContainerTypeInfo(list, str, pairs=True),
+            default=[],
+            listify=True,
+            validator=lambda x: 'must be of length 2 or empty' if len(x) not in {0, 2} else None,
+        ),
+    )
+    def pkgconfig_method(self, args: T.Tuple[str], kwargs: 'kwargs.DependencyPkgConfigVar') -> str:
         return self.held_object.get_pkgconfig_variable(args[0], **kwargs)
 
     @FeatureNew('dependency.get_configtool_variable', '0.44.0')

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -125,11 +125,8 @@ class FeatureOptionHolder(ObjectHolder[coredata.UserFeatureOption]):
         return self.value == 'auto'
 
     @permittedKwargs({'error_message'})
-    def require_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> coredata.UserFeatureOption:
-        if len(args) != 1:
-            raise InvalidArguments(f'Expected 1 argument, got {len(args)}.')
-        if not isinstance(args[0], bool):
-            raise InvalidArguments('boolean argument expected.')
+    @typed_pos_args('feature_option.require', bool)
+    def require_method(self, args: T.Tuple[bool], kwargs: TYPE_kwargs) -> coredata.UserFeatureOption:
         error_message = kwargs.pop('error_message', '')
         if error_message and not isinstance(error_message, str):
             raise InterpreterException("Error message must be a string.")
@@ -145,11 +142,8 @@ class FeatureOptionHolder(ObjectHolder[coredata.UserFeatureOption]):
         return self.as_disabled()
 
     @noKwargs
-    def disable_auto_if_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> coredata.UserFeatureOption:
-        if len(args) != 1:
-            raise InvalidArguments(f'Expected 1 argument, got {len(args)}.')
-        if not isinstance(args[0], bool):
-            raise InvalidArguments('boolean argument expected.')
+    @typed_pos_args('feature_option.disable_auto_if', bool)
+    def disable_auto_if_method(self, args: T.Tuple[bool], kwargs: TYPE_kwargs) -> coredata.UserFeatureOption:
         return copy.deepcopy(self.held_object) if self.value != 'auto' or not args[0] else self.as_disabled()
 
 

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -124,21 +124,20 @@ class FeatureOptionHolder(ObjectHolder[coredata.UserFeatureOption]):
     def auto_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> bool:
         return self.value == 'auto'
 
-    @permittedKwargs({'error_message'})
     @typed_pos_args('feature_option.require', bool)
-    def require_method(self, args: T.Tuple[bool], kwargs: TYPE_kwargs) -> coredata.UserFeatureOption:
-        error_message = kwargs.pop('error_message', '')
-        if error_message and not isinstance(error_message, str):
-            raise InterpreterException("Error message must be a string.")
+    @typed_kwargs(
+        'feature_option.require',
+        KwargInfo('error_message', (str, NoneType))
+    )
+    def require_method(self, args: T.Tuple[bool], kwargs: 'kwargs.FeatureOptionRequire') -> coredata.UserFeatureOption:
         if args[0]:
             return copy.deepcopy(self.held_object)
 
-        assert isinstance(error_message, str)
         if self.value == 'enabled':
-            prefix = f'Feature {self.held_object.name} cannot be enabled'
-            if error_message:
-                prefix += ': '
-            raise InterpreterException(prefix + error_message)
+            err_msg = f'Feature {self.held_object.name} cannot be enabled'
+            if kwargs['error_message']:
+                err_msg += f': {kwargs["error_message"]}'
+            raise InterpreterException(err_msg)
         return self.as_disabled()
 
     @noKwargs

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -508,17 +508,9 @@ class DependencyHolder(ObjectHolder[Dependency]):
 
     @FeatureNew('dependency.as_system', '0.52.0')
     @noKwargs
-    def as_system_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> Dependency:
-        args = listify(args)
-        new_is_system = 'system'
-        if len(args) > 1:
-            raise InterpreterException('as_system takes only one optional value')
-        if len(args) == 1:
-            if not isinstance(args[0], str):
-                raise InterpreterException('as_system takes exactly one string parameter')
-            new_is_system = args[0]
-        new_dep = self.held_object.generate_system_dependency(new_is_system)
-        return new_dep
+    @typed_pos_args('dependency.as_system', optargs=[str])
+    def as_system_method(self, args: T.Tuple[T.Optional[str]], kwargs: TYPE_kwargs) -> Dependency:
+        return self.held_object.generate_system_dependency(args[0] or 'system')
 
     @FeatureNew('dependency.as_link_whole', '0.56.0')
     @noKwargs

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -469,14 +469,9 @@ class DependencyHolder(ObjectHolder[Dependency]):
     @FeatureDeprecated('dependency.get_pkgconfig_variable', '0.56.0',
                        'use dependency.get_variable(pkgconfig : ...) instead')
     @permittedKwargs({'define_variable', 'default'})
-    def pkgconfig_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
-        args = listify(args)
-        if len(args) != 1:
-            raise InterpreterException('get_pkgconfig_variable takes exactly one argument.')
-        varname = args[0]
-        if not isinstance(varname, str):
-            raise InterpreterException('Variable name must be a string.')
-        return self.held_object.get_pkgconfig_variable(varname, kwargs)
+    @typed_pos_args('dependency.get_pkgconfig_variable', str)
+    def pkgconfig_method(self, args: T.Tuple[str], kwargs: TYPE_kwargs) -> str:
+        return self.held_object.get_pkgconfig_variable(args[0], kwargs)
 
     @FeatureNew('dependency.get_configtool_variable', '0.44.0')
     @FeatureDeprecated('dependency.get_configtool_variable', '0.56.0',

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -250,3 +250,14 @@ class DependencyPkgConfigVar(TypedDict):
 
     default: T.Optional[str]
     define_variable: T.List[str]
+
+
+
+class DependencyGetVariable(TypedDict):
+
+    cmake: T.Optional[str]
+    pkgconfig: T.Optional[str]
+    configtool: T.Optional[str]
+    internal: T.Optional[str]
+    default_value: T.Optional[str]
+    pkgconfig_define: T.List[str]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -261,3 +261,8 @@ class DependencyGetVariable(TypedDict):
     internal: T.Optional[str]
     default_value: T.Optional[str]
     pkgconfig_define: T.List[str]
+
+
+class ConfigurationDataSet(TypedDict):
+
+    description: T.Optional[str]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -239,3 +239,8 @@ class RunCommand(TypedDict):
     check: bool
     capture: T.Optional[bool]
     env: build.EnvironmentVariables
+
+
+class FeatureOptionRequire(TypedDict):
+
+    error_message: T.Optional[str]

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -244,3 +244,9 @@ class RunCommand(TypedDict):
 class FeatureOptionRequire(TypedDict):
 
     error_message: T.Optional[str]
+
+
+class DependencyPkgConfigVar(TypedDict):
+
+    default: T.Optional[str]
+    define_variable: T.List[str]

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -20,7 +20,7 @@ from . import ExtensionModule, ModuleReturnValue, ModuleObject
 
 from .. import build, mesonlib, mlog, dependencies
 from ..cmake import SingleTargetOptions, TargetOptions, cmake_defines_to_args
-from ..interpreter import ConfigurationDataObject, SubprojectHolder
+from ..interpreter import SubprojectHolder
 from ..interpreterbase import (
     FeatureNew,
     FeatureNewKwargs,
@@ -358,7 +358,7 @@ class CmakeModule(ExtensionModule):
         if 'configuration' not in kwargs:
             raise mesonlib.MesonException('"configuration" not specified.')
         conf = kwargs['configuration']
-        if not isinstance(conf, ConfigurationDataObject):
+        if not isinstance(conf, build.ConfigurationData):
             raise mesonlib.MesonException('Argument "configuration" is not of type configuration_data')
 
         prefix = state.environment.coredata.get_option(mesonlib.OptionKey('prefix'))
@@ -372,8 +372,8 @@ class CmakeModule(ExtensionModule):
             extra = PACKAGE_INIT_EXT.replace('@absInstallDir@', abs_install_dir)
             extra = extra.replace('@installPrefix@', prefix)
 
-        self.create_package_file(ifile_abs, ofile_abs, PACKAGE_RELATIVE_PATH, extra, conf.conf_data)
-        conf.mark_used()
+        self.create_package_file(ifile_abs, ofile_abs, PACKAGE_RELATIVE_PATH, extra, conf)
+        conf.used = True
 
         conffile = os.path.normpath(inputfile.relative_name())
         if conffile not in self.interpreter.build_def_files:

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -325,7 +325,7 @@ class GnomeModule(ExtensionModule):
         # Check if pkgconfig has a variable
         dep = self._get_dep(state, depname, native=True, required=False)
         if dep.found() and dep.type_name == 'pkgconfig':
-            value = dep.get_pkgconfig_variable(varname, {})
+            value = dep.get_pkgconfig_variable(varname, [], None)
             if value:
                 return ExternalProgram(name, [value])
 

--- a/mesonbuild/modules/sourceset.py
+++ b/mesonbuild/modules/sourceset.py
@@ -154,8 +154,12 @@ class SourceSet(MutableModuleObject):
             def _get_from_config_data(key):
                 nonlocal config_cache
                 if key not in config_cache:
-                    args = [key] if strict else [key, False]
-                    config_cache[key] = config_data.get_method(args, {})
+                    if key in config_data:
+                        config_cache[key] = config_data.get(key)[0]
+                    elif strict:
+                        raise InvalidArguments(f'sourceset.apply: key "{key}" not in passed configuration, and strict set.')
+                    else:
+                        config_cache[key] = False
                 return config_cache[key]
 
         files = self.collect(_get_from_config_data, False)

--- a/mesonbuild/modules/unstable_simd.py
+++ b/mesonbuild/modules/unstable_simd.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from .. import mesonlib, compilers, mlog
+from .. import build
 
 from . import ExtensionModule
 
@@ -57,8 +58,7 @@ class SimdModule(ExtensionModule):
         compiler = kwargs['compiler']
         if not isinstance(compiler, compilers.compilers.Compiler):
             raise mesonlib.MesonException('Compiler argument must be a compiler object.')
-        cdata = self.interpreter.func_configuration_data(None, [], {})
-        conf = cdata.conf_data
+        conf = build.ConfigurationData()
         for iset in self.isets:
             if iset not in kwargs:
                 continue
@@ -82,7 +82,7 @@ class SimdModule(ExtensionModule):
             all_lang_args = old_lang_args + args
             lib_kwargs[langarg_key] = all_lang_args
             result.append(self.interpreter.func_static_lib(None, [libname], lib_kwargs))
-        return [result, cdata]
+        return [result, conf]
 
 def initialize(*args, **kwargs):
     return SimdModule(*args, **kwargs)

--- a/test cases/common/14 configure file/meson.build
+++ b/test cases/common/14 configure file/meson.build
@@ -275,9 +275,6 @@ configure_file(
 
 test('configure-file', test_file)
 
-cdata = configuration_data()
-cdata.set('invalid_value', ['array'])
-
 # Dictionaries
 
 cdata = configuration_data({

--- a/test cases/common/187 args flattening/meson.build
+++ b/test cases/common/187 args flattening/meson.build
@@ -6,13 +6,6 @@ assert(arr == ['bar', 'baz'], 'get_variable with array fallback is broken')
 set_variable('arr', ['bar', 'baz'])
 assert(arr == ['bar', 'baz'], 'set_variable(array) is broken')
 
-conf = configuration_data()
-conf.set('foo', ['bar', 'baz'])
-assert(conf.get('foo') == ['bar', 'baz'], 'configuration_data.set(array) is broken')
-
-arr = conf.get('does-not-exist', ['bar', 'baz'])
-assert(arr == ['bar', 'baz'], 'configuration_data.get with array fallback is broken')
-
 arr = meson.get_cross_property('does-not-exist', ['bar', 'baz'])
 assert(arr == ['bar', 'baz'], 'meson.get_cross_property with array fallback is broken')
 
@@ -27,5 +20,6 @@ assert(arr == ['bar', 'baz'], 'meson.get_external_property native:false with arr
 
 # Test deprecated behaviour
 
+conf = configuration_data()
 conf.set(['foo', 'bar'])
 message(conf.get('foo'))

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2306,7 +2306,6 @@ class AllPlatformTests(BasePlatformTests):
             self.assertEqual(f.read().strip(), b'/* #undef FOO_BAR */')
         with open(os.path.join(self.builddir, 'nosubst-nocopy2.txt'), 'rb') as f:
             self.assertEqual(f.read().strip(), b'')
-        self.assertRegex(out, r"DEPRECATION:.*\['array'\] is invalid.*dict")
 
     def test_dirs(self):
         with tempfile.TemporaryDirectory() as containing:

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -148,18 +148,18 @@ class LinuxlikeTests(BasePlatformTests):
         self.assertTrue(foo_dep.found())
         self.assertEqual(foo_dep.get_version(), '1.0')
         self.assertIn('-lfoo', foo_dep.get_link_args())
-        self.assertEqual(foo_dep.get_pkgconfig_variable('foo', {}), 'bar')
-        self.assertPathEqual(foo_dep.get_pkgconfig_variable('datadir', {}), '/usr/data')
+        self.assertEqual(foo_dep.get_pkgconfig_variable('foo', [], None), 'bar')
+        self.assertPathEqual(foo_dep.get_pkgconfig_variable('datadir', [], None), '/usr/data')
 
         libhello_nolib = PkgConfigDependency('libhello_nolib', env, kwargs)
         self.assertTrue(libhello_nolib.found())
         self.assertEqual(libhello_nolib.get_link_args(), [])
         self.assertEqual(libhello_nolib.get_compile_args(), [])
-        self.assertEqual(libhello_nolib.get_pkgconfig_variable('foo', {}), 'bar')
-        self.assertEqual(libhello_nolib.get_pkgconfig_variable('prefix', {}), self.prefix)
+        self.assertEqual(libhello_nolib.get_pkgconfig_variable('foo', [], None), 'bar')
+        self.assertEqual(libhello_nolib.get_pkgconfig_variable('prefix', [], None), self.prefix)
         if version_compare(libhello_nolib.check_pkgconfig(libhello_nolib.pkgbin),">=0.29.1"):
-            self.assertEqual(libhello_nolib.get_pkgconfig_variable('escaped_var', {}), r'hello\ world')
-        self.assertEqual(libhello_nolib.get_pkgconfig_variable('unescaped_var', {}), 'hello world')
+            self.assertEqual(libhello_nolib.get_pkgconfig_variable('escaped_var', [], None), r'hello\ world')
+        self.assertEqual(libhello_nolib.get_pkgconfig_variable('unescaped_var', [], None), 'hello world')
 
         cc = detect_c_compiler(env, MachineChoice.HOST)
         if cc.get_id() in {'gcc', 'clang'}:


### PR DESCRIPTION
This series adds full type annotations and use of the typed_* decorators for interpreter objects. as part of that work I've changed the `ConfigurationDataObject` into a proper `ConfigurationDataHolder`, that is a holder and acts and works like a holder, with all of the core logic pushed into `build.ConfigurationData`, and the interpreter logic in the interpreter. This has a nice cleaning effect throughout the code base.

There is one contentious change here, and that's dropping support for setting and getting values that are not `str | int | bool`. We never meant to accept other kinds of values, but we did, and we only deprecated that support at the start of the year, so it may well be too soon to drop that. Nevertheless, I've included that in the series as it allows more cleanups, and allows for full type checking, which, I think is pretty valuable.