### PR TITLE
mdist: allow passing options to setup, allow specifying options to setup in meson.build

### DIFF
--- a/docs/markdown/Creating-releases.md
+++ b/docs/markdown/Creating-releases.md
@@ -60,6 +60,13 @@ for example when done in CI that already does its own testing.
 So with `--no-tests` you can tell Meson "Do not build and test generated
 packages.".
 
+## Run the build and test with custom configurations
+
+The `meson dist` comand accepts arbitrary arguments after `--`, which will be
+forwarded to `meson setup` when invoking the build and test step of the
+generated packages. It can be used to perform a distcheck for specific
+configurations.
+
 ## Use `--allow-dirty` to override error when git repository contains uncommitted changes
 
 *Since 0.62.0* Instead of emitting a warning when a repository contains

--- a/docs/markdown/snippets/add_dist_args.md
+++ b/docs/markdown/snippets/add_dist_args.md
@@ -1,0 +1,6 @@
+## It is now possible to customize the setup arguments to ninja dist
+
+A new function has been added: [[meson.add_dist_args]]. This allows specifying
+arguments which will be used in the generated `ninja dist` target to customize
+how the distcheck stage will configure the build. By default a distcheck simply
+uses the same configuration as the main build.

--- a/docs/markdown/snippets/dist-accepts-setup-args.md
+++ b/docs/markdown/snippets/dist-accepts-setup-args.md
@@ -1,0 +1,6 @@
+## dist now accepts arguments to be passed to setup
+
+When performing a distcheck, it is sometimes desirable to check various
+configurations. Previously, Meson ran the distcheck using the same
+configuration as the current build. Now it is possible to override this in
+`meson dist` without first reconfiguring the main build.

--- a/docs/yaml/builtins/meson.yaml
+++ b/docs/yaml/builtins/meson.yaml
@@ -5,6 +5,18 @@ description: |
   system. This object is always mapped in the `meson` variable.
 
 methods:
+  - name: add_dist_args
+    returns: void
+    since: 0.63.0
+    description: |
+      Passes additional arguments to `meson dist` to be used when building and
+      testing the generated tarball.
+
+    varargs:
+      name: arg
+      type: str
+      description: the args to pass
+
   - name: add_dist_script
     returns: void
     since: 0.48.0

--- a/mesonbuild/backend/ninjabackend.py
+++ b/mesonbuild/backend/ninjabackend.py
@@ -3208,9 +3208,13 @@ https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47485'''))
         return sorted(cmds)
 
     def generate_dist(self):
+        if self.build.dist_args_exclusive:
+            dist_args = self.build.dist_args_exclusive
+        else:
+            dist_args = ['--reuse-setup-args'] + self.build.dist_args
         elem = NinjaBuildElement(self.all_outputs, 'meson-dist', 'CUSTOM_COMMAND', 'PHONY')
         elem.add_item('DESC', 'Creating source packages')
-        elem.add_item('COMMAND', self.environment.get_build_command() + ['dist'])
+        elem.add_item('COMMAND', self.environment.get_build_command() + ['dist'] + dist_args)
         elem.add_item('pool', 'console')
         self.add_build(elem)
         # Alias that runs the target defined above

--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -236,6 +236,8 @@ class Build:
         self.subproject_dir = ''
         self.install_scripts: T.List['ExecutableSerialisation'] = []
         self.postconf_scripts: T.List['ExecutableSerialisation'] = []
+        self.dist_args: T.List[str] = []
+        self.dist_args_exclusive: T.List[str] = []
         self.dist_scripts: T.List['ExecutableSerialisation'] = []
         self.install_dirs: T.List[InstallDir] = []
         self.dep_manifest_name: T.Optional[str] = None

--- a/mesonbuild/mdist.py
+++ b/mesonbuild/mdist.py
@@ -326,7 +326,7 @@ def run(options):
     archives = determine_archives_to_generate(options)
 
     subprojects = {}
-    extra_meson_args = []
+    extra_meson_args = ['setup']
 
     if options.reuse_setup_args or not options.SETUP_ARGS:
         extra_meson_args += create_cmdline_args(bld_root)


### PR DESCRIPTION
Also reduce the number of arguments manually specified when reading currently active config.

Fixes #10181