### PR TITLE
fix python traceback when gtkdoc needs an exe_wrapper but doesn't have one

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1417,8 +1417,10 @@ class GnomeModule(ExtensionModule):
             t_args.append(f'--{program_name}={path}')
         if namespace:
             t_args.append('--namespace=' + namespace)
-        if state.environment.need_exe_wrapper() and not isinstance(state.environment.get_exe_wrapper(), EmptyExternalProgram):
-            t_args.append('--run=' + ' '.join(state.environment.get_exe_wrapper().get_command()))
+        # if not need_exe_wrapper, we get an EmptyExternalProgram. If none provided, we get NoneType
+        exe_wrapper = state.environment.get_exe_wrapper()
+        if not isinstance(exe_wrapper, (NoneType, EmptyExternalProgram)):
+            t_args.append('--run=' + ' '.join(exe_wrapper.get_command()))
         t_args.append(f'--htmlargs={"@@".join(kwargs["html_args"])}')
         t_args.append(f'--scanargs={"@@".join(kwargs["scan_args"])}')
         t_args.append(f'--scanobjsargs={"@@".join(kwargs["scanobjs_args"])}')


### PR DESCRIPTION
In commit c88bfdbefc2f79ac2dfa9bff5847c350de5f5db8 we added support for an exe_wrapper to gtkdoc, which checked twice whether the environment says it is needed, and didn't check at all whether one was provided.

The result:

```
  File "/usr/lib/python3/dist-packages/mesonbuild/modules/gnome.py", line 1354, in gtkdoc
    t_args.append('--run=' + ' '.join(state.environment.get_exe_wrapper().get_command()))
AttributeError: 'NoneType' object has no attribute 'get_command'
```

Instead, check whether we have a valid exe_wrapper (if we don't need one, then even when one is defined in the cross file, we get an EmptyExternalProgram) and if we do, use it.

If we don't have one, but need one, then we revert back to the behavior before commit c88bfdbefc2f79ac2dfa9bff5847c350de5f5db8, which probably means "executing the doc target causes the command to error out with "Exec format error".