### PR TITLE
Fix default install tag for shared lib symlinks

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3092,8 +3092,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         return self.get_target_filename(t)
 
     def generate_shlib_aliases(self, target, outdir):
-        aliases = target.get_aliases()
-        for alias, to in aliases.items():
+        for alias, to, tag in target.get_aliases():
             aliasfile = os.path.join(self.environment.get_build_dir(), outdir, alias)
             try:
                 os.remove(aliasfile)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1464,8 +1464,8 @@ You probably should put it in link_with instead.''')
         else:
             self.extra_args[language] = args
 
-    def get_aliases(self) -> T.Dict[str, str]:
-        return {}
+    def get_aliases(self) -> T.List[T.Tuple[str, str, str]]:
+        return []
 
     def get_langs_used_by_deps(self) -> T.List[str]:
         '''
@@ -2233,7 +2233,7 @@ class SharedLibrary(BuildTarget):
     def get_all_link_deps(self):
         return [self] + self.get_transitive_link_deps()
 
-    def get_aliases(self) -> T.Dict[str, str]:
+    def get_aliases(self) -> T.List[T.Tuple[str, str, str]]:
         """
         If the versioned library name is libfoo.so.0.100.0, aliases are:
         * libfoo.so.0 (soversion) -> libfoo.so.0.100.0
@@ -2241,7 +2241,7 @@ class SharedLibrary(BuildTarget):
         Same for dylib:
         * libfoo.dylib (unversioned; for linking) -> libfoo.0.dylib
         """
-        aliases: T.Dict[str, str] = {}
+        aliases: T.List[T.Tuple[str, str, str]] = []
         # Aliases are only useful with .so and .dylib libraries. Also if
         # there's no self.soversion (no versioning), we don't need aliases.
         if self.suffix not in ('so', 'dylib') or not self.soversion:
@@ -2253,14 +2253,16 @@ class SharedLibrary(BuildTarget):
         if self.suffix == 'so' and self.ltversion and self.ltversion != self.soversion:
             alias_tpl = self.filename_tpl.replace('ltversion', 'soversion')
             ltversion_filename = alias_tpl.format(self)
-            aliases[ltversion_filename] = self.filename
+            tag = self.install_tag[0] or 'runtime'
+            aliases.append((ltversion_filename, self.filename, tag))
         # libfoo.so.0/libfoo.0.dylib is the actual library
         else:
             ltversion_filename = self.filename
         # Unversioned alias:
         #  libfoo.so -> libfoo.so.0
         #  libfoo.dylib -> libfoo.0.dylib
-        aliases[self.basic_filename_tpl.format(self)] = ltversion_filename
+        tag = self.install_tag[0] or 'devel'
+        aliases.append((self.basic_filename_tpl.format(self), ltversion_filename, tag))
         return aliases
 
     def type_suffix(self):

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -428,11 +428,11 @@ class Installer:
         append_to_log(self.lf, to_file)
         return True
 
-    def do_symlink(self, target: str, link: str, full_dst_dir: str) -> bool:
+    def do_symlink(self, target: str, link: str, full_dst_dir: str, allow_missing: bool) -> bool:
         abs_target = target
         if not os.path.isabs(target):
             abs_target = os.path.join(full_dst_dir, target)
-        if not os.path.exists(abs_target):
+        if not os.path.exists(abs_target) and not allow_missing:
             raise MesonException(f'Tried to install symlink to missing file {abs_target}')
         if os.path.exists(link):
             if not os.path.islink(link):
@@ -592,7 +592,7 @@ class Installer:
             full_dst_dir = get_destdir_path(destdir, fullprefix, s.install_path)
             full_link_name = get_destdir_path(destdir, fullprefix, s.name)
             dm.makedirs(full_dst_dir, exist_ok=True)
-            if self.do_symlink(s.target, full_link_name, full_dst_dir):
+            if self.do_symlink(s.target, full_link_name, full_dst_dir, s.allow_missing):
                 self.did_install_something = True
 
     def install_man(self, d: InstallData, dm: DirMaker, destdir: str, fullprefix: str) -> None:
@@ -676,7 +676,6 @@ class Installer:
             outdir = get_destdir_path(destdir, fullprefix, t.outdir)
             outname = os.path.join(outdir, os.path.basename(fname))
             final_path = os.path.join(d.prefix, t.outdir, os.path.basename(fname))
-            aliases = t.aliases
             should_strip = t.strip
             install_rpath = t.install_rpath
             install_name_mappings = t.install_name_mappings
@@ -711,9 +710,6 @@ class Installer:
                 self.do_copydir(d, fname, outname, None, install_mode, dm)
             else:
                 raise RuntimeError(f'Unknown file type for {fname!r}')
-            for alias, target in aliases.items():
-                symlinkfilename = os.path.join(outdir, alias)
-                self.do_symlink(target, symlinkfilename, outdir)
             if file_copied:
                 self.did_install_something = True
                 try:

--- a/test cases/unit/99 install all targets/meson.build
+++ b/test cases/unit/99 install all targets/meson.build
@@ -43,6 +43,12 @@ both_libraries('both', 'lib.c',
   install: true,
 )
 
+# Unversioned .so file should have 'devel' tag, others should have 'runtime' tag
+shared_library('versioned_shared', 'lib.c',
+  install: true,
+  version: '1.2.3',
+)
+
 # Those files should have custom tag
 install_data('bar-custom.txt',
   install_dir: get_option('datadir'),

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -3886,10 +3886,12 @@ class AllPlatformTests(BasePlatformTests):
                 Path(installpath, 'usr/bin/both2.pdb'),
                 Path(installpath, 'usr/bin/bothcustom.pdb'),
                 Path(installpath, 'usr/bin/shared.pdb'),
+                Path(installpath, 'usr/bin/versioned_shared-1.pdb'),
                 Path(installpath, 'usr/lib/both.lib'),
                 Path(installpath, 'usr/lib/both2.lib'),
                 Path(installpath, 'usr/lib/bothcustom.lib'),
                 Path(installpath, 'usr/lib/shared.lib'),
+                Path(installpath, 'usr/lib/versioned_shared.lib'),
             }
         elif is_windows() or is_cygwin():
             expected_devel |= {
@@ -3897,6 +3899,11 @@ class AllPlatformTests(BasePlatformTests):
                 Path(installpath, 'usr/lib/libboth2.dll.a'),
                 Path(installpath, 'usr/lib/libshared.dll.a'),
                 Path(installpath, 'usr/lib/libbothcustom.dll.a'),
+                Path(installpath, 'usr/lib/libversioned_shared.dll.a'),
+            }
+        else:
+            expected_devel |= {
+                Path(installpath, 'usr/' + shared_lib_name('versioned_shared')),
             }
 
         expected_runtime = expected_common | {
@@ -3907,6 +3914,20 @@ class AllPlatformTests(BasePlatformTests):
             Path(installpath, 'usr/' + shared_lib_name('both')),
             Path(installpath, 'usr/' + shared_lib_name('both2')),
         }
+
+        if is_windows() or is_cygwin():
+            expected_runtime |= {
+                Path(installpath, 'usr/' + shared_lib_name('versioned_shared-1')),
+            }
+        elif is_osx():
+            expected_runtime |= {
+                Path(installpath, 'usr/' + shared_lib_name('versioned_shared.1')),
+            }
+        else:
+            expected_runtime |= {
+                Path(installpath, 'usr/' + shared_lib_name('versioned_shared') + '.1'),
+                Path(installpath, 'usr/' + shared_lib_name('versioned_shared') + '.1.2.3'),
+            }
 
         expected_custom = expected_common | {
             Path(installpath, 'usr/share'),


### PR DESCRIPTION
Versioned shared libraries should have .so file in devel, .so.1 and
.so.1.2.3 in runtime.