### PR TITLE
fix detection of language standard library paths

### DIFF
--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -251,11 +251,9 @@ class ClangCPPCompiler(ClangCompiler, CPPCompiler):
         # be passed to a different compiler with a different set of default
         # search paths, such as when using Clang for C/C++ and gfortran for
         # fortran,
-        search_dir = self._get_search_dirs(env)
         search_dirs: T.List[str] = []
-        if search_dir is not None:
-            for d in search_dir.split()[-1][len('libraries: ='):].split(':'):
-                search_dirs.append(f'-L{d}')
+        for d in self.get_compiler_dirs(env, 'libraries'):
+            search_dirs.append(f'-L{d}')
         return search_dirs + ['-lstdc++']
 
 
@@ -270,11 +268,9 @@ class AppleClangCPPCompiler(ClangCPPCompiler):
         # be passed to a different compiler with a different set of default
         # search paths, such as when using Clang for C/C++ and gfortran for
         # fortran,
-        search_dir = self._get_search_dirs(env)
         search_dirs: T.List[str] = []
-        if search_dir is not None:
-            for d in search_dir.split()[-1][len('libraries: ='):].split(':'):
-                search_dirs.append(f'-L{d}')
+        for d in self.get_compiler_dirs(env, 'libraries'):
+            search_dirs.append(f'-L{d}')
         return search_dirs + ['-lc++']
 
 
@@ -430,11 +426,9 @@ class GnuCPPCompiler(GnuCompiler, CPPCompiler):
         # be passed to a different compiler with a different set of default
         # search paths, such as when using Clang for C/C++ and gfortran for
         # fortran,
-        search_dir = self._get_search_dirs(env)
         search_dirs: T.List[str] = []
-        if search_dir is not None:
-            for d in search_dir.split()[-1][len('libraries: ='):].split(':'):
-                search_dirs.append(f'-L{d}')
+        for d in self.get_compiler_dirs(env, 'libraries'):
+            search_dirs.append(f'-L{d}')
         return ['-lstdc++']
 
 

--- a/mesonbuild/compilers/fortran.py
+++ b/mesonbuild/compilers/fortran.py
@@ -215,11 +215,9 @@ class GnuFortranCompiler(GnuCompiler, FortranCompiler):
         # be passed to a different compiler with a different set of default
         # search paths, such as when using Clang for C/C++ and gfortran for
         # fortran,
-        search_dir = self._get_search_dirs(env)
         search_dirs: T.List[str] = []
-        if search_dir is not None:
-            for d in search_dir.split()[-1][len('libraries: ='):].split(':'):
-                search_dirs.append(f'-L{d}')
+        for d in self.get_compiler_dirs(env, 'libraries'):
+            search_dirs.append(f'-L{d}')
         return search_dirs + ['-lgfortran', '-lm']
 
     def has_header(self, hname: str, prefix: str, env: 'Environment', *,
@@ -482,11 +480,9 @@ class FlangFortranCompiler(ClangCompiler, FortranCompiler):
         # search paths, such as when using Clang for C/C++ and gfortran for
         # fortran,
         # XXX: Untested....
-        search_dir = self._get_search_dirs(env)
         search_dirs: T.List[str] = []
-        if search_dir is not None:
-            for d in search_dir.split()[-1][len('libraries: ='):].split(':'):
-                search_dirs.append(f'-L{d}')
+        for d in self.get_compiler_dirs(env, 'libraries'):
+            search_dirs.append(f'-L{d}')
         return search_dirs + ['-lflang', '-lpgmath']
 
 class ArmLtdFlangFortranCompiler(FlangFortranCompiler):


### PR DESCRIPTION
The code in the C++ and Fortran compilers' `language_stdlib_only_link_flags` method is broken and cannot possibly have ever worked.  Instead of splitting by line, it splits by whitespace and therefore, instead of the last line of the compiler output:

 programs: =/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
libraries: =/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/12.0.0

it is only the last field that has its first 11 characters removed. Instead of reinventing the wheel with a new and brittle pattern, reuse get_compiler_dirs.

Fixes: 64c267c49 ("compilers: Add default search path stdlib_only_link_flags", 2021-09-25)
Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>