### PR TITLE
main: Make the msys/python check work again, in some cases

### DIFF
--- a/mesonbuild/mesonmain.py
+++ b/mesonbuild/mesonmain.py
@@ -29,7 +29,6 @@ from . import mesonlib
 from . import mlog
 from . import mconf, mdist, minit, minstall, mintro, msetup, mtest, rewriter, msubprojects, munstable_coredata, mcompile, mdevenv
 from .mesonlib import MesonException, MesonBugException
-from .environment import detect_msys2_arch
 from .wrap import wraptool
 from .scripts import env2mfile
 
@@ -235,13 +234,9 @@ def run(original_args, mainfile):
     ensure_stdout_accepts_unicode()
 
     # https://github.com/mesonbuild/meson/issues/3653
-    if sys.platform.lower() == 'msys':
-        mlog.error('This python3 seems to be msys/python on MSYS2 Windows, which is known to have path semantics incompatible with Meson')
-        msys2_arch = detect_msys2_arch()
-        if msys2_arch:
-            mlog.error('Please install and use mingw-w64-i686-python3 and/or mingw-w64-x86_64-python3 with Pacman')
-        else:
-            mlog.error('Please download and use Python as detailed at: https://mesonbuild.com/Getting-meson.html')
+    if sys.platform == 'cygwin' and os.environ.get('MSYSTEM', '') not in ['MSYS', '']:
+        mlog.error('This python3 seems to be msys/python on MSYS2 Windows, but you are in a MinGW environment')
+        mlog.error('Please install and use mingw-w64-x86_64-python3 and/or mingw-w64-x86_64-meson with Pacman')
         return 2
 
     # Set the meson command that will be used to run scripts and so on


### PR DESCRIPTION
msys/python in MSYS2 pretends to be cygwin in all cases for some time
now, so this check was impossible to hit.

The underlying confusion it tried to prevent is still there, namely trying
to build with mingw but wrongly using a msys/cygwin python/meson.

We can use the MSYSTEM env var to detect if we are in a mingw shell, and
in case the Python doesn't match we suggest installing mingw variants of both
python and meson.

Using msys/python + meson in a MSYS environment works fine on the other hand,
so no need to error out in that case.

Fixes #8726

Also addresses the concern raised in
https://github.com/mesonbuild/meson/issues/3653#issuecomment-474122564