### PR TITLE
Validate that introspection command exited cleanly.

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -415,6 +415,8 @@ class PythonExternalProgram(ExternalProgram):
         cmd = self.get_command() + [tmpfilename]
         p, stdout, stderr = mesonlib.Popen_safe(cmd)
         os.unlink(tmpfilename)
+        if p.returncode != 0:
+            raise mesonlib.MesonException('Trying to introspect Python configuration failed.\n\n'  + stdout + stderr)
         try:
             info = json.loads(stdout)
         except json.JSONDecodeError:


### PR DESCRIPTION
In Debian sid the script actually fails with this:

```
/root/./pyscript.py:6: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  import distutils.command.install
Traceback (most recent call last):
  File "/root/./pyscript.py", line 6, in <module>
    import distutils.command.install
ModuleNotFoundError: No module named 'distutils.command'
```

which gets written to `stderr`. `stdout` is empty which apparently is valid JSON so it will not cause any errors.