### PR TITLE
Move dataonly pkgconfig file to datadir/pkgconfig

### DIFF
--- a/docs/markdown/snippets/dataonly-pkgconfig-default-install-path.md
+++ b/docs/markdown/snippets/dataonly-pkgconfig-default-install-path.md
@@ -1,0 +1,4 @@
+## `dataonly` Pkgconfig Default Install Path
+
+The default install path for `dataonly` pkgconfig files has changed from
+`${libdir}/pkgconfig` to `${datadir}/pkgconfig`.

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -524,6 +524,7 @@ class PkgConfigModule(ExtensionModule):
             blocked_vars = ['libraries', 'libraries_private', 'require_private', 'extra_cflags', 'subdirs']
             if any(k in kwargs for k in blocked_vars):
                 raise mesonlib.MesonException(f'Cannot combine dataonly with any of {blocked_vars}')
+            default_install_dir = os.path.join(state.environment.get_datadir(), 'pkgconfig')
 
         subdirs = mesonlib.stringlistify(kwargs.get('subdirs', default_subdirs))
         version = kwargs.get('version', default_version)

--- a/test cases/common/44 pkgconfig-gen/test.json
+++ b/test cases/common/44 pkgconfig-gen/test.json
@@ -6,7 +6,6 @@
     {"type": "file", "file": "usr/lib/pkgconfig/libanswer.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/libfoo.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/libhello.pc"},
-    {"type": "file", "file": "usr/lib/pkgconfig/libhello_nolib.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/libvartest.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/libvartest2.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/simple2.pc"},
@@ -14,7 +13,8 @@
     {"type": "file", "file": "usr/lib/pkgconfig/simple5.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/simple6.pc"},
     {"type": "file", "file": "usr/lib/pkgconfig/ct.pc"},
-    {"type": "file", "file": "usr/lib/pkgconfig/ct0.pc"}
+    {"type": "file", "file": "usr/lib/pkgconfig/ct0.pc"},
+    {"type": "file", "file": "usr/share/pkgconfig/libhello_nolib.pc"}
   ],
   "stdout": [
     {


### PR DESCRIPTION
dataonly files are architecture independent (lib vs lib64 for example).

Fixes #9902

CC @Tachi107 @eli-schwartz 