### PR TITLE
Add support for multiline f-strings

### DIFF
--- a/docs/markdown/Syntax.md
+++ b/docs/markdown/Syntax.md
@@ -178,7 +178,7 @@ These are raw strings that do not support the escape sequences listed
 above.  These strings can also be combined with the string formatting
 functionality via `.format()` described below.
 
-Note that multiline f-strings are not supported.
+Note that multiline f-string support was added in version 0.63.
 
 ### String index
 
@@ -211,8 +211,8 @@ As can be seen, the formatting works by replacing placeholders of type
 *(Added 0.58)*
 
 Format strings can be used as a non-positional alternative to the
-string formatting functionality described above. Note that multiline f-strings
-are not supported.
+string formatting functionality described above. Note that multiline f-string
+support was added in version 0.63.
 
 ```meson
 n = 10

--- a/docs/markdown/snippets/support-multiline-fstring.md
+++ b/docs/markdown/snippets/support-multiline-fstring.md
@@ -1,0 +1,22 @@
+## Added support for multiline fstrings
+
+Added support for multiline f-strings which use the same syntax as f-strings
+for string substition.
+
+```meson
+x = 'hello'
+y = 'world'
+
+msg = f'''Sending a message...
+"@x@ @y@"
+'''
+```
+
+which produces:
+
+```
+Sending a message....
+
+"hello world"
+
+```

--- a/mesonbuild/interpreterbase/interpreterbase.py
+++ b/mesonbuild/interpreterbase/interpreterbase.py
@@ -217,7 +217,10 @@ class InterpreterBase:
         elif isinstance(cur, mparser.TernaryNode):
             return self.evaluate_ternary(cur)
         elif isinstance(cur, mparser.FormatStringNode):
-            return self.evaluate_fstring(cur)
+            if isinstance(cur, mparser.MultilineFormatStringNode):
+                return self.evaluate_multiline_fstring(cur)
+            else:
+                return self.evaluate_fstring(cur)
         elif isinstance(cur, mparser.ContinueNode):
             raise ContinueRequest()
         elif isinstance(cur, mparser.BreakNode):
@@ -366,6 +369,10 @@ class InterpreterBase:
             return self.evaluate_statement(node.trueblock)
         else:
             return self.evaluate_statement(node.falseblock)
+
+    @FeatureNew('multiline format strings', '0.63.0')
+    def evaluate_multiline_fstring(self, node: mparser.MultilineFormatStringNode) -> InterpreterObject:
+        return self.evaluate_fstring(node)
 
     @FeatureNew('format strings', '0.58.0')
     def evaluate_fstring(self, node: mparser.FormatStringNode) -> InterpreterObject:

--- a/test cases/common/62 string arithmetic/meson.build
+++ b/test cases/common/62 string arithmetic/meson.build
@@ -1,16 +1,8 @@
 project('string arithmetic', 'c')
 
-if 'foo' + 'bar' != 'foobar'
-  error('String concatenation is broken')
-endif
-
-if 'foo' + 'bar' + 'baz' != 'foobarbaz'
-  error('Many-string concatenation is broken')
-endif
+assert('foo' + 'bar' == 'foobar')
+assert('foo' + 'bar' + 'baz' == 'foobarbaz')
 
 a = 'a'
 b = 'b'
-
-if a + b + 'c' != 'abc'
-  error('String concat with variables is broken.')
-endif
+assert(a + b + 'c' == 'abc')

--- a/test cases/common/62 string arithmetic/meson.build
+++ b/test cases/common/62 string arithmetic/meson.build
@@ -1,4 +1,4 @@
-project('string arithmetic', 'c')
+project('string arithmetic', 'c', meson_version: '>=0.62.0')
 
 assert('foo' + 'bar' == 'foobar')
 assert('foo' + 'bar' + 'baz' == 'foobarbaz')
@@ -6,3 +6,44 @@ assert('foo' + 'bar' + 'baz' == 'foobarbaz')
 a = 'a'
 b = 'b'
 assert(a + b + 'c' == 'abc')
+
+# ------------------------------------------------------------------------------
+# format strings:
+# ------------------------------------------------------------------------------
+sub1 = 'the'
+sub2 = ' quick\n'
+sub3 = '    brown'
+sub4 = '\nfox'
+x = f'@sub1@@sub2@@sub3@@sub4@'
+
+assert(x == sub1 + sub2 + sub3 + sub4)
+assert(x == 'the quick\n    brown\nfox')
+
+# ------------------------------------------------------------------------------
+#  multi-line format strings
+# ------------------------------------------------------------------------------
+y_actual = f'''This is a multi-line comment with string substition:
+  "@sub1@@sub2@@sub3@@sub4@"
+
+And I can even substitute the entry multiple times!
+
+@sub1@
+@sub2@
+@sub3@
+'''
+
+y_expect = '''This is a multi-line comment with string substition:
+  "the quick
+    brown
+fox"
+
+And I can even substitute the entry multiple times!
+
+the
+ quick
+
+    brown
+'''
+message('actual=' + y_actual)
+message('expect=' + y_expect)
+assert(y_actual == y_expect)

--- a/test cases/common/62 string arithmetic/test.json
+++ b/test cases/common/62 string arithmetic/test.json
@@ -1,0 +1,7 @@
+{
+  "stdout": [
+    {
+      "line": "test cases/common/62 string arithmetic/meson.build:25: WARNING: Project targeting '>=0.62.0' but tried to use feature introduced in '0.63.0': multiline format strings."
+    }
+  ]
+}


### PR DESCRIPTION
+ Extend the parser to recognize the multiline f-strings, which the
documentation already implies will work.

The syntax is like:
```
x = 'hello'
y = 'world'

msg = f'''This is a multiline string.

Sending a message: '@x@ @y@'
'''
```

which produces:
```
This is a multiline string.

Sending a message: 'hello world'

```

+ Added some f-string tests cases to "62 string arithmetic" to exercise
the new behavior.