### PR TITLE
subproject: fix version validation on lookup

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -829,6 +829,11 @@ external dependencies (including libraries) must go to "dependencies".''')
             subproject = self.subprojects[subp_name]
             if required and not subproject.found():
                 raise InterpreterException(f'Subproject "{subproject.subdir}" required but not found.')
+            if 'version' in kwargs:
+                pv = self.build.subprojects[subp_name]
+                wanted = kwargs['version']
+                if pv == 'undefined' or not mesonlib.version_compare_many(pv, wanted)[0]:
+                    raise InterpreterException(f'Subproject {subp_name} version is {pv} but {wanted} required.')
             return subproject
 
         r = self.environment.wrap_resolver

--- a/test cases/failing/120 subproject version conflict/meson.build
+++ b/test cases/failing/120 subproject version conflict/meson.build
@@ -1,0 +1,4 @@
+project('120 subproject version conflict')
+
+A_dep = subproject('A').get_variable('A_dep')
+B_dep = subproject('B', version: '1').get_variable('B_dep')

--- a/test cases/failing/120 subproject version conflict/subprojects/A/meson.build
+++ b/test cases/failing/120 subproject version conflict/subprojects/A/meson.build
@@ -1,0 +1,4 @@
+project('A')
+
+B_dep = subproject('B').get_variable('B_dep')
+A_dep = declare_dependency(dependencies: B_dep)

--- a/test cases/failing/120 subproject version conflict/subprojects/B/meson.build
+++ b/test cases/failing/120 subproject version conflict/subprojects/B/meson.build
@@ -1,0 +1,3 @@
+project('B', version: '100')
+
+B_dep = declare_dependency()

--- a/test cases/failing/120 subproject version conflict/test.json
+++ b/test cases/failing/120 subproject version conflict/test.json
@@ -1,0 +1,7 @@
+{
+    "stdout": [
+        {
+            "line": "test cases/failing/120 subproject version conflict/meson.build:4:0: ERROR: Subproject B version is 100 but 1 required."
+        }
+    ]
+}


### PR DESCRIPTION
Fixes a bug where the subproject version was not validated
when the subproject had already been processed.

The bug would cause inconsistent build results if the subproject was
referenced more than once (diamond) with conflicting version requirements.