### PR TITLE
add FeatureNew decorators for various modules that were lacking them

### DIFF
--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -212,6 +212,7 @@ class CmakeModule(ExtensionModule):
     cmake_detected = False
     cmake_root = None
 
+    @FeatureNew('CMake Module', '0.50.0')
     def __init__(self, interpreter):
         super().__init__(interpreter)
         self.methods.update({

--- a/mesonbuild/modules/dlang.py
+++ b/mesonbuild/modules/dlang.py
@@ -21,12 +21,14 @@ import os
 from . import ExtensionModule
 from .. import dependencies
 from .. import mlog
+from ..interpreterbase import FeatureNew
 from ..mesonlib import Popen_safe, MesonException
 
 class DlangModule(ExtensionModule):
     class_dubbin = None
     init_dub = False
 
+    @FeatureNew('Dlang Module', '0.48.0')
     def __init__(self, interpreter):
         super().__init__(interpreter)
         self.methods.update({

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -41,6 +41,7 @@ if T.TYPE_CHECKING:
 
 class FSModule(ExtensionModule):
 
+    @FeatureNew('Fs Module', '0.53.0')
     def __init__(self, interpreter: 'Interpreter') -> None:
         super().__init__(interpreter)
         self.methods.update({

--- a/mesonbuild/modules/python3.py
+++ b/mesonbuild/modules/python3.py
@@ -16,12 +16,13 @@ import sysconfig
 from .. import mesonlib
 
 from . import ExtensionModule
-from ..interpreterbase import noKwargs, permittedKwargs, FeatureDeprecated
+from ..interpreterbase import noKwargs, permittedKwargs, FeatureDeprecated, FeatureNew
 from ..build import known_shmod_kwargs
 from ..programs import ExternalProgram
 
 
 class Python3Module(ExtensionModule):
+    @FeatureNew('python3 module', '0.38.0')
     @FeatureDeprecated('python3 module', '0.48.0')
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/mesonbuild/modules/qt6.py
+++ b/mesonbuild/modules/qt6.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 from .qt import QtBaseModule
+from ..interpreterbase import FeatureNew
 
 
 class Qt6Module(QtBaseModule):
 
+    @FeatureNew('Qt6 Module', '0.57.0')
     def __init__(self, interpreter):
         QtBaseModule.__init__(self, interpreter, qt_version=6)
 


### PR DESCRIPTION
Going back to 0.38, though some of them are far older. The original implementation of FeatureNew only added backdated feature checks that far, anyway.