### PR TITLE
fix regression in vcs_tag when the VCS program is not installed

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -1055,7 +1055,7 @@ def detect_rust_compiler(env: 'Environment', for_machine: MachineChoice) -> Rust
                 else:
                     linker = type(cc.linker)(compiler, for_machine, cc.LINKER_PREFIX,
                                              always_args=always_args, version=cc.linker.version,
-                                             **extra_args) # type: ignore
+                                             **extra_args)
             elif 'link' in override[0]:
                 linker = guess_win_linker(env,
                                           override, cls, for_machine, use_linker_prefix=False)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1728,7 +1728,9 @@ external dependencies (including libraries) must go to "dependencies".''')
         vcs_cmd = kwargs['command']
         source_dir = os.path.normpath(os.path.join(self.environment.get_source_dir(), self.subdir))
         if vcs_cmd:
-            vcs_cmd[0] = self.find_program_impl(vcs_cmd[0])
+            maincmd = self.find_program_impl(vcs_cmd[0], required=False)
+            if maincmd.found():
+                vcs_cmd[0] = maincmd
         else:
             vcs = mesonlib.detect_vcs(source_dir)
             if vcs:

--- a/test cases/common/66 vcstag/meson.build
+++ b/test cases/common/66 vcstag/meson.build
@@ -9,9 +9,15 @@ output : 'vcstag-custom.c',
 command : ['git', 'show-ref', '-s', 'refs/heads/master'],
 fallback : '1.0.0')
 
+version_src_notfound_fallback = vcs_tag(input : 'vcstag.c.in',
+output : 'vcstag-notfound-fallback.c',
+command : ['git-but-not-found-sorry', 'show-ref', '-s', 'refs/heads/master'],
+fallback : '1.0.0')
+
 version_src_fallback = vcs_tag(input : 'vcstag.c.in',
 output : 'vcstag-fallback.c')
 
 executable('tagprog', 'tagprog.c', version_src)
 executable('tagprog-custom', 'tagprog.c', version_src_custom)
 executable('tagprog-fallback', 'tagprog.c', version_src_fallback)
+executable('tagprog-notfound-fallback', 'tagprog.c', version_src_notfound_fallback)


### PR DESCRIPTION
We are supposed to fallback on the fallback when running the vcstagger, but instead we errored out during configure.

Fixes regression in commit b402817fb6f0392812bfa272bdbc05c9c30139fa. Before this, we used shutil.which || relative paths, and in the latter case if it could not be found we still wrote out that path but it failed to run in vcstagger. Now, we use find_program under the hood, so it needs to be run in non-fatal mode, and if it is not found, we simply keep the original command string. It's a VCS command, so if we magically end up finding it at runtime because it was installed after running configure, that is *fine*.