### PR TITLE
mtest: print stderr of TAP/Rust tests in verbose/non-parallel mode

### DIFF
--- a/mesonbuild/mtest.py
+++ b/mesonbuild/mtest.py
@@ -665,9 +665,8 @@ class ConsoleLogger(TestLogger):
 
         if not harness.options.quiet or not result.res.is_ok():
             self.flush()
-            if harness.options.verbose and not result.is_parallel and result.cmdline:
-                if not result.needs_parsing:
-                    print(self.output_end)
+            if harness.options.verbose and not result.is_parallel and result.cmdline and not result.needs_parsing:
+                print(self.output_end)
                 print(harness.format(result, mlog.colorize_console(), max_left_width=self.max_left_width))
             else:
                 print(harness.format(result, mlog.colorize_console(), max_left_width=self.max_left_width),


### PR DESCRIPTION
Verbose, non-parallel tests generally print their output as they run, rather than
after they finish.  This however is not the case if stdout of the test is parsed
as is the case for TAP and Rust tests.  In this case, the output during the run
is the list of the subtests, but stderr still has to be printed after the test
finishes.

Conflicts:
	mesonbuild/mtest.py [use harness.options.verbose instead of result.verbose]