### PR TITLE
gnome: fix typo in vapigen option metadatadir

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1934,7 +1934,7 @@ class GnomeModule(ExtensionModule):
         cmd: T.List[T.Union[str, 'ExternalProgram']]
         cmd = [state.find_program('vapigen'), '--quiet', f'--library={library}', f'--directory={build_dir}']
         cmd.extend([f'--vapidir={d}' for d in kwargs['vapi_dirs']])
-        cmd.extend([f'--metadatdir={d}' for d in kwargs['metadata_dirs']])
+        cmd.extend([f'--metadatadir={d}' for d in kwargs['metadata_dirs']])
         cmd.extend([f'--girdir={d}' for d in kwargs['gir_dirs']])
         cmd += pkg_cmd
         cmd += ['--metadatadir=' + source_dir]


### PR DESCRIPTION
This typo was introduced in 9ef36fa80bf4483bcd837ea3985a51ab533c7972 - #9594 and can cause a build failure, because --metadatdir is not a valid vapigen option. This can be seen for example in the [fontmanager](https://github.com/FontManager/font-manager) or [AppStream](https://github.com/ximion/appstream) builds, so this fix should ideally be part of 0.60.1.

@eli-schwartz @dcbaker