### PR TITLE
wayland: Also lookup scanner in pkgconfig

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1472,12 +1472,12 @@ external dependencies (including libraries) must go to "dependencies".''')
                           required: bool = True, silent: bool = True,
                           wanted: T.Union[str, T.List[str]] = '',
                           search_dirs: T.Optional[T.List[str]] = None,
-                          version_func: T.Optional[T.Callable[[T.Union['ExternalProgram', 'build.Executable', 'OverrideProgram']], str]] = None
-                          ) -> T.Union['ExternalProgram', 'build.Executable', 'OverrideProgram']:
+                          version_func: T.Optional[T.Callable[[T.Union['ExternalProgram', 'build.Executable', 'OverrideProgram']], str]] = None,
+                          depname: T.Optional[str] = None, varname: T.Optional[str] = None) -> T.Union['ExternalProgram', 'build.Executable', 'OverrideProgram']:
         args = mesonlib.listify(args)
 
         extra_info: T.List[mlog.TV_Loggable] = []
-        progobj = self.program_lookup(args, for_machine, required, search_dirs, extra_info)
+        progobj = self.program_lookup(args, for_machine, required, search_dirs, depname, varname, extra_info)
         if progobj is None:
             progobj = self.notfound_program(args)
 
@@ -1521,7 +1521,9 @@ external dependencies (including libraries) must go to "dependencies".''')
         return progobj
 
     def program_lookup(self, args: T.List[mesonlib.FileOrString], for_machine: MachineChoice,
-                       required: bool, search_dirs: T.List[str], extra_info: T.List[mlog.TV_Loggable]
+                       required: bool, search_dirs: T.List[str],
+                       depname: T.Optional[str], varname: T.Optional[str],
+                       extra_info: T.List[mlog.TV_Loggable]
                        ) -> T.Optional[T.Union[ExternalProgram, build.Executable, OverrideProgram]]:
         progobj = self.program_from_overrides(args, extra_info)
         if progobj:
@@ -1535,6 +1537,20 @@ external dependencies (including libraries) must go to "dependencies".''')
             return self.find_program_fallback(fallback, args, required, extra_info)
 
         progobj = self.program_from_file_for(for_machine, args)
+        if progobj is None and depname:
+            # Check if the program path is found in a pkgconfig variable.
+            # Currently only used internally by gnome and wayland modules, this
+            # code path is not (yet?) exposed in public find_program() function.
+            name = args[0]
+            if not varname:
+                varname = name.replace('-', '_')
+            df = DependencyFallbacksHolder(self, [depname], allow_fallback=False)
+            dep = df.lookup({'native': for_machine == MachineChoice.BUILD,
+                             'required': False})
+            if dep.found():
+                path = dep.get_variable(pkgconfig=varname, default_value='')
+                if path:
+                    progobj = ExternalProgram(name, [path], silent=True)
         if progobj is None:
             progobj = self.program_from_system(args, search_dirs, extra_info)
         if progobj is None and args[0].endswith('python3'):

--- a/mesonbuild/modules/__init__.py
+++ b/mesonbuild/modules/__init__.py
@@ -82,9 +82,11 @@ class ModuleState:
     def find_program(self, prog: T.Union[str, T.List[str]], required: bool = True,
                      version_func: T.Optional[T.Callable[['ExternalProgram'], str]] = None,
                      wanted: T.Optional[str] = None, silent: bool = False,
-                     for_machine: MachineChoice = MachineChoice.HOST) -> 'ExternalProgram':
+                     for_machine: MachineChoice = MachineChoice.HOST,
+                     depname: T.Optional[str] = None, varname: T.Optional[str] = None) -> 'ExternalProgram':
         return self._interpreter.find_program_impl(prog, required=required, version_func=version_func,
-                                                   wanted=wanted, silent=silent, for_machine=for_machine)
+                                                   wanted=wanted, silent=silent, for_machine=for_machine,
+                                                   depname=depname, varname=varname)
 
     def test(self, args: T.Tuple[str, T.Union[build.Executable, build.Jar, 'ExternalProgram', mesonlib.File]],
              workdir: T.Optional[str] = None,

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -319,25 +319,9 @@ class GnomeModule(ExtensionModule):
 
     def _get_native_binary(self, state: 'ModuleState', name: str, depname: str,
                            varname: str, required: bool = True) -> T.Union[ExternalProgram, OverrideProgram, 'build.Executable']:
-        # Look in overrides in case glib/gtk/etc are built as subproject
-        prog = self.interpreter.program_from_overrides([name], [])
-        if prog is not None:
-            return prog
-
-        # Look in machine file
-        prog_list = state.environment.lookup_binary_entry(MachineChoice.HOST, name)
-        if prog_list is not None:
-            return ExternalProgram.from_entry(name, prog_list)
-
-        # Check if pkgconfig has a variable
-        dep = self._get_dep(state, depname, native=True, required=False)
-        if dep.found() and dep.type_name == 'pkgconfig':
-            value = dep.get_pkgconfig_variable(varname, [], None)
-            if value:
-                return ExternalProgram(name, [value])
-
-        # Normal program lookup
-        return state.find_program(name, required=required)
+        return state.find_program(name, for_machine=MachineChoice.BUILD,
+                                  required=required,
+                                  depname=depname, varname=varname)
 
     @typed_kwargs(
         'gnome.post_install',

--- a/mesonbuild/modules/unstable_wayland.py
+++ b/mesonbuild/modules/unstable_wayland.py
@@ -45,7 +45,9 @@ class WaylandModule(ExtensionModule):
     )
     def scan_xml(self, state, args, kwargs):
         if self.scanner_bin is None:
-            self.scanner_bin = state.find_program('wayland-scanner', for_machine=MachineChoice.BUILD)
+            self.scanner_bin = state.find_program('wayland-scanner',
+                                                  for_machine=MachineChoice.BUILD,
+                                                  depname='wayland-scanner')
 
         scope = 'public' if kwargs['public'] else 'private'
         sides = [i for i in ['client', 'server'] if kwargs[i]]


### PR DESCRIPTION
This moves generally useful logic from GNOME module's
_get_native_binary() into find_program() implementation. We could decide
later to expose it as public API.