### PR TITLE
Change jar() default install dir

### DIFF
--- a/docs/markdown/snippets/jar_default_install_dir.md
+++ b/docs/markdown/snippets/jar_default_install_dir.md
@@ -1,0 +1,5 @@
+## JAR default install dir
+
+The previous default for `jar()` was `libdir`. With this release, it has been
+changed to `datadir/java`. Please open an issue if this is not a sane default
+for your system.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2627,6 +2627,9 @@ class Jar(BuildTarget):
             return ['-cp', os.pathsep.join(cp_paths)]
         return []
 
+    def get_default_install_dir(self, environment: environment.Environment) -> T.Tuple[str, str]:
+        return environment.get_jar_dir(), '{jardir}'
+
 @dataclass(eq=False)
 class CustomTargetIndex(HoldableObject):
 

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -814,6 +814,10 @@ class Environment:
             return self.get_bindir()
         return self.get_libdir()
 
+    def get_jar_dir(self) -> str:
+        """Install dir for JAR files"""
+        return f"{self.get_datadir()}/java"
+
     def get_static_lib_dir(self) -> str:
         "Install dir for the static library"
         return self.get_libdir()


### PR DESCRIPTION
The previous install dir seemed incorrect when looking at various Linux distributions.

Closes #3830