### PR TITLE
remove incorrect deprecated feature for vcs_tag

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1663,8 +1663,6 @@ external dependencies (including libraries) must go to "dependencies".''')
             raise InterpreterException('Unknown target_type.')
 
     @permittedKwargs({'input', 'output', 'fallback', 'command', 'replace_string'})
-    @FeatureDeprecatedKwargs('custom_target', '0.47.0', ['build_always'],
-                             'combine build_by_default and build_always_stale instead.')
     @noPosargs
     def func_vcs_tag(self, node, args, kwargs):
         if 'input' not in kwargs or 'output' not in kwargs:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1715,8 +1715,8 @@ external dependencies (including libraries) must go to "dependencies".''')
     @typed_kwargs(
         'custom_target',
         COMMAND_KW,
-        CT_BUILD_ALWAYS.evolve(deprecated='0.47.0'),
-        CT_BUILD_ALWAYS_STALE.evolve(since='0.47.0'),
+        CT_BUILD_ALWAYS,
+        CT_BUILD_ALWAYS_STALE,
         CT_BUILD_BY_DEFAULT,
         CT_INPUT_KW,
         CT_INSTALL_DIR_KW,

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -285,6 +285,7 @@ CT_BUILD_BY_DEFAULT: KwargInfo[T.Optional[bool]] = KwargInfo('build_by_default',
 CT_BUILD_ALWAYS: KwargInfo[T.Optional[bool]] = KwargInfo(
     'build_always', (bool, NoneType),
      deprecated='0.47.0',
+     deprecated_message='combine build_by_default and build_always_stale instead.',
 )
 
 CT_BUILD_ALWAYS_STALE: KwargInfo[T.Optional[bool]] = KwargInfo(

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -282,10 +282,15 @@ CT_INSTALL_DIR_KW: KwargInfo[T.List[T.Union[str, bool]]] = KwargInfo(
 
 CT_BUILD_BY_DEFAULT: KwargInfo[T.Optional[bool]] = KwargInfo('build_by_default', (bool, type(None)), since='0.40.0')
 
-CT_BUILD_ALWAYS: KwargInfo[T.Optional[bool]] = KwargInfo('build_always', (bool, NoneType))
+CT_BUILD_ALWAYS: KwargInfo[T.Optional[bool]] = KwargInfo(
+    'build_always', (bool, NoneType),
+     deprecated='0.47.0',
+)
 
 CT_BUILD_ALWAYS_STALE: KwargInfo[T.Optional[bool]] = KwargInfo(
-    'build_always_stale', (bool, NoneType))
+    'build_always_stale', (bool, NoneType),
+    since='0.47.0',
+)
 
 INCLUDE_DIRECTORIES: KwargInfo[T.List[T.Union[str, IncludeDirs]]] = KwargInfo(
     'include_dirs',


### PR DESCRIPTION
In commit 06481666f4e74ecef01e59351fc345ab0962d998 this warning got moved from build.py to the interpreter. Unfortunately it got added to the wrong function... it is supposed to be part of custom_target and even mentions this as the feature_name.

Since then, build_always became a KwargInfo and has the deprecated-since attribute baked into it. But it didn't have the additional message which it really should have.

Add that message at the same time we remove it from vcs_tag.