### PR TITLE
pypi: include a ninja extra

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,8 @@ console_scripts =
   meson = mesonbuild.mesonmain:main
 
 [options.extras_require]
+ninja =
+  ninja>=1.8.2
 progress =
   tqdm
 typing =


### PR DESCRIPTION
This will really help with pipx run, as `pipx run meson[ninja]` will now work on any system with pipx 0.17 or newer, no dependencies required. This now includes GitHub Actions, which just updated to pipx 1.0.0. Pipx run lets you use recent (always <1 week old) versions of anything on PyPI.