### PR TITLE
type annotations cleanup

### DIFF
--- a/mesonbuild/dependencies/dev.py
+++ b/mesonbuild/dependencies/dev.py
@@ -29,7 +29,7 @@ from mesonbuild.interpreterbase.decorators import FeatureDeprecated
 from .. import mesonlib, mlog
 from ..compilers import AppleClangCCompiler, AppleClangCPPCompiler, detect_compiler_for
 from ..environment import get_llvm_tool_names
-from ..mesonlib import version_compare, stringlistify, extract_as_list, MachineChoice
+from ..mesonlib import version_compare, stringlistify, extract_as_list
 from .base import DependencyException, DependencyMethods, strip_system_libdirs, SystemDependency
 from .cmake import CMakeDependency
 from .configtool import ConfigToolDependency
@@ -39,7 +39,8 @@ from .pkgconfig import PkgConfigDependency
 
 if T.TYPE_CHECKING:
     from ..envconfig import MachineInfo
-    from .. environment import Environment
+    from ..environment import Environment
+    from ..mesonlib import MachineChoice
     from typing_extensions import TypedDict
 
     class JNISystemDependencyKW(TypedDict):

--- a/mesonbuild/interpreter/dependencyfallbacks.py
+++ b/mesonbuild/interpreter/dependencyfallbacks.py
@@ -1,5 +1,6 @@
-from .interpreterobjects import SubprojectHolder, extract_required_kwarg
+from __future__ import annotations
 
+from .interpreterobjects import extract_required_kwarg
 from .. import mlog
 from .. import dependencies
 from .. import build
@@ -7,12 +8,13 @@ from ..wrap import WrapMode
 from ..mesonlib import OptionKey, extract_as_list, stringlistify, version_compare_many, listify
 from ..dependencies import Dependency, DependencyException, NotFoundDependency
 from ..interpreterbase import (MesonInterpreterObject, FeatureNew,
-                               InterpreterException, InvalidArguments,
-                               TYPE_nkwargs, TYPE_nvar)
+                               InterpreterException, InvalidArguments)
 
 import typing as T
 if T.TYPE_CHECKING:
     from .interpreter import Interpreter
+    from ..interpreterbase import TYPE_nkwargs, TYPE_nvar
+    from .interpreterobjects import SubprojectHolder
 
 
 class DependencyFallbacksHolder(MesonInterpreterObject):

--- a/mesonbuild/interpreter/interpreterobjects.py
+++ b/mesonbuild/interpreter/interpreterobjects.py
@@ -16,10 +16,10 @@ from ..modules import ModuleReturnValue, ModuleObject, ModuleState, ExtensionMod
 from ..backend.backends import TestProtocol
 from ..interpreterbase import (
                                ContainerTypeInfo, KwargInfo, MesonOperator,
-                               InterpreterObject, MesonInterpreterObject, ObjectHolder, MutableInterpreterObject,
-                               FeatureCheckBase, FeatureNew, FeatureDeprecated,
+                               MesonInterpreterObject, ObjectHolder, MutableInterpreterObject,
+                               FeatureNew, FeatureDeprecated,
                                typed_pos_args, typed_kwargs, typed_operator,
-                               noArgsFlattening, noPosargs, noKwargs, unholder_return, TYPE_var, TYPE_kwargs, TYPE_nvar, TYPE_nkwargs,
+                               noArgsFlattening, noPosargs, noKwargs, unholder_return,
                                flatten, resolve_second_level_holders, InterpreterException, InvalidArguments, InvalidCode)
 from ..interpreter.type_checking import NoneType, ENV_SEPARATOR_KW
 from ..dependencies import Dependency, ExternalLibrary, InternalDependency
@@ -32,7 +32,7 @@ if T.TYPE_CHECKING:
     from . import kwargs
     from ..cmake.interpreter import CMakeInterpreter
     from ..envconfig import MachineInfo
-    from ..interpreterbase import SubProject
+    from ..interpreterbase import FeatureCheckBase, InterpreterObject, SubProject, TYPE_var, TYPE_kwargs, TYPE_nvar, TYPE_nkwargs
     from .interpreter import Interpreter
 
     from typing_extensions import TypedDict

--- a/mesonbuild/modules/fs.py
+++ b/mesonbuild/modules/fs.py
@@ -21,7 +21,6 @@ from .. import mlog
 from . import ExtensionModule
 from ..mesonlib import (
     File,
-    FileOrString,
     MesonException,
     path_is_in_root,
 )
@@ -30,6 +29,7 @@ from ..interpreterbase import FeatureNew, KwargInfo, typed_kwargs, typed_pos_arg
 if T.TYPE_CHECKING:
     from . import ModuleState
     from ..interpreter import Interpreter
+    from ..mesonlib import FileOrString
 
     from typing_extensions import TypedDict
 

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -14,6 +14,7 @@
 
 '''This module provides helper functions for Gnome/GLib related
 functionality such as gobject-introspection, gresources and gtk-doc'''
+from __future__ import annotations
 
 import copy
 import itertools
@@ -30,7 +31,7 @@ from .. import build
 from .. import interpreter
 from .. import mesonlib
 from .. import mlog
-from ..build import BuildTarget, CustomTarget, CustomTargetIndex, Executable, GeneratedList, InvalidArguments
+from ..build import CustomTarget, CustomTargetIndex, Executable, GeneratedList, InvalidArguments
 from ..dependencies import Dependency, PkgConfigDependency, InternalDependency
 from ..interpreter.type_checking import DEPENDS_KW, DEPEND_FILES_KW, INSTALL_KW, NoneType, in_set_validator
 from ..interpreterbase import noPosargs, noKwargs, FeatureNew, FeatureDeprecated
@@ -46,6 +47,7 @@ if T.TYPE_CHECKING:
     from typing_extensions import Literal, TypedDict
 
     from . import ModuleState
+    from ..build import BuildTarget
     from ..compilers import Compiler
     from ..interpreter import Interpreter
     from ..interpreterbase import TYPE_var, TYPE_kwargs

--- a/mesonbuild/modules/java.py
+++ b/mesonbuild/modules/java.py
@@ -11,17 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import os
 import pathlib
 import typing as T
+
 from mesonbuild import mesonlib
 from mesonbuild.build import CustomTarget, CustomTargetIndex, GeneratedList, Target
-from mesonbuild.compilers import detect_compiler_for, Compiler
-from mesonbuild.interpreter import Interpreter
+from mesonbuild.compilers import detect_compiler_for
 from mesonbuild.interpreterbase.decorators import ContainerTypeInfo, FeatureDeprecated, FeatureNew, KwargInfo, typed_pos_args, typed_kwargs
 from mesonbuild.mesonlib import version_compare, MachineChoice
-from . import NewExtensionModule, ModuleReturnValue, ModuleState
+from . import NewExtensionModule, ModuleReturnValue
+
+if T.TYPE_CHECKING:
+    from . import ModuleState
+    from ..compilers import Compiler
+    from ..interpreter import Interpreter
 
 class JavaModule(NewExtensionModule):
     @FeatureNew('Java Module', '0.60.0')

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import os
 import shutil
@@ -23,17 +24,19 @@ from .. import build
 from .. import coredata
 from .. import mlog
 from ..dependencies import find_external_dependency, Dependency, ExternalLibrary
-from ..mesonlib import MesonException, File, FileOrString, version_compare, Popen_safe
+from ..mesonlib import MesonException, File, version_compare, Popen_safe
 from ..interpreter import extract_required_kwarg
 from ..interpreter.type_checking import NoneType
 from ..interpreterbase import ContainerTypeInfo, FeatureDeprecated, KwargInfo, noPosargs, FeatureNew, typed_kwargs
-from ..programs import ExternalProgram, NonExistingExternalProgram
+from ..programs import NonExistingExternalProgram
 
 if T.TYPE_CHECKING:
     from . import ModuleState
     from ..dependencies.qt import QtPkgConfigDependency, QmakeQtDependency
     from ..interpreter import Interpreter
     from ..interpreter import kwargs
+    from ..mesonlib import FileOrString
+    from ..programs import ExternalProgram
 
     QtDependencyType = T.Union[QtPkgConfigDependency, QmakeQtDependency]
 

--- a/mesonbuild/scripts/depscan.py
+++ b/mesonbuild/scripts/depscan.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import json
 import os
@@ -20,8 +21,11 @@ import re
 import sys
 import typing as T
 
-from ..backend.ninjabackend import TargetDependencyScannerInfo, ninja_quote
+from ..backend.ninjabackend import ninja_quote
 from ..compilers.compilers import lang_suffixes
+
+if T.TYPE_CHECKING:
+    from ..backend.ninjabackend import TargetDependencyScannerInfo
 
 CPP_IMPORT_RE = re.compile(r'\w*import ([a-zA-Z0-9]+);')
 CPP_EXPORT_RE = re.compile(r'\w*export module ([a-zA-Z0-9]+);')
@@ -38,13 +42,13 @@ FORTRAN_USE_RE = re.compile(FORTRAN_USE_PAT, re.IGNORECASE)
 class DependencyScanner:
     def __init__(self, pickle_file: str, outfile: str, sources: T.List[str]):
         with open(pickle_file, 'rb') as pf:
-            self.target_data = pickle.load(pf) # type: TargetDependencyScannerInfo
+            self.target_data: TargetDependencyScannerInfo = pickle.load(pf)
         self.outfile = outfile
         self.sources = sources
-        self.provided_by = {} # type: T.Dict[str, str]
-        self.exports = {} # type: T.Dict[str, str]
-        self.needs = {} # type: T.Dict[str, T.List[str]]
-        self.sources_with_exports = [] # type: T.List[str]
+        self.provided_by: T.Dict[str, str] = {}
+        self.exports: T.Dict[str, str] = {}
+        self.needs: T.Dict[str, T.List[str]] = {}
+        self.sources_with_exports: T.List[str] = []
 
     def scan_file(self, fname: str) -> None:
         suffix = os.path.splitext(fname)[1][1:].lower()

--- a/mesonbuild/scripts/run_tool.py
+++ b/mesonbuild/scripts/run_tool.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
-import subprocess
 import itertools
 import fnmatch
 from pathlib import Path
@@ -21,6 +21,9 @@ from concurrent.futures import ThreadPoolExecutor
 from ..compilers import lang_suffixes
 from ..mesonlib import Popen_safe
 import typing as T
+
+if T.TYPE_CHECKING:
+    import subprocess
 
 def parse_pattern_file(fname: Path) -> T.List[str]:
     patterns = []

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 # Work around some pathlib bugs...
 from mesonbuild import _pathlib
@@ -80,6 +81,20 @@ if T.TYPE_CHECKING:
         failfast: bool
         no_unittests: bool
         only: T.List[str]
+
+    # In previous python versions the global variables are lost in ProcessPoolExecutor.
+    # So, we use this tuple to restore some of them
+    class GlobalState(T.NamedTuple):
+        compile_commands:   T.List[str]
+        clean_commands:     T.List[str]
+        test_commands:      T.List[str]
+        install_commands:   T.List[str]
+        uninstall_commands: T.List[str]
+
+        backend:      'Backend'
+        backend_flags: T.List[str]
+
+        host_c_compiler: T.Optional[str]
 
 ALL_TESTS = ['cmake', 'common', 'native', 'warning-meson', 'failing-meson', 'failing-build', 'failing-test',
              'keyval', 'platform-osx', 'platform-windows', 'platform-linux',
@@ -586,20 +601,6 @@ def detect_parameter_files(test: TestDef, test_build_dir: str) -> T.Tuple[Path, 
         crossfile = format_parameter_file('crossfile.ini', test, test_build_dir)
 
     return nativefile, crossfile
-
-# In previous python versions the global variables are lost in ProcessPoolExecutor.
-# So, we use this tuple to restore some of them
-class GlobalState(T.NamedTuple):
-    compile_commands:   T.List[str]
-    clean_commands:     T.List[str]
-    test_commands:      T.List[str]
-    install_commands:   T.List[str]
-    uninstall_commands: T.List[str]
-
-    backend:      'Backend'
-    backend_flags: T.List[str]
-
-    host_c_compiler: T.Optional[str]
 
 def run_test(test: TestDef,
              extra_args: T.List[str],


### PR DESCRIPTION
- use `__future__.annotations`
- move imports to TYPE_CHECKING
- move type-checking classes to TYPE_CHECKING