### PR TITLE
wrap: use shared function to connect to wrapdb with better errors

### DIFF
--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -132,9 +132,9 @@ class Runner:
             branch, revision = wraptool.parse_patch_url(patch_url)
         except WrapException:
             return
-        new_branch, new_revision = wraptool.get_latest_version(self.wrap.name)
+        new_branch, new_revision = wraptool.get_latest_version(self.wrap.name, self.options.allow_insecure)
         if new_branch != branch or new_revision != revision:
-            wraptool.update_wrap_file(self.wrap.filename, self.wrap.name, new_branch, new_revision)
+            wraptool.update_wrap_file(self.wrap.filename, self.wrap.name, new_branch, new_revision, self.options.allow_insecure)
             self.log('  -> New wrap file downloaded.')
 
     def update_file(self) -> bool:

--- a/mesonbuild/msubprojects.py
+++ b/mesonbuild/msubprojects.py
@@ -25,6 +25,7 @@ if T.TYPE_CHECKING:
         subprojects: T.List[str]
         types: str
         subprojects_func: T.Callable[[], bool]
+        allow_insecure: bool
 
     class UpdateArguments(Arguments):
         rebase: bool
@@ -575,6 +576,8 @@ def add_common_arguments(p: argparse.ArgumentParser) -> None:
                    help=f'Comma-separated list of subproject types. Supported types are: {ALL_TYPES_STRING} (default: all)')
     p.add_argument('--num-processes', default=None, type=int,
                    help='How many parallel processes to use (Since 0.59.0).')
+    p.add_argument('--allow-insecure', default=False, action='store_true',
+                   help='Allow insecure server connections.')
 
 def add_subprojects_argument(p: argparse.ArgumentParser) -> None:
     p.add_argument('subprojects', nargs='*',
@@ -643,7 +646,7 @@ def run(options: 'Arguments') -> int:
     if not os.path.isdir(subprojects_dir):
         mlog.log('Directory', mlog.bold(src_dir), 'does not seem to have subprojects.')
         return 0
-    r = Resolver(src_dir, 'subprojects')
+    r = Resolver(src_dir, 'subprojects', wrap_frontend=True, allow_insecure=options.allow_insecure)
     if options.subprojects:
         wraps = [wrap for name, wrap in r.wraps.items() if name in options.subprojects]
     else:

--- a/mesonbuild/wrap/wraptool.py
+++ b/mesonbuild/wrap/wraptool.py
@@ -20,8 +20,7 @@ import typing as T
 
 from glob import glob
 from urllib.parse import urlparse
-from urllib.request import urlopen
-from .wrap import WrapException
+from .wrap import open_wrapdburl, WrapException
 
 from .. import mesonlib
 
@@ -59,7 +58,7 @@ def add_arguments(parser: 'argparse.ArgumentParser') -> None:
     p.set_defaults(wrap_func=promote)
 
 def get_releases() -> T.Dict[str, T.Any]:
-    url = urlopen('https://wrapdb.mesonbuild.com/v2/releases.json')
+    url = open_wrapdburl('https://wrapdb.mesonbuild.com/v2/releases.json')
     return T.cast('T.Dict[str, T.Any]', json.loads(url.read().decode()))
 
 def list_projects(options: 'argparse.Namespace') -> None:
@@ -97,7 +96,7 @@ def install(options: 'argparse.Namespace') -> None:
     if os.path.exists(wrapfile):
         raise SystemExit('Wrap file already exists.')
     (version, revision) = get_latest_version(name)
-    url = urlopen(f'https://wrapdb.mesonbuild.com/v2/{name}_{version}-{revision}/{name}.wrap')
+    url = open_wrapdburl(f'https://wrapdb.mesonbuild.com/v2/{name}_{version}-{revision}/{name}.wrap')
     with open(wrapfile, 'wb') as f:
         f.write(url.read())
     print(f'Installed {name} version {version} revision {revision}')
@@ -140,7 +139,7 @@ def get_current_version(wrapfile: str) -> T.Tuple[str, str, str, str, T.Optional
     return branch, revision, wrap_data['directory'], wrap_data['source_filename'], patch_filename
 
 def update_wrap_file(wrapfile: str, name: str, new_version: str, new_revision: str) -> None:
-    url = urlopen(f'https://wrapdb.mesonbuild.com/v2/{name}_{new_version}-{new_revision}/{name}.wrap')
+    url = open_wrapdburl(f'https://wrapdb.mesonbuild.com/v2/{name}_{new_version}-{new_revision}/{name}.wrap')
     with open(wrapfile, 'wb') as f:
         f.write(url.read())
 


### PR DESCRIPTION
We currently inconsistently handle connection, `has_ssl`, and printing errors on urlopen failure between `meson subprojects` and `meson wrap`.

Make the latter work more like the former.