### PR TITLE
python module: windows dll name for pypy needs special casing

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -65,6 +65,8 @@ jobs:
             git
             mercurial
             lcov
+            wget
+            unzip
             mingw-w64-${{ matrix.MSYS2_ARCH }}-cmake
             mingw-w64-${{ matrix.MSYS2_ARCH }}-glib2
             mingw-w64-${{ matrix.MSYS2_ARCH }}-libxml2
@@ -81,8 +83,26 @@ jobs:
         run: |
           python3 -m pip --disable-pip-version-check install gcovr jsonschema pefile pytest pytest-subtests pytest-xdist coverage codecov
 
+      - name: Install pypy3 on x86_64
+        run: |
+          mkdir pypy3local
+          pushd pypy3local
+          wget -nv https://downloads.python.org/pypy/pypy3.8-v7.3.9-win64.zip
+          unzip pypy3.8-v7.3.9-win64.zip
+          mv pypy3.8-v7.3.9-win64/* ./
+          popd
+        if: ${{ matrix.MSYS2_ARCH == 'x86_64' }}
+
       - name: Run Tests
         run: |
+          if [[ "${{ matrix.MSYS2_ARCH }}" == "x86_64" ]]; then
+            # There apparently is no clean way to add to the PATH in the 
+            # previous step?
+            # See for instance https://github.com/msys2/setup-msys2/issues/171
+            export PATH=$PATH:$PWD/pypy3local
+            # Make sure it is on the PATH
+            pypy3 -c "import sys; print(sys.version)"
+          fi
           export BOOST_ROOT=
           export PATHEXT="$PATHEXT;.py"
 

--- a/ci/run.ps1
+++ b/ci/run.ps1
@@ -54,18 +54,26 @@ echo "Extracting ci_data.zip"
 Expand-Archive $env:AGENT_WORKFOLDER\ci_data.zip -DestinationPath $env:AGENT_WORKFOLDER\ci_data
 & "$env:AGENT_WORKFOLDER\ci_data\install.ps1" -Arch $env:arch -Compiler $env:compiler -Boost $true -DMD $dmd
 
+if ($env:arch -eq 'x64') {
+    DownloadFile -Source https://downloads.python.org/pypy/pypy3.8-v7.3.9-win64.zip -Destination $env:AGENT_WORKFOLDER\pypy38.zip
+    Expand-Archive $env:AGENT_WORKFOLDER\pypy38.zip -DestinationPath $env:AGENT_WORKFOLDER\pypy38
+    $ENV:Path = $ENV:Path + ";$ENV:AGENT_WORKFOLDER\pypy38\pypy3.8-v7.3.9-win64;$ENV:AGENT_WORKFOLDER\pypy38\pypy3.8-v7.3.9-win64\Scripts"
+    pypy3 -m ensurepip
+}
+
 
 echo "=== PATH BEGIN ==="
 echo ($env:Path).Replace(';',"`n")
 echo "=== PATH END ==="
 echo ""
 
-$progs = @("python","ninja","pkg-config","cl","rc","link")
+$progs = @("python","ninja","pkg-config","cl","rc","link","pypy3")
 foreach ($prog in $progs) {
   echo ""
   echo "Locating ${prog}:"
   where.exe $prog
 }
+
 
 echo ""
 echo "Ninja / MSBuld version:"

--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -186,12 +186,20 @@ class PythonSystemDependency(SystemDependency, _PythonDependencyBase):
     def _get_windows_link_args(self) -> T.Optional[T.List[str]]:
         if self.platform.startswith('win'):
             vernum = self.variables.get('py_version_nodot')
+            verdot = self.variables.get('py_version_short')
+            imp_lower = self.variables.get('implementation_lower', 'python')
             if self.static:
                 libpath = Path('libs') / f'libpython{vernum}.a'
             else:
                 comp = self.get_compiler()
                 if comp.id == "gcc":
-                    libpath = Path(f'python{vernum}.dll')
+                    if imp_lower == 'pypy' and verdot == '3.8':
+                        # The naming changed between 3.8 and 3.9
+                        libpath = Path(f'libpypy3-c.dll')
+                    elif imp_lower == 'pypy':
+                        libpath = Path(f'libpypy{verdot}-c.dll')
+                    else:
+                        libpath = Path(f'python{vernum}.dll')
                 else:
                     libpath = Path('libs') / f'python{vernum}.lib'
             # base_prefix to allow for virtualenvs.

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -651,7 +651,8 @@ def _run_test(test: TestDef,
     (returncode, stdo, stde) = run_configure(gen_args, env=test.env, catch_exception=True)
     try:
         logfile = Path(test_build_dir, 'meson-logs', 'meson-log.txt')
-        mesonlog = logfile.open(errors='ignore', encoding='utf-8').read()
+        with logfile.open(errors='ignore', encoding='utf-8') as fid:
+            mesonlog = fid.read()
     except Exception:
         mesonlog = no_meson_log_msg
     cicmds = run_ci_commands(mesonlog)


### PR DESCRIPTION
Fix one source of problems when using meson with PyPy3: the name of the DLL. 

Along the way, fix a file descriptor being left open.