### PR TITLE
better sanity checks on target output names

### DIFF
--- a/docs/markdown/i18n-module.md
+++ b/docs/markdown/i18n-module.md
@@ -46,7 +46,7 @@ This function also defines targets for maintainers to use:
 ### i18n.merge_file()
 
 This merges translations into a text file using `msgfmt`. See
-[[@custom_tgt]]
+[[custom_tgt]]
 for normal keywords. In addition it accepts these keywords:
 
 * `output`: same as `custom_target` but only accepts one item
@@ -63,7 +63,7 @@ for normal keywords. In addition it accepts these keywords:
 ### i18n.itstool_join()
 
 This joins translations into a XML file using `itstool`. See
-[[@custom_tgt]]
+[[custom_tgt]]
 for normal keywords. In addition it accepts these keywords:
 
 * `output`: same as `custom_target` but only accepts one item

--- a/docs/markdown/i18n-module.md
+++ b/docs/markdown/i18n-module.md
@@ -49,6 +49,9 @@ This merges translations into a text file using `msgfmt`. See
 [[@custom_tgt]]
 for normal keywords. In addition it accepts these keywords:
 
+* `output`: same as `custom_target` but only accepts one item
+* `install_dir`: same as `custom_target` but only accepts one item
+* `install_tag`: same as `custom_target` but only accepts one item
 * `data_dirs`: (*Added 0.41.0*) list of directories for its files (See
   also `i18n.gettext()`)
 * `po_dir`: directory containing translations, relative to current directory
@@ -63,6 +66,9 @@ This joins translations into a XML file using `itstool`. See
 [[@custom_tgt]]
 for normal keywords. In addition it accepts these keywords:
 
+* `output`: same as `custom_target` but only accepts one item
+* `install_dir`: same as `custom_target` but only accepts one item
+* `install_tag`: same as `custom_target` but only accepts one item
 * `its_files`: filenames of ITS files that should be used explicitly
   (XML translation rules are autodetected otherwise).
 * `mo_targets` *required*: mo file generation targets as returned by `i18n.gettext()`.

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -442,10 +442,10 @@ class NinjaBackend(backends.Backend):
         'benchmark', etc, and also for RunTargets.
         https://github.com/mesonbuild/meson/issues/1644
         '''
-        if dummy_outfile.startswith('meson-'):
+        if dummy_outfile.startswith('meson-internal__'):
             raise AssertionError(f'Invalid usage of create_phony_target with {dummy_outfile!r}')
 
-        to_name = f'meson-{dummy_outfile}'
+        to_name = f'meson-internal__{dummy_outfile}'
         elem = NinjaBuildElement(all_outputs, dummy_outfile, 'phony', to_name)
         self.add_build(elem)
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -58,6 +58,7 @@ from .type_checking import (
     CT_INPUT_KW,
     CT_INSTALL_DIR_KW,
     CT_OUTPUT_KW,
+    OUTPUT_KW,
     DEFAULT_OPTIONS,
     DEPENDS_KW,
     DEPEND_FILES_KW,
@@ -2392,7 +2393,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         KwargInfo('install', (bool, NoneType), since='0.50.0'),
         KwargInfo('install_dir', (str, bool), default='',
                   validator=lambda x: 'must be `false` if boolean' if x is True else None),
-        KwargInfo('output', str, required=True),
+        OUTPUT_KW,
         KwargInfo('output_format', str, default='c', since='0.47.0',
                   validator=in_set_validator({'c', 'nasm'})),
     )
@@ -2448,8 +2449,6 @@ class Interpreter(InterpreterBase, HoldableObject):
             mlog.warning('Output file', mlog.bold(ofile_rpath, True), 'for configure_file() at', current_call, 'overwrites configure_file() output at', first_call)
         else:
             self.configure_file_outputs[ofile_rpath] = self.current_lineno
-        if os.path.dirname(output) != '':
-            raise InterpreterException('Output file name must not contain a subdirectory.')
         (ofile_path, ofile_fname) = os.path.split(os.path.join(self.subdir, output))
         ofile_abs = os.path.join(self.environment.build_dir, ofile_path, ofile_fname)
 

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -2927,9 +2927,12 @@ Try setting b_lundef to false instead.'''.format(self.coredata.options[OptionKey
                     To define a target that builds in that directory you must define it
                     in the meson.build file in that directory.
             '''))
-        if name.startswith('meson-'):
-            raise InvalidArguments("Target names starting with 'meson-' are reserved "
+        if name.startswith('meson-internal__'):
+            raise InvalidArguments("Target names starting with 'meson-internal__' are reserved "
                                    "for Meson's internal use. Please rename.")
+        if name.startswith('meson-') and '.' not in name:
+            raise InvalidArguments("Target names starting with 'meson-' and without a file extension "
+                                   "are reserved for Meson's internal use. Please rename.")
         if name in coredata.FORBIDDEN_TARGET_NAMES:
             raise InvalidArguments(f"Target name '{name}' is reserved for Meson's "
                                    "internal use. Please rename.")

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -57,7 +57,7 @@ from .type_checking import (
     CT_BUILD_BY_DEFAULT,
     CT_INPUT_KW,
     CT_INSTALL_DIR_KW,
-    CT_OUTPUT_KW,
+    MULTI_OUTPUT_KW,
     OUTPUT_KW,
     DEFAULT_OPTIONS,
     DEPENDS_KW,
@@ -1761,7 +1761,7 @@ class Interpreter(InterpreterBase, HoldableObject):
     @typed_kwargs(
         'vcs_tag',
         CT_INPUT_KW.evolve(required=True),
-        CT_OUTPUT_KW,
+        MULTI_OUTPUT_KW,
         # Cannot use the COMMAND_KW because command is allowed to be empty
         KwargInfo(
             'command',
@@ -1851,7 +1851,7 @@ class Interpreter(InterpreterBase, HoldableObject):
         CT_INPUT_KW,
         CT_INSTALL_DIR_KW,
         CT_INSTALL_TAG_KW,
-        CT_OUTPUT_KW,
+        MULTI_OUTPUT_KW,
         DEPENDS_KW,
         DEPEND_FILES_KW,
         DEPFILE_KW,

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -277,6 +277,13 @@ CT_OUTPUT_KW: KwargInfo[T.List[str]] = KwargInfo(
     validator=_output_validator,
 )
 
+OUTPUT_KW: KwargInfo[str] = KwargInfo(
+    'output',
+    str,
+    required=True,
+    validator=lambda x: _output_validator([x])
+)
+
 CT_INPUT_KW: KwargInfo[T.List[T.Union[str, File, ExternalProgram, BuildTarget, CustomTarget, CustomTargetIndex, ExtractedObjects, GeneratedList]]] = KwargInfo(
     'input',
     ContainerTypeInfo(list, (str, File, ExternalProgram, BuildTarget, CustomTarget, CustomTargetIndex, ExtractedObjects, GeneratedList)),

--- a/mesonbuild/interpreter/type_checking.py
+++ b/mesonbuild/interpreter/type_checking.py
@@ -268,7 +268,7 @@ def _output_validator(outputs: T.List[str]) -> T.Optional[str]:
 
     return None
 
-CT_OUTPUT_KW: KwargInfo[T.List[str]] = KwargInfo(
+MULTI_OUTPUT_KW: KwargInfo[T.List[str]] = KwargInfo(
     'output',
     ContainerTypeInfo(list, str, allow_empty=False),
     listify=True,

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -20,7 +20,7 @@ from . import ExtensionModule, ModuleReturnValue
 from .. import build
 from .. import mesonlib
 from .. import mlog
-from ..interpreter.type_checking import CT_BUILD_BY_DEFAULT, CT_INPUT_KW, CT_INSTALL_DIR_KW, CT_INSTALL_TAG_KW, MULTI_OUTPUT_KW, INSTALL_KW, NoneType, in_set_validator
+from ..interpreter.type_checking import CT_BUILD_BY_DEFAULT, CT_INPUT_KW, INSTALL_TAG_KW, OUTPUT_KW, INSTALL_KW, NoneType, in_set_validator
 from ..interpreterbase import FeatureNew
 from ..interpreterbase.decorators import ContainerTypeInfo, KwargInfo, noPosargs, typed_kwargs, typed_pos_args
 from ..scripts.gettext import read_linguas
@@ -41,11 +41,11 @@ if T.TYPE_CHECKING:
             str, build.BuildTarget, build.CustomTarget, build.CustomTargetIndex,
             build.ExtractedObjects, build.GeneratedList, ExternalProgram,
             mesonlib.File]]
-        output: T.List[str]
+        output: str
         build_by_default: bool
         install: bool
-        install_dir: T.List[T.Union[str, bool]]
-        install_tag: T.List[str]
+        install_dir: T.Optional[str]
+        install_tag: T.Optional[str]
         args: T.List[str]
         data_dirs: T.List[str]
         po_dir: str
@@ -66,11 +66,11 @@ if T.TYPE_CHECKING:
             str, build.BuildTarget, build.CustomTarget, build.CustomTargetIndex,
             build.ExtractedObjects, build.GeneratedList, ExternalProgram,
             mesonlib.File]]
-        output: T.List[str]
+        output: str
         build_by_default: bool
         install: bool
-        install_dir: T.List[T.Union[str, bool]]
-        install_tag: T.List[str]
+        install_dir: T.Optional[str]
+        install_tag: T.Optional[str]
         its_files: T.List[str]
         mo_targets: T.List[T.Union[build.BuildTarget, build.CustomTarget, build.CustomTargetIndex]]
 
@@ -152,9 +152,9 @@ class I18nModule(ExtensionModule):
         'i18n.merge_file',
         CT_BUILD_BY_DEFAULT,
         CT_INPUT_KW,
-        CT_INSTALL_DIR_KW,
-        CT_INSTALL_TAG_KW,
-        MULTI_OUTPUT_KW,
+        KwargInfo('install_dir', (str, NoneType)),
+        INSTALL_TAG_KW,
+        OUTPUT_KW,
         INSTALL_KW,
         _ARGS.evolve(since='0.51.0'),
         _DATA_DIRS.evolve(since='0.41.0'),
@@ -187,6 +187,9 @@ class I18nModule(ExtensionModule):
         if build_by_default is None:
             build_by_default = kwargs['install']
 
+        install_dir = [kwargs['install_dir']] if kwargs['install_dir'] is not None else None
+        install_tag = [kwargs['install_tag']] if kwargs['install_tag'] is not None else None
+
         ct = build.CustomTarget(
             '',
             state.subdir,
@@ -194,11 +197,11 @@ class I18nModule(ExtensionModule):
             state.environment,
             command,
             kwargs['input'],
-            kwargs['output'],
+            [kwargs['output']],
             build_by_default=build_by_default,
             install=kwargs['install'],
-            install_dir=kwargs['install_dir'],
-            install_tag=kwargs['install_tag'],
+            install_dir=install_dir,
+            install_tag=install_tag,
         )
 
         return ModuleReturnValue(ct, [ct])
@@ -321,9 +324,9 @@ class I18nModule(ExtensionModule):
         'i18n.itstool_join',
         CT_BUILD_BY_DEFAULT,
         CT_INPUT_KW,
-        CT_INSTALL_DIR_KW,
-        CT_INSTALL_TAG_KW,
-        MULTI_OUTPUT_KW,
+        KwargInfo('install_dir', (str, NoneType)),
+        INSTALL_TAG_KW,
+        OUTPUT_KW,
         INSTALL_KW,
         _ARGS.evolve(),
         KwargInfo('its_files', ContainerTypeInfo(list, str)),
@@ -359,6 +362,9 @@ class I18nModule(ExtensionModule):
         if build_by_default is None:
             build_by_default = kwargs['install']
 
+        install_dir = [kwargs['install_dir']] if kwargs['install_dir'] is not None else None
+        install_tag = [kwargs['install_tag']] if kwargs['install_tag'] is not None else None
+
         ct = build.CustomTarget(
             '',
             state.subdir,
@@ -366,12 +372,12 @@ class I18nModule(ExtensionModule):
             state.environment,
             command,
             kwargs['input'],
-            kwargs['output'],
+            [kwargs['output']],
             build_by_default=build_by_default,
             extra_depends=mo_targets,
             install=kwargs['install'],
-            install_dir=kwargs['install_dir'],
-            install_tag=kwargs['install_tag'],
+            install_dir=install_dir,
+            install_tag=install_tag,
         )
 
         return ModuleReturnValue(ct, [ct])

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -20,7 +20,7 @@ from . import ExtensionModule, ModuleReturnValue
 from .. import build
 from .. import mesonlib
 from .. import mlog
-from ..interpreter.type_checking import CT_BUILD_BY_DEFAULT, CT_INPUT_KW, CT_INSTALL_DIR_KW, CT_INSTALL_TAG_KW, CT_OUTPUT_KW, INSTALL_KW, NoneType, in_set_validator
+from ..interpreter.type_checking import CT_BUILD_BY_DEFAULT, CT_INPUT_KW, CT_INSTALL_DIR_KW, CT_INSTALL_TAG_KW, MULTI_OUTPUT_KW, INSTALL_KW, NoneType, in_set_validator
 from ..interpreterbase import FeatureNew
 from ..interpreterbase.decorators import ContainerTypeInfo, KwargInfo, noPosargs, typed_kwargs, typed_pos_args
 from ..scripts.gettext import read_linguas
@@ -154,7 +154,7 @@ class I18nModule(ExtensionModule):
         CT_INPUT_KW,
         CT_INSTALL_DIR_KW,
         CT_INSTALL_TAG_KW,
-        CT_OUTPUT_KW,
+        MULTI_OUTPUT_KW,
         INSTALL_KW,
         _ARGS.evolve(since='0.51.0'),
         _DATA_DIRS.evolve(since='0.41.0'),
@@ -323,7 +323,7 @@ class I18nModule(ExtensionModule):
         CT_INPUT_KW,
         CT_INSTALL_DIR_KW,
         CT_INSTALL_TAG_KW,
-        CT_OUTPUT_KW,
+        MULTI_OUTPUT_KW,
         INSTALL_KW,
         _ARGS.evolve(),
         KwargInfo('its_files', ContainerTypeInfo(list, str)),

--- a/mesonbuild/modules/unstable_rust.py
+++ b/mesonbuild/modules/unstable_rust.py
@@ -19,7 +19,7 @@ from . import ExtensionModule, ModuleReturnValue
 from .. import mlog
 from ..build import BothLibraries, BuildTarget, CustomTargetIndex, Executable, ExtractedObjects, GeneratedList, IncludeDirs, CustomTarget, StructuredSources
 from ..dependencies import Dependency, ExternalLibrary
-from ..interpreter.interpreter import TEST_KWARGS
+from ..interpreter.interpreter import TEST_KWARGS, OUTPUT_KW
 from ..interpreterbase import ContainerTypeInfo, InterpreterException, KwargInfo, FeatureNew, typed_kwargs, typed_pos_args, noPosargs
 from ..mesonlib import File
 
@@ -173,7 +173,7 @@ class RustModule(ExtensionModule):
             listify=True,
             required=True,
         ),
-        KwargInfo('output', str, required=True),
+        OUTPUT_KW,
     )
     def bindgen(self, state: 'ModuleState', args: T.List, kwargs: 'FuncBindgen') -> ModuleReturnValue:
         """Wrapper around bindgen to simplify it's use.

--- a/test cases/failing/26 output subdir/test.json
+++ b/test cases/failing/26 output subdir/test.json
@@ -1,7 +1,7 @@
 {
   "stdout": [
     {
-      "line": "test cases/failing/26 output subdir/meson.build:3:0: ERROR: Output file name must not contain a subdirectory."
+      "line": "test cases/failing/26 output subdir/meson.build:3:0: ERROR: configure_file keyword argument \"output\" Output 'subdir/foo' must not contain a path segment."
     }
   ]
 }


### PR DESCRIPTION
I started this journey wondering whether it was possible to create bad ninja targets that clash with builtin target names. Turns out it is possible, but only in very specify circumstances.

While looking at that and inspecting the sanity checking for custom_target's `output:` kwarg, I noticed that it does a lot of useful checks that aren't necessarily being done elsewhere, such as configure_file which turned out to not actually need the first fix.

So yeah, turns out that we need to do custom_target's output validator checks in several more places. Let's do that.