### PR TITLE
packaging: fix the MSI bundling of distutils sub-packages

### DIFF
--- a/packaging/createmsi.py
+++ b/packaging/createmsi.py
@@ -72,6 +72,7 @@ def get_more_modules():
             'distutils.version',
             'distutils.command.build_ext',
             'distutils.command.build',
+            'distutils.command.install',
             'filecmp',
             ]
 


### PR DESCRIPTION
Fixes regression in commit 05b5a1e56fe8f5400b65d0d69680cc6531fe74f8. This added usage of another module in the python module's introspection of `meson.exe runpython`, but the MSI packaging didn't adapt, causing it to fail to be detected due to ImportError.

Fixes #9975