### PR TITLE
backends/ninja: generate symlink aliases for rust/cs/swift libraries too

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -735,6 +735,9 @@ class NinjaBackend(backends.Backend):
         self.introspection_data[name] = {}
         # Generate rules for all dependency targets
         self.process_target_dependencies(target)
+
+        self.generate_shlib_aliases(target, self.get_target_dir(target))
+
         # If target uses a language that cannot link to C objects,
         # just generate for that language and return.
         if isinstance(target, build.Jar):
@@ -899,7 +902,6 @@ class NinjaBackend(backends.Backend):
             final_obj_list = obj_list
         elem = self.generate_link(target, outname, final_obj_list, linker, pch_objects, stdlib_args=stdlib_args)
         self.generate_dependency_scan_target(target, compiled_sources, source2object, generated_source_files)
-        self.generate_shlib_aliases(target, self.get_target_dir(target))
         self.add_build(elem)
 
     def should_use_dyndeps_for_target(self, target: 'build.BuildTarget') -> bool:


### PR DESCRIPTION
Basically the last thing we did during target processing was to generate shlib symlinks for e.g. libfoo.so -> libfoo.so.1.

In some cases we would dispatch to another function and return early, though, which meant we never got far enough to generate the symlinks. This then led to breakage when people tried to compile against libfoo.so

This surely breaks -uninstalled.pc usage, and also caused problems in https://github.com/rust-lang/rust/pull/90260