### PR TITLE
validate the literal directory "subprojects" when checking sandbox violations

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2462,9 +2462,9 @@ external dependencies (including libraries) must go to "dependencies".''')
                 try:
                     self.validate_within_subproject(self.subdir, a)
                 except InterpreterException:
-                    mlog.warning('include_directories sandbox violation!')
+                    mlog.warning('include_directories sandbox violation!', location=self.current_node)
                     print(textwrap.dedent(f'''\
-                        The project is trying to access the directory {a} which belongs to a different
+                        The project is trying to access the directory {a!r} which belongs to a different
                         subproject. This is a problem as it hardcodes the relative paths of these two projects.
                         This makes it impossible to compile the project in any other directory layout and also
                         prevents the subproject from changing its own directory layout.

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2681,11 +2681,12 @@ Try setting b_lundef to false instead.'''.format(self.coredata.options[OptionKey
             # /opt/vendorsdk/src/file_with_license_restrictions.c
             return
         project_root = Path(srcdir, self.root_subdir)
+        subproject_dir = project_root / self.subproject_dir
         if norm == project_root:
             return
         if project_root not in norm.parents:
             raise InterpreterException(f'Sandbox violation: Tried to grab {inputtype} {norm.name} outside current (sub)project.')
-        if project_root / self.subproject_dir in norm.parents:
+        if subproject_dir == norm or subproject_dir in norm.parents:
             raise InterpreterException(f'Sandbox violation: Tried to grab {inputtype} {norm.name} from a nested subproject.')
 
     @T.overload


### PR DESCRIPTION
We do not want anyone touching this entire directory tree, but due to the way it was implemented, we only checked if its direct parent was a subproject violation. This generally worked, unless people tried to add `subprojects/` as an include directory.

Patch this hole. It now provides the same warning any sandbox violation does (but is not currently an error, just a "will become an error in the future").
