### PR TITLE
Remove a spurious debug print in Python module

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -414,7 +414,6 @@ class PythonExternalProgram(ExternalProgram):
         if subdir_parts[-len(install_subdir_parts):] == install_subdir_parts:
             pypath = os.path.join(basedir, *subdir_parts[:-len(install_subdir_parts)])
             self.devenv_pythonpath.add(pypath)
-            print('done', pypath)
 
     def _check_version(self, version: str) -> bool:
         if self.name == 'python2':


### PR DESCRIPTION
This prints many lines of unwanted `"done /absolute/path"`, I noticed this when testing 0.62.0rc1 with SciPy.

Introduced in commit 79c6075b56, Cc @xclaesse. Can this be backported for 0.62.0?

[ci skip]