### PR TITLE
D compiler checks

### DIFF
--- a/docs/markdown/snippets/d_compiler_checks.md
+++ b/docs/markdown/snippets/d_compiler_checks.md
@@ -1,0 +1,13 @@
+## D compiler checks
+
+Some compiler checks are implemented for D:
+ - `run`
+ - `sizeof`
+ - `has_header` (to check if a module is present)
+ - `alignment`
+
+Example:
+
+```meson
+ptr_size = meson.get_compiler('d').sizeof('void*')
+```

--- a/test cases/d/14 dub with deps/meson.build
+++ b/test cases/d/14 dub with deps/meson.build
@@ -1,4 +1,4 @@
-project('dub-with-deps-example', ['c', 'd'])
+project('dub-with-deps-example', ['d'])
 
 dub_exe = find_program('dub', required : false)
 if not dub_exe.found()
@@ -17,7 +17,7 @@ arch = host_machine.cpu_family()
 
 if host_machine.system() == 'windows'
     # check if toolchain is 32bits
-    sz = meson.get_compiler('c').sizeof('void*')
+    sz = meson.get_compiler('d').sizeof('void*')
     if arch == 'x86' or sz == 4
         arch = 'x86_mscoff'
     endif

--- a/test cases/d/15 compiler run checks/meson.build
+++ b/test cases/d/15 compiler run checks/meson.build
@@ -1,0 +1,50 @@
+project('test-d-run-checks', 'd')
+
+dc = meson.get_compiler('d')
+
+run_sizeof = dc.run('int main() { return (void*).sizeof; }')
+if run_sizeof.returncode() == 8
+    run_versions = ['Is64bits']
+elif run_sizeof.returncode() == 4
+    run_versions = ['Is32bits']
+endif
+run_sizeof_exe = executable('run_sizeof', 'test_sizeof.d',
+    d_module_versions: run_versions,
+)
+test('test D compiler run', run_sizeof_exe)
+
+sizeof_sizeof = dc.sizeof('void*')
+if sizeof_sizeof == 8
+    run_versions = ['Is64bits']
+elif sizeof_sizeof == 4
+    run_versions = ['Is32bits']
+endif
+sizeof_sizeof_exe = executable('sizeof_sizeof', 'test_sizeof.d',
+    d_module_versions: run_versions,
+)
+test('test D compiler sizeof', sizeof_sizeof_exe)
+
+if not dc.has_header('std.stdio')
+    error('Could not find std.stdio import')
+endif
+
+if dc.has_header('not_a_d_module')
+    error('has_header inconsistent result')
+endif
+
+# same checks as C/C++ alignments (D has same alignment requirements as C)
+
+# These tests should return the same value on all
+# platforms. If (and when) they don't, fix 'em up.
+if dc.alignment('char') != 1
+error('Alignment of char misdetected.')
+endif
+
+dbl_alignment = dc.alignment('double')
+
+if dbl_alignment == 8 or dbl_alignment == 4
+message('Alignment of double ok.')
+else
+error('Alignment of double misdetected.')
+endif
+

--- a/test cases/d/15 compiler run checks/test_sizeof.d
+++ b/test cases/d/15 compiler run checks/test_sizeof.d
@@ -1,0 +1,17 @@
+module test_sizeof;
+
+alias voidp = void*;
+
+int main()
+{
+    version(Is64bits) {
+        enum expectedSz = 8;
+    }
+    else version(Is32bits) {
+        enum expectedSz = 4;
+    }
+    else {
+        assert(false, "No version set!");
+    }
+    return expectedSz == voidp.sizeof ? 0 : 1;
+}


### PR DESCRIPTION
Implement and test a few compiler checks for D:
 - run
 - sizeof
 - has_header
 - alignment

May be a function to test built-in D versions would be useful too, but that would be specific to D.
Something like:
```meson
meson.get_compiler('d').has_version('LittleEndian')
```