### PR TITLE
interpreter: add a new function add_project_dependencies()

### DIFF
--- a/data/syntax-highlighting/vim/syntax/meson.vim
+++ b/data/syntax-highlighting/vim/syntax/meson.vim
@@ -68,6 +68,7 @@ syn keyword mesonBuiltin
   \ add_global_link_arguments
   \ add_languages
   \ add_project_arguments
+  \ add_project_dependencies
   \ add_project_link_arguments
   \ add_test_setup
   \ alias_target

--- a/docs/markdown/snippets/add_project_dependencies.md
+++ b/docs/markdown/snippets/add_project_dependencies.md
@@ -1,0 +1,11 @@
+## `add_project_dependencies()` function
+
+Dependencies can now be added to all build products using
+`add_project_dependencies()`.  This can be useful in several
+cases:
+
+* with special dependencies such as `dependency('threads')`
+* with system libraries such as `find_library('m')`
+* with the `include_directories` keyword argument of
+`declare_dependency()`, to add both source and build
+directories to the include search path

--- a/docs/yaml/functions/add_project_dependencies.yaml
+++ b/docs/yaml/functions/add_project_dependencies.yaml
@@ -1,0 +1,16 @@
+name: add_project_dependencies
+since: 0.63.0
+returns: void
+description: |
+  Adds arguments to the compiler and linker command line, so that the
+  given set of dependencies is included in all build products for this
+  project.
+
+
+varargs:
+  type: dep
+  name: dependencies
+  description: The dependencies to add; if internal dependencies are included,
+    they must not include any built object.
+
+kwargs_inherit: add_global_arguments

--- a/mesonbuild/ast/interpreter.py
+++ b/mesonbuild/ast/interpreter.py
@@ -114,6 +114,7 @@ class AstInterpreter(InterpreterBase):
                            'add_global_arguments': self.func_do_nothing,
                            'add_global_link_arguments': self.func_do_nothing,
                            'add_project_arguments': self.func_do_nothing,
+                           'add_project_dependencies': self.func_do_nothing,
                            'add_project_link_arguments': self.func_do_nothing,
                            'message': self.func_do_nothing,
                            'generator': self.func_do_nothing,

--- a/mesonbuild/dependencies/__init__.py
+++ b/mesonbuild/dependencies/__init__.py
@@ -18,7 +18,7 @@ from .hdf5 import hdf5_factory
 from .base import Dependency, InternalDependency, ExternalDependency, NotFoundDependency
 from .base import (
         ExternalLibrary, DependencyException, DependencyMethods,
-        BuiltinDependency, SystemDependency)
+        BuiltinDependency, SystemDependency, get_leaf_external_dependencies)
 from .cmake import CMakeDependency
 from .configtool import ConfigToolDependency
 from .dub import DubDependency
@@ -65,6 +65,7 @@ __all__ = [
 
     'find_external_dependency',
     'get_dep_identifier',
+    'get_leaf_external_dependencies',
 ]
 
 """Dependency representations and discovery logic.

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -23,7 +23,7 @@ import itertools
 import typing as T
 from enum import Enum
 
-from .. import mlog
+from .. import mlog, mesonlib
 from ..compilers import clib_langs
 from ..mesonlib import LibType, MachineChoice, MesonException, HoldableObject
 from ..mesonlib import version_compare_many
@@ -459,6 +459,22 @@ class ExternalLibrary(ExternalDependency):
         if not link_args:
             new.link_args = []
         return new
+
+
+def get_leaf_external_dependencies(deps: T.List[Dependency]) -> T.List[Dependency]:
+    if not deps:
+        # Ensure that we always return a new instance
+        return deps.copy()
+    final_deps = []
+    while deps:
+        next_deps = []
+        for d in mesonlib.listify(deps):
+            if not isinstance(d, Dependency) or d.is_built():
+                raise DependencyException('Dependencies must be external dependencies')
+            final_deps.append(d)
+            next_deps.extend(d.ext_deps)
+        deps = next_deps
+    return final_deps
 
 
 def sort_libpaths(libpaths: T.List[str], refpaths: T.List[str]) -> T.List[str]:

--- a/mesonbuild/dependencies/base.py
+++ b/mesonbuild/dependencies/base.py
@@ -165,6 +165,9 @@ class Dependency(HoldableObject):
         else:
             return 'unknown'
 
+    def get_include_dirs(self) -> T.List['IncludeDirs']:
+        return []
+
     def get_include_type(self) -> str:
         return self.include_type
 
@@ -297,6 +300,9 @@ class InternalDependency(Dependency):
             self.version, final_includes, final_compile_args,
             final_link_args, final_libraries, final_whole_libraries,
             final_sources, final_deps, self.variables, [], [])
+
+    def get_include_dirs(self) -> T.List['IncludeDirs']:
+        return self.include_directories
 
     def get_variable(self, *, cmake: T.Optional[str] = None, pkgconfig: T.Optional[str] = None,
                      configtool: T.Optional[str] = None, internal: T.Optional[str] = None,

--- a/mesonbuild/interpreter/compiler.py
+++ b/mesonbuild/interpreter/compiler.py
@@ -239,20 +239,7 @@ class CompilerHolder(ObjectHolder['Compiler']):
         return args
 
     def _determine_dependencies(self, deps: T.List['dependencies.Dependency'], endl: str = ':') -> T.Tuple[T.List['dependencies.Dependency'], str]:
-        if deps:
-            final_deps = []
-            while deps:
-                next_deps = []
-                for d in mesonlib.listify(deps):
-                    if not isinstance(d, dependencies.Dependency) or d.is_built():
-                        raise InterpreterException('Dependencies must be external dependencies')
-                    final_deps.append(d)
-                    next_deps.extend(d.ext_deps)
-                deps = next_deps
-            deps = final_deps
-        else:
-            # Ensure that we always return a new instance
-            deps = deps.copy()
+        deps = dependencies.get_leaf_external_dependencies(deps)
         return deps, self._dep_msg(deps, endl)
 
     @typed_pos_args('compiler.alignment', str)

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -669,7 +669,6 @@ class Interpreter(InterpreterBase, HoldableObject):
         variables = self.extract_variables(kwargs, list_new=True)
         d_module_versions = extract_as_list(kwargs, 'd_module_versions')
         d_import_dirs = self.extract_incdirs(kwargs, 'd_import_dirs')
-        final_deps = []
         srcdir = Path(self.environment.source_dir)
         # convert variables which refer to an -uninstalled.pc style datadir
         for k, v in variables.items():
@@ -683,15 +682,14 @@ class Interpreter(InterpreterBase, HoldableObject):
                 if p.is_absolute() and p.is_dir() and srcdir / self.root_subdir in p.resolve().parents:
                     variables[k] = P_OBJ.DependencyVariableString(v)
         for d in deps:
-            if not isinstance(d, (dependencies.Dependency, dependencies.ExternalLibrary, dependencies.InternalDependency)):
-                raise InterpreterException('Dependencies must be external deps')
-            final_deps.append(d)
+            if not isinstance(d, dependencies.Dependency):
+                raise InterpreterException('Invalid dependency')
         for l in libs:
             if isinstance(l, dependencies.Dependency):
                 raise InterpreterException('''Entries in "link_with" may only be self-built targets,
 external dependencies (including libraries) must go to "dependencies".''')
         dep = dependencies.InternalDependency(version, incs, compile_args,
-                                              link_args, libs, libs_whole, sources, final_deps,
+                                              link_args, libs, libs_whole, sources, deps,
                                               variables, d_module_versions, d_import_dirs)
         return dep
 

--- a/test cases/common/251 add_project_dependencies/inc/lib.h
+++ b/test cases/common/251 add_project_dependencies/inc/lib.h
@@ -1,0 +1,2 @@
+#pragma once
+extern int ok(void);

--- a/test cases/common/251 add_project_dependencies/lib.c
+++ b/test cases/common/251 add_project_dependencies/lib.c
@@ -1,0 +1,14 @@
+#include <zlib.h>
+#include <math.h>
+
+#ifndef DEFINED
+#error expected compile_arg not found
+#endif
+
+double zero;
+int ok(void) {
+    void * something = deflate;
+    if(something != 0)
+        return 0;
+    return (int)cos(zero);
+}

--- a/test cases/common/251 add_project_dependencies/main.c
+++ b/test cases/common/251 add_project_dependencies/main.c
@@ -1,0 +1,5 @@
+#include "lib.h"
+
+int main(void) {
+    return ok();
+}

--- a/test cases/common/251 add_project_dependencies/meson.build
+++ b/test cases/common/251 add_project_dependencies/meson.build
@@ -1,0 +1,22 @@
+project('zlib system dependency', 'c')
+
+cc = meson.get_compiler('c')
+
+m = cc.find_library('m', required: false)
+add_project_dependencies(m, language: ['c'])
+
+z = dependency('zlib', method: 'system', required: false)
+if not z.found()
+  error('MESON_SKIP_TEST zlib not present')
+endif
+
+z_c_args = z.partial_dependency(compile_args: true, includes: true)
+add_project_dependencies(z_c_args, language: 'c', native: false)
+
+global_dep = declare_dependency(include_directories: include_directories('inc'),
+                                compile_args: '-DDEFINED')
+add_project_dependencies(global_dep, language: 'c', native: false)
+
+lib = static_library('rary', 'lib.c')
+exe = executable('prog', 'main.c', link_with: lib, dependencies: z)
+test('test', exe)

--- a/test cases/failing/124 override and add_project_dependency/inc/lib.h
+++ b/test cases/failing/124 override and add_project_dependency/inc/lib.h
@@ -1,0 +1,2 @@
+#pragma once
+void f(void);

--- a/test cases/failing/124 override and add_project_dependency/lib.c
+++ b/test cases/failing/124 override and add_project_dependency/lib.c
@@ -1,0 +1,3 @@
+#include <stdio.h>
+#include "lib.h"
+void f() {puts("hello");}

--- a/test cases/failing/124 override and add_project_dependency/meson.build
+++ b/test cases/failing/124 override and add_project_dependency/meson.build
@@ -1,0 +1,8 @@
+project('super', 'c')
+
+inc = include_directories('inc')
+lib = static_library('sneaky', 'lib.c', include_directories: inc)
+meson.override_dependency('sneaky',
+  declare_dependency(link_with: lib, include_directories: inc))
+
+subproject('a')

--- a/test cases/failing/124 override and add_project_dependency/subprojects/a/meson.build
+++ b/test cases/failing/124 override and add_project_dependency/subprojects/a/meson.build
@@ -1,0 +1,10 @@
+project('a', 'c')
+
+dep = dependency('sneaky')
+
+# does not work
+add_project_dependencies(dep, language: 'c')
+executable('prog', 'prog.c')
+
+# this would work instead:
+# executable('prog', 'prog.c', dependencies: dep)

--- a/test cases/failing/124 override and add_project_dependency/subprojects/a/prog.c
+++ b/test cases/failing/124 override and add_project_dependency/subprojects/a/prog.c
@@ -1,0 +1,6 @@
+#include "lib.h"
+
+int main() {
+    f();
+    return 0;
+}

--- a/test cases/failing/124 override and add_project_dependency/test.json
+++ b/test cases/failing/124 override and add_project_dependency/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/124 override and add_project_dependency/subprojects/a/meson.build:6:0: ERROR: Dependencies must be external dependencies"
+    }
+  ]
+}

--- a/test cases/failing/125 targets before add_project_dependency/inc/lib.h
+++ b/test cases/failing/125 targets before add_project_dependency/inc/lib.h
@@ -1,0 +1,2 @@
+#pragma once
+void f(void);

--- a/test cases/failing/125 targets before add_project_dependency/lib.c
+++ b/test cases/failing/125 targets before add_project_dependency/lib.c
@@ -1,0 +1,3 @@
+#include <stdio.h>
+#include "lib.h"
+void f() {puts("hello");}

--- a/test cases/failing/125 targets before add_project_dependency/meson.build
+++ b/test cases/failing/125 targets before add_project_dependency/meson.build
@@ -1,0 +1,5 @@
+project('test', 'c')
+
+static_library('lib', 'lib.c')
+inc = include_directories('inc')
+add_project_dependencies(declare_dependency(include_directories: inc), language: 'c')

--- a/test cases/failing/125 targets before add_project_dependency/test.json
+++ b/test cases/failing/125 targets before add_project_dependency/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/125 targets before add_project_dependency/meson.build:5:0: ERROR: Tried to use 'add_project_dependencies' after a build target has been declared."
+    }
+  ]
+}


### PR DESCRIPTION
This function can be used to add fundamental dependencies such as `libm`, `dependency('threads')` or glib to all build products in one fell swoop.  This can be useful whenever, due to a project's coding conventions, it is not really possible to compile any source file without including the dependency.

This function also makes it possible to add an `include_directories()` object to the project, removing the need to list both source and global directories. An example from QEMU is this:

```
  add_project_arguments('-isystem', meson.current_source_dir() / 'linux-headers',
                        '-isystem', 'linux-headers',
                        language: ['c', 'cpp'])
```

which might become:

```
   linux_headers = declare_dependency(include_directories: 'linux-headers').as_system('system')
   add_project_dependencies(linux_headers, language: ['c', 'cpp'])
```