### PR TITLE
vcs_tag: properly handle non-str commands

### DIFF
--- a/docs/yaml/functions/vcs_tag.yaml
+++ b/docs/yaml/functions/vcs_tag.yaml
@@ -22,13 +22,15 @@ description: |
 
 kwargs:
   command:
-    type: list[str]
+    type: list[str | file]
     description: |
       The command to execute, see [[custom_target]] for details
       on how this command must be specified.
 
       This parameter is optional. If it is absent, Meson will try
       its best to find a suitable default command.
+
+      *(since 0.62.0)* [[@file]] is accepted.
 
   input:
     type: str

--- a/docs/yaml/functions/vcs_tag.yaml
+++ b/docs/yaml/functions/vcs_tag.yaml
@@ -22,7 +22,7 @@ description: |
 
 kwargs:
   command:
-    type: list[str | file]
+    type: list[exe | external_program | custom_tgt | file | str]
     description: |
       The command to execute, see [[custom_target]] for details
       on how this command must be specified.
@@ -31,6 +31,8 @@ kwargs:
       its best to find a suitable default command.
 
       *(since 0.62.0)* [[@file]] is accepted.
+
+      *(since 0.63.0)* [[@custom_tgt]], [[@exe]], and [[@external_program]] are accepted.
 
   input:
     type: str

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1752,11 +1752,14 @@ external dependencies (including libraries) must go to "dependencies".''')
         vcs_cmd = kwargs['command']
         source_dir = os.path.normpath(os.path.join(self.environment.get_source_dir(), self.subdir))
         if vcs_cmd:
-            if isinstance(vcs_cmd[0], mesonlib.File):
-                FeatureNew.single_use('vcs_tag with file as the first argument', '0.62.0', self.subproject, location=node)
-            maincmd = self.find_program_impl(vcs_cmd[0], required=False)
-            if maincmd.found():
-                vcs_cmd[0] = maincmd
+            if isinstance(vcs_cmd[0], (str, mesonlib.File)):
+                if isinstance(vcs_cmd[0], mesonlib.File):
+                    FeatureNew.single_use('vcs_tag with file as the first argument', '0.62.0', self.subproject, location=node)
+                maincmd = self.find_program_impl(vcs_cmd[0], required=False)
+                if maincmd.found():
+                    vcs_cmd[0] = maincmd
+            else:
+                FeatureNew.single_use('vcs_tag with custom_tgt, external_program, or exe as the first argument', '0.63.0', self.subproject, location=node)
         else:
             vcs = mesonlib.detect_vcs(source_dir)
             if vcs:

--- a/mesonbuild/interpreter/interpreter.py
+++ b/mesonbuild/interpreter/interpreter.py
@@ -1752,6 +1752,8 @@ external dependencies (including libraries) must go to "dependencies".''')
         vcs_cmd = kwargs['command']
         source_dir = os.path.normpath(os.path.join(self.environment.get_source_dir(), self.subdir))
         if vcs_cmd:
+            if isinstance(vcs_cmd[0], mesonlib.File):
+                FeatureNew.single_use('vcs_tag with file as the first argument', '0.62.0', self.subproject, location=node)
             maincmd = self.find_program_impl(vcs_cmd[0], required=False)
             if maincmd.found():
                 vcs_cmd[0] = maincmd

--- a/test cases/common/66 vcstag/meson.build
+++ b/test cases/common/66 vcstag/meson.build
@@ -17,7 +17,12 @@ fallback : '1.0.0')
 version_src_fallback = vcs_tag(input : 'vcstag.c.in',
 output : 'vcstag-fallback.c')
 
+version_src_file = vcs_tag(input : 'vcstag.c.in',
+output : 'vcstag-file.c',
+command : files('version.py'))
+
 executable('tagprog', 'tagprog.c', version_src)
 executable('tagprog-custom', 'tagprog.c', version_src_custom)
 executable('tagprog-fallback', 'tagprog.c', version_src_fallback)
 executable('tagprog-notfound-fallback', 'tagprog.c', version_src_notfound_fallback)
+executable('tagprog-file', 'tagprog.c', version_src_file)

--- a/test cases/common/66 vcstag/meson.build
+++ b/test cases/common/66 vcstag/meson.build
@@ -17,12 +17,26 @@ fallback : '1.0.0')
 version_src_fallback = vcs_tag(input : 'vcstag.c.in',
 output : 'vcstag-fallback.c')
 
+git = find_program('git')
+
+version_src_git_program = vcs_tag(input : 'vcstag.c.in',
+output : 'vcstag-git-program.c',
+command : [git, 'rev-parse', 'HEAD'],
+fallback : '1.0.0')
+
 version_src_file = vcs_tag(input : 'vcstag.c.in',
 output : 'vcstag-file.c',
 command : files('version.py'))
 
-executable('tagprog', 'tagprog.c', version_src)
+tagprog = executable('tagprog', 'tagprog.c', version_src)
+
+version_src_executable = vcs_tag(input : 'vcstag.c.in',
+output : 'vcstag-executable.c',
+command : [tagprog])
+
 executable('tagprog-custom', 'tagprog.c', version_src_custom)
 executable('tagprog-fallback', 'tagprog.c', version_src_fallback)
 executable('tagprog-notfound-fallback', 'tagprog.c', version_src_notfound_fallback)
+executable('tagprog-git-program', 'tagprog.c', version_src_git_program)
+executable('tagprog-executable', 'tagprog.c', version_src_executable)
 executable('tagprog-file', 'tagprog.c', version_src_file)

--- a/test cases/common/66 vcstag/version.py
+++ b/test cases/common/66 vcstag/version.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+print('3.14')


### PR DESCRIPTION


Hi,

Currently `vcs_tag` does not accept anything but string as its first `command` argument, which forces you to write things like this:

https://github.com/gsliepen/tinc/blob/1.1/meson.build#L38-L40

https://github.com/gsliepen/tinc/blob/1.1/src/include/meson.build#L3-L4

Docs were updated to match annotated types on top of the function. Not sure how you're supposed to call `vcs_tag` with `custom_target`, so there's no test for it.

Could it be an error in type annotation, or is there something obvious I'm not seeing?

