### PR TITLE
Add support for EnvironmentVariables in Rust targets

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -44,6 +44,7 @@ if T.TYPE_CHECKING:
     from ..linkers.linkers import DynamicLinker, StaticLinker
     from ..compilers.cs import CsCompiler
     from ..compilers.fortran import FortranCompiler
+    from ..compilers.rust import RustCompiler
 
     CommandArgOrStr = T.List[T.Union['NinjaCommandArg', str]]
     RUST_EDITIONS = Literal['2015', '2018', '2021']
@@ -1846,7 +1847,7 @@ class NinjaBackend(backends.Backend):
         return target.rust_dependency_map.get(dependency.name, dependency.name).replace('-', '_')
 
     def generate_rust_target(self, target: build.BuildTarget) -> None:
-        rustc = target.compilers['rust']
+        rustc = T.cast('RustCompiler', target.compilers['rust'])
         # Rust compiler takes only the main file as input and
         # figures out what other files are needed via import
         # statements and magic.
@@ -2063,8 +2064,9 @@ class NinjaBackend(backends.Backend):
             for rpath_arg in rpath_args:
                 args += ['-C', 'link-arg=' + rpath_arg + ':' + os.path.join(rustc.get_sysroot(), 'lib')]
 
-        if target.env:
-            args.extend(rustc.get_env_args(target.env))
+        compiler_name = self.compiler_to_rule_name(rustc)
+        if rustc.needs_env_wrapper:
+            compiler_name = self.get_compiler_rule_name(rustc.get_language(), rustc.for_machine, 'ENV')
 
         proc_macro_dylib_path = None
         if getattr(target, 'rust_crate_type', '') == 'proc-macro':
@@ -2077,12 +2079,26 @@ class NinjaBackend(backends.Backend):
                                      proc_macro_dylib_path,
                                      project_deps)
 
-        compiler_name = self.compiler_to_rule_name(rustc)
         element = NinjaBuildElement(self.all_outputs, target_name, compiler_name, main_rust_file)
         if orderdeps:
             element.add_orderdep(orderdeps)
         if deps:
             element.add_dep(deps)
+        if rustc.needs_env_wrapper:
+            env: T.List[str] = []
+            nargs: T.List[str] = []
+            itr = iter(args)
+            for a in itr:
+                if a == '--env-set':
+                    a = next(itr)
+                elif a.startswith('--env-set='):
+                    a = a.split('=', 1)[1]
+                else:
+                    nargs.append(a)
+                    continue
+                env.extend(['--env', a])
+            element.add_item('ENV', env)
+            args = nargs
         element.add_item('ARGS', args)
         element.add_item('targetdep', depfile)
         element.add_item('cratetype', cratetype)
@@ -2369,7 +2385,7 @@ class NinjaBackend(backends.Backend):
                                 depfile=depfile,
                                 extra='restat = 1'))
 
-    def generate_rust_compile_rules(self, compiler):
+    def generate_rust_compile_rules(self, compiler: RustCompiler) -> None:
         rule = self.compiler_to_rule_name(compiler)
         command = compiler.get_exelist() + ['$ARGS', '$in']
         description = 'Compiling Rust source $in'
@@ -2377,6 +2393,12 @@ class NinjaBackend(backends.Backend):
         depstyle = 'gcc'
         self.add_rule(NinjaRule(rule, command, [], description, deps=depstyle,
                                 depfile=depfile))
+        if compiler.needs_env_wrapper:
+            rule = self.get_compiler_rule_name(compiler.get_language(), compiler.for_machine, 'ENV')
+            command = self.environment.get_build_command() + ['--internal', 'exe', '$ENV', '--'] + command
+            description = f'{description} (wrapped to set environment variables)'
+            self.add_rule(NinjaRule(rule, command, [], description, deps=depstyle,
+                                    depfile=depfile))
 
     def generate_swift_compile_rules(self, compiler):
         rule = self.compiler_to_rule_name(compiler)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2064,7 +2064,7 @@ class NinjaBackend(backends.Backend):
             for rpath_arg in rpath_args:
                 args += ['-C', 'link-arg=' + rpath_arg + ':' + os.path.join(rustc.get_sysroot(), 'lib')]
 
-        compiler_name = self.compiler_to_rule_name(rustc)
+        compiler_name: str = self.compiler_to_rule_name(rustc)
         if rustc.needs_env_wrapper:
             compiler_name = self.get_compiler_rule_name(rustc.get_language(), rustc.for_machine, 'ENV')
 
@@ -2099,6 +2099,9 @@ class NinjaBackend(backends.Backend):
                 env.extend(['--env', a])
             element.add_item('ENV', env)
             args = nargs
+        else:
+            # XXX: this needs a heiristc
+            args.extend(['-Z', 'unstable-options'])
         element.add_item('ARGS', args)
         element.add_item('targetdep', depfile)
         element.add_item('cratetype', cratetype)

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -2063,6 +2063,9 @@ class NinjaBackend(backends.Backend):
             for rpath_arg in rpath_args:
                 args += ['-C', 'link-arg=' + rpath_arg + ':' + os.path.join(rustc.get_sysroot(), 'lib')]
 
+        if target.env:
+            args.extend(rustc.get_env_args(target.env))
+
         proc_macro_dylib_path = None
         if getattr(target, 'rust_crate_type', '') == 'proc-macro':
             proc_macro_dylib_path = os.path.abspath(os.path.join(target.subdir, target.get_filename()))

--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -987,6 +987,7 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
             continue
 
         version = search_version(out)
+        is_nightly = 'nightly' in out
         cls: T.Type[RustCompiler] = rust.RustCompiler
 
         # Clippy is a wrapper around rustc, but it doesn't have rustc in it's
@@ -1078,7 +1079,7 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
             env.coredata.add_lang_args(cls.language, cls, for_machine, env)
             return cls(
                 compiler, version, for_machine, is_cross, info, exe_wrap,
-                linker=linker)
+                linker=linker, is_nightly=is_nightly)
 
     _handle_exceptions(popen_exceptions, compilers)
     raise EnvironmentException('Unreachable code (exception to make mypy happy)')

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -60,7 +60,8 @@ class RustCompiler(Compiler):
                  is_cross: bool, info: 'MachineInfo',
                  exe_wrapper: T.Optional['ExternalProgram'] = None,
                  full_version: T.Optional[str] = None,
-                 linker: T.Optional['DynamicLinker'] = None):
+                 linker: T.Optional['DynamicLinker'] = None,
+                 is_nightly: bool = False):
         super().__init__([], exelist, version, for_machine, info,
                          is_cross=is_cross, full_version=full_version,
                          linker=linker)
@@ -69,6 +70,7 @@ class RustCompiler(Compiler):
         if 'link' in self.linker.id:
             self.base_options.add(OptionKey('b_vscrt'))
         self.native_static_libs: T.List[str] = []
+        self.is_nightly = is_nightly
 
     def needs_static_linker(self) -> bool:
         return False

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -9,7 +9,7 @@ import re
 import typing as T
 
 from .. import coredata
-from ..mesonlib import EnvironmentException, MesonException, Popen_safe_logged, OptionKey
+from ..mesonlib import EnvironmentException, MesonException, Popen_safe_logged, OptionKey, version_compare
 from .compilers import Compiler, clike_debug_args
 
 if T.TYPE_CHECKING:
@@ -71,6 +71,7 @@ class RustCompiler(Compiler):
             self.base_options.add(OptionKey('b_vscrt'))
         self.native_static_libs: T.List[str] = []
         self.is_nightly = is_nightly
+        self.needs_env_wrapper = not (version_compare(self.version, '>= 1.76') and self.is_nightly)
 
     def needs_static_linker(self) -> bool:
         return False

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from __future__ import annotations
 import os
 import sys
 import argparse
@@ -12,7 +11,7 @@ import subprocess
 import typing as T
 import locale
 
-from ..utils.core import ExecutableSerialisation
+from ..utils.core import ExecutableSerialisation, EnvironmentVariables
 
 if T.TYPE_CHECKING:
     from typing_extensions import Protocol
@@ -22,6 +21,7 @@ if T.TYPE_CHECKING:
         unpickle: bool
         capture: bool
         feed: bool
+        env: T.List[str]
 
 
 def buildparser() -> argparse.ArgumentParser:
@@ -29,6 +29,7 @@ def buildparser() -> argparse.ArgumentParser:
     parser.add_argument('--unpickle')
     parser.add_argument('--capture')
     parser.add_argument('--feed')
+    parser.add_argument('--env', action='append', default=[])
     return parser
 
 def run_exe(exe: ExecutableSerialisation, extra_env: T.Optional[T.Dict[str, str]] = None) -> int:
@@ -119,7 +120,12 @@ def run(args: T.List[str]) -> int:
             exe = pickle.load(f)
             exe.pickled = True
     else:
-        exe = ExecutableSerialisation(cmd_args, capture=options.capture, feed=options.feed)
+        env = EnvironmentVariables()
+        for e in options.env:
+            name, value = e.split('=')
+            # This is internal, we can pick whatever separator we want!
+            env.append(name, value.split(':'))
+        exe = ExecutableSerialisation(cmd_args, capture=options.capture, feed=options.feed, env=env)
 
     return run_exe(exe)
 

--- a/mesonbuild/scripts/meson_exe.py
+++ b/mesonbuild/scripts/meson_exe.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from __future__ import annotations
 import os
 import sys
 import argparse
@@ -12,6 +13,16 @@ import typing as T
 import locale
 
 from ..utils.core import ExecutableSerialisation
+
+if T.TYPE_CHECKING:
+    from typing_extensions import Protocol
+
+    class Args(Protocol):
+
+        unpickle: bool
+        capture: bool
+        feed: bool
+
 
 def buildparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description='Custom executable wrapper for Meson. Do not run on your own, mmm\'kay?')
@@ -93,6 +104,7 @@ def run_exe(exe: ExecutableSerialisation, extra_env: T.Optional[T.Dict[str, str]
 
 def run(args: T.List[str]) -> int:
     parser = buildparser()
+    options: Args
     options, cmd_args = parser.parse_known_args(args)
     # argparse supports double dash to separate options and positional arguments,
     # but the user has to remove it manually.

--- a/test cases/rust/23 env/generator.py
+++ b/test cases/rust/23 env/generator.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import textwrap
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('outdir')
+    args = parser.parse_args()
+
+    with open(os.path.join(args.outdir, 'generated.rs'), 'w') as f:
+        f.write(textwrap.dedent('''\
+            fn generated() {
+                std::process::exit(0);
+            }'''))
+
+
+if __name__ == '__main__':
+    main()

--- a/test cases/rust/23 env/main.rs
+++ b/test cases/rust/23 env/main.rs
@@ -1,0 +1,5 @@
+include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+
+fn main() {
+    generated();
+}

--- a/test cases/rust/23 env/meson.build
+++ b/test cases/rust/23 env/meson.build
@@ -1,0 +1,16 @@
+project('rust environment variables', 'rust')
+
+gen = find_program('generator.py')
+
+ct = custom_target(
+  'generated.rs',
+  output : 'generated.rs',
+  command : [gen, '@OUTDIR@'],
+)
+
+exe = executable('main', 'main.rs', ct, env: {'OUT_DIR': meson.current_build_dir()})
+
+test('main test', exe)
+
+# test that generated and non-generated work together
+executable('static', 'static.rs')

--- a/test cases/rust/23 env/meson.build
+++ b/test cases/rust/23 env/meson.build
@@ -8,7 +8,7 @@ ct = custom_target(
   command : [gen, '@OUTDIR@'],
 )
 
-exe = executable('main', 'main.rs', ct, env: {'OUT_DIR': meson.current_build_dir()})
+exe = executable('main', 'main.rs', ct, rust_args: ['--env-set', 'OUT_DIR=' + meson.current_build_dir()])
 
 test('main test', exe)
 

--- a/test cases/rust/23 env/static.rs
+++ b/test cases/rust/23 env/static.rs
@@ -1,0 +1,3 @@
+fn main() {
+    std::process::exit(0);
+}


### PR DESCRIPTION
Idiomatic usage of Rust requires the use of environment variables at a compile time. This can be seen in the common idiom:
```rust
include!(concat!(env!("OUT_DIR"), "/generated.rs"))
```
Which is a very common thing to do. While I think the structured_sources proposal is more elegant and generally a better idea, both for the purpose of building cargo based projects with meson, and for the purpose of including incomplete snippets, we should support environment variables for Rust based targets.

This series adds that support by adding the `env` keyword to build_targets (usage in non-rust targets is considered an error), and generates two different rust rules, one for env wrapping and one for non wrapping.