### PR TITLE
lots of fixes to i18n script tool handling

### DIFF
--- a/docs/markdown/snippets/merge_file_sanity.md
+++ b/docs/markdown/snippets/merge_file_sanity.md
@@ -1,0 +1,15 @@
+## i18n.merge_file no longer arbitrarily leaves your project half-built
+
+The i18n module partially accounts for builds with NLS disabled, by disabling
+gettext compiled translation catalogs if it cannot build them. Due to
+implementation details, this also disabled important data files created via
+merge_file, leading to important desktop files etc. not being installed.
+
+This overreaction has been fixed. It is no longer possible to have NLS-disabled
+builds which break the project by not installing important files which have
+nothing to do with NLS (other than including some).
+
+If you were depending on not having the Gettext tools installed and
+successfully mis-building your project, you may need to make your project
+actually work with NLS disabled, for example by providing some version of your
+files which is still installed even when merge_file cannot be run.

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -167,10 +167,7 @@ class I18nModule(ExtensionModule):
     )
     def merge_file(self, state: 'ModuleState', args: T.List['TYPE_var'], kwargs: 'MergeFile') -> ModuleReturnValue:
         if self.tools['msgfmt'] is None:
-            self.tools['msgfmt'] = state.find_program('msgfmt', required=False, for_machine=mesonlib.MachineChoice.BUILD)
-        if not self.tools['msgfmt'].found():
-            self.nogettext_warning(state.current_node)
-            return ModuleReturnValue(None, [])
+            self.tools['msgfmt'] = state.find_program('msgfmt', for_machine=mesonlib.MachineChoice.BUILD)
         podir = path.join(state.build_to_src, state.subdir, kwargs['po_dir'])
 
         ddirs = self._get_data_dirs(state, kwargs['data_dirs'])

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -32,6 +32,7 @@ if T.TYPE_CHECKING:
     from ..build import Target
     from ..interpreter import Interpreter
     from ..interpreterbase import TYPE_var
+    from ..mparser import BaseNode
     from ..programs import ExternalProgram
 
     class MergeFile(TypedDict):
@@ -140,8 +141,8 @@ class I18nModule(ExtensionModule):
         }
 
     @staticmethod
-    def nogettext_warning() -> None:
-        mlog.warning('Gettext not found, all translation targets will be ignored.', once=True)
+    def nogettext_warning(location: BaseNode) -> None:
+        mlog.warning('Gettext not found, all translation targets will be ignored.', once=True, location=location)
 
     @staticmethod
     def _get_data_dirs(state: 'ModuleState', dirs: T.Iterable[str]) -> T.List[str]:
@@ -168,7 +169,7 @@ class I18nModule(ExtensionModule):
         if self.tools['msgfmt'] is None:
             self.tools['msgfmt'] = state.find_program('msgfmt', required=False, for_machine=mesonlib.MachineChoice.BUILD)
         if not self.tools['msgfmt'].found():
-            self.nogettext_warning()
+            self.nogettext_warning(state.current_node)
             return ModuleReturnValue(None, [])
         podir = path.join(state.build_to_src, state.subdir, kwargs['po_dir'])
 
@@ -229,7 +230,7 @@ class I18nModule(ExtensionModule):
                 self.tools[tool] = state.find_program(tool, required=False, for_machine=mesonlib.MachineChoice.BUILD)
             # still not found?
             if not self.tools[tool].found():
-                self.nogettext_warning()
+                self.nogettext_warning(state.current_node)
                 return ModuleReturnValue(None, [])
         packagename = args[0]
         pkg_arg = f'--pkgname={packagename}'

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -175,11 +175,10 @@ class I18nModule(ExtensionModule):
         command.extend(state.environment.get_build_command())
         command.extend([
             '--internal', 'msgfmthelper',
-            '@INPUT@', '@OUTPUT@', kwargs['type'], podir
         ])
         if datadirs:
             command.append(datadirs)
-
+        command.extend(['@INPUT@', '@OUTPUT@', kwargs['type'], podir])
         if kwargs['args']:
             command.append('--')
             command.extend(kwargs['args'])

--- a/mesonbuild/scripts/itstool.py
+++ b/mesonbuild/scripts/itstool.py
@@ -24,11 +24,13 @@ parser.add_argument('command')
 parser.add_argument('--build-dir', default='')
 parser.add_argument('-i', '--input', default='')
 parser.add_argument('-o', '--output', default='')
+parser.add_argument('--itstool', default='itstool')
 parser.add_argument('--its', action='append', default=[])
 parser.add_argument('mo_files', nargs='+')
 
 
-def run_join(build_dir: str, its_files: T.List[str], mo_files: T.List[str], in_fname: str, out_fname: str) -> int:
+def run_join(build_dir: str, itstool: str, its_files: T.List[str], mo_files: T.List[str],
+             in_fname: str, out_fname: str) -> int:
     if not mo_files:
         print('No mo files specified to use for translation.')
         return 1
@@ -53,7 +55,7 @@ def run_join(build_dir: str, its_files: T.List[str], mo_files: T.List[str], in_f
             shutil.copy(mo_file, tmp_mo_fname)
             locale_mo_files.append(tmp_mo_fname)
 
-        cmd = ['itstool']
+        cmd = [itstool]
         if its_files:
             for fname in its_files:
                 cmd.extend(['-i', fname])
@@ -73,6 +75,7 @@ def run(args: T.List[str]) -> int:
 
     if command == 'join':
         return run_join(build_dir,
+                        options.itstool,
                         options.its,
                         options.mo_files,
                         options.input,

--- a/mesonbuild/scripts/msgfmthelper.py
+++ b/mesonbuild/scripts/msgfmthelper.py
@@ -22,6 +22,7 @@ parser.add_argument('input')
 parser.add_argument('output')
 parser.add_argument('type')
 parser.add_argument('podir')
+parser.add_argument('--msgfmt', default='msgfmt')
 parser.add_argument('--datadirs', default='')
 parser.add_argument('args', default=[], metavar='extra msgfmt argument', nargs='*')
 
@@ -32,6 +33,6 @@ def run(args: T.List[str]) -> int:
     if options.datadirs:
         env = os.environ.copy()
         env.update({'GETTEXTDATADIRS': options.datadirs})
-    return subprocess.call(['msgfmt', '--' + options.type, '-d', options.podir,
+    return subprocess.call([options.msgfmt, '--' + options.type, '-d', options.podir,
                             '--template', options.input,  '-o', options.output] + options.args,
                            env=env)

--- a/test cases/frameworks/6 gettext/data/meson.build
+++ b/test cases/frameworks/6 gettext/data/meson.build
@@ -4,6 +4,7 @@ i18n.merge_file(
   output: '@BASENAME@',
   type: 'desktop',
   po_dir: '../po',
+  data_dirs: '../po',
   install: true,
   install_dir: join_paths(get_option('datadir'), 'applications')
 )

--- a/test cases/frameworks/6 gettext/data2/meson.build
+++ b/test cases/frameworks/6 gettext/data2/meson.build
@@ -3,6 +3,7 @@ i18n.merge_file(
   output: 'test.plugin',
   type: 'desktop',
   po_dir: '../po',
+  data_dirs: '../po',
   args: ['--keyword=Description'],
   install: true,
   install_dir: join_paths(get_option('datadir'), 'applications')


### PR DESCRIPTION
By the way, argparse sucks and I hate it.

Some things this fixes:
- argparse sucks and mishandles arguments, but only sometimes
- check for tools which we need at configure time and respect machine file overrides, rather than using `shutil.which('xgettext')` as a universal sentinel. Log what we found, because state.find_program has decent logging and shutil.which does not because shutil.which is a low level python function and not something that belongs in the high level parts of the Meson interpreter
- Stop disabling really important, downright crucial parts of peoples' builds.

Fixes #6165
Fixes #8436