### PR TITLE
Log that DUB dependency is not found because of missing lib

### DIFF
--- a/mesonbuild/dependencies/dub.py
+++ b/mesonbuild/dependencies/dub.py
@@ -148,6 +148,10 @@ class DubDependency(ExternalDependency):
                     if lib_path:
                         self.link_args.append(lib_path)
                     else:
+                        if os.path.exists(file):
+                            mlog.debug("Cannot use " + file + " as a library")
+                        else:
+                            mlog.debug("Cannot find " + file)
                         self.is_found = False
 
     def _find_right_lib_path(self,

--- a/mesonbuild/dependencies/dub.py
+++ b/mesonbuild/dependencies/dub.py
@@ -147,11 +147,11 @@ class DubDependency(ExternalDependency):
                     lib_path = self._find_right_lib_path(file, comp, description)
                     if lib_path:
                         self.link_args.append(lib_path)
+                    elif os.path.exists(file):
+                        mlog.debug(f'Cannot use {file} as a library')
+                        self.is_found = False
                     else:
-                        if os.path.exists(file):
-                            mlog.debug("Cannot use " + file + " as a library")
-                        else:
-                            mlog.debug("Cannot find " + file)
+                        mlog.debug(f'Cannot find {file}')
                         self.is_found = False
 
     def _find_right_lib_path(self,


### PR DESCRIPTION
Dub is a bit messy at times and won't necessarily build all dependencies of a package.
So when one runs `dub build vibe-d:http`, DUB will build ONLY this package, and not all the packages it depends on.
(I think this is possible because of compiling static libraries).

This situation can create confusion, which I think is the main reason of #7560.

This problem is not Meson's to solve, but a hint would help users of where to turn to.