### PR TITLE
cmake: add arch_independent kwarg

### DIFF
--- a/docs/markdown/CMake-module.md
+++ b/docs/markdown/CMake-module.md
@@ -226,7 +226,7 @@ specification](Machine-files.md).
 ### cmake.write_basic_package_version_file()
 
 This function is the equivalent of the corresponding [CMake
-function](https://cmake.org/cmake/help/v3.11/module/CMakePackageConfigHelpers.html#generating-a-package-version-file),
+function](https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#command:write_basic_package_version_file),
 it generates a `name` package version file.
 
 * `name`: the name of the package.
@@ -235,6 +235,8 @@ it generates a `name` package version file.
 `AnyNewerVersion`, `SameMajorVersion`, `SameMinorVersion` or `ExactVersion`.
 It defaults to `AnyNewerVersion`. Depending on your cmake installation some kind of
 compatibility may not be available.
+* `arch_independent`: *new in 0.62.0*, if true the generated package file
+  will skip architecture checks. Useful for header-only libraries.
 * `install_dir`: optional installation directory, it defaults to `$(libdir)/cmake/$(name)`
 
 

--- a/docs/markdown/snippets/cmake_version_file_arch.md
+++ b/docs/markdown/snippets/cmake_version_file_arch.md
@@ -1,0 +1,7 @@
+## arch_independent kwarg in cmake.write_basic_package_version_file
+
+The `write_basic_package_version_file()` function from the `cmake` module
+now supports an `arch_independent` kwarg, so that architecture checks in
+the generated Package Version file are skipped, reproducing the behaviour of
+CMake's [ARCH_INDEPENDENT](https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#command:write_basic_package_version_file)
+option.

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -42,6 +42,7 @@ from ..interpreterbase import (
 if T.TYPE_CHECKING:
     class WriteBasicPackageVersionFile(T.TypedDict):
 
+        arch_independent: bool
         compatibility: str
         install_dir: T.Optional[str]
         name: str
@@ -270,12 +271,14 @@ class CmakeModule(ExtensionModule):
     @noPosargs
     @typed_kwargs(
         'cmake.write_basic_package_version_file',
+        KwargInfo('arch_independent', bool, default=False, since='0.62.0'),
         KwargInfo('compatibility', str, default='AnyNewerVersion', validator=in_set_validator(set(COMPATIBILITIES))),
         KwargInfo('install_dir', (str, NoneType), default=None),
         KwargInfo('name', str, required=True),
         KwargInfo('version', str, required=True),
     )
     def write_basic_package_version_file(self, state, args, kwargs: 'WriteBasicPackageVersionFile'):
+        arch_independent = kwargs['arch_independent']
         compatibility = kwargs['compatibility']
         name = kwargs['name']
         version = kwargs['version']
@@ -296,7 +299,8 @@ class CmakeModule(ExtensionModule):
 
         conf = {
             'CVF_VERSION': (version, ''),
-            'CMAKE_SIZEOF_VOID_P': (str(self.detect_voidp_size(state.environment)), '')
+            'CMAKE_SIZEOF_VOID_P': (str(self.detect_voidp_size(state.environment)), ''),
+            'CVF_ARCH_INDEPENDENT': (arch_independent, ''),
         }
         mesonlib.do_conf_file(template_file, version_file, conf, 'meson')
 


### PR DESCRIPTION
CMake's `write_basic_package_version_file` has supported an `ARCH_INDEPENDENT` option since version 3.14 that make it skip its architecture check in the Version file.

With this patch Meson now supports it as well, and the change is also compatible with older CMake versions, as they will simply ignore the option.

This also slightly changes the contents of the generated Version file when `arch_independent` is not set: previously, the `if()` needed to skip the arch check was always filled with an empty string, while CMake puts `"FALSE"` (or `"TRUE"`) in it. Now, that `if()` will always be filled with either `"False"` or `"True"`, better matching CMake's behaviour.

I still have to add this to the documentation and mark the new kwarg as introduced in Meson 0.62.0 (I don't know how, though), so I'm marking this as a draft