### PR TITLE
Check for clang before guessing gcc or lcc

### DIFF
--- a/mesonbuild/compilers/detect.py
+++ b/mesonbuild/compilers/detect.py
@@ -334,7 +334,7 @@ def _detect_c_or_cpp_compiler(env: 'Environment', lang: str, for_machine: Machin
         version = search_version(out)
 
         guess_gcc_or_lcc: T.Optional[str] = None
-        if 'Free Software Foundation' in out or 'xt-' in out:
+        if 'Free Software Foundation' in out or out.startswith('xt-'):
             guess_gcc_or_lcc = 'gcc'
         if 'e2k' in out and 'lcc' in out:
             guess_gcc_or_lcc = 'lcc'


### PR DESCRIPTION
clang --version can yield a string like below when its installed into
such a directory

clang version 14.0.0 (https://github.com/llvm/llvm-project 3f43d803382d57e3fc010ca19833077d1023e9c9)
Target: aarch64-yoe-linux
Thread model: posix
InstalledDir: /mnt/b/yoe/master/build/tmp/work/cortexa72-yoe-linux/gnome-text-editor/42.0-r0/recipe-sysroot-native/usr/bin/aarch64-yoe-linux

as you can see InstallDir has 'xt-' subtring and this trips the check to
guess gcc

if 'Free Software Foundation' in out or 'xt-' in out:

Therefore, check if compiler is clang then there is no point of running
this check anyway.

Signed-off-by: Khem Raj <raj.khem@gmail.com>