### PR TITLE
minit: refuse to allow creating broken projects

### DIFF
--- a/mesonbuild/minit.py
+++ b/mesonbuild/minit.py
@@ -23,6 +23,7 @@ import os
 import re
 from glob import glob
 from mesonbuild import mesonlib
+from mesonbuild.coredata import FORBIDDEN_TARGET_NAMES
 from mesonbuild.environment import detect_ninja
 from mesonbuild.templates.samplefactory import sameple_generator
 import typing as T
@@ -81,6 +82,9 @@ def autodetect_options(options: 'argparse.Namespace', sample: bool = False) -> N
     if not options.executable:
         options.executable = options.name
         print(f'Using "{options.executable}" (project name) as name of executable to build.')
+    if options.executable in FORBIDDEN_TARGET_NAMES:
+        raise mesonlib.MesonException(f'Executable name {options.executable!r} is reserved for Meson internal use. '
+                                      'Refusing to init an invalid project.')
     if sample:
         # The rest of the autodetection is not applicable to generating sample projects.
         return


### PR DESCRIPTION
Some executable names are invalid, and while it's unlikely anyone will specify such a thing using the --executable argument, it's not unlikely that people experimenting will attempt to use meson init in a directory named "test".

This then defaults to that for both the project name and the sample target name, and the latter produces errors when you try to build it.

Fixes #10321