### PR TITLE
compilers: push the compiler id to a class variable

### DIFF
--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -185,9 +185,7 @@ class ClangCCompiler(_ClangCStds, ClangCompiler, CCompiler):
 
 class ArmLtdClangCCompiler(ClangCCompiler):
 
-    def __init__(self, *args, **kwargs):
-        ClangCCompiler.__init__(self, *args, **kwargs)
-        self.id = 'armltdclang'
+    id = 'armltdclang'
 
 
 class AppleClangCCompiler(ClangCCompiler):
@@ -204,6 +202,9 @@ class AppleClangCCompiler(ClangCCompiler):
 
 
 class EmscriptenCCompiler(EmscriptenMixin, ClangCCompiler):
+
+    id = 'emscripten'
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,
@@ -214,7 +215,6 @@ class EmscriptenCCompiler(EmscriptenMixin, ClangCCompiler):
         ClangCCompiler.__init__(self, exelist, version, for_machine, is_cross,
                                 info, exe_wrapper=exe_wrapper, linker=linker,
                                 defines=defines, full_version=full_version)
-        self.id = 'emscripten'
 
 
 class ArmclangCCompiler(ArmclangCompiler, CCompiler):
@@ -326,6 +326,9 @@ class PGICCompiler(PGICompiler, CCompiler):
 
 
 class NvidiaHPC_CCompiler(PGICompiler, CCompiler):
+
+    id = 'nvidia_hpc'
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,
@@ -333,7 +336,6 @@ class NvidiaHPC_CCompiler(PGICompiler, CCompiler):
         CCompiler.__init__(self, exelist, version, for_machine, is_cross,
                            info, exe_wrapper, linker=linker, full_version=full_version)
         PGICompiler.__init__(self)
-        self.id = 'nvidia_hpc'
 
 
 class ElbrusCCompiler(ElbrusCompiler, CCompiler):

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -260,9 +260,8 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
 
 
 class ArmLtdClangCPPCompiler(ClangCPPCompiler):
-    def __init__(self, *args, **kwargs):
-        ClangCPPCompiler.__init__(self, *args, **kwargs)
-        self.id = 'armltdclang'
+
+    id = 'armltdclang'
 
 
 class AppleClangCPPCompiler(ClangCPPCompiler):
@@ -280,6 +279,9 @@ class AppleClangCPPCompiler(ClangCPPCompiler):
 
 
 class EmscriptenCPPCompiler(EmscriptenMixin, ClangCPPCompiler):
+
+    id = 'emscripten'
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,
@@ -290,7 +292,6 @@ class EmscriptenCPPCompiler(EmscriptenMixin, ClangCPPCompiler):
         ClangCPPCompiler.__init__(self, exelist, version, for_machine, is_cross,
                                   info, exe_wrapper=exe_wrapper, linker=linker,
                                   defines=defines, full_version=full_version)
-        self.id = 'emscripten'
 
     def get_option_compile_args(self, options: 'KeyedOptionDictType') -> T.List[str]:
         args = []
@@ -448,6 +449,9 @@ class PGICPPCompiler(PGICompiler, CPPCompiler):
 
 
 class NvidiaHPC_CPPCompiler(PGICompiler, CPPCompiler):
+
+    id = 'nvidia_hpc'
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,
@@ -455,8 +459,6 @@ class NvidiaHPC_CPPCompiler(PGICompiler, CPPCompiler):
         CPPCompiler.__init__(self, exelist, version, for_machine, is_cross,
                              info, exe_wrapper, linker=linker, full_version=full_version)
         PGICompiler.__init__(self)
-
-        self.id = 'nvidia_hpc'
 
 
 class ElbrusCPPCompiler(ElbrusCompiler, CPPCompiler):
@@ -697,6 +699,9 @@ class CPP11AsCPP14Mixin(CompilerMixinBase):
 
 
 class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixin, MSVCCompiler, CPPCompiler):
+
+    id = 'msvc'
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
                  is_cross: bool, info: 'MachineInfo', target: str,
                  exe_wrapper: T.Optional['ExternalProgram'] = None,
@@ -705,7 +710,6 @@ class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixi
         CPPCompiler.__init__(self, exelist, version, for_machine, is_cross,
                              info, exe_wrapper, linker=linker, full_version=full_version)
         MSVCCompiler.__init__(self, target)
-        self.id = 'msvc'
 
     def get_options(self) -> 'KeyedOptionDictType':
         cpp_stds = ['none', 'c++11', 'vc++11']
@@ -737,6 +741,9 @@ class VisualStudioCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixi
         return args
 
 class ClangClCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixin, ClangClCompiler, CPPCompiler):
+
+    id = 'clang-cl'
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
                  is_cross: bool, info: 'MachineInfo', target: str,
                  exe_wrapper: T.Optional['ExternalProgram'] = None,
@@ -745,7 +752,6 @@ class ClangClCPPCompiler(CPP11AsCPP14Mixin, VisualStudioLikeCPPCompilerMixin, Cl
         CPPCompiler.__init__(self, exelist, version, for_machine, is_cross,
                              info, exe_wrapper, linker=linker, full_version=full_version)
         ClangClCompiler.__init__(self, target)
-        self.id = 'clang-cl'
 
     def get_options(self) -> 'KeyedOptionDictType':
         cpp_stds = ['none', 'c++11', 'vc++11', 'c++14', 'vc++14', 'c++17', 'vc++17', 'c++latest']

--- a/mesonbuild/compilers/cs.py
+++ b/mesonbuild/compilers/cs.py
@@ -40,9 +40,8 @@ class CsCompiler(BasicLinkerIsCompilerMixin, Compiler):
     language = 'cs'
 
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
-                 info: 'MachineInfo', comp_id: str, runner: T.Optional[str] = None):
+                 info: 'MachineInfo', runner: T.Optional[str] = None):
         super().__init__(exelist, version, for_machine, info)
-        self.id = comp_id
         self.runner = runner
 
     @classmethod
@@ -121,19 +120,20 @@ class CsCompiler(BasicLinkerIsCompilerMixin, Compiler):
 
 
 class MonoCompiler(CsCompiler):
+
+    id = 'mono'
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
                  info: 'MachineInfo'):
-        super().__init__(exelist, version, for_machine, info, 'mono',
-                         runner='mono')
+        super().__init__(exelist, version, for_machine, info, runner='mono')
 
     def rsp_file_syntax(self) -> 'RSPFileSyntax':
         return RSPFileSyntax.GCC
 
 
 class VisualStudioCsCompiler(CsCompiler):
-    def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
-                 info: 'MachineInfo'):
-        super().__init__(exelist, version, for_machine, info, 'csc')
+
+    id = 'csc'
 
     def get_buildtype_args(self, buildtype: str) -> T.List[str]:
         res = mono_buildtype_args[buildtype]

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -173,6 +173,8 @@ class CudaCompiler(Compiler):
     # Reverse map -short to --long options.
     _FLAG_SHORT2LONG_WITHARGS = {v: k for k, v in _FLAG_LONG2SHORT_WITHARGS.items()}
 
+    id = 'nvcc'
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
                  is_cross: bool, exe_wrapper: T.Optional['ExternalProgram'],
                  host_compiler: Compiler, info: 'MachineInfo',
@@ -182,7 +184,6 @@ class CudaCompiler(Compiler):
         self.exe_wrapper = exe_wrapper
         self.host_compiler = host_compiler
         self.base_options = host_compiler.base_options
-        self.id = 'nvcc'
         self.warn_args = {level: self._to_host_flags(flags) for level, flags in host_compiler.warn_args.items()}
 
     @classmethod

--- a/mesonbuild/compilers/d.py
+++ b/mesonbuild/compilers/d.py
@@ -681,6 +681,7 @@ class GnuDCompiler(GnuCompiler, DCompiler):
 
     # we mostly want DCompiler, but that gives us the Compiler.LINKER_PREFIX instead
     LINKER_PREFIX = GnuCompiler.LINKER_PREFIX
+    id = 'gcc'
 
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
                  info: 'MachineInfo', arch: str, *,
@@ -692,7 +693,6 @@ class GnuDCompiler(GnuCompiler, DCompiler):
                            exe_wrapper=exe_wrapper, linker=linker,
                            full_version=full_version, is_cross=is_cross)
         GnuCompiler.__init__(self, {})
-        self.id = 'gcc'
         default_warn_args = ['-Wall', '-Wdeprecated']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -760,6 +760,8 @@ def find_ldc_dmd_frontend_version(version_output: T.Optional[str]) -> T.Optional
 
 class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
 
+    id = 'llvm'
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
                  info: 'MachineInfo', arch: str, *,
                  exe_wrapper: T.Optional['ExternalProgram'] = None,
@@ -770,7 +772,6 @@ class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
                            exe_wrapper=exe_wrapper, linker=linker,
                            full_version=full_version, is_cross=is_cross)
         DmdLikeCompilerMixin.__init__(self, dmd_frontend_version=find_ldc_dmd_frontend_version(version_output))
-        self.id = 'llvm'
         self.base_options = {OptionKey(o) for o in ['b_coverage', 'b_colorout', 'b_vscrt', 'b_ndebug']}
 
     def get_colorout_args(self, colortype: str) -> T.List[str]:
@@ -824,6 +825,8 @@ class LLVMDCompiler(DmdLikeCompilerMixin, DCompiler):
 
 class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
 
+    id = 'dmd'
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
                  info: 'MachineInfo', arch: str, *,
                  exe_wrapper: T.Optional['ExternalProgram'] = None,
@@ -834,7 +837,6 @@ class DmdDCompiler(DmdLikeCompilerMixin, DCompiler):
                            exe_wrapper=exe_wrapper, linker=linker,
                            full_version=full_version, is_cross=is_cross)
         DmdLikeCompilerMixin.__init__(self, version)
-        self.id = 'dmd'
         self.base_options = {OptionKey(o) for o in ['b_coverage', 'b_colorout', 'b_vscrt', 'b_ndebug']}
 
     def get_colorout_args(self, colortype: str) -> T.List[str]:

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -260,6 +260,7 @@ class ElbrusFortranCompiler(ElbrusCompiler, FortranCompiler):
 class G95FortranCompiler(FortranCompiler):
 
     LINKER_PREFIX = '-Wl,'
+    id = 'g95'
 
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
@@ -268,7 +269,6 @@ class G95FortranCompiler(FortranCompiler):
         FortranCompiler.__init__(self, exelist, version, for_machine,
                                  is_cross, info, exe_wrapper, linker=linker,
                                  full_version=full_version)
-        self.id = 'g95'
         default_warn_args = ['-Wall']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -286,15 +286,7 @@ class G95FortranCompiler(FortranCompiler):
 class SunFortranCompiler(FortranCompiler):
 
     LINKER_PREFIX = '-Wl,'
-
-    def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
-                 info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
-                 linker: T.Optional['DynamicLinker'] = None,
-                 full_version: T.Optional[str] = None):
-        FortranCompiler.__init__(self, exelist, version, for_machine,
-                                 is_cross, info, exe_wrapper, linker=linker,
-                                 full_version=full_version)
-        self.id = 'sun'
+    id = 'sun'
 
     def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
         return ['-fpp']
@@ -318,6 +310,7 @@ class SunFortranCompiler(FortranCompiler):
 class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
 
     file_suffixes = ('f90', 'f', 'for', 'ftn', 'fpp', )
+    id = 'intel'
 
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
@@ -329,7 +322,6 @@ class IntelFortranCompiler(IntelGnuLikeCompiler, FortranCompiler):
         # FIXME: Add support for OS X and Windows in detect_fortran_compiler so
         # we are sent the type of compiler
         IntelGnuLikeCompiler.__init__(self)
-        self.id = 'intel'
         default_warn_args = ['-warn', 'general', '-warn', 'truncated_source']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -404,6 +396,8 @@ class IntelClFortranCompiler(IntelVisualStudioLikeCompiler, FortranCompiler):
 
 class PathScaleFortranCompiler(FortranCompiler):
 
+    id = 'pathscale'
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,
@@ -411,7 +405,6 @@ class PathScaleFortranCompiler(FortranCompiler):
         FortranCompiler.__init__(self, exelist, version, for_machine,
                                  is_cross, info, exe_wrapper, linker=linker,
                                  full_version=full_version)
-        self.id = 'pathscale'
         default_warn_args = ['-fullwarn']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -447,6 +440,8 @@ class PGIFortranCompiler(PGICompiler, FortranCompiler):
 
 class NvidiaHPC_FortranCompiler(PGICompiler, FortranCompiler):
 
+    id = 'nvidia_hpc'
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,
@@ -456,7 +451,6 @@ class NvidiaHPC_FortranCompiler(PGICompiler, FortranCompiler):
                                  full_version=full_version)
         PGICompiler.__init__(self)
 
-        self.id = 'nvidia_hpc'
         default_warn_args = ['-Minform=inform']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -466,6 +460,8 @@ class NvidiaHPC_FortranCompiler(PGICompiler, FortranCompiler):
 
 class FlangFortranCompiler(ClangCompiler, FortranCompiler):
 
+    id = 'flang'
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,
@@ -474,7 +470,6 @@ class FlangFortranCompiler(ClangCompiler, FortranCompiler):
                                  is_cross, info, exe_wrapper, linker=linker,
                                  full_version=full_version)
         ClangCompiler.__init__(self, {})
-        self.id = 'flang'
         default_warn_args = ['-Minform=inform']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -496,11 +491,11 @@ class FlangFortranCompiler(ClangCompiler, FortranCompiler):
 
 class ArmLtdFlangFortranCompiler(FlangFortranCompiler):
 
-    def __init__(self, *args, **kwargs):
-        FlangFortranCompiler.__init__(self, *args, **kwargs)
-        self.id = 'armltdflang'
+    id = 'armltdflang'
 
 class Open64FortranCompiler(FortranCompiler):
+
+    id = 'open64'
 
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
@@ -509,7 +504,6 @@ class Open64FortranCompiler(FortranCompiler):
         FortranCompiler.__init__(self, exelist, version, for_machine,
                                  is_cross, info, exe_wrapper, linker=linker,
                                  full_version=full_version)
-        self.id = 'open64'
         default_warn_args = ['-fullwarn']
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -522,6 +516,8 @@ class Open64FortranCompiler(FortranCompiler):
 
 class NAGFortranCompiler(FortranCompiler):
 
+    id = 'nagfor'
+
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,
@@ -529,7 +525,6 @@ class NAGFortranCompiler(FortranCompiler):
         FortranCompiler.__init__(self, exelist, version, for_machine,
                                  is_cross, info, exe_wrapper, linker=linker,
                                  full_version=full_version)
-        self.id = 'nagfor'
         # Warnings are on by default; -w disables (by category):
         self.warn_args = {
             '0': ['-w=all'],

--- a/mesonbuild/compilers/java.py
+++ b/mesonbuild/compilers/java.py
@@ -30,11 +30,11 @@ if T.TYPE_CHECKING:
 class JavaCompiler(BasicLinkerIsCompilerMixin, Compiler):
 
     language = 'java'
+    id = 'unknown'
 
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
                  info: 'MachineInfo', full_version: T.Optional[str] = None):
         super().__init__(exelist, version, for_machine, info, full_version=full_version)
-        self.id = 'unknown'
         self.javarunner = 'java'
 
     def get_werror_args(self) -> T.List[str]:

--- a/mesonbuild/compilers/mixins/arm.py
+++ b/mesonbuild/compilers/mixins/arm.py
@@ -74,10 +74,11 @@ class ArmCompiler(Compiler):
 
     """Functionality that is common to all ARM family compilers."""
 
+    id = 'arm'
+
     def __init__(self) -> None:
         if not self.is_cross:
             raise mesonlib.EnvironmentException('armcc supports only cross-compilation.')
-        self.id = 'arm'
         default_warn_args = []  # type: T.List[str]
         self.warn_args = {'0': [],
                           '1': default_warn_args,
@@ -140,6 +141,8 @@ class ArmclangCompiler(Compiler):
     This is the Keil armclang.
     '''
 
+    id = 'armclang'
+
     def __init__(self) -> None:
         if not self.is_cross:
             raise mesonlib.EnvironmentException('armclang supports only cross-compilation.')
@@ -148,7 +151,6 @@ class ArmclangCompiler(Compiler):
             raise mesonlib.EnvironmentException(f'Unsupported Linker {self.linker.exelist}, must be armlink')
         if not mesonlib.version_compare(self.version, '==' + self.linker.version):
             raise mesonlib.EnvironmentException('armlink version does not match with compiler version')
-        self.id = 'armclang'
         self.base_options = {
             OptionKey(o) for o in
             ['b_pch', 'b_lto', 'b_pgo', 'b_sanitize', 'b_coverage',

--- a/mesonbuild/compilers/mixins/c2000.py
+++ b/mesonbuild/compilers/mixins/c2000.py
@@ -55,10 +55,11 @@ c2000_debug_args = {
 
 class C2000Compiler(Compiler):
 
+    id = 'c2000'
+
     def __init__(self) -> None:
         if not self.is_cross:
             raise EnvironmentException('c2000 supports only cross-compilation.')
-        self.id = 'c2000'
 
         self.can_compile_suffixes.add('asm')    # Assembly
         self.can_compile_suffixes.add('cla')    # Control Law Accelerator (CLA)

--- a/mesonbuild/compilers/mixins/ccrx.py
+++ b/mesonbuild/compilers/mixins/ccrx.py
@@ -59,10 +59,11 @@ class CcrxCompiler(Compiler):
         is_cross = True
         can_compile_suffixes = set()  # type: T.Set[str]
 
+    id = 'ccrx'
+
     def __init__(self) -> None:
         if not self.is_cross:
             raise EnvironmentException('ccrx supports only cross-compilation.')
-        self.id = 'ccrx'
         # Assembly
         self.can_compile_suffixes.add('src')
         default_warn_args = []  # type: T.List[str]

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -45,9 +45,10 @@ clang_optimization_args = {
 
 class ClangCompiler(GnuLikeCompiler):
 
+    id = 'clang'
+
     def __init__(self, defines: T.Optional[T.Dict[str, str]]):
         super().__init__()
-        self.id = 'clang'
         self.defines = defines or {}
         self.base_options.update(
             {OptionKey('b_colorout'), OptionKey('b_lto_threads'), OptionKey('b_lto_mode')})

--- a/mesonbuild/compilers/mixins/compcert.py
+++ b/mesonbuild/compilers/mixins/compcert.py
@@ -60,8 +60,9 @@ ccomp_args_to_wul = [
 
 class CompCertCompiler(Compiler):
 
+    id = 'ccomp'
+
     def __init__(self) -> None:
-        self.id = 'ccomp'
         # Assembly
         self.can_compile_suffixes.add('s')
         default_warn_args = []  # type: T.List[str]

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -32,9 +32,10 @@ class ElbrusCompiler(GnuLikeCompiler):
     # Elbrus compiler is nearly like GCC, but does not support
     # PCH, LTO, sanitizers and color output as of version 1.21.x.
 
+    id = 'lcc'
+
     def __init__(self) -> None:
         super().__init__()
-        self.id = 'lcc'
         self.base_options = {OptionKey(o) for o in ['b_pgo', 'b_coverage', 'b_ndebug', 'b_staticpic', 'b_lundef', 'b_asneeded']}
         default_warn_args = ['-Wall']
         self.warn_args = {'0': [],

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -328,10 +328,10 @@ class GnuCompiler(GnuLikeCompiler):
     GnuCompiler represents an actual GCC in its many incarnations.
     Compilers imitating GCC (Clang/Intel) should use the GnuLikeCompiler ABC.
     """
+    id = 'gcc'
 
     def __init__(self, defines: T.Optional[T.Dict[str, str]]):
         super().__init__()
-        self.id = 'gcc'
         self.defines = defines or {}
         self.base_options.update({OptionKey('b_colorout'), OptionKey('b_lto_threads')})
 

--- a/mesonbuild/compilers/mixins/intel.py
+++ b/mesonbuild/compilers/mixins/intel.py
@@ -66,6 +66,7 @@ class IntelGnuLikeCompiler(GnuLikeCompiler):
         '3': ['-O3'],
         's': ['-Os'],
     }
+    id = 'intel'
 
     def __init__(self) -> None:
         super().__init__()
@@ -77,7 +78,6 @@ class IntelGnuLikeCompiler(GnuLikeCompiler):
         self.base_options = {mesonlib.OptionKey(o) for o in [
             'b_pch', 'b_lundef', 'b_asneeded', 'b_pgo', 'b_coverage',
             'b_ndebug', 'b_staticpic', 'b_pie']}
-        self.id = 'intel'
         self.lang_header = 'none'
 
     def get_pch_suffix(self) -> str:
@@ -145,9 +145,7 @@ class IntelVisualStudioLikeCompiler(VisualStudioLikeCompiler):
         's': ['/Os'],
     }
 
-    def __init__(self, target: str) -> None:
-        super().__init__(target)
-        self.id = 'intel-cl'
+    id = 'intel-cl'
 
     def get_compiler_check_args(self, mode: CompileCheckMode) -> T.List[str]:
         args = super().get_compiler_check_args(mode)

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -43,9 +43,10 @@ pgi_buildtype_args = {
 
 class PGICompiler(Compiler):
 
+    id = 'pgi'
+
     def __init__(self) -> None:
         self.base_options = {OptionKey('b_pch')}
-        self.id = 'pgi'
 
         default_warn_args = ['-Minform=inform']
         self.warn_args = {'0': [],

--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -388,9 +388,7 @@ class MSVCCompiler(VisualStudioLikeCompiler):
 
     """Specific to the Microsoft Compilers."""
 
-    def __init__(self, target: str):
-        super().__init__(target)
-        self.id = 'msvc'
+    id = 'msvc'
 
     def get_compile_debugfile_args(self, rel_obj: str, pch: bool = False) -> T.List[str]:
         args = super().get_compile_debugfile_args(rel_obj, pch)
@@ -420,9 +418,10 @@ class ClangClCompiler(VisualStudioLikeCompiler):
 
     """Specific to Clang-CL."""
 
+    id = 'clang-cl'
+
     def __init__(self, target: str):
         super().__init__(target)
-        self.id = 'clang-cl'
 
         # Assembly
         self.can_compile_suffixes.add('s')

--- a/mesonbuild/compilers/mixins/xc16.py
+++ b/mesonbuild/compilers/mixins/xc16.py
@@ -55,10 +55,11 @@ xc16_debug_args = {
 
 class Xc16Compiler(Compiler):
 
+    id = 'xc16'
+
     def __init__(self) -> None:
         if not self.is_cross:
             raise EnvironmentException('xc16 supports only cross-compilation.')
-        self.id = 'xc16'
         # Assembly
         self.can_compile_suffixes.add('s')
         default_warn_args = []  # type: T.List[str]

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -44,6 +44,7 @@ class RustCompiler(Compiler):
 
     # rustc doesn't invoke the compiler itself, it doesn't need a LINKER_PREFIX
     language = 'rust'
+    id = 'rustc'
 
     _WARNING_LEVELS: T.Dict[str, T.List[str]] = {
         '0': ['-A', 'warnings'],
@@ -61,7 +62,6 @@ class RustCompiler(Compiler):
                          is_cross=is_cross, full_version=full_version,
                          linker=linker)
         self.exe_wrapper = exe_wrapper
-        self.id = 'rustc'
         self.base_options.add(OptionKey('b_colorout'))
         if 'link' in self.linker.id:
             self.base_options.add(OptionKey('b_vscrt'))
@@ -205,11 +205,4 @@ class ClippyRustCompiler(RustCompiler):
     This just provides us a different id
     """
 
-    def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
-                 is_cross: bool, info: 'MachineInfo',
-                 exe_wrapper: T.Optional['ExternalProgram'] = None,
-                 full_version: T.Optional[str] = None,
-                 linker: T.Optional['DynamicLinker'] = None):
-        super().__init__(exelist, version, for_machine, is_cross, info,
-                         exe_wrapper, full_version, linker)
-        self.id = 'clippy-driver rustc'
+    id = 'clippy-driver rustc'

--- a/mesonbuild/compilers/swift.py
+++ b/mesonbuild/compilers/swift.py
@@ -37,6 +37,7 @@ class SwiftCompiler(Compiler):
 
     LINKER_PREFIX = ['-Xlinker']
     language = 'swift'
+    id = 'llvm'
 
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
                  is_cross: bool, info: 'MachineInfo', full_version: T.Optional[str] = None,
@@ -45,7 +46,6 @@ class SwiftCompiler(Compiler):
                          is_cross=is_cross, full_version=full_version,
                          linker=linker)
         self.version = version
-        self.id = 'llvm'
 
     def needs_static_linker(self) -> bool:
         return True

--- a/mesonbuild/compilers/vala.py
+++ b/mesonbuild/compilers/vala.py
@@ -27,12 +27,12 @@ if T.TYPE_CHECKING:
 class ValaCompiler(Compiler):
 
     language = 'vala'
+    id = 'valac'
 
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice,
                  is_cross: bool, info: 'MachineInfo'):
         super().__init__(exelist, version, for_machine, info, is_cross=is_cross)
         self.version = version
-        self.id = 'valac'
         self.base_options = {OptionKey('b_colorout')}
 
     def needs_static_linker(self) -> bool:


### PR DESCRIPTION
It really is a per class value, and shouldn't be set per instance. It
also allows us to get rid of useless constructors, including those
breaking mypy