### PR TITLE
Windows: Improve Python 3.8+ module check on Windows

### DIFF
--- a/mesonbuild/modules/python.py
+++ b/mesonbuild/modules/python.py
@@ -727,10 +727,22 @@ class PythonModule(ExtensionModule):
         found_modules: T.List[str] = []
         missing_modules: T.List[str] = []
         if python.found() and want_modules:
+            # Python 3.8.x or later require add_dll_directory() to be called on Windows if
+            # the needed modules require external DLLs that are not bundled with the modules.
+            # Simplify things by calling add_dll_directory() on the paths in %PATH%
+            add_paths_cmd = ''
+            if hasattr(os, 'add_dll_directory'):
+                add_paths_cmds = []
+                paths = os.environ['PATH'].split(os.pathsep)
+                for path in paths:
+                    if path != '' and os.path.isdir(path):
+                        add_paths_cmds.append(f'os.add_dll_directory({path!r})')
+                add_paths_cmd = 'import os;' + ';'.join(reversed(add_paths_cmds)) + ';'
+
             for mod in want_modules:
                 p, *_ = mesonlib.Popen_safe(
                     python.command +
-                    ['-c', f'import {mod}'])
+                    ['-c', f'{add_paths_cmd}import {mod}'])
                 if p.returncode != 0:
                     missing_modules.append(mod)
                 else:


### PR DESCRIPTION
Hi,

From the commit message:

<i>On Python 3.8.x and later, if the imported module requires non-system DLLs that are not installed nor bundled with the module package, `os.add_dll_directory()` must be called on every path that contains the required DLLs, so that the module
can be imported successfully by Python.</i>

<i>Make things easier for people by calling `os.add_dll_directory()` on the valid directories in %PATH%, so that such module checks can be carried out successfully with much less manual intervention.</i>

Note that for running applications, application authors and/or packagers are still responsible for bundling the needed DLLs and/or using `os.add_dll_directory()` as needed.

With blessings, thank you.