### PR TITLE
Add type annotations to the Pkgconfig Module, and fix lots of bugs

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1044,7 +1044,7 @@ class Backend:
         tests.
         """
         result: T.Set[str] = set()
-        prospectives: T.Set[T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex]] = set()
+        prospectives: T.Set[build.BuildTargetTypes] = set()
         if isinstance(target, build.BuildTarget):
             prospectives.update(target.get_transitive_link_deps())
             # External deps

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -58,6 +58,7 @@ if T.TYPE_CHECKING:
 
     GeneratedTypes = T.Union['CustomTarget', 'CustomTargetIndex', 'GeneratedList']
     LibTypes = T.Union['SharedLibrary', 'StaticLibrary', 'CustomTarget', 'CustomTargetIndex']
+    BuildTargetTypes = T.Union['BuildTarget', 'CustomTarget', 'CustomTargetIndex']
 
 pch_kwargs = {'c_pch', 'cpp_pch'}
 
@@ -1066,11 +1067,11 @@ class BuildTarget(Target):
         return ExtractedObjects(self, self.sources, self.generated, self.objects,
                                 recursive)
 
-    def get_all_link_deps(self) -> 'ImmutableListProtocol[T.Union[BuildTarget, CustomTarget, CustomTargetIndex]]':
+    def get_all_link_deps(self) -> ImmutableListProtocol[BuildTargetTypes]:
         return self.get_transitive_link_deps()
 
     @lru_cache(maxsize=None)
-    def get_transitive_link_deps(self) -> 'ImmutableListProtocol[T.Union[BuildTarget, CustomTarget, CustomTargetIndex]]':
+    def get_transitive_link_deps(self) -> ImmutableListProtocol[BuildTargetTypes]:
         result: T.List[Target] = []
         for i in self.link_targets:
             result += i.get_all_link_deps()
@@ -2402,7 +2403,7 @@ class CommandBase:
     dependencies: T.List[T.Union[BuildTarget, 'CustomTarget']]
     subproject: str
 
-    def flatten_command(self, cmd: T.Sequence[T.Union[str, File, programs.ExternalProgram, 'BuildTarget', 'CustomTarget', 'CustomTargetIndex']]) -> \
+    def flatten_command(self, cmd: T.Sequence[T.Union[str, File, programs.ExternalProgram, BuildTargetTypes]]) -> \
             T.List[T.Union[str, File, BuildTarget, 'CustomTarget']]:
         cmd = listify(cmd)
         final_cmd: T.List[T.Union[str, File, BuildTarget, 'CustomTarget']] = []
@@ -2444,10 +2445,11 @@ class CustomTarget(Target, CommandBase):
                  subproject: str,
                  environment: environment.Environment,
                  command: T.Sequence[T.Union[
-                     str, BuildTarget, CustomTarget, CustomTargetIndex, GeneratedList, programs.ExternalProgram, File]],
+                     str, BuildTargetTypes, GeneratedList,
+                     programs.ExternalProgram, File]],
                  sources: T.Sequence[T.Union[
-                     str, File, BuildTarget, CustomTarget, CustomTargetIndex,
-                     ExtractedObjects, GeneratedList, programs.ExternalProgram]],
+                     str, File, BuildTargetTypes, ExtractedObjects,
+                     GeneratedList, programs.ExternalProgram]],
                  outputs: T.List[str],
                  *,
                  build_always_stale: bool = False,
@@ -2633,7 +2635,7 @@ class RunTarget(Target, CommandBase):
     typename = 'run'
 
     def __init__(self, name: str,
-                 command: T.Sequence[T.Union[str, File, BuildTarget, 'CustomTarget', 'CustomTargetIndex', programs.ExternalProgram]],
+                 command: T.Sequence[T.Union[str, File, BuildTargetTypes, programs.ExternalProgram]],
                  dependencies: T.Sequence[Target],
                  subdir: str,
                  subproject: str,

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -85,8 +85,6 @@ from .type_checking import (
     VARIABLES_KW,
     NoneType,
     in_set_validator,
-    variables_validator,
-    variables_convertor,
     env_convertor_with_method
 )
 from . import primitives as P_OBJ
@@ -672,29 +670,6 @@ class Interpreter(InterpreterBase, HoldableObject):
     def func_files(self, node: mparser.FunctionNode, args: T.Tuple[T.List[str]], kwargs: 'TYPE_kwargs') -> T.List[mesonlib.File]:
         return self.source_strings_to_files(args[0])
 
-    # Used by pkgconfig.generate()
-    def extract_variables(self, kwargs: T.Dict[str, T.Union[T.Dict[str, str], T.List[str], str]],
-                          argname: str = 'variables', list_new: bool = False,
-                          dict_new: bool = False) -> T.Dict[str, str]:
-        variables = kwargs.get(argname, {})
-        if isinstance(variables, dict):
-            if dict_new and variables:
-                FeatureNew.single_use(f'{argname} as dictionary', '0.56.0', self.subproject, location=self.current_node)
-        else:
-            variables = mesonlib.stringlistify(variables)
-            if list_new:
-                FeatureNew.single_use(f'{argname} as list of strings', '0.56.0', self.subproject, location=self.current_node)
-
-        invalid_msg = variables_validator(variables)
-        if invalid_msg is not None:
-            raise InterpreterException(invalid_msg)
-
-        variables = variables_convertor(variables)
-        for k, v in variables.items():
-            if not isinstance(v, str):
-                raise InterpreterException('variables values must be strings.')
-
-        return variables
 
     @noPosargs
     @typed_kwargs(

--- a/mesonbuild/interpreterbase/decorators.py
+++ b/mesonbuild/interpreterbase/decorators.py
@@ -389,10 +389,10 @@ class KwargInfo(T.Generic[_T]):
                  default: T.Optional[_T] = None,
                  since: T.Optional[str] = None,
                  since_message: T.Optional[str] = None,
-                 since_values: T.Optional[T.Dict[_T, T.Union[str, T.Tuple[str, str]]]] = None,
+                 since_values: T.Optional[T.Dict[T.Union[_T, T.Type[T.List], T.Type[T.Dict]], T.Union[str, T.Tuple[str, str]]]] = None,
                  deprecated: T.Optional[str] = None,
                  deprecated_message: T.Optional[str] = None,
-                 deprecated_values: T.Optional[T.Dict[_T, T.Union[str, T.Tuple[str, str]]]] = None,
+                 deprecated_values: T.Optional[T.Dict[T.Union[_T, T.Type[T.List], T.Type[T.Dict]], T.Union[str, T.Tuple[str, str]]]] = None,
                  validator: T.Optional[T.Callable[[T.Any], T.Optional[str]]] = None,
                  convertor: T.Optional[T.Callable[[_T], object]] = None,
                  not_set_warning: T.Optional[str] = None):
@@ -418,10 +418,10 @@ class KwargInfo(T.Generic[_T]):
                default: T.Union[_T, None, _NULL_T] = _NULL,
                since: T.Union[str, None, _NULL_T] = _NULL,
                since_message: T.Union[str, None, _NULL_T] = _NULL,
-               since_values: T.Union[T.Dict[_T, T.Union[str, T.Tuple[str, str]]], None, _NULL_T] = _NULL,
+               since_values: T.Union[T.Dict[T.Union[_T, T.Type[T.List], T.Type[T.Dict]], T.Union[str, T.Tuple[str, str]]], None, _NULL_T] = _NULL,
                deprecated: T.Union[str, None, _NULL_T] = _NULL,
                deprecated_message: T.Union[str, None, _NULL_T] = _NULL,
-               deprecated_values: T.Union[T.Dict[_T, T.Union[str, T.Tuple[str, str]]], None, _NULL_T] = _NULL,
+               deprecated_values: T.Union[T.Dict[T.Union[_T, T.Type[T.List], T.Type[T.Dict]], T.Union[str, T.Tuple[str, str]]], None, _NULL_T] = _NULL,
                validator: T.Union[T.Callable[[_T], T.Optional[str]], None, _NULL_T] = _NULL,
                convertor: T.Union[T.Callable[[_T], TYPE_var], None, _NULL_T] = _NULL) -> 'KwargInfo':
         """Create a shallow copy of this KwargInfo, with modifications.

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -538,7 +538,7 @@ class PkgConfigModule(ExtensionModule):
             raise mesonlib.MesonException('dataonly must be boolean.')
         if dataonly:
             default_subdirs = []
-            blocked_vars = ['libraries', 'libraries_private', 'require_private', 'extra_cflags', 'subdirs']
+            blocked_vars = ['libraries', 'libraries_private', 'requires_private', 'extra_cflags', 'subdirs']
             if any(k in kwargs for k in blocked_vars):
                 raise mesonlib.MesonException(f'Cannot combine dataonly with any of {blocked_vars}')
             default_install_dir = os.path.join(state.environment.get_datadir(), 'pkgconfig')

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -615,8 +615,14 @@ class PkgConfigModule(ExtensionModule):
             install_dir = mainlib.get_custom_install_dir()
             if install_dir and isinstance(install_dir[0], str):
                 default_install_dir = os.path.join(install_dir[0], 'pkgconfig')
-        elif kwargs['version'] is None:
-            FeatureNew.single_use('pkgconfig.generate implicit version keyword', '0.46.0', state.subproject)
+        else:
+            if kwargs['version'] is None:
+                FeatureNew.single_use('pkgconfig.generate implicit version keyword', '0.46.0', state.subproject)
+            if kwargs['name'] is None:
+                raise build.InvalidArguments(
+                    'pkgconfig.generate: if a library is not passed as a '
+                    'positional argument, the name keyword argument is '
+                    'required.')
 
         dataonly = kwargs['dataonly']
         if dataonly:
@@ -629,6 +635,7 @@ class PkgConfigModule(ExtensionModule):
         subdirs = kwargs['subdirs'] or default_subdirs
         version = kwargs['version'] if kwargs['version'] is not None else default_version
         name = kwargs['name'] if kwargs['name'] is not None else default_name
+        assert isinstance(name, str), 'for mypy'
         filebase = kwargs['filebase'] if kwargs['filebase'] is not None else name
         description = kwargs['description'] if kwargs['description'] is not None else default_description
         url = kwargs['url']

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -297,16 +297,17 @@ class DependenciesHelper:
 
     def remove_dups(self) -> None:
         # Set of ids that have already been handled and should not be added any more
-        exclude: T.Set[build.Target] = set()
+        exclude: T.Set[str] = set()
 
         # We can't just check if 'x' is excluded because we could have copies of
         # the same SharedLibrary object for example.
         def _ids(x: T.Union[str, build.CustomTarget, build.CustomTargetIndex, build.StaticLibrary]) -> T.Iterable[str]:
-            if isinstance(x, build.Target):
+            if isinstance(x, str):
+                yield x
+            else:
                 if x.get_id() in self.metadata:
                     yield self.metadata[x.get_id()].display_name
                 yield x.get_id()
-            yield x
 
         # Exclude 'x' in all its forms and return if it was already excluded
         def _add_exclude(x: T.Union[str, build.CustomTarget, build.CustomTargetIndex, build.StaticLibrary]) -> bool:

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -19,7 +19,7 @@ from pathlib import PurePath
 import os
 import typing as T
 
-from . import ExtensionModule, ModuleInfo
+from . import NewExtensionModule, ModuleInfo
 from . import ModuleReturnValue
 from .. import build
 from .. import dependencies
@@ -361,7 +361,7 @@ class DependenciesHelper:
         exclude = set()
         self.cflags = _fn(self.cflags)
 
-class PkgConfigModule(ExtensionModule):
+class PkgConfigModule(NewExtensionModule):
 
     INFO = ModuleInfo('pkgconfig')
 
@@ -369,8 +369,8 @@ class PkgConfigModule(ExtensionModule):
     # variable so that multiple `import()`s share metadata
     _metadata: T.ClassVar[T.Dict[str, MetaData]] = {}
 
-    def __init__(self, interpreter: Interpreter):
-        super().__init__(interpreter)
+    def __init__(self) -> None:
+        super().__init__()
         self.methods.update({
             'generate': self.generate,
         })
@@ -737,4 +737,4 @@ class PkgConfigModule(ExtensionModule):
 
 
 def initialize(interp: Interpreter) -> PkgConfigModule:
-    return PkgConfigModule(interp)
+    return PkgConfigModule()

--- a/mesonbuild/modules/pkgconfig.py
+++ b/mesonbuild/modules/pkgconfig.py
@@ -108,21 +108,21 @@ class DependenciesHelper:
         self.link_whole_targets: T.List[T.Union[build.CustomTarget, build.CustomTargetIndex, build.StaticLibrary]] = []
         self.metadata = metadata
 
-    def add_pub_libs(self, libs: T.Sequence[ANY_DEP]) -> None:
+    def add_pub_libs(self, libs: T.List[ANY_DEP]) -> None:
         p_libs, reqs, cflags = self._process_libs(libs, True)
         self.pub_libs = p_libs + self.pub_libs # prepend to preserve dependencies
         self.pub_reqs += reqs
         self.cflags += cflags
 
-    def add_priv_libs(self, libs: T.Sequence[ANY_DEP]) -> None:
+    def add_priv_libs(self, libs: T.List[ANY_DEP]) -> None:
         p_libs, reqs, _ = self._process_libs(libs, False)
         self.priv_libs = p_libs + self.priv_libs
         self.priv_reqs += reqs
 
-    def add_pub_reqs(self, reqs: T.Sequence[T.Union[str, dependencies.Dependency]]) -> None:
+    def add_pub_reqs(self, reqs: T.List[T.Union[str, build.StaticLibrary, build.SharedLibrary, dependencies.Dependency]]) -> None:
         self.pub_reqs += self._process_reqs(reqs)
 
-    def add_priv_reqs(self, reqs: T.Sequence[T.Union[str, dependencies.Dependency]]) -> None:
+    def add_priv_reqs(self, reqs: T.List[T.Union[str, build.StaticLibrary, build.SharedLibrary, dependencies.Dependency]]) -> None:
         self.priv_reqs += self._process_reqs(reqs)
 
     def _check_generated_pc_deprecation(self, obj: T.Union[build.CustomTarget, build.CustomTargetIndex, build.StaticLibrary, build.SharedLibrary]) -> None:
@@ -142,7 +142,7 @@ class DependenciesHelper:
                          location=data.location)
         data.warned = True
 
-    def _process_reqs(self, reqs: T.Sequence[T.Union[str, dependencies.Dependency]]) -> T.List[str]:
+    def _process_reqs(self, reqs: T.Sequence[T.Union[str, build.StaticLibrary, build.SharedLibrary, dependencies.Dependency]]) -> T.List[str]:
         '''Returns string names of requirements'''
         processed_reqs: T.List[str] = []
         for obj in mesonlib.listify(reqs):
@@ -159,7 +159,7 @@ class DependenciesHelper:
             elif isinstance(obj, str):
                 name, version_req = self.split_version_req(obj)
                 processed_reqs.append(name)
-                self.add_version_reqs(name, version_req)
+                self.add_version_reqs(name, [version_req] if version_req is not None else None)
             elif isinstance(obj, dependencies.Dependency) and not obj.found():
                 pass
             elif isinstance(obj, ThreadDependency):
@@ -174,7 +174,7 @@ class DependenciesHelper:
         self.cflags += mesonlib.stringlistify(cflags)
 
     def _process_libs(
-            self, libs: T.Sequence[ANY_DEP], public: bool
+            self, libs: T.List[ANY_DEP], public: bool
             ) -> T.Tuple[T.List[T.Union[str, build.SharedLibrary, build.StaticLibrary, build.CustomTarget, build.CustomTargetIndex]], T.List[str], T.List[str]]:
         libs = mesonlib.listify(libs)
         processed_libs: T.List[T.Union[str, build.SharedLibrary, build.StaticLibrary, build.CustomTarget, build.CustomTargetIndex]] = []
@@ -230,8 +230,8 @@ class DependenciesHelper:
         return processed_libs, processed_reqs, processed_cflags
 
     def _add_lib_dependencies(
-            self, link_targets: T.List[T.Union[build.StaticLibrary, build.SharedLibrary, build.CustomTarget, build.CustomTargetIndex]],
-            link_whole_targets: T.List[T.Union[build.StaticLibrary, build.CustomTarget, build.CustomTargetIndex]],
+            self, link_targets: T.Sequence[build.BuildTargetTypes],
+            link_whole_targets: T.Sequence[T.Union[build.StaticLibrary, build.CustomTarget, build.CustomTargetIndex]],
             external_deps: T.List[dependencies.Dependency],
             public: bool,
             private_external_deps: bool = False) -> None:
@@ -241,6 +241,9 @@ class DependenciesHelper:
             # Internal libraries (uninstalled static library) will be promoted
             # to link_whole, treat them as such here.
             if t.is_internal():
+                # `is_internal` shouldn't return True for anything but a
+                # StaticLibrary, or a CustomTarget that is a StaticLibrary
+                assert isinstance(t, (build.StaticLibrary, build.CustomTarget, build.CustomTargetIndex)), 'for mypy'
                 self._add_link_whole(t, public)
             else:
                 add_libs([t])
@@ -248,11 +251,11 @@ class DependenciesHelper:
             self._add_link_whole(t, public)
         # And finally its external dependencies
         if private_external_deps:
-            self.add_priv_libs(external_deps)
+            self.add_priv_libs(T.cast('T.List[ANY_DEP]', external_deps))
         else:
-            add_libs(external_deps)
+            add_libs(T.cast('T.List[ANY_DEP]', external_deps))
 
-    def _add_link_whole(self, t: T.Union[build.CustomTarget, build.CustomTargetIndex, build.StaticLibrary, build.SharedLibrary], public: bool) -> None:
+    def _add_link_whole(self, t: T.Union[build.CustomTarget, build.CustomTargetIndex, build.StaticLibrary], public: bool) -> None:
         # Don't include static libraries that we link_whole. But we still need to
         # include their dependencies: a static library we link_whole
         # could itself link to a shared library or an installed static library.
@@ -301,7 +304,7 @@ class DependenciesHelper:
 
         # We can't just check if 'x' is excluded because we could have copies of
         # the same SharedLibrary object for example.
-        def _ids(x: T.Union[str, build.CustomTarget, build.CustomTargetIndex, build.StaticLibrary]) -> T.Iterable[str]:
+        def _ids(x: T.Union[str, build.CustomTarget, build.CustomTargetIndex, build.StaticLibrary, build.SharedLibrary]) -> T.Iterable[str]:
             if isinstance(x, str):
                 yield x
             else:
@@ -310,7 +313,7 @@ class DependenciesHelper:
                 yield x.get_id()
 
         # Exclude 'x' in all its forms and return if it was already excluded
-        def _add_exclude(x: T.Union[str, build.CustomTarget, build.CustomTargetIndex, build.StaticLibrary]) -> bool:
+        def _add_exclude(x: T.Union[str, build.CustomTarget, build.CustomTargetIndex, build.StaticLibrary, build.SharedLibrary]) -> bool:
             was_excluded = False
             for i in _ids(x):
                 if i in exclude:
@@ -473,14 +476,14 @@ class PkgConfigModule(ExtensionModule):
             outdir = state.environment.scratch_dir
             prefix = PurePath(_as_str(coredata.get_option(mesonlib.OptionKey('prefix'))))
             if pkgroot:
-                pkgroot = PurePath(pkgroot)
-                if not pkgroot.is_absolute():
-                    pkgroot = prefix / pkgroot
-                elif prefix not in pkgroot.parents:
+                pkgroot_ = PurePath(pkgroot)
+                if not pkgroot_.is_absolute():
+                    pkgroot_ = prefix / pkgroot
+                elif prefix not in pkgroot_.parents:
                     raise mesonlib.MesonException('Pkgconfig prefix cannot be outside of the prefix '
                                                   'when pkgconfig.relocatable=true. '
-                                                  f'Pkgconfig prefix is {pkgroot.as_posix()}.')
-                prefix = PurePath('${pcfiledir}', os.path.relpath(prefix, pkgroot))
+                                                  f'Pkgconfig prefix is {pkgroot_.as_posix()}.')
+                prefix = PurePath('${pcfiledir}', os.path.relpath(prefix, pkgroot_))
         fname = os.path.join(outdir, pcfile)
         with open(fname, 'w', encoding='utf-8') as ofile:
             for optname in optnames:
@@ -695,10 +698,10 @@ class PkgConfigModule(ExtensionModule):
         pkgroot = pkgroot_name = kwargs['install_dir'] or default_install_dir
         if pkgroot is None:
             if mesonlib.is_freebsd():
-                pkgroot = os.path.join(state.environment.coredata.get_option(mesonlib.OptionKey('prefix')), 'libdata', 'pkgconfig')
+                pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(mesonlib.OptionKey('prefix'))), 'libdata', 'pkgconfig')
                 pkgroot_name = os.path.join('{prefix}', 'libdata', 'pkgconfig')
             else:
-                pkgroot = os.path.join(state.environment.coredata.get_option(mesonlib.OptionKey('libdir')), 'pkgconfig')
+                pkgroot = os.path.join(_as_str(state.environment.coredata.get_option(mesonlib.OptionKey('libdir'))), 'pkgconfig')
                 pkgroot_name = os.path.join('{libdir}', 'pkgconfig')
         relocatable = state.get_option('relocatable', module='pkgconfig')
         self._generate_pkgconfig_file(state, deps, subdirs, name, description, url,

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -48,6 +48,7 @@ modules = [
     'mesonbuild/modules/java.py',
     'mesonbuild/modules/keyval.py',
     'mesonbuild/modules/modtest.py',
+    'mesonbuild/modules/pkgconfig.py',
     'mesonbuild/modules/qt.py',
     'mesonbuild/modules/rust.py',
     'mesonbuild/modules/sourceset.py',

--- a/test cases/failing/46 pkgconfig variables zero length/test.json
+++ b/test cases/failing/46 pkgconfig variables zero length/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/46 pkgconfig variables zero length/meson.build:8:5: ERROR: empty variable name"
+      "line": "test cases/failing/46 pkgconfig variables zero length/meson.build:8:5: ERROR: pkgconfig.generate keyword argument \"variables\" empty variable name"
     }
   ]
 }

--- a/test cases/failing/47 pkgconfig variables zero length value/test.json
+++ b/test cases/failing/47 pkgconfig variables zero length value/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/47 pkgconfig variables zero length value/meson.build:8:5: ERROR: empty variable value"
+      "line": "test cases/failing/47 pkgconfig variables zero length value/meson.build:8:5: ERROR: pkgconfig.generate keyword argument \"variables\" empty variable value"
     }
   ]
 }

--- a/test cases/failing/48 pkgconfig variables not key value/test.json
+++ b/test cases/failing/48 pkgconfig variables not key value/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/48 pkgconfig variables not key value/meson.build:8:5: ERROR: variable 'this_should_be_key_value' must have a value separated by equals sign."
+      "line": "test cases/failing/48 pkgconfig variables not key value/meson.build:8:5: ERROR: pkgconfig.generate keyword argument \"variables\" variable 'this_should_be_key_value' must have a value separated by equals sign."
     }
   ]
 }


### PR DESCRIPTION
~This is based on #10093.~

This began as a way to add type annotations and typed_*args to the pkgconfig module, but the typing annotations ended up leading up leading me to notice a number of other issues, largely around using CustomTarget and CustomTargetIndex as linkable targets, and around around link_whole, and then found some places where our annotations weren't strictly correct. The end result is 24 commits stepping all over the tree. I could probably shave off the last few commits and separate them into a different PR, if there was desire to land them separately.