### PR TITLE
setup.py: better requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
The first version of setuptools to properly support pyproject.toml was 42 (40-41 were buggy). It is also necessary to specify `build-backend = "setuptools.build_meta"`, otherwise you get the (horrible) default `build-backend = "setuptools.build_meta:__legacy__"`.