### PR TITLE
docs/rust: fix markdown title

### DIFF
--- a/docs/markdown/Rust.md
+++ b/docs/markdown/Rust.md
@@ -1,7 +1,7 @@
 ---
 title: Rust
 short-description: Working with Rust in Meson
----
+...
 
 # Using Rust with Meson
 


### PR DESCRIPTION
VSCode is perfectly happy with the trailing `---`, github only likes
`...` apparently.