### PR TITLE
ninjabackend: treat link_whole_targets like link_targets for Rust targets

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1659,7 +1659,10 @@ class NinjaBackend(backends.Backend):
         self.generate_generator_list_rules(target)
 
         # dependencies need to cause a relink, they're not just for odering
-        deps = [os.path.join(t.subdir, t.get_filename()) for t in target.link_targets]
+        deps = [
+            os.path.join(t.subdir, t.get_filename())
+            for t in itertools.chain(target.link_targets, target.link_whole_targets)
+        ]
 
         orderdeps: T.List[str] = []
 
@@ -1710,7 +1713,7 @@ class NinjaBackend(backends.Backend):
         args += rustc.get_output_args(os.path.join(target.subdir, target.get_filename()))
         linkdirs = mesonlib.OrderedSet()
         external_deps = target.external_deps.copy()
-        for d in target.link_targets:
+        for d in itertools.chain(target.link_targets, target.link_whole_targets):
             linkdirs.add(d.subdir)
             if d.uses_rust():
                 # specify `extern CRATE_NAME=OUTPUT_FILE` for each Rust

--- a/test cases/rust/17 staticlib link staticlib/branch.rs
+++ b/test cases/rust/17 staticlib link staticlib/branch.rs
@@ -1,0 +1,4 @@
+#[no_mangle]
+pub extern "C" fn what_have_we_here() -> i32 {
+    leaf::HOW_MANY * leaf::HOW_MANY
+}

--- a/test cases/rust/17 staticlib link staticlib/leaf.rs
+++ b/test cases/rust/17 staticlib link staticlib/leaf.rs
@@ -1,0 +1,1 @@
+pub const HOW_MANY: i32 = 5;

--- a/test cases/rust/17 staticlib link staticlib/meson.build
+++ b/test cases/rust/17 staticlib link staticlib/meson.build
@@ -1,0 +1,8 @@
+project('staticlib link staticlib', 'c', 'rust')
+
+leaf = static_library('leaf', 'leaf.rs', rust_crate_type : 'rlib')
+# Even though leaf is linked using link_with, this gets implicitly promoted to link_whole because
+# it is an internal Rust project.
+branch = static_library('branch', 'branch.rs', link_with: leaf, rust_crate_type : 'staticlib', install : true)
+e = executable('prog', 'prog.c', link_with : branch, install : true)
+test('linktest', e)

--- a/test cases/rust/17 staticlib link staticlib/prog.c
+++ b/test cases/rust/17 staticlib link staticlib/prog.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int what_have_we_here();
+
+int main(void) {
+    printf("printing %d\n", what_have_we_here());
+}

--- a/test cases/rust/17 staticlib link staticlib/test.json
+++ b/test cases/rust/17 staticlib link staticlib/test.json
@@ -1,0 +1,7 @@
+{
+  "installed": [
+    {"type": "exe", "file": "usr/bin/prog"},
+    {"type": "pdb", "file": "usr/bin/prog"},
+    {"type": "file", "file": "usr/lib/libbranch.a"}
+  ]
+}


### PR DESCRIPTION
For static library crates that depend on other internal static library
crates, all link_with targets get promoted to link_whole targets. Due to
a bug, only link_with targets are considered when generating a Rust
target for the ninja backend. This made it impossible to link a Rust
static library with another internal Rust static library.

This change fixes that issue by chaining link_whole_targets with
link_targets, just like many other languages within the ninja backend.