### PR TITLE
packaging: rework how pyinstaller gets its instructions

### DIFF
--- a/packaging/createmsi.py
+++ b/packaging/createmsi.py
@@ -39,49 +39,6 @@ def gen_guid():
     '''
     return str(uuid.uuid4()).upper()
 
-def get_all_modules_from_dir(dirname):
-    '''
-    Get all modules required for Meson build MSI package
-    from directories.
-    '''
-    modname = os.path.basename(dirname)
-    modules = [os.path.splitext(os.path.split(x)[1])[0] for x in glob(os.path.join(dirname, '*'))]
-    modules = ['mesonbuild.' + modname + '.' + x for x in modules if not x.startswith('_')]
-    return modules
-
-def get_more_modules():
-    '''
-        Getter for missing Modules.
-        Python packagers want to be minimal and only copy the things
-        that they can see that being used. They are blind to many things.
-    '''
-    return ['distutils.archive_util',
-            'distutils.cmd',
-            'distutils.config',
-            'distutils.core',
-            'distutils.debug',
-            'distutils.dep_util',
-            'distutils.dir_util',
-            'distutils.dist',
-            'distutils.errors',
-            'distutils.extension',
-            'distutils.fancy_getopt',
-            'distutils.file_util',
-            'distutils.spawn',
-            'distutils.util',
-            'distutils.version',
-            'distutils.command.build_ext',
-            'distutils.command.build',
-            'distutils.command.install',
-            'filecmp',
-            ]
-
-def get_modules():
-    modules = get_all_modules_from_dir('mesonbuild/modules')
-    modules += get_all_modules_from_dir('mesonbuild/scripts')
-    modules += get_more_modules()
-    return modules
-
 class Node:
     '''
        Node to hold path and directory values
@@ -166,7 +123,6 @@ class PackageGenerator:
             if os.path.exists(sdir):
                 shutil.rmtree(sdir)
         main_stage, ninja_stage = self.staging_dirs
-        modules = get_modules()
 
         pyinstaller = shutil.which('pyinstaller')
         if not pyinstaller:
@@ -178,10 +134,9 @@ class PackageGenerator:
             shutil.rmtree(pyinstaller_tmpdir)
         pyinst_cmd = [pyinstaller,
                       '--clean',
+                      '--additional-hooks-dir=packaging',
                       '--distpath',
                       pyinstaller_tmpdir]
-        for m in modules:
-            pyinst_cmd += ['--hidden-import', m]
         pyinst_cmd += ['meson.py']
         subprocess.check_call(pyinst_cmd)
         shutil.move(pyinstaller_tmpdir + '/meson', main_stage)

--- a/packaging/createpkg.py
+++ b/packaging/createpkg.py
@@ -22,8 +22,6 @@ import xml.etree.ElementTree as ET
 sys.path.append(os.getcwd())
 from mesonbuild import coredata
 
-from createmsi import get_modules
-
 class PkgGenerator:
 
     def __init__(self):
@@ -46,10 +44,9 @@ class PkgGenerator:
         pyinstaller_bin = '/Users/jpakkane/Library/Python/3.8/bin/pyinstaller'
         pyinst_cmd = [pyinstaller_bin,
                       '--clean',
+                      '--additional-hooks-dir=packaging',
                       '--distpath',
                       self.pkg_dir]
-        for m in get_modules():
-            pyinst_cmd += ['--hidden-import', m]
         pyinst_cmd += ['meson.py']
         subprocess.check_call(pyinst_cmd)
         tmpdir = os.path.join(self.pkg_dir, 'meson')

--- a/packaging/hook-mesonbuild.py
+++ b/packaging/hook-mesonbuild.py
@@ -1,0 +1,49 @@
+#!hint/python3
+
+"""
+PyInstaller hook to make mesonbuild include everything it needs to.
+"""
+
+import os
+from glob import glob
+
+hiddenimports = []
+
+def get_all_modules_from_dir(dirname):
+    '''
+    Get all modules required for Meson itself from directories.
+    '''
+    modname = os.path.basename(dirname)
+    modules = [os.path.splitext(os.path.split(x)[1])[0] for x in glob(os.path.join(dirname, '*'))]
+    modules = ['mesonbuild.' + modname + '.' + x for x in modules if not x.startswith('_')]
+    return modules
+
+hiddenimports += get_all_modules_from_dir('mesonbuild/modules')
+hiddenimports += get_all_modules_from_dir('mesonbuild/scripts')
+
+# Python packagers want to be minimal and only copy the things
+# that they can see being used. They are blind to many things.
+hiddenimports += [
+    # we run distutils as a subprocess via INTROSPECT_COMMAND.
+    'distutils.archive_util',
+    'distutils.cmd',
+    'distutils.config',
+    'distutils.core',
+    'distutils.debug',
+    'distutils.dep_util',
+    'distutils.dir_util',
+    'distutils.dist',
+    'distutils.errors',
+    'distutils.extension',
+    'distutils.fancy_getopt',
+    'distutils.file_util',
+    'distutils.spawn',
+    'distutils.util',
+    'distutils.version',
+    'distutils.command.build_ext',
+    'distutils.command.build',
+    'distutils.command.install',
+
+    # needed for gtk's find_program() scripts
+    'filecmp',
+]


### PR DESCRIPTION
Make use of pyinstaller hooks by creating a hook that updates how the `mesonbuild` import functions.

This is more or less the same as passing a bajillion arguments to pyinstaller's CLI, but allows the logic to be self-contained (and reusable). It becomes more obvious what parts of the process pertain to pyinstaller, and which parts pertain to MSI/pkg creation.

@jpakkane please confirm this still works. I was only able to perform... limited testing of this on Linux.