### PR TITLE
add early sanity check for test programs existing

### DIFF
--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1984,7 +1984,10 @@ external dependencies (including libraries) must go to "dependencies".''')
                              location=node)
             name = name.replace(':', '_')
         exe = args[1]
-        if isinstance(exe, mesonlib.File):
+        if isinstance(exe, ExternalProgram):
+            if not exe.found():
+                raise InvalidArguments('Tried to use not-found external program as test exe')
+        elif isinstance(exe, mesonlib.File):
             exe = self.find_program_impl([exe])
 
         env = self.unpack_env_kwarg(kwargs)


### PR DESCRIPTION
It used to be possible to do this:

```
bomb = find_program('nonexisting', required: false)
test('traceback during meson test', bomb)
```

and it would in fact bomb out, with:

```
[0/1] Running all tests.
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/mesonbuild/mesonmain.py", line 149, in run
    return options.run_func(options)
  File "/usr/lib/python3.10/site-packages/mesonbuild/mtest.py", line 2017, in run
    return th.doit()
  File "/usr/lib/python3.10/site-packages/mesonbuild/mtest.py", line 1685, in doit
    runners.extend(self.get_test_runner(test) for test in tests)
  File "/usr/lib/python3.10/site-packages/mesonbuild/mtest.py", line 1685, in <genexpr>
    runners.extend(self.get_test_runner(test) for test in tests)
  File "/usr/lib/python3.10/site-packages/mesonbuild/mtest.py", line 1586, in get_test_runner
    return SingleTestRunner(test, env, name, options)
  File "/usr/lib/python3.10/site-packages/mesonbuild/mtest.py", line 1308, in __init__
    self.cmd = self._get_cmd()
  File "/usr/lib/python3.10/site-packages/mesonbuild/mtest.py", line 1374, in _get_cmd
    test_cmd = self._get_test_cmd()
  File "/usr/lib/python3.10/site-packages/mesonbuild/mtest.py", line 1352, in _get_test_cmd
    if self.options.no_rebuild and not os.path.isfile(testentry):
  File "/usr/lib/python3.10/genericpath.py", line 30, in isfile
    st = os.stat(path)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType

ERROR: Unhandled python exception

    This is a Meson bug and should be reported!
```

This is something we explicitly check for elsewhere, for example when using a not-found program as a command in a custom target or generator.

Check for it when making a test too, and error out with a similar error.

Fixes #10091