### PR TITLE
runpython: support --version

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -18,6 +18,7 @@ import sys
 sys.modules['pathlib'] = _pathlib
 
 import os.path
+import platform
 import importlib
 import traceback
 import argparse
@@ -93,15 +94,18 @@ class CommandLineParser:
         for i in [name] + aliases:
             self.commands[i] = p
 
-    def add_runpython_arguments(self, parser):
+    def add_runpython_arguments(self, parser: argparse.ArgumentParser):
         parser.add_argument('-c', action='store_true', dest='eval_arg', default=False)
-        parser.add_argument('script_file')
+        parser.add_argument('--version', action='store_true')
+        parser.add_argument('script_file', nargs='?')
         parser.add_argument('script_args', nargs=argparse.REMAINDER)
 
     def run_runpython_command(self, options):
         import runpy
         if options.eval_arg:
             exec(options.script_file)
+        elif options.version:
+            print(platform.python_version())
         else:
             sys.argv[1:] = options.script_args
             sys.path.insert(0, os.path.dirname(options.script_file))


### PR DESCRIPTION
argparse is the gift that keeps on giving, hahaha. Suppress the script argument when --version is specified to avoid "required argument not provided" errors, and print the python version.

The version argument is required in order to make this baseline functional as a resolved python for find_program, which may specify a version and expect this to work with python itself. Our incomplete CLI wrapper over the python CLI interface was missing this.

Fixes #10162