### PR TITLE
modules/gnome: Allow gdbus_annotations to take an empty list again

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -224,12 +224,13 @@ _MK_ENUMS_COMMON_KWS: T.List[KwargInfo] = [
 ]
 
 def annotations_validator(annotations: T.List[T.Union[str, T.List[str]]]) -> T.Optional[str]:
-
     """Validate gdbus-codegen annotations argument"""
 
     badlist = 'must be made up of 3 strings for ELEMENT, KEY, and VALUE'
 
-    if all(isinstance(annot, str) for annot in annotations):
+    if not annotations:
+        return None
+    elif all(isinstance(annot, str) for annot in annotations):
         if len(annotations) == 3:
             return None
         else:

--- a/test cases/frameworks/7 gnome/gdbus/meson.build
+++ b/test cases/frameworks/7 gnome/gdbus/meson.build
@@ -6,6 +6,16 @@ gdbus_src = gnome.gdbus_codegen('generated-gdbus-no-docbook',
     ['com.example.Hello()', 'org.freedesktop.DBus.Deprecated', 'true']
   ],
 )
+
+# check that empty annotations work
+gdbus_src2 = gnome.gdbus_codegen(
+  'generated-gdbus-no-docbook2',
+  'data/com.example.Sample.xml',
+  interface_prefix : 'com.example.',
+  namespace : 'Sample',
+  annotations : [],
+)
+
 assert(gdbus_src.length() == 2, 'expected 2 targets')
 assert(gdbus_src[0].full_path().endswith('.c'), 'expected 1 c source file')
 assert(gdbus_src[1].full_path().endswith('.h'), 'expected 1 c header file')


### PR DESCRIPTION
This was allows up to 0.61.0 (including with the initial type
annotations), but was accidentally broken by fixes for other bugs in
0.61.1.

Fixes: #9883