### PR TITLE
Fix mypy 0.930 issues

### DIFF
--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -437,7 +437,7 @@ class CLikeCompiler(Compiler):
             dependencies = []
         elif not isinstance(dependencies, collections.abc.Iterable):
             # TODO: we want to ensure the front end does the listifing here
-            dependencies = [dependencies]  # type: ignore
+            dependencies = [dependencies]
         # Collect compiler arguments
         cargs = self.compiler_args()  # type: arglist.CompilerArgs
         largs = []  # type: T.List[str]

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -1319,11 +1319,11 @@ def extract_as_list(dict_object: T.Dict[_T, _U], key: _T, pop: bool = False) -> 
     '''
     Extracts all values from given dict_object and listifies them.
     '''
-    fetch = dict_object.get
+    fetch: T.Callable[[_T], _U] = dict_object.get
     if pop:
         fetch = dict_object.pop
     # If there's only one key, we don't return a list with one element
-    return listify(fetch(key, []), flatten=True)
+    return listify(fetch(key) or [], flatten=True)
 
 
 def typeslistify(item: 'T.Union[_T, T.Sequence[_T]]',


### PR DESCRIPTION
Removed errant "type: ignore".

Fixed issue with "fetch" call. This issue was the following:

Dict::get() and Dict::pop() have the following signature:

T.Callable[[_T, _U], _U | None] OR T.Callable[[_T], _U | None]

Note how the return type is _U here. When the fetch() function was
actually being called, it had the following signature:

T.Callable[[_T, T.List[_U]], T.Union[T.List[_U], _U]]

This is incompatible with the previous definitions. The solution is
simply to move where the default value is introduced if fetch() produces
None.