### PR TITLE
docs: find_program can return the current Python3 interpreter

### DIFF
--- a/docs/yaml/functions/find_program.yaml
+++ b/docs/yaml/functions/find_program.yaml
@@ -24,7 +24,9 @@ description: |
   (because the command invocator will reject the command otherwise) and
   Unixes (if the script file does not have the executable bit set).
   Hence, you *must not* manually add the interpreter while using this
-  script as part of a list of commands.
+  script as part of a list of commands. Since *0.50.0* if the "python3"
+  program is requested and it is not found in the system, Meson will return
+  its current interpreter.
 
   If you need to check for a program in a non-standard location, you can
   just pass an absolute path to `find_program`, e.g.


### PR DESCRIPTION
This was the case since 067ff7eeae26eda8edc9f7f7432f551c3e373eaa, i.e. version 0.50.0. Fixes #3856

Edit: this is useful to know, so that users (like me) can stop using `python.find_installation()` when they want to be sure to always get a result back