### PR TITLE
compilers/c_function_attributes: add retain + typo correction

### DIFF
--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -240,6 +240,7 @@ which are supported by GCC, Clang, and other compilers.
 | optimize                 |
 | packed                   |
 | pure                     |
+| retain⁴                  |
 | returns_nonnull          |
 | unused                   |
 | used                     |
@@ -260,6 +261,8 @@ which are supported by GCC, Clang, and other compilers.
 "visibility" as they provide narrower checks.
 
 ³ *New in 0.55.0*
+
+⁴ *New in 0.62.0*
 
 ### MSVC __declspec
 

--- a/docs/markdown/Reference-tables.md
+++ b/docs/markdown/Reference-tables.md
@@ -252,7 +252,7 @@ which are supported by GCC, Clang, and other compilers.
 | warning                  |
 | warn_unused_result       |
 | weak                     |
-| weakreaf                 |
+| weakref                  |
 
 \* *Changed in 0.52.0* the "visibility" target no longer includes
 "protected", which is not present in Apple's clang.

--- a/mesonbuild/compilers/c_function_attributes.py
+++ b/mesonbuild/compilers/c_function_attributes.py
@@ -113,6 +113,7 @@ C_FUNC_ATTRIBUTES = {
     'weakref': '''
         static int foo(void) { return 0; }
         static int var(void) __attribute__((weakref("foo")));''',
+    'retain': '__attribute__((retain)) int x;',
 }
 
 CXX_FUNC_ATTRIBUTES = {

--- a/test cases/common/197 function attributes/meson.build
+++ b/test cases/common/197 function attributes/meson.build
@@ -80,6 +80,12 @@ if ['gcc', 'intel'].contains(c.get_id())
   if c.get_id() == 'gcc' and c.version().version_compare('>= 7.0.0')
     attributes += 'fallthrough'
   endif
+
+  # XXX(arsen): limited to clang 13+ even though gcc 11 has it, since gcc
+  # detects support for it at compile time based on binutils version
+  if c.get_id() == 'clang' and c.version().version_compare('>= 13.0.0')
+    attributes += 'retain'
+  endif
 endif
 
 if get_option('mode') == 'single'


### PR DESCRIPTION
retain is a relatively young attribute which has proven itself useful
for working with --gc-sections -z start-stop-gc.