### PR TITLE
fix correctly detecting whether python is found if link args are empty

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -158,7 +158,7 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
         if largs is not None:
             self.link_args = largs
 
-        self.is_found = largs is not None or self.link_libpython
+        self.is_found = largs is not None or not self.link_libpython
 
         inc_paths = mesonlib.OrderedSet([
             self.variables.get('INCLUDEPY'),


### PR DESCRIPTION
There are two cases where we can assume we found the python dependency with its requisite libraries using sysconfig:

- we found the library with find_library and are prepared to link to it
- the library is not actually part of the dependency, so its presence or absence is irrelevant

In the latter case, we should consider it found if link_libpython is False. Originally we did this, but the logic was inverted in commit 5b422fce87826beff3bca85e9c9081f22b3f45b7 in an unrelated change and without explanation, likely by accident.

Normally this doesn't much matter, since a python invariably comes with a predictably located libpython and the first condition evaluates true. But that is not true for pypy, and in fact that is the reason the link_libpython check was originally added in commit 1bd14b52b26b0f4ec207bf7e38813b82bfc15f86.

Restore that original logic.

Fixes #8570