### PR TITLE
ninja backend: do not fatally error on compdb failure

### DIFF
--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -606,7 +606,7 @@ class NinjaBackend(backends.Backend):
             with open(os.path.join(builddir, 'compile_commands.json'), 'wb') as f:
                 f.write(jsondb)
         except Exception:
-            mlog.warning('Could not create compilation database.')
+            mlog.warning('Could not create compilation database.', fatal=False)
 
     # Get all generated headers. Any source file might need them so
     # we need to add an order dependency to them.


### PR DESCRIPTION
We print a warning if a compilation database isn't successfully generated, which is good, because that gives some visibility in case the user really wanted to use the compdb. But warnings default to being fatal with --fatal-meson-warnings, which is not so good, because this isn't a very important warning at all, and we'd rather not error out in such cases when building works fine and a random bonus IDE feature doesn't work.

Mark this particular warning as non-fatal.

Fixes side issue in https://github.com/mesonbuild/wrapdb/pull/343#issuecomment-1074545609