### PR TITLE
modules/qt: look for tools in libexec directory

### DIFF
--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -215,6 +215,8 @@ class QtPkgConfigDependency(_QtBase, PkgConfigDependency, metaclass=abc.ABCMeta)
             if prefix:
                 self.bindir = os.path.join(prefix, 'bin')
 
+        self.libexecdir = self.get_pkgconfig_variable('libexec_prefix', [], None)
+
     @staticmethod
     @abc.abstractmethod
     def get_pkgconfig_host_bins(core: PkgConfigDependency) -> T.Optional[str]:
@@ -277,6 +279,10 @@ class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=abc.ABCMeta):
         libdir = qvars['QT_INSTALL_LIBS']
         # Used by qt.compilers_detect()
         self.bindir = get_qmake_host_bins(qvars)
+        if 'QT_HOST_LIBEXECS' in qvars:
+            self.libexecdir = qvars['QT_HOST_LIBEXECS']
+        else:
+            self.libexecdir = qvars['QT_INSTALL_LIBEXECS']
 
         # Use the buildtype by default, but look at the b_vscrt option if the
         # compiler supports it.

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -131,6 +131,8 @@ class QtBaseModule(ExtensionModule):
             for b in self.tools:
                 if qt_dep.bindir:
                     yield os.path.join(qt_dep.bindir, b), b
+                if qt_dep.libexecdir:
+                    yield os.path.join(qt_dep.libexecdir, b), b
                 # prefer the <tool>-qt<version> of the tool to the plain one, as we
                 # don't know what the unsuffixed one points to without calling it.
                 yield f'{b}-qt{qt_dep.qtver}', b


### PR DESCRIPTION
The 'qt' module fails to detect Qt 6 tools (moc, rcc, and uic)
automatically on Linux and macOS. While qmake is located in bin/ where
detection works correctly, the tools are located in libexec/.

It's possible to help the 'qt' module find the tools by adding Qt's
libexec directory to the PATH environment variable, but this manual
workaround is not ideal.

This patch queries the libexec directory from qmake or pkg-config so
that Qt 6 tools are detected successfully.

Tested with qt6-qtbase-devel-6.2.3-2.fc35.x86_64 on Linux.

Signed-off-by: Stefan Hajnoczi <stefanha@jammr.net>