### PR TITLE
Remove unnecessary check during VS activation

### DIFF
--- a/mesonbuild/mesonlib/vsenv.py
+++ b/mesonbuild/mesonlib/vsenv.py
@@ -27,8 +27,6 @@ def _setup_vsenv(force: bool) -> bool:
     if os.environ.get('OSTYPE') == 'cygwin':
         return False
     if 'MESON_FORCE_VSENV_FOR_UNITTEST' not in os.environ:
-        if 'Visual Studio' in os.environ['PATH']:
-            return False
         # VSINSTALL is set when running setvars from a Visual Studio installation
         # Tested with Visual Studio 2012 and 2017
         if 'VSINSTALLDIR' in os.environ:


### PR DESCRIPTION
As discussed on Matrix, this doesn't seem to be a true indicator of Visual Studio environment activation