### PR TITLE
flake8 fixes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -29,5 +29,5 @@ extend-ignore =
     # A003: builtin class attribute
     A003
 per-file-ignores =
-    mesonbuild/mesonlib/__init__.py:F401
+    mesonbuild/mesonlib/__init__.py:F401,F403
 max-line-length = 120

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,4 @@ include run_tests.py
 include run_unittests.py
 include run_meson_command_tests.py
 include run_project_tests.py
-include ghwt.py
-include __main__.py
 include meson.py

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1386,7 +1386,7 @@ class Backend:
 
     def eval_custom_target_command(
             self, target: build.CustomTarget, absolute_outputs: bool = False) -> \
-                T.Tuple[T.List[str], T.List[str], T.List[str]]:
+            T.Tuple[T.List[str], T.List[str], T.List[str]]:
         # We want the outputs to be absolute only when using the VS backend
         # XXX: Maybe allow the vs backend to use relative paths too?
         source_root = self.build_to_src

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -51,7 +51,7 @@ if T.TYPE_CHECKING:
     class TargetIntrospectionData(TypedDict):
 
         language: str
-        compiler : T.List[str]
+        compiler: T.List[str]
         parameters: T.List[str]
         sources: T.List[str]
         generated_sources: T.List[str]

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1345,8 +1345,8 @@ You probably should put it in link_with instead.''')
                 if isinstance(t, (CustomTarget, CustomTargetIndex)):
                     if not t.should_install():
                         mlog.warning(f'Try to link an installed static library target {self.name} with a'
-                                      'custom target that is not installed, this might cause problems'
-                                      'when you try to use this static library')
+                                     'custom target that is not installed, this might cause problems'
+                                     'when you try to use this static library')
                 elif t.is_internal():
                     # When we're a static library and we link_with to an
                     # internal/convenience library, promote to link_whole.
@@ -1600,12 +1600,12 @@ You probably should put it in link_with instead.''')
                     link_target.force_soname = True
                 else:
                     mlog.deprecation(f'target {self.name} links against shared module {link_target.name}, which is incorrect.'
-                            '\n             '
-                            f'This will be an error in the future, so please use shared_library() for {link_target.name} instead.'
-                            '\n             '
-                            f'If shared_module() was used for {link_target.name} because it has references to undefined symbols,'
-                            '\n             '
-                            'use shared_libary() with `override_options: [\'b_lundef=false\']` instead.')
+                                     '\n             '
+                                     f'This will be an error in the future, so please use shared_library() for {link_target.name} instead.'
+                                     '\n             '
+                                     f'If shared_module() was used for {link_target.name} because it has references to undefined symbols,'
+                                     '\n             '
+                                     'use shared_libary() with `override_options: [\'b_lundef=false\']` instead.')
                     link_target.force_soname = True
 
 class Generator(HoldableObject):

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -525,7 +525,7 @@ class Target(HoldableObject):
             mlog.warning(textwrap.dedent(f'''\
                 Target "{self.name}" has a path separator in its name.
                 This is not supported, it can cause unexpected failures and will become
-                a hard error in the future.\
+                a hard error in the future.
             '''))
         self.install = False
         self.build_always_stale = False
@@ -1059,7 +1059,7 @@ class BuildTarget(Target):
                     is reserved for libraries built as part of this project. External
                     libraries must be passed using the dependencies keyword argument
                     instead, because they are conceptually "external dependencies",
-                    just like those detected with the dependency() function.\
+                    just like those detected with the dependency() function.
                 '''))
             self.link(linktarget)
         lwhole = extract_as_list(kwargs, 'link_whole')
@@ -1112,7 +1112,7 @@ class BuildTarget(Target):
                 mlog.warning(textwrap.dedent('''\
                     Please do not define rpath with a linker argument, use install_rpath
                     or build_rpath properties instead.
-                    This will become a hard error in a future Meson release.\
+                    This will become a hard error in a future Meson release.
                 '''))
         self.process_link_depends(kwargs.get('link_depends', []), environment)
         # Target-specific include dirs must be added BEFORE include dirs from

--- a/mesonbuild/cmake/traceparser.py
+++ b/mesonbuild/cmake/traceparser.py
@@ -388,6 +388,7 @@ class CMakeTraceParser:
             target.depends += [key]
 
         working_dir = None
+
         def handle_working_dir(key: str, target: CMakeGeneratorTarget) -> None:
             nonlocal working_dir
             if working_dir is None:

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1224,7 +1224,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
                 yield r
 
     def compiles(self, code: 'mesonlib.FileOrString', env: 'Environment', *,
-                extra_args: T.Union[None, T.List[str], CompilerArgs, T.Callable[[CompileCheckMode], T.List[str]]] = None,
+                 extra_args: T.Union[None, T.List[str], CompilerArgs, T.Callable[[CompileCheckMode], T.List[str]]] = None,
                  dependencies: T.Optional[T.List['Dependency']] = None,
                  mode: str = 'compile',
                  disable_cache: bool = False) -> T.Tuple[bool, bool]:

--- a/mesonbuild/compilers/cuda.py
+++ b/mesonbuild/compilers/cuda.py
@@ -259,10 +259,13 @@ class CudaCompiler(Compiler):
 
         def is_xcompiler_flag_isolated(flag: str) -> bool:
             return flag == '-Xcompiler'
+
         def is_xcompiler_flag_glued(flag: str) -> bool:
             return flag.startswith('-Xcompiler=')
+
         def is_xcompiler_flag(flag: str) -> bool:
             return is_xcompiler_flag_isolated(flag) or is_xcompiler_flag_glued(flag)
+
         def get_xcompiler_val(flag: str, flagit: T.Iterator[str]) -> str:
             if is_xcompiler_flag_glued(flag):
                 return flag[len('-Xcompiler='):]

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -613,7 +613,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
                 ccache + compiler, version, for_machine, is_cross, info,
                 exe_wrap, full_version=full_version, linker=l)
         if 'TMS320C2000 C/C++' in out or 'MSP430 C/C++' in out or 'TI ARM C/C++ Compiler' in out:
-            lnk : T.Union[T.Type[C2000DynamicLinker], T.Type[TIDynamicLinker]]
+            lnk: T.Union[T.Type[C2000DynamicLinker], T.Type[TIDynamicLinker]]
             if 'TMS320C2000 C/C++' in out:
                 cls = C2000CCompiler if lang == 'c' else C2000CPPCompiler
                 lnk = C2000DynamicLinker

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -392,7 +392,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
                 watcom_cls = [sanitize(os.path.join(os.environ['WATCOM'], 'BINNT', 'cl')),
                               sanitize(os.path.join(os.environ['WATCOM'], 'BINNT', 'cl.exe')),
                               sanitize(os.path.join(os.environ['WATCOM'], 'BINNT64', 'cl')),
-                              sanitize(os.path.join(os.environ['WATCOM'], 'BINNT64', 'cl.exe')),]
+                              sanitize(os.path.join(os.environ['WATCOM'], 'BINNT64', 'cl.exe'))]
                 found_cl = sanitize(shutil.which('cl'))
                 if found_cl in watcom_cls:
                     mlog.debug('Skipping unsupported cl.exe clone at:', found_cl)

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -255,8 +255,7 @@ def _get_compilers(env: 'Environment', lang: str, for_machine: MachineChoice) ->
 def _handle_exceptions(
         exceptions: T.Mapping[str, T.Union[Exception, str]],
         binaries: T.List[T.List[str]],
-        bintype: str = 'compiler'
-    ) -> T.NoReturn:
+        bintype: str = 'compiler') -> T.NoReturn:
     errmsg = f'Unknown {bintype}(s): {binaries}'
     if exceptions:
         errmsg += '\nThe following exception(s) were encountered:'

--- a/mesonbuild/compilers/mixins/clang.py
+++ b/mesonbuild/compilers/mixins/clang.py
@@ -106,7 +106,7 @@ class ClangCompiler(GnuLikeCompiler):
         if isinstance(self.linker, AppleDynamicLinker) and mesonlib.version_compare(self.version, '>=8.0'):
             extra_args.append('-Wl,-no_weak_imports')
         return super().has_function(funcname, prefix, env, extra_args=extra_args,
-                                   dependencies=dependencies)
+                                    dependencies=dependencies)
 
     def openmp_flags(self) -> T.List[str]:
         if mesonlib.version_compare(self.version, '>=3.8.0'):

--- a/mesonbuild/compilers/mixins/pgi.py
+++ b/mesonbuild/compilers/mixins/pgi.py
@@ -49,11 +49,12 @@ class PGICompiler(Compiler):
         self.base_options = {OptionKey('b_pch')}
 
         default_warn_args = ['-Minform=inform']
-        self.warn_args = {'0': [],
-                          '1': default_warn_args,
-                          '2': default_warn_args,
-                          '3': default_warn_args
-        }  # type: T.Dict[str, T.List[str]]
+        self.warn_args: T.Dict[str, T.List[str]] = {
+            '0': [],
+            '1': default_warn_args,
+            '2': default_warn_args,
+            '3': default_warn_args
+        }
 
     def get_module_incdir_args(self) -> T.Tuple[str]:
         return ('-module', )

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -482,7 +482,6 @@ class CMakeDependency(ExternalDependency):
                 for tgt in partial_modules:
                     mlog.debug(tgt)
 
-
             incDirs = [x for x in self.traceparser.get_cmake_var('PACKAGE_INCLUDE_DIRS') if x]
             defs = [x for x in self.traceparser.get_cmake_var('PACKAGE_DEFINITIONS') if x]
             libs_raw = [x for x in self.traceparser.get_cmake_var('PACKAGE_LIBRARIES') if x]

--- a/mesonbuild/dependencies/cmake.py
+++ b/mesonbuild/dependencies/cmake.py
@@ -546,7 +546,7 @@ class CMakeDependency(ExternalDependency):
             if not autodetected_module_list:
                 self.found_modules += [i]
 
-            rtgt = resolve_cmake_trace_targets(i ,self.traceparser, self.env,
+            rtgt = resolve_cmake_trace_targets(i, self.traceparser, self.env,
                 clib_compiler=self.clib_compiler,
                 not_found_warning=lambda x: mlog.warning('CMake: Dependency', mlog.bold(x), 'for', mlog.bold(name), 'was not found')
             )

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1706,7 +1706,7 @@ external dependencies (including libraries) must go to "dependencies".''')
             kwargs['output'][0],
             self.subdir,
             self.subproject,
-            self.environment.get_build_command() + \
+            self.environment.get_build_command() +
                 ['--internal',
                 'vcstagger',
                 '@INPUT0@',

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1029,7 +1029,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         if initial_values is not None:
             FeatureNew.single_use('configuration_data dictionary', '0.49.0', self.subproject, location=node)
             for k, v in initial_values.items():
-                if not isinstance(v, (str, int ,bool)):
+                if not isinstance(v, (str, int, bool)):
                     raise InvalidArguments(
                         f'"configuration_data": initial value dictionary key "{k!r}"" must be "str | int | bool", not "{v!r}"')
         return build.ConfigurationData(initial_values)
@@ -2308,7 +2308,7 @@ external dependencies (including libraries) must go to "dependencies".''')
             if isinstance(conf, dict):
                 FeatureNew.single_use('configure_file.configuration dictionary', '0.49.0', self.subproject, location=node)
                 for k, v in conf.items():
-                    if not isinstance(v, (str, int ,bool)):
+                    if not isinstance(v, (str, int, bool)):
                         raise InvalidArguments(
                             f'"configuration_data": initial value dictionary key "{k!r}"" must be "str | int | bool", not "{v!r}"')
                 conf = build.ConfigurationData(conf)

--- a/mesonbuild/interpreter/kwargs.py
+++ b/mesonbuild/interpreter/kwargs.py
@@ -252,7 +252,6 @@ class DependencyPkgConfigVar(TypedDict):
     define_variable: T.List[str]
 
 
-
 class DependencyGetVariable(TypedDict):
 
     cmake: T.Optional[str]

--- a/mesonbuild/interpreter/primitives/range.py
+++ b/mesonbuild/interpreter/primitives/range.py
@@ -24,7 +24,7 @@ class RangeHolder(MesonInterpreterObject, IterableObject):
     def op_index(self, other: int) -> int:
         try:
             return self.range[other]
-        except:
+        except IndexError:
             raise InvalidArguments(f'Index {other} out of bounds of range.')
 
     def iter_tuple_size(self) -> None:

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -287,8 +287,8 @@ CT_BUILD_BY_DEFAULT: KwargInfo[T.Optional[bool]] = KwargInfo('build_by_default',
 
 CT_BUILD_ALWAYS: KwargInfo[T.Optional[bool]] = KwargInfo(
     'build_always', (bool, NoneType),
-     deprecated='0.47.0',
-     deprecated_message='combine build_by_default and build_always_stale instead.',
+    deprecated='0.47.0',
+    deprecated_message='combine build_by_default and build_always_stale instead.',
 )
 
 CT_BUILD_ALWAYS_STALE: KwargInfo[T.Optional[bool]] = KwargInfo(

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -526,7 +526,7 @@ class InterpreterBase:
         self.argument_depth += 1
         reduced_pos = [self.evaluate_statement(arg) for arg in args.arguments]
         if any(x is None for x in reduced_pos):
-            raise InvalidArguments(f'At least one value in the arguments is void.')
+            raise InvalidArguments('At least one value in the arguments is void.')
         reduced_kw: T.Dict[str, InterpreterObject] = {}
         for key, val in args.kwargs.items():
             reduced_key = key_resolver(key)

--- a/mesonbuild/mesonlib/vsenv.py
+++ b/mesonbuild/mesonlib/vsenv.py
@@ -65,7 +65,7 @@ def _setup_vsenv(force: bool) -> bool:
     bat_info = json.loads(bat_json)
     if not bat_info:
         # VS installer instelled but not VS itself maybe?
-        raise MesonException(f'Could not parse vswhere.exe output')
+        raise MesonException('Could not parse vswhere.exe output')
     bat_root = pathlib.Path(bat_info[0]['installationPath'])
     if platform.machine() == 'ARM64':
         bat_path = bat_root / 'VC/Auxiliary/Build/vcvarsx86_arm64.bat'

--- a/mesonbuild/minstall.py
+++ b/mesonbuild/minstall.py
@@ -215,7 +215,7 @@ def set_mode(path: str, mode: T.Optional['FileMode'], default_umask: T.Union[str
         try:
             set_chmod(path, mode.perms, follow_symlinks=False)
         except PermissionError as e:
-            print('{path!r}: Unable to set permissions {mode.perms_s!r}: {e.strerror}, ignoring...')
+            print(f'{path!r}: Unable to set permissions {mode.perms_s!r}: {e.strerror}, ignoring...')
     else:
         sanitize_permissions(path, default_umask)
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -339,7 +339,8 @@ class GnomeModule(ExtensionModule):
         # Normal program lookup
         return state.find_program(name, required=required)
 
-    @typed_kwargs('gnome.post_install',
+    @typed_kwargs(
+        'gnome.post_install',
         KwargInfo('glib_compile_schemas', bool, default=False),
         KwargInfo('gio_querymodules', ContainerTypeInfo(list, str), default=[], listify=True),
         KwargInfo('gtk_update_icon_cache', bool, default=False),
@@ -899,7 +900,7 @@ class GnomeModule(ExtensionModule):
                            libsources: T.Sequence[T.Union[
                                str, mesonlib.File, build.GeneratedList,
                                build.CustomTarget, build.CustomTargetIndex]]
-                            ) -> str:
+                           ) -> str:
         gir_filelist_dir = state.backend.get_target_private_dir_abs(girtargets[0])
         if not os.path.isdir(gir_filelist_dir):
             os.mkdir(gir_filelist_dir)
@@ -1061,12 +1062,12 @@ class GnomeModule(ExtensionModule):
         KwargInfo('includes', ContainerTypeInfo(list, (str, GirTarget)), default=[], listify=True),
         KwargInfo('install_gir', (bool, NoneType), since='0.61.0'),
         KwargInfo('install_dir_gir', (str, bool, NoneType),
-            deprecated_values={False: ('0.61.0', 'Use install_gir to disable installation')},
-            validator=lambda x: 'as boolean can only be false' if x is True else None),
+                  deprecated_values={False: ('0.61.0', 'Use install_gir to disable installation')},
+                  validator=lambda x: 'as boolean can only be false' if x is True else None),
         KwargInfo('install_typelib', (bool, NoneType), since='0.61.0'),
         KwargInfo('install_dir_typelib', (str, bool, NoneType),
-            deprecated_values={False: ('0.61.0', 'Use install_typelib to disable installation')},
-            validator=lambda x: 'as boolean can only be false' if x is True else None),
+                  deprecated_values={False: ('0.61.0', 'Use install_typelib to disable installation')},
+                  validator=lambda x: 'as boolean can only be false' if x is True else None),
         KwargInfo('link_with', ContainerTypeInfo(list, (build.SharedLibrary, build.StaticLibrary)), default=[], listify=True),
         KwargInfo('namespace', str, required=True),
         KwargInfo('nsversion', str, required=True),
@@ -1360,7 +1361,7 @@ class GnomeModule(ExtensionModule):
         KwargInfo('mkdb_args', ContainerTypeInfo(list, str), default=[], listify=True),
         KwargInfo(
             'mode', str, default='auto', since='0.37.0',
-             validator=in_set_validator({'xml', 'sgml', 'none', 'auto'})),
+            validator=in_set_validator({'xml', 'sgml', 'none', 'auto'})),
         KwargInfo('module_version', str, default='', since='0.48.0'),
         KwargInfo('namespace', str, default='', since='0.37.0'),
         KwargInfo('scan_args', ContainerTypeInfo(list, str), default=[], listify=True),

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -196,7 +196,7 @@ class Lexer:
                         if match_text.find("\n") != -1:
                             mlog.warning(textwrap.dedent("""\
                                     Newline character in a string detected, use ''' (three single quotes) for multiline strings instead.
-                                    This will become a hard error in a future Meson release.\
+                                    This will become a hard error in a future Meson release.
                                 """),
                                 self.getline(line_start),
                                 str(lineno),

--- a/mesonbuild/mparser.py
+++ b/mesonbuild/mparser.py
@@ -15,7 +15,6 @@
 from dataclasses import dataclass
 import re
 import codecs
-import textwrap
 import types
 import typing as T
 from .mesonlib import MesonException
@@ -194,14 +193,11 @@ class Lexer:
                     elif tid in {'string', 'fstring'}:
                         # Handle here and not on the regexp to give a better error message.
                         if match_text.find("\n") != -1:
-                            mlog.warning(textwrap.dedent("""\
-                                    Newline character in a string detected, use ''' (three single quotes) for multiline strings instead.
-                                    This will become a hard error in a future Meson release.
-                                """),
-                                self.getline(line_start),
-                                str(lineno),
-                                str(col)
-                            )
+                            msg = ParseException("Newline character in a string detected, use ''' (three single quotes) "
+                                                 "for multiline strings instead.\n"
+                                                 "This will become a hard error in a future Meson release.",
+                                                 self.getline(line_start), lineno, col)
+                            mlog.warning(msg, location=BaseNode(lineno, col, filename))
                         value = match_text[2 if tid == 'fstring' else 1:-1]
                         try:
                             value = ESCAPE_SEQUENCE_SINGLE_RE.sub(decode_match, value)

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -586,7 +586,7 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
 
     p = subparsers.add_parser('update', help='Update all subprojects from wrap files')
     p.add_argument('--rebase', default=True, action='store_true',
-                   help='Rebase your branch on top of wrap\'s revision. ' + \
+                   help='Rebase your branch on top of wrap\'s revision. ' +
                         'Deprecated, it is now the default behaviour. (git only)')
     p.add_argument('--reset', default=False, action='store_true',
                    help='Checkout wrap\'s revision and hard reset to that commit. (git only)')

--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -349,7 +349,7 @@ class Resolver:
                     raise WrapException(f'Unknown wrap type {self.wrap.type!r}')
             try:
                 self.apply_patch()
-            except:
+            except Exception:
                 windows_proof_rmtree(self.dirname)
                 raise
 


### PR DESCRIPTION
Down from 242 warnings to 189.

There is one behavioral change I discovered while investigating a bizarre textwrap.dedent alignment issue: df1642f15770a40f27e6635f4d212317cbd411fc
> fix malformed warning to print the way it was meant to print

Other than that it's mostly just whitespace juggling.