### PR TITLE
fix(rpm): remove unnecessary index in loop

### DIFF
--- a/mesonbuild/modules/rpm.py
+++ b/mesonbuild/modules/rpm.py
@@ -90,7 +90,7 @@ class RPMModule(ExtensionModule):
             for compiler in required_compilers:
                 fn.write('BuildRequires: %s\n' % compiler)
             for dep in state.environment.coredata.deps.host:
-                fn.write('BuildRequires: pkgconfig(%s)\n' % dep[0])
+                fn.write('BuildRequires: pkgconfig(%s)\n' % dep)
 #   ext_libs and ext_progs have been removed from coredata so the following code
 #   no longer works. It is kept as a reminder of the idea should anyone wish
 #   to re-implement it.


### PR DESCRIPTION
Discovered this error while attempting to build swaync

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/mesonbuild/mesonmain.py", line 228, in run
    return options.run_func(options)
  File "/usr/lib/python3.10/site-packages/mesonbuild/msetup.py", line 281, in run
    app.generate()
  File "/usr/lib/python3.10/site-packages/mesonbuild/msetup.py", line 184, in generate
    self._generate(env)
  File "/usr/lib/python3.10/site-packages/mesonbuild/msetup.py", line 223, in _generate
    intr.run()
  File "/usr/lib/python3.10/site-packages/mesonbuild/interpreter/interpreter.py", line 2476, in run
    super().run()
  File "/usr/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 132, in run
    self.evaluate_codeblock(self.ast, start=1)
  File "/usr/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 157, in evaluate_codeblock
    raise e
  File "/usr/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 150, in evaluate_codeblock
    self.evaluate_statement(cur)
  File "/usr/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 167, in evaluate_statement
    return self.method_call(cur)
  File "/usr/lib/python3.10/site-packages/mesonbuild/interpreterbase/interpreterbase.py", line 598, in method_call
    return self._holderify(obj.method_call(method_name, args, kwargs))
  File "/usr/lib/python3.10/site-packages/mesonbuild/interpreter/interpreterobjects.py", line 766, in method_call
    ret = method(state, args, kwargs)
  File "/usr/lib/python3.10/site-packages/mesonbuild/interpreterbase/decorators.py", line 55, in wrapped
    return f(*wrapped_args, **wrapped_kwargs)
  File "/usr/lib/python3.10/site-packages/mesonbuild/modules/rpm.py", line 93, in generate_spec_template
    fn.write('BuildRequires: pkgconfig(%s)\n' % dep[0])
TypeError: not all arguments converted during string formatting
```
looks like some time ago it was broken (when .host was added to .deps)