### PR TITLE
wayland: Mark module stable

### DIFF
--- a/docs/markdown/Wayland-module.md
+++ b/docs/markdown/Wayland-module.md
@@ -1,13 +1,10 @@
-# Unstable Wayland Module
+# Wayland Module
 
-This module is available since version 0.62.0.
+This module is available since version 0.62.0, and has been stable since version
+1.8.0.
 
 This module provides helper functions to find wayland protocol
 xmls and to generate .c and .h files using wayland-scanner
-
-**Note**: this module is unstable. It is only provided as a technology
-preview. Its API may change in arbitrary ways between releases or it
-might be removed from Meson altogether.
 
 ## Quick Usage
 
@@ -15,7 +12,7 @@ might be removed from Meson altogether.
 project('hello-wayland', 'c')
 
 wl_dep = dependency('wayland-client')
-wl_mod = import('unstable-wayland')
+wl_mod = import('wayland')
 
 xml = wl_mod.find_protocol('xdg-shell')
 xdg_shell = wl_mod.scan_xml(xml)

--- a/mesonbuild/modules/wayland.py
+++ b/mesonbuild/modules/wayland.py
@@ -35,7 +35,7 @@ if T.TYPE_CHECKING:
 
 class WaylandModule(ExtensionModule):
 
-    INFO = ModuleInfo('wayland', '0.62.0', unstable=True)
+    INFO = ModuleInfo('wayland', '0.62.0', stabilized='1.8.0')
 
     def __init__(self, interpreter: Interpreter) -> None:
         super().__init__(interpreter)


### PR DESCRIPTION
There is no point in printing warning about unstable module, in the
worst case we can just depracate and add new API. It has been tested in
a few projects already, and this warning is a blocker on wider adoption.