### PR TITLE
devenv: Backport more features from gst-env.py

### DIFF
--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -321,4 +321,7 @@ These variables are set in environment in addition to those set using `meson.add
   layout must match the installed tree layout otherwise `import subdir.mod`
   cannot work.
 
+Since *Since 0.62.0* if bash-completion scripts are being installed and the
+shell is bash, they will be automatically sourced.
+
 {{ devenv_arguments.inc }}

--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -311,5 +311,14 @@ These variables are set in environment in addition to those set using `meson.add
   schemas is compiled. This is automatically set when using `gnome.compile_schemas()`.
   Note that this requires GLib >= 2.64 when `gnome.compile_schemas()` is used in
   more than one directory.
+- `PYTHONPATH` *Since 0.62.0* includes every directory where a python module is being
+  installed using [`python.install_sources()`](Python-module.md#install_sources)
+  and [`python.extension_module()`](Python-module.md#extension_module). Python
+  modules installed by other means, such as `install_data()` or `install_subdir()`,
+  will not be included and should be added to `PYTHONPATH` manually using
+  [`meson.add_devenv()`](Reference-manual_builtin_meson.md#mesonadd_devenv).
+  Note that when modules are installed into subdirectories the source tree
+  layout must match the installed tree layout otherwise `import subdir.mod`
+  cannot work.
 
 {{ devenv_arguments.inc }}

--- a/docs/markdown/Commands.md
+++ b/docs/markdown/Commands.md
@@ -324,4 +324,11 @@ These variables are set in environment in addition to those set using `meson.add
 Since *Since 0.62.0* if bash-completion scripts are being installed and the
 shell is bash, they will be automatically sourced.
 
+Since *Since 0.62.0* when GDB helper scripts (*-gdb.py, *-gdb.gdb, and *-gdb.csm)
+are installed with a library name that matches one being built, Meson adds the
+needed auto-load commands into `<builddir>/.gdbinit` file. When running gdb from
+top build directory, that file is loaded by gdb automatically. In the case of
+python scripts that needs to load other python modules, `PYTHONPATH` may need
+to be modified using `meson.add_devenv()`.
+
 {{ devenv_arguments.inc }}

--- a/docs/markdown/snippets/devenv.md
+++ b/docs/markdown/snippets/devenv.md
@@ -8,3 +8,11 @@ and [`python.extension_module()`](Python-module.md#extension_module).
 
 If bash-completion scripts are being installed and the shell is bash, they will
 be automatically sourced.
+
+## Setup GDB auto-load for `meson devenv`
+
+When GDB helper scripts (*-gdb.py, *-gdb.gdb, and *-gdb.csm) are installed with
+a library name that matches one being built, Meson adds the needed auto-load
+commands into `<builddir>/.gdbinit` file. When running gdb from top build
+directory, that file is loaded by gdb automatically.
+

--- a/docs/markdown/snippets/devenv.md
+++ b/docs/markdown/snippets/devenv.md
@@ -1,0 +1,5 @@
+## `PYTHONPATH` automatically defined in `meson devenv`
+
+`PYTHONPATH` now includes every directory where a python module is being
+installed using [`python.install_sources()`](Python-module.md#install_sources)
+and [`python.extension_module()`](Python-module.md#extension_module).

--- a/docs/markdown/snippets/devenv.md
+++ b/docs/markdown/snippets/devenv.md
@@ -3,3 +3,8 @@
 `PYTHONPATH` now includes every directory where a python module is being
 installed using [`python.install_sources()`](Python-module.md#install_sources)
 and [`python.extension_module()`](Python-module.md#extension_module).
+
+## Bash completion scripts sourced in `meson devenv`
+
+If bash-completion scripts are being installed and the shell is bash, they will
+be automatically sourced.

--- a/docs/markdown/snippets/devenv.md
+++ b/docs/markdown/snippets/devenv.md
@@ -16,3 +16,8 @@ a library name that matches one being built, Meson adds the needed auto-load
 commands into `<builddir>/.gdbinit` file. When running gdb from top build
 directory, that file is loaded by gdb automatically.
 
+## Print modified environment variables with `meson devenv --dump`
+
+With `--dump` option, all envorinment variables that have been modified are
+printed instead of starting an interactive shell. It can be used by shell
+scripts that wish to setup their environment themself.

--- a/docs/markdown/snippets/devenv.md
+++ b/docs/markdown/snippets/devenv.md
@@ -21,3 +21,23 @@ directory, that file is loaded by gdb automatically.
 With `--dump` option, all envorinment variables that have been modified are
 printed instead of starting an interactive shell. It can be used by shell
 scripts that wish to setup their environment themself.
+
+## New `method` and `separator` kwargs on `environment()` and `meson.add_devenv()`
+
+It simplifies this common pattern:
+```meson
+env = environment()
+env.prepend('FOO', ['a', 'b'], separator: ',')
+meson.add_devenv(env)
+```
+
+becomes one line:
+```meson
+meson.add_devenv({'FOO': ['a', 'b']}, method: 'prepend', separator: ',')
+```
+
+or two lines:
+```meson
+env = environment({'FOO': ['a', 'b']}, method: 'prepend', separator: ',')
+meson.add_devenv(env)
+```

--- a/docs/yaml/builtins/meson.yaml
+++ b/docs/yaml/builtins/meson.yaml
@@ -444,5 +444,25 @@ methods:
 
     posargs:
       env:
-        type: env
-        description: The [[@env]] object to add.
+        type: env | str | list[str] | dict[str] | dict[list[str]]
+        description: |
+          The [[@env]] object to add.
+          Since *0.62.0* list of strings is allowed in dictionnary values. In that
+          case values are joined using the separator.
+    kwargs:
+      separator:
+        type: str
+        since: 0.62.0
+        description: |
+          The separator to use for the initial values defined in
+          the first positional argument. If not explicitly specified, the default
+          path separator for the host operating system will be used, i.e. ';' for
+          Windows and ':' for UNIX/POSIX systems.
+      method:
+        type: str
+        since: 0.62.0
+        description: |
+          Must be one of 'set', 'prepend', or 'append'
+          (defaults to 'set'). Controls if initial values defined in the first
+          positional argument are prepended, appended or repace the current value
+          of the environment variable.

--- a/docs/yaml/functions/environment.yaml
+++ b/docs/yaml/functions/environment.yaml
@@ -5,8 +5,29 @@ description: Returns an empty [[@env]] object.
 
 optargs:
   env:
-    type: dict[str]
+    type: str | list[str] | dict[str] | dict[list[str]]
     since: 0.52.0
     description: |
       If provided, each key/value pair is added into the [[@env]] object
       as if [[env.set]] method was called for each of them.
+      Since *0.62.0* list of strings is allowed in dictionnary values. In that
+      case values are joined using the separator.
+
+kwargs:
+  separator:
+    type: str
+    since: 0.62.0
+    description: |
+      The separator to use for the initial values defined in
+      the first positional argument. If not explicitly specified, the default
+      path separator for the host operating system will be used, i.e. ';' for
+      Windows and ':' for UNIX/POSIX systems.
+
+  method:
+    type: str
+    since: 0.62.0
+    description: |
+      Must be one of 'set', 'prepend', or 'append'
+      (defaults to 'set'). Controls if initial values defined in the first
+      positional argument are prepended, appended or repace the current value
+      of the environment variable.

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1834,11 +1834,13 @@ class Backend:
                 # LD_LIBRARY_PATH. This allows running system applications using
                 # that library.
                 library_paths.add(tdir)
-        if mesonlib.is_windows() or mesonlib.is_cygwin():
-            extra_paths.update(library_paths)
-        elif mesonlib.is_osx():
-            env.prepend('DYLD_LIBRARY_PATH', list(library_paths))
-        else:
-            env.prepend('LD_LIBRARY_PATH', list(library_paths))
-        env.prepend('PATH', list(extra_paths))
+        if library_paths:
+            if mesonlib.is_windows() or mesonlib.is_cygwin():
+                extra_paths.update(library_paths)
+            elif mesonlib.is_osx():
+                env.prepend('DYLD_LIBRARY_PATH', list(library_paths))
+            else:
+                env.prepend('LD_LIBRARY_PATH', list(library_paths))
+        if extra_paths:
+            env.prepend('PATH', list(extra_paths))
         return env

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1484,6 +1484,7 @@ class Backend:
             mlog.log(f'Running postconf script {name!r}')
             run_exe(s, env)
 
+    @lru_cache(maxsize=1)
     def create_install_data(self) -> InstallData:
         strip_bin = self.environment.lookup_binary_entry(MachineChoice.HOST, 'strip')
         if strip_bin is None:

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -476,6 +476,9 @@ class EnvironmentVariables(HoldableObject):
     def has_name(self, name: str) -> bool:
         return name in self.varnames
 
+    def get_names(self) -> T.Set[str]:
+        return self.varnames
+
     def set(self, name: str, values: T.List[str], separator: str = os.pathsep) -> None:
         self.varnames.add(name)
         self.envvars.append((self._set, name, values, separator))

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -63,6 +63,8 @@ from .type_checking import (
     DEPFILE_KW,
     DISABLER_KW,
     ENV_KW,
+    ENV_METHOD_KW,
+    ENV_SEPARATOR_KW,
     INSTALL_KW,
     INSTALL_MODE_KW,
     CT_INSTALL_TAG_KW,
@@ -71,6 +73,7 @@ from .type_checking import (
     REQUIRED_KW,
     NoneType,
     in_set_validator,
+    env_convertor_with_method
 )
 from . import primitives as P_OBJ
 
@@ -2609,9 +2612,9 @@ external dependencies (including libraries) must go to "dependencies".''')
         for lang in kwargs['language']:
             argsdict[lang] = argsdict.get(lang, []) + args
 
-    @noKwargs
     @noArgsFlattening
     @typed_pos_args('environment', optargs=[(str, list, dict)])
+    @typed_kwargs('environment', ENV_METHOD_KW, ENV_SEPARATOR_KW.evolve(since='0.62.0'))
     def func_environment(self, node: mparser.FunctionNode, args: T.Tuple[T.Union[None, str, T.List['TYPE_var'], T.Dict[str, 'TYPE_var']]],
                          kwargs: 'TYPE_kwargs') -> build.EnvironmentVariables:
         init = args[0]
@@ -2620,7 +2623,9 @@ external dependencies (including libraries) must go to "dependencies".''')
             msg = ENV_KW.validator(init)
             if msg:
                 raise InvalidArguments(f'"environment": {msg}')
-            return ENV_KW.convertor(init)
+            if isinstance(init, dict) and any(i for i in init.values() if isinstance(i, list)):
+                FeatureNew.single_use('List of string in dictionary value', '0.62.0', self.subproject, location=node)
+            return env_convertor_with_method(init, kwargs['method'], kwargs['separator'])
         return build.EnvironmentVariables()
 
     @typed_pos_args('join_paths', varargs=str, min_varargs=1)

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -20,7 +20,7 @@ from ..interpreterbase import (
                                typed_pos_args, typed_kwargs, typed_operator,
                                noArgsFlattening, noPosargs, noKwargs, unholder_return, TYPE_var, TYPE_kwargs, TYPE_nvar, TYPE_nkwargs,
                                flatten, resolve_second_level_holders, InterpreterException, InvalidArguments, InvalidCode)
-from ..interpreter.type_checking import NoneType
+from ..interpreter.type_checking import NoneType, ENV_SEPARATOR_KW
 from ..dependencies import Dependency, ExternalLibrary, InternalDependency
 from ..programs import ExternalProgram
 from ..mesonlib import HoldableObject, MesonException, OptionKey, listify, Popen_safe
@@ -232,10 +232,6 @@ class RunProcess(MesonInterpreterObject):
     def stderr_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
         return self.stderr
 
-
-_ENV_SEPARATOR_KW = KwargInfo('separator', str, default=os.pathsep)
-
-
 class EnvironmentVariablesHolder(ObjectHolder[build.EnvironmentVariables], MutableInterpreterObject):
 
     def __init__(self, obj: build.EnvironmentVariables, interpreter: 'Interpreter'):
@@ -260,20 +256,20 @@ class EnvironmentVariablesHolder(ObjectHolder[build.EnvironmentVariables], Mutab
             FeatureNew(m, '0.58.0', location=self.current_node).use(self.subproject)
 
     @typed_pos_args('environment.set', str, varargs=str, min_varargs=1)
-    @typed_kwargs('environment.set', _ENV_SEPARATOR_KW)
+    @typed_kwargs('environment.set', ENV_SEPARATOR_KW)
     def set_method(self, args: T.Tuple[str, T.List[str]], kwargs: 'EnvironmentSeparatorKW') -> None:
         name, values = args
         self.held_object.set(name, values, kwargs['separator'])
 
     @typed_pos_args('environment.append', str, varargs=str, min_varargs=1)
-    @typed_kwargs('environment.append', _ENV_SEPARATOR_KW)
+    @typed_kwargs('environment.append', ENV_SEPARATOR_KW)
     def append_method(self, args: T.Tuple[str, T.List[str]], kwargs: 'EnvironmentSeparatorKW') -> None:
         name, values = args
         self.warn_if_has_name(name)
         self.held_object.append(name, values, kwargs['separator'])
 
     @typed_pos_args('environment.prepend', str, varargs=str, min_varargs=1)
-    @typed_kwargs('environment.prepend', _ENV_SEPARATOR_KW)
+    @typed_kwargs('environment.prepend', ENV_SEPARATOR_KW)
     def prepend_method(self, args: T.Tuple[str, T.List[str]], kwargs: 'EnvironmentSeparatorKW') -> None:
         name, values = args
         self.warn_if_has_name(name)

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -124,28 +124,6 @@ class ModuleObject(HoldableObject):
 class MutableModuleObject(ModuleObject):
     pass
 
-
-# FIXME: Port all modules to stop using self.interpreter and use API on
-# ModuleState instead. Modules should stop using this class and instead use
-# ModuleObject base class.
-class ExtensionModule(ModuleObject):
-    def __init__(self, interpreter: 'Interpreter') -> None:
-        super().__init__()
-        self.interpreter = interpreter
-        self.methods.update({
-            'found': self.found_method,
-        })
-
-    @noPosargs
-    @noKwargs
-    def found_method(self, state: 'ModuleState', args: T.List['TYPE_var'], kwargs: 'TYPE_kwargs') -> bool:
-        return self.found()
-
-    @staticmethod
-    def found() -> bool:
-        return True
-
-
 class NewExtensionModule(ModuleObject):
 
     """Class for modern modules
@@ -168,6 +146,13 @@ class NewExtensionModule(ModuleObject):
     def found() -> bool:
         return True
 
+# FIXME: Port all modules to stop using self.interpreter and use API on
+# ModuleState instead. Modules should stop using this class and instead use
+# ModuleObject base class.
+class ExtensionModule(NewExtensionModule):
+    def __init__(self, interpreter: 'Interpreter') -> None:
+        super().__init__()
+        self.interpreter = interpreter
 
 class NotFoundExtensionModule(NewExtensionModule):
 

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -26,6 +26,7 @@ if T.TYPE_CHECKING:
     from ..interpreterbase import TYPE_var, TYPE_kwargs
     from ..programs import ExternalProgram
     from ..wrap import WrapMode
+    from ..build import EnvironmentVariables
 
 class ModuleState:
     """Object passed to all module methods.
@@ -145,6 +146,9 @@ class NewExtensionModule(ModuleObject):
     @staticmethod
     def found() -> bool:
         return True
+
+    def get_devenv(self) -> T.Optional['EnvironmentVariables']:
+        return None
 
 # FIXME: Port all modules to stop using self.interpreter and use API on
 # ModuleState instead. Modules should stop using this class and instead use

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -752,8 +752,10 @@ class GnomeModule(ExtensionModule):
     def _devenv_prepend(self, varname: str, value: str) -> None:
         if self.devenv is None:
             self.devenv = build.EnvironmentVariables()
-            self.interpreter.build.devenv.append(self.devenv)
         self.devenv.prepend(varname, [value])
+
+    def get_devenv(self) -> T.Optional[build.EnvironmentVariables]:
+        return self.devenv
 
     def _get_gir_dep(self, state: 'ModuleState') -> T.Tuple[Dependency, T.Union[build.Executable, 'ExternalProgram', 'OverrideProgram'],
                                                             T.Union[build.Executable, 'ExternalProgram', 'OverrideProgram']]:

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -23,7 +23,7 @@ from . import ExtensionModule
 from .. import mesonlib
 from .. import mlog
 from ..coredata import UserFeatureOption
-from ..build import known_shmod_kwargs
+from ..build import known_shmod_kwargs, EnvironmentVariables
 from ..dependencies import DependencyMethods, PkgConfigDependency, NotFoundDependency, SystemDependency, ExtraFrameworkDependency
 from ..dependencies.base import process_method_kw
 from ..environment import detect_cpu_family
@@ -45,6 +45,7 @@ if T.TYPE_CHECKING:
     from ..environment import Environment
     from ..interpreter import Interpreter
     from ..interpreterbase.interpreterbase import TYPE_var, TYPE_kwargs
+    from ..backends import InstallData
 
     from typing_extensions import TypedDict
 
@@ -389,6 +390,21 @@ class PythonExternalProgram(ExternalProgram):
             'variables': {},
             'version': '0.0',
         }
+        self.devenv_pythonpath: T.Set[str] = set()
+
+    def add_devenv_pythonpath(self, basedir: str, subdir: str, install_subdir: str) -> None:
+        # If we install python module into 'foo/bar' subdir, we need the last 2
+        # parts of source dir to be ['foo', 'bar'] and set PYTHONPATH
+        # pointing grandparent directory. That way scripts will be able to
+        # `import foo.bar.something` just like when the are installed.
+        # If the source tree layout does not match installed layout there is
+        # nothing we can do.
+        install_subdir_parts = Path(install_subdir).parts
+        subdir_parts = Path(subdir).parts
+        if subdir_parts[-len(install_subdir_parts):] == install_subdir_parts:
+            pypath = os.path.join(basedir, *subdir_parts[:-len(install_subdir_parts)])
+            self.devenv_pythonpath.add(pypath)
+            print('done', pypath)
 
     def _check_version(self, version: str) -> bool:
         if self.name == 'python2':
@@ -505,8 +521,10 @@ class PythonInstallation(ExternalProgramHolder):
             subdir = kwargs.pop('subdir', '')
             if not isinstance(subdir, str):
                 raise InvalidArguments('"subdir" argument must be a string.')
-
             kwargs['install_dir'] = os.path.join(self.platlib_install_path, subdir)
+            self.held_object.add_devenv_pythonpath(
+                self.interpreter.environment.get_build_dir(),
+                self.interpreter.subdir, subdir)
 
         # On macOS and some Linux distros (Debian) distutils doesn't link
         # extensions against libpython. We call into distutils and mirror its
@@ -561,11 +579,19 @@ class PythonInstallation(ExternalProgramHolder):
     def install_sources_method(self, args: T.Tuple[T.List[T.Union[str, mesonlib.File]]],
                                kwargs: 'PyInstallKw') -> 'Data':
         tag = kwargs['install_tag'] or 'runtime'
-        return self.interpreter.install_data_impl(
-            self.interpreter.source_strings_to_files(args[0]),
-            self._get_install_dir_impl(kwargs['pure'], kwargs['subdir']),
+        pure = kwargs['pure']
+        sources = self.interpreter.source_strings_to_files(args[0])
+        install_subdir = kwargs['subdir']
+        install_dir = self._get_install_dir_impl(pure, install_subdir)
+        builddir = self.interpreter.environment.get_build_dir()
+        srcdir = self.interpreter.environment.get_source_dir()
+        for src in sources:
+            basedir = builddir if src.is_built else srcdir
+            subdir = os.path.dirname(src.relative_name())
+            self.held_object.add_devenv_pythonpath(basedir, subdir, install_subdir)
+        return self.interpreter.install_data_impl(sources, install_dir,
             mesonlib.FileMode(), rename=None, tag=tag, install_data_type='python',
-            install_dir_name=self._get_install_dir_name_impl(kwargs['pure'], kwargs['subdir']))
+            install_dir_name=self._get_install_dir_name_impl(pure, install_subdir))
 
     @noPosargs
     @typed_kwargs('python_installation.install_dir', _PURE_KW, _SUBDIR_KW)
@@ -641,6 +667,18 @@ class PythonModule(ExtensionModule):
         self.methods.update({
             'find_installation': self.find_installation,
         })
+
+    def get_devenv(self) -> T.Optional[EnvironmentVariables]:
+        pythonpath = set()
+        for python in self.installations.values():
+            version = python.info['version']
+            if mesonlib.version_compare(version, '>=3.0'):
+                pythonpath |= python.devenv_pythonpath
+        if pythonpath:
+            env = EnvironmentVariables()
+            env.prepend('PYTHONPATH', list(pythonpath))
+            return env
+        return None
 
     # https://www.python.org/dev/peps/pep-0397/
     @staticmethod

--- a/mesonbuild/msetup.py
+++ b/mesonbuild/msetup.py
@@ -245,7 +245,7 @@ class MesonApp:
                 profile.runctx('intr.backend.generate()', globals(), locals(), filename=fname)
             else:
                 intr.backend.generate()
-            b.devenv.append(intr.backend.get_devenv())
+            self._finalize_devenv(b, intr)
             build.save(b, dumpfile)
             if env.first_invocation:
                 # Use path resolved by coredata because they could have been
@@ -287,6 +287,13 @@ class MesonApp:
                 else:
                     os.unlink(cdf)
             raise
+
+    def _finalize_devenv(self, b: build.Build, intr: interpreter.Interpreter) -> None:
+        b.devenv.append(intr.backend.get_devenv())
+        for mod in intr.modules.values():
+            devenv = mod.get_devenv()
+            if devenv:
+                b.devenv.append(devenv)
 
 def run(options: argparse.Namespace) -> int:
     coredata.parse_cmd_line_options(options)

--- a/test cases/unit/91 devenv/meson.build
+++ b/test cases/unit/91 devenv/meson.build
@@ -1,4 +1,8 @@
-project('devenv', 'c')
+project('devenv', 'c',
+  # Because Windows Python ships only with optimized libs,
+  # we must build this project the same way.
+  default_options : ['buildtype=release'],
+)
 
 meson.add_devenv('TEST_A=1')
 foo_dep = dependency('foo', fallback: 'sub')
@@ -10,3 +14,7 @@ meson.add_devenv(env)
 # This exe links on a library built in another directory. On Windows this means
 # PATH must contain builddir/subprojects/sub to be able to run it.
 executable('app', 'main.c', dependencies: foo_dep, install: true)
+
+py = import('python').find_installation()
+py.install_sources('src/mymod/mod.py', subdir: 'mymod')
+subdir('src/mymod2')

--- a/test cases/unit/91 devenv/meson.build
+++ b/test cases/unit/91 devenv/meson.build
@@ -11,6 +11,11 @@ env = environment()
 env.append('TEST_B', ['2', '3'], separator: '+')
 meson.add_devenv(env)
 
+meson.add_devenv({'TEST_B': '0'}, separator: '+', method: 'prepend')
+
+env = environment({'TEST_B': ['4']}, separator: '+', method: 'append')
+meson.add_devenv(env)
+
 # This exe links on a library built in another directory. On Windows this means
 # PATH must contain builddir/subprojects/sub to be able to run it.
 executable('app', 'main.c', dependencies: foo_dep, install: true)

--- a/test cases/unit/91 devenv/src/mymod/mod.py
+++ b/test cases/unit/91 devenv/src/mymod/mod.py
@@ -1,0 +1,1 @@
+hello = 'world'

--- a/test cases/unit/91 devenv/src/mymod2/meson.build
+++ b/test cases/unit/91 devenv/src/mymod2/meson.build
@@ -1,0 +1,5 @@
+py.extension_module('mod2', 'mod2.c',
+  dependencies: py.dependency(),
+  subdir: 'mymod2',
+  install: true
+)

--- a/test cases/unit/91 devenv/src/mymod2/mod2.c
+++ b/test cases/unit/91 devenv/src/mymod2/mod2.c
@@ -1,0 +1,14 @@
+#include <Python.h>
+#include <string.h>
+
+static PyObject *hello(PyObject *self, PyObject *args) {
+  return PyLong_FromLong(42);
+}
+
+static PyMethodDef methods[] = {{"hello", hello, METH_NOARGS, "Hello World"},
+                                {NULL, NULL, 0, NULL}};
+
+static struct PyModuleDef mod = {PyModuleDef_HEAD_INIT, "test", NULL, -1,
+                                 methods};
+
+PyMODINIT_FUNC PyInit_mod2(void) { return PyModule_Create(&mod); }

--- a/test cases/unit/91 devenv/test-devenv.py
+++ b/test cases/unit/91 devenv/test-devenv.py
@@ -6,7 +6,7 @@ from pathlib import Path
 assert os.environ['MESON_DEVENV'] == '1'
 assert os.environ['MESON_PROJECT_NAME'] == 'devenv'
 assert os.environ['TEST_A'] == '1'
-assert os.environ['TEST_B'] == '1+2+3'
+assert os.environ['TEST_B'] == '0+1+2+3+4'
 
 from mymod.mod import hello
 assert hello == 'world'

--- a/test cases/unit/91 devenv/test-devenv.py
+++ b/test cases/unit/91 devenv/test-devenv.py
@@ -1,8 +1,15 @@
 #! /usr/bin/python
 
 import os
+from pathlib import Path
 
 assert os.environ['MESON_DEVENV'] == '1'
 assert os.environ['MESON_PROJECT_NAME'] == 'devenv'
 assert os.environ['TEST_A'] == '1'
 assert os.environ['TEST_B'] == '1+2+3'
+
+from mymod.mod import hello
+assert hello == 'world'
+
+from mymod2.mod2 import hello
+assert hello() == 42


### PR DESCRIPTION
`meson devenv` idea comes from GStreamer project' `gst-env.py` script. They have more goodies we could make everyone benefit.

- Allow setting method/separator in environment() and meson.add_devenv()
- devenv: Do not prepend empty list to PATH and LD_LIBRARY_PATH
- devenv: Add --dump option
- devenv: Setup GDB auto-load scripts
- devenv: Source bash completion scripts
- devenv: Set PYTHONPATH where we install python modules
- Add API for modules that wants to define their devenv
- modules: Make ExtensionModule inherit from NewExtensionModule
- backends: Cache creation of install data
- Cache the result of python.find_installation()