### PR TITLE
python: Remove warning about invalid install path

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -364,7 +364,6 @@ print(json.dumps({
   'paths': paths,
   'sysconfig_paths': sysconfig.get_paths(),
   'install_paths': install_paths,
-  'sys_paths': sys.path,
   'version': sysconfig.get_python_version(),
   'platform': sysconfig.get_platform(),
   'is_pypy': '__pypy__' in sys.builtin_module_names,
@@ -454,14 +453,6 @@ class PythonExternalProgram(ExternalProgram):
             # inside a venv, deb_system is *never* active hence info['paths'] may be wrong
             rel_path = self.info['sysconfig_paths'][key]
 
-        # Use python's path relative to prefix, and warn if that's not a location
-        # python will lookup for modules.
-        abs_path = Path(state.get_option('prefix'), rel_path)
-        sys_paths = [Path(i) for i in self.info['sys_paths']]
-        if abs_path not in sys_paths:
-            mlog.warning('Python files installed by Meson might not be found by python interpreter.\n',
-                         f'This warning can be avoided by setting "python.{key}dir" option.',
-                         once=True)
         return rel_path
 
 


### PR DESCRIPTION
It was originally added because proper detection was not working on
Debian, but that has been fixed since. It was causing annoying warning
by default when prefix is /usr/local that can only be avoided by setting
options.