### PR TITLE
setup.cfg: update classifier, drop deprecated

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,14 +26,13 @@ classifiers =
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
   Topic :: Software Development :: Build Tools
 long_description = Meson is a cross-platform build system designed to be both as fast and as user friendly as possible. It supports many languages and compilers, including GCC, Clang, PGI, Intel, and Visual Studio. Its build definitions are written in a simple non-Turing complete DSL.
 
 [options]
 packages = find:
 python_requires = >= 3.7
-setup_requires =
-  setuptools
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This adds 3.10 (didn't check to see if it was tested on 3.10, that should be done, but I'm using it on 3.10).

setup_requires is deprecated and should be producing warnings on modern setuptools, and never worked for setuptools anyway - setuptools can't update itself, and setuptools is what is reading this anyway!

FYI, you can keep you setup.cfg classifiers up to date with setup-cfg-fmt and pre-commit, see https://scikit-hep.org/developer for that and other recommendations for modern Python packaging.