### PR TITLE
unpin pylint in CI -- the mentioned issue is long since fixed

### DIFF
--- a/.github/workflows/lint_mypy.yml
+++ b/.github/workflows/lint_mypy.yml
@@ -23,8 +23,7 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '3.x'
-    # pylint version constraint can be removed when https://github.com/PyCQA/pylint/issues/3524 is resolved
-    - run: python -m pip install pylint==2.4.4
+    - run: python -m pip install pylint
     - run: pylint mesonbuild
 
   custom_lint:


### PR DESCRIPTION
And the outdated pin means some error messages that are a lot better in newer versions aren't available.