### PR TITLE
install: Setup VS env if we did that during setup

### DIFF
--- a/mesonbuild/mesonlib/vsenv.py
+++ b/mesonbuild/mesonlib/vsenv.py
@@ -26,15 +26,16 @@ def _setup_vsenv(force: bool) -> bool:
         return False
     if os.environ.get('OSTYPE') == 'cygwin':
         return False
-    if 'Visual Studio' in os.environ['PATH']:
-        return False
-    # VSINSTALL is set when running setvars from a Visual Studio installation
-    # Tested with Visual Studio 2012 and 2017
-    if 'VSINSTALLDIR' in os.environ:
-        return False
-    # Check explicitly for cl when on Windows
-    if shutil.which('cl.exe'):
-        return False
+    if 'MESON_FORCE_VSENV_FOR_UNITTEST' not in os.environ:
+        if 'Visual Studio' in os.environ['PATH']:
+            return False
+        # VSINSTALL is set when running setvars from a Visual Studio installation
+        # Tested with Visual Studio 2012 and 2017
+        if 'VSINSTALLDIR' in os.environ:
+            return False
+        # Check explicitly for cl when on Windows
+        if shutil.which('cl.exe'):
+            return False
     if not force:
         if shutil.which('cc'):
             return False

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 import typing as T
 
+from . import build
 from . import environment
 from .backend.backends import (
     InstallData, InstallDataBase, InstallEmptyDir, InstallSymlinkData,
@@ -32,7 +33,7 @@ from .backend.backends import (
 )
 from .coredata import major_versions_differ, MesonVersionMismatchException
 from .coredata import version as coredata_version
-from .mesonlib import Popen_safe, RealPathAction, is_windows
+from .mesonlib import Popen_safe, RealPathAction, is_windows, setup_vsenv
 from .scripts import depfixer, destdir_join
 from .scripts.meson_exe import run_exe
 try:
@@ -793,6 +794,8 @@ def run(opts: 'ArgumentType') -> int:
     if not os.path.exists(os.path.join(opts.wd, datafilename)):
         sys.exit('Install data not found. Run this command in build directory root.')
     if not opts.no_rebuild:
+        b = build.load(opts.wd)
+        setup_vsenv(b.need_vsenv)
         if not rebuild_all(opts.wd):
             sys.exit(-1)
     os.chdir(opts.wd)

--- a/run_tests.py
+++ b/run_tests.py
@@ -261,11 +261,10 @@ def ensure_backend_detects_changes(backend: Backend) -> None:
         time.sleep(1)
 
 def run_mtest_inprocess(commandlist: T.List[str]) -> T.Tuple[int, str, str]:
-    stderr = StringIO()
-    stdout = StringIO()
-    with mock.patch.object(sys, 'stdout', stdout), mock.patch.object(sys, 'stderr', stderr):
+    out = StringIO()
+    with mock.patch.object(sys, 'stdout', out), mock.patch.object(sys, 'stderr', out):
         returncode = mtest.run_with_args(commandlist)
-    return returncode, stdout.getvalue(), stderr.getvalue()
+    return returncode, stdout.getvalue()
 
 def clear_meson_configure_class_caches() -> None:
     compilers.CCompiler.find_library_cache = {}

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -249,10 +249,10 @@ class BasePlatformTests(TestCase):
 
     def run_tests(self, *, inprocess=False, override_envvars=None):
         if not inprocess:
-            self._run(self.test_command, workdir=self.builddir, override_envvars=override_envvars)
+            return self._run(self.test_command, workdir=self.builddir, override_envvars=override_envvars)
         else:
             with mock.patch.dict(os.environ, override_envvars):
-                run_mtest_inprocess(['-C', self.builddir])
+                return run_mtest_inprocess(['-C', self.builddir])[1]
 
     def install(self, *, use_destdir=True, override_envvars=None):
         if self.backend is not Backend.ninja:
@@ -263,7 +263,7 @@ class BasePlatformTests(TestCase):
                 override_envvars = destdir
             else:
                 override_envvars.update(destdir)
-        self._run(self.install_command, workdir=self.builddir, override_envvars=override_envvars)
+        return self._run(self.install_command, workdir=self.builddir, override_envvars=override_envvars)
 
     def uninstall(self, *, override_envvars=None):
         self._run(self.uninstall_command, workdir=self.builddir, override_envvars=override_envvars)

--- a/unittests/helpers.py
+++ b/unittests/helpers.py
@@ -5,11 +5,13 @@ import unittest
 import functools
 import re
 import typing as T
+from pathlib import Path
 from contextlib import contextmanager
 
 from mesonbuild.compilers import detect_c_compiler, compiler_from_language
 from mesonbuild.mesonlib import (
-    MachineChoice, is_osx, is_cygwin, EnvironmentException, OptionKey, MachineChoice
+    MachineChoice, is_osx, is_cygwin, EnvironmentException, OptionKey, MachineChoice,
+    OrderedSet
 )
 from run_tests import get_fake_env
 
@@ -170,3 +172,15 @@ def get_rpath(fname: str) -> T.Optional[str]:
     # don't check for, so clear those
     final = ':'.join([e for e in raw.split(':') if not e.startswith('/nix')])
     return final
+
+def get_path_without_cmd(cmd: str, path: str) -> str:
+    pathsep = os.pathsep
+    paths = OrderedSet([Path(p).resolve() for p in path.split(pathsep)])
+    while True:
+        full_path = shutil.which(cmd, path=path)
+        if full_path is None:
+            break
+        dirname = Path(full_path).resolve().parent
+        paths.discard(dirname)
+        path = pathsep.join([str(p) for p in paths])
+    return path


### PR DESCRIPTION
Otherwise we might not find a ninja that was picked up from the Visual
Studio installation.

```
$ meson setup _build
...
Activating VS 15.9.40
...
Found ninja-1.8.2 at "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\Ninja\ninja.EXE"
$ meson compile -C _build
Activating VS 15.9.40
...
$ meson install -C _build
Can't find ninja, can't rebuild test.
```

Fixes https://github.com/mesonbuild/meson/issues/9774