### PR TITLE
mcompile: fix broken codepaths and restore orphaned code

### DIFF
--- a/mesonbuild/mcompile.py
+++ b/mesonbuild/mcompile.py
@@ -322,19 +322,17 @@ def add_arguments(parser: 'argparse.ArgumentParser') -> None:
     )
 
 def run(options: 'argparse.Namespace') -> int:
-    cdata = coredata.load(options.wd)
     bdir = Path(options.wd)
-    buildfile = bdir / 'meson-private' / 'build.dat'
-    if not buildfile.is_file():
-        raise MesonException(f'Directory {options.wd!r} does not seem to be a Meson build directory.')
+    validate_builddir(bdir)
+    if options.targets and options.clean:
+        raise MesonException('`TARGET` and `--clean` can\'t be used simultaneously')
+
+    cdata = coredata.load(options.wd)
     b = build.load(options.wd)
     setup_vsenv(b.need_vsenv)
 
     cmd = []    # type: T.List[str]
     env = None  # type: T.Optional[T.Dict[str, str]]
-
-    if options.targets and options.clean:
-        raise MesonException('`TARGET` and `--clean` can\'t be used simultaneously')
 
     backend = cdata.get_option(mesonlib.OptionKey('backend'))
     assert isinstance(backend, str)


### PR DESCRIPTION
In commit 928078982c8643bffd95a8da06a1b4494fe87e2b a good error message about the directory not being a valid build directory, was replaced by a worse message.

In commit abaa980436f53100041bd5535589bb1c42019bd6 the error message was replaced by a traceback when trying to load the coredata before checking if it was a build directory.

Revert back to using the helper function with the good error message. Reorganize code so that we check basic things first, and do less work before detecting errors.

Fixes #9584