### PR TITLE
minstall: stop running ldconfig for the user

### DIFF
--- a/docs/markdown/snippets/no_ldconfig.md
+++ b/docs/markdown/snippets/no_ldconfig.md
@@ -1,0 +1,5 @@
+## ldconfig is no longer run on install
+
+Due to various issues of fragility and concern that it doesn't predictably do
+the right thing, meson no longer runs ldconfig during `meson install`, and
+users who need it run should run it themselves, instead.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -119,7 +119,6 @@ class InstallData:
     install_umask: T.Union[str, int]
     mesonintrospect: T.List[str]
     version: str
-    is_cross_build: bool
 
     def __post_init__(self) -> None:
         self.targets: T.List[TargetInstallData] = []
@@ -1502,8 +1501,7 @@ class Backend:
                         strip_bin,
                         umask,
                         self.environment.get_build_command() + ['introspect'],
-                        self.environment.coredata.version,
-                        self.environment.is_cross_build())
+                        self.environment.coredata.version)
         self.generate_depmf_install(d)
         self.generate_target_install(d)
         self.generate_header_install(d)


### PR DESCRIPTION
This was a nice idea in theory, but in practice it had various problems:

- On the only platform where ldconfig is expected to be run, it is
 really slow, even when the user uses a non-default prefix and ldconfig doesn't even have permission to run
- On FreeBSD, it bricked the system: #9592
- On cross builds, it should not be used and broke installing, because ldconfig may not be runnable without binfmt + qemu: #9707
- it prints weird and confusing errors in the common "custom prefix" layout: #9241

Some of these problems can be or have been fixed. But it's a constant source of footguns and complaints and for something that was originally supposed to be just "it's the right thing to do anyway, so just do it automatically" it is entirely too risky.

Ultimately I do not think there is justification for keeping this feature in since it doesn't actually make everyone happy. Better for
users to decide whether they need this themselves.

This is anyways the case for cmake and autotools and generally any other build system, so it should not be too intimidating...

Fixes #9721