### PR TITLE
sourceset module: fix minor regression in making sourcesets immutable

### DIFF
--- a/mesonbuild/modules/sourceset.py
+++ b/mesonbuild/modules/sourceset.py
@@ -186,7 +186,7 @@ class SourceSetImpl(SourceSet, MutableModuleObject):
         for s in if_true:
             if not isinstance(s, SourceSetImpl):
                 raise InvalidCode('Arguments to \'add_all\' after the first must be source sets')
-        s.frozen = True
+            s.frozen = True
         self.rules.append(SourceSetRule(keys, [], [], if_true, dependencies))
 
     def collect(self, enabled_fn: T.Callable[[str], bool],


### PR DESCRIPTION
In commit c0be7e05b070d85b38c79088df882970a5cd0279 the setting of merged sourcesets as immutable in a loop accidentally got dedented, and only applied to the last loop iteration.

Fixes regression in #9854