### PR TITLE
Contributing.md:specify max line length for docs

### DIFF
--- a/docs/markdown/Contributing.md
+++ b/docs/markdown/Contributing.md
@@ -445,10 +445,12 @@ To promote consistent naming policy, use:
 ## Documentation
 
 The `docs` directory contains the full documentation that will be used
-to generate [the Meson web site](http://mesonbuild.com). Every change
-in functionality must change the documentation pages. In most cases
-this means updating the reference documentation page but bigger
-changes might need changes in other documentation, too.
+to generate [the Meson web site](http://mesonbuild.com). Line length
+in most cases should not exceed 70 characters (lines containing links
+or examples are usually exempt). Every change in functionality must
+change the documentation pages. In most cases this means updating the
+reference documentation page but bigger changes might need changes in
+other documentation, too.
 
 All new functionality needs to have a mention in the release
 notes. These features should be written in standalone files in the


### PR DESCRIPTION
I thought it would good to specify a general rule here so people can set
their line wrapping appropriately.

[skip ci]