### PR TITLE
Dependency lookups with custom functionality can now trigger FeatureNew

### DIFF
--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -30,6 +30,7 @@ if T.TYPE_CHECKING:
     from .._typing import ImmutableListProtocol
     from ..compilers.compilers import Compiler
     from ..environment import Environment
+    from ..interpreterbase import FeatureCheckBase
     from ..build import BuildTarget, CustomTarget, IncludeDirs
     from ..mesonlib import FileOrString
 
@@ -92,6 +93,8 @@ class Dependency(HoldableObject):
         self.sources: T.List[T.Union['FileOrString', 'CustomTarget']] = []
         self.include_type = self._process_include_type_kw(kwargs)
         self.ext_deps: T.List[Dependency] = []
+        self.featurechecks: T.List['FeatureCheckBase'] = []
+        self.feature_since: T.Optional[T.Tuple[str, str]] = None
 
     def __repr__(self) -> str:
         return f'<{self.__class__.__name__} {self.name}: {self.is_found}>'

--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -500,6 +500,7 @@ class ZlibSystemDependency(SystemDependency):
 class JDKSystemDependency(SystemDependency):
     def __init__(self, environment: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__('jdk', environment, kwargs)
+        self.feature_since = ('0.59.0', '')
 
         m = self.env.machines[self.for_machine]
 

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -63,6 +63,7 @@ def netcdf_factory(env: 'Environment',
 class DlBuiltinDependency(BuiltinDependency):
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
+        self.feature_since = ('0.62.0', "consider checking for dlopen() with and without find_library('dl')")
 
         if self.clib_compiler.has_function('dlopen', '#include <dlfcn.h>', env)[0]:
             self.is_found = True
@@ -71,6 +72,7 @@ class DlBuiltinDependency(BuiltinDependency):
 class DlSystemDependency(SystemDependency):
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
+        self.feature_since = ('0.62.0', "consider checking for dlopen() with and without find_library('dl')")
 
         h = self.clib_compiler.has_header('dlfcn.h', '', env)
         self.link_args = self.clib_compiler.find_library('dl', env, [], self.libtype)
@@ -470,6 +472,7 @@ class CursesSystemDependency(SystemDependency):
 class IconvBuiltinDependency(BuiltinDependency):
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
+        self.feature_since = ('0.60.0', "consider checking for iconv_open() with and without find_library('iconv')")
         code = '''#include <iconv.h>\n\nint main() {\n    iconv_open("","");\n}''' # [ignore encoding] this is C, not python, Mr. Lint
 
         if self.clib_compiler.links(code, env)[0]:
@@ -479,6 +482,7 @@ class IconvBuiltinDependency(BuiltinDependency):
 class IconvSystemDependency(SystemDependency):
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
+        self.feature_since = ('0.60.0', "consider checking for iconv_open() with and without find_library('iconv')")
 
         h = self.clib_compiler.has_header('iconv.h', '', env)
         self.link_args = self.clib_compiler.find_library('iconv', env, [], self.libtype)
@@ -490,6 +494,7 @@ class IconvSystemDependency(SystemDependency):
 class IntlBuiltinDependency(BuiltinDependency):
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
+        self.feature_since = ('0.59.0', "consider checking for ngettext() with and without find_library('intl')")
         code = '''#include <libintl.h>\n\nint main() {\n    gettext("Hello world");\n}'''
 
         if self.clib_compiler.links(code, env)[0]:
@@ -499,6 +504,7 @@ class IntlBuiltinDependency(BuiltinDependency):
 class IntlSystemDependency(SystemDependency):
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
+        self.feature_since = ('0.59.0', "consider checking for ngettext() with and without find_library('intl')")
 
         h = self.clib_compiler.has_header('libintl.h', '', env)
         self.link_args = self.clib_compiler.find_library('intl', env, [], self.libtype)

--- a/mesonbuild/dependencies/misc.py
+++ b/mesonbuild/dependencies/misc.py
@@ -63,7 +63,7 @@ def netcdf_factory(env: 'Environment',
 class DlBuiltinDependency(BuiltinDependency):
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
-        self.feature_since = ('0.62.0', "consider checking for dlopen() with and without find_library('dl')")
+        self.feature_since = ('0.62.0', "consider checking for `dlopen` with and without `find_library('dl')`")
 
         if self.clib_compiler.has_function('dlopen', '#include <dlfcn.h>', env)[0]:
             self.is_found = True
@@ -72,7 +72,7 @@ class DlBuiltinDependency(BuiltinDependency):
 class DlSystemDependency(SystemDependency):
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
-        self.feature_since = ('0.62.0', "consider checking for dlopen() with and without find_library('dl')")
+        self.feature_since = ('0.62.0', "consider checking for `dlopen` with and without `find_library('dl')`")
 
         h = self.clib_compiler.has_header('dlfcn.h', '', env)
         self.link_args = self.clib_compiler.find_library('dl', env, [], self.libtype)
@@ -472,7 +472,7 @@ class CursesSystemDependency(SystemDependency):
 class IconvBuiltinDependency(BuiltinDependency):
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
-        self.feature_since = ('0.60.0', "consider checking for iconv_open() with and without find_library('iconv')")
+        self.feature_since = ('0.60.0', "consider checking for `iconv_open` with and without `find_library('iconv')`")
         code = '''#include <iconv.h>\n\nint main() {\n    iconv_open("","");\n}''' # [ignore encoding] this is C, not python, Mr. Lint
 
         if self.clib_compiler.links(code, env)[0]:
@@ -482,7 +482,7 @@ class IconvBuiltinDependency(BuiltinDependency):
 class IconvSystemDependency(SystemDependency):
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
-        self.feature_since = ('0.60.0', "consider checking for iconv_open() with and without find_library('iconv')")
+        self.feature_since = ('0.60.0', "consider checking for `iconv_open` with and without find_library('iconv')")
 
         h = self.clib_compiler.has_header('iconv.h', '', env)
         self.link_args = self.clib_compiler.find_library('iconv', env, [], self.libtype)
@@ -494,7 +494,7 @@ class IconvSystemDependency(SystemDependency):
 class IntlBuiltinDependency(BuiltinDependency):
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
-        self.feature_since = ('0.59.0', "consider checking for ngettext() with and without find_library('intl')")
+        self.feature_since = ('0.59.0', "consider checking for `ngettext` with and without `find_library('intl')`")
         code = '''#include <libintl.h>\n\nint main() {\n    gettext("Hello world");\n}'''
 
         if self.clib_compiler.links(code, env)[0]:
@@ -504,7 +504,7 @@ class IntlBuiltinDependency(BuiltinDependency):
 class IntlSystemDependency(SystemDependency):
     def __init__(self, name: str, env: 'Environment', kwargs: T.Dict[str, T.Any]):
         super().__init__(name, env, kwargs)
-        self.feature_since = ('0.59.0', "consider checking for ngettext() with and without find_library('intl')")
+        self.feature_since = ('0.59.0', "consider checking for `ngettext` with and without `find_library('intl')`")
 
         h = self.clib_compiler.has_header('libintl.h', '', env)
         self.link_args = self.clib_compiler.find_library('intl', env, [], self.libtype)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1598,6 +1598,11 @@ external dependencies (including libraries) must go to "dependencies".''')
             if wanted != actual:
                 mlog.debug(f'Current include type of {args[0]} is {actual}. Converting to requested {wanted}')
                 d = d.generate_system_dependency(wanted)
+        if d.feature_since is not None:
+            version, extra_msg = d.feature_since
+            FeatureNew.single_use(f'dep {d.name!r} custom lookup', version, self.subproject, extra_msg, node)
+        for f in d.featurechecks:
+            f.use(self.subproject, node)
         return d
 
     @FeatureNew('disabler', '0.44.0')

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -257,7 +257,7 @@ class EnvironmentVariablesHolder(ObjectHolder[build.EnvironmentVariables], Mutab
         # Multiple append/prepend operations was not supported until 0.58.0.
         if self.held_object.has_name(name):
             m = f'Overriding previous value of environment variable {name!r} with a new one'
-            FeatureNew(m, '0.58.0', location=self.current_node).use(self.subproject)
+            FeatureNew(m, '0.58.0').use(self.subproject, self.current_node)
 
     @typed_pos_args('environment.set', str, varargs=str, min_varargs=1)
     @typed_kwargs('environment.set', _ENV_SEPARATOR_KW)
@@ -484,7 +484,7 @@ class DependencyHolder(ObjectHolder[Dependency]):
     def variable_method(self, args: T.Tuple[T.Optional[str]], kwargs: 'kwargs.DependencyGetVariable') -> T.Union[str, T.List[str]]:
         default_varname = args[0]
         if default_varname is not None:
-            FeatureNew('Positional argument to dependency.get_variable()', '0.58.0', location=self.current_node).use(self.subproject)
+            FeatureNew('Positional argument to dependency.get_variable()', '0.58.0').use(self.subproject, self.current_node)
         return self.held_object.get_variable(
             cmake=kwargs['cmake'] or default_varname,
             pkgconfig=kwargs['pkgconfig'] or default_varname,

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -749,12 +749,11 @@ class FeatureCheckKwargsBase(metaclass=abc.ABCMeta):
         pass
 
     def __init__(self, feature_name: str, feature_version: str,
-                 kwargs: T.List[str], extra_message: T.Optional[str] = None, location: T.Optional['mparser.BaseNode'] = None):
+                 kwargs: T.List[str], extra_message: T.Optional[str] = None):
         self.feature_name = feature_name
         self.feature_version = feature_version
         self.kwargs = kwargs
         self.extra_message = extra_message
-        self.location = location
 
     def __call__(self, f: TV_func) -> TV_func:
         @wraps(f)

--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -101,7 +101,7 @@ class ExternalProject(NewExtensionModule):
 
     def _configure(self, state: 'ModuleState') -> None:
         if self.configure_command == 'waf':
-            FeatureNew('Waf external project', '0.60.0', location=state.current_node).use(self.subproject)
+            FeatureNew('Waf external project', '0.60.0').use(self.subproject, state.current_node)
             waf = state.find_program('waf')
             configure_cmd = waf.get_command()
             configure_cmd += ['configure', '-o', str(self.build_dir)]
@@ -176,7 +176,7 @@ class ExternalProject(NewExtensionModule):
                 if key_format in option:
                     break
             else:
-                FeatureNew('Default configure_option', '0.57.0', location=state.current_node).use(self.subproject)
+                FeatureNew('Default configure_option', '0.57.0').use(self.subproject, state.current_node)
                 self.configure_options.append(default)
 
     def _format_options(self, options: T.List[str], variables: T.List[T.Tuple[str, str, str]]) -> T.List[str]:


### PR DESCRIPTION
Typically needed for stuff with completely custom logic due to being:
- method `builtin` on some systems
- a base system library on other systems or simply not providing pkg-config

Plus jdk which is, um, Java. /cc @tristan957 and cross-reference #9879


(Yes, the `self.featurechecks` list is not currently used by my PR. It *will* be used by jdk -> jni, because I have a fast path for new dependencies which I think is potentially quite common, but I don't have a fast path for deprecated dependencies which I don't foresee being at all common.)