### PR TITLE
cygwin: fix python versions again

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -66,17 +66,10 @@ jobs:
             python3-devel
             python3-libxml2
             python3-libxslt
-            python38-pip
-            python38-wheel
+            python39-pip
+            python39-wheel
             vala
             zlib-devel
-
-      - name: workaround wrong python version
-        run: |
-          export PATH=/usr/sbin:/usr/bin:/usr/local/bin:$(cygpath ${SYSTEMROOT})/system32
-          update-alternatives --verbose --set python /usr/bin/python3.8
-          update-alternatives --verbose --set python3 /usr/bin/python3.8
-        shell: C:\cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
 
       - name: Run pip
         run: |


### PR DESCRIPTION
Now cygwin seems to have completed a migration of the default python to 3.9, so that is where the devel package is at.

Back out the changes from commit 3304a38496a52052ae9d58ed2459c7deb18ca703 and update the pip/wheel packages as appropriate.