### PR TITLE
Add meson.command() as a way to find out how to run Meson

### DIFF
--- a/docs/yaml/builtins/meson.yaml
+++ b/docs/yaml/builtins/meson.yaml
@@ -446,3 +446,8 @@ methods:
       env:
         type: env
         description: The [[@env]] object to add.
+
+  - name: command
+    returns: list[str]
+    since: 0.62.0
+    description: Returns the command used to run Meson as an array, with arguments.

--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -76,6 +76,7 @@ class MesonMain(MesonInterpreterObject):
                              'has_external_property': self.has_external_property_method,
                              'backend': self.backend_method,
                              'add_devenv': self.add_devenv_method,
+                             'command': self.command_method,
                              })
 
     def _find_source_script(
@@ -448,3 +449,9 @@ class MesonMain(MesonInterpreterObject):
         converted = ENV_KW.convertor(env)
         assert isinstance(converted, build.EnvironmentVariables)
         self.build.devenv.append(converted)
+
+    @FeatureNew('command', '0.62.0')
+    @noPosargs
+    @noKwargs
+    def command_method(self, args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> T.List[str]:
+        return self.interpreter.environment.get_build_command()


### PR DESCRIPTION
## Rationale
It's sometimes useful to invoke Meson from a `run_target()` or even from the built application, but currently it's not possible to do this reliably, e.g. we have to assume that `meson` is in `$PATH` and it's the right one. Exposing `Environment.get_build_command()` seems like a good solution, since this is what gets hardcoded into `build.ninja`/other backend-specific files.

I currently have two use-cases for this:
* Our project has `run_target()`s that generate binary release packages. They work by calling a python script that installs the project into a temporary directory (calling `meson install`), then doing some additional processing and generating an archive/windows installer/etc.
* I'd like to implement a simple live reloading system for our game. The idea is to have it monitor source files for changes and call `meson compile` to rebuild a `shared_module()`. The meson command and path to sources could be passed through devenv, or directly compiled into the executable.

## ...and naming things
I'm not sure whether the method should be called `command()`, `get_command()`, or something else. The compiler object has `cmd_array()` for equivalent functionality, which I'm not a big fan of, but I'm ok with using that name for consistency's sake.