### PR TITLE
new custom dependency lookup for libdl

### DIFF
--- a/docs/markdown/Dependencies.md
+++ b/docs/markdown/Dependencies.md
@@ -393,6 +393,17 @@ foreach h : check_headers
 endforeach
 ```
 
+## dl (libdl)
+
+*(added 0.62.0)*
+
+Provides access to the dynamic link interface (functions: dlopen,
+dlclose, dlsym and others). On systems where this is not built
+into libc (mostly glibc < 2.34), tries to find an external library
+providing them instead.
+
+`method` may be `auto`, `builtin` or `system`.
+
 ## Fortran Coarrays
 
 *(added 0.50.0)*

--- a/docs/markdown/snippets/libdl-dependency.md
+++ b/docs/markdown/snippets/libdl-dependency.md
@@ -1,0 +1,8 @@
+## New custom dependency for libdl
+
+```
+dependency('dl')
+```
+
+will now check for the functionality of libdl.so, but first check if it is
+provided in the libc (for example in libc on OpenBSD or in musl libc on linux).

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -36,6 +36,7 @@ from .misc import (
     BlocksDependency, OpenMPDependency, cups_factory, curses_factory, gpgme_factory,
     libgcrypt_factory, libwmf_factory, netcdf_factory, pcap_factory, python3_factory,
     shaderc_factory, threads_factory, ThreadDependency, iconv_factory, intl_factory,
+    dl_factory
 )
 from .platform import AppleFrameworks
 from .qt import qt4_factory, qt5_factory, qt6_factory
@@ -254,6 +255,7 @@ packages.update({
     'shaderc': shaderc_factory,
     'iconv': iconv_factory,
     'intl': intl_factory,
+    'dl': dl_factory,
 
     # From platform:
     'appleframeworks': AppleFrameworks,


### PR DESCRIPTION
The background to this patch can be seen here: https://github.com/mpv-player/mpv/pull/9793

In a nutshell:
Different systems/implementations of libc have different policies about having the 'libdl' library in the system. On some systems (*BSD, glibc >= 2.34) the dynamic linker interface is part of libc, on others (mostly glibc < 2.34) a separate 'libdl' library is supplied which contains the necessary functions.

In order to simplify the handling of having libdl in meson, @eli-schwartz suggested that I implement separate logic for this in meson, similar to mesonbuild/meson@2c6ccfe and mesonbuild/meson@214d035.

That's exactly what I ended up doing.
Tested the mpv build with meson with my changes on OpenBSD (libdl is missing) and on Archlinux (glib 2.33, libdl comes as a separate library).
I used this patch for mpv instead of the one now presented in https://github.com/mpv-player/mpv/pull/9793 :
```
--- a/meson.build
+++ b/meson.build
@@ -336,7 +336,7 @@ if get_option('ta-leak-report')
     features += 'ta-leak-report'
 endif
 
-libdl = cc.find_library('libdl', required: false)
+libdl = dependency('dl', required: false)
 if libdl.found()
     dependencies += libdl
     features += 'libdl'
```

The build was successful on both OpenBSD and Linux.

I'd be happy to get any comments, objections or other criticism you might have.