### PR TITLE
Armclang support

### DIFF
--- a/docs/markdown/snippets/armclang-support.md
+++ b/docs/markdown/snippets/armclang-support.md
@@ -1,0 +1,6 @@
+## Support for ARM Ltd. Clang toolchain
+
+Support for the `armltdclang` compiler has been added. This differs from the
+existing `armclang` toolchain in that it is a fork of Clang by ARM Ltd. and
+supports native compilation. The Keil `armclang` toolchain only supports
+cross-compilation to embedded devices.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1777,8 +1777,8 @@ class Executable(BuildTarget):
                 self.suffix = 'exe'
             elif machine.system.startswith('wasm') or machine.system == 'emscripten':
                 self.suffix = 'js'
-            elif ('c' in self.compilers and self.compilers['c'].get_id().startswith('arm') or
-                  'cpp' in self.compilers and self.compilers['cpp'].get_id().startswith('arm')):
+            elif ('c' in self.compilers and self.compilers['c'].get_id().startswith('armclang') or
+                  'cpp' in self.compilers and self.compilers['cpp'].get_id().startswith('armclang')):
                 self.suffix = 'axf'
             elif ('c' in self.compilers and self.compilers['c'].get_id().startswith('ccrx') or
                   'cpp' in self.compilers and self.compilers['cpp'].get_id().startswith('ccrx')):

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -183,6 +183,13 @@ class ClangCCompiler(_ClangCStds, ClangCompiler, CCompiler):
         return []
 
 
+class ArmLtdClangCCompiler(ClangCCompiler):
+
+    def __init__(self, *args, **kwargs):
+        ClangCCompiler.__init__(self, *args, **kwargs)
+        self.id = 'armltdclang'
+
+
 class AppleClangCCompiler(ClangCCompiler):
 
     """Handle the differences between Apple Clang and Vanilla Clang.

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -211,6 +211,10 @@ class EmscriptenCCompiler(EmscriptenMixin, ClangCCompiler):
 
 
 class ArmclangCCompiler(ArmclangCompiler, CCompiler):
+    '''
+    Keil armclang
+    '''
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -296,6 +296,10 @@ class EmscriptenCPPCompiler(EmscriptenMixin, ClangCPPCompiler):
 
 
 class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
+    '''
+    Keil armclang
+    '''
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -155,7 +155,7 @@ class CPPCompiler(CLikeCompiler, Compiler):
         }
 
         # Currently, remapping is only supported for Clang, Elbrus and GCC
-        assert self.id in frozenset(['clang', 'lcc', 'gcc', 'emscripten'])
+        assert self.id in frozenset(['clang', 'lcc', 'gcc', 'emscripten', 'armltdclang'])
 
         if cpp_std not in CPP_FALLBACKS:
             # 'c++03' and 'c++98' don't have fallback types
@@ -257,6 +257,12 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
             for d in search_dir.split()[-1][len('libraries: ='):].split(':'):
                 search_dirs.append(f'-L{d}')
         return search_dirs + ['-lstdc++']
+
+
+class ArmLtdClangCPPCompiler(ClangCPPCompiler):
+    def __init__(self, *args, **kwargs):
+        ClangCPPCompiler.__init__(self, *args, **kwargs)
+        self.id = 'armltdclang'
 
 
 class AppleClangCPPCompiler(ClangCPPCompiler):

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -494,6 +494,12 @@ class FlangFortranCompiler(ClangCompiler, FortranCompiler):
                 search_dirs.append(f'-L{d}')
         return search_dirs + ['-lflang', '-lpgmath']
 
+class ArmLtdFlangFortranCompiler(FlangFortranCompiler):
+
+    def __init__(self, *args, **kwargs):
+        FlangFortranCompiler.__init__(self, *args, **kwargs)
+        self.id = 'armltdflang'
+
 class Open64FortranCompiler(FortranCompiler):
 
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,

--- a/mesonbuild/compilers/mixins/arm.py
+++ b/mesonbuild/compilers/mixins/arm.py
@@ -136,6 +136,9 @@ class ArmCompiler(Compiler):
 
 
 class ArmclangCompiler(Compiler):
+    '''
+    This is the Keil armclang.
+    '''
 
     def __init__(self) -> None:
         if not self.is_cross:


### PR DESCRIPTION
---
Initial support for ARM Ltd.'s `armclang` toolchain. Not to be confused with Keil's `armclang` cross-compilation toolchain for embedded devices. Passes basic smoke tests at least.