### PR TITLE
gnome: Build documentation by default

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1461,6 +1461,7 @@ class GnomeModule(ExtensionModule):
             [],
             [f'{modulename}-decl.txt'],
             build_always_stale=True,
+            build_by_default=True,
             extra_depends=depends,
         )
         alias_target = build.AliasTarget(targetname, [custom_target], state.subdir, state.subproject)


### PR DESCRIPTION
Without this, we have the problem that the documentation is not build by
the "all" target. This in turn means that it will not have been build
during "install".

Sometimes, this works fine, i.e. meson will run the gtk-doc command just
fine in the installation step. However, the result is that any if there
are generated input files for gtk-doc, then these are not build in
advance.

We do have the PROJECT-doc target, which is sufficient when run. As
such, this patch changes things so that we have a dependncy such as

  install -> all -> PROJECT-doc -> generated input for gnome.gtkdoc

an alternative to this could be doing a more direct

  install -> PROJECT-doc -> generated input for gnome.gtkdoc

dependency chain. Doing that would fix the problem without also
"regressing" by causing the documentation to be re-build every single
time the binaries are build.