### PR TITLE
rename lint workflow for less confusion

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,22 +1,22 @@
-name: LintMypy
+name: Lint
 
 concurrency:
-  group: mypy-${{ github.head_ref }}
+  group: lint-${{ github.head_ref }}
   cancel-in-progress: true
 
 on:
   push:
     paths:
     - "**.py"
-    - ".github/workflows/lint_mypy.yml"
+    - ".github/workflows/lint.yml"
   pull_request:
     paths:
     - "**.py"
-    - ".github/workflows/lint_mypy.yml"
+    - ".github/workflows/lint.yml"
 
 jobs:
 
-  lint:
+  pylint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
For a long time now, this has done 3 different things, only one of which is mypy. But they are labeled:

- LintMypy / lint

  (runs pylint)

- LintMypy / custom_lint

  (runs a custom script)

- LintMypy / mypy

  (actually runs mypy)

This reduces the usable length of the label which isn't all that long to begin with, is actively misleading, and even when you know what is going on, it becomes harder to tell at a glance what failed. Change it to be more unambiguous.