### PR TITLE
gnome: Make sure g-ir-scanner can use pkg-config properly

### DIFF
--- a/mesonbuild/build.py
+++ b/mesonbuild/build.py
@@ -550,7 +550,7 @@ class EnvironmentVariables(HoldableObject):
         curr = env.get(name)
         return separator.join(values if curr is None else values + [curr])
 
-    def get_env(self, full_env: T.Dict[str, str]) -> T.Dict[str, str]:
+    def get_env(self, full_env: T.MutableMapping[str, str]) -> T.Dict[str, str]:
         env = full_env.copy()
         for method, name, values, separator in self.envvars:
             env[name] = method(env, name, values, separator)

--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -654,7 +654,7 @@ class Environment:
                         _p_env = re.split(r':|;', p_env)
                     p_list = list(mesonlib.OrderedSet(_p_env))
                 elif keyname == 'pkg_config_path':
-                    p_list = list(mesonlib.OrderedSet(p_env.split(':')))
+                    p_list = list(mesonlib.OrderedSet(p_env.split(os.pathsep)))
                 else:
                     p_list = split_args(p_env)
                 p_list = [e for e in p_list if e]  # filter out any empty elements

--- a/mesonbuild/modules/gnome.py
+++ b/mesonbuild/modules/gnome.py
@@ -967,6 +967,13 @@ class GnomeModule(ExtensionModule):
         elif install_dir is False:
             install = False
 
+        # g-ir-scanner uses pkg-config to find libraries such as glib. They could
+        # be built as subproject in which case we need to trick it to use
+        # -uninstalled.pc files Meson generated. It also must respect pkgconfig
+        # settings user could have set in machine file, like PKG_CONFIG_LIBDIR,
+        # SYSROOT, etc.
+        run_env = PkgConfigDependency.get_env(state.environment, MachineChoice.HOST, uninstalled=True)
+
         return GirTarget(
             girfile,
             state.subdir,
@@ -980,6 +987,7 @@ class GnomeModule(ExtensionModule):
             install=install,
             install_dir=[install_dir],
             install_tag=['devel'],
+            env=run_env,
         )
 
     @staticmethod

--- a/mesonbuild/modules/unstable_external_project.py
+++ b/mesonbuild/modules/unstable_external_project.py
@@ -155,9 +155,8 @@ class ExternalProject(NewExtensionModule):
         self.run_env['LDFLAGS'] = self._quote_and_join(link_args)
 
         self.run_env = self.user_env.get_env(self.run_env)
-
-        PkgConfigDependency.setup_env(self.run_env, self.env, MachineChoice.HOST,
-                                      Path(self.env.get_build_dir(), 'meson-uninstalled').as_posix())
+        self.run_env = PkgConfigDependency.setup_env(self.run_env, self.env, MachineChoice.HOST,
+                                                     uninstalled=True)
 
         self.build_dir.mkdir(parents=True, exist_ok=True)
         self._run('configure', configure_cmd, workdir)

--- a/unittests/linuxliketests.py
+++ b/unittests/linuxliketests.py
@@ -1152,9 +1152,12 @@ class LinuxlikeTests(BasePlatformTests):
         env = get_fake_env(testdir, self.builddir, self.prefix)
         env.coredata.set_options({OptionKey('pkg_config_path'): pkg_dir}, subproject='')
 
-        PkgConfigDependency.setup_env({}, env, MachineChoice.HOST, pkg_dir)
+        # Regression test: This used to modify the value of `pkg_config_path`
+        # option, adding the meson-uninstalled directory to it.
+        PkgConfigDependency.setup_env({}, env, MachineChoice.HOST, uninstalled=True)
+
         pkg_config_path = env.coredata.options[OptionKey('pkg_config_path')].value
-        self.assertEqual(len(pkg_config_path), 1)
+        self.assertEqual(pkg_config_path, [pkg_dir])
 
     @skipIfNoPkgconfig
     def test_pkgconfig_internal_libraries(self):


### PR DESCRIPTION
We need to setup the environment we pass to g-ir-scanner because it will
try to use pkg-config to find dependencies, and that must respect user
settings from machine file. Also make it use uninstalled pc files Meson
generated in the case dependencies, such as glib, have been built as
subproject.