### PR TITLE
gtkdochelper.py: Use os.pathsep for --path argument

### DIFF
--- a/mesonbuild/scripts/gtkdochelper.py
+++ b/mesonbuild/scripts/gtkdochelper.py
@@ -198,7 +198,7 @@ def build_gtkdoc(source_root: str, build_root: str, doc_subdir: str, src_subdirs
 
     # Make HTML documentation
     mkhtml_cmd = [options.gtkdoc_mkhtml,
-                  '--path=' + ':'.join((doc_src, abs_out)),
+                  '--path=' + os.pathsep.join((doc_src, abs_out)),
                   module,
                   ] + html_args
     if main_file:


### PR DESCRIPTION
Hi,

When attempting to build GLib's documentation using Meson, the build failed as the `--path` argument for `gtkdoc-mkhtml` passed paths that were separated by `:`, which is not valid on Windows `cmd.exe` consoles.  Fix this by using `os.pathsep` instead.

With blessings, thank you!