### PR TITLE
Add wx-config-3.1 provided by mingw-w64-x86_64-wxmsw3.1

### DIFF
--- a/mesonbuild/dependencies/ui.py
+++ b/mesonbuild/dependencies/ui.py
@@ -145,7 +145,7 @@ class SDL2DependencyConfigTool(ConfigToolDependency):
 
 class WxDependency(ConfigToolDependency):
 
-    tools = ['wx-config-3.0', 'wx-config', 'wx-config-gtk3']
+    tools = ['wx-config-3.0', 'wx-config-3.1', 'wx-config', 'wx-config-gtk3']
     tool_name = 'wx-config'
 
     def __init__(self, environment: 'Environment', kwargs: T.Dict[str, T.Any]):


### PR DESCRIPTION
On Windows using MSYS2 MinGW installing the package `mingw-w64-x86_64-wxmsw3.1` provides `wx-config-3.1`. I have tried building my software by making this exact change and it build correctly.