### PR TITLE
docs: Remove deprecated meson.source_root() from localisation page example

### DIFF
--- a/docs/markdown/Localisation.md
+++ b/docs/markdown/Localisation.md
@@ -47,9 +47,7 @@ global.
 i18n = import('i18n')
 # define GETTEXT_PACKAGE
 add_project_arguments('-DGETTEXT_PACKAGE="intltest"', language:'c')
-i18n.gettext(meson.project_name(),
-    args: '--directory=' + meson.source_root()
-)
+i18n.gettext(meson.project_name())
 ```
 
 The first command imports the `i18n` module that provides gettext


### PR DESCRIPTION
Meson already supplies the same value in `mesonbuild/scripts/gettext.py`:

```
def run_potgen(src_sub: str, xgettext: str, pkgname: str, datadirs: str, args: T.List[str]) -> int:
    ...
    return subprocess.call([xgettext, '--package-name=' + pkgname, '-p', src_sub, '-f', listfile,
                            '-D', os.environ['MESON_SOURCE_ROOT'], '-k_', '-o', ofile] + args,
                           env=child_env)
```