### PR TITLE
gnome module: fix crash due to misused function while generating gir command

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -1132,9 +1132,9 @@ class GnomeModule(ExtensionModule):
         scan_command += ['-I' + srcdir, '-I' + builddir]
         scan_command += state.get_include_args(girtargets_inc_dirs)
         scan_command += ['--filelist=' + self._make_gir_filelist(state, srcdir, ns, nsversion, girtargets, libsources)]
-        scan_command += mesonlib.listify([self._get_link_args(state, l, depends, use_gir_args=True)
-                                          for l in kwargs['link_with']])
-
+        for l in kwargs['link_with']:
+            _cflags, depends = self._get_link_args(state, l, depends, use_gir_args=True)
+            scan_command.extend(_cflags)
         _cmd, _ginc, _deps = self._scan_include(state, kwargs['includes'])
         scan_command.extend(_cmd)
         gir_inc_dirs.extend(_ginc)


### PR DESCRIPTION
In commit 68e684d51f1e469e0d9f4b499ffda15146cad98a the _get_link_args function was modified from returning a list[str] of arguments, to a tuple of both that and a modified copy of the entire target's current/enhanced dependencies (why not just the new ones? I don't know).

However, the existing use of the function was not adapted to this change, and tried to turn this entire tuple into a node of the command line. Tuples cannot flatten to lists, and mesonlib.File or HoldableObjects don't make good command line arguments.

As a result we errored out with:

```
ERROR: Argument (['-L/path/to/builddir/', '--extra-library=foo'], [<SharedLibrary 25a6634@@foo@sha: foo>, <SharedLibrary 25a6634@@foo@sha: foo>, <SharedLibrary 25a6634@@foo@sha: foo>]) in "command" is invalid
```

Split out the flags and the dependencies and update the former while replacing the latter.
