### PR TITLE
cygwin: fix broken python versions

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -71,6 +71,13 @@ jobs:
             vala
             zlib-devel
 
+      - name: workaround wrong python version
+        run: |
+          export PATH=/usr/sbin:/usr/bin:/usr/local/bin:$(cygpath ${SYSTEMROOT})/system32
+          update-alternatives --verbose --set python /usr/bin/python3.8
+          update-alternatives --verbose --set python3 /usr/bin/python3.8
+        shell: C:\cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
+
       - name: Run pip
         run: |
           export PATH=/usr/bin:/usr/local/bin:$(cygpath ${SYSTEMROOT})/system32


### PR DESCRIPTION
multiple versions of python are packaged by cygwin, and the default python is auto-selected as the latest one via a Debian-like alternatives system.

This recently broke because dblatex is built against 3.9, causing it to be installed too and resulting in multiple (inconsistent) versions of python being installed, and `python3` pointing to the one we don't have devel packages for and isn't even the default version.

Fix this by pointing back to the intended python.