### PR TITLE
Ignore detached head warning while cloning subprojects with tags

### DIFF
--- a/mesonbuild/wrap/wrap.py
+++ b/mesonbuild/wrap/wrap.py
@@ -468,7 +468,7 @@ class Resolver:
                         verbose_git(['fetch', self.wrap.get('url'), revno], self.dirname, check=True)
                         verbose_git(checkout_cmd, self.dirname, check=True)
             else:
-                verbose_git(['clone', *depth_option, '--branch', revno, self.wrap.get('url'),
+                verbose_git(['-c', 'advice.detachedHead=false', 'clone', *depth_option, '--branch', revno, self.wrap.get('url'),
                              self.directory], self.subdir_root, check=True)
             if self.wrap.values.get('clone-recursive', '').lower() == 'true':
                 verbose_git(['submodule', 'update', '--init', '--checkout', '--recursive', *depth_option],


### PR DESCRIPTION
When using a wrapped git subproject with revision specified as tag instead of commit SHA, the clone command used for cloning subprojects prints out unnecessary warning about detached head.

Meson ignores this warning for revisions specified as commit SHAs as implemented [here](https://github.com/mesonbuild/meson/commit/b57b1050a6c6d38b3adf4b8f5e40e25892c878a6) with its corresponding issue [here](https://github.com/mesonbuild/meson/issues/9318). Meson does this by cloning the repository and then doing `checkout` while ignoring `advice.detachedHead`.

However when we use tag as revision in .wrap and doing shallow clones with `depth = 1`, git clones the repository and detaches the head automatically in one step while executing `clone` command. This is done by passing `--branch` to `git clone` with revision as its parameter.

`--branch` is specified in `man git clone` as
```
       -b <name>, --branch <name>
           Instead of pointing the newly created HEAD to the branch pointed to by the cloned repository’s HEAD, point to <name> branch
           instead. In a non-bare repository, this is the branch that will be checked out.  --branch can also take tags and detaches the HEAD
           at that commit in the resulting repository.
```
Note the **`--branch can also take tags and detaches the HEAD at that commit in the resulting repository.`** which is what is used when wrap has `revision = TAG`.

### How to reproduce
Use latest meson (`0.62.1` as of writing this PR).
Clone and setup the reproduction [repository](https://github.com/zxey/meson-detached-head):
```sh
git clone https://github.com/zxey/meson-detached-head.git
cd meson-detached-head
meson setup builddir
```
The output should contain familiar git warning about detached HEAD:
```
You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false
```

With this PR the warning goes away.