### PR TITLE
Fix documentation

### DIFF
--- a/docs/markdown/D.md
+++ b/docs/markdown/D.md
@@ -37,20 +37,19 @@ executable('myapp', 'app.d', d_debug: [3, 'DebugFeatureA'])
 
 ## In `declare_dependency`
 
-*Since 0.62.0*, when declaring your own dependency using `declare_dependency`, it is
-possible to add parameters for D specific features, e.g. to propagate
+*Since 0.62.0*, when declaring your own dependency using `declare_dependency`,
+it is possible to add parameters for D specific features, e.g. to propagate
 conditional compilation versions:
 
 ```meson
 my_dep = declare_dependency(
     # ...
-    d_module_features: ['LUA_53'],
+    d_module_versions: ['LUA_53'],
     d_import_dirs: include_directories('my_lua_folder'),
 )
 ```
 
-Accepted D specific parameters are `d_module_features` and
-`d_import_dirs`.
+Accepted D specific parameters are `d_module_versions` and `d_import_dirs`.
 
 ## Using embedded unittests
 

--- a/docs/markdown/D.md
+++ b/docs/markdown/D.md
@@ -49,7 +49,8 @@ my_dep = declare_dependency(
 )
 ```
 
-Accepted D specific parameters are `d_module_versions` and `d_import_dirs`.
+Accepted D specific parameters are `d_module_versions` and `d_import_dirs`
+(DMD `-J` switch).
 
 ## Using embedded unittests
 

--- a/docs/markdown/Release-notes-for-0.62.0.md
+++ b/docs/markdown/Release-notes-for-0.62.0.md
@@ -376,14 +376,14 @@ Meson will now allow the pkg-config name to work in all cases using the followin
 ## D features in `declare_dependency`
 
 `declare_dependency`accepts parameters for D specific features.
-Accepted new parameters are `d_module_features` and `d_import_dirs`.
+Accepted new parameters are `d_module_versions` and `d_import_dirs`.
 
 This can be useful to propagate conditional compilation versions. E.g.:
 
 ```meson
 my_lua_dep = declare_dependency(
     # ...
-    d_module_features: ['LUA_53'],
+    d_module_versions: ['LUA_53'],
     d_import_dirs: include_directories('my_lua_folder'),
 )
 ```

--- a/docs/yaml/functions/declare_dependency.yaml
+++ b/docs/yaml/functions/declare_dependency.yaml
@@ -57,3 +57,17 @@ kwargs:
       this is meant to be used
       in subprojects where special variables would be provided via cmake or
       pkg-config. *since 0.56.0* it can also be a list of `'key=value'` strings.
+
+  d_module_versions:
+    type: str | list[str]
+    since: 0.62.0
+    description: |
+      a string or a list of strings,
+      the D versions to add during the compilation of D source files
+
+  d_import_dirs:
+    type: list[inc | str]
+    since: 0.62.0
+    description: |
+      the directories to add to the string search path (i.e. `-J` switch for DMD).
+      Must be [[@inc]] objects or plain strings.


### PR DESCRIPTION
Fix wrong name in the documentation: `d_module_features` was used in place of `d_module_versions`.

Complete the documentation of `declare_dependency` with addition of `d_module_versions` and `d_import_dirs` kwargs.