### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,8 @@ description = A high performance build system
 author = Jussi Pakkanen
 author_email = jpakkane@gmail.com
 url = https://mesonbuild.com
+project_urls =
+    Source = https://github.com/mesonbuild/meson
 keywords =
   meson
   mesonbuild


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)