### PR TITLE
interpreterobjects: Don't warn on set10(bool)

### DIFF
--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -320,7 +320,10 @@ class ConfigurationDataHolder(ObjectHolder[build.ConfigurationData], MutableInte
     @typed_kwargs('configuration_data.set10', _CONF_DATA_SET_KWS)
     def set10_method(self, args: T.Tuple[str, T.Union[int, bool]], kwargs: 'kwargs.ConfigurationDataSet') -> None:
         self.__check_used()
-        if isinstance(args[1], int):
+        # bool is a subclass of int, so we need to check for bool excplicitly.
+        # We already have typed_pos_args checking that this is either a bool or
+        # an int.
+        if not isinstance(args[1], bool):
             mlog.deprecation('configuration_data.set10 with number. the `set10` '
                              'method should only be used with booleans',
                              location=self.interpreter.current_node)


### PR DESCRIPTION
Python inherited a really bad design from C, booleans happen to be ints.
Which is awful, but it's true.

Fixes: #9858