### PR TITLE
coverage: be clever and detect config files for gcovr/lcov

### DIFF
--- a/docs/markdown/snippets/coverage_config_files.md
+++ b/docs/markdown/snippets/coverage_config_files.md
@@ -1,0 +1,12 @@
+## Coverage targets now respect tool config files
+
+gcovr >= 4.2 supports `gcovr.cfg` in the project source root to configure how
+coverage is generated. If Meson detects that gcovr will load this file, it no
+longer excludes the `subprojects/` directory from coverage. It's a good default
+for Meson to guess that projects want to ignore it, but not all projects prefer
+that and it is assumed that if a gcovr.cfg exists then it will manually
+include/exclude desired paths.
+
+lcov supports `.lcovrc`, but only as a systemwide or user setting. This is
+non-ideal for projects, so Meson will now detect one in the project source root
+and, if present, manually tell lcov to use it.


### PR DESCRIPTION
gcovr will read this file anyway, but if it exists we don't need to assume that the project wishes to exclude subprojects/ -- they can determine that themselves.

Fixes #3287
Closes #9761

lcov doesn't read the config file by default, but we can do the smart thing here.

Fixes #4628