### PR TITLE
fix broken module tests which caused gtkdoc-check to traceback on assert

### DIFF
--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -91,8 +91,11 @@ class ModuleState:
                   'env': env,
                   'depends': depends,
                   }
+        # typed_* takes a list, and gives a tuple to func_test. Violating that constraint
+        # makes the universe (or at least use of this function) implode
+        real_args = list(args)
         # TODO: Use interpreter internal API, but we need to go through @typed_kwargs
-        self._interpreter.func_test(self.current_node, args, kwargs)
+        self._interpreter.func_test(self.current_node, real_args, kwargs)
 
     def get_option(self, name: str, subproject: str = '',
                    machine: MachineChoice = MachineChoice.HOST,


### PR DESCRIPTION
Regression in commit 566c2c9a9c98d13f85ccef624e9ac584f64c6a4a.

The interpreter details are a bit of black magic. Functions expect tuples, but they receive lists and then the type-checking decorators convert those to tuples.

So, directly manhandling a `self._interpreter.func_*()` but passing it the tuple it nominally expected, actually explodes in your face by way of failing an assert, then dumping 'ERROR: Unhandled python exception'.

Fixes use of `gnome.gtkdoc(..., check: true)`, for example when building glib.

/cc @paper42