### PR TITLE
Fix sourceset breakage after mypy conversion

### DIFF
--- a/mesonbuild/modules/sourceset.py
+++ b/mesonbuild/modules/sourceset.py
@@ -61,21 +61,21 @@ class SourceSetRule(T.NamedTuple):
     keys: T.List[str]
     """Configuration keys that enable this rule if true"""
 
-    sources: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes]]
-    """Source files added when this rule's conditions are true"""
-
-    if_false: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes]]
-    """Source files added when this rule's conditons are false"""
-
-    sourcesets: T.List[SourceSetImpl]
-    """Other sourcesets added when this rule's conditions are true"""
-
     deps: T.List[dependencies.Dependency]
     """Dependencies that enable this rule if true"""
+
+    sources: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes]]
+    """Source files added when this rule's conditions are true"""
 
     extra_deps: T.List[dependencies.Dependency]
     """Dependencies added when this rule's conditions are true, but
        that do not make the condition false if they're absent."""
+
+    sourcesets: T.List[SourceSetImpl]
+    """Other sourcesets added when this rule's conditions are true"""
+
+    if_false: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes]]
+    """Source files added when this rule's conditons are false"""
 
 
 class SourceFiles(T.NamedTuple):
@@ -172,7 +172,7 @@ class SourceSetImpl(SourceSet, MutableModuleObject):
         keys, dependencies = self.check_conditions(when)
         sources, extra_deps = self.check_source_files(if_true)
         if_false, _ = self.check_source_files(if_false)
-        self.rules.append(SourceSetRule(keys, sources, if_false, [], dependencies, extra_deps))
+        self.rules.append(SourceSetRule(keys, dependencies, sources, extra_deps, [], if_false))
 
     @typed_pos_args('sourceset.add_all', varargs=SourceSet)
     @typed_kwargs(
@@ -200,7 +200,7 @@ class SourceSetImpl(SourceSet, MutableModuleObject):
             if not isinstance(s, SourceSetImpl):
                 raise InvalidCode('Arguments to \'add_all\' after the first must be source sets')
             s.frozen = True
-        self.rules.append(SourceSetRule(keys, [], [], if_true, dependencies, []))
+        self.rules.append(SourceSetRule(keys, dependencies, [], [], if_true, []))
 
     def collect(self, enabled_fn: T.Callable[[str], bool],
                 all_sources: bool,

--- a/mesonbuild/modules/sourceset.py
+++ b/mesonbuild/modules/sourceset.py
@@ -59,8 +59,8 @@ _WHEN_KW: KwargInfo[T.List[T.Union[str, dependencies.Dependency]]] = KwargInfo(
 
 class SourceSetRule(T.NamedTuple):
     keys: T.List[str]
-    sources: T.Any
-    if_false: T.Any
+    sources: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes]]
+    if_false: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes]]
     sourcesets: T.List[SourceSetImpl]
     deps: T.List[dependencies.Dependency]
     extra_deps: T.List[dependencies.Dependency]

--- a/mesonbuild/modules/sourceset.py
+++ b/mesonbuild/modules/sourceset.py
@@ -62,12 +62,12 @@ class SourceSetRule(T.NamedTuple):
     sources: T.Any
     if_false: T.Any
     sourcesets: T.List[SourceSetImpl]
-    dependencies: T.List[dependencies.Dependency]
+    deps: T.List[dependencies.Dependency]
 
 
 class SourceFiles(T.NamedTuple):
     sources: OrderedSet[T.Union[mesonlib.FileOrString, build.GeneratedTypes]]
-    dependencies: OrderedSet[dependencies.Dependency]
+    deps: OrderedSet[dependencies.Dependency]
 
 
 class SourceSet:
@@ -195,10 +195,10 @@ class SourceSetImpl(SourceSet, MutableModuleObject):
         if not into:
             into = SourceFiles(OrderedSet(), OrderedSet())
         for entry in self.rules:
-            if all(x.found() for x in entry.dependencies) and \
+            if all(x.found() for x in entry.deps) and \
                all(enabled_fn(key) for key in entry.keys):
                 into.sources.update(entry.sources)
-                into.dependencies.update(entry.dependencies)
+                into.deps.update(entry.deps)
                 for ss in entry.sourcesets:
                     ss.collect(enabled_fn, all_sources, into)
                 if not all_sources:
@@ -221,7 +221,7 @@ class SourceSetImpl(SourceSet, MutableModuleObject):
                                 ) -> T.List[dependencies.Dependency]:
         self.frozen = True
         files = self.collect(lambda x: True, True)
-        return list(files.dependencies)
+        return list(files.deps)
 
     @typed_pos_args('sourceset.apply', (build.ConfigurationData, dict))
     @typed_kwargs('sourceset.apply', KwargInfo('strict', bool, default=True))
@@ -272,7 +272,7 @@ class SourceFilesObject(ModuleObject):
     @noKwargs
     def dependencies_method(self, state: ModuleState, args: T.List[TYPE_var], kwargs: TYPE_kwargs
                             ) -> T.List[dependencies.Dependency]:
-        return list(self.files.dependencies)
+        return list(self.files.deps)
 
 class SourceSetModule(ExtensionModule):
     @FeatureNew('SourceSet module', '0.51.0')

--- a/mesonbuild/modules/sourceset.py
+++ b/mesonbuild/modules/sourceset.py
@@ -59,11 +59,23 @@ _WHEN_KW: KwargInfo[T.List[T.Union[str, dependencies.Dependency]]] = KwargInfo(
 
 class SourceSetRule(T.NamedTuple):
     keys: T.List[str]
+    """Configuration keys that enable this rule if true"""
+
     sources: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes]]
+    """Source files added when this rule's conditions are true"""
+
     if_false: T.List[T.Union[mesonlib.FileOrString, build.GeneratedTypes]]
+    """Source files added when this rule's conditons are false"""
+
     sourcesets: T.List[SourceSetImpl]
+    """Other sourcesets added when this rule's conditions are true"""
+
     deps: T.List[dependencies.Dependency]
+    """Dependencies that enable this rule if true"""
+
     extra_deps: T.List[dependencies.Dependency]
+    """Dependencies added when this rule's conditions are true, but
+       that do not make the condition false if they're absent."""
 
 
 class SourceFiles(T.NamedTuple):

--- a/test cases/common/212 source set configuration_data/meson.build
+++ b/test cases/common/212 source set configuration_data/meson.build
@@ -8,7 +8,7 @@ source_set = import('sourceset')
 
 sources = source_set.source_set()
 sources.add(when: 'YES',  if_false: ['nope.c'])
-sources.add(when: 'YES1', if_true: files('a.c'))
+sources.add(when: 'YES1', if_true: [files('a.c'), not_found])
 subdir('subdir')
 sources.add(when: 'NO',   if_true: 'nope.c', if_false: ['f.c'])
 sources.add(when: 'NO',   if_true: bad,      if_false: ['f.c'])
@@ -24,7 +24,7 @@ sources2.add(when: 'YES1',  if_true: 'nope.c')
 sources.add_all(when: 'NO', if_true: sources2)
 
 # test duplicate items
-sources.add(when: 'YES1',   if_true: files('a.c'))
+sources.add(when: 'YES1',   if_true: [files('a.c'), not_found])
 
 conf1 = configuration_data()
 conf1.set10('YES', true)


### PR DESCRIPTION
Dependencies in the `if_true` keyword argument do not prevent the
sources from being used; in other words, they work just like dependencies
with `disabler: false`.
    
However, this was broken in commit ab0ffc6a2 ("modules/sourceset: Fix
remaining typing issues", 2022-02-23) which changed logic instead of
just fixing typing issues.  This was likely an attempt to avoid using
`dependencies.Dependency` after the "dependencies" field was declared,
but it also broke QEMU.