### PR TITLE
Cargo subprojects, take two

### DIFF
--- a/mesonbuild/cargo/builder.py
+++ b/mesonbuild/cargo/builder.py
@@ -1,0 +1,284 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2022-2023 Intel Corporation
+
+"""Provides helpers for building AST
+
+This is meant to make building Meson AST from foreign (largely declarative)
+build descriptions easier.
+"""
+
+from __future__ import annotations
+import builtins
+import dataclasses
+import typing as T
+
+from .. import mparser
+
+
+def _token(tid: str, filename: str, value: mparser.TV_TokenTypes) -> mparser.Token[mparser.TV_TokenTypes]:
+    """Create a Token object, but with the line numbers stubbed out.
+
+    :param tid: the token id (such as string, number, etc)
+    :param filename: the filename that the token was generated from
+    :param value: the value of the token
+    :return: A Token object
+    """
+    return mparser.Token(tid, filename, -1, -1, -1, (-1, -1), value)
+
+
+def string(value: str, filename: str) -> mparser.StringNode:
+    """Build A StringNode
+
+    :param value: the value of the string
+    :param filename: the file that the value came from
+    :return: A StringNode
+    """
+    return mparser.StringNode(_token('string', filename, value))
+
+
+def number(value: int, filename: str) -> mparser.NumberNode:
+    """Build A NumberNode
+
+    :param value: the value of the number
+    :param filename: the file that the value came from
+    :return: A NumberNode
+    """
+    return mparser.NumberNode(_token('number', filename, value))
+
+
+def bool(value: builtins.bool, filename: str) -> mparser.BooleanNode:
+    """Build A BooleanNode
+
+    :param value: the value of the boolean
+    :param filename: the file that the value came from
+    :return: A BooleanNode
+    """
+    return mparser.BooleanNode(_token('bool', filename, value))
+
+
+def array(value: T.List[mparser.BaseNode], filename: str) -> mparser.ArrayNode:
+    """Build an Array Node
+
+    :param value: A list of nodes to insert into the array
+    :param filename: The file the array is from
+    :return: An ArrayNode built from the arguments
+    """
+    args = mparser.ArgumentNode(_token('array', filename, 'unused'))
+    args.arguments = value
+    return mparser.ArrayNode(args, -1, -1, -1, -1)
+
+
+def identifier(value: str, filename: str) -> mparser.IdNode:
+    """Build A IdNode
+
+    :param value: the value of the boolean
+    :param filename: the file that the value came from
+    :return: A BooleanNode
+    """
+    return mparser.IdNode(_token('id', filename, value))
+
+
+def method(name: str, id_: mparser.IdNode,
+           pos: T.Optional[T.List[mparser.BaseNode]] = None,
+           kw: T.Optional[T.Mapping[str, mparser.BaseNode]] = None,
+           ) -> mparser.MethodNode:
+    """Create a method call.
+
+    :param name: the name of the method
+    :param id_: the object to call the method of
+    :param pos: a list of positional arguments, defaults to None
+    :param kw: a dictionary of keyword arguments, defaults to None
+    :return: a method call object
+    """
+    args = mparser.ArgumentNode(_token('array', id_.filename, 'unused'))
+    if pos is not None:
+        args.arguments = pos
+    if kw is not None:
+        args.kwargs = {identifier(k, id_.filename): v for k, v in kw.items()}
+    return mparser.MethodNode(id_.filename, -1, -1, id_, name, args)
+
+
+def function(name: str, filename: str,
+             pos: T.Optional[T.List[mparser.BaseNode]] = None,
+             kw: T.Optional[T.Mapping[str, mparser.BaseNode]] = None,
+             ) -> mparser.FunctionNode:
+    """Create a function call.
+
+    :param name: the name of the function
+    :param filename: The name of the current file being evaluated
+    :param pos: a list of positional arguments, defaults to None
+    :param kw: a dictionary of keyword arguments, defaults to None
+    :return: a method call object
+    """
+    args = mparser.ArgumentNode(_token('array', filename, 'unused'))
+    if pos is not None:
+        args.arguments = pos
+    if kw is not None:
+        args.kwargs = {identifier(k, filename): v for k, v in kw.items()}
+    return mparser.FunctionNode(filename, -1, -1, -1, -1, name, args)
+
+
+def equal(lhs: mparser.BaseNode, rhs: mparser.BaseNode) -> mparser.ComparisonNode:
+    """Create an equality operation
+
+    :param lhs: The left hand side of the equal
+    :param rhs: the right hand side of the equal
+    :return: A compraison node
+    """
+    return mparser.ComparisonNode('==', lhs, rhs)
+
+
+def or_(lhs: mparser.BaseNode, rhs: mparser.BaseNode) -> mparser.OrNode:
+    """Create and OrNode
+
+    :param lhs: The Left of the Node
+    :param rhs: The Right of the Node
+    :return: The OrNode
+    """
+    return mparser.OrNode(lhs, rhs)
+
+
+def and_(lhs: mparser.BaseNode, rhs: mparser.BaseNode) -> mparser.AndNode:
+    """Create an AndNode
+
+    :param lhs: The left of the And
+    :param rhs: The right of the And
+    :return: The AndNode
+    """
+    return mparser.AndNode(lhs, rhs)
+
+
+def not_(value: mparser.BaseNode, filename: str) -> mparser.NotNode:
+    """Create a not node
+
+    :param value: The value to negate
+    :param filename: the string filename
+    :return: The NotNode
+    """
+    return mparser.NotNode(_token('not', filename, ''), value)
+
+
+def assign(value: mparser.BaseNode, varname: str, filename: str) -> mparser.AssignmentNode:
+    """Create an AssignmentNode
+
+    :param value: The rvalue
+    :param varname: The lvalue
+    :param filename: The filename
+    :return: An AssignmentNode
+    """
+    return mparser.AssignmentNode(filename, -1, -1, varname, value)
+
+
+def block(filename: str) -> mparser.CodeBlockNode:
+    return mparser.CodeBlockNode(_token('node', filename, ''))
+
+
+@dataclasses.dataclass
+class Builder:
+
+    filename: str
+
+    def assign(self, value: mparser.BaseNode, varname: str) -> mparser.AssignmentNode:
+        return assign(value, varname, self.filename)
+
+    def string(self, value: str) -> mparser.StringNode:
+        """Build A StringNode
+
+        :param value: the value of the string
+        :return: A StringNode
+        """
+        return string(value, self.filename)
+
+    def number(self, value: int) -> mparser.NumberNode:
+        """Build A NumberNode
+
+        :param value: the value of the number
+        :return: A NumberNode
+        """
+        return number(value, self.filename)
+
+    def bool(self, value: builtins.bool) -> mparser.BooleanNode:
+        """Build A BooleanNode
+
+        :param value: the value of the boolean
+        :return: A BooleanNode
+        """
+        return bool(value, self.filename)
+
+    def array(self, value: T.List[mparser.BaseNode]) -> mparser.ArrayNode:
+        """Build an Array Node
+
+        :param value: A list of nodes to insert into the array
+        :return: An ArrayNode built from the arguments
+        """
+        return array(value, self.filename)
+
+    def identifier(self, value: str) -> mparser.IdNode:
+        """Build A IdNode
+
+        :param value: the value of the boolean
+        :return: A BooleanNode
+        """
+        return identifier(value, self.filename)
+
+    def method(self, name: str, id_: mparser.IdNode,
+               pos: T.Optional[T.List[mparser.BaseNode]] = None,
+               kw: T.Optional[T.Mapping[str, mparser.BaseNode]] = None,
+               ) -> mparser.MethodNode:
+        """Create a method call.
+
+        :param name: the name of the method
+        :param id_: the object to call the method of
+        :param pos: a list of positional arguments, defaults to None
+        :param kw: a dictionary of keyword arguments, defaults to None
+        :return: a method call object
+        """
+        return method(name, id_, pos or [], kw or {})
+
+    def function(self, name: str,
+                 pos: T.Optional[T.List[mparser.BaseNode]] = None,
+                 kw: T.Optional[T.Mapping[str, mparser.BaseNode]] = None,
+                 ) -> mparser.FunctionNode:
+        """Create a function call.
+
+        :param name: the name of the function
+        :param pos: a list of positional arguments, defaults to None
+        :param kw: a dictionary of keyword arguments, defaults to None
+        :return: a method call object
+        """
+        return function(name, self.filename, pos or [], kw or {})
+
+    def equal(self, lhs: mparser.BaseNode, rhs: mparser.BaseNode) -> mparser.ComparisonNode:
+        """Create an equality operation
+
+        :param lhs: The left hand side of the equal
+        :param rhs: the right hand side of the equal
+        :return: A compraison node
+        """
+        return equal(lhs, rhs)
+
+    def or_(self, lhs: mparser.BaseNode, rhs: mparser.BaseNode) -> mparser.OrNode:
+        """Create and OrNode
+
+        :param lhs: The Left of the Node
+        :param rhs: The Right of the Node
+        :return: The OrNode
+        """
+        return or_(lhs, rhs)
+
+    def and_(self, lhs: mparser.BaseNode, rhs: mparser.BaseNode) -> mparser.AndNode:
+        """Create an AndNode
+
+        :param lhs: The left of the And
+        :param rhs: The right of the And
+        :return: The AndNode
+        """
+        return and_(lhs, rhs)
+
+    def not_(self, value: mparser.BaseNode, filename: str) -> mparser.NotNode:
+        """Create a not node
+
+        :param value: The value to negate
+        :return: The NotNode
+        """
+        return not_(value, self.filename)

--- a/mesonbuild/cargo/cfg.py
+++ b/mesonbuild/cargo/cfg.py
@@ -1,0 +1,276 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2022-2023 Intel Corporation
+
+"""Rust CFG parser.
+
+Rust uses its `cfg()` format in cargo.
+
+This may have the following functions:
+ - all()
+ - any()
+ - not()
+
+And additionally is made up of `identifier [ = str]`. Where the str is optional,
+so you could have examples like:
+```
+[target.`cfg(unix)`.dependencies]
+[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(all(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
+```
+"""
+
+from __future__ import annotations
+import dataclasses
+import enum
+import functools
+import typing as T
+
+
+from . import builder
+from .. import mparser
+from ..mesonlib import MesonBugException
+
+if T.TYPE_CHECKING:
+    _T = T.TypeVar('_T')
+    _LEX_TOKEN = T.Tuple['TokenType', T.Optional[str]]
+    _LEX_STREAM = T.Iterable[_LEX_TOKEN]
+    _LEX_STREAM_AH = T.Iterator[T.Tuple[_LEX_TOKEN, T.Optional[_LEX_TOKEN]]]
+
+
+class TokenType(enum.Enum):
+
+    LPAREN = enum.auto()
+    RPAREN = enum.auto()
+    STRING = enum.auto()
+    IDENTIFIER = enum.auto()
+    ALL = enum.auto()
+    ANY = enum.auto()
+    NOT = enum.auto()
+    COMMA = enum.auto()
+    EQUAL = enum.auto()
+
+
+def lexer(raw: str) -> _LEX_STREAM:
+    """Lex a cfg() expression.
+
+    :param raw: The raw cfg() expression
+    :return: An iterable of tokens
+    """
+    buffer: T.List[str] = []
+    is_string: bool = False
+    for s in raw:
+        if s.isspace() or s in {')', '(', ',', '='} or (s == '"' and buffer):
+            val = ''.join(buffer)
+            buffer.clear()
+            if is_string:
+                yield (TokenType.STRING, val)
+            elif val == 'any':
+                yield (TokenType.ANY, None)
+            elif val == 'all':
+                yield (TokenType.ALL, None)
+            elif val == 'not':
+                yield (TokenType.NOT, None)
+            elif val:
+                yield (TokenType.IDENTIFIER, val)
+
+            if s == '(':
+                yield (TokenType.LPAREN, None)
+                continue
+            elif s == ')':
+                yield (TokenType.RPAREN, None)
+                continue
+            elif s == ',':
+                yield (TokenType.COMMA, None)
+                continue
+            elif s == '=':
+                yield (TokenType.EQUAL, None)
+                continue
+            elif s.isspace():
+                continue
+
+        if s == '"':
+            is_string = not is_string
+        else:
+            buffer.append(s)
+    if buffer:
+        # This should always be an identifier
+        yield (TokenType.IDENTIFIER, ''.join(buffer))
+
+
+def lookahead(iter: T.Iterator[_T]) -> T.Iterator[T.Tuple[_T, T.Optional[_T]]]:
+    """Get the current value of the iterable, and the next if possible.
+
+    :param iter: The iterable to look into
+    :yield: A tuple of the current value, and, if possible, the next
+    :return: nothing
+    """
+    current: _T
+    next_: T.Optional[_T]
+    try:
+        next_ = next(iter)
+    except StopIteration:
+        # This is an empty iterator, there's nothing to look ahead to
+        return
+
+    while True:
+        current = next_
+        try:
+            next_ = next(iter)
+        except StopIteration:
+            next_ = None
+
+        yield current, next_
+
+        if next_ is None:
+            break
+
+
+@dataclasses.dataclass
+class IR:
+
+    """Base IR node for Cargo CFG."""
+
+    filename: str
+
+@dataclasses.dataclass
+class String(IR):
+
+    value: str
+
+
+@dataclasses.dataclass
+class Identifier(IR):
+
+    value: str
+
+
+@dataclasses.dataclass
+class Equal(IR):
+
+    lhs: IR
+    rhs: IR
+
+
+@dataclasses.dataclass
+class Any(IR):
+
+    args: T.List[IR]
+
+
+@dataclasses.dataclass
+class All(IR):
+
+    args: T.List[IR]
+
+
+@dataclasses.dataclass
+class Not(IR):
+
+    value: IR
+
+
+def _parse(ast: _LEX_STREAM_AH, filename: str) -> IR:
+    (token, value), n_stream = next(ast)
+    if n_stream is not None:
+        ntoken, _ = n_stream
+    else:
+        ntoken, _ = (None, None)
+
+    stream: T.List[_LEX_TOKEN]
+    if token is TokenType.IDENTIFIER:
+        if ntoken is TokenType.EQUAL:
+            return Equal(filename, Identifier(filename, value), _parse(ast, filename))
+    if token is TokenType.STRING:
+        return String(filename, value)
+    if token is TokenType.EQUAL:
+        # In this case the previous caller already has handled the equal
+        return _parse(ast, filename)
+    if token in {TokenType.ANY, TokenType.ALL}:
+        type_ = All if token is TokenType.ALL else Any
+        assert ntoken is TokenType.LPAREN
+        next(ast)  # advance the iterator to get rid of the LPAREN
+        stream = []
+        args: T.List[IR] = []
+        while token is not TokenType.RPAREN:
+            (token, value), _ = next(ast)
+            if token is TokenType.COMMA:
+                args.append(_parse(lookahead(iter(stream)), filename))
+                stream.clear()
+            else:
+                stream.append((token, value))
+        if stream:
+            args.append(_parse(lookahead(iter(stream)), filename))
+        return type_(filename, args)
+    if token is TokenType.NOT:
+        next(ast)  # advance the iterator to get rid of the LPAREN
+        stream = []
+        # Mypy can't figure out that token is overridden inside the while loop
+        while token is not TokenType.RPAREN:  # type: ignore
+            (token, value), _ = next(ast)
+            stream.append((token, value))
+        return Not(filename, _parse(lookahead(iter(stream)), filename))
+
+    raise MesonBugException(f'Unhandled Cargo token: {token}')
+
+
+def parse(ast: _LEX_STREAM, filename: str) -> IR:
+    """Parse the tokenized list into Meson AST.
+
+    :param ast: An iterable of Tokens
+    :param filename: The name of the file being parsed
+    :return: An mparser Node to be used as a conditional
+    """
+    ast_i: _LEX_STREAM_AH = lookahead(iter(ast))
+    return _parse(ast_i, filename)
+
+
+@functools.singledispatch
+def ir_to_meson(ir: T.Any) -> mparser.BaseNode:
+    raise NotImplementedError
+
+
+@ir_to_meson.register
+def _(ir: String) -> mparser.BaseNode:
+    return builder.string(ir.value, ir.filename)
+
+
+@ir_to_meson.register
+def _(ir: Identifier) -> mparser.BaseNode:
+    host_machine = builder.identifier('host_machine', ir.filename)
+    if ir.value == "target_arch":
+        return builder.method('cpu_family', host_machine)
+    elif ir.value in {"target_os", "target_family"}:
+        return builder.method('system', host_machine)
+    elif ir.value == "target_endian":
+        return builder.method('endian', host_machine)
+    raise MesonBugException(f"Unhandled Cargo identifier: {ir.value}")
+
+
+@ir_to_meson.register
+def _(ir: Equal) -> mparser.BaseNode:
+    return builder.equal(ir_to_meson(ir.lhs), ir_to_meson(ir.rhs))
+
+
+@ir_to_meson.register
+def _(ir: Not) -> mparser.BaseNode:
+    return builder.not_(ir_to_meson(ir.value), ir.filename)
+
+
+@ir_to_meson.register
+def _(ir: Any) -> mparser.BaseNode:
+    args = iter(reversed(ir.args))
+    last = next(args)
+    cur = builder.or_(ir_to_meson(next(args)), ir_to_meson(last))
+    for a in args:
+        cur = builder.or_(ir_to_meson(a), cur)
+    return cur
+
+
+@ir_to_meson.register
+def _(ir: All) -> mparser.BaseNode:
+    args = iter(reversed(ir.args))
+    last = next(args)
+    cur = builder.and_(ir_to_meson(next(args)), ir_to_meson(last))
+    for a in args:
+        cur = builder.and_(ir_to_meson(a), cur)
+    return cur

--- a/mesonbuild/cargo/interpreter.py
+++ b/mesonbuild/cargo/interpreter.py
@@ -1,0 +1,451 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2022-2023 Intel Corporation
+
+"""Interpreter for converting Cargo Toml definitions to Meson AST
+
+There are some notable limits here. We don't even try to convert something with
+a build.rs: there's so few limits on what Cargo allows a build.rs (basically
+none), and no good way for us to convert them. In that case, an actual meson
+port will be required.
+"""
+
+from __future__ import annotations
+import dataclasses
+import glob
+import importlib
+import itertools
+import json
+import os
+import shutil
+import typing as T
+
+from . import builder
+from . import version
+from .. import mparser
+from .._pathlib import Path
+from ..mesonlib import MesonException, Popen_safe
+
+if T.TYPE_CHECKING:
+    from types import ModuleType
+
+    from . import manifest
+    from ..environment import Environment
+
+# tomllib is present in python 3.11, before that it is a pypi module called tomli,
+# we try to import tomllib, then tomli,
+# TODO: add a fallback to toml2json?
+tomllib: T.Optional[ModuleType] = None
+toml2json: T.Optional[str] = None
+for t in ['tomllib', 'tomli']:
+    try:
+        tomllib = importlib.import_module(t)
+        break
+    except ImportError:
+        pass
+else:
+    # TODO: it would be better to use an Executable here, which could be looked
+    # up in the cross file or provided by a wrap. However, that will have to be
+    # passed in externally, since we don't have (and I don't think we should),
+    # have access to the `Environment` for that in this module.
+    toml2json = shutil.which('toml2json')
+
+
+def load_toml(filename: str) -> T.Dict[object, object]:
+    if tomllib:
+        with open(filename, 'rb') as f:
+            raw = tomllib.load(f)
+    else:
+        if toml2json is None:
+            raise MesonException('Could not find an implementation of tomllib, nor toml2json')
+
+        p, out, err = Popen_safe([toml2json, filename])
+        if p.returncode != 0:
+            raise MesonException('toml2json failed to decode output\n', err)
+
+        raw = json.loads(out)
+
+    if not isinstance(raw, dict):
+        raise MesonException("Cargo.toml isn't a dictionary? How did that happen?")
+
+    return raw
+
+
+def fixup_meson_varname(name: str) -> str:
+    """Fixup a meson variable name
+
+    :param name: The name to fix
+    :return: the fixed name
+    """
+    return name.replace('-', '_')
+
+# Pylance can figure out that these do not, in fact, overlap, but mypy can't
+@T.overload
+def _fixup_raw_mappings(d: manifest.BuildTarget) -> manifest.FixedBuildTarget: ...  # type: ignore
+
+@T.overload
+def _fixup_raw_mappings(d: manifest.LibTarget) -> manifest.FixedLibTarget: ...  # type: ignore
+
+@T.overload
+def _fixup_raw_mappings(d: manifest.Dependency) -> manifest.FixedDependency: ...
+
+def _fixup_raw_mappings(d: T.Union[manifest.BuildTarget, manifest.LibTarget, manifest.Dependency]
+                        ) -> T.Union[manifest.FixedBuildTarget, manifest.FixedLibTarget,
+                                     manifest.FixedDependency]:
+    """Fixup raw cargo mappings to ones more suitable for python to consume.
+
+    This does the following:
+    * replaces any `-` with `_`, cargo likes the former, but python dicts make
+      keys with `-` in them awkward to work with
+    * Convert Dependndency versions from the cargo format to something meson
+      understands
+
+    :param d: The mapping to fix
+    :return: the fixed string
+    """
+    raw = {fixup_meson_varname(k): v for k, v in d.items()}
+    if 'version' in raw:
+        assert isinstance(raw['version'], str), 'for mypy'
+        raw['version'] = version.convert(raw['version'])
+    return T.cast('T.Union[manifest.FixedBuildTarget, manifest.FixedLibTarget, manifest.FixedDependency]', raw)
+
+
+@dataclasses.dataclass
+class Package:
+
+    """Representation of a Cargo Package entry, with defaults filled in."""
+
+    name: str
+    version: str
+    description: str
+    resolver: T.Optional[str] = None
+    authors: T.List[str] = dataclasses.field(default_factory=list)
+    edition: manifest.EDITION = '2015'
+    rust_version: T.Optional[str] = None
+    documentation: T.Optional[str] = None
+    readme: T.Optional[str] = None
+    homepage: T.Optional[str] = None
+    repository: T.Optional[str] = None
+    license: T.Optional[str] = None
+    license_file: T.Optional[str] = None
+    keywords: T.List[str] = dataclasses.field(default_factory=list)
+    categories: T.List[str] = dataclasses.field(default_factory=list)
+    workspace: T.Optional[str] = None
+    build: T.Optional[str] = None
+    links: T.Optional[str] = None
+    exclude: T.List[str] = dataclasses.field(default_factory=list)
+    include: T.List[str] = dataclasses.field(default_factory=list)
+    publish: bool = True
+    metadata: T.Dict[str, T.Dict[str, str]] = dataclasses.field(default_factory=dict)
+    default_run: T.Optional[str] = None
+    autobins: bool = True
+    autoexamples: bool = True
+    autotests: bool = True
+    autobenches: bool = True
+
+
+@dataclasses.dataclass
+class Dependency:
+
+    """Representation of a Cargo Dependency Entry."""
+
+    version: T.List[str]
+    registry: T.Optional[str] = None
+    git: T.Optional[str] = None
+    branch: T.Optional[str] = None
+    rev: T.Optional[str] = None
+    path: T.Optional[str] = None
+    optional: bool = False
+    package: T.Optional[str] = None
+    default_features: bool = False
+    features: T.List[str] = dataclasses.field(default_factory=list)
+
+    @classmethod
+    def from_raw(cls, raw: manifest.DependencyV) -> Dependency:
+        """Create a dependency from a raw cargo dictionary"""
+        if isinstance(raw, str):
+            return cls(version.convert(raw))
+        return cls(**_fixup_raw_mappings(raw))
+
+
+@dataclasses.dataclass
+class BuildTarget:
+
+    name: str
+    crate_type: T.List[manifest.CRATE_TYPE] = dataclasses.field(default_factory=lambda: ['lib'])
+    path: dataclasses.InitVar[T.Optional[str]] = None
+
+    # https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-test-field
+    # True for lib, bin, test
+    test: bool = True
+
+    # https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-doctest-field
+    # True for lib
+    doctest: bool = False
+
+    # https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-bench-field
+    # True for lib, bin, benchmark
+    bench: bool = True
+
+    # https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-doc-field
+    # True for libraries and binaries
+    doc: bool = False
+
+    harness: bool = True
+    edition: manifest.EDITION = '2015'
+    required_features: T.List[str] = dataclasses.field(default_factory=list)
+    plugin: bool = False
+
+
+@dataclasses.dataclass
+class Library(BuildTarget):
+
+    """Representation of a Cargo Library Entry."""
+
+    doctest: bool = True
+    doc: bool = True
+    proc_macro: bool = False
+    crate_type: T.List[manifest.CRATE_TYPE] = dataclasses.field(default_factory=lambda: ['lib'])
+    doc_scrape_examples: bool = True
+
+
+@dataclasses.dataclass
+class Binary(BuildTarget):
+
+    """Representation of a Cargo Bin Entry."""
+
+    doc: bool = True
+
+
+@dataclasses.dataclass
+class Test(BuildTarget):
+
+    """Representation of a Cargo Test Entry."""
+
+    bench: bool = True
+
+
+@dataclasses.dataclass
+class Benchmark(BuildTarget):
+
+    """Representation of a Cargo Benchmark Entry."""
+
+    test: bool = True
+
+
+@dataclasses.dataclass
+class Example(BuildTarget):
+
+    """Representation of a Cargo Example Entry."""
+
+    crate_type: T.List[manifest.CRATE_TYPE] = dataclasses.field(default_factory=lambda: ['bin'])
+
+
+@dataclasses.dataclass
+class Manifest:
+
+    """Cargo Manifest definition.
+
+    Most of these values map up to the Cargo Manifest, but with default values
+    if not provided.
+
+    Cargo subprojects can contain what Meson wants to treat as multiple,
+    interdependent, subprojects.
+
+    :param subdir: the subdirectory that this cargo project is in
+    :param path: the path within the cargo subproject.
+    """
+
+    package: Package
+    dependencies: T.Dict[str, Dependency]
+    dev_dependencies: T.Dict[str, Dependency]
+    build_dependencies: T.Dict[str, Dependency]
+    lib: Library
+    bin: T.List[Binary]
+    test: T.List[Test]
+    bench: T.List[Benchmark]
+    example: T.List[Example]
+    features: T.Dict[str, T.List[str]]
+    target: T.Dict[str, T.Dict[str, Dependency]]
+    subdir: str
+    path: str = ''
+
+
+def _create_project(package: Package, build: builder.Builder, env: Environment) -> mparser.FunctionNode:
+    """Create a function call
+
+    :param package: The Cargo package to generate from
+    :param filename: The full path to the file
+    :param meson_version: The generating meson version
+    :return: a FunctionNode
+    """
+    args: T.List[mparser.BaseNode] = []
+    args.extend([
+        build.string(package.name),
+        build.string('rust'),
+    ])
+    kwargs: T.Dict[str, mparser.BaseNode] = {
+        'version': build.string(package.version),
+        # Always assume that the generated meson is using the latest features
+        # This will warn when when we generate deprecated code, which is helpful
+        # for the upkeep of the module
+        'meson_version': build.string(f'>= {env.coredata.version}'),
+        'default_options': build.array([build.string(f'rust_std={package.edition}')]),
+    }
+    if package.license:
+        kwargs['license'] = build.string(package.license)
+    elif package.license_file:
+        kwargs['license_files'] = build.string(package.license_file)
+
+    return build.function('project', args, kwargs)
+
+
+def _convert_manifest(raw_manifest: manifest.Manifest, subdir: str, path: str = '') -> Manifest:
+    # This cast is a bit of a hack to deal with proc-macro
+    lib = _fixup_raw_mappings(raw_manifest.get('lib', {}))
+
+    # We need to set the name field if it's not set manually,
+    # including if other fields are set in the lib section
+    lib.setdefault('name', raw_manifest['package']['name'])
+
+    pkg = T.cast('manifest.FixedPackage',
+                 {fixup_meson_varname(k): v for k, v in raw_manifest['package'].items()})
+
+    return Manifest(
+        Package(**pkg),
+        {k: Dependency.from_raw(v) for k, v in raw_manifest.get('dependencies', {}).items()},
+        {k: Dependency.from_raw(v) for k, v in raw_manifest.get('dev-dependencies', {}).items()},
+        {k: Dependency.from_raw(v) for k, v in raw_manifest.get('build-dependencies', {}).items()},
+        Library(**lib),
+        [Binary(**_fixup_raw_mappings(b)) for b in raw_manifest.get('bin', {})],
+        [Test(**_fixup_raw_mappings(b)) for b in raw_manifest.get('test', {})],
+        [Benchmark(**_fixup_raw_mappings(b)) for b in raw_manifest.get('bench', {})],
+        [Example(**_fixup_raw_mappings(b)) for b in raw_manifest.get('example', {})],
+        raw_manifest.get('features', {}),
+        {k: {k2: Dependency.from_raw(v2) for k2, v2 in v['dependencies'].items()}
+         for k, v in raw_manifest.get('target', {}).items()},
+        subdir,
+        path,
+    )
+
+
+def _load_manifests(subdir: str) -> T.Dict[str, Manifest]:
+    filename = os.path.join(subdir, 'Cargo.toml')
+    raw = load_toml(filename)
+
+    manifests: T.Dict[str, Manifest] = {}
+
+    raw_manifest: T.Union[manifest.Manifest, manifest.VirtualManifest]
+    if 'package' in raw:
+        raw_manifest = T.cast('manifest.Manifest', raw)
+        manifest_ = _convert_manifest(raw_manifest, subdir)
+        manifests[manifest_.package.name] = manifest_
+    else:
+        raw_manifest = T.cast('manifest.VirtualManifest', raw)
+
+    if 'workspace' in raw_manifest:
+        # XXX: need to verify that python glob and cargo globbing are the
+        # same and probably write  a glob implementation. Blarg
+
+        # We need to chdir here to make the glob work correctly
+        pwd = os.getcwd()
+        os.chdir(subdir)
+        members: T.Iterable[str]
+        try:
+            members = itertools.chain.from_iterable(
+                glob.glob(m) for m in raw_manifest['workspace']['members'])
+        finally:
+            os.chdir(pwd)
+        if 'exclude' in raw_manifest['workspace']:
+            members = (x for x in members if x not in raw_manifest['workspace']['exclude'])
+
+        for m in members:
+            filename = os.path.join(subdir, m, 'Cargo.toml')
+            raw = load_toml(filename)
+
+            raw_manifest = T.cast('manifest.Manifest', raw)
+            man = _convert_manifest(raw_manifest, subdir, m)
+            manifests[man.package.name] = man
+
+    return manifests
+
+
+def load_all_manifests(subproject_dir: str) -> T.Dict[str, Manifest]:
+    """Find all cargo subprojects, and load them
+
+    :param subproject_dir: Directory to look for subprojects in
+    :return: A dictionary of rust project names to Manifests
+    """
+    manifests: T.Dict[str, Manifest] = {}
+    for p in Path(subproject_dir).iterdir():
+        if p.is_dir() and (p / 'Cargo.toml').exists():
+            manifests.update(_load_manifests(str(p)))
+    return manifests
+
+
+def _create_lib(cargo: Manifest, build: builder.Builder) -> T.List[mparser.BaseNode]:
+    kw: T.Dict[str, mparser.BaseNode] = {}
+    if cargo.dependencies:
+        ids = [build.identifier(f'dep_{n}') for n in cargo.dependencies]
+        kw['dependencies'] = build.array(
+            [build.method('get_variable', i, [build.string('dep')]) for i in ids])
+
+    # FIXME: currently assuming that an rlib is being generated, which is
+    # the most common.
+    return [
+        build.assign(
+            build.function(
+                'static_library',
+                [
+                    build.string(fixup_meson_varname(cargo.package.name)),
+                    build.string(os.path.join('src', 'lib.rs')),
+                ],
+                kw,
+            ),
+            'lib'
+        ),
+
+        build.assign(
+            build.function(
+                'declare_dependency',
+                kw={'link_with': build.identifier('lib'), **kw},
+            ),
+            'dep'
+        )
+    ]
+
+
+def interpret(cargo: Manifest, env: Environment) -> mparser.CodeBlockNode:
+    filename = os.path.join(cargo.subdir, cargo.path, 'Cargo.toml')
+    build = builder.Builder(filename)
+
+    ast: T.List[mparser.BaseNode] = [
+        _create_project(cargo.package, build, env),
+        build.assign(build.function('import', [build.string('rust')]), 'rust'),
+    ]
+
+    if cargo.dependencies:
+        for name, dep in cargo.dependencies.items():
+            kw = {
+                'version': build.array([build.string(s) for s in dep.version]),
+            }
+            ast.extend([
+                build.assign(
+                    build.method(
+                        'cargo',
+                        build.identifier('rust'),
+                        [build.string(name)],
+                        kw,
+                    ),
+                    f'dep_{fixup_meson_varname(name)}',
+                ),
+            ])
+
+    # Libs are always auto-discovered and there's no other way to handle them,
+    # which is unfortunate for reproducability
+    if os.path.exists(os.path.join(env.source_dir, cargo.subdir, cargo.path, 'src', 'lib.rs')):
+        ast.extend(_create_lib(cargo, build))
+
+    # XXX: make this not awful
+    block = builder.block(filename)
+    block.lines = ast
+    return block

--- a/mesonbuild/cargo/manifest.py
+++ b/mesonbuild/cargo/manifest.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2022-2023 Intel Corporation
+
+"""Type definitions for cargo manifest files."""
+
+from __future__ import annotations
+import typing as T
+
+from typing_extensions import Literal, TypedDict, Required
+
+EDITION = Literal['2015', '2018', '2021']
+CRATE_TYPE = Literal['bin', 'lib', 'dylib', 'staticlib', 'cdylib', 'rlib', 'proc-macro']
+
+Package = TypedDict(
+    'Package',
+    {
+        'name': Required[str],
+        'version': Required[str],
+        'authors': T.List[str],
+        'edition': EDITION,
+        'rust-version': str,
+        'description': str,
+        'readme': str,
+        'license': str,
+        'license-file': str,
+        'keywords': T.List[str],
+        'categories': T.List[str],
+        'workspace': str,
+        'build': str,
+        'links': str,
+        'include': T.List[str],
+        'exclude': T.List[str],
+        'publish': bool,
+        'metadata': T.Dict[str, T.Dict[str, str]],
+        'default-run': str,
+        'autobins': bool,
+        'autoexamples': bool,
+        'autotests': bool,
+        'autobenches': bool,
+    },
+    total=False,
+)
+"""A description of the Package Dictionary."""
+
+class FixedPackage(TypedDict, total=False):
+
+    """A description of the Package Dictionary, fixed up."""
+
+    name: Required[str]
+    version: Required[str]
+    authors: T.List[str]
+    edition: EDITION
+    rust_version: str
+    description: str
+    readme: str
+    license: str
+    license_file: str
+    keywords: T.List[str]
+    categories: T.List[str]
+    workspace: str
+    build: str
+    links: str
+    include: T.List[str]
+    exclude: T.List[str]
+    publish: bool
+    metadata: T.Dict[str, T.Dict[str, str]]
+    default_run: str
+    autobins: bool
+    autoexamples: bool
+    autotests: bool
+    autobenches: bool
+
+
+class Badge(TypedDict):
+
+    """An entry in the badge section."""
+
+    status: Literal['actively-developed', 'passively-developed', 'as-is', 'experimental', 'deprecated', 'none']
+
+
+Dependency = TypedDict(
+    'Dependency',
+    {
+        'version': str,
+        'registry': str,
+        'git': str,
+        'branch': str,
+        'rev': str,
+        'path': str,
+        'optional': bool,
+        'package': str,
+        'default-features': bool,
+        'features': T.List[str],
+    },
+    total=False,
+)
+"""An entry in the *dependencies sections."""
+
+
+class FixedDependency(TypedDict, total=False):
+
+    """An entry in the *dependencies sections, fixed up."""
+
+    version: T.List[str]
+    registry: str
+    git: str
+    branch: str
+    rev: str
+    path: str
+    optional: bool
+    package: str
+    default_features: bool
+    features: T.List[str]
+
+
+DependencyV = T.Union[Dependency, str]
+"""A Dependency entry, either a string or a Dependency Dict."""
+
+
+_BaseBuildTarget = TypedDict(
+    '_BaseBuildTarget',
+    {
+        'path': str,
+        'test': bool,
+        'doctest': bool,
+        'bench': bool,
+        'doc': bool,
+        'plugin': bool,
+        'proc-macro': bool,
+        'harness': bool,
+        'edition': EDITION,
+        'crate-type': T.List[CRATE_TYPE],
+        'required-features': T.List[str],
+    },
+    total=False,
+)
+
+
+class BuildTarget(_BaseBuildTarget, total=False):
+
+    name: Required[str]
+
+class LibTarget(_BaseBuildTarget, total=False):
+
+    name: str
+
+
+class _BaseFixedBuildTarget(TypedDict, total=False):
+    path: str
+    test: bool
+    doctest: bool
+    bench: bool
+    doc: bool
+    plugin: bool
+    harness: bool
+    edition: EDITION
+    crate_type: T.List[CRATE_TYPE]
+    required_features: T.List[str]
+
+
+class FixedBuildTarget(_BaseFixedBuildTarget, total=False):
+
+    name: str
+
+class FixedLibTarget(_BaseFixedBuildTarget, total=False):
+
+    name: Required[str]
+    proc_macro: bool
+
+
+class Target(TypedDict):
+
+    """Target entry in the Manifest File."""
+
+    dependencies: T.Dict[str, DependencyV]
+
+
+class Workspace(TypedDict):
+
+    """The representation of a workspace.
+
+    In a vritual manifest the :attribute:`members` is always present, but in a
+    project manifest, an empty workspace may be provided, in which case the
+    workspace is implicitly filled in by values from the path based dependencies.
+
+    the :attribute:`exclude` is always optional
+    """
+
+    members: T.List[str]
+    exclude: T.List[str]
+
+
+Manifest = TypedDict(
+    'Manifest',
+    {
+        'package': Package,
+        'badges': T.Dict[str, Badge],
+        'dependencies': T.Dict[str, DependencyV],
+        'dev-dependencies': T.Dict[str, DependencyV],
+        'build-dependencies': T.Dict[str, DependencyV],
+        'lib': LibTarget,
+        'bin': T.List[BuildTarget],
+        'test': T.List[BuildTarget],
+        'bench': T.List[BuildTarget],
+        'example': T.List[BuildTarget],
+        'features': T.Dict[str, T.List[str]],
+        'target': T.Dict[str, Target],
+        'workspace': Workspace,
+
+        # TODO: patch?
+        # TODO: replace?
+    },
+    total=False,
+)
+"""The Cargo Manifest format."""
+
+
+class VirtualManifest(TypedDict):
+
+    """The Representation of a virtual manifest.
+
+    Cargo allows a root manifest that contains only a workspace, this is called
+    a virtual manifest. This doesn't really map 1:1 with any meson concept,
+    except perhaps the proposed "meta project".
+    """
+
+    workspace: Workspace

--- a/mesonbuild/cargo/version.py
+++ b/mesonbuild/cargo/version.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2022-2023 Intel Corporation
+
+"""Convert Cargo versions into Meson compatible ones."""
+
+from __future__ import annotations
+import typing as T
+
+
+def convert(cargo_ver: str) -> T.List[str]:
+    """Convert a Cargo compatible version into a Meson compatible one.
+
+    :param cargo_ver: The version, as Cargo specifies
+    :return: A list of version constraints, as Meson understands them
+    """
+    # Cleanup, just for safety
+    cargo_ver = cargo_ver.strip()
+    cargo_vers = [c.strip() for c in cargo_ver.split(',')]
+
+    out: T.List[str] = []
+
+    for ver in cargo_vers:
+        # This covers >= and =< as well
+        # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#comparison-requirements
+        if ver.startswith(('>', '<', '=')):
+            out.append(ver)
+
+        elif ver.startswith('~'):
+            # Rust has these tilde requirements, which means that it is >= to
+            # the version, but less than the next version
+            # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#tilde-requirements
+            # we convert those into a pair of constraints
+            v = ver[1:].split('.')
+            out.append(f'>= {".".join(v)}')
+            if len(v) == 3:
+                out.append(f'< {v[0]}.{int(v[1]) + 1}.0')
+            elif len(v) == 2:
+                out.append(f'< {v[0]}.{int(v[1]) + 1}')
+            else:
+                out.append(f'< {int(v[0]) + 1}')
+
+        elif '*' in ver:
+            # Rust has astrisk requirements,, which are like 1.* == ~1
+            # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#wildcard-requirements
+            v = ver.split('.')[:-1]
+            if v:
+                out.append(f'>= {".".join(v)}')
+            if len(v) == 2:
+                out.append(f'< {v[0]}.{int(v[1]) + 1}')
+            elif len(v) == 1:
+                out.append(f'< {int(v[0]) + 1}')
+
+        else:
+            # a Caret version is equivalent to the default strategy
+            # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements
+            if ver.startswith('^'):
+                ver = ver[1:]
+
+            # If there is no qualifier, then it means this or the next non-zero version
+            # That means that if this is `1.1.0``, then we need `>= 1.1.0` && `< 2.0.0`
+            # Or if we have `0.1.0`, then we need `>= 0.1.0` && `< 0.2.0`
+            # Or if we have `0.1`, then we need `>= 0.1.0` && `< 0.2.0`
+            # Or if we have `0.0.0`, then we need `< 1.0.0`
+            # Or if we have `0.0`, then we need `< 1.0.0`
+            # Or if we have `0`, then we need `< 1.0.0`
+            # Or if we have `0.0.3`, then we need `>= 0.0.3` && `< 0.0.4`
+            # https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio
+            #
+            # this works much like the ~ versions, but in reverse. Tilde starts
+            # at the patch version and works up, to the major version, while
+            # bare numbers start at the major version and work down to the patch
+            # version
+            vers = ver.split('.')
+            min_: T.List[str] = []
+            max_: T.List[str] = []
+            bumped = False
+            for v_ in vers:
+                if v_ != '0' and not bumped:
+                    min_.append(v_)
+                    max_.append(str(int(v_) + 1))
+                    bumped = True
+                else:
+                    if not (bumped and v_ == '0'):
+                        min_.append(v_)
+                    if not bumped:
+                        max_.append('0')
+
+            # If there is no minimum, don't emit one
+            if set(min_) != {'0'}:
+                out.append('>= {}'.format('.'.join(min_)))
+            if set(max_) != {'0'}:
+                out.append('< {}'.format('.'.join(max_)))
+            else:
+                out.append('< 1')
+
+    return out

--- a/run_mypy.py
+++ b/run_mypy.py
@@ -12,6 +12,7 @@ from mesonbuild.mesonlib import version_compare
 modules = [
     # fully typed submodules
     # 'mesonbuild/ast/',
+    'mesonbuild/cargo/',
     'mesonbuild/cmake/',
     'mesonbuild/compilers/',
     'mesonbuild/dependencies/',

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -36,6 +36,7 @@ from mesonbuild.mesonlib import python_command, setup_vsenv
 import mesonbuild.modules.pkgconfig
 
 from unittests.allplatformstests import AllPlatformTests
+from unittests.cargotests import CargoVersionTest
 from unittests.darwintests import DarwinTests
 from unittests.failuretests import FailureTests
 from unittests.linuxcrosstests import LinuxCrossArmTests, LinuxCrossMingwTests

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -36,7 +36,7 @@ from mesonbuild.mesonlib import python_command, setup_vsenv
 import mesonbuild.modules.pkgconfig
 
 from unittests.allplatformstests import AllPlatformTests
-from unittests.cargotests import CargoVersionTest
+from unittests.cargotests import CargoVersionTest, CargoCfgTest
 from unittests.darwintests import DarwinTests
 from unittests.failuretests import FailureTests
 from unittests.linuxcrosstests import LinuxCrossArmTests, LinuxCrossMingwTests

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import unittest
 import typing as T
 
+from mesonbuild.cargo import builder, cfg
+from mesonbuild.cargo.cfg import TokenType
 from mesonbuild.cargo.version import convert
 
 
@@ -59,3 +61,126 @@ class CargoVersionTest(unittest.TestCase):
             with self.subTest():
                 self.assertListEqual(convert(data), expected)
 
+
+class CargoCfgTest(unittest.TestCase):
+
+    def test_lex(self) -> None:
+        cases: T.List[T.Tuple[str, T.List[T.Tuple[TokenType, T.Optional[str]]]]] = [
+            ('"unix"', [(TokenType.STRING, 'unix')]),
+            ('unix', [(TokenType.IDENTIFIER, 'unix')]),
+            ('not(unix)', [
+                (TokenType.NOT, None),
+                (TokenType.LPAREN, None),
+                (TokenType.IDENTIFIER, 'unix'),
+                (TokenType.RPAREN, None),
+            ]),
+            ('any(unix, windows)', [
+                (TokenType.ANY, None),
+                (TokenType.LPAREN, None),
+                (TokenType.IDENTIFIER, 'unix'),
+                (TokenType.COMMA, None),
+                (TokenType.IDENTIFIER, 'windows'),
+                (TokenType.RPAREN, None),
+            ]),
+            ('target_arch = "x86_64"', [
+                (TokenType.IDENTIFIER, 'target_arch'),
+                (TokenType.EQUAL, None),
+                (TokenType.STRING, 'x86_64'),
+            ]),
+            ('all(target_arch = "x86_64", unix)', [
+                (TokenType.ALL, None),
+                (TokenType.LPAREN, None),
+                (TokenType.IDENTIFIER, 'target_arch'),
+                (TokenType.EQUAL, None),
+                (TokenType.STRING, 'x86_64'),
+                (TokenType.COMMA, None),
+                (TokenType.IDENTIFIER, 'unix'),
+                (TokenType.RPAREN, None),
+            ]),
+        ]
+        for data, expected in cases:
+            with self.subTest():
+                self.assertListEqual(list(cfg.lexer(data)), expected)
+
+    def test_parse(self) -> None:
+        cases = [
+            ('target_os = "windows"', cfg.Equal('', cfg.Identifier('', "target_os"), cfg.String('', "windows"))),
+            ('target_arch = "x86"', cfg.Equal('', cfg.Identifier('', "target_arch"), cfg.String('', "x86"))),
+            ('target_family = "unix"', cfg.Equal('', cfg.Identifier('', "target_family"), cfg.String('', "unix"))),
+            ('any(target_arch = "x86", target_arch = "x86_64")',
+                cfg.Any(
+                    '', [
+                        cfg.Equal('', cfg.Identifier('', "target_arch"), cfg.String('', "x86")),
+                        cfg.Equal('', cfg.Identifier('', "target_arch"), cfg.String('', "x86_64")),
+                    ])),
+            ('all(target_arch = "x86", target_os = "linux")',
+                cfg.All(
+                    '', [
+                        cfg.Equal('', cfg.Identifier('', "target_arch"), cfg.String('', "x86")),
+                        cfg.Equal('', cfg.Identifier('', "target_os"), cfg.String('', "linux")),
+                    ])),
+            ('not(all(target_arch = "x86", target_os = "linux"))',
+                cfg.Not(
+                    '',
+                    cfg.All(
+                        '', [
+                            cfg.Equal('', cfg.Identifier('', "target_arch"), cfg.String('', "x86")),
+                            cfg.Equal('', cfg.Identifier('', "target_os"), cfg.String('', "linux")),
+                        ]))),
+        ]
+        for data, expected in cases:
+            with self.subTest():
+                self.assertEqual(cfg.parse(iter(cfg.lexer(data)), ''), expected)
+
+    def test_ir_to_meson(self) -> None:
+        HOST_MACHINE = builder.identifier('host_machine', '')
+
+        cases = [
+            ('target_os = "windows"',
+             builder.equal(builder.method('system', HOST_MACHINE),
+                           builder.string('windows', ''))),
+            ('target_arch = "x86"',
+             builder.equal(builder.method('cpu_family', HOST_MACHINE),
+                           builder.string('x86', ''))),
+            ('target_family = "unix"',
+             builder.equal(builder.method('system', HOST_MACHINE),
+                           builder.string('unix', ''))),
+            ('not(target_arch = "x86")',
+             builder.not_(builder.equal(
+                builder.method('cpu_family', HOST_MACHINE),
+                builder.string('x86', '')), '')),
+            ('any(target_arch = "x86", target_arch = "x86_64")',
+             builder.or_(
+                builder.equal(builder.method('cpu_family', HOST_MACHINE),
+                              builder.string('x86', '')),
+                builder.equal(builder.method('cpu_family', HOST_MACHINE),
+                              builder.string('x86_64', '')))),
+            ('any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")',
+             builder.or_(
+                builder.equal(builder.method('cpu_family', HOST_MACHINE),
+                              builder.string('x86', '')),
+                builder.or_(
+                    builder.equal(builder.method('cpu_family', HOST_MACHINE),
+                                  builder.string('x86_64', '')),
+                    builder.equal(builder.method('cpu_family', HOST_MACHINE),
+                                  builder.string('aarch64', ''))))),
+            ('all(target_arch = "x86", target_arch = "x86_64")',
+             builder.and_(
+                builder.equal(builder.method('cpu_family', HOST_MACHINE),
+                              builder.string('x86', '')),
+                builder.equal(builder.method('cpu_family', HOST_MACHINE),
+                              builder.string('x86_64', '')))),
+            ('all(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")',
+             builder.and_(
+                builder.equal(builder.method('cpu_family', HOST_MACHINE),
+                              builder.string('x86', '')),
+                builder.and_(
+                    builder.equal(builder.method('cpu_family', HOST_MACHINE),
+                                  builder.string('x86_64', '')),
+                    builder.equal(builder.method('cpu_family', HOST_MACHINE),
+                                  builder.string('aarch64', ''))))),
+        ]
+        for data, expected in cases:
+            with self.subTest():
+                value = cfg.ir_to_meson(cfg.parse(iter(cfg.lexer(data)), ''))
+                self.assertEqual(value, expected)

--- a/unittests/cargotests.py
+++ b/unittests/cargotests.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright © 2022-2023 Intel Corporation
+
+from __future__ import annotations
+import unittest
+import typing as T
+
+from mesonbuild.cargo.version import convert
+
+
+class CargoVersionTest(unittest.TestCase):
+
+    def test_cargo_to_meson(self) -> None:
+        cases: T.List[T.Tuple[str, T.List[str]]] = [
+            # Basic requirements
+            ('>= 1', ['>= 1']),
+            ('> 1', ['> 1']),
+            ('= 1', ['= 1']),
+            ('< 1', ['< 1']),
+            ('<= 1', ['<= 1']),
+
+            # tilde tests
+            ('~1', ['>= 1', '< 2']),
+            ('~1.1', ['>= 1.1', '< 1.2']),
+            ('~1.1.2', ['>= 1.1.2', '< 1.2.0']),
+
+            # Wildcards
+            ('*', []),
+            ('1.*', ['>= 1', '< 2']),
+            ('2.3.*', ['>= 2.3', '< 2.4']),
+
+            # Unqualified
+            ('2', ['>= 2', '< 3']),
+            ('2.4', ['>= 2.4', '< 3']),
+            ('2.4.5', ['>= 2.4.5', '< 3']),
+            ('0.0.0', ['< 1']),
+            ('0.0', ['< 1']),
+            ('0', ['< 1']),
+            ('0.0.5', ['>= 0.0.5', '< 0.0.6']),
+            ('0.5.0', ['>= 0.5', '< 0.6']),
+            ('0.5', ['>= 0.5', '< 0.6']),
+
+            # Caret (Which is the same as unqualified)
+            ('^2', ['>= 2', '< 3']),
+            ('^2.4', ['>= 2.4', '< 3']),
+            ('^2.4.5', ['>= 2.4.5', '< 3']),
+            ('^0.0.0', ['< 1']),
+            ('^0.0', ['< 1']),
+            ('^0', ['< 1']),
+            ('^0.0.5', ['>= 0.0.5', '< 0.0.6']),
+            ('^0.5.0', ['>= 0.5', '< 0.6']),
+            ('^0.5', ['>= 0.5', '< 0.6']),
+
+            # Multiple requirements
+            ('>= 1.2.3, < 1.4.7', ['>= 1.2.3', '< 1.4.7']),
+        ]
+
+        for (data, expected) in cases:
+            with self.subTest():
+                self.assertListEqual(convert(data), expected)
+


### PR DESCRIPTION
This is still *very* WIP, but I wanted to be able to track the status of it publically, since I'm trying to get this ready to solve real issues in Mesa, ASAP.

This is the second attempt at cargo-as-a-subproject. It differs from the previous attempt in a couple of major ways:
 - uses `tomli` instead of `toml`. `tomli` is on track to be in the standard library of python 3.11, so it will only be an external dependency for older versions of python
 - uses a different AST builder approach
 - uses a bewtter cfg parser
 - is structured better, due to me understanding the problem better

TODO:

- [x] trivial example
- [x] nested crates
- [ ] virtual workspaces
- [ ] non-virtual workspaces
- [ ] option parsing
- [ ] proc-macros
- [ ] tests
- [ ] benchmarks
- [ ] examples?
- [ ] combining features from multiple subprojects
- [x] replace pytest tests with unittests
- [ ] support [system-deps](https://crates.io/crates/system-deps) thanks for pointing this out @xclaesse 
- [ ] toml2json as an alternative to tomllib/tomli
- [ ] Support cargo-c
- [ ] Figure out something better than cargo vendor, which now requires a non-trival Cargo.toml
- [ ] Write a cargo plugin to allow moving rustc version checks out of build.rs and into cargo.toml
- [ ] add suggested metadata (and support) to tell meson it's okay to ignore the build.rs