### PR TITLE
mdist: fix dist scripts in subprojects being marked as superproject scripts

### DIFF
--- a/mesonbuild/interpreter/mesonmain.py
+++ b/mesonbuild/interpreter/mesonmain.py
@@ -87,13 +87,13 @@ class MesonMain(MesonInterpreterObject):
             FeatureNew.single_use(f'Passing executable/found program object to script parameter of {name}',
                                   '0.55.0', self.subproject, location=self.current_node)
             largs.append(prog)
-            largs.extend(args)
-            return self.interpreter.backend.get_executable_serialisation(largs)
-        elif isinstance(prog, mesonlib.File):
-            FeatureNew.single_use(f'Passing file object to script parameter of {name}',
-                                  '0.57.0', self.subproject, location=self.current_node)
-        found = self.interpreter.find_program_impl([prog])
-        largs.append(found)
+        else:
+            if isinstance(prog, mesonlib.File):
+                FeatureNew.single_use(f'Passing file object to script parameter of {name}',
+                                      '0.57.0', self.subproject, location=self.current_node)
+            found = self.interpreter.find_program_impl([prog])
+            largs.append(found)
+
         largs.extend(args)
         es = self.interpreter.backend.get_executable_serialisation(largs)
         es.subproject = self.interpreter.subproject


### PR DESCRIPTION
This has never worked for built/found programs, only for script files.

In commit 2fabd4c7dc22373e99fc63823d80083ad30704b8 scripts learned an attribute stating which subproject they came from. In commit 3990754bf55727ef5593769b48f0a03c6b7a3671 dist scripts learned to run even from a subproject, and relied on that attribute to know when, in fact, they came from a subproject.

Unfortunately the original attribute was only set in one half of an if/else, and the other half returned early with only part of the work done.

Fixes #9964