### PR TITLE
fix UI regression in compiler.compiles logging

### DIFF
--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -441,7 +441,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
                 code.rel_to_builddir(self.environment.source_dir))
         testname = kwargs['name']
         extra_args = functools.partial(self._determine_args, kwargs['no_builtin_args'], kwargs['include_directories'], kwargs['args'])
-        deps, msg = self._determine_dependencies(kwargs['dependencies'])
+        deps, msg = self._determine_dependencies(kwargs['dependencies'], endl=None)
         result, cached = self.compiler.compiles(code, self.environment,
                                                 extra_args=extra_args,
                                                 dependencies=deps)


### PR DESCRIPTION
In commit b30dddd4e5b4ae6e5e1e812085a00a47e3edfcf1, various refactorings were done, during which a kwarg got accidentally dropped from the function that determined part of the log message. As a result, a ':' suddenly appeared in the log message where none should be.

Example expected output:

```
Checking if "-Werror=shadow with local shadowing" compiles: YES
```

What actually happened:

```
Checking if "-Werror=shadow with local shadowing" : compiles: YES
```

Fixes #9974