### PR TITLE
Popen_safe and wrappers can accept os.PathLike for cwd

### DIFF
--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -185,14 +185,14 @@ class GitException(MesonException):
         self.output = output.strip() if output else ''
 
 GIT = shutil.which('git')
-def git(cmd: T.List[str], workingdir: str, check: bool = False, **kwargs: T.Any) -> T.Tuple[subprocess.Popen, str, str]:
+def git(cmd: T.List[str], workingdir: T.Union[str, bytes, os.PathLike], check: bool = False, **kwargs: T.Any) -> T.Tuple[subprocess.Popen, str, str]:
     cmd = [GIT] + cmd
     p, o, e = Popen_safe(cmd, cwd=workingdir, **kwargs)
     if check and p.returncode != 0:
         raise GitException('Git command failed: ' + str(cmd), e)
     return p, o, e
 
-def quiet_git(cmd: T.List[str], workingdir: str, check: bool = False) -> T.Tuple[bool, str]:
+def quiet_git(cmd: T.List[str], workingdir: T.Union[str, bytes, os.PathLike], check: bool = False) -> T.Tuple[bool, str]:
     if not GIT:
         m = 'Git program not found.'
         if check:
@@ -203,7 +203,7 @@ def quiet_git(cmd: T.List[str], workingdir: str, check: bool = False) -> T.Tuple
         return False, e
     return True, o
 
-def verbose_git(cmd: T.List[str], workingdir: str, check: bool = False) -> bool:
+def verbose_git(cmd: T.List[str], workingdir: T.Union[str, bytes, os.PathLike], check: bool = False) -> bool:
     if not GIT:
         m = 'Git program not found.'
         if check:

--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -205,7 +205,7 @@ class ExternalProject(NewExtensionModule):
             output.flush()
         else:
             mlog.log(m)
-        p, *_ = Popen_safe(command, cwd=str(workdir), env=self.run_env,
+        p, *_ = Popen_safe(command, cwd=workdir, env=self.run_env,
                            stderr=subprocess.STDOUT,
                            stdout=output)
         if p.returncode != 0:


### PR DESCRIPTION
Do not require users to convert it to a string first. This is a waste of time and effort for exactly the same results.