### PR TITLE
tests: various improvements to make alpine packaging work

### DIFF
--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -490,8 +490,9 @@ class IconvSystemDependency(SystemDependency):
 class IntlBuiltinDependency(BuiltinDependency):
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
+        code = '''#include <libintl.h>\n\nint main() {\n    gettext("Hello world");\n}'''
 
-        if self.clib_compiler.has_function('ngettext', '', env)[0]:
+        if self.clib_compiler.links(code, env)[0]:
             self.is_found = True
 
 

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -282,7 +282,8 @@ class TestDef:
 failing_logs: T.List[str] = []
 print_debug = 'MESON_PRINT_TEST_OUTPUT' in os.environ
 under_ci = 'CI' in os.environ
-ci_jobname = os.environ.get('MESON_CI_JOBNAME', None)
+raw_ci_jobname = os.environ.get('MESON_CI_JOBNAME', None)
+ci_jobname = raw_ci_jobname if raw_ci_jobname != 'thirdparty' else None
 do_debug = under_ci or print_debug
 no_meson_log_msg = 'No meson-log.txt found.'
 
@@ -1505,8 +1506,8 @@ def clear_transitive_files() -> None:
             mesonlib.windows_proof_rm(str(d))
 
 if __name__ == '__main__':
-    if under_ci and not ci_jobname:
-        raise SystemExit('Running under CI but MESON_CI_JOBNAME is not set')
+    if under_ci and not raw_ci_jobname:
+        raise SystemExit('Running under CI but $MESON_CI_JOBNAME is not set (set to "thirdparty" if you are running outside of the github org)')
 
     setup_vsenv()
 

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -972,7 +972,7 @@ def have_java() -> bool:
 
 def skip_dont_care(t: TestDef) -> bool:
     # Everything is optional when not running on CI
-    if not under_ci:
+    if ci_jobname is None:
         return True
 
     # Non-frameworks test are allowed to determine their own skipping under CI (currently)

--- a/test cases/common/120 extract all shared library/meson.build
+++ b/test cases/common/120 extract all shared library/meson.build
@@ -6,7 +6,8 @@ endif
 
 a = static_library('a', 'one.c', 'two.c')
 b = static_library('b', 'three.c', 'four.c')
-c = shared_library('c',
+# libc.so cannot be used, it already exists as a reserved name
+c = shared_library('cee',
   objects : [a.extract_all_objects(), b.extract_all_objects()],
   vs_module_defs : 'func1234.def')
 

--- a/test cases/common/155 subproject dir name collision/custom_subproject_dir/C/meson.build
+++ b/test cases/common/155 subproject dir name collision/custom_subproject_dir/C/meson.build
@@ -1,2 +1,3 @@
 project('C', 'c')
-c = library('c', 'c.c')
+# libc.so cannot be used, it already exists as a reserved name
+c = library('cee', 'c.c')

--- a/test cases/common/72 shared subproject/subprojects/C/meson.build
+++ b/test cases/common/72 shared subproject/subprojects/C/meson.build
@@ -1,2 +1,3 @@
 project('C', 'c')
-c = library('c', 'c.c')
+# libc.so cannot be used, it already exists as a reserved name
+c = library('cee', 'c.c')

--- a/test cases/common/73 shared subproject 2/subprojects/C/meson.build
+++ b/test cases/common/73 shared subproject 2/subprojects/C/meson.build
@@ -1,2 +1,3 @@
 project('C', 'c')
-c = library('c', 'c.c')
+# libc.so cannot be used, it already exists as a reserved name
+c = library('cee', 'c.c')

--- a/test cases/common/75 custom subproject dir/custom_subproject_dir/C/meson.build
+++ b/test cases/common/75 custom subproject dir/custom_subproject_dir/C/meson.build
@@ -1,2 +1,3 @@
 project('C', 'c')
-c = shared_library('c', 'c.c')
+# libc.so cannot be used, it already exists as a reserved name
+c = shared_library('cee', 'c.c')

--- a/test cases/linuxlike/13 cmake dependency/cmVers.sh
+++ b/test cases/linuxlike/13 cmake dependency/cmVers.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-VERS=$(cmake --version | grep "cmake version")
-VERS=${VERS//cmake version/}
-
-echo -n $VERS

--- a/test cases/linuxlike/13 cmake dependency/meson.build
+++ b/test cases/linuxlike/13 cmake dependency/meson.build
@@ -6,9 +6,6 @@ if not find_program('cmake', required: false).found()
   error('MESON_SKIP_TEST cmake binary not available.')
 endif
 
-# CMake version
-cm_vers = run_command(find_program('./cmVers.sh'), check: true).stdout().strip()
-
 # Zlib is probably on all dev machines.
 
 dep = dependency('ZLIB', version : '>=1.2', method : 'cmake')
@@ -69,7 +66,7 @@ test('zlibtest4', exe4)
 
 # Test some edge cases with spaces, etc. (but only for CMake >= 3.15)
 
-if cm_vers.version_compare('>=3.15')
+if find_program('cmake', required: false, version: '>=3.15').found()
   testDep1 = dependency('ImportedTarget', required : true, method : 'cmake', cmake_module_path : 'cmake', modules: 'mesonTestLibDefs')
   testDep2 = dependency('ImportedTarget', required : true, method : 'cmake', cmake_module_path : 'cmake', modules : ['MesonTest::TestLibDefs'])
   testFlagSet1 = executable('testFlagSet1', ['testFlagSet.c'], dependencies: [testDep1])

--- a/unittests/helpers.py
+++ b/unittests/helpers.py
@@ -17,7 +17,7 @@ from run_tests import get_fake_env
 
 
 def is_ci():
-    if 'MESON_CI_JOBNAME' in os.environ:
+    if os.environ.get('MESON_CI_JOBNAME') not in {None, 'thirdparty'}:
         return True
     return False
 


### PR DESCRIPTION
See https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/29489

changes:
- make ninja detection faster and more robust. Actually checks, even on CI
- remove pointless dependency on bash in one test
- a couple of changes to how we check whether we are in CI. Distinguishes between "CI environment, so do UX and accessibility quirks" and "Meson CI environment, don't allow tests to be surprisingly skipped"
- fix the testsuite on musl libc

and finally:
- runtime fix for detecting `dependency('intl')`