### PR TITLE
Look for Qt 6 tools in libexec/

### DIFF
--- a/mesonbuild/dependencies/qt.py
+++ b/mesonbuild/dependencies/qt.py
@@ -69,6 +69,12 @@ def get_qmake_host_bins(qvars: T.Dict[str, str]) -> str:
     return qvars['QT_INSTALL_BINS']
 
 
+def get_qmake_host_libexecs(qvars: T.Dict[str, str]) -> T.Optional[str]:
+    if 'QT_HOST_LIBEXECS' in qvars:
+        return qvars['QT_HOST_LIBEXECS']
+    return qvars.get('QT_INSTALL_LIBEXECS')
+
+
 def _get_modules_lib_suffix(version: str, info: 'MachineInfo', is_debug: bool) -> str:
     """Get the module suffix based on platform and debug type."""
     suffix = ''
@@ -118,6 +124,7 @@ class _QtBase:
     link_args: T.List[str]
     clib_compiler: 'Compiler'
     env: 'Environment'
+    libexecdir: T.Optional[str] = None
 
     def __init__(self, name: str, kwargs: T.Dict[str, T.Any]):
         self.qtname = name.capitalize()
@@ -277,6 +284,7 @@ class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=abc.ABCMeta):
         libdir = qvars['QT_INSTALL_LIBS']
         # Used by qt.compilers_detect()
         self.bindir = get_qmake_host_bins(qvars)
+        self.libexecdir = get_qmake_host_libexecs(qvars)
 
         # Use the buildtype by default, but look at the b_vscrt option if the
         # compiler supports it.
@@ -353,6 +361,7 @@ class QmakeQtDependency(_QtBase, ConfigToolDependency, metaclass=abc.ABCMeta):
             self.is_found = True
             # Used by self.compilers_detect()
             self.bindir = get_qmake_host_bins(qvars)
+            self.libexecdir = get_qmake_host_libexecs(qvars)
 
     def log_info(self) -> str:
         return 'qmake'

--- a/mesonbuild/modules/qt.py
+++ b/mesonbuild/modules/qt.py
@@ -131,6 +131,8 @@ class QtBaseModule(ExtensionModule):
             for b in self.tools:
                 if qt_dep.bindir:
                     yield os.path.join(qt_dep.bindir, b), b
+                if qt_dep.libexecdir:
+                    yield os.path.join(qt_dep.libexecdir, b), b
                 # prefer the <tool>-qt<version> of the tool to the plain one, as we
                 # don't know what the unsuffixed one points to without calling it.
                 yield f'{b}-qt{qt_dep.qtver}', b

--- a/test cases/frameworks/4 qt/meson.build
+++ b/test cases/frameworks/4 qt/meson.build
@@ -1,6 +1,6 @@
-project('qt4 and 5 build test', 'cpp',
-  # Qt5 now requires C++ 11 support
-  default_options : ['cpp_std=c++11'])
+project('qt4, qt5, and qt6 build test', 'cpp',
+  # Qt6 requires C++ 17 support
+  default_options : ['cpp_std=c++17'])
 
 qt5_modules = ['Widgets']
 qt6_modules = ['Widgets']

--- a/test cases/frameworks/4 qt/qt6_lang.qrc
+++ b/test cases/frameworks/4 qt/qt6_lang.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/lang">
+        <file>qt6embedded_fr.qm</file>
+    </qresource>
+</RCC>
+

--- a/test cases/frameworks/4 qt/qt6core_fr.ts
+++ b/test cases/frameworks/4 qt/qt6core_fr.ts
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr_FR">
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="q5core.cpp" line="23"/>
+        <source>Translate me!</source>
+        <translation>Traduisez moi!</translation>
+    </message>
+</context>
+</TS>

--- a/test cases/frameworks/4 qt/qt6embedded_fr.ts
+++ b/test cases/frameworks/4 qt/qt6embedded_fr.ts
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr_FR">
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="q5core.cpp" line="23"/>
+        <source>Translate me!</source>
+        <translation>Traduisez moi!</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
This is @jlindgren90's "Add support for Qt 6.1+" #9792 with the following changes:
1. Initialize `_QtBase.libexecdir` to `None` so earlier versions of Qt that didn't report a libexec/ directory still work.
2. Handle the non-libexec/ case in `get_qmake_host_libexecs()` too.
3. Add a new commit "tests: fix incomplete Qt 6 support" that makes test "frameworks/4 qt" really work with Qt 6.

The goal is to detect the moc, rcc, uic Qt tools on Qt 6 where they moved from the bin/ directory to the libexec/ directory.

@eli-schwartz: Since @jlindren90 has not been active lately I reworked his pull request from earlier this year. This obsoletes #9792 and #10255.