### PR TITLE
Support finding toolchain relative to source root

### DIFF
--- a/docs/markdown/Machine-files.md
+++ b/docs/markdown/Machine-files.md
@@ -59,11 +59,13 @@ String and list concatenation is supported using the `+` operator,
 joining paths is supported using the `/` operator. Entries defined in
 the `[constants]` section can be used in any other section (they are
 always parsed first), entries in any other section can be used only
-within that same section and only after it has been defined.
+within that same section and only after it has been defined. The root
+of the source tree is supported using `@SOURCE_ROOT@`.
 
 ```ini
 [constants]
 toolchain = '/toolchain'
+repo_toolchain = '@SOURCE_ROOT@/tools'
 common_flags = ['--sysroot=' + toolchain / 'sysroot']
 
 [properties]
@@ -72,6 +74,7 @@ cpp_args = c_args + ['-DSOMETHING_ELSE']
 
 [binaries]
 c = toolchain / 'gcc'
+somebin = repo_toolchain / 'somebin'
 ```
 
 This can be useful with cross file composition as well. A generic

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -924,6 +924,8 @@ class MachineFileParser():
                 raise EnvironmentException(f'Malformed variable name {entry!r} in machine file.')
             # Windows paths...
             value = value.replace('\\', '\\\\')
+            # replace 'function call'
+            value = value.replace('meson.source_root()', os.getcwd())
             try:
                 ast = mparser.Parser(value, 'machinefile').parse()
                 res = self._evaluate_statement(ast.lines[0])

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -924,8 +924,8 @@ class MachineFileParser():
                 raise EnvironmentException(f'Malformed variable name {entry!r} in machine file.')
             # Windows paths...
             value = value.replace('\\', '\\\\')
-            # replace 'function call'
-            value = value.replace('meson.source_root()', os.getcwd())
+            # Fill in path to source root here
+            value = value.replace('@SOURCE_ROOT@', os.getcwd())
             try:
                 ast = mparser.Parser(value, 'machinefile').parse()
                 res = self._evaluate_statement(ast.lines[0])


### PR DESCRIPTION
Adds in a rudimentary replacement for `meson.source_root()' in the processed machine files. This was a "least intrusive" way to enable relative path definitions for toolchains in machine files. Another approach might be to pass additional information from environment.py to coredata.py when the machine files are read in. To test the change out, a cross file similar to below can be used:
```
[constants]
repo = 'meson.source_root()'
path = repo / 'relative/path/bin'
arch = 'arm-none-eabi-'

[binaries]
c = [path / arch + 'gcc']
ar = [path / arch + 'ar']
strip = [path / arch + 'strip']

[host_machine]
system = 'baremetal'
cpu_family = 'arm'
cpu = 'armv7'
endian = 'little'
```
Draft status will be removed if there is sufficient interest in adding this feature. I will be happy to update documentation and tests at that point.