### PR TITLE
do not report context on python traceback, for PermissionError

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -155,6 +155,11 @@ class CommandLineParser:
             if os.environ.get('MESON_FORCE_BACKTRACE'):
                 raise
             return 1
+        except PermissionError:
+            if os.environ.get('MESON_FORCE_BACKTRACE'):
+                raise
+            traceback.print_exc()
+            return 2
         except Exception as e:
             if os.environ.get('MESON_FORCE_BACKTRACE'):
                 raise


### PR DESCRIPTION
It's not a MesonBug which needs to be reported, and the existing error already adequately points out the problematic file.

It is impossible to get a PermissionError for files created by meson itself, once the build directory has been created, anyway.