### PR TITLE
shared module: Allow linking on Android

### DIFF
--- a/docs/yaml/functions/shared_module.yaml
+++ b/docs/yaml/functions/shared_module.yaml
@@ -15,12 +15,18 @@ description: |
 
 notes:
  - |
-   *Linking to a shared module is deprecated, and will be an error in the future*.
-   It used to be allowed because it was the only way to have a shared-library-like target that
+   *Linking to a shared module on platforms other than Android is deprecated, and will be an error
+   in the future*.
+   It was previously allowed because it was the only way to have a shared-library-like target that
    contained references to undefined symbols. However, since 0.40.0, the `override_options:`
-   [[build_target]] keyword argument can be used to create such a [[shared_library]], and shared
-   modules have other characteristics that make them incompatible with linking, such as a lack of
-   SONAME. Linking to shared modules also does not work on some platforms, such as on macOS / iOS.
+   [[build_target]] keyword argument can be used to create such a [[shared_library]] by passing
+   `override_options: 'b_lundef=false'`. Shared modules have other characteristics that make
+   them incompatible with linking, such as a lack of SONAME.
+   On macOS and iOS, linking to shared modules is disallowed by the linker, so we disallow it at
+   configure time.
+   On Android, if a shared module `foo` uses symbols from another shared module `bar`, `foo` must
+   also be linked to `bar`. Hence, linking one shared module to another will always be allowed when
+   building for Android.
 
 posargs_inherit: _build_target_base
 varargs_inherit: _build_target_base

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2792,7 +2792,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
                 commands += linker.get_std_shared_lib_link_args()
             # All shared libraries are PIC
             commands += linker.get_pic_args()
-            if not isinstance(target, build.SharedModule) or target.backwards_compat_want_soname:
+            if not isinstance(target, build.SharedModule) or target.force_soname:
                 # Add -Wl,-soname arguments on Linux, -install_name on OS X
                 commands += linker.get_soname_args(
                     self.environment, target.prefix, target.name, target.suffix,


### PR DESCRIPTION
Android requires shared modules that use symbols from other shared modules to be linked before they can be dlopen()ed in the correct order. Not doing so leads to a missing symbol error: https://github.com/android/ndk/issues/201

We need to always allow linking for this. Also add a soname, although it's not confirmed that it's needed, and it doesn't really hurt if it isn't needed.