### PR TITLE
tests: don't skip python version tests if python is found but its dep is broken [merged but github broke right then]

### DIFF
--- a/test cases/python/8 different python versions/meson.build
+++ b/test cases/python/8 different python versions/meson.build
@@ -6,18 +6,14 @@ py_mod = import('python')
 py = py_mod.find_installation(get_option('python'), required : false)
 
 if py.found()
-  py_dep = py.dependency(required : false)
+  py_dep = py.dependency()
 
-  if py_dep.found()
-    subdir('ext')
+  subdir('ext')
 
-    test('extmod',
-      py,
-      args : files('blaster.py'),
-      env : ['PYTHONPATH=' + pypathdir])
-  else
-    error('MESON_SKIP_TEST: Python libraries not found, skipping test.')
-  endif
+  test('extmod',
+    py,
+    args : files('blaster.py'),
+    env : ['PYTHONPATH=' + pypathdir])
 else
   error('MESON_SKIP_TEST: Python not found, skipping test.')
 endif


### PR DESCRIPTION
If a version of python is installed for testing against, we should assume it's actually important to test against it.