### PR TITLE
tests: bitcode: add missing b_bitcode option

### DIFF
--- a/test cases/osx/7 bitcode/meson.build
+++ b/test cases/osx/7 bitcode/meson.build
@@ -1,4 +1,5 @@
-project('bitcode test', 'c', 'objc', 'objcpp')
+project('bitcode test', 'c', 'objc', 'objcpp',
+    default_options : ['b_bitcode=true'])
 
 both_libraries('alib', 'libfoo.m')
 shared_module('amodule', 'libfoo.m')


### PR DESCRIPTION
The bitcode test did not actually have bitcode enabled,
making it not really useful.