### PR TITLE
CI images: add the JRE to Ubuntu

### DIFF
--- a/ci/ciimage/bionic/install.sh
+++ b/ci/ciimage/bionic/install.sh
@@ -27,6 +27,7 @@ pkgs=(
   libblocksruntime-dev
   libperl-dev libscalapack-mpi-dev libncurses-dev
   itstool
+  openjdk-11-jre
 )
 
 boost_pkgs=(atomic chrono date-time filesystem log regex serialization system test thread)

--- a/ci/ciimage/ubuntu-rolling/install.sh
+++ b/ci/ciimage/ubuntu-rolling/install.sh
@@ -26,6 +26,7 @@ pkgs=(
   liblapack-dev libscalapack-mpi-dev
   bindgen
   itstool
+  openjdk-11-jre
 )
 
 sed -i '/^#\sdeb-src /s/^#//' "/etc/apt/sources.list"


### PR DESCRIPTION
This is needed in order to test a pending improvement to the jni dependency in #10048.

/cc @tristan957

The purpose of this PR is to rebuild the images with the needed change. Some images are expected to fail to rebuild due to preexisting issues and we can ignore that -- they fail the weekly scheduled rebuilds too.

This lets the CI pass on Ubuntu for the other PR, because Ubuntu *does* rebuild once this is merged to master.