### PR TITLE
Add compiler detection for Intel oneAPI DPC++/C++ Compiler.

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -518,7 +518,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
             return cls(
                 compiler, version, for_machine, is_cross, info, target,
                 exe_wrap, linker=linker)
-        if 'clang' in out or 'Clang' in out:
+        if 'clang' in out or 'Clang' in out or 'oneAPI DPC++/C++' in out:
             linker = None
 
             defines = _get_clang_compiler_defines(compiler)


### PR DESCRIPTION
Reported-by: Marcus Seyfarth <m.seyfarth@gmail.com>
Suggested-by: Harry van Haaren <harry.van.haaren@intel.com>
Tested-by: Vinson Lee <vlee@freedesktop.org>
Tested-by: Marcus Seyfarth <m.seyfarth@gmail.com>
Signed-off-by: Vinson Lee <vlee@freedesktop.org>