### PR TITLE
Relocatable pkgconfig

### DIFF
--- a/docs/markdown/Builtin-options.md
+++ b/docs/markdown/Builtin-options.md
@@ -275,6 +275,27 @@ Since 0.56.0 `warning_level` can also be defined per subproject.
 Some Meson modules have built-in options. They can be set by prefixing the option
 name with the module name: `-D<module>.<option>=<value>` (e.g. `-Dpython.platlibdir=/foo`).
 
+### Pkgconfig module
+
+| Option      | Default value | Possible values | Description                                                |
+|-------------|---------------|-----------------|------------------------------------------------------------|
+| relocatable | false         | true, false     | Generate the pkgconfig files as relocatable (Since 0.63.0) |
+
+*Since 0.63.0* The `pkgconfig.relocatable` option is used by the
+pkgconfig module, namely [`pkg.generate()`](Pkgconfig-module.md) and affect how the
+`prefix` in the generated pkgconfig file is set (not to be confused
+with the [install prefix](#directories)). When it is `true` the `prefix` will be
+relative to the `install_dir`. This allows the pkgconfig file to be
+moved around and still work, as long as the relative path is not
+broken. In general this allows for the whole installed package to be
+placed anywhere on the system and still work as a dependency. When it
+is set to `false` the `prefix` will be the same as the install prefix.
+
+An error will be raised if `pkgconfig.relocatable` is `true` and the
+`install_dir` for a generated pkgconfig file points outside the
+install prefix. For example if the install prefix is `/usr` and the
+`install_dir` for a pkgconfig file is `/var/lib/pkgconfig`.
+
 ### Python module
 
 | Option           | Default value | Possible values             | Description |

--- a/docs/markdown/snippets/pkgconfig-relocatable.md
+++ b/docs/markdown/snippets/pkgconfig-relocatable.md
@@ -1,0 +1,18 @@
+## Installed pkgconfig files can now be relocatable
+
+The pkgconfig module now has a module option `pkgconfig.relocatable`.
+When set to `true`, the pkgconfig files generated will have their
+`prefix` variable set to be relative to their `install_dir`.
+
+For example to enable it from the command line run:
+
+```sh
+meson setup builddir -Dpkgconfig.relocatable=true …
+```
+
+It will only work if the `install_dir` for the generated pkgconfig
+files are located inside the install prefix of the package. Not doing
+so will cause an error.
+
+This should be useful on Windows or any other platform where
+relocatable packages are desired.

--- a/mesonbuild/coredata.py
+++ b/mesonbuild/coredata.py
@@ -1225,6 +1225,10 @@ BUILTIN_CORE_OPTIONS: 'MutableKeyedOptionDictType' = OrderedDict([
     (OptionKey('wrap_mode'),       BuiltinOption(UserComboOption, 'Wrap mode', 'default', choices=['default', 'nofallback', 'nodownload', 'forcefallback', 'nopromote'])),
     (OptionKey('force_fallback_for'), BuiltinOption(UserArrayOption, 'Force fallback for those subprojects', [])),
 
+    # Pkgconfig module
+    (OptionKey('relocatable', module='pkgconfig'),
+     BuiltinOption(UserBooleanOption, 'Generate pkgconfig files as relocatable', False)),
+
     # Python module
     (OptionKey('install_env', module='python'),
      BuiltinOption(UserComboOption, 'Which python environment to install to', 'prefix', choices=['auto', 'prefix', 'system', 'venv'])),

--- a/test cases/failing/123 pkgconfig not relocatable outside prefix/meson.build
+++ b/test cases/failing/123 pkgconfig not relocatable outside prefix/meson.build
@@ -1,0 +1,22 @@
+project(
+  'pkgconfig-not-relocatable-outside-prefix',
+  version : '1.0',
+  default_options: [
+    'pkgconfig.relocatable=true',
+  ])
+
+pkgg = import('pkgconfig')
+
+# A drive letter is needed on windows for this to be an absolute path.
+if host_machine.system() == 'windows'
+  install_dir = 'C:/opt/lib/pkgconfig'
+else
+  install_dir = '/opt/lib/pkgconfig'
+endif
+
+pkgg.generate(
+  name : 'libsimple',
+  version : '1.0',
+  description : 'A simple pkgconfig file.',
+  install_dir: install_dir,
+)

--- a/test cases/failing/123 pkgconfig not relocatable outside prefix/test.json
+++ b/test cases/failing/123 pkgconfig not relocatable outside prefix/test.json
@@ -1,0 +1,8 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/failing/123 pkgconfig not relocatable outside prefix/meson\\.build:17:5: ERROR: Pkgconfig prefix cannot be outside of the prefix when pkgconfig\\.relocatable=true. Pkgconfig prefix is (C:)?/opt/lib/pkgconfig.",
+      "match": "re"
+    }
+  ]
+}

--- a/test cases/unit/105 pkgconfig relocatable with absolute path/meson.build
+++ b/test cases/unit/105 pkgconfig relocatable with absolute path/meson.build
@@ -1,0 +1,15 @@
+project(
+  'pkgconfig-relocatable-with-absolute-path',
+  version : '1.0',
+  default_options: [
+    'pkgconfig.relocatable=true',
+  ])
+
+pkgg = import('pkgconfig')
+
+pkgg.generate(
+  name : 'libsimple',
+  version : '1.0',
+  description : 'A simple pkgconfig.',
+  install_dir: get_option('prefix')/'share/misc/pkgconfig',
+)

--- a/unittests/datatests.py
+++ b/unittests/datatests.py
@@ -128,7 +128,7 @@ class DataTests(unittest.TestCase):
         mod_subcontents = []
         content = self._get_section_content("Module options", sections, md)
         subsections = tee(re.finditer(r"^### (.+)$", content, re.MULTILINE))
-        for idx, mod in enumerate(['Python']):
+        for idx, mod in enumerate(['Pkgconfig', 'Python']):
             mod_subcontents.append(self._get_section_content(f'{mod} module', subsections[idx], content))
         for subcontent in u_subcontents + mod_subcontents:
             # Find the option names


### PR DESCRIPTION
Add `relocatable` module option for the `pkgconfig` module. When set to `true` the `prefix` of the generated pkgconfig files will be relative to their `install_dir`. 

By default this is set to `false`.

For more detail see the discussion in  #10269.