### PR TITLE
unittests: fine-tune the check for whether we are in CI

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,6 +35,7 @@ jobs:
     - env:
         CPPFLAGS: "-I/usr/local/include"
         LDFLAGS: "-L/usr/local/lib"
+        MESON_CI_JOBNAME: unittests-appleclang
         MESON_UNIT_TEST_BACKEND: ninja
         # These cannot evaluate anything, so we cannot set PATH or SDKROOT here
       run: |

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -122,13 +122,16 @@ def main():
 
     try:
         import pytest # noqa: F401
-        # Need pytest-xdist for `-n` arg
-        import xdist # noqa: F401
         pytest_args = []
-        # Don't use pytest-xdist when running single unit tests since it wastes
-        # time spawning a lot of processes to distribute tests to in that case.
-        if not running_single_tests(sys.argv, cases):
-            pytest_args += ['-n', 'auto']
+        try:
+            # Need pytest-xdist for `-n` arg
+            import xdist # noqa: F401
+            # Don't use pytest-xdist when running single unit tests since it wastes
+            # time spawning a lot of processes to distribute tests to in that case.
+            if not running_single_tests(sys.argv, cases):
+                pytest_args += ['-n', 'auto']
+        except ImportError:
+            print('pytest-xdist not found, tests will not be distributed across CPU cores')
         # Let there be colors!
         if 'CI' in os.environ:
             pytest_args += ['--color=yes']
@@ -143,7 +146,7 @@ def main():
             pass
         return subprocess.run(python_command + ['-m', 'pytest'] + pytest_args).returncode
     except ImportError:
-        print('pytest-xdist not found, using unittest instead')
+        print('pytest not found, using unittest instead')
     # Fallback to plain unittest.
     return unittest.main(defaultTest=cases, buffer=True)
 

--- a/unittests/helpers.py
+++ b/unittests/helpers.py
@@ -17,7 +17,7 @@ from run_tests import get_fake_env
 
 
 def is_ci():
-    if 'CI' in os.environ:
+    if 'MESON_CI_JOBNAME' in os.environ:
         return True
     return False
 


### PR DESCRIPTION
The $CI environment variable may be generally set by Github or Gitlab actions, and is not a reliable indicator of whether we are running "CI". It could also, for an absolutely random example that didn't *just happen*, be Alpine Linux's attempt to enable the Meson testsuite in their packaging, which... uses Gitlab CI.

In this case, we do want to perform normal skipping on not-found requirements. Instead of checking for $CI, check for $MESON_CI_JOBNAME as we already use that in all of our own CI jobs for various reasons.

This makes it easier for linux distros to package Meson without accumulating hacks like "run the testsuite using `env -u CI`".