### PR TITLE
Visual Studio: Only use /utf-8 on VS2015 or later

### DIFF
--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -130,6 +130,10 @@ class VisualStudioLikeCompiler(Compiler, metaclass=abc.ABCMeta):
             self.machine = target
         if mesonlib.version_compare(self.version, '>=19.28.29910'): # VS 16.9.0 includes cl 19.28.29910
             self.base_options.add(mesonlib.OptionKey('b_sanitize'))
+        # Exclude /utf-8 in self.always_args in VS2013 and earlier
+        if not isinstance(self, ClangClCompiler):
+            if mesonlib.version_compare(self.version, '<19.00'):
+                self.always_args.remove('/utf-8')
         assert self.linker is not None
         self.linker.machine = self.machine
 


### PR DESCRIPTION
Hi,

In PR #9192, we assume the `/utf-8` compiler flag in order to fix building items on non-English language version of Windows (CJK versions, in particular, which is what I am using), but then there are some drawbacks:

*  This flag is only available on Visual Studio 2015 or later.  So, if people are trying to check whether the compiler supports a certain flag, assuming `/utf-8` universally can break such checks as we are always going to get `command line warning D9002: unknown command line argument '/utf-8'` (or something like that).

*  I came across a few projects that produce broken code with this flag enabled when building on CJK language versions of Windows, such as libthai.  Maybe we want to (in another PR) add a flag in the project settings blob in the beginning of the Meson build files of the project that disables (disallows) the use of this flag when needed.  Alas, the safest way for such situations is to tell people to go to "Control Panel", and change the setting in "Language for non-Unicode Programs" to "English" (of any kind), reboot and perhaps reconfigure the project, and then rebuild, and things should work fine.

With blessings, thank you!