### PR TITLE
pkgconfig module: allow custom variables to reference builtin directories

### DIFF
--- a/docs/markdown/snippets/pkgconfig_directory_variables.md
+++ b/docs/markdown/snippets/pkgconfig_directory_variables.md
@@ -1,0 +1,31 @@
+## pkgconfig.generate will now include variables for builtin directories when referenced
+
+When using the `variables:` family of kwargs to `pkgconfig.generate` to refer
+to installed paths, traditionally only `prefix`, `includedir`, and `libdir`
+were available by default, and generating a correct (relocatable) pkg-config
+file required manually constructing variables for e.g. `datadir`.
+
+Meson now checks each variable to see if it begins with a reference to a
+standard directory, and if so, adds it to the list of directories for which a
+builtin variable is created.
+
+For example, before it was necessary to do this:
+```meson
+pkgconfig.generate(
+    name: 'bash-completion',
+    description: 'programmable completion for the bash shell',
+    dataonly: true,
+    variables: {
+        'prefix': get_option('prefix'),
+        'datadir': join_paths('${prefix}', get_option('datadir')),
+        'sysconfdir': join_paths('${prefix}', get_option('sysconfdir')),
+
+        'compatdir': '${sysconfdir}/bash_completion.d',
+        'completionsdir': '${datadir}/bash-completion/completions',
+        'helpersdir': '${datadir}/bash-completion/helpers',
+    },
+    install_dir: join_paths(get_option('datadir'), 'pkgconfig'),
+)
+```
+
+Now the first three variables are not needed.

--- a/test cases/common/44 pkgconfig-gen/meson.build
+++ b/test cases/common/44 pkgconfig-gen/meson.build
@@ -1,4 +1,4 @@
-project('pkgconfig-gen', 'c')
+project('pkgconfig-gen', 'c', meson_version: '>=0.60.0')
 
 # Some CI runners does not have zlib, just skip them as we need some common
 # external dependency.
@@ -149,3 +149,17 @@ ct = custom_target('stat3',
 )
 simple6 = library('simple6', link_with: ct)
 pkgg.generate(simple6)
+
+# implicit variables
+pkgg.generate(
+  name : 'libvartest',
+  description : 'Check that implicit vars are created',
+  version : libver,
+  variables: ['datadir=${prefix}/data', 'foo=${datadir}/foo', 'bar=${bindir}/bar']
+)
+pkgg.generate(
+  name : 'libvartest2',
+  description : 'Check that libdir is not an implicit var',
+  version : libver,
+  variables: ['bar=${libdir}/bar']
+)

--- a/test cases/common/44 pkgconfig-gen/test.json
+++ b/test cases/common/44 pkgconfig-gen/test.json
@@ -7,11 +7,26 @@
     {"type": "file", "file": "usr/lib/pkgconfig/libfoo.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/libhello.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/libhello_nolib.pc"},
+    {"type": "file", "file": "usr/lib/pkgconfig/libvartest.pc"},
+    {"type": "file", "file": "usr/lib/pkgconfig/libvartest2.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/simple2.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/simple3.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/simple5.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/simple6.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/ct.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/ct0.pc"}
+  ],
+  "stdout": [
+    {
+      "line": "test cases/common/44 pkgconfig-gen/meson.build:158: WARNING: Project targeting '>=0.60.0' but tried to use feature introduced in '0.62.0': pkgconfig.generate implicit variable for builtin directories."
+    },
+    {
+      "line": "test cases/common/44 pkgconfig-gen/meson.build:164: WARNING: Project targeting '>=0.60.0' but tried to use feature introduced in '0.62.0': pkgconfig.generate implicit variable for builtin directories.",
+      "count": 0
+    },
+    {
+      "comment": "This will either match in the future-deprecated notice summary, or match the warning summary",
+      "line": " * 0.62.0: {'pkgconfig.generate variable for builtin directories'}"
+    }
   ]
 }


### PR DESCRIPTION
Automatically generate additional variables and write them into the generated pkg-config file.

This means projects no longer need to manually define the ones they use, which is annoying for dataonly usages (it used to forbid setting the base library-relevant "reserved" ones, and now allows it only for dataonly. But it's bloat to manualy list them anyway).

It also fixes a regression in commit 248e6cf4736ef9ec636228da66c28f9be03aa74f which caused libdir to not be set, and to be unsettable, if the pkg-config file has no libraries but uses the ${libdir} expansion in a custom variable. This could be considered likely a case for dataonly, but it's not guaranteed.

Obsoletes / Closes #9992