### PR TITLE
Type checking for the CustomTarget initializer

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1785,10 +1785,8 @@ external dependencies (including libraries) must go to "dependencies".''')
             # string in the meantime.
             FeatureNew('custom_target() with no name argument', '0.60.0', location=node).use(self.subproject)
             name = ''
-        kwargs['install_mode'] = self._get_kwarg_install_mode(kwargs)
         if 'input' in kwargs:
             kwargs['input'] = self.source_strings_to_files(extract_as_list(kwargs, 'input'), strict=False)
-        kwargs['env'] = self.unpack_env_kwarg(kwargs)
         if 'command' in kwargs and isinstance(kwargs['command'], list) and kwargs['command']:
             if isinstance(kwargs['command'][0], str):
                 kwargs['command'][0] = self.find_program_impl([kwargs['command'][0]])

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1686,8 +1686,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         vcs_cmd = kwargs['command']
         source_dir = os.path.normpath(os.path.join(self.environment.get_source_dir(), self.subdir))
         if vcs_cmd:
-            # Is the command an executable in path or maybe a script in the source tree?
-            vcs_cmd[0] = shutil.which(vcs_cmd[0]) or os.path.join(source_dir, vcs_cmd[0])
+            vcs_cmd[0] = self.find_program_impl(vcs_cmd[0])
         else:
             vcs = mesonlib.detect_vcs(source_dir)
             if vcs:

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -167,8 +167,8 @@ class RunTarget(TypedDict):
 class CustomTarget(TypedDict):
 
     build_always: bool
-    build_always_stale: bool
-    build_by_default: bool
+    build_always_stale: T.Optional[bool]
+    build_by_default: T.Optional[bool]
     capture: bool
     command: T.List[T.Union[str, build.BuildTarget, build.CustomTarget,
                             build.CustomTargetIndex, ExternalProgram, File]]
@@ -183,7 +183,7 @@ class CustomTarget(TypedDict):
     install: bool
     install_dir: T.List[T.Union[str, bool]]
     install_mode: FileMode
-    install_tag: T.List[T.Union[str, bool]]
+    install_tag: T.List[T.Optional[str]]
     output: T.List[str]
     override_options: T.Dict[OptionKey, str]
 

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -266,3 +266,13 @@ class DependencyGetVariable(TypedDict):
 class ConfigurationDataSet(TypedDict):
 
     description: T.Optional[str]
+
+class VcsTag(TypedDict):
+
+    command: T.List[T.Union[str, build.BuildTarget, build.CustomTarget,
+                            build.CustomTargetIndex, ExternalProgram, File]]
+    fallback: T.Optional[str]
+    input: T.List[T.Union[str, build.BuildTarget, build.CustomTarget, build.CustomTargetIndex,
+                          build.ExtractedObjects, build.GeneratedList, ExternalProgram, File]]
+    output: T.List[str]
+    replace_string: str

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -244,6 +244,8 @@ def _output_validator(outputs: T.List[str]) -> T.Optional[str]:
             return 'Output must not consist only of whitespace.'
         elif has_path_sep(i):
             return f'Output {i!r} must not contain a path segment.'
+        elif '@INPUT' in i:
+            return f'output {i!r} contains "@INPUT", which is invalid. Did you mean "@PLAINNAME@" or "@BASENAME@?'
 
     return None
 
@@ -269,6 +271,7 @@ CT_INSTALL_TAG_KW: KwargInfo[T.List[T.Union[str, bool]]] = KwargInfo(
     listify=True,
     default=[],
     since='0.60.0',
+    convertor=lambda x: [y if isinstance(y, str) else None for y in x],
 )
 
 INSTALL_KW = KwargInfo('install', bool, default=False)

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1630,9 +1630,6 @@ class GnomeModule(ExtensionModule):
 
         if kwargs['docbook'] is not None:
             docbook = kwargs['docbook']
-            if not isinstance(docbook, str):
-                raise MesonException('docbook value must be a string.')
-
             # The docbook output is always ${docbook}-${name_of_xml_file}
             output = namebase + '-docbook'
             outputs = []

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1924,21 +1924,6 @@ class GnomeModule(ExtensionModule):
             capture = True
 
         header_file = output + '.h'
-        c_cmd = cmd + ['--body', '@INPUT@']
-        if mesonlib.version_compare(self._get_native_glib_version(state), '>= 2.53.4'):
-            # Silence any warnings about missing prototypes
-            c_cmd += ['--include-header', header_file]
-        body = build.CustomTarget(
-            output + '_c',
-            state.subdir,
-            state.subproject,
-            c_cmd,
-            sources,
-            [f'{output}.c'],
-            capture=capture,
-            depend_files=kwargs['depend_files'],
-        )
-
         h_cmd = cmd + ['--header', '@INPUT@']
         if new_genmarshal:
             h_cmd += ['--pragma-once']
@@ -1953,6 +1938,24 @@ class GnomeModule(ExtensionModule):
             install_dir=[kwargs['install_dir']] if kwargs['install_dir'] else [],
             capture=capture,
             depend_files=kwargs['depend_files'],
+        )
+
+        c_cmd = cmd + ['--body', '@INPUT@']
+        extra_deps: T.List[build.CustomTarget] = []
+        if mesonlib.version_compare(self._get_native_glib_version(state), '>= 2.53.4'):
+            # Silence any warnings about missing prototypes
+            c_cmd += ['--include-header', header_file]
+            extra_deps.append(header)
+        body = build.CustomTarget(
+            output + '_c',
+            state.subdir,
+            state.subproject,
+            c_cmd,
+            sources,
+            [f'{output}.c'],
+            capture=capture,
+            depend_files=kwargs['depend_files'],
+            extra_depends=extra_deps,
         )
 
         rv = [body, header]

--- a/mesonbuild/modules/hotdoc.py
+++ b/mesonbuild/modules/hotdoc.py
@@ -344,8 +344,9 @@ class HotdocTargetBuilder:
                               extra_assets=self._extra_assets,
                               subprojects=self._subprojects,
                               command=target_cmd,
-                              depends=self._dependencies,
-                              output=fullname,
+                              extra_depends=self._dependencies,
+                              outputs=[fullname],
+                              sources=[],
                               depfile=os.path.basename(depfile),
                               build_by_default=self.build_by_default)
 
@@ -379,7 +380,7 @@ class HotdocTargetHolder(CustomTargetHolder):
 class HotdocTarget(build.CustomTarget):
     def __init__(self, name, subdir, subproject, hotdoc_conf, extra_extension_paths, extra_assets,
                  subprojects, **kwargs):
-        super().__init__(name, subdir, subproject, kwargs, absolute_paths=True)
+        super().__init__(name, subdir, subproject, **kwargs, absolute_paths=True)
         self.hotdoc_conf = hotdoc_conf
         self.extra_extension_paths = extra_extension_paths
         self.extra_assets = extra_assets

--- a/mesonbuild/modules/java.py
+++ b/mesonbuild/modules/java.py
@@ -51,20 +51,22 @@ class JavaModule(ExtensionModule):
         else:
             header = f'{pathlib.Path(file.fname).stem}.h'
 
-        ct_kwargs = {
-            'input': file,
-            'output': header,
-            'command': [
+        target = CustomTarget(
+            os.path.basename(header),
+            state.subdir,
+            state.subproject,
+            [
                 self.javac.exelist[0],
                 '-d',
                 '@PRIVATE_DIR@',
                 '-h',
                 state.subdir,
                 '@INPUT@',
-            ]
-        }
-
-        target = CustomTarget(os.path.basename(header), state.subdir, state.subproject, backend=state.backend, kwargs=ct_kwargs)
+            ],
+            [file],
+            [header],
+            backend=state.backend,
+        )
         # It is only known that 1.8.0 won't pre-create the directory. 11 and 16
         # do not exhibit this behavior.
         if version_compare(self.javac.version, '1.8.0'):

--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -227,15 +227,16 @@ class ExternalProject(NewExtensionModule):
         if self.verbose:
             cmd.append('--verbose')
 
-        target_kwargs = {'output': f'{self.name}.stamp',
-                         'depfile': f'{self.name}.d',
-                         'command': cmd + ['@OUTPUT@', '@DEPFILE@'],
-                         'console': True,
-                         }
-        self.target = build.CustomTarget(self.name,
-                                         self.subdir.as_posix(),
-                                         self.subproject,
-                                         target_kwargs)
+        self.target = build.CustomTarget(
+            self.name,
+            self.subdir.as_posix(),
+            self.subproject,
+            cmd + ['@OUTPUT@', '@DEPFILE@'],
+            [],
+            [f'{self.name}.stamp'],
+            depfile=f'{self.name}.d',
+            console=True,
+        )
 
         idir = build.InstallDir(self.subdir.as_posix(),
                                 Path('dist', self.rel_prefix).as_posix(),

--- a/mesonbuild/modules/unstable_rust.py
+++ b/mesonbuild/modules/unstable_rust.py
@@ -212,18 +212,16 @@ class RustModule(ExtensionModule):
             f'rustmod-bindgen-{name}'.replace('/', '_'),
             state.subdir,
             state.subproject,
-            {
-                'input': header,
-                'output': kwargs['output'],
-                'command': self._bindgen_bin.get_command() + [
-                    '@INPUT@', '--output',
-                    os.path.join(state.environment.build_dir, '@OUTPUT@')] +
-                    kwargs['args'] + ['--'] + kwargs['c_args'] + inc_strs +
-                    ['-MD', '-MQ', '@INPUT@', '-MF', '@DEPFILE@'],
-                'depfile': '@PLAINNAME@.d',
-                'depends': depends,
-                'depend_files': depend_files,
-            },
+            self._bindgen_bin.get_command() + [
+                '@INPUT@', '--output',
+                os.path.join(state.environment.build_dir, '@OUTPUT@')] +
+                kwargs['args'] + ['--'] + kwargs['c_args'] + inc_strs +
+                ['-MD', '-MQ', '@INPUT@', '-MF', '@DEPFILE@'],
+            [header],
+            [kwargs['output']],
+            depfile='@PLAINNAME@.d',
+            extra_depends=depends,
+            depend_files=depend_files,
             backend=state.backend,
         )
 

--- a/mesonbuild/modules/windows.py
+++ b/mesonbuild/modules/windows.py
@@ -181,26 +181,25 @@ class WindowsModule(ExtensionModule):
             command: T.List[T.Union[str, ExternalProgram]] = []
             command.append(rescomp)
             command.extend(res_args)
-
-            res_kwargs: 'RcKwargs' = {
-                'output': output,
-                'input': [src],
-                'depfile': None,
-                'depend_files': wrc_depend_files,
-                'depends': wrc_depends,
-                'command': [],
-            }
-
+            depfile: T.Optional[str] = None
             # instruct binutils windres to generate a preprocessor depfile
             if rescomp_type == ResourceCompilerType.windres:
-                res_kwargs['depfile'] = f'{output}.d'
+                depfile = f'{output}.d'
                 command.extend(['--preprocessor-arg=-MD',
                                 '--preprocessor-arg=-MQ@OUTPUT@',
                                 '--preprocessor-arg=-MF@DEPFILE@'])
 
-            res_kwargs['command'] = command
-
-            res_targets.append(build.CustomTarget(name_formatted, state.subdir, state.subproject, res_kwargs))
+            res_targets.append(build.CustomTarget(
+                name_formatted,
+                state.subdir,
+                state.subproject,
+                command,
+                [src],
+                [output],
+                depfile=depfile,
+                depend_files=wrc_depend_files,
+                extra_depends=wrc_depends,
+            ))
 
         return ModuleReturnValue(res_targets, [res_targets])
 

--- a/test cases/failing/41 custom target plainname many inputs/test.json
+++ b/test cases/failing/41 custom target plainname many inputs/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/41 custom target plainname many inputs/meson.build:5:0: ERROR: Output cannot contain @PLAINNAME@ or @BASENAME@ when there is more than one input (we can't know which to use)"
+      "line": "test cases/failing/41 custom target plainname many inputs/meson.build:5:0: ERROR: custom_target: output cannot containe \"@PLAINNAME@\" or \"@BASENAME@\" when there is more than one input (we can't know which to use)"
     }
   ]
 }


### PR DESCRIPTION
Since we now do all of our user input type checking in the interpreter, the `CustomTarget` initializer can act much more as a dumb initializer, and (for the most part) assigning values to attributes. This makes the whole thing much cleaner and easier to understand, and has allowed mypy to find at least one bug!