### PR TITLE
ninjabackend: fix rust program names with dashes

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -1709,7 +1709,8 @@ class NinjaBackend(backends.Backend):
             args.extend(rustc.get_linker_always_args())
 
         args += self.generate_basic_compiler_args(target, rustc, False)
-        args += ['--crate-name', target.name]
+        # This matches rustc's default behavior.
+        args += ['--crate-name', target.name.replace('-', '_')]
         depfile = os.path.join(target.subdir, target.name + '.d')
         args += ['--emit', f'dep-info={depfile}', '--emit', 'link']
         args += target.get_extra_args('rust')

--- a/test cases/rust/1 basic/meson.build
+++ b/test cases/rust/1 basic/meson.build
@@ -1,6 +1,6 @@
 project('rustprog', 'rust')
 
-e = executable('program', 'prog.rs',
+e = executable('rust-program', 'prog.rs',
   rust_args : ['-C', 'lto'], # Just a test
   install : true
 )

--- a/test cases/rust/1 basic/subdir/meson.build
+++ b/test cases/rust/1 basic/subdir/meson.build
@@ -1,2 +1,2 @@
-e = executable('program2', 'prog.rs', install : true)
+e = executable('rust-program2', 'prog.rs', install : true)
 test('rusttest2', e)

--- a/test cases/rust/1 basic/test.json
+++ b/test cases/rust/1 basic/test.json
@@ -1,8 +1,8 @@
 {
   "installed": [
-    {"type": "exe", "file": "usr/bin/program"},
-    {"type": "pdb", "file": "usr/bin/program"},
-    {"type": "exe", "file": "usr/bin/program2"},
-    {"type": "pdb", "file": "usr/bin/program2"}
+    {"type": "exe", "file": "usr/bin/rust-program"},
+    {"type": "pdb", "file": "usr/bin/rust-program"},
+    {"type": "exe", "file": "usr/bin/rust-program2"},
+    {"type": "pdb", "file": "usr/bin/rust-program2"}
   ]
 }


### PR DESCRIPTION
This substitution matches the [behaviour of rustc][1] when inferring
crate name based on file name.

[1]: https://github.com/rust-lang/rust/tree/4e8fb743ccbec27344b2dd42de7057f41d4ebfdd/compiler/rustc_session/src/output.rs#L88
