### PR TITLE
mtest: fix logic bug that broke tests where the cmd is a Windows found program

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -224,6 +224,7 @@ class TestSerialisation:
     protocol: TestProtocol
     priority: int
     cmd_is_built: bool
+    cmd_is_exe: bool
     depends: T.List[str]
     version: str
     verbose: bool
@@ -1147,6 +1148,7 @@ class Backend:
                                    t.is_parallel, cmd_args, t.env,
                                    t.should_fail, t.timeout, t.workdir,
                                    extra_paths, t.protocol, t.priority,
+                                   isinstance(exe, build.Target),
                                    isinstance(exe, build.Executable),
                                    [x.get_id() for x in depends],
                                    self.environment.coredata.version,

--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -1349,18 +1349,18 @@ class SingleTestRunner:
 
     def _get_test_cmd(self) -> T.Optional[T.List[str]]:
         testentry = self.test.fname[0]
-        if self.options.no_rebuild and not os.path.isfile(testentry):
+        if self.options.no_rebuild and self.test.cmd_is_built and not os.path.isfile(testentry):
             raise TestException(f'The test program {testentry!r} does not exist. Cannot run tests before building them.')
         if testentry.endswith('.jar'):
             return ['java', '-jar'] + self.test.fname
         elif not self.test.is_cross_built and run_with_mono(testentry):
             return ['mono'] + self.test.fname
-        elif self.test.cmd_is_built and self.test.is_cross_built and self.test.needs_exe_wrapper:
+        elif self.test.cmd_is_exe and self.test.is_cross_built and self.test.needs_exe_wrapper:
             if self.test.exe_wrapper is None:
                 # Can not run test on cross compiled executable
                 # because there is no execute wrapper.
                 return None
-            elif self.test.cmd_is_built:
+            elif self.test.cmd_is_exe:
                 # If the command is not built (ie, its a python script),
                 # then we don't check for the exe-wrapper
                 if not self.test.exe_wrapper.found():


### PR DESCRIPTION
In this case, the test fname might have an implicit extension and cannot be found by `os.path.isfile()` -- intead use `shutil.which()` since it is guaranteed to find anything that subprocess.Popen or asyncio.create_subprocess_exec can successfully run.

Fixes #10027