### PR TITLE
gnome module: properly fallback to gtk-update-icon-cache

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -371,7 +371,7 @@ class GnomeModule(ExtensionModule):
             prog = state.find_program('gtk4-update-icon-cache', required=False)
             found = isinstance(prog, build.Executable) or prog.found()
             if not found:
-                prog = state.find_program('gtk4-update-icon-cache')
+                prog = state.find_program('gtk-update-icon-cache')
             icondir = os.path.join(datadir_abs, 'icons', 'hicolor')
             script = state.backend.get_executable_serialisation([prog, '-q', '-t', '-f', icondir])
             script.skip_if_destdir = True


### PR DESCRIPTION
Commit [a0cade8f](https://github.com/mesonbuild/meson/commit/a0cade8f1d1470cf3203baae16d181eb4df8e9fe) introduced a typo and wrongly checks for gtk4-update-icon-cache twice.
If gtk4-update-icon-cache (gtk4) is not found, look for gtk-update-icon-cache (gtk3) instead.