### PR TITLE
ninjabackend: Split preprocessing .S files and compiling .s files

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -820,7 +820,7 @@ class Backend:
         # Filter out headers and all non-source files
         sources: T.List['FileOrString'] = []
         for s in raw_sources:
-            if self.environment.is_source(s) and not self.environment.is_header(s):
+            if self.environment.is_source(s):
                 sources.append(s)
             elif self.environment.is_object(s):
                 result.append(s.relative_name())

--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -774,7 +774,7 @@ class Backend:
             fname = fname.replace(ch, '_')
         return fname
 
-    def object_filename_from_source(self, target: build.BuildTarget, source: 'FileOrString') -> str:
+    def object_filename_from_source(self, target: build.BuildTarget, source: 'FileOrString', obj_suffix: T.Optional[str] = None) -> str:
         assert isinstance(source, mesonlib.File)
         build_dir = self.environment.get_build_dir()
         rel_src = source.rel_to_builddir(self.build_to_src)
@@ -804,7 +804,8 @@ class Backend:
                 gen_source = os.path.relpath(os.path.join(build_dir, rel_src),
                                              os.path.join(self.environment.get_source_dir(), target.get_subdir()))
         machine = self.environment.machines[target.for_machine]
-        return self.canonicalize_filename(gen_source) + '.' + machine.get_object_suffix()
+        suffix = obj_suffix or machine.get_object_suffix()
+        return self.canonicalize_filename(gen_source) + '.' + suffix
 
     def determine_ext_objs(self, extobj: 'build.ExtractedObjects', proj_dir_to_build_root: str) -> T.List[str]:
         result: T.List[str] = []

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -40,6 +40,7 @@ from ..compilers import (
     mixins,
     PGICCompiler,
     VisualStudioLikeCompiler,
+    CompilerMode
 )
 from ..linkers import ArLinker, RSPFileSyntax
 from ..mesonlib import (
@@ -594,11 +595,12 @@ class NinjaBackend(backends.Backend):
         # TODO: Rather than an explicit list here, rules could be marked in the
         # rule store as being wanted in compdb
         for for_machine in MachineChoice:
-            for lang in self.environment.coredata.compilers[for_machine]:
-                rules += [f"{rule}{ext}" for rule in [self.get_compiler_rule_name(lang, for_machine)]
-                          for ext in ['', '_RSP']]
-                rules += [f"{rule}{ext}" for rule in [self.get_pch_rule_name(lang, for_machine)]
-                          for ext in ['', '_RSP']]
+            for lang, comp in self.environment.coredata.compilers[for_machine].items():
+                for mode in comp.get_compiler_modes():
+                    r = self.compiler_mode_to_rule_name(mode)
+                    rules += [f"{r}{ext}" for ext in ['', '_RSP']]
+                r = self.get_pch_rule_name(lang, for_machine)
+                rules += [f"{r}{ext}" for ext in ['', '_RSP']]
         compdb_options = ['-x'] if mesonlib.version_compare(self.ninja_version, '>=1.9') else []
         ninja_compdb = self.ninja_command + ['-t', 'compdb'] + compdb_options + rules
         builddir = self.environment.get_build_dir()
@@ -1726,15 +1728,19 @@ class NinjaBackend(backends.Backend):
 
     @classmethod
     def get_compiler_rule_name(cls, lang: str, for_machine: MachineChoice) -> str:
-        return '{}_COMPILER{}'.format(lang, cls.get_rule_suffix(for_machine))
+        return f'{lang}_COMPILER{cls.get_rule_suffix(for_machine)}'
 
     @classmethod
     def get_pch_rule_name(cls, lang: str, for_machine: MachineChoice) -> str:
-        return '{}_PCH{}'.format(lang, cls.get_rule_suffix(for_machine))
+        return f'{lang}_PCH{cls.get_rule_suffix(for_machine)}'
 
     @classmethod
     def compiler_to_rule_name(cls, compiler: Compiler) -> str:
         return cls.get_compiler_rule_name(compiler.get_language(), compiler.for_machine)
+
+    @classmethod
+    def compiler_mode_to_rule_name(cls, mode: CompilerMode) -> str:
+        return f'{mode.get_id()}{cls.get_rule_suffix(mode.compiler.for_machine)}'
 
     @classmethod
     def compiler_to_pch_rule_name(cls, compiler: Compiler) -> str:
@@ -2025,7 +2031,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         self.add_rule(NinjaRule(rule, command, args, description, **options))
         self.created_llvm_ir_rule[compiler.for_machine] = True
 
-    def generate_compile_rule_for(self, langname, compiler):
+    def generate_compile_rule_for(self, langname, compiler, mode):
         if langname == 'java':
             self.generate_java_compile_rule(compiler)
             return
@@ -2049,11 +2055,14 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         crstr = self.get_rule_suffix(compiler.for_machine)
         if langname == 'fortran':
             self.generate_fortran_dep_hack(crstr)
-        rule = self.get_compiler_rule_name(langname, compiler.for_machine)
-        depargs = NinjaCommandArg.list(compiler.get_dependency_gen_args('$out', '$DEPFILE'), Quoting.none)
-        command = compiler.get_exelist()
-        args = ['$ARGS'] + depargs + NinjaCommandArg.list(compiler.get_output_args('$out'), Quoting.none) + compiler.get_compile_only_args() + ['$in']
-        description = f'Compiling {compiler.get_display_language()} object $out'
+        rule = self.compiler_mode_to_rule_name(mode)
+        depargs = mode.get_dependency_gen_args('$out', '$DEPFILE')
+        command = mode.get_exelist()
+        args = ['$ARGS']
+        args += NinjaCommandArg.list(depargs, Quoting.none)
+        args += NinjaCommandArg.list(compiler.get_output_args('$out'), Quoting.none)
+        args += compiler.get_compile_only_args() + ['$in']
+        description = mode.get_description('$out')
         if isinstance(compiler, VisualStudioLikeCompiler):
             deps = 'msvc'
             depfile = None
@@ -2103,7 +2112,8 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             for langname, compiler in clist.items():
                 if compiler.get_id() == 'clang':
                     self.generate_llvm_ir_compile_rule(compiler)
-                self.generate_compile_rule_for(langname, compiler)
+                for mode in compiler.get_compiler_modes():
+                    self.generate_compile_rule_for(langname, compiler, mode)
                 self.generate_pch_rule_for(langname, compiler)
 
     def generate_generator_list_rules(self, target):
@@ -2467,6 +2477,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             raise AssertionError(f'BUG: sources should not contain headers {src!r}')
 
         compiler = get_compiler_for_source(target.compilers.values(), src)
+        mode = compiler.get_mode_for_source(src)
 
         commands = self._generate_single_compile_base_args(target, compiler)
 
@@ -2498,8 +2509,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         else:
             raise InvalidArguments(f'Invalid source type: {src!r}')
 
-        opt_proxy = self.get_compiler_options_for_target(target)
-        out_suffix = compiler.get_output_suffix(opt_proxy)
+        out_suffix = mode.get_output_suffix(target.get_options())
         obj_basename = self.object_filename_from_source(target, src, out_suffix)
         rel_obj = os.path.join(self.get_target_private_dir(target), obj_basename)
         dep_file = compiler.depfile_for_object(rel_obj)
@@ -2522,7 +2532,7 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
             arr.append(i)
             pch_dep = arr
 
-        compiler_name = self.compiler_to_rule_name(compiler)
+        compiler_name = self.compiler_mode_to_rule_name(mode)
         extra_deps = []
         if compiler.get_language() == 'fortran':
             # Can't read source file to scan for deps if it's generated later

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -811,7 +811,7 @@ class NinjaBackend(backends.Backend):
         for rel_src in generated_sources.keys():
             dirpart, fnamepart = os.path.split(rel_src)
             raw_src = File(True, dirpart, fnamepart)
-            if self.environment.is_source(rel_src) and not self.environment.is_header(rel_src):
+            if self.environment.is_source(rel_src):
                 if is_unity and self.get_target_source_can_unity(target, rel_src):
                     unity_deps.append(raw_src)
                     abs_src = os.path.join(self.environment.get_build_dir(), rel_src)

--- a/mesonbuild/backend/vs2010backend.py
+++ b/mesonbuild/backend/vs2010backend.py
@@ -1231,14 +1231,14 @@ class Vs2010Backend(backends.Backend):
                     # Unfortunately, we can't use self.object_filename_from_source()
                     for gen in l.genlist:
                         for src in gen.get_outputs():
-                            if self.environment.is_source(src) and not self.environment.is_header(src):
+                            if self.environment.is_source(src):
                                 path = self.get_target_generated_dir(t, gen, src)
                                 gen_src_ext = '.' + os.path.splitext(path)[1][1:]
                                 extra_link_args.append(path[:-len(gen_src_ext)] + '.obj')
 
                     for src in l.srclist:
                         obj_basename = None
-                        if self.environment.is_source(src) and not self.environment.is_header(src):
+                        if self.environment.is_source(src):
                             obj_basename = self.object_filename_from_source(t, src)
                             target_private_dir = self.relpath(self.get_target_private_dir(t),
                                                               self.get_target_dir(t))

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -413,7 +413,7 @@ class ExtractedObjects(HoldableObject):
                 sources.append(s)
 
         # Filter out headers and all non-source files
-        return [s for s in sources if environment.is_source(s) and not environment.is_header(s)]
+        return [s for s in sources if environment.is_source(s)]
 
     def classify_all_sources(self, sources: T.List[FileOrString], generated_sources: T.Sequence['GeneratedTypes']) -> T.Dict['Compiler', T.List['FileOrString']]:
         sources_ = self.get_sources(sources, generated_sources)

--- a/mesonbuild/compilers/__init__.py
+++ b/mesonbuild/compilers/__init__.py
@@ -134,6 +134,7 @@ __all__ = [
 # Bring symbols from each module into compilers sub-package namespace
 from .compilers import (
     Compiler,
+    CompilerMode,
     RunResult,
     all_languages,
     base_options,

--- a/mesonbuild/compilers/c.py
+++ b/mesonbuild/compilers/c.py
@@ -26,7 +26,7 @@ from .mixins.compcert import CompCertCompiler
 from .mixins.ti import TICompiler
 from .mixins.arm import ArmCompiler, ArmclangCompiler
 from .mixins.visualstudio import MSVCCompiler, ClangClCompiler
-from .mixins.gnu import GnuCompiler
+from .mixins.gnu import GnuCompiler, GnuCCPPCompiler
 from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler
 from .mixins.elbrus import ElbrusCompiler
@@ -252,7 +252,7 @@ class ArmclangCCompiler(ArmclangCompiler, CCompiler):
         return []
 
 
-class GnuCCompiler(GnuCompiler, CCompiler):
+class GnuCCompiler(GnuCCPPCompiler, CCompiler):
 
     _C18_VERSION = '>=8.0.0'
     _C2X_VERSION = '>=9.0.0'

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1282,6 +1282,41 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
         """
         return None
 
+    def get_compiler_modes(self) -> T.List['CompilerMode']:
+        """Get a list of CompilerMode.
+
+        Some compilers can have different modes, such as preprocessor or assembler.
+        For each mode a subclass of CompilerMode can be added into this list.
+        """
+        return [CompilerMode(self)]
+
+    def get_mode_for_source(self, source: 'mesonlib.File') -> 'CompilerMode':
+        """Get the CompilerMode for a specific source file.
+
+        For example some file suffixes can only be preprocessed and the result
+        needs to be compiled by another compiler or mode.
+        """
+        return CompilerMode(self)
+
+class CompilerMode:
+    def __init__(self, compiler: Compiler):
+        self.compiler = compiler
+
+    def get_id(self) -> str:
+        return f'{self.compiler.language}_COMPILER'
+
+    def get_description(self, output: str) -> str:
+        return f'Compiling {self.compiler.get_display_language()} object {output}'
+
+    def get_exelist(self, ccache: bool = True) -> T.List[str]:
+        return self.compiler.get_exelist(ccache)
+
+    def get_dependency_gen_args(self, outtarget: str, outfile: str) -> T.List[str]:
+        return self.compiler.get_dependency_gen_args(outtarget, outfile)
+
+    def get_output_suffix(self, options: 'KeyedOptionDictType') -> T.Optional[str]:
+        return self.compiler.get_output_suffix(options)
+
 
 def get_global_options(lang: str,
                        comp: T.Type[Compiler],

--- a/mesonbuild/compilers/compilers.py
+++ b/mesonbuild/compilers/compilers.py
@@ -1126,7 +1126,7 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def get_include_args(self, path: str, is_system: bool) -> T.List[str]:
         return []
 
-    def depfile_for_object(self, objfile: str) -> str:
+    def depfile_for_object(self, objfile: str) -> T.Optional[str]:
         return objfile + '.' + self.get_depfile_suffix()
 
     def get_depfile_suffix(self) -> str:
@@ -1274,6 +1274,13 @@ class Compiler(HoldableObject, metaclass=abc.ABCMeta):
     def get_no_warn_args(self) -> T.List[str]:
         """Arguments to completely disable warnings."""
         return []
+
+    def get_output_suffix(self, options: 'KeyedOptionDictType') -> T.Optional[str]:
+        """Suffix for compiled files, default to platform specific object file suffix.
+
+        Transpilers need to return their intermediary language suffix (e.g. 'c')
+        """
+        return None
 
 
 def get_global_options(lang: str,

--- a/mesonbuild/compilers/cpp.py
+++ b/mesonbuild/compilers/cpp.py
@@ -33,7 +33,7 @@ from .mixins.ccrx import CcrxCompiler
 from .mixins.ti import TICompiler
 from .mixins.arm import ArmCompiler, ArmclangCompiler
 from .mixins.visualstudio import MSVCCompiler, ClangClCompiler
-from .mixins.gnu import GnuCompiler
+from .mixins.gnu import GnuCompiler, GnuCCPPCompiler
 from .mixins.intel import IntelGnuLikeCompiler, IntelVisualStudioLikeCompiler
 from .mixins.clang import ClangCompiler
 from .mixins.elbrus import ElbrusCompiler
@@ -347,7 +347,7 @@ class ArmclangCPPCompiler(ArmclangCompiler, CPPCompiler):
         return []
 
 
-class GnuCPPCompiler(GnuCompiler, CPPCompiler):
+class GnuCPPCompiler(GnuCCPPCompiler, CPPCompiler):
     def __init__(self, exelist: T.List[str], version: str, for_machine: MachineChoice, is_cross: bool,
                  info: 'MachineInfo', exe_wrapper: T.Optional['ExternalProgram'] = None,
                  linker: T.Optional['DynamicLinker'] = None,

--- a/mesonbuild/compilers/cython.py
+++ b/mesonbuild/compilers/cython.py
@@ -85,3 +85,11 @@ class CythonCompiler(Compiler):
         if lang.value == 'cpp':
             args.append('--cplus')
         return args
+
+    def depfile_for_object(self, objfile: str) -> T.Optional[str]:
+        return None
+
+    def get_output_suffix(self, options: 'KeyedOptionDictType') -> str:
+        lang = options[OptionKey('language', machine=self.for_machine, lang=self.language)].value
+        assert isinstance(lang, str), 'for mypy'
+        return lang

--- a/mesonbuild/compilers/mixins/clike.py
+++ b/mesonbuild/compilers/mixins/clike.py
@@ -175,9 +175,6 @@ class CLikeCompiler(Compiler):
     def get_depfile_suffix(self) -> str:
         return 'd'
 
-    def get_exelist(self) -> T.List[str]:
-        return self.exelist.copy()
-
     def get_preprocess_only_args(self) -> T.List[str]:
         return ['-E', '-P']
 
@@ -1194,7 +1191,7 @@ class CLikeCompiler(Compiler):
         if self.id != 'clang':
             raise mesonlib.MesonException('Cannot find framework path with non-clang compiler')
         # Construct the compiler command-line
-        commands = self.get_exelist() + ['-v', '-E', '-']
+        commands = self.get_exelist(ccache=False) + ['-v', '-E', '-']
         commands += self.get_always_args()
         # Add CFLAGS/CXXFLAGS/OBJCFLAGS/OBJCXXFLAGS from the env
         commands += env.coredata.get_external_args(self.for_machine, self.language)

--- a/mesonbuild/compilers/mixins/elbrus.py
+++ b/mesonbuild/compilers/mixins/elbrus.py
@@ -48,7 +48,7 @@ class ElbrusCompiler(GnuLikeCompiler):
     def get_library_dirs(self, env: 'Environment', elf_class: T.Optional[int] = None) -> T.List[str]:
         os_env = os.environ.copy()
         os_env['LC_ALL'] = 'C'
-        stdo = Popen_safe(self.exelist + ['--print-search-dirs'], env=os_env)[1]
+        stdo = Popen_safe(self.get_exelist(ccache=False) + ['--print-search-dirs'], env=os_env)[1]
         for line in stdo.split('\n'):
             if line.startswith('libraries:'):
                 # lcc does not include '=' in --print-search-dirs output. Also it could show nonexistent dirs.
@@ -59,7 +59,7 @@ class ElbrusCompiler(GnuLikeCompiler):
     def get_program_dirs(self, env: 'Environment') -> T.List[str]:
         os_env = os.environ.copy()
         os_env['LC_ALL'] = 'C'
-        stdo = Popen_safe(self.exelist + ['--print-search-dirs'], env=os_env)[1]
+        stdo = Popen_safe(self.get_exelist(ccache=False) + ['--print-search-dirs'], env=os_env)[1]
         for line in stdo.split('\n'):
             if line.startswith('programs:'):
                 # lcc does not include '=' in --print-search-dirs output.
@@ -70,7 +70,7 @@ class ElbrusCompiler(GnuLikeCompiler):
     def get_default_include_dirs(self) -> T.List[str]:
         os_env = os.environ.copy()
         os_env['LC_ALL'] = 'C'
-        p = subprocess.Popen(self.exelist + ['-xc', '-E', '-v', '-'], env=os_env, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p = subprocess.Popen(self.get_exelist(ccache=False) + ['-xc', '-E', '-v', '-'], env=os_env, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stderr = p.stderr.read().decode('utf-8', errors='replace')
         includes = []
         for line in stderr.split('\n'):

--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -183,7 +183,7 @@ class GnuLikeCompiler(Compiler, metaclass=abc.ABCMeta):
         return gnulike_instruction_set_args.get(instruction_set, None)
 
     def get_default_include_dirs(self) -> T.List[str]:
-        return gnulike_default_include_dirs(tuple(self.exelist), self.language).copy()
+        return gnulike_default_include_dirs(tuple(self.get_exelist(ccache=False)), self.language).copy()
 
     @abc.abstractmethod
     def openmp_flags(self) -> T.List[str]:

--- a/mesonbuild/compilers/rust.py
+++ b/mesonbuild/compilers/rust.py
@@ -110,7 +110,7 @@ class RustCompiler(Compiler):
         return rust_buildtype_args[buildtype]
 
     def get_sysroot(self) -> str:
-        cmd = self.exelist + ['--print', 'sysroot']
+        cmd = self.get_exelist(ccache=False) + ['--print', 'sysroot']
         p, stdo, stde = Popen_safe(cmd)
         return stdo.split('\n')[0]
 

--- a/mesonbuild/mesonlib/universal.py
+++ b/mesonbuild/mesonlib/universal.py
@@ -418,6 +418,11 @@ class File(HoldableObject):
         return File(True, subdir, fname)
 
     @staticmethod
+    def from_built_relative(relative: str) -> 'File':
+        dirpart, fnamepart = os.path.split(relative)
+        return File(True, dirpart, fnamepart)
+
+    @staticmethod
     def from_absolute_file(fname: str) -> 'File':
         return File(False, '', fname)
 

--- a/unittests/allplatformstests.py
+++ b/unittests/allplatformstests.py
@@ -957,6 +957,8 @@ class AllPlatformTests(BasePlatformTests):
             if 'Ic-asm' in cmd['command']:
                 if cmd['file'].endswith('.S'):
                     commands['c-asm']['asm'] = compiler
+                elif cmd['file'].endswith('.s'):
+                    pass
                 elif cmd['file'].endswith('.c'):
                     commands['c-asm']['c'] = compiler
                 else:
@@ -964,6 +966,8 @@ class AllPlatformTests(BasePlatformTests):
             elif 'Icpp-asm' in cmd['command']:
                 if cmd['file'].endswith('.S'):
                     commands['cpp-asm']['asm'] = compiler
+                elif cmd['file'].endswith('.s'):
+                    pass
                 elif cmd['file'].endswith('.cpp'):
                     commands['cpp-asm']['cpp'] = compiler
                 else:
@@ -971,6 +975,8 @@ class AllPlatformTests(BasePlatformTests):
             elif 'Ic-cpp-asm' in cmd['command']:
                 if cmd['file'].endswith('.S'):
                     commands['c-cpp-asm']['asm'] = compiler
+                elif cmd['file'].endswith('.s'):
+                    pass
                 elif cmd['file'].endswith('.c'):
                     commands['c-cpp-asm']['c'] = compiler
                 elif cmd['file'].endswith('.cpp'):
@@ -980,6 +986,8 @@ class AllPlatformTests(BasePlatformTests):
             elif 'Icpp-c-asm' in cmd['command']:
                 if cmd['file'].endswith('.S'):
                     commands['cpp-c-asm']['asm'] = compiler
+                elif cmd['file'].endswith('.s'):
+                    pass
                 elif cmd['file'].endswith('.c'):
                     commands['cpp-c-asm']['c'] = compiler
                 elif cmd['file'].endswith('.cpp'):


### PR DESCRIPTION
commit d8737c5930e6e93c292903514a5028abbd0b57f4

    ninjabackend: Split preprocessing .S files and compiling .s files
    
    GCC internally compiles .S files in 2 steps. It first preprocess them
    like any C file which generate a depfile for macros like `#include`. It
    then hand the preprocessed file to GAS that generates its own depfile
    for assembly instructions like `.incbin`. Since Ninja does not support
    targets that generate multiple depfiles we have to split into 2 separate
    Ninja targets.
    
    This has the bonus side effect of opening the door to preprocess
    assembly files using any C compiler, then compile them with a different
    tool such as MASM on Windows.
    
    This is implemented with a new CompilerMode class that is basically a
    small override for a given Compiler object that represents a different
    Ninja rule with different fixed arguments. All other compiler arguments
    (e.g. c_args='-I..') are identical for all modes, so they are not a new
    language at Meson level.

commit 40b618e736cd82136fbf6f9363d92e5f1b049d15

    ninjabackend: Refactor how vala/cython transpilers works
    
    This makes the code path for transpilers more generic to make it easy to
    add new transpilers in the future (e.g. .S -> .s preprocessor). Any
    Compiler class can implement get_output_suffix() method to return the
    file suffix it can transpile to (e.g. cython -> '.c') and their output
    will be handed to another compiler, until we get a final object file.

commit d3d420707f891cddf76fc071dcbcab3ff8040f25

    ninjabackend: Fix get_target_generated_sources() return type
    
    Type annotation, documentation string, and implementation were doing 3
    different things. Change implementation to match type annotation which
    makes the most sense because it match what get_target_sources() does.
    
    All callers only use keys from the returned dictionary any way, but
    that's going to change in next commits.

commit 72a19964046ddb0db1f04713c1edb719b6fe5f0e

    compilers: Make sure to not use ccache in compiler checks
    
    ccache was used in all command lines but disabled using CCACHE_DISABLE
    in Compiler.compile() method. Wrapping invokations still has a cost,
    especially on Windows.
    
    With sccache things are even worse because CCACHE_DISABLE was not
    respected at all, making configure *extremely* slow on Windows when
    sccache is installed.

commit ec2cfa4954d2fcd7fabe9ab97577b572fd65d3b8

    compilers: Cleanup a bit languages/suffixes lists
    
    Use set where order does not matter, fix is_source() to really mean only
    source suffixes.
