### PR TITLE
Add public kwarg to set_variable()

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -295,6 +295,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         self.build_func_dict()
         self.build_holder_map()
         self.user_defined_options = user_defined_options
+        self.public_variables: T.Set[str] = set()
 
         # build_def_files needs to be defined before parse_project is called
         #
@@ -2897,12 +2898,15 @@ This will become a hard error in the future.''', location=self.current_node)
         return self.subproject != ''
 
     @typed_pos_args('set_variable', str, object)
-    @noKwargs
+    @typed_kwargs('set_variable',
+        KwargInfo('public', bool, default=False, since='0.62.0'))
     @noArgsFlattening
     @noSecondLevelHolderResolving
     def func_set_variable(self, node: mparser.BaseNode, args: T.Tuple[str, object], kwargs: 'TYPE_kwargs') -> None:
         varname, value = args
         self.set_variable(varname, value, holderify=True)
+        if kwargs['public']:
+            self.public_variables.add(varname)
 
     @typed_pos_args('get_variable', (str, Disabler), optargs=[object])
     @noKwargs

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -706,7 +706,13 @@ class SubprojectHolder(MesonInterpreterObject):
         if not isinstance(varname, str):
             raise InterpreterException('Get_variable first argument must be a string.')
         try:
-            return self.held_object.variables[varname]
+            value = self.held_object.variables[varname]
+            if varname not in self.held_object.public_variables:
+                FeatureDeprecated.single_use(
+                    'subproject.get_variable() for variable not marked public',
+                    '0.62.0', self.subproject,
+                    f'The subproject should mark public variables using set_variable({varname}, value, public: true)',self.current_node)
+            return value
         except KeyError:
             pass
 

--- a/test cases/common/241 set and get variable/meson.build
+++ b/test cases/common/241 set and get variable/meson.build
@@ -69,3 +69,7 @@ assert(not is_disabler(list_t1))
 assert(not is_disabler(list_t2))
 assert(not is_disabler(list_t3))
 assert(not is_disabler(list_t4))
+
+sub = subproject('sub')
+assert(sub.get_variable('private') == 'private')
+assert(sub.get_variable('public') == 'public')

--- a/test cases/common/241 set and get variable/subprojects/sub/meson.build
+++ b/test cases/common/241 set and get variable/subprojects/sub/meson.build
@@ -1,0 +1,5 @@
+project('sub')
+
+private = 'private'
+public = 'public'
+set_variable('public', public, public: true)


### PR DESCRIPTION
This deprecate subp.get_variable() unless the variable has been
explicitly set public by the subproject. This avoids poking at random
internal variables of a subproject and instead define what is their
public build API.