### PR TITLE
fix continued breakage in gnome module API

### DIFF
--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -675,14 +675,14 @@ class GnomeModule(ExtensionModule):
                         internal_ldflags.update(libdepflags[1])
                         external_ldflags.update(libdepflags[2])
                         gi_includes.update(libdepflags[3])
-                        depends.extend(libdepflags[4])
+                        depends = libdepflags[4]
                 extdepflags = self._get_dependencies_flags_raw(dep.ext_deps, state, depends, include_rpath,
                                                                use_gir_args)
                 cflags.update(extdepflags[0])
                 internal_ldflags.update(extdepflags[1])
                 external_ldflags.update(extdepflags[2])
                 gi_includes.update(extdepflags[3])
-                depends.extend(extdepflags[4])
+                depends = extdepflags[4]
                 for source in dep.sources:
                     if isinstance(source, GirTarget):
                         gi_includes.update([os.path.join(state.environment.get_build_dir(),


### PR DESCRIPTION
In commit 823da3990947a8f4a2152826f0d7229f8a7a0159 we tried to fix disappearing dependencies. Instead, we appended the replacement dependencies to the existing ones. But this, too, was wrong. The function doesn't return new dependencies... it returns a copied list of all the dependencies, then alone of all parts of that API, expects to overwrite the existing variable.

(Sadly, part of the internals actually uses the entire list for something.)

As a result, we produced a repeatedly growing list, which eventually scaled really badly and e.g. OOMed on gstreamer.

Instead, let's just replace the dependencies with the updated copy.