### PR TITLE
i18n: don't let our maintainer targets run via wrapped env

### DIFF
--- a/mesonbuild/backend/backends.py
+++ b/mesonbuild/backend/backends.py
@@ -1445,11 +1445,12 @@ class Backend:
 
     def get_run_target_env(self, target: build.RunTarget) -> build.EnvironmentVariables:
         env = target.env if target.env else build.EnvironmentVariables()
-        introspect_cmd = join_args(self.environment.get_build_command() + ['introspect'])
-        env.set('MESON_SOURCE_ROOT', [self.environment.get_source_dir()])
-        env.set('MESON_BUILD_ROOT', [self.environment.get_build_dir()])
-        env.set('MESON_SUBDIR', [target.subdir])
-        env.set('MESONINTROSPECT', [introspect_cmd])
+        if target.default_env:
+            introspect_cmd = join_args(self.environment.get_build_command() + ['introspect'])
+            env.set('MESON_SOURCE_ROOT', [self.environment.get_source_dir()])
+            env.set('MESON_BUILD_ROOT', [self.environment.get_build_dir()])
+            env.set('MESON_SUBDIR', [target.subdir])
+            env.set('MESONINTROSPECT', [introspect_cmd])
         return env
 
     def run_postconf_scripts(self) -> None:

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 from collections import OrderedDict
 from enum import Enum, unique
@@ -1034,7 +1035,7 @@ class NinjaBackend(backends.Backend):
             subproject_prefix = ''
         return f'{subproject_prefix}{target.name}'
 
-    def generate_run_target(self, target):
+    def generate_run_target(self, target: build.RunTarget):
         target_name = self.build_run_target_name(target)
         if not target.command:
             # This is an alias target, it has no command, it just depends on
@@ -1044,9 +1045,9 @@ class NinjaBackend(backends.Backend):
             target_env = self.get_run_target_env(target)
             _, _, cmd = self.eval_custom_target_command(target)
             meson_exe_cmd, reason = self.as_meson_exe_cmdline(target.command[0], cmd[1:],
-                                                              force_serialize=True, env=target_env,
+                                                              env=target_env,
                                                               verbose=True)
-            cmd_type = f' (wrapped by meson {reason})'
+            cmd_type = f' (wrapped by meson {reason})' if reason else ''
             internal_target_name = f'meson-{target_name}'
             elem = NinjaBuildElement(self.all_outputs, internal_target_name, 'CUSTOM_COMMAND', [])
             elem.add_item('COMMAND', meson_exe_cmd)

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -2596,7 +2596,8 @@ class RunTarget(Target, CommandBase):
                  subdir: str,
                  subproject: str,
                  environment: environment.Environment,
-                 env: T.Optional['EnvironmentVariables'] = None):
+                 env: T.Optional['EnvironmentVariables'] = None,
+                 default_env: bool = True):
         self.typename = 'run'
         # These don't produce output artifacts
         super().__init__(name, subdir, subproject, False, MachineChoice.BUILD, environment)
@@ -2605,6 +2606,7 @@ class RunTarget(Target, CommandBase):
         self.command = self.flatten_command(command)
         self.absolute_paths = False
         self.env = env
+        self.default_env = default_env
 
     def __repr__(self) -> str:
         repr_str = "<{0} {1}: {2}>"

--- a/mesonbuild/modules/i18n.py
+++ b/mesonbuild/modules/i18n.py
@@ -257,7 +257,7 @@ class I18nModule(ExtensionModule):
             potargs.append(extra_arg)
         potargs.append('--xgettext=' + self.tools['xgettext'].get_path())
         pottarget = build.RunTarget(packagename + '-pot', potargs, [], state.subdir, state.subproject,
-                                    state.environment)
+                                    state.environment, default_env=False)
         targets.append(pottarget)
 
         install = kwargs['install']
@@ -301,7 +301,7 @@ class I18nModule(ExtensionModule):
         for tool in ['msginit', 'msgmerge']:
             updatepoargs.append(f'--{tool}=' + self.tools[tool].get_path())
         updatepotarget = build.RunTarget(packagename + '-update-po', updatepoargs, [], state.subdir, state.subproject,
-                                         state.environment)
+                                         state.environment, default_env=False)
         targets.append(updatepotarget)
 
         return ModuleReturnValue([gmotargets, pottarget, updatepotarget], targets)


### PR DESCRIPTION
They are RunTargets because they are one-shot commands without outputs. But we implement them purely via our internal wrapper for gettext, so there is no reason to wrap them *again* in our internal wrapper for meson_exe and set a bunch of environment variables we know we absolutely do not need, use, or want.

This avoids the ugly "wrapped due to env" status, and allows users to directly see the command being run without going into despair at obscure pickled nonsense.

It also offers a tiny defense against upgrading Meson without reconfiguring. People should not do that, and we error out about this in a bunch of places, but `--internal gettext` has a perfectly stable interface just like most build tools that aren't part of Meson internals, since it uses command line arguments instead of pickling.