### PR TITLE
fix broken version annotations for the new itstool_join feature

### DIFF
--- a/docs/markdown/i18n-module.md
+++ b/docs/markdown/i18n-module.md
@@ -67,4 +67,4 @@ for normal keywords. In addition it accepts these keywords:
   (XML translation rules are autodetected otherwise).
 * `mo_targets` *required*: mo file generation targets as returned by `i18n.gettext()`.
 
-*Added 0.61.0*
+*Added 0.62.0*

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -288,7 +288,7 @@ class I18nModule(ExtensionModule):
 
         return ModuleReturnValue([gmotargets, pottarget, updatepotarget], targets)
 
-    @FeatureNew('i18n.itstool_join', '0.61.0')
+    @FeatureNew('i18n.itstool_join', '0.62.0')
     @noPosargs
     @typed_kwargs(
         'i18n.itstool_join',


### PR DESCRIPTION
It was not added in 0.61.0 as that was already released.