### PR TITLE
compilers: fix broken CompCert support for release flags

### DIFF
--- a/mesonbuild/compilers/mixins/compcert.py
+++ b/mesonbuild/compilers/mixins/compcert.py
@@ -32,7 +32,7 @@ ccomp_buildtype_args = {
     'plain': [''],
     'debug': ['-O0', '-g'],
     'debugoptimized': ['-O0', '-g'],
-    'release': ['-03'],
+    'release': ['-O3'],
     'minsize': ['-Os'],
     'custom': ['-Obranchless'],
 }  # type: T.Dict[str, T.List[str]]


### PR DESCRIPTION
This has been broken ever since the original implementation. Due to a typo, the optimization flag used a zero instead of an uppercase "o", which the compiler then breaks on during argument parsing because it is an invalid argument.

Fixes #10267