### PR TITLE
ninja backend: Fix usage of same constants file for native and cross

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1191,14 +1191,14 @@ class Backend:
     def get_regen_filelist(self) -> T.List[str]:
         '''List of all files whose alteration means that the build
         definition needs to be regenerated.'''
-        deps = [str(Path(self.build_to_src) / df)
-                for df in self.interpreter.get_build_def_files()]
+        deps = OrderedSet([str(Path(self.build_to_src) / df)
+                for df in self.interpreter.get_build_def_files()])
         if self.environment.is_cross_build():
-            deps.extend(self.environment.coredata.cross_files)
-        deps.extend(self.environment.coredata.config_files)
-        deps.append('meson-private/coredata.dat')
+            deps.update(self.environment.coredata.cross_files)
+        deps.update(self.environment.coredata.config_files)
+        deps.add('meson-private/coredata.dat')
         self.check_clock_skew(deps)
-        return deps
+        return list(deps)
 
     def generate_regen_info(self) -> None:
         deps = self.get_regen_filelist()
@@ -1210,7 +1210,7 @@ class Backend:
         with open(filename, 'wb') as f:
             pickle.dump(regeninfo, f)
 
-    def check_clock_skew(self, file_list: T.List[str]) -> None:
+    def check_clock_skew(self, file_list: T.Iterable[str]) -> None:
         # If a file that leads to reconfiguration has a time
         # stamp in the future, it will trigger an eternal reconfigure
         # loop.

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -2368,7 +2368,7 @@ class AllPlatformTests(BasePlatformTests):
                 endian = 'little'
                 '''.format(os.path.join(testdir, 'cross_pkgconfig.py'))))
             crossfile.flush()
-            self.meson_cross_file = crossfile.name
+            self.meson_cross_files = [crossfile.name]
 
         env = {'PKG_CONFIG_LIBDIR':  os.path.join(testdir,
                                                   'native_pkgconfig')}
@@ -2396,7 +2396,7 @@ class AllPlatformTests(BasePlatformTests):
                 endian = 'little'
                 '''.format(os.path.join(testdir, 'cross_pkgconfig'))))
             crossfile.flush()
-            self.meson_cross_file = crossfile.name
+            self.meson_cross_files = [crossfile.name]
 
         env = {'PKG_CONFIG_LIBDIR':  os.path.join(testdir,
                                                   'native_pkgconfig')}
@@ -2630,8 +2630,8 @@ class AllPlatformTests(BasePlatformTests):
         testdir = os.path.join(self.unit_test_dir, '70 cross')
         # Do a build to generate a cross file where the host is this target
         self.init(testdir, extra_args=['-Dgenerate=true'])
-        self.meson_cross_file = os.path.join(self.builddir, "crossfile")
-        self.assertTrue(os.path.exists(self.meson_cross_file))
+        self.meson_cross_files = [os.path.join(self.builddir, "crossfile")]
+        self.assertTrue(os.path.exists(self.meson_cross_files[0]))
         # Now verify that this is detected as cross
         self.new_builddir()
         self.init(testdir)
@@ -3595,14 +3595,14 @@ class AllPlatformTests(BasePlatformTests):
                 '''))
 
         # Test native C stdlib
-        self.meson_native_file = machinefile
+        self.meson_native_files = [machinefile]
         self.init(testdir)
         self.build()
 
         # Test cross C stdlib
         self.new_builddir()
-        self.meson_native_file = None
-        self.meson_cross_file = machinefile
+        self.meson_native_files = []
+        self.meson_cross_files = [machinefile]
         self.init(testdir)
         self.build()
 

--- a/unittests/baseplatformtests.py
+++ b/unittests/baseplatformtests.py
@@ -56,8 +56,8 @@ class BasePlatformTests(TestCase):
         # Get the backend
         self.backend = getattr(Backend, os.environ['MESON_UNIT_TEST_BACKEND'])
         self.meson_args = ['--backend=' + self.backend.name]
-        self.meson_native_file = None
-        self.meson_cross_file = None
+        self.meson_native_files = []
+        self.meson_cross_files = []
         self.meson_command = python_command + [get_meson_script()]
         self.setup_command = self.meson_command + self.meson_args
         self.mconf_command = self.meson_command + ['configure']
@@ -192,10 +192,10 @@ class BasePlatformTests(TestCase):
             args += ['--prefix', self.prefix]
             if self.libdir:
                 args += ['--libdir', self.libdir]
-            if self.meson_native_file:
-                args += ['--native-file', self.meson_native_file]
-            if self.meson_cross_file:
-                args += ['--cross-file', self.meson_cross_file]
+            for f in self.meson_native_files:
+                args += ['--native-file', f]
+            for f in self.meson_cross_files:
+                args += ['--cross-file', f]
         self.privatedir = os.path.join(self.builddir, 'meson-private')
         if inprocess:
             try:

--- a/unittests/linuxcrosstests.py
+++ b/unittests/linuxcrosstests.py
@@ -44,7 +44,7 @@ class LinuxCrossArmTests(BaseLinuxCrossTests):
 
     def setUp(self):
         super().setUp()
-        self.meson_cross_file = os.path.join(self.src_root, 'cross', 'ubuntu-armhf.txt')
+        self.meson_cross_files = [os.path.join(self.src_root, 'cross', 'ubuntu-armhf.txt')]
 
     def test_cflags_cross_environment_pollution(self):
         '''
@@ -66,7 +66,7 @@ class LinuxCrossArmTests(BaseLinuxCrossTests):
         https://github.com/mesonbuild/meson/issues/3089
         '''
         testdir = os.path.join(self.unit_test_dir, '33 cross file overrides always args')
-        self.meson_cross_file = os.path.join(testdir, 'ubuntu-armhf-overrides.txt')
+        self.meson_cross_files = [os.path.join(testdir, 'ubuntu-armhf-overrides.txt')]
         self.init(testdir)
         compdb = self.get_compdb()
         self.assertRegex(compdb[0]['command'], '-D_FILE_OFFSET_BITS=64.*-U_FILE_OFFSET_BITS')
@@ -137,7 +137,7 @@ class LinuxCrossMingwTests(BaseLinuxCrossTests):
 
     def setUp(self):
         super().setUp()
-        self.meson_cross_file = os.path.join(self.src_root, 'cross', 'linux-mingw-w64-64bit.txt')
+        self.meson_cross_files = [os.path.join(self.src_root, 'cross', 'linux-mingw-w64-64bit.txt')]
 
     def test_exe_wrapper_behaviour(self):
         '''
@@ -154,7 +154,7 @@ class LinuxCrossMingwTests(BaseLinuxCrossTests):
         self.wipe()
         os.mkdir(self.builddir)
         # Change cross file to use a non-existing exe_wrapper and it should fail
-        self.meson_cross_file = os.path.join(testdir, 'broken-cross.txt')
+        self.meson_cross_files = [os.path.join(testdir, 'broken-cross.txt')]
         # Force tracebacks so we can detect them properly
         env = {'MESON_FORCE_BACKTRACE': '1'}
         error_message = "An exe_wrapper is needed but was not found. Please define one in cross file and check the command and/or add it to PATH."

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1030,7 +1030,7 @@ class LinuxlikeTests(BasePlatformTests):
             endian = 'little'
             '''))
         crossfile.flush()
-        self.meson_cross_file = crossfile.name
+        self.meson_cross_files = [crossfile.name]
         self.init(testdir)
 
     def test_reconfigure(self):
@@ -1501,21 +1501,28 @@ class LinuxlikeTests(BasePlatformTests):
     def test_identity_cross(self):
         testdir = os.path.join(self.unit_test_dir, '61 identity cross')
 
+        constantsfile = tempfile.NamedTemporaryFile(mode='w')
+        constantsfile.write(textwrap.dedent('''\
+            [constants]
+            py_ext = '.py'
+            '''))
+        constantsfile.flush()
+
         nativefile = tempfile.NamedTemporaryFile(mode='w')
         nativefile.write(textwrap.dedent('''\
             [binaries]
-            c = ['{}']
-            '''.format(os.path.join(testdir, 'build_wrapper.py'))))
+            c = ['{}' + py_ext]
+            '''.format(os.path.join(testdir, 'build_wrapper'))))
         nativefile.flush()
-        self.meson_native_file = nativefile.name
+        self.meson_native_files = [constantsfile.name, nativefile.name]
 
         crossfile = tempfile.NamedTemporaryFile(mode='w')
         crossfile.write(textwrap.dedent('''\
             [binaries]
-            c = ['{}']
-            '''.format(os.path.join(testdir, 'host_wrapper.py'))))
+            c = ['{}' + py_ext]
+            '''.format(os.path.join(testdir, 'host_wrapper'))))
         crossfile.flush()
-        self.meson_cross_file = crossfile.name
+        self.meson_cross_files = [constantsfile.name, crossfile.name]
 
         # TODO should someday be explicit about build platform only here
         self.init(testdir)
@@ -1531,7 +1538,7 @@ class LinuxlikeTests(BasePlatformTests):
             c = ['{}']
             '''.format(os.path.join(testdir, 'host_wrapper.py'))))
         crossfile.flush()
-        self.meson_cross_file = crossfile.name
+        self.meson_cross_files = [crossfile.name]
         # TODO should someday be explicit about build platform only here
         self.init(testdir, override_envvars=env)
 

--- a/unittests/rewritetests.py
+++ b/unittests/rewritetests.py
@@ -15,9 +15,10 @@
 import subprocess
 import json
 import os
+import shutil
 import unittest
-from distutils.dir_util import copy_tree
 
+from mesonbuild.mesonlib import windows_proof_rmtree
 from .baseplatformtests import BasePlatformTests
 
 class RewriterTests(BasePlatformTests):
@@ -26,7 +27,9 @@ class RewriterTests(BasePlatformTests):
         self.maxDiff = None
 
     def prime(self, dirname):
-        copy_tree(os.path.join(self.rewrite_test_dir, dirname), self.builddir)
+        if os.path.exists(self.builddir):
+            windows_proof_rmtree(self.builddir)
+        shutil.copytree(os.path.join(self.rewrite_test_dir, dirname), self.builddir)
 
     def rewrite_raw(self, directory, args):
         if isinstance(args, str):


### PR DESCRIPTION
For example:
```
meson builddir \
        --native-file vs2019-paths.txt \
        --native-file vs2019-win-x64.txt \
        --cross-file vs2019-paths.txt \
        --cross-file vs2019-win-arm64.txt
```
This was causing the error:

> ERROR: Multiple producers for Ninja target "/path/to/vs2019-paths.txt". Please rename your targets.

Fix it by using a set() when generating the list of regen files, and add a test for it too.

Also fix a warning about distutils deprecation.