### PR TITLE
cmake: configure_package_config_file refactor

### DIFF
--- a/docs/markdown/CMake-module.md
+++ b/docs/markdown/CMake-module.md
@@ -262,6 +262,7 @@ the `configuration` parameter.
 * `input`: the template file where that will be treated for variable substitutions contained in `configuration`.
 * `install_dir`: optional installation directory, it defaults to `$(libdir)/cmake/$(name)`.
 * `configuration`: a `configuration_data` object that will be used for variable substitution in the template file.
+  *Since 0.62.0* it can take a dictionary instead.
 
 
 Example:

--- a/docs/markdown/snippets/cmake_configure_package_config_dict.md
+++ b/docs/markdown/snippets/cmake_configure_package_config_dict.md
@@ -1,0 +1,5 @@
+## cmake.configure_package_config_file can now take a dict
+
+The `configuration` kwarg of the `configure_package_config_file()` function
+from the `cmake` module can now take a dict object, just like the regular
+`configure_file()` function.

--- a/mesonbuild/modules/cmake.py
+++ b/mesonbuild/modules/cmake.py
@@ -53,7 +53,7 @@ if T.TYPE_CHECKING:
 
     class ConfigurePackageConfigFile(TypedDict):
 
-        configuration: build.ConfigurationData
+        configuration: T.Union[build.ConfigurationData, dict]
         input: T.Union[str, mesonlib.File]
         install_dir: T.Optional[str]
         name: str
@@ -347,7 +347,7 @@ class CmakeModule(ExtensionModule):
     @noPosargs
     @typed_kwargs(
         'cmake.configure_package_config_file',
-        KwargInfo('configuration', build.ConfigurationData, required=True),
+        KwargInfo('configuration', (build.ConfigurationData, dict), required=True),
         KwargInfo('input',
                   (str, mesonlib.File, ContainerTypeInfo(list, mesonlib.File)), required=True,
                   validator=lambda x: 'requires exactly one file' if isinstance(x, list) and len(x) != 1 else None,
@@ -372,6 +372,9 @@ class CmakeModule(ExtensionModule):
             install_dir = os.path.join(state.environment.coredata.get_option(mesonlib.OptionKey('libdir')), 'cmake', name)
 
         conf = kwargs['configuration']
+        if isinstance(conf, dict):
+            FeatureNew.single_use('cmake.configure_package_config_file dict as configuration', '0.62.0', state.subproject, location=state.current_node)
+            conf = build.ConfigurationData(conf)
 
         prefix = state.environment.coredata.get_option(mesonlib.OptionKey('prefix'))
         abs_install_dir = install_dir

--- a/test cases/cmake/20 cmake file/meson.build
+++ b/test cases/cmake/20 cmake file/meson.build
@@ -4,11 +4,9 @@ project(
 
 cmake = import('cmake')
 
-cmake_conf = configuration_data()
-cmake_conf.set_quoted('foo', 'bar')
 cmake.configure_package_config_file(
   name : 'foolib',
   input : 'foolib.cmake.in',
   install_dir : get_option('libdir') / 'cmake',
-  configuration : cmake_conf,
+  configuration : {'foo': '"bar"'},
 )


### PR DESCRIPTION
I liked so much adding a new kwarg to `write_basic_package_version_file` I thought I would try to also add something to `configure_package_config_file`. Functions taking a `cfg_data` object can generally also take a `dict`, but cmake's `configure_package_config_file` was an exception, so I added the possibility to also pass a `dict` to it.

Following @eli-schwartz's suggestion in https://github.com/mesonbuild/meson/pull/9916#discussion_r795921708 I also refactored a bit the function to use `@typed_kwargs`, but in doing so I encountered a couple of issues I don't know how to solve... The first is a regression, as now the `input` kwarg complains when passing the result of `files()`, saying that it expects a `File` or a `str` while an `array[File]` has been passed in. I think this could be worked around by saying that the function can take a list of `File`s, but it's not really a solution. The second one is less important, and is the fact that I don't know how to put the default value of `install_dir` in `@typed_kwargs`, so I have to still keep an `if isinstance` in the function.

If someone would like to help me a bit understand what's going on it would be great :)