### PR TITLE
find_program: add a version() method to match the one for dependencies

### DIFF
--- a/docs/markdown/snippets/find_program-version.md
+++ b/docs/markdown/snippets/find_program-version.md
@@ -1,0 +1,5 @@
+## found programs now have a version method
+
+The return value of [[find_program]] can now check the exact version of the
+found program, independent of the minimum version requirement. This can be used
+e.g. to perform different actions depending on the exact version detected.

--- a/docs/yaml/objects/external_program.yaml
+++ b/docs/yaml/objects/external_program.yaml
@@ -24,6 +24,14 @@ methods:
     run_command(find_program('foo'), 'arg1', 'arg2')
     ```
 
+- name: version
+  returns: str
+  since: 0.62.0
+  description: |
+    The version number as a string, for example `1.2.8`.
+
+    `unknown` if the program cannot determine the version via a `--version` argument.
+
 - name: full_path
   returns: str
   since: 0.55.0

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -516,6 +516,7 @@ class ExternalProgramHolder(ObjectHolder[ExternalProgram]):
         super().__init__(ep, interpreter)
         self.methods.update({'found': self.found_method,
                              'path': self.path_method,
+                             'version': self.version_method,
                              'full_path': self.full_path_method})
 
     @noPosargs
@@ -542,6 +543,17 @@ class ExternalProgramHolder(ObjectHolder[ExternalProgram]):
         path = self.held_object.get_path()
         assert path is not None
         return path
+
+    @noPosargs
+    @noKwargs
+    @FeatureNew('ExternalProgram.version', '0.62.0')
+    def version_method(self, args: T.List[TYPE_var], kwargs: TYPE_kwargs) -> str:
+        if not self.found():
+            raise InterpreterException('Unable to get the version of a not-found external program')
+        try:
+            return self.held_object.get_version(self.interpreter)
+        except MesonException:
+            return 'unknown'
 
     def found(self) -> bool:
         return self.held_object.found()

--- a/test cases/common/26 find program/meson.build
+++ b/test cases/common/26 find program/meson.build
@@ -25,6 +25,9 @@ assert(not prog.found(), 'Version should be too old')
 prog = find_program('print-version.py', version : '>=1.0')
 assert(prog.found(), 'Program version should match')
 
+prog = find_program('print-version.py')
+assert(prog.version() == '1.0', 'Program version should be detectable')
+
 prog = find_program('print-version-with-prefix.py', version : '>=1.0')
 assert(prog.found(), 'Program version should match')
 


### PR DESCRIPTION
It is often useful to check the found version of a program without checking whether you can successfully find `find_program('foo', required: false, version: '>=XXX')`

/cc @xclaesse 