### PR TITLE
compiler.has_argument: Add `-Werror=unknown-warning-option` to clang-cl cmd line

### DIFF
--- a/mesonbuild/compilers/mixins/visualstudio.py
+++ b/mesonbuild/compilers/mixins/visualstudio.py
@@ -445,7 +445,7 @@ class ClangClCompiler(VisualStudioLikeCompiler):
 
     def has_arguments(self, args: T.List[str], env: 'Environment', code: str, mode: str) -> T.Tuple[bool, bool]:
         if mode != 'link':
-            args = args + ['-Werror=unknown-argument']
+            args = args + ['-Werror=unknown-argument', '-Werror=unknown-warning-option']
         return super().has_arguments(args, env, code, mode)
 
     def get_toolset_version(self) -> T.Optional[str]:


### PR DESCRIPTION
This pr fixes #10283 as per https://github.com/mesonbuild/meson/issues/10283#issuecomment-1100425769, namely it adds the `-Werror=unknown-warning-option` flag to the clang-cl command line like the fix for #755.