### PR TITLE
Add a fastyaml loader for refman docs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,5 +42,5 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '3.x'
-    - run: python -m pip install mypy
+    - run: python -m pip install mypy types-PyYAML
     - run: python run_mypy.py

--- a/docs/markdown/Yaml-RefMan.md
+++ b/docs/markdown/Yaml-RefMan.md
@@ -13,7 +13,10 @@ Additionally, multiple generation backends can be supported (besides the
 Markdown generator for mesonbuild.com).
 
 The generator that reads these YAML files is located in `docs/refman`, with the
-main executable being `docs/genrefman.py`.
+main executable being `docs/genrefman.py`.  By default `genrefman.py` will load
+the yaml manual using a strict subset of yaml at the cost of loading slowly.
+You may optionally disable all these safety checks using the `fastyaml` loader,
+which will significantly speed things up at the cost of being less correct.
 
 ## Linking to the Reference Manual
 

--- a/docs/refman/loaderyaml.py
+++ b/docs/refman/loaderyaml.py
@@ -295,9 +295,9 @@ class LoaderYAML(LoaderBase):
         return [module, *objs]
 
     def load_impl(self) -> ReferenceManual:
-        mlog.log('Loading YAML refererence manual')
+        mlog.log('Loading YAML reference manual')
         with mlog.nested():
-            return ReferenceManual(
+            manual = ReferenceManual(
                 functions=[self._load_function(x) for x in self.func_dir.iterdir()],
                 objects=mesonlib.listify([
                     [self._load_object(ObjectType.ELEMENTARY, x) for x in self.elem_dir.iterdir()],
@@ -306,3 +306,8 @@ class LoaderYAML(LoaderBase):
                     [self._load_module(x) for x in self.modules_dir.iterdir()]
                 ], flatten=True)
             )
+
+            if not self.strict:
+                mlog.warning('YAML reference manual loaded using the best-effort fastyaml loader.  Results are not guaranteed to be stable or correct.')
+
+            return manual

--- a/docs/refman/main.py
+++ b/docs/refman/main.py
@@ -33,7 +33,7 @@ meson_root = Path(__file__).absolute().parents[2]
 
 def main() -> int:
     parser = argparse.ArgumentParser(description='Meson reference manual generator')
-    parser.add_argument('-l', '--loader', type=str, default='yaml', choices=['yaml', 'pickle'], help='Information loader backend')
+    parser.add_argument('-l', '--loader', type=str, default='yaml', choices=['yaml', 'fastyaml', 'pickle'], help='Information loader backend')
     parser.add_argument('-g', '--generator', type=str, choices=['print', 'pickle', 'md', 'json', 'man'], required=True, help='Generator backend')
     parser.add_argument('-s', '--sitemap', type=Path, default=meson_root / 'docs' / 'sitemap.txt', help='Path to the input sitemap.txt')
     parser.add_argument('-o', '--out', type=Path, required=True, help='Output directory for generated files')
@@ -49,6 +49,7 @@ def main() -> int:
 
     loaders: T.Dict[str, T.Callable[[], LoaderBase]] = {
         'yaml': lambda: LoaderYAML(args.input),
+        'fastyaml': lambda: LoaderYAML(args.input, strict=False),
         'pickle': lambda: LoaderPickle(args.input),
     }
 

--- a/docs/refman/main.py
+++ b/docs/refman/main.py
@@ -40,9 +40,13 @@ def main() -> int:
     parser.add_argument('-i', '--input', type=Path, default=meson_root / 'docs' / 'yaml', help='Input path for the selected loader')
     parser.add_argument('--link-defs', type=Path, help='Output file for the MD generator link definition file')
     parser.add_argument('--depfile', type=Path, default=None, help='Set to generate a depfile')
+    parser.add_argument('-q', '--quiet', action='store_true', help='Suppress verbose output')
     parser.add_argument('--force-color', action='store_true', help='Force enable colors')
     parser.add_argument('--no-modules', action='store_true', help='Disable building modules')
     args = parser.parse_args()
+
+    if args.quiet:
+        mlog.set_quiet()
 
     if args.force_color:
         mlog.colorize_console = lambda: True


### PR DESCRIPTION
`genrefman.py -l yaml` currently takes about 80 seconds on my machine.  This is almost entirely due to the usage of `strictyaml`, which [does not consider speed to be a priority](https://hitchdev.com/strictyaml/why/speed-not-a-priority/).  This PR adds a `fastyaml` loader which uses the `CLoader` from `pyyaml`.  On my machine this reduces the runtime to 0.95 seconds.  I'm not entirely sure if this is of interest to meson developers, since you can already use `-l pickle` for a similar speedup (after you do the initial load), but I thought I would put it here just in case :).