### PR TITLE
coredata: be even more robust on unpickling errors

### DIFF
--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1036,7 +1036,7 @@ def load(build_dir: str) -> CoreData:
             obj = pickle.load(f)
     except (pickle.UnpicklingError, EOFError):
         raise MesonException(load_fail_msg)
-    except (ModuleNotFoundError, AttributeError):
+    except (TypeError, ModuleNotFoundError, AttributeError):
         raise MesonException(
             f"Coredata file {filename!r} references functions or classes that don't "
             "exist. This probably means that it was generated with an old "


### PR DESCRIPTION
When reverting from 0.62 to 0.59, one can see an error like this:
    
    line 1003, in load
        obj = pickle.load(f)
      File "/Users/pm215/src/qemu-for-merges/meson/mesonbuild/mesonlib/universal.py",
    line 2076, in __setstate__
        self.__init__(**state)  # type: ignore
    TypeError: __init__() got an unexpected keyword argument 'module'
    FAILED: build.ninja
    
Raise a MesonException for TypeError as well, so that reconfiguration
proceeds using cmd_line.txt.