### PR TITLE
mtest: raise informative error message when test program doesn't exist

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1347,9 +1347,12 @@ class SingleTestRunner:
             self.console_mode = ConsoleUser.LOGGER
 
     def _get_test_cmd(self) -> T.Optional[T.List[str]]:
-        if self.test.fname[0].endswith('.jar'):
+        testentry = self.test.fname[0]
+        if self.options.no_rebuild and not os.path.isfile(testentry):
+            raise TestException(f'The test program {testentry!r} does not exist. Cannot run tests before building them.')
+        if testentry.endswith('.jar'):
             return ['java', '-jar'] + self.test.fname
-        elif not self.test.is_cross_built and run_with_mono(self.test.fname[0]):
+        elif not self.test.is_cross_built and run_with_mono(testentry):
             return ['mono'] + self.test.fname
         elif self.test.cmd_is_built and self.test.is_cross_built and self.test.needs_exe_wrapper:
             if self.test.exe_wrapper is None:


### PR DESCRIPTION
If --no-rebuild is used, the test program might not exist, spawning a FileNotFoundError inside a long traceback rooted in subprocess.Popen trying to run that test program. Current versions of Meson even say it's an "unhandled python exception".

But we can do one better and actually tell the user what is wrong, why, and what to do to fix it. And we can do so before getting waist deep in partially running tests.

Fixes #10006
Closes #10007