### PR TITLE
tests: make python2 dependency on 32-bit windows non-fatal

### DIFF
--- a/test cases/python/8 different python versions/meson.build
+++ b/test cases/python/8 different python versions/meson.build
@@ -5,15 +5,27 @@ py_mod = import('python')
 
 py = py_mod.find_installation(get_option('python'), required : false)
 
+# CI images don't have 32-bit python2 for 32-bit windows,
+# so this actually gets detected then fails
+require = not (
+  get_option('python') == 'python2' and
+  host_machine.system() == 'windows' and
+  host_machine.cpu() == 'x86'
+)
+
 if py.found()
-  py_dep = py.dependency()
+  py_dep = py.dependency(required: require)
 
-  subdir('ext')
+  if py_dep.found()
+    subdir('ext')
 
-  test('extmod',
-    py,
-    args : files('blaster.py'),
-    env : ['PYTHONPATH=' + pypathdir])
+    test('extmod',
+      py,
+      args : files('blaster.py'),
+      env : ['PYTHONPATH=' + pypathdir])
+  else
+    error('MESON_SKIP_TEST: Python libraries not found, skipping test.')
+  endif
 else
   error('MESON_SKIP_TEST: Python not found, skipping test.')
 endif


### PR DESCRIPTION
Apparently Azure provides 64-bit python2 when we try to test 32-bit, and that breaks everything on the 32-bit test runner.

I don't understand the environment setup, and that runner is disappearing soon anyway. Hopefully this shuts up the known breakage.