### PR TITLE
Add support for Qt 6.1+

### DIFF
--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -69,6 +69,12 @@ def get_qmake_host_bins(qvars: T.Dict[str, str]) -> str:
     return qvars['QT_INSTALL_BINS']
 
 
+def get_qmake_host_libexecs(qvars: T.Dict[str, str]) -> str:
+    if 'QT_HOST_LIBEXECS' in qvars:
+        return qvars['QT_HOST_LIBEXECS']
+    return qvars['QT_INSTALL_LIBEXECS']
+
+
 def _get_modules_lib_suffix(version: str, info: 'MachineInfo', is_debug: bool) -> str:
     """Get the module suffix based on platform and debug type."""
     suffix = ''
@@ -277,6 +283,7 @@ class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=abc.ABCMeta):
         libdir = qvars['QT_INSTALL_LIBS']
         # Used by qt.compilers_detect()
         self.bindir = get_qmake_host_bins(qvars)
+        self.libexecdir = get_qmake_host_libexecs(qvars)
 
         # Use the buildtype by default, but look at the b_vscrt option if the
         # compiler supports it.
@@ -353,6 +360,7 @@ class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=abc.ABCMeta):
             self.is_found = True
             # Used by self.compilers_detect()
             self.bindir = get_qmake_host_bins(qvars)
+            self.libexecdir = get_qmake_host_libexecs(qvars)
 
     def log_info(self) -> str:
         return 'qmake'

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -128,6 +128,8 @@ class QtBaseModule(ExtensionModule):
             for b in self.tools:
                 if qt_dep.bindir:
                     yield os.path.join(qt_dep.bindir, b), b
+                if qt_dep.libexecdir:
+                    yield os.path.join(qt_dep.libexecdir, b), b
                 # prefer the <tool>-qt<version> of the tool to the plain one, as we
                 # don't know what the unsuffixed one points to without calling it.
                 yield f'{b}-qt{qt_dep.qtver}', b


### PR DESCRIPTION
Qt 6.1 moved the location of some binaries from QT_HOST_BINS to
QT_HOST_LIBEXECS as noted in the changelog:

c515ee178f Move build tools to libexec instead of the bin dir
- Tools that are called by the build system and are unlikely to be
called by the user are now installed to the libexec directory.

https://code.qt.io/cgit/qt/qtreleasenotes.git/tree/qt/6.1.0/release-note.txt

To compensate, meson now needs to look for moc, rcc, uic, etc. in
QT_HOST_LIBEXECS as well as QT_HOST_BINS.

Fixes: https://github.com/mesonbuild/meson/issues/9791