### PR TITLE
Add support for rust proc-macro crates

### DIFF
--- a/docs/markdown/snippets/rust_proc_macro_crates.md
+++ b/docs/markdown/snippets/rust_proc_macro_crates.md
@@ -1,0 +1,16 @@
+## Rust proc-macro crates
+
+Rust has these handy things called proc-macro crates, which are a bit like a
+compiler plugin. We can now support them, simply build a [[shared_library]] with
+the `rust_crate_type` set to `proc-macro`.
+
+```meson
+proc = shared_library(
+  'proc',
+  'proc.rs',
+  rust_crate_type : 'proc-macro',
+  install : false,
+)
+
+user = executable('user, 'user.rs', link_with : proc)
+```

--- a/docs/yaml/functions/_build_target_base.yaml
+++ b/docs/yaml/functions/_build_target_base.yaml
@@ -276,3 +276,23 @@ kwargs:
       version specification such as `windows,6.0`. See [MSDN
       documentation](https://docs.microsoft.com/en-us/cpp/build/reference/subsystem-specify-subsystem)
       for the full list.
+
+  rust_crate_type:
+    type: str
+    since: 0.41.0
+    description: |
+      Set the specific type of rust crate to compile (when compiling rust).
+
+      If the target is an [[executable]] this defaults to "bin", the only
+      allowed value.
+
+      If it is a [[static_library]] it defaults to "lib", and may be "lib",
+      "staticlib", or "rlib". If "lib" then Rustc will pick a default, "staticlib"
+      means a C ABI library, "rlib" means a Rust ABI.
+
+      If it is a [[shared_library]] it defaults to "lib", and may be "lib",
+      "dylib", "cdylib", or "proc-macro". If "lib" then Rustc will pick a
+      default, "cdylib" means a C ABI library, "dylib" means a Rust ABI, and
+      "proc-macro" is a special rust proceedural macro crate.
+
+      "proc-macro" is new in 0.62.0.

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -1982,8 +1982,8 @@ class SharedLibrary(BuildTarget):
                 mlog.debug('Defaulting Rust dynamic library target crate type to "dylib"')
                 self.rust_crate_type = 'dylib'
             # Don't let configuration proceed with a non-dynamic crate type
-            elif self.rust_crate_type not in ['dylib', 'cdylib']:
-                raise InvalidArguments(f'Crate type "{self.rust_crate_type}" invalid for dynamic libraries; must be "dylib" or "cdylib"')
+            elif self.rust_crate_type not in ['dylib', 'cdylib', 'proc-macro']:
+                raise InvalidArguments(f'Crate type "{self.rust_crate_type}" invalid for dynamic libraries; must be "dylib", "cdylib", or "proc-macro"')
         if not hasattr(self, 'prefix'):
             self.prefix = None
         if not hasattr(self, 'suffix'):
@@ -2215,6 +2215,8 @@ class SharedLibrary(BuildTarget):
                 self.rust_crate_type = rust_crate_type
             else:
                 raise InvalidArguments(f'Invalid rust_crate_type "{rust_crate_type}": must be a string.')
+            if rust_crate_type == 'proc-macro':
+                FeatureNew.single_use('Rust crate type "proc-macro"', '0.62.0', self.subproject)
 
     def get_import_filename(self) -> T.Optional[str]:
         """

--- a/test cases/failing/54 wrong shared crate type/test.json
+++ b/test cases/failing/54 wrong shared crate type/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/54 wrong shared crate type/meson.build:7:0: ERROR: Crate type \"staticlib\" invalid for dynamic libraries; must be \"dylib\" or \"cdylib\""
+      "line": "test cases/failing/54 wrong shared crate type/meson.build:7:0: ERROR: Crate type \"staticlib\" invalid for dynamic libraries; must be \"dylib\", \"cdylib\", or \"proc-macro\""
     }
   ]
 }

--- a/test cases/rust/18 proc-macro/meson.build
+++ b/test cases/rust/18 proc-macro/meson.build
@@ -1,0 +1,19 @@
+project('rust proc-macro', 'rust')
+
+if build_machine.system() != 'linux'
+    error('MESON_SKIP_TEST, this test only works on Linux. Patches welcome.')
+endif
+
+pm = shared_library(
+  'proc_macro_examples',
+  'proc.rs',
+  rust_crate_type : 'proc-macro',
+)
+
+main = executable(
+  'main',
+  'use.rs',
+  link_with : pm
+)
+
+test('main_test', main)

--- a/test cases/rust/18 proc-macro/proc.rs
+++ b/test cases/rust/18 proc-macro/proc.rs
@@ -1,0 +1,7 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn make_answer(_item: TokenStream) -> TokenStream {
+    "fn answer() -> u32 { 42 }".parse().unwrap()
+}

--- a/test cases/rust/18 proc-macro/use.rs
+++ b/test cases/rust/18 proc-macro/use.rs
@@ -1,0 +1,8 @@
+extern crate proc_macro_examples;
+use proc_macro_examples::make_answer;
+
+make_answer!();
+
+fn main() {
+    assert_eq!(42, answer());
+}


### PR DESCRIPTION
Proc macros are the only type of rust crate that we don't support, and support is rather trivial. Plus, I've had a request to add support for them.