### PR TITLE
Deprecate configure_file(copy : true), and replace it with fs.copyfile

### DIFF
--- a/docs/markdown/Fs-module.md
+++ b/docs/markdown/Fs-module.md
@@ -215,3 +215,30 @@ fs.stem('foo/bar/baz.dll.a')  # baz.dll
    specified by `path` changes, this will trigger Meson to reconfigure the
    project. If the file specified by `path` is a `files()` object it
    cannot refer to a built file.
+
+
+### copyfile
+
+*Since 0.64.0*
+
+Copy a file from the source directory to the build directory at build time
+
+Has the following positional arguments:
+   - src `File | str`: the file to copy
+
+Has the following optional arguments:
+   - dest `str`: the name of the output file. If unset will be the basename of
+     the src argument
+
+Has the following keyword arguments:
+   - install `bool`: Whether to install the copied file, defaults to false
+   - install_dir `str`: Where to install the file to
+   - install_tag: `str`: the install tag to assign to this target
+   - install_mode `array[str | int]`: the mode to install the file with
+
+returns:
+   - a [[custom_target]] object
+
+```meson
+copy = fs.copyfile('input-file', 'output-file')
+```

--- a/docs/markdown/snippets/fs_copyfile.md
+++ b/docs/markdown/snippets/fs_copyfile.md
@@ -1,0 +1,17 @@
+## `fs.copyfile` to replace `configure_file(copy : true)`
+
+A new method has been added to the `fs` module, `copyfile`. This method replaces
+`configure_file(copy : true)`, but only copies files. Unlike `configure_file()`
+it runs at build time, and the output name is optional defaulting to the
+filename without paths of the input if unset:
+
+```meson
+fs.copyfile('src/file.txt')
+```
+Will create a file in the current build directory called `file.txt`
+
+
+```meson
+fs.copyfile('file.txt', 'outfile.txt')
+```
+Will create a copy renamed to `outfile.txt`

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2453,7 +2453,10 @@ class Interpreter(InterpreterBase, HoldableObject):
             'configuration',
             (ContainerTypeInfo(dict, (str, int, bool)), build.ConfigurationData, NoneType),
         ),
-        KwargInfo('copy', bool, default=False, since='0.47.0'),
+        KwargInfo(
+            'copy', bool, default=False, since='0.47.0',
+            deprecated='0.64.0', deprecated_message='Use fs.copy instead',
+        ),
         KwargInfo('encoding', str, default='utf-8', since='0.47.0'),
         KwargInfo('format', str, default='meson', since='0.46.0',
                   validator=in_set_validator({'meson', 'cmake', 'cmake@'})),

--- a/test cases/common/14 configure file/meson.build
+++ b/test cases/common/14 configure file/meson.build
@@ -1,4 +1,6 @@
-project('configure file test', 'c', meson_version: '>=0.47.0')
+project('configure file test', 'c', meson_version: '>=0.63.0')
+
+fs = import('fs')
 
 conf = configuration_data()
 
@@ -188,6 +190,9 @@ if ret.returncode() != 0
 endif
 # Now the same, but using a File object as an argument.
 inf2 = files('invalid-utf8.bin.in')[0]
+outf = configure_file(input : inf2,
+  output : 'invalid-utf8.bin',
+  copy: true)
 ret = run_command(check_file, inf2, outf, check: false)
 if ret.returncode() != 0
   error('Error running command: @0@\n@1@'.format(ret.stdout(), ret.stderr()))
@@ -201,6 +206,21 @@ ret = run_command(check_file, inf, outf, check: false)
 if ret.returncode() != 0
   error('Error running command: @0@\n@1@'.format(ret.stdout(), ret.stderr()))
 endif
+
+# Test the fs replacement
+# Test copying of an empty configuration data object
+inf = 'invalid-utf8.bin.in'
+outf = fs.copyfile(inf, 'invalid-utf8-1.bin')
+test('fs.copyfile string', check_file, args: [files(inf), outf])
+
+# Test with default outname of string
+outf = fs.copyfile(inf)
+test('fs.copyfile default name', check_file, args: [files(inf), outf])
+
+# Now the same, but using a File object as an argument.
+inf2 = files('invalid-utf8.bin.in')[0]
+outf = fs.copyfile(inf2, 'invalid-utf8-2.bin')
+test('fs.copyfile file', check_file, args: [inf2, outf])
 
 # Test non isolatin1 encoded input file which fails to decode with utf-8
 conf8 = configuration_data()


### PR DESCRIPTION
This is based on #9897

It's a bit of a historical accident that `configure_file` is used for copying, mainly because it was able to happen because of loose argument handling, and that we didn't yet have an `fs` module to be a clear, obvious, place to put such a helper. The `copyfile` method is basically synonymous, but with the added value of not requiring an `output` keyword argument.