### PR TITLE
modules: use find_program implementation to find programs

### DIFF
--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -34,7 +34,6 @@ from ..interpreterbase import (
     InvalidArguments,
     InterpreterException,
 )
-from ..programs import ExternalProgram
 
 
 COMPATIBILITIES = ['AnyNewerVersion', 'SameMajorVersion', 'SameMinorVersion', 'ExactVersion']
@@ -233,11 +232,11 @@ class CmakeModule(ExtensionModule):
 
         return compiler.sizeof('void *', '', env)
 
-    def detect_cmake(self):
+    def detect_cmake(self, state):
         if self.cmake_detected:
             return True
 
-        cmakebin = ExternalProgram('cmake', silent=False)
+        cmakebin = state.find_program('cmake', silent=False)
         if not cmakebin.found():
             return False
 
@@ -272,7 +271,7 @@ class CmakeModule(ExtensionModule):
         if compatibility not in COMPATIBILITIES:
             raise mesonlib.MesonException('compatibility must be either AnyNewerVersion, SameMajorVersion or ExactVersion.')
 
-        if not self.detect_cmake():
+        if not self.detect_cmake(state):
             raise mesonlib.MesonException('Unable to find cmake')
 
         pkgroot = pkgroot_name = kwargs.get('install_dir', None)

--- a/mesonbuild/modules/dlang.py
+++ b/mesonbuild/modules/dlang.py
@@ -22,7 +22,6 @@ from . import ExtensionModule
 from .. import dependencies
 from .. import mlog
 from ..mesonlib import Popen_safe, MesonException
-from ..programs import ExternalProgram
 
 class DlangModule(ExtensionModule):
     class_dubbin = None
@@ -34,7 +33,7 @@ class DlangModule(ExtensionModule):
             'generate_dub_file': self.generate_dub_file,
         })
 
-    def _init_dub(self):
+    def _init_dub(self, state):
         if DlangModule.class_dubbin is None:
             self.dubbin = dependencies.DubDependency.class_dubbin
             DlangModule.class_dubbin = self.dubbin
@@ -42,7 +41,7 @@ class DlangModule(ExtensionModule):
             self.dubbin = DlangModule.class_dubbin
 
         if DlangModule.class_dubbin is None:
-            self.dubbin = self.check_dub()
+            self.dubbin = self.check_dub(state)
             DlangModule.class_dubbin = self.dubbin
         else:
             self.dubbin = DlangModule.class_dubbin
@@ -53,7 +52,7 @@ class DlangModule(ExtensionModule):
 
     def generate_dub_file(self, state, args, kwargs):
         if not DlangModule.init_dub:
-            self._init_dub()
+            self._init_dub(state)
 
         if len(args) < 2:
             raise MesonException('Missing arguments')
@@ -109,8 +108,8 @@ class DlangModule(ExtensionModule):
         p, out = Popen_safe(self.dubbin.get_command() + args, env=env)[0:2]
         return p.returncode, out.strip()
 
-    def check_dub(self):
-        dubbin = ExternalProgram('dub', silent=True)
+    def check_dub(self, state):
+        dubbin = state.find_program('dub', silent=True)
         if dubbin.found():
             try:
                 p, out = Popen_safe(dubbin.get_command() + ['--version'])[0:2]


### PR DESCRIPTION
Do not use ExternalProgram as that is too low-level and doesn't handle e.g. machine file overrides.

Fixes #9733