### PR TITLE
compilers/gnu: use Popen_safe to prevent resource leaks

### DIFF
--- a/mesonbuild/compilers/mixins/gnu.py
+++ b/mesonbuild/compilers/mixins/gnu.py
@@ -106,14 +106,7 @@ def gnulike_default_include_dirs(compiler: T.Tuple[str, ...], lang: str) -> 'Imm
     env = os.environ.copy()
     env["LC_ALL"] = 'C'
     cmd = list(compiler) + [f'-x{lang}', '-E', '-v', '-']
-    p = subprocess.Popen(
-        cmd,
-        stdin=subprocess.DEVNULL,
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        env=env
-    )
-    stdout = p.stdout.read().decode('utf-8', errors='replace')
+    _, stdout, _ = mesonlib.Popen_safe(cmd, stderr=subprocess.STDOUT, env=env)
     parse_state = 0
     paths = []  # type: T.List[str]
     for line in stdout.split('\n'):


### PR DESCRIPTION
Fixes the following ResourceWarnings:

```
ResourceWarning: subprocess 25556 is still running
  _warn("subprocess %s is still running" % self.pid,
ResourceWarning: Enable tracemalloc to get the object allocation traceback

mesonbuild/compilers/mixins/gnu.py:195: ResourceWarning: unclosed file <_io.BufferedReader name=4>
  return gnulike_default_include_dirs(tuple(self.exelist), self.language).copy()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```