### PR TITLE
Qt: fix broken tool names

### DIFF
--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -245,7 +245,7 @@ class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=abc.ABCMeta):
 
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         _QtBase.__init__(self, name, kwargs)
-        self.tools = [f'qmake-{self.name}', 'qmake']
+        self.tools = [f'qmake{self.qtver}', f'qmake-{self.name}', 'qmake']
 
         # Add additional constraints that the Qt version is met, but preserve
         # any version requrements the user has set as well. For example, if Qt5

--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -127,6 +127,7 @@ class _QtBase:
     libexecdir: T.Optional[str] = None
 
     def __init__(self, name: str, kwargs: T.Dict[str, T.Any]):
+        self.name = name
         self.qtname = name.capitalize()
         self.qtver = name[-1]
         if self.qtver == "4":
@@ -244,7 +245,7 @@ class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=abc.ABCMeta):
 
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         _QtBase.__init__(self, name, kwargs)
-        self.tools = [f'qmake-{self.qtname}', 'qmake']
+        self.tools = [f'qmake-{self.name}', 'qmake']
 
         # Add additional constraints that the Qt version is met, but preserve
         # any version requrements the user has set as well. For example, if Qt5

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -133,8 +133,10 @@ class QtBaseModule(ExtensionModule):
                     yield os.path.join(qt_dep.bindir, b), b
                 if qt_dep.libexecdir:
                     yield os.path.join(qt_dep.libexecdir, b), b
-                # prefer the <tool>-qt<version> of the tool to the plain one, as we
+                # prefer the (official) <tool><version> or (unofficial) <tool>-qt<version>
+                # of the tool to the plain one, as we
                 # don't know what the unsuffixed one points to without calling it.
+                yield f'{b}{qt_dep.qtver}', b
                 yield f'{b}-qt{qt_dep.qtver}', b
                 yield b, b
 

--- a/test cases/frameworks/4 qt/test.json
+++ b/test cases/frameworks/4 qt/test.json
@@ -2,8 +2,8 @@
   "matrix": {
     "options": {
       "method": [
-        { "val": "config-tool", "skip_on_jobname": ["fedora", "opensuse"] },
-        { "val": "qmake", "skip_on_jobname": ["fedora", "opensuse"] },
+        { "val": "config-tool" },
+        { "val": "qmake" },
         { "val": "pkg-config" }
       ]
     }

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -387,8 +387,8 @@ class LinuxlikeTests(BasePlatformTests):
         Test that qt6 detection with qmake works. This can't be an ordinary
         test case because it involves setting the environment.
         '''
-        # Verify that qmake is for Qt5
-        if not shutil.which('qmake-qt6'):
+        # Verify that qmake is for Qt6
+        if not shutil.which('qmake6'):
             if not shutil.which('qmake'):
                 raise SkipTest('QMake not found')
             output = subprocess.getoutput('qmake --version')


### PR DESCRIPTION
There is broken behavior w.r.t. looking up tool names:
- we tried to find `foo-Qt5` instead of `foo-qt5`, resulting in two wrongly skipped jobs
- we don't look for `foo6` on Qt6, but the Qt Company finally standardized a name and it's not the one the community gathered around

Okay, now that we actually look for the right name, we actually find qt6 at all, ever. So now it turns out our support is broken. Yay! This goes together with #9792